### PR TITLE
Cross platform builds in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,53 @@
+name: Build
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [
+            aarch64-unknown-linux-gnu,
+            x86_64-linux-android,
+            i686-linux-android,
+            armv7-linux-androideabi,
+            aarch64-linux-android
+          ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: "Cache"
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ./target/${{ matrix.target }}
+          key: ${{ matrix.target }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+          target: ${{ matrix.target }}
+
+      # Install latest cross to mitigate unwind linking issue on android builds.
+      # See https://github.com/cross-rs/cross/issues/1222
+      - name: Install rust cross
+        run: |
+          cargo install cross --git https://github.com/cross-rs/cross
+  
+      - name: Build target
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --release --target ${{ matrix.target }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2801,6 +2801,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afc22eff61b133b115c6e8c74e818c628d6d5e7a502afea6f64dee076dd94326"
 dependencies = [
  "cc",
+ "openssl-sys",
  "pkg-config",
  "vcpkg",
 ]
@@ -3205,6 +3206,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.26.0+1.1.1u"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efc62c9f12b22b8f5208c23a7200a442b2e5999f8bdf80233852122b5a4f6f37"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3212,6 +3222,7 @@ checksum = "8e17f59264b2809d77ae94f0e1ebabc434773f370d6ca667bd223ea10e06cc7e"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/xmtp/Cargo.toml
+++ b/xmtp/Cargo.toml
@@ -43,4 +43,4 @@ url = "2.3.1"
 
 [dependencies.libsqlite3-sys]
 version = "0.26.0"
-features = ["bundled-sqlcipher"]
+features = ["bundled-sqlcipher-vendored-openssl"]

--- a/xmtp/src/bin/update-schema.rs
+++ b/xmtp/src/bin/update-schema.rs
@@ -13,7 +13,7 @@ use xmtp::storage::{EncryptedMessageStore, StorageOption};
 const DIESEL_TOML: &str = "./diesel.toml";
 
 /// This binary is used to to generate the schema files from a sqlite database instance
-/// and update the appropriate file. The destination is read from the `diesel.toml`
+/// and update the appropriate file. The desitation is read from the `diesel.toml`
 /// print_schema configuration.
 ///
 /// Since the migrations are embedded it can be difficult to have an instance available

--- a/xmtp/src/bin/update-schema.rs
+++ b/xmtp/src/bin/update-schema.rs
@@ -13,7 +13,7 @@ use xmtp::storage::{EncryptedMessageStore, StorageOption};
 const DIESEL_TOML: &str = "./diesel.toml";
 
 /// This binary is used to to generate the schema files from a sqlite database instance
-/// and update the appropriate file. The desitation is read from the `diesel.toml`
+/// and update the appropriate file. The destination is read from the `diesel.toml`
 /// print_schema configuration.
 ///
 /// Since the migrations are embedded it can be difficult to have an instance available
@@ -37,7 +37,7 @@ fn update_schemas_encrypted_message_store() -> Result<(), std::io::Error> {
 
     {
         // Initalize DB to read the latest table definitions
-        let _ = EncryptedMessageStore::new(StorageOption::Peristent(tmp_db.clone()), EncryptedMessageStore::generate_enc_key() ).unwrap();
+        let _ = EncryptedMessageStore::new(StorageOption::Persistent(tmp_db.clone()), EncryptedMessageStore::generate_enc_key() ).unwrap();
     }
 
     let diesel_result = exec_diesel(&tmp_db);

--- a/xmtp/src/storage/encrypted_store/mod.rs
+++ b/xmtp/src/storage/encrypted_store/mod.rs
@@ -50,7 +50,7 @@ pub type EncryptionKey = [u8; 32];
 pub enum StorageOption {
     #[default]
     Ephemeral,
-    Peristent(String),
+    Persistent(String),
 }
 
 #[allow(dead_code)]
@@ -77,7 +77,7 @@ impl EncryptedMessageStore {
     ) -> Result<Self, EncryptedMessageStoreError> {
         let db_path = match opts {
             StorageOption::Ephemeral => ":memory:",
-            StorageOption::Peristent(ref path) => path,
+            StorageOption::Persistent(ref path) => path,
         };
 
         let mut conn = SqliteConnection::establish(db_path)
@@ -215,7 +215,7 @@ mod tests {
         let db_path = format!("{}.db3", rand_string());
         {
             let mut store = EncryptedMessageStore::new(
-                StorageOption::Peristent(db_path.clone()),
+                StorageOption::Persistent(db_path.clone()),
                 EncryptedMessageStore::generate_enc_key(),
             )
             .unwrap();
@@ -263,7 +263,7 @@ mod tests {
             // Setup a persistent store
             let mut store = EncryptedMessageStore::new(
                 // StorageOption::Ephemeral,
-                StorageOption::Peristent(db_path.clone()),
+                StorageOption::Persistent(db_path.clone()),
                 enc_key.clone(),
             )
             .unwrap();
@@ -273,7 +273,7 @@ mod tests {
         } // Drop it
 
         enc_key[3] = 145; // Alter the enc_key
-        let res = EncryptedMessageStore::new(StorageOption::Peristent(db_path.clone()), enc_key);
+        let res = EncryptedMessageStore::new(StorageOption::Persistent(db_path.clone()), enc_key);
         // Ensure it fails
         assert_eq!(res.err(), Some(EncryptedMessageStoreError::DbInitError));
         fs::remove_file(db_path).unwrap();


### PR DESCRIPTION
This PR adds a GH workflow that builds across platforms, specifically the android platforms referenced in the cross_build.sh scripts, but can be extended to build for others. It seems like one of the next steps is to hook up version publishing in general for these packages/platforms, but this PR just focuses on getting the builds running in CI for validation/testing and further iteration. The builds are still relatively slow in CI, taking about 15 minutes to complete, but not nearly as slow as when running locally on a mac via qemu.