### PR TITLE
Ensure an error is thrown if no row was found to update

### DIFF
--- a/xmtp/src/storage/encrypted_store/mod.rs
+++ b/xmtp/src/storage/encrypted_store/mod.rs
@@ -963,11 +963,24 @@ mod tests {
             .unwrap();
         assert_eq!(1, invited_conversations.len());
         assert_eq!(convo_1.convo_id, invited_conversations[0].convo_id);
-
         let uninitialized_conversations = store
             .get_conversations(conn, vec![ConversationState::Uninitialized])
             .unwrap();
         assert_eq!(1, uninitialized_conversations.len());
         assert_eq!(convo_2.convo_id, uninitialized_conversations[0].convo_id);
+    }
+
+    #[test]
+    fn errors_when_no_update() {
+        let store = EncryptedMessageStore::new(
+            StorageOption::Ephemeral,
+            EncryptedMessageStore::generate_enc_key(),
+        )
+        .unwrap();
+
+        let conn = &mut store.conn().unwrap();
+
+        let result = store.update_user_refresh_timestamp(conn, "0x01", 1);
+        assert!(result.is_err());
     }
 }

--- a/xmtp/src/storage/encrypted_store/mod.rs
+++ b/xmtp/src/storage/encrypted_store/mod.rs
@@ -325,7 +325,7 @@ impl EncryptedMessageStore {
             if result.is_ok() {
                 diesel::update(refresh_jobs::table.find(kind.to_string()))
                     .set(refresh_jobs::last_run.eq(start_time))
-                    .execute(connection)?;
+                    .get_result::<RefreshJob>(connection)?;
             } else {
                 return result;
             }
@@ -374,7 +374,7 @@ impl EncryptedMessageStore {
         diesel::update(dsl::inbound_invites)
             .filter(dsl::id.eq(id))
             .set(dsl::status.eq(status as i16))
-            .execute(conn)?;
+            .get_result::<InboundInvite>(conn)?;
 
         Ok(())
     }
@@ -412,14 +412,14 @@ impl EncryptedMessageStore {
         for session in updated_sessions {
             diesel::update(schema::sessions::table.find(session.session_id))
                 .set(schema::sessions::vmac_session_data.eq(session.vmac_session_data))
-                .execute(conn)?;
+                .get_result::<StoredSession>(conn)?;
         }
         diesel::insert_into(schema::outbound_payloads::table)
             .values(new_outbound_payloads)
             .execute(conn)?;
         diesel::update(messages::table.find(message_id))
             .set(messages::state.eq(updated_message_state as i32))
-            .execute(conn)?;
+            .get_result::<StoredMessage>(conn)?;
         Ok(())
     }
 
@@ -467,7 +467,7 @@ impl EncryptedMessageStore {
         diesel::update(dsl::conversations)
             .filter(dsl::convo_id.eq(convo_id))
             .set(dsl::convo_state.eq(state as i32))
-            .execute(conn)?;
+            .get_result::<StoredConversation>(conn)?;
         Ok(())
     }
 


### PR DESCRIPTION
Our update operations don't throw an error if no row was found to update. Small PR to make sure we catch this, in case it helps @jazzz diagnose why replies currently give a NoSession error.