### PR TITLE
Change Primary key of OutboundPayloads Table

### DIFF
--- a/xmtp/migrations/2023-07-19-232818_create_outbound_payloads/up.sql
+++ b/xmtp/migrations/2023-07-19-232818_create_outbound_payloads/up.sql
@@ -1,5 +1,5 @@
 CREATE TABLE outbound_payloads (
-    msg_id TEXT NOT NULL,
+    payload_id TEXT NOT NULL,
     created_at_ns BIGINT KEY NOT NULL,
     content_topic TEXT NOT NULL,
     payload BLOB NOT NULL,

--- a/xmtp/migrations/2023-07-19-232818_create_outbound_payloads/up.sql
+++ b/xmtp/migrations/2023-07-19-232818_create_outbound_payloads/up.sql
@@ -1,5 +1,6 @@
 CREATE TABLE outbound_payloads (
-    created_at_ns BIGINT PRIMARY KEY NOT NULL,
+    msg_id TEXT NOT NULL,
+    created_at_ns BIGINT KEY NOT NULL,
     content_topic TEXT NOT NULL,
     payload BLOB NOT NULL,
     outbound_payload_state INTEGER NOT NULL

--- a/xmtp/migrations/2023-07-19-232818_create_outbound_payloads/up.sql
+++ b/xmtp/migrations/2023-07-19-232818_create_outbound_payloads/up.sql
@@ -1,5 +1,5 @@
 CREATE TABLE outbound_payloads (
-    payload_id TEXT NOT NULL,
+    payload_id TEXT PRIMARY KEY NOT NULL,
     created_at_ns BIGINT KEY NOT NULL,
     content_topic TEXT NOT NULL,
     payload BLOB NOT NULL,

--- a/xmtp/src/conversations.rs
+++ b/xmtp/src/conversations.rs
@@ -283,13 +283,13 @@ where
             header_bytes,
             ciphertext,
         };
-        Ok(StoredOutboundPayload {
-            created_at_ns: message.created_at,
-            content_topic: build_installation_message_topic(&session.installation_id()),
-            payload: envelope.encode_to_vec(),
-            outbound_payload_state: OutboundPayloadState::Pending as i32,
-            locked_until_ns: 0,
-        })
+        Ok(StoredOutboundPayload::new(
+            message.created_at,
+            build_installation_message_topic(&session.installation_id()),
+            envelope.encode_to_vec(),
+            OutboundPayloadState::Pending as i32,
+            0,
+        ))
     }
 
     pub fn process_outbound_message(

--- a/xmtp/src/storage/encrypted_store/models.rs
+++ b/xmtp/src/storage/encrypted_store/models.rs
@@ -6,6 +6,7 @@ use crate::{
     Save,
 };
 use diesel::prelude::*;
+use prost::Message;
 use std::fmt;
 use std::time::{SystemTime, UNIX_EPOCH};
 use xmtp_cryptography::hash::sha256_bytes;
@@ -96,11 +97,34 @@ pub enum OutboundPayloadState {
 #[diesel(table_name = outbound_payloads)]
 #[diesel(primary_key(created_at_ns))]
 pub struct StoredOutboundPayload {
+    pub msg_id: String,
     pub created_at_ns: i64,
     pub content_topic: String,
     pub payload: Vec<u8>,
     pub outbound_payload_state: i32,
     pub locked_until_ns: i64,
+}
+
+impl StoredOutboundPayload {
+    pub fn new(
+        created_at_ns: i64,
+        content_topic: String,
+        payload: Vec<u8>,
+        outbound_payload_state: i32,
+        locked_until_ns: i64,
+    ) -> Self {
+        let msg_id = hex::encode(sha256_bytes(
+            &(format!("{created_at_ns}:{content_topic}").encode_to_vec()),
+        ));
+        Self {
+            msg_id,
+            created_at_ns,
+            content_topic,
+            payload,
+            outbound_payload_state,
+            locked_until_ns,
+        }
+    }
 }
 
 pub fn now() -> i64 {

--- a/xmtp/src/storage/encrypted_store/models.rs
+++ b/xmtp/src/storage/encrypted_store/models.rs
@@ -97,7 +97,7 @@ pub enum OutboundPayloadState {
 #[diesel(table_name = outbound_payloads)]
 #[diesel(primary_key(created_at_ns))]
 pub struct StoredOutboundPayload {
-    pub msg_id: String,
+    pub payload_id: String,
     pub created_at_ns: i64,
     pub content_topic: String,
     pub payload: Vec<u8>,
@@ -113,11 +113,11 @@ impl StoredOutboundPayload {
         outbound_payload_state: i32,
         locked_until_ns: i64,
     ) -> Self {
-        let msg_id = hex::encode(sha256_bytes(
+        let payload_id = hex::encode(sha256_bytes(
             &(format!("{created_at_ns}:{content_topic}").encode_to_vec()),
         ));
         Self {
-            msg_id,
+            payload_id,
             created_at_ns,
             content_topic,
             payload,

--- a/xmtp/src/storage/encrypted_store/schema.rs
+++ b/xmtp/src/storage/encrypted_store/schema.rs
@@ -49,8 +49,8 @@ diesel::table! {
 }
 
 diesel::table! {
-    outbound_payloads (msg_id) {
-        msg_id -> Text,
+    outbound_payloads (payload_id) {
+        payload_id -> Text,
         created_at_ns -> BigInt,
         content_topic -> Text,
         payload -> Binary,

--- a/xmtp/src/storage/encrypted_store/schema.rs
+++ b/xmtp/src/storage/encrypted_store/schema.rs
@@ -49,7 +49,8 @@ diesel::table! {
 }
 
 diesel::table! {
-    outbound_payloads (created_at_ns) {
+    outbound_payloads (msg_id) {
+        msg_id -> Text,
         created_at_ns -> BigInt,
         content_topic -> Text,
         payload -> Binary,

--- a/xmtp/src/storage/errors.rs
+++ b/xmtp/src/storage/errors.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 pub enum StorageError {
     #[error("Diesel connection error")]
     DieselConnectError(#[from] diesel::ConnectionError),
-    #[error("Diesel result error")]
+    #[error("Diesel result error: {0}")]
     DieselResultError(#[from] diesel::result::Error),
     #[error("Pool error {0}")]
     PoolError(String),


### PR DESCRIPTION
Expecting some pushback on this one, but thought I'd put forward a solution to start the conversation. 

## Problem
There is a Primary key error being emitted when sending to an address with multiple installs.
The outbounds_payloads table uses `created_at_ns` as a primary key. This value is pulled from the timestamp which the message was created. Message fanout leads to multiple outbound payloads being created with the same key.

![image](https://github.com/xmtp/libxmtp/assets/473256/0800ad55-62ed-4ed9-9ef9-a44eb72f4d39)


## Solution
This PR adds a BREAKING CHANGE to change the primary key of the `outbound_payload` table to use a msg_id which is calculated via  Sha256("\<timestamp\>:\<topic\>");

![image](https://github.com/xmtp/libxmtp/assets/473256/2b2deaf9-bdb1-4d7a-9c6c-f2bb1d26caa4)


## Notes
- I first thought about changing the definition of `created_at_ns` to be when the outbound payload was created rather than the message, however that would lead to potential duplicate messages as double sends would not be caught or detected.
