### PR TITLE
test: add Rust lint and test workflows for main xmtpv3 crate

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,24 @@
+name: Lint
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - run: rustup component add clippy
+      - uses: actions-rs/clippy-check@v1
+        name: xmtpv3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: xmtpv3
+          args: --all-features --no-deps --manifest-path crates/xmtpv3/Cargo.toml
+      - uses: actions-rs/clippy-check@v1
+        name: xmtpv3_wasm
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: xmtpv3_wasm
+          args: --all-features --no-deps --manifest-path crates/bindings/wasm/crate/Cargo.toml

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,4 +21,4 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: xmtpv3_wasm
-          args: --all-features --no-deps --manifest-path crates/bindings/wasm/crate/Cargo.toml
+          args: --all-features --no-deps --manifest-path bindings/wasm/crate/Cargo.toml

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -1,0 +1,24 @@
+name: Test
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+jobs:
+  test-xmtpv3:
+   name: Test XMTPv3
+   runs-on: ubuntu-latest
+   steps:
+     - name: Checkout sources
+       uses: actions/checkout@v2
+     - name: Install stable toolchain
+       uses: actions-rs/toolchain@v1
+       with:
+         profile: minimal
+         toolchain: stable
+         override: true
+     - name: Run xmtpv3 cargo test
+       uses: actions-rs/cargo@v1
+       with:
+         command: test
+         args: --manifest-path crates/xmtpv3/Cargo.toml

--- a/.github/workflows/wasm_npm_test.yaml
+++ b/.github/workflows/wasm_npm_test.yaml
@@ -25,4 +25,5 @@ jobs:
          override: true
      - uses: jetli/wasm-pack-action@v0.4.0
      - uses: actions/setup-node@v3
+     - run: npm ci
      - run: npm test

--- a/.github/workflows/wasm_npm_test.yaml
+++ b/.github/workflows/wasm_npm_test.yaml
@@ -1,0 +1,27 @@
+name: Test WASM npm
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        env: ['node', 'jsdom']
+    defaults:
+      run:
+        working-directory: ./bindings/wasm
+    steps:
+     - name: Checkout sources
+       uses: actions/checkout@v2
+     - name: Install stable toolchain
+       uses: actions-rs/toolchain@v1
+       with:
+         profile: minimal
+         toolchain: stable
+         override: true
+      - uses: actions/setup-node@v3
+      - run: npm test

--- a/.github/workflows/wasm_npm_test.yaml
+++ b/.github/workflows/wasm_npm_test.yaml
@@ -23,5 +23,6 @@ jobs:
          profile: minimal
          toolchain: stable
          override: true
+     - uses: jetli/wasm-pack-action@v0.4.0
      - uses: actions/setup-node@v3
      - run: npm test

--- a/.github/workflows/wasm_npm_test.yaml
+++ b/.github/workflows/wasm_npm_test.yaml
@@ -23,5 +23,5 @@ jobs:
          profile: minimal
          toolchain: stable
          override: true
-      - uses: actions/setup-node@v3
-      - run: npm test
+     - uses: actions/setup-node@v3
+     - run: npm test


### PR DESCRIPTION
## Overview

This PR starts to add back lint and test Github workflows. We've been without CI for a while now.

## Changes

- Add a Rust lint workflow for `crates/xmtpv3`
- Add a Rust test workflow for `crates/xmtpv3`
- Add a npm test workflow for `bindings/wasm` (builds xmtpv3 crate, bindings crate then runs npm tests)

## Test Plan

All tests pass on PR!