### PR TITLE
replace json with tls_codec serialization

### DIFF
--- a/xmtp_mls/src/storage/sql_key_store.rs
+++ b/xmtp_mls/src/storage/sql_key_store.rs
@@ -6,8 +6,9 @@ use diesel::{
 };
 use log::error;
 use openmls_traits::storage::*;
-use serde::Serialize;
-use serde_json::{from_slice, from_value, Value};
+use openmls::prelude::tls_codec::{Serialize, Deserialize};
+// use serde::Serialize;
+// use serde_json::{from_slice, from_value, Value};
 
 const SELECT_QUERY: &str =
     "SELECT value_bytes FROM openmls_key_value WHERE key_bytes = ? AND version = ?";
@@ -207,6 +208,7 @@ impl SqlKeyStore {
         match results {
             Ok(data) => {
                 if let Some(entry) = data.into_iter().next() {
+                    // TODO: replace with a custom/derived deserialization method
                     match serde_json::from_slice::<V>(&entry.value_bytes) {
                         Ok(deserialized) => Ok(Some(deserialized)),
                         Err(e) => {
@@ -234,11 +236,13 @@ impl SqlKeyStore {
         match self.select_query::<VERSION>(&storage_key) {
             Ok(results) => {
                 if let Some(entry) = results.into_iter().next() {
+                    // TODO: replace with a custom/derived deserialization method
                     let list = from_slice::<Vec<Vec<u8>>>(&entry.value_bytes)?;
 
                     // Read the values from the bytes in the list
                     let mut deserialized_list = Vec::new();
                     for v in list {
+                    // TODO: replace with a custom/derived deserialization method
                         match serde_json::from_slice(&v) {
                             Ok(deserialized_value) => deserialized_list.push(deserialized_value),
                             Err(_) => return Err(MemoryStorageError::SerializationError),

--- a/xmtp_mls/src/storage/sql_key_store.rs
+++ b/xmtp_mls/src/storage/sql_key_store.rs
@@ -797,7 +797,14 @@ impl StorageProvider<CURRENT_VERSION> for SqlKeyStore {
         group_id: &GroupId,
     ) -> Result<Option<LeafNodeIndex>, Self::Error> {
         let key = build_key::<CURRENT_VERSION, &GroupId>(OWN_LEAF_NODE_INDEX_LABEL, group_id)?;
-        self.read(OWN_LEAF_NODE_INDEX_LABEL, &key)
+        match self.read::<CURRENT_VERSION>(OWN_LEAF_NODE_INDEX_LABEL, &key) {
+            Ok(Some(value)) => Ok(Some(serde_json::from_slice(&value)?)),
+            Ok(None) => Ok(None),
+            Err(e) => {
+                error!("Error reading own_leaf_index: {:?}", e);
+                Err(MemoryStorageError::None)
+            }
+        }
     }
 
     fn write_own_leaf_index<

--- a/xmtp_mls/src/storage/sql_key_store.rs
+++ b/xmtp_mls/src/storage/sql_key_store.rs
@@ -493,7 +493,14 @@ impl StorageProvider<CURRENT_VERSION> for SqlKeyStore {
     ) -> Result<Option<InterimTranscriptHash>, Self::Error> {
         let key = build_key::<CURRENT_VERSION, &GroupId>(INTERIM_TRANSCRIPT_HASH_LABEL, group_id)?;
 
-        self.read(INTERIM_TRANSCRIPT_HASH_LABEL, &key)
+        match self.read::<CURRENT_VERSION>(INTERIM_TRANSCRIPT_HASH_LABEL, &key) {
+            Ok(Some(value)) => Ok(Some(serde_json::from_slice(&value)?)),
+            Ok(None) => Ok(None),
+            Err(e) => {
+                error!("Error reading interim_transcript_hash: {:?}", e);
+                Err(MemoryStorageError::None)
+            }
+        }
     }
 
     fn confirmation_tag<

--- a/xmtp_mls/src/storage/sql_key_store.rs
+++ b/xmtp_mls/src/storage/sql_key_store.rs
@@ -512,7 +512,14 @@ impl StorageProvider<CURRENT_VERSION> for SqlKeyStore {
     ) -> Result<Option<ConfirmationTag>, Self::Error> {
         let key = build_key::<CURRENT_VERSION, &GroupId>(CONFIRMATION_TAG_LABEL, group_id)?;
 
-        self.read(CONFIRMATION_TAG_LABEL, &key)
+        match self.read::<CURRENT_VERSION>(CONFIRMATION_TAG_LABEL, &key) {
+            Ok(Some(value)) => Ok(Some(serde_json::from_slice(&value)?)),
+            Ok(None) => Ok(None),
+            Err(e) => {
+                error!("Error reading confirmation_tag: {:?}", e);
+                Err(MemoryStorageError::None)
+            }
+        }
     }
 
     fn signature_key_pair<

--- a/xmtp_mls/src/storage/sql_key_store.rs
+++ b/xmtp_mls/src/storage/sql_key_store.rs
@@ -443,8 +443,11 @@ impl StorageProvider<CURRENT_VERSION> for SqlKeyStore {
         refs.into_iter()
             .map(|proposal_ref| -> Result<_, _> {
                 let key = serde_json::to_vec(&(group_id, &proposal_ref))?;
-                match self.read(QUEUED_PROPOSAL_LABEL, &key)? {
-                    Some(proposal) => Ok((proposal_ref, proposal)),
+                match self.read::<CURRENT_VERSION>(QUEUED_PROPOSAL_LABEL, &key)? {
+                    Some(proposal) => {
+                        let proposal = serde_json::from_slice(&proposal)?;
+                        Ok((proposal_ref, proposal))
+                    }
                     None => Err(MemoryStorageError::SerializationError),
                 }
             })

--- a/xmtp_mls/src/storage/sql_key_store.rs
+++ b/xmtp_mls/src/storage/sql_key_store.rs
@@ -534,7 +534,14 @@ impl StorageProvider<CURRENT_VERSION> for SqlKeyStore {
             public_key,
         )?;
 
-        self.read(SIGNATURE_KEY_PAIR_LABEL, &key)
+        match self.read::<CURRENT_VERSION>(SIGNATURE_KEY_PAIR_LABEL, &key) {
+            Ok(Some(value)) => Ok(Some(serde_json::from_slice(&value)?)),
+            Ok(None) => Ok(None),
+            Err(e) => {
+                error!("Error reading signature_key_pair: {:?}", e);
+                Err(MemoryStorageError::None)
+            }
+        }
     }
 
     fn write_key_package<

--- a/xmtp_mls/src/storage/sql_key_store.rs
+++ b/xmtp_mls/src/storage/sql_key_store.rs
@@ -716,7 +716,14 @@ impl StorageProvider<CURRENT_VERSION> for SqlKeyStore {
         group_id: &GroupId,
     ) -> Result<Option<MessageSecrets>, Self::Error> {
         let key = build_key::<CURRENT_VERSION, &GroupId>(MESSAGE_SECRETS_LABEL, group_id)?;
-        self.read(MESSAGE_SECRETS_LABEL, &key)
+        match self.read::<CURRENT_VERSION>(MESSAGE_SECRETS_LABEL, &key) {
+            Ok(Some(value)) => Ok(Some(serde_json::from_slice(&value)?)),
+            Ok(None) => Ok(None),
+            Err(e) => {
+                error!("Error reading message secrets: {:?}", e);
+                Err(MemoryStorageError::None)
+            }
+        }
     }
 
     fn write_message_secrets<

--- a/xmtp_mls/src/storage/sql_key_store.rs
+++ b/xmtp_mls/src/storage/sql_key_store.rs
@@ -757,7 +757,14 @@ impl StorageProvider<CURRENT_VERSION> for SqlKeyStore {
         &self,
         group_id: &GroupId,
     ) -> Result<Option<ResumptionPskStore>, Self::Error> {
-        self.read(RESUMPTION_PSK_STORE_LABEL, &serde_json::to_vec(group_id)?)
+        match self.read::<CURRENT_VERSION>(RESUMPTION_PSK_STORE_LABEL, &serde_json::to_vec(group_id)?) {
+            Ok(Some(value)) => Ok(Some(serde_json::from_slice(&value)?)),
+            Ok(None) => Ok(None),
+            Err(e) => {
+                error!("Error reading resumption_psk_store: {:?}", e);
+                Err(MemoryStorageError::None)
+            }
+        }
     }
 
     fn write_resumption_psk_store<

--- a/xmtp_mls/src/storage/sql_key_store.rs
+++ b/xmtp_mls/src/storage/sql_key_store.rs
@@ -678,7 +678,14 @@ impl StorageProvider<CURRENT_VERSION> for SqlKeyStore {
         group_id: &GroupId,
     ) -> Result<Option<GroupState>, Self::Error> {
         let key = build_key::<CURRENT_VERSION, &GroupId>(GROUP_STATE_LABEL, group_id)?;
-        self.read(GROUP_STATE_LABEL, &key)
+        match self.read::<CURRENT_VERSION>(GROUP_STATE_LABEL, &key) {
+            Ok(Some(value)) => Ok(Some(serde_json::from_slice(&value)?)),
+            Ok(None) => Ok(None),
+            Err(e) => {
+                error!("Error reading group_state: {:?}", e);
+                Err(MemoryStorageError::None)
+            }
+        }
     }
 
     fn write_group_state<

--- a/xmtp_mls/src/storage/sql_key_store.rs
+++ b/xmtp_mls/src/storage/sql_key_store.rs
@@ -1011,7 +1011,14 @@ impl StorageProvider<CURRENT_VERSION> for SqlKeyStore {
         group_id: &GroupId,
     ) -> Result<Option<MlsGroupJoinConfig>, Self::Error> {
         let key = build_key::<CURRENT_VERSION, &GroupId>(JOIN_CONFIG_LABEL, group_id)?;
-        self.read(JOIN_CONFIG_LABEL, &key)
+        match self.read::<CURRENT_VERSION>(JOIN_CONFIG_LABEL, &key) {
+            Ok(Some(value)) => Ok(Some(serde_json::from_slice(&value)?)),
+            Ok(None) => Ok(None),
+            Err(e) => {
+                error!("Error reading mls_group_join_config: {:?}", e);
+                Err(MemoryStorageError::None)
+            }
+        }
     }
 
     fn write_mls_join_config<

--- a/xmtp_mls/src/storage/sql_key_store.rs
+++ b/xmtp_mls/src/storage/sql_key_store.rs
@@ -871,7 +871,14 @@ impl StorageProvider<CURRENT_VERSION> for SqlKeyStore {
         group_id: &GroupId,
     ) -> Result<Option<GroupEpochSecrets>, Self::Error> {
         let key = build_key::<CURRENT_VERSION, &GroupId>(EPOCH_SECRETS_LABEL, group_id)?;
-        self.read(EPOCH_SECRETS_LABEL, &key)
+        match self.read::<CURRENT_VERSION>(EPOCH_SECRETS_LABEL, &key) {
+            Ok(Some(value)) => Ok(Some(serde_json::from_slice(&value)?)),
+            Ok(None) => Ok(None),
+            Err(e) => {
+                error!("Error reading group_epoch_secrets: {:?}", e);
+                Err(MemoryStorageError::None)
+            }
+        }
     }
 
     fn write_group_epoch_secrets<

--- a/xmtp_mls/src/storage/sql_key_store.rs
+++ b/xmtp_mls/src/storage/sql_key_store.rs
@@ -462,7 +462,14 @@ impl StorageProvider<CURRENT_VERSION> for SqlKeyStore {
         group_id: &GroupId,
     ) -> Result<Option<TreeSync>, Self::Error> {
         let key = build_key::<CURRENT_VERSION, &GroupId>(TREE_LABEL, group_id)?;
-        self.read::<CURRENT_VERSION>(TREE_LABEL, &key)
+        match self.read::<CURRENT_VERSION>(TREE_LABEL, &key) {
+            Ok(Some(value)) => Ok(Some(serde_json::from_slice(&value)?)),
+            Ok(None) => Ok(None),
+            Err(e) => {
+                error!("Error reading treesync: {:?}", e);
+                Err(MemoryStorageError::None)
+            }
+        }
     }
 
     fn group_context<


### PR DESCRIPTION
## Summary



This patch is in `DRAFT` status until tls_codec serde (sans `serde_json`) works for our needs.

### Approach

Right now [sql_key_store.rs](https://github.com/xmtp/libxmtp/blob/main/xmtp_mls/src/storage/sql_key_store.rs) , like [memorary_storage/lib.rs](https://github.com/openmls/openmls/blob/main/memory_storage/src/lib.rs), rely heavily on using `serde_json::to_vec` and `serde_json::from_slice` et al, to de/serialize data into/out of the format that is needed for local storage and retrieval.  Mostly the `Key` and `Entity`  are  conversions from/to `Vec<u8>` which should make this fairly straightforward.

The aim here is to modify or replace what we need to (without expanding scope) locally in this repo and/or in our fork of `openmls` in order to have a usable storage interface that uses the `tls_codec` but does not rely on `serde_json` nor its conversion to a json `Value`.

read `TODO`s in code comments for more thoughts.

Need to implement the serialization for the following public types


- [x] `TreeSync`
- [ ] `openmls::prelude_test::hash_ref::HashReference`
- [x] `QueuedProposal`
 - [x] `GroupContext`
 - [x] `InterimTranscriptHash`
 - [x] `ConfirmationTag`
 - [x] `SignatureKeyPair`
 - [x] `KeyPackage`
 - [x] `HpkeKeyPair`
 - [x] `GroupState`
 - [x] `MessageSecrets`
 - [x] `ResumptionPskStore`
 - [x] `LeafNodeIndex`
 - [x] `GroupEpochSecrets`
 - [x] `MlsGroupJoinConfig`

---

### Other approach

Finish implementing any and all of the remaining serializers (and deserializers?) (spike needed - determine what's left)  in https://github.com/RustCrypto/formats/tree/master/tls_codec following the pattern laid out in e.g. https://github.com/openmls/openmls/blob/12c73315a257f8377b6b7bbe8cdb694808b6e1c2/openmls/src/group/mls_group/ser.rs