### PR TITLE
Prepare node bindings release

### DIFF
--- a/bindings_node/CHANGELOG.md
+++ b/bindings_node/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @xmtp/mls-client-bindings-node
 
+## 0.0.8
+
+- Added description option when creating groups
+- Added description getter and setter to group instances
+- Fixed DB locking issues
+- Fixed invalid policy error
+- Removed Admin status from group creators (Super Admin only)
+
 ## 0.0.7
 
 - Improved streaming welcomes

--- a/bindings_node/package.json
+++ b/bindings_node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/mls-client-bindings-node",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "repository": {
     "type": "git",
     "url": "git+https://git@github.com/xmtp/libxmtp.git",


### PR DESCRIPTION
# Summary

This PR bumps the version to `0.0.8` and updates the changelog.