### PR TITLE
Add explanations to all unreachable!

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -3453,7 +3453,7 @@ mod tests {
             .unwrap();
         let challenge = sig_request.signature_text().await.unwrap();
         let UnverifiedSignature::Passkey(sig) = passkey.sign(&challenge).unwrap() else {
-            unreachable!()
+            unreachable!("Should always be a passkey.")
         };
         sig_request
             .add_passkey_signature(FfiPasskeySignature {

--- a/xmtp_api_http/src/http_stream.rs
+++ b/xmtp_api_http/src/http_stream.rs
@@ -233,7 +233,7 @@ where
         let mut this = Pin::new(self);
         if this.poll_next_unpin(&mut cx).is_ready() {
             tracing::error!("Stream ready before established");
-            unreachable!()
+            unreachable!("Stream ready before established")
         }
     }
 }
@@ -254,7 +254,7 @@ where
         let mut this = unsafe { Pin::new_unchecked(self) };
         if this.as_mut().poll_next(&mut cx).is_ready() {
             tracing::error!("stream ready before established...");
-            unreachable!()
+            unreachable!("stream ready before established...")
         }
     }
 }

--- a/xmtp_db/src/errors.rs
+++ b/xmtp_db/src/errors.rs
@@ -54,7 +54,7 @@ pub enum StorageError {
 impl From<std::convert::Infallible> for StorageError {
     fn from(_: std::convert::Infallible) -> StorageError {
         // infallible can never fail/occur
-        unreachable!()
+        unreachable!("Infallible conversion should never fail.")
     }
 }
 

--- a/xmtp_mls/src/groups/device_sync_legacy.rs
+++ b/xmtp_mls/src/groups/device_sync_legacy.rs
@@ -325,7 +325,7 @@ where
             );
             response.error_for_status()?;
             // checked for error, the above line bubbled up
-            unreachable!();
+            unreachable!("v1 create reply: Already checked for an error");
         }
 
         let url = format!("{url}/files/{}", response.text().await?);

--- a/xmtp_mls/src/subscriptions/stream_conversations.rs
+++ b/xmtp_mls/src/subscriptions/stream_conversations.rs
@@ -234,7 +234,7 @@ where
                         // this will return immediately if we have already processed the welcome
                         // and it exists in the db
                         let Processing { future } = this.state.project() else {
-                            unreachable!()
+                            unreachable!("Streaming processing future should exist.")
                         };
                         let poll = future.poll(cx);
                         self.as_mut().try_process(poll, cx)

--- a/xmtp_proto/src/traits.rs
+++ b/xmtp_proto/src/traits.rs
@@ -210,7 +210,7 @@ where
 // Infallible errors by definition can never occur
 impl<E: std::error::Error> From<std::convert::Infallible> for ApiClientError<E> {
     fn from(_v: std::convert::Infallible) -> ApiClientError<E> {
-        unreachable!()
+        unreachable!("Infallible errors can never occur")
     }
 }
 


### PR DESCRIPTION
### Add explanatory messages to `unreachable!` macro calls across XMTP codebase to clarify impossible code paths
Adds descriptive messages to `unreachable!` macro calls in multiple files to provide context about why these code paths should never be executed:

* In [mls.rs](https://github.com/xmtp/libxmtp/pull/1974/files#diff-3a24c3e76565487a710ac9863ac05160128f4f90892e07849b555a6de43a6e8f), adds "Should always be a passkey" message in `test_associate_passkey`
* In [http_stream.rs](https://github.com/xmtp/libxmtp/pull/1974/files#diff-fbae9993dec4dc4ff72f35f19d2fc0f0f440b67250b3f34975dc15c0aa198a30), adds stream establishment state messages in both `establish` methods
* In [errors.rs](https://github.com/xmtp/libxmtp/pull/1974/files#diff-c28554f6385bb1e08c2ed9656a3618cd1f29d58e5b8dc8729b083e84078261c8), adds infallible conversion explanation in `StorageError` implementation
* In [device_sync_legacy.rs](https://github.com/xmtp/libxmtp/pull/1974/files#diff-137589ac016eb0cf4a2d9bdbc3f1935e573c830f872d8348eb09dcb8f9b853d0), adds error check message in `v1_send_sync_request`
* In [stream_conversations.rs](https://github.com/xmtp/libxmtp/pull/1974/files#diff-7c3c0adb77b28c40ac418e970ce3dbf3320238ec155456eebedc187a61878aea), adds streaming state message in `poll_next`
* In [traits.rs](https://github.com/xmtp/libxmtp/pull/1974/files#diff-a040511e61519da940d7c0956bd7917a6a8d2ce1a929d3b4b8978cc7084befb5), adds infallible error message in `ApiClientError` implementation

#### 📍Where to Start
Start with the `test_associate_passkey` function in [mls.rs](https://github.com/xmtp/libxmtp/pull/1974/files#diff-3a24c3e76565487a710ac9863ac05160128f4f90892e07849b555a6de43a6e8f) as it contains a representative example of the explanatory message additions being made across the codebase.

----

_[Macroscope](https://app.macroscope.com) summarized e531dc8._