### PR TITLE
Fix release pattern

### DIFF
--- a/.github/workflows/release-mls-validation-service.yml
+++ b/.github/workflows/release-mls-validation-service.yml
@@ -32,7 +32,7 @@ jobs:
           images: ghcr.io/xmtp/mls-validation-service
           tags: |
             type=ref,event=tag
-            type=semver,pattern={{version}}
+            type=match,pattern={{mls-validation-service-v(\d.\d.\d)}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6

--- a/.github/workflows/release-mls-validation-service.yml
+++ b/.github/workflows/release-mls-validation-service.yml
@@ -32,7 +32,7 @@ jobs:
           images: ghcr.io/xmtp/mls-validation-service
           tags: |
             type=ref,event=tag
-            type=match,pattern={{mls-validation-service-v(\d.\d.\d)}}
+            type=match,pattern={{mls-validation-service-(.*)}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6


### PR DESCRIPTION
#1160 was almost right, but not quite:
```
Processing flavor input
Warning: mls-validation-service-v0.1.0 is not a valid semver. More info: https://semver.org/
Docker image version
  mls-validation-service-v0.1.0
Docker tags
  ghcr.io/xmtp/mls-validation-service:mls-validation-service-v0.1.0
  ghcr.io/xmtp/mls-validation-service:latest
```

Use [`pattern`](https://github.com/docker/metadata-action?tab=readme-ov-file#typematch) instead