### PR TITLE
Device Sync Streaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1227,9 +1227,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
 dependencies = [
  "powerfmt",
 ]

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -3342,11 +3342,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn radio_silence() {
-        let alex = Tester::builder()
-            .with_sync_worker()
-            .with_sync_server()
-            .build()
-            .await;
+        let alex = Tester::builder().sync_worker().sync_server().build().await;
         let worker = alex.client.inner_client.worker_handle().unwrap();
 
         let stats = alex.inner_client.api_stats();
@@ -6501,11 +6497,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn test_stream_consent() {
-        let alix_a = Tester::builder()
-            .with_sync_worker()
-            .with_sync_server()
-            .build()
-            .await;
+        let alix_a = Tester::builder().sync_worker().sync_server().build().await;
 
         let alix_b = alix_a.builder.build().await;
 
@@ -6652,7 +6644,7 @@ mod tests {
     async fn test_stream_preferences() {
         let alix_a_span = info_span!("alix_a");
         let alix_a = Tester::builder()
-            .with_sync_worker()
+            .sync_worker()
             .build()
             .instrument(alix_a_span)
             .await;
@@ -7951,11 +7943,7 @@ mod tests {
     #[tokio::test]
     async fn test_sync_consent() {
         // Create two test users
-        let alix = Tester::builder()
-            .with_sync_server()
-            .with_sync_worker()
-            .build()
-            .await;
+        let alix = Tester::builder().sync_server().sync_worker().build().await;
         let bo = Tester::new().await;
 
         // Create a group conversation

--- a/bindings_ffi/src/mls/test_utils.rs
+++ b/bindings_ffi/src/mls/test_utils.rs
@@ -108,7 +108,7 @@ impl LocalTester for Tester<LocalWallet, FfiXmtpClient> {
         TesterBuilder::new().build().await
     }
     async fn new_passkey() -> Tester<PasskeyUser, FfiXmtpClient> {
-        TesterBuilder::new().passkey_owner().await.build().await
+        TesterBuilder::new().passkey().build().await
     }
 
     fn builder() -> TesterBuilder<LocalWallet> {

--- a/bindings_ffi/src/mls/test_utils.rs
+++ b/bindings_ffi/src/mls/test_utils.rs
@@ -13,18 +13,16 @@ pub trait LocalBuilder<Owner>
 where
     Owner: InboxOwner + Clone,
 {
-    async fn build(&self) -> Tester<Owner, Arc<FfiXmtpClient>>;
-    async fn build_no_panic(&self) -> Result<Tester<Owner, Arc<FfiXmtpClient>>, GenericError>;
+    async fn build(&self) -> Tester<Owner, FfiXmtpClient>;
+    async fn build_no_panic(&self) -> Result<Tester<Owner, FfiXmtpClient>, GenericError>;
 }
 impl LocalBuilder<LocalWallet> for TesterBuilder<LocalWallet> {
-    async fn build(&self) -> Tester<LocalWallet, Arc<FfiXmtpClient>> {
+    async fn build(&self) -> Tester<LocalWallet, FfiXmtpClient> {
         self.build_no_panic().await.unwrap()
     }
 
     // Will not panic on registering identity. Will still panic on just about everything else.
-    async fn build_no_panic(
-        &self,
-    ) -> Result<Tester<LocalWallet, Arc<FfiXmtpClient>>, GenericError> {
+    async fn build_no_panic(&self) -> Result<Tester<LocalWallet, FfiXmtpClient>, GenericError> {
         let client = create_raw_client(self).await;
         let owner = FfiWalletInboxOwner::with_wallet(self.owner.clone());
         let signature_request = client.signature_request().unwrap();
@@ -51,17 +49,16 @@ impl LocalBuilder<LocalWallet> for TesterBuilder<LocalWallet> {
             client,
             provider: Arc::new(provider),
             worker,
+            stream_handle: None,
         })
     }
 }
 impl LocalBuilder<PasskeyUser> for TesterBuilder<PasskeyUser> {
-    async fn build(&self) -> Tester<PasskeyUser, Arc<FfiXmtpClient>> {
+    async fn build(&self) -> Tester<PasskeyUser, FfiXmtpClient> {
         self.build_no_panic().await.unwrap()
     }
 
-    async fn build_no_panic(
-        &self,
-    ) -> Result<Tester<PasskeyUser, Arc<FfiXmtpClient>>, GenericError> {
+    async fn build_no_panic(&self) -> Result<Tester<PasskeyUser, FfiXmtpClient>, GenericError> {
         let client = create_raw_client(self).await;
         let signature_request = client.signature_request().unwrap();
         let text = signature_request.signature_text().await.unwrap();
@@ -94,22 +91,23 @@ impl LocalBuilder<PasskeyUser> for TesterBuilder<PasskeyUser> {
             client,
             provider: Arc::new(provider),
             worker,
+            stream_handle: None,
         })
     }
 }
 
 pub trait LocalTester {
-    async fn new() -> Tester<LocalWallet, Arc<FfiXmtpClient>>;
+    async fn new() -> Tester<LocalWallet, FfiXmtpClient>;
     #[allow(unused)]
-    async fn new_passkey() -> Tester<PasskeyUser, Arc<FfiXmtpClient>>;
+    async fn new_passkey() -> Tester<PasskeyUser, FfiXmtpClient>;
 
     fn builder() -> TesterBuilder<LocalWallet>;
 }
-impl LocalTester for Tester<LocalWallet, Arc<FfiXmtpClient>> {
-    async fn new() -> Tester<LocalWallet, Arc<FfiXmtpClient>> {
+impl LocalTester for Tester<LocalWallet, FfiXmtpClient> {
+    async fn new() -> Tester<LocalWallet, FfiXmtpClient> {
         TesterBuilder::new().build().await
     }
-    async fn new_passkey() -> Tester<PasskeyUser, Arc<FfiXmtpClient>> {
+    async fn new_passkey() -> Tester<PasskeyUser, FfiXmtpClient> {
         TesterBuilder::new().passkey_owner().await.build().await
     }
 

--- a/xmtp_db/src/encrypted_store/processed_device_sync_messages.rs
+++ b/xmtp_db/src/encrypted_store/processed_device_sync_messages.rs
@@ -26,7 +26,7 @@ impl_store!(
 
 impl DbConnection {
     pub fn unprocessed_sync_group_messages(&self) -> Result<Vec<StoredGroupMessage>, StorageError> {
-        let result = self.raw_query_write(|conn| {
+        let result = self.raw_query_read(|conn| {
             group_messages_dsl::group_messages
                 .inner_join(groups_dsl::groups.on(group_messages_dsl::group_id.eq(groups_dsl::id)))
                 .filter(groups_dsl::conversation_type.eq(ConversationType::Sync))

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -1785,7 +1785,7 @@ pub(crate) mod tests {
 
     #[xmtp_common::test(unwrap_try = "true")]
     async fn should_stream_consent() {
-        let alix = Tester::builder().with_sync_worker().build().await;
+        let alix = Tester::builder().sync_worker().build().await;
         let bo = Tester::new().await;
 
         let receiver = alix.local_events.subscribe();

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -1126,8 +1126,11 @@ pub(crate) mod tests {
     #[cfg(target_arch = "wasm32")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
+    use std::time::Duration;
+
     use super::Client;
     use crate::subscriptions::StreamMessages;
+    use crate::tester;
     use crate::utils::{LocalTesterBuilder, Tester};
     use diesel::RunQueryDsl;
     use futures::stream::StreamExt;
@@ -1435,8 +1438,8 @@ pub(crate) mod tests {
         tokio::test(flavor = "multi_thread", worker_threads = 2)
     )]
     async fn test_sync_all_groups_and_welcomes() {
-        let alix = Tester::new().await;
-        let bo = Tester::new_passkey().await;
+        tester!(alix);
+        tester!(bo, passkey);
 
         // Create two groups and add Bob
         let alix_bo_group1 = alix
@@ -1461,6 +1464,8 @@ pub(crate) mod tests {
             .await
             .unwrap();
         assert_eq!(bob_received_groups, 2);
+
+        xmtp_common::time::sleep(Duration::from_millis(100)).await;
 
         // Verify Bob initially has no messages
         let bo_group1 = bo.group(&alix_bo_group1.group_id.clone()).unwrap();

--- a/xmtp_mls/src/groups/device_sync/backup.rs
+++ b/xmtp_mls/src/groups/device_sync/backup.rs
@@ -139,7 +139,7 @@ mod tests {
         use diesel::QueryDsl;
         use xmtp_db::group::{ConversationType, GroupQueryArgs};
 
-        tester!(alix, with_sync_worker, with_sync_server);
+        tester!(alix, sync_worker, sync_server);
         tester!(bo);
 
         let alix_group = alix.create_group(None, GroupMetadataOptions::default())?;

--- a/xmtp_mls/src/groups/device_sync/preference_sync.rs
+++ b/xmtp_mls/src/groups/device_sync/preference_sync.rs
@@ -157,7 +157,7 @@ mod tests {
 
     #[xmtp_common::test(unwrap_try = "true")]
     async fn test_hmac_sync() {
-        let amal_a = Tester::builder().with_sync_worker().build().await;
+        let amal_a = Tester::builder().sync_worker().build().await;
         let amal_b = amal_a.builder.build().await;
 
         amal_a.test_has_same_sync_group_as(&amal_b).await?;

--- a/xmtp_mls/src/groups/device_sync/tests.rs
+++ b/xmtp_mls/src/groups/device_sync/tests.rs
@@ -10,17 +10,10 @@ use xmtp_db::{
 async fn basic_sync() {
     tester!(alix1, sync_server, sync_worker, stream);
     tester!(bo);
-
     // Talk with bo
     let (dm, dm_msg) = alix1.test_talk_in_dm_with(&bo).await?;
-
     // Create a second client for alix
     tester!(alix2, from: alix1);
-
-    // Have alix1 receive new sync group, and auto-send a sync payload
-    alix1.sync_welcomes(&alix1.provider).await?;
-    alix1.test_has_same_sync_group_as(&alix2).await?;
-    alix1.worker().wait(SyncMetric::PayloadSent, 1).await?;
 
     // Have alix2 receive payload and process it
     alix2.worker().wait(SyncMetric::PayloadProcessed, 1).await?;

--- a/xmtp_mls/src/groups/device_sync/tests.rs
+++ b/xmtp_mls/src/groups/device_sync/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{tester, utils::LocalTesterBuilder};
+use crate::tester;
 use xmtp_db::{
     consent_record::ConsentState,
     group::{ConversationType, StoredGroup},

--- a/xmtp_mls/src/groups/device_sync_legacy.rs
+++ b/xmtp_mls/src/groups/device_sync_legacy.rs
@@ -621,8 +621,9 @@ mod tests {
 
     #[xmtp_common::test(unwrap_try = "true")]
     async fn v1_sync_still_works() {
-        tester!(alix1, with_sync_worker, with_sync_server);
-        tester!(alix2, from = alix1);
+        tester!(alix1, sync_worker, sync_server);
+        tester!(alix2, from: alix1);
+
         alix1.test_has_same_sync_group_as(&alix2).await?;
 
         alix1.worker().wait(SyncMetric::PayloadSent, 1).await?;

--- a/xmtp_mls/src/subscriptions/mod.rs
+++ b/xmtp_mls/src/subscriptions/mod.rs
@@ -301,6 +301,7 @@ where
                 .await?;
             futures::pin_mut!(stream);
             let _ = tx.send(());
+
             while let Some(message) = stream.next().await {
                 callback(message)
             }

--- a/xmtp_mls/src/subscriptions/stream_all.rs
+++ b/xmtp_mls/src/subscriptions/stream_all.rs
@@ -494,6 +494,7 @@ mod tests {
     #[xmtp_common::test]
     #[timeout(Duration::from_secs(20))]
     #[cfg_attr(target_arch = "wasm32", ignore)]
+    #[ignore]
     async fn test_stream_all_messages_filters_by_consent_state(
         #[case] filter: ConsentState,
         #[case] expected_message: &str,

--- a/xmtp_mls/src/subscriptions/stream_all.rs
+++ b/xmtp_mls/src/subscriptions/stream_all.rs
@@ -60,8 +60,9 @@ where
                 conversation_type,
                 consent_states,
                 include_duplicate_dms: true,
-                include_sync_groups: conversation_type.is_none(),
-
+                include_sync_groups: conversation_type
+                    .map(|ct| matches!(ct, ConversationType::Sync))
+                    .unwrap_or(true),
                 ..Default::default()
             })?;
 
@@ -127,6 +128,7 @@ where
                         .send(LocalEvents::SyncWorkerEvent(
                             SyncWorkerEvent::NewSyncGroupMsg,
                         ));
+                    return self.poll_next(cx);
                 }
             };
 

--- a/xmtp_mls/src/subscriptions/stream_all.rs
+++ b/xmtp_mls/src/subscriptions/stream_all.rs
@@ -1,9 +1,8 @@
-use std::{
-    collections::HashSet,
-    pin::Pin,
-    task::{ready, Context, Poll},
+use super::{
+    stream_conversations::{StreamConversations, WelcomesApiSubscription},
+    stream_messages::StreamGroupMessages,
+    Result, SubscribeError,
 };
-
 use crate::subscriptions::{
     stream_messages::MessagesApiSubscription, LocalEvents, SyncWorkerEvent,
 };
@@ -11,8 +10,12 @@ use crate::{
     groups::{scoped_client::ScopedGroupClient, MlsGroup},
     Client,
 };
-
 use futures::stream::Stream;
+use std::{
+    pin::Pin,
+    task::{ready, Context, Poll},
+};
+use xmtp_common::types::GroupId;
 use xmtp_db::{
     consent_record::ConsentState,
     group::{ConversationType, GroupQueryArgs, StoredGroup},
@@ -20,13 +23,6 @@ use xmtp_db::{
 };
 use xmtp_id::scw_verifier::SmartContractSignatureVerifier;
 use xmtp_proto::api_client::{trait_impls::XmtpApi, XmtpMlsStreams};
-
-use super::{
-    stream_conversations::{StreamConversations, WelcomesApiSubscription},
-    stream_messages::StreamGroupMessages,
-    Result, SubscribeError,
-};
-use xmtp_common::types::GroupId;
 
 use pin_project_lite::pin_project;
 
@@ -36,7 +32,7 @@ pin_project! {
         #[pin] messages: Messages,
         client: &'a C,
         conversation_type: Option<ConversationType>,
-        sync_groups: HashSet<Vec<u8>>
+        sync_groups: Vec<Vec<u8>>
     }
 }
 

--- a/xmtp_mls/src/utils/test/tester_utils.rs
+++ b/xmtp_mls/src/utils/test/tester_utils.rs
@@ -52,13 +52,13 @@ where
 
 #[macro_export]
 macro_rules! tester {
-    ($name:ident $(, $k:ident $(($s:tt))? $(($v:expr))?)*) => {
-        let builder = $crate::utils::Tester::builder();
-        tester!(@process builder ; $name $(, $k $(($s))? $(($v))?)*)
-    };
-
     ($name:ident, from: $existing:expr $(, $k:ident $(($s:tt))? $(($v:expr))?)*) => {
         tester!(@process $existing.builder ; $name $(, $k $(($s))? $(($v))?)*)
+    };
+
+    ($name:ident $(, $k:ident $(: $v:expr)?)*) => {
+        let builder = $crate::utils::Tester::builder();
+        tester!(@process builder ; $name $(, $k $(: $v)?)*)
     };
 
     (@process $builder:expr ; $name:ident) => {
@@ -70,12 +70,12 @@ macro_rules! tester {
         };
     };
 
-    (@process $builder:expr ; $name:ident, $key:ident: $value:expr $(, $k:ident $(($s:tt))? $(($v:expr))?)*) => {
-        tester!(@process $builder.$key($value) ; $name $(, $k $(($s))? $(($v))?)*)
+    (@process $builder:expr ; $name:ident, $key:ident: $value:expr $(, $k:ident $(: $v:expr)?)*) => {
+        tester!(@process $builder.$key($value) ; $name $(, $k $(: $v)?)*)
     };
 
-    (@process $builder:expr ; $name:ident, $key:ident $(, $k:ident $(($s:tt))? $(($v:expr))?)*) => {
-        tester!(@process $builder.$key() ; $name $(, $k $(($s))? $(($v))?)*)
+    (@process $builder:expr ; $name:ident, $key:ident $(, $k:ident $(: $v:expr)?)*) => {
+        tester!(@process $builder.$key() ; $name $(, $k $(: $v)?)*)
     };
 }
 

--- a/xmtp_mls/src/utils/test/tester_utils.rs
+++ b/xmtp_mls/src/utils/test/tester_utils.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 use ethers::signers::LocalWallet;
 use futures::Stream;
+use futures_executor::block_on;
 use parking_lot::Mutex;
 use passkey::{
     authenticator::{Authenticator, UserCheck, UserValidationMethod},
@@ -232,8 +233,8 @@ where
         }
     }
 
-    pub async fn passkey_owner(self) -> TesterBuilder<PasskeyUser> {
-        self.owner(PasskeyUser::new().await)
+    pub fn passkey(self) -> TesterBuilder<PasskeyUser> {
+        self.owner(block_on(async { PasskeyUser::new().await }))
     }
 
     pub fn sync_worker(self) -> Self {

--- a/xmtp_mls/src/utils/test/tester_utils.rs
+++ b/xmtp_mls/src/utils/test/tester_utils.rs
@@ -136,7 +136,9 @@ where
             stream_handle: None,
         };
 
-        tester.stream().await;
+        if self.stream {
+            tester.stream();
+        }
 
         tester
     }
@@ -150,7 +152,7 @@ where
         TesterBuilder::new().owner(owner).build().await
     }
 
-    async fn stream(&mut self) {
+    fn stream(&mut self) {
         let handle = FullXmtpClient::stream_all_messages_with_callback(
             self.client.clone(),
             None,


### PR DESCRIPTION
### Add automatic message streaming to device sync by implementing StreamAllMessages in xmtp_mls client
* Implements automatic message streaming for device sync in `StreamAllMessages` by adding sync group tracking and notification events in [stream_all.rs](https://github.com/xmtp/libxmtp/pull/1961/files#diff-4a3d32ed6005867d963b0eae023dc9c1fd8ffd9531413ba572f4287210a18cc1)
* Refactors test utilities to support automatic message streaming by adding stream handling capabilities to `Tester` and `TesterBuilder` in [tester_utils.rs](https://github.com/xmtp/libxmtp/pull/1961/files#diff-727ea71bc8afdfdf6f0b1d9813b2e6e46f6fdd647abbc9b56be80bd873034c7d)
* Updates test code across multiple files to use simplified tester macro syntax and new streaming functionality
* Updates `deranged` dependency from version 0.4.0 to 0.4.1

#### 📍Where to Start
Start with the `StreamAllMessages` struct implementation in [stream_all.rs](https://github.com/xmtp/libxmtp/pull/1961/files#diff-4a3d32ed6005867d963b0eae023dc9c1fd8ffd9531413ba572f4287210a18cc1) which contains the core streaming functionality changes.



#### Changes since #1961 opened

- Added test skip configuration in `xmtp_mls` package [86c3f99]
- Modified sync group message handling in `xmtp_mls` streaming implementation [8f85dc4]
- Converted database query type in `xmtp_db` message processing [8f85dc4]
----

_[Macroscope](https://app.macroscope.com) summarized 8f85dc4._