### PR TITLE
Message send state

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -338,7 +338,7 @@ pub struct FfiListMessagesOptions {
 
 #[uniffi::export(async_runtime = "tokio")]
 impl FfiGroup {
-    pub async fn send(&self, content_bytes: Vec<u8>) -> Result<(), GenericError> {
+    pub async fn send(&self, content_bytes: Vec<u8>) -> Result<Vec<u8>, GenericError> {
         let group = MlsGroup::new(
             self.inner_client.as_ref(),
             self.group_id.clone(),
@@ -346,9 +346,9 @@ impl FfiGroup {
             self.added_by_address.clone(),
         );
 
-        group.send_message(content_bytes.as_slice()).await?;
+        let message_id = group.send_message(content_bytes.as_slice()).await?;
 
-        Ok(())
+        Ok((message_id))
     }
 
     pub async fn sync(&self) -> Result<(), GenericError> {

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -375,12 +375,15 @@ impl FfiGroup {
             self.added_by_address.clone(),
         );
 
+        
+        let delivery_status = opts.delivery_status.map(|status| status.into()); 
+
         let messages: Vec<FfiMessage> = group
             .find_messages(
                 None,
                 opts.sent_before_ns,
                 opts.sent_after_ns,
-                opts.delivery_status,
+                delivery_status,
                 opts.limit,
             )?
             .into_iter()
@@ -538,6 +541,16 @@ impl From<DeliveryStatus> for FfiDeliveryStatus {
             DeliveryStatus::Unpublished => FfiDeliveryStatus::Unpublished,
             DeliveryStatus::Published => FfiDeliveryStatus::Published,
             DeliveryStatus::Failed => FfiDeliveryStatus::Failed,
+        }
+    }
+}
+
+impl From<FfiDeliveryStatus> for DeliveryStatus {
+    fn from(status: FfiDeliveryStatus) -> Self {
+        match status {
+            FfiDeliveryStatus::Unpublished => DeliveryStatus::Unpublished,
+            FfiDeliveryStatus::Published => DeliveryStatus::Published,
+            FfiDeliveryStatus::Failed => DeliveryStatus::Failed,
         }
     }
 }

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -348,7 +348,7 @@ impl FfiGroup {
 
         let message_id = group.send_message(content_bytes.as_slice()).await?;
 
-        Ok((message_id))
+        Ok(message_id)
     }
 
     pub async fn sync(&self) -> Result<(), GenericError> {
@@ -525,6 +525,7 @@ impl From<GroupMessageKind> for FfiGroupMessageKind {
     }
 }
 
+#[derive(uniffi::Enum)]
 pub enum FfiDeliveryStatus {
     Unpublished,
     Published,

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -333,6 +333,7 @@ pub struct FfiListMessagesOptions {
     pub sent_before_ns: Option<i64>,
     pub sent_after_ns: Option<i64>,
     pub limit: Option<i64>,
+    pub delivery_status: Option<FfiDeliveryStatus>,
 }
 
 #[uniffi::export(async_runtime = "tokio")]
@@ -379,7 +380,7 @@ impl FfiGroup {
                 None,
                 opts.sent_before_ns,
                 opts.sent_after_ns,
-                None,
+                opts.delivery_status,
                 opts.limit,
             )?
             .into_iter()

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -19,7 +19,7 @@ use xmtp_mls::{
     client::Client as MlsClient,
     groups::MlsGroup,
     storage::{
-        group_message::GroupMessageKind, group_message::StoredGroupMessage, EncryptedMessageStore,
+        group_message::DeliveryStatus, group_message::GroupMessageKind, group_message::StoredGroupMessage, EncryptedMessageStore,
         EncryptionKey, StorageOption,
     },
     types::Address,
@@ -524,6 +524,22 @@ impl From<GroupMessageKind> for FfiGroupMessageKind {
     }
 }
 
+pub enum FfiDeliveryStatus {
+    Unpublished,
+    Published,
+    Failed,
+}
+
+impl From<DeliveryStatus> for FfiDeliveryStatus {
+    fn from(status: DeliveryStatus) -> Self {
+        match status {
+            DeliveryStatus::Unpublished => FfiDeliveryStatus::Unpublished,
+            DeliveryStatus::Published => FfiDeliveryStatus::Published,
+            DeliveryStatus::Failed => FfiDeliveryStatus::Failed,
+        }
+    }
+}
+
 #[derive(uniffi::Record)]
 pub struct FfiMessage {
     pub id: Vec<u8>,
@@ -532,6 +548,7 @@ pub struct FfiMessage {
     pub addr_from: String,
     pub content: Vec<u8>,
     pub kind: FfiGroupMessageKind,
+    pub delivery_status: FfiDeliveryStatus,
 }
 
 impl From<StoredGroupMessage> for FfiMessage {
@@ -543,6 +560,7 @@ impl From<StoredGroupMessage> for FfiMessage {
             addr_from: msg.sender_account_address,
             content: msg.decrypted_message_bytes,
             kind: msg.kind.into(),
+            delivery_status: msg.delivery_status.into(),
         }
     }
 }

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -298,7 +298,7 @@ where
         }
     }
 
-    pub async fn send_message(&self, message: &[u8]) -> Result<(), GroupError> {
+    pub async fn send_message(&self, message: &[u8]) -> Result<Vec<u8>, GroupError> {
         let conn = &mut self.client.store.conn()?;
 
         let update_interval = Some(5_000_000); // 5 seconds in nanoseconds
@@ -340,7 +340,7 @@ where
         if let Err(err) = self.publish_intents(conn).await {
             println!("error publishing intents: {:?}", err);
         }
-        Ok(())
+        Ok(message_id)
     }
 
     // Query the database for stored messages. Optionally filtered by time, kind, delivery_status

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -325,7 +325,7 @@ where
             &now.to_string(),
         );
         let group_message = StoredGroupMessage {
-            id: message_id,
+            id: message_id.clone(),
             group_id: self.group_id.clone(),
             decrypted_message_bytes: message.to_vec(),
             sent_at_ns: now,

--- a/xmtp_mls/src/storage/encrypted_store/group_message.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group_message.rs
@@ -74,6 +74,7 @@ where
 pub enum DeliveryStatus {
     Unpublished = 1,
     Published = 2,
+    Failed = 3,
 }
 
 impl ToSql<Integer, Sqlite> for DeliveryStatus
@@ -94,6 +95,7 @@ where
         match i32::from_sql(bytes)? {
             1 => Ok(DeliveryStatus::Unpublished),
             2 => Ok(DeliveryStatus::Published),
+            3 => Ok(DeliveryStatus::Failed),
             x => Err(format!("Unrecognized variant {}", x).into()),
         }
     }


### PR DESCRIPTION
Part of https://github.com/xmtp/libxmtp/issues/516

- [x] Add enum field of failed to delivery status for when unpublished never publishes
- [x] Expose delivery status
- [x] Expose delivery status filtering on find_messages
- [x] Expose message id on send


In a follow up PR we need to figure out how to set the delivery status to failed after 3 unsuccessful retries to publish. @tuddman maybe you have some ideas on how to do that?