### PR TITLE
Add more context to welcome and key package logs

### DIFF
--- a/xmtp_db/src/errors.rs
+++ b/xmtp_db/src/errors.rs
@@ -95,8 +95,8 @@ pub enum NotFound {
     CipherSalt(String),
     #[error("Sync Group for installation {0} not found")]
     SyncGroup(InstallationId),
-    #[error("Key Package Reference not found")]
-    KeyPackageReference,
+    #[error("Key Package Reference {handle} not found", handle = hex::encode(_0))]
+    KeyPackageReference(Vec<u8>),
     #[error("MLS Group Not Found")]
     MlsGroup,
     #[error("Post Quantum Key Pair not found")]

--- a/xmtp_mls/src/groups/mls_ext/decrypted_welcome.rs
+++ b/xmtp_mls/src/groups/mls_ext/decrypted_welcome.rs
@@ -78,7 +78,7 @@ pub(super) fn find_key_package_hash_ref<C: ConnectionExt>(
     Ok(provider
         .storage()
         .read(KEY_PACKAGE_REFERENCES, &serialized_hpke_public_key)?
-        .ok_or(NotFound::KeyPackageReference)?)
+        .ok_or(NotFound::KeyPackageReference(serialized_hpke_public_key))?)
 }
 
 /// For Curve25519 keys, we can just get the private key from the key package bundle

--- a/xmtp_mls/src/groups/welcome_sync.rs
+++ b/xmtp_mls/src/groups/welcome_sync.rs
@@ -52,7 +52,11 @@ where
                         err
                     );
                 } else {
-                    tracing::error!("failed to create group from welcome: {}", err);
+                    tracing::error!(
+                        "failed to create group from welcome created at {}: {}",
+                        welcome.created_ns,
+                        err
+                    );
                 }
 
                 Err(err)

--- a/xmtp_mls/src/worker.rs
+++ b/xmtp_mls/src/worker.rs
@@ -14,6 +14,16 @@ pub enum WorkerKind {
     KeyPackageCleaner,
 }
 
+impl Debug for WorkerKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WorkerKind::DeviceSync => write!(f, "DeviceSync"),
+            WorkerKind::DisappearingMessages => write!(f, "DisappearingMessages"),
+            WorkerKind::KeyPackageCleaner => write!(f, "KeyPackageCleaner"),
+        }
+    }
+}
+
 pub(crate) trait WorkerManager: Send + Sync {
     fn sync_metrics(&self) -> Option<Arc<WorkerMetrics<SyncMetric>>>;
     fn spawn(&self);
@@ -93,7 +103,7 @@ where
                         tracing::warn!("Pool disconnected. task will restart on reconnect");
                         break;
                     } else {
-                        tracing::error!("Worker error: {err:?}");
+                        tracing::error!("{:?} worker error: {:?}", &Core::kind(), err);
                         xmtp_common::time::sleep(WORKER_RESTART_DELAY).await;
                         tracing::info!("Restarting sync worker...");
                     }


### PR DESCRIPTION
Adds more context to logs so that we can debug any hpke or cleaner worker errors more effectively.

This depends on https://github.com/xmtp/libxmtp/pull/1852 landing first. There's one failing unit test here which is also failing in the base branch.