### PR TITLE
feat: fix bindings_js -> bindings_wasm relationship

### DIFF
--- a/.github/workflows/wasm_npm_test.yaml
+++ b/.github/workflows/wasm_npm_test.yaml
@@ -1,0 +1,29 @@
+name: Test WASM npm
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        env: ['node', 'jsdom']
+    defaults:
+      run:
+        working-directory: ./bindings_js
+    steps:
+     - name: Checkout sources
+       uses: actions/checkout@v2
+     - name: Install stable toolchain
+       uses: actions-rs/toolchain@v1
+       with:
+         profile: minimal
+         toolchain: stable
+         override: true
+     - uses: jetli/wasm-pack-action@v0.4.0
+     - uses: actions/setup-node@v3
+     - run: npm ci
+     - run: npm test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,9 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 name = "bindings_wasm"
 version = "0.1.0"
 dependencies = [
+ "getrandom 0.2.9",
  "js-sys",
+ "rand 0.7.3",
  "wasm-bindgen",
  "wasm-bindgen-test",
  "xmtp",
@@ -303,7 +305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -315,7 +317,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -459,7 +461,7 @@ checksum = "798f704d128510932661a3489b08e3f4c934a01d61c5def59ae7b8e48f19665a"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2",
  "zeroize",
@@ -486,7 +488,7 @@ dependencies = [
  "group",
  "hkdf",
  "pkcs8 0.9.0",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -528,7 +530,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -601,6 +603,19 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
@@ -629,7 +644,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1333,13 +1348,36 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1349,7 +1387,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -1358,7 +1405,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.9",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1623,7 +1679,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1896,7 +1952,7 @@ dependencies = [
  "indexmap",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -1995,7 +2051,7 @@ version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55a3fef2a1e3b3a00ce878640918820d3c51081576ac657d23af9fc7928fdb"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.9",
 ]
 
 [[package]]
@@ -2019,7 +2075,7 @@ dependencies = [
  "matrix-pickle",
  "pkcs7",
  "prost",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "sha2",
@@ -2038,6 +2094,12 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -2374,7 +2436,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fabd6e16dd08033932fc3265ad4510cc2eab24656058a6dcb107ffe274abcc95"
 dependencies = [
  "curve25519-dalek",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "zeroize",
 ]
@@ -2394,11 +2456,11 @@ dependencies = [
  "chrono",
  "ecdsa",
  "generic-array",
- "getrandom",
+ "getrandom 0.2.9",
  "hex",
  "hkdf",
  "k256",
- "rand",
+ "rand 0.8.5",
  "rlp",
  "sha2",
  "sha3",
@@ -2414,7 +2476,7 @@ dependencies = [
  "hex",
  "k256",
  "protobuf",
- "rand",
+ "rand 0.8.5",
  "rlp",
  "sha3",
  "xmtp_crypto",

--- a/bindings_js/package-lock.json
+++ b/bindings_js/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "libxmtp",
+  "name": "libxmtp-js",
   "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "libxmtp",
+      "name": "libxmtp-js",
       "version": "0.0.1",
       "license": "MIT",
       "devDependencies": {

--- a/bindings_js/package.json
+++ b/bindings_js/package.json
@@ -22,14 +22,14 @@
       "import": "./dist/es-slim/index_slim.js",
       "default": "./dist/cjs-slim/index_slim.cjs"
     },
-    "./libxmtp.wasm": "./dist/libxmtp_bg.wasm",
+    "./bindings_wasm.wasm": "./dist/bindings_wasm_bg.wasm",
     "./package.json": "./package.json"
   },
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "wasm-pack build -t web --out-dir ../src/pkg crate && rm -rf dist/ && rollup -c",
+    "build": "wasm-pack build -t web --out-dir ../bindings_js/src/pkg ../bindings_wasm && rm -rf dist/ && rollup -c",
     "build:minify": "npm run build && npx terser@latest --compress --mangle --output dist/cjs/index.cjs -- dist/cjs/index.cjs",
     "format": "npx prettier@latest --write src/ tests/ package.json rollup.config.js tsconfig.json vite.config.ts cli.js",
     "pretest": "npm run build",

--- a/bindings_js/rollup.config.js
+++ b/bindings_js/rollup.config.js
@@ -18,7 +18,7 @@ const rolls = (fmt, env) => ({
     format: fmt,
     entryFileNames:
       outdir(fmt, env) + `/[name].` + (fmt === "cjs" ? "cjs" : "js"),
-    name: "libxmtp",
+    name: "bindings_wasm",
   },
   plugins: [
     // We want to inline our wasm bundle as base64. Not needing browser users
@@ -56,8 +56,8 @@ const rolls = (fmt, env) => ({
         // on the rust code
         fs.mkdirSync(`./dist/types/pkg`, { recursive: true });
         fs.copyFileSync(
-          path.resolve("./src/pkg/libxmtp.d.ts"),
-          path.resolve(`./dist/types/pkg/libxmtp.d.ts`)
+          path.resolve("./src/pkg/bindings_wasm.d.ts"),
+          path.resolve(`./dist/types/pkg/bindings_wasm.d.ts`)
         );
       },
     },

--- a/bindings_js/src/bindings_wasm.ts
+++ b/bindings_js/src/bindings_wasm.ts
@@ -1,4 +1,4 @@
-import init, { InitInput, client_create, client_read_from_persistence, client_write_to_persistence } from "./pkg/libxmtp.js";
+import init, { InitInput, client_create, client_read_from_persistence, client_write_to_persistence } from "./pkg/bindings_wasm.js";
 
 export interface PackageLoadOptions {
   /**

--- a/bindings_js/src/index.ts
+++ b/bindings_js/src/index.ts
@@ -1,6 +1,6 @@
 export * from "./index_core.js";
-import wasm from "./pkg/libxmtp_bg.wasm";
-import { setWasmInit } from "./libxmtp.js";
+import wasm from "./pkg/bindings_wasm_bg.wasm";
+import { setWasmInit } from "./bindings_wasm.js";
 
 // @ts-ignore
 setWasmInit(() => wasm());

--- a/bindings_js/src/index_core.ts
+++ b/bindings_js/src/index_core.ts
@@ -1,1 +1,1 @@
-export { Client } from "./libxmtp.js";
+export { Client } from "./bindings_wasm.js";

--- a/bindings_wasm/Cargo.toml
+++ b/bindings_wasm/Cargo.toml
@@ -11,6 +11,8 @@ crate-type = ["cdylib", "rlib"]
 js-sys = "0.3"
 xmtp = { path = "../xmtp" }
 wasm-bindgen = "0.2"
+rand = { version = "0.7.3", features = ["wasm-bindgen"] }
+getrandom = { version = "0.2", features = ["js"] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"


### PR DESCRIPTION
## Overview

As called out in #89 - the wasm/js stuff got a little broken during the restructure. This points `bindings_js` back at `bindings_wasm`, adds dependencies to make sure it builds for `wasm` and renames a bunch of stuff in the roll-up config.

## Test Plan

- cd `bindings_js` && `npm test` passes