### PR TITLE
Update modify.rs

### DIFF
--- a/xmtp_debug/src/app/modify.rs
+++ b/xmtp_debug/src/app/modify.rs
@@ -47,7 +47,7 @@ impl Modify {
         match action {
             Remove => {
                 if inbox_id.is_none() {
-                    bail!("Inbox ID to remove must be specificied")
+                    bail!("Inbox ID to remove must be specified")
                 }
                 let inbox_id = inbox_id.expect("Checked for none");
                 local_group.member_size -= 1;
@@ -68,7 +68,7 @@ impl Modify {
                 let rng = &mut SmallRng::from_entropy();
                 let identity = identity_store
                     .load(&network)?
-                    .ok_or(eyre!("No identitites"))?
+                    .ok_or(eyre!("No identities"))?
                     .map(|i| i.value())
                     .filter(|identity| !members.iter().any(|i| *i == identity.inbox_id))
                     .choose(rng)
@@ -87,7 +87,7 @@ impl Modify {
             }
             AddExternal => {
                 if inbox_id.is_none() {
-                    bail!("Inbox ID to add must be specificied")
+                    bail!("Inbox ID to add must be specified")
                 }
                 let inbox_id = inbox_id.expect("Checked for none");
                 group


### PR DESCRIPTION
1. File: xmtp_debug/src/app/modify.rs
Change:
Old: bail!("Inbox ID to remove must be specificied")
New: bail!("Inbox ID to remove must be specified")
Reason: Corrected the spelling of "specified" to ensure clarity and professionalism in error messages.
2. File: xmtp_debug/src/app/modify.rs
Change:
Old: ok_or(eyre!("No identitites"))?
New: ok_or(eyre!("No identities"))?
Reason: Corrected the spelling of "identities" to ensure accurate communication of the error condition.
3. File: xmtp_debug/src/app/modify.rs
Change:
Old: bail!("Inbox ID to add must be specificied")
New: bail!("Inbox ID to add must be specified")
Reason: Corrected the spelling of "specified" to maintain consistency and professionalism in error messages.