### PR TITLE
Add ability to revoke installations

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -333,12 +333,9 @@ impl FfiXmtpClient {
         existing_wallet_address: &str,
         new_wallet_address: &str,
     ) -> Result<Arc<FfiSignatureRequest>, GenericError> {
-        let inbox_id = self.inner_client.inbox_id();
-        let signature_request = self.inner_client.associate_wallet(
-            inbox_id,
-            existing_wallet_address.into(),
-            new_wallet_address.into(),
-        )?;
+        let signature_request = self
+            .inner_client
+            .associate_wallet(existing_wallet_address.into(), new_wallet_address.into())?;
 
         let request = Arc::new(FfiSignatureRequest {
             inner: Arc::new(tokio::sync::Mutex::new(signature_request)),
@@ -364,10 +361,9 @@ impl FfiXmtpClient {
         &self,
         wallet_address: &str,
     ) -> Result<Arc<FfiSignatureRequest>, GenericError> {
-        let inbox_id = self.inner_client.inbox_id();
         let signature_request = self
             .inner_client
-            .revoke_wallet(inbox_id, wallet_address.into())
+            .revoke_wallets(vec![wallet_address.into()])
             .await?;
 
         let request = Arc::new(FfiSignatureRequest {

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -2918,16 +2918,17 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn ensure_removed_after_revoke() {
-        let wallet = generate_local_wallet();
-        let alix1 = ClientBuilder::new_test_client(&wallet).await;
-        let alix2 = ClientBuilder::new_test_client(&wallet).await;
-        let bo = ClientBuilder::new_test_client(&wallet).await;
+        let alix_wallet = generate_local_wallet();
+        let bo_wallet = generate_local_wallet();
+        let alix1 = ClientBuilder::new_test_client(&alix_wallet).await;
+        let alix2 = ClientBuilder::new_test_client(&alix_wallet).await;
+        let bo = ClientBuilder::new_test_client(&bo_wallet).await;
 
         let alix_group = alix1
             .create_group(None, GroupMetadataOptions::default())
             .unwrap();
         alix_group
-            .add_members(&alix1, vec![wallet.get_address()])
+            .add_members(&alix1, vec![bo_wallet.get_address()])
             .await
             .unwrap();
         let bo_group = receive_group_invite(&bo).await;
@@ -2943,7 +2944,7 @@ mod tests {
             .await
             .unwrap();
 
-        sign_with_wallet(&wallet, &mut revoke_installation_request).await;
+        sign_with_wallet(&alix_wallet, &mut revoke_installation_request).await;
         alix1
             .apply_signature_request(revoke_installation_request)
             .await

--- a/xmtp_mls/src/identity_updates.rs
+++ b/xmtp_mls/src/identity_updates.rs
@@ -222,11 +222,10 @@ where
 
     pub fn associate_wallet(
         &self,
-        // TODO: Replace this argument with a value stored on the client
-        inbox_id: String,
         existing_wallet_address: String,
         new_wallet_address: String,
     ) -> Result<SignatureRequest, ClientError> {
+        let inbox_id = self.inbox_id();
         let builder = SignatureRequestBuilder::new(inbox_id);
 
         Ok(builder
@@ -234,22 +233,45 @@ where
             .build())
     }
 
-    pub async fn revoke_wallet(
+    pub async fn revoke_wallets(
         &self,
-        inbox_id: String,
-        wallet_to_revoke: String,
+        wallets_to_revoke: Vec<String>,
     ) -> Result<SignatureRequest, ClientError> {
+        let inbox_id = self.inbox_id();
         let current_state = self
             .get_association_state(&self.store().conn()?, &inbox_id, None)
             .await?;
-        let builder = SignatureRequestBuilder::new(inbox_id);
+        let mut builder = SignatureRequestBuilder::new(inbox_id);
 
-        Ok(builder
-            .revoke_association(
+        for wallet in wallets_to_revoke {
+            builder = builder.revoke_association(
                 current_state.recovery_address().clone().into(),
-                wallet_to_revoke.into(),
+                wallet.into(),
             )
-            .build())
+        }
+
+        Ok(builder.build())
+    }
+
+    pub async fn revoke_installations(
+        &self,
+        installation_ids: Vec<Vec<u8>>,
+    ) -> Result<SignatureRequest, ClientError> {
+        let inbox_id = self.inbox_id();
+        let current_state = self
+            .get_association_state(&self.store().conn()?, &inbox_id, None)
+            .await?;
+
+        let mut builder = SignatureRequestBuilder::new(inbox_id);
+
+        for installation_id in installation_ids {
+            builder = builder.revoke_association(
+                current_state.recovery_address().clone().into(),
+                installation_id.into(),
+            )
+        }
+
+        Ok(builder.build())
     }
 
     pub async fn apply_signature_request(
@@ -398,7 +420,7 @@ pub async fn load_identity_updates<ApiClient: XmtpApi>(
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use ethers::signers::LocalWallet;
     use tracing_test::traced_test;
     use xmtp_cryptography::utils::generate_local_wallet;
@@ -418,7 +440,10 @@ mod tests {
 
     use super::load_identity_updates;
 
-    async fn sign_with_wallet(wallet: &LocalWallet, signature_request: &mut SignatureRequest) {
+    pub(crate) async fn sign_with_wallet(
+        wallet: &LocalWallet,
+        signature_request: &mut SignatureRequest,
+    ) {
         let wallet_signature: Vec<u8> = wallet
             .sign(signature_request.signature_text().as_str())
             .unwrap()
@@ -507,11 +532,7 @@ mod tests {
             .unwrap();
 
         let mut add_association_request = client
-            .associate_wallet(
-                inbox_id.clone(),
-                wallet_address.clone(),
-                wallet_2_address.clone(),
-            )
+            .associate_wallet(wallet_address.clone(), wallet_2_address.clone())
             .unwrap();
 
         sign_with_wallet(&wallet, &mut add_association_request).await;
@@ -568,11 +589,7 @@ mod tests {
         assert_logged!("Wrote association", 1);
 
         let mut add_association_request = client
-            .associate_wallet(
-                inbox_id.clone(),
-                wallet_address.clone(),
-                wallet_2_address.clone(),
-            )
+            .associate_wallet(wallet_address.clone(), wallet_2_address.clone())
             .unwrap();
 
         sign_with_wallet(&wallet, &mut add_association_request).await;
@@ -650,7 +667,7 @@ mod tests {
                 .unwrap();
             let new_wallet = generate_local_wallet();
             let mut add_association_request = client
-                .associate_wallet(inbox_id, wallet.get_address(), new_wallet.get_address())
+                .associate_wallet(wallet.get_address(), new_wallet.get_address())
                 .unwrap();
 
             sign_with_wallet(&wallet, &mut add_association_request).await;
@@ -721,5 +738,86 @@ mod tests {
         assert!(installation_diff
             .removed_installations
             .contains(&client_2_installation_key));
+    }
+
+    #[tokio::test]
+    pub async fn revoke_wallet() {
+        let recovery_wallet = generate_local_wallet();
+        let second_wallet = generate_local_wallet();
+        let client = ClientBuilder::new_test_client(&recovery_wallet).await;
+
+        let mut add_wallet_signature_request = client
+            .associate_wallet(recovery_wallet.get_address(), second_wallet.get_address())
+            .unwrap();
+
+        sign_with_wallet(&recovery_wallet, &mut add_wallet_signature_request).await;
+        sign_with_wallet(&second_wallet, &mut add_wallet_signature_request).await;
+
+        client
+            .apply_signature_request(add_wallet_signature_request)
+            .await
+            .unwrap();
+
+        let association_state_after_add = get_association_state(&client, client.inbox_id()).await;
+        assert_eq!(association_state_after_add.account_addresses().len(), 2);
+
+        // Make sure the inbox ID is correctly registered
+        let inbox_ids = client
+            .api_client
+            .get_inbox_ids(vec![second_wallet.get_address()])
+            .await
+            .unwrap();
+        assert_eq!(inbox_ids.len(), 1);
+
+        // Now revoke the second wallet
+
+        let mut revoke_signature_request = client
+            .revoke_wallets(vec![second_wallet.get_address().into()])
+            .await
+            .unwrap();
+        sign_with_wallet(&recovery_wallet, &mut revoke_signature_request).await;
+        client
+            .apply_signature_request(revoke_signature_request)
+            .await
+            .unwrap();
+
+        // Make sure that the association state has removed the second wallet
+        let association_state_after_revoke =
+            get_association_state(&client, client.inbox_id()).await;
+        assert_eq!(association_state_after_revoke.account_addresses().len(), 1);
+
+        // Make sure the inbox ID is correctly unregistered
+        let inbox_ids = client
+            .api_client
+            .get_inbox_ids(vec![second_wallet.get_address()])
+            .await
+            .unwrap();
+        assert_eq!(inbox_ids.len(), 0);
+    }
+
+    #[tokio::test]
+    pub async fn revoke_installation() {
+        let wallet = generate_local_wallet();
+        let client1 = ClientBuilder::new_test_client(&wallet).await;
+        let client2 = ClientBuilder::new_test_client(&wallet).await;
+
+        let association_state = get_association_state(&client1, client1.inbox_id()).await;
+        // Ensure there are two installations on the inbox
+        assert_eq!(association_state.installation_ids().len(), 2);
+
+        // Now revoke the second client
+        let mut revoke_installation_request = client1
+            .revoke_installations(vec![client2.installation_public_key()])
+            .await
+            .unwrap();
+        sign_with_wallet(&wallet, &mut revoke_installation_request).await;
+        client1
+            .apply_signature_request(revoke_installation_request)
+            .await
+            .unwrap();
+
+        // Make sure there is only one installation on the inbox
+        let association_state = get_association_state(&client1, client1.inbox_id()).await;
+        assert_eq!(association_state.installation_ids().len(), 1);
     }
 }


### PR DESCRIPTION
## tl;dr

- Exposes the ability to revoke installations
- Updates the internal API for revoking wallets to not require the inbox_id. We can safely assume you're always doing this with your own `inbox_id`.
- Adds a bunch more tests around revocation