### PR TITLE
Do not set originator filter in d14n

### DIFF
--- a/xmtp_api_d14n/src/compat/d14n.rs
+++ b/xmtp_api_d14n/src/compat/d14n.rs
@@ -285,7 +285,7 @@ where
         let result: QueryEnvelopesResponse = QueryEnvelopes::builder()
             .envelopes(EnvelopesQuery {
                 topics: topics.clone(),
-                originator_node_ids: vec![], //todo: set later
+                originator_node_ids: vec![],
                 last_seen: None,             //todo: set later
             })
             .build()?

--- a/xmtp_api_d14n/src/endpoints/d14n/query_envelopes.rs
+++ b/xmtp_api_d14n/src/endpoints/d14n/query_envelopes.rs
@@ -12,9 +12,7 @@ use xmtp_proto::xmtp::xmtpv4::message_api::{QueryEnvelopesRequest, QueryEnvelope
 #[builder(build_fn(error = "BodyError"))]
 pub struct QueryEnvelope {
     #[builder(setter(each(name = "topic", into)))]
-    topics: Vec<Vec<u8>>,
-    #[builder(setter(into))]
-    originator_node_ids: Vec<u32>,
+    topics: Vec<Vec<u8>>
 }
 
 impl QueryEnvelope {
@@ -38,7 +36,7 @@ impl Endpoint for QueryEnvelope {
         let query = QueryEnvelopesRequest {
             query: Some(EnvelopesQuery {
                 topics: self.topics.clone(),
-                originator_node_ids: self.originator_node_ids.clone(),
+                originator_node_ids: vec![],
                 last_seen: None,
             }),
             limit: 0,


### PR DESCRIPTION
Originator filters can't be mixed with topic filters and most clients will want to filter by topic.

Originator filters are mostly designed for node2node sync.