### PR TITLE
Switch to ubuntu 22.04 for node builds

### DIFF
--- a/.github/workflows/release-node-bindings.yml
+++ b/.github/workflows/release-node-bindings.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build-linux:
-    runs-on: warp-ubuntu-latest-x64-16x
+    runs-on: warp-ubuntu-2204-x64-16x
     strategy:
       fail-fast: false
       matrix:

--- a/bindings_node/README.md
+++ b/bindings_node/README.md
@@ -13,3 +13,7 @@
 ## Testing
 
 Before running the test suite, a local XMTP node must be running. This can be achieved by running `./dev/up` at the root of this repository. Docker is required.
+
+# Publishing
+
+To release a new version of the bindings, update the version in `package.json` with the appropriate semver value and add an entry to the CHANGELOG.md file. Once merged, manually trigger the `Release Node Bindings` workflow to build and publish the bindings.


### PR DESCRIPTION
# Summary

This switches the runner to ubuntu 22.04 when building the node bindings for better compatibility with deployments.