### PR TITLE
Native Logging with tracing for Android and iOS

### DIFF
--- a/.cargo/nextest.toml
+++ b/.cargo/nextest.toml
@@ -1,0 +1,2 @@
+[profile.default]
+retries = 3

--- a/.github/workflows/test-ffi-bindings.yml
+++ b/.github/workflows/test-ffi-bindings.yml
@@ -50,4 +50,4 @@ jobs:
       - name: Run cargo nextest on FFI bindings
         run: |
           export CLASSPATH="${{ env.CLASSPATH }}"
-          cargo nextest run --manifest-path bindings_ffi/Cargo.toml --test-threads 2
+          cargo nextest --config-file ".cargo/nextest.toml" run --manifest-path bindings_ffi/Cargo.toml --test-threads 2

--- a/.github/workflows/test-workspace.yml
+++ b/.github/workflows/test-workspace.yml
@@ -43,6 +43,6 @@ jobs:
       - name: Install nextest
         uses: taiki-e/install-action@nextest
       - name: build tests
-        run: cargo nextest run --no-run --workspace --tests --exclude xmtpv3 --exclude bindings_node --exclude bindings_wasm
+        run: cargo nextest --config-file ".cargo/nextest.toml" run --no-run --workspace --tests --exclude xmtpv3 --exclude bindings_node --exclude bindings_wasm
       - name: cargo test
-        run: cargo nextest run --workspace --test-threads 2 --exclude xmtpv3 --exclude bindings_node --exclude bindings_wasm
+        run: cargo nextest --config-file ".cargo/nextest.toml" run --workspace --test-threads 2 --exclude xmtpv3 --exclude bindings_node --exclude bindings_wasm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,6 +428,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+dependencies = [
+ "bitflags 2.6.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "bindings_node"
 version = "0.1.0"
 dependencies = [
@@ -650,6 +670,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -729,6 +758,17 @@ dependencies = [
  "crypto-common",
  "inout",
  "zeroize",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -3041,6 +3081,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
 name = "jobserver"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3618,6 +3664,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-sys"
+version = "0.5.0+25.2.9519653"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+dependencies = [
+ "jni-sys",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3947,6 +4002,20 @@ checksum = "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209"
 dependencies = [
  "elliptic-curve 0.13.8",
  "primeorder",
+]
+
+[[package]]
+name = "paranoid-android"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "101795d63d371b43e38d6e7254677657be82f17022f7f7893c268f33ac0caadc"
+dependencies = [
+ "lazy_static",
+ "ndk-sys",
+ "sharded-slab",
+ "smallvec",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4834,6 +4903,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5679,16 +5754,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread-id"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99043e46c5a15af379c06add30d9c93a6c0e8849de00d244c4a2c417da128d80"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "thread_local"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6129,6 +6194,21 @@ checksum = "6b1f47d22deb79c3f59fcf2a1f00f60cbdc05462bf17d1cd356c1fefa3f444bd"
 dependencies = [
  "time",
  "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-oslog"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528bdd1f0e27b5dd9a4ededf154e824b0532731e4af73bb531de46276e0aab1e"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cfg-if",
+ "once_cell",
+ "parking_lot 0.12.3",
  "tracing-core",
  "tracing-subscriber",
 ]
@@ -7380,12 +7460,14 @@ version = "0.1.0"
 dependencies = [
  "ethers",
  "futures",
- "log",
+ "paranoid-android",
  "parking_lot 0.12.3",
  "rand",
  "thiserror 2.0.3",
- "thread-id",
  "tokio",
+ "tracing",
+ "tracing-oslog",
+ "tracing-subscriber",
  "uniffi",
  "uuid 1.11.0",
  "xmtp_api_grpc",

--- a/bindings_ffi/Cargo.toml
+++ b/bindings_ffi/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["lib", "cdylib", "staticlib"]
 
 [dependencies]
 futures.workspace = true
-log = { version = "0.4", features = ["std"] }
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["registry", "env-filter", "fmt", "json"] }
 parking_lot.workspace = true
 thiserror.workspace = true
-thread-id = "5.0.0"
 tokio = { workspace = true, features = ["macros"] }
 uniffi = { version = "0.28.0", default-features = false, features = ["tokio"] }
 xmtp_api_grpc = { path = "../xmtp_api_grpc" }
@@ -22,6 +22,12 @@ xmtp_mls = { path = "../xmtp_mls" }
 xmtp_proto = { path = "../xmtp_proto", features = ["proto_full"] }
 xmtp_user_preferences = { path = "../xmtp_user_preferences" }
 xmtp_v2 = { path = "../xmtp_v2" }
+
+[target.'cfg(target_os = "android")'.dependencies]
+paranoid-android = "0.2"
+
+[target.'cfg(target_os = "ios")'.dependencies]
+tracing-oslog = "0.2"
 
 [build-dependencies]
 uniffi = { version = "0.28.0", features = ["build"] }

--- a/bindings_ffi/src/lib.rs
+++ b/bindings_ffi/src/lib.rs
@@ -7,9 +7,10 @@ pub mod v2;
 
 pub use crate::inbox_owner::SigningError;
 use inbox_owner::FfiInboxOwner;
-use logger::FfiLogger;
 pub use mls::*;
 use std::error::Error;
+
+extern crate tracing as log;
 
 pub use ffi::*;
 #[allow(clippy::all)]

--- a/bindings_ffi/src/xmtpv3.udl
+++ b/bindings_ffi/src/xmtpv3.udl
@@ -12,7 +12,3 @@ callback interface FfiInboxOwner {
     [Throws=SigningError]
     bytes sign(string text);
 };
-
-callback interface FfiLogger {
-    void log(u32 level, string level_label, string message);
-};

--- a/bindings_ffi/tests/test_android.kts
+++ b/bindings_ffi/tests/test_android.kts
@@ -17,20 +17,15 @@ class Web3jInboxOwner(private val credentials: Credentials) : FfiInboxOwner {
     }
 }
 
-class MockLogger : FfiLogger {
-    override fun log(level: UInt, levelLabel: String, message: String) {}
-}
-
 val privateKey: ByteArray = SecureRandom().generateSeed(32)
 val credentials: Credentials = Credentials.create(ECKeyPair.create(privateKey))
 val inboxOwner = Web3jInboxOwner(credentials)
-var logger = MockLogger()
 
 // TODO Tests sometimes hang and never complete
 // runBlocking {
 //     val apiUrl: String = System.getenv("XMTP_API_URL") ?: "http://localhost:5556"
 //     try {
-//         val client = uniffi.xmtpv3.createClient(logger, inboxOwner, apiUrl, false)
+//         val client = uniffi.xmtpv3.createClient(inboxOwner, apiUrl, false)
 //         assert(client.walletAddress() != null) {
 //             "Should be able to get wallet address"
 //         }
@@ -43,7 +38,7 @@ var logger = MockLogger()
 
 // runBlocking {
 //     try {
-//         val client = uniffi.xmtpv3.createClient(logger, inboxOwner, "http://malformed:5556", false);
+//         val client = uniffi.xmtpv3.createClient(inboxOwner, "http://malformed:5556", false);
 //         assert(false) {
 //             "Should throw error with malformed network address"
 //         }

--- a/dev/release-kotlin
+++ b/dev/release-kotlin
@@ -42,6 +42,7 @@ nix develop . --command cargo ndk -o bindings_ffi/jniLibs/ --manifest-path ./bin
   -t armv7-linux-androideabi \
   -- build --release
 
+
 for arch in arm64-v8a armeabi-v7a x86 x86_64; do
   mv "./bindings_ffi/jniLibs/$arch/$LIBRARY_NAME.so" "./bindings_ffi/jniLibs/$arch/$TARGET_NAME.so"
 done

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -4,10 +4,6 @@ components = [ "rustc", "cargo", "clippy", "rustfmt", "rust-analyzer" ]
 targets = [
   "wasm32-unknown-unknown",
   "x86_64-unknown-linux-gnu",
-  "aarch64-linux-android",
-  "armv7-linux-androideabi",
-  "x86_64-linux-android",
-  "i686-linux-android",
   "x86_64-apple-ios",
   "x86_64-apple-darwin",
   "aarch64-apple-ios"

--- a/xmtp_proto/Cargo.toml
+++ b/xmtp_proto/Cargo.toml
@@ -14,7 +14,7 @@ serde = { workspace = true }
 async-trait = "0.1"
 hex.workspace = true
 openmls_rust_crypto = { workspace = true, optional = true }
-tracing.workspace = true 
+tracing.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tonic = { workspace = true }


### PR DESCRIPTION
Replaces `FfiLogger` with native bindings to Android and iOS/Mac `Log` utilities. This removes the need to pass a logger into `xmtpv3` bindings, since it interacts directly with the android/ios libraries.


This also makes it possible to create benchmarks in `bindings_ffi`, and generate flamegraphs profiling the performance (the main reason behind opening this PR now is to profile `create_client`).

 Future work maybe interested in adding a non-blocking [appender](https://docs.rs/tracing-appender/latest/tracing_appender/) layer to write logs to a file and send them somewhere once a fork is detected.