### PR TITLE
Break up large requests to GetIdentityUpdates and do in parallel

### DIFF
--- a/xmtp_mls/src/api/identity.rs
+++ b/xmtp_mls/src/api/identity.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use super::{ApiClientWrapper, WrappedApiError};
 use crate::XmtpApi;
+use futures::future::try_join_all;
 use xmtp_id::{
     associations::{DeserializationError, IdentityUpdate},
     InboxId,
@@ -10,9 +11,11 @@ use xmtp_proto::xmtp::identity::api::v1::{
     get_identity_updates_request::Request as GetIdentityUpdatesV2RequestProto,
     get_identity_updates_response::IdentityUpdateLog,
     get_inbox_ids_request::Request as GetInboxIdsRequestProto,
-    GetIdentityUpdatesRequest as GetIdentityUpdatesV2Request, GetInboxIdsRequest,
-    PublishIdentityUpdateRequest,
+    GetIdentityUpdatesRequest as GetIdentityUpdatesV2Request, GetIdentityUpdatesResponse,
+    GetInboxIdsRequest, PublishIdentityUpdateRequest,
 };
+
+const GET_IDENTITY_UPDATES_CHUNK_SIZE: usize = 50;
 
 /// A filter for querying identity updates. `sequence_id` is the starting sequence, and only later updates will be returned.
 pub struct GetIdentityUpdatesV2Filter {
@@ -20,10 +23,10 @@ pub struct GetIdentityUpdatesV2Filter {
     pub sequence_id: Option<u64>,
 }
 
-impl From<GetIdentityUpdatesV2Filter> for GetIdentityUpdatesV2RequestProto {
-    fn from(filter: GetIdentityUpdatesV2Filter) -> Self {
+impl From<&GetIdentityUpdatesV2Filter> for GetIdentityUpdatesV2RequestProto {
+    fn from(filter: &GetIdentityUpdatesV2Filter) -> Self {
         Self {
-            inbox_id: filter.inbox_id,
+            inbox_id: filter.inbox_id.clone(),
             sequence_id: filter.sequence_id.unwrap_or(0),
         }
     }
@@ -79,30 +82,37 @@ where
         &self,
         filters: Vec<GetIdentityUpdatesV2Filter>,
     ) -> Result<InboxUpdateMap, WrappedApiError> {
-        let result = self
-            .api_client
-            .get_identity_updates_v2(GetIdentityUpdatesV2Request {
-                requests: filters.into_iter().map(|filter| filter.into()).collect(),
-            })
-            .await?;
+        let chunks = filters.chunks(GET_IDENTITY_UPDATES_CHUNK_SIZE);
 
-        result
-            .responses
-            .into_iter()
-            .map(|response| {
-                let deserialized_updates = response
-                    .updates
-                    .into_iter()
-                    .map(|update| {
-                        let deserialized: InboxUpdate = update.try_into()?;
-
-                        Ok(deserialized)
+        let chunked_results: Result<Vec<GetIdentityUpdatesResponse>, WrappedApiError> =
+            try_join_all(chunks.map(|chunk| async move {
+                let result = self
+                    .api_client
+                    .get_identity_updates_v2(GetIdentityUpdatesV2Request {
+                        requests: chunk.into_iter().map(|filter| filter.into()).collect(),
                     })
-                    .collect::<Result<Vec<InboxUpdate>, WrappedApiError>>()?;
+                    .await?;
 
-                Ok((response.inbox_id, deserialized_updates))
+                Ok(result)
+            }))
+            .await;
+
+        let inbox_map = chunked_results?
+            .into_iter()
+            .flat_map(|response| {
+                response.responses.into_iter().map(|item| {
+                    let deserialized_updates = item
+                        .updates
+                        .into_iter()
+                        .map(|update| update.try_into().map_err(WrappedApiError::from))
+                        .collect::<Result<Vec<InboxUpdate>, WrappedApiError>>()?;
+
+                    Ok((item.inbox_id, deserialized_updates))
+                })
             })
-            .collect::<Result<InboxUpdateMap, WrappedApiError>>()
+            .collect::<Result<InboxUpdateMap, WrappedApiError>>()?;
+
+        Ok(inbox_map)
     }
 
     pub async fn get_inbox_ids(

--- a/xmtp_mls/src/api/identity.rs
+++ b/xmtp_mls/src/api/identity.rs
@@ -89,7 +89,7 @@ where
                 let result = self
                     .api_client
                     .get_identity_updates_v2(GetIdentityUpdatesV2Request {
-                        requests: chunk.into_iter().map(|filter| filter.into()).collect(),
+                        requests: chunk.iter().map(|filter| filter.into()).collect(),
                     })
                     .await?;
 


### PR DESCRIPTION
## tl;dr

When querying `GetIdentityUpdates` for a large group, the list of inboxes requested might be really long. This breaks the list of requests into groups of 50 and does them all in parallel.