### PR TITLE
Expose group metadata

### DIFF
--- a/bindings_ffi/src/lib.rs
+++ b/bindings_ffi/src/lib.rs
@@ -26,6 +26,8 @@ pub enum GenericError {
     GroupError(#[from] xmtp_mls::groups::GroupError),
     #[error("Signature: {0}")]
     Signature(#[from] xmtp_cryptography::signature::SignatureError),
+    #[error("Group metadata: {0}")]
+    GroupMetadata(#[from] xmtp_mls::groups::group_metadata::GroupMetadataError),
     #[error("Generic {err}")]
     Generic { err: String },
 }

--- a/xmtp_mls/src/groups/group_permissions.rs
+++ b/xmtp_mls/src/groups/group_permissions.rs
@@ -345,6 +345,7 @@ pub(crate) fn policy_group_creator_is_admin() -> PolicySet {
     )
 }
 
+#[derive(Debug, Clone, PartialEq)]
 pub enum PreconfiguredPolicies {
     EveryoneIsAdmin,
     GroupCreatorIsAdmin,
@@ -355,6 +356,16 @@ impl PreconfiguredPolicies {
         match self {
             PreconfiguredPolicies::EveryoneIsAdmin => policy_everyone_is_admin(),
             PreconfiguredPolicies::GroupCreatorIsAdmin => policy_group_creator_is_admin(),
+        }
+    }
+
+    pub fn from_policy_set(policy_set: &PolicySet) -> Result<Self, PolicyError> {
+        if policy_set.eq(&policy_everyone_is_admin()) {
+            Ok(PreconfiguredPolicies::EveryoneIsAdmin)
+        } else if policy_set.eq(&policy_group_creator_is_admin()) {
+            Ok(PreconfiguredPolicies::GroupCreatorIsAdmin)
+        } else {
+            Err(PolicyError::InvalidPolicy)
         }
     }
 }

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -1,4 +1,4 @@
-mod group_metadata;
+pub mod group_metadata;
 mod group_permissions;
 mod intents;
 mod members;
@@ -6,6 +6,7 @@ mod subscriptions;
 mod sync;
 pub mod validated_commit;
 
+use self::group_metadata::extract_group_metadata;
 pub use self::group_permissions::PreconfiguredPolicies;
 pub use self::intents::{AddressesOrInstallationIds, IntentError};
 use self::{
@@ -337,6 +338,14 @@ where
         let mls_group = self.load_mls_group(&provider)?;
 
         Ok(mls_group.is_active())
+    }
+
+    pub fn metadata(&self) -> Result<GroupMetadata, GroupError> {
+        let conn = &self.client.store.conn()?;
+        let provider = XmtpOpenMlsProvider::new(conn);
+        let mls_group = self.load_mls_group(&provider)?;
+
+        Ok(extract_group_metadata(&mls_group)?)
     }
 }
 


### PR DESCRIPTION
## Summary

We want to be able to expose the policies and `creator_account_address` of a group so that integrators can use this information to tailor the UI.

This adds that in `libxmtp`

## Notes

This setup works well for simple policies. I think in future we are going to want more tailored methods to answer questions like "can I add a new member" that works for more complex policies (like ones involving admin roles). That can come later and build on top of this, I think.