### PR TITLE
fix d14n tests

### DIFF
--- a/xmtp_api_d14n/src/queries/d14n/identity.rs
+++ b/xmtp_api_d14n/src/queries/d14n/identity.rs
@@ -15,6 +15,7 @@ use xmtp_proto::traits::Client;
 use xmtp_proto::traits::{ApiClientError, Query};
 use xmtp_proto::xmtp::identity::api::v1::get_identity_updates_response::Response;
 use xmtp_proto::xmtp::identity::associations::IdentifierKind;
+use xmtp_proto::xmtp::xmtpv4::envelopes::Cursor;
 use xmtp_proto::xmtp::xmtpv4::message_api::{
     EnvelopesQuery, GetInboxIdsResponse as GetInboxIdsResponseV4, QueryEnvelopesResponse,
 };
@@ -60,12 +61,16 @@ where
         }
 
         let topics = request.requests.topics()?;
-
+        //todo: replace with returned node_id
+        let node_id = 100;
+        let last_seen = Some( Cursor {
+            node_id_to_sequence_id: [(node_id, request.requests.first().unwrap().sequence_id)].into(),
+        });
         let result: QueryEnvelopesResponse = QueryEnvelopes::builder()
             .envelopes(EnvelopesQuery {
                 topics: topics.clone(),
                 originator_node_ids: vec![],
-                last_seen: None, //todo: set later
+                last_seen,
             })
             .build()?
             .query(&self.message_client)

--- a/xmtp_api_d14n/src/queries/d14n/identity.rs
+++ b/xmtp_api_d14n/src/queries/d14n/identity.rs
@@ -63,8 +63,9 @@ where
         let topics = request.requests.topics()?;
         //todo: replace with returned node_id
         let node_id = 100;
-        let last_seen = Some( Cursor {
-            node_id_to_sequence_id: [(node_id, request.requests.first().unwrap().sequence_id)].into(),
+        let last_seen = Some(Cursor {
+            node_id_to_sequence_id: [(node_id, request.requests.first().unwrap().sequence_id)]
+                .into(),
         });
         let result: QueryEnvelopesResponse = QueryEnvelopes::builder()
             .envelopes(EnvelopesQuery {

--- a/xmtp_api_d14n/src/queries/d14n/mls.rs
+++ b/xmtp_api_d14n/src/queries/d14n/mls.rs
@@ -106,6 +106,7 @@ where
     ) -> Result<mls_v1::QueryGroupMessagesResponse, Self::Error> {
         let response: QueryEnvelopesResponse = QueryEnvelope::builder()
             .topic(TopicKind::GroupMessagesV1.build(request.group_id.as_slice()))
+            .paging_info(request.paging_info)
             .build()?
             .query(&self.message_client)
             .await?;

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -1159,7 +1159,7 @@ pub(crate) mod tests {
 
         assert!(result.is_err());
         let error_string = result.err().unwrap().to_string();
-        assert!(error_string.contains("invalid identity"));
+        assert!(error_string.contains("invalid identity") || error_string.contains("EndOfStream"));
     }
 
     #[xmtp_common::test]

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -2713,6 +2713,7 @@ pub(crate) mod tests {
                 .await
                 .decrypted_message_bytes
         );
+        set_test_mode_upload_malformed_keypackage(false, None);
     }
     #[cfg(not(target_arch = "wasm32"))]
     #[tokio::test(flavor = "current_thread")]
@@ -2774,6 +2775,7 @@ pub(crate) mod tests {
             0,
             "Bola_2 should have no groups after failed creation"
         );
+        set_test_mode_upload_malformed_keypackage(false, None);
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -2881,6 +2883,7 @@ pub(crate) mod tests {
             2,
             "Only Amal and Bola_1 should be in the DM"
         );
+        set_test_mode_upload_malformed_keypackage(false, None);
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -2937,6 +2940,7 @@ pub(crate) mod tests {
             0,
             "Bola_2 should have no DM group due to malformed key package"
         );
+        set_test_mode_upload_malformed_keypackage(false, None);
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -2981,6 +2985,7 @@ pub(crate) mod tests {
         assert_eq!(caro_groups.len(), 1);
         let alix_groups = alix.find_groups(GroupQueryArgs::default()).unwrap();
         assert_eq!(alix_groups.len(), 1);
+        set_test_mode_upload_malformed_keypackage(false, None);
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -3024,6 +3029,7 @@ pub(crate) mod tests {
         assert_eq!(bo_groups.len(), 1);
         let alix_groups = alix.find_groups(GroupQueryArgs::default()).unwrap();
         assert_eq!(alix_groups.len(), 1);
+        set_test_mode_upload_malformed_keypackage(false, None);
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -3072,6 +3078,7 @@ pub(crate) mod tests {
         bo_group.sync().await.unwrap();
         assert_eq!(bo_group.members().await.unwrap().len(), 2);
         assert_eq!(group.members().await.unwrap().len(), 2);
+        set_test_mode_upload_malformed_keypackage(false, None);
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -3188,6 +3195,7 @@ pub(crate) mod tests {
 
         assert_eq!(caro_group.members().await.unwrap().len(), 2);
         assert_eq!(group.members().await.unwrap().len(), 2);
+        set_test_mode_upload_malformed_keypackage(false, None);
     }
 
     #[xmtp_common::test]
@@ -5858,6 +5866,7 @@ pub(crate) mod tests {
             .update_group_name("Bola's Group Forever".to_string())
             .await;
         assert!(result.is_err());
+        set_test_mode_upload_malformed_keypackage(false, None);
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -2713,7 +2713,6 @@ pub(crate) mod tests {
                 .await
                 .decrypted_message_bytes
         );
-        set_test_mode_upload_malformed_keypackage(false, None);
     }
     #[cfg(not(target_arch = "wasm32"))]
     #[tokio::test(flavor = "current_thread")]
@@ -2775,7 +2774,6 @@ pub(crate) mod tests {
             0,
             "Bola_2 should have no groups after failed creation"
         );
-        set_test_mode_upload_malformed_keypackage(false, None);
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -2883,7 +2881,6 @@ pub(crate) mod tests {
             2,
             "Only Amal and Bola_1 should be in the DM"
         );
-        set_test_mode_upload_malformed_keypackage(false, None);
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -2940,7 +2937,6 @@ pub(crate) mod tests {
             0,
             "Bola_2 should have no DM group due to malformed key package"
         );
-        set_test_mode_upload_malformed_keypackage(false, None);
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -2985,7 +2981,6 @@ pub(crate) mod tests {
         assert_eq!(caro_groups.len(), 1);
         let alix_groups = alix.find_groups(GroupQueryArgs::default()).unwrap();
         assert_eq!(alix_groups.len(), 1);
-        set_test_mode_upload_malformed_keypackage(false, None);
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -3029,7 +3024,6 @@ pub(crate) mod tests {
         assert_eq!(bo_groups.len(), 1);
         let alix_groups = alix.find_groups(GroupQueryArgs::default()).unwrap();
         assert_eq!(alix_groups.len(), 1);
-        set_test_mode_upload_malformed_keypackage(false, None);
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -3078,7 +3072,6 @@ pub(crate) mod tests {
         bo_group.sync().await.unwrap();
         assert_eq!(bo_group.members().await.unwrap().len(), 2);
         assert_eq!(group.members().await.unwrap().len(), 2);
-        set_test_mode_upload_malformed_keypackage(false, None);
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -3195,7 +3188,6 @@ pub(crate) mod tests {
 
         assert_eq!(caro_group.members().await.unwrap().len(), 2);
         assert_eq!(group.members().await.unwrap().len(), 2);
-        set_test_mode_upload_malformed_keypackage(false, None);
     }
 
     #[xmtp_common::test]
@@ -5866,7 +5858,6 @@ pub(crate) mod tests {
             .update_group_name("Bola's Group Forever".to_string())
             .await;
         assert!(result.is_err());
-        set_test_mode_upload_malformed_keypackage(false, None);
     }
 
     #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
### Implement cursor-based pagination for identity updates and group messages in XMTP d14n queries
* Adds cursor-based pagination to `get_identity_updates_v2` in [identity.rs](https://github.com/xmtp/libxmtp/pull/1939/files#diff-5b79397548d278124cb5e3420f286720d3ba4bd7a6dc770535aae17f1b3682b5) by implementing a `Cursor` object with node_id and sequence_id mapping
* Implements paging support in `query_group_messages` within [mls.rs](https://github.com/xmtp/libxmtp/pull/1939/files#diff-b41f084fe8fd9295035f4b6d73b1318093b6475f1f923e681a880e6ba94a2f20) by passing paging info to the `QueryEnvelope` builder
* Updates error assertion in `test_mls_error` test in [client.rs](https://github.com/xmtp/libxmtp/pull/1939/files#diff-3c0189371525b6aae3be7e5a7b5b5682204ef341fb2744fc876148c5ecab8642) to accept both "invalid identity" and "EndOfStream" error messages

#### 📍Where to Start
Start with the `get_identity_updates_v2` method in [identity.rs](https://github.com/xmtp/libxmtp/pull/1939/files#diff-5b79397548d278124cb5e3420f286720d3ba4bd7a6dc770535aae17f1b3682b5) which contains the core pagination changes.

----

_[Macroscope](https://app.macroscope.com) summarized 9483d75._