### PR TITLE
Update FFI bindings

### DIFF
--- a/bindings_ffi/Makefile
+++ b/bindings_ffi/Makefile
@@ -75,6 +75,5 @@ swift:
 	mkdir -p build/swift/include
 	mv build/swift/$(PROJECT_NAME)FFI.h build/swift/include/
 	mv build/swift/$(PROJECT_NAME)FFI.modulemap build/swift/include/module.modulemap
-	sed -i '' '1s/^/import LibXMTPRust\n\n/' build/swift/$(PROJECT_NAME).swift
 
 .PHONY: $(ARCHS_IOS) $(ARCHS_MAC) framework all aarch64-apple-ios install-jar echo-jar download-toolchains swift lipo

--- a/bindings_ffi/Makefile
+++ b/bindings_ffi/Makefile
@@ -76,4 +76,6 @@ swift:
 	mv build/swift/$(PROJECT_NAME)FFI.h build/swift/include/
 	mv build/swift/$(PROJECT_NAME)FFI.modulemap build/swift/include/module.modulemap
 
+swiftlocal: libbindings_ffi.dylib framework swift
+
 .PHONY: $(ARCHS_IOS) $(ARCHS_MAC) framework all aarch64-apple-ios install-jar echo-jar download-toolchains swift lipo

--- a/bindings_ffi/src/lib.rs
+++ b/bindings_ffi/src/lib.rs
@@ -190,7 +190,7 @@ impl FfiConversation {
         &self,
         opts: FfiListMessagesOptions,
     ) -> Result<Vec<FfiMessage>, GenericError> {
-        let _ = Conversations::receive(self.inner_client.as_ref());
+        Conversations::receive(self.inner_client.as_ref()).map_err(|e| e.to_string())?;
 
         let conversation = xmtp::conversation::SecretConversation::new(
             self.inner_client.as_ref(),


### PR DESCRIPTION
- Adds properties to allow for building a very basic happy path example app in iOS
- Calls `Conversations::receive()` when trying to list messages.