### PR TITLE
Create MLS identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6196,6 +6196,7 @@ dependencies = [
  "openmls_basic_credential",
  "openmls_rust_crypto",
  "openmls_traits",
+ "prost",
  "rand 0.8.5",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,6 +257,21 @@ dependencies = [
  "rustversion",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "miniz_oxide 0.6.2",
+ "object",
+ "rustc-demangle",
 ]
 
 [[package]]
@@ -620,6 +644,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "checked_int_cast"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,6 +696,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -939,6 +988,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek-ng"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core 0.6.4",
+ "subtle-ng",
+ "zeroize",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -970,6 +1032,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56acb310e15652100da43d130af8d97b509e95af61aab1c5a7939ef24337ee17"
 dependencies = [
  "const-oid 0.9.2",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -1205,6 +1268,8 @@ dependencies = [
  "ff 0.13.0",
  "generic-array 0.14.7",
  "group 0.13.0",
+ "hkdf",
+ "pem-rfc7468",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1 0.7.2",
@@ -1832,7 +1897,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.7.1",
 ]
 
 [[package]]
@@ -2076,6 +2141,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2238,6 +2309,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "hpke-rs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be3c089364da994102385ce2bed54c7e86e190da41e0125e0213f2c061786395"
+dependencies = [
+ "hpke-rs-crypto",
+ "log",
+ "serde",
+ "serde_json",
+ "tls_codec",
+ "zeroize",
+]
+
+[[package]]
+name = "hpke-rs-crypto"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdc863a0678d194f682f20790336ea8ef4ddc748abab61a9533ac5aa1e9d27d9"
+dependencies = [
+ "getrandom 0.2.9",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "tls_codec",
+]
+
+[[package]]
+name = "hpke-rs-rust-crypto"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9c0b07cafc144f03466bf2692db1616134152a6f49afc42e86c929b756876dd"
+dependencies = [
+ "aes-gcm",
+ "chacha20poly1305",
+ "getrandom 0.2.9",
+ "hkdf",
+ "hpke-rs-crypto",
+ "p256",
+ "p384",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "sha2 0.10.7",
+ "x25519-dalek-ng",
 ]
 
 [[package]]
@@ -2822,6 +2939,15 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
@@ -3008,6 +3134,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.30.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3048,6 +3183,83 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "openmls"
+version = "0.5.0"
+source = "git+https://github.com/xmtp/openmls#2d4991b53feb3f8490ca23fbb5a5ccfff094d07d"
+dependencies = [
+ "backtrace",
+ "itertools",
+ "log",
+ "openmls_basic_credential",
+ "openmls_rust_crypto",
+ "openmls_traits",
+ "rand 0.8.5",
+ "rayon",
+ "rstest",
+ "rstest_reuse",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tls_codec",
+]
+
+[[package]]
+name = "openmls_basic_credential"
+version = "0.2.0"
+source = "git+https://github.com/xmtp/openmls#2d4991b53feb3f8490ca23fbb5a5ccfff094d07d"
+dependencies = [
+ "ed25519-dalek",
+ "openmls_traits",
+ "p256",
+ "rand 0.8.5",
+ "serde",
+ "tls_codec",
+]
+
+[[package]]
+name = "openmls_memory_keystore"
+version = "0.2.0"
+source = "git+https://github.com/xmtp/openmls#2d4991b53feb3f8490ca23fbb5a5ccfff094d07d"
+dependencies = [
+ "openmls_traits",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "openmls_rust_crypto"
+version = "0.2.0"
+source = "git+https://github.com/xmtp/openmls#2d4991b53feb3f8490ca23fbb5a5ccfff094d07d"
+dependencies = [
+ "aes-gcm",
+ "chacha20poly1305",
+ "ed25519-dalek",
+ "hkdf",
+ "hmac",
+ "hpke-rs",
+ "hpke-rs-crypto",
+ "hpke-rs-rust-crypto",
+ "openmls_memory_keystore",
+ "openmls_traits",
+ "p256",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "serde",
+ "sha2 0.10.7",
+ "thiserror",
+ "tls_codec",
+]
+
+[[package]]
+name = "openmls_traits"
+version = "0.2.0"
+source = "git+https://github.com/xmtp/openmls#2d4991b53feb3f8490ca23fbb5a5ccfff094d07d"
+dependencies = [
+ "serde",
+ "tls_codec",
 ]
 
 [[package]]
@@ -3102,6 +3314,30 @@ dependencies = [
  "openssl-src",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa 0.16.7",
+ "elliptic-curve 0.13.5",
+ "primeorder",
+ "sha2 0.10.7",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209"
+dependencies = [
+ "ecdsa 0.16.7",
+ "elliptic-curve 0.13.5",
+ "primeorder",
+ "sha2 0.10.7",
 ]
 
 [[package]]
@@ -3275,6 +3511,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3436,6 +3681,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d7ddaed09e0eb771a79ab0fd64609ba0afb0a8366421957936ad14cbd13630"
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug 0.3.0",
+ "universal-hash",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3477,6 +3733,15 @@ checksum = "3b69d39aab54d069e7f2fe8cb970493e7834601ca2d8c65fd7bbd183578080d1"
 dependencies = [
  "proc-macro2",
  "syn 2.0.16",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c2fcef82c0ec6eefcc179b978446c399b3cdf73c392c35604e399eee6df1ee3"
+dependencies = [
+ "elliptic-curve 0.13.5",
 ]
 
 [[package]]
@@ -3985,6 +4250,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07f2d176c472198ec1e6551dc7da28f1c089652f66a7b722676c2238ebc0edf"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7229b505ae0706e64f37ffc54a9c163e11022a6636d58fe1f3f52018257ff9f7"
+dependencies = [
+ "cfg-if 1.0.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 1.0.109",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rstest_reuse"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9b5aed35457441e7e0db509695ba3932d4c47e046777141c167efe584d0ec17"
+dependencies = [
+ "quote",
+ "rustc_version",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "rust_decimal"
 version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3999,6 +4301,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc-hex"
@@ -4608,6 +4916,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
+name = "subtle-ng"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
+
+[[package]]
 name = "svm-rs"
 version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4787,6 +5101,28 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tls_codec"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aee1e621cbf57f36f5b51ebf366b57ba153be7fed133182a9513e443ecdf506e"
+dependencies = [
+ "serde",
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3226440488120aabe7e7cc80292634a68e541c407d97b66eceaae787454dae25"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.16",
+]
 
 [[package]]
 name = "tokio"
@@ -5740,6 +6076,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "x25519-dalek-ng"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7074de8999662970c3c4c8f7f30925028dd8f4ca31ad4c055efa9cdf2ec326"
+dependencies = [
+ "curve25519-dalek-ng",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "zeroize",
+]
+
+[[package]]
 name = "xli"
 version = "0.1.0"
 dependencies = [
@@ -5844,6 +6192,10 @@ dependencies = [
  "hex",
  "libsqlite3-sys",
  "log",
+ "openmls",
+ "openmls_basic_credential",
+ "openmls_rust_crypto",
+ "openmls_traits",
  "rand 0.8.5",
  "serde",
  "serde_json",

--- a/xmtp_mls/Cargo.toml
+++ b/xmtp_mls/Cargo.toml
@@ -20,6 +20,10 @@ futures = "0.3.28"
 hex = "0.4.3"
 libsqlite3-sys = { version = "0.26.0", optional = true}
 log = "0.4.17"
+openmls = { git= "https://github.com/xmtp/openmls", features = ["test-utils"] }
+openmls_traits = { git= "https://github.com/xmtp/openmls" }
+openmls_basic_credential = { git= "https://github.com/xmtp/openmls" }
+openmls_rust_crypto = { git= "https://github.com/xmtp/openmls" }
 rand = "0.8.5"
 serde = "1.0.160"
 serde_json = "1.0.96"

--- a/xmtp_mls/Cargo.toml
+++ b/xmtp_mls/Cargo.toml
@@ -24,6 +24,7 @@ openmls = { git= "https://github.com/xmtp/openmls", features = ["test-utils"] }
 openmls_traits = { git= "https://github.com/xmtp/openmls" }
 openmls_basic_credential = { git= "https://github.com/xmtp/openmls" }
 openmls_rust_crypto = { git= "https://github.com/xmtp/openmls" }
+prost = { version = "0.11", features = ["prost-derive"] }
 rand = "0.8.5"
 serde = "1.0.160"
 serde_json = "1.0.96"

--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -1,3 +1,5 @@
+use crate::configuration::CIPHERSUITE;
+use crate::xmtp_openmls_provider::XmtpOpenMlsProvider;
 use crate::StorageError;
 use crate::{
     client::{Client, Network},
@@ -109,13 +111,14 @@ where
         // Fetch the Identity based upon the identity strategy.
         let identity = match self.identity_strategy {
             IdentityStrategy::CachedOnly(_) => {
-                // TODO
-                Identity {}
+                // TODO: persistence/retrieval
+                unimplemented!()
             }
-            IdentityStrategy::CreateIfNotFound(_owner) => {
-                // TODO
-                Identity {}
-            }
+            IdentityStrategy::CreateIfNotFound(_owner) => Identity::new(
+                CIPHERSUITE,
+                &XmtpOpenMlsProvider::default(),
+                "unimplemented".as_bytes(), // TODO
+            ),
             #[cfg(test)]
             IdentityStrategy::ExternalIdentity(a) => a,
         };

--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -114,11 +114,10 @@ where
                 // TODO: persistence/retrieval
                 unimplemented!()
             }
-            IdentityStrategy::CreateIfNotFound(_owner) => Identity::new(
-                CIPHERSUITE,
-                &XmtpOpenMlsProvider::default(),
-                "unimplemented".as_bytes(), // TODO
-            )?,
+            IdentityStrategy::CreateIfNotFound(owner) => {
+                // TODO: persistence/retrieval
+                Identity::new(CIPHERSUITE, &XmtpOpenMlsProvider::default(), &owner)?
+            }
             #[cfg(test)]
             IdentityStrategy::ExternalIdentity(a) => a,
         };

--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -118,7 +118,7 @@ where
                 CIPHERSUITE,
                 &XmtpOpenMlsProvider::default(),
                 "unimplemented".as_bytes(), // TODO
-            ),
+            )?,
             #[cfg(test)]
             IdentityStrategy::ExternalIdentity(a) => a,
         };

--- a/xmtp_mls/src/configuration.rs
+++ b/xmtp_mls/src/configuration.rs
@@ -1,4 +1,5 @@
 use openmls_traits::types::Ciphersuite;
 
 // TODO confirm ciphersuite choice
-pub const CIPHERSUITE: Ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+pub const CIPHERSUITE: Ciphersuite =
+    Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519;

--- a/xmtp_mls/src/configuration.rs
+++ b/xmtp_mls/src/configuration.rs
@@ -1,0 +1,4 @@
+use openmls_traits::types::Ciphersuite;
+
+// TODO confirm ciphersuite choice
+pub const CIPHERSUITE: Ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;

--- a/xmtp_mls/src/identity.rs
+++ b/xmtp_mls/src/identity.rs
@@ -96,3 +96,22 @@ impl Identity {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use xmtp_cryptography::utils::generate_local_wallet;
+
+    use crate::{configuration::CIPHERSUITE, xmtp_openmls_provider::XmtpOpenMlsProvider};
+
+    use super::Identity;
+
+    #[test]
+    fn does_not_error() {
+        Identity::new(
+            CIPHERSUITE,
+            &XmtpOpenMlsProvider::default(),
+            &generate_local_wallet(),
+        )
+        .unwrap();
+    }
+}

--- a/xmtp_mls/src/identity.rs
+++ b/xmtp_mls/src/identity.rs
@@ -1,6 +1,7 @@
 use openmls::{
-    prelude::{Credential, CredentialType, CredentialWithKey, CryptoConfig, KeyPackageNewError},
-    prelude_test::KeyPackage,
+    prelude::{
+        Credential, CredentialType, CredentialWithKey, CryptoConfig, KeyPackage, KeyPackageNewError,
+    },
     versions::ProtocolVersion,
 };
 use openmls_basic_credential::SignatureKeyPair;
@@ -8,12 +9,19 @@ use openmls_traits::{
     types::{Ciphersuite, CryptoError},
     OpenMlsProvider,
 };
+use prost::Message;
 use thiserror::Error;
 use xmtp_cryptography::signature::SignatureError;
+use xmtp_proto::xmtp::v3::message_contents::{
+    vmac_account_linked_key::Association, VmacAccountLinkedKey, VmacUnsignedPublicKey,
+};
 
 use crate::{
-    association::AssociationError, storage::StorageError,
+    association::{AssociationError, AssociationText, Eip191Association},
+    proto_wrapper::ProtoWrapper,
+    storage::StorageError,
     xmtp_openmls_provider::XmtpOpenMlsProvider,
+    InboxOwner,
 };
 
 #[derive(Debug, Error)]
@@ -40,15 +48,12 @@ impl Identity {
     pub(crate) fn new(
         ciphersuite: Ciphersuite,
         provider: &XmtpOpenMlsProvider,
-        id: &[u8],
+        owner: &impl InboxOwner,
     ) -> Result<Self, IdentityError> {
-        let credential = Credential::new(id.to_vec(), CredentialType::Basic).unwrap();
         let signature_keys = SignatureKeyPair::new(ciphersuite.signature_algorithm())?;
-        let credential_with_key = CredentialWithKey {
-            credential,
-            signature_key: signature_keys.to_public_vec().into(),
-        };
         signature_keys.store(provider.key_store())?;
+
+        let credential_with_key = Identity::create_credential(&signature_keys, owner)?;
 
         // The builder automatically stores it in the key store
         // TODO: Make OpenMLS not delete this once used
@@ -62,11 +67,42 @@ impl Identity {
             credential_with_key.clone(),
         )?;
 
-        // TODO: upload
+        // TODO: persist identity
+        // TODO: upload credential_with_key and last_resort_key_package
 
         Ok(Self {
             credential_with_key,
             signer: signature_keys,
+        })
+    }
+
+    fn create_credential(
+        signature_keys: &SignatureKeyPair,
+        owner: &impl InboxOwner,
+    ) -> Result<CredentialWithKey, IdentityError> {
+        // Generate association
+        let assoc_text = AssociationText::Static {
+            blockchain_address: owner.get_address(),
+            installation_public_key: signature_keys.to_public_vec(),
+        };
+        let signature = owner.sign(&assoc_text.text())?;
+        let association = Eip191Association::new(signature_keys.public(), assoc_text, signature)?;
+
+        // Create AccountLinkedKey proto
+        // TODO: Rename/revise protos. Eip191Associations are relatively big, we should decide if we want smaller credentials or not
+        let installation_key_proto: ProtoWrapper<VmacUnsignedPublicKey> =
+            signature_keys.to_public_vec().into();
+        let account_linked_key = VmacAccountLinkedKey {
+            key: Some(installation_key_proto.proto),
+            association: Some(Association::Eip191(association.into())),
+        };
+
+        // Serialize into credential
+        let credential =
+            Credential::new(account_linked_key.encode_to_vec(), CredentialType::Basic).unwrap();
+        Ok(CredentialWithKey {
+            credential,
+            signature_key: signature_keys.to_public_vec().into(),
         })
     }
 }

--- a/xmtp_mls/src/identity.rs
+++ b/xmtp_mls/src/identity.rs
@@ -1,3 +1,10 @@
+use openmls::{
+    prelude::{Credential, CredentialType, CredentialWithKey, CryptoConfig},
+    prelude_test::KeyPackage,
+    versions::ProtocolVersion,
+};
+use openmls_basic_credential::SignatureKeyPair;
+use openmls_traits::{types::Ciphersuite, OpenMlsProvider};
 use thiserror::Error;
 use xmtp_cryptography::signature::SignatureError;
 
@@ -11,4 +18,44 @@ pub enum IdentityError {
     BadAssocation(#[from] AssociationError),
 }
 
-pub struct Identity {}
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct Identity {
+    pub(crate) credential_with_key: CredentialWithKey,
+    pub(crate) signer: SignatureKeyPair,
+}
+
+impl Identity {
+    pub(crate) fn new(
+        ciphersuite: Ciphersuite,
+        provider: &impl OpenMlsProvider,
+        id: &[u8],
+    ) -> Self {
+        let credential = Credential::new(id.to_vec(), CredentialType::Basic).unwrap();
+        let signature_keys = SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
+        let credential_with_key = CredentialWithKey {
+            credential,
+            signature_key: signature_keys.to_public_vec().into(),
+        };
+        signature_keys.store(provider.key_store()).unwrap();
+
+        // TODO: Make OpenMLS not delete this once used
+        let _last_resort_key_package = KeyPackage::builder()
+            .build(
+                CryptoConfig {
+                    ciphersuite,
+                    version: ProtocolVersion::default(),
+                },
+                provider,
+                &signature_keys,
+                credential_with_key.clone(),
+            )
+            .unwrap();
+
+        // TODO: upload
+
+        Self {
+            credential_with_key,
+            signer: signature_keys,
+        }
+    }
+}

--- a/xmtp_mls/src/lib.rs
+++ b/xmtp_mls/src/lib.rs
@@ -5,6 +5,7 @@ mod configuration;
 pub mod identity;
 pub mod mock_xmtp_api_client;
 pub mod owner;
+mod proto_wrapper;
 pub mod storage;
 pub mod types;
 mod xmtp_openmls_provider;

--- a/xmtp_mls/src/lib.rs
+++ b/xmtp_mls/src/lib.rs
@@ -1,11 +1,13 @@
 pub mod association;
 pub mod builder;
 pub mod client;
+mod configuration;
 pub mod identity;
 pub mod mock_xmtp_api_client;
 pub mod owner;
 pub mod storage;
 pub mod types;
+mod xmtp_openmls_provider;
 
 pub use client::{Client, Network};
 use storage::StorageError;

--- a/xmtp_mls/src/proto_wrapper.rs
+++ b/xmtp_mls/src/proto_wrapper.rs
@@ -1,0 +1,51 @@
+use xmtp_proto::xmtp::v3::message_contents::vmac_unsigned_public_key::{
+    Union, VodozemacCurve25519,
+};
+use xmtp_proto::xmtp::v3::message_contents::{
+    VmacAccountLinkedKey, VmacInstallationLinkedKey, VmacUnsignedPublicKey,
+};
+
+// Generic wrapper for proto classes, so we can implement From trait without violating orphan rules
+pub struct ProtoWrapper<T> {
+    pub proto: T,
+}
+
+pub type InstallationPublicKey = Vec<u8>;
+
+impl From<InstallationPublicKey> for ProtoWrapper<VmacUnsignedPublicKey> {
+    fn from(public_key_bytes: InstallationPublicKey) -> Self {
+        ProtoWrapper {
+            proto: VmacUnsignedPublicKey {
+                // TODO: this timestamp is hardcoded to 0 for now, this conversion is lossy
+                created_ns: 0,
+                union: Some(Union::Curve25519(VodozemacCurve25519 {
+                    bytes: public_key_bytes,
+                })),
+            },
+        }
+    }
+}
+
+impl From<ProtoWrapper<VmacUnsignedPublicKey>> for InstallationPublicKey {
+    fn from(key: ProtoWrapper<VmacUnsignedPublicKey>) -> Self {
+        match key.proto.union.unwrap() {
+            Union::Curve25519(curve25519) => curve25519.bytes,
+        }
+    }
+}
+
+impl From<ProtoWrapper<VmacAccountLinkedKey>> for InstallationPublicKey {
+    fn from(key: ProtoWrapper<VmacAccountLinkedKey>) -> Self {
+        match key.proto.key.unwrap().union.unwrap() {
+            Union::Curve25519(curve25519) => curve25519.bytes,
+        }
+    }
+}
+
+impl From<ProtoWrapper<VmacInstallationLinkedKey>> for InstallationPublicKey {
+    fn from(key: ProtoWrapper<VmacInstallationLinkedKey>) -> Self {
+        match key.proto.key.unwrap().union.unwrap() {
+            Union::Curve25519(curve25519) => curve25519.bytes,
+        }
+    }
+}

--- a/xmtp_mls/src/storage/errors.rs
+++ b/xmtp_mls/src/storage/errors.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq)]
 pub enum StorageError {
     #[error("Diesel connection error")]
     DieselConnectError(#[from] diesel::ConnectionError),
@@ -12,8 +12,6 @@ pub enum StorageError {
     DbInitError(String),
     #[error("Store Error")]
     Store(String),
-    #[error(transparent)]
-    ImplementationError(#[from] anyhow::Error),
     #[error("serialization error")]
     SerializationError,
     #[error("unknown storage error: {0}")]

--- a/xmtp_mls/src/storage/in_memory_key_store.rs
+++ b/xmtp_mls/src/storage/in_memory_key_store.rs
@@ -52,3 +52,25 @@ impl OpenMlsKeyStore for InMemoryKeyStore {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use openmls_basic_credential::SignatureKeyPair;
+    use openmls_traits::key_store::OpenMlsKeyStore;
+
+    use crate::configuration::CIPHERSUITE;
+
+    use super::InMemoryKeyStore;
+
+    #[test]
+    fn store_read_delete() {
+        let key_store = InMemoryKeyStore::default();
+        let signature_keys = SignatureKeyPair::new(CIPHERSUITE.signature_algorithm()).unwrap();
+        let index = "index".as_bytes();
+        assert!(key_store.read::<SignatureKeyPair>(index).is_none());
+        key_store.store(index, &signature_keys).unwrap();
+        assert!(key_store.read::<SignatureKeyPair>(index).is_some());
+        key_store.delete::<SignatureKeyPair>(index).unwrap();
+        assert!(key_store.read::<SignatureKeyPair>(index).is_none());
+    }
+}

--- a/xmtp_mls/src/storage/in_memory_key_store.rs
+++ b/xmtp_mls/src/storage/in_memory_key_store.rs
@@ -1,0 +1,59 @@
+use openmls_traits::key_store::{MlsEntity, OpenMlsKeyStore};
+use std::{collections::HashMap, sync::RwLock};
+
+#[derive(Debug, Default)]
+pub struct InMemoryKeyStore {
+    values: RwLock<HashMap<Vec<u8>, Vec<u8>>>,
+}
+
+impl OpenMlsKeyStore for InMemoryKeyStore {
+    /// The error type returned by the [`OpenMlsKeyStore`].
+    type Error = InMemoryKeyStoreError;
+
+    /// Store a value `v` that implements the [`ToKeyStoreValue`] trait for
+    /// serialization for ID `k`.
+    ///
+    /// Returns an error if storing fails.
+    fn store<V: MlsEntity>(&self, k: &[u8], v: &V) -> Result<(), Self::Error> {
+        let value = serde_json::to_vec(v).map_err(|_| InMemoryKeyStoreError::SerializationError)?;
+        // We unwrap here, because this is the only function claiming a write
+        // lock on `credential_bundles`. It only holds the lock very briefly and
+        // should not panic during that period.
+        let mut values = self.values.write().unwrap();
+        values.insert(k.to_vec(), value);
+        Ok(())
+    }
+
+    /// Read and return a value stored for ID `k` that implements the
+    /// [`FromKeyStoreValue`] trait for deserialization.
+    ///
+    /// Returns [`None`] if no value is stored for `k` or reading fails.
+    fn read<V: MlsEntity>(&self, k: &[u8]) -> Option<V> {
+        // We unwrap here, because the two functions claiming a write lock on
+        // `init_key_package_bundles` (this one and `generate_key_package_bundle`) only
+        // hold the lock very briefly and should not panic during that period.
+        let values = self.values.read().unwrap();
+        if let Some(value) = values.get(k) {
+            serde_json::from_slice(value).ok()
+        } else {
+            None
+        }
+    }
+
+    /// Delete a value stored for ID `k`.
+    ///
+    /// Returns an error if storing fails.
+    fn delete<V: MlsEntity>(&self, k: &[u8]) -> Result<(), Self::Error> {
+        // We just delete both ...
+        let mut values = self.values.write().unwrap();
+        values.remove(k);
+        Ok(())
+    }
+}
+
+/// Errors thrown by the key store.
+#[derive(thiserror::Error, Debug, Copy, Clone, PartialEq, Eq)]
+pub enum InMemoryKeyStoreError {
+    #[error("Error serializing value.")]
+    SerializationError,
+}

--- a/xmtp_mls/src/storage/in_memory_key_store.rs
+++ b/xmtp_mls/src/storage/in_memory_key_store.rs
@@ -1,6 +1,8 @@
 use openmls_traits::key_store::{MlsEntity, OpenMlsKeyStore};
 use std::{collections::HashMap, sync::RwLock};
 
+use super::StorageError;
+
 #[derive(Debug, Default)]
 pub struct InMemoryKeyStore {
     values: RwLock<HashMap<Vec<u8>, Vec<u8>>>,
@@ -8,14 +10,14 @@ pub struct InMemoryKeyStore {
 
 impl OpenMlsKeyStore for InMemoryKeyStore {
     /// The error type returned by the [`OpenMlsKeyStore`].
-    type Error = InMemoryKeyStoreError;
+    type Error = StorageError;
 
     /// Store a value `v` that implements the [`ToKeyStoreValue`] trait for
     /// serialization for ID `k`.
     ///
     /// Returns an error if storing fails.
     fn store<V: MlsEntity>(&self, k: &[u8], v: &V) -> Result<(), Self::Error> {
-        let value = serde_json::to_vec(v).map_err(|_| InMemoryKeyStoreError::SerializationError)?;
+        let value = serde_json::to_vec(v).map_err(|_| StorageError::SerializationError)?;
         // We unwrap here, because this is the only function claiming a write
         // lock on `credential_bundles`. It only holds the lock very briefly and
         // should not panic during that period.
@@ -49,11 +51,4 @@ impl OpenMlsKeyStore for InMemoryKeyStore {
         values.remove(k);
         Ok(())
     }
-}
-
-/// Errors thrown by the key store.
-#[derive(thiserror::Error, Debug, Copy, Clone, PartialEq, Eq)]
-pub enum InMemoryKeyStoreError {
-    #[error("Error serializing value.")]
-    SerializationError,
 }

--- a/xmtp_mls/src/storage/mod.rs
+++ b/xmtp_mls/src/storage/mod.rs
@@ -1,5 +1,6 @@
 mod encrypted_store;
 mod errors;
+pub mod in_memory_key_store;
 
 pub use encrypted_store::{DbConnection, EncryptedMessageStore, EncryptionKey, StorageOption};
 pub use errors::StorageError;

--- a/xmtp_mls/src/xmtp_openmls_provider.rs
+++ b/xmtp_mls/src/xmtp_openmls_provider.rs
@@ -1,0 +1,28 @@
+use openmls_rust_crypto::RustCrypto;
+use openmls_traits::OpenMlsProvider;
+
+use crate::storage::in_memory_key_store::InMemoryKeyStore;
+
+#[derive(Default, Debug)]
+pub struct XmtpOpenMlsProvider {
+    crypto: RustCrypto,
+    key_store: InMemoryKeyStore,
+}
+
+impl OpenMlsProvider for XmtpOpenMlsProvider {
+    type CryptoProvider = RustCrypto;
+    type RandProvider = RustCrypto;
+    type KeyStoreProvider = InMemoryKeyStore;
+
+    fn crypto(&self) -> &Self::CryptoProvider {
+        &self.crypto
+    }
+
+    fn rand(&self) -> &Self::RandProvider {
+        &self.crypto
+    }
+
+    fn key_store(&self) -> &Self::KeyStoreProvider {
+        &self.key_store
+    }
+}


### PR DESCRIPTION
This creates an MLS credential, signing key pair, and last resort key package.

We treat the public key of the signature key pair as the installation's identity, and the address of the blockchain account as the user's identity. The MLS credential is a serialized `Eip191Association` proto, which is a wallet signature for the signature public key.

For now we store the keys in an in-memory key store.

Still to be done:
- Unit tests for credential generation - can add this once credential validation is done
- (I will work on this next) Use persistent sqlite store instead of in-memory store. We can use a `key_store` table with `key` and `value` columns for the OpenMLS storage provider. We should also define our own custom tables for storing things like the identity that we represent.
- Upload credential and key packages to network
- Better protos (currently reusing Eip191Association as the credential)