### PR TITLE
Fix failing grpc test

### DIFF
--- a/xmtp_api_grpc/src/lib.rs
+++ b/xmtp_api_grpc/src/lib.rs
@@ -53,9 +53,17 @@ mod tests {
         let client = Client::create(LOCALHOST_ADDRESS.to_string(), false)
             .await
             .unwrap();
-        let req = BatchQueryRequest { requests: vec![] };
+        let req = BatchQueryRequest {
+            requests: vec![QueryRequest {
+                content_topics: vec!["test".to_string()],
+                start_time_ns: 0,
+                end_time_ns: 0,
+                paging_info: None,
+            }],
+        };
         let result = client.batch_query(req).await.unwrap();
-        assert_eq!(result.responses.len(), 0);
+        assert_eq!(result.responses.len(), 1);
+        assert_eq!(result.responses[0].envelopes.len(), 0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
This test seems to be blocking a few PR's from landing.

It's failing now because the server behavior is slightly different [on this line](https://github.com/xmtp/xmtp-node-go/blob/aded2d716bca5950de9491817e8a262c3d3af82f/pkg/api/message/v1/service.go#L396) after [this PR](https://github.com/xmtp/xmtp-node-go/pull/354/files)