### PR TITLE
wasm scoped client fix

### DIFF
--- a/xmtp_mls/src/groups/scoped_client.rs
+++ b/xmtp_mls/src/groups/scoped_client.rs
@@ -107,6 +107,8 @@ pub trait ScopedGroupClient: Sized {
 
     fn local_events(&self) -> &broadcast::Sender<LocalEvents>;
 
+    fn worker_handle(&self) -> Option<Arc<WorkerHandle<SyncMetric>>>;
+
     fn history_sync_url(&self) -> &Option<String>;
 
     fn version_info(&self) -> &Arc<VersionInfo>;


### PR DESCRIPTION
### Add `worker_handle()` method to `ScopedGroupClient` trait to expose synchronization metrics in WebAssembly client
Extends the `ScopedGroupClient` trait interface in [scoped_client.rs](https://github.com/xmtp/libxmtp/pull/1870/files#diff-d2679cb39cd7e9b8b616339c541aa5056cad634e8cb3eab894dfd31415878363) with a new method that returns an optional `Arc<WorkerHandle<SyncMetric>>`.

#### 📍Where to Start
Start with the `worker_handle()` method implementation in the `ScopedGroupClient` trait in [scoped_client.rs](https://github.com/xmtp/libxmtp/pull/1870/files#diff-d2679cb39cd7e9b8b616339c541aa5056cad634e8cb3eab894dfd31415878363).

----

_[Macroscope](https://app.macroscope.com) summarized b86084a._