### PR TITLE
Teach xdbg --version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1280,6 +1280,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "derive_more"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3211,7 +3242,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3499,7 +3530,7 @@ dependencies = [
  "tonic",
  "tracing",
  "tracing-subscriber",
- "vergen",
+ "vergen-git2",
  "warp",
  "xmtp_common",
  "xmtp_cryptography",
@@ -6657,15 +6688,41 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
-version = "8.3.2"
+version = "9.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2990d9ea5967266ea0ccf413a4aa5c42a93dbcfda9cb49a97de6931726b12566"
+checksum = "31f25fc8f8f05df455c7941e87f093ad22522a9ff33d7a027774815acf6f0639"
 dependencies = [
  "anyhow",
- "cfg-if",
+ "derive_builder",
+ "rustversion",
+ "time",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-git2"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e63e069d8749fead1e3bab7a9d79e8fb90516b2ec66fc2243a798ecdc1a31d7"
+dependencies = [
+ "anyhow",
+ "derive_builder",
  "git2",
  "rustversion",
  "time",
+ "vergen",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-lib"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0c767e6751c09fc85cde58722cf2f1007e80e4c8d5a4321fc90d83dc54ca147"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
 ]
 
 [[package]]
@@ -6899,7 +6956,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7200,6 +7257,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "valuable",
+ "vergen-git2",
  "xmtp_api_grpc",
  "xmtp_cryptography",
  "xmtp_id",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3515,7 +3515,7 @@ dependencies = [
 
 [[package]]
 name = "mls_validation_service"
-version = "0.1.0"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ thiserror = "2.0"
 tls_codec = "0.4.1"
 tokio = { version = "1.35.1", default-features = false }
 uuid = "1.10"
+vergen-git2 = "1.0.2"
 wasm-timer = "0.2"
 web-time = "1.1"
 # Changing this version and rustls may potentially break the android build. Use Caution.

--- a/mls_validation_service/Cargo.toml
+++ b/mls_validation_service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "mls_validation_service"
-version = "0.1.0" # Intentionally decoupled from the Workspace versioning
+version = "0.1.4"
 build = "build.rs"
 license.workspace = true
 

--- a/mls_validation_service/Cargo.toml
+++ b/mls_validation_service/Cargo.toml
@@ -10,7 +10,7 @@ name = "mls-validation-service"
 path = "src/main.rs"
 
 [build-dependencies]
-vergen = { version = "8.3.2", features = ["git", "git2"] }
+vergen-git2 = { workspace = true, features = ["build"] }
 
 [dependencies]
 clap = { version = "4.4.6", features = ["derive"] }

--- a/mls_validation_service/build.rs
+++ b/mls_validation_service/build.rs
@@ -10,4 +10,3 @@ fn main() -> Result<(), Box<dyn Error>> {
         .emit()?;
     Ok(())
 }
-// this is a change

--- a/xmtp_debug/Cargo.toml
+++ b/xmtp_debug/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 version = "0.1.0"
 license.workspace = true
 
+[build-dependencies]
+vergen-git2 = { workspace = true, features = ["build"] }
+
 [dependencies]
 clap = { version = "4.5.20", features = ["derive"] }
 clap-verbosity-flag = "3.0"

--- a/xmtp_debug/build.rs
+++ b/xmtp_debug/build.rs
@@ -1,5 +1,5 @@
 use std::error::Error;
-use vergen_git2::{BuildBuilder, Emitter, Git2Builder};
+use     vergen_git2::{BuildBuilder, Emitter, Git2Builder};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let build = BuildBuilder::all_build()?;
@@ -10,4 +10,3 @@ fn main() -> Result<(), Box<dyn Error>> {
         .emit()?;
     Ok(())
 }
-// this is a change

--- a/xmtp_debug/build.rs
+++ b/xmtp_debug/build.rs
@@ -1,5 +1,5 @@
 use std::error::Error;
-use     vergen_git2::{BuildBuilder, Emitter, Git2Builder};
+use vergen_git2::{BuildBuilder, Emitter, Git2Builder};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let build = BuildBuilder::all_build()?;

--- a/xmtp_debug/src/args.rs
+++ b/xmtp_debug/src/args.rs
@@ -11,6 +11,9 @@ pub use types::*;
 /// Debug & Generate data on the XMTP Network
 #[derive(Parser, Debug)]
 pub struct AppOpts {
+    // Print Version
+    #[arg(long)]
+    pub version: bool,
     #[command(subcommand)]
     pub cmd: Option<Commands>,
     #[command(flatten)]

--- a/xmtp_debug/src/main.rs
+++ b/xmtp_debug/src/main.rs
@@ -23,8 +23,17 @@ async fn main() -> Result<()> {
     let mut logger = logger::Logger::from(&opts.log);
     logger.init()?;
 
+    if opts.version {
+        info!("Version: {0}", get_version());
+        return Ok(());
+    }
+
     let app = app::App::new(opts)?;
     app.run().await?;
 
     Ok(())
+}
+
+pub fn get_version() -> String {
+    format!("{}-{}", env!("CARGO_PKG_VERSION"), env!("VERGEN_GIT_SHA"))
 }


### PR DESCRIPTION
Introduce --version.

This also upgrades from 8.x to 9.x of vergen and changes the way version is generated in mls.