### PR TITLE
Tweak key rotation behavior

### DIFF
--- a/xmtp_db/src/encrypted_store/group.rs
+++ b/xmtp_db/src/encrypted_store/group.rs
@@ -18,6 +18,7 @@ use diesel::{
     sql_types::Integer,
 };
 use serde::{Deserialize, Serialize};
+use xmtp_common::time::now_ns;
 mod convert;
 mod dms;
 mod version;
@@ -48,7 +49,7 @@ pub struct StoredGroup {
     #[builder(default = None)]
     pub welcome_id: Option<i64>,
     /// The last time the leaf node encryption key was rotated
-    #[builder(default = "0")]
+    #[builder(default = now_ns())]
     pub rotated_at_ns: i64,
     /// Enum, [`ConversationType`] signifies the group conversation type which extends to who can access it.
     #[builder(default = "self.default_conversation_type()")]


### PR DESCRIPTION
### Initialize `StoredGroup` rotation timestamp with current time instead of zero in XMTP database
Updates the default initialization behavior in [group.rs](https://github.com/xmtp/libxmtp/pull/2018/files#diff-e3d4940853a1045db514d5c1a48581d9ef53da4ba45a7cb8387c72c99c475b5a) to set the `rotated_at_ns` field to the current timestamp in nanoseconds using the newly imported `now_ns()` function from `xmtp_common::time`.

#### 📍Where to Start
Start with the `StoredGroup` struct definition in [group.rs](https://github.com/xmtp/libxmtp/pull/2018/files#diff-e3d4940853a1045db514d5c1a48581d9ef53da4ba45a7cb8387c72c99c475b5a) where the default value for `rotated_at_ns` has been modified.

----

_[Macroscope](https://app.macroscope.com) summarized 316a206._