### PR TITLE
Upload key package before publishing identity updates

### DIFF
--- a/mls_validation_service/src/handlers.rs
+++ b/mls_validation_service/src/handlers.rs
@@ -198,7 +198,8 @@ async fn validate_inbox_id_key_package(
         error_message: "".into(),
         credential: Some(kp.credential),
         installation_public_key: kp.installation_public_key,
-        expiration: kp.inner.life_time().not_after(),
+        // We are deprecating the expiration field and key package lifetimes, so stop checking for its existence
+        expiration: 0,
     })
 }
 
@@ -377,7 +378,7 @@ fn validate_key_package(key_package_bytes: Vec<u8>) -> Result<ValidateKeyPackage
         installation_id: verified_key_package.installation_id(),
         account_address: verified_key_package.account_address,
         credential_identity_bytes: basic_credential.identity().to_vec(),
-        expiration: verified_key_package.inner.life_time().not_after(),
+        expiration: 0,
     })
 }
 

--- a/xmtp_api_grpc_gateway/Cargo.lock
+++ b/xmtp_api_grpc_gateway/Cargo.lock
@@ -1498,12 +1498,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
 name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1750,15 +1744,6 @@ name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -2217,9 +2202,9 @@ checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
 
 [[package]]
 name = "pbjson"
-version = "0.7.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e6349fa080353f4a597daffd05cb81572a9c031a6d4fff7e504947496fcc68"
+checksum = "1030c719b0ec2a2d25a5df729d6cff1acf3cc230bf766f4f97833591f7577b90"
 dependencies = [
  "base64 0.21.4",
  "serde",
@@ -2227,27 +2212,27 @@ dependencies = [
 
 [[package]]
 name = "pbjson-build"
-version = "0.7.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eea3058763d6e656105d1403cb04e0a41b7bbac6362d413e7c33be0c32279c9"
+checksum = "2580e33f2292d34be285c5bc3dba5259542b083cfad6037b6d70345f24dcb735"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.13.0",
- "prost 0.13.1",
- "prost-types 0.13.1",
+ "heck",
+ "itertools 0.11.0",
+ "prost",
+ "prost-types",
 ]
 
 [[package]]
 name = "pbjson-types"
-version = "0.7.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54e5e7bfb1652f95bc361d76f3c780d8e526b134b85417e774166ee941f0887"
+checksum = "18f596653ba4ac51bdecbb4ef6773bc7f56042dc13927910de1684ad3d32aa12"
 dependencies = [
  "bytes",
  "chrono",
  "pbjson",
  "pbjson-build",
- "prost 0.13.1",
+ "prost",
  "prost-build",
  "serde",
 ]
@@ -2516,38 +2501,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
 dependencies = [
  "bytes",
- "prost-derive 0.12.3",
-]
-
-[[package]]
-name = "prost"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13db3d3fde688c61e2446b4d843bc27a7e8af269a69440c0308021dc92333cc"
-dependencies = [
- "bytes",
- "prost-derive 0.13.1",
+ "prost-derive",
 ]
 
 [[package]]
 name = "prost-build"
-version = "0.13.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb182580f71dd070f88d01ce3de9f4da5021db7115d2e1c3605a754153b77c1"
+checksum = "c55e02e35260070b6f716a2423c2ff1c3bb1642ddca6f99e1f26d06268a0e2d2"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck",
  "itertools 0.11.0",
  "log",
  "multimap",
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost 0.13.1",
- "prost-types 0.13.1",
+ "prost",
+ "prost-types",
  "regex",
  "syn 2.0.48",
  "tempfile",
+ "which",
 ]
 
 [[package]]
@@ -2564,34 +2540,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-derive"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18bec9b0adc4eba778b33684b7ba3e7137789434769ee3ce3930463ef904cfca"
-dependencies = [
- "anyhow",
- "itertools 0.11.0",
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
-
-[[package]]
 name = "prost-types"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e"
 dependencies = [
- "prost 0.12.3",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee5168b05f49d4b0ca581206eb14a7b22fafd963efe729ac48eb03266e25cc2"
-dependencies = [
- "prost 0.13.1",
+ "prost",
 ]
 
 [[package]]
@@ -3313,7 +3267,7 @@ version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad8d03b598d3d0fff69bf533ee3ef19b8eeb342729596df84bcc7e1f96ec4059"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -3897,6 +3851,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4115,8 +4081,8 @@ dependencies = [
  "getrandom",
  "hex",
  "js-sys",
- "prost 0.12.3",
- "prost-types 0.12.3",
+ "prost",
+ "prost-types",
  "reqwest",
  "uuid 1.4.1",
  "wasm-bindgen",
@@ -4155,8 +4121,8 @@ dependencies = [
  "futures-core",
  "pbjson",
  "pbjson-types",
- "prost 0.13.1",
- "prost-types 0.13.1",
+ "prost",
+ "prost-types",
  "serde",
 ]
 

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -419,23 +419,20 @@ where
             .collect())
     }
 
-    /// Register the identity with the network
-    /// Callers should always check the result of [`text_to_sign`](Self::text_to_sign) before invoking this function.
-    ///
-    /// If `text_to_sign` returns `None`, then the wallet signature is not required and this function can be called with `None`.
-    ///
-    /// If `text_to_sign` returns `Some`, then the caller should sign the text with their wallet and pass the signature to this function.
+    /// Upload a Key Package to the network and publish the signed identity update
+    /// from the provided SignatureRequest
     pub async fn register_identity(
         &self,
         signature_request: SignatureRequest,
     ) -> Result<(), ClientError> {
         log::info!("registering identity");
-        self.apply_signature_request(signature_request).await?;
-        let connection = self.store().conn()?;
-        let provider = self.mls_provider(connection);
+        // Register the identity before applying the signature request
+        let provider = self.mls_provider(self.store().conn()?);
         self.identity()
             .register(&provider, &self.api_client)
             .await?;
+
+        self.apply_signature_request(signature_request).await?;
 
         Ok(())
     }

--- a/xmtp_mls/src/identity.rs
+++ b/xmtp_mls/src/identity.rs
@@ -269,9 +269,8 @@ impl Identity {
                     .await?,
                 ))
                 .await?;
-            let identity_update = signature_request.build_identity_update()?;
-            api_client.publish_identity_update(identity_update).await?;
 
+            // Make sure to register the identity before applying the signature request
             let identity = Self {
                 inbox_id: inbox_id.clone(),
                 installation_keys: signature_keys,
@@ -280,6 +279,9 @@ impl Identity {
             };
 
             identity.register(provider, api_client).await?;
+
+            let identity_update = signature_request.build_identity_update()?;
+            api_client.publish_identity_update(identity_update).await?;
 
             Ok(identity)
         } else {
@@ -424,7 +426,7 @@ impl Identity {
         }
         let kp = self.new_key_package(provider)?;
         let kp_bytes = kp.tls_serialize_detached()?;
-        api_client.register_installation(kp_bytes, true).await?;
+        api_client.upload_key_package(kp_bytes, true).await?;
 
         Ok(StoredIdentity::from(self).store(provider.conn_ref())?)
     }

--- a/xmtp_mls/src/verified_key_package.rs
+++ b/xmtp_mls/src/verified_key_package.rs
@@ -70,9 +70,6 @@ impl VerifiedKeyPackage {
                 ),
             );
         }
-        if !kp.life_time().is_valid() {
-            return Err(KeyPackageVerificationError::InvalidLifetime);
-        }
 
         Ok(Self::new(kp, account_address))
     }

--- a/xmtp_mls/src/verified_key_package_v2.rs
+++ b/xmtp_mls/src/verified_key_package_v2.rs
@@ -75,10 +75,6 @@ impl TryFrom<KeyPackage> for VerifiedKeyPackageV2 {
         let pub_key_bytes = leaf_node.signature_key().as_slice().to_vec();
         let credential = MlsCredential::decode(basic_credential.identity())?;
 
-        if !kp.life_time().is_valid() {
-            return Err(KeyPackageVerificationError::InvalidLifetime);
-        }
-
         Ok(Self::new(kp, credential, pub_key_bytes))
     }
 }


### PR DESCRIPTION
### TL;DR
Implements parts of https://github.com/xmtp/xmtp-node-go/issues/399

- Uses `UploadKeyPackage` instead of `RegisterInstallation` so we can deprecate the register installation endpoint
- Uploads key package _before_ publishing the identity updates for new installations. This ensures that any installation seen in an identity update must have a matching key package.
- No longer checks the lifetime of key packages when verifying

## AI Assisted Summary

### What changed?

- Removed expiration checks and set expiration to 0 in MLS validation service
- Updated the client registration process to register identity before applying signature request
- Renamed `register_installation` to `upload_key_package` in API client calls
- Removed lifetime validity checks from key package verification

