### PR TITLE
Abort if retry fails

### DIFF
--- a/xmtp_mls/src/groups/sync.rs
+++ b/xmtp_mls/src/groups/sync.rs
@@ -693,10 +693,15 @@ impl MlsGroup {
             );
             if let Err(e) = result {
                 let is_retryable = e.is_retryable();
+                let error_message = e.to_string();
                 receive_errors.push(e);
                 // If the error is retryable we cannot move on to the next message
                 // otherwise you can get into a forked group state.
                 if is_retryable {
+                    log::error!(
+                        "Aborting message processing for retryable error: {}",
+                        error_message
+                    );
                     break;
                 }
             }

--- a/xmtp_mls/src/storage/encrypted_store/mod.rs
+++ b/xmtp_mls/src/storage/encrypted_store/mod.rs
@@ -175,7 +175,7 @@ impl EncryptedMessageStore {
         Ok(())
     }
 
-    fn raw_conn(
+    pub(crate) fn raw_conn(
         &self,
     ) -> Result<PooledConnection<ConnectionManager<SqliteConnection>>, StorageError> {
         let pool_guard = self.pool.read();


### PR DESCRIPTION
## tl;dr

This fixes a bug where transient errors can turn into a forked group state.

Imagine the following situation:

There are 2 unprocessed messages on the network, the first is a valid commit and the second is an application message.
- Client attempts to process message 1, but the database is locked and all retries are exhausted
- Client moves on to message 2 and is able to successfully process it. This updates the cursor in the database, so message 1 will never be tried again

There are many similar variations to this story (API downtime, cases where conflicting commits are inconsistently applied).

This fix changes the logic so that if an error is categorized as retryable, we will abort processing all further payloads. This does put even more pressure on us to correctly identify all retryable errors. If we categorize an error that will never resolve on its own as "retryable" the group will never be able to sync past this point. We should monitor these cases and fix them, rather than ever let a client move on and potentially fork group state.