### PR TITLE
Invalid Key Package Fix for release 1.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,7 +437,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_node"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "futures",
  "hex",
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_wasm"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "console_error_panic_hook",
  "futures",
@@ -7413,7 +7413,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "async-trait",
  "ctor",
@@ -7431,7 +7431,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_d14n"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -7448,7 +7448,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_grpc"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7470,7 +7470,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_http"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7491,7 +7491,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_cli"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "chrono",
  "clap",
@@ -7523,7 +7523,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_common"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -7554,7 +7554,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_content_types"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "hex",
  "libsecp256k1",
@@ -7572,7 +7572,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_cryptography"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "bincode",
  "curve25519-dalek",
@@ -7600,7 +7600,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_id"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7636,7 +7636,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_mls"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -7709,7 +7709,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_proto"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "async-trait",
  "dynosaur",
@@ -7733,7 +7733,7 @@ dependencies = [
 
 [[package]]
 name = "xmtpv3"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "async-trait",
  "coset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ resolver = "2"
 
 [workspace.package]
 license = "MIT"
-version = "1.1.1"
+version = "1.1.2"
 
 [workspace.dependencies]
 anyhow = "1.0"

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -2163,7 +2163,10 @@ impl FfiConversation {
 #[uniffi::export]
 impl FfiConversation {
     pub fn id(&self) -> Vec<u8> {
-        self.inner.group_id.clone()
+        match self.inner.client.stitched_group(&self.inner.group_id) {
+            Ok(group) => group.group_id.clone(),
+            Err(_) => self.inner.group_id.clone(),
+        }
     }
 }
 
@@ -7555,10 +7558,6 @@ mod tests {
             "Alix should see 3 messages after sync"
         );
 
-        let group_bo = bo_conn.find_group(&convo_bo.id()).unwrap().unwrap();
-        let group_alix = alix_conn.find_group(&convo_alix.id()).unwrap().unwrap();
-        assert!(group_bo.last_message_ns.unwrap() < group_alix.last_message_ns.unwrap());
-
         // Ensure conversations remain the same
         let convo_alix_2 = client_alix
             .conversations()
@@ -7583,6 +7582,11 @@ mod tests {
             convo_alix.id(),
             convo_bo_2.id(),
             "Conversations should match"
+        );
+        assert_eq!(
+            convo_alix.id(),
+            convo_bo.id(),
+            "Conversations should get updated to match"
         );
         assert_eq!(convo_alix.id(), topic_bo_same.id(), "Topics should match");
         assert_eq!(convo_alix.id(), topic_alix_same.id(), "Topics should match");
@@ -7631,5 +7635,42 @@ mod tests {
 
         assert_eq!(final_bo_messages.len(), 5, "Bo should see 5 messages");
         assert_eq!(final_alix_messages.len(), 5, "Alix should see 5 messages");
+    }
+
+    #[tokio::test]
+    async fn test_can_successfully_thread_dms_with_no_messages() {
+        // Create two test users
+        let wallet_bo = generate_local_wallet();
+        let wallet_alix = generate_local_wallet();
+
+        let client_bo = new_test_client_with_wallet(wallet_bo).await;
+        let client_alix = new_test_client_with_wallet(wallet_alix).await;
+
+        // Find or create DM conversations
+        let convo_bo = client_bo
+            .conversations()
+            .find_or_create_dm_by_inbox_id(client_alix.inbox_id(), FfiCreateDMOptions::default())
+            .await
+            .unwrap();
+        let convo_alix = client_alix
+            .conversations()
+            .find_or_create_dm_by_inbox_id(client_bo.inbox_id(), FfiCreateDMOptions::default())
+            .await
+            .unwrap();
+
+        client_bo
+            .conversations()
+            .sync_all_conversations(None)
+            .await
+            .unwrap();
+        client_alix
+            .conversations()
+            .sync_all_conversations(None)
+            .await
+            .unwrap();
+
+        let group_bo = client_bo.conversation(convo_bo.id()).unwrap();
+        let group_alix = client_alix.conversation(convo_alix.id()).unwrap();
+        assert_eq!(group_bo.id(), group_alix.id(), "Conversations should match");
     }
 }

--- a/bindings_node/CHANGELOG.md
+++ b/bindings_node/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 1.1.2
 
-- Fixed invalid key package association
+- Fixed incorrect key package associations
+- Resolved DM stitching issues for conversations without messages
 
 ## 1.1.1
 

--- a/bindings_node/CHANGELOG.md
+++ b/bindings_node/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @xmtp/node-bindings
 
+## 1.1.2
+
+- Fixed invalid key package association
+
 ## 1.1.1
 
 - Refactored welcome message processing to prevent key package deletion on failure

--- a/bindings_node/package.json
+++ b/bindings_node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/node-bindings",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "repository": {
     "type": "git",
     "url": "git+https://git@github.com/xmtp/libxmtp.git",

--- a/bindings_node/src/conversation.rs
+++ b/bindings_node/src/conversation.rs
@@ -99,7 +99,10 @@ impl Conversation {
 
   #[napi]
   pub fn id(&self) -> String {
-    hex::encode(self.group_id.clone())
+    match self.inner_client.stitched_group(&self.group_id) {
+      Ok(group) => hex::encode(group.group_id.clone()),
+      Err(_) => hex::encode(self.group_id.clone()),
+    }
   }
 
   #[napi]

--- a/bindings_wasm/CHANGELOG.md
+++ b/bindings_wasm/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 1.1.2
 
-- Fixed invalid key package association
-
+- Fixed incorrect key package associations
+- Resolved DM stitching issues for conversations without messages
 
 ## 1.1.1
 

--- a/bindings_wasm/CHANGELOG.md
+++ b/bindings_wasm/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @xmtp/wasm-bindings
 
+## 1.1.2
+
+- Fixed invalid key package association
+
+
 ## 1.1.1
 
 - Refactored welcome message processing to prevent key package deletion on failure

--- a/bindings_wasm/package.json
+++ b/bindings_wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/wasm-bindings",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "type": "module",
   "license": "MIT",
   "description": "WASM bindings for the libXMTP rust library",

--- a/bindings_wasm/src/conversation.rs
+++ b/bindings_wasm/src/conversation.rs
@@ -131,7 +131,10 @@ impl From<MlsGroup<RustXmtpClient>> for Conversation {
 impl Conversation {
   #[wasm_bindgen]
   pub fn id(&self) -> String {
-    hex::encode(self.group_id.clone())
+    match self.inner_client.stitched_group(&self.group_id) {
+      Ok(group) => hex::encode(group.group_id.clone()),
+      Err(_) => hex::encode(self.group_id.clone()),
+    }
   }
 
   #[wasm_bindgen]

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -863,9 +863,8 @@ where
         let crypto_provider = XmtpOpenMlsProvider::new_crypto();
 
         let results: HashMap<Vec<u8>, Result<VerifiedKeyPackageV2, KeyPackageVerificationError>> =
-            installation_ids
+            key_package_results
                 .iter()
-                .zip(key_package_results.values())
                 .map(|(id, bytes)| {
                     (
                         id.clone(),

--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -1664,13 +1664,19 @@ where
                 ));
             }
 
+            let failed_installations = [
+                old_group_membership.failed_installations,
+                changes_with_kps.failed_installations,
+            ]
+            .concat();
+
             Ok(UpdateGroupMembershipIntentData::new(
                 changed_inbox_ids,
                 inbox_ids_to_remove
                     .iter()
                     .map(|s| s.to_string())
                     .collect::<Vec<String>>(),
-                changes_with_kps.failed_installations,
+                failed_installations,
             ))
         })
         .await
@@ -1957,7 +1963,11 @@ async fn apply_update_group_membership_intent(
 
     // Update the extensions to have the new GroupMembership
     let mut new_extensions = extensions.clone();
-    new_group_membership.failed_installations = changes_with_kps.failed_installations;
+    new_group_membership.failed_installations = [
+        old_group_membership.failed_installations,
+        changes_with_kps.failed_installations,
+    ]
+    .concat();
     new_extensions.add_or_replace(build_group_membership_extension(&new_group_membership));
 
     // Create the commit

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -2562,7 +2562,6 @@ pub(crate) mod tests {
 
     #[cfg(not(target_arch = "wasm32"))]
     #[tokio::test(flavor = "current_thread")]
-    #[ignore] // ignoring for now due to flakiness
     async fn test_create_group_with_member_two_installations_one_malformed_keypackage() {
         use xmtp_id::associations::test_utils::WalletTestExt;
 
@@ -2645,7 +2644,7 @@ pub(crate) mod tests {
             .unwrap();
 
         // The last message should be our "Hello from Alix"
-        assert_eq!(messages_bola_1.len(), 4);
+        assert_eq!(messages_bola_1.len(), 3);
 
         // Query messages from Alix's perspective
         let messages_alix = alix
@@ -2655,7 +2654,7 @@ pub(crate) mod tests {
             .unwrap();
 
         // The last message should be our "Hello from Alix"
-        assert_eq!(messages_alix.len(), 4);
+        assert_eq!(messages_alix.len(), 3);
         assert_eq!(
             message.to_vec(),
             get_latest_message(&group).await.decrypted_message_bytes
@@ -2669,7 +2668,6 @@ pub(crate) mod tests {
     }
     #[cfg(not(target_arch = "wasm32"))]
     #[tokio::test(flavor = "current_thread")]
-    #[ignore]
     async fn test_create_group_with_member_all_malformed_installations() {
         use xmtp_id::associations::test_utils::WalletTestExt;
 
@@ -2732,7 +2730,6 @@ pub(crate) mod tests {
 
     #[cfg(not(target_arch = "wasm32"))]
     #[tokio::test(flavor = "current_thread")]
-    #[ignore] // ignoring for now due to flakiness
     async fn test_dm_creation_with_user_two_installations_one_malformed() {
         use crate::utils::set_test_mode_upload_malformed_keypackage;
         // 1) Prepare clients
@@ -2840,7 +2837,6 @@ pub(crate) mod tests {
 
     #[cfg(not(target_arch = "wasm32"))]
     #[tokio::test(flavor = "current_thread")]
-    #[ignore]
     async fn test_dm_creation_with_user_all_malformed_installations() {
         use xmtp_id::associations::test_utils::WalletTestExt;
 

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -730,6 +730,7 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
                     dm_members,
                     disappearing_settings,
                     paused_for_version,
+                    None
                 ),
                 ConversationType::Dm => {
                     validate_dm_group(client, &mls_group, &added_by_inbox_id)?;
@@ -743,6 +744,7 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
                         dm_members,
                         disappearing_settings,
                         None,
+                        Some(welcome.created_ns as i64)
                     )
                 }
                 ConversationType::Sync => StoredGroup::new_from_welcome(
@@ -755,6 +757,7 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
                     dm_members,
                     disappearing_settings,
                     None,
+                    None
                 ),
             };
 

--- a/xmtp_mls/src/storage/encrypted_store/group.rs
+++ b/xmtp_mls/src/storage/encrypted_store/group.rs
@@ -75,6 +75,7 @@ impl StoredGroup {
         dm_members: Option<DmMembers<String>>,
         message_disappearing_settings: Option<MessageDisappearingSettings>,
         paused_for_version: Option<String>,
+        last_message_ns: Option<i64>,
     ) -> Self {
         Self {
             id,
@@ -86,7 +87,7 @@ impl StoredGroup {
             welcome_id: Some(welcome_id),
             rotated_at_ns: 0,
             dm_id: dm_members.map(String::from),
-            last_message_ns: None,
+            last_message_ns,
             message_disappear_from_ns: message_disappearing_settings.as_ref().map(|s| s.from_ns),
             message_disappear_in_ns: message_disappearing_settings.map(|s| s.in_ns),
             paused_for_version,
@@ -288,7 +289,7 @@ impl DbConnection {
             query = query.filter(sql::<diesel::sql_types::Bool>(
                 "id IN (
                     SELECT id FROM (
-                        SELECT id, 
+                        SELECT id,
                             ROW_NUMBER() OVER (PARTITION BY COALESCE(dm_id, id) ORDER BY last_message_ns DESC) AS row_num
                         FROM groups
                     ) AS ranked_groups
@@ -803,6 +804,7 @@ pub(crate) mod tests {
             "placeholder_address".to_string(),
             welcome_id.unwrap_or(xmtp_common::rand_i64()),
             ConversationType::Group,
+            None,
             None,
             None,
             None,


### PR DESCRIPTION
## Fix Key Package Association and DM Conversation Stitching
Modified conversation ID handling in FFI, Node, and WASM bindings to prioritize stitched group IDs. Updated `fetch_key_packages_for_installations` to correctly map key packages to installation IDs. Added `last_message_ns` parameter to `StoredGroup::new_from_welcome` for DM conversation stitching. Version bump to 1.1.2 across all packages.

### 📍Where to Start
Start with the key package association fix in [client.rs](https://github.com/xmtp/libxmtp/pull/1801/files#diff-de70260a705fef3f5acbf08315526f295274489e927dda73901d024f09d418fcR0) at the `fetch_key_packages_for_installations` method, then follow the conversation stitching changes in [mls.rs](https://github.com/xmtp/libxmtp/pull/1801/files#diff-f0c802614f06b1e4189d04bc799ef1e0497991a2e3f2572f8f43f851f213a25fR0)

----

_[Macroscope](https://app.macroscope.com) summarized 6095fbe._