### PR TITLE
debug wrapper for the api client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,4 +170,5 @@ chain_urls.json
 
 # Mise Configs
 .mise.toml
+emsdk/**
 emsdk

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,9 @@
 {
   "rust-analyzer.cargo.sysroot": "discover",
+  "rust-analyzer.cargo.buildScripts.enable": true,
   "rust-analyzer.linkedProjects": ["Cargo.toml"],
-  "rust-analyzer.procMacro.enable": true,
+  "rust-analyzer.cargo.allTargets": true,
+  "rust-analyzer.procMacro.enable": false,
   "rust-analyzer.diagnostics.enable": true,
   "rust-analyzer.diagnostics.disabled": [
     "unlinked-file",

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -162,6 +162,7 @@ pub async fn create_client(
 
     let mut builder = xmtp_mls::Client::builder(identity_strategy)
         .api_client(Arc::unwrap_or_clone(api).0)
+        .enable_api_debug_wrapper()
         .with_remote_verifier()?
         .store(store);
 

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -6,7 +6,7 @@ use crate::{FfiSubscribeError, GenericError};
 use prost::Message;
 use std::{collections::HashMap, convert::TryInto, sync::Arc};
 use tokio::sync::Mutex;
-use xmtp_api::{strategies, ApiClientWrapper, ApiIdentifier};
+use xmtp_api::{strategies, ApiClientWrapper, ApiDebugWrapper, ApiIdentifier};
 use xmtp_api_grpc::grpc_api_helper::Client as TonicApiClient;
 use xmtp_common::{AbortHandle, GenericStreamHandle, StreamHandle};
 use xmtp_content_types::multi_remote_attachment::MultiRemoteAttachmentCodec;
@@ -69,7 +69,7 @@ use xmtp_proto::xmtp::mls::message_contents::{DeviceSyncKind, EncodedContent};
 #[cfg(test)]
 mod test_utils;
 
-pub type RustXmtpClient = MlsClient<TonicApiClient>;
+pub type RustXmtpClient = MlsClient<ApiDebugWrapper<TonicApiClient>>;
 
 #[derive(uniffi::Object, Clone)]
 pub struct XmtpApiClient(TonicApiClient);
@@ -162,7 +162,7 @@ pub async fn create_client(
 
     let mut builder = xmtp_mls::Client::builder(identity_strategy)
         .api_client(Arc::unwrap_or_clone(api).0)
-        .enable_api_debug_wrapper()
+        .enable_api_debug_wrapper()?
         .with_remote_verifier()?
         .store(store);
 
@@ -209,7 +209,7 @@ pub async fn get_inbox_id_for_identifier(
 #[derive(uniffi::Object)]
 pub struct FfiSignatureRequest {
     inner: Arc<Mutex<SignatureRequest>>,
-    scw_verifier: RemoteSignatureVerifier<TonicApiClient>,
+    scw_verifier: RemoteSignatureVerifier<ApiDebugWrapper<TonicApiClient>>,
 }
 
 #[derive(uniffi::Record, Clone)]

--- a/bindings_node/src/client.rs
+++ b/bindings_node/src/client.rs
@@ -10,6 +10,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+use xmtp_api::ApiDebugWrapper;
 pub use xmtp_api_grpc::grpc_api_helper::Client as TonicApiClient;
 use xmtp_db::{EncryptedMessageStore, EncryptionKey, StorageOption};
 use xmtp_id::associations::builder::SignatureRequest;
@@ -19,7 +20,7 @@ use xmtp_mls::identity::IdentityStrategy;
 use xmtp_mls::Client as MlsClient;
 use xmtp_proto::xmtp::mls::message_contents::DeviceSyncKind;
 
-pub type RustXmtpClient = MlsClient<TonicApiClient>;
+pub type RustXmtpClient = MlsClient<ApiDebugWrapper<TonicApiClient>>;
 static LOGGER_INIT: std::sync::OnceLock<Result<()>> = std::sync::OnceLock::new();
 
 #[napi]
@@ -183,6 +184,8 @@ pub async fn create_client(
   let mut builder = match device_sync_server_url {
     Some(url) => xmtp_mls::Client::builder(identity_strategy)
       .api_client(api_client)
+      .enable_api_debug_wrapper()
+      .map_err(ErrorWrapper::from)?
       .with_remote_verifier()
       .map_err(ErrorWrapper::from)?
       .store(store)
@@ -190,6 +193,8 @@ pub async fn create_client(
 
     None => xmtp_mls::Client::builder(identity_strategy)
       .api_client(api_client)
+      .enable_api_debug_wrapper()
+      .map_err(ErrorWrapper::from)?
       .with_remote_verifier()
       .map_err(ErrorWrapper::from)?
       .store(store),

--- a/bindings_node/src/inbox_id.rs
+++ b/bindings_node/src/inbox_id.rs
@@ -25,7 +25,7 @@ pub async fn get_inbox_id_for_identifier(
     .map_err(ErrorWrapper::from)?;
   let client = client.build().await.map_err(ErrorWrapper::from)?;
   // api rate limit cooldown period
-  let api_client = ApiClientWrapper::new(client.into(), strategies::exponential_cooldown());
+  let api_client = ApiClientWrapper::new(client, strategies::exponential_cooldown());
 
   let identifier: xmtp_id::associations::Identifier = identifier.try_into()?;
   let api_ident: ApiIdentifier = identifier.into();

--- a/bindings_wasm/src/client.rs
+++ b/bindings_wasm/src/client.rs
@@ -7,6 +7,7 @@ use tracing_subscriber::EnvFilter;
 use tracing_subscriber::{filter, fmt::format::Pretty};
 use wasm_bindgen::prelude::{wasm_bindgen, JsError};
 use wasm_bindgen::JsValue;
+use xmtp_api::ApiDebugWrapper;
 use xmtp_api_http::XmtpHttpApiClient;
 use xmtp_db::{EncryptedMessageStore, EncryptionKey, StorageOption};
 use xmtp_id::associations::builder::SignatureRequest;
@@ -21,7 +22,7 @@ use crate::identity::Identifier;
 use crate::inbox_state::InboxState;
 use crate::signatures::SignatureRequestType;
 
-pub type RustXmtpClient = MlsClient<XmtpHttpApiClient>;
+pub type RustXmtpClient = MlsClient<ApiDebugWrapper<XmtpHttpApiClient>>;
 
 #[wasm_bindgen]
 pub struct Client {
@@ -183,11 +184,13 @@ pub async fn create_client(
   let mut builder = match device_sync_server_url {
     Some(url) => xmtp_mls::Client::builder(identity_strategy)
       .api_client(api_client)
+      .enable_api_debug_wrapper()?
       .with_remote_verifier()?
       .store(store)
       .device_sync_server_url(&url),
     None => xmtp_mls::Client::builder(identity_strategy)
       .api_client(api_client)
+      .enable_api_debug_wrapper()?
       .with_remote_verifier()?
       .store(store),
   };

--- a/bindings_wasm/src/inbox_id.rs
+++ b/bindings_wasm/src/inbox_id.rs
@@ -10,9 +10,7 @@ pub async fn get_inbox_id_for_identifier(
   #[wasm_bindgen(js_name = accountIdentifier)] account_identifier: Identifier,
 ) -> Result<Option<String>, JsError> {
   let api_client = ApiClientWrapper::new(
-    XmtpHttpApiClient::new(host.clone(), "0.0.0".into())
-      .await?
-      .into(),
+    XmtpHttpApiClient::new(host.clone(), "0.0.0".into()).await?,
     strategies::exponential_cooldown(),
   );
 

--- a/nix/libxmtp.nix
+++ b/nix/libxmtp.nix
@@ -46,11 +46,11 @@ let
             ];
           extraInputs = top;
         });
-  rust-toolchain = mkToolchain [ "wasm32-unknown-unknown" ] [ "rust-docs" "rustfmt-preview" "clippy-preview" ];
+  rust-toolchain = mkToolchain [ "wasm32-unknown-unknown" "x86_64-unknown-linux-gnu" ] [ "clippy-preview" "rust-docs" "rustfmt-preview" ];
 in
 mkShell {
   OPENSSL_DIR = "${openssl.dev}";
-  LLVM_PATH = "${llvmPackages_19.stdenv}";
+  # LLVM_PATH = "${llvmPackages_19.stdenv}";
   # CC_wasm32_unknown_unknown = "${llvmPackages_20.clang-unwrapped}/bin/clang";
   # CXX_wasm32_unknown_unknown = "${llvmPackages_20.clang-unwrapped}/bin/clang++";
   # AS_wasm32_unknown_unknown = "${llvmPackages_20.clang-unwrapped}/bin/llvm-as";

--- a/xmtp_api/src/debug_wrapper.rs
+++ b/xmtp_api/src/debug_wrapper.rs
@@ -1,0 +1,242 @@
+use std::future::Future;
+use xmtp_common::RetryableError;
+use xmtp_proto::api_client::AggregateStats;
+use xmtp_proto::api_client::ApiStats;
+use xmtp_proto::api_client::IdentityStats;
+use xmtp_proto::traits::HasStats;
+use xmtp_proto::xmtp::identity::api::v1::GetIdentityUpdatesRequest as GetIdentityUpdatesV2Request;
+use xmtp_proto::xmtp::identity::api::v1::GetIdentityUpdatesResponse as GetIdentityUpdatesV2Response;
+use xmtp_proto::xmtp::identity::api::v1::GetInboxIdsRequest;
+use xmtp_proto::xmtp::identity::api::v1::GetInboxIdsResponse;
+use xmtp_proto::xmtp::identity::api::v1::PublishIdentityUpdateRequest;
+use xmtp_proto::xmtp::identity::api::v1::PublishIdentityUpdateResponse;
+use xmtp_proto::xmtp::identity::api::v1::VerifySmartContractWalletSignaturesRequest;
+use xmtp_proto::xmtp::identity::api::v1::VerifySmartContractWalletSignaturesResponse;
+use xmtp_proto::xmtp::mls::api::v1::FetchKeyPackagesRequest;
+use xmtp_proto::xmtp::mls::api::v1::FetchKeyPackagesResponse;
+use xmtp_proto::xmtp::mls::api::v1::QueryGroupMessagesRequest;
+use xmtp_proto::xmtp::mls::api::v1::QueryGroupMessagesResponse;
+use xmtp_proto::xmtp::mls::api::v1::QueryWelcomeMessagesRequest;
+use xmtp_proto::xmtp::mls::api::v1::QueryWelcomeMessagesResponse;
+use xmtp_proto::xmtp::mls::api::v1::SendGroupMessagesRequest;
+use xmtp_proto::xmtp::mls::api::v1::SendWelcomeMessagesRequest;
+use xmtp_proto::xmtp::mls::api::v1::SubscribeGroupMessagesRequest;
+use xmtp_proto::xmtp::mls::api::v1::SubscribeWelcomeMessagesRequest;
+use xmtp_proto::xmtp::mls::api::v1::UploadKeyPackageRequest;
+use xmtp_proto::{
+    prelude::{XmtpIdentityClient, XmtpMlsClient, XmtpMlsStreams},
+    traits::ApiClientError,
+};
+pub struct ApiDebugWrapper<A> {
+    inner: A,
+}
+
+impl<A> ApiDebugWrapper<A> {
+    pub fn new(api: A) -> Self {
+        Self { inner: api }
+    }
+}
+
+async fn wrap_err<T, R, F, E>(
+    req: R,
+    stats: impl Fn() -> AggregateStats,
+) -> Result<T, ApiClientError<E>>
+where
+    R: FnOnce() -> F,
+    F: Future<Output = Result<T, ApiClientError<E>>>,
+    E: std::error::Error + Send + Sync + RetryableError + 'static,
+{
+    let res = req().await;
+    if let Err(e) = res {
+        match e {
+            ApiClientError::ClientWithEndpoint { endpoint, source } => {
+                Err(ApiClientError::ClientWithEndpointAndStats {
+                    endpoint,
+                    source,
+                    stats: stats(),
+                })
+            }
+            err @ ApiClientError::ClientWithEndpointAndStats { .. } => Err(err),
+            e => Err(ApiClientError::ErrorWithStats {
+                e: Box::new(e),
+                stats: stats(),
+            }),
+        }
+    } else {
+        res
+    }
+}
+
+#[async_trait::async_trait]
+impl<A, E> XmtpMlsClient for ApiDebugWrapper<A>
+where
+    A: XmtpMlsClient<Error = ApiClientError<E>> + Send + Sync,
+    E: std::error::Error + RetryableError + Send + Sync + 'static,
+    A: HasStats,
+{
+    type Error = ApiClientError<E>;
+
+    async fn upload_key_package(
+        &self,
+        request: UploadKeyPackageRequest,
+    ) -> Result<(), Self::Error> {
+        wrap_err(
+            || self.inner.upload_key_package(request),
+            || self.inner.aggregate_stats(),
+        )
+        .await
+    }
+
+    async fn fetch_key_packages(
+        &self,
+        request: FetchKeyPackagesRequest,
+    ) -> Result<FetchKeyPackagesResponse, Self::Error> {
+        wrap_err(
+            || self.inner.fetch_key_packages(request),
+            || self.inner.aggregate_stats(),
+        )
+        .await
+    }
+
+    async fn send_group_messages(
+        &self,
+        request: SendGroupMessagesRequest,
+    ) -> Result<(), Self::Error> {
+        wrap_err(
+            || self.inner.send_group_messages(request),
+            || self.inner.aggregate_stats(),
+        )
+        .await
+    }
+
+    async fn send_welcome_messages(
+        &self,
+        request: SendWelcomeMessagesRequest,
+    ) -> Result<(), Self::Error> {
+        wrap_err(
+            || self.inner.send_welcome_messages(request),
+            || self.inner.aggregate_stats(),
+        )
+        .await
+    }
+
+    async fn query_group_messages(
+        &self,
+        request: QueryGroupMessagesRequest,
+    ) -> Result<QueryGroupMessagesResponse, Self::Error> {
+        wrap_err(
+            || self.inner.query_group_messages(request),
+            || self.inner.aggregate_stats(),
+        )
+        .await
+    }
+
+    async fn query_welcome_messages(
+        &self,
+        request: QueryWelcomeMessagesRequest,
+    ) -> Result<QueryWelcomeMessagesResponse, Self::Error> {
+        wrap_err(
+            || self.inner.query_welcome_messages(request),
+            || self.inner.aggregate_stats(),
+        )
+        .await
+    }
+
+    fn stats(&self) -> ApiStats {
+        self.inner.stats()
+    }
+}
+
+#[async_trait::async_trait]
+impl<A, E> XmtpMlsStreams for ApiDebugWrapper<A>
+where
+    A: XmtpMlsStreams<Error = ApiClientError<E>> + Send + Sync + 'static,
+    E: std::error::Error + RetryableError + Send + Sync + 'static,
+    A: HasStats,
+{
+    type GroupMessageStream<'a> = <A as XmtpMlsStreams>::GroupMessageStream<'a>;
+
+    type WelcomeMessageStream<'a> = <A as XmtpMlsStreams>::WelcomeMessageStream<'a>;
+
+    type Error = ApiClientError<E>;
+
+    async fn subscribe_group_messages(
+        &self,
+        request: SubscribeGroupMessagesRequest,
+    ) -> Result<Self::GroupMessageStream<'_>, Self::Error> {
+        wrap_err(
+            || self.inner.subscribe_group_messages(request),
+            || self.inner.aggregate_stats(),
+        )
+        .await
+    }
+
+    async fn subscribe_welcome_messages(
+        &self,
+        request: SubscribeWelcomeMessagesRequest,
+    ) -> Result<Self::WelcomeMessageStream<'_>, Self::Error> {
+        wrap_err(
+            || self.inner.subscribe_welcome_messages(request),
+            || self.inner.aggregate_stats(),
+        )
+        .await
+    }
+}
+
+#[async_trait::async_trait]
+impl<A, E> XmtpIdentityClient for ApiDebugWrapper<A>
+where
+    A: XmtpIdentityClient<Error = ApiClientError<E>> + Send + Sync,
+    E: std::error::Error + RetryableError + Send + Sync + 'static,
+    A: HasStats,
+{
+    type Error = ApiClientError<E>;
+
+    async fn publish_identity_update(
+        &self,
+        request: PublishIdentityUpdateRequest,
+    ) -> Result<PublishIdentityUpdateResponse, Self::Error> {
+        wrap_err(
+            || self.inner.publish_identity_update(request),
+            || self.inner.aggregate_stats(),
+        )
+        .await
+    }
+
+    async fn get_identity_updates_v2(
+        &self,
+        request: GetIdentityUpdatesV2Request,
+    ) -> Result<GetIdentityUpdatesV2Response, Self::Error> {
+        wrap_err(
+            || self.inner.get_identity_updates_v2(request),
+            || self.inner.aggregate_stats(),
+        )
+        .await
+    }
+
+    async fn get_inbox_ids(
+        &self,
+        request: GetInboxIdsRequest,
+    ) -> Result<GetInboxIdsResponse, Self::Error> {
+        wrap_err(
+            || self.inner.get_inbox_ids(request),
+            || self.inner.aggregate_stats(),
+        )
+        .await
+    }
+
+    async fn verify_smart_contract_wallet_signatures(
+        &self,
+        request: VerifySmartContractWalletSignaturesRequest,
+    ) -> Result<VerifySmartContractWalletSignaturesResponse, Self::Error> {
+        wrap_err(
+            || self.inner.verify_smart_contract_wallet_signatures(request),
+            || self.inner.aggregate_stats(),
+        )
+        .await
+    }
+
+    fn identity_stats(&self) -> IdentityStats {
+        self.inner.identity_stats()
+    }
+}

--- a/xmtp_api/src/debug_wrapper.rs
+++ b/xmtp_api/src/debug_wrapper.rs
@@ -27,6 +27,8 @@ use xmtp_proto::{
     prelude::{XmtpIdentityClient, XmtpMlsClient, XmtpMlsStreams},
     traits::ApiClientError,
 };
+
+#[derive(Clone)]
 pub struct ApiDebugWrapper<A> {
     inner: A,
 }
@@ -44,7 +46,7 @@ async fn wrap_err<T, R, F, E>(
 where
     R: FnOnce() -> F,
     F: Future<Output = Result<T, ApiClientError<E>>>,
-    E: std::error::Error + Send + Sync + RetryableError + 'static,
+    E: std::error::Error + RetryableError + Send + Sync + 'static,
 {
     let res = req().await;
     if let Err(e) = res {
@@ -67,7 +69,8 @@ where
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl<A, E> XmtpMlsClient for ApiDebugWrapper<A>
 where
     A: XmtpMlsClient<Error = ApiClientError<E>> + Send + Sync,
@@ -147,7 +150,8 @@ where
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl<A, E> XmtpMlsStreams for ApiDebugWrapper<A>
 where
     A: XmtpMlsStreams<Error = ApiClientError<E>> + Send + Sync + 'static,
@@ -183,7 +187,8 @@ where
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl<A, E> XmtpIdentityClient for ApiDebugWrapper<A>
 where
     A: XmtpIdentityClient<Error = ApiClientError<E>> + Send + Sync,

--- a/xmtp_api/src/identity.rs
+++ b/xmtp_api/src/identity.rs
@@ -2,9 +2,10 @@ use std::collections::HashMap;
 
 use super::ApiClientWrapper;
 use crate::ApiError;
-use crate::{Result, XmtpApi};
+use crate::Result;
 use futures::future::try_join_all;
 use xmtp_common::RetryableError;
+use xmtp_proto::prelude::XmtpIdentityClient;
 use xmtp_proto::xmtp::identity::api::v1::{
     get_identity_updates_request::Request as GetIdentityUpdatesV2RequestProto,
     get_identity_updates_response::IdentityUpdateLog,
@@ -12,6 +13,7 @@ use xmtp_proto::xmtp::identity::api::v1::{
     GetIdentityUpdatesRequest as GetIdentityUpdatesV2Request, GetInboxIdsRequest,
     PublishIdentityUpdateRequest,
 };
+
 use xmtp_proto::xmtp::identity::api::v1::{
     VerifySmartContractWalletSignaturesRequest, VerifySmartContractWalletSignaturesResponse,
 };
@@ -45,7 +47,7 @@ pub struct ApiIdentifier {
 
 impl<ApiClient> ApiClientWrapper<ApiClient>
 where
-    ApiClient: XmtpApi,
+    ApiClient: XmtpIdentityClient,
 {
     pub async fn publish_identity_update<U: Into<IdentityUpdate>>(&self, update: U) -> Result<()> {
         self.api_client

--- a/xmtp_api/src/identity.rs
+++ b/xmtp_api/src/identity.rs
@@ -195,7 +195,7 @@ pub(crate) mod tests {
             .withf(move |req| req.identity_update.as_ref().unwrap().inbox_id.eq(&inbox_id))
             .returning(move |_| Ok(PublishIdentityUpdateResponse {}));
 
-        let wrapper = ApiClientWrapper::new(mock_api.into(), exponential().build());
+        let wrapper = ApiClientWrapper::new(mock_api, exponential().build());
         let result = wrapper.publish_identity_update(identity_update).await;
 
         assert!(result.is_ok());
@@ -236,7 +236,7 @@ pub(crate) mod tests {
                 })
             });
 
-        let wrapper = ApiClientWrapper::new(mock_api.into(), exponential().build());
+        let wrapper = ApiClientWrapper::new(mock_api, exponential().build());
         let result = wrapper
             .get_identity_updates_v2(vec![GetIdentityUpdatesV2Filter {
                 inbox_id: inbox_id_clone_2.clone(),
@@ -282,7 +282,7 @@ pub(crate) mod tests {
                 })
             });
 
-        let wrapper = ApiClientWrapper::new(mock_api.into(), exponential().build());
+        let wrapper = ApiClientWrapper::new(mock_api, exponential().build());
         let result = wrapper
             .get_inbox_ids(vec![ApiIdentifier {
                 identifier: address.clone(),

--- a/xmtp_api/src/mls.rs
+++ b/xmtp_api/src/mls.rs
@@ -386,7 +386,7 @@ pub mod tests {
                     .eq(&key_package)
             })
             .returning(move |_| Ok(()));
-        let wrapper = ApiClientWrapper::new(mock_api.into(), exponential().build());
+        let wrapper = ApiClientWrapper::new(mock_api, exponential().build());
         let result = wrapper.upload_key_package(key_package_clone, false).await;
         assert!(result.is_ok());
     }
@@ -409,7 +409,7 @@ pub mod tests {
                 ],
             })
         });
-        let wrapper = ApiClientWrapper::new(mock_api.into(), exponential().build());
+        let wrapper = ApiClientWrapper::new(mock_api, exponential().build());
         let result = wrapper
             .fetch_key_packages(installation_keys.clone())
             .await
@@ -447,7 +447,7 @@ pub mod tests {
                 })
             });
 
-        let wrapper = ApiClientWrapper::new(mock_api.into(), exponential().build());
+        let wrapper = ApiClientWrapper::new(mock_api, exponential().build());
 
         let result = wrapper
             .query_group_messages(group_id_clone, None)
@@ -479,7 +479,7 @@ pub mod tests {
                 })
             });
 
-        let wrapper = ApiClientWrapper::new(mock_api.into(), exponential().build());
+        let wrapper = ApiClientWrapper::new(mock_api, exponential().build());
 
         let result = wrapper
             .query_group_messages(group_id_clone, None)
@@ -530,7 +530,7 @@ pub mod tests {
                 })
             });
 
-        let wrapper = ApiClientWrapper::new(mock_api.into(), exponential().build());
+        let wrapper = ApiClientWrapper::new(mock_api, exponential().build());
 
         let result = wrapper
             .query_group_messages(group_id_clone2, None)
@@ -564,7 +564,7 @@ pub mod tests {
                 })
             });
 
-        let wrapper = ApiClientWrapper::new(mock_api.into(), exponential().build());
+        let wrapper = ApiClientWrapper::new(mock_api, exponential().build());
 
         let result = wrapper
             .query_group_messages(group_id_clone, None)
@@ -583,7 +583,7 @@ pub mod tests {
         client.rate_per_minute(1);
         let _ = client.set_app_version("999.999.999".into());
         let c = client.build().await.unwrap();
-        let wrapper = ApiClientWrapper::new(c.into(), Retry::default());
+        let wrapper = ApiClientWrapper::new(c, Retry::default());
         let _first = wrapper.query_group_messages(vec![0, 0], None).await;
         let now = std::time::Instant::now();
         let _second = wrapper.query_group_messages(vec![0, 0], None).await;

--- a/xmtp_api_grpc/src/grpc_api_helper.rs
+++ b/xmtp_api_grpc/src/grpc_api_helper.rs
@@ -6,7 +6,9 @@ use tonic::{metadata::MetadataValue, transport::Channel, Request};
 use xmtp_proto::traits::ApiClientError;
 
 use crate::{create_tls_channel, GrpcBuilderError, GrpcError};
+use xmtp_proto::api_client::AggregateStats;
 use xmtp_proto::api_client::{ApiBuilder, ApiStats, IdentityStats, XmtpMlsStreams};
+use xmtp_proto::traits::HasStats;
 use xmtp_proto::xmtp::mls::api::v1::{GroupMessage, WelcomeMessage};
 use xmtp_proto::{
     api_client::XmtpMlsClient,
@@ -20,8 +22,6 @@ use xmtp_proto::{
     },
     ApiEndpoint,
 };
-use xmtp_proto::api_client::AggregateStats;
-use xmtp_proto::traits::HasStats;
 #[derive(Debug, Clone)]
 pub struct Client {
     pub(crate) mls_client: ProtoMlsApiClient<Channel>,
@@ -133,7 +133,7 @@ impl HasStats for Client {
     fn aggregate_stats(&self) -> AggregateStats {
         AggregateStats {
             mls: self.stats.clone(),
-            identity: self.identity_stats.clone()
+            identity: self.identity_stats.clone(),
         }
     }
 }

--- a/xmtp_api_grpc/src/grpc_api_helper.rs
+++ b/xmtp_api_grpc/src/grpc_api_helper.rs
@@ -20,7 +20,8 @@ use xmtp_proto::{
     },
     ApiEndpoint,
 };
-
+use xmtp_proto::api_client::AggregateStats;
+use xmtp_proto::traits::HasStats;
 #[derive(Debug, Clone)]
 pub struct Client {
     pub(crate) mls_client: ProtoMlsApiClient<Channel>,
@@ -125,6 +126,15 @@ impl ApiBuilder for ClientBuilder {
             stats: ApiStats::default(),
             identity_stats: IdentityStats::default(),
         })
+    }
+}
+
+impl HasStats for Client {
+    fn aggregate_stats(&self) -> AggregateStats {
+        AggregateStats {
+            mls: self.stats.clone(),
+            identity: self.identity_stats.clone()
+        }
     }
 }
 
@@ -275,6 +285,7 @@ impl XmtpMlsStreams for Client {
         &self,
         req: SubscribeGroupMessagesRequest,
     ) -> Result<Self::GroupMessageStream<'_>, Self::Error> {
+        self.stats.subscribe_messages.count_request();
         let client = &mut self.mls_client.clone();
         let res = client
             .subscribe_group_messages(self.build_request(req))
@@ -289,6 +300,7 @@ impl XmtpMlsStreams for Client {
         &self,
         req: SubscribeWelcomeMessagesRequest,
     ) -> Result<Self::WelcomeMessageStream<'_>, Self::Error> {
+        self.stats.subscribe_welcomes.count_request();
         let client = &mut self.mls_client.clone();
         let res = client
             .subscribe_welcome_messages(self.build_request(req))

--- a/xmtp_id/src/scw_verifier/remote_signature_verifier.rs
+++ b/xmtp_id/src/scw_verifier/remote_signature_verifier.rs
@@ -17,7 +17,7 @@ pub struct RemoteSignatureVerifier<C> {
 
 impl<ApiClient> RemoteSignatureVerifier<ApiClient> {
     pub fn new(api: ApiClientWrapper<ApiClient>) -> Self {
-        Self { api: api }
+        Self { api }
     }
 }
 

--- a/xmtp_id/src/scw_verifier/remote_signature_verifier.rs
+++ b/xmtp_id/src/scw_verifier/remote_signature_verifier.rs
@@ -1,25 +1,23 @@
-use std::sync::Arc;
-
 use super::{SmartContractSignatureVerifier, ValidationResponse, VerifierError};
 use crate::associations::AccountId;
 use ethers::types::{BlockNumber, Bytes};
 use xmtp_api::ApiClientWrapper;
 
 use xmtp_proto::{
-    api_client::trait_impls::XmtpApi,
+    prelude::XmtpIdentityClient,
     xmtp::identity::api::v1::{
         VerifySmartContractWalletSignatureRequestSignature,
         VerifySmartContractWalletSignaturesRequest, VerifySmartContractWalletSignaturesResponse,
     },
 };
 
-pub struct RemoteSignatureVerifier<ApiClient> {
-    api: Arc<ApiClientWrapper<ApiClient>>,
+pub struct RemoteSignatureVerifier<C> {
+    api: ApiClientWrapper<C>,
 }
 
 impl<ApiClient> RemoteSignatureVerifier<ApiClient> {
     pub fn new(api: ApiClientWrapper<ApiClient>) -> Self {
-        Self { api: Arc::new(api) }
+        Self { api: api }
     }
 }
 
@@ -27,7 +25,7 @@ impl<ApiClient> RemoteSignatureVerifier<ApiClient> {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl<C> SmartContractSignatureVerifier for RemoteSignatureVerifier<C>
 where
-    C: XmtpApi,
+    C: XmtpIdentityClient + Send + Sync,
 {
     async fn is_valid_signature(
         &self,

--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -1,10 +1,5 @@
-use std::sync::Arc;
-
 use thiserror::Error;
 use tracing::debug;
-
-use xmtp_cryptography::signature::IdentifierValidationError;
-use xmtp_id::scw_verifier::{RemoteSignatureVerifier, SmartContractSignatureVerifier};
 
 use crate::{
     client::Client,
@@ -12,9 +7,12 @@ use crate::{
     identity_updates::load_identity_updates,
     StorageError, XmtpApi, XmtpOpenMlsProvider,
 };
+use xmtp_cryptography::signature::IdentifierValidationError;
 use xmtp_db::EncryptedMessageStore;
+use xmtp_id::scw_verifier::RemoteSignatureVerifier;
+use xmtp_id::scw_verifier::SmartContractSignatureVerifier;
 
-use xmtp_api::ApiClientWrapper;
+use xmtp_api::{ApiClientWrapper, ApiDebugWrapper};
 use xmtp_common::Retry;
 
 #[derive(Error, Debug)]
@@ -183,9 +181,9 @@ impl<ApiClient, V> ClientBuilder<ApiClient, V> {
 
     pub fn api_client<A>(self, api_client: A) -> ClientBuilder<A, V> {
         let api_retry = Retry::builder().build();
-        let wrapper = ApiClientWrapper::new(Arc::new(api_client), api_retry);
+        let api_client = ApiClientWrapper::new(api_client, api_retry);
         ClientBuilder {
-            api_client: Some(wrapper),
+            api_client: Some(api_client),
             identity: self.identity,
             identity_strategy: self.identity_strategy,
             scw_verifier: self.scw_verifier,
@@ -194,6 +192,33 @@ impl<ApiClient, V> ClientBuilder<ApiClient, V> {
             device_sync_server_url: self.device_sync_server_url,
             device_sync_worker_mode: self.device_sync_worker_mode,
         }
+    }
+
+    /// Wrap the Api Client in a Debug Adapter which prints api stats on error.
+    /// Requires the api client to be set in the builder.
+    pub fn enable_api_debug_wrapper(
+        self,
+    ) -> Result<ClientBuilder<ApiDebugWrapper<ApiClient>, V>, ClientBuilderError> {
+        if self.api_client.is_none() {
+            return Err(ClientBuilderError::MissingParameter {
+                parameter: "api_client",
+            });
+        }
+
+        Ok(ClientBuilder {
+            api_client: Some(
+                self.api_client
+                    .expect("checked for none")
+                    .attach_debug_wrapper(),
+            ),
+            identity: self.identity,
+            identity_strategy: self.identity_strategy,
+            scw_verifier: self.scw_verifier,
+            store: self.store,
+
+            device_sync_server_url: self.device_sync_server_url,
+            device_sync_worker_mode: self.device_sync_worker_mode,
+        })
     }
 
     pub fn with_scw_verifier<V2>(self, verifier: V2) -> ClientBuilder<ApiClient, V2> {
@@ -209,8 +234,6 @@ impl<ApiClient, V> ClientBuilder<ApiClient, V> {
         }
     }
 
-    /// Build the client with a default remote verifier
-    /// requires the 'api' to be set.
     pub fn with_remote_verifier(
         self,
     ) -> Result<ClientBuilder<ApiClient, RemoteSignatureVerifier<ApiClient>>, ClientBuilderError>
@@ -220,16 +243,16 @@ impl<ApiClient, V> ClientBuilder<ApiClient, V> {
         let api = self
             .api_client
             .clone()
+            .take()
             .ok_or(ClientBuilderError::MissingParameter {
                 parameter: "api_client",
             })?;
-        let remote_verifier = RemoteSignatureVerifier::new(api);
 
         Ok(ClientBuilder {
             api_client: self.api_client,
             identity: self.identity,
             identity_strategy: self.identity_strategy,
-            scw_verifier: Some(remote_verifier),
+            scw_verifier: Some(RemoteSignatureVerifier::new(api)),
             store: self.store,
 
             device_sync_server_url: self.device_sync_server_url,
@@ -588,7 +611,7 @@ pub(crate) mod tests {
             }
         });
 
-        let wrapper = ApiClientWrapper::new(mock_api.into(), retry());
+        let wrapper = ApiClientWrapper::new(mock_api, retry());
 
         let identity = IdentityStrategy::new("other_inbox_id".to_string(), ident, nonce, None);
         assert!(matches!(
@@ -632,7 +655,7 @@ pub(crate) mod tests {
             }
         });
 
-        let wrapper = ApiClientWrapper::new(mock_api.into(), retry());
+        let wrapper = ApiClientWrapper::new(mock_api, retry());
 
         let identity = IdentityStrategy::new(inbox_id.clone(), ident, nonce, None);
         assert!(dbg!(
@@ -671,7 +694,7 @@ pub(crate) mod tests {
             .unwrap();
 
         stored.store(&store.conn().unwrap()).unwrap();
-        let wrapper = ApiClientWrapper::new(mock_api.into(), retry());
+        let wrapper = ApiClientWrapper::new(mock_api, retry());
         let identity = IdentityStrategy::new(inbox_id.clone(), ident, nonce, None);
         assert!(identity
             .initialize_identity(&wrapper, &store.mls_provider().unwrap(), &scw_verifier)
@@ -708,7 +731,7 @@ pub(crate) mod tests {
 
         stored.store(&store.conn().unwrap()).unwrap();
 
-        let wrapper = ApiClientWrapper::new(mock_api.into(), retry());
+        let wrapper = ApiClientWrapper::new(mock_api, retry());
 
         let inbox_id = "inbox_id".to_string();
         let identity = IdentityStrategy::new(inbox_id.clone(), ident, nonce, None);

--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -243,7 +243,6 @@ impl<ApiClient, V> ClientBuilder<ApiClient, V> {
         let api = self
             .api_client
             .clone()
-            .take()
             .ok_or(ClientBuilderError::MissingParameter {
                 parameter: "api_client",
             })?;

--- a/xmtp_proto/src/api_client.rs
+++ b/xmtp_proto/src/api_client.rs
@@ -100,6 +100,8 @@ pub struct ApiStats {
     pub send_welcome_messages: Arc<EndpointStats>,
     pub query_group_messages: Arc<EndpointStats>,
     pub query_welcome_messages: Arc<EndpointStats>,
+    pub subscribe_messages: Arc<EndpointStats>,
+    pub subscribe_welcomes: Arc<EndpointStats>,
 }
 
 #[derive(Clone, Default, Debug)]
@@ -110,9 +112,75 @@ pub struct IdentityStats {
     pub verify_smart_contract_wallet_signature: Arc<EndpointStats>,
 }
 
+pub struct AggregateStats {
+    pub mls: ApiStats,
+    pub identity: IdentityStats,
+}
+
+impl std::fmt::Debug for AggregateStats {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "============ Api Stats ============")?;
+        writeln!(f, "UploadKeyPackage        {}", self.mls.upload_key_package)?;
+        writeln!(f, "FetchKeyPackage         {}", self.mls.fetch_key_package)?;
+        writeln!(
+            f,
+            "SendGroupMessages       {}",
+            self.mls.send_group_messages
+        )?;
+        writeln!(
+            f,
+            "SendWelcomeMessages     {}",
+            self.mls.send_welcome_messages
+        )?;
+        writeln!(
+            f,
+            "QueryGroupMessages      {}",
+            self.mls.query_group_messages
+        )?;
+        writeln!(
+            f,
+            "QueryWelcomeMessages    {}",
+            self.mls.query_welcome_messages
+        )?;
+        writeln!(f, "SubscribeMessages       {}", self.mls.subscribe_messages)?;
+        writeln!(f, "SubscribeWelcomes       {}", self.mls.subscribe_welcomes)?;
+        writeln!(f, "============ Identity ============")?;
+        writeln!(
+            f,
+            "PublishIdentityUpdate    {}",
+            self.identity.publish_identity_update
+        )?;
+        writeln!(
+            f,
+            "GetIdentityUpdatesV2     {}",
+            self.identity.get_identity_updates_v2
+        )?;
+        writeln!(f, "GetInboxIds             {}", self.identity.get_inbox_ids)?;
+        writeln!(
+            f,
+            "VerifySCWSignatures     {}",
+            self.identity.verify_smart_contract_wallet_signature
+        )?;
+        writeln!(f, "============ Stream ============")?;
+        writeln!(
+            f,
+            "SubscribeMessages        {}",
+            self.mls.subscribe_messages
+        )?;
+        writeln!(f, "SubscribeWelcomes       {}", self.mls.subscribe_welcomes)?;
+        Ok(())
+    }
+}
+
 #[derive(Default, Debug)]
 pub struct EndpointStats {
     request_count: AtomicUsize,
+}
+
+impl std::fmt::Display for EndpointStats {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.request_count.load(Ordering::Relaxed))
+    }
 }
 
 impl EndpointStats {

--- a/xmtp_proto/src/traits.rs
+++ b/xmtp_proto/src/traits.rs
@@ -1,11 +1,11 @@
 //! Api Client Traits
 
+use crate::api_client::AggregateStats;
 use http::{request, uri::PathAndQuery};
 use prost::bytes::Bytes;
 use std::borrow::Cow;
 use thiserror::Error;
 use xmtp_common::{retry_async, retryable, BoxedRetry, RetryableError};
-use crate::api_client::AggregateStats;
 
 use crate::{ApiEndpoint, ProtoError};
 
@@ -144,7 +144,12 @@ where
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum ApiClientError<E: std::error::Error> {
-    #[error("api client at endpoint \"{}\" has error {}. \n {:?} \n", endpoint, source, stats)]
+    #[error(
+        "api client at endpoint \"{}\" has error {}. \n {:?} \n",
+        endpoint,
+        source,
+        stats
+    )]
     ClientWithEndpointAndStats {
         endpoint: String,
         source: E,
@@ -153,7 +158,7 @@ pub enum ApiClientError<E: std::error::Error> {
     #[error("API Error {}, \n {:?} \n", e, stats)]
     ErrorWithStats {
         e: Box<dyn RetryableError + Send + Sync>,
-        stats: AggregateStats
+        stats: AggregateStats,
     },
     /// The client encountered an error.
     #[error("api client at endpoint \"{}\" has error {}", endpoint, source)]

--- a/xmtp_proto/src/traits.rs
+++ b/xmtp_proto/src/traits.rs
@@ -5,14 +5,12 @@ use prost::bytes::Bytes;
 use std::borrow::Cow;
 use thiserror::Error;
 use xmtp_common::{retry_async, retryable, BoxedRetry, RetryableError};
+use crate::api_client::AggregateStats;
 
-use crate::{api_client::ApiStats, ApiEndpoint, ProtoError};
+use crate::{ApiEndpoint, ProtoError};
 
 pub trait HasStats {
-    fn stats(&self) -> &ApiStats;
-}
-pub trait HasIdentityStats {
-    fn identity_stats(&self) -> crate::api_client::IdentityStats;
+    fn aggregate_stats(&self) -> AggregateStats;
 }
 
 pub trait Endpoint {
@@ -146,8 +144,19 @@ where
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum ApiClientError<E: std::error::Error> {
+    #[error("api client at endpoint \"{}\" has error {}. \n {:?} \n", endpoint, source, stats)]
+    ClientWithEndpointAndStats {
+        endpoint: String,
+        source: E,
+        stats: AggregateStats,
+    },
+    #[error("API Error {}, \n {:?} \n", e, stats)]
+    ErrorWithStats {
+        e: Box<dyn RetryableError + Send + Sync>,
+        stats: AggregateStats
+    },
     /// The client encountered an error.
-    #[error("client at \"{}\" has error {}", endpoint, source)]
+    #[error("api client at endpoint \"{}\" has error {}", endpoint, source)]
     ClientWithEndpoint {
         endpoint: String,
         /// The client error.
@@ -178,7 +187,9 @@ where
     fn is_retryable(&self) -> bool {
         use ApiClientError::*;
         match self {
-            Client { source } => retryable!(source),
+            ClientWithEndpointAndStats { source, .. } => retryable!(source),
+            ErrorWithStats { e, .. } => retryable!(e),
+            Client { source } => retryable!(*source),
             ClientWithEndpoint { source, .. } => retryable!(source),
             Body(e) => retryable!(e),
             Http(_) => true,


### PR DESCRIPTION
### Add debug wrapper to API client to include API statistics in error reporting
Introduces a new `ApiDebugWrapper` that wraps API clients to provide enhanced error reporting with API usage statistics. Key changes include:

* New `ApiDebugWrapper` implementation in [debug_wrapper.rs](https://github.com/xmtp/libxmtp/pull/1898/files#diff-81637b4ff5b1435723103d8476cf8db1c8db20746454711eb4b908f0ac431434) that intercepts API calls and enriches errors with statistics
* Modified API client architecture in [lib.rs](https://github.com/xmtp/libxmtp/pull/1898/files#diff-733320e90d15407fae52d9427d27e265b63863d314cf2eb29c23de8f91e8421a) to take direct ownership instead of using `Arc`
* Added `AggregateStats` struct in [api_client.rs](https://github.com/xmtp/libxmtp/pull/1898/files#diff-7e862515880042ad7a89178c4850f4edd3b1a449ebd83515598088bd845fe67b) for tracking MLS and identity statistics
* Updated bindings in FFI, Node, and WASM to use the debug wrapper
* Implemented `HasStats` trait for gRPC and HTTP API clients

#### 📍Where to Start
Start with the `ApiDebugWrapper` implementation in [debug_wrapper.rs](https://github.com/xmtp/libxmtp/pull/1898/files#diff-81637b4ff5b1435723103d8476cf8db1c8db20746454711eb4b908f0ac431434) which contains the core debug wrapper functionality and trait implementations.

----

_[Macroscope](https://app.macroscope.com) summarized 9c4510e._