### PR TITLE
Fix libxmtp swift action

### DIFF
--- a/.github/workflows/update-swift-repo.yml
+++ b/.github/workflows/update-swift-repo.yml
@@ -111,4 +111,3 @@ jobs:
           - Updated LibXMTP.podspec version to ${{ steps.version_info.outputs.version }}
           - Updated binary URLs to point to the new release
           - Updated checksum in Package.swift"
-gs

--- a/.github/workflows/update-swift-repo.yml
+++ b/.github/workflows/update-swift-repo.yml
@@ -3,6 +3,17 @@ on:
   push:
     tags:
       - 'swift-bindings-*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to use (without swift-bindings- prefix)'
+        required: true
+      sha7:
+        description: 'Short SHA (7 characters) of the commit'
+        required: true
+      checksum:
+        description: 'Checksum of the release zip file'
+        required: true
 
 jobs:
   update-swift-repo:


### PR DESCRIPTION
### Add manual workflow trigger with required parameters to the Swift repository update GitHub Action workflow
The [update-swift-repo.yml](https://github.com/xmtp/libxmtp/pull/1827/files#diff-2a251e50547b6c13b497dca9ce07447047452023051b37ac79b4cab8b4d4e272) workflow now includes:
* New `workflow_dispatch` trigger with required input parameters for `version`, `sha7`, and `checksum`
* Removal of an erroneous 'gs' text at the end of the file

#### 📍Where to Start
Begin by reviewing the workflow configuration in [update-swift-repo.yml](https://github.com/xmtp/libxmtp/pull/1827/files#diff-2a251e50547b6c13b497dca9ce07447047452023051b37ac79b4cab8b4d4e272) to understand the new manual trigger setup and its required parameters.

----

_[Macroscope](https://app.macroscope.com) summarized 188cc50._