### PR TITLE
Simplify aborting in streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3247,7 +3247,7 @@ dependencies = [
 [[package]]
 name = "openmls"
 version = "0.6.0-pre.2"
-source = "git+https://github.com/xmtp/openmls?rev=cf42738018d093434c955a1b50a9de34cc12b8c5#cf42738018d093434c955a1b50a9de34cc12b8c5"
+source = "git+https://github.com/xmtp/openmls?rev=87e7e257d8eb15d6662b104518becfc75ef6db76#87e7e257d8eb15d6662b104518becfc75ef6db76"
 dependencies = [
  "backtrace",
  "itertools 0.10.5",
@@ -3270,7 +3270,7 @@ dependencies = [
 [[package]]
 name = "openmls_basic_credential"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/xmtp/openmls?rev=cf42738018d093434c955a1b50a9de34cc12b8c5#cf42738018d093434c955a1b50a9de34cc12b8c5"
+source = "git+https://github.com/xmtp/openmls?rev=87e7e257d8eb15d6662b104518becfc75ef6db76#87e7e257d8eb15d6662b104518becfc75ef6db76"
 dependencies = [
  "ed25519-dalek",
  "openmls_traits",
@@ -3283,7 +3283,7 @@ dependencies = [
 [[package]]
 name = "openmls_memory_storage"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/xmtp/openmls?rev=cf42738018d093434c955a1b50a9de34cc12b8c5#cf42738018d093434c955a1b50a9de34cc12b8c5"
+source = "git+https://github.com/xmtp/openmls?rev=87e7e257d8eb15d6662b104518becfc75ef6db76#87e7e257d8eb15d6662b104518becfc75ef6db76"
 dependencies = [
  "hex",
  "log",
@@ -3296,7 +3296,7 @@ dependencies = [
 [[package]]
 name = "openmls_rust_crypto"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/xmtp/openmls?rev=cf42738018d093434c955a1b50a9de34cc12b8c5#cf42738018d093434c955a1b50a9de34cc12b8c5"
+source = "git+https://github.com/xmtp/openmls?rev=87e7e257d8eb15d6662b104518becfc75ef6db76#87e7e257d8eb15d6662b104518becfc75ef6db76"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -3320,7 +3320,7 @@ dependencies = [
 [[package]]
 name = "openmls_test"
 version = "0.1.0-pre.1"
-source = "git+https://github.com/xmtp/openmls?rev=cf42738018d093434c955a1b50a9de34cc12b8c5#cf42738018d093434c955a1b50a9de34cc12b8c5"
+source = "git+https://github.com/xmtp/openmls?rev=87e7e257d8eb15d6662b104518becfc75ef6db76#87e7e257d8eb15d6662b104518becfc75ef6db76"
 dependencies = [
  "ansi_term",
  "openmls_rust_crypto",
@@ -3335,7 +3335,7 @@ dependencies = [
 [[package]]
 name = "openmls_traits"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/xmtp/openmls?rev=cf42738018d093434c955a1b50a9de34cc12b8c5#cf42738018d093434c955a1b50a9de34cc12b8c5"
+source = "git+https://github.com/xmtp/openmls?rev=87e7e257d8eb15d6662b104518becfc75ef6db76#87e7e257d8eb15d6662b104518becfc75ef6db76"
 dependencies = [
  "serde",
  "tls_codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,10 +38,10 @@ futures = "0.3.30"
 futures-core = "0.3.30"
 hex = "0.4.3"
 log = { version = "0.4" }
-openmls = { git = "https://github.com/xmtp/openmls", rev = "cf42738018d093434c955a1b50a9de34cc12b8c5", default-features = false }
-openmls_basic_credential = { git = "https://github.com/xmtp/openmls", rev = "cf42738018d093434c955a1b50a9de34cc12b8c5" }
-openmls_rust_crypto = { git = "https://github.com/xmtp/openmls", rev = "cf42738018d093434c955a1b50a9de34cc12b8c5" }
-openmls_traits = { git = "https://github.com/xmtp/openmls", rev = "cf42738018d093434c955a1b50a9de34cc12b8c5" }
+openmls = { git = "https://github.com/xmtp/openmls", rev = "87e7e257d8eb15d6662b104518becfc75ef6db76", default-features = false }
+openmls_basic_credential = { git = "https://github.com/xmtp/openmls", rev = "87e7e257d8eb15d6662b104518becfc75ef6db76" }
+openmls_rust_crypto = { git = "https://github.com/xmtp/openmls", rev = "87e7e257d8eb15d6662b104518becfc75ef6db76" }
+openmls_traits = { git = "https://github.com/xmtp/openmls", rev = "87e7e257d8eb15d6662b104518becfc75ef6db76" }
 pbjson = "0.6.0"
 pbjson-types = "0.6.0"
 prost = "^0.12"

--- a/bindings_ffi/Cargo.lock
+++ b/bindings_ffi/Cargo.lock
@@ -2842,7 +2842,7 @@ dependencies = [
 [[package]]
 name = "openmls"
 version = "0.6.0-pre.2"
-source = "git+https://github.com/xmtp/openmls?rev=cf42738018d093434c955a1b50a9de34cc12b8c5#cf42738018d093434c955a1b50a9de34cc12b8c5"
+source = "git+https://github.com/xmtp/openmls?rev=87e7e257d8eb15d6662b104518becfc75ef6db76#87e7e257d8eb15d6662b104518becfc75ef6db76"
 dependencies = [
  "backtrace",
  "itertools 0.10.5",
@@ -2865,7 +2865,7 @@ dependencies = [
 [[package]]
 name = "openmls_basic_credential"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/xmtp/openmls?rev=cf42738018d093434c955a1b50a9de34cc12b8c5#cf42738018d093434c955a1b50a9de34cc12b8c5"
+source = "git+https://github.com/xmtp/openmls?rev=87e7e257d8eb15d6662b104518becfc75ef6db76#87e7e257d8eb15d6662b104518becfc75ef6db76"
 dependencies = [
  "ed25519-dalek",
  "openmls_traits",
@@ -2878,7 +2878,7 @@ dependencies = [
 [[package]]
 name = "openmls_memory_storage"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/xmtp/openmls?rev=cf42738018d093434c955a1b50a9de34cc12b8c5#cf42738018d093434c955a1b50a9de34cc12b8c5"
+source = "git+https://github.com/xmtp/openmls?rev=87e7e257d8eb15d6662b104518becfc75ef6db76#87e7e257d8eb15d6662b104518becfc75ef6db76"
 dependencies = [
  "hex",
  "log",
@@ -2891,7 +2891,7 @@ dependencies = [
 [[package]]
 name = "openmls_rust_crypto"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/xmtp/openmls?rev=cf42738018d093434c955a1b50a9de34cc12b8c5#cf42738018d093434c955a1b50a9de34cc12b8c5"
+source = "git+https://github.com/xmtp/openmls?rev=87e7e257d8eb15d6662b104518becfc75ef6db76#87e7e257d8eb15d6662b104518becfc75ef6db76"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -2915,7 +2915,7 @@ dependencies = [
 [[package]]
 name = "openmls_test"
 version = "0.1.0-pre.1"
-source = "git+https://github.com/xmtp/openmls?rev=cf42738018d093434c955a1b50a9de34cc12b8c5#cf42738018d093434c955a1b50a9de34cc12b8c5"
+source = "git+https://github.com/xmtp/openmls?rev=87e7e257d8eb15d6662b104518becfc75ef6db76#87e7e257d8eb15d6662b104518becfc75ef6db76"
 dependencies = [
  "ansi_term",
  "openmls_rust_crypto",
@@ -2930,7 +2930,7 @@ dependencies = [
 [[package]]
 name = "openmls_traits"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/xmtp/openmls?rev=cf42738018d093434c955a1b50a9de34cc12b8c5#cf42738018d093434c955a1b50a9de34cc12b8c5"
+source = "git+https://github.com/xmtp/openmls?rev=87e7e257d8eb15d6662b104518becfc75ef6db76#87e7e257d8eb15d6662b104518becfc75ef6db76"
 dependencies = [
  "serde",
  "tls_codec",

--- a/bindings_node/Cargo.lock
+++ b/bindings_node/Cargo.lock
@@ -2676,7 +2676,7 @@ dependencies = [
 [[package]]
 name = "openmls"
 version = "0.6.0-pre.2"
-source = "git+https://github.com/xmtp/openmls?rev=cf42738018d093434c955a1b50a9de34cc12b8c5#cf42738018d093434c955a1b50a9de34cc12b8c5"
+source = "git+https://github.com/xmtp/openmls?rev=87e7e257d8eb15d6662b104518becfc75ef6db76#87e7e257d8eb15d6662b104518becfc75ef6db76"
 dependencies = [
  "backtrace",
  "itertools 0.10.5",
@@ -2699,7 +2699,7 @@ dependencies = [
 [[package]]
 name = "openmls_basic_credential"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/xmtp/openmls?rev=cf42738018d093434c955a1b50a9de34cc12b8c5#cf42738018d093434c955a1b50a9de34cc12b8c5"
+source = "git+https://github.com/xmtp/openmls?rev=87e7e257d8eb15d6662b104518becfc75ef6db76#87e7e257d8eb15d6662b104518becfc75ef6db76"
 dependencies = [
  "ed25519-dalek",
  "openmls_traits",
@@ -2712,7 +2712,7 @@ dependencies = [
 [[package]]
 name = "openmls_memory_storage"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/xmtp/openmls?rev=cf42738018d093434c955a1b50a9de34cc12b8c5#cf42738018d093434c955a1b50a9de34cc12b8c5"
+source = "git+https://github.com/xmtp/openmls?rev=87e7e257d8eb15d6662b104518becfc75ef6db76#87e7e257d8eb15d6662b104518becfc75ef6db76"
 dependencies = [
  "hex",
  "log",
@@ -2725,7 +2725,7 @@ dependencies = [
 [[package]]
 name = "openmls_rust_crypto"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/xmtp/openmls?rev=cf42738018d093434c955a1b50a9de34cc12b8c5#cf42738018d093434c955a1b50a9de34cc12b8c5"
+source = "git+https://github.com/xmtp/openmls?rev=87e7e257d8eb15d6662b104518becfc75ef6db76#87e7e257d8eb15d6662b104518becfc75ef6db76"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -2749,7 +2749,7 @@ dependencies = [
 [[package]]
 name = "openmls_test"
 version = "0.1.0-pre.1"
-source = "git+https://github.com/xmtp/openmls?rev=cf42738018d093434c955a1b50a9de34cc12b8c5#cf42738018d093434c955a1b50a9de34cc12b8c5"
+source = "git+https://github.com/xmtp/openmls?rev=87e7e257d8eb15d6662b104518becfc75ef6db76#87e7e257d8eb15d6662b104518becfc75ef6db76"
 dependencies = [
  "ansi_term",
  "openmls_rust_crypto",
@@ -2764,7 +2764,7 @@ dependencies = [
 [[package]]
 name = "openmls_traits"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/xmtp/openmls?rev=cf42738018d093434c955a1b50a9de34cc12b8c5#cf42738018d093434c955a1b50a9de34cc12b8c5"
+source = "git+https://github.com/xmtp/openmls?rev=87e7e257d8eb15d6662b104518becfc75ef6db76#87e7e257d8eb15d6662b104518becfc75ef6db76"
 dependencies = [
  "serde",
  "tls_codec",

--- a/xmtp_api_http/src/util.rs
+++ b/xmtp_api_http/src/util.rs
@@ -48,8 +48,9 @@ pub async fn create_grpc_stream<
     endpoint: String,
     http_client: reqwest::Client,
 ) -> Result<BoxStream<'static, Result<R, Error>>, Error> {
+    log::info!("About to spawn stream");
     let stream = async_stream::stream! {
-        log::debug!("Spawning grpc http stream");
+        log::info!("Spawning grpc http stream");
         let request = http_client
                 .post(endpoint)
                 .json(&request)

--- a/xmtp_mls/src/lib.rs
+++ b/xmtp_mls/src/lib.rs
@@ -123,7 +123,7 @@ mod tests {
     #[macro_export]
     macro_rules! assert_err {
         ( $x:expr , $y:pat $(,)? ) => {
-            assert!(matches!($x, Err($y)));
+            assert!(matches!($x, Err($y)))
         };
 
         ( $x:expr, $y:pat $(,)?, $($msg:tt)+) => {{

--- a/xmtp_mls/src/storage/encrypted_store/refresh_state.rs
+++ b/xmtp_mls/src/storage/encrypted_store/refresh_state.rs
@@ -9,7 +9,7 @@ use diesel::{
 };
 
 use super::{db_connection::DbConnection, schema::refresh_state};
-use crate::{impl_store, storage::StorageError, Store};
+use crate::{impl_store, impl_store_or_ignore, storage::StorageError, StoreOrIgnore};
 
 #[repr(i32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, AsExpression, Hash, FromSqlRow)]
@@ -52,6 +52,7 @@ pub struct RefreshState {
 }
 
 impl_store!(RefreshState, refresh_state);
+impl_store_or_ignore!(RefreshState, refresh_state);
 
 impl DbConnection {
     pub fn get_refresh_state<EntityId: AsRef<Vec<u8>>>(
@@ -69,6 +70,7 @@ impl DbConnection {
 
         Ok(res)
     }
+
     pub fn get_last_cursor_for_id<IdType: AsRef<Vec<u8>>>(
         &self,
         id: IdType,
@@ -83,7 +85,7 @@ impl DbConnection {
                     entity_kind,
                     cursor: 0,
                 };
-                new_state.store(self)?;
+                new_state.store_or_ignore(self)?;
                 Ok(0)
             }
         }
@@ -119,7 +121,7 @@ impl DbConnection {
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-    use crate::storage::encrypted_store::tests::with_connection;
+    use crate::{storage::encrypted_store::tests::with_connection, Store};
 
     #[test]
     fn get_cursor_with_no_existing_state() {


### PR DESCRIPTION
## Summary

- When you receive a commit from a stream, we need to abort processing the message and sync instead. Previously we did that by decrypting the message and looking at the content to see what kind of message it was.
- There is a better way. There was a private method on the `PrivateMessageIn` that I have now made public that will let us see what kind of message it is _before_ decrypting.
- This should make streaming more performant and reliable, since we don't have to decrypt the message twice

## Related

https://github.com/xmtp/openmls/pull/36