### PR TITLE
Share networking client between XMTP clients for tests

### DIFF
--- a/xmtp/src/conversations.rs
+++ b/xmtp/src/conversations.rs
@@ -409,7 +409,7 @@ mod tests {
             InboundInvite, InboundInviteStatus, MessageState, OutboundPayloadState,
             StoredConversation, StoredMessage, StoredUser,
         },
-        test_utils::test_utils::{gen_test_client, gen_test_conversation},
+        test_utils::test_utils::{gen_test_client, gen_test_conversation, gen_two_test_clients},
         utils::{build_envelope, build_user_invite_topic},
         ClientBuilder, Fetch,
     };
@@ -469,8 +469,7 @@ mod tests {
 
     #[tokio::test]
     async fn process_outbound_messages() {
-        let alice_client = gen_test_client().await;
-        let bob_client = gen_test_client().await;
+        let (alice_client, bob_client) = gen_two_test_clients().await;
 
         let conversations = Conversations::new(&alice_client);
         let conversation =
@@ -480,10 +479,9 @@ mod tests {
         let unprocessed_messages = alice_client.store.get_unprocessed_messages().unwrap();
         assert_eq!(unprocessed_messages.len(), 1);
 
-        // TODO replace with Client.refresh_user_installations. Requires us to refactor the SDK so that
-        // two XMTP clients can share the same API client
         alice_client
-            .create_outbound_session(&bob_client.account.contact())
+            .refresh_user_installations(&bob_client.wallet_address())
+            .await
             .unwrap();
 
         conversations.process_outbound_messages().await.unwrap();

--- a/xmtp/src/test_utils.rs
+++ b/xmtp/src/test_utils.rs
@@ -6,10 +6,27 @@ pub mod test_utils {
         ClientBuilder,
     };
 
-    pub async fn gen_test_client() -> Client<MockXmtpApiClient> {
-        let mut client = ClientBuilder::new_test().build().unwrap();
+    async fn gen_test_client_internal(api_client: MockXmtpApiClient) -> Client<MockXmtpApiClient> {
+        let mut client = ClientBuilder::new_test()
+            .api_client(api_client)
+            .build()
+            .unwrap();
         client.init().await.expect("BadReg");
         client
+    }
+
+    pub async fn gen_test_client() -> Client<MockXmtpApiClient> {
+        gen_test_client_internal(MockXmtpApiClient::new()).await
+    }
+
+    // Generate test clients pointing to the same network
+    pub async fn gen_two_test_clients() -> (Client<MockXmtpApiClient>, Client<MockXmtpApiClient>) {
+        let api_client_1 = MockXmtpApiClient::new();
+        let api_client_2 = api_client_1.clone();
+        (
+            gen_test_client_internal(api_client_1).await,
+            gen_test_client_internal(api_client_2).await,
+        )
     }
 
     pub async fn gen_test_conversation<'c, A: XmtpApiClient>(


### PR DESCRIPTION
The `MockXmtpApiClient` stores network requests in memory. This means that if two separate api clients are constructed, they won't share any memory - which means that in unit tests, we are unable to validate any communication between two users that passes through the network. This PR enables us to share a `MockXmtpApiClient` between multiple XMTP clients, so that this kind of testing is unblocked.