### PR TITLE
Release swift bindings

### DIFF
--- a/.github/workflows/release_swift_bindings.yml
+++ b/.github/workflows/release_swift_bindings.yml
@@ -1,11 +1,7 @@
 name: Release Swift Bindings
 
 on:
-  push:
-    branches:
-      - main
-      - nm/staticlib
-      - cv/release-swift-bindings
+  workflow_dispatch:
 
 jobs:
   build-macos:
@@ -106,7 +102,6 @@ jobs:
           mkdir -p Sources/LibXMTP
           mv build/swift/xmtpv3.swift Sources/LibXMTP/
           make framework
-          ls -la ../
           cp ../LICENSE ./LICENSE
           zip -r LibXMTPSwiftFFI.zip Sources LibXMTPRust.xcframework LICENSE
 
@@ -126,8 +121,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: test-swift-bindings-${{ steps.slug.outputs.sha7 }}
-          release_name: Test-Swift-Bindings-${{ steps.slug.outputs.sha7 }}
+          tag_name: swift-bindings-${{ steps.slug.outputs.sha7 }}
+          release_name: Swift-Bindings-${{ steps.slug.outputs.sha7 }}
           body: "Checksum of LibXMTPSwiftFFI.zip: ${{ steps.checksum.outputs.checksum }}"
           draft: false
           prerelease: true

--- a/.github/workflows/release_swift_bindings.yml
+++ b/.github/workflows/release_swift_bindings.yml
@@ -118,8 +118,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release-Swift-Bindings-${{ steps.slug.outputs.sha7 }}
+          tag_name: test-swift-bindings-${{ github.ref }}
+          release_name: Test-Swift-Bindings-${{ steps.slug.outputs.sha7 }}
           draft: false
           prerelease: true
 

--- a/.github/workflows/release_swift_bindings.yml
+++ b/.github/workflows/release_swift_bindings.yml
@@ -1,0 +1,129 @@
+name: Release Swift Bindings
+
+on:
+  push:
+    tags:
+      - 'swift-bindings-*'
+jobs:
+
+  build-macos:
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [aarch64-apple-darwin, aarch64-apple-ios, aarch64-apple-ios-sim]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: "Cache"
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ./target/${{ matrix.target }}
+          key: ${{ matrix.target }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+          target: ${{ matrix.target }}
+
+      # Install latest cross to mitigate unwind linking issue on android builds.
+      # See https://github.com/cross-rs/cross/issues/1222
+      - name: Install rust cross
+        run: |
+          cargo install cross --git https://github.com/cross-rs/cross
+
+      - name: Build target
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --release --target ${{ matrix.target }} --manifest-path bindings_ffi/Cargo.toml --target-dir bindings_ffi/target
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.target }}
+          path: bindings_ffi/target/${{ matrix.target }}/release/libxmtpv3.a
+          retention-days: 1
+
+
+  swift:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ./target/release
+          key: ${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+          target: x86_64-apple-darwin
+      - name: Install swift
+        run: brew install swiftformat
+      - name: Generate bindings
+        working-directory: bindings_ffi
+        run: |
+          make swift
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: swift
+          path: bindings_ffi/build/swift/
+          retention-days: 1
+
+  package-swift:
+    needs: [build-macos, swift]
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: bindings_ffi/build
+
+      - name: Build archive
+        working-directory: bindings_ffi
+        run: |
+          mkdir -p Sources/LibXMTP
+          mv build/swift/xmtpv3.swift Sources/LibXMTP/
+          make framework
+          zip -r LibXMTPSwiftFFI.zip Sources LibXMTPRust.xcframework
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./bindings_ffi/LibXMTPSwiftFFI.zip
+          asset_name: LibXMTPSwiftFFI.zip
+          asset_content_type: application/zip

--- a/.github/workflows/release_swift_bindings.yml
+++ b/.github/workflows/release_swift_bindings.yml
@@ -2,10 +2,12 @@ name: Release Swift Bindings
 
 on:
   push:
-    tags:
-      - 'swift-bindings-*'
-jobs:
+    branches:
+      - main
+      - nm/staticlib
+      - cv/release-swift-bindings
 
+jobs:
   build-macos:
     runs-on: macos-latest
     strategy:
@@ -52,7 +54,6 @@ jobs:
           name: ${{ matrix.target }}
           path: bindings_ffi/target/${{ matrix.target }}/release/libxmtpv3.a
           retention-days: 1
-
 
   swift:
     runs-on: macos-latest
@@ -107,6 +108,10 @@ jobs:
           make framework
           zip -r LibXMTPSwiftFFI.zip Sources LibXMTPRust.xcframework
 
+      - name: Get short SHA
+        id: slug
+        run: echo "::set-output name=sha7::$(echo ${GITHUB_SHA} | cut -c1-7)"
+
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -114,9 +119,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref_name }}
+          release_name: Release-Swift-Bindings-${{ steps.slug.outputs.sha7 }}
           draft: false
-          prerelease: false
+          prerelease: true
 
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/release_swift_bindings.yml
+++ b/.github/workflows/release_swift_bindings.yml
@@ -108,6 +108,12 @@ jobs:
           make framework
           zip -r LibXMTPSwiftFFI.zip Sources LibXMTPRust.xcframework ../LICENSE
 
+      - name: Calculate checksum
+        id: checksum
+        working-directory: bindings_ffi
+        run: |
+          echo "::set-output name=checksum::$(swift package compute-checksum LibXMTPSwiftFFI.zip)"
+
       - name: Get short SHA
         id: slug
         run: echo "::set-output name=sha7::$(echo ${GITHUB_SHA} | cut -c1-7)"
@@ -120,6 +126,7 @@ jobs:
         with:
           tag_name: test-swift-bindings-${{ steps.slug.outputs.sha7 }}
           release_name: Test-Swift-Bindings-${{ steps.slug.outputs.sha7 }}
+          body: "Checksum of LibXMTPSwiftFFI.zip: ${{ steps.checksum.outputs.checksum }}"
           draft: false
           prerelease: true
 

--- a/.github/workflows/release_swift_bindings.yml
+++ b/.github/workflows/release_swift_bindings.yml
@@ -106,7 +106,7 @@ jobs:
           mkdir -p Sources/LibXMTP
           mv build/swift/xmtpv3.swift Sources/LibXMTP/
           make framework
-          zip -r LibXMTPSwiftFFI.zip Sources LibXMTPRust.xcframework
+          zip -r LibXMTPSwiftFFI.zip Sources LibXMTPRust.xcframework ../LICENSE
 
       - name: Get short SHA
         id: slug
@@ -118,7 +118,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: test-swift-bindings-${{ github.ref }}
+          tag_name: test-swift-bindings-${{ steps.slug.outputs.sha7 }}
           release_name: Test-Swift-Bindings-${{ steps.slug.outputs.sha7 }}
           draft: false
           prerelease: true

--- a/.github/workflows/release_swift_bindings.yml
+++ b/.github/workflows/release_swift_bindings.yml
@@ -106,13 +106,15 @@ jobs:
           mkdir -p Sources/LibXMTP
           mv build/swift/xmtpv3.swift Sources/LibXMTP/
           make framework
-          zip -r LibXMTPSwiftFFI.zip Sources LibXMTPRust.xcframework ../LICENSE
+          ls -la ../
+          cp ../LICENSE ./LICENSE
+          zip -r LibXMTPSwiftFFI.zip Sources LibXMTPRust.xcframework LICENSE
 
       - name: Calculate checksum
         id: checksum
         working-directory: bindings_ffi
         run: |
-          echo "::set-output name=checksum::$(swift package compute-checksum LibXMTPSwiftFFI.zip)"
+          echo "::set-output name=checksum::$(shasum -a 256 LibXMTPSwiftFFI.zip | awk '{ print $1 }')"
 
       - name: Get short SHA
         id: slug

--- a/bindings_ffi/Makefile
+++ b/bindings_ffi/Makefile
@@ -76,6 +76,6 @@ swift:
 	mv build/swift/$(PROJECT_NAME)FFI.h build/swift/include/
 	mv build/swift/$(PROJECT_NAME)FFI.modulemap build/swift/include/module.modulemap
 
-swiftlocal: libxmtpv3.a framework swift
+swiftlocal: libxmtpv3.a swift framework 
 
 .PHONY: $(ARCHS_IOS) $(ARCHS_MAC) framework all aarch64-apple-ios install-jar echo-jar download-toolchains swift lipo

--- a/bindings_ffi/run_swift_local.sh
+++ b/bindings_ffi/run_swift_local.sh
@@ -1,4 +1,3 @@
 # Assumes libxmtp is in a peer directory of libxmtp-swift
-make swiftlocal ; rm -rf ../../libxmtp-swift/LibXMTPRust.xcframework
-cp -r ./LibXMTPRust.xcframework ../../libxmtp-swift/LibXMTPRust.xcframework
+make swift
 cp build/swift/xmtpv3.swift ../../libxmtp-swift/Sources/LibXMTP/xmtpv3.swift


### PR DESCRIPTION
Added a GH action for adding swift bindings to a GH Release. 

~~Adding the binary artifacts to a release would allow xmtp-ios to reference our libxmtp FFI bindings without needing to use libxmtp-swift as a "middle man" repo (release artifacts can be referenced directly from Swift Package Manager).~~ It turned out that we can not get rid of the `libxmtp-swift` repo because we still need the `Source` folder which is generated from `libxmtp`, and it is not possible to access that remotely from Swift Package Manager. However, if we hold on to `libxmtp-swift`, publishing the XCFramework as a release artifact in `libxmtp` does get us around having to use `git-lfs` in our `libxmtp-swift` which is important because it turns out Swift Package Manager does not work with `git-lfs` (although Cocoa Pods does fine with `git-lfs`, go figure!). 

A "pre-release" will be generated from this branch that will be tested against `xmtp-ios` in order to validate that this strategy works for getting our static binary `libxmtp` FFI into `xmtp-ios`.

The checksum in the Release description is used for specifying a binary target in our libxmtp-swift Package.swift file (for Swift Package Manager). See: https://github.com/xmtp/libxmtp-swift/pull/4/files#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677e

See Related PRs:
- https://github.com/xmtp/libxmtp/pull/433
- https://github.com/xmtp/libxmtp-swift/pull/4
- https://github.com/xmtp/xmtp-ios/pull/225