### PR TITLE
Add more constructors to WASM bindings

### DIFF
--- a/bindings_wasm/src/consent_state.rs
+++ b/bindings_wasm/src/consent_state.rs
@@ -54,6 +54,18 @@ pub struct WasmConsent {
   pub entity: String,
 }
 
+#[wasm_bindgen]
+impl WasmConsent {
+  #[wasm_bindgen(constructor)]
+  pub fn new(entity_type: WasmConsentEntityType, state: WasmConsentState, entity: String) -> Self {
+    Self {
+      entity_type,
+      state,
+      entity,
+    }
+  }
+}
+
 impl From<WasmConsent> for StoredConsentRecord {
   fn from(consent: WasmConsent) -> Self {
     Self {

--- a/bindings_wasm/src/conversations.rs
+++ b/bindings_wasm/src/conversations.rs
@@ -15,6 +15,22 @@ pub struct WasmListConversationsOptions {
   pub limit: Option<i64>,
 }
 
+#[wasm_bindgen]
+impl WasmListConversationsOptions {
+  #[wasm_bindgen(constructor)]
+  pub fn new(
+    created_after_ns: Option<i64>,
+    created_before_ns: Option<i64>,
+    limit: Option<i64>,
+  ) -> Self {
+    Self {
+      created_after_ns,
+      created_before_ns,
+      limit,
+    }
+  }
+}
+
 #[wasm_bindgen(getter_with_clone)]
 #[derive(Clone)]
 pub struct WasmCreateGroupOptions {
@@ -23,6 +39,26 @@ pub struct WasmCreateGroupOptions {
   pub group_image_url_square: Option<String>,
   pub group_description: Option<String>,
   pub group_pinned_frame_url: Option<String>,
+}
+
+#[wasm_bindgen]
+impl WasmCreateGroupOptions {
+  #[wasm_bindgen(constructor)]
+  pub fn new(
+    permissions: Option<WasmGroupPermissionsOptions>,
+    group_name: Option<String>,
+    group_image_url_square: Option<String>,
+    group_description: Option<String>,
+    group_pinned_frame_url: Option<String>,
+  ) -> Self {
+    Self {
+      permissions,
+      group_name,
+      group_image_url_square,
+      group_description,
+      group_pinned_frame_url,
+    }
+  }
 }
 
 impl WasmCreateGroupOptions {

--- a/bindings_wasm/src/encoded_content.rs
+++ b/bindings_wasm/src/encoded_content.rs
@@ -20,8 +20,8 @@ impl WasmContentTypeId {
     type_id: String,
     version_major: u32,
     version_minor: u32,
-  ) -> WasmContentTypeId {
-    WasmContentTypeId {
+  ) -> Self {
+    Self {
       authority_id,
       type_id,
       version_major,

--- a/bindings_wasm/src/groups.rs
+++ b/bindings_wasm/src/groups.rs
@@ -57,6 +57,26 @@ pub struct WasmGroupMember {
 }
 
 #[wasm_bindgen]
+impl WasmGroupMember {
+  #[wasm_bindgen(constructor)]
+  pub fn new(
+    inbox_id: String,
+    account_addresses: Vec<String>,
+    installation_ids: Vec<String>,
+    permission_level: WasmPermissionLevel,
+    consent_state: WasmConsentState,
+  ) -> Self {
+    Self {
+      inbox_id,
+      account_addresses,
+      installation_ids,
+      permission_level,
+      consent_state,
+    }
+  }
+}
+
+#[wasm_bindgen]
 pub struct WasmGroup {
   inner_client: Arc<RustXmtpClient>,
   group_id: Vec<u8>,

--- a/bindings_wasm/src/inbox_state.rs
+++ b/bindings_wasm/src/inbox_state.rs
@@ -9,12 +9,41 @@ pub struct WasmInstallation {
   pub client_timestamp_ns: Option<u64>,
 }
 
+#[wasm_bindgen]
+impl WasmInstallation {
+  #[wasm_bindgen(constructor)]
+  pub fn new(id: String, client_timestamp_ns: Option<u64>) -> Self {
+    Self {
+      id,
+      client_timestamp_ns,
+    }
+  }
+}
+
 #[wasm_bindgen(getter_with_clone)]
 pub struct WasmInboxState {
   pub inbox_id: String,
   pub recovery_address: String,
   pub installations: Vec<WasmInstallation>,
   pub account_addresses: Vec<String>,
+}
+
+#[wasm_bindgen]
+impl WasmInboxState {
+  #[wasm_bindgen(constructor)]
+  pub fn new(
+    inbox_id: String,
+    recovery_address: String,
+    installations: Vec<WasmInstallation>,
+    account_addresses: Vec<String>,
+  ) -> Self {
+    Self {
+      inbox_id,
+      recovery_address,
+      installations,
+      account_addresses,
+    }
+  }
 }
 
 impl From<AssociationState> for WasmInboxState {

--- a/bindings_wasm/src/messages.rs
+++ b/bindings_wasm/src/messages.rs
@@ -58,6 +58,24 @@ pub struct WasmListMessagesOptions {
   pub delivery_status: Option<WasmDeliveryStatus>,
 }
 
+#[wasm_bindgen]
+impl WasmListMessagesOptions {
+  #[wasm_bindgen(constructor)]
+  pub fn new(
+    sent_before_ns: Option<i64>,
+    sent_after_ns: Option<i64>,
+    limit: Option<i64>,
+    delivery_status: Option<WasmDeliveryStatus>,
+  ) -> Self {
+    Self {
+      sent_before_ns,
+      sent_after_ns,
+      limit,
+      delivery_status,
+    }
+  }
+}
+
 #[wasm_bindgen(getter_with_clone)]
 #[derive(Clone)]
 pub struct WasmMessage {
@@ -68,6 +86,30 @@ pub struct WasmMessage {
   pub content: WasmEncodedContent,
   pub kind: WasmGroupMessageKind,
   pub delivery_status: WasmDeliveryStatus,
+}
+
+#[wasm_bindgen]
+impl WasmMessage {
+  #[wasm_bindgen(constructor)]
+  pub fn new(
+    id: String,
+    sent_at_ns: i64,
+    convo_id: String,
+    sender_inbox_id: String,
+    content: WasmEncodedContent,
+    kind: WasmGroupMessageKind,
+    delivery_status: WasmDeliveryStatus,
+  ) -> Self {
+    Self {
+      id,
+      sent_at_ns,
+      convo_id,
+      sender_inbox_id,
+      content,
+      kind,
+      delivery_status,
+    }
+  }
 }
 
 impl From<StoredGroupMessage> for WasmMessage {

--- a/bindings_wasm/src/permissions.rs
+++ b/bindings_wasm/src/permissions.rs
@@ -120,6 +120,33 @@ pub struct WasmPermissionPolicySet {
   pub update_group_pinned_frame_url_policy: WasmPermissionPolicy,
 }
 
+#[wasm_bindgen]
+impl WasmPermissionPolicySet {
+  #[wasm_bindgen(constructor)]
+  #[allow(clippy::too_many_arguments)]
+  pub fn new(
+    add_member_policy: WasmPermissionPolicy,
+    remove_member_policy: WasmPermissionPolicy,
+    add_admin_policy: WasmPermissionPolicy,
+    remove_admin_policy: WasmPermissionPolicy,
+    update_group_name_policy: WasmPermissionPolicy,
+    update_group_description_policy: WasmPermissionPolicy,
+    update_group_image_url_square_policy: WasmPermissionPolicy,
+    update_group_pinned_frame_url_policy: WasmPermissionPolicy,
+  ) -> Self {
+    Self {
+      add_member_policy,
+      remove_member_policy,
+      add_admin_policy,
+      remove_admin_policy,
+      update_group_name_policy,
+      update_group_description_policy,
+      update_group_image_url_square_policy,
+      update_group_pinned_frame_url_policy,
+    }
+  }
+}
+
 impl From<PreconfiguredPolicies> for WasmGroupPermissionsOptions {
   fn from(policy: PreconfiguredPolicies) -> Self {
     match policy {
@@ -142,7 +169,6 @@ impl WasmGroupPermissions {
 
 #[wasm_bindgen]
 impl WasmGroupPermissions {
-  #[wasm_bindgen]
   #[wasm_bindgen]
   pub fn policy_type(&self) -> Result<WasmGroupPermissionsOptions, JsError> {
     if let Ok(preconfigured_policy) = self.inner.preconfigured_policy() {


### PR DESCRIPTION
# Summary

This PR adds constructors to most structs that don't already have them. It's important for these constructors to be available in JavaScript so that it can pass in expected values to rust.