### PR TITLE
re-use `prepare_message` for history

### DIFF
--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -488,7 +488,7 @@ impl MlsGroup {
     /// * message: UTF-8 or encoded message bytes
     /// * conn: Connection to SQLite database
     /// * envelope: closure that returns context-specific [`PlaintextEnvelope`]. Closure accepts
-    /// timestamp attached to intent & stored message.
+    ///     timestamp attached to intent & stored message.
     fn prepare_message<F>(
         &self,
         message: &[u8],

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -482,7 +482,13 @@ impl MlsGroup {
         Ok(message_id)
     }
 
-    /// Prepare a message (intent & id) on this users XMTP [`Client`].
+    /// Prepare a [`IntentKind::SendMessage`] intent, and [`StoredGroupMessage`] on this users XMTP [`Client`].
+    ///
+    /// # Arguments
+    /// * message: UTF-8 or encoded message bytes
+    /// * conn: Connection to SQLite database
+    /// * envelope: closure that returns context-specific [`PlaintextEnvelope`]. Closure accepts
+    /// timestamp attached to intent & stored message.
     fn prepare_message<F>(
         &self,
         message: &[u8],


### PR DESCRIPTION
- re-uses the `prepare_message` function for message history
- introduces a closure for `prepare_message` to return a context-specific `PlaintextEnvelope`

message history functions were publishing and storing an intent, but never stored the actual history request/reply locally as a `StoredGroupMessage`. Clients who externally received the message would have the message stored because of `process_external_message` correctly forms & inserts the `StoredGroupMessage` into the database. Intent creation + message storage for history is the same as for a normal `SendMessage`, except for the proto `PlaintextEnvelope`, which differs in its version + contents. 
