### PR TITLE
Fixes creation of swift bindings in GH Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,8 @@ jobs:
 
       - name: Build target
         uses: actions-rs/cargo@v1
+        env: 
+          CROSS_NO_WARNINGS: "0"
         with:
           use-cross: true
           command: build

--- a/.github/workflows/release_swift_bindings.yml
+++ b/.github/workflows/release_swift_bindings.yml
@@ -1,9 +1,6 @@
 name: Release Swift Bindings
 
 on:
-  push:
-    branches:
-      - cv/swift-bindings-fix-ghaction 
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release_swift_bindings.yml
+++ b/.github/workflows/release_swift_bindings.yml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Build target
         uses: actions-rs/cargo@v1
+        env: 
+          CROSS_NO_WARNINGS: "0"
         with:
           use-cross: true
           command: build

--- a/.github/workflows/release_swift_bindings.yml
+++ b/.github/workflows/release_swift_bindings.yml
@@ -1,6 +1,9 @@
 name: Release Swift Bindings
 
 on:
+  push:
+    branches:
+      - cv/swift-bindings-fix-ghaction 
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The reason swift bindings randomly [stopped working](https://github.com/xmtp/libxmtp/actions/runs/7748479132/job/21131171021) is because we currently install `cross` off of its latest `main` commit

https://github.com/xmtp/libxmtp/blob/60ee7556e8c49ec0bf3e2e23c80e8fe4006b11a0/.github/workflows/build.yml#L44

And yesterday it merged this change to panic when there are warnings about images not existing: https://github.com/cross-rs/cross/pull/661.

It notes that this behavior can be overridden by setting ENV variable CROSS_NO_WARNINGS to 0 => https://github.com/cross-rs/cross/pull/661/files#diff-1a4b7a107d49cefefb1d62ea26d75f6228c316547007dcd955467880c618552fR47

I tested this behavior in a CI run here and it seemed to work: https://github.com/xmtp/libxmtp/actions/runs/7750146106/job/21135930589

The long term solution is to fix the warning here, however, this warning has existed for at least 3 months, with a fallback to using `cargo` seemingly working okay for now, so I propose that we disable the panic on warning behavior so we can continue building swift bindings while we investigate how to fix the warning.

 