### PR TITLE
Hot Fix Key Package Error

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -7110,4 +7110,35 @@ mod tests {
             assert_eq!(decoded.url, original.url);
         }
     }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
+    async fn test_can_add_installation_with_a_bad_key_package() {
+        let alix_client = new_dev_test_client().await;
+        let bo_client = new_dev_test_client().await;
+        let group = alix_client
+            .conversations()
+            .create_group_with_inbox_ids(
+                vec![
+                    "f87420435131ea1b911ad66fbe4b626b107f81955da023d049f8aef6636b8e1b".to_string(),
+                ],
+                FfiCreateGroupOptions::default(),
+            )
+            .await
+            .unwrap();
+
+        group
+            .add_members(vec![bo_client.account_address.clone()])
+            .await
+            .unwrap();
+        bo_client
+            .conversations()
+            .sync_all_conversations(None)
+            .await
+            .unwrap();
+        let bo_groups = bo_client
+            .conversations()
+            .list_groups(FfiListConversationsOptions::default())
+            .unwrap();
+        assert_eq!(bo_groups.len(), 1);
+    }
 }

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -899,8 +899,8 @@ where
             .collect()
             .await;
 
-        // If any welcomes were found, rotate your key package
-        if num_envelopes > 0 {
+        // If processed groups equal to the number of envelopes we received, then delete old kps and rotate the keys
+        if num_envelopes > 0 && num_envelopes == groups.len() {
             self.rotate_and_upload_key_package(provider).await?;
         }
 

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -856,9 +856,8 @@ where
         let crypto_provider = XmtpOpenMlsProvider::new_crypto();
 
         let results: HashMap<Vec<u8>, Result<VerifiedKeyPackageV2, KeyPackageVerificationError>> =
-            installation_ids
+            key_package_results
                 .iter()
-                .zip(key_package_results.values())
                 .map(|(id, bytes)| {
                     (
                         id.clone(),
@@ -1200,6 +1199,62 @@ pub(crate) mod tests {
         assert_eq!(groups.len(), 2);
         assert_eq!(groups[0].group_id, group_1.group_id);
         assert_eq!(groups[1].group_id, group_2.group_id);
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[cfg_attr(
+        not(target_arch = "wasm32"),
+        tokio::test(flavor = "multi_thread", worker_threads = 2)
+    )]
+    async fn double_dms() {
+        let alice_wallet = generate_local_wallet();
+        let alice = ClientBuilder::new_test_client(&alice_wallet).await;
+        let alice_provider = alice.mls_provider().unwrap();
+        let bob = ClientBuilder::new_test_client(&generate_local_wallet()).await;
+
+        let alice_dm = alice
+            .create_dm_by_inbox_id(bob.inbox_id().to_string(), DMMetadataOptions::default())
+            .await
+            .unwrap();
+        alice_dm.send_message(b"Welcome 1").await.unwrap();
+
+        let bob_dm = bob
+            .create_dm_by_inbox_id(alice.inbox_id().to_string(), DMMetadataOptions::default())
+            .await
+            .unwrap();
+
+        let alice2 = ClientBuilder::new_test_client(&alice_wallet).await;
+        let alice2_provider = alice2.mls_provider().unwrap();
+        let alice_dm2 = alice
+            .create_dm_by_inbox_id(bob.inbox_id().to_string(), DMMetadataOptions::default())
+            .await
+            .unwrap();
+        alice_dm2.send_message(b"Welcome 2").await.unwrap();
+
+        alice_dm.update_installations().await.unwrap();
+        alice.sync_welcomes(&alice_provider).await.unwrap();
+
+        alice_dm.send_message(b"Welcome from 1").await.unwrap();
+
+        bob_dm.send_message(b"Bob says hi 1").await.unwrap();
+
+        alice2.sync_welcomes(&alice2_provider).await.unwrap();
+        let groups = alice2
+            .find_groups(GroupQueryArgs {
+                ..Default::default()
+            })
+            .unwrap();
+
+        assert_eq!(groups.len(), 1);
+
+        groups[0].sync().await.unwrap();
+        let messages = groups[0]
+            .find_messages(&MsgQueryArgs {
+                ..Default::default()
+            })
+            .unwrap();
+
+        assert_eq!(messages.len(), 3);
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]

--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -186,6 +186,8 @@ where
     pub async fn sync(&self) -> Result<(), GroupError> {
         let conn = self.context().store().conn()?;
         let mls_provider = XmtpOpenMlsProvider::from(conn);
+        let conn = mls_provider.conn_ref();
+
         let epoch = self.epoch(&mls_provider).await?;
         tracing::info!(
             inbox_id = self.client.inbox_id(),
@@ -196,8 +198,18 @@ where
             self.client.inbox_id(),
             epoch
         );
-        self.maybe_update_installations(&mls_provider, None).await?;
 
+        // Also sync the "stitched DMs", if any...
+        for other_dm in conn.other_dms(&self.group_id)? {
+            let other_dm =
+                Self::new_from_arc(self.client.clone(), other_dm.id, other_dm.created_at_ns);
+            other_dm
+                .maybe_update_installations(&mls_provider, None)
+                .await?;
+            other_dm.sync_with_conn(&mls_provider).await?;
+        }
+
+        self.maybe_update_installations(&mls_provider, None).await?;
         self.sync_with_conn(&mls_provider).await
     }
 
@@ -1083,19 +1095,22 @@ where
                 Retry::default(),
                 (async { self.consume_message(provider, &message).await })
             );
-            if let Err(e) = result {
-                let is_retryable = e.is_retryable();
-                let error_message = e.to_string();
-                receive_errors.push(e);
-                // If the error is retryable we cannot move on to the next message
-                // otherwise you can get into a forked group state.
-                if is_retryable {
-                    tracing::error!(
-                        error = %error_message,
-                        "Aborting message processing for retryable error: {}",
-                        error_message
-                    );
-                    break;
+            match result {
+                Ok(_) => {}
+                Err(e) => {
+                    let is_retryable = e.is_retryable();
+                    let error_message = e.to_string();
+                    receive_errors.push(e);
+                    // If the error is retryable we cannot move on to the next message
+                    // otherwise you can get into a forked group state.
+                    if is_retryable {
+                        tracing::error!(
+                            error = %error_message,
+                            "Aborting message processing for retryable error: {}",
+                            error_message
+                        );
+                        break;
+                    }
                 }
             }
         }
@@ -1591,13 +1606,19 @@ where
                 ));
             }
 
+            let failed_installations = [
+                old_group_membership.failed_installations,
+                changes_with_kps.failed_installations,
+            ]
+            .concat();
+
             Ok(UpdateGroupMembershipIntentData::new(
                 changed_inbox_ids,
                 inbox_ids_to_remove
                     .iter()
                     .map(|s| s.to_string())
                     .collect::<Vec<String>>(),
-                changes_with_kps.failed_installations,
+                failed_installations,
             ))
         })
         .await
@@ -1773,8 +1794,7 @@ async fn calculate_membership_changes_with_keypackages<'a>(
     if !installation_diff.added_installations.is_empty() {
         let key_packages = get_keypackages_for_installation_ids(
             client,
-            installation_diff.added_installations,
-            &mut failed_installations,
+            installation_diff.added_installations.clone(),
         )
         .await?;
         for (installation_id, result) in key_packages {
@@ -1797,50 +1817,12 @@ async fn calculate_membership_changes_with_keypackages<'a>(
         failed_installations,
     ))
 }
-#[allow(dead_code)]
+
+#[allow(unused_variables, dead_code)]
 #[cfg(any(test, feature = "test-utils"))]
 async fn get_keypackages_for_installation_ids(
     client: impl ScopedGroupClient,
     added_installations: HashSet<Vec<u8>>,
-    failed_installations: &mut Vec<Vec<u8>>,
-) -> Result<HashMap<Vec<u8>, Result<VerifiedKeyPackageV2, KeyPackageVerificationError>>, ClientError>
-{
-    use crate::utils::{
-        get_test_mode_malformed_installations, is_test_mode_upload_malformed_keypackage,
-    };
-
-    let my_installation_id = client.context().installation_public_key().to_vec();
-    let key_packages = client
-        .get_key_packages_for_installation_ids(
-            added_installations
-                .iter()
-                .filter(|installation| my_installation_id.ne(*installation))
-                .cloned()
-                .collect(),
-        )
-        .await?;
-
-    tracing::info!("trying to validate keypackages");
-
-    Ok(if is_test_mode_upload_malformed_keypackage() {
-        let malformed_installations = get_test_mode_malformed_installations();
-        failed_installations.extend(malformed_installations.clone());
-
-        // Return only valid key packages (excluding malformed)
-        key_packages
-            .into_iter()
-            .filter(|(id, _)| !malformed_installations.contains(id))
-            .collect::<HashMap<_, _>>()
-    } else {
-        key_packages
-    })
-}
-#[allow(unused_variables, dead_code)]
-#[cfg(not(any(test, feature = "test-utils")))]
-async fn get_keypackages_for_installation_ids(
-    client: impl ScopedGroupClient,
-    added_installations: HashSet<Vec<u8>>,
-    failed_installations: &mut Vec<Vec<u8>>,
 ) -> Result<HashMap<Vec<u8>, Result<VerifiedKeyPackageV2, KeyPackageVerificationError>>, ClientError>
 {
     let my_installation_id = client.context().installation_public_key().to_vec();
@@ -1889,7 +1871,12 @@ async fn apply_update_group_membership_intent(
 
     // Update the extensions to have the new GroupMembership
     let mut new_extensions = extensions.clone();
-    new_group_membership.failed_installations = changes_with_kps.failed_installations;
+    let failed = [
+        old_group_membership.failed_installations,
+        changes_with_kps.failed_installations,
+    ]
+    .concat();
+    new_group_membership.failed_installations = failed;
     new_extensions.add_or_replace(build_group_membership_extension(&new_group_membership));
 
     // Create the commit

--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -1818,8 +1818,39 @@ async fn calculate_membership_changes_with_keypackages<'a>(
     ))
 }
 
-#[allow(unused_variables, dead_code)]
+#[allow(dead_code)]
 #[cfg(any(test, feature = "test-utils"))]
+async fn get_keypackages_for_installation_ids(
+    client: impl ScopedGroupClient,
+    added_installations: HashSet<Vec<u8>>,
+) -> Result<HashMap<Vec<u8>, Result<VerifiedKeyPackageV2, KeyPackageVerificationError>>, ClientError>
+{
+    use crate::utils::{
+        get_test_mode_malformed_installations, is_test_mode_upload_malformed_keypackage,
+    };
+
+    let my_installation_id = client.context().installation_public_key().to_vec();
+    let mut key_packages = client
+        .get_key_packages_for_installation_ids(
+            added_installations
+                .iter()
+                .filter(|installation| my_installation_id.ne(*installation))
+                .cloned()
+                .collect(),
+        )
+        .await?;
+
+    tracing::info!("trying to validate keypackages");
+
+    if is_test_mode_upload_malformed_keypackage() {
+        let malformed_installations = get_test_mode_malformed_installations();
+        key_packages.retain(|id, _| !malformed_installations.contains(id));
+    }
+
+    Ok(key_packages)
+}
+#[allow(unused_variables, dead_code)]
+#[cfg(not(any(test, feature = "test-utils")))]
 async fn get_keypackages_for_installation_ids(
     client: impl ScopedGroupClient,
     added_installations: HashSet<Vec<u8>>,

--- a/xmtp_mls/src/storage/encrypted_store/group.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group.rs
@@ -401,11 +401,31 @@ impl DbConnection {
             .order(dsl::last_message_ns.desc());
 
         let groups: Vec<StoredGroup> = self.raw_query_read(|conn| query.load(conn))?;
-        if groups.len() > 1 {
-            tracing::info!("More than one group found for dm_inbox_id {members:?}");
-        }
 
         Ok(groups.into_iter().next())
+    }
+
+    /// Load the other DMs that are stitched into this group
+    pub fn other_dms(&self, group_id: &[u8]) -> Result<Vec<StoredGroup>, StorageError> {
+        let query = dsl::groups.filter(dsl::id.eq(group_id));
+        let groups: Vec<StoredGroup> = self.raw_query_read(|conn| query.load(conn))?;
+
+        // Grab the dm_id of the group
+        let Some(StoredGroup {
+            id,
+            dm_id: Some(dm_id),
+            ..
+        }) = groups.into_iter().next()
+        else {
+            return Ok(vec![]);
+        };
+
+        let query = dsl::groups
+            .filter(dsl::dm_id.eq(dm_id))
+            .filter(dsl::id.ne(id));
+
+        let other_dms: Vec<StoredGroup> = self.raw_query_read(|conn| query.load(conn))?;
+        Ok(other_dms)
     }
 
     /// Updates group membership state


### PR DESCRIPTION
## Fix Key Package Mapping and Add Multi-DM Sync Support
Fixed key package mapping in `fetch_key_packages_for_installation_ids`, added support for syncing multiple DM conversations between users, and introduced test client configuration options. Added `other_dms()` method to retrieve related DM conversations and updated group sync logic to handle stitched DMs.

### 📍Where to Start
The `fetch_key_packages_for_installation_ids` method in [client.rs](https://github.com/xmtp/libxmtp/pull/1800/files#diff-de70260a705fef3f5acbf08315526f295274489e927dda73901d024f09d418fcR0) contains the core bug fix for key package mapping, which affects the security of message delivery.

----

_[Macroscope](https://app.macroscope.com) summarized b1e0f44._ (Automatic summaries will resume when PR exits draft mode or review begins).