### PR TITLE
Prepare node bindings release

### DIFF
--- a/bindings_node/CHANGELOG.md
+++ b/bindings_node/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @xmtp/mls-client-bindings-node
 
+## 0.0.7
+
+- Improved streaming welcomes
+- Improved DB retries
+- Changed encoding of the MLS database to `bincode` for performance
+- Added `find_inbox_id_by_address` to client
+- Added `find_group_by_id` and `find_message_by_id` to conversations
+
 ## 0.0.6
 
 - Fixed some group syncing issues

--- a/bindings_node/package.json
+++ b/bindings_node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/mls-client-bindings-node",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "repository": {
     "type": "git",
     "url": "git+https://git@github.com/xmtp/libxmtp.git",


### PR DESCRIPTION
# Summary

* Bumped node bindings to `0.0.7`
* Updated CHANGELOG