### PR TITLE
Revert to ubuntu-latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
       - main
 jobs:
   build:
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Switching to Warpbuild seems to work for everything except for this build and publish step, which only runs on `main`. Reverting this one until it gets resolved.