### PR TITLE
Disable hanging Android test

### DIFF
--- a/bindings_ffi/tests/test_android.kts
+++ b/bindings_ffi/tests/test_android.kts
@@ -26,21 +26,21 @@ val credentials: Credentials = Credentials.create(ECKeyPair.create(privateKey))
 val inboxOwner = Web3jInboxOwner(credentials)
 var logger = MockLogger()
 
-runBlocking {
-    val apiUrl: String = System.getenv("XMTP_API_URL") ?: "http://localhost:5556"
-    try {
-        val client = uniffi.xmtpv3.createClient(logger, inboxOwner, apiUrl, false)
-        assert(client.walletAddress() != null) {
-            "Should be able to get wallet address"
-        }
-     } catch (e: Exception) {
-        assert(false) {
-            "Should be able to construct client: " + e.message
-        }
-     }
-}
+// TODO Tests sometimes hang and never complete
+// runBlocking {
+//     val apiUrl: String = System.getenv("XMTP_API_URL") ?: "http://localhost:5556"
+//     try {
+//         val client = uniffi.xmtpv3.createClient(logger, inboxOwner, apiUrl, false)
+//         assert(client.walletAddress() != null) {
+//             "Should be able to get wallet address"
+//         }
+//      } catch (e: Exception) {
+//         assert(false) {
+//             "Should be able to construct client: " + e.message
+//         }
+//      }
+// }
 
-// TODO Tests that initialize a second client sometimes hang and never complete - disable for now
 // runBlocking {
 //     try {
 //         val client = uniffi.xmtpv3.createClient(logger, inboxOwner, "http://malformed:5556", false);


### PR DESCRIPTION
The Android tests are (occasionally) hanging indefinitely. I've debugged this a fair bit and it looks like it might be an issue with async in uniffi itself (something about the waker sometimes not triggering when an async function returns). I need a minimal repro before filing an issue, will defer this to later.