### PR TITLE
Wasm patch release - Fix default `GroupQueryArgs` (#1890)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1066,9 +1066,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1227,9 +1227,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
 ]

--- a/bindings_node/src/conversations.rs
+++ b/bindings_node/src/conversations.rs
@@ -103,7 +103,9 @@ impl From<ListConversationsOptions> for GroupQueryArgs {
       created_after_ns: opts.created_after_ns,
       include_duplicate_dms: opts.include_duplicate_dms,
       limit: opts.limit,
-      ..Default::default()
+      allowed_states: None,
+      conversation_type: None,
+      include_sync_groups: false,
     }
   }
 }

--- a/bindings_wasm/package.json
+++ b/bindings_wasm/package.json
@@ -27,7 +27,7 @@
     "build": "yarn clean && yarn build:web && yarn clean:release",
     "build:macos": "yarn clean && yarn build:web:macos && yarn clean:release",
     "build:web": "RUSTFLAGS=\"-Ctarget-feature=+bulk-memory,+mutable-globals --cfg getrandom_backend=\\\"wasm_js\\\"\" wasm-pack build --target web --out-dir ./dist --no-pack --release",
-    "build:web:macos": "CC_wasm32_unknown_unknown=/opt/homebrew/opt/llvm/bin/clang RUSTFLAGS=\"-Ctarget-feature=+bulk-memory,+mutable-globals\" wasm-pack build --target web --out-dir ./dist --no-pack --release",
+    "build:web:macos": "CC_wasm32_unknown_unknown=/opt/homebrew/opt/llvm/bin/clang RUSTFLAGS=\"-Ctarget-feature=+bulk-memory,+mutable-globals --cfg getrandom_backend=\\\"wasm_js\\\"\" wasm-pack build --target web --out-dir ./dist --no-pack --release",
     "check": "cargo check --target wasm32-unknown-unknown",
     "check:macos": "CC_wasm32_unknown_unknown=/opt/homebrew/opt/llvm/bin/clang cargo check --target wasm32-unknown-unknown",
     "clean": "rm -rf ./dist",

--- a/bindings_wasm/src/conversations.rs
+++ b/bindings_wasm/src/conversations.rs
@@ -99,7 +99,9 @@ impl From<ListConversationsOptions> for GroupQueryArgs {
       created_before_ns: opts.created_before_ns,
       include_duplicate_dms: opts.include_duplicate_dms,
       limit: opts.limit,
-      ..Default::default()
+      allowed_states: None,
+      conversation_type: None,
+      include_sync_groups: false,
     }
   }
 }


### PR DESCRIPTION
* Fix build:web:macos script

* Fix default GroupQueryArgs