### PR TITLE
Fixes unable to remove member with invalid keyPackages.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,7 +437,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_node"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "futures",
  "hex",
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_wasm"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "console_error_panic_hook",
  "futures",
@@ -7413,7 +7413,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "async-trait",
  "ctor",
@@ -7431,7 +7431,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_d14n"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -7448,7 +7448,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_grpc"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7470,7 +7470,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_http"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7491,7 +7491,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_cli"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "chrono",
  "clap",
@@ -7523,7 +7523,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_common"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -7554,7 +7554,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_content_types"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "hex",
  "libsecp256k1",
@@ -7572,7 +7572,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_cryptography"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "bincode",
  "curve25519-dalek",
@@ -7600,7 +7600,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_id"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7636,7 +7636,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_mls"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -7709,7 +7709,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_proto"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "async-trait",
  "dynosaur",
@@ -7733,7 +7733,7 @@ dependencies = [
 
 [[package]]
 name = "xmtpv3"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "async-trait",
  "coset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ resolver = "2"
 
 [workspace.package]
 license = "MIT"
-version = "1.1.2"
+version = "1.1.3"
 
 [workspace.dependencies]
 anyhow = "1.0"

--- a/bindings_node/CHANGELOG.md
+++ b/bindings_node/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @xmtp/node-bindings
 
+## 1.1.3
+
+- Fixed removing inboxes with invalid key packages from groups
+
 ## 1.1.2
 
 - Fixed incorrect key package associations

--- a/bindings_node/package.json
+++ b/bindings_node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/node-bindings",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "repository": {
     "type": "git",
     "url": "git+https://git@github.com/xmtp/libxmtp.git",

--- a/bindings_wasm/CHANGELOG.md
+++ b/bindings_wasm/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @xmtp/wasm-bindings
 
+## 1.1.3
+
+- Fixed removing inboxes with invalid key packages from groups
+
 ## 1.1.2
 
 - Fixed incorrect key package associations

--- a/bindings_wasm/package.json
+++ b/bindings_wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/wasm-bindings",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "type": "module",
   "license": "MIT",
   "description": "WASM bindings for the libXMTP rust library",

--- a/xmtp_mls/src/groups/intents.rs
+++ b/xmtp_mls/src/groups/intents.rs
@@ -3,7 +3,7 @@ use openmls::prelude::{
     MlsMessageOut,
 };
 use prost::{bytes::Bytes, DecodeError, Message};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use thiserror::Error;
 
 use xmtp_proto::xmtp::mls::database::{
@@ -363,9 +363,13 @@ impl UpdateGroupMembershipIntentData {
             new_membership.remove(inbox_id)
         }
 
-        new_membership
+        new_membership.failed_installations = new_membership
             .failed_installations
-            .extend(self.failed_installations.iter().cloned());
+            .into_iter()
+            .chain(self.failed_installations.iter().cloned())
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect();
 
         tracing::info!("updated group membership: {:?}", new_membership.members);
         new_membership

--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -1644,6 +1644,9 @@ where
             for (inbox_id, sequence_id) in changed_inbox_ids.iter() {
                 new_membership.add(inbox_id.clone(), *sequence_id);
             }
+            for inbox_id in inbox_ids_to_remove {
+                new_membership.remove(inbox_id);
+            }
 
             let changes_with_kps = calculate_membership_changes_with_keypackages(
                 &self.client,
@@ -1664,19 +1667,13 @@ where
                 ));
             }
 
-            let failed_installations = [
-                old_group_membership.failed_installations,
-                changes_with_kps.failed_installations,
-            ]
-            .concat();
-
             Ok(UpdateGroupMembershipIntentData::new(
                 changed_inbox_ids,
                 inbox_ids_to_remove
                     .iter()
                     .map(|s| s.to_string())
                     .collect::<Vec<String>>(),
-                failed_installations,
+                changes_with_kps.failed_installations,
             ))
         })
         .await
@@ -1836,7 +1833,7 @@ async fn calculate_membership_changes_with_keypackages<'a>(
 ) -> Result<MembershipDiffWithKeyPackages, GroupError> {
     let membership_diff = old_group_membership.diff(new_group_membership);
 
-    let installation_diff = client
+    let mut installation_diff = client
         .get_installation_diff(
             provider.conn_ref(),
             old_group_membership,
@@ -1847,13 +1844,13 @@ async fn calculate_membership_changes_with_keypackages<'a>(
 
     let mut new_installations = Vec::new();
     let mut new_key_packages = Vec::new();
-    let mut failed_installations = Vec::new();
+    let mut new_failed_installations = Vec::new();
 
     if !installation_diff.added_installations.is_empty() {
         let key_packages = get_keypackages_for_installation_ids(
             client,
             installation_diff.added_installations,
-            &mut failed_installations,
+            &mut new_failed_installations,
         )
         .await?;
         for (installation_id, result) in key_packages {
@@ -1864,10 +1861,31 @@ async fn calculate_membership_changes_with_keypackages<'a>(
                     ));
                     new_key_packages.push(verified_key_package.inner.clone());
                 }
-                Err(_) => failed_installations.push(installation_id.clone()),
+                Err(_) => new_failed_installations.push(installation_id.clone()),
             }
         }
     }
+
+    let mut failed_installations: Vec<Vec<u8>> = old_group_membership
+        .failed_installations
+        .clone()
+        .into_iter()
+        .chain(new_failed_installations)
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+
+    let common: HashSet<_> = failed_installations
+        .iter()
+        .filter(|item| installation_diff.removed_installations.contains(*item))
+        .cloned()
+        .collect();
+
+    failed_installations.retain(|item| !common.contains(item));
+
+    installation_diff
+        .removed_installations
+        .retain(|item| !common.contains(item));
 
     Ok(MembershipDiffWithKeyPackages::new(
         new_installations,
@@ -1914,7 +1932,7 @@ async fn get_keypackages_for_installation_ids(
 async fn get_keypackages_for_installation_ids(
     client: impl ScopedGroupClient,
     added_installations: HashSet<Vec<u8>>,
-    failed_installations: &mut Vec<Vec<u8>>,
+    failed_installations: &mut [Vec<u8>],
 ) -> Result<HashMap<Vec<u8>, Result<VerifiedKeyPackageV2, KeyPackageVerificationError>>, ClientError>
 {
     let my_installation_id = client.context().installation_public_key().to_vec();
@@ -1941,7 +1959,7 @@ async fn apply_update_group_membership_intent(
 ) -> Result<Option<PublishIntentData>, GroupError> {
     let extensions: Extensions = openmls_group.extensions().clone();
     let old_group_membership = extract_group_membership(&extensions)?;
-    let mut new_group_membership = intent_data.apply_to_group_membership(&old_group_membership);
+    let new_group_membership = intent_data.apply_to_group_membership(&old_group_membership);
     let membership_diff = old_group_membership.diff(&new_group_membership);
 
     let changes_with_kps = calculate_membership_changes_with_keypackages(
@@ -1963,11 +1981,7 @@ async fn apply_update_group_membership_intent(
 
     // Update the extensions to have the new GroupMembership
     let mut new_extensions = extensions.clone();
-    new_group_membership.failed_installations = [
-        old_group_membership.failed_installations,
-        changes_with_kps.failed_installations,
-    ]
-    .concat();
+
     new_extensions.add_or_replace(build_group_membership_extension(&new_group_membership));
 
     // Create the commit

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -2893,6 +2893,258 @@ pub(crate) mod tests {
             "Bola_2 should have no DM group due to malformed key package"
         );
     }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_add_inbox_with_bad_installation_to_group() {
+        use crate::utils::set_test_mode_upload_malformed_keypackage;
+        use xmtp_id::associations::test_utils::WalletTestExt;
+
+        let alix = ClientBuilder::new_test_client(&generate_local_wallet()).await;
+        let bo_wallet = generate_local_wallet();
+        let caro_wallet = generate_local_wallet();
+        let bo_1 = ClientBuilder::new_test_client(&bo_wallet).await;
+        let bo_2 = ClientBuilder::new_test_client(&bo_wallet).await;
+        let caro = ClientBuilder::new_test_client(&caro_wallet).await;
+
+        set_test_mode_upload_malformed_keypackage(
+            true,
+            Some(vec![bo_1.installation_id().to_vec()]),
+        );
+
+        let group = alix
+            .create_group_with_members(
+                &[caro_wallet.identifier()],
+                None,
+                GroupMetadataOptions::default(),
+            )
+            .await
+            .unwrap();
+
+        let _ = group.add_members(&[bo_wallet.identifier()]).await;
+
+        bo_2.sync_welcomes(&bo_2.mls_provider().unwrap())
+            .await
+            .unwrap();
+        caro.sync_welcomes(&caro.mls_provider().unwrap())
+            .await
+            .unwrap();
+
+        let bo_2_groups = bo_2.find_groups(GroupQueryArgs::default()).unwrap();
+        assert_eq!(bo_2_groups.len(), 1);
+        let caro_groups = caro.find_groups(GroupQueryArgs::default()).unwrap();
+        assert_eq!(caro_groups.len(), 1);
+        let alix_groups = alix.find_groups(GroupQueryArgs::default()).unwrap();
+        assert_eq!(alix_groups.len(), 1);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_add_inbox_with_good_installation_to_group_with_bad_installation() {
+        use crate::utils::set_test_mode_upload_malformed_keypackage;
+        use xmtp_id::associations::test_utils::WalletTestExt;
+
+        let bo_wallet = generate_local_wallet();
+        let caro_wallet = generate_local_wallet();
+        let alix = ClientBuilder::new_test_client(&generate_local_wallet()).await;
+        let bo_1 = ClientBuilder::new_test_client(&bo_wallet).await;
+        let bo_2 = ClientBuilder::new_test_client(&bo_wallet).await;
+        let caro = ClientBuilder::new_test_client(&caro_wallet).await;
+
+        set_test_mode_upload_malformed_keypackage(
+            true,
+            Some(vec![bo_1.installation_id().to_vec()]),
+        );
+
+        let group = alix
+            .create_group_with_members(
+                &[bo_wallet.identifier()],
+                None,
+                GroupMetadataOptions::default(),
+            )
+            .await
+            .unwrap();
+
+        let _ = group.add_members(&[caro_wallet.identifier()]).await;
+
+        caro.sync_welcomes(&caro.mls_provider().unwrap())
+            .await
+            .unwrap();
+        bo_2.sync_welcomes(&bo_2.mls_provider().unwrap())
+            .await
+            .unwrap();
+        let caro_groups = caro.find_groups(GroupQueryArgs::default()).unwrap();
+        assert_eq!(caro_groups.len(), 1);
+        let bo_groups = bo_2.find_groups(GroupQueryArgs::default()).unwrap();
+        assert_eq!(bo_groups.len(), 1);
+        let alix_groups = alix.find_groups(GroupQueryArgs::default()).unwrap();
+        assert_eq!(alix_groups.len(), 1);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_remove_inbox_with_good_installation_from_group_with_bad_installation() {
+        use crate::utils::set_test_mode_upload_malformed_keypackage;
+        use xmtp_id::associations::test_utils::WalletTestExt;
+
+        let alix_wallet = generate_local_wallet();
+        let bo_wallet = generate_local_wallet();
+        let caro_wallet = generate_local_wallet();
+        let alix_1 = ClientBuilder::new_test_client(&alix_wallet).await;
+        let alix_2 = ClientBuilder::new_test_client(&alix_wallet).await;
+        let bo = ClientBuilder::new_test_client(&bo_wallet).await;
+        let caro = ClientBuilder::new_test_client(&caro_wallet).await;
+
+        set_test_mode_upload_malformed_keypackage(
+            true,
+            Some(vec![alix_2.installation_id().to_vec()]),
+        );
+
+        let group = alix_1
+            .create_group_with_members(
+                &[bo_wallet.identifier(), caro_wallet.identifier()],
+                None,
+                GroupMetadataOptions::default(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(group.members().await.unwrap().len(), 3);
+        let _ = group.remove_members(&[caro_wallet.identifier()]).await;
+
+        caro.sync_welcomes(&caro.mls_provider().unwrap())
+            .await
+            .unwrap();
+        bo.sync_welcomes(&bo.mls_provider().unwrap()).await.unwrap();
+        group.sync().await.unwrap();
+
+        let caro_groups = caro.find_groups(GroupQueryArgs::default()).unwrap();
+        let caro_group = caro_groups.first().unwrap();
+        caro_group.sync().await.unwrap();
+        assert!(!caro_group.is_active(&caro.mls_provider().unwrap()).unwrap());
+        let bo_groups = bo.find_groups(GroupQueryArgs::default()).unwrap();
+        let bo_group = bo_groups.first().unwrap();
+        bo_group.sync().await.unwrap();
+        assert_eq!(bo_group.members().await.unwrap().len(), 2);
+        assert_eq!(group.members().await.unwrap().len(), 2);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_remove_inbox_with_bad_installation_from_group() {
+        use crate::utils::set_test_mode_upload_malformed_keypackage;
+        use xmtp_id::associations::test_utils::WalletTestExt;
+
+        let alix_wallet = generate_local_wallet();
+        let bo_wallet = generate_local_wallet();
+        let caro_wallet = generate_local_wallet();
+        let alix = ClientBuilder::new_test_client(&alix_wallet).await;
+        let bo_1 = ClientBuilder::new_test_client(&bo_wallet).await;
+        let bo_2 = ClientBuilder::new_test_client(&bo_wallet).await;
+        let caro = ClientBuilder::new_test_client(&caro_wallet).await;
+
+        set_test_mode_upload_malformed_keypackage(
+            true,
+            Some(vec![bo_1.installation_id().to_vec()]),
+        );
+
+        let group = alix
+            .create_group_with_members(
+                &[bo_wallet.identifier(), caro_wallet.identifier()],
+                None,
+                GroupMetadataOptions::default(),
+            )
+            .await
+            .unwrap();
+
+        group.sync().await.unwrap();
+
+        let message_from_alix = b"Hello from Alix";
+        group.send_message(message_from_alix).await.unwrap();
+
+        bo_2.sync_welcomes(&bo_2.mls_provider().unwrap())
+            .await
+            .unwrap();
+        caro.sync_welcomes(&caro.mls_provider().unwrap())
+            .await
+            .unwrap();
+        group.sync().await.unwrap();
+
+        let bo_groups = bo_2.find_groups(GroupQueryArgs::default()).unwrap();
+        let bo_group = bo_groups.first().unwrap();
+        bo_group.sync().await.unwrap();
+        let bo_msgs = bo_group.find_messages(&MsgQueryArgs::default()).unwrap();
+        assert_eq!(bo_msgs.len(), 1);
+        assert_eq!(bo_msgs[0].decrypted_message_bytes, message_from_alix);
+
+        let caro_groups = caro.find_groups(GroupQueryArgs::default()).unwrap();
+        let caro_group = caro_groups.first().unwrap();
+        caro_group.sync().await.unwrap();
+        let caro_msgs = caro_group.find_messages(&MsgQueryArgs::default()).unwrap();
+        assert_eq!(caro_msgs.len(), 1);
+        assert_eq!(caro_msgs[0].decrypted_message_bytes, message_from_alix);
+
+        // Bo replies before removal
+        let bo_reply = b"Hey Alix!";
+        bo_group.send_message(bo_reply).await.unwrap();
+
+        group.sync().await.unwrap();
+        let group_msgs = group.find_messages(&MsgQueryArgs::default()).unwrap();
+        assert_eq!(group_msgs.len(), 3);
+        assert_eq!(group_msgs.last().unwrap().decrypted_message_bytes, bo_reply);
+
+        // Remove Bo
+        group
+            .remove_members(&[bo_wallet.identifier()])
+            .await
+            .unwrap();
+
+        bo_2.sync_welcomes(&bo_2.mls_provider().unwrap())
+            .await
+            .unwrap();
+        caro.sync_welcomes(&caro.mls_provider().unwrap())
+            .await
+            .unwrap();
+        group.sync().await.unwrap();
+
+        // Bo should no longer be active
+        bo_group.sync().await.unwrap();
+        assert!(!bo_group.is_active(&bo_2.mls_provider().unwrap()).unwrap());
+
+        let post_removal_msg = b"Caro, just us now!";
+        group.send_message(post_removal_msg).await.unwrap();
+        let caro_post_removal_msg = b"Nice!";
+        caro_group
+            .send_message(caro_post_removal_msg)
+            .await
+            .unwrap();
+
+        caro_group.sync().await.unwrap();
+        let caro_msgs = caro_group.find_messages(&MsgQueryArgs::default()).unwrap();
+        assert_eq!(caro_msgs.len(), 5);
+        assert_eq!(
+            caro_msgs.last().unwrap().decrypted_message_bytes,
+            caro_post_removal_msg
+        );
+        group.sync().await.unwrap();
+        let alix_msgs = group.find_messages(&MsgQueryArgs::default()).unwrap();
+        assert_eq!(alix_msgs.len(), 6);
+        assert_eq!(
+            alix_msgs.last().unwrap().decrypted_message_bytes,
+            caro_post_removal_msg
+        );
+
+        let bo_msgs = bo_group.find_messages(&MsgQueryArgs::default()).unwrap();
+        assert_eq!(
+            bo_msgs.len(),
+            3,
+            "Bo should not receive messages after being removed"
+        );
+
+        assert_eq!(caro_group.members().await.unwrap().len(), 2);
+        assert_eq!(group.members().await.unwrap().len(), 2);
+    }
+
     #[wasm_bindgen_test(unsupported = tokio::test(flavor = "current_thread"))]
     async fn test_add_invalid_member() {
         let client = ClientBuilder::new_test_client(&generate_local_wallet()).await;
@@ -5433,5 +5685,93 @@ pub(crate) mod tests {
             .send_message("Message after update".as_bytes())
             .await;
         assert!(result.is_ok());
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_can_make_inbox_with_a_bad_key_package_an_admin() {
+        use crate::utils::set_test_mode_upload_malformed_keypackage;
+
+        // 1) Prepare clients
+        let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
+        let charlie = ClientBuilder::new_test_client(&generate_local_wallet()).await;
+
+        // Create a wallet for the user with a bad key package
+        let bola_wallet = generate_local_wallet();
+        let bola = ClientBuilder::new_test_client(&bola_wallet).await;
+        // Mark bola's installation as having a malformed key package
+        set_test_mode_upload_malformed_keypackage(
+            true,
+            Some(vec![bola.installation_id().to_vec()]),
+        );
+
+        // 2) Create a group with amal as the only member
+        let amal_group = amal
+            .create_group(
+                Some(PreconfiguredPolicies::AdminsOnly.to_policy_set()),
+                GroupMetadataOptions::default(),
+            )
+            .unwrap();
+        amal_group.sync().await.unwrap();
+
+        // 3) Add charlie to the group (normal member)
+        let result = amal_group
+            .add_members_by_inbox_id(&[charlie.inbox_id()])
+            .await;
+        assert!(result.is_ok());
+
+        // 4) Initially fail to add bola since they only have one bad key package
+        let result = amal_group.add_members_by_inbox_id(&[bola.inbox_id()]).await;
+        assert!(result.is_err());
+
+        // 5) Add a second installation for bola and try and re-add them
+        let bola_2 = ClientBuilder::new_test_client(&bola_wallet).await;
+        let result = amal_group.add_members_by_inbox_id(&[bola.inbox_id()]).await;
+        assert!(result.is_ok());
+
+        // 6) Test that bola can not perform an admin only action
+        bola_2
+            .sync_welcomes(&bola_2.mls_provider().unwrap())
+            .await
+            .unwrap();
+        let binding = bola_2.find_groups(GroupQueryArgs::default()).unwrap();
+        let bola_group = binding.first().unwrap();
+        bola_group.sync().await.unwrap();
+        let result = bola_group
+            .update_group_name("Bola's Group".to_string())
+            .await;
+        assert!(result.is_err());
+
+        // 7) Test adding bola as an admin
+        let result = amal_group
+            .update_admin_list(UpdateAdminListType::Add, bola.inbox_id().to_string())
+            .await;
+        assert!(result.is_ok());
+
+        // 8) Verify bola can perform an admin only action
+        bola_group.sync().await.unwrap();
+        let result = bola_group
+            .update_group_name("Bola's Group".to_string())
+            .await;
+        assert!(result.is_ok());
+
+        // 9) Verify we can remove bola as an admin
+        let result = amal_group
+            .update_admin_list(UpdateAdminListType::Remove, bola.inbox_id().to_string())
+            .await;
+        assert!(result.is_ok());
+
+        // 10) Verify bola is not an admin
+        let admins = amal_group
+            .admin_list(&amal_group.mls_provider().unwrap())
+            .unwrap();
+        assert!(!admins.contains(&bola.inbox_id().to_string()));
+
+        // 11) verify bola can't perform an admin only action
+        bola_group.sync().await.unwrap();
+        let result = bola_group
+            .update_group_name("Bola's Group Forever".to_string())
+            .await;
+        assert!(result.is_err());
     }
 }

--- a/xmtp_mls/src/identity_updates.rs
+++ b/xmtp_mls/src/identity_updates.rs
@@ -601,7 +601,7 @@ pub(crate) mod tests {
         builder::ClientBuilder,
         groups::group_membership::GroupMembership,
         storage::{db_connection::DbConnection, identity_update::StoredIdentityUpdate},
-        utils::test::FullXmtpClient,
+        utils::{set_test_mode_upload_malformed_keypackage, test::FullXmtpClient},
         Client, XmtpApi,
     };
     use xmtp_common::rand_vec;
@@ -1004,5 +1004,70 @@ pub(crate) mod tests {
         // Make sure there is only one installation on the inbox
         let association_state = get_association_state(&client1, client1.inbox_id()).await;
         assert_eq!(association_state.installation_ids().len(), 1);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tokio::test(flavor = "multi_thread")]
+    pub async fn revoke_installation_with_malformed_keypackage() {
+        let wallet = generate_local_wallet();
+        let client1: FullXmtpClient = ClientBuilder::new_test_client(&wallet).await;
+        let client2: FullXmtpClient = ClientBuilder::new_test_client(&wallet).await;
+
+        let association_state = get_association_state(&client1, client1.inbox_id()).await;
+        // Ensure there are two installations on the inbox
+        assert_eq!(association_state.installation_ids().len(), 2);
+
+        set_test_mode_upload_malformed_keypackage(
+            true,
+            Some(vec![client2.installation_public_key().to_vec()]),
+        );
+
+        // Now revoke the second client
+        let mut revoke_installation_request = client1
+            .revoke_installations(vec![client2.installation_public_key().to_vec()])
+            .await
+            .unwrap();
+        add_wallet_signature(&mut revoke_installation_request, &wallet).await;
+        client1
+            .apply_signature_request(revoke_installation_request)
+            .await
+            .unwrap();
+
+        // Make sure there is only one installation on the inbox
+        let association_state = get_association_state(&client1, client1.inbox_id()).await;
+        assert_eq!(association_state.installation_ids().len(), 1);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tokio::test(flavor = "multi_thread")]
+    pub async fn revoke_good_installation_with_other_malformed_keypackage() {
+        let wallet = generate_local_wallet();
+        let client1: FullXmtpClient = ClientBuilder::new_test_client(&wallet).await;
+        let client2: FullXmtpClient = ClientBuilder::new_test_client(&wallet).await;
+        let client3: FullXmtpClient = ClientBuilder::new_test_client(&wallet).await;
+
+        let association_state = get_association_state(&client1, client1.inbox_id()).await;
+        // Ensure there are two installations on the inbox
+        assert_eq!(association_state.installation_ids().len(), 3);
+
+        set_test_mode_upload_malformed_keypackage(
+            true,
+            Some(vec![client2.installation_public_key().to_vec()]),
+        );
+
+        // Now revoke the second client
+        let mut revoke_installation_request = client1
+            .revoke_installations(vec![client3.installation_public_key().to_vec()])
+            .await
+            .unwrap();
+        add_wallet_signature(&mut revoke_installation_request, &wallet).await;
+        client1
+            .apply_signature_request(revoke_installation_request)
+            .await
+            .unwrap();
+
+        // Make sure there is only one installation on the inbox
+        let association_state = get_association_state(&client1, client1.inbox_id()).await;
+        assert_eq!(association_state.installation_ids().len(), 2);
     }
 }


### PR DESCRIPTION
### Fix removal of group members with invalid key packages in XMTP MLS groups
* Updates `UpdateGroupMembershipIntentData.apply_to_group_membership` in [intents.rs](https://github.com/xmtp/libxmtp/pull/1808/files#diff-2288952982788551d8fa6f279ebf922ee9fb1b15222414137277d097ead95e35) to properly merge failed installations using `HashSet`
* Modifies `calculate_membership_changes_with_keypackages` in [mls_sync.rs](https://github.com/xmtp/libxmtp/pull/1808/files#diff-10f818f7918c8c0b2ed32c4f63e5060050527ed58df00ec081bbecb66065144e) to correctly filter installations that are both failed and removed
* Updates `expected_diff_matches_commit` in [validated_commit.rs](https://github.com/xmtp/libxmtp/pull/1808/files#diff-779227110741fa6ce78048adfaac1895d306d8fd502dab800774b62aada72365) to handle failed installations during validation
* Adds comprehensive test coverage in [mod.rs](https://github.com/xmtp/libxmtp/pull/1808/files#diff-c29f56a38916c7410eff8091df1a2e43487ffe20646d96827e846e475f4608d3) and [identity_updates.rs](https://github.com/xmtp/libxmtp/pull/1808/files#diff-cc071a4438743ce4ec352d6294d0ca5e6343d881afd0f7d45127e70badea403d) for invalid key package scenarios

#### 📍Where to Start
Start with the `calculate_membership_changes_with_keypackages` function in [mls_sync.rs](https://github.com/xmtp/libxmtp/pull/1808/files#diff-10f818f7918c8c0b2ed32c4f63e5060050527ed58df00ec081bbecb66065144e) which contains the core logic for handling failed installations during group membership updates.

----

_[Macroscope](https://app.macroscope.com) summarized 635bda7._