### PR TITLE
Make conversation listing sync (node + WASM)

### DIFF
--- a/bindings_node/CHANGELOG.md
+++ b/bindings_node/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.0.33
 
 - Added installation ID `bytes` to return value of `inboxState`
+- Refactored `list`, `listGroups`, and `listDms` to be synchronous
 
 ## 0.0.32
 

--- a/bindings_node/src/conversations.rs
+++ b/bindings_node/src/conversations.rs
@@ -303,7 +303,7 @@ impl Conversations {
   }
 
   #[napi]
-  pub async fn list(&self, opts: Option<ListConversationsOptions>) -> Result<Vec<Conversation>> {
+  pub fn list(&self, opts: Option<ListConversationsOptions>) -> Result<Vec<Conversation>> {
     let convo_list: Vec<Conversation> = self
       .inner_client
       .find_groups(opts.unwrap_or_default().into())
@@ -316,29 +316,19 @@ impl Conversations {
   }
 
   #[napi]
-  pub async fn list_groups(
-    &self,
-    opts: Option<ListConversationsOptions>,
-  ) -> Result<Vec<Conversation>> {
-    self
-      .list(Some(ListConversationsOptions {
-        conversation_type: Some(ConversationType::Group),
-        ..opts.unwrap_or_default()
-      }))
-      .await
+  pub fn list_groups(&self, opts: Option<ListConversationsOptions>) -> Result<Vec<Conversation>> {
+    self.list(Some(ListConversationsOptions {
+      conversation_type: Some(ConversationType::Group),
+      ..opts.unwrap_or_default()
+    }))
   }
 
   #[napi]
-  pub async fn list_dms(
-    &self,
-    opts: Option<ListConversationsOptions>,
-  ) -> Result<Vec<Conversation>> {
-    self
-      .list(Some(ListConversationsOptions {
-        conversation_type: Some(ConversationType::Dm),
-        ..opts.unwrap_or_default()
-      }))
-      .await
+  pub fn list_dms(&self, opts: Option<ListConversationsOptions>) -> Result<Vec<Conversation>> {
+    self.list(Some(ListConversationsOptions {
+      conversation_type: Some(ConversationType::Dm),
+      ..opts.unwrap_or_default()
+    }))
   }
 
   #[napi]

--- a/bindings_node/test/Conversations.test.ts
+++ b/bindings_node/test/Conversations.test.ts
@@ -22,9 +22,9 @@ describe('Conversations', () => {
     const user = createUser()
     const client = await createRegisteredClient(user)
 
-    expect((await client.conversations().list()).length).toBe(0)
-    expect((await client.conversations().listDms()).length).toBe(0)
-    expect((await client.conversations().listGroups()).length).toBe(0)
+    expect(client.conversations().list().length).toBe(0)
+    expect(client.conversations().listDms().length).toBe(0)
+    expect(client.conversations().listGroups().length).toBe(0)
   })
 
   it('should create a group chat', async () => {
@@ -67,22 +67,22 @@ describe('Conversations', () => {
 
     expect(group.consentState()).toBe(ConsentState.Allowed)
 
-    const group1 = await client1.conversations().list()
+    const group1 = client1.conversations().list()
     expect(group1.length).toBe(1)
     expect(group1[0].id).toBe(group.id)
-    expect((await client1.conversations().listDms()).length).toBe(0)
-    expect((await client1.conversations().listGroups()).length).toBe(1)
+    expect(client1.conversations().listDms().length).toBe(0)
+    expect(client1.conversations().listGroups().length).toBe(1)
 
-    expect((await client2.conversations().list()).length).toBe(0)
+    expect(client2.conversations().list().length).toBe(0)
 
     await client2.conversations().sync()
 
-    const group2 = await client2.conversations().list()
+    const group2 = client2.conversations().list()
     expect(group2.length).toBe(1)
     expect(group2[0].id).toBe(group.id)
 
-    expect((await client2.conversations().listDms()).length).toBe(0)
-    expect((await client2.conversations().listGroups()).length).toBe(1)
+    expect(client2.conversations().listDms().length).toBe(0)
+    expect(client2.conversations().listGroups().length).toBe(1)
   })
 
   it('should create a group with custom permissions', async () => {
@@ -213,25 +213,25 @@ describe('Conversations', () => {
 
     expect(group.consentState()).toBe(ConsentState.Allowed)
 
-    const group1 = await client1.conversations().list()
+    const group1 = client1.conversations().list()
     expect(group1.length).toBe(1)
     expect(group1[0].id).toBe(group.id)
     expect(group1[0].dmPeerInboxId()).toBe(client2.inboxId())
 
-    expect((await client1.conversations().listDms()).length).toBe(1)
-    expect((await client1.conversations().listGroups()).length).toBe(0)
+    expect(client1.conversations().listDms().length).toBe(1)
+    expect(client1.conversations().listGroups().length).toBe(0)
 
-    expect((await client2.conversations().list()).length).toBe(0)
+    expect(client2.conversations().list().length).toBe(0)
 
     await client2.conversations().sync()
 
-    const group2 = await client2.conversations().list()
+    const group2 = client2.conversations().list()
     expect(group2.length).toBe(1)
     expect(group2[0].id).toBe(group.id)
     expect(group2[0].dmPeerInboxId()).toBe(client1.inboxId())
 
-    expect((await client2.conversations().listDms()).length).toBe(1)
-    expect((await client2.conversations().listGroups()).length).toBe(0)
+    expect(client2.conversations().listDms().length).toBe(1)
+    expect(client2.conversations().listGroups().length).toBe(0)
 
     const dm1 = client1.conversations().findDmByTargetInboxId(client2.inboxId())
     expect(dm1).toBeDefined()
@@ -487,15 +487,15 @@ describe('Conversations', () => {
 
     const groups2 = client2.conversations()
     await groups2.sync()
-    const groupsList2 = await groups2.list()
+    const groupsList2 = groups2.list()
 
     const groups3 = client3.conversations()
     await groups3.sync()
-    const groupsList3 = await groups3.list()
+    const groupsList3 = groups3.list()
 
-    const groups4 = await client4.conversations()
+    const groups4 = client4.conversations()
     await groups4.sync()
-    const groupsList4 = await groups4.list()
+    const groupsList4 = groups4.list()
 
     const message1 = await groupsList2[0].send(encodeTextMessage('gm!'))
     const message2 = await groupsList3[0].send(encodeTextMessage('gm2!'))
@@ -530,15 +530,15 @@ describe('Conversations', () => {
 
     const groups2 = client2.conversations()
     await groups2.sync()
-    const groupsList2 = await groups2.list()
+    const groupsList2 = groups2.list()
 
     const groups3 = client3.conversations()
     await groups3.sync()
-    const groupsList3 = await groups3.list()
+    const groupsList3 = groups3.list()
 
-    const groups4 = await client4.conversations()
+    const groups4 = client4.conversations()
     await groups4.sync()
-    const groupsList4 = await groups4.list()
+    const groupsList4 = groups4.list()
 
     await groupsList4[0].send(encodeTextMessage('gm3!'))
     const message1 = await groupsList2[0].send(encodeTextMessage('gm!'))
@@ -573,15 +573,15 @@ describe('Conversations', () => {
 
     const groups2 = client2.conversations()
     await groups2.sync()
-    const groupsList2 = await groups2.list()
+    const groupsList2 = groups2.list()
 
     const groups3 = client3.conversations()
     await groups3.sync()
-    const groupsList3 = await groups3.list()
+    const groupsList3 = groups3.list()
 
-    const groups4 = await client4.conversations()
+    const groups4 = client4.conversations()
     await groups4.sync()
-    const groupsList4 = await groups4.list()
+    const groupsList4 = groups4.list()
 
     await groupsList2[0].send(encodeTextMessage('gm!'))
     await groupsList3[0].send(encodeTextMessage('gm2!'))

--- a/bindings_wasm/CHANGELOG.md
+++ b/bindings_wasm/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.0.11
 
 - Added installation ID `bytes` to return value of `inboxState`
+- Refactored `list`, `listGroups`, and `listDms` to be synchronous
 
 ## 0.0.10
 

--- a/bindings_wasm/src/conversations.rs
+++ b/bindings_wasm/src/conversations.rs
@@ -323,10 +323,7 @@ impl Conversations {
   }
 
   #[wasm_bindgen]
-  pub async fn list(
-    &self,
-    opts: Option<ListConversationsOptions>,
-  ) -> Result<js_sys::Array, JsError> {
+  pub fn list(&self, opts: Option<ListConversationsOptions>) -> Result<js_sys::Array, JsError> {
     let convo_list: js_sys::Array = self
       .inner_client
       .find_groups(opts.unwrap_or_default().into())
@@ -345,28 +342,21 @@ impl Conversations {
   }
 
   #[wasm_bindgen(js_name = listGroups)]
-  pub async fn list_groups(
+  pub fn list_groups(
     &self,
     opts: Option<ListConversationsOptions>,
   ) -> Result<js_sys::Array, JsError> {
-    self
-      .list(Some(ListConversationsOptions {
-        conversation_type: Some(ConversationType::Group),
-        ..opts.unwrap_or_default()
-      }))
-      .await
+    self.list(Some(ListConversationsOptions {
+      conversation_type: Some(ConversationType::Group),
+      ..opts.unwrap_or_default()
+    }))
   }
 
   #[wasm_bindgen(js_name = listDms)]
-  pub async fn list_dms(
-    &self,
-    opts: Option<ListConversationsOptions>,
-  ) -> Result<js_sys::Array, JsError> {
-    self
-      .list(Some(ListConversationsOptions {
-        conversation_type: Some(ConversationType::Dm),
-        ..opts.unwrap_or_default()
-      }))
-      .await
+  pub fn list_dms(&self, opts: Option<ListConversationsOptions>) -> Result<js_sys::Array, JsError> {
+    self.list(Some(ListConversationsOptions {
+      conversation_type: Some(ConversationType::Dm),
+      ..opts.unwrap_or_default()
+    }))
   }
 }


### PR DESCRIPTION
# Summary

Following the recent changes to the FFI bindings, this PR updates the `list`, `listGroups`, and `listDms` methods to be synchronous.