### PR TITLE
Undo the stitched dm id override

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -2304,6 +2304,10 @@ impl FfiConversation {
             Err(_) => self.inner.group_id.clone(),
         }
     }
+
+    pub fn topic_id(&self) -> Vec<u8> {
+        self.inner.group_id.clone()
+    }
 }
 
 #[derive(uniffi::Enum, PartialEq, Debug, Clone)]
@@ -7745,6 +7749,11 @@ mod tests {
         assert_eq!(
             convo_alix.id(),
             convo_bo.id(),
+            "Conversations should get updated to match"
+        );
+        assert_ne!(
+            convo_alix.topic_id(),
+            convo_bo.topic_id(),
             "Conversations should get updated to match"
         );
         assert_eq!(convo_alix.id(), topic_bo_same.id(), "Topics should match");

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -2299,13 +2299,6 @@ impl FfiConversation {
 #[uniffi::export]
 impl FfiConversation {
     pub fn id(&self) -> Vec<u8> {
-        match self.inner.client.stitched_group(&self.inner.group_id) {
-            Ok(group) => group.group_id.clone(),
-            Err(_) => self.inner.group_id.clone(),
-        }
-    }
-
-    pub fn topic_id(&self) -> Vec<u8> {
         self.inner.group_id.clone()
     }
 }
@@ -7746,15 +7739,10 @@ mod tests {
             convo_bo_2.id(),
             "Conversations should match"
         );
-        assert_eq!(
+        assert_ne!(
             convo_alix.id(),
             convo_bo.id(),
-            "Conversations should get updated to match"
-        );
-        assert_ne!(
-            convo_alix.topic_id(),
-            convo_bo.topic_id(),
-            "Conversations should get updated to match"
+            "Conversations id should not match dms should be matched on peerInboxId"
         );
         assert_eq!(convo_alix.id(), topic_bo_same.id(), "Topics should match");
         assert_eq!(convo_alix.id(), topic_alix_same.id(), "Topics should match");

--- a/bindings_node/src/conversation.rs
+++ b/bindings_node/src/conversation.rs
@@ -120,10 +120,7 @@ impl Conversation {
 
   #[napi]
   pub fn id(&self) -> String {
-    match self.inner_client.stitched_group(&self.group_id) {
-      Ok(group) => hex::encode(group.group_id.clone()),
-      Err(_) => hex::encode(self.group_id.clone()),
-    }
+    hex::encode(self.group_id.clone())
   }
 
   #[napi]

--- a/bindings_wasm/src/conversation.rs
+++ b/bindings_wasm/src/conversation.rs
@@ -140,10 +140,7 @@ impl From<MlsGroup<RustXmtpClient>> for Conversation {
 impl Conversation {
   #[wasm_bindgen]
   pub fn id(&self) -> String {
-    match self.inner_client.stitched_group(&self.group_id) {
-      Ok(group) => hex::encode(group.group_id.clone()),
-      Err(_) => hex::encode(self.group_id.clone()),
-    }
+    hex::encode(self.group_id.clone())
   }
 
   #[wasm_bindgen]


### PR DESCRIPTION
I think long term we want a unique identifier for conversations that is not based on the group id so that we can preserve this information without allowing people to rely on it as the source of truth.
Users managing dms should use the peerInboxId to manage the group instead of the id.

Originally introduced here https://github.com/xmtp/libxmtp/pull/1790