### PR TITLE
Add xmtpd to dev environment

### DIFF
--- a/dev/docker/docker-compose.yml
+++ b/dev/docker/docker-compose.yml
@@ -82,6 +82,6 @@ services:
       XMTPD_REPLICATION_ENABLE: true
     depends_on:
       - chain
-      - replicationdb1
+      - replicationdb
     ports:
       - 5050:5050

--- a/dev/docker/docker-compose.yml
+++ b/dev/docker/docker-compose.yml
@@ -1,3 +1,5 @@
+version: '3.8'
+
 services:
   node:
     image: xmtp/node-go:latest
@@ -56,6 +58,11 @@ services:
     image: postgres:16
     environment:
       POSTGRES_PASSWORD: xmtp
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U postgres" ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   chain:
     platform: linux/amd64
@@ -81,7 +88,9 @@ services:
       XMTPD_PAYER_ENABLE: true
       XMTPD_REPLICATION_ENABLE: true
     depends_on:
-      - chain
-      - replicationdb
+      chain:
+        condition: service_started
+      replicationdb:
+          condition: service_healthy
     ports:
       - 5050:5050

--- a/dev/docker/docker-compose.yml
+++ b/dev/docker/docker-compose.yml
@@ -51,3 +51,37 @@ services:
     image: postgres:13
     environment:
       POSTGRES_PASSWORD: xmtp
+
+  replicationdb:
+    image: postgres:16
+    environment:
+      POSTGRES_PASSWORD: xmtp
+
+  chain:
+    platform: linux/amd64
+    # note: the SHA here is tied to the XTMPD_CONTRACTS_*_ADDRESSes
+    # if you bump the version of anvil-xmtpd you will have to change the contracts
+    # you can find them inside the anvil-xmtpd image via `docker exec libxmtp-chain-1 cat contracts.env`
+    image: ghcr.io/xmtp/anvil-xmtpd:sha-0b3421b
+    command: ["--host", "0.0.0.0"]
+
+  repnode:
+    platform: linux/amd64
+    # note: avoid using :latest while xmtpd is under development to avoid breaking changes
+    image: ghcr.io/xmtp/xmtpd:sha-0b3421b
+    environment:
+      XMTPD_DB_WRITER_CONNECTION_STRING: "postgres://postgres:xmtp@replicationdb:5432/postgres?sslmode=disable"
+      XMTPD_CONTRACTS_RPC_URL: "http://chain:8545"
+      XMTPD_CONTRACTS_NODES_ADDRESS: 0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512
+      XMTPD_CONTRACTS_MESSAGES_ADDRESS: 0x5FbDB2315678afecb367f032d93F642f64180aa3
+      XMTPD_CONTRACTS_IDENTITY_UPDATES_ADDRESS: 0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0
+      XMTPD_SIGNER_PRIVATE_KEY: 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
+      XMTPD_PAYER_PRIVATE_KEY: 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
+      XMTPD_MLS_VALIDATION_GRPC_ADDRESS: "validation:50051"
+      XMTPD_PAYER_ENABLE: true
+      XMTPD_REPLICATION_ENABLE: true
+    depends_on:
+      - chain
+      - replicationdb1
+    ports:
+      - 5050:5050

--- a/dev/docker/up
+++ b/dev/docker/up
@@ -3,4 +3,4 @@ set -eou pipefail
 script_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 "${script_dir}"/compose pull
-"${script_dir}"/compose up -d --build
+"${script_dir}"/compose up -d --build --remove-orphans --wait


### PR DESCRIPTION
This adds all the required docker images to run a local `v4/replication` environment in libxmtp.

So far nothing uses the replicated node on port 5050.