### PR TITLE
log cleanup

### DIFF
--- a/xmtp_db/src/encrypted_store/database/wasm.rs
+++ b/xmtp_db/src/encrypted_store/database/wasm.rs
@@ -197,7 +197,6 @@ impl ConnectionExt for WasmDbConnection {
         F: FnOnce(&mut Self::Connection) -> Result<T, diesel::result::Error>,
         Self: Sized,
     {
-        tracing::info!("{}", self.path());
         let mut conn = self.conn.lock();
         Ok(fun(&mut conn)?)
     }
@@ -207,7 +206,6 @@ impl ConnectionExt for WasmDbConnection {
         F: FnOnce(&mut Self::Connection) -> Result<T, diesel::result::Error>,
         Self: Sized,
     {
-        tracing::info!("{}", self.path());
         let mut conn = self.conn.lock();
         Ok(fun(&mut conn)?)
     }


### PR DESCRIPTION
### Remove database path logging from `WasmDbConnection` raw query methods in XMTP database
Removes `tracing::info!` log statements that were logging database path information from the `raw_query_read` and `raw_query_write` methods in the `WasmDbConnection` implementation of the `ConnectionExt` trait in [wasm.rs](https://github.com/xmtp/libxmtp/pull/1993/files#diff-71dbf76b367beb548f956d1b3691acd50ccfd261d71bcf16520089e1d2f467e6).

#### 📍Where to Start
Start with the `WasmDbConnection` implementation in [wasm.rs](https://github.com/xmtp/libxmtp/pull/1993/files#diff-71dbf76b367beb548f956d1b3691acd50ccfd261d71bcf16520089e1d2f467e6), focusing on the `raw_query_read` and `raw_query_write` methods.

----

_[Macroscope](https://app.macroscope.com) summarized 7976579._