### PR TITLE
Fix clippy on generated code & add a deny for warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV RUSTUP_PERMIT_COPY_RENAME "yes"
 
 RUN cargo check
 RUN cargo fmt --check
-RUN cargo clippy --all-features --no-deps -Dwarnings
+RUN cargo clippy --all-features --no-deps -- -Dwarnings
 # some tests are setup as integration tests 👀 xmtp_mls
 RUN for crate in xmtp_cryptography xmtp_proto xmtp_v2; do cd ${crate}; cargo test; done
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV RUSTUP_PERMIT_COPY_RENAME "yes"
 
 RUN cargo check
 RUN cargo fmt --check
-RUN cargo clippy --all-features --no-deps
+RUN cargo clippy --all-features --no-deps -Dwarnings
 # some tests are setup as integration tests 👀 xmtp_mls
 RUN for crate in xmtp_cryptography xmtp_proto xmtp_v2; do cd ${crate}; cargo test; done
 

--- a/xmtp_mls/src/groups/subscriptions.rs
+++ b/xmtp_mls/src/groups/subscriptions.rs
@@ -75,7 +75,7 @@ where
         client: Arc<Client<ApiClient>>,
         group_id: Vec<u8>,
         created_at_ns: i64,
-        mut callback: impl FnMut(StoredGroupMessage) + Send + 'static,
+        callback: impl FnMut(StoredGroupMessage) + Send + 'static,
     ) -> Result<StreamCloser, GroupError> {
         Ok(Client::<ApiClient>::stream_messages_with_callback(
             client,
@@ -86,7 +86,7 @@ where
                     cursor: 0,
                 },
             )]),
-            move |message| callback(message),
+            callback,
         )?)
     }
 }

--- a/xmtp_proto/src/lib.rs
+++ b/xmtp_proto/src/lib.rs
@@ -1,3 +1,10 @@
-include!("gen/mod.rs");
+#[allow(clippy::all)]
+mod generated {
+    include!("gen/mod.rs");
+}
+
+pub use generated::*;
+
+// pub use gen::*;
 #[cfg(feature = "xmtp-message_api-v1")]
 pub mod api_client;

--- a/xmtp_proto/src/lib.rs
+++ b/xmtp_proto/src/lib.rs
@@ -2,9 +2,7 @@
 mod generated {
     include!("gen/mod.rs");
 }
-
 pub use generated::*;
 
-// pub use gen::*;
 #[cfg(feature = "xmtp-message_api-v1")]
 pub mod api_client;


### PR DESCRIPTION
This gets rid of the clippy warnings on code generated for protos by allowing all on an intermediate module declaration, as well as makes it a requirement for clippy to successfully finish w/o warnings for the Dockerfile build