### PR TITLE
Add serde rename for validationError field of KeyPackageStatus

### DIFF
--- a/bindings_wasm/src/inbox_state.rs
+++ b/bindings_wasm/src/inbox_state.rs
@@ -84,6 +84,7 @@ pub struct KeyPackageStatus {
   #[wasm_bindgen(js_name = lifetime)]
   pub lifetime: Option<Lifetime>,
   #[wasm_bindgen(js_name = validationError)]
+  #[serde(rename = "validationError")]
   pub validation_error: Option<String>,
 }
 


### PR DESCRIPTION
validationError field was missing in browser sdk after serialization