### PR TITLE
Sanitize EVM addresses in more locations

### DIFF
--- a/bindings_ffi/src/lib.rs
+++ b/bindings_ffi/src/lib.rs
@@ -26,6 +26,8 @@ pub enum GenericError {
     GroupError(#[from] xmtp_mls::groups::GroupError),
     #[error("Signature: {0}")]
     Signature(#[from] xmtp_cryptography::signature::SignatureError),
+    #[error("Address validation: {0}")]
+    AddressValidation(#[from] xmtp_mls::utils::address::AddressValidationError),
     #[error("Generic {err}")]
     Generic { err: String },
 }

--- a/bindings_ffi/src/lib.rs
+++ b/bindings_ffi/src/lib.rs
@@ -26,8 +26,6 @@ pub enum GenericError {
     GroupError(#[from] xmtp_mls::groups::GroupError),
     #[error("Signature: {0}")]
     Signature(#[from] xmtp_cryptography::signature::SignatureError),
-    #[error("Address validation: {0}")]
-    AddressValidation(#[from] xmtp_mls::utils::address::AddressValidationError),
     #[error("Generic {err}")]
     Generic { err: String },
 }

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -9,7 +9,6 @@ use std::sync::{Arc, Mutex};
 use tokio::sync::{oneshot, oneshot::Sender};
 use xmtp_api_grpc::grpc_api_helper::Client as TonicApiClient;
 use xmtp_mls::builder::IdentityStrategy;
-use xmtp_mls::utils::address::sanitize_evm_addresses;
 use xmtp_mls::{
     builder::ClientBuilder,
     client::Client as MlsClient,
@@ -119,9 +118,8 @@ impl FfiXmtpClient {
         account_addresses: Vec<String>,
     ) -> Result<Vec<bool>, GenericError> {
         let inner = self.inner_client.as_ref();
-        let sanitized_addresses = sanitize_evm_addresses(account_addresses)?;
 
-        let results: Vec<bool> = inner.can_message(sanitized_addresses).await?;
+        let results: Vec<bool> = inner.can_message(account_addresses).await?;
 
         Ok(results)
     }

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -12,6 +12,7 @@ use crate::{
         EncryptedMessageStore, StorageError,
     },
     types::Address,
+    utils::address::sanitize_evm_addresses,
     verified_key_package::{KeyPackageVerificationError, VerifiedKeyPackage},
     xmtp_openmls_provider::XmtpOpenMlsProvider,
     Fetch,
@@ -47,6 +48,8 @@ pub enum Network {
 
 #[derive(Debug, Error)]
 pub enum ClientError {
+    #[error("Address validation: {0}")]
+    AddressValidation(#[from] crate::utils::address::AddressValidationError),
     #[error("could not publish: {0}")]
     PublishError(String),
     #[error("storage error: {0}")]
@@ -449,6 +452,7 @@ where
         &self,
         account_addresses: Vec<String>,
     ) -> Result<Vec<bool>, ClientError> {
+        let account_addresses = sanitize_evm_addresses(account_addresses)?;
         let identity_updates = self
             .api_client
             .get_identity_updates(0, account_addresses.clone())


### PR DESCRIPTION
In the long-term, it may make sense to create a 'SanitizedAddress' type to enforce that all account addresses have been sanitized via strong typing, rather than detecting each case one by one