### PR TITLE
fix: can now safely remove aes-gcm and hkdf from xmtp-keystore

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -958,14 +958,11 @@ checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 name = "xmtp-keystore"
 version = "0.1.0"
 dependencies = [
- "aes-gcm",
  "base64",
  "corecrypto",
  "ecdsa",
  "generic-array",
- "getrandom",
  "hex",
- "hkdf",
  "k256",
  "protobuf",
  "rand",

--- a/crates/xmtp-keystore/Cargo.toml
+++ b/crates/xmtp-keystore/Cargo.toml
@@ -10,12 +10,9 @@ rand = "0.8.4"
 protobuf = "3.2.0"
 base64 = "0.21.0"
 hex = "0.4"
-hkdf = "0.12.3"
 sha2 = "0.10.6"
 k256 = {version = "0.12.0", features = ["ecdh"]}
 ecdsa = "0.15.1"
 sha3 = "0.10.6"
 rlp = "0.5.2"
-aes-gcm = "0.10.1"
 generic-array = "0.14.6"
-getrandom = {version = "0.2.8", features = ["js"]}


### PR DESCRIPTION
**Overview**

This PR demonstrates that the xmtp-keystore crate no longer needs aes-gcm or hkdf dependencies, these have fully migrated to `corecrypto`.

This is a tiny precursor PR to moving signature verification logic out of xmtp-keystore which I have lined up next.