### PR TITLE
fix: quicken the interval to update install list

### DIFF
--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -226,7 +226,8 @@ where
 
         let update_interval = Some(1_000_000); // 1 second in ns
 
-        self.maybe_update_installation_list(conn, update_interval).await?;
+        self.maybe_update_installation_list(conn, update_interval)
+            .await?;
 
         let intent_data: Vec<u8> = SendMessageIntentData::new(message.to_vec()).into();
         let intent =

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -224,7 +224,7 @@ where
     pub async fn send_message(&self, message: &[u8]) -> Result<(), GroupError> {
         let conn = &mut self.client.store.conn()?;
 
-        let update_interval = Some(1_000_000); // 1 second in ns
+        let update_interval = Some(5_000_000); // 5 seconds in ns
 
         self.maybe_update_installation_list(conn, update_interval)
             .await?;

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -224,7 +224,9 @@ where
     pub async fn send_message(&self, message: &[u8]) -> Result<(), GroupError> {
         let conn = &mut self.client.store.conn()?;
 
-        self.maybe_update_installation_list(conn).await?;
+        let update_interval = Some(1_000_000); // 1 second in ns
+
+        self.maybe_update_installation_list(conn, update_interval).await?;
 
         let intent_data: Vec<u8> = SendMessageIntentData::new(message.to_vec()).into();
         let intent =

--- a/xmtp_mls/src/groups/sync.rs
+++ b/xmtp_mls/src/groups/sync.rs
@@ -636,7 +636,7 @@ where
             Some(val) => val,
             None => UPDATE_INSTALLATION_LIST_INTERVAL_NS,
         };
-        
+
         let now = crate::utils::time::now_ns();
         let last = conn.get_installation_list_time_checked(self.group_id.clone())?;
         let elapsed = now - last;


### PR DESCRIPTION
## Summary

@nplasterer noticed that it is a bad UX to have to wait to get multiple devices' messages synced. 

This patch sets the interval when `send` messages to ~~1 second~~ 5 seconds to update the list (as opposed to 30 minutes).    