### PR TITLE
Dedupe test actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,9 +34,3 @@ jobs:
         with:
           command: test
           args: --manifest-path bindings_swift/Cargo.toml
-
-      - name: Run cargo test on xmtpv3
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path xmtp/Cargo.toml


### PR DESCRIPTION
The project used to have two separate workspaces (Pre: #87) 

Now that the entire workspace tests are run, it's not needed to run the core crate independently 