### PR TITLE
Make proto reference explicit

### DIFF
--- a/xmtp_proto/build.rs
+++ b/xmtp_proto/build.rs
@@ -29,7 +29,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let status = Command::new("buf")
         .arg("generate")
-        .arg("https://github.com/xmtp/proto.git#branch=xmtpv3,subdir=proto")
+        .arg("https://github.com/xmtp/proto.git#branch=xmtpv3,ref=5647bfc6ed447b6ae89e462ebfe5971c2d9aa482,subdir=proto")
         .current_dir(env!("CARGO_MANIFEST_DIR"))
         .status()
         .unwrap();


### PR DESCRIPTION
## Problem

Updates to https://github.com/xmtp/proto/tree/xmtpv3 cause local development environments to break, due the `xmtp_proto` package being refetched everytime the package is built. 

## Solution
This PR makes the reference explicit so that it's tracked in git. In the future any changes to the Proto repo will not be fetched until the appropriate code has been merged into main, and a commit updates the reference in build.rs.

