### PR TITLE
feat: rustls and full grpc api support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,9 +93,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.6.16"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "113713495a32dd0ab52baf5c10044725aa3aec00b31beda84218e469029b72a3"
+checksum = "3b32c5ea3aabaf4deb5f5ced2d688ec0844c881c9e6c696a8b769a05fc691e62"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -566,9 +566,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.18"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
+checksum = "66b91535aa35fea1523ad1b86cb6b53c28e0ae566ba4a460f4457e936cad7c6f"
 dependencies = [
  "bytes",
  "fnv",
@@ -866,9 +866,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f508063cc7bb32987c71511216bd5a32be15bccb6a80b52df8b9d7f01fc3aa2"
+checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
 
 [[package]]
 name = "log"
@@ -1076,16 +1076,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
-name = "prettyplease"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
-dependencies = [
- "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1106,9 +1096,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.9"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
+checksum = "7f835c582e6bd972ba8347313300219fed5bfa52caf175298d860b61ff6069bb"
 dependencies = [
  "bytes",
  "heck",
@@ -1117,11 +1107,9 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prettyplease",
  "prost",
  "prost-types",
  "regex",
- "syn 1.0.109",
  "tempfile",
  "which",
 ]
@@ -1275,9 +1263,9 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustix"
-version = "0.37.12"
+version = "0.37.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722529a737f5a942fdbac3a46cee213053196737c5eaa3386d52e85b786f2659"
+checksum = "85597d61f83914ddeba6a47b3b8ffe7365107221c2e557ed94426489fefb5f77"
 dependencies = [
  "bitflags",
  "errno",
@@ -1694,9 +1682,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.9.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
+checksum = "38bd8e87955eb13c1986671838177d6792cdc52af9bffced0d2c8a9a7f741ab3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2207,7 +2195,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-rustls",
- "tonic 0.9.2",
+ "tonic 0.9.1",
  "tonic-reflection",
  "tower",
  "webpki-roots",
@@ -2223,7 +2211,7 @@ dependencies = [
  "prost",
  "prost-types",
  "serde",
- "tonic 0.9.2",
+ "tonic 0.9.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,6 +249,16 @@ name = "const-oid"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -661,6 +693,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
+dependencies = [
+ "http",
+ "hyper",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -908,6 +955,12 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "pbjson"
@@ -1247,6 +1300,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+dependencies = [
+ "base64 0.21.0",
+]
+
+[[package]]
 name = "rustls-webpki"
 version = "0.100.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1267,6 +1341,15 @@ name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+
+[[package]]
+name = "schannel"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+dependencies = [
+ "windows-sys 0.42.0",
+]
 
 [[package]]
 name = "scoped-tls"
@@ -1302,6 +1385,29 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1563,10 +1669,36 @@ dependencies = [
 
 [[package]]
 name = "tonic"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "base64 0.13.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "prost-derive",
+ "tokio-stream",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
+ "async-stream",
  "async-trait",
  "axum",
  "base64 0.21.0",
@@ -1581,12 +1713,28 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
+ "rustls-pemfile",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tonic-reflection"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67494bad4dda4c9bffae901dfe14e2b2c0f760adb4706dc10beeb81799f7f7b2"
+dependencies = [
+ "bytes",
+ "prost",
+ "prost-types",
+ "tokio",
+ "tokio-stream",
+ "tonic 0.8.3",
 ]
 
 [[package]]
@@ -1628,6 +1776,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1822,6 +1971,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa54963694b65584e170cf5dc46aeb4dcaa5584e652ff5f3952e56d66aff0125"
+dependencies = [
+ "rustls-webpki",
+]
+
+[[package]]
 name = "which"
 version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1870,6 +2028,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
  "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -2025,6 +2198,8 @@ name = "xmtp-networking"
 version = "0.1.0"
 dependencies = [
  "base64 0.21.0",
+ "hyper",
+ "hyper-rustls",
  "pbjson",
  "pbjson-types",
  "prost",
@@ -2032,7 +2207,10 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-rustls",
- "tonic",
+ "tonic 0.9.2",
+ "tonic-reflection",
+ "tower",
+ "webpki-roots",
  "xmtp-proto",
 ]
 
@@ -2045,7 +2223,7 @@ dependencies = [
  "prost",
  "prost-types",
  "serde",
- "tonic",
+ "tonic 0.9.2",
 ]
 
 [[package]]

--- a/bindings/xmtp_rust_swift/.gitignore
+++ b/bindings/xmtp_rust_swift/.gitignore
@@ -15,8 +15,8 @@ bundle.zip
 .build
 
 # Ignore swift files in include/
-./include/Generated/*.swift
-./include/Generated/xmtp_rust_swift/*.swift
+/include/Generated/*.swift
+/include/Generated/xmtp_rust_swift/*.swift
 
 # Ignore Generated, gets rebuilt on cargo build
-./Generated
+/Generated

--- a/bindings/xmtp_rust_swift/.gitignore
+++ b/bindings/xmtp_rust_swift/.gitignore
@@ -13,4 +13,10 @@ bundle.zip
 /target
 /Cargo.lock
 .build
+
+# Ignore swift files in include/
+./include/Generated/*.swift
+./include/Generated/xmtp_rust_swift/*.swift
+
+# Ignore Generated, gets rebuilt on cargo build
 ./Generated

--- a/bindings/xmtp_rust_swift/Generated/xmtp_rust_swift/xmtp_rust_swift.swift
+++ b/bindings/xmtp_rust_swift/Generated/xmtp_rust_swift/xmtp_rust_swift.swift
@@ -22,7 +22,7 @@ class CbWrapper$query {
         self.cb = cb
     }
 }
-public func publish<GenericIntoRustString: IntoRustString>(_ host: GenericIntoRustString, _ token: GenericIntoRustString, _ json_envelopes: GenericIntoRustString) async -> ResponseJson {
+public func publish<GenericIntoRustString: IntoRustString>(_ host: GenericIntoRustString, _ token: GenericIntoRustString, _ json_envelopes: RustVec<GenericIntoRustString>) async -> ResponseJson {
     func onComplete(cbWrapperPtr: UnsafeMutableRawPointer?, rustFnRetVal: __swift_bridge__$ResponseJson) {
         let wrapper = Unmanaged<CbWrapper$publish>.fromOpaque(cbWrapperPtr!).takeRetainedValue()
         wrapper.cb(.success(rustFnRetVal.intoSwiftRepr()))
@@ -36,7 +36,7 @@ public func publish<GenericIntoRustString: IntoRustString>(_ host: GenericIntoRu
         let wrapper = CbWrapper$publish(cb: callback)
         let wrapperPtr = Unmanaged.passRetained(wrapper).toOpaque()
 
-        __swift_bridge__$publish(wrapperPtr, onComplete, { let rustString = host.intoRustString(); rustString.isOwned = false; return rustString.ptr }(), { let rustString = token.intoRustString(); rustString.isOwned = false; return rustString.ptr }(), { let rustString = json_envelopes.intoRustString(); rustString.isOwned = false; return rustString.ptr }())
+        __swift_bridge__$publish(wrapperPtr, onComplete, { let rustString = host.intoRustString(); rustString.isOwned = false; return rustString.ptr }(), { let rustString = token.intoRustString(); rustString.isOwned = false; return rustString.ptr }(), { let val = json_envelopes; val.isOwned = false; return val.ptr }())
     })
 }
 class CbWrapper$publish {

--- a/bindings/xmtp_rust_swift/src/lib.rs
+++ b/bindings/xmtp_rust_swift/src/lib.rs
@@ -14,7 +14,7 @@ mod ffi {
 
     extern "Rust" {
         async fn query(host: String, topic: String, json_paging_info: String) -> ResponseJson;
-        async fn publish(host: String, token: String, json_envelopes: String) -> ResponseJson;
+        async fn publish(host: String, token: String, json_envelopes: Vec<String>) -> ResponseJson;
         async fn subscribe(host: String, topics: Vec<String>) -> ResponseJson;
         fn poll_subscription(subscription_id: String) -> ResponseJson;
     }
@@ -38,9 +38,9 @@ async fn query(host: String, topic: String, json_paging_info: String) -> ffi::Re
     }
 }
 
-async fn publish(host: String, token: String, json_envelopes: String) -> ffi::ResponseJson {
+async fn publish(host: String, token: String, json_envelopes: Vec<String>) -> ffi::ResponseJson {
     println!(
-        "Received a request to publish host: {}, token: {}, envelopes: {}",
+        "Received a request to publish host: {}, token: {}, envelopes: {:?}",
         host, token, json_envelopes
     );
     let publish_result = grpc_api_helper::publish_serialized(host, token, json_envelopes).await;
@@ -137,7 +137,7 @@ mod tests {
         let publish_result = super::publish(
             ADDRESS.to_string(),
             "test".to_string(),
-            xmtp_networking::grpc_api_helper::test_envelope(topic.to_string()),
+            vec!(xmtp_networking::grpc_api_helper::test_envelope(topic.to_string())),
         )
         .await;
         assert_eq!(publish_result.error, "");

--- a/bindings/xmtp_rust_swift/src/subscriptions.rs
+++ b/bindings/xmtp_rust_swift/src/subscriptions.rs
@@ -22,9 +22,9 @@ pub fn get_messages(id: String) -> Option<Vec<Envelope>> {
     let sub = subscriptions.get(&id);
     let new_messages = sub?.get_and_reset_pending();
 
-    if new_messages.len() > 0 {
+    if !new_messages.is_empty() {
         return Some(new_messages);
     }
 
-    return None;
+    None
 }

--- a/crates/xmtp-networking/Cargo.toml
+++ b/crates/xmtp-networking/Cargo.toml
@@ -10,10 +10,7 @@ xmtp-proto = { path = "../xmtp-proto", features = ["proto_full"] }
 prost = { version  = "^0.11", features = ["prost-derive"] }
 tonic = { version = "^0.9", features = ["tls"] }
 tokio = { version = "1.24", features = ["macros", "rt-multi-thread"] }
-<<<<<<< HEAD
-=======
 tonic-reflection = "0.6.0"
->>>>>>> fcfa6c0 (fix: need to somehow rework the URI for publish)
 tokio-rustls = "0.24.0"
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/xmtp-networking/Cargo.toml
+++ b/crates/xmtp-networking/Cargo.toml
@@ -10,6 +10,10 @@ xmtp-proto = { path = "../xmtp-proto", features = ["proto_full"] }
 prost = { version  = "^0.11", features = ["prost-derive"] }
 tonic = { version = "^0.9", features = ["tls"] }
 tokio = { version = "1.24", features = ["macros", "rt-multi-thread"] }
+<<<<<<< HEAD
+=======
+tonic-reflection = "0.6.0"
+>>>>>>> fcfa6c0 (fix: need to somehow rework the URI for publish)
 tokio-rustls = "0.24.0"
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/xmtp-networking/Cargo.toml
+++ b/crates/xmtp-networking/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tonic = "^0.9"
 xmtp-proto = { path = "../xmtp-proto", features = ["proto_full"] }
 prost = { version  = "^0.11", features = ["prost-derive"] }
+tonic = { version = "^0.9", features = ["tls"] }
 tokio = { version = "1.24", features = ["macros", "rt-multi-thread"] }
 tokio-rustls = "0.24.0"
 serde = { version = "1.0.160", features = ["derive"] }
@@ -16,3 +16,7 @@ serde_json = "1.0"
 base64 = "0.21.0"
 pbjson = "0.5.1"
 pbjson-types = "0.5.1"
+webpki-roots = "0.23.0"
+hyper = "0.14.26"
+hyper-rustls = { version = "0.24.0", features = ["http2"]}
+tower = "0.4.13"

--- a/crates/xmtp-networking/src/grpc_api_helper.rs
+++ b/crates/xmtp-networking/src/grpc_api_helper.rs
@@ -5,7 +5,6 @@ use tonic::{metadata::MetadataValue, transport::Channel, Request, Streaming};
 use xmtp_proto::xmtp::message_api::v1::{self, Envelope};
 use hyper::{client::HttpConnector, Uri};
 use tokio_rustls::rustls::{ClientConfig, OwnedTrustAnchor, RootCertStore};
-use tonic::{metadata::MetadataValue, Request};
 
 use std::str::FromStr;
 

--- a/crates/xmtp-networking/src/grpc_api_helper.rs
+++ b/crates/xmtp-networking/src/grpc_api_helper.rs
@@ -140,9 +140,8 @@ pub async fn publish(
 
     let request = v1::PublishRequest { envelopes };
 
-    // TODO: this code sucks, but if the host was TLS, we need to use the tls_client otherwise
-    // we need to use the non_tls_client. It's hard to DRY up because both clients have
-    // different types and can't be assigned to the same variable.
+    // TODO: See above about DRY-ing up clients. Probably want to re-use the same client
+    // in the future.
     let response = if host.starts_with("https://") {
         println!("Using TLS client");
         // Set up the TLS client

--- a/crates/xmtp-networking/src/grpc_api_helper.rs
+++ b/crates/xmtp-networking/src/grpc_api_helper.rs
@@ -77,8 +77,7 @@ pub async fn query(
                 format!("Failed to create TLS connector: {}", e),
             )
         })?;
-        // TODO: Ideally I'd get the entire hyper::Client created in a separate function
-        // but I'm hitting some lifetime issues
+        // TODO: I can't get this part into a helper function because of lifetime woes
         let client = hyper::Client::builder().build(connector);
         let uri = Uri::from_str(&host)
             .map_err(|e| tonic::Status::new(tonic::Code::Internal, format!("{}", e)))?;

--- a/crates/xmtp-networking/src/grpc_api_helper.rs
+++ b/crates/xmtp-networking/src/grpc_api_helper.rs
@@ -1,10 +1,10 @@
+use hyper::{client::HttpConnector, Uri};
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::oneshot;
-use tonic::{metadata::MetadataValue, transport::Channel, Request, Streaming};
-use xmtp_proto::xmtp::message_api::v1::{self, Envelope};
-use hyper::{client::HttpConnector, Uri};
 use tokio_rustls::rustls::{ClientConfig, OwnedTrustAnchor, RootCertStore};
+use tonic::{metadata::MetadataValue, Request, Streaming};
+use xmtp_proto::xmtp::message_api::v1::{self, Envelope};
 
 use std::str::FromStr;
 
@@ -214,7 +214,7 @@ pub async fn subscribe(host: String, topics: Vec<String>) -> Result<Subscription
     };
     let stream = client.subscribe(request).await.unwrap().into_inner();
 
-    return Ok(Subscription::start(stream).await);
+    Ok(Subscription::start(stream).await)
 }
 
 // Return the json serialization of an Envelope with bytes
@@ -222,7 +222,7 @@ pub fn test_envelope(topic: String) -> String {
     let time_since_epoch = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
     let envelope = v1::Envelope {
         timestamp_ns: time_since_epoch.as_nanos() as u64,
-        content_topic: topic.to_string(),
+        content_topic: topic,
         message: vec![65],
         ..Default::default()
     };

--- a/crates/xmtp-networking/src/grpc_api_helper.rs
+++ b/crates/xmtp-networking/src/grpc_api_helper.rs
@@ -77,7 +77,8 @@ pub async fn query(
                 format!("Failed to create TLS connector: {}", e),
             )
         })?;
-        // TODO: I can't get this part into a helper function because of lifetime woes
+        // TODO: Ideally I'd get the entire hyper::Client created in a separate function
+        // but I'm hitting some lifetime issues
         let client = hyper::Client::builder().build(connector);
         let uri = Uri::from_str(&host)
             .map_err(|e| tonic::Status::new(tonic::Code::Internal, format!("{}", e)))?;

--- a/crates/xmtp-networking/src/grpc_api_helper.rs
+++ b/crates/xmtp-networking/src/grpc_api_helper.rs
@@ -192,11 +192,13 @@ pub async fn publish(
 pub async fn publish_serialized(
     host: String,
     token: String,
-    json_envelopes: String,
+    json_envelopes: Vec<String>,
 ) -> Result<String, String> {
-    // Deserialize the JSON string into a vector of Envelopes
-    let envelopes: Vec<v1::Envelope> = serde_json::from_str(&json_envelopes)
-        .map_err(|e| format!("Failed to deserialize JSON: {}", e))?;
+    // Map the json_envelops to a Vec<v1::Envelope> using serde_json
+    let envelopes: Vec<v1::Envelope> = json_envelopes
+        .iter()
+        .map(|e| serde_json::from_str(e).map_err(|e| format!("{}", e)))
+        .collect::<Result<Vec<v1::Envelope>, String>>()?;
     let response = publish(host, token, envelopes)
         .await
         .map_err(|e| format!("{}", e))?;

--- a/crates/xmtp-networking/src/lib.rs
+++ b/crates/xmtp-networking/src/lib.rs
@@ -8,7 +8,7 @@ pub mod serialize_utils;
 mod tests {
     use super::*;
     use grpc_api_helper::test_envelope;
-    use grpc_api_helper::{publish, publish_serialized, query_serialized, subscribe};
+    use grpc_api_helper::{publish_serialized, query_serialized, subscribe};
 
     #[tokio::test]
     async fn grpc_query_test() {

--- a/crates/xmtp-networking/src/lib.rs
+++ b/crates/xmtp-networking/src/lib.rs
@@ -55,4 +55,24 @@ mod tests {
         .await
         .expect("Timed out");
     }
+
+    #[test]
+    fn grpc_query_local_test() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let resp = query_serialized(
+                "http://localhost:15555".to_string(),
+                "test".to_string(),
+                "".to_string(),
+            )
+            .await;
+            println!("{:?}", resp);
+            assert!(resp.is_ok());
+            // Check that the response has some messages
+            // Assert response is a string that isn't empty and starts with a { like JSON
+            let resp_str = resp.unwrap();
+            assert!(!resp_str.is_empty());
+            assert!(resp_str.starts_with('{'));
+        });
+    }
 }

--- a/crates/xmtp-networking/src/lib.rs
+++ b/crates/xmtp-networking/src/lib.rs
@@ -37,7 +37,7 @@ mod tests {
 
             // Skipping the auth token because we have authn disabled on the local
             // xmtp-node-go instance
-            publish(
+            publish_serialized(
                 host.to_string(),
                 "".to_string(),
                 test_envelope(String::from(topic)),

--- a/crates/xmtp-networking/src/lib.rs
+++ b/crates/xmtp-networking/src/lib.rs
@@ -8,7 +8,7 @@ pub mod serialize_utils;
 mod tests {
     use super::*;
     use grpc_api_helper::test_envelope;
-    use grpc_api_helper::{publish, query_serialized, subscribe};
+    use grpc_api_helper::{publish, publish_serialized, query_serialized, subscribe};
 
     #[tokio::test]
     async fn grpc_query_test() {
@@ -73,6 +73,21 @@ mod tests {
             let resp_str = resp.unwrap();
             assert!(!resp_str.is_empty());
             assert!(resp_str.starts_with('{'));
+        });
+    }
+
+    #[test]
+    fn test_publish_simple() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let resp = publish_serialized(
+                "https://dev.xmtp.network:5556".to_string(),
+                "token".to_string(),
+                "[]".to_string(),
+            )
+            .await;
+            println!("{:?}", resp);
+            assert!(resp.is_ok());
         });
     }
 }

--- a/crates/xmtp-networking/src/lib.rs
+++ b/crates/xmtp-networking/src/lib.rs
@@ -76,18 +76,19 @@ mod tests {
         });
     }
 
-    #[test]
-    fn test_publish_simple() {
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        rt.block_on(async {
-            let resp = publish_serialized(
-                "https://dev.xmtp.network:5556".to_string(),
-                "token".to_string(),
-                Vec::new(),
-            )
-            .await;
-            println!("{:?}", resp);
-            assert!(resp.is_ok());
-        });
-    }
+    // NOTE: this test fails because we cannot generate a valid token
+    // #[test]
+    // fn test_publish_simple() {
+    //     let rt = tokio::runtime::Runtime::new().unwrap();
+    //     rt.block_on(async {
+    //         let resp = publish_serialized(
+    //             "https://dev.xmtp.network:5556".to_string(),
+    //             "token".to_string(),
+    //             Vec::new(),
+    //         )
+    //         .await;
+    //         println!("{:?}", resp);
+    //         assert!(resp.is_ok());
+    //     });
+    // }
 }

--- a/crates/xmtp-networking/src/lib.rs
+++ b/crates/xmtp-networking/src/lib.rs
@@ -40,7 +40,7 @@ mod tests {
             publish_serialized(
                 host.to_string(),
                 "".to_string(),
-                test_envelope(String::from(topic)),
+                vec!(test_envelope(String::from(topic))),
             )
             .await
             .unwrap();
@@ -61,7 +61,7 @@ mod tests {
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {
             let resp = query_serialized(
-                "http://localhost:15555".to_string(),
+                "http://localhost:5556".to_string(),
                 "test".to_string(),
                 "".to_string(),
             )
@@ -83,7 +83,7 @@ mod tests {
             let resp = publish_serialized(
                 "https://dev.xmtp.network:5556".to_string(),
                 "token".to_string(),
-                "[]".to_string(),
+                Vec::new(),
             )
             .await;
             println!("{:?}", resp);


### PR DESCRIPTION
## Overview

This implements TLS for gRPC api connections, albeit in a slightly ugly way. My main inspiration was the rust_tls [example](https://github.com/hyperium/tonic/blob/master/examples/src/tls_rustls/client.rs) in tonic repo. This code has been tested with `xmtp-ios` and passes all tests if used as an approximate drop-in replacement for gRPC.

I want to DRY things up, especially with client creation but I'm wrangling with Rust lifetimes and complicated return types. For now, I'll stick to this (works and is tested) and we can refactor iteratively.

## Changes

- Rework publish/query/subscribe to initialize either TLS enabled or non-TLS clients, depending on the host string passed in.
- Change `publish` to take a Vec of JSON-encoded envelope protos. This ends up being more ergonomic than trying to construct then JSON encode a list of Envelopes in Swift

## Tests
- Unit tests (if local node is up)
- E2E tests by running xmtp-ios (requires additional code in xmtp-rust-swift repo and [xmtp-ios](https://github.com/xmtp/xmtp-ios/tree/4052e23) to utilize the Rust gRPC api service

