### PR TITLE
Export keccak for use in crate

### DIFF
--- a/xmtp_cryptography/src/hash.rs
+++ b/xmtp_cryptography/src/hash.rs
@@ -1,0 +1,7 @@
+use sha3::{Digest, Keccak256};
+
+pub fn keccak256(msg: &str) -> Vec<u8> {
+    let k = Keccak256::digest(msg);
+
+    k.as_slice().to_vec()
+}

--- a/xmtp_cryptography/src/lib.rs
+++ b/xmtp_cryptography/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod hash;
 pub mod signature;
 pub mod utils;


### PR DESCRIPTION
This PR exports a Keccak function for use in other packages.

Re-importing libraries in different packages leads to version conflicts as structs from non-semver compatible versions are treated ad distinct. This causes many headaches. Exporting common functions ensures that the entire crate is using the same version of a library and reduces conflicts.