### PR TITLE
Teach testnet to use separate endpoints for payer and grpc APIs

### DIFF
--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -236,10 +236,10 @@ async fn main() -> color_eyre::eyre::Result<()> {
 
     let grpc: Box<dyn XmtpApi> = match (cli.testnet, &cli.env) {
         (true, Env::Local) => {
-            Box::new(ClientV4::create("http://localhost:5050".into(), false).await?)
+            Box::new(ClientV4::create("http://localhost:5050".into(), "http://localhost:5050".into(), false).await?)
         }
         (true, Env::Dev) => {
-            Box::new(ClientV4::create("https://grpc.testnet.xmtp.network:443".into(), true).await?)
+            Box::new(ClientV4::create("https://grpc.testnet.xmtp.network:443".into(), "https://payer.testnet.xmtp.network:443".into(), true).await?)
         }
         (false, Env::Local) => {
             Box::new(ClientV3::create("http://localhost:5556".into(), false).await?)

--- a/xmtp_api_grpc/src/replication_client.rs
+++ b/xmtp_api_grpc/src/replication_client.rs
@@ -72,25 +72,34 @@ pub struct ClientV4 {
 }
 
 impl ClientV4 {
-    pub async fn create(host: String, is_secure: bool) -> Result<Self, Error> {
-        let host = host.to_string();
+    pub async fn create(grpc_url: String, payer_url: String, is_secure: bool) -> Result<Self, Error> {
         let app_version = MetadataValue::try_from(&String::from("0.0.0"))
             .map_err(|e| Error::new(ErrorKind::MetadataError).with(e))?;
         let libxmtp_version = MetadataValue::try_from(&String::from("0.0.0"))
             .map_err(|e| Error::new(ErrorKind::MetadataError).with(e))?;
 
-        let channel = match is_secure {
-            true => create_tls_channel(host).await?,
-            false => Channel::from_shared(host)
+        let grpc_channel = match is_secure {
+            true => create_tls_channel(grpc_url).await?,
+            false => Channel::from_shared(grpc_url)
                 .map_err(|e| Error::new(ErrorKind::SetupCreateChannelError).with(e))?
                 .connect()
                 .await
                 .map_err(|e| Error::new(ErrorKind::SetupConnectionError).with(e))?,
         };
 
+        let payer_channel = match is_secure {
+            true => create_tls_channel(payer_url).await?,
+            false => Channel::from_shared(payer_url)
+                .map_err(|e| Error::new(ErrorKind::SetupCreateChannelError).with(e))?
+                .connect()
+                .await
+                .map_err(|e| Error::new(ErrorKind::SetupConnectionError).with(e))?,
+        };
+
+
         // GroupMessageInputTODO(mkysel) for now we assume both payer and replication are on the same host
-        let client = ReplicationApiClient::new(channel.clone());
-        let payer_client = PayerApiClient::new(channel.clone());
+        let client = ReplicationApiClient::new(grpc_channel.clone());
+        let payer_client = PayerApiClient::new(payer_channel.clone());
 
         Ok(Self {
             client,


### PR DESCRIPTION
We have split the payer service from the API service.