### PR TITLE
Add network stats to the client

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -5,6 +5,7 @@ use crate::worker::FfiSyncWorker;
 use crate::worker::FfiSyncWorkerMode;
 use crate::{FfiSubscribeError, GenericError};
 use prost::Message;
+use xmtp_proto::api_client::AggregateStats;
 use xmtp_proto::api_client::ApiStats;
 use xmtp_proto::api_client::IdentityStats;
 use std::{collections::HashMap, convert::TryInto, sync::Arc};
@@ -334,6 +335,13 @@ impl FfiXmtpClient {
 
     pub fn api_identity_statistics(&self) -> FfiIdentityStats {
         self.inner_client.identity_api_stats().into()
+    }
+
+    pub fn api_aggregate_statistics(&self) -> String {
+        let api = self.inner_client.api_stats();
+        let identity = self.inner_client.identity_api_stats();
+        let aggregate = AggregateStats { mls: api, identity };
+        format!("{:?}", aggregate)
     }
 
     pub fn inbox_id(&self) -> InboxId {

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -3378,7 +3378,6 @@ mod tests {
         let tester = Tester::builder().sync_worker().sync_server().build().await;
         let client: &FfiXmtpClient = &tester.client;
 
-        // Trigger some known stats activity
         let bo = Tester::new().await;
         let _conversation = client
             .conversations()
@@ -3393,7 +3392,6 @@ mod tests {
             .conversations()
             .list(FfiListConversationsOptions::default());
 
-        // --- Check FfiApiStats ---
         let api_stats = client.api_statistics();
         assert!(
             api_stats.send_group_messages >= 1,
@@ -3404,7 +3402,6 @@ mod tests {
             "Expected at least one welcome message"
         );
 
-        // --- Check FfiIdentityStats ---
         let identity_stats = client.api_identity_statistics();
         assert_eq!(
             identity_stats.publish_identity_update, 1,
@@ -3415,7 +3412,6 @@ mod tests {
             "Expected get_inbox_ids to be called"
         );
 
-        // --- Check FfiAggregateStats string ---
         let aggregate_str = client.api_aggregate_statistics();
         println!("Aggregate Stats:\n{}", aggregate_str);
 

--- a/bindings_node/src/client.rs
+++ b/bindings_node/src/client.rs
@@ -1,5 +1,5 @@
 use crate::conversations::Conversations;
-use crate::identity::{Identifier, IdentityExt};
+use crate::identity::{ApiStats, Identifier, IdentityExt, IdentityStats};
 use crate::inbox_state::InboxState;
 use crate::signatures::SignatureRequestType;
 use crate::ErrorWrapper;

--- a/bindings_node/src/client.rs
+++ b/bindings_node/src/client.rs
@@ -18,6 +18,7 @@ use xmtp_mls::builder::SyncWorkerMode as XmtpSyncWorkerMode;
 use xmtp_mls::groups::MlsGroup;
 use xmtp_mls::identity::IdentityStrategy;
 use xmtp_mls::Client as MlsClient;
+use xmtp_proto::api_client::AggregateStats;
 
 pub type RustXmtpClient = MlsClient<ApiDebugWrapper<TonicApiClient>>;
 pub type RustMlsGroup = MlsGroup<ApiDebugWrapper<TonicApiClient>, xmtp_db::DefaultStore>;
@@ -346,5 +347,23 @@ impl Client {
     let num_groups_synced: u32 = num_groups_synced.try_into().map_err(ErrorWrapper::from)?;
 
     Ok(num_groups_synced)
+  }
+
+  #[napi]
+  pub fn api_statistics(&self) -> ApiStats {
+    self.inner_client.api_stats().into()
+  }
+
+  #[napi]
+  pub fn api_identity_statistics(&self) -> IdentityStats {
+    self.inner_client.identity_api_stats().into()
+  }
+
+  #[napi]
+  pub fn api_aggregate_statistics(&self) -> String {
+    let api = self.inner_client.api_stats();
+    let identity = self.inner_client.identity_api_stats();
+    let aggregate = AggregateStats { mls: api, identity };
+    format!("{:?}", aggregate)
   }
 }

--- a/bindings_node/src/identity.rs
+++ b/bindings_node/src/identity.rs
@@ -1,4 +1,5 @@
 use crate::ErrorWrapper;
+use napi::bindgen_prelude::BigInt;
 use napi_derive::napi;
 use xmtp_cryptography::signature::IdentifierValidationError;
 use xmtp_id::associations::{ident, Identifier as XmtpIdentifier};
@@ -53,5 +54,53 @@ impl IdentityExt<Identifier, XmtpIdentifier> for Vec<Identifier> {
     let ident: Result<Vec<_>, ErrorWrapper<IdentifierValidationError>> =
       self.into_iter().map(|ident| ident.try_into()).collect();
     ident
+  }
+}
+
+#[napi(object)]
+pub struct ApiStats {
+  pub upload_key_package: BigInt,
+  pub fetch_key_package: BigInt,
+  pub send_group_messages: BigInt,
+  pub send_welcome_messages: BigInt,
+  pub query_group_messages: BigInt,
+  pub query_welcome_messages: BigInt,
+  pub subscribe_messages: BigInt,
+  pub subscribe_welcomes: BigInt,
+}
+
+impl From<xmtp_proto::api_client::ApiStats> for ApiStats {
+  fn from(stats: xmtp_proto::api_client::ApiStats) -> Self {
+    Self {
+      upload_key_package: BigInt::from(stats.upload_key_package.get_count() as u64),
+      fetch_key_package: BigInt::from(stats.fetch_key_package.get_count() as u64),
+      send_group_messages: BigInt::from(stats.send_group_messages.get_count() as u64),
+      send_welcome_messages: BigInt::from(stats.send_welcome_messages.get_count() as u64),
+      query_group_messages: BigInt::from(stats.query_group_messages.get_count() as u64),
+      query_welcome_messages: BigInt::from(stats.query_welcome_messages.get_count() as u64),
+      subscribe_messages: BigInt::from(stats.subscribe_messages.get_count() as u64),
+      subscribe_welcomes: BigInt::from(stats.subscribe_welcomes.get_count() as u64),
+    }
+  }
+}
+
+#[napi(object)]
+pub struct IdentityStats {
+  pub publish_identity_update: BigInt,
+  pub get_identity_updates_v2: BigInt,
+  pub get_inbox_ids: BigInt,
+  pub verify_smart_contract_wallet_signature: BigInt,
+}
+
+impl From<xmtp_proto::api_client::IdentityStats> for IdentityStats {
+  fn from(stats: xmtp_proto::api_client::IdentityStats) -> Self {
+    Self {
+      publish_identity_update: BigInt::from(stats.publish_identity_update.get_count() as u64),
+      get_identity_updates_v2: BigInt::from(stats.get_identity_updates_v2.get_count() as u64),
+      get_inbox_ids: BigInt::from(stats.get_inbox_ids.get_count() as u64),
+      verify_smart_contract_wallet_signature: BigInt::from(
+        stats.verify_smart_contract_wallet_signature.get_count() as u64,
+      ),
+    }
   }
 }

--- a/bindings_wasm/src/client.rs
+++ b/bindings_wasm/src/client.rs
@@ -19,7 +19,7 @@ use xmtp_mls::Client as MlsClient;
 use xmtp_proto::api_client::AggregateStats;
 
 use crate::conversations::Conversations;
-use crate::identity::{ApiStats, Identifier, IdentityStats, StreamStats};
+use crate::identity::{ApiStats, Identifier, IdentityStats};
 use crate::inbox_state::InboxState;
 use crate::signatures::SignatureRequestType;
 
@@ -369,11 +369,6 @@ impl Client {
   #[wasm_bindgen(js_name = apiIdentityStatistics)]
   pub fn api_identity_statistics(&self) -> IdentityStats {
     self.inner_client.identity_api_stats().into()
-  }
-
-  #[wasm_bindgen(js_name = apiStreamStatistics)]
-  pub fn api_stream_statistics(&self) -> StreamStats {
-    self.inner_client.api_stats().into()
   }
 
   #[wasm_bindgen(js_name = apiAggregateStatistics)]

--- a/bindings_wasm/src/client.rs
+++ b/bindings_wasm/src/client.rs
@@ -371,7 +371,7 @@ impl Client {
     self.inner_client.identity_api_stats().into()
   }
 
-  #[wasm_bindgen(js_name = apiStatistics)]
+  #[wasm_bindgen(js_name = apiStreamStatistics)]
   pub fn api_stream_statistics(&self) -> StreamStats {
     self.inner_client.api_stats().into()
   }

--- a/bindings_wasm/src/client.rs
+++ b/bindings_wasm/src/client.rs
@@ -16,9 +16,10 @@ use xmtp_mls::builder::SyncWorkerMode;
 use xmtp_mls::groups::MlsGroup;
 use xmtp_mls::identity::IdentityStrategy;
 use xmtp_mls::Client as MlsClient;
+use xmtp_proto::api_client::AggregateStats;
 
 use crate::conversations::Conversations;
-use crate::identity::Identifier;
+use crate::identity::{ApiStats, Identifier, IdentityStats};
 use crate::inbox_state::InboxState;
 use crate::signatures::SignatureRequestType;
 
@@ -358,5 +359,23 @@ impl Client {
       .map_err(|_| JsError::new("Failed to convert usize to u32"))?;
 
     Ok(num_groups_synced)
+  }
+
+  #[wasm_bindgen(js_name = apiStatistics)]
+  pub fn api_statistics(&self) -> ApiStats {
+    self.inner_client.api_stats().into()
+  }
+
+  #[wasm_bindgen(js_name = apiIdentityStatistics)]
+  pub fn api_identity_statistics(&self) -> IdentityStats {
+    self.inner_client.identity_api_stats().into()
+  }
+
+  #[wasm_bindgen(js_name = apiAggregateStatistics)]
+  pub fn api_aggregate_statistics(&self) -> String {
+    let api = self.inner_client.api_stats();
+    let identity = self.inner_client.identity_api_stats();
+    let aggregate = AggregateStats { mls: api, identity };
+    format!("{:?}", aggregate)
   }
 }

--- a/bindings_wasm/src/client.rs
+++ b/bindings_wasm/src/client.rs
@@ -19,7 +19,7 @@ use xmtp_mls::Client as MlsClient;
 use xmtp_proto::api_client::AggregateStats;
 
 use crate::conversations::Conversations;
-use crate::identity::{ApiStats, Identifier, IdentityStats};
+use crate::identity::{ApiStats, Identifier, IdentityStats, StreamStats};
 use crate::inbox_state::InboxState;
 use crate::signatures::SignatureRequestType;
 
@@ -369,6 +369,11 @@ impl Client {
   #[wasm_bindgen(js_name = apiIdentityStatistics)]
   pub fn api_identity_statistics(&self) -> IdentityStats {
     self.inner_client.identity_api_stats().into()
+  }
+
+  #[wasm_bindgen(js_name = apiStatistics)]
+  pub fn api_stream_statistics(&self) -> StreamStats {
+    self.inner_client.api_stats().into()
   }
 
   #[wasm_bindgen(js_name = apiAggregateStatistics)]

--- a/bindings_wasm/src/identity.rs
+++ b/bindings_wasm/src/identity.rs
@@ -64,8 +64,6 @@ pub struct ApiStats {
   pub send_welcome_messages: u64,
   pub query_group_messages: u64,
   pub query_welcome_messages: u64,
-  pub subscribe_messages: u64,
-  pub subscribe_welcomes: u64,
 }
 
 #[wasm_bindgen]
@@ -78,8 +76,6 @@ impl ApiStats {
     send_welcome_messages: u64,
     query_group_messages: u64,
     query_welcome_messages: u64,
-    subscribe_messages: u64,
-    subscribe_welcomes: u64,
   ) -> Self {
     Self {
       upload_key_package,
@@ -88,8 +84,6 @@ impl ApiStats {
       send_welcome_messages,
       query_group_messages,
       query_welcome_messages,
-      subscribe_messages,
-      subscribe_welcomes,
     }
   }
 }
@@ -103,8 +97,6 @@ impl From<xmtp_proto::api_client::ApiStats> for ApiStats {
       send_welcome_messages: stats.send_welcome_messages.get_count() as u64,
       query_group_messages: stats.query_group_messages.get_count() as u64,
       query_welcome_messages: stats.query_welcome_messages.get_count() as u64,
-      subscribe_messages: stats.subscribe_messages.get_count() as u64,
-      subscribe_welcomes: stats.subscribe_welcomes.get_count() as u64,
     }
   }
 }
@@ -145,6 +137,36 @@ impl From<xmtp_proto::api_client::IdentityStats> for IdentityStats {
       verify_smart_contract_wallet_signature: stats
         .verify_smart_contract_wallet_signature
         .get_count() as u64,
+    }
+  }
+}
+
+#[wasm_bindgen(getter_with_clone)]
+#[derive(Clone)]
+pub struct StreamStats {
+  pub subscribe_messages: u64,
+  pub subscribe_welcomes: u64,
+}
+
+#[wasm_bindgen]
+impl StreamStats {
+  #[wasm_bindgen(constructor)]
+  pub fn new(
+    subscribe_messages: u64,
+    subscribe_welcomes: u64,
+  ) -> Self {
+    Self {
+      subscribe_messages,
+      subscribe_welcomes,
+    }
+  }
+}
+
+impl From<xmtp_proto::api_client::ApiStats> for StreamStats {
+  fn from(stats: xmtp_proto::api_client::ApiStats) -> Self {
+    Self {
+      subscribe_messages: stats.subscribe_messages.get_count() as u64,
+      subscribe_welcomes: stats.subscribe_welcomes.get_count() as u64,
     }
   }
 }

--- a/bindings_wasm/src/identity.rs
+++ b/bindings_wasm/src/identity.rs
@@ -151,10 +151,7 @@ pub struct StreamStats {
 #[wasm_bindgen]
 impl StreamStats {
   #[wasm_bindgen(constructor)]
-  pub fn new(
-    subscribe_messages: u64,
-    subscribe_welcomes: u64,
-  ) -> Self {
+  pub fn new(subscribe_messages: u64, subscribe_welcomes: u64) -> Self {
     Self {
       subscribe_messages,
       subscribe_welcomes,

--- a/bindings_wasm/src/identity.rs
+++ b/bindings_wasm/src/identity.rs
@@ -54,3 +54,97 @@ impl IdentityExt<Identifier, XmtpIdentifier> for Vec<Identifier> {
     ident
   }
 }
+
+#[wasm_bindgen(getter_with_clone)]
+#[derive(Clone)]
+pub struct ApiStats {
+  pub upload_key_package: u64,
+  pub fetch_key_package: u64,
+  pub send_group_messages: u64,
+  pub send_welcome_messages: u64,
+  pub query_group_messages: u64,
+  pub query_welcome_messages: u64,
+  pub subscribe_messages: u64,
+  pub subscribe_welcomes: u64,
+}
+
+#[wasm_bindgen]
+impl ApiStats {
+  #[wasm_bindgen(constructor)]
+  pub fn new(
+    upload_key_package: u64,
+    fetch_key_package: u64,
+    send_group_messages: u64,
+    send_welcome_messages: u64,
+    query_group_messages: u64,
+    query_welcome_messages: u64,
+    subscribe_messages: u64,
+    subscribe_welcomes: u64,
+  ) -> Self {
+    Self {
+      upload_key_package,
+      fetch_key_package,
+      send_group_messages,
+      send_welcome_messages,
+      query_group_messages,
+      query_welcome_messages,
+      subscribe_messages,
+      subscribe_welcomes,
+    }
+  }
+}
+
+impl From<xmtp_proto::api_client::ApiStats> for ApiStats {
+  fn from(stats: xmtp_proto::api_client::ApiStats) -> Self {
+    Self {
+      upload_key_package: stats.upload_key_package.get_count() as u64,
+      fetch_key_package: stats.fetch_key_package.get_count() as u64,
+      send_group_messages: stats.send_group_messages.get_count() as u64,
+      send_welcome_messages: stats.send_welcome_messages.get_count() as u64,
+      query_group_messages: stats.query_group_messages.get_count() as u64,
+      query_welcome_messages: stats.query_welcome_messages.get_count() as u64,
+      subscribe_messages: stats.subscribe_messages.get_count() as u64,
+      subscribe_welcomes: stats.subscribe_welcomes.get_count() as u64,
+    }
+  }
+}
+
+#[wasm_bindgen(getter_with_clone)]
+#[derive(Clone)]
+pub struct IdentityStats {
+  pub publish_identity_update: u64,
+  pub get_identity_updates_v2: u64,
+  pub get_inbox_ids: u64,
+  pub verify_smart_contract_wallet_signature: u64,
+}
+
+#[wasm_bindgen]
+impl IdentityStats {
+  #[wasm_bindgen(constructor)]
+  pub fn new(
+    publish_identity_update: u64,
+    get_identity_updates_v2: u64,
+    get_inbox_ids: u64,
+    verify_smart_contract_wallet_signature: u64,
+  ) -> Self {
+    Self {
+      publish_identity_update,
+      get_identity_updates_v2,
+      get_inbox_ids,
+      verify_smart_contract_wallet_signature,
+    }
+  }
+}
+
+impl From<xmtp_proto::api_client::IdentityStats> for IdentityStats {
+  fn from(stats: xmtp_proto::api_client::IdentityStats) -> Self {
+    Self {
+      publish_identity_update: stats.publish_identity_update.get_count() as u64,
+      get_identity_updates_v2: stats.get_identity_updates_v2.get_count() as u64,
+      get_inbox_ids: stats.get_inbox_ids.get_count() as u64,
+      verify_smart_contract_wallet_signature: stats
+        .verify_smart_contract_wallet_signature
+        .get_count() as u64,
+    }
+  }
+}

--- a/bindings_wasm/src/identity.rs
+++ b/bindings_wasm/src/identity.rs
@@ -64,28 +64,8 @@ pub struct ApiStats {
   pub send_welcome_messages: u64,
   pub query_group_messages: u64,
   pub query_welcome_messages: u64,
-}
-
-#[wasm_bindgen]
-impl ApiStats {
-  #[wasm_bindgen(constructor)]
-  pub fn new(
-    upload_key_package: u64,
-    fetch_key_package: u64,
-    send_group_messages: u64,
-    send_welcome_messages: u64,
-    query_group_messages: u64,
-    query_welcome_messages: u64,
-  ) -> Self {
-    Self {
-      upload_key_package,
-      fetch_key_package,
-      send_group_messages,
-      send_welcome_messages,
-      query_group_messages,
-      query_welcome_messages,
-    }
-  }
+  pub subscribe_messages: u64,
+  pub subscribe_welcomes: u64,
 }
 
 impl From<xmtp_proto::api_client::ApiStats> for ApiStats {
@@ -97,6 +77,8 @@ impl From<xmtp_proto::api_client::ApiStats> for ApiStats {
       send_welcome_messages: stats.send_welcome_messages.get_count() as u64,
       query_group_messages: stats.query_group_messages.get_count() as u64,
       query_welcome_messages: stats.query_welcome_messages.get_count() as u64,
+      subscribe_messages: stats.subscribe_messages.get_count() as u64,
+      subscribe_welcomes: stats.subscribe_welcomes.get_count() as u64,
     }
   }
 }
@@ -110,24 +92,6 @@ pub struct IdentityStats {
   pub verify_smart_contract_wallet_signature: u64,
 }
 
-#[wasm_bindgen]
-impl IdentityStats {
-  #[wasm_bindgen(constructor)]
-  pub fn new(
-    publish_identity_update: u64,
-    get_identity_updates_v2: u64,
-    get_inbox_ids: u64,
-    verify_smart_contract_wallet_signature: u64,
-  ) -> Self {
-    Self {
-      publish_identity_update,
-      get_identity_updates_v2,
-      get_inbox_ids,
-      verify_smart_contract_wallet_signature,
-    }
-  }
-}
-
 impl From<xmtp_proto::api_client::IdentityStats> for IdentityStats {
   fn from(stats: xmtp_proto::api_client::IdentityStats) -> Self {
     Self {
@@ -137,33 +101,6 @@ impl From<xmtp_proto::api_client::IdentityStats> for IdentityStats {
       verify_smart_contract_wallet_signature: stats
         .verify_smart_contract_wallet_signature
         .get_count() as u64,
-    }
-  }
-}
-
-#[wasm_bindgen(getter_with_clone)]
-#[derive(Clone)]
-pub struct StreamStats {
-  pub subscribe_messages: u64,
-  pub subscribe_welcomes: u64,
-}
-
-#[wasm_bindgen]
-impl StreamStats {
-  #[wasm_bindgen(constructor)]
-  pub fn new(subscribe_messages: u64, subscribe_welcomes: u64) -> Self {
-    Self {
-      subscribe_messages,
-      subscribe_welcomes,
-    }
-  }
-}
-
-impl From<xmtp_proto::api_client::ApiStats> for StreamStats {
-  fn from(stats: xmtp_proto::api_client::ApiStats) -> Self {
-    Self {
-      subscribe_messages: stats.subscribe_messages.get_count() as u64,
-      subscribe_welcomes: stats.subscribe_welcomes.get_count() as u64,
     }
   }
 }


### PR DESCRIPTION
Closes https://github.com/xmtp/libxmtp/issues/2021

Adds the ability to get api and identity network stats