### PR TITLE
fix: start disappearing messages worker when building the client

### DIFF
--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -220,6 +220,8 @@ where
         client.start_sync_worker();
     }
 
+    client.start_disappearing_messages_cleaner_worker();
+
     Ok(client)
 }
 

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -273,6 +273,9 @@ where
         if self.history_sync_url.is_some() {
             self.start_sync_worker();
         }
+
+        self.start_disappearing_messages_cleaner_worker();
+
         Ok(())
     }
 }


### PR DESCRIPTION
Initialize the disappearing message deleter in the client builder so it runs automatically.