### PR TITLE
fix: deprecation warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ futures = "0.3.30"
 futures-core = "0.3.30"
 hex = "0.4.3"
 log = { version = "0.4", features = ["release_max_level_debug"] }
-openmls = { git = "https://github.com/xmtp/openmls", rev = "9cb3207", default_features = false }
+openmls = { git = "https://github.com/xmtp/openmls", rev = "9cb3207", default-features = false }
 openmls_basic_credential = { git = "https://github.com/xmtp/openmls", rev = "9cb3207" }
 openmls_rust_crypto = { git = "https://github.com/xmtp/openmls", rev = "9cb3207" }
 openmls_traits = { git = "https://github.com/xmtp/openmls", rev = "9cb3207" }

--- a/xmtp_cryptography/Cargo.toml
+++ b/xmtp_cryptography/Cargo.toml
@@ -24,5 +24,4 @@ thiserror = { workspace = true }
 ws = ["ethers/ws"]
 
 [dev-dependencies]
-
 tokio = { version = "1.28.1", features = ["rt", "macros"] }

--- a/xmtp_id/Cargo.toml
+++ b/xmtp_id/Cargo.toml
@@ -3,8 +3,6 @@ edition = "2021"
 name = "xmtp_id"
 version = "0.1.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 async-trait.workspace = true
 chrono.workspace = true


### PR DESCRIPTION
## Summary

- Quick PR to fix a deprecation warning that was presenting when building.
- other minor `Cargo.toml` cleanup while I was looking at it

