### PR TITLE
Node Streams Debugging + Logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,6 +431,7 @@ dependencies = [
 name = "bindings_node"
 version = "0.1.0"
 dependencies = [
+ "futures",
  "hex",
  "napi",
  "napi-build",

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -112,7 +112,7 @@ pub async fn create_client(
         None => EncryptedMessageStore::new_unencrypted(storage_option).await?,
     };
     log::info!("Creating XMTP client");
-    let identity_strategy = IdentityStrategy::CreateIfNotFound(
+    let identity_strategy = IdentityStrategy::new(
         inbox_id.clone(),
         account_address.clone(),
         nonce,

--- a/bindings_node/Cargo.toml
+++ b/bindings_node/Cargo.toml
@@ -23,6 +23,7 @@ xmtp_cryptography = { path = "../xmtp_cryptography" }
 xmtp_id = { path = "../xmtp_id" }
 xmtp_mls = { path = "../xmtp_mls" }
 xmtp_proto = { path = "../xmtp_proto", features = ["proto_full"] }
+futures.workspace = true
 
 [build-dependencies]
 napi-build = "2.0.1"

--- a/bindings_node/Cargo.toml
+++ b/bindings_node/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib"]
 # Default enable napi4 feature, see https://nodejs.org/api/n-api.html#node-api-version-matrix
 hex.workspace = true
 napi = { version = "2.12.2", default-features = false, features = [
+  "napi4",
   "napi6",
   "async",
 ] }

--- a/bindings_node/src/client.rs
+++ b/bindings_node/src/client.rs
@@ -155,7 +155,7 @@ pub async fn create_client(
       .map_err(|_| Error::from_reason("Error creating unencrypted message store"))?,
   };
 
-  let identity_strategy = IdentityStrategy::CreateIfNotFound(
+  let identity_strategy = IdentityStrategy::new(
     inbox_id.clone(),
     account_address.clone().to_lowercase(),
     // this is a temporary solution

--- a/bindings_node/src/streams.rs
+++ b/bindings_node/src/streams.rs
@@ -63,6 +63,14 @@ impl StreamCloser {
     }
   }
 
+  #[napi]
+  pub async fn wait_for_ready(&self) -> Result<(), Error> {
+    let mut stream_handle = self.handle.lock().await;
+    futures::future::OptionFuture::from((*stream_handle).as_mut().map(|s| s.wait_for_ready()))
+      .await;
+    Ok(())
+  }
+
   /// Checks if this stream is closed
   #[napi]
   pub fn is_closed(&self) -> bool {

--- a/bindings_node/test/Client.test.ts
+++ b/bindings_node/test/Client.test.ts
@@ -1,7 +1,12 @@
 import { v4 } from 'uuid'
 import { toBytes } from 'viem'
 import { describe, expect, it } from 'vitest'
-import { createClient, createRegisteredClient, createUser } from '@test/helpers'
+import {
+  createClient,
+  createRegisteredClient,
+  createUser,
+  encodeTextMessage,
+} from '@test/helpers'
 import {
   ConsentEntityType,
   ConsentState,
@@ -248,5 +253,35 @@ describe('Client', () => {
     expect(() =>
       verifySignedWithPublicKey(text, signature, new Uint8Array())
     ).toThrow()
+  })
+})
+
+describe('Streams', () => {
+  it.only('should stream all messages', async () => {
+    const user = createUser()
+    const client1 = await createRegisteredClient(user)
+
+    const user2 = createUser()
+    const client2 = await createRegisteredClient(user2)
+
+    const group = await client1
+      .conversations()
+      .createGroup([user2.account.address])
+
+    await client2.conversations().sync()
+    const group2 = client2.conversations().findGroupById(group.id())
+
+    let messages = new Array()
+    let stream = client2.conversations().streamAllMessages((msg) => {
+      console.log('Message', msg)
+      messages.push(msg)
+    })
+    await stream.waitForReady()
+    group.send(encodeTextMessage('Test1'))
+    group.send(encodeTextMessage('Test2'))
+    group.send(encodeTextMessage('Test3'))
+    group.send(encodeTextMessage('Test4'))
+    await stream.endAndWait()
+    expect(messages.length).toBe(4)
   })
 })

--- a/bindings_node/test/Client.test.ts
+++ b/bindings_node/test/Client.test.ts
@@ -6,6 +6,7 @@ import {
   createRegisteredClient,
   createUser,
   encodeTextMessage,
+  sleep,
 } from '@test/helpers'
 import {
   ConsentEntityType,
@@ -257,7 +258,7 @@ describe('Client', () => {
 })
 
 describe('Streams', () => {
-  it.only('should stream all messages', async () => {
+  it('should stream all messages', async () => {
     const user = createUser()
     const client1 = await createRegisteredClient(user)
 
@@ -272,6 +273,7 @@ describe('Streams', () => {
     const group2 = client2.conversations().findGroupById(group.id())
 
     let messages = new Array()
+    client2.conversations().syncAllConversations()
     let stream = client2.conversations().streamAllMessages((msg) => {
       console.log('Message', msg)
       messages.push(msg)
@@ -281,6 +283,7 @@ describe('Streams', () => {
     group.send(encodeTextMessage('Test2'))
     group.send(encodeTextMessage('Test3'))
     group.send(encodeTextMessage('Test4'))
+    await sleep(1000)
     await stream.endAndWait()
     expect(messages.length).toBe(4)
   })

--- a/bindings_node/test/helpers.ts
+++ b/bindings_node/test/helpers.ts
@@ -80,3 +80,9 @@ export const encodeTextMessage = (text: string) => {
     content: new TextEncoder().encode(text),
   }
 }
+
+export function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}

--- a/bindings_node/test/helpers.ts
+++ b/bindings_node/test/helpers.ts
@@ -44,7 +44,7 @@ export const createClient = async (user: User) => {
     user.account.address,
     undefined,
     undefined,
-    { level: 'trace', structured: true }
+    { level: 'info' }
   )
 }
 

--- a/bindings_node/test/helpers.ts
+++ b/bindings_node/test/helpers.ts
@@ -44,7 +44,7 @@ export const createClient = async (user: User) => {
     user.account.address,
     undefined,
     undefined,
-    { level: 'info' }
+    { level: 'trace', structured: true }
   )
 }
 

--- a/bindings_wasm/src/client.rs
+++ b/bindings_wasm/src/client.rs
@@ -153,7 +153,7 @@ pub async fn create_client(
       .map_err(|_| JsError::new("Error creating unencrypted message store"))?,
   };
 
-  let identity_strategy = IdentityStrategy::CreateIfNotFound(
+  let identity_strategy = IdentityStrategy::new(
     inbox_id.clone(),
     account_address.clone().to_lowercase(),
     // this is a temporary solution

--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -535,7 +535,7 @@ where
     let inbox_id = generate_inbox_id(&w.get_address(), &nonce)?;
     let client = create_client(
         cli,
-        IdentityStrategy::CreateIfNotFound(inbox_id, w.get_address(), nonce, None),
+        IdentityStrategy::new(inbox_id, w.get_address(), nonce, None),
         client,
     )
     .await?;

--- a/xmtp_debug/src/app/clients.rs
+++ b/xmtp_debug/src/app/clients.rs
@@ -72,7 +72,7 @@ async fn new_client_inner(
         dir.join(db_name)
     };
 
-    let client = crate::DbgClient::builder(IdentityStrategy::CreateIfNotFound(
+    let client = crate::DbgClient::builder(IdentityStrategy::new(
         inbox_id,
         wallet.get_address(),
         nonce,

--- a/xmtp_mls/src/api/mls.rs
+++ b/xmtp_mls/src/api/mls.rs
@@ -70,6 +70,12 @@ where
         group_id: Vec<u8>,
         id_cursor: Option<u64>,
     ) -> Result<Vec<GroupMessage>, ApiError> {
+        tracing::debug!(
+            group_id = hex::encode(&group_id),
+            id_cursor,
+            inbox_id = self.inbox_id,
+            "query group messages"
+        );
         let mut out: Vec<GroupMessage> = vec![];
         let page_size = 100;
         let mut id_cursor = id_cursor;
@@ -114,6 +120,12 @@ where
         installation_id: Vec<u8>,
         id_cursor: Option<u64>,
     ) -> Result<Vec<WelcomeMessage>, ApiError> {
+        tracing::debug!(
+            installation_id = hex::encode(&installation_id),
+            cursor = id_cursor,
+            inbox_id = self.inbox_id,
+            "query welcomes"
+        );
         let mut out: Vec<WelcomeMessage> = vec![];
         let page_size = 100;
         let mut id_cursor = id_cursor;
@@ -162,6 +174,7 @@ where
         key_package: Vec<u8>,
         is_inbox_id_credential: bool,
     ) -> Result<(), ApiError> {
+        tracing::debug!(inbox_id = self.inbox_id, "upload key packages");
         retry_async!(
             self.retry_strategy,
             (async {
@@ -184,6 +197,7 @@ where
         &self,
         installation_keys: Vec<Vec<u8>>,
     ) -> Result<KeyPackageMap, ApiError> {
+        tracing::debug!(inbox_id = self.inbox_id, "fetch key packages");
         let res = retry_async!(
             self.retry_strategy,
             (async {
@@ -220,6 +234,7 @@ where
         &self,
         messages: &[WelcomeMessageInput],
     ) -> Result<(), ApiError> {
+        tracing::debug!(inbox_id = self.inbox_id, "send welcome messages");
         retry_async!(
             self.retry_strategy,
             (async {
@@ -236,6 +251,11 @@ where
 
     #[tracing::instrument(level = "trace", skip_all)]
     pub async fn send_group_messages(&self, group_messages: Vec<&[u8]>) -> Result<(), ApiError> {
+        tracing::debug!(
+            inbox_id = self.inbox_id,
+            "sending [{}] group messages",
+            group_messages.len()
+        );
         let to_send: Vec<GroupMessageInput> = group_messages
             .iter()
             .map(|msg| GroupMessageInput {
@@ -267,6 +287,7 @@ where
     where
         ApiClient: XmtpMlsStreams,
     {
+        tracing::debug!(inbox_id = self.inbox_id, "subscribing to group messages");
         self.api_client
             .subscribe_group_messages(SubscribeGroupMessagesRequest {
                 filters: filters.into_iter().map(|f| f.into()).collect(),
@@ -282,6 +303,7 @@ where
     where
         ApiClient: XmtpMlsStreams,
     {
+        tracing::debug!(inbox_id = self.inbox_id, "subscribing to welcome messages");
         self.api_client
             .subscribe_welcome_messages(SubscribeWelcomeMessagesRequest {
                 filters: vec![WelcomeFilterProto {

--- a/xmtp_mls/src/api/mod.rs
+++ b/xmtp_mls/src/api/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     XmtpApi,
 };
 use thiserror::Error;
-use xmtp_id::associations::DeserializationError as AssociationDeserializationError;
+use xmtp_id::{associations::DeserializationError as AssociationDeserializationError, InboxId};
 use xmtp_proto::Error as ApiError;
 
 pub use identity::*;
@@ -34,6 +34,7 @@ impl RetryableError for WrappedApiError {
 pub struct ApiClientWrapper<ApiClient> {
     pub(crate) api_client: Arc<ApiClient>,
     pub(crate) retry_strategy: Retry,
+    pub(crate) inbox_id: Option<InboxId>,
 }
 
 impl<ApiClient> ApiClientWrapper<ApiClient>
@@ -44,6 +45,13 @@ where
         Self {
             api_client,
             retry_strategy,
+            inbox_id: None,
         }
+    }
+
+    /// Attach an InboxId to this API Client Wrapper.
+    /// Attaches an inbox_id context to tracing logs, useful for debugging
+    pub(crate) fn attach_inbox_id(&mut self, inbox_id: Option<InboxId>) {
+        self.inbox_id = inbox_id;
     }
 }

--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -186,7 +186,11 @@ where
     let store = store
         .take()
         .ok_or(ClientBuilderError::MissingParameter { parameter: "store" })?;
-    debug!("Initializing identity");
+
+    debug!(
+        inbox_id = identity_strategy.inbox_id(),
+        "Initializing identity"
+    );
 
     let identity = identity_strategy
         .initialize_identity(&api_client_wrapper, &store, &scw_verifier)

--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -344,7 +344,7 @@ pub(crate) mod tests {
             IdentityStrategyTestCase {
                 strategy: {
                     let (legacy_key, legacy_account_address) = generate_random_legacy_key().await;
-                    IdentityStrategy::CreateIfNotFound(
+                    IdentityStrategy::new(
                         generate_inbox_id(&legacy_account_address, &1).unwrap(),
                         legacy_account_address.clone(),
                         1,
@@ -356,7 +356,7 @@ pub(crate) mod tests {
             IdentityStrategyTestCase {
                 strategy: {
                     let (legacy_key, legacy_account_address) = generate_random_legacy_key().await;
-                    IdentityStrategy::CreateIfNotFound(
+                    IdentityStrategy::new(
                         generate_inbox_id(&legacy_account_address, &1).unwrap(),
                         legacy_account_address.clone(),
                         0,
@@ -368,7 +368,7 @@ pub(crate) mod tests {
             IdentityStrategyTestCase {
                 strategy: {
                     let (legacy_key, legacy_account_address) = generate_random_legacy_key().await;
-                    IdentityStrategy::CreateIfNotFound(
+                    IdentityStrategy::new(
                         generate_inbox_id(&legacy_account_address, &0).unwrap(),
                         legacy_account_address.clone(),
                         0,
@@ -381,7 +381,7 @@ pub(crate) mod tests {
             IdentityStrategyTestCase {
                 strategy: {
                     let account_address = generate_local_wallet().get_address();
-                    IdentityStrategy::CreateIfNotFound(
+                    IdentityStrategy::new(
                         generate_inbox_id(&account_address, &1).unwrap(),
                         account_address.clone(),
                         0,
@@ -394,7 +394,7 @@ pub(crate) mod tests {
                 strategy: {
                     let nonce = 1;
                     let account_address = generate_local_wallet().get_address();
-                    IdentityStrategy::CreateIfNotFound(
+                    IdentityStrategy::new(
                         generate_inbox_id(&account_address, &nonce).unwrap(),
                         account_address.clone(),
                         nonce,
@@ -407,7 +407,7 @@ pub(crate) mod tests {
                 strategy: {
                     let nonce = 0;
                     let account_address = generate_local_wallet().get_address();
-                    IdentityStrategy::CreateIfNotFound(
+                    IdentityStrategy::new(
                         generate_inbox_id(&account_address, &nonce).unwrap(),
                         account_address.clone(),
                         nonce,
@@ -450,7 +450,7 @@ pub(crate) mod tests {
         let id = generate_inbox_id(&legacy_account_address, &0).unwrap();
         println!("{}", id.len());
 
-        let identity_strategy = IdentityStrategy::CreateIfNotFound(
+        let identity_strategy = IdentityStrategy::new(
             generate_inbox_id(&legacy_account_address, &0).unwrap(),
             legacy_account_address.clone(),
             0,
@@ -483,7 +483,7 @@ pub(crate) mod tests {
         assert!(client1.inbox_id() == client2.inbox_id());
         assert!(client1.installation_public_key() == client2.installation_public_key());
 
-        let client3 = ClientBuilder::new(IdentityStrategy::CreateIfNotFound(
+        let client3 = ClientBuilder::new(IdentityStrategy::new(
             generate_inbox_id(&legacy_account_address, &0).unwrap(),
             legacy_account_address.to_string(),
             0,
@@ -499,7 +499,7 @@ pub(crate) mod tests {
         assert!(client1.inbox_id() == client3.inbox_id());
         assert!(client1.installation_public_key() == client3.installation_public_key());
 
-        let client4 = ClientBuilder::new(IdentityStrategy::CreateIfNotFound(
+        let client4 = ClientBuilder::new(IdentityStrategy::new(
             generate_inbox_id(&legacy_account_address, &0).unwrap(),
             legacy_account_address.to_string(),
             0,
@@ -548,8 +548,7 @@ pub(crate) mod tests {
 
         let wrapper = ApiClientWrapper::new(mock_api.into(), Retry::default());
 
-        let identity =
-            IdentityStrategy::CreateIfNotFound("other_inbox_id".to_string(), address, nonce, None);
+        let identity = IdentityStrategy::new("other_inbox_id".to_string(), address, nonce, None);
         assert!(matches!(
             identity
                 .initialize_identity(&wrapper, &store, &scw_verifier)
@@ -590,7 +589,7 @@ pub(crate) mod tests {
 
         let wrapper = ApiClientWrapper::new(mock_api.into(), Retry::default());
 
-        let identity = IdentityStrategy::CreateIfNotFound(inbox_id.clone(), address, nonce, None);
+        let identity = IdentityStrategy::new(inbox_id.clone(), address, nonce, None);
         assert!(dbg!(
             identity
                 .initialize_identity(&wrapper, &store, &scw_verifier)
@@ -629,7 +628,7 @@ pub(crate) mod tests {
 
         stored.store(&store.conn().unwrap()).unwrap();
         let wrapper = ApiClientWrapper::new(mock_api.into(), Retry::default());
-        let identity = IdentityStrategy::CreateIfNotFound(inbox_id.clone(), address, nonce, None);
+        let identity = IdentityStrategy::new(inbox_id.clone(), address, nonce, None);
         assert!(identity
             .initialize_identity(&wrapper, &store, &scw_verifier)
             .await
@@ -669,8 +668,7 @@ pub(crate) mod tests {
         let wrapper = ApiClientWrapper::new(mock_api.into(), Retry::default());
 
         let inbox_id = "inbox_id".to_string();
-        let identity =
-            IdentityStrategy::CreateIfNotFound(inbox_id.clone(), address.clone(), nonce, None);
+        let identity = IdentityStrategy::new(inbox_id.clone(), address.clone(), nonce, None);
         let err = identity
             .initialize_identity(&wrapper, &store, &scw_verifier)
             .await
@@ -695,7 +693,7 @@ pub(crate) mod tests {
 
         let nonce = 1;
         let inbox_id = generate_inbox_id(&wallet.get_address(), &nonce).unwrap();
-        let client_a = Client::builder(IdentityStrategy::CreateIfNotFound(
+        let client_a = Client::builder(IdentityStrategy::new(
             inbox_id.clone(),
             wallet.get_address(),
             nonce,
@@ -719,7 +717,7 @@ pub(crate) mod tests {
             .await
             .unwrap();
 
-        let client_b = Client::builder(IdentityStrategy::CreateIfNotFound(
+        let client_b = Client::builder(IdentityStrategy::new(
             inbox_id,
             wallet.get_address(),
             nonce,
@@ -743,7 +741,7 @@ pub(crate) mod tests {
         //     EncryptedMessageStore::new_unencrypted(StorageOption::Persistent(tmpdb.clone()))
         //         .unwrap();
 
-        // ClientBuilder::new(IdentityStrategy::CreateIfNotFound(
+        // ClientBuilder::new(IdentityStrategy::new(
         //     generate_local_wallet().get_address(),
         //     None,
         // ))
@@ -805,7 +803,7 @@ pub(crate) mod tests {
                 let account_address = format!("{scw_addr:?}");
                 let account_id = AccountId::new_evm(anvil_meta.chain_id, account_address.clone());
 
-                let identity_strategy = IdentityStrategy::CreateIfNotFound(
+                let identity_strategy = IdentityStrategy::new(
                     generate_inbox_id(&account_address, &0).unwrap(),
                     account_address,
                     0,

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -218,7 +218,7 @@ where
     /// It is expected that most users will use the [`ClientBuilder`](crate::builder::ClientBuilder) instead of instantiating
     /// a client directly.
     pub fn new(
-        api_client: ApiClientWrapper<ApiClient>,
+        mut api_client: ApiClientWrapper<ApiClient>,
         identity: Identity,
         store: EncryptedMessageStore,
         scw_verifier: V,
@@ -227,6 +227,7 @@ where
     where
         V: SmartContractSignatureVerifier,
     {
+        api_client.attach_inbox_id(Some(identity.inbox_id().to_string()));
         let context = Arc::new(XmtpMlsLocalContext {
             identity,
             store,
@@ -723,6 +724,7 @@ where
 
     /// Download all unread welcome messages and converts to a group struct, ignoring malformed messages.
     /// Returns any new groups created in the operation
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn sync_welcomes(
         &self,
         conn: &DbConnection,

--- a/xmtp_mls/src/groups/intents.rs
+++ b/xmtp_mls/src/groups/intents.rs
@@ -86,6 +86,7 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
         if intent_kind != IntentKind::SendMessage {
             conn.update_rotated_at_ns(self.group_id.clone())?;
         }
+        tracing::debug!(inbox_id = self.client.inbox_id(), intent_kind = %intent_kind, "queued intent");
 
         Ok(intent)
     }

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -591,6 +591,7 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
 
     /// Send a message on this users XMTP [`Client`].
     pub async fn send_message(&self, message: &[u8]) -> Result<Vec<u8>, GroupError> {
+        tracing::debug!(inbox_id = self.client.inbox_id(), "sending message");
         let conn = self.context().store().conn()?;
         let provider = XmtpOpenMlsProvider::from(conn);
         self.send_message_with_provider(message, &provider).await

--- a/xmtp_mls/src/groups/subscriptions.rs
+++ b/xmtp_mls/src/groups/subscriptions.rs
@@ -180,6 +180,7 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
 }
 
 /// Stream messages from groups in `group_id_to_info`
+#[tracing::instrument(level = "debug", skip_all)]
 pub(crate) async fn stream_messages<ScopedClient>(
     client: &ScopedClient,
     group_id_to_info: Arc<HashMap<Vec<u8>, MessagesStreamInfo>>,
@@ -200,9 +201,12 @@ where
             let group_id_to_info = group_id_to_info.clone();
             async move {
                 let envelope = res.map_err(GroupError::from)?;
-                tracing::info!("Received message streaming payload");
                 let group_id = extract_group_id(&envelope)?;
-                tracing::info!("Extracted group id {}", hex::encode(&group_id));
+                tracing::info!(
+                    inbox_id = client.inbox_id(),
+                    group_id = hex::encode(&group_id),
+                    "Received message streaming payload"
+                );
                 let stream_info =
                     group_id_to_info
                         .get(&group_id)

--- a/xmtp_mls/src/identity.rs
+++ b/xmtp_mls/src/identity.rs
@@ -74,7 +74,7 @@ pub enum IdentityStrategy {
 }
 
 impl IdentityStrategy {
-    pub fn inbox_id<'a>(&'a self) -> Option<InboxIdRef<'a>> {
+    pub fn inbox_id(&self) -> Option<InboxIdRef<'_>> {
         use IdentityStrategy::*;
         match self {
             CreateIfNotFound { ref inbox_id, .. } => Some(inbox_id),
@@ -82,7 +82,7 @@ impl IdentityStrategy {
         }
     }
 
-    /// Create a new Identity Strategy.
+    /// Create a new Identity Strategy, with [`IdentityStrategy::CreateIfNotFound`].
     /// If an Identity is not found in the local store, creates a new one.
     pub fn new(
         inbox_id: InboxId,

--- a/xmtp_mls/src/storage/encrypted_store/group.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group.rs
@@ -521,9 +521,9 @@ impl std::fmt::Display for ConversationType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         use ConversationType::*;
         match self {
-            Group => write!(f, "{}", "group"),
-            Dm => write!(f, "{}", "dm"),
-            Sync => write!(f, "{}", "sync"),
+            Group => write!(f, "group"),
+            Dm => write!(f, "dm"),
+            Sync => write!(f, "sync"),
         }
     }
 }

--- a/xmtp_mls/src/storage/encrypted_store/group.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group.rs
@@ -492,6 +492,7 @@ pub enum ConversationType {
     Dm = 2,
     Sync = 3,
 }
+
 impl ToSql<Integer, Sqlite> for ConversationType
 where
     i32: ToSql<Integer, Sqlite>,
@@ -512,6 +513,17 @@ where
             2 => Ok(ConversationType::Dm),
             3 => Ok(ConversationType::Sync),
             x => Err(format!("Unrecognized variant {}", x).into()),
+        }
+    }
+}
+
+impl std::fmt::Display for ConversationType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use ConversationType::*;
+        match self {
+            Group => write!(f, "{}", "group"),
+            Dm => write!(f, "{}", "dm"),
+            Sync => write!(f, "{}", "sync"),
         }
     }
 }

--- a/xmtp_mls/src/utils/test/mod.rs
+++ b/xmtp_mls/src/utils/test/mod.rs
@@ -175,7 +175,7 @@ where
     let nonce = 1;
     let inbox_id = generate_inbox_id(&owner.get_address(), &nonce).unwrap();
 
-    let client = Client::<A>::builder(IdentityStrategy::CreateIfNotFound(
+    let client = Client::<A>::builder(IdentityStrategy::new(
         inbox_id,
         owner.get_address(),
         nonce,
@@ -208,7 +208,7 @@ where
     let nonce = 1;
     let inbox_id = generate_inbox_id(&owner.get_address(), &nonce).unwrap();
 
-    let mut builder = Client::<A, V>::builder(IdentityStrategy::CreateIfNotFound(
+    let mut builder = Client::<A, V>::builder(IdentityStrategy::new(
         inbox_id,
         owner.get_address(),
         nonce,


### PR DESCRIPTION
adds more logs with an `inbox_id` key to filter by specific clients via `inbox_id`.

Node was completely missing stream messages, probably because of `ThreadSafeFunction`


Ultimately, `napi4` feature needed to be enabled. This should fix @humanagent issues with the streams, and a streaming test was added to node which should ensure this does not happen in the future