### PR TITLE
Break up fetch and store macros

### DIFF
--- a/xmtp_mls/src/lib.rs
+++ b/xmtp_mls/src/lib.rs
@@ -36,55 +36,6 @@ pub trait Delete<Model> {
     fn delete(&mut self, key: Self::Key) -> Result<usize, StorageError>;
 }
 
-#[macro_export]
-macro_rules! impl_fetch_and_store {
-    ($model:ty, $table:ident) => {
-        impl $crate::Store<$crate::storage::encrypted_store::DbConnection> for $model {
-            fn store(
-                &self,
-                into: &mut $crate::storage::encrypted_store::DbConnection,
-            ) -> Result<(), $crate::StorageError> {
-                diesel::insert_into($table::table)
-                    .values(self)
-                    .execute(into)
-                    .map_err(|e| $crate::StorageError::from(e))?;
-                Ok(())
-            }
-        }
-
-        impl $crate::Fetch<$model> for $crate::storage::encrypted_store::DbConnection {
-            type Key = ();
-            fn fetch(&mut self, _key: Self::Key) -> Result<Option<$model>, $crate::StorageError> {
-                use $crate::storage::encrypted_store::schema::$table::dsl::*;
-                Ok($table.first(self).optional()?)
-            }
-        }
-    };
-
-    ($model:ty, $table:ident, $key:ty) => {
-        impl $crate::Store<$crate::storage::encrypted_store::DbConnection> for $model {
-            fn store(
-                &self,
-                into: &mut $crate::storage::encrypted_store::DbConnection,
-            ) -> Result<(), $crate::StorageError> {
-                diesel::insert_into($table::table)
-                    .values(self)
-                    .execute(into)
-                    .map_err(|e| $crate::StorageError::from(e))?;
-                Ok(())
-            }
-        }
-
-        impl $crate::Fetch<$model> for $crate::storage::encrypted_store::DbConnection {
-            type Key = $key;
-            fn fetch(&mut self, key: Self::Key) -> Result<Option<$model>, $crate::StorageError> {
-                use $crate::storage::encrypted_store::schema::$table::dsl::*;
-                Ok($table.find(key).first(self).optional()?)
-            }
-        }
-    };
-}
-
 #[cfg(test)]
 mod tests {
     use std::sync::Once;

--- a/xmtp_mls/src/storage/encrypted_store/group.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group.rs
@@ -11,7 +11,8 @@ use diesel::{
 };
 
 use super::schema::groups;
-use crate::impl_fetch_and_store;
+use crate::impl_fetch;
+use crate::impl_store;
 
 /// The Group ID type.
 pub type ID = Vec<u8>;
@@ -29,7 +30,8 @@ pub struct StoredGroup {
     pub membership_state: GroupMembershipState,
 }
 
-impl_fetch_and_store!(StoredGroup, groups, Vec<u8>);
+impl_fetch!(StoredGroup, groups, Vec<u8>);
+impl_store!(StoredGroup, groups);
 
 impl StoredGroup {
     pub fn new(id: ID, created_at_ns: i64, membership_state: GroupMembershipState) -> Self {

--- a/xmtp_mls/src/storage/encrypted_store/group_message.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group_message.rs
@@ -1,7 +1,8 @@
 use diesel::prelude::*;
 
 use super::schema::group_messages;
-use crate::impl_fetch_and_store;
+use crate::impl_fetch;
+use crate::impl_store;
 
 #[derive(Insertable, Identifiable, Queryable, Debug, Clone)]
 #[diesel(table_name = group_messages)]
@@ -24,4 +25,5 @@ pub struct StoredGroupMessage {
     pub sender_wallet_address: String,
 }
 
-impl_fetch_and_store!(StoredGroupMessage, group_messages, Vec<u8>);
+impl_fetch!(StoredGroupMessage, group_messages, Vec<u8>);
+impl_store!(StoredGroupMessage, group_messages);

--- a/xmtp_mls/src/storage/encrypted_store/identity.rs
+++ b/xmtp_mls/src/storage/encrypted_store/identity.rs
@@ -3,7 +3,7 @@ use diesel::prelude::*;
 use super::schema::identity;
 use crate::{
     identity::Identity,
-    impl_fetch_and_store,
+    impl_fetch, impl_store,
     storage::serialization::{db_deserialize, db_serialize},
 };
 
@@ -18,7 +18,8 @@ pub struct StoredIdentity {
     rowid: Option<i32>,
 }
 
-impl_fetch_and_store!(StoredIdentity, identity);
+impl_fetch!(StoredIdentity, identity);
+impl_store!(StoredIdentity, identity);
 
 impl StoredIdentity {
     pub fn new(

--- a/xmtp_mls/src/storage/encrypted_store/key_store_entry.rs
+++ b/xmtp_mls/src/storage/encrypted_store/key_store_entry.rs
@@ -1,7 +1,7 @@
 use diesel::prelude::*;
 
 use super::{schema::openmls_key_store, DbConnection, StorageError};
-use crate::{impl_fetch_and_store, Delete};
+use crate::{impl_fetch, impl_store, Delete};
 
 #[derive(Insertable, Queryable, Debug, Clone)]
 #[diesel(table_name = openmls_key_store)]
@@ -11,7 +11,8 @@ pub struct StoredKeyStoreEntry {
     pub value_bytes: Vec<u8>,
 }
 
-impl_fetch_and_store!(StoredKeyStoreEntry, openmls_key_store, Vec<u8>);
+impl_fetch!(StoredKeyStoreEntry, openmls_key_store, Vec<u8>);
+impl_store!(StoredKeyStoreEntry, openmls_key_store);
 
 impl Delete<StoredKeyStoreEntry> for DbConnection {
     type Key = Vec<u8>;

--- a/xmtp_mls/src/storage/encrypted_store/topic_refresh_state.rs
+++ b/xmtp_mls/src/storage/encrypted_store/topic_refresh_state.rs
@@ -1,7 +1,8 @@
 use diesel::prelude::*;
 
 use super::schema::topic_refresh_state;
-use crate::impl_fetch_and_store;
+use crate::impl_fetch;
+use crate::impl_store;
 
 #[derive(Insertable, Identifiable, Queryable, Debug, Clone)]
 #[diesel(table_name = topic_refresh_state)]
@@ -11,4 +12,5 @@ pub struct TopicRefreshState {
     pub last_message_timestamp_ns: i64,
 }
 
-impl_fetch_and_store!(TopicRefreshState, topic_refresh_state);
+impl_fetch!(TopicRefreshState, topic_refresh_state, String);
+impl_store!(TopicRefreshState, topic_refresh_state);


### PR DESCRIPTION
## Summary

1. I broke up the `impl_fetch` and `impl_store` macros to better support the `group_intent` table, and others where fetching and storing might be done against separate models. 
2. I moved the macro definitions into the `encrypted_store` module. Even if the macros actually get exposed at the root, it feels odd to have code that is specific to one datastore sitting in `lib.rs`. Especially since when we get to WASM support, we will likely need to exclude this code from compilation via feature.

## Notes

I'm sure I could have made things work with a single macro that supported more complex arguments to support something like the `group_intents` table. But macros are complicated enough on their own - might as well keep each one small and readable.