### PR TITLE
Fork fixes node dev release patch

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -4144,7 +4144,7 @@ mod tests {
 
         // alix published + processed group creation and name update
         assert_eq!(alix_provider.conn_ref().intents_published(), 2);
-        assert_eq!(alix_provider.conn_ref().intents_deleted(), 2);
+        assert_eq!(alix_provider.conn_ref().intents_processed(), 2);
 
         bo_group
             .conversation

--- a/xmtp_db/src/errors.rs
+++ b/xmtp_db/src/errors.rs
@@ -152,6 +152,12 @@ impl RetryableError for StorageError {
             Self::DieselConnect(_) => true,
             Self::DieselResult(result) => retryable!(result),
             Self::Duplicate(d) => retryable!(d),
+            Self::Io(_) => true,
+            Self::OpenMlsStorage(storage) => retryable!(storage),
+            #[cfg(not(target_arch = "wasm32"))]
+            Self::Native(_) => true,
+            #[cfg(target_arch = "wasm32")]
+            Self::Wasm(_) => true,
             _ => false,
         }
     }

--- a/xmtp_db/src/lib.rs
+++ b/xmtp_db/src/lib.rs
@@ -80,6 +80,7 @@ pub mod test_util {
                     intents_created INT DEFAULT 0,
                     intents_published INT DEFAULT 0,
                     intents_deleted INT DEFAULT 0,
+                    intents_processed INT DEFAULT 0,
                     rowid integer PRIMARY KEY CHECK (rowid = 1) -- There can only be one meta
                 );
                 "#,
@@ -93,6 +94,12 @@ pub mod test_util {
                 BEGIN
                     UPDATE test_metadata SET intents_published = intents_published + 1;
                 END;"#,
+                r#"CREATE TRIGGER intents_processed_tracking AFTER UPDATE OF state ON group_intents
+                FOR EACH ROW
+                WHEN NEW.state = 5
+                BEGIN
+                    UPDATE test_metadata SET intents_processed = intents_processed + 1;
+                END;"#,
                 r#"CREATE TRIGGER intents_deleted_tracking AFTER DELETE ON group_intents
                 FOR EACH ROW
                 BEGIN
@@ -101,8 +108,9 @@ pub mod test_util {
                 r#"INSERT INTO test_metadata (
                     intents_created,
                     intents_deleted,
-                    intents_published
-                ) VALUES (0, 0,0);"#,
+                    intents_published,
+                    intents_processed
+                ) VALUES (0, 0, 0, 0);"#,
             ];
 
             for query in queries {
@@ -124,6 +132,22 @@ pub mod test_util {
                 let mut row = conn
                     .load(sql_query(
                         "SELECT intents_published FROM test_metadata WHERE rowid = 1",
+                    ))
+                    .unwrap();
+                let row = row.next().unwrap().unwrap();
+                Ok::<_, StorageError>(
+                    <i32 as FromSqlRow<diesel::sql_types::Integer, _>>::build_from_row(&row)
+                        .unwrap(),
+                )
+            })
+            .unwrap()
+        }
+
+        pub fn intents_processed(&self) -> i32 {
+            self.raw_query_read(|conn| {
+                let mut row = conn
+                    .load(sql_query(
+                        "SELECT intents_processed FROM test_metadata WHERE rowid = 1",
                     ))
                     .unwrap();
                 let row = row.next().unwrap().unwrap();

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -924,7 +924,7 @@ where
         provider: &XmtpOpenMlsProvider,
         welcome: &welcome_message::V1,
     ) -> Result<MlsGroup<Self>, GroupError> {
-        let result = MlsGroup::create_from_welcome(self, provider, welcome).await;
+        let result = MlsGroup::create_from_welcome(self, provider, welcome, true).await;
 
         match result {
             Ok(mls_group) => Ok(mls_group),

--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -36,7 +36,7 @@ use xmtp_db::{
     refresh_state::EntityKind,
     sql_key_store,
     user_preferences::StoredUserPreferences,
-    Delete, Fetch, ProviderTransactions, StorageError, StoreOrIgnore,
+    Fetch, ProviderTransactions, StorageError, StoreOrIgnore,
 };
 
 use futures::future::try_join_all;
@@ -341,6 +341,17 @@ where
                         last_err
                     );
                     return Err(last_err.unwrap_or(GroupError::IntentNotCommitted));
+                }
+                Ok(Some(StoredGroupIntent {
+                    id,
+                    state: IntentState::Processed,
+                    ..
+                })) => {
+                    tracing::warn!(
+                        "not retrying intent ID {id}. since it is in state processed. {:?}",
+                        last_err
+                    );
+                    return Ok(());
                 }
                 Ok(Some(StoredGroupIntent { id, state, .. })) => {
                     tracing::warn!("retrying intent ID {id}. intent currently in state {state:?}");
@@ -990,6 +1001,10 @@ where
                                 tracing::warn!("Intent [{}] moved to error status", intent_id);
                                 Ok(provider.conn_ref().set_group_intent_error(intent_id)?)
                             }
+                            IntentState::Processed => {
+                                tracing::warn!("Intent [{}] moved to Processed status", intent_id);
+                                Ok(provider.conn_ref().set_group_intent_processed(intent_id)?)
+                            }
                         }
                     })
                 }).await?;
@@ -1184,7 +1199,7 @@ where
                     // If the error is retryable we cannot move on to the next message
                     // otherwise you can get into a forked group state.
                     if is_retryable {
-                        tracing::error!(
+                        tracing::info!(
                             error = %error_message,
                             "Aborting message processing for retryable error: {}",
                             error_message
@@ -1381,8 +1396,7 @@ where
                             installation_id = %self.client.installation_id(),
                             "Skipping intent because no publish data returned"
                         );
-                        let deleter: &dyn Delete<StoredGroupIntent, Key = i32> = provider.conn_ref();
-                        deleter.delete(intent.id)?;
+                        provider.conn_ref().set_group_intent_processed(intent.id)?
                     }
                 }
             }
@@ -1538,8 +1552,7 @@ where
                     }
                 }
             }
-            let deleter: &dyn Delete<StoredGroupIntent, Key = i32> = conn;
-            deleter.delete(intent.id)?;
+            conn.set_group_intent_processed(intent.id)?
         }
 
         Ok(())
@@ -2098,7 +2111,7 @@ pub(crate) mod tests {
 
         // create group intent
         amal_group_a.sync().await.unwrap();
-        assert_eq!(provider.conn_ref().intents_deleted(), 1);
+        assert_eq!(provider.conn_ref().intents_processed(), 1);
 
         for _ in 0..100 {
             let s = xmtp_common::rand_string::<100>();

--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -563,6 +563,7 @@ where
         mls_group: &mut OpenMlsGroup,
         message: PrivateMessageIn,
         envelope: &GroupMessageV1,
+        allow_cursor_increment: bool,
     ) -> Result<(), GroupMessageProcessingError> {
         let GroupMessageV1 {
             created_ns: envelope_timestamp_ns,
@@ -637,12 +638,19 @@ where
             );
             let processed_message = mls_group.process_message(provider, message)?;
 
-            let is_updated = provider.conn_ref().update_cursor(
-                &envelope.group_id,
-                EntityKind::Group,
-                *cursor as i64,
-            )?;
-            if !is_updated {
+            let requires_processing = if allow_cursor_increment {
+                provider.conn_ref().update_cursor(
+                    &envelope.group_id,
+                    EntityKind::Group,
+                    *cursor as i64,
+                )?
+            } else {
+                let current_cursor = provider
+                    .conn_ref()
+                    .get_last_cursor_for_id(&envelope.group_id, EntityKind::Group)?;
+                current_cursor < *cursor as i64
+            };
+            if !requires_processing {
                 return Err(ProcessIntentError::AlreadyProcessed(*cursor).into());
             }
             let previous_epoch = mls_group.epoch().as_u64();
@@ -879,13 +887,22 @@ where
     }
 
     /// This function is idempotent. No need to wrap in a transaction.
+    ///
+    /// # Parameters
+    /// * `provider` - The OpenMLS provider for database access
+    /// * `envelope` - The message envelope to process
+    /// * `trust_message_order` - Controls whether to allow epoch increments from commits and msg cursor increments.
+    ///   Set to `true` when processing messages from trusted ordered sources (queries), and `false` when
+    ///   processing from potentially out-of-order sources like streams.
     #[tracing::instrument(skip(self, provider, envelope), level = "debug")]
     pub(crate) async fn process_message(
         &self,
         provider: &XmtpOpenMlsProvider,
         envelope: &GroupMessageV1,
-        allow_epoch_increment: bool,
+        trust_message_order: bool,
     ) -> Result<(), GroupMessageProcessingError> {
+        let allow_epoch_increment = trust_message_order;
+        let allow_cursor_increment = trust_message_order;
         let cursor = envelope.id;
         let mls_message_in = MlsMessageIn::tls_deserialize_exact(&envelope.data)?;
 
@@ -934,11 +951,19 @@ where
                     let maybe_validated_commit = self.stage_and_validate_intent(&mls_group, &intent, provider, &message, envelope).await;
 
                     provider.transaction(|provider| {
-                        let is_updated =
-                            provider
+                        let requires_processing = if allow_cursor_increment {
+                            provider.conn_ref().update_cursor(
+                                &envelope.group_id,
+                                EntityKind::Group,
+                                cursor as i64,
+                            )?
+                        } else {
+                            let current_cursor = provider
                                 .conn_ref()
-                                .update_cursor(&envelope.group_id, EntityKind::Group, cursor as i64)?;
-                        if !is_updated {
+                                .get_last_cursor_for_id(&envelope.group_id, EntityKind::Group)?;
+                            current_cursor < cursor as i64
+                        };
+                        if !requires_processing {
                             return Err(ProcessIntentError::AlreadyProcessed(cursor).into());
                         }
 
@@ -989,6 +1014,7 @@ where
                         &mut mls_group,
                         message,
                         envelope,
+                        allow_cursor_increment,
                     )
                     .await
                 })

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -2102,8 +2102,8 @@ pub(crate) mod tests {
     use prost::Message;
     use std::sync::Arc;
     use wasm_bindgen_test::wasm_bindgen_test;
-    use xmtp_common::assert_err;
     use xmtp_common::time::now_ns;
+    use xmtp_common::{assert_err, assert_ok};
     use xmtp_content_types::{group_updated::GroupUpdatedCodec, ContentCodec};
     use xmtp_cryptography::utils::generate_local_wallet;
     use xmtp_id::associations::test_utils::WalletTestExt;
@@ -4734,6 +4734,46 @@ pub(crate) mod tests {
         assert!(errors
             .iter()
             .any(|err| err.to_string().contains("already processed")));
+    }
+
+    #[xmtp_common::test]
+    async fn skip_already_processed_intents() {
+        let alix = ClientBuilder::new_test_client(&generate_local_wallet()).await;
+
+        let bo_wallet = generate_local_wallet();
+        let bo_client = ClientBuilder::new_test_client(&bo_wallet).await;
+
+        let alix_group = alix
+            .create_group(None, GroupMetadataOptions::default())
+            .unwrap();
+
+        alix_group
+            .add_members_by_inbox_id(&[bo_client.inbox_id()])
+            .await
+            .unwrap();
+
+        bo_client
+            .sync_welcomes(&bo_client.mls_provider().unwrap())
+            .await
+            .unwrap();
+        let bo_groups = bo_client.find_groups(GroupQueryArgs::default()).unwrap();
+        let bo_group = bo_groups.first().unwrap();
+        bo_group.send_message(&[2]).await.unwrap();
+        let bo_provider = bo_client.mls_provider().unwrap();
+        let intent = bo_provider
+            .conn_ref()
+            .find_group_intents(
+                bo_group.clone().group_id,
+                Some(vec![IntentState::Processed]),
+                None,
+            )
+            .unwrap();
+        assert_eq!(intent.len(), 2); //key_update and send_message
+
+        let process_result = bo_group
+            .sync_until_intent_resolved(&bo_provider, intent[1].id)
+            .await;
+        assert_ok!(process_result);
     }
 
     #[xmtp_common::test(flavor = "multi_thread")]

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -5769,4 +5769,176 @@ pub(crate) mod tests {
             .await;
         assert!(result.is_err());
     }
+
+    #[xmtp_common::test(flavor = "multi_thread")]
+    async fn can_stream_out_of_order_without_forking() {
+        let wallet_a = generate_local_wallet();
+        let wallet_b = generate_local_wallet();
+        let wallet_c = generate_local_wallet();
+        let client_a1 = ClientBuilder::new_test_client(&wallet_a).await;
+        let client_b = ClientBuilder::new_test_client(&wallet_b).await;
+        let client_c = ClientBuilder::new_test_client(&wallet_c).await;
+
+        // Create a group
+        let group_a = client_a1
+            .create_group(None, GroupMetadataOptions::default())
+            .unwrap();
+
+        // Add client_b and client_c to the group
+        group_a
+            .add_members_by_inbox_id(&[client_b.inbox_id(), client_c.inbox_id()])
+            .await
+            .unwrap();
+
+        // Sync the group
+        client_b
+            .sync_welcomes(&client_b.mls_provider().unwrap())
+            .await
+            .unwrap();
+        let binding = client_b.find_groups(GroupQueryArgs::default()).unwrap();
+        let group_b = binding.first().unwrap();
+
+        client_c
+            .sync_welcomes(&client_c.mls_provider().unwrap())
+            .await
+            .unwrap();
+        let binding = client_c.find_groups(GroupQueryArgs::default()).unwrap();
+        let group_c = binding.first().unwrap();
+
+        // Each client sends a message and syncs (ensures any key update commits are sent)
+        group_a
+            .send_message_optimistic("Message a1".as_bytes())
+            .unwrap();
+        group_a
+            .publish_intents(&group_a.mls_provider().unwrap())
+            .await
+            .unwrap();
+
+        group_a.sync().await.unwrap();
+        group_b.sync().await.unwrap();
+        group_c.sync().await.unwrap();
+
+        group_b
+            .send_message_optimistic("Message b1".as_bytes())
+            .unwrap();
+        group_b
+            .publish_intents(&group_b.mls_provider().unwrap())
+            .await
+            .unwrap();
+
+        group_a.sync().await.unwrap();
+        group_b.sync().await.unwrap();
+        group_c.sync().await.unwrap();
+
+        group_c
+            .send_message_optimistic("Message c1".as_bytes())
+            .unwrap();
+        group_c
+            .publish_intents(&group_c.mls_provider().unwrap())
+            .await
+            .unwrap();
+
+        // Sync the groups
+        group_a.sync().await.unwrap();
+        group_b.sync().await.unwrap();
+        group_c.sync().await.unwrap();
+
+        // After client a adds b and c, and they each sent a message, all groups are in the same epoch
+        assert_eq!(
+            group_a
+                .epoch(&client_a1.mls_provider().unwrap())
+                .await
+                .unwrap(),
+            3
+        );
+        assert_eq!(
+            group_b
+                .epoch(&client_b.mls_provider().unwrap())
+                .await
+                .unwrap(),
+            3
+        );
+        assert_eq!(
+            group_c
+                .epoch(&client_c.mls_provider().unwrap())
+                .await
+                .unwrap(),
+            3
+        );
+
+        // Client b updates the group name, (incrementing the epoch from 3 to 4), and syncs
+        group_b
+            .update_group_name("Group B".to_string())
+            .await
+            .unwrap();
+        group_b.sync().await.unwrap();
+
+        // Client c sends two text messages before incrementing the epoch
+        group_c
+            .send_message_optimistic("Message c2".as_bytes())
+            .unwrap();
+        group_c
+            .publish_intents(&group_c.mls_provider().unwrap())
+            .await
+            .unwrap();
+        group_b.sync().await.unwrap();
+
+        // Retrieve all messages from group B, verify they contain the two messages from client c even though they were sent from the wrong epoch
+        let messages = client_b
+            .api_client
+            .query_group_messages(group_b.group_id.clone(), None)
+            .await
+            .unwrap();
+        assert_eq!(messages.len(), 8);
+
+        // Get reference to last message
+        let last_message = messages.last().unwrap();
+
+        // Simulating group_a streaming out of order by processing the last_message first
+        let v1_last_message = match &last_message.version {
+            Some(xmtp_proto::xmtp::mls::api::v1::group_message::Version::V1(v1)) => v1,
+            _ => panic!("Expected V1 message"),
+        };
+
+        // This is the key line, because we pass in false for incrementing epoch/cursor (simulating streaming)
+        // This processing will not longer update the cursor, so we will not be forked
+        let increment_epoch = false;
+        let result = group_a
+            .process_message(
+                &client_a1.mls_provider().unwrap(),
+                v1_last_message,
+                increment_epoch,
+            )
+            .await;
+        assert!(result.is_ok());
+
+        // Now syncing a will update group_a group name since the cursor has NOT moved on past it
+        group_a.sync().await.unwrap();
+        group_b.sync().await.unwrap();
+        group_c.sync().await.unwrap();
+
+        assert_eq!(
+            group_b
+                .epoch(&client_b.mls_provider().unwrap())
+                .await
+                .unwrap(),
+            4
+        );
+        assert_eq!(
+            group_c
+                .epoch(&client_c.mls_provider().unwrap())
+                .await
+                .unwrap(),
+            4
+        );
+        // We pass on the last line because a's cursor has not moved past any commits, even though it processed
+        // messages out of order
+        assert_eq!(
+            group_a
+                .epoch(&client_a1.mls_provider().unwrap())
+                .await
+                .unwrap(),
+            4
+        );
+    }
 }

--- a/xmtp_mls/src/subscriptions/stream_conversations.rs
+++ b/xmtp_mls/src/subscriptions/stream_conversations.rs
@@ -411,7 +411,7 @@ where
 
         let group = retry_async!(
             Retry::default(),
-            (async { MlsGroup::create_from_welcome(client, provider, welcome).await })
+            (async { MlsGroup::create_from_welcome(client, provider, welcome, false).await })
         );
 
         if let Err(e) = group {
@@ -483,7 +483,8 @@ mod test {
 
     #[rstest::rstest]
     #[xmtp_common::test]
-    #[timeout(std::time::Duration::from_secs(5))]
+    #[timeout(std::time::Duration::from_secs(7))]
+    #[cfg_attr(target_arch = "wasm32", ignore)]
     async fn test_dm_streaming() {
         let alix = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
         let bo = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);

--- a/xmtp_mls/src/subscriptions/stream_messages.rs
+++ b/xmtp_mls/src/subscriptions/stream_messages.rs
@@ -403,7 +403,9 @@ where
                 cursor_id,
                 inbox_id = self.inbox_id(),
                 group_id = hex::encode(&self.msg.group_id),
-                "group message not found"
+                "no further processing for streamed message [{}] in group [{}]",
+                &cursor_id,
+                hex::encode(&self.msg.group_id),
             );
 
             Ok(None)


### PR DESCRIPTION
### Modify MLS message processing to prevent group state forking by marking intents as processed instead of deleted and controlling cursor increments
* Adds new `Processed` state to `IntentState` enum in [group_intent.rs](https://github.com/xmtp/libxmtp/pull/1873/files#diff-17a09cbc9886e242f0ff0189d4750dbfd8226be9344e7b41814967745cfe0a0c) and implements `set_group_intent_processed` method
* Modifies message processing in [mls_sync.rs](https://github.com/xmtp/libxmtp/pull/1873/files#diff-10f818f7918c8c0b2ed32c4f63e5060050527ed58df00ec081bbecb66065144e) and [mod.rs](https://github.com/xmtp/libxmtp/pull/1873/files#diff-c29f56a38916c7410eff8091df1a2e43487ffe20646d96827e846e475f4608d3) to make cursor increments optional via `allow_cursor_increment` parameter
* Expands retryable storage errors in [errors.rs](https://github.com/xmtp/libxmtp/pull/1873/files#diff-c28554f6385bb1e08c2ed9656a3618cd1f29d58e5b8dc8729b083e84078261c8) to include I/O, OpenMLS storage, and platform-specific errors
* Updates test utilities in [lib.rs](https://github.com/xmtp/libxmtp/pull/1873/files#diff-c199e5ef558d146f375307a50b45a68225e86dae21ed1b8197ea96c49412182c) to track processed intents
* Improves logging context for streamed messages in [stream_messages.rs](https://github.com/xmtp/libxmtp/pull/1873/files#diff-ee8c2d1c90650351a2245875b62af09f2c152c29643200276da5743cd59424e7)

#### 📍Where to Start
Start with the `create_from_welcome` method in [mod.rs](https://github.com/xmtp/libxmtp/pull/1873/files#diff-c29f56a38916c7410eff8091df1a2e43487ffe20646d96827e846e475f4608d3) which introduces the new `allow_cursor_increment` parameter that controls cursor behavior during message processing.

----

_[Macroscope](https://app.macroscope.com) summarized 3038652._