### PR TITLE
Adds is_active method to groups

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -416,6 +416,16 @@ impl FfiGroup {
     pub fn created_at_ns(&self) -> i64 {
         self.created_at_ns
     }
+
+    pub fn is_active(&self) -> Result<bool, GenericError> {
+        let group = MlsGroup::new(
+            self.inner_client.as_ref(),
+            self.group_id.clone(),
+            self.created_at_ns,
+        );
+
+        Ok(group.is_active()?)
+    }
 }
 
 #[uniffi::export]

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -323,6 +323,14 @@ where
 
         self.sync_with_conn(conn).await
     }
+
+    pub fn is_active(&self) -> Result<bool, GroupError> {
+        let conn = &self.client.store.conn()?;
+        let provider = XmtpOpenMlsProvider::new(conn);
+        let mls_group = self.load_mls_group(&provider)?;
+
+        Ok(mls_group.is_active())
+    }
 }
 
 fn extract_message_v1(message: GroupMessage) -> Result<GroupMessageV1, MessageProcessingError> {
@@ -703,6 +711,10 @@ mod tests {
         assert_eq!(members_changed_codec.members_removed.len(), 1);
         assert_eq!(members_changed_codec.installations_added.len(), 0);
         assert_eq!(members_changed_codec.installations_removed.len(), 0);
+
+        let bola_group = receive_group_invite(&bola).await;
+        bola_group.sync().await.unwrap();
+        assert!(!bola_group.is_active().unwrap())
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Adds a method `is_active` to groups to check if the current installation is still a member of the group. If the member has been removed, this method will return `false`.

## Notes

We should think about storing this data in the DB instead of pulling it from the OpenMLS Group. Might be more performant there, considering how often this field could be checked in some client applications. We have to load the entire group state from the DB to compute it.

I'll make a TODO ticket for that.