### PR TITLE
Update identity doc - ensure consistency of adds/removes

### DIFF
--- a/xmtp_mls/IDENTITY.md
+++ b/xmtp_mls/IDENTITY.md
@@ -137,7 +137,7 @@ Clients must perform the following validation prior to publishing each payload o
 1. Publish a commit to remove nodes from the conversation that are not in the list of valid installations.
 1. Publish a commit to add nodes to the conversation that are in the list of valid installations and not already present.
 
-These commits must include an attached proof (credential or revocation). When validating add/remove commits, clients must verify either that the proposer has permissions to add/remove accounts from the group, or that a proof of installation synchronization was attached to the commit.
+These commits must include an attached proof (credential or revocation). When validating add/remove commits, clients must verify either that the proposer has permissions to add/remove accounts from the group, or that a proof of installation revocation was attached to the commit.
 
 ### Server trust
 

--- a/xmtp_mls/IDENTITY.md
+++ b/xmtp_mls/IDENTITY.md
@@ -88,8 +88,6 @@ Credential validation must be performed by clients at the [events described by t
 1. Recover the wallet public key from the recoverable ECDSA `signature` on the association text.
 1. Derive the wallet address from the public key and verify that it matches the `wallet_address` on the association.
 
-Currently, verifying revocations require a degree of server trust, however this is not the long-term goal - see [Server trust](#server-trust).
-
 ### Installation revocation
 
 _Note: Revocation is not scheduled to be built until Q2 2024 or later_

--- a/xmtp_mls/IDENTITY.md
+++ b/xmtp_mls/IDENTITY.md
@@ -83,7 +83,6 @@ Apps built on XMTP have a reduced need for safety numbers to be shown, as client
 
 Credential validation must be performed by clients at the [events described by the MLS spec](https://www.rfc-editor.org/rfc/rfc9420.html#name-credential-validation) as follows:
 
-1. Verify that the referenced `installation_public_key` has not been revoked (see [Installation revocation](#installation-revocation)).
 1. Verify that the referenced `installation_public_key` matches the `signature_key` of the leaf node.
 1. Derive the association text using the `association_text_version`, `creation_iso8601_time`, `installation_public_key`, with a label of `Grant Messaging Access`.
 1. Recover the wallet public key from the recoverable ECDSA `signature` on the association text.
@@ -130,7 +129,7 @@ Revocations may not apply immediately on all groups. In order to ensure transcri
 
 At any time in the course of a conversation, the list of valid installations for the participating wallet addresses may change via registration or revocation.
 
-Clients must perform the following validation prior to publishing each payload on the group, as well as periodically:
+Clients must perform the following validation prior to publishing each payload on the group, as well as periodically. XMTP clients may perform performance optimizations, such as caching installation lists with a short TTL.
 
 1. Assemble a list of wallet addresses in the conversation from the leaf nodes.
 1. Fetch all identity updates on those wallet addresses.
@@ -138,7 +137,7 @@ Clients must perform the following validation prior to publishing each payload o
 1. Publish a commit to remove nodes from the conversation that are not in the list of valid installations.
 1. Publish a commit to add nodes to the conversation that are in the list of valid installations and not already present.
 
-XMTP clients may perform performance optimizations, such as caching installation lists with a short TTL.
+These commits must include an attached proof (credential or revocation). When validating add/remove commits, clients must verify either that the proposer has permissions to add/remove accounts from the group, or that a proof of installation synchronization was attached to the commit.
 
 ### Server trust
 


### PR DESCRIPTION
Incorporating feedback from @neekolas, my summary of his ideas:

The most important thing about processing commits to add/remove members is *consistency*. When some members apply a commit and others reject it, the group state gets mangled.

The validation code must not rely on network requests to verify an added installation was not revoked - as this leaves open the door to race conditions where different group members get different results immediately after a revocation.

Let's allow revoked installations to be added, but group members should periodically check for revoked installations in the group, and publish a commit to remove them that all group members will apply consistently (this logic is already in the doc).

We should also be able to attach a revocation proof to remove commits so that members can validate removals without going to the network, in the same way that a credential is presented in add commits, so that members can validate adds without going to the network.

To shorten the time window after a revocation gets committed to every group, the installation performing the revocation should go ahead and update all the groups that it knows of (this logic is already in the doc).