### PR TITLE
On stream welcome, call sync instead of create from welcome

### DIFF
--- a/xmtp_mls/src/groups/scoped_client.rs
+++ b/xmtp_mls/src/groups/scoped_client.rs
@@ -1,5 +1,6 @@
 use super::device_sync::handle::{SyncMetric, WorkerHandle};
 use super::group_membership::{GroupMembership, MembershipDiff};
+use super::GroupError;
 use crate::utils::VersionInfo;
 use crate::verified_key_package_v2::KeyPackageVerificationError;
 use crate::{
@@ -57,6 +58,8 @@ pub trait LocalScopedGroupClient: Send + Sync + Sized {
     fn context(&self) -> Arc<XmtpMlsLocalContext> {
         self.context_ref().clone()
     }
+
+    async fn sync_welcomes(&self, provider: &XmtpOpenMlsProvider) -> Result<(), GroupError>;
 
     async fn get_installation_diff(
         &self,
@@ -129,6 +132,11 @@ pub trait ScopedGroupClient: Sized {
         self.context_ref().clone()
     }
 
+    async fn sync_welcomes(&self, provider: &XmtpOpenMlsProvider) -> Result<(), GroupError> {
+        let _ = self.sync_welcomes(provider).await?;
+        Ok(())
+    }
+
     async fn get_installation_diff(
         &self,
         conn: &DbConnection,
@@ -190,6 +198,11 @@ where
 
     fn version_info(&self) -> &Arc<VersionInfo> {
         &self.version_info
+    }
+
+    async fn sync_welcomes(&self, provider: &XmtpOpenMlsProvider) -> Result<(), GroupError> {
+        let _ = self.sync_welcomes(provider).await?;
+        Ok(())
     }
 
     async fn get_installation_diff(
@@ -294,6 +307,10 @@ where
         (**self).mls_provider()
     }
 
+    async fn sync_welcomes(&self, provider: &XmtpOpenMlsProvider) -> Result<(), GroupError> {
+        (**self).sync_welcomes(provider).await
+    }
+
     async fn get_installation_diff(
         &self,
         conn: &DbConnection,
@@ -389,6 +406,10 @@ where
 
     fn mls_provider(&self) -> Result<XmtpOpenMlsProvider, StorageError> {
         (**self).mls_provider()
+    }
+
+    async fn sync_welcomes(&self, provider: &XmtpOpenMlsProvider) -> Result<(), GroupError> {
+        (**self).sync_welcomes(provider).await
     }
 
     async fn get_installation_diff(
@@ -487,6 +508,11 @@ where
 
     fn mls_provider(&self) -> Result<XmtpOpenMlsProvider, StorageError> {
         (**self).mls_provider()
+    }
+
+    async fn sync_welcomes(&self, provider: &XmtpOpenMlsProvider) -> Result<(), GroupError> {
+        let _ = (**self).sync_welcomes(provider).await?;
+        Ok(())
     }
 
     async fn get_installation_diff(

--- a/xmtp_mls/src/groups/scoped_client.rs
+++ b/xmtp_mls/src/groups/scoped_client.rs
@@ -198,7 +198,7 @@ where
     }
 
     async fn sync_welcomes(&self, provider: &XmtpOpenMlsProvider) -> Result<(), GroupError> {
-        let _ = self.sync_welcomes(provider).await?;
+        let _ = crate::Client::<ApiClient, Verifier>::sync_welcomes(provider).await?;
         Ok(())
     }
 

--- a/xmtp_mls/src/groups/scoped_client.rs
+++ b/xmtp_mls/src/groups/scoped_client.rs
@@ -132,10 +132,7 @@ pub trait ScopedGroupClient: Sized {
         self.context_ref().clone()
     }
 
-    async fn sync_welcomes(&self, provider: &XmtpOpenMlsProvider) -> Result<(), GroupError> {
-        let _ = self.sync_welcomes(provider).await?;
-        Ok(())
-    }
+    async fn sync_welcomes(&self, provider: &XmtpOpenMlsProvider) -> Result<(), GroupError>;
 
     async fn get_installation_diff(
         &self,

--- a/xmtp_mls/src/subscriptions/stream_conversations.rs
+++ b/xmtp_mls/src/subscriptions/stream_conversations.rs
@@ -407,20 +407,12 @@ where
             "Trying to process streamed welcome"
         );
 
-        let group = retry_async!(
+        retry_async!(
             Retry::default(),
-            (async { MlsGroup::create_from_welcome(client, provider, welcome, false).await })
-        );
+            (async { client.sync_welcomes(provider).await })
+        )?;
 
-        if let Err(e) = group {
-            tracing::info!("Processing welcome failed, trying to load existing..");
-            // try to load it from the store again in case of race
-            return self
-                .load_from_store(id)
-                .map_err(|_| SubscribeError::from(e));
-        }
-
-        Ok((group?, id))
+        self.load_from_store(id)
     }
 
     /// Load a group from disk by its welcome_id


### PR DESCRIPTION
### Modify welcome message processing in XMTP MLS to sync welcomes instead of creating groups directly from welcome messages
Introduces a new `sync_welcomes` method in the `LocalScopedGroupClient` trait and modifies the welcome message processing flow in [scoped_client.rs](https://github.com/xmtp/libxmtp/pull/1883/files#diff-d2679cb39cd7e9b8b616339c541aa5056cad634e8cb3eab894dfd31415878363). The `WelcomeProcessor` implementation in [stream_conversations.rs](https://github.com/xmtp/libxmtp/pull/1883/files#diff-7c3c0adb77b28c40ac418e970ce3dbf3320238ec155456eebedc187a61878aea) now synchronizes welcome messages before loading groups from the store, replacing the previous direct creation and fallback approach.

#### 📍Where to Start
Start with the `sync_welcomes` method implementation in [scoped_client.rs](https://github.com/xmtp/libxmtp/pull/1883/files#diff-d2679cb39cd7e9b8b616339c541aa5056cad634e8cb3eab894dfd31415878363), then follow the changes in the `WelcomeProcessor::process` method in [stream_conversations.rs](https://github.com/xmtp/libxmtp/pull/1883/files#diff-7c3c0adb77b28c40ac418e970ce3dbf3320238ec155456eebedc187a61878aea).

----

_[Macroscope](https://app.macroscope.com) summarized ee29236._