### PR TITLE
Set intent state to processed

### DIFF
--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -562,6 +562,7 @@ where
             }
         } else if let Some(id) = crate::utils::id::calculate_message_id_for_intent(intent)? {
             conn.set_delivery_status_to_published(&id, envelope_timestamp_ns)?;
+            return Ok(IntentState::Processed);
         }
 
         Ok(IntentState::Committed)


### PR DESCRIPTION
## The Problem

When you are streaming messages from a conversation at the same time you are publishing them, a race condition can lead to the message already being processed before the sync completes. That leads to a `MessageProcessingError` for a message that was actually successful if we try to set it to `IntentState::Committed`. That's because we can only transition to the `Committed` state from `Published`, but not from `Processed` (which would be an invalid state transition).

This error prevents us from moving the cursor forward and might have other side-effects.

## Solution
For application messages, just got directly to `Processed` without a stop in `Committed`.