### PR TITLE
Disable hanging Android test

### DIFF
--- a/bindings_ffi/tests/test_android.kts
+++ b/bindings_ffi/tests/test_android.kts
@@ -40,12 +40,13 @@ runBlocking {
      }
 }
 
-runBlocking {
-    try {
-        val client = uniffi.xmtpv3.createClient(logger, inboxOwner, "http://malformed:5556", false);
-        assert(false) {
-            "Should throw error with malformed network address"
-        }
-     } catch (e: Exception) {
-     }
-}
+// TODO Tests that initialize a second client sometimes hang and never complete - disable for now
+// runBlocking {
+//     try {
+//         val client = uniffi.xmtpv3.createClient(logger, inboxOwner, "http://malformed:5556", false);
+//         assert(false) {
+//             "Should throw error with malformed network address"
+//         }
+//      } catch (e: Exception) {
+//      }
+// }


### PR DESCRIPTION
Tests that initialize a second client on Android sometimes hang and never complete. Disabling this for now so that it doesn't block anyone, but I will come back to investigate this later.