### PR TITLE
Adds test for group members function for non group creator client

### DIFF
--- a/xmtp_mls/src/groups/members.rs
+++ b/xmtp_mls/src/groups/members.rs
@@ -44,14 +44,15 @@ impl MlsGroup {
 
         let conn = provider.conn_ref();
         let association_state_map = StoredAssociationState::batch_read_from_cache(conn, &requests)?;
+        let mutable_metadata = self.mutable_metadata()?;
         // TODO: Figure out what to do with missing members from the local DB. Do we go to the network? Load from identity updates?
         // Right now I am just omitting them
         let members = association_state_map
             .into_iter()
             .map(|association_state| {
                 let inbox_id_str = association_state.inbox_id().to_string();
-                let is_admin = self.is_admin(inbox_id_str.clone())?;
-                let is_super_admin = self.is_super_admin(inbox_id_str.clone())?;
+                let is_admin = mutable_metadata.is_admin(&inbox_id_str);
+                let is_super_admin = mutable_metadata.is_super_admin(&inbox_id_str);
                 let permission_level = if is_super_admin {
                     PermissionLevel::SuperAdmin
                 } else if is_admin {

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -925,9 +925,11 @@ mod tests {
         builder::ClientBuilder,
         codecs::{group_updated::GroupUpdatedCodec, ContentCodec},
         groups::{
-            build_group_membership_extension, group_membership::GroupMembership,
-            group_mutable_metadata::MetadataField, members::PermissionLevel, PreconfiguredPolicies,
-            UpdateAdminListType,
+            build_group_membership_extension,
+            group_membership::GroupMembership,
+            group_mutable_metadata::MetadataField,
+            members::{GroupMember, PermissionLevel},
+            PreconfiguredPolicies, UpdateAdminListType,
         },
         storage::{
             group_intent::IntentState,
@@ -1103,11 +1105,27 @@ mod tests {
         assert_eq!(bola_group_name, "New Group");
 
         // Check if both clients can see the members correctly
-        let amal_members = amal_group.members().unwrap();
-        let bola_members = bola_group.members().unwrap();
+        let amal_members: Vec<GroupMember> = amal_group.members().unwrap();
+        let bola_members: Vec<GroupMember> = bola_group.members().unwrap();
 
         assert_eq!(amal_members.len(), 2);
-        assert_eq!(bola_members.len(), 2); // failing here, see len == 0
+        assert_eq!(bola_members.len(), 2);
+
+        for member in &amal_members {
+            if member.inbox_id == amal.inbox_id() {
+                assert_eq!(
+                    member.permission_level,
+                    PermissionLevel::SuperAdmin,
+                    "Amal should be a super admin"
+                );
+            } else if member.inbox_id == bola.inbox_id() {
+                assert_eq!(
+                    member.permission_level,
+                    PermissionLevel::Member,
+                    "Bola should be a member"
+                );
+            }
+        }
     }
 
     // Amal and Bola will both try and add Charlie from the same epoch.

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -1085,7 +1085,10 @@ mod tests {
         let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
         let amal_group = amal.create_group(None).unwrap();
-        amal_group.add_members_by_inbox_id(&amal, vec![bola.inbox_id()]).await.unwrap();
+        amal_group
+            .add_members_by_inbox_id(&amal, vec![bola.inbox_id()])
+            .await
+            .unwrap();
 
         // Get bola's version of the same group
         let bola_groups = bola.sync_welcomes().await.unwrap();
@@ -1104,7 +1107,7 @@ mod tests {
         let bola_members = bola_group.members().unwrap();
 
         assert_eq!(amal_members.len(), 2);
-        assert_eq!(bola_members.len(), 2); // failing here!
+        assert_eq!(bola_members.len(), 2); // failing here, see len == 0
     }
 
     // Amal and Bola will both try and add Charlie from the same epoch.


### PR DESCRIPTION
Adds a test for #769 

Cherry-picked commits from https://github.com/xmtp/libxmtp/pull/768, which was targeting a branch that got squashed into `main`. Also removed some unwraps. 

#769 looks like it was indeed fixed by https://github.com/xmtp/libxmtp/pull/781. Seems like a good idea to add the test so any breaks will be caught in the future.

