### PR TITLE
Move message lookup to client

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -251,6 +251,11 @@ impl FfiXmtpClient {
         })
     }
 
+    pub fn message(&self, message_id: Vec<u8>) -> Result<FfiMessage, GenericError> {
+        let message = self.inner_client.message(message_id)?;
+        Ok(message.into())
+    }
+
     pub async fn can_message(
         &self,
         account_addresses: Vec<String>,
@@ -538,17 +543,6 @@ impl FfiGroup {
         group.sync(&self.inner_client).await?;
 
         Ok(())
-    }
-
-    pub async fn message(&self, message_id: Vec<u8>) -> Result<FfiMessage, GenericError> {
-        let group = MlsGroup::new(
-            self.inner_client.context().clone(),
-            self.group_id.clone(),
-            self.created_at_ns,
-        );
-
-        let message = group.message(message_id)?;
-        Ok(message.into())
     }
 
     pub fn find_messages(

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -40,6 +40,7 @@ use crate::{
     storage::{
         db_connection::DbConnection,
         group::{GroupMembershipState, StoredGroup},
+        group_message::StoredGroupMessage,
         refresh_state::EntityKind,
         sql_key_store, EncryptedMessageStore, StorageError,
     },
@@ -330,6 +331,20 @@ where
             None => Err(ClientError::Storage(StorageError::NotFound(format!(
                 "group {}",
                 hex::encode(group_id)
+            )))),
+        }
+    }
+
+    /// Look up a message by its ID
+    /// Returns a [`StoredGroupMessage`] if the message exists, or an error if it does not
+    pub fn message(&self, message_id: Vec<u8>) -> Result<StoredGroupMessage, ClientError> {
+        let conn = &mut self.store().conn()?;
+        let message = conn.get_group_message(&message_id)?;
+        match message {
+            Some(message) => Ok(message),
+            None => Err(ClientError::Storage(StorageError::NotFound(format!(
+                "message {}",
+                hex::encode(message_id)
             )))),
         }
     }

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -81,7 +81,7 @@ use crate::{
         group::{GroupMembershipState, Purpose, StoredGroup},
         group_intent::{IntentKind, NewGroupIntent},
         group_message::{DeliveryStatus, GroupMessageKind, StoredGroupMessage},
-        sql_key_store, StorageError,
+        sql_key_store,
     },
     utils::{id::calculate_message_id, time::now_ns},
     xmtp_openmls_provider::XmtpOpenMlsProvider,

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -487,20 +487,6 @@ impl MlsGroup {
         Ok(messages)
     }
 
-    /// Look up a message by its ID
-    /// Returns a [`StoredGroupMessage`] if the message exists, or an error if it does not
-    pub fn message(&self, message_id: Vec<u8>) -> Result<StoredGroupMessage, GroupError> {
-        let conn = self.context.store.conn()?;
-        let message = conn.get_group_message(&message_id)?;
-        match message {
-            Some(message) => Ok(message),
-            None => Err(GroupError::Storage(StorageError::NotFound(format!(
-                "message {}",
-                hex::encode(message_id)
-            )))),
-        }
-    }
-
     /**
      * Add members to the group by account address
      *


### PR DESCRIPTION
# Summary

This PR moves the find message by ID method to the client in `xmtp_mls` and `bindings_ffi`.