### PR TITLE
Allow Multiple Sessions

### DIFF
--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -153,6 +153,7 @@ async fn main() {
                 .await
                 .unwrap();
             info!("Address is: {}", client.wallet_address());
+            info!("Installation_id: {}", client.installation_id());
         }
         Commands::ListConversations {} => {
             info!("List Conversations");

--- a/xmtp/migrations/2023-06-03-011250_create_sessions/up.sql
+++ b/xmtp/migrations/2023-06-03-011250_create_sessions/up.sql
@@ -2,6 +2,6 @@ CREATE TABLE IF NOT EXISTS sessions (
     session_id TEXT PRIMARY KEY NOT NULL,
     created_at BIGINT NOT NULL,
     updated_at BIGINT NOT NULL,
-    peer_installation_id TEXT  NOT NULL,
+    peer_installation_id TEXT NOT NULL,
     vmac_session_data BLOB NOT NULL
 )

--- a/xmtp/migrations/2023-06-03-011250_create_sessions/up.sql
+++ b/xmtp/migrations/2023-06-03-011250_create_sessions/up.sql
@@ -1,6 +1,7 @@
 CREATE TABLE IF NOT EXISTS sessions (
     session_id TEXT PRIMARY KEY NOT NULL,
     created_at BIGINT NOT NULL,
+    updated_at BIGINT NOT NULL,
     peer_installation_id TEXT  NOT NULL,
     vmac_session_data BLOB NOT NULL
 )

--- a/xmtp/migrations/2023-06-03-011250_create_sessions/up.sql
+++ b/xmtp/migrations/2023-06-03-011250_create_sessions/up.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS sessions (
-    peer_installation_id TEXT PRIMARY KEY NOT NULL,
-    session_id TEXT NOT NULL,
+    session_id TEXT PRIMARY KEY NOT NULL,
     created_at BIGINT NOT NULL,
+    peer_installation_id TEXT  NOT NULL,
     vmac_session_data BLOB NOT NULL
 )

--- a/xmtp/src/client.rs
+++ b/xmtp/src/client.rs
@@ -160,7 +160,7 @@ where
     ) -> Result<SessionManager, ClientError> {
         let existing_session = self
             .store
-            .get_session_with_conn(&contact.installation_id(), conn)?;
+            .get_latest_session_for_installation(&contact.installation_id(), conn)?;
         match existing_session {
             Some(i) => Ok(SessionManager::try_from(&i)?),
             None => self.create_outbound_session(conn, contact),

--- a/xmtp/src/conversations.rs
+++ b/xmtp/src/conversations.rs
@@ -522,13 +522,13 @@ where
                 let my_sessions = self
                     .client
                     .store
-                    .get_sessions(&self.client.wallet_address(), transaction)?;
+                    .get_latest_sessions(&self.client.wallet_address(), transaction)?;
                 let their_user_addr =
                     peer_addr_from_convo_id(&message.convo_id, &self.client.wallet_address())?;
                 let their_sessions = self
                     .client
                     .store
-                    .get_sessions(&their_user_addr, transaction)?;
+                    .get_latest_sessions(&their_user_addr, transaction)?;
                 if their_sessions.is_empty() {
                     return Err(ConversationError::NoSessions(their_user_addr));
                 }

--- a/xmtp/src/message.rs
+++ b/xmtp/src/message.rs
@@ -30,6 +30,7 @@ pub struct DecodedInboundMessage {
     pub recipient_installation_id: InstallationId,
     pub is_prekey_message: bool,
     pub ciphertext: Vec<u8>,
+    pub sent_at_ns: i64,
 }
 
 impl TryFrom<InboundMessage> for DecodedInboundMessage {
@@ -48,6 +49,7 @@ impl TryFrom<InboundMessage> for DecodedInboundMessage {
             recipient_installation_id: unsealed_header.recipient_installation_id,
             is_prekey_message: unsealed_header.is_prekey_message,
             ciphertext: message_envelope.ciphertext,
+            sent_at_ns: value.sent_at_ns,
         })
     }
 }

--- a/xmtp/src/session.rs
+++ b/xmtp/src/session.rs
@@ -112,8 +112,8 @@ impl TryFrom<&SessionManager> for StoredSession {
 
     fn try_from(value: &SessionManager) -> Result<Self, Self::Error> {
         Ok(StoredSession::new(
-            value.peer_installation_id.clone(),
             value.session.session_id(),
+            value.peer_installation_id.clone(),
             // TODO: Better error handling approach. StoreError and SessionError end up being dependent on eachother
             value
                 .session_bytes()

--- a/xmtp/src/session.rs
+++ b/xmtp/src/session.rs
@@ -66,10 +66,10 @@ impl SessionManager {
 
     pub fn decrypt(
         &mut self,
-        message: OlmMessage,
+        message: &OlmMessage,
         into: &mut DbConnection,
     ) -> Result<Vec<u8>, SessionError> {
-        let res = self.session.decrypt(&message)?;
+        let res = self.session.decrypt(message)?;
 
         self.save(into)?;
 
@@ -162,7 +162,7 @@ mod tests {
                 .unwrap();
 
             let reply = b_to_a_olm_session.session.encrypt("hello to you");
-            let decrypted_reply = a_to_b_session.decrypt(reply, conn).unwrap();
+            let decrypted_reply = a_to_b_session.decrypt(&reply, conn).unwrap();
             assert_eq!(decrypted_reply, "hello to you".as_bytes());
 
             let updated_results: Vec<StoredSession> = conn.fetch_all().unwrap();

--- a/xmtp/src/storage/encrypted_store/mod.rs
+++ b/xmtp/src/storage/encrypted_store/mod.rs
@@ -497,7 +497,7 @@ impl EncryptedMessageStore {
         conn: &mut PooledConnection<ConnectionManager<SqliteConnection>>,
     ) -> Result<(), StorageError> {
         for session in updated_sessions {
-            diesel::update(schema::sessions::table.find(session.peer_installation_id))
+            diesel::update(schema::sessions::table.find(session.session_id))
                 .set(schema::sessions::vmac_session_data.eq(session.vmac_session_data))
                 .get_result::<StoredSession>(conn)?;
         }

--- a/xmtp/src/storage/encrypted_store/mod.rs
+++ b/xmtp/src/storage/encrypted_store/mod.rs
@@ -199,7 +199,7 @@ impl EncryptedMessageStore {
     ) -> Result<Vec<StoredSession>, StorageError> {
         if !is_wallet_address(user_address) {
             return Err(StorageError::Unknown(
-                "incorrectly formatted waleltAddress".into(),
+                "incorrectly formatted walletAddress".into(),
             ));
         }
         let session_list = sql_query("Select sessions.* from
@@ -212,6 +212,7 @@ impl EncryptedMessageStore {
                     )as ids
                 left join sessions on ids.session_id = sessions.session_id
         ").bind::<Text,_>(user_address).load::<StoredSession>(conn).map_err(|e| StorageError::Unknown(e.to_string()))?;
+
         Ok(session_list)
     }
 

--- a/xmtp/src/storage/encrypted_store/models.rs
+++ b/xmtp/src/storage/encrypted_store/models.rs
@@ -163,6 +163,7 @@ pub fn now() -> i64 {
 pub struct StoredSession {
     pub session_id: String,
     pub created_at: i64,
+    pub updated_at: i64,
     pub peer_installation_id: String,
     pub vmac_session_data: Vec<u8>,
     pub user_address: String,
@@ -175,10 +176,12 @@ impl StoredSession {
         vmac_session_data: Vec<u8>,
         user_address: String,
     ) -> Self {
+        let now = now();
         Self {
             session_id,
             peer_installation_id,
-            created_at: now(),
+            created_at: now,
+            updated_at: now,
             vmac_session_data,
             user_address,
         }
@@ -192,6 +195,7 @@ impl Save<DbConnection> for StoredSession {
             .set((
                 sessions::vmac_session_data.eq(&self.vmac_session_data),
                 sessions::peer_installation_id.eq(&self.peer_installation_id),
+                sessions::updated_at.eq(now()),
             ))
             .execute(into)?;
 

--- a/xmtp/src/storage/encrypted_store/models.rs
+++ b/xmtp/src/storage/encrypted_store/models.rs
@@ -170,14 +170,14 @@ pub struct StoredSession {
 
 impl StoredSession {
     pub fn new(
-        peer_installation_id: String,
         session_id: String,
+        peer_installation_id: String,
         vmac_session_data: Vec<u8>,
         user_address: String,
     ) -> Self {
         Self {
-            peer_installation_id,
             session_id,
+            peer_installation_id,
             created_at: now(),
             vmac_session_data,
             user_address,

--- a/xmtp/src/storage/encrypted_store/models.rs
+++ b/xmtp/src/storage/encrypted_store/models.rs
@@ -157,7 +157,7 @@ pub fn now() -> i64 {
         .as_nanos() as i64
 }
 
-#[derive(Insertable, Identifiable, Queryable, Clone, PartialEq, Debug)]
+#[derive(Insertable, Identifiable, Queryable, Clone, PartialEq, Debug, QueryableByName)]
 #[diesel(table_name = sessions)]
 #[diesel(primary_key(session_id))]
 pub struct StoredSession {

--- a/xmtp/src/storage/encrypted_store/schema.rs
+++ b/xmtp/src/storage/encrypted_store/schema.rs
@@ -81,6 +81,7 @@ diesel::table! {
     sessions (session_id) {
         session_id -> Text,
         created_at -> BigInt,
+        updated_at -> BigInt,
         peer_installation_id -> Text,
         vmac_session_data -> Binary,
         user_address -> Text,

--- a/xmtp/src/storage/encrypted_store/schema.rs
+++ b/xmtp/src/storage/encrypted_store/schema.rs
@@ -78,7 +78,7 @@ diesel::table! {
 }
 
 diesel::table! {
-    sessions (peer_installation_id) {
+    sessions (session_id) {
         session_id -> Text,
         created_at -> BigInt,
         peer_installation_id -> Text,

--- a/xmtp/src/utils.rs
+++ b/xmtp/src/utils.rs
@@ -40,3 +40,18 @@ pub fn base64_encode(bytes: &[u8]) -> String {
 pub fn key_fingerprint(key: &Curve25519PublicKey) -> String {
     base64_encode(keccak256(key.to_string().as_str()).as_slice())
 }
+
+pub fn is_wallet_address(address: &str) -> bool {
+    if !address.starts_with("0x") {
+        return false;
+    }
+
+    if address.len() != 42 {
+        return false;
+    }
+
+    if !address.chars().all(|c| char::is_ascii_hexdigit(&c)) {
+        return false;
+    }
+    return true;
+}

--- a/xmtp/src/utils.rs
+++ b/xmtp/src/utils.rs
@@ -50,8 +50,8 @@ pub fn is_wallet_address(address: &str) -> bool {
         return false;
     }
 
-    if !address.chars().all(|c| char::is_ascii_hexdigit(&c)) {
+    if !address[2..].chars().all(|c| char::is_ascii_hexdigit(&c)) {
         return false;
     }
-    return true;
+    true
 }


### PR DESCRIPTION
This PR implements the approach in #200 

The major change is that the sessions table now contains multiple sessions for a given peer_installation_id. As a heuristic the most recently updated sessions is the the one that should be used for outdoing messages.

Note: This breaks existing installations. All previous installations should be deleted to ensure consistency 