### PR TITLE
Improve error handling

### DIFF
--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -128,12 +128,12 @@ pub enum MessageProcessingError {
     Identity(#[from] IdentityError),
     #[error("openmls process message error: {0}")]
     OpenMlsProcessMessage(
-        #[from] openmls::prelude::ProcessMessageError<sql_key_store::MemoryStorageError>,
+        #[from] openmls::prelude::ProcessMessageError<sql_key_store::SqlKeyStoreError>,
     ),
     #[error("merge pending commit: {0}")]
     MergePendingCommit(#[from] openmls::group::MergePendingCommitError<StorageError>),
     #[error("merge staged commit: {0}")]
-    MergeStagedCommit(#[from] openmls::group::MergeCommitError<sql_key_store::MemoryStorageError>),
+    MergeStagedCommit(#[from] openmls::group::MergeCommitError<sql_key_store::SqlKeyStoreError>),
     #[error(
         "no pending commit to merge. group epoch is {group_epoch:?} and got {message_epoch:?}"
     )]
@@ -163,6 +163,8 @@ pub enum MessageProcessingError {
     WrongCredentialType(#[from] BasicCredentialError),
     #[error("proto decode error: {0}")]
     DecodeError(#[from] prost::DecodeError),
+    #[error("clear pending commit error: {0}")]
+    ClearPendingCommit(#[from] sql_key_store::SqlKeyStoreError),
     #[error(transparent)]
     Group(#[from] Box<GroupError>),
     #[error("generic:{0}")]

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -175,7 +175,7 @@ impl crate::retry::RetryableError for MessageProcessingError {
     fn is_retryable(&self) -> bool {
         match self {
             Self::Group(group_error) => retryable!(group_error),
-            Self::Identity(identity_error) => retryable!(identity_error),
+            // Self::Identity(identity_error) => false,
             Self::Diesel(diesel_error) => retryable!(diesel_error),
             Self::Storage(s) => retryable!(s),
             Self::Generic(err) => err.contains("database is locked"),

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -104,7 +104,7 @@ pub enum GroupError {
     #[error("intent error: {0}")]
     Intent(#[from] IntentError),
     #[error("create message: {0}")]
-    CreateMessage(#[from] openmls::prelude::CreateMessageError<sql_key_store::MemoryStorageError>),
+    CreateMessage(#[from] openmls::prelude::CreateMessageError<sql_key_store::SqlKeyStoreError>),
     #[error("TLS Codec error: {0}")]
     TlsError(#[from] TlsCodecError),
     #[error("No changes found in commit")]
@@ -113,14 +113,14 @@ pub enum GroupError {
     AddressNotFound(Vec<String>),
     #[error("add members: {0}")]
     UpdateGroupMembership(
-        #[from] openmls::prelude::UpdateGroupMembershipError<sql_key_store::MemoryStorageError>,
+        #[from] openmls::prelude::UpdateGroupMembershipError<sql_key_store::SqlKeyStoreError>,
     ),
     #[error("group create: {0}")]
-    GroupCreate(#[from] openmls::group::NewGroupError<sql_key_store::MemoryStorageError>),
+    GroupCreate(#[from] openmls::group::NewGroupError<sql_key_store::SqlKeyStoreError>),
     #[error("self update: {0}")]
-    SelfUpdate(#[from] openmls::group::SelfUpdateError<sql_key_store::MemoryStorageError>),
+    SelfUpdate(#[from] openmls::group::SelfUpdateError<sql_key_store::SqlKeyStoreError>),
     #[error("welcome error: {0}")]
-    WelcomeError(#[from] openmls::prelude::WelcomeError<sql_key_store::MemoryStorageError>),
+    WelcomeError(#[from] openmls::prelude::WelcomeError<sql_key_store::SqlKeyStoreError>),
     #[error("Invalid extension {0}")]
     InvalidExtension(#[from] openmls::prelude::InvalidExtensionError),
     #[error("Invalid signature: {0}")]
@@ -157,7 +157,7 @@ pub enum GroupError {
     EncodeError(#[from] prost::EncodeError),
     #[error("create group context proposal error: {0}")]
     CreateGroupContextExtProposalError(
-        #[from] CreateGroupContextExtProposalError<sql_key_store::MemoryStorageError>,
+        #[from] CreateGroupContextExtProposalError<sql_key_store::SqlKeyStoreError>,
     ),
     #[error("Credential error")]
     CredentialError(#[from] BasicCredentialError),

--- a/xmtp_mls/src/groups/sync.rs
+++ b/xmtp_mls/src/groups/sync.rs
@@ -257,11 +257,7 @@ impl MlsGroup {
                     log::warn!("error validating commit: {:?}", maybe_validated_commit);
                     match openmls_group.clear_pending_commit(provider.storage()) {
                         Ok(_) => (),
-                        Err(_) => {
-                            return Err(MessageProcessingError::Generic(
-                                "Error clearing pending commit after failed validation".to_string(),
-                            ))
-                        }
+                        Err(err) => return Err(MessageProcessingError::ClearPendingCommit(err)),
                     }
                     conn.set_group_intent_error(intent.id)?;
                     // Return before merging commit since it does not pass validation
@@ -280,11 +276,7 @@ impl MlsGroup {
                     log::error!("error merging commit: {}", err);
                     match openmls_group.clear_pending_commit(provider.storage()) {
                         Ok(_) => (),
-                        Err(_) => {
-                            return Err(MessageProcessingError::Generic(
-                                "Error clearing pending commit".to_string(),
-                            ))
-                        }
+                        Err(err) => return Err(MessageProcessingError::ClearPendingCommit(err)),
                     }
 
                     conn.set_group_intent_to_publish(intent.id)?;

--- a/xmtp_mls/src/groups/validated_commit.rs
+++ b/xmtp_mls/src/groups/validated_commit.rs
@@ -24,6 +24,8 @@ use xmtp_proto::xmtp::{
 use crate::{
     configuration::GROUP_MEMBERSHIP_EXTENSION_ID,
     identity_updates::{InstallationDiff, InstallationDiffError},
+    retry::RetryableError,
+    retryable,
     storage::db_connection::DbConnection,
     Client, XmtpApi,
 };
@@ -80,6 +82,15 @@ pub enum CommitValidationError {
     GroupMutablePermissions(#[from] GroupMutablePermissionsError),
     #[error("PSKs are not support")]
     NoPSKSupport,
+}
+
+impl RetryableError for CommitValidationError {
+    fn is_retryable(&self) -> bool {
+        match self {
+            CommitValidationError::InstallationDiff(diff_error) => retryable!(diff_error),
+            _ => false,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Hash)]

--- a/xmtp_mls/src/identity.rs
+++ b/xmtp_mls/src/identity.rs
@@ -3,7 +3,7 @@ use std::array::TryFromSliceError;
 use crate::configuration::GROUP_PERMISSIONS_EXTENSION_ID;
 use crate::storage::db_connection::DbConnection;
 use crate::storage::identity::StoredIdentity;
-use crate::storage::sql_key_store::{MemoryStorageError, KEY_PACKAGE_REFERENCES};
+use crate::storage::sql_key_store::{SqlKeyStoreError, KEY_PACKAGE_REFERENCES};
 use crate::storage::EncryptedMessageStore;
 use crate::{
     api::{ApiClientWrapper, WrappedApiError},
@@ -148,7 +148,7 @@ pub enum IdentityError {
     #[error(transparent)]
     StorageError(#[from] crate::storage::StorageError),
     #[error(transparent)]
-    OpenMlsStorageError(#[from] MemoryStorageError),
+    OpenMlsStorageError(#[from] SqlKeyStoreError),
     #[error(transparent)]
     KeyPackageGenerationError(#[from] openmls::key_packages::errors::KeyPackageNewError),
     #[error(transparent)]

--- a/xmtp_mls/src/identity_updates.rs
+++ b/xmtp_mls/src/identity_updates.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use crate::storage::association_state::StoredAssociationState;
+use crate::{retry::RetryableError, retryable, storage::association_state::StoredAssociationState};
 use prost::Message;
 use thiserror::Error;
 use xmtp_id::associations::{
@@ -34,6 +34,14 @@ pub struct InstallationDiff {
 pub enum InstallationDiffError {
     #[error(transparent)]
     Client(#[from] ClientError),
+}
+
+impl RetryableError for InstallationDiffError {
+    fn is_retryable(&self) -> bool {
+        match self {
+            InstallationDiffError::Client(client_error) => retryable!(client_error),
+        }
+    }
 }
 
 impl<'a, ApiClient> Client<ApiClient>

--- a/xmtp_mls/src/retry.rs
+++ b/xmtp_mls/src/retry.rs
@@ -23,21 +23,15 @@ use smart_default::SmartDefault;
 /// Specifies which errors are retryable.
 /// All Errors are not retryable by-default.
 pub trait RetryableError: std::error::Error {
-    fn is_retryable(&self) -> bool {
-        log::info!("Default retriable error");
-        false
-    }
+    fn is_retryable(&self) -> bool;
 }
-
-// we use &T and make use of autoref specialization
-impl<T> RetryableError for &T where T: std::error::Error {}
 
 /// Options to specify how to retry a function
 #[derive(SmartDefault, Debug, PartialEq, Eq, Copy, Clone)]
 pub struct Retry {
-    #[default = 3]
+    #[default = 5]
     retries: usize,
-    #[default(_code = "std::time::Duration::from_millis(100)")]
+    #[default(_code = "std::time::Duration::from_millis(200)")]
     duration: std::time::Duration,
 }
 

--- a/xmtp_mls/src/storage/errors.rs
+++ b/xmtp_mls/src/storage/errors.rs
@@ -1,7 +1,6 @@
 use std::sync::PoisonError;
 
 use diesel::result::DatabaseErrorKind;
-use openmls::prelude::CreationFromExternalError;
 use thiserror::Error;
 
 use crate::{retry::RetryableError, retryable};

--- a/xmtp_mls/src/storage/errors.rs
+++ b/xmtp_mls/src/storage/errors.rs
@@ -5,6 +5,8 @@ use thiserror::Error;
 
 use crate::{retry::RetryableError, retryable};
 
+use super::sql_key_store;
+
 #[derive(Debug, Error)]
 pub enum StorageError {
     #[error("Diesel connection error")]
@@ -42,8 +44,9 @@ impl<T> From<PoisonError<T>> for StorageError {
 impl RetryableError for diesel::result::Error {
     fn is_retryable(&self) -> bool {
         match self {
-            Self::DatabaseError(DatabaseErrorKind::Unknown, _) => true,
-            Self::DatabaseError(_, _) => false,
+            Self::DatabaseError(DatabaseErrorKind::UniqueViolation, _) => false,
+            Self::DatabaseError(DatabaseErrorKind::CheckViolation, _) => false,
+            Self::DatabaseError(DatabaseErrorKind::NotNullViolation, _) => false,
             // TODO: Figure out the full list of non-retryable errors.
             // The diesel code has a comment that "this type is not meant to be exhaustively matched"
             // so best is probably to return true here and map known errors to something else
@@ -67,7 +70,7 @@ impl RetryableError for StorageError {
 }
 
 // OpenMLS KeyStore errors
-impl RetryableError for openmls::group::AddMembersError<StorageError> {
+impl RetryableError for openmls::group::AddMembersError<sql_key_store::SqlKeyStoreError> {
     fn is_retryable(&self) -> bool {
         match self {
             Self::CreateCommitError(commit) => retryable!(commit),
@@ -78,7 +81,7 @@ impl RetryableError for openmls::group::AddMembersError<StorageError> {
     }
 }
 
-impl RetryableError for openmls::group::CreateCommitError<StorageError> {
+impl RetryableError for openmls::group::CreateCommitError<sql_key_store::SqlKeyStoreError> {
     fn is_retryable(&self) -> bool {
         match self {
             Self::KeyStoreError(storage) => retryable!(storage),
@@ -94,7 +97,7 @@ impl RetryableError for openmls::key_packages::errors::KeyPackageNewError {
     }
 }
 
-impl RetryableError for openmls::group::RemoveMembersError<StorageError> {
+impl RetryableError for openmls::group::RemoveMembersError<sql_key_store::SqlKeyStoreError> {
     fn is_retryable(&self) -> bool {
         match self {
             Self::CreateCommitError(commit) => retryable!(commit),
@@ -105,7 +108,7 @@ impl RetryableError for openmls::group::RemoveMembersError<StorageError> {
     }
 }
 
-impl RetryableError for openmls::group::NewGroupError<StorageError> {
+impl RetryableError for openmls::group::NewGroupError<sql_key_store::SqlKeyStoreError> {
     fn is_retryable(&self) -> bool {
         match self {
             Self::StorageError(storage) => retryable!(storage),
@@ -114,7 +117,9 @@ impl RetryableError for openmls::group::NewGroupError<StorageError> {
     }
 }
 
-impl RetryableError for openmls::group::UpdateGroupMembershipError<StorageError> {
+impl RetryableError
+    for openmls::group::UpdateGroupMembershipError<sql_key_store::SqlKeyStoreError>
+{
     fn is_retryable(&self) -> bool {
         match self {
             Self::CreateCommitError(create_commit) => retryable!(create_commit),
@@ -125,7 +130,7 @@ impl RetryableError for openmls::group::UpdateGroupMembershipError<StorageError>
     }
 }
 
-impl RetryableError for openmls::prelude::MlsGroupStateError<StorageError> {
+impl RetryableError for openmls::prelude::MlsGroupStateError<sql_key_store::SqlKeyStoreError> {
     fn is_retryable(&self) -> bool {
         match self {
             Self::StorageError(storage) => retryable!(storage),
@@ -134,7 +139,9 @@ impl RetryableError for openmls::prelude::MlsGroupStateError<StorageError> {
     }
 }
 
-impl RetryableError for openmls::prelude::CreateGroupContextExtProposalError<StorageError> {
+impl RetryableError
+    for openmls::prelude::CreateGroupContextExtProposalError<sql_key_store::SqlKeyStoreError>
+{
     fn is_retryable(&self) -> bool {
         match self {
             Self::CreateCommitError(create_commit) => retryable!(create_commit),
@@ -145,7 +152,7 @@ impl RetryableError for openmls::prelude::CreateGroupContextExtProposalError<Sto
     }
 }
 
-impl RetryableError for openmls::group::SelfUpdateError<StorageError> {
+impl RetryableError for openmls::group::SelfUpdateError<sql_key_store::SqlKeyStoreError> {
     fn is_retryable(&self) -> bool {
         match self {
             Self::CreateCommitError(commit) => retryable!(commit),
@@ -156,9 +163,10 @@ impl RetryableError for openmls::group::SelfUpdateError<StorageError> {
     }
 }
 
-impl RetryableError for openmls::prelude::CreationFromExternalError<StorageError> {
+impl RetryableError
+    for openmls::prelude::CreationFromExternalError<sql_key_store::SqlKeyStoreError>
+{
     fn is_retryable(&self) -> bool {
-        log::info!("checking if creation from external error is retryable");
         match self {
             Self::WriteToStorageError(storage) => retryable!(storage),
             _ => false,
@@ -166,7 +174,7 @@ impl RetryableError for openmls::prelude::CreationFromExternalError<StorageError
     }
 }
 
-impl RetryableError for openmls::group::WelcomeError<StorageError> {
+impl RetryableError for openmls::prelude::WelcomeError<sql_key_store::SqlKeyStoreError> {
     fn is_retryable(&self) -> bool {
         match self {
             Self::PublicGroupError(creation_err) => retryable!(creation_err),

--- a/xmtp_mls/src/storage/errors.rs
+++ b/xmtp_mls/src/storage/errors.rs
@@ -158,6 +158,7 @@ impl RetryableError for openmls::group::SelfUpdateError<StorageError> {
 
 impl RetryableError for openmls::prelude::CreationFromExternalError<StorageError> {
     fn is_retryable(&self) -> bool {
+        log::info!("checking if creation from external error is retryable");
         match self {
             Self::WriteToStorageError(storage) => retryable!(storage),
             _ => false,

--- a/xmtp_mls/src/storage/sql_key_store.rs
+++ b/xmtp_mls/src/storage/sql_key_store.rs
@@ -869,7 +869,7 @@ impl StorageProvider<CURRENT_VERSION> for SqlKeyStore {
 
         for proposal_ref in proposal_refs {
             let key = bincode::serialize(&(group_id, proposal_ref))?;
-            let _ = self.delete::<CURRENT_VERSION>(QUEUED_PROPOSAL_LABEL, &key)?;
+            self.delete::<CURRENT_VERSION>(QUEUED_PROPOSAL_LABEL, &key)?;
         }
 
         let key = build_key::<CURRENT_VERSION, &GroupId>(PROPOSAL_QUEUE_REFS_LABEL, group_id)?;


### PR DESCRIPTION
## tl;dr

- I noticed a bunch of cases where we were swallowing database errors in the SQL keystore. This fixes all of those and makes it hard fail if there is a database connection problem.
- Renames `MemoryKeystoreError` to `SqlKeyStoreError`
- Makes more error types support the RetryableError trait

## Notes
This is causing even more database locking errors, but that's a lot better than having read/write/delete operations failing silently. I had to add more retries to the default error handler to make this work, which is bad. Exponential backoff would be better than just hammering the db repeatedly.

The end goal of this is to better handle errors in `process_for_id` when syncing messages. If you have a bad message that fails, we don't really know whether to retry it or roll back the commit and move on to the next message in the queue.