### PR TITLE
Don't increment cursors when processing messages from stream

### DIFF
--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -5931,7 +5931,8 @@ pub(crate) mod tests {
                 .unwrap(),
             4
         );
-        // We fail on the last line because a1 is forked from b and c, stuck on epoch 3
+        // We pass on the last line because a's cursor has not moved past any commits, even though it processed
+        // messages out of order
         assert_eq!(
             group_a
                 .epoch(&client_a1.mls_provider().unwrap())

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -5769,4 +5769,174 @@ pub(crate) mod tests {
             .await;
         assert!(result.is_err());
     }
+
+    #[xmtp_common::test(flavor = "multi_thread")]
+    async fn handles_out_of_order_messages() {
+        let wallet_a = generate_local_wallet();
+        let wallet_b = generate_local_wallet();
+        let wallet_c = generate_local_wallet();
+        let client_a1 = ClientBuilder::new_test_client(&wallet_a).await;
+        let client_b = ClientBuilder::new_test_client(&wallet_b).await;
+        let client_c = ClientBuilder::new_test_client(&wallet_c).await;
+
+        // Create a group
+        let group_a1 = client_a1
+            .create_group(None, GroupMetadataOptions::default())
+            .unwrap();
+
+        // Add client_b and client_c to the group
+        group_a1
+            .add_members_by_inbox_id(&[client_b.inbox_id(), client_c.inbox_id()])
+            .await
+            .unwrap();
+
+        // Sync the group
+        client_b
+            .sync_welcomes(&client_b.mls_provider().unwrap())
+            .await
+            .unwrap();
+        let binding = client_b.find_groups(GroupQueryArgs::default()).unwrap();
+        let group_b = binding.first().unwrap();
+
+        client_c
+            .sync_welcomes(&client_c.mls_provider().unwrap())
+            .await
+            .unwrap();
+        let binding = client_c.find_groups(GroupQueryArgs::default()).unwrap();
+        let group_c = binding.first().unwrap();
+
+        // Each client sends a message and syncs
+        group_a1
+            .send_message_optimistic("Message a1".as_bytes())
+            .unwrap();
+        group_a1
+            .publish_intents(&group_a1.mls_provider().unwrap())
+            .await
+            .unwrap();
+
+        group_a1.sync().await.unwrap();
+        group_b.sync().await.unwrap();
+        group_c.sync().await.unwrap();
+
+        group_b
+            .send_message_optimistic("Message b1".as_bytes())
+            .unwrap();
+        group_b
+            .publish_intents(&group_b.mls_provider().unwrap())
+            .await
+            .unwrap();
+
+        group_a1.sync().await.unwrap();
+        group_b.sync().await.unwrap();
+        group_c.sync().await.unwrap();
+
+        group_c
+            .send_message_optimistic("Message c1".as_bytes())
+            .unwrap();
+        group_c
+            .publish_intents(&group_c.mls_provider().unwrap())
+            .await
+            .unwrap();
+
+        // Sync the groups
+        group_a1.sync().await.unwrap();
+        group_b.sync().await.unwrap();
+        group_c.sync().await.unwrap();
+
+        // After being client a adds b and c, all groups are in the same epoch
+        assert_eq!(
+            group_a1
+                .epoch(&client_a1.mls_provider().unwrap())
+                .await
+                .unwrap(),
+            3
+        );
+        assert_eq!(
+            group_b
+                .epoch(&client_b.mls_provider().unwrap())
+                .await
+                .unwrap(),
+            3
+        );
+        assert_eq!(
+            group_c
+                .epoch(&client_c.mls_provider().unwrap())
+                .await
+                .unwrap(),
+            3
+        );
+
+        // Client b updates the group name (incrementing the epoch from 1 to 2) and syncs
+        group_b
+            .update_group_name("Group B".to_string())
+            .await
+            .unwrap();
+        group_b.sync().await.unwrap();
+
+        // Client c sends two text messages before incrementing the epoch
+        group_c
+            .send_message_optimistic("Message c2".as_bytes())
+            .unwrap();
+        group_c
+            .publish_intents(&group_c.mls_provider().unwrap())
+            .await
+            .unwrap();
+        group_b.sync().await.unwrap();
+
+        // Retrieve all messages from group B, verify they contain the two messages from client c even though they were sent from the wrong epoch
+        let messages = client_b
+            .api_client
+            .query_group_messages(group_b.group_id.clone(), None)
+            .await
+            .unwrap();
+        assert_eq!(messages.len(), 8);
+
+        // Get reference to last two messages
+        let last_message = messages.last().unwrap();
+
+        // Simulating group_a streaming out of order by processing the last_message first
+        let v1_last_message = match &last_message.version {
+            Some(xmtp_proto::xmtp::mls::api::v1::group_message::Version::V1(v1)) => v1,
+            _ => panic!("Expected V1 message"),
+        };
+
+        // This is the key line, because we pass in false for incrementing epoch/cursor
+        let increment_epoch = false;
+        let result = group_a1
+            .process_message(
+                &client_a1.mls_provider().unwrap(),
+                v1_last_message,
+                increment_epoch,
+            )
+            .await;
+        assert!(result.is_ok());
+
+        // Now syncing will not update group_a1 group name since the cursor has moved on past it, we are forked!
+        group_a1.sync().await.unwrap();
+        group_b.sync().await.unwrap();
+        group_c.sync().await.unwrap();
+
+        assert_eq!(
+            group_b
+                .epoch(&client_b.mls_provider().unwrap())
+                .await
+                .unwrap(),
+            4
+        );
+        assert_eq!(
+            group_c
+                .epoch(&client_c.mls_provider().unwrap())
+                .await
+                .unwrap(),
+            4
+        );
+        // We fail on the last line because a1 is forked from b and c, stuck on epoch 3
+        assert_eq!(
+            group_a1
+                .epoch(&client_a1.mls_provider().unwrap())
+                .await
+                .unwrap(),
+            4
+        );
+    }
 }


### PR DESCRIPTION
### Prevent message cursor increments during stream processing to avoid missing out-of-order messages in MLS group messaging
Modifies message processing logic in [mls_sync.rs](https://github.com/xmtp/libxmtp/pull/1861/files#diff-10f818f7918c8c0b2ed32c4f63e5060050527ed58df00ec081bbecb66065144e) to conditionally update cursors based on message source ordering guarantees. The `validate_and_process_external_message` function now accepts an `allow_cursor_increment` parameter, while `process_message` uses a `trust_message_order` parameter to control cursor updates. A new test in [mod.rs](https://github.com/xmtp/libxmtp/pull/1861/files#diff-c29f56a38916c7410eff8091df1a2e43487ffe20646d96827e846e475f4608d3) validates that group state remains consistent when processing out-of-order messages from streams.

#### 📍Where to Start
Start with the `validate_and_process_external_message` function in [mls_sync.rs](https://github.com/xmtp/libxmtp/pull/1861/files#diff-10f818f7918c8c0b2ed32c4f63e5060050527ed58df00ec081bbecb66065144e) which contains the core changes to cursor update logic.

----

_[Macroscope](https://app.macroscope.com) summarized 3cfcc93._