### PR TITLE
message stream test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7640,6 +7640,7 @@ dependencies = [
  "libsqlite3-sys",
  "mockall",
  "mockito",
+ "once_cell",
  "openmls",
  "openmls_basic_credential",
  "openmls_rust_crypto",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7506,6 +7506,7 @@ dependencies = [
  "futures",
  "getrandom",
  "gloo-timers 0.3.0",
+ "hex",
  "js-sys",
  "once_cell",
  "parking_lot 0.12.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7506,7 +7506,6 @@ dependencies = [
  "futures",
  "getrandom",
  "gloo-timers 0.3.0",
- "hex",
  "js-sys",
  "once_cell",
  "parking_lot 0.12.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_trace"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d564b0f7a9c9e272c7e43c59f1f09ba04d060774ba7c5fa14c2f966bbd6c4e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6430,6 +6439,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing_android_trace"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84fae205f9c07bfae3d36d199ab985118c90d225ff70a38e7ff3ecbdb4ef61bc"
+dependencies = [
+ "android_trace",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "trait-variant"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7748,6 +7771,7 @@ dependencies = [
  "tracing",
  "tracing-oslog",
  "tracing-subscriber",
+ "tracing_android_trace",
  "uniffi",
  "uuid 1.12.0",
  "xmtp_api",

--- a/bindings_ffi/Cargo.toml
+++ b/bindings_ffi/Cargo.toml
@@ -39,6 +39,7 @@ fdlimit = { version = "0.3", optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 paranoid-android = "0.2"
+tracing_android_trace = { version = "0.1", features = ["api_level_29"] }
 
 [target.'cfg(target_os = "ios")'.dependencies]
 tracing-oslog = "0.2"

--- a/bindings_ffi/src/logger.rs
+++ b/bindings_ffi/src/logger.rs
@@ -13,12 +13,16 @@ mod android {
     where
         S: Subscriber + for<'a> LookupSpan<'a>,
     {
+        use tracing_subscriber::EnvFilter;
         let api_calls_filter = EnvFilter::builder().parse_lossy("xmtp_api=debug");
         vec![
             paranoid_android::layer(env!("CARGO_PKG_NAME"))
                 .with_thread_names(true)
-                .with_filter(tracing_subscriber::filter::LevelFilter::DEBUG),
-            tracing_android_trace::AndroidTraceAsyncLayer::new().with_filter(api_calls_filter),
+                .with_filter(tracing_subscriber::filter::LevelFilter::DEBUG)
+                .boxed(),
+            tracing_android_trace::AndroidTraceAsyncLayer::new()
+                .with_filter(api_calls_filter)
+                .boxed(),
         ]
     }
 }

--- a/bindings_ffi/src/logger.rs
+++ b/bindings_ffi/src/logger.rs
@@ -13,9 +13,13 @@ mod android {
     where
         S: Subscriber + for<'a> LookupSpan<'a>,
     {
-        paranoid_android::layer(env!("CARGO_PKG_NAME"))
-            .with_thread_names(true)
-            .with_filter(tracing_subscriber::filter::LevelFilter::DEBUG)
+        let api_calls_filter = EnvFilter::builder().parse_lossy("xmtp_api=debug");
+        vec![
+            paranoid_android::layer(env!("CARGO_PKG_NAME"))
+                .with_thread_names(true)
+                .with_filter(tracing_subscriber::filter::LevelFilter::DEBUG),
+            tracing_android_trace::AndroidTraceAsyncLayer::new().with_filter(api_calls_filter),
+        ]
     }
 }
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -15,6 +15,7 @@ tracing.workspace = true
 web-time.workspace = true
 xmtp_cryptography.workspace = true
 
+hex = { workspace = true, optional = true }
 # optional
 once_cell = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
@@ -49,6 +50,9 @@ tracing-subscriber = { workspace = true, features = [
   "ansi",
   "json",
 ] }
+parking_lot.workspace = true
+once_cell.workspace = true
+hex.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 tokio = { workspace = true, features = ["time", "macros", "rt", "sync"] }
@@ -73,6 +77,8 @@ test-utils = [
   "dep:tracing-wasm",
   "dep:console_error_panic_hook",
   "dep:tracing-forest",
+  "dep:once_cell",
+  "dep:hex",
 ]
 bench = [
   "test-utils",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -15,7 +15,6 @@ tracing.workspace = true
 web-time.workspace = true
 xmtp_cryptography.workspace = true
 
-hex = { workspace = true, optional = true }
 # optional
 once_cell = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
@@ -52,7 +51,6 @@ tracing-subscriber = { workspace = true, features = [
 ] }
 parking_lot.workspace = true
 once_cell.workspace = true
-hex.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 tokio = { workspace = true, features = ["time", "macros", "rt", "sync"] }
@@ -78,7 +76,6 @@ test-utils = [
   "dep:console_error_panic_hook",
   "dep:tracing-forest",
   "dep:once_cell",
-  "dep:hex",
 ]
 bench = [
   "test-utils",

--- a/common/src/fmt.rs
+++ b/common/src/fmt.rs
@@ -5,9 +5,8 @@ pub fn truncate_hex(hex_string: impl AsRef<str>) -> String {
         return String::new();
     }
 
-    // Determine if string has 0x prefix
-    let hex_value = if hex_string.starts_with("0x") {
-        &hex_string[2..]
+    let hex_value = if let Some(hex_value) = hex_string.strip_prefix("0x") {
+        hex_value
     } else {
         hex_string
     };

--- a/common/src/fmt.rs
+++ b/common/src/fmt.rs
@@ -1,0 +1,38 @@
+pub fn truncate_hex(hex_string: impl AsRef<str>) -> String {
+    let hex_string = hex_string.as_ref();
+    // If empty string, return it
+    if hex_string.is_empty() {
+        return String::new();
+    }
+
+    // Determine if string has 0x prefix
+    let hex_value = if hex_string.starts_with("0x") {
+        &hex_string[2..]
+    } else {
+        hex_string
+    };
+
+    // If the hex value is 8 or fewer chars, return original string
+    if hex_value.len() <= 8 {
+        return hex_string.to_string();
+    }
+
+    format!(
+        "0x{}...{}",
+        &hex_value[..4],
+        &hex_value[hex_value.len() - 4..]
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_long_hex() {
+        assert_eq!(
+            truncate_hex("0x5bf078bd83995fe83092d93c5655f059"),
+            "0x5bf0...f059"
+        );
+    }
+}

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -21,6 +21,8 @@ pub use stream_handles::*;
 
 pub mod time;
 
+pub mod fmt;
+
 use rand::{
     distributions::{Alphanumeric, DistString},
     RngCore,

--- a/common/src/test.rs
+++ b/common/src/test.rs
@@ -43,7 +43,7 @@ impl InboxIdReplace {
 impl Drop for InboxIdReplace {
     fn drop(&mut self) {
         let mut ids = REPLACE_IDS.lock();
-        for id in &self.ids.keys() {
+        for id in self.ids.keys() {
             let _ = ids.remove(id.as_str());
         }
     }

--- a/common/src/test.rs
+++ b/common/src/test.rs
@@ -17,6 +17,7 @@ use crate::time::Expired;
 mod logger;
 mod macros;
 
+pub use logger::InboxIdReplace;
 static INIT: OnceLock<()> = OnceLock::new();
 
 #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]

--- a/common/src/test.rs
+++ b/common/src/test.rs
@@ -26,17 +26,12 @@ static INIT: OnceLock<()> = OnceLock::new();
 static REPLACE_IDS: Lazy<Mutex<HashMap<String, String>>> = Lazy::new(|| Mutex::new(HashMap::new()));
 
 /// Replace inbox id in Contextual output with a name (i.e Alix, Bo, etc.)
+#[derive(Default)]
 pub struct InboxIdReplace {
     ids: HashMap<String, String>,
 }
 
 impl InboxIdReplace {
-    pub fn new() -> Self {
-        Self {
-            ids: HashMap::new(),
-        }
-    }
-
     pub fn add(&mut self, id: &str, name: &str) {
         self.ids.insert(id.to_string(), name.to_string());
         let mut ids = REPLACE_IDS.lock();
@@ -48,7 +43,7 @@ impl InboxIdReplace {
 impl Drop for InboxIdReplace {
     fn drop(&mut self) {
         let mut ids = REPLACE_IDS.lock();
-        for (id, _name) in &self.ids {
+        for id in &self.ids.keys() {
             let _ = ids.remove(id.as_str());
         }
     }

--- a/common/src/test/logger.rs
+++ b/common/src/test/logger.rs
@@ -1,42 +1,8 @@
 // copy-paste of https://docs.rs/tracing-forest/latest/src/tracing_forest/printer/pretty.rs.html#62
 // but with slight variations
-use once_cell::sync::Lazy;
-use parking_lot::Mutex;
-use std::collections::HashMap;
 use std::fmt::{self, Write};
 use tracing_forest::printer::Formatter;
 use tracing_forest::tree::{Event, Span, Tree};
-
-static REPLACE_IDS: Lazy<Mutex<HashMap<String, String>>> = Lazy::new(|| Mutex::new(HashMap::new()));
-
-/// Replace inbox id in Contextual output with a name (i.e Alix, Bo, etc.)
-pub struct InboxIdReplace {
-    ids: HashMap<String, String>,
-}
-
-impl InboxIdReplace {
-    pub fn new() -> Self {
-        Self {
-            ids: HashMap::new(),
-        }
-    }
-
-    pub fn add(&mut self, id: &str, name: &str) {
-        self.ids.insert(id.to_string(), name.to_string());
-        let mut ids = REPLACE_IDS.lock();
-        ids.insert(id.to_string(), name.to_string());
-    }
-}
-
-// remove ids for replacement from map on drop
-impl Drop for InboxIdReplace {
-    fn drop(&mut self) {
-        let mut ids = REPLACE_IDS.lock();
-        for (id, _name) in &self.ids {
-            let _ = ids.remove(id.as_str());
-        }
-    }
-}
 
 type IndentVec = Vec<Indent>;
 
@@ -75,7 +41,7 @@ impl Contextual {
         let mut message = String::new();
         if let Some(msg) = event.message() {
             message = message + msg;
-            let ids = REPLACE_IDS.lock();
+            let ids = super::REPLACE_IDS.lock();
             for (id, name) in ids.iter() {
                 message = message.replace(id, name);
             }

--- a/common/src/test/logger.rs
+++ b/common/src/test/logger.rs
@@ -40,7 +40,7 @@ impl Contextual {
     fn format_event(event: &Event, writer: &mut String) -> fmt::Result {
         let mut message = String::new();
         if let Some(msg) = event.message() {
-            message = message + msg;
+            message += msg;
             let ids = super::REPLACE_IDS.lock();
             for (id, name) in ids.iter() {
                 message = message.replace(id, name);

--- a/common/src/test/logger.rs
+++ b/common/src/test/logger.rs
@@ -1,8 +1,42 @@
 // copy-paste of https://docs.rs/tracing-forest/latest/src/tracing_forest/printer/pretty.rs.html#62
 // but with slight variations
+use once_cell::sync::Lazy;
+use parking_lot::Mutex;
+use std::collections::HashMap;
 use std::fmt::{self, Write};
 use tracing_forest::printer::Formatter;
 use tracing_forest::tree::{Event, Span, Tree};
+
+static REPLACE_IDS: Lazy<Mutex<HashMap<String, String>>> = Lazy::new(|| Mutex::new(HashMap::new()));
+
+/// Replace inbox id in Contextual output with a name (i.e Alix, Bo, etc.)
+pub struct InboxIdReplace {
+    ids: HashMap<String, String>,
+}
+
+impl InboxIdReplace {
+    pub fn new() -> Self {
+        Self {
+            ids: HashMap::new(),
+        }
+    }
+
+    pub fn add(&mut self, id: &str, name: &str) {
+        self.ids.insert(id.to_string(), name.to_string());
+        let mut ids = REPLACE_IDS.lock();
+        ids.insert(id.to_string(), name.to_string());
+    }
+}
+
+// remove ids for replacement from map on drop
+impl Drop for InboxIdReplace {
+    fn drop(&mut self) {
+        let mut ids = REPLACE_IDS.lock();
+        for (id, _name) in &self.ids {
+            let _ = ids.remove(id.as_str());
+        }
+    }
+}
 
 type IndentVec = Vec<Indent>;
 
@@ -38,8 +72,14 @@ impl Contextual {
     }
 
     fn format_event(event: &Event, writer: &mut String) -> fmt::Result {
-        if let Some(message) = event.message() {
-            writer.write_str(message)?;
+        let mut message = String::new();
+        if let Some(msg) = event.message() {
+            message = message + msg;
+            let ids = REPLACE_IDS.lock();
+            for (id, name) in ids.iter() {
+                message = message.replace(id, name);
+            }
+            writer.write_str(&message)?;
         }
         /*
                     for field in event.fields().iter() {

--- a/dev/test-wasm-interactive
+++ b/dev/test-wasm-interactive
@@ -16,6 +16,7 @@ WASM_BINDGEN_SPLIT_LINKED_MODULES=1 \
   WASM_BINDGEN_TEST_ONLY_WEB=1 \
   NO_HEADLESS=1 \
   cargo test --target wasm32-unknown-unknown --release \
+  test_stream_all_messages_does_not_lose_messages \
   -p $PACKAGE -- \
   --skip xmtp_mls::storage::encrypted_store::group_message::tests::it_cannot_insert_message_without_group \
   --skip xmtp_mls::groups::tests::process_messages_abort_on_retryable_error \

--- a/dev/test-wasm-interactive
+++ b/dev/test-wasm-interactive
@@ -16,7 +16,6 @@ WASM_BINDGEN_SPLIT_LINKED_MODULES=1 \
   WASM_BINDGEN_TEST_ONLY_WEB=1 \
   NO_HEADLESS=1 \
   cargo test --target wasm32-unknown-unknown --release \
-  test_stream_all_messages_does_not_lose_messages \
   -p $PACKAGE -- \
   --skip xmtp_mls::storage::encrypted_store::group_message::tests::it_cannot_insert_message_without_group \
   --skip xmtp_mls::groups::tests::process_messages_abort_on_retryable_error \

--- a/xmtp_api/src/identity.rs
+++ b/xmtp_api/src/identity.rs
@@ -53,7 +53,7 @@ where
         Ok(())
     }
 
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[tracing::instrument(level = "debug", skip(self), fields(len = filters.len()))]
     pub async fn get_identity_updates_v2<T>(
         &self,
         filters: Vec<GetIdentityUpdatesV2Filter>,
@@ -93,7 +93,7 @@ where
         Ok(res)
     }
 
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[tracing::instrument(level = "debug", skip(self), fields(len = account_addresses.len()))]
     pub async fn get_inbox_ids(
         &self,
         account_addresses: Vec<String>,
@@ -120,7 +120,7 @@ where
             .collect())
     }
 
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn verify_smart_contract_wallet_signatures(
         &self,
         request: VerifySmartContractWalletSignaturesRequest,

--- a/xmtp_api/src/mls.rs
+++ b/xmtp_api/src/mls.rs
@@ -718,7 +718,6 @@ pub mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn cooldowns_apply_to_concurrent_fns() {
-        xmtp_common::logger();
         let mut mock_api = MockApiClient::new();
         let group_id = vec![1, 2, 3];
 

--- a/xmtp_api/src/mls.rs
+++ b/xmtp_api/src/mls.rs
@@ -112,7 +112,6 @@ where
 
             id_cursor = Some(paging_info.id_cursor);
         }
-
         Ok(out)
     }
 

--- a/xmtp_api/src/mls.rs
+++ b/xmtp_api/src/mls.rs
@@ -67,7 +67,7 @@ impl<ApiClient> ApiClientWrapper<ApiClient>
 where
     ApiClient: XmtpApi,
 {
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[tracing::instrument(level = "debug", skip(self), fields(group_id = hex::encode(&group_id)))]
     pub async fn query_group_messages(
         &self,
         group_id: Vec<u8>,
@@ -116,6 +116,7 @@ where
     }
 
     /// Query for the latest message on a group
+    #[tracing::instrument(level = "debug", skip(self), fields(group_id = hex::encode(group_id)))]
     pub async fn query_latest_group_message<Id: AsRef<[u8]> + Copy>(
         &self,
         group_id: Id,
@@ -145,7 +146,7 @@ where
         Ok(result.messages.into_iter().next())
     }
 
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[tracing::instrument(level = "debug", skip(self), fields(installation_id = hex::encode(&installation_id)))]
     pub async fn query_welcome_messages<Id: AsRef<[u8]> + Copy>(
         &self,
         installation_id: Id,
@@ -200,7 +201,7 @@ where
     /// New InboxID clients should set `is_inbox_id_credential` to true.
     /// V3 clients should have `is_inbox_id_credential` to `false`.
     /// Not indicating your client version will result in validation failure.
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn upload_key_package(
         &self,
         key_package: Vec<u8>,
@@ -225,7 +226,7 @@ where
         Ok(())
     }
 
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn fetch_key_packages(
         &self,
         installation_keys: Vec<Vec<u8>>,
@@ -265,7 +266,7 @@ where
         Ok(mapping)
     }
 
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn send_welcome_messages(&self, messages: &[WelcomeMessageInput]) -> Result<()> {
         tracing::debug!(inbox_id = self.inbox_id, "send welcome messages");
         retry_async!(
@@ -283,7 +284,7 @@ where
         Ok(())
     }
 
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn send_group_messages(&self, group_messages: Vec<GroupMessageInput>) -> Result<()> {
         tracing::debug!(
             inbox_id = self.inbox_id,

--- a/xmtp_api/src/mls.rs
+++ b/xmtp_api/src/mls.rs
@@ -146,7 +146,7 @@ where
         Ok(result.messages.into_iter().next())
     }
 
-    #[tracing::instrument(level = "debug", skip(self), fields(installation_id = hex::encode(&installation_id)))]
+    #[tracing::instrument(level = "debug", skip(self), fields(installation_id = hex::encode(installation_id)))]
     pub async fn query_welcome_messages<Id: AsRef<[u8]> + Copy>(
         &self,
         installation_id: Id,

--- a/xmtp_api_http/src/error.rs
+++ b/xmtp_api_http/src/error.rs
@@ -163,7 +163,7 @@ pub enum HttpClientError {
     HeaderValue(#[from] reqwest::header::InvalidHeaderValue),
     #[error(transparent)]
     HeaderName(#[from] reqwest::header::InvalidHeaderName),
-    #[error(transparent)]
+    #[error("error deserializing json response {0}")]
     Json(#[from] serde_json::Error),
 }
 

--- a/xmtp_api_http/src/http_stream.rs
+++ b/xmtp_api_http/src/http_stream.rs
@@ -111,7 +111,7 @@ where
     fn on_bytes(bytes: bytes::Bytes, remaining: &mut Vec<u8>) -> Result<Vec<R>, HttpClientError> {
         let bytes = &[remaining.as_ref(), bytes.as_ref()].concat();
         remaining.clear();
-        let de = Deserializer::from_slice(&bytes);
+        let de = Deserializer::from_slice(bytes);
         let mut deser_stream = de.into_iter::<GrpcResponse<R>>();
         let mut items = Vec::new();
         while let Some(item) = deser_stream.next() {

--- a/xmtp_api_http/src/http_stream.rs
+++ b/xmtp_api_http/src/http_stream.rs
@@ -110,15 +110,12 @@ where
 {
     fn on_bytes(bytes: bytes::Bytes, remaining: &mut Vec<u8>) -> Result<Vec<R>, HttpClientError> {
         let bytes = &[remaining.as_ref(), bytes.as_ref()].concat();
-        let de = Deserializer::from_slice(bytes);
+        remaining.clear();
+        let de = Deserializer::from_slice(&bytes);
         let mut deser_stream = de.into_iter::<GrpcResponse<R>>();
         let mut items = Vec::new();
-        loop {
-            let item = deser_stream.next();
-            if item.is_none() {
-                break;
-            }
-            match item.expect("checked for none;") {
+        while let Some(item) = deser_stream.next() {
+            match item {
                 Ok(GrpcResponse::Ok(response)) => items.push(response),
                 Ok(GrpcResponse::SubscriptionItem(item)) => items.push(item.result),
                 Ok(GrpcResponse::Err(e)) => {
@@ -126,8 +123,7 @@ where
                 }
                 Err(e) => {
                     if e.is_eof() {
-                        *remaining = (&**bytes)[deser_stream.byte_offset()..].to_vec();
-                        break;
+                        *remaining = bytes[deser_stream.byte_offset()..].to_vec();
                     } else {
                         return Err(HttpClientError::from(e));
                     }

--- a/xmtp_mls/Cargo.toml
+++ b/xmtp_mls/Cargo.toml
@@ -157,6 +157,7 @@ xmtp_api = { workspace = true, features = ["test-utils"] }
 xmtp_id = { path = "../xmtp_id", features = ["test-utils"] }
 xmtp_proto = { workspace = true, features = ["test-utils"] }
 fdlimit = { workspace = true }
+once_cell.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 ctor.workspace = true

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -807,6 +807,11 @@ where
         conn: &DbConnection,
     ) -> Result<Vec<GroupMessage>, ClientError> {
         let id_cursor = conn.get_last_cursor_for_id(group_id, EntityKind::Group)?;
+        tracing::info!(
+            "querying group messages from cursor = {}, group = {}",
+            id_cursor,
+            hex::encode(group_id)
+        );
 
         let messages = self
             .api_client

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -813,11 +813,6 @@ where
         conn: &DbConnection,
     ) -> Result<Vec<GroupMessage>, ClientError> {
         let id_cursor = conn.get_last_cursor_for_id(group_id, EntityKind::Group)?;
-        tracing::info!(
-            "querying group messages from cursor = {}, group = {}",
-            id_cursor,
-            hex::encode(group_id)
-        );
 
         let messages = self
             .api_client

--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -493,11 +493,6 @@ where
             intent.kind,
             message_epoch
         );
-        #[cfg(test)]
-        {
-            let mut w = crate::PROCESSED.lock();
-            w.push((*cursor, intent.clone()));
-        }
 
         if let Some((staged_commit, validated_commit)) = commit {
             tracing::info!(
@@ -1280,11 +1275,6 @@ where
                             intent.id,
                             intent.kind
                         );
-                        #[cfg(test)]
-                        {
-                            let mut w = crate::PUBLISHED.lock();
-                            w.push(intent.clone());
-                        }
                         if has_staged_commit {
                             tracing::info!("Commit sent. Stopping further publishes for this round");
                             return Ok(());

--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -203,7 +203,6 @@ where
     // TODO: Should probably be renamed to `sync_with_provider`
     #[tracing::instrument(skip_all)]
     pub async fn sync_with_conn(&self, provider: &XmtpOpenMlsProvider) -> Result<(), GroupError> {
-        tracing::info!("RECEIVING");
         let _mutex = self.mutex.lock().await;
         let mut errors: Vec<GroupError> = vec![];
 
@@ -1116,12 +1115,10 @@ where
 
     #[tracing::instrument(skip_all, level = "debug")]
     pub(super) async fn receive(&self, provider: &XmtpOpenMlsProvider) -> Result<(), GroupError> {
-        tracing::info!("RECEIVING");
         let messages = self
             .client
             .query_group_messages(&self.group_id, provider.conn_ref())
             .await?;
-        tracing::info!("CONTINUING TO PROCESS");
         self.process_messages(messages, provider).await?;
         Ok(())
     }

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -478,13 +478,8 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
         // Get the group ID for locking
         let group_id = self.group_id.clone();
 
-        tracing::info!(
-            "TRYING TO LOAD MLS GROUP for group_id={}",
-            hex::encode(&group_id)
-        );
         // Acquire the lock asynchronously
         let _lock = self.mls_commit_lock.get_lock_async(group_id.clone()).await;
-        tracing::info!("LOADING GROUP");
 
         // Load the MLS group
         let mls_group =
@@ -493,7 +488,7 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
                 .ok_or(StorageError::from(NotFound::GroupById(
                     self.group_id.to_vec(),
                 )))?;
-        tracing::info!("PERFORM OPERATION");
+
         // Perform the operation with the MLS group
         operation(mls_group).await.map_err(Into::into)
     }
@@ -1941,6 +1936,7 @@ pub(crate) mod tests {
     #[cfg(target_arch = "wasm32")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
+    use crate::groups::scoped_client::ScopedGroupClient;
     use diesel::connection::SimpleConnection;
     use diesel::RunQueryDsl;
     use futures::future::join_all;
@@ -1956,7 +1952,6 @@ pub(crate) mod tests {
 
     use super::{group_permissions::PolicySet, DMMetadataOptions, MlsGroup};
     use crate::groups::group_mutable_metadata::MessageDisappearingSettings;
-    use crate::groups::scoped_client::ScopedGroupClient;
     use crate::groups::{
         MAX_GROUP_DESCRIPTION_LENGTH, MAX_GROUP_IMAGE_URL_LENGTH, MAX_GROUP_NAME_LENGTH,
     };

--- a/xmtp_mls/src/lib.rs
+++ b/xmtp_mls/src/lib.rs
@@ -19,7 +19,7 @@ pub mod verified_key_package_v2;
 pub use client::{Client, Network};
 use parking_lot::Mutex;
 use std::collections::HashMap;
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 use storage::{xmtp_openmls_provider::XmtpOpenMlsProvider, DuplicateItem, StorageError};
 use tokio::sync::Mutex as TokioMutex;
 
@@ -83,9 +83,6 @@ impl GroupCommitLock {
 pub struct MlsGroupGuard {
     _permit: tokio::sync::OwnedMutexGuard<()>,
 }
-
-// Static instance of `GroupCommitLock`
-// pub static MLS_COMMIT_LOCK: LazyLock<GroupCommitLock> = LazyLock::new(GroupCommitLock::new);
 
 /// Inserts a model to the underlying data store, erroring if it already exists
 pub trait Store<StorageConnection> {

--- a/xmtp_mls/src/lib.rs
+++ b/xmtp_mls/src/lib.rs
@@ -26,14 +26,6 @@ use tokio::sync::Mutex as TokioMutex;
 pub use xmtp_id::InboxOwner;
 pub use xmtp_proto::api_client::trait_impls::*;
 
-#[cfg(test)]
-pub static PUBLISHED: once_cell::sync::Lazy<Mutex<Vec<storage::group_intent::StoredGroupIntent>>> =
-    once_cell::sync::Lazy::new(|| Mutex::new(Vec::new()));
-#[cfg(test)]
-pub static PROCESSED: once_cell::sync::Lazy<
-    Mutex<Vec<(u64, storage::group_intent::StoredGroupIntent)>>,
-> = once_cell::sync::Lazy::new(|| Mutex::new(Vec::new()));
-
 /// A manager for group-specific semaphores
 #[derive(Debug)]
 pub struct GroupCommitLock {
@@ -93,7 +85,7 @@ pub struct MlsGroupGuard {
 }
 
 // Static instance of `GroupCommitLock`
-pub static MLS_COMMIT_LOCK: LazyLock<GroupCommitLock> = LazyLock::new(GroupCommitLock::new);
+// pub static MLS_COMMIT_LOCK: LazyLock<GroupCommitLock> = LazyLock::new(GroupCommitLock::new);
 
 /// Inserts a model to the underlying data store, erroring if it already exists
 pub trait Store<StorageConnection> {

--- a/xmtp_mls/src/storage/encrypted_store/group_intent.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group_intent.rs
@@ -63,7 +63,7 @@ pub enum IntentState {
     Error = 4,
 }
 
-#[derive(Queryable, Identifiable, Debug, PartialEq, Clone)]
+#[derive(Queryable, Identifiable, PartialEq, Clone)]
 #[diesel(table_name = group_intents)]
 #[diesel(primary_key(id))]
 pub struct StoredGroupIntent {
@@ -77,6 +77,36 @@ pub struct StoredGroupIntent {
     pub publish_attempts: i32,
     pub staged_commit: Option<Vec<u8>>,
     pub published_in_epoch: Option<i64>,
+}
+
+impl std::fmt::Debug for StoredGroupIntent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "StoredGroupIntent {{")?;
+        write!(f, "id: {} ", self.id)?;
+        write!(f, "kind: {} ", self.kind)?;
+        write!(f, "group_id: {} ", hex::encode(&self.group_id))?;
+        /* write!(f, "data: {} ", hex::encode(&self.data))?; */
+        write!(f, "state: {:?} ", self.state)?;
+        write!(
+            f,
+            "payload_hash: {:?} ",
+            self.payload_hash.as_ref().map(|h| hex::encode(h))
+        )?;
+        /*write!(
+            f,
+            "post_commit_data: {:?}",
+            self.post_commit_data.as_ref().map(|d| hex::encode(d))
+        )?;*/
+        write!(f, "publish_attempts: {:?} ", self.publish_attempts)?;
+        /*write!(
+            f,
+            "staged_commit: {:?}",
+            self.staged_commit.as_ref().map(|c| hex::encode(c))
+        )?;*/
+        write!(f, "published_in_epoch: {:?} ", self.published_in_epoch)?;
+        write!(f, "StoredGroupIntent }}")?;
+        Ok(())
+    }
 }
 
 impl StoredGroupIntent {

--- a/xmtp_mls/src/storage/encrypted_store/group_intent.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group_intent.rs
@@ -88,7 +88,7 @@ impl std::fmt::Debug for StoredGroupIntent {
         write!(
             f,
             "group_id: {}, ",
-            fmt::truncate_hex(&hex::encode(&self.group_id))
+            fmt::truncate_hex(hex::encode(&self.group_id))
         )?;
         write!(f, "data: {}, ", fmt::truncate_hex(hex::encode(&self.data)))?;
         write!(f, "state: {:?}, ", self.state)?;
@@ -97,7 +97,7 @@ impl std::fmt::Debug for StoredGroupIntent {
             "payload_hash: {:?}, ",
             self.payload_hash
                 .as_ref()
-                .map(|h| fmt::truncate_hex(&hex::encode(h)))
+                .map(|h| fmt::truncate_hex(hex::encode(h)))
         )?;
         write!(
             f,

--- a/xmtp_mls/src/storage/encrypted_store/group_intent.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group_intent.rs
@@ -7,6 +7,7 @@ use diesel::{
     sql_types::Integer,
 };
 use prost::Message;
+use xmtp_common::fmt;
 
 use super::{
     db_connection::DbConnection,
@@ -81,30 +82,40 @@ pub struct StoredGroupIntent {
 
 impl std::fmt::Debug for StoredGroupIntent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "StoredGroupIntent {{")?;
-        write!(f, "id: {} ", self.id)?;
-        write!(f, "kind: {} ", self.kind)?;
-        write!(f, "group_id: {} ", hex::encode(&self.group_id))?;
-        /* write!(f, "data: {} ", hex::encode(&self.data))?; */
-        write!(f, "state: {:?} ", self.state)?;
+        write!(f, "StoredGroupIntent {{ ")?;
+        write!(f, "id: {}, ", self.id)?;
+        write!(f, "kind: {}, ", self.kind)?;
         write!(
             f,
-            "payload_hash: {:?} ",
-            self.payload_hash.as_ref().map(|h| hex::encode(h))
+            "group_id: {}, ",
+            fmt::truncate_hex(&hex::encode(&self.group_id))
         )?;
-        /*write!(
+        write!(f, "data: {}, ", fmt::truncate_hex(hex::encode(&self.data)))?;
+        write!(f, "state: {:?}, ", self.state)?;
+        write!(
             f,
-            "post_commit_data: {:?}",
-            self.post_commit_data.as_ref().map(|d| hex::encode(d))
-        )?;*/
-        write!(f, "publish_attempts: {:?} ", self.publish_attempts)?;
-        /*write!(
+            "payload_hash: {:?}, ",
+            self.payload_hash
+                .as_ref()
+                .map(|h| fmt::truncate_hex(&hex::encode(h)))
+        )?;
+        write!(
             f,
-            "staged_commit: {:?}",
-            self.staged_commit.as_ref().map(|c| hex::encode(c))
-        )?;*/
+            "post_commit_data: {:?}, ",
+            self.post_commit_data
+                .as_ref()
+                .map(|d| fmt::truncate_hex(hex::encode(d)))
+        )?;
+        write!(f, "publish_attempts: {:?}, ", self.publish_attempts)?;
+        write!(
+            f,
+            "staged_commit: {:?}, ",
+            self.staged_commit
+                .as_ref()
+                .map(|c| fmt::truncate_hex(hex::encode(c)))
+        )?;
         write!(f, "published_in_epoch: {:?} ", self.published_in_epoch)?;
-        write!(f, "StoredGroupIntent }}")?;
+        write!(f, " }}")?;
         Ok(())
     }
 }

--- a/xmtp_mls/src/subscriptions/stream_all.rs
+++ b/xmtp_mls/src/subscriptions/stream_all.rs
@@ -294,7 +294,7 @@ mod tests {
     #[cfg_attr(target_arch = "wasm32", ignore)]
     async fn test_stream_all_messages_does_not_lose_messages() {
         xmtp_common::logger();
-        let mut replace = xmtp_common::InboxIdReplace::new();
+        let mut replace = xmtp_common::InboxIdReplace::default();
         let caro = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let alix = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
         let eve = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
@@ -389,7 +389,7 @@ mod tests {
             .iter()
             .map(|m| String::from_utf8_lossy(m.decrypted_message_bytes.as_slice()).to_string())
             .collect::<Vec<String>>();
-        let duplicates = find_duplicates_with_count(&msgs);
+        let duplicates = find_duplicates_with_count(msgs);
         /*
         for message in messages.iter() {
             let m = String::from_utf8_lossy(message.decrypted_message_bytes.as_slice());
@@ -403,7 +403,6 @@ mod tests {
     async fn test_stream_all_messages_detached_group_changes() {
         let caro = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let hale = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
-        tracing::info!(inbox_id = hale.inbox_id(), "HALE");
         let stream = caro.stream_all_messages(None).await.unwrap();
 
         let caro_id = caro.inbox_id().to_string();

--- a/xmtp_mls/src/subscriptions/stream_all.rs
+++ b/xmtp_mls/src/subscriptions/stream_all.rs
@@ -278,6 +278,7 @@ mod tests {
     #[cfg_attr(target_arch = "wasm32", ignore)]
     async fn test_stream_all_messages_does_not_lose_messages() {
         xmtp_common::logger();
+        let mut replace = xmtp_common::InboxIdReplace::new();
         let caro = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let alix = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
         let eve = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
@@ -286,7 +287,10 @@ mod tests {
         tracing::info!(inbox_id = bo.inbox_id(), installation_id = %bo.installation_id(), "BO={}", bo.inbox_id());
         tracing::info!(inbox_id = alix.inbox_id(), installation_id = %alix.installation_id(), "ALIX={}", alix.inbox_id());
         tracing::info!(inbox_id = caro.inbox_id(), installation_id = %caro.installation_id(), "CARO={}", caro.inbox_id());
-
+        replace.add(caro.inbox_id(), "caro");
+        replace.add(eve.inbox_id(), "eve");
+        replace.add(alix.inbox_id(), "alix");
+        replace.add(bo.inbox_id(), "bo");
         let alix_group = alix
             .create_group(None, GroupMetadataOptions::default())
             .unwrap();

--- a/xmtp_mls/src/subscriptions/stream_all.rs
+++ b/xmtp_mls/src/subscriptions/stream_all.rs
@@ -377,22 +377,6 @@ mod tests {
         })
         .await;
 
-        tracing::info!("Total Messages: {}", messages.len());
-        tracing::info!("--------------------------");
-        tracing::info!("PUBLISHED");
-        tracing::info!("--------------------------");
-        let published = crate::PUBLISHED.lock();
-        let processed = crate::PROCESSED.lock();
-        for i in published.iter() {
-            tracing::info!("{:?}", i);
-        }
-        tracing::info!("--------------------------");
-        tracing::info!("PROCESSED");
-        tracing::info!("--------------------------");
-
-        for (cursor, i) in processed.iter() {
-            tracing::info!("cursor = {}, Intent={:?}", cursor, i);
-        }
         assert_eq!(messages.len(), 6);
     }
 

--- a/xmtp_mls/src/subscriptions/stream_all.rs
+++ b/xmtp_mls/src/subscriptions/stream_all.rs
@@ -322,7 +322,7 @@ mod tests {
 
         let alix_group_pointer = alix_group.clone();
         xmtp_common::spawn(None, async move {
-            for i in 0..10 {
+            for i in 0..15 {
                 let msg = format!("main spam {i}");
                 alix_group_pointer
                     .send_message(msg.as_bytes())
@@ -338,7 +338,7 @@ mod tests {
         let caro_id = caro.inbox_id().to_string();
         xmtp_common::spawn(None, async move {
             let caro = &caro_id;
-            for i in 0..10 {
+            for i in 0..15 {
                 let new_group = eve
                     .create_group(None, GroupMetadataOptions::default())
                     .unwrap();
@@ -352,7 +352,7 @@ mod tests {
         // this forces our streams to handle resubscribes while receiving lots of messages
         xmtp_common::spawn(None, async move {
             let bo_group = &bo_group;
-            for i in 0..10 {
+            for i in 0..15 {
                 bo_group
                     .send_message(format!("bo msg {i}").as_bytes())
                     .await
@@ -362,7 +362,13 @@ mod tests {
         });
 
         let mut messages = Vec::new();
-        let timeout = if cfg!(target_arch = "wasm32") { 10 } else { 10 };
+        let timeout = if cfg!(target_arch = "wasm32") {
+            15
+        } else if cfg!(feature = "http-api") {
+            10
+        } else {
+            5
+        };
 
         loop {
             tokio::select! {
@@ -390,7 +396,7 @@ mod tests {
             tracing::info!("{}", m);
         }*/
         assert!(duplicates.is_empty());
-        assert_eq!(messages.len(), 30, "too many messages mean duplicates, too little means missed. Also ensure timeout is sufficient.");
+        assert_eq!(messages.len(), 45, "too many messages mean duplicates, too little means missed. Also ensure timeout is sufficient.");
     }
 
     #[wasm_bindgen_test(unsupported = tokio::test(flavor = "multi_thread", worker_threads = 10))]

--- a/xmtp_mls/src/subscriptions/stream_all.rs
+++ b/xmtp_mls/src/subscriptions/stream_all.rs
@@ -291,7 +291,7 @@ mod tests {
     }
 
     #[wasm_bindgen_test(unsupported = tokio::test(flavor = "multi_thread"))]
-    // #[cfg_attr(target_arch = "wasm32", ignore)]
+    #[cfg_attr(target_arch = "wasm32", ignore)]
     async fn test_stream_all_messages_does_not_lose_messages() {
         xmtp_common::logger();
         let mut replace = xmtp_common::InboxIdReplace::new();

--- a/xmtp_mls/src/subscriptions/stream_messages.rs
+++ b/xmtp_mls/src/subscriptions/stream_messages.rs
@@ -520,14 +520,15 @@ where
             self.msg.group_id.clone(),
             self.msg.created_ns as i64,
         );
-        let epoch = group.epoch(&self.provider).await.unwrap_or(0);
+        tracing::info!("recovery sync");
+        // let epoch = group.epoch(&self.provider).await.unwrap_or(0);
         tracing::debug!(
             inbox_id = self.client.inbox_id(),
             group_id = hex::encode(&self.msg.group_id),
             cursor_id = self.msg.id,
-            epoch = epoch,
-            "attempting recovery sync epoch={}",
-            epoch
+            // epoch = epoch,
+            "attempting recovery sync",
+            // epoch
         );
         // Swallow errors here, since another process may have successfully saved the message
         // to the DB
@@ -545,8 +546,9 @@ where
                 inbox_id = self.client.inbox_id(),
                 group_id = hex::encode(&self.msg.group_id),
                 cursor_id = self.msg.id,
-                "recovery sync triggered by streamed message successful. epoch = {}",
-                epoch
+                "recovery sync triggered by streamed message successful. epoch = {} for group = {}",
+                epoch,
+                hex::encode(&self.msg.group_id)
             )
         }
     }

--- a/xmtp_mls/src/subscriptions/stream_messages.rs
+++ b/xmtp_mls/src/subscriptions/stream_messages.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::HashMap,
     future::Future,
     pin::Pin,
     task::{ready, Context, Poll},
@@ -97,7 +97,6 @@ pin_project! {
         #[pin] state: State<'a, Subscription>,
         client: &'a C,
         group_list: HashMap<GroupId, MessagePosition>,
-        drained: VecDeque<Option<Result<GroupMessage>>>,
     }
 }
 
@@ -132,7 +131,7 @@ where
 
         let mut group_list = group_list
             .into_iter()
-            .map(|group_id| (group_id, 1u64))
+            .map(|group_id| (group_id, 0u64))
             .collect::<HashMap<GroupId, u64>>();
 
         let cursors = group_list
@@ -164,7 +163,7 @@ where
             .inspect(|(group_id, cursor)| {
                 tracing::debug!(
                     "subscribed to group {} at {}",
-                    hex::encode(group_id),
+                    xmtp_common::fmt::truncate_hex(&hex::encode(group_id)),
                     cursor
                 )
             })
@@ -177,7 +176,6 @@ where
             client,
             state: Default::default(),
             group_list: group_list.into_iter().map(|(g, c)| (g, c.into())).collect(),
-            drained: VecDeque::new(),
         })
     }
 
@@ -224,41 +222,14 @@ where
                 let stream = client.api().subscribe_group_messages(filters).await?;
                 Ok((stream, new_group, Some(1)))
             }
-            _ => {
-                let msg = client
-                    .api()
-                    .query_latest_group_message(new_group.as_slice())
-                    .await?;
-
-                let mut cursor = None;
-                if let Some(m) = msg {
-                    let m = extract_message_v1(m.clone())?;
-                    if let Some(new) = filters.iter_mut().find(|f| f.group_id == new_group) {
-                        new.id_cursor = Some(m.id);
-                        cursor = Some(m.id);
-                    }
+            c => {
+                if let Some(new) = filters.iter_mut().find(|f| f.group_id == new_group) {
+                    new.id_cursor = Some(c as u64);
                 }
                 let stream = client.api().subscribe_group_messages(filters).await?;
-                Ok((stream, new_group, cursor))
+                Ok((stream, new_group, Some(c as u64)))
             }
         }
-    }
-
-    // needed mainly for slower connections when we may receive messages
-    // in between a switch.
-    pub(super) fn drain(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> VecDeque<Option<Result<GroupMessage>>> {
-        let mut drained = VecDeque::new();
-        let mut this = self.as_mut().project();
-        while let Poll::Ready(msg) = this.inner.as_mut().poll_next(cx) {
-            drained.push_back(msg.map(|v| {
-                v.map_err(xmtp_proto::ApiError::from)
-                    .map_err(SubscribeError::from)
-            }));
-        }
-        drained
     }
 }
 
@@ -276,14 +247,6 @@ where
 
         match this.state.as_mut().project() {
             Waiting => {
-                if let Some(envelope) = this.drained.pop_front().flatten() {
-                    let future = ProcessMessageFuture::new(*this.client, envelope?)?;
-                    let future = future.process();
-                    this.state.set(State::Processing {
-                        future: FutureWrapper::new(future),
-                    });
-                    return self.try_update_state(cx);
-                }
                 if let Some(envelope) = ready!(this.inner.poll_next(cx)) {
                     let future = ProcessMessageFuture::new(
                         *this.client,
@@ -306,9 +269,7 @@ where
                 if let Some(c) = cursor {
                     this.set_cursor(group.as_slice(), c)
                 };
-                let drained = self.as_mut().drain(cx);
                 let mut this = self.as_mut().project();
-                this.drained.extend(drained);
                 this.inner.set(stream);
                 if let Some(cursor) = this.group_list.get(group.as_slice()) {
                     tracing::debug!(
@@ -413,8 +374,9 @@ where
             inbox_id = self.inbox_id(),
             group_id = hex::encode(&self.msg.group_id),
             cursor_id,
-            "[{}]  is about to process streamed envelope cursor_id=[{}]",
+            "[{}]  is about to process streamed envelope for group {} cursor_id=[{}]",
             self.inbox_id(),
+            xmtp_common::fmt::truncate_hex(&hex::encode(&self.msg.group_id)),
             &cursor_id
         );
 
@@ -520,15 +482,15 @@ where
             self.msg.group_id.clone(),
             self.msg.created_ns as i64,
         );
-        tracing::info!("recovery sync");
-        // let epoch = group.epoch(&self.provider).await.unwrap_or(0);
+        let epoch = group.epoch(&self.provider).await.unwrap_or(0);
         tracing::debug!(
             inbox_id = self.client.inbox_id(),
             group_id = hex::encode(&self.msg.group_id),
             cursor_id = self.msg.id,
-            // epoch = epoch,
-            "attempting recovery sync",
-            // epoch
+            epoch = epoch,
+            "attempting recovery sync for group {} in epoch {}",
+            xmtp_common::fmt::truncate_hex(hex::encode(&self.msg.group_id)),
+            epoch
         );
         // Swallow errors here, since another process may have successfully saved the message
         // to the DB

--- a/xmtp_mls/src/subscriptions/stream_messages.rs
+++ b/xmtp_mls/src/subscriptions/stream_messages.rs
@@ -223,6 +223,7 @@ where
                 Ok((stream, new_group, Some(1)))
             }
             c => {
+                // should we query for the latest message here instead?
                 if let Some(new) = filters.iter_mut().find(|f| f.group_id == new_group) {
                     new.id_cursor = Some(c as u64);
                 }

--- a/xmtp_mls/src/subscriptions/stream_messages.rs
+++ b/xmtp_mls/src/subscriptions/stream_messages.rs
@@ -163,7 +163,7 @@ where
             .inspect(|(group_id, cursor)| {
                 tracing::debug!(
                     "subscribed to group {} at {}",
-                    xmtp_common::fmt::truncate_hex(&hex::encode(group_id)),
+                    xmtp_common::fmt::truncate_hex(hex::encode(group_id)),
                     cursor
                 )
             })
@@ -377,7 +377,7 @@ where
             cursor_id,
             "[{}]  is about to process streamed envelope for group {} cursor_id=[{}]",
             self.inbox_id(),
-            xmtp_common::fmt::truncate_hex(&hex::encode(&self.msg.group_id)),
+            xmtp_common::fmt::truncate_hex(hex::encode(&self.msg.group_id)),
             &cursor_id
         );
 

--- a/xmtp_mls/src/utils/test/mod.rs
+++ b/xmtp_mls/src/utils/test/mod.rs
@@ -88,6 +88,18 @@ impl ClientBuilder<TestClient, MockSmartContractSignatureVerifier> {
         .await
     }
 
+    pub async fn new_test_client_dev(owner: &impl InboxOwner) -> FullXmtpClient {
+        let api_client = <TestClient as XmtpTestClient>::create_dev().await;
+
+        build_with_verifier(
+            owner,
+            api_client,
+            MockSmartContractSignatureVerifier::new(true),
+            None,
+        )
+        .await
+    }
+
     pub async fn new_test_client_with_history(
         owner: &impl InboxOwner,
         history_sync_url: &str,


### PR DESCRIPTION
- logging improvements
    - allow replacing inbox id with a name (alix, bo, eve, etc) in test logs
```rust
let mut replace = xmtp_common::InboxIdReplace::new();
replace.add(caro.inbox_id(), "caro");
replace.add(eve.inbox_id(), "eve");
replace.add(alix.inbox_id(), "alix");
replace.add(bo.inbox_id(), "bo");
```

- fix duplicate messages in streams by removing drain() and improving stream all missing test
- move commit lock from being global to existing in the client. This avoids interference with tests that use lots of clients
- fix http-stream de-serialization errors because of a bug handling extra un-serialized bytes
- instrument every api function