### PR TITLE
Bump versions for 1.2.0-rc4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,7 +474,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_node"
-version = "1.3.0-dev"
+version = "1.2.0-rc4"
 dependencies = [
  "chrono",
  "futures",
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_wasm"
-version = "1.3.0-dev"
+version = "1.2.0-rc4"
 dependencies = [
  "chrono",
  "console_error_panic_hook",
@@ -7795,7 +7795,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api"
-version = "1.3.0-dev"
+version = "1.2.0-rc4"
 dependencies = [
  "async-trait",
  "ctor 0.4.2",
@@ -7815,7 +7815,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_d14n"
-version = "1.3.0-dev"
+version = "1.2.0-rc4"
 dependencies = [
  "async-trait",
  "ctor 0.4.2",
@@ -7842,7 +7842,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_grpc"
-version = "1.3.0-dev"
+version = "1.2.0-rc4"
 dependencies = [
  "async-trait",
  "futures",
@@ -7859,7 +7859,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_http"
-version = "1.3.0-dev"
+version = "1.2.0-rc4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7883,7 +7883,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_archive"
-version = "1.3.0-dev"
+version = "1.2.0-rc4"
 dependencies = [
  "aes-gcm",
  "async-compression",
@@ -7910,7 +7910,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_cli"
-version = "1.3.0-dev"
+version = "1.2.0-rc4"
 dependencies = [
  "chrono",
  "clap",
@@ -7943,7 +7943,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_common"
-version = "1.3.0-dev"
+version = "1.2.0-rc4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7979,7 +7979,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_content_types"
-version = "1.3.0-dev"
+version = "1.2.0-rc4"
 dependencies = [
  "prost",
  "serde",
@@ -7993,7 +7993,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_cryptography"
-version = "1.3.0-dev"
+version = "1.2.0-rc4"
 dependencies = [
  "bincode",
  "curve25519-dalek",
@@ -8021,7 +8021,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_db"
-version = "1.3.0-dev"
+version = "1.2.0-rc4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8059,7 +8059,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_db_test"
-version = "1.3.0-dev"
+version = "1.2.0-rc4"
 dependencies = [
  "derive_builder",
  "diesel",
@@ -8072,7 +8072,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_id"
-version = "1.3.0-dev"
+version = "1.2.0-rc4"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8108,7 +8108,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_macro"
-version = "1.3.0-dev"
+version = "1.2.0-rc4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8119,7 +8119,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_mls"
-version = "1.3.0-dev"
+version = "1.2.0-rc4"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -8198,7 +8198,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_mls_common"
-version = "1.3.0-dev"
+version = "1.2.0-rc4"
 dependencies = [
  "openmls",
  "prost",
@@ -8212,7 +8212,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_proto"
-version = "1.3.0-dev"
+version = "1.2.0-rc4"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -8236,7 +8236,7 @@ dependencies = [
 
 [[package]]
 name = "xmtpv3"
-version = "1.3.0-dev"
+version = "1.2.0-rc4"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ resolver = "2"
 
 [workspace.package]
 license = "MIT"
-version = "1.3.0-dev"
+version = "1.2.0-rc4"
 
 [workspace.dependencies]
 aes-gcm = { version = "0.10.3", features = ["std"] }

--- a/bindings_node/package.json
+++ b/bindings_node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/node-bindings",
-  "version": "1.3.0-dev",
+  "version": "1.2.0-rc4",
   "repository": {
     "type": "git",
     "url": "git+https://git@github.com/xmtp/libxmtp.git",

--- a/bindings_wasm/package.json
+++ b/bindings_wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/wasm-bindings",
-  "version": "1.3.0-dev",
+  "version": "1.2.0-rc4",
   "type": "module",
   "license": "MIT",
   "description": "WASM bindings for the libXMTP rust library",


### PR DESCRIPTION
### Bump workspace and package versions from 1.3.0-dev to 1.2.0-rc4 across Rust workspace and Node.js bindings
Updates version numbers from `1.3.0-dev` to `1.2.0-rc4` across multiple configuration files:
- Updates workspace version in [Cargo.toml](https://github.com/xmtp/libxmtp/pull/2032/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542)
- Updates package versions in [Cargo.lock](https://github.com/xmtp/libxmtp/pull/2032/files#diff-13ee4b2252c9e516a0547f2891aa2105c3ca71c6d7a1e682c69be97998dfc87e) for all workspace packages including `bindings_node`, `bindings_wasm`, `xmtp_api`, `xmtp_mls`, and other XMTP packages
- Updates Node.js package versions in [bindings_node/package.json](https://github.com/xmtp/libxmtp/pull/2032/files#diff-bc8be8e755c9188d5b1c3402b397741f9151dad43d877a181f31003052d10b99) and [bindings_wasm/package.json](https://github.com/xmtp/libxmtp/pull/2032/files#diff-4a621639e0561b5b01c30ab7fa75cc2b67c54dad6763ecabda35df8e2b16b14e)

#### 📍Where to Start
Start with the workspace version change in [Cargo.toml](https://github.com/xmtp/libxmtp/pull/2032/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542) to understand the scope of the version bump.

----

_[Macroscope](https://app.macroscope.com) summarized 154a0c0._