### PR TITLE
lowercase the address when creating new identities

### DIFF
--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -459,8 +459,8 @@ mod tests {
         let store =
             EncryptedMessageStore::new_unencrypted(StorageOption::Persistent(tmpdb)).unwrap();
         let nonce = 0;
-        let address = rand_string();
-        let inbox_id = "inbox_id".to_string();
+        let address = generate_local_wallet().get_address();
+        let inbox_id = generate_inbox_id(&address, &nonce);
 
         let address_cloned = address.clone();
         let inbox_id_cloned = inbox_id.clone();
@@ -476,7 +476,7 @@ mod tests {
         let wrapper = ApiClientWrapper::new(mock_api, Retry::default());
 
         let identity = IdentityStrategy::CreateIfNotFound(inbox_id.clone(), address, nonce, None);
-        assert!(identity.initialize_identity(&wrapper, &store).await.is_ok());
+        assert!(dbg!(identity.initialize_identity(&wrapper, &store).await).is_ok());
     }
 
     // Use a stored identity as long as the inbox_id matches the one provided.
@@ -488,8 +488,8 @@ mod tests {
         let store =
             EncryptedMessageStore::new_unencrypted(StorageOption::Persistent(tmpdb)).unwrap();
         let nonce = 0;
-        let address = rand_string();
-        let inbox_id = "inbox_id".to_string();
+        let address = generate_local_wallet().get_address();
+        let inbox_id = generate_inbox_id(&address, &nonce);
 
         let stored: StoredIdentity = (&Identity {
             inbox_id: inbox_id.clone(),

--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -113,11 +113,8 @@ mod tests {
     use crate::identity::IdentityError;
     use crate::retry::Retry;
     use crate::{
-        api::test_utils::*,
-        identity::Identity,
-        storage::identity::StoredIdentity,
-        utils::test::{rand_string, rand_vec},
-        Store,
+        api::test_utils::*, identity::Identity, storage::identity::StoredIdentity,
+        utils::test::rand_vec, Store,
     };
     use ethers::signers::Signer;
     use ethers_core::k256;
@@ -423,8 +420,8 @@ mod tests {
         let store =
             EncryptedMessageStore::new_unencrypted(StorageOption::Persistent(tmpdb)).unwrap();
         let nonce = 0;
-        let address = rand_string();
-        let inbox_id = "inbox_id".to_string();
+        let address = generate_local_wallet().get_address();
+        let inbox_id = generate_inbox_id(&address, &nonce);
 
         let address_cloned = address.clone();
         let inbox_id_cloned = inbox_id.clone();
@@ -509,8 +506,9 @@ mod tests {
     async fn stored_identity_mismatch() {
         let mock_api = MockApiClient::new();
 
-        let network_address = rand_string();
-        let stored_inbox_id = "stored_inbox_id".to_string();
+        let nonce = 0;
+        let address = generate_local_wallet().get_address();
+        let stored_inbox_id = generate_inbox_id(&address, &nonce);
 
         let tmpdb = tmp_path();
         let store =
@@ -530,7 +528,7 @@ mod tests {
 
         let inbox_id = "inbox_id".to_string();
         let identity =
-            IdentityStrategy::CreateIfNotFound(inbox_id.clone(), network_address.clone(), 0, None);
+            IdentityStrategy::CreateIfNotFound(inbox_id.clone(), address.clone(), nonce, None);
         let err = identity
             .initialize_identity(&wrapper, &store)
             .await

--- a/xmtp_mls/src/identity.rs
+++ b/xmtp_mls/src/identity.rs
@@ -188,6 +188,7 @@ impl Identity {
         provider: &XmtpOpenMlsProvider,
     ) -> Result<Self, IdentityError> {
         // check if address is already associated with an inbox_id
+        let address = address.to_lowercase();
         let inbox_ids = api_client.get_inbox_ids(vec![address.clone()]).await?;
         let associated_inbox_id = inbox_ids.get(&address);
         let signature_keys = SignatureKeyPair::new(CIPHERSUITE.signature_algorithm())?;


### PR DESCRIPTION
We probably should use a better canonical data type for address(e.g. ethers::types::Address) but lowering the case when creating a new identity covers a lot of use cases as it's the entrance.
