### PR TITLE
Add scaffolding for new policy framework

### DIFF
--- a/xmtp_mls/src/groups/group_permissions.rs
+++ b/xmtp_mls/src/groups/group_permissions.rs
@@ -1,0 +1,358 @@
+use super::validated_commit::{AggregatedMembershipChange, CommitParticipant, ValidatedCommit};
+
+pub trait Policy {
+    fn evaluate(&self, actor: &CommitParticipant, change: &AggregatedMembershipChange) -> bool;
+}
+
+#[derive(Clone, Copy, Debug)]
+#[allow(dead_code)]
+pub enum StandardPolicies {
+    Allow,
+    Deny,
+    // Allow if the change only applies to subject installations with the same account address as the actor
+    AllowSameMember,
+    // AllowIfActorAdmin, TODO: Enable this once we have admin roles
+    // AllowIfActorCreator, TODO: Enable this once we know who the creator is
+    // AllowIfSubjectRevoked, TODO: Enable this once we have revocation and have context on who is revoked
+}
+
+impl Policy for StandardPolicies {
+    fn evaluate(&self, actor: &CommitParticipant, change: &AggregatedMembershipChange) -> bool {
+        match self {
+            StandardPolicies::Allow => true,
+            StandardPolicies::Deny => false,
+            StandardPolicies::AllowSameMember => change.account_address == actor.account_address,
+        }
+    }
+}
+
+// An AndCondition evaluates to true if all the policies it contains evaluate to true
+pub struct AndCondition<PolicyType>
+where
+    PolicyType: Policy,
+{
+    policies: Vec<PolicyType>,
+}
+
+impl<PolicyType> AndCondition<PolicyType>
+where
+    PolicyType: Policy,
+{
+    pub fn new(policies: Vec<PolicyType>) -> Self {
+        Self { policies }
+    }
+}
+
+impl<PolicyType> Policy for AndCondition<PolicyType>
+where
+    PolicyType: Policy,
+{
+    fn evaluate(&self, actor: &CommitParticipant, change: &AggregatedMembershipChange) -> bool {
+        self.policies
+            .iter()
+            .all(|policy| policy.evaluate(actor, change))
+    }
+}
+
+// An AnyCondition evaluates to true if any of the contained policies evaluate to true
+pub struct AnyCondition<PolicyType>
+where
+    PolicyType: Policy,
+{
+    policies: Vec<PolicyType>,
+}
+
+impl<PolicyType> AnyCondition<PolicyType>
+where
+    PolicyType: Policy,
+{
+    pub fn new(policies: Vec<PolicyType>) -> Self {
+        Self { policies }
+    }
+}
+
+impl<PolicyType> Policy for AnyCondition<PolicyType>
+where
+    PolicyType: Policy,
+{
+    fn evaluate(&self, actor: &CommitParticipant, change: &AggregatedMembershipChange) -> bool {
+        self.policies
+            .iter()
+            .any(|policy| policy.evaluate(actor, change))
+    }
+}
+
+// A NotCondition evaluates to true if the contained policy evaluates to false
+pub struct NotCondition<PolicyType>
+where
+    PolicyType: Policy,
+{
+    policy: PolicyType,
+}
+
+impl<PolicyType> NotCondition<PolicyType>
+where
+    PolicyType: Policy,
+{
+    pub fn new(policy: PolicyType) -> Self {
+        Self { policy }
+    }
+}
+
+impl<PolicyType> Policy for NotCondition<PolicyType>
+where
+    PolicyType: Policy,
+{
+    fn evaluate(&self, actor: &CommitParticipant, change: &AggregatedMembershipChange) -> bool {
+        !self.policy.evaluate(actor, change)
+    }
+}
+
+#[allow(dead_code)]
+pub struct GroupPermissions<
+    AddMemberPolicy,
+    RemoveMemberPolicy,
+    AddInstallationPolicy,
+    RemoveInstallationPolicy,
+> where
+    AddMemberPolicy: Policy,
+    RemoveMemberPolicy: Policy,
+    AddInstallationPolicy: Policy,
+    RemoveInstallationPolicy: Policy,
+{
+    pub add_member_policy: AddMemberPolicy,
+    pub remove_member_policy: RemoveMemberPolicy,
+    pub add_installation_policy: AddInstallationPolicy,
+    pub remove_installation_policy: RemoveInstallationPolicy,
+}
+
+#[allow(dead_code)]
+impl<AddMemberPolicy, RemoveMemberPolicy, AddInstallationPolicy, RemoveInstallationPolicy>
+    GroupPermissions<
+        AddMemberPolicy,
+        RemoveMemberPolicy,
+        AddInstallationPolicy,
+        RemoveInstallationPolicy,
+    >
+where
+    AddMemberPolicy: Policy,
+    RemoveMemberPolicy: Policy,
+    AddInstallationPolicy: Policy,
+    RemoveInstallationPolicy: Policy,
+{
+    pub fn new(
+        add_member_policy: AddMemberPolicy,
+        remove_member_policy: RemoveMemberPolicy,
+        add_installation_policy: AddInstallationPolicy,
+        remove_installation_policy: RemoveInstallationPolicy,
+    ) -> Self {
+        Self {
+            add_member_policy,
+            remove_member_policy,
+            add_installation_policy,
+            remove_installation_policy,
+        }
+    }
+
+    pub fn evaluate_commit(&self, commit: &ValidatedCommit) -> bool {
+        if self.evaluate_add_member(commit) == false {
+            return false;
+        }
+        if self.evaluate_remove_member(commit) == false {
+            return false;
+        }
+        if self.evaluate_add_installation(commit) == false {
+            return false;
+        }
+        if self.evaluate_remove_installation(commit) == false {
+            return false;
+        }
+        return true;
+    }
+
+    fn evaluate_add_member(&self, commit: &ValidatedCommit) -> bool {
+        for change in commit.members_added.iter() {
+            if !self.add_member_policy.evaluate(&commit.actor, change) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    fn evaluate_remove_member(&self, commit: &ValidatedCommit) -> bool {
+        for change in commit.members_removed.iter() {
+            if !self.remove_member_policy.evaluate(&commit.actor, change) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    fn evaluate_add_installation(&self, commit: &ValidatedCommit) -> bool {
+        for change in commit.installations_added.iter() {
+            if !self.add_installation_policy.evaluate(&commit.actor, change) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    fn evaluate_remove_installation(&self, commit: &ValidatedCommit) -> bool {
+        for change in commit.installations_removed.iter() {
+            if !self
+                .remove_installation_policy
+                .evaluate(&commit.actor, change)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::utils::test::{rand_vec, rand_wallet_address};
+
+    use super::*;
+
+    fn build_change(
+        account_address: Option<String>,
+        installation_id: Option<Vec<u8>>,
+    ) -> AggregatedMembershipChange {
+        AggregatedMembershipChange {
+            account_address: account_address.unwrap_or_else(|| rand_wallet_address()),
+            installation_ids: vec![installation_id.unwrap_or_else(|| rand_vec())],
+        }
+    }
+
+    fn build_actor(
+        account_address: Option<String>,
+        installation_id: Option<Vec<u8>>,
+    ) -> CommitParticipant {
+        CommitParticipant {
+            account_address: account_address.unwrap_or_else(|| rand_wallet_address()),
+            installation_id: installation_id.unwrap_or_else(|| rand_vec()),
+        }
+    }
+
+    fn build_validated_commit(
+        // Add a member with the same account address as the actor if true, random account address if false
+        member_added: Option<bool>,
+        member_removed: Option<bool>,
+        installation_added: Option<bool>,
+        installation_removed: Option<bool>,
+    ) -> ValidatedCommit {
+        let actor = build_actor(None, None);
+        let build_membership_change = |same_address_as_actor| {
+            if same_address_as_actor {
+                vec![build_change(Some(actor.account_address.clone()), None)]
+            } else {
+                vec![build_change(None, None)]
+            }
+        };
+        ValidatedCommit {
+            actor: actor.clone(),
+            members_added: member_added.map(build_membership_change).unwrap_or(vec![]),
+            members_removed: member_removed
+                .map(build_membership_change)
+                .unwrap_or_else(|| vec![]),
+            installations_added: installation_added
+                .map(build_membership_change)
+                .unwrap_or_else(|| vec![]),
+            installations_removed: installation_removed
+                .map(build_membership_change)
+                .unwrap_or_else(|| vec![]),
+        }
+    }
+
+    #[test]
+    fn test_allow_all() {
+        let permissions = GroupPermissions::new(
+            StandardPolicies::Allow,
+            StandardPolicies::Allow,
+            StandardPolicies::Allow,
+            StandardPolicies::Allow,
+        );
+        let commit = build_validated_commit(Some(true), Some(true), Some(true), Some(true));
+        assert!(permissions.evaluate_commit(&commit));
+    }
+
+    #[test]
+    fn test_deny() {
+        let permissions = GroupPermissions::new(
+            StandardPolicies::Deny,
+            StandardPolicies::Deny,
+            StandardPolicies::Deny,
+            StandardPolicies::Deny,
+        );
+
+        let member_added_commit = build_validated_commit(Some(false), None, None, None);
+        assert!(permissions.evaluate_commit(&member_added_commit) == false);
+
+        let member_removed_commit = build_validated_commit(None, Some(false), None, None);
+        assert!(permissions.evaluate_commit(&member_removed_commit) == false);
+
+        let installation_added_commit = build_validated_commit(None, None, Some(false), None);
+        assert!(permissions.evaluate_commit(&installation_added_commit) == false);
+
+        let installation_removed_commit = build_validated_commit(None, None, None, Some(false));
+        assert!(permissions.evaluate_commit(&installation_removed_commit) == false);
+    }
+
+    #[test]
+    fn test_allow_same_member() {
+        let permissions = GroupPermissions::new(
+            StandardPolicies::AllowSameMember,
+            StandardPolicies::Deny,
+            StandardPolicies::Deny,
+            StandardPolicies::Deny,
+        );
+
+        let commit_with_same_member = build_validated_commit(Some(true), None, None, None);
+        assert!(permissions.evaluate_commit(&commit_with_same_member));
+
+        let commit_with_different_member = build_validated_commit(Some(false), None, None, None);
+        assert!(permissions.evaluate_commit(&commit_with_different_member) == false);
+    }
+
+    #[test]
+    fn test_and_condition() {
+        let permissions = GroupPermissions::new(
+            AndCondition::new(vec![StandardPolicies::Deny, StandardPolicies::Allow]),
+            StandardPolicies::Allow,
+            StandardPolicies::Allow,
+            StandardPolicies::Allow,
+        );
+
+        let member_added_commit = build_validated_commit(Some(true), None, None, None);
+        assert!(permissions.evaluate_commit(&member_added_commit) == false);
+    }
+
+    #[test]
+    fn test_any_condition() {
+        let permissions = GroupPermissions::new(
+            AnyCondition::new(vec![StandardPolicies::Deny, StandardPolicies::Allow]),
+            StandardPolicies::Allow,
+            StandardPolicies::Allow,
+            StandardPolicies::Allow,
+        );
+
+        let member_added_commit = build_validated_commit(Some(true), None, None, None);
+        assert!(permissions.evaluate_commit(&member_added_commit));
+    }
+
+    #[test]
+    fn test_not_condition() {
+        let permissions = GroupPermissions::new(
+            NotCondition::new(StandardPolicies::Allow),
+            StandardPolicies::Allow,
+            StandardPolicies::Allow,
+            StandardPolicies::Allow,
+        );
+
+        let member_added_commit = build_validated_commit(Some(true), None, None, None);
+
+        assert!(permissions.evaluate_commit(&member_added_commit) == false);
+    }
+}

--- a/xmtp_mls/src/groups/group_permissions.rs
+++ b/xmtp_mls/src/groups/group_permissions.rs
@@ -34,6 +34,7 @@ where
     policies: Vec<PolicyType>,
 }
 
+#[allow(dead_code)]
 impl<PolicyType> AndCondition<PolicyType>
 where
     PolicyType: Policy,

--- a/xmtp_mls/src/groups/group_permissions.rs
+++ b/xmtp_mls/src/groups/group_permissions.rs
@@ -27,6 +27,7 @@ impl Policy for StandardPolicies {
 }
 
 // An AndCondition evaluates to true if all the policies it contains evaluate to true
+#[derive(Clone, Debug)]
 pub struct AndCondition<PolicyType>
 where
     PolicyType: Policy,
@@ -56,6 +57,7 @@ where
 }
 
 // An AnyCondition evaluates to true if any of the contained policies evaluate to true
+#[derive(Clone, Debug)]
 pub struct AnyCondition<PolicyType>
 where
     PolicyType: Policy,
@@ -85,6 +87,7 @@ where
 }
 
 // A NotCondition evaluates to true if the contained policy evaluates to false
+#[derive(Clone, Debug)]
 pub struct NotCondition<PolicyType>
 where
     PolicyType: Policy,
@@ -118,10 +121,10 @@ pub struct GroupPermissions<
     AddInstallationPolicy,
     RemoveInstallationPolicy,
 > where
-    AddMemberPolicy: Policy,
-    RemoveMemberPolicy: Policy,
-    AddInstallationPolicy: Policy,
-    RemoveInstallationPolicy: Policy,
+    AddMemberPolicy: Policy + std::fmt::Debug,
+    RemoveMemberPolicy: Policy + std::fmt::Debug,
+    AddInstallationPolicy: Policy + std::fmt::Debug,
+    RemoveInstallationPolicy: Policy + std::fmt::Debug,
 {
     pub add_member_policy: AddMemberPolicy,
     pub remove_member_policy: RemoveMemberPolicy,
@@ -138,10 +141,10 @@ impl<AddMemberPolicy, RemoveMemberPolicy, AddInstallationPolicy, RemoveInstallat
         RemoveInstallationPolicy,
     >
 where
-    AddMemberPolicy: Policy,
-    RemoveMemberPolicy: Policy,
-    AddInstallationPolicy: Policy,
-    RemoveInstallationPolicy: Policy,
+    AddMemberPolicy: Policy + std::fmt::Debug,
+    RemoveMemberPolicy: Policy + std::fmt::Debug,
+    AddInstallationPolicy: Policy + std::fmt::Debug,
+    RemoveInstallationPolicy: Policy + std::fmt::Debug,
 {
     pub fn new(
         add_member_policy: AddMemberPolicy,
@@ -185,9 +188,20 @@ where
     ) -> bool
     where
         I: Iterator<Item = &'a AggregatedMembershipChange>,
-        P: Policy,
+        P: Policy + std::fmt::Debug,
     {
-        changes.all(|change| policy.evaluate(actor, change))
+        changes.all(|change| {
+            let is_ok = policy.evaluate(actor, change);
+            if !is_ok {
+                log::info!(
+                    "Policy {:?} failed for actor {:?} and change {:?}",
+                    policy,
+                    actor,
+                    change
+                );
+            }
+            is_ok
+        })
     }
 }
 

--- a/xmtp_mls/src/groups/group_permissions.rs
+++ b/xmtp_mls/src/groups/group_permissions.rs
@@ -63,6 +63,7 @@ where
     policies: Vec<PolicyType>,
 }
 
+#[allow(dead_code)]
 impl<PolicyType> AnyCondition<PolicyType>
 where
     PolicyType: Policy,
@@ -91,6 +92,7 @@ where
     policy: PolicyType,
 }
 
+#[allow(dead_code)]
 impl<PolicyType> NotCondition<PolicyType>
 where
     PolicyType: Policy,

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -1,4 +1,5 @@
 mod intents;
+mod group_permissions;
 mod members;
 pub mod validated_commit;
 use intents::SendMessageIntentData;

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -1,5 +1,5 @@
-mod intents;
 mod group_permissions;
+mod intents;
 mod members;
 pub mod validated_commit;
 use intents::SendMessageIntentData;

--- a/xmtp_mls/src/groups/validated_commit.rs
+++ b/xmtp_mls/src/groups/validated_commit.rs
@@ -40,7 +40,7 @@ pub enum CommitValidationError {
 
 // A participant in a commit. Could be the actor or the subject of a proposal
 #[derive(Clone, Debug)]
-pub(crate) struct CommitParticipant {
+pub struct CommitParticipant {
     pub account_address: Address,
     pub installation_id: Vec<u8>,
 }

--- a/xmtp_mls/src/groups/validated_commit.rs
+++ b/xmtp_mls/src/groups/validated_commit.rs
@@ -39,18 +39,21 @@ pub enum CommitValidationError {
 }
 
 // A participant in a commit. Could be the actor or the subject of a proposal
+#[derive(Clone, Debug)]
 pub(crate) struct CommitParticipant {
-    pub(crate) account_address: Address,
-    pub(crate) installation_id: Vec<u8>,
+    pub account_address: Address,
+    pub installation_id: Vec<u8>,
 }
 
 // An aggregation of all the installation_ids for a given membership change
+#[derive(Clone, Debug)]
 pub struct AggregatedMembershipChange {
     pub(crate) installation_ids: Vec<Vec<u8>>,
     pub(crate) account_address: Address,
 }
 
 // A parsed and validated commit that we can apply permissions and rules to
+#[derive(Clone, Debug)]
 pub struct ValidatedCommit {
     pub(crate) actor: CommitParticipant,
     pub(crate) members_added: Vec<AggregatedMembershipChange>,

--- a/xmtp_mls/src/utils/test.rs
+++ b/xmtp_mls/src/utils/test.rs
@@ -5,8 +5,14 @@ use rand::{
     Rng,
 };
 
+use crate::types::Address;
+
 pub fn rand_string() -> String {
     Alphanumeric.sample_string(&mut rand::thread_rng(), 24)
+}
+
+pub fn rand_wallet_address() -> Address {
+    Alphanumeric.sample_string(&mut rand::thread_rng(), 42)
 }
 
 pub fn rand_vec() -> Vec<u8> {


### PR DESCRIPTION
## Summary

- Adds in some basic structure for defining permissions and policies for evaluating proposals in commits
- Adds a few basic policies that can be enforced with the metadata we have right now
- Enables composition of simpler policies to form more complex policies

## Next up
- Serialization of the policies into something we can use in the metadata field
- Adding group creator/admin status to the `ValidatedCommit` object so it can be used in a policy
- Integrating immutable group metadata to determine group creator/admin status
- Enabling policy enforcement (initially with everything set to Allow)
- Adding some more logging and traceability to policy rejections. Devs should know why a commit was rejected

### Expected initial policies for V1

**Add Member**
- Actor is an installation with the same wallet address as the group creator

**Remove Member**
- Actor is an installation with the same wallet address as the group creator
OR
- The subject of the change has only one installation and that installation was revoked before the time of the commit

**Add Installation to existing member**
- Any group member can add an installation if the credential maps to the same account address as an existing member

**Remove installation from existing member**
- The subject installation has been revoked before the time of the commit