### PR TITLE
speed up sync init

### DIFF
--- a/bindings_node/src/signatures.rs
+++ b/bindings_node/src/signatures.rs
@@ -97,7 +97,7 @@ impl Client {
     let other_installation_ids = inbox_state
       .installation_ids()
       .into_iter()
-      .filter(|id| id != &installation_id)
+      .filter(|id| id != installation_id)
       .collect();
     let signature_request = self
       .inner_client()

--- a/bindings_wasm/src/signatures.rs
+++ b/bindings_wasm/src/signatures.rs
@@ -101,7 +101,7 @@ impl Client {
     let other_installation_ids = inbox_state
       .installation_ids()
       .into_iter()
-      .filter(|id| id != &installation_id)
+      .filter(|id| id != installation_id)
       .collect();
     let signature_request = self
       .inner_client()

--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -443,7 +443,7 @@ async fn main() -> color_eyre::eyre::Result<()> {
             let conn = client.store().conn().unwrap();
             let provider = client.mls_provider().unwrap();
             client.sync_welcomes(&conn).await.unwrap();
-            client.start_sync_worker(&provider).await.unwrap();
+            client.start_sync_worker().await.unwrap();
             client
                 .send_sync_request(&provider, DeviceSyncKind::MessageHistory)
                 .await
@@ -453,7 +453,7 @@ async fn main() -> color_eyre::eyre::Result<()> {
         Commands::ListHistorySyncMessages {} => {
             let conn = client.store().conn()?;
             client.sync_welcomes(&conn).await?;
-            let group = client.get_sync_group()?;
+            let group = client.get_sync_group(&conn)?;
             let group_id_str = hex::encode(group.group_id.clone());
             group.sync().await?;
             let messages = group

--- a/examples/cli/debug.rs
+++ b/examples/cli/debug.rs
@@ -71,7 +71,7 @@ pub async fn debug_welcome_messages(
 ) -> Result<(), String> {
     let api_client = client.api();
     let envelopes = api_client
-        .query_welcome_messages(installation_id, None)
+        .query_welcome_messages(&installation_id, None)
         .await
         .unwrap();
     for envelope in envelopes {

--- a/xmtp_mls/Cargo.toml
+++ b/xmtp_mls/Cargo.toml
@@ -95,6 +95,8 @@ tracing-subscriber = { workspace = true, features = [
     "env-filter",
     "fmt",
     "ansi",
+    "json",
+    "registry"
 ], optional = true }
 
 
@@ -151,6 +153,7 @@ tracing-subscriber = { workspace = true, features = [
     "env-filter",
     "fmt",
     "ansi",
+    "json",
 ] }
 xmtp_api_grpc = { path = "../xmtp_api_grpc", features = ["test-utils"] }
 xmtp_api_http = { path = "../xmtp_api_http", features = ["test-utils"] }
@@ -163,7 +166,7 @@ diesel-wasm-sqlite = { workspace = true, features = [
 ] }
 ethers = { workspace = true, features = ["rustls"] }
 openmls = { workspace = true, features = ["js"] }
-tracing-subscriber = { workspace = true, features = ["env-filter"] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 tracing-wasm = { version = "0.2" }
 wasm-bindgen-test.workspace = true
 xmtp_api_http = { path = "../xmtp_api_http", features = ["test-utils"] }

--- a/xmtp_mls/benches/sync.rs
+++ b/xmtp_mls/benches/sync.rs
@@ -29,14 +29,13 @@ fn start_sync_worker(c: &mut Criterion) {
             || {
                 bench_async_setup(|| async {
                     let client = clients::new_client(true).await;
-                    let provider = client.mls_provider().unwrap();
                     // set history sync URL
-                    (client, provider, span.clone())
+                    (client, span.clone())
                 })
             },
-            |(client, provider, span)| async move {
+            |(client, span)| async move {
                 client
-                    .start_sync_worker(&provider)
+                    .start_sync_worker()
                     .instrument(span)
                     .await
                     .unwrap()

--- a/xmtp_mls/src/api/mls.rs
+++ b/xmtp_mls/src/api/mls.rs
@@ -117,11 +117,11 @@ where
     #[tracing::instrument(level = "trace", skip_all)]
     pub async fn query_welcome_messages(
         &self,
-        installation_id: Vec<u8>,
+        installation_id: &[u8],
         id_cursor: Option<u64>,
     ) -> Result<Vec<WelcomeMessage>, ApiError> {
         tracing::debug!(
-            installation_id = hex::encode(&installation_id),
+            installation_id = hex::encode(installation_id),
             cursor = id_cursor,
             inbox_id = self.inbox_id,
             "query welcomes"
@@ -135,7 +135,7 @@ where
                 (async {
                     self.api_client
                         .query_welcome_messages(QueryWelcomeMessagesRequest {
-                            installation_key: installation_id.clone(),
+                            installation_key: installation_id.to_vec(),
                             paging_info: Some(PagingInfo {
                                 id_cursor: id_cursor.unwrap_or(0),
                                 limit: page_size,

--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -709,7 +709,7 @@ pub(crate) mod tests {
         register_client(&client_a, wallet).await;
         assert!(client_a.identity().is_ready());
 
-        let keybytes_a = client_a.installation_public_key();
+        let keybytes_a = client_a.installation_public_key().to_vec();
         drop(client_a);
 
         // Reload the existing store and wallet
@@ -729,7 +729,7 @@ pub(crate) mod tests {
         .build_with_verifier()
         .await
         .unwrap();
-        let keybytes_b = client_b.installation_public_key();
+        let keybytes_b = client_b.installation_public_key().to_vec();
         drop(client_b);
 
         // Ensure the persistence was used to store the generated keys
@@ -762,7 +762,7 @@ pub(crate) mod tests {
             .build_with_verifier()
             .await
             .unwrap();
-        assert_eq!(client_d.installation_public_key(), keybytes_a);
+        assert_eq!(client_d.installation_public_key().to_vec(), keybytes_a);
     }
 
     /// anvil cannot be used in WebAssembly

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -546,10 +546,10 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
 
     pub(crate) fn create_and_insert_sync_group(
         client: Arc<ScopedClient>,
+        provider: &XmtpOpenMlsProvider,
     ) -> Result<MlsGroup<ScopedClient>, GroupError> {
         let context = client.context();
         let creator_inbox_id = context.inbox_id();
-        let provider = client.mls_provider()?;
 
         let protected_metadata =
             build_protected_metadata_extension(creator_inbox_id, ConversationType::Sync)?;
@@ -687,7 +687,7 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
             decrypted_message_bytes: message.to_vec(),
             sent_at_ns: now,
             kind: GroupMessageKind::Application,
-            sender_installation_id: self.context().installation_public_key(),
+            sender_installation_id: self.context().installation_public_key().into(),
             sender_inbox_id: self.context().inbox_id().to_string(),
             delivery_status: DeliveryStatus::Unpublished,
         };
@@ -1668,7 +1668,7 @@ pub(crate) mod tests {
         let serialized_welcome = welcome.tls_serialize_detached().unwrap();
         let send_welcomes_action = SendWelcomesAction::new(
             vec![Installation {
-                installation_key: new_member_client.installation_public_key(),
+                installation_key: new_member_client.installation_public_key().into(),
                 hpke_public_key: hpke_init_key,
             }],
             serialized_welcome,

--- a/xmtp_mls/src/groups/scoped_client.rs
+++ b/xmtp_mls/src/groups/scoped_client.rs
@@ -37,6 +37,10 @@ pub trait LocalScopedGroupClient: Send + Sync + Sized {
         self.context_ref().inbox_id()
     }
 
+    fn installation_id(&self) -> &[u8] {
+        self.context_ref().installation_public_key()
+    }
+
     fn mls_provider(&self) -> Result<XmtpOpenMlsProvider, ClientError> {
         self.context_ref().mls_provider()
     }
@@ -99,6 +103,10 @@ pub trait ScopedGroupClient: Sized {
 
     fn inbox_id(&self) -> InboxIdRef<'_> {
         self.context_ref().inbox_id()
+    }
+
+    fn installation_id(&self) -> &[u8] {
+        self.context_ref().installation_public_key()
     }
 
     fn mls_provider(&self) -> Result<XmtpOpenMlsProvider, ClientError> {

--- a/xmtp_mls/src/identity_updates.rs
+++ b/xmtp_mls/src/identity_updates.rs
@@ -812,8 +812,8 @@ pub(crate) mod tests {
         let client_2 = ClientBuilder::new_test_client(&wallet_2).await;
         let client_3 = ClientBuilder::new_test_client(&wallet_3).await;
 
-        let client_2_installation_key = client_2.installation_public_key();
-        let client_3_installation_key = client_3.installation_public_key();
+        let client_2_installation_key = client_2.installation_public_key().to_vec();
+        let client_3_installation_key = client_3.installation_public_key().to_vec();
 
         let mut inbox_ids: Vec<String> = vec![];
 
@@ -902,11 +902,11 @@ pub(crate) mod tests {
         assert_eq!(installation_diff.added_installations.len(), 1);
         assert!(installation_diff
             .added_installations
-            .contains(&client_3_installation_key),);
+            .contains(&client_3_installation_key.to_vec()),);
         assert_eq!(installation_diff.removed_installations.len(), 1);
         assert!(installation_diff
             .removed_installations
-            .contains(&client_2_installation_key));
+            .contains(&client_2_installation_key.to_vec()));
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
@@ -979,7 +979,7 @@ pub(crate) mod tests {
 
         // Now revoke the second client
         let mut revoke_installation_request = client1
-            .revoke_installations(vec![client2.installation_public_key()])
+            .revoke_installations(vec![client2.installation_public_key().to_vec()])
             .await
             .unwrap();
         add_wallet_signature(&mut revoke_installation_request, &wallet).await;

--- a/xmtp_mls/src/intents.rs
+++ b/xmtp_mls/src/intents.rs
@@ -52,7 +52,7 @@ impl Intents {
     /// apply the update after the provided `ProcessingFn` has completed successfully.
     pub(crate) async fn process_for_id<Fut, ProcessingFn, ReturnValue, ErrorType>(
         &self,
-        entity_id: &Vec<u8>,
+        entity_id: &[u8],
         entity_kind: EntityKind,
         cursor: u64,
         process_envelope: ProcessingFn,

--- a/xmtp_mls/src/storage/encrypted_store/refresh_state.rs
+++ b/xmtp_mls/src/storage/encrypted_store/refresh_state.rs
@@ -92,7 +92,7 @@ impl DbConnection {
 
     pub fn update_cursor(
         &self,
-        entity_id: &Vec<u8>,
+        entity_id: &[u8],
         entity_kind: EntityKind,
         cursor: i64,
     ) -> Result<bool, StorageError> {

--- a/xmtp_mls/src/subscriptions.rs
+++ b/xmtp_mls/src/subscriptions.rs
@@ -305,7 +305,7 @@ where
         tracing::info!(inbox_id = self.inbox_id(), "Setting up conversation stream");
         let subscription = self
             .api_client
-            .subscribe_welcome_messages(installation_key, Some(id_cursor))
+            .subscribe_welcome_messages(installation_key.into(), Some(id_cursor))
             .await?;
 
         let stream = subscription


### PR DESCRIPTION
- optimizes db connections in sync to share a provider/connection
- moves sync init to spawned task, speeding up registration by not blocking it on a sync to the group

![Screenshot 2024-12-02 at 4 45 49 PM](https://github.com/user-attachments/assets/434b6525-8e4c-4e8d-a687-d82845e93bcb)
