### PR TITLE
Fix node stream arg types

### DIFF
--- a/bindings_node/src/conversations.rs
+++ b/bindings_node/src/conversations.rs
@@ -703,7 +703,7 @@ impl Conversations {
   }
 
   #[napi(
-    ts_args_type = "callback: (err: null | Error, result: Message | undefined, consentStates: ConsentState[] | undefined) => void"
+    ts_args_type = "callback: (err: null | Error, result: Message | undefined) => void, consentStates?: ConsentState[]"
   )]
   pub fn stream_all_group_messages(
     &self,
@@ -714,7 +714,7 @@ impl Conversations {
   }
 
   #[napi(
-    ts_args_type = "callback: (err: null | Error, result: Message | undefined, consentStates: ConsentState[] | undefined) => void"
+    ts_args_type = "callback: (err: null | Error, result: Message | undefined) => void, consentStates?: ConsentState[]"
   )]
   pub fn stream_all_dm_messages(
     &self,


### PR DESCRIPTION
### Modify TypeScript callback function signatures in Node.js bindings to move `consentStates` from callback parameter to function parameter
Updates the TypeScript type definitions in [conversations.rs](https://github.com/xmtp/libxmtp/pull/1972/files#diff-305d8a9df912ee15a450791cf1af33e26798a0a4877f6a4dc457d291914bc126) for the `stream_all_group_messages` and `stream_all_dm_messages` methods by:

* Moving `consentStates` from being the third parameter of the callback function to an optional parameter of the main function
* Simplifying the callback function signature to only include `err` and `result` parameters

#### 📍Where to Start
Start with the type definitions for `stream_all_group_messages` and `stream_all_dm_messages` in [conversations.rs](https://github.com/xmtp/libxmtp/pull/1972/files#diff-305d8a9df912ee15a450791cf1af33e26798a0a4877f6a4dc457d291914bc126)

----

_[Macroscope](https://app.macroscope.com) summarized 7d552f0._