### PR TITLE
Expose the installation ids

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -137,6 +137,13 @@ impl FfiXmtpClient {
 
         Ok(results)
     }
+
+    pub async fn installation_ids(&self) -> Result<Vec<Vec<u8>>, GenericError> {
+        let address = self.inner_client.account_address();
+        let installations = self.inner_client.get_all_active_installation_ids(vec![address]).await?;
+
+        Ok(installations)
+    }
 }
 
 #[uniffi::export(async_runtime = "tokio")]


### PR DESCRIPTION
I need the installation ids so that I can subscribe to the welcome messages for push notifications. See https://github.com/xmtp/xmtp-android/pull/210/files#diff-c1e187fd354e09e849ec1f8ab18c9ea87454f6df08bf89690b3ff83ac9d6ce2eR36