### PR TITLE
chore(dep): upgrading tonic to 0.12.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4727,9 +4727,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+checksum = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile 2.2.0",
@@ -5823,9 +5823,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f6ba989e4b2c58ae83d862d3a3e27690b6e3ae630d0deb59f3697f32aa88ad"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ tokio = { version = "1.35.1", default-features = false }
 # Test with Android and Swift first.
 # Its probably preferable to one day use https://github.com/rustls/rustls-native-certs
 # Until then, always test agains iOS/Android after updating these dependencies & making a PR
-tonic = { version = "0.12", features = ["tls", "tls-native-roots", "tls-webpki-roots"] }
+tonic = { version = "0.12.3", features = ["tls", "tls-native-roots", "tls-webpki-roots"] }
 rustls = { version = "=0.23.7", features = ["ring"] }
 # Pinned Dependencies
 tracing = { version = "0.1", features = ["log", "release_max_level_debug"] }


### PR DESCRIPTION
**Description**
Upgrade tonic to version 0.12.3.

**Issue**
The current version has a vulnerability reported [here RUSTSEC-2024-0376](https://rustsec.org/advisories/RUSTSEC-2024-0376.html).