### PR TITLE
Explicitly pass OpenMlsProvider to metadata functions

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -997,7 +997,8 @@ impl FfiGroup {
             self.created_at_ns,
         );
 
-        let group_name = group.group_name()?;
+        let provider = group.mls_provider()?;
+        let group_name = group.group_name(&provider)?;
 
         Ok(group_name)
     }
@@ -1026,7 +1027,7 @@ impl FfiGroup {
             self.created_at_ns,
         );
 
-        let group_image_url_square = group.group_image_url_square()?;
+        let group_image_url_square = group.group_image_url_square(group.mls_provider()?)?;
 
         Ok(group_image_url_square)
     }
@@ -1055,7 +1056,7 @@ impl FfiGroup {
             self.created_at_ns,
         );
 
-        let group_description = group.group_description()?;
+        let group_description = group.group_description(group.mls_provider()?)?;
 
         Ok(group_description)
     }
@@ -1084,7 +1085,7 @@ impl FfiGroup {
             self.created_at_ns,
         );
 
-        let group_pinned_frame_url = group.group_pinned_frame_url()?;
+        let group_pinned_frame_url = group.group_pinned_frame_url(group.mls_provider()?)?;
 
         Ok(group_pinned_frame_url)
     }
@@ -1096,7 +1097,7 @@ impl FfiGroup {
             self.created_at_ns,
         );
 
-        let admin_list = group.admin_list()?;
+        let admin_list = group.admin_list(group.mls_provider()?)?;
 
         Ok(admin_list)
     }
@@ -1108,7 +1109,7 @@ impl FfiGroup {
             self.created_at_ns,
         );
 
-        let super_admin_list = group.super_admin_list()?;
+        let super_admin_list = group.super_admin_list(group.mls_provider()?)?;
 
         Ok(super_admin_list)
     }
@@ -1238,7 +1239,7 @@ impl FfiGroup {
             self.created_at_ns,
         );
 
-        Ok(group.is_active()?)
+        Ok(group.is_active(group.mls_provider()?)?)
     }
 
     pub fn added_by_inbox_id(&self) -> Result<String, GenericError> {
@@ -1258,7 +1259,7 @@ impl FfiGroup {
             self.created_at_ns,
         );
 
-        let metadata = group.metadata()?;
+        let metadata = group.metadata(group.mls_provider()?)?;
         Ok(Arc::new(FfiGroupMetadata {
             inner: Arc::new(metadata),
         }))

--- a/bindings_node/src/lib.rs
+++ b/bindings_node/src/lib.rs
@@ -17,9 +17,9 @@ where
   E: std::error::Error;
 
 impl<T: std::error::Error> std::fmt::Display for ErrorWrapper<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-        write!(f, "{}", self.0)
-    }
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+    write!(f, "{}", self.0)
+  }
 }
 
 impl<T> From<T> for ErrorWrapper<T>

--- a/bindings_node/src/lib.rs
+++ b/bindings_node/src/lib.rs
@@ -6,3 +6,33 @@ mod messages;
 pub mod mls_client;
 mod permissions;
 mod streams;
+
+use napi::bindgen_prelude::Error;
+
+/// Wrapper over any error
+/// to make most error handling in napi cleaner
+#[derive(Debug)]
+pub struct ErrorWrapper<E>(E)
+where
+  E: std::error::Error;
+
+impl<T: std::error::Error> std::fmt::Display for ErrorWrapper<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl<T> From<T> for ErrorWrapper<T>
+where
+  T: std::error::Error,
+{
+  fn from(err: T) -> ErrorWrapper<T> {
+    ErrorWrapper(err)
+  }
+}
+
+impl<T: std::error::Error> From<ErrorWrapper<T>> for napi::bindgen_prelude::Error {
+  fn from(e: ErrorWrapper<T>) -> napi::bindgen_prelude::Error {
+    Error::from_reason(e.to_string())
+  }
+}

--- a/examples/cli/serializable.rs
+++ b/examples/cli/serializable.rs
@@ -30,7 +30,13 @@ impl<'a> From<&'a MlsGroup> for SerializableGroup {
             .map(|m| m.inbox_id)
             .collect::<Vec<String>>();
 
-        let metadata = group.metadata().expect("could not load metadata");
+        let metadata = group
+            .metadata(
+                group
+                    .mls_provider()
+                    .expect("MLS Provider could not be created"),
+            )
+            .expect("could not load metadata");
         let permissions = group.permissions().expect("could not load permissions");
 
         Self {

--- a/xmtp_mls/src/groups/members.rs
+++ b/xmtp_mls/src/groups/members.rs
@@ -46,7 +46,7 @@ impl MlsGroup {
         let conn = provider.conn_ref();
         let association_states =
             StoredAssociationState::batch_read_from_cache(conn, requests.clone())?;
-        let mutable_metadata = self.mutable_metadata()?;
+        let mutable_metadata = self.mutable_metadata(provider)?;
         if association_states.len() != requests.len() {
             // Cache miss - not expected to happen because:
             // 1. We don't allow updates to the group metadata unless we have already validated the association state


### PR DESCRIPTION
This will allow caller to decide whether to instantiate new connection or pass existing one. reduces the number of connections used for `list_members`.

---

_*Note*_ all of the metadata methods for a group pull their own `connection`. These methods are generally for one specific thing, and are the sorts of methods that may generally be composed with alot of the same call (iterate over `$X` groups and get the group name for instance). if parallelized, these calls could possibly block the thread, since our SQLite pool is blocking. To mitigate this, we could 'reserve' a single SQLite connection, instantiate a `XMTPOpenMlsProvider` with it, and re-use it for all read-only metadata methods. This will reduce the amount of concurrent connections being pulled from the pool.