### PR TITLE
Get all duplicate dms for a dm

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -2284,6 +2284,18 @@ impl FfiConversation {
         let debug_info = self.inner.debug_info().await?;
         Ok(debug_info.into())
     }
+
+    pub async fn find_duplicate_dms(&self) -> Result<Vec<Arc<FfiConversation>>, GenericError> {
+        let dms = self
+            .inner
+            .client
+            .find_duplicate_dms_for_group(&self.inner.group_id)?;
+
+        let ffi_conversations: Vec<Arc<FfiConversation>> =
+            dms.into_iter().map(|dm| Arc::new(dm.into())).collect();
+
+        Ok(ffi_conversations)
+    }
 }
 
 #[uniffi::export]

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -7955,7 +7955,6 @@ mod tests {
             .await
             .unwrap();
 
-        // Force sync (in case creation and stitching logic is async-dependent)
         client_a
             .conversations()
             .sync_all_conversations(None)
@@ -7970,11 +7969,6 @@ mod tests {
         let group_a = client_a.conversation(dm1.id()).unwrap();
         let duplicates = group_a.find_duplicate_dms().await.unwrap();
 
-        // Expect at least 2 groups with the same dm_id
-        assert!(
-            duplicates.len() >= 2,
-            "Expected at least 2 duplicate DMs, found {}",
-            duplicates.len()
-        );
+        assert_eq!(duplicates.len(), 1);
     }
 }

--- a/bindings_node/src/conversation.rs
+++ b/bindings_node/src/conversation.rs
@@ -796,4 +796,18 @@ impl Conversation {
       .map(Into::into)
       .map_err(|e| napi::Error::from_reason(e.to_string()))
   }
+
+  #[napi]
+  pub async fn find_duplicate_dms(&self) -> Result<Vec<Conversation>> {
+    // Await the async call and handle errors
+    let dms = self
+      .inner_client
+      .clone()
+      .find_duplicate_dms_for_group(&self.group_id)
+      .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+
+    let conversations: Vec<Conversation> = dms.into_iter().map(Into::into).collect();
+
+    Ok(conversations)
+  }
 }

--- a/bindings_wasm/src/conversation.rs
+++ b/bindings_wasm/src/conversation.rs
@@ -688,6 +688,20 @@ impl Conversation {
 
     Ok(crate::to_value(&ConversationDebugInfo::new(debug_info))?)
   }
+
+  #[wasm_bindgen(js_name = findDuplicateDms)]
+  pub async fn find_duplicate_dms(&self) -> Result<Vec<Conversation>, JsError> {
+    // Await the async function first, then handle the error
+    let dms = self
+      .inner_client
+      .clone()
+      .find_duplicate_dms_for_group(&self.group_id)
+      .map_err(|e| JsError::new(&e.to_string()))?;
+
+    let conversations: Vec<Conversation> = dms.into_iter().map(Into::into).collect();
+
+    Ok(conversations)
+  }
 }
 
 #[cfg(test)]

--- a/xmtp_db/src/encrypted_store/group.rs
+++ b/xmtp_db/src/encrypted_store/group.rs
@@ -554,33 +554,6 @@ impl DbConnection {
 
         Ok(())
     }
-
-    pub fn find_duplicate_dms_for_group(
-        &self,
-        group_id: &Vec<u8>,
-    ) -> Result<Vec<StoredGroup>, StorageError> {
-        self.raw_query_read(|conn| {
-            let target_dm_id: Option<String> = dsl::groups
-                .filter(dsl::id.eq(group_id.as_slice()))
-                .select(dsl::dm_id)
-                .first::<Option<String>>(conn)
-                .optional()?
-                .flatten();
-
-            match target_dm_id {
-                Some(dm_id) => {
-                    // Fetch all groups with the same dm_id and type Dm
-                    let results = dsl::groups
-                        .filter(dsl::conversation_type.eq(ConversationType::Dm))
-                        .filter(dsl::dm_id.eq(dm_id))
-                        .load::<StoredGroup>(conn)?;
-
-                    Ok(results)
-                }
-                None => Ok(vec![]),
-            }
-        })
-    }
 }
 
 #[repr(i32)]
@@ -1068,53 +1041,5 @@ pub(crate) mod tests {
             100,
             GroupMembershipState::Allowed,
         );
-    }
-
-    #[xmtp_common::test]
-    async fn test_find_duplicate_dms_returns_expected_groups() {
-        with_connection_async(|conn| async move {
-            let shared_dm_id = "dm:alice:bob".to_string();
-
-            let dm1 = StoredGroup::builder()
-                .id(rand_vec::<24>())
-                .created_at_ns(now_ns())
-                .membership_state(GroupMembershipState::Allowed)
-                .added_by_inbox_id("test_addr")
-                .dm_id(Some(shared_dm_id.clone()))
-                .conversation_type(ConversationType::Dm)
-                .build()
-                .unwrap();
-
-            let dm2 = StoredGroup::builder()
-                .id(rand_vec::<24>())
-                .created_at_ns(now_ns())
-                .membership_state(GroupMembershipState::Allowed)
-                .added_by_inbox_id("test_addr")
-                .dm_id(Some(shared_dm_id.clone()))
-                .conversation_type(ConversationType::Dm)
-                .build()
-                .unwrap();
-
-            // Also add a unique DM (should not be returned)
-            let unique_dm = StoredGroup::builder()
-                .id(rand_vec::<24>())
-                .created_at_ns(now_ns())
-                .membership_state(GroupMembershipState::Allowed)
-                .added_by_inbox_id("test_addr")
-                .dm_id(Some("dm:charlie:dana".to_string()))
-                .conversation_type(ConversationType::Dm)
-                .build()
-                .unwrap();
-
-            dm1.store(&conn).unwrap();
-            dm2.store(&conn).unwrap();
-            unique_dm.store(&conn).unwrap();
-
-            let duplicates = conn.find_duplicate_dms_for_group(&dm1.id).unwrap();
-            assert_eq!(duplicates.len(), 2);
-            let no_duplicates = conn.find_duplicate_dms_for_group(&unique_dm.id).unwrap();
-            assert_eq!(no_duplicates.len(), 1);
-        })
-        .await
     }
 }

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -681,7 +681,7 @@ where
         group_id: &[u8],
     ) -> Result<Vec<MlsGroup<Self>>, ClientError> {
         let conn = self.context().store().conn()?;
-        let duplicates = conn.other_dms(&group_id.to_vec())?;
+        let duplicates = conn.other_dms(group_id)?;
 
         let mls_groups = duplicates
             .into_iter()

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -675,6 +675,22 @@ where
             .map_err(Into::into)
     }
 
+    /// Find all the duplicate dms for this group
+    pub fn find_duplicate_dms_for_group(
+        &self,
+        group_id: &[u8],
+    ) -> Result<Vec<MlsGroup<Self>>, ClientError> {
+        let conn = self.context().store().conn()?;
+        let duplicates = conn.find_duplicate_dms_for_group(&group_id.to_vec())?;
+
+        let mls_groups = duplicates
+            .into_iter()
+            .map(|g| MlsGroup::new(self.clone(), g.id, g.created_at_ns))
+            .collect();
+
+        Ok(mls_groups)
+    }
+
     /// Fetches the message disappearing settings for a given group ID.
     ///
     /// Returns `Some(MessageDisappearingSettings)` if the group exists and has valid settings,

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -681,7 +681,7 @@ where
         group_id: &[u8],
     ) -> Result<Vec<MlsGroup<Self>>, ClientError> {
         let conn = self.context().store().conn()?;
-        let duplicates = conn.find_duplicate_dms_for_group(&group_id.to_vec())?;
+        let duplicates = conn.other_dms(&group_id.to_vec())?;
 
         let mls_groups = duplicates
             .into_iter()


### PR DESCRIPTION
Enables the ability to get all the topics for a dm.

Part of https://github.com/xmtp/libxmtp/issues/1499