### PR TITLE
Lowercase address when checking association state

### DIFF
--- a/bindings_node/CHANGELOG.md
+++ b/bindings_node/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @xmtp/node-bindings
 
+## 0.0.28
+
+- Removed `is_installation_authorized` and `is_address_authorized` from `Client`
+- Lowercased `address` passed to `is_address_authorized`
+
 ## 0.0.27
 
 - Switched to Ubuntu 22.04 for builds

--- a/bindings_node/package.json
+++ b/bindings_node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/node-bindings",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "repository": {
     "type": "git",
     "url": "git+https://git@github.com/xmtp/libxmtp.git",

--- a/bindings_node/src/inbox_id.rs
+++ b/bindings_node/src/inbox_id.rs
@@ -1,8 +1,11 @@
 use crate::ErrorWrapper;
 use napi::bindgen_prelude::Result;
+use napi::bindgen_prelude::Uint8Array;
 use napi_derive::napi;
+use std::sync::Arc;
 use xmtp_api_grpc::grpc_api_helper::Client as TonicApiClient;
 use xmtp_id::associations::generate_inbox_id as xmtp_id_generate_inbox_id;
+use xmtp_id::associations::MemberIdentifier;
 use xmtp_mls::api::ApiClientWrapper;
 use xmtp_mls::retry::Retry;
 
@@ -36,4 +39,54 @@ pub fn generate_inbox_id(account_address: String) -> Result<String> {
   // create_client function above, which also has a hard-coded nonce of 1
   let result = xmtp_id_generate_inbox_id(&account_address, &1).map_err(ErrorWrapper::from)?;
   Ok(result)
+}
+
+#[napi]
+pub async fn is_installation_authorized(
+  host: String,
+  inbox_id: String,
+  installation_id: Uint8Array,
+) -> Result<bool> {
+  is_member_of_association_state(
+    &host,
+    &inbox_id,
+    &MemberIdentifier::Installation(installation_id.to_vec()),
+  )
+  .await
+}
+
+#[napi]
+pub async fn is_address_authorized(
+  host: String,
+  inbox_id: String,
+  address: String,
+) -> Result<bool> {
+  is_member_of_association_state(
+    &host,
+    &inbox_id,
+    &MemberIdentifier::Address(address.to_lowercase()),
+  )
+  .await
+}
+
+async fn is_member_of_association_state(
+  host: &str,
+  inbox_id: &str,
+  identifier: &MemberIdentifier,
+) -> Result<bool> {
+  let api_client = TonicApiClient::create(host, true)
+    .await
+    .map_err(ErrorWrapper::from)?;
+  let api_client = ApiClientWrapper::new(Arc::new(api_client), Retry::default());
+
+  let is_member = xmtp_mls::identity_updates::is_member_of_association_state(
+    &api_client,
+    inbox_id,
+    identifier,
+    None,
+  )
+  .await
+  .map_err(ErrorWrapper::from)?;
+
+  Ok(is_member)
 }

--- a/bindings_node/test/helpers.ts
+++ b/bindings_node/test/helpers.ts
@@ -8,6 +8,7 @@ import {
   createClient as create,
   generateInboxId,
   getInboxIdForAddress,
+  LogLevel,
   SignatureRequestType,
 } from '../dist/index'
 
@@ -44,7 +45,7 @@ export const createClient = async (user: User) => {
     user.account.address,
     undefined,
     undefined,
-    { level: 'info' }
+    { level: LogLevel.info }
   )
 }
 
@@ -81,7 +82,7 @@ export const encodeTextMessage = (text: string) => {
   }
 }
 
-export function sleep(ms) {
+export function sleep(ms: number) {
   return new Promise((resolve) => {
     setTimeout(resolve, ms)
   })

--- a/bindings_node/test/inboxId.test.ts
+++ b/bindings_node/test/inboxId.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import { createRegisteredClient, createUser, TEST_API_URL } from '@test/helpers'
-import { generateInboxId, getInboxIdForAddress } from '../dist/index'
+import {
+  generateInboxId,
+  getInboxIdForAddress,
+  isAddressAuthorized,
+  isInstallationAuthorized,
+} from '../dist/index'
 
 describe('generateInboxId', () => {
   it('should generate an inbox id', () => {
@@ -30,5 +35,31 @@ describe('getInboxIdForAddress', () => {
       user.account.address
     )
     expect(inboxId).toBe(client.inboxId())
+  })
+})
+
+describe('isInstallationAuthorized', () => {
+  it('should return true if installation is authorized', async () => {
+    const user = createUser()
+    const client = await createRegisteredClient(user)
+    const isAuthorized = await isInstallationAuthorized(
+      TEST_API_URL,
+      client.inboxId(),
+      client.installationIdBytes()
+    )
+    expect(isAuthorized).toBe(true)
+  })
+})
+
+describe('isAddressAuthorized', () => {
+  it('should return true if address is authorized', async () => {
+    const user = createUser()
+    const client = await createRegisteredClient(user)
+    const isAuthorized = await isAddressAuthorized(
+      TEST_API_URL,
+      client.inboxId(),
+      user.account.address
+    )
+    expect(isAuthorized).toBe(true)
   })
 })


### PR DESCRIPTION
# Summary

- Removed `is_installation_authorized` and `is_address_authorized` from `Client`
- Moved `is_installation_authorized` and `is_address_authorized` to `inbox_id` mod
- Lowercased address passed to `is_address_authorized` before checking association state
- Added tests for `is_installation_authorized` and `is_address_authorized`
- Updated version and CHANGELOG for release