### PR TITLE
file appender

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7822,6 +7822,7 @@ dependencies = [
  "thiserror 2.0.11",
  "tokio",
  "tracing",
+ "tracing-appender",
  "tracing-oslog",
  "tracing-subscriber",
  "tracing_android_trace",

--- a/bindings_ffi/Cargo.toml
+++ b/bindings_ffi/Cargo.toml
@@ -15,6 +15,7 @@ prost.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["macros"] }
 tracing.workspace = true
+tracing-appender = "0.2"
 tracing-subscriber = { workspace = true, features = [
   "registry",
   "env-filter",

--- a/bindings_ffi/src/logger.rs
+++ b/bindings_ffi/src/logger.rs
@@ -1,13 +1,28 @@
+use crate::GenericError;
+use log::level_filters::LevelFilter;
 use log::Subscriber;
-use std::sync::Once;
+use parking_lot::Mutex;
+use std::io::Write;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, LazyLock, OnceLock,
+};
+use tracing_appender::non_blocking::NonBlockingBuilder;
+use tracing_appender::non_blocking::WorkerGuard;
+use tracing_appender::rolling::RollingFileAppender;
+use tracing_subscriber::fmt::format::DefaultFields;
+use tracing_subscriber::fmt::format::Format;
+use tracing_subscriber::fmt::MakeWriter;
 use tracing_subscriber::{
-    layer::SubscriberExt, registry::LookupSpan, util::SubscriberInitExt, Layer,
+    filter::Filtered, fmt, layer::Layered, layer::SubscriberExt, registry::LookupSpan,
+    registry::Registry, reload, util::SubscriberInitExt, EnvFilter, Layer,
 };
 
 pub const FILTER_DIRECTIVE: &str = "xmtp_mls=debug,xmtp_id=debug,\
                     xmtp_api=debug,xmtp_api_grpc=debug,xmtp_proto=debug,\
                     xmtp_common=debug,xmtp_api_d14n=debug,\
-                    xmtp_content_types=debug,xmtp_cryptography=debug,xmtp_user_preferences=debug,xmtpv3=debug";
+                    xmtp_content_types=debug,xmtp_cryptography=debug,\
+                    xmtp_user_preferences=debug,xmtpv3=debug,xmtp_db=debug";
 
 #[cfg(target_os = "android")]
 pub use android::*;
@@ -88,12 +103,145 @@ mod other {
     }
 }
 
-static LOGGER_INIT: Once = Once::new();
+enum EmptyOrFileWriter {
+    Empty,
+    File(tracing_appender::non_blocking::NonBlocking),
+}
+
+impl Default for EmptyOrFileWriter {
+    fn default() -> Self {
+        Self::Empty
+    }
+}
+
+impl Write for EmptyOrFileWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        match self {
+            Self::Empty => Ok(buf.len()),
+            Self::File(ref mut f) => f.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        match self {
+            Self::Empty => Ok(()),
+            Self::File(ref mut f) => f.flush(),
+        }
+    }
+}
+
+impl MakeWriter<'_> for EmptyOrFileWriter {
+    type Writer = Self;
+
+    fn make_writer(&self) -> Self::Writer {
+        match self {
+            Self::Empty => Self::Empty,
+            Self::File(f) => Self::File(f.make_writer()),
+        }
+    }
+}
+
+// this is a crazy type b/c tracing uses recursive "Layer" types to allow for an arbitrary number
+// of layers
+// however, this allows us to dynamically reload the debug file at runtime
+static LOGGER: LazyLock<
+    Arc<
+        Mutex<
+            reload::Handle<
+                Filtered<
+                    fmt::Layer<
+                        Layered<Box<dyn Layer<Registry> + Send + Sync>, Registry>,
+                        DefaultFields,
+                        Format,
+                        EmptyOrFileWriter,
+                    >,
+                    EnvFilter,
+                    Layered<Box<dyn Layer<Registry> + Send + Sync>, Registry>,
+                >,
+                Layered<Box<dyn Layer<Registry> + Send + Sync>, Registry>,
+            >,
+        >,
+    >,
+> = LazyLock::new(|| {
+    let native_layer = native_layer();
+    // just turn the layer off for now
+    let fmt = fmt::Layer::default()
+        .with_writer(EmptyOrFileWriter::default())
+        .with_filter(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::OFF.into())
+                .parse_lossy("off"),
+        );
+    let (filter, reload_handle) = reload::Layer::new(fmt);
+    let _ = tracing_subscriber::registry()
+        .with(native_layer.boxed())
+        .with(filter)
+        .init();
+    Arc::new(Mutex::new(reload_handle))
+});
+
+// needs to be alive for the duration of execution
+static WORKER: OnceLock<Arc<Mutex<Option<WorkerGuard>>>> = OnceLock::new();
+
+static FILE_INITIALIZED: LazyLock<Arc<AtomicBool>> =
+    LazyLock::new(|| Arc::new(AtomicBool::new(false)));
+
+/// turns on logging to a file on-disk in the directory specified.
+/// files will be prefixed with 'libxmtp.log' and suffixed with the timestamp,
+/// i.e "libxmtp.log.2025-04-02"
+/// A maximum of 10 log files are kept.
+#[uniffi::export]
+pub fn enter_debug_writer(directory: String) -> Result<(), GenericError> {
+    if !FILE_INITIALIZED.load(Ordering::Relaxed) {
+        enable_debug_file_inner(directory)?;
+        FILE_INITIALIZED.store(true, Ordering::Relaxed);
+    }
+    Ok(())
+}
+
+fn enable_debug_file_inner(directory: String) -> Result<(), GenericError> {
+    let file_appender = RollingFileAppender::builder()
+        .filename_prefix("libxmtp.log")
+        .max_log_files(10)
+        .build(&directory)?;
+    let (non_blocking, worker) = NonBlockingBuilder::default()
+        .thread_name("libxmtp-log-writer")
+        .finish(file_appender);
+    let _ = WORKER.set(Arc::new(Mutex::new(Some(worker))));
+    let handle = LOGGER.lock();
+    handle.modify(|l| {
+        *l.inner_mut().writer_mut() = EmptyOrFileWriter::File(non_blocking);
+        let filter = EnvFilter::builder()
+            .parse(FILTER_DIRECTIVE)
+            .unwrap_or_else(|_| EnvFilter::new("info"));
+        *l.filter_mut() = filter;
+    })?;
+    Ok(())
+}
+
+/// Flush loglines from libxmtp log writer to the file, ensuring logs are written.
+/// This should be called before the program exits, to ensure all the logs in memory have been
+/// written. this ends the writer thread.
+#[uniffi::export]
+pub fn exit_debug_writer() -> Result<(), GenericError> {
+    let handle = LOGGER.lock();
+    if let Some(w) = WORKER.get() {
+        if let Some(w) = w.lock().take() {
+            drop(w)
+        }
+    }
+    handle.modify(|l| {
+        *l.inner_mut().writer_mut() = EmptyOrFileWriter::Empty;
+        *l.filter_mut() = EnvFilter::builder()
+            .with_default_directive(LevelFilter::OFF.into())
+            .parse_lossy("off");
+    })?;
+    FILE_INITIALIZED.store(false, Ordering::Relaxed);
+    Ok(())
+}
+
 pub fn init_logger() {
-    LOGGER_INIT.call_once(|| {
-        let native_layer = native_layer();
-        let _ = tracing_subscriber::registry().with(native_layer).try_init();
-    });
+    let _ = *LOGGER;
 }
 
 #[cfg(test)]
@@ -102,6 +250,7 @@ pub use test_logger::*;
 #[cfg(test)]
 mod test_logger {
     use super::*;
+    use std::io::Read;
     use tracing_subscriber::EnvFilter;
 
     pub fn native_layer<S>() -> impl Layer<S>
@@ -113,8 +262,32 @@ mod test_logger {
 
     #[test]
     fn test_directive() {
-        let _filer = EnvFilter::builder()
+        let _filter = EnvFilter::builder()
             .parse(FILTER_DIRECTIVE)
             .expect("should parse correctly");
+    }
+
+    #[test]
+    fn test_file_appender() {
+        init_logger();
+        let s = xmtp_common::rand_hexstring();
+        let path = std::env::temp_dir().join(format!("{}-log-test", s));
+        enter_debug_writer(path.display().to_string()).unwrap();
+        let rand_nums = hex::encode(xmtp_common::rand_vec::<100>());
+        tracing::info!("test log");
+        tracing::debug!(rand_nums);
+        tracing::info!("test log");
+        exit_debug_writer().unwrap();
+
+        let entries = std::fs::read_dir(path).unwrap().collect::<Vec<_>>();
+        assert_eq!(entries.len(), 1);
+        for entry in entries.iter() {
+            println!("entry  {:?}", entry);
+            let mut file = std::fs::File::open(&entry.as_ref().unwrap().path()).unwrap();
+            let mut contents = String::new();
+            file.read_to_string(&mut contents).unwrap();
+            assert!(contents.contains(&rand_nums));
+            std::fs::remove_file(entry.as_ref().unwrap().path()).unwrap();
+        }
     }
 }

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -74,6 +74,7 @@ pub async fn connect_to_backend(
     is_secure: bool,
 ) -> Result<Arc<XmtpApiClient>, GenericError> {
     init_logger();
+
     log::info!(
         host,
         is_secure,

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1741481578,
-        "narHash": "sha256-JBTSyJFQdO3V8cgcL08VaBUByEU6P5kXbTJN6R0PFQo=",
+        "lastModified": 1743649204,
+        "narHash": "sha256-uourC72krB5YdGzpHaXOUBXaORkcabPNF+H7sMvZKsw=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "bb1c9567c43e4434f54e9481eb4b8e8e0d50f0b5",
+        "rev": "8b9ee4e59a737b1dbefbd398caae8595ecffcf6a",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1741934023,
-        "narHash": "sha256-PMzzgtK4a70hpaUbjASuvSzLGjJP/3P7mGnqQOyTBiM=",
+        "lastModified": 1742452566,
+        "narHash": "sha256-sVuLDQ2UIWfXUBbctzrZrXM2X05YjX08K7XHMztt36E=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "4f956eacc9ec619bcd98f4580c663a8749978cc8",
+        "rev": "7d9ba794daf5e8cc7ee728859bc688d8e26d5f06",
         "type": "github"
       },
       "original": {
@@ -41,11 +41,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1741352980,
-        "narHash": "sha256-+u2UunDA4Cl5Fci3m7S643HzKmIDAe+fiXrLqYsR2fs=",
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f4330d22f1c5d2ba72d3d22df5597d123fdb60a9",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
         "type": "github"
       },
       "original": {
@@ -75,11 +75,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1740993113,
-        "narHash": "sha256-XY6CUZft7wjB/cbLyi/xeOZHh2mizSAT0EaYo9wuRXI=",
+        "lastModified": 1743671500,
+        "narHash": "sha256-IJ2vPxTzDQNIEKScJ3JDOXBOJoXglErDeUI/I6rBOfU=",
         "owner": "shazow",
         "repo": "foundry.nix",
-        "rev": "ed2a08376f14c0caf2b97418c91a66872e5ab3e2",
+        "rev": "815a4d4a35ebf5c4ef855d8d4c5655fcbe63ee41",
         "type": "github"
       },
       "original": {
@@ -91,11 +91,11 @@
     },
     "mkshell-util": {
       "locked": {
-        "lastModified": 1740692349,
-        "narHash": "sha256-1+kTqYwUEPP8MESiVt0060vyXQb21xIDZjbgtcGSybk=",
+        "lastModified": 1743693235,
+        "narHash": "sha256-vYNsbSwTUeg8lWn88TfjLncpAda79eeiMW1b8OI2uvY=",
         "owner": "insipx",
         "repo": "mkShell-util.nix",
-        "rev": "962beb57c1d152a3f5599cfb89852a0dd4842893",
+        "rev": "39cbf41fea7db929df5d4abedc79006a24919d77",
         "type": "github"
       },
       "original": {
@@ -120,11 +120,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1740877520,
-        "narHash": "sha256-oiwv/ZK/2FhGxrCkQkB83i7GnWXPPLzoqFHpDD3uYpk=",
+        "lastModified": 1743296961,
+        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "147dee35aab2193b174e4c0868bd80ead5ce755c",
+        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1741865919,
-        "narHash": "sha256-4thdbnP6dlbdq+qZWTsm4ffAwoS8Tiq1YResB+RP6WE=",
+        "lastModified": 1743568003,
+        "narHash": "sha256-ZID5T65E8ruHqWRcdvZLsczWDOAWIE7om+vQOREwiX0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "573c650e8a14b2faa0041645ab18aed7e60f0c9a",
+        "rev": "b7ba7f9f45c5cd0d8625e9e217c28f8eb6a19a76",
         "type": "github"
       },
       "original": {
@@ -163,11 +163,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1741895161,
-        "narHash": "sha256-D8SLPa4vxA1EQdFi1SNJKeFOSCKk79hIv2l0ovfk2is=",
+        "lastModified": 1742296961,
+        "narHash": "sha256-gCpvEQOrugHWLimD1wTFOJHagnSEP6VYBDspq96Idu0=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "185f9deb452760f3abc2fde0500398e3198678cd",
+        "rev": "15d87419f1a123d8f888d608129c3ce3ff8f13d4",
         "type": "github"
       },
       "original": {

--- a/nix/libxmtp.nix
+++ b/nix/libxmtp.nix
@@ -48,7 +48,7 @@ let
 
   rust-toolchain = fenix.fromToolchainFile {
     file = ./../rust-toolchain.toml;
-    sha256 = "sha256-Hn2uaQzRLidAWpfmRwSRdImifGUCAb9HeAqTYFXWeQk=";
+    sha256 = "sha256-X/4ZBHO3iW0fOenQ3foEvscgAPJYl2abspaBThDOukI=";
   };
 in
 mkShell {

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -901,7 +901,7 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
     /// * message: UTF-8 or encoded message bytes
     /// * conn: Connection to SQLite database
     /// * envelope: closure that returns context-specific [`PlaintextEnvelope`]. Closure accepts
-    ///     timestamp attached to intent & stored message.
+    ///   timestamp attached to intent & stored message.
     fn prepare_message<F>(
         &self,
         message: &[u8],

--- a/xmtp_mls/src/groups/validated_commit.rs
+++ b/xmtp_mls/src/groups/validated_commit.rs
@@ -277,11 +277,11 @@ impl LibXMTPVersion {
  * Commit Validation Rules:
  * 1. If the `sequence_id` for an inbox has changed, it can only increase
  * 2. The client must create an expected diff of installations added and removed based on the difference between the current
- *      [`GroupMembership`] and the [`GroupMembership`] found in the [`StagedCommit`]
+ *    [`GroupMembership`] and the [`GroupMembership`] found in the [`StagedCommit`]
  * 3. Installations may only be added or removed in the commit if they were added/removed in the expected diff
  * 4. For updates (either updating a path or via an Update Proposal) clients must verify that the `installation_id` is
- *      present in the [`AssociationState`] for the `inbox_id` presented in the credential at the `to_sequence_id` found in the
- *      new [`GroupMembership`].
+ *    present in the [`AssociationState`] for the `inbox_id` presented in the credential at the `to_sequence_id` found in the
+ *    new [`GroupMembership`].
  * 5. All proposals in a commit must come from the same installation
  * 6. No PSK proposals will be allowed
  * 7. New installations may be missing from the commit but still be present in the expected diff.


### PR DESCRIPTION
introduces `enter_debug_writer` and `exit_debug_writer` to uniffi bindings.

Calling `enter_debug_writer` with a directory path will create a file with a timestamp in the format `libxmtp.log.2025-04-02` in the directory specified. that directory will hold a max of 10 log files.

`exit_debug_writer` flushes the loglines to the file and shuts down the log writer thread. this should be done before the program exits to ensure all loglines are present in the file on-disk