### PR TITLE
contextual logging, remove optional cursor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6255,6 +6255,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-forest"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee40835db14ddd1e3ba414292272eddde9dad04d3d4b65509656414d1c42592f"
+dependencies = [
+ "chrono",
+ "smallvec",
+ "thiserror 1.0.69",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-futures"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6262,6 +6275,17 @@ checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
  "pin-project",
  "tracing",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
 ]
 
 [[package]]
@@ -6322,6 +6346,7 @@ dependencies = [
  "time",
  "tracing",
  "tracing-core",
+ "tracing-log",
  "tracing-serde",
  "valuable",
  "valuable-serde",
@@ -7395,6 +7420,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-flame",
+ "tracing-forest",
  "tracing-subscriber",
  "tracing-wasm",
  "wasm-bindgen",

--- a/bindings_ffi/src/logger.rs
+++ b/bindings_ffi/src/logger.rs
@@ -46,47 +46,7 @@ mod other {
     where
         S: Subscriber + for<'a> LookupSpan<'a>,
     {
-        use tracing_subscriber::{
-            fmt::{self, format},
-            EnvFilter, Layer,
-        };
-        let structured = std::env::var("STRUCTURED");
-        let is_structured = matches!(structured, Ok(s) if s == "true" || s == "1");
-
-        let filter = || {
-            EnvFilter::builder()
-                .with_default_directive(tracing::metadata::LevelFilter::INFO.into())
-                .from_env_lossy()
-        };
-
-        vec![
-            // structured JSON logger
-            is_structured
-                .then(|| {
-                    tracing_subscriber::fmt::layer()
-                        .json()
-                        .flatten_event(true)
-                        .with_level(true)
-                        .with_filter(filter())
-                })
-                .boxed(),
-            // default logger
-            (!is_structured)
-                .then(|| {
-                    fmt::layer()
-                        .compact()
-                        .fmt_fields({
-                            format::debug_fn(move |writer, field, value| {
-                                if field.name() == "message" {
-                                    write!(writer, "{:?}", value)?;
-                                }
-                                Ok(())
-                            })
-                        })
-                        .with_filter(filter())
-                })
-                .boxed(),
-        ]
+        xmtp_common::logger_layer()
     }
 }
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -21,6 +21,7 @@ tracing-subscriber = { workspace = true, features = [
   "ansi",
   "json",
 ], optional = true }
+tracing-forest = { version = "0.1", optional = true, features = ["chrono"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { workspace = true, features = ["js"] }
@@ -34,6 +35,7 @@ wasm-bindgen.workspace = true
 
 [dev-dependencies]
 thiserror.workspace = true
+tracing-forest = { version = "0.1", features = ["chrono"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 tokio = { workspace = true, features = ["time", "macros", "rt", "sync"] }
@@ -53,6 +55,7 @@ test-utils = [
   "dep:tracing-subscriber",
   "dep:tracing-wasm",
   "dep:console_error_panic_hook",
+  "dep:tracing-forest"
 ]
 bench = [
   "test-utils",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -15,13 +15,13 @@ xmtp_cryptography.workspace = true
 once_cell = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
 tracing-flame = { version = "0.2", optional = true }
+tracing-forest = { version = "0.1", optional = true, features = ["chrono"] }
 tracing-subscriber = { workspace = true, features = [
   "fmt",
   "env-filter",
   "ansi",
   "json",
 ], optional = true }
-tracing-forest = { version = "0.1", optional = true, features = ["chrono"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { workspace = true, features = ["js"] }
@@ -55,7 +55,7 @@ test-utils = [
   "dep:tracing-subscriber",
   "dep:tracing-wasm",
   "dep:console_error_panic_hook",
-  "dep:tracing-forest"
+  "dep:tracing-forest",
 ]
 bench = [
   "test-utils",

--- a/common/src/test/logger.rs
+++ b/common/src/test/logger.rs
@@ -1,0 +1,163 @@
+// copy-paste of https://docs.rs/tracing-forest/latest/src/tracing_forest/printer/pretty.rs.html#62
+// but with slight variations
+use std::fmt::{self, Write};
+use tracing_forest::printer::Formatter;
+use tracing_forest::tree::{Event, Span, Tree};
+
+type IndentVec = Vec<Indent>;
+
+pub struct Contextual;
+impl Contextual {
+    fn format_tree(
+        tree: &Tree,
+        duration_root: Option<f64>,
+        indent: &mut IndentVec,
+        writer: &mut String,
+    ) -> fmt::Result {
+        match tree {
+            Tree::Event(event) => {
+                // write!(writer, "{:36} ", event.timestamp().to_rfc3339())?;
+                // write!(writer, "{:<8} ", event.level())?;
+                Contextual::format_indent(indent, writer)?;
+                Contextual::format_event(event, writer)
+            }
+            Tree::Span(span) => {
+                // write!(writer, "{:36} ", span.timestamp().to_rfc3339())?;
+                // write!(writer, "{:<8} ", span.level())?;
+                Contextual::format_indent(indent, writer)?;
+                Contextual::format_span(span, duration_root, indent, writer)
+            }
+        }
+    }
+
+    fn format_indent(indent: &[Indent], writer: &mut String) -> fmt::Result {
+        for indent in indent {
+            writer.write_str(indent.repr())?;
+        }
+        Ok(())
+    }
+
+    fn format_event(event: &Event, writer: &mut String) -> fmt::Result {
+        if let Some(message) = event.message() {
+            writer.write_str(message)?;
+        }
+        /*
+                    for field in event.fields().iter() {
+                        write!(writer, " | {}: {}", field.key(), field.value())?;
+                    }
+        */
+        writeln!(writer)
+    }
+
+    fn format_span(
+        span: &Span,
+        duration_root: Option<f64>,
+        indent: &mut IndentVec,
+        writer: &mut String,
+    ) -> fmt::Result {
+        let total_duration = span.total_duration().as_nanos() as f64;
+        let inner_duration = span.inner_duration().as_nanos() as f64;
+        let root_duration = duration_root.unwrap_or(total_duration);
+        let percent_total_of_root_duration = 100.0 * total_duration / root_duration;
+
+        write!(
+            writer,
+            "{} [ {} | ",
+            span.name(),
+            DurationDisplay(total_duration)
+        )?;
+
+        if inner_duration > 0.0 {
+            let base_duration = span.base_duration().as_nanos() as f64;
+            let percent_base_of_root_duration = 100.0 * base_duration / root_duration;
+            write!(writer, "{:.2}% / ", percent_base_of_root_duration)?;
+        }
+
+        write!(writer, "{:.2}% ]", percent_total_of_root_duration)?;
+        /*
+                    for (n, field) in span.shared.fields.iter().enumerate() {
+                        write!(
+                            writer,
+                            "{} {}: {}",
+                            if n == 0 { "" } else { " |" },
+                            field.key(),
+                            field.value()
+                        )?;
+                    }
+        */
+        writeln!(writer)?;
+
+        if let Some((last, remaining)) = span.nodes().split_last() {
+            match indent.last_mut() {
+                Some(edge @ Indent::Turn) => *edge = Indent::Null,
+                Some(edge @ Indent::Fork) => *edge = Indent::Line,
+                _ => {}
+            }
+
+            indent.push(Indent::Fork);
+
+            for tree in remaining {
+                if let Some(edge) = indent.last_mut() {
+                    *edge = Indent::Fork;
+                }
+                Contextual::format_tree(tree, Some(root_duration), indent, writer)?;
+            }
+
+            if let Some(edge) = indent.last_mut() {
+                *edge = Indent::Turn;
+            }
+            Contextual::format_tree(last, Some(root_duration), indent, writer)?;
+
+            indent.pop();
+        }
+
+        Ok(())
+    }
+}
+impl Formatter for Contextual {
+    type Error = std::fmt::Error;
+
+    fn fmt(&self, tree: &Tree) -> Result<String, Self::Error> {
+        let mut writer = String::with_capacity(256);
+        Contextual::format_tree(tree, None, &mut IndentVec::new(), &mut writer)?;
+        Ok(writer)
+    }
+}
+
+enum Indent {
+    Null,
+    Line,
+    Fork,
+    Turn,
+}
+
+impl Indent {
+    fn repr(&self) -> &'static str {
+        match self {
+            Self::Null => "   ",
+            Self::Line => "│  ",
+            Self::Fork => "┝━ ",
+            Self::Turn => "┕━ ",
+        }
+    }
+}
+
+struct DurationDisplay(f64);
+
+// Taken from chrono
+impl fmt::Display for DurationDisplay {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut t = self.0;
+        for unit in ["ns", "µs", "ms", "s"] {
+            if t < 10.0 {
+                return write!(f, "{:.2}{}", t, unit);
+            } else if t < 100.0 {
+                return write!(f, "{:.1}{}", t, unit);
+            } else if t < 1000.0 {
+                return write!(f, "{:.0}{}", t, unit);
+            }
+            t /= 1000.0;
+        }
+        write!(f, "{:.0}s", t * 1000.0)
+    }
+}

--- a/xmtp_mls/Cargo.toml
+++ b/xmtp_mls/Cargo.toml
@@ -147,6 +147,7 @@ wasm-bindgen-test.workspace = true
 xmtp_common = { workspace = true, features = ["test-utils"] }
 xmtp_id = { path = "../xmtp_id", features = ["test-utils"] }
 xmtp_proto = { workspace = true, features = ["test-utils"] }
+fdlimit = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 ctor.workspace = true

--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -183,19 +183,15 @@ where
     pub async fn sync(&self) -> Result<(), GroupError> {
         let conn = self.context().store().conn()?;
         let mls_provider = XmtpOpenMlsProvider::from(conn);
+        let epoch = self.epoch(&mls_provider).await?;
         tracing::info!(
             inbox_id = self.client.inbox_id(),
             installation_id = %self.client.installation_id(),
             group_id = hex::encode(&self.group_id),
-            "[{}] syncing group",
-            self.client.inbox_id()
-        );
-        tracing::info!(
-            inbox_id = self.client.inbox_id(),
-            installation_id = %self.client.installation_id(),
-            group_id = hex::encode(&self.group_id),
-            "current epoch for [{}] in sync()",
+            epoch = epoch,
+            "[{}] syncing group, epoch = {}",
             self.client.inbox_id(),
+            epoch
         );
         self.maybe_update_installations(&mls_provider, None).await?;
 
@@ -369,7 +365,7 @@ where
     > {
         let GroupMessageV1 {
             created_ns: envelope_timestamp_ns,
-            id: ref msg_id,
+            id: ref cursor,
             ..
         } = *envelope;
 
@@ -390,10 +386,10 @@ where
                             inbox_id = self.client.inbox_id(),
                             installation_id = %self.client.installation_id(),
                             group_id = hex::encode(&self.group_id),
-                            msg_id,
+                            cursor,
                             intent.id,
                             intent.kind = %intent.kind,
-                            "Intent was published in epoch {} but group is currently in epoch {}",
+                            "Intent for msg = [{cursor}] was published in epoch {} but group is currently in epoch {}",
                             published_in_epoch,
                             group_epoch
                         );
@@ -476,7 +472,7 @@ where
         let message_epoch = message.epoch();
         let GroupMessageV1 {
             created_ns: envelope_timestamp_ns,
-            id: ref msg_id,
+            id: ref cursor,
             ..
         } = *envelope;
 
@@ -484,7 +480,7 @@ where
             inbox_id = self.client.inbox_id(),
             installation_id = %self.client.installation_id(),
             group_id = hex::encode(&self.group_id),
-            msg_id,
+            cursor,
             intent.id,
             intent.kind = %intent.kind,
             "[{}]-[{}] processing own message for intent {} / {:?}, message_epoch: {}",
@@ -522,11 +518,10 @@ where
         mls_group: &mut OpenMlsGroup,
         message: PrivateMessageIn,
         envelope: &GroupMessageV1,
-        cursor: Option<i64>,
     ) -> Result<(), GroupMessageProcessingError> {
         let GroupMessageV1 {
             created_ns: envelope_timestamp_ns,
-            id: ref msg_id,
+            id: ref cursor,
             ..
         } = *envelope;
 
@@ -563,8 +558,8 @@ where
             current_epoch = mls_group.epoch().as_u64(),
             msg_epoch = processed_message.epoch().as_u64(),
             msg_group_id = hex::encode(processed_message.group_id().as_slice()),
-            msg_id,
-            "[{}] extracted sender inbox d: {}",
+            cursor,
+            "[{}] extracted sender inbox id: {}",
             self.client.inbox_id(),
             sender_inbox_id
         );
@@ -585,26 +580,47 @@ where
         };
 
         provider.transaction(|provider| {
+            tracing::debug!(
+                inbox_id = self.client.inbox_id(),
+                installation_id = %self.client.installation_id(),
+                group_id = hex::encode(&self.group_id),
+                current_epoch = mls_group.epoch().as_u64(),
+                msg_epoch = processed_message.epoch().as_u64(),
+                cursor = ?cursor,
+                "[{}] processing message in transaction epoch = {}, cursor = {:?}",
+                self.client.inbox_id(),
+                mls_group.epoch().as_u64(),
+                cursor
+            );
             let processed_message = mls_group.process_message(provider, message)?;
 
-            if let Some(cursor) = cursor {
-                let is_updated = provider.conn_ref().update_cursor(
-                    &envelope.group_id,
-                    EntityKind::Group,
-                    cursor,
-                )?;
-                if !is_updated {
-                    return Err(ProcessIntentError::AlreadyProcessed(cursor as u64).into());
-                }
+            let is_updated = provider.conn_ref().update_cursor(
+                &envelope.group_id,
+                EntityKind::Group,
+                *cursor as i64,
+            )?;
+            if !is_updated {
+                return Err(ProcessIntentError::AlreadyProcessed(*cursor as u64).into());
             }
-
+            let previous_epoch = mls_group.epoch().as_u64();
             self.process_external_message(
                 provider,
                 mls_group,
                 processed_message,
                 envelope,
                 validated_commit,
-            )
+            )?;
+            let new_epoch = mls_group.epoch().as_u64();
+            if new_epoch > previous_epoch {
+                tracing::info!(
+                    "[{}] externally processed message [{}] advanced epoch from [{}] to [{}]",
+                    self.client.inbox_id(),
+                    cursor,
+                    previous_epoch,
+                    new_epoch
+                );
+            }
+            Ok::<_, GroupMessageProcessingError>(())
         })?;
 
         Ok(())
@@ -621,7 +637,7 @@ where
     ) -> Result<(), GroupMessageProcessingError> {
         let GroupMessageV1 {
             created_ns: envelope_timestamp_ns,
-            id: ref msg_id,
+            id: ref cursor,
             ..
         } = *envelope;
 
@@ -640,7 +656,7 @@ where
                     current_epoch = mls_group.epoch().as_u64(),
                     msg_epoch,
                     msg_group_id,
-                    msg_id,
+                    cursor,
                     "[{}] decoding application message",
                     self.context().inbox_id()
                 );
@@ -788,7 +804,7 @@ where
                     current_epoch = mls_group.epoch().as_u64(),
                     msg_epoch,
                     msg_group_id,
-                    msg_id,
+                    cursor,
                     "[{}] received staged commit. Merging and clearing any pending commits",
                     self.context().inbox_id()
                 );
@@ -801,7 +817,7 @@ where
                     current_epoch = mls_group.epoch().as_u64(),
                     msg_epoch,
                     msg_group_id,
-                    msg_id,
+                    cursor,
                     "[{}] staged commit is valid, will attempt to merge",
                     self.context().inbox_id()
                 );
@@ -818,15 +834,14 @@ where
         Ok(())
     }
 
-    #[tracing::instrument(level = "trace", skip_all)]
     /// This function is idempotent. No need to wrap in a transaction.
     pub(crate) async fn process_message(
         &self,
         provider: &XmtpOpenMlsProvider,
         envelope: &GroupMessageV1,
         allow_epoch_increment: bool,
-        cursor: Option<i64>,
     ) -> Result<(), GroupMessageProcessingError> {
+        let cursor = envelope.id;
         let mls_message_in = MlsMessageIn::tls_deserialize_exact(&envelope.data)?;
 
         let message = match mls_message_in.extract() {
@@ -846,7 +861,7 @@ where
             inbox_id = self.client.inbox_id(),
             installation_id = %self.client.installation_id(),
             group_id = hex::encode(&self.group_id),
-            msg_id = envelope.id,
+            cursor = envelope.id,
             "Processing envelope with hash {}, id = {}",
             hex::encode(sha256(envelope.data.as_slice())),
             envelope.id
@@ -860,7 +875,7 @@ where
                     inbox_id = self.client.inbox_id(),
                     installation_id = %self.client.installation_id(),
                     group_id = hex::encode(&self.group_id),
-                    msg_id = envelope.id,
+                    cursor = envelope.id,
                     intent_id,
                     intent.kind = %intent.kind,
                     "client [{}] is about to process own envelope [{}] for intent [{}]",
@@ -874,14 +889,12 @@ where
                     let maybe_validated_commit = self.stage_and_validate_intent(&mls_group, &intent, provider, &message, envelope).await;
 
                     provider.transaction(|provider| {
-                        if let Some(cursor) = cursor {
-                            let is_updated =
-                                provider
-                                    .conn_ref()
-                                    .update_cursor(&envelope.group_id, EntityKind::Group, cursor)?;
-                            if !is_updated {
-                                return Err(ProcessIntentError::AlreadyProcessed(cursor as u64).into());
-                            }
+                        let is_updated =
+                            provider
+                                .conn_ref()
+                                .update_cursor(&envelope.group_id, EntityKind::Group, cursor as i64)?;
+                        if !is_updated {
+                            return Err(ProcessIntentError::AlreadyProcessed(cursor as u64).into());
                         }
 
                         let intent_state = match maybe_validated_commit {
@@ -919,7 +932,7 @@ where
                     inbox_id = self.client.inbox_id(),
                     installation_id = %self.client.installation_id(),
                     group_id = hex::encode(&self.group_id),
-                    msg_id = envelope.id,
+                    cursor = envelope.id,
                     "client [{}] is about to process external envelope [{}]",
                     self.client.inbox_id(),
                     envelope.id
@@ -931,7 +944,6 @@ where
                         &mut mls_group,
                         message,
                         envelope,
-                        cursor,
                     )
                     .await
                 })
@@ -998,31 +1010,29 @@ where
                 inbox_id = self.client.inbox_id(),
                 installation_id = %self.client.installation_id(),
                 group_id = hex::encode(&self.group_id),
-                "Message already processed: skipped msgId:[{}] entity kind:[{:?}] last cursor in db: [{}]",
+                "Message already processed: skipped cursor:[{}] entity kind:[{:?}] last cursor in db: [{}]",
                 msgv1.id,
                 message_entity_kind,
                 last_cursor
             );
             Err(GroupMessageProcessingError::AlreadyProcessed(msgv1.id))
         } else {
-            let cursor = &msgv1.id;
             // Download all unread welcome messages and convert to groups.
             // In a database transaction, increment the cursor for a given entity and
             // apply the update after the provided `ProcessingFn` has completed successfully.
-
-            self.process_message(provider, msgv1, true, Some(*cursor as i64)).await
+            self.process_message(provider, msgv1, true).await
             .inspect(|_| {
                 tracing::info!(
                     "Transaction completed successfully: process for group [{}] envelope cursor[{}]",
                     hex::encode(&msgv1.group_id),
-                    cursor
+                    msgv1.id
                 );
             })
             .inspect_err(|err| {
                 tracing::info!(
                     "Transaction failed: process for group [{}] envelope cursor [{}] error:[{}]",
                     hex::encode(&msgv1.group_id),
-                    cursor,
+                    msgv1.id,
                     err
                 );
             })?;
@@ -1094,7 +1104,7 @@ where
         }
 
         tracing::info!(
-            "{}: Storing a transcript message with {} members added and {} members removed and {} metadata changes",
+            "[{}]: Storing a transcript message with {} members added and {} members removed and {} metadata changes",
             self.context().inbox_id(),
             validated_commit.added_inboxes.len(),
             validated_commit.removed_inboxes.len(),
@@ -1146,7 +1156,7 @@ where
         Ok(Some(msg))
     }
 
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[tracing::instrument(skip_all)]
     pub(super) async fn publish_intents(
         &self,
         provider: &XmtpOpenMlsProvider,
@@ -1209,7 +1219,7 @@ where
                             intent.id,
                             intent.kind = %intent.kind,
                             group_id = hex::encode(&self.group_id),
-                            "client [{}] set stored intent [{}] to state `published`",
+                            "[{}] set stored intent [{}] to state `published`",
                             self.client.inbox_id(),
                             intent.id
                         );

--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -600,7 +600,7 @@ where
                 *cursor as i64,
             )?;
             if !is_updated {
-                return Err(ProcessIntentError::AlreadyProcessed(*cursor as u64).into());
+                return Err(ProcessIntentError::AlreadyProcessed(*cursor).into());
             }
             let previous_epoch = mls_group.epoch().as_u64();
             self.process_external_message(
@@ -894,7 +894,7 @@ where
                                 .conn_ref()
                                 .update_cursor(&envelope.group_id, EntityKind::Group, cursor as i64)?;
                         if !is_updated {
-                            return Err(ProcessIntentError::AlreadyProcessed(cursor as u64).into());
+                            return Err(ProcessIntentError::AlreadyProcessed(cursor).into());
                         }
 
                         let intent_state = match maybe_validated_commit {

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -1331,6 +1331,14 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
         Ok(())
     }
 
+    /// Get the current epoch number of the group.
+    pub async fn epoch(&self, provider: &XmtpOpenMlsProvider) -> Result<u64, GroupError> {
+        self.load_mls_group_with_lock_async(provider, |mls_group| {
+            futures::future::ready(Ok(mls_group.epoch().as_u64()))
+        })
+        .await
+    }
+
     /// Update this installation's leaf key in the group by creating a key update commit
     pub async fn key_update(&self) -> Result<(), GroupError> {
         let provider = self.client.mls_provider()?;
@@ -4090,7 +4098,7 @@ pub(crate) mod tests {
         };
         let provider = client.mls_provider().unwrap();
         let process_result = group
-            .process_message(&provider, &first_message, false, None)
+            .process_message(&provider, &first_message, false)
             .await;
 
         assert_err!(

--- a/xmtp_mls/src/lib.rs
+++ b/xmtp_mls/src/lib.rs
@@ -161,6 +161,7 @@ pub(crate) mod tests {
     #[cfg_attr(not(target_arch = "wasm32"), ctor::ctor)]
     #[cfg(not(target_arch = "wasm32"))]
     fn _setup() {
-        xmtp_common::logger()
+        xmtp_common::logger();
+        let _ = fdlimit::raise_fd_limit();
     }
 }

--- a/xmtp_mls/src/storage/encrypted_store/mod.rs
+++ b/xmtp_mls/src/storage/encrypted_store/mod.rs
@@ -357,7 +357,7 @@ where
     fn transaction<T, F, E>(&self, fun: F) -> Result<T, E>
     where
         F: FnOnce(&XmtpOpenMlsProviderPrivate<Db, <Db as XmtpDb>::Connection>) -> Result<T, E>,
-        E: From<diesel::result::Error> + From<StorageError>;
+        E: From<diesel::result::Error> + From<StorageError> + std::error::Error;
 }
 
 impl<Db> ProviderTransactions<Db> for XmtpOpenMlsProviderPrivate<Db, <Db as XmtpDb>::Connection>
@@ -381,7 +381,7 @@ where
     fn transaction<T, F, E>(&self, fun: F) -> Result<T, E>
     where
         F: FnOnce(&XmtpOpenMlsProviderPrivate<Db, <Db as XmtpDb>::Connection>) -> Result<T, E>,
-        E: From<diesel::result::Error> + From<StorageError>,
+        E: From<diesel::result::Error> + From<StorageError> + std::error::Error,
     {
         tracing::debug!("Transaction beginning");
 

--- a/xmtp_mls/src/storage/encrypted_store/native.rs
+++ b/xmtp_mls/src/storage/encrypted_store/native.rs
@@ -147,8 +147,8 @@ impl NativeDb {
             .as_ref()
             .ok_or(StorageError::PoolNeedsConnection)?;
 
-        tracing::debug!(
-            "Pulling connection from pool, idle_connections={}, total_connections={}",
+        tracing::trace!(
+            "pulling connection from pool, idle={}, total={}",
             pool.state().idle_connections,
             pool.state().connections
         );

--- a/xmtp_mls/src/subscriptions/stream_conversations.rs
+++ b/xmtp_mls/src/subscriptions/stream_conversations.rs
@@ -330,6 +330,7 @@ where
     C: ScopedGroupClient + Clone,
 {
     /// Process the welcome. if its a group, create the group and return it.
+    #[tracing::instrument(skip_all)]
     pub async fn process(self) -> Result<Option<(MlsGroup<C>, Option<i64>)>> {
         use WelcomeOrGroup::*;
         let (group, welcome_id) = match self.item {

--- a/xmtp_mls/src/subscriptions/stream_messages.rs
+++ b/xmtp_mls/src/subscriptions/stream_messages.rs
@@ -395,6 +395,7 @@ where
     }
 
     /// process a message, returning the message from the database and the cursor of the message.
+    #[tracing::instrument(skip_all)]
     pub(crate) async fn process(self) -> Result<Option<(StoredGroupMessage, u64)>> {
         let group_message::V1 {
             // the cursor ID is the position in the monolithic backend topic
@@ -407,7 +408,7 @@ where
             inbox_id = self.inbox_id(),
             group_id = hex::encode(&self.msg.group_id),
             cursor_id,
-            "client inbox_id=[{}]  is about to process streamed envelope cursor_id=[{}]",
+            "[{}]  is about to process streamed envelope cursor_id=[{}]",
             self.inbox_id(),
             &cursor_id
         );
@@ -424,6 +425,11 @@ where
             .get_group_message_by_timestamp(&self.msg.group_id, *created_ns as i64)?;
 
         if let Some(msg) = new_message {
+            tracing::debug!(
+                "[{}] processed stream envelope [{}]",
+                self.inbox_id(),
+                &cursor_id
+            );
             Ok(Some((msg, *cursor_id)))
         } else {
             tracing::warn!(
@@ -447,15 +453,18 @@ where
                     self.msg.group_id.clone(),
                     &self.provider,
                 )?;
+                let epoch = group.epoch(&self.provider).await?;
                 tracing::debug!(
                     inbox_id = self.inbox_id(),
                     group_id = hex::encode(&self.msg.group_id),
                     cursor_id = self.msg.id,
-                    "current epoch for [{}] in process_stream_entry()",
+                    epoch = epoch,
+                    "epoch={} for [{}] in process_stream_entry()",
+                    epoch,
                     self.inbox_id(),
                 );
                 group
-                    .process_message(&self.provider, &self.msg, false, None)
+                    .process_message(&self.provider, &self.msg, false)
                     .await
                     // NOTE: We want to make sure we retry an error in process_message
                     .map_err(SubscribeError::ReceiveGroup)
@@ -505,11 +514,14 @@ where
             self.msg.group_id.clone(),
             self.msg.created_ns as i64,
         );
+        let epoch = group.epoch(&self.provider).await.unwrap_or(0);
         tracing::debug!(
             inbox_id = self.client.inbox_id(),
             group_id = hex::encode(&self.msg.group_id),
             cursor_id = self.msg.id,
-            "attempting recovery sync"
+            epoch = epoch,
+            "attempting recovery sync epoch={}",
+            epoch
         );
         // Swallow errors here, since another process may have successfully saved the message
         // to the DB
@@ -522,11 +534,13 @@ where
                 "recovery sync triggered by streamed message failed: {}", err
             );
         } else {
+            let epoch = group.epoch(&self.provider).await.unwrap_or(0);
             tracing::debug!(
                 inbox_id = self.client.inbox_id(),
                 group_id = hex::encode(&self.msg.group_id),
                 cursor_id = self.msg.id,
-                "recovery sync triggered by streamed message successful"
+                "recovery sync triggered by streamed message successful. epoch = {}",
+                epoch
             )
         }
     }


### PR DESCRIPTION
- get cursor from message envelope rather than having be optional
- this PR adds contextual logging, which outputs logs grouped by context in a tree format based on tracing spans.
    - enable contextual logging with `CONTEXTUAL=1`, i.e `CONTEXTUAL=1 RUST_LOG=xmtp_mls::subscriptions=debug,xmtp_mls::groups::mls_sync=debug cargo test`
    - contextual logging is only available in tests and does not effect production binary

