### PR TITLE
CLI Release Process

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -44,17 +44,11 @@ jobs:
           override: true
           target: ${{ matrix.target }}
 
-      # Install latest cross to mitigate unwind linking issue on android builds.
-      # See https://github.com/cross-rs/cross/issues/1222
-      - name: Install rust cross
-        run: |
-          cargo install cross --git https://github.com/cross-rs/cross
-
       - name: Build target
         uses: actions-rs/cargo@v1
         if:
         with:
-          use-cross: ${{ matrix.build != 'macos-aarch64' }}
+          use-cross: false
           command: build
           args: --release --target ${{ matrix.target }} --manifest-path examples/cli/Cargo.toml --target-dir examples/cli/target
 

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -93,15 +93,15 @@ jobs:
           draft: false
           prerelease: true
 
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./examples/cli/target/x86_64-pc-windows-gnu.exe
-          asset_name: cli-x86_64-pc-windows-gnu.exe
-          asset_content_type: application/octet-stream
+      #   - name: Upload Release Asset
+      #     uses: actions/upload-release-asset@v1
+      #     env:
+      #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #     with:
+      #       upload_url: ${{ steps.create_release.outputs.upload_url }}
+      #       asset_path: ./examples/cli/target/x86_64-pc-windows-gnu.exe
+      #       asset_name: cli-x86_64-pc-windows-gnu.exe
+      #       asset_content_type: application/octet-stream
 
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
@@ -112,6 +112,7 @@ jobs:
           asset_path: ./examples/cli/target/aarch64-apple-darwin
           asset_name: cli-aarch64-apple-darwin
           asset_content_type: application/octet-stream
+
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
         env:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Upload binary
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.target }}
+          name: ${{ matrix.build }}
           path: examples/cli/target/${{ matrix.target }}/release/xmtp_cli*
           retention-days: 1
 
@@ -75,7 +75,7 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v3
         with:
-          path: examples/cli/target
+          path: /artifacts
 
       - name: Get short SHA
         id: slug
@@ -110,8 +110,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./examples/cli/target/aarch64-apple-darwin/release/xmtp_cli
-          asset_name: cli-aarch64-apple-darwin
+          asset_path: /artifacts/macos-aarch64/xmtp_cli
+          asset_name: cli-macos-aarch64
           asset_content_type: application/octet-stream
 
       - name: Upload Release Asset
@@ -120,6 +120,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./examples/cli/target/x86_64-unknown-linux-gnu/release/xmtp_cli
-          asset_name: cli-x86_64-unknown-linux-gnu
+          asset_path: /artifacts/linux-x86_64/xmtp_cli
+          asset_name: cli-linux-x86_64
           asset_content_type: application/octet-stream

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v3
         with:
-          path: /artifacts
+          path: ./artifacts
 
       - name: Get short SHA
         id: slug
@@ -110,7 +110,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: /artifacts/macos-aarch64/xmtp_cli
+          asset_path: ./artifacts/macos-aarch64/xmtp_cli
           asset_name: cli-macos-aarch64
           asset_content_type: application/octet-stream
 
@@ -120,6 +120,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: /artifacts/linux-x86_64/xmtp_cli
+          asset_path: ./artifacts/linux-x86_64/xmtp_cli
           asset_name: cli-linux-x86_64
           asset_content_type: application/octet-stream

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -35,7 +35,8 @@ jobs:
             ~/.cargo/git
             ./examples/cli/target/${{ matrix.target }}
           key: ${{ matrix.target }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
-
+      - run: sudo apt install musl-tools
+        if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
       - name: Install rust
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -17,7 +17,7 @@ jobs:
             os: warp-ubuntu-latest-x64-16x
             target: x86_64-unknown-linux-gnu
           - build: macos-aarch64
-            os: macos-latest
+            os: warp-macos-13-arm64-6x
             target: aarch64-apple-darwin
         #   - build: windows-x86_64-gnu
         #     os: windows-latest

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -57,6 +57,7 @@ jobs:
           retention-days: 1
 
   release:
+    needs: ["build"]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         build:
           - linux-x86_64
-          - windows-x86_64-gnu
+          #   - windows-x86_64-gnu
           - macos-aarch64
         include:
           - build: linux-x86_64
@@ -19,9 +19,9 @@ jobs:
           - build: macos-aarch64
             os: macos-latest
             target: aarch64-apple-darwin
-        #   - build: windows-x86_64-gnu
-        #     os: windows-latest
-        #     target: x86_64-pc-windows-gnu
+          - build: windows-x86_64-gnu
+            os: windows-latest
+            target: x86_64-pc-windows-gnu
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -2,7 +2,7 @@ name: Release CLI
 on:
   push:
     branches:
-      - nm/cli-release
+      - main
 jobs:
   build:
     strategy:
@@ -10,6 +10,7 @@ jobs:
       matrix:
         build:
           - linux-x86_64
+          #   Windows is erroring right now
           #   - windows-x86_64-gnu
           - macos-aarch64
         include:
@@ -35,6 +36,7 @@ jobs:
             ~/.cargo/git
             ./examples/cli/target/${{ matrix.target }}
           key: ${{ matrix.target }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+
       - run: sudo apt install musl-tools
         if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
       - name: Install rust

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,0 +1,113 @@
+name: Build
+on:
+  push:
+    branches:
+      - nm/cli-release
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          [
+            x86_64-pc-windows-gnu,
+            aarch64-apple-darwin,
+            x86_64-unknown-linux-gnu,
+          ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: "Cache"
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ./target/${{ matrix.target }}
+          key: ${{ matrix.target }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+          target: ${{ matrix.target }}
+
+      # Install latest cross to mitigate unwind linking issue on android builds.
+      # See https://github.com/cross-rs/cross/issues/1222
+      - name: Install rust cross
+        run: |
+          cargo install cross --git https://github.com/cross-rs/cross
+
+      - name: Build target
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --release --target ${{ matrix.target }} --manifest-path examples/cli/Cargo.toml --target-dir examples/cli/target
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: cli-${{ matrix.target }}
+          path: examples/cli/target/${{ matrix.target }}/release/xmtp_cli
+          retention-days: 1
+
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: examples/cli/target
+
+      - name: Get short SHA
+        id: slug
+        run: echo "::set-output name=sha7::$(echo ${GITHUB_SHA} | cut -c1-7)"
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: cli-${{ steps.slug.outputs.sha7 }}
+          release_name: cli-${{ steps.slug.outputs.sha7 }}
+          body: "Release of cli for commit ${{ github.sha}}"
+          draft: false
+          prerelease: true
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./examples/cli/target/x86_64-pc-windows-gnu.exe
+          asset_name: cli-x86_64-pc-windows-gnu.exe
+          asset_content_type: application/octet-stream
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./examples/cli/target/aarch64-apple-darwin
+          asset_name: cli-aarch64-apple-darwin
+          asset_content_type: application/octet-stream
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./examples/cli/target/x86_64-unknown-linux-gnu
+          asset_name: cli-x86_64-unknown-linux-gnu
+          asset_content_type: application/octet-stream

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -5,16 +5,25 @@ on:
       - nm/cli-release
 jobs:
   build:
-    runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
-      matrix:
-        target:
-          [
-            x86_64-pc-windows-gnu,
-            aarch64-apple-darwin,
-            x86_64-unknown-linux-gnu,
-          ]
+        fail-fast: false
+        matrix:
+            build: 
+                - windows-x86_64-gnu,
+                - macos-aarch64
+                - linux-x86_64
+                runs-on: ubuntu-latest
+            include: 
+                - build: linux-x86_64
+                  os: warp-ubuntu-latest-x64-16x
+                  target: x86_64-unknown-linux-gnu
+                - build: macos-aarch64
+                  os: macos-latest
+                  target: aarch64-apple-darwin
+                - build: windows-x86_64-gnu
+                  os: windows-latest
+                  target: x86_64-pc-windows-gnu
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -52,8 +61,8 @@ jobs:
       - name: Upload binary
         uses: actions/upload-artifact@v3
         with:
-          name: cli-${{ matrix.target }}
-          path: examples/cli/target/${{ matrix.target }}/release/xmtp_cli
+          name: cli-${{ matrix.build }}
+          path: examples/cli/target/${{ matrix.target }}/release
           retention-days: 1
 
   release:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - nm/cli-release
 jobs:
   build:
     strategy:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -52,8 +52,9 @@ jobs:
 
       - name: Build target
         uses: actions-rs/cargo@v1
+        if:
         with:
-          use-cross: true
+          use-cross: ${{ matrix.build != 'macos-aarch64' }}
           command: build
           args: --release --target ${{ matrix.target }} --manifest-path examples/cli/Cargo.toml --target-dir examples/cli/target
 
@@ -61,7 +62,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: cli-${{ matrix.build }}
-          path: examples/cli/target/${{ matrix.target }}/release
+          path: examples/cli/target/${{ matrix.target }}/release/xmtp_cli*
           retention-days: 1
 
   release:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -6,12 +6,12 @@ on:
 jobs:
   build:
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         build:
-          - windows-x86_64-gnu,
-          - macos-aarch64
           - linux-x86_64
+          - windows-x86_64-gnu
+          - macos-aarch64
         include:
           - build: linux-x86_64
             os: warp-ubuntu-latest-x64-16x

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -15,7 +15,7 @@ jobs:
         include:
           - build: linux-x86_64
             os: warp-ubuntu-latest-x64-16x
-            target: x86_64-unknown-linux-gnu
+            target: x86_64-unknown-linux-musl
           - build: macos-aarch64
             os: warp-macos-13-arm64-6x
             target: aarch64-apple-darwin

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -6,23 +6,22 @@ on:
 jobs:
   build:
     strategy:
-        fail-fast: false
-        matrix:
-            build: 
-                - windows-x86_64-gnu,
-                - macos-aarch64
-                - linux-x86_64
-                runs-on: ubuntu-latest
-            include: 
-                - build: linux-x86_64
-                  os: warp-ubuntu-latest-x64-16x
-                  target: x86_64-unknown-linux-gnu
-                - build: macos-aarch64
-                  os: macos-latest
-                  target: aarch64-apple-darwin
-                - build: windows-x86_64-gnu
-                  os: windows-latest
-                  target: x86_64-pc-windows-gnu
+      fail-fast: false
+      matrix:
+        build:
+          - windows-x86_64-gnu,
+          - macos-aarch64
+          - linux-x86_64
+        include:
+          - build: linux-x86_64
+            os: warp-ubuntu-latest-x64-16x
+            target: x86_64-unknown-linux-gnu
+          - build: macos-aarch64
+            os: macos-latest
+            target: aarch64-apple-darwin
+          - build: windows-x86_64-gnu
+            os: windows-latest
+            target: x86_64-pc-windows-gnu
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Upload binary
         uses: actions/upload-artifact@v3
         with:
-          name: cli-${{ matrix.build }}
+          name: ${{ matrix.target }}
           path: examples/cli/target/${{ matrix.target }}/release/xmtp_cli*
           retention-days: 1
 
@@ -92,7 +92,7 @@ jobs:
           body: "Release of cli for commit ${{ github.sha}}"
           draft: false
           prerelease: true
-      - run: ls -la ./examples/cli/target
+      - run: ls -la ./examples/cli/target && ls -la ./examples/cli/target/x86_64-unknown-linux-gnu
 
       #   - name: Upload Release Asset
       #     uses: actions/upload-release-asset@v1

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -19,18 +19,13 @@ jobs:
           - build: macos-aarch64
             os: macos-latest
             target: aarch64-apple-darwin
-          - build: windows-x86_64-gnu
-            os: windows-latest
-            target: x86_64-pc-windows-gnu
+        #   - build: windows-x86_64-gnu
+        #     os: windows-latest
+        #     target: x86_64-pc-windows-gnu
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v1
-      - name: Choco help
-        if: ${{ matrix.build == 'windows-x86_64-gnu' }}
-        uses: crazy-max/ghaction-chocolatey@v3
-        with:
-          args: install openssl
 
       - name: "Cache"
         uses: actions/cache@v3
@@ -48,6 +43,12 @@ jobs:
           profile: minimal
           override: true
           target: ${{ matrix.target }}
+
+      - name: Install openssl windows
+        if: ${{ matrix.build == 'windows-x86_64-gnu' }}
+        uses: crazy-max/ghaction-chocolatey@v3
+        with:
+          args: install openssl
 
       - name: Build target
         uses: actions-rs/cargo@v1

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -19,9 +19,9 @@ jobs:
           - build: macos-aarch64
             os: macos-latest
             target: aarch64-apple-darwin
-          - build: windows-x86_64-gnu
-            os: windows-latest
-            target: x86_64-pc-windows-gnu
+        #   - build: windows-x86_64-gnu
+        #     os: windows-latest
+        #     target: x86_64-pc-windows-gnu
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - nm/cli-release
 jobs:
   build:
     strategy:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -92,6 +92,7 @@ jobs:
           body: "Release of cli for commit ${{ github.sha}}"
           draft: false
           prerelease: true
+      - run: ls -la ./examples/cli/target
 
       #   - name: Upload Release Asset
       #     uses: actions/upload-release-asset@v1
@@ -109,7 +110,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./examples/cli/target/aarch64-apple-darwin
+          asset_path: ./examples/cli/target/aarch64-apple-darwin/release/xmtp_cli
           asset_name: cli-aarch64-apple-darwin
           asset_content_type: application/octet-stream
 
@@ -119,6 +120,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./examples/cli/target/x86_64-unknown-linux-gnu
+          asset_path: ./examples/cli/target/x86_64-unknown-linux-gnu/release/xmtp_cli
           asset_name: cli-x86_64-unknown-linux-gnu
           asset_content_type: application/octet-stream

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -26,6 +26,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
+      - name: Choco help
+        if: ${{ matrix.build == 'windows-x86_64-gnu' }}
+        uses: crazy-max/ghaction-chocolatey@v3
+        with:
+          args: install openssl
 
       - name: "Cache"
         uses: actions/cache@v3

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -92,7 +92,6 @@ jobs:
           body: "Release of cli for commit ${{ github.sha}}"
           draft: false
           prerelease: true
-      - run: ls -la ./examples/cli/target && ls -la ./examples/cli/target/x86_64-unknown-linux-gnu
 
       #   - name: Upload Release Asset
       #     uses: actions/upload-release-asset@v1

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -33,7 +33,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            ./target/${{ matrix.target }}
+            ./examples/cli/target/${{ matrix.target }}
           key: ${{ matrix.target }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
 
       - name: Install rust

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Release CLI
 on:
   push:
     branches:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - nm/cli-release
   pull_request:
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - nm/cli-release
   pull_request:
 jobs:
   test:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1507,6 +1507,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
+name = "femme"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc04871e5ae3aa2952d552dae6b291b3099723bf779a8054281c1366a54613ef"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "ff"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5530,6 +5546,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
 dependencies = [
  "cfg-if",
+ "serde",
+ "serde_json",
  "wasm-bindgen-macro",
 ]
 
@@ -5885,9 +5903,9 @@ name = "xmtp_cli"
 version = "0.1.0"
 dependencies = [
  "clap",
- "env_logger",
  "ethers",
  "ethers-core",
+ "femme",
  "futures",
  "hex",
  "kv-log-macro",

--- a/examples/cli/Cargo.toml
+++ b/examples/cli/Cargo.toml
@@ -14,9 +14,9 @@ path = "cli-client.rs"
 
 [dependencies]
 clap = { version = "4.4.6", features = ["derive"] }
-env_logger = "0.10.0"
 ethers = "2.0.4"
 ethers-core = "2.0.4"
+femme = "2.2.1"
 futures = "0.3.28"
 hex = "0.4.3"
 kv-log-macro = "1.0.7"

--- a/examples/cli/README.md
+++ b/examples/cli/README.md
@@ -40,7 +40,7 @@ Use the CLI to send a [double ratchet message](https://github.com/xmtp/libxmtp/b
 6. Add user 2 to the group
 
    ```bash
-   ./xli.sh --db user1.db3 add-group-members --account-addresses $USER_2_ACCOUNT_ADDRESS $GROUP_ID
+   ./xli.sh --db user1.db3 add-group-members $GROUP_ID --account-addresses $USER_2_ACCOUNT_ADDRESS
    ```
 
 7. Send a message

--- a/examples/cli/README.md
+++ b/examples/cli/README.md
@@ -40,7 +40,7 @@ Use the CLI to send a [double ratchet message](https://github.com/xmtp/libxmtp/b
 6. Add user 2 to the group
 
    ```bash
-   ./xli.sh --db user1.db3 add-group-member $GROUP_ID $USER_2_ACCOUNT_ADDRESS
+   ./xli.sh --db user1.db3 add-group-members --account-addresses $USER_2_ACCOUNT_ADDRESS $GROUP_ID
    ```
 
 7. Send a message

--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -84,6 +84,10 @@ enum Commands {
         #[arg(value_name = "Message")]
         msg: String,
     },
+    GroupInfo {
+        #[arg(value_name = "Group ID")]
+        group_id: String,
+    },
     ListGroupMessages {
         #[arg(value_name = "Group ID")]
         group_id: String,
@@ -313,7 +317,17 @@ async fn main() {
             let group_id = hex::encode(group.group_id);
             info!("Created group {}", group_id, { command_output: true, group_id: group_id})
         }
-
+        Commands::GroupInfo { group_id } => {
+            let client = create_client(&cli, IdentityStrategy::CachedOnly)
+                .await
+                .unwrap();
+            let group = &client
+                .group(hex::decode(group_id).expect("bad group id"))
+                .expect("group not found");
+            group.sync().await.unwrap();
+            let serializable: SerializableGroup = group.into();
+            info!("Group {}", group_id, { command_output: true, group_id: group_id, group_info: make_value(&serializable) })
+        }
         Commands::Clear {} => {
             fs::remove_file(cli.db.unwrap()).unwrap();
         }

--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -85,17 +85,17 @@ enum Commands {
         #[arg(value_name = "Group ID")]
         group_id: String,
     },
-    AddGroupMember {
+    AddGroupMembers {
         #[arg(value_name = "Group ID")]
         group_id: String,
-        #[arg(value_name = "Wallet Address")]
-        account_address: String,
+        #[clap(short, long, value_parser, num_args = 1.., value_delimiter = ' ')]
+        account_addresses: Vec<String>,
     },
-    RemoveGroupMember {
+    RemoveGroupMembers {
         #[arg(value_name = "Group ID")]
         group_id: String,
-        #[arg(value_name = "Wallet Address")]
-        account_address: String,
+        #[clap(short, long, value_parser, num_args = 1.., value_delimiter = ' ')]
+        account_addresses: Vec<String>,
     },
     /// Information about the account that owns the DB
     Info {},
@@ -251,9 +251,9 @@ async fn main() {
                 )
             }
         }
-        Commands::AddGroupMember {
+        Commands::AddGroupMembers {
             group_id,
-            account_address,
+            account_addresses,
         } => {
             let client = create_client(&cli, IdentityStrategy::CachedOnly)
                 .await
@@ -264,18 +264,18 @@ async fn main() {
                 .expect("failed to get group");
 
             group
-                .add_members(vec![account_address.clone()])
+                .add_members(account_addresses.clone())
                 .await
                 .expect("failed to add member");
 
             info!(
                 "Successfully added {} to group {}",
-                account_address, group_id, { command_output: true, group_id: group_id}
+                account_addresses.join(", "), group_id, { command_output: true, group_id: group_id}
             );
         }
-        Commands::RemoveGroupMember {
+        Commands::RemoveGroupMembers {
             group_id,
-            account_address,
+            account_addresses,
         } => {
             let client = create_client(&cli, IdentityStrategy::CachedOnly)
                 .await
@@ -286,13 +286,13 @@ async fn main() {
                 .expect("failed to get group");
 
             group
-                .remove_members(vec![account_address.clone()])
+                .remove_members(account_addresses.clone())
                 .await
                 .expect("failed to add member");
 
             info!(
                 "Successfully removed {} from group {}",
-                account_address, group_id, { command_output: true }
+                account_addresses.join(", "), group_id, { command_output: true }
             );
         }
         Commands::CreateGroup { permissions } => {

--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -345,11 +345,11 @@ async fn create_client(cli: &Cli, account: IdentityStrategy) -> Result<Client, C
     builder.build().await.map_err(CliError::ClientBuilder)
 }
 
-async fn register(cli: &Cli, seed_phrase: Option<String>) -> Result<(), CliError> {
-    let w: Wallet = if seed_phrase.is_some() {
+async fn register(cli: &Cli, maybe_seed_phrase: Option<String>) -> Result<(), CliError> {
+    let w: Wallet = if let Some(seed_phrase) = maybe_seed_phrase {
         Wallet::LocalWallet(
             MnemonicBuilder::<English>::default()
-                .phrase(seed_phrase.unwrap().as_str())
+                .phrase(seed_phrase.as_str())
                 .build()
                 .unwrap(),
         )

--- a/examples/cli/serializable.rs
+++ b/examples/cli/serializable.rs
@@ -1,0 +1,78 @@
+use prost::Message;
+use serde::Serialize;
+use xmtp_mls::{
+    codecs::{text::TextCodec, ContentCodec},
+    groups::MlsGroup,
+    storage::group_message::StoredGroupMessage,
+};
+use xmtp_proto::{api_client::XmtpMlsClient, xmtp::mls::message_contents::EncodedContent};
+
+#[derive(Serialize, Debug)]
+pub struct SerializableGroupMetadata {
+    creator_account_address: String,
+    policy: String,
+}
+
+#[derive(Serialize, Debug)]
+pub struct SerializableGroup {
+    pub group_id: String,
+    pub members: Vec<String>,
+    pub metadata: SerializableGroupMetadata,
+}
+
+impl<A: XmtpMlsClient> From<&MlsGroup<'_, A>> for SerializableGroup {
+    fn from(group: &MlsGroup<'_, A>) -> Self {
+        let group_id = hex::encode(group.group_id.clone());
+        let members = group
+            .members()
+            .expect("could not load members")
+            .into_iter()
+            .map(|m| m.account_address)
+            .collect::<Vec<String>>();
+
+        let metadata = group.metadata().expect("could not load metadata");
+
+        Self {
+            group_id,
+            members,
+            metadata: SerializableGroupMetadata {
+                creator_account_address: metadata.creator_account_address.clone(),
+                policy: metadata
+                    .preconfigured_policy()
+                    .expect("could not get policy")
+                    .to_string(),
+            },
+        }
+    }
+}
+
+#[derive(Serialize, Debug, Clone)]
+pub struct SerializableMessage {
+    sender_account_address: String,
+    sent_at_ns: u64,
+    message_text: Option<String>,
+    // content_type: String
+}
+
+impl SerializableMessage {
+    pub fn from_stored_message(msg: &StoredGroupMessage) -> Self {
+        let maybe_text = maybe_get_text(msg);
+        Self {
+            sender_account_address: msg.sender_account_address.clone(),
+            sent_at_ns: msg.sent_at_ns as u64,
+            message_text: maybe_text,
+        }
+    }
+}
+
+pub fn maybe_get_text(msg: &StoredGroupMessage) -> Option<String> {
+    let contents = msg.decrypted_message_bytes.clone();
+    let Ok(encoded_content) = EncodedContent::decode(contents.as_slice()) else {
+        return None;
+    };
+    let Ok(decoded) = TextCodec::decode(encoded_content) else {
+        log::warn!("Skipping over unrecognized codec");
+        return None;
+    };
+    Some(decoded)
+}

--- a/xmtp_api_grpc/src/lib.rs
+++ b/xmtp_api_grpc/src/lib.rs
@@ -53,7 +53,12 @@ mod tests {
         let client = Client::create(LOCALHOST_ADDRESS.to_string(), false)
             .await
             .unwrap();
-        let req = BatchQueryRequest { requests: vec![] };
+        let req = BatchQueryRequest {
+            requests: vec![QueryRequest {
+                content_topics: vec!["foo".to_string()],
+                ..QueryRequest::default()
+            }],
+        };
         let result = client.batch_query(req).await.unwrap();
         assert_eq!(result.responses.len(), 0);
     }

--- a/xmtp_api_grpc/src/lib.rs
+++ b/xmtp_api_grpc/src/lib.rs
@@ -55,12 +55,12 @@ mod tests {
             .unwrap();
         let req = BatchQueryRequest {
             requests: vec![QueryRequest {
-                content_topics: vec!["/junk/some-random-topic-with-no-messages".to_string()],
+                content_topics: vec!["some-random-topic-with-no-messages".to_string()],
                 ..QueryRequest::default()
             }],
         };
         let result = client.batch_query(req).await.unwrap();
-        assert_eq!(result.responses.len(), 0);
+        assert_eq!(result.responses.len(), 1);
     }
 
     #[tokio::test]

--- a/xmtp_api_grpc/src/lib.rs
+++ b/xmtp_api_grpc/src/lib.rs
@@ -55,7 +55,7 @@ mod tests {
             .unwrap();
         let req = BatchQueryRequest {
             requests: vec![QueryRequest {
-                content_topics: vec!["foo".to_string()],
+                content_topics: vec!["/junk/some-random-topic-with-no-messages".to_string()],
                 ..QueryRequest::default()
             }],
         };

--- a/xmtp_mls/src/groups/group_permissions.rs
+++ b/xmtp_mls/src/groups/group_permissions.rs
@@ -345,8 +345,9 @@ pub(crate) fn policy_group_creator_is_admin() -> PolicySet {
     )
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub enum PreconfiguredPolicies {
+    #[default]
     EveryoneIsAdmin,
     GroupCreatorIsAdmin,
 }
@@ -367,12 +368,6 @@ impl PreconfiguredPolicies {
         } else {
             Err(PolicyError::InvalidPolicy)
         }
-    }
-}
-
-impl Default for PreconfiguredPolicies {
-    fn default() -> Self {
-        PreconfiguredPolicies::EveryoneIsAdmin
     }
 }
 

--- a/xmtp_mls/src/groups/group_permissions.rs
+++ b/xmtp_mls/src/groups/group_permissions.rs
@@ -376,6 +376,12 @@ impl Default for PreconfiguredPolicies {
     }
 }
 
+impl std::fmt::Display for PreconfiguredPolicies {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::utils::test::{rand_account_address, rand_vec};


### PR DESCRIPTION
## Summary

- Adds a release pipeline for the CLI so that we can have binaries built for linux and MacOS that can be easily downloaded
- Updates the CLI to support registering to the network with a seed phrase. This should make it easier to incorporate with existing wallets and the V2 SDK, since you can share the wallet and register with both
- Adds support for prettier logging to the CLI and fixes up json logging with the `--json` option
- Adds support for adding/removing multiple members at one time

## Notes

One side effect of this is that every merge to main will trigger a release, which creates a tag and triggers the `Release` workflow that runs on `tags: *`. That doesn't seem so bad, but we can always filter down which release tags we want to run the Workflow from if it is a total of compute.