### PR TITLE
Fix Sync Behavior

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -8108,7 +8108,6 @@ mod tests {
 
         sg2.sync().await.unwrap();
 
-        tracing::info!("Sync group id {:?}", sg2.group_id);
         alix2_worker
             .wait(SyncMetric::V1ConsentReceived, 1)
             .await

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -8072,9 +8072,6 @@ mod tests {
 
         assert_eq!(sg1.group_id, sg2.group_id);
 
-        // sg1.sync().await.unwrap();
-        // sg2.sync().await.unwrap();
-
         alix.conversations()
             .sync_all_conversations(None)
             .await

--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -482,7 +482,7 @@ async fn main() -> color_eyre::eyre::Result<()> {
         Commands::ListHistorySyncMessages {} => {
             let provider = client.mls_provider()?;
             client.sync_welcomes(&provider).await?;
-            let group = client.get_sync_group(provider.conn_ref())?;
+            let group = client.get_sync_group(&provider)?;
             let group_id_str = hex::encode(group.group_id.clone());
             group.sync().await?;
             let messages = group.find_messages(&MsgQueryArgs {

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -1025,10 +1025,15 @@ where
         provider: &XmtpOpenMlsProvider,
     ) -> Result<usize, ClientError> {
         self.sync_welcomes(provider).await?;
-        self.get_sync_group(provider)?.sync().await?;
-        // let active_groups_count = self.sync_all_groups(groups, provider).await?;
+        let groups = provider
+            .conn_ref()
+            .all_sync_groups()?
+            .into_iter()
+            .map(|g| MlsGroup::new(self.clone(), g.id, g.created_at_ns))
+            .collect();
+        let active_groups_count = self.sync_all_groups(groups, provider).await?;
 
-        Ok(1)
+        Ok(active_groups_count)
     }
 
     /**

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -159,7 +159,6 @@ pub struct DeviceSync {
 
     #[allow(unused)] // TODO: Will be used very soon...
     pub(crate) mode: SyncWorkerMode,
-    #[cfg(any(test, feature = "test-utils"))]
     pub(crate) worker_handle: Arc<parking_lot::Mutex<Option<Arc<WorkerHandle<SyncMetric>>>>>,
 }
 
@@ -295,7 +294,6 @@ where
             device_sync: DeviceSync {
                 server_url: device_sync_server_url,
                 mode: device_sync_worker_mode,
-                #[cfg(any(test, feature = "test-utils"))]
                 worker_handle: Arc::new(parking_lot::Mutex::default()),
             },
         }

--- a/xmtp_mls/src/groups/device_sync.rs
+++ b/xmtp_mls/src/groups/device_sync.rs
@@ -193,7 +193,6 @@ pub struct SyncWorker<ApiClient, V> {
     retry: Retry,
 
     // Number of events processed
-    #[cfg(any(test, feature = "test-utils"))]
     handle: std::sync::Arc<WorkerHandle<SyncMetric>>,
 }
 

--- a/xmtp_mls/src/groups/device_sync.rs
+++ b/xmtp_mls/src/groups/device_sync.rs
@@ -213,6 +213,7 @@ where
 
         while let Some(event) = self.stream.next().await {
             let event = event?;
+
             match event {
                 LocalEvents::SyncMessage(msg) => match msg {
                     SyncMessage::Reply { message_id } => {
@@ -226,6 +227,10 @@ where
                     }
                 },
                 LocalEvents::OutgoingPreferenceUpdates(preference_updates) => {
+                    if preference_updates.is_empty() {
+                        continue;
+                    }
+
                     retry_async!(
                         self.retry,
                         (async {
@@ -542,7 +547,7 @@ where
             handle.increment_metric(SyncMetric::V1PayloadSent);
         }
 
-        tracing::error!(
+        tracing::info!(
             "Backup payload sent to sync group {:?}",
             sync_group.group_id
         );

--- a/xmtp_mls/src/groups/device_sync.rs
+++ b/xmtp_mls/src/groups/device_sync.rs
@@ -235,8 +235,8 @@ where
                         })
                     )?;
                 }
-                LocalEvents::IncomingPreferenceUpdate(_) => {
-                    tracing::info!("Incoming preference update");
+                LocalEvents::IncomingPreferenceUpdate(u) => {
+                    tracing::error!("Incoming preference update");
                 }
                 _ => {}
             }

--- a/xmtp_mls/src/groups/device_sync.rs
+++ b/xmtp_mls/src/groups/device_sync.rs
@@ -409,11 +409,9 @@ where
             Err(_) => {
                 let sync_group =
                     MlsGroup::create_and_insert_sync_group(Arc::new(self.clone()), provider)?;
+                tracing::info!("Creating sync group: {:?}", sync_group.group_id);
+                sync_group.add_missing_installations(provider).await?;
                 sync_group.sync_with_conn(provider).await?;
-                tracing::error!("Creating sync group: {:?}", sync_group.group_id);
-
-                let sync_group = self.group(sync_group.group_id)?;
-                sync_group.update_installations().await?;
 
                 sync_group
             }

--- a/xmtp_mls/src/groups/device_sync/consent_sync.rs
+++ b/xmtp_mls/src/groups/device_sync/consent_sync.rs
@@ -29,25 +29,16 @@ pub(crate) mod tests {
     const HISTORY_SERVER_PORT: u16 = 5558;
 
     use super::*;
-    use crate::{builder::ClientBuilder, groups::scoped_client::ScopedGroupClient};
+    use crate::{groups::scoped_client::ScopedGroupClient, utils::tester::Tester};
     use xmtp_db::consent_record::{ConsentState, ConsentType};
 
-    use xmtp_common::{
-        assert_ok,
-        time::{Duration, Instant},
-    };
     use xmtp_cryptography::utils::generate_local_wallet;
     use xmtp_id::associations::test_utils::WalletTestExt;
 
     #[xmtp_common::test]
     #[cfg_attr(target_family = "wasm", ignore)]
     async fn test_consent_sync() {
-        let history_sync_url = format!("http://{}:{}", HISTORY_SERVER_HOST, HISTORY_SERVER_PORT);
-        let wallet = generate_local_wallet();
-        let amal_a = ClientBuilder::new_test_client_with_history(&wallet, &history_sync_url).await;
-        let amal_a_provider = amal_a.mls_provider().unwrap();
-        let amal_a_conn = amal_a_provider.conn_ref();
-        let amal_a_worker = amal_a.sync_worker_handle().unwrap();
+        let amal_a = Tester::new().await;
 
         // create an alix installation and consent with alix
         let alix_wallet = generate_local_wallet();
@@ -60,68 +51,48 @@ pub(crate) mod tests {
         amal_a.set_consent_states(&[consent_record]).await.unwrap();
 
         // Ensure that consent record now exists.
-        let syncable_consent_records = amal_a.syncable_consent_records(amal_a_conn).unwrap();
+        let syncable_consent_records = amal_a
+            .syncable_consent_records(amal_a.provider.conn_ref())
+            .unwrap();
         assert_eq!(syncable_consent_records.len(), 1);
 
         // Create a second installation for amal with sync.
-        let amal_b = ClientBuilder::new_test_client_with_history(&wallet, &history_sync_url).await;
+        let amal_b = amal_a.clone().await;
 
-        let amal_b_provider = amal_b.mls_provider().unwrap();
-        let amal_b_conn = amal_b_provider.conn_ref();
-        let amal_b_worker = amal_b.sync_worker_handle().unwrap();
-
-        let consent_records_b = amal_b.syncable_consent_records(amal_b_conn).unwrap();
+        let consent_records_b = amal_b
+            .syncable_consent_records(amal_b.provider.conn_ref())
+            .unwrap();
         assert_eq!(consent_records_b.len(), 0);
-        // make sure amal's workers have time to sync
-        // 3 Intents:
-        //  1.) UpdateGroupMembership Intent for new sync group
-        //  2.) Device Sync Request
-        //  3.) MessageHistory Sync Request
-        amal_b_worker.wait_for_new_events(1).await.unwrap();
 
-        let old_group_id = amal_a.get_sync_group(amal_a_conn).unwrap().group_id;
-        // Check for new welcomes to new groups in the first installation (should be welcomed to a new sync group from amal_b).
-        amal_a.sync_welcomes(&amal_a_provider).await.unwrap();
-        let new_group_id = amal_a.get_sync_group(amal_a_conn).unwrap().group_id;
-        // group id should have changed to the new sync group created by the second installation
-        assert_ne!(old_group_id, new_group_id);
-
-        let consent_a = amal_a.syncable_consent_records(amal_a_conn).unwrap().len();
-
-        // Have amal_a receive the message (and auto-process)
-        amal_a_worker
-            .block_for_num_events(1, async {
-                let amal_a_sync_group = amal_a.get_sync_group(amal_a_conn).unwrap();
-                assert_ok!(amal_a_sync_group.sync_with_conn(&amal_a_provider).await);
-            })
+        amal_b
+            .worker
+            .wait(SyncMetric::V1ConsentReceived, 1)
             .await
             .unwrap();
 
-        xmtp_common::wait_for_some(|| async {
-            amal_b
-                .get_latest_sync_reply(&amal_b_provider, DeviceSyncKind::Consent)
-                .await
-                .unwrap()
-        })
-        .await;
+        let old_group_id = amal_a.get_sync_group(&amal_a.provider).unwrap().group_id;
+        // Check for new welcomes to new groups in the first installation (should be welcomed to a new sync group from amal_b).
+        amal_a.sync_welcomes(&amal_a.provider).await.unwrap();
+        let new_group_id = amal_a.get_sync_group(&amal_a.provider).unwrap().group_id;
+        // group id should have changed to the new sync group created by the second installation
+        assert_ne!(old_group_id, new_group_id);
 
-        // Wait up to 20 seconds for sync to process (typically is almost instant)
-        xmtp_common::wait_for_eq(
-            || {
-                let consent_b = amal_b.syncable_consent_records(amal_b_conn).unwrap().len();
-                futures::future::ready(consent_b != consent_a)
-            },
-            true,
-        )
-        .await
-        .unwrap();
+        let consent_a = amal_a
+            .syncable_consent_records(amal_a.provider.conn_ref())
+            .unwrap()
+            .len();
+
+        // Have amal_a receive the message (and auto-process)
+        amal_b.worker.wait(SyncMetric::V1PayloadProcessed, 1).await;
 
         // Test consent streaming
-        let amal_b_sync_group = amal_b.get_sync_group(amal_b_conn).unwrap();
+        let amal_b_sync_group = amal_b.get_sync_group(&amal_b.provider).unwrap();
         let bo_wallet = generate_local_wallet();
 
         // Ensure bo is not consented with amal_b
-        let mut bo_consent_with_amal_b = amal_b_conn
+        let mut bo_consent_with_amal_b = amal_b
+            .provider
+            .conn_ref()
             .get_consent_record(bo_wallet.get_inbox_id(0), ConsentType::InboxId)
             .unwrap();
         assert!(bo_consent_with_amal_b.is_none());
@@ -135,24 +106,20 @@ pub(crate) mod tests {
             )])
             .await
             .unwrap();
-        assert!(amal_a_conn
+        assert!(amal_a
+            .provider
+            .conn_ref()
             .get_consent_record(bo_wallet.get_inbox_id(0), ConsentType::InboxId)
             .unwrap()
             .is_some());
         let amal_a_subscription = amal_a.local_events().subscribe();
 
         // Wait for the consent to get streamed to the amal_b
-        let start = Instant::now();
-        while bo_consent_with_amal_b.is_none() {
-            assert_ok!(amal_b_sync_group.sync_with_conn(&amal_b_provider).await);
-            bo_consent_with_amal_b = amal_b_conn
-                .get_consent_record(bo_wallet.get_inbox_id(0), ConsentType::InboxId)
-                .unwrap();
-
-            if start.elapsed() > Duration::from_secs(1) {
-                panic!("Consent update did not stream");
-            }
-        }
+        amal_b_sync_group
+            .sync_with_conn(&amal_b.provider)
+            .await
+            .unwrap();
+        amal_b.worker.wait(SyncMetric::V1ConsentReceived, 1).await;
 
         // No new messages were generated for the amal_a installation during this time.
         assert!(amal_a_subscription.is_empty());

--- a/xmtp_mls/src/groups/device_sync/consent_sync.rs
+++ b/xmtp_mls/src/groups/device_sync/consent_sync.rs
@@ -56,7 +56,7 @@ pub(crate) mod tests {
         assert_eq!(syncable_consent_records.len(), 1);
 
         // Create a second installation for amal with sync.
-        let amal_b = amal_a.clone().await;
+        let amal_b = amal_a.new_installation().await;
 
         amal_b
             .worker()

--- a/xmtp_mls/src/groups/device_sync/consent_sync.rs
+++ b/xmtp_mls/src/groups/device_sync/consent_sync.rs
@@ -59,7 +59,7 @@ pub(crate) mod tests {
         let amal_b = amal_a.clone().await;
 
         amal_b
-            .worker
+            .worker()
             .wait(SyncMetric::V1RequestSent, 1)
             .await
             .unwrap();
@@ -76,7 +76,7 @@ pub(crate) mod tests {
             .await
             .unwrap();
         amal_a
-            .worker
+            .worker()
             .wait(SyncMetric::V1PayloadSent, 1)
             .await
             .unwrap();
@@ -89,7 +89,7 @@ pub(crate) mod tests {
             .await
             .unwrap();
         amal_b
-            .worker
+            .worker()
             .wait(SyncMetric::V1PayloadProcessed, 1)
             .await
             .unwrap();
@@ -116,7 +116,7 @@ pub(crate) mod tests {
             .await
             .unwrap();
         amal_a
-            .worker
+            .worker()
             .wait(SyncMetric::V1ConsentSent, 2)
             .await
             .unwrap();
@@ -128,7 +128,7 @@ pub(crate) mod tests {
             .await
             .unwrap();
         amal_b
-            .worker
+            .worker()
             .wait(SyncMetric::V1ConsentReceived, 1)
             .await
             .unwrap();

--- a/xmtp_mls/src/groups/device_sync/consent_sync.rs
+++ b/xmtp_mls/src/groups/device_sync/consent_sync.rs
@@ -27,7 +27,7 @@ pub(crate) mod tests {
 
     use crate::{
         groups::{device_sync::handle::SyncMetric, scoped_client::ScopedGroupClient},
-        utils::tester::Tester,
+        utils::tester::{Tester, XmtpClientWalletTester},
     };
     use xmtp_db::consent_record::{ConsentState, ConsentType, StoredConsentRecord};
 

--- a/xmtp_mls/src/groups/device_sync/handle.rs
+++ b/xmtp_mls/src/groups/device_sync/handle.rs
@@ -77,7 +77,7 @@ where
     ) -> Result<(), xmtp_common::time::Expired> {
         let metric = self.metrics.lock().entry(metric).or_default().clone();
 
-        let result = xmtp_common::time::timeout(Duration::from_secs(20), async {
+        let result = xmtp_common::time::timeout(Duration::from_secs(5), async {
             loop {
                 if metric.load(Ordering::SeqCst) >= count {
                     return;

--- a/xmtp_mls/src/groups/device_sync/handle.rs
+++ b/xmtp_mls/src/groups/device_sync/handle.rs
@@ -1,0 +1,156 @@
+use futures::stream::FuturesUnordered;
+use parking_lot::Mutex;
+use std::{
+    collections::HashMap,
+    future::Future,
+    hash::Hash,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+use tokio::sync::Notify;
+use tokio_stream::StreamExt;
+
+pub struct WorkerHandle<Metric>
+where
+    Metric: PartialEq + Hash,
+{
+    metrics: Mutex<HashMap<Metric, Arc<AtomicUsize>>>,
+    notify: Notify,
+}
+
+#[derive(PartialEq, Eq, Hash, Clone, Copy)]
+pub enum SyncMetric {
+    Init,
+    SyncGroupWelcomesProcessed,
+    RequestReceived,
+    PayloadSent,
+    PayloadProcessed,
+    HmacSent,
+    HmacReceived,
+    ConsentSent,
+    ConsentReceived,
+
+    V1ConsentSent,
+    V1ConsentReceived,
+    V1HmacSent,
+    V1HmacReceived,
+    V1PayloadSent,
+    V1PayloadProcessed,
+}
+
+impl<Metric> WorkerHandle<Metric>
+where
+    Metric: PartialEq + Eq + Hash + Clone + Copy,
+{
+    pub(super) fn new() -> Self {
+        Self {
+            metrics: Mutex::default(),
+            notify: Notify::new(),
+        }
+    }
+
+    pub fn get(&self, metric: Metric) -> usize {
+        let mut lock = self.metrics.lock();
+        let atomic = lock.entry(metric).or_default();
+        atomic.load(Ordering::SeqCst)
+    }
+
+    pub(crate) fn increment_metric(&self, metric: Metric) {
+        let mut lock = self.metrics.lock();
+        let atomic = lock.entry(metric).or_default();
+        atomic.fetch_add(1, Ordering::SeqCst);
+        self.notify.notify_waiters();
+    }
+
+    pub fn reset(&self) {
+        *self.metrics.lock() = HashMap::new();
+    }
+
+    /// Blocks until metric's specified count is met
+    pub async fn wait(
+        &self,
+        metric: Metric,
+        count: usize,
+    ) -> Result<(), xmtp_common::time::Expired> {
+        let metric = self.metrics.lock().entry(metric).or_default().clone();
+
+        let result = xmtp_common::time::timeout(Duration::from_secs(20), async {
+            loop {
+                if metric.load(Ordering::SeqCst) >= count {
+                    return;
+                }
+                self.notify.notified().await;
+            }
+        })
+        .await;
+
+        if metric.load(Ordering::SeqCst) >= count {
+            return Ok(());
+        }
+
+        result
+    }
+
+    pub async fn do_until<F, Fut>(
+        &self,
+        metric: Metric,
+        count: usize,
+        f: F,
+    ) -> Result<(), xmtp_common::time::Expired>
+    where
+        F: Fn() -> Fut,
+        Fut: Future<Output = ()>,
+    {
+        let metric = self.metrics.lock().entry(metric).or_default().clone();
+        xmtp_common::time::timeout(Duration::from_secs(20), async {
+            while metric.load(Ordering::SeqCst) < count {
+                f().await;
+                xmtp_common::yield_().await;
+            }
+        })
+        .await
+    }
+
+    pub fn clear_metric(&self, metric: Metric) {
+        self.metrics
+            .lock()
+            .entry(metric)
+            .or_default()
+            .store(0, Ordering::SeqCst);
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+pub trait WorkHandleCollection<Metric> {
+    /// Blocks until a metrics specified count is met in at least one handle.
+    /// Useful when testing several clients, and you need at least one of them to do a job.
+    async fn wait_one(&self, metric: Metric, count: usize);
+}
+
+#[async_trait::async_trait(?Send)]
+impl<Metric> WorkHandleCollection<Metric> for Vec<&WorkerHandle<Metric>>
+where
+    Metric: PartialEq + Eq + Hash + Clone + Copy,
+{
+    async fn wait_one(&self, metric: Metric, count: usize) {
+        let metrics: Vec<Arc<AtomicUsize>> = self
+            .iter()
+            .map(|h| h.metrics.lock().entry(metric).or_default().clone())
+            .collect();
+
+        while !metrics.iter().any(|m| m.load(Ordering::SeqCst) >= count) {
+            let mut notify: FuturesUnordered<_> =
+                self.iter().map(|h| h.notify.notified()).collect();
+            notify.next().await;
+        }
+    }
+}
+
+impl WorkerHandle<SyncMetric> {
+    pub async fn wait_for_init(&self) -> Result<(), xmtp_common::time::Expired> {
+        self.wait(SyncMetric::Init, 1).await
+    }
+}

--- a/xmtp_mls/src/groups/device_sync/handle.rs
+++ b/xmtp_mls/src/groups/device_sync/handle.rs
@@ -39,6 +39,7 @@ pub enum SyncMetric {
     V1HmacReceived,
     V1PayloadSent,
     V1PayloadProcessed,
+    V1RequestSent,
 }
 
 impl<Metric> WorkerHandle<Metric>

--- a/xmtp_mls/src/groups/device_sync/message_sync.rs
+++ b/xmtp_mls/src/groups/device_sync/message_sync.rs
@@ -104,13 +104,13 @@ pub(crate) mod tests {
         wait_for_min_intents(amal_b_conn, 3).await;
         tracing::info!("Waiting for intents published");
 
-        let old_group_id = amal_a.get_sync_group(amal_a_conn).unwrap().group_id;
+        let old_group_id = amal_a.get_sync_group(&amal_a_provider).unwrap().group_id;
         // Check for new welcomes to new groups in the first installation (should be welcomed to a new sync group from amal_b).
         amal_a
             .sync_welcomes(&amal_a_provider)
             .await
             .expect("sync_welcomes");
-        let new_group_id = amal_a.get_sync_group(amal_a_conn).unwrap().group_id;
+        let new_group_id = amal_a.get_sync_group(&amal_a_provider).unwrap().group_id;
         // group id should have changed to the new sync group created by the second installation
         assert_ne!(old_group_id, new_group_id);
 
@@ -121,7 +121,7 @@ pub(crate) mod tests {
             .unwrap();
 
         // Have amal_a receive the message (and auto-process)
-        let amal_a_sync_group = amal_a.get_sync_group(amal_a_conn).unwrap();
+        let amal_a_sync_group = amal_a.get_sync_group(&amal_a_provider).unwrap();
         assert_ok!(amal_a_sync_group.sync_with_conn(&amal_a_provider).await);
 
         xmtp_common::wait_for_some(|| async {
@@ -162,7 +162,7 @@ pub(crate) mod tests {
         //  3.) MessageHistory Sync Request
         wait_for_min_intents(amal_a_conn, 3).await;
         tracing::info!("Waiting for intents published");
-        let old_group_id = amal_a.get_sync_group(amal_a_conn).unwrap().group_id;
+        let old_group_id = amal_a.get_sync_group(&amal_a_provider).unwrap().group_id;
 
         // let old_group_id = amal_a.get_sync_group(amal_a_conn).unwrap().group_id;
         tracing::info!("Disconnecting");
@@ -204,7 +204,7 @@ pub(crate) mod tests {
             .sync_welcomes(&amal_a_provider)
             .await
             .expect("sync_welcomes");
-        let new_group_id = amal_a.get_sync_group(amal_a_conn).unwrap().group_id;
+        let new_group_id = amal_a.get_sync_group(&amal_a_provider).unwrap().group_id;
         // group id should have changed to the new sync group created by the second installation
         assert_ne!(old_group_id, new_group_id);
     }

--- a/xmtp_mls/src/groups/device_sync/preference_sync.rs
+++ b/xmtp_mls/src/groups/device_sync/preference_sync.rs
@@ -129,7 +129,7 @@ mod tests {
             device_sync::{handle::SyncMetric, preference_sync::UserPreferenceUpdate},
             scoped_client::ScopedGroupClient,
         },
-        utils::tester::Tester,
+        utils::tester::{Tester, XmtpClientWalletTester},
     };
     use serde::{Deserialize, Serialize};
     use xmtp_db::{

--- a/xmtp_mls/src/groups/device_sync/preference_sync.rs
+++ b/xmtp_mls/src/groups/device_sync/preference_sync.rs
@@ -163,7 +163,7 @@ mod tests {
     #[xmtp_common::test]
     async fn test_hmac_sync() {
         let amal_a = Tester::new().await;
-        let amal_b = amal_a.clone().await;
+        let amal_b = amal_a.new_installation().await;
 
         // wait for the new sync group
         amal_a.worker().wait_for_init().await.unwrap();

--- a/xmtp_mls/src/groups/device_sync/preference_sync.rs
+++ b/xmtp_mls/src/groups/device_sync/preference_sync.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{groups::scoped_client::LocalScopedGroupClient, Client};
+use crate::{groups::scoped_client::ScopedGroupClient, Client};
 use xmtp_db::{consent_record::StoredConsentRecord, user_preferences::StoredUserPreferences};
 
 use serde::{Deserialize, Serialize};
@@ -68,7 +68,7 @@ impl UserPreferenceUpdate {
     }
 
     /// Process and insert incoming preference updates over the sync group
-    pub(crate) fn process_incoming_preference_update<C: LocalScopedGroupClient>(
+    pub(crate) fn process_incoming_preference_update<C: ScopedGroupClient>(
         update_proto: UserPreferenceUpdateProto,
         client: &C,
         provider: &XmtpOpenMlsProvider,

--- a/xmtp_mls/src/groups/device_sync/preference_sync.rs
+++ b/xmtp_mls/src/groups/device_sync/preference_sync.rs
@@ -166,8 +166,8 @@ mod tests {
         let amal_b = amal_a.clone().await;
 
         // wait for the new sync group
-        amal_a.worker.wait_for_init().await.unwrap();
-        amal_b.worker.wait_for_init().await.unwrap();
+        amal_a.worker().wait_for_init().await.unwrap();
+        amal_b.worker().wait_for_init().await.unwrap();
 
         amal_a.sync_welcomes(&amal_a.provider).await.unwrap();
 
@@ -180,7 +180,7 @@ mod tests {
 
         // Wait for a to process the new hmac key
         amal_a
-            .worker
+            .worker()
             .wait(SyncMetric::V1HmacReceived, 1)
             .await
             .unwrap();

--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -832,11 +832,15 @@ where
                                     .send(LocalEvents::IncomingPreferenceUpdate(updates));
                             }
                             _ => {
+                                tracing::error!("?");
                                 return Err(GroupMessageProcessingError::InvalidPayload);
                             }
                         }
                     }
-                    None => return Err(GroupMessageProcessingError::InvalidPayload),
+                    None => {
+                        tracing::error!("??");
+                        return Err(GroupMessageProcessingError::InvalidPayload);
+                    }
                 }
             }
             ProcessedMessageContent::ProposalMessage(_proposal_ptr) => {
@@ -1296,6 +1300,8 @@ where
                 Some(vec![IntentState::ToPublish]),
                 None,
             )?;
+
+            tracing::error!("heh {intents:?}");
 
             for intent in intents {
                 let result = retry_async!(

--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -1301,8 +1301,6 @@ where
                 None,
             )?;
 
-            tracing::error!("heh {intents:?}");
-
             for intent in intents {
                 let result = retry_async!(
                     Retry::default(),

--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -28,7 +28,6 @@ use crate::{
     subscriptions::{LocalEvents, SyncMessage},
     utils::{self, hash::sha256, id::calculate_message_id, time::hmac_epoch},
 };
-use xmtp_db::xmtp_openmls_provider::XmtpOpenMlsProvider;
 use xmtp_db::{
     db_connection::DbConnection,
     group_intent::{IntentKind, IntentState, StoredGroupIntent, ID},
@@ -38,6 +37,7 @@ use xmtp_db::{
     user_preferences::StoredUserPreferences,
     Delete, Fetch, ProviderTransactions, StorageError, StoreOrIgnore,
 };
+use xmtp_db::{group::ConversationType, xmtp_openmls_provider::XmtpOpenMlsProvider};
 
 use futures::future::try_join_all;
 use hkdf::Hkdf;
@@ -820,7 +820,9 @@ where
                                 // and returns a copy of what was inserted
                                 let updates =
                                     UserPreferenceUpdate::process_incoming_preference_update(
-                                        update, provider,
+                                        update,
+                                        &self.client,
+                                        &provider,
                                     )?;
 
                                 // Broadcast those updates for integrators to be notified of changes
@@ -1550,6 +1552,13 @@ where
         provider: &XmtpOpenMlsProvider,
         update_interval_ns: Option<i64>,
     ) -> Result<(), GroupError> {
+        let Some(stored_group) = provider.conn_ref().find_group(&self.group_id)? else {
+            return Ok(());
+        };
+        if stored_group.conversation_type == ConversationType::Sync {
+            return Ok(());
+        }
+
         // determine how long of an interval in time to use before updating list
         let interval_ns = update_interval_ns.unwrap_or(sync_update_installations_interval_ns());
 

--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -822,7 +822,7 @@ where
                                     UserPreferenceUpdate::process_incoming_preference_update(
                                         update,
                                         &self.client,
-                                        &provider,
+                                        provider,
                                     )?;
 
                                 // Broadcast those updates for integrators to be notified of changes
@@ -832,13 +832,11 @@ where
                                     .send(LocalEvents::IncomingPreferenceUpdate(updates));
                             }
                             _ => {
-                                tracing::error!("?");
                                 return Err(GroupMessageProcessingError::InvalidPayload);
                             }
                         }
                     }
                     None => {
-                        tracing::error!("??");
                         return Err(GroupMessageProcessingError::InvalidPayload);
                     }
                 }

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -1543,7 +1543,7 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
             .map(UserPreferenceUpdate::ConsentUpdate)
             .collect();
 
-        if !new_records.is_empty() && self.client.history_sync_url().is_some() {
+        if !new_records.is_empty() {
             // Dispatch an update event so it can be synced across devices
             let _ = self
                 .client

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -1543,13 +1543,11 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
             .map(UserPreferenceUpdate::ConsentUpdate)
             .collect();
 
-        if !new_records.is_empty() {
-            // Dispatch an update event so it can be synced across devices
-            let _ = self
-                .client
-                .local_events()
-                .send(LocalEvents::OutgoingPreferenceUpdates(new_records));
-        }
+        // Dispatch an update event so it can be synced across devices
+        let _ = self
+            .client
+            .local_events()
+            .send(LocalEvents::OutgoingPreferenceUpdates(new_records));
 
         Ok(())
     }

--- a/xmtp_mls/src/groups/scoped_client.rs
+++ b/xmtp_mls/src/groups/scoped_client.rs
@@ -1,3 +1,4 @@
+use super::device_sync::handle::{SyncMetric, WorkerHandle};
 use super::group_membership::{GroupMembership, MembershipDiff};
 use crate::utils::VersionInfo;
 use crate::verified_key_package_v2::KeyPackageVerificationError;
@@ -35,7 +36,7 @@ pub trait LocalScopedGroupClient: Send + Sync + Sized {
 
     fn local_events(&self) -> &broadcast::Sender<LocalEvents>;
 
-    fn history_sync_url(&self) -> &Option<String>;
+    fn worker_handle(&self) -> Option<Arc<WorkerHandle<SyncMetric>>>;
 
     fn version_info(&self) -> &Arc<VersionInfo>;
 
@@ -183,8 +184,8 @@ where
         Client::<ApiClient, Verifier>::context(self)
     }
 
-    fn history_sync_url(&self) -> &Option<String> {
-        &self.device_sync.server_url
+    fn worker_handle(&self) -> Option<Arc<WorkerHandle<SyncMetric>>> {
+        self.device_sync.worker_handle()
     }
 
     fn version_info(&self) -> &Arc<VersionInfo> {
@@ -269,8 +270,8 @@ where
         (**self).local_events()
     }
 
-    fn history_sync_url(&self) -> &Option<String> {
-        (**self).history_sync_url()
+    fn worker_handle(&self) -> Option<Arc<WorkerHandle<SyncMetric>>> {
+        (**self).worker_handle()
     }
 
     fn version_info(&self) -> &Arc<VersionInfo> {
@@ -370,8 +371,8 @@ where
         (**self).local_events()
     }
 
-    fn history_sync_url(&self) -> &Option<String> {
-        (**self).history_sync_url()
+    fn worker_handle(&self) -> Option<Arc<WorkerHandle<SyncMetric>>> {
+        (**self).worker_handle()
     }
 
     fn version_info(&self) -> &Arc<VersionInfo> {
@@ -468,8 +469,8 @@ where
         (**self).local_events()
     }
 
-    fn history_sync_url(&self) -> &Option<String> {
-        (**self).history_sync_url()
+    fn worker_handle(&self) -> Option<Arc<WorkerHandle<SyncMetric>>> {
+        (**self).worker_handle()
     }
 
     fn version_info(&self) -> &Arc<VersionInfo> {

--- a/xmtp_mls/src/groups/subscriptions.rs
+++ b/xmtp_mls/src/groups/subscriptions.rs
@@ -109,7 +109,7 @@ pub(crate) mod tests {
 
     #[rstest::rstest]
     #[xmtp_common::test]
-    #[timeout(Duration::from_secs(5))]
+    #[timeout(Duration::from_secs(10))]
     async fn test_decode_group_message_bytes() {
         let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;

--- a/xmtp_mls/src/utils/test/mod.rs
+++ b/xmtp_mls/src/utils/test/mod.rs
@@ -298,68 +298,6 @@ where
     }
 }
 
-#[derive(Default)]
-pub struct WorkerHandle {
-    processed: AtomicUsize,
-    notify: Notify,
-}
-
-impl WorkerHandle {
-    pub async fn wait_for_new_events(&self, mut count: usize) -> Result<(), Expired> {
-        timeout(xmtp_common::time::Duration::from_secs(3), async {
-            while count > 0 {
-                self.notify.notified().await;
-                count -= 1;
-            }
-        })
-        .await?;
-
-        Ok(())
-    }
-
-    pub async fn wait_for_processed_count(&self, expected: usize) -> Result<(), Expired> {
-        timeout(xmtp_common::time::Duration::from_secs(3), async {
-            while self.processed.load(Ordering::SeqCst) < expected {
-                self.notify.notified().await;
-            }
-        })
-        .await?;
-
-        Ok(())
-    }
-
-    pub async fn block_for_num_events<Fut>(&self, num_events: usize, op: Fut) -> Result<(), Expired>
-    where
-        Fut: Future<Output = ()>,
-    {
-        let processed_count = self.processed_count();
-        op.await;
-        self.wait_for_processed_count(processed_count + num_events)
-            .await?;
-        Ok(())
-    }
-
-    pub fn processed_count(&self) -> usize {
-        self.processed.load(Ordering::SeqCst)
-    }
-
-    pub fn increment(&self) {
-        self.processed
-            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-        self.notify.notify_waiters();
-    }
-}
-
-impl<ApiClient, V> Client<ApiClient, V> {
-    pub fn sync_worker_handle(&self) -> Option<Arc<WorkerHandle>> {
-        self.device_sync.worker_handle.lock().clone()
-    }
-
-    pub(crate) fn set_sync_worker_handle(&self, handle: Arc<WorkerHandle>) {
-        *self.device_sync.worker_handle.lock() = Some(handle);
-    }
-}
-
 pub async fn register_client<T: XmtpApi, V: SmartContractSignatureVerifier>(
     client: &Client<T, V>,
     owner: impl InboxOwner,

--- a/xmtp_mls/src/utils/test/mod.rs
+++ b/xmtp_mls/src/utils/test/mod.rs
@@ -76,7 +76,7 @@ impl ClientBuilder<TestClient, MockSmartContractSignatureVerifier> {
             owner,
             api_client,
             MockSmartContractSignatureVerifier::new(true),
-            None,
+            Some(HISTORY_SYNC_URL),
             None,
         )
         .await

--- a/xmtp_mls/src/utils/test/mod.rs
+++ b/xmtp_mls/src/utils/test/mod.rs
@@ -3,16 +3,9 @@
 #[cfg(any(test, feature = "test-utils"))]
 pub mod tester;
 
-use std::{
-    future::Future,
-    sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc,
-    },
-};
+use std::sync::Arc;
 use tokio::sync::Notify;
 use xmtp_api::ApiIdentifier;
-use xmtp_common::time::{timeout, Expired};
 use xmtp_id::{
     associations::{test_utils::MockSmartContractSignatureVerifier, Identifier},
     scw_verifier::{RemoteSignatureVerifier, SmartContractSignatureVerifier},

--- a/xmtp_mls/src/utils/test/tester.rs
+++ b/xmtp_mls/src/utils/test/tester.rs
@@ -79,7 +79,7 @@ where
         }
     }
 
-    pub(crate) async fn clone(&self) -> Self {
+    pub(crate) async fn new_installation(&self) -> Self {
         let cloned = Self::new_from_owner(self.owner.clone()).await;
         // The cloned will have created a new sync grup and invited you to it.
         // Sync the welcomes to become a part of it.

--- a/xmtp_mls/src/utils/test/tester.rs
+++ b/xmtp_mls/src/utils/test/tester.rs
@@ -1,6 +1,9 @@
 #![allow(unused)]
 
-use crate::builder::ClientBuilder;
+use crate::{
+    builder::ClientBuilder,
+    groups::device_sync::handle::{SyncMetric, WorkerHandle},
+};
 use ethers::signers::LocalWallet;
 use parking_lot::Mutex;
 use passkey::{
@@ -31,6 +34,7 @@ pub(crate) struct Tester<Owner> {
     pub owner: Owner,
     pub client: FullXmtpClient,
     pub provider: Arc<XmtpOpenMlsProvider>,
+    pub worker: Arc<WorkerHandle<SyncMetric>>,
 }
 
 impl Tester<LocalWallet> {
@@ -59,11 +63,13 @@ where
     pub(crate) async fn new_from_owner(owner: Owner) -> Self {
         let client = ClientBuilder::new_test_client(&owner).await;
         let provider = client.mls_provider().unwrap();
+        let worker = client.device_sync.worker_handle().unwrap();
 
         Self {
             owner,
             client,
             provider: Arc::new(provider),
+            worker,
         }
     }
 }

--- a/xmtp_mls/src/utils/test/tester.rs
+++ b/xmtp_mls/src/utils/test/tester.rs
@@ -122,13 +122,13 @@ pub(crate) struct TesterBuilder<Owner> {
 }
 
 impl<Owner> TesterBuilder<Owner> {
-    pub(crate) fn owner<NewOwner>(self: Self, owner: NewOwner) -> TesterBuilder<NewOwner> {
+    pub(crate) fn owner<NewOwner>(self, owner: NewOwner) -> TesterBuilder<NewOwner> {
         TesterBuilder {
             owner: Some(owner),
             sync_mode: self.sync_mode,
         }
     }
-    pub(crate) fn sync_mode(self: Self, mode: SyncWorkerMode) -> Self {
+    pub(crate) fn sync_mode(self, mode: SyncWorkerMode) -> Self {
         Self {
             sync_mode: Some(mode),
             ..self


### PR DESCRIPTION
### Refactor sync behavior to use provider-based access and add metric tracking for sync operations in XMTP MLS client
* Introduces a new metrics tracking system through the `WorkerHandle` in [handle.rs](https://github.com/xmtp/libxmtp/pull/1865/files#diff-316ee7c6adf5e43532329e72195ecd03a4378035231738f55fe1e1a888711f5c) that monitors sync events and provides waiting mechanisms
* Changes `sync_preferences` return type from `u32` to `u64` in [mls.rs](https://github.com/xmtp/libxmtp/pull/1865/files#diff-3a24c3e76565487a710ac9863ac05160128f4f90892e07849b555a6de43a6e8f) to prevent data loss
* Modifies sync group access to use provider-based approach instead of direct database connections across multiple files
* Updates test framework in [tester.rs](https://github.com/xmtp/libxmtp/pull/1865/files#diff-e248276c2fffaa7ac565757538c70a86a548e6d8369d4be1e61d122ab98a4061) to support metric-based wait conditions instead of time-based waits
* Adds instrumentation to sync operations in [device_sync.rs](https://github.com/xmtp/libxmtp/pull/1865/files#diff-fe691b22a6268a0ff6ae46b00e693850b30ea7ced6afe483ee9c97602aaddde2) for tracking various sync events

#### 📍Where to Start
Start with the new metrics tracking implementation in [handle.rs](https://github.com/xmtp/libxmtp/pull/1865/files#diff-316ee7c6adf5e43532329e72195ecd03a4378035231738f55fe1e1a888711f5c), which introduces the core functionality for monitoring sync operations.

----

_[Macroscope](https://app.macroscope.com) summarized 5ce3d9a._