### PR TITLE
fix: Project Name Error

### DIFF
--- a/xmtp_user_preferences/README.md
+++ b/xmtp_user_preferences/README.md
@@ -1,3 +1,3 @@
-# XTMP Personal Private Portable Preferences
+# XMTP Personal Private Portable Preferences
 
 A library for encrypting messages where the sender and recipient are the same (self-messaging).


### PR DESCRIPTION
I noticed that the project name was incorrectly written as **XTMP** instead of **XMTP** in the documentation. PR corrects the typo to ensure accuracy and consistency throughout the project materials. Please review to ensure the quality and accuracy of the documentation.