### PR TITLE
Notification broadcast system for streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5410,6 +5410,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -6512,6 +6513,7 @@ dependencies = [
  "thiserror",
  "tls_codec 0.4.1",
  "tokio",
+ "tokio-stream",
  "toml",
  "tracing",
  "tracing-flame",

--- a/xmtp_mls/Cargo.toml
+++ b/xmtp_mls/Cargo.toml
@@ -50,6 +50,7 @@ smart-default = "0.7.1"
 thiserror = { workspace = true }
 tls_codec = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
+tokio-stream = { version = "0.1", features = ["sync"] }
 toml = "0.8.4"
 xmtp_cryptography = { workspace = true }
 xmtp_id = { path = "../xmtp_id" }


### PR DESCRIPTION
fixes #504 


Adds a new `LocalEvent` enum as well as a `broadcast::Sender` stored on `Client`. A sender can produce receivers as-needed for streams in order to send-receive events for the local client. Any future irrelevant events can be safely ignored + dropped on a per-stream basis.