### PR TITLE
feat: use same name for .a files for cocoapod support

### DIFF
--- a/bindings/xmtp_rust_swift/Makefile
+++ b/bindings/xmtp_rust_swift/Makefile
@@ -22,7 +22,7 @@ aarch64-apple-ios:
 	cargo build --target $@ --target-dir ./target --release
 
 $(LIB): $(ARCHS_IOS) $(ARCHS_MAC) aarch64-apple-ios
-	rm -f lipo_macos lipo_ios_simulator
+	rm -rf lipo_macos lipo_ios_simulator
 	mkdir -p lipo_macos lipo_ios_simulator
 	lipo -create -output lipo_ios_simulator/libxmtp_rust_swift.a $(foreach arch,$(ARCHS_IOS),$(wildcard target/$(arch)/release/$(LIB)))
 	lipo -create -output lipo_macos/libxmtp_rust_swift.a $(foreach arch,$(ARCHS_MAC),$(wildcard target/$(arch)/release/$(LIB)))

--- a/bindings/xmtp_rust_swift/Makefile
+++ b/bindings/xmtp_rust_swift/Makefile
@@ -22,9 +22,10 @@ aarch64-apple-ios:
 	cargo build --target $@ --target-dir ./target --release
 
 $(LIB): $(ARCHS_IOS) $(ARCHS_MAC) aarch64-apple-ios
-	rm -f libxmtp_rust_swift_iossimulator.a libxmtp_rust_swift_macos.a
-	lipo -create -output libxmtp_rust_swift_iossimulator.a $(foreach arch,$(ARCHS_IOS),$(wildcard target/$(arch)/release/$(LIB)))
-	lipo -create -output libxmtp_rust_swift_macos.a $(foreach arch,$(ARCHS_MAC),$(wildcard target/$(arch)/release/$(LIB)))
+	rm -f lipo_macos lipo_ios_simulator
+	mkdir -p lipo_macos lipo_ios_simulator
+	lipo -create -output lipo_ios_simulator/libxmtp_rust_swift.a $(foreach arch,$(ARCHS_IOS),$(wildcard target/$(arch)/release/$(LIB)))
+	lipo -create -output lipo_macos/libxmtp_rust_swift.a $(foreach arch,$(ARCHS_MAC),$(wildcard target/$(arch)/release/$(LIB)))
 
 move_gen:
 	# Move "Generated" directory to "include"
@@ -34,9 +35,9 @@ move_gen:
 pkg: $(LIB) move_gen
 	rm -rf XMTPRustSwift.xcframework
 	xcodebuild -create-xcframework \
-		-library ./libxmtp_rust_swift_macos.a \
+		-library ./lipo_macos/libxmtp_rust_swift.a \
 		-headers ./include/ \
-		-library ./libxmtp_rust_swift_iossimulator.a \
+		-library ./lipo_ios_simulator/libxmtp_rust_swift.a \
 		-headers ./include/ \
 		-library ./target/aarch64-apple-ios/release/libxmtp_rust_swift.a \
 		-headers ./include/ \

--- a/bindings/xmtp_rust_swift/copy_xcframework_to_swift.sh
+++ b/bindings/xmtp_rust_swift/copy_xcframework_to_swift.sh
@@ -7,7 +7,7 @@ set -ex
 
 # Look for an xmtp_rust_swift repo at the sibling layer of the top level of this repo so ../../../
 
-REPONAME="xmtp_rust_swift"
+REPONAME="xmtp-rust-swift"
 REPOPATH="../../../$REPONAME"
 # Now move the XMTPRustSwift.xcframework to the Swift package
 rm -rf "$REPOPATH/XMTPRustSwift.xcframework"


### PR DESCRIPTION
## Overview

Our original setup named the `.a` files with their target platform e.g. `libxmtp_rust_swift_macos.a`. Cocoapods doesn't like that:
```
 -> XMTPRust (0.1.0)
    - ERROR | [OSX] unknown: Encountered an unknown error (Unable to install vendored xcframework `XMTPRustSwift` for Pod `XMTPRust` because it contains static libraries
with differing binary names: libxmtp_rust_swift, libxmtp_rust_swift_iossimulator, and libxmtp_rust_swift_macos.
```

So instead we name all of the platform-specific libraries `libxmtp_rust_swift.a` and use separate directories to hold them until xcframework assembly time.

## Test Plan

Use XMTPRustSwift.xcframework in xmtp-ios and ensure tests pass