### PR TITLE
Clear pending commit state after commit validation fails

### DIFF
--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -2030,4 +2030,49 @@ mod tests {
 
         assert_eq!(protected_metadata.creator_inbox_id, amal.inbox_id());
     }
+
+    #[tokio::test]
+    async fn test_can_update_gce_after_failed_commit() {
+        // Step 1: Amal creates a group
+        let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
+        let policies = Some(PreconfiguredPolicies::AllMembers);
+        let amal_group = amal.create_group(policies).unwrap();
+        amal_group.sync(&amal).await.unwrap();
+
+        // Step 2:  Amal adds Bola to the group
+        let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
+        amal_group.add_members_by_inbox_id(&amal, vec![bola.inbox_id()]).await.unwrap();
+
+        // Step 3: Verify that Bola can update the group name, and amal sees the update
+        bola.sync_welcomes().await.unwrap();
+        let bola_groups = bola.find_groups(None, None, None, None).unwrap();
+        let bola_group: &MlsGroup = bola_groups.first().unwrap();
+        bola_group.sync(&bola).await.unwrap();
+        bola_group.update_group_name(&bola, "Name Update 1".to_string()).await.unwrap();
+        amal_group.sync(&amal).await.unwrap();
+        let name = amal_group.group_name().unwrap();
+        assert_eq!(name, "Name Update 1");
+
+        // Step 4:  Bola attempts an action that they do not have permissions for like add admin, fails as expected
+        let result = bola_group.update_admin_list(&bola, UpdateAdminListType::Add, bola.inbox_id()).await;
+        if let Err(e) = &result {
+            eprintln!("Error updating admin list: {:?}", e);
+        }
+        // Step 5: Now have Bola attempt to update the group name again => It is failing for some reason
+        let result = bola_group.update_group_name(&bola, "Name Update 2".to_string()).await;
+        if let Err(e) = &result {
+            eprintln!("FAILING WHEN UPDATING GROUP NAME AFTER FAILED UPDATE COMMIT: {:?}", e);
+        }
+
+        // Step 6: Verify that the group name has been updated
+        amal_group.sync(&amal).await.unwrap();
+        let binding = amal_group.mutable_metadata().expect("msg");
+        let amal_group_name: &String = binding
+            .attributes
+            .get(&MetadataField::GroupName.to_string())
+            .unwrap();
+        assert_eq!(amal_group_name, "Name Update 2"); // <= Currently failing because error above on second name update is unexpectedly showing up
+
+        // If you comment out step 4, the test passes
+    }
 }

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -2041,38 +2041,51 @@ mod tests {
 
         // Step 2:  Amal adds Bola to the group
         let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
-        amal_group.add_members_by_inbox_id(&amal, vec![bola.inbox_id()]).await.unwrap();
+        amal_group
+            .add_members_by_inbox_id(&amal, vec![bola.inbox_id()])
+            .await
+            .unwrap();
 
         // Step 3: Verify that Bola can update the group name, and amal sees the update
         bola.sync_welcomes().await.unwrap();
         let bola_groups = bola.find_groups(None, None, None, None).unwrap();
         let bola_group: &MlsGroup = bola_groups.first().unwrap();
         bola_group.sync(&bola).await.unwrap();
-        bola_group.update_group_name(&bola, "Name Update 1".to_string()).await.unwrap();
+        bola_group
+            .update_group_name(&bola, "Name Update 1".to_string())
+            .await
+            .unwrap();
         amal_group.sync(&amal).await.unwrap();
         let name = amal_group.group_name().unwrap();
         assert_eq!(name, "Name Update 1");
 
         // Step 4:  Bola attempts an action that they do not have permissions for like add admin, fails as expected
-        let result = bola_group.update_admin_list(&bola, UpdateAdminListType::Add, bola.inbox_id()).await;
+        let result = bola_group
+            .update_admin_list(&bola, UpdateAdminListType::Add, bola.inbox_id())
+            .await;
         if let Err(e) = &result {
             eprintln!("Error updating admin list: {:?}", e);
         }
         // Step 5: Now have Bola attempt to update the group name again => It is failing for some reason
-        let result = bola_group.update_group_name(&bola, "Name Update 2".to_string()).await;
-        if let Err(e) = &result {
-            eprintln!("FAILING WHEN UPDATING GROUP NAME AFTER FAILED UPDATE COMMIT: {:?}", e);
-        }
+        bola_group
+            .update_group_name(&bola, "Name Update 2".to_string())
+            .await
+            .unwrap();
 
-        // Step 6: Verify that the group name has been updated
+        // Step 6: Verify that both clients can sync without error and that the group name has been updated
         amal_group.sync(&amal).await.unwrap();
+        bola_group.sync(&bola).await.unwrap();
         let binding = amal_group.mutable_metadata().expect("msg");
         let amal_group_name: &String = binding
             .attributes
             .get(&MetadataField::GroupName.to_string())
             .unwrap();
-        assert_eq!(amal_group_name, "Name Update 2"); // <= Currently failing because error above on second name update is unexpectedly showing up
-
-        // If you comment out step 4, the test passes
+        assert_eq!(amal_group_name, "Name Update 2");
+        let binding = bola_group.mutable_metadata().expect("msg");
+        let bola_group_name: &String = binding
+            .attributes
+            .get(&MetadataField::GroupName.to_string())
+            .unwrap();
+        assert_eq!(bola_group_name, "Name Update 2");
     }
 }

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -2066,7 +2066,7 @@ mod tests {
         if let Err(e) = &result {
             eprintln!("Error updating admin list: {:?}", e);
         }
-        // Step 5: Now have Bola attempt to update the group name again => It is failing for some reason
+        // Step 5: Now have Bola attempt to update the group name again
         bola_group
             .update_group_name(&bola, "Name Update 2".to_string())
             .await

--- a/xmtp_mls/src/groups/sync.rs
+++ b/xmtp_mls/src/groups/sync.rs
@@ -14,13 +14,10 @@ use super::{
     GroupError, MlsGroup,
 };
 use crate::{
-    client::{self, MessageProcessingError},
+    client::MessageProcessingError,
     codecs::{group_updated::GroupUpdatedCodec, ContentCodec},
     configuration::{DELIMITER, MAX_INTENT_PUBLISH_ATTEMPTS, UPDATE_INSTALLATIONS_INTERVAL_NS},
-    groups::{
-        intents::UpdateMetadataIntentData,
-        validated_commit::{CommitValidationError, ValidatedCommit},
-    },
+    groups::{intents::UpdateMetadataIntentData, validated_commit::ValidatedCommit},
     hpke::{encrypt_welcome, HpkeError},
     identity::parse_credential,
     identity_updates::load_identity_updates,
@@ -234,9 +231,7 @@ impl MlsGroup {
                             ))
                         }
                     }
-                    return Err(client::MessageProcessingError::CommitValidation(
-                        CommitValidationError::InsufficientPermissions,
-                    ));
+                    return Ok(());
                 }
 
                 let validated_commit = maybe_validated_commit.unwrap();

--- a/xmtp_mls/src/groups/sync.rs
+++ b/xmtp_mls/src/groups/sync.rs
@@ -156,8 +156,9 @@ impl MlsGroup {
                             "not retrying intent ID {}. since it is in state Error",
                             intent.id,
                         );
-                        return Err(last_err
-                            .unwrap_or(GroupError::Generic("Group intent could not be committed".to_string())));
+                        return Err(last_err.unwrap_or(GroupError::Generic(
+                            "Group intent could not be committed".to_string(),
+                        )));
                     }
                     log::warn!(
                         "retrying intent ID {}. intent currently in state {:?}",

--- a/xmtp_mls/src/groups/sync.rs
+++ b/xmtp_mls/src/groups/sync.rs
@@ -156,7 +156,8 @@ impl MlsGroup {
                             "not retrying intent ID {}. since it is in state Error",
                             intent.id,
                         );
-                        return Ok(());
+                        return Err(last_err
+                            .unwrap_or(GroupError::Generic("Group intent could not be committed".to_string())));
                     }
                     log::warn!(
                         "retrying intent ID {}. intent currently in state {:?}",

--- a/xmtp_mls/src/storage/encrypted_store/group_intent.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group_intent.rs
@@ -193,13 +193,11 @@ impl DbConnection {
         }
     }
 
-    // Set the intent with the given ID to `Committed`
+    // Set the intent with the given ID to `Error`
     pub fn set_group_intent_error(&self, intent_id: ID) -> Result<(), StorageError> {
         let res = self.raw_query(|conn| {
             diesel::update(dsl::group_intents)
                 .filter(dsl::id.eq(intent_id))
-                // State machine requires that the only valid state transition to Committed is from
-                // Published
                 .set(dsl::state.eq(IntentState::Error))
                 .execute(conn)
         })?;


### PR DESCRIPTION
Fixes #805 

Changes for preventing groups being stuck in a pending-commit state:
1. when a staged commit fails validation, clear pending commit state and set intent state to failed =>
https://github.com/xmtp/libxmtp/pull/820/files#diff-202bbf85eac4d977447dc52cf6f01c12b56e9b8e72e579844bfa5bc43862acecR233-R243
3. do not return an error for functions passed into `process_for_id` if they contain db transactions you do not wish to be rolled back
https://github.com/xmtp/libxmtp/pull/820/files#diff-202bbf85eac4d977447dc52cf6f01c12b56e9b8e72e579844bfa5bc43862acecR244-R246
4. do not retry intents with `IntentState::Error`, instead return an error
https://github.com/xmtp/libxmtp/pull/820/files#diff-202bbf85eac4d977447dc52cf6f01c12b56e9b8e72e579844bfa5bc43862acecR154-R161