### PR TITLE
android/iOS CI Checks

### DIFF
--- a/.github/workflows/check-ios-android-bindings.yml
+++ b/.github/workflows/check-ios-android-bindings.yml
@@ -19,9 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          - aarch64-apple-ios
-          - x86_64-apple-ios
-          - aarch64-apple-ios-sim
           - x86_64-apple-darwin
           - aarch64-apple-darwin
     steps:

--- a/.github/workflows/check-ios-android-bindings.yml
+++ b/.github/workflows/check-ios-android-bindings.yml
@@ -1,0 +1,75 @@
+name: Check iOS & Android Bindings
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - "*"
+      - "bindings_ffi/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "dev/**"
+      - "rust-toolchain"
+      - ".cargo/**"
+jobs:
+  check-swift:
+    runs-on: warp-macos-13-arm64-6x
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - aarch64-apple-ios
+          - x86_64-apple-ios
+          - aarch64-apple-ios-sim
+          - x86_64-apple-darwin
+          - aarch64-apple-darwin
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Nix
+        uses: cachix/install-nix-action@v30
+        with:
+          # Mostly to avoid GitHub rate limiting
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      - uses: DeterminateSystems/flakehub-cache-action@main
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            .
+      - name: Build target
+        run: |
+          nix develop . --command \
+            cargo check --target ${{ matrix.target }} --manifest-path bindings_ffi/Cargo.toml
+  check-android:
+    runs-on: warp-ubuntu-latest-x64-16x
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - x86_64-linux-android
+          # We can add other targets later by making a pkg derivation and configuring LD_LIBRARY_PATH
+          # according to https://github.com/bburdette/tauri-zknotes/blob/7aa3495dc2c8a266d81c2fa3e51ae347e9c2597d/flake.nix#L158
+          # but this is good for just checking to ensure it compiles on this target
+          # Can also run android emulator here after cloning xmtp-android
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Nix
+        uses: cachix/install-nix-action@v30
+        with:
+          # Mostly to avoid GitHub rate limiting
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      - uses: DeterminateSystems/flakehub-cache-action@main
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            .
+      - name: check target
+        run: |
+          nix develop .#android --command \
+            cargo check --target ${{ matrix.target }} --manifest-path bindings_ffi/Cargo.toml

--- a/.github/workflows/check-ios-android-bindings.yml
+++ b/.github/workflows/check-ios-android-bindings.yml
@@ -5,7 +5,7 @@ on:
       - main
   pull_request:
     paths:
-      - "*"
+      - ".github/workflows/check-ios-android-bindings.yml"
       - "bindings_ffi/**"
       - "Cargo.toml"
       - "Cargo.lock"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,47 +196,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "askama"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b79091df18a97caea757e28cd2d5fda49c6cd4bd01ddffd7ff01ace0c0ad2c28"
-dependencies = [
- "askama_derive",
- "askama_escape",
-]
-
-[[package]]
-name = "askama_derive"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19fe8d6cb13c4714962c072ea496f3392015f0989b1a2847bb4b2d9effd71d83"
-dependencies = [
- "askama_parser",
- "basic-toml",
- "mime",
- "mime_guess",
- "proc-macro2",
- "quote",
- "serde",
- "syn 2.0.90",
-]
-
-[[package]]
-name = "askama_escape"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
-
-[[package]]
-name = "askama_parser"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acb1161c6b64d1c3d83108213c2a2533a342ac225aabd0bda218278c2ddb00c0"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,7 +436,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.90",
 ]
@@ -4977,6 +4936,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "rinja"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dc4940d00595430b3d7d5a01f6222b5e5b51395d1120bdb28d854bb8abb17a5"
+dependencies = [
+ "itoa",
+ "rinja_derive",
+]
+
+[[package]]
+name = "rinja_derive"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d9ed0146aef6e2825f1b1515f074510549efba38d71f4554eec32eb36ba18b"
+dependencies = [
+ "basic-toml",
+ "memchr",
+ "mime",
+ "mime_guess",
+ "proc-macro2",
+ "quote",
+ "rinja_parser",
+ "rustc-hash 2.1.1",
+ "serde",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "rinja_parser"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f9a866e2e00a7a1fb27e46e9e324a6f7c0e7edc4543cae1d38f4e4a100c610"
+dependencies = [
+ "memchr",
+ "nom",
+ "serde",
+]
+
+[[package]]
 name = "ripemd"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5018,6 +5016,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc-hex"
@@ -6574,9 +6578,9 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "uniffi"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cb08c58c7ed7033150132febe696bef553f891b1ede57424b40d87a89e3c170"
+checksum = "ba62a57e90f9baed5ad02a71a0870180fa1cc35499093b2d21be2edfb68ec0f7"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.15.4",
@@ -6588,12 +6592,11 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cade167af943e189a55020eda2c314681e223f1e42aca7c4e52614c2b627698f"
+checksum = "2242f35214f1e0e3b47c495d340c69f649f9a9ece3a943a29e275686cc884533"
 dependencies = [
  "anyhow",
- "askama",
  "camino",
  "cargo_metadata 0.15.4",
  "fs-err",
@@ -6602,6 +6605,7 @@ dependencies = [
  "heck",
  "once_cell",
  "paste",
+ "rinja",
  "serde",
  "textwrap",
  "toml 0.5.11",
@@ -6612,9 +6616,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7cf32576e08104b7dc2a6a5d815f37616e66c6866c2a639fe16e6d2286b75b"
+checksum = "c887a6c9a2857d8dc2ab0c8d578e8aa4978145b4fd65ed44296341e89aebc3cc"
 dependencies = [
  "anyhow",
  "camino",
@@ -6622,37 +6626,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "uniffi_checksum_derive"
-version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "802d2051a700e3ec894c79f80d2705b69d85844dafbbe5d1a92776f8f48b563a"
-dependencies = [
- "quote",
- "syn 2.0.90",
-]
-
-[[package]]
 name = "uniffi_core"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7687007d2546c454d8ae609b105daceb88175477dac280707ad6d95bcd6f1f"
+checksum = "cad9fbdeb7ae4daf8d0f7704a3b638c37018eb16bb701e30fa17a2dd3e2d39c1"
 dependencies = [
  "anyhow",
  "async-compat",
  "bytes",
- "log",
  "once_cell",
  "paste",
  "static_assertions",
 ]
 
 [[package]]
-name = "uniffi_macros"
-version = "0.28.3"
+name = "uniffi_internal_macros"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12c65a5b12ec544ef136693af8759fb9d11aefce740fb76916721e876639033b"
+checksum = "22a9dba1d78b9ce429439891089c223478043d52a1c3176a0fcea2b5573a7fcf"
 dependencies = [
- "bincode",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "uniffi_macros"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78dd5f8eefba5898b901086f5e7916da67b9a5286a01cc44e910cd75fa37c630"
+dependencies = [
  "camino",
  "fs-err",
  "once_cell",
@@ -6666,21 +6668,20 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a74ed96c26882dac1ca9b93ca23c827e284bacbd7ec23c6f0b0372f747d59e4"
+checksum = "9d5965b1d4ffacef1eaa72fef9c00d2491641e87ad910f6c5859b9c503ddb16a"
 dependencies = [
  "anyhow",
- "bytes",
  "siphasher",
- "uniffi_checksum_derive",
+ "uniffi_internal_macros",
 ]
 
 [[package]]
 name = "uniffi_testing"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6f984f0781f892cc864a62c3a5c60361b1ccbd68e538e6c9fbced5d82268ac"
+checksum = "43b0f35750a3e1836f10f26e4eceba688748b8a1e94a6ee251c976099d984d4f"
 dependencies = [
  "anyhow",
  "camino",
@@ -6691,14 +6692,13 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037820a4cfc4422db1eaa82f291a3863c92c7d1789dc513489c36223f9b4cdfc"
+checksum = "279b82bac9a382c796a0d210bb8354a0b813499b28aa1de046c85d78ca389805"
 dependencies = [
  "anyhow",
  "textwrap",
  "uniffi_meta",
- "uniffi_testing",
  "weedle2",
 ]
 

--- a/bindings_ffi/Cargo.toml
+++ b/bindings_ffi/Cargo.toml
@@ -20,7 +20,7 @@ tracing-subscriber = { workspace = true, features = [
   "fmt",
   "json",
 ] }
-uniffi = { version = "0.28.0", default-features = false, features = ["tokio"] }
+uniffi = { version = "0.29.0", default-features = false, features = ["tokio"] }
 xmtp_api.workspace = true
 xmtp_api_grpc.workspace = true
 xmtp_common.workspace = true
@@ -45,7 +45,7 @@ tracing_android_trace = { version = "0.1", features = ["api_level_29"] }
 tracing-oslog = "0.2"
 
 [build-dependencies]
-uniffi = { version = "0.28.0", features = ["build"] }
+uniffi = { version = "0.29.0", features = ["build"] }
 
 [[bin]]
 name = "ffi-uniffi-bindgen"
@@ -56,7 +56,7 @@ required-features = ["uniffi/cli"]
 ethers = { workspace = true, features = ["rustls"] }
 rand.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }
-uniffi = { version = "0.28.0", features = ["bindgen-tests"] }
+uniffi = { version = "0.29.0", features = ["bindgen-tests"] }
 uuid = { workspace = true, features = ["v4", "fast-rng"] }
 xmtp_api_grpc = { workspace = true, features = ["test-utils"] }
 xmtp_mls = { workspace = true, features = ["test-utils"] }

--- a/bindings_ffi/src/logger.rs
+++ b/bindings_ffi/src/logger.rs
@@ -51,9 +51,7 @@ mod ios {
         let libxmtp_filter = EnvFilter::builder()
             .parse(FILTER_DIRECTIVE)
             .unwrap_or_else(|_| EnvFilter::new("info"));
-
         let subsystem = format!("org.xmtp.{}", env!("CARGO_PKG_NAME"));
-
         OsLogger::new(subsystem, "default").with_filter(libxmtp_filter)
     }
 }
@@ -104,11 +102,19 @@ pub use test_logger::*;
 #[cfg(test)]
 mod test_logger {
     use super::*;
+    use tracing_subscriber::EnvFilter;
 
     pub fn native_layer<S>() -> impl Layer<S>
     where
         S: Subscriber + for<'a> LookupSpan<'a>,
     {
         xmtp_common::logger_layer()
+    }
+
+    #[test]
+    fn test_directive() {
+        let _filer = EnvFilter::builder()
+            .parse(FILTER_DIRECTIVE)
+            .expect("should parse correctly");
     }
 }

--- a/bindings_node/package.json
+++ b/bindings_node/package.json
@@ -47,7 +47,7 @@
     "prettier-plugin-packagejson": "^2.5.8",
     "tsx": "^4.19.3",
     "typescript": "^5.7.3",
-    "uuid": "^11.0.5",
+    "uuid": "^11.1.0",
     "viem": "^2.23.2",
     "vite": "^6.1.0",
     "vite-tsconfig-paths": "^5.1.4",

--- a/bindings_node/yarn.lock
+++ b/bindings_node/yarn.lock
@@ -1963,7 +1963,7 @@ __metadata:
     prettier-plugin-packagejson: "npm:^2.5.8"
     tsx: "npm:^4.19.3"
     typescript: "npm:^5.7.3"
-    uuid: "npm:^11.0.5"
+    uuid: "npm:^11.1.0"
     viem: "npm:^2.23.2"
     vite: "npm:^6.1.0"
     vite-tsconfig-paths: "npm:^5.1.4"
@@ -3885,12 +3885,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^11.0.5":
-  version: 11.0.5
-  resolution: "uuid@npm:11.0.5"
+"uuid@npm:^11.1.0":
+  version: 11.1.0
+  resolution: "uuid@npm:11.1.0"
   bin:
     uuid: dist/esm/bin/uuid
-  checksum: 10/0594ecdff3051e15d4a2c614b4c72e73af373bde0a5d156512353c01156975295d024ae8d7151846d7bd4d22ccd251b16ed51b4318fa71505fb20ad984102dc1
+  checksum: 10/d2da43b49b154d154574891ced66d0c83fc70caaad87e043400cf644423b067542d6f3eb641b7c819224a7cd3b4c2f21906acbedd6ec9c6a05887aa9115a9cf5
   languageName: node
   linkType: hard
 

--- a/dev/release-kotlin
+++ b/dev/release-kotlin
@@ -7,7 +7,9 @@ WHITE='\033[0;97m'
 
 NC='\033[0m' # No Color
 
+PROJECT_NAME="xmtpv3"
 XMTP_ANDROID="${1:-$(realpath ../xmtp-android)}"
+
 if [ ! -d $XMTP_ANDROID ]; then
   echo -e "${RED}xmtp-android directory not detected${NC}"
   echo -e "${RED}Ensure directory exists.${NC}"
@@ -15,6 +17,15 @@ if [ ! -d $XMTP_ANDROID ]; then
   exit
 fi
 echo -e "${GREEN}Android Directory:${NC} $XMTP_ANDROID"
+
+CARGO="nix develop -i .#android --command cargo"
+SED="nix develop -i .#android --command sed"
+
+WORKSPACE_MANIFEST="$($CARGO locate-project --workspace --message-format=plain)"
+WORKSPACE_PATH="$(dirname $WORKSPACE_MANIFEST)"
+BINDINGS_MANIFEST="$WORKSPACE_PATH/bindings_ffi/Cargo.toml"
+BINDINGS_PATH="$(dirname $BINDINGS_MANIFEST)"
+TARGET_DIR="$WORKSPACE_PATH/target"
 
 # Local script to release android jniLibs with same environment as CI
 if [[ "${OSTYPE}" == "darwin"* ]]; then
@@ -32,16 +43,49 @@ if [[ "${OSTYPE}" == "darwin"* ]]; then
   fi
 fi
 
+LIB_FILE=$([ "$(uname)" == "Darwin" ] && echo "lib$PROJECT_NAME.dylib" || echo "lib$PROJECT_NAME.so")
+
+echo "gen kotlin artifacts from xmtpv3 bindings..."
+cd $WORKSPACE_PATH
+$CARGO build --release -p xmtpv3
+rm -f $BINDINGS_PATH/src/uniffi/$PROJECT_NAME/$PROJECT_NAME.kt
+$CARGO run --bin ffi-uniffi-bindgen \
+  --manifest-path $BINDINGS_MANIFEST \
+  --features uniffi/cli --release -- \
+  generate \
+  --lib-file $TARGET_DIR/release/$LIB_FILE $BINDINGS_PATH/src/$PROJECT_NAME.udl \
+  --language kotlin
+
+cd $BINDINGS_PATH
+make libxmtp-version
+cp libxmtp-version.txt src/uniffi/$PROJECT_NAME/
+
+echo "$BINDINGS_PATH/src/uniffi/xmtpv3/xmtpv3.kt"
+# 1) Replace `return "xmtpv3"` with `return "uniffi_xmtpv3"`
+# 2) Replace `value.forEach { (k, v) ->` with `value.iterator().forEach { (k, v) ->`
+#    in the file xmtpv3.kt
+# nix sed is used to be consistent across mac and linux
+$SED -i \
+    -e 's/return "xmtpv3"/return "uniffi_xmtpv3"/' \
+    -e 's/value\.forEach { (k, v) ->/value.iterator().forEach { (k, v) ->/g' \
+    "$BINDINGS_PATH/src/uniffi/xmtpv3/xmtpv3.kt"
+
+echo "Replacements done in $XMTP_ANDROID/library/src/main/java/xmtpv3.kt"
+
+cp $BINDINGS_PATH/src/uniffi/xmtpv3/xmtpv3.kt $XMTP_ANDROID/library/src/main/java/xmtpv3.kt
+cp $BINDINGS_PATH/src/uniffi/xmtpv3/libxmtp-version.txt $XMTP_ANDROID/library/src/main/java/libxmtp-version.txt
+
+cd $WORKSPACE_PATH
+
 LIBRARY_NAME="libxmtpv3"
 TARGET_NAME="libuniffi_xmtpv3"
 
-nix develop . --command cargo ndk -o bindings_ffi/jniLibs/ --manifest-path ./bindings_ffi/Cargo.toml \
+$CARGO ndk -o bindings_ffi/jniLibs/ --manifest-path ./bindings_ffi/Cargo.toml \
   -t aarch64-linux-android \
   -t x86_64-linux-android \
   -t i686-linux-android \
   -t armv7-linux-androideabi \
   -- build --release
-
 
 for arch in arm64-v8a armeabi-v7a x86 x86_64; do
   mv "./bindings_ffi/jniLibs/$arch/$LIBRARY_NAME.so" "./bindings_ffi/jniLibs/$arch/$TARGET_NAME.so"

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1729492502,
-        "narHash": "sha256-d6L4bBlUWr4sHC+eRXo+4acFPEFXKmqHpM/BfQ5gQQw=",
+        "lastModified": 1740378829,
+        "narHash": "sha256-cwmm7F73aQFJY6YN1roNibNKwxT6FlfXkG3MEbpSp7Q=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "4002a1ec3486b855f341d2b864ba06b61e73af28",
+        "rev": "92823f1b0c919d7e2d806956aaf98e90f3761ab7",
         "type": "github"
       },
       "original": {
@@ -21,55 +21,84 @@
         "type": "github"
       }
     },
-    "flake-utils": {
+    "flake-parts": {
       "inputs": {
-        "systems": "systems"
+        "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "lastModified": 1738453229,
+        "narHash": "sha256-7H9XgNiGLKN1G1CgRh0vUL4AheZSYzPm+zmZ7vxbJdo=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "32ea77a06711b758da0ad9bd6a844c5740a87abd",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "mkshell-util": {
+      "locked": {
+        "lastModified": 1740069870,
+        "narHash": "sha256-hO4lmUPE80gi22FJfJcqBX3B+Sy+cUikLgOUpvWKh80=",
+        "owner": "insipx",
+        "repo": "mkShell-util.nix",
+        "rev": "740bd88b2e664854c9cdcde37cd98874349364c8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "insipx",
+        "repo": "mkShell-util.nix",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1729307008,
-        "narHash": "sha256-QUvb6epgKi9pCu9CttRQW4y5NqJ+snKr1FZpG/x3Wtc=",
+        "lastModified": 1740339700,
+        "narHash": "sha256-cbrw7EgQhcdFnu6iS3vane53bEagZQy/xyIkDWpCgVE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a9b86fc2290b69375c5542b622088eb6eca2a7c3",
+        "rev": "04ef94c4c1582fd485bbfdb8c4a8ba250e359195",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.05",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1738452942,
+        "narHash": "sha256-vJzFZGaCpnmo7I6i416HaBLpC+hvcURh/BQwROcGIp8=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
       }
     },
     "root": {
       "inputs": {
         "fenix": "fenix",
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "flake-parts": "flake-parts",
+        "mkshell-util": "mkshell-util",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
       }
     },
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1729454508,
-        "narHash": "sha256-1W5B/CnLgdC03iIFG0wtawO1+dGDWDpc84PeOHo2ecU=",
+        "lastModified": 1740329432,
+        "narHash": "sha256-eKQ7aBkNvF5AhUpyJ1cW450jxomZ4gTIaYir5qsNl7Y=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "9323b5385863739d1c113f02e4cf3f2777c09977",
+        "rev": "6d68c475c7aaf7534251182662456a4bf4216dfe",
         "type": "github"
       },
       "original": {

--- a/nix/android.nix
+++ b/nix/android.nix
@@ -1,0 +1,97 @@
+{ mkShell
+, darwin
+, androidenv
+, stdenv
+, pkg-config
+, kotlin
+, ktlint
+, jdk17
+, cargo-ndk
+, sqlite
+, openssl
+, lib
+, fenix
+, gnused
+}:
+let
+  frameworks = if stdenv.isDarwin then darwin.apple_sdk.frameworks else null;
+  inherit (androidComposition) androidsdk;
+
+  android = {
+    platforms = [ "33" "34" ];
+    platformTools = "33.0.3";
+    buildTools = [ "30.0.3" ];
+  };
+
+  androidTargets = [
+    "aarch64-linux-android"
+    "armv7-linux-androideabi"
+    "x86_64-linux-android"
+    "i686-linux-android"
+  ];
+
+  # Pinned Rust Version
+  rust-toolchain = fenix.combine [
+    fenix.stable.cargo
+    fenix.stable.rustc
+    (lib.forEach
+      androidTargets
+      (target: fenix.targets."${target}".stable.rust-std))
+  ];
+
+  sdkArgs = {
+    platformVersions = android.platforms;
+    platformToolsVersion = android.platformTools;
+    buildToolsVersions = android.buildTools;
+    emulatorVersion = "34.1.9";
+    systemImageTypes = [ "google_apis_playstore" "default" ];
+    abiVersions = [ "x86_64" ];
+    includeNDK = true;
+    includeEmulator = true;
+    includeSystemImages = true;
+  };
+
+  # https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/android.section.md
+  androidHome = "${androidComposition.androidsdk}/libexec/android-sdk";
+  androidComposition = androidenv.composeAndroidPackages sdkArgs;
+  androidEmulator = androidenv.emulateApp {
+    name = "libxmtp-emulator-34";
+    platformVersion = "34";
+    abiVersion = "x86_64"; # armeabi-v7a, mips, x86_64
+    systemImageType = "default";
+  };
+in
+mkShell {
+  OPENSSL_DIR = "${openssl.dev}";
+  ANDROID_HOME = androidHome;
+  NDK_HOME = "${androidComposition.androidsdk}/libexec/android-sdk/ndk/${builtins.head (lib.lists.reverseList (builtins.split "-" "${androidComposition.ndk-bundle}"))}";
+  ANDROID_SDK_ROOT = androidHome; # ANDROID_SDK_ROOT is deprecated, but some tools may still use it;
+  ANDROID_NDK_ROOT = "${androidHome}/ndk-bundle";
+  EMULATOR = "${androidEmulator}";
+
+  # Packages available to flake while building the environment
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    rust-toolchain
+    kotlin
+    ktlint
+    androidsdk
+    jdk17
+    cargo-ndk
+    androidEmulator
+    gnused # for ./dev/release-kotlin
+
+    # System Libraries
+    sqlite
+    openssl
+  ] ++ lib.optionals stdenv.isDarwin [
+    # optional packages if on darwin, in order to check if build passes locally
+    frameworks.CoreServices
+    frameworks.Carbon
+    frameworks.ApplicationServices
+    frameworks.AppKit
+    darwin.cctools
+  ];
+}
+

--- a/nix/ios.nix
+++ b/nix/ios.nix
@@ -1,0 +1,67 @@
+# This build will only work on darwin
+{ stdenv
+, darwin
+, lib
+, fenix
+, pkg-config
+, mkShell
+, openssl
+, sqlite
+, zstd
+, llvmPackages_19
+, xcbuild
+, ...
+}:
+
+let
+  inherit (stdenv) isDarwin;
+  inherit (darwin.apple_sdk) frameworks;
+
+  iosTargets = [
+    "x86_64-apple-darwin"
+    "aarch64-apple-ios"
+    "x86_64-apple-ios"
+    "aarch64-apple-ios-sim"
+  ];
+
+  # Pinned Rust Version
+  rust-toolchain = fenix.combine [
+    fenix.stable.cargo
+    fenix.stable.rustc
+    (lib.forEach
+      iosTargets
+      (target: fenix.targets."${target}".stable.rust-std))
+  ];
+in
+mkShell {
+  OPENSSL_DIR = "${openssl.dev}";
+  LLVM_PATH = "${llvmPackages_19.stdenv}";
+  # CC_wasm32_unknown_unknown = "${llvmPackages_20.clang-unwrapped}/bin/clang";
+  # CXX_wasm32_unknown_unknown = "${llvmPackages_20.clang-unwrapped}/bin/clang++";
+  # AS_wasm32_unknown_unknown = "${llvmPackages_20.clang-unwrapped}/bin/llvm-as";
+  # AR_wasm32_unknown_unknown = "${llvmPackages_20.clang-unwrapped}/bin/llvm-ar";
+  # STRIP_wasm32_unknown_unknown = "${llvmPackages_20.clang-unwrapped}/bin/llvm-strip";
+  # disable -fzerocallusedregs in clang
+  hardeningDisable = [ "zerocallusedregs" ];
+  OPENSSL_LIB_DIR = "${lib.getLib openssl}/lib";
+  OPENSSL_NO_VENDOR = 1;
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs =
+    [
+      rust-toolchain
+
+      # native libs
+      zstd
+      openssl
+      sqlite
+      xcbuild
+    ]
+    ++ lib.optionals isDarwin [
+      frameworks.CoreServices
+      frameworks.Carbon
+      frameworks.ApplicationServices
+      frameworks.AppKit
+      darwin.cctools
+    ];
+}

--- a/nix/libxmtp.nix
+++ b/nix/libxmtp.nix
@@ -1,0 +1,97 @@
+{ shells
+, stdenv
+, darwin
+, lib
+, fenix
+, pkg-config
+, mktemp
+, jdk21
+, kotlin
+, diesel-cli
+, gnuplot
+, flamegraph
+, cargo-flamegraph
+, inferno
+, openssl
+, sqlite
+, corepack
+, lnav
+, zstd
+, llvmPackages_19
+, wasm-bindgen-cli
+, ...
+}:
+
+let
+  inherit (stdenv) isDarwin;
+  inherit (darwin.apple_sdk) frameworks;
+  inherit (shells) combineShell;
+  mkShell =
+    top:
+    (
+      combineShell
+        {
+          otherShells = with shells;
+            [
+              mkLinters
+              mkCargo
+              mkRustWasm
+              mkGrpc
+            ];
+          extraInputs = top;
+        });
+
+  rust-toolchain = fenix.fromToolchainFile {
+    file = ./../rust-toolchain;
+    sha256 = "sha256-AJ6LX/Q/Er9kS15bn9iflkUwcgYqRQxiOIL2ToVAXaU=";
+  };
+in
+mkShell {
+  OPENSSL_DIR = "${openssl.dev}";
+  LLVM_PATH = "${llvmPackages_19.stdenv}";
+  # CC_wasm32_unknown_unknown = "${llvmPackages_20.clang-unwrapped}/bin/clang";
+  # CXX_wasm32_unknown_unknown = "${llvmPackages_20.clang-unwrapped}/bin/clang++";
+  # AS_wasm32_unknown_unknown = "${llvmPackages_20.clang-unwrapped}/bin/llvm-as";
+  # AR_wasm32_unknown_unknown = "${llvmPackages_20.clang-unwrapped}/bin/llvm-ar";
+  # STRIP_wasm32_unknown_unknown = "${llvmPackages_20.clang-unwrapped}/bin/llvm-strip";
+  # disable -fzerocallusedregs in clang
+  hardeningDisable = [ "zerocallusedregs" ];
+  OPENSSL_LIB_DIR = "${lib.getLib openssl}/lib";
+  OPENSSL_NO_VENDOR = 1;
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs =
+    [
+      rust-toolchain
+      wasm-bindgen-cli
+      fenix.rust-analyzer
+      zstd
+
+      # native libs
+      openssl
+      sqlite
+
+      mktemp
+      jdk21
+      kotlin
+      diesel-cli
+
+      # Random devtools
+      # tokio-console
+      gnuplot
+      flamegraph
+      cargo-flamegraph
+      inferno
+      lnav
+
+      # make sure to use nodePackages! or it will install yarn irrespective of environmental node.
+      corepack
+    ]
+    ++ lib.optionals isDarwin [
+      frameworks.CoreServices
+      frameworks.Carbon
+      frameworks.ApplicationServices
+      frameworks.AppKit
+      darwin.cctools
+    ];
+}


### PR DESCRIPTION
checks each swift target compile, and the `x86_64` android target (other android targets are possible but a little more complicated, can be done later on) on bindings_ffi  changes


unfortunately, github withdrew support for free nix flake caching: https://determinate.systems/posts/magic-nix-cache-free-tier-eol/ so nix check will be a bit longer, although still not bad