### PR TITLE
Conversation and sync list updates for Node & Wasm Bindings

### DIFF
--- a/bindings_node/src/conversation.rs
+++ b/bindings_node/src/conversation.rs
@@ -105,6 +105,22 @@ pub struct Conversation {
   created_at_ns: i64,
 }
 
+#[napi]
+pub struct ConversationListItem {
+  conversation: Conversation,
+  last_message: Option<Message>,
+}
+
+#[napi]
+impl ConversationListItem {
+  pub fn conversation(&self) -> Arc<Conversation> {
+    Arc::new(self.conversation.clone())
+  }
+  pub fn last_message(&self) -> Option<Message> {
+    self.last_message.clone()
+  }
+}
+
 impl From<MlsGroup<RustXmtpClient>> for Conversation {
   fn from(mls_group: MlsGroup<RustXmtpClient>) -> Self {
     Conversation {

--- a/bindings_node/src/conversations.rs
+++ b/bindings_node/src/conversations.rs
@@ -18,7 +18,10 @@ use crate::conversation::MessageDisappearingSettings;
 use crate::message::Message;
 use crate::permissions::{GroupPermissionsOptions, PermissionPolicySet};
 use crate::ErrorWrapper;
-use crate::{client::RustXmtpClient, conversation::Conversation, streams::StreamCloser};
+use crate::{
+  client::RustXmtpClient, consent_state::ConsentState, conversation::Conversation,
+  streams::StreamCloser,
+};
 
 #[napi]
 #[derive(Debug)]
@@ -84,6 +87,7 @@ pub struct ListConversationsOptions {
   pub created_before_ns: Option<i64>,
   pub limit: Option<i64>,
   pub conversation_type: Option<ConversationType>,
+  pub consent_states: Option<Vec<ConsentState>>,
 }
 
 impl From<ListConversationsOptions> for GroupQueryArgs {
@@ -98,6 +102,7 @@ impl From<ListConversationsOptions> for GroupQueryArgs {
       .maybe_created_after_ns(opts.created_after_ns)
       .maybe_created_before_ns(opts.created_before_ns)
       .maybe_limit(opts.limit)
+      .maybe_consent_states(consent_states.map(|cs| cs.into()))
   }
 }
 

--- a/bindings_node/src/conversations.rs
+++ b/bindings_node/src/conversations.rs
@@ -322,11 +322,20 @@ impl Conversations {
   }
 
   #[napi]
-  pub async fn sync_all_conversations(&self) -> Result<usize> {
+  pub async fn sync_all_conversations(
+    &self,
+    consent_states: Option<Vec<ConsentState>>,
+  ) -> Result<usize> {
     let provider = self
       .inner_client
       .mls_provider()
       .map_err(ErrorWrapper::from)?;
+
+    let consents: Option<Vec<ConsentState>> =
+      consent_states.map(|states| states.into_iter().map(|state| state.into()).collect());
+    let num_groups_synced: usize = inner
+      .sync_all_welcomes_and_groups(&provider, consents)
+      .await?;
 
     let num_groups_synced = self
       .inner_client

--- a/bindings_wasm/src/conversation.rs
+++ b/bindings_wasm/src/conversation.rs
@@ -114,6 +114,22 @@ pub struct Conversation {
   created_at_ns: i64,
 }
 
+#[wasm_bindgen]
+pub struct ConversationListItem {
+  conversation: Conversation,
+  last_message: Option<Message>,
+}
+
+#[wasm_bindgen]
+impl ConversationListItem {
+  pub fn conversation(&self) -> Arc<Conversation> {
+    Arc::new(self.conversation.clone())
+  }
+  pub fn last_message(&self) -> Option<Message> {
+    self.last_message.clone()
+  }
+}
+
 impl Conversation {
   pub fn new(inner_client: Arc<RustXmtpClient>, group_id: Vec<u8>, created_at_ns: i64) -> Self {
     Self {

--- a/bindings_wasm/src/conversations.rs
+++ b/bindings_wasm/src/conversations.rs
@@ -371,15 +371,20 @@ impl Conversations {
   }
 
   #[wasm_bindgen(js_name = syncAllConversations)]
-  pub async fn sync_all_conversations(&self) -> Result<usize, JsError> {
+  pub async fn sync_all_conversations(
+    &self,
+    consent_states: Option<Vec<ConsentState>>,
+  ) -> Result<usize, JsError> {
     let provider = self
       .inner_client
       .mls_provider()
       .map_err(|e| JsError::new(format!("{}", e).as_str()))?;
 
+    let consents: Option<Vec<ConsentState>> =
+      consent_states.map(|states| states.into_iter().map(|state| state.into()).collect());
     let num_groups_synced = self
       .inner_client
-      .sync_all_welcomes_and_groups(&provider, None)
+      .sync_all_welcomes_and_groups(&provider, consents)
       .await
       .map_err(|e| JsError::new(format!("{}", e).as_str()))?;
 

--- a/bindings_wasm/src/conversations.rs
+++ b/bindings_wasm/src/conversations.rs
@@ -83,6 +83,8 @@ pub struct ListConversationsOptions {
   #[wasm_bindgen(js_name = createdBeforeNs)]
   pub created_before_ns: Option<i64>,
   pub limit: Option<i64>,
+  #[wasm_bindgen(js_name = consentState)]
+  pub consent_states: Option<Vec<ConsentState>>,
 }
 
 impl From<ListConversationsOptions> for GroupQueryArgs {
@@ -97,6 +99,7 @@ impl From<ListConversationsOptions> for GroupQueryArgs {
       .maybe_created_after_ns(opts.created_after_ns)
       .maybe_created_before_ns(opts.created_before_ns)
       .maybe_limit(opts.limit)
+      .maybe_consent_states(opts.consent_states.map(Into::into))
   }
 }
 


### PR DESCRIPTION
- [ ] Filter conversation list by consent https://github.com/xmtp/libxmtp/pull/1512
- [ ] Filter conversation sync all by consent https://github.com/xmtp/libxmtp/pull/1512
- [ ] Switch conversation list to use new conversation list item which includes the last message https://github.com/xmtp/libxmtp/pull/1437