### PR TITLE
Message History: handle Reply better

### DIFF
--- a/xmtp_mls/src/configuration.rs
+++ b/xmtp_mls/src/configuration.rs
@@ -19,6 +19,8 @@ pub const UPDATE_INSTALLATIONS_INTERVAL_NS: i64 = NANOSECONDS_IN_HOUR / 2; // 30
 
 pub const MAX_GROUP_SIZE: u8 = 250;
 
+pub const DELIMITER: char = '\x01';
+
 /// MLS Extension Types
 ///
 /// Copied from draft-ietf-mls-protocol-16:

--- a/xmtp_mls/src/groups/message_history.rs
+++ b/xmtp_mls/src/groups/message_history.rs
@@ -481,7 +481,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(amal_b_messages.len(), 1);
-        
+
         // for message in amal_b_messages {
         //     println!("{:?}", String::from_utf8(message.decrypted_message_bytes));
         // }

--- a/xmtp_mls/src/groups/message_history.rs
+++ b/xmtp_mls/src/groups/message_history.rs
@@ -481,10 +481,6 @@ mod tests {
             .unwrap();
 
         assert_eq!(amal_b_messages.len(), 1);
-
-        // for message in amal_b_messages {
-        //     println!("{:?}", String::from_utf8(message.decrypted_message_bytes));
-        // }
     }
 
     #[tokio::test]

--- a/xmtp_mls/src/groups/sync.rs
+++ b/xmtp_mls/src/groups/sync.rs
@@ -25,11 +25,11 @@ use xmtp_proto::{
         },
         GroupMessage, WelcomeMessageInput,
     },
-    xmtp::mls::message_contents::plaintext_envelope::v2::MessageType::{Request, Reply},
+    xmtp::mls::message_contents::plaintext_envelope::v2::MessageType::{Reply, Request},
     xmtp::mls::message_contents::plaintext_envelope::{Content, V1, V2},
     xmtp::mls::message_contents::GroupMembershipChanges,
-    xmtp::mls::message_contents::{MessageHistoryRequest, MessageHistoryReply},
     xmtp::mls::message_contents::PlaintextEnvelope,
+    xmtp::mls::message_contents::{MessageHistoryReply, MessageHistoryRequest},
 };
 
 use super::{
@@ -46,7 +46,7 @@ use crate::{
     api::IdentityUpdate,
     client::MessageProcessingError,
     codecs::{membership_change::GroupMembershipChangeCodec, ContentCodec},
-    configuration::{MAX_INTENT_PUBLISH_ATTEMPTS, UPDATE_INSTALLATIONS_INTERVAL_NS},
+    configuration::{DELIMITER, MAX_INTENT_PUBLISH_ATTEMPTS, UPDATE_INSTALLATIONS_INTERVAL_NS},
     groups::{intents::UpdateMetadataIntentData, validated_commit::ValidatedCommit},
     hpke::{encrypt_welcome, HpkeError},
     identity::v3::Identity,
@@ -313,56 +313,65 @@ where
                     Some(Content::V2(V2 {
                         idempotency_key,
                         message_type,
-                    })) => {
-                        match message_type {
-                            Some(Request(MessageHistoryRequest {
-                                request_id,
-                                pin_code,
-                            })) => {
-                                let contents = format!("{request_id}:{pin_code}").into_bytes();
-                                let message_id = calculate_message_id(
-                                    &self.group_id,
-                                    &contents,
-                                    &self.client.account_address(),
-                                    &idempotency_key,
-                                );
-                                StoredGroupMessage {
-                                    id: message_id,
-                                    group_id: self.group_id.clone(),
-                                    decrypted_message_bytes: contents,
-                                    sent_at_ns: envelope_timestamp_ns as i64,
-                                    kind: GroupMessageKind::Application,
-                                    sender_installation_id,
-                                    sender_account_address,
-                                    delivery_status: DeliveryStatus::Published,
-                                }
-                                .store(provider.conn())?
+                    })) => match message_type {
+                        Some(Request(MessageHistoryRequest {
+                            request_id,
+                            pin_code,
+                        })) => {
+                            let contents =
+                                format!("{request_id}{DELIMITER}{pin_code}").into_bytes();
+                            let message_id = calculate_message_id(
+                                &self.group_id,
+                                &contents,
+                                &self.client.account_address(),
+                                &idempotency_key,
+                            );
+                            StoredGroupMessage {
+                                id: message_id,
+                                group_id: self.group_id.clone(),
+                                decrypted_message_bytes: contents,
+                                sent_at_ns: envelope_timestamp_ns as i64,
+                                kind: GroupMessageKind::Application,
+                                sender_installation_id,
+                                sender_account_address,
+                                delivery_status: DeliveryStatus::Published,
                             }
-                            Some(Reply(MessageHistoryReply { request_id: _, url, encryption_key, signing_key, bundle_hash })) => {
-                                let contents = format!("{url}:{:?}:{:?}:{:?}", encryption_key, signing_key, bundle_hash).into_bytes();
-                                let message_id = calculate_message_id(
-                                    &self.group_id,
-                                    &contents,
-                                    &self.client.account_address(),
-                                    &idempotency_key,
-                                );
-                                StoredGroupMessage {
-                                    id: message_id,
-                                    group_id: self.group_id.clone(),
-                                    decrypted_message_bytes: contents,
-                                    sent_at_ns: envelope_timestamp_ns as i64,
-                                    kind: GroupMessageKind::Application,
-                                    sender_installation_id,
-                                    sender_account_address,
-                                    delivery_status: DeliveryStatus::Published,
-                                }
-                                .store(provider.conn())?
-                            }
-                            _ => {
-                                return Err(MessageProcessingError::InvalidPayload);
-                            }
+                            .store(provider.conn())?
                         }
-                    }
+                        Some(Reply(MessageHistoryReply {
+                            request_id: _,
+                            url,
+                            encryption_key,
+                            signing_key,
+                            bundle_hash,
+                        })) => {
+                            let contents = format!(
+                                "{url}{DELIMITER}{:?}{DELIMITER}{:?}{DELIMITER}{:?}",
+                                encryption_key, signing_key, bundle_hash
+                            )
+                            .into_bytes();
+                            let message_id = calculate_message_id(
+                                &self.group_id,
+                                &contents,
+                                &self.client.account_address(),
+                                &idempotency_key,
+                            );
+                            StoredGroupMessage {
+                                id: message_id,
+                                group_id: self.group_id.clone(),
+                                decrypted_message_bytes: contents,
+                                sent_at_ns: envelope_timestamp_ns as i64,
+                                kind: GroupMessageKind::Application,
+                                sender_installation_id,
+                                sender_account_address,
+                                delivery_status: DeliveryStatus::Published,
+                            }
+                            .store(provider.conn())?
+                        }
+                        _ => {
+                            return Err(MessageProcessingError::InvalidPayload);
+                        }
+                    },
                     None => return Err(MessageProcessingError::InvalidPayload),
                 }
             }


### PR DESCRIPTION
## Summary

- adds a `configuration/` `DELIMITER` (rather than the brittle `:` I hacked in yesterday.
- sets the `send_message_history_request()` to return the PIN, as the sending party/device will absolutely need that.
- handles a roundtrip of:
  - sending out a `Request(MessageHistoryRequest { .. })`
  -  replying with a `Reply(MessageHistoryReply { .. })` 
 - stores both on the respective client's store