### PR TITLE
Libxmtp swift pr gh action works off tag or manual input

### DIFF
--- a/.github/workflows/update-swift-repo.yml
+++ b/.github/workflows/update-swift-repo.yml
@@ -44,7 +44,16 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             TAG="${{ github.event.inputs.tag }}"
           else
-            TAG="${{ github.ref_name }}"
+            # Find the swift-bindings-* tag on the current commit
+            COMMIT_SHA=$(git rev-parse HEAD)
+            SWIFT_TAG=$(git tag --points-at $COMMIT_SHA | grep "^swift-bindings-" | head -n 1)
+            
+            # If no swift-bindings-* tag found, fall back to github.ref_name
+            if [[ -z "$SWIFT_TAG" ]]; then
+              TAG="${{ github.ref_name }}"
+            else
+              TAG="$SWIFT_TAG"
+            fi
           fi
           
           # Extract version and SHA from tag

--- a/.github/workflows/update-swift-repo.yml
+++ b/.github/workflows/update-swift-repo.yml
@@ -5,14 +5,8 @@ on:
       - 'swift-bindings-*'
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Version to use (without swift-bindings- prefix)'
-        required: true
-      sha7:
-        description: 'Short SHA (7 characters) of the commit'
-        required: true
-      checksum:
-        description: 'Checksum of the release zip file'
+      tag:
+        description: 'Tag to use (e.g. swift-bindings-0.1.0.abc1234)'
         required: true
 
 jobs:
@@ -23,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: libxmtp
-          ref: ${{ github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref }}
       
       - name: Checkout libxmtp-swift
         uses: actions/checkout@v4
@@ -46,14 +40,23 @@ jobs:
           # Replace the major version in the original version string
           VERSION=$(echo $ORIG_VERSION | sed "s/^$MAJOR_VERSION/$NEW_MAJOR/")
           
-          SHA7="${{ github.event.client_payload.sha7 }}"
+          # Get the tag - either from the push event or from workflow_dispatch input
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            TAG="${{ github.ref_name }}"
+          fi
+          
+          # Extract version and SHA from tag
+          VERSION_INPUT=$(echo $TAG | sed 's/swift-bindings-//' | cut -d. -f1-3)
+          SHA7=$(echo $TAG | cut -d. -f4)
+          RELEASE_TAG="${TAG}"
           
           # If version contains "dev", append the git commit SHA
           if [[ "$VERSION" == *"dev"* ]]; then
             VERSION="${VERSION}.${SHA7}"
           fi
           
-          RELEASE_TAG="swift-bindings-${{ github.event.client_payload.version }}.${SHA7}"
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "sha7=${SHA7}" >> $GITHUB_OUTPUT
           echo "release_tag=${RELEASE_TAG}" >> $GITHUB_OUTPUT
@@ -86,8 +89,19 @@ jobs:
       
       - name: Get checksum from release
         id: get_checksum
+        env:
+          GH_TOKEN: ${{ secrets.LIBXMTP_SWIFT_PAT }}
         run: |
-          CHECKSUM="${{ github.event.client_payload.checksum }}"
+          # Fetch the checksum from the release description
+          RELEASE_TAG="${{ steps.version_info.outputs.release_tag }}"
+          CHECKSUM=$(gh api repos/xmtp/libxmtp/releases/tags/$RELEASE_TAG --jq '.body' | grep -o 'Checksum of LibXMTPSwiftFFI.zip: [a-f0-9]*' | cut -d' ' -f4)
+          
+          # Verify we got a valid checksum
+          if [[ ! $CHECKSUM =~ ^[a-f0-9]+$ ]]; then
+            echo "Failed to extract valid checksum from release description"
+            exit 1
+          fi
+          
           echo "checksum=${CHECKSUM}" >> $GITHUB_OUTPUT
       
       - name: Update Package.swift

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3169,7 +3169,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -6007,9 +6007,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3169,7 +3169,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6007,9 +6007,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
 dependencies = [
  "backtrace",
  "bytes",


### PR DESCRIPTION
### Modify GitHub workflow to use tag-based version handling for libxmtp Swift repository updates
The workflow now processes version information differently in [update-swift-repo.yml](https://github.com/xmtp/libxmtp/pull/1833/files#diff-2a251e50547b6c13b497dca9ce07447047452023051b37ac79b4cab8b4d4e272):

* Consolidates version inputs into a single `tag` parameter following the format `swift-bindings-0.1.0.abc1234`
* Extracts version and SHA7 information automatically from tags for both manual and push triggers
* Retrieves checksums from release descriptions via GitHub API instead of manual input
* Determines `RELEASE_TAG` directly from the tag value rather than constructing it

#### 📍Where to Start
Begin reviewing the workflow trigger and input parameter definitions in [update-swift-repo.yml](https://github.com/xmtp/libxmtp/pull/1833/files#diff-2a251e50547b6c13b497dca9ce07447047452023051b37ac79b4cab8b4d4e272), as this establishes the new tag-based version handling approach.

----

_[Macroscope](https://app.macroscope.com) summarized f63f91f._