### PR TITLE
Add content types to node bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,6 +452,7 @@ dependencies = [
  "xmtp_api",
  "xmtp_api_grpc",
  "xmtp_common",
+ "xmtp_content_types",
  "xmtp_cryptography",
  "xmtp_id",
  "xmtp_mls",

--- a/bindings_node/Cargo.toml
+++ b/bindings_node/Cargo.toml
@@ -30,11 +30,11 @@ tracing-subscriber = { workspace = true, features = [
 xmtp_api.workspace = true
 xmtp_api_grpc.workspace = true
 xmtp_common.workspace = true
+xmtp_content_types.workspace = true
 xmtp_cryptography.workspace = true
 xmtp_id.workspace = true
 xmtp_mls.workspace = true
 xmtp_proto = { workspace = true, features = ["proto_full"] }
-
 [build-dependencies]
 napi-build = "2.0.1"
 

--- a/bindings_node/src/content_types/mod.rs
+++ b/bindings_node/src/content_types/mod.rs
@@ -1,0 +1,33 @@
+use napi_derive::napi;
+use xmtp_mls::storage::group_message::ContentType as XmtpContentType;
+
+#[napi]
+pub enum ContentType {
+  Unknown,
+  Text,
+  GroupMembershipChange,
+  GroupUpdated,
+  Reaction,
+  ReadReceipt,
+  Reply,
+  Attachment,
+  RemoteAttachment,
+  TransactionReference,
+}
+
+impl From<ContentType> for XmtpContentType {
+  fn from(value: ContentType) -> Self {
+    match value {
+      ContentType::Unknown => XmtpContentType::Unknown,
+      ContentType::Text => XmtpContentType::Text,
+      ContentType::GroupMembershipChange => XmtpContentType::GroupMembershipChange,
+      ContentType::GroupUpdated => XmtpContentType::GroupUpdated,
+      ContentType::Reaction => XmtpContentType::Reaction,
+      ContentType::ReadReceipt => XmtpContentType::ReadReceipt,
+      ContentType::Reply => XmtpContentType::Reply,
+      ContentType::Attachment => XmtpContentType::Attachment,
+      ContentType::RemoteAttachment => XmtpContentType::RemoteAttachment,
+      ContentType::TransactionReference => XmtpContentType::TransactionReference,
+    }
+  }
+}

--- a/bindings_node/src/content_types/mod.rs
+++ b/bindings_node/src/content_types/mod.rs
@@ -1,6 +1,7 @@
 use napi_derive::napi;
 use xmtp_mls::storage::group_message::ContentType as XmtpContentType;
 
+pub mod multi_remote_attachment;
 pub mod reaction;
 
 #[napi]

--- a/bindings_node/src/content_types/mod.rs
+++ b/bindings_node/src/content_types/mod.rs
@@ -1,6 +1,8 @@
 use napi_derive::napi;
 use xmtp_mls::storage::group_message::ContentType as XmtpContentType;
 
+pub mod reaction;
+
 #[napi]
 pub enum ContentType {
   Unknown,

--- a/bindings_node/src/content_types/multi_remote_attachment.rs
+++ b/bindings_node/src/content_types/multi_remote_attachment.rs
@@ -1,0 +1,113 @@
+use napi::bindgen_prelude::{Result, Uint8Array};
+use napi_derive::napi;
+use prost::Message;
+use xmtp_content_types::multi_remote_attachment::MultiRemoteAttachmentCodec;
+use xmtp_content_types::ContentCodec;
+use xmtp_proto::xmtp::mls::message_contents::content_types::{
+  MultiRemoteAttachment as XmtpMultiRemoteAttachment,
+  RemoteAttachmentInfo as XmtpRemoteAttachmentInfo,
+};
+use xmtp_proto::xmtp::mls::message_contents::EncodedContent;
+
+use crate::ErrorWrapper;
+
+#[napi(object)]
+pub struct RemoteAttachmentInfo {
+  pub secret: Uint8Array,
+  pub content_digest: String,
+  pub nonce: Uint8Array,
+  pub scheme: String,
+  pub url: String,
+  pub salt: Uint8Array,
+  pub content_length: Option<u32>,
+  pub filename: Option<String>,
+}
+
+impl From<RemoteAttachmentInfo> for XmtpRemoteAttachmentInfo {
+  fn from(remote_attachment_info: RemoteAttachmentInfo) -> Self {
+    XmtpRemoteAttachmentInfo {
+      content_digest: remote_attachment_info.content_digest,
+      secret: remote_attachment_info.secret.to_vec(),
+      nonce: remote_attachment_info.nonce.to_vec(),
+      salt: remote_attachment_info.salt.to_vec(),
+      scheme: remote_attachment_info.scheme,
+      url: remote_attachment_info.url,
+      content_length: remote_attachment_info.content_length,
+      filename: remote_attachment_info.filename,
+    }
+  }
+}
+
+impl From<XmtpRemoteAttachmentInfo> for RemoteAttachmentInfo {
+  fn from(remote_attachment_info: XmtpRemoteAttachmentInfo) -> Self {
+    RemoteAttachmentInfo {
+      secret: Uint8Array::from(remote_attachment_info.secret.as_slice()),
+      content_digest: remote_attachment_info.content_digest,
+      nonce: Uint8Array::from(remote_attachment_info.nonce.as_slice()),
+      scheme: remote_attachment_info.scheme,
+      url: remote_attachment_info.url,
+      salt: Uint8Array::from(remote_attachment_info.salt.as_slice()),
+      content_length: remote_attachment_info.content_length,
+      filename: remote_attachment_info.filename,
+    }
+  }
+}
+
+#[napi(object)]
+pub struct MultiRemoteAttachment {
+  pub attachments: Vec<RemoteAttachmentInfo>,
+}
+
+impl From<MultiRemoteAttachment> for XmtpMultiRemoteAttachment {
+  fn from(multi_remote_attachment: MultiRemoteAttachment) -> Self {
+    XmtpMultiRemoteAttachment {
+      attachments: multi_remote_attachment
+        .attachments
+        .into_iter()
+        .map(Into::into)
+        .collect(),
+    }
+  }
+}
+
+impl From<XmtpMultiRemoteAttachment> for MultiRemoteAttachment {
+  fn from(multi_remote_attachment: XmtpMultiRemoteAttachment) -> Self {
+    MultiRemoteAttachment {
+      attachments: multi_remote_attachment
+        .attachments
+        .into_iter()
+        .map(Into::into)
+        .collect(),
+    }
+  }
+}
+
+#[napi]
+pub fn encode_multi_remote_attachment(
+  multi_remote_attachment: MultiRemoteAttachment,
+) -> Result<Uint8Array> {
+  // Convert MultiRemoteAttachment to MultiRemoteAttachment
+  let multi_remote_attachment: XmtpMultiRemoteAttachment = multi_remote_attachment.into();
+
+  // Use MultiRemoteAttachmentCodec to encode the attachments
+  let encoded =
+    MultiRemoteAttachmentCodec::encode(multi_remote_attachment).map_err(ErrorWrapper::from)?;
+
+  // Encode the EncodedContent to bytes
+  let mut buf = Vec::new();
+  encoded.encode(&mut buf).map_err(ErrorWrapper::from)?;
+
+  Ok(Uint8Array::from(buf.as_slice()))
+}
+
+#[napi]
+pub fn decode_multi_remote_attachment(bytes: Uint8Array) -> Result<MultiRemoteAttachment> {
+  // Decode bytes into EncodedContent
+  let encoded_content =
+    EncodedContent::decode(bytes.to_vec().as_slice()).map_err(ErrorWrapper::from)?;
+
+  // Use MultiRemoteAttachmentCodec to decode into MultiRemoteAttachment and convert to MultiRemoteAttachment
+  MultiRemoteAttachmentCodec::decode(encoded_content)
+    .map(Into::into)
+    .map_err(|e| napi::Error::from_reason(e.to_string()))
+}

--- a/bindings_node/src/content_types/multi_remote_attachment.rs
+++ b/bindings_node/src/content_types/multi_remote_attachment.rs
@@ -41,12 +41,12 @@ impl From<RemoteAttachmentInfo> for XmtpRemoteAttachmentInfo {
 impl From<XmtpRemoteAttachmentInfo> for RemoteAttachmentInfo {
   fn from(remote_attachment_info: XmtpRemoteAttachmentInfo) -> Self {
     RemoteAttachmentInfo {
-      secret: Uint8Array::from(remote_attachment_info.secret.as_slice()),
+      secret: Uint8Array::from(remote_attachment_info.secret),
       content_digest: remote_attachment_info.content_digest,
-      nonce: Uint8Array::from(remote_attachment_info.nonce.as_slice()),
+      nonce: Uint8Array::from(remote_attachment_info.nonce),
       scheme: remote_attachment_info.scheme,
       url: remote_attachment_info.url,
-      salt: Uint8Array::from(remote_attachment_info.salt.as_slice()),
+      salt: Uint8Array::from(remote_attachment_info.salt),
       content_length: remote_attachment_info.content_length,
       filename: remote_attachment_info.filename,
     }
@@ -97,7 +97,7 @@ pub fn encode_multi_remote_attachment(
   let mut buf = Vec::new();
   encoded.encode(&mut buf).map_err(ErrorWrapper::from)?;
 
-  Ok(Uint8Array::from(buf.as_slice()))
+  Ok(Uint8Array::from(buf))
 }
 
 #[napi]

--- a/bindings_node/src/content_types/reaction.rs
+++ b/bindings_node/src/content_types/reaction.rs
@@ -1,0 +1,118 @@
+use napi::bindgen_prelude::{Result, Uint8Array};
+use napi_derive::napi;
+use prost::Message;
+use xmtp_content_types::reaction::ReactionCodec;
+use xmtp_content_types::ContentCodec;
+use xmtp_proto::xmtp::mls::message_contents::content_types::ReactionV2;
+use xmtp_proto::xmtp::mls::message_contents::EncodedContent;
+
+use crate::ErrorWrapper;
+
+#[napi(object)]
+pub struct Reaction {
+  pub reference: String,
+  pub reference_inbox_id: String,
+  pub action: ReactionAction,
+  pub content: String,
+  pub schema: ReactionSchema,
+}
+
+impl From<Reaction> for ReactionV2 {
+  fn from(reaction: Reaction) -> Self {
+    ReactionV2 {
+      reference: reaction.reference,
+      reference_inbox_id: reaction.reference_inbox_id,
+      action: reaction.action.into(),
+      content: reaction.content,
+      schema: reaction.schema.into(),
+    }
+  }
+}
+
+impl From<ReactionV2> for Reaction {
+  fn from(reaction: ReactionV2) -> Self {
+    Reaction {
+      reference: reaction.reference,
+      reference_inbox_id: reaction.reference_inbox_id,
+      action: match reaction.action {
+        1 => ReactionAction::Added,
+        2 => ReactionAction::Removed,
+        _ => ReactionAction::Unknown,
+      },
+      content: reaction.content,
+      schema: match reaction.schema {
+        1 => ReactionSchema::Unicode,
+        2 => ReactionSchema::Shortcode,
+        3 => ReactionSchema::Custom,
+        _ => ReactionSchema::Unknown,
+      },
+    }
+  }
+}
+
+#[napi]
+pub fn encode_reaction(reaction: Reaction) -> Result<Uint8Array> {
+  // Convert Reaction to Reaction
+  let reaction: ReactionV2 = reaction.into();
+
+  // Use ReactionCodec to encode the reaction
+  let encoded = ReactionCodec::encode(reaction).map_err(ErrorWrapper::from)?;
+
+  // Encode the EncodedContent to bytes
+  let mut buf = Vec::new();
+  encoded.encode(&mut buf).map_err(ErrorWrapper::from)?;
+
+  Ok(Uint8Array::from(buf.as_slice()))
+}
+
+#[napi]
+pub fn decode_reaction(bytes: Uint8Array) -> Result<Reaction> {
+  // Decode bytes into EncodedContent
+  let encoded_content =
+    EncodedContent::decode(bytes.to_vec().as_slice()).map_err(ErrorWrapper::from)?;
+
+  // Use ReactionCodec to decode into Reaction and convert to Reaction
+  ReactionCodec::decode(encoded_content)
+    .map(Into::into)
+    .map_err(|e| napi::Error::from_reason(e.to_string()))
+}
+
+#[napi]
+#[derive(Default, PartialEq, Debug)]
+pub enum ReactionAction {
+  Unknown,
+  #[default]
+  Added,
+  Removed,
+}
+
+impl From<ReactionAction> for i32 {
+  fn from(action: ReactionAction) -> Self {
+    match action {
+      ReactionAction::Unknown => 0,
+      ReactionAction::Added => 1,
+      ReactionAction::Removed => 2,
+    }
+  }
+}
+
+#[napi]
+#[derive(Default, PartialEq)]
+pub enum ReactionSchema {
+  Unknown,
+  #[default]
+  Unicode,
+  Shortcode,
+  Custom,
+}
+
+impl From<ReactionSchema> for i32 {
+  fn from(schema: ReactionSchema) -> Self {
+    match schema {
+      ReactionSchema::Unknown => 0,
+      ReactionSchema::Unicode => 1,
+      ReactionSchema::Shortcode => 2,
+      ReactionSchema::Custom => 3,
+    }
+  }
+}

--- a/bindings_node/src/conversation.rs
+++ b/bindings_node/src/conversation.rs
@@ -21,7 +21,7 @@ use crate::{
   consent_state::ConsentState,
   conversations::{HmacKey, MessageDisappearingSettings},
   encoded_content::EncodedContent,
-  message::{ListMessagesOptions, Message},
+  message::{ListMessagesOptions, Message, MessageWithReactions},
   permissions::{GroupPermissions, MetadataField, PermissionPolicy, PermissionUpdateType},
   streams::StreamCloser,
   ErrorWrapper,
@@ -184,6 +184,42 @@ impl Conversation {
       .map_err(ErrorWrapper::from)?
       .into_iter()
       .map(|msg| msg.into())
+      .collect();
+
+    Ok(messages)
+  }
+
+  #[napi]
+  pub async fn find_messages_with_reactions(
+    &self,
+    opts: Option<ListMessagesOptions>,
+  ) -> Result<Vec<MessageWithReactions>> {
+    let opts = opts.unwrap_or_default();
+    let group = MlsGroup::new(
+      self.inner_client.clone(),
+      self.group_id.clone(),
+      self.created_at_ns,
+    );
+    let provider = group.mls_provider().map_err(ErrorWrapper::from)?;
+    let conversation_type = group
+      .conversation_type(&provider)
+      .await
+      .map_err(ErrorWrapper::from)?;
+    let kind = match conversation_type {
+      ConversationType::Group => None,
+      ConversationType::Dm => None,
+      ConversationType::Sync => None,
+    };
+    let opts = MsgQueryArgs {
+      kind,
+      ..opts.into()
+    };
+
+    let messages: Vec<MessageWithReactions> = group
+      .find_messages_with_reactions(&opts)
+      .map_err(ErrorWrapper::from)?
+      .into_iter()
+      .map(Into::into)
       .collect();
 
     Ok(messages)

--- a/bindings_node/src/lib.rs
+++ b/bindings_node/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod client;
 mod consent_state;
+pub mod content_types;
 mod conversation;
 mod conversations;
 mod encoded_content;

--- a/bindings_node/src/message.rs
+++ b/bindings_node/src/message.rs
@@ -8,7 +8,7 @@ use xmtp_mls::storage::group_message::{
 use napi_derive::napi;
 use xmtp_proto::xmtp::mls::message_contents::EncodedContent as XmtpEncodedContent;
 
-use crate::encoded_content::EncodedContent;
+use crate::{content_types::ContentType, encoded_content::EncodedContent};
 
 #[napi]
 pub enum GroupMessageKind {
@@ -75,12 +75,16 @@ pub struct ListMessagesOptions {
   pub limit: Option<i64>,
   pub delivery_status: Option<DeliveryStatus>,
   pub direction: Option<SortDirection>,
+  pub content_types: Option<Vec<ContentType>>,
 }
 
 impl From<ListMessagesOptions> for MsgQueryArgs {
   fn from(opts: ListMessagesOptions) -> MsgQueryArgs {
     let delivery_status = opts.delivery_status.map(Into::into);
     let direction = opts.direction.map(Into::into);
+    let content_types = opts
+      .content_types
+      .map(|types| types.into_iter().map(Into::into).collect());
 
     MsgQueryArgs {
       sent_before_ns: opts.sent_before_ns,
@@ -88,6 +92,7 @@ impl From<ListMessagesOptions> for MsgQueryArgs {
       delivery_status,
       limit: opts.limit,
       direction,
+      content_types,
       ..Default::default()
     }
   }

--- a/bindings_node/src/message.rs
+++ b/bindings_node/src/message.rs
@@ -2,7 +2,7 @@ use napi::bindgen_prelude::Uint8Array;
 use prost::Message as ProstMessage;
 use xmtp_mls::storage::group_message::{
   DeliveryStatus as XmtpDeliveryStatus, GroupMessageKind as XmtpGroupMessageKind, MsgQueryArgs,
-  SortDirection as XmtpSortDirection, StoredGroupMessage,
+  SortDirection as XmtpSortDirection, StoredGroupMessage, StoredGroupMessageWithReactions,
 };
 
 use napi_derive::napi;
@@ -137,6 +137,26 @@ impl From<StoredGroupMessage> for Message {
       content,
       kind: msg.kind.into(),
       delivery_status: msg.delivery_status.into(),
+    }
+  }
+}
+
+#[napi(object)]
+#[derive(Clone)]
+pub struct MessageWithReactions {
+  pub message: Message,
+  pub reactions: Vec<Message>,
+}
+
+impl From<StoredGroupMessageWithReactions> for MessageWithReactions {
+  fn from(msg_with_reactions: StoredGroupMessageWithReactions) -> Self {
+    Self {
+      message: msg_with_reactions.message.into(),
+      reactions: msg_with_reactions
+        .reactions
+        .into_iter()
+        .map(|reaction| reaction.into())
+        .collect(),
     }
   }
 }


### PR DESCRIPTION
# Summary

- Added reaction content type
- Added `content_types` option to `ListMessagesOptions`
- Added `find_messages_with_reactions` method to `Conversation`
- Added multi remote attachment content type