### PR TITLE
Envelope Validation

### DIFF
--- a/xmtp_api_d14n/src/protocol/mod.rs
+++ b/xmtp_api_d14n/src/protocol/mod.rs
@@ -11,6 +11,9 @@ pub mod envelopes;
 pub mod extractors;
 pub use extractors::*;
 
+pub mod validation;
+pub use validation::*;
+
 mod impls;
 
 use openmls::prelude::ProtocolVersion;

--- a/xmtp_api_d14n/src/protocol/traits.rs
+++ b/xmtp_api_d14n/src/protocol/traits.rs
@@ -4,6 +4,7 @@
 use super::ExtractionError;
 use super::PayloadExtractor;
 use super::TopicExtractor;
+use super::ValidationError;
 use xmtp_common::RetryableError;
 use xmtp_common::retryable;
 use xmtp_proto::ConversionError;
@@ -37,6 +38,8 @@ pub enum EnvelopeError {
     // generic implementations like Tuples
     #[error("{0}")]
     DynError(Box<dyn RetryableError + Send + Sync>),
+    #[error(transparent)]
+    Validation(#[from] ValidationError),
 }
 
 impl RetryableError for EnvelopeError {
@@ -46,6 +49,7 @@ impl RetryableError for EnvelopeError {
             Self::Extraction(e) => retryable!(e),
             Self::TopicMismatch => false,
             Self::DynError(d) => retryable!(d),
+            Self::Validation(e) => retryable!(e),
         }
     }
 }

--- a/xmtp_api_d14n/src/protocol/validation.rs
+++ b/xmtp_api_d14n/src/protocol/validation.rs
@@ -1,0 +1,85 @@
+use super::{EnvelopeError, EnvelopeVisitor};
+use std::collections::HashMap;
+use thiserror::Error;
+use xmtp_common::{RetryableError, time::now_ns};
+use xmtp_proto::xmtp::{
+    identity::associations::RecoverableEcdsaSignature,
+    xmtpv4::envelopes::{
+        OriginatorEnvelope, UnsignedOriginatorEnvelope, originator_envelope::Proof,
+    },
+};
+
+const NS_IN_SEC: i64 = 1_000_000_000;
+pub const NS_IN_HALF_HOUR: i64 = NS_IN_SEC * 60 * 30;
+
+pub struct QueryEnvelopeValidator {
+    originator_public_keys: HashMap<u32, Vec<u8>>,
+    originator_proof: Option<RecoverableEcdsaSignature>,
+}
+
+#[derive(Debug, Error)]
+pub enum ValidationError {
+    #[error("Message AAD is corrupt or invalid")]
+    BadAAD,
+    #[error("Invalid signature on {envelope:?} envelope")]
+    InvalidSignature { envelope: EnvelopeType },
+    #[error("{envelope:?} envelope in message is missing proof")]
+    MissingProof { envelope: EnvelopeType },
+    #[error("Received incorrect proof on {envelope:?} envelope in message. Found {found:?}")]
+    IncorrectProof {
+        envelope: EnvelopeType,
+        found: Proof,
+    },
+    #[error("Time discrepancy is too great. ({0}ns)")]
+    TimeDiscrepancy(i64),
+}
+
+impl RetryableError for ValidationError {
+    fn is_retryable(&self) -> bool {
+        false
+    }
+}
+
+//impl From<ValidationError> for EnvelopeError {
+//    fn from(err: ValidationError) -> Self {
+//        EnvelopeError::Validation(err)
+//    }
+//}
+
+#[derive(Debug)]
+enum EnvelopeType {
+    Originator,
+}
+
+impl EnvelopeVisitor<'_> for QueryEnvelopeValidator {
+    type Error = ValidationError;
+
+    fn visit_originator(&mut self, e: &OriginatorEnvelope) -> Result<(), Self::Error> {
+        match &e.proof {
+            Some(Proof::OriginatorSignature(ecdsa_sig)) => {
+                self.originator_proof = Some(ecdsa_sig.clone());
+                Ok(())
+            }
+            Some(found) => Err(ValidationError::IncorrectProof {
+                envelope: EnvelopeType::Originator,
+                found: found.clone(),
+            }),
+            None => Err(ValidationError::MissingProof {
+                envelope: EnvelopeType::Originator,
+            }),
+        }
+    }
+
+    fn visit_unsigned_originator(
+        &mut self,
+        e: &UnsignedOriginatorEnvelope,
+    ) -> Result<(), Self::Error> {
+        // Check the time discrepancy
+        let time_diff = now_ns() - e.originator_ns;
+        if time_diff > NS_IN_HALF_HOUR {
+            return Err(ValidationError::TimeDiscrepancy(time_diff));
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
### Add envelope validation system with 30-minute time discrepancy checks and signature verification in XMTP protocol
Introduces a new validation system for XMTP protocol envelopes through several key changes:

* Adds new `validation` module in [protocol/validation.rs](https://github.com/xmtp/libxmtp/pull/2016/files#diff-0df948e296a8ab6515f0a6e34a7a910eea55ee3e0aee7628616350335c2a5b89) implementing `QueryEnvelopeValidator` with time-based validation and signature verification for originator envelopes
* Extends `EnvelopeError` enum in [protocol/traits.rs](https://github.com/xmtp/libxmtp/pull/2016/files#diff-297e793d7f5174ff592f761aaec88158d67dc19a5e749b1b11f6f9cc87e3c14b) with a new `Validation` variant to handle validation errors
* Modifies `from_recoverable_ecdsa` method in [verified_signature.rs](https://github.com/xmtp/libxmtp/pull/2016/files#diff-77573fa987722614a7a219a3a656502f7d2b8c27daf0da69d950a72bc933b71b) to accept generic `RecoveryMessage` types
* Makes validation module publicly accessible through [protocol/mod.rs](https://github.com/xmtp/libxmtp/pull/2016/files#diff-a6a03e2b7cb5148bd7a191af8d4afd652a5e1de9af749bdfd6f35dbf1f9ee7d0)

#### 📍Where to Start
Start with the new validation implementation in [validation.rs](https://github.com/xmtp/libxmtp/pull/2016/files#diff-0df948e296a8ab6515f0a6e34a7a910eea55ee3e0aee7628616350335c2a5b89) which contains the core `QueryEnvelopeValidator` struct and validation logic.

----

_[Macroscope](https://app.macroscope.com) summarized d9061aa._