### PR TITLE
Enable legacy key when `account_address` is already associated with an `inbox_id`

### DIFF
--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -301,7 +301,7 @@ mod tests {
         let legacy_account_address = "0x0bd00b21af9a2d538103c3aaf95cb507f8af1b28";
         let legacy_key = hex::decode("0880bdb7a8b3f6ede81712220a20ad528ea38ce005268c4fb13832cfed13c2b2219a378e9099e48a38a30d66ef991a96010a4c08aaa8e6f5f9311a430a41047fd90688ca39237c2899281cdf2756f9648f93767f91c0e0f74aed7e3d3a8425e9eaa9fa161341c64aa1c782d004ff37ffedc887549ead4a40f18d1179df9dff124612440a403c2cb2338fb98bfe5f6850af11f6a7e97a04350fc9d37877060f8d18e8f66de31c77b3504c93cf6a47017ea700a48625c4159e3f7e75b52ff4ea23bc13db77371001").unwrap();
         let identity_strategy = IdentityStrategy::CreateIfNotFound(
-            generate_inbox_id(&legacy_account_address, &0),
+            generate_inbox_id(legacy_account_address, &0),
             legacy_account_address.to_string(),
             0,
             Some(legacy_key),
@@ -318,15 +318,17 @@ mod tests {
         assert!(signature_request.is_ready());
         client1.register_identity(signature_request).await.unwrap();
 
-        let client2 = ClientBuilder::new(identity_strategy)
+        let client2: Client<GrpcClient> = ClientBuilder::new(identity_strategy)
             .temp_store()
             .local_grpc()
             .await
             .build()
             .await
             .unwrap();
-
+        let signature_request = client2.context.signature_request().unwrap();
+        assert!(signature_request.is_ready());
         assert!(client1.inbox_id() == client2.inbox_id());
+        client2.register_identity(signature_request).await.unwrap(); // second installation key is registered
     }
 
     // Should return error if inbox associated with given account_address doesn't match the provided one.

--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -296,7 +296,6 @@ mod tests {
     }
 
     // Create two clients sequencially with the same inbox id & legacy key
-    //
     #[tokio::test]
     async fn test_twice_client_creation() {
         let legacy_account_address = "0x0bd00b21af9a2d538103c3aaf95cb507f8af1b28";

--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -295,9 +295,9 @@ mod tests {
         }
     }
 
-    // Create two clients sequencially with the same inbox id & legacy key
+    // Create two clients sequencially with the same inbox id & legacy key.
     #[tokio::test]
-    async fn test_twice_client_creation() {
+    async fn test_client_creation_twice() {
         let legacy_account_address = "0x0bd00b21af9a2d538103c3aaf95cb507f8af1b28";
         let legacy_key = hex::decode("0880bdb7a8b3f6ede81712220a20ad528ea38ce005268c4fb13832cfed13c2b2219a378e9099e48a38a30d66ef991a96010a4c08aaa8e6f5f9311a430a41047fd90688ca39237c2899281cdf2756f9648f93767f91c0e0f74aed7e3d3a8425e9eaa9fa161341c64aa1c782d004ff37ffedc887549ead4a40f18d1179df9dff124612440a403c2cb2338fb98bfe5f6850af11f6a7e97a04350fc9d37877060f8d18e8f66de31c77b3504c93cf6a47017ea700a48625c4159e3f7e75b52ff4ea23bc13db77371001").unwrap();
         let identity_strategy = IdentityStrategy::CreateIfNotFound(
@@ -307,13 +307,16 @@ mod tests {
             Some(legacy_key),
         );
 
-        let client1 = ClientBuilder::new(identity_strategy.clone())
+        let client1: Client<GrpcClient> = ClientBuilder::new(identity_strategy.clone())
             .temp_store()
             .local_grpc()
             .await
             .build()
             .await
             .unwrap();
+        let signature_request = client1.context.signature_request().unwrap();
+        assert!(signature_request.is_ready());
+        client1.register_identity(signature_request).await.unwrap();
 
         let client2 = ClientBuilder::new(identity_strategy)
             .temp_store()

--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -295,6 +295,38 @@ mod tests {
         }
     }
 
+    // Create two clients sequencially with the same inbox id & legacy key
+    //
+    #[tokio::test]
+    async fn test_twice_client_creation() {
+        let legacy_account_address = "0x0bd00b21af9a2d538103c3aaf95cb507f8af1b28";
+        let legacy_key = hex::decode("0880bdb7a8b3f6ede81712220a20ad528ea38ce005268c4fb13832cfed13c2b2219a378e9099e48a38a30d66ef991a96010a4c08aaa8e6f5f9311a430a41047fd90688ca39237c2899281cdf2756f9648f93767f91c0e0f74aed7e3d3a8425e9eaa9fa161341c64aa1c782d004ff37ffedc887549ead4a40f18d1179df9dff124612440a403c2cb2338fb98bfe5f6850af11f6a7e97a04350fc9d37877060f8d18e8f66de31c77b3504c93cf6a47017ea700a48625c4159e3f7e75b52ff4ea23bc13db77371001").unwrap();
+        let identity_strategy = IdentityStrategy::CreateIfNotFound(
+            generate_inbox_id(&legacy_account_address, &0),
+            legacy_account_address.to_string(),
+            0,
+            Some(legacy_key),
+        );
+
+        let client1 = ClientBuilder::new(identity_strategy.clone())
+            .temp_store()
+            .local_grpc()
+            .await
+            .build()
+            .await
+            .unwrap();
+
+        let client2 = ClientBuilder::new(identity_strategy)
+            .temp_store()
+            .local_grpc()
+            .await
+            .build()
+            .await
+            .unwrap();
+
+        assert!(client1.inbox_id() == client2.inbox_id());
+    }
+
     // Should return error if inbox associated with given account_address doesn't match the provided one.
     #[tokio::test]
     async fn api_identity_mismatch() {

--- a/xmtp_mls/src/identity.rs
+++ b/xmtp_mls/src/identity.rs
@@ -176,10 +176,10 @@ impl Identity {
     /// Create a new [Identity] instance.
     ///
     /// If the address is already associated with an inbox_id, the existing inbox_id will be used.
-    /// Prioritize legacy key if provided, otherwise will need to require a signature from wallet.
+    /// Prioritize legacy key if provided, otherwise identity.signature_request is not ready and needs to be signed from users.
     ///
     /// If the address is NOT associated with an inbox_id, a new inbox_id will be generated.
-    /// Prioritize legacy key if provided, otherwise will need to require a signature from wallet.
+    /// Prioritize legacy key if provided, otherwise identity.signature_request is not ready and needs to be signed from users.
     pub(crate) async fn new<ApiClient: XmtpMlsClient + XmtpIdentityClient>(
         inbox_id: InboxId,
         address: String,

--- a/xmtp_mls/src/identity.rs
+++ b/xmtp_mls/src/identity.rs
@@ -271,14 +271,11 @@ impl Identity {
                 ))
                 .await?;
 
-            let identity_update = signature_request.build_identity_update()?;
-            api_client.publish_identity_update(identity_update).await?;
-
             let identity = Self {
                 inbox_id: inbox_id.clone(),
                 installation_keys: signature_keys,
                 credential: create_credential(inbox_id)?,
-                signature_request: None,
+                signature_request: Some(signature_request),
             };
             Ok(identity)
         } else {

--- a/xmtp_mls/src/identity.rs
+++ b/xmtp_mls/src/identity.rs
@@ -83,7 +83,6 @@ impl IdentityStrategy {
                 legacy_signed_private_key,
             ) => {
                 if let Some(stored_identity) = stored_identity {
-                    info!("Calling Identity::new");
                     if inbox_id != stored_identity.inbox_id {
                         return Err(IdentityError::InboxIdMismatch {
                             id: inbox_id.clone(),
@@ -93,7 +92,6 @@ impl IdentityStrategy {
 
                     Ok(stored_identity)
                 } else {
-                    info!("Calling Identity::new");
                     Identity::new(
                         inbox_id,
                         address,


### PR DESCRIPTION
Now, no signature request when creating clients if legacy key is provided.