### PR TITLE
Use credential proto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3059,10 +3059,10 @@ dependencies = [
  "ethers",
  "hex",
  "log",
- "openmls 0.5.0 (git+https://github.com/xmtp/openmls)",
- "openmls_basic_credential 0.2.0 (git+https://github.com/xmtp/openmls)",
- "openmls_rust_crypto 0.2.0 (git+https://github.com/xmtp/openmls)",
- "openmls_traits 0.2.0 (git+https://github.com/xmtp/openmls)",
+ "openmls",
+ "openmls_basic_credential",
+ "openmls_rust_crypto",
+ "openmls_traits",
  "prost",
  "rand 0.8.5",
  "serde",
@@ -3319,30 +3319,9 @@ dependencies = [
  "backtrace",
  "itertools 0.10.5",
  "log",
- "openmls_basic_credential 0.2.0 (git+https://github.com/xmtp/openmls?branch=main)",
- "openmls_rust_crypto 0.2.0 (git+https://github.com/xmtp/openmls?branch=main)",
- "openmls_traits 0.2.0 (git+https://github.com/xmtp/openmls?branch=main)",
- "rand 0.8.5",
- "rayon",
- "rstest",
- "rstest_reuse",
- "serde",
- "serde_json",
- "thiserror",
- "tls_codec",
-]
-
-[[package]]
-name = "openmls"
-version = "0.5.0"
-source = "git+https://github.com/xmtp/openmls#d72380028c6c7e5e73f526a75c6f65bdaa93b6b4"
-dependencies = [
- "backtrace",
- "itertools 0.10.5",
- "log",
- "openmls_basic_credential 0.2.0 (git+https://github.com/xmtp/openmls)",
- "openmls_rust_crypto 0.2.0 (git+https://github.com/xmtp/openmls)",
- "openmls_traits 0.2.0 (git+https://github.com/xmtp/openmls)",
+ "openmls_basic_credential",
+ "openmls_rust_crypto",
+ "openmls_traits",
  "rand 0.8.5",
  "rayon",
  "rstest",
@@ -3359,20 +3338,7 @@ version = "0.2.0"
 source = "git+https://github.com/xmtp/openmls?branch=main#5764be718b112819e08893a55dfa38fd6ece5727"
 dependencies = [
  "ed25519-dalek",
- "openmls_traits 0.2.0 (git+https://github.com/xmtp/openmls?branch=main)",
- "p256",
- "rand 0.8.5",
- "serde",
- "tls_codec",
-]
-
-[[package]]
-name = "openmls_basic_credential"
-version = "0.2.0"
-source = "git+https://github.com/xmtp/openmls#d72380028c6c7e5e73f526a75c6f65bdaa93b6b4"
-dependencies = [
- "ed25519-dalek",
- "openmls_traits 0.2.0 (git+https://github.com/xmtp/openmls)",
+ "openmls_traits",
  "p256",
  "rand 0.8.5",
  "serde",
@@ -3384,17 +3350,7 @@ name = "openmls_memory_keystore"
 version = "0.2.0"
 source = "git+https://github.com/xmtp/openmls?branch=main#5764be718b112819e08893a55dfa38fd6ece5727"
 dependencies = [
- "openmls_traits 0.2.0 (git+https://github.com/xmtp/openmls?branch=main)",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
-name = "openmls_memory_keystore"
-version = "0.2.0"
-source = "git+https://github.com/xmtp/openmls#d72380028c6c7e5e73f526a75c6f65bdaa93b6b4"
-dependencies = [
- "openmls_traits 0.2.0 (git+https://github.com/xmtp/openmls)",
+ "openmls_traits",
  "serde_json",
  "thiserror",
 ]
@@ -3412,32 +3368,8 @@ dependencies = [
  "hpke-rs",
  "hpke-rs-crypto",
  "hpke-rs-rust-crypto",
- "openmls_memory_keystore 0.2.0 (git+https://github.com/xmtp/openmls?branch=main)",
- "openmls_traits 0.2.0 (git+https://github.com/xmtp/openmls?branch=main)",
- "p256",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "serde",
- "sha2",
- "thiserror",
- "tls_codec",
-]
-
-[[package]]
-name = "openmls_rust_crypto"
-version = "0.2.0"
-source = "git+https://github.com/xmtp/openmls#d72380028c6c7e5e73f526a75c6f65bdaa93b6b4"
-dependencies = [
- "aes-gcm",
- "chacha20poly1305",
- "ed25519-dalek",
- "hkdf",
- "hmac",
- "hpke-rs",
- "hpke-rs-crypto",
- "hpke-rs-rust-crypto",
- "openmls_memory_keystore 0.2.0 (git+https://github.com/xmtp/openmls)",
- "openmls_traits 0.2.0 (git+https://github.com/xmtp/openmls)",
+ "openmls_memory_keystore",
+ "openmls_traits",
  "p256",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -3451,15 +3383,6 @@ dependencies = [
 name = "openmls_traits"
 version = "0.2.0"
 source = "git+https://github.com/xmtp/openmls?branch=main#5764be718b112819e08893a55dfa38fd6ece5727"
-dependencies = [
- "serde",
- "tls_codec",
-]
-
-[[package]]
-name = "openmls_traits"
-version = "0.2.0"
-source = "git+https://github.com/xmtp/openmls#d72380028c6c7e5e73f526a75c6f65bdaa93b6b4"
 dependencies = [
  "serde",
  "tls_codec",
@@ -6457,10 +6380,10 @@ dependencies = [
  "libsqlite3-sys",
  "log",
  "mockall",
- "openmls 0.5.0 (git+https://github.com/xmtp/openmls?branch=main)",
- "openmls_basic_credential 0.2.0 (git+https://github.com/xmtp/openmls?branch=main)",
- "openmls_rust_crypto 0.2.0 (git+https://github.com/xmtp/openmls?branch=main)",
- "openmls_traits 0.2.0 (git+https://github.com/xmtp/openmls?branch=main)",
+ "openmls",
+ "openmls_basic_credential",
+ "openmls_rust_crypto",
+ "openmls_traits",
  "prost",
  "rand 0.8.5",
  "serde",

--- a/mls_validation_service/Cargo.toml
+++ b/mls_validation_service/Cargo.toml
@@ -16,10 +16,10 @@ xmtp_proto = { path = "../xmtp_proto", features = [
     "grpc",
     "tonic",
 ] }
-openmls = { git = "https://github.com/xmtp/openmls", features = ["test-utils"] }
-openmls_traits = { git = "https://github.com/xmtp/openmls" }
-openmls_basic_credential = { git = "https://github.com/xmtp/openmls" }
-openmls_rust_crypto = { git = "https://github.com/xmtp/openmls" }
+openmls = { git = "https://github.com/xmtp/openmls", features = ["test-utils"], branch = "main" }
+openmls_traits = { git = "https://github.com/xmtp/openmls", branch = "main" }
+openmls_basic_credential = { git = "https://github.com/xmtp/openmls", branch = "main" }
+openmls_rust_crypto = { git = "https://github.com/xmtp/openmls", branch = "main" }
 xmtp_mls = { path = "../xmtp_mls" }
 serde = "1.0.189"
 hex = "0.4.3"

--- a/mls_validation_service/src/handlers.rs
+++ b/mls_validation_service/src/handlers.rs
@@ -142,11 +142,11 @@ mod tests {
     use openmls_basic_credential::SignatureKeyPair;
     use prost::Message;
     use xmtp_mls::{
-        association::{AssociationContext, AssociationText, Eip191Association},
+        association::{AssociationContext, Credential},
         InboxOwner,
     };
     use xmtp_proto::xmtp::{
-        mls::message_contents::Eip191Association as Eip191AssociationProto,
+        mls::message_contents::MlsCredential as CredentialProto,
         mls_validation::v1::validate_key_packages_request::KeyPackage as KeyPackageProtoWrapper,
     };
 
@@ -160,25 +160,16 @@ mod tests {
         let signature_key_pair = SignatureKeyPair::new(CIPHERSUITE.signature_algorithm()).unwrap();
         let pub_key = signature_key_pair.public();
         let account_address = wallet.get_address();
-        let association_text = AssociationText::new_static(
-            AssociationContext::GrantMessagingAccess,
-            account_address.clone(),
-            pub_key.to_vec(),
-            "2021-01-01T00:00:00Z".to_string(),
-        );
-        let signature = wallet
-            .sign(&association_text.text())
-            .expect("failed to sign");
 
-        let association =
-            Eip191Association::new(pub_key, association_text, signature).expect("bad signature");
-        let association_proto: Eip191AssociationProto = association.into();
-        let mut buf = Vec::new();
-        association_proto
-            .encode(&mut buf)
-            .expect("failed to serialize");
+        let credential = Credential::create_eip191(&signature_key_pair, &wallet)
+            .expect("failed to create credential");
+        let credential_proto: CredentialProto = credential.into();
 
-        (buf, signature_key_pair, account_address)
+        (
+            credential_proto.encode_to_vec(),
+            signature_key_pair,
+            account_address,
+        )
     }
 
     fn build_key_package_bytes(

--- a/mls_validation_service/src/handlers.rs
+++ b/mls_validation_service/src/handlers.rs
@@ -141,10 +141,7 @@ mod tests {
     };
     use openmls_basic_credential::SignatureKeyPair;
     use prost::Message;
-    use xmtp_mls::{
-        association::{AssociationContext, Credential},
-        InboxOwner,
-    };
+    use xmtp_mls::{association::Credential, InboxOwner};
     use xmtp_proto::xmtp::{
         mls::message_contents::MlsCredential as CredentialProto,
         mls_validation::v1::validate_key_packages_request::KeyPackage as KeyPackageProtoWrapper,
@@ -158,7 +155,7 @@ mod tests {
         let rng = &mut rand::thread_rng();
         let wallet = LocalWallet::new(rng);
         let signature_key_pair = SignatureKeyPair::new(CIPHERSUITE.signature_algorithm()).unwrap();
-        let pub_key = signature_key_pair.public();
+        let _pub_key = signature_key_pair.public();
         let account_address = wallet.get_address();
 
         let credential = Credential::create_eip191(&signature_key_pair, &wallet)

--- a/mls_validation_service/src/validation_helpers.rs
+++ b/mls_validation_service/src/validation_helpers.rs
@@ -1,16 +1,15 @@
 use prost::Message;
-use xmtp_mls::association::{AssociationContext, Eip191Association};
-use xmtp_proto::xmtp::mls::message_contents::Eip191Association as Eip191AssociationProto;
+use xmtp_mls::association::Credential;
+use xmtp_proto::xmtp::mls::message_contents::MlsCredential as CredentialProto;
 
 pub fn identity_to_account_address(identity: &[u8], pub_key: &[u8]) -> Result<String, String> {
-    let proto_value = Eip191AssociationProto::decode(identity).map_err(|e| format!("{:?}", e))?;
-    let association = Eip191Association::from_proto_with_expected_address(
-        AssociationContext::GrantMessagingAccess,
-        pub_key,
-        proto_value.clone(),
-        proto_value.account_address,
+    let proto = CredentialProto::decode(identity).map_err(|e| format!("{:?}", e))?;
+    let credential = Credential::from_proto_validated(
+        proto,
+        None, // expected_account_address,
+        Some(pub_key),
     )
     .map_err(|e| format!("{:?}", e))?;
 
-    Ok(association.address())
+    Ok(credential.address())
 }

--- a/xmtp_cryptography/src/signature.rs
+++ b/xmtp_cryptography/src/signature.rs
@@ -234,7 +234,7 @@ pub mod tests {
         assert!(is_valid_ethereum_address(
             "0x7e57Aed10441c8879ce08E45805EC01Ee9689c9f"
         ));
-        assert_eq!(is_valid_ethereum_address("123"), false);
+        assert!(!is_valid_ethereum_address("123"));
     }
 
     #[test]

--- a/xmtp_mls/src/association.rs
+++ b/xmtp_mls/src/association.rs
@@ -279,7 +279,7 @@ impl AssociationText {
                 account_address,
                 installation_public_key,
                 iso8601_time,
-            } => gen_static_text_v1(account_address, installation_public_key, &iso8601_time),
+            } => gen_static_text_v1(account_address, installation_public_key, iso8601_time),
         }
     }
 

--- a/xmtp_mls/src/association.rs
+++ b/xmtp_mls/src/association.rs
@@ -27,6 +27,8 @@ pub enum AssociationError {
         provided_addr: Address,
         signing_addr: Address,
     },
+    #[error("Malformed association")]
+    MalformedAssociation,
 }
 
 enum Association {
@@ -62,7 +64,10 @@ impl Credential {
         expected_account_address: Option<&str>, // Must validate when fetching identity updates
         expected_installation_public_key: Option<&[u8]>, // Must cross-reference against leaf node when relevant
     ) -> Result<Self, AssociationError> {
-        let association = match proto.association.unwrap() {
+        let association = match proto
+            .association
+            .ok_or(AssociationError::MalformedAssociation)?
+        {
             AssociationProto::Eip191(assoc) => Eip191Association::from_proto_validated(
                 assoc,
                 AssociationContext::GrantMessagingAccess,

--- a/xmtp_mls/src/groups/group_permissions.rs
+++ b/xmtp_mls/src/groups/group_permissions.rs
@@ -216,8 +216,8 @@ mod tests {
         installation_id: Option<Vec<u8>>,
     ) -> AggregatedMembershipChange {
         AggregatedMembershipChange {
-            account_address: account_address.unwrap_or_else(|| rand_account_address()),
-            installation_ids: vec![installation_id.unwrap_or_else(|| rand_vec())],
+            account_address: account_address.unwrap_or_else(rand_account_address),
+            installation_ids: vec![installation_id.unwrap_or_else(rand_vec)],
         }
     }
 
@@ -226,8 +226,8 @@ mod tests {
         installation_id: Option<Vec<u8>>,
     ) -> CommitParticipant {
         CommitParticipant {
-            account_address: account_address.unwrap_or_else(|| rand_account_address()),
-            installation_id: installation_id.unwrap_or_else(|| rand_vec()),
+            account_address: account_address.unwrap_or_else(rand_account_address),
+            installation_id: installation_id.unwrap_or_else(rand_vec),
         }
     }
 
@@ -248,16 +248,18 @@ mod tests {
         };
         ValidatedCommit {
             actor: actor.clone(),
-            members_added: member_added.map(build_membership_change).unwrap_or(vec![]),
+            members_added: member_added
+                .map(build_membership_change)
+                .unwrap_or_default(),
             members_removed: member_removed
                 .map(build_membership_change)
-                .unwrap_or_else(|| vec![]),
+                .unwrap_or_else(std::vec::Vec::new),
             installations_added: installation_added
                 .map(build_membership_change)
-                .unwrap_or_else(|| vec![]),
+                .unwrap_or_else(std::vec::Vec::new),
             installations_removed: installation_removed
                 .map(build_membership_change)
-                .unwrap_or_else(|| vec![]),
+                .unwrap_or_else(std::vec::Vec::new),
         }
     }
 
@@ -283,16 +285,16 @@ mod tests {
         );
 
         let member_added_commit = build_validated_commit(Some(false), None, None, None);
-        assert!(permissions.evaluate_commit(&member_added_commit) == false);
+        assert!(!permissions.evaluate_commit(&member_added_commit));
 
         let member_removed_commit = build_validated_commit(None, Some(false), None, None);
-        assert!(permissions.evaluate_commit(&member_removed_commit) == false);
+        assert!(!permissions.evaluate_commit(&member_removed_commit));
 
         let installation_added_commit = build_validated_commit(None, None, Some(false), None);
-        assert!(permissions.evaluate_commit(&installation_added_commit) == false);
+        assert!(!permissions.evaluate_commit(&installation_added_commit));
 
         let installation_removed_commit = build_validated_commit(None, None, None, Some(false));
-        assert!(permissions.evaluate_commit(&installation_removed_commit) == false);
+        assert!(!permissions.evaluate_commit(&installation_removed_commit));
     }
 
     #[test]
@@ -308,7 +310,7 @@ mod tests {
         assert!(permissions.evaluate_commit(&commit_with_same_member));
 
         let commit_with_different_member = build_validated_commit(Some(false), None, None, None);
-        assert!(permissions.evaluate_commit(&commit_with_different_member) == false);
+        assert!(!permissions.evaluate_commit(&commit_with_different_member));
     }
 
     #[test]
@@ -321,7 +323,7 @@ mod tests {
         );
 
         let member_added_commit = build_validated_commit(Some(true), None, None, None);
-        assert!(permissions.evaluate_commit(&member_added_commit) == false);
+        assert!(!permissions.evaluate_commit(&member_added_commit));
     }
 
     #[test]
@@ -348,6 +350,6 @@ mod tests {
 
         let member_added_commit = build_validated_commit(Some(true), None, None, None);
 
-        assert!(permissions.evaluate_commit(&member_added_commit) == false);
+        assert!(!permissions.evaluate_commit(&member_added_commit));
     }
 }

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -372,7 +372,7 @@ where
                     sent_at_ns: envelope_timestamp_ns as i64,
                     kind: GroupMessageKind::Application,
                     sender_installation_id,
-                    sender_account_address: sender_account_address,
+                    sender_account_address,
                 };
                 message.store(provider.conn())?;
             }

--- a/xmtp_mls/src/groups/validated_commit.rs
+++ b/xmtp_mls/src/groups/validated_commit.rs
@@ -329,7 +329,7 @@ mod tests {
         let bola_key_package = get_key_package(&bola);
 
         let amal_group = amal.create_group().unwrap();
-        let mut amal_conn = amal.store.conn().unwrap();
+        let amal_conn = amal.store.conn().unwrap();
         let amal_provider = amal.mls_provider(&amal_conn);
         let mut mls_group = amal_group.load_mls_group(&amal_provider).unwrap();
         // Create a pending commit to add bola to the group

--- a/xmtp_mls/src/identity.rs
+++ b/xmtp_mls/src/identity.rs
@@ -1,4 +1,3 @@
-use chrono::Utc;
 use openmls::{
     extensions::LastResortExtension,
     prelude::{
@@ -15,7 +14,7 @@ use xmtp_cryptography::signature::SignatureError;
 use xmtp_proto::xmtp::mls::message_contents::MlsCredential as CredentialProto;
 
 use crate::{
-    association::{AssociationContext, AssociationError, Credential},
+    association::{AssociationError, Credential},
     configuration::CIPHERSUITE,
     storage::{identity::StoredIdentity, StorageError},
     types::Address,


### PR DESCRIPTION
Use a wrapper `MlsCredential` proto instead of the `Eip191Association` proto for two reasons:

1. Include the `installation_public_key` inside of the credential, as suggested by Cryspen
2. Allow for other association types. In particular, we will be introducing an association type using the XMTP v2 identity key, for migration purposes.

There is some validation logic we will need to double-check, for example verifying that identity updates correspond to the correct wallet address, as well as installation syncing logic - will follow up on this after the break.