### PR TITLE
Bindings for the DM peer inbox id

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -3958,6 +3958,27 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
+    async fn test_get_dm_peer_inbox_id() {
+        let alix = new_test_client().await;
+        let bo = new_test_client().await;
+
+        let alix_dm = alix
+            .conversations()
+            .create_dm(bo.account_address.clone())
+            .await
+            .unwrap();
+
+        let alix_dm_peer_inbox = alix_dm.dm_peer_inbox_id().unwrap();
+        assert_eq!(alix_dm_peer_inbox, bo.inbox_id());
+
+        bo.conversations().sync().await.unwrap();
+        let bo_dm = bo.conversation(alix_dm.id()).unwrap();
+
+        let bo_dm_peer_inbox = bo_dm.dm_peer_inbox_id().unwrap();
+        assert_eq!(bo_dm_peer_inbox, alix.inbox_id());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
     async fn test_set_and_get_member_consent() {
         let alix = new_test_client().await;
         let bo = new_test_client().await;

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -1416,6 +1416,10 @@ impl FfiConversation {
             inner: Arc::new(metadata),
         }))
     }
+
+    pub fn dm_peer_inbox_id(&self) -> Result<String, GenericError> {
+        self.inner.dm_inbox_id().map_err(Into::into)
+    }
 }
 
 #[uniffi::export]

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -1005,15 +1005,11 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
     /// Find the `inbox_id` of the group member who is the peer of this dm
     pub fn dm_inbox_id(&self) -> Result<String, GroupError> {
         let conn = self.context().store().conn()?;
-        conn.find_group(self.group_id.clone())
-            .map_err(GroupError::from)
-            .and_then(|fetch_result| {
-                fetch_result
-                    .map(|group| group.dm_inbox_id.clone())
-                    .ok_or_else(|| GroupError::GroupNotFound)
-            })
+        let group = conn
+            .find_group(self.group_id.clone())?
+            .ok_or(GroupError::GroupNotFound)?;
+        Ok(group.dm_inbox_id.ok_or(GroupError::GroupNotFound)?)
     }
-
 
     /// Find the `consent_state` of the group
     pub fn consent_state(&self) -> Result<ConsentState, GroupError> {

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -1008,7 +1008,7 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
         let group = conn
             .find_group(self.group_id.clone())?
             .ok_or(GroupError::GroupNotFound)?;
-        Ok(group.dm_inbox_id.ok_or(GroupError::GroupNotFound)?)
+        group.dm_inbox_id.ok_or(GroupError::GroupNotFound)
     }
 
     /// Find the `consent_state` of the group

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -1002,6 +1002,19 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
             })
     }
 
+    /// Find the `inbox_id` of the group member who is the peer of this dm
+    pub fn dm_inbox_id(&self) -> Result<String, GroupError> {
+        let conn = self.context().store().conn()?;
+        conn.find_group(self.group_id.clone())
+            .map_err(GroupError::from)
+            .and_then(|fetch_result| {
+                fetch_result
+                    .map(|group| group.dm_inbox_id.clone())
+                    .ok_or_else(|| GroupError::GroupNotFound)
+            })
+    }
+
+
     /// Find the `consent_state` of the group
     pub fn consent_state(&self) -> Result<ConsentState, GroupError> {
         let conn = self.context().store().conn()?;


### PR DESCRIPTION
Performance will greatly improve if we can get this off the stored group instead of fetching the members.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced methods to retrieve the inbox ID of direct messaging peers for both individual conversations and group contexts.
- **Bug Fixes**
	- Added test cases to ensure the accuracy of the new inbox ID retrieval methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->