### PR TITLE
fix: use mls tag for container image instead of mls-dev

### DIFF
--- a/dev/docker/docker-compose.yml
+++ b/dev/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   node:
-    image: xmtp/node-go:mls-dev
+    image: xmtp/node-go:mls
     platform: linux/amd64
     environment:
       - GOWAKU-NODEKEY=8a30dcb604b0b53627a5adc054dbf434b446628d4bd1eccc681d223f0550ce67


### PR DESCRIPTION
The change to use the `mls-dev` image was unintentionally merged in with https://github.com/xmtp/libxmtp/pull/426