### PR TITLE
Database migration for Conversation stitching

### DIFF
--- a/xmtp_mls/migrations/2024-12-04-190255_add_dm_id_to_groups/down.sql
+++ b/xmtp_mls/migrations/2024-12-04-190255_add_dm_id_to_groups/down.sql
@@ -1,0 +1,1 @@
+-- This file should undo anything in `up.sql`

--- a/xmtp_mls/migrations/2024-12-04-190255_add_dm_id_to_groups/down.sql
+++ b/xmtp_mls/migrations/2024-12-04-190255_add_dm_id_to_groups/down.sql
@@ -1,1 +1,1 @@
--- This file should undo anything in `up.sql`
+ALTER TABLE groups DROP COLUMN dm_id;

--- a/xmtp_mls/migrations/2024-12-04-190255_add_dm_id_to_groups/up.sql
+++ b/xmtp_mls/migrations/2024-12-04-190255_add_dm_id_to_groups/up.sql
@@ -1,5 +1,5 @@
 ALTER TABLE groups
-ADD COLUMN dm_id BLOB;
+ADD COLUMN dm_id TEXT;
 
 UPDATE groups
 SET dm_id = LOWER(CONCAT('dm:', dm_inbox_id))

--- a/xmtp_mls/migrations/2024-12-04-190255_add_dm_id_to_groups/up.sql
+++ b/xmtp_mls/migrations/2024-12-04-190255_add_dm_id_to_groups/up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE groups
+ADD COLUMN dm_id BLOB;
+
+UPDATE groups
+SET dm_id = LOWER(CONCAT('dm:', dm_inbox_id))
+WHERE dm_inbox_id IS NOT NULL;

--- a/xmtp_mls/src/storage/encrypted_store/group.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group.rs
@@ -42,6 +42,8 @@ pub struct StoredGroup {
     pub dm_inbox_id: Option<String>,
     /// The last time the leaf node encryption key was rotated
     pub rotated_at_ns: i64,
+    /// The dm_id of the dm to stitch together
+    pub dm_id: Option<String>,
 }
 
 impl_fetch!(StoredGroup, groups, Vec<u8>);
@@ -58,6 +60,10 @@ impl StoredGroup {
         conversation_type: ConversationType,
         dm_inbox_id: Option<String>,
     ) -> Self {
+        // Construct the dm_id string if dm_inbox_id is provided
+        let dm_id = dm_inbox_id
+            .as_ref()
+            .map(|inbox_id| format!("dm:{}", inbox_id).to_lowercase());
         Self {
             id,
             created_at_ns,
@@ -68,6 +74,7 @@ impl StoredGroup {
             welcome_id: Some(welcome_id),
             rotated_at_ns: 0,
             dm_inbox_id,
+            dm_id,
         }
     }
 
@@ -79,6 +86,10 @@ impl StoredGroup {
         added_by_inbox_id: String,
         dm_inbox_id: Option<String>,
     ) -> Self {
+        // Construct the dm_id string if dm_inbox_id is provided
+        let dm_id = dm_inbox_id
+            .as_ref()
+            .map(|inbox_id| format!("dm:{}", inbox_id).to_lowercase());
         Self {
             id,
             created_at_ns,
@@ -92,6 +103,7 @@ impl StoredGroup {
             welcome_id: None,
             rotated_at_ns: 0,
             dm_inbox_id,
+            dm_id,
         }
     }
 
@@ -112,6 +124,7 @@ impl StoredGroup {
             welcome_id: None,
             rotated_at_ns: 0,
             dm_inbox_id: None,
+            dm_id: None,
         }
     }
 }

--- a/xmtp_mls/src/storage/encrypted_store/schema.rs
+++ b/xmtp_mls/src/storage/encrypted_store/schema.rs
@@ -50,12 +50,12 @@ diesel::table! {
         created_at_ns -> BigInt,
         membership_state -> Integer,
         installations_last_checked -> BigInt,
+        conversation_type -> Integer,
         added_by_inbox_id -> Text,
         welcome_id -> Nullable<BigInt>,
         dm_inbox_id -> Nullable<Text>,
         rotated_at_ns -> BigInt,
-        conversation_type -> Integer,
-        dm_id -> Nullable<Binary>,
+        dm_id -> Nullable<Text>,
     }
 }
 

--- a/xmtp_mls/src/storage/encrypted_store/schema.rs
+++ b/xmtp_mls/src/storage/encrypted_store/schema.rs
@@ -50,11 +50,12 @@ diesel::table! {
         created_at_ns -> BigInt,
         membership_state -> Integer,
         installations_last_checked -> BigInt,
-        conversation_type -> Integer,
         added_by_inbox_id -> Text,
         welcome_id -> Nullable<BigInt>,
         dm_inbox_id -> Nullable<Text>,
         rotated_at_ns -> BigInt,
+        conversation_type -> Integer,
+        dm_id -> Nullable<Binary>,
     }
 }
 


### PR DESCRIPTION
That database migration portion of https://github.com/xmtp/libxmtp/issues/1142

Sets a new dm_id on groups that we can stitch on in the form of `"dm:{dm_inbox_id}".to_lower_case()`

This is a little different than what was suggested of `"dm:{lower_inbox_id}:{higher_inbox_id}".to_lower_case()` because we don't need this dm_id to be the same for both parties correct? Only for the current inboxId to thread. That being said if we want to go this more verbose route it will greatly complicated the migration.