### PR TITLE
fix http stream

### DIFF
--- a/xmtp_api_http/src/lib.rs
+++ b/xmtp_api_http/src/lib.rs
@@ -580,8 +580,7 @@ pub mod tests {
             .contains("invalid identity"));
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[xmtp_common::test]
     async fn test_get_inbox_ids() {
         use xmtp_proto::xmtp::identity::api::v1::{
             get_inbox_ids_request::Request, GetInboxIdsRequest,

--- a/xmtp_mls/src/groups/summary.rs
+++ b/xmtp_mls/src/groups/summary.rs
@@ -151,7 +151,6 @@ impl MessageIdentifier {
 #[derive(Default)]
 pub struct ProcessSummary {
     pub total_messages: Vec<u64>,
-    /// vector of ids
     pub new_messages: Vec<MessageIdentifier>,
     pub errored: Vec<(u64, GroupMessageProcessingError)>,
 }

--- a/xmtp_mls/src/subscriptions/mod.rs
+++ b/xmtp_mls/src/subscriptions/mod.rs
@@ -225,7 +225,7 @@ where
         match future.process().await? {
             ProcessWelcomeResult::New { group, .. } => Ok(group),
             ProcessWelcomeResult::NewStored { group, .. } => Ok(group),
-            ProcessWelcomeResult::IgnoreId { .. } => {
+            ProcessWelcomeResult::IgnoreId { .. } | ProcessWelcomeResult::Ignore => {
                 Err(stream_conversations::ConversationStreamError::InvalidConversationType.into())
             }
         }

--- a/xmtp_mls/src/subscriptions/mod.rs
+++ b/xmtp_mls/src/subscriptions/mod.rs
@@ -8,7 +8,9 @@ use xmtp_id::scw_verifier::SmartContractSignatureVerifier;
 use xmtp_proto::{api_client::XmtpMlsStreams, xmtp::mls::api::v1::WelcomeMessage};
 
 use stream_all::StreamAllMessages;
-use stream_conversations::{ProcessWelcomeFuture, StreamConversations, WelcomeOrGroup};
+use stream_conversations::{
+    ProcessWelcomeFuture, ProcessWelcomeResult, StreamConversations, WelcomeOrGroup,
+};
 
 mod stream_all;
 mod stream_conversations;
@@ -220,13 +222,13 @@ where
             WelcomeOrGroup::Welcome(envelope),
             None,
         )?;
-        future
-            .process()
-            .await?
-            .map(|(group, _)| group)
-            .ok_or_else(|| {
-                stream_conversations::ConversationStreamError::InvalidConversationType.into()
-            })
+        match future.process().await? {
+            ProcessWelcomeResult::New { group, .. } => Ok(group),
+            ProcessWelcomeResult::NewStored { group, .. } => Ok(group),
+            ProcessWelcomeResult::IgnoreId { .. } => {
+                Err(stream_conversations::ConversationStreamError::InvalidConversationType.into())
+            }
+        }
     }
 
     #[tracing::instrument(level = "debug", skip_all)]

--- a/xmtp_mls/src/subscriptions/stream_all.rs
+++ b/xmtp_mls/src/subscriptions/stream_all.rs
@@ -628,14 +628,13 @@ mod tests {
                 .group_list
                 .get(group.group_id.as_slice())
                 .unwrap();
-            assert!(*cursor > 0.into());
+            assert!(*cursor > 1.into());
         }
-        /*
+
         eve_group
             .send_message(b"decryptable message")
             .await
             .unwrap();
         assert_msg!(s, "decryptable message");
-        */
     }
 }

--- a/xmtp_mls/src/subscriptions/stream_all.rs
+++ b/xmtp_mls/src/subscriptions/stream_all.rs
@@ -630,10 +630,12 @@ mod tests {
                 .unwrap();
             assert!(*cursor > 0.into());
         }
+        /*
         eve_group
             .send_message(b"decryptable message")
             .await
             .unwrap();
         assert_msg!(s, "decryptable message");
+        */
     }
 }

--- a/xmtp_mls/src/subscriptions/stream_all.rs
+++ b/xmtp_mls/src/subscriptions/stream_all.rs
@@ -154,7 +154,6 @@ mod tests {
     use futures::StreamExt;
     use std::sync::Arc;
     use std::time::Duration;
-    use tokio::time::sleep;
 
     use xmtp_cryptography::utils::generate_local_wallet;
     use xmtp_id::associations::test_utils::WalletTestExt;
@@ -334,7 +333,7 @@ mod tests {
 
     #[rstest::rstest]
     #[xmtp_common::test]
-    #[timeout(Duration::from_secs(15))]
+    #[timeout(Duration::from_secs(60))]
     #[cfg_attr(target_arch = "wasm32", ignore)]
     async fn test_stream_all_messages_does_not_lose_messages() {
         let mut replace = xmtp_common::InboxIdReplace::default();
@@ -405,7 +404,11 @@ mod tests {
         });
 
         let mut messages = Vec::new();
-        let timeout = Duration::from_secs(10);
+        let timeout = if cfg!(target_arch = "wasm32") {
+            Duration::from_secs(20)
+        } else {
+            Duration::from_secs(10)
+        };
         loop {
             tokio::select! {
                 Some(msg) = stream.next() => {
@@ -417,7 +420,6 @@ mod tests {
                     }
                 },
                 _ = xmtp_common::time::sleep(timeout) => break
-
             }
         }
 
@@ -426,11 +428,6 @@ mod tests {
             .map(|m| String::from_utf8_lossy(m.decrypted_message_bytes.as_slice()).to_string())
             .collect::<Vec<String>>();
         let duplicates = find_duplicates_with_count(msgs);
-        /*
-        for message in messages.iter() {
-            let m = String::from_utf8_lossy(message.decrypted_message_bytes.as_slice());
-            tracing::info!("{}", m);
-        }*/
         assert!(duplicates.is_empty());
         assert_eq!(messages.len(), 45, "too many messages mean duplicates, too little means missed. Also ensure timeout is sufficient.");
     }
@@ -496,7 +493,6 @@ mod tests {
     #[xmtp_common::test]
     #[timeout(Duration::from_secs(20))]
     #[cfg_attr(target_arch = "wasm32", ignore)]
-    #[ignore]
     async fn test_stream_all_messages_filters_by_consent_state(
         #[case] filter: ConsentState,
         #[case] expected_message: &str,
@@ -539,7 +535,7 @@ mod tests {
 
         let provider = sender.mls_provider().unwrap();
         sender.sync_welcomes(&provider).await.unwrap();
-        sleep(Duration::from_millis(100)).await;
+        xmtp_common::time::sleep(Duration::from_millis(100)).await;
 
         let stream = sender
             .stream_all_messages(None, Some(vec![filter]))
@@ -588,20 +584,20 @@ mod tests {
         let eve_group = eve_groups.first().unwrap();
         group.sync().await.unwrap();
         // get the group epoch to 28
-        for _ in 0..14 {
+        for _ in 0..7 {
             group
                 .update_group_name(format!("test name {}", xmtp_common::rand_string::<5>()))
                 .await
                 .unwrap();
         }
-        for _ in 0..100 {
+        for _ in 0..25 {
             eve_group
                 .send_message(format!("message {}", xmtp_common::rand_string::<5>()).as_bytes())
                 .await
                 .unwrap();
         }
         // get the group epoch to 28
-        for _ in 0..14 {
+        for _ in 0..7 {
             group
                 .update_group_name(format!("test name {}", xmtp_common::rand_string::<5>()))
                 .await

--- a/xmtp_mls/src/subscriptions/stream_conversations.rs
+++ b/xmtp_mls/src/subscriptions/stream_conversations.rs
@@ -677,7 +677,7 @@ mod test {
         // It should NOT appear in the stream
         let result =
             xmtp_common::time::timeout(std::time::Duration::from_millis(100), stream.next()).await;
-
+        // tracing::error!("{:?}", result);
         assert!(result.is_err(), "Duplicate DM was unexpectedly streamed");
     }
 }

--- a/xmtp_mls/src/subscriptions/stream_conversations.rs
+++ b/xmtp_mls/src/subscriptions/stream_conversations.rs
@@ -142,7 +142,7 @@ pin_project! {
         /// State that indicates the stream is waiting on a IO/Network future to finish processing the current message
         /// before moving on to the next one
         Processing {
-            #[pin] future: FutureWrapper<'a, Result<Option<(MlsGroup<C>, Option<i64>)>>>
+            #[pin] future: FutureWrapper<'a, Result<ProcessWelcomeResult<C>>>
         }
     }
 }
@@ -252,6 +252,18 @@ where
     }
 }
 
+pub enum ProcessWelcomeResult<C> {
+    /// New Group and welcome id
+    New { group: MlsGroup<C>, id: i64 },
+    /// A group we already have/we created that might not have a welcome id
+    NewStored {
+        group: MlsGroup<C>,
+        maybe_id: Option<i64>,
+    },
+    /// Skip this welcome but add and id to known welcome ids
+    IgnoreId { id: i64 },
+}
+
 impl<'a, C, Subscription> StreamConversations<'a, C, Subscription>
 where
     C: ScopedGroupClient + Clone + 'a,
@@ -261,31 +273,45 @@ where
     #[allow(clippy::type_complexity)]
     fn try_process(
         mut self: Pin<&mut Self>,
-        poll: Poll<Result<Option<(MlsGroup<C>, Option<i64>)>>>,
+        poll: Poll<Result<ProcessWelcomeResult<C>>>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<<Self as Stream>::Item>> {
         use Poll::*;
         let mut this = self.as_mut().project();
         match poll {
-            Ready(Ok(Some((group, welcome_id)))) => {
+            Ready(Ok(ProcessWelcomeResult::New {
+                group,
+                id: welcome_id,
+            })) => {
                 tracing::debug!(
                     group_id = hex::encode(&group.group_id),
                     "finished processing with group {}",
                     hex::encode(&group.group_id)
                 );
-                if let Some(id) = welcome_id {
-                    this.known_welcome_ids.insert(id);
-                }
+                this.known_welcome_ids.insert(welcome_id);
                 this.state.set(ProcessState::Waiting);
                 Ready(Some(Ok(group)))
             }
-            // we are ignoring this payload
-            Ready(Ok(None)) => {
-                tracing::debug!("ignoring this payload");
+            // we are ignoring this payload with id
+            Ready(Ok(ProcessWelcomeResult::IgnoreId { id })) => {
+                tracing::debug!("ignoring streamed conversation payload with welcome id {id}");
+                this.known_welcome_ids.insert(id);
                 this.state.as_mut().set(ProcessState::Waiting);
                 // we have to re-ad this task to the queue
                 // to let http know we are waiting on the next item
                 self.poll_next(cx)
+            }
+            Ready(Ok(ProcessWelcomeResult::NewStored { group, maybe_id })) => {
+                tracing::debug!(
+                    group_id = hex::encode(&group.group_id),
+                    "finished processing with group {}",
+                    hex::encode(&group.group_id)
+                );
+                if let Some(id) = maybe_id {
+                    this.known_welcome_ids.insert(id);
+                }
+                this.state.set(ProcessState::Waiting);
+                Ready(Some(Ok(group)))
             }
             Ready(Err(e)) => {
                 this.state.as_mut().set(ProcessState::Waiting);
@@ -346,12 +372,13 @@ where
 {
     /// Process the welcome. if its a group, create the group and return it.
     #[tracing::instrument(skip_all)]
-    pub async fn process(self) -> Result<Option<(MlsGroup<C>, Option<i64>)>> {
+    pub async fn process(self) -> Result<ProcessWelcomeResult<C>> {
         use WelcomeOrGroup::*;
-        let (group, welcome_id) = match self.item {
+        let process_result = match self.item {
             Welcome(ref w) => {
                 let welcome = extract_welcome_message(w)?;
                 let id = welcome.id as i64;
+                tracing::debug!("got welcome with id {}", id);
                 // try to load it from store first and avoid overhead
                 // of processing a welcome & erroring
                 // for immediate return, this must stay in the top-level future,
@@ -360,52 +387,51 @@ where
                     tracing::debug!(
                         "Found existing welcome. Returning from db & skipping processing"
                     );
-                    let (group, id) = self.load_from_store(id).map(|(g, v)| (g, Some(v)))?;
-                    let metadata = group.metadata(&self.provider).await?;
-
-                    // If it's a duplicate DM, don't stream
-                    if metadata.conversation_type == ConversationType::Dm
-                        && self.provider.conn_ref().has_duplicate_dm(&group.group_id)?
-                    {
-                        tracing::debug!(
-                            "Duplicate DM group detected from welcome. Skipping stream."
-                        );
-                        return Ok(None);
-                    }
-
-                    return Ok(self
-                        .conversation_type
-                        .is_none_or(|ct| ct == metadata.conversation_type)
-                        .then_some((group, id)));
+                    let (group, id) = self.load_from_store(id)?;
+                    return self.filter(ProcessWelcomeResult::New { group, id }).await;
                 }
-
                 let (group, id) = self.on_welcome(welcome).await?;
-                (group, Some(id))
+                ProcessWelcomeResult::New { group, id }
             }
-            Group(id) => {
+            Group(ref id) => {
                 tracing::debug!("Stream conversations got existing group, pulling from db.");
                 let (group, stored_group) =
-                    MlsGroup::new_validated(self.client, id, &self.provider)?;
+                    MlsGroup::new_validated(self.client.clone(), id.to_vec(), &self.provider)?;
 
+                ProcessWelcomeResult::NewStored {
+                    group,
+                    maybe_id: stored_group.welcome_id,
+                }
+            }
+        };
+        self.filter(process_result).await
+    }
+
+    /// Filter for streamed conversations
+    async fn filter(&self, processed: ProcessWelcomeResult<C>) -> Result<ProcessWelcomeResult<C>> {
+        use ProcessWelcomeResult::*;
+        match processed {
+            New { group, id } => {
                 let metadata = group.metadata(&self.provider).await?;
-
                 // If it's a duplicate DM, don’t stream
                 if metadata.conversation_type == ConversationType::Dm
                     && self.provider.conn_ref().has_duplicate_dm(&group.group_id)?
                 {
                     tracing::debug!("Duplicate DM group detected from Group(id). Skipping stream.");
-                    return Ok(None);
+                    return Ok(ProcessWelcomeResult::IgnoreId { id });
                 }
 
-                (group, stored_group.welcome_id)
+                if self
+                    .conversation_type
+                    .is_none_or(|ct| ct == metadata.conversation_type)
+                {
+                    return Ok(ProcessWelcomeResult::New { group, id });
+                } else {
+                    return Ok(ProcessWelcomeResult::IgnoreId { id });
+                }
             }
-        };
-
-        let metadata = group.metadata(&self.provider).await?;
-        Ok(self
-            .conversation_type
-            .is_none_or(|ct| ct == metadata.conversation_type)
-            .then_some((group, welcome_id)))
+            other => Ok(other),
+        }
     }
 
     /// process a new welcome, returning the Group & Welcome ID
@@ -677,7 +703,6 @@ mod test {
         // It should NOT appear in the stream
         let result =
             xmtp_common::time::timeout(std::time::Duration::from_millis(100), stream.next()).await;
-        // tracing::error!("{:?}", result);
         assert!(result.is_err(), "Duplicate DM was unexpectedly streamed");
     }
 }

--- a/xmtp_mls/src/subscriptions/stream_messages.rs
+++ b/xmtp_mls/src/subscriptions/stream_messages.rs
@@ -420,7 +420,7 @@ where
             this.state.set(State::Waiting);
             return self.as_mut().poll_next(cx);
         }
-        return self.as_mut().resolve_replaying(cx, replay_until);
+        self.as_mut().resolve_replaying(cx, replay_until)
     }
 }
 

--- a/xmtp_mls/src/subscriptions/stream_messages.rs
+++ b/xmtp_mls/src/subscriptions/stream_messages.rs
@@ -364,7 +364,9 @@ where
     ) -> Result<()> {
         let mut current_msg = 0;
         while current_msg < replay_until {
-            if let Poll::Ready(Some(envelope)) = self.as_mut().next_message(cx) {
+            let r = self.as_mut().next_message(cx);
+            // match self.as_mut().next_mes
+            if let Poll::Ready(Some(envelope)) = r {
                 let envelope = envelope?;
                 current_msg = envelope.id;
             }


### PR DESCRIPTION
### Refactor HTTP stream implementation and message processing in XMTP to improve welcome message handling and message replay functionality
* Introduces new `ProcessWelcomeResult` enum in [stream_conversations.rs](https://github.com/xmtp/libxmtp/pull/1959/files#diff-7c3c0adb77b28c40ac418e970ce3dbf3320238ec155456eebedc187a61878aea) with variants for handling different welcome message scenarios
* Implements new `Replaying` state in [stream_messages.rs](https://github.com/xmtp/libxmtp/pull/1959/files#diff-ee8c2d1c90650351a2245875b62af09f2c152c29643200276da5743cd59424e7) for improved message replay using async/await pattern
* Updates `poll_next` method in [http_stream.rs](https://github.com/xmtp/libxmtp/pull/1959/files#diff-fbae9993dec4dc4ff72f35f19d2fc0f0f440b67250b3f34975dc15c0aa198a30) to handle byte processing more explicitly
* Modifies test configurations in [lib.rs](https://github.com/xmtp/libxmtp/pull/1959/files#diff-7e1515ecc32ccaeb4f793f7caf1e1d05f4b47383a19d2e179784d79b9c192bcf) to use unified `xmtp_common::test` macro
* Adjusts test parameters and timeouts in [stream_all.rs](https://github.com/xmtp/libxmtp/pull/1959/files#diff-4a3d32ed6005867d963b0eae023dc9c1fd8ffd9531413ba572f4287210a18cc1) for improved reliability

#### 📍Where to Start
Start with the `ProcessWelcomeResult` enum and associated changes in [stream_conversations.rs](https://github.com/xmtp/libxmtp/pull/1959/files#diff-7c3c0adb77b28c40ac418e970ce3dbf3320238ec155456eebedc187a61878aea) as it introduces core changes to the welcome message processing flow.

----

_[Macroscope](https://app.macroscope.com) summarized da3fa9b._