### PR TITLE
Update group.members()

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -389,7 +389,8 @@ pub struct FfiGroup {
 
 #[derive(uniffi::Record)]
 pub struct FfiGroupMember {
-    pub account_address: String,
+    pub inbox_id: String,
+    pub account_addresses: Vec<String>,
     pub installation_ids: Vec<Vec<u8>>,
 }
 
@@ -483,7 +484,8 @@ impl FfiGroup {
             .members()?
             .into_iter()
             .map(|member| FfiGroupMember {
-                account_address: member.account_address,
+                inbox_id: member.inbox_id,
+                account_addresses: member.account_addresses,
                 installation_ids: member.installation_ids,
             })
             .collect();

--- a/examples/cli/serializable.rs
+++ b/examples/cli/serializable.rs
@@ -27,7 +27,7 @@ impl<'a> From<&'a MlsGroup> for SerializableGroup {
             .members()
             .expect("could not load members")
             .into_iter()
-            .map(|m| m.account_address)
+            .map(|m| m.inbox_id)
             .collect::<Vec<String>>();
 
         let metadata = group.metadata().expect("could not load metadata");

--- a/xmtp_id/src/associations/serialization.rs
+++ b/xmtp_id/src/associations/serialization.rs
@@ -386,6 +386,7 @@ impl From<AssociationState> for AssociationStateProto {
 
 impl TryFrom<AssociationStateProto> for AssociationState {
     type Error = DeserializationError;
+
     fn try_from(proto: AssociationStateProto) -> Result<Self, Self::Error> {
         let members = proto
             .members

--- a/xmtp_id/src/associations/state.rs
+++ b/xmtp_id/src/associations/state.rs
@@ -108,6 +108,26 @@ impl AssociationState {
             .collect()
     }
 
+    pub fn account_addresses(&self) -> Vec<String> {
+        self.members_by_kind(MemberKind::Address)
+            .into_iter()
+            .filter_map(|member| match member.identifier {
+                MemberIdentifier::Address(address) => Some(address),
+                MemberIdentifier::Installation(_) => None,
+            })
+            .collect()
+    }
+
+    pub fn installation_ids(&self) -> Vec<Vec<u8>> {
+        self.members_by_kind(MemberKind::Installation)
+            .into_iter()
+            .filter_map(|member| match member.identifier {
+                MemberIdentifier::Address(_) => None,
+                MemberIdentifier::Installation(installation_id) => Some(installation_id),
+            })
+            .collect()
+    }
+
     pub fn diff(&self, new_state: &Self) -> AssociationStateDiff {
         let new_members: Vec<MemberIdentifier> = new_state
             .members

--- a/xmtp_mls/src/groups/group_membership.rs
+++ b/xmtp_mls/src/groups/group_membership.rs
@@ -1,3 +1,4 @@
+use openmls::extensions::Extensions;
 use prost::{DecodeError, Message};
 use std::collections::HashMap;
 use xmtp_proto::xmtp::mls::message_contents::GroupMembership as GroupMembershipProto;

--- a/xmtp_mls/src/groups/group_membership.rs
+++ b/xmtp_mls/src/groups/group_membership.rs
@@ -1,4 +1,3 @@
-use openmls::extensions::Extensions;
 use prost::{DecodeError, Message};
 use std::collections::HashMap;
 use xmtp_proto::xmtp::mls::message_contents::GroupMembership as GroupMembershipProto;

--- a/xmtp_mls/src/storage/encrypted_store/association_state.rs
+++ b/xmtp_mls/src/storage/encrypted_store/association_state.rs
@@ -1,9 +1,15 @@
 use diesel::prelude::*;
 use prost::Message;
-use xmtp_id::associations::{AssociationState, DeserializationError};
+use xmtp_id::{
+    associations::{AssociationState, DeserializationError},
+    InboxId,
+};
 use xmtp_proto::xmtp::identity::associations::AssociationState as AssociationStateProto;
 
-use super::schema::association_state;
+use super::{
+    schema::association_state::{self, dsl},
+    DbConnection,
+};
 use crate::{impl_fetch, impl_store_or_ignore, storage::StorageError, Fetch, StoreOrIgnore};
 
 /// StoredIdentityUpdate holds a serialized IdentityUpdate record
@@ -22,13 +28,13 @@ impl TryFrom<StoredAssociationState> for AssociationState {
     type Error = DeserializationError;
 
     fn try_from(stored_state: StoredAssociationState) -> Result<Self, Self::Error> {
-        AssociationStateProto::decode(stored_state.state.as_slice())?.try_into()
+        Ok(AssociationStateProto::decode(stored_state.state.as_slice())?.try_into()?)
     }
 }
 
 impl StoredAssociationState {
     pub fn write_to_cache(
-        conn: &super::db_connection::DbConnection,
+        conn: &DbConnection,
         inbox_id: String,
         sequence_id: i64,
         state: AssociationState,
@@ -43,7 +49,7 @@ impl StoredAssociationState {
     }
 
     pub fn read_from_cache(
-        conn: &super::db_connection::DbConnection,
+        conn: &DbConnection,
         inbox_id: String,
         sequence_id: i64,
     ) -> Result<Option<AssociationState>, StorageError> {
@@ -61,5 +67,87 @@ impl StoredAssociationState {
                     })
             })
             .transpose()
+    }
+
+    pub fn batch_read_from_cache(
+        conn: &DbConnection,
+        identifiers: &Vec<(InboxId, i64)>,
+    ) -> Result<Vec<AssociationState>, StorageError> {
+        // If no identifier provided, return empty hash map
+        if identifiers.is_empty() {
+            return Ok(vec![]);
+        }
+        let mut query = dsl::association_state.into_boxed();
+        for (inbox_id, sequence_id) in identifiers {
+            query = query.or_filter(
+                dsl::inbox_id
+                    .eq(inbox_id)
+                    .and(dsl::sequence_id.eq(sequence_id)),
+            );
+        }
+        let association_states =
+            conn.raw_query(|query_conn| query.load::<StoredAssociationState>(query_conn))?;
+
+        Ok(association_states
+            .into_iter()
+            .map(|stored_association_state| stored_association_state.try_into())
+            .collect::<Result<Vec<AssociationState>, DeserializationError>>()
+            .map_err(|err| StorageError::Deserialization(err.to_string()))?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::storage::encrypted_store::tests::with_connection;
+
+    use super::*;
+
+    #[test]
+    fn test_batch_read() {
+        with_connection(|conn| {
+            let association_state = AssociationState::new("1234".to_string(), 0);
+            let inbox_id = association_state.inbox_id().clone();
+            StoredAssociationState::write_to_cache(
+                conn,
+                inbox_id.to_string(),
+                1,
+                association_state,
+            )
+            .unwrap();
+
+            let association_state_2 = AssociationState::new("456".to_string(), 2);
+            let inbox_id_2 = association_state_2.inbox_id().clone();
+            StoredAssociationState::write_to_cache(
+                conn,
+                association_state_2.inbox_id().clone(),
+                2,
+                association_state_2,
+            )
+            .unwrap();
+
+            let first_association_state = StoredAssociationState::batch_read_from_cache(
+                conn,
+                &vec![(inbox_id.to_string(), 1)],
+            )
+            .unwrap();
+            assert_eq!(first_association_state.len(), 1);
+            assert_eq!(first_association_state[0].inbox_id(), &inbox_id);
+
+            let both_association_states = StoredAssociationState::batch_read_from_cache(
+                conn,
+                &vec![(inbox_id.to_string(), 1), (inbox_id_2.to_string(), 2)],
+            )
+            .unwrap();
+
+            assert_eq!(both_association_states.len(), 2);
+
+            let no_results = StoredAssociationState::batch_read_from_cache(
+                conn,
+                // Mismatched inbox_id and sequence_id
+                &vec![(inbox_id.to_string(), 2)],
+            )
+            .unwrap();
+            assert_eq!(no_results.len(), 0);
+        })
     }
 }

--- a/xmtp_mls/src/storage/encrypted_store/association_state.rs
+++ b/xmtp_mls/src/storage/encrypted_store/association_state.rs
@@ -28,7 +28,7 @@ impl TryFrom<StoredAssociationState> for AssociationState {
     type Error = DeserializationError;
 
     fn try_from(stored_state: StoredAssociationState) -> Result<Self, Self::Error> {
-        Ok(AssociationStateProto::decode(stored_state.state.as_slice())?.try_into()?)
+        AssociationStateProto::decode(stored_state.state.as_slice())?.try_into()
     }
 }
 
@@ -88,11 +88,11 @@ impl StoredAssociationState {
         let association_states =
             conn.raw_query(|query_conn| query.load::<StoredAssociationState>(query_conn))?;
 
-        Ok(association_states
+        association_states
             .into_iter()
             .map(|stored_association_state| stored_association_state.try_into())
             .collect::<Result<Vec<AssociationState>, DeserializationError>>()
-            .map_err(|err| StorageError::Deserialization(err.to_string()))?)
+            .map_err(|err| StorageError::Deserialization(err.to_string()))
     }
 }
 


### PR DESCRIPTION
## tl;dr

- Updates the `group.members()` method to load from the StoredAssociationState table

## Notes

Still a bit of a hack. This approach assumes we have a `StoredAssociationState` for each member at their current `sequence_id`. The next iteration on top of this will build the association state in cases where the inbox is missing from the cache.

In pretty much all cases we should have it cached but we shouldn't need to rely on that being true.