### PR TITLE
Update node bindings group permissions

### DIFF
--- a/bindings_node/src/lib.rs
+++ b/bindings_node/src/lib.rs
@@ -4,4 +4,5 @@ pub mod encoded_content;
 mod groups;
 mod messages;
 pub mod mls_client;
+mod permissions;
 mod streams;

--- a/bindings_node/src/permissions.rs
+++ b/bindings_node/src/permissions.rs
@@ -1,0 +1,172 @@
+use napi::bindgen_prelude::{Error, Result};
+use napi_derive::napi;
+use xmtp_mls::groups::{
+  group_mutable_metadata::MetadataField,
+  group_permissions::{
+    BasePolicies, GroupMutablePermissions, MembershipPolicies, MetadataBasePolicies,
+    MetadataPolicies, PermissionsBasePolicies, PermissionsPolicies,
+  },
+  intents::{PermissionPolicyOption, PermissionUpdateType},
+  PreconfiguredPolicies,
+};
+
+#[napi]
+pub enum NapiGroupPermissionsOptions {
+  AllMembers,
+  AdminOnly,
+  CustomPolicy,
+}
+
+#[napi]
+pub enum NapiPermissionUpdateType {
+  AddMember,
+  RemoveMember,
+  AddAdmin,
+  RemoveAdmin,
+  UpdateMetadata,
+}
+
+impl From<&NapiPermissionUpdateType> for PermissionUpdateType {
+  fn from(update_type: &NapiPermissionUpdateType) -> Self {
+    match update_type {
+      NapiPermissionUpdateType::AddMember => PermissionUpdateType::AddMember,
+      NapiPermissionUpdateType::RemoveMember => PermissionUpdateType::RemoveMember,
+      NapiPermissionUpdateType::AddAdmin => PermissionUpdateType::AddAdmin,
+      NapiPermissionUpdateType::RemoveAdmin => PermissionUpdateType::RemoveAdmin,
+      NapiPermissionUpdateType::UpdateMetadata => PermissionUpdateType::UpdateMetadata,
+    }
+  }
+}
+
+#[napi]
+pub enum NapiPermissionPolicy {
+  Allow,
+  Deny,
+  Admin,
+  SuperAdmin,
+  DoesNotExist,
+  Other,
+}
+
+impl TryInto<PermissionPolicyOption> for NapiPermissionPolicy {
+  type Error = Error;
+
+  fn try_into(self) -> Result<PermissionPolicyOption> {
+    match self {
+      NapiPermissionPolicy::Allow => Ok(PermissionPolicyOption::Allow),
+      NapiPermissionPolicy::Deny => Ok(PermissionPolicyOption::Deny),
+      NapiPermissionPolicy::Admin => Ok(PermissionPolicyOption::AdminOnly),
+      NapiPermissionPolicy::SuperAdmin => Ok(PermissionPolicyOption::SuperAdminOnly),
+      _ => Err(Error::from_reason("InvalidPermissionPolicyOption")),
+    }
+  }
+}
+
+impl From<&MembershipPolicies> for NapiPermissionPolicy {
+  fn from(policies: &MembershipPolicies) -> Self {
+    if let MembershipPolicies::Standard(base_policy) = policies {
+      match base_policy {
+        BasePolicies::Allow => NapiPermissionPolicy::Allow,
+        BasePolicies::Deny => NapiPermissionPolicy::Deny,
+        BasePolicies::AllowSameMember => NapiPermissionPolicy::Other,
+        BasePolicies::AllowIfAdminOrSuperAdmin => NapiPermissionPolicy::Admin,
+        BasePolicies::AllowIfSuperAdmin => NapiPermissionPolicy::SuperAdmin,
+      }
+    } else {
+      NapiPermissionPolicy::Other
+    }
+  }
+}
+
+impl From<&MetadataPolicies> for NapiPermissionPolicy {
+  fn from(policies: &MetadataPolicies) -> Self {
+    if let MetadataPolicies::Standard(base_policy) = policies {
+      match base_policy {
+        MetadataBasePolicies::Allow => NapiPermissionPolicy::Allow,
+        MetadataBasePolicies::Deny => NapiPermissionPolicy::Deny,
+        MetadataBasePolicies::AllowIfActorAdminOrSuperAdmin => NapiPermissionPolicy::Admin,
+        MetadataBasePolicies::AllowIfActorSuperAdmin => NapiPermissionPolicy::SuperAdmin,
+      }
+    } else {
+      NapiPermissionPolicy::Other
+    }
+  }
+}
+
+impl From<&PermissionsPolicies> for NapiPermissionPolicy {
+  fn from(policies: &PermissionsPolicies) -> Self {
+    if let PermissionsPolicies::Standard(base_policy) = policies {
+      match base_policy {
+        PermissionsBasePolicies::Deny => NapiPermissionPolicy::Deny,
+        PermissionsBasePolicies::AllowIfActorAdminOrSuperAdmin => NapiPermissionPolicy::Admin,
+        PermissionsBasePolicies::AllowIfActorSuperAdmin => NapiPermissionPolicy::SuperAdmin,
+      }
+    } else {
+      NapiPermissionPolicy::Other
+    }
+  }
+}
+
+#[napi(object)]
+pub struct NapiPermissionPolicySet {
+  pub add_member_policy: NapiPermissionPolicy,
+  pub remove_member_policy: NapiPermissionPolicy,
+  pub add_admin_policy: NapiPermissionPolicy,
+  pub remove_admin_policy: NapiPermissionPolicy,
+  pub update_group_name_policy: NapiPermissionPolicy,
+  pub update_group_description_policy: NapiPermissionPolicy,
+  pub update_group_image_url_square_policy: NapiPermissionPolicy,
+  pub update_group_pinned_frame_url_policy: NapiPermissionPolicy,
+}
+
+impl From<PreconfiguredPolicies> for NapiGroupPermissionsOptions {
+  fn from(policy: PreconfiguredPolicies) -> Self {
+    match policy {
+      PreconfiguredPolicies::AllMembers => NapiGroupPermissionsOptions::AllMembers,
+      PreconfiguredPolicies::AdminsOnly => NapiGroupPermissionsOptions::AdminOnly,
+    }
+  }
+}
+
+#[napi]
+pub struct NapiGroupPermissions {
+  inner: GroupMutablePermissions,
+}
+
+#[napi]
+impl NapiGroupPermissions {
+  pub fn new(permissions: GroupMutablePermissions) -> Self {
+    Self { inner: permissions }
+  }
+
+  #[napi]
+  pub fn policy_type(&self) -> Result<NapiGroupPermissionsOptions> {
+    if let Ok(preconfigured_policy) = self.inner.preconfigured_policy() {
+      Ok(preconfigured_policy.into())
+    } else {
+      Ok(NapiGroupPermissionsOptions::CustomPolicy)
+    }
+  }
+
+  #[napi]
+  pub fn policy_set(&self) -> Result<NapiPermissionPolicySet> {
+    let policy_set = &self.inner.policies;
+    let metadata_policy_map = &policy_set.update_metadata_policy;
+    let get_policy = |field: &str| {
+      metadata_policy_map
+        .get(field)
+        .map(NapiPermissionPolicy::from)
+        .unwrap_or(NapiPermissionPolicy::DoesNotExist)
+    };
+    Ok(NapiPermissionPolicySet {
+      add_member_policy: NapiPermissionPolicy::from(&policy_set.add_member_policy),
+      remove_member_policy: NapiPermissionPolicy::from(&policy_set.remove_member_policy),
+      add_admin_policy: NapiPermissionPolicy::from(&policy_set.add_admin_policy),
+      remove_admin_policy: NapiPermissionPolicy::from(&policy_set.remove_admin_policy),
+      update_group_name_policy: get_policy(MetadataField::GroupName.as_str()),
+      update_group_description_policy: get_policy(MetadataField::Description.as_str()),
+      update_group_image_url_square_policy: get_policy(MetadataField::GroupImageUrlSquare.as_str()),
+      update_group_pinned_frame_url_policy: get_policy(MetadataField::GroupPinnedFrameUrl.as_str()),
+    })
+  }
+}

--- a/bindings_node/test/Conversations.test.ts
+++ b/bindings_node/test/Conversations.test.ts
@@ -1,4 +1,3 @@
-import { encode } from 'punycode'
 import { describe, expect, it } from 'vitest'
 import { AsyncStream } from '@test/AsyncStream'
 import {
@@ -6,7 +5,7 @@ import {
   createUser,
   encodeTextMessage,
 } from '@test/helpers'
-import { GroupPermissions, NapiGroup, NapiMessage } from '../dist'
+import { NapiGroup, NapiGroupPermissionsOptions, NapiMessage } from '../dist'
 
 describe('Conversations', () => {
   it('should not have initial conversations', async () => {
@@ -30,8 +29,18 @@ describe('Conversations', () => {
     expect(group.isActive()).toBe(true)
     expect(group.groupName()).toBe('')
     expect(group.groupPermissions().policyType()).toBe(
-      GroupPermissions.EveryoneIsAdmin
+      NapiGroupPermissionsOptions.AllMembers
     )
+    expect(group.groupPermissions().policySet()).toEqual({
+      addMemberPolicy: 0,
+      removeMemberPolicy: 2,
+      addAdminPolicy: 3,
+      removeAdminPolicy: 3,
+      updateGroupNamePolicy: 0,
+      updateGroupDescriptionPolicy: 0,
+      updateGroupImageUrlSquarePolicy: 0,
+      updateGroupPinnedFrameUrlPolicy: 0,
+    })
     expect(group.addedByInboxId()).toBe(client1.inboxId())
     expect(group.findMessages().length).toBe(1)
     const members = group.listMembers()
@@ -130,14 +139,25 @@ describe('Conversations', () => {
     const groupWithPermissions = await client1
       .conversations()
       .createGroup([user4.account.address], {
-        permissions: GroupPermissions.GroupCreatorIsAdmin,
+        permissions: NapiGroupPermissionsOptions.AdminOnly,
       })
     expect(groupWithPermissions).toBeDefined()
     expect(groupWithPermissions.groupName()).toBe('')
     expect(groupWithPermissions.groupImageUrlSquare()).toBe('')
     expect(groupWithPermissions.groupPermissions().policyType()).toBe(
-      GroupPermissions.GroupCreatorIsAdmin
+      NapiGroupPermissionsOptions.AdminOnly
     )
+
+    expect(groupWithPermissions.groupPermissions().policySet()).toEqual({
+      addMemberPolicy: 2,
+      removeMemberPolicy: 2,
+      addAdminPolicy: 3,
+      removeAdminPolicy: 3,
+      updateGroupNamePolicy: 2,
+      updateGroupDescriptionPolicy: 2,
+      updateGroupImageUrlSquarePolicy: 2,
+      updateGroupPinnedFrameUrlPolicy: 2,
+    })
 
     const groupWithDescription = await client1
       .conversations()


### PR DESCRIPTION
# Summary

This PR updates the node bindings with the latest group permissions changes to match the FFI bindings.