### PR TITLE
[d14n] newClientEnvelopes endpoint, fix extracting from Vec<Envelope>

### DIFF
--- a/dev/docker/docker-compose-d14n.yml
+++ b/dev/docker/docker-compose-d14n.yml
@@ -14,7 +14,7 @@ services:
     image: ghcr.io/xmtp/contracts:sha-85dc71a
   register-node:
     platform: linux/amd64
-    image: ghcr.io/xmtp/xmtpd-cli:sha-457eff4
+    image: ghcr.io/xmtp/xmtpd-cli:sha-7f034a1
     env_file:
       - local.env
     command: ["register-node", "--http-address=${REGISTER_NODE_HTTP_ADDRESS}", "--node-owner-address=${REGISTER_NODE_OWNER_ADDRESS}", "--admin.private-key=${REGISTER_NODE_ADMIN_KEY}", "--node-signing-key-pub=${REGISTER_NODE_PUBKEY}"]
@@ -24,7 +24,7 @@ services:
     restart: on-failure
   enable-node:
     platform: linux/amd64
-    image: ghcr.io/xmtp/xmtpd-cli:sha-457eff4
+    image: ghcr.io/xmtp/xmtpd-cli:sha-7f034a1
     env_file:
       - local.env
     command: ["add-node-to-network", "--admin.private-key=${REGISTER_NODE_ADMIN_KEY}", "--node-id=100"]
@@ -36,7 +36,7 @@ services:
     restart: on-failure
   repnode:
     platform: linux/amd64
-    image: ghcr.io/xmtp/xmtpd:sha-457eff4
+    image: ghcr.io/xmtp/xmtpd:sha-7f034a1
     env_file:
       - local.env
     depends_on:
@@ -47,4 +47,3 @@ services:
     ports:
       - 5050:5050
       - 5055:5055
-

--- a/xmtp_api_d14n/src/endpoints/d14n/get_newest_envelopes.rs
+++ b/xmtp_api_d14n/src/endpoints/d14n/get_newest_envelopes.rs
@@ -1,0 +1,70 @@
+use derive_builder::Builder;
+use prost::Message;
+use prost::bytes::Bytes;
+use std::borrow::Cow;
+use xmtp_proto::traits::{BodyError, Endpoint};
+use xmtp_proto::xmtp::xmtpv4::message_api::FILE_DESCRIPTOR_SET;
+use xmtp_proto::xmtp::xmtpv4::message_api::{GetNewestEnvelopeRequest, GetNewestEnvelopeResponse};
+
+/// Query a single thing
+#[derive(Debug, Builder, Default, Clone)]
+#[builder(build_fn(error = "BodyError"))]
+pub struct GetNewestEnvelopes {
+    #[builder(setter(each(name = "topic", into)))]
+    topics: Vec<Vec<u8>>,
+}
+
+impl GetNewestEnvelopes {
+    pub fn builder() -> GetNewestEnvelopesBuilder {
+        Default::default()
+    }
+}
+
+/// NOTE:insipx
+/// Will get latest message for each topic
+/// if there is no latest message, returns null in place of that message
+/// ensure ordering is not affected by this null variable, or that extractors
+/// do no unintentially skip nulls when they should preserve length.
+impl Endpoint for GetNewestEnvelopes {
+    type Output = GetNewestEnvelopeResponse;
+
+    fn http_endpoint(&self) -> Cow<'static, str> {
+        Cow::from("/mls/v2/fetch-key-packages")
+    }
+
+    fn grpc_endpoint(&self) -> Cow<'static, str> {
+        crate::path_and_query::<GetNewestEnvelopeRequest>(FILE_DESCRIPTOR_SET)
+    }
+
+    fn body(&self) -> Result<Bytes, BodyError> {
+        let query = GetNewestEnvelopeRequest {
+            topics: self.topics.clone(),
+        };
+        Ok(query.encode_to_vec().into())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use xmtp_proto::prelude::*;
+
+    #[xmtp_common::test]
+    fn test_file_descriptor() {
+        use xmtp_proto::xmtp::xmtpv4::message_api::{
+            FILE_DESCRIPTOR_SET, GetNewestEnvelopeRequest,
+        };
+        let pnq = crate::path_and_query::<GetNewestEnvelopeRequest>(FILE_DESCRIPTOR_SET);
+        println!("{}", pnq);
+    }
+
+    #[xmtp_common::test]
+    async fn get_newest_envelopes() {
+        use crate::d14n::GetNewestEnvelopes;
+
+        let client = crate::TestClient::create_local_d14n();
+        let client = client.build().await.unwrap();
+
+        let endpoint = GetNewestEnvelopes::builder().topic(vec![]).build().unwrap();
+        assert!(endpoint.query(&client).await.is_ok());
+    }
+}

--- a/xmtp_api_d14n/src/endpoints/d14n/mod.rs
+++ b/xmtp_api_d14n/src/endpoints/d14n/mod.rs
@@ -6,3 +6,6 @@ pub use query_envelopes::*;
 
 mod get_inbox_ids;
 pub use get_inbox_ids::*;
+
+mod get_newest_envelopes;
+pub use get_newest_envelopes::*;

--- a/xmtp_api_d14n/src/protocol/extractors.rs
+++ b/xmtp_api_d14n/src/protocol/extractors.rs
@@ -4,16 +4,15 @@ use xmtp_common::{RetryableError, retryable};
 use xmtp_proto::identity_v1::get_identity_updates_response::IdentityUpdateLog;
 use xmtp_proto::{ConversionError, mls_v1};
 
-use super::EnvelopeError;
+use super::{EnvelopeError, Extractor, ProtocolEnvelope};
 use super::{TopicKind, traits::EnvelopeVisitor};
-use itertools::Itertools;
 use openmls::prelude::KeyPackageVerifyError;
 use openmls::{
     framing::MlsMessageIn,
     prelude::{KeyPackageIn, ProtocolMessage, tls_codec::Deserialize},
 };
 use openmls_rust_crypto::RustCrypto;
-use std::collections::HashMap;
+use std::marker::PhantomData;
 use xmtp_proto::xmtp::identity::api::v1::get_identity_updates_request;
 use xmtp_proto::xmtp::identity::associations::IdentityUpdate;
 use xmtp_proto::xmtp::mls::api::v1::KeyPackageUpload;
@@ -26,6 +25,59 @@ use xmtp_proto::xmtp::mls::api::v1::{
 use xmtp_proto::xmtp::xmtpv4::envelopes::ClientEnvelope;
 use xmtp_proto::xmtp::xmtpv4::envelopes::UnsignedOriginatorEnvelope;
 use xmtp_proto::xmtp::xmtpv4::envelopes::client_envelope::Payload;
+
+/// Build a [`SequencedExtractor`]
+#[derive(Default)]
+pub struct SequencedExtractorBuilder<Envelope> {
+    envelopes: Vec<Envelope>,
+}
+
+impl<Envelope> SequencedExtractorBuilder<Envelope> {
+    pub fn envelopes<E>(self, envelopes: Vec<E>) -> SequencedExtractorBuilder<E> {
+        SequencedExtractorBuilder::<E> { envelopes }
+    }
+
+    pub fn build<Extractor>(self) -> SequencedExtractor<Envelope, Extractor> {
+        SequencedExtractor {
+            envelopes: self.envelopes,
+            _marker: PhantomData,
+        }
+    }
+}
+
+/// Extract data from a sequence of envelopes, preserving
+/// per-envelope data like Sequence ID
+// TODO: Could probably act on a generic of impl Iterator
+// but could be a later improvement
+pub struct SequencedExtractor<Envelope, Extractor> {
+    envelopes: Vec<Envelope>,
+    _marker: PhantomData<Extractor>,
+}
+
+impl SequencedExtractor<(), ()> {
+    pub fn builder() -> SequencedExtractorBuilder<()> {
+        SequencedExtractorBuilder::default()
+    }
+}
+
+impl<'a, Envelope, E> Extractor for SequencedExtractor<Envelope, E>
+where
+    E: Extractor + EnvelopeVisitor<'a> + Default,
+    Envelope: ProtocolEnvelope<'a>,
+    EnvelopeError: From<<E as EnvelopeVisitor<'a>>::Error>,
+{
+    type Output = Result<Vec<<E as Extractor>::Output>, EnvelopeError>;
+
+    fn get(self) -> Self::Output {
+        let mut out = Vec::with_capacity(self.envelopes.len());
+        for envelope in self.envelopes.into_iter() {
+            let mut extractor = E::default();
+            envelope.accept(&mut extractor)?;
+            out.push(extractor.get());
+        }
+        Ok(out)
+    }
+}
 
 #[derive(thiserror::Error, Debug)]
 pub enum ExtractionError {
@@ -44,16 +96,66 @@ impl RetryableError for ExtractionError {
     }
 }
 
-/// Type to extract Group and Welcome Messages from Originator Envelopes
+/// Type to extract a Welcome Message from Originator Envelopes
 #[derive(Default)]
-pub struct MessageExtractor {
+pub struct WelcomeMessageExtractor {
     originator_sequence_id: u64,
     created_ns: u64,
-    pub group_messages: Vec<mls_v1::GroupMessage>,
-    pub welcome_messages: Vec<mls_v1::WelcomeMessage>,
+    welcome_message: mls_v1::WelcomeMessage,
 }
 
-impl EnvelopeVisitor<'_> for MessageExtractor {
+impl Extractor for WelcomeMessageExtractor {
+    type Output = mls_v1::WelcomeMessage;
+
+    fn get(self) -> Self::Output {
+        self.welcome_message
+    }
+}
+
+impl EnvelopeVisitor<'_> for WelcomeMessageExtractor {
+    type Error = ConversionError;
+
+    fn visit_unsigned_originator(
+        &mut self,
+        envelope: &UnsignedOriginatorEnvelope,
+    ) -> Result<(), Self::Error> {
+        self.originator_sequence_id = envelope.originator_sequence_id;
+        self.created_ns = envelope.originator_ns as u64;
+        Ok(())
+    }
+
+    fn visit_welcome_message_v1(&mut self, message: &WelcomeMessageV1) -> Result<(), Self::Error> {
+        let message = mls_v1::welcome_message::Version::V1(mls_v1::welcome_message::V1 {
+            id: self.originator_sequence_id,
+            created_ns: self.created_ns,
+            installation_key: message.installation_key.clone(),
+            data: message.data.clone(),
+            hpke_public_key: message.hpke_public_key.clone(),
+        });
+        self.welcome_message = mls_v1::WelcomeMessage {
+            version: Some(message),
+        };
+        Ok(())
+    }
+}
+
+/// Type to extract a Group Message from Originator Envelopes
+#[derive(Default)]
+pub struct GroupMessageExtractor {
+    originator_sequence_id: u64,
+    created_ns: u64,
+    group_message: mls_v1::GroupMessage,
+}
+
+impl Extractor for GroupMessageExtractor {
+    type Output = mls_v1::GroupMessage;
+
+    fn get(self) -> Self::Output {
+        self.group_message
+    }
+}
+
+impl EnvelopeVisitor<'_> for GroupMessageExtractor {
     type Error = ConversionError;
 
     fn visit_unsigned_originator(
@@ -83,23 +185,9 @@ impl EnvelopeVisitor<'_> for MessageExtractor {
             sender_hmac: message.sender_hmac.clone(),
             should_push: message.should_push,
         });
-        self.group_messages.push(mls_v1::GroupMessage {
+        self.group_message = mls_v1::GroupMessage {
             version: Some(message),
-        });
-        Ok(())
-    }
-
-    fn visit_welcome_message_v1(&mut self, message: &WelcomeMessageV1) -> Result<(), Self::Error> {
-        let message = mls_v1::welcome_message::Version::V1(mls_v1::welcome_message::V1 {
-            id: self.originator_sequence_id,
-            created_ns: self.created_ns,
-            installation_key: message.installation_key.clone(),
-            data: message.data.clone(),
-            hpke_public_key: message.hpke_public_key.clone(),
-        });
-        self.welcome_messages.push(mls_v1::WelcomeMessage {
-            version: Some(message),
-        });
+        };
         Ok(())
     }
 }
@@ -333,37 +421,28 @@ impl EnvelopeVisitor<'_> for PayloadExtractor {
 pub struct IdentityUpdateExtractor {
     originator_sequence_id: u64,
     server_timestamp_ns: u64,
-    updates: Vec<IdentityUpdate>,
+    update: IdentityUpdate,
 }
 
+impl Extractor for IdentityUpdateExtractor {
+    type Output = (String, IdentityUpdateLog);
+
+    fn get(self) -> Self::Output {
+        (
+            self.update.inbox_id.clone(),
+            IdentityUpdateLog {
+                sequence_id: self.originator_sequence_id,
+                server_timestamp_ns: self.server_timestamp_ns,
+                update: Some(self.update),
+            },
+        )
+    }
+}
+
+/// extract an update from a single envelope
 impl IdentityUpdateExtractor {
     pub fn new() -> Self {
         Self::default()
-    }
-
-    /// All inbox ids represented by the envelopes
-    pub fn inbox_ids(&self) -> Vec<String> {
-        self.updates
-            .iter()
-            .cloned()
-            .unique_by(|u| u.inbox_id.clone())
-            .map(|u| u.inbox_id)
-            .collect()
-    }
-
-    pub fn get(self) -> HashMap<String, Vec<IdentityUpdateLog>> {
-        let mut updates = HashMap::new();
-        for update in self.updates.into_iter() {
-            updates
-                .entry(update.inbox_id.clone())
-                .or_insert_with(Vec::new)
-                .push(IdentityUpdateLog {
-                    sequence_id: self.originator_sequence_id,
-                    server_timestamp_ns: self.server_timestamp_ns,
-                    update: Some(update),
-                });
-        }
-        updates
     }
 }
 
@@ -380,7 +459,7 @@ impl EnvelopeVisitor<'_> for IdentityUpdateExtractor {
     }
 
     fn visit_identity_update(&mut self, u: &IdentityUpdate) -> Result<(), Self::Error> {
-        self.updates.push(u.clone());
+        self.update = u.clone();
         Ok(())
     }
 }

--- a/xmtp_api_d14n/src/protocol/extractors.rs
+++ b/xmtp_api_d14n/src/protocol/extractors.rs
@@ -127,6 +127,11 @@ impl EnvelopeVisitor<'_> for KeyPackageExtractor {
         Ok(())
     }
 
+    fn visit_none(&mut self) -> Result<(), Self::Error> {
+        // TODO: Handle empty key package response (when key package is None)
+        Ok(())
+    }
+
     fn visit_upload_key_package(
         &mut self,
         req: &UploadKeyPackageRequest,

--- a/xmtp_api_d14n/src/protocol/impls.rs
+++ b/xmtp_api_d14n/src/protocol/impls.rs
@@ -14,6 +14,7 @@ use xmtp_proto::xmtp::mls::api::v1::{
 use xmtp_proto::xmtp::xmtpv4::envelopes::{
     ClientEnvelope, OriginatorEnvelope, PayerEnvelope, UnsignedOriginatorEnvelope,
 };
+use xmtp_proto::xmtp::xmtpv4::message_api::get_newest_envelope_response;
 
 // enables combining arbitrary # of visitors into one, ext: process = (ValidateMessage::new(), ExtractMessage::new());
 // Therefore not re-doing deserialization for each processing step.
@@ -91,6 +92,20 @@ impl<'a> EnvelopeVisitor<'a> for Tuple {
 
     fn visit_identity_update(&mut self, u: &IdentityUpdate) -> Result<(), Self::Error> {
         for_tuples!( #( Tuple.visit_identity_update(u)?; )* );
+        Ok(())
+    }
+
+    fn visit_none(&mut self) -> Result<(), Self::Error> {
+        for_tuples!( #( Tuple.visit_none()?; )* );
+        Ok(())
+    }
+
+    /// Visit a Newest Envelope Response
+    fn visit_newest_envelope_response(
+        &mut self,
+        u: &get_newest_envelope_response::Response,
+    ) -> Result<(), Self::Error> {
+        for_tuples!( #( Tuple.visit_newest_envelope_response(u)?; )* );
         Ok(())
     }
 }

--- a/xmtp_api_d14n/src/protocol/impls.rs
+++ b/xmtp_api_d14n/src/protocol/impls.rs
@@ -110,6 +110,7 @@ impl<'a> EnvelopeVisitor<'a> for Tuple {
     }
 }
 
+// run extractors of the same type in sequence
 impl<'a, T> EnvelopeVisitor<'a> for Vec<T>
 where
     T: EnvelopeVisitor<'a>,

--- a/xmtp_api_d14n/src/protocol/traits.rs
+++ b/xmtp_api_d14n/src/protocol/traits.rs
@@ -187,6 +187,11 @@ pub trait Envelope<'env> {
     fn client_envelopes(&self) -> Result<Vec<ClientEnvelope>, EnvelopeError>;
 }
 
+pub trait Extractor {
+    type Output;
+    fn get(self) -> Self::Output;
+}
+
 /// Allows us to call these methods straight on the protobuf types without any
 /// parsing/matching first.
 impl<'env, T> Envelope<'env> for T

--- a/xmtp_api_d14n/src/protocol/traits.rs
+++ b/xmtp_api_d14n/src/protocol/traits.rs
@@ -21,6 +21,7 @@ use xmtp_proto::xmtp::xmtpv4::envelopes::client_envelope::Payload;
 use xmtp_proto::xmtp::xmtpv4::envelopes::{
     ClientEnvelope, OriginatorEnvelope, PayerEnvelope, UnsignedOriginatorEnvelope,
 };
+use xmtp_proto::xmtp::xmtpv4::message_api::get_newest_envelope_response;
 
 /// Envelope Visitor type for ergonomic handling of serialized nested envelope types.
 ///
@@ -109,11 +110,29 @@ pub trait EnvelopeVisitor<'env> {
         Ok(())
     }
 
+    /// Visit an Identity Updates Request
     fn visit_identity_updates_request(
         &mut self,
         _u: &get_identity_updates_request::Request,
     ) -> Result<(), Self::Error> {
         tracing::debug!("visit_identity_updates_request");
+        Ok(())
+    }
+
+    /// Visit an empty type in a fixed-length array
+    /// Useful is client expects a constant length between
+    /// requests and responses
+    fn visit_none(&mut self) -> Result<(), Self::Error> {
+        tracing::debug!("visit_none");
+        Ok(())
+    }
+
+    /// Visit a Newest Envelope Response
+    fn visit_newest_envelope_response(
+        &mut self,
+        _u: &get_newest_envelope_response::Response,
+    ) -> Result<(), Self::Error> {
+        tracing::debug!("visit_newest_envelope_response");
         Ok(())
     }
 }

--- a/xmtp_mls/src/identity_updates.rs
+++ b/xmtp_mls/src/identity_updates.rs
@@ -107,6 +107,7 @@ where
         to_sequence_id: Option<i64>,
     ) -> Result<AssociationState, ClientError> {
         let updates = conn.get_identity_updates(inbox_id, None, to_sequence_id)?;
+        tracing::info!("cached {:?}", updates);
         let last_sequence_id = updates
             .last()
             .ok_or::<ClientError>(AssociationError::MissingIdentityUpdate.into())?
@@ -125,8 +126,10 @@ where
 
         let unverified_updates = updates
             .into_iter()
+            // deserialize identity update payload
             .map(UnverifiedIdentityUpdate::try_from)
             .collect::<Result<Vec<UnverifiedIdentityUpdate>, AssociationError>>()?;
+        tracing::info!("UPDATES {:?}", unverified_updates);
         let updates = verify_updates(unverified_updates, &self.scw_verifier).await?;
 
         let association_state = get_state(updates)?;

--- a/xmtp_mls/src/identity_updates.rs
+++ b/xmtp_mls/src/identity_updates.rs
@@ -107,7 +107,6 @@ where
         to_sequence_id: Option<i64>,
     ) -> Result<AssociationState, ClientError> {
         let updates = conn.get_identity_updates(inbox_id, None, to_sequence_id)?;
-        tracing::info!("cached {:?}", updates);
         let last_sequence_id = updates
             .last()
             .ok_or::<ClientError>(AssociationError::MissingIdentityUpdate.into())?
@@ -129,7 +128,6 @@ where
             // deserialize identity update payload
             .map(UnverifiedIdentityUpdate::try_from)
             .collect::<Result<Vec<UnverifiedIdentityUpdate>, AssociationError>>()?;
-        tracing::info!("UPDATES {:?}", unverified_updates);
         let updates = verify_updates(unverified_updates, &self.scw_verifier).await?;
 
         let association_state = get_state(updates)?;
@@ -514,7 +512,6 @@ pub async fn load_identity_updates<ApiClient: XmtpApi>(
         .get_identity_updates_v2(filters)
         .await?
         .collect::<HashMap<_, Vec<InboxUpdate>>>();
-
     let to_store = updates
         .iter()
         .flat_map(move |(inbox_id, updates)| {


### PR DESCRIPTION
- Fetch latest key package for each installation in one query rather than in many queries
- Fix extractors, introducing `SequencedExtractor` combinator which extracts over a `Vec<>` of protocol envelopes/protobuf, and creates a new extractor for each envelope. This ensures we're not accidentally overwriting a value during the extraction, and allows extractors to be focused on just extracting from a single `OriginatorEnvelope`. `SequencedExtractor` handles envelopes and getting the expected Vec<> of results
- introduced `Extractor` trait which defines an `Output` type and a method to get the output, `fn get`. This makes it possible to create combinator types for extractors like `SequencedExtractor`
