### PR TITLE
Rename to differentiate between blockchain account address and XMTP installation key

### DIFF
--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -7,23 +7,21 @@ extern crate log;
 extern crate xmtp;
 
 use clap::{Parser, Subcommand};
-use ethers_core::types::H160;
 use log::{error, info};
 use std::fs;
 use std::path::PathBuf;
 use std::time::Duration;
 use thiserror::Error;
-use url::ParseError;
 use xmtp::builder::{AccountStrategy, ClientBuilderError};
 use xmtp::client::ClientError;
-use xmtp::conversation::{ConversationError, ListMessagesOptions, Conversation};
+use xmtp::conversation::{Conversation, ConversationError, ListMessagesOptions};
 use xmtp::conversations::Conversations;
 use xmtp::storage::{
     now, EncryptedMessageStore, EncryptionKey, MessageState, StorageError, StorageOption,
 };
 use xmtp::types::networking::XmtpApiClient;
 use xmtp::InboxOwner;
-use xmtp_cryptography::signature::{h160addr_to_string, RecoverableSignature, SignatureError};
+use xmtp_cryptography::signature::{RecoverableSignature, SignatureError};
 use xmtp_cryptography::utils::{rng, seeded_rng, LocalWallet};
 use xmtp_networking::grpc_api_helper::Client as ApiClient;
 type Client = xmtp::client::Client<ApiClient>;

--- a/xmtp/src/account.rs
+++ b/xmtp/src/account.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::sync::{Mutex, MutexGuard};
 
 use crate::{
-    association::{Association, AssociationError},
+    association::{AssociationError, Eip191Association},
     contact::Contact,
     types::Address,
     vmac_protos::ProtoWrapper,
@@ -95,7 +95,7 @@ impl<'de> Deserialize<'de> for VmacAccount {
 #[derive(Serialize, Deserialize)]
 pub struct Account {
     pub(crate) keys: Mutex<VmacAccount>,
-    pub(crate) assoc: Association,
+    pub(crate) assoc: Eip191Association,
 }
 
 impl fmt::Debug for Account {
@@ -111,7 +111,7 @@ impl fmt::Debug for Account {
 }
 
 impl Account {
-    pub fn new(keys: VmacAccount, assoc: Association) -> Self {
+    pub fn new(keys: VmacAccount, assoc: Eip191Association) -> Self {
         // TODO: Validate Association on initialization
 
         Self {
@@ -121,7 +121,7 @@ impl Account {
     }
 
     pub fn generate(
-        sf: impl Fn(Vec<u8>) -> Result<Association, AssociationError>,
+        sf: impl Fn(Vec<u8>) -> Result<Eip191Association, AssociationError>,
     ) -> Result<Self, AccountError> {
         let keys = VmacAccount::generate();
         let bytes = keys.bytes_to_sign();
@@ -204,15 +204,15 @@ pub(crate) mod tests {
 
     use crate::association::AssociationError;
 
-    use super::{Account, Association};
+    use super::{Account, Eip191Association};
     use ethers::core::rand::thread_rng;
     use ethers::signers::{LocalWallet, Signer};
     use ethers_core::types::{Address as EthAddress, Signature};
     use ethers_core::utils::hex;
     use serde_json::json;
 
-    pub fn test_wallet_signer(pub_key: Vec<u8>) -> Result<Association, AssociationError> {
-        Association::test(pub_key)
+    pub fn test_wallet_signer(pub_key: Vec<u8>) -> Result<Eip191Association, AssociationError> {
+        Eip191Association::test(pub_key)
     }
 
     #[test]

--- a/xmtp/src/association.rs
+++ b/xmtp/src/association.rs
@@ -27,12 +27,12 @@ pub enum AssociationError {
 /// An Association is link between a blockchain account and an xmtp installation for the purposes of
 /// authentication.
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
-pub struct Association {
+pub struct Eip191Association {
     text: AssociationText,
     signature: RecoverableSignature,
 }
 
-impl Association {
+impl Eip191Association {
     pub fn new(
         installation_public_key: &[u8],
         text: AssociationText,
@@ -90,8 +90,8 @@ impl Association {
     }
 }
 
-impl From<Association> for Eip191AssociationProto {
-    fn from(assoc: Association) -> Self {
+impl From<Eip191Association> for Eip191AssociationProto {
+    fn from(assoc: Eip191Association) -> Self {
         Self {
             wallet_address: assoc.address(),
             // Hardcoded version for now
@@ -165,7 +165,7 @@ pub mod tests {
     use xmtp_cryptography::{signature::h160addr_to_string, utils::rng};
     use xmtp_proto::xmtp::v3::message_contents::Eip191Association as Eip191AssociationProto;
 
-    use super::{Association, AssociationText};
+    use super::{AssociationText, Eip191Association};
 
     #[tokio::test]
     async fn assoc_gen() {
@@ -200,11 +200,11 @@ pub mod tests {
             .await
             .expect("BadSign");
 
-        assert!(Association::new(&key_bytes, text.clone(), sig.into()).is_ok());
-        assert!(Association::new(&bad_key_bytes, text.clone(), sig.into()).is_err());
-        assert!(Association::new(&key_bytes, bad_text1.clone(), sig.into()).is_err());
-        assert!(Association::new(&key_bytes, bad_text2.clone(), sig.into()).is_err());
-        assert!(Association::new(&key_bytes, text.clone(), other_sig.into()).is_err());
+        assert!(Eip191Association::new(&key_bytes, text.clone(), sig.into()).is_ok());
+        assert!(Eip191Association::new(&bad_key_bytes, text.clone(), sig.into()).is_err());
+        assert!(Eip191Association::new(&key_bytes, bad_text1.clone(), sig.into()).is_err());
+        assert!(Eip191Association::new(&key_bytes, bad_text2.clone(), sig.into()).is_err());
+        assert!(Eip191Association::new(&key_bytes, text.clone(), other_sig.into()).is_err());
     }
 
     #[tokio::test]
@@ -218,7 +218,7 @@ pub mod tests {
         };
         let sig = wallet.sign_message(text.text()).await.expect("BadSign");
 
-        let assoc = Association::new(&key_bytes, text.clone(), sig.into()).unwrap();
+        let assoc = Eip191Association::new(&key_bytes, text.clone(), sig.into()).unwrap();
         let proto_signature: Eip191AssociationProto = assoc.into();
 
         assert_eq!(proto_signature.association_text_version, 1);

--- a/xmtp/src/builder.rs
+++ b/xmtp/src/builder.rs
@@ -1,6 +1,6 @@
 use crate::{
     account::{Account, AccountError},
-    association::{Association, AssociationError, AssociationText},
+    association::{AssociationError, AssociationText, Eip191Association},
     client::{Client, Network},
     storage::{now, EncryptedMessageStore, StoredUser},
     types::networking::XmtpApiClient,
@@ -142,7 +142,7 @@ where
     }
 
     fn sign_new_account(owner: &O) -> Result<Account, ClientBuilderError> {
-        let sign = |public_key_bytes: Vec<u8>| -> Result<Association, AssociationError> {
+        let sign = |public_key_bytes: Vec<u8>| -> Result<Eip191Association, AssociationError> {
             let assoc_text = AssociationText::Static {
                 blockchain_address: owner.get_address(),
                 installation_public_key: public_key_bytes.clone(),
@@ -150,7 +150,7 @@ where
 
             let signature = owner.sign(&assoc_text.text())?;
 
-            Association::new(public_key_bytes.as_slice(), assoc_text, signature)
+            Eip191Association::new(public_key_bytes.as_slice(), assoc_text, signature)
         };
 
         Account::generate(sign).map_err(ClientBuilderError::AccountInitialization)

--- a/xmtp/src/builder.rs
+++ b/xmtp/src/builder.rs
@@ -144,8 +144,8 @@ where
     fn sign_new_account(owner: &O) -> Result<Account, ClientBuilderError> {
         let sign = |public_key_bytes: Vec<u8>| -> Result<Association, AssociationError> {
             let assoc_text = AssociationText::Static {
-                addr: owner.get_address(),
-                account_public_key: public_key_bytes.clone(),
+                blockchain_address: owner.get_address(),
+                installation_public_key: public_key_bytes.clone(),
             };
 
             let signature = owner.sign(&assoc_text.text())?;

--- a/xmtp/src/client.rs
+++ b/xmtp/src/client.rs
@@ -122,7 +122,7 @@ where
         self.is_initialized = true;
 
         // Send any unsent messages
-        if let Err(err) = Conversations::process_outbound_messages(&self).await {
+        if let Err(err) = Conversations::process_outbound_messages(self).await {
             log::error!("Could not process outbound messages on init: {:?}", err)
         }
 

--- a/xmtp/src/contact.rs
+++ b/xmtp/src/contact.rs
@@ -9,7 +9,7 @@ use xmtp_proto::xmtp::v3::message_contents::{
 };
 
 use crate::{
-    association::{Association, AssociationError},
+    association::{AssociationError, Eip191Association},
     utils::key_fingerprint,
     vmac_protos::ProtoWrapper,
 };
@@ -69,7 +69,7 @@ impl Contact {
         extract_identity_key(self.bundle.clone())
     }
 
-    pub fn association(&self) -> Result<Association, ContactError> {
+    pub fn association(&self) -> Result<Eip191Association, ContactError> {
         let ik = self.identity_key()?;
         let key_bytes = match ik.clone().key {
             Some(key) => match key.union {
@@ -81,7 +81,7 @@ impl Contact {
         let proto_association = extract_proto_association(ik)?;
 
         // This will validate that the signature matches the wallet address
-        let association = Association::from_proto_with_expected_address(
+        let association = Eip191Association::from_proto_with_expected_address(
             key_bytes.as_slice(),
             proto_association,
             self.wallet_address.clone(),

--- a/xmtp/src/conversation.rs
+++ b/xmtp/src/conversation.rs
@@ -153,7 +153,7 @@ where
         )
         .store(&mut self.client.store.conn().unwrap())?;
 
-        if let Err(err) = Conversations::process_outbound_messages(&self.client).await {
+        if let Err(err) = Conversations::process_outbound_messages(self.client).await {
             log::error!("Could not process outbound messages on init: {:?}", err)
         }
 


### PR DESCRIPTION
An association proves that a given XMTP installation key is acting on behalf of a given blockchain account address, typically using a signature of some kind. There can be multiple different types of associations, one of which is an [EIP191 association](https://eips.ethereum.org/EIPS/eip-191). I'm adding [another association type](https://github.com/xmtp/proto/pull/97) shortly.

We haven't settled on consistent terminology until recently. To avoid confusion, this renames:
- Association.addr -> Association.blockchain_address
- Association.account_public_key -> Association.installation_public_key
- Association -> Eip191Association

Also fix some lints/unused imports.

**Note: This PR will break any existing databases used by the CLI. Please re-register any installations after this lands.**