### PR TITLE
Fix node release workflow

### DIFF
--- a/.github/workflows/release-node-bindings.yml
+++ b/.github/workflows/release-node-bindings.yml
@@ -274,6 +274,10 @@ jobs:
       - name: Enable corepack
         run: corepack enable
 
+      - name: Install dependencies
+        working-directory: bindings_node
+        run: yarn
+
       - name: Generate version
         working-directory: bindings_node
         run: yarn generate:version


### PR DESCRIPTION
# Summary

I forgot to add a `yarn install` before generating a version file during the Node bindings release workflow.