### PR TITLE
Stop setting new lifetimes

### DIFF
--- a/xmtp_mls/src/identity.rs
+++ b/xmtp_mls/src/identity.rs
@@ -24,7 +24,6 @@ use openmls::{
     extensions::{
         ApplicationIdExtension, Extension, ExtensionType, Extensions, LastResortExtension,
     },
-    key_packages::Lifetime,
     messages::proposals::ProposalType,
     prelude::{Capabilities, Credential as OpenMlsCredential},
     prelude_test::KeyPackage,
@@ -381,7 +380,6 @@ impl Identity {
             .leaf_node_capabilities(capabilities)
             .leaf_node_extensions(leaf_node_extensions)
             .key_package_extensions(key_package_extensions)
-            .key_package_lifetime(Lifetime::new(6 * 30 * 86400))
             .build(
                 CIPHERSUITE,
                 &provider,

--- a/xmtp_mls/src/verified_key_package.rs
+++ b/xmtp_mls/src/verified_key_package.rs
@@ -32,8 +32,6 @@ pub enum KeyPackageVerificationError {
     InvalidCredential,
     #[error(transparent)]
     Association(#[from] AssociationError),
-    #[error("invalid lifetime")]
-    InvalidLifetime,
     #[error("generic: {0}")]
     Generic(String),
     #[error("wrong credential type")]

--- a/xmtp_mls/src/verified_key_package_v2.rs
+++ b/xmtp_mls/src/verified_key_package_v2.rs
@@ -18,8 +18,6 @@ pub enum KeyPackageVerificationError {
     TlsError(#[from] TlsCodecError),
     #[error("mls validation: {0}")]
     MlsValidation(#[from] KeyPackageVerifyError),
-    #[error("invalid lifetime")]
-    InvalidLifetime,
     #[error("wrong credential type")]
     WrongCredentialType(#[from] BasicCredentialError),
     #[error(transparent)]


### PR DESCRIPTION
## tl;dr

- Stops setting new lifetimes on key packages, so that we don't run in to cases of users with invalid key packages in 6 months
- Anyone with a key package with no lifetime will appear as being invalid to an older client version, which will prevent anyone from adding them to a group. Reading existing commits that add that member to a group will also fail on client SDK versions that still check for lifetimes.
- Ideally we roll this out concurrently to wiping all existing installations, and we get everyone upgraded to a newer SDK version.