### PR TITLE
Error handling refactor

### DIFF
--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::HashMap,
-    mem::Discriminant,
     sync::{
         atomic::{AtomicUsize, Ordering},
         Arc,
@@ -9,14 +8,11 @@ use std::{
 
 use futures::stream::{self, FuturesUnordered, StreamExt};
 use openmls::{
-    credentials::errors::BasicCredentialError,
     framing::{MlsMessageBodyIn, MlsMessageIn},
-    group::GroupEpoch,
     messages::Welcome,
     prelude::tls_codec::{Deserialize, Error as TlsCodecError},
 };
 use openmls_traits::OpenMlsProvider;
-use prost::EncodeError;
 use thiserror::Error;
 use tokio::sync::broadcast;
 
@@ -35,26 +31,23 @@ use xmtp_proto::xmtp::mls::api::v1::{
     GroupMessage, WelcomeMessage,
 };
 
-use crate::storage::wallet_addresses::WalletEntry;
 use crate::{
     api::ApiClientWrapper,
-    groups::{
-        group_permissions::PolicySet, validated_commit::CommitValidationError, GroupError,
-        GroupMetadataOptions, IntentError, MlsGroup,
-    },
+    groups::{group_permissions::PolicySet, GroupError, GroupMetadataOptions, MlsGroup},
     identity::{parse_credential, Identity, IdentityError},
     identity_updates::{load_identity_updates, IdentityUpdateError},
     intents::Intents,
     mutex_registry::MutexRegistry,
     retry::Retry,
     retry_async, retryable,
+    storage::wallet_addresses::WalletEntry,
     storage::{
         consent_record::{ConsentState, ConsentType, StoredConsentRecord},
         db_connection::DbConnection,
         group::{GroupMembershipState, GroupQueryArgs, StoredGroup},
         group_message::StoredGroupMessage,
         refresh_state::EntityKind,
-        sql_key_store, EncryptedMessageStore, StorageError,
+        EncryptedMessageStore, StorageError,
     },
     subscriptions::{LocalEventError, LocalEvents},
     verified_key_package_v2::{KeyPackageVerificationError, VerifiedKeyPackageV2},
@@ -91,8 +84,6 @@ pub enum ClientError {
     TlsError(#[from] TlsCodecError),
     #[error("key package verification: {0}")]
     KeyPackageVerification(#[from] KeyPackageVerificationError),
-    #[error("syncing errors: {0:?}")]
-    SyncingError(Vec<MessageProcessingError>),
     #[error("Stream inconsistency error: {0}")]
     StreamInconsistency(String),
     #[error("Association error: {0}")]
@@ -126,86 +117,6 @@ impl crate::retry::RetryableError for ClientError {
             ClientError::Api(api_error) => retryable!(api_error),
             ClientError::Storage(storage_error) => retryable!(storage_error),
             ClientError::Generic(err) => err.contains("database is locked"),
-            _ => false,
-        }
-    }
-}
-
-/// Errors that can occur when reading and processing a message off the network
-#[derive(Debug, Error)]
-pub enum MessageProcessingError {
-    #[error("[{0}] already processed")]
-    AlreadyProcessed(u64),
-    #[error("diesel error: {0}")]
-    Diesel(#[from] diesel::result::Error),
-    #[error("[{message_time_ns:?}] invalid sender with credential: {credential:?}")]
-    InvalidSender {
-        message_time_ns: u64,
-        credential: Vec<u8>,
-    },
-    #[error("invalid payload")]
-    InvalidPayload,
-    #[error(transparent)]
-    Identity(#[from] IdentityError),
-    #[error("openmls process message error: {0}")]
-    OpenMlsProcessMessage(#[from] openmls::prelude::ProcessMessageError),
-    #[error("merge staged commit: {0}")]
-    MergeStagedCommit(#[from] openmls::group::MergeCommitError<sql_key_store::SqlKeyStoreError>),
-    #[error(
-        "no pending commit to merge. group epoch is {group_epoch:?} and got {message_epoch:?}"
-    )]
-    NoPendingCommit {
-        message_epoch: GroupEpoch,
-        group_epoch: GroupEpoch,
-    },
-    #[error("intent error: {0}")]
-    Intent(#[from] IntentError),
-    #[error("storage error: {0}")]
-    Storage(#[from] crate::storage::StorageError),
-    #[error("TLS Codec error: {0}")]
-    TlsError(#[from] TlsCodecError),
-    #[error("unsupported message type: {0:?}")]
-    UnsupportedMessageType(Discriminant<MlsMessageBodyIn>),
-    #[error("commit validation")]
-    CommitValidation(#[from] CommitValidationError),
-    #[error("codec")]
-    Codec(#[from] crate::codecs::CodecError),
-    #[error("encode proto: {0}")]
-    EncodeProto(#[from] EncodeError),
-    #[error("epoch increment not allowed")]
-    EpochIncrementNotAllowed,
-    #[error("Welcome processing error: {0}")]
-    WelcomeProcessing(Box<GroupError>),
-    #[error("wrong credential type")]
-    WrongCredentialType(#[from] BasicCredentialError),
-    #[error("proto decode error: {0}")]
-    DecodeError(#[from] prost::DecodeError),
-    #[error("clear pending commit error: {0}")]
-    ClearPendingCommit(#[from] sql_key_store::SqlKeyStoreError),
-    #[error(transparent)]
-    Group(#[from] Box<GroupError>),
-    #[error("Serialization/Deserialization Error {0}")]
-    Serde(#[from] serde_json::Error),
-    #[error("generic:{0}")]
-    Generic(String),
-    #[error("intent is missing staged_commit field")]
-    IntentMissingStagedCommit,
-    #[error(transparent)]
-    Deserialization(#[from] xmtp_id::associations::DeserializationError),
-    #[error(transparent)]
-    LocalEvent(#[from] LocalEventError),
-}
-
-impl crate::retry::RetryableError for MessageProcessingError {
-    fn is_retryable(&self) -> bool {
-        match self {
-            Self::Group(group_error) => retryable!(group_error),
-            Self::Identity(identity_error) => retryable!(identity_error),
-            Self::OpenMlsProcessMessage(err) => retryable!(err),
-            Self::MergeStagedCommit(err) => retryable!(err),
-            Self::Diesel(diesel_error) => retryable!(diesel_error),
-            Self::Storage(s) => retryable!(s),
-            Self::Generic(err) => err.contains("database is locked"),
             _ => false,
         }
     }
@@ -857,9 +768,7 @@ where
                                             tracing::error!("failed to create group from welcome: {}", err);
                                         }
 
-                                        Err(MessageProcessingError::WelcomeProcessing(
-                                            Box::new(err)
-                                        ))
+                                        Err(err)
                                     }
                                 }
                             },

--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -1,8 +1,3 @@
-use std::{
-    collections::{HashMap, HashSet},
-    mem::discriminant,
-};
-
 use super::{
     build_extensions_for_admin_lists_update, build_extensions_for_metadata_update,
     build_extensions_for_permissions_update, build_group_membership_extension,
@@ -10,12 +5,10 @@ use super::{
         Installation, PostCommitAction, SendMessageIntentData, SendWelcomesAction,
         UpdateAdminListIntentData, UpdateGroupMembershipIntentData, UpdatePermissionIntentData,
     },
-    validated_commit::extract_group_membership,
-    GroupError, MlsGroup, ScopedGroupClient,
+    validated_commit::{extract_group_membership, CommitValidationError},
+    GroupError, IntentError, MlsGroup, ScopedGroupClient,
 };
-
 use crate::{
-    client::MessageProcessingError,
     codecs::{group_updated::GroupUpdatedCodec, ContentCodec},
     configuration::{
         GRPC_DATA_LIMIT, MAX_GROUP_SIZE, MAX_INTENT_PUBLISH_ATTEMPTS, MAX_PAST_EPOCHS,
@@ -23,8 +16,9 @@ use crate::{
     },
     groups::{intents::UpdateMetadataIntentData, validated_commit::ValidatedCommit},
     hpke::{encrypt_welcome, HpkeError},
-    identity::parse_credential,
+    identity::{parse_credential, IdentityError},
     identity_updates::load_identity_updates,
+    intents::ProcessIntentError,
     retry::{Retry, RetryableError},
     retry_async,
     storage::{
@@ -33,6 +27,7 @@ use crate::{
         group_message::{DeliveryStatus, GroupMessageKind, StoredGroupMessage},
         refresh_state::EntityKind,
         serialization::{db_deserialize, db_serialize},
+        sql_key_store,
     },
     subscriptions::LocalEvents,
     utils::{hash::sha256, id::calculate_message_id},
@@ -41,7 +36,6 @@ use crate::{
 };
 use crate::{groups::device_sync::DeviceSyncContent, subscriptions::SyncMessage};
 use futures::future::try_join_all;
-use openmls::framing::WireFormat;
 use openmls::{
     credentials::BasicCredential,
     extensions::Extensions,
@@ -49,15 +43,21 @@ use openmls::{
     group::{GroupEpoch, StagedCommit},
     key_packages::KeyPackage,
     prelude::{
-        tls_codec::{Deserialize, Serialize},
+        tls_codec::{Deserialize, Error as TlsCodecError, Serialize},
         LeafNodeIndex, MlsGroup as OpenMlsGroup, MlsMessageBodyIn, MlsMessageIn, PrivateMessageIn,
         ProcessedMessage, ProcessedMessageContent, Sender,
     },
     treesync::LeafNodeParameters,
 };
+use openmls::{framing::WireFormat, prelude::BasicCredentialError};
 use openmls_traits::{signatures::Signer, OpenMlsProvider};
 use prost::bytes::Bytes;
 use prost::Message;
+use std::{
+    collections::{HashMap, HashSet},
+    mem::{discriminant, Discriminant},
+};
+use thiserror::Error;
 use tracing::debug;
 use xmtp_id::{InboxId, InboxIdRef};
 use xmtp_proto::xmtp::mls::{
@@ -73,6 +73,86 @@ use xmtp_proto::xmtp::mls::{
         GroupUpdated, PlaintextEnvelope,
     },
 };
+
+#[derive(Debug, Error)]
+pub enum GroupMessageProcessingError {
+    #[error("[{0}] already processed")]
+    AlreadyProcessed(u64),
+    #[error("diesel error: {0}")]
+    Diesel(#[from] diesel::result::Error),
+    #[error("[{message_time_ns:?}] invalid sender with credential: {credential:?}")]
+    InvalidSender {
+        message_time_ns: u64,
+        credential: Vec<u8>,
+    },
+    #[error("invalid payload")]
+    InvalidPayload,
+    #[error("storage error: {0}")]
+    Storage(#[from] crate::storage::StorageError),
+    #[error(transparent)]
+    Identity(#[from] IdentityError),
+    #[error("openmls process message error: {0}")]
+    OpenMlsProcessMessage(#[from] openmls::prelude::ProcessMessageError),
+    #[error("merge staged commit: {0}")]
+    MergeStagedCommit(#[from] openmls::group::MergeCommitError<sql_key_store::SqlKeyStoreError>),
+    #[error("TLS Codec error: {0}")]
+    TlsError(#[from] TlsCodecError),
+    #[error("unsupported message type: {0:?}")]
+    UnsupportedMessageType(Discriminant<MlsMessageBodyIn>),
+    #[error("commit validation")]
+    CommitValidation(#[from] CommitValidationError),
+    #[error("epoch increment not allowed")]
+    EpochIncrementNotAllowed,
+    #[error("clear pending commit error: {0}")]
+    ClearPendingCommit(#[from] sql_key_store::SqlKeyStoreError),
+    #[error("Serialization/Deserialization Error {0}")]
+    Serde(#[from] serde_json::Error),
+    #[error("intent is missing staged_commit field")]
+    IntentMissingStagedCommit,
+    #[error("encode proto: {0}")]
+    EncodeProto(#[from] prost::EncodeError),
+    #[error("proto decode error: {0}")]
+    DecodeProto(#[from] prost::DecodeError),
+    #[error(transparent)]
+    Intent(#[from] IntentError),
+    #[error(transparent)]
+    Codec(#[from] crate::codecs::CodecError),
+    #[error("wrong credential type")]
+    WrongCredentialType(#[from] BasicCredentialError),
+    #[error(transparent)]
+    ProcessIntent(#[from] ProcessIntentError),
+    #[error(transparent)]
+    AssociationDeserialization(#[from] xmtp_id::associations::DeserializationError),
+}
+
+impl crate::retry::RetryableError for GroupMessageProcessingError {
+    fn is_retryable(&self) -> bool {
+        match self {
+            Self::Diesel(err) => err.is_retryable(),
+            Self::Storage(err) => err.is_retryable(),
+            Self::Identity(err) => err.is_retryable(),
+            Self::OpenMlsProcessMessage(err) => err.is_retryable(),
+            Self::MergeStagedCommit(err) => err.is_retryable(),
+            Self::ProcessIntent(err) => err.is_retryable(),
+            Self::CommitValidation(err) => err.is_retryable(),
+            Self::ClearPendingCommit(err) => err.is_retryable(),
+            Self::WrongCredentialType(_)
+            | Self::Codec(_)
+            | Self::AlreadyProcessed(_)
+            | Self::InvalidSender { .. }
+            | Self::DecodeProto(_)
+            | Self::InvalidPayload
+            | Self::Intent(_)
+            | Self::EpochIncrementNotAllowed
+            | Self::EncodeProto(_)
+            | Self::IntentMissingStagedCommit
+            | Self::Serde(_)
+            | Self::AssociationDeserialization(_)
+            | Self::TlsError(_)
+            | Self::UnsupportedMessageType(_) => false,
+        }
+    }
+}
 
 #[derive(Debug)]
 struct PublishIntentData {
@@ -272,7 +352,7 @@ where
         provider: &XmtpOpenMlsProvider,
         message: ProtocolMessage,
         envelope: &GroupMessageV1,
-    ) -> Result<IntentState, MessageProcessingError> {
+    ) -> Result<IntentState, GroupMessageProcessingError> {
         let GroupMessageV1 {
             created_ns: envelope_timestamp_ns,
             id: ref msg_id,
@@ -330,7 +410,7 @@ where
                 let pending_commit = if let Some(staged_commit) = intent.staged_commit {
                     decode_staged_commit(staged_commit)?
                 } else {
-                    return Err(MessageProcessingError::IntentMissingStagedCommit);
+                    return Err(GroupMessageProcessingError::IntentMissingStagedCommit);
                 };
 
                 tracing::info!(
@@ -400,7 +480,7 @@ where
         provider: &XmtpOpenMlsProvider,
         message: PrivateMessageIn,
         envelope: &GroupMessageV1,
-    ) -> Result<(), MessageProcessingError> {
+    ) -> Result<(), GroupMessageProcessingError> {
         let GroupMessageV1 {
             created_ns: envelope_timestamp_ns,
             id: ref msg_id,
@@ -446,8 +526,7 @@ where
                 let message_bytes = application_message.into_bytes();
 
                 let mut bytes = Bytes::from(message_bytes.clone());
-                let envelope = PlaintextEnvelope::decode(&mut bytes)
-                    .map_err(MessageProcessingError::DecodeError)?;
+                let envelope = PlaintextEnvelope::decode(&mut bytes)?;
 
                 match envelope.content {
                     Some(Content::V1(V1 {
@@ -552,10 +631,10 @@ where
                             conn.insert_or_replace_consent_records(&[update.try_into()?])?;
                         }
                         _ => {
-                            return Err(MessageProcessingError::InvalidPayload);
+                            return Err(GroupMessageProcessingError::InvalidPayload);
                         }
                     },
-                    None => return Err(MessageProcessingError::InvalidPayload),
+                    None => return Err(GroupMessageProcessingError::InvalidPayload),
                 }
             }
             ProcessedMessageContent::ProposalMessage(_proposal_ptr) => {
@@ -619,17 +698,17 @@ where
         provider: &XmtpOpenMlsProvider,
         envelope: &GroupMessageV1,
         allow_epoch_increment: bool,
-    ) -> Result<(), MessageProcessingError> {
+    ) -> Result<(), GroupMessageProcessingError> {
         let mls_message_in = MlsMessageIn::tls_deserialize_exact(&envelope.data)?;
 
         let message = match mls_message_in.extract() {
             MlsMessageBodyIn::PrivateMessage(message) => Ok(message),
-            other => Err(MessageProcessingError::UnsupportedMessageType(
+            other => Err(GroupMessageProcessingError::UnsupportedMessageType(
                 discriminant(&other),
             )),
         }?;
         if !allow_epoch_increment && message.content_type() == ContentType::Commit {
-            return Err(MessageProcessingError::EpochIncrementNotAllowed);
+            return Err(GroupMessageProcessingError::EpochIncrementNotAllowed);
         }
 
         let intent = provider
@@ -694,7 +773,7 @@ where
                 self.process_external_message(openmls_group, provider, message, envelope)
                     .await
             }
-            Err(err) => Err(MessageProcessingError::Storage(err)),
+            Err(err) => Err(GroupMessageProcessingError::Storage(err)),
         }
     }
 
@@ -704,10 +783,10 @@ where
         envelope: &GroupMessage,
         openmls_group: &mut OpenMlsGroup,
         conn: &DbConnection,
-    ) -> Result<(), MessageProcessingError> {
+    ) -> Result<(), GroupMessageProcessingError> {
         let msgv1 = match &envelope.version {
             Some(GroupMessageVersion::V1(value)) => value,
-            _ => return Err(MessageProcessingError::InvalidPayload),
+            _ => return Err(GroupMessageProcessingError::InvalidPayload),
         };
 
         let mls_message_in = MlsMessageIn::tls_deserialize_exact(&msgv1.data)?;
@@ -728,7 +807,7 @@ where
                 message_entity_kind,
                 last_cursor
             );
-            Err(MessageProcessingError::AlreadyProcessed(msgv1.id))
+            Err(GroupMessageProcessingError::AlreadyProcessed(msgv1.id))
         } else {
             self.client
                 .intents()
@@ -739,7 +818,7 @@ where
                     |provider| async move {
                         self.process_message(openmls_group, &provider, msgv1, true)
                             .await?;
-                        Ok(())
+                        Ok::<(), GroupMessageProcessingError>(())
                     },
                 )
                 .await?;
@@ -755,7 +834,7 @@ where
     ) -> Result<(), GroupError> {
         let mut openmls_group = self.load_mls_group(provider)?;
 
-        let mut receive_errors = vec![];
+        let mut receive_errors: Vec<GroupMessageProcessingError> = vec![];
         for message in messages.into_iter() {
             let result = retry_async!(
                 Retry::default(),
@@ -804,7 +883,7 @@ where
         conn: &DbConnection,
         validated_commit: ValidatedCommit,
         timestamp_ns: u64,
-    ) -> Result<Option<StoredGroupMessage>, MessageProcessingError> {
+    ) -> Result<Option<StoredGroupMessage>, GroupMessageProcessingError> {
         if validated_commit.is_empty() {
             return Ok(None);
         }
@@ -1273,7 +1352,7 @@ fn extract_message_sender(
     openmls_group: &mut OpenMlsGroup,
     decrypted_message: &ProcessedMessage,
     message_created_ns: u64,
-) -> Result<(InboxId, Vec<u8>), MessageProcessingError> {
+) -> Result<(InboxId, Vec<u8>), GroupMessageProcessingError> {
     if let Sender::Member(leaf_node_index) = decrypted_message.sender() {
         if let Some(member) = openmls_group.member_at(*leaf_node_index) {
             if member.credential.eq(decrypted_message.credential()) {
@@ -1285,7 +1364,7 @@ fn extract_message_sender(
     }
 
     let basic_credential = BasicCredential::try_from(decrypted_message.credential().clone())?;
-    return Err(MessageProcessingError::InvalidSender {
+    return Err(GroupMessageProcessingError::InvalidSender {
         message_time_ns: message_created_ns,
         credential: basic_credential.identity().to_vec(),
     });
@@ -1408,7 +1487,7 @@ fn get_and_clear_pending_commit(
     Ok(commit)
 }
 
-fn decode_staged_commit(data: Vec<u8>) -> Result<StagedCommit, MessageProcessingError> {
+fn decode_staged_commit(data: Vec<u8>) -> Result<StagedCommit, GroupMessageProcessingError> {
     Ok(db_deserialize(&data)?)
 }
 

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -12,6 +12,7 @@ pub(super) mod subscriptions;
 pub mod validated_commit;
 
 use intents::SendMessageIntentData;
+use mls_sync::GroupMessageProcessingError;
 use openmls::{
     credentials::{BasicCredential, CredentialType},
     error::LibraryError,
@@ -72,7 +73,7 @@ use xmtp_proto::xmtp::mls::{
 
 use crate::{
     api::WrappedApiError,
-    client::{deserialize_welcome, ClientError, MessageProcessingError, XmtpMlsLocalContext},
+    client::{deserialize_welcome, ClientError, XmtpMlsLocalContext},
     configuration::{
         CIPHERSUITE, GROUP_MEMBERSHIP_EXTENSION_ID, GROUP_PERMISSIONS_EXTENSION_ID, MAX_GROUP_SIZE,
         MAX_PAST_EPOCHS, MUTABLE_METADATA_EXTENSION_ID,
@@ -81,6 +82,7 @@ use crate::{
     hpke::{decrypt_welcome, HpkeError},
     identity::{parse_credential, IdentityError},
     identity_updates::{load_identity_updates, InstallationDiffError},
+    intents::ProcessIntentError,
     retry::RetryableError,
     storage::{
         consent_record::{ConsentState, ConsentType, StoredConsentRecord},
@@ -137,9 +139,9 @@ pub enum GroupError {
     #[error("client: {0}")]
     Client(#[from] ClientError),
     #[error("receive error: {0}")]
-    ReceiveError(#[from] MessageProcessingError),
+    ReceiveError(#[from] GroupMessageProcessingError),
     #[error("Receive errors: {0:?}")]
-    ReceiveErrors(Vec<MessageProcessingError>),
+    ReceiveErrors(Vec<GroupMessageProcessingError>),
     #[error("generic: {0}")]
     Generic(String),
     #[error("diesel error {0}")]
@@ -183,32 +185,29 @@ pub enum GroupError {
     NoPSKSupport,
     #[error("Metadata update must specify a metadata field")]
     InvalidPermissionUpdate,
-    #[error("The intent publishing task was cancelled")]
-    PublishCancelled,
-    #[error("the publish failed to complete due to panic")]
-    PublishPanicked,
     #[error("dm requires target inbox_id")]
     InvalidDmMissingInboxId,
     #[error("Missing metadata field {name}")]
     MissingMetadataField { name: String },
-    #[error("Message was processed but is missing")]
-    MissingMessage,
     #[error("sql key store error: {0}")]
     SqlKeyStore(#[from] sql_key_store::SqlKeyStoreError),
-    #[error("No pending commit found")]
-    MissingPendingCommit,
     #[error("Sync failed to wait for intent")]
     SyncFailedToWait,
     #[error("cannot change metadata of DM")]
     DmGroupMetadataForbidden,
-    #[error("Group intent could not be committed")]
+    #[error("Missing pending commit")]
+    MissingPendingCommit,
+    #[error("Intent not committed")]
     IntentNotCommitted,
+    #[error(transparent)]
+    ProcessIntent(#[from] ProcessIntentError),
 }
 
 impl RetryableError for GroupError {
     fn is_retryable(&self) -> bool {
         match self {
             Self::Api(api_error) => api_error.is_retryable(),
+            Self::ReceiveErrors(errors) => errors.iter().any(|e| e.is_retryable()),
             Self::Client(client_error) => client_error.is_retryable(),
             Self::Diesel(diesel) => diesel.is_retryable(),
             Self::Storage(storage) => storage.is_retryable(),
@@ -219,9 +218,42 @@ impl RetryableError for GroupError {
             Self::GroupCreate(group) => group.is_retryable(),
             Self::SelfUpdate(update) => update.is_retryable(),
             Self::WelcomeError(welcome) => welcome.is_retryable(),
+            Self::SqlKeyStore(sql) => sql.is_retryable(),
+            Self::Sync(errs) => errs.iter().any(|e| e.is_retryable()),
             Self::InstallationDiff(diff) => diff.is_retryable(),
             Self::CreateGroupContextExtProposalError(create) => create.is_retryable(),
-            _ => false,
+            Self::CommitValidation(err) => err.is_retryable(),
+            Self::WrappedApi(err) => err.is_retryable(),
+            Self::MessageHistory(err) => err.is_retryable(),
+            Self::ProcessIntent(err) => err.is_retryable(),
+            Self::SyncFailedToWait => true,
+            Self::GroupNotFound
+            | Self::GroupMetadata(_)
+            | Self::GroupMutableMetadata(_)
+            | Self::GroupMutablePermissions(_)
+            | Self::UserLimitExceeded
+            | Self::InvalidGroupMembership
+            | Self::Intent(_)
+            | Self::LocalEvent(_)
+            | Self::CreateMessage(_)
+            | Self::TlsError(_)
+            | Self::IntentNotCommitted
+            | Self::Generic(_)
+            | Self::InvalidDmMissingInboxId
+            | Self::MissingSequenceId
+            | Self::AddressNotFound(_)
+            | Self::InvalidExtension(_)
+            | Self::MissingMetadataField { .. }
+            | Self::DmGroupMetadataForbidden
+            | Self::Signature(_)
+            | Self::LeafNodeError(_)
+            | Self::NoPSKSupport
+            | Self::MissingPendingCommit
+            | Self::InvalidPermissionUpdate
+            | Self::AddressValidation(_)
+            | Self::InvalidPublicKeys(_)
+            | Self::CredentialError(_)
+            | Self::EncodeError(_) => false,
         }
     }
 }
@@ -1162,17 +1194,19 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
     }
 }
 
-fn extract_message_v1(message: GroupMessage) -> Result<GroupMessageV1, MessageProcessingError> {
+fn extract_message_v1(
+    message: GroupMessage,
+) -> Result<GroupMessageV1, GroupMessageProcessingError> {
     match message.version {
         Some(GroupMessageVersion::V1(value)) => Ok(value),
-        _ => Err(MessageProcessingError::InvalidPayload),
+        _ => Err(GroupMessageProcessingError::InvalidPayload),
     }
 }
 
-pub fn extract_group_id(message: &GroupMessage) -> Result<Vec<u8>, MessageProcessingError> {
+pub fn extract_group_id(message: &GroupMessage) -> Result<Vec<u8>, GroupMessageProcessingError> {
     match &message.version {
         Some(GroupMessageVersion::V1(value)) => Ok(value.group_id.clone()),
-        _ => Err(MessageProcessingError::InvalidPayload),
+        _ => Err(GroupMessageProcessingError::InvalidPayload),
     }
 }
 
@@ -1554,7 +1588,6 @@ pub(crate) mod tests {
     use crate::{
         assert_err,
         builder::ClientBuilder,
-        client::MessageProcessingError,
         codecs::{group_updated::GroupUpdatedCodec, ContentCodec},
         groups::{
             build_dm_protected_metadata_extension, build_mutable_metadata_extension_default,
@@ -1563,6 +1596,7 @@ pub(crate) mod tests {
             group_mutable_metadata::MetadataField,
             intents::{PermissionPolicyOption, PermissionUpdateType},
             members::{GroupMember, PermissionLevel},
+            mls_sync::GroupMessageProcessingError,
             validate_dm_group, DeliveryStatus, GroupError, GroupMetadataOptions,
             PreconfiguredPolicies, UpdateAdminListType,
         },
@@ -1883,7 +1917,7 @@ pub(crate) mod tests {
             let mut mls_group = alix_group.load_mls_group(&provider).unwrap();
             let mut existing_extensions = mls_group.extensions().clone();
             let mut group_membership = GroupMembership::new();
-            group_membership.add("foo".to_string(), 1);
+            group_membership.add("deadbeef".to_string(), 1);
             existing_extensions.add_or_replace(build_group_membership_extension(&group_membership));
             mls_group
                 .update_group_context_extensions(
@@ -3638,7 +3672,7 @@ pub(crate) mod tests {
 
         assert_err!(
             process_result,
-            MessageProcessingError::EpochIncrementNotAllowed
+            GroupMessageProcessingError::EpochIncrementNotAllowed
         );
     }
 

--- a/xmtp_mls/src/groups/subscriptions.rs
+++ b/xmtp_mls/src/groups/subscriptions.rs
@@ -63,13 +63,13 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
                             self.process_message(&mut openmls_group, &provider, msgv1, false)
                                 .await
                                 // NOTE: We want to make sure we retry an error in process_message
-                                .map_err(SubscribeError::Receive)
+                                .map_err(SubscribeError::ReceiveGroup)
                         })
                         .await
                 })
             );
 
-            if let Err(SubscribeError::Receive(_)) = process_result {
+            if let Err(SubscribeError::ReceiveGroup(_)) = process_result {
                 tracing::debug!(
                     inbox_id = self.client.inbox_id(),
                     group_id = hex::encode(&self.group_id),
@@ -99,8 +99,9 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
                     inbox_id = self.client.inbox_id(),
                     group_id = hex::encode(&self.group_id),
                     msg_id = msgv1.id,
-                    err = %e,
-                    "process stream entry {:?}", e
+                    err = e.to_string(),
+                    "process stream entry {:?}",
+                    e
                 );
             }
         }

--- a/xmtp_mls/src/storage/sql_key_store.rs
+++ b/xmtp_mls/src/storage/sql_key_store.rs
@@ -253,7 +253,10 @@ impl RetryableError for SqlKeyStoreError {
     fn is_retryable(&self) -> bool {
         match self {
             SqlKeyStoreError::Storage(err) => retryable!(err),
-            _ => false,
+            SqlKeyStoreError::SerializationError => false,
+            SqlKeyStoreError::UnsupportedMethod => false,
+            SqlKeyStoreError::UnsupportedValueTypeBytes => false,
+            SqlKeyStoreError::NotFound => false,
         }
     }
 }

--- a/xmtp_mls/src/subscriptions.rs
+++ b/xmtp_mls/src/subscriptions.rs
@@ -10,8 +10,8 @@ use xmtp_id::scw_verifier::SmartContractSignatureVerifier;
 use xmtp_proto::{api_client::XmtpMlsStreams, xmtp::mls::api::v1::WelcomeMessage};
 
 use crate::{
-    client::{extract_welcome_message, ClientError, MessageProcessingError},
-    groups::{subscriptions, GroupError, MlsGroup},
+    client::{extract_welcome_message, ClientError},
+    groups::{mls_sync::GroupMessageProcessingError, subscriptions, GroupError, MlsGroup},
     retry::{Retry, RetryableError},
     retry_async, retryable,
     storage::{
@@ -135,8 +135,8 @@ pub enum SubscribeError {
     Group(#[from] GroupError),
     #[error("group message expected in database but is missing")]
     GroupMessageNotFound,
-    #[error("processing message in stream: {0}")]
-    Receive(#[from] MessageProcessingError),
+    #[error("processing group message in stream: {0}")]
+    ReceiveGroup(#[from] GroupMessageProcessingError),
     #[error(transparent)]
     Database(#[from] diesel::result::Error),
     #[error(transparent)]
@@ -155,7 +155,7 @@ impl RetryableError for SubscribeError {
             Client(e) => retryable!(e),
             Group(e) => retryable!(e),
             GroupMessageNotFound => true,
-            Receive(e) => retryable!(e),
+            ReceiveGroup(e) => retryable!(e),
             Database(e) => retryable!(e),
             Storage(e) => retryable!(e),
             Api(e) => retryable!(e),


### PR DESCRIPTION
## tl;dr

- Refactors `MessageProcessingError` into `GroupMessageProcessingError` that is more narrowly scoped
- Uses `GroupError` to handle errors when processing Welcomes
- Make `process_for_id` take a generic error type to support both
- Trim down unused error variants
- Make `RetryableError` explicit and don't use `_ => false`