### PR TITLE
Filter initial membership change message in dm groups from SDK

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -1660,11 +1660,11 @@ impl FfiConversationMetadata {
         self.inner.creator_inbox_id.clone()
     }
 
-    pub fn conversation_type(&self) -> String {
+    pub fn conversation_type(&self) -> FfiConversationType {
         match self.inner.conversation_type {
-            ConversationType::Group => "group".to_string(),
-            ConversationType::Dm => "dm".to_string(),
-            ConversationType::Sync => "sync".to_string(),
+            ConversationType::Group => FfiConversationType::Group,
+            ConversationType::Dm => FfiConversationType::Dm,
+            ConversationType::Sync => FfiConversationType::Sync,
         }
     }
 }

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -967,6 +967,15 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
         Ok(mutable_metadata.super_admin_list.contains(&inbox_id))
     }
 
+    /// Retrieves the conversation type of the group from the group's metadata extension.
+    pub fn conversation_type(
+        &self,
+        provider: impl OpenMlsProvider,
+    ) -> Result<ConversationType, GroupError> {
+        let metadata = self.metadata(provider)?;
+        Ok(metadata.conversation_type)
+    }
+
     /// Updates the admin list of the group and syncs the changes to the network.
     pub async fn update_admin_list(
         &self,

--- a/xmtp_mls/src/storage/encrypted_store/group_message.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group_message.rs
@@ -148,6 +148,11 @@ impl MsgQueryArgs {
         self
     }
 
+    pub fn maybe_kind(mut self, kind: Option<GroupMessageKind>) -> Self {
+        self.kind = kind;
+        self
+    }
+
     pub fn direction(mut self, direction: SortDirection) -> Self {
         self.direction = Some(direction);
         self


### PR DESCRIPTION
Closes https://github.com/xmtp/libxmtp/issues/1228


DM groups only ever have one membership change message, and it happens on DM creation, and if it fails DM is not created. You can not leave or add new ids to a DM group. Therefore it should be safe to just filter membership change messages from `find_messages` "queries" in DM groups in order to clear out the noisy user added message at the beginning of all DM groups.