### PR TITLE
`get_inbox_id_for_address` static method

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -31,7 +31,6 @@ use xmtp_mls::{
         group_message::StoredGroupMessage, EncryptedMessageStore, EncryptionKey, StorageOption,
     },
 };
-use xmtp_proto::api_client::XmtpIdentityClient;
 
 pub type RustXmtpClient = MlsClient<TonicApiClient>;
 

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -139,7 +139,7 @@ pub async fn get_inbox_id_for_address(
     let results = api_client
         .get_inbox_ids(vec![account_address.clone()])
         .await
-        .map_err(|err| GenericError::from_error(err))?;
+        .map_err(GenericError::from_error)?;
 
     Ok(results.get(&account_address).cloned())
 }

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -821,8 +821,8 @@ impl FfiGroupPermissions {
 #[cfg(test)]
 mod tests {
     use crate::{
-        inbox_owner::SigningError, logger::FfiLogger, FfiConversationCallback, FfiInboxOwner,
-        LegacyIdentitySource,
+        get_inbox_id_for_address, inbox_owner::SigningError, logger::FfiLogger,
+        FfiConversationCallback, FfiInboxOwner, LegacyIdentitySource,
     };
     use std::{
         env,
@@ -949,6 +949,24 @@ mod tests {
         .unwrap();
         register_client(&ffi_inbox_owner, &client).await;
         return client;
+    }
+
+    #[tokio::test]
+    async fn get_inbox_id() {
+        let client = new_test_client().await;
+        let real_inbox_id = client.inbox_id();
+
+        let from_network = get_inbox_id_for_address(
+            Box::new(MockLogger {}),
+            xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(),
+            false,
+            client.account_address.clone(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(real_inbox_id, from_network);
     }
 
     // Try a query on a test topic, and make sure we get a response


### PR DESCRIPTION
## tl;dr

When creating a V3 client from a platform SDK, you are going to want to name the database file based on the `inbox_id` instead of the wallet address. That means you need to know the `inbox_id` before the client is created.

You can use `get_inbox_id_for_address` to look up an existing value. If none, you can use `generate_inbox_id(address, 0)`