### PR TITLE
All String lower case

### DIFF
--- a/xmtp_cryptography/src/signature.rs
+++ b/xmtp_cryptography/src/signature.rs
@@ -111,7 +111,7 @@ fn eip_191_prefix(msg: &str) -> String {
 pub fn h160addr_to_string(bytes: H160) -> String {
     let mut s = String::from("0x");
     s.push_str(&hex::encode(bytes));
-    s
+    s.to_lowercase()
 }
 
 // This should ONLY be used for ed25519 keys, not ethereum/secp256k1 keys.

--- a/xmtp_id/src/associations/association_log.rs
+++ b/xmtp_id/src/associations/association_log.rs
@@ -77,7 +77,9 @@ impl IdentityAction for CreateInbox {
 
         let account_address = self.account_address.clone();
         let recovered_signer = self.initial_address_signature.recover_signer().await?;
-        if recovered_signer.ne(&MemberIdentifier::Address(account_address.clone())) {
+        if recovered_signer.ne(&MemberIdentifier::Address(
+            account_address.clone().to_lowercase(),
+        )) {
             return Err(AssociationError::MissingExistingMember);
         }
 
@@ -226,7 +228,9 @@ impl IdentityAction for RevokeAssociation {
         let state_recovery_address = existing_state.recovery_address();
 
         // Ensure this message is signed by the recovery address
-        if recovery_signer.ne(&MemberIdentifier::Address(state_recovery_address.clone())) {
+        if recovery_signer.ne(&MemberIdentifier::Address(
+            state_recovery_address.clone().to_lowercase(),
+        )) {
             return Err(AssociationError::MissingExistingMember);
         }
 

--- a/xmtp_id/src/associations/member.rs
+++ b/xmtp_id/src/associations/member.rs
@@ -14,10 +14,21 @@ impl std::fmt::Display for MemberKind {
 }
 
 /// A MemberIdentifier can be either an Address or an Installation Public Key
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Eq, Hash)]
 pub enum MemberIdentifier {
     Address(String),
     Installation(Vec<u8>),
+}
+
+impl PartialEq<MemberIdentifier> for MemberIdentifier {
+    fn eq(&self, other: &MemberIdentifier) -> bool {
+        self.installation().eq(&other.installation())
+            || self
+                .address()
+                .unwrap()
+                .to_lowercase()
+                .eq(&other.address().unwrap().to_lowercase())
+    }
 }
 
 impl MemberIdentifier {

--- a/xmtp_id/src/associations/member.rs
+++ b/xmtp_id/src/associations/member.rs
@@ -14,21 +14,10 @@ impl std::fmt::Display for MemberKind {
 }
 
 /// A MemberIdentifier can be either an Address or an Installation Public Key
-#[derive(Clone, Debug, Eq, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub enum MemberIdentifier {
     Address(String),
     Installation(Vec<u8>),
-}
-
-impl PartialEq<MemberIdentifier> for MemberIdentifier {
-    fn eq(&self, other: &MemberIdentifier) -> bool {
-        self.installation().eq(&other.installation())
-            || self
-                .address()
-                .unwrap()
-                .to_lowercase()
-                .eq(&other.address().unwrap().to_lowercase())
-    }
 }
 
 impl MemberIdentifier {
@@ -73,7 +62,7 @@ impl std::fmt::Display for MemberIdentifier {
 
 impl From<String> for MemberIdentifier {
     fn from(address: String) -> Self {
-        MemberIdentifier::Address(address)
+        MemberIdentifier::Address(address.to_lowercase())
     }
 }
 

--- a/xmtp_id/src/associations/signature.rs
+++ b/xmtp_id/src/associations/signature.rs
@@ -220,7 +220,10 @@ impl Signature for Erc1271Signature {
             .await?;
         if is_valid {
             Ok(MemberIdentifier::Address(
-                self.account_id.get_account_address().to_string(),
+                self.account_id
+                    .get_account_address()
+                    .to_string()
+                    .to_lowercase(),
             ))
         } else {
             Err(SignatureError::Invalid)
@@ -334,7 +337,7 @@ impl Signature for LegacyDelegatedSignature {
         // }
 
         Ok(MemberIdentifier::Address(
-            signed_public_key.account_address(),
+            signed_public_key.account_address().to_lowercase(),
         ))
     }
 

--- a/xmtp_id/src/associations/state.rs
+++ b/xmtp_id/src/associations/state.rs
@@ -60,7 +60,7 @@ impl AssociationState {
 
     pub fn set_recovery_address(&self, recovery_address: String) -> Self {
         let mut new_state = self.clone();
-        new_state.recovery_address = recovery_address;
+        new_state.recovery_address = recovery_address.to_lowercase();
 
         new_state
     }
@@ -171,7 +171,7 @@ impl AssociationState {
                 members
             },
             seen_signatures: HashSet::new(),
-            recovery_address: account_address,
+            recovery_address: account_address.to_lowercase(),
             inbox_id,
         }
     }

--- a/xmtp_id/src/associations/test_utils.rs
+++ b/xmtp_id/src/associations/test_utils.rs
@@ -21,7 +21,7 @@ pub fn rand_string() -> String {
         .map(char::from)
         .collect();
 
-    v
+    v.to_lowercase()
 }
 
 pub fn rand_u64() -> u64 {

--- a/xmtp_mls/src/identity.rs
+++ b/xmtp_mls/src/identity.rs
@@ -172,7 +172,7 @@ impl Identity {
         let associated_inbox_id = inbox_ids.get(&address);
         let signature_keys = SignatureKeyPair::new(CIPHERSUITE.signature_algorithm())?;
         let installation_public_key = signature_keys.public();
-        let member_identifier: MemberIdentifier = address.clone().into();
+        let member_identifier: MemberIdentifier = address.clone().to_lowercase().into();
 
         if let Some(associated_inbox_id) = associated_inbox_id {
             // If an inbox is associated, we just need to associate the installation key

--- a/xmtp_mls/src/identity_updates.rs
+++ b/xmtp_mls/src/identity_updates.rs
@@ -162,7 +162,7 @@ where
         let nonce = maybe_nonce.unwrap_or(0);
         let inbox_id = generate_inbox_id(&wallet_address, &nonce);
         let installation_public_key = self.identity().installation_keys.public();
-        let member_identifier: MemberIdentifier = wallet_address.into();
+        let member_identifier: MemberIdentifier = wallet_address.to_lowercase().into();
 
         let builder = SignatureRequestBuilder::new(inbox_id);
         let mut signature_request = builder


### PR DESCRIPTION
Make all string lower case to avoid mismatch addresses like `0xABC` and `0xabc`