### PR TITLE
Add trait impl for fetch_one

### DIFF
--- a/xmtp/src/builder.rs
+++ b/xmtp/src/builder.rs
@@ -137,7 +137,7 @@ where
         store: &mut EncryptedMessageStore,
     ) -> Result<Option<Account>, ClientBuilderError> {
         let conn = &mut store.conn()?;
-        let mut accounts = conn.fetch()?;
+        let mut accounts = conn.fetch_all()?;
         Ok(accounts.pop())
     }
 

--- a/xmtp/src/conversations.rs
+++ b/xmtp/src/conversations.rs
@@ -756,16 +756,16 @@ mod tests {
 
         let conn = &mut bob_client.store.conn().unwrap();
 
-        let inbound_invites: Vec<InboundInvite> = conn.fetch().unwrap();
+        let inbound_invites: Vec<InboundInvite> = conn.fetch_all().unwrap();
         assert_eq!(inbound_invites.len(), 1);
         assert!(inbound_invites[0].status == InboundInviteStatus::Processed as i16);
 
-        let users: Vec<StoredUser> = conn.fetch().unwrap();
+        let users: Vec<StoredUser> = conn.fetch_all().unwrap();
         // Expect 2 users because Bob is always in his own DB already
         assert_eq!(users.len(), 2);
         assert_eq!(users[1].user_address, alice_client.wallet_address());
 
-        let conversations: Vec<StoredConversation> = conn.fetch().unwrap();
+        let conversations: Vec<StoredConversation> = conn.fetch_all().unwrap();
         assert_eq!(conversations.len(), 1);
         assert_eq!(conversations[0].peer_address, alice_client.wallet_address());
     }
@@ -810,15 +810,15 @@ mod tests {
 
         let conn = &mut bob_client.store.conn().unwrap();
 
-        let inbound_invites: Vec<InboundInvite> = conn.fetch().unwrap();
+        let inbound_invites: Vec<InboundInvite> = conn.fetch_all().unwrap();
         assert_eq!(inbound_invites.len(), 1);
         assert!(inbound_invites[0].status == InboundInviteStatus::DecryptionFailure as i16);
 
-        let users: Vec<StoredUser> = conn.fetch().unwrap();
+        let users: Vec<StoredUser> = conn.fetch_all().unwrap();
         // Expect 1 user because Bob is always in his own DB already
         assert_eq!(users.len(), 1);
 
-        let conversations: Vec<StoredConversation> = conn.fetch().unwrap();
+        let conversations: Vec<StoredConversation> = conn.fetch_all().unwrap();
         assert_eq!(conversations.len(), 0);
     }
 

--- a/xmtp/src/lib.rs
+++ b/xmtp/src/lib.rs
@@ -37,9 +37,14 @@ pub trait Store<I> {
     fn store(&self, into: &mut I) -> Result<(), StorageError>;
 }
 
-// Fetches all instances of a model from the underlying data store
 pub trait Fetch<T> {
-    fn fetch(&mut self) -> Result<Vec<T>, StorageError>;
+    type Key<'a>
+    where
+        Self: 'a;
+    // Fetches all instances of a model from the underlying data store
+    fn fetch_all(&mut self) -> Result<Vec<T>, StorageError>;
+    // Fetches a single instance by key of a model from the underlying data store
+    fn fetch_one<'a>(&mut self, key: Self::Key<'a>) -> Result<Option<T>, StorageError>;
 }
 
 // Updates an existing instance of the model in the data store

--- a/xmtp/src/lib.rs
+++ b/xmtp/src/lib.rs
@@ -38,12 +38,12 @@ pub trait Store<I> {
 }
 
 pub trait Fetch<T> {
-    type Key<'a>
-    where
-        Self: 'a;
+    type Key<'a>;
     // Fetches all instances of a model from the underlying data store
     fn fetch_all(&mut self) -> Result<Vec<T>, StorageError>;
+
     // Fetches a single instance by key of a model from the underlying data store
+    #[allow(clippy::needless_lifetimes)]
     fn fetch_one<'a>(&mut self, key: Self::Key<'a>) -> Result<Option<T>, StorageError>;
 }
 

--- a/xmtp/src/session.rs
+++ b/xmtp/src/session.rs
@@ -151,7 +151,7 @@ mod tests {
 
         a_to_b_session.store(conn).unwrap();
 
-        let results: Vec<StoredSession> = conn.fetch().unwrap();
+        let results: Vec<StoredSession> = conn.fetch_all().unwrap();
         assert_eq!(results.len(), 1);
         let initial_session_data = &results.get(0).unwrap().vmac_session_data;
 
@@ -165,7 +165,7 @@ mod tests {
             let decrypted_reply = a_to_b_session.decrypt(reply, conn).unwrap();
             assert_eq!(decrypted_reply, "hello to you".as_bytes());
 
-            let updated_results: Vec<StoredSession> = conn.fetch().unwrap();
+            let updated_results: Vec<StoredSession> = conn.fetch_all().unwrap();
             assert_eq!(updated_results.len(), 1);
             let updated_session_data = &updated_results.get(0).unwrap().vmac_session_data;
 

--- a/xmtp/src/storage/encrypted_store/mod.rs
+++ b/xmtp/src/storage/encrypted_store/mod.rs
@@ -154,7 +154,7 @@ impl EncryptedMessageStore {
     }
 
     pub fn get_account(&mut self) -> Result<Option<Account>, StorageError> {
-        let mut account_list: Vec<Account> = self.conn().unwrap().fetch()?;
+        let mut account_list: Vec<Account> = self.conn().unwrap().fetch_all()?;
 
         warn_length(&account_list, "StoredAccount", 1);
 
@@ -214,13 +214,9 @@ impl EncryptedMessageStore {
         conn: &mut DbConnection,
         user_address_str: &str,
     ) -> Result<Vec<StoredInstallation>, StorageError> {
-        use self::schema::installations::dsl as schema;
-
-        let installation_list = schema::installations
-            .filter(schema::user_address.eq(user_address_str))
-            .load::<StoredInstallation>(conn)
-            .map_err(|e| StorageError::Unknown(e.to_string()))?;
-
+        let installation_list = installations::table
+            .filter(installations::user_address.eq(user_address_str))
+            .load::<StoredInstallation>(conn)?;
         Ok(installation_list)
     }
 
@@ -637,52 +633,83 @@ impl Store<DbConnection> for StoredSession {
 }
 
 impl Fetch<StoredMessage> for DbConnection {
-    fn fetch(&mut self) -> Result<Vec<StoredMessage>, StorageError> {
+    type Key<'a> = i32;
+    fn fetch_all(&mut self) -> Result<Vec<StoredMessage>, StorageError> {
         use self::schema::messages::dsl::*;
 
         messages
             .load::<StoredMessage>(self)
             .map_err(StorageError::DieselResultError)
     }
+
+    fn fetch_one<'a>(&mut self, key: Self::Key<'a>) -> Result<Option<StoredMessage>, StorageError> {
+        use self::schema::messages::dsl::*;
+        Ok(messages.find(key).first(self).optional()?)
+    }
 }
 
 impl Fetch<StoredSession> for DbConnection {
-    fn fetch(&mut self) -> Result<Vec<StoredSession>, StorageError> {
+    type Key<'a> = &'a str;
+    fn fetch_all(&mut self) -> Result<Vec<StoredSession>, StorageError> {
         use self::schema::sessions::dsl::*;
 
         sessions
             .load::<StoredSession>(self)
             .map_err(StorageError::DieselResultError)
     }
+
+    fn fetch_one<'a>(&mut self, key: Self::Key<'a>) -> Result<Option<StoredSession>, StorageError> {
+        use self::schema::sessions::dsl::*;
+        Ok(sessions.find(key).first(self).optional()?)
+    }
 }
 
 impl Fetch<InboundInvite> for DbConnection {
-    fn fetch(&mut self) -> Result<Vec<InboundInvite>, StorageError> {
+    type Key<'a> = &'a str;
+    fn fetch_all(&mut self) -> Result<Vec<InboundInvite>, StorageError> {
         use self::schema::inbound_invites::dsl::*;
 
         inbound_invites
             .load::<InboundInvite>(self)
             .map_err(StorageError::DieselResultError)
     }
+
+    fn fetch_one<'a>(&mut self, key: Self::Key<'a>) -> Result<Option<InboundInvite>, StorageError> {
+        use self::schema::inbound_invites::dsl::*;
+        Ok(inbound_invites.find(key).first(self).optional()?)
+    }
 }
 
 impl Fetch<StoredUser> for DbConnection {
-    fn fetch(&mut self) -> Result<Vec<StoredUser>, StorageError> {
+    type Key<'a> = &'a str;
+    fn fetch_all(&mut self) -> Result<Vec<StoredUser>, StorageError> {
         use self::schema::users::dsl;
 
         dsl::users
             .load::<StoredUser>(self)
             .map_err(StorageError::DieselResultError)
     }
+    fn fetch_one<'a>(&mut self, key: Self::Key<'a>) -> Result<Option<StoredUser>, StorageError> {
+        use self::schema::users::dsl::*;
+        Ok(users.find(key).first(self).optional()?)
+    }
 }
 
 impl Fetch<StoredConversation> for DbConnection {
-    fn fetch(&mut self) -> Result<Vec<StoredConversation>, StorageError> {
+    type Key<'a> = &'a str;
+    fn fetch_all(&mut self) -> Result<Vec<StoredConversation>, StorageError> {
         use self::schema::conversations::dsl;
 
         dsl::conversations
             .load::<StoredConversation>(self)
             .map_err(StorageError::DieselResultError)
+    }
+    fn fetch_one<'a>(
+        &mut self,
+        key: Self::Key<'a>,
+    ) -> Result<Option<StoredConversation>, StorageError> {
+        use self::schema::conversations::dsl::*;
+        Ok(conversations.find(key).first(self).optional()?)
     }
 }
 
@@ -698,7 +725,8 @@ impl Store<DbConnection> for Account {
 }
 
 impl Fetch<Account> for DbConnection {
-    fn fetch(&mut self) -> Result<Vec<Account>, StorageError> {
+    type Key<'a> = i32;
+    fn fetch_all(&mut self) -> Result<Vec<Account>, StorageError> {
         use self::schema::accounts::dsl::*;
 
         let stored_accounts = accounts
@@ -711,6 +739,17 @@ impl Fetch<Account> for DbConnection {
             .map(|f| serde_json::from_slice(&f.serialized_key).unwrap())
             .collect())
     }
+
+    fn fetch_one<'a>(&mut self, key: Self::Key<'a>) -> Result<Option<Account>, StorageError> {
+        use self::schema::accounts::dsl::*;
+        let stored_account: Option<StoredAccount> = accounts.find(key).first(self).optional()?;
+
+        match stored_account {
+            None => Ok(None),
+            Some(a) => serde_json::from_slice(&a.serialized_key)
+                .map_err(|e| StorageError::Unknown(format!("Failed to deserialize key:{}", e))),
+        }
+    }
 }
 
 impl Store<DbConnection> for StoredInstallation {
@@ -720,6 +759,24 @@ impl Store<DbConnection> for StoredInstallation {
             .execute(into)?;
 
         Ok(())
+    }
+}
+
+impl Fetch<StoredInstallation> for DbConnection {
+    type Key<'a> = &'a str;
+    fn fetch_all(&mut self) -> Result<Vec<StoredInstallation>, StorageError> {
+        use self::schema::installations::dsl;
+
+        dsl::installations
+            .load::<StoredInstallation>(self)
+            .map_err(StorageError::DieselResultError)
+    }
+    fn fetch_one<'a>(
+        &mut self,
+        key: Self::Key<'a>,
+    ) -> Result<Option<StoredInstallation>, StorageError> {
+        use self::schema::installations::dsl::*;
+        Ok(installations.find(key).first(self).optional()?)
     }
 }
 
@@ -803,7 +860,7 @@ mod tests {
         .store(conn)
         .unwrap();
 
-        let v: Vec<StoredMessage> = conn.fetch().unwrap();
+        let v: Vec<StoredMessage> = conn.fetch_all().unwrap();
         assert_eq!(4, v.len());
     }
 
@@ -828,7 +885,7 @@ mod tests {
             .store(conn)
             .unwrap();
 
-            let v: Vec<StoredMessage> = conn.fetch().unwrap();
+            let v: Vec<StoredMessage> = conn.fetch_all().unwrap();
             assert_eq!(1, v.len());
         }
 
@@ -864,7 +921,7 @@ mod tests {
         msg0.store(conn).unwrap();
         msg1.store(conn).unwrap();
 
-        let msgs: Vec<StoredMessage> = conn.fetch().unwrap();
+        let msgs: Vec<StoredMessage> = conn.fetch_all().unwrap();
 
         assert_eq!(2, msgs.len());
         assert_eq!(msg0, msgs[0]);
@@ -922,7 +979,7 @@ mod tests {
         let conn = &mut store.conn().unwrap();
         session.store(conn).unwrap();
 
-        let results: Vec<StoredSession> = conn.fetch().unwrap();
+        let results: Vec<StoredSession> = conn.fetch_all().unwrap();
         assert_eq!(1, results.len());
     }
 
@@ -1032,7 +1089,7 @@ mod tests {
         });
 
         assert!(result.is_ok());
-        let db_results: Vec<InboundInvite> = conn.fetch().unwrap();
+        let db_results: Vec<InboundInvite> = conn.fetch_all().unwrap();
         assert_eq!(1, db_results.len());
 
         let inbound_invite_ptr = &inbound_invite;

--- a/xmtp/src/storage/encrypted_store/mod.rs
+++ b/xmtp/src/storage/encrypted_store/mod.rs
@@ -642,7 +642,7 @@ impl Fetch<StoredMessage> for DbConnection {
             .map_err(StorageError::DieselResultError)
     }
 
-    fn fetch_one<'a>(&mut self, key: Self::Key<'a>) -> Result<Option<StoredMessage>, StorageError> {
+    fn fetch_one(&mut self, key: i32) -> Result<Option<StoredMessage>, StorageError> where {
         use self::schema::messages::dsl::*;
         Ok(messages.find(key).first(self).optional()?)
     }
@@ -658,7 +658,7 @@ impl Fetch<StoredSession> for DbConnection {
             .map_err(StorageError::DieselResultError)
     }
 
-    fn fetch_one<'a>(&mut self, key: Self::Key<'a>) -> Result<Option<StoredSession>, StorageError> {
+    fn fetch_one(&mut self, key: &str) -> Result<Option<StoredSession>, StorageError> {
         use self::schema::sessions::dsl::*;
         Ok(sessions.find(key).first(self).optional()?)
     }
@@ -674,7 +674,7 @@ impl Fetch<InboundInvite> for DbConnection {
             .map_err(StorageError::DieselResultError)
     }
 
-    fn fetch_one<'a>(&mut self, key: Self::Key<'a>) -> Result<Option<InboundInvite>, StorageError> {
+    fn fetch_one(&mut self, key: &str) -> Result<Option<InboundInvite>, StorageError> {
         use self::schema::inbound_invites::dsl::*;
         Ok(inbound_invites.find(key).first(self).optional()?)
     }
@@ -689,7 +689,7 @@ impl Fetch<StoredUser> for DbConnection {
             .load::<StoredUser>(self)
             .map_err(StorageError::DieselResultError)
     }
-    fn fetch_one<'a>(&mut self, key: Self::Key<'a>) -> Result<Option<StoredUser>, StorageError> {
+    fn fetch_one(&mut self, key: &str) -> Result<Option<StoredUser>, StorageError> {
         use self::schema::users::dsl::*;
         Ok(users.find(key).first(self).optional()?)
     }
@@ -704,10 +704,7 @@ impl Fetch<StoredConversation> for DbConnection {
             .load::<StoredConversation>(self)
             .map_err(StorageError::DieselResultError)
     }
-    fn fetch_one<'a>(
-        &mut self,
-        key: Self::Key<'a>,
-    ) -> Result<Option<StoredConversation>, StorageError> {
+    fn fetch_one(&mut self, key: &str) -> Result<Option<StoredConversation>, StorageError> {
         use self::schema::conversations::dsl::*;
         Ok(conversations.find(key).first(self).optional()?)
     }
@@ -740,7 +737,7 @@ impl Fetch<Account> for DbConnection {
             .collect())
     }
 
-    fn fetch_one<'a>(&mut self, key: Self::Key<'a>) -> Result<Option<Account>, StorageError> {
+    fn fetch_one(&mut self, key: i32) -> Result<Option<Account>, StorageError> {
         use self::schema::accounts::dsl::*;
         let stored_account: Option<StoredAccount> = accounts.find(key).first(self).optional()?;
 
@@ -771,10 +768,7 @@ impl Fetch<StoredInstallation> for DbConnection {
             .load::<StoredInstallation>(self)
             .map_err(StorageError::DieselResultError)
     }
-    fn fetch_one<'a>(
-        &mut self,
-        key: Self::Key<'a>,
-    ) -> Result<Option<StoredInstallation>, StorageError> {
+    fn fetch_one(&mut self, key: &str) -> Result<Option<StoredInstallation>, StorageError> {
         use self::schema::installations::dsl::*;
         Ok(installations.find(key).first(self).optional()?)
     }


### PR DESCRIPTION
This PR adds a new function to the Fetch trait to get items by table key, in anticipation of some refactoring.

Example usage `let user: StoredUser = conn.fetch_one("0x7751e17d76f6a9517aa73445321b5c3ee5dd91da")?;`

- added function 'fetch_one' to the Fetch Trait
- previous `fetch` function renamed to `fetch_all` for accuracy

     