### PR TITLE
build: prep flutter -dev.2 to pickup validation changes

### DIFF
--- a/.github/workflows/bindings_flutter_release.yaml
+++ b/.github/workflows/bindings_flutter_release.yaml
@@ -2,7 +2,15 @@ name: release bindings_flutter
 on:
   workflow_dispatch:
 env:
-  RELEASE_VERSION: '0.1.0-development.1'
+  RELEASE_VERSION: '0.1.0-development.2'
+  # this ^ version should be kept in sync:
+  # - pubspec.yaml
+  # - linux/CMakeLists.txt
+  # - android/gradle.properties
+  # - ios/xmtp_bindings_flutter.podspec
+  # - macos/xmtp_bindings_flutter.podspec
+  # TODO: automate that ^ and then also `dart pub publish` on release
+  # TODO: `dart pub publish` in this workflow after creating the release
 defaults:
   run:
     working-directory: ./bindings_flutter

--- a/bindings_flutter/CHANGELOG.md
+++ b/bindings_flutter/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.0-development.2
+- pickup latest validation service updates
+
 ## 0.1.0-development.1
 - move from v2 to main branch on libxmtp
 - mls client creation

--- a/bindings_flutter/Cargo.lock
+++ b/bindings_flutter/Cargo.lock
@@ -4955,6 +4955,7 @@ dependencies = [
  "tracing",
  "xmtp_cryptography",
  "xmtp_proto",
+ "xmtp_v2",
 ]
 
 [[package]]

--- a/bindings_flutter/android/gradle.properties
+++ b/bindings_flutter/android/gradle.properties
@@ -1,4 +1,4 @@
-xmtp_bindings_flutter_version=0.1.0-development.1
+xmtp_bindings_flutter_version=0.1.0-development.2
 # These versions should be kept in sync:
 # - pubspec.yaml
 # - android/gradle.properties

--- a/bindings_flutter/ios/xmtp_bindings_flutter.podspec
+++ b/bindings_flutter/ios/xmtp_bindings_flutter.podspec
@@ -4,7 +4,7 @@
 # See generally
 #  https://cjycode.com/flutter_rust_bridge/library/platform_setup/ios_and_macos.html
 
-release_version = '0.1.0-development.1'
+release_version = '0.1.0-development.2'
 # These versions should be kept in sync:
 # - pubspec.yaml
 # - android/gradle.properties

--- a/bindings_flutter/linux/CMakeLists.txt
+++ b/bindings_flutter/linux/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.10)
 
 # TODO: set this externally as part of invoking linux build
 set(LibraryName "xmtp_bindings_flutter")
-set(ReleaseVersion "0.1.0-development.1")
+set(ReleaseVersion "0.1.0-development.2")
 
 # Download the binaries if they are not already present.
 project("${LibraryName}")

--- a/bindings_flutter/macos/xmtp_bindings_flutter.podspec
+++ b/bindings_flutter/macos/xmtp_bindings_flutter.podspec
@@ -4,7 +4,7 @@
 # See generally
 #  https://cjycode.com/flutter_rust_bridge/library/platform_setup/ios_and_macos.html
 
-release_version = '0.1.0-development.1'
+release_version = '0.1.0-development.2'
 # These versions should be kept in sync:
 # - pubspec.yaml
 # - android/gradle.properties

--- a/bindings_flutter/pubspec.yaml
+++ b/bindings_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: xmtp_bindings_flutter
 description: low-level flutter bindings to libxmtp
 repository: https://github.com/xmtp/libxmtp
-version: 0.1.0-development.1
+version: 0.1.0-development.2
 # When this is updated it should be mirrored in
 # android/build.gradle
 # ios/xmtp_bindings_flutter.podspec


### PR DESCRIPTION
This preps the next flutter libxmtp release to pickup the validation service changes.