### PR TITLE
Update node bindings

### DIFF
--- a/bindings_node/CHANGELOG.md
+++ b/bindings_node/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @xmtp/mls-client-bindings-node
 
+## 0.0.11
+
+- Added `inbox_state` to client
+- Skip duplicate message processing when streaming
+
 ## 0.0.10
 
 - Fixed several group syncing issues

--- a/bindings_node/package.json
+++ b/bindings_node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/mls-client-bindings-node",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "repository": {
     "type": "git",
     "url": "git+https://git@github.com/xmtp/libxmtp.git",

--- a/bindings_node/src/conversations.rs
+++ b/bindings_node/src/conversations.rs
@@ -20,6 +20,7 @@ pub struct NapiListConversationsOptions {
 }
 
 #[napi(object)]
+#[derive(Clone)]
 pub struct NapiCreateGroupOptions {
   pub permissions: Option<NapiGroupPermissionsOptions>,
   pub group_name: Option<String>,
@@ -77,16 +78,21 @@ impl NapiConversations {
       _ => None,
     };
 
-    let convo = self
-      .inner_client
-      .create_group(group_permissions, options.into_group_metadata_options())
-      .map_err(|e| Error::from_reason(format!("ClientError: {}", e)))?;
-    if !account_addresses.is_empty() {
-      convo
-        .add_members(&self.inner_client, account_addresses)
+    let metadata_options = options.clone().into_group_metadata_options();
+
+    let convo = if account_addresses.is_empty() {
+      self
+        .inner_client
+        .create_group(group_permissions, metadata_options)
+        .map_err(|e| Error::from_reason(format!("ClientError: {}", e)))?
+    } else {
+      self
+        .inner_client
+        .create_group_with_members(account_addresses, group_permissions, metadata_options)
         .await
-        .map_err(|e| Error::from_reason(format!("GroupError: {}", e)))?;
-    }
+        .map_err(|e| Error::from_reason(format!("ClientError: {}", e)))?
+    };
+
     let out = NapiGroup::new(
       self.inner_client.clone(),
       convo.group_id,

--- a/bindings_node/test/Client.test.ts
+++ b/bindings_node/test/Client.test.ts
@@ -31,4 +31,16 @@ describe('Client', () => {
     const inboxId = await client.findInboxIdByAddress(user.account.address)
     expect(inboxId).toBe(client.inboxId())
   })
+
+  it('should return the correct inbox state', async () => {
+    const user = createUser()
+    const client = await createRegisteredClient(user)
+    const inboxState = await client.inboxState(false)
+    expect(inboxState.inboxId).toBe(client.inboxId())
+    expect(inboxState.installationIds).toEqual([client.installationId()])
+    expect(inboxState.accountAddresses).toEqual([
+      user.account.address.toLowerCase(),
+    ])
+    expect(inboxState.recoveryAddress).toBe(user.account.address.toLowerCase())
+  })
 })


### PR DESCRIPTION
# Summary

* Added `inbox_state` to client
* Refactored `create_group` to use `create_group_with_members`
* Updated node bindings version and CHANGELOG

### Notes

This update does not provide client methods for adding/removing wallets or revoking installations. This functionality will be provided in a followup PR.