### PR TITLE
Remove cross from android/kotlin release build

### DIFF
--- a/.github/workflows/release-kotlin-bindings.yml
+++ b/.github/workflows/release-kotlin-bindings.yml
@@ -34,16 +34,12 @@ jobs:
           workspaces: |
             .
             bindings_ffi
-      # Install latest cross to mitigate unwind linking issue on android builds.
-      # See https://github.com/cross-rs/cross/issues/1222
-      - name: Install cross
-        run: |
-          cargo install cross --git https://github.com/cross-rs/cross
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-ndk
       - name: Build target
-        env:
-          CROSS_NO_WARNINGS: "0"
         run: |
-          cross build --release --target ${{ matrix.target }} --manifest-path bindings_ffi/Cargo.toml
+          cargo ndk -o bindings_ffi/jniLibs/ --manifest-path bindings_ffi/Cargo.toml -t ${{ matrix.target }} -- build --release
       - name: Prepare JNI libs
         run: |
           mkdir -p bindings_ffi/jniLibs/${{ matrix.output_target }}/ && \


### PR DESCRIPTION
Easy speed up for release builds is using `cargo ndk` instead of cross. Warp build runners include the ANDROID SDK and environment variables necessary to accomplish this: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#android

it saves us time by not needing to `cargo install cross`, works better with the swatinem rust cache, and does not require starting up docker images/containers to compile the android targets

confirmed working [here](https://github.com/xmtp/libxmtp/actions/runs/13639077834)

cross build time: ~3m:30s: https://github.com/xmtp/libxmtp/actions/runs/13593803910
uncached cargo ndk build time: ~2m:26s https://github.com/xmtp/libxmtp/actions/runs/13639077834
cached cargo ndk build time: ~1min:20 - 2min https://github.com/xmtp/libxmtp/actions/runs/13639181066