### PR TITLE
Small tester! Macro Syntax Fix

### DIFF
--- a/xmtp_mls/src/utils/test/tester_utils.rs
+++ b/xmtp_mls/src/utils/test/tester_utils.rs
@@ -53,8 +53,8 @@ where
 
 #[macro_export]
 macro_rules! tester {
-    ($name:ident, from: $existing:expr $(, $k:ident $(($s:tt))? $(($v:expr))?)*) => {
-        tester!(@process $existing.builder ; $name $(, $k $(($s))? $(($v))?)*)
+    ($name:ident, from: $existing:expr $(, $k:ident $(: $v:expr)?)*) => {
+        tester!(@process $existing.builder ; $name $(, $k $(: $v)?)*)
     };
 
     ($name:ident $(, $k:ident $(: $v:expr)?)*) => {


### PR DESCRIPTION
### Standardize parameter syntax in `tester!` macro to use colon-based format in `xmtp_mls` utils
Updates the pattern matching in the `tester!` macro implementation to use a consistent `$(: $v:expr)?` syntax for parameter value specification, replacing the previous multiple optional capture groups approach that used `$(($s:tt))?` and `$(($v:expr))?` patterns in [tester_utils.rs](https://github.com/xmtp/libxmtp/pull/1963/files#diff-727ea71bc8afdfdf6f0b1d9813b2e6e46f6fdd647abbc9b56be80bd873034c7d).

#### 📍Where to Start
Start with the `tester!` macro implementation in [tester_utils.rs](https://github.com/xmtp/libxmtp/pull/1963/files#diff-727ea71bc8afdfdf6f0b1d9813b2e6e46f6fdd647abbc9b56be80bd873034c7d) which contains the core pattern matching changes.



#### Changes since #1963 opened

- Added comprehensive test suite for `xmtp_mls` group functionality [28268ef]
- Modified DM creation API in `xmtp_mls` to support optional metadata [28268ef]
- Updated language bindings for optional DM metadata [28268ef]
- Updated test implementations for modified DM API [28268ef]
----

_[Macroscope](https://app.macroscope.com) summarized 28268ef._