### PR TITLE
Make general conversation to encompass group dms and groups.

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -3923,7 +3923,7 @@ mod tests {
         assert_eq!(alix_dms.len(), 1);
 
         let bola_dms = bola_conversations
-            .list_groups(FfiListConversationsOptions::default())
+            .list_dms(FfiListConversationsOptions::default())
             .await
             .unwrap();
         assert_eq!(bola_dms.len(), 1);

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -820,7 +820,10 @@ impl FfiConversations {
         Ok(out)
     }
 
-    pub async fn create_dm(&self, account_address: String) -> Result<Arc<FfiConversation>, GenericError> {
+    pub async fn create_dm(
+        &self,
+        account_address: String,
+    ) -> Result<Arc<FfiConversation>, GenericError> {
         log::info!("creating dm with target address: {}", account_address);
 
         let convo = self.inner_client.create_dm(account_address).await?;
@@ -906,7 +909,7 @@ impl FfiConversations {
 
         Ok(convo_list)
     }
-    
+
     pub async fn list_groups(
         &self,
         opts: FfiListConversationsOptions,
@@ -932,7 +935,7 @@ impl FfiConversations {
 
         Ok(convo_list)
     }
-    
+
     pub async fn list_dms(
         &self,
         opts: FfiListConversationsOptions,
@@ -959,7 +962,10 @@ impl FfiConversations {
         Ok(convo_list)
     }
 
-    pub async fn stream_groups(&self, callback: Box<dyn FfiConversationCallback>) -> FfiStreamCloser {
+    pub async fn stream_groups(
+        &self,
+        callback: Box<dyn FfiConversationCallback>,
+    ) -> FfiStreamCloser {
         let client = self.inner_client.clone();
         let handle = RustXmtpClient::stream_conversations_with_callback(
             client.clone(),
@@ -993,7 +999,7 @@ impl FfiConversations {
         FfiStreamCloser::new(handle)
     }
 
-    pub async fn stream_conversations(&self, callback: Box<dyn FfiConversationCallback>) -> FfiStreamCloser {
+    pub async fn stream(&self, callback: Box<dyn FfiConversationCallback>) -> FfiStreamCloser {
         let client = self.inner_client.clone();
         let handle = RustXmtpClient::stream_conversations_with_callback(
             client.clone(),
@@ -1017,7 +1023,7 @@ impl FfiConversations {
         let handle = RustXmtpClient::stream_all_messages_with_callback(
             self.inner_client.clone(),
             move |message| message_callback.on_message(message.into()),
-            Some(ConversationType::Group)
+            Some(ConversationType::Group),
         );
 
         FfiStreamCloser::new(handle)
@@ -1030,7 +1036,7 @@ impl FfiConversations {
         let handle = RustXmtpClient::stream_all_dm_messages_with_callback(
             self.inner_client.clone(),
             move |message| message_callback.on_message(message.into()),
-            Some(ConversationType::Dm)
+            Some(ConversationType::Dm),
         );
 
         FfiStreamCloser::new(handle)
@@ -1043,7 +1049,7 @@ impl FfiConversations {
         let handle = RustXmtpClient::stream_all_messages_with_callback(
             self.inner_client.clone(),
             move |message| message_callback.on_message(message.into()),
-            None
+            None,
         );
 
         FfiStreamCloser::new(handle)
@@ -1879,10 +1885,10 @@ mod tests {
     use super::{create_client, FfiMessage, FfiMessageCallback, FfiXmtpClient};
     use crate::{
         get_inbox_id_for_address, inbox_owner::SigningError, logger::FfiLogger, FfiConsent,
-        FfiConsentEntityType, FfiConsentState, FfiConversationCallback, FfiCreateGroupOptions,
-        FfiConversation, FfiConversationMessageKind, FfiGroupPermissionsOptions, FfiInboxOwner,
-        FfiListConversationsOptions, FfiListMessagesOptions, FfiMetadataField, FfiPermissionPolicy,
-        FfiPermissionPolicySet, FfiPermissionUpdateType,
+        FfiConsentEntityType, FfiConsentState, FfiConversation, FfiConversationCallback,
+        FfiConversationMessageKind, FfiCreateGroupOptions, FfiGroupPermissionsOptions,
+        FfiInboxOwner, FfiListConversationsOptions, FfiListMessagesOptions, FfiMetadataField,
+        FfiPermissionPolicy, FfiPermissionPolicySet, FfiPermissionUpdateType,
     };
     use ethers::utils::hex;
     use rand::distributions::{Alphanumeric, DistString};

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -271,16 +271,6 @@ impl FfiXmtpClient {
         })
     }
 
-    // deprecated use conversation instead
-    pub fn group(&self, group_id: Vec<u8>) -> Result<FfiConversation, GenericError> {
-        let convo = self.inner_client.group(group_id)?;
-        Ok(FfiConversation {
-            inner_client: self.inner_client.clone(),
-            conversation_id: convo.group_id,
-            created_at_ns: convo.created_at_ns,
-        })
-    }
-
     pub fn conversation(&self, conversation_id: Vec<u8>) -> Result<FfiConversation, GenericError> {
         let convo = self.inner_client.group(conversation_id)?;
         Ok(FfiConversation {

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -959,7 +959,7 @@ impl FfiConversations {
         Ok(convo_list)
     }
 
-    pub async fn stream(&self, callback: Box<dyn FfiConversationCallback>) -> FfiStreamCloser {
+    pub async fn stream_groups(&self, callback: Box<dyn FfiConversationCallback>) -> FfiStreamCloser {
         let client = self.inner_client.clone();
         let handle = RustXmtpClient::stream_conversations_with_callback(
             client.clone(),
@@ -971,6 +971,23 @@ impl FfiConversations {
                 }))
             },
             false,
+        );
+
+        FfiStreamCloser::new(handle)
+    }
+
+    pub async fn stream_conversations(&self, callback: Box<dyn FfiConversationCallback>) -> FfiStreamCloser {
+        let client = self.inner_client.clone();
+        let handle = RustXmtpClient::stream_conversations_with_callback(
+            client.clone(),
+            move |convo| {
+                callback.on_conversation(Arc::new(FfiConversation {
+                    inner_client: client.clone(),
+                    conversation_id: convo.group_id,
+                    created_at_ns: convo.created_at_ns,
+                }))
+            },
+            true,
         );
 
         FfiStreamCloser::new(handle)

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -3893,7 +3893,7 @@ mod tests {
         let alix_conversations = alix.conversations();
         let bola_conversations = bola.conversations();
 
-        let _alix_group = alix_conversations
+        let _alix_dm = alix_conversations
             .create_dm(bola.account_address.clone())
             .await
             .unwrap();
@@ -3904,16 +3904,40 @@ mod tests {
         assert_eq!(bola_num_sync, 1);
 
         let alix_groups = alix_conversations
-            .list(FfiListConversationsOptions::default())
+            .list_groups(FfiListConversationsOptions::default())
             .await
             .unwrap();
         assert_eq!(alix_groups.len(), 0);
 
         let bola_groups = bola_conversations
-            .list(FfiListConversationsOptions::default())
+            .list_groups(FfiListConversationsOptions::default())
             .await
             .unwrap();
         assert_eq!(bola_groups.len(), 0);
+
+        let alix_dms = alix_conversations
+            .list_dms(FfiListConversationsOptions::default())
+            .await
+            .unwrap();
+        assert_eq!(alix_dms.len(), 1);
+
+        let bola_dms = bola_conversations
+            .list_groups(FfiListConversationsOptions::default())
+            .await
+            .unwrap();
+        assert_eq!(bola_dms.len(), 1);
+
+        let alix_conversations = alix_conversations
+            .list(FfiListConversationsOptions::default())
+            .await
+            .unwrap();
+        assert_eq!(alix_conversations.len(), 1);
+
+        let bola_conversations = bola_conversations
+            .list(FfiListConversationsOptions::default())
+            .await
+            .unwrap();
+        assert_eq!(bola_conversations.len(), 1);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 5)]

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -932,7 +932,7 @@ impl FfiConversations {
     ) -> Result<Vec<Arc<FfiConversation>>, GenericError> {
         let inner = self.inner_client.as_ref();
         let convo_list: Vec<Arc<FfiConversation>> = inner
-            .find_dms(FindGroupParams {
+            .find_groups(FindGroupParams {
                 allowed_states: None,
                 created_after_ns: opts.created_after_ns,
                 created_before_ns: opts.created_before_ns,
@@ -974,7 +974,7 @@ impl FfiConversations {
 
     pub async fn stream_dms(&self, callback: Box<dyn FfiConversationCallback>) -> FfiStreamCloser {
         let client = self.inner_client.clone();
-        let handle = RustXmtpClient::stream_dms_with_callback(
+        let handle = RustXmtpClient::stream_conversations_with_callback(
             client.clone(),
             move |convo| {
                 callback.on_conversation(Arc::new(FfiConversation {
@@ -1023,7 +1023,7 @@ impl FfiConversations {
         &self,
         message_callback: Box<dyn FfiMessageCallback>,
     ) -> FfiStreamCloser {
-        let handle = RustXmtpClient::stream_all_dm_messages_with_callback(
+        let handle = RustXmtpClient::stream_all_messages_with_callback(
             self.inner_client.clone(),
             move |message| message_callback.on_message(message.into()),
             Some(ConversationType::Dm),
@@ -1147,7 +1147,7 @@ impl FfiConversation {
     pub async fn send(&self, content_bytes: Vec<u8>) -> Result<Vec<u8>, GenericError> {
         let group = MlsGroup::new(
             self.inner_client.context().clone(),
-            self.group_id.clone(),
+            self.conversation_id.clone(),
             self.created_at_ns,
         );
 
@@ -1161,7 +1161,7 @@ impl FfiConversation {
     pub fn send_optimistic(&self, content_bytes: Vec<u8>) -> Result<Vec<u8>, GenericError> {
         let group = MlsGroup::new(
             self.inner_client.context().clone(),
-            self.group_id.clone(),
+            self.conversation_id.clone(),
             self.created_at_ns,
         );
 
@@ -1174,7 +1174,7 @@ impl FfiConversation {
     pub async fn publish_messages(&self) -> Result<(), GenericError> {
         let group = MlsGroup::new(
             self.inner_client.context().clone(),
-            self.group_id.clone(),
+            self.conversation_id.clone(),
             self.created_at_ns,
         );
         group.publish_messages(&self.inner_client).await?;
@@ -1184,7 +1184,7 @@ impl FfiConversation {
     pub async fn sync(&self) -> Result<(), GenericError> {
         let group = MlsGroup::new(
             self.inner_client.context().clone(),
-            self.group_id.clone(),
+            self.conversation_id.clone(),
             self.created_at_ns,
         );
 
@@ -1199,7 +1199,7 @@ impl FfiConversation {
     ) -> Result<Vec<FfiMessage>, GenericError> {
         let group = MlsGroup::new(
             self.inner_client.context().clone(),
-            self.group_id.clone(),
+            self.conversation_id.clone(),
             self.created_at_ns,
         );
 
@@ -1226,7 +1226,7 @@ impl FfiConversation {
     ) -> Result<FfiMessage, GenericError> {
         let group = MlsGroup::new(
             self.inner_client.context().clone(),
-            self.group_id.clone(),
+            self.conversation_id.clone(),
             self.created_at_ns,
         );
         let message = group
@@ -1240,7 +1240,7 @@ impl FfiConversation {
     pub async fn list_members(&self) -> Result<Vec<FfiConversationMember>, GenericError> {
         let group = MlsGroup::new(
             self.inner_client.context().clone(),
-            self.group_id.clone(),
+            self.conversation_id.clone(),
             self.created_at_ns,
         );
 
@@ -1269,7 +1269,7 @@ impl FfiConversation {
 
         let group = MlsGroup::new(
             self.inner_client.context().clone(),
-            self.group_id.clone(),
+            self.conversation_id.clone(),
             self.created_at_ns,
         );
 
@@ -1288,7 +1288,7 @@ impl FfiConversation {
 
         let group = MlsGroup::new(
             self.inner_client.context().clone(),
-            self.group_id.clone(),
+            self.conversation_id.clone(),
             self.created_at_ns,
         );
 
@@ -1302,7 +1302,7 @@ impl FfiConversation {
     pub async fn remove_members(&self, account_addresses: Vec<String>) -> Result<(), GenericError> {
         let group = MlsGroup::new(
             self.inner_client.context().clone(),
-            self.group_id.clone(),
+            self.conversation_id.clone(),
             self.created_at_ns,
         );
 
@@ -1319,7 +1319,7 @@ impl FfiConversation {
     ) -> Result<(), GenericError> {
         let group = MlsGroup::new(
             self.inner_client.context().clone(),
-            self.group_id.clone(),
+            self.conversation_id.clone(),
             self.created_at_ns,
         );
 
@@ -1333,7 +1333,7 @@ impl FfiConversation {
     pub async fn update_group_name(&self, group_name: String) -> Result<(), GenericError> {
         let group = MlsGroup::new(
             self.inner_client.context().clone(),
-            self.group_id.clone(),
+            self.conversation_id.clone(),
             self.created_at_ns,
         );
 
@@ -1347,7 +1347,7 @@ impl FfiConversation {
     pub fn group_name(&self) -> Result<String, GenericError> {
         let group = MlsGroup::new(
             self.inner_client.context().clone(),
-            self.group_id.clone(),
+            self.conversation_id.clone(),
             self.created_at_ns,
         );
 
@@ -1363,7 +1363,7 @@ impl FfiConversation {
     ) -> Result<(), GenericError> {
         let group = MlsGroup::new(
             self.inner_client.context().clone(),
-            self.group_id.clone(),
+            self.conversation_id.clone(),
             self.created_at_ns,
         );
 
@@ -1377,7 +1377,7 @@ impl FfiConversation {
     pub fn group_image_url_square(&self) -> Result<String, GenericError> {
         let group = MlsGroup::new(
             self.inner_client.context().clone(),
-            self.group_id.clone(),
+            self.conversation_id.clone(),
             self.created_at_ns,
         );
 
@@ -1392,7 +1392,7 @@ impl FfiConversation {
     ) -> Result<(), GenericError> {
         let group = MlsGroup::new(
             self.inner_client.context().clone(),
-            self.group_id.clone(),
+            self.conversation_id.clone(),
             self.created_at_ns,
         );
 
@@ -1406,7 +1406,7 @@ impl FfiConversation {
     pub fn group_description(&self) -> Result<String, GenericError> {
         let group = MlsGroup::new(
             self.inner_client.context().clone(),
-            self.group_id.clone(),
+            self.conversation_id.clone(),
             self.created_at_ns,
         );
 
@@ -1421,7 +1421,7 @@ impl FfiConversation {
     ) -> Result<(), GenericError> {
         let group = MlsGroup::new(
             self.inner_client.context().clone(),
-            self.group_id.clone(),
+            self.conversation_id.clone(),
             self.created_at_ns,
         );
 
@@ -1435,7 +1435,7 @@ impl FfiConversation {
     pub fn group_pinned_frame_url(&self) -> Result<String, GenericError> {
         let group = MlsGroup::new(
             self.inner_client.context().clone(),
-            self.group_id.clone(),
+            self.conversation_id.clone(),
             self.created_at_ns,
         );
 
@@ -1447,7 +1447,7 @@ impl FfiConversation {
     pub fn admin_list(&self) -> Result<Vec<String>, GenericError> {
         let group = MlsGroup::new(
             self.inner_client.context().clone(),
-            self.group_id.clone(),
+            self.conversation_id.clone(),
             self.created_at_ns,
         );
 
@@ -1459,7 +1459,7 @@ impl FfiConversation {
     pub fn super_admin_list(&self) -> Result<Vec<String>, GenericError> {
         let group = MlsGroup::new(
             self.inner_client.context().clone(),
-            self.group_id.clone(),
+            self.conversation_id.clone(),
             self.created_at_ns,
         );
 
@@ -1481,7 +1481,7 @@ impl FfiConversation {
     pub async fn add_admin(&self, inbox_id: String) -> Result<(), GenericError> {
         let group = MlsGroup::new(
             self.inner_client.context().clone(),
-            self.group_id.clone(),
+            self.conversation_id.clone(),
             self.created_at_ns,
         );
         group
@@ -1494,7 +1494,7 @@ impl FfiConversation {
     pub async fn remove_admin(&self, inbox_id: String) -> Result<(), GenericError> {
         let group = MlsGroup::new(
             self.inner_client.context().clone(),
-            self.group_id.clone(),
+            self.conversation_id.clone(),
             self.created_at_ns,
         );
         group
@@ -1507,7 +1507,7 @@ impl FfiConversation {
     pub async fn add_super_admin(&self, inbox_id: String) -> Result<(), GenericError> {
         let group = MlsGroup::new(
             self.inner_client.context().clone(),
-            self.group_id.clone(),
+            self.conversation_id.clone(),
             self.created_at_ns,
         );
         group
@@ -1520,7 +1520,7 @@ impl FfiConversation {
     pub async fn remove_super_admin(&self, inbox_id: String) -> Result<(), GenericError> {
         let group = MlsGroup::new(
             self.inner_client.context().clone(),
-            self.group_id.clone(),
+            self.conversation_id.clone(),
             self.created_at_ns,
         );
         group
@@ -1537,7 +1537,7 @@ impl FfiConversation {
     pub fn group_permissions(&self) -> Result<Arc<FfiGroupPermissions>, GenericError> {
         let group = MlsGroup::new(
             self.inner_client.context().clone(),
-            self.group_id.clone(),
+            self.conversation_id.clone(),
             self.created_at_ns,
         );
 
@@ -1555,7 +1555,7 @@ impl FfiConversation {
     ) -> Result<(), GenericError> {
         let group = MlsGroup::new(
             self.inner_client.context().clone(),
-            self.group_id.clone(),
+            self.conversation_id.clone(),
             self.created_at_ns,
         );
         group
@@ -1574,7 +1574,7 @@ impl FfiConversation {
         let inner_client = Arc::clone(&self.inner_client);
         let handle = MlsGroup::stream_with_callback(
             inner_client,
-            self.group_id.clone(),
+            self.conversation_id.clone(),
             self.created_at_ns,
             move |message| message_callback.on_message(message.into()),
         );
@@ -1589,7 +1589,7 @@ impl FfiConversation {
     pub fn is_active(&self) -> Result<bool, GenericError> {
         let group = MlsGroup::new(
             self.inner_client.context().clone(),
-            self.group_id.clone(),
+            self.conversation_id.clone(),
             self.created_at_ns,
         );
 
@@ -1599,7 +1599,7 @@ impl FfiConversation {
     pub fn consent_state(&self) -> Result<FfiConsentState, GenericError> {
         let group = MlsGroup::new(
             self.inner_client.context().clone(),
-            self.group_id.clone(),
+            self.conversation_id.clone(),
             self.created_at_ns,
         );
 
@@ -1611,7 +1611,7 @@ impl FfiConversation {
     pub fn update_consent_state(&self, state: FfiConsentState) -> Result<(), GenericError> {
         let group = MlsGroup::new(
             self.inner_client.context().clone(),
-            self.group_id.clone(),
+            self.conversation_id.clone(),
             self.created_at_ns,
         );
 
@@ -1623,7 +1623,7 @@ impl FfiConversation {
     pub fn added_by_inbox_id(&self) -> Result<String, GenericError> {
         let group = MlsGroup::new(
             self.inner_client.context().clone(),
-            self.group_id.clone(),
+            self.conversation_id.clone(),
             self.created_at_ns,
         );
 
@@ -1633,7 +1633,7 @@ impl FfiConversation {
     pub fn group_metadata(&self) -> Result<Arc<FfiConversationMetadata>, GenericError> {
         let group = MlsGroup::new(
             self.inner_client.context().clone(),
-            self.group_id.clone(),
+            self.conversation_id.clone(),
             self.created_at_ns,
         );
 
@@ -1647,7 +1647,7 @@ impl FfiConversation {
 #[uniffi::export]
 impl FfiConversation {
     pub fn id(&self) -> Vec<u8> {
-        self.group_id.clone()
+        self.conversation_id.clone()
     }
 }
 
@@ -2048,7 +2048,7 @@ mod tests {
         async fn update_installations(&self) -> Result<(), GroupError> {
             let group = MlsGroup::new(
                 self.inner_client.context().clone(),
-                self.group_id.clone(),
+                self.conversation_id.clone(),
                 self.created_at_ns,
             );
 
@@ -2599,8 +2599,8 @@ mod tests {
 
         let alix_group1 = alix_groups[0].clone();
         let alix_group5 = alix_groups[5].clone();
-        let bo_group1 = bo.group(alix_group1.id()).unwrap();
-        let bo_group5 = bo.group(alix_group5.id()).unwrap();
+        let bo_group1 = bo.conversation(alix_group1.id()).unwrap();
+        let bo_group5 = bo.conversation(alix_group5.id()).unwrap();
 
         alix_group1.send("alix1".as_bytes().to_vec()).await.unwrap();
         alix_group5.send("alix1".as_bytes().to_vec()).await.unwrap();
@@ -2614,7 +2614,7 @@ mod tests {
         assert_eq!(bo_messages1.len(), 0);
         assert_eq!(bo_messages5.len(), 0);
 
-        bo.conversations().sync_all_groups().await.unwrap();
+        bo.conversations().sync_all_conversations().await.unwrap();
 
         let bo_messages1 = bo_group1
             .find_messages(FfiListMessagesOptions::default())
@@ -2642,7 +2642,7 @@ mod tests {
                 .unwrap();
         }
         bo.conversations().sync().await.unwrap();
-        let num_groups_synced_1: u32 = bo.conversations().sync_all_groups().await.unwrap();
+        let num_groups_synced_1: u32 = bo.conversations().sync_all_conversations().await.unwrap();
         assert!(num_groups_synced_1 == 30);
 
         // Remove bo from all groups and sync
@@ -2659,11 +2659,11 @@ mod tests {
         }
 
         // First sync after removal needs to process all groups and set them to inactive
-        let num_groups_synced_2: u32 = bo.conversations().sync_all_groups().await.unwrap();
+        let num_groups_synced_2: u32 = bo.conversations().sync_all_conversations().await.unwrap();
         assert!(num_groups_synced_2 == 30);
 
         // Second sync after removal will not process inactive groups
-        let num_groups_synced_3: u32 = bo.conversations().sync_all_groups().await.unwrap();
+        let num_groups_synced_3: u32 = bo.conversations().sync_all_conversations().await.unwrap();
         assert!(num_groups_synced_3 == 0);
     }
 
@@ -2686,7 +2686,7 @@ mod tests {
             .unwrap();
 
         bo.conversations().sync().await.unwrap();
-        let bo_group = bo.group(alix_group.id()).unwrap();
+        let bo_group = bo.conversation(alix_group.id()).unwrap();
 
         bo_group.send("bo1".as_bytes().to_vec()).await.unwrap();
         // Temporary workaround for OpenMLS issue - make sure Alix's epoch is up-to-date
@@ -2768,8 +2768,8 @@ mod tests {
         client2.conversations().sync().await.unwrap();
 
         // Find groups for both clients
-        let client1_group = client1.group(group.id()).unwrap();
-        let client2_group = client2.group(group.id()).unwrap();
+        let client1_group = client1.conversation(group.id()).unwrap();
+        let client2_group = client2.conversation(group.id()).unwrap();
 
         // Sync both groups
         client1_group.sync().await.unwrap();
@@ -2801,7 +2801,7 @@ mod tests {
         assert_eq!(client1_members.len(), 2);
 
         client2.conversations().sync().await.unwrap();
-        let client2_group = client2.group(group.id()).unwrap();
+        let client2_group = client2.conversation(group.id()).unwrap();
         let client2_members = client2_group.list_members().await.unwrap();
         assert_eq!(client2_members.len(), 2);
     }
@@ -2840,9 +2840,9 @@ mod tests {
         caro.conversations().sync().await.unwrap();
 
         // Alix and Caro find the group
-        let alix_group = alix.group(group.id()).unwrap();
-        let bo_group = bo.group(group.id()).unwrap();
-        let caro_group = caro.group(group.id()).unwrap();
+        let alix_group = alix.conversation(group.id()).unwrap();
+        let bo_group = bo.conversation(group.id()).unwrap();
+        let caro_group = caro.conversation(group.id()).unwrap();
 
         alix_group.update_installations().await.unwrap();
         log::info!("Alix sending first message");
@@ -2882,7 +2882,7 @@ mod tests {
 
         // New installation of bo finds the group
         bo2.conversations().sync().await.unwrap();
-        let bo2_group = bo2.group(group.id()).unwrap();
+        let bo2_group = bo2.conversation(group.id()).unwrap();
 
         log::info!("Bo sending fourth message");
         // Bo sends a message to the group
@@ -2949,7 +2949,7 @@ mod tests {
 
         bo.conversations().sync().await.unwrap();
 
-        let bo_group = bo.group(alix_group.id()).unwrap();
+        let bo_group = bo.conversation(alix_group.id()).unwrap();
 
         // Move forward 4 epochs
         alix_group
@@ -3020,7 +3020,7 @@ mod tests {
             .unwrap();
 
         bo.conversations().sync().await.unwrap();
-        let bo_group = bo.group(alix_group.id()).unwrap();
+        let bo_group = bo.conversation(alix_group.id()).unwrap();
 
         bo_group.send("bo1".as_bytes().to_vec()).await.unwrap();
         alix_group.send("alix1".as_bytes().to_vec()).await.unwrap();
@@ -3076,7 +3076,7 @@ mod tests {
             .unwrap();
 
         bo.conversations().sync().await.unwrap();
-        let bo_group = bo.group(alix_group.id()).unwrap();
+        let bo_group = bo.conversation(alix_group.id()).unwrap();
 
         alix_group.sync().await.unwrap();
         let alix_members = alix_group.list_members().await.unwrap();
@@ -3293,7 +3293,9 @@ mod tests {
             .unwrap();
 
         bola.inner_client.sync_welcomes().await.unwrap();
-        let bola_group = bola.group(amal_group.group_id.clone()).unwrap();
+        let bola_group = bola
+            .conversation(amal_group.conversation_id.clone())
+            .unwrap();
 
         let stream_callback = RustStreamCallback::default();
         let stream_closer = bola_group.stream(Box::new(stream_callback.clone())).await;
@@ -3895,9 +3897,9 @@ mod tests {
             .create_dm(bola.account_address.clone())
             .await
             .unwrap();
-        let alix_num_sync = alix_conversations.sync_all_groups().await.unwrap();
+        let alix_num_sync = alix_conversations.sync_all_conversations().await.unwrap();
         bola_conversations.sync().await.unwrap();
-        let bola_num_sync = bola_conversations.sync_all_groups().await.unwrap();
+        let bola_num_sync = bola_conversations.sync_all_conversations().await.unwrap();
         assert_eq!(alix_num_sync, 1);
         assert_eq!(bola_num_sync, 1);
 
@@ -3932,7 +3934,7 @@ mod tests {
         assert_eq!(alix_initial_consent, FfiConsentState::Allowed);
 
         bo.conversations().sync().await.unwrap();
-        let bo_group = bo.group(alix_group.id()).unwrap();
+        let bo_group = bo.conversation(alix_group.id()).unwrap();
 
         let bo_initial_consent = bo_group.consent_state().unwrap();
         assert_eq!(bo_initial_consent, FfiConsentState::Unknown);
@@ -3944,7 +3946,7 @@ mod tests {
         assert_eq!(alix_updated_consent, FfiConsentState::Denied);
         bo.set_consent_states(vec![FfiConsent {
             state: FfiConsentState::Allowed,
-            entity_type: FfiConsentEntityType::GroupId,
+            entity_type: FfiConsentEntityType::ConversationId,
             entity: hex::encode(bo_group.id()),
         }])
         .await

--- a/bindings_node/src/consent_state.rs
+++ b/bindings_node/src/consent_state.rs
@@ -38,7 +38,7 @@ pub enum NapiConsentEntityType {
 impl From<NapiConsentEntityType> for ConsentType {
   fn from(entity_type: NapiConsentEntityType) -> Self {
     match entity_type {
-      NapiConsentEntityType::GroupId => ConsentType::GroupId,
+      NapiConsentEntityType::GroupId => ConsentType::ConversationId,
       NapiConsentEntityType::InboxId => ConsentType::InboxId,
       NapiConsentEntityType::Address => ConsentType::Address,
     }

--- a/bindings_node/src/conversations.rs
+++ b/bindings_node/src/conversations.rs
@@ -7,6 +7,7 @@ use napi::threadsafe_function::{ErrorStrategy, ThreadsafeFunction, ThreadsafeFun
 use napi::JsFunction;
 use napi_derive::napi;
 use xmtp_mls::client::FindGroupParams;
+use xmtp_mls::groups::group_metadata::ConversationType;
 use xmtp_mls::groups::{GroupMetadataOptions, PreconfiguredPolicies};
 
 use crate::messages::NapiMessage;
@@ -210,7 +211,7 @@ impl NapiConversations {
           ThreadsafeFunctionCallMode::Blocking,
         );
       },
-      false,
+      Some(ConversationType::Group),
     );
 
     Ok(NapiStreamCloser::new(stream_closer))
@@ -225,6 +226,7 @@ impl NapiConversations {
       move |message| {
         tsfn.call(Ok(message.into()), ThreadsafeFunctionCallMode::Blocking);
       },
+      Some(ConversationType::Group),
     );
 
     Ok(NapiStreamCloser::new(stream_closer))

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -41,8 +41,7 @@ use xmtp_proto::xmtp::mls::api::v1::{
 use crate::{
     api::ApiClientWrapper,
     groups::{
-        group_permissions::PolicySet, validated_commit::CommitValidationError, GroupError,
-        GroupMetadataOptions, IntentError, MlsGroup,
+        group_metadata::ConversationType, group_permissions::PolicySet, validated_commit::CommitValidationError, GroupError, GroupMetadataOptions, IntentError, MlsGroup
     },
     identity::{parse_credential, Identity, IdentityError},
     identity_updates::{load_identity_updates, IdentityUpdateError},
@@ -224,7 +223,7 @@ pub struct FindGroupParams {
     pub created_after_ns: Option<i64>,
     pub created_before_ns: Option<i64>,
     pub limit: Option<i64>,
-    pub include_dm_groups: bool,
+    pub conversation_type: Option<ConversationType>,
 }
 
 /// Clients manage access to the network, identity, and data store
@@ -636,29 +635,7 @@ where
                 params.created_after_ns,
                 params.created_before_ns,
                 params.limit,
-                params.include_dm_groups,
-            )?
-            .into_iter()
-            .map(|stored_group| {
-                MlsGroup::new(
-                    self.context.clone(),
-                    stored_group.id,
-                    stored_group.created_at_ns,
-                )
-            })
-            .collect())
-    }
-
-    pub fn find_dms(&self, params: FindGroupParams) -> Result<Vec<MlsGroup>, ClientError> {
-        Ok(self
-            .store()
-            .conn()?
-            .find_groups(
-                params.allowed_states,
-                params.created_after_ns,
-                params.created_before_ns,
-                params.limit,
-                true,
+                params.conversation_type,
             )?
             .into_iter()
             .map(|stored_group| {

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -649,6 +649,28 @@ where
             .collect())
     }
 
+    pub fn find_dms(&self, params: FindGroupParams) -> Result<Vec<MlsGroup>, ClientError> {
+        Ok(self
+            .store()
+            .conn()?
+            .find_groups(
+                params.allowed_states,
+                params.created_after_ns,
+                params.created_before_ns,
+                params.limit,
+                true,
+            )?
+            .into_iter()
+            .map(|stored_group| {
+                MlsGroup::new(
+                    self.context.clone(),
+                    stored_group.id,
+                    stored_group.created_at_ns,
+                )
+            })
+            .collect())
+    }
+
     /// Upload a Key Package to the network and publish the signed identity update
     /// from the provided SignatureRequest
     pub async fn register_identity(

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -41,7 +41,9 @@ use xmtp_proto::xmtp::mls::api::v1::{
 use crate::{
     api::ApiClientWrapper,
     groups::{
-        group_metadata::ConversationType, group_permissions::PolicySet, validated_commit::CommitValidationError, GroupError, GroupMetadataOptions, IntentError, MlsGroup
+        group_metadata::ConversationType, group_permissions::PolicySet,
+        validated_commit::CommitValidationError, GroupError, GroupMetadataOptions, IntentError,
+        MlsGroup,
     },
     identity::{parse_credential, Identity, IdentityError},
     identity_updates::{load_identity_updates, IdentityUpdateError},

--- a/xmtp_mls/src/groups/message_history.rs
+++ b/xmtp_mls/src/groups/message_history.rs
@@ -25,6 +25,7 @@ use xmtp_proto::{
     },
 };
 
+use super::group_metadata::ConversationType;
 use super::{GroupError, MlsGroup};
 
 use crate::XmtpApi;
@@ -135,7 +136,7 @@ where
 
     pub async fn ensure_member_of_all_groups(&self, inbox_id: String) -> Result<(), GroupError> {
         let conn = self.store().conn()?;
-        let groups = conn.find_groups(None, None, None, None, false)?;
+        let groups = conn.find_groups(None, None, None, None, Some(ConversationType::Group))?;
         for group in groups {
             let group = self.group(group.id)?;
             Box::pin(group.add_members_by_inbox_id(self, vec![inbox_id.clone()])).await?;
@@ -384,7 +385,7 @@ where
             self.sync_welcomes().await?;
 
             let conn = self.store().conn()?;
-            let groups = conn.find_groups(None, None, None, None, false)?;
+            let groups = conn.find_groups(None, None, None, None, Some(ConversationType::Group))?;
             for crate::storage::group::StoredGroup { id, .. } in groups.into_iter() {
                 let group = self.group(id)?;
                 Box::pin(group.sync(self)).await?;
@@ -502,14 +503,14 @@ where
 
     async fn prepare_groups_to_sync(&self) -> Result<Vec<StoredGroup>, MessageHistoryError> {
         let conn = self.store().conn()?;
-        Ok(conn.find_groups(None, None, None, None, false)?)
+        Ok(conn.find_groups(None, None, None, None, Some(ConversationType::Group))?)
     }
 
     async fn prepare_messages_to_sync(
         &self,
     ) -> Result<Vec<StoredGroupMessage>, MessageHistoryError> {
         let conn = self.store().conn()?;
-        let groups = conn.find_groups(None, None, None, None, false)?;
+        let groups = conn.find_groups(None, None, None, None, Some(ConversationType::Group))?;
         let mut all_messages: Vec<StoredGroupMessage> = vec![];
 
         for StoredGroup { id, .. } in groups.into_iter() {

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -381,11 +381,11 @@ impl MlsGroup {
         );
 
         stored_group.store(provider.conn_ref())?;
-        Ok(Self::new(
-            context.clone(),
-            group_id,
-            stored_group.created_at_ns,
-        ))
+        let new_group = Self::new(context.clone(), group_id, stored_group.created_at_ns);
+
+        // Consent state defaults to allowed when the user creates the group
+        new_group.update_consent_state(ConsentState::Allowed)?;
+        Ok(new_group)
     }
 
     // Create a group from a decrypted and decoded welcome message

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -3229,7 +3229,7 @@ mod tests {
         let _ = bola.sync_welcomes().await;
         let bola_groups = bola
             .find_groups(FindGroupParams {
-                include_dm_groups: true,
+                conversation_type: None,
                 ..FindGroupParams::default()
             })
             .unwrap();

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -1041,8 +1041,10 @@ impl MlsGroup {
     /// Find the `consent_state` of the group
     pub fn consent_state(&self) -> Result<ConsentState, GroupError> {
         let conn = self.context.store.conn()?;
-        let record =
-            conn.get_consent_record(hex::encode(self.group_id.clone()), ConsentType::GroupId)?;
+        let record = conn.get_consent_record(
+            hex::encode(self.group_id.clone()),
+            ConsentType::ConversationId,
+        )?;
 
         match record {
             Some(rec) => Ok(rec.state),
@@ -1053,7 +1055,7 @@ impl MlsGroup {
     pub fn update_consent_state(&self, state: ConsentState) -> Result<(), GroupError> {
         let conn = self.context.store.conn()?;
         conn.insert_or_replace_consent_records(vec![StoredConsentRecord::new(
-            ConsentType::GroupId,
+            ConsentType::ConversationId,
             state,
             hex::encode(self.group_id.clone()),
         )])?;

--- a/xmtp_mls/src/storage/encrypted_store/consent_record.rs
+++ b/xmtp_mls/src/storage/encrypted_store/consent_record.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 #[diesel(table_name = consent_records)]
 #[diesel(primary_key(entity_type, entity))]
 pub struct StoredConsentRecord {
-    /// Enum, [`ConsentType`] representing the type of consent (group_id inbox_id, etc..)
+    /// Enum, [`ConsentType`] representing the type of consent (conversation_id inbox_id, etc..)
     pub entity_type: ConsentType,
     /// Enum, [`ConsentState`] representing the state of consent (allowed, denied, etc..)
     pub state: ConsentState,
@@ -85,8 +85,8 @@ impl DbConnection {
 #[diesel(sql_type = Integer)]
 /// Type of consent record stored
 pub enum ConsentType {
-    /// Consent is for a group
-    GroupId = 1,
+    /// Consent is for a conversation
+    ConversationId = 1,
     /// Consent is for an inbox
     InboxId = 2,
     /// Consent is for an address
@@ -109,7 +109,7 @@ where
 {
     fn from_sql(bytes: <Sqlite as Backend>::RawValue<'_>) -> deserialize::Result<Self> {
         match i32::from_sql(bytes)? {
-            1 => Ok(ConsentType::GroupId),
+            1 => Ok(ConsentType::ConversationId),
             2 => Ok(ConsentType::InboxId),
             3 => Ok(ConsentType::Address),
             x => Err(format!("Unrecognized variant {}", x).into()),

--- a/xmtp_mls/src/storage/encrypted_store/group.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group.rs
@@ -15,7 +15,9 @@ use super::{
     db_connection::DbConnection,
     schema::{groups, groups::dsl},
 };
-use crate::{groups::group_metadata::ConversationType, impl_fetch, impl_store, DuplicateItem, StorageError};
+use crate::{
+    groups::group_metadata::ConversationType, impl_fetch, impl_store, DuplicateItem, StorageError,
+};
 
 /// The Group ID type.
 pub type ID = Vec<u8>;
@@ -150,7 +152,7 @@ impl DbConnection {
                 ConversationType::Dm => {
                     query = query.filter(dsl::dm_inbox_id.is_not_null());
                 }
-                ConversationType::Sync => {},
+                ConversationType::Sync => {}
             }
         }
 
@@ -468,7 +470,9 @@ pub(crate) mod tests {
             let test_group_3 = generate_dm(Some(GroupMembershipState::Allowed));
             test_group_3.store(conn).unwrap();
 
-            let all_results = conn.find_groups(None, None, None, None, Some(ConversationType::Group)).unwrap();
+            let all_results = conn
+                .find_groups(None, None, None, None, Some(ConversationType::Group))
+                .unwrap();
             assert_eq!(all_results.len(), 2);
 
             let pending_results = conn
@@ -484,12 +488,20 @@ pub(crate) mod tests {
             assert_eq!(pending_results.len(), 1);
 
             // Offset and limit
-            let results_with_limit = conn.find_groups(None, None, None, Some(1), Some(ConversationType::Group)).unwrap();
+            let results_with_limit = conn
+                .find_groups(None, None, None, Some(1), Some(ConversationType::Group))
+                .unwrap();
             assert_eq!(results_with_limit.len(), 1);
             assert_eq!(results_with_limit[0].id, test_group_1.id);
 
             let results_with_created_at_ns_after = conn
-                .find_groups(None, Some(test_group_1.created_at_ns), None, Some(1), Some(ConversationType::Group))
+                .find_groups(
+                    None,
+                    Some(test_group_1.created_at_ns),
+                    None,
+                    Some(1),
+                    Some(ConversationType::Group),
+                )
                 .unwrap();
             assert_eq!(results_with_created_at_ns_after.len(), 1);
             assert_eq!(results_with_created_at_ns_after[0].id, test_group_2.id);
@@ -504,7 +516,9 @@ pub(crate) mod tests {
             assert_eq!(dm_results[2].id, test_group_3.id);
 
             // test only dms are returned
-            let dm_results = conn.find_groups(None, None, None, None, Some(ConversationType::Dm)).unwrap();
+            let dm_results = conn
+                .find_groups(None, None, None, None, Some(ConversationType::Dm))
+                .unwrap();
             assert_eq!(dm_results.len(), 1);
             assert_eq!(dm_results[0].id, test_group_3.id);
         })

--- a/xmtp_mls/src/storage/encrypted_store/group.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group.rs
@@ -15,7 +15,7 @@ use super::{
     db_connection::DbConnection,
     schema::{groups, groups::dsl},
 };
-use crate::{impl_fetch, impl_store, DuplicateItem, StorageError};
+use crate::{groups::group_metadata::ConversationType, impl_fetch, impl_store, DuplicateItem, StorageError};
 
 /// The Group ID type.
 pub type ID = Vec<u8>;
@@ -122,7 +122,7 @@ impl DbConnection {
         created_after_ns: Option<i64>,
         created_before_ns: Option<i64>,
         limit: Option<i64>,
-        include_dm_groups: bool,
+        conversation_type: Option<ConversationType>,
     ) -> Result<Vec<StoredGroup>, StorageError> {
         let mut query = dsl::groups.order(dsl::created_at_ns.asc()).into_boxed();
 
@@ -142,41 +142,18 @@ impl DbConnection {
             query = query.limit(limit);
         }
 
-        if !include_dm_groups {
-            query = query.filter(dsl::dm_inbox_id.is_null());
+        if let Some(conversation_type) = conversation_type {
+            match conversation_type {
+                ConversationType::Group => {
+                    query = query.filter(dsl::dm_inbox_id.is_null());
+                }
+                ConversationType::Dm => {
+                    query = query.filter(dsl::dm_inbox_id.is_not_null());
+                }
+                ConversationType::Sync => {},
+            }
         }
 
-        query = query.filter(dsl::purpose.eq(Purpose::Conversation));
-
-        Ok(self.raw_query(|conn| query.load(conn))?)
-    }
-
-    pub fn find_dms(
-        &self,
-        allowed_states: Option<Vec<GroupMembershipState>>,
-        created_after_ns: Option<i64>,
-        created_before_ns: Option<i64>,
-        limit: Option<i64>,
-    ) -> Result<Vec<StoredGroup>, StorageError> {
-        let mut query = dsl::groups.order(dsl::created_at_ns.asc()).into_boxed();
-
-        if let Some(allowed_states) = allowed_states {
-            query = query.filter(dsl::membership_state.eq_any(allowed_states));
-        }
-
-        if let Some(created_after_ns) = created_after_ns {
-            query = query.filter(dsl::created_at_ns.gt(created_after_ns));
-        }
-
-        if let Some(created_before_ns) = created_before_ns {
-            query = query.filter(dsl::created_at_ns.lt(created_before_ns));
-        }
-
-        if let Some(limit) = limit {
-            query = query.limit(limit);
-        }
-
-        query = query.filter(dsl::dm_inbox_id.is_not_null());
         query = query.filter(dsl::purpose.eq(Purpose::Conversation));
 
         Ok(self.raw_query(|conn| query.load(conn))?)
@@ -491,7 +468,7 @@ pub(crate) mod tests {
             let test_group_3 = generate_dm(Some(GroupMembershipState::Allowed));
             test_group_3.store(conn).unwrap();
 
-            let all_results = conn.find_groups(None, None, None, None, false).unwrap();
+            let all_results = conn.find_groups(None, None, None, None, Some(ConversationType::Group)).unwrap();
             assert_eq!(all_results.len(), 2);
 
             let pending_results = conn
@@ -500,19 +477,19 @@ pub(crate) mod tests {
                     None,
                     None,
                     None,
-                    false,
+                    Some(ConversationType::Group),
                 )
                 .unwrap();
             assert_eq!(pending_results[0].id, test_group_1.id);
             assert_eq!(pending_results.len(), 1);
 
             // Offset and limit
-            let results_with_limit = conn.find_groups(None, None, None, Some(1), false).unwrap();
+            let results_with_limit = conn.find_groups(None, None, None, Some(1), Some(ConversationType::Group)).unwrap();
             assert_eq!(results_with_limit.len(), 1);
             assert_eq!(results_with_limit[0].id, test_group_1.id);
 
             let results_with_created_at_ns_after = conn
-                .find_groups(None, Some(test_group_1.created_at_ns), None, Some(1), false)
+                .find_groups(None, Some(test_group_1.created_at_ns), None, Some(1), Some(ConversationType::Group))
                 .unwrap();
             assert_eq!(results_with_created_at_ns_after.len(), 1);
             assert_eq!(results_with_created_at_ns_after[0].id, test_group_2.id);
@@ -522,9 +499,14 @@ pub(crate) mod tests {
             assert_eq!(synced_groups.len(), 0);
 
             // test that dm groups are included
-            let dm_results = conn.find_groups(None, None, None, None, true).unwrap();
+            let dm_results = conn.find_groups(None, None, None, None, None).unwrap();
             assert_eq!(dm_results.len(), 3);
             assert_eq!(dm_results[2].id, test_group_3.id);
+
+            // test only dms are returned
+            let dm_results = conn.find_groups(None, None, None, None, Some(ConversationType::Dm)).unwrap();
+            assert_eq!(dm_results.len(), 1);
+            assert_eq!(dm_results[0].id, test_group_3.id);
         })
     }
 

--- a/xmtp_mls/src/subscriptions.rs
+++ b/xmtp_mls/src/subscriptions.rs
@@ -896,7 +896,11 @@ mod tests {
         let closer = Client::<TestClient>::stream_conversations_with_callback(
             alix.clone(),
             move |g| {
-                let mut groups: parking_lot::lock_api::MutexGuard<'_, parking_lot::RawMutex, Vec<crate::groups::MlsGroup>> = groups_pointer.lock();
+                let mut groups: parking_lot::lock_api::MutexGuard<
+                    '_,
+                    parking_lot::RawMutex,
+                    Vec<crate::groups::MlsGroup>,
+                > = groups_pointer.lock();
                 groups.push(g);
                 notify_pointer.notify_one();
             },
@@ -920,7 +924,6 @@ mod tests {
             let grps = groups.lock();
             assert_eq!(grps.len(), 1);
         }
-
 
         closer.handle.abort();
 
@@ -998,7 +1001,11 @@ mod tests {
         let mut closer = Client::<TestClient>::stream_all_messages_with_callback(
             bo.clone(),
             move |message| {
-                let mut messages: parking_lot::lock_api::MutexGuard<'_, parking_lot::RawMutex, Vec<StoredGroupMessage>> = messages_pointer.lock();
+                let mut messages: parking_lot::lock_api::MutexGuard<
+                    '_,
+                    parking_lot::RawMutex,
+                    Vec<StoredGroupMessage>,
+                > = messages_pointer.lock();
                 messages.push(message);
                 notify_pointer.notify_one();
             },
@@ -1036,7 +1043,11 @@ mod tests {
         let mut closer = Client::<TestClient>::stream_all_messages_with_callback(
             bo.clone(),
             move |message| {
-                let mut messages: parking_lot::lock_api::MutexGuard<'_, parking_lot::RawMutex, Vec<StoredGroupMessage>> = messages_pointer.lock();
+                let mut messages: parking_lot::lock_api::MutexGuard<
+                    '_,
+                    parking_lot::RawMutex,
+                    Vec<StoredGroupMessage>,
+                > = messages_pointer.lock();
                 messages.push(message);
                 notify_pointer.notify_one();
             },
@@ -1050,7 +1061,10 @@ mod tests {
             .unwrap();
 
         let result = notify.wait_for_delivery().await;
-        assert!(result.is_err(), "Stream unexpectedly received a Group message");
+        assert!(
+            result.is_err(),
+            "Stream unexpectedly received a Group message"
+        );
 
         alix_dm
             .send_message("second".as_bytes(), &alix)
@@ -1065,7 +1079,6 @@ mod tests {
 
         closer.handle.abort();
 
-
         // Start a stream with all conversations
         let messages: Arc<Mutex<Vec<StoredGroupMessage>>> = Arc::new(Mutex::new(Vec::new()));
         // Wait for 2 seconds for the group creation to be streamed
@@ -1075,7 +1088,11 @@ mod tests {
         let mut closer = Client::<TestClient>::stream_all_messages_with_callback(
             bo.clone(),
             move |message| {
-                let mut messages: parking_lot::lock_api::MutexGuard<'_, parking_lot::RawMutex, Vec<StoredGroupMessage>> = messages_pointer.lock();
+                let mut messages: parking_lot::lock_api::MutexGuard<
+                    '_,
+                    parking_lot::RawMutex,
+                    Vec<StoredGroupMessage>,
+                > = messages_pointer.lock();
                 messages.push(message);
                 notify_pointer.notify_one();
             },


### PR DESCRIPTION
Closes https://github.com/xmtp/libxmtp/issues/1130

Brings the language in the bindings more inline with conversation than group to make it easier to understand with groupDMs.

Adds a bunch of specific dm and group functionality to allow backwards compatibility for V2 migrations.