### PR TITLE
Renamed contact.id to installation_id

### DIFF
--- a/xmtp/src/client.rs
+++ b/xmtp/src/client.rs
@@ -86,7 +86,7 @@ where
 
         if !registered_bundles
             .iter()
-            .any(|contact| contact.id() == app_contact_bundle.id())
+            .any(|contact| contact.installation_id() == app_contact_bundle.installation_id())
         {
             self.publish_user_contact().await?;
         }

--- a/xmtp/src/contact.rs
+++ b/xmtp/src/contact.rs
@@ -99,7 +99,7 @@ impl Contact {
     }
 
     // The id of a contact is the base64 encoding of the keccak256 hash of the identity key
-    pub fn id(&self) -> String {
+    pub fn installation_id(&self) -> String {
         base64_encode(keccak256(self.vmac_identity_key().to_string().as_str()).as_slice())
     }
 

--- a/xmtp/src/conversation.rs
+++ b/xmtp/src/conversation.rs
@@ -56,7 +56,7 @@ where
         let mut client = self.client.lock().await;
 
         for contact in self.members.iter() {
-            let id = contact.id();
+            let id = contact.installation_id();
             // TODO: Persist session to database
             let mut session = client.create_outbound_session(contact.clone())?;
             // TODO: Replace with proper protobuf invite message

--- a/xmtp/src/session.rs
+++ b/xmtp/src/session.rs
@@ -33,7 +33,7 @@ impl SessionManager {
         let persisted = Session::new(
             session.session_id(),
             contact.wallet_address.clone(),
-            contact.id(),
+            contact.installation_id(),
             session_bytes,
         );
 


### PR DESCRIPTION
When trying to work thought the contact path I found the Contact::Id concept to be hard to follow, and figured I would split this out into it's own PR for discussion. 

This PR is a small proposal to rename it to Contact::Installation_id to add clarity and match the other places it is used. Open to other suggestions however in the newer objects its referred to as a "installation_id" and in other places referred to as the Contact::Id which makes tracing the source code difficult. 

