### PR TITLE
Ensure previous worker processes are cleaned up before starting persistent logs.

### DIFF
--- a/bindings_ffi/src/logger.rs
+++ b/bindings_ffi/src/logger.rs
@@ -300,6 +300,9 @@ fn enable_debug_file_inner(
     max_files: u32,
     log_level: FfiLogLevel,
 ) -> Result<(), GenericError> {
+    // First, ensure any previous logger is properly shut down
+    let _ = exit_debug_writer();
+    
     let version = env!("CARGO_PKG_VERSION");
     let file_appender = RollingFileAppender::builder()
         .filename_prefix(format!("libxmtp-v{}.log", version))
@@ -310,7 +313,17 @@ fn enable_debug_file_inner(
     let (non_blocking, worker) = NonBlockingBuilder::default()
         .thread_name("libxmtp-log-writer")
         .finish(file_appender);
-    let _ = WORKER.set(Arc::new(Mutex::new(Some(worker))));
+    
+    // Initialize the worker container if needed
+    if WORKER.get().is_none() {
+        let _ = WORKER.set(Arc::new(Mutex::new(None)));
+    }
+    
+    // Now we can safely update the worker
+    if let Some(worker_container) = WORKER.get() {
+        *worker_container.lock() = Some(worker);
+    }
+    
     let handle = LOGGER.lock();
     handle.modify(|l| {
         *l.inner_mut().writer_mut() = EmptyOrFileWriter::File(non_blocking);

--- a/bindings_ffi/src/logger.rs
+++ b/bindings_ffi/src/logger.rs
@@ -302,7 +302,7 @@ fn enable_debug_file_inner(
 ) -> Result<(), GenericError> {
     // First, ensure any previous logger is properly shut down
     let _ = exit_debug_writer();
-    
+
     let version = env!("CARGO_PKG_VERSION");
     let file_appender = RollingFileAppender::builder()
         .filename_prefix(format!("libxmtp-v{}.log", version))
@@ -313,17 +313,17 @@ fn enable_debug_file_inner(
     let (non_blocking, worker) = NonBlockingBuilder::default()
         .thread_name("libxmtp-log-writer")
         .finish(file_appender);
-    
+
     // Initialize the worker container if needed
     if WORKER.get().is_none() {
         let _ = WORKER.set(Arc::new(Mutex::new(None)));
     }
-    
+
     // Now we can safely update the worker
     if let Some(worker_container) = WORKER.get() {
         *worker_container.lock() = Some(worker);
     }
-    
+
     let handle = LOGGER.lock();
     handle.modify(|l| {
         *l.inner_mut().writer_mut() = EmptyOrFileWriter::File(non_blocking);


### PR DESCRIPTION
The behavior I was seeing in downstream SDKs was the following:

1. ❌The first time I started the persistent logs they did not work. They would create an empty file but not write to them. (this might not have been the very first app run)
2.  ✅ Killing the app process and starting the persistent logs, then they would start working again. 
3. ❌Deactivating and trying to start again would get me back in the state of 1.

After this update:

1. ✅ First time I start the persistent logs they seem to work, files are updating as expected.
2. ✅ Killing and restarting the app and starting persistent logging works as expected
3. ✅ Deactivating and restarting the logs also seems to work fine.