### PR TITLE
feat: methods to allow insecure export and import of vodozemac identies

### DIFF
--- a/bindings/wasm/crate/src/lib.rs
+++ b/bindings/wasm/crate/src/lib.rs
@@ -31,7 +31,9 @@ pub fn create_outbound_session(
     message: &str,
 ) -> Result<Box<[JsValue]>, JsValue> {
     // Look up both handles in INSTANCE_MAP
-    let instances = INSTANCE_MAP.lock().unwrap();
+    let instances = INSTANCE_MAP.lock().map_err(|e| {
+        JsValue::from_str(&format!("Error getting instance map lock: {}", e))
+    })?;
     let mut sending_instance = instances
         .get(sending_handle)
         .ok_or("sending_handle not found")?
@@ -65,7 +67,9 @@ pub fn create_inbound_session(
     message: &str,
 ) -> Result<Box<[JsValue]>, JsValue> {
     // Look up both handles in INSTANCE_MAP
-    let instances = INSTANCE_MAP.lock().unwrap();
+    let instances = INSTANCE_MAP.lock().map_err(|e| {
+        JsValue::from_str(&format!("Error getting instance map lock: {}", e))
+    })?;
     let sending_instance = instances
         .get(sending_handle)
         .ok_or("sending_handle not found")?
@@ -97,7 +101,9 @@ pub fn encrypt_message(
     session_id: &str,
     message: &str,
 ) -> Result<String, JsValue> {
-    let instances = INSTANCE_MAP.lock().unwrap();
+    let instances = INSTANCE_MAP.lock().map_err(|e| {
+        JsValue::from_str(&format!("Error getting instance map lock: {}", e))
+    })?;
     let mut instance = instances
         .get(sending_handle)
         .ok_or("sending_handle not found")?
@@ -117,7 +123,9 @@ pub fn decrypt_message(
     session_id: &str,
     ciphertext: &str,
 ) -> Result<String, JsValue> {
-    let instances = INSTANCE_MAP.lock().unwrap();
+    let instances = INSTANCE_MAP.lock().map_err(|e| {
+        JsValue::from_str(&format!("Error getting instance map lock: {}", e))
+    })?;
     let mut instance = instances
         .get(handle)
         .ok_or("handle not found")?
@@ -136,7 +144,9 @@ pub fn decrypt_message(
 // is a JSON object which can subsequently be imported into another VoodooInstance
 #[wasm_bindgen]
 pub fn get_public_account_json(handle: &str) -> Result<String, JsValue> {
-    let instances = INSTANCE_MAP.lock().unwrap();
+    let instances = INSTANCE_MAP.lock().map_err(|e| {
+        JsValue::from_str(&format!("Error getting instance map lock: {}", e))
+    })?;
     let instance = instances
         .get(handle)
         .ok_or("handle not found")?
@@ -151,7 +161,9 @@ pub fn get_public_account_json(handle: &str) -> Result<String, JsValue> {
 // no distinction between "public" and "private" accounts in this implementation yet.
 #[wasm_bindgen]
 pub fn add_or_get_public_account_from_json(public_account_json: &str) -> Result<String, JsValue> {
-    let mut instances = INSTANCE_MAP.lock().unwrap();
+    let mut instances = INSTANCE_MAP.lock().map_err(|e| {
+        JsValue::from_str(&format!("Error getting instance map lock: {}", e))
+    })?;
 
     let public_instance = VoodooInstance::from_public_account_json(public_account_json).map_err(|e| {
         JsValue::from_str(&format!("Error creating VoodooInstance from public account json: {}", e))

--- a/bindings/wasm/src/xmtpv3.ts
+++ b/bindings/wasm/src/xmtpv3.ts
@@ -144,6 +144,7 @@ export class XMTPWasm {
     return get_public_account_json(handle);
   }
 
+  // TODO: currently returns VoodooInstance as there is no corresponding public type yet
   addOrGetPublicAccountFromJSON(json: string): VoodooInstance {
     const handle = add_or_get_public_account_from_json(json);
     return new VoodooInstance(this, handle);

--- a/bindings/wasm/src/xmtpv3.ts
+++ b/bindings/wasm/src/xmtpv3.ts
@@ -5,6 +5,8 @@ import init, {
   create_inbound_session,
   decrypt_message,
   encrypt_message,
+  get_public_account_json,
+  add_or_get_public_account_from_json,
   e2e_selftest,
 } from "./pkg/libxmtp.js";
 
@@ -70,6 +72,10 @@ export class VoodooInstance {
   async decryptMessage(sessionId: string, ciphertext: string): Promise<string> {
     return this.wasmModule.decryptMessage(this.handle, sessionId, ciphertext);
   }
+
+  toPublicJSON(): string {
+    return this.wasmModule.getPublicAccountJSON(this.handle);
+  }
 }
 
 // Keep around for old test cases
@@ -132,6 +138,15 @@ export class XMTPWasm {
     ciphertext: string
   ): string {
     return decrypt_message(handle, sessionId, ciphertext);
+  }
+
+  getPublicAccountJSON(handle: string): string {
+    return get_public_account_json(handle);
+  }
+
+  addOrGetPublicAccountFromJSON(json: string): VoodooInstance {
+    const handle = add_or_get_public_account_from_json(json);
+    return new VoodooInstance(this, handle);
   }
 
   /**

--- a/bindings/wasm/tests/wasmpkg.test.ts
+++ b/bindings/wasm/tests/wasmpkg.test.ts
@@ -57,3 +57,28 @@ it("can send a message", async () => {
   const decrypted = await bob.decryptMessage(sessionId, encrypted);
   expect(decrypted).toBe(msg);
 });
+
+it("can send a message to a public instance", async () => {
+  const wasm = await XMTPWasm.initialize();
+  const alice = wasm.newVoodooInstance();
+  const bob = wasm.newVoodooInstance();
+
+  const bobJson = bob.toPublicJSON();
+  const publicBob = wasm.addOrGetPublicAccountFromJSON(bobJson);
+  // Use publicBob to create the session
+  const { sessionId, payload } = await alice.createOutboundSession(
+    publicBob,
+    "hello there"
+  );
+  await bob.createInboundSession(alice, payload);
+  expect(typeof sessionId).toBe("string");
+
+  // Test another round trip
+  const msg = "hello there";
+  const encrypted = await alice.encryptMessage(sessionId, msg);
+  expect(typeof encrypted).toBe("string");
+
+  const decrypted = await bob.decryptMessage(sessionId, encrypted);
+  expect(decrypted).toBe(msg);
+
+});

--- a/crates/xmtpv3/src/manager.rs
+++ b/crates/xmtpv3/src/manager.rs
@@ -38,6 +38,23 @@ impl VoodooInstance {
         VoodooPublicIdentity::new(&self.account)
     }
 
+    pub fn public_account_json(&self) -> Result<String> {
+        let public_account = self.public_account();
+        serde_json::to_string(&public_account).map_err(|e| e.into())
+    }
+
+    // TODO: STARTINGTASK: The goal is to remove this pattern altogether and
+    // build a better abstraction for the public account, rather than creating
+    // new VoodooInstances for all contacts
+    pub fn from_public_account_json(public_account_json: &str) -> Result<Self> {
+        let public_account: VoodooPublicIdentity = serde_json::from_str(public_account_json)?;
+        let account = public_account.get_account()?;
+        Ok(Self {
+            account,
+            sessions: HashMap::new(),
+        })
+    }
+
     // Creates an outbound session and returns a handle which is just the index
     // // TODO: STARTINGTASK: this should take the one-time-keys and pre-keys as
     // arguments too, part of the VoodooPublicIdentity maybe?


### PR DESCRIPTION
## Overview

This PR adds methods to xmtpv3 and xmtpv3_wasm to allow us to export a JSON dump of the "public identity" (which is currently equivalent to the whole identity). We pair this with a PR in xmtp-js which publishes the contact bundle to a `voodoo-contact` topic, fetches it and uses it for tests.

## Changes

These changes are slightly painful, but necessary until we have a real public/private distinction. For now, our strategy is to allow `xmtpv3_wasm` to take JSON, save the account, and return a handle. This handle can be used to start conversations.

So the basic flow (encapsulated by our Javascript code in xmtpv3) is:
```
const myHandle = new_voodoo_instance()
const otherExport = other.get_public_account_json()
const otherHandle = add_or_get_public_account_from_json(otherExport)
create_outbound_session(myHandle, OtherHandle)
```

## Test Plan

- new roundtrip test with JSON export/import