### PR TITLE
feat: can reference any branch and have protos build correctly

### DIFF
--- a/crates/xmtp-proto/build.rs
+++ b/crates/xmtp-proto/build.rs
@@ -29,7 +29,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let status = Command::new("buf")
         .arg("generate")
-        .arg("buf.build/xmtp/proto")
+        .arg("https://github.com/xmtp/proto.git#branch=michaelx-rust_v3_protos,subdir=proto")
         .current_dir(env!("CARGO_MANIFEST_DIR"))
         .status()
         .unwrap();

--- a/crates/xmtp-proto/build.rs
+++ b/crates/xmtp-proto/build.rs
@@ -29,7 +29,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let status = Command::new("buf")
         .arg("generate")
-        .arg("https://github.com/xmtp/proto.git#branch=michaelx-rust_v3_protos,subdir=proto")
+        .arg("https://github.com/xmtp/proto.git#branch=xmtpv3,subdir=proto")
         .current_dir(env!("CARGO_MANIFEST_DIR"))
         .status()
         .unwrap();


### PR DESCRIPTION
## Overview

Issue: https://github.com/orgs/xmtp/projects/8/views/4?pane=issue&itemId=26452558

This provides an example for being able to reference any xmtp/proto branch we want to target. Since `xmtp-proto` is shared, whatever branch we choose needs to be kept up to date with `xmtp/proto#main`.

## Test Plan

- Confirm that a new test field was added correctly
- Ensure that `cargo build` passes in `xmtp-proto` and in `xmtp-networking` which consumes xmtp-proto

## Open Question

What do you want to call our working branch? Should we utilize `beta` again? Edit: no, we're using `xmtpv3` on xmtp/proto
