### PR TITLE
Allocate sql queries in wasm memory space

### DIFF
--- a/diesel-wasm-sqlite/src/ffi.rs
+++ b/diesel-wasm-sqlite/src/ffi.rs
@@ -296,7 +296,7 @@ extern "C" {
     pub fn prepare_v3(
         this: &SQLite,
         database: &JsValue,
-        sql: &str,
+        sql: *mut u8,
         n_byte: i32,
         prep_flags: u32,
         stmt: &JsValue,


### PR DESCRIPTION
Skip an extra copy per query in JS space by allocating directly in wasm memory space.

Handles #1027 