### PR TITLE
Async Transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-barrier"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04b50fe84d0aea412a4e751cb01b9e26e2be533b2708607c2a2a739b192ee45a"
+dependencies = [
+ "async-mutex",
+ "event-listener",
+]
+
+[[package]]
+name = "async-mutex"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1493,6 +1512,12 @@ dependencies = [
  "walkdir",
  "yansi",
 ]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "eyre"
@@ -5856,6 +5881,8 @@ dependencies = [
 name = "xmtp_mls"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "async-barrier",
  "async-trait",
  "chrono",
  "ctor",

--- a/xmtp_mls/Cargo.toml
+++ b/xmtp_mls/Cargo.toml
@@ -57,3 +57,5 @@ tempfile = "3.5.0"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 xmtp_api_grpc = { path = "../xmtp_api_grpc" }
 xmtp_id = { path = "../xmtp_id", features = ["test-utils"] }
+async-barrier = "1.1"
+anyhow.workspace = true

--- a/xmtp_mls/src/groups/message_history.rs
+++ b/xmtp_mls/src/groups/message_history.rs
@@ -299,8 +299,7 @@ mod tests {
     use super::*;
     use xmtp_cryptography::utils::generate_local_wallet;
 
-    use crate::assert_ok;
-    use crate::builder::ClientBuilder;
+    use crate::{assert_ok, builder::ClientBuilder};
 
     #[tokio::test]
     async fn test_allow_history_sync() {

--- a/xmtp_mls/src/storage/encrypted_store/group.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group.rs
@@ -303,9 +303,8 @@ pub(crate) mod tests {
             })
             .unwrap();
 
-            let fetched_group: Result<Option<StoredGroup>, StorageError> =
-                conn.fetch(&test_group.id);
-            assert_ok!(fetched_group, Some(test_group));
+            let fetched_group: Option<StoredGroup> = conn.fetch(&test_group.id).unwrap();
+            assert_eq!(fetched_group, Some(test_group));
         })
     }
 
@@ -398,10 +397,9 @@ pub(crate) mod tests {
             })
             .unwrap();
 
-            let fetched_group: Result<Option<StoredGroup>, StorageError> =
-                conn.fetch(&test_group.id);
-            assert_ok!(fetched_group, Some(test_group));
-            let purpose = fetched_group.unwrap().unwrap().purpose;
+            let fetched_group: Option<StoredGroup> = conn.fetch(&test_group.id).unwrap();
+            assert_eq!(fetched_group, Some(test_group));
+            let purpose = fetched_group.unwrap().purpose;
             assert_eq!(purpose, Purpose::Conversation);
         })
     }

--- a/xmtp_mls/src/storage/encrypted_store/group_intent.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group_intent.rs
@@ -581,11 +581,17 @@ mod tests {
 
             let commit_result = conn.set_group_intent_committed(intent.id);
             assert!(commit_result.is_err());
-            assert_eq!(commit_result.err().unwrap(), StorageError::NotFound);
+            assert!(matches!(
+                commit_result.err().unwrap(),
+                StorageError::NotFound
+            ));
 
             let to_publish_result = conn.set_group_intent_to_publish(intent.id);
             assert!(to_publish_result.is_err());
-            assert_eq!(to_publish_result.err().unwrap(), StorageError::NotFound);
+            assert!(matches!(
+                to_publish_result.err().unwrap(),
+                StorageError::NotFound
+            ));
         })
     }
 

--- a/xmtp_mls/src/storage/encrypted_store/group_message.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group_message.rs
@@ -218,7 +218,7 @@ mod tests {
     fn it_does_not_error_on_empty_messages() {
         with_connection(|conn| {
             let id = vec![0x0];
-            assert_ok!(conn.get_group_message(id), None);
+            assert_eq!(conn.get_group_message(id).unwrap(), None);
         })
     }
 
@@ -233,7 +233,7 @@ mod tests {
             message.store(conn).unwrap();
 
             let stored_message = conn.get_group_message(id);
-            assert_ok!(stored_message, Some(message));
+            assert_eq!(stored_message.unwrap(), Some(message));
         })
     }
 

--- a/xmtp_mls/src/storage/errors.rs
+++ b/xmtp_mls/src/storage/errors.rs
@@ -2,18 +2,18 @@ use thiserror::Error;
 
 use crate::{retry::RetryableError, retryable};
 
-#[derive(Debug, Error, PartialEq)]
+#[derive(Debug, Error)]
 pub enum StorageError {
     #[error("Diesel connection error")]
     DieselConnect(#[from] diesel::ConnectionError),
     #[error("Diesel result error: {0}")]
     DieselResult(#[from] diesel::result::Error),
     #[error("Pool error: {0}")]
-    Pool(String),
+    Pool(#[from] diesel::r2d2::PoolError),
     #[error("Either incorrect encryptionkey or file is not a db: {0}")]
-    DbInit(String),
-    #[error("Store Error")]
-    Store(String),
+    DbInit(#[from] diesel::r2d2::Error),
+    #[error("Error migrating database {0}")]
+    MigrationError(#[from] Box<dyn std::error::Error + Send + Sync>),
     #[error("serialization error")]
     Serialization,
     #[error("deserialization error")]


### PR DESCRIPTION
- adds `async_transaction` fn to `EncryptedMessageStore` which allows running transactions in async context
- refactors some errors on `StorageError` to remove the `String` in place of real error types. This should make backtraces better.
