### PR TITLE
Added missing architectures to swift bindings github action

### DIFF
--- a/.github/workflows/release_swift_bindings.yml
+++ b/.github/workflows/release_swift_bindings.yml
@@ -12,7 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [aarch64-apple-darwin, aarch64-apple-ios, aarch64-apple-ios-sim]
+        # target: [aarch64-apple-darwin, aarch64-apple-ios, aarch64-apple-ios-sim]
+        target: [aarch64-apple-ios, x86_64-apple-ios, aarch64-apple-ios-sim, x86_64-apple-darwin, aarch64-apple-darwin]
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -90,6 +91,10 @@ jobs:
   package-swift:
     needs: [build-macos, swift]
     runs-on: macos-latest
+    strategy:
+      matrix:
+        # target: [aarch64-apple-darwin, aarch64-apple-ios, aarch64-apple-ios-sim]
+        target: [aarch64-apple-ios, x86_64-apple-ios, aarch64-apple-ios-sim, x86_64-apple-darwin, aarch64-apple-darwin]    
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -98,6 +103,20 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           path: bindings_ffi/build
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+          target: ${{ matrix.target }}
+  
+        # Install latest cross to mitigate unwind linking issue on android builds.
+        # See https://github.com/cross-rs/cross/issues/1222
+      - name: Install rust cross
+        run: |
+          cargo install cross --git https://github.com/cross-rs/cross
 
       - name: Build archive
         working-directory: bindings_ffi

--- a/.github/workflows/release_swift_bindings.yml
+++ b/.github/workflows/release_swift_bindings.yml
@@ -1,9 +1,6 @@
 name: Release Swift Bindings
 
 on:
-  push:
-    branches:
-      - cv/fix-gh-action-arch-targets-swift-bindings
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release_swift_bindings.yml
+++ b/.github/workflows/release_swift_bindings.yml
@@ -1,6 +1,9 @@
 name: Release Swift Bindings
 
 on:
+  push:
+    branches:
+      - cv/fix-gh-action-arch-targets-swift-bindings
   workflow_dispatch:
 
 jobs:
@@ -101,7 +104,7 @@ jobs:
         run: |
           mkdir -p Sources/LibXMTP
           mv build/swift/xmtpv3.swift Sources/LibXMTP/
-          make framework
+          make swiftaction
           cp ../LICENSE ./LICENSE
           zip -r LibXMTPSwiftFFI.zip Sources LibXMTPRust.xcframework LICENSE
 

--- a/.github/workflows/release_swift_bindings.yml
+++ b/.github/workflows/release_swift_bindings.yml
@@ -104,26 +104,12 @@ jobs:
         with:
           path: bindings_ffi/build
 
-      - name: Install rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-          target: ${{ matrix.target }}
-  
-        # Install latest cross to mitigate unwind linking issue on android builds.
-        # See https://github.com/cross-rs/cross/issues/1222
-      - name: Install rust cross
-        run: |
-          cargo install cross --git https://github.com/cross-rs/cross
-
       - name: Build archive
         working-directory: bindings_ffi
         run: |
           mkdir -p Sources/LibXMTP
           mv build/swift/xmtpv3.swift Sources/LibXMTP/
-          make swiftaction
+          make framework
           cp ../LICENSE ./LICENSE
           zip -r LibXMTPSwiftFFI.zip Sources LibXMTPRust.xcframework LICENSE
 

--- a/.github/workflows/release_swift_bindings.yml
+++ b/.github/workflows/release_swift_bindings.yml
@@ -12,7 +12,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # target: [aarch64-apple-darwin, aarch64-apple-ios, aarch64-apple-ios-sim]
         target: [aarch64-apple-ios, x86_64-apple-ios, aarch64-apple-ios-sim, x86_64-apple-darwin, aarch64-apple-darwin]
     steps:
       - name: Checkout
@@ -91,10 +90,6 @@ jobs:
   package-swift:
     needs: [build-macos, swift]
     runs-on: macos-latest
-    strategy:
-      matrix:
-        # target: [aarch64-apple-darwin, aarch64-apple-ios, aarch64-apple-ios-sim]
-        target: [aarch64-apple-ios, x86_64-apple-ios, aarch64-apple-ios-sim, x86_64-apple-darwin, aarch64-apple-darwin]    
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/bindings_ffi/Makefile
+++ b/bindings_ffi/Makefile
@@ -78,6 +78,4 @@ swift:
 
 swiftlocal: libxmtpv3.a swift framework 
 
-swiftaction: libxmtpv3.a framework 
-
 .PHONY: $(ARCHS_IOS) $(ARCHS_MAC) framework all aarch64-apple-ios install-jar echo-jar download-toolchains swift lipo

--- a/bindings_ffi/Makefile
+++ b/bindings_ffi/Makefile
@@ -78,4 +78,6 @@ swift:
 
 swiftlocal: libxmtpv3.a swift framework 
 
+swiftaction: libxmtpv3.a framework 
+
 .PHONY: $(ARCHS_IOS) $(ARCHS_MAC) framework all aarch64-apple-ios install-jar echo-jar download-toolchains swift lipo


### PR DESCRIPTION
We were failing a `pod spec lint` test that was required for publishing to the public Cocoapods repo. Verified that by adding the extra archtectures to our XCFramework via the update in this PR, this has been fixed. 

See https://github.com/xmtp/libxmtp-swift/pull/5/files for more details.

This change is verified by running `pod spec lint LibXMTP.podspec` in the root folder + branch of the PR linked above. 

That podspec links to the release that corresponds to the tagged commit from this PR: https://github.com/xmtp/libxmtp/releases/tag/swift-bindings-308ed57