### PR TITLE
Fix duplicate sessions

### DIFF
--- a/xmtp/migrations/2023-06-03-011250_create_sessions/up.sql
+++ b/xmtp/migrations/2023-06-03-011250_create_sessions/up.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS sessions (
-    session_id TEXT PRIMARY KEY NOT NULL,
+    peer_installation_id TEXT PRIMARY KEY NOT NULL,
+    session_id TEXT NOT NULL,
     created_at BIGINT NOT NULL,
-    peer_installation_id TEXT NOT NULL,
     vmac_session_data BLOB NOT NULL
 )

--- a/xmtp/src/session.rs
+++ b/xmtp/src/session.rs
@@ -1,6 +1,6 @@
 use crate::{
     contact::Contact,
-    storage::{DbConnection  , StorageError, StoredSession},
+    storage::{DbConnection, StorageError, StoredSession},
     Save, Store,
 };
 use thiserror::Error;
@@ -112,8 +112,8 @@ impl TryFrom<&SessionManager> for StoredSession {
 
     fn try_from(value: &SessionManager) -> Result<Self, Self::Error> {
         Ok(StoredSession::new(
-            value.session.session_id(),
             value.peer_installation_id.clone(),
+            value.session.session_id(),
             // TODO: Better error handling approach. StoreError and SessionError end up being dependent on eachother
             value
                 .session_bytes()

--- a/xmtp/src/storage/encrypted_store/mod.rs
+++ b/xmtp/src/storage/encrypted_store/mod.rs
@@ -469,11 +469,9 @@ impl EncryptedMessageStore {
         session: StoredSession,
         conn: &mut PooledConnection<ConnectionManager<SqliteConnection>>,
     ) -> Result<(), StorageError> {
-        if !self.session_exists_for_installation(&session.peer_installation_id, conn)? {
-            diesel::insert_or_ignore_into(schema::sessions::table)
-                .values(session)
-                .execute(conn)?;
-        }
+        diesel::insert_or_ignore_into(schema::sessions::table)
+            .values(session)
+            .execute(conn)?;
         Ok(())
     }
 

--- a/xmtp/src/storage/encrypted_store/mod.rs
+++ b/xmtp/src/storage/encrypted_store/mod.rs
@@ -495,7 +495,7 @@ impl EncryptedMessageStore {
         conn: &mut PooledConnection<ConnectionManager<SqliteConnection>>,
     ) -> Result<(), StorageError> {
         for session in updated_sessions {
-            diesel::update(schema::sessions::table.find(session.session_id))
+            diesel::update(schema::sessions::table.find(session.peer_installation_id))
                 .set(schema::sessions::vmac_session_data.eq(session.vmac_session_data))
                 .get_result::<StoredSession>(conn)?;
         }

--- a/xmtp/src/storage/encrypted_store/mod.rs
+++ b/xmtp/src/storage/encrypted_store/mod.rs
@@ -469,9 +469,11 @@ impl EncryptedMessageStore {
         session: StoredSession,
         conn: &mut PooledConnection<ConnectionManager<SqliteConnection>>,
     ) -> Result<(), StorageError> {
-        diesel::insert_or_ignore_into(schema::sessions::table)
-            .values(session)
-            .execute(conn)?;
+        if !self.session_exists_for_installation(&session.peer_installation_id, conn)? {
+            diesel::insert_or_ignore_into(schema::sessions::table)
+                .values(session)
+                .execute(conn)?;
+        }
         Ok(())
     }
 

--- a/xmtp/src/storage/encrypted_store/models.rs
+++ b/xmtp/src/storage/encrypted_store/models.rs
@@ -149,15 +149,15 @@ pub struct StoredSession {
 
 impl StoredSession {
     pub fn new(
-        session_id: String,
         peer_installation_id: String,
+        session_id: String,
         vmac_session_data: Vec<u8>,
         user_address: String,
     ) -> Self {
         Self {
+            peer_installation_id,
             session_id,
             created_at: now(),
-            peer_installation_id,
             vmac_session_data,
             user_address,
         }

--- a/xmtp/src/storage/encrypted_store/schema.rs
+++ b/xmtp/src/storage/encrypted_store/schema.rs
@@ -77,7 +77,7 @@ diesel::table! {
 }
 
 diesel::table! {
-    sessions (session_id) {
+    sessions (peer_installation_id) {
         session_id -> Text,
         created_at -> BigInt,
         peer_installation_id -> Text,


### PR DESCRIPTION
## Problem

When replying to message the client was creating a new unnecessary session. The root cause was that refresh_user_installations creates a session, which was allowed because the primary key on the sessions table was set to `session_id`.

### Path 

- Initializing a conversation causes a refresh of the users contact bundles
- New contact creates a new session via `insert_or_ignore_session`.
- since the primary key was set to `session_id` there was never a conflict and sqlite allowed the operation

## Solution

This PR changes the primary key to `peer_installation_id` such that only one session can be created for a given installation. This results in no extra sessions being added.
