### PR TITLE
Clean up empty intents

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -2304,6 +2304,98 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
+    async fn test_create_new_installations_does_not_fork_group() {
+        let bo_wallet_key = &mut rng();
+        let bo_wallet = xmtp_cryptography::utils::LocalWallet::new(bo_wallet_key);
+
+        // Create clients
+        let alix = new_test_client().await;
+        let bo = new_test_client_with_wallet(bo_wallet.clone()).await;
+        let caro = new_test_client().await;
+
+        let message_callbacks = RustStreamCallback::default();
+        let stream_messages = alix
+            .conversations()
+            .stream_all_messages(Box::new(message_callbacks.clone()))
+            .await;
+        stream_messages.wait_for_ready().await;
+
+        let group = alix
+            .conversations()
+            .create_group(
+                vec![bo.account_address.clone(), caro.account_address.clone()],
+                FfiCreateGroupOptions::default(),
+            )
+            .await
+            .unwrap();
+
+        // Sync groups
+        alix.conversations().sync().await.unwrap();
+        bo.conversations().sync().await.unwrap();
+        caro.conversations().sync().await.unwrap();
+
+        // Find groups for both clients
+        let alix_group = alix.group(group.id()).unwrap();
+        let caro_group = bo.group(group.id()).unwrap();
+
+        // Send messages
+        alix_group
+            .send("First message".as_bytes().to_vec())
+            .await
+            .unwrap();
+
+        caro_group
+            .send("Second message".as_bytes().to_vec())
+            .await
+            .unwrap();
+
+        // Drop and delete local database for client2
+        bo.release_db_connection().unwrap();
+
+        // Recreate client2 (new installation)
+        let bo2 = new_test_client_with_wallet(bo_wallet).await;
+
+        // let bo_message_callbacks = RustStreamCallback::default();
+        // let bo_stream_messages = bo2
+        //     .conversations()
+        //     .stream_all_messages(Box::new(bo_message_callbacks.clone()))
+        //     .await;
+        // bo_stream_messages.wait_for_ready().await;
+
+        // Send a message that will break the group
+        alix_group
+            .send("Third message".as_bytes().to_vec())
+            .await
+            .unwrap();
+
+        let bo_group = bo2.group(group.id()).unwrap();
+
+        bo_group
+            .send("Fourth message".as_bytes().to_vec())
+            .await
+            .unwrap();
+
+        caro_group
+            .send("Fifth message".as_bytes().to_vec())
+            .await
+            .unwrap();
+
+        let caro_messages = caro_group
+            .find_messages(FfiListMessagesOptions::default())
+            .unwrap();
+        let alix_messages = alix_group
+            .find_messages(FfiListMessagesOptions::default())
+            .unwrap();
+        let bo_messages = bo_group
+            .find_messages(FfiListMessagesOptions::default())
+            .unwrap();
+
+        assert_eq!(caro_messages.len(), 5);
+        assert_eq!(alix_messages.len(), 6);
+        assert_eq!(bo_messages.len(), 5);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
     async fn test_can_send_messages_when_epochs_behind() {
         let alix = new_test_client().await;
         let bo = new_test_client().await;

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -2400,7 +2400,8 @@ mod tests {
 
         assert_eq!(caro_messages.len(), 5);
         assert_eq!(alix_messages.len(), 6);
-        assert_eq!(bo_messages.len(), 5);
+        // Bo 2 only sees three messages since it joined after the first 2 were sent
+        assert_eq!(bo_messages.len(), 3);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 5)]

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -2386,6 +2386,11 @@ mod tests {
             .await
             .unwrap();
 
+        alix_group.sync().await.unwrap();
+        bo_group.sync().await.unwrap();
+        bo2_group.sync().await.unwrap();
+        caro_group.sync().await.unwrap();
+
         // Get the message count for all the clients
         let caro_messages = caro_group
             .find_messages(FfiListMessagesOptions::default())
@@ -2393,11 +2398,9 @@ mod tests {
         let alix_messages = alix_group
             .find_messages(FfiListMessagesOptions::default())
             .unwrap();
-        bo_group.sync().await.unwrap();
         let bo_messages = bo_group
             .find_messages(FfiListMessagesOptions::default())
             .unwrap();
-
         let bo2_messages = bo2_group
             .find_messages(FfiListMessagesOptions::default())
             .unwrap();

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -1455,7 +1455,7 @@ mod tests {
         bola_group
             .add_members_by_inbox_id(&bola, vec![charlie.inbox_id()])
             .await
-            .expect_err("expected error");
+            .expect("bola's add should succeed in a no-op");
 
         amal_group
             .receive(&amal.store().conn().unwrap(), &amal)
@@ -1494,8 +1494,8 @@ mod tests {
                 None,
             )
             .unwrap();
-        // Bola should have one uncommitted intent in `Error::Failed` state for the failed attempt at adding Charlie, who is already in the group
-        assert_eq!(bola_failed_intents.len(), 1);
+        // Bola's attempted add should be deleted, since it will have been a no-op on the second try
+        assert_eq!(bola_failed_intents.len(), 0);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/xmtp_mls/src/subscriptions.rs
+++ b/xmtp_mls/src/subscriptions.rs
@@ -237,7 +237,7 @@ where
         let (tx, rx) = oneshot::channel();
 
         let handle = tokio::spawn(async move {
-            let mut stream = client.stream_conversations().await.unwrap();
+            let mut stream = client.stream_conversations().await?;
             let _ = tx.send(());
             while let Some(convo) = stream.next().await {
                 convo_callback(convo)


### PR DESCRIPTION
## tl;dr

- We [recently made a change](https://github.com/xmtp/libxmtp/pull/927/files) where `get_publish_intent_data` returns an `Option`, but we were not properly handling the None value of the return.
- In the case where there is no publish intent data, we should delete the intent since there is nothing left to do.