### PR TITLE
Lower the timeout values for the rust connection

### DIFF
--- a/xmtp_networking/src/grpc_api_helper.rs
+++ b/xmtp_networking/src/grpc_api_helper.rs
@@ -46,7 +46,7 @@ fn get_tls_connector() -> HttpsConnector<tower::timeout::Timeout<HttpConnector>>
                 .enable_http2()
                 .wrap_connector(s)
         })
-        .timeout(Duration::from_secs(2))
+        .timeout(Duration::from_secs(5))
         .service(http)
 }
 
@@ -76,7 +76,7 @@ impl Client {
             let tls_conn = hyper::Client::builder()
                 .pool_idle_timeout(Duration::from_secs(5))
                 .http2_keep_alive_interval(Duration::from_secs(3))
-                .http2_keep_alive_timeout(Duration::from_secs(2))
+                .http2_keep_alive_timeout(Duration::from_secs(5))
                 .build(connector);
 
             let uri =
@@ -91,11 +91,11 @@ impl Client {
         } else {
             let channel = Channel::from_shared(host)
                 .map_err(|e| Error::new(ErrorKind::SetupError).with(e))?
-                .timeout(Duration::from_secs(2))
-                .connect_timeout(Duration::from_secs(2))
-                .tcp_keepalive(Some(Duration::from_secs(5)))
-                .http2_keep_alive_interval(Duration::from_secs(5))
-                .keep_alive_timeout(Duration::from_secs(2))
+                .timeout(Duration::from_secs(5))
+                .connect_timeout(Duration::from_secs(5))
+                .tcp_keepalive(Some(Duration::from_secs(3)))
+                .http2_keep_alive_interval(Duration::from_secs(3))
+                .keep_alive_timeout(Duration::from_secs(5))
                 .connect()
                 .await
                 .map_err(|e| Error::new(ErrorKind::SetupError).with(e))?;

--- a/xmtp_networking/src/grpc_api_helper.rs
+++ b/xmtp_networking/src/grpc_api_helper.rs
@@ -46,7 +46,7 @@ fn get_tls_connector() -> HttpsConnector<tower::timeout::Timeout<HttpConnector>>
                 .enable_http2()
                 .wrap_connector(s)
         })
-        .timeout(Duration::from_secs(5))
+        .timeout(Duration::from_secs(2))
         .service(http)
 }
 
@@ -74,9 +74,9 @@ impl Client {
             let connector = get_tls_connector();
 
             let tls_conn = hyper::Client::builder()
-                .pool_idle_timeout(Duration::from_secs(30))
-                .http2_keep_alive_interval(Duration::from_secs(10))
-                .http2_keep_alive_timeout(Duration::from_secs(5))
+                .pool_idle_timeout(Duration::from_secs(5))
+                .http2_keep_alive_interval(Duration::from_secs(3))
+                .http2_keep_alive_timeout(Duration::from_secs(2))
                 .build(connector);
 
             let uri =
@@ -91,11 +91,11 @@ impl Client {
         } else {
             let channel = Channel::from_shared(host)
                 .map_err(|e| Error::new(ErrorKind::SetupError).with(e))?
-                .timeout(Duration::from_secs(5))
-                .connect_timeout(Duration::from_secs(5))
-                .tcp_keepalive(Some(Duration::from_secs(10)))
-                .http2_keep_alive_interval(Duration::from_secs(10))
-                .keep_alive_timeout(Duration::from_secs(5))
+                .timeout(Duration::from_secs(2))
+                .connect_timeout(Duration::from_secs(2))
+                .tcp_keepalive(Some(Duration::from_secs(5)))
+                .http2_keep_alive_interval(Duration::from_secs(5))
+                .keep_alive_timeout(Duration::from_secs(2))
                 .connect()
                 .await
                 .map_err(|e| Error::new(ErrorKind::SetupError).with(e))?;


### PR DESCRIPTION
This PR https://github.com/xmtp/libxmtp/pull/261 greatly improved the disconnection issue https://github.com/xmtp/xmtp-react-native/issues/129 in react native. But hovering around 10 seconds to reconnect was still not ideal. Lets drop this timeout down even lower for the time being to improve this for current integrators while we look to find a better improvement here. The only draw back is that this may cause a lot more unnecessary network pings or maybe it won't be that noticeable.

Since I'm not super familiar with Rust I looked to other repos with hyper implementations to see what timeouts they used for these fields
pool_idle_timeout: https://github.com/risingwavelabs/risingwave/blob/a46292eedc9a6d1ad10b5fb3e7d89495edfccad2/src/connector/src/common.rs#L423-L431
Otherwise just halved them. The common theme was 5 seconds for all the timeouts so maybe I dropped some of these down too low. Open to thoughts.
