### PR TITLE
Fix WASM group debug info

### DIFF
--- a/bindings_wasm/src/conversation.rs
+++ b/bindings_wasm/src/conversation.rs
@@ -657,7 +657,11 @@ impl Conversation {
       .await
       .map_err(|e| JsError::new(&format!("{e}")))?;
 
-    Ok(crate::to_value(&ConversationDebugInfo::new(debug_info))?)
+    Ok(crate::to_value(&ConversationDebugInfo {
+      epoch: debug_info.epoch,
+      maybe_forked: debug_info.maybe_forked,
+      fork_details: debug_info.fork_details,
+    })?)
   }
 
   #[wasm_bindgen(js_name = findDuplicateDms)]

--- a/bindings_wasm/src/conversations.rs
+++ b/bindings_wasm/src/conversations.rs
@@ -174,22 +174,13 @@ impl MessageDisappearingSettings {
 #[wasm_bindgen(getter_with_clone)]
 #[derive(Clone, serde::Serialize)]
 pub struct ConversationDebugInfo {
-  #[wasm_bindgen(js_name = epoch)]
   pub epoch: u64,
   #[wasm_bindgen(js_name = maybeForked)]
+  #[serde(rename = "maybeForked")]
   pub maybe_forked: bool,
   #[wasm_bindgen(js_name = forkDetails)]
+  #[serde(rename = "forkDetails")]
   pub fork_details: String,
-}
-
-impl ConversationDebugInfo {
-  pub fn new(xmtp_debug_info: XmtpConversationDebugInfo) -> Self {
-    Self {
-      epoch: xmtp_debug_info.epoch,
-      maybe_forked: xmtp_debug_info.maybe_forked,
-      fork_details: xmtp_debug_info.fork_details,
-    }
-  }
 }
 
 #[wasm_bindgen(getter_with_clone)]

--- a/bindings_wasm/src/conversations.rs
+++ b/bindings_wasm/src/conversations.rs
@@ -16,10 +16,7 @@ use xmtp_db::group::GroupMembershipState as XmtpGroupMembershipState;
 use xmtp_db::group::GroupQueryArgs;
 use xmtp_db::user_preferences::HmacKey as XmtpHmacKey;
 use xmtp_mls::groups::group_mutable_metadata::MessageDisappearingSettings as XmtpMessageDisappearingSettings;
-use xmtp_mls::groups::{
-  ConversationDebugInfo as XmtpConversationDebugInfo, DMMetadataOptions, GroupMetadataOptions,
-  PreconfiguredPolicies,
-};
+use xmtp_mls::groups::{DMMetadataOptions, GroupMetadataOptions, PreconfiguredPolicies};
 
 #[wasm_bindgen]
 #[derive(Debug, Clone)]


### PR DESCRIPTION
# Summary

- Added `#[serde(rename = "...")]` attributes
- Removed unnecessary constructor

Resolves #1983 