### PR TITLE
Show stream is closed

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -5,7 +5,10 @@ use crate::logger::FfiLogger;
 use crate::GenericError;
 use futures::StreamExt;
 use std::convert::TryInto;
-use std::sync::{Arc, Mutex};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
+};
 use tokio::sync::{oneshot, oneshot::Sender};
 use xmtp_api_grpc::grpc_api_helper::Client as TonicApiClient;
 use xmtp_mls::builder::IdentityStrategy;
@@ -217,6 +220,8 @@ impl FfiConversations {
     ) -> Result<Arc<FfiStreamCloser>, GenericError> {
         let inner_client = Arc::clone(&self.inner_client);
         let (close_sender, close_receiver) = oneshot::channel::<()>();
+        let is_closed = Arc::new(AtomicBool::new(false));
+        let is_closed_clone = is_closed.clone();
 
         tokio::spawn(async move {
             let client = inner_client.as_ref();
@@ -239,11 +244,13 @@ impl FfiConversations {
                     }
                 }
             }
+            is_closed_clone.store(true, Ordering::Relaxed);
             log::info!("closing stream");
         });
 
         Ok(Arc::new(FfiStreamCloser {
             close_fn: Arc::new(Mutex::new(Some(close_sender))),
+            is_closed_atomic: is_closed,
         }))
     }
 }
@@ -366,6 +373,8 @@ impl FfiGroup {
         let group_id = self.group_id.clone();
         let created_at_ns = self.created_at_ns;
         let (close_sender, close_receiver) = oneshot::channel::<()>();
+        let is_closed = Arc::new(AtomicBool::new(false));
+        let is_closed_clone = is_closed.clone();
 
         tokio::spawn(async move {
             let client = inner_client.as_ref();
@@ -385,11 +394,13 @@ impl FfiGroup {
                     }
                 }
             }
+            is_closed_clone.store(true, Ordering::Relaxed);
             log::info!("closing stream");
         });
 
         Ok(Arc::new(FfiStreamCloser {
             close_fn: Arc::new(Mutex::new(Some(close_sender))),
+            is_closed_atomic: is_closed,
         }))
     }
 
@@ -429,6 +440,7 @@ impl From<StoredGroupMessage> for FfiMessage {
 #[derive(uniffi::Object)]
 pub struct FfiStreamCloser {
     close_fn: Arc<Mutex<Option<Sender<()>>>>,
+    is_closed_atomic: Arc<AtomicBool>,
 }
 
 #[uniffi::export]
@@ -442,6 +454,10 @@ impl FfiStreamCloser {
                 log::warn!("close_fn already closed");
             }
         }
+    }
+
+    pub fn is_closed(&self) -> bool {
+        self.is_closed_atomic.load(Ordering::Relaxed)
     }
 }
 
@@ -795,6 +811,7 @@ mod tests {
         assert_eq!(stream_callback.message_count(), 2);
 
         stream.end();
+        assert!(stream.is_closed());
     }
 
     // Disabling this flakey test until it's reliable

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -811,6 +811,7 @@ mod tests {
         assert_eq!(stream_callback.message_count(), 2);
 
         stream.end();
+        tokio::time::sleep(tokio::time::Duration::from_millis(5)).await;
         assert!(stream.is_closed());
     }
 

--- a/dev/docker/docker-compose.yml
+++ b/dev/docker/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - db
 
   validation:
-    image: xmtp/mls-validation-service:latest
+    image: ghcr.io/xmtp/mls-validation-service:main
     platform: linux/amd64
     build:
       context: ../..


### PR DESCRIPTION
## Summary

Callers are probably interested in whether a stream has been closed by the server. This PR exposes that information with a new `is_closed()` method. 