### PR TITLE
Allow updates to existing releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           artifacts: "bindings_ffi/libxmtp-android.zip"
+          allowUpdates: "true"
 
   swift:
     runs-on: warp-ubuntu-latest-x64-4x


### PR DESCRIPTION
## Summary

I'd like to be able to publish releases of this package through the Github UI. I believe with this change, once I publish a release in the UI the workflow will pick up the tag and update the release with the right Kotlin artifact.