### PR TITLE
[d14n] fix get_identity_updates_v2

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,8 @@
   "rust-analyzer.diagnostics.disabled": [
     "unlinked-file",
     "unresolved-macro-call",
-    "unresolved-proc-macro"
+    "unresolved-proc-macro",
+    "macro-error"
   ],
   "rust-analyzer.procMacro.attributes.enable": true,
   "rust-analyzer.procMacro.ignored": {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7636,6 +7636,7 @@ dependencies = [
  "futures",
  "hex",
  "impl-trait-for-tuples",
+ "itertools 0.14.0",
  "once_cell",
  "openmls",
  "openmls_rust_crypto",

--- a/xmtp_api_d14n/Cargo.toml
+++ b/xmtp_api_d14n/Cargo.toml
@@ -11,6 +11,7 @@ derive_builder.workspace = true
 futures.workspace = true
 hex.workspace = true
 impl-trait-for-tuples = "0.2"
+itertools.workspace = true
 once_cell.workspace = true
 openmls_rust_crypto = { workspace = true }
 parking_lot.workspace = true

--- a/xmtp_api_d14n/src/protocol/traits.rs
+++ b/xmtp_api_d14n/src/protocol/traits.rs
@@ -156,10 +156,12 @@ impl RetryableError for EnvelopeError {
     }
 }
 
+// TODO: Make topic type instead of bytes
+// topic not fixed length
 /// A Generic Higher-Level Envelope
 pub trait Envelope<'env> {
     /// Get the topic for an envelope
-    fn topic(&self) -> Result<Vec<Vec<u8>>, EnvelopeError>;
+    fn topics(&self) -> Result<Vec<Vec<u8>>, EnvelopeError>;
     /// Get the payload for an envelope
     fn payload(&self) -> Result<Vec<Payload>, EnvelopeError>;
     /// Build the ClientEnvelope
@@ -172,7 +174,7 @@ impl<'env, T> Envelope<'env> for T
 where
     T: ProtocolEnvelope<'env> + std::fmt::Debug,
 {
-    fn topic(&self) -> Result<Vec<Vec<u8>>, EnvelopeError> {
+    fn topics(&self) -> Result<Vec<Vec<u8>>, EnvelopeError> {
         let mut extractor = TopicExtractor::new();
         self.accept(&mut extractor)?;
         Ok(extractor.get()?)

--- a/xmtp_api_d14n/src/queries/d14n/mls.rs
+++ b/xmtp_api_d14n/src/queries/d14n/mls.rs
@@ -30,7 +30,6 @@ where
         request: mls_v1::UploadKeyPackageRequest,
     ) -> Result<(), Self::Error> {
         let envelopes = request.client_envelopes()?;
-        tracing::info!("{:?}", envelopes);
         PublishClientEnvelopes::builder()
             .envelopes(envelopes)
             .build()?

--- a/xmtp_mls/src/identity_updates.rs
+++ b/xmtp_mls/src/identity_updates.rs
@@ -87,6 +87,7 @@ where
     }
 
     /// Get the latest association state available on the network for the given `inbox_id`
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn get_latest_association_state(
         &self,
         conn: &DbConnection,
@@ -213,6 +214,7 @@ where
 
     /// Generate a `CreateInbox` signature request for the given wallet address.
     /// If no nonce is provided, use 0
+    #[tracing::instrument(level = "trace", skip_all)]
     pub async fn create_inbox(
         &self,
         identifier: Identifier,
@@ -250,6 +252,7 @@ where
     }
 
     /// Generate a `AssociateWallet` signature request using an existing wallet and a new wallet address
+    #[tracing::instrument(level = "trace", skip_all)]
     pub async fn associate_identity(
         &self,
         new_identifier: Identifier,
@@ -403,6 +406,7 @@ where
 
     /// Given two group memberships and the diff, get the list of installations that were added or removed
     /// between the two membership states.
+    #[tracing::instrument(level = "trace", skip_all)]
     pub async fn get_installation_diff(
         &self,
         conn: &DbConnection,
@@ -483,7 +487,7 @@ where
 
 /// For the given list of `inbox_id`s get all updates from the network that are newer than the last known `sequence_id`,
 /// write them in the db, and return the updates
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(level = "debug", skip_all)]
 pub async fn load_identity_updates<ApiClient: XmtpApi>(
     api_client: &ApiClientWrapper<ApiClient>,
     conn: &DbConnection,

--- a/xmtp_proto/src/convert.rs
+++ b/xmtp_proto/src/convert.rs
@@ -102,7 +102,7 @@ impl TryFrom<OriginatorEnvelope> for IdentityUpdateLog {
                 return Err(ConversionError::Missing {
                     item: "identity_update",
                     r#type: std::any::type_name::<OriginatorEnvelope>(),
-                })
+                });
             }
         };
 


### PR DESCRIPTION
### Refactor identity updates processing in XMTP API to fix `get_identity_updates_v2` by introducing `IdentityUpdateExtractor` and updating envelope topic handling
* Introduces new `IdentityUpdateExtractor` struct in [extractors.rs](https://github.com/xmtp/libxmtp/pull/1911/files#diff-d2d7968b9b5a923564614e2886371f572dc90e4e480488d964ac876049eb5421) to handle identity update processing
* Renames `topic()` to `topics()` in `Envelope` trait to support multiple topics in [traits.rs](https://github.com/xmtp/libxmtp/pull/1911/files#diff-297e793d7f5174ff592f761aaec88158d67dc19a5e749b1b11f6f9cc87e3c14b)
* Refactors `get_identity_updates_v2` in [identity.rs](https://github.com/xmtp/libxmtp/pull/1911/files#diff-5b79397548d278124cb5e3420f286720d3ba4bd7a6dc770535aae17f1b3682b5) to use the new extractor
* Adds tracing instrumentation to identity update methods in [identity_updates.rs](https://github.com/xmtp/libxmtp/pull/1911/files#diff-cc071a4438743ce4ec352d6294d0ca5e6343d881afd0f7d45127e70badea403d)
* Integrates `itertools 0.14.0` as a project dependency

#### 📍Where to Start
Start with the `IdentityUpdateExtractor` implementation in [extractors.rs](https://github.com/xmtp/libxmtp/pull/1911/files#diff-d2d7968b9b5a923564614e2886371f572dc90e4e480488d964ac876049eb5421), which contains the core logic for processing identity updates.

----

_[Macroscope](https://app.macroscope.com) summarized ffda214._