### PR TITLE
try to reproduce stream-conversation bug

### DIFF
--- a/xmtp_mls/src/lib.rs
+++ b/xmtp_mls/src/lib.rs
@@ -129,10 +129,16 @@ mod tests {
     // Execute once before any tests are run
     #[ctor::ctor]
     // Capture traces in a variable that can be checked in tests, as well as outputting them to stdout on test failure
-    #[traced_test]
+    // #[traced_test]
     fn setup() {
+        use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+
+        tracing_subscriber::registry()
+            .with(fmt::layer())
+            .with(EnvFilter::from_default_env())
+            .init();
         // Capture logs (e.g. log::info!()) as traces too
-        let _ = tracing_log::LogTracer::init_with_filter(LevelFilter::Debug);
+        // let _ = tracing_log::LogTracer::init_with_filter(LevelFilter::Debug);
     }
 
     /// Note: tests that use this must have the #[traced_test] attribute

--- a/xmtp_mls/src/subscriptions.rs
+++ b/xmtp_mls/src/subscriptions.rs
@@ -802,17 +802,6 @@ mod tests {
         ])
         .await;
 
-        let alix_group_pointer = alix_group.clone();
-        let alix_pointer = alix.clone();
-        tokio::spawn(async move {
-            for _ in 0..100 {
-                let _ = alix_group_pointer
-                    .send_message(b"spam", &alix_pointer)
-                    .await;
-                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-            }
-        });
-
         let conversation_amount = Arc::new(AtomicU64::new(10));
         let amt = conversation_amount.clone();
         let _closer =

--- a/xmtp_mls/src/subscriptions.rs
+++ b/xmtp_mls/src/subscriptions.rs
@@ -802,14 +802,14 @@ mod tests {
         ])
         .await;
 
-        let conversation_amount = Arc::new(AtomicU64::new(10));
+        let conversation_amount = Arc::new(AtomicU64::new(100));
         let amt = conversation_amount.clone();
         let _closer =
             Client::<TestClient>::stream_conversations_with_callback(caro.clone(), move |_g| {
                 amt.fetch_sub(1, atomic::Ordering::SeqCst);
             });
 
-        for _ in 0..10 {
+        for _ in 0..100 {
             let alix_group = alix
                 .create_group(None, GroupMetadataOptions::default())
                 .unwrap();


### PR DESCRIPTION
rel https://github.com/xmtp/libxmtp/issues/1081



Was not able to reproduce, `stream_conversations` already has logic for handling errors from the database if the welcome already exists: https://github.com/xmtp/libxmtp/blob/cd0fc5cb43e000a4cca7bc2c3007957c03ae2555/xmtp_mls/src/subscriptions.rs#L97

In all cases, running three separate `stream_all_messages`, then creating 100 groups, resulted in `stream_conversations` still receiving each group sent