### PR TITLE
Move more workflows back to github runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
           retention-days: 1
 
   build-macos:
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:
@@ -105,7 +105,7 @@ jobs:
           retention-days: 1
 
   kotlin:
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -137,7 +137,7 @@ jobs:
           retention-days: 1
 
   swift:
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -196,7 +196,7 @@ jobs:
 
   package-swift:
     needs: [build-macos, swift]
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v1


### PR DESCRIPTION
## Summary

In the last PR I missed a few workflows that need to be moved off of Warp