### PR TITLE
Create new Subscribe2 method

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "rust-analyzer.linkedProjects": [
     "bindings_ffi/Cargo.toml",
-    "examples/cli/Cargo.toml"
+    "examples/cli/Cargo.toml",
+    "xmtp_api_grpc_gateway/Cargo.toml"
   ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6400,7 +6422,9 @@ dependencies = [
 name = "xmtp_api_grpc"
 version = "0.1.0"
 dependencies = [
+ "async-stream",
  "base64 0.21.5",
+ "futures",
  "http-body",
  "hyper",
  "hyper-rustls",
@@ -6483,6 +6507,7 @@ name = "xmtp_proto"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "futures",
  "pbjson",
  "pbjson-types",
  "prost",

--- a/xmtp_api_grpc/Cargo.toml
+++ b/xmtp_api_grpc/Cargo.toml
@@ -22,6 +22,8 @@ hyper-rustls = { version = "0.24.2", features = ["http2"] }
 http-body = "0.4.5"
 tower = "0.4.13"
 webpki-roots = "0.23.0"
+async-stream = "0.3.5"
+futures = "0.3.29"
 
 [dev-dependencies]
 uuid = { version = "1.3.1", features = ["v4"] }

--- a/xmtp_api_grpc/src/grpc_api_helper.rs
+++ b/xmtp_api_grpc/src/grpc_api_helper.rs
@@ -389,6 +389,8 @@ impl MutableApiSubscription for GrpcMutableSubscription {
 
 #[async_trait]
 impl XmtpMlsClient for Client {
+    type Subscription = GrpcMutableSubscription;
+
     async fn register_installation(
         &self,
         req: RegisterInstallationRequest,

--- a/xmtp_api_grpc/src/lib.rs
+++ b/xmtp_api_grpc/src/lib.rs
@@ -9,14 +9,14 @@ pub use grpc_api_helper::Client;
 mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
+    use super::*;
+    use futures::StreamExt;
     use xmtp_proto::{
-        api_client::{XmtpApiClient, XmtpApiSubscription},
+        api_client::{MutableApiSubscription, XmtpApiClient, XmtpApiSubscription},
         xmtp::message_api::v1::{
             BatchQueryRequest, Envelope, PublishRequest, QueryRequest, SubscribeRequest,
         },
     };
-
-    use super::*;
 
     // Return the json serialization of an Envelope with bytes
     pub fn test_envelope(topic: String) -> Envelope {
@@ -148,5 +148,59 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.envelopes.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn bidrectional_streaming_test() {
+        let client = Client::create(LOCALHOST_ADDRESS.to_string(), false)
+            .await
+            .unwrap();
+
+        let topic = uuid::Uuid::new_v4();
+        let mut stream = client
+            .subscribe2(SubscribeRequest {
+                content_topics: vec![topic.to_string()],
+            })
+            .await
+            .unwrap();
+
+        // Publish an envelope to the topic of the stream
+        let env = test_envelope(topic.to_string());
+        client
+            .publish(
+                "".to_string(),
+                PublishRequest {
+                    envelopes: vec![env],
+                },
+            )
+            .await
+            .unwrap();
+
+        let value = stream.next().await.unwrap().unwrap();
+        assert_eq!(value.content_topic, topic.to_string());
+
+        // Change the topic of the stream to something else
+        let topic_2 = uuid::Uuid::new_v4();
+        stream
+            .update(SubscribeRequest {
+                content_topics: vec![topic_2.to_string()],
+            })
+            .await
+            .unwrap();
+
+        // Publish an envelope to the new topic
+        let env_2 = test_envelope(topic_2.to_string());
+        client
+            .publish(
+                "".to_string(),
+                PublishRequest {
+                    envelopes: vec![env_2],
+                },
+            )
+            .await
+            .unwrap();
+
+        let value_2 = stream.next().await.unwrap().unwrap();
+        assert_eq!(value_2.content_topic, topic_2.to_string());
     }
 }

--- a/xmtp_api_grpc_gateway/Cargo.lock
+++ b/xmtp_api_grpc_gateway/Cargo.lock
@@ -554,6 +554,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "platforms",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.33",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1153,6 +1180,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27573eac26f4dd11e2b1916c3fe1baa56407c83c71a773a8ba17ec0bca03b6b7"
+
+[[package]]
 name = "fixed-hash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1228,9 +1261,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1243,9 +1276,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1253,15 +1286,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+checksum = "0f4fb8693db0cf099eadcca0efe2a5a22e4550f98ed16aba6c48700da29597bc"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1270,9 +1303,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
 
 [[package]]
 name = "futures-locks"
@@ -1286,9 +1319,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1297,15 +1330,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
 
 [[package]]
 name = "futures-task"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
 
 [[package]]
 name = "futures-timer"
@@ -1319,9 +1352,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2359,6 +2392,12 @@ name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
+name = "platforms"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14e6ab3f592e6fb464fc9712d8d6e6912de6473954635fd76a589d832cffcbb0"
 
 [[package]]
 name = "ppv-lite86"
@@ -3952,6 +3991,7 @@ name = "xmtp_api_grpc_gateway"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "futures",
  "getrandom",
  "hex",
  "js-sys",
@@ -3970,11 +4010,13 @@ dependencies = [
 name = "xmtp_cryptography"
 version = "0.1.0"
 dependencies = [
+ "curve25519-dalek",
  "ecdsa 0.15.1",
  "ethers",
  "ethers-core",
  "hex",
  "k256 0.12.0",
+ "log",
  "rand",
  "rand_chacha",
  "serde",
@@ -3988,6 +4030,7 @@ name = "xmtp_proto"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "futures",
  "pbjson",
  "pbjson-types",
  "prost",

--- a/xmtp_api_grpc_gateway/Cargo.toml
+++ b/xmtp_api_grpc_gateway/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 async-trait = "0.1.68"
+futures = "0.3.29"
 getrandom = { version = "0.2", features = ["js"] }
 hex = "0.4"
 js-sys = "0.3"

--- a/xmtp_api_grpc_gateway/src/lib.rs
+++ b/xmtp_api_grpc_gateway/src/lib.rs
@@ -26,7 +26,8 @@ impl XmtpGrpcGatewayClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl XmtpApiClient for XmtpGrpcGatewayClient {
     type Subscription = XmtpGrpcGatewaySubscription;
     type MutableSubscription = XmtpGrpcGatewayMutableSubscription;
@@ -115,7 +116,8 @@ impl XmtpApiSubscription for XmtpGrpcGatewaySubscription {
 
 pub struct XmtpGrpcGatewayMutableSubscription {}
 
-#[async_trait(?Send)]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl MutableApiSubscription for XmtpGrpcGatewayMutableSubscription {
     async fn update(&mut self, _req: SubscribeRequest) -> Result<(), Error> {
         // TODO

--- a/xmtp_api_grpc_gateway/src/lib.rs
+++ b/xmtp_api_grpc_gateway/src/lib.rs
@@ -1,5 +1,8 @@
 use async_trait::async_trait;
-use xmtp_proto::api_client::{Error, ErrorKind, XmtpApiClient, XmtpApiSubscription};
+use futures::Stream;
+use xmtp_proto::api_client::{
+    Error, ErrorKind, MutableApiSubscription, XmtpApiClient, XmtpApiSubscription,
+};
 use xmtp_proto::xmtp::message_api::v1::{
     BatchQueryRequest, BatchQueryResponse, Envelope, PublishRequest, PublishResponse, QueryRequest,
     QueryResponse, SubscribeRequest,
@@ -26,6 +29,7 @@ impl XmtpGrpcGatewayClient {
 #[async_trait(?Send)]
 impl XmtpApiClient for XmtpGrpcGatewayClient {
     type Subscription = XmtpGrpcGatewaySubscription;
+    type MutableSubscription = XmtpGrpcGatewayMutableSubscription;
 
     fn set_app_version(&mut self, _version: String) {
         // TODO
@@ -54,6 +58,14 @@ impl XmtpApiClient for XmtpGrpcGatewayClient {
         &self,
         _request: SubscribeRequest,
     ) -> Result<XmtpGrpcGatewaySubscription, Error> {
+        // TODO
+        Err(Error::new(ErrorKind::SubscribeError))
+    }
+
+    async fn subscribe2(
+        &self,
+        _request: SubscribeRequest,
+    ) -> Result<Self::MutableSubscription, Error> {
         // TODO
         Err(Error::new(ErrorKind::SubscribeError))
     }
@@ -99,4 +111,29 @@ impl XmtpApiSubscription for XmtpGrpcGatewaySubscription {
     }
 
     fn close_stream(&mut self) {}
+}
+
+pub struct XmtpGrpcGatewayMutableSubscription {}
+
+#[async_trait(?Send)]
+impl MutableApiSubscription for XmtpGrpcGatewayMutableSubscription {
+    async fn update(&mut self, _req: SubscribeRequest) -> Result<(), Error> {
+        // TODO
+        Err(Error::new(ErrorKind::SubscriptionUpdateError))
+    }
+
+    fn close(&self) {
+        // TODO
+    }
+}
+
+impl Stream for XmtpGrpcGatewayMutableSubscription {
+    type Item = Result<Envelope, Error>;
+
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        std::task::Poll::Ready(None)
+    }
 }

--- a/xmtp_mls/src/api_client_wrapper.rs
+++ b/xmtp_mls/src/api_client_wrapper.rs
@@ -384,6 +384,7 @@ mod tests {
 
         #[async_trait]
         impl XmtpMlsClient for ApiClient {
+            type Subscription = MockMutableSubscription;
             async fn register_installation(
                 &self,
                 request: RegisterInstallationRequest,

--- a/xmtp_mls/src/groups/validated_commit.rs
+++ b/xmtp_mls/src/groups/validated_commit.rs
@@ -321,7 +321,7 @@ mod tests {
         let bola_key_package = get_key_package(&bola);
 
         let amal_group = amal.create_group().unwrap();
-        let mut amal_conn = amal.store.conn().unwrap();
+        let amal_conn = amal.store.conn().unwrap();
         let amal_provider = amal.mls_provider(&amal_conn);
         let mut mls_group = amal_group.load_mls_group(&amal_provider).unwrap();
         // Create a pending commit to add bola to the group

--- a/xmtp_proto/Cargo.toml
+++ b/xmtp_proto/Cargo.toml
@@ -13,6 +13,7 @@ tonic = { version = "^0.9", optional = true }
 serde = "1.0.160"
 pbjson = "0.5.1"
 pbjson-types = "0.5.1"
+futures = "0.3.29"
 
 [features]
 default = []

--- a/xmtp_proto/src/api_client.rs
+++ b/xmtp_proto/src/api_client.rs
@@ -91,7 +91,7 @@ pub trait XmtpApiSubscription {
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-pub trait MutableApiSubscription {
+pub trait MutableApiSubscription: Stream<Item = Result<Envelope, Error>> {
     async fn update(&mut self, req: SubscribeRequest) -> Result<(), Error>;
     fn close(&self);
 }
@@ -101,7 +101,7 @@ pub trait MutableApiSubscription {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait XmtpApiClient {
     type Subscription: XmtpApiSubscription;
-    type MutableSubscription: MutableApiSubscription + Stream<Item = Result<Envelope, Error>>;
+    type MutableSubscription: MutableApiSubscription;
 
     fn set_app_version(&mut self, version: String);
 
@@ -127,6 +127,8 @@ pub trait XmtpApiClient {
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait XmtpMlsClient {
+    type Subscription: MutableApiSubscription;
+
     async fn register_installation(
         &self,
         request: RegisterInstallationRequest,


### PR DESCRIPTION
## Summary

- Adds support for the `Subscribe2` API endpoint, which allows callers to update their list of content topics without closing/re-opening the subscription
- Uses a new subscription return type. Instead of our home-brewed Subscription struct `subscribe2` returns a struct that fulfills `futures::Stream` + a new custom trait (`MutableApiSubscription`) that allows callers to update the content topics.