### PR TITLE
Message Failed State

### DIFF
--- a/xmtp_mls/src/groups/sync.rs
+++ b/xmtp_mls/src/groups/sync.rs
@@ -35,7 +35,6 @@ use crate::{
         group_intent::{IntentKind, IntentState, NewGroupIntent, StoredGroupIntent, ID},
         group_message::{DeliveryStatus, GroupMessageKind, StoredGroupMessage},
         refresh_state::EntityKind,
-        StorageError,
     },
     utils::{hash::sha256, id::calculate_message_id},
     xmtp_openmls_provider::XmtpOpenMlsProvider,
@@ -165,19 +164,6 @@ impl MlsGroup {
                     // This is expected. The intent gets deleted on success
                     return Ok(());
                 }
-                // if the intent is failed, mark the optimistic message as failed
-                Ok(Some(
-                    intent @ StoredGroupIntent {
-                        state: IntentState::Error,
-                        kind: IntentKind::SendMessage,
-                        ..
-                    },
-                )) => {
-                    let message_id = intent.message_id();
-                    if let Some(id) = message_id {
-                        conn.set_delivery_status_to_failed(&id)?;
-                    }
-                }
                 Ok(Some(StoredGroupIntent {
                     id,
                     state: IntentState::Error,
@@ -295,36 +281,9 @@ impl MlsGroup {
                 }
             }
             IntentKind::SendMessage => {
-                let intent_data = SendMessageIntentData::from_bytes(intent.data.as_slice())?;
-                let group_id = openmls_group.group_id().as_slice();
-                let decrypted_message_data = intent_data.message.as_slice();
-
-                let envelope = PlaintextEnvelope::decode(decrypted_message_data)
-                    .map_err(MessageProcessingError::DecodeError)?;
-
-                match envelope.content {
-                    Some(Content::V1(V1 {
-                        idempotency_key,
-                        content,
-                    })) => {
-                        let message_id = calculate_message_id(group_id, &content, &idempotency_key);
-
-                        conn.set_delivery_status_to_published(&message_id, envelope_timestamp_ns)?;
-                    }
-                    Some(Content::V2(V2 {
-                        idempotency_key: _,
-                        message_type,
-                    })) => {
-                        debug!(
-                            "Send Message History Request with message_type {:#?}",
-                            message_type
-                        );
-
-                        // return Empty Ok because it is okay to not process this self message
-                        return Ok(());
-                    }
-                    None => return Err(MessageProcessingError::InvalidPayload),
-                };
+                if let Some(id) = intent.message_id()? {
+                    conn.set_delivery_status_to_published(&id, envelope_timestamp_ns)?;
+                }
             }
         };
 
@@ -773,7 +732,9 @@ impl MlsGroup {
                 if (intent.publish_attempts + 1) as usize >= MAX_INTENT_PUBLISH_ATTEMPTS {
                     log::error!("intent {} has reached max publish attempts", intent.id);
                     // TODO: Eventually clean up errored attempts
-                    provider.conn().set_group_intent_error(intent.id)?;
+                    provider
+                        .conn()
+                        .set_group_intent_error_and_fail_msg(&intent)?;
                 } else {
                     provider
                         .conn()

--- a/xmtp_mls/src/storage/encrypted_store/group_intent.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group_intent.rs
@@ -7,14 +7,15 @@ use diesel::{
     sql_types::Integer,
     sqlite::Sqlite,
 };
+use prost::Message;
 
 use super::{
     db_connection::DbConnection,
     group,
     schema::{group_intents, group_intents::dsl},
 };
-use crate::{impl_fetch, impl_store, storage::StorageError, Delete};
-
+use crate::{impl_fetch, impl_store, storage::StorageError, Delete, groups::intents::SendMessageIntentData, utils::id::calculate_message_id};
+use xmtp_proto::xmtp::mls::message_contents::{plaintext_envelope::{Content, V1}, PlaintextEnvelope};
 pub type ID = i32;
 
 #[repr(i32)]
@@ -65,6 +66,32 @@ pub struct StoredGroupIntent {
     pub payload_hash: Option<Vec<u8>>,
     pub post_commit_data: Option<Vec<u8>>,
     pub publish_attempts: i32,
+}
+
+impl StoredGroupIntent {
+    /// Calculate the message id for this intent.
+    ///
+    ///
+    /// # Returns
+    /// Returns [`Option::None`] if [`StoredGroupIntent`] is not [`IntentKind::SendMessage`] or if
+    /// an error occurs during decoding of intent data.
+    pub fn message_id(&self) -> Option<Vec<u8>> {
+        if self.kind != IntentKind::SendMessage {
+            return None;
+        }
+        
+        let data = SendMessageIntentData::from_bytes(&self.data).ok()?;
+        let envelope: PlaintextEnvelope = PlaintextEnvelope::decode(data.message.as_slice()).ok()?;
+        // optimistic message should always have a plaintext envelope
+        let PlaintextEnvelope { 
+            content: Some(Content::V1(V1 { 
+                content: message,
+                idempotency_key: key
+            }))
+        } = envelope else { return None; };
+        
+        Some(calculate_message_id(&self.group_id, &message, &key))
+    }
 }
 
 impl_fetch!(StoredGroupIntent, group_intents, ID);

--- a/xmtp_mls/src/storage/encrypted_store/group_message.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group_message.rs
@@ -188,6 +188,20 @@ impl DbConnection {
                 .execute(conn)
         })?)
     }
+
+    pub fn set_delivery_status_to_failed<MessageId: AsRef<[u8]>>(
+        &self,
+        msg_id: &MessageId,
+    ) -> Result<usize, StorageError> {
+        Ok(self.raw_query(|conn| {
+            diesel::update(dsl::group_messages)
+                .filter(dsl::id.eq(msg_id.as_ref()))
+                .set((
+                    dsl::delivery_status.eq(DeliveryStatus::Published),
+                ))
+                .execute(conn)
+        })?)
+    }
 }
 
 #[cfg(test)]

--- a/xmtp_mls/src/storage/errors.rs
+++ b/xmtp_mls/src/storage/errors.rs
@@ -3,7 +3,7 @@ use std::sync::PoisonError;
 use diesel::result::DatabaseErrorKind;
 use thiserror::Error;
 
-use crate::{retry::RetryableError, retryable};
+use crate::{groups::intents::IntentError, retry::RetryableError, retryable};
 
 use super::sql_key_store;
 
@@ -33,6 +33,8 @@ pub enum StorageError {
     PoolNeedsConnection,
     #[error("Conflict")]
     Conflict(String),
+    #[error(transparent)]
+    Intent(#[from] IntentError),
 }
 
 impl<T> From<PoisonError<T>> for StorageError {


### PR DESCRIPTION
fixes #671 


> Mark the optimistic message as FAILED whenever its intent is marked as failed (set_group_intent_error)

added `message_id` function to `StoredGroupIntent` that calculates a `message_id` if the intent is of type `SendMessage`. On intent fail we can access the message and set it to failed in `publish_intents`.

> Make sure that every possible [error case in this method](https://github.com/xmtp/libxmtp/blob/main/xmtp_mls/src/groups/sync.rs#L156) results in the corresponding intent either being marked as TO_PUBLISH or FAILED

Verified that the intent is only returned as failed from `publish_intents`

> At some point in the future revisit whether there is a possibility of an infinite loop of intent retries. Maybe we should call increment_intent_publish_attempt_count() wherever we reset an intent to TO_PUBLISH, and just set a really high retry limit, like 10?

Intent retries are limited by 3 in `sync_until_intent_resolved` and also to 3 in `publish_intents`.

