### PR TITLE
Allow streaming group messages

### DIFF
--- a/xmtp_api_grpc/src/lib.rs
+++ b/xmtp_api_grpc/src/lib.rs
@@ -187,7 +187,9 @@ mod tests {
             })
             .await
             .unwrap();
-
+        
+        // Sleep 100ms to ensure subscription is updated
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         // Publish an envelope to the new topic
         let env_2 = test_envelope(topic_2.to_string());
         client

--- a/xmtp_api_grpc/src/lib.rs
+++ b/xmtp_api_grpc/src/lib.rs
@@ -187,7 +187,7 @@ mod tests {
             })
             .await
             .unwrap();
-        
+
         // Sleep 100ms to ensure subscription is updated
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         // Publish an envelope to the new topic

--- a/xmtp_mls/src/api_client_wrapper.rs
+++ b/xmtp_mls/src/api_client_wrapper.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 use crate::{retry::Retry, retry_async};
 use xmtp_proto::{
     api_client::{
-        Envelope, Error as ApiError, ErrorKind, PagingInfo, QueryRequest, XmtpApiClient,
-        XmtpMlsClient,
+        Envelope, Error as ApiError, ErrorKind, PagingInfo, QueryRequest, SubscribeRequest,
+        XmtpApiClient, XmtpMlsClient,
     },
     xmtp::{
         message_api::{
@@ -272,6 +272,15 @@ where
         )?;
 
         Ok(())
+    }
+
+    pub async fn subscribe(
+        &self,
+        content_topics: Vec<String>,
+    ) -> Result<ApiClient::MutableSubscription, ApiError> {
+        self.api_client
+            .subscribe2(SubscribeRequest { content_topics })
+            .await
     }
 }
 

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -99,6 +99,8 @@ pub enum MessageProcessingError {
     Codec(#[from] crate::codecs::CodecError),
     #[error("encode proto: {0}")]
     EncodeProto(#[from] EncodeError),
+    #[error("epoch increment not allowed")]
+    EpochIncrementNotAllowed,
 }
 
 impl crate::retry::RetryableError for MessageProcessingError {

--- a/xmtp_mls/src/groups/subscriptions.rs
+++ b/xmtp_mls/src/groups/subscriptions.rs
@@ -20,7 +20,7 @@ where
             // Attempt processing immediately, but fail if the message is not an Application Message
             // Returning an error should roll back the DB tx
             self.process_message(&mut openmls_group, &provider, &envelope, false)
-                .map_err(|err| GroupError::ReceiveError(err))
+                .map_err(GroupError::ReceiveError)
         });
 
         if let Some(GroupError::ReceiveError(_)) = process_result.err() {

--- a/xmtp_mls/src/groups/subscriptions.rs
+++ b/xmtp_mls/src/groups/subscriptions.rs
@@ -1,0 +1,128 @@
+use std::pin::Pin;
+
+use crate::storage::group_message::StoredGroupMessage;
+use futures::{Stream, StreamExt};
+use xmtp_proto::api_client::{XmtpApiClient, XmtpMlsClient};
+use xmtp_proto::xmtp::message_api::v1::Envelope;
+
+use super::{GroupError, MlsGroup};
+
+impl<'c, ApiClient> MlsGroup<'c, ApiClient>
+where
+    ApiClient: XmtpApiClient + XmtpMlsClient,
+{
+    async fn process_stream_entry(
+        &self,
+        envelope: Envelope,
+    ) -> Result<Option<StoredGroupMessage>, GroupError> {
+        let process_result = self.client.store.transaction(|provider| {
+            let mut openmls_group = self.load_mls_group(&provider)?;
+            // Attempt processing immediately, but fail if the message is not an Application Message
+            // Returning an error should roll back the DB tx
+            self.process_message(&mut openmls_group, &provider, &envelope, false)
+                .map_err(|err| GroupError::ReceiveError(err))
+        });
+
+        if let Some(GroupError::ReceiveError(_)) = process_result.err() {
+            self.sync().await?;
+        }
+
+        // Load the message from the DB to handle cases where it may have been
+        // already processed in another thread
+        let new_message = self
+            .client
+            .store
+            .conn()?
+            .get_group_message_by_timestamp(&self.group_id, envelope.timestamp_ns as i64)?;
+
+        Ok(new_message)
+    }
+
+    pub async fn stream(
+        &'c self,
+    ) -> Result<Pin<Box<dyn Stream<Item = StoredGroupMessage> + 'c>>, GroupError> {
+        let subscription = self.client.api_client.subscribe(vec![self.topic()]).await?;
+        let stream = subscription
+            .map(|res| async {
+                match res {
+                    Ok(envelope) => self.process_stream_entry(envelope).await,
+                    Err(err) => Err(GroupError::Api(err)),
+                }
+            })
+            .filter_map(move |res| async {
+                match res.await {
+                    Ok(Some(message)) => Some(message),
+                    Ok(None) => None,
+                    Err(err) => {
+                        log::error!("Error processing stream entry: {:?}", err);
+                        None
+                    }
+                }
+            });
+
+        Ok(Box::pin(stream))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use xmtp_cryptography::utils::generate_local_wallet;
+
+    use crate::{builder::ClientBuilder, storage::group_message::GroupMessageKind};
+    use futures::StreamExt;
+
+    #[tokio::test]
+    async fn test_subscribe_messages() {
+        let amal = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
+        amal.register_identity().await.unwrap();
+        let bola = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
+        bola.register_identity().await.unwrap();
+
+        let amal_group = amal.create_group().unwrap();
+        // Add bola
+        amal_group
+            .add_members_by_installation_id(vec![bola.installation_public_key()])
+            .await
+            .unwrap();
+
+        // Get bola's version of the same group
+        let bola_groups = bola.sync_welcomes().await.unwrap();
+        let bola_group = bola_groups.first().unwrap();
+
+        let mut stream = bola_group.stream().await.unwrap();
+
+        amal_group.send_message("hello".as_bytes()).await.unwrap();
+
+        let first_val = stream.next().await.unwrap();
+        assert_eq!(first_val.decrypted_message_bytes, "hello".as_bytes());
+
+        amal_group.send_message("goodbye".as_bytes()).await.unwrap();
+
+        let second_val = stream.next().await.unwrap();
+        assert_eq!(second_val.decrypted_message_bytes, "goodbye".as_bytes());
+    }
+
+    #[tokio::test]
+    async fn test_subscribe_membership_changes() {
+        let amal = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
+        amal.register_identity().await.unwrap();
+        let bola = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
+        bola.register_identity().await.unwrap();
+
+        let amal_group = amal.create_group().unwrap();
+
+        let mut stream = amal_group.stream().await.unwrap();
+
+        amal_group
+            .add_members_by_installation_id(vec![bola.installation_public_key()])
+            .await
+            .unwrap();
+
+        let first_val = stream.next().await.unwrap();
+        assert_eq!(first_val.kind, GroupMessageKind::MembershipChange);
+
+        amal_group.send_message("hello".as_bytes()).await.unwrap();
+        let second_val = stream.next().await.unwrap();
+        assert_eq!(second_val.decrypted_message_bytes, "hello".as_bytes());
+    }
+}

--- a/xmtp_mls/src/storage/encrypted_store/group_message.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group_message.rs
@@ -114,6 +114,21 @@ impl DbConnection<'_> {
                 .optional()
         })?)
     }
+
+    pub fn get_group_message_by_timestamp<GroupId: AsRef<[u8]>>(
+        &self,
+        group_id: GroupId,
+        timestamp: i64,
+    ) -> Result<Option<StoredGroupMessage>, StorageError> {
+        use super::schema::group_messages::dsl;
+        Ok(self.raw_query(|conn| {
+            dsl::group_messages
+                .filter(dsl::group_id.eq(group_id.as_ref()))
+                .filter(dsl::sent_at_ns.eq(timestamp))
+                .first(conn)
+                .optional()
+        })?)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Adds support for `subscribe2` in `ApiClientWrapper`
- Convert stream of envelopes into a stream of `StoredGroupMessages`
- Handle streaming of group messages, whether sent by yourself or by others

## Notes

There are a few things about the implementation worth calling out, as they are subtle

1. We are not moving the `topic_refresh_state` when we are processing application messages. Streams may have been started after the last sync and may have been interrupted mid-sync so they are not considered safe to increment epochs. In the case of envelopes containing Commits, we will interrupt and roll back processing of the message and call `sync()` to load messages in the correct order from the server. This ensures that all commits are processed in the correct order.
2. We don't return the successfully processed messages from `process_message`, and instead rely on looking up the `StoredGroupMessage` based on the timestamp of the envelope. This is because messages can only be processed once, so if another thread has already synced the message (for example, after sending a commit) we will get an error if we attempt to process it a second time receiving it from the stream.