### PR TITLE
Node patch fix swallow stream errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,7 +437,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_node"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "chrono",
  "futures",
@@ -463,7 +463,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_wasm"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "chrono",
  "console_error_panic_hook",
@@ -7434,7 +7434,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "async-trait",
  "ctor",
@@ -7452,7 +7452,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_d14n"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "async-trait",
  "ctor",
@@ -7474,7 +7474,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_grpc"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7496,7 +7496,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_http"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7519,7 +7519,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_cli"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "chrono",
  "clap",
@@ -7553,7 +7553,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_common"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -7587,7 +7587,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_content_types"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "hex",
  "libsecp256k1",
@@ -7605,7 +7605,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_cryptography"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "bincode",
  "curve25519-dalek",
@@ -7633,7 +7633,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_db"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "bincode",
  "derive_builder",
@@ -7664,7 +7664,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_id"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7701,7 +7701,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_macro"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7712,7 +7712,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_mls"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -7780,7 +7780,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_proto"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -7805,7 +7805,7 @@ dependencies = [
 
 [[package]]
 name = "xmtpv3"
-version = "1.1.6"
+version = "1.1.8"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ resolver = "2"
 
 [workspace.package]
 license = "MIT"
-version = "1.1.6"
+version = "1.1.8"
 
 [workspace.dependencies]
 anyhow = "1.0"

--- a/bindings_node/package.json
+++ b/bindings_node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/node-bindings",
-  "version": "1.1.6",
+  "version": "1.1.8",
   "repository": {
     "type": "git",
     "url": "git+https://git@github.com/xmtp/libxmtp.git",

--- a/bindings_node/src/conversations.rs
+++ b/bindings_node/src/conversations.rs
@@ -657,15 +657,42 @@ impl Conversations {
         tracing::trace!(
             inbox_id,
             conversation_type = ?conversation_type,
-            "[received] calling tsfn callback"
+            "[received] message result"
         );
-        tsfn.call(
-          message
-            .map(Into::into)
-            .map_err(ErrorWrapper::from)
-            .map_err(Error::from),
-          ThreadsafeFunctionCallMode::Blocking,
-        );
+
+        // Skip any messages that are errors
+        if let Err(err) = &message {
+          tracing::warn!(
+            inbox_id,
+            error = ?err,
+            "[received] message error, swallowing to continue stream"
+          );
+          return; // Skip this message entirely
+        }
+
+        // For successful messages, try to transform and pass to JS
+        // otherwise log error and continue stream
+        match message
+          .map(Into::into)
+          .map_err(ErrorWrapper::from)
+          .map_err(Error::from)
+        {
+          Ok(transformed_msg) => {
+            tracing::trace!(
+              inbox_id,
+              "[received] calling tsfn callback with successful message"
+            );
+            tsfn.call(Ok(transformed_msg), ThreadsafeFunctionCallMode::Blocking);
+          }
+          Err(err) => {
+            // Just in case the transformation itself fails
+            tracing::error!(
+              inbox_id,
+              error = ?err,
+              "[received] error during message transformation, swallowing to continue stream"
+            );
+          }
+        }
       },
     );
 

--- a/bindings_wasm/package.json
+++ b/bindings_wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/wasm-bindings",
-  "version": "1.1.6",
+  "version": "1.1.8",
   "type": "module",
   "license": "MIT",
   "description": "WASM bindings for the libXMTP rust library",


### PR DESCRIPTION
### Improve error handling in `Conversations.stream_all_messages` to skip failed messages instead of swallowing stream errors
The error handling logic in [conversations.rs](https://github.com/xmtp/libxmtp/pull/1945/files#diff-305d8a9df912ee15a450791cf1af33e26798a0a4877f6a4dc457d291914bc126) has been updated to handle message streaming failures more gracefully. The changes include:

* Added explicit error checks before message transformation and callback execution
* Implemented skip behavior for failed messages instead of passing errors to JavaScript
* Enhanced logging for error scenarios with more detailed messages
* Updated version numbers from `1.1.6` to `1.1.8` across multiple package configuration files

#### 📍Where to Start
Begin reviewing the `stream_all_messages` method in [conversations.rs](https://github.com/xmtp/libxmtp/pull/1945/files#diff-305d8a9df912ee15a450791cf1af33e26798a0a4877f6a4dc457d291914bc126) which contains the core error handling changes.

----

_[Macroscope](https://app.macroscope.com) summarized 60008e9._