### PR TITLE
Refresh Sessions

### DIFF
--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -15,7 +15,7 @@ extern crate xmtp;
 
 use clap::{Parser, Subcommand};
 use ethers_core::types::H160;
-use log::{error, info};
+use log::{debug, error, info};
 use std::fs;
 use std::path::PathBuf;
 use thiserror::Error;

--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -9,7 +9,6 @@ $ RUST_LOG=info cargo run -- --db ~/hello2.db3 send 0x5c1c5699cc216366723fd172e9
 ```
 */
 
-
 extern crate ethers;
 extern crate log;
 extern crate xmtp;
@@ -17,10 +16,10 @@ extern crate xmtp;
 use clap::{Parser, Subcommand};
 use ethers_core::types::H160;
 use log::{error, info};
+use std::fs;
 use std::path::PathBuf;
 use thiserror::Error;
 use url::ParseError;
-use xmtp::Save;
 use walletconnect::client::{CallError, ConnectorError, SessionError};
 use walletconnect::{qr, Client as WcClient, Metadata};
 use xmtp::builder::{AccountStrategy, ClientBuilderError};
@@ -28,16 +27,10 @@ use xmtp::client::ClientError;
 use xmtp::storage::{EncryptedMessageStore, EncryptionKey, StorageError, StorageOption};
 use xmtp::types::Address;
 use xmtp::InboxOwner;
-use xmtp_networking::grpc_api_helper::Client as ApiClient;
+use xmtp::Save;
 use xmtp_cryptography::signature::{h160addr_to_string, RecoverableSignature, SignatureError};
-use xmtp_cryptography::utils::{rng, LocalWallet};
-
-// use xmtp_networking::Client as ApiClient;
-// use xmtp_cryptography::signature::{h160addr_to_string, RecoverableSignature, SignatureError};
-// use xmtp_cryptography::utils::{rng, LocalWallet};
-
-
-// type ApiClient = xmtp_networking::Client;
+use xmtp_cryptography::utils::{rng, seeded_rng, LocalWallet};
+use xmtp_networking::grpc_api_helper::Client as ApiClient;
 type Client = xmtp::client::Client<ApiClient>;
 type ClientBuilder = xmtp::builder::ClientBuilder<ApiClient, Wallet>;
 
@@ -73,10 +66,13 @@ enum Commands {
         msg: String,
     },
 
-    Test {
-        #[arg(value_name = "FOO")]
-        var: String,
+    TestReg {
+        #[arg(value_name = "seed")]
+        wallet_seed: u64,
     },
+
+    Refresh {},
+    Clear {},
 }
 
 #[derive(Debug, Error)]
@@ -141,23 +137,48 @@ async fn main() {
         }
         Commands::Send { addr, msg } => {
             info!("Send");
-            let client = create_client(cli.db, AccountStrategy::CachedOnly("nil".into())).await.unwrap();
+            let client = create_client(cli.db, AccountStrategy::CachedOnly("nil".into()))
+                .await
+                .unwrap();
             send(client, addr, msg).await.unwrap();
         }
-        Commands::Test {var }=> {
-            info!("TEst");
-            let client = create_client(cli.db, AccountStrategy::CachedOnly("nil".into())).await.unwrap();
-            client.refresh_user_installations(&client.wallet_address()).await;
+        Commands::TestReg { wallet_seed } => {
+            info!("TestReg");
+            let w = Wallet::LocalWallet(LocalWallet::new(&mut seeded_rng(*wallet_seed)));
+            let mut client = create_client(cli.db, AccountStrategy::CreateIfNotFound(w))
+                .await
+                .unwrap();
+            client.init().await.unwrap();
+        }
+        Commands::Refresh {} => {
+            info!("Refresh");
+            let client = create_client(cli.db, AccountStrategy::CachedOnly("nil".into()))
+                .await
+                .unwrap();
+            client
+                .refresh_user_installations(&client.wallet_address())
+                .await
+                .unwrap();
+        }
+        Commands::Clear {} => {
+            fs::remove_file(cli.db.unwrap()).unwrap();
         }
     }
 }
 
-async fn create_client (db: Option<PathBuf>, account: AccountStrategy<Wallet>) -> Result<Client, CliError> {
+async fn create_client(
+    db: Option<PathBuf>,
+    account: AccountStrategy<Wallet>,
+) -> Result<Client, CliError> {
     let msg_store = get_encrypted_store(db).unwrap();
 
     let client_result = ClientBuilder::new(account)
-        .network(xmtp::Network::Dev)
-        .api_client(ApiClient::create("http://localhost:5556".into(), false).await.unwrap())
+        .network(xmtp::Network::Local("http://localhost:5556"))
+        .api_client(
+            ApiClient::create("http://localhost:5556".into(), false)
+                .await
+                .unwrap(),
+        )
         .store(msg_store)
         .build();
 

--- a/examples/cli/xli.sh
+++ b/examples/cli/xli.sh
@@ -1,0 +1,1 @@
+RUST_LOG=INFO cargo run "$@"

--- a/xmtp/migrations/2023-07-10-223309_add_installations/up.sql
+++ b/xmtp/migrations/2023-07-10-223309_add_installations/up.sql
@@ -3,7 +3,6 @@ CREATE TABLE installations (
     user_address TEXT NOT NULL,
     first_seen_ns BIGINT NOT NULL,
     contact BLOB NOT NULL,
-    contact_hash TEXT NOT NULL,
     expires_at_ns BIGINT,
     FOREIGN KEY(user_address) REFERENCES users(user_address)
 );

--- a/xmtp/src/client.rs
+++ b/xmtp/src/client.rs
@@ -186,14 +186,6 @@ where
         Ok(())
     }
 
-    pub async fn bootstrap_sessions(&self, user_address: &str) -> Result<(), ClientError> {
-        for x in self.store.get_sessions(user_address)? {
-            info!("{:?}", x)
-        }
-
-        Ok(())
-    }
-
     pub fn create_uninitialized_session(
         &self,
         contact: &Contact,

--- a/xmtp/src/contact.rs
+++ b/xmtp/src/contact.rs
@@ -2,7 +2,6 @@ use prost::{DecodeError, EncodeError, Message};
 use thiserror::Error;
 
 use vodozemac::Curve25519PublicKey;
-use xmtp_cryptography::hash::keccak256;
 use xmtp_proto::xmtp::v3::message_contents::{
     installation_contact_bundle::Version as ContactBundleVersionProto,
     vmac_account_linked_key::Association as AssociationProto, vmac_unsigned_public_key,
@@ -11,7 +10,7 @@ use xmtp_proto::xmtp::v3::message_contents::{
 
 use crate::{
     association::{Association, AssociationError},
-    utils::base64_encode,
+    utils::key_fingerprint,
     vmac_protos::ProtoWrapper,
 };
 
@@ -93,7 +92,7 @@ impl Contact {
 
     // The id of a contact is the base64 encoding of the keccak256 hash of the identity key
     pub fn installation_id(&self) -> String {
-        base64_encode(keccak256(self.vmac_identity_key().to_string().as_str()).as_slice())
+        key_fingerprint(&self.vmac_identity_key())
     }
 
     pub fn vmac_identity_key(&self) -> Curve25519PublicKey {

--- a/xmtp/src/conversation.rs
+++ b/xmtp/src/conversation.rs
@@ -57,7 +57,7 @@ where
     ) -> Result<Self, ConversationError> {
         let obj = SecretConversation {
             client,
-            peer_address: peer_address.clone(),
+            peer_address,
             members,
         };
         obj.client.store.insert_or_ignore_user(StoredUser {

--- a/xmtp/src/conversations.rs
+++ b/xmtp/src/conversations.rs
@@ -41,7 +41,7 @@ where
                         self.get_start_time(job).unsigned_abs(),
                         crate::utils::build_user_invite_topic(my_contact.installation_id()),
                     ))
-                    .map_err(|_| StorageError::Unknown)?;
+                    .map_err(|e| StorageError::Unknown(e.to_string()))?;
                 // Save all invites
                 for envelope in downloaded {
                     self.client

--- a/xmtp/src/lib.rs
+++ b/xmtp/src/lib.rs
@@ -19,10 +19,6 @@ pub mod vmac_protos;
 
 pub use builder::ClientBuilder;
 pub use client::{Client, Network};
-use diesel::{
-    r2d2::{ConnectionManager, PooledConnection},
-    SqliteConnection,
-};
 use storage::StorageError;
 use xmtp_cryptography::signature::{RecoverableSignature, SignatureError};
 

--- a/xmtp/src/lib.rs
+++ b/xmtp/src/lib.rs
@@ -18,6 +18,10 @@ pub mod vmac_protos;
 
 pub use builder::ClientBuilder;
 pub use client::{Client, Network};
+use diesel::{
+    r2d2::{ConnectionManager, PooledConnection},
+    SqliteConnection,
+};
 use storage::StorageError;
 use xmtp_cryptography::signature::{RecoverableSignature, SignatureError};
 

--- a/xmtp/src/session.rs
+++ b/xmtp/src/session.rs
@@ -45,6 +45,10 @@ impl SessionManager {
         self.session.session_id()
     }
 
+    pub fn installation_id(&self) -> String {
+        self.peer_installation_id.clone()
+    }
+
     pub fn session_bytes(&self) -> Result<Vec<u8>, SessionError> {
         let res = serde_json::to_vec(&self.session.pickle())?;
         Ok(res)

--- a/xmtp/src/storage/encrypted_store/mod.rs
+++ b/xmtp/src/storage/encrypted_store/mod.rs
@@ -653,7 +653,7 @@ mod tests {
         let res_expected_err = store.lock_refresh_job(RefreshJobKind::Message, |_, job| {
             assert_eq!(job.id, RefreshJobKind::Message.to_string());
 
-            Err(StorageError::Unknown)
+            Err(StorageError::Unknown(String::from("RefreshJob failed")))
         });
         assert!(res_expected_err.is_err());
 

--- a/xmtp/src/storage/encrypted_store/mod.rs
+++ b/xmtp/src/storage/encrypted_store/mod.rs
@@ -171,7 +171,7 @@ impl EncryptedMessageStore {
             .filter(peer_installation_id.eq(installation_id))
             .order(created_at.desc())
             .load::<StoredSession>(conn)
-            .map_err(|_| StorageError::Unknown)?;
+            .map_err(|e| StorageError::Unknown(e.to_string()))?;
 
         warn_length(&session_list, "StoredSession", 1);
         Ok(session_list.pop())
@@ -232,7 +232,7 @@ impl EncryptedMessageStore {
             .filter(dsl::user_address.eq(user_address))
             .order(dsl::first_seen_ns.desc())
             .load::<StoredInstallation>(conn)
-            .map_err(|_| StorageError::Unknown)?;
+            .map_err(|e| StorageError::Unknown(e.to_string()))?;
 
         Ok(install_list)
     }

--- a/xmtp/src/storage/encrypted_store/models.rs
+++ b/xmtp/src/storage/encrypted_store/models.rs
@@ -199,8 +199,12 @@ impl StoredInstallation {
             user_address: contact.wallet_address.clone(),
             first_seen_ns: now(),
             contact: contact_bytes,
-            contact_hash: contact_hash,
+            contact_hash,
             expires_at_ns: None,
         })
+    }
+
+    pub fn get_contact(&self) -> Result<Contact, ContactError> {
+        Contact::from_bytes(self.contact.clone(), self.user_address.clone())
     }
 }

--- a/xmtp/src/storage/encrypted_store/models.rs
+++ b/xmtp/src/storage/encrypted_store/models.rs
@@ -187,21 +187,18 @@ pub struct StoredInstallation {
     pub user_address: String,
     pub first_seen_ns: i64,
     pub contact: Vec<u8>,
-    pub contact_hash: String,
     pub expires_at_ns: Option<i64>,
 }
 
 impl StoredInstallation {
     pub fn new(contact: &Contact) -> Result<Self, ContactError> {
         let contact_bytes: Vec<u8> = contact.try_into()?;
-        let contact_hash = hex::encode(sha256_bytes(&contact_bytes).as_slice());
 
         Ok(Self {
             installation_id: contact.installation_id(),
             user_address: contact.wallet_address.clone(),
             first_seen_ns: now(),
             contact: contact_bytes,
-            contact_hash,
             expires_at_ns: None,
         })
     }

--- a/xmtp/src/storage/encrypted_store/schema.rs
+++ b/xmtp/src/storage/encrypted_store/schema.rs
@@ -33,7 +33,6 @@ diesel::table! {
         user_address -> Text,
         first_seen_ns -> BigInt,
         contact -> Binary,
-        contact_hash -> Text,
         expires_at_ns -> Nullable<BigInt>,
     }
 }

--- a/xmtp/src/storage/errors.rs
+++ b/xmtp/src/storage/errors.rs
@@ -1,3 +1,4 @@
+use crate::contact::ContactError;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -14,8 +15,10 @@ pub enum StorageError {
     Store(String),
     #[error(transparent)]
     ImplementationError(#[from] anyhow::Error),
+    #[error("ContactError")]
+    ContactError(#[from] ContactError),
     #[error("serialization error")]
     SerializationError,
-    #[error("unknown storage error")]
-    Unknown,
+    #[error("unknown storage error: {0}")]
+    Unknown(String),
 }

--- a/xmtp/src/utils.rs
+++ b/xmtp/src/utils.rs
@@ -1,5 +1,7 @@
 use base64::{engine::general_purpose, Engine as _};
 use std::time::{SystemTime, UNIX_EPOCH};
+use vodozemac::Curve25519PublicKey;
+use xmtp_cryptography::hash::keccak256;
 
 use xmtp_proto::xmtp::message_api::v1::Envelope;
 
@@ -29,4 +31,8 @@ pub fn build_envelope(content_topic: String, message: Vec<u8>) -> Envelope {
 
 pub fn base64_encode(bytes: &[u8]) -> String {
     general_purpose::STANDARD_NO_PAD.encode(bytes)
+}
+
+pub fn key_fingerprint(key: &Curve25519PublicKey) -> String {
+    base64_encode(keccak256(key.to_string().as_str()).as_slice())
 }

--- a/xmtp_cryptography/src/utils.rs
+++ b/xmtp_cryptography/src/utils.rs
@@ -8,6 +8,10 @@ pub fn rng() -> impl CryptoRng + RngCore {
     ChaCha20Rng::from_entropy()
 }
 
+pub fn seeded_rng(seed: u64) -> impl CryptoRng + RngCore {
+    ChaCha20Rng::seed_from_u64(seed)
+}
+
 pub fn eth_address(pubkey: &VerifyingKey) -> Result<String, String> {
     // Get the public key bytes
     let binding = pubkey.to_encoded_point(false);

--- a/xmtp_networking/src/lib.rs
+++ b/xmtp_networking/src/lib.rs
@@ -3,12 +3,13 @@ pub mod grpc_api_helper;
 pub const LOCALHOST_ADDRESS: &str = "http://localhost:5556";
 pub const DEV_ADDRESS: &str = "https://dev.xmtp.network:5556";
 
+pub use grpc_api_helper::Client;
+
 #[cfg(test)]
 mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::*;
-    use grpc_api_helper::Client;
     use xmtp::types::networking::XmtpApiClient;
     use xmtp::types::networking::XmtpApiSubscription;
     use xmtp_proto::xmtp::message_api::v1::{


### PR DESCRIPTION
This PR adds the ability to detect new installations, so they can be included in message fanout.

Not covered in this PR:
- generating sessions for new installations
- integration of refresh_installations 

