### PR TITLE
fix local dockerfile

### DIFF
--- a/dev/docker/docker-compose.yml
+++ b/dev/docker/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     platform: linux/amd64
     build:
       context: ../..
-      dockerfile: ./dev/validation_service/Dockerfile
+      dockerfile: ./dev/validation_service/local.Dockerfile
     environment:
       ANVIL_URL: "http://anvil:8545"
   anvil:
@@ -47,4 +47,3 @@ services:
     image: postgres:13
     environment:
       POSTGRES_PASSWORD: xmtp
-


### PR DESCRIPTION
accidentally left in Dockerfile instead of changing it back to local.Dockerfile

(will make a new workflow for x86 devices in a different PR, but this is needed as not to break peoples local docker builds from main)