### PR TITLE
Implement `inbox_sequence_id` method in client

### DIFF
--- a/bindings_ffi/src/lib.rs
+++ b/bindings_ffi/src/lib.rs
@@ -34,10 +34,6 @@ pub enum GenericError {
     ),
     #[error("Generic {err}")]
     Generic { err: String },
-    #[error(transparent)]
-    SignatureRequestError(#[from] xmtp_id::associations::builder::SignatureRequestError),
-    #[error(transparent)]
-    Erc1271SignatureError(#[from] xmtp_id::associations::signature::SignatureError),
 }
 
 impl From<String> for GenericError {

--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -374,7 +374,7 @@ async fn register(cli: &Cli, maybe_seed_phrase: Option<String>) -> Result<(), Cl
     )
     .await?;
     if let Err(e) = client
-        .register_identity(client.identity().get_signature_request().unwrap()) // TODO: remove `.unwrap()`. What should [Identity::request_signature()] return?
+        .register_identity(client.identity().signature_request().unwrap())
         .await
     {
         error!("Initialization Failed: {}", e.to_string());

--- a/xmtp_id/src/associations/builder.rs
+++ b/xmtp_id/src/associations/builder.rs
@@ -14,7 +14,7 @@ use super::{
         UnsignedChangeRecoveryAddress, UnsignedCreateInbox, UnsignedIdentityUpdate,
         UnsignedRevokeAssociation,
     },
-    Action, IdentityUpdate, MemberIdentifier, MemberKind, Signature, SignatureError,
+    Action, IdentityUpdate, MemberIdentifier, Signature, SignatureError,
 };
 
 /// The SignatureField is used to map the signatures from a [SignatureRequest] back to the correct
@@ -188,14 +188,6 @@ impl SignatureRequest {
             signatures: HashMap::new(),
             client_timestamp_ns,
         }
-    }
-
-    pub fn missing_address_signatures(&self) -> Vec<MemberIdentifier> {
-        self.missing_signatures()
-            .iter()
-            .filter(|member| member.kind() == MemberKind::Address)
-            .cloned()
-            .collect()
     }
 
     pub fn missing_signatures(&self) -> Vec<MemberIdentifier> {

--- a/xmtp_id/src/associations/signature.rs
+++ b/xmtp_id/src/associations/signature.rs
@@ -6,7 +6,6 @@ use super::MemberIdentifier;
 use async_trait::async_trait;
 use ed25519_dalek::{Signature as Ed25519Signature, VerifyingKey};
 use ethers::{
-    providers::{Http, Middleware, Provider},
     types::{BlockNumber, U64},
     utils::hash_message,
 };
@@ -40,10 +39,6 @@ pub enum SignatureError {
     AddressValidationError(#[from] xmtp_cryptography::signature::AddressValidationError),
     #[error("Invalid account address")]
     InvalidAccountAddress(#[from] rustc_hex::FromHexError),
-    #[error(transparent)]
-    UrlParseError(#[from] url::ParseError),
-    #[error(transparent)]
-    ProviderError(#[from] ethers::providers::ProviderError),
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -143,12 +138,6 @@ pub struct AccountId {
 }
 
 impl AccountId {
-    pub fn new(chain_id: String, account_address: String) -> Self {
-        AccountId {
-            chain_id,
-            account_address,
-        }
-    }
     pub fn is_evm_chain(&self) -> bool {
         self.chain_id.starts_with("eip155")
     }
@@ -166,8 +155,6 @@ pub struct Erc1271Signature {
     chain_rpc_url: String,
 }
 
-unsafe impl Send for Erc1271Signature {}
-
 impl Erc1271Signature {
     pub fn new(
         signature_text: String,
@@ -183,27 +170,6 @@ impl Erc1271Signature {
             chain_rpc_url,
             block_number,
         }
-    }
-
-    /// Fetch Chain ID & block number from the RPC URL and create the new ERC1271 Signature
-    /// This could be used by platform SDK who only needs to provide the RPC URL and account address.
-    pub async fn new_with_rpc(
-        signature_text: String,
-        signature_bytes: Vec<u8>,
-        account_address: String,
-        chain_rpc_url: String,
-    ) -> Result<Self, SignatureError> {
-        let provider = Provider::<Http>::try_from(&chain_rpc_url)?;
-        let block_number = provider.get_block_number().await?;
-        let chain_id = provider.get_chainid().await?;
-        let account_id = AccountId::new(chain_id.to_string(), account_address);
-        Ok(Erc1271Signature::new(
-            signature_text,
-            signature_bytes,
-            account_id,
-            chain_rpc_url,
-            block_number.as_u64(),
-        ))
     }
 }
 

--- a/xmtp_mls/src/api/identity.rs
+++ b/xmtp_mls/src/api/identity.rs
@@ -29,6 +29,7 @@ impl From<GetIdentityUpdatesV2Filter> for GetIdentityUpdatesV2RequestProto {
     }
 }
 
+#[derive(Clone)]
 pub struct InboxUpdate {
     pub sequence_id: u64,
     pub server_timestamp_ns: u64,

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -228,7 +228,7 @@ impl MlsGroup {
         let mutable_metadata = build_mutable_metadata_extension_default(&context.identity)?;
         let group_membership = build_starting_group_membership_extension(
             context.inbox_id(),
-            context.inbox_latest_sequence_id(),
+            context.inbox_sequence_id(),
         );
         let mutable_permissions =
             build_mutable_permissions_extension(permissions.unwrap_or_default().to_policy_set())?;
@@ -341,7 +341,7 @@ impl MlsGroup {
         let mutable_metadata = build_mutable_metadata_extension_default(&context.identity)?;
         let group_membership = build_starting_group_membership_extension(
             context.inbox_id(),
-            context.inbox_latest_sequence_id(),
+            context.inbox_sequence_id(),
         );
         let mutable_permissions =
             build_mutable_permissions_extension(PreconfiguredPolicies::default().to_policy_set())?;
@@ -653,7 +653,7 @@ fn build_protected_metadata_extension(
     };
     let metadata = GroupMetadata::new(
         group_type,
-        identity.get_inbox_id().clone(),
+        identity.inbox_id().clone(),
         // TODO: Remove me
         "inbox_id".to_string(),
     );

--- a/xmtp_mls/src/groups/sync.rs
+++ b/xmtp_mls/src/groups/sync.rs
@@ -20,6 +20,7 @@ use crate::{
     groups::{intents::UpdateMetadataIntentData, validated_commit::ValidatedCommit},
     hpke::{encrypt_welcome, HpkeError},
     identity::Identity,
+    identity_updates::load_identity_updates,
     retry::Retry,
     retry_async, retry_sync,
     storage::{
@@ -830,7 +831,7 @@ impl MlsGroup {
         inbox_ids.extend(inbox_ids_to_add);
         let conn = provider.conn_ref();
         // Load any missing updates from the network
-        client.load_identity_updates(conn, &inbox_ids).await?;
+        load_identity_updates(&client.api_client, conn, inbox_ids.clone()).await?;
 
         let latest_sequence_id_map = conn.get_latest_sequence_id(&inbox_ids)?;
 

--- a/xmtp_mls/src/storage/encrypted_store/identity.rs
+++ b/xmtp_mls/src/storage/encrypted_store/identity.rs
@@ -48,6 +48,7 @@ impl From<StoredIdentity> for Identity {
     fn from(identity: StoredIdentity) -> Self {
         Identity {
             inbox_id: identity.inbox_id.clone(),
+            sequence_id: 0, // not stored
             installation_keys: db_deserialize(&identity.installation_keys).unwrap(),
             credential: db_deserialize(&identity.credential_bytes).unwrap(),
             signature_request: None,


### PR DESCRIPTION
# tl;dr

Refactor `load_identity_updates` method into a function so that it can be used during client creation.
Add `sequence_id` field in `Identity` struct.
Some renaming according to [rust style guidelines](https://doc.rust-lang.org/1.0.0/style/README.html)
