### PR TITLE
Account Scaffolding

### DIFF
--- a/bindings_js/src/bindings_wasm.ts
+++ b/bindings_js/src/bindings_wasm.ts
@@ -69,6 +69,16 @@ export class Client {
     return new Client(clientId);
   }
 
+  public static async createTest() {
+    await initializeModule();
+
+    const account_id = register((s: String) => {
+      return "VGhpc0lzQVRlc3RTdHJpbmc="; // TODO: Replace with valid signature
+    });
+    let clientId = client_create(account_id);
+    return new Client(clientId);
+  }
+
   public static resetAll() {
     resetModule();
   }

--- a/bindings_js/src/bindings_wasm.ts
+++ b/bindings_js/src/bindings_wasm.ts
@@ -84,9 +84,9 @@ export class Client {
   }
 
   public static async create_account(
-    f: (s: String) => String
+    signFunc: (s: String) => String
   ): Promise<AccountHandle> {
     await initializeModule();
-    return register(f);
+    return register(signFunc);
   }
 }

--- a/bindings_js/src/bindings_wasm.ts
+++ b/bindings_js/src/bindings_wasm.ts
@@ -1,4 +1,12 @@
-import init, { InitInput, client_create, client_read_from_persistence, client_write_to_persistence } from "./pkg/bindings_wasm.js";
+import init, {
+  InitInput,
+  client_create,
+  client_read_from_persistence,
+  client_write_to_persistence,
+  register,
+} from "./pkg/bindings_wasm.js";
+
+type AccountHandle = number;
 
 export interface PackageLoadOptions {
   /**
@@ -55,14 +63,20 @@ export class Client {
     return client_read_from_persistence(this.clientId, key);
   }
 
-  public static async create() {
+  public static async create(account_id: number) {
     await initializeModule();
-    let clientId = client_create();
+    let clientId = client_create(account_id);
     return new Client(clientId);
   }
 
   public static resetAll() {
     resetModule();
   }
-}
 
+  public static async create_account(
+    f: (s: String) => String
+  ): Promise<AccountHandle> {
+    await initializeModule();
+    return register(f);
+  }
+}

--- a/bindings_js/tests/wasmpkg.test.ts
+++ b/bindings_js/tests/wasmpkg.test.ts
@@ -2,11 +2,11 @@ import { beforeEach, expect, it } from "vitest";
 import { Client } from "..";
 
 it("can instantiate multiple instances", async () => {
-  const a = await Client.create();
+  const a = await Client.createTest();
   expect(a).toBeDefined();
 
   // Make sure we can call it again
-  const b = await Client.create();
+  const b = await Client.createTest();
   expect(b).toBeDefined();
 
   expect(a).not.toEqual(b);
@@ -16,7 +16,7 @@ let client: Client;
 
 beforeEach(async () => {
   Client.resetAll();
-  client = await Client.create();
+  client = await Client.createTest();
 });
 
 it("can read and write to in-memory storage", async () => {

--- a/bindings_wasm/src/lib.rs
+++ b/bindings_wasm/src/lib.rs
@@ -1,16 +1,32 @@
 mod local_storage_persistence;
 
+use base64::{engine::general_purpose, Engine as _};
+use js_sys::{Float32Array, Uint8Array};
 use local_storage_persistence::LocalStoragePersistence;
-use std::sync::Mutex;
+use std::{error::Error, sync::Mutex};
 use wasm_bindgen::prelude::*;
-use xmtp::{Client, ClientBuilder};
+use xmtp::{
+    account::{Account, AccountFactory, Association},
+    Client, ClientBuilder, Signable,
+};
 
 static CLIENT_LIST: Mutex<Vec<Client<LocalStoragePersistence>>> = Mutex::new(Vec::new());
+static ACCOUNT_FACTORY: Mutex<Vec<Account>> = Mutex::new(Vec::new());
 
 // TODO: Custom JS Error subclasses (https://github.com/xmtp/libxmtp/issues/104)
 
+// Passing Vecs across wasm boundary using Uint8Array views results in unsafe code
+// use base64 instead
+pub fn to_base64(bytes: Vec<u8>) -> String {
+    general_purpose::STANDARD_NO_PAD.encode(bytes)
+}
+pub fn from_base64(s: &str) -> Result<Vec<u8>, base64::DecodeError> {
+    let bytes = general_purpose::STANDARD_NO_PAD.decode(s)?;
+    Ok(bytes)
+}
+
 #[wasm_bindgen]
-pub fn client_create() -> Result<usize, JsError> {
+pub fn client_create(account_id: usize) -> Result<usize, JsError> {
     console_error_panic_hook::set_once();
     let mut clients = CLIENT_LIST.lock().unwrap();
     clients.push(
@@ -43,4 +59,22 @@ pub fn client_read_from_persistence(
     let client = clients.get_mut(client_id).expect("Client not found");
     let value = client.read_from_persistence(key)?;
     Ok(value)
+}
+
+#[wasm_bindgen]
+pub fn register(f: js_sys::Function) -> Result<usize, JsError> {
+    console_error_panic_hook::set_once();
+
+    let af = AccountFactory::new();
+    let key_bytes = to_base64(af.bytes_to_sign());
+    let sig = f
+        .call1(&JsValue::NULL, &JsValue::from_str(&key_bytes))
+        .unwrap()
+        .as_string()
+        .unwrap();
+
+    let account = af.finalize_key(from_base64(&sig)?);
+    let mut accounts = ACCOUNT_FACTORY.lock().unwrap();
+    accounts.push(account);
+    Ok(accounts.len() - 1)
 }

--- a/bindings_wasm/src/lib.rs
+++ b/bindings_wasm/src/lib.rs
@@ -17,10 +17,10 @@ static ACCOUNTS: Mutex<Vec<Account>> = Mutex::new(Vec::new());
 // Passing Vecs across wasm boundary using Uint8Array views results in unsafe code
 // use base64 instead
 pub fn to_base64(bytes: Vec<u8>) -> String {
-    general_purpose::STANDARD_NO_PAD.encode(bytes)
+    general_purpose::STANDARD.encode(bytes)
 }
 pub fn from_base64(s: &str) -> Result<Vec<u8>, base64::DecodeError> {
-    let bytes = general_purpose::STANDARD_NO_PAD.decode(s)?;
+    let bytes = general_purpose::STANDARD.decode(s)?;
     Ok(bytes)
 }
 

--- a/bindings_wasm/tests/client.rs
+++ b/bindings_wasm/tests/client.rs
@@ -1,4 +1,6 @@
-use bindings_wasm::{client_create, client_read_from_persistence, client_write_to_persistence};
+use bindings_wasm::{
+    client_create, client_read_from_persistence, client_write_to_persistence, register,
+};
 use wasm_bindgen::JsError;
 use wasm_bindgen_test::*;
 
@@ -11,10 +13,16 @@ fn unwrap_js_error<T>(result: Result<T, JsError>) -> T {
     }
 }
 
+fn create_js_signer() -> js_sys::Function {
+    js_sys::Function::new_with_args("str", " return 'SGVsbG8gV29ybGQh'") // Returns base64 string
+}
+
 wasm_bindgen_test_configure!(run_in_browser);
 #[wasm_bindgen_test]
 fn can_pass_persistence_methods() {
-    let client_id = unwrap_js_error(client_create());
+    // TODO: Update test with valid signature
+    let account_id = unwrap_js_error(register(create_js_signer()));
+    let client_id = unwrap_js_error(client_create(account_id));
     assert_eq!(
         unwrap_js_error(client_read_from_persistence(client_id, "foo")),
         None

--- a/xmtp/src/account.rs
+++ b/xmtp/src/account.rs
@@ -1,19 +1,68 @@
+use std::vec;
+
 use serde::{Deserialize, Serialize};
-use vodozemac::olm::{Account, AccountPickle};
+use vodozemac::olm::{Account as OlmAccount, AccountPickle as OlmAccountPickle};
+
+use crate::Signable;
+
+type Address = String;
+
+#[derive(Serialize, Deserialize)]
+pub enum AssociationFormat {
+    Eip191,
+}
+
+#[derive(Serialize, Deserialize)]
+pub enum AssociationType {
+    Static,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Association {
+    pub addr: Address,
+    pub key_bytes: String,
+    pub text: String,
+    pub format: AssociationFormat,
+    pub proof: Vec<u8>,
+    pub proof_type: AssociationType,
+}
+
+impl Association {
+    pub fn test() -> Self {
+        Self {
+            addr: "ADDR".to_string(),
+            key_bytes: "KEY_BYTES".to_string(),
+            text: "TEXT".to_string(),
+            format: AssociationFormat::Eip191,
+            proof: vec![0, 2, 3, 5, 67],
+            proof_type: AssociationType::Static,
+        }
+    }
+}
 
 pub struct VmacAccount {
-    pub account: Account,
+    account: OlmAccount,
 }
 
 // Struct that holds an account and adds some serialization methods on top
 impl VmacAccount {
     // Create a new instance
-    pub fn new(account: Account) -> Self {
+    pub fn new(account: OlmAccount) -> Self {
         Self { account }
     }
 
     pub fn generate() -> Self {
-        Self::new(Account::new())
+        Self::new(OlmAccount::new())
+    }
+
+    pub fn get(&self) -> &OlmAccount {
+        &self.account
+    }
+}
+
+impl Signable for VmacAccount {
+    fn bytes_to_sign(&self) -> Vec<u8> {
+        self.account.curve25519_key().to_vec()
     }
 }
 
@@ -34,8 +83,54 @@ impl<'de> Deserialize<'de> for VmacAccount {
     where
         D: serde::de::Deserializer<'de>,
     {
-        let pickle: AccountPickle = Deserialize::deserialize(deserializer)?;
-        let account = Account::from_pickle(pickle);
+        let pickle: OlmAccountPickle = Deserialize::deserialize(deserializer)?;
+        let account = OlmAccount::from_pickle(pickle);
+
         Ok(Self::new(account))
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Account {
+    keys: VmacAccount,
+    assoc: Association,
+}
+
+impl Account {
+    pub fn new(keys: VmacAccount, assoc: Association) -> Self {
+        Self { keys, assoc }
+    }
+
+    pub fn generate(sf: impl Fn(Vec<u8>) -> Association + 'static) -> Self {
+        let keys = VmacAccount::generate();
+        let bytes = keys.bytes_to_sign();
+        Self::new(keys, sf(bytes))
+    }
+
+    pub fn addr(&self) -> Address {
+        self.assoc.addr.clone()
+    }
+}
+
+pub fn test_wallet_signer(_: Vec<u8>) -> Association {
+    Association::test()
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{test_wallet_signer, Account};
+
+    #[test]
+    fn account_serialize() {
+        let account = Account::generate(test_wallet_signer);
+        let serialized_account = json!(account).to_string();
+        let serialized_account_other = json!(account).to_string();
+
+        assert_eq!(serialized_account, serialized_account_other);
+
+        let recovered_account: Account = serde_json::from_str(&serialized_account).unwrap();
+        assert_eq!(account.addr(), recovered_account.addr());
     }
 }

--- a/xmtp/src/account.rs
+++ b/xmtp/src/account.rs
@@ -112,11 +112,11 @@ impl Account {
     }
 }
 
-pub struct AccountFactory {
+pub struct AccountCreator {
     key: VmacAccount,
 }
 
-impl AccountFactory {
+impl AccountCreator {
     pub fn new() -> Self {
         Self {
             key: VmacAccount::generate(),
@@ -128,7 +128,7 @@ impl AccountFactory {
     }
 }
 
-impl Signable for AccountFactory {
+impl Signable for AccountCreator {
     fn bytes_to_sign(&self) -> Vec<u8> {
         self.key.bytes_to_sign()
     }
@@ -144,7 +144,7 @@ mod tests {
 
     use crate::{account::Association, Signable};
 
-    use super::{test_wallet_signer, Account, AccountFactory};
+    use super::{test_wallet_signer, Account, AccountCreator};
 
     #[test]
     fn account_serialize() {
@@ -160,9 +160,9 @@ mod tests {
 
     #[test]
     fn account_generate() {
-        let factory = AccountFactory::new();
-        let _ = factory.bytes_to_sign();
-        let account = factory.finalize_key(vec![11, 22, 33]);
+        let ac = AccountCreator::new();
+        let _ = ac.bytes_to_sign();
+        let account = ac.finalize_key(vec![11, 22, 33]);
 
         assert_eq!(account.assoc, Association::test())
     }

--- a/xmtp/src/builder.rs
+++ b/xmtp/src/builder.rs
@@ -136,7 +136,7 @@ mod tests {
         let client = ClientBuilder::new_test().build().unwrap();
         assert!(!client
             .account
-            .account
+            .get()
             .identity_keys()
             .curve25519
             .to_bytes()
@@ -160,8 +160,8 @@ mod tests {
 
         // Ensure the persistence was used to store the generated keys
         assert_eq!(
-            client_a.account.account.curve25519_key().to_bytes(),
-            client_b.account.account.curve25519_key().to_bytes()
+            client_a.account.get().curve25519_key().to_bytes(),
+            client_b.account.get().curve25519_key().to_bytes()
         )
     }
 

--- a/xmtp/src/builder.rs
+++ b/xmtp/src/builder.rs
@@ -1,5 +1,5 @@
 use crate::{
-    account::VmacAccount,
+    account::{Account, VmacAccount},
     client::{Client, Network},
     persistence::{NamespacedPersistence, Persistence},
 };
@@ -25,6 +25,7 @@ where
     network: Network,
     persistence: Option<P>,
     wallet_address: Option<String>,
+    account: Option<Account>,
 }
 
 impl<P> ClientBuilder<P>
@@ -36,6 +37,7 @@ where
             network: Network::Dev,
             persistence: None,
             wallet_address: None,
+            account: None,
         }
     }
 
@@ -46,6 +48,11 @@ where
 
     pub fn persistence(mut self, persistence: P) -> Self {
         self.persistence = Some(persistence);
+        self
+    }
+
+    pub fn account(mut self, account: Account) -> Self {
+        self.account = Some(account);
         self
     }
 

--- a/xmtp/src/lib.rs
+++ b/xmtp/src/lib.rs
@@ -7,7 +7,7 @@ pub mod vmac_protos;
 pub use builder::ClientBuilder;
 pub use client::Client;
 
-trait Signable {
+pub trait Signable {
     fn bytes_to_sign(&self) -> Vec<u8>;
 }
 

--- a/xmtp/src/lib.rs
+++ b/xmtp/src/lib.rs
@@ -7,6 +7,10 @@ pub mod vmac_protos;
 pub use builder::ClientBuilder;
 pub use client::Client;
 
+trait Signable {
+    fn bytes_to_sign(&self) -> Vec<u8>;
+}
+
 #[cfg(test)]
 mod tests {
     use crate::builder::ClientBuilder;


### PR DESCRIPTION
This PR adds plumbing for a Higher Order account object. 

- Creates `Account` struct
- Adds `AccountCreator` to help create accounts
- Adds Mechanism for Implementors to sign keys
- Adds Association struct to add flexible signatures
- updates WasmBindings


Work saved for followup PRs

- Signature generation and validation
- Update Client and ClientBuilder to use `Account` not `VmacAccount` 