### PR TITLE
Switch to ImmutableMetadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1514,13 +1514,13 @@ dependencies = [
 
 [[package]]
 name = "ethers"
-version = "2.0.11"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5344eea9b20effb5efeaad29418215c4d27017639fd1f908260f59cbbd226e"
+checksum = "6c7cd562832e2ff584fa844cd2f6e5d4f35bbe11b28c7c9b8df957b2e1d0c701"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
- "ethers-core 2.0.11",
+ "ethers-core 2.0.13",
  "ethers-etherscan",
  "ethers-middleware",
  "ethers-providers",
@@ -1530,11 +1530,11 @@ dependencies = [
 
 [[package]]
 name = "ethers-addressbook"
-version = "2.0.11"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c405f24ea3a517899ba7985385c43dc4a7eb1209af3b1e0a1a32d7dcc7f8d09"
+checksum = "35dc9a249c066d17e8947ff52a4116406163cf92c7f0763cb8c001760b26403f"
 dependencies = [
- "ethers-core 2.0.11",
+ "ethers-core 2.0.13",
  "once_cell",
  "serde",
  "serde_json",
@@ -1542,14 +1542,14 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract"
-version = "2.0.11"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0111ead599d17a7bff6985fd5756f39ca7033edc79a31b23026a8d5d64fa95cd"
+checksum = "43304317c7f776876e47f2f637859f6d0701c1ec7930a150f169d5fbe7d76f5a"
 dependencies = [
  "const-hex",
  "ethers-contract-abigen",
  "ethers-contract-derive",
- "ethers-core 2.0.11",
+ "ethers-core 2.0.13",
  "ethers-providers",
  "futures-util",
  "once_cell",
@@ -1561,14 +1561,14 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-abigen"
-version = "2.0.11"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51258120c6b47ea9d9bec0d90f9e8af71c977fbefbef8213c91bfed385fe45eb"
+checksum = "f9f96502317bf34f6d71a3e3d270defaa9485d754d789e15a8e04a84161c95eb"
 dependencies = [
  "Inflector",
  "const-hex",
  "dunce",
- "ethers-core 2.0.11",
+ "ethers-core 2.0.13",
  "ethers-etherscan",
  "eyre",
  "prettyplease 0.2.16",
@@ -1585,14 +1585,14 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-derive"
-version = "2.0.11"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936e7a0f1197cee2b62dc89f63eff3201dbf87c283ff7e18d86d38f83b845483"
+checksum = "452ff6b0a64507ce8d67ffd48b1da3b42f03680dcf5382244e9c93822cbbf5de"
 dependencies = [
  "Inflector",
  "const-hex",
  "ethers-contract-abigen",
- "ethers-core 2.0.11",
+ "ethers-core 2.0.13",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -1628,9 +1628,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-core"
-version = "2.0.11"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f03e0bdc216eeb9e355b90cf610ef6c5bb8aca631f97b5ae9980ce34ea7878d"
+checksum = "aab3cef6cc1c9fd7f787043c81ad3052eff2b96a3878ef1526aa446311bdbfc9"
 dependencies = [
  "arrayvec",
  "bytes 1.5.0",
@@ -1658,12 +1658,12 @@ dependencies = [
 
 [[package]]
 name = "ethers-etherscan"
-version = "2.0.11"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abbac2c890bdbe0f1b8e549a53b00e2c4c1de86bb077c1094d1f38cdf9381a56"
+checksum = "16d45b981f5fa769e1d0343ebc2a44cfa88c9bc312eb681b676318b40cef6fb1"
 dependencies = [
  "chrono",
- "ethers-core 2.0.11",
+ "ethers-core 2.0.13",
  "reqwest",
  "semver",
  "serde",
@@ -1674,14 +1674,14 @@ dependencies = [
 
 [[package]]
 name = "ethers-middleware"
-version = "2.0.11"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "681ece6eb1d10f7cf4f873059a77c04ff1de4f35c63dd7bccde8f438374fcb93"
+checksum = "145211f34342487ef83a597c1e69f0d3e01512217a7c72cc8a25931854c7dca0"
 dependencies = [
  "async-trait",
  "auto_impl",
  "ethers-contract",
- "ethers-core 2.0.11",
+ "ethers-core 2.0.13",
  "ethers-etherscan",
  "ethers-providers",
  "ethers-signers",
@@ -1701,9 +1701,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-providers"
-version = "2.0.11"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25d6c0c9455d93d4990c06e049abf9b30daf148cf461ee939c11d88907c60816"
+checksum = "fb6b15393996e3b8a78ef1332d6483c11d839042c17be58decc92fa8b1c3508a"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1711,7 +1711,7 @@ dependencies = [
  "bytes 1.5.0",
  "const-hex",
  "enr",
- "ethers-core 2.0.11",
+ "ethers-core 2.0.13",
  "futures-channel",
  "futures-core",
  "futures-timer",
@@ -1739,9 +1739,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-signers"
-version = "2.0.11"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb1b714e227bbd2d8c53528adb580b203009728b17d0d0e4119353aa9bc5532"
+checksum = "b3b125a103b56aef008af5d5fb48191984aa326b50bfd2557d231dc499833de3"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1749,7 +1749,7 @@ dependencies = [
  "const-hex",
  "elliptic-curve 0.13.8",
  "eth-keystore",
- "ethers-core 2.0.11",
+ "ethers-core 2.0.13",
  "rand 0.8.5",
  "sha2 0.10.8",
  "thiserror",
@@ -1758,15 +1758,15 @@ dependencies = [
 
 [[package]]
 name = "ethers-solc"
-version = "2.0.11"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64f710586d147864cff66540a6d64518b9ff37d73ef827fee430538265b595f"
+checksum = "d21df08582e0a43005018a858cc9b465c5fff9cf4056651be64f844e57d1f55f"
 dependencies = [
  "cfg-if 1.0.0",
  "const-hex",
  "dirs 5.0.1",
  "dunce",
- "ethers-core 2.0.11",
+ "ethers-core 2.0.13",
  "glob",
  "home",
  "md-5",
@@ -2761,9 +2761,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
+checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3423,7 +3423,7 @@ dependencies = [
 [[package]]
 name = "openmls"
 version = "0.5.0"
-source = "git+https://github.com/xmtp/openmls?branch=main#acc326fc8fc66ba57192cd822894b02f9f94cb46"
+source = "git+https://github.com/xmtp/openmls?rev=0da7dcb#0da7dcb79d7f66e520041b54c34f82a10216cd72"
 dependencies = [
  "backtrace",
  "itertools 0.10.5",
@@ -3444,7 +3444,7 @@ dependencies = [
 [[package]]
 name = "openmls_basic_credential"
 version = "0.2.0"
-source = "git+https://github.com/xmtp/openmls?branch=main#acc326fc8fc66ba57192cd822894b02f9f94cb46"
+source = "git+https://github.com/xmtp/openmls?rev=0da7dcb#0da7dcb79d7f66e520041b54c34f82a10216cd72"
 dependencies = [
  "ed25519-dalek",
  "openmls_traits",
@@ -3457,7 +3457,7 @@ dependencies = [
 [[package]]
 name = "openmls_memory_keystore"
 version = "0.2.0"
-source = "git+https://github.com/xmtp/openmls?branch=main#acc326fc8fc66ba57192cd822894b02f9f94cb46"
+source = "git+https://github.com/xmtp/openmls?rev=0da7dcb#0da7dcb79d7f66e520041b54c34f82a10216cd72"
 dependencies = [
  "openmls_traits",
  "serde_json",
@@ -3467,7 +3467,7 @@ dependencies = [
 [[package]]
 name = "openmls_rust_crypto"
 version = "0.2.0"
-source = "git+https://github.com/xmtp/openmls?branch=main#acc326fc8fc66ba57192cd822894b02f9f94cb46"
+source = "git+https://github.com/xmtp/openmls?rev=0da7dcb#0da7dcb79d7f66e520041b54c34f82a10216cd72"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -3491,7 +3491,7 @@ dependencies = [
 [[package]]
 name = "openmls_traits"
 version = "0.2.0"
-source = "git+https://github.com/xmtp/openmls?branch=main#acc326fc8fc66ba57192cd822894b02f9f94cb46"
+source = "git+https://github.com/xmtp/openmls?rev=0da7dcb#0da7dcb79d7f66e520041b54c34f82a10216cd72"
 dependencies = [
  "serde",
  "tls_codec",
@@ -6138,9 +6138,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
+checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -6148,9 +6148,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
+checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
 dependencies = [
  "bumpalo",
  "log",
@@ -6163,9 +6163,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.39"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
+checksum = "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -6175,9 +6175,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
+checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6185,9 +6185,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
+checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6198,9 +6198,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
+checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
 
 [[package]]
 name = "web-sys"
@@ -6553,7 +6553,7 @@ dependencies = [
  "clap",
  "env_logger",
  "ethers",
- "ethers-core 2.0.11",
+ "ethers-core 2.0.13",
  "futures",
  "hex",
  "log",
@@ -6598,7 +6598,7 @@ dependencies = [
  "curve25519-dalek",
  "ecdsa 0.15.1",
  "ethers",
- "ethers-core 2.0.11",
+ "ethers-core 2.0.13",
  "hex",
  "k256 0.12.0",
  "log",
@@ -6622,7 +6622,7 @@ dependencies = [
  "diesel",
  "diesel_migrations",
  "ethers",
- "ethers-core 2.0.11",
+ "ethers-core 2.0.13",
  "flume",
  "futures",
  "hex",
@@ -6687,7 +6687,7 @@ dependencies = [
  "chrono",
  "ecdsa 0.15.1",
  "ethers",
- "ethers-core 2.0.11",
+ "ethers-core 2.0.13",
  "generic-array 0.14.7",
  "getrandom 0.2.12",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,10 @@ futures = "0.3.30"
 futures-core = "0.3.30"
 hex = "0.4.3"
 log = "0.4.20"
-openmls = { git = "https://github.com/xmtp/openmls", branch = "main" }
-openmls_basic_credential = { git = "https://github.com/xmtp/openmls", branch = "main" }
-openmls_rust_crypto = { git = "https://github.com/xmtp/openmls", branch = "main" }
-openmls_traits = { git = "https://github.com/xmtp/openmls", branch = "main" }
+openmls = { git = "https://github.com/xmtp/openmls", rev = "0da7dcb" }
+openmls_basic_credential = { git = "https://github.com/xmtp/openmls", rev = "0da7dcb" }
+openmls_rust_crypto = { git = "https://github.com/xmtp/openmls", rev = "0da7dcb" }
+openmls_traits = { git = "https://github.com/xmtp/openmls", rev = "0da7dcb" }
 prost = "0.11"
 prost-types = " 0.11"
 rand = "0.8.5"

--- a/bindings_ffi/Cargo.lock
+++ b/bindings_ffi/Cargo.lock
@@ -1242,9 +1242,9 @@ dependencies = [
 
 [[package]]
 name = "ethers"
-version = "2.0.11"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5344eea9b20effb5efeaad29418215c4d27017639fd1f908260f59cbbd226e"
+checksum = "6c7cd562832e2ff584fa844cd2f6e5d4f35bbe11b28c7c9b8df957b2e1d0c701"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1258,9 +1258,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-addressbook"
-version = "2.0.12"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bf35eb7d2e2092ad41f584951e08ec7c077b142dba29c4f1b8f52d2efddc49c"
+checksum = "35dc9a249c066d17e8947ff52a4116406163cf92c7f0763cb8c001760b26403f"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1270,9 +1270,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract"
-version = "2.0.11"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0111ead599d17a7bff6985fd5756f39ca7033edc79a31b23026a8d5d64fa95cd"
+checksum = "43304317c7f776876e47f2f637859f6d0701c1ec7930a150f169d5fbe7d76f5a"
 dependencies = [
  "const-hex",
  "ethers-contract-abigen",
@@ -1289,9 +1289,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-abigen"
-version = "2.0.12"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbdfb952aafd385b31d316ed80d7b76215ce09743c172966d840e96924427e0c"
+checksum = "f9f96502317bf34f6d71a3e3d270defaa9485d754d789e15a8e04a84161c95eb"
 dependencies = [
  "Inflector",
  "const-hex",
@@ -1313,9 +1313,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-derive"
-version = "2.0.12"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7465c814a2ecd0de0442160da13584205d1cdc08f4717a6511cad455bd5d7dc4"
+checksum = "452ff6b0a64507ce8d67ffd48b1da3b42f03680dcf5382244e9c93822cbbf5de"
 dependencies = [
  "Inflector",
  "const-hex",
@@ -1329,9 +1329,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-core"
-version = "2.0.12"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "918b1a9ba585ea61022647def2f27c29ba19f6d2a4a4c8f68a9ae97fd5769737"
+checksum = "aab3cef6cc1c9fd7f787043c81ad3052eff2b96a3878ef1526aa446311bdbfc9"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1359,9 +1359,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-etherscan"
-version = "2.0.12"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "facabf8551b4d1a3c08cb935e7fca187804b6c2525cc0dafb8e5a6dd453a24de"
+checksum = "16d45b981f5fa769e1d0343ebc2a44cfa88c9bc312eb681b676318b40cef6fb1"
 dependencies = [
  "chrono",
  "ethers-core",
@@ -1375,9 +1375,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-middleware"
-version = "2.0.11"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "681ece6eb1d10f7cf4f873059a77c04ff1de4f35c63dd7bccde8f438374fcb93"
+checksum = "145211f34342487ef83a597c1e69f0d3e01512217a7c72cc8a25931854c7dca0"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1402,9 +1402,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-providers"
-version = "2.0.11"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25d6c0c9455d93d4990c06e049abf9b30daf148cf461ee939c11d88907c60816"
+checksum = "fb6b15393996e3b8a78ef1332d6483c11d839042c17be58decc92fa8b1c3508a"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1439,9 +1439,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-signers"
-version = "2.0.11"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb1b714e227bbd2d8c53528adb580b203009728b17d0d0e4119353aa9bc5532"
+checksum = "b3b125a103b56aef008af5d5fb48191984aa326b50bfd2557d231dc499833de3"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1458,9 +1458,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-solc"
-version = "2.0.12"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2e46e3ec8ef0c986145901fa9864205dc4dcee701f9846be2d56112d34bdea"
+checksum = "d21df08582e0a43005018a858cc9b465c5fff9cf4056651be64f844e57d1f55f"
 dependencies = [
  "cfg-if",
  "const-hex",
@@ -2556,7 +2556,7 @@ dependencies = [
 [[package]]
 name = "openmls"
 version = "0.5.0"
-source = "git+https://github.com/xmtp/openmls?branch=main#a12c7435209b6714531bc0a1619f4fdf7c57d7c0"
+source = "git+https://github.com/xmtp/openmls?rev=0da7dcb#0da7dcb79d7f66e520041b54c34f82a10216cd72"
 dependencies = [
  "backtrace",
  "itertools 0.10.5",
@@ -2577,7 +2577,7 @@ dependencies = [
 [[package]]
 name = "openmls_basic_credential"
 version = "0.2.0"
-source = "git+https://github.com/xmtp/openmls?branch=main#a12c7435209b6714531bc0a1619f4fdf7c57d7c0"
+source = "git+https://github.com/xmtp/openmls?rev=0da7dcb#0da7dcb79d7f66e520041b54c34f82a10216cd72"
 dependencies = [
  "ed25519-dalek",
  "openmls_traits",
@@ -2590,7 +2590,7 @@ dependencies = [
 [[package]]
 name = "openmls_memory_keystore"
 version = "0.2.0"
-source = "git+https://github.com/xmtp/openmls?branch=main#a12c7435209b6714531bc0a1619f4fdf7c57d7c0"
+source = "git+https://github.com/xmtp/openmls?rev=0da7dcb#0da7dcb79d7f66e520041b54c34f82a10216cd72"
 dependencies = [
  "openmls_traits",
  "serde_json",
@@ -2600,7 +2600,7 @@ dependencies = [
 [[package]]
 name = "openmls_rust_crypto"
 version = "0.2.0"
-source = "git+https://github.com/xmtp/openmls?branch=main#a12c7435209b6714531bc0a1619f4fdf7c57d7c0"
+source = "git+https://github.com/xmtp/openmls?rev=0da7dcb#0da7dcb79d7f66e520041b54c34f82a10216cd72"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -2624,7 +2624,7 @@ dependencies = [
 [[package]]
 name = "openmls_traits"
 version = "0.2.0"
-source = "git+https://github.com/xmtp/openmls?branch=main#a12c7435209b6714531bc0a1619f4fdf7c57d7c0"
+source = "git+https://github.com/xmtp/openmls?rev=0da7dcb#0da7dcb79d7f66e520041b54c34f82a10216cd72"
 dependencies = [
  "serde",
  "tls_codec",

--- a/bindings_ffi/Cargo.toml
+++ b/bindings_ffi/Cargo.toml
@@ -28,8 +28,8 @@ name = "ffi-uniffi-bindgen"
 path = "src/bin.rs"
 
 [dev-dependencies]
-ethers = "2.0.4"
-ethers-core = "2.0.4"
+ethers = "2.0.13"
+ethers-core = "2.0.13"
 tempfile = "3.5.0"
 tokio = { version = "1.28.1", features = ["full"] }
 uniffi = { version = "0.25.3", features = ["bindgen-tests"] }

--- a/bindings_wasm/Cargo.toml
+++ b/bindings_wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
+edition = "2021"
 name = "bindings_wasm"
 version = "0.1.0"
-edition = "2021"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -13,15 +13,15 @@ hex = "0.4"
 js-sys = "0.3"
 prost = { version = "0.11", features = ["prost-derive"] }
 prost-types = "0.11"
-wasm-bindgen = "0.2.87"
-wasm-bindgen-futures = "0.4.37"
+wasm-bindgen = "0.2.91"
+wasm-bindgen-futures = "0.4.41"
 xmtp_api_grpc_gateway = { path = "../xmtp_api_grpc_gateway" }
 xmtp_cryptography = { path = "../xmtp_cryptography", features = ["ws"] }
 xmtp_proto = { path = "../xmtp_proto", features = ["proto_full"] }
 
 [dev-dependencies]
 uuid = { version = "1.3.1", features = ["v4"] }
-wasm-bindgen-test = "0.3.34"
+wasm-bindgen-test = "0.3.41"
 
 [profile.release]
 opt-level = "s"

--- a/mls_validation_service/Cargo.toml
+++ b/mls_validation_service/Cargo.toml
@@ -30,5 +30,5 @@ xmtp_proto = { path = "../xmtp_proto", features = [
 ] }
 
 [dev-dependencies]
-ethers = "2.0.10"
-rand = "0.8.5"
+ethers = "2.0.13"
+rand = { workspace = true }

--- a/xmtp_mls/Cargo.toml
+++ b/xmtp_mls/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
+edition = "2021"
 name = "xmtp_mls"
 version = "0.1.0"
-edition = "2021"
 
 [[bin]]
 doc = false
@@ -10,9 +10,9 @@ path = "src/bin/update-schema.rs"
 
 [features]
 default = ["types", "native"]
-types = []
 grpc = ["xmtp_proto/grpc"]
 native = ["libsqlite3-sys/bundled-sqlcipher-vendored-openssl"]
+types = []
 
 [dependencies]
 anyhow = "1.0.71"
@@ -30,9 +30,7 @@ futures = "0.3.28"
 hex = "0.4.3"
 libsqlite3-sys = { version = "0.26.0", optional = true }
 log = "0.4.17"
-openmls = { workspace = true, features = [
-    "test-utils",
-] }
+openmls = { workspace = true, features = ["test-utils"] }
 openmls_basic_credential = { workspace = true }
 openmls_rust_crypto = { workspace = true }
 openmls_traits = { workspace = true }
@@ -54,7 +52,6 @@ xmtp_v2 = { path = "../xmtp_v2" }
 ctor = "0.2"
 flume = "0.11"
 mockall = "0.11.4"
-rand = "0.8.5"
 tempfile = "3.5.0"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 xmtp_api_grpc = { path = "../xmtp_api_grpc" }

--- a/xmtp_mls/src/groups/group_metadata.rs
+++ b/xmtp_mls/src/groups/group_metadata.rs
@@ -79,11 +79,11 @@ impl TryFrom<GroupMetadata> for Vec<u8> {
     }
 }
 
-impl TryFrom<&[u8]> for GroupMetadata {
+impl TryFrom<&Vec<u8>> for GroupMetadata {
     type Error = GroupMetadataError;
 
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        let proto_val = GroupMetadataProto::decode(value)?;
+    fn try_from(value: &Vec<u8>) -> Result<Self, Self::Error> {
+        let proto_val = GroupMetadataProto::decode(value.as_slice())?;
         Self::from_proto(proto_val)
     }
 }
@@ -127,7 +127,7 @@ pub fn extract_group_metadata(group: &OpenMlsGroup) -> Result<GroupMetadata, Gro
     let extension = group
         .export_group_context()
         .extensions()
-        .protected_metadata()
+        .immutable_metadata()
         .ok_or(GroupMetadataError::MissingExtension)?;
 
     extension.metadata().try_into()

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -7,7 +7,7 @@ mod sync;
 pub mod validated_commit;
 
 use openmls::{
-    extensions::{Extension, Extensions, ProtectedMetadata},
+    extensions::{Extension, Extensions, Metadata},
     group::{MlsGroupCreateConfig, MlsGroupJoinConfig},
     prelude::{
         CredentialWithKey, CryptoConfig, GroupId, MlsGroup as OpenMlsGroup, Welcome as MlsWelcome,
@@ -364,15 +364,9 @@ fn build_protected_metadata_extension(
         identity.account_address.clone(),
         policies,
     );
-    let protected_metadata = ProtectedMetadata::new(
-        &identity.installation_keys,
-        identity.application_id(),
-        identity.credential()?,
-        identity.installation_keys.to_public_vec(),
-        metadata.try_into()?,
-    )?;
+    let protected_metadata = Metadata::new(metadata.try_into()?);
 
-    Ok(Extension::ProtectedMetadata(protected_metadata))
+    Ok(Extension::ImmutableMetadata(protected_metadata))
 }
 
 fn build_group_config(


### PR DESCRIPTION
## Summary

- Upgrades OpenMLS to the latest version, which includes a simplified version of Immutable Metadata
- Upgrades a few dependencies to the latest version, which will allow us to do the next upgrade of OpenMLS