### PR TITLE
Refresh only on send

### DIFF
--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -64,8 +64,6 @@ enum Commands {
         msg: String,
     },
     Recv {},
-
-    Refresh {},
     ListContacts {},
     Clear {},
 }
@@ -189,16 +187,6 @@ async fn main() {
                 .unwrap();
             info!("Address is: {}", client.wallet_address());
             recv(&client).await.unwrap();
-        }
-        Commands::Refresh {} => {
-            info!("Refresh");
-            let client = create_client(&cli, AccountStrategy::CachedOnly("nil".into()))
-                .await
-                .unwrap();
-            client
-                .refresh_user_installations(&client.wallet_address())
-                .await
-                .unwrap();
         }
         Commands::ListContacts {} => {
             let client = create_client(&cli, AccountStrategy::CachedOnly("nil".into()))

--- a/xmtp/src/client.rs
+++ b/xmtp/src/client.rs
@@ -118,9 +118,6 @@ where
             self.publish_user_contact().await?;
         }
 
-        self.refresh_user_installations(&app_contact_bundle.wallet_address)
-            .await?;
-
         self.is_initialized = true;
         Ok(())
     }

--- a/xmtp/src/conversation.rs
+++ b/xmtp/src/conversation.rs
@@ -190,9 +190,6 @@ where
     }
 
     pub async fn initialize(&self) -> Result<(), ConversationError> {
-        self.client
-            .refresh_user_installations(self.peer_address().as_str())
-            .await?;
         let inner_invite_bytes = Invitation::build_inner_invite_bytes(self.peer_address.clone())?;
         let conn = &mut self.client.store.conn()?;
         for contact in self.members(conn)?.iter() {

--- a/xmtp/src/conversations.rs
+++ b/xmtp/src/conversations.rs
@@ -498,6 +498,8 @@ where
     ) -> Result<(), ConversationError> {
         let peer_address =
             peer_addr_from_convo_id(&message.convo_id, &self.client.wallet_address())?;
+
+        // Refresh remote installations
         self.client
             .refresh_user_installations_if_stale(&peer_address)
             .await?;
@@ -547,6 +549,7 @@ where
     }
 
     pub async fn process_outbound_messages(&self) -> Result<(), ConversationError> {
+        //Update self installations
         self.client
             .refresh_user_installations_if_stale(&self.client.wallet_address())
             .await?;

--- a/xmtp/src/conversations.rs
+++ b/xmtp/src/conversations.rs
@@ -549,7 +549,7 @@ where
     }
 
     pub async fn process_outbound_messages(&self) -> Result<(), ConversationError> {
-        //Update self installations
+        //Refresh self installations
         self.client
             .refresh_user_installations_if_stale(&self.client.wallet_address())
             .await?;


### PR DESCRIPTION

## Problem 
Currently libxmtp refreshes installations On Client:initialization, conversation:Initialization and message sending. 

This change isn't strictly a problem but does add complexity around when sessions are initiated.

## Solution 
Refresh installations only on send. Currently Send is the only time when new installations are needed. 
- Receive uses existing sessions or creates a new one from a prekey message. 
- Installation management is not implemented yet. 

To cut down on complexity and help with debugging for the time being, this PR updates the library to only refresh on send.