### PR TITLE
Stop running advisories CI step twice

### DIFF
--- a/.github/workflows/cargo-deny-checker.yml
+++ b/.github/workflows/cargo-deny-checker.yml
@@ -1,5 +1,10 @@
 name: Cargo-Deny Checker
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   cargo-deny:


### PR DESCRIPTION
Since there was no selector on the branch, it would just run twice