### PR TITLE
Use connection customizer

### DIFF
--- a/xmtp_mls/src/storage/encrypted_store/connection_customizer.rs
+++ b/xmtp_mls/src/storage/encrypted_store/connection_customizer.rs
@@ -1,0 +1,31 @@
+use super::EncryptionKey;
+use diesel::connection::SimpleConnection;
+use diesel::{r2d2::CustomizeConnection, SqliteConnection};
+
+#[derive(Debug, Clone)]
+pub struct ConnectionCustomizer {
+    encryption_key: Option<EncryptionKey>,
+}
+
+impl ConnectionCustomizer {
+    pub fn new(encryption_key: Option<EncryptionKey>) -> Self {
+        Self { encryption_key }
+    }
+}
+
+impl CustomizeConnection<SqliteConnection, diesel::r2d2::Error> for ConnectionCustomizer {
+    fn on_acquire(&self, conn: &mut SqliteConnection) -> Result<(), diesel::r2d2::Error> {
+        conn.batch_execute("PRAGMA journal_mode = WAL;")
+            .map_err(diesel::r2d2::Error::QueryError)?;
+
+        if let Some(encryption_key) = self.encryption_key {
+            conn.batch_execute(&format!(
+                "PRAGMA key = \"x'{}'\";",
+                hex::encode(encryption_key)
+            ))
+            .map_err(diesel::r2d2::Error::QueryError)?;
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary

I discovered that our connection pool (R2D2) has a more native way to apply operations to each of the underlying Sqlite connections. You can specify a struct that implements the `CustomizeConnection` trait when you are setting up the pool. The `on_acquire` function will then be called on each new connection created by the pool.

This seems preferable to applying it to the connections after they've already been pulled from the pool, since we don't know whether the connection is new or is being re-used. 