### PR TITLE
Update node bindings

### DIFF
--- a/bindings_node/CHANGELOG.md
+++ b/bindings_node/CHANGELOG.md
@@ -1,8 +1,18 @@
 # @xmtp/mls-client-bindings-node
 
+## 0.0.12
+
+- Added ability to add wallet associations to a client
+- Added ability to revoke wallet associations from a client
+- Added ability to revoke all installation IDs from a client
+- Added `getLatestInboxState` to client
+- Added installation timestamps to `inboxState`
+- Updated `send_optimistic` to return the message ID as a hex string
+- Added consent state methods to groups and client
+
 ## 0.0.11
 
-- Added `inbox_state` to client
+- Added `inboxState` to client
 - Skip duplicate message processing when streaming
 
 ## 0.0.10
@@ -29,8 +39,8 @@
 - Improved streaming welcomes
 - Improved DB retries
 - Changed encoding of the MLS database to `bincode` for performance
-- Added `find_inbox_id_by_address` to client
-- Added `find_group_by_id` and `find_message_by_id` to conversations
+- Added `findInboxIdByAddress` to client
+- Added `findGroupById` and `findMessageById` to conversations
 
 ## 0.0.6
 
@@ -40,11 +50,11 @@
 
 - Added ability to set group name and image URL during creation
 - Added getter and setter for group image URL
-- Renamed `add_erc1271_signature` to `add_scw_signature`
+- Renamed `addErc1271Signature` to `addScwSignature`
 
 ## 0.0.4
 
-- Added `stream_all_messages`
+- Added `streamAllMessages`
 
 ## 0.0.3
 

--- a/bindings_node/package.json
+++ b/bindings_node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/mls-client-bindings-node",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "repository": {
     "type": "git",
     "url": "git+https://git@github.com/xmtp/libxmtp.git",

--- a/bindings_node/src/consent_state.rs
+++ b/bindings_node/src/consent_state.rs
@@ -1,0 +1,63 @@
+use napi_derive::napi;
+use xmtp_mls::storage::consent_record::{ConsentState, ConsentType, StoredConsentRecord};
+
+#[napi]
+pub enum NapiConsentState {
+  Unknown,
+  Allowed,
+  Denied,
+}
+
+impl From<ConsentState> for NapiConsentState {
+  fn from(state: ConsentState) -> Self {
+    match state {
+      ConsentState::Unknown => NapiConsentState::Unknown,
+      ConsentState::Allowed => NapiConsentState::Allowed,
+      ConsentState::Denied => NapiConsentState::Denied,
+    }
+  }
+}
+
+impl From<NapiConsentState> for ConsentState {
+  fn from(state: NapiConsentState) -> Self {
+    match state {
+      NapiConsentState::Unknown => ConsentState::Unknown,
+      NapiConsentState::Allowed => ConsentState::Allowed,
+      NapiConsentState::Denied => ConsentState::Denied,
+    }
+  }
+}
+
+#[napi]
+pub enum NapiConsentEntityType {
+  GroupId,
+  InboxId,
+  Address,
+}
+
+impl From<NapiConsentEntityType> for ConsentType {
+  fn from(entity_type: NapiConsentEntityType) -> Self {
+    match entity_type {
+      NapiConsentEntityType::GroupId => ConsentType::GroupId,
+      NapiConsentEntityType::InboxId => ConsentType::InboxId,
+      NapiConsentEntityType::Address => ConsentType::Address,
+    }
+  }
+}
+
+#[napi(object)]
+pub struct NapiConsent {
+  pub entity_type: NapiConsentEntityType,
+  pub state: NapiConsentState,
+  pub entity: String,
+}
+
+impl From<NapiConsent> for StoredConsentRecord {
+  fn from(consent: NapiConsent) -> Self {
+    Self {
+      entity_type: consent.entity_type.into(),
+      state: consent.state.into(),
+      entity: consent.entity,
+    }
+  }
+}

--- a/bindings_node/src/conversations.rs
+++ b/bindings_node/src/conversations.rs
@@ -11,6 +11,7 @@ use xmtp_mls::groups::{GroupMetadataOptions, PreconfiguredPolicies};
 
 use crate::messages::NapiMessage;
 use crate::permissions::NapiGroupPermissionsOptions;
+use crate::ErrorWrapper;
 use crate::{groups::NapiGroup, mls_client::RustXmtpClient, streams::NapiStreamCloser};
 
 #[napi(object)]
@@ -105,12 +106,12 @@ impl NapiConversations {
 
   #[napi]
   pub fn find_group_by_id(&self, group_id: String) -> Result<NapiGroup> {
-    let group_id = hex::decode(group_id).map_err(|e| Error::from_reason(format!("{}", e)))?;
+    let group_id = hex::decode(group_id).map_err(ErrorWrapper::from)?;
 
     let group = self
       .inner_client
       .group(group_id)
-      .map_err(|e| Error::from_reason(format!("{}", e)))?;
+      .map_err(ErrorWrapper::from)?;
 
     Ok(NapiGroup::new(
       self.inner_client.clone(),
@@ -121,12 +122,12 @@ impl NapiConversations {
 
   #[napi]
   pub fn find_message_by_id(&self, message_id: String) -> Result<NapiMessage> {
-    let message_id = hex::decode(message_id).map_err(|e| Error::from_reason(format!("{}", e)))?;
+    let message_id = hex::decode(message_id).map_err(ErrorWrapper::from)?;
 
     let message = self
       .inner_client
       .message(message_id)
-      .map_err(|e| Error::from_reason(format!("{}", e)))?;
+      .map_err(ErrorWrapper::from)?;
 
     Ok(NapiMessage::from(message))
   }
@@ -141,7 +142,7 @@ impl NapiConversations {
       .inner_client
       .process_streamed_welcome_message(envelope_bytes)
       .await
-      .map_err(|e| Error::from_reason(format!("{}", e)))?;
+      .map_err(ErrorWrapper::from)?;
     let out = NapiGroup::new(
       self.inner_client.clone(),
       group.group_id,
@@ -156,7 +157,7 @@ impl NapiConversations {
       .inner_client
       .sync_welcomes()
       .await
-      .map_err(|e| Error::from_reason(format!("{}", e)))?;
+      .map_err(ErrorWrapper::from)?;
     Ok(())
   }
 
@@ -178,7 +179,7 @@ impl NapiConversations {
         limit: opts.limit,
         ..FindGroupParams::default()
       })
-      .map_err(|e| Error::from_reason(format!("{}", e)))?
+      .map_err(ErrorWrapper::from)?
       .into_iter()
       .map(|group| {
         NapiGroup::new(

--- a/bindings_node/src/groups.rs
+++ b/bindings_node/src/groups.rs
@@ -107,7 +107,7 @@ impl NapiGroup {
 
   /// send a message without immediately publishing to the delivery service.
   #[napi]
-  pub fn send_optimistic(&self, encoded_content: NapiEncodedContent) -> Result<Vec<u8>> {
+  pub fn send_optimistic(&self, encoded_content: NapiEncodedContent) -> Result<String> {
     let encoded_content: EncodedContent = encoded_content.into();
     let group = MlsGroup::new(
       self.inner_client.context().clone(),
@@ -119,7 +119,7 @@ impl NapiGroup {
       .send_message_optimistic(encoded_content.encode_to_vec().as_slice())
       .map_err(ErrorWrapper::from)?;
 
-    Ok(id)
+    Ok(hex::encode(id.clone()))
   }
 
   /// Publish all unpublished messages

--- a/bindings_node/src/groups.rs
+++ b/bindings_node/src/groups.rs
@@ -545,7 +545,7 @@ impl NapiGroup {
 
     let group_pinned_frame_url = group
       .group_pinned_frame_url(group.mls_provider().map_err(ErrorWrapper::from)?)
-      .map_err(|e| Error::from_reason(format!("{}", e)))?;
+      .map_err(ErrorWrapper::from)?;
 
     Ok(group_pinned_frame_url)
   }

--- a/bindings_node/src/groups.rs
+++ b/bindings_node/src/groups.rs
@@ -1,7 +1,7 @@
 use std::{ops::Deref, sync::Arc};
 
 use napi::{
-  bindgen_prelude::{Error, Result, Uint8Array},
+  bindgen_prelude::{Result, Uint8Array},
   threadsafe_function::{ErrorStrategy, ThreadsafeFunction, ThreadsafeFunctionCallMode},
   JsFunction,
 };

--- a/bindings_node/src/inbox_state.rs
+++ b/bindings_node/src/inbox_state.rs
@@ -29,7 +29,7 @@ impl From<AssociationState> for NapiInboxState {
           MemberIdentifier::Address(_) => None,
           MemberIdentifier::Installation(inst) => Some(NapiInstallation {
             id: ed25519_public_key_to_address(inst.as_slice()),
-            client_timestamp_ns: m.client_timestamp_ns.map(|ts| BigInt::from(ts)),
+            client_timestamp_ns: m.client_timestamp_ns.map(BigInt::from),
           }),
         })
         .collect(),

--- a/bindings_node/src/inbox_state.rs
+++ b/bindings_node/src/inbox_state.rs
@@ -1,0 +1,39 @@
+use napi::bindgen_prelude::BigInt;
+use napi_derive::napi;
+use xmtp_cryptography::signature::ed25519_public_key_to_address;
+use xmtp_id::associations::{AssociationState, MemberIdentifier};
+
+#[napi(object)]
+pub struct NapiInstallation {
+  pub id: String,
+  pub client_timestamp_ns: Option<BigInt>,
+}
+
+#[napi(object)]
+pub struct NapiInboxState {
+  pub inbox_id: String,
+  pub recovery_address: String,
+  pub installations: Vec<NapiInstallation>,
+  pub account_addresses: Vec<String>,
+}
+
+impl From<AssociationState> for NapiInboxState {
+  fn from(state: AssociationState) -> Self {
+    Self {
+      inbox_id: state.inbox_id().to_string(),
+      recovery_address: state.recovery_address().to_string(),
+      installations: state
+        .members()
+        .into_iter()
+        .filter_map(|m| match m.identifier {
+          MemberIdentifier::Address(_) => None,
+          MemberIdentifier::Installation(inst) => Some(NapiInstallation {
+            id: ed25519_public_key_to_address(inst.as_slice()),
+            client_timestamp_ns: m.client_timestamp_ns.map(|ts| BigInt::from(ts)),
+          }),
+        })
+        .collect(),
+      account_addresses: state.account_addresses(),
+    }
+  }
+}

--- a/bindings_node/src/lib.rs
+++ b/bindings_node/src/lib.rs
@@ -1,8 +1,9 @@
 #![recursion_limit = "256"]
 #![warn(clippy::unwrap_used)]
 
+mod consent_state;
 mod conversations;
-pub mod encoded_content;
+mod encoded_content;
 mod groups;
 mod inbox_state;
 mod messages;

--- a/bindings_node/src/lib.rs
+++ b/bindings_node/src/lib.rs
@@ -4,6 +4,7 @@
 mod conversations;
 pub mod encoded_content;
 mod groups;
+mod inbox_state;
 mod messages;
 pub mod mls_client;
 mod permissions;

--- a/bindings_node/src/mls_client.rs
+++ b/bindings_node/src/mls_client.rs
@@ -1,4 +1,5 @@
 use crate::conversations::NapiConversations;
+use crate::inbox_state::NapiInboxState;
 use napi::bindgen_prelude::{Error, Result, Uint8Array};
 use napi_derive::napi;
 use std::collections::HashMap;
@@ -8,8 +9,8 @@ use tokio::sync::Mutex;
 pub use xmtp_api_grpc::grpc_api_helper::Client as TonicApiClient;
 use xmtp_cryptography::signature::ed25519_public_key_to_address;
 use xmtp_id::associations::builder::SignatureRequest;
+use xmtp_id::associations::generate_inbox_id as xmtp_id_generate_inbox_id;
 use xmtp_id::associations::unverified::UnverifiedSignature;
-use xmtp_id::associations::{generate_inbox_id as xmtp_id_generate_inbox_id, AssociationState};
 use xmtp_mls::api::ApiClientWrapper;
 use xmtp_mls::builder::ClientBuilder;
 use xmtp_mls::identity::IdentityStrategy;
@@ -26,29 +27,6 @@ pub enum NapiSignatureRequestType {
   CreateInbox,
   RevokeWallet,
   RevokeInstallations,
-}
-
-#[napi(object)]
-pub struct NapiInboxState {
-  pub inbox_id: String,
-  pub recovery_address: String,
-  pub installation_ids: Vec<String>,
-  pub account_addresses: Vec<String>,
-}
-
-impl From<AssociationState> for NapiInboxState {
-  fn from(state: AssociationState) -> Self {
-    Self {
-      inbox_id: state.inbox_id().to_string(),
-      recovery_address: state.recovery_address().to_string(),
-      installation_ids: state
-        .installation_ids()
-        .into_iter()
-        .map(|id| ed25519_public_key_to_address(id.as_slice()))
-        .collect(),
-      account_addresses: state.account_addresses(),
-    }
-  }
 }
 
 #[napi]

--- a/bindings_node/src/mls_client.rs
+++ b/bindings_node/src/mls_client.rs
@@ -157,7 +157,7 @@ impl NapiClient {
 
   #[napi]
   pub fn is_registered(&self) -> bool {
-    self.inner_client.identity().signature_request().is_none()
+    self.inner_client.identity().is_ready()
   }
 
   #[napi]
@@ -254,6 +254,21 @@ impl NapiClient {
     let state = self
       .inner_client
       .inbox_state(refresh_from_network)
+      .await
+      .map_err(|e| Error::from_reason(format!("{}", e)))?;
+    Ok(state.into())
+  }
+
+  #[napi]
+  pub async fn get_latest_inbox_state(&self, inbox_id: String) -> Result<NapiInboxState> {
+    let conn = self
+      .inner_client
+      .store()
+      .conn()
+      .map_err(|e| Error::from_reason(format!("{}", e)))?;
+    let state = self
+      .inner_client
+      .get_latest_association_state(&conn, &inbox_id)
       .await
       .map_err(|e| Error::from_reason(format!("{}", e)))?;
     Ok(state.into())

--- a/bindings_node/test/Client.test.ts
+++ b/bindings_node/test/Client.test.ts
@@ -40,7 +40,8 @@ describe('Client', () => {
     const client = await createRegisteredClient(user)
     const inboxState = await client.inboxState(false)
     expect(inboxState.inboxId).toBe(client.inboxId())
-    expect(inboxState.installationIds).toEqual([client.installationId()])
+    expect(inboxState.installations.length).toBe(1)
+    expect(inboxState.installations[0].id).toBe(client.installationId())
     expect(inboxState.accountAddresses).toEqual([
       user.account.address.toLowerCase(),
     ])
@@ -50,7 +51,8 @@ describe('Client', () => {
     const client2 = await createClient(user2)
     const inboxState2 = await client2.getLatestInboxState(client.inboxId())
     expect(inboxState2.inboxId).toBe(client.inboxId())
-    expect(inboxState2.installationIds).toEqual([client.installationId()])
+    expect(inboxState.installations.length).toBe(1)
+    expect(inboxState.installations[0].id).toBe(client.installationId())
     expect(inboxState2.accountAddresses).toEqual([
       user.account.address.toLowerCase(),
     ])
@@ -153,10 +155,12 @@ describe('Client', () => {
     const client3 = await createRegisteredClient(user)
 
     const inboxState = await client3.inboxState(true)
-    expect(inboxState.installationIds.length).toEqual(3)
-    expect(inboxState.installationIds).toContain(client.installationId())
-    expect(inboxState.installationIds).toContain(client2.installationId())
-    expect(inboxState.installationIds).toContain(client3.installationId())
+    expect(inboxState.installations.length).toBe(3)
+
+    const installationIds = inboxState.installations.map((i) => i.id)
+    expect(installationIds).toContain(client.installationId())
+    expect(installationIds).toContain(client2.installationId())
+    expect(installationIds).toContain(client3.installationId())
 
     const signatureText = await client3.revokeInstallationsSignatureText()
     expect(signatureText).toBeDefined()
@@ -172,6 +176,8 @@ describe('Client', () => {
     )
     await client3.applySignatureRequests()
     const inboxState2 = await client3.inboxState(true)
-    expect(inboxState2.installationIds).toEqual([client3.installationId()])
+
+    expect(inboxState2.installations.length).toBe(1)
+    expect(inboxState2.installations[0].id).toBe(client3.installationId())
   })
 })

--- a/bindings_node/test/Client.test.ts
+++ b/bindings_node/test/Client.test.ts
@@ -2,7 +2,11 @@ import { v4 } from 'uuid'
 import { toBytes } from 'viem'
 import { describe, expect, it } from 'vitest'
 import { createClient, createRegisteredClient, createUser } from '@test/helpers'
-import { NapiSignatureRequestType } from '../dist'
+import {
+  NapiConsentEntityType,
+  NapiConsentState,
+  NapiSignatureRequestType,
+} from '../dist'
 
 describe('Client', () => {
   it('should not be registered at first', async () => {
@@ -179,5 +183,42 @@ describe('Client', () => {
 
     expect(inboxState2.installations.length).toBe(1)
     expect(inboxState2.installations[0].id).toBe(client3.installationId())
+  })
+
+  it('should manage consent states', async () => {
+    const user1 = createUser()
+    const user2 = createUser()
+    const client1 = await createRegisteredClient(user1)
+    const client2 = await createRegisteredClient(user2)
+    const group = await client1
+      .conversations()
+      .createGroup([user2.account.address])
+
+    await client2.conversations().sync()
+    const group2 = client2.conversations().findGroupById(group.id())
+
+    expect(
+      await client2.getConsentState(NapiConsentEntityType.GroupId, group2.id())
+    ).toBe(NapiConsentState.Unknown)
+
+    await client2.setConsentStates([
+      {
+        entityType: NapiConsentEntityType.GroupId,
+        entity: group2.id(),
+        state: NapiConsentState.Allowed,
+      },
+    ])
+
+    expect(
+      await client2.getConsentState(NapiConsentEntityType.GroupId, group2.id())
+    ).toBe(NapiConsentState.Allowed)
+
+    expect(group2.consentState()).toBe(NapiConsentState.Allowed)
+
+    group2.updateConsentState(NapiConsentState.Denied)
+
+    expect(
+      await client2.getConsentState(NapiConsentEntityType.GroupId, group2.id())
+    ).toBe(NapiConsentState.Denied)
   })
 })

--- a/bindings_node/test/Client.test.ts
+++ b/bindings_node/test/Client.test.ts
@@ -45,6 +45,16 @@ describe('Client', () => {
       user.account.address.toLowerCase(),
     ])
     expect(inboxState.recoveryAddress).toBe(user.account.address.toLowerCase())
+
+    const user2 = createUser()
+    const client2 = await createClient(user2)
+    const inboxState2 = await client2.getLatestInboxState(client.inboxId())
+    expect(inboxState2.inboxId).toBe(client.inboxId())
+    expect(inboxState2.installationIds).toEqual([client.installationId()])
+    expect(inboxState2.accountAddresses).toEqual([
+      user.account.address.toLowerCase(),
+    ])
+    expect(inboxState2.recoveryAddress).toBe(user.account.address.toLowerCase())
   })
 
   it('should add a wallet association to the client', async () => {


### PR DESCRIPTION
# Summary

- Added `getLatestInboxState` to client
- Added installation timestamps to `inboxState`
- Updated `send_optimistic` to return the message ID as a hex string
- Added consent state methods to groups and client
- Updated CHANGELOG and version