### PR TITLE
feat: add a new binding for iOS -> Swift package

### DIFF
--- a/bindings/xmtp_rust_swift/.gitignore
+++ b/bindings/xmtp_rust_swift/.gitignore
@@ -8,6 +8,7 @@ tags
 # Ignore intermediate build files
 *.a
 XMTPRustSwift.xcframework
+bundle.zip
 
 /target
 /Cargo.lock

--- a/bindings/xmtp_rust_swift/.gitignore
+++ b/bindings/xmtp_rust_swift/.gitignore
@@ -1,0 +1,14 @@
+# No ctags files
+tags
+
+# No vim swap files
+*.swp
+*.swo
+
+# Ignore intermediate build files
+*.a
+XMTPRustSwift.xcframework
+
+/target
+/Cargo.lock
+.build

--- a/bindings/xmtp_rust_swift/Cargo.toml
+++ b/bindings/xmtp_rust_swift/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "xmtp_rust_swift"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+xmtp-keystore = { path = "../../crates/xmtp-keystore" }
+corecrypto = { path = "../../crates/corecrypto" }
+
+[lib]
+name = "xmtp_rust_swift"
+crate-type = [ "staticlib" ]

--- a/bindings/xmtp_rust_swift/Makefile
+++ b/bindings/xmtp_rust_swift/Makefile
@@ -1,0 +1,32 @@
+# Simulator config
+ARCHS_IOS = x86_64-apple-ios aarch64-apple-ios-sim
+ARCHS_MAC = x86_64-apple-darwin aarch64-apple-darwin
+# Not used
+# ARCHS_MACCATALYST = x86_64-apple-ios-macabi aarch64-apple-ios-macabi
+LIB=libxmtp_rust_swift.a
+
+all: pkg
+
+.PHONY: $(ARCHS_IOS) $(ARCHS_MAC) pkg all aarch64-apple-ios
+$(ARCHS_IOS): %:
+	cargo build --target $@ --release --no-default-features
+
+$(ARCHS_MAC): %:
+	cargo build --target $@ --release --no-default-features
+
+aarch64-apple-ios:
+	cargo build --target $@ --release
+
+$(LIB): $(ARCHS_IOS) $(ARCHS_MAC) aarch64-apple-ios
+	lipo -create -output libxmtp_rust_swift_iossimulator.a $(foreach arch,$(ARCHS_IOS),$(wildcard target/$(arch)/release/$(LIB)))
+	lipo -create -output libxmtp_rust_swift_macos.a $(foreach arch,$(ARCHS_MAC),$(wildcard target/$(arch)/release/$(LIB)))
+
+pkg: $(LIB)
+	xcodebuild -create-xcframework \
+		-library ./libxmtp_rust_swift_macos.a \
+		-headers ./include/ \
+		-library ./libxmtp_rust_swift_iossimulator.a \
+		-headers ./include/ \
+		-library ./target/aarch64-apple-ios/release/libxmtp_rust_swift.a \
+		-headers ./include/ \
+		-output XMTPRustSwift.xcframework

--- a/bindings/xmtp_rust_swift/Makefile
+++ b/bindings/xmtp_rust_swift/Makefile
@@ -5,6 +5,11 @@ ARCHS_MAC = x86_64-apple-darwin aarch64-apple-darwin
 # ARCHS_MACCATALYST = x86_64-apple-ios-macabi aarch64-apple-ios-macabi
 LIB=libxmtp_rust_swift.a
 
+download-toolchains:
+	rustup target add $(ARCHS_IOS)
+	rustup target add $(ARCHS_MAC)
+	rustup target add aarch64-apple-ios
+
 all: pkg
 
 $(ARCHS_IOS): %:
@@ -38,4 +43,4 @@ pkg: $(LIB)
 push-to-derived:
 	./copy_xcframework_to_deriveddata.sh
 
-.PHONY: $(ARCHS_IOS) $(ARCHS_MAC) pkg all aarch64-apple-ios push-to-derived
+.PHONY: $(ARCHS_IOS) $(ARCHS_MAC) pkg all aarch64-apple-ios push-to-derived download-toolchains

--- a/bindings/xmtp_rust_swift/Makefile
+++ b/bindings/xmtp_rust_swift/Makefile
@@ -7,7 +7,6 @@ LIB=libxmtp_rust_swift.a
 
 all: pkg
 
-.PHONY: $(ARCHS_IOS) $(ARCHS_MAC) pkg all aarch64-apple-ios
 $(ARCHS_IOS): %:
 	cargo build --target $@ --release --no-default-features
 
@@ -35,3 +34,8 @@ pkg: $(LIB)
 	rm -f bundle.zip
 	zip -r bundle.zip XMTPRustSwift.xcframework
 	openssl dgst -sha256 bundle.zip
+
+push-to-derived:
+	./copy_xcframework_to_deriveddata.sh
+
+.PHONY: $(ARCHS_IOS) $(ARCHS_MAC) pkg all aarch64-apple-ios push-to-derived

--- a/bindings/xmtp_rust_swift/Makefile
+++ b/bindings/xmtp_rust_swift/Makefile
@@ -18,10 +18,12 @@ aarch64-apple-ios:
 	cargo build --target $@ --release
 
 $(LIB): $(ARCHS_IOS) $(ARCHS_MAC) aarch64-apple-ios
+	rm -f libxmtp_rust_swift_iossimulator.a libxmtp_rust_swift_macos.a
 	lipo -create -output libxmtp_rust_swift_iossimulator.a $(foreach arch,$(ARCHS_IOS),$(wildcard target/$(arch)/release/$(LIB)))
 	lipo -create -output libxmtp_rust_swift_macos.a $(foreach arch,$(ARCHS_MAC),$(wildcard target/$(arch)/release/$(LIB)))
 
 pkg: $(LIB)
+	rm -rf XMTPRustSwift.xcframework
 	xcodebuild -create-xcframework \
 		-library ./libxmtp_rust_swift_macos.a \
 		-headers ./include/ \
@@ -30,3 +32,6 @@ pkg: $(LIB)
 		-library ./target/aarch64-apple-ios/release/libxmtp_rust_swift.a \
 		-headers ./include/ \
 		-output XMTPRustSwift.xcframework
+	rm -f bundle.zip
+	zip -r bundle.zip XMTPRustSwift.xcframework
+	openssl dgst -sha256 bundle.zip

--- a/bindings/xmtp_rust_swift/Package.swift
+++ b/bindings/xmtp_rust_swift/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version:5.3
+import PackageDescription
+import Foundation
+let package = Package(
+        name: "XMTPRustSwift",
+        platforms: [
+            .iOS(.v13), 
+            .macOS(.v11)
+        ],
+        products: [
+            .library(
+                name: "XMTPRustSwift",
+                targets: ["XMTPRustSwift"]),
+        ],
+        targets: [
+            .binaryTarget(
+                name: "XMTPRustSwift",
+                url: "https://raw.githubusercontent.com/michaelx11/build_files/main/swift_bundle_hosting/bundle.zip",
+                checksum: "b8751114bcdd405219f74a1a2f623b8a35e2007e29176fdf373fb119a91a2a60"),
+        ]
+)

--- a/bindings/xmtp_rust_swift/Package.swift
+++ b/bindings/xmtp_rust_swift/Package.swift
@@ -15,7 +15,6 @@ let package = Package(
         targets: [
             .binaryTarget(
                 name: "XMTPRustSwift",
-                url: "https://raw.githubusercontent.com/michaelx11/build_files/main/swift_bundle_hosting/bundle.zip",
-                checksum: "b8751114bcdd405219f74a1a2f623b8a35e2007e29176fdf373fb119a91a2a60"),
+                path: "XMTPRustSwift.xcframework"
         ]
 )

--- a/bindings/xmtp_rust_swift/README.md
+++ b/bindings/xmtp_rust_swift/README.md
@@ -1,0 +1,3 @@
+# XMTP Rust Swift helper
+
+Do things in Rust that are hard in Swift

--- a/bindings/xmtp_rust_swift/README.md
+++ b/bindings/xmtp_rust_swift/README.md
@@ -1,3 +1,27 @@
-# XMTP Rust Swift helper
+# XMTP Rust Swift
 
-Do things in Rust that are hard in Swift
+This repo builds a crate for iOS targets and packages it in an XMTPRustSwift.xcframework file.
+
+It pairs with [xmtp-rust-swift](https://github.com/xmtp/xmtp-rust-swift) which is a tiny public repo hosting a Swift Package that wraps the XMTPRustSwift.xcframework produced here.
+
+## Structure
+
+- `Cargo.toml` here can reference any local crate in `libxmtp`, such as corecrypto or keystore
+- `include/module.modulemap` - can remain untouched as it just imports the `xmtp_rust_swift.h` header
+- `include/xmtp_rust_swift.h` - contains C function declarations that are exported into Swift land
+
+## Workflow
+
+- Write code in `./src` to expose functionality to Swift
+- Then update `include/xmtp_rust_swift.h` with any new functions or declarations
+- Run `make pkg` to produce the XMTPRustFramework.xcframework
+
+## Optional Steps for xmtp-ios integration
+
+- Get set up with Xcode
+- Clone [xmtp-ios](https://github.com/xmtp/xmtp-ios)
+- Open Xcode, then open the `xmtp-ios` folder at the top-level in Xcode
+- Follow README.md there to get Xcode roughly set up
+- Try running a build, it should complain about no `XMTPRustSwift.xcframework` in the `xmtp-rust-swift` Swift package checkout in DerivedData
+- Run `make push-to-derived` in this repo (libxmtp) to perform a hacky step which puts the xcframework in the right places in DerivedData
+- Try building and testing again in Xcode and it should work

--- a/bindings/xmtp_rust_swift/README.md
+++ b/bindings/xmtp_rust_swift/README.md
@@ -10,9 +10,15 @@ It pairs with [xmtp-rust-swift](https://github.com/xmtp/xmtp-rust-swift) which i
 - `include/module.modulemap` - can remain untouched as it just imports the `xmtp_rust_swift.h` header
 - `include/xmtp_rust_swift.h` - contains C function declarations that are exported into Swift land
 
+## Prerequisites
+
+- Rust
+- Run `make download-toolchains` to get all the iOS and MacOS toolchains
+
 ## Workflow
 
 - Write code in `./src` to expose functionality to Swift
+- Run `cargo test` to make sure your code works
 - Then update `include/xmtp_rust_swift.h` with any new functions or declarations
 - Run `make pkg` to produce the XMTPRustFramework.xcframework
 

--- a/bindings/xmtp_rust_swift/copy_xcframework_to_deriveddata.sh
+++ b/bindings/xmtp_rust_swift/copy_xcframework_to_deriveddata.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# This script copies the built XCFramework to all DerivedData directories
+# that contain a Package.swift file that references the XCFramework.
+# This is needed in tandem with xmtp-rust-swift development builds that use a local xcframework .binaryTarget
+#
+# Steps:
+# - Scan derived data for xmtp-rust-swift checkouts
+# - Look for paths like: /Users/michaelx/Library/Developer/Xcode/DerivedData/ios2-elqrwwtgpigvwehajufcujbhyfpg/SourcePackages/checkouts/xmtp-rust-swift/
+# - Then copy the XMTPRustSwift.xcframework to the checkout
+
+derived_data_dirs=$(find ~/Library/Developer/Xcode/DerivedData -type d -name "xmtp-rust-swift")
+for dir in $derived_data_dirs; do
+  if grep -q "XMTPRustSwift.xcframework" "$dir/Package.swift"; then
+    echo "Copying to $dir"
+    cp -r XMTPRustSwift.xcframework "$dir"
+  else
+    echo "Skipping $dir"
+  fi
+done

--- a/bindings/xmtp_rust_swift/include/module.modulemap
+++ b/bindings/xmtp_rust_swift/include/module.modulemap
@@ -1,0 +1,4 @@
+module XMTPRustSwift {
+    header "xmtp_rust_swift.h"
+    export *
+}

--- a/bindings/xmtp_rust_swift/include/xmtp_rust_swift.h
+++ b/bindings/xmtp_rust_swift/include/xmtp_rust_swift.h
@@ -1,0 +1,8 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+int32_t add(int32_t a, int32_t b);
+
+bool flip(bool a);

--- a/bindings/xmtp_rust_swift/include/xmtp_rust_swift.h
+++ b/bindings/xmtp_rust_swift/include/xmtp_rust_swift.h
@@ -3,8 +3,4 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-int32_t add(int32_t a, int32_t b);
-
-bool flip(bool a);
-
 bool encryption_selftest(void);

--- a/bindings/xmtp_rust_swift/include/xmtp_rust_swift.h
+++ b/bindings/xmtp_rust_swift/include/xmtp_rust_swift.h
@@ -6,3 +6,5 @@
 int32_t add(int32_t a, int32_t b);
 
 bool flip(bool a);
+
+bool encryption_selftest(void);

--- a/bindings/xmtp_rust_swift/src/lib.rs
+++ b/bindings/xmtp_rust_swift/src/lib.rs
@@ -1,0 +1,19 @@
+#[no_mangle]
+pub extern "C" fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+#[no_mangle]
+pub extern "C" fn flip(a: bool) -> bool {
+    !a
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/bindings/xmtp_rust_swift/src/lib.rs
+++ b/bindings/xmtp_rust_swift/src/lib.rs
@@ -1,10 +1,60 @@
+use corecrypto::{encryption};
+
 #[no_mangle]
 pub extern "C" fn add(a: i32, b: i32) -> i32 {
     a + b
 }
+
 #[no_mangle]
 pub extern "C" fn flip(a: bool) -> bool {
     !a
+}
+
+#[no_mangle]
+pub extern "C" fn encryption_selftest() -> bool {
+    // Simple key choice, same as previous test but I chopped a digit off the first column
+    let secret: Vec<u8> = vec![
+        24, 230, 18, 30, 212, 117, 106, 175, 141, 208, 177, 22, 206, 183, 244, 74, 178, 241, 9,
+        79, 76, 175, 89, 36, 228, 189, 7, 3, 83, 115, 158, 106, 60, 139, 3, 156, 222, 117, 37,
+        194, 19, 76, 127, 247, 107, 202, 93, 122, 222, 63, 229, 155, 215, 145, 243, 231, 2,
+        220, 151, 225, 136, 193, 228, 82, 28,
+    ];
+
+    let plaintext: Vec<u8> = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+    let aead: Vec<u8> = vec![10, 11, 12, 13, 14, 15, 16, 17, 18, 19];
+
+    // Invoke encrypt on the plaintext
+    let encrypt_result = encryption::encrypt(
+        plaintext.as_slice(),
+        secret.as_slice(),
+        Some(aead.as_slice()),
+    );
+
+    if encrypt_result.is_err() {
+        return false;
+    }
+    let encryption::Ciphertext {
+        payload,
+        hkdf_salt,
+        gcm_nonce,
+    } = encrypt_result.unwrap();
+
+    // Invoke decrypt on the ciphertext
+    let decrypt_result = encryption::decrypt(
+        payload.as_slice(),
+        hkdf_salt.as_slice(),
+        gcm_nonce.as_slice(),
+        secret.as_slice(),
+        Some(&aead),
+    );
+
+    if decrypt_result.is_err() {
+        return false;
+    }
+    if decrypt_result.unwrap() != plaintext {
+        return false;
+    }
+    return true;
 }
 
 #[cfg(test)]

--- a/bindings/xmtp_rust_swift/src/lib.rs
+++ b/bindings/xmtp_rust_swift/src/lib.rs
@@ -1,23 +1,13 @@
-use corecrypto::{encryption};
-
-#[no_mangle]
-pub extern "C" fn add(a: i32, b: i32) -> i32 {
-    a + b
-}
-
-#[no_mangle]
-pub extern "C" fn flip(a: bool) -> bool {
-    !a
-}
+use corecrypto::encryption;
 
 #[no_mangle]
 pub extern "C" fn encryption_selftest() -> bool {
     // Simple key choice, same as previous test but I chopped a digit off the first column
     let secret: Vec<u8> = vec![
-        24, 230, 18, 30, 212, 117, 106, 175, 141, 208, 177, 22, 206, 183, 244, 74, 178, 241, 9,
-        79, 76, 175, 89, 36, 228, 189, 7, 3, 83, 115, 158, 106, 60, 139, 3, 156, 222, 117, 37,
-        194, 19, 76, 127, 247, 107, 202, 93, 122, 222, 63, 229, 155, 215, 145, 243, 231, 2,
-        220, 151, 225, 136, 193, 228, 82, 28,
+        24, 230, 18, 30, 212, 117, 106, 175, 141, 208, 177, 22, 206, 183, 244, 74, 178, 241, 9, 79,
+        76, 175, 89, 36, 228, 189, 7, 3, 83, 115, 158, 106, 60, 139, 3, 156, 222, 117, 37, 194, 19,
+        76, 127, 247, 107, 202, 93, 122, 222, 63, 229, 155, 215, 145, 243, 231, 2, 220, 151, 225,
+        136, 193, 228, 82, 28,
     ];
 
     let plaintext: Vec<u8> = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
@@ -62,8 +52,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+    fn test_encryption() {
+        assert!(encryption_selftest());
     }
 }


### PR DESCRIPTION
## Overview

The goal of this project is to ship Rust code in a format that iOS/MacOS can consume natively. This may help unblock React-Native efforts (see: [issue](https://github.com/xmtp/xmtp-react-native/issues/10)).

Our strategy here is simple (credit to this [blog post](https://betterprogramming.pub/from-rust-to-swift-df9bde59b7cd))
- Build Rust code and target iOS/MacOS resulting in libraries ".a" files
- Package those libraries into an XCFramework
- Pair this with https://github.com/xmtp/xmtp-rust-swift - a thin repo that provides a Swift package interface wrapping the XCFramework
- Consume xmtp-rust-swift via Swift Package Manager in xmtp-ios

## Current Functionality

We can build xmtp-ios with xmtp-rust-swift via local XCFramework injection

Make-driven
- builds
- local XCFramework injection (or clean remote references if XCFramework bundle is hosted somewhere publicly)

## Missing Functionality

Lots of room to refine the remote hosting flow. Ideally every build would put a temp object in an HTTPS accessible bucket and update the Package.swift in xmtp-rust-swift in a custom branch so devs can reference it.