### PR TITLE
create functions for client creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2186,6 +2186,7 @@ name = "xmtp-networking"
 version = "0.1.0"
 dependencies = [
  "base64 0.21.0",
+ "http-body",
  "hyper",
  "hyper-rustls",
  "pbjson",

--- a/crates/xmtp-networking/Cargo.toml
+++ b/crates/xmtp-networking/Cargo.toml
@@ -21,3 +21,4 @@ webpki-roots = "0.23.0"
 hyper = "0.14.26"
 hyper-rustls = { version = "0.24.0", features = ["http2"]}
 tower = "0.4.13"
+http-body = "0.4.5"


### PR DESCRIPTION
This PR reduces code repetition by creating functions to create the clients. 

To improve further, the code could be restructured such that 'Query' And 'Publish' are implemented for the ClientType. Rather that trying to return two different objects from the same function, implement generic Query and Publish for all ClientsTypes. 