### PR TITLE
Use GitHub action runner for publishing

### DIFF
--- a/.github/workflows/release-node-bindings.yml
+++ b/.github/workflows/release-node-bindings.yml
@@ -225,7 +225,7 @@ jobs:
   publish:
     permissions:
       id-token: write
-    runs-on: warp-ubuntu-latest-x64-8x
+    runs-on: ubuntu-latest
     needs: [build-linux, build-macos, build-windows]
     steps:
       - name: Checkout


### PR DESCRIPTION
# Summary

An official GitHub action runner is required to publish a package with provenance.