### PR TITLE
Remove dependency on xmtp_mls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6919,7 +6919,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "xmtp_cryptography",
- "xmtp_mls",
  "xmtp_proto",
 ]
 

--- a/xmtp_id/Cargo.toml
+++ b/xmtp_id/Cargo.toml
@@ -24,8 +24,7 @@ sha2 = "0.10.8"
 thiserror.workspace = true
 tracing.workspace = true
 xmtp_cryptography.workspace = true
-xmtp_mls.workspace = true
-xmtp_proto.workspace = true
+xmtp_proto = { workspace = true, features = ["proto_full"] }
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/xmtp_id/src/associations/builder.rs
+++ b/xmtp_id/src/associations/builder.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
+use crate::utils::now_ns;
 use thiserror::Error;
-use xmtp_mls::utils::time::now_ns;
 
 use super::{
     association_log::{AddAssociation, ChangeRecoveryAddress, CreateInbox, RevokeAssociation},

--- a/xmtp_id/src/lib.rs
+++ b/xmtp_id/src/lib.rs
@@ -1,34 +1,42 @@
 pub mod associations;
-pub mod credential_verifier;
+pub mod utils;
+// pub mod credential_verifier;
 pub mod erc1271_verifier;
-
-use std::sync::RwLock;
-
-use openmls::prelude::Credential as OpenMlsCredential;
-use openmls_basic_credential::SignatureKeyPair;
+use ethers::signers::{LocalWallet, Signer};
+use futures::executor;
 use openmls_traits::types::CryptoError;
 use thiserror::Error;
-use xmtp_mls::{
-    configuration::CIPHERSUITE,
-    credential::{AssociationError, Credential, UnsignedGrantMessagingAccessData},
-    types::Address,
-    utils::time::now_ns,
-};
+use xmtp_cryptography::signature::{h160addr_to_string, RecoverableSignature, SignatureError};
 
-use crate::credential_verifier::{CredentialVerifier, VerificationError, VerificationRequest};
+/**
+ * COMMENTING OUT A BUNCH OF THIS CODE TO REMOVE DEPENDENCY ON XMTP_MLS
+ */
+// use std::sync::RwLock;
+
+// use openmls::prelude::Credential as OpenMlsCredential;
+// use openmls_basic_credential::SignatureKeyPair;
+
+// use xmtp_mls::{
+//     configuration::CIPHERSUITE,
+//     credential::{AssociationError, Credential, UnsignedGrantMessagingAccessData},
+//     types::Address,
+//     utils::time::now_ns,
+// };
+
+// use crate::credential_verifier::{CredentialVerifier, VerificationError, VerificationRequest};
 
 #[derive(Debug, Error)]
 pub enum IdentityError {
-    #[error("bad association: {0}")]
-    BadAssocation(#[from] AssociationError),
+    // #[error("bad association: {0}")]
+    // BadAssocation(#[from] AssociationError),
     #[error("generating key-pairs: {0}")]
     KeyGenerationError(#[from] CryptoError),
     #[error("uninitialized identity")]
     UninitializedIdentity,
     #[error("protobuf deserialization: {0}")]
     Deserialization(#[from] prost::DecodeError),
-    #[error("credential verification {0}")]
-    VerificationError(#[from] VerificationError),
+    // #[error("credential verification {0}")]
+    // VerificationError(#[from] VerificationError),
 }
 
 #[async_trait::async_trait]
@@ -36,63 +44,80 @@ pub trait WalletIdentity {
     async fn is_smart_wallet(&self, block: Option<u64>) -> Result<bool, IdentityError>;
 }
 
-pub struct Identity {
-    #[allow(dead_code)]
-    pub(crate) account_address: Address,
-    #[allow(dead_code)]
-    pub(crate) installation_keys: SignatureKeyPair,
-    pub(crate) credential: RwLock<Option<OpenMlsCredential>>,
-    pub(crate) unsigned_association_data: Option<UnsignedGrantMessagingAccessData>,
+pub trait InboxOwner {
+    /// Get address of the wallet.
+    fn get_address(&self) -> String;
+    /// Sign text with the wallet.
+    fn sign(&self, text: &str) -> Result<RecoverableSignature, SignatureError>;
 }
 
-impl Identity {
-    // Creates a credential that is not yet wallet signed. Implementors should sign the payload returned by 'text_to_sign'
-    // and call 'register' with the signature.
-    #[allow(dead_code)]
-    pub(crate) fn create_to_be_signed(account_address: String) -> Result<Self, IdentityError> {
-        let signature_keys = SignatureKeyPair::new(CIPHERSUITE.signature_algorithm())?;
-        let unsigned_association_data = UnsignedGrantMessagingAccessData::new(
-            account_address.clone(),
-            signature_keys.to_public_vec(),
-            now_ns() as u64,
-        )?;
-        let identity = Self {
-            account_address,
-            installation_keys: signature_keys,
-            credential: RwLock::new(None),
-            unsigned_association_data: Some(unsigned_association_data),
-        };
-
-        Ok(identity)
+impl InboxOwner for LocalWallet {
+    fn get_address(&self) -> String {
+        h160addr_to_string(self.address())
     }
 
-    pub fn text_to_sign(&self) -> Option<String> {
-        if self.credential().is_ok() {
-            return None;
-        }
-        self.unsigned_association_data
-            .clone()
-            .map(|data| data.text())
-    }
-
-    fn credential(&self) -> Result<OpenMlsCredential, IdentityError> {
-        self.credential
-            .read()
-            .unwrap_or_else(|err| err.into_inner())
-            .clone()
-            .ok_or(IdentityError::UninitializedIdentity)
-    }
-
-    /// Get an account address verified by the
-    pub async fn get_validated_account_address(
-        credential: &[u8],
-        installation_public_key: &[u8],
-    ) -> Result<String, IdentityError> {
-        let request = VerificationRequest::new(credential, installation_public_key);
-        let credential = <Credential as CredentialVerifier>::verify_credential(request).await?;
-        Ok(credential.account_address().to_string())
+    fn sign(&self, text: &str) -> Result<RecoverableSignature, SignatureError> {
+        Ok(executor::block_on(self.sign_message(text))?.to_vec().into())
     }
 }
+
+// pub struct Identity {
+//     #[allow(dead_code)]
+//     pub(crate) account_address: Address,
+//     #[allow(dead_code)]
+//     pub(crate) installation_keys: SignatureKeyPair,
+//     pub(crate) credential: RwLock<Option<OpenMlsCredential>>,
+//     pub(crate) unsigned_association_data: Option<UnsignedGrantMessagingAccessData>,
+// }
+
+// impl Identity {
+//     // Creates a credential that is not yet wallet signed. Implementors should sign the payload returned by 'text_to_sign'
+//     // and call 'register' with the signature.
+//     #[allow(dead_code)]
+//     pub(crate) fn create_to_be_signed(account_address: String) -> Result<Self, IdentityError> {
+//         let signature_keys = SignatureKeyPair::new(CIPHERSUITE.signature_algorithm())?;
+//         let unsigned_association_data = UnsignedGrantMessagingAccessData::new(
+//             account_address.clone(),
+//             signature_keys.to_public_vec(),
+//             now_ns() as u64,
+//         )?;
+//         let identity = Self {
+//             account_address,
+//             installation_keys: signature_keys,
+//             credential: RwLock::new(None),
+//             unsigned_association_data: Some(unsigned_association_data),
+//         };
+
+//         Ok(identity)
+//     }
+
+//     pub fn text_to_sign(&self) -> Option<String> {
+//         if self.credential().is_ok() {
+//             return None;
+//         }
+//         self.unsigned_association_data
+//             .clone()
+//             .map(|data| data.text())
+//     }
+
+//     fn credential(&self) -> Result<OpenMlsCredential, IdentityError> {
+//         self.credential
+//             .read()
+//             .unwrap_or_else(|err| err.into_inner())
+//             .clone()
+//             .ok_or(IdentityError::UninitializedIdentity)
+//     }
+
+//     /// Get an account address verified by the
+//     pub async fn get_validated_account_address(
+//         credential: &[u8],
+//         installation_public_key: &[u8],
+//     ) -> Result<String, IdentityError> {
+//         let request = VerificationRequest::new(credential, installation_public_key);
+//         let credential = <Credential as CredentialVerifier>::verify_credential(request).await?;
+//         Ok(credential.account_address().to_string())
+//     }
+// }
 
 #[cfg(test)]
 mod tests {
@@ -104,7 +129,6 @@ mod tests {
     };
     use std::str::FromStr;
     use xmtp_cryptography::utils::generate_local_wallet;
-    use xmtp_mls::InboxOwner;
 
     struct EthereumWallet {
         provider: Provider<Http>,

--- a/xmtp_id/src/utils/mod.rs
+++ b/xmtp_id/src/utils/mod.rs
@@ -1,0 +1,3 @@
+pub mod time;
+
+pub use time::*;

--- a/xmtp_id/src/utils/time.rs
+++ b/xmtp_id/src/utils/time.rs
@@ -1,0 +1,11 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub const NS_IN_SEC: i64 = 1_000_000_000;
+
+pub fn now_ns() -> i64 {
+    let now = SystemTime::now();
+
+    now.duration_since(UNIX_EPOCH)
+        .expect("Time went backwards")
+        .as_nanos() as i64
+}


### PR DESCRIPTION
## tl;dr

- Comments out any code that references `xmtp_mls` to remove a cyclical dependency. We'll bring this code back once we integrate it with `xmtp_id` and will remove any references to `xmtp_mls` when we do that.
- Moves the `inbox_owner` trait to `xmtp_id`, since it feels like the right fit.

## Next up

Refactor `xmtp_mls` to use the `xmtp_id` version of the InboxOwner trait