### PR TITLE
Update state machine

### DIFF
--- a/xmtp/README.md
+++ b/xmtp/README.md
@@ -82,7 +82,7 @@ processMessages():
         Fetch the installations and sessions of all users from the DB
         For each installation:
             If installation.state == UNINITIALIZED:
-                Create an outbound session (hold it in memory)
+                Create an outbound session
         For each session:
             // Build the plaintext payload
             If conversation.state == UNINITIALIZED:


### PR DESCRIPTION
Updated to reflect current understanding: @jazzz is doing everything before L86, I'm working on L86 onwards.

I'm not sure yet if we actually need a `state` field on `Installation` as we can just check whether a `Session` row exists or not, feel free to do whatever makes sense. Originally added because I figured we would need a state for when decryption failure happens, but not sure yet if it is necessary.