### PR TITLE
Add message-history feature to xmtp_mls

### DIFF
--- a/bindings_ffi/Cargo.toml
+++ b/bindings_ffi/Cargo.toml
@@ -17,7 +17,7 @@ uniffi = { version = "0.28.0", features = ["tokio", "cli"] }
 xmtp_api_grpc = { path = "../xmtp_api_grpc" }
 xmtp_cryptography = { path = "../xmtp_cryptography" }
 xmtp_id = { path = "../xmtp_id" }
-xmtp_mls = { path = "../xmtp_mls", features = ["native"] }
+xmtp_mls = { path = "../xmtp_mls", features = ["native", "message-history"] }
 xmtp_proto = { path = "../xmtp_proto", features = ["proto_full"] }
 xmtp_user_preferences = { path = "../xmtp_user_preferences" }
 xmtp_v2 = { path = "../xmtp_v2" }

--- a/bindings_node/Cargo.toml
+++ b/bindings_node/Cargo.toml
@@ -24,7 +24,7 @@ tonic = { version = "^0.12", features = ["tls"] }
 xmtp_api_grpc = { path = "../xmtp_api_grpc" }
 xmtp_cryptography = { path = "../xmtp_cryptography" }
 xmtp_id = { path = "../xmtp_id" }
-xmtp_mls = { path = "../xmtp_mls", features = ["native"] }
+xmtp_mls = { path = "../xmtp_mls", features = ["native", "message-history"] }
 xmtp_proto = { path = "../xmtp_proto", features = ["proto_full"] }
 
 [build-dependencies]

--- a/bindings_wasm/Cargo.toml
+++ b/bindings_wasm/Cargo.toml
@@ -15,7 +15,7 @@ wasm-bindgen-futures = "0.4.41"
 xmtp_api_http = { path = "../xmtp_api_http" }
 xmtp_cryptography = { path = "../xmtp_cryptography" }
 xmtp_id = { path = "../xmtp_id" }
-xmtp_mls = { path = "../xmtp_mls", features = [] }
+xmtp_mls = { path = "../xmtp_mls", features = ["message-history"] }
 xmtp_proto = { path = "../xmtp_proto", features = ["proto_full"] }
 
 [dev-dependencies]

--- a/examples/cli/Cargo.toml
+++ b/examples/cli/Cargo.toml
@@ -32,5 +32,5 @@ tokio = "1.28.1"
 xmtp_api_grpc = { path = "../../xmtp_api_grpc" }
 xmtp_cryptography = { path = "../../xmtp_cryptography" }
 xmtp_id = { path = "../../xmtp_id" }
-xmtp_mls = { path = "../../xmtp_mls", features = ["native"] }
+xmtp_mls = { path = "../../xmtp_mls", features = ["native", "message-history"] }
 xmtp_proto = { path = "../../xmtp_proto", features = ["proto_full"] }

--- a/xmtp_mls/Cargo.toml
+++ b/xmtp_mls/Cargo.toml
@@ -20,13 +20,13 @@ bench = [
 ]
 default = ["native"]
 http-api = ["xmtp_api_http"]
+message-history = []
 native = ["libsqlite3-sys/bundled-sqlcipher-vendored-openssl", "xmtp_api_grpc"]
 test-utils = ["xmtp_id/test-utils"]
 
 [dependencies]
 aes-gcm = { version = "0.10.3", features = ["std"] }
 async-stream.workspace = true
-trait-variant.workspace = true
 bincode = "1.3.3"
 diesel = { version = "2.2.2", features = [
     "sqlite",
@@ -60,6 +60,7 @@ tokio = { workspace = true, features = [
 tokio-stream = { version = "0.1", features = ["sync"] }
 toml = "0.8.4"
 tracing.workspace = true
+trait-variant.workspace = true
 xmtp_cryptography = { workspace = true }
 xmtp_id = { path = "../xmtp_id" }
 xmtp_proto = { workspace = true, features = ["proto_full", "convert"] }
@@ -78,6 +79,7 @@ anyhow.workspace = true
 async-barrier = "1.1"
 criterion = { version = "0.5", features = ["html_reports", "async_tokio"] }
 ctor.workspace = true
+ethers.workspace = true
 mockall = "0.13.0"
 mockito = "1.4.0"
 tempfile = "3.5.0"
@@ -87,7 +89,6 @@ tracing-test = "0.2.4"
 tracing.workspace = true
 xmtp_api_grpc = { path = "../xmtp_api_grpc" }
 xmtp_id = { path = "../xmtp_id", features = ["test-utils"] }
-ethers.workspace = true
 
 [[bench]]
 harness = false

--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -140,7 +140,11 @@ where
         )
         .await?;
 
+        #[cfg(feature = "message-history")]
         let client = Client::new(api_client_wrapper, identity, store, self.history_sync_url);
+
+        #[cfg(not(feature = "message-history"))]
+        let client = Client::new(api_client_wrapper, identity, store);
 
         Ok(client)
     }

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -223,6 +223,7 @@ impl From<&str> for ClientError {
 pub struct Client<ApiClient> {
     pub(crate) api_client: ApiClientWrapper<ApiClient>,
     pub(crate) context: Arc<XmtpMlsLocalContext>,
+    #[cfg(feature = "message-history")]
     pub(crate) history_sync_url: Option<String>,
     pub(crate) local_events: broadcast::Sender<LocalEvents>,
 }
@@ -278,7 +279,7 @@ where
         api_client: ApiClientWrapper<ApiClient>,
         identity: Identity,
         store: EncryptedMessageStore,
-        history_sync_url: Option<String>,
+        #[cfg(feature = "message-history")] history_sync_url: Option<String>,
     ) -> Self {
         let context = XmtpMlsLocalContext {
             identity,
@@ -289,6 +290,7 @@ where
         Self {
             api_client,
             context: Arc::new(context),
+            #[cfg(feature = "message-history")]
             history_sync_url,
             local_events: tx,
         }
@@ -465,6 +467,7 @@ where
         Ok(group)
     }
 
+    #[cfg(feature = "message-history")]
     pub(crate) fn create_sync_group(&self) -> Result<MlsGroup, ClientError> {
         log::info!("creating sync group");
         let sync_group = MlsGroup::create_and_insert_sync_group(self.context.clone())?;

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -5,6 +5,7 @@ pub mod group_permissions;
 pub mod intents;
 pub mod members;
 #[allow(dead_code)]
+#[cfg(feature = "message-history")]
 pub mod message_history;
 mod subscriptions;
 mod sync;
@@ -35,6 +36,8 @@ use tokio::sync::Mutex;
 
 pub use self::group_permissions::PreconfiguredPolicies;
 pub use self::intents::{AddressesOrInstallationIds, IntentError};
+#[cfg(feature = "message-history")]
+use self::message_history::MessageHistoryError;
 use self::{
     group_membership::GroupMembership,
     group_metadata::extract_group_metadata,
@@ -51,7 +54,6 @@ use self::{
 use self::{
     group_metadata::{ConversationType, GroupMetadata, GroupMetadataError},
     group_permissions::PolicySet,
-    message_history::MessageHistoryError,
     validated_commit::CommitValidationError,
 };
 use std::{collections::HashSet, sync::Arc};
@@ -169,6 +171,7 @@ pub enum GroupError {
     CredentialError(#[from] BasicCredentialError),
     #[error("LeafNode error")]
     LeafNodeError(#[from] LibraryError),
+    #[cfg(feature = "message-history")]
     #[error("Message History error: {0}")]
     MessageHistory(#[from] Box<MessageHistoryError>),
     #[error("Installation diff error: {0}")]
@@ -405,6 +408,7 @@ impl MlsGroup {
         Self::create_from_welcome(client, provider, welcome, inbox_id, welcome_id).await
     }
 
+    #[cfg(feature = "message-history")]
     pub(crate) fn create_and_insert_sync_group(
         context: Arc<XmtpMlsLocalContext>,
     ) -> Result<MlsGroup, GroupError> {

--- a/xmtp_mls/src/groups/sync.rs
+++ b/xmtp_mls/src/groups/sync.rs
@@ -13,6 +13,8 @@ use super::{
     validated_commit::extract_group_membership,
     GroupError, MlsGroup,
 };
+#[cfg(feature = "message-history")]
+use crate::groups::message_history::MessageHistoryContent;
 use crate::{
     client::MessageProcessingError,
     codecs::{group_updated::GroupUpdatedCodec, ContentCodec},
@@ -20,10 +22,7 @@ use crate::{
         GRPC_DATA_LIMIT, MAX_GROUP_SIZE, MAX_INTENT_PUBLISH_ATTEMPTS, MAX_PAST_EPOCHS,
         SYNC_UPDATE_INSTALLATIONS_INTERVAL_NS,
     },
-    groups::{
-        intents::UpdateMetadataIntentData, message_history::MessageHistoryContent,
-        validated_commit::ValidatedCommit,
-    },
+    groups::{intents::UpdateMetadataIntentData, validated_commit::ValidatedCommit},
     hpke::{encrypt_welcome, HpkeError},
     identity::parse_credential,
     identity_updates::load_identity_updates,
@@ -69,12 +68,14 @@ use xmtp_proto::xmtp::mls::{
         GroupMessage, WelcomeMessageInput,
     },
     message_contents::{
-        plaintext_envelope::{
-            v2::MessageType::{Reply, Request},
-            Content, V1, V2,
-        },
+        plaintext_envelope::{Content, V1, V2},
         GroupUpdated, PlaintextEnvelope,
     },
+};
+
+#[cfg(feature = "message-history")]
+use xmtp_proto::xmtp::mls::message_contents::plaintext_envelope::v2::MessageType::{
+    Reply, Request,
 };
 
 #[derive(Debug)]
@@ -417,6 +418,7 @@ impl MlsGroup {
                         idempotency_key,
                         message_type,
                     })) => match message_type {
+                        #[cfg(feature = "message-history")]
                         Some(Request(history_request)) => {
                             let content: MessageHistoryContent =
                                 MessageHistoryContent::Request(history_request);
@@ -440,6 +442,7 @@ impl MlsGroup {
                             }
                             .store_or_ignore(provider.conn_ref())?;
                         }
+                        #[cfg(feature = "message-history")]
                         Some(Reply(history_reply)) => {
                             let content: MessageHistoryContent =
                                 MessageHistoryContent::Reply(history_reply);


### PR DESCRIPTION
# Summary

* Added `message-history` to `xmtp_mls` crate
* Gated all message history code behind `message-history` feature
* Enabled `message-history` feature for CLI and all bindings