### PR TITLE
Remove the default New Group name

### DIFF
--- a/xmtp_mls/src/configuration.rs
+++ b/xmtp_mls/src/configuration.rs
@@ -37,5 +37,5 @@ pub const MUTABLE_METADATA_EXTENSION_ID: u16 = 0xff00;
 pub const GROUP_MEMBERSHIP_EXTENSION_ID: u16 = 0xff01;
 pub const GROUP_PERMISSIONS_EXTENSION_ID: u16 = 0xff02;
 
-pub const DEFAULT_GROUP_NAME: &str = "New Group";
-pub const DEFAULT_GROUP_DESCRIPTION: &str = "New Group Description";
+pub const DEFAULT_GROUP_NAME: &str = "";
+pub const DEFAULT_GROUP_DESCRIPTION: &str = "";

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -1103,7 +1103,7 @@ mod tests {
 
         // Verify bola can see the group name
         let bola_group_name = bola_group.group_name().unwrap();
-        assert_eq!(bola_group_name, "New Group");
+        assert_eq!(bola_group_name, "");
 
         // Check if both clients can see the members correctly
         let amal_members: Vec<GroupMember> = amal_group.members().unwrap();
@@ -1570,7 +1570,7 @@ mod tests {
             .attributes
             .get(&MetadataField::GroupName.to_string())
             .unwrap()
-            .eq("New Group"));
+            .eq(""));
 
         // Add bola to the group
         amal_group
@@ -1587,7 +1587,7 @@ mod tests {
             .attributes
             .get(&MetadataField::GroupName.to_string())
             .unwrap()
-            .eq("New Group"));
+            .eq(""));
 
         // Update group name
         amal_group
@@ -1645,7 +1645,7 @@ mod tests {
             .attributes
             .get(&MetadataField::GroupName.to_string())
             .unwrap()
-            .eq("New Group"));
+            .eq(""));
 
         // Add bola to the group
         amal_group
@@ -1662,7 +1662,7 @@ mod tests {
             .attributes
             .get(&MetadataField::GroupName.to_string())
             .unwrap()
-            .eq("New Group"));
+            .eq(""));
 
         // Update group name
         amal_group


### PR DESCRIPTION
Fixes https://github.com/xmtp/libxmtp/issues/816

Set the group name to an empty string by default so it's easier to see if a group name has been set or not.

From proto3 documentation
`In proto3, if a string field is not set, it defaults to an empty string. You don't need to explicitly mark a string as optional because all fields can be unset.`