### PR TITLE
Add clippy

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,4 +14,11 @@ jobs:
         name: xmtp-keystore
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          name: xmtp-keystore
+          args: --all-features --no-deps --manifest-path crates/xmtp-keystore/Cargo.toml
+      - uses: actions-rs/clippy-check@v1
+        name: corecrypto
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: corecrypto
           args: --all-features --no-deps --manifest-path crates/xmtp-keystore/Cargo.toml


### PR DESCRIPTION
## Summary
- Adds clippy lint step

## Notes
I _think_ the reason there are no annotations on this PR is because none of the .rs files were touched, so it ignores the warnings found in the check. But we'll see. The [annotations are being created](https://github.com/xmtp/libxmtp/pull/26/checks?check_run_id=12351234048).