### PR TITLE
Remove non-zero nonce restriction for client creation that doesn't use legacy key

### DIFF
--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -266,39 +266,36 @@ mod tests {
             IdentityStrategyTestCase {
                 strategy: {
                     let (legacy_key, legacy_account_address) = generate_random_legacy_key().await;
-                    let strategy = IdentityStrategy::CreateIfNotFound(
+                    IdentityStrategy::CreateIfNotFound(
                         generate_inbox_id(&legacy_account_address, &1),
                         legacy_account_address.clone(),
                         1,
                         Some(legacy_key),
-                    );
-                    strategy
+                    )
                 },
                 err: Some("Nonce must be 0 if legacy key is provided".to_string()),
             },
             IdentityStrategyTestCase {
                 strategy: {
                     let (legacy_key, legacy_account_address) = generate_random_legacy_key().await;
-                    let strategy = IdentityStrategy::CreateIfNotFound(
+                    IdentityStrategy::CreateIfNotFound(
                         generate_inbox_id(&legacy_account_address, &1),
                         legacy_account_address.clone(),
                         0,
                         Some(legacy_key),
-                    );
-                    strategy
+                    )
                 },
                 err: Some("Inbox ID doesn't match nonce & address".to_string()),
             },
             IdentityStrategyTestCase {
                 strategy: {
                     let (legacy_key, legacy_account_address) = generate_random_legacy_key().await;
-                    let strategy = IdentityStrategy::CreateIfNotFound(
+                    IdentityStrategy::CreateIfNotFound(
                         generate_inbox_id(&legacy_account_address, &0),
                         legacy_account_address.clone(),
                         0,
                         Some(legacy_key),
-                    );
-                    strategy
+                    )
                 },
                 err: None,
             },
@@ -320,13 +317,12 @@ mod tests {
                 strategy: {
                     let nonce = 1;
                     let account_address = generate_local_wallet().get_address();
-                    let strategy = IdentityStrategy::CreateIfNotFound(
+                    IdentityStrategy::CreateIfNotFound(
                         generate_inbox_id(&account_address, &nonce),
                         account_address.clone(),
                         nonce,
                         None,
-                    );
-                    strategy
+                    )
                 },
                 err: None,
             },
@@ -334,13 +330,12 @@ mod tests {
                 strategy: {
                     let nonce = 0;
                     let account_address = generate_local_wallet().get_address();
-                    let strategy = IdentityStrategy::CreateIfNotFound(
+                    IdentityStrategy::CreateIfNotFound(
                         generate_inbox_id(&account_address, &nonce),
                         account_address.clone(),
                         nonce,
                         None,
-                    );
-                    strategy
+                    )
                 },
                 err: None,
             },

--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -256,11 +256,6 @@ mod tests {
     // Test client creation using various identity strategies that creates new inboxes
     #[tokio::test]
     async fn test_client_creation() {
-        let (legacy_key, legacy_account_address) = generate_random_legacy_key().await;
-        let non_legacy_account_address = generate_local_wallet().get_address();
-        let nonce_for_legacy = 0;
-        let nonce_for_non_legacy = rand_u64();
-
         struct IdentityStrategyTestCase {
             strategy: IdentityStrategy,
             err: Option<String>,
@@ -269,58 +264,84 @@ mod tests {
         let identity_strategies_test_cases = vec![
             // legacy cases
             IdentityStrategyTestCase {
-                strategy: IdentityStrategy::CreateIfNotFound(
-                    generate_inbox_id(&legacy_account_address, &111),
-                    legacy_account_address.to_string(),
-                    111,
-                    Some(legacy_key.clone()),
-                ),
+                strategy: {
+                    let (legacy_key, legacy_account_address) = generate_random_legacy_key().await;
+                    let strategy = IdentityStrategy::CreateIfNotFound(
+                        generate_inbox_id(&legacy_account_address, &1),
+                        legacy_account_address.clone(),
+                        1,
+                        Some(legacy_key),
+                    );
+                    strategy
+                },
                 err: Some("Nonce must be 0 if legacy key is provided".to_string()),
             },
             IdentityStrategyTestCase {
-                strategy: IdentityStrategy::CreateIfNotFound(
-                    generate_inbox_id(&legacy_account_address, &111),
-                    legacy_account_address.to_string(),
-                    nonce_for_legacy,
-                    Some(legacy_key.clone()),
-                ),
+                strategy: {
+                    let (legacy_key, legacy_account_address) = generate_random_legacy_key().await;
+                    let strategy = IdentityStrategy::CreateIfNotFound(
+                        generate_inbox_id(&legacy_account_address, &1),
+                        legacy_account_address.clone(),
+                        0,
+                        Some(legacy_key),
+                    );
+                    strategy
+                },
                 err: Some("Inbox ID doesn't match nonce & address".to_string()),
             },
             IdentityStrategyTestCase {
-                strategy: IdentityStrategy::CreateIfNotFound(
-                    generate_inbox_id(&legacy_account_address, &nonce_for_legacy),
-                    legacy_account_address.to_string(),
-                    nonce_for_legacy,
-                    Some(legacy_key.clone()),
-                ),
+                strategy: {
+                    let (legacy_key, legacy_account_address) = generate_random_legacy_key().await;
+                    let strategy = IdentityStrategy::CreateIfNotFound(
+                        generate_inbox_id(&legacy_account_address, &0),
+                        legacy_account_address.clone(),
+                        0,
+                        Some(legacy_key),
+                    );
+                    strategy
+                },
                 err: None,
             },
             // non-legacy cases
             IdentityStrategyTestCase {
-                strategy: IdentityStrategy::CreateIfNotFound(
-                    generate_inbox_id(&non_legacy_account_address, &0),
-                    non_legacy_account_address.clone(),
-                    0,
-                    None,
-                ),
-                err: Some("Nonce must be non-zero if legacy key is not provided".to_string()),
-            },
-            IdentityStrategyTestCase {
-                strategy: IdentityStrategy::CreateIfNotFound(
-                    generate_inbox_id(&non_legacy_account_address, &0),
-                    non_legacy_account_address.clone(),
-                    nonce_for_non_legacy,
-                    None,
-                ),
+                strategy: {
+                    let account_address = generate_local_wallet().get_address();
+                    let strategy = IdentityStrategy::CreateIfNotFound(
+                        generate_inbox_id(&account_address, &1),
+                        account_address.clone(),
+                        0,
+                        None,
+                    );
+                    strategy
+                },
                 err: Some("Inbox ID doesn't match nonce & address".to_string()),
             },
             IdentityStrategyTestCase {
-                strategy: IdentityStrategy::CreateIfNotFound(
-                    generate_inbox_id(&non_legacy_account_address, &nonce_for_non_legacy),
-                    non_legacy_account_address.clone(),
-                    nonce_for_non_legacy,
-                    None,
-                ),
+                strategy: {
+                    let nonce = 1;
+                    let account_address = generate_local_wallet().get_address();
+                    let strategy = IdentityStrategy::CreateIfNotFound(
+                        generate_inbox_id(&account_address, &nonce),
+                        account_address.clone(),
+                        nonce,
+                        None,
+                    );
+                    strategy
+                },
+                err: None,
+            },
+            IdentityStrategyTestCase {
+                strategy: {
+                    let nonce = 0;
+                    let account_address = generate_local_wallet().get_address();
+                    let strategy = IdentityStrategy::CreateIfNotFound(
+                        generate_inbox_id(&account_address, &nonce),
+                        account_address.clone(),
+                        nonce,
+                        None,
+                    );
+                    strategy
+                },
                 err: None,
             },
         ];

--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -303,13 +303,12 @@ mod tests {
             IdentityStrategyTestCase {
                 strategy: {
                     let account_address = generate_local_wallet().get_address();
-                    let strategy = IdentityStrategy::CreateIfNotFound(
+                    IdentityStrategy::CreateIfNotFound(
                         generate_inbox_id(&account_address, &1),
                         account_address.clone(),
                         0,
                         None,
-                    );
-                    strategy
+                    )
                 },
                 err: Some("Inbox ID doesn't match nonce & address".to_string()),
             },

--- a/xmtp_mls/src/identity.rs
+++ b/xmtp_mls/src/identity.rs
@@ -272,11 +272,6 @@ impl Identity {
 
             Ok(identity)
         } else {
-            if nonce == 0 {
-                return Err(IdentityError::NewIdentity(
-                    "Nonce must be non-zero if legacy key is not provided".to_string(),
-                ));
-            }
             if inbox_id != generate_inbox_id(&address, &nonce) {
                 return Err(IdentityError::NewIdentity(
                     "Inbox ID doesn't match nonce & address".to_string(),


### PR DESCRIPTION
Also optimized the tests so that they won't use same account address for client creation.

# side chat

PR is smol but let me give a side chat. My understanding for nonce is

- If it uses legacy key or __intend__ to use legacy key as an added association in the future, the nonce should be 0.
```text
XIP-46

CreateInbox
If the initial_address_signature comes from a Legacy Delegated Account, the Inbox must have been created with nonce 0

AddAssociation
If either the existing_member_signature or the new_member_signature is a Legacy Delegated signature the Inbox must have been created with nonce 0.
```

- If non legacy key is or will be involved, then we can use whatever nonce.

So it seems to me that nonce is primarily for legacy key so that we can verify the one-way relationship from address to inbox Id. Why do we need this & will we still need this after legacy key is fully deprecated?