### PR TITLE
Patch openssl-sys crate to v0.9.92

### DIFF
--- a/bindings_ffi/Cargo.lock
+++ b/bindings_ffi/Cargo.lock
@@ -2650,18 +2650,17 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.2.1+3.2.0"
+version = "111.28.1+1.1.1w"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fe476c29791a5ca0d1273c697e96085bbabbbea2ef7afd5617e78a4b40332d3"
+checksum = "4bf7e82ffd6d3d6e6524216a0bfd85509f68b5b28354e8e7800057e44cefa9b4"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.99"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae"
+version = "0.9.92"
+source = "git+https://github.com/xmtp/rust-openssl.git?branch=clone-v0.9.92#00dacb9318930fbdd845cd4b36281e44c8d0c30f"
 dependencies = [
  "cc",
  "libc",

--- a/bindings_ffi/Cargo.toml
+++ b/bindings_ffi/Cargo.toml
@@ -20,6 +20,15 @@ xmtp_proto = { path = "../xmtp_proto", features = ["proto_full", "grpc"] }
 xmtp_user_preferences = { path = "../xmtp_user_preferences" }
 xmtp_v2 = { path = "../xmtp_v2" }
 
+# NOTE: A regression in openssl-sys exists where libatomic is dynamically linked 
+# for i686-linux-android targets. https://github.com/sfackler/rust-openssl/issues/2163
+#
+# This is fixed in the openssl-sys fork at
+# https://github.com/xmtp/rust-openssl on the branch clone-v0.9.92, which is pinned
+# to that version. Once this is addressed upstream we can remove the patch.
+[patch.crates-io]
+openssl-sys = { git = "https://github.com/xmtp/rust-openssl.git", branch = "clone-v0.9.92" }
+
 [build-dependencies]
 uniffi = { version = "0.25.3", features = ["build"] }
 


### PR DESCRIPTION
A regression in openssl-sys exists where libatomic is dynamically linked 
for i686-linux-android targets. https://github.com/sfackler/rust-openssl/issues/2163

The result is dynamically linked symbols are included in the binary header link table:

```
         U __atomic_fetch_or_8
         U __atomic_is_lock_free
         U __atomic_load
```

The presence of these symbols breaks Android CI tests for i686 targets with the following error:

```
java.lang.UnsatisfiedLinkError: Unable to load library 'uniffi_xmtpv3':
	dlopen failed: cannot locate symbol "__atomic_is_lock_free" referenced by "/data/app/org.xmtp.android.library.test-Cq_BL0nCyvMEKUk7x28gzw==/base.apk!/lib/x86/libuniffi_xmtpv3.so"...
```


This is fixed in the openssl-sys fork at https://github.com/xmtp/rust-openssl on the branch clone-v0.9.92, which is pinned
to that version. Version 0.9.92 statically links libatomic for i686 targets. Once this is addressed upstream we can remove the patch.

A patch is required as openssl-sys is a dependency crate. A fork is required  because it is not possible to patch to an older version of the same source.