### PR TITLE
HPKE followups

### DIFF
--- a/xmtp_db/src/configuration.rs
+++ b/xmtp_db/src/configuration.rs
@@ -1,3 +1,5 @@
+use xmtp_common::NS_IN_DAY;
+
 #[allow(unused)]
 pub const MAX_DB_POOL_SIZE: u32 = 25;
 
@@ -6,7 +8,6 @@ const KEYS_EXPIRATION_INTERVAL_NS: i64 = NS_IN_DAY; // 1 day
 
 #[cfg(target_arch = "wasm32")]
 pub use wasm::*;
-use xmtp_common::NS_IN_DAY;
 
 #[cfg(target_arch = "wasm32")]
 mod wasm {

--- a/xmtp_db/src/encrypted_store/key_package_history.rs
+++ b/xmtp_db/src/encrypted_store/key_package_history.rs
@@ -92,17 +92,6 @@ impl<C: ConnectionExt> DbConnection<C> {
         .map_err(StorageError::from) // convert ConnectionError into StorageError
     }
 
-    pub fn delete_expired_key_packages(&self) -> Result<(), StorageError> {
-        use crate::schema::key_package_history::dsl;
-
-        self.raw_query_write(|conn| {
-            diesel::delete(dsl::key_package_history.filter(dsl::delete_at_ns.le(now_ns())))
-                .execute(conn)
-        })?;
-
-        Ok(())
-    }
-
     pub fn delete_key_package_history_up_to_id(&self, id: i32) -> Result<(), StorageError> {
         self.raw_query_write(|conn| {
             diesel::delete(

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -561,7 +561,7 @@ where
             return Ok(group);
         };
 
-        let mut decrypted_welcome: Option<Result<DecryptedWelcome, StorageError>> = None;
+        let mut decrypted_welcome: Option<Result<DecryptedWelcome, GroupError>> = None;
         let result = provider.transaction(|provider| {
             let result = DecryptedWelcome::from_encrypted_bytes(
                 provider,

--- a/xmtp_mls/src/groups/welcome_sync.rs
+++ b/xmtp_mls/src/groups/welcome_sync.rs
@@ -69,6 +69,7 @@ where
         let envelopes = store.query_welcome_messages(provider.db()).await?;
         let num_envelopes = envelopes.len();
 
+        // TODO: Update cursor correctly if some of the welcomes fail and some of the welcomes succeed
         let groups: Vec<MlsGroup<Api, Db>> = stream::iter(envelopes.into_iter())
             .filter_map(|envelope: WelcomeMessage| async {
                 let welcome_v1 = match envelope.version {

--- a/xmtp_mls/src/groups/welcome_sync.rs
+++ b/xmtp_mls/src/groups/welcome_sync.rs
@@ -38,7 +38,7 @@ where
         &self,
         welcome: &welcome_message::V1,
     ) -> Result<MlsGroup<Api, Db>, GroupError> {
-        let result = MlsGroup::create_from_welcome(self.context.clone(), welcome, true).await;
+        let result = MlsGroup::create_from_welcome(self.context.clone(), welcome).await;
 
         match result {
             Ok(mls_group) => Ok(mls_group),

--- a/xmtp_mls/src/groups/welcome_sync.rs
+++ b/xmtp_mls/src/groups/welcome_sync.rs
@@ -90,8 +90,10 @@ where
             .collect()
             .await;
 
-        // If processed groups equal to the number of envelopes we received, then delete old kps and rotate the keys
-        if num_envelopes > 0 && num_envelopes == groups.len() {
+        // Rotate the keys regardless of whether the welcomes failed or succeeded. It is better to over-rotate than
+        // to under-rotate, as the latter risks leaving expired key packages on the network. We already have a max
+        // rotation interval.
+        if num_envelopes > 0 {
             let provider = self.context.mls_provider();
             self.context.identity.queue_key_rotation(&provider).await?;
         }


### PR DESCRIPTION
Best way to review this PR is commit by commit.

Changes:
1. Address remaining feedback from https://github.com/xmtp/libxmtp/pull/2044
2. Tidy cursor logic, and leave comments explaining what needs to be fixed for the next release. This PR is release-blocking, and we might need a refactor, which is too risky for this PR.
3. Rotate key packages even if received welcomes did not decrypt - this prevents clients from reaching a 'stuck' state where the key package on the server has already been deleted locally.