### PR TITLE
Improve Code Comments for Clarity and Grammar

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -6256,7 +6256,7 @@ mod tests {
 
         bo_dm.send("Hello in DM".as_bytes().to_vec()).await.unwrap();
 
-        // Verify that client_a and client_b received the dm message to wallet a address
+        // Verify that client_a and client_b received the dm message to wallet an address
         client_a
             .conversations()
             .sync_all_conversations(None)

--- a/common/src/retry.rs
+++ b/common/src/retry.rs
@@ -1,4 +1,4 @@
-//! A retry strategy that works with rusts native [`std::error::Error`] type.
+//! A retry strategy that works with rust's native [`std::error::Error`] type.
 //!
 //! TODO: Could make the impl of `RetryableError` trait into a proc-macro to auto-derive Retryable
 //! on annotated enum variants.
@@ -21,7 +21,7 @@ use rand::Rng;
 pub struct NotSpecialized;
 
 /// Specifies which errors are retryable.
-/// All Errors are not retryable by-default.
+/// All Errors are not retryable by default.
 pub trait RetryableError<SP = NotSpecialized>: std::error::Error {
     fn is_retryable(&self) -> bool;
 }

--- a/xmtp_v2/src/traits.rs
+++ b/xmtp_v2/src/traits.rs
@@ -1,4 +1,4 @@
-// This trait acts as a abstraction layer to allow "SignatureVerifiers" to be used with other types
+// This trait acts as an abstraction layer to allow "SignatureVerifiers" to be used with other types
 // of Signature-like enums one day
 pub trait SignatureVerifiable<T> {
     fn get_signature(&self) -> Option<T>;


### PR DESCRIPTION


### 1. File: `bindings_ffi/src/mls.rs`
- **Old:** `// Verify that client_a and client_b received the dm message to wallet a address`
- **New:** `// Verify that client_a and client_b received the dm message to wallet an address`
- **Reason:** Corrected a grammatical error for clarity.

### 2. File: `common/src/retry.rs`
- **Old:** `//! A retry strategy that works with rusts native [`std::error::Error`] type.`
- **New:** `//! A retry strategy that works with rust's native [`std::error::Error`] type.`
- **Reason:** Fixed the possessive form of "Rust."

- **Old:** `/// All Errors are not retryable by-default.`
- **New:** `/// All Errors are not retryable by default.`
- **Reason:** Removed the hyphen for clarity.

### 3. File: `xmtp_v2/src/traits.rs`
- **Old:** `// This trait acts as a abstraction layer to allow "SignatureVerifiers" to be used with other types`
- **New:** `// This trait acts as an abstraction layer to allow "SignatureVerifiers" to be used with other types`
- **Reason:** Corrected "a" to "an" for grammatical accuracy.

## Summary
These changes enhance clarity and grammatical correctness in the code comments.