### PR TITLE
fix: allow multiple getter calls on QueryResponse without transferring ownership

### DIFF
--- a/bindings_swift/src/types.rs
+++ b/bindings_swift/src/types.rs
@@ -55,7 +55,7 @@ impl From<PagingInfo> for crate::ffi::PagingInfo {
             },
             None => None,
         };
-        
+
         crate::ffi::PagingInfo {
             limit: paging_info.limit,
             direction: crate::ffi::SortDirection::from(
@@ -93,12 +93,13 @@ pub struct QueryResponse {
 }
 
 impl QueryResponse {
-    pub fn envelopes(self) -> Vec<crate::Envelope> {
-        self._envelopes
+    pub fn envelopes(&self) -> Vec<crate::Envelope> {
+        self._envelopes.clone()
     }
 
-    pub fn paging_info(self) -> Option<crate::ffi::PagingInfo> {
-        self._paging_info
+    pub fn paging_info(&self) -> Option<crate::ffi::PagingInfo> {
+        self._paging_info.as_ref()?;
+        self._paging_info.clone()
     }
 }
 


### PR DESCRIPTION
## Overview

When we try to call both `.envelopes()` and `.paging_info()` on a Rust QueryResponse from the Swift side, we get a "memory already freed" exception. The semantics of the getters was transferring ownership on first call.

This change makes it so the getters return a clone (not ideal) - maybe we can look into returning a slice or a Smart Pointer-like object in a future optimization.

## Test Plan

- ios side no longer crashes when calling `.paging_info()` after a `.envelopes()` call