### PR TITLE
fix: try removing npm install from prepare phase

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "./bindings/wasm/dist"
   ],
   "scripts": {
-    "prepare": "cd bindings/wasm && npm install && npm run build",
+    "prepare": "cd bindings/wasm && npm run build",
     "build": "cd bindings/wasm && wasm-pack build -t web --out-dir src/pkg crate && rm -rf dist/ && rollup -c"
   },
   "dependencies": {


### PR DESCRIPTION
## Overview

Github actions on `xmtp-js` consuming the `xmtpv3_wasm` were taking 8 mins. Now those same actions take ~3-5 minutes thanks to @neekolas 's tip about removing a spurious `npm install`.

<img width="841" alt="Screen Shot 2023-04-03 at 2 43 24 PM" src="https://user-images.githubusercontent.com/1329295/229634365-864bfbbc-393a-4065-b096-dd5b49b8d145.png">
