### PR TITLE
Replace close with end

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -397,7 +397,7 @@ pub struct FfiMessageStreamCloser {
 
 #[uniffi::export]
 impl FfiMessageStreamCloser {
-    pub fn close(&self) {
+    pub fn end(&self) {
         match self.close_fn.lock() {
             Ok(mut close_fn_option) => {
                 let _ = close_fn_option.take().map(|close_fn| close_fn.send(()));

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -397,7 +397,7 @@ pub struct FfiMessageStreamCloser {
 
 #[uniffi::export]
 impl FfiMessageStreamCloser {
-    pub fn closeStream(&self) {
+    pub fn close_stream(&self) {
         match self.close_fn.lock() {
             Ok(mut close_fn_option) => {
                 let _ = close_fn_option.take().map(|close_fn| close_fn.send(()));

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -397,7 +397,7 @@ pub struct FfiMessageStreamCloser {
 
 #[uniffi::export]
 impl FfiMessageStreamCloser {
-    pub fn end(&self) {
+    pub fn closeStream(&self) {
         match self.close_fn.lock() {
             Ok(mut close_fn_option) => {
                 let _ = close_fn_option.take().map(|close_fn| close_fn.send(()));

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -397,7 +397,7 @@ pub struct FfiMessageStreamCloser {
 
 #[uniffi::export]
 impl FfiMessageStreamCloser {
-    pub fn close_stream(&self) {
+    pub fn end(&self) {
         match self.close_fn.lock() {
             Ok(mut close_fn_option) => {
                 let _ = close_fn_option.take().map(|close_fn| close_fn.send(()));


### PR DESCRIPTION
## Summary

The Uniffi generated code adds a magic `close` function to generated Kotlin code. This conflicts with the `close` function on one of our types. Renamed to `end` to avoid conflicts.