### PR TITLE
Add a MsgQueryArgs struct

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -15,6 +15,7 @@ use xmtp_id::{
     },
     InboxId,
 };
+use xmtp_mls::storage::group_message::MsgQueryArgs;
 use xmtp_mls::storage::group_message::SortDirection;
 use xmtp_mls::{
     api::ApiClientWrapper,
@@ -1222,12 +1223,12 @@ impl FfiConversation {
 
         let messages: Vec<FfiMessage> = group
             .find_messages(
-                None,
-                opts.sent_before_ns,
-                opts.sent_after_ns,
-                delivery_status,
-                opts.limit,
-                direction,
+                &MsgQueryArgs::default()
+                    .maybe_sent_before_ns(opts.sent_before_ns)
+                    .maybe_sent_after_ns(opts.sent_after_ns)
+                    .maybe_delivery_status(delivery_status)
+                    .maybe_limit(opts.limit)
+                    .maybe_direction(direction),
             )?
             .into_iter()
             .map(|msg| msg.into())

--- a/bindings_node/src/groups.rs
+++ b/bindings_node/src/groups.rs
@@ -6,10 +6,13 @@ use napi::{
   JsFunction,
 };
 use xmtp_cryptography::signature::ed25519_public_key_to_address;
-use xmtp_mls::groups::{
-  group_metadata::{ConversationType, GroupMetadata},
-  members::PermissionLevel,
-  MlsGroup, UpdateAdminListType,
+use xmtp_mls::{
+  groups::{
+    group_metadata::{ConversationType, GroupMetadata},
+    members::PermissionLevel,
+    MlsGroup, UpdateAdminListType,
+  },
+  storage::group_message::MsgQueryArgs,
 };
 use xmtp_proto::xmtp::mls::message_contents::EncodedContent;
 
@@ -167,12 +170,11 @@ impl NapiGroup {
 
     let messages: Vec<NapiMessage> = group
       .find_messages(
-        None,
-        opts.sent_before_ns,
-        opts.sent_after_ns,
-        delivery_status,
-        opts.limit,
-        None,
+        &MsgQueryArgs::default()
+          .maybe_sent_before_ns(opts.sent_before_ns)
+          .maybe_sent_after_ns(opts.sent_after_ns)
+          .maybe_delivery_status(delivery_status)
+          .maybe_limit(opts.limit),
       )
       .map_err(ErrorWrapper::from)?
       .into_iter()

--- a/bindings_wasm/src/groups.rs
+++ b/bindings_wasm/src/groups.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use wasm_bindgen::JsValue;
 use wasm_bindgen::{prelude::wasm_bindgen, JsError};
-use xmtp_mls::storage::group_message::{DeliveryStatus, MsgQueryArgs};
+use xmtp_mls::storage::group_message::MsgQueryArgs;
 
 use crate::encoded_content::WasmEncodedContent;
 use crate::messages::{WasmListMessagesOptions, WasmMessage};

--- a/bindings_wasm/src/groups.rs
+++ b/bindings_wasm/src/groups.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use wasm_bindgen::JsValue;
 use wasm_bindgen::{prelude::wasm_bindgen, JsError};
+use xmtp_mls::storage::group_message::{DeliveryStatus, MsgQueryArgs};
 
 use crate::encoded_content::WasmEncodedContent;
 use crate::messages::{WasmListMessagesOptions, WasmMessage};
@@ -189,12 +190,11 @@ impl WasmGroup {
 
     let messages: Vec<WasmMessage> = group
       .find_messages(
-        None,
-        opts.sent_before_ns,
-        opts.sent_after_ns,
-        delivery_status,
-        opts.limit,
-        None,
+        &MsgQueryArgs::default()
+          .maybe_sent_before_ns(opts.sent_before_ns)
+          .maybe_sent_after_ns(opts.sent_after_ns)
+          .maybe_delivery_status(delivery_status)
+          .maybe_limit(opts.limit),
       )
       .map_err(|e| JsError::new(&format!("{e}")))?
       .into_iter()

--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -21,7 +21,7 @@ use prost::Message;
 use xmtp_id::associations::unverified::{UnverifiedRecoverableEcdsaSignature, UnverifiedSignature};
 use xmtp_mls::client::FindGroupParams;
 use xmtp_mls::groups::message_history::MessageHistoryContent;
-use xmtp_mls::storage::group_message::GroupMessageKind;
+use xmtp_mls::storage::group_message::{GroupMessageKind, MsgQueryArgs};
 
 use crate::{
     json_logger::make_value,
@@ -253,9 +253,7 @@ async fn main() {
                 .await
                 .expect("failed to get group");
 
-            let messages = group
-                .find_messages(None, None, None, None, None, None)
-                .unwrap();
+            let messages = group.find_messages(&MsgQueryArgs::default()).unwrap();
             if cli.json {
                 let json_serializable_messages = messages
                     .iter()
@@ -388,14 +386,7 @@ async fn main() {
             let group_id_str = hex::encode(group.group_id.clone());
             group.sync().await.unwrap();
             let messages = group
-                .find_messages(
-                    Some(GroupMessageKind::Application),
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                )
+                .find_messages(&MsgQueryArgs::default().kind(GroupMessageKind::Application))
                 .unwrap();
             info!("Listing history sync messages", { group_id: group_id_str, messages: messages.len()});
             for message in messages {

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -985,6 +985,7 @@ pub(crate) mod tests {
         identity::serialize_key_package_hash_ref,
         storage::{
             consent_record::{ConsentState, ConsentType, StoredConsentRecord},
+            group_message::MsgQueryArgs,
             schema::identity_updates,
         },
         XmtpApi,
@@ -1165,14 +1166,10 @@ pub(crate) mod tests {
 
         let bo_groups = bo.find_groups(FindGroupParams::default()).unwrap();
         let bo_group1 = bo.group(alix_bo_group1.clone().group_id).unwrap();
-        let bo_messages1 = bo_group1
-            .find_messages(None, None, None, None, None, None)
-            .unwrap();
+        let bo_messages1 = bo_group1.find_messages(&MsgQueryArgs::default()).unwrap();
         assert_eq!(bo_messages1.len(), 0);
         let bo_group2 = bo.group(alix_bo_group2.clone().group_id).unwrap();
-        let bo_messages2 = bo_group2
-            .find_messages(None, None, None, None, None, None)
-            .unwrap();
+        let bo_messages2 = bo_group2.find_messages(&MsgQueryArgs::default()).unwrap();
         assert_eq!(bo_messages2.len(), 0);
         alix_bo_group1
             .send_message(vec![1, 2, 3].as_slice())
@@ -1185,14 +1182,10 @@ pub(crate) mod tests {
 
         bo.sync_all_groups(bo_groups).await.unwrap();
 
-        let bo_messages1 = bo_group1
-            .find_messages(None, None, None, None, None, None)
-            .unwrap();
+        let bo_messages1 = bo_group1.find_messages(&MsgQueryArgs::default()).unwrap();
         assert_eq!(bo_messages1.len(), 1);
         let bo_group2 = bo.group(alix_bo_group2.clone().group_id).unwrap();
-        let bo_messages2 = bo_group2
-            .find_messages(None, None, None, None, None, None)
-            .unwrap();
+        let bo_messages2 = bo_group2.find_messages(&MsgQueryArgs::default()).unwrap();
         assert_eq!(bo_messages2.len(), 1);
     }
 
@@ -1254,9 +1247,7 @@ pub(crate) mod tests {
         // assert!(!bola_group.is_active().unwrap());
 
         // Bola should have one readable message (them being added to the group)
-        let mut bola_messages = bola_group
-            .find_messages(None, None, None, None, None, None)
-            .unwrap();
+        let mut bola_messages = bola_group.find_messages(&MsgQueryArgs::default()).unwrap();
 
         assert_eq!(bola_messages.len(), 1);
 
@@ -1276,9 +1267,7 @@ pub(crate) mod tests {
         // Sync Bola's state to get the latest
         bola_group.sync().await.unwrap();
         // Find Bola's updated list of messages
-        bola_messages = bola_group
-            .find_messages(None, None, None, None, None, None)
-            .unwrap();
+        bola_messages = bola_group.find_messages(&MsgQueryArgs::default()).unwrap();
         // Bola should have been able to decrypt the last message
         assert_eq!(bola_messages.len(), 2);
         assert_eq!(

--- a/xmtp_mls/src/groups/message_history.rs
+++ b/xmtp_mls/src/groups/message_history.rs
@@ -29,6 +29,7 @@ use xmtp_proto::{
 use super::group_metadata::ConversationType;
 use super::{GroupError, MlsGroup};
 
+use crate::storage::group_message::MsgQueryArgs;
 use crate::XmtpApi;
 use crate::{
     client::ClientError,
@@ -156,14 +157,8 @@ where
         // sync the group
         sync_group.sync().await?;
 
-        let messages = sync_group.find_messages(
-            Some(GroupMessageKind::Application),
-            None,
-            None,
-            None,
-            None,
-            None,
-        )?;
+        let messages = sync_group
+            .find_messages(&MsgQueryArgs::default().kind(GroupMessageKind::Application))?;
 
         let last_message = messages.last();
         if let Some(msg) = last_message {
@@ -215,14 +210,8 @@ where
         // sync the group
         Box::pin(sync_group.sync()).await?;
 
-        let messages = sync_group.find_messages(
-            Some(GroupMessageKind::Application),
-            None,
-            None,
-            None,
-            None,
-            None,
-        )?;
+        let messages = sync_group
+            .find_messages(&MsgQueryArgs::default().kind(GroupMessageKind::Application))?;
 
         let last_message = match messages.last() {
             Some(msg) => {
@@ -284,14 +273,8 @@ where
         // sync the group
         sync_group.sync().await?;
 
-        let messages = sync_group.find_messages(
-            Some(GroupMessageKind::Application),
-            None,
-            None,
-            None,
-            None,
-            None,
-        )?;
+        let messages = sync_group
+            .find_messages(&MsgQueryArgs::default().kind(GroupMessageKind::Application))?;
         let last_message = messages.last();
 
         let history_request: Option<(String, String)> = if let Some(msg) = last_message {
@@ -333,14 +316,8 @@ where
         // sync the group
         sync_group.sync().await?;
 
-        let messages = sync_group.find_messages(
-            Some(GroupMessageKind::Application),
-            None,
-            None,
-            None,
-            None,
-            None,
-        )?;
+        let messages = sync_group
+            .find_messages(&MsgQueryArgs::default().kind(GroupMessageKind::Application))?;
 
         let last_message = messages.last();
 
@@ -409,14 +386,8 @@ where
         pin_code: &str,
     ) -> Result<(), MessageHistoryError> {
         let sync_group = self.get_sync_group()?;
-        let requests = sync_group.find_messages(
-            Some(GroupMessageKind::Application),
-            None,
-            None,
-            None,
-            None,
-            None,
-        )?;
+        let requests = sync_group
+            .find_messages(&MsgQueryArgs::default().kind(GroupMessageKind::Application))?;
         let request = requests.into_iter().find(|msg| {
             let message_history_content =
                 serde_json::from_slice::<MessageHistoryContent>(&msg.decrypted_message_bytes);
@@ -521,7 +492,7 @@ where
         let mut all_messages: Vec<StoredGroupMessage> = vec![];
 
         for StoredGroup { id, .. } in groups.into_iter() {
-            let messages = conn.get_group_messages(id, None, None, None, None, None, None)?;
+            let messages = conn.get_group_messages(&id, &MsgQueryArgs::default())?;
             all_messages.extend(messages);
         }
 
@@ -865,14 +836,7 @@ pub(crate) mod tests {
         // make sure there's only 1 message in the sync group
         let sync_group = client.get_sync_group().unwrap();
         let messages = sync_group
-            .find_messages(
-                Some(GroupMessageKind::Application),
-                None,
-                None,
-                None,
-                None,
-                None,
-            )
+            .find_messages(&MsgQueryArgs::default().kind(GroupMessageKind::Application))
             .unwrap();
         assert_eq!(messages.len(), 1);
     }
@@ -917,14 +881,7 @@ pub(crate) mod tests {
         // make sure there's 2 messages in the sync group
         let sync_group = client.get_sync_group().unwrap();
         let messages = sync_group
-            .find_messages(
-                Some(GroupMessageKind::Application),
-                None,
-                None,
-                None,
-                None,
-                None,
-            )
+            .find_messages(&MsgQueryArgs::default().kind(GroupMessageKind::Application))
             .unwrap();
         assert_eq!(messages.len(), 2);
     }
@@ -1074,15 +1031,7 @@ pub(crate) mod tests {
 
         let amal_b_conn = amal_b.store().conn().unwrap();
         let amal_b_messages = amal_b_conn
-            .get_group_messages(
-                amal_b_sync_group.group_id,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-            )
+            .get_group_messages(&amal_b_sync_group.group_id, &MsgQueryArgs::default())
             .unwrap();
 
         assert_eq!(amal_b_messages.len(), 1);

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -90,7 +90,7 @@ use crate::{
         db_connection::DbConnection,
         group::{GroupMembershipState, Purpose, StoredGroup},
         group_intent::IntentKind,
-        group_message::{DeliveryStatus, GroupMessageKind, SortDirection, StoredGroupMessage},
+        group_message::{DeliveryStatus, GroupMessageKind, MsgQueryArgs, StoredGroupMessage},
         sql_key_store,
     },
     utils::{id::calculate_message_id, time::now_ns},
@@ -667,23 +667,10 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
     /// and limit
     pub fn find_messages(
         &self,
-        kind: Option<GroupMessageKind>,
-        sent_before_ns: Option<i64>,
-        sent_after_ns: Option<i64>,
-        delivery_status: Option<DeliveryStatus>,
-        limit: Option<i64>,
-        direction: Option<SortDirection>,
+        args: &MsgQueryArgs,
     ) -> Result<Vec<StoredGroupMessage>, GroupError> {
         let conn = self.context().store().conn()?;
-        let messages = conn.get_group_messages(
-            &self.group_id,
-            sent_after_ns,
-            sent_before_ns,
-            kind,
-            delivery_status,
-            limit,
-            direction,
-        )?;
+        let messages = conn.get_group_messages(&self.group_id, args)?;
 
         Ok(messages)
     }
@@ -1550,7 +1537,7 @@ pub(crate) mod tests {
             consent_record::ConsentState,
             group::Purpose,
             group_intent::{IntentKind, IntentState},
-            group_message::{GroupMessageKind, StoredGroupMessage},
+            group_message::{GroupMessageKind, MsgQueryArgs, StoredGroupMessage},
         },
         utils::test::FullXmtpClient,
         xmtp_openmls_provider::XmtpOpenMlsProvider,
@@ -1568,9 +1555,7 @@ pub(crate) mod tests {
 
     async fn get_latest_message(group: &MlsGroup<FullXmtpClient>) -> StoredGroupMessage {
         group.sync().await.unwrap();
-        let mut messages = group
-            .find_messages(None, None, None, None, None, None)
-            .unwrap();
+        let mut messages = group.find_messages(&MsgQueryArgs::default()).unwrap();
         messages.pop().unwrap()
     }
 
@@ -1654,9 +1639,7 @@ pub(crate) mod tests {
             .await
             .unwrap();
         // Check for messages
-        let messages = group
-            .find_messages(None, None, None, None, None, None)
-            .unwrap();
+        let messages = group.find_messages(&MsgQueryArgs::default()).unwrap();
         assert_eq!(messages.len(), 1);
         assert_eq!(messages.first().unwrap().decrypted_message_bytes, msg);
     }
@@ -1833,9 +1816,7 @@ pub(crate) mod tests {
             .await
             .unwrap();
 
-        let bola_messages = bola_group
-            .find_messages(None, None, None, None, None, None)
-            .unwrap();
+        let bola_messages = bola_group.find_messages(&MsgQueryArgs::default()).unwrap();
         let matching_message = bola_messages
             .iter()
             .find(|m| m.decrypted_message_bytes == "hello from amal".as_bytes());
@@ -1950,9 +1931,7 @@ pub(crate) mod tests {
             .await
             .expect("group create failure");
 
-        let messages_with_add = group
-            .find_messages(None, None, None, None, None, None)
-            .unwrap();
+        let messages_with_add = group.find_messages(&MsgQueryArgs::default()).unwrap();
         assert_eq!(messages_with_add.len(), 1);
 
         // Try and add another member without merging the pending commit
@@ -1961,9 +1940,7 @@ pub(crate) mod tests {
             .await
             .expect("group remove members failure");
 
-        let messages_with_remove = group
-            .find_messages(None, None, None, None, None, None)
-            .unwrap();
+        let messages_with_remove = group.find_messages(&MsgQueryArgs::default()).unwrap();
         assert_eq!(messages_with_remove.len(), 2);
 
         // We are expecting 1 message on the group topic, not 2, because the second one should have
@@ -2012,9 +1989,7 @@ pub(crate) mod tests {
         let bola_groups = bola_client.find_groups(FindGroupParams::default()).unwrap();
         let bola_group = bola_groups.first().unwrap();
         bola_group.sync().await.unwrap();
-        let bola_messages = bola_group
-            .find_messages(None, None, None, None, None, None)
-            .unwrap();
+        let bola_messages = bola_group.find_messages(&MsgQueryArgs::default()).unwrap();
         assert_eq!(bola_messages.len(), 1);
     }
 
@@ -2063,9 +2038,7 @@ pub(crate) mod tests {
             .unwrap();
         tracing::info!("created the group with 2 additional members");
         assert_eq!(group.members().await.unwrap().len(), 3);
-        let messages = group
-            .find_messages(None, None, None, None, None, None)
-            .unwrap();
+        let messages = group.find_messages(&MsgQueryArgs::default()).unwrap();
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].kind, GroupMessageKind::MembershipChange);
         let encoded_content =
@@ -2080,9 +2053,7 @@ pub(crate) mod tests {
             .unwrap();
         assert_eq!(group.members().await.unwrap().len(), 2);
         tracing::info!("removed bola");
-        let messages = group
-            .find_messages(None, None, None, None, None, None)
-            .unwrap();
+        let messages = group.find_messages(&MsgQueryArgs::default()).unwrap();
         assert_eq!(messages.len(), 2);
         assert_eq!(messages[1].kind, GroupMessageKind::MembershipChange);
         let encoded_content =
@@ -2155,14 +2126,7 @@ pub(crate) mod tests {
         amal_group.sync().await.expect("sync failed");
 
         let amal_messages = amal_group
-            .find_messages(
-                Some(GroupMessageKind::Application),
-                None,
-                None,
-                None,
-                None,
-                None,
-            )
+            .find_messages(&MsgQueryArgs::default().kind(GroupMessageKind::Application))
             .unwrap()
             .into_iter()
             .collect::<Vec<StoredGroupMessage>>();
@@ -3144,14 +3108,7 @@ pub(crate) mod tests {
         ];
 
         let messages = amal_group
-            .find_messages(
-                Some(GroupMessageKind::Application),
-                None,
-                None,
-                None,
-                None,
-                None,
-            )
+            .find_messages(&MsgQueryArgs::default().kind(GroupMessageKind::Application))
             .unwrap()
             .into_iter()
             .collect::<Vec<StoredGroupMessage>>();
@@ -3197,9 +3154,7 @@ pub(crate) mod tests {
         amal_group.publish_messages().await.unwrap();
         bola_group.sync().await.unwrap();
 
-        let messages = bola_group
-            .find_messages(None, None, None, None, None, None)
-            .unwrap();
+        let messages = bola_group.find_messages(&MsgQueryArgs::default()).unwrap();
         let delivery = messages
             .iter()
             .cloned()
@@ -3252,9 +3207,7 @@ pub(crate) mod tests {
 
         // Amal sync and reads message
         amal_dm.sync().await.unwrap();
-        let messages = amal_dm
-            .find_messages(None, None, None, None, None, None)
-            .unwrap();
+        let messages = amal_dm.find_messages(&MsgQueryArgs::default()).unwrap();
         assert_eq!(messages.len(), 2);
         let message = messages.last().unwrap();
         assert_eq!(message.decrypted_message_bytes, b"test one");
@@ -3407,12 +3360,8 @@ pub(crate) mod tests {
         alix1_group.sync().await.unwrap();
         alix2_group.sync().await.unwrap();
 
-        let alix1_messages = alix1_group
-            .find_messages(None, None, None, None, None, None)
-            .unwrap();
-        let alix2_messages = alix2_group
-            .find_messages(None, None, None, None, None, None)
-            .unwrap();
+        let alix1_messages = alix1_group.find_messages(&MsgQueryArgs::default()).unwrap();
+        let alix2_messages = alix2_group.find_messages(&MsgQueryArgs::default()).unwrap();
         assert_eq!(alix1_messages.len(), alix2_messages.len());
 
         assert!(alix1_messages
@@ -3519,12 +3468,8 @@ pub(crate) mod tests {
         alix1_group.sync().await.unwrap();
         alix2_group.sync().await.unwrap();
 
-        let alix1_messages = alix1_group
-            .find_messages(None, None, None, None, None, None)
-            .unwrap();
-        let alix2_messages = alix2_group
-            .find_messages(None, None, None, None, None, None)
-            .unwrap();
+        let alix1_messages = alix1_group.find_messages(&MsgQueryArgs::default()).unwrap();
+        let alix2_messages = alix2_group.find_messages(&MsgQueryArgs::default()).unwrap();
         assert_eq!(alix1_messages.len(), alix2_messages.len());
 
         assert!(alix1_messages
@@ -3662,24 +3607,10 @@ pub(crate) mod tests {
         bo_group.sync().await.unwrap();
 
         let alix_messages = alix_group
-            .find_messages(
-                Some(GroupMessageKind::Application),
-                None,
-                None,
-                None,
-                None,
-                None,
-            )
+            .find_messages(&MsgQueryArgs::default().kind(GroupMessageKind::Application))
             .unwrap();
         let bo_messages = bo_group
-            .find_messages(
-                Some(GroupMessageKind::Application),
-                None,
-                None,
-                None,
-                None,
-                None,
-            )
+            .find_messages(&MsgQueryArgs::default().kind(GroupMessageKind::Application))
             .unwrap();
 
         assert_eq!(alix_messages.len(), 2);
@@ -3699,24 +3630,10 @@ pub(crate) mod tests {
         bo_group.sync().await.unwrap();
 
         let alix_messages = alix_group
-            .find_messages(
-                Some(GroupMessageKind::Application),
-                None,
-                None,
-                None,
-                None,
-                None,
-            )
+            .find_messages(&MsgQueryArgs::default().kind(GroupMessageKind::Application))
             .unwrap();
         let bo_messages = bo_group
-            .find_messages(
-                Some(GroupMessageKind::Application),
-                None,
-                None,
-                None,
-                None,
-                None,
-            )
+            .find_messages(&MsgQueryArgs::default().kind(GroupMessageKind::Application))
             .unwrap();
         assert_eq!(bo_messages.len(), 3);
         assert_eq!(alix_messages.len(), 3); // Fails here, 2 != 3


### PR DESCRIPTION
The number of params to the message query functions is really growing. Let's switch out all those params for a struct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced `MsgQueryArgs` for streamlined message querying, enhancing clarity and maintainability.
  - Updated the `find_messages` method across multiple components to utilize the new `MsgQueryArgs` structure.

- **Bug Fixes**
  - Improved error handling in various methods to provide clearer feedback and maintain robust control flow.

- **Documentation**
  - Enhanced comments and documentation to clarify the usage of updated methods and structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->