### PR TITLE
Upgrade download-artifact action

### DIFF
--- a/.github/workflows/release-kotlin-bindings.yml
+++ b/.github/workflows/release-kotlin-bindings.yml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: bindings_ffi/jniLibs
 


### PR DESCRIPTION
# Summary

This _may_ fix the `Release Kotlin Bindings` workflow. Artifacts are being uploaded with v4 of the `upload-artifact` action and being downloaded with v3 of the `download-artifact` action. These versions are not compatible, which may be the reason that the artifacts can't be retrieved during this workflow.