### PR TITLE
Add disappearing message methods to Conversation (WASM)

### DIFF
--- a/bindings_wasm/CHANGELOG.md
+++ b/bindings_wasm/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @xmtp/wasm-bindings
 
+## 0.0.16
+
+- Added `isMessageDisappearingEnabled` method to `Conversation`
+- Added `messageDisappearingSettings` method to `Conversation`
+- Added `removeMessageDisappearingSettings` method to `Conversation`
+- Added `messageDisappearingSettings` method to `Conversation`
+- Updated JS names for `MessageDisappearingSettings` fields
+- Removed automatic filtering of DM group messages
+
 ## 0.0.15
 
 - Added `consent_states`, `include_sync_groups`, and `include_duplicate_dms` to `ListConversationsOptions`

--- a/bindings_wasm/README.md
+++ b/bindings_wasm/README.md
@@ -8,3 +8,8 @@
 - `yarn`: Installs all dependencies (required before building)
 - `yarn build`: Build a release version of the WASM bindings for the current platform
 - `yarn lint`: Run cargo clippy and fmt checks
+- `yarn check:macos`: Run cargo check for macOS (requires Homebrew and `llvm` to be installed)
+
+# Publishing
+
+To release a new version of the bindings, update the version in `package.json` with the appropriate semver value and add an entry to the CHANGELOG.md file. Once merged, manually trigger the `Release WASM Bindings` workflow to build and publish the bindings.

--- a/bindings_wasm/package.json
+++ b/bindings_wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/wasm-bindings",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "type": "module",
   "license": "MIT",
   "description": "WASM bindings for the libXMTP rust library",

--- a/bindings_wasm/package.json
+++ b/bindings_wasm/package.json
@@ -27,6 +27,7 @@
     "build": "yarn clean && yarn build:web && yarn build:copy && yarn clean:release",
     "build:web": "cargo xtask build BindingsWasm --out-dir ./dist --plain -- --release",
     "build:copy": "node scripts/copyFiles.js",
+    "check:macos": "CC_wasm32_unknown_unknown=/opt/homebrew/opt/llvm/bin/clang cargo check --target wasm32-unknown-unknown",
     "clean:release": "rm -f ./dist/package.json",
     "clean": "rm -rf ./dist",
     "lint": "yarn lint:clippy && yarn lint:fmt",

--- a/bindings_wasm/src/conversation.rs
+++ b/bindings_wasm/src/conversation.rs
@@ -15,7 +15,7 @@ use xmtp_mls::groups::{
   intents::PermissionUpdateType as XmtpPermissionUpdateType,
   members::PermissionLevel as XmtpPermissionLevel, MlsGroup, UpdateAdminListType,
 };
-use xmtp_mls::storage::group_message::{GroupMessageKind as XmtpGroupMessageKind, MsgQueryArgs};
+use xmtp_mls::storage::group_message::MsgQueryArgs;
 use xmtp_proto::xmtp::mls::message_contents::EncodedContent as XmtpEncodedContent;
 
 use prost::Message as ProstMessage;
@@ -199,7 +199,7 @@ impl Conversation {
       .map_err(|e| JsError::new(&format!("{e}")))?;
     let kind = match conversation_type {
       ConversationType::Group => None,
-      ConversationType::Dm => Some(XmtpGroupMessageKind::Application),
+      ConversationType::Dm => None,
       ConversationType::Sync => None,
     };
 

--- a/bindings_wasm/src/conversations.rs
+++ b/bindings_wasm/src/conversations.rs
@@ -143,12 +143,23 @@ impl ListConversationsOptions {
 #[wasm_bindgen(getter_with_clone)]
 #[derive(Clone)]
 pub struct MessageDisappearingSettings {
+  #[wasm_bindgen(js_name = fromNs)]
   pub from_ns: i64,
+  #[wasm_bindgen(js_name = inNs)]
   pub in_ns: i64,
 }
 
 impl From<MessageDisappearingSettings> for XmtpMessageDisappearingSettings {
   fn from(value: MessageDisappearingSettings) -> Self {
+    Self {
+      from_ns: value.from_ns,
+      in_ns: value.in_ns,
+    }
+  }
+}
+
+impl From<XmtpMessageDisappearingSettings> for MessageDisappearingSettings {
+  fn from(value: XmtpMessageDisappearingSettings) -> Self {
     Self {
       from_ns: value.from_ns,
       in_ns: value.in_ns,


### PR DESCRIPTION
# Summary

This PR updates the WASM bindings with the following changes:

- Added `isMessageDisappearingEnabled` method to `Conversation`
- Added `messageDisappearingSettings` method to `Conversation`
- Added `removeMessageDisappearingSettings` method to `Conversation`
- Added `messageDisappearingSettings` method to `Conversation`
- Updated JS names for `MessageDisappearingSettings` fields
- Removed automatic filtering of DM group messages