### PR TITLE
Session Initiation on client initialization

### DIFF
--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -73,6 +73,7 @@ enum Commands {
     },
 
     Refresh {},
+    ListContacts {},
     Clear {},
 }
 
@@ -161,6 +162,16 @@ async fn main() {
                 .refresh_user_installations(&client.wallet_address())
                 .await
                 .unwrap();
+        }
+        Commands::ListContacts {} => {
+            let client = create_client(cli.db, AccountStrategy::CachedOnly("nil".into()))
+                .await
+                .unwrap();
+
+            let contacts = client.get_contacts(&client.wallet_address()).await.unwrap();
+            for (index, contact) in contacts.iter().enumerate() {
+                info!(" [{}]  Contact: {:?}", index, contact.installation_id());
+            }
         }
         Commands::Clear {} => {
             fs::remove_file(cli.db.unwrap()).unwrap();

--- a/xmtp/README.md
+++ b/xmtp/README.md
@@ -79,10 +79,7 @@ process_messages():
             If user.last_refreshed is uninitialized or more than THRESHOLD ago:
                 refresh_user_installations()    // Could be kicked off asynchronously or synchronously
                 return  // refreshUserInstallations() will call back into processMessages() when ready
-        Fetch the installations and sessions of all users from the DB
-        For each installation:
-            If installation.state == UNINITIALIZED:
-                Create an outbound session
+        Fetch the sessions of all users from the DB
         For each session:
             // Build the plaintext payload
             If conversation.state == UNINITIALIZED:
@@ -102,11 +99,13 @@ process_messages():
 refresh_user_installations(user):
     Fetch installations/contact bundles for the user from the network
     Fetch installations/contact bundles for the user from the DB
+    
+    For each installation from the DB:
+            if is expired or revoked, delete it from the DB
     In a single transaction:
-        For each installation from the DB:
-            If it doesn't exist in the network contact bundles or is expired or revoked, delete it from the DB
-        For each installation from the network:
-            If it doesn't exist in the DB, insert it with installation.state = UNINITIALIZED
+        For each new installation from the network:
+            save installation to local cache
+            create new session for new installation
         Set user.last_refreshed to NOW
     process_messages();  // Could be kicked off asynchronously or synchronously
     return

--- a/xmtp/src/client.rs
+++ b/xmtp/src/client.rs
@@ -2,7 +2,7 @@ use core::fmt;
 use std::fmt::Formatter;
 
 use diesel::Connection;
-use log::{debug, info};
+use log::info;
 use thiserror::Error;
 use vodozemac::olm::OlmMessage;
 
@@ -96,6 +96,9 @@ where
         {
             self.publish_user_contact().await?;
         }
+
+        self.refresh_user_installations(&app_contact_bundle.wallet_address)
+            .await?;
 
         self.is_initialized = true;
         Ok(())

--- a/xmtp/src/client.rs
+++ b/xmtp/src/client.rs
@@ -2,7 +2,7 @@ use core::fmt;
 use std::fmt::Formatter;
 
 use diesel::Connection;
-use log::info;
+use log::{debug, info};
 use thiserror::Error;
 use vodozemac::olm::OlmMessage;
 
@@ -162,7 +162,7 @@ where
 
         let new_installs = contacts
             .iter()
-            .filter(|contact| self_install_id == contact.installation_id())
+            .filter(|contact| self_install_id != contact.installation_id())
             .filter(|contact| !installation_map.contains_key(&contact.installation_id()))
             .filter_map(|contact| StoredInstallation::new(contact).ok());
 
@@ -178,6 +178,9 @@ where
                         transaction_manager,
                     )?;
                 }
+
+                self.store
+                    .update_user_refresh_timestamp(transaction_manager, user_address)?;
 
                 Ok(())
             },

--- a/xmtp/src/client.rs
+++ b/xmtp/src/client.rs
@@ -10,7 +10,7 @@ use crate::{
     account::Account,
     contact::{Contact, ContactError},
     session::SessionManager,
-    storage::{EncryptedMessageStore, StorageError, StoredInstallation, StoredSession},
+    storage::{now, EncryptedMessageStore, StorageError, StoredInstallation, StoredSession},
     types::networking::{PublishRequest, QueryRequest, XmtpApiClient},
     types::Address,
     utils::{build_envelope, build_user_contact_topic, key_fingerprint},
@@ -153,6 +153,9 @@ where
     /// Fetch Installations from the Network and create unintialized sessions for newly discovered contacts
     // TODO: Reduce Visibility
     pub async fn refresh_user_installations(&self, user_address: &str) -> Result<(), ClientError> {
+        // Store the timestamp of when the refresh process begins
+        let refresh_timestmap = now();
+
         let self_install_id = key_fingerprint(&self.account.identity_keys().curve25519);
         let contacts = self.get_contacts(user_address).await?;
 
@@ -182,8 +185,11 @@ where
                     )?;
                 }
 
-                self.store
-                    .update_user_refresh_timestamp(transaction_manager, user_address)?;
+                self.store.update_user_refresh_timestamp(
+                    transaction_manager,
+                    user_address,
+                    refresh_timestmap,
+                )?;
 
                 Ok(())
             },

--- a/xmtp/src/storage/encrypted_store/mod.rs
+++ b/xmtp/src/storage/encrypted_store/mod.rs
@@ -217,9 +217,10 @@ impl EncryptedMessageStore {
         &self,
         conn: &mut PooledConnection<ConnectionManager<SqliteConnection>>,
         user_address: &str,
+        timestamp: i64,
     ) -> Result<usize, StorageError> {
         diesel::update(users::table.filter(users::user_address.eq(user_address)))
-            .set(users::last_refreshed.eq(now()))
+            .set(users::last_refreshed.eq(timestamp))
             .execute(conn)
             .map_err(|e| e.into())
     }

--- a/xmtp/src/storage/encrypted_store/mod.rs
+++ b/xmtp/src/storage/encrypted_store/mod.rs
@@ -20,7 +20,7 @@ use self::{
         accounts, conversations, inbound_invites, installations, messages, refresh_jobs, users,
     },
 };
-use super::StorageError;
+use super::{now, StorageError};
 use crate::{account::Account, Errorer, Fetch, Store};
 use diesel::{
     connection::SimpleConnection,
@@ -211,6 +211,17 @@ impl EncryptedMessageStore {
 
         warn_length(&user_list, "StoredUser", 1);
         Ok(user_list.pop())
+    }
+
+    pub fn update_user_refresh_timestamp(
+        &self,
+        conn: &mut PooledConnection<ConnectionManager<SqliteConnection>>,
+        user_address: &str,
+    ) -> Result<usize, StorageError> {
+        diesel::update(users::table.filter(users::user_address.eq(user_address)))
+            .set(users::last_refreshed.eq(now()))
+            .execute(conn)
+            .map_err(|e| e.into())
     }
 
     pub fn insert_or_ignore_user(&self, user: StoredUser) -> Result<(), StorageError> {


### PR DESCRIPTION
The PR enables Installation refresh + session initialization on client initialization. 

This allows the client to operate with the latest set of sibling installations, by pulling the latest list everytime the client is created. A mechanism is needed to  ensure this list stays up to date over the course of the clients lifecycle however that is out of scope for now. 

On Send clients will also need to refresh the foreign installations to ensure messages are fanned out to the correct installations. 

