### PR TITLE
Add xmtp_user_preferences to main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
+name = "arrayref"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,7 +468,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
 dependencies = [
- "sha2",
+ "sha2 0.10.8",
  "tinyvec",
 ]
 
@@ -722,10 +728,10 @@ dependencies = [
  "bs58",
  "coins-core",
  "digest 0.10.7",
- "hmac",
+ "hmac 0.12.1",
  "k256 0.13.3",
  "serde",
- "sha2",
+ "sha2 0.10.8",
  "thiserror",
 ]
 
@@ -737,11 +743,11 @@ checksum = "3db8fba409ce3dc04f7d804074039eb68b960b0829161f8e06c95fea3f122528"
 dependencies = [
  "bitvec 1.0.1",
  "coins-bip32",
- "hmac",
+ "hmac 0.12.1",
  "once_cell",
  "pbkdf2 0.12.2",
  "rand 0.8.5",
- "sha2",
+ "sha2 0.10.8",
  "thiserror",
 ]
 
@@ -760,7 +766,7 @@ dependencies = [
  "ripemd",
  "serde",
  "serde_derive",
- "sha2",
+ "sha2 0.10.8",
  "sha3 0.10.8",
  "thiserror",
 ]
@@ -906,6 +912,16 @@ dependencies = [
  "generic-array 0.14.7",
  "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+dependencies = [
+ "generic-array 0.14.7",
+ "subtle",
 ]
 
 [[package]]
@@ -1222,7 +1238,7 @@ dependencies = [
  "ed25519",
  "rand_core 0.6.4",
  "serde",
- "sha2",
+ "sha2 0.10.8",
  "subtle",
  "zeroize",
 ]
@@ -1350,13 +1366,13 @@ dependencies = [
  "ctr",
  "digest 0.10.7",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "pbkdf2 0.11.0",
  "rand 0.8.5",
  "scrypt",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.8",
  "sha3 0.10.8",
  "thiserror",
  "uuid 0.8.2",
@@ -1735,7 +1751,7 @@ dependencies = [
  "eth-keystore",
  "ethers-core 2.0.11",
  "rand 0.8.5",
- "sha2",
+ "sha2 0.10.8",
  "thiserror",
  "tracing",
 ]
@@ -2298,7 +2314,17 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hmac"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -2308,6 +2334,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac-drbg"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
+dependencies = [
+ "digest 0.9.0",
+ "generic-array 0.14.7",
+ "hmac 0.8.1",
 ]
 
 [[package]]
@@ -2355,7 +2392,7 @@ dependencies = [
  "p384",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
- "sha2",
+ "sha2 0.10.8",
  "x25519-dalek",
 ]
 
@@ -2737,7 +2774,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "ecdsa 0.14.8",
  "elliptic-curve 0.12.3",
- "sha2",
+ "sha2 0.10.8",
  "sha3 0.10.8",
 ]
 
@@ -2751,7 +2788,7 @@ dependencies = [
  "ecdsa 0.15.1",
  "elliptic-curve 0.12.3",
  "once_cell",
- "sha2",
+ "sha2 0.10.8",
  "signature 2.0.0",
 ]
 
@@ -2765,7 +2802,7 @@ dependencies = [
  "ecdsa 0.16.9",
  "elliptic-curve 0.13.8",
  "once_cell",
- "sha2",
+ "sha2 0.10.8",
  "signature 2.0.0",
 ]
 
@@ -2849,6 +2886,54 @@ dependencies = [
  "bitflags 2.4.1",
  "libc",
  "redox_syscall",
+]
+
+[[package]]
+name = "libsecp256k1"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95b09eff1b35ed3b33b877ced3a691fc7a481919c7e29c53c906226fcf55e2a1"
+dependencies = [
+ "arrayref",
+ "base64 0.13.1",
+ "digest 0.9.0",
+ "hmac-drbg",
+ "libsecp256k1-core",
+ "libsecp256k1-gen-ecmult",
+ "libsecp256k1-gen-genmult",
+ "rand 0.8.5",
+ "serde",
+ "sha2 0.9.9",
+ "typenum",
+]
+
+[[package]]
+name = "libsecp256k1-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be9b9bb642d8522a44d533eab56c16c738301965504753b03ad1de3425d5451"
+dependencies = [
+ "crunchy",
+ "digest 0.9.0",
+ "subtle",
+]
+
+[[package]]
+name = "libsecp256k1-gen-ecmult"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3038c808c55c87e8a172643a7d87187fc6c4174468159cb3090659d55bcb4809"
+dependencies = [
+ "libsecp256k1-core",
+]
+
+[[package]]
+name = "libsecp256k1-gen-genmult"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
+dependencies = [
+ "libsecp256k1-core",
 ]
 
 [[package]]
@@ -3326,7 +3411,7 @@ dependencies = [
  "chacha20poly1305",
  "ed25519-dalek",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "hpke-rs",
  "hpke-rs-crypto",
  "hpke-rs-rust-crypto",
@@ -3336,7 +3421,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "serde",
- "sha2",
+ "sha2 0.10.8",
  "thiserror",
  "tls_codec",
 ]
@@ -3425,7 +3510,7 @@ dependencies = [
  "ecdsa 0.16.9",
  "elliptic-curve 0.13.8",
  "primeorder",
- "sha2",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -3593,9 +3678,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
  "digest 0.10.7",
- "hmac",
+ "hmac 0.12.1",
  "password-hash",
- "sha2",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -3605,7 +3690,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -4339,7 +4424,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
  "crypto-bigint 0.4.9",
- "hmac",
+ "hmac 0.12.1",
  "zeroize",
 ]
 
@@ -4349,7 +4434,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -4666,10 +4751,10 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f9e24d2b632954ded8ab2ef9fea0a0c769ea56ea98bddbafbad22caeeadf45d"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "pbkdf2 0.11.0",
  "salsa20",
- "sha2",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -4864,6 +4949,19 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -5150,7 +5248,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.8",
  "thiserror",
  "url",
  "zip",
@@ -6397,7 +6495,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "serde",
- "sha2",
+ "sha2 0.10.8",
  "sha3 0.10.8",
  "thiserror",
  "tokio",
@@ -6458,6 +6556,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "xmtp_user_preferences"
+version = "0.1.0"
+dependencies = [
+ "base64 0.21.6",
+ "libsecp256k1",
+ "once_cell",
+ "prost",
+ "rand 0.8.5",
+ "xmtp_proto",
+ "xmtp_v2",
+]
+
+[[package]]
 name = "xmtp_v2"
 version = "0.1.0"
 dependencies = [
@@ -6475,7 +6586,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rlp",
  "serde",
- "sha2",
+ "sha2 0.10.8",
  "sha3 0.10.8",
  "thiserror",
  "tokio",
@@ -6520,7 +6631,7 @@ dependencies = [
  "crc32fast",
  "crossbeam-utils",
  "flate2",
- "hmac",
+ "hmac 0.12.1",
  "pbkdf2 0.11.0",
  "sha1",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "xmtp_cryptography",
   "xmtp_api_grpc",
   "xmtp_proto",
+  "xmtp_user_preferences",
   "xmtp_v2",
   "xmtp_mls",
 ]

--- a/xmtp_user_preferences/Cargo.toml
+++ b/xmtp_user_preferences/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "xmtp_user_preferences"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+xmtp_proto = { path = "../xmtp_proto", features = ["xmtp-message_contents"] }
+xmtp_v2 = { path = "../xmtp_v2" }
+prost = { workspace = true, features = ["prost-derive"] }
+base64 = "0.21.4"
+# Need to include this as a dep or compile will fail because of a version mismatch
+once_cell = "1.18.0"
+
+[dev-dependencies]
+libsecp256k1 = { version = "0.7.1", default-features = false, features = [
+    "hmac",
+    "static-context",
+] }
+rand = "0.8.5"

--- a/xmtp_user_preferences/README.md
+++ b/xmtp_user_preferences/README.md
@@ -1,0 +1,3 @@
+# XTMP Personal Private Portable Preferences
+
+A library for encrypting messages where the sender and recipient are the same (self-messaging).

--- a/xmtp_user_preferences/src/encryption.rs
+++ b/xmtp_user_preferences/src/encryption.rs
@@ -1,0 +1,55 @@
+use xmtp_proto::xmtp::message_contents::{
+    ciphertext::{Aes256gcmHkdfsha256, Union},
+    Ciphertext,
+};
+use xmtp_v2::encryption::{decrypt, encrypt, hkdf};
+
+const PRIVATE_PREFERENCES_ENCRYPTION_KEY_SALT: &[u8] = b"XMTP_PRIVATE_PREFERENCES_ENCRYPTION";
+
+fn derive_encryption_key(private_key: &[u8]) -> Result<[u8; 32], String> {
+    let derived_key = hkdf(private_key, PRIVATE_PREFERENCES_ENCRYPTION_KEY_SALT)?;
+
+    Ok(derived_key)
+}
+
+pub fn encrypt_to_ciphertext(
+    private_key: &[u8],
+    message: &[u8],
+    additional_data: &[u8],
+) -> Result<Ciphertext, String> {
+    let secret_key = derive_encryption_key(private_key)?;
+    let raw_ciphertext = encrypt(message, &secret_key, Some(additional_data))?;
+
+    Ok(Ciphertext {
+        union: Some(Union::Aes256GcmHkdfSha256(Aes256gcmHkdfsha256 {
+            hkdf_salt: raw_ciphertext.hkdf_salt,
+            gcm_nonce: raw_ciphertext.gcm_nonce,
+            payload: raw_ciphertext.payload,
+        })),
+    })
+}
+
+pub fn decrypt_ciphertext(
+    private_key: &[u8],
+    ciphertext: Ciphertext,
+    additional_data: &[u8],
+) -> Result<Vec<u8>, String> {
+    let encryption_key = derive_encryption_key(private_key)?;
+    let unwrapped = unwrap_ciphertext(ciphertext)?;
+    let decrypted = decrypt(
+        unwrapped.payload.as_slice(),
+        unwrapped.hkdf_salt.as_slice(),
+        unwrapped.gcm_nonce.as_slice(),
+        &encryption_key,
+        Some(additional_data),
+    )?;
+
+    Ok(decrypted)
+}
+
+fn unwrap_ciphertext(ciphertext: Ciphertext) -> Result<Aes256gcmHkdfsha256, String> {
+    match ciphertext.union {
+        Some(Union::Aes256GcmHkdfSha256(data)) => Ok(data),
+        _ => Err("unrecognized format".to_string()),
+    }
+}

--- a/xmtp_user_preferences/src/lib.rs
+++ b/xmtp_user_preferences/src/lib.rs
@@ -1,0 +1,106 @@
+mod encryption;
+pub mod topic;
+
+use prost::Message as ProstMessage;
+use xmtp_proto::xmtp::message_contents::{
+    private_preferences_payload::Version as PrivatePreferencesVersion, Ciphertext,
+    PrivatePreferencesPayload,
+};
+
+use crate::encryption::{decrypt_ciphertext, encrypt_to_ciphertext};
+
+pub fn encrypt_message(
+    public_key: &[u8],  // secp256k1 public key, used as additional data
+    private_key: &[u8], // secp256k1 private key
+    message: &[u8],     // any byte array
+) -> Result<Vec<u8>, String> {
+    let ciphertext = encrypt_to_ciphertext(private_key, message, public_key)?;
+    let user_preferences_message = PrivatePreferencesPayload {
+        version: Some(PrivatePreferencesVersion::V1(ciphertext)),
+    };
+
+    Ok(user_preferences_message.encode_to_vec())
+}
+
+pub fn decrypt_message(
+    public_key: &[u8],  // secp256k1 public key, used as additional data
+    private_key: &[u8], // secp256k1 private key
+    message: &[u8], // message encrypted with `encrypt_message`. Should be an encoded PrivatePreferencesPayload
+) -> Result<Vec<u8>, String> {
+    let ciphertext = get_ciphertext(message)?;
+    let payload_bytes = decrypt_ciphertext(private_key, ciphertext, public_key)?;
+
+    Ok(payload_bytes)
+}
+
+fn get_ciphertext(message: &[u8]) -> Result<Ciphertext, String> {
+    let ecies_message =
+        PrivatePreferencesPayload::decode(message).map_err(|e| format!("{:?}", e))?;
+    let ciphertext = match ecies_message.version {
+        Some(PrivatePreferencesVersion::V1(ciphertext)) => ciphertext,
+        None => return Err("no ciphertext found".to_string()),
+    };
+
+    Ok(ciphertext)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use libsecp256k1::{PublicKey, SecretKey};
+
+    pub fn generate_keypair() -> (SecretKey, PublicKey) {
+        let secret_key = SecretKey::random(&mut rand::thread_rng());
+        let public_key = PublicKey::from_secret_key(&secret_key);
+
+        (secret_key, public_key)
+    }
+
+    #[test]
+    fn test_round_trip() {
+        let (private_key, pub_key) = generate_keypair();
+        let message = "hello world".as_bytes().to_vec();
+
+        let encrypted =
+            encrypt_message(&pub_key.serialize(), &private_key.serialize(), &message).unwrap();
+        assert!(encrypted.len() > 0);
+
+        let decrypted =
+            decrypt_message(&pub_key.serialize(), &private_key.serialize(), &encrypted).unwrap();
+
+        assert_eq!(message, decrypted);
+    }
+
+    #[test]
+    fn decrypt_fails_with_incorrect_private_key() {
+        let (private_key, pub_key) = generate_keypair();
+        let message = "hello world".as_bytes().to_vec();
+
+        let encrypted =
+            encrypt_message(&pub_key.serialize(), &private_key.serialize(), &message).unwrap();
+        assert!(encrypted.len() > 0);
+        let (other_private_key, _) = generate_keypair();
+
+        let decrypt_result = decrypt_message(
+            &pub_key.serialize(),
+            &other_private_key.serialize(),
+            &encrypted,
+        );
+
+        assert_eq!(decrypt_result.is_err(), true);
+    }
+
+    #[test]
+    fn decrypt_fails_with_incorrect_pub_key() {
+        let (private_key, pub_key) = generate_keypair();
+        let message = "hi".as_bytes().to_vec();
+
+        let encrypted =
+            encrypt_message(&pub_key.serialize(), &private_key.serialize(), &message).unwrap();
+
+        let ciphertext = get_ciphertext(&encrypted).unwrap();
+        let failed_decrypt =
+            decrypt_ciphertext(&private_key.serialize(), ciphertext, "foo".as_bytes());
+        assert!(failed_decrypt.is_err());
+    }
+}

--- a/xmtp_user_preferences/src/topic.rs
+++ b/xmtp_user_preferences/src/topic.rs
@@ -1,0 +1,49 @@
+use base64::{engine::general_purpose, Engine as _};
+use xmtp_v2::{encryption::hkdf, hashes::sha256};
+
+const PRIVATE_PREFERENCES_TOPIC_SALT: &[u8] = b"XMTP_PRIVATE_PREFERENCES_TOPIC";
+
+// Converts the private key into an unlinkable identifier
+// Changing the salt will create a different identifier
+pub fn generate_topic_identifier(secret: &[u8], salt: &[u8]) -> Result<String, String> {
+    // Derive a key based on the secret and the salt
+    let derived_key = hkdf(secret, salt)?;
+    // Hash the derived key one more time to get a public topic identifier
+    let topic = sha256(&derived_key);
+
+    let topic = general_purpose::URL_SAFE_NO_PAD.encode(topic);
+    Ok(topic)
+}
+
+pub fn generate_private_preferences_topic_identifier(secret: &[u8]) -> Result<String, String> {
+    generate_topic_identifier(secret, PRIVATE_PREFERENCES_TOPIC_SALT)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::generate_keypair;
+
+    use super::*;
+
+    #[test]
+    fn generate_topic() {
+        let (priv_key, _) = generate_keypair();
+
+        let topic = generate_topic_identifier(&priv_key.serialize(), b"test").unwrap();
+        let topic_2 = generate_topic_identifier(&priv_key.serialize(), b"test-2").unwrap();
+
+        assert!(topic != topic_2);
+    }
+
+    #[test]
+    fn generate_reference_identifier() {
+        // We randomly generated this key as an explicit example for reference tests across SDKs.
+        let k = &[
+            69, 239, 223, 17, 3, 219, 126, 21, 172, 74, 55, 18, 123, 240, 246, 149, 158, 74, 183,
+            229, 236, 98, 133, 184, 95, 44, 130, 35, 138, 113, 36, 211,
+        ];
+        let identifier = generate_private_preferences_topic_identifier(k).unwrap();
+
+        assert_eq!(identifier, "EBsHSM9lLmELuUVCMJ-tPE0kDcok1io9IwUO6WPC-cM");
+    }
+}


### PR DESCRIPTION
## Summary

As part of @nakajima's project to give us one set of bindings to rule them all, we are going to need to bring `xmtp_user_preferences` out of the V2 branch and into main. This does that, but replaces the `xmtp_crypto` dependency with `xmtp_v2`. The two appear to be identical, save the rename. 

All the code in here (minus the dependency rename) is a direct copy/paste from V2.