### PR TITLE
TLS Support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,6 +229,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
 
 [[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +671,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
+dependencies = [
+ "http",
+ "hyper",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -908,6 +933,12 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "pbjson"
@@ -1247,6 +1278,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+dependencies = [
+ "base64 0.21.0",
+]
+
+[[package]]
 name = "rustls-webpki"
 version = "0.100.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1267,6 +1319,15 @@ name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+
+[[package]]
+name = "schannel"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+dependencies = [
+ "windows-sys 0.42.0",
+]
 
 [[package]]
 name = "scoped-tls"
@@ -1302,6 +1363,29 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1628,6 +1712,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1822,6 +1907,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa54963694b65584e170cf5dc46aeb4dcaa5584e652ff5f3952e56d66aff0125"
+dependencies = [
+ "rustls-webpki",
+]
+
+[[package]]
 name = "which"
 version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1870,6 +1964,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
  "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -2025,6 +2134,9 @@ name = "xmtp-networking"
 version = "0.1.0"
 dependencies = [
  "base64 0.21.0",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
  "pbjson",
  "pbjson-types",
  "prost",
@@ -2033,6 +2145,8 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tonic",
+ "tower",
+ "webpki-roots",
  "xmtp-proto",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,6 +1779,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "uuid"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b55a3fef2a1e3b3a00ce878640918820d3c51081576ac657d23af9fc7928fdb"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2146,6 +2155,7 @@ dependencies = [
  "tokio-rustls",
  "tonic",
  "tower",
+ "uuid",
  "webpki-roots",
  "xmtp-proto",
 ]

--- a/bindings/xmtp_rust_swift/Generated/xmtp_rust_swift/xmtp_rust_swift.h
+++ b/bindings/xmtp_rust_swift/Generated/xmtp_rust_swift/xmtp_rust_swift.h
@@ -59,7 +59,7 @@ struct __private__ResultPtrAndPtr __swift_bridge__$RustSubscription$get_messages
 void __swift_bridge__$RustSubscription$close(void* self);
 void* __swift_bridge__$QueryResponse$envelopes(void* self);
 struct __swift_bridge__$Option$PagingInfo __swift_bridge__$QueryResponse$paging_info(void* self);
-void __swift_bridge__$create_client(void* callback_wrapper, void __swift_bridge__$create_client$async(void* callback_wrapper, struct __private__ResultPtrAndPtr ret), void* host);
+void __swift_bridge__$create_client(void* callback_wrapper, void __swift_bridge__$create_client$async(void* callback_wrapper, struct __private__ResultPtrAndPtr ret), void* host, bool is_secure);
 void __swift_bridge__$RustClient$query(void* callback_wrapper, void __swift_bridge__$RustClient$query$async(void* callback_wrapper, struct __private__ResultPtrAndPtr ret), void* self, void* topic, struct __private__OptionU64 start_time_ns, struct __private__OptionU64 end_time_ns, struct __swift_bridge__$Option$PagingInfo paging_info);
 void __swift_bridge__$RustClient$publish(void* callback_wrapper, void __swift_bridge__$RustClient$publish$async(void* callback_wrapper, struct __private__ResultVoidAndPtr ret), void* self, void* token, void* envelopes);
 void __swift_bridge__$RustClient$subscribe(void* callback_wrapper, void __swift_bridge__$RustClient$subscribe$async(void* callback_wrapper, struct __private__ResultPtrAndPtr ret), void* self, void* topics);

--- a/bindings/xmtp_rust_swift/Generated/xmtp_rust_swift/xmtp_rust_swift.swift
+++ b/bindings/xmtp_rust_swift/Generated/xmtp_rust_swift/xmtp_rust_swift.swift
@@ -1,4 +1,4 @@
-public func create_client<GenericIntoRustString: IntoRustString>(_ host: GenericIntoRustString) async throws -> RustClient {
+public func create_client<GenericIntoRustString: IntoRustString>(_ host: GenericIntoRustString, _ is_secure: Bool) async throws -> RustClient {
     func onComplete(cbWrapperPtr: UnsafeMutableRawPointer?, rustFnRetVal: __private__ResultPtrAndPtr) {
         let wrapper = Unmanaged<CbWrapper$create_client>.fromOpaque(cbWrapperPtr!).takeRetainedValue()
         if rustFnRetVal.is_ok {
@@ -16,7 +16,7 @@ public func create_client<GenericIntoRustString: IntoRustString>(_ host: Generic
         let wrapper = CbWrapper$create_client(cb: callback)
         let wrapperPtr = Unmanaged.passRetained(wrapper).toOpaque()
 
-        __swift_bridge__$create_client(wrapperPtr, onComplete, { let rustString = host.intoRustString(); rustString.isOwned = false; return rustString.ptr }())
+        __swift_bridge__$create_client(wrapperPtr, onComplete, { let rustString = host.intoRustString(); rustString.isOwned = false; return rustString.ptr }(), is_secure)
     })
 }
 class CbWrapper$create_client {

--- a/bindings/xmtp_rust_swift/include/Generated/xmtp_rust_swift/xmtp_rust_swift.h
+++ b/bindings/xmtp_rust_swift/include/Generated/xmtp_rust_swift/xmtp_rust_swift.h
@@ -59,7 +59,7 @@ struct __private__ResultPtrAndPtr __swift_bridge__$RustSubscription$get_messages
 void __swift_bridge__$RustSubscription$close(void* self);
 void* __swift_bridge__$QueryResponse$envelopes(void* self);
 struct __swift_bridge__$Option$PagingInfo __swift_bridge__$QueryResponse$paging_info(void* self);
-void __swift_bridge__$create_client(void* callback_wrapper, void __swift_bridge__$create_client$async(void* callback_wrapper, struct __private__ResultPtrAndPtr ret), void* host);
+void __swift_bridge__$create_client(void* callback_wrapper, void __swift_bridge__$create_client$async(void* callback_wrapper, struct __private__ResultPtrAndPtr ret), void* host, bool is_secure);
 void __swift_bridge__$RustClient$query(void* callback_wrapper, void __swift_bridge__$RustClient$query$async(void* callback_wrapper, struct __private__ResultPtrAndPtr ret), void* self, void* topic, struct __private__OptionU64 start_time_ns, struct __private__OptionU64 end_time_ns, struct __swift_bridge__$Option$PagingInfo paging_info);
 void __swift_bridge__$RustClient$publish(void* callback_wrapper, void __swift_bridge__$RustClient$publish$async(void* callback_wrapper, struct __private__ResultVoidAndPtr ret), void* self, void* token, void* envelopes);
 void __swift_bridge__$RustClient$subscribe(void* callback_wrapper, void __swift_bridge__$RustClient$subscribe$async(void* callback_wrapper, struct __private__ResultPtrAndPtr ret), void* self, void* topics);

--- a/bindings/xmtp_rust_swift/include/Generated/xmtp_rust_swift/xmtp_rust_swift.swift
+++ b/bindings/xmtp_rust_swift/include/Generated/xmtp_rust_swift/xmtp_rust_swift.swift
@@ -1,4 +1,4 @@
-public func create_client<GenericIntoRustString: IntoRustString>(_ host: GenericIntoRustString) async throws -> RustClient {
+public func create_client<GenericIntoRustString: IntoRustString>(_ host: GenericIntoRustString, _ is_secure: Bool) async throws -> RustClient {
     func onComplete(cbWrapperPtr: UnsafeMutableRawPointer?, rustFnRetVal: __private__ResultPtrAndPtr) {
         let wrapper = Unmanaged<CbWrapper$create_client>.fromOpaque(cbWrapperPtr!).takeRetainedValue()
         if rustFnRetVal.is_ok {
@@ -16,7 +16,7 @@ public func create_client<GenericIntoRustString: IntoRustString>(_ host: Generic
         let wrapper = CbWrapper$create_client(cb: callback)
         let wrapperPtr = Unmanaged.passRetained(wrapper).toOpaque()
 
-        __swift_bridge__$create_client(wrapperPtr, onComplete, { let rustString = host.intoRustString(); rustString.isOwned = false; return rustString.ptr }())
+        __swift_bridge__$create_client(wrapperPtr, onComplete, { let rustString = host.intoRustString(); rustString.isOwned = false; return rustString.ptr }(), is_secure)
     })
 }
 class CbWrapper$create_client {

--- a/bindings/xmtp_rust_swift/src/lib.rs
+++ b/bindings/xmtp_rust_swift/src/lib.rs
@@ -48,7 +48,7 @@ mod ffi {
     extern "Rust" {
         type RustClient;
 
-        async fn create_client(host: String) -> Result<RustClient, String>;
+        async fn create_client(host: String, is_secure: bool) -> Result<RustClient, String>;
 
         async fn query(
             &mut self,
@@ -72,8 +72,8 @@ pub struct RustClient {
     client: grpc_api_helper::Client,
 }
 
-async fn create_client(host: String) -> Result<RustClient, String> {
-    let client = grpc_api_helper::Client::create(host)
+async fn create_client(host: String, is_secure: bool) -> Result<RustClient, String> {
+    let client = grpc_api_helper::Client::create(host, is_secure)
         .await
         .map_err(|e| format!("{}", e))?;
 
@@ -175,7 +175,9 @@ mod tests {
     // Try a query on a test topic, and make sure we get a response
     #[tokio::test]
     async fn test_publish_query() {
-        let mut client = super::create_client(ADDRESS.to_string()).await.unwrap();
+        let mut client = super::create_client(ADDRESS.to_string(), false)
+            .await
+            .unwrap();
         let topic = Uuid::new_v4();
         let publish_result = client
             .publish("".to_string(), vec![test_envelope(topic.to_string())])
@@ -201,7 +203,9 @@ mod tests {
     #[tokio::test]
     async fn test_subscribe() {
         let topic = Uuid::new_v4();
-        let mut client = super::create_client(ADDRESS.to_string()).await.unwrap();
+        let mut client = super::create_client(ADDRESS.to_string(), false)
+            .await
+            .unwrap();
         let sub = client.subscribe(vec![topic.to_string()]).await.unwrap();
         std::thread::sleep(std::time::Duration::from_millis(100));
         let publish_result = client

--- a/crates/xmtp-networking/Cargo.toml
+++ b/crates/xmtp-networking/Cargo.toml
@@ -21,3 +21,4 @@ hyper-rustls = { version = "0.24.0", features = ["http2"]}
 http-body = "0.4.5"
 tower = "0.4.13"
 webpki-roots = "0.23.0"
+uuid = { version = "1.3.1", features = ["v4"] }

--- a/crates/xmtp-networking/Cargo.toml
+++ b/crates/xmtp-networking/Cargo.toml
@@ -16,3 +16,8 @@ serde_json = "1.0"
 base64 = "0.21.0"
 pbjson = "0.5.1"
 pbjson-types = "0.5.1"
+hyper = "0.14.26"
+hyper-rustls = { version = "0.24.0", features = ["http2"]}
+http-body = "0.4.5"
+tower = "0.4.13"
+webpki-roots = "0.23.0"

--- a/crates/xmtp-networking/Cargo.toml
+++ b/crates/xmtp-networking/Cargo.toml
@@ -21,4 +21,6 @@ hyper-rustls = { version = "0.24.0", features = ["http2"]}
 http-body = "0.4.5"
 tower = "0.4.13"
 webpki-roots = "0.23.0"
+
+[dev-dependencies]
 uuid = { version = "1.3.1", features = ["v4"] }

--- a/crates/xmtp-networking/src/lib.rs
+++ b/crates/xmtp-networking/src/lib.rs
@@ -22,7 +22,7 @@ mod tests {
 
     #[tokio::test]
     async fn grpc_query_test() {
-        let mut client = Client::create("http://localhost:5556".to_string())
+        let mut client = Client::create("http://localhost:5556".to_string(), false)
             .await
             .unwrap();
 
@@ -36,11 +36,11 @@ mod tests {
 
     #[tokio::test]
     async fn publish_test() {
-        let mut client = Client::create("http://localhost:5556".to_string())
+        let mut client = Client::create("http://localhost:5556".to_string(), false)
             .await
             .unwrap();
 
-        let topic = "test-publish";
+        let topic = uuid::Uuid::new_v4();
         let env = test_envelope(topic.to_string());
 
         let _result = client.publish("".to_string(), vec![env]).await.unwrap();
@@ -55,7 +55,7 @@ mod tests {
     #[tokio::test]
     async fn subscribe_test() {
         tokio::time::timeout(std::time::Duration::from_secs(5), async move {
-            let mut client = Client::create("http://localhost:5556".to_string())
+            let mut client = Client::create("http://localhost:5556".to_string(), false)
                 .await
                 .unwrap();
 
@@ -83,5 +83,19 @@ mod tests {
         })
         .await
         .expect("Timed out");
+    }
+
+    #[tokio::test]
+    async fn tls_test() {
+        let mut client = Client::create("https://dev.xmtp.network:5556".to_string(), true)
+            .await
+            .unwrap();
+
+        let result = client
+            .query(uuid::Uuid::new_v4().to_string(), None, None, None)
+            .await
+            .unwrap();
+
+        assert_eq!(result.envelopes.len(), 0);
     }
 }


### PR DESCRIPTION
## Summary

- Adds `is_secure` option to client creation and uses @jazzz and @michaelx11's code to implement TLS
- Adds a new TLS test against the dev network

## Notes

I do not have the Rust generics chops to figure out how to merge the `MessageApiClient` types into one, so I settled on an `enum` for both the `Client` and the `Conn`.

Ideally these would be a single value, and given that `MessageApiClient` is generic itself this feels plausible. But this will do for now.