### PR TITLE
Fix test failures caused by two tests fighting over the same file.

### DIFF
--- a/bindings_ffi/src/lib.rs
+++ b/bindings_ffi/src/lib.rs
@@ -275,7 +275,10 @@ mod tests {
     };
     use tempfile::TempPath;
     use xmtp::InboxOwner;
-    use xmtp_cryptography::{signature::RecoverableSignature, utils::rng};
+    use xmtp_cryptography::{
+        signature::{RecoverableSignature, SigningKey},
+        utils::rng,
+    };
 
     #[derive(Clone)]
     pub struct LocalWalletInboxOwner {
@@ -336,8 +339,8 @@ mod tests {
     async fn test_create_client_with_storage() {
         let ffi_inbox_owner = LocalWalletInboxOwner::new();
 
-        // NOTE: if you're copying and pasting this test, make sure you change the filename here
-        let path = TempPath::from_path("./ffidb.db3");
+        let dbfilename = xmtp_cryptography::utils::generate_local_wallet().get_address();
+        let path = TempPath::from_path(format!("./test-{}.db", dbfilename));
 
         let client_a = create_client(
             Box::new(MockLogger {}),
@@ -377,8 +380,8 @@ mod tests {
     async fn test_create_client_with_key() {
         let ffi_inbox_owner = LocalWalletInboxOwner::new();
 
-        // NOTE: if you're copying and pasting this test, make sure you change the filename here
-        let path = TempPath::from_path("./ffidb.db4");
+        let dbfilename = xmtp_cryptography::utils::generate_local_wallet().get_address();
+        let path = TempPath::from_path(format!("./test-{}.db", dbfilename));
 
         let key = static_enc_key().to_vec();
 

--- a/bindings_ffi/src/lib.rs
+++ b/bindings_ffi/src/lib.rs
@@ -336,6 +336,7 @@ mod tests {
     async fn test_create_client_with_storage() {
         let ffi_inbox_owner = LocalWalletInboxOwner::new();
 
+        // NOTE: if you're copying and pasting this test, make sure you change the filename here
         let path = TempPath::from_path("./ffidb.db3");
 
         let client_a = create_client(
@@ -376,7 +377,8 @@ mod tests {
     async fn test_create_client_with_key() {
         let ffi_inbox_owner = LocalWalletInboxOwner::new();
 
-        let path = TempPath::from_path("./ffidb.db3");
+        // NOTE: if you're copying and pasting this test, make sure you change the filename here
+        let path = TempPath::from_path("./ffidb.db4");
 
         let key = static_enc_key().to_vec();
 

--- a/bindings_ffi/src/lib.rs
+++ b/bindings_ffi/src/lib.rs
@@ -275,10 +275,7 @@ mod tests {
     };
     use tempfile::TempPath;
     use xmtp::InboxOwner;
-    use xmtp_cryptography::{
-        signature::{RecoverableSignature, SigningKey},
-        utils::rng,
-    };
+    use xmtp_cryptography::{signature::RecoverableSignature, utils::rng};
 
     #[derive(Clone)]
     pub struct LocalWalletInboxOwner {

--- a/bindings_ffi/src/lib.rs
+++ b/bindings_ffi/src/lib.rs
@@ -336,8 +336,7 @@ mod tests {
     async fn test_create_client_with_storage() {
         let ffi_inbox_owner = LocalWalletInboxOwner::new();
 
-        let dbfilename = xmtp_cryptography::utils::generate_local_wallet().get_address();
-        let path = TempPath::from_path(format!("./test-{}.db", dbfilename));
+        let path = TempPath::from_path(format!("./test-{}.db", ffi_inbox_owner.get_address()));
 
         let client_a = create_client(
             Box::new(MockLogger {}),
@@ -377,8 +376,7 @@ mod tests {
     async fn test_create_client_with_key() {
         let ffi_inbox_owner = LocalWalletInboxOwner::new();
 
-        let dbfilename = xmtp_cryptography::utils::generate_local_wallet().get_address();
-        let path = TempPath::from_path(format!("./test-{}.db", dbfilename));
+        let path = TempPath::from_path(format!("./test-{}.db", ffi_inbox_owner.get_address()));
 
         let key = static_enc_key().to_vec();
 


### PR DESCRIPTION
These tests were passing in isolation but failed when run concurrently. This PR fixes that and adds a comment to hopefully prevent it from happening in the future.