### PR TITLE
XLI tidying

### DIFF
--- a/examples/cli/README.md
+++ b/examples/cli/README.md
@@ -5,11 +5,11 @@ XLI is an demo XMTPv3 console client, which allows developers to send and receiv
 ## Running
 
 Register accounts:
-`RUST_LOG=info cargo run -- --db ~/user1.db3 reg -L`
-`RUST_LOG=info cargo run -- --db ~/user2.db3 reg -L`
+`./xli.sh --db user1.db3 register`
+`./xli.sh --db user2.db3 register`
 
 Get wallet address:
-`RUST_LOG=info cargo run -- --db ~/user2.db3 info`
+`./xli.sh --db user2.db3 info`
 
 Send message:
-`RUST_LOG=info cargo run -- --db ~/user1.db3 send <user2_address> "hello"`
+`./xli.sh --db user1.db3 send <user2_address> "hello"`

--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -228,7 +228,7 @@ fn get_encrypted_store(db: Option<PathBuf>) -> Result<EncryptedMessageStore, Cli
     let store = match db {
         Some(path) => {
             let s = path.as_path().to_string_lossy().to_string();
-            info!("Using persistent storage:{} ", s);
+            info!("Using persistent storage: {} ", s);
             EncryptedMessageStore::new_unencrypted(StorageOption::Persistent(s))
         }
 

--- a/examples/cli/xli.sh
+++ b/examples/cli/xli.sh
@@ -1,1 +1,1 @@
-RUST_LOG=INFO cargo run "$@"
+RUST_LOG=INFO cargo run -- "$@"


### PR DESCRIPTION
Some quick tidying of the CLI in preparation for end-to-end testing:

- Combine `reg` and `testReg` into `register`, with an optional `seed` param to allow for multi-installation wallet testing
- Remove WalletConnect option from `register` as this is no longer functional after WalletConnect V1 was deprecated (at least until there is a viable v2 rust client)
- Update example commands and comments