### PR TITLE
Add ability to remove members

### DIFF
--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -253,6 +253,16 @@ where
                     .map(|member| member.index)
                     .collect();
 
+                let num_leaf_nodes = leaf_nodes.len();
+
+                if num_leaf_nodes != intent_data.installation_ids.len() {
+                    return Err(GroupError::Generic(format!(
+                        "expected {} leaf nodes, found {}",
+                        intent_data.installation_ids.len(),
+                        num_leaf_nodes
+                    )));
+                }
+
                 // The second return value is a Welcome, which is only possible if there
                 // are pending proposals. Ignoring for now
                 let (commit, _, _) = openmls_group.remove_members(

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -352,8 +352,6 @@ mod tests {
         // Add another client onto the network
         let client_2 = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
         client_2.register_identity().await.unwrap();
-        let client_3 = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
-        client_3.register_identity().await.unwrap();
 
         let provider = client_1.mls_provider();
         let group = client_1.create_group().expect("create group");
@@ -367,7 +365,7 @@ mod tests {
 
         // Try and add another member without merging the pending commit
         group
-            .add_members_by_installation_id(vec![client_3
+            .remove_members_by_installation_id(vec![client_2
                 .identity
                 .installation_keys
                 .to_public_vec()])

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -268,7 +268,7 @@ where
                 let (commit, _, _) = openmls_group.remove_members(
                     provider,
                     &self.client.identity.installation_keys,
-                    &leaf_nodes.as_slice(),
+                    leaf_nodes.as_slice(),
                 )?;
 
                 let commit_bytes = commit.tls_serialize_detached()?;


### PR DESCRIPTION
## Summary

- Adds support for the `RemoveMembers` intent data
- Adds some methods for removing members from a group
- Adds a test case for removing members, including the complicated case where there are multiple messages that result in a commit queued up to publish. Only the first should succeed while the rest will fail until the network has been synced.