### PR TITLE
None evals to default

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -1240,7 +1240,7 @@ impl FfiConversations {
 
         let convo = self
             .inner_client
-            .create_group(group_permissions, metadata_options)?;
+            .create_group(group_permissions, Some(metadata_options))?;
 
         Ok(Arc::new(convo.into()))
     }

--- a/bindings_node/src/conversations.rs
+++ b/bindings_node/src/conversations.rs
@@ -319,7 +319,7 @@ impl Conversations {
 
     let group = self
       .inner_client
-      .create_group(group_permissions, metadata_options)
+      .create_group(group_permissions, Some(metadata_options))
       .map_err(|e| Error::from_reason(format!("ClientError: {}", e)))?;
 
     Ok(group.into())

--- a/bindings_wasm/src/conversations.rs
+++ b/bindings_wasm/src/conversations.rs
@@ -355,7 +355,7 @@ impl Conversations {
 
     let group = self
       .inner_client
-      .create_group(group_permissions, metadata_options)
+      .create_group(group_permissions, Some(metadata_options))
       .map_err(|e| JsError::new(format!("{}", e).as_str()))?;
 
     Ok(group.into())

--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -439,10 +439,7 @@ async fn main() -> color_eyre::eyre::Result<()> {
                 }
             };
             let group = client
-                .create_group(
-                    Some(group_permissions.to_policy_set()),
-                    GroupMetadataOptions::default(),
-                )
+                .create_group(Some(group_permissions.to_policy_set()), None)
                 .expect("failed to create group");
             let group_id = hex::encode(group.group_id);
             info!(

--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -47,7 +47,6 @@ use xmtp_db::{
 };
 use xmtp_id::associations::unverified::UnverifiedSignature;
 use xmtp_id::associations::{AssociationError, AssociationState, Identifier, MemberKind};
-use xmtp_mls::common::group::GroupMetadataOptions;
 use xmtp_mls::configuration::DeviceSyncUrls;
 use xmtp_mls::context::XmtpContextProvider;
 use xmtp_mls::groups::device_sync_legacy::DeviceSyncContent;

--- a/xmtp_mls/benches/group_limit.rs
+++ b/xmtp_mls/benches/group_limit.rs
@@ -7,7 +7,6 @@ use std::{collections::HashMap, sync::Arc};
 use tokio::runtime::{Builder, Runtime};
 use tracing::{trace_span, Instrument};
 use xmtp_common::bench::{self, bench_async_setup, BENCH_ROOT_SPAN};
-use xmtp_mls::common::group::GroupMetadataOptions;
 use xmtp_mls::{
     builder::ClientBuilder,
     utils::bench::{create_identities_if_dont_exist, BenchClient, Identity},
@@ -68,9 +67,7 @@ fn add_to_empty_group(c: &mut Criterion) {
             b.to_async(&runtime).iter_batched(
                 || {
                     (
-                        client
-                            .create_group(None, GroupMetadataOptions::default())
-                            .unwrap(),
+                        client.create_group(None, None).unwrap(),
                         addrs.clone(),
                         span.clone(),
                     )
@@ -106,9 +103,7 @@ fn add_to_empty_group_by_inbox_id(c: &mut Criterion) {
             b.to_async(&runtime).iter_batched(
                 || {
                     (
-                        client
-                            .create_group(None, GroupMetadataOptions::default())
-                            .unwrap(),
+                        client.create_group(None, None).unwrap(),
                         span.clone(),
                         ids.clone(),
                     )
@@ -155,9 +150,7 @@ fn add_to_100_member_group_by_inbox_id(c: &mut Criterion) {
             b.to_async(&runtime).iter_batched(
                 || {
                     bench_async_setup(|| async {
-                        let group = client
-                            .create_group(None, GroupMetadataOptions::default())
-                            .unwrap();
+                        let group = client.create_group(None, None).unwrap();
                         group
                             .add_members_by_inbox_id(
                                 // it is OK to take from the back for now because we aren't getting
@@ -208,9 +201,7 @@ fn remove_all_members_from_group(c: &mut Criterion) {
             b.to_async(&runtime).iter_batched(
                 || {
                     bench_async_setup(|| async {
-                        let group = client
-                            .create_group(None, GroupMetadataOptions::default())
-                            .unwrap();
+                        let group = client.create_group(None, None).unwrap();
                         group.add_members_by_inbox_id(ids).await.unwrap();
                         let ids = id_slice.clone();
                         (group, span.clone(), ids)
@@ -252,9 +243,7 @@ fn remove_half_members_from_group(c: &mut Criterion) {
             b.to_async(&runtime).iter_batched(
                 || {
                     bench_async_setup(|| async {
-                        let group = client
-                            .create_group(None, GroupMetadataOptions::default())
-                            .unwrap();
+                        let group = client.create_group(None, None).unwrap();
                         group.add_members_by_inbox_id(ids).await.unwrap();
                         let ids = ids
                             .iter()
@@ -300,9 +289,7 @@ fn add_1_member_to_group(c: &mut Criterion) {
             b.to_async(&runtime).iter_batched(
                 || {
                     bench_async_setup(|| async {
-                        let group = client
-                            .create_group(None, GroupMetadataOptions::default())
-                            .unwrap();
+                        let group = client.create_group(None, None).unwrap();
                         group.add_members_by_inbox_id(ids).await.unwrap();
                         let member = inbox_ids.last().unwrap().clone();
                         (group, vec![member], span.clone())

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -924,7 +924,6 @@ pub(crate) mod tests {
         schema::identity_updates, ConnectionExt, Fetch,
     };
     use xmtp_id::associations::test_utils::WalletTestExt;
-    
 
     #[xmtp_common::test]
     async fn test_group_member_recovery() {

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -474,14 +474,14 @@ where
     pub fn create_group(
         &self,
         permissions_policy_set: Option<PolicySet>,
-        opts: GroupMetadataOptions,
+        opts: Option<GroupMetadataOptions>,
     ) -> Result<MlsGroup<ApiClient, Db>, ClientError> {
         tracing::info!("creating group");
         let group: MlsGroup<ApiClient, Db> = MlsGroup::create_and_insert(
             self.context.clone(),
             GroupMembershipState::Allowed,
             permissions_policy_set.unwrap_or_default(),
-            opts,
+            opts.unwrap_or_default(),
         )?;
 
         // notify streams of our new group
@@ -506,7 +506,7 @@ where
         &self,
         account_identifiers: &[Identifier],
         permissions_policy_set: Option<PolicySet>,
-        opts: GroupMetadataOptions,
+        opts: Option<GroupMetadataOptions>,
     ) -> Result<MlsGroup<ApiClient, Db>, ClientError> {
         tracing::info!("creating group");
         let group = self.create_group(permissions_policy_set, opts)?;
@@ -520,7 +520,7 @@ where
         &self,
         inbox_ids: &[InboxId],
         permissions_policy_set: Option<PolicySet>,
-        opts: GroupMetadataOptions,
+        opts: Option<GroupMetadataOptions>,
     ) -> Result<MlsGroup<ApiClient, Db>, ClientError> {
         tracing::info!("creating group");
         let group = self.create_group(permissions_policy_set, opts)?;
@@ -934,9 +934,7 @@ pub(crate) mod tests {
         let bola_a = ClientBuilder::new_test_client(&bola_wallet).await;
         let bola_b = ClientBuilder::new_test_client(&bola_wallet).await;
 
-        let group = amal
-            .create_group(None, GroupMetadataOptions::default())
-            .unwrap();
+        let group = amal.create_group(None, None).unwrap();
 
         // Add both of Bola's installations to the group
         group
@@ -1020,12 +1018,8 @@ pub(crate) mod tests {
     #[xmtp_common::test]
     async fn test_find_groups() {
         let client = ClientBuilder::new_test_client(&generate_local_wallet()).await;
-        let group_1 = client
-            .create_group(None, GroupMetadataOptions::default())
-            .unwrap();
-        let group_2 = client
-            .create_group(None, GroupMetadataOptions::default())
-            .unwrap();
+        let group_1 = client.create_group(None, None).unwrap();
+        let group_2 = client.create_group(None, None).unwrap();
 
         let groups = client.find_groups(GroupQueryArgs::default()).unwrap();
         assert_eq!(groups.len(), 2);
@@ -1123,9 +1117,7 @@ pub(crate) mod tests {
         let alice = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bob = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
-        let alice_bob_group = alice
-            .create_group(None, GroupMetadataOptions::default())
-            .unwrap();
+        let alice_bob_group = alice.create_group(None, None).unwrap();
         alice_bob_group
             .add_members_by_inbox_id(&[bob.inbox_id()])
             .await
@@ -1151,12 +1143,8 @@ pub(crate) mod tests {
         let alix = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bo = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
-        let alix_bo_group1 = alix
-            .create_group(None, GroupMetadataOptions::default())
-            .unwrap();
-        let alix_bo_group2 = alix
-            .create_group(None, GroupMetadataOptions::default())
-            .unwrap();
+        let alix_bo_group1 = alix.create_group(None, None).unwrap();
+        let alix_bo_group2 = alix.create_group(None, None).unwrap();
         alix_bo_group1
             .add_members_by_inbox_id(&[bo.inbox_id()])
             .await
@@ -1204,12 +1192,8 @@ pub(crate) mod tests {
         tester!(bo, passkey);
 
         // Create two groups and add Bob
-        let alix_bo_group1 = alix
-            .create_group(None, GroupMetadataOptions::default())
-            .unwrap();
-        let alix_bo_group2 = alix
-            .create_group(None, GroupMetadataOptions::default())
-            .unwrap();
+        let alix_bo_group1 = alix.create_group(None, None).unwrap();
+        let alix_bo_group2 = alix.create_group(None, None).unwrap();
 
         alix_bo_group1
             .add_members_by_inbox_id(&[bo.inbox_id()])
@@ -1333,9 +1317,7 @@ pub(crate) mod tests {
         let bola = Tester::new().await;
 
         // Create a group and invite bola
-        let amal_group = amal
-            .create_group(None, GroupMetadataOptions::default())
-            .unwrap();
+        let amal_group = amal.create_group(None, None).unwrap();
         amal_group
             .add_members_by_inbox_id(&[bola.inbox_id()])
             .await
@@ -1433,13 +1415,9 @@ pub(crate) mod tests {
             .find_key_package_history_entry_by_hash_ref(bo_original_init_key.clone());
         assert!(bo_original_from_db.is_ok());
 
-        alix.create_group_with_members(
-            &[bo_wallet.identifier()],
-            None,
-            GroupMetadataOptions::default(),
-        )
-        .await
-        .unwrap();
+        alix.create_group_with_members(&[bo_wallet.identifier()], None, None)
+            .await
+            .unwrap();
         let bo_keys_queued_for_rotation = bo.context.db().is_identity_needs_rotation().unwrap();
         assert!(!bo_keys_queued_for_rotation);
 
@@ -1506,13 +1484,9 @@ pub(crate) mod tests {
         // Alix's key should not have changed at all
         assert_eq!(alix_original_init_key, alix_key_2);
 
-        alix.create_group_with_members(
-            &[bo_wallet.identifier()],
-            None,
-            GroupMetadataOptions::default(),
-        )
-        .await
-        .unwrap();
+        alix.create_group_with_members(&[bo_wallet.identifier()], None, None)
+            .await
+            .unwrap();
         bo.sync_welcomes().await.unwrap();
 
         // Bo should have two groups now
@@ -1576,11 +1550,7 @@ pub(crate) mod tests {
         futures::pin_mut!(stream);
 
         let group = alix
-            .create_group_with_inbox_ids(
-                &[bo.inbox_id().to_string()],
-                None,
-                GroupMetadataOptions::default(),
-            )
+            .create_group_with_inbox_ids(&[bo.inbox_id().to_string()], None, None)
             .await
             .unwrap();
         xmtp_common::time::sleep(std::time::Duration::from_millis(500)).await;

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -924,7 +924,7 @@ pub(crate) mod tests {
         schema::identity_updates, ConnectionExt, Fetch,
     };
     use xmtp_id::associations::test_utils::WalletTestExt;
-    use xmtp_mls_common::group::GroupMetadataOptions;
+    
 
     #[xmtp_common::test]
     async fn test_group_member_recovery() {

--- a/xmtp_mls/src/groups/device_sync/archive.rs
+++ b/xmtp_mls/src/groups/device_sync/archive.rs
@@ -114,9 +114,7 @@ mod tests {
         let alix = Tester::new().await;
         let bo = Tester::new().await;
 
-        let alix_group = alix
-            .create_group(None, GroupMetadataOptions::default())
-            .unwrap();
+        let alix_group = alix.create_group(None, None).unwrap();
         alix_group
             .add_members_by_inbox_id(&[bo.inbox_id()])
             .await
@@ -177,7 +175,7 @@ mod tests {
         tester!(alix, sync_worker, sync_server);
         tester!(bo);
 
-        let alix_group = alix.create_group(None, GroupMetadataOptions::default())?;
+        let alix_group = alix.create_group(None, None)?;
 
         // wait for user preference update
         wait_for_min_intents(alix.provider.db(), 2).await?;

--- a/xmtp_mls/src/groups/intents.rs
+++ b/xmtp_mls/src/groups/intents.rs
@@ -811,7 +811,7 @@ pub(crate) mod tests {
     use openmls::prelude::{MlsMessageBodyIn, MlsMessageIn, ProcessedMessageContent};
     use tls_codec::Deserialize;
     use xmtp_cryptography::utils::generate_local_wallet;
-    
+
     use xmtp_proto::xmtp::mls::api::v1::{group_message, GroupMessage};
 
     use crate::{builder::ClientBuilder, context::XmtpContextProvider, utils::ConcreteMlsGroup};

--- a/xmtp_mls/src/groups/intents.rs
+++ b/xmtp_mls/src/groups/intents.rs
@@ -875,9 +875,7 @@ pub(crate) mod tests {
         let client_b = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
         // client A makes a group with client B, and then sends a message to client B.
-        let group_a = client_a
-            .create_group(None, GroupMetadataOptions::default())
-            .expect("create group");
+        let group_a = client_a.create_group(None, None).expect("create group");
         group_a
             .add_members_by_inbox_id(&[client_b.inbox_id()])
             .await

--- a/xmtp_mls/src/groups/intents.rs
+++ b/xmtp_mls/src/groups/intents.rs
@@ -811,7 +811,7 @@ pub(crate) mod tests {
     use openmls::prelude::{MlsMessageBodyIn, MlsMessageIn, ProcessedMessageContent};
     use tls_codec::Deserialize;
     use xmtp_cryptography::utils::generate_local_wallet;
-    use xmtp_mls_common::group::GroupMetadataOptions;
+    
     use xmtp_proto::xmtp::mls::api::v1::{group_message, GroupMessage};
 
     use crate::{builder::ClientBuilder, context::XmtpContextProvider, utils::ConcreteMlsGroup};

--- a/xmtp_mls/src/groups/subscriptions.rs
+++ b/xmtp_mls/src/groups/subscriptions.rs
@@ -111,7 +111,6 @@ pub(crate) mod tests {
     use super::*;
     use crate::builder::ClientBuilder;
     use xmtp_db::group_message::GroupMessageKind;
-    
 
     use std::time::Duration;
     use xmtp_cryptography::utils::generate_local_wallet;

--- a/xmtp_mls/src/groups/subscriptions.rs
+++ b/xmtp_mls/src/groups/subscriptions.rs
@@ -111,7 +111,7 @@ pub(crate) mod tests {
     use super::*;
     use crate::builder::ClientBuilder;
     use xmtp_db::group_message::GroupMessageKind;
-    use xmtp_mls_common::group::GroupMetadataOptions;
+    
 
     use std::time::Duration;
     use xmtp_cryptography::utils::generate_local_wallet;

--- a/xmtp_mls/src/groups/subscriptions.rs
+++ b/xmtp_mls/src/groups/subscriptions.rs
@@ -125,9 +125,7 @@ pub(crate) mod tests {
         let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
-        let amal_group = amal
-            .create_group(None, GroupMetadataOptions::default())
-            .unwrap();
+        let amal_group = amal.create_group(None, None).unwrap();
         // Add bola
         amal_group
             .add_members_by_inbox_id(&[bola.inbox_id()])
@@ -162,9 +160,7 @@ pub(crate) mod tests {
         let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bola = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
 
-        let amal_group = amal
-            .create_group(None, GroupMetadataOptions::default())
-            .unwrap();
+        let amal_group = amal.create_group(None, None).unwrap();
         // Add bola
         amal_group
             .add_members_by_inbox_id(&[bola.inbox_id()])
@@ -194,9 +190,7 @@ pub(crate) mod tests {
     #[cfg_attr(target_arch = "wasm32", ignore)]
     async fn test_subscribe_multiple() {
         let amal = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
-        let group = amal
-            .create_group(None, GroupMetadataOptions::default())
-            .unwrap();
+        let group = amal.create_group(None, None).unwrap();
 
         let stream = group.stream().await.unwrap();
         futures::pin_mut!(stream);
@@ -227,9 +221,7 @@ pub(crate) mod tests {
         let amal = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
         let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
-        let amal_group = amal
-            .create_group(None, GroupMetadataOptions::default())
-            .unwrap();
+        let amal_group = amal.create_group(None, None).unwrap();
 
         let stream = amal_group.stream().await.unwrap();
         futures::pin_mut!(stream);

--- a/xmtp_mls/src/groups/tests/mod.rs
+++ b/xmtp_mls/src/groups/tests/mod.rs
@@ -117,9 +117,7 @@ async fn force_add_member(
 async fn test_send_message() {
     let wallet = generate_local_wallet();
     let client = ClientBuilder::new_test_client(&wallet).await;
-    let group = client
-        .create_group(None, GroupMetadataOptions::default())
-        .expect("create group");
+    let group = client.create_group(None, None).expect("create group");
     group.send_message(b"hello").await.expect("send message");
 
     let messages = client
@@ -134,9 +132,7 @@ async fn test_send_message() {
 async fn test_receive_self_message() {
     let wallet = generate_local_wallet();
     let client = ClientBuilder::new_test_client(&wallet).await;
-    let group = client
-        .create_group(None, GroupMetadataOptions::default())
-        .expect("create group");
+    let group = client.create_group(None, None).expect("create group");
     let msg = b"hello";
     group.send_message(msg).await.expect("send message");
 
@@ -151,9 +147,7 @@ async fn test_receive_self_message() {
 async fn test_receive_message_from_other() {
     let alix = ClientBuilder::new_test_client(&generate_local_wallet()).await;
     let bo = ClientBuilder::new_test_client(&generate_local_wallet()).await;
-    let alix_group = alix
-        .create_group(None, GroupMetadataOptions::default())
-        .expect("create group");
+    let alix_group = alix.create_group(None, None).expect("create group");
     alix_group
         .add_members_by_inbox_id(&[bo.inbox_id()])
         .await
@@ -184,9 +178,7 @@ async fn test_members_func_from_non_creator() {
     let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
     let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
-    let amal_group = amal
-        .create_group(None, GroupMetadataOptions::default())
-        .unwrap();
+    let amal_group = amal.create_group(None, None).unwrap();
     amal_group
         .add_members_by_inbox_id(&[bola.inbox_id()])
         .await
@@ -236,9 +228,7 @@ async fn test_add_member_conflict() {
     let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
     let charlie = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
-    let amal_group = amal
-        .create_group(None, GroupMetadataOptions::default())
-        .unwrap();
+    let amal_group = amal.create_group(None, None).unwrap();
     // Add bola
     amal_group
         .add_members_by_inbox_id(&[bola.inbox_id()])
@@ -334,9 +324,7 @@ fn test_create_from_welcome_validation() {
         let alix = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bo = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
-        let alix_group = alix
-            .create_group(None, GroupMetadataOptions::default())
-            .unwrap();
+        let alix_group = alix.create_group(None, None).unwrap();
         let provider = alix.mls_provider();
         // Doctor the group membership
         let mut mls_group = alix_group
@@ -447,9 +435,7 @@ async fn test_dm_stitching() {
 async fn test_add_inbox() {
     let client = ClientBuilder::new_test_client(&generate_local_wallet()).await;
     let client_2 = ClientBuilder::new_test_client(&generate_local_wallet()).await;
-    let group = client
-        .create_group(None, GroupMetadataOptions::default())
-        .expect("create group");
+    let group = client.create_group(None, None).expect("create group");
 
     group
         .add_members_by_inbox_id(&[client_2.inbox_id()])
@@ -486,11 +472,7 @@ async fn test_create_group_with_member_two_installations_one_malformed_keypackag
 
     // 3) Create the group, inviting bola (which internally includes bola_1 and bola_2)
     let group = alix
-        .create_group_with_members(
-            &[bola_wallet.identifier()],
-            None,
-            GroupMetadataOptions::default(),
-        )
+        .create_group_with_members(&[bola_wallet.identifier()], None, None)
         .await
         .unwrap();
 
@@ -589,11 +571,7 @@ async fn test_create_group_with_member_all_malformed_installations() {
 
     // 3) Attempt to create the group, which should fail
     let result = alix
-        .create_group_with_members(
-            &[bola_wallet.identifier()],
-            None,
-            GroupMetadataOptions::default(),
-        )
+        .create_group_with_members(&[bola_wallet.identifier()], None, None)
         .await;
     // 4) Ensure group creation failed
     assert!(
@@ -780,11 +758,7 @@ async fn test_add_inbox_with_bad_installation_to_group() {
     set_test_mode_upload_malformed_keypackage(true, Some(vec![bo_1.installation_id().to_vec()]));
 
     let group = alix
-        .create_group_with_members(
-            &[caro_wallet.identifier()],
-            None,
-            GroupMetadataOptions::default(),
-        )
+        .create_group_with_members(&[caro_wallet.identifier()], None, None)
         .await
         .unwrap();
 
@@ -817,11 +791,7 @@ async fn test_add_inbox_with_good_installation_to_group_with_bad_installation() 
     set_test_mode_upload_malformed_keypackage(true, Some(vec![bo_1.installation_id().to_vec()]));
 
     let group = alix
-        .create_group_with_members(
-            &[bo_wallet.identifier()],
-            None,
-            GroupMetadataOptions::default(),
-        )
+        .create_group_with_members(&[bo_wallet.identifier()], None, None)
         .await
         .unwrap();
 
@@ -857,7 +827,7 @@ async fn test_remove_inbox_with_good_installation_from_group_with_bad_installati
         .create_group_with_members(
             &[bo_wallet.identifier(), caro_wallet.identifier()],
             None,
-            GroupMetadataOptions::default(),
+            None,
         )
         .await
         .unwrap();
@@ -900,7 +870,7 @@ async fn test_remove_inbox_with_bad_installation_from_group() {
         .create_group_with_members(
             &[bo_wallet.identifier(), caro_wallet.identifier()],
             None,
-            GroupMetadataOptions::default(),
+            None,
         )
         .await
         .unwrap();
@@ -988,9 +958,7 @@ async fn test_remove_inbox_with_bad_installation_from_group() {
 #[xmtp_common::test]
 async fn test_add_invalid_member() {
     let client = ClientBuilder::new_test_client(&generate_local_wallet()).await;
-    let group = client
-        .create_group(None, GroupMetadataOptions::default())
-        .expect("create group");
+    let group = client.create_group(None, None).expect("create group");
 
     let result = group.add_members_by_inbox_id(&["1234".to_string()]).await;
 
@@ -1001,9 +969,7 @@ async fn test_add_invalid_member() {
 async fn test_add_unregistered_member() {
     let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
     let unconnected_ident = Identifier::rand_ethereum();
-    let group = amal
-        .create_group(None, GroupMetadataOptions::default())
-        .unwrap();
+    let group = amal.create_group(None, None).unwrap();
     let result = group.add_members(&[unconnected_ident]).await;
 
     assert!(result.is_err());
@@ -1015,9 +981,7 @@ async fn test_remove_inbox() {
     // Add another client onto the network
     let client_2 = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
-    let group = client_1
-        .create_group(None, GroupMetadataOptions::default())
-        .expect("create group");
+    let group = client_1.create_group(None, None).expect("create group");
     group
         .add_members_by_inbox_id(&[client_2.inbox_id()])
         .await
@@ -1052,9 +1016,7 @@ async fn test_key_update() {
     let client = ClientBuilder::new_test_client_no_sync(&generate_local_wallet()).await;
     let bola_client = ClientBuilder::new_test_client_no_sync(&generate_local_wallet()).await;
 
-    let group = client
-        .create_group(None, GroupMetadataOptions::default())
-        .expect("create group");
+    let group = client.create_group(None, None).expect("create group");
     group
         .add_members_by_inbox_id(&[bola_client.inbox_id()])
         .await
@@ -1092,9 +1054,7 @@ async fn test_key_update() {
 async fn test_post_commit() {
     let client = ClientBuilder::new_test_client(&generate_local_wallet()).await;
     let client_2 = ClientBuilder::new_test_client(&generate_local_wallet()).await;
-    let group = client
-        .create_group(None, GroupMetadataOptions::default())
-        .expect("create group");
+    let group = client.create_group(None, None).expect("create group");
 
     group
         .add_members_by_inbox_id(&[client_2.inbox_id()])
@@ -1119,9 +1079,7 @@ async fn test_remove_by_account_address() {
     let charlie_wallet = &generate_local_wallet();
     let _charlie = ClientBuilder::new_test_client(charlie_wallet).await;
 
-    let group = amal
-        .create_group(None, GroupMetadataOptions::default())
-        .unwrap();
+    let group = amal.create_group(None, None).unwrap();
     group
         .add_members(&[bola_wallet.identifier(), charlie_wallet.identifier()])
         .await
@@ -1165,9 +1123,7 @@ async fn test_removed_members_cannot_send_message_to_others() {
     let charlie_wallet = &generate_local_wallet();
     let charlie = ClientBuilder::new_test_client(charlie_wallet).await;
 
-    let amal_group = amal
-        .create_group(None, GroupMetadataOptions::default())
-        .unwrap();
+    let amal_group = amal.create_group(None, None).unwrap();
     amal_group
         .add_members(&[bola_wallet.identifier(), charlie_wallet.identifier()])
         .await
@@ -1229,9 +1185,7 @@ async fn test_add_missing_installations() {
     let amal = ClientBuilder::new_test_client(&amal_wallet).await;
     let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
-    let group = amal
-        .create_group(None, GroupMetadataOptions::default())
-        .unwrap();
+    let group = amal.create_group(None, None).unwrap();
     group
         .add_members_by_inbox_id(&[bola.inbox_id()])
         .await
@@ -1266,9 +1220,7 @@ async fn test_self_resolve_epoch_mismatch() {
     let charlie = ClientBuilder::new_test_client(&generate_local_wallet()).await;
     let dave_wallet = generate_local_wallet();
     let dave = ClientBuilder::new_test_client(&dave_wallet).await;
-    let amal_group = amal
-        .create_group(None, GroupMetadataOptions::default())
-        .unwrap();
+    let amal_group = amal.create_group(None, None).unwrap();
     // Add bola to the group
     amal_group
         .add_members_by_inbox_id(&[bola.inbox_id()])
@@ -1318,7 +1270,7 @@ async fn test_group_permissions() {
     let amal_group = amal
         .create_group(
             Some(PreconfiguredPolicies::AdminsOnly.to_policy_set()),
-            GroupMetadataOptions::default(),
+            None,
         )
         .unwrap();
     // Add bola to the group
@@ -1344,12 +1296,12 @@ async fn test_group_options() {
     let amal_group = amal
         .create_group(
             None,
-            GroupMetadataOptions {
+            Some(GroupMetadataOptions {
                 name: Some("Group Name".to_string()),
                 image_url_square: Some("url".to_string()),
                 description: Some("group description".to_string()),
                 message_disappearing_settings: Some(expected_group_message_disappearing_settings),
-            },
+            }),
         )
         .unwrap();
 
@@ -1398,7 +1350,7 @@ async fn test_max_limit_add() {
     let amal_group = amal
         .create_group(
             Some(PreconfiguredPolicies::AdminsOnly.to_policy_set()),
-            GroupMetadataOptions::default(),
+            None,
         )
         .unwrap();
     let mut clients = Vec::new();
@@ -1423,9 +1375,7 @@ async fn test_group_mutable_data() {
 
     // Create a group and verify it has the default group name
     let policy_set = Some(PreconfiguredPolicies::AdminsOnly.to_policy_set());
-    let amal_group = amal
-        .create_group(policy_set, GroupMetadataOptions::default())
-        .unwrap();
+    let amal_group = amal.create_group(policy_set, None).unwrap();
     amal_group.sync().await.unwrap();
 
     let group_mutable_metadata = amal_group.mutable_metadata().unwrap();
@@ -1505,11 +1455,7 @@ async fn test_update_policies_empty_group() {
     // Create a group with amal and bola
     let policy_set = Some(PreconfiguredPolicies::AdminsOnly.to_policy_set());
     let amal_group = amal
-        .create_group_with_members(
-            &[bola_wallet.identifier()],
-            policy_set,
-            GroupMetadataOptions::default(),
-        )
+        .create_group_with_members(&[bola_wallet.identifier()], policy_set, None)
         .await
         .unwrap();
 
@@ -1530,9 +1476,7 @@ async fn test_update_policies_empty_group() {
 
     // Create a group with just amal
     let policy_set_2 = Some(PreconfiguredPolicies::AdminsOnly.to_policy_set());
-    let amal_group_2 = amal
-        .create_group(policy_set_2, GroupMetadataOptions::default())
-        .unwrap();
+    let amal_group_2 = amal.create_group(policy_set_2, None).unwrap();
 
     // Verify empty group fails to update metadata before syncing
     amal_group_2
@@ -1565,9 +1509,7 @@ async fn test_update_group_image_url_square() {
 
     // Create a group and verify it has the default group name
     let policy_set = Some(PreconfiguredPolicies::AdminsOnly.to_policy_set());
-    let amal_group = amal
-        .create_group(policy_set, GroupMetadataOptions::default())
-        .unwrap();
+    let amal_group = amal.create_group(policy_set, None).unwrap();
     amal_group.sync().await.unwrap();
 
     let group_mutable_metadata = amal_group.mutable_metadata().unwrap();
@@ -1599,9 +1541,7 @@ async fn test_update_group_message_expiration_settings() {
 
     // Create a group and verify it has the default group name
     let policy_set = Some(PreconfiguredPolicies::AdminsOnly.to_policy_set());
-    let amal_group = amal
-        .create_group(policy_set, GroupMetadataOptions::default())
-        .unwrap();
+    let amal_group = amal.create_group(policy_set, None).unwrap();
     amal_group.sync().await.unwrap();
 
     let group_mutable_metadata = amal_group.mutable_metadata().unwrap();
@@ -1659,9 +1599,7 @@ async fn test_group_mutable_data_group_permissions() {
 
     // Create a group and verify it has the default group name
     let policy_set = Some(PreconfiguredPolicies::Default.to_policy_set());
-    let amal_group = amal
-        .create_group(policy_set, GroupMetadataOptions::default())
-        .unwrap();
+    let amal_group = amal.create_group(policy_set, None).unwrap();
     amal_group.sync().await.unwrap();
 
     let group_mutable_metadata = amal_group.mutable_metadata().unwrap();
@@ -1737,9 +1675,7 @@ async fn test_group_admin_list_update() {
     let charlie = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
     let policy_set = Some(PreconfiguredPolicies::AdminsOnly.to_policy_set());
-    let amal_group = amal
-        .create_group(policy_set, GroupMetadataOptions::default())
-        .unwrap();
+    let amal_group = amal.create_group(policy_set, None).unwrap();
     amal_group.sync().await.unwrap();
 
     // Add bola to the group
@@ -1837,9 +1773,7 @@ async fn test_group_super_admin_list_update() {
     let caro = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
     let policy_set = Some(PreconfiguredPolicies::AdminsOnly.to_policy_set());
-    let amal_group = amal
-        .create_group(policy_set, GroupMetadataOptions::default())
-        .unwrap();
+    let amal_group = amal.create_group(policy_set, None).unwrap();
     amal_group.sync().await.unwrap();
 
     // Add bola to the group
@@ -1943,9 +1877,7 @@ async fn test_group_members_permission_level_update() {
     let caro = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
     let policy_set = Some(PreconfiguredPolicies::AdminsOnly.to_policy_set());
-    let amal_group = amal
-        .create_group(policy_set, GroupMetadataOptions::default())
-        .unwrap();
+    let amal_group = amal.create_group(policy_set, None).unwrap();
     amal_group.sync().await.unwrap();
 
     // Add Bola and Caro to the group
@@ -2040,9 +1972,7 @@ async fn test_staged_welcome() {
     let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
     // Amal creates a group
-    let amal_group = amal
-        .create_group(None, GroupMetadataOptions::default())
-        .unwrap();
+    let amal_group = amal.create_group(None, None).unwrap();
 
     // Amal adds Bola to the group
     amal_group
@@ -2077,9 +2007,7 @@ async fn test_staged_welcome() {
 async fn test_can_read_group_creator_inbox_id() {
     let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
     let policy_set = Some(PreconfiguredPolicies::Default.to_policy_set());
-    let amal_group = amal
-        .create_group(policy_set, GroupMetadataOptions::default())
-        .unwrap();
+    let amal_group = amal.create_group(policy_set, None).unwrap();
     amal_group.sync().await.unwrap();
 
     let mutable_metadata = amal_group.mutable_metadata().unwrap();
@@ -2100,9 +2028,7 @@ async fn test_can_update_gce_after_failed_commit() {
     // Step 1: Amal creates a group
     let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
     let policy_set = Some(PreconfiguredPolicies::Default.to_policy_set());
-    let amal_group = amal
-        .create_group(policy_set, GroupMetadataOptions::default())
-        .unwrap();
+    let amal_group = amal.create_group(policy_set, None).unwrap();
     amal_group.sync().await.unwrap();
 
     // Step 2:  Amal adds Bola to the group
@@ -2159,9 +2085,7 @@ async fn test_can_update_gce_after_failed_commit() {
 async fn test_can_update_permissions_after_group_creation() {
     let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
     let policy_set = Some(PreconfiguredPolicies::AdminsOnly.to_policy_set());
-    let amal_group: &ConcreteMlsGroup = &amal
-        .create_group(policy_set, GroupMetadataOptions::default())
-        .unwrap();
+    let amal_group: &ConcreteMlsGroup = &amal.create_group(policy_set, None).unwrap();
 
     // Step 2:  Amal adds Bola to the group
     let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
@@ -2223,9 +2147,7 @@ async fn test_optimistic_send() {
     let amal = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
     let bola_wallet = generate_local_wallet();
     let bola = Arc::new(ClientBuilder::new_test_client(&bola_wallet).await);
-    let amal_group = amal
-        .create_group(None, GroupMetadataOptions::default())
-        .unwrap();
+    let amal_group = amal.create_group(None, None).unwrap();
     amal_group.sync().await.unwrap();
     // Add bola to the group
     amal_group
@@ -2372,9 +2294,7 @@ async fn process_messages_abort_on_retryable_error() {
     let alix = ClientBuilder::new_test_client(&generate_local_wallet()).await;
     let bo = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
-    let alix_group = alix
-        .create_group(None, GroupMetadataOptions::default())
-        .unwrap();
+    let alix_group = alix.create_group(None, None).unwrap();
 
     alix_group
         .add_members_by_inbox_id(&[bo.inbox_id()])
@@ -2422,9 +2342,7 @@ async fn skip_already_processed_messages() {
     let bo_wallet = generate_local_wallet();
     let bo_client = ClientBuilder::new_test_client_no_sync(&bo_wallet).await;
 
-    let alix_group = alix
-        .create_group(None, GroupMetadataOptions::default())
-        .unwrap();
+    let alix_group = alix.create_group(None, None).unwrap();
 
     alix_group
         .add_members_by_inbox_id(&[bo_client.inbox_id()])
@@ -2465,9 +2383,7 @@ async fn skip_already_processed_intents() {
     let bo_wallet = generate_local_wallet();
     let bo_client = ClientBuilder::new_test_client(&bo_wallet).await;
 
-    let alix_group = alix
-        .create_group(None, GroupMetadataOptions::default())
-        .unwrap();
+    let alix_group = alix.create_group(None, None).unwrap();
 
     alix_group
         .add_members_by_inbox_id(&[bo_client.inbox_id()])
@@ -2499,9 +2415,7 @@ async fn test_parallel_syncs() {
     let alix1 = Arc::new(ClientBuilder::new_test_client(&wallet).await);
     alix1.device_sync().wait_for_sync_worker_init().await;
 
-    let alix1_group = alix1
-        .create_group(None, GroupMetadataOptions::default())
-        .unwrap();
+    let alix1_group = alix1.create_group(None, None).unwrap();
 
     let alix2 = ClientBuilder::new_test_client(&wallet).await;
 
@@ -2591,9 +2505,7 @@ async fn create_membership_update_no_sync(group: &ConcreteMlsGroup) {
 async fn add_missing_installs_reentrancy() {
     let wallet = generate_local_wallet();
     let alix1 = ClientBuilder::new_test_client(&wallet).await;
-    let alix1_group = alix1
-        .create_group(None, GroupMetadataOptions::default())
-        .unwrap();
+    let alix1_group = alix1.create_group(None, None).unwrap();
 
     let alix2 = ClientBuilder::new_test_client(&wallet).await;
 
@@ -2667,9 +2579,7 @@ async fn respect_allow_epoch_increment() {
     let wallet = generate_local_wallet();
     let client = ClientBuilder::new_test_client(&wallet).await;
 
-    let group = client
-        .create_group(None, GroupMetadataOptions::default())
-        .unwrap();
+    let group = client.create_group(None, None).unwrap();
 
     let _client_2 = ClientBuilder::new_test_client(&wallet).await;
 
@@ -2703,9 +2613,7 @@ async fn test_get_and_set_consent() {
     let alix = ClientBuilder::new_test_client(&generate_local_wallet()).await;
     let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
     let caro = ClientBuilder::new_test_client(&generate_local_wallet()).await;
-    let alix_group = alix
-        .create_group(None, GroupMetadataOptions::default())
-        .unwrap();
+    let alix_group = alix.create_group(None, None).unwrap();
 
     // group consent state should be allowed if user created it
     assert_eq!(alix_group.consent_state().unwrap(), ConsentState::Allowed);
@@ -2761,11 +2669,7 @@ async fn test_max_past_epochs() {
     let alix = ClientBuilder::new_test_client(&generate_local_wallet()).await;
     let bo = ClientBuilder::new_test_client(&bo_wallet).await;
     let alix_group = alix
-        .create_group_with_members(
-            &[bo_wallet.identifier()],
-            None,
-            GroupMetadataOptions::default(),
-        )
+        .create_group_with_members(&[bo_wallet.identifier()], None, None)
         .await
         .unwrap();
 
@@ -2953,9 +2857,7 @@ async fn test_respects_character_limits_for_group_metadata() {
     let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
     let policy_set = Some(PreconfiguredPolicies::AdminsOnly.to_policy_set());
-    let amal_group = amal
-        .create_group(policy_set, GroupMetadataOptions::default())
-        .unwrap();
+    let amal_group = amal.create_group(policy_set, None).unwrap();
     amal_group.sync().await.unwrap();
 
     let overlong_name = "a".repeat(MAX_GROUP_NAME_LENGTH + 1);
@@ -3094,9 +2996,7 @@ async fn test_can_set_min_supported_protocol_version_for_commit() {
     // ensure the version is as expected
     assert!(bo.context.version_info() != &amal_version);
     // Step 2: Amal creates a group and adds bo as a member
-    let amal_group = amal
-        .create_group(None, GroupMetadataOptions::default())
-        .unwrap();
+    let amal_group = amal.create_group(None, None).unwrap();
     amal_group
         .add_members_by_inbox_id(&[bo.context.identity.inbox_id()])
         .await
@@ -3191,9 +3091,7 @@ async fn test_client_on_old_version_pauses_after_joining_min_version_group() {
     assert!(bo.version_info().pkg_version() == amal.version_info().pkg_version());
 
     // Step 2: Amal creates a group and adds bo as a member
-    let amal_group = amal
-        .create_group(None, GroupMetadataOptions::default())
-        .unwrap();
+    let amal_group = amal.create_group(None, None).unwrap();
     amal_group
         .add_members_by_inbox_id(&[bo.context.identity.inbox_id()])
         .await
@@ -3286,9 +3184,7 @@ async fn test_only_super_admins_can_set_min_supported_protocol_version() {
     let amal = ClientBuilder::new_test_client(&generate_local_wallet()).await;
     let bo = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
-    let amal_group = amal
-        .create_group(None, GroupMetadataOptions::default())
-        .unwrap();
+    let amal_group = amal.create_group(None, None).unwrap();
     amal_group
         .add_members_by_inbox_id(&[bo.context.identity.inbox_id()])
         .await
@@ -3360,9 +3256,7 @@ async fn test_send_message_while_paused_after_welcome_returns_expected_error() {
     let bo = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
     // Amal creates a group and adds bo
-    let amal_group = amal
-        .create_group(None, GroupMetadataOptions::default())
-        .unwrap();
+    let amal_group = amal.create_group(None, None).unwrap();
     amal_group
         .add_members_by_inbox_id(&[bo.context.identity.inbox_id()])
         .await
@@ -3416,9 +3310,7 @@ async fn test_send_message_after_min_version_update_gets_expected_error() {
     let bo = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
     // Amal creates a group and adds bo
-    let amal_group = amal
-        .create_group(None, GroupMetadataOptions::default())
-        .unwrap();
+    let amal_group = amal.create_group(None, None).unwrap();
     amal_group
         .add_members_by_inbox_id(&[bo.context.identity.inbox_id()])
         .await
@@ -3507,7 +3399,7 @@ async fn test_can_make_inbox_with_a_bad_key_package_an_admin() {
     let amal_group = amal
         .create_group(
             Some(PreconfiguredPolicies::AdminsOnly.to_policy_set()),
-            GroupMetadataOptions::default(),
+            None,
         )
         .unwrap();
     amal_group.sync().await.unwrap();
@@ -3576,9 +3468,7 @@ async fn test_when_processing_message_return_future_wrong_epoch_group_marked_pro
     let client_a = ClientBuilder::new_test_client(&generate_local_wallet()).await;
     let client_b = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
-    let group_a = client_a
-        .create_group(None, GroupMetadataOptions::default())
-        .unwrap();
+    let group_a = client_a.create_group(None, None).unwrap();
     group_a
         .add_members_by_inbox_id(&[client_b.inbox_id()])
         .await
@@ -3616,9 +3506,7 @@ async fn can_stream_out_of_order_without_forking() {
     let client_c = ClientBuilder::new_test_client(&wallet_c).await;
 
     // Create a group
-    let group_a = client_a1
-        .create_group(None, GroupMetadataOptions::default())
-        .unwrap();
+    let group_a = client_a1.create_group(None, None).unwrap();
 
     // Add client_b and client_c to the group
     group_a

--- a/xmtp_mls/src/groups/tests/test_key_updates.rs
+++ b/xmtp_mls/src/groups/tests/test_key_updates.rs
@@ -9,11 +9,7 @@ async fn test_key_rotation_with_optimistic_send() {
     tester!(alix, stream);
     tester!(bo, stream);
     let g = alix
-        .create_group_with_inbox_ids(
-            &[bo.inbox_id().to_string()],
-            None,
-            GroupMetadataOptions::default(),
-        )
+        .create_group_with_inbox_ids(&[bo.inbox_id().to_string()], None, None)
         .await?;
 
     bo.sync_welcomes().await?;
@@ -61,11 +57,7 @@ async fn key_update_out_of_epoch() {
     tester!(greg);
 
     let g = alix
-        .create_group_with_inbox_ids(
-            &[bo.inbox_id().to_string()],
-            None,
-            GroupMetadataOptions::default(),
-        )
+        .create_group_with_inbox_ids(&[bo.inbox_id().to_string()], None, None)
         .await?;
 
     bo.sync_welcomes().await?;

--- a/xmtp_mls/src/groups/tests/test_key_updates.rs
+++ b/xmtp_mls/src/groups/tests/test_key_updates.rs
@@ -1,4 +1,4 @@
-use crate::{groups::GroupMetadataOptions, tester};
+use crate::tester;
 use futures::future::join_all;
 use std::{future::Future, pin::Pin, time::Duration};
 use xmtp_common::{retry_async, Retry};

--- a/xmtp_mls/src/subscriptions/stream_all.rs
+++ b/xmtp_mls/src/subscriptions/stream_all.rs
@@ -193,9 +193,7 @@ mod tests {
         let caro_wallet = generate_local_wallet();
         let caro = ClientBuilder::new_test_client(&caro_wallet).await;
 
-        let alix_group = alix
-            .create_group(None, GroupMetadataOptions::default())
-            .unwrap();
+        let alix_group = alix.create_group(None, None).unwrap();
         tracing::info!("Created alix group {}", hex::encode(&alix_group.group_id));
         alix_group
             .add_members_by_inbox_id(&[caro.inbox_id()])
@@ -218,9 +216,7 @@ mod tests {
         alix_group.send_message(b"third").await.unwrap();
         assert_msg!(stream, "third");
 
-        let alix_group_2 = alix
-            .create_group(None, GroupMetadataOptions::default())
-            .unwrap();
+        let alix_group_2 = alix.create_group(None, None).unwrap();
         alix_group_2
             .add_members_by_inbox_id(&[caro.inbox_id()])
             .await
@@ -241,17 +237,13 @@ mod tests {
         let bo = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let caro = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
-        let alix_group = alix
-            .create_group(None, GroupMetadataOptions::default())
-            .unwrap();
+        let alix_group = alix.create_group(None, None).unwrap();
         alix_group
             .add_members_by_inbox_id(&[caro.inbox_id()])
             .await
             .unwrap();
 
-        let bo_group = bo
-            .create_group(None, GroupMetadataOptions::default())
-            .unwrap();
+        let bo_group = bo.create_group(None, None).unwrap();
         bo_group
             .add_members_by_inbox_id(&[caro.inbox_id()])
             .await
@@ -279,9 +271,7 @@ mod tests {
         let alix = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bo = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
-        let alix_group = alix
-            .create_group(None, GroupMetadataOptions::default())
-            .unwrap();
+        let alix_group = alix.create_group(None, None).unwrap();
         alix_group
             .add_members_by_inbox_id(&[bo.inbox_id()])
             .await
@@ -374,9 +364,7 @@ mod tests {
         replace.add(eve.inbox_id(), "eve");
         replace.add(alix.inbox_id(), "alix");
         replace.add(bo.inbox_id(), "bo");
-        let alix_group = alix
-            .create_group(None, GroupMetadataOptions::default())
-            .unwrap();
+        let alix_group = alix.create_group(None, None).unwrap();
         alix_group
             .add_members_by_inbox_id(&[caro.inbox_id(), bo.inbox_id()])
             .await
@@ -405,9 +393,7 @@ mod tests {
         xmtp_common::spawn(None, async move {
             let caro = &caro_id;
             for i in 0..15 {
-                let new_group = eve
-                    .create_group(None, GroupMetadataOptions::default())
-                    .unwrap();
+                let new_group = eve.create_group(None, None).unwrap();
                 new_group.add_members_by_inbox_id(&[caro]).await.unwrap();
                 let msg = format!("EVE spam {i} from new group");
                 new_group.send_message(msg.as_bytes()).await.unwrap();
@@ -468,9 +454,7 @@ mod tests {
         xmtp_common::spawn(None, async move {
             let caro = &caro_id;
             for i in 0..5 {
-                let new_group = hale
-                    .create_group(None, GroupMetadataOptions::default())
-                    .unwrap();
+                let new_group = hale.create_group(None, None).unwrap();
                 new_group.add_members_by_inbox_id(&[caro]).await.unwrap();
                 tracing::info!(
                     "\n\n HALE SENDING {i} to group {}\n\n",
@@ -525,18 +509,14 @@ mod tests {
         let receiver = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
         // Create group with Allowed consent
-        let allowed_group = sender
-            .create_group(None, GroupMetadataOptions::default())
-            .unwrap();
+        let allowed_group = sender.create_group(None, None).unwrap();
         allowed_group
             .add_members_by_inbox_id(&[receiver.inbox_id()])
             .await
             .unwrap();
 
         // Create group with Denied consent
-        let denied_group = sender
-            .create_group(None, GroupMetadataOptions::default())
-            .unwrap();
+        let denied_group = sender.create_group(None, None).unwrap();
         denied_group
             .add_members_by_inbox_id(&[receiver.inbox_id()])
             .await
@@ -546,9 +526,7 @@ mod tests {
             .unwrap();
 
         // Create group with Unknown consent
-        let unknown_group = sender
-            .create_group(None, GroupMetadataOptions::default())
-            .unwrap();
+        let unknown_group = sender.create_group(None, None).unwrap();
         unknown_group
             .add_members_by_inbox_id(&[receiver.inbox_id()])
             .await
@@ -588,9 +566,7 @@ mod tests {
         let alice = Arc::new(ClientBuilder::new_test_client_no_sync(&wallet).await);
         let bob = ClientBuilder::new_test_client_no_sync(&generate_local_wallet()).await;
         let eve = ClientBuilder::new_test_client_no_sync(&generate_local_wallet()).await;
-        let group = alice
-            .create_group(None, GroupMetadataOptions::default())
-            .unwrap();
+        let group = alice.create_group(None, None).unwrap();
 
         group
             .add_members_by_inbox_id(&[bob.inbox_id(), eve.inbox_id()])

--- a/xmtp_mls/src/subscriptions/stream_all.rs
+++ b/xmtp_mls/src/subscriptions/stream_all.rs
@@ -178,7 +178,6 @@ mod tests {
     use futures::StreamExt;
     use std::sync::Arc;
     use std::time::Duration;
-    
 
     use xmtp_cryptography::utils::generate_local_wallet;
     use xmtp_id::associations::test_utils::WalletTestExt;

--- a/xmtp_mls/src/subscriptions/stream_all.rs
+++ b/xmtp_mls/src/subscriptions/stream_all.rs
@@ -178,7 +178,7 @@ mod tests {
     use futures::StreamExt;
     use std::sync::Arc;
     use std::time::Duration;
-    use xmtp_mls_common::group::GroupMetadataOptions;
+    
 
     use xmtp_cryptography::utils::generate_local_wallet;
     use xmtp_id::associations::test_utils::WalletTestExt;

--- a/xmtp_mls/src/subscriptions/stream_conversations.rs
+++ b/xmtp_mls/src/subscriptions/stream_conversations.rs
@@ -413,9 +413,7 @@ mod test {
     async fn test_stream_welcomes() {
         let alice = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
         let bob = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
-        let alice_bob_group = alice
-            .create_group(None, GroupMetadataOptions::default())
-            .unwrap();
+        let alice_bob_group = alice.create_group(None, None).unwrap();
 
         let mut stream = StreamConversations::new(&bob.context, None).await.unwrap();
         let group_id = alice_bob_group.group_id.clone();
@@ -466,9 +464,7 @@ mod test {
             .await
             .unwrap();
 
-        let group = alix
-            .create_group(None, GroupMetadataOptions::default())
-            .unwrap();
+        let group = alix.create_group(None, None).unwrap();
         group
             .add_members_by_inbox_id(&[bo.inbox_id()])
             .await
@@ -522,9 +518,7 @@ mod test {
         assert!(group.is_ok());
         groups.push(group.unwrap());
 
-        let group = alix
-            .create_group(None, GroupMetadataOptions::default())
-            .unwrap();
+        let group = alix.create_group(None, None).unwrap();
         group
             .add_members_by_inbox_id(&[bo.inbox_id()])
             .await
@@ -549,13 +543,10 @@ mod test {
             .unwrap();
         futures::pin_mut!(stream);
 
-        alix.create_group(None, GroupMetadataOptions::default())
-            .unwrap();
+        alix.create_group(None, None).unwrap();
         let _self_group = stream.next().await.unwrap();
 
-        let group = bo
-            .create_group(None, GroupMetadataOptions::default())
-            .unwrap();
+        let group = bo.create_group(None, None).unwrap();
         group
             .add_members_by_inbox_id(&[alix.inbox_id()])
             .await
@@ -576,11 +567,7 @@ mod test {
         let bo = Arc::new(ClientBuilder::new_test_client_no_sync(&generate_local_wallet()).await);
 
         let alix_group = alix
-            .create_group_with_inbox_ids(
-                &[bo.inbox_id().to_string()],
-                None,
-                GroupMetadataOptions::default(),
-            )
+            .create_group_with_inbox_ids(&[bo.inbox_id().to_string()], None, None)
             .await
             .unwrap();
 

--- a/xmtp_mls/src/subscriptions/stream_conversations.rs
+++ b/xmtp_mls/src/subscriptions/stream_conversations.rs
@@ -402,7 +402,6 @@ mod test {
 
     use futures::StreamExt;
     use xmtp_cryptography::utils::generate_local_wallet;
-    
 
     #[cfg(target_arch = "wasm32")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);

--- a/xmtp_mls/src/subscriptions/stream_conversations.rs
+++ b/xmtp_mls/src/subscriptions/stream_conversations.rs
@@ -402,7 +402,7 @@ mod test {
 
     use futures::StreamExt;
     use xmtp_cryptography::utils::generate_local_wallet;
-    use xmtp_mls_common::group::GroupMetadataOptions;
+    
 
     #[cfg(target_arch = "wasm32")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);

--- a/xmtp_mls/src/subscriptions/stream_messages.rs
+++ b/xmtp_mls/src/subscriptions/stream_messages.rs
@@ -703,7 +703,7 @@ pub mod tests {
     use crate::builder::ClientBuilder;
     use rstest::*;
     use xmtp_cryptography::utils::generate_local_wallet;
-    use xmtp_mls_common::group::GroupMetadataOptions;
+    
 
     #[rstest]
     #[xmtp_common::test]

--- a/xmtp_mls/src/subscriptions/stream_messages.rs
+++ b/xmtp_mls/src/subscriptions/stream_messages.rs
@@ -712,9 +712,7 @@ pub mod tests {
         let alice = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
         let bob = ClientBuilder::new_test_client(&generate_local_wallet()).await;
 
-        let alice_group = alice
-            .create_group(None, GroupMetadataOptions::default())
-            .unwrap();
+        let alice_group = alice.create_group(None, None).unwrap();
         tracing::info!("Group Id = [{}]", hex::encode(&alice_group.group_id));
 
         alice_group

--- a/xmtp_mls/src/subscriptions/stream_messages.rs
+++ b/xmtp_mls/src/subscriptions/stream_messages.rs
@@ -703,7 +703,6 @@ pub mod tests {
     use crate::builder::ClientBuilder;
     use rstest::*;
     use xmtp_cryptography::utils::generate_local_wallet;
-    
 
     #[rstest]
     #[xmtp_common::test]

--- a/xmtp_mls/src/utils/events.rs
+++ b/xmtp_mls/src/utils/events.rs
@@ -33,7 +33,7 @@ pub async fn upload_debug_archive(
 mod tests {
     use std::time::Duration;
 
-    use xmtp_mls_common::group::GroupMetadataOptions;
+    
 
     use crate::{configuration::DeviceSyncUrls, tester, utils::events::upload_debug_archive};
 

--- a/xmtp_mls/src/utils/events.rs
+++ b/xmtp_mls/src/utils/events.rs
@@ -54,11 +54,7 @@ mod tests {
         alix.sync_welcomes().await?;
 
         let g = alix
-            .create_group_with_inbox_ids(
-                &[bo.inbox_id().to_string()],
-                None,
-                GroupMetadataOptions::default(),
-            )
+            .create_group_with_inbox_ids(&[bo.inbox_id().to_string()], None, None)
             .await?;
         g.update_group_name("Group with the buds".to_string())
             .await?;

--- a/xmtp_mls/src/utils/events.rs
+++ b/xmtp_mls/src/utils/events.rs
@@ -33,8 +33,6 @@ pub async fn upload_debug_archive(
 mod tests {
     use std::time::Duration;
 
-    
-
     use crate::{configuration::DeviceSyncUrls, tester, utils::events::upload_debug_archive};
 
     #[xmtp_common::test(unwrap_try = "true")]


### PR DESCRIPTION
### Make GroupMetadataOptions parameter optional in group creation methods to allow None values to default to GroupMetadataOptions::default()
Changes the `create_group`, `create_group_with_members`, and `create_group_with_inbox_ids` method signatures in [client.rs](https://github.com/xmtp/libxmtp/pull/2054/files#diff-3c0189371525b6aae3be7e5a7b5b5682204ef341fb2744fc876148c5ecab8642) to accept `Option<GroupMetadataOptions>` instead of `GroupMetadataOptions`, using `unwrap_or_default()` internally when None is passed. Updates all test files, benchmarks, examples, and language bindings to pass `None` instead of `GroupMetadataOptions::default()` when default metadata options are desired, while FFI, WASM, and Node.js bindings wrap existing metadata options in `Some()`.

#### 📍Where to Start
Start with the `create_group` method signature changes in [client.rs](https://github.com/xmtp/libxmtp/pull/2054/files#diff-3c0189371525b6aae3be7e5a7b5b5682204ef341fb2744fc876148c5ecab8642) to understand how the optional parameter is handled with `unwrap_or_default()`.

----

_[Macroscope](https://app.macroscope.com) summarized fc7c24b._