### PR TITLE
Update workspace Cargo.toml version of wasm stable release for min version api filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_node"
-version = "1.2.0-dev"
+version = "1.1.7"
 dependencies = [
  "chrono",
  "futures",
@@ -452,7 +452,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_wasm"
-version = "1.2.0-dev"
+version = "1.1.7"
 dependencies = [
  "chrono",
  "console_error_panic_hook",
@@ -7608,7 +7608,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api"
-version = "1.2.0-dev"
+version = "1.1.7"
 dependencies = [
  "async-trait",
  "ctor",
@@ -7628,7 +7628,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_d14n"
-version = "1.2.0-dev"
+version = "1.1.7"
 dependencies = [
  "async-trait",
  "ctor",
@@ -7650,7 +7650,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_grpc"
-version = "1.2.0-dev"
+version = "1.1.7"
 dependencies = [
  "async-trait",
  "futures",
@@ -7667,7 +7667,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_http"
-version = "1.2.0-dev"
+version = "1.1.7"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7691,7 +7691,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_cli"
-version = "1.2.0-dev"
+version = "1.1.7"
 dependencies = [
  "chrono",
  "clap",
@@ -7724,7 +7724,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_common"
-version = "1.2.0-dev"
+version = "1.1.7"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7757,7 +7757,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_content_types"
-version = "1.2.0-dev"
+version = "1.1.7"
 dependencies = [
  "prost",
  "serde",
@@ -7771,7 +7771,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_cryptography"
-version = "1.2.0-dev"
+version = "1.1.7"
 dependencies = [
  "bincode",
  "curve25519-dalek",
@@ -7799,7 +7799,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_db"
-version = "1.2.0-dev"
+version = "1.1.7"
 dependencies = [
  "bincode",
  "derive_builder",
@@ -7832,7 +7832,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_id"
-version = "1.2.0-dev"
+version = "1.1.7"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7868,7 +7868,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_macro"
-version = "1.2.0-dev"
+version = "1.1.7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7879,7 +7879,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_mls"
-version = "1.2.0-dev"
+version = "1.1.7"
 dependencies = [
  "aes-gcm",
  "async-compression",
@@ -7947,7 +7947,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_proto"
-version = "1.2.0-dev"
+version = "1.1.7"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -7971,7 +7971,7 @@ dependencies = [
 
 [[package]]
 name = "xmtpv3"
-version = "1.2.0-dev"
+version = "1.1.7"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ resolver = "2"
 
 [workspace.package]
 license = "MIT"
-version = "1.2.0-dev"
+version = "1.1.7"
 
 [workspace.dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
### Downgrade workspace and package versions from `1.2.0-dev` to `1.1.7` for min version API filtering
Updates version numbers across the XMTP ecosystem in:
* [Cargo.toml](https://github.com/xmtp/libxmtp/pull/1914/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542) - Workspace package version downgraded
* [Cargo.lock](https://github.com/xmtp/libxmtp/pull/1914/files#diff-13ee4b2252c9e516a0547f2891aa2105c3ca71c6d7a1e682c69be97998dfc87e) - Version changes for 16 XMTP packages including `bindings_node`, `bindings_wasm`, `xmtp_api` and related packages

#### 📍Where to Start
Begin review with the workspace version change in [Cargo.toml](https://github.com/xmtp/libxmtp/pull/1914/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542), followed by the package version updates in [Cargo.lock](https://github.com/xmtp/libxmtp/pull/1914/files#diff-13ee4b2252c9e516a0547f2891aa2105c3ca71c6d7a1e682c69be97998dfc87e)

----

_[Macroscope](https://app.macroscope.com) summarized 6567319._