### PR TITLE
Create group with initial members

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -714,14 +714,14 @@ impl FfiConversations {
             _ => None,
         };
 
-        let convo = self
-            .inner_client
-            .create_group(group_permissions, metadata_options)?;
-        if !account_addresses.is_empty() {
-            convo
-                .add_members(&self.inner_client, account_addresses)
-                .await?;
-        }
+        let convo = if account_addresses.is_empty() {
+            self.inner_client
+                .create_group(group_permissions, metadata_options)?
+        } else {
+            self.inner_client
+                .create_group_with_members(account_addresses, group_permissions, metadata_options)
+                .await?
+        };
 
         let out = Arc::new(FfiGroup {
             inner_client: self.inner_client.clone(),


### PR DESCRIPTION
## tl;dr
- Adds a new `create_group_with_members` function that creates a group and adds the initial members _before_ firing a `NewGroup` event
- Uses this in the FFI bindings

## More info

I noticed that we were creating new groups and seeing two commits immediately. I believe this is because we are creating the group and then adding members as two distinct steps.

After the group is created we fire the `NewGroup` event which gets sent to any client streaming new groups. Apps like Converse will immediately call `sync()` which will create a commit adding the rest of your installations to the group. There is a race where that call may come back faster than the client can add the first members.

Now this can all happen with a single commit instead of two.