### PR TITLE
Remove `sideEffects` field in `package.json`

### DIFF
--- a/user_preferences_bindings_wasm/.changeset/forty-trains-travel.md
+++ b/user_preferences_bindings_wasm/.changeset/forty-trains-travel.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/user-preferences-bindings-wasm": patch
+---
+
+Remove `sideEffects` field from `package.json`

--- a/user_preferences_bindings_wasm/package-lock.json
+++ b/user_preferences_bindings_wasm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xmtp/user-preferences-bindings-wasm",
-  "version": "0.2.0",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@xmtp/user-preferences-bindings-wasm",
-      "version": "0.2.0",
+      "version": "0.3.4",
       "devDependencies": {
         "@changesets/cli": "^2.26.2",
         "wasm-pack": "^0.12.1"

--- a/user_preferences_bindings_wasm/package.json
+++ b/user_preferences_bindings_wasm/package.json
@@ -40,7 +40,6 @@
       "import": "./dist/web/user_preferences_bindings_wasm.js"
     }
   },
-  "sideEffects": false,
   "devDependencies": {
     "@changesets/cli": "^2.26.2",
     "wasm-pack": "^0.12.1"


### PR DESCRIPTION
the `sideEffects` field causes `webpack` to remove necessary code when building for our MetaMask Snap.