### PR TITLE
Adds tests showing authn abilities lost after wallet is associated to another inbox_id

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -1824,7 +1824,7 @@ mod tests {
         FfiConsentState, FfiConversation, FfiConversationCallback, FfiConversationMessageKind,
         FfiCreateGroupOptions, FfiGroupPermissionsOptions, FfiInboxOwner,
         FfiListConversationsOptions, FfiListMessagesOptions, FfiMetadataField, FfiPermissionPolicy,
-        FfiPermissionPolicySet, FfiPermissionUpdateType, FfiSubscribeError, GenericError,
+        FfiPermissionPolicySet, FfiPermissionUpdateType, FfiSubscribeError,
     };
     use ethers::utils::hex;
     use rand::distributions::{Alphanumeric, DistString};
@@ -1837,16 +1837,13 @@ mod tests {
         time::{Duration, Instant},
     };
     use tokio::{sync::Notify, time::error::Elapsed};
-    use tracing_subscriber::layer::Identity;
     use xmtp_cryptography::{signature::RecoverableSignature, utils::rng};
     use xmtp_id::associations::{
         generate_inbox_id,
-        test_utils::add_wallet_signature,
         unverified::{UnverifiedRecoverableEcdsaSignature, UnverifiedSignature},
     };
     use xmtp_mls::{
         api::test_utils::{wait_for_eq, wait_for_ok},
-        client::ClientError,
         groups::{scoped_client::LocalScopedGroupClient, GroupError},
         storage::EncryptionKey,
         InboxOwner,
@@ -4635,7 +4632,7 @@ mod tests {
         register_client(&ffi_inbox_owner_b1, &client_b1).await;
 
         // Step 3: Wallet B creates a second client for inbox_id B
-        let client_b2 = create_client(
+        let _client_b2 = create_client(
             xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(),
             false,
             Some(tmp_path()),


### PR DESCRIPTION
Closes https://github.com/xmtp/libxmtp/issues/1359

1. Once a wallet/address has been associated to an existing inbox_id, it will fail when trying to create a client with a new inbox_id derived from its own address.
2. For two wallets A and B that created identities with inbox_id A and B, if we successfully add association from wallet B to inbox_id A, then wallet B will no longer be able to create a client for inbox_id B. 