### PR TITLE
feat(xdbg): basic send message command

### DIFF
--- a/xmtp_debug/src/app.rs
+++ b/xmtp_debug/src/app.rs
@@ -14,6 +14,8 @@ mod inspect;
 mod modify;
 /// Query for data on the network
 mod query;
+/// Send functionality
+mod send;
 /// Local storage
 mod store;
 /// Types shared between App Functions
@@ -96,6 +98,7 @@ impl App {
         if let Some(cmd) = cmd {
             match cmd {
                 Generate(g) => generate::Generate::new(g, backend, db).run().await,
+                Send(s) => send::Send::new(s, backend, db).run().await,
                 Inspect(i) => inspect::Inspect::new(i, backend, db).run().await,
                 Query(_q) => todo!(),
                 Info(i) => info::Info::new(i, backend, db).run().await,

--- a/xmtp_debug/src/app/generate/groups.rs
+++ b/xmtp_debug/src/app/generate/groups.rs
@@ -34,6 +34,7 @@ impl GenerateGroups {
     }
 
     pub async fn create_groups(&self, n: usize, invitees: usize) -> Result<Vec<Group>> {
+        // TODO: Check if identities still exist
         let mut groups: Vec<Group> = Vec::with_capacity(n);
         let style = ProgressStyle::with_template(
             "{bar} {pos}/{len} elapsed {elapsed} remaining {eta_precise}",

--- a/xmtp_debug/src/app/send.rs
+++ b/xmtp_debug/src/app/send.rs
@@ -1,0 +1,58 @@
+use std::sync::Arc;
+
+use crate::args;
+use color_eyre::eyre::{eyre, Result};
+use rand::prelude::*;
+
+use super::store::{Database, GroupStore, IdentityStore};
+
+#[derive(Debug)]
+pub struct Send {
+    db: Arc<redb::Database>,
+    opts: args::Send,
+    network: args::BackendOpts,
+}
+
+impl Send {
+    pub fn new(opts: args::Send, network: args::BackendOpts, db: Arc<redb::Database>) -> Self {
+        Self { opts, network, db }
+    }
+
+    pub async fn run(self) -> Result<()> {
+        use args::ActionKind::*;
+        let args::Send { ref action, .. } = self.opts;
+
+        match action {
+            Message => self.message().await,
+        }
+    }
+
+    async fn message(&self) -> Result<()> {
+        let Self { ref network, .. } = self;
+        let args::Send {
+            ref data, group_id, ..
+        } = &self.opts;
+
+        let group_store: GroupStore = self.db.clone().into();
+        let identity_store: IdentityStore = self.db.clone().into();
+        let key = (u64::from(network), **group_id);
+        let group = group_store
+            .get(key.into())?
+            .ok_or(eyre!("No group with id {}", group_id))?;
+        let member = group
+            .members
+            .choose(&mut rand::thread_rng())
+            .ok_or(eyre!("Empty group, no members to send message!"))?;
+        let key = (u64::from(network), *member);
+        let identity = identity_store
+            .get(key.into())?
+            .ok_or(eyre!("No Identity with inbox_id [{}]", hex::encode(member)))?;
+
+        let client = crate::app::client_from_identity(&identity, network).await?;
+        let conn = client.store().conn()?;
+        client.sync_welcomes(&conn).await?;
+        let xmtp_group = client.group(group.id.to_vec())?;
+        xmtp_group.send_message(data.as_bytes()).await?;
+        Ok(())
+    }
+}

--- a/xmtp_debug/src/args.rs
+++ b/xmtp_debug/src/args.rs
@@ -27,9 +27,23 @@ pub enum Commands {
     Generate(Generate),
     Modify(Modify),
     Inspect(Inspect),
+    Send(Send),
     Query(Query),
     Info(InfoOpts),
     Export(ExportOpts),
+}
+
+/// Send Data on the network
+#[derive(Args, Debug)]
+pub struct Send {
+    pub action: ActionKind,
+    pub data: String,
+    pub group_id: GroupId,
+}
+
+#[derive(ValueEnum, Debug, Clone)]
+pub enum ActionKind {
+    Message,
 }
 
 /// Generate Groups/Messages/Users


### PR DESCRIPTION
adds 

```
cargo xdbg send message "sup" 844301cdf88e75d841105684f782c5bc
```

to send a message using a random user to a specific group

This is useful for inspecting network payloads in-flight, for instance running this `curl` command with libxmtp in http-api mode:

```
curl -H 'Content-Type: application/json' \-d '{  "filters": [    {      "groupId": "Bbus/1pm8uOzvmRk/Cp6LA=="    }  ]}' -X POST http://localhost:5555/mls/v1/subscribe-group-messages
```

and running the xdbg `send-message` command. Used to help debug #997 for browser streaming

