### PR TITLE
Add WorldChain support

### DIFF
--- a/xmtp_id/src/scw_verifier/chain_urls_default.json
+++ b/xmtp_id/src/scw_verifier/chain_urls_default.json
@@ -5,5 +5,6 @@
   "eip155:324": "https://mainnet.era.zksync.io",
   "eip155:8453": "https://base.llamarpc.com",
   "eip155:42161": "https://arbitrum.llamarpc.com",
-  "eip155:59144": "https://linea-rpc.publicnode.com"
+  "eip155:59144": "https://linea-rpc.publicnode.com",
+  "eip155:480": "https://worldchain-mainnet.g.alchemy.com/public"
 }


### PR DESCRIPTION
## tl;dr

- Adds support for WorldChain to our Smart Contract signature verifier

## Notes

There is some risk when adding additional chains. As long as everyone is using the `RemoteSmartContractSignatureVerifier`, this is fine. If someone was using an outdated version of the local smart contract signature verifier (don't know of anyone using this) and they interacted with a WorldChain smart wallet you could get into a state where a group would fork, since some members would see the user as valid and others as invalid. 

This feels low risk since the local smart contract signature verifier is so unused, and WorldChain smart wallets are not on the network today.