### PR TITLE
Make permissions configurable

### DIFF
--- a/bindings_flutter/src/libxmtp_api.rs
+++ b/bindings_flutter/src/libxmtp_api.rs
@@ -104,7 +104,7 @@ impl Client {
     }
 
     pub async fn create_group(&self, account_addresses: Vec<String>) -> Result<Group, XmtpError> {
-        let group = self.inner.client.create_group()?;
+        let group = self.inner.client.create_group(None)?;
         // TODO: consider filtering self address from the list
         if !account_addresses.is_empty() {
             group.add_members(account_addresses).await?;

--- a/xmtp_mls/src/groups/group_permissions.rs
+++ b/xmtp_mls/src/groups/group_permissions.rs
@@ -332,10 +332,37 @@ fn default_remove_installation_policy() -> MembershipPolicies {
     MembershipPolicies::deny()
 }
 
-// The default policy set for a group
-// Currently set to allow everyone to do everything
-pub(crate) fn default_group_policy() -> PolicySet {
+/// A policy where any member can add or remove any other member
+pub(crate) fn policy_everyone_is_admin() -> PolicySet {
     PolicySet::new(MembershipPolicies::allow(), MembershipPolicies::allow())
+}
+
+/// A policy where only the group creator can add or remove members
+pub(crate) fn policy_group_creator_is_admin() -> PolicySet {
+    PolicySet::new(
+        MembershipPolicies::allow_if_actor_creator(),
+        MembershipPolicies::allow_if_actor_creator(),
+    )
+}
+
+pub enum PreconfiguredPolicies {
+    EveryoneIsAdmin,
+    GroupCreatorIsAdmin,
+}
+
+impl PreconfiguredPolicies {
+    pub fn to_policy_set(&self) -> PolicySet {
+        match self {
+            PreconfiguredPolicies::EveryoneIsAdmin => policy_everyone_is_admin(),
+            PreconfiguredPolicies::GroupCreatorIsAdmin => policy_group_creator_is_admin(),
+        }
+    }
+}
+
+impl Default for PreconfiguredPolicies {
+    fn default() -> Self {
+        PreconfiguredPolicies::EveryoneIsAdmin
+    }
 }
 
 #[cfg(test)]

--- a/xmtp_mls/src/groups/members.rs
+++ b/xmtp_mls/src/groups/members.rs
@@ -74,7 +74,7 @@ mod tests {
         let bola_a = ClientBuilder::new_test_client(&bola_wallet).await;
         let bola_b = ClientBuilder::new_test_client(&bola_wallet).await;
 
-        let group = amal.create_group().unwrap();
+        let group = amal.create_group(None).unwrap();
         // Add both of Bola's installations to the group
         group
             .add_members_by_installation_id(vec![

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -6,19 +6,14 @@ mod subscriptions;
 mod sync;
 pub mod validated_commit;
 
-use openmls::{
-    extensions::{Extension, Extensions, ProtectedMetadata},
-    group::{MlsGroupCreateConfig, MlsGroupJoinConfig},
-    prelude::{
-        CredentialWithKey, CryptoConfig, GroupId, MlsGroup as OpenMlsGroup, Welcome as MlsWelcome,
-        WireFormatPolicy,
-    },
+pub use self::group_permissions::PreconfiguredPolicies;
+pub use self::intents::{AddressesOrInstallationIds, IntentError};
+use self::{
+    group_metadata::{ConversationType, GroupMetadata, GroupMetadataError},
+    group_permissions::PolicySet,
+    intents::{AddMembersIntentData, RemoveMembersIntentData},
+    validated_commit::CommitValidationError,
 };
-use openmls_traits::OpenMlsProvider;
-use thiserror::Error;
-
-use intents::SendMessageIntentData;
-
 use crate::{
     client::{deserialize_welcome, ClientError, MessageProcessingError},
     configuration::CIPHERSUITE,
@@ -39,7 +34,17 @@ use crate::{
     xmtp_openmls_provider::XmtpOpenMlsProvider,
     Client, Store,
 };
-
+use intents::SendMessageIntentData;
+use openmls::{
+    extensions::{Extension, Extensions, ProtectedMetadata},
+    group::{MlsGroupCreateConfig, MlsGroupJoinConfig},
+    prelude::{
+        CredentialWithKey, CryptoConfig, GroupId, MlsGroup as OpenMlsGroup, Welcome as MlsWelcome,
+        WireFormatPolicy,
+    },
+};
+use openmls_traits::OpenMlsProvider;
+use thiserror::Error;
 use xmtp_cryptography::signature::is_valid_ed25519_public_key;
 use xmtp_proto::{
     api_client::XmtpMlsClient,
@@ -47,15 +52,6 @@ use xmtp_proto::{
         group_message::{Version as GroupMessageVersion, V1 as GroupMessageV1},
         GroupMessage,
     },
-};
-
-pub use self::intents::{AddressesOrInstallationIds, IntentError};
-
-use self::{
-    group_metadata::{ConversationType, GroupMetadata, GroupMetadataError},
-    group_permissions::{default_group_policy, PolicySet},
-    intents::{AddMembersIntentData, RemoveMembersIntentData},
-    validated_commit::CommitValidationError,
 };
 
 #[derive(Debug, Error)]
@@ -160,11 +156,16 @@ where
     pub fn create_and_insert(
         client: &'c Client<ApiClient>,
         membership_state: GroupMembershipState,
+        permissions: Option<PreconfiguredPolicies>,
     ) -> Result<Self, GroupError> {
         let conn = client.store.conn()?;
         let provider = XmtpOpenMlsProvider::new(&conn);
-        let protected_metadata =
-            build_protected_metadata_extension(&client.identity, default_group_policy())?;
+        let protected_metadata = build_protected_metadata_extension(
+            &client.identity,
+            permissions
+                .unwrap_or(PreconfiguredPolicies::default())
+                .to_policy_set(),
+        )?;
         let group_config = build_group_config(protected_metadata)?;
 
         let mut mls_group = OpenMlsGroup::new(
@@ -438,7 +439,7 @@ mod tests {
     async fn test_send_message() {
         let wallet = generate_local_wallet();
         let client = ClientBuilder::new_test_client(&wallet).await;
-        let group = client.create_group().expect("create group");
+        let group = client.create_group(None).expect("create group");
         group.send_message(b"hello").await.expect("send message");
 
         let messages = client
@@ -454,7 +455,7 @@ mod tests {
     async fn test_receive_self_message() {
         let wallet = generate_local_wallet();
         let client = ClientBuilder::new_test_client(&wallet).await;
-        let group = client.create_group().expect("create group");
+        let group = client.create_group(None).expect("create group");
         let msg = b"hello";
         group.send_message(msg).await.expect("send message");
 
@@ -474,7 +475,7 @@ mod tests {
         let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let charlie = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
-        let amal_group = amal.create_group().unwrap();
+        let amal_group = amal.create_group(None).unwrap();
         // Add bola
         amal_group
             .add_members_by_installation_id(vec![bola.installation_public_key()])
@@ -540,7 +541,7 @@ mod tests {
     async fn test_add_installation() {
         let client = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let client_2 = ClientBuilder::new_test_client(&generate_local_wallet()).await;
-        let group = client.create_group().expect("create group");
+        let group = client.create_group(None).expect("create group");
 
         group
             .add_members_by_installation_id(vec![client_2.installation_public_key()])
@@ -561,7 +562,7 @@ mod tests {
     #[tokio::test]
     async fn test_add_invalid_member() {
         let client = ClientBuilder::new_test_client(&generate_local_wallet()).await;
-        let group = client.create_group().expect("create group");
+        let group = client.create_group(None).expect("create group");
 
         let result = group
             .add_members_by_installation_id(vec![b"1234".to_vec()])
@@ -574,7 +575,7 @@ mod tests {
     async fn test_add_unregistered_member() {
         let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let unconnected_wallet_address = generate_local_wallet().get_address();
-        let group = amal.create_group().unwrap();
+        let group = amal.create_group(None).unwrap();
         let result = group.add_members(vec![unconnected_wallet_address]).await;
 
         assert!(result.is_err());
@@ -586,7 +587,7 @@ mod tests {
         // Add another client onto the network
         let client_2 = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
-        let group = client_1.create_group().expect("create group");
+        let group = client_1.create_group(None).expect("create group");
         group
             .add_members_by_installation_id(vec![client_2.installation_public_key()])
             .await
@@ -621,7 +622,7 @@ mod tests {
         let client = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bola_client = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
-        let group = client.create_group().expect("create group");
+        let group = client.create_group(None).expect("create group");
         group
             .add_members(vec![bola_client.account_address()])
             .await
@@ -656,7 +657,7 @@ mod tests {
     async fn test_post_commit() {
         let client = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let client_2 = ClientBuilder::new_test_client(&generate_local_wallet()).await;
-        let group = client.create_group().expect("create group");
+        let group = client.create_group(None).expect("create group");
 
         group
             .add_members_by_installation_id(vec![client_2.installation_public_key()])
@@ -679,7 +680,7 @@ mod tests {
         let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let charlie = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
-        let group = amal.create_group().unwrap();
+        let group = amal.create_group(None).unwrap();
         group
             .add_members(vec![bola.account_address(), charlie.account_address()])
             .await
@@ -724,7 +725,7 @@ mod tests {
         let amal = ClientBuilder::new_test_client(&amal_wallet).await;
         let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
-        let group = amal.create_group().unwrap();
+        let group = amal.create_group(None).unwrap();
         group
             .add_members(vec![bola.account_address()])
             .await
@@ -762,7 +763,7 @@ mod tests {
         let amal = ClientBuilder::new_test_client(&amal_wallet).await;
         let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
-        let group = amal.create_group().unwrap();
+        let group = amal.create_group(None).unwrap();
         group
             .add_members(vec![bola.account_address()])
             .await
@@ -787,7 +788,7 @@ mod tests {
         let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let charlie = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let dave = ClientBuilder::new_test_client(&generate_local_wallet()).await;
-        let amal_group = amal.create_group().unwrap();
+        let amal_group = amal.create_group(None).unwrap();
         // Add bola to the group
         amal_group
             .add_members(vec![bola.account_address()])

--- a/xmtp_mls/src/groups/subscriptions.rs
+++ b/xmtp_mls/src/groups/subscriptions.rs
@@ -92,7 +92,7 @@ mod tests {
         let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
-        let amal_group = amal.create_group().unwrap();
+        let amal_group = amal.create_group(None).unwrap();
         // Add bola
         amal_group
             .add_members_by_installation_id(vec![bola.installation_public_key()])
@@ -119,7 +119,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
     async fn test_subscribe_multiple() {
         let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
-        let group = amal.create_group().unwrap();
+        let group = amal.create_group(None).unwrap();
 
         let stream = group.stream().await.unwrap();
 
@@ -148,7 +148,7 @@ mod tests {
         let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
-        let amal_group = amal.create_group().unwrap();
+        let amal_group = amal.create_group(None).unwrap();
 
         let mut stream = amal_group.stream().await.unwrap();
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;

--- a/xmtp_mls/src/groups/validated_commit.rs
+++ b/xmtp_mls/src/groups/validated_commit.rs
@@ -374,7 +374,7 @@ mod tests {
         let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bola_key_package = get_key_package(&bola);
 
-        let amal_group = amal.create_group().unwrap();
+        let amal_group = amal.create_group(None).unwrap();
         let amal_conn = amal.store.conn().unwrap();
         let amal_provider = amal.mls_provider(&amal_conn);
         let mut mls_group = amal_group.load_mls_group(&amal_provider).unwrap();
@@ -445,7 +445,7 @@ mod tests {
         let amal_1_provider = amal_1.mls_provider(&amal_1_conn);
         let amal_2_provider = amal_2.mls_provider(&amal_2_conn);
 
-        let amal_group = amal_1.create_group().unwrap();
+        let amal_group = amal_1.create_group(None).unwrap();
         let mut amal_mls_group = amal_group.load_mls_group(&amal_1_provider).unwrap();
 
         let amal_2_kp = amal_2.identity.new_key_package(&amal_2_provider).unwrap();
@@ -483,7 +483,7 @@ mod tests {
         let amal_provider = amal.mls_provider(&amal_conn);
         let bola_provider = bola.mls_provider(&bola_conn);
 
-        let amal_group = amal.create_group().unwrap();
+        let amal_group = amal.create_group(None).unwrap();
         let mut amal_mls_group = amal_group.load_mls_group(&amal_provider).unwrap();
 
         // Create a key package with a malformed credential


### PR DESCRIPTION
## Summary

- Adds optional `permissions` parameter to group creation, allowing devs to configure groups where only the group creator can add/remove members
- Bubbles this up to the bindings so that SDK devs can add the new option.
- This will be a breaking change for iOS/Android since it adds a new parameter to `createGroup`