### PR TITLE
docs: add disclaimer banner in preparation for going public

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# XMTP <> Vodozemac Development Branch
+# XMTP <> Vodozemac Development (WIP!)
 
-> :warning: **Under Construction**: This code is WIP and should not be used in any real-world context
+> :warning: :warning: :warning: **Under Construction**: This code is WIP and should not be used in any real-world context
 
 This repo contains Rust crates, platform-bindings and examples needed to build a new XMTP protocol using [vodozemac](https://github.com/matrix-org/vodozemac)
 


### PR DESCRIPTION
## Overview

One of our values is working in the open, but more practically our xmtp-js integration is a lot harder without having a repo dependency. Using local file dependencies breaks our CI.

## Changes

This adds an admonition banner to the README to alert any visitors that this is purely WIP.

![Screen Shot 2023-04-03 at 11 03 45 AM](https://user-images.githubusercontent.com/1329295/229591017-5d780e66-6a3c-4d28-a3ab-383b4dfe3345.png)
