### PR TITLE
Prepare node bindings for release

### DIFF
--- a/bindings_node/CHANGELOG.md
+++ b/bindings_node/CHANGELOG.md
@@ -1,4 +1,9 @@
-# @xmtp/mls-client-bindings-node
+# @xmtp/node-bindings
+
+## 0.0.13
+
+- Added logging option when creating a client
+- Added `inboxAddresses` to client
 
 ## 0.0.12
 

--- a/bindings_node/package.json
+++ b/bindings_node/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@xmtp/mls-client-bindings-node",
-  "version": "0.0.12",
+  "name": "@xmtp/node-bindings",
+  "version": "0.0.13",
   "repository": {
     "type": "git",
     "url": "git+https://git@github.com/xmtp/libxmtp.git",

--- a/bindings_node/test/Client.test.ts
+++ b/bindings_node/test/Client.test.ts
@@ -221,4 +221,28 @@ describe('Client', () => {
       await client2.getConsentState(NapiConsentEntityType.GroupId, group2.id())
     ).toBe(NapiConsentState.Denied)
   })
+
+  it('should get inbox addresses', async () => {
+    const user = createUser()
+    const user2 = createUser()
+    const client = await createRegisteredClient(user)
+    const client2 = await createRegisteredClient(user2)
+    const inboxAddresses = await client.addressesFromInboxId(true, [
+      client.inboxId(),
+    ])
+    expect(inboxAddresses.length).toBe(1)
+    expect(inboxAddresses[0].inboxId).toBe(client.inboxId())
+    expect(inboxAddresses[0].accountAddresses).toEqual([
+      user.account.address.toLowerCase(),
+    ])
+
+    const inboxAddresses2 = await client2.addressesFromInboxId(true, [
+      client2.inboxId(),
+    ])
+    expect(inboxAddresses2.length).toBe(1)
+    expect(inboxAddresses2[0].inboxId).toBe(client2.inboxId())
+    expect(inboxAddresses2[0].accountAddresses).toEqual([
+      user2.account.address.toLowerCase(),
+    ])
+  })
 })

--- a/bindings_node/test/helpers.ts
+++ b/bindings_node/test/helpers.ts
@@ -36,7 +36,16 @@ export const createClient = async (user: User) => {
   const inboxId =
     (await getInboxIdForAddress(TEST_API_URL, false, user.account.address)) ||
     generateInboxId(user.account.address)
-  return create(TEST_API_URL, false, dbPath, inboxId, user.account.address)
+  return create(
+    TEST_API_URL,
+    false,
+    dbPath,
+    inboxId,
+    user.account.address,
+    undefined,
+    undefined,
+    'off'
+  )
 }
 
 export const createRegisteredClient = async (user: User) => {

--- a/bindings_node/yarn.lock
+++ b/bindings_node/yarn.lock
@@ -1503,9 +1503,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/mls-client-bindings-node@workspace:.":
+"@xmtp/node-bindings@workspace:.":
   version: 0.0.0-use.local
-  resolution: "@xmtp/mls-client-bindings-node@workspace:."
+  resolution: "@xmtp/node-bindings@workspace:."
   dependencies:
     "@ianvs/prettier-plugin-sort-imports": "npm:^4.2.1"
     "@napi-rs/cli": "npm:^3.0.0-alpha.55"


### PR DESCRIPTION
# Summary

- Renamed `@xmtp/mls-client-bindings-node` => `@xmtp/node-bindings`
- Updated CHANGELOG
- Bumped version to `0.0.13`