### PR TITLE
Fix DB issues

### DIFF
--- a/bindings_ffi/README.md
+++ b/bindings_ffi/README.md
@@ -53,8 +53,10 @@ There is no support for using breakpoints or a debugger with FFI currently. Meth
 1. Examine the database in your app
    1. Use logs to find the location of the Sqlite database and the database encryption key
    1. Find the database (for example, on Android emulator use Device File Explorer in Android Studio)
-   1. Copy the database to your local machine and open it on the command line using `sqlite3`
+   1. `brew install sqlcipher`
+   1. Copy the database to your local machine and open it on the command line using `sqlcipher <file>.db3`
    1. Decrypt the database if needed [as follows](https://utelle.github.io/SQLite3MultipleCiphers/docs/configuration/config_sql_pragmas/#pragma-key) (or disable database encryption before running the app)
+      1. Note that decryption is buggy if using `sqlite3` - `sqlcipher` is necessary here
 
 # Releasing new version
 

--- a/bindings_ffi/examples/ExampleInstrumentedTest.kt
+++ b/bindings_ffi/examples/ExampleInstrumentedTest.kt
@@ -24,8 +24,8 @@ class ExampleInstrumentedTest {
         val credentials: Credentials = Credentials.create(ECKeyPair.create(privateKey))
         val inboxOwner = Web3jInboxOwner(credentials)
         runBlocking {
-            val client = uniffi.xmtpv3.createClient(AndroidFfiLogger(), inboxOwner, EMULATOR_LOCALHOST_ADDRESS, false)
-            assertNotNull("Should be able to construct client", client.walletAddress())
+            val client = uniffi.xmtpv3.createClient(AndroidFfiLogger(), inboxOwner, EMULATOR_LOCALHOST_ADDRESS, false, null, null)
+            assertNotNull("Should be able to construct client", client.accountAddress())
             client.close()
         }
     }
@@ -38,7 +38,7 @@ class ExampleInstrumentedTest {
         runBlocking {
             var didThrow = false;
             try {
-                val client = uniffi.xmtpv3.createClient(AndroidFfiLogger(), inboxOwner, "http://incorrect:5556", false)
+                val client = uniffi.xmtpv3.createClient(AndroidFfiLogger(), inboxOwner, "http://incorrect:5556", false, null, null)
             } catch (e: Exception) {
                 didThrow = true
             }

--- a/bindings_ffi/examples/MainActivity.kt
+++ b/bindings_ffi/examples/MainActivity.kt
@@ -15,6 +15,7 @@ import java.io.File
 import java.nio.charset.StandardCharsets
 import java.security.SecureRandom
 
+const val EMULATOR_LOCALHOST_ADDRESS = "http://10.0.2.2:5556"
 const val DEV_NETWORK_ADDRESS = "https://dev.xmtp.network:5556"
 
 class Web3jInboxOwner(private val credentials: Credentials) : FfiInboxOwner {
@@ -58,7 +59,7 @@ class MainActivity : AppCompatActivity() {
                 val client = uniffi.xmtpv3.createClient(
                     AndroidFfiLogger(),
                     inboxOwner,
-                    DEV_NETWORK_ADDRESS,
+                    EMULATOR_LOCALHOST_ADDRESS,
                     true,
                     dbPath,
                     dbEncryptionKey

--- a/bindings_ffi/src/lib.rs
+++ b/bindings_ffi/src/lib.rs
@@ -282,7 +282,7 @@ mod tests {
         distributions::{Alphanumeric, DistString},
     };
     use xmtp_cryptography::{signature::RecoverableSignature, utils::rng};
-    use xmtp_mls::InboxOwner;
+    use xmtp_mls::{storage::EncryptionKey, InboxOwner};
 
     #[derive(Clone)]
     pub struct LocalWalletInboxOwner {
@@ -324,6 +324,10 @@ mod tests {
     pub fn tmp_path() -> String {
         let db_name = rand_string();
         format!("{}/{}.db3", env::temp_dir().to_str().unwrap(), db_name)
+    }
+
+    fn static_enc_key() -> EncryptionKey {
+        [2u8; 32]
     }
 
     async fn new_test_client() -> Arc<FfiXmtpClient> {

--- a/bindings_ffi/src/lib.rs
+++ b/bindings_ffi/src/lib.rs
@@ -53,10 +53,6 @@ fn stringify_error_chain<T: Error>(error: &T) -> String {
     result
 }
 
-fn static_enc_key() -> EncryptionKey {
-    [2u8; 32]
-}
-
 #[uniffi::export(async_runtime = "tokio")]
 pub async fn create_client(
     logger: Box<dyn FfiLogger>,
@@ -81,19 +77,21 @@ pub async fn create_client(
         db,
         encryption_key.is_some()
     );
-    let key: EncryptionKey = match encryption_key {
-        Some(key) => key.try_into().map_err(|_err| GenericError::Generic {
-            err: "Malformed 32 byte encryption key".to_string(),
-        })?,
-        None => static_enc_key(),
+
+    let storage_option = match db {
+        Some(path) => StorageOption::Persistent(path),
+        None => StorageOption::Ephemeral,
     };
 
-    let store = match db {
-        // TODO support encryption
-        Some(path) => EncryptedMessageStore::new_unencrypted(StorageOption::Persistent(path)),
-
-        None => EncryptedMessageStore::new(StorageOption::Ephemeral, key),
-    }?;
+    let store = match encryption_key {
+        Some(key) => {
+            let key: EncryptionKey = key.try_into().map_err(|_err| GenericError::Generic {
+                err: "Malformed 32 byte encryption key".to_string(),
+            })?;
+            EncryptedMessageStore::new(storage_option, key)?
+        }
+        None => EncryptedMessageStore::new_unencrypted(storage_option)?,
+    };
 
     log::info!("Creating XMTP client");
     let xmtp_client: RustXmtpClient = ClientBuilder::new(inbox_owner.into())
@@ -277,8 +275,7 @@ mod tests {
     use std::{env, sync::Arc};
 
     use crate::{
-        create_client, inbox_owner::SigningError, logger::FfiLogger, static_enc_key, FfiInboxOwner,
-        FfiXmtpClient,
+        create_client, inbox_owner::SigningError, logger::FfiLogger, FfiInboxOwner, FfiXmtpClient,
     };
     use ethers_core::rand::{
         self,
@@ -391,7 +388,6 @@ mod tests {
         )
     }
 
-    #[ignore]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_create_client_with_key() {
         let ffi_inbox_owner = LocalWalletInboxOwner::new();
@@ -414,7 +410,7 @@ mod tests {
         drop(client_a);
 
         let mut other_key = static_enc_key();
-        other_key[0] = 1;
+        other_key[31] = 1;
 
         let result_errored = create_client(
             Box::new(MockLogger {}),

--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -51,11 +51,12 @@ where
 {
     fn initialize_identity(
         self,
-        store: &EncryptedMessageStore,
         provider: &'a XmtpOpenMlsProvider,
     ) -> Result<Identity, ClientBuilderError> {
-        let identity_option: Option<Identity> =
-            store.conn()?.fetch(&())?.map(|i: StoredIdentity| i.into());
+        let identity_option: Option<Identity> = provider
+            .conn()
+            .fetch(&())?
+            .map(|i: StoredIdentity| i.into());
         debug!("Existing identity in store: {:?}", identity_option);
         match self {
             IdentityStrategy::CachedOnly => {
@@ -144,9 +145,7 @@ where
         let conn = store.conn()?;
         let provider = XmtpOpenMlsProvider::new(&conn);
         debug!("Initializing identity");
-        let identity = self
-            .identity_strategy
-            .initialize_identity(&store, &provider)?;
+        let identity = self.identity_strategy.initialize_identity(&provider)?;
         Ok(Client::new(api_client, network, identity, store))
     }
 }


### PR DESCRIPTION
Key learnings:
- The `sqlite3` command-line tool supports `pragma key`, but encrypts/decrypts in a way that is non-compliant with `sqlcipher`. There is a `sqlcipher` command-line tool that can be used to open sqlite databases encrypted via `sqlcipher` instead.
- We were unnecessarily opening a second connection when initializing the identity. The ephemeral store only allows one connection open at a time, which is why it was locking up when used via the bindings (and probably via CLI too).
- The sqlcipher `pragma key` initialization must be run on *every connection*, not just the first time the database is opened. If different connections write to the database with different encryption keys, the database becomes corrupted and can no longer be opened.

Added fixes for these, as well as unit tests and updating READMEs.

Also modified the bindings to create an unencrypted database when no encryption key is passed, rather than an encrypted database with a hardcoded encryption key. This should make development/debugging a little bit easier. Note that there isn't much of a security difference between using a hardcoded encryption key and no encryption key at all.