### PR TITLE
Topic syncing and concurrency

### DIFF
--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use log::debug;
 use openmls::{
     framing::{MlsMessageIn, MlsMessageInBody},
     messages::Welcome,
@@ -179,10 +180,19 @@ where
             .store
             .get_last_synced_timestamp_for_topic(&mut conn, topic)?;
 
-        Ok(self
+        let envelopes = self
             .api_client
             .read_topic(topic, last_synced_timestamp_ns as u64)
-            .await?)
+            .await?;
+
+        debug!(
+            "Pulled {} envelopes from topic {} starting at timestamp {}",
+            envelopes.len(),
+            topic,
+            last_synced_timestamp_ns
+        );
+
+        Ok(envelopes)
     }
 
     // Get a flat list of one key package per installation for all the wallet addresses provided.

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -216,7 +216,7 @@ where
 
         let envelopes = self
             .api_client
-            .read_topic(topic, last_synced_timestamp_ns as u64)
+            .read_topic(topic, last_synced_timestamp_ns as u64 + 1)
             .await?;
 
         debug!(

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -241,11 +241,13 @@ where
         // TODO: We can handle errors in the transaction() function to make error handling
         // cleaner. Retryable errors can possibly be part of their own enum
         XmtpOpenMlsProvider::transaction(&mut self.store.conn()?, |provider| {
-            let is_updated = EncryptedMessageStore::update_last_synced_timestamp_for_topic(
-                &mut provider.conn().borrow_mut(),
-                topic,
-                envelope_timestamp_ns as i64,
-            )?;
+            let is_updated = {
+                EncryptedMessageStore::update_last_synced_timestamp_for_topic(
+                    &mut provider.conn().borrow_mut(),
+                    topic,
+                    envelope_timestamp_ns as i64,
+                )?
+            };
             if !is_updated {
                 return Err(MessageProcessingError::AlreadyProcessed(
                     envelope_timestamp_ns,

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -400,5 +400,8 @@ mod tests {
             bob_received_groups.first().unwrap().group_id,
             alice_bob_group.group_id
         );
+
+        let duplicate_received_groups = bob.sync_welcomes().await.unwrap();
+        assert_eq!(duplicate_received_groups.len(), 0);
     }
 }

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -298,7 +298,7 @@ where
 
         let groups: Vec<MlsGroup<ApiClient>> = envelopes
             .into_iter()
-            .map(|envelope: Envelope| -> Option<MlsGroup<ApiClient>> {
+            .filter_map(|envelope: Envelope| {
                 self.process_for_topic(&welcome_topic, envelope.timestamp_ns, |provider| {
                     let welcome = match extract_welcome(&envelope.message) {
                         Ok(welcome) => welcome,
@@ -320,7 +320,6 @@ where
                 .ok()
                 .flatten()
             })
-            .filter_map(|option| option)
             .collect();
 
         Ok(groups)

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -411,15 +411,7 @@ where
 
     pub async fn receive(&self) -> Result<(), GroupError> {
         let topic = get_group_topic(&self.group_id);
-        let last_message_timestamp_ns = self
-            .client
-            .store
-            .get_last_synced_timestamp_for_topic(&mut self.client.store.conn()?, &topic)?;
-        let envelopes = self
-            .client
-            .api_client
-            .read_topic(&topic, last_message_timestamp_ns as u64)
-            .await?;
+        let envelopes = self.client.pull_from_topic(&topic).await?;
         debug!("Received {} envelopes", envelopes.len());
         self.process_messages(envelopes)
     }

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -209,7 +209,7 @@ where
             return Ok(());
         }
         debug!(
-            "[{}]processing own message for intent {} / {:?}",
+            "[{}] processing own message for intent {} / {:?}",
             self.client.account_address(),
             intent.id,
             intent.kind
@@ -314,7 +314,6 @@ where
             }
         };
 
-        openmls_group.save(provider.key_store())?; // TODO include provider in transaction
         Ok(())
     }
 
@@ -375,7 +374,9 @@ where
                             &mut openmls_group,
                             &provider,
                             &envelope,
-                        )
+                        )?;
+                        openmls_group.save(provider.key_store())?;
+                        Ok(())
                     },
                 )
             })
@@ -385,6 +386,7 @@ where
         if receive_errors.is_empty() {
             Ok(())
         } else {
+            debug!("Message processing errors: {:?}", receive_errors);
             Err(GroupError::ReceiveError(receive_errors))
         }
     }
@@ -610,6 +612,7 @@ where
                                 ciphertext: action.welcome_message.clone(),
                             })
                             .collect();
+                        debug!("Sending {} welcomes", welcomes.len());
                         self.client.api_client.publish_welcomes(welcomes).await?;
                     }
                 }

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -241,19 +241,18 @@ where
                     });
                 }
                 debug!("[{}] merging pending commit", self.client.account_address());
-                match openmls_group.merge_pending_commit(provider) {
-                    Err(MergePendingCommitError::MlsGroupStateError(err)) => {
-                        debug!("error merging commit: {}", err);
-                        openmls_group.clear_pending_commit();
-                        {
-                            EncryptedMessageStore::set_group_intent_to_publish(
-                                &mut provider.conn().borrow_mut(),
-                                intent.id,
-                            )?;
-                        }
+                if let Err(MergePendingCommitError::MlsGroupStateError(err)) =
+                    openmls_group.merge_pending_commit(provider)
+                {
+                    debug!("error merging commit: {}", err);
+                    openmls_group.clear_pending_commit();
+                    {
+                        EncryptedMessageStore::set_group_intent_to_publish(
+                            &mut provider.conn().borrow_mut(),
+                            intent.id,
+                        )?;
                     }
-                    _ => (),
-                };
+                }
                 // TOOD: Handle writing transcript messages for adding/removing members
             }
             IntentKind::SendMessage => {

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -1,6 +1,6 @@
 mod intents;
-
 use intents::SendMessageIntentData;
+#[cfg(not(test))]
 use log::debug;
 use openmls::{
     framing::ProtocolMessage,
@@ -14,6 +14,8 @@ use openmls::{
 };
 use openmls_traits::OpenMlsProvider;
 use std::mem::discriminant;
+#[cfg(test)]
+use std::println as debug;
 use thiserror::Error;
 use tls_codec::{Deserialize, Serialize};
 use xmtp_proto::api_client::{Envelope, XmtpApiClient, XmtpMlsClient};

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -285,7 +285,6 @@ where
             "[{}] processing private message",
             self.client.account_address()
         );
-        // TODO include provider in transaction
         let decrypted_message = openmls_group.process_message(provider, message)?;
         let (sender_account_address, sender_installation_id) =
             self.validate_message_sender(openmls_group, &decrypted_message, envelope_timestamp_ns)?;

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -1,11 +1,6 @@
 mod intents;
 
-#[cfg(test)]
-use std::println as debug;
-
 use intents::SendMessageIntentData;
-#[cfg(not(test))]
-use log::debug;
 use openmls::{
     framing::ProtocolMessage,
     group::{GroupEpoch, MergePendingCommitError},
@@ -412,7 +407,6 @@ where
     pub async fn receive(&self) -> Result<(), GroupError> {
         let topic = get_group_topic(&self.group_id);
         let envelopes = self.client.pull_from_topic(&topic).await?;
-        debug!("Received {} envelopes", envelopes.len());
         self.process_messages(envelopes)
     }
 

--- a/xmtp_mls/src/identity.rs
+++ b/xmtp_mls/src/identity.rs
@@ -62,7 +62,9 @@ impl Identity {
         };
 
         identity.new_key_package(provider)?;
-        StoredIdentity::from(&identity).store(*provider.conn().borrow_mut())?;
+        {
+            StoredIdentity::from(&identity).store(*provider.conn().borrow_mut())?;
+        }
 
         // TODO: upload credential_with_key and last_resort_key_package
 

--- a/xmtp_mls/src/storage/encrypted_store/topic_refresh_state.rs
+++ b/xmtp_mls/src/storage/encrypted_store/topic_refresh_state.rs
@@ -1,7 +1,7 @@
 use diesel::prelude::*;
 
-use super::schema::topic_refresh_state;
-use crate::{impl_fetch, impl_store};
+use super::{schema::topic_refresh_state, DbConnection, EncryptedMessageStore};
+use crate::{impl_fetch, impl_store, storage::StorageError, Fetch, Store};
 
 #[derive(Insertable, Identifiable, Queryable, Debug, Clone)]
 #[diesel(table_name = topic_refresh_state)]
@@ -13,3 +13,24 @@ pub struct TopicRefreshState {
 
 impl_fetch!(TopicRefreshState, topic_refresh_state, String);
 impl_store!(TopicRefreshState, topic_refresh_state);
+
+impl EncryptedMessageStore {
+    pub fn get_last_synced_timestamp_for_topic(
+        &self,
+        conn: &mut DbConnection,
+        topic: &str,
+    ) -> Result<i64, StorageError> {
+        let state: Option<TopicRefreshState> = conn.fetch(&topic.to_string())?;
+        match state {
+            Some(state) => Ok(state.last_message_timestamp_ns),
+            None => {
+                let new_state = TopicRefreshState {
+                    topic: topic.to_string(),
+                    last_message_timestamp_ns: 0,
+                };
+                new_state.store(conn)?;
+                Ok(0)
+            }
+        }
+    }
+}

--- a/xmtp_mls/src/storage/encrypted_store/topic_refresh_state.rs
+++ b/xmtp_mls/src/storage/encrypted_store/topic_refresh_state.rs
@@ -46,7 +46,7 @@ impl EncryptedMessageStore {
                     .filter(dsl::last_message_timestamp_ns.lt(timestamp_ns))
                     .set(dsl::last_message_timestamp_ns.eq(timestamp_ns))
                     .execute(conn)?;
-                Ok(if num_updated == 1 { true } else { false })
+                Ok(num_updated == 1)
             }
             None => Err(StorageError::NotFound),
         }

--- a/xmtp_mls/src/xmtp_openmls_provider.rs
+++ b/xmtp_mls/src/xmtp_openmls_provider.rs
@@ -35,7 +35,10 @@ impl<'a> XmtpOpenMlsProvider<'a> {
     /// XmtpOpenMlsProvider::transaction(conn, |provider| {
     ///     // do some operations requiring provider
     ///     // access the connection with .conn()
-    ///     provider.conn().borrow_mut()
+    ///     // wrap in a block so that the borrow is ended
+    ///    {
+    ///         provider.conn().borrow_mut()
+    ///    }
     /// })
     /// ```
     pub fn transaction<T, F, E>(connection: &mut DbConnection, fun: F) -> Result<T, E>


### PR DESCRIPTION
1. Only pull down payloads we haven't already processed (via `pull_from_topic`)
2. Do all payload processing within an atomic transaction that also updates the `last_synced_payload_time` (via `process_for_topic`)

These methods are agnostic to which topic, so can be used for both welcomes and group message processing, as well as any other case in the future. Unsure if they belong on `Client` or somewhere else.

Some missing pieces:
1. More complicated concurrency test cases
1. Sophisticated error handling (when an error happens, do we update `last_synced_payload_time` or do we not?)
1. Will add a follow-up PR to improve the [safety](https://github.com/xmtp/libxmtp/pull/335#discussion_r1396469800) of borrowing the DB connection in a transaction