### PR TITLE
Add a check wasm script

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,5 @@
 [target.wasm32-unknown-unknown]
 runner = 'wasm-bindgen-test-runner'
-linker = "wasm-ld"
 
 [alias]
 b = "build"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,6 @@
 [target.wasm32-unknown-unknown]
 runner = 'wasm-bindgen-test-runner'
+linker = "wasm-ld"
 
 [alias]
 b = "build"

--- a/bindings_wasm/build.rs
+++ b/bindings_wasm/build.rs
@@ -1,7 +1,0 @@
-fn main() {
-  let target = std::env::var("TARGET").unwrap_or_default();
-  if cfg!(target_os = "macos") && target == "wasm32-unknown-unknown" {
-    println!("cargo:rustc-link-arg=--linker=wasm-ld");
-    println!("cargo:rustc-env=CC_wasm32-unknown-unknown=/opt/homebrew/opt/llvm/bin/clang");
-  }
-}

--- a/dev/check-wasm
+++ b/dev/check-wasm
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [[ "${OSTYPE}" == "darwin"* ]]; then
+    export CC_wasm32-unknown-unknown = "/opt/homebrew/opt/llvm/bin/clang"
+fi
+
+cargo check -p bindings_wasm --target wasm32-unknown-unknown

--- a/dev/check-wasm
+++ b/dev/check-wasm
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ "${OSTYPE}" == "darwin"* ]]; then
-    export CC_wasm32-unknown-unknown = "/opt/homebrew/opt/llvm/bin/clang"
+    export CC_wasm32_unknown_unknown=/opt/homebrew/opt/llvm/bin/clang
 fi
 
 cargo check -p bindings_wasm --target wasm32-unknown-unknown


### PR DESCRIPTION
Setting env vars in the build script sets them too late, and config.toml doesn't allow for os specific configs, so we'll have to use a script for now to check wasm.