### PR TITLE
Fix panic in SQLCipher version logging

### DIFF
--- a/xmtp_mls/src/storage/errors.rs
+++ b/xmtp_mls/src/storage/errors.rs
@@ -35,6 +35,8 @@ pub enum StorageError {
     Conflict(String),
     #[error(transparent)]
     Intent(#[from] IntentError),
+    #[error("The SQLCipher Sqlite extension is not present, but an encryption key is given")]
+    SqlCipherNotLoaded,
 }
 
 impl<T> From<PoisonError<T>> for StorageError {


### PR DESCRIPTION
If the `enc_key` is set, but the `sql_cipher` version is non-existent (which means sqlcipher sqlite extension is not there) returns an error