### PR TITLE
add builder pattern for Client

### DIFF
--- a/bindings_wasm/src/lib.rs
+++ b/bindings_wasm/src/lib.rs
@@ -1,15 +1,19 @@
 use std::sync::Mutex;
 
 use wasm_bindgen::prelude::*;
-use xmtp::client::Client;
 use xmtp::persistence::InMemoryPersistence;
+use xmtp::{Client, ClientBuilder};
 
 static CLIENT_LIST: Mutex<Vec<Client<InMemoryPersistence>>> = Mutex::new(Vec::new());
 
 #[wasm_bindgen]
 pub fn client_create() -> usize {
     let mut clients = CLIENT_LIST.lock().unwrap();
-    clients.push(Client::new(InMemoryPersistence::new()));
+    clients.push(
+        ClientBuilder::new()
+            .persistence(InMemoryPersistence::new())
+            .build(),
+    );
     clients.len() - 1
 }
 

--- a/xmtp/src/builder.rs
+++ b/xmtp/src/builder.rs
@@ -41,18 +41,18 @@ where
     }
 }
 
-impl ClientBuilder<InMemoryPersistence> {
-    pub fn new_test() -> Self {
-        Self::new().persistence(InMemoryPersistence::new())
-    }
-}
-
 #[cfg(test)]
 mod tests {
 
     use crate::{client::Network, persistence::InMemoryPersistence};
 
     use super::ClientBuilder;
+
+    impl ClientBuilder<InMemoryPersistence> {
+        pub fn new_test() -> Self {
+            Self::new().persistence(InMemoryPersistence::new())
+        }
+    }
 
     #[test]
     fn builder_test() {

--- a/xmtp/src/builder.rs
+++ b/xmtp/src/builder.rs
@@ -1,6 +1,6 @@
 use crate::{
     client::{Client, Network},
-    persistence::{InMemoryPersistence, Persistence},
+    persistence::Persistence,
 };
 
 #[derive(Default)]

--- a/xmtp/src/builder.rs
+++ b/xmtp/src/builder.rs
@@ -1,0 +1,69 @@
+use crate::{
+    client::{Client, Network},
+    persistence::{InMemoryPersistence, Persistence},
+};
+
+#[derive(Default)]
+pub struct ClientBuilder<P>
+where
+    P: Persistence,
+{
+    network: Network,
+    persistence: Option<P>,
+}
+
+impl<P> ClientBuilder<P>
+where
+    P: Persistence,
+{
+    pub fn new() -> Self {
+        Self {
+            network: Network::Dev,
+            persistence: None,
+        }
+    }
+
+    pub fn network(mut self, network: Network) -> Self {
+        self.network = network;
+        self
+    }
+
+    pub fn persistence(mut self, persistence: P) -> Self {
+        self.persistence = Some(persistence);
+        self
+    }
+
+    pub fn build(self) -> Client<P> {
+        Client {
+            network: self.network,
+            persistence: self.persistence.expect("A persistence engine must be set"),
+        }
+    }
+}
+
+impl ClientBuilder<InMemoryPersistence> {
+    pub fn new_test() -> Self {
+        Self::new().persistence(InMemoryPersistence::new())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::{client::Network, persistence::InMemoryPersistence};
+
+    use super::ClientBuilder;
+
+    #[test]
+    fn builder_test() {
+        ClientBuilder::new_test().build();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_runtime_panic() {
+        ClientBuilder::<InMemoryPersistence>::new()
+            .network(Network::Dev)
+            .build();
+    }
+}

--- a/xmtp/src/client.rs
+++ b/xmtp/src/client.rs
@@ -1,17 +1,27 @@
 use crate::persistence::Persistence;
 
+#[derive(Clone, Copy)]
+pub enum Network {
+    Local(&'static str),
+    Dev,
+    Prod,
+}
+
+impl Default for Network {
+    fn default() -> Self {
+        Network::Dev
+    }
+}
+
 pub struct Client<P>
 where
     P: Persistence,
 {
-    persistence: P,
+    pub network: Network,
+    pub persistence: P,
 }
 
 impl<P: Persistence> Client<P> {
-    pub fn new(persistence: P) -> Self {
-        Client { persistence }
-    }
-
     pub fn write_to_persistence(&mut self, s: String, b: &[u8]) -> Result<(), String> {
         self.persistence.write(s, b)
     }

--- a/xmtp/src/lib.rs
+++ b/xmtp/src/lib.rs
@@ -1,13 +1,14 @@
+pub mod builder;
 pub mod client;
 pub mod persistence;
 
 #[cfg(test)]
 mod tests {
-    use crate::{client::Client, persistence::InMemoryPersistence};
+    use crate::builder::ClientBuilder;
 
     #[test]
     fn can_pass_persistence_methods() {
-        let mut client = Client::new(InMemoryPersistence::new());
+        let mut client = ClientBuilder::new_test().build();
         assert_eq!(
             client.read_from_persistence("foo".to_string()).unwrap(),
             None

--- a/xmtp/src/lib.rs
+++ b/xmtp/src/lib.rs
@@ -2,6 +2,9 @@ pub mod builder;
 pub mod client;
 pub mod persistence;
 
+pub use builder::ClientBuilder;
+pub use client::Client;
+
 #[cfg(test)]
 mod tests {
     use crate::builder::ClientBuilder;


### PR DESCRIPTION
# Problem

Adding new parameters to the `Client` struct results in having to update all existing instantiations (tests and external apps) - Making development/future usability painful. 

# Solution
Implement the builder pattern for Client. This allows developers an mechanism to use a sensible default implementation, while also customizing the object as needed. 

Advantages:
- Insulates developers from changes to the client Struct
- Allows customization of the client object, as opposed to only implementing Default for Client 
- Allows specific implementations for test clients etc.