### PR TITLE
Pass in rotation policy and set cargo version on log file

### DIFF
--- a/bindings_ffi/src/logger.rs
+++ b/bindings_ffi/src/logger.rs
@@ -211,6 +211,57 @@ impl From<FfiLogRotation> for tracing_appender::rolling::Rotation {
     }
 }
 
+/// Enum representing log levels
+#[derive(uniffi::Enum, PartialEq, Debug, Clone)]
+pub enum FfiLogLevel {
+    /// Error level logs only
+    Error = 0,
+    /// Warning level and above
+    Warn = 1,
+    /// Info level and above
+    Info = 2,
+    /// Debug level and above
+    Debug = 3,
+    /// Trace level and all logs
+    Trace = 4,
+}
+
+impl FfiLogLevel {
+    fn to_filter_directive(&self) -> &str {
+        match self {
+            FfiLogLevel::Error => {
+                "xmtp_mls=error,xmtp_id=error,\
+                    xmtp_api=error,xmtp_api_grpc=error,xmtp_proto=error,\
+                    xmtp_common=error,xmtp_api_d14n=error,\
+                    xmtp_content_types=error,xmtp_cryptography=error,\
+                    xmtp_user_preferences=error,xmtpv3=error,xmtp_db=error"
+            }
+            FfiLogLevel::Warn => {
+                "xmtp_mls=warn,xmtp_id=warn,\
+                    xmtp_api=warn,xmtp_api_grpc=warn,xmtp_proto=warn,\
+                    xmtp_common=warn,xmtp_api_d14n=warn,\
+                    xmtp_content_types=warn,xmtp_cryptography=warn,\
+                    xmtp_user_preferences=warn,xmtpv3=warn,xmtp_db=warn"
+            }
+            FfiLogLevel::Info => {
+                "xmtp_mls=info,xmtp_id=info,\
+                    xmtp_api=info,xmtp_api_grpc=info,xmtp_proto=info,\
+                    xmtp_common=info,xmtp_api_d14n=info,\
+                    xmtp_content_types=info,xmtp_cryptography=info,\
+                    xmtp_user_preferences=info,xmtpv3=info,xmtp_db=info"
+            }
+            FfiLogLevel::Debug => FILTER_DIRECTIVE,
+            FfiLogLevel::Trace => {
+                "xmtp_mls=trace,xmtp_id=trace,\
+                    xmtp_api=trace,xmtp_api_grpc=trace,xmtp_proto=trace,\
+                    xmtp_common=trace,xmtp_api_d14n=trace,\
+                    xmtp_content_types=trace,xmtp_cryptography=trace,\
+                    xmtp_user_preferences=trace,xmtpv3=trace,xmtp_db=trace"
+            }
+        }
+    }
+}
+
 /// turns on logging to a file on-disk in the directory specified.
 /// files will be prefixed with 'libxmtp.log' and suffixed with the timestamp,
 /// i.e "libxmtp.log.2025-04-02"
@@ -218,11 +269,26 @@ impl From<FfiLogRotation> for tracing_appender::rolling::Rotation {
 #[uniffi::export]
 pub fn enter_debug_writer(
     directory: String,
+    log_level: FfiLogLevel,
     rotation: FfiLogRotation,
     max_files: u32,
 ) -> Result<(), GenericError> {
+    enter_debug_writer_with_level(directory, rotation, max_files, log_level)
+}
+
+/// turns on logging to a file on-disk with a specified log level.
+/// files will be prefixed with 'libxmtp.log' and suffixed with the timestamp,
+/// i.e "libxmtp.log.2025-04-02"
+/// A maximum of 'max_files' log files are kept.
+#[uniffi::export]
+pub fn enter_debug_writer_with_level(
+    directory: String,
+    rotation: FfiLogRotation,
+    max_files: u32,
+    log_level: FfiLogLevel,
+) -> Result<(), GenericError> {
     if !FILE_INITIALIZED.load(Ordering::Relaxed) {
-        enable_debug_file_inner(directory, rotation, max_files)?;
+        enable_debug_file_inner(directory, rotation, max_files, log_level)?;
         FILE_INITIALIZED.store(true, Ordering::Relaxed);
     }
     Ok(())
@@ -232,6 +298,7 @@ fn enable_debug_file_inner(
     directory: String,
     rotation: FfiLogRotation,
     max_files: u32,
+    log_level: FfiLogLevel,
 ) -> Result<(), GenericError> {
     let version = env!("CARGO_PKG_VERSION");
     let file_appender = RollingFileAppender::builder()
@@ -248,7 +315,7 @@ fn enable_debug_file_inner(
     handle.modify(|l| {
         *l.inner_mut().writer_mut() = EmptyOrFileWriter::File(non_blocking);
         let filter = EnvFilter::builder()
-            .parse(FILTER_DIRECTIVE)
+            .parse(log_level.to_filter_directive())
             .unwrap_or_else(|_| EnvFilter::new("info"));
         *l.filter_mut() = filter;
     })?;
@@ -308,10 +375,16 @@ mod test_logger {
         init_logger();
         let s = xmtp_common::rand_hexstring();
         let path = std::env::temp_dir().join(format!("{}-log-test", s));
-        enter_debug_writer(path.display().to_string(), FfiLogRotation::Minutely, 10).unwrap();
+        enter_debug_writer(
+            path.display().to_string(),
+            FfiLogLevel::Trace,
+            FfiLogRotation::Minutely,
+            10,
+        )
+        .unwrap();
         let rand_nums = hex::encode(xmtp_common::rand_vec::<100>());
         tracing::info!("test log");
-        tracing::debug!(rand_nums);
+        tracing::trace!(rand_nums);
         tracing::info!("test log");
         exit_debug_writer().unwrap();
 

--- a/bindings_ffi/src/logger.rs
+++ b/bindings_ffi/src/logger.rs
@@ -216,7 +216,11 @@ impl From<FfiLogRotation> for tracing_appender::rolling::Rotation {
 /// i.e "libxmtp.log.2025-04-02"
 /// A maximum of 'max_files' log files are kept.
 #[uniffi::export]
-pub fn enter_debug_writer(directory: String, rotation: FfiLogRotation, max_files: u32) -> Result<(), GenericError> {
+pub fn enter_debug_writer(
+    directory: String,
+    rotation: FfiLogRotation,
+    max_files: u32,
+) -> Result<(), GenericError> {
     if !FILE_INITIALIZED.load(Ordering::Relaxed) {
         enable_debug_file_inner(directory, rotation, max_files)?;
         FILE_INITIALIZED.store(true, Ordering::Relaxed);
@@ -224,14 +228,18 @@ pub fn enter_debug_writer(directory: String, rotation: FfiLogRotation, max_files
     Ok(())
 }
 
-fn enable_debug_file_inner(directory: String, rotation: FfiLogRotation, max_files: u32) -> Result<(), GenericError> {
+fn enable_debug_file_inner(
+    directory: String,
+    rotation: FfiLogRotation,
+    max_files: u32,
+) -> Result<(), GenericError> {
     let version = env!("CARGO_PKG_VERSION");
     let file_appender = RollingFileAppender::builder()
         .filename_prefix(format!("libxmtp-v{}.log", version))
         .rotation(rotation.into())
         .max_log_files(max_files as usize)
         .build(&directory)?;
-    
+
     let (non_blocking, worker) = NonBlockingBuilder::default()
         .thread_name("libxmtp-log-writer")
         .finish(file_appender);


### PR DESCRIPTION
### Add configurable log rotation and version-based log filenames to `enter_debug_writer` in `bindings_ffi/logger.rs`
* Introduces new FFI enums `FfiLogRotation` and `FfiLogLevel` for configuring log rotation periods and verbosity levels
* Modifies `enter_debug_writer` to accept rotation policy and log level parameters
* Adds new `enter_debug_writer_with_level` function implementing the enhanced logging configuration
* Updates log filename format to include cargo version (`libxmtp-v{version}.log`)

#### 📍Where to Start
Start with the modified `enter_debug_writer` function in [logger.rs](https://github.com/xmtp/libxmtp/pull/1819/files#diff-4bbabc172ad0589d5364e814aa0311a1792f06663618c2bbb82fe06fe62e418a) which now accepts additional parameters and calls the new `enter_debug_writer_with_level` function.

----

_[Macroscope](https://app.macroscope.com) summarized e1f1346._