### PR TITLE
Update node bindings version and changelog

### DIFF
--- a/bindings_node/CHANGELOG.md
+++ b/bindings_node/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @xmtp/mls-client-bindings-node
 
+## 0.0.5
+
+- Added ability to set group name and image URL during creation
+- Added getter and setter for group image URL
+- Renamed `add_erc1271_signature` to `add_scw_signature`
+
 ## 0.0.4
 
 - Added `stream_all_messages`

--- a/bindings_node/package.json
+++ b/bindings_node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/mls-client-bindings-node",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "repository": {
     "type": "git",
     "url": "git+https://git@github.com/xmtp/libxmtp.git",


### PR DESCRIPTION
# Summary

- Bumped node bindings version to `0.0.5`
- Updated CHANGELOG