### PR TITLE
Update workspace Cargo.toml version of node stable release for min version api filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,7 +437,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_node"
-version = "1.2.0-dev"
+version = "1.1.6"
 dependencies = [
  "chrono",
  "futures",
@@ -463,7 +463,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_wasm"
-version = "1.2.0-dev"
+version = "1.1.6"
 dependencies = [
  "chrono",
  "console_error_panic_hook",
@@ -7434,7 +7434,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api"
-version = "1.2.0-dev"
+version = "1.1.6"
 dependencies = [
  "async-trait",
  "ctor",
@@ -7452,7 +7452,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_d14n"
-version = "1.2.0-dev"
+version = "1.1.6"
 dependencies = [
  "async-trait",
  "ctor",
@@ -7474,7 +7474,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_grpc"
-version = "1.2.0-dev"
+version = "1.1.6"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7496,7 +7496,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_http"
-version = "1.2.0-dev"
+version = "1.1.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7519,7 +7519,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_cli"
-version = "1.2.0-dev"
+version = "1.1.6"
 dependencies = [
  "chrono",
  "clap",
@@ -7553,7 +7553,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_common"
-version = "1.2.0-dev"
+version = "1.1.6"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -7587,7 +7587,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_content_types"
-version = "1.2.0-dev"
+version = "1.1.6"
 dependencies = [
  "hex",
  "libsecp256k1",
@@ -7605,7 +7605,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_cryptography"
-version = "1.2.0-dev"
+version = "1.1.6"
 dependencies = [
  "bincode",
  "curve25519-dalek",
@@ -7633,7 +7633,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_db"
-version = "1.2.0-dev"
+version = "1.1.6"
 dependencies = [
  "bincode",
  "derive_builder",
@@ -7664,7 +7664,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_id"
-version = "1.2.0-dev"
+version = "1.1.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7701,7 +7701,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_macro"
-version = "1.2.0-dev"
+version = "1.1.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7712,7 +7712,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_mls"
-version = "1.2.0-dev"
+version = "1.1.6"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -7780,7 +7780,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_proto"
-version = "1.2.0-dev"
+version = "1.1.6"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -7805,7 +7805,7 @@ dependencies = [
 
 [[package]]
 name = "xmtpv3"
-version = "1.2.0-dev"
+version = "1.1.6"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ resolver = "2"
 
 [workspace.package]
 license = "MIT"
-version = "1.2.0-dev"
+version = "1.1.6"
 
 [workspace.dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
### Update XMTP workspace and package versions from `1.2.0-dev` to `1.1.6` for minimum version API filtering
Updates version numbers across the XMTP ecosystem in:
* [Cargo.toml](https://github.com/xmtp/libxmtp/pull/1913/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542) - Workspace package version change
* [Cargo.lock](https://github.com/xmtp/libxmtp/pull/1913/files#diff-13ee4b2252c9e516a0547f2891aa2105c3ca71c6d7a1e682c69be97998dfc87e) - Version updates for 16 XMTP packages including `bindings_node`, `xmtp_api`, `xmtp_cli`, and related dependencies

#### 📍Where to Start
Begin review with the workspace version update in [Cargo.toml](https://github.com/xmtp/libxmtp/pull/1913/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542), followed by the package version changes in [Cargo.lock](https://github.com/xmtp/libxmtp/pull/1913/files#diff-13ee4b2252c9e516a0547f2891aa2105c3ca71c6d7a1e682c69be97998dfc87e)

----

_[Macroscope](https://app.macroscope.com) summarized 72c6a4c._