### PR TITLE
Lint warning cleanup

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,9 +25,3 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: ffi
           args: --all-features --no-deps --manifest-path bindings_ffi/Cargo.toml
-      - uses: actions-rs/clippy-check@v1
-        name: Lint api_grpc_gateway
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: api_grpc_gateway
-          args: --all-features --no-deps --manifest-path xmtp_api_grpc_gateway/Cargo.toml

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,33 @@
+name: Lint
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - run: rustup component add clippy
+      - uses: bufbuild/buf-setup-action@v1.17.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions-rs/clippy-check@v1
+        name: Lint main workspace
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: workspace
+          args: --all-features --no-deps
+      - uses: actions-rs/clippy-check@v1
+        name: Lint ffi
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ffi
+          args: --all-features --no-deps --manifest-path bindings_ffi/Cargo.toml
+      - uses: actions-rs/clippy-check@v1
+        name: Lint api_grpc_gateway
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: api_grpc_gateway
+          args: --all-features --no-deps --manifest-path xmtp_api_grpc_gateway/Cargo.toml

--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -311,8 +311,8 @@ async fn send<'c>(group: MlsGroup<'c, ApiClient>, msg: String) -> Result<(), Cli
     Ok(())
 }
 
-fn format_messages<'c, A: XmtpApiClient + XmtpMlsClient>(
-    convo: &MlsGroup<'c, A>,
+fn format_messages<A: XmtpApiClient + XmtpMlsClient>(
+    convo: &MlsGroup<'_, A>,
     my_wallet_address: String,
 ) -> Result<String, CliError> {
     let mut output: Vec<String> = vec![];

--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -298,7 +298,7 @@ async fn get_group(client: &Client, group_id: Vec<u8>) -> Result<MlsGroup<ApiCli
     Ok(group)
 }
 
-async fn send<'c>(group: MlsGroup<'c, ApiClient>, msg: String) -> Result<(), CliError> {
+async fn send(group: MlsGroup<'_, ApiClient>, msg: String) -> Result<(), CliError> {
     group
         .send_message(msg.into_bytes().as_slice())
         .await

--- a/mls_validation_service/src/handlers.rs
+++ b/mls_validation_service/src/handlers.rs
@@ -174,7 +174,7 @@ mod tests {
             .encode(&mut buf)
             .expect("failed to serialize");
 
-        return (buf, signature_key_pair, wallet_address);
+        (buf, signature_key_pair, wallet_address)
     }
 
     fn build_key_package_bytes(
@@ -221,7 +221,7 @@ mod tests {
         let first_response = &res.into_inner().responses[0];
         assert_eq!(first_response.installation_id, keypair.public());
         assert_eq!(first_response.wallet_address, wallet_address);
-        assert!(first_response.credential_identity_bytes.len() > 0);
+        assert!(!first_response.credential_identity_bytes.is_empty());
     }
 
     #[tokio::test]
@@ -251,7 +251,7 @@ mod tests {
 
         let first_response = &res.into_inner().responses[0];
 
-        assert_eq!(first_response.is_ok, false);
+        assert!(!first_response.is_ok);
         assert_eq!(first_response.wallet_address, "".to_string());
     }
 }

--- a/xmtp/src/client.rs
+++ b/xmtp/src/client.rs
@@ -409,9 +409,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(contacts.len(), 1);
-        let installation_bundle = match contacts[0].clone().bundle.version.unwrap() {
-            Version::V1(bundle) => bundle,
-        };
+        let Version::V1(installation_bundle) = contacts[0].clone().bundle.version.unwrap();
         assert!(installation_bundle.fallback_key.is_some());
         assert!(installation_bundle.identity_key.is_some());
         contacts[0].vmac_identity_key();

--- a/xmtp/src/codecs/text.rs
+++ b/xmtp/src/codecs/text.rs
@@ -6,10 +6,10 @@ use super::{CodecError, ContentCodec};
 
 pub struct TextCodec {}
 impl TextCodec {
-    const AUTHORITY_ID: &str = "xmtp.org";
-    const TYPE_ID: &str = "text";
-    const ENCODING_KEY: &str = "encoding";
-    const ENCODING_UTF8: &str = "UTF-8";
+    const AUTHORITY_ID: &'static str = "xmtp.org";
+    const TYPE_ID: &'static str = "text";
+    const ENCODING_KEY: &'static str = "encoding";
+    const ENCODING_UTF8: &'static str = "UTF-8";
 }
 
 impl ContentCodec<String> for TextCodec {

--- a/xmtp/src/conversations.rs
+++ b/xmtp/src/conversations.rs
@@ -475,7 +475,7 @@ mod tests {
                 content_topics: vec![build_installation_message_topic(
                     &bob_client.installation_id(),
                 )],
-                start_time_ns: 0 as u64,
+                start_time_ns: 0_u64,
                 end_time_ns: now() as u64,
                 paging_info: None,
             })

--- a/xmtp/src/storage/encrypted_store/mod.rs
+++ b/xmtp/src/storage/encrypted_store/mod.rs
@@ -901,7 +901,7 @@ mod tests {
             let store = EncryptedMessageStore::new(
                 // StorageOption::Ephemeral,
                 StorageOption::Persistent(db_path.clone()),
-                enc_key.clone(),
+                enc_key,
             )
             .unwrap();
 

--- a/xmtp_api_grpc/Cargo.toml
+++ b/xmtp_api_grpc/Cargo.toml
@@ -8,16 +8,16 @@ edition = "2021"
 [dependencies]
 tonic = "^0.9"
 xmtp_proto = { path = "../xmtp_proto", features = ["proto_full", "grpc"] }
-prost = { version  = "^0.11", features = ["prost-derive"] }
+prost = { version = "^0.11", features = ["prost-derive"] }
 tokio = { version = "1.24", features = ["macros", "rt-multi-thread", "time"] }
-tokio-rustls = "0.24.0"
+tokio-rustls = "0.24.1"
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0"
 base64 = "0.21.0"
 pbjson = "0.5.1"
 pbjson-types = "0.5.1"
 hyper = "0.14.26"
-hyper-rustls = { version = "0.24.0", features = ["http2"]}
+hyper-rustls = { version = "0.24.0", features = ["http2"] }
 http-body = "0.4.5"
 tower = "0.4.13"
 webpki-roots = "0.23.0"

--- a/xmtp_api_grpc/src/grpc_api_helper.rs
+++ b/xmtp_api_grpc/src/grpc_api_helper.rs
@@ -29,7 +29,7 @@ use xmtp_proto::{
 fn tls_config() -> ClientConfig {
     let mut roots = RootCertStore::empty();
     // Need to convert into OwnedTrustAnchor
-    roots.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
+    roots.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
         OwnedTrustAnchor::from_subject_spki_name_constraints(
             ta.subject,
             ta.spki,

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -307,7 +307,7 @@ where
     // Download all unread welcome messages and convert to groups.
     // Returns any new groups created in the operation
     #[allow(dead_code)]
-    pub(crate) async fn sync_welcomes(&self) -> Result<Vec<MlsGroup<ApiClient>>, ClientError> {
+    pub async fn sync_welcomes(&self) -> Result<Vec<MlsGroup<ApiClient>>, ClientError> {
         let welcome_topic = get_welcome_topic(&self.installation_public_key());
         let envelopes = self.pull_from_topic(&welcome_topic).await?;
 

--- a/xmtp_mls/src/storage/encrypted_store/topic_refresh_state.rs
+++ b/xmtp_mls/src/storage/encrypted_store/topic_refresh_state.rs
@@ -97,12 +97,11 @@ pub(crate) mod tests {
                 last_message_timestamp_ns: 123,
             };
             entry.store(&mut conn).unwrap();
-            assert_eq!(
+            assert!(
                 EncryptedMessageStore::update_last_synced_timestamp_for_topic(
                     &mut conn, "topic", 124
                 )
-                .unwrap(),
-                true
+                .unwrap()
             );
             let entry: Option<TopicRefreshState> = conn.fetch(&"topic".to_string()).unwrap();
             assert_eq!(entry.unwrap().last_message_timestamp_ns, 124);
@@ -117,12 +116,11 @@ pub(crate) mod tests {
                 last_message_timestamp_ns: 123,
             };
             entry.store(&mut conn).unwrap();
-            assert_eq!(
-                EncryptedMessageStore::update_last_synced_timestamp_for_topic(
+            assert!(
+                !EncryptedMessageStore::update_last_synced_timestamp_for_topic(
                     &mut conn, "topic", 122
                 )
-                .unwrap(),
-                false
+                .unwrap()
             );
             let entry: Option<TopicRefreshState> = conn.fetch(&"topic".to_string()).unwrap();
             assert_eq!(entry.unwrap().last_message_timestamp_ns, 123);


### PR DESCRIPTION
## Summary

- With the addition of the .devcontainer, we lost the annotations on PRs for lint warnings. Errors are caught by the Docker build, but warnings get lost in the logs of that Docker build and go nowhere. This PR fixes some of those warnings and re-adds the lint Github workflow to get the annotations back.
- I fixed a few warnings manually and the rest were fixed with `cargo clippy --fix`