### PR TITLE
Create v3 credential from v2 identity if needed

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -147,7 +147,7 @@ impl FfiXmtpClient {
         recoverable_wallet_signature: Option<Vec<u8>>,
     ) -> Result<(), GenericError> {
         self.inner_client
-            .register_identity_with_external_signature(recoverable_wallet_signature)
+            .register_identity(recoverable_wallet_signature)
             .await?;
 
         Ok(())

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -90,8 +90,7 @@ pub async fn create_client(
         LegacyIdentitySource::Network => LegacyIdentity::Network(legacy_key_result?),
         LegacyIdentitySource::KeyGenerator => LegacyIdentity::KeyGenerator(legacy_key_result?),
     };
-    let identity_strategy =
-        IdentityStrategy::CreateUnsignedIfNotFound(account_address, legacy_identity);
+    let identity_strategy = IdentityStrategy::CreateIfNotFound(account_address, legacy_identity);
     let xmtp_client: RustXmtpClient = ClientBuilder::new(identity_strategy)
         .api_client(api_client)
         .store(store)

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -9,6 +9,7 @@ use std::sync::{Arc, Mutex};
 use tokio::sync::{oneshot, oneshot::Sender};
 use xmtp_api_grpc::grpc_api_helper::Client as TonicApiClient;
 use xmtp_mls::builder::IdentityStrategy;
+use xmtp_mls::builder::LegacyIdentity;
 use xmtp_mls::{
     builder::ClientBuilder,
     client::Client as MlsClient,
@@ -81,11 +82,21 @@ pub async fn create_client(
     };
 
     log::info!("Creating XMTP client");
-    let identity_strategy: IdentityStrategy<RustInboxOwner> = account_address.into();
+    let legacy_key_result =
+        legacy_signed_private_key_proto.ok_or("No legacy key provided".to_string());
+    let legacy_identity = match legacy_identity_source {
+        LegacyIdentitySource::None => LegacyIdentity::None,
+        LegacyIdentitySource::Static => LegacyIdentity::Static(legacy_key_result?),
+        LegacyIdentitySource::Network => LegacyIdentity::Network(legacy_key_result?),
+        LegacyIdentitySource::KeyGenerator => LegacyIdentity::KeyGenerator(legacy_key_result?),
+    };
+    let identity_strategy =
+        IdentityStrategy::CreateUnsignedIfNotFound(account_address, legacy_identity);
     let xmtp_client: RustXmtpClient = ClientBuilder::new(identity_strategy)
         .api_client(api_client)
         .store(store)
-        .build()?;
+        .build()
+        .await?;
 
     log::info!(
         "Created XMTP client for address: {}",

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -1,4 +1,3 @@
-use crate::inbox_owner::RustInboxOwner;
 pub use crate::inbox_owner::SigningError;
 use crate::logger::init_logger;
 use crate::logger::FfiLogger;

--- a/bindings_flutter/src/libxmtp_api.rs
+++ b/bindings_flutter/src/libxmtp_api.rs
@@ -131,7 +131,7 @@ impl SignatureRequiredClient {
     pub async fn sign(&self, signature: Vec<u8>) -> Result<Client, XmtpError> {
         self.inner
             .client
-            .register_identity_with_external_signature(Some(signature))
+            .register_identity(Some(signature))
             .await?;
         return Ok(Client {
             inner: self.inner.clone(),

--- a/bindings_flutter/src/libxmtp_api.rs
+++ b/bindings_flutter/src/libxmtp_api.rs
@@ -139,6 +139,7 @@ impl SignatureRequiredClient {
     }
 }
 
+// TODO
 pub async fn create_client(
     // logger_fn: impl Fn(u32, String, String) -> DartFnFuture<()>,
     host: String,

--- a/bindings_flutter/src/libxmtp_api.rs
+++ b/bindings_flutter/src/libxmtp_api.rs
@@ -6,7 +6,7 @@ use xmtp_cryptography::utils::LocalWallet;
 pub use xmtp_mls::builder::ClientBuilderError;
 pub use xmtp_mls::storage::StorageError;
 use xmtp_mls::{
-    builder::ClientBuilder, builder::IdentityStrategy, client::Client as MlsClient,
+    builder::ClientBuilder, builder::IdentityStrategy, builder::LegacyIdentity, client::Client as MlsClient,
     storage::EncryptedMessageStore, storage::StorageOption,
 };
 pub use xmtp_proto::api_client::Error as ApiError;
@@ -139,7 +139,6 @@ impl SignatureRequiredClient {
     }
 }
 
-// TODO
 pub async fn create_client(
     // logger_fn: impl Fn(u32, String, String) -> DartFnFuture<()>,
     host: String,
@@ -154,7 +153,7 @@ pub async fn create_client(
     let store = EncryptedMessageStore::new(StorageOption::Persistent(db_path), encryption_key)?;
     // log::info!("Creating XMTP client");
     let identity_strategy: IdentityStrategy =
-        IdentityStrategy::CreateIfNotFound(account_address);
+        IdentityStrategy::CreateIfNotFound(account_address, LegacyIdentity::None); // TODO plumb legacy identity here
     let xmtp_client = ClientBuilder::new(identity_strategy)
         .api_client(api_client)
         .store(store)

--- a/bindings_flutter/src/libxmtp_api.rs
+++ b/bindings_flutter/src/libxmtp_api.rs
@@ -154,7 +154,7 @@ pub async fn create_client(
     let store = EncryptedMessageStore::new(StorageOption::Persistent(db_path), encryption_key)?;
     // log::info!("Creating XMTP client");
     let identity_strategy: IdentityStrategy =
-        IdentityStrategy::CreateUnsignedIfNotFound(account_address);
+        IdentityStrategy::CreateIfNotFound(account_address);
     let xmtp_client = ClientBuilder::new(identity_strategy)
         .api_client(api_client)
         .store(store)

--- a/bindings_flutter/src/libxmtp_api.rs
+++ b/bindings_flutter/src/libxmtp_api.rs
@@ -153,12 +153,13 @@ pub async fn create_client(
     let api_client = ApiClient::create(host.clone(), is_secure).await?;
     let store = EncryptedMessageStore::new(StorageOption::Persistent(db_path), encryption_key)?;
     // log::info!("Creating XMTP client");
-    let identity_strategy: IdentityStrategy<LocalWallet> =
+    let identity_strategy: IdentityStrategy =
         IdentityStrategy::CreateUnsignedIfNotFound(account_address);
     let xmtp_client = ClientBuilder::new(identity_strategy)
         .api_client(api_client)
         .store(store)
-        .build()?;
+        .build()
+        .await?;
 
     // log::info!(
     //     "Created XMTP client for address: {}",

--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -17,7 +17,7 @@ use xmtp_cryptography::{
     utils::{rng, seeded_rng, LocalWallet},
 };
 use xmtp_mls::{
-    builder::{ClientBuilderError, IdentityStrategy},
+    builder::{ClientBuilderError, IdentityStrategy, LegacyIdentitySource},
     client::ClientError,
     groups::MlsGroup,
     storage::{EncryptedMessageStore, EncryptionKey, StorageError, StorageOption},
@@ -294,7 +294,7 @@ async fn create_client(cli: &Cli, account: IdentityStrategy<Wallet>) -> Result<C
         );
     }
 
-    builder.build().map_err(CliError::ClientBuilder)
+    builder.build().await.map_err(CliError::ClientBuilder)
 }
 
 async fn register(cli: &Cli, wallet_seed: &u64) -> Result<(), CliError> {
@@ -304,7 +304,11 @@ async fn register(cli: &Cli, wallet_seed: &u64) -> Result<(), CliError> {
         Wallet::LocalWallet(LocalWallet::new(&mut seeded_rng(*wallet_seed)))
     };
 
-    let client = create_client(cli, IdentityStrategy::CreateIfNotFound(w)).await?;
+    let client = create_client(
+        cli,
+        IdentityStrategy::CreateIfNotFound(w, LegacyIdentitySource::None),
+    )
+    .await?;
     info!("Address is: {}", client.account_address());
 
     if let Err(e) = client.register_identity().await {

--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -306,7 +306,7 @@ async fn register(cli: &Cli, wallet_seed: &u64) -> Result<(), CliError> {
 
     let client = create_client(
         cli,
-        IdentityStrategy::CreateUnsignedIfNotFound(w.get_address(), LegacyIdentity::None),
+        IdentityStrategy::CreateIfNotFound(w.get_address(), LegacyIdentity::None),
     )
     .await?;
     info!("Address is: {}", client.account_address());

--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -312,10 +312,7 @@ async fn register(cli: &Cli, wallet_seed: &u64) -> Result<(), CliError> {
     info!("Address is: {}", client.account_address());
     let signature: Option<Vec<u8>> = client.text_to_sign().map(|t| w.sign(&t).unwrap().into());
 
-    if let Err(e) = client
-        .register_identity_with_external_signature(signature)
-        .await
-    {
+    if let Err(e) = client.register_identity(signature).await {
         error!("Initialization Failed: {}", e.to_string());
         panic!("Could not init");
     };

--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -231,14 +231,13 @@ where
 #[cfg(test)]
 mod tests {
 
-    use ethers::signers::{LocalWallet, Signer, Wallet};
-    use ethers_core::k256::ecdsa::SigningKey;
+    use ethers::signers::{Signer};
+    
     use xmtp_api_grpc::grpc_api_helper::Client as GrpcClient;
     use xmtp_cryptography::utils::generate_local_wallet;
 
     use super::{ClientBuilder, IdentityStrategy};
     use crate::{
-        owner,
         storage::{EncryptedMessageStore, StorageOption},
         utils::test::tmp_path,
         Client, InboxOwner,

--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -117,7 +117,7 @@ impl IdentityStrategy {
         legacy_identity: LegacyIdentity,
     ) -> Result<Identity, ClientBuilderError> {
         let identity = match legacy_identity {
-            // This is a fresh install for a pre-existing user, and at most one v2 signature (enable_identity)
+            // This is a fresh install, and at most one v2 signature (enable_identity)
             // has been requested so far, so it's fine to request another one (grant_messaging_access).
             LegacyIdentity::None | LegacyIdentity::Network(_) => {
                 Identity::create_to_be_signed(account_address)?
@@ -132,7 +132,7 @@ impl IdentityStrategy {
             LegacyIdentity::Static(legacy_signed_private_key) => {
                 if Identity::has_existing_legacy_credential(api_client, &account_address).await? {
                     // Another installation has already derived a v3 key from this v2 key.
-                    // Don't reuse the same v2 key - make a new one altogether.
+                    // Don't reuse the same v2 key - make a new key altogether.
                     Identity::create_to_be_signed(account_address)?
                 } else {
                     Identity::create_from_legacy(account_address, legacy_signed_private_key)?
@@ -152,12 +152,6 @@ where
         IdentityStrategy::CreateIfNotFound(value.get_address(), LegacyIdentity::None)
     }
 }
-
-// impl From<String> for IdentityStrategy /*<Owner>*/ {
-//     fn from(account_address: String) -> Self {
-//         IdentityStrategy::CreateIfNotFound(account_address)
-//     }
-// }
 
 pub struct ClientBuilder<ApiClient> {
     api_client: Option<ApiClient>,

--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -231,8 +231,8 @@ where
 #[cfg(test)]
 mod tests {
 
-    use ethers::signers::{Signer};
-    
+    use ethers::signers::Signer;
+
     use xmtp_api_grpc::grpc_api_helper::Client as GrpcClient;
     use xmtp_cryptography::utils::generate_local_wallet;
 
@@ -272,10 +272,7 @@ mod tests {
             let signature: Option<Vec<u8>> = client
                 .text_to_sign()
                 .map(|text| owner.sign(&text).unwrap().into());
-            client
-                .register_identity_with_external_signature(signature)
-                .await
-                .unwrap();
+            client.register_identity(signature).await.unwrap();
             client
         }
     }
@@ -309,10 +306,7 @@ mod tests {
         let signature: Option<Vec<u8>> = client_a
             .text_to_sign()
             .map(|text| wallet.sign(&text).unwrap().into());
-        client_a
-            .register_identity_with_external_signature(signature)
-            .await
-            .unwrap(); // Persists the identity on registration
+        client_a.register_identity(signature).await.unwrap(); // Persists the identity on registration
         let keybytes_a = client_a.installation_public_key();
         drop(client_a);
 

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -4,7 +4,6 @@ use crate::{
         validated_commit::CommitValidationError, AddressesOrInstallationIds, IntentError, MlsGroup,
     },
     identity::Identity,
-    retry::Retry,
     storage::{
         db_connection::DbConnection,
         group::{GroupMembershipState, StoredGroup},
@@ -699,7 +698,7 @@ mod tests {
         bola.sync_welcomes().await.unwrap();
         let bola_groups = bola.find_groups(None, None, None, None).unwrap();
         assert_eq!(bola_groups.len(), 1);
-        let bola_group = bola_groups.get(0).unwrap();
+        let bola_group = bola_groups.first().unwrap();
         bola_group.sync().await.unwrap();
 
         // Bola should have one readable message (them being added to the group)

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -155,13 +155,13 @@ where
     /// It is expected that most users will use the [`ClientBuilder`](crate::builder::ClientBuilder) instead of instantiating
     /// a client directly.
     pub fn new(
-        api_client: ApiClient,
+        api_client: ApiClientWrapper<ApiClient>,
         network: Network,
         identity: Identity,
         store: EncryptedMessageStore,
     ) -> Self {
         Self {
-            api_client: ApiClientWrapper::new(api_client, Retry::default()),
+            api_client,
             _network: network,
             identity,
             store,

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -233,12 +233,6 @@ where
             .collect())
     }
 
-    /// Deprecated
-    pub async fn register_identity(&self) -> Result<(), ClientError> {
-        self.register_identity_with_external_signature(None).await?;
-        Ok(())
-    }
-
     /// Register the identity with the network
     /// Callers should always check the result of [`text_to_sign`](Self::text_to_sign) before invoking this function.
     ///
@@ -565,7 +559,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_mls_error() {
-        let client = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
+        let client = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let result = client.api_client.register_installation(vec![1, 2, 3]).await;
 
         assert!(result.is_err());
@@ -576,8 +570,7 @@ mod tests {
     #[tokio::test]
     async fn test_register_installation() {
         let wallet = generate_local_wallet();
-        let client = ClientBuilder::new_test_client(wallet.clone().into()).await;
-        client.register_identity().await.unwrap();
+        let client = ClientBuilder::new_test_client(&wallet).await;
 
         // Make sure the installation is actually on the network
         let installation_ids = client
@@ -590,8 +583,7 @@ mod tests {
     #[tokio::test]
     async fn test_rotate_key_package() {
         let wallet = generate_local_wallet();
-        let client = ClientBuilder::new_test_client(wallet.clone().into()).await;
-        client.register_identity().await.unwrap();
+        let client = ClientBuilder::new_test_client(&wallet).await;
 
         // Get original KeyPackage.
         let kp1 = client
@@ -616,7 +608,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_groups() {
-        let client = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
+        let client = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let group_1 = client.create_group().unwrap();
         let group_2 = client.create_group().unwrap();
 
@@ -628,10 +620,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_sync_welcomes() {
-        let alice = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
-        alice.register_identity().await.unwrap();
-        let bob = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
-        bob.register_identity().await.unwrap();
+        let alice = ClientBuilder::new_test_client(&generate_local_wallet()).await;
+        let bob = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
         let alice_bob_group = alice.create_group().unwrap();
         alice_bob_group
@@ -652,9 +642,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_can_message() {
-        let amal = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
-        let bola = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
-        futures::try_join!(amal.register_identity(), bola.register_identity()).unwrap();
+        let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
+        let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let charlie_address = generate_local_wallet().get_address();
 
         let can_message_result = amal
@@ -670,7 +659,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_welcome_encryption() {
-        let client = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
+        let client = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let conn = client.store.conn().unwrap();
         let provider = client.mls_provider(&conn);
 
@@ -688,9 +677,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_add_remove_then_add_again() {
-        let amal = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
-        let bola = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
-        bola.register_identity().await.unwrap();
+        let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
+        let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
         // Create a group and invite bola
         let amal_group = amal.create_group().unwrap();
@@ -745,9 +733,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_stream_welcomes() {
-        let alice = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
-        let bob = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
-        bob.register_identity().await.unwrap();
+        let alice = ClientBuilder::new_test_client(&generate_local_wallet()).await;
+        let bob = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
         let alice_bob_group = alice.create_group().unwrap();
 

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -178,8 +178,8 @@ where
     }
 
     /// In some cases, the client may need a signature from the wallet to call [`register_identity`](Self::register_identity).
-    /// Integrators should always check the `text_to_sign` return value of this function before calling [`register_identity_with_external_signature`](Self::register_identity_with_external_signature).
-    /// If `text_to_sign` returns `None`, then the wallet signature is not required and [`register_identity_with_external_signature`](Self::register_identity_with_external_signature) can be called with None as an argument.
+    /// Integrators should always check the `text_to_sign` return value of this function before calling [`register_identity`](Self::register_identity).
+    /// If `text_to_sign` returns `None`, then the wallet signature is not required and [`register_identity`](Self::register_identity) can be called with None as an argument.
     pub fn text_to_sign(&self) -> Option<String> {
         self.identity.text_to_sign()
     }
@@ -238,7 +238,7 @@ where
     /// If `text_to_sign` returns `None`, then the wallet signature is not required and this function can be called with `None`.
     ///
     /// If `text_to_sign` returns `Some`, then the caller should sign the text with their wallet and pass the signature to this function.
-    pub async fn register_identity_with_external_signature(
+    pub async fn register_identity(
         &self,
         recoverable_wallet_signature: Option<Vec<u8>>,
     ) -> Result<(), ClientError> {

--- a/xmtp_mls/src/credential/mod.rs
+++ b/xmtp_mls/src/credential/mod.rs
@@ -78,12 +78,12 @@ impl Credential {
     }
 
     pub fn create_legacy(
+        installation_keys: &SignatureKeyPair,
         legacy_signed_private_key: Vec<u8>,
-        installation_public_key: Vec<u8>,
     ) -> Result<Self, AssociationError> {
         let association = LegacyCreateIdentityAssociation::create(
             legacy_signed_private_key,
-            installation_public_key,
+            installation_keys.to_public_vec(),
         )?;
         Ok(Self::LegacyCreateIdentity(association))
     }

--- a/xmtp_mls/src/credential/mod.rs
+++ b/xmtp_mls/src/credential/mod.rs
@@ -77,7 +77,7 @@ impl Credential {
         Ok(Self::GrantMessagingAccess(association))
     }
 
-    pub fn create_legacy(
+    pub fn create_from_legacy(
         installation_keys: &SignatureKeyPair,
         legacy_signed_private_key: Vec<u8>,
     ) -> Result<Self, AssociationError> {

--- a/xmtp_mls/src/credential/mod.rs
+++ b/xmtp_mls/src/credential/mod.rs
@@ -158,7 +158,9 @@ impl From<Credential> for MlsCredentialProto {
                 Credential::GrantMessagingAccess(assoc) => {
                     Some(AssociationProto::MessagingAccess(assoc.into()))
                 }
-                Credential::LegacyCreateIdentity(_assoc) => todo!(),
+                Credential::LegacyCreateIdentity(assoc) => {
+                    Some(AssociationProto::LegacyCreateIdentity(assoc.into()))
+                }
             },
         }
     }

--- a/xmtp_mls/src/groups/group_permissions.rs
+++ b/xmtp_mls/src/groups/group_permissions.rs
@@ -350,7 +350,7 @@ mod tests {
         AggregatedMembershipChange {
             account_address: account_address.unwrap_or_else(rand_account_address),
             installation_ids: vec![installation_id.unwrap_or_else(rand_vec)],
-            is_creator: is_creator,
+            is_creator,
         }
     }
 
@@ -393,13 +393,13 @@ mod tests {
                 .unwrap_or_default(),
             members_removed: member_removed
                 .map(build_membership_change)
-                .unwrap_or_else(std::vec::Vec::new),
+                .unwrap_or_default(),
             installations_added: installation_added
                 .map(build_membership_change)
-                .unwrap_or_else(std::vec::Vec::new),
+                .unwrap_or_default(),
             installations_removed: installation_removed
                 .map(build_membership_change)
-                .unwrap_or_else(std::vec::Vec::new),
+                .unwrap_or_default(),
         }
     }
 

--- a/xmtp_mls/src/groups/members.rs
+++ b/xmtp_mls/src/groups/members.rs
@@ -68,13 +68,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_member_list() {
-        let amal = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
+        let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bola_wallet = generate_local_wallet();
         // Add two separate installations for Bola
-        let bola_a = ClientBuilder::new_test_client(bola_wallet.clone().into()).await;
-        bola_a.register_identity().await.unwrap();
-        let bola_b = ClientBuilder::new_test_client(bola_wallet.clone().into()).await;
-        bola_b.register_identity().await.unwrap();
+        let bola_a = ClientBuilder::new_test_client(&bola_wallet).await;
+        let bola_b = ClientBuilder::new_test_client(&bola_wallet).await;
 
         let group = amal.create_group().unwrap();
         // Add both of Bola's installations to the group

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -426,7 +426,7 @@ mod tests {
     #[tokio::test]
     async fn test_send_message() {
         let wallet = generate_local_wallet();
-        let client = ClientBuilder::new_test_client(wallet.into()).await;
+        let client = ClientBuilder::new_test_client(&wallet).await;
         let group = client.create_group().expect("create group");
         group.send_message(b"hello").await.expect("send message");
 
@@ -442,7 +442,7 @@ mod tests {
     #[tokio::test]
     async fn test_receive_self_message() {
         let wallet = generate_local_wallet();
-        let client = ClientBuilder::new_test_client(wallet.into()).await;
+        let client = ClientBuilder::new_test_client(&wallet).await;
         let group = client.create_group().expect("create group");
         let msg = b"hello";
         group.send_message(msg).await.expect("send message");
@@ -459,15 +459,9 @@ mod tests {
     // The group should resolve to a consistent state
     #[tokio::test]
     async fn test_add_member_conflict() {
-        let amal = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
-        let bola = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
-        let charlie = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
-        futures::future::join_all(vec![
-            amal.register_identity(),
-            bola.register_identity(),
-            charlie.register_identity(),
-        ])
-        .await;
+        let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
+        let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
+        let charlie = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
         let amal_group = amal.create_group().unwrap();
         // Add bola
@@ -533,9 +527,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_add_installation() {
-        let client = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
-        let client_2 = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
-        client_2.register_identity().await.unwrap();
+        let client = ClientBuilder::new_test_client(&generate_local_wallet()).await;
+        let client_2 = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let group = client.create_group().expect("create group");
 
         group
@@ -556,7 +549,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_add_invalid_member() {
-        let client = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
+        let client = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let group = client.create_group().expect("create group");
 
         let result = group
@@ -568,7 +561,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_add_unregistered_member() {
-        let amal = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
+        let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let unconnected_wallet_address = generate_local_wallet().get_address();
         let group = amal.create_group().unwrap();
         let result = group.add_members(vec![unconnected_wallet_address]).await;
@@ -578,10 +571,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_remove_installation() {
-        let client_1 = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
+        let client_1 = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         // Add another client onto the network
-        let client_2 = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
-        client_2.register_identity().await.unwrap();
+        let client_2 = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
         let group = client_1.create_group().expect("create group");
         group
@@ -615,9 +607,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_key_update() {
-        let client = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
-        let bola_client = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
-        bola_client.register_identity().await.unwrap();
+        let client = ClientBuilder::new_test_client(&generate_local_wallet()).await;
+        let bola_client = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
         let group = client.create_group().expect("create group");
         group
@@ -652,9 +643,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_post_commit() {
-        let client = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
-        let client_2 = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
-        client_2.register_identity().await.unwrap();
+        let client = ClientBuilder::new_test_client(&generate_local_wallet()).await;
+        let client_2 = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let group = client.create_group().expect("create group");
 
         group
@@ -674,12 +664,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_remove_by_account_address() {
-        let amal = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
-        amal.register_identity().await.unwrap();
-        let bola = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
-        bola.register_identity().await.unwrap();
-        let charlie = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
-        charlie.register_identity().await.unwrap();
+        let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
+        let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
+        let charlie = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
         let group = amal.create_group().unwrap();
         group
@@ -719,11 +706,8 @@ mod tests {
     async fn test_get_missing_members() {
         // Setup for test
         let amal_wallet = generate_local_wallet();
-        let amal = ClientBuilder::new_test_client(amal_wallet.clone().into()).await;
-        amal.register_identity().await.unwrap();
-
-        let bola = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
-        bola.register_identity().await.unwrap();
+        let amal = ClientBuilder::new_test_client(&amal_wallet).await;
+        let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
         let group = amal.create_group().unwrap();
         group
@@ -741,8 +725,7 @@ mod tests {
         assert_eq!(_placeholder.len(), 0);
 
         // Add a second installation for amal using the same wallet
-        let amal_2nd = ClientBuilder::new_test_client(amal_wallet.into()).await;
-        amal_2nd.register_identity().await.unwrap();
+        let amal_2nd = ClientBuilder::new_test_client(&amal_wallet).await;
 
         // Here we should find a new installation
         let (missing_members, _placeholder) = group.get_missing_members(&provider).await.unwrap();
@@ -761,11 +744,8 @@ mod tests {
     async fn test_add_missing_installations() {
         // Setup for test
         let amal_wallet = generate_local_wallet();
-        let amal = ClientBuilder::new_test_client(amal_wallet.clone().into()).await;
-        amal.register_identity().await.unwrap();
-
-        let bola = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
-        bola.register_identity().await.unwrap();
+        let amal = ClientBuilder::new_test_client(&amal_wallet).await;
+        let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
         let group = amal.create_group().unwrap();
         group
@@ -779,8 +759,7 @@ mod tests {
         // Finished with setup
 
         // add a second installation for amal using the same wallet
-        let amal_2nd = ClientBuilder::new_test_client(amal_wallet.into()).await;
-        amal_2nd.register_identity().await.unwrap();
+        let amal_2nd = ClientBuilder::new_test_client(&amal_wallet).await;
 
         // test that adding the new installation(s), worked
         let new_installations_count = group.add_missing_installations(&provider).await.unwrap();
@@ -789,16 +768,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_self_resolve_epoch_mismatch() {
-        let amal = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
-        let bola = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
-        let charlie = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
-        let dave = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
-        let (_, _, _, _) = tokio::join!(
-            amal.register_identity(),
-            bola.register_identity(),
-            charlie.register_identity(),
-            dave.register_identity(),
-        );
+        let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
+        let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
+        let charlie = ClientBuilder::new_test_client(&generate_local_wallet()).await;
+        let dave = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let amal_group = amal.create_group().unwrap();
         // Add bola to the group
         amal_group

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -725,7 +725,7 @@ mod tests {
         assert_eq!(_placeholder.len(), 0);
 
         // Add a second installation for amal using the same wallet
-        let amal_2nd = ClientBuilder::new_test_client(&amal_wallet).await;
+        let _amal_2nd = ClientBuilder::new_test_client(&amal_wallet).await;
 
         // Here we should find a new installation
         let (missing_members, _placeholder) = group.get_missing_members(&provider).await.unwrap();
@@ -759,7 +759,7 @@ mod tests {
         // Finished with setup
 
         // add a second installation for amal using the same wallet
-        let amal_2nd = ClientBuilder::new_test_client(&amal_wallet).await;
+        let _amal_2nd = ClientBuilder::new_test_client(&amal_wallet).await;
 
         // test that adding the new installation(s), worked
         let new_installations_count = group.add_missing_installations(&provider).await.unwrap();

--- a/xmtp_mls/src/groups/subscriptions.rs
+++ b/xmtp_mls/src/groups/subscriptions.rs
@@ -90,10 +90,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
     async fn test_subscribe_messages() {
-        let amal = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
-        amal.register_identity().await.unwrap();
-        let bola = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
-        bola.register_identity().await.unwrap();
+        let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
+        let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
         let amal_group = amal.create_group().unwrap();
         // Add bola
@@ -121,7 +119,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
     async fn test_subscribe_multiple() {
-        let amal = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
+        let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let group = amal.create_group().unwrap();
 
         let stream = group.stream().await.unwrap();
@@ -148,10 +146,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
     async fn test_subscribe_membership_changes() {
-        let amal = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
-        amal.register_identity().await.unwrap();
-        let bola = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
-        bola.register_identity().await.unwrap();
+        let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
+        let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
         let amal_group = amal.create_group().unwrap();
 

--- a/xmtp_mls/src/groups/validated_commit.rs
+++ b/xmtp_mls/src/groups/validated_commit.rs
@@ -370,8 +370,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_membership_changes() {
-        let amal = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
-        let bola = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
+        let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
+        let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bola_key_package = get_key_package(&bola);
 
         let amal_group = amal.create_group().unwrap();
@@ -436,8 +436,8 @@ mod tests {
     #[tokio::test]
     async fn test_installation_changes() {
         let wallet = generate_local_wallet();
-        let amal_1 = ClientBuilder::new_test_client(wallet.clone().into()).await;
-        let amal_2 = ClientBuilder::new_test_client(wallet.into()).await;
+        let amal_1 = ClientBuilder::new_test_client(&wallet).await;
+        let amal_2 = ClientBuilder::new_test_client(&wallet).await;
 
         let amal_1_conn = amal_1.store.conn().unwrap();
         let amal_2_conn = amal_2.store.conn().unwrap();
@@ -474,8 +474,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_bad_key_package() {
-        let amal = ClientBuilder::new_test_client(generate_local_wallet().clone().into()).await;
-        let bola = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
+        let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
+        let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
         let amal_conn = amal.store.conn().unwrap();
         let bola_conn = bola.store.conn().unwrap();

--- a/xmtp_mls/src/identity.rs
+++ b/xmtp_mls/src/identity.rs
@@ -250,7 +250,7 @@ impl Identity {
                 };
                 let Ok(credential) = Credential::from_proto_validated(
                     proto,
-                    Some(&account_address), // expected_account_address
+                    Some(account_address), // expected_account_address
                     None,                   // expected_installation_public_key
                 ) else {
                     continue;
@@ -307,7 +307,7 @@ mod tests {
         let (store, api_client) = get_test_resources().await;
         let conn = store.conn().unwrap();
         let provider = XmtpOpenMlsProvider::new(&conn);
-        let identity =
+        let _identity =
             create_registered_identity(&provider, &api_client, &generate_local_wallet()).await;
     }
 

--- a/xmtp_mls/src/identity.rs
+++ b/xmtp_mls/src/identity.rs
@@ -251,7 +251,7 @@ impl Identity {
                 let Ok(credential) = Credential::from_proto_validated(
                     proto,
                     Some(account_address), // expected_account_address
-                    None,                   // expected_installation_public_key
+                    None,                  // expected_installation_public_key
                 ) else {
                     continue;
                 };
@@ -339,20 +339,37 @@ mod tests {
             .unwrap();
     }
 
-    // #[tokio::test]
-    // async fn test_legacy_identity() {
-    //     let (store, api_client) = get_test_resources().await;
-    //     let conn = store.conn().unwrap();
-    //     let provider = XmtpOpenMlsProvider::new(&conn);
-    //     let wallet = generate_local_wallet();
-    //     let identity = Identity::create_from_legacy(wallet.get_address()).unwrap();
-    //     let text_to_sign = identity.text_to_sign().unwrap();
-    //     let signature = wallet.sign_message(text_to_sign).await.unwrap().to_vec();
-    //     identity
-    //         .register(&provider, &api_client, Some(signature))
-    //         .await
-    //         .unwrap();
-    // }
+    #[tokio::test]
+    async fn test_legacy_identity() {
+        let legacy_address = "0x419cb1fa5635b0c6df47c9dc5765c8f1f4dff78e";
+        let legacy_signed_private_key_proto = vec![
+            8, 128, 154, 196, 133, 220, 244, 197, 216, 23, 18, 34, 10, 32, 214, 70, 104, 202, 68,
+            204, 25, 202, 197, 141, 239, 159, 145, 249, 55, 242, 147, 126, 3, 124, 159, 207, 96,
+            135, 134, 122, 60, 90, 82, 171, 131, 162, 26, 153, 1, 10, 79, 8, 128, 154, 196, 133,
+            220, 244, 197, 216, 23, 26, 67, 10, 65, 4, 232, 32, 50, 73, 113, 99, 115, 168, 104,
+            229, 206, 24, 217, 132, 223, 217, 91, 63, 137, 136, 50, 89, 82, 186, 179, 150, 7, 127,
+            140, 10, 165, 117, 233, 117, 196, 134, 227, 143, 125, 210, 187, 77, 195, 169, 162, 116,
+            34, 20, 196, 145, 40, 164, 246, 139, 197, 154, 233, 190, 148, 35, 131, 240, 106, 103,
+            18, 70, 18, 68, 10, 64, 90, 24, 36, 99, 130, 246, 134, 57, 60, 34, 142, 165, 221, 123,
+            63, 27, 138, 242, 195, 175, 212, 146, 181, 152, 89, 48, 8, 70, 104, 94, 163, 0, 25,
+            196, 228, 190, 49, 108, 141, 60, 174, 150, 177, 115, 229, 138, 92, 105, 170, 226, 204,
+            249, 206, 12, 37, 145, 3, 35, 226, 15, 49, 20, 102, 60, 16, 1,
+        ];
+        let (store, api_client) = get_test_resources().await;
+        let conn = store.conn().unwrap();
+        let provider = XmtpOpenMlsProvider::new(&conn);
+        let identity = Identity::create_from_legacy(
+            legacy_address.to_string(),
+            legacy_signed_private_key_proto,
+        )
+        .unwrap();
+        assert!(identity.text_to_sign().is_none());
+        identity
+            .register(&provider, &api_client, None)
+            .await
+            .unwrap();
+        assert_eq!(identity.account_address, legacy_address);
+    }
 
     #[tokio::test]
     async fn test_invalid_external_signature() {

--- a/xmtp_mls/src/storage/encrypted_store/refresh_state.rs
+++ b/xmtp_mls/src/storage/encrypted_store/refresh_state.rs
@@ -152,7 +152,7 @@ pub(crate) mod tests {
             let entity_kind = EntityKind::Group;
             let entry = RefreshState {
                 entity_id: id.clone(),
-                entity_kind: entity_kind,
+                entity_kind,
                 cursor: 123,
             };
             entry.store(conn).unwrap();

--- a/xmtp_mls/src/verified_key_package.rs
+++ b/xmtp_mls/src/verified_key_package.rs
@@ -128,7 +128,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_invalid_application_id() {
-        let client = ClientBuilder::new_test_client(generate_local_wallet().into()).await;
+        let client = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let conn = client.store.conn().unwrap();
         let provider = client.mls_provider(&conn);
 

--- a/xmtp_user_preferences/src/lib.rs
+++ b/xmtp_user_preferences/src/lib.rs
@@ -63,7 +63,7 @@ mod test {
 
         let encrypted =
             encrypt_message(&pub_key.serialize(), &private_key.serialize(), &message).unwrap();
-        assert!(encrypted.len() > 0);
+        assert!(!encrypted.is_empty());
 
         let decrypted =
             decrypt_message(&pub_key.serialize(), &private_key.serialize(), &encrypted).unwrap();
@@ -78,7 +78,7 @@ mod test {
 
         let encrypted =
             encrypt_message(&pub_key.serialize(), &private_key.serialize(), &message).unwrap();
-        assert!(encrypted.len() > 0);
+        assert!(!encrypted.is_empty());
         let (other_private_key, _) = generate_keypair();
 
         let decrypt_result = decrypt_message(
@@ -87,7 +87,7 @@ mod test {
             &encrypted,
         );
 
-        assert_eq!(decrypt_result.is_err(), true);
+        assert!(decrypt_result.is_err());
     }
 
     #[test]


### PR DESCRIPTION
- Derive v3 credential from v2 identity if needed
- Implement serialization of LegacyCreateIdentityAssociation
- Replace deprecated methods (register_identity_with_external_signature -> register_identity, CreateUnsignedIfNotFound -> CreateIfNotFound)
- Update CLI and bindings