### PR TITLE
Update workspace version for 1.1.1 patch release

### DIFF
--- a/.github/workflows/check-ios-android-bindings.yml
+++ b/.github/workflows/check-ios-android-bindings.yml
@@ -21,19 +21,16 @@ jobs:
         target:
           - x86_64-apple-darwin
           - aarch64-apple-darwin
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Nix
-        uses: cachix/install-nix-action@v31
+      - uses: DeterminateSystems/nix-installer-action@main
         with:
-          # Mostly to avoid GitHub rate limiting
-          extra_nix_config: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-      - uses: cachix/cachix-action@v16
-        with:
-          name: xmtp
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          determinate: true
+      - uses: DeterminateSystems/flakehub-cache-action@main
       - name: Cache
         uses: Swatinem/rust-cache@v2
         with:
@@ -45,6 +42,9 @@ jobs:
             cargo check --target ${{ matrix.target }} --manifest-path bindings_ffi/Cargo.toml
   check-android:
     runs-on: warp-ubuntu-latest-x64-16x
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -57,12 +57,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Nix
-        uses: cachix/install-nix-action@v31
+      - uses: DeterminateSystems/nix-installer-action@main
         with:
-          # Mostly to avoid GitHub rate limiting
-          extra_nix_config: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+          determinate: true
+      - uses: DeterminateSystems/flakehub-cache-action@main
       - uses: cachix/cachix-action@v16
         with:
           name: xmtp

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,7 +437,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_node"
-version = "1.0.0-rc1"
+version = "1.1.1"
 dependencies = [
  "futures",
  "hex",
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_wasm"
-version = "1.0.0-rc1"
+version = "1.1.1"
 dependencies = [
  "console_error_panic_hook",
  "futures",
@@ -7450,7 +7450,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api"
-version = "1.0.0-rc1"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "ctor",
@@ -7468,7 +7468,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_d14n"
-version = "1.0.0-rc1"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "ctor",
@@ -7489,7 +7489,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_grpc"
-version = "1.0.0-rc1"
+version = "1.1.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7511,7 +7511,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_http"
-version = "1.0.0-rc1"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7534,7 +7534,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_cli"
-version = "1.0.0-rc1"
+version = "1.1.1"
 dependencies = [
  "chrono",
  "clap",
@@ -7567,7 +7567,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_common"
-version = "1.0.0-rc1"
+version = "1.1.1"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -7599,7 +7599,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_content_types"
-version = "1.0.0-rc1"
+version = "1.1.1"
 dependencies = [
  "hex",
  "libsecp256k1",
@@ -7617,7 +7617,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_cryptography"
-version = "1.0.0-rc1"
+version = "1.1.1"
 dependencies = [
  "bincode",
  "curve25519-dalek",
@@ -7645,7 +7645,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_id"
-version = "1.0.0-rc1"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7681,7 +7681,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_macro"
-version = "1.0.0-rc1"
+version = "1.1.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7692,7 +7692,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_mls"
-version = "1.0.0-rc1"
+version = "1.1.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -7766,7 +7766,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_proto"
-version = "1.0.0-rc1"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "dynosaur",
@@ -7791,7 +7791,7 @@ dependencies = [
 
 [[package]]
 name = "xmtpv3"
-version = "1.0.0-rc1"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "coset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ resolver = "2"
 
 [workspace.package]
 license = "MIT"
-version = "1.0.0-rc1"
+version = "1.1.1"
 
 [workspace.dependencies]
 anyhow = "1.0"

--- a/bindings_node/CHANGELOG.md
+++ b/bindings_node/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @xmtp/node-bindings
 
+## 1.1.1
+
+- fix: don't delete Keypackages if processing the welcome messages fails
+
 ## 1.0.0
 
 - Improved DM stitching

--- a/bindings_node/package.json
+++ b/bindings_node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/node-bindings",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "repository": {
     "type": "git",
     "url": "git+https://git@github.com/xmtp/libxmtp.git",

--- a/bindings_wasm/CHANGELOG.md
+++ b/bindings_wasm/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @xmtp/wasm-bindings
 
+## 1.1.1
+
+- fix: don't delete Keypackages if processing the welcome messages fails
+
 ## 1.1.0
 
 - Added `inbox_state_from_inbox_ids` method to `Client`

--- a/bindings_wasm/package.json
+++ b/bindings_wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/wasm-bindings",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "license": "MIT",
   "description": "WASM bindings for the libXMTP rust library",

--- a/dev/check-android
+++ b/dev/check-android
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -eou pipefail
+
+nix develop .#android --command \
+    cargo check --target x86_64-linux-android --manifest-path bindings_ffi/Cargo.toml

--- a/dev/check-swift
+++ b/dev/check-swift
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -eou pipefail
+
+nix develop . --command \
+  cargo check --target aarch64-apple-darwin --manifest-path bindings_ffi/Cargo.toml


### PR DESCRIPTION
## Update workspace and package versions to 1.1.1 with CI improvements
Version bump from 1.0.0-rc1/1.1.0 to 1.1.1 across workspace packages and bindings. Replaced Cachix with DeterminateSystems tools in CI workflow. Added new development scripts for checking Android and iOS bindings compilation. Updated changelogs with fix for keypackage deletion behavior.

### 📍Where to Start
The CI workflow changes in [.github/workflows/check-ios-android-bindings.yml](https://github.com/xmtp/libxmtp/pull/1792/files#diff-8f0c89ef7a3c2697b238f6afa2f692ff8c87fb8b96c9c329ad347cd0f583947fR0), followed by the new development scripts [dev/check-android](https://github.com/xmtp/libxmtp/pull/1792/files#diff-17428734e000aa8d2651e6d3b4e4d465e665464f65f4721bec7f602734c14f6aR0) and [dev/check-swift](https://github.com/xmtp/libxmtp/pull/1792/files#diff-c8c1e55a0752eb359264f208fdcb086c2a566b00754695317a17f4108e1a2ebcR0)

----

_[Macroscope](https://app.macroscope.com) summarized 58bb611._