### PR TITLE
fix: explicit add x86_64-unknown-linux-gnu target in dev/build_validation_service_local

### DIFF
--- a/dev/build_validation_service_local
+++ b/dev/build_validation_service_local
@@ -8,6 +8,7 @@ if [ ! -x "$(command -v x86_64-linux-gnu-gcc)" ] && [ "$(uname)" = "Darwin" ]; t
     brew install x86_64-unknown-linux-gnu    
 fi
 
+rustup target add x86_64-unknown-linux-gnu
 export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc
 cargo build --release --package mls_validation_service --target x86_64-unknown-linux-gnu
 mkdir -p .cache


### PR DESCRIPTION
I was running into errors locally when `dev/build_validation_service_local` was running. This fixes it.