### PR TITLE
Get or create account as part of initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2383,6 +2383,8 @@ dependencies = [
 name = "xmtp"
 version = "0.1.0"
 dependencies = [
+ "serde",
+ "serde_json",
  "vodozemac",
 ]
 

--- a/bindings_wasm/src/lib.rs
+++ b/bindings_wasm/src/lib.rs
@@ -12,7 +12,7 @@ pub fn client_create() -> usize {
     clients.push(
         ClientBuilder::new()
             .persistence(InMemoryPersistence::new())
-            .account("unknown".to_string())
+            .find_or_create_account("unknown".to_string())
             .unwrap()
             .build(),
     );

--- a/bindings_wasm/src/lib.rs
+++ b/bindings_wasm/src/lib.rs
@@ -12,6 +12,8 @@ pub fn client_create() -> usize {
     clients.push(
         ClientBuilder::new()
             .persistence(InMemoryPersistence::new())
+            .account("unknown".to_string())
+            .unwrap()
             .build(),
     );
     clients.len() - 1

--- a/xmtp/Cargo.toml
+++ b/xmtp/Cargo.toml
@@ -6,5 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+serde = "1.0.160"
+serde_json = "1.0.96"
 vodozemac = {git= "https://github.com/xmtp/vodozemac", branch="dev"}
 

--- a/xmtp/src/account.rs
+++ b/xmtp/src/account.rs
@@ -1,0 +1,41 @@
+use serde::{Deserialize, Serialize};
+use vodozemac::olm::{Account, AccountPickle};
+
+pub struct VmacAccount {
+    pub account: Account,
+}
+
+// Struct that holds an account and adds some serialization methods on top
+impl VmacAccount {
+    // Create a new instance
+    pub fn new(account: Account) -> Self {
+        Self { account }
+    }
+
+    pub fn generate() -> Self {
+        Self::new(Account::new())
+    }
+}
+
+// Implement Serialize trait for VmacAccount
+impl Serialize for VmacAccount {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        let pickle = self.account.pickle();
+        pickle.serialize(serializer)
+    }
+}
+
+// Implement Deserialize trait for VmacAccount
+impl<'de> Deserialize<'de> for VmacAccount {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        let pickle: AccountPickle = Deserialize::deserialize(deserializer)?;
+        let account = Account::from_pickle(pickle);
+        Ok(Self::new(account))
+    }
+}

--- a/xmtp/src/builder.rs
+++ b/xmtp/src/builder.rs
@@ -55,7 +55,7 @@ where
                 let account = VmacAccount::generate();
                 let data = serde_json::to_string(&account).map_err(|e| format!("{}", e))?;
 
-                persistence.write(key.clone(), data.as_bytes())?;
+                persistence.write(key, data.as_bytes())?;
 
                 self.account = Some(account)
             }

--- a/xmtp/src/builder.rs
+++ b/xmtp/src/builder.rs
@@ -108,27 +108,27 @@ mod tests {
             .is_empty())
     }
 
-    #[test]
-    fn persistence_test() {
-        let persistence = InMemoryPersistence::new();
-        let client_a = ClientBuilder::new()
-            .persistence(persistence)
-            .account("foo".to_string())
-            .unwrap()
-            .build();
+    // #[test]
+    // fn persistence_test() {
+    //     let persistence = InMemoryPersistence::new();
+    //     let client_a = ClientBuilder::new()
+    //         .persistence(persistence)
+    //         .account("foo".to_string())
+    //         .unwrap()
+    //         .build();
 
-        let client_b = ClientBuilder::new()
-            .persistence(persistence)
-            .account("foo".to_string())
-            .unwrap()
-            .build();
+    //     let client_b = ClientBuilder::new()
+    //         .persistence(persistence)
+    //         .account("foo".to_string())
+    //         .unwrap()
+    //         .build();
 
-        // Ensure the persistence was used to store the generated keys
-        assert_eq!(
-            client_a.account.account.curve25519_key().to_bytes(),
-            client_b.account.account.curve25519_key().to_bytes()
-        )
-    }
+    //     // Ensure the persistence was used to store the generated keys
+    //     assert_eq!(
+    //         client_a.account.account.curve25519_key().to_bytes(),
+    //         client_b.account.account.curve25519_key().to_bytes()
+    //     )
+    // }
 
     #[test]
     #[should_panic]

--- a/xmtp/src/builder.rs
+++ b/xmtp/src/builder.rs
@@ -45,7 +45,6 @@ where
         let existing = persistence.read(key.clone());
         match existing {
             Ok(Some(data)) => {
-                println!("Found data in key {}", key.clone());
                 let data_string = std::str::from_utf8(&data).map_err(|e| format!("{}", e))?;
                 let account: VmacAccount =
                     serde_json::from_str(data_string).map_err(|e| format!("{}", e))?;

--- a/xmtp/src/builder.rs
+++ b/xmtp/src/builder.rs
@@ -1,4 +1,7 @@
+use std::borrow::Borrow;
+
 use crate::{
+    account::VmacAccount,
     client::{Client, Network},
     persistence::Persistence,
 };
@@ -10,6 +13,7 @@ where
 {
     network: Network,
     persistence: Option<P>,
+    account: Option<VmacAccount>,
 }
 
 impl<P> ClientBuilder<P>
@@ -20,6 +24,7 @@ where
         Self {
             network: Network::Dev,
             persistence: None,
+            account: None,
         }
     }
 
@@ -33,12 +38,46 @@ where
         self
     }
 
+    pub fn account(mut self, wallet_address: String) -> Result<Self, String> {
+        let key = get_account_storage_key(wallet_address);
+        let persistence = self.persistence.as_mut().ok_or_else(|| {
+            "Persistence engine must be set before setting the account".to_string()
+        })?;
+
+        let existing = persistence.read(key.clone());
+        match existing {
+            Ok(Some(data)) => {
+                println!("Found data in key {}", key.clone());
+                let data_string = std::str::from_utf8(&data).map_err(|e| format!("{}", e))?;
+                let account: VmacAccount =
+                    serde_json::from_str(data_string).map_err(|e| format!("{}", e))?;
+                self.account = Some(account)
+            }
+            Ok(None) => {
+                let account = VmacAccount::generate();
+                let data = serde_json::to_string(&account).map_err(|e| format!("{}", e))?;
+
+                persistence.write(key.clone(), data.as_bytes())?;
+
+                self.account = Some(account)
+            }
+            Err(e) => return Err(format!("Failed to read from persistence: {}", e)),
+        }
+
+        Ok(self)
+    }
+
     pub fn build(self) -> Client<P> {
         Client {
             network: self.network,
             persistence: self.persistence.expect("A persistence engine must be set"),
+            account: self.account.expect("An account must be set"),
         }
     }
+}
+
+pub fn get_account_storage_key(wallet_address: String) -> String {
+    format!("account_{}", wallet_address)
 }
 
 #[cfg(test)]
@@ -50,13 +89,45 @@ mod tests {
 
     impl ClientBuilder<InMemoryPersistence> {
         pub fn new_test() -> Self {
-            Self::new().persistence(InMemoryPersistence::new())
+            Self::new()
+                .persistence(InMemoryPersistence::new())
+                .account("unknown".to_string())
+                .unwrap()
         }
     }
 
     #[test]
     fn builder_test() {
-        ClientBuilder::new_test().build();
+        let client = ClientBuilder::new_test().build();
+        assert!(!client
+            .account
+            .account
+            .identity_keys()
+            .curve25519
+            .to_bytes()
+            .is_empty())
+    }
+
+    #[test]
+    fn persistence_test() {
+        let persistence = InMemoryPersistence::new();
+        let client_a = ClientBuilder::new()
+            .persistence(persistence)
+            .account("foo".to_string())
+            .unwrap()
+            .build();
+
+        let client_b = ClientBuilder::new()
+            .persistence(persistence)
+            .account("foo".to_string())
+            .unwrap()
+            .build();
+
+        // Ensure the persistence was used to store the generated keys
+        assert_eq!(
+            client_a.account.account.curve25519_key().to_bytes(),
+            client_b.account.account.curve25519_key().to_bytes()
+        )
     }
 
     #[test]

--- a/xmtp/src/builder.rs
+++ b/xmtp/src/builder.rs
@@ -1,5 +1,3 @@
-use std::borrow::Borrow;
-
 use crate::{
     account::VmacAccount,
     client::{Client, Network},
@@ -108,27 +106,27 @@ mod tests {
             .is_empty())
     }
 
-    // #[test]
-    // fn persistence_test() {
-    //     let persistence = InMemoryPersistence::new();
-    //     let client_a = ClientBuilder::new()
-    //         .persistence(persistence)
-    //         .account("foo".to_string())
-    //         .unwrap()
-    //         .build();
+    #[test]
+    fn persistence_test() {
+        let persistence = InMemoryPersistence::new();
+        let client_a = ClientBuilder::new()
+            .persistence(persistence)
+            .account("foo".to_string())
+            .unwrap()
+            .build();
 
-    //     let client_b = ClientBuilder::new()
-    //         .persistence(persistence)
-    //         .account("foo".to_string())
-    //         .unwrap()
-    //         .build();
+        let client_b = ClientBuilder::new()
+            .persistence(client_a.persistence)
+            .account("foo".to_string())
+            .unwrap()
+            .build();
 
-    //     // Ensure the persistence was used to store the generated keys
-    //     assert_eq!(
-    //         client_a.account.account.curve25519_key().to_bytes(),
-    //         client_b.account.account.curve25519_key().to_bytes()
-    //     )
-    // }
+        // Ensure the persistence was used to store the generated keys
+        assert_eq!(
+            client_a.account.account.curve25519_key().to_bytes(),
+            client_b.account.account.curve25519_key().to_bytes()
+        )
+    }
 
     #[test]
     #[should_panic]

--- a/xmtp/src/builder.rs
+++ b/xmtp/src/builder.rs
@@ -36,7 +36,7 @@ where
         self
     }
 
-    pub fn account(mut self, wallet_address: String) -> Result<Self, String> {
+    pub fn find_or_create_account(mut self, wallet_address: String) -> Result<Self, String> {
         let key = get_account_storage_key(wallet_address);
         let persistence = self.persistence.as_mut().ok_or_else(|| {
             "Persistence engine must be set before setting the account".to_string()
@@ -88,7 +88,7 @@ mod tests {
         pub fn new_test() -> Self {
             Self::new()
                 .persistence(InMemoryPersistence::new())
-                .account("unknown".to_string())
+                .find_or_create_account("unknown".to_string())
                 .unwrap()
         }
     }
@@ -110,13 +110,13 @@ mod tests {
         let persistence = InMemoryPersistence::new();
         let client_a = ClientBuilder::new()
             .persistence(persistence)
-            .account("foo".to_string())
+            .find_or_create_account("foo".to_string())
             .unwrap()
             .build();
 
         let client_b = ClientBuilder::new()
             .persistence(client_a.persistence)
-            .account("foo".to_string())
+            .find_or_create_account("foo".to_string())
             .unwrap()
             .build();
 

--- a/xmtp/src/client.rs
+++ b/xmtp/src/client.rs
@@ -1,15 +1,54 @@
-use crate::persistence::Persistence;
+use crate::{account::VmacAccount, persistence::Persistence};
+use serde_json;
+use vodozemac::olm::Account;
 
 pub struct Client<P>
 where
     P: Persistence,
 {
     persistence: P,
+    account: Option<VmacAccount>,
 }
 
 impl<P: Persistence> Client<P> {
     pub fn new(persistence: P) -> Self {
-        Client { persistence }
+        Client {
+            persistence,
+            account: None,
+        }
+    }
+
+    pub fn create(persistence: P) -> Result<Self, String> {
+        // Right now we don't know the wallet address, which would ideally be prefixed in the key for the storage.
+        // This is because many clients may be instantiated with the same shared storage (ie. LocalStorage.)
+        // Defaulting wallet address to "unknown" for now
+        let account = Client::get_or_create_account(persistence, "unknown".to_string())?;
+
+        Ok(Self::new(persistence, account))
+    }
+
+    pub fn get_or_create_account(
+        mut persistence: P,
+        wallet_address: String,
+    ) -> Result<VmacAccount, String> {
+        let key = get_account_storage_key(wallet_address);
+        let existing = persistence.read(key.clone());
+        match existing {
+            Ok(Some(data)) => {
+                let data_string = std::str::from_utf8(&data).map_err(|e| format!("{}", e))?;
+                let account: VmacAccount =
+                    serde_json::from_str(data_string).map_err(|e| format!("{}", e))?;
+                Ok(account)
+            }
+            Ok(None) => {
+                let account = VmacAccount::generate();
+                let data = serde_json::to_string(&account).map_err(|e| format!("{}", e))?;
+                persistence.write(key, data.as_bytes())?;
+
+                Ok(account)
+            }
+            Err(e) => Err(format!("Failed to read from persistence: {}", e)),
+        }
     }
 
     pub fn write_to_persistence(&mut self, s: String, b: &[u8]) -> Result<(), String> {
@@ -19,4 +58,8 @@ impl<P: Persistence> Client<P> {
     pub fn read_from_persistence(&self, s: String) -> Result<Option<Vec<u8>>, String> {
         self.persistence.read(s)
     }
+}
+
+pub fn get_account_storage_key(wallet_address: String) -> String {
+    format!("account_{}", wallet_address)
 }

--- a/xmtp/src/client.rs
+++ b/xmtp/src/client.rs
@@ -1,16 +1,11 @@
 use crate::{account::VmacAccount, persistence::Persistence};
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Default)]
 pub enum Network {
     Local(&'static str),
+    #[default]
     Dev,
     Prod,
-}
-
-impl Default for Network {
-    fn default() -> Self {
-        Network::Dev
-    }
 }
 
 pub struct Client<P>

--- a/xmtp/src/client.rs
+++ b/xmtp/src/client.rs
@@ -1,5 +1,4 @@
 use crate::{account::VmacAccount, persistence::Persistence};
-use serde_json;
 
 #[derive(Clone, Copy)]
 pub enum Network {

--- a/xmtp/src/client.rs
+++ b/xmtp/src/client.rs
@@ -1,6 +1,5 @@
 use crate::{account::VmacAccount, persistence::Persistence};
 use serde_json;
-use vodozemac::olm::Account;
 
 #[derive(Clone, Copy)]
 pub enum Network {
@@ -21,6 +20,7 @@ where
 {
     pub network: Network,
     pub persistence: P,
+    pub account: VmacAccount,
 }
 
 impl<P: Persistence> Client<P> {
@@ -28,35 +28,7 @@ impl<P: Persistence> Client<P> {
         self.persistence.write(s, b)
     }
 
-    pub fn get_or_create_account(
-        mut persistence: P,
-        wallet_address: String,
-    ) -> Result<VmacAccount, String> {
-        let key = get_account_storage_key(wallet_address);
-        let existing = persistence.read(key.clone());
-        match existing {
-            Ok(Some(data)) => {
-                let data_string = std::str::from_utf8(&data).map_err(|e| format!("{}", e))?;
-                let account: VmacAccount =
-                    serde_json::from_str(data_string).map_err(|e| format!("{}", e))?;
-                Ok(account)
-            }
-            Ok(None) => {
-                let account = VmacAccount::generate();
-                let data = serde_json::to_string(&account).map_err(|e| format!("{}", e))?;
-                persistence.write(key, data.as_bytes())?;
-
-                Ok(account)
-            }
-            Err(e) => Err(format!("Failed to read from persistence: {}", e)),
-        }
-    }
-
     pub fn read_from_persistence(&self, s: String) -> Result<Option<Vec<u8>>, String> {
         self.persistence.read(s)
     }
-}
-
-pub fn get_account_storage_key(wallet_address: String) -> String {
-    format!("account_{}", wallet_address)
 }

--- a/xmtp/src/lib.rs
+++ b/xmtp/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod account;
 pub mod client;
 pub mod persistence;
 


### PR DESCRIPTION
## Summary

- First pass at getting or creating a VmacAccount as part of the client building process. 
- Makes `Account` serializable, by wrapping in a struct and using the pickled value to JSON serialize
- Includes the account on the `Client` struct

## Ticket
https://github.com/xmtp/libxmtp/issues/73

## Notes
- I haven't included any state on whether the key has been uploaded or not. Going to handle that in a subsequent PR, but it should be pretty straightforward to modify the serialize method to include more data as needed.
- I am currently using JSON as the serialization format. We may ultimately want protos even for some of these data types that don't go to the network, just because it enforces some type safety and is faster to read/write. But we can handle that separately if we even care.
- We are going to want to prefix the storage key for the account with a wallet address, so that one persistence can handle multiple accounts. But we currently don't know that address, so I am defaulting to `unknown`