### PR TITLE
remove bindings_wasm from workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [workspace]
 
 members = [
-  "bindings_wasm",
   "xmtp",
   "xmtp_crypto",
   "xmtp_cryptography",
@@ -16,4 +15,5 @@ members = [
 exclude = [
   "bindings_js",
   "bindings_swift",
+  "bindings_wasm",
 ]


### PR DESCRIPTION
[The client list](https://github.com/xmtp/libxmtp/blob/c50cd1d78bdd63e2fd1dd993e3fd03431342d7af/bindings_wasm/src/lib.rs#L12) in the wasm bindings puts heavy restrictions on the xmtp:Client struct. Namely that every component implements the 'Send' trait. 

As wasm is being deprioritized for the time being, it would be faster to remove this restriction, and not worry about keeping the wasm bindings.

This change removes `bindings_wasm` from the workspace so that the client is no longer limited by WASM requirements.

