### PR TITLE
Fix xmtpd-cli flag

### DIFF
--- a/dev/docker/docker-compose-d14n.yml
+++ b/dev/docker/docker-compose-d14n.yml
@@ -20,13 +20,14 @@ services:
     image: ghcr.io/xmtp/xmtpd-cli:main
     env_file:
       - local.env
-    command: [
-      "register-node",
-      "--http-address=${REGISTER_NODE_HTTP_ADDRESS}",
-      "--node-owner-address=${REGISTER_NODE_OWNER_ADDRESS}",
-      "--admin.private-key=${REGISTER_NODE_ADMIN_KEY}",
-      "--node-signing-key-pub=${REGISTER_NODE_PUBKEY}"
-    ]
+    command:
+      [
+        "register-node",
+        "--http-address=${REGISTER_NODE_HTTP_ADDRESS}",
+        "--node-owner-address=${REGISTER_NODE_OWNER_ADDRESS}",
+        "--admin.private-key=${REGISTER_NODE_ADMIN_KEY}",
+        "--node-signing-key-pub=${REGISTER_NODE_PUBKEY}",
+      ]
     depends_on:
       chain:
         condition: service_started
@@ -37,11 +38,12 @@ services:
     image: ghcr.io/xmtp/xmtpd-cli:main
     env_file:
       - local.env
-    command: [
-      "add-node-to-network",
-      "--private-key=${REGISTER_NODE_ADMIN_KEY}",
-      "--node-id=100"
-    ]
+    command:
+      [
+        "add-node-to-network",
+        "--admin.private-key=${REGISTER_NODE_ADMIN_KEY}",
+        "--node-id=100",
+      ]
     depends_on:
       chain:
         condition: service_started


### PR DESCRIPTION
### Update `xmtpd-cli` parameter name from `--private-key` to `--admin.private-key` in Docker Compose configuration
The changes in [docker-compose-d14n.yml](https://github.com/xmtp/libxmtp/pull/1836/files#diff-f3b95b320e721deae58c0f228c225c5dc895a08336200f71f989ac0764d95776) include:
* Standardize parameter naming by changing `--private-key` to `--admin.private-key` for the `REGISTER_NODE_ADMIN_KEY` environment variable in the second `xmtpd-cli` service
* Reformat command arrays in both `xmtpd-cli` services for improved readability

#### 📍Where to Start
Begin by reviewing the service configurations in [docker-compose-d14n.yml](https://github.com/xmtp/libxmtp/pull/1836/files#diff-f3b95b320e721deae58c0f228c225c5dc895a08336200f71f989ac0764d95776), focusing on the command parameter changes in the `xmtpd-cli` services.

----

_[Macroscope](https://app.macroscope.com) summarized df672b1._