### PR TITLE
Update node bindings

### DIFF
--- a/bindings_node/src/conversation.rs
+++ b/bindings_node/src/conversation.rs
@@ -12,10 +12,7 @@ use xmtp_mls::{
     intents::PermissionUpdateType as XmtpPermissionUpdateType,
     members::PermissionLevel as XmtpPermissionLevel, MlsGroup, UpdateAdminListType,
   },
-  storage::{
-    group::ConversationType,
-    group_message::{GroupMessageKind as XmtpGroupMessageKind, MsgQueryArgs},
-  },
+  storage::{group::ConversationType, group_message::MsgQueryArgs},
 };
 use xmtp_proto::xmtp::mls::message_contents::EncodedContent as XmtpEncodedContent;
 
@@ -173,7 +170,7 @@ impl Conversation {
       .map_err(ErrorWrapper::from)?;
     let kind = match conversation_type {
       ConversationType::Group => None,
-      ConversationType::Dm => Some(XmtpGroupMessageKind::Application),
+      ConversationType::Dm => None,
       ConversationType::Sync => None,
     };
     let opts = MsgQueryArgs {

--- a/bindings_node/src/conversation.rs
+++ b/bindings_node/src/conversation.rs
@@ -29,40 +29,12 @@ use crate::{
   ErrorWrapper,
 };
 use prost::Message as ProstMessage;
-use xmtp_mls::groups::group_mutable_metadata::MessageDisappearingSettings as XmtpConversationMessageDisappearingSettings;
 
 use napi_derive::napi;
 
 #[napi]
 pub struct GroupMetadata {
   inner: XmtpGroupMetadata,
-}
-
-/// Settings for disappearing messages in a conversation.
-///
-/// # Fields
-///
-/// * `from_ns` - The timestamp (in nanoseconds) from when messages should be tracked for deletion.
-/// * `in_ns` - The duration (in nanoseconds) after which tracked messages will be deleted.
-#[napi(object)]
-#[derive(Clone)]
-pub struct MessageDisappearingSettings {
-  pub from_ns: i64,
-  pub in_ns: i64,
-}
-
-#[napi]
-impl MessageDisappearingSettings {
-  #[napi]
-  pub fn new(from_ns: i64, in_ns: i64) -> Self {
-    Self { from_ns, in_ns }
-  }
-}
-
-impl From<MessageDisappearingSettings> for XmtpConversationMessageDisappearingSettings {
-  fn from(value: MessageDisappearingSettings) -> Self {
-    XmtpConversationMessageDisappearingSettings::new(value.from_ns, value.in_ns)
-  }
 }
 
 #[napi]

--- a/bindings_node/src/conversations.rs
+++ b/bindings_node/src/conversations.rs
@@ -20,6 +20,7 @@ use crate::message::Message;
 use crate::permissions::{GroupPermissionsOptions, PermissionPolicySet};
 use crate::ErrorWrapper;
 use crate::{client::RustXmtpClient, conversation::Conversation, streams::StreamCloser};
+use xmtp_mls::groups::group_mutable_metadata::MessageDisappearingSettings as XmtpMessageDisappearingSettings;
 
 #[napi]
 #[derive(Debug)]
@@ -100,6 +101,31 @@ impl From<ListConversationsOptions> for GroupQueryArgs {
         .map(|vec| vec.into_iter().map(Into::into).collect()),
       include_duplicate_dms: opts.include_duplicate_dms,
       ..Default::default()
+    }
+  }
+}
+
+#[napi(object)]
+#[derive(Clone)]
+pub struct MessageDisappearingSettings {
+  pub from_ns: i64,
+  pub in_ns: i64,
+}
+
+impl From<MessageDisappearingSettings> for XmtpMessageDisappearingSettings {
+  fn from(value: MessageDisappearingSettings) -> Self {
+    Self {
+      from_ns: value.from_ns,
+      in_ns: value.in_ns,
+    }
+  }
+}
+
+impl From<XmtpMessageDisappearingSettings> for MessageDisappearingSettings {
+  fn from(value: XmtpMessageDisappearingSettings) -> Self {
+    Self {
+      from_ns: value.from_ns,
+      in_ns: value.in_ns,
     }
   }
 }

--- a/bindings_node/src/conversations.rs
+++ b/bindings_node/src/conversations.rs
@@ -78,27 +78,29 @@ impl From<GroupMembershipState> for XmtpGroupMembershipState {
 }
 
 #[napi(object)]
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct ListConversationsOptions {
   pub allowed_states: Option<Vec<GroupMembershipState>>,
+  pub consent_states: Option<Vec<ConsentState>>,
   pub created_after_ns: Option<i64>,
   pub created_before_ns: Option<i64>,
+  pub include_duplicate_dms: bool,
   pub limit: Option<i64>,
   pub conversation_type: Option<ConversationType>,
 }
 
 impl From<ListConversationsOptions> for GroupQueryArgs {
   fn from(opts: ListConversationsOptions) -> GroupQueryArgs {
-    GroupQueryArgs::default()
-      .maybe_allowed_states(
-        opts
-          .allowed_states
-          .map(|states| states.into_iter().map(From::from).collect()),
-      )
-      .maybe_conversation_type(opts.conversation_type.map(|ct| ct.into()))
-      .maybe_created_after_ns(opts.created_after_ns)
-      .maybe_created_before_ns(opts.created_before_ns)
-      .maybe_limit(opts.limit)
+    GroupQueryArgs {
+      created_before_ns: opts.created_before_ns,
+      created_after_ns: opts.created_after_ns,
+      limit: opts.limit,
+      consent_states: opts
+        .consent_states
+        .map(|vec| vec.into_iter().map(Into::into).collect()),
+      include_duplicate_dms: opts.include_duplicate_dms,
+      ..Default::default()
+    }
   }
 }
 


### PR DESCRIPTION
# Summary

- Added new methods to create groups by inbox ID
- Added consent states option to `sync_all_conversations`
- Updated list conversations options to include `consent_states` and `include_duplicate_dms`
- Removed automatic message filtering from DM groups
- Added disappearing messages methods to conversations
- Updated conversations list methods to return conversations and their last message