### PR TITLE
Fixed spelling errors i

### DIFF
--- a/diagrams/diagrams.md
+++ b/diagrams/diagrams.md
@@ -7,7 +7,7 @@ The diagrams represent the creation of a group chat between Alice, Bob, and Char
 Note: calls into LibXMTP with the `conversations.` prefix use the [Conversations](https://github.com/xmtp/libxmtp/blob/204b35a337daf2a9f2ed0cb20199e254d0a7493a/bindings_ffi/src/mls.rs#L188) protocol, and calls with a `group.` prefix use the [Group](https://github.com/xmtp/libxmtp/blob/204b35a337daf2a9f2ed0cb20199e254d0a7493a/bindings_ffi/src/mls.rs#L315) protocol.
 
 * *form-group.mermaid* - Covers Steps 1-4 of forming a group.  In LibXMTP, steps 1 and 2 happen at the same time, and steps 3 and 4 can also be consolidated by calling `newGroup()` with multiple participants.
-* *send-recieve.mermaid* - Covers sending and receiving messages to the newly formed group.
+* *send-receive.mermaid* - Covers sending and receiving messages to the newly formed group.
 * *add-remove.mermaid* - Covers adding and removing group members.
 * *sync-installations.mermaid* - Covers how to find out if group members have added/removed an installation, and how to respond.
 

--- a/xmtp_debug/src/app/generate/identity.rs
+++ b/xmtp_debug/src/app/generate/identity.rs
@@ -61,7 +61,7 @@ impl GenerateIdentity {
                 self.identity_store.clear_network(&self.network)?;
             }
         }
-        info!("Could not find identitites to load, creating new identitites");
+        info!("Could not find identities to load, creating new identities");
         let identities = self.create_identities(n).await?;
         self.identity_store
             .set_all(identities.as_slice(), &self.network)?;


### PR DESCRIPTION

## Changes Made

### 1. File: `diagrams/diagrams.md`
- **Old Word:** `send-receive.mermaid`
- **New Word:** `send-recieve.mermaid`
- **Reason for Change:** Corrected spelling for accurate terminology.

### 2. File: `xmtp_debug/src/app/generate/identity.rs`
- **Old Word:** `identitites`
- **New Word:** `identities`
- **Reason for Change:** Corrected spelling for consistency and clarity.

## Summary of Changes
- Fixed spelling errors in `diagrams/diagrams.md` and `xmtp_debug/src/app/generate/identity.rs` to enhance clarity and professionalism.