### PR TITLE
mock db

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7979,6 +7979,7 @@ dependencies = [
  "dyn-clone",
  "hex",
  "libsqlite3-sys",
+ "mockall",
  "openmls",
  "openmls_basic_credential",
  "openmls_rust_crypto",

--- a/xmtp_db/Cargo.toml
+++ b/xmtp_db/Cargo.toml
@@ -17,6 +17,7 @@ ctor.workspace = true
 derive_builder.workspace = true
 diesel_migrations = { workspace = true, features = ["sqlite"] }
 hex.workspace = true
+mockall.workspace = true
 openmls.workspace = true
 openmls_basic_credential.workspace = true
 openmls_rust_crypto.workspace = true

--- a/xmtp_db/src/encrypted_store/mod.rs
+++ b/xmtp_db/src/encrypted_store/mod.rs
@@ -70,8 +70,8 @@ pub enum StorageOption {
 }
 
 pub struct TransactionGuard<'a> {
-    in_transaction: Arc<AtomicBool>,
-    _mutex_guard: parking_lot::MutexGuard<'a, ()>,
+    pub(crate) in_transaction: Arc<AtomicBool>,
+    pub(crate) _mutex_guard: parking_lot::MutexGuard<'a, ()>,
 }
 
 impl Drop for TransactionGuard<'_> {

--- a/xmtp_db/src/lib.rs
+++ b/xmtp_db/src/lib.rs
@@ -10,6 +10,8 @@ mod traits;
 pub use traits::*;
 pub mod xmtp_openmls_provider;
 pub use xmtp_openmls_provider::*;
+#[cfg(any(feature = "test-utils", test))]
+pub mod mock;
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;

--- a/xmtp_db/src/mock.rs
+++ b/xmtp_db/src/mock.rs
@@ -1,0 +1,87 @@
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+
+use diesel::{
+    connection::{AnsiTransactionManager, TransactionManager},
+    prelude::SqliteConnection,
+};
+use mockall::mock;
+use parking_lot::Mutex;
+
+use crate::{
+    ConnectionError, ConnectionExt, DbConnection, StorageOption, TransactionGuard, XmtpDb,
+};
+
+pub struct MockConnection {
+    inner: Arc<Mutex<SqliteConnection>>,
+    in_transaction: Arc<AtomicBool>,
+    transaction_lock: Arc<Mutex<()>>,
+}
+
+// TODO: We should use diesels test transaction
+impl ConnectionExt for MockConnection {
+    type Connection = SqliteConnection;
+
+    fn start_transaction(&self) -> Result<crate::TransactionGuard<'_>, crate::ConnectionError> {
+        let guard = self.transaction_lock.lock();
+        let mut c = self.inner.lock();
+        AnsiTransactionManager::begin_transaction(&mut *c)?;
+        self.in_transaction.store(true, Ordering::SeqCst);
+
+        Ok(TransactionGuard {
+            _mutex_guard: guard,
+            in_transaction: self.in_transaction.clone(),
+        })
+    }
+
+    fn raw_query_read<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
+    where
+        F: FnOnce(&mut Self::Connection) -> Result<T, diesel::result::Error>,
+        Self: Sized,
+    {
+        let mut conn = self.inner.lock();
+        fun(&mut conn).map_err(ConnectionError::from)
+    }
+
+    fn raw_query_write<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
+    where
+        F: FnOnce(&mut Self::Connection) -> Result<T, diesel::result::Error>,
+        Self: Sized,
+    {
+        let mut conn = self.inner.lock();
+        fun(&mut conn).map_err(ConnectionError::from)
+    }
+}
+
+pub struct MockDb;
+
+mock! {
+    pub MockDb { }
+
+    impl XmtpDb for MockDb {
+    type Connection = MockConnection;
+
+    fn init(&self, opts: &StorageOption) -> Result<(), ConnectionError>;
+
+    /// The Options this databae was created with
+    fn opts(&self) -> &crate::StorageOption;
+
+    /// Validate a connection is as expected
+    fn validate(&self, _opts: &StorageOption) -> Result<(), ConnectionError>;
+
+    /// Returns the Connection implementation for this Database
+    fn conn(&self) -> MockConnection;
+
+    /// Returns a higher-level wrapeped DbConnection from which high-level queries may be
+    /// accessed.
+    fn db(&self) -> DbConnection<MockConnection>;
+
+    /// Reconnect to the database
+    fn reconnect(&self) -> Result<(), ConnectionError>;
+
+    /// Release connection to the database, closing it
+    fn disconnect(&self) -> Result<(), ConnectionError>;
+    }
+}


### PR DESCRIPTION
### Add mock database functionality to `xmtp_db` package for testing
* Implements mock database functionality in new `mock` module with `MockConnection` and `MockDb` structs in [mock.rs](https://github.com/xmtp/libxmtp/pull/2020/files#diff-a33010f529ff112a9cecbe97825a88a6bf662298ee71bca5c5c53c61c2dd7999)
* Adds `mockall` dependency to [Cargo.toml](https://github.com/xmtp/libxmtp/pull/2020/files#diff-4ab479f5820b3bb9458d1508e1785c89d7230eeeeeaf8a9d88861e56ccee8d9b) and [Cargo.lock](https://github.com/xmtp/libxmtp/pull/2020/files#diff-13ee4b2252c9e516a0547f2891aa2105c3ca71c6d7a1e682c69be97998dfc87e)
* Modifies visibility of `TransactionGuard` fields to `pub(crate)` in [mod.rs](https://github.com/xmtp/libxmtp/pull/2020/files#diff-7c11a42d3a8d1e571eea6a833dfe388063c036317c4d7a6fbce207fbb3beb387)
* Adds conditionally compiled `mock` module in [lib.rs](https://github.com/xmtp/libxmtp/pull/2020/files#diff-c199e5ef558d146f375307a50b45a68225e86dae21ed1b8197ea96c49412182c)

#### 📍Where to Start
Start with the mock implementations in [mock.rs](https://github.com/xmtp/libxmtp/pull/2020/files#diff-a33010f529ff112a9cecbe97825a88a6bf662298ee71bca5c5c53c61c2dd7999) which contains the core mock functionality including the `MockConnection` and `MockDb` structs.

----

_[Macroscope](https://app.macroscope.com) summarized 5f057e8._