### PR TITLE
Fix d14n hosts in xdbg

### DIFF
--- a/xmtp_api_d14n/src/compat/d14n.rs
+++ b/xmtp_api_d14n/src/compat/d14n.rs
@@ -15,7 +15,7 @@ use xmtp_proto::traits::Client;
 use xmtp_proto::traits::{ApiClientError, Query};
 use xmtp_proto::v4_utils::{
     build_group_message_topic, build_identity_topic_from_hex_encoded, build_key_package_topic,
-    build_welcome_message_topic, extract_client_envelope, extract_unsigned_originator_envelope,
+    build_welcome_message_topic, Extract
 };
 use xmtp_proto::xmtp::identity::api::v1::get_identity_updates_response::{
     IdentityUpdateLog, Response,
@@ -196,49 +196,17 @@ where
         &self,
         request: mls_v1::QueryGroupMessagesRequest,
     ) -> Result<mls_v1::QueryGroupMessagesResponse, Self::Error> {
-        let query_envelopes = EnvelopesQuery {
-            topics: vec![build_group_message_topic(request.group_id.as_slice())],
-            originator_node_ids: Vec::new(), // todo: set later
-            last_seen: None,                 // todo: set later
-        };
-
-        let response_envelopes: QueryEnvelopesResponse = QueryEnvelope::builder()
+        let response: QueryEnvelopesResponse = QueryEnvelope::builder()
             .topic(build_group_message_topic(request.group_id.as_slice()))
             .build()?
             .query(&self.message_client)
             .await?;
 
-        let messages = response_envelopes
+        let messages = response
             .envelopes
             .into_iter()
-            .filter_map(|envelope| {
-                let unsigned_originator_envelope =
-                    extract_unsigned_originator_envelope(&envelope).ok()?;
-                let client_envelope = extract_client_envelope(&envelope).ok()?;
-                let payload = client_envelope.payload?;
-
-                if let Payload::GroupMessage(group_message) = payload {
-                    if let Some(mls_v1::group_message_input::Version::V1(v1_group_message)) =
-                        group_message.version
-                    {
-                        return Some(mls_v1::GroupMessage {
-                            version: Some(mls_v1::group_message::Version::V1(
-                                mls_v1::group_message::V1 {
-                                    id: unsigned_originator_envelope.originator_sequence_id,
-                                    created_ns: unsigned_originator_envelope.originator_ns as u64,
-                                    group_id: request.group_id.clone(),
-                                    data: v1_group_message.data,
-                                    sender_hmac: v1_group_message.sender_hmac,
-                                    should_push: v1_group_message.should_push,
-                                },
-                            )),
-                        });
-                    }
-                }
-
-                None
-            })
-            .collect::<Vec<_>>();
+            .map(mls_v1::GroupMessage::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
 
         Ok(mls_v1::QueryGroupMessagesResponse {
             messages,
@@ -250,50 +218,19 @@ where
         &self,
         request: mls_v1::QueryWelcomeMessagesRequest,
     ) -> Result<mls_v1::QueryWelcomeMessagesResponse, Self::Error> {
-        let query = EnvelopesQuery {
-            topics: vec![build_welcome_message_topic(
+        let response = QueryEnvelope::builder()
+            .topic(build_welcome_message_topic(
                 request.installation_key.as_slice(),
-            )],
-            originator_node_ids: vec![], // todo: set later
-            last_seen: None,             // todo: set later
-        };
-
-        let response_envelopes = QueryEnvelopes::builder()
-            .envelopes(query)
+            ))
             .build()?
             .query(&self.message_client)
             .await?;
 
-        let messages = response_envelopes
+        let messages = response
             .envelopes
             .into_iter()
-            .filter_map(|envelope| {
-                let unsigned_originator_envelope =
-                    extract_unsigned_originator_envelope(&envelope).ok()?;
-                let client_envelope = extract_client_envelope(&envelope).ok()?;
-                let payload = client_envelope.payload?;
-
-                if let Payload::WelcomeMessage(welcome_message) = payload {
-                    if let Some(mls_v1::welcome_message_input::Version::V1(v1_welcome_message)) =
-                        welcome_message.version
-                    {
-                        return Some(mls_v1::WelcomeMessage {
-                            version: Some(mls_v1::welcome_message::Version::V1(
-                                mls_v1::welcome_message::V1 {
-                                    id: unsigned_originator_envelope.originator_sequence_id,
-                                    created_ns: unsigned_originator_envelope.originator_ns as u64,
-                                    installation_key: request.installation_key.clone(),
-                                    data: v1_welcome_message.data,
-                                    hpke_public_key: v1_welcome_message.hpke_public_key,
-                                },
-                            )),
-                        });
-                    }
-                }
-
-                None
-            })
-            .collect::<Vec<_>>();
+            .map(mls_v1::WelcomeMessage::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
 
         Ok(mls_v1::QueryWelcomeMessagesResponse {
             messages,

--- a/xmtp_api_d14n/src/compat/d14n.rs
+++ b/xmtp_api_d14n/src/compat/d14n.rs
@@ -15,7 +15,7 @@ use xmtp_proto::traits::Client;
 use xmtp_proto::traits::{ApiClientError, Query};
 use xmtp_proto::v4_utils::{
     build_group_message_topic, build_identity_topic_from_hex_encoded, build_key_package_topic,
-    build_welcome_message_topic, Extract
+    build_welcome_message_topic, Extract,
 };
 use xmtp_proto::xmtp::identity::api::v1::get_identity_updates_response::{
     IdentityUpdateLog, Response,

--- a/xmtp_id/src/associations/serialization.rs
+++ b/xmtp_id/src/associations/serialization.rs
@@ -715,7 +715,7 @@ impl TryFrom<String> for AccountId {
             return Err(ConversionError::InvalidValue {
                 item: "eth account_id",
                 expected: "well-formed chain_id & address",
-                got: "chain_id/address did not pass validation",
+                got: "chain_id/address did not pass validation".to_string(),
             });
         }
 

--- a/xmtp_id/src/associations/serialization.rs
+++ b/xmtp_id/src/associations/serialization.rs
@@ -922,7 +922,7 @@ pub(crate) mod tests {
             Err(ConversionError::InvalidValue {
                 item: "eth account_id",
                 expected: "well-formed chain_id & address",
-                got: "chain_id/address did not pass validation"
+                ..
             })
         ));
     }

--- a/xmtp_proto/src/error.rs
+++ b/xmtp_proto/src/error.rs
@@ -234,7 +234,7 @@ pub enum ConversionError {
         /// description of the item expected, i.e 'a negative integer'
         expected: &'static str,
         /// description of the value received i.e 'a positive integer'
-        got: &'static str,
+        got: String,
     },
     #[error("decoding proto {0}")]
     Decode(#[from] prost::DecodeError),
@@ -249,6 +249,14 @@ pub enum ConversionError {
         // What is the value
         value: Option<String>,
     },
+    #[error("version not supported")]
+    InvalidVersion,
+    // TODO: Probably should not be apart of conversion,
+    // conversions using openml sshould be put further up the stack
+    #[error(transparent)]
+    OpenMls(#[from] openmls::prelude::Error),
+    #[error(transparent)]
+    Protocol(#[from] openmls::framing::errors::ProtocolMessageError),
 }
 
 /// Error resulting from proto conversions/mutations

--- a/xmtp_proto/src/impls.rs
+++ b/xmtp_proto/src/impls.rs
@@ -1,0 +1,13 @@
+/// Std implementations for some generated types
+use crate::xmtp::xmtpv4::envelopes::client_envelope::Payload;
+
+impl std::fmt::Display for Payload {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Payload::GroupMessage(_) => write!(f, "Payload::GroupMessage"),
+            Payload::WelcomeMessage(_) => write!(f, "Payload::WelcomeMessage"),
+            Payload::UploadKeyPackage(_) => write!(f, "Payload::UploadKeyPackage"),
+            Payload::IdentityUpdate(_) => write!(f, "Payload::IdentityUpdate"),
+        }
+    }
+}

--- a/xmtp_proto/src/lib.rs
+++ b/xmtp_proto/src/lib.rs
@@ -6,6 +6,7 @@ mod generated {
 pub use generated::*;
 
 mod error;
+mod impls;
 
 pub use error::*;
 


### PR DESCRIPTION
## Refactor GRPC client configuration in xdbg BackendOpts
Modified `BackendOpts::connect` method to create separate GRPC client configurations for payer and message services, with TLS settings derived from URL schemes instead of hardcoded values

### 📍Where to Start
The `connect` method implementation in `BackendOpts` struct at [args.rs](https://github.com/xmtp/libxmtp/pull/1774/files#diff-f5a20f8b0880b662184dc94120d482df9acbc8ceffc02f7e81c0d6a491d69ec3)

----

_[Macroscope](https://app.macroscope.com) summarized c74fece._