### PR TITLE
Libxmtp Versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,10 @@ _site
 
 # Generated Uniffi definitions
 xmtpv3.kt
+
+# Libxmtp build version
+libxmtp-version.txt
+
+# Directories from v2 branch
+bindings_swift/
+ecies_bindings_wasm/

--- a/bindings_ffi/Makefile
+++ b/bindings_ffi/Makefile
@@ -81,7 +81,7 @@ swift: libxmtp-version
 	mkdir -p build/swift/include
 	mv build/swift/$(PROJECT_NAME)FFI.h build/swift/include/
 	mv build/swift/$(PROJECT_NAME)FFI.modulemap build/swift/include/module.modulemap
-	mv libxmtp-version.txt build/swift/
+	cp libxmtp-version.txt build/swift/
 
 swiftlocal: libxmtpv3.a swift framework 
 

--- a/bindings_ffi/Makefile
+++ b/bindings_ffi/Makefile
@@ -69,7 +69,7 @@ framework: lipo
 		-output LibXMTPRust.xcframework
 
 # build uniffi bindings for swift
-swift:
+swift: libxmtp-version
 	cargo build --release
 	rm -rf build/swift
 	target/release/ffi-uniffi-bindgen generate \
@@ -81,6 +81,7 @@ swift:
 	mkdir -p build/swift/include
 	mv build/swift/$(PROJECT_NAME)FFI.h build/swift/include/
 	mv build/swift/$(PROJECT_NAME)FFI.modulemap build/swift/include/module.modulemap
+	mv libxmtp-version.txt build/swift/
 
 swiftlocal: libxmtpv3.a swift framework 
 

--- a/bindings_ffi/Makefile
+++ b/bindings_ffi/Makefile
@@ -7,6 +7,9 @@ ARCHS_MAC = x86_64-apple-darwin aarch64-apple-darwin
 # ARCHS_MACCATALYST = x86_64-apple-ios-macabi aarch64-apple-ios-macabi
 LIB=libxmtpv3.a
 JAR_DIR=$(shell pwd)/tests/jar
+GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
+GIT_COMMIT_HASH=$(shell git log -1 --pretty=format:"%h")
+GIT_COMMIT_DATE=$(shell TZ=UTC git log -1 --date=iso-local --pretty=format:"%ad")
 
 install-jar:
 	mkdir -p $(JAR_DIR) && \
@@ -26,6 +29,9 @@ download-toolchains:
 	rustup target add aarch64-apple-ios
 
 all: framework
+
+libxmtp-version:
+	echo "Version: $(GIT_COMMIT_HASH)\nBranch: $(GIT_BRANCH)\nDate: $(GIT_COMMIT_DATE)" > libxmtp-version.txt
 
 $(ARCHS_IOS): %:
 	cross build --target $@ --target-dir ./target --release --no-default-features

--- a/bindings_ffi/build.rs
+++ b/bindings_ffi/build.rs
@@ -1,3 +1,9 @@
+use std::process::Command;
+
 fn main() {
     uniffi::generate_scaffolding("./src/xmtpv3.udl").expect("Building the UDL file failed");
+    Command::new("make")
+        .args(&["libxmtp-version"])
+        .status()
+        .expect("failed to make libxmtp-version");
 }

--- a/bindings_ffi/examples/MainActivity.kt
+++ b/bindings_ffi/examples/MainActivity.kt
@@ -84,7 +84,7 @@ class MainActivity : AppCompatActivity() {
                     walletSignature = inboxOwner.sign(textToSign)
                 }
                 client.registerIdentity(walletSignature);
-                textView.text = "Client constructed, wallet address: " + client.accountAddress()
+                textView.text = "Libxmtp version\n" + uniffi.xmtpv3.getVersionInfo() + "\n\nClient constructed, wallet address: " + client.accountAddress()
                 Log.i("App", "Setting up conversation streaming")
                 client.conversations().stream(ConversationCallback());
             } catch (e: Exception) {

--- a/bindings_ffi/gen_kotlin.sh
+++ b/bindings_ffi/gen_kotlin.sh
@@ -9,3 +9,5 @@ bindings_ffi/target/release/ffi-uniffi-bindgen generate \
     $CRATE_NAME/src/$PROJECT_NAME.udl \
     --language kotlin
 popd > /dev/null
+make libxmtp-version
+mv libxmtp-version.txt src/uniffi/$PROJECT_NAME/

--- a/bindings_ffi/gen_kotlin.sh
+++ b/bindings_ffi/gen_kotlin.sh
@@ -10,4 +10,4 @@ bindings_ffi/target/release/ffi-uniffi-bindgen generate \
     --language kotlin
 popd > /dev/null
 make libxmtp-version
-mv libxmtp-version.txt src/uniffi/$PROJECT_NAME/
+cp libxmtp-version.txt src/uniffi/$PROJECT_NAME/

--- a/bindings_ffi/run_swift_local.sh
+++ b/bindings_ffi/run_swift_local.sh
@@ -1,3 +1,4 @@
 # Assumes libxmtp is in a peer directory of libxmtp-swift
 make swift
 cp build/swift/xmtpv3.swift ../../libxmtp-swift/Sources/LibXMTP/xmtpv3.swift
+cp build/swift/libxmtp-version.txt ../../libxmtp-swift/Sources/LibXMTP/libxmtp-version.txt

--- a/bindings_ffi/setup_android_example.sh
+++ b/bindings_ffi/setup_android_example.sh
@@ -12,7 +12,9 @@ cp -r jniLibs $APP_PATH/app/src/main/
 
 # Copy the .kt files to the example project
 rm -f $APP_PATH/app/src/main/java/$PROJECT_NAME.kt
+rm -f $APP_PATH/app/src/main/java/libxmtp-version.txt
 cp src/uniffi/$PROJECT_NAME/$PROJECT_NAME.kt $APP_PATH/app/src/main/java/
+cp src/uniffi/$PROJECT_NAME/libxmtp-version.txt $APP_PATH/app/src/main/java/
 
 # Copy MainActivity.kt and ExampleInstrumentedTest.kt to the example project (comment this out if copying to a different app)
 rm -f $APP_PATH/app/src/main/java/com/example/xmtpv3_example/MainActivity.kt

--- a/bindings_ffi/src/lib.rs
+++ b/bindings_ffi/src/lib.rs
@@ -56,3 +56,18 @@ fn stringify_error_chain<T: Error>(error: &T) -> String {
 
     result
 }
+
+#[uniffi::export]
+pub fn get_version_info() -> String {
+    include_str!("../libxmtp-version.txt").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::get_version_info;
+
+    #[test]
+    pub fn test_get_version_info() {
+        print!("{}", get_version_info());
+    }
+}


### PR DESCRIPTION
Debugging libxmtp issues in the future is going to get confusing with multiple versions of libxmtp integrated between the client SDK's/apps. This creates a libxmtp version file called `libxmtp-version.txt` of the following format. It gets automatically re-generated on every build.
```
Version: 902728d
Branch: rich/libxmtp-version
Date: 2024-02-10 01:31:49 +0000
```

I've updated the various build scripts to place this file next to the `.kt` and `.swift` definitions, so they can be verified at build time and checked into the SDK repo alongside the source. Please let me know if I missed a build script.

![Screenshot 2024-02-09 at 5 58 47 PM](https://github.com/xmtp/libxmtp/assets/696206/2aeee5bb-e982-45d1-bd84-10a6404f9508)

I've also added a method to retrieve the version *at runtime* called `getVersionInfo()`. I think this will be useful to display somewhere in the final app for debugging purposes and bug reports:

![Screenshot 2024-02-09 at 6 11 02 PM](https://github.com/xmtp/libxmtp/assets/696206/aface7f2-9310-4b0f-a1b0-3035d514dc58)

FYI @dmccartney - I'm not sure how the flutter build works, but if you give me some pointers I can add this there as well!