### PR TITLE
Fix MLS Validation Service docker tag for good

### DIFF
--- a/.github/workflows/release-mls-validation-service.yml
+++ b/.github/workflows/release-mls-validation-service.yml
@@ -31,7 +31,6 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository_owner }}/mls-validation-service
           tags: |
-            type=ref,event=tag
             type=match,pattern=mls-validation-service-(.*),group=1
             type=match,pattern=mls-validation-service-v(.*),group=1
 

--- a/.github/workflows/release-mls-validation-service.yml
+++ b/.github/workflows/release-mls-validation-service.yml
@@ -29,10 +29,11 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/xmtp/mls-validation-service
+          images: ghcr.io/${{ github.repository_owner }}/mls-validation-service
           tags: |
             type=ref,event=tag
-            type=match,pattern={{mls-validation-service-(.*)}},group=1
+            type=match,pattern=mls-validation-service-(.*),group=1
+            type=match,pattern=mls-validation-service-v(.*),group=1
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6


### PR DESCRIPTION
This finally works as expected. Tested [here](https://github.com/Nomadic-Workplace/docker-gh-actions-test/actions/runs/11461301831).

It now makes these three tags:
```
Docker tags
  ghcr.io/xmtp/mls-validation-service:v1.0.0
  ghcr.io/xmtpmls-validation-service:1.0.0
  ghcr.io/xmtp/mls-validation-service:latest
```

Do both `v1.0.0` and `1.0.0` as that is what the `semver` template does that we use in `xmtpd`