### PR TITLE
fix: don't delete KeyPackages if processing the welcome messages fail

### DIFF
--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -908,7 +908,7 @@ where
             .await;
 
         // If processed groups equal to the number of envelopes we received, then delete old kps and rotate the keys
-        if num_envelopes == groups.len() {
+        if num_envelopes > 0 && num_envelopes == groups.len() {
             self.rotate_and_upload_key_package(provider).await?;
         }
 

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -907,8 +907,8 @@ where
             .collect()
             .await;
 
-        // If any welcomes were found, rotate your key package
-        if num_envelopes > 0 {
+        // If processed groups equal to the number of envelopes we received, then delete old kps and rotate the keys
+        if num_envelopes == groups.len() {
             self.rotate_and_upload_key_package(provider).await?;
         }
 


### PR DESCRIPTION
Fix not deleting the KeyPackages if processing welcome messages failed on some of the received ones.
closes #1786