### PR TITLE
feat: incredibly bare-bones in-memory message store by wrapping olm::Session

### DIFF
--- a/crates/xmtpv3/src/lib.rs
+++ b/crates/xmtpv3/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod account;
 pub mod manager;
+pub mod session;
 
 #[cfg(test)]
 mod tests {
@@ -65,5 +66,53 @@ mod tests {
             .unwrap();
 
         assert_eq!(alice_plaintext, "Hello Alice");
+    }
+
+    #[test]
+    pub fn test_conversation_and_message_counts() {
+        let mut alice = VoodooInstance::new();
+        let mut bob = VoodooInstance::new();
+        let bob_public = bob.public_account();
+        let alice_public = alice.public_account();
+
+        let (alice_session_id, alice_msg) = alice
+            .create_outbound_session(&bob_public, "Hello Bob")
+            .unwrap();
+
+        let (bob_session_id, bob_plaintext) = bob
+            .create_inbound_session(&alice_public, &alice_msg)
+            .unwrap();
+
+        assert_eq!(alice_session_id, bob_session_id);
+        assert_eq!(bob_plaintext, "Hello Bob");
+
+        let bob_msg = bob.encrypt_message(&bob_session_id, "Hello Alice").unwrap();
+
+        let alice_plaintext = alice.decrypt_message(&alice_session_id, &bob_msg).unwrap();
+
+        assert_eq!(alice_plaintext, "Hello Alice");
+
+        // another round, this time lots of bob messages
+        let bob_msg2 = bob.encrypt_message(&bob_session_id, "2").unwrap();
+        let bob_msg3 = bob.encrypt_message(&bob_session_id, "3").unwrap();
+
+        // Check that the session bob has with alice has 3 sent, 1 received
+        let bob_session = bob.sessions.get(&bob_session_id).unwrap();
+        assert_eq!(bob_session.my_messages.len(), 3);
+        assert_eq!(bob_session.their_messages.len(), 0);
+        
+        let alice_session = alice.sessions.get(&alice_session_id).unwrap();
+        assert_eq!(alice_session.my_messages.len(), 0);
+        // Will not be 3 because two messages have not been fed into Alice's decrypt
+        assert_eq!(alice_session.their_messages.len(), 1);
+
+        let _ = alice.decrypt_message(&alice_session_id, &bob_msg2).unwrap();
+        let _ = alice.decrypt_message(&alice_session_id, &bob_msg3).unwrap();
+        let alice_session = alice.sessions.get(&alice_session_id).unwrap();
+        assert_eq!(alice_session.their_messages.len(), 3);
+
+        // Check bob's last message against Alice's message store
+        assert_eq!(alice_session.their_messages[2], "3");
+        assert_eq!(bob_session.my_messages[2], "3");
     }
 }

--- a/crates/xmtpv3/src/manager.rs
+++ b/crates/xmtpv3/src/manager.rs
@@ -2,14 +2,16 @@ use anyhow::Result;
 
 use serde_json::json;
 use std::collections::HashMap;
-use vodozemac::olm::{Account, OlmMessage, Session, SessionConfig};
+use vodozemac::olm::{Account, OlmMessage, SessionConfig};
 
 use crate::account::VoodooPublicIdentity;
+use crate::session::VoodooSession;
+
 
 // This struct contains all logic for a Voodoo messaging session
 pub struct VoodooInstance {
     pub account: Account,
-    pub sessions: HashMap<String, Session>,
+    pub sessions: HashMap<String, VoodooSession>,
 }
 
 impl Default for VoodooInstance {
@@ -78,7 +80,7 @@ impl VoodooInstance {
         );
         let ciphertext = session.encrypt(message);
         let session_id = session.session_id();
-        self.sessions.insert(session_id.clone(), session);
+        self.sessions.insert(session_id.clone(), VoodooSession::new(session));
         Ok((session_id, ciphertext))
     }
 
@@ -120,7 +122,7 @@ impl VoodooInstance {
                 }
                 None => {
                     // We don't have the session, so we need to store it and return the plaintext
-                    self.sessions.insert(session_id.clone(), self_session);
+                    self.sessions.insert(session_id.clone(), VoodooSession::new(self_session));
                 }
             }
             // Decode received_plaintext bytes as utf-8

--- a/crates/xmtpv3/src/session.rs
+++ b/crates/xmtpv3/src/session.rs
@@ -1,0 +1,34 @@
+use anyhow::Result;
+use vodozemac::olm::{OlmMessage, Session};
+
+// Wrapper struct for Olm sessions with additional metadata
+pub struct VoodooSession {
+    pub session: Session,
+    // NOTE: this does not save the first plaintext encoded in the
+    // outbound session
+    // TODO: instead of storing pure plaintext, we should store higher level structs
+    pub my_messages: Vec<String>,
+    pub their_messages: Vec<String>,
+}
+
+impl VoodooSession {
+    pub fn new(olm_session: Session) -> Self {
+        Self {
+            session: olm_session,
+            my_messages: Vec::new(),
+            their_messages: Vec::new(),
+        }
+    }
+
+    pub fn encrypt(&mut self, plaintext: &str) -> OlmMessage {
+        let message = self.session.encrypt(plaintext);
+        self.my_messages.push(plaintext.to_string());
+        message
+    }
+
+    pub fn decrypt(&mut self, message: &OlmMessage) -> Result<Vec<u8>> {
+        let plaintext = self.session.decrypt(message)?;
+        self.their_messages.push(String::from_utf8(plaintext.clone())?);
+        Ok(plaintext)
+    }
+}


### PR DESCRIPTION
## Overview

This is a quick PR to start the idea of storing messages in WASM land. To do this, we wrap the `olm::Session` with our own struct. This struct should be a serializable type at some point.

## Test Plan

Added unit tests to check `my_messages` and `their_messages`. Rest of tests should continue to pass.