### PR TITLE
Warn on diesel:unique_violation

### DIFF
--- a/xmtp/src/conversations.rs
+++ b/xmtp/src/conversations.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use diesel::Connection;
 use futures::executor::block_on;
-use log::info;
+use log::{info, warn};
 use prost::Message;
 use vodozemac::olm::{self, OlmMessage};
 use xmtp_proto::xmtp::{
@@ -101,6 +101,7 @@ where
         self.client
             .store
             .lock_refresh_job(RefreshJobKind::Message, |conn, job| {
+                warn!("{}", self.get_start_time(&job).unsigned_abs());
                 let downloaded =
                     futures::executor::block_on(self.client.download_latest_from_topic(
                         self.get_start_time(&job).unsigned_abs(),


### PR DESCRIPTION
Currently fetching messages from the network uses a `PADDING_TIME_NS` value of 30secs. Refreshing the within that time window leads to a diesel::databaseError being thrown as the decoded message already exists in the database.

This PR handles the uniqueViolation and emits a warning only. 

## Questions
- is 30seconds an appropriate value for `PADDING_TIME_NS`?