### PR TITLE
Refresh user installations if stale

### DIFF
--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -230,11 +230,6 @@ async fn send(client: Client, addr: &str, msg: &String) -> Result<(), CliError> 
         .new_secret_conversation(addr.to_string())
         .unwrap();
     conversation.send_message(msg).unwrap();
-    client
-        .refresh_user_installations(&client.wallet_address())
-        .await
-        .unwrap();
-    client.refresh_user_installations(addr).await.unwrap();
     conversations.process_outbound_messages().await.unwrap();
     conversations.publish_outbound_payloads().await.unwrap();
     info!("Message locally committed");

--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -231,8 +231,7 @@ async fn send(client: Client, addr: &str, msg: &String) -> Result<(), CliError> 
         .unwrap();
     conversation.send_message(msg).unwrap();
     conversations.process_outbound_messages().await.unwrap();
-    conversations.publish_outbound_payloads().await.unwrap();
-    info!("Message locally committed");
+    info!("Message successfully sent");
 
     Ok(())
 }

--- a/xmtp/src/storage/encrypted_store/mod.rs
+++ b/xmtp/src/storage/encrypted_store/mod.rs
@@ -224,10 +224,10 @@ impl EncryptedMessageStore {
         conn: &mut PooledConnection<ConnectionManager<SqliteConnection>>,
         user_address: &str,
         timestamp: i64,
-    ) -> Result<usize, StorageError> {
-        diesel::update(users::table.filter(users::user_address.eq(user_address)))
+    ) -> Result<StoredUser, StorageError> {
+        diesel::update(users::table.find(user_address))
             .set(users::last_refreshed.eq(timestamp))
-            .execute(conn)
+            .get_result::<StoredUser>(conn)
             .map_err(|e| e.into())
     }
 


### PR DESCRIPTION
Small PR with two changes:
1. When processing messages, refresh user installations if they are stale
2. Publish the outbound messages immediately after processing them.

To summarize, these are the steps when sending a message:
1. Write the message to the database
2. Encrypt the message into payloads (possibly refreshing installations along the way)
3. Publish the messages to the server

Steps (2) and (3) were originally separated out because they involve network calls that may potentially fail (e.g. device is offline, the network request takes a long time, device is killed, etc). So there is a DB write between each step, and each step can be picked up independently. The change in this PR means that (3) automatically starts after (2).

In a future PR I'd like to also kick off (2) from (1) in a background thread, so that clients don't have to wait for a server request to get confirmation that their send is happening. However, there is some refactoring that is needed because `Conversation` doesn't hold a reference to `Conversations`. In a later PR I'm thinking I can move the methods on `Conversations` onto `Conversation`.