### PR TITLE
chore: clippy cleanup in bindings_ffi

### DIFF
--- a/bindings_ffi/build.rs
+++ b/bindings_ffi/build.rs
@@ -3,7 +3,7 @@ use std::process::Command;
 fn main() {
     uniffi::generate_scaffolding("./src/xmtpv3.udl").expect("Building the UDL file failed");
     Command::new("make")
-        .args(&["libxmtp-version"])
+        .args(["libxmtp-version"])
         .status()
         .expect("failed to make libxmtp-version");
 }

--- a/bindings_ffi/src/logger.rs
+++ b/bindings_ffi/src/logger.rs
@@ -20,7 +20,7 @@ impl log::Log for RustLogger {
             self.logger.lock().expect("Logger mutex is poisoned!").log(
                 record.level() as u32,
                 record.level().to_string(),
-                format!("[libxmtp] {}", record.args().to_string()),
+                format!("[libxmtp] {}", record.args()),
             );
         }
     }

--- a/bindings_ffi/src/v2.rs
+++ b/bindings_ffi/src/v2.rs
@@ -167,11 +167,11 @@ impl From<FfiV2QueryRequest> for QueryRequest {
             start_time_ns: req.start_time_ns,
             end_time_ns: req.end_time_ns,
             paging_info: req.paging_info.map(|paging_info| {
-                return PagingInfo {
+                PagingInfo {
                     limit: paging_info.limit,
                     direction: paging_info.direction as i32,
                     cursor: paging_info.cursor.map(|c| c.into()), // TODO: fix me
-                };
+                }
             }),
         }
     }
@@ -183,12 +183,10 @@ impl From<QueryRequest> for FfiV2QueryRequest {
             content_topics: req.content_topics,
             start_time_ns: req.start_time_ns,
             end_time_ns: req.end_time_ns,
-            paging_info: req.paging_info.map(|paging_info| {
-                return FfiPagingInfo {
-                    limit: paging_info.limit,
-                    direction: FfiSortDirection::from_i32(paging_info.direction),
-                    cursor: proto_cursor_to_ffi(paging_info.cursor),
-                };
+            paging_info: req.paging_info.map(|paging_info| FfiPagingInfo {
+                limit: paging_info.limit,
+                direction: FfiSortDirection::from_i32(paging_info.direction),
+                cursor: proto_cursor_to_ffi(paging_info.cursor),
             }),
         }
     }
@@ -204,12 +202,10 @@ impl From<QueryResponse> for FfiV2QueryResponse {
     fn from(resp: QueryResponse) -> Self {
         Self {
             envelopes: resp.envelopes.into_iter().map(|env| env.into()).collect(),
-            paging_info: resp.paging_info.map(|paging_info| {
-                return FfiPagingInfo {
-                    limit: paging_info.limit,
-                    direction: FfiSortDirection::from_i32(paging_info.direction),
-                    cursor: None,
-                };
+            paging_info: resp.paging_info.map(|paging_info| FfiPagingInfo {
+                limit: paging_info.limit,
+                direction: FfiSortDirection::from_i32(paging_info.direction),
+                cursor: None,
             }),
         }
     }
@@ -220,11 +216,11 @@ impl From<FfiV2QueryResponse> for QueryResponse {
         Self {
             envelopes: resp.envelopes.into_iter().map(|env| env.into()).collect(),
             paging_info: resp.paging_info.map(|paging_info| {
-                return PagingInfo {
+                PagingInfo {
                     limit: paging_info.limit,
                     direction: paging_info.direction as i32,
                     cursor: None, // TODO: fix me
-                };
+                }
             }),
         }
     }

--- a/bindings_flutter/src/libxmtp_api.rs
+++ b/bindings_flutter/src/libxmtp_api.rs
@@ -121,7 +121,7 @@ impl Client {
                 created_at_ns: group.created_at_ns,
             })
             .collect();
-        return Ok(groups);
+        Ok(groups)
     }
 
     pub async fn create_group(&self, account_addresses: Vec<String>) -> Result<Group, XmtpError> {
@@ -131,10 +131,10 @@ impl Client {
             group.add_members(account_addresses).await?;
         }
         self.inner.sync_welcomes().await?;
-        return Ok(Group {
+        Ok(Group {
             group_id: group.group_id,
             created_at_ns: group.created_at_ns,
-        });
+        })
     }
 
     pub async fn list_members(&self, group_id: Vec<u8>) -> Result<Vec<GroupMember>, XmtpError> {
@@ -223,9 +223,9 @@ pub struct SignatureRequiredClient {
 impl SignatureRequiredClient {
     pub async fn sign(&self, signature: Vec<u8>) -> Result<Client, XmtpError> {
         self.inner.register_identity(Some(signature)).await?;
-        return Ok(Client {
+        Ok(Client {
             inner: self.inner.clone(),
-        });
+        })
     }
 }
 
@@ -259,10 +259,10 @@ pub async fn create_client(
     if text_to_sign.is_none() {
         return Ok(CreatedClient::Ready(Client { inner }));
     }
-    return Ok(CreatedClient::RequiresSignature(SignatureRequiredClient {
+    Ok(CreatedClient::RequiresSignature(SignatureRequiredClient {
         text_to_sign: text_to_sign.unwrap(),
         inner,
-    }));
+    }))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Small Friday cleanup.  Addresses all but one clippy warnings in the `bindings_{ffi, flutter}/` crates.