### PR TITLE
Fix default `GroupQueryArgs`

### DIFF
--- a/bindings_node/src/conversations.rs
+++ b/bindings_node/src/conversations.rs
@@ -103,7 +103,9 @@ impl From<ListConversationsOptions> for GroupQueryArgs {
       created_after_ns: opts.created_after_ns,
       include_duplicate_dms: opts.include_duplicate_dms,
       limit: opts.limit,
-      ..Default::default()
+      allowed_states: None,
+      conversation_type: None,
+      include_sync_groups: false,
     }
   }
 }

--- a/bindings_wasm/package.json
+++ b/bindings_wasm/package.json
@@ -27,7 +27,7 @@
     "build": "yarn clean && yarn build:web && yarn clean:release",
     "build:macos": "yarn clean && yarn build:web:macos && yarn clean:release",
     "build:web": "RUSTFLAGS=\"-Ctarget-feature=+bulk-memory,+mutable-globals --cfg getrandom_backend=\\\"wasm_js\\\"\" wasm-pack build --target web --out-dir ./dist --no-pack --release",
-    "build:web:macos": "CC_wasm32_unknown_unknown=/opt/homebrew/opt/llvm/bin/clang RUSTFLAGS=\"-Ctarget-feature=+bulk-memory,+mutable-globals\" wasm-pack build --target web --out-dir ./dist --no-pack --release",
+    "build:web:macos": "CC_wasm32_unknown_unknown=/opt/homebrew/opt/llvm/bin/clang RUSTFLAGS=\"-Ctarget-feature=+bulk-memory,+mutable-globals --cfg getrandom_backend=\\\"wasm_js\\\"\" wasm-pack build --target web --out-dir ./dist --no-pack --release",
     "check": "cargo check --target wasm32-unknown-unknown",
     "check:macos": "CC_wasm32_unknown_unknown=/opt/homebrew/opt/llvm/bin/clang cargo check --target wasm32-unknown-unknown",
     "clean": "rm -rf ./dist",

--- a/bindings_wasm/src/conversations.rs
+++ b/bindings_wasm/src/conversations.rs
@@ -99,7 +99,9 @@ impl From<ListConversationsOptions> for GroupQueryArgs {
       created_before_ns: opts.created_before_ns,
       include_duplicate_dms: opts.include_duplicate_dms,
       limit: opts.limit,
-      ..Default::default()
+      allowed_states: None,
+      conversation_type: None,
+      include_sync_groups: false,
     }
   }
 }


### PR DESCRIPTION
# Summary

- Specified default `GroupQueryArgs` instead of relying on built-in defaults for `ListConversationsOptions`
- Fixed `build:web:macos` NPM script

I tested this locally with the dev tool and sync groups are no longer being returned.