### PR TITLE
aggregate Identity creation

### DIFF
--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -38,10 +38,6 @@ pub enum ClientBuilderError {
     #[error("Uncovered Case")]
     UncoveredCase,
 
-    // #[error("Associating an address to account failed")]
-    // AssociationFailed(#[from] AssociationError),
-    // #[error("Error Initializing Store")]
-    // StoreInitialization(#[from] SE),
     #[error("Error initializing identity: {0}")]
     IdentityInitialization(#[from] IdentityError),
 

--- a/xmtp_mls/src/identity/xmtp_id/identity.rs
+++ b/xmtp_mls/src/identity/xmtp_id/identity.rs
@@ -1,6 +1,7 @@
 use std::array::TryFromSliceError;
 
 use ed25519_dalek::SigningKey;
+use ethers::signers::{LocalWallet, WalletError};
 use openmls::{
     credentials::{errors::BasicCredentialError, BasicCredential},
     prelude::Credential as OpenMlsCredential,
@@ -31,6 +32,7 @@ use xmtp_v2::k256_helper;
 use crate::{
     api::{ApiClientWrapper, WrappedApiError},
     configuration::CIPHERSUITE,
+    InboxOwner,
 };
 
 #[derive(Debug, Error)]
@@ -47,6 +49,8 @@ pub enum IdentityError {
     BasicCredential(#[from] BasicCredentialError),
     #[error("Legacy key re-use")]
     LegacyKeyReuse,
+    #[error("legacy key does not match address")]
+    LegacyKeyMismatch,
     #[error("Installation key {0}")]
     InstallationKey(String),
     #[error("Malformed legacy key: {0}")]
@@ -55,6 +59,8 @@ pub enum IdentityError {
     LegacySignature(String),
     #[error(transparent)]
     Crypto(#[from] CryptoError),
+    #[error(transparent)]
+    WalletError(#[from] WalletError),
 }
 
 #[derive(Debug, Clone)]
@@ -96,6 +102,12 @@ impl Identity {
                 return Err(IdentityError::LegacyKeyReuse);
             }
 
+            // sanity check if address matches the one derived from legacy_signed_private_key
+            let legacy_key_address = legacy_key_to_address(legacy_signed_private_key.clone())?;
+            if address != legacy_key_address {
+                return Err(IdentityError::LegacyKeyMismatch);
+            }
+
             // 2. has legacy key, no inbox -> create an inbox and sign the installation key with the legacy key.
             let nonce = 0;
             let inbox_id = generate_inbox_id(&address, &nonce);
@@ -106,22 +118,16 @@ impl Identity {
                 .build();
 
             signature_request
-                .add_signature(Box::new(
-                    sign_with_installation_key(
-                        signature_request.signature_text(),
-                        sized_installation_key(signature_keys.private())?,
-                    )
-                    .await?,
-                ))
+                .add_signature(Box::new(sign_with_installation_key(
+                    signature_request.signature_text(),
+                    sized_installation_key(signature_keys.private())?,
+                )?))
                 .await?;
             signature_request
-                .add_signature(Box::new(
-                    sign_with_legacy_key(
-                        signature_request.signature_text(),
-                        legacy_signed_private_key,
-                    )
-                    .await?,
-                ))
+                .add_signature(Box::new(sign_with_legacy_key(
+                    signature_request.signature_text(),
+                    legacy_signed_private_key,
+                )?))
                 .await?;
             let identity_update = signature_request.build_identity_update()?;
             api_client.publish_identity_update(identity_update).await?;
@@ -155,13 +161,10 @@ impl Identity {
                 .build();
 
             signature_request
-                .add_signature(Box::new(
-                    sign_with_installation_key(
-                        signature_request.signature_text(),
-                        sized_installation_key(signature_keys.private())?,
-                    )
-                    .await?,
-                ))
+                .add_signature(Box::new(sign_with_installation_key(
+                    signature_request.signature_text(),
+                    sized_installation_key(signature_keys.private())?,
+                )?))
                 .await?;
 
             let identity = Self {
@@ -180,7 +183,7 @@ impl Identity {
     }
 }
 
-async fn sign_with_installation_key(
+fn sign_with_installation_key(
     signature_text: String,
     installation_private_key: &[u8; 32],
 ) -> Result<InstallationKeySignature, IdentityError> {
@@ -201,7 +204,21 @@ async fn sign_with_installation_key(
     Ok(installation_key_sig)
 }
 
-async fn sign_with_legacy_key(
+/// Convert a legacy signed private key(secp256k1) to an address.
+fn legacy_key_to_address(legacy_signed_private_key: Vec<u8>) -> Result<String, IdentityError> {
+    let legacy_signed_private_key_proto =
+        LegacySignedPrivateKeyProto::decode(legacy_signed_private_key.as_slice())?;
+    let signed_private_key::Union::Secp256k1(secp256k1) = legacy_signed_private_key_proto
+        .union
+        .ok_or(IdentityError::MalformedLegacyKey(
+            "Missing secp256k1.union field".to_string(),
+        ))?;
+    let legacy_private_key = secp256k1.bytes;
+    let wallet: LocalWallet = LocalWallet::from_bytes(&legacy_private_key)?;
+    Ok(wallet.get_address())
+}
+
+fn sign_with_legacy_key(
     signature_text: String,
     legacy_signed_private_key: Vec<u8>,
 ) -> Result<LegacyDelegatedSignature, IdentityError> {

--- a/xmtp_mls/src/identity/xmtp_id/identity.rs
+++ b/xmtp_mls/src/identity/xmtp_id/identity.rs
@@ -73,108 +73,87 @@ impl Identity {
 
     /// Create a new [Identity] instance.
     ///
-    /// If the address is not associated with an inbox_id, a new inbox_id will be generated.
-    /// Use legacy key to sign if it's present, otherwise users will be required to sign with their wallet.
-    ///
-    /// If the address is already associated with an inbox_id, the existing inbox_id will be used.
-    /// Users will be required to sign with their wallet.
-    ///
+    /// If legacy_key is provided
+    ///     1. If `address` is associated with an inbox -> return an LegacyKeyReuse error.
+    ///     2. If `address` is NOT associated with an inbox -> create a new inbox and sign the installation key with the legacy key.
+    /// If legacy_key is NOT provided
+    ///     3. If `address` is associated with an inbox -> sign the installation key with the wallet.
+    ///     4. If `address` is NOT associated with an inbox -> create a new inbox and sign the installation key with the wallet.
     pub(crate) async fn new<ApiClient: XmtpMlsClient + XmtpIdentityClient>(
         address: String,
         legacy_signed_private_key: Option<Vec<u8>>,
         api_client: &ApiClientWrapper<ApiClient>,
     ) -> Result<Self, IdentityError> {
-        // check if address is already associated with an inbox_id
         let inbox_ids = api_client.get_inbox_ids(vec![address.clone()]).await?;
-        let inbox_id = inbox_ids.get(&address);
+        let associated_inbox_id: Option<&InboxId> = inbox_ids.get(&address);
+        let member_identifier: MemberIdentifier = address.clone().into();
         let signature_keys = SignatureKeyPair::new(CIPHERSUITE.signature_algorithm())?;
         let installation_public_key = signature_keys.public();
-        let member_identifier: MemberIdentifier = address.clone().into();
 
-        // if an inbox is not associated, we will create a new one
-        // and sign the installation key using legacy key or wallet.
-        if inbox_id.is_none() {
-            if let Some(legacy_signed_private_key) = legacy_signed_private_key {
-                // TODO: check if address matches legacy_signed_private_key
-                let nonce = 0;
-                let inbox_id = generate_inbox_id(&address, &nonce);
-                let mut builder = SignatureRequestBuilder::new(inbox_id.clone());
-                builder = builder.create_inbox(member_identifier.clone(), nonce);
-                let mut signature_request = builder
-                    .add_association(installation_public_key.to_vec().into(), member_identifier)
-                    .build();
-
-                // We can pre-sign the request with an installation key signature, since we have access to the key
-                signature_request
-                    .add_signature(Box::new(
-                        sign_with_installation_key(
-                            signature_request.signature_text(),
-                            sized_installation_key(signature_keys.private())?,
-                        )
-                        .await?,
-                    ))
-                    .await?;
-                signature_request
-                    .add_signature(Box::new(
-                        sign_with_legacy_key(
-                            signature_request.signature_text(),
-                            legacy_signed_private_key,
-                        )
-                        .await?,
-                    ))
-                    .await?;
-                let identity_update = signature_request.build_identity_update()?;
-                api_client.publish_identity_update(identity_update).await?;
-
-                let identity = Self {
-                    inbox_id: inbox_id.clone(),
-                    installation_keys: signature_keys,
-                    credential: create_credential(inbox_id)?,
-                    signature_request: None,
-                };
-
-                Ok(identity)
-            } else {
-                let nonce = rand::random::<u64>();
-                let inbox_id = generate_inbox_id(&address, &nonce);
-                let mut builder = SignatureRequestBuilder::new(inbox_id.clone());
-                builder = builder.create_inbox(member_identifier.clone(), nonce);
-
-                let mut signature_request = builder
-                    .add_association(installation_public_key.to_vec().into(), member_identifier)
-                    .build();
-
-                // We can pre-sign the request with an installation key signature, since we have access to the key
-                signature_request
-                    .add_signature(Box::new(
-                        sign_with_installation_key(
-                            signature_request.signature_text(),
-                            sized_installation_key(signature_keys.private())?,
-                        )
-                        .await?,
-                    ))
-                    .await?;
-
-                let identity = Self {
-                    inbox_id: inbox_id.clone(),
-                    installation_keys: signature_keys,
-                    credential: create_credential(inbox_id.clone())?,
-                    signature_request: Some(signature_request),
-                };
-
-                Ok(identity)
+        if let Some(legacy_signed_private_key) = legacy_signed_private_key {
+            // 1. has legacy key, has inbox -> LegacyKeyReuse error
+            if associated_inbox_id.is_some() {
+                return Err(IdentityError::LegacyKeyReuse);
             }
-        } else {
-            // If an inbox is associated, we just need to associate the installation key
-            // Only wallet is allowed to sign the installation key, legacy key is not
-            let nonce = rand::random::<u64>();
+
+            // 2. has legacy key, no inbox -> create an inbox and sign the installation key with the legacy key.
+            let nonce = 0;
             let inbox_id = generate_inbox_id(&address, &nonce);
-            let builder = SignatureRequestBuilder::new(inbox_id.clone());
+            let mut builder = SignatureRequestBuilder::new(inbox_id.clone());
+            builder = builder.create_inbox(member_identifier.clone(), nonce);
             let mut signature_request = builder
                 .add_association(installation_public_key.to_vec().into(), member_identifier)
                 .build();
 
-            // We can pre-sign the request with an installation key signature, since we have access to the key
+            signature_request
+                .add_signature(Box::new(
+                    sign_with_installation_key(
+                        signature_request.signature_text(),
+                        sized_installation_key(signature_keys.private())?,
+                    )
+                    .await?,
+                ))
+                .await?;
+            signature_request
+                .add_signature(Box::new(
+                    sign_with_legacy_key(
+                        signature_request.signature_text(),
+                        legacy_signed_private_key,
+                    )
+                    .await?,
+                ))
+                .await?;
+            let identity_update = signature_request.build_identity_update()?;
+            api_client.publish_identity_update(identity_update).await?;
+
+            let identity = Self {
+                inbox_id: inbox_id.clone(),
+                installation_keys: signature_keys,
+                credential: create_credential(inbox_id)?,
+                signature_request: None,
+            };
+
+            Ok(identity)
+        } else {
+            let (builder, inbox_id) = if let Some(associated_inbox_id) = associated_inbox_id {
+                // 3. no legacy key, has inbox -> sign the installation key with the wallet.
+                (
+                    SignatureRequestBuilder::new(associated_inbox_id.clone()),
+                    associated_inbox_id.clone(),
+                )
+            } else {
+                // 4. no legacy key, no inbox -> create a new inbox and sign the installation key with the wallet.
+                let nonce = rand::random::<u64>();
+                let new_inbox_id = generate_inbox_id(&address, &nonce);
+                let builder = SignatureRequestBuilder::new(new_inbox_id.clone())
+                    .create_inbox(member_identifier.clone(), nonce);
+                (builder, new_inbox_id.clone())
+            };
+
+            let mut signature_request = builder
+                .add_association(installation_public_key.to_vec().into(), member_identifier)
+                .build();
+
             signature_request
                 .add_signature(Box::new(
                     sign_with_installation_key(


### PR DESCRIPTION
# Summary

aggregated Identity creation logic to make platform SDK's job easier. i.e. merged `create_from_legacy` and `create_to_be_signed` into one function.

Instead of requiring platform SDK to choose what it wants, we just let them pass in `address` and `Option<legacy_key>` and take care of the rest.