### PR TITLE
Update aliases, add `Identifier` constructor (WASM)

### DIFF
--- a/bindings_wasm/CHANGELOG.md
+++ b/bindings_wasm/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @xmtp/wasm-bindings
 
+## 1.0.0-rc2
+
+- Updated some WASM aliases to remove references to addresses
+- Added new camelCase aliases
+- Added `Identifier` class constructor
+
 ## 1.0.0-rc1
 
 - Added `pausedForVersion` to groups for client enforcement

--- a/bindings_wasm/package.json
+++ b/bindings_wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/wasm-bindings",
-  "version": "1.0.0-rc1",
+  "version": "1.0.0-rc2",
   "type": "module",
   "license": "MIT",
   "description": "WASM bindings for the libXMTP rust library",

--- a/bindings_wasm/src/client.rs
+++ b/bindings_wasm/src/client.rs
@@ -184,7 +184,7 @@ pub async fn create_client(
 
 #[wasm_bindgen]
 impl Client {
-  #[wasm_bindgen(getter, js_name = accountAddress)]
+  #[wasm_bindgen(getter, js_name = accountIdentifier)]
   pub fn account_identifier(&self) -> Identifier {
     self.account_identifier.clone()
   }
@@ -286,7 +286,7 @@ impl Client {
     Ok(())
   }
 
-  #[wasm_bindgen(js_name = findInboxIdByAddress)]
+  #[wasm_bindgen(js_name = findInboxIdByIdentifier)]
   pub async fn find_inbox_id_by_identifier(
     &self,
     identifier: Identifier,

--- a/bindings_wasm/src/conversation.rs
+++ b/bindings_wasm/src/conversation.rs
@@ -57,7 +57,7 @@ pub struct GroupMember {
   #[wasm_bindgen(js_name = inboxId)]
   #[serde(rename = "inboxId")]
   pub inbox_id: String,
-  #[wasm_bindgen(js_name = accountAddresses)]
+  #[wasm_bindgen(js_name = accountIdentifiers)]
   #[serde(rename = "accountIdentifiers")]
   pub account_identifiers: Vec<Identifier>,
   #[wasm_bindgen(js_name = installationIds)]
@@ -75,11 +75,11 @@ pub struct GroupMember {
 impl GroupMember {
   #[wasm_bindgen(constructor)]
   pub fn new(
-    inbox_id: String,
-    account_identifiers: Vec<Identifier>,
-    installation_ids: Vec<String>,
-    permission_level: PermissionLevel,
-    consent_state: ConsentState,
+    #[wasm_bindgen(js_name = inboxId)] inbox_id: String,
+    #[wasm_bindgen(js_name = accountIdentifiers)] account_identifiers: Vec<Identifier>,
+    #[wasm_bindgen(js_name = installationIds)] installation_ids: Vec<String>,
+    #[wasm_bindgen(js_name = permissionLevel)] permission_level: PermissionLevel,
+    #[wasm_bindgen(js_name = consentState)] consent_state: ConsentState,
   ) -> Self {
     Self {
       inbox_id,

--- a/bindings_wasm/src/identity.rs
+++ b/bindings_wasm/src/identity.rs
@@ -6,7 +6,9 @@ use xmtp_id::associations::{ident, Identifier as XmtpIdentifier};
 #[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize)]
 pub struct Identifier {
   pub identifier: String,
+  #[wasm_bindgen(js_name = identifierKind)]
   pub identifier_kind: IdentifierKind,
+  #[wasm_bindgen(js_name = relyingParty)]
   pub relying_party: Option<String>,
 }
 

--- a/bindings_wasm/src/identity.rs
+++ b/bindings_wasm/src/identity.rs
@@ -13,6 +13,22 @@ pub struct Identifier {
 }
 
 #[wasm_bindgen]
+impl Identifier {
+  #[wasm_bindgen(constructor)]
+  pub fn new(
+    identifier: String,
+    #[wasm_bindgen(js_name = identifierKind)] identifier_kind: IdentifierKind,
+    #[wasm_bindgen(js_name = relyingParty)] relying_party: Option<String>,
+  ) -> Self {
+    Self {
+      identifier,
+      identifier_kind,
+      relying_party,
+    }
+  }
+}
+
+#[wasm_bindgen]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize)]
 pub enum IdentifierKind {
   Ethereum,

--- a/bindings_wasm/src/inbox_id.rs
+++ b/bindings_wasm/src/inbox_id.rs
@@ -4,10 +4,10 @@ use xmtp_api::{strategies, ApiClientWrapper, ApiIdentifier};
 use xmtp_api_http::XmtpHttpApiClient;
 use xmtp_id::associations::Identifier as XmtpIdentifier;
 
-#[wasm_bindgen(js_name = getInboxIdForAddress)]
-pub async fn get_inbox_id_for_address(
+#[wasm_bindgen(js_name = getInboxIdForIdentifier)]
+pub async fn get_inbox_id_for_identifier(
   host: String,
-  account_identifier: Identifier,
+  #[wasm_bindgen(js_name = accountIdentifier)] account_identifier: Identifier,
 ) -> Result<Option<String>, JsError> {
   let api_client = ApiClientWrapper::new(
     XmtpHttpApiClient::new(host.clone(), "0.0.0".into())?.into(),
@@ -25,7 +25,9 @@ pub async fn get_inbox_id_for_address(
 }
 
 #[wasm_bindgen(js_name = generateInboxId)]
-pub fn generate_inbox_id(account_identifier: Identifier) -> Result<String, JsError> {
+pub fn generate_inbox_id(
+  #[wasm_bindgen(js_name = accountIdentifier)] account_identifier: Identifier,
+) -> Result<String, JsError> {
   // ensure that the nonce is always 1 for now since this will only be used for the
   // create_client function above, which also has a hard-coded nonce of 1
   let ident: XmtpIdentifier = account_identifier.try_into()?;

--- a/bindings_wasm/src/inbox_state.rs
+++ b/bindings_wasm/src/inbox_state.rs
@@ -31,7 +31,7 @@ pub struct InboxState {
   #[wasm_bindgen(js_name = recoveryIdentifier)]
   pub recovery_identifier: Identifier,
   pub installations: Vec<Installation>,
-  #[wasm_bindgen(js_name = accountAddresses)]
+  #[wasm_bindgen(js_name = accountIdentifiers)]
   pub account_identifiers: Vec<Identifier>,
 }
 


### PR DESCRIPTION
# Summary

- Renamed some WASM aliases that references addresses
- Added new camelCase aliases
- Added class constructor for `Identifier`
- Updated version and changelog