### PR TITLE
Add nonce option to create_client

### DIFF
--- a/bindings_node/src/client.rs
+++ b/bindings_node/src/client.rs
@@ -3,7 +3,7 @@ use crate::identity::{Identifier, IdentityExt};
 use crate::inbox_state::InboxState;
 use crate::signatures::SignatureRequestType;
 use crate::ErrorWrapper;
-use napi::bindgen_prelude::{Error, Result, Uint8Array};
+use napi::bindgen_prelude::{BigInt, Error, Result, Uint8Array};
 use napi_derive::napi;
 use std::collections::HashMap;
 use std::ops::Deref;
@@ -139,6 +139,7 @@ pub async fn create_client(
   db_path: Option<String>,
   inbox_id: String,
   account_identifier: Identifier,
+  nonce: Option<BigInt>,
   encryption_key: Option<Uint8Array>,
   device_sync_server_url: Option<String>,
   device_sync_worker_mode: Option<SyncWorkerMode>,
@@ -178,8 +179,7 @@ pub async fn create_client(
   let identity_strategy = IdentityStrategy::new(
     inbox_id.clone(),
     internal_account_identifier,
-    // this is a temporary solution
-    1,
+    nonce.map(|n| n.get_u64().1).unwrap_or(1),
     None,
   );
 

--- a/bindings_node/test/helpers.ts
+++ b/bindings_node/test/helpers.ts
@@ -57,6 +57,7 @@ export const createClient = async (user: User) => {
     },
     undefined,
     undefined,
+    undefined,
     SyncWorkerMode.disabled,
     { level: LogLevel.off }
   )

--- a/bindings_wasm/src/client.rs
+++ b/bindings_wasm/src/client.rs
@@ -143,6 +143,7 @@ pub async fn create_client(
   host: String,
   inbox_id: String,
   account_identifier: Identifier,
+  nonce: Option<u64>,
   db_path: Option<String>,
   encryption_key: Option<Uint8Array>,
   device_sync_server_url: Option<String>,
@@ -177,8 +178,7 @@ pub async fn create_client(
   let identity_strategy = IdentityStrategy::new(
     inbox_id.clone(),
     account_identifier.clone().try_into()?,
-    // this is a temporary solution
-    1,
+    nonce.unwrap_or(1),
     None,
   );
 


### PR DESCRIPTION
# Summary

- Added `nonce` option to the `create_client` method in the WASM and node bindings