### PR TITLE
Don't update welcome cursor from stream

### DIFF
--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -935,7 +935,7 @@ where
         provider: &XmtpOpenMlsProvider,
         welcome: &welcome_message::V1,
     ) -> Result<MlsGroup<Self>, GroupError> {
-        let result = MlsGroup::create_from_welcome(self, provider, welcome).await;
+        let result = MlsGroup::create_from_welcome(self, provider, welcome, true).await;
 
         match result {
             Ok(mls_group) => Ok(mls_group),

--- a/xmtp_mls/src/subscriptions/stream_conversations.rs
+++ b/xmtp_mls/src/subscriptions/stream_conversations.rs
@@ -409,7 +409,7 @@ where
 
         let group = retry_async!(
             Retry::default(),
-            (async { MlsGroup::create_from_welcome(client, provider, welcome).await })
+            (async { MlsGroup::create_from_welcome(client, provider, welcome, false).await })
         );
 
         if let Err(e) = group {

--- a/xmtp_mls/src/subscriptions/stream_conversations.rs
+++ b/xmtp_mls/src/subscriptions/stream_conversations.rs
@@ -481,7 +481,7 @@ mod test {
 
     #[rstest::rstest]
     #[xmtp_common::test]
-    #[timeout(std::time::Duration::from_secs(5))]
+    #[timeout(std::time::Duration::from_secs(7))]
     #[cfg_attr(target_arch = "wasm32", ignore)]
     async fn test_dm_streaming() {
         let alix = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);


### PR DESCRIPTION
### Prevent cursor updates during welcome message processing from stream sources by adding conditional cursor increment control to `MlsGroup::create_from_welcome`
* Adds `allow_cursor_increment` parameter to `MlsGroup::create_from_welcome` in [mod.rs](https://github.com/xmtp/libxmtp/pull/1863/files#diff-c29f56a38916c7410eff8091df1a2e43487ffe20646d96827e846e475f4608d3) to control cursor updates based on message source
* Updates `process_new_welcome` in [client.rs](https://github.com/xmtp/libxmtp/pull/1863/files#diff-3c0189371525b6aae3be7e5a7b5b5682204ef341fb2744fc876148c5ecab8642) to allow cursor increments for trusted ordered sources
* Modifies stream processing in [stream_conversations.rs](https://github.com/xmtp/libxmtp/pull/1863/files#diff-7c3c0adb77b28c40ac418e970ce3dbf3320238ec155456eebedc187a61878aea) to disable cursor increments for potentially out-of-order stream sources

#### 📍Where to Start
Start with the `create_from_welcome` method in [mod.rs](https://github.com/xmtp/libxmtp/pull/1863/files#diff-c29f56a38916c7410eff8091df1a2e43487ffe20646d96827e846e475f4608d3) which contains the core logic for conditional cursor updates.

----

_[Macroscope](https://app.macroscope.com) summarized 791ba6f._