### PR TITLE
raw_query_write for load_from_store

### DIFF
--- a/xmtp_db/src/encrypted_store/group.rs
+++ b/xmtp_db/src/encrypted_store/group.rs
@@ -384,7 +384,7 @@ impl DbConnection {
             .order(dsl::created_at_ns.asc())
             .filter(dsl::welcome_id.eq(welcome_id));
 
-        let groups = self.raw_query_read(|conn| query.load(conn))?;
+        let groups = self.raw_query_write(|conn| query.load(conn))?;
 
         if groups.len() > 1 {
             tracing::warn!(


### PR DESCRIPTION
### Add raw query write capability for load_from_store functionality in encrypted store group handling
The changes appear to be related to the encrypted store group functionality in [group.rs](https://github.com/xmtp/libxmtp/pull/1923/files#diff-e3d4940853a1045db514d5c1a48581d9ef53da4ba45a7cb8387c72c99c475b5a), though no functional changes are visible in the provided diff section. The code shown includes the `find_groups` method implementation and SQL query handling for group management.

#### 📍Where to Start
Begin reviewing the changes in the `DbConnection` implementation within [group.rs](https://github.com/xmtp/libxmtp/pull/1923/files#diff-e3d4940853a1045db514d5c1a48581d9ef53da4ba45a7cb8387c72c99c475b5a), particularly focusing on the `find_groups` method.

----

_[Macroscope](https://app.macroscope.com) summarized eaf73fe._