### PR TITLE
16 KB Alignment in Native Libraries

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -13,3 +13,16 @@ update-schema = "run --bin update-schema --features update-schema"
 
 [build]
 rustflags = ["--cfg", "tracing_unstable"]
+
+
+[target.aarch64-linux-android]
+rustflags = ["-Clink-arg=-Wl,-z,max-page-size=16384"]
+
+[target.armv7-linux-androideabi]
+rustflags = ["-Clink-arg=-Wl,-z,max-page-size=16384"]
+
+[target.i686-linux-android]
+rustflags = ["-Clink-arg=-Wl,-z,max-page-size=16384"]
+
+[target.x86_64-linux-android]
+rustflags = ["-Clink-arg=-Wl,-z,max-page-size=16384"]

--- a/.github/workflows/release-kotlin-bindings.yml
+++ b/.github/workflows/release-kotlin-bindings.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Build target
         run: |
           cargo ndk --platform 23 -o bindings_ffi/jniLibs/ --manifest-path bindings_ffi/Cargo.toml -t ${{ matrix.target }} -- build --release
+      - name: Check ELF alignment
+        run: |
+          readelf -l target/${{ matrix.target }}/release/libxmtpv3.so | grep -i align
       - name: Prepare JNI libs
         run: |
           mkdir -p bindings_ffi/jniLibs/${{ matrix.output_target }}/ && \


### PR DESCRIPTION
Fixes https://github.com/xmtp/libxmtp/issues/1988

When compiling a .so library you need to configure the build process to use 16 KB page alignment. Android now flags native libraries that are only aligned to the older 4 KB boundary.