### PR TITLE
Download invites

### DIFF
--- a/xmtp/migrations/2023-07-24-074929_refresh_jobs/down.sql
+++ b/xmtp/migrations/2023-07-24-074929_refresh_jobs/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE refresh_jobs;

--- a/xmtp/migrations/2023-07-24-074929_refresh_jobs/up.sql
+++ b/xmtp/migrations/2023-07-24-074929_refresh_jobs/up.sql
@@ -1,0 +1,10 @@
+CREATE TABLE refresh_jobs (
+    id TEXT PRIMARY KEY NOT NULL,
+    last_run BIGINT NOT NULL
+);
+
+INSERT INTO refresh_jobs
+    VALUES ('invite', 0);
+
+INSERT INTO refresh_jobs
+    VALUES ('message', 0)

--- a/xmtp/src/conversations.rs
+++ b/xmtp/src/conversations.rs
@@ -31,7 +31,7 @@ where
         SecretConversation::new(self.client, wallet_address, contacts)
     }
 
-    pub fn download_invites(&self) -> Result<Vec<Invitation>, ConversationError> {
+    pub fn save_invites(&self) -> Result<Vec<Invitation>, ConversationError> {
         let mut invites = Vec::new();
 
         self.client
@@ -81,11 +81,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn download_invites() {
+    async fn save_invites() {
         let mut alice_client = ClientBuilder::new_test().build().unwrap();
         alice_client.init().await.unwrap();
 
-        let invites = Conversations::new(&alice_client).download_invites();
+        let invites = Conversations::new(&alice_client).save_invites();
         assert!(invites.is_ok());
     }
 }

--- a/xmtp/src/conversations.rs
+++ b/xmtp/src/conversations.rs
@@ -1,8 +1,13 @@
+use diesel::Connection;
+
 use crate::{
     conversation::{ConversationError, SecretConversation},
+    storage::{RefreshJob, RefreshJobKind},
     types::networking::XmtpApiClient,
     Client,
 };
+
+const PADDING_TIME: i64 = 30 * 1000 * 1000;
 
 pub struct Conversations<'c, A>
 where
@@ -26,6 +31,35 @@ where
         let contacts = self.client.get_contacts(wallet_address.as_str()).await?;
         SecretConversation::new(self.client, wallet_address, contacts)
     }
+
+    /**
+    *  Get the `refresh_jobs` record with an id of `invites`, and obtain a lock on the row:
+       Store `now()` in memory to mark the job execution start
+       Fetch all messages from invite topic with timestamp > refresh_job.last_run - PADDING_TIME # PADDING TIME accounts for eventual consistency of network. Maybe 30s.
+       For each message in topic:
+           Save (or ignore if already exists) raw message to inbound_invite table with status of PENDING
+       Update `refresh_jobs` record last_run = current_timestamp
+    */
+    pub fn download_invites(&self) -> Result<(), ConversationError> {
+        self.client
+            .store
+            .lock_refresh_job(RefreshJobKind::Invite, |conn, job| {
+                let res = futures::executor::block_on(async {
+                    println!("Hello world");
+                    return "foo";
+                });
+                println!("res: {:?}", res);
+                Ok(())
+            })
+            .unwrap();
+
+        Ok(())
+    }
+
+    fn get_start_time(&self, job: RefreshJob) -> i64 {
+        // Adjust for padding and ensure start_time > 0
+        std::cmp::max(job.last_run - PADDING_TIME, 0)
+    }
 }
 
 #[cfg(test)]
@@ -47,5 +81,14 @@ mod tests {
 
         assert_eq!(conversation.peer_address(), bob_client.wallet_address());
         conversation.initialize().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn download_invites() {
+        let mut alice_client = ClientBuilder::new_test().build().unwrap();
+        alice_client.init().await.unwrap();
+
+        let invites = Conversations::new(&alice_client).download_invites();
+        assert!(invites.is_ok());
     }
 }

--- a/xmtp/src/conversations.rs
+++ b/xmtp/src/conversations.rs
@@ -47,8 +47,7 @@ where
                 }
 
                 Ok(())
-            })
-            .unwrap();
+            })?;
 
         Ok(invites)
     }

--- a/xmtp/src/conversations.rs
+++ b/xmtp/src/conversations.rs
@@ -6,7 +6,7 @@ use crate::{
     Client,
 };
 
-const PADDING_TIME: i64 = 30 * 1000 * 1000;
+const PADDING_TIME_NS: i64 = 30 * 1000 * 1000 * 1000;
 
 pub struct Conversations<'c, A>
 where
@@ -55,7 +55,7 @@ where
 
     fn get_start_time(&self, job: RefreshJob) -> i64 {
         // Adjust for padding and ensure start_time > 0
-        std::cmp::max(job.last_run - PADDING_TIME, 0)
+        std::cmp::max(job.last_run - PADDING_TIME_NS, 0)
     }
 }
 

--- a/xmtp/src/storage/encrypted_store/mod.rs
+++ b/xmtp/src/storage/encrypted_store/mod.rs
@@ -564,7 +564,7 @@ mod tests {
         .unwrap();
 
         store
-            .lock_refresh_job(RefreshJobKind::Invite, |conn, job| {
+            .lock_refresh_job(RefreshJobKind::Invite, |_, job| {
                 assert_eq!(job.id, RefreshJobKind::Invite.to_string());
                 assert_eq!(job.last_run, 0);
 
@@ -573,14 +573,14 @@ mod tests {
             .unwrap();
 
         store
-            .lock_refresh_job(RefreshJobKind::Invite, |conn, job| {
+            .lock_refresh_job(RefreshJobKind::Invite, |_, job| {
                 assert!(job.last_run > 0);
 
                 Ok(())
             })
             .unwrap();
 
-        let res_expected_err = store.lock_refresh_job(RefreshJobKind::Message, |conn, job| {
+        let res_expected_err = store.lock_refresh_job(RefreshJobKind::Message, |_, job| {
             assert_eq!(job.id, RefreshJobKind::Message.to_string());
 
             Err(StorageError::Unknown)
@@ -588,7 +588,7 @@ mod tests {
         assert!(res_expected_err.is_err());
 
         store
-            .lock_refresh_job(RefreshJobKind::Message, |conn, job| {
+            .lock_refresh_job(RefreshJobKind::Message, |_, job| {
                 // Ensure that last run time does not change if the job fails
                 assert_eq!(job.last_run, 0);
 

--- a/xmtp/src/storage/encrypted_store/mod.rs
+++ b/xmtp/src/storage/encrypted_store/mod.rs
@@ -26,7 +26,6 @@ use diesel::{
     connection::SimpleConnection,
     prelude::*,
     r2d2::{ConnectionManager, Pool, PooledConnection},
-    result::Error,
 };
 
 use xmtp_cryptography::utils as crypto_utils;

--- a/xmtp/src/storage/encrypted_store/mod.rs
+++ b/xmtp/src/storage/encrypted_store/mod.rs
@@ -19,13 +19,14 @@ use rand::RngCore;
 
 use self::{
     models::*,
-    schema::{accounts, conversations, messages, users},
+    schema::{accounts, conversations, messages, refresh_jobs, users},
 };
 use crate::{account::Account, Errorer, Fetch, Store};
 use diesel::{
     connection::SimpleConnection,
     prelude::*,
     r2d2::{ConnectionManager, Pool, PooledConnection},
+    result::Error,
 };
 
 use xmtp_cryptography::utils as crypto_utils;
@@ -245,6 +246,36 @@ impl EncryptedMessageStore {
             .load::<StoredMessage>(conn)?;
 
         Ok(msg_list)
+    }
+
+    pub fn lock_refresh_job<F>(&self, kind: RefreshJobKind, cb: F) -> Result<(), StorageError>
+    where
+        F: FnOnce(
+            &mut PooledConnection<ConnectionManager<SqliteConnection>>,
+            RefreshJob,
+        ) -> Result<(), StorageError>,
+    {
+        let conn = &mut self.conn()?;
+        conn.transaction::<(), StorageError, _>(|connection| {
+            let start_time = now();
+            let job: RefreshJob = refresh_jobs::table
+                .find::<String>(kind.to_string())
+                .first::<RefreshJob>(connection)?;
+
+            let result = cb(connection, job);
+
+            if result.is_ok() {
+                diesel::update(refresh_jobs::table.find(kind.to_string()))
+                    .set(refresh_jobs::last_run.eq(start_time))
+                    .execute(connection)?;
+            } else {
+                return result;
+            }
+
+            Ok(())
+        })?;
+
+        Ok(())
     }
 }
 
@@ -522,5 +553,47 @@ mod tests {
 
         let results: Vec<StoredSession> = store.fetch().unwrap();
         assert_eq!(1, results.len());
+    }
+
+    #[test]
+    fn lock_refresh_job() {
+        let store = EncryptedMessageStore::new(
+            StorageOption::Ephemeral,
+            EncryptedMessageStore::generate_enc_key(),
+        )
+        .unwrap();
+
+        store
+            .lock_refresh_job(RefreshJobKind::Invite, |conn, job| {
+                assert_eq!(job.id, RefreshJobKind::Invite.to_string());
+                assert_eq!(job.last_run, 0);
+
+                Ok(())
+            })
+            .unwrap();
+
+        store
+            .lock_refresh_job(RefreshJobKind::Invite, |conn, job| {
+                assert!(job.last_run > 0);
+
+                Ok(())
+            })
+            .unwrap();
+
+        let res_expected_err = store.lock_refresh_job(RefreshJobKind::Message, |conn, job| {
+            assert_eq!(job.id, RefreshJobKind::Message.to_string());
+
+            Err(StorageError::Unknown)
+        });
+        assert!(res_expected_err.is_err());
+
+        store
+            .lock_refresh_job(RefreshJobKind::Message, |conn, job| {
+                // Ensure that last run time does not change if the job fails
+                assert_eq!(job.last_run, 0);
+
+                Ok(())
+            })
+            .unwrap();
     }
 }

--- a/xmtp/src/storage/encrypted_store/models.rs
+++ b/xmtp/src/storage/encrypted_store/models.rs
@@ -232,7 +232,7 @@ impl Save<EncryptedMessageStore> for RefreshJob {
         let conn = &mut into.conn()?;
 
         diesel::update(refresh_jobs::table)
-            .set((refresh_jobs::last_run.eq(&self.last_run)))
+            .set(refresh_jobs::last_run.eq(&self.last_run))
             .execute(conn)?;
 
         Ok(())

--- a/xmtp/src/storage/encrypted_store/schema.rs
+++ b/xmtp/src/storage/encrypted_store/schema.rs
@@ -49,6 +49,13 @@ diesel::table! {
 }
 
 diesel::table! {
+    refresh_jobs (id) {
+        id -> Text,
+        last_run -> BigInt,
+    }
+}
+
+diesel::table! {
     sessions (session_id) {
         session_id -> Text,
         created_at -> BigInt,
@@ -75,6 +82,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     installations,
     messages,
     outbound_payloads,
+    refresh_jobs,
     sessions,
     users,
 );

--- a/xmtp/src/storage/mod.rs
+++ b/xmtp/src/storage/mod.rs
@@ -3,9 +3,9 @@ mod errors;
 
 pub use encrypted_store::{
     models::{
-        now, ConversationState, MessageState, NewStoredMessage, OutboundPayloadState,
-        StoredConversation, StoredInstallation, StoredMessage, StoredOutboundPayload,
-        StoredSession, StoredUser,
+        now, ConversationState, MessageState, NewStoredMessage, OutboundPayloadState, RefreshJob,
+        RefreshJobKind, StoredConversation, StoredInstallation, StoredMessage,
+        StoredOutboundPayload, StoredSession, StoredUser,
     },
     EncryptedMessageStore, EncryptionKey, StorageOption,
 };


### PR DESCRIPTION
## Summary

- Creates table for `refresh_jobs`
- Creates helper function for getting the latest refresh job in a transaction and doing something with it
- Adds code for downloading invites

## Next up
- Storing the invites in the DB
- Figure out a better solution for transactionality. See [this thread](https://xmtp-labs.slack.com/archives/C05GBHEAGPP/p1690192829199419)

## Notes
- I realized that row level locking in SQLite isn't a thing...instead the entire database is locked for the transaction. Given how little concurrency is needed in our app, that may be fine, but is something we should keep an eye on.