### PR TITLE
Delete .gitignore file for bindings release build

### DIFF
--- a/.github/workflows/release-wasm-bindings.yml
+++ b/.github/workflows/release-wasm-bindings.yml
@@ -49,10 +49,14 @@ jobs:
         run: |
           source ./../emsdk/emsdk_env.sh
           yarn build
+      - name: list dist/ dir
+        working-directory: bindings_wasm
+        run: ls -la ./dist/
       - name: Publish to NPM
         uses: JS-DevTools/npm-publish@v3
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: bindings_wasm
+          dry-run: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-wasm-bindings.yml
+++ b/.github/workflows/release-wasm-bindings.yml
@@ -49,14 +49,10 @@ jobs:
         run: |
           source ./../emsdk/emsdk_env.sh
           yarn build
-      - name: list dist/ dir
-        working-directory: bindings_wasm
-        run: ls -la ./dist/
       - name: Publish to NPM
         uses: JS-DevTools/npm-publish@v3
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: bindings_wasm
-          dry-run: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/bindings_wasm/package.json
+++ b/bindings_wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/wasm-bindings",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "type": "module",
   "license": "MIT",
   "description": "WASM bindings for the libXMTP rust library",

--- a/bindings_wasm/package.json
+++ b/bindings_wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/wasm-bindings",
-  "version": "0.0.18",
+  "version": "0.0.17",
   "type": "module",
   "license": "MIT",
   "description": "WASM bindings for the libXMTP rust library",

--- a/bindings_wasm/package.json
+++ b/bindings_wasm/package.json
@@ -24,10 +24,11 @@
     "directory": "bindings_wasm"
   },
   "scripts": {
-    "build": "yarn clean && yarn build:web",
+    "build": "yarn clean && yarn build:web && yarn clean:release",
     "build:web": "RUSTFLAGS=\"-Ctarget-feature=+bulk-memory,+mutable-globals\" wasm-pack build --target web --out-dir ./dist --no-pack --release",
     "check:macos": "CC_wasm32_unknown_unknown=/opt/homebrew/opt/llvm/bin/clang cargo check --target wasm32-unknown-unknown",
     "clean": "rm -rf ./dist",
+    "clean:release": "rm ./dist/.gitignore",
     "lint": "yarn lint:clippy && yarn lint:fmt",
     "lint:clippy": "cargo clippy --locked --all-features --target wasm32-unknown-unknown --no-deps -- -D warnings",
     "lint:fmt": "cargo fmt --check",


### PR DESCRIPTION
`wasm-pack` generates a .gitignore which prevents the dist file from being included in the webassembly bindings