### PR TITLE
create ChaosConnection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "accessory"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb3791c4beae5b827e93558ac83a88e63a841aad61759a05d9b577ef16030470"
+dependencies = [
+ "macroific",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1215,6 +1227,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
 
 [[package]]
+name = "delegate-display"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9926686c832494164c33a36bf65118f4bd6e704000b58c94681bf62e9ad67a74"
+dependencies = [
+ "impartial-ord",
+ "itoa",
+ "macroific",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "der"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1271,7 +1297,16 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
 dependencies = [
- "derive_more-impl",
+ "derive_more-impl 1.0.0",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl 2.0.1",
 ]
 
 [[package]]
@@ -1283,6 +1318,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1905,6 +1952,18 @@ checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
 dependencies = [
  "indenter",
  "once_cell",
+]
+
+[[package]]
+name = "fancy_constructor"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fac0fd7f4636276b4bd7b3148d0ba2c1c3fbede2b5214e47e7fedb70b02cde44"
+dependencies = [
+ "macroific",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2891,6 +2950,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "impartial-ord"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab604ee7085efba6efc65e4ebca0e9533e3aff6cb501d7d77b211e3a781c6d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "impl-codec"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2933,6 +3003,40 @@ name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
+name = "indexed_db_futures"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94eebf0199c01a1560770d964efb1fb09183a3afc0b1c1397fac1bfdbfa7d6cf"
+dependencies = [
+ "accessory",
+ "cfg-if",
+ "delegate-display",
+ "derive_more 2.0.1",
+ "fancy_constructor",
+ "indexed_db_futures_macros_internal",
+ "js-sys",
+ "sealed",
+ "smallvec",
+ "thiserror 2.0.12",
+ "tokio",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "indexed_db_futures_macros_internal"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caeba94923b68f254abef921cea7e7698bf4675fdd89d7c58bf1ed885b49a27d"
+dependencies = [
+ "macroific",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
 
 [[package]]
 name = "indexmap"
@@ -3269,6 +3373,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 dependencies = [
  "hashbrown 0.15.2",
+]
+
+[[package]]
+name = "macroific"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f276537b4b8f981bf1c13d79470980f71134b7bdcc5e6e911e910e556b0285"
+dependencies = [
+ "macroific_attr_parse",
+ "macroific_core",
+ "macroific_macro",
+]
+
+[[package]]
+name = "macroific_attr_parse"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad4023761b45fcd36abed8fb7ae6a80456b0a38102d55e89a57d9a594a236be9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sealed",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "macroific_core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a7594d3c14916fa55bef7e9d18c5daa9ed410dd37504251e4b75bbdeec33e3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sealed",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "macroific_macro"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4da6f2ed796261b0a74e2b52b42c693bb6dee1effba3a482c49592659f824b3b"
+dependencies = [
+ "macroific_attr_parse",
+ "macroific_core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -5201,7 +5353,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346a3b32eba2640d17a9cb5927056b08f3de90f65b72fe09402c2ad07d684d0b"
 dependencies = [
  "cfg-if",
- "derive_more",
+ "derive_more 1.0.0",
  "parity-scale-codec",
  "scale-info-derive",
 ]
@@ -5288,6 +5440,17 @@ checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring 0.17.14",
  "untrusted 0.9.0",
+]
+
+[[package]]
+name = "sealed"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f968c5ea23d555e670b449c1c5e7b2fc399fdaec1d304a17cd48e288abc107"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -5652,11 +5815,12 @@ dependencies = [
 
 [[package]]
 name = "sqlite-wasm-rs"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e866c298399bec6d380563f52cae40a85f81e88d2b700b74731db758ea99266"
+checksum = "a46f82f6a905a1fdc5abe7ee0869bee63f5320344c593fe55554f443b178bd75"
 dependencies = [
  "fragile",
+ "indexed_db_futures",
  "js-sys",
  "once_cell",
  "parking_lot 0.12.3",
@@ -7836,6 +8000,18 @@ dependencies = [
  "xmtp_cryptography",
  "xmtp_proto",
  "zeroize",
+]
+
+[[package]]
+name = "xmtp_db_test"
+version = "1.3.0-dev"
+dependencies = [
+ "derive_builder",
+ "diesel",
+ "parking_lot 0.12.3",
+ "rand 0.8.5",
+ "xmtp_common",
+ "xmtp_db",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
   "xmtp_api_d14n",
   "xmtp_macro",
   "xmtp_db",
+  "xmtp_db_test",
 ]
 
 # Used when cargo commands in the workspace root, such as `cargo test`, are run without flags.

--- a/README.md
+++ b/README.md
@@ -80,15 +80,18 @@ STRUCTURED=1 cargo test
 - Two ways to replace InboxIds/InstallationIds/EthAddresses with a
   human-readable string name in logs
 
+_NOTE_: Only works when using `CONTEXTUAL=1` flag. So to get the replacement,
+`CONTEXTUAL=1 cargo test`
+
 1.)
 
-Before the test runs, add an `InboxIdReplace` declaration to the top
+Before the test runs, add an `TestLogReplace` declaration to the top
 `replace.add` accepts two arguments: the string to replace in logs and the
-string to replace it with. Note that on dropping the "InboxIdReplace" object,
+string to replace it with. Note that on dropping the "TestLogReplace" object,
 the replacements will no longer be made.
 
 ```rust
-let mut replace = InboxIdReplace::default();
+let mut replace = TestLogReplace::default();
 replace.add(alix.installation_id(), "alix_installation_id");
 ```
 

--- a/bindings_ffi/src/mls/test_utils.rs
+++ b/bindings_ffi/src/mls/test_utils.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use ethers::signers::LocalWallet;
-use xmtp_common::{tmp_path, InboxIdReplace};
+use xmtp_common::{tmp_path, TestLogReplace};
 use xmtp_id::InboxOwner;
 use xmtp_mls::utils::test::tester_utils::*;
 
@@ -24,7 +24,7 @@ impl LocalBuilder<LocalWallet> for TesterBuilder<LocalWallet> {
     // Will not panic on registering identity. Will still panic on just about everything else.
     async fn build_no_panic(&self) -> Result<Tester<LocalWallet, FfiXmtpClient>, GenericError> {
         let client = create_raw_client(self).await;
-        let mut replace = InboxIdReplace::default();
+        let mut replace = TestLogReplace::default();
         if let Some(name) = &self.name {
             let ident = self.owner.get_identifier().unwrap();
             replace.add(&ident.to_string(), &format!("{name}_ident"));
@@ -71,7 +71,7 @@ impl LocalBuilder<PasskeyUser> for TesterBuilder<PasskeyUser> {
 
     async fn build_no_panic(&self) -> Result<Tester<PasskeyUser, FfiXmtpClient>, GenericError> {
         let client = create_raw_client(self).await;
-        let mut replace = InboxIdReplace::default();
+        let mut replace = TestLogReplace::default();
         if let Some(name) = &self.name {
             let ident = self.owner.get_identifier().unwrap();
             replace.add(&ident.to_string(), &format!("{name}_ident"));

--- a/common/src/test.rs
+++ b/common/src/test.rs
@@ -24,11 +24,11 @@ static REPLACE_IDS: Lazy<Mutex<HashMap<String, String>>> = Lazy::new(|| Mutex::n
 
 /// Replace inbox id in Contextual output with a name (i.e Alix, Bo, etc.)
 #[derive(Default)]
-pub struct InboxIdReplace {
+pub struct TestLogReplace {
     ids: HashMap<String, String>,
 }
 
-impl InboxIdReplace {
+impl TestLogReplace {
     pub fn add(&mut self, id: &str, name: &str) {
         self.ids.insert(id.to_string(), name.to_string());
         let mut ids = REPLACE_IDS.lock();
@@ -37,7 +37,7 @@ impl InboxIdReplace {
 }
 
 // remove ids for replacement from map on drop
-impl Drop for InboxIdReplace {
+impl Drop for TestLogReplace {
     fn drop(&mut self) {
         let mut ids = REPLACE_IDS.lock();
         for id in self.ids.keys() {

--- a/xmtp_db/src/encrypted_store/database/native.rs
+++ b/xmtp_db/src/encrypted_store/database/native.rs
@@ -177,8 +177,8 @@ impl XmtpDb for NativeDb {
         self.conn.clone()
     }
 
-    fn validate(&self, opts: &StorageOption) -> Result<(), Self::Error> {
-        self.customizer.validate(opts)
+    fn validate(&self, opts: &StorageOption) -> Result<(), ConnectionError> {
+        self.customizer.validate(opts).map_err(Into::into)
     }
 
     fn disconnect(&self) -> Result<(), Self::Error> {

--- a/xmtp_db/src/encrypted_store/database/wasm.rs
+++ b/xmtp_db/src/encrypted_store/database/wasm.rs
@@ -222,7 +222,7 @@ impl XmtpDb for WasmDb {
         self.conn.clone()
     }
 
-    fn validate(&self, _opts: &StorageOption) -> Result<(), Self::Error> {
+    fn validate(&self, _opts: &StorageOption) -> Result<(), crate::ConnectionError> {
         Ok(())
     }
 

--- a/xmtp_db/src/encrypted_store/mod.rs
+++ b/xmtp_db/src/encrypted_store/mod.rs
@@ -40,6 +40,7 @@ use crate::Store;
 
 pub use database::*;
 
+use diesel::connection::SimpleConnection;
 use diesel::{connection::LoadConnection, migration::MigrationConnection, prelude::*, sql_query};
 use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
 use std::sync::{
@@ -73,16 +74,6 @@ impl Drop for TransactionGuard<'_> {
     fn drop(&mut self) {
         self.in_transaction.store(false, Ordering::SeqCst);
     }
-}
-
-pub trait Database {
-    type Db: XmtpDb;
-
-    fn init_db(&mut self) -> Result<(), StorageError>;
-    fn db(&self) -> &Self::Db;
-    fn take(self) -> Self::Db
-    where
-        Self: Sized;
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -190,8 +181,28 @@ pub trait XmtpDb {
     /// The Connection type for this database
     type Connection: ConnectionExt + Send;
 
+    fn init(&self, opts: &StorageOption) -> Result<(), ConnectionError>
+    where
+        ConnectionError: From<<Self::Connection as ConnectionExt>::Error>,
+    {
+        self.validate(opts)?;
+        self.conn().raw_query_write(|conn| {
+            conn.batch_execute("PRAGMA journal_mode = WAL;")?;
+            conn.run_pending_migrations(MIGRATIONS)
+                .map_err(diesel::result::Error::QueryBuilderError)?;
+
+            let sqlite_version =
+                sql_query("SELECT sqlite_version() AS version").load::<SqliteVersion>(conn)?;
+            tracing::info!("sqlite_version={}", sqlite_version[0].version);
+
+            tracing::info!("Migrations successful");
+            Ok(())
+        })?;
+        Ok(())
+    }
+
     /// Validate a connection is as expected
-    fn validate(&self, _opts: &StorageOption) -> Result<(), Self::Error> {
+    fn validate(&self, _opts: &StorageOption) -> Result<(), ConnectionError> {
         Ok(())
     }
 
@@ -204,6 +215,9 @@ pub trait XmtpDb {
     /// Release connection to the database, closing it
     fn disconnect(&self) -> Result<(), Self::Error>;
 }
+
+// TODO: at some point should create factory trait or something to avoid using #[cfg], since #[cfg]
+// can become difficult to reason about in higher level contexts
 
 #[cfg(not(target_arch = "wasm32"))]
 pub type EncryptedMessageStore = self::store::EncryptedMessageStore<native::NativeDb>;
@@ -229,8 +243,8 @@ impl EncryptedMessageStore {
     ) -> Result<Self, StorageError> {
         tracing::info!("Setting up DB connection pool");
         let db = native::NativeDb::new(&opts, enc_key)?;
-        let mut store = Self { db, opts };
-        store.init_db()?;
+        db.init(&opts)?;
+        let store = Self { db };
         Ok(store)
     }
 }
@@ -254,8 +268,8 @@ impl EncryptedMessageStore {
         _enc_key: Option<EncryptionKey>,
     ) -> Result<Self, StorageError> {
         let db = wasm::WasmDb::new(&opts).await?;
-        let mut this = Self { db, opts };
-        this.init_db()?;
+        db.init(&opts)?;
+        let this = Self { db };
         Ok(this)
     }
 }
@@ -464,8 +478,8 @@ pub(crate) mod tests {
         #[cfg(target_arch = "wasm32")]
         let db = wasm::WasmDb::new(&opts).await.unwrap();
 
-        let store = EncryptedMessageStore { db, opts };
-        store.db.validate(&store.opts).unwrap();
+        let store = EncryptedMessageStore { db };
+        store.db.validate(&opts).unwrap();
 
         store
             .db

--- a/xmtp_db/src/encrypted_store/user_preferences.rs
+++ b/xmtp_db/src/encrypted_store/user_preferences.rs
@@ -69,9 +69,7 @@ impl StoredUserPreferences {
         cycled_at: Option<i64>,
     ) -> Result<(), StorageError> {
         if key.len() != 42 {
-            return Err(StorageError::Generic(
-                "HMAC key needs to be 42 bytes".to_string(),
-            ));
+            return Err(StorageError::InvalidHmacLength);
         }
 
         let mut preferences = Self::load(conn)?;

--- a/xmtp_db/src/test_utils.rs
+++ b/xmtp_db/src/test_utils.rs
@@ -2,6 +2,7 @@
 
 use crate::{DbConnection, EncryptedMessageStore, StorageOption};
 use xmtp_common::tmp_path;
+mod impls;
 
 impl EncryptedMessageStore {
     pub fn generate_enc_key() -> [u8; 32] {

--- a/xmtp_db/src/test_utils/impls.rs
+++ b/xmtp_db/src/test_utils/impls.rs
@@ -1,0 +1,195 @@
+use diesel::result::DatabaseErrorKind;
+/// Extra trait implementations for xmtp_db types
+use rand::{
+    Rng,
+    distributions::{Distribution, Standard},
+    prelude::IteratorRandom,
+};
+
+use crate::{
+    DuplicateItem, NotFound, StorageError, refresh_state::EntityKind,
+    sql_key_store::SqlKeyStoreError,
+};
+
+// choose a random db error in StorageError
+// only cover errors that can happen in db access
+impl Distribution<StorageError> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> StorageError {
+        match rng.gen_range(0..=13) {
+            0 => StorageError::DieselConnect(rand_diesel_conn_err(rng)),
+            1 => StorageError::DieselResult(rand_diesel_result(rng)),
+            2 => StorageError::NotFound(rand::random()),
+            3 => StorageError::Duplicate(DuplicateItem::WelcomeId(Some(i64::MAX))),
+            4 => rand::random(),
+            5 => StorageError::IntentionalRollback,
+            6 => StorageError::DbSerialize,
+            7 => StorageError::DbDeserialize,
+            8 => StorageError::Builder(derive_builder::UninitializedFieldError::new("test field")),
+            10 => rand::random(), // platform
+            11 => StorageError::Prost(prost::DecodeError::new("test random decode error")),
+            12 => StorageError::Connection(rand::random()),
+            13 => StorageError::Conversion(xmtp_proto::ConversionError::Unspecified(
+                "random test error",
+            )),
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl Distribution<SqlKeyStoreError> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> SqlKeyStoreError {
+        use SqlKeyStoreError::*;
+        match rng.gen_range(0..=5) {
+            0 => UnsupportedValueTypeBytes,
+            1 => UnsupportedMethod,
+            2 => SerializationError,
+            3 => NotFound,
+            4 => Storage(rand_diesel_result(rng)),
+            5 => Connection(rand::random()),
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl Distribution<NotFound> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> NotFound {
+        match rng.gen_range(0..=13) {
+            0 => NotFound::GroupByWelcome(i64::MAX),
+            1 => NotFound::GroupById(Vec::new()),
+            2 => NotFound::InstallationTimeForGroup(Vec::new()),
+            3 => NotFound::InboxIdForAddress("random test inbox".into()),
+            4 => NotFound::MessageById(Vec::new()),
+            5 => NotFound::DmByInbox("random dm by inbox".into()),
+            6 => NotFound::IntentForToPublish(i32::MAX),
+            7 => NotFound::IntentForPublish(i32::MAX),
+            8 => NotFound::IntentForCommitted(i32::MIN),
+            9 => NotFound::IntentById(i32::MIN),
+            10 => NotFound::RefreshStateByIdAndKind(Vec::new(), EntityKind::Group),
+            11 => NotFound::CipherSalt("random salt for testing".into()),
+            12 => NotFound::SyncGroup(xmtp_common::rand_array::<32>().into()),
+            13 => NotFound::MlsGroup,
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl Distribution<crate::ConnectionError> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> crate::ConnectionError {
+        match rng.gen_range(0..=1) {
+            0 => crate::ConnectionError::Database(rand_diesel_result(rng)),
+            1 => crate::ConnectionError::Platform(rand::random()),
+            _ => unreachable!(),
+        }
+    }
+}
+
+fn rand_diesel_conn_err<R: Rng + ?Sized>(rng: &mut R) -> diesel::ConnectionError {
+    use diesel::ConnectionError::*;
+    vec![
+        diesel::ConnectionError::InvalidCString(
+            std::ffi::CString::new(b"f\0oo".to_vec()).unwrap_err(),
+        ),
+        BadConnection("rand bad connection err".into()),
+        InvalidConnectionUrl("bad conn url".into()),
+        CouldntSetupConfiguration(rand_diesel_result(rng)),
+    ]
+    .into_iter()
+    .choose(rng)
+    .unwrap()
+}
+
+fn rand_diesel_result<R: Rng + ?Sized>(rng: &mut R) -> diesel::result::Error {
+    use diesel::result::Error::*;
+    vec![
+        InvalidCString(std::ffi::CString::new(b"f\0oo".to_vec()).unwrap_err()),
+        DatabaseError(
+            rand_db_error(rng),
+            Box::new("Random Db Test Error".to_string()),
+        ),
+        diesel::result::Error::NotFound,
+        QueryBuilderError(Box::new(std::io::Error::other("Rand query builder error"))),
+        DeserializationError(Box::new(std::io::Error::other(
+            "rand deserialization error",
+        ))),
+        SerializationError(Box::new(std::io::Error::other("Rand serialization error"))),
+        RollbackTransaction,
+        AlreadyInTransaction,
+        NotInTransaction,
+    ]
+    .into_iter()
+    .choose(rng)
+    .unwrap()
+}
+
+fn rand_db_error<R: Rng + ?Sized>(rng: &mut R) -> DatabaseErrorKind {
+    use DatabaseErrorKind::*;
+    vec![
+        UniqueViolation,
+        ForeignKeyViolation,
+        UnableToSendCommand,
+        SerializationFailure,
+        ReadOnlyTransaction,
+        RestrictViolation,
+        NotNullViolation,
+        CheckViolation,
+        ExclusionViolation,
+        ClosedConnection,
+        Unknown,
+    ]
+    .into_iter()
+    .choose(rng)
+    .unwrap()
+}
+
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+mod native {
+    use crate::PlatformStorageError;
+
+    use super::*;
+    impl Distribution<PlatformStorageError> for Standard {
+        fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> PlatformStorageError {
+            match rng.gen_range(0..=9) {
+                0 => PlatformStorageError::DbConnection(rand_r2d2_err(rng)),
+                1 => PlatformStorageError::PoolNeedsConnection,
+                2 => PlatformStorageError::SqlCipherNotLoaded,
+                3 => PlatformStorageError::SqlCipherKeyIncorrect,
+                4 => PlatformStorageError::DieselResult(rand_diesel_result(rng)),
+                5 => PlatformStorageError::NotFound(rand::random()),
+                6 => PlatformStorageError::Io(std::io::Error::other("test io error")),
+                7 => PlatformStorageError::FromHex(hex::FromHexError::OddLength),
+                8 => PlatformStorageError::DieselConnect(rand_diesel_conn_err(rng)),
+                9 => {
+                    PlatformStorageError::Boxed(Box::new(std::io::Error::other("test boxed error")))
+                }
+                _ => unreachable!(),
+            }
+        }
+    }
+
+    fn rand_r2d2_err<R: Rng + ?Sized>(rng: &mut R) -> diesel::r2d2::Error {
+        match rng.gen_range(0..=1) {
+            0 => diesel::r2d2::Error::ConnectionError(rand_diesel_conn_err(rng)),
+            1 => diesel::r2d2::Error::QueryError(rand_diesel_result(rng)),
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+mod wasm {
+    use crate::PlatformStorageError;
+
+    use super::*;
+    impl Distribution<crate::PlatformStorageError> for Standard {
+        fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> crate::PlatformStorageError {
+            match rng.gen_range(0..=2) {
+                0 => PlatformStorageError::SAH(sqlite_wasm_rs::export::OpfsSAHError::Generic(
+                    "rand test opfs err".to_string(),
+                )),
+                1 => PlatformStorageError::Connection(rand_diesel_conn_err(rng)),
+                2 => PlatformStorageError::DieselResult(rand_diesel_result(rng)),
+                _ => unreachable!(),
+            }
+        }
+    }
+}

--- a/xmtp_db_test/README.md
+++ b/xmtp_db_test/README.md
@@ -1,0 +1,1 @@
+# A test backend for xmtp_db

--- a/xmtp_db_test/src/chaos.rs
+++ b/xmtp_db_test/src/chaos.rs
@@ -1,0 +1,278 @@
+use derive_builder::Builder;
+use parking_lot::Mutex;
+use rand::{Rng, distributions::Standard, prelude::Distribution};
+use std::{collections::HashMap, sync::Arc};
+use xmtp_db::ConnectionExt;
+
+const TRANSACTION_START_HOOK: &str = "TRANSACTION_START_HOOK";
+const PRE_READ_HOOK: &str = "PRE_READ_HOOK";
+const PRE_WRITE_HOOK: &str = "PREWRITE_HOOK";
+
+const POST_READ_HOOK: &str = "POST_READ_HOOK";
+const POST_WRITE_HOOK: &str = "POST_WRITE_HOOK";
+
+// --------------------------------------------------------
+// /\/\/\/\/\/\/\/\/\/\||Static Hooks||\/\/\/\/\/\/\/\/\/\/\
+// --------------------------------------------------------
+
+const STATIC_TRANSACTION_START_HOOK: &str = "STATIC_TRANSACTION_START_HOOK";
+
+const STATIC_PRE_READ_HOOK: &str = "STATIC_PRE_READ_HOOK";
+const STATIC_PRE_WRITE_HOOK: &str = "STATIC_PRE_WRITE_HOOK";
+
+const STATIC_POST_READ_HOOK: &str = "STATIC_POST_READ_HOOK";
+const STATIC_POST_WRITE_HOOK: &str = "STATIC_POST_WRITE_HOOK";
+
+type HookFn<C> = Box<dyn Fn(&C) + Send + Sync>;
+
+#[derive(Builder)]
+#[builder(setter(into), build_fn(validate = "Self::validate"))]
+#[allow(clippy::type_complexity)]
+pub struct ChaosConnection<C> {
+    db: C,
+    #[builder(setter(skip), default)]
+    hooks: Arc<Mutex<HashMap<&'static str, Vec<HookFn<C>>>>>,
+    #[builder(setter(skip), default)]
+    static_hooks: Arc<Mutex<HashMap<&'static str, Vec<HookFn<C>>>>>,
+    /// Set a probability for errors to occur when running transactions
+    #[builder(default = "0.0")]
+    error_frequency: f64,
+}
+
+impl<C> Clone for ChaosConnection<C>
+where
+    C: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            db: self.db.clone(),
+            hooks: self.hooks.clone(),
+            static_hooks: self.static_hooks.clone(),
+            error_frequency: self.error_frequency,
+        }
+    }
+}
+
+impl<C> ChaosConnection<C>
+where
+    C: Clone,
+{
+    pub fn builder() -> ChaosConnectionBuilder<C> {
+        Default::default()
+    }
+}
+
+impl<C> ChaosConnectionBuilder<C> {
+    // validate that the frequency is between the correct values
+    fn validate(&self) -> Result<(), String> {
+        // ensure error frequency is a percentage
+        if let Some(frequency) = self.error_frequency {
+            if !(frequency < 1.0 && frequency > 0.0) {
+                return Err(
+                    "error_frequency must be a value between 0.0 and 1.0 (EX: 0.40)".to_string(),
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<C> ChaosConnection<C> {
+    pub fn get_mod(&self, hook: &'static str) -> Option<HookFn<C>> {
+        let mut m = self.hooks.lock();
+        m.get_mut(hook).map(|h| h.pop())?
+    }
+
+    pub fn run_hook(&self, hook: &'static str) {
+        if let Some(f) = self.get_mod(hook) {
+            f(&self.db)
+        }
+    }
+
+    pub fn run_static_hooks(&self, hook: &'static str) {
+        let h = self.static_hooks.lock();
+        if let Some(f) = h.get(hook) {
+            f.iter().for_each(|h| h(&self.db));
+        }
+    }
+
+    /// Add a hook to run after the next transaction is started
+    pub fn start_transaction_hook<F>(&self, f: F)
+    where
+        F: Fn(&C) + Send + Sync + 'static,
+    {
+        let mut m = self.hooks.lock();
+        m.entry(TRANSACTION_START_HOOK)
+            .or_default()
+            .push(Box::new(f));
+    }
+
+    /// Add a hook to run before the next read
+    pub fn pre_read_hook<F>(&self, f: F)
+    where
+        F: Fn(&C) + Send + Sync + 'static,
+    {
+        let mut m = self.hooks.lock();
+        m.entry(PRE_READ_HOOK).or_default().push(Box::new(f))
+    }
+
+    /// Add a hook to run after the next read
+    pub fn post_read_hook<F>(&self, f: F)
+    where
+        F: Fn(&C) + Send + Sync + 'static,
+    {
+        let mut m = self.hooks.lock();
+        m.entry(POST_READ_HOOK).or_default().push(Box::new(f))
+    }
+
+    /// Add a hook to run before the next write
+    pub fn pre_write_hook<F>(&self, f: F)
+    where
+        F: Fn(&C) + Send + Sync + 'static,
+    {
+        let mut m = self.hooks.lock();
+        m.entry(PRE_WRITE_HOOK).or_default().push(Box::new(f))
+    }
+
+    /// Add a hook to run after the next write
+    pub fn post_write_hook<F>(&self, f: F)
+    where
+        F: Fn(&C) + Send + Sync + 'static,
+    {
+        let mut m = self.hooks.lock();
+        m.entry(POST_WRITE_HOOK).or_default().push(Box::new(f))
+    }
+
+    /// Add a static hook to run on transaction start.
+    /// Static hooks run on every invocation of a transaction.
+    /// Static transaction hook is run before the dynamic
+    /// transaction start hook.
+    pub fn static_start_transaction_hook<F>(&self, f: F)
+    where
+        F: Fn(&C) + Send + Sync + 'static,
+    {
+        let mut m = self.static_hooks.lock();
+        m.entry(STATIC_TRANSACTION_START_HOOK)
+            .or_default()
+            .push(Box::new(f));
+    }
+
+    /// Add a hook to run before every read
+    /// Static hooks run on every invocation of a rea.
+    /// Static hooks are run before dynamic hooks in the 'PRE' stage,
+    /// but after dynamic hooks in the 'POST' stage.
+    pub fn static_pre_read_hook<F>(&self, f: F)
+    where
+        F: Fn(&C) + Send + Sync + 'static,
+    {
+        let mut m = self.static_hooks.lock();
+        m.entry(STATIC_PRE_READ_HOOK).or_default().push(Box::new(f))
+    }
+
+    /// Add a hook to run after every read
+    /// Static hooks run on every invocation of a read.
+    /// Static hooks are run before dynamic hooks in the 'PRE' stage,
+    /// but after dynamic hooks in the 'POST' stage.
+    pub fn static_post_read_hook<F>(&self, f: F)
+    where
+        F: Fn(&C) + Send + Sync + 'static,
+    {
+        let mut m = self.static_hooks.lock();
+        m.entry(STATIC_POST_READ_HOOK)
+            .or_default()
+            .push(Box::new(f))
+    }
+
+    /// Add a hook to run before every write
+    /// Static hooks run on every invocation of a write,
+    /// Static hooks are run before dynamic hooks in the 'PRE' stage,
+    /// but after dynamic hooks in the 'POST' stage.
+    pub fn static_pre_write_hook<F>(&self, f: F)
+    where
+        F: Fn(&C) + Send + Sync + 'static,
+    {
+        let mut m = self.static_hooks.lock();
+        m.entry(STATIC_PRE_WRITE_HOOK)
+            .or_default()
+            .push(Box::new(f))
+    }
+
+    /// Add a hook to run after every write
+    /// Static hooks run on every invocation of a write,
+    /// Static hooks are run before dynamic hooks in the 'PRE' stage,
+    /// but after dynamic hooks in the 'POST' stage.
+    pub fn static_post_write_hook<F>(&self, f: F)
+    where
+        F: Fn(&C) + Send + Sync + 'static,
+    {
+        let mut m = self.static_hooks.lock();
+        m.entry(STATIC_POST_WRITE_HOOK)
+            .or_default()
+            .push(Box::new(f))
+    }
+
+    /// Possible return a random error
+    /// Error return chace is decided by `error_frequency`.
+    pub fn maybe_random_error<T>(&self) -> Result<(), T>
+    where
+        Standard: Distribution<T>,
+        T: std::error::Error + xmtp_common::RetryableError,
+    {
+        let mut rng = rand::thread_rng();
+
+        // Generate a random float between 0 and 1
+        if rng.gen_range::<f64, _>(0.0..1.0) < self.error_frequency {
+            Err(rand::random())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl<C> ConnectionExt for ChaosConnection<C>
+where
+    C: ConnectionExt,
+    <C as ConnectionExt>::Error: From<xmtp_db::ConnectionError>,
+{
+    type Connection = C::Connection;
+    type Error = <C as ConnectionExt>::Error;
+
+    fn start_transaction(&self) -> Result<xmtp_db::TransactionGuard<'_>, Self::Error> {
+        self.maybe_random_error::<xmtp_db::ConnectionError>()?;
+        let result = self.db.start_transaction();
+        self.run_static_hooks(STATIC_TRANSACTION_START_HOOK);
+        self.run_hook(TRANSACTION_START_HOOK);
+        result
+    }
+
+    fn raw_query_read<T, F>(&self, fun: F) -> Result<T, Self::Error>
+    where
+        F: FnOnce(&mut Self::Connection) -> Result<T, diesel::result::Error>,
+        Self: Sized,
+    {
+        self.run_static_hooks(STATIC_PRE_READ_HOOK);
+        self.run_hook(PRE_READ_HOOK);
+        self.maybe_random_error::<xmtp_db::ConnectionError>()?;
+        let result = self.db.raw_query_read(fun);
+        // TODO: we could potentially pass T into the POST hook,
+        // and then the test could do some (probably unsafe) casting to
+        // get a specific type out. Unsure if useful?
+        self.run_hook(POST_READ_HOOK);
+        self.run_static_hooks(STATIC_POST_READ_HOOK);
+        result
+    }
+
+    fn raw_query_write<T, F>(&self, fun: F) -> Result<T, Self::Error>
+    where
+        F: FnOnce(&mut Self::Connection) -> Result<T, diesel::result::Error>,
+        Self: Sized,
+    {
+        self.run_static_hooks(STATIC_PRE_WRITE_HOOK);
+        self.run_hook(PRE_WRITE_HOOK);
+        self.maybe_random_error::<xmtp_db::ConnectionError>()?;
+        let result = self.db.raw_query_write(fun);
+        self.run_hook(POST_WRITE_HOOK);
+        self.run_static_hooks(STATIC_POST_WRITE_HOOK);
+        result
+    }
+}

--- a/xmtp_db_test/src/lib.rs
+++ b/xmtp_db_test/src/lib.rs
@@ -1,0 +1,103 @@
+use std::sync::Arc;
+use xmtp_db::{DefaultDatabase, EncryptionKey, StorageError, StorageOption, XmtpDb};
+
+pub mod chaos;
+
+pub type ChaosConnection = chaos::ChaosConnection<xmtp_db::DefaultConnection>;
+
+#[derive(Clone)]
+pub struct ChaosDb<Db = DefaultDatabase>
+where
+    Db: XmtpDb,
+{
+    db: Db,
+    conn: Arc<chaos::ChaosConnection<<Db as XmtpDb>::Connection>>,
+}
+
+impl<Db, E> XmtpDb for ChaosDb<Db>
+where
+    Db: XmtpDb<Error = E>,
+    StorageError: From<E>,
+    xmtp_db::ConnectionError: From<E>,
+    <Db as XmtpDb>::Connection: Send + Sync,
+    <<Db as XmtpDb>::Connection as xmtp_db::ConnectionExt>::Error: From<xmtp_db::ConnectionError>,
+{
+    type Error = <Db as XmtpDb>::Error;
+
+    type Connection = Arc<chaos::ChaosConnection<Db::Connection>>;
+
+    fn conn(&self) -> Self::Connection {
+        self.conn.clone()
+    }
+
+    fn reconnect(&self) -> Result<(), Self::Error> {
+        self.db.reconnect()
+    }
+
+    fn disconnect(&self) -> Result<(), Self::Error> {
+        self.db.disconnect()
+    }
+}
+
+pub type EncryptedMessageStore = xmtp_db::store::EncryptedMessageStore<ChaosDb>;
+
+pub struct ChaosStoreBuilder<Db> {
+    error_frequency: f64,
+    db: Db,
+}
+
+impl<Db> ChaosStoreBuilder<Db> {
+    pub fn error_frequency(self, f: f64) -> Self {
+        Self {
+            error_frequency: f,
+            ..self
+        }
+    }
+
+    pub fn db<NewDb>(self, db: NewDb) -> ChaosStoreBuilder<NewDb> {
+        ChaosStoreBuilder {
+            db,
+            error_frequency: self.error_frequency,
+        }
+    }
+}
+
+impl<Db, E> ChaosStoreBuilder<Db>
+where
+    Db: XmtpDb<Error = E> + Clone,
+    StorageError: From<E>,
+    <Db as XmtpDb>::Connection: Clone + Send + Sync,
+    xmtp_db::ConnectionError: From<<<Db as XmtpDb>::Connection as xmtp_db::ConnectionExt>::Error>,
+    <<Db as XmtpDb>::Connection as xmtp_db::ConnectionExt>::Error: From<xmtp_db::ConnectionError>,
+{
+    /// Build the EncryptedMessageStore with Chaos
+    /// Returns a tuple of (ChaosConnection, EncryptedMessageStore)
+    /// the ChaosConnection may be used to add cHaOS
+    pub fn build(
+        self,
+        opts: StorageOption,
+        _enc_key: EncryptionKey,
+    ) -> (
+        Arc<chaos::ChaosConnection<<Db as XmtpDb>::Connection>>,
+        xmtp_db::store::EncryptedMessageStore<ChaosDb<Db>>,
+    ) {
+        // let store = xmtp_db::store::EncryptedMessageStore::<Db>::new(opts, enc_key);
+        let conn = chaos::ChaosConnection::builder()
+            .db(self.db.conn())
+            .error_frequency(self.error_frequency)
+            .build()
+            .unwrap();
+        let conn = Arc::new(conn);
+
+        let chaos_db = ChaosDb::<Db> {
+            db: self.db,
+            conn: conn.clone(),
+        };
+        chaos_db.db.init(&opts).unwrap();
+        let store = xmtp_db::store::EncryptedMessageStore::<ChaosDb<Db>>::builder()
+            .db(chaos_db)
+            .build()
+            .unwrap();
+        (conn, store)
+    }
+}

--- a/xmtp_mls/src/subscriptions/stream_all.rs
+++ b/xmtp_mls/src/subscriptions/stream_all.rs
@@ -335,7 +335,7 @@ mod tests {
     #[timeout(Duration::from_secs(60))]
     #[cfg_attr(target_arch = "wasm32", ignore)]
     async fn test_stream_all_messages_does_not_lose_messages() {
-        let mut replace = xmtp_common::InboxIdReplace::default();
+        let mut replace = xmtp_common::TestLogReplace::default();
         let caro = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let alix = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
         let eve = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);

--- a/xmtp_mls/src/subscriptions/stream_conversations.rs
+++ b/xmtp_mls/src/subscriptions/stream_conversations.rs
@@ -730,7 +730,7 @@ mod test {
 
     #[rstest::rstest]
     #[xmtp_common::test]
-    #[timeout(std::time::Duration::from_secs(5))]
+    #[timeout(std::time::Duration::from_secs(15))]
     async fn test_duplicate_dm_not_streamed() {
         use xmtp_cryptography::utils::generate_local_wallet;
 

--- a/xmtp_mls/src/utils/test/tester_utils.rs
+++ b/xmtp_mls/src/utils/test/tester_utils.rs
@@ -22,8 +22,8 @@ use public_suffix::PublicSuffixList;
 use std::{ops::Deref, sync::Arc};
 use url::Url;
 use xmtp_api::XmtpApi;
-use xmtp_common::InboxIdReplace;
 use xmtp_common::StreamHandle;
+use xmtp_common::TestLogReplace;
 use xmtp_cryptography::{signature::SignatureError, utils::generate_local_wallet};
 use xmtp_db::{group_message::StoredGroupMessage, XmtpOpenMlsProvider};
 use xmtp_id::{
@@ -52,7 +52,7 @@ where
     pub stream_handle: Option<Box<dyn StreamHandle<StreamOutput = Result<(), SubscribeError>>>>,
     /// Replacement names for this tester
     /// Replacements are removed on drop
-    pub replace: InboxIdReplace,
+    pub replace: TestLogReplace,
 }
 
 #[macro_export]
@@ -112,7 +112,7 @@ where
     Owner: InboxOwner + Clone + 'static,
 {
     async fn build(&self) -> Tester<Owner, FullXmtpClient> {
-        let mut replace = InboxIdReplace::default();
+        let mut replace = TestLogReplace::default();
         if let Some(name) = &self.name {
             let ident = self.owner.get_identifier().unwrap();
             replace.add(&ident.to_string(), &format!("{name}_ident"));


### PR DESCRIPTION
### Add ChaosConnection testing framework to enable controlled database failure testing in xmtp_db
* Introduces new `xmtp_db_test` crate with `ChaosConnection` and `ChaosDb` types in [chaos.rs](https://github.com/xmtp/libxmtp/pull/1880/files#diff-df2b513d22d7d148b8703d5e1523a2f47d6517552c6fc8f1faef2a3b4594bf96) and [lib.rs](https://github.com/xmtp/libxmtp/pull/1880/files#diff-a32dcd00c7d74f02617a80127cde921149c91219365c3bec74bbb08a2a85cbf4) for injecting controlled failures into database operations
* Refactors database initialization by moving `init` functionality into `XmtpDb` trait in [encrypted_store/mod.rs](https://github.com/xmtp/libxmtp/pull/1880/files#diff-7c11a42d3a8d1e571eea6a833dfe388063c036317c4d7a6fbce207fbb3beb387)
* Implements builder pattern for `EncryptedMessageStore` in [store.rs](https://github.com/xmtp/libxmtp/pull/1880/files#diff-f1de360321de1fef095d744b4ffadee38cfe02d86d0dede6eaca479c3d7e5760)
* Standardizes error handling across database implementations to use `ConnectionError`
* Renames `InboxIdReplace` to `TestLogReplace` across multiple test files

#### 📍Where to Start
Start with the `ChaosConnection` implementation in [chaos.rs](https://github.com/xmtp/libxmtp/pull/1880/files#diff-df2b513d22d7d148b8703d5e1523a2f47d6517552c6fc8f1faef2a3b4594bf96) which defines the core testing framework functionality.

----

_[Macroscope](https://app.macroscope.com) summarized b1eb713._