### PR TITLE
Change session handling

### DIFF
--- a/xmtp/README.md
+++ b/xmtp/README.md
@@ -192,28 +192,31 @@ process_inbound_messages():
         If the payload is malformed and the proto cannot be decoded:
             Set inbound_invite state to INVALID
             continue
-        If an existing session exists with the `sender.installation_id`:
-            Decrypt the ciphertext using the existing session
+
+        If session from get_session:
+            Decrypt ciphertext using session
             If decryption fails:
                 Set inbound_message state to DECRYPTION_FAILURE
                 continue
-            Update session in the database
-        else:
-            Create a new inbound session with the sender
-            Decrypt the ciphertext using the new session
-            If decryption fails:
-                Set inbound_invite state to DECRYPTION_FAILURE
-                continue
-            Persist the session to the database
-
+            Update/save session in the database
+    
         If message validation fails:
-            Set inbound_invite state to INVALID
+            Set inbound_message state to INVALID
             continue
 
-       
-        persis message
-        Set inbound_invite state to PROCESSED
+        persist message
+        Set inbound_message state to PROCESSED
 
+get_session(message):
+ 
+    For each session with `session.installation_id` == `sender.installation_id`:  // Regardless of message type
+        If the message can be decrypted:
+            return session
+
+    if message.type == Prekey:
+        return new inbound session
+    else:
+        NoSession available -- message cannot be decrypted
 ```
 
 ...


### PR DESCRIPTION
## Problem
The receive path is not currently handing messages correctly, which is resulting in errors when receiving messages. 

The core issue is that new Prekey messages are not creating new sessions when needed, which is leading to decryption failures. The end result is that two installations can never get synchronized if two sessions were created simultaneously.

## Solution
I'm proposing this new receive path which will handle the case where two peers are sending from different sessions. The change here is that PreKey messages should be checked against existing sessions: If no match create a new session.