### PR TITLE
Move staged commit to intents

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -2465,13 +2465,14 @@ mod tests {
         let alix_group = alix.group(group.id()).unwrap();
         let bo_group = bo.group(group.id()).unwrap();
         let caro_group = caro.group(group.id()).unwrap();
-
+        log::info!("Alix sending first message");
         // Alix sends a message in the group
         alix_group
             .send("First message".as_bytes().to_vec())
             .await
             .unwrap();
 
+        log::info!("Caro sending second message");
         // Caro sends a message in the group
         caro_group
             .send("Second message".as_bytes().to_vec())
@@ -2489,6 +2490,7 @@ mod tests {
             .await;
         bo_stream_messages.wait_for_ready().await;
 
+        log::info!("Alix sending third message after Bo's second installation added");
         // Alix sends a message to the group
         alix_group
             .send("Third message".as_bytes().to_vec())
@@ -2499,21 +2501,27 @@ mod tests {
         bo2.conversations().sync().await.unwrap();
         let bo2_group = bo2.group(group.id()).unwrap();
 
+        log::info!("Bo sending fourth message");
         // Bo sends a message to the group
         bo2_group
             .send("Fourth message".as_bytes().to_vec())
             .await
             .unwrap();
 
+        log::info!("Caro sending fifth message");
         // Caro sends a message in the group
         caro_group
             .send("Fifth message".as_bytes().to_vec())
             .await
             .unwrap();
 
+        log::info!("Syncing alix");
         alix_group.sync().await.unwrap();
+        log::info!("Syncing bo 1");
         bo_group.sync().await.unwrap();
+        log::info!("Syncing bo 2");
         bo2_group.sync().await.unwrap();
+        log::info!("Syncing caro");
         caro_group.sync().await.unwrap();
 
         // Get the message count for all the clients

--- a/dev/docker/compose
+++ b/dev/docker/compose
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -eou pipefail
 
-docker-compose -f dev/docker/docker-compose.yml -p "libxmtp" "$@"
+docker compose -f dev/docker/docker-compose.yml -p "libxmtp" "$@"

--- a/xmtp_mls/Cargo.toml
+++ b/xmtp_mls/Cargo.toml
@@ -9,15 +9,24 @@ name = "update-schema"
 path = "src/bin/update-schema.rs"
 
 [features]
+bench = [
+    "test-utils",
+    "indicatif",
+    "tracing-subscriber",
+    "anyhow",
+    "tracing-flame",
+    "once_cell",
+    "xmtp_api_grpc",
+]
 default = ["native"]
 grpc = ["xmtp_proto/grpc"]
+http-api = ["xmtp_api_http"]
 native = ["libsqlite3-sys/bundled-sqlcipher-vendored-openssl"]
 test-utils = []
-bench = ["test-utils", "indicatif", "tracing-subscriber", "anyhow", "tracing-flame", "once_cell", "xmtp_api_grpc"]
-http-api = ["xmtp_api_http"]
 
 [dependencies]
 aes-gcm = { version = "0.10.3", features = ["std"] }
+async-stream.workspace = true
 async-trait.workspace = true
 bincode = "1.3.3"
 chrono = { workspace = true }
@@ -28,68 +37,70 @@ diesel = { version = "2.2.2", features = [
 ] }
 diesel_migrations = { version = "2.2.0", features = ["sqlite"] }
 ed25519-dalek = "2.1.1"
-ethers.workspace = true
 ethers-core.workspace = true
+ethers.workspace = true
 futures.workspace = true
-parking_lot = "0.12.3"
 hex.workspace = true
 libsqlite3-sys = { version = "0.29.0", optional = true }
 log.workspace = true
-tracing.workspace = true
 openmls = { workspace = true, features = ["test-utils"] }
 openmls_basic_credential = { workspace = true }
 openmls_rust_crypto = { workspace = true }
 openmls_traits = { workspace = true }
+parking_lot = "0.12.3"
 prost = { workspace = true, features = ["prost-derive"] }
 rand = { workspace = true }
 reqwest = { version = "0.12.4", features = ["stream"] }
 ring = "0.17.8"
+scoped-futures = "0.1"
 serde = { workspace = true }
 serde_json.workspace = true
 sha2.workspace = true
 smart-default = "0.7.1"
 thiserror = { workspace = true }
 tls_codec = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread", "tracing"] }
-tokio-stream = { version = "0.1", features = ["sync"]  }
-async-stream.workspace = true
+tokio = { workspace = true, features = [
+    "macros",
+    "rt-multi-thread",
+    "tracing",
+] }
+tokio-stream = { version = "0.1", features = ["sync"] }
 toml = "0.8.4"
+tracing.workspace = true
 xmtp_cryptography = { workspace = true }
 xmtp_id = { path = "../xmtp_id" }
 xmtp_proto = { workspace = true, features = ["proto_full", "convert"] }
 xmtp_v2 = { path = "../xmtp_v2" }
-scoped-futures = "0.1"
 
 # Test/Bench Utils
+anyhow = { workspace = true, optional = true }
+indicatif = { version = "0.17", optional = true }
+once_cell = { version = "1.19", optional = true }
+tracing-flame = { version = "0.2", optional = true }
+tracing-subscriber = { workspace = true, optional = true }
 xmtp_api_grpc = { path = "../xmtp_api_grpc", optional = true }
 xmtp_api_http = { path = "../xmtp_api_http", optional = true }
-tracing-subscriber = { workspace = true, optional = true }
-indicatif = { version = "0.17", optional = true }
-anyhow = { workspace = true, optional = true }
-tracing-flame = { version = "0.2", optional = true }
-once_cell = { version = "1.19", optional = true }
 
 [dev-dependencies]
+anyhow.workspace = true
+async-barrier = "1.1"
+criterion = { version = "0.5", features = ["html_reports", "async_tokio"] }
 ctor.workspace = true
 flume = "0.11"
 mockall = "0.13.0"
 mockito = "1.4.0"
 tempfile = "3.5.0"
-tracing.workspace = true
-tracing-subscriber.workspace = true
 tracing-log = "0.2.0"
+tracing-subscriber.workspace = true
 tracing-test = "0.2.4"
+tracing.workspace = true
 xmtp_api_grpc = { path = "../xmtp_api_grpc" }
 xmtp_id = { path = "../xmtp_id", features = ["test-utils"] }
-async-barrier = "1.1"
-anyhow.workspace = true
-criterion = { version = "0.5", features = ["html_reports", "async_tokio"] }
 
 [[bench]]
+harness = false
 name = "group_limit"
-harness = false
 
 [[bench]]
-name = "crypto"
 harness = false
-
+name = "crypto"

--- a/xmtp_mls/migrations/2024-08-22-044745_add_staged_commit/down.sql
+++ b/xmtp_mls/migrations/2024-08-22-044745_add_staged_commit/down.sql
@@ -1,0 +1,7 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE group_intents
+    DROP COLUMN staged_commit;
+
+ALTER TABLE group_intents
+    DROP COLUMN published_in_epoch;
+

--- a/xmtp_mls/migrations/2024-08-22-044745_add_staged_commit/up.sql
+++ b/xmtp_mls/migrations/2024-08-22-044745_add_staged_commit/up.sql
@@ -1,0 +1,7 @@
+-- Your SQL goes here
+ALTER TABLE group_intents
+    ADD COLUMN staged_commit BLOB;
+
+ALTER TABLE group_intents
+    ADD COLUMN published_in_epoch BIGINT;
+

--- a/xmtp_mls/src/groups/subscriptions.rs
+++ b/xmtp_mls/src/groups/subscriptions.rs
@@ -66,7 +66,8 @@ impl MlsGroup {
         );
 
         if let Some(GroupError::ReceiveError(_)) = process_result.as_ref().err() {
-            self.sync(&client).await?;
+            self.sync_with_conn(&client.mls_provider()?, &client)
+                .await?;
         } else if process_result.is_err() {
             log::error!("Process stream entry {:?}", process_result.err());
         }

--- a/xmtp_mls/src/lib.rs
+++ b/xmtp_mls/src/lib.rs
@@ -11,6 +11,7 @@ pub mod groups;
 mod hpke;
 pub mod identity;
 mod identity_updates;
+mod mutex_registry;
 pub mod owner;
 pub mod retry;
 pub mod storage;

--- a/xmtp_mls/src/mutex_registry.rs
+++ b/xmtp_mls/src/mutex_registry.rs
@@ -1,0 +1,23 @@
+use std::{collections::HashMap, sync::Arc};
+
+use tokio::sync::Mutex;
+
+#[derive(Debug, Clone)]
+pub struct MutexRegistry {
+    mutexes: HashMap<Vec<u8>, Arc<Mutex<()>>>,
+}
+
+impl MutexRegistry {
+    pub fn new() -> Self {
+        Self {
+            mutexes: HashMap::new(),
+        }
+    }
+
+    pub fn get_mutex(&mut self, key: Vec<u8>) -> Arc<Mutex<()>> {
+        self.mutexes
+            .entry(key)
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone()
+    }
+}

--- a/xmtp_mls/src/storage/encrypted_store/schema.rs
+++ b/xmtp_mls/src/storage/encrypted_store/schema.rs
@@ -18,6 +18,8 @@ diesel::table! {
         payload_hash -> Nullable<Binary>,
         post_commit_data -> Nullable<Binary>,
         publish_attempts -> Integer,
+        staged_commit -> Nullable<Binary>,
+        published_in_epoch -> Nullable<BigInt>,
     }
 }
 

--- a/xmtp_mls/src/storage/mod.rs
+++ b/xmtp_mls/src/storage/mod.rs
@@ -1,6 +1,6 @@
 mod encrypted_store;
 mod errors;
-mod serialization;
+pub mod serialization;
 pub mod sql_key_store;
 
 pub use encrypted_store::*;


### PR DESCRIPTION
## tl;dr

- Moves `staged_commits` from being handled by OpenMLS to being stored on each intent
- Adds a mutex for each group's sync operations. Only one sync may happen in parallel at any time per group
- Creates database columns for storing the staged commit and the epoch the commit was published
- Updates a test for message conflicts to better check for forked group states
- I found some cases where we were calling `publish_intents` and then immediately calling `sync`. That should not be necessary, since we call `publish_intents` from inside the sync method
- Adds tests for parallel  and reentrant syncs

## More Info
[https://github.com/xmtp/libxmtp/issues/979](https://github.com/xmtp/libxmtp/issues/979#issuecomment-2303541848)
