### PR TITLE
Update uniffi version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,10 +186,6 @@ jobs:
           path: .
       - name: Build archive
         run: |
-          # not sure why we're building this one
-          # mv aarch64-unknown-linux-gnu/libxmtpv3.so jniLibs/arm64-v8a/
-          # mkdir -p jniLibs/x86_64
-          # mv x86_64-linux-android/libxmtpv3.so jniLibs/x86_64/
           mkdir -p jniLibs/x86
           mv i686-linux-android/libxmtpv3.so jniLibs/x86/
           mkdir -p jniLibs/armeabi-v7a

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.target }}
-          path: bindings_ffi/target/${{ matrix.target }}/release/libbindings_ffi.so
+          path: bindings_ffi/target/${{ matrix.target }}/release/libxmtpv3.so
           retention-days: 1
 
   build-macos:
@@ -107,7 +107,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.target }}
-          path: bindings_ffi/target/${{ matrix.target }}/release/libbindings_ffi.dylib
+          path: bindings_ffi/target/${{ matrix.target }}/release/libxmtpv3.dylib
           retention-days: 1        
 
   kotlin:
@@ -187,15 +187,15 @@ jobs:
       - name: Build archive
         run: |
           # not sure why we're building this one
-          # mv aarch64-unknown-linux-gnu/libbindings_ffi.so jniLibs/arm64-v8a/
+          # mv aarch64-unknown-linux-gnu/libxmtpv3.so jniLibs/arm64-v8a/
           # mkdir -p jniLibs/x86_64
-          # mv x86_64-linux-android/libbindings_ffi.so jniLibs/x86_64/
+          # mv x86_64-linux-android/libxmtpv3.so jniLibs/x86_64/
           mkdir -p jniLibs/x86
-          mv i686-linux-android/libbindings_ffi.so jniLibs/x86/
+          mv i686-linux-android/libxmtpv3.so jniLibs/x86/
           mkdir -p jniLibs/armeabi-v7a
-          mv armv7-linux-androideabi/libbindings_ffi.so jniLibs/armeabi-v7a/
+          mv armv7-linux-androideabi/libxmtpv3.so jniLibs/armeabi-v7a/
           mkdir -p jniLibs/arm64-v8a
-          mv aarch64-linux-android/libbindings_ffi.so jniLibs/arm64-v8a/
+          mv aarch64-linux-android/libxmtpv3.so jniLibs/arm64-v8a/
           mkdir -p java
           mv kotlin/xmtpv3.kt java/
           zip -r libxmtp-android.zip jniLibs java

--- a/bindings_ffi/Cargo.toml
+++ b/bindings_ffi/Cargo.toml
@@ -11,14 +11,19 @@ crate-type = ["lib", "cdylib"]
 [dependencies]
 log = { version = "0.4", features = ["std"] }
 thiserror = "1.0.40"
-uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "6938c262293802f00a373f0d1aa16a2079071b24", features = ["tokio", "cli"] }
-uniffi_macros = { git = "https://github.com/mozilla/uniffi-rs", rev = "6938c262293802f00a373f0d1aa16a2079071b24" }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "cae8edc45ba5b56bfcbf35b60c1ab6a97d1bf9da", features = [
+    "tokio",
+    "cli",
+] }
+uniffi_macros = { git = "https://github.com/mozilla/uniffi-rs", rev = "cae8edc45ba5b56bfcbf35b60c1ab6a97d1bf9da" }
 xmtp = { path = "../xmtp" }
 xmtp_cryptography = { path = "../xmtp_cryptography" }
 xmtp_networking = { path = "../xmtp_networking" }
 
 [build_dependencies]
-uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "6938c262293802f00a373f0d1aa16a2079071b24", features = ["build"] }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "cae8edc45ba5b56bfcbf35b60c1ab6a97d1bf9da", features = [
+    "build",
+] }
 
 [[bin]]
 name = "ffi-uniffi-bindgen"
@@ -28,13 +33,15 @@ path = "src/bin.rs"
 ethers = "2.0.4"
 ethers-core = "2.0.4"
 tokio = { version = "1.0", features = ["full"] }
-uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "6938c262293802f00a373f0d1aa16a2079071b24", features = ["bindgen-tests"] }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "cae8edc45ba5b56bfcbf35b60c1ab6a97d1bf9da", features = [
+    "bindgen-tests",
+] }
 
 # NOTE: Thei release profile reduce bundle size from 230M to 41M - may have performance impliciations
 # https://stackoverflow.com/a/54842093
 [profile.release]
-opt-level = 'z'     # Optimize for size
-lto = true          # Enable link-time optimization
-codegen-units = 1   # Reduce number of codegen units to increase optimizations
-panic = 'abort'     # Abort on panic
-strip = true        # Strip symbols from binary*
+opt-level = 'z'   # Optimize for size
+lto = true        # Enable link-time optimization
+codegen-units = 1 # Reduce number of codegen units to increase optimizations
+panic = 'abort'   # Abort on panic
+strip = true      # Strip symbols from binary*

--- a/bindings_ffi/Cargo.toml
+++ b/bindings_ffi/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "bindings_ffi"
+name = "xmtpv3"
 version = "0.1.0"
 edition = "2021"
 

--- a/bindings_ffi/Makefile
+++ b/bindings_ffi/Makefile
@@ -5,7 +5,7 @@ ARCHS_IOS = x86_64-apple-ios aarch64-apple-ios-sim
 ARCHS_MAC = x86_64-apple-darwin aarch64-apple-darwin
 # Not used
 # ARCHS_MACCATALYST = x86_64-apple-ios-macabi aarch64-apple-ios-macabi
-LIB=libbindings_ffi.dylib
+LIB=libxmtpv3.dylib
 JAR_DIR=$(shell pwd)/tests/jar
 
 install-jar:

--- a/bindings_ffi/cross_build.sh
+++ b/bindings_ffi/cross_build.sh
@@ -16,7 +16,7 @@ main() {
       cross build --target aarch64-linux-android --target-dir ./target --profile $PROFILE
 
   # Move everything to jniLibs folder and rename
-  LIBRARY_NAME="libbindings_ffi"
+  LIBRARY_NAME="libxmtpv3"
   TARGET_NAME="libuniffi_xmtpv3"
   rm -rf jniLibs/
   # mkdir -p jniLibs/armeabi-v7a/ && \

--- a/bindings_ffi/gen_kotlin.sh
+++ b/bindings_ffi/gen_kotlin.sh
@@ -5,7 +5,7 @@ cargo build --release
 pushd .. > /dev/null
 rm -f $CRATE_NAME/src/uniffi/$PROJECT_NAME/$PROJECT_NAME.kt
 bindings_ffi/target/release/ffi-uniffi-bindgen generate \
-    --lib-file bindings_ffi/target/release/libbindings_ffi.dylib \
+    --lib-file bindings_ffi/target/release/libxmtpv3.dylib \
     $CRATE_NAME/src/$PROJECT_NAME.udl \
     --language kotlin
 popd > /dev/null


### PR DESCRIPTION
- Updates the uniffi crate the the latest version; Incorporating https://github.com/mozilla/uniffi-rs/pull/1692.
- updates the package name from `bindings_ffi` to `xmtpv3` to provide consistent module paths. 

```
---- uniffi_foreign_language_testcase_test_android_kts stdout ----
Creating testing out_dir: /Users/jazz/dev/libxmtp/bindings_ffi/target/tmp/bindings_ffi-3492e72b41fe83b6
thread 'uniffi_foreign_language_testcase_test_android_kts' panicked at 'assertion failed: `(left == right)`
  left: `CallbackInterface { module_path: "bindings_ffi", name: "FfiLogger" }`,
 right: `CallbackInterface { module_path: "xmtpv3", name: "FfiLogger" }`', /Users/jazz/.cargo/git/checkouts/uniffi-rs-6f89edd2a1ffa4bd/cae8edc/uniffi_bindgen/src/interface/universe.rs:42:17
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
