### PR TITLE
Wasm alloy fix

### DIFF
--- a/bindings_wasm/src/tests/mod.rs
+++ b/bindings_wasm/src/tests/mod.rs
@@ -6,12 +6,12 @@ use crate::inbox_id::generate_inbox_id;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_test::*;
 use xmtp_api_http::constants::ApiUrls;
-use xmtp_cryptography::utils::{rng, LocalWallet};
+use xmtp_cryptography::utils::generate_local_wallet;
 use xmtp_id::InboxOwner;
 
 async fn create_test_client() -> Client {
   // crate::opfs::Opfs::wipe_files().await.unwrap();
-  let wallet = LocalWallet::new(&mut rng());
+  let wallet = generate_local_wallet();
   let account_address = wallet.get_identifier().unwrap_throw();
   let host = ApiUrls::LOCAL_ADDRESS.to_string();
   let inbox_id = generate_inbox_id(account_address.clone().into());


### PR DESCRIPTION
### Replace direct LocalWallet constructor usage with generate_local_wallet helper function in WASM bindings test module
The change replaces the direct usage of `LocalWallet::new(&mut rng())` with a `generate_local_wallet()` helper function in the WASM bindings test module. The import statement is updated from `use xmtp_cryptography::utils::{rng, LocalWallet};` to `use xmtp_cryptography::utils::generate_local_wallet;` in [bindings_wasm/src/tests/mod.rs](https://github.com/xmtp/libxmtp/pull/2064/files#diff-b835d89530fceeffa7f5fb97597f27b54bd86cbdc576f88dfeea0e4a07f5c349).

#### 📍Where to Start
Start with the wallet creation code in the test module at [bindings_wasm/src/tests/mod.rs](https://github.com/xmtp/libxmtp/pull/2064/files#diff-b835d89530fceeffa7f5fb97597f27b54bd86cbdc576f88dfeea0e4a07f5c349).

----

_[Macroscope](https://app.macroscope.com) summarized beafce5._