### PR TITLE
Disable worker in most tests

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -3309,7 +3309,7 @@ mod tests {
         // One identity update pushed. Zero interaction with groups.
         assert_eq!(ident_stats.publish_identity_update.get_count(), 1);
         assert_eq!(stats.send_welcome_messages.get_count(), 0);
-        assert_eq!(stats.send_group_messages.get_count(), 2);
+        assert_eq!(stats.send_group_messages.get_count(), 3);
 
         let bo = new_test_client();
         let conversation = alex

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -3815,8 +3815,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_create_group_with_members() {
-        let amal = new_test_client().await;
-        let bola = new_test_client().await;
+        let amal = Tester::new().await;
+        let bola = Tester::new().await;
 
         let group = amal
             .conversations()

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -6189,8 +6189,8 @@ mod tests {
             .sync_all_conversations(None)
             .await
             .unwrap();
-        assert_eq!(alix_num_sync, 2);
-        assert_eq!(bola_num_sync, 2);
+        assert_eq!(alix_num_sync, 1);
+        assert_eq!(bola_num_sync, 1);
 
         let alix_groups = alix_conversations
             .list_groups(FfiListConversationsOptions::default())

--- a/bindings_ffi/src/mls/test_utils.rs
+++ b/bindings_ffi/src/mls/test_utils.rs
@@ -1,0 +1,146 @@
+use std::sync::Arc;
+
+use ethers::signers::LocalWallet;
+use xmtp_common::tmp_path;
+use xmtp_id::InboxOwner;
+use xmtp_mls::{builder::SyncWorkerMode, utils::test::tester::*};
+
+use crate::inbox_owner::FfiInboxOwner;
+
+use super::{tests::FfiWalletInboxOwner, *};
+
+pub trait LocalBuilder<Owner>
+where
+    Owner: InboxOwner + Clone,
+{
+    async fn build(&self) -> Tester<Owner, Arc<FfiXmtpClient>>;
+    async fn build_no_panic(&self) -> Result<Tester<Owner, Arc<FfiXmtpClient>>, GenericError>;
+}
+impl LocalBuilder<LocalWallet> for TesterBuilder<LocalWallet> {
+    async fn build(&self) -> Tester<LocalWallet, Arc<FfiXmtpClient>> {
+        self.build_no_panic().await.unwrap()
+    }
+
+    // Will not panic on registering identity. Will still panic on just about everything else.
+    async fn build_no_panic(
+        &self,
+    ) -> Result<Tester<LocalWallet, Arc<FfiXmtpClient>>, GenericError> {
+        let client = create_raw_client(&self).await;
+        let owner = FfiWalletInboxOwner::with_wallet(self.owner.clone());
+        let signature_request = client.signature_request().unwrap();
+        signature_request
+            .add_ecdsa_signature(
+                owner
+                    .sign(signature_request.signature_text().await.unwrap())
+                    .unwrap(),
+            )
+            .await?;
+        client.register_identity(signature_request).await?;
+
+        let provider = client.inner_client.mls_provider()?;
+        let worker = client.inner_client.worker_handle();
+
+        if let Some(worker) = &worker {
+            worker.wait_for_init().await.unwrap();
+        }
+
+        Ok(Tester {
+            builder: self.clone(),
+            client,
+            provider: Arc::new(provider),
+            worker,
+        })
+    }
+}
+impl LocalBuilder<PasskeyUser> for TesterBuilder<PasskeyUser> {
+    async fn build(&self) -> Tester<PasskeyUser, Arc<FfiXmtpClient>> {
+        self.build_no_panic().await.unwrap()
+    }
+
+    async fn build_no_panic(
+        &self,
+    ) -> Result<Tester<PasskeyUser, Arc<FfiXmtpClient>>, GenericError> {
+        let client = create_raw_client(&self).await;
+        let signature_request = client.signature_request().unwrap();
+        let text = signature_request.signature_text().await.unwrap();
+        let UnverifiedSignature::Passkey(signature) = self.owner.sign(&text).unwrap() else {
+            unreachable!("Passkeys only provide passkey signatures.");
+        };
+
+        signature_request
+            .add_passkey_signature(FfiPasskeySignature {
+                authenticator_data: signature.authenticator_data,
+                client_data_json: signature.client_data_json,
+                public_key: signature.public_key,
+                signature: signature.signature,
+            })
+            .await
+            .unwrap();
+        client.register_identity(signature_request).await?;
+
+        let provider = client.inner_client.mls_provider().unwrap();
+        let worker = client.inner_client.worker_handle();
+
+        Ok(Tester {
+            builder: self.clone(),
+            client,
+            provider: Arc::new(provider),
+            worker,
+        })
+    }
+}
+
+pub trait LocalTester {
+    async fn new() -> Tester<LocalWallet, Arc<FfiXmtpClient>>;
+    async fn new_passkey() -> Tester<PasskeyUser, Arc<FfiXmtpClient>>;
+
+    fn builder() -> TesterBuilder<LocalWallet>;
+}
+impl LocalTester for Tester<LocalWallet, Arc<FfiXmtpClient>> {
+    async fn new() -> Tester<LocalWallet, Arc<FfiXmtpClient>> {
+        TesterBuilder::new().build().await
+    }
+    async fn new_passkey() -> Tester<PasskeyUser, Arc<FfiXmtpClient>> {
+        TesterBuilder::new().passkey_owner().await.build().await
+    }
+
+    fn builder() -> TesterBuilder<LocalWallet> {
+        TesterBuilder::new()
+    }
+}
+
+async fn create_raw_client<Owner>(builder: &TesterBuilder<Owner>) -> Arc<FfiXmtpClient>
+where
+    Owner: InboxOwner,
+{
+    let nonce = 1;
+    let ident = builder.owner.get_identifier().unwrap();
+    let inbox_id = ident.inbox_id(nonce).unwrap();
+
+    let client = create_client(
+        connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false)
+            .await
+            .unwrap(),
+        Some(tmp_path()),
+        Some(xmtp_db::EncryptedMessageStore::generate_enc_key().into()),
+        &inbox_id,
+        ident.into(),
+        1,
+        None,
+        builder.sync_url.clone(),
+        Some(
+            builder
+                .sync_mode
+                .as_ref()
+                .unwrap_or(&SyncWorkerMode::Disabled)
+                .clone()
+                .into(),
+        ),
+    )
+    .await
+    .unwrap();
+    let conn = client.inner_client.context().store().conn().unwrap();
+    conn.register_triggers();
+
+    client
+}

--- a/bindings_ffi/src/mls/test_utils.rs
+++ b/bindings_ffi/src/mls/test_utils.rs
@@ -25,7 +25,7 @@ impl LocalBuilder<LocalWallet> for TesterBuilder<LocalWallet> {
     async fn build_no_panic(
         &self,
     ) -> Result<Tester<LocalWallet, Arc<FfiXmtpClient>>, GenericError> {
-        let client = create_raw_client(&self).await;
+        let client = create_raw_client(self).await;
         let owner = FfiWalletInboxOwner::with_wallet(self.owner.clone());
         let signature_request = client.signature_request().unwrap();
         signature_request
@@ -60,7 +60,7 @@ impl LocalBuilder<PasskeyUser> for TesterBuilder<PasskeyUser> {
     async fn build_no_panic(
         &self,
     ) -> Result<Tester<PasskeyUser, Arc<FfiXmtpClient>>, GenericError> {
-        let client = create_raw_client(&self).await;
+        let client = create_raw_client(self).await;
         let signature_request = client.signature_request().unwrap();
         let text = signature_request.signature_text().await.unwrap();
         let UnverifiedSignature::Passkey(signature) = self.owner.sign(&text).unwrap() else {
@@ -92,6 +92,7 @@ impl LocalBuilder<PasskeyUser> for TesterBuilder<PasskeyUser> {
 
 pub trait LocalTester {
     async fn new() -> Tester<LocalWallet, Arc<FfiXmtpClient>>;
+    #[allow(unused)]
     async fn new_passkey() -> Tester<PasskeyUser, Arc<FfiXmtpClient>>;
 
     fn builder() -> TesterBuilder<LocalWallet>;

--- a/bindings_ffi/src/mls/test_utils.rs
+++ b/bindings_ffi/src/mls/test_utils.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use ethers::signers::LocalWallet;
 use xmtp_common::tmp_path;
 use xmtp_id::InboxOwner;
-use xmtp_mls::{builder::SyncWorkerMode, utils::test::tester::*};
+use xmtp_mls::utils::test::tester::*;
 
 use crate::inbox_owner::FfiInboxOwner;
 
@@ -41,7 +41,9 @@ impl LocalBuilder<LocalWallet> for TesterBuilder<LocalWallet> {
         let worker = client.inner_client.worker_handle();
 
         if let Some(worker) = &worker {
-            worker.wait_for_init().await.unwrap();
+            if self.wait_for_init {
+                worker.wait_for_init().await.unwrap();
+            }
         }
 
         Ok(Tester {
@@ -80,6 +82,12 @@ impl LocalBuilder<PasskeyUser> for TesterBuilder<PasskeyUser> {
 
         let provider = client.inner_client.mls_provider().unwrap();
         let worker = client.inner_client.worker_handle();
+
+        if let Some(worker) = &worker {
+            if self.wait_for_init {
+                worker.wait_for_init().await.unwrap();
+            }
+        }
 
         Ok(Tester {
             builder: self.clone(),
@@ -129,14 +137,7 @@ where
         1,
         None,
         builder.sync_url.clone(),
-        Some(
-            builder
-                .sync_mode
-                .as_ref()
-                .unwrap_or(&SyncWorkerMode::Disabled)
-                .clone()
-                .into(),
-        ),
+        Some(builder.sync_mode.clone().into()),
     )
     .await
     .unwrap();

--- a/bindings_ffi/src/worker.rs
+++ b/bindings_ffi/src/worker.rs
@@ -14,3 +14,12 @@ impl From<FfiSyncWorkerMode> for SyncWorkerMode {
         }
     }
 }
+
+impl From<SyncWorkerMode> for FfiSyncWorkerMode {
+    fn from(value: SyncWorkerMode) -> Self {
+        match value {
+            SyncWorkerMode::Enabled => Self::Enabled,
+            SyncWorkerMode::Disabled => Self::Disabled,
+        }
+    }
+}

--- a/xmtp_mls/src/groups/device_sync/consent_sync.rs
+++ b/xmtp_mls/src/groups/device_sync/consent_sync.rs
@@ -27,7 +27,7 @@ pub(crate) mod tests {
 
     use crate::{
         groups::{device_sync::handle::SyncMetric, scoped_client::ScopedGroupClient},
-        utils::tester::{Tester, XmtpClientWalletTester},
+        utils::tester::*,
     };
     use xmtp_db::consent_record::{ConsentState, ConsentType, StoredConsentRecord};
 
@@ -56,7 +56,7 @@ pub(crate) mod tests {
         assert_eq!(syncable_consent_records.len(), 1);
 
         // Create a second installation for amal with sync.
-        let amal_b = amal_a.new_installation().await;
+        let amal_b = amal_a.builder.build().await;
 
         amal_b
             .worker()

--- a/xmtp_mls/src/groups/device_sync/consent_sync.rs
+++ b/xmtp_mls/src/groups/device_sync/consent_sync.rs
@@ -69,6 +69,8 @@ pub(crate) mod tests {
             .unwrap();
         assert_eq!(consent_records_b.len(), 0);
 
+        amal_a.test_has_same_sync_group_as(&amal_b).await.unwrap();
+
         amal_a
             .get_sync_group(&amal_a.provider)
             .unwrap()

--- a/xmtp_mls/src/groups/device_sync/preference_sync.rs
+++ b/xmtp_mls/src/groups/device_sync/preference_sync.rs
@@ -129,7 +129,7 @@ mod tests {
             device_sync::{handle::SyncMetric, preference_sync::UserPreferenceUpdate},
             scoped_client::ScopedGroupClient,
         },
-        utils::tester::{Tester, XmtpClientWalletTester},
+        utils::tester::{LocalTester, Tester, XmtpClientTesterBuilder},
     };
     use serde::{Deserialize, Serialize};
     use xmtp_db::{
@@ -163,7 +163,7 @@ mod tests {
     #[xmtp_common::test]
     async fn test_hmac_sync() {
         let amal_a = Tester::new().await;
-        let amal_b = amal_a.new_installation().await;
+        let amal_b = amal_a.builder.build().await;
 
         // wait for the new sync group
         amal_a.worker().wait_for_init().await.unwrap();

--- a/xmtp_mls/src/lib.rs
+++ b/xmtp_mls/src/lib.rs
@@ -15,13 +15,15 @@ pub mod types;
 pub mod utils;
 pub mod verified_key_package_v2;
 
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test;
+
 pub use client::{Client, Network};
 use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex as TokioMutex;
 use xmtp_db::{xmtp_openmls_provider::XmtpOpenMlsProvider, DuplicateItem, StorageError};
-
 pub use xmtp_id::InboxOwner;
 pub use xmtp_proto::api_client::trait_impls::*;
 

--- a/xmtp_mls/src/test/client_test_utils.rs
+++ b/xmtp_mls/src/test/client_test_utils.rs
@@ -1,0 +1,67 @@
+#![allow(unused)]
+
+use xmtp_api::XmtpApi;
+use xmtp_id::scw_verifier::SmartContractSignatureVerifier;
+
+use crate::{
+    groups::{DMMetadataOptions, GroupError, MlsGroup},
+    Client,
+};
+
+// Please ensure that all public functions defined in this module
+// start with `test_`
+impl<ApiClient, V> Client<ApiClient, V>
+where
+    ApiClient: XmtpApi,
+    V: SmartContractSignatureVerifier,
+{
+    /// Creates a DM with the other client, sends a message, and ensures delivery,
+    /// returning the created dm and sent message contents
+    pub async fn test_talk_in_dm_with(
+        &self,
+        other: &Self,
+    ) -> Result<(MlsGroup<Self>, String), GroupError> {
+        self.sync_welcomes(&self.mls_provider()?).await?;
+        let dm = self
+            .find_or_create_dm_by_inbox_id(other.inbox_id(), DMMetadataOptions::default())
+            .await?;
+
+        other.sync_welcomes(&other.mls_provider()?).await?;
+        let other_dm = other
+            .find_or_create_dm_by_inbox_id(self.inbox_id(), DMMetadataOptions::default())
+            .await?;
+
+        // Since the other client synced welcomes before creating a DM
+        // the group_id should be the same.
+        assert_eq!(dm.group_id, other_dm.group_id);
+
+        let msg = dm.test_can_talk_with(&other_dm).await?;
+
+        Ok((dm, msg))
+    }
+
+    pub async fn test_has_same_sync_group_as(&self, other: &Self) -> Result<(), GroupError> {
+        self.sync_welcomes(&self.mls_provider()?).await?;
+        other.sync_welcomes(&other.mls_provider()?).await?;
+
+        let sync_group = self.get_sync_group(&self.mls_provider()?)?;
+        let other_sync_group = other.get_sync_group(&other.mls_provider()?)?;
+
+        sync_group.sync().await?;
+        other_sync_group.sync().await?;
+
+        assert_eq!(sync_group.group_id, other_sync_group.group_id);
+
+        let epoch = sync_group.epoch(&self.mls_provider()?).await?;
+        let other_epoch = other_sync_group.epoch(&other.mls_provider()?).await?;
+        assert_eq!(epoch, other_epoch);
+
+        let ratchet_tree = sync_group
+            .load_mls_group_with_lock(&self.mls_provider()?, |g| Ok(g.export_ratchet_tree()))?;
+        let other_ratchet_tree = other_sync_group
+            .load_mls_group_with_lock(&other.mls_provider()?, |g| Ok(g.export_ratchet_tree()))?;
+        assert_eq!(ratchet_tree, other_ratchet_tree);
+
+        Ok(())
+    }
+}

--- a/xmtp_mls/src/test/group_test_utils.rs
+++ b/xmtp_mls/src/test/group_test_utils.rs
@@ -1,0 +1,23 @@
+#![allow(unused)]
+#![allow(clippy::unwrap_used)]
+
+use crate::groups::{scoped_client::ScopedGroupClient, GroupError, MlsGroup};
+use xmtp_db::group_message::MsgQueryArgs;
+
+impl<Client: ScopedGroupClient> MlsGroup<Client> {
+    // Sends a mesage to other group and ensures delivery, returning sent message contents.
+    pub async fn test_can_talk_with(&self, other: &Self) -> Result<String, GroupError> {
+        let msg = xmtp_common::rand_string::<20>();
+        self.send_message(msg.as_bytes()).await?;
+
+        // Sync to pull down the message
+        other.sync().await?;
+        let mut other_msgs = other.find_messages(&MsgQueryArgs::default())?;
+        assert_eq!(
+            msg.as_bytes(),
+            other_msgs.pop().unwrap().decrypted_message_bytes
+        );
+
+        Ok(msg)
+    }
+}

--- a/xmtp_mls/src/test/mod.rs
+++ b/xmtp_mls/src/test/mod.rs
@@ -1,0 +1,2 @@
+pub mod client_test_utils;
+pub mod group_test_utils;

--- a/xmtp_mls/src/utils/test/mod.rs
+++ b/xmtp_mls/src/utils/test/mod.rs
@@ -6,6 +6,7 @@ pub mod tester;
 use std::sync::Arc;
 use tokio::sync::Notify;
 use xmtp_api::ApiIdentifier;
+use xmtp_api_http::HttpClientBuilderError;
 use xmtp_id::{
     associations::{test_utils::MockSmartContractSignatureVerifier, Identifier},
     scw_verifier::{RemoteSignatureVerifier, SmartContractSignatureVerifier},

--- a/xmtp_mls/src/utils/test/mod.rs
+++ b/xmtp_mls/src/utils/test/mod.rs
@@ -6,7 +6,6 @@ pub mod tester;
 use std::sync::Arc;
 use tokio::sync::Notify;
 use xmtp_api::ApiIdentifier;
-use xmtp_api_http::HttpClientBuilderError;
 use xmtp_id::{
     associations::{test_utils::MockSmartContractSignatureVerifier, Identifier},
     scw_verifier::{RemoteSignatureVerifier, SmartContractSignatureVerifier},

--- a/xmtp_mls/src/utils/test/tester.rs
+++ b/xmtp_mls/src/utils/test/tester.rs
@@ -141,6 +141,12 @@ where
 
 impl TesterBuilder<LocalWallet> {
     pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Default for TesterBuilder<LocalWallet> {
+    fn default() -> Self {
         Self {
             owner: generate_local_wallet(),
             sync_mode: None,


### PR DESCRIPTION
### Refactor test utilities to disable worker functionality and centralize test code in dedicated modules
The changes introduce a new test utilities architecture across multiple modules:

* Creates new dedicated test utility modules in [test_utils.rs](https://github.com/xmtp/libxmtp/pull/1871/files#diff-e625a5e3c0d28f66ea251e3a79a48d4cf2bd04fd45798a579a063279bfed10c9) and [test/](https://github.com/xmtp/libxmtp/pull/1871/files#diff-35a55a678113e771eee7cd402eef50c8e827bf40895cfdef62e0812ee70f9c68) containing shared test functionality
* Implements builder pattern for test client creation through `LocalBuilder` and `TesterBuilder` traits
* Moves test code from [mls.rs](https://github.com/xmtp/libxmtp/pull/1871/files#diff-3a24c3e76565487a710ac9863ac05160128f4f90892e07849b555a6de43a6e8f) into organized utility modules
* Adds conversion between `SyncWorkerMode` and `FfiSyncWorkerMode` enums in [worker.rs](https://github.com/xmtp/libxmtp/pull/1871/files#diff-55a1d1c7e33a2adb1278c5836309dc0dc82dd533777703af1658e3be89fa1ac1)
* Modifies `find_or_create_dm_by_inbox_id` in [client.rs](https://github.com/xmtp/libxmtp/pull/1871/files#diff-3c0189371525b6aae3be7e5a7b5b5682204ef341fb2744fc876148c5ecab8642) to accept any `AsIdRef` type

#### 📍Where to Start
Start with the new test utilities module [test_utils.rs](https://github.com/xmtp/libxmtp/pull/1871/files#diff-e625a5e3c0d28f66ea251e3a79a48d4cf2bd04fd45798a579a063279bfed10c9) which contains the core test infrastructure including the `LocalBuilder` trait and test client creation utilities.

----

_[Macroscope](https://app.macroscope.com) summarized 6247df9._