### PR TITLE
Bring back rust caching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,11 +35,11 @@ jobs:
           toolchain: stable
           override: true
 
-      # - uses: Swatinem/rust-cache@v2
-      #   with:
-      #     workspaces: |
-      #       .
-      #       bindings_ffi
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            . -> root
+            bindings_ffi -> bindings
 
       - name: Run cargo test on main workspace
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
## Summary

- We were previously running out of disk space, causing CI to fail. Having deleted several large packages in the main workspace I am hoping we can bring back the Rust cache without issues