### PR TITLE
Add some Identity client methods

### DIFF
--- a/xmtp_id/src/associations/association_log.rs
+++ b/xmtp_id/src/associations/association_log.rs
@@ -1,11 +1,12 @@
 use super::hashes::generate_inbox_id;
 use super::member::{Member, MemberIdentifier, MemberKind};
 use super::serialization::{
-    from_identity_update_proto, to_identity_update_proto, DeserializationError, SerializationError,
+    from_identity_update_proto, to_identity_update_proto, DeserializationError,
 };
 use super::signature::{Signature, SignatureError, SignatureKind};
 use super::state::AssociationState;
 
+use prost::Message;
 use thiserror::Error;
 use xmtp_proto::xmtp::identity::associations::IdentityUpdate as IdentityUpdateProto;
 
@@ -33,6 +34,10 @@ pub enum AssociationError {
     SignatureNotAllowed(String, String),
     #[error("Replay detected")]
     Replay,
+    #[error("Deserialization error {0}")]
+    Deserialization(#[from] DeserializationError),
+    #[error("Missing identity update")]
+    MissingIdentityUpdate,
 }
 
 pub trait IdentityAction {
@@ -323,7 +328,7 @@ impl IdentityUpdate {
         }
     }
 
-    pub fn to_proto(&self) -> Result<IdentityUpdateProto, SerializationError> {
+    pub fn to_proto(&self) -> IdentityUpdateProto {
         to_identity_update_proto(self)
     }
 
@@ -332,10 +337,8 @@ impl IdentityUpdate {
     }
 }
 
-impl TryFrom<IdentityUpdate> for IdentityUpdateProto {
-    type Error = SerializationError;
-
-    fn try_from(proto: IdentityUpdate) -> Result<IdentityUpdateProto, Self::Error> {
+impl From<IdentityUpdate> for IdentityUpdateProto {
+    fn from(proto: IdentityUpdate) -> IdentityUpdateProto {
         IdentityUpdate::to_proto(&proto)
     }
 }
@@ -344,6 +347,15 @@ impl TryFrom<IdentityUpdateProto> for IdentityUpdate {
     type Error = DeserializationError;
 
     fn try_from(proto: IdentityUpdateProto) -> Result<IdentityUpdate, Self::Error> {
+        IdentityUpdate::from_proto(proto)
+    }
+}
+
+impl TryFrom<Vec<u8>> for IdentityUpdate {
+    type Error = DeserializationError;
+
+    fn try_from(bytes: Vec<u8>) -> Result<IdentityUpdate, Self::Error> {
+        let proto = IdentityUpdateProto::decode(bytes.as_slice())?;
         IdentityUpdate::from_proto(proto)
     }
 }

--- a/xmtp_id/src/associations/mod.rs
+++ b/xmtp_id/src/associations/mod.rs
@@ -12,7 +12,7 @@ mod unsigned_actions;
 pub use self::association_log::*;
 pub use self::hashes::generate_inbox_id;
 pub use self::member::{Member, MemberIdentifier, MemberKind};
-pub use self::serialization::{DeserializationError, SerializationError};
+pub use self::serialization::DeserializationError;
 pub use self::signature::{Signature, SignatureError, SignatureKind};
 pub use self::state::AssociationState;
 

--- a/xmtp_id/src/associations/serialization.rs
+++ b/xmtp_id/src/associations/serialization.rs
@@ -13,6 +13,7 @@ use super::{
     },
     IdentityUpdate, MemberIdentifier, Signature,
 };
+use prost::DecodeError;
 use thiserror::Error;
 use xmtp_proto::xmtp::identity::associations::{
     identity_action::Kind as IdentityActionKindProto,
@@ -34,6 +35,8 @@ pub enum DeserializationError {
     MissingMemberIdentifier,
     #[error("Missing signature")]
     Signature,
+    #[error("Decode error {0}")]
+    Decode(#[from] DecodeError),
 }
 
 pub fn from_identity_update_proto(
@@ -221,29 +224,18 @@ fn from_signature_kind_proto(
     })
 }
 
-// Serialization
-#[derive(Error, Debug)]
-pub enum SerializationError {
-    #[error("Missing action")]
-    MissingAction,
-}
-
-pub fn to_identity_update_proto(
-    identity_update: &IdentityUpdate,
-) -> Result<IdentityUpdateProto, SerializationError> {
+pub fn to_identity_update_proto(identity_update: &IdentityUpdate) -> IdentityUpdateProto {
     let actions: Vec<IdentityActionProto> = identity_update
         .actions
         .iter()
         .map(to_identity_action_proto)
         .collect();
 
-    let proto = IdentityUpdateProto {
+    IdentityUpdateProto {
         client_timestamp_ns: identity_update.client_timestamp_ns,
         inbox_id: identity_update.inbox_id.clone(),
         actions,
-    };
-
-    Ok(proto)
+    }
 }
 
 fn to_identity_action_proto(action: &Action) -> IdentityActionProto {
@@ -330,8 +322,7 @@ mod tests {
             rand_u64(),
         );
 
-        let serialized_update =
-            to_identity_update_proto(&identity_update).expect("serialization should succeed");
+        let serialized_update = to_identity_update_proto(&identity_update);
 
         assert_eq!(
             serialized_update.client_timestamp_ns,
@@ -342,8 +333,7 @@ mod tests {
         let deserialized_update = from_identity_update_proto(serialized_update.clone())
             .expect("deserialization should succeed");
 
-        let reserialized =
-            to_identity_update_proto(&deserialized_update).expect("serialization should succeed");
+        let reserialized = to_identity_update_proto(&deserialized_update);
 
         assert_eq!(serialized_update, reserialized);
     }

--- a/xmtp_mls/src/api/identity.rs
+++ b/xmtp_mls/src/api/identity.rs
@@ -17,7 +17,7 @@ use xmtp_proto::{
 
 /// A filter for querying identity updates. `sequence_id` is the starting sequence, and only later updates will be returned.
 pub struct GetIdentityUpdatesV2Filter {
-    pub inbox_id: String,
+    pub inbox_id: InboxId,
     pub sequence_id: Option<u64>,
 }
 
@@ -68,7 +68,7 @@ where
     ) -> Result<(), WrappedApiError> {
         self.api_client
             .publish_identity_update(PublishIdentityUpdateRequest {
-                identity_update: Some(update.try_into()?),
+                identity_update: Some(update.into()),
             })
             .await?;
 
@@ -179,7 +179,7 @@ mod tests {
                         updates: vec![IdentityUpdateLog {
                             sequence_id: 1,
                             server_timestamp_ns: 1,
-                            update: Some(identity_update.to_proto().unwrap()),
+                            update: Some(identity_update.to_proto()),
                         }],
                     }],
                 })

--- a/xmtp_mls/src/api/mod.rs
+++ b/xmtp_mls/src/api/mod.rs
@@ -5,10 +5,7 @@ pub mod test_utils;
 
 use crate::retry::Retry;
 use thiserror::Error;
-use xmtp_id::associations::{
-    DeserializationError as AssociationDeserializationError,
-    SerializationError as AssociationSerializationError,
-};
+use xmtp_id::associations::DeserializationError as AssociationDeserializationError;
 use xmtp_proto::api_client::{Error as ApiError, XmtpIdentityClient, XmtpMlsClient};
 
 pub use identity::*;
@@ -20,8 +17,6 @@ pub enum WrappedApiError {
     Api(#[from] ApiError),
     #[error("Deserialization error {0}")]
     AssociationDeserialization(#[from] AssociationDeserializationError),
-    #[error("Serialization error {0}")]
-    AssociationSerialization(#[from] AssociationSerializationError),
 }
 
 #[derive(Debug)]

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -11,6 +11,7 @@ use openmls_traits::OpenMlsProvider;
 use prost::EncodeError;
 use thiserror::Error;
 
+use xmtp_id::associations::AssociationError;
 use xmtp_proto::{
     api_client::{XmtpIdentityClient, XmtpMlsClient},
     xmtp::mls::api::v1::{
@@ -60,6 +61,8 @@ pub enum ClientError {
     Diesel(#[from] diesel::result::Error),
     #[error("Query failed: {0}")]
     QueryError(#[from] xmtp_proto::api_client::Error),
+    #[error("API error: {0}")]
+    Api(#[from] crate::api::WrappedApiError),
     #[error("identity error: {0}")]
     Identity(#[from] crate::identity::IdentityError),
     #[error("TLS Codec error: {0}")]
@@ -70,6 +73,8 @@ pub enum ClientError {
     SyncingError(Vec<MessageProcessingError>),
     #[error("Stream inconsistency error: {0}")]
     StreamInconsistency(String),
+    #[error("Association error: {0}")]
+    Association(#[from] AssociationError),
     #[error("generic:{0}")]
     Generic(String),
 }

--- a/xmtp_mls/src/identity_updates.rs
+++ b/xmtp_mls/src/identity_updates.rs
@@ -1,0 +1,83 @@
+use prost::Message;
+use xmtp_id::associations::{get_state, AssociationError, AssociationState, IdentityUpdate};
+use xmtp_proto::api_client::{XmtpIdentityClient, XmtpMlsClient};
+
+use crate::{
+    api::GetIdentityUpdatesV2Filter,
+    client::ClientError,
+    storage::{db_connection::DbConnection, identity_update::StoredIdentityUpdate},
+    Client,
+};
+
+impl<'a, ApiClient> Client<ApiClient>
+where
+    ApiClient: XmtpMlsClient + XmtpIdentityClient,
+{
+    /// For the given list of `inbox_id`s get all updates from the network that are newer than the last known `sequence_id``
+    pub async fn load_identity_updates(
+        &self,
+        conn: &'a DbConnection<'a>,
+        inbox_ids: Vec<String>,
+    ) -> Result<(), ClientError> {
+        let existing_sequence_ids = conn.get_latest_sequence_id(&inbox_ids)?;
+        let filters = inbox_ids
+            .into_iter()
+            .map(|inbox_id| GetIdentityUpdatesV2Filter {
+                sequence_id: existing_sequence_ids
+                    .get(&inbox_id)
+                    .cloned()
+                    .map(|i| i as u64),
+                inbox_id,
+            })
+            .collect();
+
+        let updates = self.api_client.get_identity_updates_v2(filters).await?;
+
+        let to_store = updates
+            .into_iter()
+            .flat_map(|(inbox_id, updates)| {
+                updates.into_iter().map(move |update| StoredIdentityUpdate {
+                    inbox_id: inbox_id.clone(),
+                    sequence_id: update.sequence_id as i64,
+                    server_timestamp_ns: update.server_timestamp_ns as i64,
+                    payload: update.update.to_proto().encode_to_vec(),
+                })
+            })
+            .collect::<Vec<StoredIdentityUpdate>>();
+
+        Ok(conn.insert_or_ignore_identity_updates(&to_store)?)
+    }
+
+    pub fn get_association_state<InboxId: AsRef<str>>(
+        &self,
+        conn: &'a DbConnection<'a>,
+        inbox_id: InboxId,
+        to_sequence_id: Option<i64>,
+    ) -> Result<AssociationState, ClientError> {
+        let updates = conn.get_identity_updates(inbox_id, None, to_sequence_id)?;
+        let last_update = updates.last();
+        if last_update.is_none() {
+            return Err(AssociationError::MissingIdentityUpdate.into());
+        }
+        if let Some(sequence_id) = to_sequence_id {
+            if last_update
+                .expect("already checked")
+                .sequence_id
+                .ne(&sequence_id)
+            {
+                return Err(AssociationError::MissingIdentityUpdate.into());
+            }
+        }
+        let updates = updates
+            .into_iter()
+            .map(IdentityUpdate::try_from)
+            .collect::<Result<Vec<IdentityUpdate>, AssociationError>>()?;
+
+        Ok(get_state(updates)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // TODO once we have identity APIs working
+}

--- a/xmtp_mls/src/lib.rs
+++ b/xmtp_mls/src/lib.rs
@@ -7,6 +7,7 @@ pub mod credential;
 pub mod groups;
 mod hpke;
 pub mod identity;
+mod identity_updates;
 pub mod owner;
 pub mod retry;
 pub mod storage;

--- a/xmtp_mls/src/storage/mod.rs
+++ b/xmtp_mls/src/storage/mod.rs
@@ -4,7 +4,7 @@ mod serialization;
 pub mod sql_key_store;
 
 pub use encrypted_store::{
-    db_connection, group, group_intent, group_message, identity, key_store_entry, refresh_state,
-    EncryptedMessageStore, EncryptionKey, RawDbConnection, StorageOption,
+    db_connection, group, group_intent, group_message, identity, identity_update, key_store_entry,
+    refresh_state, EncryptedMessageStore, EncryptionKey, RawDbConnection, StorageOption,
 };
 pub use errors::StorageError;


### PR DESCRIPTION
### TL;DR
- Adds a new method to the client for loading `IdentityUpdates` from the network into the DB
- Adds a new method to the client for getting the association state at a given sequence ID
- Changes `IdentityUpdate` serialization to never return errors.
- Allows setting `from_sequence_id` and `to_sequence_id` on one database method, to support incremental updates

## What else

- Tests will have to wait until we have an API

