### PR TITLE
Update insert_or_ignore

### DIFF
--- a/xmtp/src/builder.rs
+++ b/xmtp/src/builder.rs
@@ -170,7 +170,7 @@ where
             #[cfg(test)]
             AccountStrategy::ExternalAccount(a) => a,
         };
-        store.insert_or_ignore_user(
+        store.insert_user(
             &mut store.conn()?,
             StoredUser {
                 user_address: account.addr(),

--- a/xmtp/src/client.rs
+++ b/xmtp/src/client.rs
@@ -225,7 +225,7 @@ where
         );
 
         conn.transaction(|transaction_manager| -> Result<(), ClientError> {
-            self.store.insert_or_ignore_user(
+            self.store.insert_user(
                 transaction_manager,
                 StoredUser {
                     user_address: user_address.to_string(),
@@ -238,8 +238,8 @@ where
                 let session = self.create_uninitialized_session(&install.get_contact()?)?;
 
                 self.store
-                    .insert_or_ignore_install(transaction_manager, install)?;
-                self.store.insert_or_ignore_session(
+                    .insert_install(transaction_manager, install)?;
+                self.store.insert_session(
                     transaction_manager,
                     StoredSession::try_from(&session)?,
                 )?;

--- a/xmtp/src/conversation.rs
+++ b/xmtp/src/conversation.rs
@@ -115,7 +115,7 @@ where
     ) -> Result<(), ConversationError> {
         let peer_address = peer_addr_from_convo_id(convo_id, &client.wallet_address())?;
         let created_at = now();
-        client.store.insert_or_ignore_user(
+        client.store.insert_user(
             conn,
             StoredUser {
                 user_address: peer_address.clone(),
@@ -124,7 +124,7 @@ where
             },
         )?;
 
-        client.store.insert_or_ignore_conversation(
+        client.store.insert_conversation(
             conn,
             StoredConversation {
                 peer_address,

--- a/xmtp/src/conversations.rs
+++ b/xmtp/src/conversations.rs
@@ -194,7 +194,7 @@ impl<A: XmtpApiClient> Conversations<A> {
 
         client
             .store
-            .insert_or_ignore_message(conn, stored_message)?;
+            .insert_message(conn, stored_message)?;
 
         Ok(())
     }


### PR DESCRIPTION
This PR updates usages of insert_or_ignore to consume a helper that runs Ok() in the event of a duplicate primary key error. Updated var names and added some tests for the helper.

This should close out https://github.com/xmtp/libxmtp/issues/227.