### PR TITLE
Update encryption.rs

### DIFF
--- a/xmtp_v2/src/encryption.rs
+++ b/xmtp_v2/src/encryption.rs
@@ -16,7 +16,7 @@ pub struct Ciphertext {
 
 pub fn hkdf(secret: &[u8], salt: &[u8]) -> Result<[u8; 32], String> {
     let hk = Hkdf::<Sha256>::new(Some(salt), secret);
-    let mut okm = [0u8; 42];
+    let mut okm = [0u8; 32];
     let res = hk.expand(&[], &mut okm);
     if res.is_err() {
         return Err(res.err().unwrap().to_string());


### PR DESCRIPTION
The hkdf function is used to derive a 32-byte key from the input secret and salt using HKDF-SHA256. However, the original code allocates a buffer of 42 bytes ([0u8; 42]), which is unnecessary because only 32 bytes are required.