### PR TITLE
Register legacy keys on first use

### DIFF
--- a/xmtp_mls/src/identity.rs
+++ b/xmtp_mls/src/identity.rs
@@ -5,7 +5,6 @@ use crate::storage::db_connection::DbConnection;
 use crate::storage::identity::StoredIdentity;
 use crate::storage::sql_key_store::{MemoryStorageError, KEY_PACKAGE_REFERENCES};
 use crate::storage::EncryptedMessageStore;
-use crate::{api, Fetch, Store};
 use crate::{
     api::{ApiClientWrapper, WrappedApiError},
     configuration::{CIPHERSUITE, GROUP_MEMBERSHIP_EXTENSION_ID, MUTABLE_METADATA_EXTENSION_ID},
@@ -13,6 +12,7 @@ use crate::{
     xmtp_openmls_provider::XmtpOpenMlsProvider,
     XmtpApi,
 };
+use crate::{Fetch, Store};
 use ed25519_dalek::SigningKey;
 use ethers::signers::WalletError;
 use log::debug;


### PR DESCRIPTION
## tl;dr

When creating a client with legacy keys there are no signature requests, so we need to call `identity.register()` after the identity updates are published as part of `Identity::new()`. Otherwise it will leave clients in a half-registered state with no way for callers to fix.

## Next up

We need tests that generate new legacy keys (not just static fixtures) to properly test this case. We should add those next.