### PR TITLE
Make `NoChanges` NoOp

### DIFF
--- a/bindings_ffi/Cargo.lock
+++ b/bindings_ffi/Cargo.lock
@@ -3051,9 +3051,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -5981,6 +5981,7 @@ dependencies = [
  "openmls_basic_credential",
  "openmls_rust_crypto",
  "openmls_traits",
+ "parking_lot",
  "prost 0.12.3",
  "rand",
  "reqwest 0.12.4",

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -110,8 +110,8 @@ pub enum GroupError {
     CreateMessage(#[from] openmls::prelude::CreateMessageError<sql_key_store::SqlKeyStoreError>),
     #[error("TLS Codec error: {0}")]
     TlsError(#[from] TlsCodecError),
-    #[error("No changes found in commit")]
-    NoChanges,
+    #[error("SequenceId not found in local db")]
+    MissingSequenceId,
     #[error("Addresses not found {0:?}")]
     AddressNotFound(Vec<String>),
     #[error("add members: {0}")]

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -592,7 +592,8 @@ impl MlsGroup {
         // If some existing group member has an update, this will return an intent with changes
         // when we really should return an error
         if intent_data.is_empty() {
-            return Err(GroupError::NoChanges);
+            log::warn!("Member already added");
+            return Ok(());
         }
 
         let intent = provider.conn().insert_group_intent(NewGroupIntent::new(

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -1492,8 +1492,8 @@ mod tests {
                 None,
             )
             .unwrap();
-        // Bola should have one uncommitted intent for the failed attempt at adding Charlie, who is already in the group
-        assert_eq!(bola_uncommitted_intents.len(), 1);
+        // Bola should have one uncommitted intent in `Error::Failed` state for the failed attempt at adding Charlie, who is already in the group
+        assert_eq!(bola_uncommitted_intents.len(), 0);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/xmtp_mls/src/groups/sync.rs
+++ b/xmtp_mls/src/groups/sync.rs
@@ -1312,4 +1312,26 @@ mod tests {
         }
         futures::future::join_all(futures).await;
     }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn publish_intents_no_changes() {
+        let wallet = generate_local_wallet();
+        let amal = Arc::new(ClientBuilder::new_test_client(&wallet).await);
+        let amal_group: Arc<MlsGroup> =
+            Arc::new(amal.create_group(None, Default::default()).unwrap());
+
+        let mut futures = vec![];
+        let conn = amal.context().store.conn().unwrap();
+
+        for _ in 0..10 {
+            let client = amal.clone();
+            let conn = conn.clone();
+            let group = amal_group.clone();
+
+            futures.push(async move {
+                group.publish_intents(conn, &client).await.unwrap();
+            });
+        }
+        futures::future::join_all(futures).await;
+    }
 }

--- a/xmtp_mls/src/groups/sync.rs
+++ b/xmtp_mls/src/groups/sync.rs
@@ -841,6 +841,7 @@ impl MlsGroup {
 
     // Takes a StoredGroupIntent and returns the payload and post commit data as a tuple
     // A return value of [`Option::None`] means this intent would not change the group.
+    #[allow(clippy::type_complexity)]
     #[tracing::instrument(level = "trace", skip_all)]
     async fn get_publish_intent_data<ApiClient>(
         &self,

--- a/xmtp_mls/src/groups/sync.rs
+++ b/xmtp_mls/src/groups/sync.rs
@@ -833,6 +833,10 @@ impl MlsGroup {
                     client.inbox_id(),
                     intent.id
                 );
+            } else {
+                provider
+                    .conn()
+                    .set_group_intent_error_and_fail_msg(&intent)?;
             }
         }
 

--- a/xmtp_mls/src/groups/sync.rs
+++ b/xmtp_mls/src/groups/sync.rs
@@ -1094,7 +1094,7 @@ impl MlsGroup {
                                 "Could not find existing sequence ID for inbox {}",
                                 inbox_id
                             );
-                            return Err(GroupError::NoChanges);
+                            return Err(GroupError::MissingSequenceId);
                         }
                     }
 

--- a/xmtp_mls/src/storage/encrypted_store/identity_update.rs
+++ b/xmtp_mls/src/storage/encrypted_store/identity_update.rs
@@ -97,7 +97,7 @@ impl DbConnection {
         Ok(self.raw_query(|conn| query.first::<i64>(conn))?)
     }
 
-    /// Given a list of inbox_ids return a hashamp of each inbox ID -> highest known sequence ID
+    /// Given a list of inbox_ids return a HashMap of each inbox ID -> highest known sequence ID
     #[tracing::instrument(level = "trace", skip_all)]
     pub fn get_latest_sequence_id(
         &self,


### PR DESCRIPTION
This converts the `NoChanges` err to NoOp in two places. It leaves the error on `get_membership_update_intent`. 