### PR TITLE
Group sync improvements

### DIFF
--- a/bindings_ffi/src/inbox_owner.rs
+++ b/bindings_ffi/src/inbox_owner.rs
@@ -27,16 +27,6 @@ impl RustInboxOwner {
     }
 }
 
-#[derive(uniffi::Object)]
-pub struct SignerCallback {}
-
-#[uniffi::export]
-impl SignerCallback {
-    fn on_signature(&self, result: Result<Vec<u8>, SigningError>) {
-        
-    }
-}
-
 impl xmtp_mls::InboxOwner for RustInboxOwner {
     fn get_address(&self) -> String {
         self.ffi_inbox_owner.get_address().to_lowercase()

--- a/bindings_ffi/src/inbox_owner.rs
+++ b/bindings_ffi/src/inbox_owner.rs
@@ -27,6 +27,16 @@ impl RustInboxOwner {
     }
 }
 
+#[derive(uniffi::Object)]
+pub struct SignerCallback {}
+
+#[uniffi::export]
+impl SignerCallback {
+    fn on_signature(&self, result: Result<Vec<u8>, SigningError>) {
+        
+    }
+}
+
 impl xmtp_mls::InboxOwner for RustInboxOwner {
     fn get_address(&self) -> String {
         self.ffi_inbox_owner.get_address().to_lowercase()

--- a/xmtp_mls/migrations/2023-10-29-205333_state_machine_init/up.sql
+++ b/xmtp_mls/migrations/2023-10-29-205333_state_machine_init/up.sql
@@ -55,6 +55,9 @@ CREATE TABLE group_intents (
     "payload_hash" BLOB UNIQUE,
     -- (Optional) data needed for the post-commit flow. For example, welcome messages
     "post_commit_data" BLOB,
+    -- The number of publish attempts
+    "publish_attempts" INT NOT NULL DEFAULT 0,
+    
     FOREIGN KEY (group_id) REFERENCES groups(id)
 );
 

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -267,8 +267,8 @@ where
     pub(crate) async fn query_group_messages(
         &self,
         group_id: &Vec<u8>,
+        conn: &'a DbConnection<'a>,
     ) -> Result<Vec<GroupMessage>, ClientError> {
-        let conn = self.store.conn()?;
         let id_cursor = conn.get_last_cursor_for_id(group_id, EntityKind::Group)?;
 
         let welcomes = self
@@ -279,8 +279,10 @@ where
         Ok(welcomes)
     }
 
-    pub(crate) async fn query_welcome_messages(&self) -> Result<Vec<WelcomeMessage>, ClientError> {
-        let conn = self.store.conn()?;
+    pub(crate) async fn query_welcome_messages(
+        &self,
+        conn: &'a DbConnection<'a>,
+    ) -> Result<Vec<WelcomeMessage>, ClientError> {
         let installation_id = self.installation_public_key();
         let id_cursor = conn.get_last_cursor_for_id(&installation_id, EntityKind::Welcome)?;
 
@@ -362,7 +364,7 @@ where
     // Download all unread welcome messages and convert to groups.
     // Returns any new groups created in the operation
     pub async fn sync_welcomes(&self) -> Result<Vec<MlsGroup<ApiClient>>, ClientError> {
-        let envelopes = self.query_welcome_messages().await?;
+        let envelopes = self.query_welcome_messages(&self.store.conn()?).await?;
         let id = self.installation_public_key();
         let groups: Vec<MlsGroup<ApiClient>> = envelopes
             .into_iter()

--- a/xmtp_mls/src/configuration.rs
+++ b/xmtp_mls/src/configuration.rs
@@ -11,4 +11,4 @@ pub const WELCOME_HPKE_LABEL: &str = "MLS_WELCOME";
 
 pub const MAX_GROUP_SYNC_RETRIES: usize = 3;
 
-pub const MAX_INTENT_PUBLISH_ATTEMPTS: usize = 3;
+pub const MAX_INTENT_PUBLISH_ATTEMPTS: usize = 2;

--- a/xmtp_mls/src/configuration.rs
+++ b/xmtp_mls/src/configuration.rs
@@ -8,3 +8,7 @@ pub const CIPHERSUITE: Ciphersuite =
 pub const MLS_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::Mls10;
 
 pub const WELCOME_HPKE_LABEL: &str = "MLS_WELCOME";
+
+pub const MAX_GROUP_SYNC_RETRIES: usize = 3;
+
+pub const MAX_INTENT_PUBLISH_ATTEMPTS: usize = 3;

--- a/xmtp_mls/src/configuration.rs
+++ b/xmtp_mls/src/configuration.rs
@@ -11,4 +11,4 @@ pub const WELCOME_HPKE_LABEL: &str = "MLS_WELCOME";
 
 pub const MAX_GROUP_SYNC_RETRIES: usize = 3;
 
-pub const MAX_INTENT_PUBLISH_ATTEMPTS: usize = 2;
+pub const MAX_INTENT_PUBLISH_ATTEMPTS: usize = 3;

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -3,74 +3,55 @@ mod group_permissions;
 mod intents;
 mod members;
 mod subscriptions;
+mod sync;
 pub mod validated_commit;
 use crate::{
     client::deserialize_welcome,
-    codecs::ContentCodec,
-    hpke::{decrypt_welcome, encrypt_welcome, HpkeError},
-    storage::{group_intent::ID, refresh_state::EntityKind},
-    Fetch,
+    hpke::{decrypt_welcome, HpkeError},
+    utils::address::AddressValidationError,
 };
 use intents::SendMessageIntentData;
-use log::debug;
 use openmls::{
     extensions::{Extension, Extensions, ProtectedMetadata},
-    framing::ProtocolMessage,
-    group::{MergePendingCommitError, MlsGroupJoinConfig},
+    group::{MlsGroupCreateConfig, MlsGroupJoinConfig},
     prelude::{
-        CredentialWithKey, CryptoConfig, GroupId, LeafNodeIndex, MlsGroup as OpenMlsGroup,
-        MlsGroupCreateConfig, MlsMessageIn, MlsMessageInBody, PrivateMessageIn, ProcessedMessage,
-        ProcessedMessageContent, Sender, Welcome as MlsWelcome, WireFormatPolicy,
+        CredentialWithKey, CryptoConfig, GroupId, MlsGroup as OpenMlsGroup, Welcome as MlsWelcome,
+        WireFormatPolicy,
     },
-    prelude_test::KeyPackage,
 };
 use openmls_traits::OpenMlsProvider;
-use prost::Message;
-use std::mem::discriminant;
 use thiserror::Error;
-use tls_codec::{Deserialize, Serialize};
-use xmtp_cryptography::signature::{is_valid_ed25519_public_key, is_valid_ethereum_address};
+use xmtp_cryptography::signature::is_valid_ed25519_public_key;
 use xmtp_proto::{
     api_client::XmtpMlsClient,
     xmtp::mls::api::v1::{
         group_message::{Version as GroupMessageVersion, V1 as GroupMessageV1},
-        welcome_message_input::{
-            Version as WelcomeMessageInputVersion, V1 as WelcomeMessageInputV1,
-        },
-        GroupMessage, WelcomeMessageInput,
+        GroupMessage,
     },
-    xmtp::mls::message_contents::GroupMembershipChanges,
 };
 
 pub use self::intents::{AddressesOrInstallationIds, IntentError};
 use self::{
     group_metadata::{ConversationType, GroupMetadata, GroupMetadataError},
     group_permissions::{default_group_policy, PolicySet},
-    intents::{
-        AddMembersIntentData, Installation, PostCommitAction, RemoveMembersIntentData,
-        SendWelcomesAction,
-    },
+    intents::{AddMembersIntentData, RemoveMembersIntentData},
     validated_commit::CommitValidationError,
 };
 use crate::{
     client::{ClientError, MessageProcessingError},
-    codecs::membership_change::GroupMembershipChangeCodec,
     configuration::CIPHERSUITE,
-    groups::validated_commit::ValidatedCommit,
     identity::Identity,
-    retry,
-    retry::{Retry, RetryableError},
-    retry_async, retryable,
+    retry::RetryableError,
+    retryable,
     storage::{
-        db_connection::DbConnection,
         group::{GroupMembershipState, StoredGroup},
-        group_intent::{IntentKind, IntentState, NewGroupIntent, StoredGroupIntent},
+        group_intent::{IntentKind, NewGroupIntent},
         group_message::{GroupMessageKind, StoredGroupMessage},
         StorageError,
     },
-    utils::{hash::sha256, id::get_message_id, time::now_ns},
+    utils::{address::sanitize_evm_addresses, time::now_ns},
     xmtp_openmls_provider::XmtpOpenMlsProvider,
-    Client, Delete, Store,
+    Client, Store,
 };
 
 #[derive(Debug, Error)]
@@ -112,13 +93,15 @@ pub enum GroupError {
     #[error("diesel error {0}")]
     Diesel(#[from] diesel::result::Error),
     #[error("The address {0:?} is not a valid ethereum address")]
-    InvalidAddresses(Vec<String>),
+    AddressValidation(#[from] AddressValidationError),
     #[error("Public Keys {0:?} are not valid ed25519 public keys")]
     InvalidPublicKeys(Vec<Vec<u8>>),
     #[error("Commit validation error {0}")]
     CommitValidation(#[from] CommitValidationError),
     #[error("Metadata error {0}")]
     GroupMetadata(#[from] GroupMetadataError),
+    #[error("Errors occurred during sync {0:?}")]
+    Sync(Vec<GroupError>),
     #[error("Hpke error: {0}")]
     Hpke(#[from] HpkeError),
 }
@@ -126,6 +109,8 @@ pub enum GroupError {
 impl RetryableError for GroupError {
     fn is_retryable(&self) -> bool {
         match self {
+            Self::Diesel(diesel) => retryable!(diesel),
+            Self::Storage(storage) => retryable!(storage),
             Self::ReceiveError(msg) => retryable!(msg),
             Self::AddMembers(members) => retryable!(members),
             Self::RemoveMembers(members) => retryable!(members),
@@ -157,10 +142,7 @@ where
     }
 
     // Load the stored MLS group from the OpenMLS provider's keystore
-    pub fn load_mls_group(
-        &self,
-        provider: &XmtpOpenMlsProvider,
-    ) -> Result<OpenMlsGroup, GroupError> {
+    fn load_mls_group(&self, provider: &XmtpOpenMlsProvider) -> Result<OpenMlsGroup, GroupError> {
         let mls_group =
             OpenMlsGroup::load(&GroupId::from_slice(&self.group_id), provider.key_store())
                 .ok_or(GroupError::GroupNotFound)?;
@@ -261,294 +243,11 @@ where
         Ok(messages)
     }
 
-    fn process_own_message(
+    pub async fn add_members(
         &self,
-        intent: StoredGroupIntent,
-        openmls_group: &mut OpenMlsGroup,
-        provider: &XmtpOpenMlsProvider,
-        message: ProtocolMessage,
-        envelope_timestamp_ns: u64,
-        allow_epoch_increment: bool,
-    ) -> Result<(), MessageProcessingError> {
-        if intent.state == IntentState::Committed {
-            return Ok(());
-        }
-        debug!(
-            "[{}] processing own message for intent {} / {:?}",
-            self.client.account_address(),
-            intent.id,
-            intent.kind
-        );
-
-        let conn = provider.conn();
-        match intent.kind {
-            IntentKind::AddMembers | IntentKind::RemoveMembers | IntentKind::KeyUpdate => {
-                if !allow_epoch_increment {
-                    return Err(MessageProcessingError::EpochIncrementNotAllowed);
-                }
-                let maybe_pending_commit = openmls_group.pending_commit();
-                // We don't get errors with merge_pending_commit when there are no commits to merge
-                if maybe_pending_commit.is_none() {
-                    let message_epoch = message.epoch();
-                    let group_epoch = openmls_group.epoch();
-                    debug!(
-                        "no pending commit to merge. Group epoch: {}. Message epoch: {}",
-                        group_epoch, message_epoch
-                    );
-                    conn.set_group_intent_to_publish(intent.id)?;
-
-                    return Err(MessageProcessingError::NoPendingCommit {
-                        message_epoch,
-                        group_epoch,
-                    });
-                }
-                let maybe_validated_commit = ValidatedCommit::from_staged_commit(
-                    maybe_pending_commit.expect("already checked"),
-                    openmls_group,
-                )?;
-
-                debug!("[{}] merging pending commit", self.client.account_address());
-                if let Err(MergePendingCommitError::MlsGroupStateError(err)) =
-                    openmls_group.merge_pending_commit(provider)
-                {
-                    debug!("error merging commit: {}", err);
-                    openmls_group.clear_pending_commit();
-                    conn.set_group_intent_to_publish(intent.id)?;
-                } else {
-                    // If no error committing the change, write a transcript message
-                    self.save_transcript_message(
-                        conn,
-                        maybe_validated_commit,
-                        envelope_timestamp_ns,
-                    )?;
-                }
-                // TOOD: Handle writing transcript messages for adding/removing members
-            }
-            IntentKind::SendMessage => {
-                let intent_data = SendMessageIntentData::from_bytes(intent.data.as_slice())?;
-                let group_id = openmls_group.group_id().as_slice();
-                let decrypted_message_data = intent_data.message.as_slice();
-                StoredGroupMessage {
-                    id: get_message_id(decrypted_message_data, group_id, envelope_timestamp_ns),
-                    group_id: group_id.to_vec(),
-                    decrypted_message_bytes: intent_data.message,
-                    sent_at_ns: envelope_timestamp_ns as i64,
-                    kind: GroupMessageKind::Application,
-                    sender_installation_id: self.client.installation_public_key(),
-                    sender_account_address: self.client.account_address(),
-                }
-                .store(conn)?;
-            }
-        };
-
-        conn.set_group_intent_committed(intent.id)?;
-
-        Ok(())
-    }
-
-    fn save_transcript_message(
-        &self,
-        conn: &DbConnection,
-        maybe_validated_commit: Option<ValidatedCommit>,
-        timestamp_ns: u64,
-    ) -> Result<Option<StoredGroupMessage>, MessageProcessingError> {
-        let mut transcript_message = None;
-        if let Some(validated_commit) = maybe_validated_commit {
-            // If there are no members added or removed, don't write a transcript message
-            if validated_commit.members_added.is_empty()
-                && validated_commit.members_removed.is_empty()
-            {
-                return Ok(None);
-            }
-            let sender_installation_id = validated_commit.actor_installation_id();
-            let sender_account_address = validated_commit.actor_account_address();
-            let payload: GroupMembershipChanges = validated_commit.into();
-            let encoded_payload = GroupMembershipChangeCodec::encode(payload)?;
-            let mut encoded_payload_bytes = Vec::new();
-            encoded_payload.encode(&mut encoded_payload_bytes)?;
-            let group_id = self.group_id.as_slice();
-            let message_id =
-                get_message_id(encoded_payload_bytes.as_slice(), group_id, timestamp_ns);
-            let msg = StoredGroupMessage {
-                id: message_id,
-                group_id: group_id.to_vec(),
-                decrypted_message_bytes: encoded_payload_bytes.to_vec(),
-                sent_at_ns: timestamp_ns as i64,
-                kind: GroupMessageKind::MembershipChange,
-                sender_installation_id,
-                sender_account_address,
-            };
-
-            msg.store(conn)?;
-            transcript_message = Some(msg);
-        }
-
-        Ok(transcript_message)
-    }
-
-    fn process_private_message(
-        &self,
-        openmls_group: &mut OpenMlsGroup,
-        provider: &XmtpOpenMlsProvider,
-        message: PrivateMessageIn,
-        envelope_timestamp_ns: u64,
-        allow_epoch_increment: bool,
-    ) -> Result<(), MessageProcessingError> {
-        debug!(
-            "[{}] processing private message",
-            self.client.account_address()
-        );
-        let decrypted_message = openmls_group.process_message(provider, message)?;
-        let (sender_account_address, sender_installation_id) =
-            validate_message_sender(openmls_group, &decrypted_message, envelope_timestamp_ns)?;
-
-        match decrypted_message.into_content() {
-            ProcessedMessageContent::ApplicationMessage(application_message) => {
-                let message_bytes = application_message.into_bytes();
-                let message_id =
-                    get_message_id(&message_bytes, &self.group_id, envelope_timestamp_ns);
-                StoredGroupMessage {
-                    id: message_id,
-                    group_id: self.group_id.clone(),
-                    decrypted_message_bytes: message_bytes,
-                    sent_at_ns: envelope_timestamp_ns as i64,
-                    kind: GroupMessageKind::Application,
-                    sender_installation_id,
-                    sender_account_address,
-                }
-                .store(provider.conn())?;
-            }
-            ProcessedMessageContent::ProposalMessage(_proposal_ptr) => {
-                // intentionally left blank.
-            }
-            ProcessedMessageContent::ExternalJoinProposalMessage(_external_proposal_ptr) => {
-                // intentionally left blank.
-            }
-            ProcessedMessageContent::StagedCommitMessage(staged_commit) => {
-                if !allow_epoch_increment {
-                    return Err(MessageProcessingError::EpochIncrementNotAllowed);
-                }
-                debug!(
-                    "[{}] received staged commit. Merging and clearing any pending commits",
-                    self.client.account_address()
-                );
-
-                let sc = *staged_commit;
-                // Validate the commit
-                let validated_commit = ValidatedCommit::from_staged_commit(&sc, openmls_group)?;
-                openmls_group.merge_staged_commit(provider, sc)?;
-                self.save_transcript_message(
-                    provider.conn(),
-                    validated_commit,
-                    envelope_timestamp_ns,
-                )?;
-            }
-        };
-
-        Ok(())
-    }
-
-    fn process_message(
-        &self,
-        openmls_group: &mut OpenMlsGroup,
-        provider: &XmtpOpenMlsProvider,
-        envelope: &GroupMessageV1,
-        allow_epoch_increment: bool,
-    ) -> Result<(), MessageProcessingError> {
-        let mls_message_in = MlsMessageIn::tls_deserialize_exact(&envelope.data)?;
-
-        let message = match mls_message_in.extract() {
-            MlsMessageInBody::PrivateMessage(message) => Ok(message),
-            other => Err(MessageProcessingError::UnsupportedMessageType(
-                discriminant(&other),
-            )),
-        }?;
-
-        let intent = provider
-            .conn()
-            .find_group_intent_by_payload_hash(sha256(envelope.data.as_slice()));
-        match intent {
-            // Intent with the payload hash matches
-            Ok(Some(intent)) => self.process_own_message(
-                intent,
-                openmls_group,
-                provider,
-                message.into(),
-                envelope.created_ns,
-                allow_epoch_increment,
-            ),
-            Err(err) => Err(MessageProcessingError::Storage(err)),
-            // No matching intent found
-            Ok(None) => self.process_private_message(
-                openmls_group,
-                provider,
-                message,
-                envelope.created_ns,
-                allow_epoch_increment,
-            ),
-        }
-    }
-
-    fn consume_message(
-        &self,
-        envelope: &GroupMessage,
-        openmls_group: &mut OpenMlsGroup,
-    ) -> Result<(), MessageProcessingError> {
-        let msgv1 = match &envelope.version {
-            Some(GroupMessageVersion::V1(value)) => value,
-            _ => return Err(MessageProcessingError::InvalidPayload),
-        };
-
-        self.client.process_for_id(
-            &msgv1.group_id,
-            EntityKind::Group,
-            msgv1.id,
-            |provider| -> Result<(), MessageProcessingError> {
-                self.process_message(openmls_group, &provider, msgv1, true)?;
-                openmls_group.save(provider.key_store())?;
-                Ok(())
-            },
-        )?;
-        Ok(())
-    }
-
-    pub fn process_messages(&self, messages: Vec<GroupMessage>) -> Result<(), GroupError> {
-        let conn = &self.client.store.conn()?;
-        let provider = self.client.mls_provider(conn);
-        let mut openmls_group = self.load_mls_group(&provider)?;
-
-        let receive_errors: Vec<MessageProcessingError> = messages
-            .into_iter()
-            .map(|envelope| -> Result<(), MessageProcessingError> {
-                retry!(
-                    Retry::default(),
-                    (|| self.consume_message(&envelope, &mut openmls_group))
-                )
-            })
-            .filter_map(Result::err)
-            .collect();
-
-        if receive_errors.is_empty() {
-            Ok(())
-        } else {
-            debug!("Message processing errors: {:?}", receive_errors);
-            Err(GroupError::ReceiveErrors(receive_errors))
-        }
-    }
-
-    async fn receive<'a>(&self, conn: &'a DbConnection<'a>) -> Result<(), GroupError> {
-        let messages = self
-            .client
-            .query_group_messages(&self.group_id, conn)
-            .await?;
-
-        self.process_messages(messages)?;
-
-        Ok(())
-    }
-
-    pub async fn add_members(&self, account_addresses: Vec<String>) -> Result<(), GroupError> {
-        validate_evm_addresses(&account_addresses)?;
+        account_addresses_to_add: Vec<String>,
+    ) -> Result<(), GroupError> {
+        let account_addresses = sanitize_evm_addresses(account_addresses_to_add)?;
         let conn = &mut self.client.store.conn()?;
         let intent_data: Vec<u8> =
             AddMembersIntentData::new(account_addresses.into()).try_into()?;
@@ -558,7 +257,7 @@ where
             intent_data,
         ))?;
 
-        self.sync_and_wait(conn, intent.id).await
+        self.sync_until_intent_resolved(conn, intent.id).await
     }
 
     pub async fn add_members_by_installation_id(
@@ -574,11 +273,14 @@ where
             intent_data,
         ))?;
 
-        self.sync_and_wait(conn, intent.id).await
+        self.sync_until_intent_resolved(conn, intent.id).await
     }
 
-    pub async fn remove_members(&self, account_addresses: Vec<String>) -> Result<(), GroupError> {
-        validate_evm_addresses(&account_addresses)?;
+    pub async fn remove_members(
+        &self,
+        account_addresses_to_remove: Vec<String>,
+    ) -> Result<(), GroupError> {
+        let account_addresses = sanitize_evm_addresses(account_addresses_to_remove)?;
         let conn = &mut self.client.store.conn()?;
         let intent_data: Vec<u8> = RemoveMembersIntentData::new(account_addresses.into()).into();
         let intent = conn.insert_group_intent(NewGroupIntent::new(
@@ -587,7 +289,7 @@ where
             intent_data,
         ))?;
 
-        self.sync_and_wait(conn, intent.id).await
+        self.sync_until_intent_resolved(conn, intent.id).await
     }
 
     #[allow(dead_code)]
@@ -604,7 +306,7 @@ where
             intent_data,
         ))?;
 
-        self.sync_and_wait(conn, intent.id).await
+        self.sync_until_intent_resolved(conn, intent.id).await
     }
 
     // Update this installation's leaf key in the group by creating a key update commit
@@ -614,256 +316,6 @@ where
         intent.store(conn)?;
 
         self.sync_with_conn(conn).await
-    }
-
-    pub async fn sync(&self) -> Result<(), GroupError> {
-        let conn = &mut self.client.store.conn()?;
-        self.sync_with_conn(conn).await
-    }
-
-    async fn sync_with_conn<'a>(&self, conn: &'a DbConnection<'a>) -> Result<(), GroupError> {
-        self.publish_intents(conn).await?;
-        if let Err(e) = self.receive(conn).await {
-            log::warn!("receive error {:?}", e);
-        }
-        self.post_commit(conn).await?;
-
-        Ok(())
-    }
-
-    async fn sync_and_wait<'a>(
-        &self,
-        conn: &'a DbConnection<'a>,
-        intent_id: ID,
-    ) -> Result<(), GroupError> {
-        let mut num_attempts = 0;
-        let max_attempts = 3;
-        while num_attempts < max_attempts {
-            // Sync with conn will swollow errors on the receive side,
-            // but we should pay attention to errors on the publish side
-            self.sync_with_conn(conn).await?;
-            let intent: Option<StoredGroupIntent> = conn.fetch(&intent_id)?;
-            match intent {
-                None => {
-                    // This is expected. The intent gets deleted on success
-                    return Ok(());
-                }
-                _ => {
-                    num_attempts += 1;
-                }
-            }
-        }
-
-        Err(GroupError::Generic("failed to wait for intent".to_string()))
-    }
-
-    pub(crate) async fn publish_intents<'a>(
-        &self,
-        conn: &'a DbConnection<'a>,
-    ) -> Result<(), GroupError> {
-        let provider = self.client.mls_provider(conn);
-        let mut openmls_group = self.load_mls_group(&provider)?;
-
-        let intents = provider.conn().find_group_intents(
-            self.group_id.clone(),
-            Some(vec![IntentState::ToPublish]),
-            None,
-        )?;
-
-        for intent in intents {
-            let result = retry_async!(
-                Retry::default(),
-                (async {
-                    self.get_publish_intent_data(&provider, &mut openmls_group, &intent)
-                        .await
-                })
-            );
-            if let Err(e) = result {
-                log::error!("error getting publish intent data {:?}", e);
-                // TODO: Figure out which types of errors we should abort completely on and which
-                // ones are safe to continue with
-                continue;
-            }
-
-            let (payload, post_commit_data) = result.expect("result already checked");
-            let payload_slice = payload.as_slice();
-
-            self.client
-                .api_client
-                .send_group_messages(vec![payload_slice])
-                .await?;
-
-            provider.conn().set_group_intent_published(
-                intent.id,
-                sha256(payload_slice),
-                post_commit_data,
-            )?;
-        }
-        openmls_group.save(provider.key_store())?;
-
-        Ok(())
-    }
-
-    // Takes a StoredGroupIntent and returns the payload and post commit data as a tuple
-    async fn get_publish_intent_data(
-        &self,
-        provider: &XmtpOpenMlsProvider<'_>,
-        openmls_group: &mut OpenMlsGroup,
-        intent: &StoredGroupIntent,
-    ) -> Result<(Vec<u8>, Option<Vec<u8>>), GroupError> {
-        match intent.kind {
-            IntentKind::SendMessage => {
-                // We can safely assume all SendMessage intents have data
-                let intent_data = SendMessageIntentData::from_bytes(intent.data.as_slice())?;
-                // TODO: Handle pending_proposal errors and UseAfterEviction errors
-                let msg = openmls_group.create_message(
-                    provider,
-                    &self.client.identity.installation_keys,
-                    intent_data.message.as_slice(),
-                )?;
-
-                let msg_bytes = msg.tls_serialize_detached()?;
-                Ok((msg_bytes, None))
-            }
-            IntentKind::AddMembers => {
-                let intent_data = AddMembersIntentData::from_bytes(intent.data.as_slice())?;
-
-                let key_packages = self
-                    .client
-                    .get_key_packages(intent_data.address_or_id)
-                    .await?;
-
-                let mls_key_packages: Vec<KeyPackage> =
-                    key_packages.iter().map(|kp| kp.inner.clone()).collect();
-
-                let (commit, welcome, _group_info) = openmls_group.add_members(
-                    provider,
-                    &self.client.identity.installation_keys,
-                    mls_key_packages.as_slice(),
-                )?;
-
-                if let Some(staged_commit) = openmls_group.pending_commit() {
-                    // Validate the commit, even if it's from yourself
-                    ValidatedCommit::from_staged_commit(staged_commit, openmls_group)?;
-                }
-
-                let commit_bytes = commit.tls_serialize_detached()?;
-
-                let installations = key_packages
-                    .iter()
-                    .map(Installation::from_verified_key_package)
-                    .collect();
-
-                let post_commit_data =
-                    Some(PostCommitAction::from_welcome(welcome, installations)?.to_bytes());
-
-                Ok((commit_bytes, post_commit_data))
-            }
-            IntentKind::RemoveMembers => {
-                let intent_data = RemoveMembersIntentData::from_bytes(intent.data.as_slice())?;
-
-                let installation_ids = {
-                    match intent_data.address_or_id {
-                        AddressesOrInstallationIds::AccountAddresses(addrs) => {
-                            self.client.get_all_active_installation_ids(addrs).await?
-                        }
-                        AddressesOrInstallationIds::InstallationIds(ids) => ids,
-                    }
-                };
-
-                let leaf_nodes: Vec<LeafNodeIndex> = openmls_group
-                    .members()
-                    .filter(|member| installation_ids.contains(&member.signature_key))
-                    .map(|member| member.index)
-                    .collect();
-
-                let num_leaf_nodes = leaf_nodes.len();
-
-                if num_leaf_nodes != installation_ids.len() {
-                    return Err(GroupError::Generic(format!(
-                        "expected {} leaf nodes, found {}",
-                        installation_ids.len(),
-                        num_leaf_nodes
-                    )));
-                }
-
-                // The second return value is a Welcome, which is only possible if there
-                // are pending proposals. Ignoring for now
-                let (commit, _, _) = openmls_group.remove_members(
-                    provider,
-                    &self.client.identity.installation_keys,
-                    leaf_nodes.as_slice(),
-                )?;
-
-                if let Some(staged_commit) = openmls_group.pending_commit() {
-                    // Validate the commit, even if it's from yourself
-                    ValidatedCommit::from_staged_commit(staged_commit, openmls_group)?;
-                }
-
-                let commit_bytes = commit.tls_serialize_detached()?;
-
-                Ok((commit_bytes, None))
-            }
-            IntentKind::KeyUpdate => {
-                let (commit, _, _) =
-                    openmls_group.self_update(provider, &self.client.identity.installation_keys)?;
-
-                Ok((commit.tls_serialize_detached()?, None))
-            }
-        }
-    }
-
-    pub(crate) async fn post_commit(&self, conn: &DbConnection<'_>) -> Result<(), GroupError> {
-        let intents = conn.find_group_intents(
-            self.group_id.clone(),
-            Some(vec![IntentState::Committed]),
-            None,
-        )?;
-
-        for intent in intents {
-            if intent.post_commit_data.is_some() {
-                let post_commit_data = intent.post_commit_data.unwrap();
-                let post_commit_action = PostCommitAction::from_bytes(post_commit_data.as_slice())?;
-                match post_commit_action {
-                    PostCommitAction::SendWelcomes(action) => {
-                        self.send_welcomes(action).await?;
-                    }
-                }
-            }
-            let deleter: &dyn Delete<StoredGroupIntent, Key = i32> = conn;
-            deleter.delete(intent.id)?;
-        }
-
-        Ok(())
-    }
-
-    async fn send_welcomes(&self, action: SendWelcomesAction) -> Result<(), GroupError> {
-        let welcomes = action
-            .installations
-            .into_iter()
-            .map(|installation| -> Result<WelcomeMessageInput, HpkeError> {
-                let installation_key = installation.installation_key;
-                let encrypted = encrypt_welcome(
-                    action.welcome_message.as_slice(),
-                    installation.hpke_public_key.as_slice(),
-                )?;
-
-                Ok(WelcomeMessageInput {
-                    version: Some(WelcomeMessageInputVersion::V1(WelcomeMessageInputV1 {
-                        installation_key,
-                        data: encrypted,
-                        hpke_public_key: installation.hpke_public_key,
-                    })),
-                })
-            })
-            .collect::<Result<Vec<WelcomeMessageInput>, HpkeError>>()?;
-
-        self.client
-            .api_client
-            .send_welcome_messages(welcomes)
-            .await?;
-
-        Ok(())
     }
 }
 
@@ -887,53 +339,6 @@ fn validate_ed25519_keys(keys: &[Vec<u8>]) -> Result<(), GroupError> {
     }
 
     Ok(())
-}
-
-fn validate_evm_addresses(account_addresses: &[String]) -> Result<(), GroupError> {
-    let mut invalid = account_addresses
-        .iter()
-        .filter(|a| !is_valid_ethereum_address(a))
-        .peekable();
-
-    if invalid.peek().is_some() {
-        return Err(GroupError::InvalidAddresses(
-            invalid.map(ToString::to_string).collect::<Vec<_>>(),
-        ));
-    }
-
-    Ok(())
-}
-
-fn validate_message_sender(
-    openmls_group: &mut OpenMlsGroup,
-    decrypted_message: &ProcessedMessage,
-    message_created_ns: u64,
-) -> Result<(String, Vec<u8>), MessageProcessingError> {
-    let mut sender_account_address = None;
-    let mut sender_installation_id = None;
-    if let Sender::Member(leaf_node_index) = decrypted_message.sender() {
-        if let Some(member) = openmls_group.member_at(*leaf_node_index) {
-            if member.credential.eq(decrypted_message.credential()) {
-                sender_account_address = Identity::get_validated_account_address(
-                    member.credential.identity(),
-                    &member.signature_key,
-                )
-                .ok();
-                sender_installation_id = Some(member.signature_key);
-            }
-        }
-    }
-
-    if sender_account_address.is_none() {
-        return Err(MessageProcessingError::InvalidSender {
-            message_time_ns: message_created_ns,
-            credential: decrypted_message.credential().identity().to_vec(),
-        });
-    }
-    Ok((
-        sender_account_address.unwrap(),
-        sender_installation_id.unwrap(),
-    ))
 }
 
 fn build_protected_metadata_extension(
@@ -1009,7 +414,7 @@ mod tests {
         let msg = b"hello";
         group.send_message(msg).await.expect("send message");
 
-        group.receive().await.unwrap();
+        group.receive(&client.store.conn().unwrap()).await.unwrap();
         // Check for messages
         // println!("HERE: {:#?}", messages);
         let messages = group.find_messages(None, None, None, None).unwrap();
@@ -1052,7 +457,10 @@ mod tests {
             .await
             .expect_err("expected err");
 
-        amal_group.receive().await.expect_err("expected error");
+        amal_group
+            .receive(&amal.store.conn().unwrap())
+            .await
+            .expect_err("expected error");
 
         // Check Amal's MLS group state.
         let amal_db = amal.store.conn().unwrap();

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -6,9 +6,9 @@ mod subscriptions;
 mod sync;
 pub mod validated_commit;
 use crate::{
-    api_client_wrapper::IdentityUpdate,
     client::deserialize_welcome,
     hpke::{decrypt_welcome, HpkeError},
+    identity::IdentityError,
     utils::address::AddressValidationError,
 };
 use intents::SendMessageIntentData;
@@ -320,116 +320,6 @@ where
 
         self.sync_with_conn(conn).await
     }
-
-    #[allow(dead_code)]
-    async fn get_missing_members(
-        &self,
-        provider: &XmtpOpenMlsProvider<'_>,
-    ) -> Result<(Vec<Vec<u8>>, Vec<Vec<u8>>), GroupError> {
-        let current_members = self.members_with_provider(provider)?;
-        let account_addresses = current_members
-            .iter()
-            .map(|m| m.account_address.clone())
-            .collect();
-
-        let current_member_map: HashMap<String, GroupMember> = current_members
-            .into_iter()
-            .map(|m| (m.account_address.clone(), m))
-            .collect();
-
-        let change_list = self
-            .client
-            .api_client
-            // TODO: Get a real start time from the database
-            .get_identity_updates(0, account_addresses)
-            .await?;
-
-        let to_add: Vec<Vec<u8>> = change_list
-            .into_iter()
-            .filter_map(|(account_address, updates)| {
-                let member_changes: Vec<Vec<u8>> = updates
-                    .into_iter()
-                    .filter_map(|change| match change {
-                        IdentityUpdate::NewInstallation(new_member) => {
-                            let current_member = current_member_map.get(&account_address);
-                            current_member?;
-                            if current_member
-                                .expect("already checked")
-                                .installation_ids
-                                .contains(&new_member.installation_key)
-                            {
-                                return None;
-                            }
-
-                            Some(new_member.installation_key)
-                        }
-                        IdentityUpdate::RevokeInstallation(_) => {
-                            log::warn!("Revocation found. Not handled");
-
-                            None
-                        }
-                        IdentityUpdate::Invalid => {
-                            log::warn!("Invalid identity update found");
-
-                            None
-                        }
-                    })
-                    .collect();
-
-                if !member_changes.is_empty() {
-                    return Some(member_changes);
-                }
-                None
-            })
-            .flatten()
-            .collect();
-
-        Ok((to_add, vec![]))
-    }
-
-    #[allow(dead_code)]
-    async fn add_missing_installations(
-        &self,
-        provider: &XmtpOpenMlsProvider<'_>,
-    ) -> Result<usize, GroupError> {
-        let (missing_members, _placeholder) = self.get_missing_members(provider).await?;
-        if missing_members.is_empty() {
-            return Ok(0);
-        }
-        let new_member_installations_count = missing_members.len();
-        self.add_members_by_installation_id(missing_members).await?;
-
-        Ok(new_member_installations_count)
-    }
-
-    async fn send_welcomes(&self, action: SendWelcomesAction) -> Result<(), GroupError> {
-        let welcomes = action
-            .installations
-            .into_iter()
-            .map(|installation| -> Result<WelcomeMessageInput, HpkeError> {
-                let installation_key = installation.installation_key;
-                let encrypted = encrypt_welcome(
-                    action.welcome_message.as_slice(),
-                    installation.hpke_public_key.as_slice(),
-                )?;
-
-                Ok(WelcomeMessageInput {
-                    version: Some(WelcomeMessageInputVersion::V1(WelcomeMessageInputV1 {
-                        installation_key,
-                        data: encrypted,
-                        hpke_public_key: installation.hpke_public_key,
-                    })),
-                })
-            })
-            .collect::<Result<Vec<WelcomeMessageInput>, HpkeError>>()?;
-
-        self.client
-            .api_client
-            .send_welcome_messages(welcomes)
-            .await?;
-
-        Ok(())
-    }
 }
 
 fn extract_message_v1(message: GroupMessage) -> Result<GroupMessageV1, MessageProcessingError> {
@@ -501,7 +391,7 @@ mod tests {
     use openmls::prelude::Member;
     use xmtp_cryptography::utils::generate_local_wallet;
 
-    use crate::{builder::ClientBuilder, storage::group_intent::IntentState};
+    use crate::{builder::ClientBuilder, storage::group_intent::IntentState, InboxOwner};
 
     #[tokio::test]
     async fn test_send_message() {
@@ -642,6 +532,16 @@ mod tests {
         let result = group
             .add_members_by_installation_id(vec![b"1234".to_vec()])
             .await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_add_unregistered_member() {
+        let amal = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
+        let unconnected_wallet_address = generate_local_wallet().get_address();
+        let group = amal.create_group().unwrap();
+        let result = group.add_members(vec![unconnected_wallet_address]).await;
 
         assert!(result.is_err());
     }

--- a/xmtp_mls/src/groups/sync.rs
+++ b/xmtp_mls/src/groups/sync.rs
@@ -1,0 +1,689 @@
+use super::{intents::SendMessageIntentData, GroupError, MlsGroup};
+use crate::{
+    codecs::ContentCodec,
+    hpke::{encrypt_welcome, HpkeError},
+    retry_async,
+    storage::{
+        group_intent::{IntentKind, IntentState, ID},
+        refresh_state::EntityKind,
+        StorageError,
+    },
+    Fetch,
+};
+use log::debug;
+use openmls::{
+    framing::ProtocolMessage,
+    group::MergePendingCommitError,
+    prelude::{
+        LeafNodeIndex, MlsGroup as OpenMlsGroup, MlsMessageIn, MlsMessageInBody, PrivateMessageIn,
+        ProcessedMessage, ProcessedMessageContent, Sender,
+    },
+    prelude_test::KeyPackage,
+};
+use openmls_traits::OpenMlsProvider;
+use prost::Message;
+use std::mem::discriminant;
+use tls_codec::{Deserialize, Serialize};
+use xmtp_proto::{
+    api_client::XmtpMlsClient,
+    xmtp::mls::api::v1::{
+        group_message::{Version as GroupMessageVersion, V1 as GroupMessageV1},
+        welcome_message_input::{
+            Version as WelcomeMessageInputVersion, V1 as WelcomeMessageInputV1,
+        },
+        GroupMessage, WelcomeMessageInput,
+    },
+    xmtp::mls::message_contents::GroupMembershipChanges,
+};
+
+use super::intents::{
+    AddMembersIntentData, AddressesOrInstallationIds, Installation, PostCommitAction,
+    RemoveMembersIntentData, SendWelcomesAction,
+};
+use crate::{
+    client::MessageProcessingError,
+    codecs::membership_change::GroupMembershipChangeCodec,
+    groups::validated_commit::ValidatedCommit,
+    identity::Identity,
+    retry,
+    retry::Retry,
+    storage::{
+        db_connection::DbConnection,
+        group_intent::StoredGroupIntent,
+        group_message::{GroupMessageKind, StoredGroupMessage},
+    },
+    utils::{hash::sha256, id::get_message_id},
+    xmtp_openmls_provider::XmtpOpenMlsProvider,
+    Delete, Store,
+};
+
+impl<'c, ApiClient> MlsGroup<'c, ApiClient>
+where
+    ApiClient: XmtpMlsClient,
+{
+    pub async fn sync(&self) -> Result<(), GroupError> {
+        let conn = &mut self.client.store.conn()?;
+        self.sync_with_conn(conn).await
+    }
+
+    pub(super) async fn sync_with_conn<'a>(
+        &self,
+        conn: &'a DbConnection<'a>,
+    ) -> Result<(), GroupError> {
+        let mut errors: Vec<GroupError> = vec![];
+
+        // Even if publish fails, continue to receiving
+        if let Err(publish_error) = self.publish_intents(conn).await {
+            log::error!("error publishing intents {:?}", publish_error);
+            errors.push(publish_error);
+        }
+
+        // Even if receiving fails, continue to post_commit
+        if let Err(receive_error) = self.receive(conn).await {
+            log::error!("receive error {:?}", receive_error);
+            // We don't return an error if receive fails, because it's possible this is caused
+            // by malicious data sent over the network, or messages from before the user was
+            // added to the group
+        }
+
+        if let Err(post_commit_err) = self.post_commit(conn).await {
+            log::error!("post commit error {:?}", post_commit_err);
+            errors.push(post_commit_err);
+        }
+
+        // Return a combination of publish and post_commit errors
+        if !errors.is_empty() {
+            return Err(GroupError::Sync(errors));
+        }
+
+        Ok(())
+    }
+
+    /**
+     * Sync the group and wait for the intent to be deleted
+     * Group syncing may involve picking up messages unrelated to the intent, so simply checking for errors
+     * does not give a clear signal as to whether the intent was successfully completed or not.
+     *
+     * This method will retry up to `crate::configuration::MAX_GROUP_SYNC_RETRIES` times.
+     */
+    pub(super) async fn sync_until_intent_resolved<'a>(
+        &self,
+        conn: &'a DbConnection<'a>,
+        intent_id: ID,
+    ) -> Result<(), GroupError> {
+        let mut num_attempts = 0;
+        // Return the last error to the caller if we fail to sync
+        let mut last_err: Option<GroupError> = None;
+        while num_attempts < crate::configuration::MAX_GROUP_SYNC_RETRIES {
+            if let Err(err) = self.sync_with_conn(conn).await {
+                log::error!("error syncing group {:?}", err);
+                last_err = Some(err);
+            }
+
+            // This will return early if the fetch fails
+            let intent: Result<Option<StoredGroupIntent>, StorageError> = conn.fetch(&intent_id);
+            match intent {
+                Ok(None) => {
+                    // This is expected. The intent gets deleted on success
+                    return Ok(());
+                }
+                Ok(Some(intent)) => {
+                    log::warn!(
+                        "retrying intent ID {}. intent currently in state {:?}",
+                        intent.id,
+                        intent.state
+                    );
+                }
+                Err(err) => {
+                    log::error!("database error fetching intent {:?}", err);
+                    last_err = Some(GroupError::Storage(err));
+                }
+            };
+            num_attempts += 1;
+        }
+
+        Err(last_err.unwrap_or(GroupError::Generic("failed to wait for intent".to_string())))
+    }
+
+    fn process_own_message(
+        &self,
+        intent: StoredGroupIntent,
+        openmls_group: &mut OpenMlsGroup,
+        provider: &XmtpOpenMlsProvider,
+        message: ProtocolMessage,
+        envelope_timestamp_ns: u64,
+        allow_epoch_increment: bool,
+    ) -> Result<(), MessageProcessingError> {
+        if intent.state == IntentState::Committed {
+            return Ok(());
+        }
+        debug!(
+            "[{}] processing own message for intent {} / {:?}",
+            self.client.account_address(),
+            intent.id,
+            intent.kind
+        );
+
+        let conn = provider.conn();
+        match intent.kind {
+            IntentKind::AddMembers | IntentKind::RemoveMembers | IntentKind::KeyUpdate => {
+                if !allow_epoch_increment {
+                    return Err(MessageProcessingError::EpochIncrementNotAllowed);
+                }
+                let maybe_pending_commit = openmls_group.pending_commit();
+                // We don't get errors with merge_pending_commit when there are no commits to merge
+                if maybe_pending_commit.is_none() {
+                    let message_epoch = message.epoch();
+                    let group_epoch = openmls_group.epoch();
+                    debug!(
+                        "no pending commit to merge. Group epoch: {}. Message epoch: {}",
+                        group_epoch, message_epoch
+                    );
+                    conn.set_group_intent_to_publish(intent.id)?;
+
+                    return Err(MessageProcessingError::NoPendingCommit {
+                        message_epoch,
+                        group_epoch,
+                    });
+                }
+                let maybe_validated_commit = ValidatedCommit::from_staged_commit(
+                    maybe_pending_commit.expect("already checked"),
+                    openmls_group,
+                )?;
+
+                debug!("[{}] merging pending commit", self.client.account_address());
+                if let Err(MergePendingCommitError::MlsGroupStateError(err)) =
+                    openmls_group.merge_pending_commit(provider)
+                {
+                    debug!("error merging commit: {}", err);
+                    openmls_group.clear_pending_commit();
+                    conn.set_group_intent_to_publish(intent.id)?;
+                } else {
+                    // If no error committing the change, write a transcript message
+                    self.save_transcript_message(
+                        conn,
+                        maybe_validated_commit,
+                        envelope_timestamp_ns,
+                    )?;
+                }
+                // TOOD: Handle writing transcript messages for adding/removing members
+            }
+            IntentKind::SendMessage => {
+                let intent_data = SendMessageIntentData::from_bytes(intent.data.as_slice())?;
+                let group_id = openmls_group.group_id().as_slice();
+                let decrypted_message_data = intent_data.message.as_slice();
+                StoredGroupMessage {
+                    id: get_message_id(decrypted_message_data, group_id, envelope_timestamp_ns),
+                    group_id: group_id.to_vec(),
+                    decrypted_message_bytes: intent_data.message,
+                    sent_at_ns: envelope_timestamp_ns as i64,
+                    kind: GroupMessageKind::Application,
+                    sender_installation_id: self.client.installation_public_key(),
+                    sender_account_address: self.client.account_address(),
+                }
+                .store(conn)?;
+            }
+        };
+
+        conn.set_group_intent_committed(intent.id)?;
+
+        Ok(())
+    }
+
+    fn process_external_message(
+        &self,
+        openmls_group: &mut OpenMlsGroup,
+        provider: &XmtpOpenMlsProvider,
+        message: PrivateMessageIn,
+        envelope_timestamp_ns: u64,
+        allow_epoch_increment: bool,
+    ) -> Result<(), MessageProcessingError> {
+        debug!(
+            "[{}] processing private message",
+            self.client.account_address()
+        );
+        let decrypted_message = openmls_group.process_message(provider, message)?;
+        let (sender_account_address, sender_installation_id) =
+            validate_message_sender(openmls_group, &decrypted_message, envelope_timestamp_ns)?;
+
+        match decrypted_message.into_content() {
+            ProcessedMessageContent::ApplicationMessage(application_message) => {
+                let message_bytes = application_message.into_bytes();
+                let message_id =
+                    get_message_id(&message_bytes, &self.group_id, envelope_timestamp_ns);
+                StoredGroupMessage {
+                    id: message_id,
+                    group_id: self.group_id.clone(),
+                    decrypted_message_bytes: message_bytes,
+                    sent_at_ns: envelope_timestamp_ns as i64,
+                    kind: GroupMessageKind::Application,
+                    sender_installation_id,
+                    sender_account_address,
+                }
+                .store(provider.conn())?;
+            }
+            ProcessedMessageContent::ProposalMessage(_proposal_ptr) => {
+                // intentionally left blank.
+            }
+            ProcessedMessageContent::ExternalJoinProposalMessage(_external_proposal_ptr) => {
+                // intentionally left blank.
+            }
+            ProcessedMessageContent::StagedCommitMessage(staged_commit) => {
+                if !allow_epoch_increment {
+                    return Err(MessageProcessingError::EpochIncrementNotAllowed);
+                }
+                debug!(
+                    "[{}] received staged commit. Merging and clearing any pending commits",
+                    self.client.account_address()
+                );
+
+                let sc = *staged_commit;
+                // Validate the commit
+                let validated_commit = ValidatedCommit::from_staged_commit(&sc, openmls_group)?;
+                openmls_group.merge_staged_commit(provider, sc)?;
+                self.save_transcript_message(
+                    provider.conn(),
+                    validated_commit,
+                    envelope_timestamp_ns,
+                )?;
+            }
+        };
+
+        Ok(())
+    }
+
+    pub(super) fn process_message(
+        &self,
+        openmls_group: &mut OpenMlsGroup,
+        provider: &XmtpOpenMlsProvider,
+        envelope: &GroupMessageV1,
+        allow_epoch_increment: bool,
+    ) -> Result<(), MessageProcessingError> {
+        let mls_message_in = MlsMessageIn::tls_deserialize_exact(&envelope.data)?;
+
+        let message = match mls_message_in.extract() {
+            MlsMessageInBody::PrivateMessage(message) => Ok(message),
+            other => Err(MessageProcessingError::UnsupportedMessageType(
+                discriminant(&other),
+            )),
+        }?;
+
+        let intent = provider
+            .conn()
+            .find_group_intent_by_payload_hash(sha256(envelope.data.as_slice()));
+        match intent {
+            // Intent with the payload hash matches
+            Ok(Some(intent)) => self.process_own_message(
+                intent,
+                openmls_group,
+                provider,
+                message.into(),
+                envelope.created_ns,
+                allow_epoch_increment,
+            ),
+            Err(err) => Err(MessageProcessingError::Storage(err)),
+            // No matching intent found
+            Ok(None) => self.process_external_message(
+                openmls_group,
+                provider,
+                message,
+                envelope.created_ns,
+                allow_epoch_increment,
+            ),
+        }
+    }
+
+    fn consume_message(
+        &self,
+        envelope: &GroupMessage,
+        openmls_group: &mut OpenMlsGroup,
+    ) -> Result<(), MessageProcessingError> {
+        let msgv1 = match &envelope.version {
+            Some(GroupMessageVersion::V1(value)) => value,
+            _ => return Err(MessageProcessingError::InvalidPayload),
+        };
+
+        self.client.process_for_id(
+            &msgv1.group_id,
+            EntityKind::Group,
+            msgv1.id,
+            |provider| -> Result<(), MessageProcessingError> {
+                self.process_message(openmls_group, &provider, msgv1, true)?;
+                openmls_group.save(provider.key_store())?;
+                Ok(())
+            },
+        )?;
+        Ok(())
+    }
+
+    pub fn process_messages<'a>(
+        &self,
+        messages: Vec<GroupMessage>,
+        conn: &'a DbConnection<'a>,
+    ) -> Result<(), GroupError> {
+        let provider = self.client.mls_provider(conn);
+        let mut openmls_group = self.load_mls_group(&provider)?;
+
+        let receive_errors: Vec<MessageProcessingError> = messages
+            .into_iter()
+            .map(|envelope| -> Result<(), MessageProcessingError> {
+                retry!(
+                    Retry::default(),
+                    (|| self.consume_message(&envelope, &mut openmls_group))
+                )
+            })
+            .filter_map(Result::err)
+            .collect();
+
+        if receive_errors.is_empty() {
+            Ok(())
+        } else {
+            debug!("Message processing errors: {:?}", receive_errors);
+            Err(GroupError::ReceiveErrors(receive_errors))
+        }
+    }
+
+    pub(super) async fn receive<'a>(&self, conn: &'a DbConnection<'a>) -> Result<(), GroupError> {
+        let messages = self
+            .client
+            .query_group_messages(&self.group_id, conn)
+            .await?;
+
+        self.process_messages(messages, conn)?;
+
+        Ok(())
+    }
+
+    fn save_transcript_message(
+        &self,
+        conn: &DbConnection,
+        maybe_validated_commit: Option<ValidatedCommit>,
+        timestamp_ns: u64,
+    ) -> Result<Option<StoredGroupMessage>, MessageProcessingError> {
+        let mut transcript_message = None;
+        if let Some(validated_commit) = maybe_validated_commit {
+            // If there are no members added or removed, don't write a transcript message
+            if validated_commit.members_added.is_empty()
+                && validated_commit.members_removed.is_empty()
+            {
+                return Ok(None);
+            }
+            let sender_installation_id = validated_commit.actor_installation_id();
+            let sender_account_address = validated_commit.actor_account_address();
+            let payload: GroupMembershipChanges = validated_commit.into();
+            let encoded_payload = GroupMembershipChangeCodec::encode(payload)?;
+            let mut encoded_payload_bytes = Vec::new();
+            encoded_payload.encode(&mut encoded_payload_bytes)?;
+            let group_id = self.group_id.as_slice();
+            let message_id =
+                get_message_id(encoded_payload_bytes.as_slice(), group_id, timestamp_ns);
+            let msg = StoredGroupMessage {
+                id: message_id,
+                group_id: group_id.to_vec(),
+                decrypted_message_bytes: encoded_payload_bytes.to_vec(),
+                sent_at_ns: timestamp_ns as i64,
+                kind: GroupMessageKind::MembershipChange,
+                sender_installation_id,
+                sender_account_address,
+            };
+
+            msg.store(conn)?;
+            transcript_message = Some(msg);
+        }
+
+        Ok(transcript_message)
+    }
+
+    pub(super) async fn publish_intents<'a>(
+        &self,
+        conn: &'a DbConnection<'a>,
+    ) -> Result<(), GroupError> {
+        let provider = self.client.mls_provider(conn);
+        let mut openmls_group = self.load_mls_group(&provider)?;
+
+        let intents = provider.conn().find_group_intents(
+            self.group_id.clone(),
+            Some(vec![IntentState::ToPublish]),
+            None,
+        )?;
+        let num_intents = intents.len();
+
+        for intent in intents {
+            if intent.publish_attempts >= (crate::configuration::MAX_INTENT_PUBLISH_ATTEMPTS as i32)
+            {
+                log::error!("intent {} has reached max publish attempts", intent.id);
+                // TODO: Eventually clean up errored attempts
+                conn.set_group_intent_error(intent.id)?;
+                continue;
+            }
+
+            let result = retry_async!(
+                Retry::default(),
+                (async {
+                    self.get_publish_intent_data(&provider, &mut openmls_group, &intent)
+                        .await
+                })
+            );
+
+            if let Err(err) = result {
+                log::error!("error getting publish intent data {:?}", err);
+                conn.increment_intent_publish_attempt_count(intent.id)?;
+                return Err(err);
+            }
+
+            let (payload, post_commit_data) = result.expect("already checked");
+            let payload_slice = payload.as_slice();
+
+            self.client
+                .api_client
+                .send_group_messages(vec![payload_slice])
+                .await?;
+
+            provider.conn().set_group_intent_published(
+                intent.id,
+                sha256(payload_slice),
+                post_commit_data,
+            )?;
+        }
+
+        if num_intents > 0 {
+            openmls_group.save(provider.key_store())?;
+        }
+
+        Ok(())
+    }
+
+    // Takes a StoredGroupIntent and returns the payload and post commit data as a tuple
+    async fn get_publish_intent_data(
+        &self,
+        provider: &XmtpOpenMlsProvider<'_>,
+        openmls_group: &mut OpenMlsGroup,
+        intent: &StoredGroupIntent,
+    ) -> Result<(Vec<u8>, Option<Vec<u8>>), GroupError> {
+        match intent.kind {
+            IntentKind::SendMessage => {
+                // We can safely assume all SendMessage intents have data
+                let intent_data = SendMessageIntentData::from_bytes(intent.data.as_slice())?;
+                // TODO: Handle pending_proposal errors and UseAfterEviction errors
+                let msg = openmls_group.create_message(
+                    provider,
+                    &self.client.identity.installation_keys,
+                    intent_data.message.as_slice(),
+                )?;
+
+                let msg_bytes = msg.tls_serialize_detached()?;
+                Ok((msg_bytes, None))
+            }
+            IntentKind::AddMembers => {
+                let intent_data = AddMembersIntentData::from_bytes(intent.data.as_slice())?;
+
+                let key_packages = self
+                    .client
+                    .get_key_packages(intent_data.address_or_id)
+                    .await?;
+
+                let mls_key_packages: Vec<KeyPackage> =
+                    key_packages.iter().map(|kp| kp.inner.clone()).collect();
+
+                let (commit, welcome, _group_info) = openmls_group.add_members(
+                    provider,
+                    &self.client.identity.installation_keys,
+                    mls_key_packages.as_slice(),
+                )?;
+
+                if let Some(staged_commit) = openmls_group.pending_commit() {
+                    // Validate the commit, even if it's from yourself
+                    ValidatedCommit::from_staged_commit(staged_commit, openmls_group)?;
+                }
+
+                let commit_bytes = commit.tls_serialize_detached()?;
+
+                let installations = key_packages
+                    .iter()
+                    .map(Installation::from_verified_key_package)
+                    .collect();
+
+                let post_commit_data =
+                    Some(PostCommitAction::from_welcome(welcome, installations)?.to_bytes());
+
+                Ok((commit_bytes, post_commit_data))
+            }
+            IntentKind::RemoveMembers => {
+                let intent_data = RemoveMembersIntentData::from_bytes(intent.data.as_slice())?;
+
+                let installation_ids = {
+                    match intent_data.address_or_id {
+                        AddressesOrInstallationIds::AccountAddresses(addrs) => {
+                            self.client.get_all_active_installation_ids(addrs).await?
+                        }
+                        AddressesOrInstallationIds::InstallationIds(ids) => ids,
+                    }
+                };
+
+                let leaf_nodes: Vec<LeafNodeIndex> = openmls_group
+                    .members()
+                    .filter(|member| installation_ids.contains(&member.signature_key))
+                    .map(|member| member.index)
+                    .collect();
+
+                let num_leaf_nodes = leaf_nodes.len();
+
+                if num_leaf_nodes != installation_ids.len() {
+                    return Err(GroupError::Generic(format!(
+                        "expected {} leaf nodes, found {}",
+                        installation_ids.len(),
+                        num_leaf_nodes
+                    )));
+                }
+
+                // The second return value is a Welcome, which is only possible if there
+                // are pending proposals. Ignoring for now
+                let (commit, _, _) = openmls_group.remove_members(
+                    provider,
+                    &self.client.identity.installation_keys,
+                    leaf_nodes.as_slice(),
+                )?;
+
+                if let Some(staged_commit) = openmls_group.pending_commit() {
+                    // Validate the commit, even if it's from yourself
+                    ValidatedCommit::from_staged_commit(staged_commit, openmls_group)?;
+                }
+
+                let commit_bytes = commit.tls_serialize_detached()?;
+
+                Ok((commit_bytes, None))
+            }
+            IntentKind::KeyUpdate => {
+                let (commit, _, _) =
+                    openmls_group.self_update(provider, &self.client.identity.installation_keys)?;
+
+                Ok((commit.tls_serialize_detached()?, None))
+            }
+        }
+    }
+
+    pub(crate) async fn post_commit(&self, conn: &DbConnection<'_>) -> Result<(), GroupError> {
+        let intents = conn.find_group_intents(
+            self.group_id.clone(),
+            Some(vec![IntentState::Committed]),
+            None,
+        )?;
+
+        for intent in intents {
+            if intent.post_commit_data.is_some() {
+                let post_commit_data = intent.post_commit_data.unwrap();
+                let post_commit_action = PostCommitAction::from_bytes(post_commit_data.as_slice())?;
+                match post_commit_action {
+                    PostCommitAction::SendWelcomes(action) => {
+                        self.send_welcomes(action).await?;
+                    }
+                }
+            }
+            let deleter: &dyn Delete<StoredGroupIntent, Key = i32> = conn;
+            deleter.delete(intent.id)?;
+        }
+
+        Ok(())
+    }
+
+    async fn send_welcomes(&self, action: SendWelcomesAction) -> Result<(), GroupError> {
+        let welcomes = action
+            .installations
+            .into_iter()
+            .map(|installation| -> Result<WelcomeMessageInput, HpkeError> {
+                let installation_key = installation.installation_key;
+                let encrypted = encrypt_welcome(
+                    action.welcome_message.as_slice(),
+                    installation.hpke_public_key.as_slice(),
+                )?;
+
+                Ok(WelcomeMessageInput {
+                    version: Some(WelcomeMessageInputVersion::V1(WelcomeMessageInputV1 {
+                        installation_key,
+                        data: encrypted,
+                        hpke_public_key: installation.hpke_public_key,
+                    })),
+                })
+            })
+            .collect::<Result<Vec<WelcomeMessageInput>, HpkeError>>()?;
+
+        self.client
+            .api_client
+            .send_welcome_messages(welcomes)
+            .await?;
+
+        Ok(())
+    }
+}
+
+fn validate_message_sender(
+    openmls_group: &mut OpenMlsGroup,
+    decrypted_message: &ProcessedMessage,
+    message_created_ns: u64,
+) -> Result<(String, Vec<u8>), MessageProcessingError> {
+    let mut sender_account_address = None;
+    let mut sender_installation_id = None;
+    if let Sender::Member(leaf_node_index) = decrypted_message.sender() {
+        if let Some(member) = openmls_group.member_at(*leaf_node_index) {
+            if member.credential.eq(decrypted_message.credential()) {
+                sender_account_address = Identity::get_validated_account_address(
+                    member.credential.identity(),
+                    &member.signature_key,
+                )
+                .ok();
+                sender_installation_id = Some(member.signature_key);
+            }
+        }
+    }
+
+    if sender_account_address.is_none() {
+        return Err(MessageProcessingError::InvalidSender {
+            message_time_ns: message_created_ns,
+            credential: decrypted_message.credential().identity().to_vec(),
+        });
+    }
+    Ok((
+        sender_account_address.unwrap(),
+        sender_installation_id.unwrap(),
+    ))
+}

--- a/xmtp_mls/src/groups/sync.rs
+++ b/xmtp_mls/src/groups/sync.rs
@@ -183,10 +183,8 @@ where
                     );
                     conn.set_group_intent_to_publish(intent.id)?;
 
-                    return Err(MessageProcessingError::NoPendingCommit {
-                        message_epoch,
-                        group_epoch,
-                    });
+                    // Return OK here, because an error will roll back the transaction
+                    return Ok(());
                 }
                 let maybe_validated_commit = ValidatedCommit::from_staged_commit(
                     maybe_pending_commit.expect("already checked"),
@@ -197,7 +195,7 @@ where
                 if let Err(MergePendingCommitError::MlsGroupStateError(err)) =
                     openmls_group.merge_pending_commit(provider)
                 {
-                    debug!("error merging commit: {}", err);
+                    log::error!("error merging commit: {}", err);
                     openmls_group.clear_pending_commit();
                     conn.set_group_intent_to_publish(intent.id)?;
                 } else {

--- a/xmtp_mls/src/storage/encrypted_store/group_intent.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group_intent.rs
@@ -36,6 +36,7 @@ pub enum IntentState {
     ToPublish = 1,
     Published = 2,
     Committed = 3,
+    Error = 4,
 }
 
 #[derive(Queryable, Identifiable, Debug, PartialEq, Clone)]
@@ -49,6 +50,7 @@ pub struct StoredGroupIntent {
     pub state: IntentState,
     pub payload_hash: Option<Vec<u8>>,
     pub post_commit_data: Option<Vec<u8>>,
+    pub publish_attempts: i32,
 }
 
 impl_fetch!(StoredGroupIntent, group_intents, ID);
@@ -192,6 +194,24 @@ impl DbConnection<'_> {
         }
     }
 
+    // Set the intent with the given ID to `Committed`
+    pub fn set_group_intent_error(&self, intent_id: ID) -> Result<(), StorageError> {
+        let res = self.raw_query(|conn| {
+            diesel::update(dsl::group_intents)
+                .filter(dsl::id.eq(intent_id))
+                // State machine requires that the only valid state transition to Committed is from
+                // Published
+                .set(dsl::state.eq(IntentState::Error))
+                .execute(conn)
+        })?;
+
+        match res {
+            // If nothing matched the query, return an error. Either ID or state was wrong
+            0 => Err(StorageError::NotFound),
+            _ => Ok(()),
+        }
+    }
+
     // Simple lookup of intents by payload hash, meant to be used when processing messages off the
     // network
     pub fn find_group_intent_by_payload_hash(
@@ -206,6 +226,20 @@ impl DbConnection<'_> {
         })?;
 
         Ok(result)
+    }
+
+    pub fn increment_intent_publish_attempt_count(
+        &self,
+        intent_id: ID,
+    ) -> Result<(), StorageError> {
+        self.raw_query(|conn| {
+            diesel::update(dsl::group_intents)
+                .filter(dsl::id.eq(intent_id))
+                .set(dsl::publish_attempts.eq(dsl::publish_attempts + 1))
+                .execute(conn)
+        })?;
+
+        Ok(())
     }
 }
 
@@ -546,6 +580,28 @@ mod tests {
             let to_publish_result = conn.set_group_intent_to_publish(intent.id);
             assert!(to_publish_result.is_err());
             assert_eq!(to_publish_result.err().unwrap(), StorageError::NotFound);
+        })
+    }
+
+    #[test]
+    fn test_increment_publish_attempts() {
+        let group_id = rand_vec();
+        with_connection(|conn| {
+            insert_group(conn, group_id.clone());
+            NewGroupIntent::new(IntentKind::AddMembers, group_id.clone(), rand_vec())
+                .store(conn)
+                .unwrap();
+
+            let mut intent = find_first_intent(conn, group_id.clone());
+            assert_eq!(intent.publish_attempts, 0);
+            conn.increment_intent_publish_attempt_count(intent.id)
+                .unwrap();
+            intent = find_first_intent(conn, group_id.clone());
+            assert_eq!(intent.publish_attempts, 1);
+            conn.increment_intent_publish_attempt_count(intent.id)
+                .unwrap();
+            intent = find_first_intent(conn, group_id.clone());
+            assert_eq!(intent.publish_attempts, 2);
         })
     }
 }

--- a/xmtp_mls/src/storage/encrypted_store/group_intent.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group_intent.rs
@@ -84,6 +84,17 @@ impl NewGroupIntent {
 }
 
 impl DbConnection<'_> {
+    pub fn insert_group_intent(
+        &self,
+        to_save: NewGroupIntent,
+    ) -> Result<StoredGroupIntent, StorageError> {
+        Ok(self.raw_query(|conn| {
+            diesel::insert_into(dsl::group_intents)
+                .values(to_save)
+                .get_result(conn)
+        })?)
+    }
+
     // Query for group_intents by group_id, optionally filtering by state and kind
     pub fn find_group_intents(
         &self,

--- a/xmtp_mls/src/storage/encrypted_store/schema.rs
+++ b/xmtp_mls/src/storage/encrypted_store/schema.rs
@@ -9,6 +9,7 @@ diesel::table! {
         state -> Integer,
         payload_hash -> Nullable<Binary>,
         post_commit_data -> Nullable<Binary>,
+        publish_attempts -> Integer,
     }
 }
 

--- a/xmtp_mls/src/utils/address.rs
+++ b/xmtp_mls/src/utils/address.rs
@@ -1,0 +1,28 @@
+use thiserror::Error;
+use xmtp_cryptography::signature::is_valid_ethereum_address;
+
+#[derive(Debug, Error)]
+pub enum AddressValidationError {
+    #[error("invalid addresses: {0:?}")]
+    InvalidAddresses(Vec<String>),
+}
+
+pub fn sanitize_evm_addresses(
+    account_addresses: Vec<String>,
+) -> Result<Vec<String>, AddressValidationError> {
+    let mut invalid = account_addresses
+        .iter()
+        .filter(|a| !is_valid_ethereum_address(a))
+        .peekable();
+
+    if invalid.peek().is_some() {
+        return Err(AddressValidationError::InvalidAddresses(
+            invalid.map(ToString::to_string).collect::<Vec<_>>(),
+        ));
+    }
+
+    Ok(account_addresses
+        .iter()
+        .map(|address| address.to_lowercase())
+        .collect())
+}

--- a/xmtp_mls/src/utils/mod.rs
+++ b/xmtp_mls/src/utils/mod.rs
@@ -1,3 +1,4 @@
+pub mod address;
 pub mod hash;
 pub mod id;
 #[cfg(test)]


### PR DESCRIPTION
## Summary

This crosses off several todos in the group syncing protocol to make it more closely match the initial state machine designs.

1. When adding/removing members or doing a key update we now will retry the entire sync flow up to 3 times, waiting for the intent to be resolved. This helps handle cases where the intent cannot be successfully published until the receive flow has been run. This can happen when the MLS group has a pending commit, which will block any add/remove operations until the pending commit is resolved. This also helps handle cases where the local epoch is behind the remote epoch. Previously these issues would only be fixed the next time `sync()` was run
2. We now correctly return errors when adding/removing members fails
3. We now lowercase all wallet addresses that have been input from outside callers (for example in `add_members` or `remove_members`)
4. If an intent fails to be published through 3 successive iterations of sync, we move it to a state of "Error" which will prevent it from blocking future publishes
5. Moves all the synchronization code to a separate file, since `groups/mod.rs` was getting quite unwieldy