### PR TITLE
Default CLI to dev network

### DIFF
--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -187,17 +187,14 @@ async fn create_client(
     account: AccountStrategy<Wallet>,
 ) -> Result<Client, CliError> {
     let msg_store = get_encrypted_store(db).unwrap();
-    let mut builder = ClientBuilder::new(account)
-        .store(msg_store);
+    let mut builder = ClientBuilder::new(account).store(msg_store);
 
     if true {
-        builder = builder
-            .network(xmtp::Network::Local("https://api.dev.xmtp.network"))
-            .api_client(
-                ApiClient::create("https://api.dev.xmtp.network".into(), true)
-                    .await
-                    .unwrap(),
-            );
+        builder = builder.network(xmtp::Network::Dev).api_client(
+            ApiClient::create("https://api.dev.xmtp.network".into(), true)
+                .await
+                .unwrap(),
+        );
     } else {
         builder = builder
             .network(xmtp::Network::Local("http://localhost:5556"))
@@ -208,9 +205,7 @@ async fn create_client(
             );
     }
 
-    builder
-        .build()
-        .map_err(CliError::ClientBuilder)
+    builder.build().map_err(CliError::ClientBuilder)
 }
 
 async fn register(db: Option<PathBuf>, use_local: bool, wallet_seed: &u64) -> Result<(), CliError> {

--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -187,18 +187,30 @@ async fn create_client(
     account: AccountStrategy<Wallet>,
 ) -> Result<Client, CliError> {
     let msg_store = get_encrypted_store(db).unwrap();
+    let mut builder = ClientBuilder::new(account)
+        .store(msg_store);
 
-    let client_result = ClientBuilder::new(account)
-        .network(xmtp::Network::Local("http://localhost:5556"))
-        .api_client(
-            ApiClient::create("http://localhost:5556".into(), false)
-                .await
-                .unwrap(),
-        )
-        .store(msg_store)
-        .build();
+    if true {
+        builder = builder
+            .network(xmtp::Network::Local("https://api.dev.xmtp.network"))
+            .api_client(
+                ApiClient::create("https://api.dev.xmtp.network".into(), true)
+                    .await
+                    .unwrap(),
+            );
+    } else {
+        builder = builder
+            .network(xmtp::Network::Local("http://localhost:5556"))
+            .api_client(
+                ApiClient::create("http://localhost:5556".into(), false)
+                    .await
+                    .unwrap(),
+            );
+    }
 
-    client_result.map_err(CliError::ClientBuilder)
+    builder
+        .build()
+        .map_err(CliError::ClientBuilder)
 }
 
 async fn register(db: Option<PathBuf>, use_local: bool, wallet_seed: &u64) -> Result<(), CliError> {

--- a/xmtp/src/client.rs
+++ b/xmtp/src/client.rs
@@ -43,7 +43,7 @@ pub enum ClientError {
     #[error("dieselError: {0}")]
     Ddd(#[from] diesel::result::Error),
     #[error("Query failed: {0}")]
-    QueryError(String),
+    QueryError(#[from] crate::types::networking::Error),
     #[error("generic:{0}")]
     Generic(String),
 }
@@ -135,8 +135,7 @@ where
                 end_time_ns: 0,
                 paging_info: None,
             })
-            .await
-            .map_err(|e| ClientError::QueryError(format!("Could not query for contacts: {}", e)))?;
+            .await?;
 
         let mut contacts = vec![];
         for envelope in response.envelopes {
@@ -321,8 +320,7 @@ where
                     envelopes: vec![envelope],
                 },
             )
-            .await
-            .map_err(|e| ClientError::PublishError(format!("Could not publish contact: {}", e)))?;
+            .await?;
 
         Ok(())
     }
@@ -352,8 +350,7 @@ where
                 // TODO: Pagination
                 paging_info: None,
             })
-            .await
-            .map_err(|e| ClientError::QueryError(format!("Could not query topic: {}", e)))?;
+            .await?;
 
         Ok(response.envelopes)
     }

--- a/xmtp/src/types.rs
+++ b/xmtp/src/types.rs
@@ -57,7 +57,12 @@ pub mod networking {
                 ErrorKind::PublishError => "publish error",
                 ErrorKind::QueryError => "query error",
                 ErrorKind::SubscribeError => "subscribe error",
-            })
+            })?;
+            if self.source().is_some() {
+                f.write_str(": ")?;
+                f.write_str(&self.source().unwrap().to_string())?;
+            }
+            Ok(())
         }
     }
 

--- a/xmtp/src/utils.rs
+++ b/xmtp/src/utils.rs
@@ -14,15 +14,15 @@ pub fn get_current_time_ns() -> u64 {
 }
 
 pub fn build_user_contact_topic(wallet_address: String) -> String {
-    format!("/xmtp/1/contact-{}/proto", wallet_address)
+    format!("/xmtp/3/contact-{}/proto", wallet_address)
 }
 
 pub fn build_user_invite_topic(public_key: String) -> String {
-    format!("xmtp/1/invite-{}/proto", public_key)
+    format!("/xmtp/3/invite-{}/proto", public_key)
 }
 
 pub fn build_installation_message_topic(installation_id: &str) -> String {
-    format!("xmtp/1/message-{}/proto", installation_id)
+    format!("/xmtp/3/message-{}/proto", installation_id)
 }
 
 pub fn build_envelope(content_topic: String, message: Vec<u8>) -> Envelope {


### PR DESCRIPTION
This PR:
- Defaults the CLI to use the XMTP dev network
- Adds a `--local` option for pointing to localhost instead
- Use `/xmtp/3` endpoints instead of `/xmtp/1` endpoints for consistency with client versioning
- Adds detail to networking errors

This means that external consumers don't have to run a local node in order to run the CLI, and it means the CLI can be tested across multiple machines.

Will land https://github.com/xmtp/xmtp-node-go/pull/286 and verify that the dev network accepts CLI requests before landing this.