### PR TITLE
XmtpApiError Cleanup

### DIFF
--- a/common/src/retry.rs
+++ b/common/src/retry.rs
@@ -18,6 +18,23 @@
 
 use crate::time::Duration;
 use rand::Rng;
+use std::error::Error;
+use std::sync::Arc;
+
+// Rust 1.86 added Trait upcasting, so we can add these infallible conversions
+// which is useful when getting error messages
+impl From<Box<dyn RetryableError>> for Box<dyn Error> {
+    fn from(retryable: Box<dyn RetryableError>) -> Box<dyn Error> {
+        retryable
+    }
+}
+
+// NOTE: From<> implementation is not possible here b/c of rust orphan rules (relaxed for Box
+// types)
+/// Convert an Arc<RetryableError> to a Standard Library Arc<Error>
+pub fn arc_retryable_to_error(retryable: Arc<dyn RetryableError>) -> Arc<dyn Error> {
+    retryable
+}
 
 #[cfg(not(target_arch = "wasm32"))]
 pub type BoxedRetry = Retry<Box<dyn Strategy + Send + Sync>>;

--- a/xmtp_api/src/mls.rs
+++ b/xmtp_api/src/mls.rs
@@ -12,7 +12,6 @@ use xmtp_proto::xmtp::mls::api::v1::{
     SortDirection, SubscribeGroupMessagesRequest, SubscribeWelcomeMessagesRequest,
     UploadKeyPackageRequest, WelcomeMessage, WelcomeMessageInput,
 };
-use xmtp_proto::ApiError;
 // the max page size for queries
 const MAX_PAGE_SIZE: u32 = 100;
 
@@ -97,7 +96,7 @@ where
                         .await
                 })
             )
-            .map_err(ApiError::from)?;
+            .map_err(crate::dyn_err)?;
             let num_messages = result.messages.len();
             out.append(&mut result.messages);
 
@@ -141,7 +140,7 @@ where
                     .await
             })
         )
-        .map_err(ApiError::from)?;
+        .map_err(crate::dyn_err)?;
 
         Ok(result.messages.into_iter().next())
     }
@@ -177,7 +176,7 @@ where
                         .await
                 })
             )
-            .map_err(ApiError::from)?;
+            .map_err(crate::dyn_err)?;
 
             let num_messages = result.messages.len();
             out.append(&mut result.messages);
@@ -221,7 +220,7 @@ where
                     .await
             })
         )
-        .map_err(ApiError::from)?;
+        .map_err(crate::dyn_err)?;
 
         Ok(())
     }
@@ -242,10 +241,10 @@ where
                     .await
             })
         )
-        .map_err(ApiError::from)?;
+        .map_err(crate::dyn_err)?;
 
         if res.key_packages.len() != installation_keys.len() {
-            return Err(crate::Error::MismatchedKeyPackages {
+            return Err(crate::ApiError::MismatchedKeyPackages {
                 key_packages: res.key_packages.len(),
                 installation_keys: installation_keys.len(),
             });
@@ -279,7 +278,7 @@ where
                     .await
             })
         )
-        .map_err(ApiError::from)?;
+        .map_err(crate::dyn_err)?;
 
         Ok(())
     }
@@ -302,7 +301,7 @@ where
                     .await
             })
         )
-        .map_err(ApiError::from)?;
+        .map_err(crate::dyn_err)?;
 
         Ok(())
     }
@@ -320,8 +319,7 @@ where
                 filters: filters.into_iter().map(|f| f.into()).collect(),
             })
             .await
-            .map_err(ApiError::from)
-            .map_err(crate::Error::from)
+            .map_err(crate::dyn_err)
     }
 
     pub async fn subscribe_welcome_messages(
@@ -344,8 +342,7 @@ where
                 }],
             })
             .await
-            .map_err(ApiError::from)
-            .map_err(crate::Error::from)
+            .map_err(crate::dyn_err)
     }
 }
 

--- a/xmtp_api/src/test_utils.rs
+++ b/xmtp_api/src/test_utils.rs
@@ -59,18 +59,6 @@ pub enum MockError {
     RateLimit,
 }
 
-impl xmtp_proto::XmtpApiError for MockError {
-    fn api_call(&self) -> Option<xmtp_proto::ApiEndpoint> {
-        None
-    }
-    fn code(&self) -> Option<xmtp_proto::Code> {
-        None
-    }
-    fn grpc_message(&self) -> Option<&str> {
-        None
-    }
-}
-
 impl xmtp_common::RetryableError for MockError {
     fn is_retryable(&self) -> bool {
         true

--- a/xmtp_api_d14n/src/compat/d14n/identity.rs
+++ b/xmtp_api_d14n/src/compat/d14n/identity.rs
@@ -1,7 +1,6 @@
 use super::D14nClient;
 use crate::{d14n::PublishClientEnvelopes, d14n::QueryEnvelopes, endpoints::d14n::GetInboxIds};
 use xmtp_common::RetryableError;
-use xmtp_proto::XmtpApiError;
 use xmtp_proto::api_client::{IdentityStats, XmtpIdentityClient};
 use xmtp_proto::identity_v1;
 use xmtp_proto::traits::Client;
@@ -20,7 +19,7 @@ use xmtp_proto::xmtp::xmtpv4::message_api::{
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<C, P, E> XmtpIdentityClient for D14nClient<C, P>
 where
-    E: XmtpApiError + std::error::Error + RetryableError + Send + Sync + 'static,
+    E: std::error::Error + RetryableError + Send + Sync + 'static,
     P: Send + Sync + Client<Error = E>,
     C: Send + Sync + Client<Error = E>,
     ApiClientError<E>: From<ApiClientError<<P as Client>::Error>>

--- a/xmtp_api_d14n/src/compat/d14n/mls.rs
+++ b/xmtp_api_d14n/src/compat/d14n/mls.rs
@@ -1,7 +1,6 @@
 use crate::d14n::PublishClientEnvelopes;
 use crate::d14n::QueryEnvelope;
 use xmtp_common::RetryableError;
-use xmtp_proto::XmtpApiError;
 use xmtp_proto::api_client::{ApiStats, XmtpMlsClient};
 use xmtp_proto::mls_v1;
 use xmtp_proto::traits::Client;
@@ -18,7 +17,7 @@ use super::D14nClient;
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<C, P, E> XmtpMlsClient for D14nClient<C, P>
 where
-    E: XmtpApiError + std::error::Error + RetryableError + Send + Sync + 'static,
+    E: std::error::Error + RetryableError + Send + Sync + 'static,
     P: Send + Sync + Client,
     C: Send + Sync + Client<Error = E>,
     ApiClientError<E>: From<ApiClientError<<P as Client>::Error>>

--- a/xmtp_api_d14n/src/compat/d14n/streams.rs
+++ b/xmtp_api_d14n/src/compat/d14n/streams.rs
@@ -1,7 +1,6 @@
 use super::D14nClient;
 use futures::stream;
 use xmtp_common::RetryableError;
-use xmtp_proto::XmtpApiError;
 use xmtp_proto::api_client::XmtpMlsStreams;
 use xmtp_proto::mls_v1;
 use xmtp_proto::traits::{ApiClientError, Client};
@@ -12,7 +11,7 @@ impl<C, P, E> XmtpMlsStreams for D14nClient<C, P>
 where
     C: Send + Sync + Client<Error = E>,
     P: Send + Sync + Client,
-    E: XmtpApiError + std::error::Error + RetryableError + Send + Sync + 'static,
+    E: std::error::Error + RetryableError + Send + Sync + 'static,
 {
     type Error = ApiClientError<E>;
 

--- a/xmtp_api_d14n/src/compat/v3.rs
+++ b/xmtp_api_d14n/src/compat/v3.rs
@@ -1,7 +1,6 @@
 use crate::v3::*;
 use futures::stream;
 use xmtp_common::RetryableError;
-use xmtp_proto::XmtpApiError;
 use xmtp_proto::api_client::{
     ApiStats, IdentityStats, XmtpIdentityClient, XmtpMlsClient, XmtpMlsStreams,
 };
@@ -72,7 +71,7 @@ where
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<C, E> XmtpMlsClient for V3Client<C>
 where
-    E: XmtpApiError + std::error::Error + RetryableError + Send + Sync + 'static,
+    E: std::error::Error + RetryableError + Send + Sync + 'static,
     C: Send + Sync + Client<Error = E>,
     ApiClientError<E>: From<ApiClientError<<C as Client>::Error>> + Send + Sync + 'static,
 {
@@ -151,7 +150,7 @@ where
 impl<C, E> XmtpIdentityClient for V3Client<C>
 where
     C: Send + Sync + Client<Error = E>,
-    E: XmtpApiError + std::error::Error + RetryableError + Send + Sync + 'static,
+    E: std::error::Error + RetryableError + Send + Sync + 'static,
 {
     type Error = ApiClientError<E>;
 
@@ -225,7 +224,7 @@ where
 impl<C, E> XmtpMlsStreams for V3Client<C>
 where
     C: Send + Sync + Client<Error = E>,
-    E: XmtpApiError + std::error::Error + RetryableError + Send + Sync + 'static,
+    E: std::error::Error + RetryableError + Send + Sync + 'static,
 {
     type Error = ApiClientError<E>;
 

--- a/xmtp_api_grpc/src/error.rs
+++ b/xmtp_api_grpc/src/error.rs
@@ -54,23 +54,3 @@ impl xmtp_common::retry::RetryableError for GrpcError {
         true
     }
 }
-
-impl xmtp_proto::XmtpApiError for GrpcError {
-    fn api_call(&self) -> Option<xmtp_proto::ApiEndpoint> {
-        None
-    }
-
-    fn code(&self) -> Option<xmtp_proto::Code> {
-        match &self {
-            GrpcError::Status(status) => Some(status.code().into()),
-            _ => None,
-        }
-    }
-
-    fn grpc_message(&self) -> Option<&str> {
-        match &self {
-            GrpcError::Status(status) => Some(status.message()),
-            _ => None,
-        }
-    }
-}

--- a/xmtp_api_http/src/error.rs
+++ b/xmtp_api_http/src/error.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use xmtp_proto::{ApiEndpoint, Code, XmtpApiError};
 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct ErrorResponse {
@@ -39,25 +38,5 @@ pub enum HttpClientError {
 impl xmtp_common::RetryableError for HttpClientError {
     fn is_retryable(&self) -> bool {
         true
-    }
-}
-
-impl XmtpApiError for HttpClientError {
-    fn api_call(&self) -> Option<ApiEndpoint> {
-        None
-    }
-
-    fn code(&self) -> Option<Code> {
-        match self {
-            Self::Grpc(e) => Some(e.code.into()),
-            _ => None,
-        }
-    }
-
-    fn grpc_message(&self) -> Option<&str> {
-        match self {
-            Self::Grpc(e) => Some(&e.message),
-            _ => None,
-        }
     }
 }

--- a/xmtp_id/src/scw_verifier/mod.rs
+++ b/xmtp_id/src/scw_verifier/mod.rs
@@ -35,7 +35,7 @@ pub enum VerifierError {
     #[error("URLs must be preceeded with eip144:")]
     MalformedEipUrl,
     #[error(transparent)]
-    Api(#[from] xmtp_api::Error),
+    Api(#[from] xmtp_api::ApiError),
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -39,11 +39,9 @@ pub enum ClientBuilderError {
     #[error(transparent)]
     Identity(#[from] crate::identity::IdentityError),
     #[error(transparent)]
-    WrappedApiError(#[from] xmtp_api::Error),
+    WrappedApiError(#[from] xmtp_api::ApiError),
     #[error(transparent)]
     GroupError(#[from] crate::groups::GroupError),
-    #[error(transparent)]
-    Api(#[from] xmtp_proto::ApiError),
     #[error(transparent)]
     DeviceSync(#[from] crate::groups::device_sync::DeviceSyncError),
 }

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -71,7 +71,7 @@ pub enum ClientError {
     #[error("storage error: {0}")]
     Storage(#[from] StorageError),
     #[error("API error: {0}")]
-    Api(#[from] xmtp_api::Error),
+    Api(#[from] xmtp_api::ApiError),
     #[error("identity error: {0}")]
     Identity(#[from] crate::identity::IdentityError),
     #[error("TLS Codec error: {0}")]

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -124,7 +124,7 @@ pub enum GroupError {
     #[error("Max user limit exceeded.")]
     UserLimitExceeded,
     #[error("api error: {0}")]
-    WrappedApi(#[from] xmtp_api::Error),
+    WrappedApi(#[from] xmtp_api::ApiError),
     #[error("invalid group membership")]
     InvalidGroupMembership,
     #[error("storage error: {0}")]

--- a/xmtp_mls/src/identity.rs
+++ b/xmtp_mls/src/identity.rs
@@ -218,7 +218,7 @@ pub enum IdentityError {
     #[error(transparent)]
     Signer(#[from] xmtp_cryptography::SignerError),
     #[error(transparent)]
-    ApiClient(#[from] xmtp_api::Error),
+    ApiClient(#[from] xmtp_api::ApiError),
     #[error(transparent)]
     AddressValidation(#[from] IdentifierValidationError),
 }

--- a/xmtp_mls/src/subscriptions/mod.rs
+++ b/xmtp_mls/src/subscriptions/mod.rs
@@ -192,9 +192,9 @@ pub enum SubscribeError {
     #[error(transparent)]
     ConversationStream(#[from] stream_conversations::ConversationStreamError),
     #[error(transparent)]
-    Api(#[from] xmtp_proto::ApiError),
-    #[error(transparent)]
-    ApiClient(#[from] xmtp_api::Error),
+    ApiClient(#[from] xmtp_api::ApiError),
+    #[error("{0}")]
+    BoxError(Box<dyn RetryableError + Send + Sync>),
 }
 
 impl RetryableError for SubscribeError {
@@ -209,8 +209,8 @@ impl RetryableError for SubscribeError {
             NotFound(e) => retryable!(e),
             MessageStream(e) => retryable!(e),
             ConversationStream(e) => retryable!(e),
-            Api(e) => retryable!(e),
             ApiClient(e) => retryable!(e),
+            BoxError(e) => retryable!(e),
         }
     }
 }

--- a/xmtp_mls/src/subscriptions/stream_messages.rs
+++ b/xmtp_mls/src/subscriptions/stream_messages.rs
@@ -250,7 +250,7 @@ where
                 if let Some(envelope) = ready!(this.inner.poll_next(cx)) {
                     let future = ProcessMessageFuture::new(
                         *this.client,
-                        envelope.map_err(xmtp_proto::ApiError::from)?,
+                        envelope.map_err(|e| SubscribeError::BoxError(Box::new(e)))?,
                     )?;
                     let future = future.process();
                     this.state.set(State::Processing {

--- a/xmtp_proto/src/api_client.rs
+++ b/xmtp_proto/src/api_client.rs
@@ -17,6 +17,7 @@ use crate::xmtp::mls::api::v1::{
 use futures::Stream;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use xmtp_common::RetryableError;
 
 #[cfg(any(test, feature = "test-utils"))]
 pub trait XmtpTestClient {
@@ -91,94 +92,6 @@ pub mod trait_impls {
     }
 }
 
-pub trait XmtpApiSubscription {
-    fn is_closed(&self) -> bool;
-    fn get_messages(&self) -> Vec<Envelope>;
-    fn close_stream(&mut self);
-}
-
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-pub trait MutableApiSubscription: Stream<Item = Result<Envelope, Self::Error>> + Send {
-    type Error;
-    async fn update(&mut self, req: SubscribeRequest) -> Result<(), Self::Error>;
-    fn close(&self);
-}
-
-// Wasm futures don't have `Send` or `Sync` bounds.
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-pub trait XmtpApiClient {
-    type Subscription: XmtpApiSubscription;
-    type MutableSubscription: MutableApiSubscription;
-    type Error;
-
-    async fn publish(
-        &self,
-        token: String,
-        request: PublishRequest,
-    ) -> Result<PublishResponse, Self::Error>;
-
-    async fn subscribe(&self, request: SubscribeRequest)
-        -> Result<Self::Subscription, Self::Error>;
-
-    async fn subscribe2(
-        &self,
-        request: SubscribeRequest,
-    ) -> Result<Self::MutableSubscription, Self::Error>;
-
-    async fn query(&self, request: QueryRequest) -> Result<QueryResponse, Self::Error>;
-
-    async fn batch_query(
-        &self,
-        request: BatchQueryRequest,
-    ) -> Result<BatchQueryResponse, Self::Error>;
-}
-
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-impl<T> XmtpApiClient for Box<T>
-where
-    T: XmtpApiClient + Sync + ?Sized,
-{
-    type Subscription = <T as XmtpApiClient>::Subscription;
-    type MutableSubscription = <T as XmtpApiClient>::MutableSubscription;
-    type Error = <T as XmtpApiClient>::Error;
-
-    async fn publish(
-        &self,
-        token: String,
-        request: PublishRequest,
-    ) -> Result<PublishResponse, Self::Error> {
-        (**self).publish(token, request).await
-    }
-
-    async fn subscribe(
-        &self,
-        request: SubscribeRequest,
-    ) -> Result<Self::Subscription, Self::Error> {
-        (**self).subscribe(request).await
-    }
-
-    async fn subscribe2(
-        &self,
-        request: SubscribeRequest,
-    ) -> Result<Self::MutableSubscription, Self::Error> {
-        (**self).subscribe2(request).await
-    }
-
-    async fn query(&self, request: QueryRequest) -> Result<QueryResponse, Self::Error> {
-        (**self).query(request).await
-    }
-
-    async fn batch_query(
-        &self,
-        request: BatchQueryRequest,
-    ) -> Result<BatchQueryResponse, Self::Error> {
-        (**self).batch_query(request).await
-    }
-}
-
 #[derive(Clone, Default, Debug)]
 pub struct ApiStats {
     pub upload_key_package: Arc<EndpointStats>,
@@ -217,7 +130,7 @@ impl EndpointStats {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 pub trait XmtpMlsClient {
-    type Error: crate::XmtpApiError + 'static;
+    type Error: RetryableError + Send + Sync + 'static;
     async fn upload_key_package(&self, request: UploadKeyPackageRequest)
         -> Result<(), Self::Error>;
     async fn fetch_key_packages(
@@ -362,7 +275,7 @@ pub trait XmtpMlsStreams {
     type WelcomeMessageStream<'a>: Stream<Item = Result<WelcomeMessage, Self::Error>> + Send + 'a
     where
         Self: 'a;
-    type Error: crate::XmtpApiError + 'static;
+    type Error: RetryableError + Send + Sync + 'static;
 
     async fn subscribe_group_messages(
         &self,
@@ -384,7 +297,7 @@ pub trait XmtpMlsStreams {
     type WelcomeMessageStream<'a>: Stream<Item = Result<WelcomeMessage, Self::Error>> + 'a
     where
         Self: 'a;
-    type Error: crate::XmtpApiError + 'static;
+    type Error: RetryableError + Send + Sync + 'static;
 
     async fn subscribe_group_messages(
         &self,
@@ -465,7 +378,7 @@ where
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 pub trait XmtpIdentityClient {
-    type Error: crate::XmtpApiError + 'static;
+    type Error: RetryableError + Send + Sync + 'static;
     async fn publish_identity_update(
         &self,
         request: PublishIdentityUpdateRequest,

--- a/xmtp_proto/src/error.rs
+++ b/xmtp_proto/src/error.rs
@@ -1,159 +1,5 @@
 use thiserror::Error;
-use xmtp_common::retry::RetryableError;
-
-pub trait XmtpApiError:
-    std::fmt::Debug + std::fmt::Display + std::error::Error + Send + Sync + RetryableError
-{
-    /// The failing ApiCall
-    fn api_call(&self) -> Option<ApiEndpoint>;
-    /// grpc status error code
-    fn code(&self) -> Option<Code>;
-    /// message associated with this gRPC Error, if any.
-    /// this is not the same as the Display implementation
-    fn grpc_message(&self) -> Option<&str>;
-}
-
-#[derive(Error, Debug)]
-pub struct ApiError {
-    inner: Box<dyn XmtpApiError>,
-}
-
-impl RetryableError for ApiError {
-    fn is_retryable(&self) -> bool {
-        self.inner.is_retryable()
-    }
-}
-
-impl std::fmt::Display for ApiError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.inner)
-    }
-}
-
-impl<E> From<E> for ApiError
-where
-    E: XmtpApiError + std::error::Error + std::fmt::Display + std::fmt::Debug + 'static,
-{
-    fn from(v: E) -> ApiError {
-        Self { inner: Box::new(v) }
-    }
-}
-
-// GRPC Error Code
-#[derive(PartialEq, Eq, Copy, Clone, Debug)]
-pub enum Code {
-    /// The operation completed successfully.
-    Ok = 0,
-    /// The operation was cancelled.
-    Cancelled = 1,
-    /// Unknown error.
-    Unknown = 2,
-    /// Client specified an invalid argument.
-    InvalidArgument = 3,
-    /// Deadline expired before operation could complete.
-    DeadlineExceeded = 4,
-    /// Some requested entity was not found.
-    NotFound = 5,
-    /// Some entity that we attempted to create already exists.
-    AlreadyExists = 6,
-    /// The caller does not have permission to execute the specified operation.
-    PermissionDenied = 7,
-    /// Some resource has been exhausted (rate limit).
-    ResourceExhausted = 8,
-    /// The system is not in a state required for the operation's execution.
-    FailedPrecondition = 9,
-    /// The operation was aborted.
-    Aborted = 10,
-    /// Operation was attempted past the valid range.
-    OutOfRange = 11,
-    /// Operation is not implemented or not supported.
-    Unimplemented = 12,
-    /// Internal error.
-    Internal = 13,
-    /// The service is currently unavailable.
-    Unavailable = 14,
-    /// Unrecoverable data loss or corruption.
-    DataLoss = 15,
-    /// The request does not have valid authentication credentials
-    Unauthenticated = 16,
-}
-
-impl From<usize> for Code {
-    fn from(v: usize) -> Code {
-        use Code::*;
-        match v {
-            0 => Ok,
-            1 => Cancelled,
-            2 => Unknown,
-            3 => InvalidArgument,
-            4 => DeadlineExceeded,
-            5 => NotFound,
-            6 => AlreadyExists,
-            7 => PermissionDenied,
-            8 => ResourceExhausted,
-            9 => FailedPrecondition,
-            10 => Aborted,
-            11 => OutOfRange,
-            12 => Unimplemented,
-            13 => Internal,
-            14 => Unavailable,
-            15 => DataLoss,
-            16 => Unauthenticated,
-            _ => Unknown,
-        }
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-mod convert {
-    impl From<super::Code> for tonic::Code {
-        fn from(v: super::Code) -> tonic::Code {
-            match v {
-                super::Code::Ok => tonic::Code::Ok,
-                super::Code::Cancelled => tonic::Code::Cancelled,
-                super::Code::Unknown => tonic::Code::Unknown,
-                super::Code::InvalidArgument => tonic::Code::InvalidArgument,
-                super::Code::DeadlineExceeded => tonic::Code::DeadlineExceeded,
-                super::Code::NotFound => tonic::Code::NotFound,
-                super::Code::AlreadyExists => tonic::Code::AlreadyExists,
-                super::Code::PermissionDenied => tonic::Code::PermissionDenied,
-                super::Code::ResourceExhausted => tonic::Code::ResourceExhausted,
-                super::Code::FailedPrecondition => tonic::Code::FailedPrecondition,
-                super::Code::Aborted => tonic::Code::Aborted,
-                super::Code::OutOfRange => tonic::Code::OutOfRange,
-                super::Code::Unimplemented => tonic::Code::Unimplemented,
-                super::Code::Internal => tonic::Code::Internal,
-                super::Code::Unavailable => tonic::Code::Unavailable,
-                super::Code::DataLoss => tonic::Code::DataLoss,
-                super::Code::Unauthenticated => tonic::Code::Unauthenticated,
-            }
-        }
-    }
-
-    impl From<tonic::Code> for super::Code {
-        fn from(v: tonic::Code) -> super::Code {
-            match v {
-                tonic::Code::Ok => super::Code::Ok,
-                tonic::Code::Cancelled => super::Code::Cancelled,
-                tonic::Code::Unknown => super::Code::Unknown,
-                tonic::Code::InvalidArgument => super::Code::InvalidArgument,
-                tonic::Code::DeadlineExceeded => super::Code::DeadlineExceeded,
-                tonic::Code::NotFound => super::Code::NotFound,
-                tonic::Code::AlreadyExists => super::Code::AlreadyExists,
-                tonic::Code::PermissionDenied => super::Code::PermissionDenied,
-                tonic::Code::ResourceExhausted => super::Code::ResourceExhausted,
-                tonic::Code::FailedPrecondition => super::Code::FailedPrecondition,
-                tonic::Code::Aborted => super::Code::Aborted,
-                tonic::Code::OutOfRange => super::Code::OutOfRange,
-                tonic::Code::Unimplemented => super::Code::Unimplemented,
-                tonic::Code::Internal => super::Code::Internal,
-                tonic::Code::Unavailable => super::Code::Unavailable,
-                tonic::Code::DataLoss => super::Code::DataLoss,
-                tonic::Code::Unauthenticated => super::Code::Unauthenticated,
-            }
-        }
-    }
-}
+use xmtp_common::RetryableError;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum ApiEndpoint {
@@ -253,6 +99,17 @@ pub enum ConversionError {
     OpenMls(#[from] openmls::prelude::Error),
     #[error(transparent)]
     Protocol(#[from] openmls::framing::errors::ProtocolMessageError),
+}
+
+// Conversion errors themselves not really retryable because the bytes are static,
+// the conversions are done in-memory, so a retrying a conversion should not change the outcome.
+// The API call is what should be retried.
+// If retry on a conversion error is desired a new error enum + custom Retrayble implementation
+// should be preferred.
+impl RetryableError for ConversionError {
+    fn is_retryable(&self) -> bool {
+        false
+    }
 }
 
 /// Error resulting from proto conversions/mutations

--- a/xmtp_proto/src/lib.rs
+++ b/xmtp_proto/src/lib.rs
@@ -34,7 +34,6 @@ pub mod prelude {
         ApiBuilder, ArcedXmtpApi, BoxedXmtpApi, XmtpIdentityClient, XmtpMlsClient, XmtpMlsStreams,
     };
     pub use super::traits::{ApiClientError, Client, Endpoint, Query};
-    pub use super::XmtpApiError;
 }
 
 pub mod identity_v1 {

--- a/xmtp_proto/src/traits.rs
+++ b/xmtp_proto/src/traits.rs
@@ -6,7 +6,7 @@ use std::borrow::Cow;
 use thiserror::Error;
 use xmtp_common::{retry_async, retryable, BoxedRetry, RetryableError};
 
-use crate::{api_client::ApiStats, ApiEndpoint, Code, ProtoError, XmtpApiError};
+use crate::{api_client::ApiStats, ApiEndpoint, ProtoError};
 
 pub trait HasStats {
     fn stats(&self) -> &ApiStats;
@@ -47,7 +47,7 @@ pub type BoxedClient = Box<
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 pub trait Client {
-    type Error: XmtpApiError + std::error::Error + Send + Sync + 'static;
+    type Error: std::error::Error + Send + Sync + 'static;
     type Stream: futures::Stream;
 
     async fn request(
@@ -80,7 +80,7 @@ where
         retry: BoxedRetry,
     ) -> Result<T, ApiClientError<C::Error>>
     where
-        C::Error: RetryableError + XmtpApiError,
+        C::Error: RetryableError,
     {
         retry_async!(retry, (async { self.query(client).await }))
     }
@@ -93,7 +93,7 @@ impl<E, T, C> Query<T, C> for E
 where
     E: Endpoint<Output = T> + Sync,
     C: Client + Sync + Send,
-    C::Error: XmtpApiError,
+    C::Error: std::error::Error,
     T: Default + prost::Message + 'static,
     // TODO: figure out how to get conversions right
     // T: TryFrom<E::Output>,
@@ -120,7 +120,7 @@ where
 
 impl<E> ApiClientError<E>
 where
-    E: XmtpApiError + std::error::Error + 'static,
+    E: std::error::Error + 'static,
 {
     /*
         fn client(endpoint: String, source: E) -> Self {
@@ -169,39 +169,9 @@ pub enum ApiClientError<E: std::error::Error> {
     InvalidUri(#[from] http::uri::InvalidUri),
 }
 
-//TODO: this should just be apart of the standard rust error type
-impl<E> XmtpApiError for ApiClientError<E>
-where
-    E: XmtpApiError + std::error::Error + RetryableError + 'static,
-{
-    fn api_call(&self) -> Option<ApiEndpoint> {
-        match self {
-            Self::ClientWithEndpoint { source, .. } => source.api_call(),
-            Self::Client { source } => source.api_call(),
-            _ => None,
-        }
-    }
-
-    fn code(&self) -> Option<Code> {
-        match self {
-            Self::ClientWithEndpoint { source, .. } => source.code(),
-            Self::Client { source } => source.code(),
-            _ => None,
-        }
-    }
-
-    fn grpc_message(&self) -> Option<&str> {
-        match self {
-            Self::ClientWithEndpoint { source, .. } => source.grpc_message(),
-            Self::Client { source } => source.grpc_message(),
-            _ => None,
-        }
-    }
-}
-
 impl<E> RetryableError for ApiClientError<E>
 where
-    E: XmtpApiError + RetryableError + std::error::Error + 'static,
+    E: RetryableError + std::error::Error + 'static,
 {
     fn is_retryable(&self) -> bool {
         use ApiClientError::*;
@@ -219,7 +189,7 @@ where
 }
 
 // Infallible errors by definition can never occur
-impl<E: std::error::Error + XmtpApiError> From<std::convert::Infallible> for ApiClientError<E> {
+impl<E: std::error::Error> From<std::convert::Infallible> for ApiClientError<E> {
     fn from(_v: std::convert::Infallible) -> ApiClientError<E> {
         unreachable!()
     }
@@ -267,19 +237,6 @@ pub mod mock {
 
     #[derive(thiserror::Error, Debug)]
     pub enum MockError {}
-    impl XmtpApiError for MockError {
-        fn api_call(&self) -> Option<ApiEndpoint> {
-            None
-        }
-
-        fn code(&self) -> Option<Code> {
-            None
-        }
-
-        fn grpc_message(&self) -> Option<&str> {
-            None
-        }
-    }
 
     impl RetryableError for MockError {
         fn is_retryable(&self) -> bool {


### PR DESCRIPTION
The `XmtpApiError` trait was a way to hoist the gRPC errors into the higher level context of ApiClientWrapper. Since rate limit handling is now delegated to the lower level client, we no longer need this trait and can simplify