### PR TITLE
Move back to generating protos from main

### DIFF
--- a/dev/gen_protos.sh
+++ b/dev/gen_protos.sh
@@ -5,7 +5,7 @@ if ! cargo install --list | grep "protoc-gen-prost-crate" > /dev/null; then
         exit 1
     fi
 fi
-if ! buf generate https://github.com/xmtp/proto.git#branch=nmolnar/mls-verification-service,subdir=proto; then
+if ! buf generate https://github.com/xmtp/proto.git#branch=main,subdir=proto; then
     echo "Failed to generate protobuf definitions"
     exit 1
 fi


### PR DESCRIPTION
## Summary

Generate protos from `main` now that we don't have any other weird proto branches floating around.