### PR TITLE
feat: adds ability to load messages into file, encrypt, and decrypt

### DIFF
--- a/xmtp_mls/Cargo.toml
+++ b/xmtp_mls/Cargo.toml
@@ -15,6 +15,8 @@ native = ["libsqlite3-sys/bundled-sqlcipher-vendored-openssl"]
 types = []
 
 [dependencies]
+aes = "0.8.4"
+aes-gcm = { version = "0.10.3", features = ["std"] }
 async-trait.workspace = true
 chrono = { workspace = true }
 diesel = { version = "2.1.3", features = [

--- a/xmtp_mls/src/groups/message_history.rs
+++ b/xmtp_mls/src/groups/message_history.rs
@@ -57,7 +57,7 @@ pub enum MessageHistoryError {
     AesGcm(#[from] aes_gcm::Error),
 }
 
-impl<'c, ApiClient> Client<ApiClient>
+impl<ApiClient> Client<ApiClient>
 where
     ApiClient: XmtpApi,
 {

--- a/xmtp_mls/src/storage/encrypted_store/group_message.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group_message.rs
@@ -7,6 +7,7 @@ use diesel::{
     sql_types::Integer,
     sqlite::Sqlite,
 };
+use serde::Serialize;
 
 use super::{
     db_connection::DbConnection,
@@ -14,7 +15,7 @@ use super::{
 };
 use crate::{impl_fetch, impl_store, StorageError};
 
-#[derive(Insertable, Identifiable, Queryable, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Insertable, Identifiable, Queryable, Eq, PartialEq)]
 #[diesel(table_name = group_messages)]
 #[diesel(primary_key(id))]
 /// Successfully processed messages to be returned to the User.
@@ -38,7 +39,7 @@ pub struct StoredGroupMessage {
 }
 
 #[repr(i32)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, AsExpression, FromSqlRow)]
+#[derive(Debug, Copy, Clone, Serialize, Eq, PartialEq, AsExpression, FromSqlRow)]
 #[diesel(sql_type = Integer)]
 pub enum GroupMessageKind {
     Application = 1,
@@ -69,7 +70,7 @@ where
 }
 
 #[repr(i32)]
-#[derive(Debug, Copy, Clone, FromSqlRow, Eq, PartialEq, AsExpression)]
+#[derive(Debug, Copy, Clone, Serialize, Eq, PartialEq, FromSqlRow, AsExpression)]
 #[diesel(sql_type = Integer)]
 pub enum DeliveryStatus {
     Unpublished = 1,


### PR DESCRIPTION
## Summary

- `Serialize` StoredGroupMessages into JSON to write to a `.jsonl` file
- Encrypts that file via AES-GCM
- Includes functions to decrypt that file

Follow up PR(s) will leverage using these functions to flow the files through the [message-history-server.](https://github.com/xmtp/xmtp-message-history-server)