### PR TITLE
docs: fix typo in contract constant docker-compose.yml

### DIFF
--- a/dev/docker/docker-compose.yml
+++ b/dev/docker/docker-compose.yml
@@ -66,7 +66,7 @@ services:
 
   chain:
     platform: linux/amd64
-    # note: the SHA here is tied to the XTMPD_CONTRACTS_*_ADDRESSes
+    # note: the SHA here is tied to the XMTPD_CONTRACTS_*_ADDRESSes
     # if you bump the version of anvil-xmtpd you will have to change the contracts
     # you can find them inside the anvil-xmtpd image via `docker exec libxmtp-chain-1 cat contracts.env`
     image: ghcr.io/xmtp/anvil-xmtpd:sha-9d0de26


### PR DESCRIPTION
# Description:
This PR fixes a typo in the contract constant name. The incorrect identifier XTMPD_CONTRACTS has been corrected to XMTPD_CONTRACTS for consistency and accuracy.

# Changes:

Renamed XTMPD_CONTRACTS to XMTPD_CONTRACTS in relevant files.

# Why this is needed:

Ensures correct naming conventions.
Prevents potential confusion or errors when referencing the constant.

No functional changes were made.