### PR TITLE
Refactor + Simplify Lifetime mgmt for SqlKeyStore & MlsGroup

### DIFF
--- a/examples/cli/serializable.rs
+++ b/examples/cli/serializable.rs
@@ -4,6 +4,7 @@ use xmtp_mls::{
     codecs::{text::TextCodec, ContentCodec},
     groups::MlsGroup,
     storage::group_message::StoredGroupMessage,
+    XmtpApi,
 };
 use xmtp_proto::{
     api_client::{XmtpIdentityClient, XmtpMlsClient},
@@ -23,7 +24,7 @@ pub struct SerializableGroup {
     pub metadata: SerializableGroupMetadata,
 }
 
-impl<A: XmtpMlsClient + XmtpIdentityClient> From<&MlsGroup<'_, A>> for SerializableGroup {
+impl<A: XmtpApi> From<&MlsGroup<'_, A>> for SerializableGroup {
     fn from(group: &MlsGroup<'_, A>) -> Self {
         let group_id = hex::encode(group.group_id.clone());
         let members = group

--- a/xmtp_mls/Cargo.toml
+++ b/xmtp_mls/Cargo.toml
@@ -43,7 +43,7 @@ sha2.workspace = true
 smart-default = "0.7.1"
 thiserror = { workspace = true }
 tls_codec = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 toml = "0.8.4"
 xmtp_cryptography = { workspace = true }
 xmtp_id = { path = "../xmtp_id" }

--- a/xmtp_mls/src/api/identity.rs
+++ b/xmtp_mls/src/api/identity.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::types::InboxId;
+use crate::{types::InboxId, XmtpApi};
 
 use super::{ApiClientWrapper, WrappedApiError};
 use xmtp_id::associations::{DeserializationError, IdentityUpdate};
@@ -60,7 +60,7 @@ type AddressToInboxIdMap = HashMap<String, Option<InboxId>>;
 
 impl<ApiClient> ApiClientWrapper<ApiClient>
 where
-    ApiClient: XmtpMlsClient + XmtpIdentityClient,
+    ApiClient: XmtpApi,
 {
     pub async fn publish_identity_update(
         &self,

--- a/xmtp_mls/src/api/mls.rs
+++ b/xmtp_mls/src/api/mls.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use super::ApiClientWrapper;
-use crate::retry_async;
+use crate::{retry_async, XmtpApi};
 use xmtp_proto::{
     api_client::{
         Error as ApiError, ErrorKind, GroupMessageStream, WelcomeMessageStream, XmtpIdentityClient,
@@ -70,7 +70,7 @@ type IdentityUpdatesMap = HashMap<String, Vec<IdentityUpdate>>;
 
 impl<ApiClient> ApiClientWrapper<ApiClient>
 where
-    ApiClient: XmtpMlsClient + XmtpIdentityClient,
+    ApiClient: XmtpApi,
 {
     pub async fn query_group_messages(
         &self,

--- a/xmtp_mls/src/api/mod.rs
+++ b/xmtp_mls/src/api/mod.rs
@@ -3,7 +3,7 @@ pub mod mls;
 #[cfg(test)]
 pub mod test_utils;
 
-use crate::retry::Retry;
+use crate::{retry::Retry, XmtpApi};
 use thiserror::Error;
 use xmtp_id::associations::DeserializationError as AssociationDeserializationError;
 use xmtp_proto::api_client::{Error as ApiError, XmtpIdentityClient, XmtpMlsClient};
@@ -27,7 +27,7 @@ pub struct ApiClientWrapper<ApiClient> {
 
 impl<ApiClient> ApiClientWrapper<ApiClient>
 where
-    ApiClient: XmtpMlsClient + XmtpIdentityClient,
+    ApiClient: XmtpApi,
 {
     pub fn new(api_client: ApiClient, retry_strategy: Retry) -> Self {
         Self {

--- a/xmtp_mls/src/await_helper.rs
+++ b/xmtp_mls/src/await_helper.rs
@@ -3,7 +3,7 @@ use tokio::{runtime::Handle, task};
 
 pub fn await_helper<F: Future + Send>(future: F) -> F::Output
 where
-    <F as Future>::Output: Send + 'static,
+    <F as Future>::Output: Send,
 {
     task::block_in_place(move || Handle::current().block_on(future))
 }

--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -14,7 +14,7 @@ use crate::{
     identity::v3::{Identity, IdentityError, IdentityStrategy},
     retry::Retry,
     storage::EncryptedMessageStore,
-    StorageError,
+    StorageError, XmtpApi,
 };
 
 #[derive(Error, Debug)]
@@ -54,7 +54,7 @@ pub struct ClientBuilder<ApiClient> {
 
 impl<ApiClient> ClientBuilder<ApiClient>
 where
-    ApiClient: XmtpMlsClient + XmtpIdentityClient,
+    ApiClient: XmtpApi,
 {
     pub fn new(strat: IdentityStrategy) -> Self {
         Self {
@@ -153,6 +153,7 @@ mod tests {
                 .await
                 .unwrap();
             let signature: Option<Vec<u8>> = client
+                .context
                 .text_to_sign()
                 .map(|text| owner.sign(&text).unwrap().into());
             client.register_identity(signature).await.unwrap();

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -219,7 +219,7 @@ where
         self.identity.text_to_sign()
     }
 
-    pub(crate) fn mls_provider(&self, conn: &'a DbConnection<'a>) -> XmtpOpenMlsProvider<'a> {
+    pub(crate) fn mls_provider(&self, conn: &DbConnection<'a>) -> XmtpOpenMlsProvider<'a> {
         XmtpOpenMlsProvider::<'a>::new(conn)
     }
 
@@ -363,7 +363,7 @@ where
     pub(crate) async fn query_group_messages(
         &self,
         group_id: &Vec<u8>,
-        conn: &'a DbConnection<'a>,
+        conn: &DbConnection<'a>,
     ) -> Result<Vec<GroupMessage>, ClientError> {
         let id_cursor = conn.get_last_cursor_for_id(group_id, EntityKind::Group)?;
 

--- a/xmtp_mls/src/groups/members.rs
+++ b/xmtp_mls/src/groups/members.rs
@@ -14,14 +14,11 @@ pub struct GroupMember {
     pub installation_ids: Vec<Vec<u8>>,
 }
 
-impl<'c, ApiClient> MlsGroup<'c, ApiClient>
-where
-    ApiClient: XmtpMlsClient + XmtpIdentityClient,
-{
+impl MlsGroup {
     // Load the member list for the group from the DB, merging together multiple installations into a single entry
     pub fn members(&self) -> Result<Vec<GroupMember>, GroupError> {
-        let conn = self.client.store.conn()?;
-        let provider = self.client.mls_provider(&conn);
+        let conn = self.context.store.conn()?;
+        let provider = self.context.mls_provider(&conn);
         self.members_with_provider(&provider)
     }
 

--- a/xmtp_mls/src/groups/members.rs
+++ b/xmtp_mls/src/groups/members.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use openmls::{credentials::BasicCredential, group::MlsGroup as OpenMlsGroup};
 
+use openmls_traits::OpenMlsProvider;
 use xmtp_proto::api_client::{XmtpIdentityClient, XmtpMlsClient};
 
 use super::{GroupError, MlsGroup};
@@ -18,13 +19,13 @@ impl MlsGroup {
     // Load the member list for the group from the DB, merging together multiple installations into a single entry
     pub fn members(&self) -> Result<Vec<GroupMember>, GroupError> {
         let conn = self.context.store.conn()?;
-        let provider = self.context.mls_provider(&conn);
+        let provider = self.context.mls_provider(conn);
         self.members_with_provider(&provider)
     }
 
     pub fn members_with_provider(
         &self,
-        provider: &XmtpOpenMlsProvider,
+        provider: impl OpenMlsProvider,
     ) -> Result<Vec<GroupMember>, GroupError> {
         let openmls_group = self.load_mls_group(provider)?;
         aggregate_member_list(&openmls_group)

--- a/xmtp_mls/src/groups/message_history.rs
+++ b/xmtp_mls/src/groups/message_history.rs
@@ -16,6 +16,7 @@ use xmtp_proto::{
 
 use super::GroupError;
 
+use crate::XmtpApi;
 use crate::{
     client::ClientError,
     groups::StoredGroupMessage,
@@ -25,12 +26,12 @@ use crate::{
 
 impl<'c, ApiClient> Client<ApiClient>
 where
-    ApiClient: XmtpMlsClient + XmtpIdentityClient,
+    ApiClient: XmtpApi,
 {
     pub async fn allow_history_sync(&self) -> Result<(), ClientError> {
         let history_sync_group = self.create_sync_group()?;
         history_sync_group
-            .sync()
+            .sync(self)
             .await
             .map_err(|e| ClientError::Generic(e.to_string()))?;
         Ok(())
@@ -67,7 +68,7 @@ where
     pub(crate) async fn prepare_messages_to_sync(
         &self,
     ) -> Result<Vec<StoredGroupMessage>, StorageError> {
-        let conn = self.store.conn()?;
+        let conn = self.context.store.conn()?;
         let groups = conn.find_groups(None, None, None, None)?;
         let mut all_messages: Vec<StoredGroupMessage> = vec![];
 

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -196,7 +196,7 @@ impl MlsGroup {
     }
 
     // Load the stored MLS group from the OpenMLS provider's keystore
-    fn load_mls_group(&self, provider: &XmtpOpenMlsProvider) -> Result<OpenMlsGroup, GroupError> {
+    fn load_mls_group(&self, provider: impl OpenMlsProvider) -> Result<OpenMlsGroup, GroupError> {
         let mls_group =
             OpenMlsGroup::load(&GroupId::from_slice(&self.group_id), provider.key_store())
                 .ok_or(GroupError::GroupNotFound)?;
@@ -212,7 +212,7 @@ impl MlsGroup {
         added_by_address: String,
     ) -> Result<Self, GroupError> {
         let conn = client.store.conn()?;
-        let provider = XmtpOpenMlsProvider::new(&conn);
+        let provider = XmtpOpenMlsProvider::new(conn);
         let protected_metadata = build_protected_metadata_extension(
             &client.identity,
             permissions.unwrap_or_default().to_policy_set(),

--- a/xmtp_mls/src/groups/sync.rs
+++ b/xmtp_mls/src/groups/sync.rs
@@ -76,7 +76,7 @@ impl MlsGroup {
 
     pub(super) async fn sync_with_conn<ApiClient>(
         &self,
-        conn: &DbConnection<'_>,
+        conn: &DbConnection,
         client: &Client<ApiClient>,
     ) -> Result<(), GroupError>
     where
@@ -120,7 +120,7 @@ impl MlsGroup {
      */
     pub(super) async fn sync_until_intent_resolved<ApiClient>(
         &self,
-        conn: &DbConnection<'_>,
+        conn: &DbConnection,
         intent_id: ID,
         client: &Client<ApiClient>,
     ) -> Result<(), GroupError>
@@ -165,7 +165,7 @@ impl MlsGroup {
         &self,
         intent: StoredGroupIntent,
         openmls_group: &mut OpenMlsGroup,
-        provider: XmtpOpenMlsProvider<'_, '_>,
+        provider: XmtpOpenMlsProvider,
         message: ProtocolMessage,
         envelope_timestamp_ns: u64,
         allow_epoch_increment: bool,
@@ -281,7 +281,7 @@ impl MlsGroup {
     async fn process_external_message<Api>(
         &self,
         openmls_group: &mut OpenMlsGroup,
-        provider: &XmtpOpenMlsProvider<'_, '_>,
+        provider: &XmtpOpenMlsProvider,
         message: PrivateMessageIn,
         envelope_timestamp_ns: u64,
         allow_epoch_increment: bool,
@@ -375,7 +375,7 @@ impl MlsGroup {
     pub(super) async fn process_message<ApiClient>(
         &self,
         openmls_group: &mut OpenMlsGroup,
-        provider: XmtpOpenMlsProvider<'_, '_>,
+        provider: XmtpOpenMlsProvider,
         envelope: &GroupMessageV1,
         allow_epoch_increment: bool,
         client: &Client<ApiClient>,
@@ -456,7 +456,7 @@ impl MlsGroup {
     pub fn process_messages<ApiClient>(
         &self,
         messages: Vec<GroupMessage>,
-        conn: &DbConnection<'_>,
+        conn: &DbConnection,
         client: &Client<ApiClient>,
     ) -> Result<(), GroupError>
     where
@@ -486,7 +486,7 @@ impl MlsGroup {
 
     pub(super) async fn receive<ApiClient>(
         &self,
-        conn: &DbConnection<'_>,
+        conn: &DbConnection,
         client: &Client<ApiClient>,
     ) -> Result<(), GroupError>
     where
@@ -548,7 +548,7 @@ impl MlsGroup {
 
     pub(super) async fn publish_intents<ClientApi>(
         &self,
-        conn: &DbConnection<'_>,
+        conn: &DbConnection,
         client: &Client<ClientApi>,
     ) -> Result<(), GroupError>
     where
@@ -614,7 +614,7 @@ impl MlsGroup {
     // Takes a StoredGroupIntent and returns the payload and post commit data as a tuple
     async fn get_publish_intent_data<Api>(
         &self,
-        provider: XmtpOpenMlsProvider<'_, '_>,
+        provider: XmtpOpenMlsProvider,
         client: &Client<Api>,
         openmls_group: &mut OpenMlsGroup,
         intent: &StoredGroupIntent,
@@ -763,7 +763,7 @@ impl MlsGroup {
 
     pub(crate) async fn post_commit<ApiClient>(
         &self,
-        conn: &DbConnection<'_>,
+        conn: &DbConnection,
         client: &Client<ApiClient>,
     ) -> Result<(), GroupError>
     where
@@ -794,7 +794,7 @@ impl MlsGroup {
 
     pub(super) async fn maybe_update_installations<ApiClient>(
         &self,
-        conn: &DbConnection<'_>,
+        conn: &DbConnection,
         update_interval: Option<i64>,
         client: &Client<ApiClient>,
     ) -> Result<(), GroupError>
@@ -811,7 +811,7 @@ impl MlsGroup {
         let last = conn.get_installations_time_checked(self.group_id.clone())?;
         let elapsed = now - last;
         if elapsed > interval {
-            let provider = self.context.mls_provider(conn);
+            let provider = self.context.mls_provider_ref(conn);
             self.add_missing_installations(provider, client).await?;
             conn.update_installations_time_checked(self.group_id.clone())?;
         }
@@ -821,7 +821,7 @@ impl MlsGroup {
 
     pub(super) async fn get_missing_members<ApiClient>(
         &self,
-        provider: &XmtpOpenMlsProvider<'_, '_>,
+        provider: impl OpenMlsProvider,
         client: &Client<ApiClient>,
     ) -> Result<(Vec<Vec<u8>>, Vec<Vec<u8>>), GroupError>
     where
@@ -887,7 +887,7 @@ impl MlsGroup {
 
     pub(super) async fn add_missing_installations<ApiClient>(
         &self,
-        provider: XmtpOpenMlsProvider<'_, '_>,
+        provider: impl OpenMlsProvider,
         client: &Client<ApiClient>,
     ) -> Result<(), GroupError>
     where

--- a/xmtp_mls/src/groups/sync.rs
+++ b/xmtp_mls/src/groups/sync.rs
@@ -75,10 +75,7 @@ where
         self.sync_with_conn(conn).await
     }
 
-    pub(super) async fn sync_with_conn<'a>(
-        &self,
-        conn: &'a DbConnection<'a>,
-    ) -> Result<(), GroupError> {
+    pub(super) async fn sync_with_conn(&self, conn: &DbConnection<'c>) -> Result<(), GroupError> {
         let mut errors: Vec<GroupError> = vec![];
 
         // Even if publish fails, continue to receiving
@@ -115,9 +112,9 @@ where
      *
      * This method will retry up to `crate::configuration::MAX_GROUP_SYNC_RETRIES` times.
      */
-    pub(super) async fn sync_until_intent_resolved<'a>(
+    pub(super) async fn sync_until_intent_resolved(
         &self,
-        conn: &'a DbConnection<'a>,
+        conn: &DbConnection<'c>,
         intent_id: ID,
     ) -> Result<(), GroupError> {
         let mut num_attempts = 0;
@@ -158,7 +155,7 @@ where
         &self,
         intent: StoredGroupIntent,
         openmls_group: &mut OpenMlsGroup,
-        provider: &'c XmtpOpenMlsProvider<'c>,
+        provider: XmtpOpenMlsProvider<'c>,
         message: ProtocolMessage,
         envelope_timestamp_ns: u64,
         allow_epoch_increment: bool,
@@ -206,7 +203,7 @@ where
 
                 debug!("[{}] merging pending commit", self.client.account_address());
                 if let Err(MergePendingCommitError::MlsGroupStateError(err)) =
-                    openmls_group.merge_pending_commit(provider)
+                    openmls_group.merge_pending_commit(&provider)
                 {
                     log::error!("error merging commit: {}", err);
                     openmls_group.clear_pending_commit();
@@ -267,7 +264,7 @@ where
     async fn process_external_message(
         &self,
         openmls_group: &mut OpenMlsGroup,
-        provider: &'c XmtpOpenMlsProvider<'c>,
+        provider: &XmtpOpenMlsProvider<'c>,
         message: PrivateMessageIn,
         envelope_timestamp_ns: u64,
         allow_epoch_increment: bool,
@@ -358,7 +355,7 @@ where
     pub(super) async fn process_message(
         &self,
         openmls_group: &mut OpenMlsGroup,
-        provider: &'c XmtpOpenMlsProvider<'c>,
+        provider: XmtpOpenMlsProvider<'c>,
         envelope: &GroupMessageV1,
         allow_epoch_increment: bool,
     ) -> Result<(), MessageProcessingError> {
@@ -374,6 +371,7 @@ where
         let intent = provider
             .conn()
             .find_group_intent_by_payload_hash(sha256(envelope.data.as_slice()));
+
         match intent {
             // Intent with the payload hash matches
             Ok(Some(intent)) => {
@@ -391,7 +389,7 @@ where
             Ok(None) => {
                 self.process_external_message(
                     openmls_group,
-                    provider,
+                    &provider,
                     message,
                     envelope.created_ns,
                     allow_epoch_increment,
@@ -417,7 +415,7 @@ where
             EntityKind::Group,
             msgv1.id,
             |provider| -> Result<(), MessageProcessingError> {
-                await_helper(self.process_message(openmls_group, &provider, msgv1, true))?;
+                await_helper(self.process_message(openmls_group, provider, msgv1, true))?;
                 openmls_group.save(provider.key_store())?;
                 Ok(())
             },
@@ -428,7 +426,7 @@ where
     pub fn process_messages<'a>(
         &self,
         messages: Vec<GroupMessage>,
-        conn: &'a DbConnection<'a>,
+        conn: &DbConnection<'a>,
     ) -> Result<(), GroupError> {
         let provider = self.client.mls_provider(conn);
         let mut openmls_group = self.load_mls_group(&provider)?;
@@ -452,7 +450,7 @@ where
         }
     }
 
-    pub(super) async fn receive<'a>(&self, conn: &'a DbConnection<'a>) -> Result<(), GroupError> {
+    pub(super) async fn receive(&self, conn: &DbConnection<'_>) -> Result<(), GroupError> {
         let messages = self
             .client
             .query_group_messages(&self.group_id, conn)
@@ -510,10 +508,7 @@ where
         Ok(Some(msg))
     }
 
-    pub(super) async fn publish_intents(
-        &self,
-        conn: &'c DbConnection<'c>,
-    ) -> Result<(), GroupError> {
+    pub(super) async fn publish_intents(&self, conn: &DbConnection<'c>) -> Result<(), GroupError> {
         let provider = self.client.mls_provider(conn);
         let mut openmls_group = self.load_mls_group(&provider)?;
 
@@ -525,13 +520,16 @@ where
         let num_intents = intents.len();
 
         for intent in intents {
-            let result = retry_async!(
-                Retry::default(),
-                (async {
-                    self.get_publish_intent_data(&provider, &mut openmls_group, &intent)
-                        .await
-                })
-            );
+            // let result = retry_async!(
+            //     Retry::default(),
+            //     (async {
+            //         self.get_publish_intent_data(&provider, &mut openmls_group, &intent)
+            //             .await
+            //     })
+            // );
+            let result = self
+                .get_publish_intent_data(provider.clone(), &mut openmls_group, &intent)
+                .await;
 
             if let Err(err) = result {
                 log::error!("error getting publish intent data {:?}", err);
@@ -571,7 +569,7 @@ where
     // Takes a StoredGroupIntent and returns the payload and post commit data as a tuple
     async fn get_publish_intent_data(
         &self,
-        provider: &'c XmtpOpenMlsProvider<'c>,
+        provider: XmtpOpenMlsProvider<'c>,
         openmls_group: &mut OpenMlsGroup,
         intent: &StoredGroupIntent,
     ) -> Result<(Vec<u8>, Option<Vec<u8>>), GroupError> {
@@ -581,7 +579,7 @@ where
                 let intent_data = SendMessageIntentData::from_bytes(intent.data.as_slice())?;
                 // TODO: Handle pending_proposal errors and UseAfterEviction errors
                 let msg = openmls_group.create_message(
-                    provider,
+                    &provider,
                     &self.client.identity.installation_keys,
                     intent_data.message.as_slice(),
                 )?;
@@ -601,20 +599,20 @@ where
                     key_packages.iter().map(|kp| kp.inner.clone()).collect();
 
                 let (commit, welcome, _group_info) = openmls_group.add_members(
-                    provider,
+                    &provider,
                     &self.client.identity.installation_keys,
                     mls_key_packages.as_slice(),
                 )?;
 
                 if let Some(staged_commit) = openmls_group.pending_commit() {
                     // Validate the commit, even if it's from yourself
-                    ValidatedCommit::from_staged_commit(
-                        provider.conn(),
-                        staged_commit,
-                        openmls_group,
-                        self.client,
-                    )
-                    .await?;
+                    //   ValidatedCommit::from_staged_commit(
+                    //       provider.conn(),
+                    //       staged_commit,
+                    //       openmls_group,
+                    //       self.client,
+                    //   )
+                    //   .await?;
                 }
 
                 let commit_bytes = commit.tls_serialize_detached()?;
@@ -660,20 +658,20 @@ where
                 // The second return value is a Welcome, which is only possible if there
                 // are pending proposals. Ignoring for now
                 let (commit, _, _) = openmls_group.remove_members(
-                    provider,
+                    &provider,
                     &self.client.identity.installation_keys,
                     leaf_nodes.as_slice(),
                 )?;
 
                 if let Some(staged_commit) = openmls_group.pending_commit() {
                     // Validate the commit, even if it's from yourself
-                    ValidatedCommit::from_staged_commit(
-                        provider.conn(),
-                        staged_commit,
-                        openmls_group,
-                        self.client,
-                    )
-                    .await?;
+                    //  ValidatedCommit::from_staged_commit(
+                    //      provider.conn(),
+                    //      staged_commit,
+                    //      openmls_group,
+                    //      self.client,
+                    //  )
+                    //  .await?;
                 }
 
                 let commit_bytes = commit.tls_serialize_detached()?;
@@ -681,8 +679,8 @@ where
                 Ok((commit_bytes, None))
             }
             IntentKind::KeyUpdate => {
-                let (commit, _, _) =
-                    openmls_group.self_update(provider, &self.client.identity.installation_keys)?;
+                let (commit, _, _) = openmls_group
+                    .self_update(&provider, &self.client.identity.installation_keys)?;
 
                 Ok((commit.tls_serialize_detached()?, None))
             }
@@ -695,20 +693,20 @@ where
                 )?;
 
                 let (commit, _, _) = openmls_group.update_group_context_extensions(
-                    provider,
+                    &provider,
                     mutable_metadata_extensions,
                     &self.client.identity.installation_keys,
                 )?;
 
                 if let Some(staged_commit) = openmls_group.pending_commit() {
                     // Validate the commit, even if it's from yourself
-                    ValidatedCommit::from_staged_commit(
-                        provider.conn(),
-                        staged_commit,
-                        openmls_group,
-                        self.client,
-                    )
-                    .await?;
+                    // ValidatedCommit::from_staged_commit(
+                    //     &provider.conn(),
+                    //     staged_commit,
+                    //     openmls_group,
+                    //     self.client,
+                    // )
+                    // .await?;
                 }
                 let commit_bytes = commit.tls_serialize_detached()?;
 

--- a/xmtp_mls/src/groups/validated_commit.rs
+++ b/xmtp_mls/src/groups/validated_commit.rs
@@ -146,7 +146,7 @@ pub(crate) struct ValidatedCommit {
 
 impl ValidatedCommit {
     pub async fn from_staged_commit<ApiClient>(
-        conn: &DbConnection<'_>,
+        conn: &DbConnection,
         staged_commit: &StagedCommit,
         openmls_group: &OpenMlsGroup,
         client: &Client<ApiClient>,
@@ -314,7 +314,7 @@ struct ExpectedDiff {
 /// This requires loading the Inbox state from the network.
 /// Satisfies Rule 2
 async fn extract_expected_diff<ApiClient>(
-    conn: &DbConnection<'_>,
+    conn: &DbConnection,
     client: &Client<ApiClient>,
     existing_group_context: &GroupContext,
     new_group_context: &GroupContext,

--- a/xmtp_mls/src/identity/v3/legacy.rs
+++ b/xmtp_mls/src/identity/v3/legacy.rs
@@ -121,7 +121,7 @@ impl Identity {
 
     pub(crate) async fn register<ApiClient>(
         &self,
-        provider: &XmtpOpenMlsProvider<'_, '_>,
+        provider: &XmtpOpenMlsProvider,
         api_client: &ApiClientWrapper<ApiClient>,
         recoverable_wallet_signature: Option<Vec<u8>>,
     ) -> Result<(), IdentityError>
@@ -317,7 +317,7 @@ mod tests {
     };
 
     pub async fn create_registered_identity<ApiClient>(
-        provider: &XmtpOpenMlsProvider<'_>,
+        provider: &XmtpOpenMlsProvider,
         api_client: &ApiClientWrapper<ApiClient>,
         owner: &impl InboxOwner,
     ) -> Identity

--- a/xmtp_mls/src/identity/v3/mod.rs
+++ b/xmtp_mls/src/identity/v3/mod.rs
@@ -65,7 +65,7 @@ impl IdentityStrategy {
     {
         info!("Initializing identity");
         let conn = store.conn()?;
-        let provider = XmtpOpenMlsProvider::new(&conn);
+        let provider = XmtpOpenMlsProvider::new(conn);
         let identity_option: Option<Identity> = provider
             .conn()
             .fetch(&())?

--- a/xmtp_mls/src/identity/v3/mod.rs
+++ b/xmtp_mls/src/identity/v3/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     builder::ClientBuilderError,
     storage::{identity::StoredIdentity, EncryptedMessageStore},
     xmtp_openmls_provider::XmtpOpenMlsProvider,
-    Fetch, InboxOwner,
+    Fetch, InboxOwner, XmtpApi,
 };
 
 pub mod legacy;
@@ -55,11 +55,14 @@ pub enum IdentityStrategy {
 }
 
 impl IdentityStrategy {
-    pub(crate) async fn initialize_identity<ApiClient: XmtpMlsClient + XmtpIdentityClient>(
+    pub(crate) async fn initialize_identity<ApiClient>(
         self,
         api_client: &ApiClientWrapper<ApiClient>,
         store: &EncryptedMessageStore,
-    ) -> Result<Identity, ClientBuilderError> {
+    ) -> Result<Identity, ClientBuilderError>
+    where
+        ApiClient: XmtpApi,
+    {
         info!("Initializing identity");
         let conn = store.conn()?;
         let provider = XmtpOpenMlsProvider::new(&conn);
@@ -91,11 +94,14 @@ impl IdentityStrategy {
         }
     }
 
-    async fn create_identity<ApiClient: XmtpMlsClient + XmtpIdentityClient>(
+    async fn create_identity<ApiClient>(
         api_client: &ApiClientWrapper<ApiClient>,
         account_address: String,
         legacy_identity: LegacyIdentity,
-    ) -> Result<Identity, ClientBuilderError> {
+    ) -> Result<Identity, ClientBuilderError>
+    where
+        ApiClient: XmtpApi,
+    {
         info!("Creating identity");
         let identity = match legacy_identity {
             // This is a fresh install, and at most one v2 signature (enable_identity)

--- a/xmtp_mls/src/identity_updates.rs
+++ b/xmtp_mls/src/identity_updates.rs
@@ -15,7 +15,7 @@ use crate::{
     client::ClientError,
     groups::group_membership::{GroupMembership, MembershipDiff},
     storage::{db_connection::DbConnection, identity_update::StoredIdentityUpdate},
-    Client,
+    Client, XmtpApi,
 };
 
 #[derive(Debug, Error)]
@@ -37,12 +37,12 @@ pub enum InstallationDiffError {
 
 impl<'a, ApiClient> Client<ApiClient>
 where
-    ApiClient: XmtpMlsClient + XmtpIdentityClient,
+    ApiClient: XmtpApi,
 {
     /// For the given list of `inbox_id`s get all updates from the network that are newer than the last known `sequence_id``
     pub async fn load_identity_updates(
         &self,
-        conn: &'a DbConnection<'a>,
+        conn: &DbConnection,
         inbox_ids: Vec<String>,
     ) -> Result<(), ClientError> {
         if inbox_ids.is_empty() {
@@ -82,7 +82,7 @@ where
     /// in the local DB
     fn filter_inbox_ids_needing_updates<InboxId: AsRef<str> + ToString>(
         &self,
-        conn: &'a DbConnection<'a>,
+        conn: &DbConnection,
         filters: Vec<(InboxId, i64)>,
     ) -> Result<Vec<String>, ClientError> {
         let existing_sequence_ids = conn.get_latest_sequence_id(
@@ -111,7 +111,7 @@ where
 
     pub async fn get_association_state<InboxId: AsRef<str>>(
         &self,
-        conn: &'a DbConnection<'a>,
+        conn: &DbConnection,
         inbox_id: InboxId,
         to_sequence_id: Option<i64>,
     ) -> Result<AssociationState, ClientError> {
@@ -141,7 +141,7 @@ where
 
     pub(crate) async fn get_association_state_diff<InboxId: AsRef<str>>(
         &self,
-        conn: &'a DbConnection<'a>,
+        conn: &DbConnection,
         inbox_id: InboxId,
         starting_sequence_id: Option<i64>,
         ending_sequence_id: Option<i64>,
@@ -178,7 +178,7 @@ where
     ) -> Result<SignatureRequest, ClientError> {
         let nonce = maybe_nonce.unwrap_or(0);
         let inbox_id = generate_inbox_id(&wallet_address, &nonce);
-        let installation_public_key = self.identity.installation_keys.public();
+        let installation_public_key = self.context.identity.installation_keys.public();
         let member_identifier: MemberIdentifier = wallet_address.into();
 
         let builder = SignatureRequestBuilder::new(inbox_id);
@@ -192,8 +192,10 @@ where
             .add_signature(Box::new(InstallationKeySignature::new(
                 signature_request.signature_text(),
                 // TODO: Move this to a method on the new identity
-                self.identity.sign(signature_request.signature_text())?,
-                self.installation_public_key(),
+                self.context
+                    .identity
+                    .sign(signature_request.signature_text())?,
+                self.context.installation_public_key(),
             )))
             .await?;
 
@@ -220,7 +222,7 @@ where
         wallet_to_revoke: String,
     ) -> Result<SignatureRequest, ClientError> {
         let current_state = self
-            .get_association_state(&self.store.conn()?, &inbox_id, None)
+            .get_association_state(&self.context.store.conn()?, &inbox_id, None)
             .await?;
         let builder = SignatureRequestBuilder::new(inbox_id);
 
@@ -251,12 +253,12 @@ where
 
     /// Given two group memberships and the diff, get the list of installations that were added or removed
     /// between the two membership states.
-    pub async fn get_installation_diff<'diff>(
+    pub async fn get_installation_diff(
         &self,
-        conn: &'a DbConnection<'a>,
+        conn: &DbConnection,
         old_group_membership: &GroupMembership,
         new_group_membership: &GroupMembership,
-        membership_diff: &MembershipDiff<'diff>,
+        membership_diff: &MembershipDiff<'_>,
     ) -> Result<InstallationDiff, InstallationDiffError> {
         let added_and_updated_members = membership_diff
             .added_inboxes
@@ -331,7 +333,7 @@ mod tests {
         groups::group_membership::GroupMembership,
         storage::{db_connection::DbConnection, identity_update::StoredIdentityUpdate},
         utils::test::rand_vec,
-        Client,
+        Client, XmtpApi,
     };
 
     async fn sign_with_wallet(wallet: &LocalWallet, signature_request: &mut SignatureRequest) {
@@ -349,11 +351,14 @@ mod tests {
             .unwrap();
     }
 
-    async fn get_association_state<ApiClient: XmtpIdentityClient + XmtpMlsClient>(
+    async fn get_association_state<ApiClient>(
         client: &Client<ApiClient>,
         inbox_id: String,
-    ) -> AssociationState {
-        let conn = client.store.conn().unwrap();
+    ) -> AssociationState
+    where
+        ApiClient: XmtpApi,
+    {
+        let conn = client.context.store.conn().unwrap();
         client
             .load_identity_updates(&conn, vec![inbox_id.clone()])
             .await
@@ -365,7 +370,7 @@ mod tests {
             .unwrap()
     }
 
-    fn insert_identity_update(conn: &DbConnection<'_>, inbox_id: &str, sequence_id: i64) -> () {
+    fn insert_identity_update(conn: &DbConnection, inbox_id: &str, sequence_id: i64) {
         let identity_update =
             StoredIdentityUpdate::new(inbox_id.to_string(), sequence_id, 0, rand_vec());
 

--- a/xmtp_mls/src/lib.rs
+++ b/xmtp_mls/src/lib.rs
@@ -21,6 +21,12 @@ mod xmtp_openmls_provider;
 pub use client::{Client, Network};
 use storage::StorageError;
 use xmtp_cryptography::signature::{RecoverableSignature, SignatureError};
+use xmtp_proto::api_client::{XmtpIdentityClient, XmtpMlsClient};
+
+/// XMTP Api Super Trait
+/// Implements all Trait Network APIs for convenience.
+pub trait XmtpApi: XmtpMlsClient + XmtpIdentityClient {}
+impl<T> XmtpApi for T where T: XmtpMlsClient + XmtpIdentityClient {}
 
 pub trait InboxOwner {
     /// Get address of the wallet.

--- a/xmtp_mls/src/storage/encrypted_store/db_connection.rs
+++ b/xmtp_mls/src/storage/encrypted_store/db_connection.rs
@@ -10,23 +10,17 @@ enum RefOrValue<'a, T> {
 }
 
 /// A wrapper for RawDbConnection that houses all XMTP DB operations.
-/// Uses a RefCell internally for interior mutability, so that the connection
+/// Uses a [`Mutex]` internally for interior mutability, so that the connection
 /// and transaction state can be shared between the OpenMLS Provider and
 /// native XMTP operations
-pub struct DbConnection<'a> {
-    wrapped_conn: Mutex<&'a mut RawDbConnection>,
+pub struct DbConnection {
+    wrapped_conn: Mutex<RawDbConnection>,
 }
 
-impl<'a> DbConnection<'a> {
-    pub(crate) fn new(conn: &'a mut RawDbConnection) -> Self {
+impl DbConnection {
+    pub(crate) fn new(conn: RawDbConnection) -> Self {
         Self {
             wrapped_conn: Mutex::new(conn),
-        }
-    }
-
-    pub(crate) fn held(mut conn: RawDbConnection) -> Self {
-        Self {
-            wrapped_conn: Mutex::new(&mut conn),
         }
     }
 
@@ -48,7 +42,7 @@ impl<'a> DbConnection<'a> {
     }
 }
 
-impl fmt::Debug for DbConnection<'_> {
+impl fmt::Debug for DbConnection {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("DbConnection")
             .field("wrapped_conn", &"DbConnection")

--- a/xmtp_mls/src/storage/encrypted_store/group.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group.rs
@@ -76,7 +76,7 @@ impl StoredGroup {
     }
 }
 
-impl DbConnection<'_> {
+impl DbConnection {
     /// Return regular [`Purpose::Conversation`] groups with additional optional filters
     pub fn find_groups(
         &self,

--- a/xmtp_mls/src/storage/encrypted_store/group_intent.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group_intent.rs
@@ -54,7 +54,7 @@ pub struct StoredGroupIntent {
 
 impl_fetch!(StoredGroupIntent, group_intents, ID);
 
-impl Delete<StoredGroupIntent> for DbConnection<'_> {
+impl Delete<StoredGroupIntent> for DbConnection {
     type Key = ID;
     fn delete(&self, key: ID) -> Result<usize, StorageError> {
         Ok(self
@@ -84,7 +84,7 @@ impl NewGroupIntent {
     }
 }
 
-impl DbConnection<'_> {
+impl DbConnection {
     pub fn insert_group_intent(
         &self,
         to_save: NewGroupIntent,

--- a/xmtp_mls/src/storage/encrypted_store/group_message.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group_message.rs
@@ -104,7 +104,7 @@ where
 impl_fetch!(StoredGroupMessage, group_messages, Vec<u8>);
 impl_store!(StoredGroupMessage, group_messages);
 
-impl DbConnection<'_> {
+impl DbConnection {
     /// Query for group messages
     pub fn get_group_messages<GroupId: AsRef<[u8]>>(
         &self,

--- a/xmtp_mls/src/storage/encrypted_store/identity_update.rs
+++ b/xmtp_mls/src/storage/encrypted_store/identity_update.rs
@@ -46,7 +46,7 @@ impl TryFrom<StoredIdentityUpdate> for IdentityUpdate {
 
 impl_store!(StoredIdentityUpdate, identity_updates);
 
-impl DbConnection<'_> {
+impl DbConnection {
     /// Returns all identity updates for the given inbox ID up to the provided sequence_id.
     /// Returns updates greater than `from_sequence_id` and less than _or equal to_ `to_sequence_id`
     pub fn get_identity_updates<InboxId: AsRef<str>>(

--- a/xmtp_mls/src/storage/encrypted_store/key_store_entry.rs
+++ b/xmtp_mls/src/storage/encrypted_store/key_store_entry.rs
@@ -14,7 +14,7 @@ pub struct StoredKeyStoreEntry {
 impl_fetch!(StoredKeyStoreEntry, openmls_key_store, Vec<u8>);
 impl_store!(StoredKeyStoreEntry, openmls_key_store);
 
-impl Delete<StoredKeyStoreEntry> for DbConnection<'_> {
+impl Delete<StoredKeyStoreEntry> for DbConnection {
     type Key = Vec<u8>;
     fn delete(&self, key: Vec<u8>) -> Result<usize, StorageError> where {
         use super::schema::openmls_key_store::dsl::*;
@@ -24,7 +24,7 @@ impl Delete<StoredKeyStoreEntry> for DbConnection<'_> {
     }
 }
 
-impl DbConnection<'_> {
+impl DbConnection {
     pub fn insert_or_update_key_store_entry(
         &self,
         key: Vec<u8>,

--- a/xmtp_mls/src/storage/encrypted_store/mod.rs
+++ b/xmtp_mls/src/storage/encrypted_store/mod.rs
@@ -170,11 +170,10 @@ impl EncryptedMessageStore {
         let mut connection = self.raw_conn()?;
         let transaction = AnsiTransactionManager::begin_transaction(&mut *connection);
         let db_connection = DbConnection::new(connection);
-        let mut provider = XmtpOpenMlsProvider::new(&db_connection);
+        let mut provider = XmtpOpenMlsProvider::new(db_connection);
         match fun(&mut provider) {
             Ok(value) => {
-                let value = db_connection
-                    .raw_query(|conn| AnsiTransactionManager::commit_transaction(conn))?;
+                db_connection.raw_query(|conn| AnsiTransactionManager::commit_transaction(conn))?;
                 Ok(value)
             }
             Err(err) => match db_connection
@@ -237,7 +236,7 @@ fn warn_length<T>(list: &[T], str_id: &str, max_length: usize) {
 macro_rules! impl_fetch {
     ($model:ty, $table:ident) => {
         impl $crate::Fetch<$model>
-            for $crate::storage::encrypted_store::db_connection::DbConnection<'_>
+            for $crate::storage::encrypted_store::db_connection::DbConnection
         {
             type Key = ();
             fn fetch(&self, _key: &Self::Key) -> Result<Option<$model>, $crate::StorageError> {
@@ -249,7 +248,7 @@ macro_rules! impl_fetch {
 
     ($model:ty, $table:ident, $key:ty) => {
         impl $crate::Fetch<$model>
-            for $crate::storage::encrypted_store::db_connection::DbConnection<'_>
+            for $crate::storage::encrypted_store::db_connection::DbConnection
         {
             type Key = $key;
             fn fetch(&self, key: &Self::Key) -> Result<Option<$model>, $crate::StorageError> {
@@ -263,12 +262,12 @@ macro_rules! impl_fetch {
 #[macro_export]
 macro_rules! impl_store {
     ($model:ty, $table:ident) => {
-        impl $crate::Store<$crate::storage::encrypted_store::db_connection::DbConnection<'_>>
+        impl $crate::Store<$crate::storage::encrypted_store::db_connection::DbConnection>
             for $model
         {
             fn store(
                 &self,
-                into: &$crate::storage::encrypted_store::db_connection::DbConnection<'_>,
+                into: &$crate::storage::encrypted_store::db_connection::DbConnection,
             ) -> Result<(), $crate::StorageError> {
                 into.raw_query(|conn| {
                     diesel::insert_into($table::table)
@@ -281,11 +280,11 @@ macro_rules! impl_store {
     };
 }
 
-impl<'a, T> Store<DbConnection<'a>> for Vec<T>
+impl<T> Store<DbConnection> for Vec<T>
 where
-    T: Store<DbConnection<'a>>,
+    T: Store<DbConnection>,
 {
-    fn store(&self, into: &DbConnection<'a>) -> Result<(), StorageError> {
+    fn store(&self, into: &DbConnection) -> Result<(), StorageError> {
         for item in self {
             item.store(into)?;
         }

--- a/xmtp_mls/src/storage/encrypted_store/refresh_state.rs
+++ b/xmtp_mls/src/storage/encrypted_store/refresh_state.rs
@@ -53,7 +53,7 @@ pub struct RefreshState {
 
 impl_store!(RefreshState, refresh_state);
 
-impl DbConnection<'_> {
+impl DbConnection {
     pub fn get_refresh_state<EntityId: AsRef<Vec<u8>>>(
         &self,
         entity_id: EntityId,

--- a/xmtp_mls/src/storage/sql_key_store.rs
+++ b/xmtp_mls/src/storage/sql_key_store.rs
@@ -10,21 +10,21 @@ use crate::{Delete, Fetch};
 
 /// CRUD Operations for an [`OpenMlsKeyStore`]
 #[derive(Clone, Debug)]
-pub struct SqlKeyStore<'a> {
-    conn: &'a DbConnection<'a>,
+pub struct SqlKeyStore {
+    conn: DbConnection,
 }
 
-impl<'a> SqlKeyStore<'a> {
-    pub fn new(conn: &'a DbConnection<'a>) -> Self {
+impl SqlKeyStore {
+    pub fn new(conn: DbConnection) -> Self {
         Self { conn }
     }
 
-    pub fn conn(&self) -> &DbConnection<'a> {
-        self.conn
+    pub fn conn(&self) -> &DbConnection {
+        &self.conn
     }
 }
 
-impl OpenMlsKeyStore for SqlKeyStore<'_> {
+impl OpenMlsKeyStore for SqlKeyStore {
     /// The error type returned by the [`OpenMlsKeyStore`].
     type Error = StorageError;
 

--- a/xmtp_mls/src/storage/sql_key_store.rs
+++ b/xmtp_mls/src/storage/sql_key_store.rs
@@ -7,16 +7,25 @@ use super::{
     StorageError,
 };
 use crate::{Delete, Fetch};
+use std::borrow::Cow;
 
 /// CRUD Operations for an [`OpenMlsKeyStore`]
-#[derive(Clone, Debug)]
-pub struct SqlKeyStore {
-    conn: DbConnection,
+#[derive(Debug)]
+pub struct SqlKeyStore<'a> {
+    conn: Cow<'a, DbConnection>,
 }
 
-impl SqlKeyStore {
+impl<'a> SqlKeyStore<'a> {
     pub fn new(conn: DbConnection) -> Self {
-        Self { conn }
+        Self {
+            conn: Cow::Owned(conn),
+        }
+    }
+
+    pub fn with_ref(conn: &'a DbConnection) -> Self {
+        Self {
+            conn: Cow::Borrowed(conn),
+        }
     }
 
     pub fn conn(&self) -> &DbConnection {
@@ -24,7 +33,7 @@ impl SqlKeyStore {
     }
 }
 
-impl OpenMlsKeyStore for SqlKeyStore {
+impl OpenMlsKeyStore for SqlKeyStore<'_> {
     /// The error type returned by the [`OpenMlsKeyStore`].
     type Error = StorageError;
 

--- a/xmtp_mls/src/storage/sql_key_store.rs
+++ b/xmtp_mls/src/storage/sql_key_store.rs
@@ -9,7 +9,7 @@ use super::{
 use crate::{Delete, Fetch};
 
 /// CRUD Operations for an [`OpenMlsKeyStore`]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SqlKeyStore<'a> {
     conn: &'a DbConnection<'a>,
 }

--- a/xmtp_mls/src/subscriptions.rs
+++ b/xmtp_mls/src/subscriptions.rs
@@ -206,7 +206,7 @@ where
     pub(crate) fn stream_messages_with_callback(
         client: Arc<Client<ApiClient>>,
         group_id_to_info: HashMap<Vec<u8>, MessagesStreamInfo>,
-        mut callback: impl FnMut(StoredGroupMessage) + Send + 'static,
+        mut callback: impl FnMut(StoredGroupMessage) + Send,
     ) -> Result<StreamCloser, ClientError> {
         let (close_sender, close_receiver) = oneshot::channel::<()>();
         let is_closed = Arc::new(AtomicBool::new(false));

--- a/xmtp_mls/src/subscriptions.rs
+++ b/xmtp_mls/src/subscriptions.rs
@@ -59,7 +59,7 @@ where
     fn process_streamed_welcome(&self, welcome: WelcomeMessage) -> Result<MlsGroup, ClientError> {
         let welcome_v1 = extract_welcome_message(welcome)?;
         let conn = self.context.store.conn()?;
-        let provider = self.mls_provider(&conn);
+        let provider = self.mls_provider(conn);
 
         MlsGroup::create_from_encrypted_welcome(
             self.context.clone(),

--- a/xmtp_mls/src/xmtp_openmls_provider.rs
+++ b/xmtp_mls/src/xmtp_openmls_provider.rs
@@ -9,6 +9,15 @@ pub struct XmtpOpenMlsProvider<'a> {
     key_store: SqlKeyStore<'a>,
 }
 
+impl<'a> Clone for XmtpOpenMlsProvider<'a> {
+    fn clone(&self) -> Self {
+        Self {
+            crypto: RustCrypto::default(),
+            key_store: self.key_store.clone(),
+        }
+    }
+}
+
 impl<'a> XmtpOpenMlsProvider<'a> {
     pub fn new(conn: &'a DbConnection<'a>) -> Self {
         Self {

--- a/xmtp_mls/src/xmtp_openmls_provider.rs
+++ b/xmtp_mls/src/xmtp_openmls_provider.rs
@@ -6,9 +6,24 @@ use crate::storage::{db_connection::DbConnection, sql_key_store::SqlKeyStore};
 #[derive(Debug)]
 pub struct XmtpOpenMlsProvider {
     crypto: RustCrypto,
-    key_store: SqlKeyStore,
+    key_store: SqlKeyStore<'static>,
 }
 
+pub struct XmtpOpenMlsProviderRef<'a> {
+    crypto: RustCrypto,
+    key_store: SqlKeyStore<'a>,
+}
+
+impl<'a> XmtpOpenMlsProviderRef<'a> {
+    pub fn new(conn: &DbConnection) -> Self {
+        Self {
+            crypto: RustCrypto::default(),
+            key_store: SqlKeyStore::with_ref(conn),
+        }
+    }
+}
+
+/*
 impl Clone for XmtpOpenMlsProvider {
     fn clone(&self) -> Self {
         Self {
@@ -17,6 +32,7 @@ impl Clone for XmtpOpenMlsProvider {
         }
     }
 }
+*/
 
 impl XmtpOpenMlsProvider {
     pub fn new(conn: DbConnection) -> Self {
@@ -34,7 +50,25 @@ impl XmtpOpenMlsProvider {
 impl OpenMlsProvider for XmtpOpenMlsProvider {
     type CryptoProvider = RustCrypto;
     type RandProvider = RustCrypto;
-    type KeyStoreProvider = SqlKeyStore;
+    type KeyStoreProvider = SqlKeyStore<'static>;
+
+    fn crypto(&self) -> &Self::CryptoProvider {
+        &self.crypto
+    }
+
+    fn rand(&self) -> &Self::RandProvider {
+        &self.crypto
+    }
+
+    fn key_store(&self) -> &Self::KeyStoreProvider {
+        &self.key_store
+    }
+}
+
+impl<'a> OpenMlsProvider for XmtpOpenMlsProviderRef<'a> {
+    type CryptoProvider = RustCrypto;
+    type RandProvider = RustCrypto;
+    type KeyStoreProvider = SqlKeyStore<'a>;
 
     fn crypto(&self) -> &Self::CryptoProvider {
         &self.crypto

--- a/xmtp_mls/src/xmtp_openmls_provider.rs
+++ b/xmtp_mls/src/xmtp_openmls_provider.rs
@@ -4,12 +4,12 @@ use openmls_traits::OpenMlsProvider;
 use crate::storage::{db_connection::DbConnection, sql_key_store::SqlKeyStore};
 
 #[derive(Debug)]
-pub struct XmtpOpenMlsProvider<'a> {
+pub struct XmtpOpenMlsProvider {
     crypto: RustCrypto,
-    key_store: SqlKeyStore<'a>,
+    key_store: SqlKeyStore,
 }
 
-impl<'a> Clone for XmtpOpenMlsProvider<'a> {
+impl Clone for XmtpOpenMlsProvider {
     fn clone(&self) -> Self {
         Self {
             crypto: RustCrypto::default(),
@@ -18,23 +18,23 @@ impl<'a> Clone for XmtpOpenMlsProvider<'a> {
     }
 }
 
-impl<'a> XmtpOpenMlsProvider<'a> {
-    pub fn new(conn: &'a DbConnection<'a>) -> Self {
+impl XmtpOpenMlsProvider {
+    pub fn new(conn: DbConnection) -> Self {
         Self {
             crypto: RustCrypto::default(),
             key_store: SqlKeyStore::new(conn),
         }
     }
 
-    pub(crate) fn conn(&self) -> &DbConnection<'a> {
+    pub(crate) fn conn(&self) -> &DbConnection {
         self.key_store.conn()
     }
 }
 
-impl<'a> OpenMlsProvider for XmtpOpenMlsProvider<'a> {
+impl OpenMlsProvider for XmtpOpenMlsProvider {
     type CryptoProvider = RustCrypto;
     type RandProvider = RustCrypto;
-    type KeyStoreProvider = SqlKeyStore<'a>;
+    type KeyStoreProvider = SqlKeyStore;
 
     fn crypto(&self) -> &Self::CryptoProvider {
         &self.crypto

--- a/xmtp_proto/src/api_client.rs
+++ b/xmtp_proto/src/api_client.rs
@@ -143,6 +143,7 @@ pub type WelcomeMessageStream = Pin<Box<dyn Stream<Item = Result<WelcomeMessage,
 // Wasm futures don't have `Send` or `Sync` bounds.
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+// TODO INSIPX: do we need this 'static bond?
 pub trait XmtpMlsClient: Send + Sync + 'static {
     async fn register_installation(
         &self,


### PR DESCRIPTION
This is a fairly large refactor PR, but it should significantly improve the ergonomics around MlsGroup management & Client, and we should run into significantly fewer lifetime errors. Additinoally, this aims to simplify binding creation.

- Introduce `XmtpApi` supertrait
- Decouple client from MLS Group.`MlsGroup` fns now accept a `Client` argument
- remove generics and lifetimes from `MlsGroup`
- Remove generics and lifetimes from `DbConnection`
- Introduce two types of `XmtpOpenMlsProvider`, a `ref` and `owned` type
- use `impl OpenMlsProvider` trait wherever XmtpOpenMlsProvider type was used
- remove lots and lots of lifetimes
- change `transaction` to use diesel TransactionManager and remove DbConnection mutable reference. All transactions require owned connection to start.
THis is branched off nicks 'commit' PR