### PR TITLE
fix 'GetNewestEnvelope' http endpoint

### DIFF
--- a/xmtp_api_d14n/src/endpoints/d14n/get_newest_envelopes.rs
+++ b/xmtp_api_d14n/src/endpoints/d14n/get_newest_envelopes.rs
@@ -29,7 +29,7 @@ impl Endpoint for GetNewestEnvelopes {
     type Output = GetNewestEnvelopeResponse;
 
     fn http_endpoint(&self) -> Cow<'static, str> {
-        Cow::from("/mls/v2/fetch-key-packages")
+        Cow::from("/mls/v2/get-newest-envelope")
     }
 
     fn grpc_endpoint(&self) -> Cow<'static, str> {


### PR DESCRIPTION
### Update HTTP endpoint path from `/mls/v2/fetch-key-packages` to `/mls/v2/get-newest-envelope` to fix `GetNewestEnvelope` endpoint routing
The HTTP endpoint path in [get_newest_envelopes.rs](https://github.com/xmtp/libxmtp/pull/2000/files#diff-6b987dc38693ad29759aaf434eebda9fea0c0a6cb4b9b7716986d86aa0b2d5f1) has been corrected to align with the endpoint's actual functionality.

#### 📍Where to Start
Begin reviewing the endpoint configuration in [get_newest_envelopes.rs](https://github.com/xmtp/libxmtp/pull/2000/files#diff-6b987dc38693ad29759aaf434eebda9fea0c0a6cb4b9b7716986d86aa0b2d5f1) where the HTTP path is defined.

----

_[Macroscope](https://app.macroscope.com) summarized 3876afa._