### PR TITLE
Add ability to order messages

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -3404,11 +3404,7 @@ mod tests {
         // Bola gets the group id. This will be needed to fetch the group from
         // the database.
         let bola_groups = bola_conversations
-            .list(crate::FfiListConversationsOptions {
-                created_after_ns: None,
-                created_before_ns: None,
-                limit: None,
-            })
+            .list(FfiListConversationsOptions::default())
             .await
             .unwrap();
 
@@ -3595,11 +3591,7 @@ mod tests {
         let bola_conversations = bola.conversations();
         let _ = bola_conversations.sync().await;
         let bola_groups = bola_conversations
-            .list(crate::FfiListConversationsOptions {
-                created_after_ns: None,
-                created_before_ns: None,
-                limit: None,
-            })
+            .list(FfiListConversationsOptions::default())
             .await
             .unwrap();
 
@@ -3704,11 +3696,7 @@ mod tests {
         let bola_conversations = bola.conversations();
         let _ = bola_conversations.sync().await;
         let bola_groups = bola_conversations
-            .list(crate::FfiListConversationsOptions {
-                created_after_ns: None,
-                created_before_ns: None,
-                limit: None,
-            })
+            .list(FfiListConversationsOptions::default())
             .await
             .unwrap();
 

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -528,7 +528,6 @@ pub struct FfiListConversationsOptions {
     pub created_after_ns: Option<i64>,
     pub created_before_ns: Option<i64>,
     pub limit: Option<i64>,
-    pub consent_state: Option<FfiConsentState>,
 }
 
 #[derive(uniffi::Object)]

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -15,6 +15,7 @@ use xmtp_id::{
     },
     InboxId,
 };
+use xmtp_mls::storage::group_message::SortDirection;
 use xmtp_mls::{
     api::ApiClientWrapper,
     builder::ClientBuilder,
@@ -40,7 +41,6 @@ use xmtp_mls::{
     },
     AbortHandle, GenericStreamHandle, StreamHandle,
 };
-use xmtp_proto::xmtp::mls::api::v1::SortDirection;
 
 pub type RustXmtpClient = MlsClient<TonicApiClient>;
 
@@ -887,7 +887,6 @@ impl FfiConversations {
                 created_before_ns: opts.created_before_ns,
                 limit: opts.limit,
                 conversation_type: None,
-                consent_state: opts.consent_state.into(),
             })?
             .into_iter()
             .map(|group| {
@@ -914,7 +913,6 @@ impl FfiConversations {
                 created_before_ns: opts.created_before_ns,
                 limit: opts.limit,
                 conversation_type: Some(ConversationType::Group),
-                consent_state: opts.consent_state.into(),
             })?
             .into_iter()
             .map(|group| {
@@ -941,7 +939,6 @@ impl FfiConversations {
                 created_before_ns: opts.created_before_ns,
                 limit: opts.limit,
                 conversation_type: Some(ConversationType::Dm),
-                consent_state: opts.consent_state.into(),
             })?
             .into_iter()
             .map(|group| {
@@ -1221,14 +1218,17 @@ impl FfiConversation {
             self.created_at_ns,
         );
 
+        let delivery_status = opts.delivery_status.map(|status| status.into());
+        let direction = opts.direction.map(|dir| dir.into());
+
         let messages: Vec<FfiMessage> = group
             .find_messages(
                 None,
                 opts.sent_before_ns,
                 opts.sent_after_ns,
-                opts.delivery_status.into(),
+                delivery_status,
                 opts.limit,
-                opts.direction.into(),
+                direction,
             )?
             .into_iter()
             .map(|msg| msg.into())

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -528,6 +528,7 @@ pub struct FfiListConversationsOptions {
     pub created_after_ns: Option<i64>,
     pub created_before_ns: Option<i64>,
     pub limit: Option<i64>,
+    pub consent_state: Option<FfiConsentState>,
 }
 
 #[derive(uniffi::Object)]
@@ -886,6 +887,7 @@ impl FfiConversations {
                 created_before_ns: opts.created_before_ns,
                 limit: opts.limit,
                 conversation_type: None,
+                consent_state: opts.consent_state.into(),
             })?
             .into_iter()
             .map(|group| {
@@ -912,6 +914,7 @@ impl FfiConversations {
                 created_before_ns: opts.created_before_ns,
                 limit: opts.limit,
                 conversation_type: Some(ConversationType::Group),
+                consent_state: opts.consent_state.into(),
             })?
             .into_iter()
             .map(|group| {
@@ -938,6 +941,7 @@ impl FfiConversations {
                 created_before_ns: opts.created_before_ns,
                 limit: opts.limit,
                 conversation_type: Some(ConversationType::Dm),
+                consent_state: opts.consent_state.into(),
             })?
             .into_iter()
             .map(|group| {

--- a/bindings_node/src/groups.rs
+++ b/bindings_node/src/groups.rs
@@ -172,6 +172,7 @@ impl NapiGroup {
         opts.sent_after_ns,
         delivery_status,
         opts.limit,
+        None,
       )
       .map_err(ErrorWrapper::from)?
       .into_iter()

--- a/bindings_wasm/src/groups.rs
+++ b/bindings_wasm/src/groups.rs
@@ -194,6 +194,7 @@ impl WasmGroup {
         opts.sent_after_ns,
         delivery_status,
         opts.limit,
+        None,
       )
       .map_err(|e| JsError::new(&format!("{e}")))?
       .into_iter()

--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -253,7 +253,9 @@ async fn main() {
                 .await
                 .expect("failed to get group");
 
-            let messages = group.find_messages(None, None, None, None, None).unwrap();
+            let messages = group
+                .find_messages(None, None, None, None, None, None)
+                .unwrap();
             if cli.json {
                 let json_serializable_messages = messages
                     .iter()
@@ -386,7 +388,14 @@ async fn main() {
             let group_id_str = hex::encode(group.group_id.clone());
             group.sync().await.unwrap();
             let messages = group
-                .find_messages(Some(GroupMessageKind::Application), None, None, None, None)
+                .find_messages(
+                    Some(GroupMessageKind::Application),
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                )
                 .unwrap();
             info!("Listing history sync messages", { group_id: group_id_str, messages: messages.len()});
             for message in messages {

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -224,6 +224,7 @@ pub struct FindGroupParams {
     pub created_before_ns: Option<i64>,
     pub limit: Option<i64>,
     pub conversation_type: Option<ConversationType>,
+    pub consent_state: Option<ConsentState>,
 }
 
 /// Clients manage access to the network, identity, and data store
@@ -691,6 +692,7 @@ where
                 params.created_before_ns,
                 params.limit,
                 params.conversation_type,
+                params.consent_state,
             )?
             .into_iter()
             .map(|stored_group| {

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -224,7 +224,6 @@ pub struct FindGroupParams {
     pub created_before_ns: Option<i64>,
     pub limit: Option<i64>,
     pub conversation_type: Option<ConversationType>,
-    pub consent_state: Option<ConsentState>,
 }
 
 /// Clients manage access to the network, identity, and data store
@@ -692,7 +691,6 @@ where
                 params.created_before_ns,
                 params.limit,
                 params.conversation_type,
-                params.consent_state,
             )?
             .into_iter()
             .map(|stored_group| {

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -1168,12 +1168,12 @@ pub(crate) mod tests {
         let bo_groups = bo.find_groups(FindGroupParams::default()).unwrap();
         let bo_group1 = bo.group(alix_bo_group1.clone().group_id).unwrap();
         let bo_messages1 = bo_group1
-            .find_messages(None, None, None, None, None)
+            .find_messages(None, None, None, None, None, None)
             .unwrap();
         assert_eq!(bo_messages1.len(), 0);
         let bo_group2 = bo.group(alix_bo_group2.clone().group_id).unwrap();
         let bo_messages2 = bo_group2
-            .find_messages(None, None, None, None, None)
+            .find_messages(None, None, None, None, None, None)
             .unwrap();
         assert_eq!(bo_messages2.len(), 0);
         alix_bo_group1
@@ -1188,12 +1188,12 @@ pub(crate) mod tests {
         bo.sync_all_groups(bo_groups).await.unwrap();
 
         let bo_messages1 = bo_group1
-            .find_messages(None, None, None, None, None)
+            .find_messages(None, None, None, None, None, None)
             .unwrap();
         assert_eq!(bo_messages1.len(), 1);
         let bo_group2 = bo.group(alix_bo_group2.clone().group_id).unwrap();
         let bo_messages2 = bo_group2
-            .find_messages(None, None, None, None, None)
+            .find_messages(None, None, None, None, None, None)
             .unwrap();
         assert_eq!(bo_messages2.len(), 1);
     }
@@ -1257,7 +1257,7 @@ pub(crate) mod tests {
 
         // Bola should have one readable message (them being added to the group)
         let mut bola_messages = bola_group
-            .find_messages(None, None, None, None, None)
+            .find_messages(None, None, None, None, None, None)
             .unwrap();
 
         assert_eq!(bola_messages.len(), 1);
@@ -1279,7 +1279,7 @@ pub(crate) mod tests {
         bola_group.sync().await.unwrap();
         // Find Bola's updated list of messages
         bola_messages = bola_group
-            .find_messages(None, None, None, None, None)
+            .find_messages(None, None, None, None, None, None)
             .unwrap();
         // Bola should have been able to decrypt the last message
         assert_eq!(bola_messages.len(), 2);

--- a/xmtp_mls/src/groups/message_history.rs
+++ b/xmtp_mls/src/groups/message_history.rs
@@ -162,6 +162,7 @@ where
             None,
             None,
             None,
+            None,
         )?;
 
         let last_message = messages.last();
@@ -216,6 +217,7 @@ where
 
         let messages = sync_group.find_messages(
             Some(GroupMessageKind::Application),
+            None,
             None,
             None,
             None,
@@ -288,6 +290,7 @@ where
             None,
             None,
             None,
+            None,
         )?;
         let last_message = messages.last();
 
@@ -332,6 +335,7 @@ where
 
         let messages = sync_group.find_messages(
             Some(GroupMessageKind::Application),
+            None,
             None,
             None,
             None,
@@ -407,6 +411,7 @@ where
         let sync_group = self.get_sync_group()?;
         let requests = sync_group.find_messages(
             Some(GroupMessageKind::Application),
+            None,
             None,
             None,
             None,
@@ -516,7 +521,7 @@ where
         let mut all_messages: Vec<StoredGroupMessage> = vec![];
 
         for StoredGroup { id, .. } in groups.into_iter() {
-            let messages = conn.get_group_messages(id, None, None, None, None, None)?;
+            let messages = conn.get_group_messages(id, None, None, None, None, None, None)?;
             all_messages.extend(messages);
         }
 
@@ -860,7 +865,14 @@ pub(crate) mod tests {
         // make sure there's only 1 message in the sync group
         let sync_group = client.get_sync_group().unwrap();
         let messages = sync_group
-            .find_messages(Some(GroupMessageKind::Application), None, None, None, None)
+            .find_messages(
+                Some(GroupMessageKind::Application),
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
             .unwrap();
         assert_eq!(messages.len(), 1);
     }
@@ -905,7 +917,14 @@ pub(crate) mod tests {
         // make sure there's 2 messages in the sync group
         let sync_group = client.get_sync_group().unwrap();
         let messages = sync_group
-            .find_messages(Some(GroupMessageKind::Application), None, None, None, None)
+            .find_messages(
+                Some(GroupMessageKind::Application),
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
             .unwrap();
         assert_eq!(messages.len(), 2);
     }
@@ -1055,7 +1074,15 @@ pub(crate) mod tests {
 
         let amal_b_conn = amal_b.store().conn().unwrap();
         let amal_b_messages = amal_b_conn
-            .get_group_messages(amal_b_sync_group.group_id, None, None, None, None, None)
+            .get_group_messages(
+                amal_b_sync_group.group_id,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
             .unwrap();
 
         assert_eq!(amal_b_messages.len(), 1);

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -1549,7 +1549,9 @@ pub(crate) mod tests {
 
     async fn get_latest_message(group: &MlsGroup<FullXmtpClient>) -> StoredGroupMessage {
         group.sync().await.unwrap();
-        let mut messages = group.find_messages(None, None, None, None, None, None).unwrap();
+        let mut messages = group
+            .find_messages(None, None, None, None, None, None)
+            .unwrap();
         messages.pop().unwrap()
     }
 
@@ -1633,7 +1635,9 @@ pub(crate) mod tests {
             .await
             .unwrap();
         // Check for messages
-        let messages = group.find_messages(None, None, None, None, None, None).unwrap();
+        let messages = group
+            .find_messages(None, None, None, None, None, None)
+            .unwrap();
         assert_eq!(messages.len(), 1);
         assert_eq!(messages.first().unwrap().decrypted_message_bytes, msg);
     }
@@ -1927,7 +1931,9 @@ pub(crate) mod tests {
             .await
             .expect("group create failure");
 
-        let messages_with_add = group.find_messages(None, None, None, None, None, None).unwrap();
+        let messages_with_add = group
+            .find_messages(None, None, None, None, None, None)
+            .unwrap();
         assert_eq!(messages_with_add.len(), 1);
 
         // Try and add another member without merging the pending commit
@@ -1936,7 +1942,9 @@ pub(crate) mod tests {
             .await
             .expect("group remove members failure");
 
-        let messages_with_remove = group.find_messages(None, None, None, None, None, None).unwrap();
+        let messages_with_remove = group
+            .find_messages(None, None, None, None, None, None)
+            .unwrap();
         assert_eq!(messages_with_remove.len(), 2);
 
         // We are expecting 1 message on the group topic, not 2, because the second one should have
@@ -2036,7 +2044,9 @@ pub(crate) mod tests {
             .unwrap();
         tracing::info!("created the group with 2 additional members");
         assert_eq!(group.members().await.unwrap().len(), 3);
-        let messages = group.find_messages(None, None, None, None, None, None).unwrap();
+        let messages = group
+            .find_messages(None, None, None, None, None, None)
+            .unwrap();
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].kind, GroupMessageKind::MembershipChange);
         let encoded_content =
@@ -2051,7 +2061,9 @@ pub(crate) mod tests {
             .unwrap();
         assert_eq!(group.members().await.unwrap().len(), 2);
         tracing::info!("removed bola");
-        let messages = group.find_messages(None, None, None, None, None, None).unwrap();
+        let messages = group
+            .find_messages(None, None, None, None, None, None)
+            .unwrap();
         assert_eq!(messages.len(), 2);
         assert_eq!(messages[1].kind, GroupMessageKind::MembershipChange);
         let encoded_content =
@@ -2124,7 +2136,14 @@ pub(crate) mod tests {
         amal_group.sync().await.expect("sync failed");
 
         let amal_messages = amal_group
-            .find_messages(Some(GroupMessageKind::Application), None, None, None, None, None)
+            .find_messages(
+                Some(GroupMessageKind::Application),
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
             .unwrap()
             .into_iter()
             .collect::<Vec<StoredGroupMessage>>();
@@ -3106,7 +3125,14 @@ pub(crate) mod tests {
         ];
 
         let messages = amal_group
-            .find_messages(Some(GroupMessageKind::Application), None, None, None, None, None)
+            .find_messages(
+                Some(GroupMessageKind::Application),
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
             .unwrap()
             .into_iter()
             .collect::<Vec<StoredGroupMessage>>();
@@ -3207,7 +3233,9 @@ pub(crate) mod tests {
 
         // Amal sync and reads message
         amal_dm.sync().await.unwrap();
-        let messages = amal_dm.find_messages(None, None, None, None, None, None).unwrap();
+        let messages = amal_dm
+            .find_messages(None, None, None, None, None, None)
+            .unwrap();
         assert_eq!(messages.len(), 2);
         let message = messages.last().unwrap();
         assert_eq!(message.decrypted_message_bytes, b"test one");
@@ -3615,10 +3643,24 @@ pub(crate) mod tests {
         bo_group.sync().await.unwrap();
 
         let alix_messages = alix_group
-            .find_messages(Some(GroupMessageKind::Application), None, None, None, None, None)
+            .find_messages(
+                Some(GroupMessageKind::Application),
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
             .unwrap();
         let bo_messages = bo_group
-            .find_messages(Some(GroupMessageKind::Application), None, None, None, None, None)
+            .find_messages(
+                Some(GroupMessageKind::Application),
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
             .unwrap();
 
         assert_eq!(alix_messages.len(), 2);
@@ -3638,10 +3680,24 @@ pub(crate) mod tests {
         bo_group.sync().await.unwrap();
 
         let alix_messages = alix_group
-            .find_messages(Some(GroupMessageKind::Application), None, None, None, None, None)
+            .find_messages(
+                Some(GroupMessageKind::Application),
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
             .unwrap();
         let bo_messages = bo_group
-            .find_messages(Some(GroupMessageKind::Application), None, None, None, None, None)
+            .find_messages(
+                Some(GroupMessageKind::Application),
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
             .unwrap();
         assert_eq!(bo_messages.len(), 3);
         assert_eq!(alix_messages.len(), 3); // Fails here, 2 != 3

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -65,7 +65,7 @@ use xmtp_id::InboxId;
 use xmtp_proto::xmtp::mls::{
     api::v1::{
         group_message::{Version as GroupMessageVersion, V1 as GroupMessageV1},
-        GroupMessage,
+        GroupMessage, SortDirection,
     },
     message_contents::{
         plaintext_envelope::{Content, V1},
@@ -671,6 +671,7 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
         sent_after_ns: Option<i64>,
         delivery_status: Option<DeliveryStatus>,
         limit: Option<i64>,
+        direction: Option<SortDirection>,
     ) -> Result<Vec<StoredGroupMessage>, GroupError> {
         let conn = self.context().store().conn()?;
         let messages = conn.get_group_messages(
@@ -680,6 +681,7 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
             kind,
             delivery_status,
             limit,
+            direction,
         )?;
 
         Ok(messages)

--- a/xmtp_mls/src/storage/encrypted_store/group.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group.rs
@@ -1,10 +1,8 @@
 //! The Group database table. Stored information surrounding group membership and ID's.
 
-use diesel::query_dsl::QueryDsl;
 use diesel::{
     backend::Backend,
     deserialize::{self, FromSql, FromSqlRow},
-    dsl::sql,
     expression::AsExpression,
     prelude::*,
     serialize::{self, IsNull, Output, ToSql},
@@ -14,9 +12,8 @@ use diesel::{
 use serde::{Deserialize, Serialize};
 
 use super::{
-    consent_record::ConsentState,
     db_connection::DbConnection,
-    schema::groups::{self, dsl},
+    schema::{groups, groups::dsl},
     Sqlite,
 };
 use crate::{
@@ -129,56 +126,40 @@ impl DbConnection {
         created_before_ns: Option<i64>,
         limit: Option<i64>,
         conversation_type: Option<ConversationType>,
-        consent_state: Option<ConsentState>,
     ) -> Result<Vec<StoredGroup>, StorageError> {
-        use crate::storage::schema::consent_records::dsl as consent_dsl;
-        use crate::storage::schema::groups::dsl as groups_dsl;
-
-        let mut query = groups_dsl::groups
-            .order(groups_dsl::created_at_ns.asc())
-            .into_boxed();
+        let mut query = dsl::groups.order(dsl::created_at_ns.asc()).into_boxed();
 
         if let Some(allowed_states) = allowed_states {
-            query = query.filter(groups_dsl::membership_state.eq_any(allowed_states));
+            query = query.filter(dsl::membership_state.eq_any(allowed_states));
         }
 
         if let Some(created_after_ns) = created_after_ns {
-            query = query.filter(groups_dsl::created_at_ns.gt(created_after_ns));
+            query = query.filter(dsl::created_at_ns.gt(created_after_ns));
         }
 
         if let Some(created_before_ns) = created_before_ns {
-            query = query.filter(groups_dsl::created_at_ns.lt(created_before_ns));
-        }
-
-        if let Some(conversation_type) = conversation_type {
-            match conversation_type {
-                ConversationType::Group => {
-                    query = query.filter(groups_dsl::dm_inbox_id.is_null());
-                }
-                ConversationType::Dm => {
-                    query = query.filter(groups_dsl::dm_inbox_id.is_not_null());
-                }
-                ConversationType::Sync => {}
-            }
-        }
-
-        if let Some(state) = consent_state {
-            query =
-                query
-                    .inner_join(consent_dsl::consent_records.on(
-                        sql::<diesel::sql_types::Text>("hex(groups.id)").eq(consent_dsl::entity),
-                    ))
-                    .filter(consent_dsl::state.eq(state))
-                    .select(groups_dsl::groups::all_columns());
+            query = query.filter(dsl::created_at_ns.lt(created_before_ns));
         }
 
         if let Some(limit) = limit {
             query = query.limit(limit);
         }
 
-        query = query.filter(groups_dsl::purpose.eq(Purpose::Conversation));
+        if let Some(conversation_type) = conversation_type {
+            match conversation_type {
+                ConversationType::Group => {
+                    query = query.filter(dsl::dm_inbox_id.is_null());
+                }
+                ConversationType::Dm => {
+                    query = query.filter(dsl::dm_inbox_id.is_not_null());
+                }
+                ConversationType::Sync => {}
+            }
+        }
 
-        Ok(self.raw_query(|conn| query.load::<StoredGroup>(conn))?)
+        query = query.filter(dsl::purpose.eq(Purpose::Conversation));
+
+        Ok(self.raw_query(|conn| query.load(conn))?)
     }
 
     /// Return only the [`Purpose::Sync`] groups
@@ -520,7 +501,7 @@ pub(crate) mod tests {
             test_group_3.store(conn).unwrap();
 
             let all_results = conn
-                .find_groups(None, None, None, None, Some(ConversationType::Group), None)
+                .find_groups(None, None, None, None, Some(ConversationType::Group))
                 .unwrap();
             assert_eq!(all_results.len(), 2);
 
@@ -531,7 +512,6 @@ pub(crate) mod tests {
                     None,
                     None,
                     Some(ConversationType::Group),
-                    None,
                 )
                 .unwrap();
             assert_eq!(pending_results[0].id, test_group_1.id);
@@ -539,7 +519,7 @@ pub(crate) mod tests {
 
             // Offset and limit
             let results_with_limit = conn
-                .find_groups(None, None, None, Some(1), Some(ConversationType::Group), None)
+                .find_groups(None, None, None, Some(1), Some(ConversationType::Group))
                 .unwrap();
             assert_eq!(results_with_limit.len(), 1);
             assert_eq!(results_with_limit[0].id, test_group_1.id);
@@ -551,7 +531,6 @@ pub(crate) mod tests {
                     None,
                     Some(1),
                     Some(ConversationType::Group),
-                    None,
                 )
                 .unwrap();
             assert_eq!(results_with_created_at_ns_after.len(), 1);
@@ -562,7 +541,7 @@ pub(crate) mod tests {
             assert_eq!(synced_groups.len(), 0);
 
             // test that dm groups are included
-            let dm_results = conn.find_groups(None, None, None, None, None, None).unwrap();
+            let dm_results = conn.find_groups(None, None, None, None, None).unwrap();
             assert_eq!(dm_results.len(), 3);
             assert_eq!(dm_results[2].id, test_group_3.id);
 
@@ -572,7 +551,7 @@ pub(crate) mod tests {
 
             // test only dms are returned
             let dm_results = conn
-                .find_groups(None, None, None, None, Some(ConversationType::Dm), None)
+                .find_groups(None, None, None, None, Some(ConversationType::Dm))
                 .unwrap();
             assert_eq!(dm_results.len(), 1);
             assert_eq!(dm_results[0].id, test_group_3.id);

--- a/xmtp_mls/src/storage/encrypted_store/group_message.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group_message.rs
@@ -116,6 +116,7 @@ impl_store_or_ignore!(StoredGroupMessage, group_messages);
 
 impl DbConnection {
     /// Query for group messages
+    #[allow(clippy::too_many_arguments)]
     pub fn get_group_messages<GroupId: AsRef<[u8]>>(
         &self,
         group_id: GroupId,

--- a/xmtp_mls/src/storage/encrypted_store/group_message.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group_message.rs
@@ -147,12 +147,10 @@ impl DbConnection {
             query = query.filter(dsl::delivery_status.eq(status));
         }
 
-        if let Some(dir) = direction {
-            query = match dir {
-                SortDirection::Ascending => query.order(dsl::sent_at_ns.asc()),
-                SortDirection::Descending => query.order(dsl::sent_at_ns.desc()),
-            };
-        }
+        query = match direction.unwrap_or(SortDirection::Ascending) {
+            SortDirection::Ascending => query.order(dsl::sent_at_ns.asc()),
+            SortDirection::Descending => query.order(dsl::sent_at_ns.desc()),
+        };
 
         if let Some(limit) = limit {
             query = query.limit(limit);

--- a/xmtp_mls/src/storage/encrypted_store/group_message.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group_message.rs
@@ -141,16 +141,16 @@ impl DbConnection {
             query = query.filter(dsl::delivery_status.eq(status));
         }
 
-        if let Some(limit) = limit {
-            query = query.limit(limit);
-        }
-
         if let Some(dir) = direction {
             query = match dir {
                 SortDirection::Ascending => query.order(dsl::sent_at_ns.asc()),
                 SortDirection::Descending => query.order(dsl::sent_at_ns.desc()),
                 SortDirection::Unspecified => query,
             };
+        }
+
+        if let Some(limit) = limit {
+            query = query.limit(limit);
         }
 
         Ok(self.raw_query(|conn| query.load::<StoredGroupMessage>(conn))?)

--- a/xmtp_mls/src/storage/encrypted_store/group_message.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group_message.rs
@@ -431,13 +431,15 @@ pub(crate) mod tests {
             group.store(conn).unwrap();
 
             let messages = vec![
-                generate_message(None, Some(&group.id), Some(1_000)),
                 generate_message(None, Some(&group.id), Some(10_000)),
+                generate_message(None, Some(&group.id), Some(1_000)),
                 generate_message(None, Some(&group.id), Some(100_000)),
                 generate_message(None, Some(&group.id), Some(1_000_000)),
             ];
 
-            let membership_changes_asc = conn
+            assert_ok!(messages.store(conn));
+
+            let messages_asc = conn
                 .get_group_messages(
                     &group.id,
                     None,
@@ -448,9 +450,13 @@ pub(crate) mod tests {
                     Some(SortDirection::Ascending),
                 )
                 .unwrap();
-            assert_eq!(membership_changes_asc[0], messages[0]);
+            assert_eq!(messages_asc.len(), 4);
+            assert_eq!(messages_asc[0].sent_at_ns, 1_000);
+            assert_eq!(messages_asc[1].sent_at_ns, 10_000);
+            assert_eq!(messages_asc[2].sent_at_ns, 100_000);
+            assert_eq!(messages_asc[3].sent_at_ns, 1_000_000);
 
-            let membership_changes_desc = conn
+            let messages_desc = conn
                 .get_group_messages(
                     &group.id,
                     None,
@@ -461,7 +467,11 @@ pub(crate) mod tests {
                     Some(SortDirection::Descending),
                 )
                 .unwrap();
-            assert_eq!(membership_changes_desc[0], messages[4]);
+            assert_eq!(messages_desc.len(), 4);
+            assert_eq!(messages_desc[0].sent_at_ns, 1_000_000);
+            assert_eq!(messages_desc[1].sent_at_ns, 100_000);
+            assert_eq!(messages_desc[2].sent_at_ns, 10_000);
+            assert_eq!(messages_desc[3].sent_at_ns, 1_000);
         })
         .await
     }


### PR DESCRIPTION
Messages always come in ascending order which is not useful with messaging as you actually always want them in descending order. This allows us to specify a direction so that limit works correctly still select the correct N items based on the sort direction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced messaging framework with improved consent management and message retrieval options.
  - Added sorting capabilities for message retrieval, allowing users to specify ascending or descending order.
  - Updated command-line interface (CLI) for better message querying flexibility.

- **Bug Fixes**
  - Improved error handling in message synchronization and retrieval processes.

- **Tests**
  - Expanded test coverage for new functionalities, ensuring robust performance and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->