### PR TITLE
The first message sent gets lost when Epochs behind 

### DIFF
--- a/bindings_ffi/Cargo.lock
+++ b/bindings_ffi/Cargo.lock
@@ -977,9 +977,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.2.0"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35b696af9ff4c0d2a507db2c5faafa8aa0205e297e5f11e203a24226d5355e7a"
+checksum = "bf97ee7261bb708fa3402fa9c17a54b70e90e3cb98afb3dc8999d5512cb03f94"
 dependencies = [
  "diesel_derives",
  "libsqlite3-sys",
@@ -2550,9 +2550,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+checksum = "d4588d65215825ee71ebff9e1c9982067833b1355d7546845ffdb3165cbd7456"
 dependencies = [
  "cc",
  "openssl-sys",

--- a/bindings_ffi/Cargo.lock
+++ b/bindings_ffi/Cargo.lock
@@ -4848,6 +4848,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -5903,6 +5904,7 @@ dependencies = [
  "thiserror",
  "tls_codec 0.4.0",
  "tokio",
+ "tokio-stream",
  "toml 0.8.8",
  "tracing",
  "xmtp_cryptography",

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -2229,6 +2229,88 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
+    async fn test_can_send_messages_when_epochs_behind() {
+        let alix = new_test_client().await;
+        let bo = new_test_client().await;
+        let caro = new_test_client().await;
+
+        let alix_group = alix
+            .conversations()
+            .create_group(
+                vec![caro.account_address.clone()],
+                FfiCreateGroupOptions::default(),
+            )
+            .await
+            .unwrap();
+
+        caro.conversations().sync().await.unwrap();
+
+        let caro_group = caro.group(alix_group.id()).unwrap();
+
+        alix_group
+            .send("alix message 1".as_bytes().to_vec())
+            .await
+            .unwrap();
+        caro_group
+            .send("caro message 1".as_bytes().to_vec())
+            .await
+            .unwrap();
+        alix_group
+            .add_members(vec![bo.account_address.clone()])
+            .await
+            .unwrap();
+        alix_group
+            .send("alix message 2".as_bytes().to_vec())
+            .await
+            .unwrap();
+        caro_group
+            .send("caro message 2".as_bytes().to_vec())
+            .await
+            .unwrap();
+
+        bo.conversations().sync().await.unwrap();
+        let bo_group = bo.group(alix_group.id()).unwrap();
+        bo_group
+            .send("bo message 1".as_bytes().to_vec())
+            .await
+            .unwrap();
+
+        bo_group.sync().await.unwrap();
+        alix_group.sync().await.unwrap();
+        caro_group.sync().await.unwrap();
+
+        let alix_messages = alix_group
+            .find_messages(FfiListMessagesOptions::default())
+            .unwrap();
+        let caro_messages = caro_group
+            .find_messages(FfiListMessagesOptions::default())
+            .unwrap();
+        let bo_messages = bo_group
+            .find_messages(FfiListMessagesOptions::default())
+            .unwrap();
+
+        let caro_message_2_found_bo = bo_messages
+            .iter()
+            .any(|message| message.content == "caro message 2".as_bytes());
+        assert!(
+            caro_message_2_found_bo,
+            "\"caro message 2\" not found in bo_messages"
+        );
+
+        let caro_message_2_found = alix_messages
+            .iter()
+            .any(|message| message.content == "caro message 2".as_bytes());
+        assert!(
+            caro_message_2_found,
+            "\"caro message 2\" not found in alix_messages"
+        );
+
+        assert_eq!(alix_messages.len(), 7);
+        assert_eq!(caro_messages.len(), 6);
+        assert_eq!(bo_messages.len(), 3);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
     async fn test_can_add_members_when_out_of_sync() {
         let alix = new_test_client().await;
         let bo = new_test_client().await;

--- a/bindings_node/Cargo.lock
+++ b/bindings_node/Cargo.lock
@@ -4588,6 +4588,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -5452,6 +5453,7 @@ dependencies = [
  "thiserror",
  "tls_codec 0.4.1",
  "tokio",
+ "tokio-stream",
  "toml",
  "tracing",
  "xmtp_cryptography",

--- a/bindings_node/Cargo.lock
+++ b/bindings_node/Cargo.lock
@@ -846,9 +846,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.2.0"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35b696af9ff4c0d2a507db2c5faafa8aa0205e297e5f11e203a24226d5355e7a"
+checksum = "bf97ee7261bb708fa3402fa9c17a54b70e90e3cb98afb3dc8999d5512cb03f94"
 dependencies = [
  "diesel_derives",
  "libsqlite3-sys",
@@ -2373,9 +2373,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+checksum = "d4588d65215825ee71ebff9e1c9982067833b1355d7546845ffdb3165cbd7456"
 dependencies = [
  "cc",
  "openssl-sys",
@@ -2885,9 +2885,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -5443,6 +5443,7 @@ dependencies = [
  "openmls_basic_credential",
  "openmls_rust_crypto",
  "openmls_traits",
+ "parking_lot",
  "prost 0.12.6",
  "rand",
  "reqwest 0.12.4",

--- a/xmtp_mls/src/groups/sync.rs
+++ b/xmtp_mls/src/groups/sync.rs
@@ -342,7 +342,7 @@ impl MlsGroup {
                     intent.id,
                     group_epoch,
                     message_epoch,
-                    3, // max_past_epochs, TODO: expose from OpenMLS MlsGroup
+                    1, // max_past_epochs, TODO: expose from OpenMLS MlsGroup
                 ) {
                     conn.set_group_intent_to_publish(intent.id)?;
                     return Ok(());


### PR DESCRIPTION
When the epoch of a group is changed a users messages won't successfully send until a sync is performed.


Possible related to our `max_past_epochs` setting not being honored by openmls. That would explain why, after the epoch is pushed forward by 1, the first message isn't decryptable. But we sync after sending, so all messages afterwards are decryptable