### PR TITLE
Cleanup bindings

### DIFF
--- a/bindings_node/src/conversations.rs
+++ b/bindings_node/src/conversations.rs
@@ -93,7 +93,7 @@ pub struct ListConversationsOptions {
   pub conversation_type: Option<ConversationType>,
   pub created_after_ns: Option<i64>,
   pub created_before_ns: Option<i64>,
-  pub include_duplicate_dms: bool,
+  pub include_duplicate_dms: Option<bool>,
   pub limit: Option<i64>,
 }
 
@@ -105,7 +105,7 @@ impl From<ListConversationsOptions> for GroupQueryArgs {
         .map(|vec| vec.into_iter().map(Into::into).collect()),
       created_before_ns: opts.created_before_ns,
       created_after_ns: opts.created_after_ns,
-      include_duplicate_dms: opts.include_duplicate_dms,
+      include_duplicate_dms: opts.include_duplicate_dms.unwrap_or_default(),
       limit: opts.limit,
       allowed_states: None,
       conversation_type: opts.conversation_type.map(Into::into),

--- a/bindings_node/src/conversations.rs
+++ b/bindings_node/src/conversations.rs
@@ -90,6 +90,7 @@ impl From<GroupMembershipState> for XmtpGroupMembershipState {
 #[derive(Default)]
 pub struct ListConversationsOptions {
   pub consent_states: Option<Vec<ConsentState>>,
+  pub conversation_type: Option<ConversationType>,
   pub created_after_ns: Option<i64>,
   pub created_before_ns: Option<i64>,
   pub include_duplicate_dms: bool,
@@ -107,7 +108,7 @@ impl From<ListConversationsOptions> for GroupQueryArgs {
       include_duplicate_dms: opts.include_duplicate_dms,
       limit: opts.limit,
       allowed_states: None,
-      conversation_type: None,
+      conversation_type: opts.conversation_type.map(Into::into),
       include_sync_groups: false,
       activity_after_ns: None,
     }
@@ -522,54 +523,6 @@ impl Conversations {
   }
 
   #[napi]
-  pub fn list_groups(
-    &self,
-    opts: Option<ListConversationsOptions>,
-  ) -> Result<Vec<ConversationListItem>> {
-    let convo_list: Vec<ConversationListItem> = self
-      .inner_client
-      .list_conversations(GroupQueryArgs {
-        conversation_type: Some(XmtpConversationType::Group),
-        ..GroupQueryArgs::from(opts.unwrap_or_default())
-      })
-      .map_err(ErrorWrapper::from)?
-      .into_iter()
-      .map(|conversation_item| ConversationListItem {
-        conversation: conversation_item.group.into(),
-        last_message: conversation_item
-          .last_message
-          .map(|stored_message| stored_message.into()),
-      })
-      .collect();
-
-    Ok(convo_list)
-  }
-
-  #[napi]
-  pub fn list_dms(
-    &self,
-    opts: Option<ListConversationsOptions>,
-  ) -> Result<Vec<ConversationListItem>> {
-    let convo_list: Vec<ConversationListItem> = self
-      .inner_client
-      .list_conversations(GroupQueryArgs {
-        conversation_type: Some(XmtpConversationType::Dm),
-        ..GroupQueryArgs::from(opts.unwrap_or_default())
-      })
-      .map_err(ErrorWrapper::from)?
-      .into_iter()
-      .map(|conversation_item| ConversationListItem {
-        conversation: conversation_item.group.into(),
-        last_message: conversation_item
-          .last_message
-          .map(|stored_message| stored_message.into()),
-      })
-      .collect();
-
-    Ok(convo_list)
-  }
-
-  #[napi]
   pub fn get_hmac_keys(&self) -> Result<HashMap<String, Vec<HmacKey>>> {
     let inner = self.inner_client.as_ref();
     let conversations = inner
@@ -594,7 +547,9 @@ impl Conversations {
     Ok(hmac_map)
   }
 
-  #[napi(ts_args_type = "callback: (err: null | Error, result: Conversation | undefined) => void")]
+  #[napi(
+    ts_args_type = "callback: (err: Error | null, result: Conversation | undefined) => void, conversationType?: ConversationType"
+  )]
   pub fn stream(
     &self,
     callback: JsFunction,
@@ -617,16 +572,6 @@ impl Conversations {
     );
 
     Ok(StreamCloser::new(stream_closer))
-  }
-
-  #[napi(ts_args_type = "callback: (err: null | Error, result: Conversation | undefined) => void")]
-  pub fn stream_groups(&self, callback: JsFunction) -> Result<StreamCloser> {
-    self.stream(callback, Some(ConversationType::Group))
-  }
-
-  #[napi(ts_args_type = "callback: (err: null | Error, result: Conversation | undefined) => void")]
-  pub fn stream_dms(&self, callback: JsFunction) -> Result<StreamCloser> {
-    self.stream(callback, Some(ConversationType::Dm))
   }
 
   #[napi(
@@ -700,28 +645,6 @@ impl Conversations {
     );
 
     Ok(StreamCloser::new(stream_closer))
-  }
-
-  #[napi(
-    ts_args_type = "callback: (err: null | Error, result: Message | undefined) => void, consentStates?: ConsentState[]"
-  )]
-  pub fn stream_all_group_messages(
-    &self,
-    callback: JsFunction,
-    consent_states: Option<Vec<ConsentState>>,
-  ) -> Result<StreamCloser> {
-    self.stream_all_messages(callback, Some(ConversationType::Group), consent_states)
-  }
-
-  #[napi(
-    ts_args_type = "callback: (err: null | Error, result: Message | undefined) => void, consentStates?: ConsentState[]"
-  )]
-  pub fn stream_all_dm_messages(
-    &self,
-    callback: JsFunction,
-    consent_states: Option<Vec<ConsentState>>,
-  ) -> Result<StreamCloser> {
-    self.stream_all_messages(callback, Some(ConversationType::Dm), consent_states)
   }
 
   #[napi(ts_args_type = "callback: (err: null | Error, result: Consent[] | undefined) => void")]

--- a/bindings_node/test/Conversations.test.ts
+++ b/bindings_node/test/Conversations.test.ts
@@ -8,6 +8,8 @@ import {
 import {
   ConsentState,
   Conversation,
+  Conversations,
+  ConversationType,
   GroupPermissionsOptions,
   IdentifierKind,
   Message,
@@ -25,8 +27,6 @@ describe('Conversations', () => {
     const client = await createRegisteredClient(user)
 
     expect(client.conversations().list().length).toBe(0)
-    expect(client.conversations().listDms().length).toBe(0)
-    expect(client.conversations().listGroups().length).toBe(0)
   })
 
   it('should create a group chat', async () => {
@@ -76,8 +76,14 @@ describe('Conversations', () => {
     expect(groups1.length).toBe(1)
     expect(groups1[0].conversation.id()).toBe(group.id())
 
-    expect(client1.conversations().listDms().length).toBe(0)
-    expect(client1.conversations().listGroups().length).toBe(1)
+    expect(
+      client1.conversations().list({ conversationType: ConversationType.Dm })
+        .length
+    ).toBe(0)
+    expect(
+      client1.conversations().list({ conversationType: ConversationType.Group })
+        .length
+    ).toBe(1)
 
     expect(client2.conversations().list().length).toBe(0)
 
@@ -87,8 +93,14 @@ describe('Conversations', () => {
     expect(groups2.length).toBe(1)
     expect(groups2[0].conversation.id()).toBe(group.id())
 
-    expect(client2.conversations().listDms().length).toBe(0)
-    expect(client2.conversations().listGroups().length).toBe(1)
+    expect(
+      client2.conversations().list({ conversationType: ConversationType.Dm })
+        .length
+    ).toBe(0)
+    expect(
+      client2.conversations().list({ conversationType: ConversationType.Group })
+        .length
+    ).toBe(1)
   })
 
   it('should create a group with custom permissions', async () => {
@@ -236,8 +248,14 @@ describe('Conversations', () => {
     expect(groups1[0].conversation.id()).toBe(group.id())
     expect(groups1[0].conversation.dmPeerInboxId()).toBe(client2.inboxId())
 
-    expect(client1.conversations().listDms().length).toBe(1)
-    expect(client1.conversations().listGroups().length).toBe(0)
+    expect(
+      client1.conversations().list({ conversationType: ConversationType.Dm })
+        .length
+    ).toBe(1)
+    expect(
+      client1.conversations().list({ conversationType: ConversationType.Group })
+        .length
+    ).toBe(0)
 
     expect(client2.conversations().list().length).toBe(0)
 
@@ -248,8 +266,14 @@ describe('Conversations', () => {
     expect(groups2[0].conversation.id()).toBe(group.id())
     expect(groups2[0].conversation.dmPeerInboxId()).toBe(client1.inboxId())
 
-    expect(client2.conversations().listDms().length).toBe(1)
-    expect(client2.conversations().listGroups().length).toBe(0)
+    expect(
+      client2.conversations().list({ conversationType: ConversationType.Dm })
+        .length
+    ).toBe(1)
+    expect(
+      client2.conversations().list({ conversationType: ConversationType.Group })
+        .length
+    ).toBe(0)
 
     const dm1 = client1.conversations().findDmByTargetInboxId(client2.inboxId())
     expect(dm1).toBeDefined()
@@ -471,9 +495,9 @@ describe('Conversations', () => {
     const client3 = await createRegisteredClient(user3)
     const client4 = await createRegisteredClient(user4)
     let groups: Conversation[] = []
-    const stream = client3.conversations().streamGroups((err, convo) => {
+    const stream = client3.conversations().stream((err, convo) => {
       groups.push(convo!)
-    })
+    }, ConversationType.Group)
     const group3 = await client4.conversations().createDm({
       identifier: user3.account.address,
       identifierKind: IdentifierKind.Ethereum,
@@ -508,9 +532,9 @@ describe('Conversations', () => {
     const client3 = await createRegisteredClient(user3)
     const client4 = await createRegisteredClient(user4)
     let groups: Conversation[] = []
-    const stream = client3.conversations().streamDms((err, convo) => {
+    const stream = client3.conversations().stream((err, convo) => {
       groups.push(convo!)
-    })
+    }, ConversationType.Dm)
     const group1 = await client1.conversations().createGroup([
       {
         identifier: user3.account.address,
@@ -662,11 +686,9 @@ describe('Conversations', () => {
     })
 
     let messages: Message[] = []
-    const stream = client1
-      .conversations()
-      .streamAllGroupMessages((err, message) => {
-        messages.push(message!)
-      })
+    const stream = client1.conversations().streamAllMessages((err, message) => {
+      messages.push(message!)
+    }, ConversationType.Group)
 
     const groups2 = client2.conversations()
     await groups2.sync()
@@ -722,11 +744,9 @@ describe('Conversations', () => {
     })
 
     let messages: Message[] = []
-    const stream = client1
-      .conversations()
-      .streamAllDmMessages((err, message) => {
-        messages.push(message!)
-      })
+    const stream = client1.conversations().streamAllMessages((err, message) => {
+      messages.push(message!)
+    }, ConversationType.Dm)
 
     const groups2 = client2.conversations()
     await groups2.sync()

--- a/bindings_wasm/src/conversation.rs
+++ b/bindings_wasm/src/conversation.rs
@@ -693,7 +693,7 @@ impl Conversation {
   }
 
   #[wasm_bindgen(js_name = getDebugInfo)]
-  pub async fn get_debug_info(&self) -> Result<JsValue, JsError> {
+  pub async fn debug_info(&self) -> Result<JsValue, JsError> {
     let group = self.to_mls_group();
     let debug_info = group
       .debug_info()

--- a/bindings_wasm/src/conversations.rs
+++ b/bindings_wasm/src/conversations.rs
@@ -92,7 +92,7 @@ pub struct ListConversationsOptions {
   #[wasm_bindgen(js_name = createdBeforeNs)]
   pub created_before_ns: Option<i64>,
   #[wasm_bindgen(js_name = includeDuplicateDms)]
-  pub include_duplicate_dms: bool,
+  pub include_duplicate_dms: Option<bool>,
   pub limit: Option<i64>,
 }
 
@@ -104,7 +104,7 @@ impl From<ListConversationsOptions> for GroupQueryArgs {
         .map(|states| states.into_iter().map(From::from).collect()),
       created_after_ns: opts.created_after_ns,
       created_before_ns: opts.created_before_ns,
-      include_duplicate_dms: opts.include_duplicate_dms,
+      include_duplicate_dms: opts.include_duplicate_dms.unwrap_or_default(),
       limit: opts.limit,
       allowed_states: None,
       conversation_type: opts.conversation_type.map(Into::into),

--- a/bindings_wasm/src/conversations.rs
+++ b/bindings_wasm/src/conversations.rs
@@ -85,6 +85,8 @@ impl From<GroupMembershipState> for XmtpGroupMembershipState {
 pub struct ListConversationsOptions {
   #[wasm_bindgen(js_name = consentStates)]
   pub consent_states: Option<Vec<ConsentState>>,
+  #[wasm_bindgen(js_name = conversationType)]
+  pub conversation_type: Option<ConversationType>,
   #[wasm_bindgen(js_name = createdAfterNs)]
   pub created_after_ns: Option<i64>,
   #[wasm_bindgen(js_name = createdBeforeNs)]
@@ -105,7 +107,7 @@ impl From<ListConversationsOptions> for GroupQueryArgs {
       include_duplicate_dms: opts.include_duplicate_dms,
       limit: opts.limit,
       allowed_states: None,
-      conversation_type: None,
+      conversation_type: opts.conversation_type.map(Into::into),
       include_sync_groups: false,
       activity_after_ns: None,
     }
@@ -117,6 +119,7 @@ impl ListConversationsOptions {
   #[wasm_bindgen(constructor)]
   pub fn new(
     consent_states: Option<Vec<ConsentState>>,
+    conversation_type: Option<ConversationType>,
     created_after_ns: Option<i64>,
     created_before_ns: Option<i64>,
     include_duplicate_dms: bool,
@@ -124,6 +127,7 @@ impl ListConversationsOptions {
   ) -> Self {
     Self {
       consent_states,
+      conversation_type,
       created_after_ns,
       created_before_ns,
       include_duplicate_dms,
@@ -546,51 +550,6 @@ impl Conversations {
     Ok(convo_list)
   }
 
-  #[wasm_bindgen(js_name = listGroups)]
-  pub fn list_groups(
-    &self,
-    opts: Option<ListConversationsOptions>,
-  ) -> Result<js_sys::Array, JsError> {
-    let convo_list: js_sys::Array = self
-      .inner_client
-      .list_conversations(GroupQueryArgs {
-        conversation_type: Some(XmtpConversationType::Group),
-        ..GroupQueryArgs::from(opts.unwrap_or_default())
-      })
-      .map_err(|e| JsError::new(format!("{}", e).as_str()))?
-      .into_iter()
-      .map(|group| {
-        JsValue::from(ConversationListItem::new(
-          group.group.into(),
-          group.last_message.map(|m| m.into()),
-        ))
-      })
-      .collect();
-
-    Ok(convo_list)
-  }
-
-  #[wasm_bindgen(js_name = listDms)]
-  pub fn list_dms(&self, opts: Option<ListConversationsOptions>) -> Result<js_sys::Array, JsError> {
-    let convo_list: js_sys::Array = self
-      .inner_client
-      .list_conversations(GroupQueryArgs {
-        conversation_type: Some(XmtpConversationType::Dm),
-        ..GroupQueryArgs::from(opts.unwrap_or_default())
-      })
-      .map_err(|e| JsError::new(format!("{}", e).as_str()))?
-      .into_iter()
-      .map(|group| {
-        JsValue::from(ConversationListItem::new(
-          group.group.into(),
-          group.last_message.map(|m| m.into()),
-        ))
-      })
-      .collect();
-
-    Ok(convo_list)
-  }
-
   #[wasm_bindgen(js_name = getHmacKeys)]
   pub fn get_hmac_keys(&self) -> Result<JsValue, JsError> {
     let inner = self.inner_client.as_ref();
@@ -632,16 +591,6 @@ impl Conversations {
     );
 
     Ok(StreamCloser::new(stream_closer))
-  }
-
-  #[wasm_bindgen(js_name = "streamGroups")]
-  pub fn stream_groups(&self, callback: StreamCallback) -> Result<StreamCloser, JsError> {
-    self.stream(callback, Some(ConversationType::Group))
-  }
-
-  #[wasm_bindgen(js_name = "streamDms")]
-  pub fn stream_dms(&self, callback: StreamCallback) -> Result<StreamCloser, JsError> {
-    self.stream(callback, Some(ConversationType::Dm))
   }
 
   #[wasm_bindgen(js_name = "streamAllMessages")]

--- a/bindings_wasm/src/conversations.rs
+++ b/bindings_wasm/src/conversations.rs
@@ -122,7 +122,7 @@ impl ListConversationsOptions {
     conversation_type: Option<ConversationType>,
     created_after_ns: Option<i64>,
     created_before_ns: Option<i64>,
-    include_duplicate_dms: bool,
+    include_duplicate_dms: Option<bool>,
     limit: Option<i64>,
   ) -> Self {
     Self {


### PR DESCRIPTION
# Summary

- Added `conversation_type` to `ListConversationsOptions`
- Changed `include_duplicate_dms` to be optional
- Removed `listDms`
- Removed `listGroups`
- Fixed `conversations.stream` arguments type
- Removed `stream_groups`
- Removed `stream_dms`
- Removed `stream_all_group_messages`
- Removed `stream_all_dm_messages`
- Renamed `get_debug_info` => `debug_info` to match Node bindings (WASM)

This removes some duplicate code that will now be handled by the SDKs.