### PR TITLE
Run all tests on PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,20 +11,14 @@ jobs:
       - uses: actions/checkout@v1
       - run: rustup component add clippy
       - uses: actions-rs/clippy-check@v1
-        name: xmtp-keystore
+        name: root
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          name: xmtp-keystore
-          args: --all-features --no-deps --manifest-path crates/xmtp-keystore/Cargo.toml
+          name: root
+          args: --all-features --no-deps
       - uses: actions-rs/clippy-check@v1
-        name: corecrypto
+        name: xmtp_rust_swift
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          name: corecrypto
-          args: --all-features --no-deps --manifest-path crates/xmtp-keystore/Cargo.toml
-      - uses: actions-rs/clippy-check@v1
-        name: libxmtp-core
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: libxmtp-core
-          args: --all-features --no-deps --manifest-path crates/libxmtp-core/Cargo.toml
+          name: xmtp_rust_swift
+          args: --all-features --no-deps --manifest-path bindings/xmtp_rust_swift/Cargo.toml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,13 +11,13 @@ jobs:
       - uses: actions/checkout@v1
       - run: rustup component add clippy
       - uses: actions-rs/clippy-check@v1
-        name: root
+        name: Lint main workspace
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: root
           args: --all-features --no-deps
       - uses: actions-rs/clippy-check@v1
-        name: xmtp_rust_swift
+        name: Lint xmtp_rust_swift
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: xmtp_rust_swift

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
         name: Lint main workspace
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          name: root
+          name: workspace
           args: --all-features --no-deps
       - uses: actions-rs/clippy-check@v1
         name: Lint xmtp_rust_swift

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: rustup component add clippy
+      - uses: bufbuild/buf-setup-action@v1.17.0
       - uses: actions-rs/clippy-check@v1
         name: Lint main workspace
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,27 +6,29 @@ on:
   pull_request:
 jobs:
   test-keystore:
-   name: Test Keystore
-   runs-on: ubuntu-latest
-   steps:
-     - name: Checkout sources
-       uses: actions/checkout@v2
+    name: Test Keystore
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
 
-     - name: Install stable toolchain
-       uses: actions-rs/toolchain@v1
-       with:
-         profile: minimal
-         toolchain: stable
-         override: true
+      - name: Start Docker containers
+        run: docker-compose -f ./dev/docker-compose.yml up -d
 
-     - name: Run cargo test on xmtp-keystore
-       uses: actions-rs/cargo@v1
-       with:
-         command: test
-         args: --manifest-path crates/xmtp-keystore/Cargo.toml
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
 
-     - name: Run cargo test on libxmtp-core
-       uses: actions-rs/cargo@v1
-       with:
-         command: test
-         args: --manifest-path crates/libxmtp-core/Cargo.toml
+      - name: Run cargo test on main workspace
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+      - name: Run cargo test on Swift bindings
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --manifest-path bindings/xmtp_rust_swift/Cargo.toml

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,6 +15,8 @@ jobs:
       - name: Start Docker containers
         run: docker-compose -f ./dev/docker-compose.yml up -d
 
+      - uses: bufbuild/buf-setup-action@v1.17.0
+
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,8 +5,8 @@ on:
       - main
   pull_request:
 jobs:
-  test-keystore:
-    name: Test Keystore
+  test:
+    name: Test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources

--- a/README.md
+++ b/README.md
@@ -6,12 +6,20 @@ This code is preliminary and meant for benchmarking. See latest progress `benchm
 
 Libxmtp is a platform agnostic implementation of the core cryptographic functionality to be used in XMTP sdk's
 
+## Requirements
+
+- To build `xmtp-proto` Buf must be installed on your machine. Visit the [Buf documentation](https://buf.build/docs/installation) for more info
+
 ## Structure
 
 Top-level
+
 - crates/ - the pure Rust implementation of XMTP APIs, agnostic to any per-language or per-platform binding
- - crates/xmtp-keystore - first crate, implements the Keystore API in Rust
+- crates/xmtp-keystore - first crate, implements the Keystore API in Rust
+- crates/xmtp-proto - Generated code for handling XMTP protocol buffers
+- crates/xmtp-networking - API client for XMTP's GRPC API, using code from `crates/xmtp-proto`
 - bindings/wasm - depends on libxmtp to generate a WASM library and bindings
+- bindings/xmtp_rust_swift - Swift bindings
 
 ## Rust Keystore QuickStart
 

--- a/bindings/xmtp_rust_swift/src/lib.rs
+++ b/bindings/xmtp_rust_swift/src/lib.rs
@@ -88,10 +88,7 @@ impl RustClient {
         end_time_ns: Option<u64>,
         paging_info: Option<ffi::PagingInfo>,
     ) -> Result<QueryResponse, String> {
-        let info = match paging_info {
-            Some(info) => Some(PagingInfo::from(info)),
-            None => None,
-        };
+        let info = paging_info.map(PagingInfo::from);
 
         let result = self
             .client
@@ -99,7 +96,7 @@ impl RustClient {
             .await
             .map_err(|e| format!("{}", e))?;
 
-        return Ok(QueryResponse::from(result));
+        Ok(QueryResponse::from(result))
     }
 
     async fn publish(
@@ -117,7 +114,7 @@ impl RustClient {
             .await
             .map_err(|e| format!("{}", e))?;
 
-        return Ok(());
+        Ok(())
     }
 
     async fn subscribe(&mut self, topics: Vec<String>) -> Result<RustSubscription, String> {
@@ -127,7 +124,7 @@ impl RustClient {
             .await
             .map_err(|e| format!("{}", e))?;
 
-        return Ok(RustSubscription { subscription });
+        Ok(RustSubscription { subscription })
     }
 }
 
@@ -139,14 +136,14 @@ impl RustSubscription {
     pub fn get_messages(&self) -> Result<Vec<ffi::Envelope>, String> {
         let new_messages = self.subscription.get_messages();
         // TODO: Figure out how to return an error if the stream is closed
-        if new_messages.len() > 0 {
+        if !new_messages.is_empty() {
             return Ok(new_messages
                 .iter()
                 .map(|e| ffi::Envelope::from(e.clone()))
                 .collect());
         }
 
-        return Ok(vec![]);
+        Ok(vec![])
     }
 
     pub fn close(&mut self) {

--- a/bindings/xmtp_rust_swift/src/types.rs
+++ b/bindings/xmtp_rust_swift/src/types.rs
@@ -106,13 +106,10 @@ impl From<ProtoQueryResponse> for QueryResponse {
         let envelopes = query_response
             .envelopes
             .into_iter()
-            .map(|envelope| crate::ffi::Envelope::from(envelope))
+            .map(crate::ffi::Envelope::from)
             .collect();
 
-        let paging_info = match query_response.paging_info {
-            Some(paging_info) => Some(crate::ffi::PagingInfo::from(paging_info)),
-            None => None,
-        };
+        let paging_info = query_response.paging_info.map(crate::ffi::PagingInfo::from);
 
         QueryResponse {
             _envelopes: envelopes,

--- a/crates/xmtp-networking/src/grpc_api_helper.rs
+++ b/crates/xmtp-networking/src/grpc_api_helper.rs
@@ -79,11 +79,11 @@ impl Client {
             let uri = Uri::from_str(&host)
                 .map_err(|e| tonic::Status::new(tonic::Code::Internal, format!("{}", e)))?;
 
-            let tls_client = MessageApiClient::with_origin(tls_conn.clone(), uri);
+            let tls_client = MessageApiClient::with_origin(tls_conn, uri);
 
-            return Ok(Self {
+            Ok(Self {
                 client: InnerApiClient::Tls(tls_client),
-            });
+            })
         } else {
             let channel = Channel::from_shared(host)
                 .map_err(|e| tonic::Status::new(tonic::Code::Internal, format!("{}", e)))?
@@ -91,11 +91,11 @@ impl Client {
                 .await
                 .map_err(|e| tonic::Status::new(tonic::Code::Internal, format!("{}", e)))?;
 
-            let client = MessageApiClient::new(channel.clone());
+            let client = MessageApiClient::new(channel);
 
-            return Ok(Self {
+            Ok(Self {
                 client: InnerApiClient::Plain(client),
-            });
+            })
         }
     }
 

--- a/crates/xmtp-networking/src/grpc_api_helper.rs
+++ b/crates/xmtp-networking/src/grpc_api_helper.rs
@@ -145,7 +145,7 @@ impl Client {
                 .into_inner(),
         };
 
-        return Ok(Subscription::start(stream).await);
+        Ok(Subscription::start(stream).await)
     }
 
     pub async fn query(


### PR DESCRIPTION
## Summary

- Updates the Github workflows to run _all_ the tests in CI. Takes advantage of our workspace `Cargo.toml` to get most of our tests in one shot, and then separately runs the `xmtp_rust_swift` tests which have an unconnected `Cargo.toml`
- Simplifies lint job