### PR TITLE
Wasm, Node binding fixes

### DIFF
--- a/bindings_wasm/src/tests/mod.rs
+++ b/bindings_wasm/src/tests/mod.rs
@@ -23,6 +23,7 @@ async fn create_test_client() -> Client {
     Some(db),
     None,
     None,
+    None,
     Some(LogOptions {
       structured: false,
       performance: true,

--- a/xmtp_mls/src/groups/device_sync.rs
+++ b/xmtp_mls/src/groups/device_sync.rs
@@ -1,7 +1,7 @@
 use super::{GroupError, MlsGroup};
 use crate::configuration::WORKER_RESTART_DELAY;
 use crate::groups::disappearing_messages::DisappearingMessagesCleanerWorker;
-use crate::groups::scoped_client::LocalScopedGroupClient;
+use crate::groups::scoped_client::ScopedGroupClient;
 use crate::{
     client::ClientError,
     configuration::NS_IN_HOUR,

--- a/xmtp_mls/src/groups/scoped_client.rs
+++ b/xmtp_mls/src/groups/scoped_client.rs
@@ -109,8 +109,6 @@ pub trait ScopedGroupClient: Sized {
 
     fn worker_handle(&self) -> Option<Arc<WorkerHandle<SyncMetric>>>;
 
-    fn history_sync_url(&self) -> &Option<String>;
-
     fn version_info(&self) -> &Arc<VersionInfo>;
 
     fn inbox_id(&self) -> InboxIdRef<'_> {


### PR DESCRIPTION
### Update WASM bindings and MLS group client interfaces to modify test client creation and remove history sync URL functionality
The changes span across three files with varying impacts:

* Modifies `create_test_client` function in [bindings_wasm/src/tests/mod.rs](https://github.com/xmtp/libxmtp/pull/1874/files#diff-b835d89530fceeffa7f5fb97597f27b54bd86cbdc576f88dfeea0e4a07f5c349) to include an additional `None` parameter
* Removes `history_sync_url` method from `ScopedGroupClient` trait in [xmtp_mls/src/groups/scoped_client.rs](https://github.com/xmtp/libxmtp/pull/1874/files#diff-d2679cb39cd7e9b8b616339c541aa5056cad634e8cb3eab894dfd31415878363)
* Updates import from `LocalScopedGroupClient` to `ScopedGroupClient` in [xmtp_mls/src/groups/device_sync.rs](https://github.com/xmtp/libxmtp/pull/1874/files#diff-fe691b22a6268a0ff6ae46b00e693850b30ea7ced6afe483ee9c97602aaddde2)

#### 📍Where to Start
Start with the `ScopedGroupClient` trait changes in [xmtp_mls/src/groups/scoped_client.rs](https://github.com/xmtp/libxmtp/pull/1874/files#diff-d2679cb39cd7e9b8b616339c541aa5056cad634e8cb3eab894dfd31415878363) as this contains the most impactful change with the removal of the `history_sync_url` method.

----

_[Macroscope](https://app.macroscope.com) summarized cae98b4._