### PR TITLE
Add lint workflow for WASM bindings

### DIFF
--- a/.github/workflows/lint-wasm-bindings.yaml
+++ b/.github/workflows/lint-wasm-bindings.yaml
@@ -1,0 +1,32 @@
+name: Lint WASM Bindings
+
+on:
+  pull_request:
+    paths:
+      - "bindings_wasm/**"
+      - ".github/workflows/lint-wasm-bindings.yaml"
+      - "rustfmt.toml"
+env:
+  CARGO_TERM_COLOR: always
+jobs:
+  lint:
+    name: Lint
+    runs-on: warp-ubuntu-latest-x64-16x
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Update rust toolchains
+        run: rustup update
+
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            bindings_wasm
+
+      - name: Run clippy and fail on warnings
+        run: cargo clippy --manifest-path bindings_wasm/Cargo.toml --all-features --all-targets --no-deps -- -Dwarnings
+
+      - name: Run format check
+        run: cargo fmt --manifest-path bindings_wasm/Cargo.toml --check


### PR DESCRIPTION
# Summary

Added a GitHub workflow for linting the WASM bindings.