### PR TITLE
Update workspace Cargo.toml version to 1.3.0-dev on main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_node"
-version = "1.2.0-dev"
+version = "1.3.0-dev"
 dependencies = [
  "chrono",
  "futures",
@@ -452,7 +452,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_wasm"
-version = "1.2.0-dev"
+version = "1.3.0-dev"
 dependencies = [
  "chrono",
  "console_error_panic_hook",
@@ -7608,7 +7608,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api"
-version = "1.2.0-dev"
+version = "1.3.0-dev"
 dependencies = [
  "async-trait",
  "ctor",
@@ -7628,7 +7628,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_d14n"
-version = "1.2.0-dev"
+version = "1.3.0-dev"
 dependencies = [
  "async-trait",
  "ctor",
@@ -7655,7 +7655,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_grpc"
-version = "1.2.0-dev"
+version = "1.3.0-dev"
 dependencies = [
  "async-trait",
  "futures",
@@ -7672,7 +7672,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_http"
-version = "1.2.0-dev"
+version = "1.3.0-dev"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7696,7 +7696,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_cli"
-version = "1.2.0-dev"
+version = "1.3.0-dev"
 dependencies = [
  "chrono",
  "clap",
@@ -7729,7 +7729,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_common"
-version = "1.2.0-dev"
+version = "1.3.0-dev"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7762,7 +7762,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_content_types"
-version = "1.2.0-dev"
+version = "1.3.0-dev"
 dependencies = [
  "prost",
  "serde",
@@ -7776,7 +7776,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_cryptography"
-version = "1.2.0-dev"
+version = "1.3.0-dev"
 dependencies = [
  "bincode",
  "curve25519-dalek",
@@ -7804,7 +7804,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_db"
-version = "1.2.0-dev"
+version = "1.3.0-dev"
 dependencies = [
  "anyhow",
  "bincode",
@@ -7839,7 +7839,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_id"
-version = "1.2.0-dev"
+version = "1.3.0-dev"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7875,7 +7875,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_macro"
-version = "1.2.0-dev"
+version = "1.3.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7886,7 +7886,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_mls"
-version = "1.2.0-dev"
+version = "1.3.0-dev"
 dependencies = [
  "aes-gcm",
  "async-compression",
@@ -7959,7 +7959,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_proto"
-version = "1.2.0-dev"
+version = "1.3.0-dev"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -7983,7 +7983,7 @@ dependencies = [
 
 [[package]]
 name = "xmtpv3"
-version = "1.2.0-dev"
+version = "1.3.0-dev"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ resolver = "2"
 
 [workspace.package]
 license = "MIT"
-version = "1.2.0-dev"
+version = "1.3.0-dev"
 
 [workspace.dependencies]
 anyhow = "1.0"

--- a/bindings_node/package.json
+++ b/bindings_node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/node-bindings",
-  "version": "1.2.0-dev",
+  "version": "1.3.0-dev",
   "repository": {
     "type": "git",
     "url": "git+https://git@github.com/xmtp/libxmtp.git",

--- a/bindings_wasm/package.json
+++ b/bindings_wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/wasm-bindings",
-  "version": "1.2.0-dev",
+  "version": "1.3.0-dev",
   "type": "module",
   "license": "MIT",
   "description": "WASM bindings for the libXMTP rust library",


### PR DESCRIPTION
### Increment workspace and package versions from 1.2.0-dev to 1.3.0-dev to prepare for new development cycle
Updates version numbers across the workspace:
* Workspace `Cargo.toml` version updated to `1.3.0-dev` in [Cargo.toml](https://github.com/xmtp/libxmtp/pull/1970/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542)
* Node.js bindings version updated in [bindings_node/package.json](https://github.com/xmtp/libxmtp/pull/1970/files#diff-bc8be8e755c9188d5b1c3402b397741f9151dad43d877a181f31003052d10b99)
* WebAssembly bindings version updated in [bindings_wasm/package.json](https://github.com/xmtp/libxmtp/pull/1970/files#diff-4a621639e0561b5b01c30ab7fa75cc2b67c54dad6763ecabda35df8e2b16b14e)
* Multiple package versions updated in [Cargo.lock](https://github.com/xmtp/libxmtp/pull/1970/files#diff-13ee4b2252c9e516a0547f2891aa2105c3ca71c6d7a1e682c69be97998dfc87e) including `bindings_node`, `bindings_wasm`, `xmtp_api`, `xmtp_api_d14n`, `xmtp_api_grpc`, `xmtp_api_http`, `xmtp_cli`, `xmtp_common`, `xmtp_content_types`, `xmtp_cryptography`, `xmtp_db`, `xmtp_id`, `xmtp_macro`, `xmtp_mls`, `xmtp_proto`, and `xmtpv3`

#### 📍Where to Start
Start with the workspace version update in [Cargo.toml](https://github.com/xmtp/libxmtp/pull/1970/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542), which drives the version updates across all packages.

----

_[Macroscope](https://app.macroscope.com) summarized e279bae._