### PR TITLE
fix: dont even have todo. err instead.

### DIFF
--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -123,6 +123,8 @@ pub enum MessageProcessingError {
     WrongCredentialType(#[from] BasicCredentialError),
     #[error("proto decode error: {0}")]
     DecodeError(#[from] prost::DecodeError),
+    #[error("generic:{0}")]
+    Generic(String),
 }
 
 impl crate::retry::RetryableError for MessageProcessingError {

--- a/xmtp_mls/src/groups/sync.rs
+++ b/xmtp_mls/src/groups/sync.rs
@@ -237,7 +237,9 @@ where
                         conn.set_delivery_status_to_published(&message_id, envelope_timestamp_ns)?;
                     }
                     Some(Content::V2(_)) => {
-                        todo!()
+                        return Err(MessageProcessingError::Generic(
+                            "not yet implemented".into(),
+                        ))
                     }
                     None => return Err(MessageProcessingError::InvalidPayload),
                 };
@@ -297,7 +299,9 @@ where
                         .store(provider.conn())?
                     }
                     Some(Content::V2(_)) => {
-                        todo!()
+                        return Err(MessageProcessingError::Generic(
+                            "not yet implemented".into(),
+                        ))
                     }
                     None => return Err(MessageProcessingError::InvalidPayload),
                 }


### PR DESCRIPTION
## Summary

The existence of `Content::V2(_)` as a match arm was causing problems and crashing on the `todo!()`

This patch changes those `todo`s to `Err` instead.