### PR TITLE
fix: bump GH actions versions

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -15,16 +15,16 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and Push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           platforms: linux/amd64

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -6,7 +6,6 @@ mod subscriptions;
 mod sync;
 pub mod validated_commit;
 
-
 use intents::SendMessageIntentData;
 use openmls::{
     extensions::{Extension, Extensions, Metadata},
@@ -55,8 +54,8 @@ use crate::{
     },
     utils::{
         address::{sanitize_evm_addresses, AddressValidationError},
-        time::now_ns,
         id::calculate_message_id,
+        time::now_ns,
     },
     xmtp_openmls_provider::XmtpOpenMlsProvider,
     Client, Store,


### PR DESCRIPTION
## Summary

Fixes CI.  Methinks it was using cached versions of `1.76.0` for one layer and trying to build on `latest` which as of yesterday is `1.77.0`; hence the cross-link errrors.