### PR TITLE
added `serialize` and `deserialize` functions to `diesel-wasm-sqlite` backend

### DIFF
--- a/diesel-wasm-sqlite/package.js
+++ b/diesel-wasm-sqlite/package.js
@@ -313,9 +313,21 @@ export class SQLite {
     return this.sqlite3.capi.sqlite3_value_free(value);
   }
 
-  /*
-  serialize(database, zSchema, size, flags) {
-    return this.module._sqlite3_serialize(database, zSchema, size, flags);
+  sqlite3_serialize(database, z_schema, p_size, m_flags) {
+    try {
+      return this.sqlite3.capi.sqlite3_serialize(database, z_schema, p_size, m_flags);
+    } catch (error) {
+      console.log("error serializing");
+      throw error;
+    }
   }
-  */
+
+  sqlite3_deserialize(database, z_schema, p_data, sz_database, sz_buffer, m_flags) {
+    try {
+      return this.sqlite3.capi.sqlite3_deserialize(database, z_schema, p_data, sz_database, sz_buffer, m_flags);
+    } catch (error) {
+      console.log("error deserializing");
+      throw error;
+    }
+  }
 }

--- a/diesel-wasm-sqlite/src/ffi.rs
+++ b/diesel-wasm-sqlite/src/ffi.rs
@@ -328,4 +328,23 @@ extern "C" {
     #[wasm_bindgen(method)]
     pub fn value_free(this: &SQLite, value: *mut u8);
 
+    #[wasm_bindgen(method)]
+    pub fn sqlite3_serialize(
+        this: &SQLite,
+        database: &JsValue,
+        z_schema: &str,
+        p_size: Option<&mut i64>,
+        m_flags: u32
+    ) -> *mut u8;
+
+    #[wasm_bindgen(method)]
+    pub fn sqlite3_deserialize(
+        this: &SQLite,
+        database: &JsValue,
+        z_schema: &str,
+        p_data: &mut u8,
+        sz_database: i64,
+        sz_buffer: i64,
+        m_flags: u32
+    ) -> i32;
 }


### PR DESCRIPTION
Resolves #1003 

This PR has been made after doing thorough research on the serialize and deserialize sqlite3 functions, all the necessary changes have been made. 

- [x] added new foreign function interfaces in `ffi.rs`
- [x] implemented the logic for the function in both `package.js` and `connection/raw.rs`

Please let me know if there are any changes/fixes needed to this PR.