### PR TITLE
remove option from map

### DIFF
--- a/xmtp_mls/src/api/identity.rs
+++ b/xmtp_mls/src/api/identity.rs
@@ -56,7 +56,7 @@ impl TryFrom<IdentityUpdateLog> for InboxUpdate {
 type InboxUpdateMap = HashMap<InboxId, Vec<InboxUpdate>>;
 
 /// Maps account addresses to inbox IDs. If no inbox ID found, the value will be None
-type AddressToInboxIdMap = HashMap<String, Option<InboxId>>;
+type AddressToInboxIdMap = HashMap<String, InboxId>;
 
 impl<ApiClient> ApiClientWrapper<ApiClient>
 where
@@ -122,7 +122,8 @@ where
         Ok(result
             .responses
             .into_iter()
-            .map(|inbox_id| (inbox_id.address, inbox_id.inbox_id))
+            .filter(|inbox_id| inbox_id.inbox_id.is_some())
+            .map(|inbox_id| (inbox_id.address, inbox_id.inbox_id.unwrap()))
             .collect())
     }
 }

--- a/xmtp_mls/src/api/identity.rs
+++ b/xmtp_mls/src/api/identity.rs
@@ -238,9 +238,6 @@ mod tests {
             .expect("should work");
 
         assert_eq!(result.len(), 1);
-        assert_eq!(
-            result.get(&address).unwrap().as_ref().unwrap(),
-            &inbox_id_clone_2
-        );
+        assert_eq!(result.get(&address).unwrap(), &inbox_id_clone_2);
     }
 }


### PR DESCRIPTION
Use `V` instead of `Option<V>` because HashMap has built-in  Option<V> when returning a value.