### PR TITLE
ci: include github_token in buf-setup-action to fix rate limit failures

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,8 @@ jobs:
       - uses: actions/checkout@v1
       - run: rustup component add clippy
       - uses: bufbuild/buf-setup-action@v1.17.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions-rs/clippy-check@v1
         name: Lint main workspace
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
         run: dev/up
 
       - uses: bufbuild/buf-setup-action@v1.17.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/wasm_npm_test.yaml
+++ b/.github/workflows/wasm_npm_test.yaml
@@ -15,16 +15,18 @@ jobs:
       run:
         working-directory: ./bindings_js
     steps:
-     - name: Checkout sources
-       uses: actions/checkout@v2
-     - name: Install stable toolchain
-       uses: actions-rs/toolchain@v1
-       with:
-         profile: minimal
-         toolchain: stable
-         override: true
-     - uses: jetli/wasm-pack-action@v0.4.0
-     - uses: actions/setup-node@v3
-     - uses: bufbuild/buf-setup-action@v1.17.0
-     - run: npm ci
-     - run: npm test
+    - name: Checkout sources
+      uses: actions/checkout@v2
+    - name: Install stable toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+    - uses: jetli/wasm-pack-action@v0.4.0
+    - uses: actions/setup-node@v3
+    - uses: bufbuild/buf-setup-action@v1.17.0
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+    - run: npm ci
+    - run: npm test


### PR DESCRIPTION
CI is [sometimes failing](https://github.com/xmtp/libxmtp/actions/runs/4949960074/jobs/8852897436) with these rate limit errors:
```plain
> Run bufbuild/buf-setup-action@v1.17.0
Warning: No github_token supplied, API requests will be subject to stricter rate limiting
Setting up buf version "1.17.0"
Resolving the download URL for the current platform...
Error: API rate limit exceeded for 70.37.167.[5](https://github.com/xmtp/libxmtp/actions/runs/4949960074/jobs/8852897436#step:4:6)1. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)
```

So this PR updates GH action references to include `github_token` to avoid the errors as per https://github.com/bufbuild/buf-setup-action#github-token