### PR TITLE
fix: add .subscribe / async support to wasm client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,6 +296,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindings_wasm"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "getrandom 0.2.9",
+ "hex",
+ "js-sys",
+ "prost",
+ "prost-types",
+ "uuid 1.3.3",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test",
+ "xmtp_api_grpc_gateway",
+ "xmtp_cryptography",
+ "xmtp_proto",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,6 +776,16 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "const-oid"
@@ -3883,10 +3912,12 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.24.0",
+ "tokio-util 0.7.8",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 0.25.2",
  "winreg",
@@ -4168,6 +4199,12 @@ checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
 dependencies = [
  "parking_lot",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -4913,6 +4950,8 @@ dependencies = [
  "bytes 1.4.0",
  "futures-core",
  "futures-sink",
+ "futures-util",
+ "hashbrown",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -5366,6 +5405,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
+name = "wasm-bindgen-test"
+version = "0.3.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e6e302a7ea94f83a6d09e78e7dc7d9ca7b186bc2829c24a22d0753efd680671"
+dependencies = [
+ "console_error_panic_hook",
+ "js-sys",
+ "scoped-tls",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecb993dd8c836930ed130e020e77d9b2e65dd0fbab1b67c790b0f5d80b11a575"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4609d447824375f43e1ffbc051b50ad8f4b3ae8219680c94452ea05eb240ac7"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5798,6 +5874,8 @@ name = "xmtp_api_grpc"
 version = "0.1.0"
 dependencies = [
  "base64 0.21.1",
+ "futures",
+ "futures-util",
  "http-body",
  "hyper",
  "hyper-rustls",
@@ -5812,6 +5890,32 @@ dependencies = [
  "tower",
  "uuid 1.3.3",
  "webpki-roots 0.23.0",
+ "xmtp_proto",
+]
+
+[[package]]
+name = "xmtp_api_grpc_gateway"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "bytes 1.4.0",
+ "futures",
+ "futures-util",
+ "getrandom 0.2.9",
+ "hex",
+ "js-sys",
+ "prost",
+ "prost-types",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util 0.7.8",
+ "uuid 1.3.3",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test",
+ "xmtp_cryptography",
  "xmtp_proto",
 ]
 
@@ -5838,6 +5942,7 @@ name = "xmtp_proto"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "futures",
  "pbjson",
  "pbjson-types",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,12 @@
 [workspace]
 
 members = [
+  "bindings_wasm",
   "examples/cli",
   "xmtp",
   "xmtp_cryptography",
   "xmtp_api_grpc",
+  "xmtp_api_grpc_gateway",
   "xmtp_proto",
   "xmtp_v2",
 ]
@@ -12,10 +14,14 @@ members = [
 exclude = [
   "bindings_ffi",
   "bindings_js",
-  "bindings_wasm",
-  "xmtp_api_grpc_gateway",
 ]
 
 # Make the feature resolver explicit.
 # See https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html#details
 resolver = "2"
+
+[profile.release.package.bindings_wasm]
+opt-level = "s"
+
+[profile.release.package.xmtp_api_grpc_gateway]
+opt-level = "s"

--- a/bindings_ffi/src/lib.rs
+++ b/bindings_ffi/src/lib.rs
@@ -13,7 +13,7 @@ use xmtp::conversation::{ListMessagesOptions, Conversation};
 use xmtp::conversations::Conversations;
 use xmtp::storage::{EncryptedMessageStore, EncryptionKey, StorageOption, StoredMessage};
 use xmtp::types::Address;
-use xmtp_api_grpc::grpc_api_helper::Client as TonicApiClient;
+use xmtp_api_grpc::grpc_api_helper::XmtpGrpcClient as TonicApiClient;
 
 use crate::inbox_owner::RustInboxOwner;
 pub use crate::inbox_owner::SigningError;

--- a/bindings_wasm/Cargo.toml
+++ b/bindings_wasm/Cargo.toml
@@ -23,5 +23,3 @@ xmtp_proto = { path = "../xmtp_proto", features = ["proto_full"] }
 uuid = { version = "1.3.1", features = ["v4"] }
 wasm-bindgen-test = "0.3.34"
 
-[profile.release]
-opt-level = "s"

--- a/bindings_wasm/src/lib.rs
+++ b/bindings_wasm/src/lib.rs
@@ -3,7 +3,7 @@ use xmtp_api_grpc_gateway::XmtpGrpcGatewayClient;
 
 #[wasm_bindgen]
 pub struct WasmXmtpClient {
-    api: XmtpGrpcGatewayClient,
+    api: XmtpGrpcGatewayClient<'static>,
     // inbox_owner: WasmInboxOwner,
 }
 

--- a/bindings_wasm/src/lib.rs
+++ b/bindings_wasm/src/lib.rs
@@ -3,7 +3,7 @@ use xmtp_api_grpc_gateway::XmtpGrpcGatewayClient;
 
 #[wasm_bindgen]
 pub struct WasmXmtpClient {
-    api: XmtpGrpcGatewayClient<'static>,
+    api: XmtpGrpcGatewayClient,
     // inbox_owner: WasmInboxOwner,
 }
 

--- a/bindings_wasm/tests/web.rs
+++ b/bindings_wasm/tests/web.rs
@@ -6,9 +6,7 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen_test::*;
 use xmtp_cryptography::signature::RecoverableSignature;
 use xmtp_proto::api_client::XmtpApiClient;
-use xmtp_proto::xmtp::message_api::v1::{
-    BatchQueryRequest, Envelope, PublishRequest, QueryRequest,
-};
+use xmtp_proto::xmtp::message_api::v1::{Envelope, QueryRequest};
 
 // Only run these tests in a browser.
 wasm_bindgen_test_configure!(run_in_browser);

--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -20,7 +20,7 @@ use xmtp::storage::{
     now, EncryptedMessageStore, EncryptionKey, MessageState, StorageError, StorageOption,
 };
 use xmtp::InboxOwner;
-use xmtp_api_grpc::grpc_api_helper::Client as ApiClient;
+use xmtp_api_grpc::grpc_api_helper::XmtpGrpcClient as ApiClient;
 use xmtp_cryptography::signature::{RecoverableSignature, SignatureError};
 use xmtp_cryptography::utils::{rng, seeded_rng, LocalWallet};
 use xmtp_proto::api_client::XmtpApiClient;

--- a/xmtp/Cargo.toml
+++ b/xmtp/Cargo.toml
@@ -36,7 +36,7 @@ ethers-core = "2.0.4"
 prost = { version = "0.11", features = ["prost-derive"] }
 futures = "0.3.28"
 base64 = "0.21.1"
-tokio = "1.28.1"
+tokio = { version = "1.28.1", features = ["macros", "time"] }
 anyhow = "1.0.71"
 
 [dev-dependencies]

--- a/xmtp/src/conversation.rs
+++ b/xmtp/src/conversation.rs
@@ -12,7 +12,6 @@ use crate::{
     Client, Store,
 };
 use xmtp_proto::api_client::XmtpApiClient;
-use xmtp_proto::xmtp::message_api::v1::PublishRequest;
 
 use prost::{DecodeError, Message};
 // use async_trait::async_trait;

--- a/xmtp/src/mock_xmtp_api_client.rs
+++ b/xmtp/src/mock_xmtp_api_client.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use futures::stream::Empty;
 use std::{
     collections::HashMap,
     sync::{Arc, Mutex},
@@ -6,20 +7,6 @@ use std::{
 use xmtp_proto::api_client::*;
 
 pub struct MockXmtpApiSubscription {}
-
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-impl XmtpApiSubscription for MockXmtpApiSubscription {
-    fn is_closed(&self) -> bool {
-        false
-    }
-
-    async fn get_messages(&mut self) -> Vec<Envelope> {
-        vec![]
-    }
-
-    fn close_stream(&mut self) {}
-}
 
 struct InnerMockXmtpApiClient {
     pub messages: HashMap<String, Vec<Envelope>>,
@@ -58,7 +45,7 @@ impl Clone for MockXmtpApiClient {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl XmtpApiClient for MockXmtpApiClient {
-    type Subscription = MockXmtpApiSubscription;
+    type Subscription = Empty<Envelope>;
 
     fn set_app_version(&mut self, version: String) {
         let mut inner = self.inner_client.lock().unwrap();
@@ -100,7 +87,7 @@ impl XmtpApiClient for MockXmtpApiClient {
         Err(Error::new(ErrorKind::SubscribeError))
     }
 
-    async fn batch_query(&self, request: BatchQueryRequest) -> Result<BatchQueryResponse, Error> {
+    async fn batch_query(&self, _request: BatchQueryRequest) -> Result<BatchQueryResponse, Error> {
         Err(Error::new(ErrorKind::BatchQueryError))
     }
 }

--- a/xmtp/src/mock_xmtp_api_client.rs
+++ b/xmtp/src/mock_xmtp_api_client.rs
@@ -7,12 +7,14 @@ use xmtp_proto::api_client::*;
 
 pub struct MockXmtpApiSubscription {}
 
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl XmtpApiSubscription for MockXmtpApiSubscription {
     fn is_closed(&self) -> bool {
         false
     }
 
-    fn get_messages(&self) -> Vec<Envelope> {
+    async fn get_messages(&mut self) -> Vec<Envelope> {
         vec![]
     }
 

--- a/xmtp_api_grpc/Cargo.toml
+++ b/xmtp_api_grpc/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+futures-util = "0.3"
+futures = "0.3"
 tonic = "^0.9"
 xmtp_proto = { path = "../xmtp_proto", features = ["proto_full", "grpc"] }
 prost = { version  = "^0.11", features = ["prost-derive"] }

--- a/xmtp_api_grpc/src/grpc_api_helper.rs
+++ b/xmtp_api_grpc/src/grpc_api_helper.rs
@@ -245,12 +245,13 @@ impl Subscription {
     }
 }
 
-impl XmtpApiSubscription for Subscription {
+#[async_trait]
+impl<'a> XmtpApiSubscription for Subscription {
     fn is_closed(&self) -> bool {
         self.closed.load(Ordering::SeqCst)
     }
 
-    fn get_messages(&self) -> Vec<Envelope> {
+    async fn get_messages(&mut self) -> Vec<Envelope> {
         let mut pending = self.pending.lock().unwrap();
         let items = pending.drain(..).collect::<Vec<Envelope>>();
         items

--- a/xmtp_api_grpc/src/lib.rs
+++ b/xmtp_api_grpc/src/lib.rs
@@ -116,12 +116,12 @@ mod tests {
             tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
             // Ensure that messages appear
-            let results = stream_handler.get_messages();
+            let results = stream_handler.get_messages().await;
             println!("{}", results.len());
             assert!(results.len() == 1);
 
             // Ensure that the messages array has been cleared
-            let second_results = stream_handler.get_messages();
+            let second_results = stream_handler.get_messages().await;
             assert!(second_results.is_empty());
 
             // Ensure the is_closed status is propagated

--- a/xmtp_api_grpc_gateway/Cargo.lock
+++ b/xmtp_api_grpc_gateway/Cargo.lock
@@ -4038,6 +4038,7 @@ name = "xmtp_proto"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "futures",
  "pbjson",
  "pbjson-types",
  "prost",

--- a/xmtp_api_grpc_gateway/Cargo.lock
+++ b/xmtp_api_grpc_gateway/Cargo.lock
@@ -39,6 +39,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1438,6 +1449,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2661,10 +2675,12 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 0.25.2",
  "winreg",
@@ -3392,7 +3408,19 @@ dependencies = [
  "num_cpus",
  "pin-project-lite",
  "socket2 0.5.4",
+ "tokio-macros",
  "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -3439,6 +3467,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
+ "hashbrown 0.12.3",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -3767,6 +3797,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4609d447824375f43e1ffbc051b50ad8f4b3ae8219680c94452ea05eb240ac7"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3952,12 +3995,19 @@ name = "xmtp_api_grpc_gateway"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "bytes",
+ "futures",
+ "futures-util",
  "getrandom",
  "hex",
  "js-sys",
  "prost",
  "prost-types",
  "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
  "uuid 1.4.1",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/xmtp_api_grpc_gateway/Cargo.toml
+++ b/xmtp_api_grpc_gateway/Cargo.toml
@@ -19,7 +19,7 @@ prost-types = "0.11"
 reqwest = { version = "0.11.20", features = ["json", "stream"] }
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0"
-tokio = {version="1.28.1", features=["rt", "sync", "macros", "io-util"]}
+tokio = {version="1.28.1", features=["rt", "sync", "time", "macros", "io-util"]}
 tokio-util = {version="0.7.8", features=["codec", "rt", "io-util"]}
 wasm-bindgen = "0.2.87"
 wasm-bindgen-futures = "0.4.37"
@@ -29,6 +29,3 @@ xmtp_proto = { path = "../xmtp_proto", features = ["proto_full"] }
 [dev-dependencies]
 uuid = { version = "1.3.1", features = ["v4"] }
 wasm-bindgen-test = "0.3.34"
-
-[profile.release]
-opt-level = "s"

--- a/xmtp_api_grpc_gateway/Cargo.toml
+++ b/xmtp_api_grpc_gateway/Cargo.toml
@@ -8,12 +8,19 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 async-trait = "0.1.68"
+bytes = "1.4.0"
+futures = "0.3"
+futures-util = "0.3"
 getrandom = { version = "0.2", features = ["js"] }
 hex = "0.4"
 js-sys = "0.3"
 prost = { version = "0.11", features = ["prost-derive"] }
 prost-types = "0.11"
-reqwest = { version = "0.11.20", features = ["json"] }
+reqwest = { version = "0.11.20", features = ["json", "stream"] }
+serde = { version = "1.0.160", features = ["derive"] }
+serde_json = "1.0"
+tokio = {version="1.28.1", features=["rt", "sync", "macros", "io-util"]}
+tokio-util = {version="0.7.8", features=["codec", "rt", "io-util"]}
 wasm-bindgen = "0.2.87"
 wasm-bindgen-futures = "0.4.37"
 xmtp_cryptography = { path = "../xmtp_cryptography", features = ["ws"] }

--- a/xmtp_api_grpc_gateway/src/lib.rs
+++ b/xmtp_api_grpc_gateway/src/lib.rs
@@ -1,14 +1,10 @@
 use async_trait::async_trait;
-use bytes::Bytes;
 use futures_util::stream::LocalBoxStream;
-use futures_util::task::noop_waker_ref;
 use futures_util::{FutureExt, StreamExt, TryStreamExt};
 use serde::Deserialize;
-use std::marker::PhantomData;
-use std::task::{Context, Poll};
 use tokio_util::codec::{FramedRead, LinesCodec};
 use tokio_util::io::StreamReader;
-use xmtp_proto::api_client::{Error, ErrorKind, XmtpApiClient, XmtpApiSubscription};
+use xmtp_proto::api_client::{Error, ErrorKind, XmtpApiClient};
 use xmtp_proto::xmtp::message_api::v1::{
     BatchQueryRequest, BatchQueryResponse, Envelope, PublishRequest, PublishResponse, QueryRequest,
     QueryResponse, SubscribeRequest,
@@ -18,25 +14,24 @@ use xmtp_proto::xmtp::message_api::v1::{
 pub const LOCALHOST_ADDRESS: &str = "http://localhost:5555";
 pub const DEV_ADDRESS: &str = "https://dev.xmtp.network:5555";
 
-pub struct XmtpGrpcGatewayClient<'a> {
+pub struct XmtpGrpcGatewayClient {
     url: String,
     http: reqwest::Client,
-    phantom: PhantomData<&'a XmtpGrpcGatewaySubscription<'a>>,
 }
 
-impl<'a> XmtpGrpcGatewayClient<'a> {
+impl XmtpGrpcGatewayClient {
     pub fn new(url: String) -> Self {
         XmtpGrpcGatewayClient {
             url,
             http: reqwest::Client::new(),
-            phantom: PhantomData,
         }
     }
 }
 
-#[async_trait(?Send)]
-impl<'a> XmtpApiClient for XmtpGrpcGatewayClient<'a> {
-    type Subscription = XmtpGrpcGatewaySubscription<'a>;
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl XmtpApiClient for XmtpGrpcGatewayClient {
+    type Subscription = LocalBoxStream<'static, Envelope>;
 
     fn set_app_version(&mut self, _version: String) {
         // TODO
@@ -61,10 +56,7 @@ impl<'a> XmtpApiClient for XmtpGrpcGatewayClient<'a> {
             .map_err(|e| Error::new(ErrorKind::PublishError).with(e))?)
     }
 
-    async fn subscribe(
-        &self,
-        request: SubscribeRequest,
-    ) -> Result<XmtpGrpcGatewaySubscription<'a>, Error> {
+    async fn subscribe(&self, request: SubscribeRequest) -> Result<Self::Subscription, Error> {
         // grpc-gateway streams newline-delimited JSON bodies
         let response = self
             .http
@@ -77,7 +69,23 @@ impl<'a> XmtpApiClient for XmtpGrpcGatewayClient<'a> {
             .flatten()
             .boxed_local();
 
-        Ok(XmtpGrpcGatewaySubscription::start(response))
+        let bytes_reader = StreamReader::new(
+            response.map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err)),
+        );
+        let codec = LinesCodec::new_with_max_length(1024 * 1024);
+        let frames_reader = FramedRead::with_capacity(bytes_reader, codec, 8 * 1024 * 1024);
+        let stream = frames_reader
+            .map(|frame_res| match frame_res {
+                Ok(frame_str) => serde_json::from_str::<SubscribeResult>(frame_str.as_str())
+                    .map(|v| v.result)
+                    .map_err(|e| Error::new(ErrorKind::SubscribeError).with(e)),
+                Err(err) => Err(Error::new(ErrorKind::SubscribeError).with(err)),
+            })
+            // Discard any messages that we can't parse.
+            // TODO: consider surfacing these in a log somewhere
+            .filter_map(|r| async move { r.ok() })
+            .boxed_local();
+        return Ok(stream);
     }
 
     async fn query(&self, request: QueryRequest) -> Result<QueryResponse, Error> {
@@ -109,11 +117,6 @@ impl<'a> XmtpApiClient for XmtpGrpcGatewayClient<'a> {
     }
 }
 
-pub struct XmtpGrpcGatewaySubscription<'a> {
-    // When this is `None`, the stream has been closed.
-    pub stream: Option<LocalBoxStream<'a, Result<Envelope, Error>>>,
-}
-
 // The result of calling .subscribe()
 // The grpc-gateway streams newline-delimited JSON bodies
 // in this shape:
@@ -124,76 +127,4 @@ pub struct XmtpGrpcGatewaySubscription<'a> {
 #[derive(Deserialize, Debug)]
 struct SubscribeResult {
     result: Envelope,
-}
-
-impl<'a> XmtpGrpcGatewaySubscription<'a> {
-    pub fn start(req: LocalBoxStream<'a, Result<Bytes, reqwest::Error>>) -> Self {
-        let bytes_reader = StreamReader::new(
-            req.map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err)),
-        );
-        let codec = LinesCodec::new_with_max_length(1024 * 1024);
-        let frames_reader = FramedRead::with_capacity(bytes_reader, codec, 8 * 1024 * 1024);
-        let stream = frames_reader
-            .map(|frame_res| match frame_res {
-                Ok(frame_str) => serde_json::from_str::<SubscribeResult>(frame_str.as_str())
-                    .map(|v| v.result)
-                    .map_err(|e| Error::new(ErrorKind::SubscribeError).with(e)),
-                Err(err) => Err(Error::new(ErrorKind::SubscribeError).with(err)),
-            })
-            .boxed_local();
-
-        XmtpGrpcGatewaySubscription {
-            stream: Some(stream),
-        }
-    }
-}
-
-#[async_trait(?Send)]
-impl<'a> XmtpApiSubscription for XmtpGrpcGatewaySubscription<'a> {
-    fn is_closed(&self) -> bool {
-        return self.stream.is_none();
-    }
-
-    // HACK: this consumes from the stream whatever is already ready.
-    // TODO: implement a JS-friendly promise/future interface instead
-    async fn get_messages(&mut self) -> Vec<Envelope> {
-        if self.stream.is_none() {
-            return vec![];
-        }
-        let stream = self.stream.as_mut().unwrap();
-        let mut items: Vec<Envelope> = Vec::new();
-
-        // TODO: consider using `size_hint` and fixing buffer size
-        // let (lower, upper) = self.stream.unwrap().size_hint();
-        // let capacity = clamp(lower, 10, 50);
-        // items.reserve(capacity);
-        // ... and on append: if items.len() >= capacity { return items; }
-
-        // For now we rely on the subscriber to periodically call `get_messages`.
-        // There is no hint to JS to tell it when to wake up and check for more.
-        // So we use this no-op waker as context.
-        // TODO: implement JS event or promise instead.
-        let mut cx = Context::from_waker(noop_waker_ref());
-        loop {
-            match stream.as_mut().poll_next(&mut cx) {
-                Poll::Pending => {
-                    return items;
-                }
-                Poll::Ready(Some(item)) => {
-                    if item.is_ok() {
-                        items.push(item.unwrap());
-                    }
-                    // else item.is_err() and we discard it.
-                }
-                Poll::Ready(None) => {
-                    self.stream = None;
-                    return items;
-                }
-            }
-        }
-    }
-
-    fn close_stream(&mut self) {
-        self.stream = None;
-    }
 }

--- a/xmtp_api_grpc_gateway/src/lib.rs
+++ b/xmtp_api_grpc_gateway/src/lib.rs
@@ -1,4 +1,13 @@
 use async_trait::async_trait;
+use bytes::Bytes;
+use futures_util::stream::LocalBoxStream;
+use futures_util::task::noop_waker_ref;
+use futures_util::{FutureExt, StreamExt, TryStreamExt};
+use serde::Deserialize;
+use std::marker::PhantomData;
+use std::task::{Context, Poll};
+use tokio_util::codec::{FramedRead, LinesCodec};
+use tokio_util::io::StreamReader;
 use xmtp_proto::api_client::{Error, ErrorKind, XmtpApiClient, XmtpApiSubscription};
 use xmtp_proto::xmtp::message_api::v1::{
     BatchQueryRequest, BatchQueryResponse, Envelope, PublishRequest, PublishResponse, QueryRequest,
@@ -9,23 +18,25 @@ use xmtp_proto::xmtp::message_api::v1::{
 pub const LOCALHOST_ADDRESS: &str = "http://localhost:5555";
 pub const DEV_ADDRESS: &str = "https://dev.xmtp.network:5555";
 
-pub struct XmtpGrpcGatewayClient {
+pub struct XmtpGrpcGatewayClient<'a> {
     url: String,
     http: reqwest::Client,
+    phantom: PhantomData<&'a XmtpGrpcGatewaySubscription<'a>>,
 }
 
-impl XmtpGrpcGatewayClient {
+impl<'a> XmtpGrpcGatewayClient<'a> {
     pub fn new(url: String) -> Self {
         XmtpGrpcGatewayClient {
             url,
             http: reqwest::Client::new(),
+            phantom: PhantomData,
         }
     }
 }
 
 #[async_trait(?Send)]
-impl XmtpApiClient for XmtpGrpcGatewayClient {
-    type Subscription = XmtpGrpcGatewaySubscription;
+impl<'a> XmtpApiClient for XmtpGrpcGatewayClient<'a> {
+    type Subscription = XmtpGrpcGatewaySubscription<'a>;
 
     fn set_app_version(&mut self, _version: String) {
         // TODO
@@ -36,67 +47,153 @@ impl XmtpApiClient for XmtpGrpcGatewayClient {
         token: String,
         request: PublishRequest,
     ) -> Result<PublishResponse, Error> {
-        let res: PublishResponse = self
+        let response = self
             .http
             .post(&format!("{}/message/v1/publish", self.url))
             .bearer_auth(token)
             .json(&request)
             .send()
             .await
-            .map_err(|e| Error::new(ErrorKind::PublishError).with(e))?
-            .json()
-            .await
             .map_err(|e| Error::new(ErrorKind::PublishError).with(e))?;
-        Ok(res)
+        Ok(response
+            .json::<PublishResponse>()
+            .await
+            .map_err(|e| Error::new(ErrorKind::PublishError).with(e))?)
     }
 
     async fn subscribe(
         &self,
-        _request: SubscribeRequest,
-    ) -> Result<XmtpGrpcGatewaySubscription, Error> {
-        // TODO
-        Err(Error::new(ErrorKind::SubscribeError))
+        request: SubscribeRequest,
+    ) -> Result<XmtpGrpcGatewaySubscription<'a>, Error> {
+        // grpc-gateway streams newline-delimited JSON bodies
+        let response = self
+            .http
+            .post(&format!("{}/message/v1/subscribe", self.url))
+            .json(&request)
+            .send()
+            .into_stream()
+            .filter_map(|r| async move { r.ok() })
+            .map(|r| r.bytes_stream())
+            .flatten()
+            .boxed_local();
+
+        Ok(XmtpGrpcGatewaySubscription::start(response))
     }
 
     async fn query(&self, request: QueryRequest) -> Result<QueryResponse, Error> {
-        let res: QueryResponse = self
+        let response = self
             .http
             .post(&format!("{}/message/v1/query", self.url))
             .json(&request)
             .send()
             .await
-            .map_err(|e| Error::new(ErrorKind::QueryError).with(e))?
-            .json()
-            .await
             .map_err(|e| Error::new(ErrorKind::QueryError).with(e))?;
-        Ok(res)
+        Ok(response
+            .json::<QueryResponse>()
+            .await
+            .map_err(|e| Error::new(ErrorKind::QueryError).with(e))?)
     }
 
     async fn batch_query(&self, request: BatchQueryRequest) -> Result<BatchQueryResponse, Error> {
-        let res: BatchQueryResponse = self
+        let response = self
             .http
             .post(&format!("{}/message/v1/batch-query", self.url))
             .json(&request)
             .send()
             .await
-            .map_err(|e| Error::new(ErrorKind::BatchQueryError).with(e))?
-            .json()
-            .await
             .map_err(|e| Error::new(ErrorKind::BatchQueryError).with(e))?;
-        Ok(res)
+        Ok(response
+            .json::<BatchQueryResponse>()
+            .await
+            .map_err(|e| Error::new(ErrorKind::BatchQueryError).with(e))?)
     }
 }
 
-// TODO: implement JSON segmented streaming
-pub struct XmtpGrpcGatewaySubscription {}
-impl XmtpApiSubscription for XmtpGrpcGatewaySubscription {
+pub struct XmtpGrpcGatewaySubscription<'a> {
+    // When this is `None`, the stream has been closed.
+    pub stream: Option<LocalBoxStream<'a, Result<Envelope, Error>>>,
+}
+
+// The result of calling .subscribe()
+// The grpc-gateway streams newline-delimited JSON bodies
+// in this shape:
+//  { result: { ... Envelope ... } }\n
+//  { result: { ... Envelope ... } }\n
+//  { result: { ... Envelope ... } }\n
+// So we use this to pluck the `Envelope` as the `result`.
+#[derive(Deserialize, Debug)]
+struct SubscribeResult {
+    result: Envelope,
+}
+
+impl<'a> XmtpGrpcGatewaySubscription<'a> {
+    pub fn start(req: LocalBoxStream<'a, Result<Bytes, reqwest::Error>>) -> Self {
+        let bytes_reader = StreamReader::new(
+            req.map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err)),
+        );
+        let codec = LinesCodec::new_with_max_length(1024 * 1024);
+        let frames_reader = FramedRead::with_capacity(bytes_reader, codec, 8 * 1024 * 1024);
+        let stream = frames_reader
+            .map(|frame_res| match frame_res {
+                Ok(frame_str) => serde_json::from_str::<SubscribeResult>(frame_str.as_str())
+                    .map(|v| v.result)
+                    .map_err(|e| Error::new(ErrorKind::SubscribeError).with(e)),
+                Err(err) => Err(Error::new(ErrorKind::SubscribeError).with(err)),
+            })
+            .boxed_local();
+
+        XmtpGrpcGatewaySubscription {
+            stream: Some(stream),
+        }
+    }
+}
+
+#[async_trait(?Send)]
+impl<'a> XmtpApiSubscription for XmtpGrpcGatewaySubscription<'a> {
     fn is_closed(&self) -> bool {
-        true
+        return self.stream.is_none();
     }
 
-    fn get_messages(&self) -> Vec<Envelope> {
-        vec![]
+    // HACK: this consumes from the stream whatever is already ready.
+    // TODO: implement a JS-friendly promise/future interface instead
+    async fn get_messages(&mut self) -> Vec<Envelope> {
+        if self.stream.is_none() {
+            return vec![];
+        }
+        let stream = self.stream.as_mut().unwrap();
+        let mut items: Vec<Envelope> = Vec::new();
+
+        // TODO: consider using `size_hint` and fixing buffer size
+        // let (lower, upper) = self.stream.unwrap().size_hint();
+        // let capacity = clamp(lower, 10, 50);
+        // items.reserve(capacity);
+        // ... and on append: if items.len() >= capacity { return items; }
+
+        // For now we rely on the subscriber to periodically call `get_messages`.
+        // There is no hint to JS to tell it when to wake up and check for more.
+        // So we use this no-op waker as context.
+        // TODO: implement JS event or promise instead.
+        let mut cx = Context::from_waker(noop_waker_ref());
+        loop {
+            match stream.as_mut().poll_next(&mut cx) {
+                Poll::Pending => {
+                    return items;
+                }
+                Poll::Ready(Some(item)) => {
+                    if item.is_ok() {
+                        items.push(item.unwrap());
+                    }
+                    // else item.is_err() and we discard it.
+                }
+                Poll::Ready(None) => {
+                    self.stream = None;
+                    return items;
+                }
+            }
+        }
     }
 
-    fn close_stream(&mut self) {}
+    fn close_stream(&mut self) {
+        self.stream = None;
+    }
 }

--- a/xmtp_proto/Cargo.toml
+++ b/xmtp_proto/Cargo.toml
@@ -9,6 +9,7 @@ async-trait = "0.1.68"
 prost = { version = "0.11", features = ["prost-derive"] }
 # Only necessary if using Protobuf well-known types:
 prost-types = "0.11"
+futures = "0.3"
 tonic = { version = "^0.9", optional = true }
 serde = "1.0.160"
 pbjson = "0.5.1"

--- a/xmtp_proto/src/api_client.rs
+++ b/xmtp_proto/src/api_client.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use futures::Stream;
 use std::{error::Error as StdError, fmt};
 
 pub use super::xmtp::message_api::v1::{
@@ -72,13 +73,9 @@ impl StdError for Error {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-pub trait XmtpApiSubscription {
-    fn is_closed(&self) -> bool;
-    async fn get_messages(&mut self) -> Vec<Envelope>;
-    fn close_stream(&mut self);
-}
+pub trait XmtpApiSubscription {}
+
+impl<T: Stream<Item = Envelope>> XmtpApiSubscription for T {}
 
 // Wasm futures don't have `Send` or `Sync` bounds.
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]

--- a/xmtp_proto/src/api_client.rs
+++ b/xmtp_proto/src/api_client.rs
@@ -72,9 +72,11 @@ impl StdError for Error {
     }
 }
 
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait XmtpApiSubscription {
     fn is_closed(&self) -> bool;
-    fn get_messages(&self) -> Vec<Envelope>;
+    async fn get_messages(&mut self) -> Vec<Envelope>;
     fn close_stream(&mut self);
 }
 


### PR DESCRIPTION
This picks up where #222 left off implementing `Subscribe` in the wasm/grpc-gateway client.