### PR TITLE
Add detail and address feedback on identity doc

### DIFF
--- a/xmtp_mls/IDENTITY.md
+++ b/xmtp_mls/IDENTITY.md
@@ -40,7 +40,7 @@ XMTP: <Label>\n\n
 
 | Label                   | Described in section                                    |
 | ----------------------- | ------------------------------------------------------- |
-| Grant messaging access  | [Installation registration](#installation-provisioning) |
+| Grant messaging access  | [Installation registration](#installation-registration) |
 | Revoke messaging access | [Installation revocation](#installation-revocation)     |
 
 ### Installation registration

--- a/xmtp_mls/IDENTITY.md
+++ b/xmtp_mls/IDENTITY.md
@@ -24,9 +24,11 @@ Using per-installation keys provides the following benefits:
 - The user may enumerate the installations that have messaging access to their account.
 - The user may revoke keys on a per-installation level.
 
-## Ethereum wallet
+## Identity lifecycle
 
-Today, an Ethereum wallet consists of a secp256k1 keypair, and is identified by a a public address, which is the hex-encoding of the last 20 bytes of the Keccak-256 hash of the public key, prepended by `0x`. The user is expected to have a pre-existing Ethereum wallet prior to onboarding with XMTP.
+### Ethereum wallet
+
+As of Nov 30 2023, an Ethereum wallet consists of a secp256k1 keypair, and is identified by a public address, which is the hex-encoding of the last 20 bytes of the Keccak-256 hash of the public key, prepended by `0x`. The wallet keys do not expire and are not rotatable - in the event of a compromise, the user must create a new wallet. The user is expected to have a pre-existing Ethereum wallet prior to onboarding with XMTP.
 
 The wallet keys can be used to sign arbitrary text, with most wallet software requiring explicit [user acceptance](https://docs.metamask.io/wallet/how-to/sign-data/#use-personal_sign) of the signature text. The signature text is formatted according to version `0x45` of [EIP-191](https://eips.ethereum.org/EIPS/eip-191), and is signed via a recoverable ECDSA signature.
 
@@ -38,17 +40,15 @@ XMTP: <Label>\n\n
 
 | Label                   | Described in section                                    |
 | ----------------------- | ------------------------------------------------------- |
-| Grant messaging access  | [Installation provisioning](#installation-provisioning) |
+| Grant messaging access  | [Installation registration](#installation-provisioning) |
 | Revoke messaging access | [Installation revocation](#installation-revocation)     |
 
-There is currently no way to rotate the keys associated with an Ethereum wallet. In the event that a wallet is compromised, the user must create a new wallet.
+### Installation registration
 
-## Installation provisioning
-
-XMTP installations hold a long-lived Ed25519 key-pair (the 'installation key') and are identified via the Ethereum addressing format. The public installation key is used as the `signature_key` in all MLS leaf nodes, and is associated with the account's wallet via a wallet-signed credential. Every new app installation gains messaging access as follows:
+XMTP installations consist of a long-lived Ed25519 key-pair (the 'installation key') and are identified via the Ethereum addressing format. The public installation key is used as the `signature_key` in all MLS leaf nodes, and is associated with the account's wallet via a wallet-signed credential. Every new app installation gains messaging access as follows:
 
 1. The new Ed25519 key pair (installation key) is generated and stored on the device.
-2. The app prompts the user to sign the public key with their Ethereum wallet. The user is expected to inspect the text and reject the signing request if the data is invalid, for example if the displayed time is incorrect. Association text version 1 format:
+2. The app prompts the user to sign the public key with their Ethereum wallet. The user is expected to inspect the text and reject the signing request if the data is invalid, for example if the displayed time is incorrect. The format for version 1 of the association text is as follows:
 
    ```
    XMTP: Grant Messaging Access
@@ -63,7 +63,7 @@ XMTP installations hold a long-lived Ed25519 key-pair (the 'installation key') a
    struct {
         association_text_version: i32,
         signature: bytes,
-        creation_iso8601_time: string,
+        iso8601_time: string,
         wallet_address: string,
    } Eip191Association;
 
@@ -75,19 +75,71 @@ XMTP installations hold a long-lived Ed25519 key-pair (the 'installation key') a
    ```
 
 4. A last resort KeyPackage (containing the credential and signed by the installation key per the [MLS spec](https://www.rfc-editor.org/rfc/rfc9420.html#name-key-packages)) is generated and stored on the device.
-5. The app publishes the last resort key package to the server. The server will provide all valid last resort key packages for a given wallet address to any client that requests it.
+5. The app publishes the last resort key package to the server. The server will provide all identity updates (registrations and revocations) for a given wallet address to any client that requests it.
 
-## Credential validation
+### Credential validation
 
-## Installation revocation
+In XMTP there is no need for a centralized authentication service to validate credentials, nor for safety numbers to be shown in apps built on top of XMTP, as clients can locally validate that a credential is valid.
 
-At any time, the user may enumerate active installations by querying for all identity updates under the account. The user may identify each installation by the creation time as well as the installation key from the signing text.
+Credential validation must be performed by clients at the [events described by the MLS spec](https://www.rfc-editor.org/rfc/rfc9420.html#name-credential-validation) as follows:
 
-In the event of a compromise, malicious app, or no longer used installation, the user may revoke an installation’s messaging access going forward by signing a revocation payload containing the installation’s identity keys using their wallet and publishing it to the server. This will subsequently be surfaced in the identity update list for clients to validate.
+1. Verify that the referenced `installation_public_key` matches the `signature_key` of the leaf node.
+1. Derive the association text using the `association_text_version`, `creation_iso8601_time`, `installation_public_key`, with a label of `Grant Messaging Access`.
+1. Recover the wallet public key from the recoverable ECDSA `signature` on the association text.
+1. Derive the wallet address from the public key and verify that it matches the `wallet_address` on the association.
 
-## Authentication service
+### Installation revocation
 
-Unlike in other messaging providers, XMTP accounts are key-pairs. This means that the link between an installation and an account can be achieved via a signature that can be programmatically validated on any client device. There is no need for a centralized service to validate credentials, nor for safety numbers to be shown in apps built on top of XMTP. Additionally, apps built on top of XMTP may choose to layer on decentralized name resolution protocols such as ENS in order to display a user-friendly name.
+_Note: Revocation is not scheduled to be built until Q2 2024 or later_
+
+Users may revoke an installation as follows:
+
+1. Enumerate active installations by querying for all identity updates under the account. The user may identify each installation by the creation time as well as the installation public key of the credential.
+1. Select the installation to revoke.
+1. The app prompts the user to sign the revocation with their Ethereum wallet. The user is expected to inspect the text and reject the signing request if the data is invalid, for example if the displayed time is incorrect. The format for version 1 of the association text is as follows:
+
+   ```
+   XMTP: Revoke Messaging Access
+
+   Current Time: <ISO 8601 date and time with local UTC offset>
+   Installation ID: <hex(last_20_bytes(keccak256(Ed25519PublicKey)))>
+   ```
+
+1. The signature and related data is then protobuf-serialized to form the revocation:
+
+   ```
+   struct {
+       installation_public_key: bytes,
+       eip191_association: Eip191Association
+   } InstallationRevocation;
+   ```
+
+1. The app publishes the revocation to the server. The server will provide all identity updates (registrations and revocations) for a given wallet address to any client that requests it.
+
+Validation of revocations is identical to the process described in [Credential Validation](#credential-validation), except that a label of `Revoke Messaging Access` is used.
+
+Once an installation is revoked, it cannot be re-registered or re-provisioned. The time displayed on the revocation is for informational purposes only.
+
+### Installation synchronization
+
+At any time in the course of a conversation, the list of valid installations for the participating wallet addresses may change via registration or revocation.
+
+Clients must perform the following validation prior to publishing each payload on the group:
+
+1. Assemble a list of wallet addresses in the conversation from the leaf nodes.
+1. Fetch all identity updates on those wallet addresses, and construct a list of valid installations.
+1. Remove nodes from the conversation that are not in the list of valid installations.
+1. Add nodes to the conversation that are in the list of valid installations and not already present.
+
+Clients must perform the following validation on receiving each payload in the group:
+
+1. Query the server for identity updates on the sending wallet address and verify that the sending installation has not been revoked.
+
+XMTP clients may perform performance optimizations, such as caching installation lists with a short TTL.
+
+An open area of investigation is ensuring transcript consistency in the face of revoked clients. If the server can maintain a strict ordering between revocations and payloads in the conversations (such as commits performed by the revoked clients), then all participants may apply the updates in a consistent way.
+
+### Delivery service and server trust
 
 Although registrations and revocations cannot be forged, we currently rely on trust in centralized XMTP servers not to maliciously hide installation registration and revocation payloads from clients that request them. Current decentralization efforts within XMTP will eventually produce a trustless public immutable record of registrations and revocations that does not rely on any single entity.
 
@@ -105,3 +157,7 @@ The latter can be addressed using the mechanism described in the earlier section
 **Mapping from conversations to accounts**
 
 Will add this in next PR.
+
+Clients must perform the following validation when a member is added:
+
+Clients must perform the following validation when a member is removed:

--- a/xmtp_mls/IDENTITY.md
+++ b/xmtp_mls/IDENTITY.md
@@ -45,7 +45,7 @@ XMTP: <Label>\n\n
 
 ### Installation registration
 
-XMTP installations consist of a long-lived Ed25519 key-pair (the 'installation key') and are identified via the Ethereum addressing format. The public installation key is used as the `signature_key` in all MLS leaf nodes, and is associated with the account's wallet via a wallet-signed credential. Every new app installation gains messaging access as follows:
+XMTP installations consist of a long-lived Ed25519 key-pair (the 'installation key') and are identified via the Ethereum addressing format. The public installation key is used as the `signature_key` in all MLS leaf nodes and nowhere else, and is associated with the account's wallet via a wallet-signed credential. Every new app installation gains messaging access as follows:
 
 1. The new Ed25519 key pair (installation key) is generated and stored on the device.
 2. The app prompts the user to sign the public key with their Ethereum wallet. The user is expected to inspect the text and reject the signing request if the data is invalid, for example if the displayed time is incorrect. The format for version 1 of the association text is as follows:

--- a/xmtp_mls/IDENTITY.md
+++ b/xmtp_mls/IDENTITY.md
@@ -8,13 +8,13 @@ Amal's account (Ethereum wallet address)
 ├── Converse app (mobile phone)
 │   └── Installation key bundle 1
 │
-├── Coinbase Wallet (mobile phone)
+├── Coinbase Wallet app (mobile phone)
 │   └── Installation key bundle 2
 │
-├── Lenster (tablet)
+├── Lenster app (tablet)
 │   └── Installation key bundle 3
 │
-└── Coinbase Wallet (tablet)
+└── Coinbase Wallet app (tablet)
     └── Installation key bundle 4
 ```
 
@@ -23,6 +23,14 @@ Using per-installation keys provides the following benefits:
 - Installation private keys are never shared across devices or published onto the network.
 - The user may enumerate the installations that have messaging access to their account.
 - The user may revoke keys on a per-installation level.
+
+**Ethereum wallet**
+
+Today, an Ethereum wallet consists of a [secp256k1 keypair](https://ethereum.org/en/developers/docs/accounts/#account-creation), and is identified by a a public address, which is the hex-encoding of the last 20 bytes of the Keccak-256 hash of the public key, prepended by `0x`. The user is expected to have a pre-existing Ethereum wallet prior to onboarding with XMTP.
+
+The owner of a wallet may sign arbitrary text with the wallet. Most wallet software requires explicit [user acceptance](https://docs.metamask.io/wallet/how-to/sign-data/#use-personal_sign) of the signature text. The signature text is formatted according to version `0x45` of [ERC-191](https://eips.ethereum.org/EIPS/eip-191), and is signed via a recoverable ECDSA signature.
+
+There is currently no way to rotate the keys associated with an Ethereum wallet. In the event that a wallet is compromised, the user must create a new wallet.
 
 **Installation provisioning**
 

--- a/xmtp_mls/IDENTITY.md
+++ b/xmtp_mls/IDENTITY.md
@@ -140,8 +140,6 @@ Clients must perform the following validation prior to publishing each payload o
 
 XMTP clients may perform performance optimizations, such as caching installation lists with a short TTL.
 
-An open area of investigation is ensuring transcript consistency in the face of revoked clients. If the server can maintain a strict ordering between revocations and payloads in the conversation (especially commits performed by the revoked clients), then all participants can achieve consensus on whether a payload from the revoked client should be applied or not.
-
 ### Server trust
 
 We currently rely on trust in centralized XMTP servers, which could do the following if malicious.

--- a/xmtp_mls/IDENTITY.md
+++ b/xmtp_mls/IDENTITY.md
@@ -131,17 +131,24 @@ Clients must perform the following validation prior to publishing each payload o
 1. Remove nodes from the conversation that are not in the list of valid installations.
 1. Add nodes to the conversation that are in the list of valid installations and not already present.
 
-Clients must perform the following validation on receiving each payload in the group:
+XMTP clients may perform performance optimizations, such as caching installation lists with a short TTL.
+
+To support revocations (Q2+ 2024), clients must additionally perform the following validation on receiving each payload in the group:
 
 1. Query the server for identity updates on the sending wallet address and verify that the sending installation has not been revoked.
 
-XMTP clients may perform performance optimizations, such as caching installation lists with a short TTL.
+An open area of investigation is ensuring transcript consistency in the face of revoked clients. If the server can maintain a strict ordering between revocations and payloads in the conversation (especially commits performed by the revoked clients), then all participants can achieve consensus on whether a payload from the revoked client should be applied or not.
 
-An open area of investigation is ensuring transcript consistency in the face of revoked clients. If the server can maintain a strict ordering between revocations and payloads in the conversations (such as commits performed by the revoked clients), then all participants may apply the updates in a consistent way.
+### Server trust
 
-### Delivery service and server trust
+We currently rely on trust in centralized XMTP servers, which could do the following if malicious.
 
-Although registrations and revocations cannot be forged, we currently rely on trust in centralized XMTP servers not to maliciously hide installation registration and revocation payloads from clients that request them. Current decentralization efforts within XMTP will eventually produce a trustless public immutable record of registrations and revocations that does not rely on any single entity.
+1. **Selectively omit payloads**. A malicious server could hide registrations (and application messages) from valid installations in order to censor them, or revocations for invalid installations in order to prevent post-compromise recovery.
+   - Decentralization efforts within XMTP aim to produce an immutable log of these events (H1 2024).
+1. **Reorder payloads**. A malicious server could reorder messages and commits within a conversation.
+   - Decentralization efforts within XMTP aim to produce a consensus-driven ordering of commits at minimum (H2+ 2024).
+
+Note, however, that a malicious server is unable to forge payloads due to the use of digital signatures.
 
 ## Synchronizing MLS group membership
 

--- a/xmtp_mls/IDENTITY.md
+++ b/xmtp_mls/IDENTITY.md
@@ -28,7 +28,7 @@ Using per-installation keys provides the following benefits:
 
 ### Ethereum wallet
 
-As of Nov 30 2023, an Ethereum wallet consists of a secp256k1 keypair, and is identified by a public address, which is the hex-encoding of the last 20 bytes of the Keccak-256 hash of the public key, prepended by `0x`. The wallet keys do not expire and are not rotatable - in the event of a compromise, the user must create a new wallet. The user is expected to have a pre-existing Ethereum wallet prior to onboarding with XMTP.
+As of Nov 30 2023, an Ethereum wallet consists of a secp256k1 keypair, and is identified by a public address, which is the hex-encoding of the last 20 bytes of the Keccak-256 hash of the public key, prepended by `0x`. Wallet keys do not expire and are not rotatable - in the event of a compromise, the user must create a new wallet. The user is expected to have a pre-existing Ethereum wallet prior to onboarding with XMTP.
 
 The wallet keys can be used to sign arbitrary text, with most wallet software requiring explicit [user acceptance](https://docs.metamask.io/wallet/how-to/sign-data/#use-personal_sign) of the signature text. The signature text is formatted according to version `0x45` of [EIP-191](https://eips.ethereum.org/EIPS/eip-191), and is signed via a recoverable ECDSA signature.
 


### PR DESCRIPTION
Preview the doc here: https://github.com/xmtp/libxmtp/blob/rich/identity-doc-updates/xmtp_mls/IDENTITY.md

Adding more detail that was requested during review, as well as addressing feedback.

- Add context on ethereum wallets
- Add detail on signature formats and signature labelling
- Add installation_public_key to credentials
- Clean up time representation
- Add detail on credential validation and installation synchronization
- Add detail on revocation
- Add account-level membership description