### PR TITLE
Use write-ahead-logging for sqlite database

### DIFF
--- a/bindings_ffi/examples/MainActivity.kt
+++ b/bindings_ffi/examples/MainActivity.kt
@@ -47,7 +47,9 @@ class MainActivity : AppCompatActivity() {
         val privateKey: ByteArray = SecureRandom().generateSeed(32)
         val credentials: Credentials = Credentials.create(ECKeyPair.create(privateKey))
         val inboxOwner = Web3jInboxOwner(credentials)
-        val dbPath: String = this.filesDir.absolutePath + "/android_example.db3"
+        val dbDir: File = File(this.filesDir.absolutePath, "xmtp_db")
+        dbDir.mkdir()
+        val dbPath: String = dbDir.absolutePath + "/android_example.db3"
         val dbEncryptionKey: List<UByte> = SecureRandom().generateSeed(32).asUByteArray().asList()
         Log.i(
             "App",
@@ -70,6 +72,6 @@ class MainActivity : AppCompatActivity() {
             }
         }
 
-        File(dbPath).delete()
+        dbDir.deleteRecursively()
     }
 }

--- a/xmtp_mls/src/storage/encrypted_store/mod.rs
+++ b/xmtp_mls/src/storage/encrypted_store/mod.rs
@@ -116,9 +116,10 @@ impl EncryptedMessageStore {
     }
 
     fn init_db(&mut self) -> Result<(), StorageError> {
-        log::info!("Running DB migrations");
         let conn = &mut self.raw_conn()?;
+        conn.batch_execute("PRAGMA journal_mode = WAL;")?;
 
+        log::info!("Running DB migrations");
         conn.run_pending_migrations(MIGRATIONS)
             .map_err(|e| StorageError::DbInit(e.to_string()))?;
 

--- a/xmtp_mls/src/storage/encrypted_store/mod.rs
+++ b/xmtp_mls/src/storage/encrypted_store/mod.rs
@@ -117,7 +117,8 @@ impl EncryptedMessageStore {
 
     fn init_db(&mut self) -> Result<(), StorageError> {
         let conn = &mut self.raw_conn()?;
-        conn.batch_execute("PRAGMA journal_mode = WAL;")?;
+        conn.batch_execute("PRAGMA journal_mode = WAL;")
+            .map_err(|e| StorageError::DbInit(e.to_string()))?;
 
         log::info!("Running DB migrations");
         conn.run_pending_migrations(MIGRATIONS)


### PR DESCRIPTION
More information here: https://www.sqlite.org/wal.html

This is a feature of sqlite intended to allow for situations where higher concurrency is needed. We can see if it fixes https://github.com/xmtp/libxmtp/pull/368#issuecomment-1854561605, but it's a good practice regardless.

Tested on Android emulator