### PR TITLE
Add Tester

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1066,9 +1066,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -7882,11 +7882,14 @@ name = "xmtp_mls"
 version = "1.2.0-dev"
 dependencies = [
  "aes-gcm",
+ "anyhow",
  "async-compression",
+ "async-trait",
  "bincode",
  "bytes",
  "chrono",
  "const_format",
+ "coset",
  "criterion",
  "ctor",
  "diesel",
@@ -7894,6 +7897,7 @@ dependencies = [
  "ethers",
  "fdlimit",
  "futures",
+ "futures-executor",
  "futures-util",
  "getrandom 0.2.15",
  "gloo-timers 0.3.0",
@@ -7910,8 +7914,10 @@ dependencies = [
  "openssl",
  "openssl-sys",
  "parking_lot 0.12.3",
+ "passkey",
  "pin-project-lite",
  "prost",
+ "public-suffix",
  "rand 0.8.5",
  "reqwest 0.12.15",
  "rstest",
@@ -7929,6 +7935,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trait-variant",
+ "url",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-sys",

--- a/bindings_ffi/src/inbox_owner.rs
+++ b/bindings_ffi/src/inbox_owner.rs
@@ -1,8 +1,9 @@
 use crate::identity::FfiIdentifier;
-use xmtp_cryptography::signature::{
-    IdentifierValidationError, RecoverableSignature, SignatureError,
+use xmtp_cryptography::signature::{IdentifierValidationError, SignatureError};
+use xmtp_id::associations::{
+    unverified::{UnverifiedRecoverableEcdsaSignature, UnverifiedSignature},
+    Identifier,
 };
-use xmtp_id::associations::Identifier;
 
 // TODO proper error handling
 #[derive(uniffi::Error, Debug, thiserror::Error)]
@@ -49,11 +50,13 @@ impl xmtp_mls::InboxOwner for RustInboxOwner {
         ident.try_into()
     }
 
-    fn sign(&self, text: &str) -> Result<RecoverableSignature, SignatureError> {
+    fn sign(&self, text: &str) -> Result<UnverifiedSignature, SignatureError> {
         let bytes = self
             .ffi_inbox_owner
             .sign(text.to_string())
             .map_err(|_flat_err| SignatureError::Unknown)?;
-        Ok(RecoverableSignature::Eip191Signature(bytes))
+        Ok(UnverifiedSignature::RecoverableEcdsa(
+            UnverifiedRecoverableEcdsaSignature::new(bytes),
+        ))
     }
 }

--- a/xmtp_debug/src/app.rs
+++ b/xmtp_debug/src/app.rs
@@ -28,8 +28,6 @@ use std::{fs, path::PathBuf, sync::Arc};
 use xmtp_cryptography::utils::LocalWallet;
 use xmtp_db::{EncryptedMessageStore, StorageOption};
 use xmtp_id::InboxOwner;
-use xmtp_id::associations::unverified::UnverifiedRecoverableEcdsaSignature;
-use xmtp_id::associations::unverified::UnverifiedSignature;
 use xmtp_mls::identity::IdentityStrategy;
 
 use crate::args::{self, AppOpts};

--- a/xmtp_debug/src/app/clients.rs
+++ b/xmtp_debug/src/app/clients.rs
@@ -111,9 +111,7 @@ pub async fn register_client(client: &crate::DbgClient, owner: impl InboxOwner) 
     );
     if let Some(mut req) = signature_request {
         let signature_text = req.signature_text();
-        let unverified_signature = UnverifiedSignature::RecoverableEcdsa(
-            UnverifiedRecoverableEcdsaSignature::new(owner.sign(&signature_text)?.into()),
-        );
+        let unverified_signature = owner.sign(&signature_text)?;
         req.add_signature(unverified_signature, client.scw_verifier())
             .await?;
 

--- a/xmtp_id/src/associations/unverified.rs
+++ b/xmtp_id/src/associations/unverified.rs
@@ -378,10 +378,10 @@ impl UnverifiedInstallationKeySignature {
 #[derive(Debug, Clone, PartialEq)]
 pub struct UnverifiedPasskeySignature {
     // This json string contains the challenge we sent out
-    pub(crate) public_key: Vec<u8>,
-    pub(crate) signature: Vec<u8>,
-    pub(crate) authenticator_data: Vec<u8>,
-    pub(crate) client_data_json: Vec<u8>,
+    pub public_key: Vec<u8>,
+    pub signature: Vec<u8>,
+    pub authenticator_data: Vec<u8>,
+    pub client_data_json: Vec<u8>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -392,6 +392,9 @@ pub struct UnverifiedRecoverableEcdsaSignature {
 impl UnverifiedRecoverableEcdsaSignature {
     pub fn new(signature_bytes: Vec<u8>) -> Self {
         Self { signature_bytes }
+    }
+    pub fn signature_bytes(&self) -> &[u8] {
+        &self.signature_bytes
     }
 }
 

--- a/xmtp_mls/Cargo.toml
+++ b/xmtp_mls/Cargo.toml
@@ -24,6 +24,12 @@ test-utils = [
   "xmtp_api_grpc/test-utils",
   "dep:const_format",
   "xmtp_common/test-utils",
+  "dep:ethers",
+  "dep:passkey",
+  "dep:coset",
+  "dep:url",
+  "dep:public-suffix",
+  "dep:futures-executor",
 ]
 bench = [
   "test-utils",
@@ -40,11 +46,12 @@ default = ["grpc-api"]
 grpc-api = ["dep:xmtp_api_grpc", "xmtp_api_d14n?/grpc-api"]
 http-api = ["dep:xmtp_api_http", "xmtp_api_d14n?/http-api"]
 d14n = ["dep:xmtp_api_d14n"]
-update-schema = ["toml"]
+update-schema = ["toml", "anyhow"]
 
 [dependencies]
 aes-gcm = { version = "0.10.3", features = ["std"] }
 async-compression.workspace = true
+async-trait.workspace = true
 bincode.workspace = true
 bytes.workspace = true
 futures = { workspace = true, features = ["alloc", "std"] }
@@ -57,7 +64,7 @@ parking_lot.workspace = true
 pin-project-lite.workspace = true
 prost = { workspace = true, features = ["prost-derive"] }
 rand = { workspace = true }
-reqwest = { workspace = true }
+reqwest = { workspace = true, features = ["stream"] }
 serde = { workspace = true }
 serde_json.workspace = true
 sha2.workspace = true
@@ -65,6 +72,9 @@ thiserror = { workspace = true }
 tls_codec = { workspace = true }
 tokio-stream = { workspace = true, default-features = false, features = [
   "sync",
+] }
+tokio-util = { version = "0.7", default-features = false, features = [
+  "compat",
 ] }
 tracing.workspace = true
 trait-variant.workspace = true
@@ -80,10 +90,16 @@ xmtp_id = { path = "../xmtp_id" }
 xmtp_proto = { workspace = true, features = ["convert"] }
 
 # Optional/Features
+anyhow = { workspace = true, optional = true }
 const_format = { workspace = true, optional = true }
+coset = { version = "0.3", optional = true }
 ethers = { workspace = true, features = ["openssl"], optional = true }
 fdlimit = { workspace = true, optional = true }
+futures-executor = { version = "0.3", optional = true }
+passkey = { version = "0.4", optional = true }
+public-suffix = { version = "0.1.2", optional = true }
 toml = { version = "0.8.4", optional = true }
+url = { workspace = true, optional = true }
 xmtp_api_d14n = { workspace = true, optional = true }
 xmtp_api_http = { path = "../xmtp_api_http", optional = true }
 
@@ -111,9 +127,6 @@ dyn-clone.workspace = true
 openmls.workspace = true
 openssl.workspace = true
 openssl-sys.workspace = true
-tokio-util = { version = "0.7", default-features = false, features = [
-  "compat",
-] }
 xmtp_api_grpc = { workspace = true, optional = true }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
@@ -137,6 +150,11 @@ fdlimit = { workspace = true }
 once_cell.workspace = true
 rstest = { workspace = true, features = ["async-timeout"] }
 xmtp_db = { workspace = true, features = ["test-utils"] }
+passkey = { version = "0.4" }
+coset = { version = "0.3" }
+url = { workspace = true }
+public-suffix = { version = "0.1.2" }
+futures-executor = { version = "0.3" }
 xmtp_api_d14n = { workspace = true, features = ["test-utils"] }
 
 

--- a/xmtp_mls/benches/identity.rs
+++ b/xmtp_mls/benches/identity.rs
@@ -2,13 +2,7 @@ use crate::tracing::Instrument;
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use tokio::runtime::{Builder, Runtime};
 use xmtp_common::bench::{self, bench_async_setup, BENCH_ROOT_SPAN};
-use xmtp_id::{
-    associations::{
-        builder::SignatureRequest,
-        unverified::{UnverifiedRecoverableEcdsaSignature, UnverifiedSignature},
-    },
-    InboxOwner,
-};
+use xmtp_id::{associations::builder::SignatureRequest, InboxOwner};
 use xmtp_mls::utils::bench::{clients, BenchClient};
 
 #[macro_use]
@@ -26,9 +20,7 @@ fn setup() -> Runtime {
 async fn ecdsa_signature(client: &BenchClient, owner: impl InboxOwner) -> SignatureRequest {
     let mut signature_request = client.context().signature_request().unwrap();
     let signature_text = signature_request.signature_text();
-    let unverified_signature = UnverifiedSignature::RecoverableEcdsa(
-        UnverifiedRecoverableEcdsaSignature::new(owner.sign(&signature_text).unwrap().into()),
-    );
+    let unverified_signature = owner.sign(&signature_text).unwrap();
     signature_request
         .add_signature(unverified_signature, client.scw_verifier())
         .await

--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -231,9 +231,7 @@ pub(crate) mod tests {
     use xmtp_cryptography::utils::{generate_local_wallet, rng};
     use xmtp_cryptography::XmtpInstallationCredential;
     use xmtp_id::associations::test_utils::{MockSmartContractSignatureVerifier, WalletTestExt};
-    use xmtp_id::associations::unverified::{
-        UnverifiedRecoverableEcdsaSignature, UnverifiedSignature,
-    };
+    use xmtp_id::associations::unverified::UnverifiedSignature;
     use xmtp_id::associations::{Identifier, ValidatedLegacySignedPublicKey};
     use xmtp_id::scw_verifier::SmartContractSignatureVerifier;
     use xmtp_proto::api_client::ApiBuilder;
@@ -261,12 +259,7 @@ pub(crate) mod tests {
         let signature_text = signature_request.signature_text();
         let scw_verifier = MockSmartContractSignatureVerifier::new(true);
         signature_request
-            .add_signature(
-                UnverifiedSignature::RecoverableEcdsa(UnverifiedRecoverableEcdsaSignature::new(
-                    owner.sign(&signature_text).unwrap().into(),
-                )),
-                &scw_verifier,
-            )
+            .add_signature(owner.sign(&signature_text).unwrap(), &scw_verifier)
             .await
             .unwrap();
 
@@ -298,7 +291,10 @@ pub(crate) mod tests {
         .encode(&mut public_key_buf)
         .unwrap();
         let message = ValidatedLegacySignedPublicKey::text(&public_key_buf);
-        let signed_public_key: Vec<u8> = wallet.sign(&message).unwrap().into();
+        let signed_public_key = match wallet.sign(&message).unwrap() {
+            UnverifiedSignature::RecoverableEcdsa(sig) => sig.signature_bytes().to_vec(),
+            _ => unreachable!("Wallets only provide ecdsa signatures."),
+        };
         let (bytes, recovery_id) = signed_public_key.as_slice().split_at(64);
         let recovery_id = recovery_id[0];
         let signed_private_key: SignedPrivateKey = SignedPrivateKey {

--- a/xmtp_mls/src/utils/bench/clients.rs
+++ b/xmtp_mls/src/utils/bench/clients.rs
@@ -2,13 +2,7 @@ use crate::utils::test::{TestClient as TestApiClient, HISTORY_SYNC_URL};
 use crate::{client::Client, identity::IdentityStrategy};
 use ethers::signers::LocalWallet;
 use xmtp_id::associations::test_utils::WalletTestExt;
-use xmtp_id::{
-    associations::{
-        builder::SignatureRequest,
-        unverified::{UnverifiedRecoverableEcdsaSignature, UnverifiedSignature},
-    },
-    InboxOwner,
-};
+use xmtp_id::{associations::builder::SignatureRequest, InboxOwner};
 use xmtp_proto::api_client::{ApiBuilder, XmtpTestClient};
 
 pub type BenchClient = Client<TestApiClient>;
@@ -65,9 +59,7 @@ pub async fn new_unregistered_client(history_sync: bool) -> (BenchClient, LocalW
 pub async fn ecdsa_signature(client: &BenchClient, owner: impl InboxOwner) -> SignatureRequest {
     let mut signature_request = client.context().signature_request().unwrap();
     let signature_text = signature_request.signature_text();
-    let unverified_signature = UnverifiedSignature::RecoverableEcdsa(
-        UnverifiedRecoverableEcdsaSignature::new(owner.sign(&signature_text).unwrap().into()),
-    );
+    let unverified_signature = owner.sign(&signature_text).unwrap();
     signature_request
         .add_signature(unverified_signature, client.scw_verifier())
         .await

--- a/xmtp_mls/src/utils/test/mod.rs
+++ b/xmtp_mls/src/utils/test/mod.rs
@@ -1,5 +1,8 @@
 #![allow(clippy::unwrap_used)]
 
+#[cfg(any(test, feature = "test-utils"))]
+pub mod tester;
+
 use std::{
     future::Future,
     sync::{
@@ -11,11 +14,7 @@ use tokio::sync::Notify;
 use xmtp_api::ApiIdentifier;
 use xmtp_common::time::{timeout, Expired};
 use xmtp_id::{
-    associations::{
-        test_utils::MockSmartContractSignatureVerifier,
-        unverified::{UnverifiedRecoverableEcdsaSignature, UnverifiedSignature},
-        Identifier,
-    },
+    associations::{test_utils::MockSmartContractSignatureVerifier, Identifier},
     scw_verifier::{RemoteSignatureVerifier, SmartContractSignatureVerifier},
 };
 use xmtp_proto::api_client::{ApiBuilder, XmtpTestClient};
@@ -338,9 +337,8 @@ pub async fn register_client<T: XmtpApi, V: SmartContractSignatureVerifier>(
 ) {
     let mut signature_request = client.context.signature_request().unwrap();
     let signature_text = signature_request.signature_text();
-    let unverified_signature = UnverifiedSignature::RecoverableEcdsa(
-        UnverifiedRecoverableEcdsaSignature::new(owner.sign(&signature_text).unwrap().into()),
-    );
+    let unverified_signature = owner.sign(&signature_text).unwrap();
+
     signature_request
         .add_signature(unverified_signature, client.scw_verifier())
         .await

--- a/xmtp_mls/src/utils/test/tester.rs
+++ b/xmtp_mls/src/utils/test/tester.rs
@@ -1,0 +1,226 @@
+#![allow(unused)]
+
+use crate::builder::ClientBuilder;
+use ethers::signers::LocalWallet;
+use parking_lot::Mutex;
+use passkey::{
+    authenticator::{Authenticator, UserCheck, UserValidationMethod},
+    client::{Client, DefaultClientData},
+    types::{ctap2::*, rand::random_vec, webauthn::*, Bytes, Passkey},
+};
+use public_suffix::PublicSuffixList;
+use std::{ops::Deref, sync::Arc};
+use url::Url;
+use xmtp_cryptography::{signature::SignatureError, utils::generate_local_wallet};
+use xmtp_db::XmtpOpenMlsProvider;
+use xmtp_id::{
+    associations::{
+        ident,
+        unverified::{UnverifiedPasskeySignature, UnverifiedSignature},
+        Identifier,
+    },
+    InboxOwner,
+};
+
+use super::FullXmtpClient;
+
+/// A test client wrapper that auto-exposes all of the usual component access boilerplate.
+/// Makes testing easier and less repetetive.
+#[allow(dead_code)]
+pub(crate) struct Tester<Owner> {
+    pub owner: Owner,
+    pub client: FullXmtpClient,
+    pub provider: Arc<XmtpOpenMlsProvider>,
+}
+
+impl Tester<LocalWallet> {
+    pub(crate) async fn new() -> Self {
+        let wallet = generate_local_wallet();
+        Self::new_from_owner(wallet).await
+    }
+}
+
+impl Tester<PasskeyUser> {
+    pub(crate) async fn new_passkey() -> Self {
+        let passkey_user = PasskeyUser::new().await;
+        Self::new_from_owner(passkey_user).await
+    }
+}
+
+#[allow(dead_code)]
+impl<Owner> Tester<Owner>
+where
+    Owner: InboxOwner + Clone + 'static,
+{
+    pub(crate) async fn clone(&self) -> Self {
+        Self::new_from_owner(self.owner.clone()).await
+    }
+
+    pub(crate) async fn new_from_owner(owner: Owner) -> Self {
+        let client = ClientBuilder::new_test_client(&owner).await;
+        let provider = client.mls_provider().unwrap();
+
+        Self {
+            owner,
+            client,
+            provider: Arc::new(provider),
+        }
+    }
+}
+
+impl<Owner> Deref for Tester<Owner>
+where
+    Owner: InboxOwner,
+{
+    type Target = FullXmtpClient;
+
+    fn deref(&self) -> &Self::Target {
+        &self.client
+    }
+}
+
+pub type PasskeyCredential = PublicKeyCredential<AuthenticatorAttestationResponse>;
+pub type PasskeyClient = Client<Option<Passkey>, PkUserValidationMethod, PublicSuffixList>;
+
+#[derive(Clone)]
+pub struct PasskeyUser {
+    origin: Url,
+    pk_cred: Arc<PasskeyCredential>,
+    pk_client: Arc<Mutex<PasskeyClient>>,
+}
+
+impl InboxOwner for PasskeyUser {
+    fn sign(&self, text: &str) -> Result<UnverifiedSignature, SignatureError> {
+        let text = text.as_bytes().to_vec();
+        let sign_request = CredentialRequestOptions {
+            public_key: PublicKeyCredentialRequestOptions {
+                challenge: Bytes::from(text),
+                timeout: None,
+                rp_id: Some(String::from(self.origin.domain().unwrap())),
+                allow_credentials: None,
+                user_verification: UserVerificationRequirement::default(),
+                hints: None,
+                attestation: AttestationConveyancePreference::None,
+                attestation_formats: None,
+                extensions: None,
+            },
+        };
+
+        let mut pk_client = self.pk_client.lock();
+
+        let cred = pk_client.authenticate(self.origin.clone(), sign_request, DefaultClientData);
+        let cred = futures_executor::block_on(cred).unwrap();
+        let resp = cred.response;
+
+        let signature = resp.signature.to_vec();
+
+        Ok(UnverifiedSignature::Passkey(UnverifiedPasskeySignature {
+            public_key: self.public_key(),
+            signature,
+            authenticator_data: resp.authenticator_data.to_vec(),
+            client_data_json: resp.client_data_json.to_vec(),
+        }))
+    }
+
+    fn get_identifier(
+        &self,
+    ) -> Result<
+        xmtp_id::associations::Identifier,
+        xmtp_cryptography::signature::IdentifierValidationError,
+    > {
+        Ok(Identifier::Passkey(ident::Passkey {
+            key: self.public_key(),
+            relying_party: None,
+        }))
+    }
+}
+
+impl PasskeyUser {
+    pub async fn new() -> Self {
+        let origin = url::Url::parse("https://xmtp.chat").expect("Should parse");
+        let parameters_from_rp = PublicKeyCredentialParameters {
+            ty: PublicKeyCredentialType::PublicKey,
+            alg: coset::iana::Algorithm::ES256,
+        };
+        let pk_user_entity = PublicKeyCredentialUserEntity {
+            id: random_vec(32).into(),
+            display_name: "Alex Passkey".into(),
+            name: "apk@example.org".into(),
+        };
+        let pk_auth_store: Option<Passkey> = None;
+        let pk_aaguid = Aaguid::new_empty();
+        let pk_user_validation_method = PkUserValidationMethod {};
+        let pk_auth = Authenticator::new(pk_aaguid, pk_auth_store, pk_user_validation_method);
+        let mut pk_client = Client::new(pk_auth);
+
+        let request = CredentialCreationOptions {
+            public_key: PublicKeyCredentialCreationOptions {
+                rp: PublicKeyCredentialRpEntity {
+                    id: None, // Leaving the ID as None means use the effective domain
+                    name: origin.domain().unwrap().into(),
+                },
+                user: pk_user_entity,
+                // We're not passing a challenge here because we don't care about the credential and the user_entity behind it (for now).
+                // It's guaranteed to be unique, and that's good enough for us.
+                // All we care about is if that unique credential signs below.
+                challenge: Bytes::from(vec![]),
+                pub_key_cred_params: vec![parameters_from_rp],
+                timeout: None,
+                exclude_credentials: None,
+                authenticator_selection: None,
+                hints: None,
+                attestation: AttestationConveyancePreference::None,
+                attestation_formats: None,
+                extensions: None,
+            },
+        };
+
+        // Now create the credential.
+        let pk_cred = pk_client
+            .register(origin.clone(), request, DefaultClientData)
+            .await
+            .unwrap();
+
+        Self {
+            pk_client: Arc::new(Mutex::new(pk_client)),
+            pk_cred: Arc::new(pk_cred),
+            origin,
+        }
+    }
+
+    fn public_key(&self) -> Vec<u8> {
+        self.pk_cred.response.public_key.as_ref().unwrap()[26..].to_vec()
+    }
+
+    pub fn identifier(&self) -> Identifier {
+        Identifier::Passkey(ident::Passkey {
+            key: self.public_key(),
+            relying_party: self.origin.domain().map(str::to_string),
+        })
+    }
+}
+
+pub struct PkUserValidationMethod {}
+#[async_trait::async_trait]
+impl UserValidationMethod for PkUserValidationMethod {
+    type PasskeyItem = Passkey;
+    async fn check_user<'a>(
+        &self,
+        _credential: Option<&'a Passkey>,
+        presence: bool,
+        verification: bool,
+    ) -> Result<UserCheck, Ctap2Error> {
+        Ok(UserCheck {
+            presence,
+            verification,
+        })
+    }
+
+    fn is_verification_enabled(&self) -> Option<bool> {
+        Some(true)
+    }
+
+    fn is_presence_enabled(&self) -> bool {
+        true
+    }
+}


### PR DESCRIPTION
### Refactor signature handling API to return `UnverifiedSignature` from `InboxOwner.sign()` method and add passkey authentication testing framework
* Changes the `InboxOwner` trait's `sign` method signature to return `UnverifiedSignature` instead of `RecoverableSignature` in [lib.rs](https://github.com/xmtp/libxmtp/pull/1848/files#diff-6d185fb06d195e60f107738ea29d87622e08e3f669cee2ec51679de2aca1cef4)
* Updates signature handling across multiple components to use the new signature type system, including [inbox_owner.rs](https://github.com/xmtp/libxmtp/pull/1848/files#diff-4d504695e98afcf23c02f610ed090e64b4382db525cb81542f29df07e4941c32), [cli-client.rs](https://github.com/xmtp/libxmtp/pull/1848/files#diff-f8d2d658173104f0800be684cee6943e0820acb1e8f1ef270d0d98df3c31c5a8), and [clients.rs](https://github.com/xmtp/libxmtp/pull/1848/files#diff-f251302a34aaefa8d847fbe261211c21aa97857edc8225ba0fc8042f87c16b70)
* Makes fields in `UnverifiedPasskeySignature` public and adds `signature_bytes()` method to `UnverifiedRecoverableEcdsaSignature` in [unverified.rs](https://github.com/xmtp/libxmtp/pull/1848/files#diff-9ab2dc4956f2b209203f71b3135f391b5f43a9bfc0585452d127c232f5939552)
* Introduces new test utility framework in [tester.rs](https://github.com/xmtp/libxmtp/pull/1848/files#diff-e248276c2fffaa7ac565757538c70a86a548e6d8369d4be1e61d122ab98a4061) for passkey-based authentication testing
* Adds new dependencies to `xmtp_mls` package including `passkey`, `coset`, `url`, and others in [Cargo.toml](https://github.com/xmtp/libxmtp/pull/1848/files#diff-059eacd406dc20809ba996685ce8d6e42f5d6bc8d1c52d486d55c5c1765c5e1d)

#### 📍Where to Start
Start with the `InboxOwner` trait changes in [lib.rs](https://github.com/xmtp/libxmtp/pull/1848/files#diff-6d185fb06d195e60f107738ea29d87622e08e3f669cee2ec51679de2aca1cef4) which defines the new signature handling API, then move to the implementation in [inbox_owner.rs](https://github.com/xmtp/libxmtp/pull/1848/files#diff-4d504695e98afcf23c02f610ed090e64b4382db525cb81542f29df07e4941c32).

----

_[Macroscope](https://app.macroscope.com) summarized 13e8a62._