### PR TITLE
Builder Interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4452,7 +4452,7 @@ dependencies = [
  "diesel_migrations",
  "env_logger",
  "ethers",
- "ethers-core",
+ "futures",
  "hex",
  "log",
  "prost",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4452,6 +4452,7 @@ dependencies = [
  "diesel_migrations",
  "env_logger",
  "ethers",
+ "ethers-core",
  "futures",
  "hex",
  "log",

--- a/bindings_ffi/src/lib.rs
+++ b/bindings_ffi/src/lib.rs
@@ -30,13 +30,9 @@ async fn create_client(
     // TODO proper error handling
 ) -> Result<xmtp::Client<FfiApiClient, InMemoryPersistence, UnencryptedMessageStore>, String> {
     let api_client = FfiApiClient::new(host, is_secure).await?;
-    let persistence = InMemoryPersistence::new();
-    let store = UnencryptedMessageStore::default();
 
     let xmtp_client = xmtp::ClientBuilder::new(owner.into())
         .api_client(api_client)
-        .persistence(persistence)
-        .store(store)
         .build()
         .map_err(|e| format!("{:?}", e))?;
 

--- a/xmtp/Cargo.toml
+++ b/xmtp/Cargo.toml
@@ -26,8 +26,8 @@ log = "0.4.17"
 rand = "0.8.5"
 toml = "0.7.4"
 ethers = "2.0.4"
-ethers-core = "2.0.4"
 prost = { version = "0.11", features = ["prost-derive"] }
+futures = "0.3.28"
 
 [dev-dependencies]
 env_logger = "0.10.0"

--- a/xmtp/Cargo.toml
+++ b/xmtp/Cargo.toml
@@ -26,6 +26,7 @@ log = "0.4.17"
 rand = "0.8.5"
 toml = "0.7.4"
 ethers = "2.0.4"
+ethers-core = "2.0.4"
 prost = { version = "0.11", features = ["prost-derive"] }
 futures = "0.3.28"
 

--- a/xmtp/examples/cli-client.rs
+++ b/xmtp/examples/cli-client.rs
@@ -20,7 +20,7 @@ fn main() {
 
     let wallet = LocalWallet::new(&mut rand::thread_rng());
 
-    let client_result = xmtp::ClientBuilder::new(wallet)
+    let client_result = xmtp::ClientBuilder::new(wallet.into())
         .network(xmtp::client::Network::Dev)
         .api_client(MockXmtpApiClient::default())
         .persistence(InMemoryPersistence::default())

--- a/xmtp/examples/cli-client.rs
+++ b/xmtp/examples/cli-client.rs
@@ -3,13 +3,12 @@ extern crate ethers;
 extern crate log;
 extern crate xmtp;
 
-use ethers::signers::{LocalWallet, Signer};
 use ethers_core::rand;
 use log::{error, info, warn};
 use xmtp::networking::MockXmtpApiClient;
 use xmtp::persistence::in_memory_persistence::InMemoryPersistence;
 use xmtp::storage::{StorageOption, UnencryptedMessageStore};
-use xmtp_cryptography::signature::h160addr_to_string;
+use xmtp_cryptography::utils::LocalWallet;
 
 /// A complete example of a minimal xmtp client which can send and recieve messages.
 /// run this example from the cli:  `RUST_LOG=DEBUG cargo run --example cli-client`
@@ -21,12 +20,11 @@ fn main() {
 
     let wallet = LocalWallet::new(&mut rand::thread_rng());
 
-    let client_result = xmtp::ClientBuilder::new()
+    let client_result = xmtp::ClientBuilder::new(wallet)
         .network(xmtp::client::Network::Dev)
         .api_client(MockXmtpApiClient::default())
         .persistence(InMemoryPersistence::default())
         .store(msg_store)
-        .wallet_address(&h160addr_to_string(wallet.address()))
         .build();
 
     let _client = match client_result {

--- a/xmtp/src/account.rs
+++ b/xmtp/src/account.rs
@@ -6,14 +6,16 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use vodozemac::olm::{Account as OlmAccount, AccountPickle as OlmAccountPickle};
-use xmtp_cryptography::signature::RecoverableSignature;
+use vodozemac::olm::{Account as OlmAccount, AccountPickle as OlmAccountPickle, IdentityKeys};
+use xmtp_cryptography::signature::{RecoverableSignature, SignatureError};
 use xmtp_proto::xmtp::v3::message_contents::{
     VmacAccountLinkedKey, VmacContactBundle, VmacDeviceLinkedKey, VmacUnsignedPublicKey,
 };
 
 #[derive(Debug, Error)]
 pub enum AccountError {
+    #[error("generating new account")]
+    BadGeneration(#[from] SignatureError),
     #[error("bad association")]
     BadAssocation(#[from] AssociationError),
     #[error("unknown error")]
@@ -85,10 +87,14 @@ impl Account {
         Self { keys, assoc }
     }
 
-    pub fn generate(sf: impl Fn(Vec<u8>) -> Association + 'static) -> Self {
+    pub fn generate(
+        sf: impl Fn(&Vec<u8>) -> Result<Association, AssociationError>,
+    ) -> Result<Self, AccountError> {
         let keys = VmacAccount::generate();
         let bytes = keys.bytes_to_sign();
-        Self::new(keys, sf(bytes))
+
+        let assoc = sf(&bytes)?;
+        Ok(Self::new(keys, assoc))
     }
 
     pub fn addr(&self) -> Address {
@@ -119,6 +125,10 @@ impl Account {
             identity_key: Some(identity_key),
             prekey: Some(fallback_key),
         }
+    }
+
+    pub fn get_keys(&self) -> IdentityKeys {
+        self.keys.account.identity_keys()
     }
 }
 
@@ -161,6 +171,8 @@ impl Signable for AccountCreator {
 #[cfg(test)]
 mod tests {
 
+    use crate::association::AssociationError;
+
     use super::{Account, AccountCreator, Association};
     use ethers::core::rand::thread_rng;
     use ethers::signers::{LocalWallet, Signer};
@@ -169,13 +181,13 @@ mod tests {
     use serde_json::json;
     use xmtp_cryptography::{signature::h160addr_to_string, utils::rng};
 
-    pub fn test_wallet_signer(_: Vec<u8>) -> Association {
-        Association::test().expect("Test Association failed to generate")
+    pub fn test_wallet_signer(_: &Vec<u8>) -> Result<Association, AssociationError> {
+        Association::test()
     }
 
     #[test]
     fn account_serialize() {
-        let account = Account::generate(test_wallet_signer);
+        let account = Account::generate(test_wallet_signer).unwrap();
         let serialized_account = json!(account).to_string();
         let serialized_account_other = json!(account).to_string();
 

--- a/xmtp/src/account.rs
+++ b/xmtp/src/account.rs
@@ -88,12 +88,12 @@ impl Account {
     }
 
     pub fn generate(
-        sf: impl Fn(&Vec<u8>) -> Result<Association, AssociationError>,
+        sf: impl Fn(Vec<u8>) -> Result<Association, AssociationError>,
     ) -> Result<Self, AccountError> {
         let keys = VmacAccount::generate();
         let bytes = keys.bytes_to_sign();
 
-        let assoc = sf(&bytes)?;
+        let assoc = sf(bytes)?;
         Ok(Self::new(keys, assoc))
     }
 
@@ -181,7 +181,7 @@ mod tests {
     use serde_json::json;
     use xmtp_cryptography::{signature::h160addr_to_string, utils::rng};
 
-    pub fn test_wallet_signer(_: &Vec<u8>) -> Result<Association, AssociationError> {
+    pub fn test_wallet_signer(_: Vec<u8>) -> Result<Association, AssociationError> {
         Association::test()
     }
 

--- a/xmtp/src/builder.rs
+++ b/xmtp/src/builder.rs
@@ -7,10 +7,7 @@ use crate::{
     types::Address,
     Errorer, InboxOwner,
 };
-use ethers::signers::{LocalWallet, Signer};
-use ethers_core::utils::hash_message;
 use thiserror::Error;
-use xmtp_cryptography::{signature::h160addr_to_string, utils::rng};
 
 #[derive(Error, Debug)]
 pub enum ClientBuilderError<PE> {
@@ -112,28 +109,6 @@ where
     pub fn account(mut self, account: Account) -> Self {
         self.account = Some(account);
         self
-    }
-
-    pub fn wallet_address(mut self, wallet_address: &str) -> Self {
-        self.wallet_address = Some(wallet_address.to_string());
-        self
-    }
-
-    // Temp function to generate a full account, using a random local wallet
-    fn generate_account() -> Result<Account, AccountError> {
-        // TODO: Replace with real wallet signature
-        let wallet = LocalWallet::new(&mut rng());
-        let addr = h160addr_to_string(wallet.address());
-
-        let ac = AccountCreator::new(addr);
-        let msg = ac.text_to_sign();
-        let hash = hash_message(msg);
-        let sig = wallet
-            .sign_hash(hash)
-            .expect("Bad Signature with fake wallet");
-        let account = ac.finalize(sig.to_vec())?;
-
-        Ok(account)
     }
 
     pub fn store(mut self, store: S) -> Self {

--- a/xmtp/src/builder.rs
+++ b/xmtp/src/builder.rs
@@ -143,7 +143,7 @@ where
     }
 
     fn create_new_account(&self) -> Result<Account, AccountError> {
-        let sign = |public_key_bytes: &Vec<u8>| -> Result<Association, AssociationError> {
+        let sign = |public_key_bytes: Vec<u8>| -> Result<Association, AssociationError> {
             let assoc_text = AssociationText::Static {
                 addr: self.wallet_address.clone(),
                 account_public_key: public_key_bytes.clone(),

--- a/xmtp/src/builder.rs
+++ b/xmtp/src/builder.rs
@@ -34,6 +34,7 @@ pub enum ClientBuilderError<PE> {
 pub enum AccountStrategy<O: InboxOwner> {
     CreateIfNotFound(O),
     CachedOnly(Address),
+    #[cfg(test)]
     ExternalAccount(Account),
 }
 
@@ -119,8 +120,9 @@ where
     fn get_address(&self) -> Address {
         match &self.account_strategy {
             AccountStrategy::CachedOnly(a) => a.clone(),
-            AccountStrategy::ExternalAccount(e) => e.addr(),
             AccountStrategy::CreateIfNotFound(o) => o.get_address(),
+            #[cfg(test)]
+            AccountStrategy::ExternalAccount(e) => e.addr(),
         }
     }
 
@@ -210,7 +212,7 @@ where
             AccountStrategy::CreateIfNotFound(owner) => {
                 Self::find_or_create_account(&owner, &mut persistence)?
             }
-
+            #[cfg(test)]
             AccountStrategy::ExternalAccount(a) => a,
         };
 

--- a/xmtp/src/client.rs
+++ b/xmtp/src/client.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use prost::Message;
 use xmtp_proto::xmtp::{message_api::v1::Envelope, v3::message_contents::VmacContactBundle};
-
+//TODO: Remove Comment
 #[derive(Clone, Copy, Default)]
 pub enum Network {
     Local(&'static str),

--- a/xmtp/src/client.rs
+++ b/xmtp/src/client.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use prost::Message;
 use xmtp_proto::xmtp::{message_api::v1::Envelope, v3::message_contents::VmacContactBundle};
-//TODO: Remove Comment
+
 #[derive(Clone, Copy, Default)]
 pub enum Network {
     Local(&'static str),

--- a/xmtp/src/lib.rs
+++ b/xmtp/src/lib.rs
@@ -3,14 +3,17 @@ pub mod association;
 pub mod builder;
 pub mod client;
 pub mod networking;
+pub mod owner;
 pub mod persistence;
 pub mod storage;
 mod types;
 mod utils;
 pub mod vmac_protos;
 
+use association::AssociationText;
 pub use builder::ClientBuilder;
 pub use client::Client;
+use xmtp_cryptography::signature::{RecoverableSignature, SignatureError};
 
 pub trait Signable {
     fn bytes_to_sign(&self) -> Vec<u8>;
@@ -27,6 +30,11 @@ pub trait Store<I> {
 pub trait Fetch<T> {
     type E;
     fn fetch(&mut self) -> Result<Vec<T>, Self::E>;
+}
+
+pub trait InboxOwner {
+    fn get_address(&self) -> String;
+    fn sign(&self, text: AssociationText) -> Result<RecoverableSignature, SignatureError>;
 }
 
 #[cfg(test)]

--- a/xmtp/src/owner/evm_owner.rs
+++ b/xmtp/src/owner/evm_owner.rs
@@ -1,0 +1,18 @@
+use crate::{association::AssociationText, InboxOwner};
+
+pub use ethers::signers::{LocalWallet, Signer};
+use futures::executor;
+use xmtp_cryptography::signature::{h160addr_to_string, RecoverableSignature, SignatureError};
+
+impl InboxOwner for LocalWallet {
+    fn get_address(&self) -> String {
+        h160addr_to_string(self.address())
+    }
+
+    fn sign(&self, text: AssociationText) -> Result<RecoverableSignature, SignatureError> {
+        let signature = executor::block_on(self.sign_message(text.text()))
+            .map_err(|e| SignatureError::ThirdPartyError(e.to_string()))?;
+
+        Ok(RecoverableSignature::Eip191Signature(signature.to_vec()))
+    }
+}

--- a/xmtp/src/owner/mod.rs
+++ b/xmtp/src/owner/mod.rs
@@ -1,0 +1,2 @@
+// #[cfg(feature = "ethers")]
+mod evm_owner;

--- a/xmtp_cryptography/Cargo.toml
+++ b/xmtp_cryptography/Cargo.toml
@@ -6,6 +6,7 @@ rust-version = "1.64"
 
 [dependencies]
 ecdsa = "0.15.1"
+ethers = "2.0.4"
 ethers-core = "2.0.4"
 hex = "0.4"
 k256 = {version = "0.12.0", features = ["ecdh"]}
@@ -16,5 +17,5 @@ sha3 = "0.10.6"
 thiserror = "1.0.40"
 
 [dev-dependencies]
-ethers = "2.0.4"
+
 tokio = {version="1.28.1", features=["rt", "macros"]}

--- a/xmtp_cryptography/src/signature.rs
+++ b/xmtp_cryptography/src/signature.rs
@@ -18,6 +18,8 @@ pub enum SignatureError {
     },
     #[error("Error creating signature")]
     SigningError(#[from] ecdsa::Error),
+    #[error("Error thrown from thirdParty")]
+    ThirdPartyError(String),
     #[error("unknown data store error")]
     Unknown,
 }

--- a/xmtp_cryptography/src/utils.rs
+++ b/xmtp_cryptography/src/utils.rs
@@ -1,3 +1,4 @@
+pub use ethers::prelude::LocalWallet;
 use ethers_core::utils::keccak256;
 use k256::ecdsa::VerifyingKey;
 use rand::{CryptoRng, RngCore, SeedableRng};
@@ -16,4 +17,8 @@ pub fn eth_address(pubkey: &VerifyingKey) -> Result<String, String> {
 
     // Return the result as hex string, take the last 20 bytes
     Ok(format!("0x{}", hex::encode(&hash[12..])))
+}
+
+pub fn generate_local_wallet() -> LocalWallet {
+    LocalWallet::new(&mut rng())
 }

--- a/xmtp_keystore/src/lib.rs
+++ b/xmtp_keystore/src/lib.rs
@@ -276,7 +276,7 @@ mod tests {
             SignedPrivateKey::ethereum_personal_digest(xmtp_test_message.as_bytes());
         assert_eq!(
             xmtp_test_digest,
-            general_purpose::STANDARD.encode(&derived_digest)
+            general_purpose::STANDARD.encode(derived_digest)
         );
     }
 

--- a/xmtp_networking/src/lib.rs
+++ b/xmtp_networking/src/lib.rs
@@ -12,12 +12,11 @@ mod tests {
     pub fn test_envelope(topic: String) -> Envelope {
         let time_since_epoch = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
 
-        return Envelope {
+        Envelope {
             timestamp_ns: time_since_epoch.as_nanos() as u64,
-            content_topic: topic.to_string(),
+            content_topic: topic,
             message: vec![65],
-            ..Default::default()
-        };
+        }
     }
 
     #[tokio::test]
@@ -62,7 +61,7 @@ mod tests {
             let topic = uuid::Uuid::new_v4();
             let mut stream_handler = client.subscribe(vec![topic.to_string()]).await.unwrap();
 
-            assert_eq!(stream_handler.is_closed(), false);
+            assert!(stream_handler.is_closed());
             // Skipping the auth token because we have authn disabled on the local
             // xmtp-node-go instance
             client
@@ -80,11 +79,11 @@ mod tests {
 
             // Ensure that the messages array has been cleared
             let second_results = stream_handler.get_messages();
-            assert!(second_results.len() == 0);
+            assert!(second_results.is_empty());
 
             // Ensure the is_closed status is propagated
             stream_handler.close_stream();
-            assert_eq!(stream_handler.is_closed(), true);
+            assert!(stream_handler.is_closed());
         })
         .await
         .expect("Timed out");

--- a/xmtp_networking/src/lib.rs
+++ b/xmtp_networking/src/lib.rs
@@ -61,7 +61,7 @@ mod tests {
             let topic = uuid::Uuid::new_v4();
             let mut stream_handler = client.subscribe(vec![topic.to_string()]).await.unwrap();
 
-            assert!(stream_handler.is_closed());
+            assert!(!stream_handler.is_closed());
             // Skipping the auth token because we have authn disabled on the local
             // xmtp-node-go instance
             client


### PR DESCRIPTION
Refactors the Builder interface to include passing in a signer

## Highlights
- InboxOwner Trait
  - Provides a common interface for Signers, which can be passed into the account builder
  - Currently implemented for ethers::LocalWallet, will implement for other signers when we tackle platformSDKs
- Adds AccountStrategy enum to ClientBuilder, which allows control of the account fetching behavior
  - Passing in a impl InboxOwner ->   CreateIfNotFound,
  - Passing in a Address -> LoadCachedOnly
  - Passing in an Account -> Use  ExternalAccount
  - This was left over from Integrating with the FFI bindings, however is not strictly needed after the refactor. Open to dropping.
- Simplifies the api for creating a Client
- Ported to use Account, rather than VmacAccount  
  



