### PR TITLE
(tweak) Make ciphersuite consistent

### DIFF
--- a/mls_validation_service/src/handlers.rs
+++ b/mls_validation_service/src/handlers.rs
@@ -418,7 +418,8 @@ mod tests {
 
     use super::*;
 
-    const CIPHERSUITE: Ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+    const CIPHERSUITE: Ciphersuite =
+        Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519;
 
     fn generate_identity() -> (Vec<u8>, SignatureKeyPair, String) {
         let rng = &mut rand::thread_rng();


### PR DESCRIPTION
This is the ciphersuite defined in the unit tests of the validation service. It's inconsistent with the one we're using in production currently: https://github.com/xmtp/libxmtp/blob/945bfd32c0885984f02a2671a556dd46d71dfe43/xmtp_mls/src/configuration.rs#L5

Just tidying to avoid confusion