### PR TITLE
update bindings wasm build & xtask

### DIFF
--- a/.github/workflows/lint-wasm-bindings.yaml
+++ b/.github/workflows/lint-wasm-bindings.yaml
@@ -1,5 +1,4 @@
 name: Lint WASM Bindings
-
 on:
   pull_request:
     paths:
@@ -15,18 +14,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Update rust toolchains
         run: rustup update
-
       - name: Cache
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: |
             bindings_wasm
-
       - name: Run clippy and fail on warnings
-        run: cargo clippy --manifest-path bindings_wasm/Cargo.toml --all-features --all-targets --no-deps -- -Dwarnings
-
+        run: cargo clippy --manifest-path bindings_wasm/Cargo.toml --all-features --target wasm32-unknown-unknown --no-deps -- -Dwarnings
       - name: Run format check
         run: cargo fmt --manifest-path bindings_wasm/Cargo.toml --check

--- a/bindings_wasm/build.rs
+++ b/bindings_wasm/build.rs
@@ -1,0 +1,10 @@
+use std::env;
+// use std::process::Command;
+
+fn main() {
+  let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+  if target_arch != "wasm32" {
+    // Emit a compile error if the target is not wasm32-unknown-unknown
+    panic!("This crate only supports the wasm32 architecture");
+  }
+}

--- a/bindings_wasm/package.json
+++ b/bindings_wasm/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "build": "yarn clean && yarn build:web && yarn clean:release",
-    "build:web": "cargo xtask build BindingsWasm --out-dir ./dist -- --release",
+    "build:web": "cargo xtask build BindingsWasm --out-dir ./dist --plain -- --release",
     "clean:release": "rm -f ./dist/package.json",
     "clean": "rm -rf ./dist",
     "format:check": "cargo fmt --check",

--- a/bindings_wasm/src/mls_client.rs
+++ b/bindings_wasm/src/mls_client.rs
@@ -8,7 +8,7 @@ use xmtp_api_http::XmtpHttpApiClient;
 use xmtp_cryptography::signature::ed25519_public_key_to_address;
 use xmtp_id::associations::builder::SignatureRequest;
 use xmtp_mls::builder::ClientBuilder;
-use xmtp_mls::groups::scoped_client::LocalScopedGroupClient;
+use xmtp_mls::groups::scoped_client::ScopedGroupClient;
 use xmtp_mls::identity::IdentityStrategy;
 use xmtp_mls::storage::{EncryptedMessageStore, EncryptionKey, StorageOption};
 use xmtp_mls::Client as MlsClient;

--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -23,7 +23,7 @@ pub fn build(extra_args: &[String], flags: flags::Build) -> Result<()> {
     } else {
         sp_running = Some(sp.start());
         Box::new(|s: &str| {
-            sp_running.as_ref().unwrap().text(s).update();
+            sp_running.as_ref().unwrap().text(s.trim()).update();
         }) as Box<dyn Fn(&str)>
     };
 
@@ -180,7 +180,7 @@ fn pretty_print<T>(cmd: xshell::Cmd, f: impl Fn(&str) -> T) -> Result<()> {
             let mut buf = String::new();
             reader.read_line(&mut buf)?;
             if !buf.is_empty() {
-                f(buf.trim());
+                f(&buf);
             }
         }
     }

--- a/xtask/src/cmds.rs
+++ b/xtask/src/cmds.rs
@@ -17,6 +17,8 @@ pub mod flags {
                 cmd BindingsWasm {
                     optional -o,--out-dir path: PathBuf
                 }
+                /// plain output, dont show a spinner
+                optional --plain
             }
         }
     }
@@ -36,6 +38,7 @@ pub mod flags {
 
     #[derive(Debug)]
     pub struct Build {
+        pub plain: bool,
         pub subcommand: BuildCmd,
     }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -5,7 +5,7 @@ use color_eyre::eyre::Result;
 use std::env;
 
 pub use cmds::flags;
-// pub const WASM_RUSTFLAGS: &str = "-Ctarget-feature=+bulk-memory,+mutable-globals";
+pub const WASM_RUSTFLAGS: &str = "-Ctarget-feature=+bulk-memory,+mutable-globals";
 
 pub mod tasks {
     use super::*;


### PR DESCRIPTION
This explicitly disallows the wasm bindings to be built with any target other than `wasm32-unknown-unknown`, as well as lets the xtask run w/o a spinner.

It also adds RUSTFLAGS to the xtask build, in order to enable building the webassembly with `bulk-memory`, which is required for `wasm-opt`