### PR TITLE
Add new finder methods to node bindings

### DIFF
--- a/bindings_node/src/conversations.rs
+++ b/bindings_node/src/conversations.rs
@@ -88,6 +88,34 @@ impl NapiConversations {
   }
 
   #[napi]
+  pub fn find_group_by_id(&self, group_id: String) -> Result<NapiGroup> {
+    let group_id = hex::decode(group_id).map_err(|e| Error::from_reason(format!("{}", e)))?;
+
+    let group = self
+      .inner_client
+      .group(group_id)
+      .map_err(|e| Error::from_reason(format!("{}", e)))?;
+
+    Ok(NapiGroup::new(
+      self.inner_client.clone(),
+      group.group_id,
+      group.created_at_ns,
+    ))
+  }
+
+  #[napi]
+  pub fn find_message_by_id(&self, message_id: String) -> Result<NapiMessage> {
+    let message_id = hex::decode(message_id).map_err(|e| Error::from_reason(format!("{}", e)))?;
+
+    let message = self
+      .inner_client
+      .message(message_id)
+      .map_err(|e| Error::from_reason(format!("{}", e)))?;
+
+    Ok(NapiMessage::from(message))
+  }
+
+  #[napi]
   pub async fn process_streamed_welcome_message(
     &self,
     envelope_bytes: Uint8Array,

--- a/bindings_node/src/mls_client.rs
+++ b/bindings_node/src/mls_client.rs
@@ -269,4 +269,15 @@ impl NapiClient {
 
     Ok(())
   }
+
+  #[napi]
+  pub async fn find_inbox_id_by_address(&self, address: String) -> Result<Option<String>> {
+    let inbox_id = self
+      .inner_client
+      .find_inbox_id_from_address(address)
+      .await
+      .map_err(|e| Error::from_reason(format!("{}", e)))?;
+
+    Ok(inbox_id)
+  }
 }

--- a/bindings_node/test/Client.test.ts
+++ b/bindings_node/test/Client.test.ts
@@ -24,4 +24,11 @@ describe('Client', () => {
     const canMessage = await client.canMessage([user.account.address])
     expect(canMessage).toEqual({ [user.account.address.toLowerCase()]: true })
   })
+
+  it('should find an inbox ID from an address', async () => {
+    const user = createUser()
+    const client = await createRegisteredClient(user)
+    const inboxId = await client.findInboxIdByAddress(user.account.address)
+    expect(inboxId).toBe(client.inboxId())
+  })
 })

--- a/bindings_node/test/Conversations.test.ts
+++ b/bindings_node/test/Conversations.test.ts
@@ -55,6 +55,37 @@ describe('Conversations', () => {
     expect(group2[0].id).toBe(group.id)
   })
 
+  it('should find a group by ID', async () => {
+    const user1 = createUser()
+    const user2 = createUser()
+    const client1 = await createRegisteredClient(user1)
+    const client2 = await createRegisteredClient(user2)
+    const group = await client1
+      .conversations()
+      .createGroup([user2.account.address])
+    expect(group).toBeDefined()
+    expect(group.id()).toBeDefined()
+    const foundGroup = client1.conversations().findGroupById(group.id())
+    expect(foundGroup).toBeDefined()
+    expect(foundGroup!.id()).toBe(group.id())
+  })
+
+  it('should find a message by ID', async () => {
+    const user1 = createUser()
+    const user2 = createUser()
+    const client1 = await createRegisteredClient(user1)
+    await createRegisteredClient(user2)
+    const group = await client1
+      .conversations()
+      .createGroup([user2.account.address])
+    const messageId = await group.send(encodeTextMessage('gm!'))
+    expect(messageId).toBeDefined()
+
+    const message = client1.conversations().findMessageById(messageId)
+    expect(message).toBeDefined()
+    expect(message!.id).toBe(messageId)
+  })
+
   it('should create a new group with options', async () => {
     const user1 = createUser()
     const user2 = createUser()


### PR DESCRIPTION
# Summary

This PR adds the group, message, and inbox ID finder methods to the node bindings