### PR TITLE
Add ApiClientWrapper methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.35"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -6956,6 +6956,7 @@ dependencies = [
  "tracing-subscriber",
  "xmtp_api_grpc",
  "xmtp_cryptography",
+ "xmtp_id",
  "xmtp_proto",
  "xmtp_v2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,27 +9,26 @@ members = [
   "xmtp_user_preferences",
   "xmtp_v2",
   "xmtp_mls",
-  "xmtp_id"
+  "xmtp_id",
 ]
 
-exclude = [
-  "bindings_ffi",
-  "bindings_wasm",
-  "xmtp_api_grpc_gateway",
-]
+exclude = ["bindings_ffi", "bindings_wasm", "xmtp_api_grpc_gateway"]
 
 # Make the feature resolver explicit.
 # See https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html#details
 resolver = "2"
 
 [workspace.dependencies]
+anyhow = "1.0"
 async-trait = "0.1.77"
-chrono = "0.4"
+chrono = "0.4.38"
+ctor = "0.2"
 ethers = "2.0.11"
 ethers-core = "2.0.4"
 futures = "0.3.30"
 futures-core = "0.3.30"
 hex = "0.4.3"
+jsonrpsee = { version = "0.22", features = ["macros", "server", "client-core"] }
 log = "0.4"
 openmls = { git = "https://github.com/xmtp/openmls", rev = "9288932" }
 openmls_basic_credential = { git = "https://github.com/xmtp/openmls", rev = "9288932" }
@@ -45,10 +44,7 @@ tls_codec = "0.4.0"
 tokio = { version = "1.35.1", features = ["macros"] }
 tonic = "^0.11"
 tracing = "0.1"
-anyhow = "1.0"
-jsonrpsee = { version = "0.22", features = ["macros", "server", "client-core"] }
 tracing-subscriber = { version = "0.3.18", features = ["fmt", "env-filter"] }
-ctor = "0.2"
 
 # Internal Crate Dependencies
 xmtp_cryptography = { path = "xmtp_cryptography" }

--- a/bindings_ffi/Cargo.lock
+++ b/bindings_ffi/Cargo.lock
@@ -579,16 +579,16 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.31"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -5411,6 +5411,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "xmtp_id"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "ethers",
+ "futures",
+ "hex",
+ "log",
+ "openmls",
+ "openmls_basic_credential",
+ "openmls_rust_crypto",
+ "openmls_traits",
+ "prost 0.12.3",
+ "rand",
+ "serde",
+ "sha2",
+ "thiserror",
+ "tracing",
+ "xmtp_cryptography",
+ "xmtp_proto",
+]
+
+[[package]]
 name = "xmtp_mls"
 version = "0.1.0"
 dependencies = [
@@ -5438,6 +5463,7 @@ dependencies = [
  "tokio",
  "toml 0.8.8",
  "xmtp_cryptography",
+ "xmtp_id",
  "xmtp_proto",
  "xmtp_v2",
 ]

--- a/xmtp_id/Cargo.toml
+++ b/xmtp_id/Cargo.toml
@@ -38,3 +38,6 @@ surf = "2.3"
 tokio = { workspace = true, features = ["time"] }
 tokio-test = "0.4"
 tracing-subscriber.workspace = true
+
+[features]
+test-utils = []

--- a/xmtp_id/src/associations/association_log.rs
+++ b/xmtp_id/src/associations/association_log.rs
@@ -332,6 +332,22 @@ impl IdentityUpdate {
     }
 }
 
+impl TryFrom<IdentityUpdate> for IdentityUpdateProto {
+    type Error = SerializationError;
+
+    fn try_from(proto: IdentityUpdate) -> Result<IdentityUpdateProto, Self::Error> {
+        IdentityUpdate::to_proto(&proto)
+    }
+}
+
+impl TryFrom<IdentityUpdateProto> for IdentityUpdate {
+    type Error = DeserializationError;
+
+    fn try_from(proto: IdentityUpdateProto) -> Result<IdentityUpdate, Self::Error> {
+        IdentityUpdate::from_proto(proto)
+    }
+}
+
 impl IdentityAction for IdentityUpdate {
     fn update_state(
         &self,

--- a/xmtp_id/src/associations/mod.rs
+++ b/xmtp_id/src/associations/mod.rs
@@ -5,12 +5,14 @@ mod member;
 mod serialization;
 mod signature;
 mod state;
-#[cfg(test)]
-mod test_utils;
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_utils;
 mod unsigned_actions;
 
 pub use self::association_log::*;
+pub use self::hashes::generate_inbox_id;
 pub use self::member::{Member, MemberIdentifier, MemberKind};
+pub use self::serialization::{DeserializationError, SerializationError};
 pub use self::signature::{Signature, SignatureError, SignatureKind};
 pub use self::state::AssociationState;
 
@@ -35,12 +37,9 @@ pub fn get_state(updates: Vec<IdentityUpdate>) -> Result<AssociationState, Assoc
     new_state.ok_or(AssociationError::NotCreated)
 }
 
-#[cfg(test)]
-mod tests {
-    use tests::hashes::generate_inbox_id;
-
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_defaults {
     use self::test_utils::{rand_string, rand_u64, rand_vec, MockSignature};
-
     use super::*;
 
     impl IdentityUpdate {
@@ -53,7 +52,8 @@ mod tests {
         fn default() -> Self {
             let existing_member = rand_string();
             let new_member = rand_vec();
-            return Self {
+
+            Self {
                 existing_member_signature: MockSignature::new_boxed(
                     true,
                     existing_member.into(),
@@ -67,7 +67,7 @@ mod tests {
                     None,
                 ),
                 new_member_identifier: new_member.into(),
-            };
+            }
         }
     }
 
@@ -75,7 +75,8 @@ mod tests {
     impl Default for CreateInbox {
         fn default() -> Self {
             let signer = rand_string();
-            return Self {
+
+            Self {
                 nonce: rand_u64(),
                 account_address: signer.clone(),
                 initial_address_signature: MockSignature::new_boxed(
@@ -84,14 +85,15 @@ mod tests {
                     SignatureKind::Erc191,
                     None,
                 ),
-            };
+            }
         }
     }
 
     impl Default for RevokeAssociation {
         fn default() -> Self {
             let signer = rand_string();
-            return Self {
+
+            Self {
                 recovery_address_signature: MockSignature::new_boxed(
                     true,
                     signer.into(),
@@ -99,11 +101,20 @@ mod tests {
                     None,
                 ),
                 revoked_member: rand_string().into(),
-            };
+            }
         }
     }
+}
 
-    fn new_test_inbox() -> AssociationState {
+#[cfg(test)]
+mod tests {
+    use tests::hashes::generate_inbox_id;
+
+    use self::test_utils::{rand_string, rand_vec, MockSignature};
+
+    use super::*;
+
+    pub fn new_test_inbox() -> AssociationState {
         let create_request = CreateInbox::default();
         let inbox_id = generate_inbox_id(&create_request.account_address, &create_request.nonce);
         let identity_update =
@@ -112,7 +123,7 @@ mod tests {
         get_state(vec![identity_update]).unwrap()
     }
 
-    fn new_test_inbox_with_installation() -> AssociationState {
+    pub fn new_test_inbox_with_installation() -> AssociationState {
         let initial_state = new_test_inbox();
         let inbox_id = initial_state.inbox_id().clone();
         let initial_wallet_address: MemberIdentifier =

--- a/xmtp_id/src/associations/serialization.rs
+++ b/xmtp_id/src/associations/serialization.rs
@@ -28,6 +28,8 @@ use xmtp_proto::xmtp::identity::associations::{
 pub enum DeserializationError {
     #[error("Missing action")]
     MissingAction,
+    #[error("Missing update")]
+    MissingUpdate,
     #[error("Missing member identifier")]
     MissingMemberIdentifier,
     #[error("Missing signature")]

--- a/xmtp_id/src/associations/test_utils.rs
+++ b/xmtp_id/src/associations/test_utils.rs
@@ -1,5 +1,16 @@
 use rand::{distributions::Alphanumeric, Rng};
-use xmtp_proto::xmtp::identity::associations::Signature as SignatureProto;
+use xmtp_proto::{
+    xmtp::identity::associations::{
+        signature::Signature as SignatureKindProto, Erc1271Signature as Erc1271SignatureProto,
+        LegacyDelegatedSignature as LegacyDelegatedSignatureProto,
+        RecoverableEcdsaSignature as RecoverableEcdsaSignatureProto,
+        RecoverableEd25519Signature as RecoverableEd25519SignatureProto,
+        Signature as SignatureProto,
+    },
+    xmtp::message_contents::{
+        Signature as LegacySignatureProto, SignedPublicKey as LegacySignedPublicKeyProto,
+    },
+};
 
 use super::{MemberIdentifier, Signature, SignatureError, SignatureKind};
 
@@ -68,6 +79,35 @@ impl Signature for MockSignature {
     }
 
     fn to_proto(&self) -> SignatureProto {
-        SignatureProto { signature: None }
+        match self.signature_kind {
+            SignatureKind::Erc191 => SignatureProto {
+                signature: Some(SignatureKindProto::Erc191(RecoverableEcdsaSignatureProto {
+                    bytes: vec![0],
+                })),
+            },
+            SignatureKind::Erc1271 => SignatureProto {
+                signature: Some(SignatureKindProto::Erc1271(Erc1271SignatureProto {
+                    contract_address: "0xdead".into(),
+                    block_number: 0,
+                    signature: vec![0],
+                })),
+            },
+            SignatureKind::InstallationKey => SignatureProto {
+                signature: Some(SignatureKindProto::InstallationKey(
+                    RecoverableEd25519SignatureProto { bytes: vec![0] },
+                )),
+            },
+            SignatureKind::LegacyDelegated => SignatureProto {
+                signature: Some(SignatureKindProto::DelegatedErc191(
+                    LegacyDelegatedSignatureProto {
+                        delegated_key: Some(LegacySignedPublicKeyProto {
+                            key_bytes: vec![0],
+                            signature: Some(LegacySignatureProto { union: None }),
+                        }),
+                        signature: Some(RecoverableEcdsaSignatureProto { bytes: vec![0] }),
+                    },
+                )),
+            },
+        }
     }
 }

--- a/xmtp_mls/Cargo.toml
+++ b/xmtp_mls/Cargo.toml
@@ -15,18 +15,20 @@ native = ["libsqlite3-sys/bundled-sqlcipher-vendored-openssl"]
 types = []
 
 [dependencies]
+async-trait.workspace = true
+chrono = { workspace = true }
 diesel = { version = "2.1.3", features = [
     "sqlite",
     "r2d2",
     "returning_clauses_for_sqlite_3_35",
 ] }
 diesel_migrations = { version = "2.1.0", features = ["sqlite"] }
-async-trait.workspace = true
+ethers-core.workspace = true
 ethers.workspace = true
-ethers-core.workspace = true 
-futures.workspace = true 
+futures.workspace = true
 hex.workspace = true
-log.workspace = true 
+libsqlite3-sys = { version = "0.26.0", optional = true }
+log.workspace = true
 openmls = { workspace = true, features = ["test-utils"] }
 openmls_basic_credential = { workspace = true }
 openmls_rust_crypto = { workspace = true }
@@ -34,16 +36,15 @@ openmls_traits = { workspace = true }
 prost = { workspace = true, features = ["prost-derive"] }
 rand = { workspace = true }
 serde = { workspace = true }
-serde_json.workspace = true 
+serde_json.workspace = true
+smart-default = "0.7.1"
 thiserror = { workspace = true }
 tls_codec = { workspace = true }
 tokio = { workspace = true }
-chrono = { workspace = true } 
-libsqlite3-sys = { version = "0.26.0", optional = true }
-smart-default = "0.7.1"
 toml = "0.8.4"
-xmtp_proto = { workspace = true, features = ["proto_full"] }
 xmtp_cryptography = { workspace = true }
+xmtp_id = { path = "../xmtp_id" }
+xmtp_proto = { workspace = true, features = ["proto_full"] }
 xmtp_v2 = { path = "../xmtp_v2" }
 
 [dev-dependencies]
@@ -53,3 +54,4 @@ mockall = "0.11.4"
 tempfile = "3.5.0"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 xmtp_api_grpc = { path = "../xmtp_api_grpc" }
+xmtp_id = { path = "../xmtp_id", features = ["test-utils"] }

--- a/xmtp_mls/src/api/identity.rs
+++ b/xmtp_mls/src/api/identity.rs
@@ -1,0 +1,245 @@
+use std::collections::HashMap;
+
+use crate::types::InboxId;
+
+use super::{ApiClientWrapper, WrappedApiError};
+use xmtp_id::associations::{DeserializationError, IdentityUpdate};
+use xmtp_proto::{
+    api_client::{XmtpIdentityClient, XmtpMlsClient},
+    xmtp::identity::api::v1::{
+        get_identity_updates_request::Request as GetIdentityUpdatesV2RequestProto,
+        get_identity_updates_response::IdentityUpdateLog,
+        get_inbox_ids_request::Request as GetInboxIdsRequestProto,
+        GetIdentityUpdatesRequest as GetIdentityUpdatesV2Request, GetInboxIdsRequest,
+        PublishIdentityUpdateRequest,
+    },
+};
+
+/// A filter for querying identity updates. `sequence_id` is the starting sequence, and only later updates will be returned.
+pub struct GetIdentityUpdatesV2Filter {
+    pub inbox_id: String,
+    pub sequence_id: Option<u64>,
+}
+
+impl From<GetIdentityUpdatesV2Filter> for GetIdentityUpdatesV2RequestProto {
+    fn from(filter: GetIdentityUpdatesV2Filter) -> Self {
+        Self {
+            inbox_id: filter.inbox_id,
+            sequence_id: filter.sequence_id.unwrap_or(0),
+        }
+    }
+}
+
+pub struct InboxUpdate {
+    pub sequence_id: u64,
+    pub server_timestamp_ns: u64,
+    pub update: IdentityUpdate,
+}
+
+impl TryFrom<IdentityUpdateLog> for InboxUpdate {
+    type Error = DeserializationError;
+
+    fn try_from(update: IdentityUpdateLog) -> Result<Self, Self::Error> {
+        Ok(Self {
+            sequence_id: update.sequence_id,
+            server_timestamp_ns: update.server_timestamp_ns,
+            update: update
+                .update
+                .ok_or(DeserializationError::MissingUpdate)?
+                // TODO: Figure out what to do with requests that don't deserialize correctly. Maybe we want to just filter them out?,
+                .try_into()?,
+        })
+    }
+}
+
+/// A mapping of `inbox_id` -> Vec<InboxUpdate>
+type InboxUpdateMap = HashMap<InboxId, Vec<InboxUpdate>>;
+
+/// Maps account addresses to inbox IDs. If no inbox ID found, the value will be None
+type AddressToInboxIdMap = HashMap<String, Option<InboxId>>;
+
+impl<ApiClient> ApiClientWrapper<ApiClient>
+where
+    ApiClient: XmtpMlsClient + XmtpIdentityClient,
+{
+    pub async fn publish_identity_update(
+        &self,
+        update: IdentityUpdate,
+    ) -> Result<(), WrappedApiError> {
+        self.api_client
+            .publish_identity_update(PublishIdentityUpdateRequest {
+                identity_update: Some(update.try_into()?),
+            })
+            .await?;
+
+        Ok(())
+    }
+
+    pub async fn get_identity_updates_v2(
+        &self,
+        filters: Vec<GetIdentityUpdatesV2Filter>,
+    ) -> Result<InboxUpdateMap, WrappedApiError> {
+        let result = self
+            .api_client
+            .get_identity_updates_v2(GetIdentityUpdatesV2Request {
+                requests: filters.into_iter().map(|filter| filter.into()).collect(),
+            })
+            .await?;
+
+        result
+            .responses
+            .into_iter()
+            .map(|response| {
+                let deserialized_updates = response
+                    .updates
+                    .into_iter()
+                    .map(|update| {
+                        let deserialized: InboxUpdate = update.try_into()?;
+
+                        Ok(deserialized)
+                    })
+                    .collect::<Result<Vec<InboxUpdate>, WrappedApiError>>()?;
+
+                Ok((response.inbox_id, deserialized_updates))
+            })
+            .collect::<Result<InboxUpdateMap, WrappedApiError>>()
+    }
+
+    pub async fn get_inbox_ids(
+        &self,
+        account_addresses: Vec<String>,
+    ) -> Result<AddressToInboxIdMap, WrappedApiError> {
+        let result = self
+            .api_client
+            .get_inbox_ids(GetInboxIdsRequest {
+                requests: account_addresses
+                    .into_iter()
+                    .map(|address| GetInboxIdsRequestProto { address })
+                    .collect(),
+            })
+            .await?;
+
+        Ok(result
+            .responses
+            .into_iter()
+            .map(|inbox_id| (inbox_id.address, inbox_id.inbox_id))
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_utils::*;
+    use super::GetIdentityUpdatesV2Filter;
+    use crate::{api::ApiClientWrapper, retry::Retry};
+    use xmtp_id::associations::{test_utils::rand_string, Action, CreateInbox, IdentityUpdate};
+    use xmtp_proto::xmtp::identity::api::v1::{
+        get_identity_updates_response::{
+            IdentityUpdateLog, Response as GetIdentityUpdatesResponseItem,
+        },
+        get_inbox_ids_response::Response as GetInboxIdsResponseItem,
+        GetIdentityUpdatesResponse, GetInboxIdsResponse, PublishIdentityUpdateResponse,
+    };
+
+    fn create_identity_update(inbox_id: String) -> IdentityUpdate {
+        IdentityUpdate::new_test(vec![Action::CreateInbox(CreateInbox::default())], inbox_id)
+    }
+
+    #[tokio::test]
+    async fn publish_identity_update() {
+        let mut mock_api = MockApiClient::new();
+        let inbox_id = rand_string();
+        let identity_update = create_identity_update(inbox_id.clone());
+
+        mock_api
+            .expect_publish_identity_update()
+            .withf(move |req| req.identity_update.as_ref().unwrap().inbox_id.eq(&inbox_id))
+            .returning(move |_| Ok(PublishIdentityUpdateResponse {}));
+
+        let wrapper = ApiClientWrapper::new(mock_api, Retry::default());
+        let result = wrapper.publish_identity_update(identity_update).await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn get_identity_update_v2() {
+        let mut mock_api = MockApiClient::new();
+        let inbox_id = rand_string();
+        let inbox_id_clone = inbox_id.clone();
+        let inbox_id_clone_2 = inbox_id.clone();
+        mock_api
+            .expect_get_identity_updates_v2()
+            .withf(move |req| req.requests.first().unwrap().inbox_id.eq(&inbox_id))
+            .returning(move |_| {
+                let identity_update = create_identity_update(inbox_id_clone.clone());
+                Ok(GetIdentityUpdatesResponse {
+                    responses: vec![GetIdentityUpdatesResponseItem {
+                        inbox_id: inbox_id_clone.clone(),
+                        updates: vec![IdentityUpdateLog {
+                            sequence_id: 1,
+                            server_timestamp_ns: 1,
+                            update: Some(identity_update.to_proto().unwrap()),
+                        }],
+                    }],
+                })
+            });
+
+        let wrapper = ApiClientWrapper::new(mock_api, Retry::default());
+        let result = wrapper
+            .get_identity_updates_v2(vec![GetIdentityUpdatesV2Filter {
+                inbox_id: inbox_id_clone_2.clone(),
+                sequence_id: None,
+            }])
+            .await
+            .expect("should work");
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result.get(&inbox_id_clone_2).unwrap().len(), 1);
+        assert_eq!(
+            result
+                .get(&inbox_id_clone_2)
+                .unwrap()
+                .first()
+                .unwrap()
+                .update
+                .inbox_id,
+            inbox_id_clone_2
+        );
+    }
+
+    #[tokio::test]
+    async fn get_inbox_ids() {
+        let mut mock_api = MockApiClient::new();
+        let inbox_id = rand_string();
+        let inbox_id_clone = inbox_id.clone();
+        let inbox_id_clone_2 = inbox_id.clone();
+        let address = rand_string();
+        let address_clone = address.clone();
+        let address_clone_2 = address.clone();
+
+        mock_api
+            .expect_get_inbox_ids()
+            .withf(move |req| req.requests.first().unwrap().address.eq(&address_clone))
+            .returning(move |_| {
+                Ok(GetInboxIdsResponse {
+                    responses: vec![GetInboxIdsResponseItem {
+                        address: address_clone_2.clone(),
+                        inbox_id: Some(inbox_id_clone.clone()),
+                    }],
+                })
+            });
+
+        let wrapper = ApiClientWrapper::new(mock_api, Retry::default());
+        let result = wrapper
+            .get_inbox_ids(vec![address.clone()])
+            .await
+            .expect("should work");
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result.get(&address).unwrap().as_ref().unwrap(),
+            &inbox_id_clone_2
+        );
+    }
+}

--- a/xmtp_mls/src/api/mls.rs
+++ b/xmtp_mls/src/api/mls.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use super::ApiClientWrapper;
+use crate::retry_async;
 use xmtp_proto::{
     api_client::{
         Error as ApiError, ErrorKind, GroupMessageStream, WelcomeMessageStream, XmtpIdentityClient,
@@ -18,14 +20,7 @@ use xmtp_proto::{
     },
 };
 
-use crate::{retry::Retry, retry_async};
-
-#[derive(Debug)]
-pub struct ApiClientWrapper<ApiClient> {
-    api_client: ApiClient,
-    retry_strategy: Retry,
-}
-
+/// A filter for querying group messages
 pub struct GroupFilter {
     pub group_id: Vec<u8>,
     pub id_cursor: Option<u64>,
@@ -49,17 +44,34 @@ impl From<GroupFilter> for GroupFilterProto {
     }
 }
 
+#[derive(Debug, PartialEq)]
+pub struct NewInstallation {
+    pub installation_key: Vec<u8>,
+    pub credential_bytes: Vec<u8>,
+    pub timestamp_ns: u64,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct RevokeInstallation {
+    pub installation_key: Vec<u8>, // TODO: Add proof of revocation
+    pub timestamp_ns: u64,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum IdentityUpdate {
+    NewInstallation(NewInstallation),
+    RevokeInstallation(RevokeInstallation),
+    Invalid,
+}
+
+type KeyPackageMap = HashMap<Vec<u8>, Vec<u8>>;
+
+type IdentityUpdatesMap = HashMap<String, Vec<IdentityUpdate>>;
+
 impl<ApiClient> ApiClientWrapper<ApiClient>
 where
     ApiClient: XmtpMlsClient + XmtpIdentityClient,
 {
-    pub fn new(api_client: ApiClient, retry_strategy: Retry) -> Self {
-        Self {
-            api_client,
-            retry_strategy,
-        }
-    }
-
     pub async fn query_group_messages(
         &self,
         group_id: Vec<u8>,
@@ -344,122 +356,22 @@ where
     }
 }
 
-#[derive(Debug, PartialEq)]
-pub struct NewInstallation {
-    pub installation_key: Vec<u8>,
-    pub credential_bytes: Vec<u8>,
-    pub timestamp_ns: u64,
-}
-
-#[derive(Debug, PartialEq)]
-pub struct RevokeInstallation {
-    pub installation_key: Vec<u8>, // TODO: Add proof of revocation
-    pub timestamp_ns: u64,
-}
-
-#[derive(Debug, PartialEq)]
-pub enum IdentityUpdate {
-    NewInstallation(NewInstallation),
-    RevokeInstallation(RevokeInstallation),
-    Invalid,
-}
-
-type KeyPackageMap = HashMap<Vec<u8>, Vec<u8>>;
-
-type IdentityUpdatesMap = HashMap<String, Vec<IdentityUpdate>>;
-
 #[cfg(test)]
 pub mod tests {
-    use async_trait::async_trait;
-    use mockall::mock;
-    use xmtp_api_grpc::grpc_api_helper::Client as GrpcClient;
+    use super::super::test_utils::*;
+    use super::super::*;
+
     use xmtp_proto::{
-        api_client::{
-            Error, ErrorKind, GroupMessageStream, WelcomeMessageStream, XmtpIdentityClient,
-            XmtpMlsClient,
-        },
-        xmtp::identity::api::v1::{
-            GetIdentityUpdatesRequest as GetIdentityUpdatesV2Request,
-            GetIdentityUpdatesResponse as GetIdentityUpdatesV2Response, GetInboxIdsRequest,
-            GetInboxIdsResponse, PublishIdentityUpdateRequest, PublishIdentityUpdateResponse,
-        },
+        api_client::{Error, ErrorKind},
         xmtp::mls::api::v1::{
             fetch_key_packages_response::KeyPackage,
             get_identity_updates_response::{
                 update::Kind as UpdateKind, NewInstallationUpdate, Update, WalletUpdates,
             },
-            group_message::{Version as GroupMessageVersion, V1 as GroupMessageV1},
-            FetchKeyPackagesRequest, FetchKeyPackagesResponse, GetIdentityUpdatesRequest,
-            GetIdentityUpdatesResponse, GroupMessage, PagingInfo, QueryGroupMessagesRequest,
-            QueryGroupMessagesResponse, QueryWelcomeMessagesRequest, QueryWelcomeMessagesResponse,
-            RegisterInstallationRequest, RegisterInstallationResponse, SendGroupMessagesRequest,
-            SendWelcomeMessagesRequest, SubscribeGroupMessagesRequest,
-            SubscribeWelcomeMessagesRequest, UploadKeyPackageRequest,
+            FetchKeyPackagesResponse, GetIdentityUpdatesResponse, PagingInfo,
+            QueryGroupMessagesResponse, RegisterInstallationResponse,
         },
     };
-
-    use super::ApiClientWrapper;
-    use crate::retry::Retry;
-
-    pub async fn get_test_api_client() -> ApiClientWrapper<GrpcClient> {
-        ApiClientWrapper::new(
-            GrpcClient::create("http://localhost:5556".to_string(), false)
-                .await
-                .unwrap(),
-            Retry::default(),
-        )
-    }
-
-    fn build_group_messages(num_messages: usize, group_id: Vec<u8>) -> Vec<GroupMessage> {
-        let mut out: Vec<GroupMessage> = vec![];
-        for i in 0..num_messages {
-            out.push(GroupMessage {
-                version: Some(GroupMessageVersion::V1(GroupMessageV1 {
-                    id: i as u64,
-                    created_ns: i as u64,
-                    group_id: group_id.clone(),
-                    data: vec![i as u8],
-                    sender_hmac: vec![],
-                })),
-            })
-        }
-        out
-    }
-
-    // Create a mock XmtpClient for testing the client wrapper
-    mock! {
-        pub ApiClient {}
-
-        #[async_trait]
-        impl XmtpMlsClient for ApiClient {
-            async fn register_installation(
-                &self,
-                request: RegisterInstallationRequest,
-            ) -> Result<RegisterInstallationResponse, Error>;
-            async fn upload_key_package(&self, request: UploadKeyPackageRequest) -> Result<(), Error>;
-            async fn fetch_key_packages(
-                &self,
-                request: FetchKeyPackagesRequest,
-            ) -> Result<FetchKeyPackagesResponse, Error>;
-            async fn send_group_messages(&self, request: SendGroupMessagesRequest) -> Result<(), Error>;
-            async fn send_welcome_messages(&self, request: SendWelcomeMessagesRequest) -> Result<(), Error>;
-            async fn get_identity_updates(
-                &self,
-                request: GetIdentityUpdatesRequest,
-            ) -> Result<GetIdentityUpdatesResponse, Error>;
-            async fn query_group_messages(&self, request: QueryGroupMessagesRequest) -> Result<QueryGroupMessagesResponse, Error>;
-            async fn query_welcome_messages(&self, request: QueryWelcomeMessagesRequest) -> Result<QueryWelcomeMessagesResponse, Error>;
-            async fn subscribe_group_messages(&self, request: SubscribeGroupMessagesRequest) -> Result<GroupMessageStream, Error>;
-            async fn subscribe_welcome_messages(&self, request: SubscribeWelcomeMessagesRequest) -> Result<WelcomeMessageStream, Error>;
-        }
-
-        #[async_trait]
-        impl XmtpIdentityClient for ApiClient {
-            async fn publish_identity_update(&self, request: PublishIdentityUpdateRequest) -> Result<PublishIdentityUpdateResponse, Error>;
-            async fn get_identity_updates_v2(&self, request: GetIdentityUpdatesV2Request) -> Result<GetIdentityUpdatesV2Response, Error>;
-            async fn get_inbox_ids(&self, request: GetInboxIdsRequest) -> Result<GetInboxIdsResponse, Error>;
-        }
-    }
 
     #[tokio::test]
     async fn test_register_installation() {

--- a/xmtp_mls/src/api/mod.rs
+++ b/xmtp_mls/src/api/mod.rs
@@ -1,0 +1,43 @@
+pub mod identity;
+pub mod mls;
+#[cfg(test)]
+pub mod test_utils;
+
+use crate::retry::Retry;
+use thiserror::Error;
+use xmtp_id::associations::{
+    DeserializationError as AssociationDeserializationError,
+    SerializationError as AssociationSerializationError,
+};
+use xmtp_proto::api_client::{Error as ApiError, XmtpIdentityClient, XmtpMlsClient};
+
+pub use identity::*;
+pub use mls::*;
+
+#[derive(Debug, Error)]
+pub enum WrappedApiError {
+    #[error("API client error: {0}")]
+    Api(#[from] ApiError),
+    #[error("Deserialization error {0}")]
+    AssociationDeserialization(#[from] AssociationDeserializationError),
+    #[error("Serialization error {0}")]
+    AssociationSerialization(#[from] AssociationSerializationError),
+}
+
+#[derive(Debug)]
+pub struct ApiClientWrapper<ApiClient> {
+    api_client: ApiClient,
+    retry_strategy: Retry,
+}
+
+impl<ApiClient> ApiClientWrapper<ApiClient>
+where
+    ApiClient: XmtpMlsClient + XmtpIdentityClient,
+{
+    pub fn new(api_client: ApiClient, retry_strategy: Retry) -> Self {
+        Self {
+            api_client,
+            retry_strategy,
+        }
+    }
+}

--- a/xmtp_mls/src/api/test_utils.rs
+++ b/xmtp_mls/src/api/test_utils.rs
@@ -1,0 +1,85 @@
+use async_trait::async_trait;
+use mockall::mock;
+use xmtp_api_grpc::grpc_api_helper::Client as GrpcClient;
+use xmtp_proto::{
+    api_client::{
+        Error, GroupMessageStream, WelcomeMessageStream, XmtpIdentityClient, XmtpMlsClient,
+    },
+    xmtp::identity::api::v1::{
+        GetIdentityUpdatesRequest as GetIdentityUpdatesV2Request,
+        GetIdentityUpdatesResponse as GetIdentityUpdatesV2Response, GetInboxIdsRequest,
+        GetInboxIdsResponse, PublishIdentityUpdateRequest, PublishIdentityUpdateResponse,
+    },
+    xmtp::mls::api::v1::{
+        group_message::{Version as GroupMessageVersion, V1 as GroupMessageV1},
+        FetchKeyPackagesRequest, FetchKeyPackagesResponse, GetIdentityUpdatesRequest,
+        GetIdentityUpdatesResponse, GroupMessage, QueryGroupMessagesRequest,
+        QueryGroupMessagesResponse, QueryWelcomeMessagesRequest, QueryWelcomeMessagesResponse,
+        RegisterInstallationRequest, RegisterInstallationResponse, SendGroupMessagesRequest,
+        SendWelcomeMessagesRequest, SubscribeGroupMessagesRequest, SubscribeWelcomeMessagesRequest,
+        UploadKeyPackageRequest,
+    },
+};
+
+use super::ApiClientWrapper;
+use crate::retry::Retry;
+
+pub async fn get_test_api_client() -> ApiClientWrapper<GrpcClient> {
+    ApiClientWrapper::new(
+        GrpcClient::create("http://localhost:5556".to_string(), false)
+            .await
+            .unwrap(),
+        Retry::default(),
+    )
+}
+
+pub fn build_group_messages(num_messages: usize, group_id: Vec<u8>) -> Vec<GroupMessage> {
+    let mut out: Vec<GroupMessage> = vec![];
+    for i in 0..num_messages {
+        out.push(GroupMessage {
+            version: Some(GroupMessageVersion::V1(GroupMessageV1 {
+                id: i as u64,
+                created_ns: i as u64,
+                group_id: group_id.clone(),
+                data: vec![i as u8],
+                sender_hmac: vec![],
+            })),
+        })
+    }
+    out
+}
+
+// Create a mock XmtpClient for testing the client wrapper
+mock! {
+    pub ApiClient {}
+
+    #[async_trait]
+    impl XmtpMlsClient for ApiClient {
+        async fn register_installation(
+            &self,
+            request: RegisterInstallationRequest,
+        ) -> Result<RegisterInstallationResponse, Error>;
+        async fn upload_key_package(&self, request: UploadKeyPackageRequest) -> Result<(), Error>;
+        async fn fetch_key_packages(
+            &self,
+            request: FetchKeyPackagesRequest,
+        ) -> Result<FetchKeyPackagesResponse, Error>;
+        async fn send_group_messages(&self, request: SendGroupMessagesRequest) -> Result<(), Error>;
+        async fn send_welcome_messages(&self, request: SendWelcomeMessagesRequest) -> Result<(), Error>;
+        async fn get_identity_updates(
+            &self,
+            request: GetIdentityUpdatesRequest,
+        ) -> Result<GetIdentityUpdatesResponse, Error>;
+        async fn query_group_messages(&self, request: QueryGroupMessagesRequest) -> Result<QueryGroupMessagesResponse, Error>;
+        async fn query_welcome_messages(&self, request: QueryWelcomeMessagesRequest) -> Result<QueryWelcomeMessagesResponse, Error>;
+        async fn subscribe_group_messages(&self, request: SubscribeGroupMessagesRequest) -> Result<GroupMessageStream, Error>;
+        async fn subscribe_welcome_messages(&self, request: SubscribeWelcomeMessagesRequest) -> Result<WelcomeMessageStream, Error>;
+    }
+
+    #[async_trait]
+    impl XmtpIdentityClient for ApiClient {
+        async fn publish_identity_update(&self, request: PublishIdentityUpdateRequest) -> Result<PublishIdentityUpdateResponse, Error>;
+        async fn get_identity_updates_v2(&self, request: GetIdentityUpdatesV2Request) -> Result<GetIdentityUpdatesV2Response, Error>;
+        async fn get_inbox_ids(&self, request: GetInboxIdsRequest) -> Result<GetInboxIdsResponse, Error>;
+    }
+}

--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 use xmtp_proto::api_client::{XmtpIdentityClient, XmtpMlsClient};
 
 use crate::{
-    api_client_wrapper::ApiClientWrapper,
+    api::ApiClientWrapper,
     client::{Client, Network},
     identity::{Identity, IdentityError},
     retry::Retry,

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -20,7 +20,7 @@ use xmtp_proto::{
 };
 
 use crate::{
-    api_client_wrapper::{ApiClientWrapper, IdentityUpdate},
+    api::{ApiClientWrapper, IdentityUpdate},
     groups::{
         validated_commit::CommitValidationError, AddressesOrInstallationIds, IntentError, MlsGroup,
         PreconfiguredPolicies,

--- a/xmtp_mls/src/groups/sync.rs
+++ b/xmtp_mls/src/groups/sync.rs
@@ -40,7 +40,7 @@ use super::{
 };
 
 use crate::{
-    api_client_wrapper::IdentityUpdate,
+    api::IdentityUpdate,
     client::MessageProcessingError,
     codecs::{membership_change::GroupMembershipChangeCodec, ContentCodec},
     configuration::{MAX_INTENT_PUBLISH_ATTEMPTS, UPDATE_INSTALLATIONS_INTERVAL_NS},

--- a/xmtp_mls/src/identity.rs
+++ b/xmtp_mls/src/identity.rs
@@ -25,7 +25,7 @@ use xmtp_proto::{
 };
 
 use crate::{
-    api_client_wrapper::{ApiClientWrapper, IdentityUpdate},
+    api::{ApiClientWrapper, IdentityUpdate},
     configuration::CIPHERSUITE,
     credential::{AssociationError, Credential, UnsignedGrantMessagingAccessData},
     storage::{identity::StoredIdentity, StorageError},
@@ -286,7 +286,7 @@ mod tests {
 
     use super::Identity;
     use crate::{
-        api_client_wrapper::{tests::get_test_api_client, ApiClientWrapper},
+        api::{test_utils::get_test_api_client, ApiClientWrapper},
         storage::EncryptedMessageStore,
         xmtp_openmls_provider::XmtpOpenMlsProvider,
         InboxOwner,

--- a/xmtp_mls/src/lib.rs
+++ b/xmtp_mls/src/lib.rs
@@ -1,4 +1,4 @@
-pub mod api_client_wrapper;
+pub mod api;
 pub mod builder;
 pub mod client;
 pub mod codecs;

--- a/xmtp_mls/src/subscriptions.rs
+++ b/xmtp_mls/src/subscriptions.rs
@@ -16,7 +16,7 @@ use xmtp_proto::{
 };
 
 use crate::{
-    api_client_wrapper::GroupFilter,
+    api::GroupFilter,
     client::{extract_welcome_message, ClientError},
     groups::{extract_group_id, GroupError, MlsGroup},
     storage::group_message::StoredGroupMessage,


### PR DESCRIPTION
## tl;dr

- Refactors our API Client Wrapper and moves it to its own module, with separate files for MLS and Identity methods
- Adds new Identity methods
- Adds mocks for Identity API and tests using those mocks

## Notes

- @insipx I borrowed some pieces of your pending PR that I needed here. Hopefully won't be too annoying with conflicts.
- Right now I'm being strict with serialization errors. We should think through how we really want to behave once this goes to prod. One person's bad update shouldn't break the entire group. And we should make sure this is safe to add new features like one-way associations later (since those don't change commit processing).

## Issues
- https://github.com/xmtp/libxmtp/issues/629