### PR TITLE
Pass in DBConnection Explicitly

### DIFF
--- a/xmtp/src/builder.rs
+++ b/xmtp/src/builder.rs
@@ -126,7 +126,7 @@ where
             None => {
                 info!("Creating new XMTP identity");
                 let new_account = Self::sign_new_account(owner)?;
-                new_account.store(store)?;
+                new_account.store(&mut store.conn().unwrap())?;
                 Ok(new_account)
             }
         }
@@ -136,7 +136,8 @@ where
     fn retrieve_persisted_account(
         store: &mut EncryptedMessageStore,
     ) -> Result<Option<Account>, ClientBuilderError> {
-        let mut accounts = store.fetch()?;
+        let conn = &mut store.conn()?;
+        let mut accounts = conn.fetch()?;
         Ok(accounts.pop())
     }
 

--- a/xmtp/src/client.rs
+++ b/xmtp/src/client.rs
@@ -226,7 +226,7 @@ where
         let session = SessionManager::from_olm_session(olm_session, contact)
             .map_err(|_| ClientError::Unknown)?;
 
-        session.store(&self.store)?;
+        session.store(&mut self.store.conn().unwrap())?;
 
         Ok(session)
     }
@@ -252,7 +252,7 @@ where
         let session = SessionManager::from_olm_session(create_result.session, &contact)
             .map_err(|_| ClientError::Unknown)?;
 
-        session.store(&self.store)?;
+        session.store(&mut self.store.conn().unwrap())?;
 
         Ok((session, create_result.plaintext))
     }

--- a/xmtp/src/conversation.rs
+++ b/xmtp/src/conversation.rs
@@ -122,7 +122,7 @@ where
             content_bytes,
             MessageState::Unprocessed as i32,
         )
-        .store(&self.client.store)?;
+        .store(&mut self.client.store.conn().unwrap())?;
         Ok(())
     }
 

--- a/xmtp/src/lib.rs
+++ b/xmtp/src/lib.rs
@@ -33,17 +33,17 @@ pub trait Errorer {
 
 // Inserts a model to the underlying data store
 pub trait Store<I> {
-    fn store(&self, into: &I) -> Result<(), StorageError>;
+    fn store(&self, into: &mut I) -> Result<(), StorageError>;
 }
 
 // Fetches all instances of a model from the underlying data store
 pub trait Fetch<T> {
-    fn fetch(&self) -> Result<Vec<T>, StorageError>;
+    fn fetch(&mut self) -> Result<Vec<T>, StorageError>;
 }
 
 // Updates an existing instance of the model in the data store
 pub trait Save<I> {
-    fn save(&self, into: &I) -> Result<(), StorageError>;
+    fn save(&self, into: &mut I) -> Result<(), StorageError>;
 }
 
 pub trait InboxOwner {

--- a/xmtp/src/storage/encrypted_store/models.rs
+++ b/xmtp/src/storage/encrypted_store/models.rs
@@ -1,4 +1,4 @@
-use super::{schema::*, EncryptedMessageStore};
+use super::{schema::*, DbConnection, EncryptedMessageStore};
 use crate::{
     account::Account,
     contact::{Contact, ContactError},
@@ -137,16 +137,14 @@ impl StoredSession {
     }
 }
 
-impl Save<EncryptedMessageStore> for StoredSession {
-    fn save(&self, into: &EncryptedMessageStore) -> Result<(), StorageError> {
-        let conn = &mut into.conn()?;
-
+impl Save<DbConnection> for StoredSession {
+    fn save(&self, into: &mut DbConnection) -> Result<(), StorageError> {
         diesel::update(sessions::table)
             .set((
                 sessions::vmac_session_data.eq(&self.vmac_session_data),
                 sessions::peer_installation_id.eq(&self.peer_installation_id),
             ))
-            .execute(conn)?;
+            .execute(into)?;
 
         Ok(())
     }
@@ -229,13 +227,11 @@ pub struct RefreshJob {
     pub last_run: i64,
 }
 
-impl Save<EncryptedMessageStore> for RefreshJob {
-    fn save(&self, into: &EncryptedMessageStore) -> Result<(), StorageError> {
-        let conn = &mut into.conn()?;
-
+impl Save<DbConnection> for RefreshJob {
+    fn save(&self, into: &mut DbConnection) -> Result<(), StorageError> {
         diesel::update(refresh_jobs::table)
             .set(refresh_jobs::last_run.eq(&self.last_run))
-            .execute(conn)?;
+            .execute(into)?;
 
         Ok(())
     }

--- a/xmtp/src/storage/mod.rs
+++ b/xmtp/src/storage/mod.rs
@@ -7,6 +7,6 @@ pub use encrypted_store::{
         OutboundPayloadState, RefreshJob, RefreshJobKind, StoredConversation, StoredInstallation,
         StoredMessage, StoredOutboundPayload, StoredSession, StoredUser,
     },
-    EncryptedMessageStore, EncryptionKey, StorageOption,
+    DbConnection, EncryptedMessageStore, EncryptionKey, StorageOption,
 };
 pub use errors::StorageError;


### PR DESCRIPTION
## Summary

I've been running into issues using code that calls our `Save` or `Store` traits inside a transaction. This is because the traits attempt to get a new connection from the pool when the pool is already being used for the transaction manager.

We need to make the connection used explicit instead of implicit to make our existing code work with transactions.

This does that by making the `Save`, `Fetch`, and `Store` traits expect a `DbConnection` instead of an `EncryptedMessageStore`. We'll also want to make the methods on `EncryptedMessageStore` take in a `DbConnection` instance explicitly, so that they can be used safely from inside a transaction. That can be handled in a subsequent PR.

## Alternatives considered

- We could ditch the `Save` and `Store` traits altogether, and just add methods on `EncryptedMessageStore` that take in a DbConnection. That ultimately works the same way, but I like the tidiness of using traits for these operations that are so similar. I do kinda want to get rid of the `Fetch` trait and move those operations to the `EncryptedMessageStore`, since I think in the fullness of time each entity's fetch is going to need slightly different parameters for querying. 
- Keep the existing traits and add additional `SaveWithConn`, `StoreWithConn`, `FetchWithConn` that take in an explicit connection. I don't hate that, but it feels unnecessary given that most of our code is ultimately going to be called from somewhere inside a transaction.

## Potential Challenges

- In order to make this approach work with other connections beyond `SQLite` we will need to do some trickery with features to redefine what the `DBConnection` type references depending on what database you are targeting.
- Because SQLite can only have a single concurrent connection, care needs to be taken to ensure that only one `conn`  exists at a time. `DbConnection`s should be created as early as possible and re-used. That means other functions that operate on the database will also need to take in a `DbConnection` as an argument whereas before they could simply rely on having access to an `EncryptedMessageStore`.