### PR TITLE
Simplify external API interface

### DIFF
--- a/bindings_ffi/src/lib.rs
+++ b/bindings_ffi/src/lib.rs
@@ -174,8 +174,6 @@ impl FfiConversation {
             self.inner_client.as_ref(),
             self.peer_address.clone(),
         );
-        let conversations = xmtp::conversations::Conversations::new(self.inner_client.as_ref());
-
         conversation
             .send(content_bytes)
             .await

--- a/bindings_ffi/src/lib.rs
+++ b/bindings_ffi/src/lib.rs
@@ -178,10 +178,6 @@ impl FfiConversation {
 
         conversation
             .send(content_bytes)
-            .map_err(|e| e.to_string())?;
-
-        conversations
-            .process_outbound_messages()
             .await
             .map_err(|e| e.to_string())?;
 

--- a/bindings_ffi/src/lib.rs
+++ b/bindings_ffi/src/lib.rs
@@ -174,6 +174,8 @@ impl FfiConversation {
             self.inner_client.as_ref(),
             self.peer_address.clone(),
         );
+        let conversations = xmtp::conversations::Conversations::new(self.inner_client.as_ref());
+
         conversation
             .send(content_bytes)
             .await

--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -258,8 +258,7 @@ async fn send(client: Client, addr: &str, msg: &String) -> Result<(), CliError> 
         .new_secret_conversation(addr.to_string())
         .unwrap();
     conversation.initialize().await.unwrap();
-    conversation.send_text(msg).unwrap();
-    conversations.process_outbound_messages().await.unwrap();
+    conversation.send_text(msg).await.unwrap();
     info!("Message successfully sent");
 
     Ok(())

--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -266,8 +266,7 @@ async fn send(client: Client, addr: &str, msg: &String) -> Result<(), CliError> 
 
 async fn recv(client: &Client) -> Result<(), CliError> {
     let conversations = Conversations::new(client);
-    conversations.save_inbound_messages()?;
-    conversations.process_inbound_messages()?;
+    conversations.receive()?;
 
     Ok(())
 }

--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -160,8 +160,7 @@ async fn main() {
                 .unwrap();
 
             recv(&client).await.unwrap();
-            let conversations = Conversations::new(&client);
-            let convo_list = conversations.list(true).await.unwrap();
+            let convo_list = Conversations::list(&client, true).await.unwrap();
 
             for (index, convo) in convo_list.iter().enumerate() {
                 info!(
@@ -253,10 +252,7 @@ async fn register(cli: &Cli, use_local_db: bool, wallet_seed: &u64) -> Result<()
 }
 
 async fn send(client: Client, addr: &str, msg: &String) -> Result<(), CliError> {
-    let conversations = Conversations::new(&client);
-    let conversation = conversations
-        .new_secret_conversation(addr.to_string())
-        .unwrap();
+    let conversation = SecretConversation::new(&client, addr.to_string()).unwrap();
     conversation.initialize().await.unwrap();
     conversation.send_text(msg).await.unwrap();
     info!("Message successfully sent");
@@ -265,9 +261,7 @@ async fn send(client: Client, addr: &str, msg: &String) -> Result<(), CliError> 
 }
 
 async fn recv(client: &Client) -> Result<(), CliError> {
-    let conversations = Conversations::new(client);
-    conversations.receive()?;
-
+    Conversations::receive(client)?;
     Ok(())
 }
 

--- a/xmtp/src/client.rs
+++ b/xmtp/src/client.rs
@@ -1,37 +1,27 @@
 use core::fmt;
-use std::{fmt::Formatter, time::Duration};
+use std::fmt::Formatter;
 
 use diesel::Connection;
 use log::{debug, info};
-use prost::Message;
 use thiserror::Error;
-use vodozemac::olm::{self, PreKeyMessage};
+use vodozemac::olm::PreKeyMessage;
 
 use crate::{
     account::Account,
     contact::{Contact, ContactError},
-    conversation::peer_addr_from_convo_id,
+    conversations::Conversations,
     session::SessionManager,
     storage::{
-        now, DbConnection, EncryptedMessageStore, MessageState, OutboundPayloadState, StorageError,
-        StoredInstallation, StoredMessage, StoredOutboundPayload, StoredSession, StoredUser,
+        now, DbConnection, EncryptedMessageStore, StorageError, StoredInstallation, StoredSession,
+        StoredUser,
     },
     types::networking::{PublishRequest, QueryRequest, XmtpApiClient},
     types::Address,
-    utils::{
-        base64_encode, build_envelope, build_installation_message_topic, build_user_contact_topic,
-        key_fingerprint,
-    },
+    utils::{build_envelope, build_user_contact_topic, key_fingerprint},
     Store,
 };
 use std::collections::HashMap;
-use xmtp_proto::xmtp::{
-    message_api::v1::Envelope,
-    v3::message_contents::{
-        EdDsaSignature, PadlockMessageEnvelope, PadlockMessageHeader, PadlockMessagePayload,
-        PadlockMessagePayloadVersion, PadlockMessageSealedMetadata,
-    },
-};
+use xmtp_proto::xmtp::message_api::v1::Envelope;
 
 const INSTALLATION_REFRESH_INTERVAL_NS: i64 = 0;
 
@@ -57,8 +47,6 @@ pub enum ClientError {
     QueryError(#[from] crate::types::networking::Error),
     #[error("generic:{0}")]
     Generic(String),
-    #[error("No sessions for user: {0}")]
-    NoSessions(String),
 }
 
 impl From<String> for ClientError {
@@ -134,7 +122,8 @@ where
         self.is_initialized = true;
 
         // Send any unsent messages
-        if let Err(err) = self.process_outbound_messages().await {
+        let conversations = Conversations::new(&self);
+        if let Err(err) = conversations.process_outbound_messages().await {
             log::error!("Could not process outbound messages on init: {:?}", err)
         }
 
@@ -388,184 +377,16 @@ where
         }
         Ok(None)
     }
-
-    fn create_outbound_payload(
-        &self,
-        session: &mut SessionManager,
-        message: &StoredMessage,
-    ) -> Result<StoredOutboundPayload, ClientError> {
-        let is_prekey_message = !session.has_received_message();
-
-        let metadata = PadlockMessageSealedMetadata {
-            sender_user_address: self.wallet_address(),
-            sender_installation_id: self.account.contact().installation_id(),
-            recipient_user_address: session.user_address(),
-            recipient_installation_id: session.installation_id(),
-            is_prekey_message,
-        };
-        // TODO encrypted sealed metadata using sealed sender
-        let sealed_metadata = metadata.encode_to_vec();
-        let message_header = PadlockMessageHeader {
-            sent_ns: message.created_at as u64,
-            sealed_metadata,
-        };
-        let header_bytes = message_header.encode_to_vec();
-        // TODO expose a vmac method to sign bytes rather than string
-        // https://matrix-org.github.io/vodozemac/vodozemac/olm/struct.Account.html#method.sign
-        let header_signature = self.account.sign(&base64_encode(&header_bytes));
-        let header_signature = EdDsaSignature {
-            bytes: header_signature.to_bytes().to_vec(),
-        };
-
-        let payload = PadlockMessagePayload {
-            message_version: PadlockMessagePayloadVersion::One as i32,
-            header_signature: Some(header_signature),
-            convo_id: message.convo_id.clone(),
-            content_bytes: message.content.clone(),
-        };
-        let olm_message = session.encrypt(&payload.encode_to_vec());
-
-        let ciphertext = match olm_message {
-            olm::OlmMessage::Normal(message) => message.to_bytes(),
-            olm::OlmMessage::PreKey(prekey_message) => prekey_message.to_bytes(),
-        };
-        let envelope: PadlockMessageEnvelope = PadlockMessageEnvelope {
-            header_bytes,
-            ciphertext,
-        };
-        Ok(StoredOutboundPayload::new(
-            message.created_at,
-            build_installation_message_topic(&session.installation_id()),
-            envelope.encode_to_vec(),
-            OutboundPayloadState::Pending as i32,
-            0,
-        ))
-    }
-
-    pub async fn process_outbound_message(
-        &self,
-        message: &StoredMessage,
-    ) -> Result<(), ClientError> {
-        let peer_address = peer_addr_from_convo_id(&message.convo_id, &self.wallet_address())
-            .map_err(|e| e.to_string())?;
-
-        // Refresh remote installations
-        self.refresh_user_installations_if_stale(&peer_address)
-            .await?;
-        self.store
-            .conn()
-            .unwrap()
-            .transaction(|transaction| -> Result<(), ClientError> {
-                let my_sessions = self
-                    .store
-                    .get_latest_sessions(&self.wallet_address(), transaction)?;
-                let their_user_addr =
-                    peer_addr_from_convo_id(&message.convo_id, &self.wallet_address())
-                        .map_err(|e| e.to_string())?;
-                let their_sessions = self
-                    .store
-                    .get_latest_sessions(&their_user_addr, transaction)?;
-                if their_sessions.is_empty() {
-                    return Err(ClientError::NoSessions(their_user_addr));
-                }
-
-                let mut outbound_payloads = Vec::new();
-                let mut updated_sessions = Vec::new();
-                for stored_session in my_sessions.iter().chain(&their_sessions) {
-                    if stored_session.peer_installation_id
-                        == self.account.contact().installation_id()
-                    {
-                        continue;
-                    }
-                    let mut session = SessionManager::try_from(stored_session)?;
-                    let outbound_payload = self.create_outbound_payload(&mut session, message)?;
-                    let updated_session = StoredSession::try_from(&session)?;
-                    outbound_payloads.push(outbound_payload);
-                    updated_sessions.push(updated_session);
-                }
-
-                self.store.commit_outbound_payloads_for_message(
-                    message.id,
-                    MessageState::LocallyCommitted,
-                    outbound_payloads,
-                    updated_sessions,
-                    transaction,
-                )?;
-                Ok(())
-            })?;
-
-        Ok(())
-    }
-
-    pub async fn process_outbound_messages(&self) -> Result<(), ClientError> {
-        //Refresh self installations
-        self.refresh_user_installations_if_stale(&self.wallet_address())
-            .await?;
-        let mut messages = self.store.get_unprocessed_messages()?;
-        log::debug!("Processing {} messages", messages.len());
-        messages.sort_by(|a, b| a.created_at.cmp(&b.created_at));
-        for message in messages {
-            if let Err(e) = self.process_outbound_message(&message).await {
-                log::error!(
-                    "Couldn't process message with ID {} because of error: {:?}",
-                    message.id,
-                    e
-                );
-                // TODO update message status to failed on non-retryable errors so that we don't retry it next time
-            }
-        }
-
-        self.publish_outbound_payloads().await?;
-        Ok(())
-    }
-
-    pub async fn publish_outbound_payloads(&self) -> Result<(), ClientError> {
-        let unsent_payloads = self.store.fetch_and_lock_outbound_payloads(
-            OutboundPayloadState::Pending,
-            Duration::from_secs(60).as_nanos() as i64,
-        )?;
-
-        if unsent_payloads.is_empty() {
-            return Ok(());
-        }
-
-        let envelopes = unsent_payloads
-            .iter()
-            .map(|payload| Envelope {
-                content_topic: payload.content_topic.clone(),
-                timestamp_ns: payload.created_at_ns as u64,
-                message: payload.payload.clone(),
-            })
-            .collect();
-
-        // TODO: API tokens
-        self.api_client
-            .publish("".to_string(), PublishRequest { envelopes })
-            .await?;
-
-        let payload_ids = unsent_payloads
-            .iter()
-            .map(|payload| payload.created_at_ns)
-            .collect();
-        self.store.update_and_unlock_outbound_payloads(
-            payload_ids,
-            OutboundPayloadState::ServerAcknowledged,
-        )?;
-        Ok(())
-    }
 }
 
 #[cfg(test)]
 mod tests {
-    use prost::Message;
     use xmtp_proto::xmtp::v3::message_contents::installation_contact_bundle::Version;
     use xmtp_proto::xmtp::v3::message_contents::vmac_unsigned_public_key::Union::Curve25519;
     use xmtp_proto::xmtp::v3::message_contents::vmac_unsigned_public_key::VodozemacCurve25519;
 
-    use crate::conversation::convo_id;
-    use crate::storage::{MessageState, StoredMessage};
     use crate::test_utils::test_utils::gen_test_client;
-    use crate::{ClientBuilder, ContentCodec, TextCodec};
+    use crate::ClientBuilder;
 
     #[tokio::test]
     async fn registration() {
@@ -632,36 +453,4 @@ mod tests {
 
     #[tokio::test]
     async fn test_roundtrip_encrypt() {}
-
-    #[tokio::test]
-    async fn create_outbound_payload() {
-        let alice_client = gen_test_client().await;
-        let bob_client = gen_test_client().await;
-
-        let mut session = alice_client
-            .get_session(
-                &mut alice_client.store.conn().unwrap(),
-                &bob_client.account.contact(),
-            )
-            .unwrap();
-
-        let _payload = alice_client
-            .create_outbound_payload(
-                &mut session,
-                &StoredMessage {
-                    id: 0,
-                    created_at: 0,
-                    convo_id: convo_id(alice_client.wallet_address(), bob_client.wallet_address()),
-                    addr_from: alice_client.wallet_address(),
-                    sent_at_ns: 0,
-                    content: TextCodec::encode("Hello world".to_string())
-                        .unwrap()
-                        .encode_to_vec(),
-                    state: MessageState::Unprocessed as i32,
-                },
-            )
-            .unwrap();
-
-        // TODO validate the payload when implementing the receiver side
-    }
 }

--- a/xmtp/src/client.rs
+++ b/xmtp/src/client.rs
@@ -9,6 +9,7 @@ use vodozemac::olm::PreKeyMessage;
 use crate::{
     account::Account,
     contact::{Contact, ContactError},
+    conversations::Conversations,
     session::SessionManager,
     storage::{
         now, DbConnection, EncryptedMessageStore, StorageError, StoredInstallation, StoredSession,
@@ -119,6 +120,13 @@ where
         }
 
         self.is_initialized = true;
+
+        // Send any unsent messages
+        let conversations = Conversations::new(&self);
+        if let Err(err) = conversations.process_outbound_messages().await {
+            log::error!("Could not process outbound messages on init: {:?}", err)
+        }
+
         Ok(())
     }
 

--- a/xmtp/src/client.rs
+++ b/xmtp/src/client.rs
@@ -122,8 +122,7 @@ where
         self.is_initialized = true;
 
         // Send any unsent messages
-        let conversations = Conversations::new(&self);
-        if let Err(err) = conversations.process_outbound_messages().await {
+        if let Err(err) = Conversations::process_outbound_messages(&self).await {
             log::error!("Could not process outbound messages on init: {:?}", err)
         }
 

--- a/xmtp/src/conversation.rs
+++ b/xmtp/src/conversation.rs
@@ -2,7 +2,6 @@ use crate::{
     client::ClientError,
     codecs::{text::TextCodec, CodecError, ContentCodec},
     contact::Contact,
-    conversations::Conversations,
     invitation::{Invitation, InvitationError},
     message::PayloadError,
     session::SessionError,
@@ -37,8 +36,6 @@ pub enum ConversationError {
     Storage(#[from] StorageError),
     #[error("diesel error: {0}")]
     Diesel(#[from] diesel::result::Error),
-    #[error("No sessions for user: {0}")]
-    NoSessions(String),
     #[error("Session: {0}")]
     Session(#[from] SessionError),
     #[error("Network error: {0}")]
@@ -159,8 +156,7 @@ where
         )
         .store(&mut self.client.store.conn().unwrap())?;
 
-        let conversations = Conversations::new(&self.client);
-        if let Err(err) = conversations.process_outbound_messages().await {
+        if let Err(err) = self.client.process_outbound_messages().await {
             log::error!("Could not process outbound messages on init: {:?}", err)
         }
 
@@ -295,9 +291,6 @@ mod tests {
         conversation.initialize().await.unwrap();
         conversation.send_text("Hello, world!").await.unwrap();
         conversation.send_text("Hello, again").await.unwrap();
-
-        conversations.process_outbound_messages().await.unwrap();
-
         let results = conversation
             .list_messages(&ListMessagesOptions::default())
             .await

--- a/xmtp/src/conversations.rs
+++ b/xmtp/src/conversations.rs
@@ -33,41 +33,24 @@ use crate::{
 
 const PADDING_TIME_NS: i64 = 30 * 1000 * 1000 * 1000;
 
-pub struct Conversations<'c, A>
-where
-    A: XmtpApiClient,
-{
-    pub(crate) client: &'c Client<A>,
+pub struct Conversations<A: XmtpApiClient> {
+    _phantom: std::marker::PhantomData<A>,
 }
 
-impl<'c, A> Conversations<'c, A>
-where
-    A: XmtpApiClient,
-{
-    pub fn new(client: &'c Client<A>) -> Self {
-        Self { client }
-    }
-
-    pub fn new_secret_conversation(
-        &self,
-        wallet_address: String,
-    ) -> Result<SecretConversation<A>, ConversationError> {
-        SecretConversation::create(self.client, wallet_address)
-    }
-
+impl<A: XmtpApiClient> Conversations<A> {
     pub async fn list(
-        &self,
+        client: &Client<A>,
         refresh_from_network: bool,
     ) -> Result<Vec<SecretConversation<A>>, ConversationError> {
         if refresh_from_network {
-            self.save_invites()?;
-            self.process_invites()?;
+            Conversations::save_invites(client)?;
+            Conversations::process_invites(client)?;
         }
-        let conn = &mut self.client.store.conn()?;
+        let conn = &mut client.store.conn()?;
 
         let mut secret_convos: Vec<SecretConversation<A>> = vec![];
 
-        let convos: Vec<StoredConversation> = self.client.store.get_conversations(
+        let convos: Vec<StoredConversation> = client.store.get_conversations(
             conn,
             vec![
                 ConversationState::InviteReceived,
@@ -76,50 +59,44 @@ where
         )?;
         log::debug!("Retrieved {:?} convos from the database", convos.len());
         for convo in convos {
-            let peer_address =
-                peer_addr_from_convo_id(&convo.convo_id, &self.client.account.addr())?;
+            let peer_address = peer_addr_from_convo_id(&convo.convo_id, &client.account.addr())?;
 
-            let convo = SecretConversation::new(self.client, peer_address);
+            let convo = SecretConversation::new(client, peer_address)?;
             secret_convos.push(convo);
         }
 
         Ok(secret_convos)
     }
 
-    pub fn receive(&self) -> Result<(), ConversationError> {
-        if self.save_inbound_messages().is_err() {
+    pub fn receive(client: &Client<A>) -> Result<(), ConversationError> {
+        if Conversations::save_inbound_messages(client).is_err() {
             log::warn!("Saving messages did not complete successfully");
         }
-        self.process_inbound_messages()?;
+        Conversations::process_inbound_messages(client)?;
 
         Ok(())
     }
 
-    pub fn save_inbound_messages(&self) -> Result<(), ConversationError> {
-        let inbound_topic = build_installation_message_topic(&self.client.installation_id());
+    pub fn save_inbound_messages(client: &Client<A>) -> Result<(), ConversationError> {
+        let inbound_topic = build_installation_message_topic(&client.installation_id());
 
-        self.client
+        client
             .store
             .lock_refresh_job(RefreshJobKind::Message, |conn, job| {
                 log::debug!(
                     "Refresh messages start time: {}",
-                    self.get_start_time(&job).unsigned_abs()
+                    Conversations::<A>::get_start_time(&job).unsigned_abs()
                 );
-                let downloaded =
-                    futures::executor::block_on(self.client.download_latest_from_topic(
-                        self.get_start_time(&job).unsigned_abs(),
-                        inbound_topic,
-                    ))
-                    .map_err(|e| StorageError::Unknown(e.to_string()))?;
+                let downloaded = futures::executor::block_on(client.download_latest_from_topic(
+                    Conversations::<A>::get_start_time(&job).unsigned_abs(),
+                    inbound_topic,
+                ))
+                .map_err(|e| StorageError::Unknown(e.to_string()))?;
 
                 log::info!("Messages Downloaded:{}", downloaded.len());
 
                 for envelope in downloaded {
-                    if let Err(e) = self
-                        .client
-                        .store
-                        .save_inbound_message(conn, envelope.into())
-                    {
+                    if let Err(e) = client.store.save_inbound_message(conn, envelope.into()) {
                         log::error!("Unable to save message:{}", e);
                     }
                 }
@@ -130,27 +107,24 @@ where
         Ok(())
     }
 
-    pub fn process_inbound_messages(&self) -> Result<(), StorageError> {
-        let conn = &mut self.client.store.conn()?;
+    pub fn process_inbound_messages(client: &Client<A>) -> Result<(), StorageError> {
+        let conn = &mut client.store.conn()?;
         conn.transaction::<_, StorageError, _>(|transaction_manager| {
-            let msgs = self
-                .client
+            let msgs = client
                 .store
                 .get_inbound_messages(transaction_manager, InboundMessageStatus::Pending)?;
             for msg in msgs {
                 let payload_id = msg.id.clone();
-                match self.process_inbound_message(transaction_manager, msg) {
+                match Conversations::process_inbound_message(client, transaction_manager, msg) {
                     Ok(status) => {
                         info!(
                             "message processed: {:?}. Status: {:?}",
                             payload_id,
                             status.clone()
                         );
-                        self.client.store.set_msg_status(
-                            transaction_manager,
-                            payload_id,
-                            status,
-                        )?;
+                        client
+                            .store
+                            .set_msg_status(transaction_manager, payload_id, status)?;
                     }
                     Err(err) => {
                         log::error!("Error processing msg: {:?}", err);
@@ -163,15 +137,14 @@ where
     }
 
     fn process_inbound_message(
-        &self,
+        client: &Client<A>,
         conn: &mut DbConnection,
         msg: InboundMessage,
     ) -> Result<InboundMessageStatus, ConversationError> {
         let payload = DecodedInboundMessage::try_from(msg.clone())?;
         let olm_message = (&payload).try_into()?;
 
-        let existing_sessions = self
-            .client
+        let existing_sessions = client
             .store
             .get_latest_sessions_for_installation(&payload.sender_installation_id, conn)?;
 
@@ -187,7 +160,7 @@ where
 
             match session.decrypt(&olm_message, conn) {
                 Ok(p) => {
-                    self.process_plaintext(conn, &p, &payload)?;
+                    Conversations::process_plaintext(client, conn, &p, &payload)?;
                     return Ok(InboundMessageStatus::Processed);
                 }
                 Err(_) => continue,
@@ -196,7 +169,7 @@ where
 
         // No existing session, attempt to create new session
         if let OlmMessage::PreKey(m) = olm_message {
-            self.process_prekey_message(conn, m, &payload)?;
+            Conversations::process_prekey_message(client, conn, m, &payload)?;
             Ok(InboundMessageStatus::Processed)
         } else {
             log::warn!("Message:{} could not be decrypted", msg.id);
@@ -205,7 +178,7 @@ where
     }
 
     fn process_plaintext(
-        &self,
+        client: &Client<A>,
         conn: &mut DbConnection,
         bytes: &Vec<u8>,
         payload: &DecodedInboundMessage,
@@ -223,7 +196,7 @@ where
             payload.sent_at_ns,
         );
 
-        self.client
+        client
             .store
             .insert_or_ignore_message(conn, stored_message)?;
 
@@ -231,12 +204,12 @@ where
     }
 
     fn process_prekey_message(
-        &self,
+        client: &Client<A>,
         conn: &mut DbConnection,
         msg: olm::PreKeyMessage,
         payload: &DecodedInboundMessage,
     ) -> Result<(), ConversationError> {
-        let network_contact = block_on(self.client.download_contact_for_installation(
+        let network_contact = block_on(client.download_contact_for_installation(
             &payload.sender_address,
             &payload.sender_installation_id,
         ))?;
@@ -250,28 +223,25 @@ where
             }
         };
 
-        let (_, plaintext) = self.client.create_inbound_session(conn, &contact, msg)?;
-        self.process_plaintext(conn, &plaintext, payload)?;
+        let (_, plaintext) = client.create_inbound_session(conn, &contact, msg)?;
+        Conversations::process_plaintext(client, conn, &plaintext, payload)?;
         Ok(())
     }
 
-    pub fn save_invites(&self) -> Result<(), ConversationError> {
-        let my_contact = self.client.account.contact();
+    pub fn save_invites(client: &Client<A>) -> Result<(), ConversationError> {
+        let my_contact = client.account.contact();
 
-        self.client
+        client
             .store
             .lock_refresh_job(RefreshJobKind::Invite, |conn, job| {
-                let downloaded =
-                    futures::executor::block_on(self.client.download_latest_from_topic(
-                        self.get_start_time(&job).unsigned_abs(),
-                        crate::utils::build_user_invite_topic(my_contact.installation_id()),
-                    ))
-                    .map_err(|e| StorageError::Unknown(e.to_string()))?;
+                let downloaded = futures::executor::block_on(client.download_latest_from_topic(
+                    Conversations::<A>::get_start_time(&job).unsigned_abs(),
+                    crate::utils::build_user_invite_topic(my_contact.installation_id()),
+                ))
+                .map_err(|e| StorageError::Unknown(e.to_string()))?;
                 // Save all invites
                 for envelope in downloaded {
-                    self.client
-                        .store
-                        .save_inbound_invite(conn, envelope.into())?;
+                    client.store.save_inbound_invite(conn, envelope.into())?;
                 }
 
                 Ok(())
@@ -280,27 +250,24 @@ where
         Ok(())
     }
 
-    pub fn process_invites(&self) -> Result<(), ConversationError> {
-        let conn = &mut self.client.store.conn()?;
+    pub fn process_invites(client: &Client<A>) -> Result<(), ConversationError> {
+        let conn = &mut client.store.conn()?;
         conn.transaction::<_, StorageError, _>(|transaction_manager| {
-            let invites = self
-                .client
+            let invites = client
                 .store
                 .get_inbound_invites(transaction_manager, InboundInviteStatus::Pending)?;
             for invite in invites {
                 let invite_id = invite.id.clone();
-                match self.process_inbound_invite(transaction_manager, invite) {
+                match Conversations::process_inbound_invite(client, transaction_manager, invite) {
                     Ok(status) => {
                         log::debug!(
                             "Invite processed: {:?}. Status: {:?}",
                             invite_id,
                             status.clone()
                         );
-                        self.client.store.set_invite_status(
-                            transaction_manager,
-                            invite_id,
-                            status,
-                        )?;
+                        client
+                            .store
+                            .set_invite_status(transaction_manager, invite_id, status)?;
                     }
                     Err(err) => {
                         log::error!("Error processing invite: {:?}", err);
@@ -316,7 +283,7 @@ where
     }
 
     fn process_inbound_invite(
-        &self,
+        client: &Client<A>,
         conn: &mut DbConnection,
         invite: InboundInvite,
     ) -> Result<InboundInviteStatus, ConversationError> {
@@ -327,7 +294,8 @@ where
             }
         };
 
-        let existing_session = self.find_existing_session_with_conn(&invitation.inviter, conn)?;
+        let existing_session =
+            Conversations::find_existing_session_with_conn(client, &invitation.inviter, conn)?;
         let plaintext: Vec<u8>;
 
         let olm_message = match serde_json::from_slice(&invitation.ciphertext) {
@@ -358,10 +326,7 @@ where
                 };
 
                 (_, plaintext) =
-                    match self
-                        .client
-                        .create_inbound_session(conn, &invitation.inviter, prek_key)
-                    {
+                    match client.create_inbound_session(conn, &invitation.inviter, prek_key) {
                         Ok((session, plaintext)) => (session, plaintext),
                         Err(err) => {
                             log::error!("Error creating session: {:?}", err);
@@ -372,12 +337,13 @@ where
         };
 
         let inner_invite: ProtoWrapper<InvitationV1> = plaintext.try_into()?;
-        if !self.validate_invite(&invitation, &inner_invite.proto) {
+        if !Conversations::validate_invite(client, &invitation, &inner_invite.proto) {
             return Ok(InboundInviteStatus::Invalid);
         }
         // Create the user if doesn't exist
-        let peer_address = self.get_invite_peer_address(&invitation, &inner_invite.proto);
-        self.client.store.insert_or_ignore_user_with_conn(
+        let peer_address =
+            Conversations::get_invite_peer_address(client, &invitation, &inner_invite.proto);
+        client.store.insert_or_ignore_user_with_conn(
             conn,
             StoredUser {
                 user_address: peer_address.clone(),
@@ -387,12 +353,12 @@ where
         )?;
 
         // Create the conversation if doesn't exist
-        self.client.store.insert_or_ignore_conversation_with_conn(
+        client.store.insert_or_ignore_conversation_with_conn(
             conn,
             StoredConversation {
                 convo_id: convo_id(
                     peer_address.clone(),
-                    self.client.account.contact().wallet_address,
+                    client.account.contact().wallet_address,
                 ),
                 peer_address,
                 created_at: now(),
@@ -403,8 +369,12 @@ where
         Ok(InboundInviteStatus::Processed)
     }
 
-    fn validate_invite(&self, invitation: &Invitation, inner_invite: &InvitationV1) -> bool {
-        let my_wallet_address = self.client.account.contact().wallet_address;
+    fn validate_invite(
+        client: &Client<A>,
+        invitation: &Invitation,
+        inner_invite: &InvitationV1,
+    ) -> bool {
+        let my_wallet_address = client.account.contact().wallet_address;
         let inviter_is_my_other_device = my_wallet_address == invitation.inviter.wallet_address;
 
         if inviter_is_my_other_device {
@@ -415,11 +385,11 @@ where
     }
 
     fn get_invite_peer_address(
-        &self,
+        client: &Client<A>,
         invitation: &Invitation,
         inner_invite: &InvitationV1,
     ) -> String {
-        let my_wallet_address = self.client.account.contact().wallet_address;
+        let my_wallet_address = client.account.contact().wallet_address;
         let inviter_is_my_other_device = my_wallet_address == invitation.inviter.wallet_address;
 
         if inviter_is_my_other_device {
@@ -430,20 +400,19 @@ where
     }
 
     fn find_existing_session_with_conn(
-        &self,
+        client: &Client<A>,
         contact: &Contact,
         conn: &mut DbConnection,
     ) -> Result<Option<SessionManager>, ConversationError> {
-        self.find_existing_session(&contact.installation_id(), conn)
+        Conversations::find_existing_session(client, &contact.installation_id(), conn)
     }
 
     fn find_existing_session(
-        &self,
+        client: &Client<A>,
         installation_id: &str,
         conn: &mut DbConnection,
     ) -> Result<Option<SessionManager>, ConversationError> {
-        let stored_session = self
-            .client
+        let stored_session = client
             .store
             .get_latest_session_for_installation(installation_id, conn)?;
 
@@ -453,21 +422,21 @@ where
         }
     }
 
-    fn get_start_time(&self, job: &RefreshJob) -> i64 {
+    fn get_start_time(job: &RefreshJob) -> i64 {
         // Adjust for padding and ensure start_time > 0
         std::cmp::max(job.last_run - PADDING_TIME_NS, 0)
     }
 
     fn create_outbound_payload(
-        &self,
+        client: &Client<A>,
         session: &mut SessionManager,
         message: &StoredMessage,
     ) -> Result<StoredOutboundPayload, ConversationError> {
         let is_prekey_message = !session.has_received_message();
 
         let metadata = PadlockMessageSealedMetadata {
-            sender_user_address: self.client.wallet_address(),
-            sender_installation_id: self.client.account.contact().installation_id(),
+            sender_user_address: client.wallet_address(),
+            sender_installation_id: client.account.contact().installation_id(),
             recipient_user_address: session.user_address(),
             recipient_installation_id: session.installation_id(),
             is_prekey_message,
@@ -481,7 +450,7 @@ where
         let header_bytes = message_header.encode_to_vec();
         // TODO expose a vmac method to sign bytes rather than string
         // https://matrix-org.github.io/vodozemac/vodozemac/olm/struct.Account.html#method.sign
-        let header_signature = self.client.account.sign(&base64_encode(&header_bytes));
+        let header_signature = client.account.sign(&base64_encode(&header_bytes));
         let header_signature = EdDsaSignature {
             bytes: header_signature.to_bytes().to_vec(),
         };
@@ -512,26 +481,23 @@ where
     }
 
     pub async fn process_outbound_message(
-        &self,
+        client: &Client<A>,
         message: &StoredMessage,
     ) -> Result<(), ConversationError> {
-        let peer_address =
-            peer_addr_from_convo_id(&message.convo_id, &self.client.wallet_address())?;
+        let peer_address = peer_addr_from_convo_id(&message.convo_id, &client.wallet_address())?;
 
         // Refresh remote installations
-        self.client
+        client
             .refresh_user_installations_if_stale(&peer_address)
             .await?;
-        self.client.store.conn().unwrap().transaction(
+        client.store.conn().unwrap().transaction(
             |transaction| -> Result<(), ConversationError> {
-                let my_sessions = self
-                    .client
+                let my_sessions = client
                     .store
-                    .get_latest_sessions(&self.client.wallet_address(), transaction)?;
+                    .get_latest_sessions(&client.wallet_address(), transaction)?;
                 let their_user_addr =
-                    peer_addr_from_convo_id(&message.convo_id, &self.client.wallet_address())?;
-                let their_sessions = self
-                    .client
+                    peer_addr_from_convo_id(&message.convo_id, &client.wallet_address())?;
+                let their_sessions = client
                     .store
                     .get_latest_sessions(&their_user_addr, transaction)?;
                 if their_sessions.is_empty() {
@@ -542,18 +508,19 @@ where
                 let mut updated_sessions = Vec::new();
                 for stored_session in my_sessions.iter().chain(&their_sessions) {
                     if stored_session.peer_installation_id
-                        == self.client.account.contact().installation_id()
+                        == client.account.contact().installation_id()
                     {
                         continue;
                     }
                     let mut session = SessionManager::try_from(stored_session)?;
-                    let outbound_payload = self.create_outbound_payload(&mut session, message)?;
+                    let outbound_payload =
+                        Conversations::create_outbound_payload(client, &mut session, message)?;
                     let updated_session = StoredSession::try_from(&session)?;
                     outbound_payloads.push(outbound_payload);
                     updated_sessions.push(updated_session);
                 }
 
-                self.client.store.commit_outbound_payloads_for_message(
+                client.store.commit_outbound_payloads_for_message(
                     message.id,
                     MessageState::LocallyCommitted,
                     outbound_payloads,
@@ -567,16 +534,16 @@ where
         Ok(())
     }
 
-    pub async fn process_outbound_messages(&self) -> Result<(), ConversationError> {
+    pub async fn process_outbound_messages(client: &Client<A>) -> Result<(), ConversationError> {
         //Refresh self installations
-        self.client
-            .refresh_user_installations_if_stale(&self.client.wallet_address())
+        client
+            .refresh_user_installations_if_stale(&client.wallet_address())
             .await?;
-        let mut messages = self.client.store.get_unprocessed_messages()?;
+        let mut messages = client.store.get_unprocessed_messages()?;
         log::debug!("Processing {} messages", messages.len());
         messages.sort_by(|a, b| a.created_at.cmp(&b.created_at));
         for message in messages {
-            if let Err(e) = self.process_outbound_message(&message).await {
+            if let Err(e) = Conversations::process_outbound_message(client, &message).await {
                 log::error!(
                     "Couldn't process message with ID {} because of error: {:?}",
                     message.id,
@@ -586,12 +553,12 @@ where
             }
         }
 
-        self.publish_outbound_payloads().await?;
+        Conversations::publish_outbound_payloads(client).await?;
         Ok(())
     }
 
-    pub async fn publish_outbound_payloads(&self) -> Result<(), ConversationError> {
-        let unsent_payloads = self.client.store.fetch_and_lock_outbound_payloads(
+    pub async fn publish_outbound_payloads(client: &Client<A>) -> Result<(), ConversationError> {
+        let unsent_payloads = client.store.fetch_and_lock_outbound_payloads(
             OutboundPayloadState::Pending,
             Duration::from_secs(60).as_nanos() as i64,
         )?;
@@ -610,7 +577,7 @@ where
             .collect();
 
         // TODO: API tokens
-        self.client
+        client
             .api_client
             .publish("".to_string(), PublishRequest { envelopes })
             .await?;
@@ -619,7 +586,7 @@ where
             .iter()
             .map(|payload| payload.created_at_ns)
             .collect();
-        self.client.store.update_and_unlock_outbound_payloads(
+        client.store.update_and_unlock_outbound_payloads(
             payload_ids,
             OutboundPayloadState::ServerAcknowledged,
         )?;
@@ -634,17 +601,14 @@ mod tests {
 
     use crate::{
         codecs::{text::TextCodec, ContentCodec},
-        conversation::convo_id,
+        conversation::{convo_id, SecretConversation},
         conversations::Conversations,
         invitation::Invitation,
-        mock_xmtp_api_client::MockXmtpApiClient,
         storage::{
             now, InboundInvite, InboundInviteStatus, MessageState, StoredConversation,
             StoredMessage, StoredUser,
         },
-        test_utils::test_utils::{
-            gen_test_client, gen_test_client_internal, gen_test_conversation, gen_two_test_clients,
-        },
+        test_utils::test_utils::{gen_test_client, gen_test_conversation, gen_two_test_clients},
         types::networking::XmtpApiClient,
         utils::{build_envelope, build_installation_message_topic, build_user_invite_topic},
         ClientBuilder, Fetch,
@@ -658,12 +622,9 @@ mod tests {
     async fn create_secret_conversation() {
         let alice_client = gen_test_client().await;
         let bob_client = gen_test_client().await;
-
-        let conversations = Conversations::new(&alice_client);
-        let conversation = conversations
-            .new_secret_conversation(bob_client.wallet_address().to_string())
-            .unwrap();
-
+        let conversation =
+            SecretConversation::new(&alice_client, bob_client.wallet_address().to_string())
+                .unwrap();
         assert_eq!(conversation.peer_address(), bob_client.wallet_address());
         conversation.initialize().await.unwrap();
     }
@@ -672,8 +633,7 @@ mod tests {
     async fn save_invites() {
         let mut alice_client = ClientBuilder::new_test().build().unwrap();
         alice_client.init().await.unwrap();
-
-        let invites = Conversations::new(&alice_client).save_invites();
+        let invites = Conversations::save_invites(&alice_client);
         assert!(invites.is_ok());
     }
 
@@ -682,7 +642,6 @@ mod tests {
         let alice_client = gen_test_client().await;
         let bob_client = gen_test_client().await;
 
-        let conversations = Conversations::new(&alice_client);
         let mut session = alice_client
             .get_session(
                 &mut alice_client.store.conn().unwrap(),
@@ -690,22 +649,22 @@ mod tests {
             )
             .unwrap();
 
-        let _payload = conversations
-            .create_outbound_payload(
-                &mut session,
-                &StoredMessage {
-                    id: 0,
-                    created_at: 0,
-                    convo_id: convo_id(alice_client.wallet_address(), bob_client.wallet_address()),
-                    addr_from: alice_client.wallet_address(),
-                    sent_at_ns: 0,
-                    content: TextCodec::encode("Hello world".to_string())
-                        .unwrap()
-                        .encode_to_vec(),
-                    state: MessageState::Unprocessed as i32,
-                },
-            )
-            .unwrap();
+        let _payload = Conversations::create_outbound_payload(
+            &alice_client,
+            &mut session,
+            &StoredMessage {
+                id: 0,
+                created_at: 0,
+                convo_id: convo_id(alice_client.wallet_address(), bob_client.wallet_address()),
+                addr_from: alice_client.wallet_address(),
+                sent_at_ns: 0,
+                content: TextCodec::encode("Hello world".to_string())
+                    .unwrap()
+                    .encode_to_vec(),
+                state: MessageState::Unprocessed as i32,
+            },
+        )
+        .unwrap();
 
         // TODO validate the payload when implementing the receiver side
     }
@@ -714,12 +673,11 @@ mod tests {
     async fn process_outbound_messages() {
         let (alice_client, bob_client) = gen_two_test_clients().await;
 
-        let conversations = Conversations::new(&alice_client);
-        let conversation =
-            gen_test_conversation(&conversations, &bob_client.wallet_address()).await;
-
+        let conversation = gen_test_conversation(&alice_client, &bob_client.wallet_address()).await;
         conversation.send_text("Hello world").await.unwrap();
-        conversations.process_outbound_messages().await.unwrap();
+        Conversations::process_outbound_messages(&alice_client)
+            .await
+            .unwrap();
         let response = bob_client
             .api_client
             .query(QueryRequest {
@@ -770,8 +728,7 @@ mod tests {
             )
             .unwrap();
 
-        let bob_conversations = Conversations::new(&bob_client);
-        let process_result = bob_conversations.process_invites();
+        let process_result = Conversations::process_invites(&bob_client);
         assert!(process_result.is_ok());
 
         let conn = &mut bob_client.store.conn().unwrap();
@@ -824,8 +781,7 @@ mod tests {
             )
             .unwrap();
 
-        let bob_conversations = Conversations::new(&bob_client);
-        let process_result = bob_conversations.process_invites();
+        let process_result = Conversations::process_invites(&bob_client);
         assert!(process_result.is_ok());
 
         let conn = &mut bob_client.store.conn().unwrap();
@@ -849,19 +805,10 @@ mod tests {
 
         let bob_address = bob_client.account.contact().wallet_address;
 
-        let a_convos = Conversations::new(&alice_client);
-        let b_convos = Conversations::new(&bob_client);
-
-        let a_to_b = a_convos
-            .new_secret_conversation(bob_address.clone())
-            .unwrap();
-
+        let a_to_b = SecretConversation::new(&alice_client, bob_address.clone()).unwrap();
         // Send First Message
-
         a_to_b.send_text("Hi").await.unwrap();
-        a_convos.process_outbound_messages().await.unwrap();
-        a_convos.publish_outbound_payloads().await.unwrap();
-        b_convos.receive().unwrap();
+        Conversations::receive(&bob_client).unwrap();
 
         let bob_messages = bob_client
             .store
@@ -893,19 +840,9 @@ mod tests {
         }
 
         // Reply
-        let b_to_a = b_convos
-            .new_secret_conversation(bob_address.clone())
-            .unwrap();
-
+        let b_to_a = SecretConversation::new(&bob_client, bob_address.clone()).unwrap();
         b_to_a.send_text("Reply").await.unwrap();
-        bob_client
-            .refresh_user_installations(&bob_address)
-            .await
-            .unwrap();
-        b_convos.process_outbound_messages().await.unwrap();
-        b_convos.publish_outbound_payloads().await.unwrap();
-
-        a_convos.receive().unwrap();
+        Conversations::receive(&alice_client).unwrap();
 
         let _alice_messages = alice_client
             .store
@@ -925,15 +862,11 @@ mod tests {
 
     #[tokio::test]
     async fn list() {
-        let api_client = MockXmtpApiClient::new();
-        let alice_client = gen_test_client_internal(api_client.clone()).await;
-        let bob_client = gen_test_client_internal(api_client.clone()).await;
+        let (alice_client, bob_client) = gen_two_test_clients().await;
 
-        let conversations = Conversations::new(&alice_client);
-        let conversation =
-            gen_test_conversation(&conversations, &bob_client.wallet_address()).await;
+        let conversation = gen_test_conversation(&alice_client, &bob_client.wallet_address()).await;
 
-        let list = conversations.list(true).await.unwrap();
+        let list = Conversations::list(&alice_client, true).await.unwrap();
         assert_eq!(list.len(), 1);
         assert_eq!(list[0].peer_address(), conversation.peer_address());
     }

--- a/xmtp/src/conversations.rs
+++ b/xmtp/src/conversations.rs
@@ -715,10 +715,7 @@ mod tests {
         let conversation =
             gen_test_conversation(&conversations, &bob_client.wallet_address()).await;
 
-        conversation.send_text("Hello world").unwrap();
-        let unprocessed_messages = alice_client.store.get_unprocessed_messages().unwrap();
-        assert_eq!(unprocessed_messages.len(), 1);
-
+        conversation.send_text("Hello world").await.unwrap();
         conversations.process_outbound_messages().await.unwrap();
         let response = bob_client
             .api_client
@@ -858,11 +855,7 @@ mod tests {
 
         // Send First Message
 
-        a_to_b.send_text("Hi").unwrap();
-        alice_client
-            .refresh_user_installations(&bob_address)
-            .await
-            .unwrap();
+        a_to_b.send_text("Hi").await.unwrap();
         a_convos.process_outbound_messages().await.unwrap();
         a_convos.publish_outbound_payloads().await.unwrap();
         b_convos.receive().unwrap();
@@ -901,7 +894,7 @@ mod tests {
             .new_secret_conversation(bob_address.clone())
             .unwrap();
 
-        b_to_a.send_text("Reply").unwrap();
+        b_to_a.send_text("Reply").await.unwrap();
         bob_client
             .refresh_user_installations(&bob_address)
             .await

--- a/xmtp/src/conversations.rs
+++ b/xmtp/src/conversations.rs
@@ -1,6 +1,6 @@
 use diesel::Connection;
 use futures::executor::block_on;
-use log::{info, warn};
+use log::info;
 use prost::Message;
 use vodozemac::olm::{self, OlmMessage};
 use xmtp_proto::xmtp::v3::message_contents::{InvitationV1, PadlockMessagePayload};
@@ -92,7 +92,10 @@ where
         self.client
             .store
             .lock_refresh_job(RefreshJobKind::Message, |conn, job| {
-                warn!("{}", self.get_start_time(&job).unsigned_abs());
+                log::debug!(
+                    "Refresh messages start time: {}",
+                    self.get_start_time(&job).unsigned_abs()
+                );
                 let downloaded =
                     futures::executor::block_on(self.client.download_latest_from_topic(
                         self.get_start_time(&job).unsigned_abs(),

--- a/xmtp/src/conversations.rs
+++ b/xmtp/src/conversations.rs
@@ -1,17 +1,9 @@
-use std::time::Duration;
-
 use diesel::Connection;
 use futures::executor::block_on;
 use log::{info, warn};
 use prost::Message;
 use vodozemac::olm::{self, OlmMessage};
-use xmtp_proto::xmtp::{
-    message_api::v1::{Envelope, PublishRequest},
-    v3::message_contents::{
-        EdDsaSignature, InvitationV1, PadlockMessageEnvelope, PadlockMessageHeader,
-        PadlockMessagePayload, PadlockMessagePayloadVersion, PadlockMessageSealedMetadata,
-    },
-};
+use xmtp_proto::xmtp::v3::message_contents::{InvitationV1, PadlockMessagePayload};
 
 use crate::{
     contact::Contact,
@@ -21,12 +13,11 @@ use crate::{
     session::SessionManager,
     storage::{
         now, ConversationState, DbConnection, InboundInvite, InboundInviteStatus, InboundMessage,
-        InboundMessageStatus, MessageState, NewStoredMessage, OutboundPayloadState, RefreshJob,
-        RefreshJobKind, StorageError, StoredConversation, StoredMessage, StoredOutboundPayload,
-        StoredSession, StoredUser,
+        InboundMessageStatus, MessageState, NewStoredMessage, RefreshJob, RefreshJobKind,
+        StorageError, StoredConversation, StoredUser,
     },
     types::networking::XmtpApiClient,
-    utils::{base64_encode, build_installation_message_topic},
+    utils::build_installation_message_topic,
     vmac_protos::ProtoWrapper,
     Client,
 };
@@ -454,191 +445,17 @@ where
         // Adjust for padding and ensure start_time > 0
         std::cmp::max(job.last_run - PADDING_TIME_NS, 0)
     }
-
-    fn create_outbound_payload(
-        &self,
-        session: &mut SessionManager,
-        message: &StoredMessage,
-    ) -> Result<StoredOutboundPayload, ConversationError> {
-        let is_prekey_message = !session.has_received_message();
-
-        let metadata = PadlockMessageSealedMetadata {
-            sender_user_address: self.client.wallet_address(),
-            sender_installation_id: self.client.account.contact().installation_id(),
-            recipient_user_address: session.user_address(),
-            recipient_installation_id: session.installation_id(),
-            is_prekey_message,
-        };
-        // TODO encrypted sealed metadata using sealed sender
-        let sealed_metadata = metadata.encode_to_vec();
-        let message_header = PadlockMessageHeader {
-            sent_ns: message.created_at as u64,
-            sealed_metadata,
-        };
-        let header_bytes = message_header.encode_to_vec();
-        // TODO expose a vmac method to sign bytes rather than string
-        // https://matrix-org.github.io/vodozemac/vodozemac/olm/struct.Account.html#method.sign
-        let header_signature = self.client.account.sign(&base64_encode(&header_bytes));
-        let header_signature = EdDsaSignature {
-            bytes: header_signature.to_bytes().to_vec(),
-        };
-
-        let payload = PadlockMessagePayload {
-            message_version: PadlockMessagePayloadVersion::One as i32,
-            header_signature: Some(header_signature),
-            convo_id: message.convo_id.clone(),
-            content_bytes: message.content.clone(),
-        };
-        let olm_message = session.encrypt(&payload.encode_to_vec());
-
-        let ciphertext = match olm_message {
-            olm::OlmMessage::Normal(message) => message.to_bytes(),
-            olm::OlmMessage::PreKey(prekey_message) => prekey_message.to_bytes(),
-        };
-        let envelope: PadlockMessageEnvelope = PadlockMessageEnvelope {
-            header_bytes,
-            ciphertext,
-        };
-        Ok(StoredOutboundPayload::new(
-            message.created_at,
-            build_installation_message_topic(&session.installation_id()),
-            envelope.encode_to_vec(),
-            OutboundPayloadState::Pending as i32,
-            0,
-        ))
-    }
-
-    pub async fn process_outbound_message(
-        &self,
-        message: &StoredMessage,
-    ) -> Result<(), ConversationError> {
-        let peer_address =
-            peer_addr_from_convo_id(&message.convo_id, &self.client.wallet_address())?;
-
-        // Refresh remote installations
-        self.client
-            .refresh_user_installations_if_stale(&peer_address)
-            .await?;
-        self.client.store.conn().unwrap().transaction(
-            |transaction| -> Result<(), ConversationError> {
-                let my_sessions = self
-                    .client
-                    .store
-                    .get_latest_sessions(&self.client.wallet_address(), transaction)?;
-                let their_user_addr =
-                    peer_addr_from_convo_id(&message.convo_id, &self.client.wallet_address())?;
-                let their_sessions = self
-                    .client
-                    .store
-                    .get_latest_sessions(&their_user_addr, transaction)?;
-                if their_sessions.is_empty() {
-                    return Err(ConversationError::NoSessions(their_user_addr));
-                }
-
-                let mut outbound_payloads = Vec::new();
-                let mut updated_sessions = Vec::new();
-                for stored_session in my_sessions.iter().chain(&their_sessions) {
-                    if stored_session.peer_installation_id
-                        == self.client.account.contact().installation_id()
-                    {
-                        continue;
-                    }
-                    let mut session = SessionManager::try_from(stored_session)?;
-                    let outbound_payload = self.create_outbound_payload(&mut session, message)?;
-                    let updated_session = StoredSession::try_from(&session)?;
-                    outbound_payloads.push(outbound_payload);
-                    updated_sessions.push(updated_session);
-                }
-
-                self.client.store.commit_outbound_payloads_for_message(
-                    message.id,
-                    MessageState::LocallyCommitted,
-                    outbound_payloads,
-                    updated_sessions,
-                    transaction,
-                )?;
-                Ok(())
-            },
-        )?;
-
-        Ok(())
-    }
-
-    pub async fn process_outbound_messages(&self) -> Result<(), ConversationError> {
-        //Refresh self installations
-        self.client
-            .refresh_user_installations_if_stale(&self.client.wallet_address())
-            .await?;
-        let mut messages = self.client.store.get_unprocessed_messages()?;
-        log::debug!("Processing {} messages", messages.len());
-        messages.sort_by(|a, b| a.created_at.cmp(&b.created_at));
-        for message in messages {
-            if let Err(e) = self.process_outbound_message(&message).await {
-                log::error!(
-                    "Couldn't process message with ID {} because of error: {:?}",
-                    message.id,
-                    e
-                );
-                // TODO update message status to failed on non-retryable errors so that we don't retry it next time
-            }
-        }
-
-        self.publish_outbound_payloads().await?;
-        Ok(())
-    }
-
-    pub async fn publish_outbound_payloads(&self) -> Result<(), ConversationError> {
-        let unsent_payloads = self.client.store.fetch_and_lock_outbound_payloads(
-            OutboundPayloadState::Pending,
-            Duration::from_secs(60).as_nanos() as i64,
-        )?;
-
-        if unsent_payloads.is_empty() {
-            return Ok(());
-        }
-
-        let envelopes = unsent_payloads
-            .iter()
-            .map(|payload| Envelope {
-                content_topic: payload.content_topic.clone(),
-                timestamp_ns: payload.created_at_ns as u64,
-                message: payload.payload.clone(),
-            })
-            .collect();
-
-        // TODO: API tokens
-        self.client
-            .api_client
-            .publish("".to_string(), PublishRequest { envelopes })
-            .await?;
-
-        let payload_ids = unsent_payloads
-            .iter()
-            .map(|payload| payload.created_at_ns)
-            .collect();
-        self.client.store.update_and_unlock_outbound_payloads(
-            payload_ids,
-            OutboundPayloadState::ServerAcknowledged,
-        )?;
-        Ok(())
-    }
 }
 
 #[cfg(test)]
 mod tests {
-    use prost::Message;
     use xmtp_proto::xmtp::message_api::v1::QueryRequest;
 
     use crate::{
-        codecs::{text::TextCodec, ContentCodec},
-        conversation::convo_id,
         conversations::Conversations,
         invitation::Invitation,
         mock_xmtp_api_client::MockXmtpApiClient,
-        storage::{
-            now, InboundInvite, InboundInviteStatus, MessageState, StoredConversation,
-            StoredMessage, StoredUser,
-        },
+        storage::{now, InboundInvite, InboundInviteStatus, StoredConversation, StoredUser},
         test_utils::test_utils::{
             gen_test_client, gen_test_client_internal, gen_test_conversation, gen_two_test_clients,
         },
@@ -675,39 +492,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn create_outbound_payload() {
-        let alice_client = gen_test_client().await;
-        let bob_client = gen_test_client().await;
-
-        let conversations = Conversations::new(&alice_client);
-        let mut session = alice_client
-            .get_session(
-                &mut alice_client.store.conn().unwrap(),
-                &bob_client.account.contact(),
-            )
-            .unwrap();
-
-        let _payload = conversations
-            .create_outbound_payload(
-                &mut session,
-                &StoredMessage {
-                    id: 0,
-                    created_at: 0,
-                    convo_id: convo_id(alice_client.wallet_address(), bob_client.wallet_address()),
-                    addr_from: alice_client.wallet_address(),
-                    sent_at_ns: 0,
-                    content: TextCodec::encode("Hello world".to_string())
-                        .unwrap()
-                        .encode_to_vec(),
-                    state: MessageState::Unprocessed as i32,
-                },
-            )
-            .unwrap();
-
-        // TODO validate the payload when implementing the receiver side
-    }
-
-    #[tokio::test]
     async fn process_outbound_messages() {
         let (alice_client, bob_client) = gen_two_test_clients().await;
 
@@ -716,7 +500,7 @@ mod tests {
             gen_test_conversation(&conversations, &bob_client.wallet_address()).await;
 
         conversation.send_text("Hello world").await.unwrap();
-        conversations.process_outbound_messages().await.unwrap();
+        alice_client.process_outbound_messages().await.unwrap();
         let response = bob_client
             .api_client
             .query(QueryRequest {
@@ -856,8 +640,7 @@ mod tests {
         // Send First Message
 
         a_to_b.send_text("Hi").await.unwrap();
-        a_convos.process_outbound_messages().await.unwrap();
-        a_convos.publish_outbound_payloads().await.unwrap();
+        alice_client.process_outbound_messages().await.unwrap();
         b_convos.receive().unwrap();
 
         let bob_messages = bob_client
@@ -895,12 +678,7 @@ mod tests {
             .unwrap();
 
         b_to_a.send_text("Reply").await.unwrap();
-        bob_client
-            .refresh_user_installations(&bob_address)
-            .await
-            .unwrap();
-        b_convos.process_outbound_messages().await.unwrap();
-        b_convos.publish_outbound_payloads().await.unwrap();
+        bob_client.process_outbound_messages().await.unwrap();
 
         a_convos.receive().unwrap();
 

--- a/xmtp/src/test_utils.rs
+++ b/xmtp/src/test_utils.rs
@@ -1,14 +1,11 @@
 #[cfg(test)]
 pub mod test_utils {
     use crate::{
-        conversation::SecretConversation, conversations::Conversations,
-        mock_xmtp_api_client::MockXmtpApiClient, types::networking::XmtpApiClient, Client,
-        ClientBuilder,
+        conversation::SecretConversation, mock_xmtp_api_client::MockXmtpApiClient,
+        types::networking::XmtpApiClient, Client, ClientBuilder,
     };
 
-    pub async fn gen_test_client_internal(
-        api_client: MockXmtpApiClient,
-    ) -> Client<MockXmtpApiClient> {
+    async fn gen_test_client_internal(api_client: MockXmtpApiClient) -> Client<MockXmtpApiClient> {
         let mut client = ClientBuilder::new_test()
             .api_client(api_client)
             .build()
@@ -32,15 +29,11 @@ pub mod test_utils {
     }
 
     pub async fn gen_test_conversation<'c, A: XmtpApiClient>(
-        conversations: &'c Conversations<'c, A>,
+        client: &'c Client<A>,
         peer_address: &str,
     ) -> SecretConversation<'c, A> {
-        let convo = conversations
-            .new_secret_conversation(peer_address.to_string())
-            .unwrap();
-
+        let convo = SecretConversation::new(client, peer_address.to_string()).unwrap();
         convo.initialize().await.unwrap();
-
         convo
     }
 }


### PR DESCRIPTION
There are two changes here:

1. Make all methods of `Conversations` static, and accept a `Client` argument, so that `Conversations` doesn't need to be instantiated anywhere. `Conversations` doesn't really hold state anyway and effectively functions as a wrapper for `Client` right now, so it doesn't make sense for consumers to have to instantiate it and hold onto it.
2. Call `process_outbound_messages()` on init and on message send, so that consumers don't have to manually call it.

This simplifies the client API quite a bit, as can be seen in `bindings_ffi` and in the `CLI`.

Ideally, we could have spawned a separate thread to call `process_outbound_messages` so that the existing thread is not blocked, but that requires additional refactoring. This requires us to enforce `XmtpApiClient` is `Send + Sync` (which is easy), but also comes up against issues with lifetimes for `Client`, for which a reference is needed in the other thread that may outlive the current thread. This possibly requires us to start using `Arcs` again.