### PR TITLE
Make member identifier the address instead of account_id

### DIFF
--- a/xmtp_id/src/associations/verified_signature.rs
+++ b/xmtp_id/src/associations/verified_signature.rs
@@ -148,7 +148,7 @@ impl VerifiedSignature {
             *block_number = response.block_number;
 
             Ok(Self::new(
-                MemberIdentifier::Address(account_id.into()),
+                MemberIdentifier::Address(account_id.get_account_address().to_string()),
                 SignatureKind::Erc1271,
                 signature_bytes.to_vec(),
             ))

--- a/xmtp_id/src/associations/verified_signature.rs
+++ b/xmtp_id/src/associations/verified_signature.rs
@@ -148,7 +148,9 @@ impl VerifiedSignature {
             *block_number = response.block_number;
 
             Ok(Self::new(
-                MemberIdentifier::Address(account_id.get_account_address().to_string()),
+                MemberIdentifier::Address(
+                    account_id.get_account_address().to_string().to_lowercase(),
+                ),
                 SignatureKind::Erc1271,
                 signature_bytes.to_vec(),
             ))

--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -789,12 +789,12 @@ pub(crate) mod tests {
                 let contract_call = scw_factory.create_account(owners.clone(), nonce);
 
                 contract_call.send().await.unwrap().await.unwrap();
-                let account_id = AccountId::new_evm(anvil_meta.chain_id, format!("{scw_addr:?}"));
-                let account_id_string: String = account_id.clone().into();
+                let account_address = format!("{scw_addr:?}");
+                let account_id = AccountId::new_evm(anvil_meta.chain_id, account_address.clone());
 
                 let identity_strategy = IdentityStrategy::CreateIfNotFound(
-                    generate_inbox_id(&account_id_string, &0),
-                    account_id_string,
+                    generate_inbox_id(&account_address, &0),
+                    account_address,
                     0,
                     None,
                 );


### PR DESCRIPTION
## tl;dr

- Makes the publicly visible address for a SCW the contract address and not the CAIP-10 address with the chain ID

## Follow-ups

Bind SCW addresses to a single chain to avoid abuse of expired signers using 6492 signatures between chains.