### PR TITLE
fix(group): make group changes thread safe

### DIFF
--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -754,6 +754,8 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
         &self,
         inbox_ids: &[S],
     ) -> Result<(), GroupError> {
+        let _permit = MLS_COMMIT_LOCK.acquire().await.unwrap();
+
         let provider = self.client.mls_provider()?;
         let ids = inbox_ids.iter().map(AsRef::as_ref).collect::<Vec<&str>>();
         let intent_data = self

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -96,6 +96,7 @@ use crate::{
     utils::{id::calculate_message_id, time::now_ns},
     xmtp_openmls_provider::XmtpOpenMlsProvider,
     Store,
+    MLS_COMMIT_LOCK
 };
 
 #[derive(Debug, Error)]
@@ -810,6 +811,8 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
         &self,
         inbox_ids: &[InboxIdRef<'_>],
     ) -> Result<(), GroupError> {
+        let _permit = MLS_COMMIT_LOCK.acquire().await.unwrap();
+
         let provider = self.client.store().conn()?.into();
 
         let intent_data = self

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -641,6 +641,8 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
     ///
     /// If so, adds/removes those group members
     pub async fn update_installations(&self) -> Result<(), GroupError> {
+        let _permit = MLS_COMMIT_LOCK.acquire().await.unwrap();
+
         let provider = self.client.mls_provider()?;
         self.maybe_update_installations(&provider, Some(0)).await?;
         Ok(())
@@ -833,6 +835,8 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
     /// Updates the name of the group. Will error if the user does not have the appropriate permissions
     /// to perform these updates.
     pub async fn update_group_name(&self, group_name: String) -> Result<(), GroupError> {
+        let _permit = MLS_COMMIT_LOCK.acquire().await.unwrap();
+
         let provider = self.client.mls_provider()?;
         if self.metadata(&provider)?.conversation_type == ConversationType::Dm {
             return Err(GroupError::DmGroupMetadataForbidden);
@@ -851,6 +855,8 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
         permission_policy: PermissionPolicyOption,
         metadata_field: Option<MetadataField>,
     ) -> Result<(), GroupError> {
+        let _permit = MLS_COMMIT_LOCK.acquire().await.unwrap();
+
         let provider = self.client.mls_provider()?;
         if self.metadata(&provider)?.conversation_type == ConversationType::Dm {
             return Err(GroupError::DmGroupMetadataForbidden);
@@ -892,6 +898,8 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
         &self,
         group_description: String,
     ) -> Result<(), GroupError> {
+        let _permit = MLS_COMMIT_LOCK.acquire().await.unwrap();
+
         let provider = self.client.mls_provider()?;
         if self.metadata(&provider)?.conversation_type == ConversationType::Dm {
             return Err(GroupError::DmGroupMetadataForbidden);
@@ -921,6 +929,8 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
         &self,
         group_image_url_square: String,
     ) -> Result<(), GroupError> {
+        let _permit = MLS_COMMIT_LOCK.acquire().await.unwrap();
+
         let provider = self.client.mls_provider()?;
         if self.metadata(&provider)?.conversation_type == ConversationType::Dm {
             return Err(GroupError::DmGroupMetadataForbidden);
@@ -954,6 +964,8 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
         &self,
         pinned_frame_url: String,
     ) -> Result<(), GroupError> {
+        let _permit = MLS_COMMIT_LOCK.acquire().await.unwrap();
+
         let provider = self.client.mls_provider()?;
         if self.metadata(&provider)?.conversation_type == ConversationType::Dm {
             return Err(GroupError::DmGroupMetadataForbidden);
@@ -1031,6 +1043,8 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
         action_type: UpdateAdminListType,
         inbox_id: String,
     ) -> Result<(), GroupError> {
+        let _permit = MLS_COMMIT_LOCK.acquire().await.unwrap();
+
         let provider = self.client.mls_provider()?;
         if self.metadata(&provider)?.conversation_type == ConversationType::Dm {
             return Err(GroupError::DmGroupMetadataForbidden);

--- a/xmtp_mls/src/lib.rs
+++ b/xmtp_mls/src/lib.rs
@@ -127,11 +127,11 @@ pub(crate) mod tests {
         use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
         let filter = EnvFilter::builder()
-            .with_default_directive(tracing::metadata::LevelFilter::TRACE.into())
+            .with_default_directive(tracing::metadata::LevelFilter::INFO.into())
             .from_env_lossy();
 
         tracing_subscriber::registry()
-            .with(fmt::layer())
+            .with(fmt::layer().pretty())
             .with(filter)
             .init();
     }


### PR DESCRIPTION
Changes:
Make adding and removing members in an MLS group thread-safe.

Issue:
In rare parallel scenarios, invoking Add or Remove members in an MLS group could result in a ForkedGroups issue, leaving some users in an outdated state. This problem arises when the group state is fetched, and a commit is generated, potentially publishing two or more intents with the same group state. If one of these intents gets published and its within commit is merged, the second intent, even if republished, continues to reference the outdated group state.

As a result, the client is unable to decrypt the commit due to an AEAD error. Furthermore, all upcoming messages, belong to future epoch, remain undecryptable.