### PR TITLE
Add curl to dockerfile

### DIFF
--- a/dev/validation_service/Dockerfile
+++ b/dev/validation_service/Dockerfile
@@ -4,7 +4,7 @@ COPY . .
 RUN cargo build --release --package mls_validation_service
 
 FROM debian:bullseye-slim
-RUN apt-get update && apt-get install -y sqlite3
+RUN apt-get update && apt-get install -y sqlite3 curl
 COPY --from=builder /code/target/release/mls-validation-service /usr/local/bin/mls-validation-service
 ENV RUST_LOG=info
 CMD ["mls-validation-service"]


### PR DESCRIPTION
## tl;dr

I would like to use [Container Health Checks](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/healthcheck.html) for the replication testnet so that I can deploy this service without a load balancer using Service Discovery.

The easiest way to do that is to add curl and ping the `/health` endpoint from within the container