### PR TITLE
Display Messages in CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,8 +602,13 @@ version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
+ "iana-time-zone",
+ "js-sys",
  "num-integer",
  "num-traits",
+ "time 0.1.45",
+ "wasm-bindgen",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2279,6 +2293,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2440,6 +2477,15 @@ dependencies = [
  "io-lifetimes",
  "rustix",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "isolang"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f80f221db1bc708b71128757b9396727c04de86968081e18e89b0575e03be071"
+dependencies = [
+ "phf",
 ]
 
 [[package]]
@@ -4627,6 +4673,17 @@ dependencies = [
 
 [[package]]
 name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "time"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
@@ -4640,6 +4697,16 @@ name = "time-core"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+
+[[package]]
+name = "timeago"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5082dc942361cdfb74eab98bf995762d6015e5bb3a20bf7c5c71213778b4fcb4"
+dependencies = [
+ "chrono",
+ "isolang",
+]
 
 [[package]]
 name = "tiny-keccak"
@@ -5153,6 +5220,12 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -5362,6 +5435,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.0",
+]
 
 [[package]]
 name = "windows-sys"
@@ -5595,6 +5677,7 @@ dependencies = [
  "futures",
  "log",
  "thiserror",
+ "timeago",
  "tokio",
  "url",
  "walletconnect",
@@ -5728,7 +5811,7 @@ dependencies = [
  "hmac",
  "pbkdf2 0.11.0",
  "sha1",
- "time",
+ "time 0.3.21",
  "zstd",
 ]
 

--- a/examples/cli/Cargo.toml
+++ b/examples/cli/Cargo.toml
@@ -22,4 +22,5 @@ walletconnect = {git="https://github.com/nlordell/walletconnect-rs.git", feature
 xmtp = { path = "../../xmtp" }
 xmtp_cryptography = { path = "../../xmtp_cryptography"}
 xmtp_networking = { path = "../../xmtp_networking"}
+timeago = "0.4.1"
 

--- a/examples/cli/README.md
+++ b/examples/cli/README.md
@@ -9,7 +9,7 @@ This is a demo XMTP v3-alpha console client (CLI) that you can use to send and r
 
 ## Send a double ratchet message
 
-Use the CLI to send a [double ratchet message](https://github.com/xmtp/libxmtp/blob/main/README.md#double-ratchet-messaging) between test wallets on the XMTP `dev` network. 
+Use the CLI to send a [double ratchet message](https://github.com/xmtp/libxmtp/blob/main/README.md#double-ratchet-messaging) between test wallets on the XMTP `dev` network.
 
 1. Go to the `examples/cli` directory.
 
@@ -37,7 +37,7 @@ Use the CLI to send a [double ratchet message](https://github.com/xmtp/libxmtp/b
    ./xli.sh --db user1.db3 send <user2_address> "hello"
    ```
 
-6. List conversations.
+6. List conversations and messages.
 
    ```bash
    ./xli.sh --db user1.db3 list-conversations

--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -134,22 +134,18 @@ async fn main() {
 
     let cli = Cli::parse();
 
-    match &cli.command {
-        Commands::Register { wallet_seed } => {
-            info!("Register");
-            if let Err(e) = register(&cli, true, wallet_seed).await {
-                error!("Registration failed: {:?}", e)
-            }
+    if let Commands::Register { wallet_seed } = &cli.command {
+        info!("Register");
+        if let Err(e) = register(&cli, true, wallet_seed).await {
+            error!("Registration failed: {:?}", e)
         }
-        _ => (),
+        return;
     }
 
     match &cli.command {
+        #[allow(unused_variables)]
         Commands::Register { wallet_seed } => {
-            info!("Register");
-            if let Err(e) = register(&cli, true, wallet_seed).await {
-                error!("Registration failed: {:?}", e)
-            }
+            unreachable!()
         }
         Commands::Info {} => {
             info!("Info");

--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -11,15 +11,19 @@ use ethers_core::types::H160;
 use log::{error, info};
 use std::fs;
 use std::path::PathBuf;
+use std::time::Duration;
 use thiserror::Error;
 use url::ParseError;
 use walletconnect::client::{CallError, ConnectorError, SessionError};
 use walletconnect::{qr, Client as WcClient, Metadata};
 use xmtp::builder::{AccountStrategy, ClientBuilderError};
 use xmtp::client::ClientError;
-use xmtp::conversation::ConversationError;
+use xmtp::conversation::{ConversationError, ListMessagesOptions, SecretConversation};
 use xmtp::conversations::Conversations;
-use xmtp::storage::{EncryptedMessageStore, EncryptionKey, StorageError, StorageOption};
+use xmtp::storage::{
+    now, EncryptedMessageStore, EncryptionKey, MessageState, StorageError, StorageOption,
+};
+use xmtp::types::networking::XmtpApiClient;
 use xmtp::InboxOwner;
 use xmtp_cryptography::signature::{h160addr_to_string, RecoverableSignature, SignatureError};
 use xmtp_cryptography::utils::{rng, seeded_rng, LocalWallet};
@@ -86,8 +90,21 @@ enum CliError {
     ClientBuilder(#[from] ClientBuilderError),
     #[error("ConversationError: {0}")]
     ConversationError(#[from] ConversationError),
+    #[error("generic:{0}")]
+    Generic(String),
 }
 
+impl From<String> for CliError {
+    fn from(value: String) -> Self {
+        Self::Generic(value)
+    }
+}
+
+impl From<&str> for CliError {
+    fn from(value: &str) -> Self {
+        Self::Generic(value.to_string())
+    }
+}
 /// This is an abstraction which allows the CLI to choose between different wallet types.
 enum Wallet {
     WalletConnectWallet(WalletConnectWallet),
@@ -124,6 +141,16 @@ async fn main() {
                 error!("Registration failed: {:?}", e)
             }
         }
+        _ => (),
+    }
+
+    match &cli.command {
+        Commands::Register { wallet_seed } => {
+            info!("Register");
+            if let Err(e) = register(&cli, true, wallet_seed).await {
+                error!("Registration failed: {:?}", e)
+            }
+        }
         Commands::Info {} => {
             info!("Info");
             let client = create_client(&cli, AccountStrategy::CachedOnly("nil".into()))
@@ -136,10 +163,19 @@ async fn main() {
             let client = create_client(&cli, AccountStrategy::CachedOnly("nil".into()))
                 .await
                 .unwrap();
+
+            recv(&client).await.unwrap();
             let conversations = Conversations::new(&client);
             let convo_list = conversations.list(true).await.unwrap();
+
             for (index, convo) in convo_list.iter().enumerate() {
-                info!(" [{}] Convo with {}", index, convo.peer_address());
+                info!(
+                    "====== [{}] Convo with {} ======{}{}",
+                    index,
+                    convo.peer_address(),
+                    "\n",
+                    format_messages(convo).await.unwrap()
+                );
             }
         }
         Commands::Send { addr, msg } => {
@@ -252,6 +288,34 @@ async fn recv(client: &Client) -> Result<(), CliError> {
     Ok(())
 }
 
+async fn format_messages<'c, A: XmtpApiClient>(
+    convo: &SecretConversation<'c, A>,
+) -> Result<String, CliError> {
+    let mut output: Vec<String> = vec![];
+    let opts = ListMessagesOptions::default();
+
+    for msg in convo.list_messages(&opts).await? {
+        let contents = msg.get_text().map_err(|e| e.to_string())?;
+        let is_inbound = msg.state == MessageState::Received as i32;
+        let direction = if is_inbound {
+            String::from("    -------->")
+        } else {
+            String::from("<--------    ")
+        };
+
+        let msg_line = format!(
+            "[{:>15} ]    {}       {}",
+            pretty_delta(now() as u64, msg.created_at as u64),
+            direction,
+            contents
+        );
+        output.push(msg_line);
+    }
+    output.reverse();
+
+    Ok(output.join("\n"))
+}
+
 fn static_enc_key() -> EncryptionKey {
     [2u8; 32]
 }
@@ -271,6 +335,11 @@ fn get_encrypted_store(db: &Option<PathBuf>) -> Result<EncryptedMessageStore, Cl
     };
 
     store.map_err(|e| e.into())
+}
+
+fn pretty_delta(now: u64, then: u64) -> String {
+    let f = timeago::Formatter::new();
+    f.convert(Duration::from_nanos(now - then))
 }
 
 /// This wraps a Walletconnect::client into a struct which could be used in the xmtp::client.

--- a/xmtp/src/lib.rs
+++ b/xmtp/src/lib.rs
@@ -24,6 +24,8 @@ pub use client::{Client, Network};
 use storage::StorageError;
 use xmtp_cryptography::signature::{RecoverableSignature, SignatureError};
 
+pub use codecs::{text::TextCodec, ContentCodec};
+
 pub trait Signable {
     fn bytes_to_sign(&self) -> Vec<u8>;
 }


### PR DESCRIPTION
This PR makes updated to the CLI to make it more usable for testing. 

- check for messages on 'list-conversations'
- Display encoded message contents 


Example: 
![image](https://github.com/xmtp/libxmtp/assets/473256/5d906157-6108-4f87-9183-4e44630417f9)


Note: Currently assumes that only Text EncodedPayloads are present