### PR TITLE
Fix Grammar and Documentation Issues

### DIFF
--- a/diagrams/diagrams.md
+++ b/diagrams/diagrams.md
@@ -7,7 +7,7 @@ The diagrams represent the creation of a group chat between Alice, Bob, and Char
 Note: calls into LibXMTP with the `conversations.` prefix use the [Conversations](https://github.com/xmtp/libxmtp/blob/204b35a337daf2a9f2ed0cb20199e254d0a7493a/bindings_ffi/src/mls.rs#L188) protocol, and calls with a `group.` prefix use the [Group](https://github.com/xmtp/libxmtp/blob/204b35a337daf2a9f2ed0cb20199e254d0a7493a/bindings_ffi/src/mls.rs#L315) protocol.
 
 - _form-group.mermaid_ - Covers Steps 1-4 of forming a group. In LibXMTP, steps 1 and 2 happen at the same time, and steps 3 and 4 can also be consolidated by calling `newGroup()` with multiple participants.
-- _send-receive.mermaid_ - Covers sending and receiving messages to the newly formed group.
+- _send-receive.mermaid_ - Covers sending and receiving messages in the newly formed group.
 - _add-remove.mermaid_ - Covers adding and removing group members.
 - _sync-installations.mermaid_ - Covers how to find out if group members have added/removed an installation, and how to respond.
 

--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -58,7 +58,7 @@ pub struct ClientBuilder<ApiClient, V = RemoteSignatureVerifier<ApiClient>> {
 }
 
 impl<ApiClient, V> Client<ApiClient, V> {
-    /// Ge tthe builder for this [`Client`]
+    /// Get the builder for this [`Client`]
     pub fn builder(strategy: IdentityStrategy) -> ClientBuilder<ApiClient, V> {
         ClientBuilder::<ApiClient, V>::new(strategy)
     }

--- a/xmtp_v2/src/traits.rs
+++ b/xmtp_v2/src/traits.rs
@@ -1,4 +1,4 @@
-// This trait acts as a abstraction layer to allow "SignatureVerifiers" to be used with other types
+// This trait acts as an abstraction layer to allow "SignatureVerifiers" to be used with other types
 // of Signature-like enums one day
 pub trait SignatureVerifiable<T> {
     fn get_signature(&self) -> Option<T>;


### PR DESCRIPTION


Changes:

1. diagrams/diagrams.md:
- to the newly formed group
+ in the newly formed group
Reason: Better preposition usage for group context

2. xmtp_mls/src/builder.rs:
- /// Ge tthe builder
+ /// Get the builder
Reason: Fixed documentation typo

3. xmtp_v2/src/traits.rs:
- acts as a abstraction
+ acts as an abstraction
Reason: Correct article before vowel sound

These changes improve documentation clarity and grammar correctness across the codebase.