### PR TITLE
Bindings improvements

### DIFF
--- a/bindings_ffi/src/lib.rs
+++ b/bindings_ffi/src/lib.rs
@@ -115,7 +115,7 @@ pub struct FfiXmtpClient {
     inner_client: Arc<RustXmtpClient>,
 }
 
-#[uniffi::export]
+#[uniffi::export(async_runtime = "tokio")]
 impl FfiXmtpClient {
     pub fn account_address(&self) -> Address {
         self.inner_client.account_address()
@@ -125,6 +125,17 @@ impl FfiXmtpClient {
         Arc::new(FfiConversations {
             inner_client: self.inner_client.clone(),
         })
+    }
+
+    pub async fn can_message(
+        &self,
+        account_addresses: Vec<String>,
+    ) -> Result<Vec<bool>, GenericError> {
+        let inner = self.inner_client.as_ref();
+
+        let results: Vec<bool> = inner.can_message(account_addresses).await?;
+
+        Ok(results)
     }
 }
 
@@ -282,6 +293,10 @@ impl FfiGroup {
 impl FfiGroup {
     pub fn id(&self) -> Vec<u8> {
         self.group_id.clone()
+    }
+
+    pub fn created_at_ns(&self) -> i64 {
+        self.created_at_ns
     }
 }
 

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -396,6 +396,26 @@ where
         Ok(groups)
     }
 
+    pub async fn can_message(
+        &self,
+        account_addresses: Vec<String>,
+    ) -> Result<Vec<bool>, ClientError> {
+        let identity_updates = self
+            .api_client
+            .get_identity_updates(0, account_addresses.clone())
+            .await?;
+
+        Ok(account_addresses
+            .iter()
+            .map(|address| {
+                identity_updates
+                    .get(address)
+                    .map(has_active_installation)
+                    .unwrap_or(false)
+            })
+            .collect())
+    }
+
     // fn process_streamed_welcome(
     //     &self,
     //     envelope: Envelope,
@@ -449,6 +469,19 @@ fn deserialize_welcome(welcome_bytes: &Vec<u8>) -> Result<Welcome, ClientError> 
             "unexpected message type in welcome".to_string(),
         )),
     }
+}
+
+fn has_active_installation(updates: &Vec<IdentityUpdate>) -> bool {
+    let mut active_count = 0;
+    for update in updates {
+        match update {
+            IdentityUpdate::Invalid => {}
+            IdentityUpdate::NewInstallation(_) => active_count += 1,
+            IdentityUpdate::RevokeInstallation(_) => active_count -= 1,
+        }
+    }
+
+    active_count > 0
 }
 
 #[cfg(test)]
@@ -542,6 +575,24 @@ mod tests {
 
         let duplicate_received_groups = bob.sync_welcomes().await.unwrap();
         assert_eq!(duplicate_received_groups.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_can_message() {
+        let amal = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
+        let bola = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
+        futures::try_join!(amal.register_identity(), bola.register_identity()).unwrap();
+        let charlie_address = generate_local_wallet().get_address();
+
+        let can_message_result = amal
+            .can_message(vec![
+                amal.account_address(),
+                bola.account_address(),
+                charlie_address,
+            ])
+            .await
+            .unwrap();
+        assert_eq!(can_message_result, vec![true, true, false]);
     }
 
     // #[tokio::test]


### PR DESCRIPTION
## Summary

- Adds `can_message` method to `Client`
- Exposes the `created_at_ns` time to FFI callers