### PR TITLE
Fix PRAGMA key or salt has incorrect value when generating groups

### DIFF
--- a/xmtp_db/src/encrypted_store/database/native.rs
+++ b/xmtp_db/src/encrypted_store/database/native.rs
@@ -104,6 +104,8 @@ pub enum PlatformStorageError {
     SqlCipherNotLoaded,
     #[error("PRAGMA key or salt has incorrect value")]
     SqlCipherKeyIncorrect,
+    #[error("Database is locked")]
+    DatabaseLocked,
     #[error(transparent)]
     DieselResult(#[from] diesel::result::Error),
     #[error(transparent)]
@@ -125,6 +127,7 @@ impl RetryableError for PlatformStorageError {
             Self::SqlCipherNotLoaded => true,
             Self::PoolNeedsConnection => true,
             Self::SqlCipherKeyIncorrect => false,
+            Self::DatabaseLocked => true,
             Self::DieselResult(result) => retryable!(result),
             Self::Io(_) => true,
             Self::DieselConnect(_) => true,

--- a/xmtp_db/src/encrypted_store/database/native/sqlcipher_connection.rs
+++ b/xmtp_db/src/encrypted_store/database/native/sqlcipher_connection.rs
@@ -270,7 +270,16 @@ impl super::ValidatedConnection for EncryptedConnection {
             SELECT count(*) FROM sqlite_master;",
             self.pragmas()
         ))
-        .map_err(|_| PlatformStorageError::SqlCipherKeyIncorrect)?;
+        .map_err(|e| {
+            let err_msg = e.to_string();
+            if err_msg.contains("database is locked") {
+                tracing::debug!("Database is locked; retryable error");
+                PlatformStorageError::DatabaseLocked
+            } else {
+                tracing::error!("SQLCipher PRAGMA batch_execute failed: {:?}", e);
+                PlatformStorageError::SqlCipherKeyIncorrect
+            }
+        })?;
 
         let CipherProviderVersion {
             cipher_provider_version,

--- a/xmtp_debug/src/app.rs
+++ b/xmtp_debug/src/app.rs
@@ -6,6 +6,7 @@ mod clients;
 mod export;
 /// Generate functionality
 mod generate;
+mod identity_lock;
 /// Information about this app
 mod info;
 /// Inspect data on the XMTP Network

--- a/xmtp_debug/src/app/generate/groups.rs
+++ b/xmtp_debug/src/app/generate/groups.rs
@@ -1,4 +1,5 @@
 //! Group Generation
+use crate::app::identity_lock::get_identity_lock;
 use crate::app::{
     store::{Database, GroupStore, IdentityStore, RandomDatabase},
     types::*,
@@ -61,6 +62,9 @@ impl GenerateGroups {
             let semaphore = semaphore.clone();
             handles.push(set.spawn(async move {
                 let _permit = semaphore.acquire().await?;
+                let identity_lock = get_identity_lock(&identity.inbox_id)?;
+                let _lock_guard = identity_lock.lock().await;
+
                 debug!(address = identity.address(), "group owner");
                 let client = app::client_from_identity(&identity, &network).await?;
                 let ids = invitees

--- a/xmtp_debug/src/app/generate/messages.rs
+++ b/xmtp_debug/src/app/generate/messages.rs
@@ -1,3 +1,4 @@
+use crate::app::identity_lock::get_identity_lock;
 use crate::{
     app::{
         self,
@@ -8,27 +9,10 @@ use crate::{
 use color_eyre::eyre::{self, Result, eyre};
 use indicatif::{ProgressBar, ProgressStyle};
 use rand::{Rng, SeedableRng, rngs::SmallRng, seq::SliceRandom};
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex, OnceLock};
-use tokio::sync::Mutex as TokioMutex;
+use std::sync::Arc;
 use xmtp_mls::groups::summary::SyncSummary;
 
 mod content_type;
-
-type IdentityLockMap = Arc<Mutex<HashMap<[u8; 32], Arc<TokioMutex<()>>>>>;
-
-static IDENTITY_LOCKS: OnceLock<IdentityLockMap> = OnceLock::new();
-
-fn get_identity_lock(inbox_id: &[u8; 32]) -> Result<Arc<TokioMutex<()>>, eyre::Error> {
-    let locks = IDENTITY_LOCKS.get_or_init(|| Arc::new(Mutex::new(HashMap::new())));
-    let mut map = locks
-        .lock()
-        .map_err(|e| eyre!("Failed to lock IDENTITY_LOCKS: {}", e))?;
-    Ok(map
-        .entry(*inbox_id)
-        .or_insert_with(|| Arc::new(TokioMutex::new(())))
-        .clone())
-}
 
 #[derive(thiserror::Error, Debug)]
 enum MessageSendError {

--- a/xmtp_debug/src/app/identity_lock.rs
+++ b/xmtp_debug/src/app/identity_lock.rs
@@ -1,0 +1,20 @@
+use crate::app::types::InboxId;
+use color_eyre::eyre::{self, eyre};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
+use tokio::sync::Mutex as TokioMutex;
+
+type IdentityLockMap = Arc<Mutex<HashMap<InboxId, Arc<TokioMutex<()>>>>>;
+
+static IDENTITY_LOCKS: OnceLock<IdentityLockMap> = OnceLock::new();
+
+pub fn get_identity_lock(inbox_id: &InboxId) -> Result<Arc<TokioMutex<()>>, eyre::Error> {
+    let locks = IDENTITY_LOCKS.get_or_init(|| Arc::new(Mutex::new(HashMap::new())));
+    let mut map = locks
+        .lock()
+        .map_err(|e| eyre!("Failed to lock IDENTITY_LOCKS: {}", e))?;
+    Ok(map
+        .entry(*inbox_id)
+        .or_insert_with(|| Arc::new(TokioMutex::new(())))
+        .clone())
+}

--- a/xmtp_debug/src/logger.rs
+++ b/xmtp_debug/src/logger.rs
@@ -55,7 +55,8 @@ impl Logger {
 
         // prefer `RUST_LOG` variable if set
         // otherwise passed-in level filter
-        let app_filter = || EnvFilter::builder().parse_lossy(format!("xdbg={verbosity}"));
+        let app_filter = EnvFilter::try_from_default_env()
+            .unwrap_or_else(|_| EnvFilter::builder().parse_lossy(format!("xdbg={verbosity}")));
         let file_filter = || {
             EnvFilter::builder().parse_lossy(
                 "xmtp_api_d14n=DEBUG,xmtp_api=DEBUG,xmtp_mls=DEBUG,xmtp_id=DEBUG,xmtp_cryptography=DEBUG,xmtp_api_grpc=DEBUG",
@@ -67,7 +68,7 @@ impl Logger {
 
         let subscriber = subscriber
             // default, always-on layer
-            .with(human_layer(app_filter(), true, std::io::stdout))
+            .with(human_layer(app_filter, true, std::io::stdout))
             .with(json.then(|| {
                 let mut json = log_file_name.clone();
                 json.set_extension("json");


### PR DESCRIPTION
### Fix PRAGMA key or salt has incorrect value when generating groups by adding database lock error handling and centralizing identity locking mechanism
The changes address database locking issues during group generation by introducing proper error handling and synchronization mechanisms:

• Add `DatabaseLocked` error variant to `PlatformStorageError` enum in [xmtp_db/src/encrypted_store/database/native.rs](https://github.com/xmtp/libxmtp/pull/2047/files#diff-9c5fcd135cb75c60427dc72ce9b51c5b99360469cd932477dfb52e7c3a1e61a1) and mark it as retryable
• Modify `EncryptedConnection::validate` method in [xmtp_db/src/encrypted_store/database/native/sqlcipher_connection.rs](https://github.com/xmtp/libxmtp/pull/2047/files#diff-5aafb5776b64881635a9ea8902e418042e23678555b9428c087949cc670810c6) to detect "database is locked" errors and return `DatabaseLocked` instead of `SqlCipherKeyIncorrect`
• Create centralized identity locking module in [xmtp_debug/src/app/identity_lock.rs](https://github.com/xmtp/libxmtp/pull/2047/files#diff-1961ca982454d4504d4865361cb8a1146d2bb4cff5048cb38ccdf3b6c51d0189) with `get_identity_lock` function and global `IDENTITY_LOCKS` map
• Update group generation in [xmtp_debug/src/app/generate/groups.rs](https://github.com/xmtp/libxmtp/pull/2047/files#diff-1c8a93d4e8378594c3b7f915c003997cdb53d02264698262eb58907e5e7d7261) to acquire identity locks before creating groups
• Remove local identity locking implementation from [xmtp_debug/src/app/generate/messages.rs](https://github.com/xmtp/libxmtp/pull/2047/files#diff-eeaf742c78c261e05257950d12daa2ec07c1dfe459a732f2ee1484f184da9371) in favor of centralized module
• Modify logger initialization in [xmtp_debug/src/logger.rs](https://github.com/xmtp/libxmtp/pull/2047/files#diff-2f28ac77c46314285c19f032f6f5ff9f5f7a66c1a94c02d3cfcc94d83f341bbd) to prioritize environment variables over verbosity-based configuration

#### 📍Where to Start
Start with the `validate` method in the `EncryptedConnection` implementation in [xmtp_db/src/encrypted_store/database/native/sqlcipher_connection.rs](https://github.com/xmtp/libxmtp/pull/2047/files#diff-5aafb5776b64881635a9ea8902e418042e23678555b9428c087949cc670810c6) to understand how database lock errors are now properly detected and handled.

----

_[Macroscope](https://app.macroscope.com) summarized 9c539ad._