### PR TITLE
Remove async declaration from group message streaming with callback

### DIFF
--- a/bindings_ffi/Cargo.lock
+++ b/bindings_ffi/Cargo.lock
@@ -39,9 +39,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -5514,6 +5514,8 @@ dependencies = [
 name = "xmtp_mls"
 version = "0.1.0"
 dependencies = [
+ "aes",
+ "aes-gcm",
  "async-trait",
  "chrono",
  "diesel",

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -498,8 +498,7 @@ impl FfiGroup {
             self.group_id.clone(),
             self.created_at_ns,
             move |message| message_callback.on_message(message.into()),
-        )
-        .await?;
+        )?;
 
         Ok(Arc::new(FfiStreamCloser {
             close_fn: stream_closer.close_fn,

--- a/xmtp_mls/src/groups/subscriptions.rs
+++ b/xmtp_mls/src/groups/subscriptions.rs
@@ -80,7 +80,7 @@ impl MlsGroup {
             .await?)
     }
 
-    pub async fn stream_with_callback<ApiClient>(
+    pub fn stream_with_callback<ApiClient>(
         client: Arc<Client<ApiClient>>,
         group_id: Vec<u8>,
         created_at_ns: i64,


### PR DESCRIPTION
# Summary

`MlsGroup::stream_with_callback` does not need to be `async`, which creates issues with `napi-rs` bindings.