### PR TITLE
opfs improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,6 +469,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "serde_bytes",
+ "tokio",
  "tracing",
  "tracing-subscriber",
  "tracing-web",

--- a/bindings_wasm/Cargo.toml
+++ b/bindings_wasm/Cargo.toml
@@ -30,6 +30,7 @@ xmtp_db.workspace = true
 xmtp_id.workspace = true
 xmtp_mls = { workspace = true, features = ["test-utils", "http-api"] }
 xmtp_proto = { workspace = true, features = ["proto_full"] }
+tokio = { workspace = true, features = ["sync"] }
 
 [dev-dependencies]
 wasm-bindgen-test.workspace = true

--- a/bindings_wasm/src/tests/mod.rs
+++ b/bindings_wasm/src/tests/mod.rs
@@ -9,13 +9,13 @@ use xmtp_api_http::constants::ApiUrls;
 use xmtp_cryptography::utils::{rng, LocalWallet};
 use xmtp_id::InboxOwner;
 
-async fn create_test_client() -> Client {
+async fn create_test_client(db: Option<String>) -> Client {
   // crate::opfs::Opfs::wipe_files().await.unwrap();
   let wallet = LocalWallet::new(&mut rng());
   let account_address = wallet.get_identifier().unwrap_throw();
   let host = ApiUrls::LOCAL_ADDRESS.to_string();
   let inbox_id = generate_inbox_id(account_address.clone().into());
-  let db = xmtp_common::tmp_path();
+  let db = db.unwrap_or(xmtp_common::tmp_path();
   create_client(
     host.clone(),
     inbox_id.unwrap(),

--- a/bindings_wasm/src/tests/web.rs
+++ b/bindings_wasm/src/tests/web.rs
@@ -6,22 +6,72 @@ wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
 #[wasm_bindgen_test]
 pub async fn test_create_client() {
-  create_test_client().await;
+  create_test_client(None).await;
 }
 
 #[wasm_bindgen_test]
 pub async fn wipe_client_files() {
-  xmtp_db::init_sqlite().await;
-  Opfs::wipe_files().await.unwrap();
-  let client = create_test_client().await;
-  let count = Opfs::get_file_count();
+  Opfs::init_opfs_clean_slate().await;
+  let _ = create_test_client(Some("test-sah-db".to_string())).await;
+  let count = Opfs::get_file_count().unwrap();
   assert_eq!(count, 1);
 
-  let files = Opfs::ls();
+  let files = Opfs::ls().unwrap();
   tracing::info!("Files");
   for file in files.iter() {
     tracing::info!("file: {}", file);
     Opfs::rm(file).unwrap();
   }
-  assert_eq!(Opfs::get_file_count(), 0);
+  assert_eq!(Opfs::get_file_count().unwrap(), 0);
+}
+
+#[wasm_bindgen_test]
+async fn it_should_exist() {
+  Opfs::init_opfs_clean_slate().await;
+  let _ = create_test_client(Some("test-sah-db".to_string())).await;
+  assert!(Opfs::exists());
+}
+
+#[wasm_bindgen_test]
+async fn it_should_not_have_error() {
+  Opfs::init_opfs_clean_slate().await;
+  let _ = create_test_client(Some("test-sah-db".to_string())).await;
+  assert_eq!(Opfs::error(), None);
+}
+
+#[wasm_bindgen_test]
+async fn it_should_have_files() {
+  Opfs::init_opfs_clean_slate().await;
+  let _ = create_test_client(Some("test-sah-db".to_string())).await;
+  let files = Opfs::ls().unwrap();
+  let file_count = Opfs::get_file_count().unwrap();
+  assert_eq!(file_count, 1);
+}
+
+#[wasm_bindgen_test]
+async fn it_should_have_capacity() {
+  Opfs::init_opfs_clean_slate().await;
+  let _ = create_test_client(Some("test-sah-db".to_string())).await;
+  assert_eq!(Opfs::get_capacity().unwrap(), 6);
+}
+
+#[wasm_bindgen_test]
+async fn it_should_manage_capacity() {
+  Opfs::init_opfs_clean_slate().await;
+  let _ = create_test_client(Some("test-sah-db".to_string())).await;
+  Opfs::add_capacity(1).await.unwrap();
+  assert_eq!(Opfs::get_capacity().unwrap(), 7);
+  Opfs::reduce_capacity(2).await.unwrap();
+  assert_eq!(Opfs::get_capacity().unwrap(), 5);
+  Opfs::add_capacity(1).await.unwrap();
+  assert_eq!(Opfs::get_capacity().unwrap(), 6);
+}
+
+#[wasm_bindgen_test]
+async fn it_should_get_file_names() {
+  Opfs::init_opfs_clean_slate().await;
+  let _ = create_test_client(Some("test-sah-db".to_string())).await;
+  let files: Vec<String> = Opfs::ls().unwrap();
+  assert_eq!(files, vec!["/test-sah-db".to_string()]);
+  assert_eq!(Opfs::get_file_count().unwrap(), 1);
 }

--- a/xmtp_db/src/encrypted_store/mod.rs
+++ b/xmtp_db/src/encrypted_store/mod.rs
@@ -42,7 +42,7 @@ pub use native::RawDbConnection;
 #[cfg(not(target_arch = "wasm32"))]
 pub use sqlcipher_connection::EncryptedConnection;
 #[cfg(target_arch = "wasm32")]
-pub use wasm::{OpfsSAHError, OpfsSAHPoolUtil, SQLITE, init_sqlite};
+pub use wasm::{OPFS, OpfsSAHError, OpfsSAHPoolUtil, init_opfs};
 
 use super::{StorageError, xmtp_openmls_provider::XmtpOpenMlsProviderPrivate};
 use crate::Store;


### PR DESCRIPTION
### Refactor OPFS implementation to improve error handling and add initialization controls in `bindings_wasm` package
* Implements proper error handling by modifying `ls()`, `get_file_count()`, and `get_capacity()` methods to return `Result` types in [opfs.rs](https://github.com/xmtp/libxmtp/pull/1826/files#diff-240b8cb26acfcf6e28e1086d5a4490d6627bcf122b1ea4d38d0e76a01112b545)
* Adds new `init_opfs_clean_slate()` method that initializes OPFS with file wiping and sets capacity to 6 in [opfs.rs](https://github.com/xmtp/libxmtp/pull/1826/files#diff-240b8cb26acfcf6e28e1086d5a4490d6627bcf122b1ea4d38d0e76a01112b545)
* Renames SQLite-related identifiers to OPFS throughout [wasm.rs](https://github.com/xmtp/libxmtp/pull/1826/files#diff-19c6744af0481bdbb202f3e10379f94040d4d9348d5f2397ed79047f7658117a) and [opfs.rs](https://github.com/xmtp/libxmtp/pull/1826/files#diff-240b8cb26acfcf6e28e1086d5a4490d6627bcf122b1ea4d38d0e76a01112b545)
* Adds comprehensive test coverage for OPFS functionality in [web.rs](https://github.com/xmtp/libxmtp/pull/1826/files#diff-ed09478efbae7f67eb6af40ad9bb3974288c7540446122f594e55632db48d889)
* Modifies `create_test_client` to accept optional database name parameter in [mod.rs](https://github.com/xmtp/libxmtp/pull/1826/files#diff-b835d89530fceeffa7f5fb97597f27b54bd86cbdc576f88dfeea0e4a07f5c349)

#### 📍Where to Start
Start with the OPFS implementation changes in [opfs.rs](https://github.com/xmtp/libxmtp/pull/1826/files#diff-240b8cb26acfcf6e28e1086d5a4490d6627bcf122b1ea4d38d0e76a01112b545), which contains the core functionality changes including the new error handling and initialization methods.

----

_[Macroscope](https://app.macroscope.com) summarized cd24779._