### PR TITLE
Share provider everywhere

### DIFF
--- a/bindings_ffi/src/lib.rs
+++ b/bindings_ffi/src/lib.rs
@@ -63,6 +63,8 @@ pub enum GenericError {
 pub enum FfiSubscribeError {
     #[error("Subscribe Error {0}")]
     Subscribe(#[from] xmtp_mls::subscriptions::SubscribeError),
+    #[error("Storage error: {0}")]
+    Storage(#[from] xmtp_mls::storage::StorageError),
 }
 
 impl From<String> for GenericError {

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -295,8 +295,8 @@ impl FfiXmtpClient {
 
     pub async fn find_inbox_id(&self, address: String) -> Result<Option<String>, GenericError> {
         let inner = self.inner_client.as_ref();
-
-        let result = inner.find_inbox_id_from_address(address).await?;
+        let conn = self.inner_client.store().conn()?;
+        let result = inner.find_inbox_id_from_address(&conn, address).await?;
         Ok(result)
     }
 
@@ -881,8 +881,8 @@ impl FfiConversations {
 
     pub async fn sync(&self) -> Result<(), GenericError> {
         let inner = self.inner_client.as_ref();
-        let conn = inner.store().conn()?;
-        inner.sync_welcomes(&conn).await?;
+        let provider = inner.mls_provider()?;
+        inner.sync_welcomes(&provider).await?;
         Ok(())
     }
 
@@ -898,12 +898,11 @@ impl FfiConversations {
         consent_state: Option<FfiConsentState>,
     ) -> Result<u32, GenericError> {
         let inner = self.inner_client.as_ref();
-        let conn = inner.store().conn()?;
-
+        let provider = inner.mls_provider()?;
         let consent: Option<ConsentState> = consent_state.map(|state| state.into());
-
-        let num_groups_synced: usize = inner.sync_all_welcomes_and_groups(&conn, consent).await?;
-
+        let num_groups_synced: usize = inner
+            .sync_all_welcomes_and_groups(&provider, consent)
+            .await?;
         // Convert usize to u32 for compatibility with Uniffi
         let num_groups_synced: u32 = num_groups_synced
             .try_into()
@@ -1267,9 +1266,10 @@ impl FfiConversation {
         &self,
         envelope_bytes: Vec<u8>,
     ) -> Result<FfiMessage, FfiSubscribeError> {
+        let provider = self.inner.mls_provider()?;
         let message = self
             .inner
-            .process_streamed_group_message(envelope_bytes)
+            .process_streamed_group_message(&provider, envelope_bytes)
             .await?;
         let ffi_message = message.into();
 
@@ -1853,6 +1853,8 @@ mod tests {
         conversations: Mutex<Vec<Arc<FfiConversation>>>,
         consent_updates: Mutex<Vec<FfiConsent>>,
         notify: Notify,
+        inbox_id: Option<String>,
+        installation_id: Option<String>,
     }
 
     impl RustStreamCallback {
@@ -1872,12 +1874,22 @@ mod tests {
             .await?;
             Ok(())
         }
+
+        pub fn from_client(client: &FfiXmtpClient) -> Self {
+            RustStreamCallback {
+                inbox_id: Some(client.inner_client.inbox_id().to_string()),
+                installation_id: Some(hex::encode(client.inner_client.installation_public_key())),
+                ..Default::default()
+            }
+        }
     }
 
     impl FfiMessageCallback for RustStreamCallback {
         fn on_message(&self, message: FfiMessage) {
             let mut messages = self.messages.lock().unwrap();
             log::info!(
+                inbox_id = self.inbox_id,
+                installation_id = self.installation_id,
                 "ON MESSAGE Received\n-------- \n{}\n----------",
                 String::from_utf8_lossy(&message.content)
             );
@@ -1893,7 +1905,11 @@ mod tests {
 
     impl FfiConversationCallback for RustStreamCallback {
         fn on_conversation(&self, group: Arc<super::FfiConversation>) {
-            log::debug!("received conversation");
+            log::debug!(
+                inbox_id = self.inbox_id,
+                installation_id = self.installation_id,
+                "received conversation"
+            );
             let _ = self.num_messages.fetch_add(1, Ordering::SeqCst);
             let mut convos = self.conversations.lock().unwrap();
             convos.push(group);
@@ -1907,7 +1923,11 @@ mod tests {
 
     impl FfiConsentCallback for RustStreamCallback {
         fn on_consent_update(&self, mut consent: Vec<FfiConsent>) {
-            log::debug!("received consent update");
+            log::debug!(
+                inbox_id = self.inbox_id,
+                installation_id = self.installation_id,
+                "received consent update"
+            );
             let mut consent_updates = self.consent_updates.lock().unwrap();
             consent_updates.append(&mut consent);
             self.notify.notify_one();
@@ -2774,7 +2794,7 @@ mod tests {
         let caro = new_test_client().await;
 
         // Alix begins a stream for all messages
-        let message_callbacks = Arc::new(RustStreamCallback::default());
+        let message_callbacks = Arc::new(RustStreamCallback::from_client(&alix));
         let stream_messages = alix
             .conversations()
             .stream_all_messages(message_callbacks.clone())
@@ -2821,12 +2841,12 @@ mod tests {
         let bo2 = new_test_client_with_wallet(bo_wallet).await;
 
         // Bo begins a stream for all messages
-        let bo_message_callbacks = Arc::new(RustStreamCallback::default());
-        let bo_stream_messages = bo2
+        let bo2_message_callbacks = Arc::new(RustStreamCallback::from_client(&bo2));
+        let bo2_stream_messages = bo2
             .conversations()
-            .stream_all_messages(bo_message_callbacks.clone())
+            .stream_all_messages(bo2_message_callbacks.clone())
             .await;
-        bo_stream_messages.wait_for_ready().await;
+        bo2_stream_messages.wait_for_ready().await;
 
         alix_group.update_installations().await.unwrap();
 
@@ -3190,7 +3210,7 @@ mod tests {
         let bo = new_test_client().await;
         let caro = new_test_client().await;
 
-        let caro_conn = caro.inner_client.store().conn().unwrap();
+        let caro_provider = caro.inner_client.mls_provider().unwrap();
 
         let alix_group = alix
             .conversations()
@@ -3220,7 +3240,11 @@ mod tests {
             )
             .await
             .unwrap();
-        let _ = caro.inner_client.sync_welcomes(&caro_conn).await.unwrap();
+        let _ = caro
+            .inner_client
+            .sync_welcomes(&caro_provider)
+            .await
+            .unwrap();
 
         bo_group.send("second".as_bytes().to_vec()).await.unwrap();
         stream_callback.wait_for_delivery(None).await.unwrap();
@@ -3239,7 +3263,7 @@ mod tests {
         let amal = new_test_client().await;
         let bola = new_test_client().await;
 
-        let bola_conn = bola.inner_client.store().conn().unwrap();
+        let bola_provider = bola.inner_client.mls_provider().unwrap();
 
         let amal_group: Arc<FfiConversation> = amal
             .conversations()
@@ -3250,7 +3274,10 @@ mod tests {
             .await
             .unwrap();
 
-        bola.inner_client.sync_welcomes(&bola_conn).await.unwrap();
+        bola.inner_client
+            .sync_welcomes(&bola_provider)
+            .await
+            .unwrap();
         let bola_group = bola.conversation(amal_group.id()).unwrap();
 
         let stream_callback = Arc::new(RustStreamCallback::default());

--- a/bindings_node/src/client.rs
+++ b/bindings_node/src/client.rs
@@ -275,9 +275,14 @@ impl Client {
 
   #[napi]
   pub async fn find_inbox_id_by_address(&self, address: String) -> Result<Option<String>> {
+    let conn = self
+      .inner_client()
+      .store()
+      .conn()
+      .map_err(ErrorWrapper::from)?;
     let inbox_id = self
       .inner_client
-      .find_inbox_id_from_address(address)
+      .find_inbox_id_from_address(&conn, address)
       .await
       .map_err(ErrorWrapper::from)?;
 

--- a/bindings_node/src/conversation.rs
+++ b/bindings_node/src/conversation.rs
@@ -197,8 +197,9 @@ impl Conversation {
       self.created_at_ns,
     );
     let envelope_bytes: Vec<u8> = envelope_bytes.deref().to_vec();
+    let provider = group.mls_provider().map_err(ErrorWrapper::from)?;
     let message = group
-      .process_streamed_group_message(envelope_bytes)
+      .process_streamed_group_message(&provider, envelope_bytes)
       .await
       .map_err(ErrorWrapper::from)?;
 

--- a/bindings_node/src/conversations.rs
+++ b/bindings_node/src/conversations.rs
@@ -235,14 +235,13 @@ impl Conversations {
 
   #[napi]
   pub async fn sync(&self) -> Result<()> {
-    let conn = self
+    let provider = self
       .inner_client
-      .store()
-      .conn()
+      .mls_provider()
       .map_err(ErrorWrapper::from)?;
     self
       .inner_client
-      .sync_welcomes(&conn)
+      .sync_welcomes(&provider)
       .await
       .map_err(ErrorWrapper::from)?;
     Ok(())
@@ -250,15 +249,14 @@ impl Conversations {
 
   #[napi]
   pub async fn sync_all_conversations(&self) -> Result<usize> {
-    let conn = self
+    let provider = self
       .inner_client
-      .store()
-      .conn()
+      .mls_provider()
       .map_err(ErrorWrapper::from)?;
 
     let num_groups_synced = self
       .inner_client
-      .sync_all_welcomes_and_groups(&conn, None)
+      .sync_all_welcomes_and_groups(&provider, None)
       .await
       .map_err(ErrorWrapper::from)?;
 

--- a/bindings_wasm/src/client.rs
+++ b/bindings_wasm/src/client.rs
@@ -12,7 +12,6 @@ use xmtp_api_http::XmtpHttpApiClient;
 use xmtp_cryptography::signature::ed25519_public_key_to_address;
 use xmtp_id::associations::builder::SignatureRequest;
 use xmtp_mls::builder::ClientBuilder;
-use xmtp_mls::groups::scoped_client::ScopedGroupClient;
 use xmtp_mls::identity::IdentityStrategy;
 use xmtp_mls::storage::{EncryptedMessageStore, EncryptionKey, StorageOption};
 use xmtp_mls::Client as MlsClient;
@@ -273,9 +272,14 @@ impl Client {
 
   #[wasm_bindgen(js_name = findInboxIdByAddress)]
   pub async fn find_inbox_id_by_address(&self, address: String) -> Result<Option<String>, JsError> {
+    let conn = self
+      .inner_client
+      .store()
+      .conn()
+      .map_err(|e| JsError::new(format!("{}", e).as_str()))?;
     let inbox_id = self
       .inner_client
-      .find_inbox_id_from_address(address)
+      .find_inbox_id_from_address(&conn, address)
       .await
       .map_err(|e| JsError::new(format!("{}", e).as_str()))?;
 

--- a/bindings_wasm/src/conversations.rs
+++ b/bindings_wasm/src/conversations.rs
@@ -269,14 +269,13 @@ impl Conversations {
 
   #[wasm_bindgen]
   pub async fn sync(&self) -> Result<(), JsError> {
-    let conn = self
+    let provider = self
       .inner_client
-      .store()
-      .conn()
+      .mls_provider()
       .map_err(|e| JsError::new(format!("{}", e).as_str()))?;
     self
       .inner_client
-      .sync_welcomes(&conn)
+      .sync_welcomes(&provider)
       .await
       .map_err(|e| JsError::new(format!("{}", e).as_str()))?;
 
@@ -285,15 +284,14 @@ impl Conversations {
 
   #[wasm_bindgen(js_name = syncAllConversations)]
   pub async fn sync_all_conversations(&self) -> Result<usize, JsError> {
-    let conn = self
+    let provider = self
       .inner_client
-      .store()
-      .conn()
+      .mls_provider()
       .map_err(|e| JsError::new(format!("{}", e).as_str()))?;
 
     let num_groups_synced = self
       .inner_client
-      .sync_all_welcomes_and_groups(&conn, None)
+      .sync_all_welcomes_and_groups(&provider, None)
       .await
       .map_err(|e| JsError::new(format!("{}", e).as_str()))?;
 

--- a/xmtp_debug/src/app/generate/messages.rs
+++ b/xmtp_debug/src/app/generate/messages.rs
@@ -8,7 +8,6 @@ use crate::{
 use color_eyre::eyre::{self, eyre, Result};
 use rand::{rngs::SmallRng, seq::SliceRandom, Rng, SeedableRng};
 use std::sync::Arc;
-use xmtp_mls::XmtpOpenMlsProvider;
 
 mod content_type;
 
@@ -118,10 +117,9 @@ impl GenerateMessages {
                 hex::encode(inbox_id)
             ))?;
             let client = app::client_from_identity(&identity, &network).await?;
-            let conn = client.store().conn()?;
-            client.sync_welcomes(&conn).await?;
+            let provider = client.mls_provider()?;
+            client.sync_welcomes(&provider).await?;
             let group = client.group(group.id.into())?;
-            let provider: XmtpOpenMlsProvider = conn.into();
             group.maybe_update_installations(&provider, None).await?;
             group.sync_with_conn(&provider).await?;
             let words = rng.gen_range(0..*max_message_size);

--- a/xmtp_debug/src/app/send.rs
+++ b/xmtp_debug/src/app/send.rs
@@ -49,8 +49,8 @@ impl Send {
             .ok_or(eyre!("No Identity with inbox_id [{}]", hex::encode(member)))?;
 
         let client = crate::app::client_from_identity(&identity, network).await?;
-        let conn = client.store().conn()?;
-        client.sync_welcomes(&conn).await?;
+        let provider = client.mls_provider()?;
+        client.sync_welcomes(&provider).await?;
         let xmtp_group = client.group(group.id.to_vec())?;
         xmtp_group.send_message(data.as_bytes()).await?;
         Ok(())

--- a/xmtp_mls/src/api/mls.rs
+++ b/xmtp_mls/src/api/mls.rs
@@ -115,9 +115,9 @@ where
     }
 
     #[tracing::instrument(level = "trace", skip_all)]
-    pub async fn query_welcome_messages(
+    pub async fn query_welcome_messages<Id: AsRef<[u8]> + Copy>(
         &self,
-        installation_id: &[u8],
+        installation_id: Id,
         id_cursor: Option<u64>,
     ) -> Result<Vec<WelcomeMessage>, ApiError> {
         tracing::debug!(
@@ -135,7 +135,7 @@ where
                 (async {
                     self.api_client
                         .query_welcome_messages(QueryWelcomeMessagesRequest {
-                            installation_key: installation_id.to_vec(),
+                            installation_key: installation_id.as_ref().to_vec(),
                             paging_info: Some(PagingInfo {
                                 id_cursor: id_cursor.unwrap_or(0),
                                 limit: page_size,
@@ -297,7 +297,7 @@ where
 
     pub async fn subscribe_welcome_messages(
         &self,
-        installation_key: Vec<u8>,
+        installation_key: &[u8],
         id_cursor: Option<u64>,
     ) -> Result<impl futures::Stream<Item = Result<WelcomeMessage, ApiError>> + '_, ApiError>
     where
@@ -307,7 +307,7 @@ where
         self.api_client
             .subscribe_welcome_messages(SubscribeWelcomeMessagesRequest {
                 filters: vec![WelcomeFilterProto {
-                    installation_key,
+                    installation_key: installation_key.to_vec(),
                     id_cursor: id_cursor.unwrap_or(0),
                 }],
             })

--- a/xmtp_mls/src/groups/device_sync.rs
+++ b/xmtp_mls/src/groups/device_sync.rs
@@ -401,7 +401,7 @@ where
         let content = DeviceSyncContent::Request(request.clone());
         let content_bytes = serde_json::to_vec(&content)?;
 
-        let _message_id = sync_group.prepare_message(&content_bytes, provider.conn_ref(), {
+        let _message_id = sync_group.prepare_message(&content_bytes, provider, {
             let request = request.clone();
             move |_time_ns| PlaintextEnvelope {
                 content: Some(Content::V2(V2 {
@@ -445,7 +445,6 @@ where
         provider: &XmtpOpenMlsProvider,
         contents: DeviceSyncReplyProto,
     ) -> Result<(), DeviceSyncError> {
-        let conn = provider.conn_ref();
         // find the sync group
         let sync_group = self.get_sync_group(provider.conn_ref())?;
 
@@ -457,7 +456,7 @@ where
             .await?;
 
         // add original sender to all groups on this device on the node
-        self.ensure_member_of_all_groups(conn, &msg.sender_inbox_id)
+        self.ensure_member_of_all_groups(provider, &msg.sender_inbox_id)
             .await?;
 
         // the reply message
@@ -471,7 +470,7 @@ where
             (content_bytes, contents)
         };
 
-        sync_group.prepare_message(&content_bytes, conn, |_time_ns| PlaintextEnvelope {
+        sync_group.prepare_message(&content_bytes, provider, |_time_ns| PlaintextEnvelope {
             content: Some(Content::V2(V2 {
                 idempotency_key: new_request_id(),
                 message_type: Some(MessageType::DeviceSyncReply(contents)),
@@ -491,8 +490,10 @@ where
         let sync_group = self.get_sync_group(provider.conn_ref())?;
         sync_group.sync_with_conn(provider).await?;
 
-        let messages = sync_group
-            .find_messages(&MsgQueryArgs::default().kind(GroupMessageKind::Application))?;
+        let messages = provider.conn_ref().get_group_messages(
+            &sync_group.group_id,
+            &MsgQueryArgs::default().kind(GroupMessageKind::Application),
+        )?;
 
         for msg in messages.into_iter().rev() {
             let Ok(msg_content) =
@@ -565,13 +566,14 @@ where
         self.insert_encrypted_syncables(provider, enc_payload, &enc_key.try_into()?)
             .await?;
 
-        self.sync_welcomes(provider.conn_ref()).await?;
+        self.sync_welcomes(provider).await?;
 
         let groups =
             conn.find_groups(GroupQueryArgs::default().conversation_type(ConversationType::Group))?;
         for crate::storage::group::StoredGroup { id, .. } in groups.into_iter() {
-            let group = self.group(id)?;
-            Box::pin(group.sync()).await?;
+            let group = self.group_with_conn(provider.conn_ref(), id)?;
+            group.maybe_update_installations(provider, None).await?;
+            Box::pin(group.sync_with_conn(provider)).await?;
         }
 
         Ok(())
@@ -579,14 +581,18 @@ where
 
     async fn ensure_member_of_all_groups(
         &self,
-        conn: &DbConnection,
+        provider: &XmtpOpenMlsProvider,
         inbox_id: &str,
     ) -> Result<(), GroupError> {
+        let conn = provider.conn_ref();
         let groups =
             conn.find_groups(GroupQueryArgs::default().conversation_type(ConversationType::Group))?;
         for group in groups {
-            let group = self.group(group.id)?;
-            Box::pin(group.add_members_by_inbox_id(&[inbox_id.to_string()])).await?;
+            let group = self.group_with_conn(conn, group.id)?;
+            Box::pin(
+                group.add_members_by_inbox_id_with_provider(provider, &[inbox_id.to_string()]),
+            )
+            .await?;
         }
 
         Ok(())

--- a/xmtp_mls/src/groups/device_sync/message_sync.rs
+++ b/xmtp_mls/src/groups/device_sync/message_sync.rs
@@ -106,7 +106,7 @@ pub(crate) mod tests {
         let old_group_id = amal_a.get_sync_group(amal_a_conn).unwrap().group_id;
         // Check for new welcomes to new groups in the first installation (should be welcomed to a new sync group from amal_b).
         amal_a
-            .sync_welcomes(amal_a_conn)
+            .sync_welcomes(&amal_a_provider)
             .await
             .expect("sync_welcomes");
         let new_group_id = amal_a.get_sync_group(amal_a_conn).unwrap().group_id;
@@ -205,7 +205,7 @@ pub(crate) mod tests {
 
         // Check for new welcomes to new groups in the first installation (should be welcomed to a new sync group from amal_b).
         amal_a
-            .sync_welcomes(amal_a_conn)
+            .sync_welcomes(&amal_a_provider)
             .await
             .expect("sync_welcomes");
         let new_group_id = amal_a.get_sync_group(amal_a_conn).unwrap().group_id;
@@ -262,7 +262,7 @@ pub(crate) mod tests {
     async fn test_externals_cant_join_sync_group() {
         let wallet = generate_local_wallet();
         let amal = ClientBuilder::new_test_client_with_history(&wallet, HISTORY_SYNC_URL).await;
-        amal.sync_welcomes(&amal.store().conn().unwrap())
+        amal.sync_welcomes(&amal.mls_provider().unwrap())
             .await
             .expect("sync welcomes");
 
@@ -271,7 +271,7 @@ pub(crate) mod tests {
             ClientBuilder::new_test_client_with_history(&bo_wallet, HISTORY_SYNC_URL).await;
 
         bo_client
-            .sync_welcomes(&bo_client.store().conn().unwrap())
+            .sync_welcomes(&bo_client.mls_provider().unwrap())
             .await
             .expect("sync welcomes");
 

--- a/xmtp_mls/src/groups/intents.rs
+++ b/xmtp_mls/src/groups/intents.rs
@@ -33,6 +33,7 @@ use crate::{
     },
     types::Address,
     verified_key_package_v2::{KeyPackageVerificationError, VerifiedKeyPackageV2},
+    XmtpOpenMlsProvider,
 };
 
 use super::{
@@ -58,16 +59,17 @@ pub enum IntentError {
 impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
     pub fn queue_intent(
         &self,
+        provider: &XmtpOpenMlsProvider,
         intent_kind: IntentKind,
         intent_data: Vec<u8>,
     ) -> Result<StoredGroupIntent, GroupError> {
-        self.context().store().transaction(|provider| {
+        self.context().store().transaction(provider, |provider| {
             let conn = provider.conn_ref();
             self.queue_intent_with_conn(conn, intent_kind, intent_data)
         })
     }
 
-    pub fn queue_intent_with_conn(
+    fn queue_intent_with_conn(
         &self,
         conn: &DbConnection,
         intent_kind: IntentKind,
@@ -800,7 +802,7 @@ pub(crate) mod tests {
 
         // Client B sends a message to Client A
         let groups_b = client_b
-            .sync_welcomes(&client_b.store().conn().unwrap())
+            .sync_welcomes(&client_b.mls_provider().unwrap())
             .await
             .unwrap();
         assert_eq!(groups_b.len(), 1);

--- a/xmtp_mls/src/groups/scoped_client.rs
+++ b/xmtp_mls/src/groups/scoped_client.rs
@@ -3,9 +3,9 @@ use crate::{
     api::ApiClientWrapper,
     client::{ClientError, XmtpMlsLocalContext},
     identity_updates::{InstallationDiff, InstallationDiffError},
-    intents::Intents,
-    storage::{DbConnection, EncryptedMessageStore},
+    storage::{DbConnection, EncryptedMessageStore, StorageError},
     subscriptions::LocalEvents,
+    types::InstallationId,
     verified_key_package_v2::VerifiedKeyPackageV2,
     xmtp_openmls_provider::XmtpOpenMlsProvider,
     Client,
@@ -37,15 +37,13 @@ pub trait LocalScopedGroupClient: Send + Sync + Sized {
         self.context_ref().inbox_id()
     }
 
-    fn installation_id(&self) -> &[u8] {
+    fn installation_id(&self) -> InstallationId {
         self.context_ref().installation_public_key()
     }
 
-    fn mls_provider(&self) -> Result<XmtpOpenMlsProvider, ClientError> {
+    fn mls_provider(&self) -> Result<XmtpOpenMlsProvider, StorageError> {
         self.context_ref().mls_provider()
     }
-
-    fn intents(&self) -> &Arc<Intents>;
 
     fn context_ref(&self) -> &Arc<XmtpMlsLocalContext>;
 
@@ -105,15 +103,13 @@ pub trait ScopedGroupClient: Sized {
         self.context_ref().inbox_id()
     }
 
-    fn installation_id(&self) -> &[u8] {
+    fn installation_id(&self) -> InstallationId {
         self.context_ref().installation_public_key()
     }
 
-    fn mls_provider(&self) -> Result<XmtpOpenMlsProvider, ClientError> {
+    fn mls_provider(&self) -> Result<XmtpOpenMlsProvider, StorageError> {
         self.context_ref().mls_provider()
     }
-
-    fn intents(&self) -> &Arc<Intents>;
 
     fn context_ref(&self) -> &Arc<XmtpMlsLocalContext>;
 
@@ -171,10 +167,6 @@ where
 
     fn context_ref(&self) -> &Arc<XmtpMlsLocalContext> {
         Client::<ApiClient, Verifier>::context(self)
-    }
-
-    fn intents(&self) -> &Arc<Intents> {
-        crate::Client::<ApiClient, Verifier>::intents(self)
     }
 
     fn history_sync_url(&self) -> &Option<String> {
@@ -264,10 +256,6 @@ where
         (**self).store()
     }
 
-    fn intents(&self) -> &Arc<Intents> {
-        (**self).intents()
-    }
-
     fn inbox_id(&self) -> InboxIdRef<'_> {
         (**self).inbox_id()
     }
@@ -276,7 +264,7 @@ where
         (**self).context_ref()
     }
 
-    fn mls_provider(&self) -> Result<XmtpOpenMlsProvider, ClientError> {
+    fn mls_provider(&self) -> Result<XmtpOpenMlsProvider, StorageError> {
         (**self).mls_provider()
     }
 
@@ -358,10 +346,6 @@ where
         (**self).history_sync_url()
     }
 
-    fn intents(&self) -> &Arc<Intents> {
-        (**self).intents()
-    }
-
     fn inbox_id(&self) -> InboxIdRef<'_> {
         (**self).inbox_id()
     }
@@ -370,7 +354,7 @@ where
         (**self).context_ref()
     }
 
-    fn mls_provider(&self) -> Result<XmtpOpenMlsProvider, ClientError> {
+    fn mls_provider(&self) -> Result<XmtpOpenMlsProvider, StorageError> {
         (**self).mls_provider()
     }
 

--- a/xmtp_mls/src/groups/subscriptions.rs
+++ b/xmtp_mls/src/groups/subscriptions.rs
@@ -14,6 +14,7 @@ use crate::storage::refresh_state::EntityKind;
 use crate::storage::StorageError;
 use crate::subscriptions::MessagesStreamInfo;
 use crate::subscriptions::SubscribeError;
+use crate::XmtpOpenMlsProvider;
 use crate::{retry::Retry, retry_async};
 use prost::Message;
 use xmtp_proto::xmtp::mls::api::v1::GroupMessage;
@@ -22,6 +23,7 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
     /// Internal stream processing function
     pub(crate) async fn process_stream_entry(
         &self,
+        provider: &XmtpOpenMlsProvider,
         envelope: GroupMessage,
     ) -> Result<StoredGroupMessage, SubscribeError> {
         let msgv1 = extract_message_v1(envelope)?;
@@ -45,8 +47,8 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
                     let msgv1 = &msgv1;
                     self.context()
                         .store()
-                        .transaction_async(|provider| async move {
-                            let mut openmls_group = self.load_mls_group(&provider)?;
+                        .transaction_async(provider, |provider| async move {
+                            let mut openmls_group = self.load_mls_group(provider)?;
 
                             // Attempt processing immediately, but fail if the message is not an Application Message
                             // Returning an error should roll back the DB tx
@@ -60,7 +62,7 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
                                 openmls_group.epoch()
                             );
 
-                            self.process_message(&mut openmls_group, &provider, msgv1, false)
+                            self.process_message(&mut openmls_group, provider, msgv1, false)
                                 .await
                                 // NOTE: We want to make sure we retry an error in process_message
                                 .map_err(SubscribeError::ReceiveGroup)
@@ -78,7 +80,7 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
                 );
                 // Swallow errors here, since another process may have successfully saved the message
                 // to the DB
-                if let Err(err) = self.sync_with_conn(&self.client.mls_provider()?).await {
+                if let Err(err) = self.sync_with_conn(provider).await {
                     tracing::warn!(
                         inbox_id = self.client.inbox_id(),
                         group_id = hex::encode(&self.group_id),
@@ -108,10 +110,8 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
 
         // Load the message from the DB to handle cases where it may have been already processed in
         // another thread
-        let new_message = self
-            .context()
-            .store()
-            .conn()?
+        let new_message = provider
+            .conn_ref()
             .get_group_message_by_timestamp(&self.group_id, created_ns as i64)?
             .ok_or(SubscribeError::GroupMessageNotFound)?;
 
@@ -133,20 +133,21 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
     /// Converts some `SubscribeError` variants to an Option, if they are inconsequential.
     pub async fn process_streamed_group_message(
         &self,
+        provider: &XmtpOpenMlsProvider,
         envelope_bytes: Vec<u8>,
     ) -> Result<StoredGroupMessage, SubscribeError> {
         let envelope = GroupMessage::decode(envelope_bytes.as_slice())?;
-        self.process_stream_entry(envelope).await
+        self.process_stream_entry(provider, envelope).await
     }
 
-    pub async fn stream(
-        &self,
+    pub async fn stream<'a>(
+        &'a self,
     ) -> Result<
-        impl Stream<Item = Result<StoredGroupMessage, SubscribeError>> + use<'_, ScopedClient>,
+        impl Stream<Item = Result<StoredGroupMessage, SubscribeError>> + use<'a, ScopedClient>,
         ClientError,
     >
     where
-        <ScopedClient as ScopedGroupClient>::ApiClient: XmtpMlsStreams + 'static,
+        <ScopedClient as ScopedGroupClient>::ApiClient: XmtpMlsStreams + 'a,
     {
         let group_list = HashMap::from([(
             self.group_id.clone(),
@@ -180,14 +181,15 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
 }
 
 /// Stream messages from groups in `group_id_to_info`
+// TODO: Note when to use a None provider
 #[tracing::instrument(level = "debug", skip_all)]
-pub(crate) async fn stream_messages<ScopedClient>(
-    client: &ScopedClient,
+pub(crate) async fn stream_messages<'a, ScopedClient>(
+    client: &'a ScopedClient,
     group_id_to_info: Arc<HashMap<Vec<u8>, MessagesStreamInfo>>,
-) -> Result<impl Stream<Item = Result<StoredGroupMessage, SubscribeError>> + '_, ClientError>
+) -> Result<impl Stream<Item = Result<StoredGroupMessage, SubscribeError>> + 'a, ClientError>
 where
     ScopedClient: ScopedGroupClient,
-    <ScopedClient as ScopedGroupClient>::ApiClient: XmtpApi + XmtpMlsStreams + 'static,
+    <ScopedClient as ScopedGroupClient>::ApiClient: XmtpApi + XmtpMlsStreams + 'a,
 {
     let filters: Vec<GroupFilter> = group_id_to_info
         .iter()
@@ -200,6 +202,7 @@ where
         .then(move |res| {
             let group_id_to_info = group_id_to_info.clone();
             async move {
+                let provider = client.mls_provider()?;
                 let envelope = res.map_err(GroupError::from)?;
                 let group_id = extract_group_id(&envelope)?;
                 tracing::info!(
@@ -214,7 +217,8 @@ where
                             "Received message for a non-subscribed group".to_string(),
                         ))?;
                 let mls_group = MlsGroup::new(client, group_id, stream_info.convo_created_at_ns);
-                mls_group.process_stream_entry(envelope).await
+
+                mls_group.process_stream_entry(&provider, envelope).await
             }
         })
         .inspect(|e| {
@@ -296,8 +300,9 @@ pub(crate) mod tests {
         let message = messages.first().unwrap();
         let mut message_bytes: Vec<u8> = Vec::new();
         message.encode(&mut message_bytes).unwrap();
+        let provider = amal.mls_provider().unwrap();
         let message_again = amal_group
-            .process_streamed_group_message(message_bytes)
+            .process_streamed_group_message(&provider, message_bytes)
             .await;
 
         if let Ok(message) = message_again {
@@ -327,7 +332,7 @@ pub(crate) mod tests {
 
         // Get bola's version of the same group
         let bola_groups = bola
-            .sync_welcomes(&bola.store().conn().unwrap())
+            .sync_welcomes(&bola.mls_provider().unwrap())
             .await
             .unwrap();
         let bola_group = Arc::new(bola_groups.first().unwrap().clone());

--- a/xmtp_mls/src/intents.rs
+++ b/xmtp_mls/src/intents.rs
@@ -8,13 +8,7 @@
 //! Intents are written to local storage (SQLite), before being published to the delivery service via gRPC. An
 //! intent is fully resolved (success or failure) once it
 
-use crate::{
-    client::XmtpMlsLocalContext,
-    retry::RetryableError,
-    storage::{refresh_state::EntityKind, EncryptedMessageStore},
-    xmtp_openmls_provider::XmtpOpenMlsProvider,
-};
-use std::{future::Future, sync::Arc};
+use crate::retry::RetryableError;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -34,63 +28,5 @@ impl RetryableError for ProcessIntentError {
             Self::Diesel(err) => err.is_retryable(),
             Self::Storage(err) => err.is_retryable(),
         }
-    }
-}
-
-/// Intents holding the context of this Client
-pub struct Intents {
-    pub(crate) context: Arc<XmtpMlsLocalContext>,
-}
-
-impl Intents {
-    pub(crate) fn store(&self) -> &EncryptedMessageStore {
-        self.context.store()
-    }
-
-    /// Download all unread welcome messages and convert to groups.
-    /// In a database transaction, increment the cursor for a given entity and
-    /// apply the update after the provided `ProcessingFn` has completed successfully.
-    pub(crate) async fn process_for_id<Fut, ProcessingFn, ReturnValue, ErrorType>(
-        &self,
-        entity_id: &[u8],
-        entity_kind: EntityKind,
-        cursor: u64,
-        process_envelope: ProcessingFn,
-    ) -> Result<ReturnValue, ErrorType>
-    where
-        Fut: Future<Output = Result<ReturnValue, ErrorType>>,
-        ProcessingFn: FnOnce(XmtpOpenMlsProvider) -> Fut,
-        ErrorType: From<diesel::result::Error>
-            + From<crate::storage::StorageError>
-            + From<ProcessIntentError>
-            + std::fmt::Display,
-    {
-        self.store()
-            .transaction_async(|provider| async move {
-                let is_updated =
-                    provider
-                        .conn_ref()
-                        .update_cursor(entity_id, entity_kind, cursor as i64)?;
-                if !is_updated {
-                    return Err(ProcessIntentError::AlreadyProcessed(cursor).into());
-                }
-                process_envelope(provider).await
-            })
-            .await
-            .inspect(|_| {
-                tracing::info!(
-                    "Transaction completed successfully: process for entity [{:?}] envelope cursor[{}]",
-                    entity_id,
-                    cursor
-            );
-            })
-            .inspect_err(|err| {
-                tracing::info!(
-                    "Transaction failed: process for entity [{:?}] envelope cursor[{}] error:[{}]",
-                    entity_id,
-                    cursor,
-                    err
-                );
-            })
     }
 }

--- a/xmtp_mls/src/storage/encrypted_store/db_connection.rs
+++ b/xmtp_mls/src/storage/encrypted_store/db_connection.rs
@@ -51,6 +51,8 @@ where
         self.inner.lock()
     }
 
+    /// Internal-only API to get the underlying `diesel::Connection` reference
+    /// without a scope
     pub(super) fn inner_ref(&self) -> Arc<Mutex<C>> {
         self.inner.clone()
     }

--- a/xmtp_mls/src/storage/encrypted_store/refresh_state.rs
+++ b/xmtp_mls/src/storage/encrypted_store/refresh_state.rs
@@ -90,13 +90,13 @@ impl DbConnection {
         }
     }
 
-    pub fn update_cursor(
+    pub fn update_cursor<Id: AsRef<[u8]>>(
         &self,
-        entity_id: &[u8],
+        entity_id: Id,
         entity_kind: EntityKind,
         cursor: i64,
     ) -> Result<bool, StorageError> {
-        let state: Option<RefreshState> = self.get_refresh_state(entity_id, entity_kind)?;
+        let state: Option<RefreshState> = self.get_refresh_state(&entity_id, entity_kind)?;
         match state {
             Some(state) => {
                 use super::schema::refresh_state::dsl;
@@ -110,7 +110,7 @@ impl DbConnection {
             }
             None => Err(StorageError::NotFound(format!(
                 "state for entity ID {} with kind {:?}",
-                hex::encode(entity_id),
+                hex::encode(entity_id.as_ref()),
                 entity_kind
             ))),
         }

--- a/xmtp_mls/src/types.rs
+++ b/xmtp_mls/src/types.rs
@@ -1,2 +1,86 @@
 pub type Address = String;
-pub type InstallationId = String;
+
+use std::fmt;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct InstallationId([u8; 32]);
+
+impl fmt::Display for InstallationId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", hex::encode(self.0))
+    }
+}
+
+impl std::ops::Deref for InstallationId {
+    type Target = [u8; 32];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl AsRef<[u8]> for InstallationId {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl From<InstallationId> for Vec<u8> {
+    fn from(value: InstallationId) -> Self {
+        value.0.to_vec()
+    }
+}
+
+impl From<[u8; 32]> for InstallationId {
+    fn from(value: [u8; 32]) -> Self {
+        InstallationId(value)
+    }
+}
+
+impl PartialEq<Vec<u8>> for InstallationId {
+    fn eq(&self, other: &Vec<u8>) -> bool {
+        self.0.eq(&other[..])
+    }
+}
+
+impl PartialEq<InstallationId> for Vec<u8> {
+    fn eq(&self, other: &InstallationId) -> bool {
+        other.0.eq(&self[..])
+    }
+}
+
+impl PartialEq<&Vec<u8>> for InstallationId {
+    fn eq(&self, other: &&Vec<u8>) -> bool {
+        self.0.eq(&other[..])
+    }
+}
+
+impl PartialEq<InstallationId> for &Vec<u8> {
+    fn eq(&self, other: &InstallationId) -> bool {
+        other.0.eq(&self[..])
+    }
+}
+
+impl PartialEq<[u8]> for InstallationId {
+    fn eq(&self, other: &[u8]) -> bool {
+        self.0.eq(other)
+    }
+}
+
+impl PartialEq<InstallationId> for [u8] {
+    fn eq(&self, other: &InstallationId) -> bool {
+        other.0.eq(self)
+    }
+}
+
+impl PartialEq<[u8; 32]> for InstallationId {
+    fn eq(&self, other: &[u8; 32]) -> bool {
+        self.0.eq(other)
+    }
+}
+
+impl PartialEq<InstallationId> for [u8; 32] {
+    fn eq(&self, other: &InstallationId) -> bool {
+        other.0.eq(&self[..])
+    }
+}

--- a/xmtp_mls/src/xmtp_openmls_provider.rs
+++ b/xmtp_mls/src/xmtp_openmls_provider.rs
@@ -19,7 +19,11 @@ impl<C> XmtpOpenMlsProviderPrivate<C> {
         }
     }
 
-    pub(crate) fn conn_ref(&self) -> &DbConnectionPrivate<C> {
+    pub fn new_crypto() -> RustCrypto {
+        RustCrypto::default()
+    }
+
+    pub fn conn_ref(&self) -> &DbConnectionPrivate<C> {
         self.key_store.conn_ref()
     }
 }


### PR DESCRIPTION
- Transactions take a `&XmtpOpenMlsProvider`
- Methods that previously pulled a connection take a provider
- `process_for_id` removed, and inlined where it was used
    - the closure & indirection proved too complicated to figure out the lifetimes for. It also seemed to be too much indirection for only a couple lines of code
    - inlined into `consume_message`
    - created `process_new_welcome`
    - these use `transaction_async` directly and share a `&XmtpOpenMlsProvider`