### PR TITLE
fix: streaming disconnect after delay

### DIFF
--- a/xmtp_api_grpc/src/grpc_api_helper.rs
+++ b/xmtp_api_grpc/src/grpc_api_helper.rs
@@ -33,7 +33,6 @@ async fn create_tls_channel(address: String) -> Result<Channel, Error> {
         .map_err(|e| Error::new(ErrorKind::SetupError).with(e))?
         .keep_alive_while_idle(true)
         .connect_timeout(Duration::from_secs(5))
-        .http2_keep_alive_interval(Duration::from_secs(10))
         .keep_alive_timeout(Duration::from_secs(25))
         .tls_config(ClientTlsConfig::new())
         .map_err(|e| Error::new(ErrorKind::SetupError).with(e))?

--- a/xmtp_api_grpc/src/lib.rs
+++ b/xmtp_api_grpc/src/lib.rs
@@ -249,7 +249,7 @@ mod tests {
     #[tokio::test]
     async fn long_lived_subscribe_test() {
         let auth_token = get_auth_token();
-        tokio::time::timeout(std::time::Duration::from_secs(30), async move {
+        tokio::time::timeout(std::time::Duration::from_secs(100), async move {
             let client = Client::create(DEV_ADDRESS.to_string(), true).await.unwrap();
 
             let topic = uuid::Uuid::new_v4();
@@ -278,7 +278,7 @@ mod tests {
                 panic!("Message 1 Error: {}", err);
             }
 
-            tokio::time::sleep(std::time::Duration::from_secs(15)).await;
+            tokio::time::sleep(std::time::Duration::from_secs(50)).await;
             client
                 .publish(
                     auth_token.to_string(),


### PR DESCRIPTION
After a lot of reading and trial error I found that the tests will pass if we remove this line.
I even bumped the test up to a 300 second delay to make sure it still passes and confirmed that it does.