### PR TITLE
removed members should not be able to send messages

### DIFF
--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -1774,7 +1774,7 @@ mod tests {
             .any(|m| m.inbox_id == charlie.inbox_id()));
 
         group.sync(&amal).await.expect("sync failed");
-        
+
         group
             .send_message(b"hello", &bola)
             .await
@@ -1788,7 +1788,7 @@ mod tests {
             .unwrap()
             .into_iter()
             .collect::<Vec<StoredGroupMessage>>();
-         
+
         // FIXME:st this is passing ONLY because the message IS being sent to the group
         assert_eq!(amal_messages.len(), 1);
     }

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -1793,7 +1793,7 @@ mod tests {
         let message = amal_messages.first().unwrap();
 
         // FIXME:st this is passing ONLY because the message IS being sent to the group
-        assert!(message_text.eq(&message.decrypted_message_bytes[..]));
+        assert_eq!(message_text, &message.decrypted_message_bytes[..]);
         assert_eq!(amal_messages.len(), 1);
     }
 

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -1775,8 +1775,9 @@ mod tests {
 
         group.sync(&amal).await.expect("sync failed");
 
+        let message_text = b"hello";
         group
-            .send_message(b"hello", &bola)
+            .send_message(message_text, &bola)
             .await
             .expect_err("expected send_message to fail");
 
@@ -1789,7 +1790,10 @@ mod tests {
             .into_iter()
             .collect::<Vec<StoredGroupMessage>>();
 
+        let message = amal_messages.first().unwrap();
+        
         // FIXME:st this is passing ONLY because the message IS being sent to the group
+        assert!(message_text.eq(&message.decrypted_message_bytes[..]));
         assert_eq!(amal_messages.len(), 1);
     }
 

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -1791,7 +1791,7 @@ mod tests {
             .collect::<Vec<StoredGroupMessage>>();
 
         let message = amal_messages.first().unwrap();
-        
+
         // FIXME:st this is passing ONLY because the message IS being sent to the group
         assert!(message_text.eq(&message.decrypted_message_bytes[..]));
         assert_eq!(amal_messages.len(), 1);

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -1737,6 +1737,62 @@ mod tests {
         assert!(!bola_group.is_active().unwrap())
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn test_removed_members_cannot_send_message_to_others() {
+        let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
+        let bola_wallet = &generate_local_wallet();
+        let bola = ClientBuilder::new_test_client(bola_wallet).await;
+        let charlie_wallet = &generate_local_wallet();
+        let charlie = ClientBuilder::new_test_client(charlie_wallet).await;
+
+        let group = amal
+            .create_group(None, GroupMetadataOptions::default())
+            .unwrap();
+        group
+            .add_members(
+                &amal,
+                vec![bola_wallet.get_address(), charlie_wallet.get_address()],
+            )
+            .await
+            .unwrap();
+        assert_eq!(group.members().unwrap().len(), 3);
+
+        group
+            .remove_members(&amal, vec![bola_wallet.get_address()])
+            .await
+            .unwrap();
+        assert_eq!(group.members().unwrap().len(), 2);
+        assert!(group
+            .members()
+            .unwrap()
+            .iter()
+            .all(|m| m.inbox_id != bola.inbox_id()));
+        assert!(group
+            .members()
+            .unwrap()
+            .iter()
+            .any(|m| m.inbox_id == charlie.inbox_id()));
+
+        group.sync(&amal).await.expect("sync failed");
+        
+        group
+            .send_message(b"hello", &bola)
+            .await
+            .expect_err("expected send_message to fail");
+
+        group.sync(&bola).await.expect("sync failed");
+        group.sync(&amal).await.expect("sync failed");
+
+        let amal_messages = group
+            .find_messages(Some(GroupMessageKind::Application), None, None, None, None)
+            .unwrap()
+            .into_iter()
+            .collect::<Vec<StoredGroupMessage>>();
+         
+        // FIXME:st this is passing ONLY because the message IS being sent to the group
+        assert_eq!(amal_messages.len(), 1);
+    }
+
     // TODO:nm add more tests for filling in missing installations
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]


### PR DESCRIPTION
## Summary

From https://github.com/xmtp/libxmtp/issues/900, a member who has been from from a group should NOT be able to send messages to that group - after they have been removed from that group.   The test in this patch confirms they (still) can.

