### PR TITLE
Ensure Invites Sent

### DIFF
--- a/bindings_ffi/src/lib.rs
+++ b/bindings_ffi/src/lib.rs
@@ -114,9 +114,8 @@ impl FfiConversations {
         let conversations = xmtp::conversations::Conversations::new(self.inner_client.as_ref());
         let convo = conversations
             .new_secret_conversation(wallet_address)
+            .await
             .map_err(|e| e.to_string())?;
-        // TODO: This should happen as part of `new_secret_conversation` and should only send to new participants
-        convo.initialize().await.map_err(|e| e.to_string())?;
 
         let out = Arc::new(FfiConversation {
             inner_client: self.inner_client.clone(),

--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -256,8 +256,8 @@ async fn send(client: Client, addr: &str, msg: &String) -> Result<(), CliError> 
     let conversations = Conversations::new(&client);
     let conversation = conversations
         .new_secret_conversation(addr.to_string())
+        .await
         .unwrap();
-    conversation.initialize().await.unwrap();
     conversation.send_message(msg).unwrap();
     conversations.process_outbound_messages().await.unwrap();
     info!("Message successfully sent");

--- a/xmtp/migrations/2023-06-30-063813_create_users_and_conversations/up.sql
+++ b/xmtp/migrations/2023-06-30-063813_create_users_and_conversations/up.sql
@@ -7,6 +7,5 @@ CREATE TABLE conversations (
   convo_id TEXT PRIMARY KEY NOT NULL,
   peer_address TEXT NOT NULL,
   created_at BIGINT NOT NULL,
-  convo_state INTEGER NOT NULL,
   FOREIGN KEY(peer_address) REFERENCES users(user_address)
 );

--- a/xmtp/migrations/2023-08-21-234651_conversation_invite/down.sql
+++ b/xmtp/migrations/2023-08-21-234651_conversation_invite/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE conversation_invites;

--- a/xmtp/migrations/2023-08-21-234651_conversation_invite/up.sql
+++ b/xmtp/migrations/2023-08-21-234651_conversation_invite/up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE conversation_invites (
+    installation_id TEXT NOT NULL,
+    conversation_id TEXT NOT NULL,
+    created_at_ns BIGINT NOT NULL,
+    direction SMALLINT NOT NULL,
+    PRIMARY KEY (installation_id, conversation_id)
+);

--- a/xmtp/src/conversation.rs
+++ b/xmtp/src/conversation.rs
@@ -6,9 +6,8 @@ use crate::{
     message::PayloadError,
     session::SessionError,
     storage::{
-        now, ConversationInvite, ConversationInviteDirection, ConversationState, DbConnection,
-        MessageState, NewStoredMessage, StorageError, StoredConversation, StoredMessage,
-        StoredUser,
+        now, ConversationInvite, ConversationInviteDirection, DbConnection, MessageState,
+        NewStoredMessage, StorageError, StoredConversation, StoredMessage, StoredUser,
     },
     types::networking::PublishRequest,
     types::networking::XmtpApiClient,
@@ -134,7 +133,6 @@ where
                 peer_address: obj.peer_address(),
                 convo_id: obj.convo_id(),
                 created_at: now(),
-                convo_state: ConversationState::Uninitialized as i32,
             },
         )?;
 
@@ -255,12 +253,6 @@ where
                 ConversationInvite::new(id, self.convo_id(), ConversationInviteDirection::Outbound),
             )?;
         }
-
-        self.client.store.set_conversation_state(
-            conn,
-            self.convo_id().as_str(),
-            ConversationState::Invited,
-        )?;
 
         Ok(())
     }

--- a/xmtp/src/conversation.rs
+++ b/xmtp/src/conversation.rs
@@ -216,7 +216,7 @@ where
             })
             .collect::<Vec<Contact>>();
 
-        if to_invite.len() == 0 {
+        if to_invite.is_empty() {
             return Ok(());
         }
 

--- a/xmtp/src/conversations.rs
+++ b/xmtp/src/conversations.rs
@@ -20,10 +20,10 @@ use crate::{
     message::DecodedInboundMessage,
     session::SessionManager,
     storage::{
-        now, ConversationInvite, ConversationInviteDirection, ConversationState, DbConnection,
-        InboundInvite, InboundInviteStatus, InboundMessage, InboundMessageStatus, MessageState,
-        NewStoredMessage, OutboundPayloadState, RefreshJob, RefreshJobKind, StorageError,
-        StoredConversation, StoredMessage, StoredOutboundPayload, StoredSession, StoredUser,
+        now, ConversationInvite, ConversationInviteDirection, DbConnection, InboundInvite,
+        InboundInviteStatus, InboundMessage, InboundMessageStatus, MessageState, NewStoredMessage,
+        OutboundPayloadState, RefreshJob, RefreshJobKind, StorageError, StoredConversation,
+        StoredMessage, StoredOutboundPayload, StoredSession, StoredUser,
     },
     types::networking::XmtpApiClient,
     utils::{base64_encode, build_installation_message_topic},
@@ -70,13 +70,7 @@ where
 
         let mut secret_convos: Vec<SecretConversation<A>> = vec![];
 
-        let convos: Vec<StoredConversation> = self.client.store.get_conversations(
-            conn,
-            vec![
-                ConversationState::InviteReceived,
-                ConversationState::Invited,
-            ],
-        )?;
+        let convos: Vec<StoredConversation> = self.client.store.get_conversations(conn)?;
         log::debug!("Retrieved {:?} convos from the database", convos.len());
         for convo in convos {
             let peer_address =
@@ -396,7 +390,6 @@ where
                 convo_id: conversation_id.clone(),
                 peer_address,
                 created_at: now(),
-                convo_state: ConversationState::InviteReceived as i32,
             },
         )?;
 

--- a/xmtp/src/storage/encrypted_store/models.rs
+++ b/xmtp/src/storage/encrypted_store/models.rs
@@ -338,6 +338,37 @@ impl From<Envelope> for InboundInvite {
     }
 }
 
+#[derive(Clone, Debug)]
+pub enum ConversationInviteDirection {
+    Inbound = 0,
+    Outbound = 1,
+}
+
+#[derive(Insertable, Identifiable, Queryable, Clone, PartialEq, Debug)]
+#[diesel(primary_key(installation_id, conversation_id))]
+#[diesel(table_name = conversation_invites)]
+pub struct ConversationInvite {
+    pub installation_id: String,
+    pub conversation_id: String,
+    pub created_at_ns: i64,
+    pub direction: i16,
+}
+
+impl ConversationInvite {
+    pub fn new(
+        installation_id: String,
+        conversation_id: String,
+        direction: ConversationInviteDirection,
+    ) -> Self {
+        Self {
+            installation_id,
+            conversation_id,
+            created_at_ns: now(),
+            direction: direction as i16,
+        }
+    }
+}
+
 #[derive(Insertable, Identifiable, Queryable, Clone, PartialEq, Debug)]
 #[diesel(table_name = inbound_messages)]
 pub struct InboundMessage {

--- a/xmtp/src/storage/encrypted_store/models.rs
+++ b/xmtp/src/storage/encrypted_store/models.rs
@@ -22,12 +22,6 @@ pub struct StoredUser {
     pub last_refreshed: i64,
 }
 
-pub enum ConversationState {
-    Uninitialized = 0,
-    Invited = 10,
-    InviteReceived = 20,
-}
-
 #[derive(Insertable, Identifiable, Selectable, Queryable, PartialEq, Debug, Clone)]
 #[diesel(table_name = conversations)]
 #[diesel(primary_key(convo_id))]
@@ -35,7 +29,6 @@ pub struct StoredConversation {
     pub convo_id: String,
     pub peer_address: String, // links to users table
     pub created_at: i64,
-    pub convo_state: i32, // ConversationState
 }
 
 pub enum MessageState {

--- a/xmtp/src/storage/encrypted_store/schema.rs
+++ b/xmtp/src/storage/encrypted_store/schema.rs
@@ -22,7 +22,6 @@ diesel::table! {
         convo_id -> Text,
         peer_address -> Text,
         created_at -> BigInt,
-        convo_state -> Integer,
     }
 }
 

--- a/xmtp/src/storage/encrypted_store/schema.rs
+++ b/xmtp/src/storage/encrypted_store/schema.rs
@@ -9,6 +9,15 @@ diesel::table! {
 }
 
 diesel::table! {
+    conversation_invites (installation_id, conversation_id) {
+        installation_id -> Text,
+        conversation_id -> Text,
+        created_at_ns -> BigInt,
+        direction -> SmallInt,
+    }
+}
+
+diesel::table! {
     conversations (convo_id) {
         convo_id -> Text,
         peer_address -> Text,
@@ -101,6 +110,7 @@ diesel::joinable!(installations -> users (user_address));
 
 diesel::allow_tables_to_appear_in_same_query!(
     accounts,
+    conversation_invites,
     conversations,
     inbound_invites,
     inbound_messages,

--- a/xmtp/src/storage/mod.rs
+++ b/xmtp/src/storage/mod.rs
@@ -3,10 +3,10 @@ mod errors;
 
 pub use encrypted_store::{
     models::{
-        now, ConversationInvite, ConversationInviteDirection, ConversationState, InboundInvite,
-        InboundInviteStatus, InboundMessage, InboundMessageStatus, MessageState, NewStoredMessage,
-        OutboundPayloadState, RefreshJob, RefreshJobKind, StoredConversation, StoredInstallation,
-        StoredMessage, StoredOutboundPayload, StoredSession, StoredUser,
+        now, ConversationInvite, ConversationInviteDirection, InboundInvite, InboundInviteStatus,
+        InboundMessage, InboundMessageStatus, MessageState, NewStoredMessage, OutboundPayloadState,
+        RefreshJob, RefreshJobKind, StoredConversation, StoredInstallation, StoredMessage,
+        StoredOutboundPayload, StoredSession, StoredUser,
     },
     DbConnection, EncryptedMessageStore, EncryptionKey, StorageOption,
 };

--- a/xmtp/src/storage/mod.rs
+++ b/xmtp/src/storage/mod.rs
@@ -3,10 +3,10 @@ mod errors;
 
 pub use encrypted_store::{
     models::{
-        now, ConversationState, InboundInvite, InboundInviteStatus, InboundMessage,
-        InboundMessageStatus, MessageState, NewStoredMessage, OutboundPayloadState, RefreshJob,
-        RefreshJobKind, StoredConversation, StoredInstallation, StoredMessage,
-        StoredOutboundPayload, StoredSession, StoredUser,
+        now, ConversationInvite, ConversationInviteDirection, ConversationState, InboundInvite,
+        InboundInviteStatus, InboundMessage, InboundMessageStatus, MessageState, NewStoredMessage,
+        OutboundPayloadState, RefreshJob, RefreshJobKind, StoredConversation, StoredInstallation,
+        StoredMessage, StoredOutboundPayload, StoredSession, StoredUser,
     },
     DbConnection, EncryptedMessageStore, EncryptionKey, StorageOption,
 };

--- a/xmtp/src/test_utils.rs
+++ b/xmtp/src/test_utils.rs
@@ -37,9 +37,8 @@ pub mod test_utils {
     ) -> SecretConversation<'c, A> {
         let convo = conversations
             .new_secret_conversation(peer_address.to_string())
+            .await
             .unwrap();
-
-        convo.initialize().await.unwrap();
 
         convo
     }


### PR DESCRIPTION
## Summary

- Overhauls conversation initialization to only send invites to `installation_id`s that have not already been invited by this installation. If an invite has been received, or has previously been sent to, the `installation_id` it will be skipped
- Completely removes the concept of "conversation state", as it is no longer a binary "is initialized" or not. As peers are added to the conversation invites can be sent incrementally.
- Calls `conversation.initialize` as part of `new_secret_conversation`

## Notes

This approach ensures that any new installation will receive an invite. But it does mean that each installation can receive more than one invite for a given conversation.

For example let's say the following installations exist: A1, A2, B1, B2.

A1 initiates the conversation and will send invites to A2, B1, and B2. Great. Everyone has an invite.

In this model, A2 will also send invites to B1 and B2 the first time it loads the conversation, unless they have already received an invite from B1 or B2.
B1 and B2 will send invites to A2 and B2 on first load, unless they have already received an invite from A2 or B2 first.

This is needlessly inefficient, but will ensure that if a B3 is added later that they will be added to the conversation as soon as ANY other member of the conversation initializes the conversation.

I'm open to suggestions for a more direct and efficient approach that also guarantees everyone gets an invite. One possible follow-on is to take @richardhuaaa's suggestion of bundling the invitation and a message. This would tie the invites to something that had to be sent anyways (but at the cost of making a new installation unaware of a conversation until the next message is sent).