### PR TITLE
Remove cycled at timestamps from wasm and node

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -1569,9 +1569,7 @@ impl TryFrom<PreferenceUpdate> for FfiPreferenceUpdate {
     type Error = GenericError;
     fn try_from(value: PreferenceUpdate) -> Result<Self, Self::Error> {
         match value {
-            PreferenceUpdate::Hmac { key, cycled_at_ns } => {
-                Ok(FfiPreferenceUpdate::HMAC { key, cycled_at_ns })
-            }
+            PreferenceUpdate::Hmac { key, .. } => Ok(FfiPreferenceUpdate::HMAC { key }),
             // These are filtered out in the stream and should not be here
             // We're keeping preference update and consent streams separate right now.
             PreferenceUpdate::Consent(_) => Err(GenericError::Generic {
@@ -2739,7 +2737,7 @@ pub trait FfiPreferenceCallback: Send + Sync {
 
 #[derive(uniffi::Enum, Debug)]
 pub enum FfiPreferenceUpdate {
-    HMAC { key: Vec<u8>, cycled_at_ns: i64 },
+    HMAC { key: Vec<u8> },
 }
 
 #[derive(uniffi::Object)]

--- a/bindings_node/src/conversations.rs
+++ b/bindings_node/src/conversations.rs
@@ -184,14 +184,14 @@ pub enum Tag<T> {
 #[derive(Serialize, Deserialize)]
 pub enum UserPreferenceUpdate {
   ConsentUpdate { consent: Consent },
-  HmacKeyUpdate { key: Vec<u8>, cycled_at_ns: i64 },
+  HmacKeyUpdate { key: Vec<u8> },
 }
 
 impl From<XmtpUserPreferenceUpdate> for Tag<UserPreferenceUpdate> {
   fn from(value: XmtpUserPreferenceUpdate) -> Self {
     match value {
-      XmtpUserPreferenceUpdate::Hmac { key, cycled_at_ns } => {
-        Tag::V(UserPreferenceUpdate::HmacKeyUpdate { key, cycled_at_ns })
+      XmtpUserPreferenceUpdate::Hmac { key, .. } => {
+        Tag::V(UserPreferenceUpdate::HmacKeyUpdate { key })
       }
       XmtpUserPreferenceUpdate::Consent(consent) => Tag::V(UserPreferenceUpdate::ConsentUpdate {
         consent: Consent::from(consent),

--- a/bindings_wasm/src/user_preferences.rs
+++ b/bindings_wasm/src/user_preferences.rs
@@ -15,7 +15,6 @@ pub enum UserPreference {
     // serde bytes converts to Uint8Array
     #[serde(with = "serde_bytes")]
     key: Vec<u8>,
-    cycled_at_ns: i64,
   },
 }
 
@@ -25,9 +24,7 @@ impl From<PreferenceUpdate> for UserPreference {
       PreferenceUpdate::Consent(c) => UserPreference::Consent {
         consent: Consent::from(c),
       },
-      PreferenceUpdate::Hmac { key, cycled_at_ns } => {
-        UserPreference::HmacKeyUpdate { key, cycled_at_ns }
-      }
+      PreferenceUpdate::Hmac { key, .. } => UserPreference::HmacKeyUpdate { key },
     }
   }
 }


### PR DESCRIPTION
### Remove `cycled_at_ns` timestamp field from HMAC key updates in WASM and Node bindings
Updates the data structures in both [conversations.rs](https://github.com/xmtp/libxmtp/pull/1975/files#diff-305d8a9df912ee15a450791cf1af33e26798a0a4877f6a4dc457d291914bc126) and [user_preferences.rs](https://github.com/xmtp/libxmtp/pull/1975/files#diff-893678c68a0f1ba62175ede6c4c400859dea823b37cd42c293efcb7ea92e88cd) by removing the `cycled_at_ns` timestamp field from the `HmacKeyUpdate` variants in their respective enums:

* Removes `cycled_at_ns: i64` field from `UserPreferenceUpdate::HmacKeyUpdate` in Node bindings
* Removes `cycled_at_ns: i64` field from `UserPreference::HmacKeyUpdate` in WASM bindings
* Updates corresponding `From` implementations to ignore the timestamp field during conversion

#### 📍Where to Start
Start with the `UserPreferenceUpdate` enum modifications in [conversations.rs](https://github.com/xmtp/libxmtp/pull/1975/files#diff-305d8a9df912ee15a450791cf1af33e26798a0a4877f6a4dc457d291914bc126), followed by the parallel changes in [user_preferences.rs](https://github.com/xmtp/libxmtp/pull/1975/files#diff-893678c68a0f1ba62175ede6c4c400859dea823b37cd42c293efcb7ea92e88cd).



#### Changes since #1975 opened

- Removed `cycled_at_ns` timestamp field from `FfiPreferenceUpdate::HMAC` variant in WASM and Node bindings [8f20bd9]
----

_[Macroscope](https://app.macroscope.com) summarized 8f20bd9._