### PR TITLE
Recreate Fork

### DIFF
--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -13,6 +13,9 @@ pub(super) mod mls_sync;
 pub(super) mod subscriptions;
 pub mod validated_commit;
 
+#[cfg(test)]
+pub mod test_utils;
+
 use self::device_sync::DeviceSyncError;
 pub use self::group_permissions::PreconfiguredPolicies;
 use self::scoped_client::ScopedGroupClient;

--- a/xmtp_mls/src/groups/test_utils.rs
+++ b/xmtp_mls/src/groups/test_utils.rs
@@ -1,0 +1,20 @@
+use crate::storage::group_message::MsgQueryArgs;
+
+use super::{scoped_client::ScopedGroupClient, MlsGroup};
+use anyhow::Result;
+
+impl<Client: ScopedGroupClient> MlsGroup<Client> {
+    pub async fn test_can_talk_with(&self, other: &Self) -> Result<()> {
+        let msg = xmtp_common::rand_string::<20>();
+        self.send_message(msg.as_bytes()).await?;
+
+        other.sync().await?;
+        let mut other_msgs = other.find_messages(&MsgQueryArgs::default())?;
+        assert_eq!(
+            msg.as_bytes(),
+            other_msgs.pop().unwrap().decrypted_message_bytes
+        );
+
+        Ok(())
+    }
+}

--- a/xmtp_mls/src/utils/test/mod.rs
+++ b/xmtp_mls/src/utils/test/mod.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::unwrap_used)]
 
+pub mod tester;
+
 use std::{
     future::Future,
     sync::{

--- a/xmtp_mls/src/utils/test/tester.rs
+++ b/xmtp_mls/src/utils/test/tester.rs
@@ -1,0 +1,41 @@
+use ethers::signers::LocalWallet;
+use std::ops::Deref;
+use xmtp_cryptography::utils::generate_local_wallet;
+
+use crate::{builder::ClientBuilder, storage::xmtp_openmls_provider::XmtpOpenMlsProvider};
+
+use super::FullXmtpClient;
+
+/// A test client wrapper that auto-exposes all of the usual component access boilerplate.
+/// Makes testing easier and less repetetive.
+pub(crate) struct Tester {
+    pub wallet: LocalWallet,
+    pub client: FullXmtpClient,
+    pub provider: XmtpOpenMlsProvider,
+    // pub worker: Arc<WorkerHandle<SyncMetric>>,
+}
+
+impl Tester {
+    pub(crate) async fn new() -> Self {
+        let wallet = generate_local_wallet();
+        Self::new_from_wallet(wallet).await
+    }
+    pub(crate) async fn new_from_wallet(wallet: LocalWallet) -> Self {
+        let client = ClientBuilder::new_test_client(&wallet).await;
+        let provider = client.mls_provider().unwrap();
+
+        Self {
+            wallet,
+            client,
+            provider,
+        }
+    }
+}
+
+impl Deref for Tester {
+    type Target = FullXmtpClient;
+
+    fn deref(&self) -> &Self::Target {
+        &self.client
+    }
+}


### PR DESCRIPTION
## Add MLS client forking support and test utilities
Added support for multiple client installations (forking) in MLS groups with test utilities. New `Tester` struct for client management, `test_can_talk_with` utility for group communication verification, and a test demonstrating multi-device message synchronization.

### 📍Where to Start
Start with the `try_to_fork()` test function in [client.rs](https://github.com/xmtp/libxmtp/pull/1798/files#diff-de70260a705fef3f5acbf08315526f295274489e927dda73901d024f09d418fcR0) which demonstrates the core forking functionality, then review the new `Tester` implementation in [tester.rs](https://github.com/xmtp/libxmtp/pull/1798/files#diff-f92919048d8a2c3c8ada9b621e60c41263274024ab58090c380dc5ca7271e96bR0)

----

_[Macroscope](https://app.macroscope.com) summarized 90b6491._