### PR TITLE
skip empty key packages

### DIFF
--- a/xmtp_mls/src/api/mls.rs
+++ b/xmtp_mls/src/api/mls.rs
@@ -242,6 +242,7 @@ where
                     key_package.key_package_tls_serialized,
                 )
             })
+            .filter(|(_, key_package)| key_package.len() > 0)
             .collect();
 
         Ok(mapping)


### PR DESCRIPTION
if an installation id has a keypackage of length `0`, don't include it