### PR TITLE
Fix missing members due to cache inconsistency

### DIFF
--- a/bindings_ffi/src/logger.rs
+++ b/bindings_ffi/src/logger.rs
@@ -20,7 +20,7 @@ impl log::Log for RustLogger {
             self.logger.lock().expect("Logger mutex is poisoned!").log(
                 record.level() as u32,
                 record.level().to_string(),
-                format!("[libxmtp] {}", record.args()),
+                format!("[libxmtp][t:{}] {}", thread_id::get(), record.args()),
             );
         }
     }

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -2297,6 +2297,8 @@ mod tests {
         let client1_members = client1_group.list_members().unwrap();
         assert_eq!(client1_members.len(), 2);
 
+        client2.conversations().sync().await.unwrap();
+        let client2_group = client2.group(group.id()).unwrap();
         let client2_members = client2_group.list_members().unwrap();
         assert_eq!(client2_members.len(), 2);
     }

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -1536,7 +1536,7 @@ mod tests {
 
     impl FfiLogger for MockLogger {
         fn log(&self, _level: u32, level_label: String, message: String) {
-            println!("[{}][t:{}]: {}", level_label, thread_id::get(), message)
+            println!("[{}]{}", level_label, message)
         }
     }
 

--- a/xmtp_mls/migrations/2024-05-11-004236_cache_association_state/up.sql
+++ b/xmtp_mls/migrations/2024-05-11-004236_cache_association_state/up.sql
@@ -1,3 +1,5 @@
+-- Caches the computed association state at a given sequence ID in an inbox log,
+-- so that we don't need to replay the whole log.
 CREATE TABLE association_state (
     "inbox_id" TEXT NOT NULL,
     "sequence_id" BIGINT NOT NULL,

--- a/xmtp_mls/migrations/2024-05-15-145138_new_schema/up.sql
+++ b/xmtp_mls/migrations/2024-05-15-145138_new_schema/up.sql
@@ -87,6 +87,8 @@ CREATE TABLE group_intents(
 
 CREATE INDEX group_intents_group_id_state ON group_intents(group_id, state);
 
+-- Caches the identity update payload at a given sequence ID, so that API calls
+-- don't need to be repeated.
 CREATE TABLE identity_updates(
     -- The inbox_id the update refers to
     "inbox_id" text NOT NULL,

--- a/xmtp_mls/src/api/identity.rs
+++ b/xmtp_mls/src/api/identity.rs
@@ -17,6 +17,7 @@ use xmtp_proto::xmtp::identity::api::v1::{
 
 const GET_IDENTITY_UPDATES_CHUNK_SIZE: usize = 50;
 
+#[derive(Debug)]
 /// A filter for querying identity updates. `sequence_id` is the starting sequence, and only later updates will be returned.
 pub struct GetIdentityUpdatesV2Filter {
     pub inbox_id: InboxId,

--- a/xmtp_mls/src/groups/group_membership.rs
+++ b/xmtp_mls/src/groups/group_membership.rs
@@ -105,6 +105,7 @@ impl From<&GroupMembership> for Vec<u8> {
     }
 }
 
+#[derive(Debug)]
 pub struct MembershipDiff<'inbox_id> {
     pub added_inboxes: Vec<&'inbox_id String>,
     pub removed_inboxes: Vec<&'inbox_id String>,

--- a/xmtp_mls/src/groups/members.rs
+++ b/xmtp_mls/src/groups/members.rs
@@ -43,14 +43,14 @@ impl MlsGroup {
             .collect::<Vec<_>>();
 
         let conn = provider.conn_ref();
-        let requests_len = requests.len();
-        let association_state_map = StoredAssociationState::batch_read_from_cache(conn, requests)?;
+        let association_state_map =
+            StoredAssociationState::batch_read_from_cache(conn, requests.clone())?;
         let mutable_metadata = self.mutable_metadata()?;
         // TODO: Figure out what to do with missing members from the local DB. Do we go to the network? Load from identity updates?
         // Right now I am just omitting them
-        if association_state_map.len() != requests_len {
+        if association_state_map.len() != requests.len() {
             // Cache miss - should either error if not expected, or should fetch from network if it is expected
-            log::error!("Failed to load all members for group");
+            log::error!("Failed to load all members for group: {:?}", requests);
         }
         let members = association_state_map
             .into_iter()

--- a/xmtp_mls/src/groups/members.rs
+++ b/xmtp_mls/src/groups/members.rs
@@ -43,10 +43,15 @@ impl MlsGroup {
             .collect::<Vec<_>>();
 
         let conn = provider.conn_ref();
+        let requests_len = requests.len();
         let association_state_map = StoredAssociationState::batch_read_from_cache(conn, requests)?;
         let mutable_metadata = self.mutable_metadata()?;
         // TODO: Figure out what to do with missing members from the local DB. Do we go to the network? Load from identity updates?
         // Right now I am just omitting them
+        if association_state_map.len() != requests_len {
+            // Cache miss - should either error if not expected, or should fetch from network if it is expected
+            log::error!("Failed to load all members for group");
+        }
         let members = association_state_map
             .into_iter()
             .map(|association_state| {

--- a/xmtp_mls/src/identity_updates.rs
+++ b/xmtp_mls/src/identity_updates.rs
@@ -152,11 +152,8 @@ where
             .get_association_state(conn, inbox_id.as_ref(), starting_sequence_id)
             .await?;
 
-        let incremental_updates = conn.get_identity_updates(
-            &inbox_id.as_ref(),
-            starting_sequence_id,
-            ending_sequence_id,
-        )?;
+        let incremental_updates =
+            conn.get_identity_updates(inbox_id.as_ref(), starting_sequence_id, ending_sequence_id)?;
 
         let last_sequence_id = incremental_updates.last().map(|update| update.sequence_id);
         if ending_sequence_id.is_some()

--- a/xmtp_mls/src/storage/encrypted_store/association_state.rs
+++ b/xmtp_mls/src/storage/encrypted_store/association_state.rs
@@ -47,7 +47,7 @@ impl StoredAssociationState {
         }
         .store_or_ignore(conn);
 
-        if !result.is_err() {
+        if result.is_ok() {
             log::debug!(
                 "Wrote association state to cache: {} {}",
                 inbox_id,
@@ -78,7 +78,7 @@ impl StoredAssociationState {
             })
             .transpose();
 
-        if !result.is_err() && result.as_ref().unwrap().is_some() {
+        if result.is_ok() && result.as_ref().unwrap().is_some() {
             log::debug!(
                 "Loaded association state from cache: {} {}",
                 inbox_id,

--- a/xmtp_mls/src/storage/encrypted_store/association_state.rs
+++ b/xmtp_mls/src/storage/encrypted_store/association_state.rs
@@ -40,12 +40,22 @@ impl StoredAssociationState {
         state: AssociationState,
     ) -> Result<(), StorageError> {
         let state_proto: AssociationStateProto = state.into();
-        StoredAssociationState {
-            inbox_id,
+        let result = StoredAssociationState {
+            inbox_id: inbox_id.clone(),
             sequence_id,
             state: state_proto.encode_to_vec(),
         }
-        .store_or_ignore(conn)
+        .store_or_ignore(conn);
+
+        if !result.is_err() {
+            log::debug!(
+                "Wrote association state to cache: {} {}",
+                inbox_id,
+                sequence_id
+            );
+        }
+
+        result
     }
 
     pub fn read_from_cache(
@@ -56,7 +66,7 @@ impl StoredAssociationState {
         let stored_state: Option<StoredAssociationState> =
             conn.fetch(&(inbox_id.to_string(), sequence_id))?;
 
-        stored_state
+        let result = stored_state
             .map(|stored_state| {
                 stored_state
                     .try_into()
@@ -66,7 +76,17 @@ impl StoredAssociationState {
                         ))
                     })
             })
-            .transpose()
+            .transpose();
+
+        if !result.is_err() && result.as_ref().unwrap().is_some() {
+            log::debug!(
+                "Loaded association state from cache: {} {}",
+                inbox_id,
+                sequence_id
+            );
+        }
+
+        result
     }
 
     pub fn batch_read_from_cache(

--- a/xmtp_mls/src/storage/encrypted_store/association_state.rs
+++ b/xmtp_mls/src/storage/encrypted_store/association_state.rs
@@ -93,7 +93,6 @@ impl StoredAssociationState {
         conn: &DbConnection,
         identifiers: Vec<(InboxId, i64)>,
     ) -> Result<Vec<AssociationState>, StorageError> {
-        // If no identifier provided, return empty hash map
         if identifiers.is_empty() {
             return Ok(vec![]);
         }

--- a/xmtp_mls/src/storage/encrypted_store/mod.rs
+++ b/xmtp_mls/src/storage/encrypted_store/mod.rs
@@ -184,7 +184,7 @@ impl EncryptedMessageStore {
             .as_ref()
             .ok_or(StorageError::PoolNeedsConnection)?;
 
-        log::info!(
+        log::debug!(
             "Pulling connection from pool, idle_connections={}, total_connections={}",
             pool.state().idle_connections,
             pool.state().connections


### PR DESCRIPTION
Depends on https://github.com/xmtp/libxmtp/pull/937

We currently write the association state cache whenever we compute an association state from scratch. Also, whenever we read an association state, we check the cache, and if it's not there, we go ahead and re-compute it. However, there are two codepaths that behave a little differently, causing us to underreport the members in a group:
1. One codepath computes incremental updates to an existing state, and does not update the cache.
2. One codepath batch reads multiple association states from the cache, and silently omits anything it doesn't find rather than re-computing it.

I've done a few things in this PR:

1. When computing incremental updates, make sure we also write to the cache
2. When batch reading from the cache, bake in a hard assumption that the cache will be up-to-date, and throw errors if we don't find what we expect
3. Some small improvements to our logging