### PR TITLE
Pass db connection to key updates

### DIFF
--- a/xmtp_mls/src/groups/intents.rs
+++ b/xmtp_mls/src/groups/intents.rs
@@ -96,7 +96,7 @@ where
         should_push: bool,
     ) -> Result<StoredGroupIntent, GroupError> {
         if intent_kind == IntentKind::SendMessage {
-            self.maybe_insert_key_update_intent()?;
+            self.maybe_insert_key_update_intent(conn)?;
         }
 
         let intent = conn.insert_group_intent(NewGroupIntent::new(
@@ -114,9 +114,10 @@ where
         Ok(intent)
     }
 
-    fn maybe_insert_key_update_intent(&self) -> Result<(), GroupError> {
-        let provider = self.mls_provider();
-        let conn = provider.db();
+    fn maybe_insert_key_update_intent(
+        &self,
+        conn: &DbConnection<<Db as XmtpDb>::Connection>,
+    ) -> Result<(), GroupError> {
         let last_rotated_at_ns = conn.get_rotated_at_ns(self.group_id.clone())?;
         let now_ns = xmtp_common::time::now_ns();
         let elapsed_ns = now_ns - last_rotated_at_ns;


### PR DESCRIPTION
### Modify `maybe_insert_key_update_intent` method to accept database connection parameter in group intent system
The `maybe_insert_key_update_intent` method in [intents.rs](https://github.com/xmtp/libxmtp/pull/2024/files#diff-2288952982788551d8fa6f279ebf922ee9fb1b15222414137277d097ead95e35) has been refactored to accept a database connection parameter instead of creating one internally. The method signature now includes `conn: &DbConnection<<Db as XmtpDb>::Connection>` as a parameter, and the calling code in `queue_intent_with_conn` has been updated to pass its existing database connection.

#### 📍Where to Start
Start with the modified `maybe_insert_key_update_intent` method in [intents.rs](https://github.com/xmtp/libxmtp/pull/2024/files#diff-2288952982788551d8fa6f279ebf922ee9fb1b15222414137277d097ead95e35), which now accepts a database connection parameter.

----

_[Macroscope](https://app.macroscope.com) summarized 73f9f34._