### PR TITLE
use rstest, add xmtp_common::test macro, set a timeout to subscription tests for native/web

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4770,6 +4770,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "reqwest"
 version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4967,6 +4973,36 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rstest"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.90",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -7550,6 +7586,7 @@ dependencies = [
  "web-sys",
  "web-time",
  "xmtp_cryptography",
+ "xmtp_macro",
 ]
 
 [[package]]
@@ -7635,6 +7672,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "xmtp_macro"
+version = "1.0.0-rc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+ "tokio",
+ "wasm-bindgen-test",
+]
+
+[[package]]
 name = "xmtp_mls"
 version = "1.0.0-rc1"
 dependencies = [
@@ -7678,6 +7726,7 @@ dependencies = [
  "prost",
  "rand",
  "reqwest 0.12.12",
+ "rstest",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
   "xmtp_content_types",
   "common",
   "xmtp_api_d14n",
+  "xmtp_macro",
 ]
 
 # Make the feature resolver explicit.
@@ -49,6 +50,7 @@ ed25519 = "2.2.3"
 ed25519-dalek = { version = "2.1.1", features = ["zeroize"] }
 ethers = { version = "2.0", default-features = false }
 fdlimit = "0.3"
+rstest = "0.25"
 futures = { version = "0.3.30", default-features = false }
 getrandom = { version = "0.2", default-features = false }
 arc-swap = "1.7"
@@ -112,6 +114,7 @@ xmtp_cryptography = { path = "xmtp_cryptography" }
 xmtp_id = { path = "xmtp_id" }
 xmtp_mls = { path = "xmtp_mls" }
 xmtp_proto = { path = "xmtp_proto" }
+xmtp_macro = { path = "xmtp_macro" }
 
 
 [profile.dev]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -16,6 +16,9 @@ web-time.workspace = true
 xmtp_cryptography.workspace = true
 
 # optional
+xmtp_macro = { workspace = true, optional = true }
+
+
 once_cell = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
 tracing-flame = { version = "0.2", optional = true }
@@ -37,6 +40,7 @@ web-sys = { workspace = true, features = ["Window"] }
 wasm-bindgen-futures.workspace = true
 wasm-bindgen.workspace = true
 tokio = { workspace = true, features = ["time", "sync"] }
+wasm-bindgen-test = { workspace = true, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio-stream = { workspace = true, features = ["time"] }
@@ -51,6 +55,7 @@ tracing-subscriber = { workspace = true, features = [
 ] }
 parking_lot.workspace = true
 once_cell.workspace = true
+xmtp_macro.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 tokio = { workspace = true, features = ["time", "macros", "rt", "sync"] }
@@ -76,6 +81,8 @@ test-utils = [
   "dep:console_error_panic_hook",
   "dep:tracing-forest",
   "dep:once_cell",
+  "dep:wasm-bindgen-test",
+  "dep:xmtp_macro",
 ]
 bench = [
   "test-utils",

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -7,6 +7,14 @@ mod test;
 #[cfg(any(test, feature = "test-utils"))]
 pub use test::*;
 
+#[allow(unused)]
+#[macro_use]
+extern crate xmtp_macro;
+
+#[doc(hidden)]
+#[cfg(any(test, feature = "test-utils"))]
+pub use xmtp_macro::test;
+
 #[cfg(feature = "bench")]
 pub mod bench;
 

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -7,11 +7,7 @@ mod test;
 #[cfg(any(test, feature = "test-utils"))]
 pub use test::*;
 
-#[allow(unused)]
-#[macro_use]
-extern crate xmtp_macro;
-
-#[doc(hidden)]
+#[doc(inline)]
 #[cfg(any(test, feature = "test-utils"))]
 pub use xmtp_macro::test;
 

--- a/common/src/retry.rs
+++ b/common/src/retry.rs
@@ -296,12 +296,12 @@ impl RetryBuilder<ExponentialBackoff, ()> {
 /// Builder for [`Retry`].
 ///
 /// # Example
-/// ```
+/// ```ignore
 /// use xmtp_common::retry::RetryBuilder;
 ///
 /// RetryBuilder::default()
 ///     .retries(5)
-///     .with_strategy(ExponentialBackoff::default())
+///     .with_strategy(xmtp_common::ExponentialBackoff::default())
 ///     .build();
 /// ```
 impl<S: Strategy, C: Strategy> RetryBuilder<S, C> {
@@ -463,10 +463,11 @@ macro_rules! retryable {
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use super::*;
+
     #[cfg(target_arch = "wasm32")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
-    use super::*;
     use thiserror::Error;
     use tokio::sync::mpsc;
 
@@ -493,8 +494,7 @@ pub(crate) mod tests {
         Err(SomeError::ARetryableError)
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_macro::test]
     async fn it_retries_twice_and_succeeds() {
         let mut i = 0;
         let mut test_fn = || -> Result<(), SomeError> {
@@ -509,8 +509,7 @@ pub(crate) mod tests {
         retry_async!(Retry::default(), (async { test_fn() })).unwrap();
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_macro::test]
     async fn it_works_with_random_args() {
         let mut i = 0;
         let list = vec!["String".into(), "Foo".into()];
@@ -525,8 +524,7 @@ pub(crate) mod tests {
         retry_async!(Retry::default(), (async { test_fn() })).unwrap();
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_macro::test]
     async fn it_fails_on_three_retries() {
         let closure = || -> Result<(), SomeError> {
             retry_error_fn()?;
@@ -537,8 +535,7 @@ pub(crate) mod tests {
         assert!(result.is_err())
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_macro::test]
     async fn it_only_runs_non_retryable_once() {
         let mut attempts = 0;
         let mut test_fn = || -> Result<(), SomeError> {
@@ -551,8 +548,7 @@ pub(crate) mod tests {
         assert_eq!(attempts, 1);
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_macro::test]
     async fn it_works_async() {
         async fn retryable_async_fn(rx: &mut mpsc::Receiver<usize>) -> Result<(), SomeError> {
             let val = rx.recv().await.unwrap();
@@ -577,8 +573,7 @@ pub(crate) mod tests {
         assert!(rx.is_empty());
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_macro::test]
     async fn it_works_async_mut() {
         async fn retryable_async_fn(data: &mut usize) -> Result<(), SomeError> {
             if *data == 2 {
@@ -598,8 +593,7 @@ pub(crate) mod tests {
         .unwrap();
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[xmtp_macro::test]
     fn backoff_retry() {
         let backoff_retry = Retry::default();
         let time_spent = crate::time::Instant::now();

--- a/common/src/wasm.rs
+++ b/common/src/wasm.rs
@@ -1,6 +1,9 @@
 use futures::{FutureExt, Stream, StreamExt};
 use std::{future::Future, pin::Pin, task::Poll};
 
+#[cfg(any(test, target_arch = "wasm32"))]
+pub use wasm_bindgen_test::wasm_bindgen_test as test;
+
 /// Global Marker trait for WebAssembly
 #[cfg(target_arch = "wasm32")]
 pub trait Wasm {}

--- a/common/src/wasm.rs
+++ b/common/src/wasm.rs
@@ -1,9 +1,6 @@
 use futures::{FutureExt, Stream, StreamExt};
 use std::{future::Future, pin::Pin, task::Poll};
 
-#[cfg(any(test, target_arch = "wasm32"))]
-pub use wasm_bindgen_test::wasm_bindgen_test as test;
-
 /// Global Marker trait for WebAssembly
 #[cfg(target_arch = "wasm32")]
 pub trait Wasm {}

--- a/dev/test/wasm-interactive
+++ b/dev/test/wasm-interactive
@@ -10,6 +10,7 @@ if [ -z "${1:-}" ]; then
 fi
 
 PACKAGE=$1
+TESTS=${2:-}
 
 export RUSTFLAGS="-Ctarget-feature=+bulk-memory,+mutable-globals,+atomics ${RUSTFLAGS:=}"
 export WASM_BINDGEN_TEST_ONLY_WEB=1
@@ -17,6 +18,7 @@ export NO_HEADLESS=1
 
 cargo test --target wasm32-unknown-unknown --release \
   -p $PACKAGE -- \
+  $TESTS \
   --skip xmtp_mls::storage::encrypted_store::group_message::tests::it_cannot_insert_message_without_group \
   --skip xmtp_mls::groups::tests::process_messages_abort_on_retryable_error \
   --skip  xmtp_mls::storage::encrypted_store::group::tests::test_find_groups \

--- a/nix/filesets.nix
+++ b/nix/filesets.nix
@@ -16,6 +16,7 @@ let
     (commonCargoSources ./../xmtp_proto)
     (commonCargoSources ./../common)
     (commonCargoSources ./../xmtp_content_types)
+    (commonCargoSources ./../xmtp_macro)
     ./../xmtp_id/src/scw_verifier/chain_urls_default.json
     ./../xmtp_id/artifact
     ./../xmtp_mls/migrations

--- a/nix/libxmtp.nix
+++ b/nix/libxmtp.nix
@@ -11,6 +11,7 @@
 , gnuplot
 , flamegraph
 , cargo-flamegraph
+, cargo-expand
 , inferno
 , openssl
 , sqlcipher
@@ -83,6 +84,7 @@ mkShell {
       gnuplot
       flamegraph
       cargo-flamegraph
+      cargo-expand
       inferno
       lnav
 

--- a/xmtp_macro/Cargo.toml
+++ b/xmtp_macro/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "xmtp_macro"
+edition = "2024"
+license.workspace = true
+version.workspace = true
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "2.0", default-features = false, features = [
+  "parsing",
+  "proc-macro",
+  "derive",
+  "printing",
+] }
+
+[lib]
+proc-macro = true
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test.workspace = true

--- a/xmtp_macro/README.md
+++ b/xmtp_macro/README.md
@@ -1,0 +1,1 @@
+# Utility Macros for XMTP Crates

--- a/xmtp_macro/src/lib.rs
+++ b/xmtp_macro/src/lib.rs
@@ -8,6 +8,7 @@ use quote::quote;
 /// On wasm32 architecture, it delegates to `wasm_bindgen_test::wasm_bindgen_test`.
 /// On all other architectures, it delegates to `tokio::test`.
 ///
+/// When using with 'rstest', ensure any other test invocations come after rstest invocation.
 /// # Example
 ///
 /// ```ignore

--- a/xmtp_macro/src/lib.rs
+++ b/xmtp_macro/src/lib.rs
@@ -50,14 +50,12 @@ pub fn test(
         #[cfg_attr(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")), wasm_bindgen_test::wasm_bindgen_test)]
     });
 
-    if attributes.flavor.is_some() && attributes.r#async {
-        let flavor = attributes.flavor.expect("checked for none");
+    if attributes.r#async {
+        let flavor = attributes
+            .flavor
+            .unwrap_or(syn::LitStr::new("current_thread", Span::call_site()));
         tokens.extend(quote!{
             #[cfg_attr(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))), tokio::test(flavor = #flavor))]
-        });
-    } else if attributes.r#async {
-        tokens.extend(quote!{
-            #[cfg_attr(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))), tokio::test(flavor = "current_thread"))]
         });
     } else {
         tokens.extend(quote!{

--- a/xmtp_macro/src/lib.rs
+++ b/xmtp_macro/src/lib.rs
@@ -33,7 +33,7 @@ pub fn test(
 
     // Skip over other attributes to `fn #ident ...`, and extract `#ident`
     let mut leading_tokens = Vec::new();
-    while let Some(token) = body.next() {
+    for token in body.by_ref() {
         leading_tokens.push(token.clone());
         if let TokenTree::Ident(token) = token {
             if token == "async" {
@@ -81,18 +81,10 @@ fn find_ident(iter: &mut impl Iterator<Item = TokenTree>) -> Option<Ident> {
     }
 }
 
+#[derive(Default)]
 struct Attributes {
     r#async: bool,
     flavor: Option<syn::LitStr>,
-}
-
-impl Default for Attributes {
-    fn default() -> Self {
-        Self {
-            r#async: false,
-            flavor: None,
-        }
-    }
 }
 
 impl Attributes {

--- a/xmtp_macro/src/lib.rs
+++ b/xmtp_macro/src/lib.rs
@@ -1,0 +1,110 @@
+extern crate proc_macro;
+
+use proc_macro2::*;
+use quote::quote;
+
+/// A test macro that delegates to the appropriate test framework based on the target architecture.
+///
+/// On wasm32 architecture, it delegates to `wasm_bindgen_test::wasm_bindgen_test`.
+/// On all other architectures, it delegates to `tokio::test`.
+///
+/// # Example
+///
+/// ```ignore
+/// #[test]
+/// async fn test_something() {
+///     assert_eq!(2 + 2, 4);
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn test(
+    attr: proc_macro::TokenStream,
+    body: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    // Parse the input function
+    let mut attributes = Attributes::default();
+    let attribute_parser = syn::meta::parser(|meta| attributes.parse(meta));
+    let mut tokens = Vec::<TokenTree>::new();
+
+    syn::parse_macro_input!(attr with attribute_parser);
+
+    let mut body = TokenStream::from(body).into_iter().peekable();
+
+    // Skip over other attributes to `fn #ident ...`, and extract `#ident`
+    let mut leading_tokens = Vec::new();
+    while let Some(token) = body.next() {
+        leading_tokens.push(token.clone());
+        if let TokenTree::Ident(token) = token {
+            if token == "async" {
+                attributes.r#async = true;
+            }
+            if token == "fn" {
+                break;
+            }
+        }
+    }
+
+    let ident = find_ident(&mut body).expect("expected a function name");
+
+    tokens.extend( quote! {
+        #[cfg_attr(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")), wasm_bindgen_test::wasm_bindgen_test)]
+    });
+
+    if attributes.flavor.is_some() && attributes.r#async {
+        let flavor = attributes.flavor.expect("checked for none");
+        tokens.extend(quote!{
+            #[cfg_attr(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))), tokio::test(flavor = #flavor))]
+        });
+    } else if attributes.r#async {
+        tokens.extend(quote!{
+            #[cfg_attr(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))), tokio::test(flavor = "current_thread"))]
+        });
+    } else {
+        tokens.extend(quote!{
+            #[cfg_attr(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))), test)]
+        });
+    }
+
+    tokens.extend(leading_tokens);
+    tokens.push(ident.into());
+    tokens.extend(body);
+    // Return the modified token stream
+    tokens.into_iter().collect::<TokenStream>().into()
+}
+
+fn find_ident(iter: &mut impl Iterator<Item = TokenTree>) -> Option<Ident> {
+    match iter.next()? {
+        TokenTree::Ident(i) => Some(i),
+        TokenTree::Group(g) if g.delimiter() == Delimiter::None => {
+            find_ident(&mut g.stream().into_iter())
+        }
+        _ => None,
+    }
+}
+
+struct Attributes {
+    r#async: bool,
+    flavor: Option<syn::LitStr>,
+}
+
+impl Default for Attributes {
+    fn default() -> Self {
+        Self {
+            r#async: false,
+            flavor: None,
+        }
+    }
+}
+
+impl Attributes {
+    fn parse(&mut self, meta: syn::meta::ParseNestedMeta) -> syn::parse::Result<()> {
+        if meta.path.is_ident("async") {
+            self.r#async = true;
+        } else if meta.path.is_ident("flavor") {
+            self.flavor = Some(meta.value()?.parse::<syn::LitStr>()?);
+        } else {
+            return Err(meta.error("unknown attribute"));
+        }
+        Ok(())
+    }
+}

--- a/xmtp_macro/tests/integration.rs
+++ b/xmtp_macro/tests/integration.rs
@@ -1,0 +1,14 @@
+#[xmtp_macro::test]
+async fn try_test() {
+    println!("t");
+}
+
+#[xmtp_macro::test]
+fn try_test_sync() {
+    println!("t");
+}
+
+#[xmtp_macro::test(flavor = "multi_thread")]
+async fn try_test_flavor() {
+    println!("t");
+}

--- a/xmtp_mls/Cargo.toml
+++ b/xmtp_mls/Cargo.toml
@@ -148,6 +148,7 @@ openmls = { workspace = true, features = ["js"] }
 tokio = { workspace = true, features = ["macros", "rt", "time"] }
 wasm-bindgen-futures.workspace = true
 web-sys.workspace = true
+
 [dev-dependencies]
 anyhow.workspace = true
 const_format.workspace = true
@@ -160,6 +161,7 @@ xmtp_id = { path = "../xmtp_id", features = ["test-utils"] }
 xmtp_proto = { workspace = true, features = ["test-utils"] }
 fdlimit = { workspace = true }
 once_cell.workspace = true
+rstest = { workspace = true, features = ["async-timeout"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 ctor.workspace = true

--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -328,8 +328,7 @@ pub(crate) mod tests {
         (buf, address.to_lowercase())
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn builder_test() {
         let wallet = generate_local_wallet();
         let client = ClientBuilder::new_test_client(&wallet).await;
@@ -337,8 +336,7 @@ pub(crate) mod tests {
     }
 
     // Test client creation using various identity strategies that creates new inboxes
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn test_client_creation() {
         struct IdentityStrategyTestCase {
             strategy: IdentityStrategy,
@@ -447,8 +445,7 @@ pub(crate) mod tests {
     // - create client2 from same db with [IdentityStrategy::CachedOnly]
     // - create client3 from same db with [IdentityStrategy::CreateIfNotFound]
     // - create client4 with different db.
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn test_2nd_time_client_creation() {
         let (legacy_key, legacy_account_address) = generate_random_legacy_key().await;
         let legacy_ident = Identifier::eth(&legacy_account_address).unwrap();
@@ -516,8 +513,7 @@ pub(crate) mod tests {
     }
 
     // Should return error if inbox associated with given account_address doesn't match the provided one.
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn api_identity_mismatch() {
         let mut mock_api = MockApiClient::new();
         let tmpdb = tmp_path();
@@ -560,8 +556,7 @@ pub(crate) mod tests {
     }
 
     // Use the account_address associated inbox
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn api_identity_happy_path() {
         let mut mock_api = MockApiClient::new();
         let tmpdb = tmp_path();
@@ -603,8 +598,7 @@ pub(crate) mod tests {
     }
 
     // Use a stored identity as long as the inbox_id matches the one provided.
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn stored_identity_happy_path() {
         let mock_api = MockApiClient::new();
         let tmpdb = tmp_path();
@@ -638,8 +632,7 @@ pub(crate) mod tests {
             .is_ok());
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn stored_identity_mismatch() {
         let mock_api = MockApiClient::new();
         let scw_verifier = MockSmartContractSignatureVerifier::new(true);
@@ -681,8 +674,7 @@ pub(crate) mod tests {
         );
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn identity_persistence_test() {
         let tmpdb = tmp_path();
         let wallet = &generate_local_wallet();

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -1079,8 +1079,7 @@ pub(crate) mod tests {
         XmtpApi,
     };
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn test_group_member_recovery() {
         let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bola_wallet = generate_local_wallet();
@@ -1107,8 +1106,7 @@ pub(crate) mod tests {
         assert_eq!(members.len(), 2);
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn test_mls_error() {
         let client = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let result = client
@@ -1121,8 +1119,7 @@ pub(crate) mod tests {
         assert!(error_string.contains("invalid identity"));
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn test_register_installation() {
         let wallet = generate_local_wallet();
         let client = ClientBuilder::new_test_client(&wallet).await;
@@ -1172,8 +1169,7 @@ pub(crate) mod tests {
         assert_ne!(init1, init2);
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn test_find_groups() {
         let client = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let group_1 = client
@@ -1189,8 +1185,7 @@ pub(crate) mod tests {
         assert!(groups.iter().any(|g| g.group_id == group_2.group_id));
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn test_find_inbox_id() {
         let wallet = generate_local_wallet();
         let client = ClientBuilder::new_test_client(&wallet).await;
@@ -1522,8 +1517,7 @@ pub(crate) mod tests {
         serialize_key_package_hash_ref(&kp_result.inner, &client.mls_provider()?)
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn test_key_package_rotation() {
         let alix_wallet = generate_local_wallet();
         let bo_wallet = generate_local_wallet();
@@ -1599,8 +1593,7 @@ pub(crate) mod tests {
         assert!(bo_original_after_delete.is_err());
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn test_find_or_create_dm_by_inbox_id() {
         let user1 = generate_local_wallet();
         let user2 = generate_local_wallet();
@@ -1649,8 +1642,7 @@ pub(crate) mod tests {
         assert_eq!(conversations[0].group_id, dm1.group_id);
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn should_stream_consent() {
         let alix_wallet = generate_local_wallet();
         let bo_wallet = generate_local_wallet();

--- a/xmtp_mls/src/groups/device_sync/backup.rs
+++ b/xmtp_mls/src/groups/device_sync/backup.rs
@@ -95,11 +95,7 @@ mod tests {
     use std::{path::Path, sync::Arc};
     use xmtp_cryptography::utils::generate_local_wallet;
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(
-        not(target_arch = "wasm32"),
-        tokio::test(flavor = "multi_thread", worker_threads = 1)
-    )]
+    #[xmtp_common::test]
     async fn test_buffer_export_import() {
         use futures::io::BufReader;
         use futures_util::AsyncReadExt;

--- a/xmtp_mls/src/groups/device_sync/consent_sync.rs
+++ b/xmtp_mls/src/groups/device_sync/consent_sync.rs
@@ -24,7 +24,6 @@ where
 pub(crate) mod tests {
     #[cfg(target_arch = "wasm32")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-    use wasm_bindgen_test::wasm_bindgen_test;
 
     const HISTORY_SERVER_HOST: &str = "localhost";
     const HISTORY_SERVER_PORT: u16 = 5558;
@@ -42,7 +41,7 @@ pub(crate) mod tests {
     use xmtp_cryptography::utils::generate_local_wallet;
     use xmtp_id::associations::test_utils::WalletTestExt;
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "multi_thread", worker_threads = 1))]
+    #[xmtp_common::test]
     #[cfg_attr(target_family = "wasm", ignore)]
     async fn test_consent_sync() {
         let history_sync_url = format!("http://{}:{}", HISTORY_SERVER_HOST, HISTORY_SERVER_PORT);

--- a/xmtp_mls/src/groups/device_sync/message_sync.rs
+++ b/xmtp_mls/src/groups/device_sync/message_sync.rs
@@ -58,7 +58,7 @@ pub(crate) mod tests {
     use xmtp_cryptography::utils::generate_local_wallet;
     use xmtp_id::associations::test_utils::WalletTestExt;
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "multi_thread", worker_threads = 1))]
+    #[xmtp_common::test]
     #[cfg_attr(target_family = "wasm", ignore)]
     async fn test_message_history_sync() {
         let wallet = generate_local_wallet();
@@ -146,7 +146,7 @@ pub(crate) mod tests {
         .unwrap();
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "multi_thread", worker_threads = 1))]
+    #[xmtp_common::test]
     async fn test_sync_continues_during_db_disconnect() {
         let wallet = generate_local_wallet();
         let amal_a = ClientBuilder::new_test_client_with_history(&wallet, HISTORY_SYNC_URL).await;
@@ -208,7 +208,7 @@ pub(crate) mod tests {
         assert_ne!(old_group_id, new_group_id);
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "multi_thread", worker_threads = 1))]
+    #[xmtp_common::test]
     async fn test_prepare_groups_to_sync() {
         let wallet = generate_local_wallet();
         let amal_a = ClientBuilder::new_test_client(&wallet).await;
@@ -225,7 +225,7 @@ pub(crate) mod tests {
         assert_eq!(result.len(), 2);
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "multi_thread", worker_threads = 1))]
+    #[xmtp_common::test]
     async fn test_externals_cant_join_sync_group() {
         let wallet = generate_local_wallet();
         let amal = ClientBuilder::new_test_client_with_history(&wallet, HISTORY_SYNC_URL).await;

--- a/xmtp_mls/src/groups/device_sync/preference_sync.rs
+++ b/xmtp_mls/src/groups/device_sync/preference_sync.rs
@@ -97,7 +97,6 @@ mod tests {
         storage::consent_record::{ConsentState, ConsentType},
     };
     use crypto_utils::generate_local_wallet;
-    use wasm_bindgen_test::wasm_bindgen_test;
 
     #[derive(Serialize, Deserialize, Clone)]
     #[repr(i32)]
@@ -105,7 +104,7 @@ mod tests {
         ConsentUpdate(StoredConsentRecord) = 1,
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "multi_thread", worker_threads = 1))]
+    #[xmtp_common::test]
     async fn test_can_deserialize_between_versions() {
         let consent_record = StoredConsentRecord {
             entity: "hello there".to_string(),
@@ -122,7 +121,7 @@ mod tests {
         assert_eq!(update.state, ConsentState::Allowed);
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "multi_thread", worker_threads = 1))]
+    #[xmtp_common::test]
     async fn test_hmac_sync() {
         let wallet = generate_local_wallet();
         let amal_a =

--- a/xmtp_mls/src/groups/group_membership.rs
+++ b/xmtp_mls/src/groups/group_membership.rs
@@ -150,8 +150,7 @@ pub(crate) mod tests {
 
     use super::GroupMembership;
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[xmtp_common::test]
     fn test_equality_works() {
         let inbox_id_1 = "inbox_1".to_string();
         let sequence_id_1: u64 = 1;
@@ -170,8 +169,7 @@ pub(crate) mod tests {
         assert!(member_map_1.ne(&member_map_2));
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[xmtp_common::test]
     fn test_diff() {
         let mut initial_members = GroupMembership::new();
         initial_members.add("inbox_1".into(), 1);

--- a/xmtp_mls/src/groups/group_permissions.rs
+++ b/xmtp_mls/src/groups/group_permissions.rs
@@ -1459,8 +1459,7 @@ pub(crate) mod tests {
 
     /// Tests that a commit by a non admin/super admin can add and remove members
     /// with allow policies.
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[xmtp_common::test]
     fn test_allow_all() {
         let permissions = PolicySet::new(
             MembershipPolicies::allow(),
@@ -1484,8 +1483,7 @@ pub(crate) mod tests {
     }
 
     /// Tests that a commit by a non admin/super admin is denied for add and remove member policies.
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[xmtp_common::test]
     fn test_deny() {
         let permissions = PolicySet::new(
             MembershipPolicies::deny(),
@@ -1520,8 +1518,7 @@ pub(crate) mod tests {
     }
 
     /// Tests that a group creator can perform super admin actions.
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[xmtp_common::test]
     fn test_actor_is_creator() {
         let permissions = PolicySet::new(
             MembershipPolicies::allow_if_actor_super_admin(),
@@ -1568,8 +1565,7 @@ pub(crate) mod tests {
     }
 
     /// Tests that and conditions are enforced as expected.
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[xmtp_common::test]
     fn test_and_condition() {
         let permissions = PolicySet::new(
             MembershipPolicies::and(vec![
@@ -1596,8 +1592,7 @@ pub(crate) mod tests {
     }
 
     /// Tests that any conditions are enforced as expected.
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[xmtp_common::test]
     fn test_any_condition() {
         let permissions = PolicySet::new(
             MembershipPolicies::any(vec![
@@ -1624,8 +1619,7 @@ pub(crate) mod tests {
     }
 
     /// Tests that the PolicySet can be serialized and deserialized.
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[xmtp_common::test]
     fn test_serialize() {
         let permissions = PolicySet::new(
             MembershipPolicies::any(vec![
@@ -1653,8 +1647,7 @@ pub(crate) mod tests {
     }
 
     /// Tests that the PolicySet can enforce update group name policy.
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[xmtp_common::test]
     /// Tests that the PolicySet can enforce update group name policy.
     fn test_update_group_name() {
         let allow_permissions = PolicySet::new(
@@ -1691,8 +1684,7 @@ pub(crate) mod tests {
     }
 
     /// Tests that the preconfigured policy functions work as expected
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[xmtp_common::test]
     fn test_preconfigured_policy() {
         let group_permissions = GroupMutablePermissions::new(default_policy());
 
@@ -1713,8 +1705,7 @@ pub(crate) mod tests {
     }
 
     /// Tests that the preconfigured policy functions work as expected with new metadata fields.
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[xmtp_common::test]
     fn test_preconfigured_policy_equality_new_metadata() {
         let mut metadata_policies_map = MetadataPolicies::default_map(MetadataPolicies::allow());
         metadata_policies_map.insert("new_metadata_field".to_string(), MetadataPolicies::allow());
@@ -1748,8 +1739,7 @@ pub(crate) mod tests {
     }
 
     /// Tests that the permission update policy is enforced as expected.
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[xmtp_common::test]
     fn test_permission_update() {
         let permissions = PolicySet::new(
             MembershipPolicies::allow(),
@@ -1770,8 +1760,7 @@ pub(crate) mod tests {
     }
 
     /// Tests that the PolicySet can evaluate field updates with unknown policies.
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[xmtp_common::test]
     fn test_evaluate_field_with_unknown_policy() {
         // Create a group whose default metadata can be updated by any member
         let permissions = PolicySet::new(
@@ -1848,8 +1837,7 @@ pub(crate) mod tests {
         assert!(permissions.evaluate_commit(&non_existing_field_updated_commit));
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[xmtp_common::test]
     fn test_dm_group_permissions() {
         // Simulate a group with DM Permissions
         let permissions = PolicySet::new_dm();

--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -2060,8 +2060,7 @@ pub(crate) mod tests {
         }
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test(flavor = "multi_thread"))]
+    #[xmtp_common::test]
     async fn hmac_keys_work_as_expected() {
         let wallet = generate_local_wallet();
         let amal = Arc::new(ClientBuilder::new_test_client(&wallet).await);

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -2192,7 +2192,7 @@ pub(crate) mod tests {
             .unwrap();
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn test_send_message() {
         let wallet = generate_local_wallet();
         let client = ClientBuilder::new_test_client(&wallet).await;
@@ -2209,7 +2209,7 @@ pub(crate) mod tests {
         assert_eq!(messages.len(), 2);
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn test_receive_self_message() {
         let wallet = generate_local_wallet();
         let client = ClientBuilder::new_test_client(&wallet).await;
@@ -2229,8 +2229,7 @@ pub(crate) mod tests {
         assert_eq!(messages.first().unwrap().decrypted_message_bytes, msg);
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn test_receive_message_from_other() {
         let alix = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bo = ClientBuilder::new_test_client(&generate_local_wallet()).await;
@@ -2262,7 +2261,7 @@ pub(crate) mod tests {
     }
 
     // Test members function from non group creator
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn test_members_func_from_non_creator() {
         let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
@@ -2318,7 +2317,7 @@ pub(crate) mod tests {
 
     // Amal and Bola will both try and add Charlie from the same epoch.
     // The group should resolve to a consistent state
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn test_add_member_conflict() {
         let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
@@ -2464,7 +2463,7 @@ pub(crate) mod tests {
         });
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn test_dm_stitching() {
         let alix_wallet = generate_local_wallet();
         let alix = ClientBuilder::new_test_client(&alix_wallet).await;
@@ -2536,7 +2535,7 @@ pub(crate) mod tests {
         assert_eq!(msg, "No, let's use this dm");
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn test_add_inbox() {
         let client = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let client_2 = ClientBuilder::new_test_client(&generate_local_wallet()).await;
@@ -2894,7 +2893,8 @@ pub(crate) mod tests {
             "Bola_2 should have no DM group due to malformed key package"
         );
     }
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+
+    #[xmtp_common::test]
     async fn test_add_invalid_member() {
         let client = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let group = client
@@ -2906,7 +2906,7 @@ pub(crate) mod tests {
         assert!(result.is_err());
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn test_add_unregistered_member() {
         let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let unconnected_ident = Identifier::rand_ethereum();
@@ -2918,7 +2918,7 @@ pub(crate) mod tests {
         assert!(result.is_err());
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn test_remove_inbox() {
         let client_1 = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         // Add another client onto the network
@@ -2956,7 +2956,7 @@ pub(crate) mod tests {
         assert_eq!(messages.len(), 2);
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn test_key_update() {
         let client = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bola_client = ClientBuilder::new_test_client(&generate_local_wallet()).await;
@@ -3000,7 +3000,7 @@ pub(crate) mod tests {
         assert_eq!(bola_messages.len(), 1);
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn test_post_commit() {
         let client = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let client_2 = ClientBuilder::new_test_client(&generate_local_wallet()).await;
@@ -3023,7 +3023,7 @@ pub(crate) mod tests {
         assert_eq!(welcome_messages.len(), 1);
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn test_remove_by_account_address() {
         let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bola_wallet = &generate_local_wallet();
@@ -3071,7 +3071,7 @@ pub(crate) mod tests {
             .unwrap())
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn test_removed_members_cannot_send_message_to_others() {
         let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bola_wallet = &generate_local_wallet();
@@ -3135,7 +3135,7 @@ pub(crate) mod tests {
         assert!(amal_messages.is_empty());
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn test_add_missing_installations() {
         // Setup for test
         let amal_wallet = generate_local_wallet();
@@ -3172,7 +3172,7 @@ pub(crate) mod tests {
         assert_eq!(num_members, 3);
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "multi_thread", worker_threads = 10))]
+    #[xmtp_common::test(flavor = "multi_thread")]
     async fn test_self_resolve_epoch_mismatch() {
         let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
@@ -3222,7 +3222,7 @@ pub(crate) mod tests {
         assert!(expected_latest_message.eq(&dave_latest_message.decrypted_message_bytes));
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn test_group_permissions() {
         let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
@@ -3248,7 +3248,7 @@ pub(crate) mod tests {
             .is_err(),);
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn test_group_options() {
         let expected_group_message_disappearing_settings =
             MessageDisappearingSettings::new(100, 200);
@@ -3309,7 +3309,7 @@ pub(crate) mod tests {
         );
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     #[ignore]
     async fn test_max_limit_add() {
         let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
@@ -3334,7 +3334,7 @@ pub(crate) mod tests {
             .is_err(),);
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn test_group_mutable_data() {
         let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
@@ -3426,7 +3426,7 @@ pub(crate) mod tests {
         assert_eq!(bola_group_name, "New Group Name 1");
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn test_update_policies_empty_group() {
         let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bola_wallet = generate_local_wallet();
@@ -3493,7 +3493,7 @@ pub(crate) mod tests {
         assert_eq!(group_name_2, "New Group Name 2");
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn test_update_group_image_url_square() {
         let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
@@ -3531,7 +3531,7 @@ pub(crate) mod tests {
         assert_eq!(amal_group_image_url, "a url");
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test(flavor = "current_thread")]
     async fn test_update_group_message_expiration_settings() {
         let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
@@ -3593,7 +3593,7 @@ pub(crate) mod tests {
         );
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test(flavor = "current_thread")]
     async fn test_group_mutable_data_group_permissions() {
         let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bola_wallet = generate_local_wallet();
@@ -3682,7 +3682,7 @@ pub(crate) mod tests {
         assert_eq!(amal_group_name, "New Group Name 2");
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn test_group_admin_list_update() {
         let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bola_wallet = generate_local_wallet();
@@ -3801,7 +3801,7 @@ pub(crate) mod tests {
             .expect_err("expected err");
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn test_group_super_admin_list_update() {
         let bola_wallet = generate_local_wallet();
         let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
@@ -3912,7 +3912,7 @@ pub(crate) mod tests {
             .expect_err("expected err");
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn test_group_members_permission_level_update() {
         let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
@@ -4009,7 +4009,7 @@ pub(crate) mod tests {
         assert_eq!(count_member, 0, "no members have no admin status");
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn test_staged_welcome() {
         // Create Clients
         let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
@@ -4052,7 +4052,7 @@ pub(crate) mod tests {
         );
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn test_can_read_group_creator_inbox_id() {
         let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let policy_set = Some(PreconfiguredPolicies::Default.to_policy_set());
@@ -4079,7 +4079,7 @@ pub(crate) mod tests {
         assert_eq!(protected_metadata.creator_inbox_id, amal.inbox_id());
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn test_can_update_gce_after_failed_commit() {
         // Step 1: Amal creates a group
         let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
@@ -4147,7 +4147,7 @@ pub(crate) mod tests {
         assert_eq!(bola_group_name, "Name Update 2");
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn test_can_update_permissions_after_group_creation() {
         let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let policy_set = Some(PreconfiguredPolicies::AdminsOnly.to_policy_set());
@@ -4212,7 +4212,7 @@ pub(crate) mod tests {
         assert_eq!(members.len(), 3);
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn test_optimistic_send() {
         let amal = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
         let bola_wallet = generate_local_wallet();
@@ -4302,7 +4302,7 @@ pub(crate) mod tests {
         );
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn test_dm_creation() {
         let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
@@ -4372,7 +4372,7 @@ pub(crate) mod tests {
         assert!(!is_bola_super_admin);
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn process_messages_abort_on_retryable_error() {
         let alix = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bo = ClientBuilder::new_test_client(&generate_local_wallet()).await;
@@ -4424,7 +4424,7 @@ pub(crate) mod tests {
         }
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn skip_already_processed_messages() {
         let alix = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
@@ -4474,7 +4474,7 @@ pub(crate) mod tests {
             .any(|err| err.to_string().contains("already processed")));
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "multi_thread", worker_threads = 5))]
+    #[xmtp_common::test(flavor = "multi_thread")]
     async fn test_parallel_syncs() {
         let wallet = generate_local_wallet();
         let alix1 = Arc::new(ClientBuilder::new_test_client(&wallet).await);
@@ -4577,7 +4577,7 @@ pub(crate) mod tests {
      * We need to be safe even in situations where there are multiple
      * intents that do the same thing, leading to conflicts
      */
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "multi_thread", worker_threads = 5))]
+    #[xmtp_common::test(flavor = "multi_thread")]
     async fn add_missing_installs_reentrancy() {
         let wallet = generate_local_wallet();
         let alix1 = ClientBuilder::new_test_client(&wallet).await;
@@ -4654,7 +4654,7 @@ pub(crate) mod tests {
             .any(|m| m.decrypted_message_bytes == "hi from alix1".as_bytes()));
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "multi_thread", worker_threads = 5))]
+    #[xmtp_common::test(flavor = "multi_thread")]
     async fn respect_allow_epoch_increment() {
         let wallet = generate_local_wallet();
         let client = ClientBuilder::new_test_client(&wallet).await;
@@ -4693,7 +4693,7 @@ pub(crate) mod tests {
         );
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test)]
+    #[xmtp_common::test]
     async fn test_get_and_set_consent() {
         let alix = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
@@ -4752,7 +4752,7 @@ pub(crate) mod tests {
         assert_eq!(caro_group.consent_state().unwrap(), ConsentState::Allowed);
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test)]
+    #[xmtp_common::test]
     // TODO(rich): Generalize the test once fixed - test messages that are 0, 1, 2, 3, 4, 5 epochs behind
     async fn test_max_past_epochs() {
         // Create group with two members
@@ -4936,7 +4936,7 @@ pub(crate) mod tests {
         ));
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn test_respects_character_limits_for_group_metadata() {
         let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
@@ -5051,7 +5051,7 @@ pub(crate) mod tests {
         }
     }
 
-    #[test]
+    #[xmtp_common::test]
     fn test_increment_patch_version() {
         assert_eq!(increment_patch_version("1.2.3"), Some("1.2.4".to_string()));
         assert_eq!(increment_patch_version("0.0.9"), Some("0.0.10".to_string()));
@@ -5067,7 +5067,7 @@ pub(crate) mod tests {
         assert_eq!(increment_patch_version("invalid"), None);
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn test_can_set_min_supported_protocol_version_for_commit() {
         // Step 1: Create two clients, amal is one version ahead of bo
         let mut amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
@@ -5136,7 +5136,7 @@ pub(crate) mod tests {
         assert_eq!(messages.len(), 4);
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn test_client_on_old_version_pauses_after_joining_min_version_group() {
         // Step 1: Create three clients, amal and bo are one version ahead of caro
         let mut amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
@@ -5238,7 +5238,7 @@ pub(crate) mod tests {
         );
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn test_only_super_admins_can_set_min_supported_protocol_version() {
         let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bo = ClientBuilder::new_test_client(&generate_local_wallet()).await;
@@ -5314,7 +5314,7 @@ pub(crate) mod tests {
         assert_eq!(min_version.unwrap(), amal.version_info().pkg_version());
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn test_send_message_while_paused_after_welcome_returns_expected_error() {
         // Create two clients with different versions
         let mut amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
@@ -5363,7 +5363,7 @@ pub(crate) mod tests {
         }
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn test_send_message_after_min_version_update_gets_expected_error() {
         // Create two clients with different versions
         let mut amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;

--- a/xmtp_mls/src/groups/subscriptions.rs
+++ b/xmtp_mls/src/groups/subscriptions.rs
@@ -143,8 +143,8 @@ pub(crate) mod tests {
         }
     }
 
-    #[xmtp_common::test(flavor = "current_thread")]
     #[rstest::rstest]
+    #[xmtp_common::test(flavor = "current_thread")]
     #[timeout(Duration::from_secs(5))]
     async fn test_subscribe_messages() {
         let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
@@ -179,8 +179,8 @@ pub(crate) mod tests {
     }
 
     // TODO: THIS TESTS ALSO LOSES MESSAGES
-    #[xmtp_common::test(flavor = "multi_thread")]
     #[rstest::rstest]
+    #[xmtp_common::test(flavor = "multi_thread")]
     #[timeout(Duration::from_secs(5))]
     #[cfg_attr(target_arch = "wasm32", ignore)]
     async fn test_subscribe_multiple() {
@@ -211,8 +211,8 @@ pub(crate) mod tests {
         }
     }
 
-    #[xmtp_common::test]
     #[rstest::rstest]
+    #[xmtp_common::test]
     #[timeout(Duration::from_secs(5))]
     async fn test_subscribe_membership_changes() {
         let amal = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);

--- a/xmtp_mls/src/groups/subscriptions.rs
+++ b/xmtp_mls/src/groups/subscriptions.rs
@@ -102,11 +102,14 @@ pub(crate) mod tests {
         builder::ClientBuilder, groups::GroupMetadataOptions,
         storage::group_message::GroupMessageKind,
     };
+    use std::time::Duration;
     use xmtp_cryptography::utils::generate_local_wallet;
 
     use futures::StreamExt;
 
+    #[rstest::rstest]
     #[xmtp_common::test]
+    #[timeout(Duration::from_secs(5))]
     async fn test_decode_group_message_bytes() {
         let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
@@ -141,6 +144,8 @@ pub(crate) mod tests {
     }
 
     #[xmtp_common::test(flavor = "current_thread")]
+    #[rstest::rstest]
+    #[timeout(Duration::from_secs(5))]
     async fn test_subscribe_messages() {
         let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bola = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
@@ -175,6 +180,8 @@ pub(crate) mod tests {
 
     // TODO: THIS TESTS ALSO LOSES MESSAGES
     #[xmtp_common::test(flavor = "multi_thread")]
+    #[rstest::rstest]
+    #[timeout(Duration::from_secs(5))]
     #[cfg_attr(target_arch = "wasm32", ignore)]
     async fn test_subscribe_multiple() {
         let amal = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
@@ -205,6 +212,8 @@ pub(crate) mod tests {
     }
 
     #[xmtp_common::test]
+    #[rstest::rstest]
+    #[timeout(Duration::from_secs(5))]
     async fn test_subscribe_membership_changes() {
         let amal = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
         let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;

--- a/xmtp_mls/src/groups/subscriptions.rs
+++ b/xmtp_mls/src/groups/subscriptions.rs
@@ -105,9 +105,8 @@ pub(crate) mod tests {
     use xmtp_cryptography::utils::generate_local_wallet;
 
     use futures::StreamExt;
-    use wasm_bindgen_test::wasm_bindgen_test;
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "multi_thread", worker_threads = 10))]
+    #[xmtp_common::test]
     async fn test_decode_group_message_bytes() {
         let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
@@ -141,7 +140,7 @@ pub(crate) mod tests {
         }
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test(flavor = "current_thread")]
     async fn test_subscribe_messages() {
         let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bola = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
@@ -175,7 +174,7 @@ pub(crate) mod tests {
     }
 
     // TODO: THIS TESTS ALSO LOSES MESSAGES
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "multi_thread", worker_threads = 10))]
+    #[xmtp_common::test(flavor = "multi_thread")]
     #[cfg_attr(target_arch = "wasm32", ignore)]
     async fn test_subscribe_multiple() {
         let amal = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
@@ -205,7 +204,7 @@ pub(crate) mod tests {
         }
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn test_subscribe_membership_changes() {
         let amal = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
         let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;

--- a/xmtp_mls/src/identity_updates.rs
+++ b/xmtp_mls/src/identity_updates.rs
@@ -674,8 +674,7 @@ pub(crate) mod tests {
         assert!(is_member);
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn create_inbox_round_trip() {
         let wallet = generate_local_wallet();
         let wallet_ident = wallet.identifier();
@@ -701,8 +700,7 @@ pub(crate) mod tests {
         assert!(association_state.get(&wallet_ident.into()).is_some())
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn add_association() {
         let wallet = generate_local_wallet();
         let wallet_2 = generate_local_wallet();
@@ -796,8 +794,7 @@ pub(crate) mod tests {
         });
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn load_identity_updates_if_needed() {
         let wallet = generate_local_wallet();
         let client = ClientBuilder::new_test_client(&wallet).await;
@@ -814,8 +811,7 @@ pub(crate) mod tests {
         assert_eq!(filtered.unwrap(), vec!["inbox_1"]);
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn get_installation_diff() {
         let wallet_1 = generate_local_wallet();
         let wallet_2 = generate_local_wallet();
@@ -922,8 +918,7 @@ pub(crate) mod tests {
             .contains(&client_2_installation_key.to_vec()));
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     pub async fn revoke_wallet() {
         let recovery_wallet = generate_local_wallet();
         let second_wallet = generate_local_wallet();
@@ -979,8 +974,7 @@ pub(crate) mod tests {
         assert_eq!(inbox_ids.len(), 0);
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     pub async fn revoke_installation() {
         let wallet = generate_local_wallet();
         let client1: FullXmtpClient = ClientBuilder::new_test_client(&wallet).await;

--- a/xmtp_mls/src/storage/encrypted_store/association_state.rs
+++ b/xmtp_mls/src/storage/encrypted_store/association_state.rs
@@ -119,8 +119,7 @@ pub(crate) mod tests {
 
     use super::*;
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn test_batch_read() {
         with_connection(|conn| {
             let association_state = AssociationState::new(

--- a/xmtp_mls/src/storage/encrypted_store/consent_record.rs
+++ b/xmtp_mls/src/storage/encrypted_store/consent_record.rs
@@ -219,8 +219,7 @@ mod tests {
         }
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn insert_and_read() {
         with_connection(|conn| {
             let inbox_id = "inbox_1";

--- a/xmtp_mls/src/storage/encrypted_store/conversation_list.rs
+++ b/xmtp_mls/src/storage/encrypted_store/conversation_list.rs
@@ -183,9 +183,8 @@ pub(crate) mod tests {
     use crate::storage::group_message::ContentType;
     use crate::storage::tests::with_connection;
     use crate::Store;
-    use wasm_bindgen_test::wasm_bindgen_test;
 
-    #[wasm_bindgen_test(unsupported = tokio::test)]
+    #[xmtp_common::test]
     async fn test_single_group_multiple_messages() {
         with_connection(|conn| {
             // Create a group
@@ -221,7 +220,8 @@ pub(crate) mod tests {
         })
         .await
     }
-    #[wasm_bindgen_test(unsupported = tokio::test)]
+
+    #[xmtp_common::test]
     async fn test_three_groups_specific_ordering() {
         with_connection(|conn| {
             // Create three groups
@@ -262,7 +262,8 @@ pub(crate) mod tests {
         })
         .await
     }
-    #[wasm_bindgen_test(unsupported = tokio::test)]
+
+    #[xmtp_common::test]
     async fn test_group_with_newer_message_update() {
         with_connection(|conn| {
             // Create a group
@@ -313,8 +314,7 @@ pub(crate) mod tests {
         .await
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn test_find_conversations_by_consent_state() {
         with_connection(|conn| {
             let test_group_1 = generate_group(Some(GroupMembershipState::Allowed));

--- a/xmtp_mls/src/storage/encrypted_store/group.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group.rs
@@ -797,8 +797,7 @@ pub(crate) mod tests {
         )
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn test_it_stores_group() {
         with_connection(|conn| {
             let test_group = generate_group(None);
@@ -813,8 +812,7 @@ pub(crate) mod tests {
         .await
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn test_it_fetches_group() {
         with_connection(|conn| {
             let test_group = generate_group(None);
@@ -832,8 +830,7 @@ pub(crate) mod tests {
         .await
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn test_it_updates_group_membership_state() {
         with_connection(|conn| {
             let test_group = generate_group(Some(GroupMembershipState::Pending));
@@ -854,8 +851,7 @@ pub(crate) mod tests {
         .await
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn test_dm_stitching() {
         with_connection(|conn| {
             let dm1 = StoredGroup::new(
@@ -893,8 +889,7 @@ pub(crate) mod tests {
         .await;
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn test_find_groups() {
         with_connection(|conn| {
             let test_group_1 = generate_group(Some(GroupMembershipState::Pending));
@@ -974,8 +969,7 @@ pub(crate) mod tests {
         .await
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn test_installations_last_checked_is_updated() {
         with_connection(|conn| {
             let test_group = generate_group(None);
@@ -997,8 +991,7 @@ pub(crate) mod tests {
         .await
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn test_new_group_has_correct_purpose() {
         with_connection(|conn| {
             let test_group = generate_group(None);
@@ -1018,8 +1011,7 @@ pub(crate) mod tests {
         .await
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn test_new_sync_group() {
         with_connection(|conn| {
             let id = rand_vec::<24>();
@@ -1051,8 +1043,7 @@ pub(crate) mod tests {
         .await
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn test_find_groups_by_consent_state() {
         with_connection(|conn| {
             let test_group_1 = generate_group(Some(GroupMembershipState::Allowed));
@@ -1120,8 +1111,7 @@ pub(crate) mod tests {
         .await
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn test_get_group_welcome_ids() {
         with_connection(|conn| {
             let mls_groups = vec![

--- a/xmtp_mls/src/storage/encrypted_store/group_intent.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group_intent.rs
@@ -487,8 +487,7 @@ pub(crate) mod tests {
         .unwrap()
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn test_store_and_fetch() {
         let group_id = rand_vec::<24>();
         let data = rand_vec::<24>();
@@ -521,8 +520,7 @@ pub(crate) mod tests {
         .await
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn test_query() {
         let group_id = rand_vec::<24>();
 
@@ -601,8 +599,7 @@ pub(crate) mod tests {
         .await
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn find_by_payload_hash() {
         let group_id = rand_vec::<24>();
 
@@ -645,8 +642,7 @@ pub(crate) mod tests {
         .await
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn test_happy_path_state_transitions() {
         let group_id = rand_vec::<24>();
 
@@ -692,8 +688,7 @@ pub(crate) mod tests {
         .await
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn test_republish_state_transition() {
         let group_id = rand_vec::<24>();
 
@@ -738,8 +733,7 @@ pub(crate) mod tests {
         .await
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn test_invalid_state_transition() {
         let group_id = rand_vec::<24>();
 
@@ -775,8 +769,7 @@ pub(crate) mod tests {
         .await
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn test_increment_publish_attempts() {
         let group_id = rand_vec::<24>();
         with_connection(|conn| {

--- a/xmtp_mls/src/storage/encrypted_store/group_message.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group_message.rs
@@ -486,7 +486,6 @@ pub(crate) mod tests {
         storage::encrypted_store::{group::tests::generate_group, tests::with_connection},
         Store,
     };
-    use wasm_bindgen_test::wasm_bindgen_test;
     use xmtp_common::{assert_err, assert_ok, rand_time, rand_vec};
     use xmtp_content_types::should_push;
 
@@ -513,7 +512,7 @@ pub(crate) mod tests {
         }
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test)]
+    #[xmtp_common::test]
     async fn it_does_not_error_on_empty_messages() {
         with_connection(|conn| {
             let id = vec![0x0];
@@ -522,7 +521,7 @@ pub(crate) mod tests {
         .await
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test)]
+    #[xmtp_common::test]
     async fn it_gets_messages() {
         with_connection(|conn| {
             let group = generate_group(None);
@@ -538,7 +537,7 @@ pub(crate) mod tests {
         .await
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test)]
+    #[xmtp_common::test]
     async fn it_cannot_insert_message_without_group() {
         use diesel::result::{DatabaseErrorKind::ForeignKeyViolation, Error::DatabaseError};
 
@@ -552,7 +551,7 @@ pub(crate) mod tests {
         .await
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test)]
+    #[xmtp_common::test]
     async fn it_gets_many_messages() {
         use crate::storage::encrypted_store::schema::group_messages::dsl;
 
@@ -587,7 +586,7 @@ pub(crate) mod tests {
         .await
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test)]
+    #[xmtp_common::test]
     async fn it_gets_messages_by_time() {
         with_connection(|conn| {
             let group = generate_group(None);
@@ -638,7 +637,7 @@ pub(crate) mod tests {
         .await
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test)]
+    #[xmtp_common::test]
     async fn it_deletes_middle_message_by_expiration_time() {
         with_connection(|conn| {
             let mut group = generate_group(None);
@@ -681,7 +680,7 @@ pub(crate) mod tests {
         .await
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test)]
+    #[xmtp_common::test]
     async fn it_gets_messages_by_kind() {
         with_connection(|conn| {
             let group = generate_group(None);
@@ -736,7 +735,7 @@ pub(crate) mod tests {
         .await
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test)]
+    #[xmtp_common::test]
     async fn it_orders_messages_by_sent() {
         with_connection(|conn| {
             let group = generate_group(None);
@@ -784,7 +783,7 @@ pub(crate) mod tests {
         .await
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test)]
+    #[xmtp_common::test]
     async fn it_gets_messages_by_content_type() {
         with_connection(|conn| {
             let group = generate_group(None);

--- a/xmtp_mls/src/storage/encrypted_store/identity.rs
+++ b/xmtp_mls/src/storage/encrypted_store/identity.rs
@@ -74,8 +74,7 @@ pub(crate) mod tests {
     use crate::Store;
     use xmtp_common::rand_vec;
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn can_only_store_one_identity() {
         let store = EncryptedMessageStore::new(
             StorageOption::Ephemeral,

--- a/xmtp_mls/src/storage/encrypted_store/identity_cache.rs
+++ b/xmtp_mls/src/storage/encrypted_store/identity_cache.rs
@@ -115,8 +115,7 @@ pub(crate) mod tests {
     use xmtp_id::associations::Identifier;
 
     // Test storing duplicated wallets (same inbox_id and wallet_address)
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn test_store_duplicated_wallets() {
         with_connection(|conn| {
             let entry1 = IdentityCache {
@@ -140,8 +139,7 @@ pub(crate) mod tests {
     }
 
     // Test storing and fetching multiple wallet addresses with multiple keys
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn test_fetch_and_store_identity_cache() {
         with_connection(|conn| {
             let ident1 = Identifier::rand_ethereum();

--- a/xmtp_mls/src/storage/encrypted_store/identity_update.rs
+++ b/xmtp_mls/src/storage/encrypted_store/identity_update.rs
@@ -145,8 +145,7 @@ pub(crate) mod tests {
         )
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn insert_and_read() {
         with_connection(|conn| {
             let inbox_id = "inbox_1";
@@ -171,8 +170,7 @@ pub(crate) mod tests {
         .await;
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn test_filter() {
         with_connection(|conn| {
             let inbox_id = "inbox_1";
@@ -205,8 +203,7 @@ pub(crate) mod tests {
         .await
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn test_get_latest_sequence_id() {
         with_connection(|conn| {
             let inbox_1 = "inbox_1";
@@ -242,8 +239,7 @@ pub(crate) mod tests {
         .await
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn get_single_sequence_id() {
         with_connection(|conn| {
             let inbox_id = "inbox_1";

--- a/xmtp_mls/src/storage/encrypted_store/key_package_history.rs
+++ b/xmtp_mls/src/storage/encrypted_store/key_package_history.rs
@@ -96,8 +96,7 @@ mod tests {
     #[cfg(target_arch = "wasm32")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn test_store_key_package_history_entry() {
         with_connection(|conn| {
             let hash_ref = rand_vec::<24>();
@@ -117,8 +116,7 @@ mod tests {
         .await
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn test_store_multiple() {
         with_connection(|conn| {
             let hash_ref1 = rand_vec::<24>();

--- a/xmtp_mls/src/storage/encrypted_store/mod.rs
+++ b/xmtp_mls/src/storage/encrypted_store/mod.rs
@@ -396,7 +396,6 @@ pub(crate) mod tests {
     use diesel::sql_types::{BigInt, Blob, Integer, Text};
     use group::ConversationType;
     use schema::groups;
-    use wasm_bindgen_test::wasm_bindgen_test;
 
     use super::*;
     use crate::{
@@ -433,7 +432,7 @@ pub(crate) mod tests {
         }
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test)]
+    #[xmtp_common::test]
     async fn ephemeral_store() {
         let store = EncryptedMessageStore::new(
             StorageOption::Ephemeral,
@@ -451,7 +450,7 @@ pub(crate) mod tests {
         assert_eq!(fetched_identity.inbox_id, inbox_id);
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test)]
+    #[xmtp_common::test]
     async fn persistent_store() {
         let db_path = tmp_path();
         {
@@ -504,7 +503,7 @@ pub(crate) mod tests {
         EncryptedMessageStore::remove_db_files(db_path)
     }
 
-    #[wasm_bindgen_test::wasm_bindgen_test(unsupported = tokio::test)]
+    #[xmtp_common::test]
     async fn test_dm_id_migration() {
         let db_path = tmp_path();
         let opts = StorageOption::Persistent(db_path.clone());
@@ -619,7 +618,7 @@ pub(crate) mod tests {
         EncryptedMessageStore::remove_db_files(db_path)
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test)]
+    #[xmtp_common::test]
     async fn encrypted_db_with_multiple_connections() {
         let db_path = tmp_path();
         {

--- a/xmtp_mls/src/storage/encrypted_store/refresh_state.rs
+++ b/xmtp_mls/src/storage/encrypted_store/refresh_state.rs
@@ -133,8 +133,7 @@ pub(crate) mod tests {
     use super::*;
     use crate::{storage::encrypted_store::tests::with_connection, Store};
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn get_cursor_with_no_existing_state() {
         with_connection(|conn| {
             let id = vec![1, 2, 3];
@@ -148,8 +147,7 @@ pub(crate) mod tests {
         .await
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn get_timestamp_with_existing_state() {
         with_connection(|conn| {
             let id = vec![1, 2, 3];
@@ -165,8 +163,7 @@ pub(crate) mod tests {
         .await
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn update_timestamp_when_bigger() {
         with_connection(|conn| {
             let id = vec![1, 2, 3];
@@ -184,8 +181,7 @@ pub(crate) mod tests {
         .await
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn dont_update_timestamp_when_smaller() {
         with_connection(|conn| {
             let entity_id = vec![1, 2, 3];
@@ -205,8 +201,7 @@ pub(crate) mod tests {
         .await
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn allow_installation_and_welcome_same_id() {
         with_connection(|conn| {
             let entity_id = vec![1, 2, 3];

--- a/xmtp_mls/src/storage/encrypted_store/user_preferences.rs
+++ b/xmtp_mls/src/storage/encrypted_store/user_preferences.rs
@@ -93,8 +93,7 @@ mod tests {
 
     use super::*;
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn test_insert_and_update_preferences() {
         let wallet = generate_local_wallet();
         let client = ClientBuilder::new_test_client(&wallet).await;

--- a/xmtp_mls/src/storage/sql_key_store.rs
+++ b/xmtp_mls/src/storage/sql_key_store.rs
@@ -1047,8 +1047,7 @@ pub(crate) mod tests {
     };
     use xmtp_common::tmp_path;
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn store_read_delete() {
         let db_path = tmp_path();
         let store = EncryptedMessageStore::new(
@@ -1097,8 +1096,7 @@ pub(crate) mod tests {
     impl Key<CURRENT_VERSION> for ProposalRef {}
     impl Entity<CURRENT_VERSION> for ProposalRef {}
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn list_append_remove() {
         let db_path = tmp_path();
         let store = EncryptedMessageStore::new(
@@ -1180,8 +1178,7 @@ pub(crate) mod tests {
         assert!(proposals_read.unwrap().is_empty());
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn group_state() {
         let db_path = tmp_path();
         let store = EncryptedMessageStore::new(

--- a/xmtp_mls/src/subscriptions/stream_all.rs
+++ b/xmtp_mls/src/subscriptions/stream_all.rs
@@ -121,9 +121,9 @@ mod tests {
     use xmtp_cryptography::utils::generate_local_wallet;
     use xmtp_id::associations::test_utils::WalletTestExt;
 
-    #[xmtp_common::test]
     #[rstest::rstest]
-    #[timeout(Duration::from_secs(5))]
+    #[xmtp_common::test]
+    #[timeout(Duration::from_secs(15))]
     async fn test_stream_all_messages_changing_group_list() {
         let alix = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bo = ClientBuilder::new_test_client(&generate_local_wallet()).await;

--- a/xmtp_mls/src/subscriptions/stream_all.rs
+++ b/xmtp_mls/src/subscriptions/stream_all.rs
@@ -118,11 +118,12 @@ mod tests {
     use futures::StreamExt;
     use std::sync::Arc;
     use std::time::Duration;
-    use wasm_bindgen_test::wasm_bindgen_test;
     use xmtp_cryptography::utils::generate_local_wallet;
     use xmtp_id::associations::test_utils::WalletTestExt;
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "multi_thread", worker_threads = 10))]
+    #[xmtp_common::test]
+    #[rstest::rstest]
+    #[timeout(Duration::from_secs(5))]
     async fn test_stream_all_messages_changing_group_list() {
         let alix = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bo = ClientBuilder::new_test_client(&generate_local_wallet()).await;
@@ -169,7 +170,9 @@ mod tests {
         assert_msg!(stream, "fifth");
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "multi_thread", worker_threads = 10))]
+    #[rstest::rstest]
+    #[xmtp_common::test]
+    #[timeout(Duration::from_secs(5))]
     async fn test_stream_all_messages_unchanging_group_list() {
         let alix = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bo = ClientBuilder::new_test_client(&generate_local_wallet()).await;
@@ -206,7 +209,9 @@ mod tests {
         assert_msg!(stream, "fourth");
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "multi_thread"))]
+    #[rstest::rstest]
+    #[xmtp_common::test]
+    #[timeout(Duration::from_secs(5))]
     async fn test_dm_stream_all_messages() {
         let alix = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bo = ClientBuilder::new_test_client(&generate_local_wallet()).await;
@@ -288,7 +293,9 @@ mod tests {
         counts
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "multi_thread"))]
+    #[rstest::rstest]
+    #[xmtp_common::test]
+    #[timeout(Duration::from_secs(15))]
     #[cfg_attr(target_arch = "wasm32", ignore)]
     async fn test_stream_all_messages_does_not_lose_messages() {
         xmtp_common::logger();
@@ -390,7 +397,9 @@ mod tests {
         assert_eq!(messages.len(), 45, "too many messages mean duplicates, too little means missed. Also ensure timeout is sufficient.");
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "multi_thread", worker_threads = 10))]
+    #[rstest::rstest]
+    #[xmtp_common::test]
+    #[timeout(Duration::from_secs(5))]
     async fn test_stream_all_messages_detached_group_changes() {
         let caro = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let hale = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);

--- a/xmtp_mls/src/subscriptions/stream_all.rs
+++ b/xmtp_mls/src/subscriptions/stream_all.rs
@@ -124,6 +124,7 @@ mod tests {
     #[rstest::rstest]
     #[xmtp_common::test]
     #[timeout(Duration::from_secs(15))]
+    #[cfg_attr(target_arch = "wasm32", ignore)]
     async fn test_stream_all_messages_changing_group_list() {
         let alix = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bo = ClientBuilder::new_test_client(&generate_local_wallet()).await;

--- a/xmtp_mls/src/subscriptions/stream_all.rs
+++ b/xmtp_mls/src/subscriptions/stream_all.rs
@@ -172,7 +172,7 @@ mod tests {
 
     #[rstest::rstest]
     #[xmtp_common::test]
-    #[timeout(Duration::from_secs(5))]
+    #[timeout(Duration::from_secs(15))]
     async fn test_stream_all_messages_unchanging_group_list() {
         let alix = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bo = ClientBuilder::new_test_client(&generate_local_wallet()).await;

--- a/xmtp_mls/src/subscriptions/stream_conversations.rs
+++ b/xmtp_mls/src/subscriptions/stream_conversations.rs
@@ -460,6 +460,8 @@ mod test {
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
     #[xmtp_common::test]
+    #[rstest::rstest]
+    #[timeout(std::time::Duration::from_secs(5))]
     async fn test_stream_welcomes() {
         let alice = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
         let bob = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
@@ -479,6 +481,8 @@ mod test {
     }
 
     #[xmtp_common::test]
+    #[rstest::rstest]
+    #[timeout(std::time::Duration::from_secs(5))]
     async fn test_dm_streaming() {
         let alix = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
         let bo = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
@@ -585,6 +589,8 @@ mod test {
     }
 
     #[xmtp_common::test]
+    #[rstest::rstest]
+    #[timeout(std::time::Duration::from_secs(5))]
     async fn test_self_group_creation() {
         let alix = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
         let bo = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);

--- a/xmtp_mls/src/subscriptions/stream_conversations.rs
+++ b/xmtp_mls/src/subscriptions/stream_conversations.rs
@@ -459,8 +459,8 @@ mod test {
     #[cfg(target_arch = "wasm32")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
-    #[xmtp_common::test]
     #[rstest::rstest]
+    #[xmtp_common::test]
     #[timeout(std::time::Duration::from_secs(5))]
     async fn test_stream_welcomes() {
         let alice = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
@@ -480,8 +480,8 @@ mod test {
         assert_eq!(bob_received_groups.group_id, group_id);
     }
 
-    #[xmtp_common::test]
     #[rstest::rstest]
+    #[xmtp_common::test]
     #[timeout(std::time::Duration::from_secs(5))]
     async fn test_dm_streaming() {
         let alix = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
@@ -588,8 +588,8 @@ mod test {
         assert_eq!(groups.len(), 3);
     }
 
-    #[xmtp_common::test]
     #[rstest::rstest]
+    #[xmtp_common::test]
     #[timeout(std::time::Duration::from_secs(5))]
     async fn test_self_group_creation() {
         let alix = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);

--- a/xmtp_mls/src/subscriptions/stream_conversations.rs
+++ b/xmtp_mls/src/subscriptions/stream_conversations.rs
@@ -454,13 +454,12 @@ mod test {
     use crate::storage::group::GroupQueryArgs;
 
     use futures::StreamExt;
-    use wasm_bindgen_test::wasm_bindgen_test;
     use xmtp_cryptography::utils::generate_local_wallet;
 
     #[cfg(target_arch = "wasm32")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn test_stream_welcomes() {
         let alice = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
         let bob = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
@@ -479,7 +478,7 @@ mod test {
         assert_eq!(bob_received_groups.group_id, group_id);
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "multi_thread"))]
+    #[xmtp_common::test]
     async fn test_dm_streaming() {
         let alix = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
         let bo = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
@@ -585,7 +584,7 @@ mod test {
         assert_eq!(groups.len(), 3);
     }
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "multi_thread"))]
+    #[xmtp_common::test]
     async fn test_self_group_creation() {
         let alix = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
         let bo = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);

--- a/xmtp_mls/src/subscriptions/stream_messages.rs
+++ b/xmtp_mls/src/subscriptions/stream_messages.rs
@@ -528,6 +528,8 @@ mod tests {
     use xmtp_cryptography::utils::generate_local_wallet;
 
     #[xmtp_common::test]
+    #[rstest::rstest]
+    #[timeout(std::time::Duration::from_secs(5))]
     async fn test_stream_messages() {
         let alice = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
         let bob = ClientBuilder::new_test_client(&generate_local_wallet()).await;

--- a/xmtp_mls/src/subscriptions/stream_messages.rs
+++ b/xmtp_mls/src/subscriptions/stream_messages.rs
@@ -527,8 +527,8 @@ mod tests {
     use crate::{builder::ClientBuilder, groups::GroupMetadataOptions};
     use xmtp_cryptography::utils::generate_local_wallet;
 
-    #[xmtp_common::test]
     #[rstest::rstest]
+    #[xmtp_common::test]
     #[timeout(std::time::Duration::from_secs(5))]
     async fn test_stream_messages() {
         let alice = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);

--- a/xmtp_mls/src/subscriptions/stream_messages.rs
+++ b/xmtp_mls/src/subscriptions/stream_messages.rs
@@ -522,13 +522,12 @@ mod tests {
     use std::sync::Arc;
 
     use futures::stream::StreamExt;
-    use wasm_bindgen_test::wasm_bindgen_test;
 
     use crate::assert_msg;
     use crate::{builder::ClientBuilder, groups::GroupMetadataOptions};
     use xmtp_cryptography::utils::generate_local_wallet;
 
-    #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
+    #[xmtp_common::test]
     async fn test_stream_messages() {
         let alice = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
         let bob = ClientBuilder::new_test_client(&generate_local_wallet()).await;


### PR DESCRIPTION
- adds `xmtp_common::test` macro which delegates to `tokio::test` the native `test` or `wasm_bindgen_test::wasm_bindgen_test` depending on async/sync/architecture


timeouts are able to be set for individual tests using `rstest` crate. Note, `rstest` invocation must come before `xmtp_common::test`:
```rust
#[rstest::rstest]
#[xmtp_common::test]
#[timeout(std::time::Duration::from_secs(10)]
fn my_test() {
}
```

This makes it possible to figure out which tests are hanging WASM in CI by annotating suspect tests with `#[timeout]`

closes https://github.com/xmtp/libxmtp/issues/1748