### PR TITLE
Re-enable multi-thread testing on stream tests

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -6420,7 +6420,7 @@ mod tests {
         assert!(bo_msgs.iter().any(|msg| msg.content.eq(&data)));
     }
 
-    #[tokio::test(flavor = "current_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
     async fn test_stream_consent() {
         let alix_a = Tester::builder().sync_worker().sync_server().build().await;
 
@@ -6565,7 +6565,7 @@ mod tests {
         b_stream.end_and_wait().await.unwrap();
     }
 
-    #[tokio::test(flavor = "current_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
     async fn test_stream_preferences() {
         let alix_a_span = info_span!("alix_a");
         let alix_a = Tester::builder()


### PR DESCRIPTION
### Enable multi-threaded execution with 5 worker threads for `test_stream_consent` and `test_stream_preferences` tests in `bindings_ffi/mls.rs`
Updates test configuration attributes in [mls.rs](https://github.com/xmtp/libxmtp/pull/1999/files#diff-3a24c3e76565487a710ac9863ac05160128f4f90892e07849b555a6de43a6e8f) to change test execution from single-threaded (`current_thread`) to multi-threaded mode with 5 worker threads for two test functions: `test_stream_consent` and `test_stream_preferences`.

#### 📍Where to Start
Start with the test functions `test_stream_consent` and `test_stream_preferences` in [mls.rs](https://github.com/xmtp/libxmtp/pull/1999/files#diff-3a24c3e76565487a710ac9863ac05160128f4f90892e07849b555a6de43a6e8f) to review the test configuration changes.

----

_[Macroscope](https://app.macroscope.com) summarized d401d3d._