### PR TITLE
fix(sync): skip already processed messages

### DIFF
--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -754,12 +754,12 @@ where
     ) -> Result<Vec<GroupMessage>, ClientError> {
         let id_cursor = conn.get_last_cursor_for_id(group_id, EntityKind::Group)?;
 
-        let welcomes = self
+        let messages = self
             .api_client
             .query_group_messages(group_id.to_vec(), Some(id_cursor as u64))
             .await?;
 
-        Ok(welcomes)
+        Ok(messages)
     }
 
     /// Query for welcome messages that have a `sequence_id` > than the highest cursor

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -3358,11 +3358,11 @@ pub(crate) mod tests {
             .unwrap();
 
         let alix_message = vec![1];
-        alix_group
-            .send_message(&alix_message)
+        alix_group.send_message(&alix_message).await.unwrap();
+        bo_client
+            .sync_welcomes(&bo_client.store().conn().unwrap())
             .await
             .unwrap();
-        bo_client.sync_welcomes(&bo_client.store().conn().unwrap()).await.unwrap();
         let bo_groups = bo_client.find_groups(GroupQueryArgs::default()).unwrap();
         let bo_group = bo_groups.first().unwrap();
 
@@ -3378,7 +3378,9 @@ pub(crate) mod tests {
             }
         }
 
-        let process_result = bo_group.process_messages(bo_messages_from_api, &bo_client.mls_provider().unwrap()).await;
+        let process_result = bo_group
+            .process_messages(bo_messages_from_api, &bo_client.mls_provider().unwrap())
+            .await;
         if let Some(GroupError::ReceiveErrors(errors)) = process_result.err() {
             assert_eq!(errors.len(), 2);
             assert!(errors

--- a/xmtp_mls/src/intents.rs
+++ b/xmtp_mls/src/intents.rs
@@ -60,13 +60,13 @@ impl Intents {
                 );
                 result
             })
-            .map_err(|err| {
+            .inspect_err(|err| {
                 tracing::info!(
-                    "Transaction failed: process for entity [{:?}] envelope cursor[{}]",
+                    "Transaction failed: process for entity [{:?}] envelope cursor[{}] error:[{}]",
                     entity_id,
-                    cursor
+                    cursor,
+                    err
                 );
-                err
             })
     }
 }

--- a/xmtp_mls/src/intents.rs
+++ b/xmtp_mls/src/intents.rs
@@ -52,5 +52,27 @@ impl Intents {
                 process_envelope(provider).await
             })
             .await
+            .map(|result| {
+                tracing::info!(
+                    entity_id,
+                    entity_kind,
+                    cursor,
+                    "Transaction completed successfully: process for entity [{}] envelope cursor[{}]",
+                    entity_id,
+                    cursor
+                );
+                result
+            })
+            .map_err(|err| {
+                tracing::info!(
+                    entity_id,
+                    entity_kind,
+                    cursor,
+                    "Transaction failed: process for entity [{}] envelope cursor[{}]",
+                    entity_id,
+                    cursor
+                );
+                err
+            })
     }
 }

--- a/xmtp_mls/src/intents.rs
+++ b/xmtp_mls/src/intents.rs
@@ -52,13 +52,12 @@ impl Intents {
                 process_envelope(provider).await
             })
             .await
-            .map(|result| {
+            .inspect(|_| {
                 tracing::info!(
                     "Transaction completed successfully: process for entity [{:?}] envelope cursor[{}]",
                     entity_id,
                     cursor
-                );
-                result
+            );
             })
             .inspect_err(|err| {
                 tracing::info!(

--- a/xmtp_mls/src/intents.rs
+++ b/xmtp_mls/src/intents.rs
@@ -54,10 +54,7 @@ impl Intents {
             .await
             .map(|result| {
                 tracing::info!(
-                    entity_id,
-                    entity_kind,
-                    cursor,
-                    "Transaction completed successfully: process for entity [{}] envelope cursor[{}]",
+                    "Transaction completed successfully: process for entity [{:?}] envelope cursor[{}]",
                     entity_id,
                     cursor
                 );
@@ -65,10 +62,7 @@ impl Intents {
             })
             .map_err(|err| {
                 tracing::info!(
-                    entity_id,
-                    entity_kind,
-                    cursor,
-                    "Transaction failed: process for entity [{}] envelope cursor[{}]",
+                    "Transaction failed: process for entity [{:?}] envelope cursor[{}]",
                     entity_id,
                     cursor
                 );


### PR DESCRIPTION
**Description:**
Added a check to skip processing messages that have already been handled, returning an AlreadyProcessed error when a duplicate message is detected.

**Issue:**
Previously, a race condition or repeated messages from an integrator feed could cause the message processor to reprocess already-handled messages. This could result in multiple wrong-epoch errors, increasing the risk of missing critical messages due to excessive error handling within the message stream.

**Tests:**
- [x] Added unit tests.
Created a test to simulate the scenario where a message has already been processed, ensuring the new check correctly identifies and skips duplicates.