### PR TITLE
Do not allow overriding an intent that is already published

### DIFF
--- a/xmtp_mls/src/storage/encrypted_store/group_intent.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group_intent.rs
@@ -227,7 +227,7 @@ impl DbConnection {
                 tracing::info!("Set intent {intent_id} to published");
                 tracing::info!(
                     "intent {intent_id} that was just saved to DB has payload_hash: {:?}",
-                    payload_hash_clone
+                    hex::encode(payload_hash_clone)
                 );
                 Ok(())
             }

--- a/xmtp_mls/src/storage/encrypted_store/group_intent.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group_intent.rs
@@ -206,7 +206,6 @@ impl DbConnection {
                 .filter(
                     dsl::state
                         .eq(IntentState::ToPublish)
-                        .or(dsl::state.eq(IntentState::Published)),
                 )
                 .set((
                     dsl::state.eq(IntentState::Published),

--- a/xmtp_mls/src/storage/encrypted_store/group_intent.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group_intent.rs
@@ -197,6 +197,7 @@ impl DbConnection {
         staged_commit: Option<Vec<u8>>,
         published_in_epoch: i64,
     ) -> Result<(), StorageError> {
+        let payload_hash_clone = payload_hash.clone();
         let res = self.raw_query(|conn| {
             diesel::update(dsl::group_intents)
                 .filter(dsl::id.eq(intent_id))
@@ -222,7 +223,14 @@ impl DbConnection {
             0 => Err(StorageError::NotFound(format!(
                 "ToPublish intent {intent_id} for publish"
             ))),
-            _ => Ok(()),
+            _ => {
+                tracing::info!("Set intent {intent_id} to published");
+                tracing::info!(
+                    "intent {intent_id} that was just saved to DB has payload_hash: {:?}",
+                    payload_hash_clone
+                );
+                Ok(())
+            }
         }
     }
 


### PR DESCRIPTION
Before this change parallel executing threads could calculate two different `payload_hash` for the same `intent id` and the second executing thread could override the first's intent in the DB even though it was already published to the network.

https://github.com/xmtp/libxmtp/blob/4336127769cbb7b5dc13595a465624fa7b123541/xmtp_mls/src/groups/mls_sync.rs#L980-L1025

This was causing an intent that was already on the network to be overwritten locally, causing the incoming message to be interpreted as an external message, which would cause the sender of the intent to be forked from the rest of the group, this was shows in tests on the following React Native PRs:

- https://github.com/xmtp/xmtp-react-native/pull/534
- https://github.com/xmtp/xmtp-react-native/pull/538

After this change the parallel executing commit messages in React Native do not cause the forked state. 