### PR TITLE
Throw errors on reading closed subscriptions

### DIFF
--- a/bindings/xmtp_rust_swift/src/types.rs
+++ b/bindings/xmtp_rust_swift/src/types.rs
@@ -55,6 +55,7 @@ impl From<PagingInfo> for crate::ffi::PagingInfo {
             },
             None => None,
         };
+        
         crate::ffi::PagingInfo {
             limit: paging_info.limit,
             direction: crate::ffi::SortDirection::from(

--- a/crates/xmtp-networking/Cargo.toml
+++ b/crates/xmtp-networking/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 tonic = "^0.9"
 xmtp-proto = { path = "../xmtp-proto", features = ["proto_full"] }
 prost = { version  = "^0.11", features = ["prost-derive"] }
-tokio = { version = "1.24", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.24", features = ["macros", "rt-multi-thread", "time"] }
 tokio-rustls = "0.24.0"
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
## Summary

- Running `get_messages` on a closed subscription will now throw an error.
- Subscriptions can be closed by either connection failure or manually closing the stream

## Notes

- Currently we make no distinction between forcibly closed Subscriptions (`close_stream`) and closure due to connection error. We also do not do retries on connection error. I kinda think retries should be the responsibility of the caller and we should leave this level simple and unopinionated on retry logic.