### PR TITLE
fix: allow get_then_check and other fixes other lint

### DIFF
--- a/xmtp_mls/src/groups/group_membership.rs
+++ b/xmtp_mls/src/groups/group_membership.rs
@@ -26,7 +26,6 @@ impl GroupMembership {
         self.members.get(inbox_id.as_ref())
     }
 
-    #[allow(clippy::unnecessary_get_then_check)]
     pub fn diff<'inbox_id>(
         &'inbox_id self,
         new_group_membership: &'inbox_id Self,
@@ -51,10 +50,10 @@ impl GroupMembership {
             .members
             .iter()
             .filter_map(|(inbox_id, _)| {
-                if self.members.get(inbox_id).is_none() {
-                    Some(inbox_id)
-                } else {
+                if self.members.contains_key(inbox_id) {
                     None
+                } else {
+                    Some(inbox_id)
                 }
             })
             .collect::<Vec<&String>>();

--- a/xmtp_mls/src/groups/group_membership.rs
+++ b/xmtp_mls/src/groups/group_membership.rs
@@ -26,6 +26,7 @@ impl GroupMembership {
         self.members.get(inbox_id.as_ref())
     }
 
+    #[allow(clippy::unnecessary_get_then_check)]
     pub fn diff<'inbox_id>(
         &'inbox_id self,
         new_group_membership: &'inbox_id Self,

--- a/xmtp_mls/src/storage/encrypted_store/db_connection.rs
+++ b/xmtp_mls/src/storage/encrypted_store/db_connection.rs
@@ -34,14 +34,13 @@ impl<'a> DbConnection<'a> {
     where
         F: FnOnce(&mut RawDbConnection) -> Result<T, diesel::result::Error>,
     {
-        let mut lock = self.wrapped_conn.lock().map_or_else(
+        let mut lock = self.wrapped_conn.lock().unwrap_or_else(
             |err| {
                 log::error!(
                     "Recovering from poisoned mutex - a thread has previously panicked holding this lock"
                 );
                 err.into_inner()
             },
-            |guard| guard,
         );
         match *lock {
             RefOrValue::Ref(ref mut conn_ref) => fun(conn_ref),


### PR DESCRIPTION
## Summary

with `1.78.0` [released today](https://blog.rust-lang.org/2024/05/02/Rust-1.78.0.html), our CI pulls `latest` and runs against the new lints, which include this one:

https://rust-lang.github.io/rust-clippy/master/index.html#/unnecessary_get_then_check

which fails to compile if you accept the lint change of using a unary `!` on an `Option<T>` instead of `is_none()` which always worked exactly as it reads.

 #rust-aint-perfect