### PR TITLE
Disable package exit codes in chocolately

### DIFF
--- a/.github/workflows/release-node-bindings.yml
+++ b/.github/workflows/release-node-bindings.yml
@@ -196,6 +196,11 @@ jobs:
             .
             bindings_node
 
+      - name: Disable usePackageExitCodes feature
+        uses: crazy-max/ghaction-chocolatey@v3
+        with:
+          args: feature disable --name="'usePackageExitCodes'"
+
       - name: Upgrade Visual Studio 2022 enterprise
         uses: crazy-max/ghaction-chocolatey@v3
         with:


### PR DESCRIPTION
# Summary

When upgrading `visualstudio2022enterprise`, a system reboot is sometimes necessary. I'm hoping with this change, the action will exit gracefully and update the cache, allowing for a successful followup run.

If this doesn't work, I'm going to try to disable the `exitOnRebootDetected` feature and see if that solves the problem.