### PR TITLE
[1/2] stream_all_messages: bindings and streaming messages from an unchanging group list

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -915,6 +915,8 @@ mod tests {
             .await
             .unwrap();
 
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
         let caro_group = caro
             .conversations()
             .create_group(vec![bo.account_address()], None)
@@ -929,6 +931,7 @@ mod tests {
             .stream_all_messages(Box::new(stream_callback.clone()))
             .await
             .unwrap();
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
         alix_group.send("first".as_bytes().to_vec()).await.unwrap();
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -935,7 +935,7 @@ mod tests {
         alix_group.send("third".as_bytes().to_vec()).await.unwrap();
         caro_group.send("fourth".as_bytes().to_vec()).await.unwrap();
 
-        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+        tokio::time::sleep(tokio::time::Duration::from_millis(400)).await;
 
         assert_eq!(stream_callback.message_count(), 4);
         stream.end();

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -931,11 +931,13 @@ mod tests {
             .unwrap();
 
         alix_group.send("first".as_bytes().to_vec()).await.unwrap();
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
         caro_group.send("second".as_bytes().to_vec()).await.unwrap();
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
         alix_group.send("third".as_bytes().to_vec()).await.unwrap();
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
         caro_group.send("fourth".as_bytes().to_vec()).await.unwrap();
-
-        tokio::time::sleep(tokio::time::Duration::from_millis(400)).await;
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
         assert_eq!(stream_callback.message_count(), 4);
         stream.end();

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -935,7 +935,7 @@ mod tests {
         alix_group.send("third".as_bytes().to_vec()).await.unwrap();
         caro_group.send("fourth".as_bytes().to_vec()).await.unwrap();
 
-        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
 
         assert_eq!(stream_callback.message_count(), 4);
         stream.end();

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -130,6 +130,16 @@ pub struct MlsGroup<'c, ApiClient> {
     client: &'c Client<ApiClient>,
 }
 
+impl<'c, ApiClient> Clone for MlsGroup<'c, ApiClient> {
+    fn clone(&self) -> Self {
+        Self {
+            client: self.client,
+            group_id: self.group_id.clone(),
+            created_at_ns: self.created_at_ns,
+        }
+    }
+}
+
 impl<'c, ApiClient> MlsGroup<'c, ApiClient>
 where
     ApiClient: XmtpMlsClient,
@@ -340,6 +350,13 @@ where
 fn extract_message_v1(message: GroupMessage) -> Result<GroupMessageV1, MessageProcessingError> {
     match message.version {
         Some(GroupMessageVersion::V1(value)) => Ok(value),
+        _ => Err(MessageProcessingError::InvalidPayload),
+    }
+}
+
+pub fn extract_group_id(message: &GroupMessage) -> Result<Vec<u8>, MessageProcessingError> {
+    match &message.version {
+        Some(GroupMessageVersion::V1(value)) => Ok(value.group_id.clone()),
         _ => Err(MessageProcessingError::InvalidPayload),
     }
 }

--- a/xmtp_mls/src/groups/subscriptions.rs
+++ b/xmtp_mls/src/groups/subscriptions.rs
@@ -12,7 +12,7 @@ impl<'c, ApiClient> MlsGroup<'c, ApiClient>
 where
     ApiClient: XmtpMlsClient,
 {
-    async fn process_stream_entry(
+    pub(crate) async fn process_stream_entry(
         &self,
         envelope: GroupMessage,
     ) -> Result<Option<StoredGroupMessage>, GroupError> {

--- a/xmtp_mls/src/lib.rs
+++ b/xmtp_mls/src/lib.rs
@@ -10,6 +10,7 @@ pub mod identity;
 pub mod owner;
 pub mod retry;
 pub mod storage;
+pub mod subscriptions;
 pub mod types;
 pub mod utils;
 pub mod verified_key_package;

--- a/xmtp_mls/src/subscriptions.rs
+++ b/xmtp_mls/src/subscriptions.rs
@@ -111,7 +111,7 @@ where
 {
     pub fn stream_conversations_with_callback(
         client: Arc<Client<ApiClient>>,
-        callback: impl Fn(MlsGroup<ApiClient>) -> () + Send + 'static,
+        callback: impl Fn(MlsGroup<ApiClient>) + Send + 'static,
     ) -> Result<StreamCloser, ClientError> {
         let (close_sender, close_receiver) = oneshot::channel::<()>();
         let is_closed = Arc::new(AtomicBool::new(false));

--- a/xmtp_mls/src/subscriptions.rs
+++ b/xmtp_mls/src/subscriptions.rs
@@ -1,0 +1,175 @@
+use std::{collections::HashMap, pin::Pin};
+
+use futures::{Stream, StreamExt};
+use xmtp_proto::{api_client::XmtpMlsClient, xmtp::mls::api::v1::WelcomeMessage};
+
+use crate::{
+    api_client_wrapper::GroupFilter,
+    client::{extract_welcome_message, ClientError},
+    groups::{extract_group_id, GroupError, MlsGroup},
+    storage::group_message::StoredGroupMessage,
+    Client,
+};
+
+struct MessagesStreamInfo<'c, ApiClient> {
+    group: MlsGroup<'c, ApiClient>,
+    cursor: u64,
+}
+
+impl<'c, ApiClient> Clone for MessagesStreamInfo<'c, ApiClient> {
+    fn clone(&self) -> Self {
+        Self {
+            group: self.group.clone(),
+            cursor: self.cursor,
+        }
+    }
+}
+
+impl<'a, ApiClient> Client<ApiClient>
+where
+    ApiClient: XmtpMlsClient,
+{
+    fn process_streamed_welcome(
+        &self,
+        welcome: WelcomeMessage,
+    ) -> Result<MlsGroup<ApiClient>, ClientError> {
+        let welcome_v1 = extract_welcome_message(welcome)?;
+        let conn = self.store.conn()?;
+        let provider = self.mls_provider(&conn);
+
+        MlsGroup::create_from_encrypted_welcome(
+            self,
+            &provider,
+            welcome_v1.hpke_public_key.as_slice(),
+            welcome_v1.data,
+        )
+        .map_err(|e| ClientError::Generic(e.to_string()))
+    }
+
+    pub async fn stream_conversations(
+        &'a self,
+    ) -> Result<Pin<Box<dyn Stream<Item = MlsGroup<ApiClient>> + Send + 'a>>, ClientError> {
+        let installation_key = self.installation_public_key();
+        let id_cursor = 0;
+
+        let subscription = self
+            .api_client
+            .subscribe_welcome_messages(installation_key, Some(id_cursor as u64))
+            .await?;
+
+        let stream = subscription
+            .map(|welcome_result| async {
+                let welcome = welcome_result?;
+                self.process_streamed_welcome(welcome)
+            })
+            .filter_map(|res| async {
+                match res.await {
+                    Ok(group) => Some(group),
+                    Err(err) => {
+                        log::error!("Error processing stream entry: {:?}", err);
+                        None
+                    }
+                }
+            });
+
+        Ok(Box::pin(stream))
+    }
+
+    pub async fn stream_all_messages(
+        &'a self,
+    ) -> Result<Pin<Box<dyn Stream<Item = StoredGroupMessage> + 'a + Send>>, ClientError> {
+        let _groups_stream = self.stream_conversations().await?;
+        self.sync_welcomes().await?;
+        let group_id_to_info: HashMap<Vec<u8>, MessagesStreamInfo<'a, ApiClient>> = self
+            .find_groups(None, None, None, None)?
+            .into_iter()
+            .map(|group| {
+                (
+                    group.group_id.clone(),
+                    MessagesStreamInfo { group, cursor: 0 },
+                )
+            })
+            .collect();
+
+        let filters: Vec<GroupFilter> = group_id_to_info
+            .iter()
+            .map(|(group_id, info)| GroupFilter::new(group_id.clone(), Some(info.cursor)))
+            .collect();
+        let messages_subscription = self.api_client.subscribe_group_messages(filters).await?;
+        let group_id_to_info_clone = group_id_to_info.clone();
+        let stream = messages_subscription
+            .map(move |res| {
+                let group_id_to_info_clone = group_id_to_info_clone.clone();
+                async move {
+                    match res {
+                        Ok(envelope) => {
+                            let group_id = extract_group_id(&envelope)?;
+                            group_id_to_info_clone
+                                .get(&group_id)
+                                .ok_or(ClientError::StreamInconsistency(
+                                    "Received message for a non-subscribed group".to_string(),
+                                ))?
+                                .group
+                                .process_stream_entry(envelope)
+                                .await
+                        }
+                        Err(err) => Err(GroupError::Api(err)),
+                    }
+                }
+            })
+            .filter_map(move |res| async {
+                match res.await {
+                    Ok(Some(message)) => Some(message),
+                    Ok(None) => None,
+                    Err(err) => {
+                        log::error!("Error processing stream entry: {:?}", err);
+                        None
+                    }
+                }
+            });
+
+        Ok(Box::pin(stream))
+        // loop {
+        //     tokio::select! {
+        //         item = groups_stream.next() => {
+        //             match item {
+        //                 Some(convo) => callback.on_conversation(Arc::new(FfiGroup {
+        //                     inner_client: inner_client.clone(),
+        //                     group_id: convo.group_id,
+        //                     created_at_ns: convo.created_at_ns,
+        //                 })),
+        //                 None => break
+        //             }
+        //         }
+        //         _ = &mut close_receiver => {
+        //             break;
+        //         }
+        //     }
+        // }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::StreamExt;
+    use xmtp_cryptography::utils::generate_local_wallet;
+
+    use crate::builder::ClientBuilder;
+
+    #[tokio::test]
+    async fn test_stream_welcomes() {
+        let alice = ClientBuilder::new_test_client(&generate_local_wallet()).await;
+        let bob = ClientBuilder::new_test_client(&generate_local_wallet()).await;
+
+        let alice_bob_group = alice.create_group(None).unwrap();
+
+        let mut bob_stream = bob.stream_conversations().await.unwrap();
+        alice_bob_group
+            .add_members(vec![bob.account_address()])
+            .await
+            .unwrap();
+
+        let bob_received_groups = bob_stream.next().await.unwrap();
+        assert_eq!(bob_received_groups.group_id, alice_bob_group.group_id);
+    }
+}


### PR DESCRIPTION
Putting this up early, so that work on propagating this to SDK's can begin in parallel. This implements `stream_all_messages()`, but it doesn't pick up messages from any groups that get created after the method was called.

Some of the setup for picking up messages from *new* groups is in this PR, but that functionality won't be complete until the next PR (along with some cleanup). At that point, only the libxmtp binary will need to be updated - the binding interface won't be any different from the one in this PR.

Other changes:
1. Make a file called `subscriptions.rs` and move `process_streamed_welcome` and `stream_conversations` to it - `client.rs` was becoming a monster file.
2. Move the logic for streaming conversations with a callback from the `stream()` method in the bindings into a `stream_conversations_with_callback` method in xmtp_mls. The logic for running an infinite listener loop in a background thread, as well as closing the stream, will also be needed for the groups stream in `stream_all_messages`.