### PR TITLE
cleanup NotFound string errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3211,7 +3211,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6899,7 +6899,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/xmtp_debug/src/args.rs
+++ b/xmtp_debug/src/args.rs
@@ -154,6 +154,17 @@ pub enum EntityKind {
     Identity,
 }
 
+impl std::fmt::Display for EntityKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use EntityKind::*;
+        match self {
+            Group => write!(f, "group"),
+            Message => write!(f, "message"),
+            Identity => write!(f, "identity"),
+        }
+    }
+}
+
 /// specify the log output
 #[derive(Args, Debug)]
 pub struct LogOptions {

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -50,7 +50,7 @@ use crate::{
         group_message::StoredGroupMessage,
         refresh_state::EntityKind,
         wallet_addresses::WalletEntry,
-        EncryptedMessageStore, StorageError,
+        EncryptedMessageStore, NotFound, StorageError,
     },
     subscriptions::{LocalEventError, LocalEvents},
     types::InstallationId,
@@ -106,6 +106,12 @@ pub enum ClientError {
     LocalEvent(#[from] LocalEventError),
     #[error("generic:{0}")]
     Generic(String),
+}
+
+impl From<NotFound> for ClientError {
+    fn from(value: NotFound) -> Self {
+        ClientError::Storage(StorageError::NotFound(value))
+    }
 }
 
 impl From<GroupError> for ClientError {
@@ -309,11 +315,7 @@ where
         address: String,
     ) -> Result<Option<String>, ClientError> {
         let results = self.find_inbox_ids_from_addresses(conn, &[address]).await?;
-        if let Some(first_result) = results.into_iter().next() {
-            Ok(first_result)
-        } else {
-            Ok(None)
-        }
+        Ok(results.into_iter().next().flatten())
     }
 
     /// Calls the server to look up the `inbox_id`s` associated with a list of addresses.
@@ -556,10 +558,9 @@ where
         {
             Some(id) => id,
             None => {
-                return Err(ClientError::Storage(StorageError::NotFound(format!(
-                    "inbox id for address {} not found",
-                    account_address
-                ))))
+                return Err(ClientError::Storage(StorageError::NotFound(
+                    NotFound::InboxIdForAddress(account_address),
+                )));
             }
         };
 
@@ -610,13 +611,10 @@ where
         group_id: Vec<u8>,
     ) -> Result<MlsGroup<Self>, ClientError> {
         let stored_group: Option<StoredGroup> = conn.fetch(&group_id)?;
-        match stored_group {
-            Some(group) => Ok(MlsGroup::new(self.clone(), group.id, group.created_at_ns)),
-            None => Err(ClientError::Storage(StorageError::NotFound(format!(
-                "group {}",
-                hex::encode(group_id)
-            )))),
-        }
+        stored_group
+            .map(|g| MlsGroup::new(self.clone(), g.id, g.created_at_ns))
+            .ok_or(NotFound::GroupById(group_id))
+            .map_err(Into::into)
     }
 
     /// Look up a group by its ID
@@ -638,17 +636,10 @@ where
         target_inbox_id: String,
     ) -> Result<MlsGroup<Self>, ClientError> {
         let conn = self.store().conn()?;
-        match conn.find_dm_group(&target_inbox_id)? {
-            Some(dm_group) => Ok(MlsGroup::new(
-                self.clone(),
-                dm_group.id,
-                dm_group.created_at_ns,
-            )),
-            None => Err(ClientError::Storage(StorageError::NotFound(format!(
-                "dm_target_inbox_id {}",
-                hex::encode(target_inbox_id)
-            )))),
-        }
+        let group = conn
+            .find_dm_group(&target_inbox_id)?
+            .ok_or(NotFound::DmByInbox(target_inbox_id))?;
+        Ok(MlsGroup::new(self.clone(), group.id, group.created_at_ns))
     }
 
     /// Look up a message by its ID
@@ -656,13 +647,7 @@ where
     pub fn message(&self, message_id: Vec<u8>) -> Result<StoredGroupMessage, ClientError> {
         let conn = &mut self.store().conn()?;
         let message = conn.get_group_message(&message_id)?;
-        match message {
-            Some(message) => Ok(message),
-            None => Err(ClientError::Storage(StorageError::NotFound(format!(
-                "message {}",
-                hex::encode(message_id)
-            )))),
-        }
+        Ok(message.ok_or(NotFound::MessageById(message_id))?)
     }
 
     /// Query for groups with optional filters

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -58,7 +58,7 @@ use self::{
     intents::IntentError,
     validated_commit::CommitValidationError,
 };
-use crate::storage::{group_message::ContentType, StorageError};
+use crate::storage::{group_message::ContentType, NotFound, StorageError};
 use xmtp_common::time::now_ns;
 use xmtp_proto::xmtp::mls::{
     api::v1::{
@@ -418,7 +418,9 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
         let mls_group =
             OpenMlsGroup::load(provider.storage(), &GroupId::from_slice(&self.group_id))
                 .map_err(crate::StorageError::from)?
-                .ok_or(crate::StorageError::NotFound("Group Not Found".into()))?;
+                .ok_or(StorageError::from(NotFound::GroupById(
+                    self.group_id.to_vec(),
+                )))?;
 
         // Perform the operation with the MLS group
         operation(mls_group).await.map_err(Into::into)

--- a/xmtp_mls/src/storage/encrypted_store/group.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group.rs
@@ -5,7 +5,7 @@ use super::{
     schema::groups::{self, dsl},
     Sqlite,
 };
-use crate::{impl_fetch, impl_store, DuplicateItem, StorageError};
+use crate::{impl_fetch, impl_store, storage::NotFound, DuplicateItem, StorageError};
 use diesel::{
     backend::Backend,
     deserialize::{self, FromSql, FromSqlRow},
@@ -379,9 +379,8 @@ impl DbConnection {
             Ok::<Option<i64>, StorageError>(ts)
         })?;
 
-        last_ts.ok_or(StorageError::NotFound(format!(
-            "installation time for group {}",
-            hex::encode(group_id)
+        last_ts.ok_or(StorageError::NotFound(NotFound::InstallationTimeForGroup(
+            group_id,
         )))
     }
 
@@ -407,10 +406,7 @@ impl DbConnection {
             Ok::<_, StorageError>(ts)
         })?;
 
-        last_ts.ok_or(StorageError::NotFound(format!(
-            "installation time for group {}",
-            hex::encode(group_id)
-        )))
+        last_ts.ok_or(NotFound::InstallationTimeForGroup(group_id).into())
     }
 
     /// Updates the 'last time checked' we checked for new installations.

--- a/xmtp_mls/src/storage/encrypted_store/sqlcipher_connection.rs
+++ b/xmtp_mls/src/storage/encrypted_store/sqlcipher_connection.rs
@@ -12,7 +12,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::storage::StorageError;
+use crate::storage::{NotFound, StorageError};
 
 use super::{EncryptionKey, StorageOption};
 
@@ -165,9 +165,9 @@ impl EncryptedConnection {
     ) -> Result<(), StorageError> {
         let mut row_iter = conn.load(sql_query("PRAGMA cipher_salt"))?;
         // cipher salt should always exist. if it doesn't SQLCipher is misconfigured.
-        let row = row_iter.next().ok_or(StorageError::NotFound(
-            "Cipher salt doesn't exist in database".into(),
-        ))??;
+        let row = row_iter
+            .next()
+            .ok_or(NotFound::CipherSalt(path.to_string()))??;
         let salt = <String as FromSqlRow<diesel::sql_types::Text, _>>::build_from_row(&row)?;
         tracing::debug!(
             salt,

--- a/xmtp_mls/src/storage/errors.rs
+++ b/xmtp_mls/src/storage/errors.rs
@@ -3,7 +3,10 @@ use std::sync::PoisonError;
 use diesel::result::DatabaseErrorKind;
 use thiserror::Error;
 
-use super::sql_key_store::{self, SqlKeyStoreError};
+use super::{
+    refresh_state::EntityKind,
+    sql_key_store::{self, SqlKeyStoreError},
+};
 use crate::groups::intents::IntentError;
 use xmtp_common::{retryable, RetryableError};
 
@@ -27,10 +30,9 @@ pub enum StorageError {
     Serialization(String),
     #[error("deserialization error")]
     Deserialization(String),
-    // TODO:insipx Make NotFound into an enum of possible items that may not be found
-    #[error("{0} not found")]
-    NotFound(String),
-    #[error("lock")]
+    #[error(transparent)]
+    NotFound(#[from] NotFound),
+    #[error("lock {0}")]
     Lock(String),
     #[error("Pool needs to  reconnect before use")]
     PoolNeedsConnection,
@@ -48,6 +50,35 @@ pub enum StorageError {
     Duplicate(DuplicateItem),
     #[error(transparent)]
     OpenMlsStorage(#[from] SqlKeyStoreError),
+}
+
+#[derive(Error, Debug)]
+// Monolithic enum for all things lost
+pub enum NotFound {
+    #[error("group with welcome id {0} not found")]
+    GroupByWelcome(i64),
+    #[error("group with id {id} not found", id = hex::encode(_0))]
+    GroupById(Vec<u8>),
+    #[error("installation time for group {id}", id = hex::encode(_0))]
+    InstallationTimeForGroup(Vec<u8>),
+    #[error("inbox id for address {0} not found")]
+    InboxIdForAddress(String),
+    #[error("message id {id} not found", id = hex::encode(_0))]
+    MessageById(Vec<u8>),
+    #[error("dm by dm_target_inbox_id {0} not found")]
+    DmByInbox(String),
+    #[error("intent with id {0} for state Publish from ToPublish not found")]
+    IntentForToPublish(i32),
+    #[error("intent with id {0} for state ToPublish from Published not found")]
+    IntentForPublish(i32),
+    #[error("intent with id {0} for state Committed from Published not found")]
+    IntentForCommitted(i32),
+    #[error("Intent with id {0} not found")]
+    IntentById(i32),
+    #[error("refresh state with id {id} and kind {1} not found", id = hex::encode(_0))]
+    RefreshStateByIdAndKind(Vec<u8>, EntityKind),
+    #[error("Cipher salt for db at [`{0}`] not found")]
+    CipherSalt(String),
 }
 
 #[derive(Error, Debug)]
@@ -102,6 +133,12 @@ impl RetryableError for StorageError {
             Self::Duplicate(d) => retryable!(d),
             _ => false,
         }
+    }
+}
+
+impl RetryableError for NotFound {
+    fn is_retryable(&self) -> bool {
+        true
     }
 }
 


### PR DESCRIPTION
Split #1376 into two to keep PRs focused. This one just refactors `NotFound` into string errors to cleanup places where we had inconsistent error messages/unnecessary `match`es, and maybe using `hex::encode` unnecessarily 