### PR TITLE
Add back streaming methods

### DIFF
--- a/bindings_ffi/Cargo.toml
+++ b/bindings_ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
+edition = "2021"
 name = "xmtpv3"
 version = "0.1.0"
-edition = "2021"
 
 [lib]
 crate-type = ["lib", "cdylib"]
@@ -11,22 +11,17 @@ futures = "0.3.28"
 log = { version = "0.4", features = ["std"] }
 thiserror = "1.0.56"
 tokio = { version = "1.28.1", features = ["macros"] }
-uniffi = { version = "0.25.3", features = [
-  "tokio",
-  "cli",
-] }
+uniffi = { version = "0.25.3", features = ["tokio", "cli"] }
 uniffi_macros = "0.25.3"
 xmtp_api_grpc = { path = "../xmtp_api_grpc" }
 xmtp_cryptography = { path = "../xmtp_cryptography" }
 xmtp_mls = { path = "../xmtp_mls", features = ["grpc", "native"] }
-xmtp_proto = { path = "../xmtp_proto", features = ["proto_full", "grpc"]}
+xmtp_proto = { path = "../xmtp_proto", features = ["proto_full", "grpc"] }
 xmtp_user_preferences = { path = "../xmtp_user_preferences" }
 xmtp_v2 = { path = "../xmtp_v2" }
 
 [build-dependencies]
-uniffi = { version = "0.25.3", features = [
-  "build",
-] }
+uniffi = { version = "0.25.3", features = ["build"] }
 
 [[bin]]
 name = "ffi-uniffi-bindgen"
@@ -37,15 +32,13 @@ ethers = "2.0.4"
 ethers-core = "2.0.4"
 tempfile = "3.5.0"
 tokio = { version = "1.28.1", features = ["full"] }
-uniffi = { version = "0.25.3", features = [
-  "bindgen-tests",
-] }
+uniffi = { version = "0.25.3", features = ["bindgen-tests"] }
 
 # NOTE: The release profile reduces bundle size from 230M to 41M - may have performance impliciations
 # https://stackoverflow.com/a/54842093
 [profile.release]
-opt-level = 'z'   # Optimize for size
-lto = true        # Enable link-time optimization
 codegen-units = 1 # Reduce number of codegen units to increase optimizations
+lto = true        # Enable link-time optimization
+opt-level = 'z'   # Optimize for size
 panic = 'abort'   # Abort on panic
 strip = true      # Strip symbols from binary*

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -210,6 +210,42 @@ impl FfiConversations {
 
         Ok(convo_list)
     }
+
+    pub async fn stream(
+        &self,
+        callback: Box<dyn FfiConversationCallback>,
+    ) -> Result<Arc<FfiStreamCloser>, GenericError> {
+        let inner_client = Arc::clone(&self.inner_client);
+        let (close_sender, close_receiver) = oneshot::channel::<()>();
+
+        tokio::spawn(async move {
+            let client = inner_client.as_ref();
+            let mut stream = client.stream_conversations().await.unwrap();
+            let mut close_receiver = close_receiver;
+            loop {
+                tokio::select! {
+                    item = stream.next() => {
+                        match item {
+                            Some(convo) => callback.on_conversation(Arc::new(FfiGroup {
+                                inner_client: inner_client.clone(),
+                                group_id: convo.group_id,
+                                created_at_ns: convo.created_at_ns,
+                            })),
+                            None => break
+                        }
+                    }
+                    _ = &mut close_receiver => {
+                        break;
+                    }
+                }
+            }
+            log::info!("closing stream");
+        });
+
+        Ok(Arc::new(FfiStreamCloser {
+            close_fn: Arc::new(Mutex::new(Some(close_sender))),
+        }))
+    }
 }
 
 #[derive(uniffi::Object)]
@@ -325,7 +361,7 @@ impl FfiGroup {
     pub async fn stream(
         &self,
         message_callback: Box<dyn FfiMessageCallback>,
-    ) -> Result<Arc<FfiMessageStreamCloser>, GenericError> {
+    ) -> Result<Arc<FfiStreamCloser>, GenericError> {
         let inner_client = Arc::clone(&self.inner_client);
         let group_id = self.group_id.clone();
         let created_at_ns = self.created_at_ns;
@@ -349,10 +385,10 @@ impl FfiGroup {
                     }
                 }
             }
-            println!("closing stream");
+            log::info!("closing stream");
         });
 
-        Ok(Arc::new(FfiMessageStreamCloser {
+        Ok(Arc::new(FfiStreamCloser {
             close_fn: Arc::new(Mutex::new(Some(close_sender))),
         }))
     }
@@ -369,7 +405,7 @@ impl FfiGroup {
     }
 }
 
-// #[derive(uniffi::Record)]
+#[derive(uniffi::Record)]
 pub struct FfiMessage {
     pub id: Vec<u8>,
     pub sent_at_ns: i64,
@@ -391,12 +427,12 @@ impl From<StoredGroupMessage> for FfiMessage {
 }
 
 #[derive(uniffi::Object)]
-pub struct FfiMessageStreamCloser {
+pub struct FfiStreamCloser {
     close_fn: Arc<Mutex<Option<Sender<()>>>>,
 }
 
 #[uniffi::export]
-impl FfiMessageStreamCloser {
+impl FfiStreamCloser {
     pub fn end(&self) {
         match self.close_fn.lock() {
             Ok(mut close_fn_option) => {
@@ -409,14 +445,21 @@ impl FfiMessageStreamCloser {
     }
 }
 
+#[uniffi::export(callback_interface)]
 pub trait FfiMessageCallback: Send + Sync {
     fn on_message(&self, message: FfiMessage);
+}
+
+#[uniffi::export(callback_interface)]
+pub trait FfiConversationCallback: Send + Sync {
+    fn on_conversation(&self, conversation: Arc<FfiGroup>);
 }
 
 #[cfg(test)]
 mod tests {
     use crate::{
-        inbox_owner::SigningError, logger::FfiLogger, FfiInboxOwner, LegacyIdentitySource,
+        inbox_owner::SigningError, logger::FfiLogger, FfiConversationCallback, FfiInboxOwner,
+        LegacyIdentitySource,
     };
     use std::{
         env,
@@ -461,15 +504,17 @@ mod tests {
     pub struct MockLogger {}
 
     impl FfiLogger for MockLogger {
-        fn log(&self, _level: u32, _level_label: String, _message: String) {}
+        fn log(&self, _level: u32, level_label: String, message: String) {
+            println!("{}: {}", level_label, message)
+        }
     }
 
     #[derive(Clone)]
-    struct RustMessageCallback {
+    struct RustStreamCallback {
         num_messages: Arc<Mutex<u32>>,
     }
 
-    impl RustMessageCallback {
+    impl RustStreamCallback {
         pub fn new() -> Self {
             Self {
                 num_messages: Arc::new(Mutex::new(0)),
@@ -481,8 +526,14 @@ mod tests {
         }
     }
 
-    impl FfiMessageCallback for RustMessageCallback {
+    impl FfiMessageCallback for RustStreamCallback {
         fn on_message(&self, _: FfiMessage) {
+            *self.num_messages.lock().unwrap() += 1;
+        }
+    }
+
+    impl FfiConversationCallback for RustStreamCallback {
+        fn on_conversation(&self, _: Arc<super::FfiGroup>) {
             *self.num_messages.lock().unwrap() += 1;
         }
     }
@@ -660,36 +711,69 @@ mod tests {
         assert!(client.register_identity(Some(signature)).await.is_err());
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
+    async fn test_conversation_streaming() {
+        let amal = new_test_client().await;
+        let bola = new_test_client().await;
+
+        let stream_callback = RustStreamCallback::new();
+
+        let stream = bola
+            .conversations()
+            .stream(Box::new(stream_callback.clone()))
+            .await
+            .unwrap();
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        amal.conversations()
+            .create_group(vec![bola.account_address()])
+            .await
+            .unwrap();
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        assert_eq!(stream_callback.message_count(), 1);
+        // Create another group and add bola
+        amal.conversations()
+            .create_group(vec![bola.account_address()])
+            .await
+            .unwrap();
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        assert_eq!(stream_callback.message_count(), 2);
+
+        stream.end();
+    }
+
     // Disabling this flakey test until it's reliable
-    // #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
-    // async fn test_streaming() {
-    //     let amal = new_test_client().await;
-    //     let bola = new_test_client().await;
+    #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
+    async fn test_streaming() {
+        let amal = new_test_client().await;
+        let bola = new_test_client().await;
 
-    //     let group = amal
-    //         .conversations()
-    //         .create_group(bola.account_address())
-    //         .await
-    //         .unwrap();
+        let group = amal
+            .conversations()
+            .create_group(vec![bola.account_address()])
+            .await
+            .unwrap();
 
-    //     let message_callback = RustMessageCallback::new();
-    //     let stream_closer = group
-    //         .stream(Box::new(message_callback.clone()))
-    //         .await
-    //         .unwrap();
+        let stream_callback = RustStreamCallback::new();
+        let stream_closer = group
+            .stream(Box::new(stream_callback.clone()))
+            .await
+            .unwrap();
 
-    //     tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
-    //     group.send("hello".as_bytes().to_vec()).await.unwrap();
-    //     tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-    //     group.send("goodbye".as_bytes().to_vec()).await.unwrap();
-    //     // Because of the event loop, I need to make the test give control
-    //     // back to the stream before it can process each message. Using sleep to do that.
-    //     // I think this will work fine in practice
-    //     tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
-    //     assert_eq!(message_callback.message_count(), 2);
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        group.send("hello".as_bytes().to_vec()).await.unwrap();
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        group.send("goodbye".as_bytes().to_vec()).await.unwrap();
+        // Because of the event loop, I need to make the test give control
+        // back to the stream before it can process each message. Using sleep to do that.
+        // I think this will work fine in practice
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        assert_eq!(stream_callback.message_count(), 2);
 
-    //     stream_closer.close();
-    //     // Make sure nothing panics calling `close` twice
-    //     stream_closer.close();
-    // }
+        stream_closer.end();
+    }
 }

--- a/bindings_ffi/src/xmtpv3.udl
+++ b/bindings_ffi/src/xmtpv3.udl
@@ -16,15 +16,3 @@ callback interface FfiInboxOwner {
 callback interface FfiLogger {
     void log(u32 level, string level_label, string message);
 };
-
-callback interface FfiMessageCallback {
-  void on_message(FfiMessage message);
-};
-
-dictionary FfiMessage {
-  bytes id;
-  i64 sent_at_ns;
-  bytes convo_id;
-  string addr_from;
-  bytes content;
-};

--- a/xmtp_mls/src/api_client_wrapper.rs
+++ b/xmtp_mls/src/api_client_wrapper.rs
@@ -2,16 +2,19 @@ use std::collections::HashMap;
 
 use crate::{retry::Retry, retry_async};
 use xmtp_proto::{
-    api_client::{Error as ApiError, ErrorKind, GroupMessageStream, XmtpMlsClient},
+    api_client::{
+        Error as ApiError, ErrorKind, GroupMessageStream, WelcomeMessageStream, XmtpMlsClient,
+    },
     xmtp::mls::api::v1::{
         get_identity_updates_response::update::Kind as UpdateKind,
         group_message_input::{Version as GroupMessageInputVersion, V1 as GroupMessageInputV1},
         subscribe_group_messages_request::Filter as GroupFilterProto,
+        subscribe_welcome_messages_request::Filter as WelcomeFilterProto,
         FetchKeyPackagesRequest, GetIdentityUpdatesRequest, GroupMessage, GroupMessageInput,
         KeyPackageUpload, PagingInfo, QueryGroupMessagesRequest, QueryWelcomeMessagesRequest,
         RegisterInstallationRequest, SendGroupMessagesRequest, SendWelcomeMessagesRequest,
-        SortDirection, SubscribeGroupMessagesRequest, UploadKeyPackageRequest, WelcomeMessage,
-        WelcomeMessageInput,
+        SortDirection, SubscribeGroupMessagesRequest, SubscribeWelcomeMessagesRequest,
+        UploadKeyPackageRequest, WelcomeMessage, WelcomeMessageInput,
     },
 };
 
@@ -319,6 +322,21 @@ where
         self.api_client
             .subscribe_group_messages(SubscribeGroupMessagesRequest {
                 filters: filters.into_iter().map(|f| f.into()).collect(),
+            })
+            .await
+    }
+
+    pub async fn subscribe_welcome_messages(
+        &self,
+        installation_key: Vec<u8>,
+        id_cursor: Option<u64>,
+    ) -> Result<WelcomeMessageStream, ApiError> {
+        self.api_client
+            .subscribe_welcome_messages(SubscribeWelcomeMessagesRequest {
+                filters: vec![WelcomeFilterProto {
+                    installation_key,
+                    id_cursor: id_cursor.unwrap_or(0),
+                }],
             })
             .await
     }

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -16,6 +16,7 @@ use crate::{
     xmtp_openmls_provider::XmtpOpenMlsProvider,
     Fetch,
 };
+use futures::{Stream, StreamExt};
 use openmls::{
     framing::{MlsMessageIn, MlsMessageInBody},
     group::GroupEpoch,
@@ -24,7 +25,7 @@ use openmls::{
 };
 use openmls_traits::OpenMlsProvider;
 use prost::EncodeError;
-use std::{collections::HashSet, mem::Discriminant};
+use std::{collections::HashSet, mem::Discriminant, pin::Pin};
 use thiserror::Error;
 use tls_codec::{Deserialize, Error as TlsSerializationError};
 use xmtp_proto::{
@@ -464,39 +465,54 @@ where
             .collect())
     }
 
-    // fn process_streamed_welcome(
-    //     &self,
-    //     envelope: Envelope,
-    // ) -> Result<MlsGroup<ApiClient>, ClientError> {
-    //     let welcome = extract_welcome(&envelope.message)?;
-    //     let conn = self.store.conn()?;
-    //     let provider = self.mls_provider(&conn);
-    //     Ok(MlsGroup::create_from_welcome(self, &provider, welcome)
-    //         .map_err(|e| ClientError::Generic(e.to_string()))?)
-    // }
+    fn process_streamed_welcome(
+        &self,
+        welcome: WelcomeMessage,
+    ) -> Result<MlsGroup<ApiClient>, ClientError> {
+        let welcome_v1 = extract_welcome_message(welcome)?;
+        let conn = self.store.conn()?;
+        let provider = self.mls_provider(&conn);
 
-    // pub async fn stream_conversations(
-    //     &'a self,
-    // ) -> Result<Pin<Box<dyn Stream<Item = MlsGroup<ApiClient>> + 'a>>, ClientError> {
-    //     let welcome_topic = get_welcome_topic(&self.installation_public_key());
-    //     let subscription = self.api_client.subscribe(vec![welcome_topic]).await?;
-    //     let stream = subscription
-    //         .map(|envelope_result| async {
-    //             let envelope = envelope_result?;
-    //             self.process_streamed_welcome(envelope)
-    //         })
-    //         .filter_map(|res| async {
-    //             match res.await {
-    //                 Ok(group) => Some(group),
-    //                 Err(err) => {
-    //                     log::error!("Error processing stream entry: {:?}", err);
-    //                     None
-    //                 }
-    //             }
-    //         });
+        Ok(MlsGroup::create_from_encrypted_welcome(
+            self,
+            &provider,
+            welcome_v1.hpke_public_key.as_slice(),
+            welcome_v1.data,
+        )
+        .map_err(|e| ClientError::Generic(e.to_string()))?)
+    }
 
-    //     Ok(Box::pin(stream))
-    // }
+    pub async fn stream_conversations(
+        &'a self,
+    ) -> Result<Pin<Box<dyn Stream<Item = MlsGroup<ApiClient>> + Send + 'a>>, ClientError> {
+        let installation_key = self.installation_public_key();
+        let id_cursor = self
+            .store
+            .conn()?
+            .get_last_cursor_for_id(&installation_key, EntityKind::Welcome)?;
+
+        let subscription = self
+            .api_client
+            .subscribe_welcome_messages(installation_key, Some(id_cursor as u64))
+            .await?;
+
+        let stream = subscription
+            .map(|welcome_result| async {
+                let welcome = welcome_result?;
+                self.process_streamed_welcome(welcome)
+            })
+            .filter_map(|res| async {
+                match res.await {
+                    Ok(group) => Some(group),
+                    Err(err) => {
+                        log::error!("Error processing stream entry: {:?}", err);
+                        None
+                    }
+                }
+            });
+
+        Ok(Box::pin(stream))
+    }
 }
 
 fn extract_welcome_message(welcome: WelcomeMessage) -> Result<WelcomeMessageV1, ClientError> {
@@ -534,6 +550,7 @@ fn has_active_installation(updates: &Vec<IdentityUpdate>) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use futures::StreamExt;
     use xmtp_cryptography::utils::generate_local_wallet;
 
     use crate::{
@@ -722,20 +739,21 @@ mod tests {
         )
     }
 
-    // #[tokio::test]
-    // async fn test_stream_welcomes() {
-    //     let alice = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
-    //     let bob = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
-    //     bob.register_identity().await.unwrap();
+    #[tokio::test]
+    async fn test_stream_welcomes() {
+        let alice = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
+        let bob = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
+        bob.register_identity().await.unwrap();
 
-    //     let alice_bob_group = alice.create_group().unwrap();
+        let alice_bob_group = alice.create_group().unwrap();
 
-    //     let mut bob_stream = bob.stream_conversations().await.unwrap();
-    //     alice_bob_group
-    //         .add_members_by_installation_id(vec![bob.installation_public_key()])
-    //         .await
-    //         .unwrap();
-    //     let bob_received_groups = bob_stream.next().await.unwrap();
-    //     assert_eq!(bob_received_groups.group_id, alice_bob_group.group_id);
-    // }
+        let mut bob_stream = bob.stream_conversations().await.unwrap();
+        alice_bob_group
+            .add_members(vec![bob.account_address()])
+            .await
+            .unwrap();
+
+        let bob_received_groups = bob_stream.next().await.unwrap();
+        assert_eq!(bob_received_groups.group_id, alice_bob_group.group_id);
+    }
 }

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -473,13 +473,13 @@ where
         let conn = self.store.conn()?;
         let provider = self.mls_provider(&conn);
 
-        Ok(MlsGroup::create_from_encrypted_welcome(
+        MlsGroup::create_from_encrypted_welcome(
             self,
             &provider,
             welcome_v1.hpke_public_key.as_slice(),
             welcome_v1.data,
         )
-        .map_err(|e| ClientError::Generic(e.to_string()))?)
+        .map_err(|e| ClientError::Generic(e.to_string()))
     }
 
     pub async fn stream_conversations(


### PR DESCRIPTION
## Summary

- Adds back conversation streaming to both the SDK and the bindings
- Replaces some interfaces defined in the UDL with `procmacro` implementations. This didn't work before, but now that we are on the latest uniffi seems to be fine.
- Renamed `MessageStreamCloser` to `StreamCloser` so that it can be used for both conversation streams and message streams.