### PR TITLE
Filter out sync groups from conversation stream

### DIFF
--- a/xmtp_mls/src/subscriptions/process_welcome.rs
+++ b/xmtp_mls/src/subscriptions/process_welcome.rs
@@ -170,6 +170,13 @@ where
         match processed {
             New { group, id } => {
                 let metadata = group.metadata().await?;
+
+                // Do not stream sync groups.
+                if metadata.conversation_type == ConversationType::Sync {
+                    tracing::debug!("Sync group welcome processed. Skipping stream.");
+                    return Ok(ProcessWelcomeResult::IgnoreId { id });
+                }
+
                 // If it's a duplicate DM, don’t stream
                 if metadata.conversation_type == ConversationType::Dm
                     && self.client.db().has_duplicate_dm(&group.group_id)?

--- a/xmtp_mls/src/subscriptions/stream_conversations.rs
+++ b/xmtp_mls/src/subscriptions/stream_conversations.rs
@@ -437,6 +437,21 @@ mod test {
     }
 
     #[rstest::rstest]
+    #[xmtp_common::test(unwrap_try = "true")]
+    #[timeout(std::time::Duration::from_secs(5))]
+    async fn test_sync_groups_are_not_streamed() {
+        tester!(alix, sync_worker);
+        let stream = alix.stream_conversations(None).await?;
+        futures::pin_mut!(stream);
+
+        tester!(_alix2, from: alix);
+
+        let result =
+            xmtp_common::time::timeout(std::time::Duration::from_millis(100), stream.next()).await;
+        assert!(result.is_err(), "Sync group should not stream");
+    }
+
+    #[rstest::rstest]
     #[case(ConversationType::Dm, "Unexpectedly received a Group")]
     #[case(ConversationType::Group, "Unexpectedly received a DM")]
     #[xmtp_common::test]


### PR DESCRIPTION
### Prevent sync groups from appearing in conversation streams by adding filter condition in ProcessWelcome.filter method
* Adds new filtering logic in `ProcessWelcome.filter` method within [process_welcome.rs](https://github.com/xmtp/libxmtp/pull/2012/files#diff-317c20511a1befc7d46c6761a7addc8b70eb46f1ef84c8b6af03e30c2412b785) to identify and exclude sync type conversations
* Implements test case `test_sync_groups_are_not_streamed` in [stream_conversations.rs](https://github.com/xmtp/libxmtp/pull/2012/files#diff-7c3c0adb77b28c40ac418e970ce3dbf3320238ec155456eebedc187a61878aea) to verify sync groups are properly filtered from conversation streams

#### 📍Where to Start
Start with the `filter` method in the `ProcessWelcome` struct in [process_welcome.rs](https://github.com/xmtp/libxmtp/pull/2012/files#diff-317c20511a1befc7d46c6761a7addc8b70eb46f1ef84c8b6af03e30c2412b785) which contains the core filtering logic.

----

_[Macroscope](https://app.macroscope.com) summarized a0b4d2b._