### PR TITLE
Remove dead endpoints

### DIFF
--- a/xmtp_api_grpc/src/grpc_api_helper.rs
+++ b/xmtp_api_grpc/src/grpc_api_helper.rs
@@ -21,11 +21,10 @@ use xmtp_proto::{
     },
     xmtp::mls::api::v1::{
         mls_api_client::MlsApiClient as ProtoMlsApiClient, FetchKeyPackagesRequest,
-        FetchKeyPackagesResponse, GetIdentityUpdatesRequest, GetIdentityUpdatesResponse,
-        QueryGroupMessagesRequest, QueryGroupMessagesResponse, QueryWelcomeMessagesRequest,
-        QueryWelcomeMessagesResponse, RegisterInstallationRequest, RegisterInstallationResponse,
-        SendGroupMessagesRequest, SendWelcomeMessagesRequest, SubscribeGroupMessagesRequest,
-        SubscribeWelcomeMessagesRequest, UploadKeyPackageRequest,
+        FetchKeyPackagesResponse, QueryGroupMessagesRequest, QueryGroupMessagesResponse,
+        QueryWelcomeMessagesRequest, QueryWelcomeMessagesResponse, SendGroupMessagesRequest,
+        SendWelcomeMessagesRequest, SubscribeGroupMessagesRequest, SubscribeWelcomeMessagesRequest,
+        UploadKeyPackageRequest,
     },
 };
 
@@ -345,19 +344,6 @@ impl MutableApiSubscription for GrpcMutableSubscription {
 #[async_trait]
 impl XmtpMlsClient for Client {
     #[tracing::instrument(level = "trace", skip_all)]
-    async fn register_installation(
-        &self,
-        req: RegisterInstallationRequest,
-    ) -> Result<RegisterInstallationResponse, Error> {
-        let client = &mut self.mls_client.clone();
-        let res = client.register_installation(req).await;
-        match res {
-            Ok(response) => Ok(response.into_inner()),
-            Err(e) => Err(Error::new(ErrorKind::MlsError).with(e)),
-        }
-    }
-
-    #[tracing::instrument(level = "trace", skip_all)]
     async fn upload_key_package(&self, req: UploadKeyPackageRequest) -> Result<(), Error> {
         let client = &mut self.mls_client.clone();
         let res = client.upload_key_package(req).await;
@@ -420,18 +406,6 @@ impl XmtpMlsClient for Client {
     ) -> Result<QueryWelcomeMessagesResponse, Error> {
         let client = &mut self.mls_client.clone();
         let res = client.query_welcome_messages(req).await;
-
-        res.map(|r| r.into_inner())
-            .map_err(|e| Error::new(ErrorKind::MlsError).with(e))
-    }
-
-    #[tracing::instrument(level = "trace", skip_all)]
-    async fn get_identity_updates(
-        &self,
-        req: GetIdentityUpdatesRequest,
-    ) -> Result<GetIdentityUpdatesResponse, Error> {
-        let client = &mut self.mls_client.clone();
-        let res = client.get_identity_updates(req).await;
 
         res.map(|r| r.into_inner())
             .map_err(|e| Error::new(ErrorKind::MlsError).with(e))

--- a/xmtp_api_http/src/lib.rs
+++ b/xmtp_api_http/src/lib.rs
@@ -13,11 +13,10 @@ use xmtp_proto::xmtp::mls::api::v1::{GroupMessage, WelcomeMessage};
 use xmtp_proto::{
     api_client::{GroupMessageStream, WelcomeMessageStream, XmtpMlsClient},
     xmtp::mls::api::v1::{
-        FetchKeyPackagesRequest, FetchKeyPackagesResponse, GetIdentityUpdatesRequest,
-        GetIdentityUpdatesResponse, QueryGroupMessagesRequest, QueryGroupMessagesResponse,
-        QueryWelcomeMessagesRequest, QueryWelcomeMessagesResponse, RegisterInstallationRequest,
-        RegisterInstallationResponse, SendGroupMessagesRequest, SendWelcomeMessagesRequest,
-        SubscribeGroupMessagesRequest, SubscribeWelcomeMessagesRequest, UploadKeyPackageRequest,
+        FetchKeyPackagesRequest, FetchKeyPackagesResponse, QueryGroupMessagesRequest,
+        QueryGroupMessagesResponse, QueryWelcomeMessagesRequest, QueryWelcomeMessagesResponse,
+        SendGroupMessagesRequest, SendWelcomeMessagesRequest, SubscribeGroupMessagesRequest,
+        SubscribeWelcomeMessagesRequest, UploadKeyPackageRequest,
     },
 };
 
@@ -54,25 +53,6 @@ impl XmtpHttpApiClient {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl XmtpMlsClient for XmtpHttpApiClient {
-    async fn register_installation(
-        &self,
-        request: RegisterInstallationRequest,
-    ) -> Result<RegisterInstallationResponse, Error> {
-        let res = self
-            .http_client
-            .post(self.endpoint(ApiEndpoints::REGISTER_INSTALLATION))
-            .json(&request)
-            .send()
-            .await
-            .map_err(|e| Error::new(ErrorKind::MlsError).with(e))?
-            .bytes()
-            .await
-            .map_err(|e| Error::new(ErrorKind::MlsError).with(e))?;
-
-        log::debug!("register_installation");
-        handle_error(&*res)
-    }
-
     async fn upload_key_package(&self, request: UploadKeyPackageRequest) -> Result<(), Error> {
         let res = self
             .http_client
@@ -141,14 +121,6 @@ impl XmtpMlsClient for XmtpHttpApiClient {
 
         log::debug!("send_welcome_messages");
         handle_error(&*res)
-    }
-
-    // deprecated
-    async fn get_identity_updates(
-        &self,
-        _request: GetIdentityUpdatesRequest,
-    ) -> Result<GetIdentityUpdatesResponse, Error> {
-        unimplemented!()
     }
 
     async fn query_group_messages(
@@ -287,10 +259,10 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn test_register_installation() {
+    async fn test_upload_key_package() {
         let client = XmtpHttpApiClient::new(ApiUrls::LOCAL_ADDRESS.to_string()).unwrap();
         let result = client
-            .register_installation(RegisterInstallationRequest {
+            .upload_key_package(UploadKeyPackageRequest {
                 is_inbox_id_credential: false,
                 key_package: Some(KeyPackageUpload {
                     key_package_tls_serialized: vec![1, 2, 3],

--- a/xmtp_mls/src/api/test_utils.rs
+++ b/xmtp_mls/src/api/test_utils.rs
@@ -11,12 +11,10 @@ use xmtp_proto::{
     },
     xmtp::mls::api::v1::{
         group_message::{Version as GroupMessageVersion, V1 as GroupMessageV1},
-        FetchKeyPackagesRequest, FetchKeyPackagesResponse, GetIdentityUpdatesRequest,
-        GetIdentityUpdatesResponse, GroupMessage, QueryGroupMessagesRequest,
+        FetchKeyPackagesRequest, FetchKeyPackagesResponse, GroupMessage, QueryGroupMessagesRequest,
         QueryGroupMessagesResponse, QueryWelcomeMessagesRequest, QueryWelcomeMessagesResponse,
-        RegisterInstallationRequest, RegisterInstallationResponse, SendGroupMessagesRequest,
-        SendWelcomeMessagesRequest, SubscribeGroupMessagesRequest, SubscribeWelcomeMessagesRequest,
-        UploadKeyPackageRequest,
+        SendGroupMessagesRequest, SendWelcomeMessagesRequest, SubscribeGroupMessagesRequest,
+        SubscribeWelcomeMessagesRequest, UploadKeyPackageRequest,
     },
 };
 
@@ -44,10 +42,6 @@ mock! {
 
     #[async_trait]
     impl XmtpMlsClient for ApiClient {
-        async fn register_installation(
-            &self,
-            request: RegisterInstallationRequest,
-        ) -> Result<RegisterInstallationResponse, Error>;
         async fn upload_key_package(&self, request: UploadKeyPackageRequest) -> Result<(), Error>;
         async fn fetch_key_packages(
             &self,
@@ -55,10 +49,6 @@ mock! {
         ) -> Result<FetchKeyPackagesResponse, Error>;
         async fn send_group_messages(&self, request: SendGroupMessagesRequest) -> Result<(), Error>;
         async fn send_welcome_messages(&self, request: SendWelcomeMessagesRequest) -> Result<(), Error>;
-        async fn get_identity_updates(
-            &self,
-            request: GetIdentityUpdatesRequest,
-        ) -> Result<GetIdentityUpdatesResponse, Error>;
         async fn query_group_messages(&self, request: QueryGroupMessagesRequest) -> Result<QueryGroupMessagesResponse, Error>;
         async fn query_welcome_messages(&self, request: QueryWelcomeMessagesRequest) -> Result<QueryWelcomeMessagesResponse, Error>;
         async fn subscribe_group_messages(&self, request: SubscribeGroupMessagesRequest) -> Result<GroupMessageStream, Error>;

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -664,7 +664,7 @@ mod tests {
         let client = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let result = client
             .api_client
-            .register_installation(vec![1, 2, 3], false)
+            .upload_key_package(vec![1, 2, 3], false)
             .await;
 
         assert!(result.is_err());

--- a/xmtp_proto/src/api_client.rs
+++ b/xmtp_proto/src/api_client.rs
@@ -13,12 +13,10 @@ use crate::xmtp::identity::api::v1::{
     GetInboxIdsResponse, PublishIdentityUpdateRequest, PublishIdentityUpdateResponse,
 };
 use crate::xmtp::mls::api::v1::{
-    FetchKeyPackagesRequest, FetchKeyPackagesResponse, GetIdentityUpdatesRequest,
-    GetIdentityUpdatesResponse, GroupMessage, QueryGroupMessagesRequest,
+    FetchKeyPackagesRequest, FetchKeyPackagesResponse, GroupMessage, QueryGroupMessagesRequest,
     QueryGroupMessagesResponse, QueryWelcomeMessagesRequest, QueryWelcomeMessagesResponse,
-    RegisterInstallationRequest, RegisterInstallationResponse, SendGroupMessagesRequest,
-    SendWelcomeMessagesRequest, SubscribeGroupMessagesRequest, SubscribeWelcomeMessagesRequest,
-    UploadKeyPackageRequest, WelcomeMessage,
+    SendGroupMessagesRequest, SendWelcomeMessagesRequest, SubscribeGroupMessagesRequest,
+    SubscribeWelcomeMessagesRequest, UploadKeyPackageRequest, WelcomeMessage,
 };
 
 #[derive(Debug)]
@@ -144,10 +142,6 @@ pub type WelcomeMessageStream = Pin<Box<dyn Stream<Item = Result<WelcomeMessage,
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait XmtpMlsClient: Send + Sync + 'static {
-    async fn register_installation(
-        &self,
-        request: RegisterInstallationRequest,
-    ) -> Result<RegisterInstallationResponse, Error>;
     async fn upload_key_package(&self, request: UploadKeyPackageRequest) -> Result<(), Error>;
     async fn fetch_key_packages(
         &self,
@@ -156,10 +150,6 @@ pub trait XmtpMlsClient: Send + Sync + 'static {
     async fn send_group_messages(&self, request: SendGroupMessagesRequest) -> Result<(), Error>;
     async fn send_welcome_messages(&self, request: SendWelcomeMessagesRequest)
         -> Result<(), Error>;
-    async fn get_identity_updates(
-        &self,
-        request: GetIdentityUpdatesRequest,
-    ) -> Result<GetIdentityUpdatesResponse, Error>;
     async fn query_group_messages(
         &self,
         request: QueryGroupMessagesRequest,


### PR DESCRIPTION
## AI Assisted Summary

### TL;DR

Removed deprecated MLS API methods and updated related functionality.

### What changed?

- Removed `register_installation` method from `XmtpMlsClient` trait and its implementations.
- Removed `get_identity_updates` method from `XmtpMlsClient` trait and its implementations.
- Removed related types and imports for these deprecated methods.
- Updated tests to reflect these changes.

### How to test?

1. Ensure all existing tests pass after removing the deprecated methods.
2. Verify that any code previously using `register_installation` now uses `upload_key_package` instead.
3. Check that no code is relying on the removed `get_identity_updates` functionality.

### Why make this change?

This change is part of an effort to streamline the MLS API by removing deprecated methods. The `register_installation` method has been replaced by `upload_key_package`, and `get_identity_updates` is no longer needed. Removing these methods simplifies the API, reduces maintenance overhead, and ensures that clients are using the most up-to-date methods for interacting with the MLS system.

---

