### PR TITLE
Deploy Rust Docs to GH Pages

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -37,13 +37,6 @@ jobs:
           profile: minimal
           override: true
 
-      - name: Run tests
-        env:
-          CARGO_INCREMENTAL: 0
-        run: |
-          cargo test
-        id: test
-
       - name: Invoke cargo doc
         run: |
           rm -rf ./_site

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -38,14 +38,7 @@ jobs:
           override: true
 
       - name: Invoke cargo doc
-        run: |
-          rm -rf ./_site
-          cargo doc --workspace --no-deps
-          rm -f target/doc/.lock
-          cp -r target/doc _site
-          echo "generating site index"
-          echo "<meta http-equiv=\"refresh\" content=\"0; url=xmtp_mls/index.html\">" > site/index.html
-          chmod -R +rX _site
+        run: ./dev/docs
         id: docgen
 
       - name: Upload artifact

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -2,7 +2,7 @@ name: GitHub Pages
 
 on:
   push:
-    branches: ["main", "nm/gh-pages"]
+    branches: ["main"]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -51,7 +51,7 @@ jobs:
           rm -f target/doc/.lock
           cp -r target/doc _site
           echo "generating site index"
-          echo "<meta http-equiv=\"refresh\" content=\"0; url=xmtp_mls/index.html\">" > target/doc/index.html
+          echo "<meta http-equiv=\"refresh\" content=\"0; url=xmtp_mls/index.html\">" > site/index.html
           chmod -R +rX _site
         id: docgen
 

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,71 @@
+name: GitHub Pages
+
+on:
+  push:
+    branches: ["main", "nm/gh-pages"]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "github-pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+      - uses: actions/setup-python@v2
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - name: Run tests
+        env:
+          CARGO_INCREMENTAL: 0
+        run: |
+          cargo test
+        id: test
+
+      - name: Invoke cargo doc
+        run: |
+          rm -rf ./_site
+          cargo doc --workspace --no-deps
+          rm -f target/doc/.lock
+          cp -r target/doc _site
+          echo "generating site index"
+          echo "<meta http-equiv=\"refresh\" content=\"0; url=xmtp_mls/index.html\">" > target/doc/index.html
+          chmod -R +rX _site
+        id: docgen
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v3

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -28,7 +28,6 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v2
-      - uses: actions/setup-python@v2
 
       - name: Install rust
         uses: actions-rs/toolchain@v1

--- a/.gitignore
+++ b/.gitignore
@@ -141,5 +141,7 @@ dist
 # JAR files
 *.jar
 
+_site
+
 # Generated Uniffi definitions
 xmtpv3.kt

--- a/dev/docs
+++ b/dev/docs
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -eou pipefail
+
+rm -rf ./_site
+cargo doc --workspace --no-deps
+rm -f target/doc/.lock
+cp -r target/doc _site
+echo "generating site index"
+echo "<meta http-equiv=\"refresh\" content=\"0; url=xmtp_mls/index.html\">" > _site/index.html
+chmod -R +rX _site

--- a/dev/docs
+++ b/dev/docs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eou pipefail
 
 rm -rf ./_site

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -1,24 +1,3 @@
-use std::{collections::HashSet, mem::Discriminant};
-
-// use futures::{Stream, StreamExt};
-use openmls::{
-    framing::{MlsMessageIn, MlsMessageInBody},
-    group::GroupEpoch,
-    messages::Welcome,
-    prelude::TlsSerializeTrait,
-};
-use openmls_traits::OpenMlsProvider;
-use prost::EncodeError;
-use thiserror::Error;
-use tls_codec::{Deserialize, Error as TlsSerializationError};
-use xmtp_proto::{
-    api_client::XmtpMlsClient,
-    xmtp::mls::api::v1::{
-        welcome_message::{Version as WelcomeMessageVersion, V1 as WelcomeMessageV1},
-        GroupMessage, WelcomeMessage,
-    },
-};
-
 use crate::{
     api_client_wrapper::{ApiClientWrapper, IdentityUpdate},
     groups::{
@@ -37,7 +16,26 @@ use crate::{
     xmtp_openmls_provider::XmtpOpenMlsProvider,
     Fetch,
 };
+use openmls::{
+    framing::{MlsMessageIn, MlsMessageInBody},
+    group::GroupEpoch,
+    messages::Welcome,
+    prelude::TlsSerializeTrait,
+};
+use openmls_traits::OpenMlsProvider;
+use prost::EncodeError;
+use std::{collections::HashSet, mem::Discriminant};
+use thiserror::Error;
+use tls_codec::{Deserialize, Error as TlsSerializationError};
+use xmtp_proto::{
+    api_client::XmtpMlsClient,
+    xmtp::mls::api::v1::{
+        welcome_message::{Version as WelcomeMessageVersion, V1 as WelcomeMessageV1},
+        GroupMessage, WelcomeMessage,
+    },
+};
 
+/// Which network the Client is connected to
 #[derive(Clone, Copy, Default, Debug)]
 pub enum Network {
     Local(&'static str),
@@ -68,6 +66,7 @@ pub enum ClientError {
     Generic(String),
 }
 
+/// An enum of errors that can occur when reading and processing a message off the network
 #[derive(Debug, Error)]
 pub enum MessageProcessingError {
     #[error("[{0}] already processed")]
@@ -135,6 +134,7 @@ impl From<&str> for ClientError {
     }
 }
 
+/// Clients manage access to the network, identity, and data store
 #[derive(Debug)]
 pub struct Client<ApiClient> {
     pub(crate) api_client: ApiClientWrapper<ApiClient>,
@@ -147,6 +147,9 @@ impl<'a, ApiClient> Client<ApiClient>
 where
     ApiClient: XmtpMlsClient,
 {
+    /// Create a new client with the given network, identity, and store.
+    /// It is expected that most users will use the [`ClientBuilder`](crate::builder::ClientBuilder) instead of instantiating
+    /// a client directly.
     pub fn new(
         api_client: ApiClient,
         network: Network,
@@ -161,23 +164,28 @@ where
         }
     }
 
+    /// Get the account address of the blockchain account associated with this client
     pub fn account_address(&self) -> Address {
         self.identity.account_address.clone()
     }
 
+    /// The installation public key is the primary identifier for an installation
     pub fn installation_public_key(&self) -> Vec<u8> {
         self.identity.installation_keys.to_public_vec()
     }
 
+    /// In some cases, the client may need a signature from the wallet to call [`register_identity`](Self::register_identity).
+    /// Integrators should always check the `text_to_sign` return value of this function before calling [`register_identity_with_external_signature`](Self::register_identity_with_external_signature).
+    /// If `text_to_sign` returns `None`, then the wallet signature is not required and [`register_identity_with_external_signature`](Self::register_identity_with_external_signature) can be called with None as an argument.
     pub fn text_to_sign(&self) -> Option<String> {
         self.identity.text_to_sign()
     }
 
-    // TODO: Remove this and figure out the correct lifetimes to allow long lived provider
     pub(crate) fn mls_provider(&self, conn: &'a DbConnection<'a>) -> XmtpOpenMlsProvider<'a> {
         XmtpOpenMlsProvider::<'a>::new(conn)
     }
 
+    /// Create a new group with the default settings
     pub fn create_group(&self) -> Result<MlsGroup<ApiClient>, ClientError> {
         log::info!("creating group");
 
@@ -187,6 +195,8 @@ where
         Ok(group)
     }
 
+    /// Look up a group by its ID
+    /// Returns a [`MlsGroup`](crate::groups::MlsGroup) if the group exists, or an error if it does not
     pub fn group(&self, group_id: Vec<u8>) -> Result<MlsGroup<ApiClient>, ClientError> {
         let conn = &mut self.store.conn()?;
         let stored_group: Option<StoredGroup> = conn.fetch(&group_id)?;
@@ -196,6 +206,13 @@ where
         }
     }
 
+    /// Query for groups with optional filters
+    ///
+    /// Filters:
+    /// - allowed_states: only return groups with the given membership states
+    /// - created_after_ns: only return groups created after the given timestamp (in nanoseconds)
+    /// - created_before_ns: only return groups created before the given timestamp (in nanoseconds)
+    /// - limit: only return the first `limit` groups
     pub fn find_groups(
         &self,
         allowed_states: Option<Vec<GroupMembershipState>>,
@@ -212,11 +229,18 @@ where
             .collect())
     }
 
+    /// Deprecated
     pub async fn register_identity(&self) -> Result<(), ClientError> {
         self.register_identity_with_external_signature(None).await?;
         Ok(())
     }
 
+    /// Register the identity with the network
+    /// Callers should always call [`text_to_sign`](Self::text_to_sign) before calling this function.
+    ///
+    /// If `text_to_sign` returns `None`, then the wallet signature is not required and this function can be called with `None`.
+    ///
+    /// If `text_to_sign` returns `Some`, then the caller should sign the text with their wallet and pass the signature to this function.
     pub async fn register_identity_with_external_signature(
         &self,
         recoverable_wallet_signature: Option<Vec<u8>>,
@@ -230,6 +254,8 @@ where
         Ok(())
     }
 
+    /// Upload a new key package to the network replacing an existing key package
+    /// This is expected to be run any time the client receives new Welcome messages
     pub async fn rotate_key_package(&self) -> Result<(), ClientError> {
         let connection = self.store.conn()?;
         let kp = self
@@ -242,6 +268,8 @@ where
         Ok(())
     }
 
+    /// Get a list of `installation_id`s associated with the given `account_addresses`
+    /// One `account_address` may have multiple `installation_id`s if the account has multiple applications or devices on the network
     pub async fn get_all_active_installation_ids(
         &self,
         account_addresses: Vec<String>,
@@ -370,8 +398,8 @@ where
             .collect::<Result<_, _>>()?)
     }
 
-    // Download all unread welcome messages and convert to groups.
-    // Returns any new groups created in the operation
+    /// Download all unread welcome messages and convert to groups.
+    /// Returns any new groups created in the operation
     pub async fn sync_welcomes(&self) -> Result<Vec<MlsGroup<ApiClient>>, ClientError> {
         let envelopes = self.query_welcome_messages(&self.store.conn()?).await?;
         let id = self.installation_public_key();
@@ -409,6 +437,13 @@ where
         Ok(groups)
     }
 
+    /// Check whether an account_address has a key package registered on the network
+    ///
+    /// Arguments:
+    /// - account_addresses: a list of account addresses to check
+    ///
+    /// Returns:
+    /// A Vec of booleans indicating whether each account address has a key package registered on the network
     pub async fn can_message(
         &self,
         account_addresses: Vec<String>,

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -236,7 +236,7 @@ where
     }
 
     /// Register the identity with the network
-    /// Callers should always call [`text_to_sign`](Self::text_to_sign) before calling this function.
+    /// Callers should always check the result of [`text_to_sign`](Self::text_to_sign) before invoking this function.
     ///
     /// If `text_to_sign` returns `None`, then the wallet signature is not required and this function can be called with `None`.
     ///

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -196,7 +196,7 @@ where
     }
 
     /// Look up a group by its ID
-    /// Returns a [`MlsGroup`](crate::groups::MlsGroup) if the group exists, or an error if it does not
+    /// Returns a [`MlsGroup`] if the group exists, or an error if it does not
     pub fn group(&self, group_id: Vec<u8>) -> Result<MlsGroup<ApiClient>, ClientError> {
         let conn = &mut self.store.conn()?;
         let stored_group: Option<StoredGroup> = conn.fetch(&group_id)?;

--- a/xmtp_mls/src/identity.rs
+++ b/xmtp_mls/src/identity.rs
@@ -132,7 +132,7 @@ impl Identity {
         }
 
         // Register the installation with the server
-        let kp = self.new_key_package(&provider)?;
+        let kp = self.new_key_package(provider)?;
         let kp_bytes = kp.tls_serialize_detached()?;
         api_client.register_installation(kp_bytes).await?;
 

--- a/xmtp_mls/src/storage/sql_key_store.rs
+++ b/xmtp_mls/src/storage/sql_key_store.rs
@@ -8,7 +8,7 @@ use super::{
 };
 use crate::{Delete, Fetch};
 
-/// CRUD Operations for an [`EncryptedMessageStore`]
+/// CRUD Operations for an [`OpenMlsKeyStore`]
 #[derive(Debug)]
 pub struct SqlKeyStore<'a> {
     conn: &'a DbConnection<'a>,
@@ -28,7 +28,7 @@ impl OpenMlsKeyStore for SqlKeyStore<'_> {
     /// The error type returned by the [`OpenMlsKeyStore`].
     type Error = StorageError;
 
-    /// Store a value `v` that implements the [`ToKeyStoreValue`] trait for
+    /// Store a value `v` that implements the [`MlsEntity`] trait for
     /// serialization for ID `k`.
     ///
     /// Returns an error if storing fails.
@@ -39,7 +39,7 @@ impl OpenMlsKeyStore for SqlKeyStore<'_> {
     }
 
     /// Read and return a value stored for ID `k` that implements the
-    /// [`FromKeyStoreValue`] trait for deserialization.
+    /// [`MlsEntity`] trait for deserialization.
     ///
     /// Returns [`None`] if no value is stored for `k` or reading fails.
     fn read<V: MlsEntity>(&self, k: &[u8]) -> Option<V> {

--- a/xmtp_v2/src/k256_helper.rs
+++ b/xmtp_v2/src/k256_helper.rs
@@ -9,7 +9,9 @@ use sha3::Keccak256;
 /// diffie_hellman - compute the shared secret between a secret key and a public key
 /// NOTE: This is a custom implementation of the diffie_hellman operation
 /// because RustCrypto hides the `y` coordinate from visibility when constructing a SharedSecret.
-/// https://github.com/RustCrypto/traits/blob/d57b54b9fcf5b28745547cb9fef313ab09780918/elliptic-curve/src/ecdh.rs#L60
+
+/// [Read more](https://github.com/RustCrypto/traits/blob/d57b54b9fcf5b28745547cb9fef313ab09780918/elliptic-curve/src/ecdh.rs#L60)
+
 /// XMTP uses the entire point in uncompressed format as secret material
 fn diffie_hellman(secret_key: &SecretKey, public_key: &PublicKey) -> Result<Vec<u8>, String> {
     // Get the public projective point from the public key


### PR DESCRIPTION
## Summary

Sets up RustDoc publishing to Github Pages. Adds some docs for `Client` (with many more to follow).