### PR TITLE
rename conn_ref to db

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -3930,8 +3930,8 @@ mod tests {
         bo_group.conversation.sync().await.unwrap();
 
         // alix published + processed group creation and name update
-        assert_eq!(alix.provider.conn_ref().intents_published(), 2);
-        assert_eq!(alix.provider.conn_ref().intents_processed(), 2);
+        assert_eq!(alix.provider.db().intents_published(), 2);
+        assert_eq!(alix.provider.db().intents_processed(), 2);
 
         bo_group
             .conversation
@@ -3939,11 +3939,11 @@ mod tests {
             .await
             .unwrap();
         message_callbacks.wait_for_delivery(None).await.unwrap();
-        assert_eq!(bo.provider.conn_ref().intents_published(), 1);
+        assert_eq!(bo.provider.db().intents_published(), 1);
 
         alix_group.send(b"Hello there".to_vec()).await.unwrap();
         message_callbacks.wait_for_delivery(None).await.unwrap();
-        assert_eq!(alix.provider.conn_ref().intents_published(), 3);
+        assert_eq!(alix.provider.db().intents_published(), 3);
 
         let dm = bo
             .conversations()
@@ -3954,7 +3954,7 @@ mod tests {
             .await
             .unwrap();
         dm.send(b"Hello again".to_vec()).await.unwrap();
-        assert_eq!(bo.provider.conn_ref().intents_published(), 3);
+        assert_eq!(bo.provider.db().intents_published(), 3);
         message_callbacks.wait_for_delivery(None).await.unwrap();
 
         // Uncomment the following lines to add more group name updates
@@ -3964,7 +3964,7 @@ mod tests {
             .await
             .unwrap();
         message_callbacks.wait_for_delivery(None).await.unwrap();
-        assert_eq!(bo.provider.conn_ref().intents_published(), 4);
+        assert_eq!(bo.provider.db().intents_published(), 4);
 
         assert_eq!(message_callbacks.message_count(), 5);
 
@@ -5638,10 +5638,7 @@ mod tests {
         alix_group.sync().await.unwrap();
 
         // Verify the settings were applied
-        let group_from_db = alix_provider
-            .conn_ref()
-            .find_group(&alix_group.id())
-            .unwrap();
+        let group_from_db = alix_provider.db().find_group(&alix_group.id()).unwrap();
         assert_eq!(
             group_from_db
                 .clone()
@@ -5663,10 +5660,7 @@ mod tests {
             .await
             .unwrap();
 
-        let bola_group_from_db = bola_provider
-            .conn_ref()
-            .find_group(&alix_group.id())
-            .unwrap();
+        let bola_group_from_db = bola_provider.db().find_group(&alix_group.id()).unwrap();
         assert_eq!(
             bola_group_from_db
                 .clone()
@@ -5707,10 +5701,7 @@ mod tests {
         alix_group.sync().await.unwrap();
 
         // Verify disappearing settings are disabled
-        let group_from_db = alix_provider
-            .conn_ref()
-            .find_group(&alix_group.id())
-            .unwrap();
+        let group_from_db = alix_provider.db().find_group(&alix_group.id()).unwrap();
         assert_eq!(
             group_from_db
                 .clone()
@@ -5776,10 +5767,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(alix_messages.len(), 2);
-        let group_from_db = alix_provider
-            .conn_ref()
-            .find_group(&alix_group.id())
-            .unwrap();
+        let group_from_db = alix_provider.db().find_group(&alix_group.id()).unwrap();
         assert_eq!(
             group_from_db
                 .clone()
@@ -5828,10 +5816,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(alix_messages.len(), 2);
-        let group_from_db = alix_provider
-            .conn_ref()
-            .find_group(&alix_group.id())
-            .unwrap();
+        let group_from_db = alix_provider.db().find_group(&alix_group.id()).unwrap();
         assert_eq!(
             group_from_db
                 .clone()
@@ -7621,9 +7606,9 @@ mod tests {
         let client_alix = new_test_client_with_wallet(wallet_alix).await;
 
         let bo_provider = client_bo.inner_client.mls_provider();
-        let bo_conn = bo_provider.conn_ref();
+        let bo_conn = bo_provider.db();
         let alix_provider = client_alix.inner_client.mls_provider();
-        let alix_conn = alix_provider.conn_ref();
+        let alix_conn = alix_provider.db();
 
         // Find or create DM conversations
         let convo_bo = client_bo

--- a/xmtp_db/src/encrypted_store/mod.rs
+++ b/xmtp_db/src/encrypted_store/mod.rs
@@ -352,7 +352,7 @@ pub trait MlsProviderExt: OpenMlsProvider {
         E: std::error::Error + From<crate::ConnectionError>;
 
     /// Get the underlying DbConnection this provider is using
-    fn conn_ref(&self) -> &DbConnection<Self::Connection>;
+    fn db(&self) -> &DbConnection<Self::Connection>;
 
     fn key_store(&self) -> &SqlKeyStore<Self::Connection>;
 }

--- a/xmtp_db/src/xmtp_openmls_provider.rs
+++ b/xmtp_db/src/xmtp_openmls_provider.rs
@@ -23,8 +23,8 @@ impl<C> XmtpOpenMlsProvider<C>
 where
     C: ConnectionExt,
 {
-    pub fn conn_ref(&self) -> &DbConnection<C> {
-        self.key_store.conn_ref()
+    pub fn db(&self) -> &DbConnection<C> {
+        self.key_store.db()
     }
 
     fn inner_transaction<T, F, E>(&self, fun: F) -> Result<T, E>
@@ -34,7 +34,7 @@ where
     {
         tracing::debug!("Transaction beginning");
 
-        let conn = self.conn_ref();
+        let conn = self.db();
         let _guard = conn.start_transaction()?;
 
         match fun(self) {
@@ -87,8 +87,8 @@ where
         XmtpOpenMlsProvider::<C>::inner_transaction(self, fun)
     }
 
-    fn conn_ref(&self) -> &DbConnection<C> {
-        self.key_store.conn_ref()
+    fn db(&self) -> &DbConnection<C> {
+        self.key_store.db()
     }
 
     fn key_store(&self) -> &SqlKeyStore<C> {
@@ -111,8 +111,8 @@ where
         XmtpOpenMlsProvider::<C>::inner_transaction(self, fun)
     }
 
-    fn conn_ref(&self) -> &DbConnection<C> {
-        self.key_store.conn_ref()
+    fn db(&self) -> &DbConnection<C> {
+        self.key_store.db()
     }
 
     fn key_store(&self) -> &SqlKeyStore<C> {

--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -128,7 +128,7 @@ impl<ApiClient, Db> ClientBuilder<ApiClient, Db> {
         // get sequence_id from identity updates and loaded into the DB
         load_identity_updates(
             &api_client,
-            provider.conn_ref(),
+            provider.db(),
             vec![identity.inbox_id.as_str()].as_slice(),
         )
         .await?;

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -582,7 +582,7 @@ where
         tracing::info!("finding or creating dm with address: {target_identity}");
         let provider = self.mls_provider();
         let inbox_id = match self
-            .find_inbox_id_from_identifier(provider.conn_ref(), target_identity.clone())
+            .find_inbox_id_from_identifier(provider.db(), target_identity.clone())
             .await?
         {
             Some(id) => id,
@@ -603,7 +603,7 @@ where
         let inbox_id = inbox_id.as_ref();
         tracing::info!("finding or creating dm with inbox_id: {}", inbox_id);
         let provider = self.mls_provider();
-        let group = provider.conn_ref().find_dm_group(&DmMembers {
+        let group = provider.db().find_dm_group(&DmMembers {
             member_one_inbox_id: self.inbox_id(),
             member_two_inbox_id: inbox_id,
         })?;
@@ -880,7 +880,7 @@ where
     #[tracing::instrument(level = "debug", skip_all)]
     pub async fn sync_welcomes(&self) -> Result<Vec<MlsGroup<Self>>, GroupError> {
         let provider = self.mls_provider();
-        let envelopes = self.query_welcome_messages(provider.conn_ref()).await?;
+        let envelopes = self.query_welcome_messages(provider.db()).await?;
         let num_envelopes = envelopes.len();
 
         let groups: Vec<MlsGroup<Self>> = stream::iter(envelopes.into_iter())
@@ -1004,7 +1004,7 @@ where
             ..GroupQueryArgs::default()
         };
         let groups = provider
-            .conn_ref()
+            .db()
             .find_groups(query_args)?
             .into_iter()
             .map(|g| MlsGroup::new(self.clone(), g.id, g.dm_id, g.created_at_ns))
@@ -1018,7 +1018,7 @@ where
         let provider = self.mls_provider();
         self.sync_welcomes().await?;
         let groups = provider
-            .conn_ref()
+            .db()
             .all_sync_groups()?
             .into_iter()
             .map(|g| MlsGroup::new(self.clone(), g.id, g.dm_id, g.created_at_ns))

--- a/xmtp_mls/src/groups/device_sync/archive/export_stream/consent_save.rs
+++ b/xmtp_mls/src/groups/device_sync/archive/export_stream/consent_save.rs
@@ -13,7 +13,7 @@ impl BackupRecordProvider for ConsentSave {
     {
         let batch = streamer
             .provider
-            .conn_ref()
+            .db()
             .consent_records_paged(Self::BATCH_SIZE, streamer.cursor)?;
 
         let records = batch

--- a/xmtp_mls/src/groups/device_sync/archive/export_stream/group_save.rs
+++ b/xmtp_mls/src/groups/device_sync/archive/export_stream/group_save.rs
@@ -32,7 +32,7 @@ impl BackupRecordProvider for GroupSave {
 
         let batch = streamer
             .provider
-            .conn_ref()
+            .db()
             .find_groups_by_id_paged(args, streamer.cursor)?;
 
         let storage = streamer.provider.storage();

--- a/xmtp_mls/src/groups/device_sync/archive/export_stream/message_save.rs
+++ b/xmtp_mls/src/groups/device_sync/archive/export_stream/message_save.rs
@@ -20,7 +20,7 @@ impl BackupRecordProvider for GroupMessageSave {
 
         let batch = streamer
             .provider
-            .conn_ref()
+            .db()
             .group_messages_paged(&args, streamer.cursor)
             .expect("Failed to load group records");
 

--- a/xmtp_mls/src/groups/device_sync/archive/importer.rs
+++ b/xmtp_mls/src/groups/device_sync/archive/importer.rs
@@ -127,10 +127,10 @@ where
     match element {
         Element::Consent(consent) => {
             let consent: StoredConsentRecord = consent.try_into()?;
-            provider.conn_ref().insert_newer_consent_record(consent)?;
+            provider.db().insert_newer_consent_record(consent)?;
         }
         Element::Group(save) => {
-            if let Ok(Some(_)) = provider.conn_ref().find_group(&save.id) {
+            if let Ok(Some(_)) = provider.db().find_group(&save.id) {
                 // Do not restore groups that already exist.
                 return Ok(());
             }
@@ -155,7 +155,7 @@ where
         }
         Element::GroupMessage(message) => {
             let message: StoredGroupMessage = message.try_into()?;
-            message.store_or_ignore(&provider.conn_ref())?;
+            message.store_or_ignore(provider.db())?;
         }
         _ => {}
     }

--- a/xmtp_mls/src/groups/device_sync/consent_sync.rs
+++ b/xmtp_mls/src/groups/device_sync/consent_sync.rs
@@ -49,7 +49,7 @@ pub(crate) mod tests {
 
         // Ensure that consent record now exists.
         let syncable_consent_records = amal_a
-            .syncable_consent_records(amal_a.provider.conn_ref())
+            .syncable_consent_records(amal_a.provider.db())
             .unwrap();
         assert_eq!(syncable_consent_records.len(), 1);
 
@@ -63,7 +63,7 @@ pub(crate) mod tests {
             .unwrap();
 
         let consent_records_b = amal_b
-            .syncable_consent_records(amal_b.provider.conn_ref())
+            .syncable_consent_records(amal_b.provider.db())
             .unwrap();
         assert_eq!(consent_records_b.len(), 0);
 
@@ -91,7 +91,7 @@ pub(crate) mod tests {
         // Ensure bo is not consented with amal_b
         let bo_consent_with_amal_b = amal_b
             .provider
-            .conn_ref()
+            .db()
             .get_consent_record(bo_wallet.get_inbox_id(0), ConsentType::InboxId)
             .unwrap();
         assert!(bo_consent_with_amal_b.is_none());

--- a/xmtp_mls/src/groups/device_sync/message_sync.rs
+++ b/xmtp_mls/src/groups/device_sync/message_sync.rs
@@ -13,7 +13,7 @@ where
     pub(super) fn syncable_groups(&self) -> Result<Vec<Syncable>, DeviceSyncError> {
         let provider = self.mls_provider();
         let groups = provider
-            .conn_ref()
+            .db()
             .find_groups(GroupQueryArgs::default())?
             .into_iter()
             .map(Syncable::Group)
@@ -24,12 +24,12 @@ where
 
     pub(super) fn syncable_messages(&self) -> Result<Vec<Syncable>, DeviceSyncError> {
         let provider = self.mls_provider();
-        let groups = provider.conn_ref().find_groups(GroupQueryArgs::default())?;
+        let groups = provider.db().find_groups(GroupQueryArgs::default())?;
 
         let mut all_messages = vec![];
         for StoredGroup { id, .. } in groups.into_iter() {
             let messages = provider
-                .conn_ref()
+                .db()
                 .get_group_messages(&id, &MsgQueryArgs::default())?;
             for msg in messages {
                 all_messages.push(Syncable::GroupMessage(msg));
@@ -86,7 +86,7 @@ pub(crate) mod tests {
         // Create a second installation for amal.
         let amal_b = ClientBuilder::new_test_client_with_history(&wallet, HISTORY_SYNC_URL).await;
         let amal_b_provider = amal_b.mls_provider();
-        let amal_b_conn = amal_b_provider.conn_ref();
+        let amal_b_conn = amal_b_provider.db();
 
         let groups_b = amal_b.syncable_groups().unwrap();
         assert_eq!(groups_b.len(), 0);
@@ -145,7 +145,7 @@ pub(crate) mod tests {
         let amal_a = ClientBuilder::new_test_client_with_history(&wallet, HISTORY_SYNC_URL).await;
 
         let amal_a_provider = amal_a.mls_provider();
-        let amal_a_conn = amal_a_provider.conn_ref();
+        let amal_a_conn = amal_a_provider.db();
 
         // make sure amal's worker has time to sync
         // 3 Intents:
@@ -163,7 +163,7 @@ pub(crate) mod tests {
         // Create a second installation for amal.
         let amal_b = ClientBuilder::new_test_client_with_history(&wallet, HISTORY_SYNC_URL).await;
         let amal_b_provider = amal_b.mls_provider();
-        let amal_b_conn = amal_b_provider.conn_ref();
+        let amal_b_conn = amal_b_provider.db();
 
         let groups_b = amal_b.syncable_groups().unwrap();
         assert_eq!(groups_b.len(), 0);

--- a/xmtp_mls/src/groups/device_sync/tests.rs
+++ b/xmtp_mls/src/groups/device_sync/tests.rs
@@ -124,7 +124,7 @@ async fn test_new_devices_not_added_to_old_sync_groups() {
     }
 
     // alix1 should have it's own created sync group and alix2's sync group
-    let alix1_sync_groups: Vec<StoredGroup> = alix1.provider.conn_ref().raw_query_read(|conn| {
+    let alix1_sync_groups: Vec<StoredGroup> = alix1.provider.db().raw_query_read(|conn| {
         dsl::groups
             .filter(dsl::conversation_type.eq(ConversationType::Sync))
             .load(conn)
@@ -134,7 +134,7 @@ async fn test_new_devices_not_added_to_old_sync_groups() {
     // alix2 should not be added to alix1's old sync group
 
     alix2.sync_welcomes().await?;
-    let alix2_sync_groups: Vec<StoredGroup> = alix2.provider.conn_ref().raw_query_read(|conn| {
+    let alix2_sync_groups: Vec<StoredGroup> = alix2.provider.db().raw_query_read(|conn| {
         dsl::groups
             .filter(dsl::conversation_type.eq(ConversationType::Sync))
             .load(conn)

--- a/xmtp_mls/src/groups/device_sync/worker.rs
+++ b/xmtp_mls/src/groups/device_sync/worker.rs
@@ -168,7 +168,7 @@ where
             );
 
             // The only thing that sync init really does right now is ensures that there's a sync group.
-            if provider.conn_ref().primary_sync_group()?.is_none() {
+            if provider.db().primary_sync_group()?.is_none() {
                 client.get_sync_group().await?;
 
                 // Ask the sync group for a sync payload if the url is present.
@@ -223,7 +223,7 @@ where
     /// Called when this device has received a device sync v1 sync reply
     async fn evt_v1_device_sync_reply(&self, message_id: Vec<u8>) -> Result<(), DeviceSyncError> {
         let provider = self.client.mls_provider();
-        if let Some(msg) = provider.conn_ref().get_group_message(&message_id)? {
+        if let Some(msg) = provider.db().get_group_message(&message_id)? {
             let content: DeviceSyncContent = serde_json::from_slice(&msg.decrypted_message_bytes)?;
             if let DeviceSyncContent::Reply(reply) = content {
                 self.client.v1_process_sync_reply(reply).await?;
@@ -235,7 +235,7 @@ where
     /// Called when this device has received a device sync v1 sync request
     async fn evt_v1_device_sync_request(&self, message_id: Vec<u8>) -> Result<(), DeviceSyncError> {
         let provider = self.client.mls_provider();
-        if let Some(msg) = provider.conn_ref().get_group_message(&message_id)? {
+        if let Some(msg) = provider.db().get_group_message(&message_id)? {
             let content: DeviceSyncContent = serde_json::from_slice(&msg.decrypted_message_bytes)?;
             if let DeviceSyncContent::Request(request) = content {
                 self.client

--- a/xmtp_mls/src/groups/disappearing_messages.rs
+++ b/xmtp_mls/src/groups/disappearing_messages.rs
@@ -96,7 +96,7 @@ where
     /// Iterate on the list of groups and delete expired messages
     async fn delete_expired_messages(&mut self) -> Result<(), DisappearingMessagesCleanerError> {
         let provider = self.client.mls_provider();
-        match provider.conn_ref().delete_expired_messages() {
+        match provider.db().delete_expired_messages() {
             Ok(deleted_count) if deleted_count > 0 => {
                 tracing::info!("Successfully deleted {} expired messages", deleted_count);
             }

--- a/xmtp_mls/src/groups/intents.rs
+++ b/xmtp_mls/src/groups/intents.rs
@@ -77,7 +77,7 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
         should_push: bool,
     ) -> Result<StoredGroupIntent, GroupError> {
         let res = self.mls_provider().transaction(|provider| {
-            let conn = provider.conn_ref();
+            let conn = provider.db();
             self.queue_intent_with_conn(conn, intent_kind, intent_data, should_push)
         });
 
@@ -112,7 +112,7 @@ impl<ScopedClient: ScopedGroupClient> MlsGroup<ScopedClient> {
 
     fn maybe_insert_key_update_intent(&self) -> Result<(), GroupError> {
         let provider = self.mls_provider();
-        let conn = provider.conn_ref();
+        let conn = provider.db();
         let last_rotated_at_ns = conn.get_rotated_at_ns(self.group_id.clone())?;
         let now_ns = xmtp_common::time::now_ns();
         let elapsed_ns = now_ns - last_rotated_at_ns;

--- a/xmtp_mls/src/groups/members.rs
+++ b/xmtp_mls/src/groups/members.rs
@@ -41,7 +41,7 @@ where
             .filter(|(_, sequence_id)| *sequence_id != 0) // Skip the initial state
             .collect::<Vec<_>>();
 
-        let conn = provider.conn_ref();
+        let conn = provider.db();
         let mut association_states: Vec<AssociationState> =
             StoredAssociationState::batch_read_from_cache(conn, requests.clone())?;
         let mutable_metadata = self.mutable_metadata()?;

--- a/xmtp_mls/src/groups/tests/mod.rs
+++ b/xmtp_mls/src/groups/tests/mod.rs
@@ -282,7 +282,7 @@ async fn test_add_member_conflict() {
     assert_eq!(bola_members_len, 3);
 
     let amal_uncommitted_intents = amal_db
-        .conn_ref()
+        .db()
         .find_group_intents(
             amal_group.group_id.clone(),
             Some(vec![
@@ -296,7 +296,7 @@ async fn test_add_member_conflict() {
     assert_eq!(amal_uncommitted_intents.len(), 0);
 
     let bola_failed_intents = bola_db
-        .conn_ref()
+        .db()
         .find_group_intents(
             bola_group.group_id.clone(),
             Some(vec![IntentState::Error]),
@@ -396,7 +396,7 @@ async fn test_dm_stitching() {
     // The dm shows up
     let alix_groups = alix
         .provider
-        .conn_ref()
+        .db()
         .raw_query_read(|conn| {
             groups::table
                 .order(groups::created_at_ns.desc())
@@ -410,7 +410,7 @@ async fn test_dm_stitching() {
     // The dm is filtered out up
     let mut alix_filtered_groups = alix
         .provider
-        .conn_ref()
+        .db()
         .find_groups(GroupQueryArgs::default())
         .unwrap();
     assert_eq!(alix_filtered_groups.len(), 1);
@@ -2483,7 +2483,7 @@ async fn skip_already_processed_intents() {
     bo_group.send_message(&[2]).await.unwrap();
     let bo_provider = bo_client.mls_provider();
     let intent = bo_provider
-        .conn_ref()
+        .db()
         .find_group_intents(
             bo_group.clone().group_id,
             Some(vec![IntentState::Processed]),
@@ -3530,7 +3530,7 @@ async fn test_when_processing_message_return_future_wrong_epoch_group_marked_pro
     assert!(!group_debug_info.fork_details.is_empty());
     client_b
         .mls_provider()
-        .conn_ref()
+        .db()
         .clear_fork_flag_for_group(&group_b.group_id)
         .unwrap();
     let group_debug_info = group_b.debug_info().await.unwrap();

--- a/xmtp_mls/src/groups/validated_commit.rs
+++ b/xmtp_mls/src/groups/validated_commit.rs
@@ -304,7 +304,7 @@ impl ValidatedCommit {
         openmls_group: &OpenMlsGroup,
     ) -> Result<Self, CommitValidationError> {
         let provider = client.mls_provider();
-        let conn = provider.conn_ref();
+        let conn = provider.db();
         // Get the immutable and mutable metadata
         let extensions = openmls_group.extensions();
         let immutable_metadata: GroupMetadata = extensions.try_into()?;
@@ -622,7 +622,7 @@ impl ExpectedDiff {
         mutable_metadata: &GroupMutableMetadata,
     ) -> Result<ExpectedDiff, CommitValidationError> {
         let provider = client.mls_provider();
-        let conn = provider.conn_ref();
+        let conn = provider.db();
         let old_group_membership = extract_group_membership(existing_group_extensions)?;
         let new_group_membership = get_latest_group_membership(staged_commit)?;
         let membership_diff = old_group_membership.diff(&new_group_membership);

--- a/xmtp_mls/src/subscriptions/mod.rs
+++ b/xmtp_mls/src/subscriptions/mod.rs
@@ -216,7 +216,7 @@ where
         envelope_bytes: Vec<u8>,
     ) -> Result<MlsGroup<Self>> {
         let provider = self.mls_provider();
-        let conn = provider.conn_ref();
+        let conn = provider.db();
         let envelope =
             WelcomeMessage::decode(envelope_bytes.as_slice()).map_err(SubscribeError::from)?;
         let known_welcomes = HashSet::from_iter(conn.group_welcome_ids()?.into_iter());

--- a/xmtp_mls/src/subscriptions/stream_all.rs
+++ b/xmtp_mls/src/subscriptions/stream_all.rs
@@ -56,7 +56,7 @@ where
             let provider = client.mls_provider();
             client.sync_welcomes().await?;
 
-            let groups = provider.conn_ref().find_groups(GroupQueryArgs {
+            let groups = provider.db().find_groups(GroupQueryArgs {
                 conversation_type,
                 consent_states,
                 include_duplicate_dms: true,

--- a/xmtp_mls/src/subscriptions/stream_conversations.rs
+++ b/xmtp_mls/src/subscriptions/stream_conversations.rs
@@ -163,10 +163,10 @@ where
         conversation_type: Option<ConversationType>,
     ) -> Result<Self> {
         let provider = client.mls_provider();
-        let conn = provider.conn_ref();
+        let conn = provider.db();
         let installation_key = client.installation_public_key();
         let id_cursor = provider
-            .conn_ref()
+            .db()
             .get_last_cursor_for_id(installation_key, EntityKind::Welcome)?;
         tracing::debug!(
             cursor = id_cursor,
@@ -489,7 +489,7 @@ where
     fn load_from_store(&self, id: i64) -> Result<(MlsGroup<C>, i64)> {
         let provider = self.client.mls_provider();
         let group = provider
-            .conn_ref()
+            .db()
             .find_group_by_welcome_id(id)?
             .ok_or(NotFound::GroupByWelcome(id))?;
         tracing::info!(

--- a/xmtp_mls/src/subscriptions/stream_messages.rs
+++ b/xmtp_mls/src/subscriptions/stream_messages.rs
@@ -206,7 +206,7 @@ where
         let last_cursor = {
             let provider = client.mls_provider();
             provider
-                .conn_ref()
+                .db()
                 .get_last_cursor_for_id(&new_group, EntityKind::Group)
         }?;
 


### PR DESCRIPTION
`conn_ref` meaning no longer makes sense, since we're not soliciting a new db connection, but instead get a smart pointer to the monolithic database object where we can call `raw_query{read|write}` to get the connection to read/write with. This higher level object is also what contains the queries we actually want to work with, like `find_groups` etc. this PR makes this distinction more clear in the code by renaming `conn_ref` to `db`

### Rename database access method from `conn_ref()` to `db()` in `MlsProviderExt` trait and update all implementations
Updates the database connection access method name across the MLS codebase:

* Renames `conn_ref()` to `db()` in the `MlsProviderExt` trait defined in [encrypted_store/mod.rs](https://github.com/xmtp/libxmtp/pull/1980/files#diff-7c11a42d3a8d1e571eea6a833dfe388063c036317c4d7a6fbce207fbb3beb387)
* Updates all implementations of `MlsProviderExt` in [sql_key_store.rs](https://github.com/xmtp/libxmtp/pull/1980/files#diff-76ee938c4cb11fbe2673615d9fde990a94ba939f4b81cc729f792783a667764a) and [xmtp_openmls_provider.rs](https://github.com/xmtp/libxmtp/pull/1980/files#diff-cf019cf13bea000df30ea4a1cb7ac863cdb71b2f7ce535f66676af92b03da690)
* Updates all call sites across the MLS codebase including group management, device sync, identity management, and subscription handling modules
* Removes commented-out implementation of `MlsProviderExt` for `Arc<Provider>`

#### 📍Where to Start
Start with the trait definition change in [encrypted_store/mod.rs](https://github.com/xmtp/libxmtp/pull/1980/files#diff-7c11a42d3a8d1e571eea6a833dfe388063c036317c4d7a6fbce207fbb3beb387) which defines the `MlsProviderExt` trait where the method name is changed from `conn_ref()` to `db()`.

----

_[Macroscope](https://app.macroscope.com) summarized 2f615f1._