### PR TITLE
Upload bundles to mock network

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2447,9 +2447,11 @@ dependencies = [
 name = "xmtp"
 version = "0.1.0"
 dependencies = [
+ "prost",
  "serde",
  "serde_json",
  "vodozemac",
+ "xmtp_networking",
  "xmtp_proto",
 ]
 

--- a/bindings_wasm/src/lib.rs
+++ b/bindings_wasm/src/lib.rs
@@ -3,9 +3,10 @@ mod local_storage_persistence;
 use local_storage_persistence::LocalStoragePersistence;
 use std::sync::Mutex;
 use wasm_bindgen::prelude::*;
-use xmtp::{Client, ClientBuilder};
+use xmtp::{networking::MockXmtpApiClient, Client, ClientBuilder};
 
-static CLIENT_LIST: Mutex<Vec<Client<LocalStoragePersistence>>> = Mutex::new(Vec::new());
+static CLIENT_LIST: Mutex<Vec<Client<LocalStoragePersistence, MockXmtpApiClient>>> =
+    Mutex::new(Vec::new());
 
 #[wasm_bindgen]
 pub fn client_create() -> usize {

--- a/xmtp/Cargo.toml
+++ b/xmtp/Cargo.toml
@@ -10,3 +10,5 @@ serde = "1.0.160"
 serde_json = "1.0.96"
 vodozemac = {git= "https://github.com/xmtp/vodozemac", branch="dev"}
 xmtp_proto = { path = "../xmtp_proto", features = ["xmtp-v3-message_contents"] }
+xmtp_networking = { path = "../xmtp_networking" }
+prost = "0.11.9"

--- a/xmtp/src/account.rs
+++ b/xmtp/src/account.rs
@@ -13,7 +13,9 @@ impl VmacAccount {
     }
 
     pub fn generate() -> Self {
-        Self::new(Account::new())
+        let mut acc = Account::new();
+        acc.generate_fallback_key();
+        Self::new(acc) 
     }
 }
 

--- a/xmtp/src/client.rs
+++ b/xmtp/src/client.rs
@@ -1,6 +1,16 @@
+use xmtp_proto::xmtp::v3::message_contents::{
+    VmacAccountLinkedKey, VmacContactBundle, VmacDeviceLinkedKey, VmacUnsignedPublicKey,
+};
+
+use prost::Message;
+use xmtp_proto::xmtp::message_api::v1::Envelope;
+
 use crate::{
     account::VmacAccount,
+    networking::XmtpApiClient,
     persistence::{NamespacedPersistence, Persistence},
+    utils,
+    vmac_protos::ProtoWrapper,
 };
 
 #[derive(Clone, Copy, Default)]
@@ -11,21 +21,126 @@ pub enum Network {
     Prod,
 }
 
-pub struct Client<P>
+impl Network {
+    pub fn url(&self) -> &'static str {
+        match self {
+            Network::Local(url) => url,
+            Network::Dev => "https://dev.xmtp.network",
+            Network::Prod => "https://production.xmtp.network",
+        }
+    }
+}
+
+pub struct Client<P, A>
 where
     P: Persistence,
+    A: XmtpApiClient + Sized,
 {
     pub network: Network,
     pub persistence: NamespacedPersistence<P>,
     pub account: VmacAccount,
+    pub api_client: Box<A>,
+    pub wallet_address: String,
 }
 
-impl<P: Persistence> Client<P> {
+impl<P: Persistence, A: XmtpApiClient + Sized> Client<P, A> {
+    pub fn publish_contact_bundle(&mut self) -> Result<(), String> {
+        let envelope = self.build_contact_envelope()?;
+        let api_client = self.api_client.as_mut();
+        api_client.publish("/contact".to_string(), vec![envelope])?;
+
+        Ok(())
+    }
+
+    fn build_contact_envelope(&self) -> Result<Envelope, String> {
+        let contact_bundle = self.build_proto_contact_bundle();
+        let mut bytes = vec![];
+        contact_bundle
+            .encode(&mut bytes)
+            .map_err(|e| format!("{}", e))?;
+
+        let wallet_address = self.wallet_address.clone();
+
+        let envelope = self.build_envelope(utils::build_user_contact_topic(wallet_address), bytes);
+
+        Ok(envelope)
+    }
+
+    fn build_envelope(&self, content_topic: String, message: Vec<u8>) -> Envelope {
+        Envelope {
+            content_topic,
+            message,
+            timestamp_ns: utils::get_current_time_ns(),
+        }
+    }
+
+    fn build_proto_contact_bundle(&self) -> VmacContactBundle {
+        let identity_key = self.account.account.curve25519_key();
+        let fallback_key = self
+            .account
+            .account
+            .fallback_key()
+            .values()
+            .next()
+            .unwrap()
+            .to_owned();
+
+        let identity_key_proto: ProtoWrapper<VmacUnsignedPublicKey> = identity_key.into();
+        let fallback_key_proto: ProtoWrapper<VmacUnsignedPublicKey> = fallback_key.into();
+        let identity_key = VmacAccountLinkedKey {
+            key: Some(identity_key_proto.proto),
+        };
+        let fallback_key = VmacDeviceLinkedKey {
+            key: Some(fallback_key_proto.proto),
+        };
+        VmacContactBundle {
+            identity_key: Some(identity_key),
+            prekey: Some(fallback_key),
+        }
+    }
+
     pub fn write_to_persistence(&mut self, s: &str, b: &[u8]) -> Result<(), String> {
         self.persistence.write(s, b)
     }
 
     pub fn read_from_persistence(&self, s: &str) -> Result<Option<Vec<u8>>, String> {
         self.persistence.read(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use xmtp_proto::xmtp::v3::message_contents::VmacContactBundle;
+
+    use crate::{builder::ClientBuilder, networking::XmtpApiClient};
+
+    use prost::Message;
+
+    #[test]
+    fn can_pass_persistence_methods() {
+        let mut client = ClientBuilder::new_test().build().unwrap();
+        assert_eq!(client.read_from_persistence("foo").unwrap(), None);
+        client.write_to_persistence("foo", b"bar").unwrap();
+        assert_eq!(
+            client.read_from_persistence("foo").unwrap(),
+            Some(b"bar".to_vec())
+        );
+    }
+
+    #[test]
+    fn can_publish_contact_bundle() {
+        let mut client = ClientBuilder::new_test().build().unwrap();
+        client.publish_contact_bundle().unwrap();
+
+        let results = client
+            .api_client
+            .query("/contact".to_string(), None, None, None)
+            .unwrap();
+        assert_eq!(results.envelopes.len(), 1);
+
+        let bundle_bytes: &Vec<u8> = results.envelopes[0].message.as_ref();
+        let bundle = VmacContactBundle::decode(&bundle_bytes[..]).unwrap();
+        assert!(bundle.identity_key.is_some());
+        assert!(bundle.prekey.is_some());
     }
 }

--- a/xmtp/src/constants.rs
+++ b/xmtp/src/constants.rs
@@ -1,0 +1,1 @@
+pub const ACCOUNT_PERSISTENCE_KEY: &str = "vmac_account";

--- a/xmtp/src/lib.rs
+++ b/xmtp/src/lib.rs
@@ -1,24 +1,11 @@
 pub mod account;
 pub mod builder;
 pub mod client;
+pub mod constants;
+pub mod networking;
 pub mod persistence;
+pub mod utils;
 pub mod vmac_protos;
 
 pub use builder::ClientBuilder;
 pub use client::Client;
-
-#[cfg(test)]
-mod tests {
-    use crate::builder::ClientBuilder;
-
-    #[test]
-    fn can_pass_persistence_methods() {
-        let mut client = ClientBuilder::new_test().build().unwrap();
-        assert_eq!(client.read_from_persistence("foo").unwrap(), None);
-        client.write_to_persistence("foo", b"bar").unwrap();
-        assert_eq!(
-            client.read_from_persistence("foo").unwrap(),
-            Some(b"bar".to_vec())
-        );
-    }
-}

--- a/xmtp/src/networking.rs
+++ b/xmtp/src/networking.rs
@@ -1,0 +1,80 @@
+use std::collections::HashMap;
+
+use xmtp_networking::grpc_api_helper::Subscription;
+use xmtp_proto::xmtp::message_api::v1::{Envelope, PagingInfo, PublishResponse, QueryResponse};
+
+pub trait XmtpApiClient {
+    fn publish(
+        &mut self,
+        token: String,
+        envelopes: Vec<Envelope>,
+        // TODO: use error enums
+    ) -> Result<PublishResponse, String>;
+
+    fn query(
+        self,
+        topic: String,
+        start_time: Option<u64>,
+        end_time: Option<u64>,
+        paging_info: Option<PagingInfo>,
+        // TODO: use error enums
+    ) -> Result<QueryResponse, String>;
+
+    // TODO: use error enums
+    fn subscribe(self, topics: Vec<String>) -> Result<Subscription, String>;
+}
+
+pub struct MockXmtpApiClient {
+    messages: HashMap<String, Vec<Envelope>>,
+}
+
+/**
+ * Temporarily adding this so I don't have to deal with Tonic issues making something work for tests
+ * TODO: Replace me with real networking client
+ */
+impl MockXmtpApiClient {
+    pub fn new() -> Self {
+        Self {
+            messages: HashMap::new(),
+        }
+    }
+}
+
+impl XmtpApiClient for MockXmtpApiClient {
+    fn publish(
+        &mut self,
+        token: String,
+        envelopes: Vec<Envelope>,
+    ) -> Result<PublishResponse, String> {
+        let mut existing: Vec<Envelope> = match self.messages.get(&token) {
+            Some(envelopes) => envelopes.clone(),
+            None => vec![],
+        };
+        existing.append(envelopes.clone().as_mut());
+        self.messages.insert(token, envelopes);
+
+        Ok(PublishResponse {})
+    }
+
+    fn query(
+        self,
+        topic: String,
+        _start_time: Option<u64>,
+        _end_time: Option<u64>,
+        _paging_info: Option<PagingInfo>,
+    ) -> Result<QueryResponse, String> {
+        let envelopes: Vec<Envelope> = match self.messages.get(&topic) {
+            Some(envelopes) => envelopes.clone(),
+            None => vec![],
+        };
+
+        Ok(QueryResponse {
+            envelopes: envelopes,
+            paging_info: None,
+        })
+    }
+
+    fn subscribe(self, _topics: Vec<String>) -> Result<Subscription, String> {
+        Err("Not implemented".to_string())
+    }
+}

--- a/xmtp/src/utils.rs
+++ b/xmtp/src/utils.rs
@@ -1,0 +1,14 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub fn get_current_time_ns() -> u64 {
+    let now = SystemTime::now();
+    // Allowing this to panic, since things have gone very wrong if this expect is hit
+    let since_epoch = now.duration_since(UNIX_EPOCH).expect("Time went backwards");
+    let nanos = since_epoch.as_nanos() as u64;
+
+    nanos
+}
+
+pub fn build_user_contact_topic(wallet_address: String) -> String {
+    format!("xmtp/1/contact_{}", wallet_address)
+}


### PR DESCRIPTION
## Summary

Pushing this up in a broken state, just for reference. But ultimately, I don't see a path to merging this until we have a proper API Client solution.

- Serializes contact bundles
- Adds an `api_client` field to the `Client` struct, to allow for future API calls
- Creates a provisional trait for the `XmtpApiClient`
- Correctly adds a fallback_key to the account on creation
- Implements that trait with a mock API client, for use in testing and until we have a proper client

## Notes

The mock API client may turn out to be more trouble than it's worth, and we probably will end up removing it altogether. But I needed something to get this feature working end-to-end, and I didn't want to take in the scope of figuring out our whole networking layer.

Even the mock API client relies on the `Envelope` types, and some of the query parameters. This requires the tonic dependency when we import it, which then breaks things in the JS bindings.