### PR TITLE
Fetch Group & Message by id & InboxId from address

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -273,6 +273,21 @@ impl FfiXmtpClient {
     pub async fn db_reconnect(&self) -> Result<(), GenericError> {
         Ok(self.inner_client.reconnect_db()?)
     }
+
+    pub async fn find_inbox_id(
+        &self,
+        account_address: String,
+    ) -> Result<Option<String>, GenericError> {
+        let inner = self.inner_client.as_ref();
+
+        let results = inner
+            .api_client
+            .get_inbox_ids(vec![account_address.clone()])
+            .await
+            .map_err(GenericError::from_error)?;
+
+        Ok(results.get(&account_address).cloned())
+    }
 }
 
 #[uniffi::export(async_runtime = "tokio")]

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -274,19 +274,11 @@ impl FfiXmtpClient {
         Ok(self.inner_client.reconnect_db()?)
     }
 
-    pub async fn find_inbox_id(
-        &self,
-        account_address: String,
-    ) -> Result<Option<String>, GenericError> {
+    pub async fn find_inbox_id(&self, address: String) -> Result<Option<String>, GenericError> {
         let inner = self.inner_client.as_ref();
 
-        let results = inner
-            .api_client
-            .get_inbox_ids(vec![account_address.clone()])
-            .await
-            .map_err(GenericError::from_error)?;
-
-        Ok(results.get(&account_address).cloned())
+        let result = inner.find_inbox_id_from_address(address).await?;
+        Ok(result)
     }
 }
 

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -253,7 +253,7 @@ where
         &self,
         address: String,
     ) -> Result<Option<String>, ClientError> {
-        let results = self.api_client.get_inbox_ids(vec![address.clone()]).await?;
+        let mut results = self.api_client.get_inbox_ids(vec![address.clone()]).await?;
         Ok(results.get(&address).cloned())
     }
 

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -254,7 +254,7 @@ where
         address: String,
     ) -> Result<Option<String>, ClientError> {
         let mut results = self.api_client.get_inbox_ids(vec![address.clone()]).await?;
-        Ok(results.get(&address).cloned())
+        Ok(results.remove(&address))
     }
 
     /// Get sequence id, may not be consistent with the backend

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -177,7 +177,7 @@ impl From<&str> for ClientError {
 /// Clients manage access to the network, identity, and data store
 #[derive(Debug)]
 pub struct Client<ApiClient> {
-    pub api_client: ApiClientWrapper<ApiClient>,
+    pub(crate) api_client: ApiClientWrapper<ApiClient>,
     pub(crate) context: Arc<XmtpMlsLocalContext>,
     pub(crate) history_sync_url: Option<String>,
 }
@@ -247,6 +247,14 @@ where
 
     pub fn inbox_id(&self) -> String {
         self.context.inbox_id()
+    }
+
+    pub async fn find_inbox_id_from_address(
+        &self,
+        address: String,
+    ) -> Result<Option<String>, ClientError> {
+        let results = self.api_client.get_inbox_ids(vec![address.clone()]).await?;
+        Ok(results.get(&address).cloned())
     }
 
     /// Get sequence id, may not be consistent with the backend

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -177,7 +177,7 @@ impl From<&str> for ClientError {
 /// Clients manage access to the network, identity, and data store
 #[derive(Debug)]
 pub struct Client<ApiClient> {
-    pub(crate) api_client: ApiClientWrapper<ApiClient>,
+    pub api_client: ApiClientWrapper<ApiClient>,
     pub(crate) context: Arc<XmtpMlsLocalContext>,
     pub(crate) history_sync_url: Option<String>,
 }


### PR DESCRIPTION
Part of https://github.com/xmtp/xmtp-react-native/issues/422 & https://github.com/xmtp/xmtp-react-native/issues/426

Fetch message and group by ID from local database.
Also add a method to fetch the inboxId from an address.