### PR TITLE
Filter membership change messages in dm groups (WASM + Node)

### DIFF
--- a/bindings_node/CHANGELOG.md
+++ b/bindings_node/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @xmtp/node-bindings
 
+## 0.0.19
+
+- Renamed `Level` to `LogLevel`
+- Filtered out group membership messages from DM groups
+
 ## 0.0.18
 
 - Added `syncAllConversations` to `Conversations`

--- a/bindings_node/CHANGELOG.md
+++ b/bindings_node/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Renamed `Level` to `LogLevel`
 - Filtered out group membership messages from DM groups
+- Fixed `syncAllConversations` export
 
 ## 0.0.18
 

--- a/bindings_node/package.json
+++ b/bindings_node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/node-bindings",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "repository": {
     "type": "git",
     "url": "git+https://git@github.com/xmtp/libxmtp.git",

--- a/bindings_node/src/client.rs
+++ b/bindings_node/src/client.rs
@@ -43,7 +43,7 @@ impl Client {
 #[napi(string_enum)]
 #[derive(Debug)]
 #[allow(non_camel_case_types)]
-pub enum Level {
+pub enum LogLevel {
   off,
   error,
   warn,
@@ -52,9 +52,9 @@ pub enum Level {
   trace,
 }
 
-impl std::fmt::Display for Level {
+impl std::fmt::Display for LogLevel {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    use Level::*;
+    use LogLevel::*;
     let s = match self {
       off => "off",
       error => "error",
@@ -75,7 +75,7 @@ pub struct LogOptions {
   /// an option so that it does not require being specified in js object.
   pub structured: Option<bool>,
   /// Filter logs by level
-  pub level: Option<Level>,
+  pub level: Option<LogLevel>,
 }
 
 fn init_logging(options: LogOptions) -> Result<()> {

--- a/bindings_node/src/conversations.rs
+++ b/bindings_node/src/conversations.rs
@@ -248,6 +248,7 @@ impl Conversations {
     Ok(())
   }
 
+  #[napi]
   pub async fn sync_all_conversations(&self) -> Result<usize> {
     let groups = self
       .inner_client

--- a/bindings_node/src/message.rs
+++ b/bindings_node/src/message.rs
@@ -1,7 +1,7 @@
 use napi::bindgen_prelude::Uint8Array;
 use prost::Message as ProstMessage;
 use xmtp_mls::storage::group_message::{
-  DeliveryStatus as XmtpDeliveryStatus, GroupMessageKind as XmtpGroupMessageKind,
+  DeliveryStatus as XmtpDeliveryStatus, GroupMessageKind as XmtpGroupMessageKind, MsgQueryArgs,
   SortDirection as XmtpSortDirection, StoredGroupMessage,
 };
 
@@ -75,6 +75,20 @@ pub struct ListMessagesOptions {
   pub limit: Option<i64>,
   pub delivery_status: Option<DeliveryStatus>,
   pub direction: Option<SortDirection>,
+}
+
+impl From<ListMessagesOptions> for MsgQueryArgs {
+  fn from(opts: ListMessagesOptions) -> MsgQueryArgs {
+    let delivery_status = opts.delivery_status.map(Into::into);
+    let direction = opts.direction.map(Into::into);
+
+    MsgQueryArgs::default()
+      .maybe_sent_before_ns(opts.sent_before_ns)
+      .maybe_sent_after_ns(opts.sent_after_ns)
+      .maybe_delivery_status(delivery_status)
+      .maybe_limit(opts.limit)
+      .maybe_direction(direction)
+  }
 }
 
 #[napi(object)]

--- a/bindings_node/test/Conversations.test.ts
+++ b/bindings_node/test/Conversations.test.ts
@@ -105,7 +105,7 @@ describe('Conversations', () => {
       updateGroupPinnedFrameUrlPolicy: 0,
     })
     expect(group.addedByInboxId()).toBe(client1.inboxId())
-    expect(group.findMessages().length).toBe(1)
+    expect(group.findMessages().length).toBe(0)
     const members = await group.listMembers()
     expect(members.length).toBe(2)
     const memberInboxIds = members.map((member) => member.inboxId)

--- a/bindings_wasm/CHANGELOG.md
+++ b/bindings_wasm/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @xmtp/wasm-bindings
 
+## 0.0.5
+
+- Filtered out group membership messages from DM groups
+
 ## 0.0.4
 
 - Added smart contract wallet signature support

--- a/bindings_wasm/package.json
+++ b/bindings_wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/wasm-bindings",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "type": "module",
   "license": "MIT",
   "description": "WASM bindings for the libXMTP rust library",


### PR DESCRIPTION
# Summary

- Filtered membership change messages in DM groups
- Renamed `Level` => `LogLevel` in Node bindings
- Added `#[napi]` attribute to `sync_all_conversations` in Node bindings
- Prepared releases for WASM and Node bindings