### PR TITLE
build: use bundled jniLibs artifact during flutter android builds

### DIFF
--- a/bindings_flutter/CHANGELOG.md
+++ b/bindings_flutter/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.0.1-development.4
+- use bundled artifacts in android CMakeLists build
+
 ## 0.0.1-development.3
 - expose `user_preferences_encrypt()` and `user_preferences_decrypt()`
 

--- a/bindings_flutter/android/CMakeLists.txt
+++ b/bindings_flutter/android/CMakeLists.txt
@@ -15,6 +15,11 @@ set(ArchiveUrl "https://github.com/xmtp/libxmtp/releases/download/${ReleaseTag}/
 set(ArchivePath "${CMAKE_CURRENT_SOURCE_DIR}/${ArchiveFileName}")
 set(LibRoot "${CMAKE_CURRENT_SOURCE_DIR}/src/main/jniLibs")
 
+# NOTE: For now, we short-circuit the download by copying from bundled artifacts/
+# TODO: actually download the published release at first-build instead
+# See also setup-apple-artifacts.sh (which does the same thing for iOS/macOS)
+file(COPY "../artifacts/android/${ArchiveFileName}" DESTINATION "${CMAKE_CURRENT_SOURCE_DIR}")
+
 if(NOT EXISTS ${ArchivePath})
   message(STATUS "Downloading ${ArchiveUrl} to ${ArchivePath}")
   file(DOWNLOAD

--- a/bindings_flutter/android/gradle.properties
+++ b/bindings_flutter/android/gradle.properties
@@ -1,4 +1,4 @@
-xmtp_bindings_flutter_version=0.0.1-development.3
+xmtp_bindings_flutter_version=0.0.1-development.4
 # These versions should be kept in sync:
 # - pubspec.yaml
 # - android/gradle.properties

--- a/bindings_flutter/ios/xmtp_bindings_flutter.podspec
+++ b/bindings_flutter/ios/xmtp_bindings_flutter.podspec
@@ -4,7 +4,7 @@
 # See generally
 #  https://cjycode.com/flutter_rust_bridge/library/platform_setup/ios_and_macos.html
 
-release_version = '0.0.1-development.3'
+release_version = '0.0.1-development.4'
 # These versions should be kept in sync:
 # - pubspec.yaml
 # - android/gradle.properties

--- a/bindings_flutter/linux/CMakeLists.txt
+++ b/bindings_flutter/linux/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.10)
 
 # TODO: set this externally as part of invoking linux build
 set(LibraryName "xmtp_bindings_flutter")
-set(ReleaseVersion "0.0.1-development.3")
+set(ReleaseVersion "0.0.1-development.4")
 
 # Download the binaries if they are not already present.
 project("${LibraryName}")

--- a/bindings_flutter/macos/xmtp_bindings_flutter.podspec
+++ b/bindings_flutter/macos/xmtp_bindings_flutter.podspec
@@ -4,7 +4,7 @@
 # See generally
 #  https://cjycode.com/flutter_rust_bridge/library/platform_setup/ios_and_macos.html
 
-release_version = '0.0.1-development.3'
+release_version = '0.0.1-development.4'
 # These versions should be kept in sync:
 # - pubspec.yaml
 # - android/gradle.properties

--- a/bindings_flutter/pubspec.yaml
+++ b/bindings_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: xmtp_bindings_flutter
 description: low-level flutter bindings to libxmtp
 repository: https://github.com/xmtp/libxmtp
-version: 0.0.1-development.3
+version: 0.0.1-development.4
 # These versions should be kept in sync:
 # - pubspec.yaml
 # - android/gradle.properties


### PR DESCRIPTION
This makes the downstream android builds behave like the iOS/macOS builds: it grabs the bundled `artifacts/android/...jniLibs.tar.gz` and uses them for android builds.

Eventually we want this repo to publish github releases with the artifacts (XCFrameworks for iOS/macOS, and jniLibs for Android). But for now we bundle these built artifacts with the `xmtp_bindings_flutter` package in pub.dev (we can get away with this for now because they're still small, eventually we'll need to pull them down at build time instead).