### PR TITLE
bindings_ffi: new client & signatureRequest.

### DIFF
--- a/bindings_ffi/src/lib.rs
+++ b/bindings_ffi/src/lib.rs
@@ -36,6 +36,8 @@ pub enum GenericError {
     Generic { err: String },
     #[error(transparent)]
     SignatureRequestError(#[from] xmtp_id::associations::builder::SignatureRequestError),
+    #[error(transparent)]
+    Erc1271SignatureError(#[from] xmtp_id::associations::signature::SignatureError),
 }
 
 impl From<String> for GenericError {

--- a/bindings_ffi/src/lib.rs
+++ b/bindings_ffi/src/lib.rs
@@ -29,9 +29,13 @@ pub enum GenericError {
     #[error("Group metadata: {0}")]
     GroupMetadata(#[from] xmtp_mls::groups::group_metadata::GroupMetadataError),
     #[error("Group permissions: {0}")]
-    GroupMutablePermissions(#[from] xmtp_mls::groups::group_permissions::GroupMutablePermissionsError),
+    GroupMutablePermissions(
+        #[from] xmtp_mls::groups::group_permissions::GroupMutablePermissionsError,
+    ),
     #[error("Generic {err}")]
     Generic { err: String },
+    #[error(transparent)]
+    SignatureRequestError(#[from] xmtp_id::associations::builder::SignatureRequestError),
 }
 
 impl From<String> for GenericError {

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -12,8 +12,7 @@ use tokio::sync::oneshot::Sender;
 use xmtp_api_grpc::grpc_api_helper::Client as TonicApiClient;
 use xmtp_id::{
     associations::{
-        builder::SignatureRequest, AccountId, Erc1271Signature, MemberIdentifier,
-        RecoverableEcdsaSignature,
+        builder::SignatureRequest, Erc1271Signature, MemberIdentifier, RecoverableEcdsaSignature,
     },
     InboxId,
 };

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -121,7 +121,7 @@ pub async fn create_client(
 
 #[derive(uniffi::Object)]
 pub struct FfiSignatureRequest {
-    // Using `tokio::sync::Mutex`bc MutexGuard cannot be sent between threads.
+    // Using `tokio::sync::Mutex`bc rust MutexGuard cannot be sent between threads.
     inner: Arc<tokio::sync::Mutex<SignatureRequest>>,
 }
 

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -146,19 +146,16 @@ impl FfiSignatureRequest {
         &self,
         signature_bytes: Vec<u8>,
         address: String,
-        chain_id: String,
         chain_rpc_url: String,
-        block_number: u64,
     ) -> Result<(), GenericError> {
         let mut inner = self.inner.lock().await;
-        let account_id = AccountId::new(chain_id, address);
-        let erc1271_siganture = Erc1271Signature::new(
+        let erc1271_siganture = Erc1271Signature::new_with_rpc(
             inner.signature_text(),
             signature_bytes,
-            account_id,
+            address,
             chain_rpc_url,
-            block_number,
-        );
+        )
+        .await?;
         inner.add_signature(Box::new(erc1271_siganture)).await?;
         Ok(())
     }

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -11,9 +11,7 @@ use std::sync::{
 use tokio::sync::oneshot::Sender;
 use xmtp_api_grpc::grpc_api_helper::Client as TonicApiClient;
 use xmtp_id::{
-    associations::{
-        builder::SignatureRequest, Erc1271Signature, MemberIdentifier, RecoverableEcdsaSignature,
-    },
+    associations::{builder::SignatureRequest, Erc1271Signature, RecoverableEcdsaSignature},
     InboxId,
 };
 use xmtp_mls::{
@@ -164,26 +162,14 @@ impl FfiSignatureRequest {
     }
 
     /// missing signatures that are from [MemberKind::Address]
-    pub async fn missing_address_signatures(
-        &self,
-    ) -> Result<Vec<Arc<FfiMemberIdentifier>>, GenericError> {
+    pub async fn missing_address_signatures(&self) -> Result<Vec<String>, GenericError> {
         let inner = self.inner.lock().await;
         Ok(inner
             .missing_address_signatures()
             .iter()
-            .map(|member| {
-                Arc::new(FfiMemberIdentifier {
-                    inner: Arc::new(member.clone()),
-                })
-            })
+            .map(|member| member.to_string())
             .collect())
     }
-}
-
-#[derive(uniffi::Object)]
-pub struct FfiMemberIdentifier {
-    #[allow(unused)]
-    inner: Arc<MemberIdentifier>,
 }
 
 #[derive(uniffi::Object)]

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -10,19 +10,25 @@ use std::sync::{
 };
 use tokio::sync::oneshot::Sender;
 use xmtp_api_grpc::grpc_api_helper::Client as TonicApiClient;
-use xmtp_id::InboxId;
-use xmtp_mls::groups::group_metadata::ConversationType;
-use xmtp_mls::groups::group_metadata::GroupMetadata;
-use xmtp_mls::groups::group_permissions::GroupMutablePermissions;
-use xmtp_mls::groups::PreconfiguredPolicies;
-use xmtp_mls::identity::IdentityStrategy;
+use xmtp_id::{
+    associations::{
+        builder::SignatureRequest, AccountId, Erc1271Signature, MemberIdentifier,
+        RecoverableEcdsaSignature,
+    },
+    InboxId,
+};
 use xmtp_mls::{
     builder::ClientBuilder,
     client::Client as MlsClient,
-    groups::MlsGroup,
+    groups::{
+        group_metadata::{ConversationType, GroupMetadata},
+        group_permissions::GroupMutablePermissions,
+        MlsGroup, PreconfiguredPolicies,
+    },
+    identity::IdentityStrategy,
     storage::{
-        group_message::DeliveryStatus, group_message::GroupMessageKind,
-        group_message::StoredGroupMessage, EncryptedMessageStore, EncryptionKey, StorageOption,
+        group_message::{DeliveryStatus, GroupMessageKind, StoredGroupMessage},
+        EncryptedMessageStore, EncryptionKey, StorageOption,
     },
 };
 
@@ -115,6 +121,76 @@ pub async fn create_client(
 }
 
 #[derive(uniffi::Object)]
+pub struct FfiSignatureRequest {
+    // Using `tokio::sync::Mutex`bc MutexGuard cannot be sent between threads.
+    inner: Arc<tokio::sync::Mutex<SignatureRequest>>,
+}
+
+#[uniffi::export(async_runtime = "tokio")]
+impl FfiSignatureRequest {
+    // Signature that's signed by EOA wallet
+    pub async fn add_ecdsa_signature(&self, signature_bytes: Vec<u8>) -> Result<(), GenericError> {
+        let mut inner = self.inner.lock().await;
+        let signature_text = inner.signature_text();
+        inner
+            .add_signature(Box::new(RecoverableEcdsaSignature::new(
+                signature_text,
+                signature_bytes,
+            )))
+            .await?;
+
+        Ok(())
+    }
+
+    pub async fn add_erc1271_signature(
+        &self,
+        signature_bytes: Vec<u8>,
+        address: String,
+        chain_id: String,
+        chain_rpc_url: String,
+        block_number: u64,
+    ) -> Result<(), GenericError> {
+        let mut inner = self.inner.lock().await;
+        let account_id = AccountId::new(chain_id, address);
+        let erc1271_siganture = Erc1271Signature::new(
+            inner.signature_text(),
+            signature_bytes,
+            account_id,
+            chain_rpc_url,
+            block_number,
+        );
+        inner.add_signature(Box::new(erc1271_siganture)).await?;
+        Ok(())
+    }
+
+    pub async fn signature_text(&self) -> Result<String, GenericError> {
+        Ok(self.inner.lock().await.signature_text())
+    }
+
+    /// missing signatures that are from [MemberKind::Address]
+    pub async fn missing_address_signatures(
+        &self,
+    ) -> Result<Vec<Arc<FfiMemberIdentifier>>, GenericError> {
+        let inner = self.inner.lock().await;
+        Ok(inner
+            .missing_address_signatures()
+            .iter()
+            .map(|member| {
+                Arc::new(FfiMemberIdentifier {
+                    inner: Arc::new(member.clone()),
+                })
+            })
+            .collect())
+    }
+}
+
+#[derive(uniffi::Object)]
+pub struct FfiMemberIdentifier {
+    #[allow(unused)]
+    inner: Arc<MemberIdentifier>,
+}
+
+#[derive(uniffi::Object)]
 pub struct FfiXmtpClient {
     inner_client: Arc<RustXmtpClient>,
 }
@@ -149,13 +225,25 @@ impl FfiXmtpClient {
 
 #[uniffi::export(async_runtime = "tokio")]
 impl FfiXmtpClient {
-    pub fn siganture_request(&self) -> Option<String> {
-        Some("signature_request".to_string())
+    pub fn signature_request(&self) -> Option<Arc<FfiSignatureRequest>> {
+        self.inner_client
+            .identity()
+            .get_signature_request()
+            .map(|request| {
+                Arc::new(FfiSignatureRequest {
+                    inner: Arc::new(tokio::sync::Mutex::new(request)),
+                })
+            })
     }
 
-    pub async fn register_identity(&self, _signature_request: String) -> Result<(), GenericError> {
-        // TODO: use proper type for signature_request and uncomment this
-        // self.inner_client.register_identity(request).await?;
+    pub async fn register_identity(
+        &self,
+        signature_request: Arc<FfiSignatureRequest>,
+    ) -> Result<(), GenericError> {
+        let signature_request = signature_request.inner.lock().await;
+        self.inner_client
+            .register_identity(signature_request.clone())
+            .await?;
 
         Ok(())
     }
@@ -663,7 +751,6 @@ impl FfiGroupMetadata {
     }
 }
 
-
 #[derive(uniffi::Object)]
 pub struct FfiGroupPermissions {
     inner: Arc<GroupMutablePermissions>,
@@ -671,7 +758,6 @@ pub struct FfiGroupPermissions {
 
 #[uniffi::export]
 impl FfiGroupPermissions {
-
     pub fn policy_type(&self) -> Result<GroupPermissions, GenericError> {
         Ok(self.inner.preconfigured_policy()?.into())
     }
@@ -794,7 +880,7 @@ mod tests {
         .await
         .unwrap();
 
-        let signature_request = client.siganture_request().unwrap();
+        let signature_request = client.signature_request().unwrap();
         client.register_identity(signature_request).await.unwrap();
         return client;
     }
@@ -804,7 +890,7 @@ mod tests {
     #[ignore]
     async fn test_client_creation() {
         let client = new_test_client().await;
-        assert!(!client.siganture_request().is_none());
+        assert!(!client.signature_request().is_none());
     }
 
     #[tokio::test]
@@ -838,12 +924,20 @@ mod tests {
         .await
         .unwrap();
 
-        assert!(client.siganture_request().is_none());
+        assert!(client.signature_request().is_none());
         client
-            .register_identity(client.siganture_request().unwrap())
+            .register_identity(client.signature_request().unwrap())
             .await
             .unwrap();
-        assert_eq!(client.siganture_request().unwrap(), inbox_id);
+        assert_eq!(
+            client
+                .signature_request()
+                .unwrap()
+                .signature_text()
+                .await
+                .unwrap(),
+            inbox_id
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -865,7 +959,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let signature_request = client_a.siganture_request().unwrap();
+        let signature_request = client_a.signature_request().unwrap();
         client_a.register_identity(signature_request).await.unwrap();
 
         let installation_pub_key = client_a.inner_client.installation_public_key();
@@ -940,13 +1034,13 @@ mod tests {
     async fn test_create_group_with_members() {
         let amal = new_test_client().await;
         let bola = new_test_client().await;
-        bola.register_identity(bola.siganture_request().unwrap())
+        bola.register_identity(bola.signature_request().unwrap())
             .await
             .unwrap();
 
         let group = amal
             .conversations()
-            .create_group(vec![bola.siganture_request().unwrap()], None)
+            .create_group(vec![bola.inner_client.account_address()], None)
             .await
             .unwrap();
 
@@ -973,7 +1067,7 @@ mod tests {
         .await
         .unwrap();
 
-        let signature_request = client.siganture_request().unwrap();
+        let signature_request = client.signature_request().unwrap();
         assert!(client.register_identity(signature_request).await.is_err());
     }
 
@@ -1021,7 +1115,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let signature_request = client_bola.siganture_request().unwrap();
+        let signature_request = client_bola.signature_request().unwrap();
         client_bola
             .register_identity(signature_request)
             .await
@@ -1058,7 +1152,7 @@ mod tests {
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
         amal.conversations()
-            .create_group(vec![bola.siganture_request().unwrap()], None)
+            .create_group(vec![bola.inner_client.account_address()], None)
             .await
             .unwrap();
 
@@ -1067,7 +1161,7 @@ mod tests {
         assert_eq!(stream_callback.message_count(), 1);
         // Create another group and add bola
         amal.conversations()
-            .create_group(vec![bola.siganture_request().unwrap()], None)
+            .create_group(vec![bola.inner_client.account_address()], None)
             .await
             .unwrap();
 
@@ -1088,7 +1182,7 @@ mod tests {
 
         let alix_group = alix
             .conversations()
-            .create_group(vec![caro.siganture_request().unwrap()], None)
+            .create_group(vec![caro.inner_client.account_address()], None)
             .await
             .unwrap();
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
@@ -1106,7 +1200,7 @@ mod tests {
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
         let bo_group = bo
             .conversations()
-            .create_group(vec![caro.siganture_request().unwrap()], None)
+            .create_group(vec![caro.inner_client.account_address()], None)
             .await
             .unwrap();
         tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
@@ -1131,7 +1225,7 @@ mod tests {
 
         let group = amal
             .conversations()
-            .create_group(vec![bola.siganture_request().unwrap()], None)
+            .create_group(vec![bola.inner_client.account_address()], None)
             .await
             .unwrap();
 
@@ -1161,13 +1255,13 @@ mod tests {
         let bola = new_test_client().await;
         log::info!(
             "Created Inbox IDs {} and {}",
-            amal.siganture_request().unwrap(),
-            bola.siganture_request().unwrap()
+            amal.inner_client.inbox_id(),
+            bola.inner_client.inbox_id()
         );
 
         let amal_group = amal
             .conversations()
-            .create_group(vec![bola.siganture_request().unwrap()], None)
+            .create_group(vec![bola.inner_client.account_address()], None)
             .await
             .unwrap();
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
@@ -1189,7 +1283,7 @@ mod tests {
         assert!(!stream_closer.is_closed());
 
         amal_group
-            .remove_members(vec![bola.siganture_request().unwrap()])
+            .remove_members(vec![bola.inner_client.account_address()])
             .await
             .unwrap();
         tokio::time::sleep(std::time::Duration::from_millis(2000)).await;
@@ -1202,7 +1296,7 @@ mod tests {
 
         tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
         amal_group
-            .add_members(vec![bola.siganture_request().unwrap()])
+            .add_members(vec![bola.inner_client.account_address()])
             .await
             .unwrap();
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
@@ -1227,7 +1321,7 @@ mod tests {
 
         // Amal creates a group and adds Bola to the group
         amal.conversations()
-            .create_group(vec![bola.siganture_request().unwrap()], None)
+            .create_group(vec![bola.inner_client.account_address()], None)
             .await
             .unwrap();
 
@@ -1254,7 +1348,7 @@ mod tests {
 
         // // Verify the welcome host_credential is equal to Amal's
         assert_eq!(
-            amal.siganture_request().unwrap(),
+            amal.inner_client.account_address(),
             added_by_address,
             "The Inviter and added_by_address do not match!"
         );

--- a/xmtp_id/src/associations/builder.rs
+++ b/xmtp_id/src/associations/builder.rs
@@ -14,7 +14,7 @@ use super::{
         UnsignedChangeRecoveryAddress, UnsignedCreateInbox, UnsignedIdentityUpdate,
         UnsignedRevokeAssociation,
     },
-    Action, IdentityUpdate, MemberIdentifier, Signature, SignatureError,
+    Action, IdentityUpdate, MemberIdentifier, MemberKind, Signature, SignatureError,
 };
 
 /// The SignatureField is used to map the signatures from a [SignatureRequest] back to the correct
@@ -188,6 +188,14 @@ impl SignatureRequest {
             signatures: HashMap::new(),
             client_timestamp_ns,
         }
+    }
+
+    pub fn missing_address_signatures(&self) -> Vec<MemberIdentifier> {
+        self.missing_signatures()
+            .iter()
+            .filter(|member| member.kind() == MemberKind::Address)
+            .cloned()
+            .collect()
     }
 
     pub fn missing_signatures(&self) -> Vec<MemberIdentifier> {

--- a/xmtp_id/src/associations/signature.rs
+++ b/xmtp_id/src/associations/signature.rs
@@ -6,6 +6,7 @@ use super::MemberIdentifier;
 use async_trait::async_trait;
 use ed25519_dalek::{Signature as Ed25519Signature, VerifyingKey};
 use ethers::{
+    providers::{Http, Middleware, Provider},
     types::{BlockNumber, U64},
     utils::hash_message,
 };
@@ -39,6 +40,10 @@ pub enum SignatureError {
     AddressValidationError(#[from] xmtp_cryptography::signature::AddressValidationError),
     #[error("Invalid account address")]
     InvalidAccountAddress(#[from] rustc_hex::FromHexError),
+    #[error(transparent)]
+    UrlParseError(#[from] url::ParseError),
+    #[error(transparent)]
+    ProviderError(#[from] ethers::providers::ProviderError),
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -178,6 +183,27 @@ impl Erc1271Signature {
             chain_rpc_url,
             block_number,
         }
+    }
+
+    /// Fetch Chain ID & block number from the RPC URL and create the new ERC1271 Signature
+    /// This could be used by platform SDK who only needs to provide the RPC URL and account address.
+    pub async fn new_with_rpc(
+        signature_text: String,
+        signature_bytes: Vec<u8>,
+        account_address: String,
+        chain_rpc_url: String,
+    ) -> Result<Self, SignatureError> {
+        let provider = Provider::<Http>::try_from(&chain_rpc_url)?;
+        let block_number = provider.get_block_number().await?;
+        let chain_id = provider.get_chainid().await?;
+        let account_id = AccountId::new(chain_id.to_string(), account_address);
+        Ok(Erc1271Signature {
+            signature_text,
+            signature_bytes,
+            account_id,
+            chain_rpc_url,
+            block_number: block_number.as_u64(),
+        })
     }
 }
 

--- a/xmtp_id/src/associations/signature.rs
+++ b/xmtp_id/src/associations/signature.rs
@@ -138,6 +138,12 @@ pub struct AccountId {
 }
 
 impl AccountId {
+    pub fn new(chain_id: String, account_address: String) -> Self {
+        AccountId {
+            chain_id,
+            account_address,
+        }
+    }
     pub fn is_evm_chain(&self) -> bool {
         self.chain_id.starts_with("eip155")
     }
@@ -154,6 +160,8 @@ pub struct Erc1271Signature {
     block_number: u64,
     chain_rpc_url: String,
 }
+
+unsafe impl Send for Erc1271Signature {}
 
 impl Erc1271Signature {
     pub fn new(

--- a/xmtp_id/src/associations/signature.rs
+++ b/xmtp_id/src/associations/signature.rs
@@ -197,13 +197,13 @@ impl Erc1271Signature {
         let block_number = provider.get_block_number().await?;
         let chain_id = provider.get_chainid().await?;
         let account_id = AccountId::new(chain_id.to_string(), account_address);
-        Ok(Erc1271Signature {
+        Ok(Erc1271Signature::new(
             signature_text,
             signature_bytes,
             account_id,
             chain_rpc_url,
-            block_number: block_number.as_u64(),
-        })
+            block_number.as_u64(),
+        ))
     }
 }
 


### PR DESCRIPTION
# summary

- Implements `signature_request` & `register_identity` on Client.
- Introduces `FfiSignatureRequest` and methods `add_ecdsa_signature`, `add_erc1271_signature`, `missing_address_signatures` etc.
- `Erc1271Signature::new_with_rpc` to make platform SDK life easier by only taking `chain_rpc_url` without `chain_id`, `block_number` for Erc1271Signature