### PR TITLE
release action for android

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,3 +51,73 @@ jobs:
           use-cross: true
           command: build
           args: --release --target ${{ matrix.target }} --manifest-path bindings_ffi/Cargo.toml --target-dir bindings_ffi/target
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.target }}.so
+          path: bindings_ffi/target/${{ matrix.target }}/release/libbindings_ffi.so
+          retention-days: 1
+
+  kotlin:
+    name: kotlin
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ./target/release
+          key: ${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+          target: x86_64-apple-darwin
+      - name : Install kotlin
+        run: brew install ktlint 
+      - name: Generate Bindings
+        working-directory: bindings_ffi
+        run: ./gen_kotlin.sh
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: xmtpv3.kt
+          path: bindings_ffi/src/uniffi/xmtpv3/xmtpv3.kt
+          retention-days: 1
+
+  package:
+    name: package
+    needs: [ build, kotlin ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: .
+      - name: Build archive
+        run: |
+          # not sure why we're building this one
+          # mv aarch64-unknown-linux-gnu.so jniLibs/arm64-v8a/libbindings_ffi.so
+          # mkdir -p jniLibs/x86_64
+          # mv x86_64-linux-android.so jniLibs/x86_64/libbindings_ffi.so
+          mkdir -p jniLibs/x86
+          mv i686-linux-android.so jniLibs/x86/libbindings_ffi.so
+          mkdir -p jniLibs/armeabi-v7a
+          mv armv7-linux-androideabi.so jniLibs/armeabi-v7a/libbindings_ffi.so
+          mkdir -p jniLibs/arm64-v8a
+          mv aarch64-linux-android.so jniLibs/arm64-v8a/libbindings_ffi.so
+          mkdir -p java
+          mv xmtpv3.kt java/xmtpv3.kt
+          zip -r libxmtp-android.zip jniLibs java
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: libxmtp-android.zip
+          path: libxmtp-android.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,3 +59,21 @@ jobs:
         git commit -m "libxmtp release $RELEASE"
         git tag $RELEASE
         git push --tags origin $RELEASE_BRANCH
+
+  ffi:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # for the release action
+    steps:
+      - uses: actions/checkout@v3
+      - name: download package
+        env:
+          HEAD_SHA: ${{ github.sha }}
+          GITHUB_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        working-directory: bindings_ffi
+        run: ./get_android_artifact.sh
+      - name: create release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "bindings_ffi/libxmtp-android.zip"

--- a/bindings_ffi/get_android_artifact.sh
+++ b/bindings_ffi/get_android_artifact.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -ex
+
+# Figure out the id of the Build run for the specified $HEAD_SHA
+RUN_ID=$(gh api /repos/$GITHUB_REPO/actions/runs \
+    -X GET \
+    -F head_sha=$HEAD_SHA \
+    --jq '.workflow_runs[] | select(.name == "Build") | .id')
+# Get the id of the libxmtp-android.zip artifacts for the run $RUN_ID
+ARTIFACT_ID=$(gh api /repos/$GITHUB_REPO/actions/runs/$RUN_ID/artifacts \
+    --jq '.artifacts[] | select(.name == "libxmtp-android.zip") | .id')
+# Fetch artifact $ARTIFACT_ID and unzip it because it will be double compressed
+# artifact.zip -> libxmtp-android.zip
+gh api /repos/$GITHUB_REPO/actions/artifacts/$ARTIFACT_ID/zip >artifact.zip
+unzip -o artifact.zip

--- a/dev/up
+++ b/dev/up
@@ -5,6 +5,12 @@ if [[ "${OSTYPE}" == "darwin"* ]]; then
     if ! which buf &>/dev/null; then brew install buf; fi
     if ! which shellcheck &>/dev/null; then brew install shellcheck; fi
     if ! which markdownlint &>/dev/null; then brew install markdownlint-cli; fi
+    if ! java -version &>/dev/null; then
+        brew install java
+        sudo ln -sfn /opt/homebrew/opt/openjdk/libexec/openjdk.jdk \
+            /Library/Java/JavaVirtualMachines/
+    fi
+    if ! kotlinc -version &>/dev/null; then brew install kotlin; fi
 fi
 
 dev/docker/up


### PR DESCRIPTION
This PR extends the `Release` action (triggered by tagging a commit) to create a release in this repo containing a zip archive with the shared libraries and the kotlin glue code that can be unzipped over the example app or the android sdk to update it to the released version of libxmtp.

The archive structure follows the pattern established by the `setup_android_example.sh` script, i.e. a properly structured `jniLibs` directory and the kotlin glue code in `java/xmtpv3.kt`. We may want to replace the zip archive with a different packaging approach in the future, but given that bare libxmtp is not intended for public consumption a more opaque approach may not be a bad choice.

The process is implemented in two stages. First it expands the existing `Build` action to not just build all the shared libraries, but to also capture them as short-lived artifacts, adds another step `kotlin` that builds the kotlin glue (relying on the `gen_kotlin.sh` script), and then `package` combines all these artifacts in a zip archive which is uploaded as a longer living artifact. The build action is executed for every push and main merge, so most of the time the archives end up unused and dropped after the set amount of time (GH default 90 days).

Second stage is associated with the `Release` action (triggered by tagging a commit, usually on the main branch). The `ffi` step will find the artifacts produced by the build action for the associated commit, downloads the zip archive and creates a libxmtp release with the archive as its artifact. This makes the archive accessible from anywhere for as long as the release exists. Obviously the release needs to be triggered while the corresponding zip archive artifact exists (i.e. within 90 days). We may want to shorten this period, I'm not sure what the storage costs will be for 90 days worth of commits.

Sample result of the release action can be seen in https://github.com/xmtp/libxmtp/releases/tag/test-release-android. The release uses the tag used to trigger it, in this case the tag was `test-release-android`. 

Additional notes inline.