### PR TITLE
Remove lots of unwraps

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,1 @@
+allow-unwrap-in-tests = true

--- a/bindings_ffi/src/lib.rs
+++ b/bindings_ffi/src/lib.rs
@@ -1,4 +1,5 @@
 #![recursion_limit = "256"]
+#![cfg_attr(not(test), warn(clippy::unwrap_used))]
 pub mod inbox_owner;
 pub mod logger;
 pub mod mls;

--- a/bindings_ffi/src/lib.rs
+++ b/bindings_ffi/src/lib.rs
@@ -1,5 +1,5 @@
 #![recursion_limit = "256"]
-#![cfg_attr(not(test), warn(clippy::unwrap_used))]
+#![warn(clippy::unwrap_used)]
 pub mod inbox_owner;
 pub mod logger;
 pub mod mls;

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -69,7 +69,6 @@ pub type RustXmtpClient = MlsClient<TonicApiClient>;
 /// xmtp.create_client(account_address, nonce, inbox_id, Option<legacy_signed_private_key_proto>)
 /// ```
 #[allow(clippy::too_many_arguments)]
-#[allow(unused)]
 #[uniffi::export(async_runtime = "tokio")]
 pub async fn create_client(
     logger: Box<dyn FfiLogger>,

--- a/bindings_ffi/src/v2.rs
+++ b/bindings_ffi/src/v2.rs
@@ -317,7 +317,7 @@ impl FfiV2Subscription {
                 return Err(GenericError::Generic {
                     err: format!(
                         "subscription event loop join error {}",
-                        join_result.unwrap_err()
+                        join_result.expect_err("checked for err")
                     ),
                 });
             }

--- a/bindings_node/src/lib.rs
+++ b/bindings_node/src/lib.rs
@@ -1,5 +1,5 @@
 #![recursion_limit = "256"]
-#![cfg_attr(not(test), warn(clippy::unwrap_used))]
+#![warn(clippy::unwrap_used)]
 
 mod conversations;
 pub mod encoded_content;

--- a/bindings_node/src/lib.rs
+++ b/bindings_node/src/lib.rs
@@ -1,4 +1,6 @@
 #![recursion_limit = "256"]
+#![cfg_attr(not(test), warn(clippy::unwrap_used))]
+
 mod conversations;
 pub mod encoded_content;
 mod groups;

--- a/xmtp_mls/src/api/identity.rs
+++ b/xmtp_mls/src/api/identity.rs
@@ -140,7 +140,12 @@ where
             .responses
             .into_iter()
             .filter(|inbox_id| inbox_id.inbox_id.is_some())
-            .map(|inbox_id| (inbox_id.address, inbox_id.inbox_id.unwrap()))
+            .map(|inbox_id| {
+                (
+                    inbox_id.address,
+                    inbox_id.inbox_id.expect("Checked for some"),
+                )
+            })
             .collect())
     }
 }

--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -480,7 +480,8 @@ mod tests {
             credential: Credential::new(CredentialType::Basic, rand_vec()),
             signature_request: None,
         })
-            .into();
+            .try_into()
+            .unwrap();
 
         stored.store(&store.conn().unwrap()).unwrap();
         let wrapper = ApiClientWrapper::new(mock_api, Retry::default());
@@ -506,7 +507,8 @@ mod tests {
             credential: Credential::new(CredentialType::Basic, rand_vec()),
             signature_request: None,
         })
-            .into();
+            .try_into()
+            .unwrap();
 
         stored.store(&store.conn().unwrap()).unwrap();
 

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -95,9 +95,15 @@ pub enum ClientError {
     SignatureRequest(#[from] SignatureRequestError),
     // the box is to prevent infinite cycle between client and group errors
     #[error(transparent)]
-    Group(#[from] Box<GroupError>),
+    Group(Box<GroupError>),
     #[error("generic:{0}")]
     Generic(String),
+}
+
+impl From<GroupError> for ClientError {
+    fn from(err: GroupError) -> ClientError {
+        ClientError::Group(Box::new(err))
+    }
 }
 
 impl crate::retry::RetryableError for ClientError {
@@ -353,8 +359,7 @@ where
             GroupMembershipState::Allowed,
             permissions_policy_set.unwrap_or_default(),
             opts,
-        )
-        .map_err(Box::new)?;
+        )?;
 
         // notify any streams of the new group
         let _ = self.local_events.send(LocalEvents::NewGroup(group.clone()));
@@ -364,8 +369,7 @@ where
 
     pub(crate) fn create_sync_group(&self) -> Result<MlsGroup, ClientError> {
         log::info!("creating sync group");
-        let sync_group =
-            MlsGroup::create_and_insert_sync_group(self.context.clone()).map_err(Box::new)?;
+        let sync_group = MlsGroup::create_and_insert_sync_group(self.context.clone())?;
 
         Ok(sync_group)
     }

--- a/xmtp_mls/src/groups/intents.rs
+++ b/xmtp_mls/src/groups/intents.rs
@@ -59,16 +59,12 @@ impl SendMessageIntentData {
     }
 
     pub(crate) fn to_bytes(&self) -> Vec<u8> {
-        let mut buf = Vec::new();
         SendMessageData {
             version: Some(SendMessageVersion::V1(SendMessageV1 {
                 payload_bytes: self.message.clone(),
             })),
         }
-        .encode(&mut buf)
-        .unwrap();
-
-        buf
+        .encode_to_vec()
     }
 
     pub(crate) fn from_bytes(data: &[u8]) -> Result<Self, IntentError> {
@@ -613,7 +609,6 @@ impl SendWelcomesAction {
     }
 
     pub(crate) fn to_bytes(&self) -> Vec<u8> {
-        let mut buf = Vec::new();
         PostCommitActionProto {
             kind: Some(PostCommitActionKind::SendWelcomes(SendWelcomesProto {
                 installations: self
@@ -625,10 +620,7 @@ impl SendWelcomesAction {
                 welcome_message: self.welcome_message.clone(),
             })),
         }
-        .encode(&mut buf)
-        .unwrap();
-
-        buf
+        .encode_to_vec()
     }
 }
 
@@ -667,9 +659,11 @@ impl PostCommitAction {
     }
 }
 
-impl From<Vec<u8>> for PostCommitAction {
-    fn from(data: Vec<u8>) -> Self {
-        PostCommitAction::from_bytes(data.as_slice()).unwrap()
+impl TryFrom<Vec<u8>> for PostCommitAction {
+    type Error = IntentError;
+
+    fn try_from(data: Vec<u8>) -> Result<Self, Self::Error> {
+        PostCommitAction::from_bytes(data.as_slice())
     }
 }
 

--- a/xmtp_mls/src/groups/message_history.rs
+++ b/xmtp_mls/src/groups/message_history.rs
@@ -444,7 +444,9 @@ pub(crate) async fn download_history_bundle(
             response
         );
         Err(MessageHistoryError::Reqwest(
-            response.error_for_status().unwrap_err(),
+            response
+                .error_for_status()
+                .expect_err("Checked for success"),
         ))
     }
 }

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -180,6 +180,8 @@ pub enum GroupError {
     PublishPanicked,
     #[error("Missing metadata field {name}")]
     MissingMetadataField { name: String },
+    #[error("Message was processed but is missing")]
+    MissingMessage,
 }
 
 impl RetryableError for GroupError {

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -178,6 +178,8 @@ pub enum GroupError {
     PublishCancelled,
     #[error("the publish failed to complete due to panic")]
     PublishPanicked,
+    #[error("Missing metadata field {name}")]
+    MissingMetadataField { name: String },
 }
 
 impl RetryableError for GroupError {
@@ -1069,7 +1071,11 @@ pub fn build_extensions_for_permissions_update(
         PermissionUpdateType::UpdateMetadata => {
             let mut metadata_policy = existing_policy_set.update_metadata_policy.clone();
             metadata_policy.insert(
-                update_permissions_intent.metadata_field_name.unwrap(),
+                update_permissions_intent.metadata_field_name.ok_or(
+                    GroupError::MissingMetadataField {
+                        name: "metadata_field_name".into(),
+                    },
+                )?,
                 update_permissions_intent.policy_option.into(),
             );
             PolicySet::new(

--- a/xmtp_mls/src/groups/subscriptions.rs
+++ b/xmtp_mls/src/groups/subscriptions.rs
@@ -139,7 +139,8 @@ impl MlsGroup {
 
 #[cfg(test)]
 mod tests {
-    use std::{sync::Arc, time::Duration};
+    use super::*;
+    use std::time::Duration;
     use tokio_stream::wrappers::UnboundedReceiverStream;
     use xmtp_cryptography::utils::generate_local_wallet;
 

--- a/xmtp_mls/src/groups/subscriptions.rs
+++ b/xmtp_mls/src/groups/subscriptions.rs
@@ -9,6 +9,7 @@ use crate::storage::group_message::StoredGroupMessage;
 use crate::subscriptions::{MessagesStreamInfo, StreamHandle};
 use crate::XmtpApi;
 use crate::{retry::Retry, retry_async, Client};
+use prost::Message;
 use xmtp_proto::xmtp::mls::api::v1::GroupMessage;
 
 impl MlsGroup {
@@ -120,12 +121,24 @@ impl MlsGroup {
             callback,
         )
     }
+    pub async fn process_streamed_group_message<ApiClient>(
+        &self,
+        envelope_bytes: Vec<u8>,
+        client: Arc<Client<ApiClient>>,
+    ) -> Result<StoredGroupMessage, GroupError>
+    where
+        ApiClient: XmtpApi,
+    {
+        let envelope = GroupMessage::decode(envelope_bytes.as_slice())
+            .map_err(|e| GroupError::Generic(e.to_string()))?;
+
+        let message = self.process_stream_entry(envelope, client).await?;
+        message.ok_or(GroupError::MissingMessage)
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use prost::Message;
     use std::{sync::Arc, time::Duration};
     use tokio_stream::wrappers::UnboundedReceiverStream;
     use xmtp_cryptography::utils::generate_local_wallet;
@@ -135,23 +148,6 @@ mod tests {
         storage::group_message::GroupMessageKind, utils::test::Delivery,
     };
     use futures::StreamExt;
-
-    impl MlsGroup {
-        pub async fn process_streamed_group_message<ApiClient>(
-            &self,
-            envelope_bytes: Vec<u8>,
-            client: Arc<Client<ApiClient>>,
-        ) -> Result<StoredGroupMessage, GroupError>
-        where
-            ApiClient: XmtpApi,
-        {
-            let envelope = GroupMessage::decode(envelope_bytes.as_slice())
-                .map_err(|e| GroupError::Generic(e.to_string()))?;
-
-            let message = self.process_stream_entry(envelope, client).await?;
-            Ok(message.unwrap())
-        }
-    }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_decode_group_message_bytes() {

--- a/xmtp_mls/src/groups/subscriptions.rs
+++ b/xmtp_mls/src/groups/subscriptions.rs
@@ -82,6 +82,21 @@ impl MlsGroup {
         Ok(new_message)
     }
 
+    pub async fn process_streamed_group_message<ApiClient>(
+        &self,
+        envelope_bytes: Vec<u8>,
+        client: Arc<Client<ApiClient>>,
+    ) -> Result<StoredGroupMessage, GroupError>
+    where
+        ApiClient: XmtpApi,
+    {
+        let envelope = GroupMessage::decode(envelope_bytes.as_slice())
+            .map_err(|e| GroupError::Generic(e.to_string()))?;
+
+        let message = self.process_stream_entry(envelope, client).await?;
+        message.ok_or(GroupError::MissingMessage)
+    }
+
     pub async fn stream<ApiClient>(
         &self,
         client: Arc<Client<ApiClient>>,
@@ -98,21 +113,6 @@ impl MlsGroup {
                 },
             )]))
             .await?)
-    }
-
-    pub async fn process_streamed_group_message<ApiClient>(
-        &self,
-        envelope_bytes: Vec<u8>,
-        client: Arc<Client<ApiClient>>,
-    ) -> Result<StoredGroupMessage, GroupError>
-    where
-        ApiClient: XmtpApi,
-    {
-        let envelope = GroupMessage::decode(envelope_bytes.as_slice())
-            .map_err(|e| GroupError::Generic(e.to_string()))?;
-
-        let message = self.process_stream_entry(envelope, client).await?;
-        message.ok_or(GroupError::MissingMessage)
     }
 
     pub fn stream_with_callback<ApiClient>(

--- a/xmtp_mls/src/groups/sync.rs
+++ b/xmtp_mls/src/groups/sync.rs
@@ -89,7 +89,7 @@ impl MlsGroup {
         log::info!(
             "current epoch for [{}] in sync() is Epoch: [{}]",
             client.inbox_id(),
-            self.load_mls_group(mls_provider).unwrap().epoch()
+            self.load_mls_group(mls_provider)?.epoch()
         );
         self.maybe_update_installations(conn.clone(), None, client)
             .await?;
@@ -984,8 +984,7 @@ impl MlsGroup {
         )?;
 
         for intent in intents {
-            if intent.post_commit_data.is_some() {
-                let post_commit_data = intent.post_commit_data.unwrap();
+            if let Some(post_commit_data) = intent.post_commit_data {
                 let post_commit_action = PostCommitAction::from_bytes(post_commit_data.as_slice())?;
                 match post_commit_action {
                     PostCommitAction::SendWelcomes(action) => {

--- a/xmtp_mls/src/groups/sync.rs
+++ b/xmtp_mls/src/groups/sync.rs
@@ -321,7 +321,7 @@ impl MlsGroup {
                     return Ok(());
                 }
 
-                let validated_commit = maybe_validated_commit.unwrap();
+                let validated_commit = maybe_validated_commit.expect("Checked for error");
 
                 log::info!(
                     "[{}] merging pending commit for intent {}",
@@ -1021,9 +1021,7 @@ impl MlsGroup {
             .get_installations_time_checked(self.group_id.clone())?;
         let elapsed = now - last;
         if elapsed > interval {
-            self.add_missing_installations(provider, client)
-                .await
-                .unwrap();
+            self.add_missing_installations(provider, client).await?;
             provider
                 .conn_ref()
                 .update_installations_time_checked(self.group_id.clone())?;

--- a/xmtp_mls/src/groups/validated_commit.rs
+++ b/xmtp_mls/src/groups/validated_commit.rs
@@ -785,7 +785,7 @@ fn extract_actor(
     if let (Some(path_update_leaf_node), Some(proposal_author_leaf_index)) =
         (path_update_leaf_node, proposal_author_leaf_index)
     {
-        let proposal_author_leaf_index = openmls_group
+        let proposal_author = openmls_group
             .member_at(*proposal_author_leaf_index)
             .ok_or(CommitValidationError::ActorCouldNotBeFound)?;
 
@@ -794,7 +794,7 @@ fn extract_actor(
             .signature_key()
             .as_slice()
             .to_vec()
-            .ne(&proposal_author_leaf_index.signature_key)
+            .ne(&proposal_author.signature_key)
         {
             return Err(CommitValidationError::MultipleActors);
         }

--- a/xmtp_mls/src/groups/validated_commit.rs
+++ b/xmtp_mls/src/groups/validated_commit.rs
@@ -782,18 +782,19 @@ fn extract_actor(
         )?;
 
     // If there is both a path update and there are proposals we need to make sure that they are from the same actor
-    if path_update_leaf_node.is_some() && proposal_author_leaf_index.is_some() {
-        let proposal_author = openmls_group
-            .member_at(*proposal_author_leaf_index.unwrap())
+    if let (Some(path_update_leaf_node), Some(proposal_author_leaf_index)) =
+        (path_update_leaf_node, proposal_author_leaf_index)
+    {
+        let proposal_author_leaf_index = openmls_group
+            .member_at(*proposal_author_leaf_index)
             .ok_or(CommitValidationError::ActorCouldNotBeFound)?;
 
         // Verify that the signature keys are the same
         if path_update_leaf_node
-            .unwrap()
             .signature_key()
             .as_slice()
             .to_vec()
-            .ne(&proposal_author.signature_key)
+            .ne(&proposal_author_leaf_index.signature_key)
         {
             return Err(CommitValidationError::MultipleActors);
         }

--- a/xmtp_mls/src/identity_updates.rs
+++ b/xmtp_mls/src/identity_updates.rs
@@ -183,7 +183,7 @@ where
             StoredAssociationState::write_to_cache(
                 conn,
                 inbox_id.as_ref().to_string(),
-                last_sequence_id.unwrap(),
+                last_sequence_id.expect("checked for some"),
                 final_state.clone(),
             )?;
         }

--- a/xmtp_mls/src/identity_updates.rs
+++ b/xmtp_mls/src/identity_updates.rs
@@ -179,11 +179,11 @@ where
         }
 
         log::debug!("Final state at {:?}: {:?}", last_sequence_id, final_state);
-        if last_sequence_id.is_some() {
+        if let Some(last_sequence_id) = last_sequence_id {
             StoredAssociationState::write_to_cache(
                 conn,
                 inbox_id.as_ref().to_string(),
-                last_sequence_id.expect("checked for some"),
+                last_sequence_id,
                 final_state.clone(),
             )?;
         }

--- a/xmtp_mls/src/lib.rs
+++ b/xmtp_mls/src/lib.rs
@@ -1,4 +1,8 @@
 #![recursion_limit = "256"]
+#![cfg_attr(
+    not(any(test, feature = "test-utils", feature = "bench")),
+    warn(clippy::unwrap_used)
+)]
 pub mod api;
 pub mod builder;
 pub mod client;

--- a/xmtp_mls/src/lib.rs
+++ b/xmtp_mls/src/lib.rs
@@ -1,8 +1,11 @@
 #![recursion_limit = "256"]
+#![warn(clippy::unwrap_used)]
+/*
 #![cfg_attr(
     not(any(test, feature = "test-utils", feature = "bench")),
     warn(clippy::unwrap_used)
 )]
+*/
 pub mod api;
 pub mod builder;
 pub mod client;

--- a/xmtp_mls/src/lib.rs
+++ b/xmtp_mls/src/lib.rs
@@ -1,11 +1,6 @@
 #![recursion_limit = "256"]
 #![warn(clippy::unwrap_used)]
-/*
-#![cfg_attr(
-    not(any(test, feature = "test-utils", feature = "bench")),
-    warn(clippy::unwrap_used)
-)]
-*/
+
 pub mod api;
 pub mod builder;
 pub mod client;

--- a/xmtp_mls/src/storage/encrypted_store/association_state.rs
+++ b/xmtp_mls/src/storage/encrypted_store/association_state.rs
@@ -78,7 +78,7 @@ impl StoredAssociationState {
             })
             .transpose();
 
-        if result.is_ok() && result.as_ref().unwrap().is_some() {
+        if let Ok(Some(_)) = result {
             log::debug!(
                 "Loaded association state from cache: {} {}",
                 inbox_id,

--- a/xmtp_mls/src/storage/encrypted_store/group.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group.rs
@@ -220,7 +220,7 @@ impl DbConnection {
                 .optional()?;
 
             if maybe_inserted_group.is_none() {
-                let existing_group: StoredGroup = dsl::groups.find(group.id).first(conn).unwrap();
+                let existing_group: StoredGroup = dsl::groups.find(group.id).first(conn)?;
                 if existing_group.welcome_id == group.welcome_id {
                     // Error so OpenMLS db transaction are rolled back on duplicate welcomes
                     return Err(diesel::result::Error::DatabaseError(

--- a/xmtp_mls/src/storage/encrypted_store/identity.rs
+++ b/xmtp_mls/src/storage/encrypted_store/identity.rs
@@ -1,4 +1,4 @@
-use crate::storage::encrypted_store::schema::identity;
+use crate::storage::{encrypted_store::schema::identity, StorageError};
 use diesel::prelude::*;
 use xmtp_id::InboxId;
 
@@ -33,25 +33,29 @@ impl StoredIdentity {
     }
 }
 
-impl From<&Identity> for StoredIdentity {
-    fn from(identity: &Identity) -> Self {
-        StoredIdentity {
+impl TryFrom<&Identity> for StoredIdentity {
+    type Error = StorageError;
+
+    fn try_from(identity: &Identity) -> Result<Self, Self::Error> {
+        Ok(StoredIdentity {
             inbox_id: identity.inbox_id.clone(),
-            installation_keys: db_serialize(&identity.installation_keys).unwrap(),
-            credential_bytes: db_serialize(&identity.credential()).unwrap(),
+            installation_keys: db_serialize(&identity.installation_keys)?,
+            credential_bytes: db_serialize(&identity.credential())?,
             rowid: None,
-        }
+        })
     }
 }
 
-impl From<StoredIdentity> for Identity {
-    fn from(identity: StoredIdentity) -> Self {
-        Identity {
+impl TryFrom<StoredIdentity> for Identity {
+    type Error = StorageError;
+
+    fn try_from(identity: StoredIdentity) -> Result<Self, Self::Error> {
+        Ok(Identity {
             inbox_id: identity.inbox_id.clone(),
-            installation_keys: db_deserialize(&identity.installation_keys).unwrap(),
-            credential: db_deserialize(&identity.credential_bytes).unwrap(),
+            installation_keys: db_deserialize(&identity.installation_keys)?,
+            credential: db_deserialize(&identity.credential_bytes)?,
             signature_request: None,
-        }
+        })
     }
 }
 

--- a/xmtp_mls/src/subscriptions.rs
+++ b/xmtp_mls/src/subscriptions.rs
@@ -114,7 +114,7 @@ where
             }
         }
 
-        Ok(creation_result.unwrap())
+        Ok(creation_result?)
     }
 
     pub async fn process_streamed_welcome_message(

--- a/xmtp_mls/src/utils/bench.rs
+++ b/xmtp_mls/src/utils/bench.rs
@@ -1,6 +1,8 @@
 //! Utilities for xmtp_mls benchmarks
 //! Utilities mostly include pre-generating identities in order to save time when writing/testing
 //! benchmarks.
+#![allow(clippy::unwrap_used)]
+
 use crate::{builder::ClientBuilder, Client};
 use ethers::signers::{LocalWallet, Signer};
 use indicatif::{ProgressBar, ProgressStyle};

--- a/xmtp_mls/src/utils/test.rs
+++ b/xmtp_mls/src/utils/test.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unwrap_used)]
 use std::env;
 
 use rand::{


### PR DESCRIPTION
- adds directive to disallow unwraps in code that is not test/benchmarks

This PR removes a bunch of unwraps found with clippy. An unwrap would panic libxmtp and crash the client, so we should never use it unless we are 100% sure it will not panic. Unwrapping in this context may also cause errors to go completely unreported in logs (if a task or something crashes or the logs are not picked up by a logger)


Added a warn lint for `unwrap` that clippy will pick up if ran without `test`,`test-utils`, or `bench` feature, i.e `cargo clippy --no-deps -- -Dwarnings`

there are a few unwraps here that could definitely been causing issues/causing crashes in probably less-common circumstances (like the one in insert_or_replace_group and permissions)