### PR TITLE
On stream welcome, call sync instead of create from welcome (#1883)

### DIFF
--- a/xmtp_mls/src/groups/scoped_client.rs
+++ b/xmtp_mls/src/groups/scoped_client.rs
@@ -1,4 +1,5 @@
 use super::group_membership::{GroupMembership, MembershipDiff};
+use super::{GroupError, MlsGroup};
 use crate::utils::VersionInfo;
 use crate::verified_key_package_v2::KeyPackageVerificationError;
 use crate::{
@@ -56,6 +57,11 @@ pub trait LocalScopedGroupClient: Send + Sync + Sized {
     fn context(&self) -> Arc<XmtpMlsLocalContext> {
         self.context_ref().clone()
     }
+
+    async fn sync_welcomes(
+        &self,
+        provider: &XmtpOpenMlsProvider,
+    ) -> Result<Vec<MlsGroup<Self>>, GroupError>;
 
     async fn get_installation_diff(
         &self,
@@ -128,6 +134,11 @@ pub trait ScopedGroupClient: Sized {
         self.context_ref().clone()
     }
 
+    async fn sync_welcomes(
+        &self,
+        provider: &XmtpOpenMlsProvider,
+    ) -> Result<Vec<MlsGroup<Self>>, GroupError>;
+
     async fn get_installation_diff(
         &self,
         conn: &DbConnection,
@@ -189,6 +200,13 @@ where
 
     fn version_info(&self) -> &Arc<VersionInfo> {
         &self.version_info
+    }
+
+    async fn sync_welcomes(
+        &self,
+        provider: &XmtpOpenMlsProvider,
+    ) -> Result<Vec<MlsGroup<Self>>, GroupError> {
+        crate::Client::<ApiClient, Verifier>::sync_welcomes(self, provider).await
     }
 
     async fn get_installation_diff(
@@ -293,6 +311,26 @@ where
         (**self).mls_provider()
     }
 
+    async fn sync_welcomes(
+        &self,
+        provider: &XmtpOpenMlsProvider,
+    ) -> Result<Vec<MlsGroup<Self>>, GroupError> {
+        // Get inner groups
+        let inner_result = (**self).sync_welcomes(provider).await?;
+
+        // Create new vector with the correct type
+        let mut result = Vec::with_capacity(inner_result.len());
+
+        // For each group in the result
+        for group in inner_result {
+            // Create a new MlsGroup with reference to self
+            let new_group = MlsGroup::new(*self, group.group_id.clone(), group.created_at_ns);
+            result.push(new_group);
+        }
+
+        Ok(result)
+    }
+
     async fn get_installation_diff(
         &self,
         conn: &DbConnection,
@@ -388,6 +426,27 @@ where
 
     fn mls_provider(&self) -> Result<XmtpOpenMlsProvider, StorageError> {
         (**self).mls_provider()
+    }
+
+    async fn sync_welcomes(
+        &self,
+        provider: &XmtpOpenMlsProvider,
+    ) -> Result<Vec<MlsGroup<Self>>, GroupError> {
+        // Get inner groups
+        let inner_result = (**self).sync_welcomes(provider).await?;
+
+        // Create new vector with the correct type
+        let mut result = Vec::with_capacity(inner_result.len());
+
+        // For each group in the result
+        for group in inner_result {
+            // Create a new MlsGroup with self as the client
+            let new_group =
+                MlsGroup::new(self.clone(), group.group_id.clone(), group.created_at_ns);
+            result.push(new_group);
+        }
+
+        Ok(result)
     }
 
     async fn get_installation_diff(
@@ -486,6 +545,27 @@ where
 
     fn mls_provider(&self) -> Result<XmtpOpenMlsProvider, StorageError> {
         (**self).mls_provider()
+    }
+
+    async fn sync_welcomes(
+        &self,
+        provider: &XmtpOpenMlsProvider,
+    ) -> Result<Vec<MlsGroup<Self>>, GroupError> {
+        // Get inner groups
+        let inner_result = (**self).sync_welcomes(provider).await?;
+
+        // Create new vector with the correct type
+        let mut result = Vec::with_capacity(inner_result.len());
+
+        // For each group in the result
+        for group in inner_result {
+            // Create a new MlsGroup with self as the client
+            let new_group =
+                MlsGroup::new(self.clone(), group.group_id.clone(), group.created_at_ns);
+            result.push(new_group);
+        }
+
+        Ok(result)
     }
 
     async fn get_installation_diff(

--- a/xmtp_mls/src/subscriptions/stream_conversations.rs
+++ b/xmtp_mls/src/subscriptions/stream_conversations.rs
@@ -409,20 +409,12 @@ where
             "Trying to process streamed welcome"
         );
 
-        let group = retry_async!(
+        retry_async!(
             Retry::default(),
-            (async { MlsGroup::create_from_welcome(client, provider, welcome, false).await })
-        );
+            (async { client.sync_welcomes(provider).await })
+        )?;
 
-        if let Err(e) = group {
-            tracing::info!("Processing welcome failed, trying to load existing..");
-            // try to load it from the store again in case of race
-            return self
-                .load_from_store(id)
-                .map_err(|_| SubscribeError::from(e));
-        }
-
-        Ok((group?, id))
+        self.load_from_store(id)
     }
 
     /// Load a group from disk by its welcome_id


### PR DESCRIPTION
* on stream welcome call sync instead of create from welcome

* remove implementation from wasm trait

* Update xmtp_mls/src/groups/scoped_client.rs



* still return vec of mls groups from sync (#1884)



---------