### PR TITLE
No message dms should still stitch

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -7734,6 +7734,11 @@ mod tests {
             convo_bo_2.id(),
             "Conversations should match"
         );
+        assert_eq!(
+            convo_alix.id(),
+            convo_bo.id(),
+            "Conversations should get updated to match"
+        );
         assert_eq!(convo_alix.id(), topic_bo_same.id(), "Topics should match");
         assert_eq!(convo_alix.id(), topic_alix_same.id(), "Topics should match");
         let alix_dms = client_alix

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -7792,11 +7792,6 @@ mod tests {
         let client_bo = new_test_client_with_wallet(wallet_bo).await;
         let client_alix = new_test_client_with_wallet(wallet_alix).await;
 
-        let bo_provider = client_bo.inner_client.mls_provider().unwrap();
-        let bo_conn = bo_provider.conn_ref();
-        let alix_provider = client_alix.inner_client.mls_provider().unwrap();
-        let alix_conn = alix_provider.conn_ref();
-
         // Find or create DM conversations
         let convo_bo = client_bo
             .conversations()
@@ -7820,8 +7815,8 @@ mod tests {
             .await
             .unwrap();
 
-        let group_bo = bo_conn.find_group(&convo_bo.id()).unwrap().unwrap();
-        let group_alix = alix_conn.find_group(&convo_alix.id()).unwrap().unwrap();
-        assert_eq!(group_bo.id, group_alix.id, "Conversations should match");
+        let group_bo = client_bo.conversation(convo_bo.id()).unwrap();
+        let group_alix = client_alix.conversation(convo_alix.id()).unwrap();
+        assert_eq!(group_bo.id(), group_alix.id(), "Conversations should match");
     }
 }

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -2181,7 +2181,10 @@ impl FfiConversation {
 #[uniffi::export]
 impl FfiConversation {
     pub fn id(&self) -> Vec<u8> {
-        self.inner.group_id.clone()
+        match self.inner.client.stitched_group(&self.inner.group_id) {
+            Ok(group) => group.group_id.clone(),
+            Err(_) => self.inner.group_id.clone(),
+        }
     }
 }
 
@@ -7704,10 +7707,6 @@ mod tests {
             3,
             "Alix should see 3 messages after sync"
         );
-
-        let group_bo = bo_conn.find_group(&convo_bo.id()).unwrap().unwrap();
-        let group_alix = alix_conn.find_group(&convo_alix.id()).unwrap().unwrap();
-        assert!(group_bo.last_message_ns.unwrap() < group_alix.last_message_ns.unwrap());
 
         // Ensure conversations remain the same
         let convo_alix_2 = client_alix

--- a/bindings_node/src/conversation.rs
+++ b/bindings_node/src/conversation.rs
@@ -99,7 +99,10 @@ impl Conversation {
 
   #[napi]
   pub fn id(&self) -> String {
-    hex::encode(self.group_id.clone())
+    match self.inner_client.stitched_group(&self.group_id) {
+      Ok(group) => hex::encode(group.group_id.clone()),
+      Err(_) => hex::encode(self.group_id.clone()),
+    }
   }
 
   #[napi]

--- a/bindings_wasm/src/conversation.rs
+++ b/bindings_wasm/src/conversation.rs
@@ -131,7 +131,10 @@ impl From<MlsGroup<RustXmtpClient>> for Conversation {
 impl Conversation {
   #[wasm_bindgen]
   pub fn id(&self) -> String {
-    hex::encode(self.group_id.clone())
+    match self.inner_client.stitched_group(&self.group_id) {
+      Ok(group) => hex::encode(group.group_id.clone()),
+      Err(_) => hex::encode(self.group_id.clone()),
+    }
   }
 
   #[wasm_bindgen]

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -730,6 +730,7 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
                     dm_members,
                     disappearing_settings,
                     paused_for_version,
+                    None
                 ),
                 ConversationType::Dm => {
                     validate_dm_group(client, &mls_group, &added_by_inbox_id)?;
@@ -743,6 +744,7 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
                         dm_members,
                         disappearing_settings,
                         None,
+                        Some(welcome.created_ns as i64)
                     )
                 }
                 ConversationType::Sync => StoredGroup::new_from_welcome(
@@ -755,6 +757,7 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
                     dm_members,
                     disappearing_settings,
                     None,
+                    None
                 ),
             };
 

--- a/xmtp_mls/src/storage/encrypted_store/group.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group.rs
@@ -807,6 +807,7 @@ pub(crate) mod tests {
             None,
             None,
             None,
+            None,
         )
     }
 


### PR DESCRIPTION
Fixes https://github.com/xmtp/libxmtp/issues/1762
Fixes https://github.com/xmtp/libxmtp/issues/1763

DMs that have no messages in them should still stitch together. Selecting the group that was created last on the network not locally.
Once DMs are stitched their id should be updated in the local database.