### PR TITLE
Fix node bindings release workflow

### DIFF
--- a/.github/workflows/release-node-bindings.yml
+++ b/.github/workflows/release-node-bindings.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Configure aarch64 toolchain
         if: startsWith(matrix.target, 'aarch64')
         run: |
+          sudo apt-get update
           sudo apt-get install -qq crossbuild-essential-arm64 crossbuild-essential-armhf
           cat >>~/.cargo/config <<EOF
           [target.aarch64-unknown-linux-gnu]
@@ -193,6 +194,11 @@ jobs:
           workspaces: |
             .
             bindings_node
+
+      - name: Upgrade Visual Studio 2022 enterprise
+        uses: crazy-max/ghaction-chocolatey@v3
+        with:
+          args: upgrade visualstudio2022enterprise
 
       - name: Install Visual Studio 2022 build tools
         uses: crazy-max/ghaction-chocolatey@v3


### PR DESCRIPTION
# Summary

The node bindings release workflow stopped working due to some install issues. To fix these, 2 changes were made:

* Added `sudo apt-get update` before installing some linux tools to ensure latest package information
* Added `choco upgrade visualstudio2022enterprise` before installing `visualstudio2022buildtools` on windows machines (see [this comment](https://github.com/actions/runner-images/issues/9154#issuecomment-1889461610) for details)