### PR TITLE
chore: finish ordering dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,18 +22,18 @@ openmls = { git = "https://github.com/xmtp/openmls", branch = "main" }
 openmls_traits = { git = "https://github.com/xmtp/openmls", branch = "main" }
 openmls_basic_credential = { git = "https://github.com/xmtp/openmls", branch = "main" }
 openmls_rust_crypto = { git = "https://github.com/xmtp/openmls", branch = "main" }
-tls_codec = "0.4.0"
-tokio = { version = "1.35.1", features = ["macros"] }
-thiserror = "1.0.56"
-rand = "0.8.5"
+async-trait = "0.1.77"
 ethers = "2.0.11"
 ethers-core = "2.0.4"
-prost = "0.11"
-prost-types = " 0.11"
-tonic = "^0.9"
-serde = "1.0.195"
 futures = "0.3.30"
 futures-core = "0.3.30"
-log = "0.4.20"
 hex = "0.4.3"
-async-trait = "0.1.77"
+log = "0.4.20"
+prost = "0.11"
+prost-types = " 0.11"
+rand = "0.8.5"
+serde = "1.0.195"
+thiserror = "1.0.56"
+tls_codec = "0.4.0"
+tokio = { version = "1.35.1", features = ["macros"] }
+tonic = "^0.9"

--- a/examples/cli/Cargo.toml
+++ b/examples/cli/Cargo.toml
@@ -10,21 +10,21 @@ path = "cli-client.rs"
 
 [dependencies]
 clap = { version = "4.4.6", features = ["derive"] }
+env_logger = "0.10.0"
 ethers = "2.0.4"
 ethers-core = "2.0.4"
-env_logger = "0.10.0"
 futures = "0.3.28"
+hex = "0.4.3"
 log = "0.4.17"
 thiserror = "1.0.40"
+timeago = "0.4.1"
 tokio = "1.28.1"
 url = "2.3.1"
 walletconnect = { git = "https://github.com/nlordell/walletconnect-rs.git", features = [
     "qr",
     "transport",
 ] }
-xmtp_mls = { path = "../../xmtp_mls", features = ["grpc", "native"] }
-xmtp_cryptography = { path = "../../xmtp_cryptography" }
 xmtp_api_grpc = { path = "../../xmtp_api_grpc" }
+xmtp_cryptography = { path = "../../xmtp_cryptography" }
+xmtp_mls = { path = "../../xmtp_mls", features = ["grpc", "native"] }
 xmtp_proto = { path = "../../xmtp_proto", features = ["proto_full", "grpc"] }
-timeago = "0.4.1"
-hex = "0.4.3"

--- a/xmtp_api_grpc/Cargo.toml
+++ b/xmtp_api_grpc/Cargo.toml
@@ -20,8 +20,8 @@ tonic = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 tokio-rustls = "0.24.1"
 tower = "0.4.13"
-xmtp_proto = { path = "../xmtp_proto", features = ["proto_full", "grpc"] }
 webpki-roots = "0.23.0"
+xmtp_proto = { path = "../xmtp_proto", features = ["proto_full", "grpc"] }
 
 [dev-dependencies]
 uuid = { version = "1.3.1", features = ["v4"] }


### PR DESCRIPTION
This patch finishes the work started from https://github.com/xmtp/libxmtp/pull/428 and orders the deps I missed in that one.