### PR TITLE
Clean up builder

### DIFF
--- a/bindings_wasm/src/lib.rs
+++ b/bindings_wasm/src/lib.rs
@@ -12,9 +12,9 @@ pub fn client_create() -> usize {
     clients.push(
         ClientBuilder::new()
             .persistence(InMemoryPersistence::new())
-            .find_or_create_account("unknown".to_string())
-            .unwrap()
-            .build(),
+            .wallet_address("unknown".to_string())
+            .build()
+            .unwrap(),
     );
     clients.len() - 1
 }

--- a/xmtp/src/builder.rs
+++ b/xmtp/src/builder.rs
@@ -41,7 +41,7 @@ where
         self
     }
 
-    pub fn find_or_create_account(&mut self) -> Result<VmacAccount, String> {
+    fn find_or_create_account(&mut self) -> Result<VmacAccount, String> {
         let wallet_address = self
             .wallet_address
             .as_ref()

--- a/xmtp/src/builder.rs
+++ b/xmtp/src/builder.rs
@@ -71,7 +71,7 @@ where
 
                 Ok(account)
             }
-            Err(e) => return Err(format!("Failed to read from persistence: {}", e)),
+            Err(e) => Err(format!("Failed to read from persistence: {}", e)),
         }
     }
 

--- a/xmtp/src/builder.rs
+++ b/xmtp/src/builder.rs
@@ -48,7 +48,7 @@ where
             .ok_or_else(|| "Wallet address must be set before setting the account".to_string())?;
 
         let key = get_account_storage_key(wallet_address.to_string());
-        let persistence = self.persistence.as_mut().ok_or_else(|| {
+        let persistence = self.persistence.as_ref().ok_or_else(|| {
             "Persistence engine must be set before setting the account".to_string()
         })?;
 
@@ -64,7 +64,10 @@ where
                 let account = VmacAccount::generate();
                 let data = serde_json::to_string(&account).map_err(|e| format!("{}", e))?;
 
-                persistence.write(key, data.as_bytes())?;
+                self.persistence
+                    .as_mut()
+                    .unwrap()
+                    .write(key, data.as_bytes())?;
 
                 Ok(account)
             }

--- a/xmtp/src/builder.rs
+++ b/xmtp/src/builder.rs
@@ -11,7 +11,7 @@ where
 {
     network: Network,
     persistence: Option<P>,
-    account: Option<VmacAccount>,
+    wallet_address: Option<String>,
 }
 
 impl<P> ClientBuilder<P>
@@ -22,7 +22,7 @@ where
         Self {
             network: Network::Dev,
             persistence: None,
-            account: None,
+            wallet_address: None,
         }
     }
 
@@ -36,8 +36,18 @@ where
         self
     }
 
-    pub fn find_or_create_account(mut self, wallet_address: String) -> Result<Self, String> {
-        let key = get_account_storage_key(wallet_address);
+    pub fn wallet_address(mut self, wallet_address: String) -> Self {
+        self.wallet_address = Some(wallet_address);
+        self
+    }
+
+    pub fn find_or_create_account(&mut self) -> Result<VmacAccount, String> {
+        let wallet_address = self
+            .wallet_address
+            .as_ref()
+            .ok_or_else(|| "Wallet address must be set before setting the account".to_string())?;
+
+        let key = get_account_storage_key(wallet_address.to_string());
         let persistence = self.persistence.as_mut().ok_or_else(|| {
             "Persistence engine must be set before setting the account".to_string()
         })?;
@@ -48,7 +58,7 @@ where
                 let data_string = std::str::from_utf8(&data).map_err(|e| format!("{}", e))?;
                 let account: VmacAccount =
                     serde_json::from_str(data_string).map_err(|e| format!("{}", e))?;
-                self.account = Some(account)
+                Ok(account)
             }
             Ok(None) => {
                 let account = VmacAccount::generate();
@@ -56,20 +66,24 @@ where
 
                 persistence.write(key, data.as_bytes())?;
 
-                self.account = Some(account)
+                Ok(account)
             }
             Err(e) => return Err(format!("Failed to read from persistence: {}", e)),
         }
-
-        Ok(self)
     }
 
-    pub fn build(self) -> Client<P> {
-        Client {
+    pub fn build(&mut self) -> Result<Client<P>, String> {
+        let account = self.find_or_create_account()?;
+        let persistence = self
+            .persistence
+            .take()
+            .expect("Persistence engine must be set");
+
+        Ok(Client {
             network: self.network,
-            persistence: self.persistence.expect("A persistence engine must be set"),
-            account: self.account.expect("An account must be set"),
-        }
+            persistence,
+            account,
+        })
     }
 }
 
@@ -88,14 +102,13 @@ mod tests {
         pub fn new_test() -> Self {
             Self::new()
                 .persistence(InMemoryPersistence::new())
-                .find_or_create_account("unknown".to_string())
-                .unwrap()
+                .wallet_address("unknown".to_string())
         }
     }
 
     #[test]
     fn builder_test() {
-        let client = ClientBuilder::new_test().build();
+        let client = ClientBuilder::new_test().build().unwrap();
         assert!(!client
             .account
             .account
@@ -110,15 +123,15 @@ mod tests {
         let persistence = InMemoryPersistence::new();
         let client_a = ClientBuilder::new()
             .persistence(persistence)
-            .find_or_create_account("foo".to_string())
-            .unwrap()
-            .build();
+            .wallet_address("foo".to_string())
+            .build()
+            .unwrap();
 
         let client_b = ClientBuilder::new()
             .persistence(client_a.persistence)
-            .find_or_create_account("foo".to_string())
-            .unwrap()
-            .build();
+            .wallet_address("foo".to_string())
+            .build()
+            .unwrap();
 
         // Ensure the persistence was used to store the generated keys
         assert_eq!(
@@ -132,6 +145,7 @@ mod tests {
     fn test_runtime_panic() {
         ClientBuilder::<InMemoryPersistence>::new()
             .network(Network::Dev)
-            .build();
+            .build()
+            .unwrap();
     }
 }

--- a/xmtp/src/lib.rs
+++ b/xmtp/src/lib.rs
@@ -12,7 +12,7 @@ mod tests {
 
     #[test]
     fn can_pass_persistence_methods() {
-        let mut client = ClientBuilder::new_test().build();
+        let mut client = ClientBuilder::new_test().build().unwrap();
         assert_eq!(
             client.read_from_persistence("foo".to_string()).unwrap(),
             None


### PR DESCRIPTION
## Summary

Small PR addressing some of the comments in https://github.com/xmtp/libxmtp/pull/95.

- Replaces `find_or_create_account` with a simple function to set the wallet_address
- Actually finds or creates the account as part of the `build` function
- Only takes a mutable reference to persistence when needed

This does have the effect of making `.build()` return a `Result<Client<P>, String>` instead of just the client.