### PR TITLE
Fix invalid policy error

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -313,6 +313,7 @@ pub struct FfiConversations {
 pub enum GroupPermissions {
     AllMembers,
     AdminOnly,
+    CustomPolicy,
 }
 
 impl From<PreconfiguredPolicies> for GroupPermissions {
@@ -1009,7 +1010,11 @@ pub struct FfiGroupPermissions {
 #[uniffi::export]
 impl FfiGroupPermissions {
     pub fn policy_type(&self) -> Result<GroupPermissions, GenericError> {
-        Ok(self.inner.preconfigured_policy()?.into())
+        if let Ok(preconfigured_policy) = self.inner.preconfigured_policy() {
+            Ok(preconfigured_policy.into())
+        } else {
+            Ok(GroupPermissions::CustomPolicy)
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #851 

We were throwing an error when reading group policies whenever the policy did not exactly match the libxmtp defined policy set for our preconfigured policy set of All Members, or Admin Only. When we added a new metadata option, those preconfigured policies would add a policy for the new metadata option, and the existing group policy sets would not have that, so we would not match any of the preconfigured policy sets.

Part 1 of the fix is to make it so that if all the metadata policies match the all members / admin only policy set default, that they can still match as being All Members / Admin Only, even if they are missing or have an new metadata policy.

Part 2 of the fix is to not return an error if the group policy set does not perfectly match a preconfigured policy set, and instead return `GroupPermissions::CustomPolicy`. This makes the SDK more robust against updates. For example this PR updates the remove member policy to default to "admin only" for "All Members". That means existing groups who already have that policy set to "allow all" will show up in new versions as a Custom Policy instead of just erroring. 


Related PRs:
- Android: https://github.com/xmtp/xmtp-android/pull/263
- Libxmtp-swift: 
- iOS:
- React Native: 