### PR TITLE
Fix signing flow for bindings with async signers

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -143,6 +143,10 @@ impl FfiXmtpClient {
         self.inner_client.account_address()
     }
 
+    pub fn text_to_sign(&self) -> Option<String> {
+        self.inner_client.text_to_sign()
+    }
+
     pub fn conversations(&self) -> Arc<FfiConversations> {
         Arc::new(FfiConversations {
             inner_client: self.inner_client.clone(),

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -144,10 +144,6 @@ impl FfiXmtpClient {
         self.inner_client.account_address()
     }
 
-    pub fn text_to_sign(&self) -> Option<String> {
-        self.inner_client.text_to_sign()
-    }
-
     pub fn conversations(&self) -> Arc<FfiConversations> {
         Arc::new(FfiConversations {
             inner_client: self.inner_client.clone(),
@@ -168,12 +164,16 @@ impl FfiXmtpClient {
 
 #[uniffi::export(async_runtime = "tokio")]
 impl FfiXmtpClient {
+    pub fn text_to_sign(&self) -> Option<String> {
+        self.inner_client.text_to_sign()
+    }
+
     pub async fn register_identity(
         &self,
-        wallet_signature: Option<Vec<u8>>,
+        recoverable_wallet_signature: Option<Vec<u8>>,
     ) -> Result<(), GenericError> {
         self.inner_client
-            .register_identity_with_external_signature(wallet_signature)
+            .register_identity_with_external_signature(recoverable_wallet_signature)
             .await?;
 
         Ok(())

--- a/xmtp_mls/src/api_client_wrapper.rs
+++ b/xmtp_mls/src/api_client_wrapper.rs
@@ -349,9 +349,10 @@ type KeyPackageMap = HashMap<Vec<u8>, Vec<u8>>;
 type IdentityUpdatesMap = HashMap<String, Vec<IdentityUpdate>>;
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use async_trait::async_trait;
     use mockall::mock;
+    use xmtp_api_grpc::grpc_api_helper::Client as GrpcClient;
     use xmtp_proto::{
         api_client::{Error, ErrorKind, GroupMessageStream, WelcomeMessageStream, XmtpMlsClient},
         xmtp::mls::api::v1::{
@@ -371,6 +372,15 @@ mod tests {
 
     use super::ApiClientWrapper;
     use crate::retry::Retry;
+
+    pub async fn get_test_api_client() -> ApiClientWrapper<GrpcClient> {
+        ApiClientWrapper::new(
+            GrpcClient::create("http://localhost:5556".to_string(), false)
+                .await
+                .unwrap(),
+            Retry::default(),
+        )
+    }
 
     fn build_group_messages(num_messages: usize, group_id: Vec<u8>) -> Vec<GroupMessage> {
         let mut out: Vec<GroupMessage> = vec![];

--- a/xmtp_mls/src/association.rs
+++ b/xmtp_mls/src/association.rs
@@ -215,7 +215,7 @@ impl From<Eip191Association> for Eip191AssociationProto {
 /// the XMTP installation public key. Different standards may choose how this information is
 /// encoded, as well as adding extra requirements for increased security.
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
-struct AssociationText {
+pub(crate) struct AssociationText {
     context: AssociationContext,
     data: AssociationData,
 }

--- a/xmtp_mls/src/association.rs
+++ b/xmtp_mls/src/association.rs
@@ -59,6 +59,19 @@ impl Credential {
         })
     }
 
+    pub fn from_external_signer(
+        association_data: AssociationText,
+        signature: Vec<u8>,
+    ) -> Result<Self, AssociationError> {
+        let association = Eip191Association::new_validated(
+            association_data,
+            RecoverableSignature::Eip191Signature(signature),
+        )?;
+        Ok(Self {
+            association: Association::Eip191(association),
+        })
+    }
+
     pub fn from_proto_validated(
         proto: MlsCredentialProto,
         expected_account_address: Option<&str>, // Must validate when fetching identity updates
@@ -215,7 +228,7 @@ impl From<Eip191Association> for Eip191AssociationProto {
 /// the XMTP installation public key. Different standards may choose how this information is
 /// encoded, as well as adding extra requirements for increased security.
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
-pub(crate) struct AssociationText {
+pub struct AssociationText {
     context: AssociationContext,
     data: AssociationData,
 }

--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -70,7 +70,7 @@ where
                     }
                     Ok(identity)
                 }
-                None => Ok(Identity::new(provider, &owner)?),
+                None => Ok(Identity::new(&owner)?),
             },
             IdentityStrategy::CreateUnsignedIfNotFound(account_address) => match identity_option {
                 Some(identity) => {
@@ -79,7 +79,7 @@ where
                     }
                     Ok(identity)
                 }
-                None => Ok(Identity::new_unsigned(provider, account_address)?),
+                None => Ok(Identity::new_unsigned(account_address)?),
             },
             #[cfg(test)]
             IdentityStrategy::ExternalIdentity(identity) => Ok(identity),
@@ -236,6 +236,7 @@ mod tests {
             .store(store_a)
             .build()
             .unwrap();
+        client_a.register_identity().await.unwrap(); // Persists the identity on registration
         let keybytes_a = client_a.installation_public_key();
         drop(client_a);
 

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -213,13 +213,10 @@ where
     pub async fn register_identity(&self) -> Result<(), ClientError> {
         log::info!("registering identity");
         let connection = self.store.conn()?;
-        let kp = self
-            .identity
-            .new_key_package(&self.mls_provider(&connection))?;
-        let kp_bytes = kp.tls_serialize_detached()?;
-
-        self.api_client.register_installation(kp_bytes).await?;
-
+        let provider = self.mls_provider(&connection);
+        self.identity
+            .register(&provider, &self.api_client, None)
+            .await?;
         Ok(())
     }
 

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -211,11 +211,19 @@ where
     }
 
     pub async fn register_identity(&self) -> Result<(), ClientError> {
+        self.register_identity_with_external_signature(None).await?;
+        Ok(())
+    }
+
+    pub async fn register_identity_with_external_signature(
+        &self,
+        wallet_signature: Option<Vec<u8>>,
+    ) -> Result<(), ClientError> {
         log::info!("registering identity");
         let connection = self.store.conn()?;
         let provider = self.mls_provider(&connection);
         self.identity
-            .register(&provider, &self.api_client, None)
+            .register(&provider, &self.api_client, wallet_signature)
             .await?;
         Ok(())
     }

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -167,6 +167,10 @@ where
         self.identity.installation_keys.to_public_vec()
     }
 
+    pub fn text_to_sign(&self) -> Option<String> {
+        self.identity.text_to_sign()
+    }
+
     // TODO: Remove this and figure out the correct lifetimes to allow long lived provider
     pub(crate) fn mls_provider(&self, conn: &'a DbConnection<'a>) -> XmtpOpenMlsProvider<'a> {
         XmtpOpenMlsProvider::<'a>::new(conn)

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -217,13 +217,13 @@ where
 
     pub async fn register_identity_with_external_signature(
         &self,
-        wallet_signature: Option<Vec<u8>>,
+        recoverable_wallet_signature: Option<Vec<u8>>,
     ) -> Result<(), ClientError> {
         log::info!("registering identity");
         let connection = self.store.conn()?;
         let provider = self.mls_provider(&connection);
         self.identity
-            .register(&provider, &self.api_client, wallet_signature)
+            .register(&provider, &self.api_client, recoverable_wallet_signature)
             .await?;
         Ok(())
     }

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -8,6 +8,7 @@ use crate::{
     client::deserialize_welcome,
     codecs::ContentCodec,
     hpke::{decrypt_welcome, encrypt_welcome, HpkeError},
+    identity::IdentityError,
     storage::refresh_state::EntityKind,
 };
 use intents::SendMessageIntentData;
@@ -120,6 +121,8 @@ pub enum GroupError {
     GroupMetadata(#[from] GroupMetadataError),
     #[error("Hpke error: {0}")]
     Hpke(#[from] HpkeError),
+    #[error("identity error: {0}")]
+    Identity(#[from] IdentityError),
 }
 
 impl RetryableError for GroupError {
@@ -181,7 +184,7 @@ where
             &client.identity.installation_keys,
             &group_config,
             CredentialWithKey {
-                credential: client.identity.credential.clone(),
+                credential: client.identity.credential()?,
                 signature_key: client.identity.installation_keys.to_public_vec().into(),
             },
         )?;
@@ -908,7 +911,7 @@ fn build_protected_metadata_extension(
     let protected_metadata = ProtectedMetadata::new(
         &identity.installation_keys,
         identity.application_id(),
-        identity.credential.clone(),
+        identity.credential()?,
         identity.installation_keys.to_public_vec(),
         metadata.try_into()?,
     )?;

--- a/xmtp_mls/src/storage/encrypted_store/identity.rs
+++ b/xmtp_mls/src/storage/encrypted_store/identity.rs
@@ -1,4 +1,4 @@
-use std::sync::{Mutex, RwLock};
+use std::sync::RwLock;
 
 use diesel::prelude::*;
 

--- a/xmtp_mls/src/storage/encrypted_store/identity.rs
+++ b/xmtp_mls/src/storage/encrypted_store/identity.rs
@@ -1,3 +1,5 @@
+use std::sync::Mutex;
+
 use diesel::prelude::*;
 
 use super::schema::identity;
@@ -41,7 +43,12 @@ impl From<&Identity> for StoredIdentity {
         StoredIdentity {
             account_address: identity.account_address.clone(),
             installation_keys: db_serialize(&identity.installation_keys).unwrap(),
-            credential_bytes: db_serialize(&identity.credential).unwrap(),
+            credential_bytes: db_serialize(
+                &identity
+                    .credential()
+                    .expect("Only persisted from register_identity() method"),
+            )
+            .unwrap(),
             rowid: None,
         }
     }
@@ -52,7 +59,7 @@ impl From<StoredIdentity> for Identity {
         Identity {
             account_address: identity.account_address,
             installation_keys: db_deserialize(&identity.installation_keys).unwrap(),
-            credential: db_deserialize(&identity.credential_bytes).unwrap(),
+            credential: Mutex::new(Some(db_deserialize(&identity.credential_bytes).unwrap())),
         }
     }
 }

--- a/xmtp_mls/src/storage/encrypted_store/identity.rs
+++ b/xmtp_mls/src/storage/encrypted_store/identity.rs
@@ -1,4 +1,4 @@
-use std::sync::Mutex;
+use std::sync::{Mutex, RwLock};
 
 use diesel::prelude::*;
 
@@ -46,7 +46,7 @@ impl From<&Identity> for StoredIdentity {
             credential_bytes: db_serialize(
                 &identity
                     .credential()
-                    .expect("Only persisted from register_identity() method"),
+                    .expect("Only persisted after registration"),
             )
             .unwrap(),
             rowid: None,
@@ -59,7 +59,7 @@ impl From<StoredIdentity> for Identity {
         Identity {
             account_address: identity.account_address,
             installation_keys: db_deserialize(&identity.installation_keys).unwrap(),
-            credential: Mutex::new(Some(db_deserialize(&identity.credential_bytes).unwrap())),
+            credential: RwLock::new(Some(db_deserialize(&identity.credential_bytes).unwrap())),
         }
     }
 }

--- a/xmtp_mls/src/storage/encrypted_store/identity.rs
+++ b/xmtp_mls/src/storage/encrypted_store/identity.rs
@@ -60,6 +60,7 @@ impl From<StoredIdentity> for Identity {
             account_address: identity.account_address,
             installation_keys: db_deserialize(&identity.installation_keys).unwrap(),
             credential: RwLock::new(Some(db_deserialize(&identity.credential_bytes).unwrap())),
+            unsigned_association_data: None,
         }
     }
 }

--- a/xmtp_mls/src/verified_key_package.rs
+++ b/xmtp_mls/src/verified_key_package.rs
@@ -159,7 +159,7 @@ mod tests {
                 &provider,
                 &client.identity.installation_keys,
                 CredentialWithKey {
-                    credential: client.identity.credential.clone(),
+                    credential: client.identity.credential().unwrap(),
                     signature_key: client.identity.installation_keys.to_public_vec().into(),
                 },
             )


### PR DESCRIPTION
We need a wallet signer from iOS/Android/etc that can be async. However, uniffi currently does not allow async callback interfaces to be passed into Rust: https://github.com/mozilla/uniffi-rs/issues/1729.

Instead, this PR restructures the libxmtp initialization process such that Rust can pass the signing text up towards the application, have it be signed externally, and then receive the signature as part of the next method call. The change in consumers looks as follows (pseudo-code), matching the changes in `bindings_ffi/src/mls.rs`.

**Before:**
```
struct Client {
  ...
}

client = await create_client(…, inbox_owner)
await client.register_identity()
```

**After:**
```
struct Client {
   ...
   text_to_sign() -> Option<String>
}

client = await create_client(…, account_address, legacy_identity_source, legacy_signed_private_key_proto)
if (text = client.text_to_sign()) {
   // Sign the text
}
await client.register_identity(signature_or_null)
```

Other notes:
- `legacy_identity_source` refers to how the XMTP v2 key was obtained (more description in the code). `legacy_signed_private_key_proto` is the serialized SignedPrivateKey from the v2 PrivateKeyBundle. This change is not related, however I've included it in this PR so that consumers don't need to perform multiple migrations.
- `register_identity()` is now idempotent - if a client has already registered before, calling it again will just no-op instead of erroring.
- We now also won't write the identity to the database unless the registration succeeds, so in the event of network failure during registration, the next run of the app will just create a new identity and then register it.