### PR TITLE
disallow metadata changes for dms

### DIFF
--- a/.github/workflows/release-swift-bindings-nix.yml
+++ b/.github/workflows/release-swift-bindings-nix.yml
@@ -49,6 +49,12 @@ jobs:
         with:
           workspaces: |
             .
+      - name: Install Nix
+        uses: cachix/install-nix-action@v17
+        with:
+          # Mostly to avoid GitHub rate limiting
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
       - name: Generate bindings
         working-directory: bindings_ffi
         run: |

--- a/flake.nix
+++ b/flake.nix
@@ -51,7 +51,6 @@
         # https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/android.section.md
         androidHome = "${androidComposition.androidsdk}/libexec/android-sdk";
         androidComposition = androidenv.composeAndroidPackages sdkArgs;
-        packages = with pkgs; [ swiftformat cargo-ndk ];
 
         # Packages available to flake while building the environment
         nativeBuildInputs = with pkgs; [ pkg-config ];
@@ -62,6 +61,7 @@
           kotlin
           androidsdk
           jdk17
+          cargo-ndk
 
           # System Libraries
           sqlite


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new error variant to enhance control over metadata updates for direct message (DM) groups.

- **Bug Fixes**
	- Implemented stricter checks to prevent unauthorized metadata modifications in DM groups, providing clearer error feedback.

- **Chores**
	- Added Nix installation to the Swift bindings release workflow for improved build environment setup.
	- Enhanced build environment by adding `cargo-ndk` package for Android application development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->