### PR TITLE
test: update action to test the entire workspace

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,8 +5,8 @@ on:
       - main
   pull_request:
 jobs:
-  test-keystore:
-   name: Test Keystore
+  test-libxmtp:
+   name: Test libxmtp
    runs-on: ubuntu-latest
    steps:
      - name: Checkout sources
@@ -23,4 +23,4 @@ jobs:
        uses: actions-rs/cargo@v1
        with:
          command: test
-         args: --manifest-path crates/xmtp-keystore/Cargo.toml
+         args: --manifest-path crates/Cargo.toml


### PR DESCRIPTION
## Overview

This change makes it so we test the entire `crates` Cargo workspace including `corecrypto`, rather than just the xmtp-keystore crate.

## Test Plan

We'll see if the test hook passes
Update: Confirmed that 1) it passes 2) it ran tests for both xmtp-keystore and corecrypto crates