### PR TITLE
Add TLS connection config

### DIFF
--- a/xmtp_api_grpc/src/grpc_api_helper.rs
+++ b/xmtp_api_grpc/src/grpc_api_helper.rs
@@ -33,7 +33,7 @@ async fn create_tls_channel(address: String) -> Result<Channel, Error> {
     let channel = Channel::from_shared(address)
         .map_err(|e| Error::new(ErrorKind::SetupError).with(e))?
         .keep_alive_while_idle(true)
-        .timeout(Duration::from_secs(5))
+        .connect_timeout(Duration::from_secs(5))
         .http2_keep_alive_interval(Duration::from_secs(3))
         .keep_alive_timeout(Duration::from_secs(5))
         .tls_config(ClientTlsConfig::new())

--- a/xmtp_api_grpc/src/grpc_api_helper.rs
+++ b/xmtp_api_grpc/src/grpc_api_helper.rs
@@ -1,6 +1,7 @@
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex}; // TODO switch to async mutexes
+use std::time::Duration;
 
 use futures::stream::{AbortHandle, Abortable};
 use futures::{SinkExt, Stream, StreamExt, TryStreamExt};
@@ -31,6 +32,10 @@ use xmtp_proto::{
 async fn create_tls_channel(address: String) -> Result<Channel, Error> {
     let channel = Channel::from_shared(address)
         .map_err(|e| Error::new(ErrorKind::SetupError).with(e))?
+        .keep_alive_while_idle(true)
+        .timeout(Duration::from_secs(5))
+        .http2_keep_alive_interval(Duration::from_secs(3))
+        .keep_alive_timeout(Duration::from_secs(5))
         .tls_config(ClientTlsConfig::new())
         .map_err(|e| Error::new(ErrorKind::SetupError).with(e))?
         .connect()


### PR DESCRIPTION
## Summary

To better catch disconnects, we are adding back some of the timeouts we previously had in the V2 client. Should help with reliability in bad network conditions.

Hat tip for @richardhuaaa for noticing this was missing.