### PR TITLE
Migrate to new d14n CLI version

### DIFF
--- a/dev/docker/docker-compose-d14n.yml
+++ b/dev/docker/docker-compose-d14n.yml
@@ -17,7 +17,7 @@ services:
 
   register-node:
     platform: linux/amd64
-    image: ghcr.io/xmtp/xmtpd-cli:main
+    image: ghcr.io/xmtp/xmtpd-cli:sha-7e2f18f
     env_file:
       - local.env
     command: [
@@ -34,12 +34,12 @@ services:
 
   enable-node:
     platform: linux/amd64
-    image: ghcr.io/xmtp/xmtpd-cli:main
+    image: ghcr.io/xmtp/xmtpd-cli:sha-7e2f18f
     env_file:
       - local.env
     command: [
       "add-node-to-network",
-      "--private-key=${REGISTER_NODE_ADMIN_KEY}",
+      "--admin.private-key=${REGISTER_NODE_ADMIN_KEY}",
       "--node-id=100"
     ]
     depends_on:


### PR DESCRIPTION
### Update Docker services to use pinned xmtpd-cli version sha-7e2f18f and align CLI parameter format
The `docker-compose-d14n.yml` configuration updates the Docker image tags for both `register-node` and `enable-node` services from `main` to a specific SHA version, while also updating the CLI parameter format for the admin private key in the `enable-node` service. Changes are made in [docker-compose-d14n.yml](https://github.com/xmtp/libxmtp/pull/1835/files#diff-f3b95b320e721deae58c0f228c225c5dc895a08336200f71f989ac0764d95776).

#### 📍Where to Start
Begin by reviewing the service configuration changes in [docker-compose-d14n.yml](https://github.com/xmtp/libxmtp/pull/1835/files#diff-f3b95b320e721deae58c0f228c225c5dc895a08336200f71f989ac0764d95776), focusing on the `register-node` and `enable-node` service definitions.

----

_[Macroscope](https://app.macroscope.com) summarized a82504c._