### PR TITLE
cleanup db platform-specific traits

### DIFF
--- a/xmtp_db/src/encrypted_store/database.rs
+++ b/xmtp_db/src/encrypted_store/database.rs
@@ -1,0 +1,28 @@
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+pub mod native;
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+pub use native::*;
+
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+pub mod wasm;
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+pub use wasm::*;
+
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+pub use wasm_exports::*;
+
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+pub use native_exports::*;
+
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+pub mod wasm_exports {
+    pub type RawDbConnection = diesel::prelude::SqliteConnection;
+    pub type DefaultDatabase = super::wasm::WasmDb;
+}
+
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+pub mod native_exports {
+    pub type DefaultDatabase = super::native::NativeDb;
+    // the native module already defines this
+    // pub type RawDbConnection = native::RawDbConnection;
+}

--- a/xmtp_db/src/encrypted_store/database/native.rs
+++ b/xmtp_db/src/encrypted_store/database/native.rs
@@ -1,3 +1,5 @@
+mod sqlcipher_connection;
+
 use crate::NotFound;
 /// Native SQLite connection using SqlCipher
 use crate::encrypted_store::DbConnectionPrivate;
@@ -16,7 +18,8 @@ pub type ConnectionManager = r2d2::ConnectionManager<SqliteConnection>;
 pub type Pool = r2d2::Pool<ConnectionManager>;
 pub type RawDbConnection = PooledConnection<ConnectionManager>;
 
-use super::{EncryptionKey, StorageOption, XmtpDb, sqlcipher_connection::EncryptedConnection};
+use self::sqlcipher_connection::EncryptedConnection;
+use crate::{EncryptionKey, StorageOption, XmtpDb};
 
 trait XmtpConnection:
     ValidatedConnection
@@ -142,7 +145,7 @@ pub struct NativeDb {
 
 impl NativeDb {
     /// This function is private so that an unencrypted database cannot be created by accident
-    pub(super) fn new(
+    pub(crate) fn new(
         opts: &StorageOption,
         enc_key: Option<EncryptionKey>,
     ) -> Result<Self, NativeStorageError> {

--- a/xmtp_db/src/encrypted_store/database/native/sqlcipher_connection.rs
+++ b/xmtp_db/src/encrypted_store/database/native/sqlcipher_connection.rs
@@ -12,9 +12,10 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::{NotFound, native::NativeStorageError};
+use super::NativeStorageError;
+use crate::NotFound;
 
-use super::{EncryptionKey, StorageOption};
+use crate::{EncryptionKey, StorageOption};
 
 pub type Salt = [u8; 16];
 const PLAINTEXT_HEADER_SIZE: usize = 32;
@@ -45,7 +46,7 @@ pub struct EncryptedConnection {
 impl EncryptedConnection {
     /// Creates a file for the salt and stores it
     pub fn new(key: EncryptionKey, opts: &StorageOption) -> Result<Self, NativeStorageError> {
-        use super::StorageOption::*;
+        use crate::StorageOption::*;
 
         let salt = match opts {
             Ephemeral => None,
@@ -256,7 +257,7 @@ impl EncryptedConnection {
     }
 }
 
-impl super::native::ValidatedConnection for EncryptedConnection {
+impl super::ValidatedConnection for EncryptedConnection {
     fn validate(&self, opts: &StorageOption) -> Result<(), NativeStorageError> {
         let conn = &mut opts.conn()?;
         let sqlcipher_version = EncryptedConnection::check_for_sqlcipher(opts, Some(conn))?;

--- a/xmtp_db/src/encrypted_store/database/wasm.rs
+++ b/xmtp_db/src/encrypted_store/database/wasm.rs
@@ -1,6 +1,6 @@
 //! WebAssembly specific connection for a SQLite Database
 //! Stores a single connection behind a mutex that's used for every libxmtp operation
-use super::{StorageOption, XmtpDb, db_connection::DbConnectionPrivate};
+use crate::{StorageOption, XmtpDb, db_connection::DbConnectionPrivate};
 use diesel::prelude::SqliteConnection;
 use diesel::{connection::AnsiTransactionManager, prelude::*};
 use parking_lot::Mutex;
@@ -106,7 +106,7 @@ impl std::fmt::Debug for WasmDb {
 
 impl WasmDb {
     pub async fn new(opts: &StorageOption) -> Result<Self, WasmStorageError> {
-        use super::StorageOption::*;
+        use crate::StorageOption::*;
         init_sqlite().await;
         maybe_resize().await?;
         let conn = match opts {

--- a/xmtp_db/src/encrypted_store/db_connection.rs
+++ b/xmtp_db/src/encrypted_store/db_connection.rs
@@ -12,7 +12,7 @@ use std::{
 use super::XmtpDb;
 
 #[cfg(not(target_arch = "wasm32"))]
-pub type DbConnection = DbConnectionPrivate<super::RawDbConnection>;
+pub type DbConnection = DbConnectionPrivate<crate::database::RawDbConnection>;
 
 #[cfg(target_arch = "wasm32")]
 pub type DbConnection = DbConnectionPrivate<diesel::prelude::SqliteConnection>;

--- a/xmtp_db/src/encrypted_store/mod.rs
+++ b/xmtp_db/src/encrypted_store/mod.rs
@@ -22,38 +22,24 @@ pub mod identity_cache;
 pub mod identity_update;
 pub mod key_package_history;
 pub mod key_store_entry;
-#[cfg(not(target_arch = "wasm32"))]
-pub(super) mod native;
 pub mod refresh_state;
 pub mod schema;
 mod schema_gen;
-#[cfg(not(target_arch = "wasm32"))]
-mod sqlcipher_connection;
+pub mod store;
 pub mod user_preferences;
-#[cfg(target_arch = "wasm32")]
-pub(super) mod wasm;
+
+pub mod database;
 
 pub use self::db_connection::DbConnection;
-#[cfg(target_arch = "wasm32")]
-pub use diesel::prelude::SqliteConnection as RawDbConnection;
 pub use diesel::sqlite::{Sqlite, SqliteConnection};
-#[cfg(not(target_arch = "wasm32"))]
-pub use native::RawDbConnection;
-#[cfg(not(target_arch = "wasm32"))]
-pub use sqlcipher_connection::EncryptedConnection;
-#[cfg(target_arch = "wasm32")]
-pub use wasm::{OpfsSAHError, OpfsSAHPoolUtil, SQLITE, init_sqlite};
 
 use super::{StorageError, xmtp_openmls_provider::XmtpOpenMlsProviderPrivate};
 use crate::Store;
+
+pub use database::*;
+
 use db_connection::DbConnectionPrivate;
-use diesel::{
-    connection::{LoadConnection, TransactionManager},
-    migration::MigrationConnection,
-    prelude::*,
-    result::Error,
-    sql_query,
-};
+use diesel::{connection::LoadConnection, migration::MigrationConnection, prelude::*, sql_query};
 use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
 
 pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!("./migrations/");
@@ -72,6 +58,16 @@ pub enum StorageOption {
     #[default]
     Ephemeral,
     Persistent(String),
+}
+
+pub trait Database {
+    type Db: XmtpDb;
+
+    fn init_db() -> Result<(), StorageError>;
+    fn db(&self) -> &Self::Db;
+    fn take(self) -> Self::Db
+    where
+        Self: Sized;
 }
 
 #[allow(async_fn_in_trait)]
@@ -102,7 +98,7 @@ pub trait XmtpDb {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-pub type EncryptedMessageStore = self::private::EncryptedMessageStore<native::NativeDb>;
+pub type EncryptedMessageStore = self::store::EncryptedMessageStore<native::NativeDb>;
 
 #[cfg(not(target_arch = "wasm32"))]
 impl EncryptedMessageStore {
@@ -132,7 +128,7 @@ impl EncryptedMessageStore {
 }
 
 #[cfg(target_arch = "wasm32")]
-pub type EncryptedMessageStore = self::private::EncryptedMessageStore<wasm::WasmDb>;
+pub type EncryptedMessageStore = self::store::EncryptedMessageStore<wasm::WasmDb>;
 
 #[cfg(target_arch = "wasm32")]
 impl EncryptedMessageStore {
@@ -157,70 +153,6 @@ impl EncryptedMessageStore {
 }
 
 /// Shared Code between WebAssembly and Native using the `XmtpDb` trait
-pub mod private {
-    use crate::xmtp_openmls_provider::XmtpOpenMlsProviderPrivate;
-
-    use super::*;
-    use diesel::connection::SimpleConnection;
-    use diesel_migrations::MigrationHarness;
-
-    #[derive(Clone, Debug)]
-    /// Manages a Sqlite db for persisting messages and other objects.
-    pub struct EncryptedMessageStore<Db> {
-        pub(super) opts: StorageOption,
-        pub(super) db: Db,
-    }
-
-    impl<Db, E> EncryptedMessageStore<Db>
-    where
-        Db: XmtpDb<Error = E>,
-        StorageError: From<E>,
-    {
-        #[tracing::instrument(level = "debug", skip_all)]
-        pub(super) fn init_db(&mut self) -> Result<(), StorageError> {
-            self.db.validate(&self.opts)?;
-            self.db.conn()?.raw_query_write(|conn| {
-                conn.batch_execute("PRAGMA journal_mode = WAL;")?;
-                tracing::info!("Running DB migrations");
-                conn.run_pending_migrations(MIGRATIONS)?;
-
-                let sqlite_version =
-                    sql_query("SELECT sqlite_version() AS version").load::<SqliteVersion>(conn)?;
-                tracing::info!("sqlite_version={}", sqlite_version[0].version);
-
-                tracing::info!("Migrations successful");
-                Ok::<_, StorageError>(())
-            })?;
-
-            Ok::<_, StorageError>(())
-        }
-
-        pub fn mls_provider(
-            &self,
-        ) -> Result<XmtpOpenMlsProviderPrivate<Db, Db::Connection>, StorageError> {
-            let conn = self.conn()?;
-            Ok(XmtpOpenMlsProviderPrivate::new(conn))
-        }
-
-        /// Pulls a new connection from the store
-        pub fn conn(
-            &self,
-        ) -> Result<DbConnectionPrivate<<Db as XmtpDb>::Connection>, StorageError> {
-            Ok(self.db.conn()?)
-        }
-
-        /// Release connection to the database, closing it
-        pub fn release_connection(&self) -> Result<(), StorageError> {
-            Ok(self.db.release_connection()?)
-        }
-
-        /// Reconnect to the database
-        pub fn reconnect(&self) -> Result<(), StorageError> {
-            Ok(self.db.reconnect()?)
-        }
-    }
-}
-
 #[allow(dead_code)]
 fn warn_length<T>(list: &[T], str_id: &str, max_length: usize) {
     if list.len() > max_length {
@@ -331,57 +263,6 @@ where
     where
         F: FnOnce(&XmtpOpenMlsProviderPrivate<Db, <Db as XmtpDb>::Connection>) -> Result<T, E>,
         E: From<StorageError> + std::error::Error;
-}
-
-impl<Db> ProviderTransactions<Db> for XmtpOpenMlsProviderPrivate<Db, <Db as XmtpDb>::Connection>
-where
-    Db: XmtpDb,
-{
-    /// Start a new database transaction with the OpenMLS Provider from XMTP
-    /// with the provided connection
-    /// # Arguments
-    /// `fun`: Scoped closure providing a MLSProvider to carry out the transaction
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// store.transaction(|provider| {
-    ///     // do some operations requiring provider
-    ///     // access the connection with .conn()
-    ///     provider.conn().db_operation()?;
-    /// })
-    /// ```
-    fn transaction<T, F, E>(&self, fun: F) -> Result<T, E>
-    where
-        F: FnOnce(&XmtpOpenMlsProviderPrivate<Db, <Db as XmtpDb>::Connection>) -> Result<T, E>,
-        E: From<StorageError> + std::error::Error,
-    {
-        tracing::debug!("Transaction beginning");
-
-        let conn = self.conn_ref();
-        let _guard = conn.start_transaction::<Db>()?;
-
-        match fun(self) {
-            Ok(value) => {
-                conn.raw_query_write(|conn| {
-                    <Db as XmtpDb>::TransactionManager::commit_transaction(&mut *conn)
-                })
-                .map_err(StorageError::from)?;
-                tracing::debug!("Transaction being committed");
-                Ok(value)
-            }
-            Err(err) => {
-                tracing::debug!("Transaction being rolled back");
-                match conn.raw_query_write(|conn| {
-                    <Db as XmtpDb>::TransactionManager::rollback_transaction(&mut *conn)
-                }) {
-                    Ok(()) => Err(err),
-                    Err(Error::BrokenTransactionManager) => Err(err),
-                    Err(rollback) => Err(StorageError::from(rollback).into()),
-                }
-            }
-        }
-    }
 }
 
 #[cfg(test)]

--- a/xmtp_db/src/encrypted_store/store.rs
+++ b/xmtp_db/src/encrypted_store/store.rs
@@ -1,0 +1,59 @@
+use super::*;
+use crate::xmtp_openmls_provider::XmtpOpenMlsProviderPrivate;
+
+use diesel::connection::SimpleConnection;
+use diesel_migrations::MigrationHarness;
+
+#[derive(Clone, Debug)]
+/// Manages a Sqlite db for persisting messages and other objects.
+pub struct EncryptedMessageStore<Db> {
+    pub(super) opts: StorageOption,
+    pub(super) db: Db,
+}
+
+impl<Db, E> EncryptedMessageStore<Db>
+where
+    Db: XmtpDb<Error = E>,
+    StorageError: From<E>,
+{
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub(super) fn init_db(&mut self) -> Result<(), StorageError> {
+        self.db.validate(&self.opts)?;
+        self.db.conn()?.raw_query_write(|conn| {
+            conn.batch_execute("PRAGMA journal_mode = WAL;")?;
+            tracing::info!("Running DB migrations");
+            conn.run_pending_migrations(MIGRATIONS)?;
+
+            let sqlite_version =
+                sql_query("SELECT sqlite_version() AS version").load::<SqliteVersion>(conn)?;
+            tracing::info!("sqlite_version={}", sqlite_version[0].version);
+
+            tracing::info!("Migrations successful");
+            Ok::<_, StorageError>(())
+        })?;
+
+        Ok::<_, StorageError>(())
+    }
+
+    pub fn mls_provider(
+        &self,
+    ) -> Result<XmtpOpenMlsProviderPrivate<Db, Db::Connection>, StorageError> {
+        let conn = self.conn()?;
+        Ok(XmtpOpenMlsProviderPrivate::new(conn))
+    }
+
+    /// Pulls a new connection from the store
+    pub fn conn(&self) -> Result<DbConnectionPrivate<<Db as XmtpDb>::Connection>, StorageError> {
+        Ok(self.db.conn()?)
+    }
+
+    /// Release connection to the database, closing it
+    pub fn release_connection(&self) -> Result<(), StorageError> {
+        Ok(self.db.release_connection()?)
+    }
+
+    /// Reconnect to the database
+    pub fn reconnect(&self) -> Result<(), StorageError> {
+        Ok(self.db.reconnect()?)
+    }
+}

--- a/xmtp_db/src/errors.rs
+++ b/xmtp_db/src/errors.rs
@@ -43,10 +43,10 @@ pub enum StorageError {
     Builder(#[from] derive_builder::UninitializedFieldError),
     #[cfg(not(target_arch = "wasm32"))]
     #[cfg_attr(not(target_arch = "wasm32"), error(transparent))]
-    Native(#[from] super::native::NativeStorageError),
+    Native(#[from] crate::database::native::NativeStorageError),
     #[cfg(target_arch = "wasm32")]
     #[cfg_attr(target_arch = "wasm32", error(transparent))]
-    Wasm(#[from] super::wasm::WasmStorageError),
+    Wasm(#[from] crate::database::wasm::WasmStorageError),
     #[error("decoding from database failed {}", _0)]
     Prost(#[from] prost::DecodeError),
 }
@@ -69,7 +69,7 @@ impl StorageError {
     pub fn db_needs_connection(&self) -> bool {
         matches!(
             self,
-            Self::Native(super::native::NativeStorageError::PoolNeedsConnection)
+            Self::Native(crate::database::native::NativeStorageError::PoolNeedsConnection)
         )
     }
 }

--- a/xmtp_db/src/xmtp_openmls_provider.rs
+++ b/xmtp_db/src/xmtp_openmls_provider.rs
@@ -1,16 +1,15 @@
-#[cfg(not(target_arch = "wasm32"))]
-use crate::native::NativeDb;
-#[cfg(target_arch = "wasm32")]
-use crate::wasm::WasmDb;
-use crate::{db_connection::DbConnectionPrivate, sql_key_store::SqlKeyStore};
+use crate::StorageError;
+use crate::database::DefaultDatabase;
+use crate::{
+    ProviderTransactions, XmtpDb, db_connection::DbConnectionPrivate, sql_key_store::SqlKeyStore,
+};
+use diesel::connection::TransactionManager;
 use openmls_rust_crypto::RustCrypto;
 use openmls_traits::OpenMlsProvider;
 use std::marker::PhantomData;
 
-#[cfg(target_arch = "wasm32")]
-pub type XmtpOpenMlsProvider = XmtpOpenMlsProviderPrivate<WasmDb, crate::RawDbConnection>;
-#[cfg(not(target_arch = "wasm32"))]
-pub type XmtpOpenMlsProvider = XmtpOpenMlsProviderPrivate<NativeDb, crate::RawDbConnection>;
+pub type XmtpOpenMlsProvider =
+    XmtpOpenMlsProviderPrivate<DefaultDatabase, crate::database::RawDbConnection>;
 
 #[derive(Debug)]
 pub struct XmtpOpenMlsProviderPrivate<Db, C> {
@@ -36,6 +35,57 @@ impl<Db, C> XmtpOpenMlsProviderPrivate<Db, C> {
 
     pub fn conn_ref(&self) -> &DbConnectionPrivate<C> {
         self.key_store.conn_ref()
+    }
+}
+
+impl<Db> ProviderTransactions<Db> for XmtpOpenMlsProviderPrivate<Db, <Db as XmtpDb>::Connection>
+where
+    Db: XmtpDb,
+{
+    /// Start a new database transaction with the OpenMLS Provider from XMTP
+    /// with the provided connection
+    /// # Arguments
+    /// `fun`: Scoped closure providing a MLSProvider to carry out the transaction
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// provider.transaction(|provider| {
+    ///     // do some operations requiring provider
+    ///     // access the connection with .conn()
+    ///     provider.conn().db_operation()?;
+    /// })
+    /// ```
+    fn transaction<T, F, E>(&self, fun: F) -> Result<T, E>
+    where
+        F: FnOnce(&XmtpOpenMlsProviderPrivate<Db, <Db as XmtpDb>::Connection>) -> Result<T, E>,
+        E: From<StorageError> + std::error::Error,
+    {
+        tracing::debug!("Transaction beginning");
+
+        let conn = self.conn_ref();
+        let _guard = conn.start_transaction::<Db>()?;
+
+        match fun(self) {
+            Ok(value) => {
+                conn.raw_query_write(|conn| {
+                    <Db as XmtpDb>::TransactionManager::commit_transaction(&mut *conn)
+                })
+                .map_err(StorageError::from)?;
+                tracing::debug!("Transaction being committed");
+                Ok(value)
+            }
+            Err(err) => {
+                tracing::debug!("Transaction being rolled back");
+                match conn.raw_query_write(|conn| {
+                    <Db as XmtpDb>::TransactionManager::rollback_transaction(&mut *conn)
+                }) {
+                    Ok(()) => Err(err),
+                    Err(diesel::result::Error::BrokenTransactionManager) => Err(err),
+                    Err(rollback) => Err(StorageError::from(rollback).into()),
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
### Reorganize database platform-specific code by moving WASM and native implementations into dedicated modules within `xmtp_db/src/encrypted_store/database`
* Creates new `database` module in [database.rs](https://github.com/xmtp/libxmtp/pull/1878/files#diff-9f8d2de22d0a8889381d9e0bd7a4c3cf5be3ffc583d7ad07548c2deb498253af) that conditionally imports and exports platform-specific modules based on target platform
* Introduces new `Database` trait in [mod.rs](https://github.com/xmtp/libxmtp/pull/1878/files#diff-7c11a42d3a8d1e571eea6a833dfe388063c036317c4d7a6fbce207fbb3beb387) defining common interface for database implementations
* Moves `EncryptedMessageStore` implementation to dedicated [store.rs](https://github.com/xmtp/libxmtp/pull/1878/files#diff-f1de360321de1fef095d744b4ffadee38cfe02d86d0dede6eaca479c3d7e5760) module
* Relocates native database code to [native.rs](https://github.com/xmtp/libxmtp/pull/1878/files#diff-9c5fcd135cb75c60427dc72ce9b51c5b99360469cd932477dfb52e7c3a1e61a1) and WASM code to [wasm.rs](https://github.com/xmtp/libxmtp/pull/1878/files#diff-71dbf76b367beb548f956d1b3691acd50ccfd261d71bcf16520089e1d2f467e6)
* Updates import paths across codebase to reference types through new module structure

#### 📍Where to Start
Start with the new `database` module entry point in [database.rs](https://github.com/xmtp/libxmtp/pull/1878/files#diff-9f8d2de22d0a8889381d9e0bd7a4c3cf5be3ffc583d7ad07548c2deb498253af) which defines the conditional imports and exports for platform-specific implementations.

----

_[Macroscope](https://app.macroscope.com) summarized 941b8bd._