### PR TITLE
Client Async Registration + Error Types

### DIFF
--- a/bindings_ffi/src/lib.rs
+++ b/bindings_ffi/src/lib.rs
@@ -36,7 +36,7 @@ async fn create_client(
         .build()
         .map_err(|e| format!("{:?}", e))?;
 
-    Ok(xmtp_client)
+    Ok(xmtp_client.init().await.map_err(|e| e.to_string())?)
 }
 
 pub struct FfiApiClient {

--- a/bindings_ffi/src/lib.rs
+++ b/bindings_ffi/src/lib.rs
@@ -31,12 +31,12 @@ async fn create_client(
 ) -> Result<xmtp::Client<FfiApiClient, InMemoryPersistence, UnencryptedMessageStore>, String> {
     let api_client = FfiApiClient::new(host, is_secure).await?;
 
-    let xmtp_client = xmtp::ClientBuilder::new(owner.into())
+    let mut xmtp_client = xmtp::ClientBuilder::new(owner.into())
         .api_client(api_client)
         .build()
         .map_err(|e| format!("{:?}", e))?;
-
-    Ok(xmtp_client.init().await.map_err(|e| e.to_string())?)
+    xmtp_client.init().await.map_err(|e| e.to_string())?;
+    Ok(xmtp_client)
 }
 
 pub struct FfiApiClient {

--- a/xmtp/examples/cli-client.rs
+++ b/xmtp/examples/cli-client.rs
@@ -12,7 +12,8 @@ use xmtp_cryptography::utils::LocalWallet;
 
 /// A complete example of a minimal xmtp client which can send and recieve messages.
 /// run this example from the cli:  `RUST_LOG=DEBUG cargo run --example cli-client`
-fn main() {
+#[tokio::main]
+async fn main() {
     env_logger::init();
     info!("Starting CLI Client....");
 
@@ -27,14 +28,21 @@ fn main() {
         .store(msg_store)
         .build();
 
-    let _client = match client_result {
+    let uninit_client = match client_result {
         Err(e) => {
             error!("ClientBuilder Error: {:?}", e);
             return;
         }
         Ok(c) => c,
     };
-    warn!("Client Is not properly initialized at this point -- Signed account not present");
+
+    let client = match uninit_client.init().await {
+        Err(e) => {
+            error!("Initialization Failed: {}", e.to_string());
+            panic!("Could not init");
+        }
+        Ok(c) => c,
+    };
 
     // Application logic
     // ...

--- a/xmtp/examples/cli-client.rs
+++ b/xmtp/examples/cli-client.rs
@@ -28,7 +28,7 @@ async fn main() {
         .store(msg_store)
         .build();
 
-    let uninit_client = match client_result {
+    let mut client = match client_result {
         Err(e) => {
             error!("ClientBuilder Error: {:?}", e);
             return;
@@ -36,12 +36,9 @@ async fn main() {
         Ok(c) => c,
     };
 
-    let client = match uninit_client.init().await {
-        Err(e) => {
-            error!("Initialization Failed: {}", e.to_string());
-            panic!("Could not init");
-        }
-        Ok(c) => c,
+    if let Err(e) = client.init().await {
+        error!("Initialization Failed: {}", e.to_string());
+        panic!("Could not init");
     };
 
     // Application logic

--- a/xmtp/examples/cli-client.rs
+++ b/xmtp/examples/cli-client.rs
@@ -21,7 +21,7 @@ fn main() {
     let wallet = LocalWallet::new(&mut rand::thread_rng());
 
     let client_result = xmtp::ClientBuilder::new(wallet.into())
-        .network(xmtp::client::Network::Dev)
+        .network(xmtp::Network::Dev)
         .api_client(MockXmtpApiClient::default())
         .persistence(InMemoryPersistence::default())
         .store(msg_store)

--- a/xmtp/examples/cli-client.rs
+++ b/xmtp/examples/cli-client.rs
@@ -4,7 +4,7 @@ extern crate log;
 extern crate xmtp;
 
 use ethers_core::rand;
-use log::{error, info, warn};
+use log::{error, info};
 use xmtp::networking::MockXmtpApiClient;
 use xmtp::persistence::in_memory_persistence::InMemoryPersistence;
 use xmtp::storage::{StorageOption, UnencryptedMessageStore};

--- a/xmtp/src/builder.rs
+++ b/xmtp/src/builder.rs
@@ -1,7 +1,7 @@
 use crate::{
     account::{Account, AccountError},
     association::{Association, AssociationError, AssociationText},
-    client::{Client, Network},
+    client::{Client, Network, UninitializedClient},
     networking::XmtpApiClient,
     persistence::{NamespacedPersistence, Persistence},
     types::Address,
@@ -196,7 +196,7 @@ where
 
         Account::generate(sign).map_err(ClientBuilderError::AccountInitialization)
     }
-    pub fn build(mut self) -> Result<Client<A, P, S>, ClientBuilderError<P::Error>> {
+    pub fn build(mut self) -> Result<UninitializedClient<A, P, S>, ClientBuilderError<P::Error>> {
         let api_client = self.api_client.take().unwrap_or_default();
         let wallet_address = self.get_address();
         let persistence = self.persistence.take().unwrap_or_default();
@@ -218,13 +218,13 @@ where
 
         let store = self.store.take().unwrap_or_default();
 
-        Ok(Client {
+        Ok(UninitializedClient::new(Client {
             api_client,
             network: self.network,
             persistence,
             account,
             _store: store,
-        })
+        }))
     }
 }
 
@@ -256,7 +256,13 @@ mod tests {
     #[test]
     fn builder_test() {
         let client = ClientBuilder::new_test().build().unwrap();
-        assert!(!client.account.get_keys().curve25519.to_bytes().is_empty())
+        assert!(!client
+            .skip_init()
+            .account
+            .get_keys()
+            .curve25519
+            .to_bytes()
+            .is_empty())
     }
 
     #[test]
@@ -269,13 +275,15 @@ mod tests {
             ClientBuilder::new(wallet.clone().into())
                 .persistence(persistence)
                 .build()
-                .unwrap();
+                .unwrap()
+                .skip_init();
 
         let client_b: Client<MockXmtpApiClient, InMemoryPersistence, UnencryptedMessageStore> =
             ClientBuilder::new(wallet.into())
                 .persistence(client_a.persistence.persistence)
                 .build()
-                .unwrap();
+                .unwrap()
+                .skip_init();
         // Ensure the persistence was used to store the generated keys
         assert_eq!(
             client_a.account.get_keys().curve25519.to_bytes(),

--- a/xmtp/src/client.rs
+++ b/xmtp/src/client.rs
@@ -75,11 +75,11 @@ where
     async fn noop(&self) {}
     pub async fn init(&mut self) -> Result<(), ClientError> {
         // Register Contact Bundles
-        let registered_bundles = self.noop().await; // Causes #[swift_bridge::bridge] to fail when noop is a member fn
+        let registered_bundles = self.get_contacts(&self.wallet_address()).await?;
 
-        // if registered_bundles.is_empty() {
-        // self.publish_user_contact().await?;
-        // }
+        if registered_bundles.is_empty() {
+            self.publish_user_contact().await?;
+        }
 
         self.is_initialized = true;
         Ok(())

--- a/xmtp/src/client.rs
+++ b/xmtp/src/client.rs
@@ -72,7 +72,6 @@ where
         self.account.addr()
     }
 
-    async fn noop(&self) {}
     pub async fn init(&mut self) -> Result<(), ClientError> {
         // Register Contact Bundles
         let registered_bundles = self.get_contacts(&self.wallet_address()).await?;
@@ -138,12 +137,12 @@ where
         Ok(envelope)
     }
 
-    #[warn(dead_code)]
+    #[allow(dead_code)]
     fn write_to_persistence(&mut self, s: &str, b: &[u8]) -> Result<(), P::Error> {
         self.persistence.write(s, b)
     }
 
-    #[warn(dead_code)]
+    #[allow(dead_code)]
     fn read_from_persistence(&self, s: &str) -> Result<Option<Vec<u8>>, P::Error> {
         self.persistence.read(s)
     }

--- a/xmtp/src/client.rs
+++ b/xmtp/src/client.rs
@@ -7,7 +7,7 @@ use crate::{
     types::Address,
     utils::{build_envelope, build_user_contact_topic},
 };
-use prost::Message;
+use prost::{DecodeError, EncodeError, Message};
 use xmtp_proto::xmtp::{message_api::v1::Envelope, v3::message_contents::VmacContactBundle};
 
 #[derive(Clone, Copy, Default)]
@@ -20,6 +20,14 @@ pub enum Network {
 
 #[derive(Debug, Error)]
 pub enum ClientError {
+    #[error("encoding error({s}) -- {e}")]
+    EncodingError { s: &'static str, e: EncodeError },
+    #[error("Decoding error({s}) -- {e}")]
+    DecodingError { s: &'static str, e: DecodeError },
+    #[error("could not publish: {0}")]
+    PublishError(String),
+    #[error("Query failed: {0}")]
+    QueryError(String),
     #[error("unknown client error")]
     Unknown,
 }
@@ -48,6 +56,31 @@ where
     A: XmtpApiClient,
     P: Persistence,
 {
+    pub fn new(
+        api_client: A,
+        network: Network,
+        persistence: NamespacedPersistence<P>,
+        account: Account,
+        store: S,
+    ) -> Self {
+        Self {
+            api_client,
+            network,
+            persistence,
+            account,
+            _store: store,
+        }
+    }
+    pub async fn init(&mut self) -> Result<&Self, ClientError> {
+        // Register Contact Bundles
+        let registered_bundles = self.get_contacts(&self.wallet_address()).await?;
+        if registered_bundles.is_empty() {
+            self.publish_user_contact().await?;
+        }
+
+        Ok(self)
+    }
+
     pub fn write_to_persistence(&mut self, s: &str, b: &[u8]) -> Result<(), P::Error> {
         self.persistence.write(s, b)
     }
@@ -60,40 +93,53 @@ where
         self.account.addr()
     }
 
-    pub async fn get_contacts(
+    async fn get_contacts(
         &self,
         wallet_address: &str,
-    ) -> Result<Vec<VmacContactBundle>, String> {
+    ) -> Result<Vec<VmacContactBundle>, ClientError> {
         let topic = build_user_contact_topic(wallet_address.to_string());
-        let response = self.api_client.query(topic, None, None, None).await?;
+        let response = self
+            .api_client
+            .query(topic, None, None, None)
+            .await
+            .map_err(ClientError::QueryError)?;
 
         let mut contacts = vec![];
         for envelope in response.envelopes {
             // TODO: Wrap the proto in some special struct
             // TODO: Handle errors better
-            let contact_bundle = VmacContactBundle::decode(envelope.message.as_slice())
-                .map_err(|e| format!("{}", e))?;
+            let contact_bundle =
+                VmacContactBundle::decode(envelope.message.as_slice()).map_err(|e| {
+                    ClientError::DecodingError {
+                        s: "FailedToDecodeContact",
+                        e,
+                    }
+                })?;
             contacts.push(contact_bundle);
         }
 
         Ok(contacts)
     }
 
-    pub async fn publish_user_contact(&mut self) -> Result<(), String> {
+    async fn publish_user_contact(&mut self) -> Result<(), ClientError> {
         let envelope = self.build_contact_envelope()?;
         self.api_client
             .publish("".to_string(), vec![envelope])
-            .await?;
+            .await
+            .map_err(ClientError::PublishError)?;
 
         Ok(())
     }
 
-    fn build_contact_envelope(&self) -> Result<Envelope, String> {
+    fn build_contact_envelope(&self) -> Result<Envelope, ClientError> {
         let contact_bundle = self.account.proto_contact_bundle();
         let mut bytes = vec![];
         contact_bundle
             .encode(&mut bytes)
-            .map_err(|e| format!("{}", e))?;
+            .map_err(|e| ClientError::EncodingError {
+                s: "FailedToEncodeContact",
+                e,
+            })?;
 
         let envelope = build_envelope(build_user_contact_topic(self.wallet_address()), bytes);
 

--- a/xmtp/src/client.rs
+++ b/xmtp/src/client.rs
@@ -71,10 +71,13 @@ where
     }
 
     pub async fn init(&mut self) -> Result<(), ClientError> {
-        // Register Contact Bundles
+        let app_contact_bundle = self.account.contact();
         let registered_bundles = self.get_contacts(&self.wallet_address()).await?;
 
-        if registered_bundles.is_empty() {
+        if !registered_bundles
+            .iter()
+            .any(|contact| contact.id() == app_contact_bundle.id())
+        {
             self.publish_user_contact().await?;
         }
 

--- a/xmtp/src/client.rs
+++ b/xmtp/src/client.rs
@@ -81,14 +81,6 @@ where
         Ok(self)
     }
 
-    pub fn write_to_persistence(&mut self, s: &str, b: &[u8]) -> Result<(), P::Error> {
-        self.persistence.write(s, b)
-    }
-
-    pub fn read_from_persistence(&self, s: &str) -> Result<Option<Vec<u8>>, P::Error> {
-        self.persistence.read(s)
-    }
-
     pub fn wallet_address(&self) -> Address {
         self.account.addr()
     }
@@ -145,6 +137,16 @@ where
 
         Ok(envelope)
     }
+
+    #[warn(dead_code)]
+    fn write_to_persistence(&mut self, s: &str, b: &[u8]) -> Result<(), P::Error> {
+        self.persistence.write(s, b)
+    }
+
+    #[warn(dead_code)]
+    fn read_from_persistence(&self, s: &str) -> Result<Option<Vec<u8>>, P::Error> {
+        self.persistence.read(s)
+    }
 }
 
 #[cfg(test)]
@@ -153,6 +155,12 @@ mod tests {
     use xmtp_proto::xmtp::v3::message_contents::vmac_unsigned_public_key::VodozemacCurve25519;
 
     use crate::ClientBuilder;
+
+    #[tokio::test]
+    async fn registration() {
+        let mut client = ClientBuilder::new_test().build().unwrap();
+        client.init().await.expect("BadReg");
+    }
 
     #[tokio::test]
     async fn test_publish_user_contact() {
@@ -194,5 +202,16 @@ mod tests {
                 )
             }
         }
+    }
+
+    #[test]
+    fn can_pass_persistence_methods() {
+        let mut client = ClientBuilder::new_test().build().unwrap();
+        assert_eq!(client.read_from_persistence("foo").unwrap(), None);
+        client.write_to_persistence("foo", b"bar").unwrap();
+        assert_eq!(
+            client.read_from_persistence("foo").unwrap(),
+            Some(b"bar".to_vec())
+        );
     }
 }

--- a/xmtp/src/client.rs
+++ b/xmtp/src/client.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use thiserror::Error;
 
 use crate::{

--- a/xmtp/src/lib.rs
+++ b/xmtp/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod account;
 pub mod association;
 pub mod builder;
-pub mod client;
+mod client;
 pub mod networking;
 pub mod owner;
 pub mod persistence;
@@ -12,7 +12,7 @@ pub mod vmac_protos;
 
 use association::AssociationText;
 pub use builder::ClientBuilder;
-pub use client::Client;
+pub use client::{Client, Network};
 use xmtp_cryptography::signature::{RecoverableSignature, SignatureError};
 
 pub trait Signable {
@@ -52,17 +52,6 @@ mod tests {
             content_topic: topic,
             message: vec![65],
         }
-    }
-
-    #[test]
-    fn can_pass_persistence_methods() {
-        let mut client = ClientBuilder::new_test().build().unwrap();
-        assert_eq!(client.read_from_persistence("foo").unwrap(), None);
-        client.write_to_persistence("foo", b"bar").unwrap();
-        assert_eq!(
-            client.read_from_persistence("foo").unwrap(),
-            Some(b"bar".to_vec())
-        );
     }
 
     #[tokio::test]

--- a/xmtp/src/lib.rs
+++ b/xmtp/src/lib.rs
@@ -11,6 +11,7 @@ mod utils;
 pub mod vmac_protos;
 
 use association::AssociationText;
+use async_trait::async_trait;
 pub use builder::ClientBuilder;
 pub use client::{Client, Network};
 use xmtp_cryptography::signature::{RecoverableSignature, SignatureError};
@@ -37,6 +38,12 @@ pub trait InboxOwner {
     fn sign(&self, text: AssociationText) -> Result<RecoverableSignature, SignatureError>;
 }
 
+#[async_trait]
+pub trait Init<T: Errorer> {
+    type Error;
+    async fn init(self) -> Result<T, T::Error>;
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{builder::ClientBuilder, networking::XmtpApiClient};
@@ -56,7 +63,7 @@ mod tests {
 
     #[tokio::test]
     async fn can_network() {
-        let mut client = ClientBuilder::new_test().build().unwrap();
+        let mut client = ClientBuilder::new_test().build().unwrap().skip_init();
         let topic = Uuid::new_v4();
 
         client

--- a/xmtp/src/lib.rs
+++ b/xmtp/src/lib.rs
@@ -11,7 +11,6 @@ mod utils;
 pub mod vmac_protos;
 
 use association::AssociationText;
-use async_trait::async_trait;
 pub use builder::ClientBuilder;
 pub use client::{Client, Network};
 use xmtp_cryptography::signature::{RecoverableSignature, SignatureError};
@@ -36,12 +35,6 @@ pub trait Fetch<T> {
 pub trait InboxOwner {
     fn get_address(&self) -> String;
     fn sign(&self, text: AssociationText) -> Result<RecoverableSignature, SignatureError>;
-}
-
-#[async_trait]
-pub trait Init<T: Errorer> {
-    type Error;
-    async fn init(self) -> Result<T, T::Error>;
 }
 
 #[cfg(test)]

--- a/xmtp/src/lib.rs
+++ b/xmtp/src/lib.rs
@@ -56,7 +56,7 @@ mod tests {
 
     #[tokio::test]
     async fn can_network() {
-        let mut client = ClientBuilder::new_test().build().unwrap().skip_init();
+        let mut client = ClientBuilder::new_test().build().unwrap();
         let topic = Uuid::new_v4();
 
         client

--- a/xmtp/src/storage/unencrypted_store/mod.rs
+++ b/xmtp/src/storage/unencrypted_store/mod.rs
@@ -14,10 +14,7 @@
 pub mod models;
 pub mod schema;
 
-use std::{
-    ops::{Deref, DerefMut},
-    sync::Mutex,
-};
+use std::{ops::DerefMut, sync::Mutex};
 
 use self::{models::*, schema::messages};
 use crate::{Errorer, Fetch, Store};


### PR DESCRIPTION
Adds registration flow for Clients. Mostly type changes, concrete errors for get the client ready for async. 

## Highlights
- Adds method for clients to publish their contact bundle if its not already found on the network. 

## Out of Scope
- Forced Registrations
  - I've made an Abstraction layer that wraps the client and forces it to be registered before being used. However SwiftBridge Errors are slowing progress. Given Swiftbridge is on its way out, I'll revisit once the new abstraction layer is in. 
  - The end goal is that developers cannot forget to init. 
   