### PR TITLE
Fix WASM bindings release workflow

### DIFF
--- a/.github/workflows/release-wasm-bindings.yml
+++ b/.github/workflows/release-wasm-bindings.yml
@@ -10,7 +10,7 @@ jobs:
   release:
     permissions:
       id-token: write
-    runs-on: warp-ubuntu-latest-x64-16x
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -25,6 +25,11 @@ jobs:
           workspaces: |
             .
             bindings_wasm
+
+      - name: Install wasm-bindgen and wasm-opt
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-bindgen, wasm-opt
 
       - name: Setup node
         uses: actions/setup-node@v4


### PR DESCRIPTION
# Summary

- Use official GitHub runner for publishing with provenance
- Install `wasm-bindgen` and `wasm-opt` before building

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the workflow configuration for releasing WASM bindings to simplify the environment specification.
	- Added a new step to install `wasm-bindgen` and `wasm-opt` tools efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->