### PR TITLE
use only v3 services for ci

### DIFF
--- a/dev/docker/compose-v3
+++ b/dev/docker/compose-v3
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -eou pipefail
+
+docker compose \
+  -f dev/docker/docker-compose.yml \
+  --env-file dev/docker/local.env \
+  -p "libxmtp" \
+  "$@"

--- a/dev/docker/up-v3
+++ b/dev/docker/up-v3
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -eou pipefail
+script_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+"${script_dir}"/compose-v3 pull
+"${script_dir}"/compose-v3 up -d --build --remove-orphans --wait --timeout 300


### PR DESCRIPTION
### Standardize Docker Compose execution by creating wrapper scripts for version 3 services in CI environment
Introduces two new shell scripts to standardize Docker container management:
* [compose-v3](https://github.com/xmtp/libxmtp/pull/1837/files#diff-5d75c69056c7813dd7e4244ca4445b5586ecd37c9ec61612bce308d3cf3f171a) script provides a wrapper for `docker compose` command with standardized configuration paths and environment variables
* [up-v3](https://github.com/xmtp/libxmtp/pull/1837/files#diff-670b8e953dc526f27ebbb26549df24e4c0030a439c7f4a7845abee3f162fdc90) script automates container startup process with a 300-second health check timeout

#### 📍Where to Start
Begin with the [compose-v3](https://github.com/xmtp/libxmtp/pull/1837/files#diff-5d75c69056c7813dd7e4244ca4445b5586ecd37c9ec61612bce308d3cf3f171a) script as it provides the core wrapper functionality that is utilized by the up-v3 script.

----

_[Macroscope](https://app.macroscope.com) summarized f0891a6._