### PR TITLE
Add crate for XPS operations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
   "xmtp_proto",
   "xmtp_user_preferences",
   "xmtp_v2",
-  "xmtp_mls",
+  "xmtp_mls", "xps-client",
 ]
 
 exclude = [

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
 channel = "stable"
 components = [ "rustc", "cargo", "clippy", "rustfmt", "rust-analyzer" ]
-targets = [ "wasm32-unknown-unknown" ]
+targets = [ "wasm32-unknown-unknown", "x86_64-unknown-linux-gnu"]
 profile = "default"

--- a/xps-client/Cargo.toml
+++ b/xps-client/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["web-programming::websocket", "web-programming::http-server", "web
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-lib_xps = { git = "https://github.com/xmtp/xps-gateway", branch = "main", package = "lib-xps" }
+lib-xps = { git = "https://github.com/xmtp/xps-gateway", branch = "main", package = "lib-xps" }
 xps-types = { git = "https://github.com/xmtp/xps-gateway", branch = "main", package = "xps-types" }
 
 xmtp_proto = { path = "../xmtp_proto" }

--- a/xps-client/Cargo.toml
+++ b/xps-client/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "xps-client"
+version = "0.1.0"
+edition = "2021"
+authors = ["XMTP Labs <eng@xmtp.com>"]
+description = "XMTP XPS Client for decentralized operations"
+homepage = "https://github.com/xmtp/libxmtp"
+repository = "https://github.com/xmtp/libxmtp"
+license = "MIT"
+keywords = ["ethereum", "did", "did:ethr", "jsonrpc"]
+categories = ["web-programming::websocket", "web-programming::http-server", "web-programming::http-client", "cryptography::cryptocurrencies"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+lib_xps = { git = "https://github.com/xmtp/xps-gateway", branch = "main", package = "lib-xps" }
+xps-types = { git = "https://github.com/xmtp/xps-gateway", branch = "main", package = "xps-types" }
+
+xmtp_proto = { path = "../xmtp_proto" }
+log.workspace = true
+futures.workspace = true
+
+

--- a/xps-client/src/lib.rs
+++ b/xps-client/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}


### PR DESCRIPTION
Wanted to get some administrative tasks + skeleton out of the way before committing code

- add x86_64-unknown-linux-gnu to `rust-toolchain.toml`

I wasn't actually sure where this should live, but the way we discussed it at the offsite seemed like it would be in `libxmtp`.

this is the crate where we plan to impl `XmtpMlsClient` using [xps](https://github.com/xps-gateway)

~nothing will build yet until [reorg](https://github.com/xmtp/xps-gateway/pull/57) is merged into xps~