### PR TITLE
Store or ignore group messages

### DIFF
--- a/xmtp_mls/src/groups/sync.rs
+++ b/xmtp_mls/src/groups/sync.rs
@@ -38,7 +38,7 @@ use crate::{
     },
     utils::{hash::sha256, id::calculate_message_id},
     xmtp_openmls_provider::XmtpOpenMlsProvider,
-    Client, Delete, Fetch, Store, XmtpApi,
+    Client, Delete, Fetch, StoreOrIgnore, XmtpApi,
 };
 use futures::future::try_join_all;
 use log::debug;
@@ -411,7 +411,7 @@ impl MlsGroup {
                             sender_inbox_id,
                             delivery_status: DeliveryStatus::Published,
                         }
-                        .store(provider.conn_ref())?
+                        .store_or_ignore(provider.conn_ref())?
                     }
                     Some(Content::V2(V2 {
                         idempotency_key,
@@ -438,7 +438,7 @@ impl MlsGroup {
                                 sender_inbox_id: sender_inbox_id.clone(),
                                 delivery_status: DeliveryStatus::Published,
                             }
-                            .store(provider.conn_ref())?;
+                            .store_or_ignore(provider.conn_ref())?;
                         }
                         Some(Reply(history_reply)) => {
                             let content: MessageHistoryContent =
@@ -461,7 +461,7 @@ impl MlsGroup {
                                 sender_inbox_id,
                                 delivery_status: DeliveryStatus::Published,
                             }
-                            .store(provider.conn_ref())?;
+                            .store_or_ignore(provider.conn_ref())?;
                         }
                         _ => {
                             return Err(MessageProcessingError::InvalidPayload);
@@ -725,7 +725,7 @@ impl MlsGroup {
             delivery_status: DeliveryStatus::Published,
         };
 
-        msg.store(conn)?;
+        msg.store_or_ignore(conn)?;
         Ok(Some(msg))
     }
 

--- a/xmtp_mls/src/storage/encrypted_store/group_message.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group_message.rs
@@ -13,7 +13,7 @@ use super::{
     db_connection::DbConnection,
     schema::{group_messages, group_messages::dsl},
 };
-use crate::{impl_fetch, impl_store, StorageError};
+use crate::{impl_fetch, impl_store, impl_store_or_ignore, StorageError};
 
 #[derive(
     Debug, Clone, Serialize, Deserialize, Insertable, Identifiable, Queryable, Eq, PartialEq,
@@ -106,6 +106,7 @@ where
 
 impl_fetch!(StoredGroupMessage, group_messages, Vec<u8>);
 impl_store!(StoredGroupMessage, group_messages);
+impl_store_or_ignore!(StoredGroupMessage, group_messages);
 
 impl DbConnection {
     /// Query for group messages


### PR DESCRIPTION
## tl;dr

- Use `store_or_ignore` for group messages, to avoid duplicate key errors. This can happen when there are multiple streams receiving your own messages.
- Shouldn't cause problems but it is noisy