### PR TITLE
feat: make libxmtp npm consumable

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The development flow will most commonly be:
 4. Write unit tests for those changes in the binding Rust crate
 5. Finally, run it end-to-end.
 
-Note you can write unit tests in `xmptv3` and the binding crate.
+Note you can write unit tests in `xmtpv3` and the binding crate.
 
 ## xmtpv3 quickstart
 

--- a/bindings/wasm/README.md
+++ b/bindings/wasm/README.md
@@ -1,7 +1,12 @@
 
-# Libxmtp
+# xmtpv3_wasm
 
-Libxmtp is a platform agnostic implementation of the core cryptographic functionality to be used in XMTP sdk's
+xmtpv3_wasm is a WASM binding library for xmtpv3
+
+## Prerequisites
+
+- Install Rust
+- Install [wasm-pack](https://rustwasm.github.io/wasm-pack/)
 
 ## QuickStart
 

--- a/bindings/wasm/package-lock.json
+++ b/bindings/wasm/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "libxmtp",
+  "name": "xmtpv3_wasm",
   "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "libxmtp",
+      "name": "xmtpv3_wasm",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {

--- a/bindings/wasm/package.json
+++ b/bindings/wasm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "libxmtp",
+  "name": "xmtpv3_wasm",
   "version": "0.0.1",
   "author": "jazzz <jazz@xmtp.com",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "./package.json": "./bindings/wasm/package.json"
   },
   "files": [
-    "dist"
+    "bindings/wasm/dist"
   ],
   "scripts": {
     "prepare": "cd bindings/wasm && npm install && npm run build",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "libxmtp",
+  "name": "xmtpv3",
   "version": "0.0.1",
   "author": "jazzz <jazz@xmtp.com",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
       "default": "./bindings/wasm/dist/cjs-slim/index_slim.cjs"
     },
     "./libxmtp.wasm": "./bindings/wasm/dist/libxmtp_bg.wasm",
-    "./package.json": "package.json"
+    "./package.json": "./package.json"
   },
   "files": [
-    "dist"
+    "./bindings/wasm/dist"
   ],
   "scripts": {
     "prepare": "cd bindings/wasm && npm install && npm run build",

--- a/package.json
+++ b/package.json
@@ -30,12 +30,7 @@
   ],
   "scripts": {
     "prepare": "cd bindings/wasm && npm install && npm run build",
-    "build": "wasm-pack build -t web --out-dir src/pkg bindings/wasm/crate && rm -rf bindings/wasm/dist/ && rollup -c && cp -r bindings/wasm/dist dist",
-    "build:minify": "npm run build && npx terser@latest --compress --mangle --output bindings/wasm/dist/cjs/index.cjs -- bindings/wasm/dist/cjs/index.cjs",
-    "format": "npx prettier@latest --write bindings/wasm/src/src/ bindings/wasm/tests/ bindings/wasm/package.json bindings/wasm/rollup.config.js bindings/wasm/tsconfig.json bindings/wasm/vite.config.ts bindings/wasm/cli.js",
-    "pretest": "npm run build",
-    "test": "vitest run && tsc",
-    "prepublishOnly": "npm test"
+    "build": "wasm-pack build -t web --out-dir src/pkg bindings/wasm/crate && rm -rf bindings/wasm/dist/ && rollup -c && cp -r bindings/wasm/dist dist"
   },
   "dependencies": {
     "@xmtp/proto": "^3.18.0"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "prepare": "cd bindings/wasm && npm install && npm run build",
-    "build": "wasm-pack build -t web --out-dir src/pkg bindings/wasm/crate && rm -rf bindings/wasm/dist/ && rollup -c && cp -r bindings/wasm/dist dist"
+    "build": "cd bindings/wasm && wasm-pack build -t web --out-dir src/pkg crate && rm -rf dist/ && rollup -c"
   },
   "dependencies": {
     "@xmtp/proto": "^3.18.0"

--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
     "./package.json": "./bindings/wasm/package.json"
   },
   "files": [
-    "bindings/wasm/dist"
+    "dist"
   ],
   "scripts": {
     "prepare": "cd bindings/wasm && npm install && npm run build",
-    "build": "wasm-pack build -t web --out-dir src/pkg bindings/wasm/crate && rm -rf bindings/wasm/dist/ && rollup -c",
+    "build": "wasm-pack build -t web --out-dir src/pkg bindings/wasm/crate && rm -rf bindings/wasm/dist/ && rollup -c && cp -r bindings/wasm/dist dist",
     "build:minify": "npm run build && npx terser@latest --compress --mangle --output bindings/wasm/dist/cjs/index.cjs -- bindings/wasm/dist/cjs/index.cjs",
     "format": "npx prettier@latest --write bindings/wasm/src/src/ bindings/wasm/tests/ bindings/wasm/package.json bindings/wasm/rollup.config.js bindings/wasm/tsconfig.json bindings/wasm/vite.config.ts bindings/wasm/cli.js",
     "pretest": "npm run build",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "xmtpv3",
+  "name": "xmtpv3_wasm",
   "version": "0.0.1",
   "author": "jazzz <jazz@xmtp.com",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
       "default": "./bindings/wasm/dist/cjs-slim/index_slim.cjs"
     },
     "./libxmtp.wasm": "./bindings/wasm/dist/libxmtp_bg.wasm",
-    "./package.json": "./bindings/wasm/package.json"
+    "./package.json": "package.json"
   },
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "libxmtp",
+  "version": "0.0.1",
+  "author": "jazzz <jazz@xmtp.com",
+  "license": "MIT",
+  "description": "Node.js package for the core XMTP utilities library",
+  "sideEffects": false,
+  "type": "module",
+  "main": "./bindings/wasm/dist/umd/index.js",
+  "module": "./bindings/wasm/dist/es/index.js",
+  "types": "./bindings/wasm/dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./bindings/wasm/dist/types/index.d.ts",
+      "node": "./bindings/wasm/dist/node/index.cjs",
+      "import": "./bindings/wasm/dist/es/index.js",
+      "default": "./bindings/wasm/dist/cjs/index.cjs"
+    },
+    "./slim": {
+      "types": "./bindings/wasm/dist/types/index.d.ts",
+      "node": "./bindings/wasm/dist/node/index.cjs",
+      "import": "./bindings/wasm/dist/es-slim/index_slim.js",
+      "default": "./bindings/wasm/dist/cjs-slim/index_slim.cjs"
+    },
+    "./libxmtp.wasm": "./bindings/wasm/dist/libxmtp_bg.wasm",
+    "./package.json": "./bindings/wasm/package.json"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "prepare": "cd bindings/wasm && npm install && npm run build",
+    "build": "wasm-pack build -t web --out-dir src/pkg bindings/wasm/crate && rm -rf bindings/wasm/dist/ && rollup -c",
+    "build:minify": "npm run build && npx terser@latest --compress --mangle --output bindings/wasm/dist/cjs/index.cjs -- bindings/wasm/dist/cjs/index.cjs",
+    "format": "npx prettier@latest --write bindings/wasm/src/src/ bindings/wasm/tests/ bindings/wasm/package.json bindings/wasm/rollup.config.js bindings/wasm/tsconfig.json bindings/wasm/vite.config.ts bindings/wasm/cli.js",
+    "pretest": "npm run build",
+    "test": "vitest run && tsc",
+    "prepublishOnly": "npm test"
+  },
+  "dependencies": {
+    "@xmtp/proto": "^3.18.0"
+  },
+  "devDependencies": {
+    "@rollup/plugin-typescript": "^10.0.1",
+    "@rollup/plugin-wasm": "^6.1.1",
+    "@types/node": "^18.11.10",
+    "rollup": "^3.11.0",
+    "tslib": "^2.4.1",
+    "typescript": "^4.9.3",
+    "vitest": "^0.25.3"
+  }
+}


### PR DESCRIPTION
## Overview

Attempt to make libxmtp consumable as a repo dependency within an external package.json file. To do this, we rename the package to `xmtpv3_wasm` from `libxmtp` to avoid some ambiguity. This package contains the WASM bindings for xmtpv3, but there could be another npm package with node-bindgen bindings for example.

## Test Plan

Doing `npm install xmtp/libxmtp#michaelx_make_libxmtp_npm_consumable` on the xmtp-js#michaelx_voodoo_client branch at least lets things build.