### PR TITLE
fix: mostly clippy annotation warnings

### DIFF
--- a/examples/cli/json_logger.rs
+++ b/examples/cli/json_logger.rs
@@ -48,7 +48,7 @@ fn get_level(level: log::Level) -> u8 {
     }
 }
 
-fn format_kv_pairs<'b>(out: &mut StdoutLock<'b>, record: &Record) {
+fn format_kv_pairs(out: &mut StdoutLock<'_>, record: &Record) {
     struct Visitor<'a, 'b> {
         string: &'a mut StdoutLock<'b>,
     }
@@ -73,7 +73,7 @@ fn format_kv_pairs<'b>(out: &mut StdoutLock<'b>, record: &Record) {
     record.key_values().visit(&mut visitor).unwrap();
 }
 
-pub fn make_value<'v, ValueType>(value: &'v ValueType) -> log::kv::Value<'v>
+pub fn make_value<ValueType>(value: &ValueType) -> log::kv::Value<'_>
 where
     ValueType: serde::Serialize,
 {

--- a/xmtp_mls/src/credential/validated_legacy_signed_public_key.rs
+++ b/xmtp_mls/src/credential/validated_legacy_signed_public_key.rs
@@ -108,8 +108,8 @@ impl TryFrom<LegacySignedPublicKeyProto> for ValidatedLegacySignedPublicKey {
 
         Ok(Self {
             account_address,
-            wallet_signature: wallet_signature,
-            serialized_key_data: serialized_key_data,
+            wallet_signature,
+            serialized_key_data,
             public_key_bytes,
             created_ns,
         })

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -164,6 +164,7 @@ where
     }
 
     // Create a new group and save it to the DB
+    #[allow(clippy::unwrap_or_default)]
     pub fn create_and_insert(
         client: &'c Client<ApiClient>,
         membership_state: GroupMembershipState,

--- a/xmtp_mls/src/storage/encrypted_store/mod.rs
+++ b/xmtp_mls/src/storage/encrypted_store/mod.rs
@@ -183,7 +183,7 @@ impl EncryptedMessageStore {
 }
 
 #[allow(dead_code)]
-fn warn_length<T>(list: &Vec<T>, str_id: &str, max_length: usize) {
+fn warn_length<T>(list: &[T], str_id: &str, max_length: usize) {
     if list.len() > max_length {
         warn!(
             "EncryptedStore expected at most {} {} however found {}. Using the Oldest.",


### PR DESCRIPTION
## Summary

Friday evening housekeeping.  Fixes some clippy annotation warnings and other noise in our GH actions.

As much as I'd like to also quiet the annotation warnings from the proto gen ones, I'm going to leave the auto-generated code alone and leave it to the upstream generator to someday 🤞 correctly annotate generated code.

