### PR TITLE
Log improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8009,6 +8009,7 @@ dependencies = [
  "uniffi",
  "url",
  "uuid 1.16.0",
+ "vergen-git2",
  "xmtp_api",
  "xmtp_api_grpc",
  "xmtp_common",

--- a/bindings_ffi/Cargo.toml
+++ b/bindings_ffi/Cargo.toml
@@ -47,6 +47,7 @@ tracing-oslog = "0.2"
 
 [build-dependencies]
 uniffi = { version = "0.29.0", features = ["build"] }
+vergen-git2 = { workspace = true, features = ["build"] }
 
 [[bin]]
 name = "ffi-uniffi-bindgen"

--- a/bindings_ffi/build.rs
+++ b/bindings_ffi/build.rs
@@ -7,15 +7,15 @@ fn main() {
         .expect("failed to make libxmtp-version");
 
     let output = Command::new("git")
-        .args(&["rev-parse", "--short=7", "HEAD"])
+        .args(["rev-parse", "--short=7", "HEAD"])
         .output();
-    
+
     let git_hash = match output {
         Ok(output) if output.status.success() => {
             String::from_utf8_lossy(&output.stdout).trim().to_string()
-        },
-        _ => "unknown".to_string()
+        }
+        _ => "unknown".to_string(),
     };
-    
+
     println!("cargo:rustc-env=GIT_COMMIT_SHA={}", git_hash);
 }

--- a/bindings_ffi/build.rs
+++ b/bindings_ffi/build.rs
@@ -1,21 +1,23 @@
 use std::process::Command;
+use std::error::Error;
+use vergen_git2::{BuildBuilder, Emitter, Git2Builder};
 
-fn main() {
+fn main() -> Result<(), Box<dyn Error>> {
     Command::new("make")
         .args(["libxmtp-version"])
         .status()
         .expect("failed to make libxmtp-version");
 
-    let output = Command::new("git")
-        .args(["rev-parse", "--short=7", "HEAD"])
-        .output();
-
-    let git_hash = match output {
-        Ok(output) if output.status.success() => {
-            String::from_utf8_lossy(&output.stdout).trim().to_string()
-        }
-        _ => "unknown".to_string(),
-    };
-
-    println!("cargo:rustc-env=GIT_COMMIT_SHA={}", git_hash);
+    let build = BuildBuilder::all_build()?;
+    let git = Git2Builder::default()
+        .sha(true)
+        .commit_timestamp(true)
+        .build()?;
+    
+    Emitter::default()
+        .add_instructions(&build)?
+        .add_instructions(&git)?
+        .emit()?;
+    
+    Ok(())
 }

--- a/bindings_ffi/build.rs
+++ b/bindings_ffi/build.rs
@@ -1,5 +1,5 @@
-use std::process::Command;
 use std::error::Error;
+use std::process::Command;
 use vergen_git2::{BuildBuilder, Emitter, Git2Builder};
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -13,11 +13,11 @@ fn main() -> Result<(), Box<dyn Error>> {
         .sha(true)
         .commit_timestamp(true)
         .build()?;
-    
+
     Emitter::default()
         .add_instructions(&build)?
         .add_instructions(&git)?
         .emit()?;
-    
+
     Ok(())
 }

--- a/bindings_ffi/build.rs
+++ b/bindings_ffi/build.rs
@@ -5,4 +5,17 @@ fn main() {
         .args(["libxmtp-version"])
         .status()
         .expect("failed to make libxmtp-version");
+
+    let output = Command::new("git")
+        .args(&["rev-parse", "--short=7", "HEAD"])
+        .output();
+    
+    let git_hash = match output {
+        Ok(output) if output.status.success() => {
+            String::from_utf8_lossy(&output.stdout).trim().to_string()
+        },
+        _ => "unknown".to_string()
+    };
+    
+    println!("cargo:rustc-env=GIT_COMMIT_SHA={}", git_hash);
 }

--- a/bindings_ffi/src/logger.rs
+++ b/bindings_ffi/src/logger.rs
@@ -270,7 +270,7 @@ fn enable_debug_file_inner(
     let _ = exit_debug_writer();
 
     let version = env!("CARGO_PKG_VERSION");
-    let commit_sha = option_env!("GIT_COMMIT_SHA").unwrap_or("unknown");
+    let commit_sha = option_env!("VERGEN_GIT_SHA").unwrap_or("unknown");
     let file_appender = RollingFileAppender::builder()
         .filename_prefix(format!("libxmtp-v{}.{}.log", version, commit_sha))
         .rotation(rotation.into())

--- a/bindings_ffi/src/logger.rs
+++ b/bindings_ffi/src/logger.rs
@@ -270,8 +270,9 @@ fn enable_debug_file_inner(
     let _ = exit_debug_writer();
 
     let version = env!("CARGO_PKG_VERSION");
+    let commit_sha = option_env!("GIT_COMMIT_SHA").unwrap_or("unknown");
     let file_appender = RollingFileAppender::builder()
-        .filename_prefix(format!("libxmtp-v{}.log", version))
+        .filename_prefix(format!("libxmtp-v{}.{}.log", version, commit_sha))
         .rotation(rotation.into())
         .max_log_files(max_files as usize)
         .build(&directory)?;

--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -641,7 +641,7 @@ where
             let requires_processing = if allow_cursor_increment {
                 tracing::info!(
                     "calling update cursor for group {}, with cursor {}, allow_cursor_increment is true", 
-                    hex::encode(envelope.group_id.as_slice()), 
+                    hex::encode(envelope.group_id.as_slice()),
                     *cursor
                 );
                 provider.conn_ref().update_cursor(

--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -639,12 +639,22 @@ where
             let processed_message = mls_group.process_message(provider, message)?;
 
             let requires_processing = if allow_cursor_increment {
+                tracing::info!(
+                    "calling update cursor for group {}, with cursor {}, allow_cursor_increment is true", 
+                    hex::encode(envelope.group_id.as_slice()), 
+                    *cursor
+                );
                 provider.conn_ref().update_cursor(
                     &envelope.group_id,
                     EntityKind::Group,
                     *cursor as i64,
                 )?
             } else {
+                tracing::info!(
+                    "will not call update cursor for group {}, with cursor {}, allow_cursor_increment is false",
+                    hex::encode(envelope.group_id.as_slice()),
+                    *cursor
+                );
                 let current_cursor = provider
                     .conn_ref()
                     .get_last_cursor_for_id(&envelope.group_id, EntityKind::Group)?;
@@ -952,12 +962,22 @@ where
 
                     provider.transaction(|provider| {
                         let requires_processing = if allow_cursor_increment {
+                            tracing::info!(
+                                "calling update cursor for group {}, with cursor {}, allow_cursor_increment is true",
+                                hex::encode(envelope.group_id.as_slice()),
+                                cursor
+                            );
                             provider.conn_ref().update_cursor(
                                 &envelope.group_id,
                                 EntityKind::Group,
                                 cursor as i64,
                             )?
                         } else {
+                            tracing::info!(
+                                "will not call update cursor for group {}, with cursor {}, allow_cursor_increment is false",
+                                hex::encode(envelope.group_id.as_slice()),
+                                cursor
+                            );
                             let current_cursor = provider
                                 .conn_ref()
                                 .get_last_cursor_for_id(&envelope.group_id, EntityKind::Group)?;

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -691,12 +691,20 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
             } = decrypted_welcome;
 
             let requires_processing = if allow_cursor_increment {
+                tracing::info!(
+                    "calling update cursor for welcome {}, allow_cursor_increment is true",
+                    welcome.id
+                );
                 provider.conn_ref().update_cursor(
                     client.context().installation_public_key(),
                     EntityKind::Welcome,
                     welcome.id as i64,
                 )?
             } else {
+                tracing::info!(
+                    "will not call update cursor for welcome {}, allow_cursor_increment is false",
+                    welcome.id
+                );
                 let current_cursor = provider
                     .conn_ref()
                     .get_last_cursor_for_id(client.context().installation_public_key(), EntityKind::Welcome)?;


### PR DESCRIPTION
### Add Git commit SHA to log filenames and enhance cursor update logging in MLS group synchronization
* Adds Git commit hash retrieval during build process in [`bindings_ffi/build.rs`](https://github.com/xmtp/libxmtp/pull/1867/files#diff-23520459d6f722ee4a1d7f511f62d7a4824ebd618563fe7f1bb02e742db13bb9) and exposes it as `GIT_COMMIT_SHA` environment variable
* Modifies log filename format in [`bindings_ffi/src/logger.rs`](https://github.com/xmtp/libxmtp/pull/1867/files#diff-4bbabc172ad0589d5364e814aa0311a1792f06663618c2bbb82fe06fe62e418a) to include Git commit SHA: `libxmtp-v{version}.{commit_sha}.log`
* Implements additional tracing information in [`xmtp_mls/src/groups/mls_sync.rs`](https://github.com/xmtp/libxmtp/pull/1867/files#diff-10f818f7918c8c0b2ed32c4f63e5060050527ed58df00ec081bbecb66065144e) and [`xmtp_mls/src/groups/mod.rs`](https://github.com/xmtp/libxmtp/pull/1867/files#diff-c29f56a38916c7410eff8091df1a2e43487ffe20646d96827e846e475f4608d3) for cursor update operations during group synchronization and welcome message processing

#### 📍Where to Start
Start with the build configuration changes in [`bindings_ffi/build.rs`](https://github.com/xmtp/libxmtp/pull/1867/files#diff-23520459d6f722ee4a1d7f511f62d7a4824ebd618563fe7f1bb02e742db13bb9) which sets up the Git commit SHA environment variable that is used by the logging system.

----

_[Macroscope](https://app.macroscope.com) summarized d043669._