### PR TITLE
Replace signatures in IdentityUpdate

### DIFF
--- a/bindings_ffi/Cargo.lock
+++ b/bindings_ffi/Cargo.lock
@@ -5908,6 +5908,7 @@ dependencies = [
  "futures",
  "log",
  "parking_lot",
+ "rand",
  "tempfile",
  "thiserror",
  "thread-id",

--- a/bindings_ffi/Cargo.toml
+++ b/bindings_ffi/Cargo.toml
@@ -43,6 +43,7 @@ path = "src/bin.rs"
 
 [dev-dependencies]
 ethers = "2.0.13"
+rand = "0.8.5"
 tempfile = "3.5.0"
 tokio = { version = "1.28.1", features = ["full"] }
 tokio-test = "0.4"

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -7,12 +7,15 @@ use std::convert::TryInto;
 use std::sync::Arc;
 use tokio::{sync::Mutex, task::AbortHandle};
 use xmtp_api_grpc::grpc_api_helper::Client as TonicApiClient;
+use xmtp_id::associations::unverified::UnverifiedErc6492Signature;
+use xmtp_id::associations::unverified::UnverifiedRecoverableEcdsaSignature;
+use xmtp_id::associations::unverified::UnverifiedSignature;
+use xmtp_id::associations::AccountId;
 use xmtp_id::associations::AssociationState;
+use xmtp_id::scw_verifier::RpcSmartContractWalletVerifier;
+use xmtp_id::scw_verifier::SmartContractSignatureVerifier;
 use xmtp_id::{
-    associations::{
-        builder::SignatureRequest, generate_inbox_id as xmtp_id_generate_inbox_id,
-        RecoverableEcdsaSignature, SmartContractWalletSignature,
-    },
+    associations::{builder::SignatureRequest, generate_inbox_id as xmtp_id_generate_inbox_id},
     InboxId,
 };
 use xmtp_mls::groups::group_mutable_metadata::MetadataField;
@@ -179,17 +182,23 @@ pub struct FfiSignatureRequest {
     inner: Arc<Mutex<SignatureRequest>>,
 }
 
+// TODO:nm store the verifier on the request from the client
+fn signature_verifier() -> impl SmartContractSignatureVerifier {
+    RpcSmartContractWalletVerifier::new("http://www.fake.com".to_string())
+}
+
 #[uniffi::export(async_runtime = "tokio")]
 impl FfiSignatureRequest {
     // Signature that's signed by EOA wallet
     pub async fn add_ecdsa_signature(&self, signature_bytes: Vec<u8>) -> Result<(), GenericError> {
         let mut inner = self.inner.lock().await;
-        let signature_text = inner.signature_text();
         inner
-            .add_signature(Box::new(RecoverableEcdsaSignature::new(
-                signature_text,
-                signature_bytes,
-            )))
+            .add_signature(
+                UnverifiedSignature::RecoverableEcdsa(UnverifiedRecoverableEcdsaSignature::new(
+                    signature_bytes,
+                )),
+                &signature_verifier(),
+            )
             .await?;
 
         Ok(())
@@ -200,17 +209,20 @@ impl FfiSignatureRequest {
         &self,
         signature_bytes: Vec<u8>,
         address: String,
-        chain_rpc_url: String,
+        chain_id: u64,
+        block_number: u64,
     ) -> Result<(), GenericError> {
         let mut inner = self.inner.lock().await;
-        let signature = SmartContractWalletSignature::new_with_rpc(
-            inner.signature_text(),
+        let account_id = AccountId::new_evm(chain_id, address);
+
+        let signature = UnverifiedSignature::Erc6492(UnverifiedErc6492Signature::new(
             signature_bytes,
-            address,
-            chain_rpc_url,
-        )
-        .await?;
-        inner.add_signature(Box::new(signature)).await?;
+            account_id,
+            block_number,
+        ));
+        inner
+            .add_signature(signature, &signature_verifier())
+            .await?;
         Ok(())
     }
 
@@ -1560,6 +1572,7 @@ impl FfiGroupPermissions {
 
 #[cfg(test)]
 mod tests {
+    use super::{create_client, signature_verifier, FfiMessage, FfiMessageCallback, FfiXmtpClient};
     use crate::{
         get_inbox_id_for_address, inbox_owner::SigningError, logger::FfiLogger,
         FfiConversationCallback, FfiCreateGroupOptions, FfiGroup, FfiGroupMessageKind,
@@ -1567,6 +1580,8 @@ mod tests {
         FfiListMessagesOptions, FfiMetadataField, FfiPermissionPolicy, FfiPermissionPolicySet,
         FfiPermissionUpdateType,
     };
+    use ethers::utils::hex;
+    use rand::distributions::{Alphanumeric, DistString};
     use std::{
         env,
         sync::{
@@ -1574,16 +1589,12 @@ mod tests {
             Arc, Mutex,
         },
     };
-
-    use super::{create_client, FfiMessage, FfiMessageCallback, FfiXmtpClient};
-    use ethers::core::rand::{
-        self,
-        distributions::{Alphanumeric, DistString},
-    };
-    use ethers::utils::hex;
     use tokio::{sync::Notify, time::error::Elapsed};
     use xmtp_cryptography::{signature::RecoverableSignature, utils::rng};
-    use xmtp_id::associations::generate_inbox_id;
+    use xmtp_id::associations::{
+        generate_inbox_id,
+        unverified::{UnverifiedRecoverableEcdsaSignature, UnverifiedSignature},
+    };
     use xmtp_mls::{
         groups::{GroupError, MlsGroup},
         storage::EncryptionKey,
@@ -1908,12 +1919,12 @@ mod tests {
             .inner
             .lock()
             .await
-            .add_signature(Box::new(
-                xmtp_id::associations::RecoverableEcdsaSignature::new(
-                    signature_text,
+            .add_signature(
+                UnverifiedSignature::RecoverableEcdsa(UnverifiedRecoverableEcdsaSignature::new(
                     wallet_signature,
-                ),
-            ))
+                )),
+                &signature_verifier(),
+            )
             .await
             .unwrap();
     }

--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -17,7 +17,7 @@ use clap::{Parser, Subcommand, ValueEnum};
 use ethers::signers::{coins_bip39::English, LocalWallet, MnemonicBuilder};
 use kv_log_macro::{error, info};
 use prost::Message;
-use xmtp_id::associations::RecoverableEcdsaSignature;
+use xmtp_id::associations::unverified::{UnverifiedRecoverableEcdsaSignature, UnverifiedSignature};
 use xmtp_mls::groups::message_history::MessageHistoryContent;
 use xmtp_mls::storage::group_message::GroupMessageKind;
 
@@ -457,14 +457,17 @@ async fn register(cli: &Cli, maybe_seed_phrase: Option<String>) -> Result<(), Cl
     )
     .await?;
     let mut signature_request = client.identity().signature_request().unwrap();
-    let signature = RecoverableEcdsaSignature::new(
-        signature_request.signature_text(),
-        w.sign(signature_request.signature_text().as_str())
-            .unwrap()
-            .into(),
-    );
+    let sig_bytes: Vec<u8> = w
+        .sign(signature_request.signature_text().as_str())
+        .unwrap()
+        .into();
+    let signature =
+        UnverifiedSignature::RecoverableEcdsa(UnverifiedRecoverableEcdsaSignature::new(sig_bytes));
     signature_request
-        .add_signature(Box::new(signature))
+        .add_signature(
+            signature,
+            client.smart_contract_signature_verifier().as_ref(),
+        )
         .await
         .unwrap();
 
@@ -509,7 +512,7 @@ fn format_messages(
         if text.is_none() {
             continue;
         }
-        // TODO:nm use inbox ID
+
         let sender = if msg.sender_inbox_id == my_account_address {
             "Me".to_string()
         } else {

--- a/mls_validation_service/src/main.rs
+++ b/mls_validation_service/src/main.rs
@@ -10,6 +10,7 @@ use health_check::health_check_server;
 use tokio::signal::unix::{signal, SignalKind};
 use tonic::transport::Server;
 
+use xmtp_id::scw_verifier::RpcSmartContractWalletVerifier;
 use xmtp_proto::xmtp::mls_validation::v1::validation_api_server::ValidationApiServer;
 
 #[macro_use]
@@ -27,8 +28,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let health_server = health_check_server(args.health_check_port as u16);
 
+    // TODO:nm replace with real verifier
+    let scw_verifier = RpcSmartContractWalletVerifier::new("http://fixme.com".to_string());
+
     let grpc_server = Server::builder()
-        .add_service(ValidationApiServer::new(ValidationService::default()))
+        .add_service(ValidationApiServer::new(ValidationService::new(
+            scw_verifier,
+        )))
         .serve_with_shutdown(addr, async {
             wait_for_quit().await;
             info!("Shutdown signal received");

--- a/xmtp_id/src/associations/association_log.rs
+++ b/xmtp_id/src/associations/association_log.rs
@@ -1,11 +1,10 @@
 use super::hashes::generate_inbox_id;
 use super::member::{Member, MemberIdentifier, MemberKind};
-use super::serialization::{from_identity_update_proto, DeserializationError};
-use super::signature::{Signature, SignatureError, SignatureKind};
+use super::serialization::DeserializationError;
+use super::signature::{SignatureError, SignatureKind};
 use super::state::AssociationState;
-use prost::Message;
+use super::verified_signature::VerifiedSignature;
 use thiserror::Error;
-use xmtp_proto::xmtp::identity::associations::IdentityUpdate as IdentityUpdateProto;
 
 #[derive(Debug, Error)]
 pub enum AssociationError {
@@ -37,8 +36,8 @@ pub enum AssociationError {
     MissingIdentityUpdate,
 }
 
-pub(crate) trait IdentityAction: Send + 'static {
-    async fn update_state(
+pub trait IdentityAction: Send + 'static {
+    fn update_state(
         &self,
         existing_state: Option<AssociationState>,
     ) -> Result<AssociationState, AssociationError>;
@@ -60,11 +59,11 @@ pub(crate) trait IdentityAction: Send + 'static {
 pub struct CreateInbox {
     pub nonce: u64,
     pub account_address: String,
-    pub initial_address_signature: Box<dyn Signature>,
+    pub initial_address_signature: VerifiedSignature,
 }
 
 impl IdentityAction for CreateInbox {
-    async fn update_state(
+    fn update_state(
         &self,
         existing_state: Option<AssociationState>,
     ) -> Result<AssociationState, AssociationError> {
@@ -73,20 +72,16 @@ impl IdentityAction for CreateInbox {
         }
 
         let account_address = self.account_address.clone();
-        let recovered_signer = self.initial_address_signature.recover_signer().await?;
+        let recovered_signer = self.initial_address_signature.signer.clone();
         if recovered_signer.ne(&MemberIdentifier::Address(
             account_address.clone().to_lowercase(),
         )) {
             return Err(AssociationError::MissingExistingMember);
         }
 
-        allowed_signature_for_kind(
-            &MemberKind::Address,
-            &self.initial_address_signature.signature_kind(),
-        )?;
+        allowed_signature_for_kind(&MemberKind::Address, &self.initial_address_signature.kind)?;
 
-        if self.initial_address_signature.signature_kind() == SignatureKind::LegacyDelegated
-            && self.nonce != 0
+        if self.initial_address_signature.kind == SignatureKind::LegacyDelegated && self.nonce != 0
         {
             return Err(AssociationError::LegacySignatureReuse);
         }
@@ -95,20 +90,20 @@ impl IdentityAction for CreateInbox {
     }
 
     fn signatures(&self) -> Vec<Vec<u8>> {
-        vec![self.initial_address_signature.bytes()]
+        vec![self.initial_address_signature.raw_bytes.clone()]
     }
 }
 
 /// AddAssociation Action
 #[derive(Debug, Clone)]
 pub struct AddAssociation {
-    pub new_member_signature: Box<dyn Signature>,
+    pub new_member_signature: VerifiedSignature,
     pub new_member_identifier: MemberIdentifier,
-    pub existing_member_signature: Box<dyn Signature>,
+    pub existing_member_signature: VerifiedSignature,
 }
 
 impl IdentityAction for AddAssociation {
-    async fn update_state(
+    fn update_state(
         &self,
         maybe_existing_state: Option<AssociationState>,
     ) -> Result<AssociationState, AssociationError> {
@@ -116,9 +111,9 @@ impl IdentityAction for AddAssociation {
         self.replay_check(&existing_state)?;
 
         // Validate the new member signature and get the recovered signer
-        let new_member_address = self.new_member_signature.recover_signer().await?;
+        let new_member_address = &self.new_member_signature.signer;
         // Validate the existing member signature and get the recovedred signer
-        let existing_member_identifier = self.existing_member_signature.recover_signer().await?;
+        let existing_member_identifier = &self.existing_member_signature.signer;
 
         if new_member_address.ne(&self.new_member_identifier) {
             return Err(AssociationError::NewMemberIdSignatureMismatch);
@@ -134,7 +129,7 @@ impl IdentityAction for AddAssociation {
         if (is_legacy_signature(&self.new_member_signature)
             || is_legacy_signature(&self.existing_member_signature))
             && existing_state.inbox_id().ne(&generate_inbox_id(
-                &existing_member_identifier.to_string(),
+                existing_member_identifier.to_string().as_str(),
                 &0,
             ))
         {
@@ -143,10 +138,10 @@ impl IdentityAction for AddAssociation {
 
         allowed_signature_for_kind(
             &self.new_member_identifier.kind(),
-            &self.new_member_signature.signature_kind(),
+            &self.new_member_signature.kind,
         )?;
 
-        let existing_member = existing_state.get(&existing_member_identifier);
+        let existing_member = existing_state.get(existing_member_identifier);
 
         let existing_entity_id = match existing_member {
             // If there is an existing member of the XID, use that member's ID
@@ -172,7 +167,7 @@ impl IdentityAction for AddAssociation {
         // Ensure that the existing member signature is correct for the existing member type
         allowed_signature_for_kind(
             &existing_entity_id.kind(),
-            &self.existing_member_signature.signature_kind(),
+            &self.existing_member_signature.kind,
         )?;
 
         // Ensure that the new member signature is correct for the new member type
@@ -181,15 +176,15 @@ impl IdentityAction for AddAssociation {
             self.new_member_identifier.kind(),
         )?;
 
-        let new_member = Member::new(new_member_address, Some(existing_entity_id));
+        let new_member = Member::new(new_member_address.clone(), Some(existing_entity_id));
 
         Ok(existing_state.add(new_member))
     }
 
     fn signatures(&self) -> Vec<Vec<u8>> {
         vec![
-            self.existing_member_signature.bytes(),
-            self.new_member_signature.bytes(),
+            self.existing_member_signature.raw_bytes.clone(),
+            self.new_member_signature.raw_bytes.clone(),
         ]
     }
 }
@@ -197,12 +192,12 @@ impl IdentityAction for AddAssociation {
 /// RevokeAssociation Action
 #[derive(Debug, Clone)]
 pub struct RevokeAssociation {
-    pub recovery_address_signature: Box<dyn Signature>,
+    pub recovery_address_signature: VerifiedSignature,
     pub revoked_member: MemberIdentifier,
 }
 
 impl IdentityAction for RevokeAssociation {
-    async fn update_state(
+    fn update_state(
         &self,
         maybe_existing_state: Option<AssociationState>,
     ) -> Result<AssociationState, AssociationError> {
@@ -216,7 +211,7 @@ impl IdentityAction for RevokeAssociation {
             ));
         }
         // Don't need to check for replay here since revocation is idempotent
-        let recovery_signer = self.recovery_address_signature.recover_signer().await?;
+        let recovery_signer = &self.recovery_address_signature.signer;
         // Make sure there is a recovery address set on the state
         let state_recovery_address = existing_state.recovery_address();
 
@@ -245,19 +240,19 @@ impl IdentityAction for RevokeAssociation {
     }
 
     fn signatures(&self) -> Vec<Vec<u8>> {
-        vec![self.recovery_address_signature.bytes()]
+        vec![self.recovery_address_signature.raw_bytes.clone()]
     }
 }
 
 /// ChangeRecoveryAddress Action
 #[derive(Debug, Clone)]
 pub struct ChangeRecoveryAddress {
-    pub recovery_address_signature: Box<dyn Signature>,
+    pub recovery_address_signature: VerifiedSignature,
     pub new_recovery_address: String,
 }
 
 impl IdentityAction for ChangeRecoveryAddress {
-    async fn update_state(
+    fn update_state(
         &self,
         existing_state: Option<AssociationState>,
     ) -> Result<AssociationState, AssociationError> {
@@ -271,7 +266,7 @@ impl IdentityAction for ChangeRecoveryAddress {
             ));
         }
 
-        let recovery_signer = self.recovery_address_signature.recover_signer().await?;
+        let recovery_signer = &self.recovery_address_signature.signer;
         if recovery_signer.ne(&existing_state.recovery_address().clone().into()) {
             return Err(AssociationError::MissingExistingMember);
         }
@@ -280,7 +275,7 @@ impl IdentityAction for ChangeRecoveryAddress {
     }
 
     fn signatures(&self) -> Vec<Vec<u8>> {
-        vec![self.recovery_address_signature.bytes()]
+        vec![self.recovery_address_signature.raw_bytes.clone()]
     }
 }
 
@@ -294,15 +289,15 @@ pub enum Action {
 }
 
 impl IdentityAction for Action {
-    async fn update_state(
+    fn update_state(
         &self,
         existing_state: Option<AssociationState>,
     ) -> Result<AssociationState, AssociationError> {
         match self {
-            Action::CreateInbox(event) => event.update_state(existing_state).await,
-            Action::AddAssociation(event) => event.update_state(existing_state).await,
-            Action::RevokeAssociation(event) => event.update_state(existing_state).await,
-            Action::ChangeRecoveryAddress(event) => event.update_state(existing_state).await,
+            Action::CreateInbox(event) => event.update_state(existing_state),
+            Action::AddAssociation(event) => event.update_state(existing_state),
+            Action::RevokeAssociation(event) => event.update_state(existing_state),
+            Action::ChangeRecoveryAddress(event) => event.update_state(existing_state),
         }
     }
 
@@ -332,41 +327,16 @@ impl IdentityUpdate {
             client_timestamp_ns,
         }
     }
-
-    pub fn to_proto(self) -> IdentityUpdateProto {
-        IdentityUpdateProto::from(self)
-    }
-
-    pub fn from_proto(proto: IdentityUpdateProto) -> Result<Self, DeserializationError> {
-        from_identity_update_proto(proto)
-    }
-}
-
-impl TryFrom<IdentityUpdateProto> for IdentityUpdate {
-    type Error = DeserializationError;
-
-    fn try_from(proto: IdentityUpdateProto) -> Result<IdentityUpdate, Self::Error> {
-        IdentityUpdate::from_proto(proto)
-    }
-}
-
-impl TryFrom<Vec<u8>> for IdentityUpdate {
-    type Error = DeserializationError;
-
-    fn try_from(bytes: Vec<u8>) -> Result<IdentityUpdate, Self::Error> {
-        let proto = IdentityUpdateProto::decode(bytes.as_slice())?;
-        IdentityUpdate::from_proto(proto)
-    }
 }
 
 impl IdentityAction for IdentityUpdate {
-    async fn update_state(
+    fn update_state(
         &self,
         existing_state: Option<AssociationState>,
     ) -> Result<AssociationState, AssociationError> {
         let mut state = existing_state.clone();
         for action in &self.actions {
-            state = Some(action.update_state(state).await?);
+            state = Some(action.update_state(state)?);
         }
 
         let new_state = state.ok_or(AssociationError::NotCreated)?;
@@ -393,8 +363,8 @@ impl IdentityAction for IdentityUpdate {
 }
 
 #[allow(clippy::borrowed_box)]
-fn is_legacy_signature(signature: &Box<dyn Signature>) -> bool {
-    signature.signature_kind() == SignatureKind::LegacyDelegated
+fn is_legacy_signature(signature: &VerifiedSignature) -> bool {
+    signature.kind == SignatureKind::LegacyDelegated
 }
 
 fn allowed_association(

--- a/xmtp_id/src/associations/mod.rs
+++ b/xmtp_id/src/associations/mod.rs
@@ -8,8 +8,8 @@ mod state;
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;
 pub mod unsigned_actions;
-mod unverified;
-mod verified_signature;
+pub mod unverified;
+pub mod verified_signature;
 
 pub use self::association_log::*;
 pub use self::hashes::generate_inbox_id;
@@ -18,23 +18,21 @@ pub use self::serialization::{map_vec, try_map_vec, DeserializationError};
 pub use self::signature::*;
 pub use self::state::{AssociationState, AssociationStateDiff};
 
-use crate::associations::association_log::IdentityAction;
-
 // Apply a single IdentityUpdate to an existing AssociationState
-pub async fn apply_update(
+pub fn apply_update(
     initial_state: AssociationState,
     update: IdentityUpdate,
 ) -> Result<AssociationState, AssociationError> {
-    update.update_state(Some(initial_state)).await
+    update.update_state(Some(initial_state))
 }
 
 // Get the current state from an array of `IdentityUpdate`s. Entire operation fails if any operation fails
-pub async fn get_state<Updates: AsRef<[IdentityUpdate]>>(
+pub fn get_state<Updates: AsRef<[IdentityUpdate]>>(
     updates: Updates,
 ) -> Result<AssociationState, AssociationError> {
     let mut state = None;
     for update in updates.as_ref().iter() {
-        let res = update.update_state(state).await;
+        let res = update.update_state(state);
         state = Some(res?);
     }
 
@@ -43,7 +41,11 @@ pub async fn get_state<Updates: AsRef<[IdentityUpdate]>>(
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_defaults {
-    use self::test_utils::{rand_string, rand_u64, rand_vec, MockSignature};
+    use self::{
+        test_utils::{rand_string, rand_u64, rand_vec},
+        unverified::{UnverifiedAction, UnverifiedIdentityUpdate},
+        verified_signature::VerifiedSignature,
+    };
     use super::*;
 
     impl IdentityUpdate {
@@ -52,22 +54,26 @@ pub mod test_defaults {
         }
     }
 
+    impl UnverifiedIdentityUpdate {
+        pub fn new_test(actions: Vec<UnverifiedAction>, inbox_id: String) -> Self {
+            Self::new(inbox_id, rand_u64(), actions)
+        }
+    }
+
     impl Default for AddAssociation {
         fn default() -> Self {
             let existing_member = rand_string();
             let new_member = rand_vec();
             Self {
-                existing_member_signature: MockSignature::new_boxed(
-                    true,
+                existing_member_signature: VerifiedSignature::new(
                     existing_member.into(),
                     SignatureKind::Erc191,
-                    None,
+                    rand_vec(),
                 ),
-                new_member_signature: MockSignature::new_boxed(
-                    true,
+                new_member_signature: VerifiedSignature::new(
                     new_member.clone().into(),
                     SignatureKind::InstallationKey,
-                    None,
+                    rand_vec(),
                 ),
                 new_member_identifier: new_member.into(),
             }
@@ -81,11 +87,10 @@ pub mod test_defaults {
             Self {
                 nonce: rand_u64(),
                 account_address: signer.clone(),
-                initial_address_signature: MockSignature::new_boxed(
-                    true,
+                initial_address_signature: VerifiedSignature::new(
                     signer.into(),
                     SignatureKind::Erc191,
-                    None,
+                    rand_vec(),
                 ),
             }
         }
@@ -95,11 +100,10 @@ pub mod test_defaults {
         fn default() -> Self {
             let signer = rand_string();
             Self {
-                recovery_address_signature: MockSignature::new_boxed(
-                    true,
+                recovery_address_signature: VerifiedSignature::new(
                     signer.into(),
                     SignatureKind::Erc191,
-                    None,
+                    rand_vec(),
                 ),
                 revoked_member: rand_string().into(),
             }
@@ -109,7 +113,10 @@ pub mod test_defaults {
 
 #[cfg(test)]
 mod tests {
-    use self::test_utils::{rand_string, rand_vec, MockSignature};
+    use self::{
+        test_utils::{rand_string, rand_vec},
+        verified_signature::VerifiedSignature,
+    };
     use super::*;
 
     pub async fn new_test_inbox() -> AssociationState {
@@ -118,7 +125,7 @@ mod tests {
         let identity_update =
             IdentityUpdate::new_test(vec![Action::CreateInbox(create_request)], inbox_id);
 
-        get_state(vec![identity_update]).await.unwrap()
+        get_state(vec![identity_update]).unwrap()
     }
 
     pub async fn new_test_inbox_with_installation() -> AssociationState {
@@ -128,11 +135,10 @@ mod tests {
             initial_state.recovery_address().clone().into();
 
         let update = Action::AddAssociation(AddAssociation {
-            existing_member_signature: MockSignature::new_boxed(
-                true,
+            existing_member_signature: VerifiedSignature::new(
                 initial_wallet_address.clone(),
                 SignatureKind::Erc191,
-                None,
+                rand_vec(),
             ),
             ..Default::default()
         });
@@ -141,7 +147,6 @@ mod tests {
             initial_state,
             IdentityUpdate::new_test(vec![update], inbox_id.clone()),
         )
-        .await
         .unwrap()
     }
 
@@ -152,7 +157,7 @@ mod tests {
         let account_address = create_request.account_address.clone();
         let identity_update =
             IdentityUpdate::new_test(vec![Action::CreateInbox(create_request)], inbox_id.clone());
-        let state = get_state(vec![identity_update]).await.unwrap();
+        let state = get_state(vec![identity_update]).unwrap();
         assert_eq!(state.members().len(), 1);
 
         let existing_entity = state.get(&account_address.clone().into()).unwrap();
@@ -168,17 +173,15 @@ mod tests {
 
         let update = Action::AddAssociation(AddAssociation {
             new_member_identifier: new_installation_identifier.clone(),
-            new_member_signature: MockSignature::new_boxed(
-                true,
+            new_member_signature: VerifiedSignature::new(
                 new_installation_identifier.clone(),
                 SignatureKind::InstallationKey,
-                None,
+                rand_vec(),
             ),
-            existing_member_signature: MockSignature::new_boxed(
-                true,
+            existing_member_signature: VerifiedSignature::new(
                 first_member.clone(),
                 SignatureKind::Erc191,
-                None,
+                rand_vec(),
             ),
         });
 
@@ -186,7 +189,6 @@ mod tests {
             initial_state,
             IdentityUpdate::new_test(vec![update], inbox_id.clone()),
         )
-        .await
         .unwrap();
         assert_eq!(new_state.members().len(), 2);
 
@@ -201,18 +203,16 @@ mod tests {
         let inbox_id = generate_inbox_id(&account_address, &create_action.nonce);
         let new_member_identifier: MemberIdentifier = rand_vec().into();
         let add_action = AddAssociation {
-            existing_member_signature: MockSignature::new_boxed(
-                true,
+            existing_member_signature: VerifiedSignature::new(
                 account_address.clone().into(),
                 SignatureKind::Erc191,
-                None,
+                rand_vec(),
             ),
             // Add an installation ID
-            new_member_signature: MockSignature::new_boxed(
-                true,
+            new_member_signature: VerifiedSignature::new(
                 new_member_identifier.clone(),
                 SignatureKind::InstallationKey,
-                None,
+                rand_vec(),
             ),
             new_member_identifier: new_member_identifier.clone(),
         };
@@ -223,7 +223,7 @@ mod tests {
             ],
             inbox_id.clone(),
         );
-        let state = get_state(vec![identity_update]).await.unwrap();
+        let state = get_state(vec![identity_update]).unwrap();
         assert_eq!(state.members().len(), 2);
         assert_eq!(
             state.get(&new_member_identifier).unwrap().added_by_entity,
@@ -237,11 +237,10 @@ mod tests {
         let create_action = CreateInbox {
             nonce: 0,
             account_address: member_identifier.to_string(),
-            initial_address_signature: MockSignature::new_boxed(
-                true,
+            initial_address_signature: VerifiedSignature::new(
                 member_identifier.clone(),
                 SignatureKind::LegacyDelegated,
-                Some("0".to_string()),
+                "0".as_bytes().to_vec(),
             ),
         };
         let inbox_id = generate_inbox_id(&member_identifier.to_string(), &0);
@@ -249,26 +248,23 @@ mod tests {
             vec![Action::CreateInbox(create_action)],
             inbox_id.clone(),
         )])
-        .await
         .unwrap();
         assert_eq!(state.members().len(), 1);
 
         // The legacy key can only be used once. After this, subsequent updates should fail
         let update = Action::AddAssociation(AddAssociation {
-            existing_member_signature: MockSignature::new_boxed(
-                true,
+            existing_member_signature: VerifiedSignature::new(
                 member_identifier,
                 SignatureKind::LegacyDelegated,
                 // All requests from the same legacy key will have the same signature nonce
-                Some("0".to_string()),
+                "0".as_bytes().to_vec(),
             ),
             ..Default::default()
         });
         let update_result = apply_update(
             state,
             IdentityUpdate::new_test(vec![update], inbox_id.clone()),
-        )
-        .await;
+        );
         assert!(matches!(update_result, Err(AssociationError::Replay)));
     }
 
@@ -286,17 +282,15 @@ mod tests {
         let new_wallet_address: MemberIdentifier = rand_string().into();
         let add_association = Action::AddAssociation(AddAssociation {
             new_member_identifier: new_wallet_address.clone(),
-            new_member_signature: MockSignature::new_boxed(
-                true,
+            new_member_signature: VerifiedSignature::new(
                 new_wallet_address.clone(),
                 SignatureKind::Erc191,
-                None,
+                rand_vec(),
             ),
-            existing_member_signature: MockSignature::new_boxed(
-                true,
+            existing_member_signature: VerifiedSignature::new(
                 installation_id.clone(),
                 SignatureKind::InstallationKey,
-                None,
+                rand_vec(),
             ),
         });
 
@@ -304,29 +298,29 @@ mod tests {
             initial_state,
             IdentityUpdate::new_test(vec![add_association], inbox_id.clone()),
         )
-        .await
         .expect("expected update to succeed");
         assert_eq!(new_state.members().len(), 3);
     }
 
     #[tokio::test]
     async fn reject_invalid_signature_on_create() {
+        // Creates a signature with the wrong signer
         let bad_signature =
-            MockSignature::new_boxed(false, rand_string().into(), SignatureKind::Erc191, None);
+            VerifiedSignature::new(rand_string().into(), SignatureKind::Erc191, rand_vec());
         let action = CreateInbox {
-            initial_address_signature: bad_signature.clone(),
+            initial_address_signature: bad_signature,
             ..Default::default()
         };
 
         let state_result = get_state(vec![IdentityUpdate::new_test(
             vec![Action::CreateInbox(action)],
             rand_string(),
-        )])
-        .await;
+        )]);
+
         assert!(state_result.is_err());
         assert!(matches!(
             state_result,
-            Err(AssociationError::Signature(SignatureError::Invalid))
+            Err(AssociationError::MissingExistingMember)
         ));
     }
 
@@ -334,8 +328,9 @@ mod tests {
     async fn reject_invalid_signature_on_update() {
         let initial_state = new_test_inbox().await;
         let inbox_id = initial_state.inbox_id().clone();
+        // Signature is from a random address
         let bad_signature =
-            MockSignature::new_boxed(false, rand_string().into(), SignatureKind::Erc191, None);
+            VerifiedSignature::new(rand_string().into(), SignatureKind::Erc191, rand_vec());
 
         let update_with_bad_existing_member = Action::AddAssociation(AddAssociation {
             existing_member_signature: bad_signature.clone(),
@@ -345,20 +340,19 @@ mod tests {
         let update_result = apply_update(
             initial_state.clone(),
             IdentityUpdate::new_test(vec![update_with_bad_existing_member], inbox_id.clone()),
-        )
-        .await;
+        );
+
         assert!(matches!(
             update_result,
-            Err(AssociationError::Signature(SignatureError::Invalid))
+            Err(AssociationError::MissingExistingMember)
         ));
 
         let update_with_bad_new_member = Action::AddAssociation(AddAssociation {
             new_member_signature: bad_signature.clone(),
-            existing_member_signature: MockSignature::new_boxed(
-                true,
+            existing_member_signature: VerifiedSignature::new(
                 initial_state.recovery_address().clone().into(),
                 SignatureKind::Erc191,
-                None,
+                rand_vec(),
             ),
             ..Default::default()
         });
@@ -366,11 +360,10 @@ mod tests {
         let update_result_2 = apply_update(
             initial_state,
             IdentityUpdate::new_test(vec![update_with_bad_new_member], inbox_id.clone()),
-        )
-        .await;
+        );
         assert!(matches!(
             update_result_2,
-            Err(AssociationError::Signature(SignatureError::Invalid))
+            Err(AssociationError::NewMemberIdSignatureMismatch)
         ));
     }
 
@@ -382,11 +375,10 @@ mod tests {
         // The default here will create an AddAssociation from a random wallet
         let update = Action::AddAssociation(AddAssociation {
             // Existing member signature is coming from a random wallet
-            existing_member_signature: MockSignature::new_boxed(
-                true,
+            existing_member_signature: VerifiedSignature::new(
                 rand_string().into(),
                 SignatureKind::Erc191,
-                None,
+                rand_vec(),
             ),
             ..Default::default()
         });
@@ -394,8 +386,7 @@ mod tests {
         let state_result = get_state(vec![IdentityUpdate::new_test(
             vec![create_request, update],
             inbox_id.clone(),
-        )])
-        .await;
+        )]);
         assert!(matches!(
             state_result,
             Err(AssociationError::MissingExistingMember)
@@ -411,26 +402,23 @@ mod tests {
         let new_installation_id: MemberIdentifier = rand_vec().into();
 
         let update = Action::AddAssociation(AddAssociation {
-            existing_member_signature: MockSignature::new_boxed(
-                true,
+            existing_member_signature: VerifiedSignature::new(
                 existing_installation.identifier.clone(),
                 SignatureKind::InstallationKey,
-                None,
+                rand_vec(),
             ),
             new_member_identifier: new_installation_id.clone(),
-            new_member_signature: MockSignature::new_boxed(
-                true,
+            new_member_signature: VerifiedSignature::new(
                 new_installation_id.clone(),
                 SignatureKind::InstallationKey,
-                None,
+                rand_vec(),
             ),
         });
 
         let update_result = apply_update(
             existing_state,
             IdentityUpdate::new_test(vec![update], inbox_id.clone()),
-        )
-        .await;
+        );
         assert!(matches!(
             update_result,
             Err(AssociationError::MemberNotAllowed(
@@ -451,11 +439,10 @@ mod tests {
             .unwrap()
             .identifier;
         let update = Action::RevokeAssociation(RevokeAssociation {
-            recovery_address_signature: MockSignature::new_boxed(
-                true,
+            recovery_address_signature: VerifiedSignature::new(
                 initial_state.recovery_address().clone().into(),
                 SignatureKind::Erc191,
-                None,
+                rand_vec(),
             ),
             revoked_member: installation_id.clone(),
         });
@@ -464,7 +451,6 @@ mod tests {
             initial_state,
             IdentityUpdate::new_test(vec![update], inbox_id.clone()),
         )
-        .await
         .expect("expected update to succeed");
         assert!(new_state.get(&installation_id).is_none());
     }
@@ -481,11 +467,10 @@ mod tests {
             .identifier;
 
         let add_second_installation = Action::AddAssociation(AddAssociation {
-            existing_member_signature: MockSignature::new_boxed(
-                true,
+            existing_member_signature: VerifiedSignature::new(
                 wallet_address.clone(),
                 SignatureKind::Erc191,
-                None,
+                rand_vec(),
             ),
             ..Default::default()
         });
@@ -494,16 +479,14 @@ mod tests {
             initial_state,
             IdentityUpdate::new_test(vec![add_second_installation], inbox_id.clone()),
         )
-        .await
         .expect("expected update to succeed");
         assert_eq!(new_state.members().len(), 3);
 
         let revocation = Action::RevokeAssociation(RevokeAssociation {
-            recovery_address_signature: MockSignature::new_boxed(
-                true,
+            recovery_address_signature: VerifiedSignature::new(
                 wallet_address.clone(),
                 SignatureKind::Erc191,
-                None,
+                rand_vec(),
             ),
             revoked_member: wallet_address.clone(),
         });
@@ -513,7 +496,6 @@ mod tests {
             new_state,
             IdentityUpdate::new_test(vec![revocation], inbox_id.clone()),
         )
-        .await
         .expect("expected update to succeed");
         assert_eq!(new_state.members().len(), 0);
     }
@@ -533,26 +515,23 @@ mod tests {
         let second_wallet_address: MemberIdentifier = rand_string().into();
         let add_second_wallet = Action::AddAssociation(AddAssociation {
             new_member_identifier: second_wallet_address.clone(),
-            new_member_signature: MockSignature::new_boxed(
-                true,
+            new_member_signature: VerifiedSignature::new(
                 second_wallet_address.clone(),
                 SignatureKind::Erc191,
-                None,
+                rand_vec(),
             ),
-            existing_member_signature: MockSignature::new_boxed(
-                true,
+            existing_member_signature: VerifiedSignature::new(
                 wallet_address.clone(),
                 SignatureKind::Erc191,
-                None,
+                rand_vec(),
             ),
         });
 
         let revoke_second_wallet = Action::RevokeAssociation(RevokeAssociation {
-            recovery_address_signature: MockSignature::new_boxed(
-                true,
+            recovery_address_signature: VerifiedSignature::new(
                 wallet_address.clone(),
                 SignatureKind::Erc191,
-                None,
+                rand_vec(),
             ),
             revoked_member: second_wallet_address.clone(),
         });
@@ -564,23 +543,20 @@ mod tests {
                 inbox_id.clone(),
             ),
         )
-        .await
         .expect("expected update to succeed");
         assert_eq!(state_after_remove.members().len(), 1);
 
         let add_second_wallet_again = Action::AddAssociation(AddAssociation {
             new_member_identifier: second_wallet_address.clone(),
-            new_member_signature: MockSignature::new_boxed(
-                true,
+            new_member_signature: VerifiedSignature::new(
                 second_wallet_address.clone(),
                 SignatureKind::Erc191,
-                None,
+                rand_vec(),
             ),
-            existing_member_signature: MockSignature::new_boxed(
-                true,
+            existing_member_signature: VerifiedSignature::new(
                 wallet_address,
                 SignatureKind::Erc191,
-                None,
+                rand_vec(),
             ),
         });
 
@@ -588,7 +564,6 @@ mod tests {
             state_after_remove,
             IdentityUpdate::new_test(vec![add_second_wallet_again], inbox_id.clone()),
         )
-        .await
         .expect("expected update to succeed");
         assert_eq!(state_after_re_add.members().len(), 2);
     }
@@ -602,11 +577,10 @@ mod tests {
         let new_recovery_address = rand_string();
         let update_recovery = Action::ChangeRecoveryAddress(ChangeRecoveryAddress {
             new_recovery_address: new_recovery_address.clone(),
-            recovery_address_signature: MockSignature::new_boxed(
-                true,
+            recovery_address_signature: VerifiedSignature::new(
                 initial_state.recovery_address().clone().into(),
                 SignatureKind::Erc191,
-                None,
+                rand_vec(),
             ),
         });
 
@@ -614,16 +588,14 @@ mod tests {
             initial_state,
             IdentityUpdate::new_test(vec![update_recovery], inbox_id.clone()),
         )
-        .await
         .expect("expected update to succeed");
         assert_eq!(new_state.recovery_address(), &new_recovery_address);
 
         let attempted_revoke = Action::RevokeAssociation(RevokeAssociation {
-            recovery_address_signature: MockSignature::new_boxed(
-                true,
+            recovery_address_signature: VerifiedSignature::new(
                 initial_recovery_address.clone(),
                 SignatureKind::Erc191,
-                None,
+                rand_vec(),
             ),
             revoked_member: initial_recovery_address.clone(),
         });
@@ -631,8 +603,7 @@ mod tests {
         let revoke_result = apply_update(
             new_state,
             IdentityUpdate::new_test(vec![attempted_revoke], inbox_id.clone()),
-        )
-        .await;
+        );
         assert!(revoke_result.is_err());
         assert!(matches!(
             revoke_result,

--- a/xmtp_id/src/associations/serialization.rs
+++ b/xmtp_id/src/associations/serialization.rs
@@ -1,18 +1,11 @@
 use std::collections::{HashMap, HashSet};
 
 use super::{
-    association_log::{
-        Action, AddAssociation, ChangeRecoveryAddress, CreateInbox, RevokeAssociation,
-    },
     member::Member,
-    signature::{
-        AccountId, InstallationKeySignature, LegacyDelegatedSignature, RecoverableEcdsaSignature,
-        SmartContractWalletSignature, ValidatedLegacySignedPublicKey,
-    },
+    signature::{AccountId, ValidatedLegacySignedPublicKey},
     state::{AssociationState, AssociationStateDiff},
     unsigned_actions::{
-        SignatureTextCreator, UnsignedAction, UnsignedAddAssociation,
-        UnsignedChangeRecoveryAddress, UnsignedCreateInbox, UnsignedIdentityUpdate,
+        UnsignedAddAssociation, UnsignedChangeRecoveryAddress, UnsignedCreateInbox,
         UnsignedRevokeAssociation,
     },
     unverified::{
@@ -21,12 +14,13 @@ use super::{
         UnverifiedInstallationKeySignature, UnverifiedLegacyDelegatedSignature,
         UnverifiedRecoverableEcdsaSignature, UnverifiedRevokeAssociation, UnverifiedSignature,
     },
-    IdentityUpdate, MemberIdentifier, Signature, SignatureError,
+    verified_signature::VerifiedSignature,
+    MemberIdentifier, SignatureError,
 };
 use prost::{DecodeError, Message};
 use regex::Regex;
 use thiserror::Error;
-use xmtp_cryptography::signature::{sanitize_evm_addresses, RecoverableSignature};
+use xmtp_cryptography::signature::sanitize_evm_addresses;
 use xmtp_proto::xmtp::{
     identity::associations::{
         identity_action::Kind as IdentityActionKindProto,
@@ -294,135 +288,19 @@ impl From<UnverifiedSignature> for SignatureWrapperProto {
     }
 }
 
-// TODO:nm delete after usage removed
-pub fn from_identity_update_proto(
-    proto: IdentityUpdateProto,
-) -> Result<IdentityUpdate, DeserializationError> {
-    let client_timestamp_ns = proto.client_timestamp_ns;
-    let inbox_id = proto.inbox_id;
-    let all_actions = proto
-        .actions
-        .into_iter()
-        .map(|action| match action.kind {
-            Some(action) => Ok(action),
-            None => Err(DeserializationError::MissingAction),
-        })
-        .collect::<Result<Vec<IdentityActionKindProto>, DeserializationError>>()?;
+impl TryFrom<Vec<u8>> for UnverifiedIdentityUpdate {
+    type Error = DeserializationError;
 
-    let signature_text = get_signature_text(&all_actions, inbox_id.clone(), client_timestamp_ns)?;
-
-    let processed_actions: Vec<Action> = all_actions
-        .into_iter()
-        .map(|action| match action {
-            IdentityActionKindProto::Add(add_action) => {
-                Ok(Action::AddAssociation(AddAssociation {
-                    new_member_signature: from_signature_proto_option(
-                        add_action.new_member_signature,
-                        signature_text.clone(),
-                    )?,
-                    existing_member_signature: from_signature_proto_option(
-                        add_action.existing_member_signature,
-                        signature_text.clone(),
-                    )?,
-                    new_member_identifier: from_member_identifier_proto_option(
-                        add_action.new_member_identifier,
-                    )?,
-                }))
-            }
-            IdentityActionKindProto::CreateInbox(create_inbox_action) => {
-                Ok(Action::CreateInbox(CreateInbox {
-                    nonce: create_inbox_action.nonce,
-                    account_address: create_inbox_action.initial_address,
-                    initial_address_signature: from_signature_proto_option(
-                        create_inbox_action.initial_address_signature,
-                        signature_text.clone(),
-                    )?,
-                }))
-            }
-            IdentityActionKindProto::ChangeRecoveryAddress(change_recovery_address_action) => {
-                Ok(Action::ChangeRecoveryAddress(ChangeRecoveryAddress {
-                    new_recovery_address: change_recovery_address_action.new_recovery_address,
-                    recovery_address_signature: from_signature_proto_option(
-                        change_recovery_address_action.existing_recovery_address_signature,
-                        signature_text.clone(),
-                    )?,
-                }))
-            }
-            IdentityActionKindProto::Revoke(revoke_action) => {
-                Ok(Action::RevokeAssociation(RevokeAssociation {
-                    revoked_member: from_member_identifier_proto_option(
-                        revoke_action.member_to_revoke,
-                    )?,
-                    recovery_address_signature: from_signature_proto_option(
-                        revoke_action.recovery_address_signature,
-                        signature_text.clone(),
-                    )?,
-                }))
-            }
-        })
-        .collect::<Result<Vec<Action>, DeserializationError>>()?;
-
-    Ok(IdentityUpdate::new(
-        processed_actions,
-        inbox_id,
-        client_timestamp_ns,
-    ))
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        let update_proto: IdentityUpdateProto = IdentityUpdateProto::decode(value.as_slice())?;
+        UnverifiedIdentityUpdate::try_from(update_proto)
+    }
 }
 
-// TODO:nm delete
-fn get_signature_text(
-    actions: &[IdentityActionKindProto],
-    inbox_id: String,
-    client_timestamp_ns: u64,
-) -> Result<String, DeserializationError> {
-    let unsigned_actions: Vec<UnsignedAction> = actions
-        .iter()
-        .map(|action| match action {
-            IdentityActionKindProto::Add(add_action) => {
-                Ok(UnsignedAction::AddAssociation(UnsignedAddAssociation {
-                    new_member_identifier: from_member_identifier_proto_option(
-                        add_action.new_member_identifier.clone(),
-                    )?,
-                }))
-            }
-            IdentityActionKindProto::CreateInbox(create_inbox_action) => {
-                Ok(UnsignedAction::CreateInbox(UnsignedCreateInbox {
-                    nonce: create_inbox_action.nonce,
-                    account_address: create_inbox_action.initial_address.clone(),
-                }))
-            }
-            IdentityActionKindProto::ChangeRecoveryAddress(change_recovery_address_action) => Ok(
-                UnsignedAction::ChangeRecoveryAddress(UnsignedChangeRecoveryAddress {
-                    new_recovery_address: change_recovery_address_action
-                        .new_recovery_address
-                        .clone(),
-                }),
-            ),
-            IdentityActionKindProto::Revoke(revoke_action) => Ok(
-                UnsignedAction::RevokeAssociation(UnsignedRevokeAssociation {
-                    revoked_member: from_member_identifier_proto_option(
-                        revoke_action.member_to_revoke.clone(),
-                    )?,
-                }),
-            ),
-        })
-        .collect::<Result<Vec<UnsignedAction>, DeserializationError>>()?;
-
-    let unsigned_update =
-        UnsignedIdentityUpdate::new(unsigned_actions, inbox_id, client_timestamp_ns);
-
-    Ok(unsigned_update.signature_text())
-}
-
-fn from_member_identifier_proto_option(
-    proto: Option<MemberIdentifierProto>,
-) -> Result<MemberIdentifier, DeserializationError> {
-    match proto {
-        None => Err(DeserializationError::MissingMemberIdentifier),
-        Some(identifier_proto) => match identifier_proto.kind {
-            Some(identifier) => Ok(identifier.into()),
-            None => Err(DeserializationError::MissingMemberIdentifier),
-        },
+impl From<UnverifiedIdentityUpdate> for Vec<u8> {
+    fn from(value: UnverifiedIdentityUpdate) -> Self {
+        let proto: IdentityUpdateProto = value.into();
+        proto.encode_to_vec()
     }
 }
 
@@ -431,121 +309,6 @@ impl From<MemberIdentifierKindProto> for MemberIdentifier {
         match proto {
             MemberIdentifierKindProto::Address(address) => address.into(),
             MemberIdentifierKindProto::InstallationPublicKey(public_key) => public_key.into(),
-        }
-    }
-}
-
-// TODO:nm delete
-fn from_signature_proto_option(
-    proto: Option<SignatureWrapperProto>,
-    signature_text: String,
-) -> Result<Box<dyn Signature>, DeserializationError> {
-    match proto {
-        None => Err(DeserializationError::Signature),
-        Some(signature_proto) => match signature_proto.signature {
-            Some(signature) => Ok(from_signature_kind_proto(signature, signature_text)?),
-            None => Err(DeserializationError::Signature),
-        },
-    }
-}
-
-// TODO:nm delete
-fn from_signature_kind_proto(
-    proto: SignatureKindProto,
-    signature_text: String,
-) -> Result<Box<dyn Signature>, DeserializationError> {
-    Ok(match proto {
-        SignatureKindProto::InstallationKey(installation_key_signature) => {
-            Box::new(InstallationKeySignature::new(
-                signature_text,
-                installation_key_signature.bytes,
-                installation_key_signature.public_key,
-            ))
-        }
-        SignatureKindProto::Erc191(erc191_signature) => Box::new(RecoverableEcdsaSignature::new(
-            signature_text,
-            erc191_signature.bytes,
-        )),
-        SignatureKindProto::Erc6492(signature) => Box::new(SmartContractWalletSignature::new(
-            signature_text,
-            signature.signature,
-            signature.account_id.try_into()?,
-            signature.chain_rpc_url,
-            signature.block_number,
-        )),
-        SignatureKindProto::DelegatedErc191(delegated_erc191_signature) => {
-            let signature_value = delegated_erc191_signature
-                .signature
-                .ok_or(DeserializationError::Signature)?;
-            let recoverable_ecdsa_signature =
-                RecoverableEcdsaSignature::new(signature_text, signature_value.bytes);
-
-            Box::new(LegacyDelegatedSignature::new(
-                recoverable_ecdsa_signature,
-                delegated_erc191_signature
-                    .delegated_key
-                    .ok_or(DeserializationError::Signature)?,
-            ))
-        }
-    })
-}
-
-// TODO:nm delete
-impl From<IdentityUpdate> for IdentityUpdateProto {
-    fn from(update: IdentityUpdate) -> IdentityUpdateProto {
-        let actions: Vec<IdentityActionProto> =
-            update.actions.into_iter().map(Into::into).collect();
-
-        IdentityUpdateProto {
-            client_timestamp_ns: update.client_timestamp_ns,
-            inbox_id: update.inbox_id,
-            actions,
-        }
-    }
-}
-
-// TODO:nm delete
-impl From<Action> for IdentityActionProto {
-    fn from(action: Action) -> IdentityActionProto {
-        match action {
-            Action::AddAssociation(add_association) => IdentityActionProto {
-                kind: Some(IdentityActionKindProto::Add(AddAssociationProto {
-                    new_member_identifier: Some(add_association.new_member_identifier.into()),
-                    new_member_signature: Some(add_association.new_member_signature.to_proto()),
-                    existing_member_signature: Some(
-                        add_association.existing_member_signature.to_proto(),
-                    ),
-                })),
-            },
-            Action::CreateInbox(create_inbox) => IdentityActionProto {
-                kind: Some(IdentityActionKindProto::CreateInbox(CreateInboxProto {
-                    nonce: create_inbox.nonce,
-                    initial_address: create_inbox.account_address,
-                    initial_address_signature: Some(
-                        create_inbox.initial_address_signature.to_proto(),
-                    ),
-                })),
-            },
-            Action::RevokeAssociation(revoke_association) => IdentityActionProto {
-                kind: Some(IdentityActionKindProto::Revoke(RevokeAssociationProto {
-                    member_to_revoke: Some(revoke_association.revoked_member.into()),
-                    recovery_address_signature: Some(
-                        revoke_association.recovery_address_signature.to_proto(),
-                    ),
-                })),
-            },
-            Action::ChangeRecoveryAddress(change_recovery_address) => IdentityActionProto {
-                kind: Some(IdentityActionKindProto::ChangeRecoveryAddress(
-                    ChangeRecoveryAddressProto {
-                        new_recovery_address: change_recovery_address.new_recovery_address,
-                        existing_recovery_address_signature: Some(
-                            change_recovery_address
-                                .recovery_address_signature
-                                .to_proto(),
-                        ),
-                    },
-                )),
-            },
         }
     }
 }
@@ -699,9 +462,12 @@ impl TryFrom<LegacySignedPublicKeyProto> for ValidatedLegacySignedPublicKey {
                 signature
             }
         };
-        let wallet_signature = RecoverableSignature::Eip191Signature(wallet_signature);
-        let account_address =
-            wallet_signature.recover_address(&Self::text(&serialized_key_data))?;
+        let verified_wallet_signature = VerifiedSignature::from_recoverable_ecdsa(
+            Self::text(&serialized_key_data),
+            &wallet_signature,
+        )?;
+
+        let account_address = verified_wallet_signature.signer.to_string();
         let account_address = sanitize_evm_addresses(vec![account_address])?[0].clone();
 
         let legacy_unsigned_public_key_proto =
@@ -719,7 +485,7 @@ impl TryFrom<LegacySignedPublicKeyProto> for ValidatedLegacySignedPublicKey {
 
         Ok(Self {
             account_address,
-            wallet_signature,
+            wallet_signature: verified_wallet_signature,
             serialized_key_data,
             public_key_bytes,
             created_ns,
@@ -729,7 +495,7 @@ impl TryFrom<LegacySignedPublicKeyProto> for ValidatedLegacySignedPublicKey {
 
 impl From<ValidatedLegacySignedPublicKey> for LegacySignedPublicKeyProto {
     fn from(validated: ValidatedLegacySignedPublicKey) -> Self {
-        let RecoverableSignature::Eip191Signature(signature) = validated.wallet_signature;
+        let signature = validated.wallet_signature.raw_bytes;
         Self {
             key_bytes: validated.serialized_key_data,
             signature: Some(SignedPublicKeySignatureProto {
@@ -822,41 +588,6 @@ mod tests {
             .clone()
             .try_into()
             .expect("deserialization error");
-
-        let reserialized = IdentityUpdateProto::from(deserialized_update);
-
-        assert_eq!(serialized_update, reserialized);
-    }
-
-    #[test]
-    fn test_round_trip() {
-        let account_address = rand_string();
-        let nonce = rand_u64();
-        let inbox_id = generate_inbox_id(&account_address, &nonce);
-
-        let identity_update = IdentityUpdate::new(
-            vec![Action::CreateInbox(CreateInbox {
-                nonce,
-                account_address,
-                initial_address_signature: Box::new(RecoverableEcdsaSignature::new(
-                    "foo".to_string(),
-                    vec![1, 2, 3],
-                )),
-            })],
-            inbox_id,
-            rand_u64(),
-        );
-
-        let serialized_update = IdentityUpdateProto::from(identity_update.clone());
-
-        assert_eq!(
-            serialized_update.client_timestamp_ns,
-            identity_update.client_timestamp_ns
-        );
-        assert_eq!(serialized_update.actions.len(), 1);
-
-        let deserialized_update = from_identity_update_proto(serialized_update.clone())
-            .expect("deserialization should succeed");
 
         let reserialized = IdentityUpdateProto::from(deserialized_update);
 

--- a/xmtp_mls/src/api/identity.rs
+++ b/xmtp_mls/src/api/identity.rs
@@ -4,7 +4,7 @@ use super::{ApiClientWrapper, WrappedApiError};
 use crate::XmtpApi;
 use futures::future::try_join_all;
 use xmtp_id::{
-    associations::{DeserializationError, IdentityUpdate},
+    associations::{unverified::UnverifiedIdentityUpdate, DeserializationError},
     InboxId,
 };
 use xmtp_proto::xmtp::identity::api::v1::{
@@ -37,7 +37,7 @@ impl From<&GetIdentityUpdatesV2Filter> for GetIdentityUpdatesV2RequestProto {
 pub struct InboxUpdate {
     pub sequence_id: u64,
     pub server_timestamp_ns: u64,
-    pub update: IdentityUpdate,
+    pub update: UnverifiedIdentityUpdate,
 }
 
 impl TryFrom<IdentityUpdateLog> for InboxUpdate {
@@ -68,7 +68,7 @@ where
 {
     pub async fn publish_identity_update(
         &self,
-        update: IdentityUpdate,
+        update: UnverifiedIdentityUpdate,
     ) -> Result<(), WrappedApiError> {
         self.api_client
             .publish_identity_update(PublishIdentityUpdateRequest {
@@ -155,7 +155,7 @@ mod tests {
     use super::super::test_utils::*;
     use super::GetIdentityUpdatesV2Filter;
     use crate::{api::ApiClientWrapper, retry::Retry};
-    use xmtp_id::associations::{test_utils::rand_string, Action, CreateInbox, IdentityUpdate};
+    use xmtp_id::associations::{test_utils::rand_string, unverified::UnverifiedIdentityUpdate};
     use xmtp_proto::xmtp::identity::api::v1::{
         get_identity_updates_response::{
             IdentityUpdateLog, Response as GetIdentityUpdatesResponseItem,
@@ -164,8 +164,12 @@ mod tests {
         GetIdentityUpdatesResponse, GetInboxIdsResponse, PublishIdentityUpdateResponse,
     };
 
-    fn create_identity_update(inbox_id: String) -> IdentityUpdate {
-        IdentityUpdate::new_test(vec![Action::CreateInbox(CreateInbox::default())], inbox_id)
+    fn create_identity_update(inbox_id: String) -> UnverifiedIdentityUpdate {
+        UnverifiedIdentityUpdate::new_test(
+            // TODO:nm Add default actions
+            vec![],
+            inbox_id,
+        )
     }
 
     #[tokio::test]
@@ -202,7 +206,7 @@ mod tests {
                         updates: vec![IdentityUpdateLog {
                             sequence_id: 1,
                             server_timestamp_ns: 1,
-                            update: Some(identity_update.to_proto()),
+                            update: Some(identity_update.into()),
                         }],
                     }],
                 })

--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -2,6 +2,7 @@ use log::debug;
 use thiserror::Error;
 
 use xmtp_cryptography::signature::AddressValidationError;
+use xmtp_id::scw_verifier::{RpcSmartContractWalletVerifier, SmartContractSignatureVerifier};
 
 use crate::{
     api::ApiClientWrapper,
@@ -51,6 +52,7 @@ pub struct ClientBuilder<ApiClient> {
     identity_strategy: IdentityStrategy,
     history_sync_url: Option<String>,
     app_version: Option<String>,
+    scw_verifier: Option<Box<dyn SmartContractSignatureVerifier>>,
 }
 
 impl<ApiClient> ClientBuilder<ApiClient>
@@ -65,6 +67,7 @@ where
             identity_strategy: strategy,
             history_sync_url: None,
             app_version: None,
+            scw_verifier: None,
         }
     }
 
@@ -93,6 +96,11 @@ where
         self
     }
 
+    pub fn scw_signatuer_verifier(mut self, verifier: impl SmartContractSignatureVerifier) -> Self {
+        self.scw_verifier = Some(Box::new(verifier));
+        self
+    }
+
     pub async fn build(mut self) -> Result<Client<ApiClient>, ClientBuilderError> {
         debug!("Building client");
         let mut api_client =
@@ -106,6 +114,13 @@ where
             api_client.set_app_version(app_version)?;
         }
 
+        let scw_verifier = self.scw_verifier.take().unwrap_or_else(|| {
+            // TODO:nm Enforce that everyone provides this
+            Box::new(RpcSmartContractWalletVerifier::new(
+                "https://fixme.com".to_string(),
+            ))
+        });
+
         let api_client_wrapper = ApiClientWrapper::new(api_client, Retry::default());
         let store = self
             .store
@@ -114,7 +129,7 @@ where
         debug!("Initializing identity");
         let identity = self
             .identity_strategy
-            .initialize_identity(&api_client_wrapper, &store)
+            .initialize_identity(&api_client_wrapper, &store, scw_verifier.as_ref())
             .await?;
 
         // get sequence_id from identity updates and loaded into the DB
@@ -147,10 +162,12 @@ mod tests {
     use openmls_traits::types::SignatureScheme;
     use prost::Message;
     use xmtp_cryptography::utils::{generate_local_wallet, rng};
-    use xmtp_id::associations::ValidatedLegacySignedPublicKey;
-    use xmtp_id::associations::{
-        generate_inbox_id, test_utils::rand_u64, RecoverableEcdsaSignature,
+    use xmtp_id::associations::test_utils::MockSmartContractSignatureVerifier;
+    use xmtp_id::associations::unverified::{
+        UnverifiedRecoverableEcdsaSignature, UnverifiedSignature,
     };
+    use xmtp_id::associations::ValidatedLegacySignedPublicKey;
+    use xmtp_id::associations::{generate_inbox_id, test_utils::rand_u64};
     use xmtp_proto::xmtp::identity::api::v1::{
         get_inbox_ids_response::Response as GetInboxIdsResponseItem, GetInboxIdsResponse,
     };
@@ -171,11 +188,14 @@ mod tests {
     async fn register_client<T: XmtpApi>(client: &Client<T>, owner: &impl InboxOwner) {
         let mut signature_request = client.context.signature_request().unwrap();
         let signature_text = signature_request.signature_text();
+        let scw_verifier = MockSmartContractSignatureVerifier::new(true);
         signature_request
-            .add_signature(Box::new(RecoverableEcdsaSignature::new(
-                signature_text.clone(),
-                owner.sign(&signature_text).unwrap().into(),
-            )))
+            .add_signature(
+                UnverifiedSignature::RecoverableEcdsa(UnverifiedRecoverableEcdsaSignature::new(
+                    owner.sign(&signature_text).unwrap().into(),
+                )),
+                &scw_verifier,
+            )
             .await
             .unwrap();
 
@@ -413,6 +433,7 @@ mod tests {
     async fn api_identity_mismatch() {
         let mut mock_api = MockApiClient::new();
         let tmpdb = tmp_path();
+        let scw_verifier = MockSmartContractSignatureVerifier::new(true);
 
         let store =
             EncryptedMessageStore::new_unencrypted(StorageOption::Persistent(tmpdb)).unwrap();
@@ -437,7 +458,7 @@ mod tests {
             IdentityStrategy::CreateIfNotFound("other_inbox_id".to_string(), address, nonce, None);
         assert!(matches!(
             identity
-                .initialize_identity(&wrapper, &store)
+                .initialize_identity(&wrapper, &store, &scw_verifier)
                 .await
                 .unwrap_err(),
             IdentityError::NewIdentity(msg) if msg == "Inbox ID mismatch"
@@ -449,6 +470,7 @@ mod tests {
     async fn api_identity_happy_path() {
         let mut mock_api = MockApiClient::new();
         let tmpdb = tmp_path();
+        let scw_verifier = MockSmartContractSignatureVerifier::new(true);
 
         let store =
             EncryptedMessageStore::new_unencrypted(StorageOption::Persistent(tmpdb)).unwrap();
@@ -470,7 +492,12 @@ mod tests {
         let wrapper = ApiClientWrapper::new(mock_api, Retry::default());
 
         let identity = IdentityStrategy::CreateIfNotFound(inbox_id.clone(), address, nonce, None);
-        assert!(dbg!(identity.initialize_identity(&wrapper, &store).await).is_ok());
+        assert!(dbg!(
+            identity
+                .initialize_identity(&wrapper, &store, &scw_verifier)
+                .await
+        )
+        .is_ok());
     }
 
     // Use a stored identity as long as the inbox_id matches the one provided.
@@ -478,6 +505,7 @@ mod tests {
     async fn stored_identity_happy_path() {
         let mock_api = MockApiClient::new();
         let tmpdb = tmp_path();
+        let scw_verifier = MockSmartContractSignatureVerifier::new(true);
 
         let store =
             EncryptedMessageStore::new_unencrypted(StorageOption::Persistent(tmpdb)).unwrap();
@@ -497,12 +525,16 @@ mod tests {
         stored.store(&store.conn().unwrap()).unwrap();
         let wrapper = ApiClientWrapper::new(mock_api, Retry::default());
         let identity = IdentityStrategy::CreateIfNotFound(inbox_id.clone(), address, nonce, None);
-        assert!(identity.initialize_identity(&wrapper, &store).await.is_ok());
+        assert!(identity
+            .initialize_identity(&wrapper, &store, &scw_verifier)
+            .await
+            .is_ok());
     }
 
     #[tokio::test]
     async fn stored_identity_mismatch() {
         let mock_api = MockApiClient::new();
+        let scw_verifier = MockSmartContractSignatureVerifier::new(true);
 
         let nonce = 0;
         let address = generate_local_wallet().get_address();
@@ -529,7 +561,7 @@ mod tests {
         let identity =
             IdentityStrategy::CreateIfNotFound(inbox_id.clone(), address.clone(), nonce, None);
         let err = identity
-            .initialize_identity(&wrapper, &store)
+            .initialize_identity(&wrapper, &store, &scw_verifier)
             .await
             .unwrap_err();
 

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -27,8 +27,9 @@ use xmtp_cryptography::signature::{sanitize_evm_addresses, AddressValidationErro
 use xmtp_id::{
     associations::{
         builder::{SignatureRequest, SignatureRequestError},
-        AssociationError, AssociationState,
+        AssociationError, AssociationState, SignatureError,
     },
+    scw_verifier::{RpcSmartContractWalletVerifier, SmartContractSignatureVerifier},
     InboxId,
 };
 
@@ -96,6 +97,8 @@ pub enum ClientError {
     StreamInconsistency(String),
     #[error("Association error: {0}")]
     Association(#[from] AssociationError),
+    #[error("signature validation error: {0}")]
+    SignatureValidation(#[from] SignatureError),
     #[error(transparent)]
     IdentityUpdate(#[from] IdentityUpdateError),
     #[error(transparent)]
@@ -357,6 +360,12 @@ where
 
     pub fn context(&self) -> &Arc<XmtpMlsLocalContext> {
         &self.context
+    }
+
+    // TODO:nm Replace with real implementation
+    pub fn smart_contract_signature_verifier(&self) -> Box<dyn SmartContractSignatureVerifier> {
+        let scw_verifier = RpcSmartContractWalletVerifier::new("http://www.fake.com".to_string());
+        Box::new(scw_verifier)
     }
 
     /// Create a new group with the default settings
@@ -1002,7 +1011,7 @@ mod tests {
         let mut bola_messages = bola_group
             .find_messages(None, None, None, None, None)
             .unwrap();
-        // TODO:nm figure out why the transcript message is no longer decryptable
+
         assert_eq!(bola_messages.len(), 1);
 
         // Add Bola back to the group

--- a/xmtp_mls/src/groups/sync.rs
+++ b/xmtp_mls/src/groups/sync.rs
@@ -701,7 +701,7 @@ impl MlsGroup {
         );
         let sender_installation_id = validated_commit.actor_installation_id();
         let sender_inbox_id = validated_commit.actor_inbox_id();
-        // TODO:nm replace with new membership change codec
+
         let payload: GroupUpdated = validated_commit.into();
         let encoded_payload = GroupUpdatedCodec::encode(payload)?;
         let mut encoded_payload_bytes = Vec::new();

--- a/xmtp_mls/src/identity_updates.rs
+++ b/xmtp_mls/src/identity_updates.rs
@@ -5,13 +5,20 @@ use crate::{
     retry_async, retryable,
     storage::association_state::StoredAssociationState,
 };
-use prost::Message;
+use futures::future::try_join_all;
 use thiserror::Error;
-use xmtp_id::associations::{
-    apply_update,
-    builder::{SignatureRequest, SignatureRequestBuilder, SignatureRequestError},
-    generate_inbox_id, get_state, AssociationError, AssociationState, AssociationStateDiff,
-    IdentityUpdate, InstallationKeySignature, MemberIdentifier,
+use xmtp_id::{
+    associations::{
+        apply_update,
+        builder::{SignatureRequest, SignatureRequestBuilder, SignatureRequestError},
+        generate_inbox_id, get_state,
+        unverified::{
+            UnverifiedIdentityUpdate, UnverifiedInstallationKeySignature, UnverifiedSignature,
+        },
+        AssociationError, AssociationState, AssociationStateDiff, IdentityUpdate, MemberIdentifier,
+        SignatureError,
+    },
+    scw_verifier::SmartContractSignatureVerifier,
 };
 
 use crate::{
@@ -116,11 +123,17 @@ where
             return Ok(association_state);
         }
 
-        let updates = updates
+        let unverified_updates = updates
             .into_iter()
-            .map(IdentityUpdate::try_from)
-            .collect::<Result<Vec<IdentityUpdate>, AssociationError>>()?;
-        let association_state = get_state(updates).await?;
+            .map(UnverifiedIdentityUpdate::try_from)
+            .collect::<Result<Vec<UnverifiedIdentityUpdate>, AssociationError>>()?;
+        let updates = verify_updates(
+            unverified_updates,
+            self.smart_contract_signature_verifier().as_ref(),
+        )
+        .await?;
+
+        let association_state = get_state(updates)?;
 
         StoredAssociationState::write_to_cache(
             conn,
@@ -172,14 +185,19 @@ where
             return Err(AssociationError::MissingIdentityUpdate.into());
         }
 
-        let incremental_updates = incremental_updates
+        let unverified_incremental_updates: Vec<UnverifiedIdentityUpdate> = incremental_updates
             .into_iter()
             .map(|update| update.try_into())
-            .collect::<Result<Vec<IdentityUpdate>, AssociationError>>()?;
+            .collect::<Result<Vec<UnverifiedIdentityUpdate>, AssociationError>>()?;
 
+        let incremental_updates = verify_updates(
+            unverified_incremental_updates,
+            self.smart_contract_signature_verifier().as_ref(),
+        )
+        .await?;
         let mut final_state = initial_state.clone();
         for update in incremental_updates {
-            final_state = apply_update(final_state, update).await?;
+            final_state = apply_update(final_state, update)?;
         }
 
         log::debug!("Final state at {:?}: {:?}", last_sequence_id, final_state);
@@ -211,14 +229,19 @@ where
             .add_association(installation_public_key.to_vec().into(), member_identifier)
             .build();
 
+        let sig_bytes = self
+            .identity()
+            .sign(signature_request.signature_text())?
+            .to_vec();
         // We can pre-sign the request with an installation key signature, since we have access to the key
         signature_request
-            .add_signature(Box::new(InstallationKeySignature::new(
-                signature_request.signature_text(),
-                // TODO: Move this to a method on the new identity
-                self.identity().sign(signature_request.signature_text())?,
-                self.installation_public_key(),
-            )))
+            .add_signature(
+                UnverifiedSignature::InstallationKey(UnverifiedInstallationKeySignature::new(
+                    sig_bytes,
+                    installation_public_key.to_vec(),
+                )),
+                self.smart_contract_signature_verifier().as_ref(),
+            )
             .await?;
 
         Ok(signature_request)
@@ -434,7 +457,7 @@ pub async fn load_identity_updates<ApiClient: XmtpApi>(
                 inbox_id: inbox_id.clone(),
                 sequence_id: update.sequence_id as i64,
                 server_timestamp_ns: update.server_timestamp_ns as i64,
-                payload: update.update.to_proto().encode_to_vec(),
+                payload: update.update.into(),
             })
         })
         .collect::<Vec<StoredIdentityUpdate>>();
@@ -443,12 +466,26 @@ pub async fn load_identity_updates<ApiClient: XmtpApi>(
     Ok(updates)
 }
 
+async fn verify_updates(
+    updates: Vec<UnverifiedIdentityUpdate>,
+    scw_verifier: &dyn SmartContractSignatureVerifier,
+) -> Result<Vec<IdentityUpdate>, SignatureError> {
+    try_join_all(
+        updates
+            .iter()
+            .map(|update| async { update.to_verified(scw_verifier).await }),
+    )
+    .await
+}
+
 #[cfg(test)]
 pub(crate) mod tests {
     use tracing_test::traced_test;
     use xmtp_cryptography::utils::generate_local_wallet;
     use xmtp_id::{
-        associations::{builder::SignatureRequest, AssociationState, RecoverableEcdsaSignature},
+        associations::{
+            builder::SignatureRequest, test_utils::add_wallet_signature, AssociationState,
+        },
         InboxOwner,
     };
 
@@ -462,24 +499,6 @@ pub(crate) mod tests {
     };
 
     use super::load_identity_updates;
-
-    pub(crate) async fn sign_with_wallet(
-        wallet: &impl InboxOwner,
-        signature_request: &mut SignatureRequest,
-    ) {
-        let wallet_signature: Vec<u8> = wallet
-            .sign(signature_request.signature_text().as_str())
-            .unwrap()
-            .into();
-
-        signature_request
-            .add_signature(Box::new(RecoverableEcdsaSignature::new(
-                signature_request.signature_text(),
-                wallet_signature,
-            )))
-            .await
-            .unwrap();
-    }
 
     async fn get_association_state<ApiClient>(
         client: &Client<ApiClient>,
@@ -519,7 +538,7 @@ pub(crate) mod tests {
             .unwrap();
         let inbox_id = signature_request.inbox_id();
 
-        sign_with_wallet(&wallet, &mut signature_request).await;
+        add_wallet_signature(&mut signature_request, &wallet).await;
 
         client
             .apply_signature_request(signature_request)
@@ -545,8 +564,8 @@ pub(crate) mod tests {
             .associate_wallet(wallet_address.clone(), wallet_2_address.clone())
             .unwrap();
 
-        sign_with_wallet(&wallet, &mut add_association_request).await;
-        sign_with_wallet(&wallet_2, &mut add_association_request).await;
+        add_wallet_signature(&mut add_association_request, &wallet).await;
+        add_wallet_signature(&mut add_association_request, &wallet_2).await;
 
         client
             .apply_signature_request(add_association_request)
@@ -590,8 +609,8 @@ pub(crate) mod tests {
             .associate_wallet(wallet_address.clone(), wallet_2_address.clone())
             .unwrap();
 
-        sign_with_wallet(&wallet, &mut add_association_request).await;
-        sign_with_wallet(&wallet_2, &mut add_association_request).await;
+        add_wallet_signature(&mut add_association_request, &wallet).await;
+        add_wallet_signature(&mut add_association_request, &wallet_2).await;
 
         client
             .apply_signature_request(add_association_request)
@@ -658,7 +677,7 @@ pub(crate) mod tests {
             let inbox_id = signature_request.inbox_id();
             inbox_ids.push(inbox_id.clone());
 
-            sign_with_wallet(&wallet, &mut signature_request).await;
+            add_wallet_signature(&mut signature_request, &wallet).await;
             client
                 .apply_signature_request(signature_request)
                 .await
@@ -668,8 +687,8 @@ pub(crate) mod tests {
                 .associate_wallet(wallet.get_address(), new_wallet.get_address())
                 .unwrap();
 
-            sign_with_wallet(&wallet, &mut add_association_request).await;
-            sign_with_wallet(&new_wallet, &mut add_association_request).await;
+            add_wallet_signature(&mut add_association_request, &wallet).await;
+            add_wallet_signature(&mut add_association_request, &new_wallet).await;
 
             client
                 .apply_signature_request(add_association_request)
@@ -748,8 +767,8 @@ pub(crate) mod tests {
             .associate_wallet(recovery_wallet.get_address(), second_wallet.get_address())
             .unwrap();
 
-        sign_with_wallet(&recovery_wallet, &mut add_wallet_signature_request).await;
-        sign_with_wallet(&second_wallet, &mut add_wallet_signature_request).await;
+        add_wallet_signature(&mut add_wallet_signature_request, &recovery_wallet).await;
+        add_wallet_signature(&mut add_wallet_signature_request, &second_wallet).await;
 
         client
             .apply_signature_request(add_wallet_signature_request)
@@ -773,7 +792,8 @@ pub(crate) mod tests {
             .revoke_wallets(vec![second_wallet.get_address()])
             .await
             .unwrap();
-        sign_with_wallet(&recovery_wallet, &mut revoke_signature_request).await;
+        add_wallet_signature(&mut revoke_signature_request, &recovery_wallet).await;
+
         client
             .apply_signature_request(revoke_signature_request)
             .await
@@ -808,7 +828,7 @@ pub(crate) mod tests {
             .revoke_installations(vec![client2.installation_public_key()])
             .await
             .unwrap();
-        sign_with_wallet(&wallet, &mut revoke_installation_request).await;
+        add_wallet_signature(&mut revoke_installation_request, &wallet).await;
         client1
             .apply_signature_request(revoke_installation_request)
             .await

--- a/xmtp_mls/src/storage/encrypted_store/identity_update.rs
+++ b/xmtp_mls/src/storage/encrypted_store/identity_update.rs
@@ -7,7 +7,7 @@ use super::{
     schema::identity_updates::{self, dsl},
 };
 use diesel::{dsl::max, prelude::*};
-use xmtp_id::associations::{AssociationError, IdentityUpdate};
+use xmtp_id::associations::{unverified::UnverifiedIdentityUpdate, AssociationError};
 
 /// StoredIdentityUpdate holds a serialized IdentityUpdate record
 #[derive(Insertable, Identifiable, Queryable, Debug, Clone, PartialEq, Eq)]
@@ -36,11 +36,11 @@ impl StoredIdentityUpdate {
     }
 }
 
-impl TryFrom<StoredIdentityUpdate> for IdentityUpdate {
+impl TryFrom<StoredIdentityUpdate> for UnverifiedIdentityUpdate {
     type Error = AssociationError;
 
     fn try_from(update: StoredIdentityUpdate) -> Result<Self, Self::Error> {
-        Ok(IdentityUpdate::try_from(update.payload)?)
+        Ok(UnverifiedIdentityUpdate::try_from(update.payload)?)
     }
 }
 

--- a/xmtp_mls/src/utils/test.rs
+++ b/xmtp_mls/src/utils/test.rs
@@ -8,7 +8,11 @@ use rand::{
 use std::sync::Arc;
 use tokio::{sync::Notify, time::error::Elapsed};
 use xmtp_api_grpc::grpc_api_helper::Client as GrpcClient;
-use xmtp_id::associations::{generate_inbox_id, RecoverableEcdsaSignature};
+use xmtp_id::associations::{
+    generate_inbox_id,
+    test_utils::MockSmartContractSignatureVerifier,
+    unverified::{UnverifiedRecoverableEcdsaSignature, UnverifiedSignature},
+};
 
 use crate::{
     builder::ClientBuilder,
@@ -98,6 +102,7 @@ impl ClientBuilder<TestClient> {
             nonce,
             None,
         ))
+        .scw_signatuer_verifier(MockSmartContractSignatureVerifier::new(true))
         .temp_store()
         .local_client()
         .await
@@ -172,11 +177,14 @@ impl Client<TestClient> {
 pub async fn register_client<T: XmtpApi>(client: &Client<T>, owner: &impl InboxOwner) {
     let mut signature_request = client.context.signature_request().unwrap();
     let signature_text = signature_request.signature_text();
+    let unverified_signature = UnverifiedSignature::RecoverableEcdsa(
+        UnverifiedRecoverableEcdsaSignature::new(owner.sign(&signature_text).unwrap().into()),
+    );
     signature_request
-        .add_signature(Box::new(RecoverableEcdsaSignature::new(
-            signature_text.clone(),
-            owner.sign(&signature_text).unwrap().into(),
-        )))
+        .add_signature(
+            unverified_signature,
+            client.smart_contract_signature_verifier().as_ref(),
+        )
         .await
         .unwrap();
 


### PR DESCRIPTION
## tl;dr

- https://github.com/xmtp/libxmtp/issues/1033
- Replaces the signatures in `IdentityUpdate` struct to use the new `VerifiedSignature`
- For clients that want to control signature verification, we will need a `MultiChainSmartContractWalletVerifier` that uses different RPC endpoints for each supported `chain_id`
- We can probably refactor the `SignatureRequest` to contain a reference to the verifier, so that it doesn't have to be passed in as part of `add_signature` in the bindings.

## Does this mean SCW signatures work

Not yet. There are still some big TODO items in here, which will cause smart contract wallet signature verification to fail (which it also is in `main`). We don't really want to use the `RpcSmartContractWalletVerifier` in normal clients. Instead we will call a (still unbuilt) RPC method to verify these signatures remotely. 