### PR TITLE
fix(ci): reduce dependabot PR spam

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,19 +5,38 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      dependencies:
+        dependency-type: "production"
+      dev-dependencies:
+        dependency-type: "development"
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      actions-deps:
+        patterns:
+          - "*"
   # Maintain dependencies for yarn
   - package-ecosystem: "npm"
     directory: "/bindings_wasm"
     schedule:
       interval: "weekly"
+    groups:
+      wasm-prod:
+        dependency-type: "production"
+      wasm-dev:
+        dependency-type: "development"
   # Maintain dependencies for yarn
   - package-ecosystem: "npm"
     directory: "/bindings_node"
     schedule:
       interval: "weekly"
+      groups:
+        node-prod:
+          dependency-type: "production"
+        node-dev:
+          dependency-type: "development"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
         dependency-type: "production"
       dev-dependencies:
         dependency-type: "development"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
@@ -20,6 +23,9 @@ updates:
       actions-deps:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
   # Maintain dependencies for yarn
   - package-ecosystem: "npm"
     directory: "/bindings_wasm"
@@ -30,13 +36,19 @@ updates:
         dependency-type: "production"
       wasm-dev:
         dependency-type: "development"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
   # Maintain dependencies for yarn
   - package-ecosystem: "npm"
     directory: "/bindings_node"
     schedule:
       interval: "weekly"
-      groups:
-        node-prod:
-          dependency-type: "production"
-        node-dev:
-          dependency-type: "development"
+    groups:
+      node-prod:
+        dependency-type: "production"
+      node-dev:
+        dependency-type: "development"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
group dependabot updates based upon dev/prod for each dependency grouping (rust/node/wasm)

closes #1250 

rel #236 