### PR TITLE
Add Rust-Toolchain, refactor generics, typos/cleanup

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "stable"
+components = [ "rustc", "cargo", "clippy", "rustfmt", "rust-analyzer" ]
+targets = [ "wasm32-unknown-unknown" ]
+profile = "default"

--- a/xmtp/src/account.rs
+++ b/xmtp/src/account.rs
@@ -36,13 +36,13 @@ pub enum AccountError {
     Unknown,
 }
 
+/// Holds an account and adds some serialization methods on top
 pub struct VmacAccount {
     account: OlmAccount,
 }
 
-// Struct that holds an account and adds some serialization methods on top
 impl VmacAccount {
-    // Create a new instance
+    /// Create a new instance
     pub fn new(account: OlmAccount) -> Self {
         Self { account }
     }

--- a/xmtp/src/account.rs
+++ b/xmtp/src/account.rs
@@ -32,8 +32,6 @@ pub enum AccountError {
     BadAssocation(#[from] AssociationError),
     #[error("mutex poisoned error")]
     MutexPoisoned,
-    #[error("unknown error")]
-    Unknown,
 }
 
 /// Holds an account and adds some serialization methods on top

--- a/xmtp/src/builder.rs
+++ b/xmtp/src/builder.rs
@@ -27,8 +27,7 @@ pub enum ClientBuilderError {
 
     #[error("Associating an address to account failed")]
     AssociationFailed(#[from] AssociationError),
-    // #[error("Error Initializing Store")]
-    // StoreInitialization(#[from] SE),
+    
     #[error("Error Initializing Account")]
     AccountInitialization(#[from] AccountError),
 

--- a/xmtp/src/builder.rs
+++ b/xmtp/src/builder.rs
@@ -33,9 +33,6 @@ pub enum ClientBuilderError {
 
     #[error("Storage Error")]
     StorageError(#[from] StorageError),
-
-    #[error("No Api Defined")]
-    NoApi
 }
 
 pub enum AccountStrategy<InboxOwner> {

--- a/xmtp/src/client.rs
+++ b/xmtp/src/client.rs
@@ -61,32 +61,29 @@ impl From<&str> for ClientError {
     }
 }
 
-pub struct Client<A>
-where
-    A: XmtpApiClient,
-{
-    pub api_client: A,
+pub struct Client<ApiClient> {
+    pub api_client: ApiClient,
     pub(crate) network: Network,
     pub(crate) account: Account,
     pub store: EncryptedMessageStore, // Temporarily exposed outside crate for CLI client
     is_initialized: bool,
 }
 
-impl<A> core::fmt::Debug for Client<A>
+impl<ApiClient> core::fmt::Debug for Client<ApiClient>
 where
-    A: XmtpApiClient,
+    ApiClient: XmtpApiClient,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "Client({:?})::{}", self.network, self.account.addr())
     }
 }
 
-impl<A> Client<A>
+impl<ApiClient> Client<ApiClient>
 where
-    A: XmtpApiClient,
+    ApiClient: XmtpApiClient,
 {
     pub fn new(
-        api_client: A,
+        api_client: ApiClient,
         network: Network,
         account: Account,
         store: EncryptedMessageStore,
@@ -192,7 +189,7 @@ where
         Ok(())
     }
 
-    /// Fetch Installations from the Network and create unintialized sessions for newly discovered contacts
+    /// Fetch Installations from the Network and create uninitialized sessions for newly discovered contacts
     // TODO: Reduce Visibility
     pub async fn refresh_user_installations(&self, user_address: &str) -> Result<(), ClientError> {
         // Store the timestamp of when the refresh process begins
@@ -448,7 +445,4 @@ mod tests {
             }
         }
     }
-
-    #[tokio::test]
-    async fn test_roundtrip_encrypt() {}
 }

--- a/xmtp/src/client.rs
+++ b/xmtp/src/client.rs
@@ -69,10 +69,7 @@ pub struct Client<ApiClient> {
     is_initialized: bool,
 }
 
-impl<ApiClient> core::fmt::Debug for Client<ApiClient>
-where
-    ApiClient: XmtpApiClient,
-{
+impl<ApiClient> core::fmt::Debug for Client<ApiClient> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "Client({:?})::{}", self.network, self.account.addr())
     }

--- a/xmtp/src/client.rs
+++ b/xmtp/src/client.rs
@@ -170,7 +170,7 @@ impl<ApiClient> Client<ApiClient> {
 
         if let Err(e) = session.store(conn) {
             match e {
-                StorageError::DieselResultError(_) => log::warn!("Session Already exists"), // TODO: Some thought is needed here, is this a critical error which should unroll?
+                StorageError::DieselResult(_) => log::warn!("Session Already exists"), // TODO: Some thought is needed here, is this a critical error which should unroll?
                 other_error => return Err(other_error.into()),
             }
         }

--- a/xmtp/src/contact.rs
+++ b/xmtp/src/contact.rs
@@ -24,9 +24,8 @@ pub enum ContactError {
     Decode(#[from] DecodeError),
     #[error("encode error")]
     Encode(#[from] EncodeError),
-    #[error("unknown error")]
-    Unknown,
 }
+
 #[derive(Clone, Debug)]
 pub struct Contact {
     pub(crate) bundle: InstallationContactBundle,

--- a/xmtp/src/conversation.rs
+++ b/xmtp/src/conversation.rs
@@ -12,7 +12,6 @@ use crate::{
     Client, Store,
 };
 use xmtp_proto::api_client::XmtpApiClient;
-use xmtp_proto::xmtp::message_api::v1::PublishRequest;
 
 use prost::{DecodeError, Message};
 // use async_trait::async_trait;

--- a/xmtp/src/lib.rs
+++ b/xmtp/src/lib.rs
@@ -29,10 +29,6 @@ pub trait Signable {
     fn bytes_to_sign(&self) -> Vec<u8>;
 }
 
-pub trait Errorer {
-    type Error;
-}
-
 // Inserts a model to the underlying data store
 pub trait Store<I> {
     fn store(&self, into: &mut I) -> Result<(), StorageError>;

--- a/xmtp/src/mock_xmtp_api_client.rs
+++ b/xmtp/src/mock_xmtp_api_client.rs
@@ -98,7 +98,7 @@ impl XmtpApiClient for MockXmtpApiClient {
         Err(Error::new(ErrorKind::SubscribeError))
     }
 
-    async fn batch_query(&self, request: BatchQueryRequest) -> Result<BatchQueryResponse, Error> {
+    async fn batch_query(&self, _request: BatchQueryRequest) -> Result<BatchQueryResponse, Error> {
         Err(Error::new(ErrorKind::BatchQueryError))
     }
 }

--- a/xmtp/src/session.rs
+++ b/xmtp/src/session.rs
@@ -97,7 +97,7 @@ impl TryFrom<&StoredSession> for SessionManager {
     type Error = StorageError;
     fn try_from(value: &StoredSession) -> Result<Self, StorageError> {
         let pickle = serde_json::from_slice(&value.vmac_session_data)
-            .map_err(|_| StorageError::SerializationError)?;
+            .map_err(|_| StorageError::Serialization)?;
 
         Ok(Self::new(
             OlmSession::from_pickle(pickle),
@@ -117,7 +117,7 @@ impl TryFrom<&SessionManager> for StoredSession {
             // TODO: Better error handling approach. StoreError and SessionError end up being dependent on eachother
             value
                 .session_bytes()
-                .map_err(|_| StorageError::SerializationError)?,
+                .map_err(|_| StorageError::Serialization)?,
             value.user_address.clone(),
         ))
     }

--- a/xmtp/src/storage/encrypted_store/mod.rs
+++ b/xmtp/src/storage/encrypted_store/mod.rs
@@ -1,11 +1,11 @@
 //! A durable object store powered by Sqlite and Diesel.
 //!
-//! Provides mechanism to store objects between sessions. The behavor of the store can be tailored by
+//! Provides mechanism to store objects between sessions. The behavior of the store can be tailored by
 //! choosing an appropriate `StoreOption`.
 //!
 //! ## Migrations
 //!
-//! Table definitions are located `<PacakgeRoot>/migrations/`. On intialization the store will see if
+//! Table definitions are located `<PacakgeRoot>/migrations/`. On initialization the store will see if
 //! there are any outstanding database migrations and perform them as needed. When updating the table
 //! definitions `schema.rs` must also be updated. To generate the correct schemas you can run
 //! `diesel print-schema` or use `cargo run update-schema` which will update the files for you.      
@@ -19,7 +19,7 @@ use self::{
     schema::{accounts, conversations, installations, messages, refresh_jobs, users, sessions},
 };
 use super::{now, StorageError};
-use crate::{account::Account, utils::is_wallet_address, Errorer, Fetch, Store};
+use crate::{account::Account, utils::is_wallet_address, Fetch, Store};
 use diesel::{
     connection::SimpleConnection,
     prelude::*,
@@ -64,14 +64,10 @@ pub struct EncryptedMessageStore {
     pool: Pool<ConnectionManager<SqliteConnection>>,
 }
 
-impl Errorer for EncryptedMessageStore {
-    type Error = StorageError;
-}
-
 impl Default for EncryptedMessageStore {
     fn default() -> Self {
         Self::new(StorageOption::Ephemeral, Self::generate_enc_key())
-            .expect("Error Occured: tring to create default Ephemeral store")
+            .expect("Error Occurred: trying to create default Ephemeral store")
     }
 }
 

--- a/xmtp/src/storage/errors.rs
+++ b/xmtp/src/storage/errors.rs
@@ -1,24 +1,19 @@
-use crate::contact::ContactError;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum StorageError {
     #[error("Diesel connection error")]
-    DieselConnectError(#[from] diesel::ConnectionError),
+    DieselConnect(#[from] diesel::ConnectionError),
     #[error("Diesel result error: {0}")]
-    DieselResultError(#[from] diesel::result::Error),
+    DieselResult(#[from] diesel::result::Error),
     #[error("Pool error {0}")]
-    PoolError(String),
+    Pool(String),
     #[error("Either incorrect encryptionkey or file is not a db {0}")]
-    DbInitError(String),
+    DbInit(String),
     #[error("Store Error")]
     Store(String),
-    #[error(transparent)]
-    ImplementationError(#[from] anyhow::Error),
-    #[error("ContactError")]
-    ContactError(#[from] ContactError),
     #[error("serialization error")]
-    SerializationError,
+    Serialization,
     #[error("unknown storage error: {0}")]
     Unknown(String),
 }

--- a/xmtp_api_grpc/src/grpc_api_helper.rs
+++ b/xmtp_api_grpc/src/grpc_api_helper.rs
@@ -96,13 +96,6 @@ impl Client {
     }
 }
 
-impl Default for Client {
-    fn default() -> Self {
-        //TODO: Remove once Default constraint lifted from clientBuilder
-        unimplemented!()
-    }
-}
-
 #[async_trait]
 impl XmtpApiClient for Client {
     type Subscription = Subscription;


### PR DESCRIPTION
Fixed a TODO that required `Default` on `XmtpApiClient`. 

I also generally did some refactoring of type parameters, although this is subjective, so I did not do it everywhere (mostly in the builder and ClientBuilder). I wanted to get thoughts on it. IMO, it's much easier to understand generics in code + documentation like `Widget<Frame, Foo, Crypto>` rather than the terse version `Widget<Q, N, O, X, P>`, especially as usage of generics increases. This does have the downside of occasionally breaking the line if Generic names are very long, or if there are lots and lots of generics, EX:


```
Widget<
      FrameForTheGpuWindow,
      CryptographicPrimitivesForY,
      GenericB,
      GenericX,
>
```

Although I've found this to be uncommon, and the benefit of readable generics to be really nice


Generally just some things I noticed, can bring over to #272 once merged if desired
