### PR TITLE
Move CLI example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5725,16 +5725,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "xli"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "env_logger",
+ "ethers",
+ "ethers-core 2.0.4",
+ "futures",
+ "log",
+ "thiserror",
+ "tokio",
+ "url",
+ "walletconnect",
+ "xmtp",
+ "xmtp_cryptography",
+]
+
+[[package]]
 name = "xmtp"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.21.1",
- "clap",
  "diesel",
  "diesel_migrations",
- "env_logger",
  "ethers",
  "ethers-core 2.0.4",
  "futures",
@@ -5742,7 +5758,6 @@ dependencies = [
  "libsqlite3-sys",
  "log",
  "prost",
- "qrcode",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -5750,10 +5765,8 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml 0.7.4",
- "url",
  "uuid 1.3.3",
  "vodozemac",
- "walletconnect",
  "xmtp_cryptography",
  "xmtp_networking",
  "xmtp_proto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 
 members = [
+  "examples/cli",
   "xmtp",
   "xmtp_crypto",
   "xmtp_cryptography",

--- a/examples/cli/Cargo.toml
+++ b/examples/cli/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "xli"
+version = "0.1.0"
+edition = "2021"
+default-run = "cli-client"
+
+[[bin]]
+name = "cli-client"
+path = "cli-client.rs"
+
+[dependencies]
+clap = {version = "4.3.0", features=["derive"]}
+ethers = "2.0.4"
+ethers-core = "2.0.4"
+env_logger = "0.10.0"
+futures = "0.3.28"
+log = "0.4.17"
+thiserror = "1.0.40"
+tokio = "1.28.1"
+url = "2.3.1"
+walletconnect = {git="https://github.com/nlordell/walletconnect-rs.git", features=["qr", "transport"]}
+xmtp = { path = "../../xmtp" }
+xmtp_cryptography = { path = "../../xmtp_cryptography"}
+
+

--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -1,7 +1,3 @@
-extern crate ethers;
-extern crate log;
-extern crate xmtp;
-
 use clap::{arg, Parser};
 use ethers_core::types::H160;
 use log::{error, info};

--- a/xmtp/Cargo.toml
+++ b/xmtp/Cargo.toml
@@ -34,14 +34,8 @@ tokio = "1.28.1"
 anyhow = "1.0.71"
 
 [dev-dependencies]
-clap = {version = "4.3.0", features=["derive"]}
-env_logger = "0.10.0"
-tokio = {version="1.28.1", features=["rt", "macros"]}
-uuid = { version = "1.3.1", features = ["v4", "fast-rng"] }
-qrcode = { version = "0.12"}
-walletconnect = {git="https://github.com/nlordell/walletconnect-rs.git", features=["qr", "transport"]}
-url = "2.3.1"
 tempfile = "3.5.0"
+uuid = { version = "1.3.1", features = ["v4", "fast-rng"] }
 
 [dependencies.libsqlite3-sys]
 version = "0.26.0"


### PR DESCRIPTION
This PR moves the cli example to the newly created examples folder. The example currently lives inside of the `xmtp` package which results in friction when it comes to managing dependencies. 

By moving the example to its own package, the dependencies can be managed independently to avoid circular dependencies. This change + #145  sets up for sending messages via cli 