### PR TITLE
Fix optimistic sending

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,9 @@ dist
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
 
+# JetBrains IDE Info
+.idea/
+
 # yarn v2
 .yarn/cache
 .yarn/unplugged

--- a/bindings_node/src/mls_client.rs
+++ b/bindings_node/src/mls_client.rs
@@ -4,7 +4,7 @@ use napi_derive::napi;
 use std::collections::HashMap;
 use std::ops::Deref;
 use std::sync::Arc;
-use xmtp_api_grpc::grpc_api_helper::Client as TonicApiClient;
+pub use xmtp_api_grpc::grpc_api_helper::Client as TonicApiClient;
 use xmtp_cryptography::signature::ed25519_public_key_to_address;
 use xmtp_id::associations::generate_inbox_id as xmtp_id_generate_inbox_id;
 use xmtp_id::associations::{

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -2597,7 +2597,21 @@ mod tests {
 
         four.await.unwrap();
 
-        let message = get_latest_message(&bola_group, &bola).await;
-        assert_eq!(message.decrypted_message_bytes, b"test four");
+        bola_group.sync(&bola).await.unwrap();
+        let messages = bola_group
+            .find_messages(None, None, None, None, None)
+            .unwrap();
+        assert_eq!(
+            messages
+                .into_iter()
+                .map(|m| m.decrypted_message_bytes)
+                .collect::<Vec<Vec<u8>>>(),
+            vec![
+                b"test one".to_vec(),
+                b"test two".to_vec(),
+                b"test three".to_vec(),
+                b"test four".to_vec(),
+            ]
+        );
     }
 }

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -485,10 +485,7 @@ impl MlsGroup {
         message_id
     }
 
-    /// Send a message, optimistically retrieving ID before knowing
-    /// the result of a message send.
-    /// This requires calling [`MlsGroup::publish_messages`] for messages to be published
-    /// to the delivery service.
+    /// Send a message, optimistically retrieving ID before the result of a message send.
     pub fn send_message_optimistic<ApiClient>(
         &self,
         message: &[u8],

--- a/xmtp_mls/src/groups/sync.rs
+++ b/xmtp_mls/src/groups/sync.rs
@@ -734,13 +734,13 @@ impl MlsGroup {
     }
 
     #[tracing::instrument(level = "trace", skip(conn, self, client))]
-    pub(super) async fn publish_intents<ClientApi>(
+    pub(super) async fn publish_intents<ApiClient>(
         &self,
         conn: DbConnection,
-        client: &Client<ClientApi>,
+        client: &Client<ApiClient>,
     ) -> Result<(), GroupError>
     where
-        ClientApi: XmtpApi,
+        ApiClient: XmtpApi,
     {
         let provider = self.context.mls_provider(conn);
         let mut openmls_group = self.load_mls_group(&provider)?;


### PR DESCRIPTION
fixes #881 


- adds new `send_optimistic` to ffi and node bindings. `send_optimistic` 
    - returns `UnpublishedMessage` with an `id()` function and a `publish()` fn.
        - `publish` publishes intents. if sending many messages in a row, only one publish needs to be called. Alternatively, the group can also be `sync`ed. 