### PR TITLE
fix: remove unused headers and update README warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
-# WARNING: DO NOT USE FOR PRODUCTION XMTP CLIENTS
-
-This code is preliminary and meant for benchmarking. See latest progress `benchmark` branch.
+> :warning: :warning: :warning: **Under Construction**: Parts of this code are in WIP and should not be used in production without guidance from the XMTP team
 
 # Libxmtp
 
-Libxmtp is a platform agnostic implementation of the core cryptographic functionality to be used in XMTP sdk's
+Libxmtp is a monorepo with multiple crates that encapsulate parts of XMTP messaging functionality, cryptography or bindings to other languages.
 
 ## Requirements
 

--- a/bindings/xmtp_rust_swift/include/module.modulemap
+++ b/bindings/xmtp_rust_swift/include/module.modulemap
@@ -1,5 +1,4 @@
 module XMTPRustSwift {
-    header "xmtp_rust_swift.h"
     header "Generated/SwiftBridgeCore.h"
     header "Generated/xmtp_rust_swift/xmtp_rust_swift.h"
     export *

--- a/bindings/xmtp_rust_swift/include/xmtp_rust_swift.h
+++ b/bindings/xmtp_rust_swift/include/xmtp_rust_swift.h
@@ -1,7 +1,0 @@
-#include <stdarg.h>
-#include <stdbool.h>
-#include <stdint.h>
-#include <stdlib.h>
-
-// Functions
-uint16_t grpc_selftest(void);


### PR DESCRIPTION
## Overview

The README top-level warning was outdated (pointing to `benchmark`) and I made it clear that different crates are at different levels of production maturity.

I also removed some old crufty headers from the Swift binding.