### PR TITLE
address tokio sec advisory cargo deny fail

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3169,7 +3169,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -6007,9 +6007,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",


### PR DESCRIPTION
### Update `tokio` to version 1.44.2 and downgrade `windows-targets` to 0.48.5 to address security advisory
Updates dependency versions in [Cargo.lock](https://github.com/xmtp/libxmtp/pull/1834/files#diff-13ee4b2252c9e516a0547f2891aa2105c3ca71c6d7a1e682c69be97998dfc87e):
* Upgrades `tokio` from 1.44.1 to 1.44.2
* Downgrades `windows-targets` from 0.52.6 to 0.48.5

#### 📍Where to Start
Start by reviewing the version changes in [Cargo.lock](https://github.com/xmtp/libxmtp/pull/1834/files#diff-13ee4b2252c9e516a0547f2891aa2105c3ca71c6d7a1e682c69be97998dfc87e) to verify the dependency updates.

----

_[Macroscope](https://app.macroscope.com) summarized bc21148._