### PR TITLE
feat: adds installation list to maybe update when send_message

### DIFF
--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -222,6 +222,9 @@ where
 
     pub async fn send_message(&self, message: &[u8]) -> Result<(), GroupError> {
         let conn = &mut self.client.store.conn()?;
+
+        self.maybe_update_installation_list(conn).await?;
+
         let intent_data: Vec<u8> = SendMessageIntentData::new(message.to_vec()).into();
         let intent =
             NewGroupIntent::new(IntentKind::SendMessage, self.group_id.clone(), intent_data);


### PR DESCRIPTION
## Summary

follow up to https://github.com/xmtp/libxmtp/pull/496#issuecomment-1939261167

This patch extends:  checking for the last time the installation list was updated, and updates it if enough time (30 min) has passed,  and adds that process when `send_message()` is called as well as `sync()`.