### PR TITLE
Troubleshoot wasm CI/Remove lifetimes from streams

### DIFF
--- a/.cargo/nextest.toml
+++ b/.cargo/nextest.toml
@@ -1,3 +1,0 @@
-[profile.default]
-default-filter = "not test(test_stream_all_messages_does_not_lose_messages)"
-retries = 1

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,15 @@
+[profile.default]
+default-filter = "not test(test_stream_all_messages_does_not_lose_messages)"
+retries = 1
+
+[profile.ci]
+default-filter = "not test(test_stream_all_messages_does_not_lose_messages)"
+retries = 0
+status-level = "skip"
+failure-output = "immediate-final"
+fail-fast = false
+
+
+[[profile.ci.overrides]]
+platform = 'wasm32-unknown-unkown'
+slow-timeout = "1m"

--- a/.github/workflows/test-ffi-bindings.yml
+++ b/.github/workflows/test-ffi-bindings.yml
@@ -53,4 +53,4 @@ jobs:
       - name: Run cargo nextest on FFI bindings
         run: |
           export CLASSPATH="${{ env.CLASSPATH }}"
-          cargo nextest --config-file ".cargo/nextest.toml" run --manifest-path bindings_ffi/Cargo.toml --test-threads 2
+          cargo nextest --profile ci run --manifest-path bindings_ffi/Cargo.toml --test-threads 2

--- a/.github/workflows/test-webassembly.yml
+++ b/.github/workflows/test-webassembly.yml
@@ -22,9 +22,10 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
   CARGO_PROFILE_TEST_DEBUG: 0
-  WASM_BINDGEN_TEST_TIMEOUT: 10000
+  WASM_BINDGEN_TEST_TIMEOUT: 256
   WASM_BINDGEN_TEST_ONLY_WEB: 1
   WASM_BINDGEN_SPLIT_LINKED_MODULES: 1
+  RSTEST_TIMEOUT: 30
 jobs:
   test:
     name: Test
@@ -54,7 +55,7 @@ jobs:
         run: |
           source ./emsdk/emsdk_env.sh
           cargo build --locked --tests --release --target wasm32-unknown-unknown -p xmtp_id -p xmtp_mls -p xmtp_api_http -p xmtp_cryptography -p xmtp_common -p bindings_wasm -p xmtp_api_d14n -p xmtp_db
-      - name: test with chrome
+      - name: test libraries
         env:
           RUSTFLAGS: --cfg tracing_unstable -Ctarget-feature=+bulk-memory,+mutable-globals,+atomics --cfg getrandom_backend="wasm_js"
           CHROMEDRIVER: "chromedriver"
@@ -62,5 +63,19 @@ jobs:
           cargo test --locked --release --target wasm32-unknown-unknown -p xmtp_mls -p xmtp_id -p xmtp_api_http -p xmtp_cryptography -p xmtp_api -p bindings_wasm -p xmtp_api_d14n -p xmtp_db -- \
             --skip encrypted_store::group_message::tests::it_cannot_insert_message_without_group \
         working-directory: ./
+      - name: test xmtp_mls client
         env:
+          RUSTFLAGS: --cfg tracing_unstable -Ctarget-feature=+bulk-memory,+mutable-globals,+atomics --cfg getrandom_backend="wasm_js"
           CHROMEDRIVER: "chromedriver"
+        run: |
+          cargo test --locked --release --target wasm32-unknown-unknown -p xmtp_mls -- \
+            --skip encrypted_store::group_message::tests::it_cannot_insert_message_without_group \
+            --skip subscriptions::
+        working-directory: ./
+      - name: test xmtp_mls subscriptions
+        env:
+          RUSTFLAGS: --cfg tracing_unstable -Ctarget-feature=+bulk-memory,+mutable-globals,+atomics --cfg getrandom_backend="wasm_js"
+          CHROMEDRIVER: "chromedriver"
+        run: |
+          cargo test --locked --release --target wasm32-unknown-unknown -p xmtp_mls -- subscriptions::
+        working-directory: ./

--- a/.github/workflows/test-workspace.yml
+++ b/.github/workflows/test-workspace.yml
@@ -57,8 +57,8 @@ jobs:
       - name: Install nextest
         uses: taiki-e/install-action@nextest
       - name: build tests
-        run: cargo nextest --config-file ".cargo/nextest.toml" run --no-run --workspace --tests --exclude xmtpv3 --exclude bindings_node --exclude bindings_wasm --all-features
+        run: cargo nextest --profile ci run --no-run --workspace --tests --exclude xmtpv3 --exclude bindings_node --exclude bindings_wasm --all-features
       - name: test workspace with grpc
-        run: cargo nextest --config-file ".cargo/nextest.toml" run --workspace --test-threads 2 --exclude xmtpv3 --exclude bindings_node --exclude bindings_wasm
+        run: cargo nextest --profile ci run --workspace --test-threads 2 --exclude xmtpv3 --exclude bindings_node --exclude bindings_wasm
       - name: test workspace with http
-        run: cargo nextest run --config-file ".cargo/nextest.toml" --workspace --exclude xmtp_api_grpc --exclude xmtpv3 --exclude bindings_node --exclude bindings_wasm --exclude xmtp_api_d14n --features http-api --test-threads 2
+        run: cargo nextest --profile ci run  --workspace --exclude xmtp_api_grpc --exclude xmtpv3 --exclude bindings_node --exclude bindings_wasm --exclude xmtp_api_d14n --features http-api --test-threads 2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517e5acbd38b6d4c59da380e8bbadc6d365bf001903ce46cf5521c53c647e07b"
+checksum = "d6967ca1ed656766e471bc323da42fb0db320ca5e1418b408650e98e4757b3d2"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -173,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-core"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3c5a28f166629752f2e7246b813cdea3243cca59aab2d4264b1fd68392c10eb"
+checksum = "5968f48d7a62587cd874bd84034831da4f7f577ce5de984828e376766efc0f32"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -185,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18cc14d832bc3331ca22a1c7819de1ede99f58f61a7d123952af7dde8de124a6"
+checksum = "f9135eb501feccf7f4cb8a183afd406a65483fdad7bbd7332d0470e5d725c92f"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -270,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-hardforks"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbff8445282ec080c2673692062bd4930d7a0d6bda257caf138cfc650c503000"
+checksum = "977d2492ce210e34baf7b36afaacea272c96fbe6774c47e23f97d14033c0e94f"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
@@ -283,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ccaa79753d7bf15f06399ea76922afbfaf8d18bebed9e8fc452984b4a90dcc9"
+checksum = "8b26fdd571915bafe857fccba4ee1a4f352965800e46a53e4a5f50187b7776fa"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -369,9 +369,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18c35fc4b03ace65001676358ffbbaefe2a2b27ee50fe777c345082c7c888be8"
+checksum = "a326d47106039f38b811057215a92139f46eef7983a4b77b10930a0ea5685b1e"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -424,7 +424,7 @@ dependencies = [
  "futures",
  "futures-utils-wasm",
  "lru 0.13.0",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "pin-project",
  "reqwest",
  "serde",
@@ -585,9 +585,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8612e0658964d616344f199ab251a49d48113992d81b92dab93ed855faa66383"
+checksum = "d4be1ce1274ddd7fdfac86e5ece1b225e9bba1f2327e20fbb30ee6b9cc1423fe"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -599,9 +599,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a384edac7283bc4c010a355fb648082860c04b826bb7a814c45263c8f304c74"
+checksum = "01e92f3708ea4e0d9139001c86c051c538af0146944a2a9c7181753bd944bf57"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
@@ -618,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd588c2d516da7deb421b8c166dc60b7ae31bca5beea29ab6621fcfa53d6ca5"
+checksum = "9afe1bd348a41f8c9b4b54dfb314886786d6201235b0b3f47198b9d910c86bb2"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -636,9 +636,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86ddeb70792c7ceaad23e57d52250107ebbb86733e52f4a25d8dc1abc931837"
+checksum = "d6195df2acd42df92a380a8db6205a5c7b41282d0ce3f4c665ecf7911ac292f1"
 dependencies = [
  "serde",
  "winnow",
@@ -646,9 +646,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "584cb97bfc5746cb9dcc4def77da11694b5d6d7339be91b7480a6a68dc129387"
+checksum = "6185e98a79cf19010722f48a74b5a65d153631d2f038cabd250f4b9e9813b8ad"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -668,7 +668,7 @@ dependencies = [
  "derive_more",
  "futures",
  "futures-utils-wasm",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -742,9 +742,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -757,33 +757,33 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.8"
+version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
@@ -1146,9 +1146,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.7.3"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "basic-toml"
@@ -1229,6 +1229,7 @@ dependencies = [
  "const-hex",
  "futures",
  "js-sys",
+ "pin-project-lite",
  "prost",
  "serde",
  "serde-wasm-bindgen",
@@ -1317,9 +1318,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c79a94619fade3c0b887670333513a67ac28a6a7e653eb260bf0d4103db38d"
+checksum = "4fd49896f12ac9b6dcd7a5998466b9b58263a695a3dd1ecc1aaca2e12a90b080"
 dependencies = [
  "cc",
  "glob",
@@ -1339,9 +1340,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
 
 [[package]]
 name = "byte-slice-cast"
@@ -1381,9 +1382,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+checksum = "0da45bc31171d8d6960122e222a67740df867c1dd53b4d51caa297084c185cab"
 dependencies = [
  "serde",
 ]
@@ -1419,9 +1420,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.24"
+version = "1.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16595d3be041c03b09d08d0858631facccee9221e579704070e6e9e4915d3bc7"
+checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
 dependencies = [
  "jobserver",
  "libc",
@@ -1634,9 +1635,9 @@ dependencies = [
 
 [[package]]
 name = "color-eyre"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e1761c0e16f8883bbbb8ce5990867f4f06bf11a0253da6495a04ce4b6ef0ec"
+checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
 dependencies = [
  "backtrace",
  "color-spantrace",
@@ -1649,9 +1650,9 @@ dependencies = [
 
 [[package]]
 name = "color-spantrace"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ddd8d5bfda1e11a501d0a7303f3bfed9aa632ebdb859be40d0fd70478ed70d5"
+checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
 dependencies = [
  "once_cell",
  "owo-colors",
@@ -1661,9 +1662,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "colored"
@@ -2010,7 +2011,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
- "parking_lot_core 0.9.10",
+ "parking_lot_core 0.9.11",
 ]
 
 [[package]]
@@ -2120,7 +2121,7 @@ dependencies = [
 [[package]]
 name = "diesel"
 version = "2.2.4"
-source = "git+https://github.com/diesel-rs/diesel?branch=master#efcb1e7e6cc921dbb92edd5fb5a6829c9625da51"
+source = "git+https://github.com/diesel-rs/diesel?branch=master#7629365ffbad24019ab3d126433d4c26c7c13c79"
 dependencies = [
  "diesel_derives",
  "downcast-rs",
@@ -2134,8 +2135,9 @@ dependencies = [
 [[package]]
 name = "diesel_derives"
 version = "2.2.0"
-source = "git+https://github.com/diesel-rs/diesel?branch=master#efcb1e7e6cc921dbb92edd5fb5a6829c9625da51"
+source = "git+https://github.com/diesel-rs/diesel?branch=master#7629365ffbad24019ab3d126433d4c26c7c13c79"
 dependencies = [
+ "darling",
  "diesel_table_macro_syntax",
  "dsl_auto_type",
  "proc-macro2",
@@ -2146,7 +2148,7 @@ dependencies = [
 [[package]]
 name = "diesel_migrations"
 version = "2.2.0"
-source = "git+https://github.com/diesel-rs/diesel?branch=master#efcb1e7e6cc921dbb92edd5fb5a6829c9625da51"
+source = "git+https://github.com/diesel-rs/diesel?branch=master#7629365ffbad24019ab3d126433d4c26c7c13c79"
 dependencies = [
  "diesel",
  "migrations_internals",
@@ -2156,7 +2158,7 @@ dependencies = [
 [[package]]
 name = "diesel_table_macro_syntax"
 version = "0.2.0"
-source = "git+https://github.com/diesel-rs/diesel?branch=master#efcb1e7e6cc921dbb92edd5fb5a6829c9625da51"
+source = "git+https://github.com/diesel-rs/diesel?branch=master#7629365ffbad24019ab3d126433d4c26c7c13c79"
 dependencies = [
  "syn 2.0.101",
 ]
@@ -2229,7 +2231,7 @@ checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
 [[package]]
 name = "dsl_auto_type"
 version = "0.1.0"
-source = "git+https://github.com/diesel-rs/diesel?branch=master#efcb1e7e6cc921dbb92edd5fb5a6829c9625da51"
+source = "git+https://github.com/diesel-rs/diesel?branch=master#7629365ffbad24019ab3d126433d4c26c7c13c79"
 dependencies = [
  "darling",
  "either",
@@ -2635,6 +2637,10 @@ name = "futures-timer"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+dependencies = [
+ "gloo-timers 0.2.6",
+ "send_wrapper",
+]
 
 [[package]]
 name = "futures-util"
@@ -2735,6 +2741,18 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "gloo-timers"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "gloo-timers"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
@@ -2769,7 +2787,7 @@ dependencies = [
  "getrandom 0.3.3",
  "hashbrown 0.15.3",
  "nonzero_ext",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "portable-atomic",
  "quanta",
  "rand 0.9.1",
@@ -2899,9 +2917,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.9"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
 
 [[package]]
 name = "hex"
@@ -3094,9 +3112,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.6"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a01595e11bdcec50946522c32dde3fc6914743000a68b93000965f2f02406d"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.3.1",
  "hyper 1.6.0",
@@ -3139,9 +3157,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c293b6b3d21eca78250dc7dbebd6b9210ec5530e038cbfe0661b5c47ab06e8"
+checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3649,9 +3667,9 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -3773,16 +3791,16 @@ dependencies = [
 [[package]]
 name = "migrations_internals"
 version = "2.2.0"
-source = "git+https://github.com/diesel-rs/diesel?branch=master#efcb1e7e6cc921dbb92edd5fb5a6829c9625da51"
+source = "git+https://github.com/diesel-rs/diesel?branch=master#7629365ffbad24019ab3d126433d4c26c7c13c79"
 dependencies = [
  "serde",
- "toml 0.8.22",
+ "toml 0.8.23",
 ]
 
 [[package]]
 name = "migrations_macros"
 version = "2.2.0"
-source = "git+https://github.com/diesel-rs/diesel?branch=master#efcb1e7e6cc921dbb92edd5fb5a6829c9625da51"
+source = "git+https://github.com/diesel-rs/diesel?branch=master#7629365ffbad24019ab3d126433d4c26c7c13c79"
 dependencies = [
  "migrations_internals",
  "proc-macro2",
@@ -3875,7 +3893,7 @@ dependencies = [
  "lru 0.14.0",
  "openmls",
  "openmls_rust_crypto",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "rand 0.8.5",
  "rstest",
  "thiserror 2.0.12",
@@ -3984,9 +4002,9 @@ dependencies = [
 
 [[package]]
 name = "napi-build"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03acbfa4f156a32188bfa09b86dc11a431b5725253fc1fc6f6df5bed273382c4"
+checksum = "44e0e3177307063d3e7e55b7dd7b648cca9d7f46daa35422c0d98cc2bf48c2c1"
 
 [[package]]
 name = "napi-derive"
@@ -4115,9 +4133,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -4426,12 +4444,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.10",
+ "parking_lot_core 0.9.11",
 ]
 
 [[package]]
@@ -4450,9 +4468,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -4747,9 +4765,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "potential_utf"
@@ -4803,9 +4821,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.32"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
+checksum = "9dee91521343f4c5c6a63edd65e54f31f5c92fe8978c40a4282f8372194c6a7d"
 dependencies = [
  "proc-macro2",
  "syn 2.0.101",
@@ -4992,7 +5010,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
 dependencies = [
  "log",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "scheduled-thread-pool",
 ]
 
@@ -5192,9 +5210,9 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
-version = "0.12.18"
+version = "0.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e98ff6b0dbbe4d5a37318f433d4fc82babd21631f194d370409ceb2e40b2f0b5"
+checksum = "a2f8e5513d63f2e5b386eb5106dc67eaf3f84e95258e210489136b8b92ad6119"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5514,7 +5532,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
 dependencies = [
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
 ]
 
 [[package]]
@@ -5660,6 +5678,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "send_wrapper"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
+
+[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5725,9 +5749,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
@@ -5960,17 +5984,19 @@ dependencies = [
 
 [[package]]
 name = "sqlite-wasm-rs"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0c6fdb636283dad1283b20bc62157ac68a7124fde269723467689c4fd6d356c"
+checksum = "4de6f7453ce1a0cd43d265e07acca106cde5d8c10052251fd0f3f34dcf5ec3b0"
 dependencies = [
+ "cc",
  "fragile",
  "indexed_db_futures",
  "js-sys",
  "once_cell",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "thiserror 2.0.12",
  "tokio",
+ "wasm-array-cp",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -6068,9 +6094,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d879005cc1b5ba4e18665be9e9501d9da3a9b95f625497c4cb7ee082b532e"
+checksum = "14c8c8f496c33dc6343dac05b4be8d9e0bca180a4caa81d7b8416b10cc2273cd"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -6331,7 +6357,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -6420,9 +6446,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -6432,18 +6458,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.9"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.26"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.9.0",
  "serde",
@@ -6455,9 +6481,9 @@ dependencies = [
 
 [[package]]
 name = "toml_write"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
@@ -6530,9 +6556,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.4"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdb0c213ca27a9f57ab69ddb290fd80d970922355b83ae380b395d3986b8a2e"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
  "bitflags 2.9.1",
  "bytes",
@@ -6584,9 +6610,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "1b1ffbcf9c6f6b99d386e7444eb608ba646ae452a36b39737deb9663b610f662"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6595,9 +6621,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
@@ -6681,7 +6707,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "once_cell",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "tracing-core",
  "tracing-subscriber",
 ]
@@ -7250,6 +7276,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-array-cp"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb633b3e235f0ebe0a35162adc1e0293fc4b7e3f3a6fc7b5374d80464267ff84"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7365,7 +7401,7 @@ checksum = "0048ad49a55b9deb3953841fa1fc5858f0efbcb7a18868c899a360269fac1b23"
 dependencies = [
  "futures",
  "js-sys",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "pin-utils",
  "slab",
  "wasm-bindgen",
@@ -7459,7 +7495,7 @@ dependencies = [
  "windows-interface",
  "windows-link",
  "windows-result",
- "windows-strings 0.4.2",
+ "windows-strings",
 ]
 
 [[package]]
@@ -7492,13 +7528,13 @@ checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-registry"
-version = "0.4.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
+checksum = "b3bab093bdd303a1240bb99b8aba8ea8a69ee19d34c9e2ef9594e708a4878820"
 dependencies = [
+ "windows-link",
  "windows-result",
- "windows-strings 0.3.1",
- "windows-targets 0.53.0",
+ "windows-strings",
 ]
 
 [[package]]
@@ -7506,15 +7542,6 @@ name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
  "windows-link",
 ]
@@ -7773,6 +7800,7 @@ dependencies = [
  "const-hex",
  "ctor 0.4.2",
  "futures",
+ "futures-timer",
  "mockall",
  "thiserror 2.0.12",
  "tokio",
@@ -7799,7 +7827,7 @@ dependencies = [
  "once_cell",
  "openmls",
  "openmls_rust_crypto",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "prost",
  "prost-types",
  "thiserror 2.0.12",
@@ -7867,13 +7895,13 @@ dependencies = [
  "openmls_traits",
  "prost",
  "reqwest",
- "serde",
  "serde_json",
  "sha2",
  "thiserror 2.0.12",
  "tokio",
  "tokio-util",
  "tracing",
+ "wasm-bindgen-test",
  "xmtp_common",
  "xmtp_db",
  "xmtp_mls_common",
@@ -7925,11 +7953,11 @@ dependencies = [
  "fdlimit",
  "futures",
  "getrandom 0.2.16",
- "gloo-timers",
+ "gloo-timers 0.3.0",
  "js-sys",
  "once_cell",
  "owo-colors",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "thiserror 2.0.12",
@@ -7958,6 +7986,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tonic",
  "tracing",
+ "wasm-bindgen-test",
  "xmtp_common",
  "xmtp_proto",
 ]
@@ -7995,13 +8024,14 @@ dependencies = [
  "diesel",
  "diesel_migrations",
  "dyn-clone",
+ "futures-timer",
  "libsqlite3-sys",
  "mockall",
  "openmls",
  "openmls_basic_credential",
  "openmls_rust_crypto",
  "openmls_traits",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "prost",
  "rand 0.8.5",
  "serde",
@@ -8009,7 +8039,7 @@ dependencies = [
  "sqlite-wasm-rs",
  "thiserror 2.0.12",
  "tokio",
- "toml 0.8.22",
+ "toml 0.8.23",
  "tracing",
  "wasm-bindgen",
  "wasm-bindgen-test",
@@ -8027,7 +8057,7 @@ version = "1.3.0-dev"
 dependencies = [
  "derive_builder",
  "diesel",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "rand 0.8.5",
  "tracing",
  "xmtp_common",
@@ -8047,7 +8077,7 @@ dependencies = [
  "ed25519-dalek",
  "futures",
  "getrandom 0.2.16",
- "gloo-timers",
+ "gloo-timers 0.3.0",
  "openmls",
  "openmls_traits",
  "p256",
@@ -8101,9 +8131,9 @@ dependencies = [
  "futures",
  "futures-executor",
  "futures-test",
+ "futures-timer",
  "futures-util",
  "getrandom 0.2.16",
- "gloo-timers",
  "hkdf",
  "hmac",
  "indicatif",
@@ -8114,9 +8144,7 @@ dependencies = [
  "openmls_basic_credential",
  "openmls_rust_crypto",
  "openmls_traits",
- "openssl",
- "openssl-sys",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "passkey",
  "pin-project-lite",
  "prost",
@@ -8163,6 +8191,7 @@ dependencies = [
  "prost",
  "serde",
  "thiserror 2.0.12",
+ "wasm-bindgen-test",
  "xmtp_common",
  "xmtp_db",
  "xmtp_id",
@@ -8206,7 +8235,7 @@ dependencies = [
  "fdlimit",
  "futures",
  "paranoid-android",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "prost",
  "rand 0.8.5",
  "thiserror 2.0.12",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,7 @@ wasm-bindgen-futures = "0.4.50"
 wasm-bindgen-test = "0.3.50"
 web-sys = "0.3"
 zeroize = "1.8"
+futures-timer = { version = "3.0", features = ["wasm-bindgen"] }
 
 # Internal Crate Dependencies
 xmtp_api = { path = "xmtp_api" }
@@ -152,6 +153,7 @@ xmtp_proto = { path = "xmtp_proto" }
 xmtp_macro = { path = "xmtp_macro" }
 xmtp_db = { path = "xmtp_db" }
 xmtp_db_test = { path = "xmtp_db_test" }
+bindings-wasm = { path = "bindings_wasm" }
 
 [profile.dbg]
 inherits = "dev"

--- a/bindings_wasm/Cargo.toml
+++ b/bindings_wasm/Cargo.toml
@@ -4,15 +4,16 @@ name = "bindings_wasm"
 version.workspace = true
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 console_error_panic_hook.workspace = true
 futures.workspace = true
 hex.workspace = true
 js-sys.workspace = true
+pin-project-lite = { workspace = true }
 prost.workspace = true
-serde.workspace = true
+serde = { workspace = true, features = ["derive"] }
 serde-wasm-bindgen = "0.6.5"
 serde_bytes = "0.11"
 tracing.workspace = true

--- a/common/src/test.rs
+++ b/common/src/test.rs
@@ -27,19 +27,19 @@ pub struct TestLogReplace {
 }
 
 impl TestLogReplace {
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
     pub fn add(&mut self, id: &str, name: &str) {
         self.ids.insert(id.to_string(), name.to_string());
         let mut ids = REPLACE_IDS.lock();
         ids.insert(id.to_string(), name.to_string());
     }
 
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
     pub fn add(&mut self, _id: &str, _name: &str) {}
 }
 
 // remove ids for replacement from map on drop
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 impl Drop for TestLogReplace {
     fn drop(&mut self) {
         let mut ids = REPLACE_IDS.lock();
@@ -163,7 +163,7 @@ pub fn logger() {
     use tracing_subscriber::util::SubscriberInitExt;
 
     INIT.get_or_init(|| {
-        let filter = EnvFilter::builder().parse("off").unwrap();
+        let filter = EnvFilter::builder().parse("info").unwrap();
 
         tracing_subscriber::registry()
             .with(tracing_wasm::WASMLayer::default())

--- a/dev/test/browser-sdk
+++ b/dev/test/browser-sdk
@@ -28,7 +28,7 @@ function ctrl_c() {
 
 function run() {
   cd $WORKSPACE_PATH
-  nix build .#bindings_wasm --no-substitute --refresh
+  nix build .#bindings_wasm --refresh
 
   if [ ! -d $DIR/xmtp-js ]; then
     git clone git@github.com:xmtp/xmtp-js.git $DIR/xmtp-js
@@ -43,13 +43,16 @@ function run() {
   rm -rf $DIR/xmtp-js/node_modules/@xmtp/wasm-bindings/dist
   cp --no-preserve=mode,ownership -r $WORKSPACE_PATH/result/dist $DIR/xmtp-js/node_modules/@xmtp/wasm-bindings/
 
-  $YARN build
+  # $YARN build
+
+  # set playwright version if version between nixpkgs and npm is different
   # set playwright to same version as nix (otherwise will not work)
-  $YARN set resolution "playwright@npm:^1.49.1" npm:$PLAYWRIGHT_VERSION
-  $YARN set resolution "playwright-core@npm:^1.49.1" npm:$PLAYWRIGHT_VERSION
+  # $YARN set resolution "playwright@npm:^1.49.1" npm:$PLAYWRIGHT_VERSION
+  # $YARN set resolution "playwright-core@npm:^1.49.1" npm:$PLAYWRIGHT_VERSION
 
   cd $WORKSPACE_PATH
-  $YARN --cwd $DIR/xmtp-js/sdks/browser-sdk test test/Conversations.test.ts
+  $YARN --cwd $DIR/xmtp-js/sdks/browser-sdk
+  $YARN --cwd $DIR/xmtp-js/sdks/browser-sdk test
 
   return 0
 }

--- a/dev/test/wasm
+++ b/dev/test/wasm
@@ -3,10 +3,15 @@ set -eou pipefail
 
 export RUSTFLAGS="-Ctarget-feature=+bulk-memory,+mutable-globals,+atomics --cfg getrandom_backend=\"wasm_js\"${RUSTFLAGS:=}"
 
+PACKAGE=${1:-}
+TESTS=${2:-}
+
 RUST_LOG=off \
+RSTEST_TIMEOUT=10 \
 WASM_BINDGEN_SPLIT_LINKED_MODULES=1 \
-  WASM_BINDGEN_TEST_ONLY_WEB=1 \
-  WASM_BINDGEN_TEST_TIMEOUT=180 \
-  CHROMEDRIVER="chromedriver" \
-  cargo test --target wasm32-unknown-unknown --release \
-  -p xmtp_mls -p xmtp_id -p xmtp_api_http -p xmtp_cryptography -p xmtp_api -p xmtp_api_d14n -p xmtp_db
+WASM_BINDGEN_TEST_ONLY_WEB=1 \
+WASM_BINDGEN_TEST_TIMEOUT=180 \
+CHROMEDRIVER="chromedriver" \
+  cargo test --locked --release --target wasm32-unknown-unknown -p $PACKAGE -- \
+            --skip encrypted_store::group_message::tests::it_cannot_insert_message_without_group \
+            $TESTS

--- a/dev/test/wasm-interactive
+++ b/dev/test/wasm-interactive
@@ -19,5 +19,4 @@ export NO_HEADLESS=1
 
 cargo test --target wasm32-unknown-unknown --release \
   -p $PACKAGE -- \
-  $TESTS \
-  --skip xmtp_mls::storage::encrypted_store::group_message::tests::it_cannot_insert_message_without_group
+  --skip xmtp_mls::storage::encrypted_store::group_message::tests::it_cannot_insert_message_without_group 

--- a/dev/test/wasm-nextest
+++ b/dev/test/wasm-nextest
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -eou pipefail
+
+export RUSTFLAGS="-Ctarget-feature=+bulk-memory,+mutable-globals,+atomics --cfg getrandom_backend=\"wasm_js\"${RUSTFLAGS:=}"
+
+WASM_BINDGEN_TEST_ONLY_WEB=1 \
+  WASM_BINDGEN_TEST_TIMEOUT=180 \
+  CHROMEDRIVER="chromedriver" \
+  cargo nextest run \
+  --profile ci \
+  --workspace -E 'platform(target) and not test(it_cannot_insert_message_without_group)' \
+  --target wasm32-unknown-unknown --release \
+  --exclude xdbg --exclude xmtpv3 --exclude bindings_node --exclude mls_validation_service --exclude xmtp_cli --exclude xmtp_api_grpc

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1747587869,
-        "narHash": "sha256-Zay3WJdSvC2VQmNqWSVLBOg/1iS/0/Q0c9JOBsB+3qw=",
+        "lastModified": 1748970125,
+        "narHash": "sha256-UDyigbDGv8fvs9aS95yzFfOKkEjx1LO3PL3DsKopohA=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "76603d32f18e0e378d9f6335c8fc286413493655",
+        "rev": "323b5746d89e04b22554b061522dfce9e4c49b18",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1747392669,
-        "narHash": "sha256-zky3+lndxKRu98PAwVK8kXPdg+Q1NVAhaI7YGrboKYA=",
+        "lastModified": 1748932954,
+        "narHash": "sha256-1HiKieYFvFi5Hw3x2/mptbbvAuL0QwlZQC9UIGNNb1w=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "c3c27e603b0d9b5aac8a16236586696338856fbb",
+        "rev": "2da33335e40ca932b4c5ea632816eed573736fba",
         "type": "github"
       },
       "original": {
@@ -41,11 +41,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1743550720,
-        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
+        "lastModified": 1748821116,
+        "narHash": "sha256-F82+gS044J1APL0n4hH50GYdPRv/5JWm34oCJYmVKdE=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
+        "rev": "49f0870db23e8c1ca0b5259734a02cd9e1e371a1",
         "type": "github"
       },
       "original": {
@@ -75,27 +75,27 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1746263487,
-        "narHash": "sha256-zOUy06gTPBv7fbRReGiQmP1xW0S8qhyTnBC++G95ENo=",
+        "lastModified": 1748855429,
+        "narHash": "sha256-qbk9L8pQtGDP2g4r5teSFeN1yAXGyCA4VEPyCC/5iXg=",
         "owner": "shazow",
         "repo": "foundry.nix",
-        "rev": "27178114871bb990a12766e01379dfe5edcb35d4",
+        "rev": "42f3e872460cb8b04e1ea0dff11e2865206ff344",
         "type": "github"
       },
       "original": {
         "owner": "shazow",
-        "ref": "monthly",
+        "ref": "stable",
         "repo": "foundry.nix",
         "type": "github"
       }
     },
     "mkshell-util": {
       "locked": {
-        "lastModified": 1748025842,
-        "narHash": "sha256-3rUUH4szSpMmlGvAKpCI0C0PE8ast7CyChd/syFXIfI=",
+        "lastModified": 1748616381,
+        "narHash": "sha256-wN0uma/2jidpGEn6Cn4txUqQ028ZBQnPx/cVQ3eHwaw=",
         "owner": "insipx",
         "repo": "mkShell-util.nix",
-        "rev": "9270b35f0ef3b830b9a5d41f26be44006c470349",
+        "rev": "84002b39c652bec9f4eb4783dca2be6a1c07146c",
         "type": "github"
       },
       "original": {
@@ -120,11 +120,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1743296961,
-        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
+        "lastModified": 1748740939,
+        "narHash": "sha256-rQaysilft1aVMwF14xIdGS3sj1yHlI6oKQNBRTF40cc=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
+        "rev": "656a64127e9d791a334452c6b6606d17539476e2",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1747958103,
-        "narHash": "sha256-qmmFCrfBwSHoWw7cVK4Aj+fns+c54EBP8cGqp/yK410=",
+        "lastModified": 1748856973,
+        "narHash": "sha256-RlTsJUvvr8ErjPBsiwrGbbHYW8XbB/oek0Gi78XdWKg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fe51d34885f7b5e3e7b59572796e1bcb427eccb1",
+        "rev": "e4b09e47ace7d87de083786b404bf232eb6c89d8",
         "type": "github"
       },
       "original": {
@@ -164,11 +164,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1747323949,
-        "narHash": "sha256-G4NwzhODScKnXqt2mEQtDFOnI0wU3L1WxsiHX3cID/0=",
+        "lastModified": 1748871544,
+        "narHash": "sha256-7V/sV6JiEp8LFmGIG3OqFDU2YNHgmodg1qNKGYXZKIY=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "f8e784353bde7cbf9a9046285c1caf41ac484ebe",
+        "rev": "25808c1ba14627876c9a031a67f404ac1927887d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
     flake-parts = { url = "github:hercules-ci/flake-parts"; };
     systems.url = "github:nix-systems/default";
     mkshell-util.url = "github:insipx/mkShell-util.nix";
-    foundry.url = "github:shazow/foundry.nix/monthly";
+    foundry.url = "github:shazow/foundry.nix/stable";
     crane = {
       url = "github:ipetkov/crane";
     };
@@ -45,7 +45,7 @@
           mkToolchain = targets: components: pkgs.fenix.combine [
             toolchain
             (pkgs.lib.forEach targets (target: (pkgs.fenix.targets."${target}".fromManifestFile rust-manifest).rust-std))
-            (pkgs.lib.forEach components (c: (inputs'.fenix.packages.fromManifestFile rust-manifest)."${c}"))
+            (pkgs.lib.forEach components (component: (inputs'.fenix.packages.fromManifestFile rust-manifest)."${component}"))
           ];
           craneLib = crane.mkLib pkgs;
           filesets = pkgs.callPackage ./nix/filesets.nix { inherit craneLib; };

--- a/nix/android.nix
+++ b/nix/android.nix
@@ -19,7 +19,7 @@ let
 
   android = {
     platforms = [ "33" "34" ];
-    platformTools = "33.0.3";
+    platformTools = "34.0.4";
     buildTools = [ "30.0.3" ];
   };
 

--- a/nix/filesets.nix
+++ b/nix/filesets.nix
@@ -17,9 +17,14 @@ let
     (commonCargoSources ./../common)
     (commonCargoSources ./../xmtp_content_types)
     (commonCargoSources ./../xmtp_macro)
+    (commonCargoSources ./../xmtp_db)
+    (commonCargoSources ./../xmtp_db_test)
+    (commonCargoSources ./../xmtp_archive)
+    (commonCargoSources ./../xmtp_mls_common)
     ./../xmtp_id/src/scw_verifier/chain_urls_default.json
     ./../xmtp_id/artifact
-    ./../xmtp_mls/migrations
+    ./../xmtp_id/src/scw_verifier/signature_validation.hex
+    ./../xmtp_db/migrations
   ];
   binaries = lib.fileset.unions [
     (commonCargoSources ./../examples/cli)

--- a/nix/libxmtp.nix
+++ b/nix/libxmtp.nix
@@ -21,9 +21,7 @@
 , corepack
 , lnav
 , zstd
-, llvmPackages_19
 , google-chrome
-, wasm-bindgen-cli
 , foundry-bin
 , graphite-cli
 , jq
@@ -65,7 +63,6 @@ mkShell {
   nativeBuildInputs = [ pkg-config ];
   buildInputs =
     [
-      wasm-bindgen-cli
       rust-toolchain
       fenix.rust-analyzer
       zstd
@@ -75,6 +72,7 @@ mkShell {
       openssl
       sqlite
       sqlcipher
+      # emscripten
 
       mktemp
       jdk21

--- a/xmtp_api/Cargo.toml
+++ b/xmtp_api/Cargo.toml
@@ -24,6 +24,7 @@ xmtp_api_grpc = { workspace = true, optional = true, features = ["test-utils"] }
 
 # test utils
 [dev-dependencies]
+futures-timer.workspace = true
 mockall.workspace = true
 xmtp_common = { workspace = true, features = ["test-utils"] }
 xmtp_id = { workspace = true, features = ["test-utils"] }

--- a/xmtp_api/src/debug_wrapper.rs
+++ b/xmtp_api/src/debug_wrapper.rs
@@ -167,16 +167,16 @@ where
     E: std::error::Error + RetryableError + Send + Sync + 'static,
     A: HasStats,
 {
-    type GroupMessageStream<'a> = <A as XmtpMlsStreams>::GroupMessageStream<'a>;
+    type GroupMessageStream = <A as XmtpMlsStreams>::GroupMessageStream;
 
-    type WelcomeMessageStream<'a> = <A as XmtpMlsStreams>::WelcomeMessageStream<'a>;
+    type WelcomeMessageStream = <A as XmtpMlsStreams>::WelcomeMessageStream;
 
     type Error = ApiClientError<E>;
 
     async fn subscribe_group_messages(
         &self,
         request: SubscribeGroupMessagesRequest,
-    ) -> Result<Self::GroupMessageStream<'_>, Self::Error> {
+    ) -> Result<Self::GroupMessageStream, Self::Error> {
         wrap_err(
             || self.inner.subscribe_group_messages(request),
             || self.inner.aggregate_stats(),
@@ -187,7 +187,7 @@ where
     async fn subscribe_welcome_messages(
         &self,
         request: SubscribeWelcomeMessagesRequest,
-    ) -> Result<Self::WelcomeMessageStream<'_>, Self::Error> {
+    ) -> Result<Self::WelcomeMessageStream, Self::Error> {
         wrap_err(
             || self.inner.subscribe_welcome_messages(request),
             || self.inner.aggregate_stats(),

--- a/xmtp_api/src/mls.rs
+++ b/xmtp_api/src/mls.rs
@@ -325,7 +325,7 @@ where
     pub async fn subscribe_group_messages(
         &self,
         filters: Vec<GroupFilter>,
-    ) -> Result<<ApiClient as XmtpMlsStreams>::GroupMessageStream<'_>>
+    ) -> Result<<ApiClient as XmtpMlsStreams>::GroupMessageStream>
     where
         ApiClient: XmtpMlsStreams,
     {
@@ -342,7 +342,7 @@ where
         &self,
         installation_key: &[u8],
         id_cursor: Option<u64>,
-    ) -> Result<<ApiClient as XmtpMlsStreams>::WelcomeMessageStream<'_>>
+    ) -> Result<<ApiClient as XmtpMlsStreams>::WelcomeMessageStream>
     where
         ApiClient: XmtpMlsStreams,
     {

--- a/xmtp_api/src/test_utils.rs
+++ b/xmtp_api/src/test_utils.rs
@@ -149,8 +149,8 @@ mod not_wasm {
         #[async_trait::async_trait]
         impl XmtpMlsStreams for ApiClient {
             type Error = MockError;
-            type GroupMessageStream<'a> = MockGroupStream;
-            type WelcomeMessageStream<'a> = MockWelcomeStream;
+            type GroupMessageStream = MockGroupStream;
+            type WelcomeMessageStream = MockWelcomeStream;
 
             async fn subscribe_group_messages(&self, request: SubscribeGroupMessagesRequest) -> Result<MockGroupStream, MockError>;
             async fn subscribe_welcome_messages(&self, request: SubscribeWelcomeMessagesRequest) -> Result<MockWelcomeStream, MockError>;
@@ -207,8 +207,8 @@ mod wasm {
         #[async_trait::async_trait(?Send)]
         impl XmtpMlsStreams for ApiClient {
             type Error = MockError;
-            type GroupMessageStream<'a> = MockGroupStream;
-            type WelcomeMessageStream<'a> = MockWelcomeStream;
+            type GroupMessageStream = MockGroupStream;
+            type WelcomeMessageStream = MockWelcomeStream;
 
             async fn subscribe_group_messages(&self, request: SubscribeGroupMessagesRequest) -> Result<MockGroupStream, MockError>;
             async fn subscribe_welcome_messages(&self, request: SubscribeWelcomeMessagesRequest) -> Result<MockWelcomeStream, MockError>;

--- a/xmtp_api_d14n/src/queries/d14n/streams.rs
+++ b/xmtp_api_d14n/src/queries/d14n/streams.rs
@@ -16,42 +16,29 @@ where
     type Error = ApiClientError<E>;
 
     #[cfg(not(target_arch = "wasm32"))]
-    type GroupMessageStream<'a>
-        = stream::BoxStream<'a, Result<mls_v1::GroupMessage, Self::Error>>
-    where
-        C: 'a,
-        P: 'a;
+    type GroupMessageStream = stream::BoxStream<'static, Result<mls_v1::GroupMessage, Self::Error>>;
     #[cfg(not(target_arch = "wasm32"))]
-    type WelcomeMessageStream<'a>
-        = stream::BoxStream<'a, Result<mls_v1::WelcomeMessage, Self::Error>>
-    where
-        C: 'a,
-        P: 'a;
+    type WelcomeMessageStream =
+        stream::BoxStream<'static, Result<mls_v1::WelcomeMessage, Self::Error>>;
 
     #[cfg(target_arch = "wasm32")]
-    type GroupMessageStream<'a>
-        = stream::LocalBoxStream<'a, Result<mls_v1::GroupMessage, Self::Error>>
-    where
-        P: 'a,
-        C: 'a;
+    type GroupMessageStream =
+        stream::LocalBoxStream<'static, Result<mls_v1::GroupMessage, Self::Error>>;
     #[cfg(target_arch = "wasm32")]
-    type WelcomeMessageStream<'a>
-        = stream::LocalBoxStream<'a, Result<mls_v1::WelcomeMessage, Self::Error>>
-    where
-        P: 'a,
-        C: 'a;
+    type WelcomeMessageStream =
+        stream::LocalBoxStream<'static, Result<mls_v1::WelcomeMessage, Self::Error>>;
 
     async fn subscribe_group_messages(
         &self,
         _request: mls_v1::SubscribeGroupMessagesRequest,
-    ) -> Result<Self::GroupMessageStream<'_>, Self::Error> {
+    ) -> Result<Self::GroupMessageStream, Self::Error> {
         todo!()
     }
 
     async fn subscribe_welcome_messages(
         &self,
         _request: mls_v1::SubscribeWelcomeMessagesRequest,
-    ) -> Result<Self::WelcomeMessageStream<'_>, Self::Error> {
+    ) -> Result<Self::WelcomeMessageStream, Self::Error> {
         todo!()
     }
 }

--- a/xmtp_api_d14n/src/queries/v3.rs
+++ b/xmtp_api_d14n/src/queries/v3.rs
@@ -229,38 +229,29 @@ where
     type Error = ApiClientError<E>;
 
     #[cfg(not(target_arch = "wasm32"))]
-    type GroupMessageStream<'a>
-        = stream::BoxStream<'a, Result<mls_v1::GroupMessage, Self::Error>>
-    where
-        C: 'a;
+    type GroupMessageStream = stream::BoxStream<'static, Result<mls_v1::GroupMessage, Self::Error>>;
     #[cfg(not(target_arch = "wasm32"))]
-    type WelcomeMessageStream<'a>
-        = stream::BoxStream<'a, Result<mls_v1::WelcomeMessage, Self::Error>>
-    where
-        C: 'a;
+    type WelcomeMessageStream =
+        stream::BoxStream<'static, Result<mls_v1::WelcomeMessage, Self::Error>>;
 
     #[cfg(target_arch = "wasm32")]
-    type GroupMessageStream<'a>
-        = stream::LocalBoxStream<'a, Result<mls_v1::GroupMessage, Self::Error>>
-    where
-        C: 'a;
+    type GroupMessageStream =
+        stream::LocalBoxStream<'static, Result<mls_v1::GroupMessage, Self::Error>>;
     #[cfg(target_arch = "wasm32")]
-    type WelcomeMessageStream<'a>
-        = stream::LocalBoxStream<'a, Result<mls_v1::WelcomeMessage, Self::Error>>
-    where
-        C: 'a;
+    type WelcomeMessageStream =
+        stream::LocalBoxStream<'static, Result<mls_v1::WelcomeMessage, Self::Error>>;
 
     async fn subscribe_group_messages(
         &self,
         _request: mls_v1::SubscribeGroupMessagesRequest,
-    ) -> Result<Self::GroupMessageStream<'_>, Self::Error> {
+    ) -> Result<Self::GroupMessageStream, Self::Error> {
         todo!()
     }
 
     async fn subscribe_welcome_messages(
         &self,
         _request: mls_v1::SubscribeWelcomeMessagesRequest,
-    ) -> Result<Self::WelcomeMessageStream<'_>, Self::Error> {
+    ) -> Result<Self::WelcomeMessageStream, Self::Error> {
         todo!()
     }
 }

--- a/xmtp_api_grpc/src/grpc_api_helper.rs
+++ b/xmtp_api_grpc/src/grpc_api_helper.rs
@@ -278,13 +278,13 @@ impl Stream for WelcomeMessageStream {
 #[async_trait::async_trait]
 impl XmtpMlsStreams for Client {
     type Error = ApiClientError<crate::GrpcError>;
-    type GroupMessageStream<'a> = GroupMessageStream;
-    type WelcomeMessageStream<'a> = WelcomeMessageStream;
+    type GroupMessageStream = GroupMessageStream;
+    type WelcomeMessageStream = WelcomeMessageStream;
 
     async fn subscribe_group_messages(
         &self,
         req: SubscribeGroupMessagesRequest,
-    ) -> Result<Self::GroupMessageStream<'_>, Self::Error> {
+    ) -> Result<Self::GroupMessageStream, Self::Error> {
         self.stats.subscribe_messages.count_request();
         let client = &mut self.mls_client.clone();
         let res = client
@@ -299,7 +299,7 @@ impl XmtpMlsStreams for Client {
     async fn subscribe_welcome_messages(
         &self,
         req: SubscribeWelcomeMessagesRequest,
-    ) -> Result<Self::WelcomeMessageStream<'_>, Self::Error> {
+    ) -> Result<Self::WelcomeMessageStream, Self::Error> {
         self.stats.subscribe_welcomes.count_request();
         let client = &mut self.mls_client.clone();
         let res = client

--- a/xmtp_api_http/src/lib.rs
+++ b/xmtp_api_http/src/lib.rs
@@ -389,20 +389,21 @@ impl XmtpMlsStreams for XmtpHttpApiClient {
     // `Trait` yet.
 
     #[cfg(not(target_arch = "wasm32"))]
-    type GroupMessageStream<'a> = stream::BoxStream<'a, Result<GroupMessage, Self::Error>>;
+    type GroupMessageStream = stream::BoxStream<'static, Result<GroupMessage, Self::Error>>;
     #[cfg(not(target_arch = "wasm32"))]
-    type WelcomeMessageStream<'a> = stream::BoxStream<'a, Result<WelcomeMessage, Self::Error>>;
+    type WelcomeMessageStream = stream::BoxStream<'static, Result<WelcomeMessage, Self::Error>>;
 
     #[cfg(target_arch = "wasm32")]
-    type GroupMessageStream<'a> = stream::LocalBoxStream<'a, Result<GroupMessage, Self::Error>>;
+    type GroupMessageStream = stream::LocalBoxStream<'static, Result<GroupMessage, Self::Error>>;
     #[cfg(target_arch = "wasm32")]
-    type WelcomeMessageStream<'a> = stream::LocalBoxStream<'a, Result<WelcomeMessage, Self::Error>>;
+    type WelcomeMessageStream =
+        stream::LocalBoxStream<'static, Result<WelcomeMessage, Self::Error>>;
 
     #[tracing::instrument(skip_all)]
     async fn subscribe_group_messages(
         &self,
         request: SubscribeGroupMessagesRequest,
-    ) -> Result<Self::GroupMessageStream<'_>, Self::Error> {
+    ) -> Result<Self::GroupMessageStream, Self::Error> {
         self.wait_for_ready().await;
         self.stats.subscribe_messages.count_request();
         Ok(create_grpc_stream::<_, GroupMessage>(
@@ -417,7 +418,7 @@ impl XmtpMlsStreams for XmtpHttpApiClient {
     async fn subscribe_welcome_messages(
         &self,
         request: SubscribeWelcomeMessagesRequest,
-    ) -> Result<Self::WelcomeMessageStream<'_>, Self::Error> {
+    ) -> Result<Self::WelcomeMessageStream, Self::Error> {
         self.wait_for_ready().await;
         self.stats.subscribe_welcomes.count_request();
         tracing::debug!("subscribe_welcome_messages");

--- a/xmtp_archive/Cargo.toml
+++ b/xmtp_archive/Cargo.toml
@@ -13,7 +13,6 @@ openmls.workspace = true
 openmls_traits.workspace = true
 prost.workspace = true
 reqwest = { workspace = true, features = ["stream"] }
-serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
@@ -26,5 +25,7 @@ xmtp_mls_common.workspace = true
 xmtp_proto.workspace = true
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
+xmtp_common = { workspace = true }
 chrono = { workspace = true, features = ["wasmbind"] }
 getrandom = { workspace = true }
+wasm-bindgen-test.workspace = true

--- a/xmtp_content_types/Cargo.toml
+++ b/xmtp_content_types/Cargo.toml
@@ -20,3 +20,6 @@ xmtp_common = { workspace = true, features = ['test-utils'] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tonic = { version = "0.12", features = ["transport"] }
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test.workspace = true

--- a/xmtp_db/Cargo.toml
+++ b/xmtp_db/Cargo.toml
@@ -72,6 +72,7 @@ wasm-bindgen = { workspace = true }
 
 
 [dev-dependencies]
+futures-timer.workspace = true
 xmtp_common = { workspace = true, features = ["test-utils"] }
 xmtp_cryptography.workspace = true
 

--- a/xmtp_db/src/encrypted_store/database/native.rs
+++ b/xmtp_db/src/encrypted_store/database/native.rs
@@ -395,7 +395,7 @@ impl ConnectionExt for NativeDbConnection {
     {
         if self.in_transaction.load(Ordering::SeqCst) {
             let mut conn = self.write.lock();
-            return fun(&mut conn).map_err(ConnectionError::from);
+            fun(&mut conn).map_err(ConnectionError::from)
         } else if let Some(pool) = &*self.read.read() {
             tracing::trace!(
                 "pulling connection from pool, idle={}, total={}",
@@ -404,12 +404,12 @@ impl ConnectionExt for NativeDbConnection {
             );
             let mut conn = pool.get().map_err(PlatformStorageError::from)?;
 
-            return fun(&mut conn).map_err(ConnectionError::from);
+            fun(&mut conn).map_err(ConnectionError::from)
         } else {
-            return Err(ConnectionError::from(
+            Err(ConnectionError::from(
                 PlatformStorageError::PoolNeedsConnection,
-            ));
-        };
+            ))
+        }
     }
 
     #[tracing::instrument(level = "trace", skip_all)]

--- a/xmtp_id/src/utils/test.rs
+++ b/xmtp_id/src/utils/test.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::unwrap_used)]
-
+#![cfg_attr(all(target_family = "wasm", target_os = "unknown"), allow(unused))]
 use alloy::network::{Ethereum, EthereumWallet};
 use alloy::primitives::{Address, Bytes};
 use alloy::providers::DynProvider;

--- a/xmtp_mls/Cargo.toml
+++ b/xmtp_mls/Cargo.toml
@@ -30,6 +30,7 @@ test-utils = [
   "dep:public-suffix",
   "dep:futures-executor",
   "dep:mockall",
+  "dep:rstest",
 ]
 bench = [
   "test-utils",
@@ -101,6 +102,7 @@ xmtp_api_http = { path = "../xmtp_api_http", optional = true }
 criterion = { workspace = true, optional = true }
 hmac = "0.12.1"
 indicatif = { version = "0.17", optional = true }
+rstest = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, features = [
   "env-filter",
   "fmt",
@@ -108,6 +110,7 @@ tracing-subscriber = { workspace = true, features = [
   "json",
   "registry",
 ], optional = true }
+
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true, features = [
@@ -119,14 +122,11 @@ tokio = { workspace = true, features = [
 chrono = { workspace = true, features = ["clock"] }
 dyn-clone.workspace = true
 openmls.workspace = true
-openssl.workspace = true
-openssl-sys.workspace = true
 xmtp_api_grpc = { workspace = true, optional = true }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 chrono = { workspace = true, features = ["wasmbind"] }
 getrandom = { workspace = true }
-gloo-timers = { workspace = true, features = ["futures"] }
 openmls = { workspace = true, features = ["js"] }
 tokio = { workspace = true, features = ["macros", "rt", "time"] }
 wasm-bindgen-futures.workspace = true
@@ -143,12 +143,13 @@ diesel = { workspace = true, features = [
 fdlimit = { workspace = true }
 futures-executor = { version = "0.3" }
 futures-test = "0.3.31"
+futures-timer.workspace = true
 mockall.workspace = true
 once_cell.workspace = true
 openmls_basic_credential.workspace = true
 passkey = { version = "0.4" }
 public-suffix = { version = "0.1.2" }
-rstest = { workspace = true, features = ["async-timeout"] }
+rstest = { workspace = true }
 rstest_reuse = { workspace = true }
 url = { workspace = true }
 wasm-bindgen-test.workspace = true
@@ -200,6 +201,3 @@ required-features = ["test-utils"]
 #harness = false
 #name = "sync"
 #required-features = ["bench"]
-
-[package.metadata.wasm-pack.profile.dev.wasm-bindgen]
-split-linked-modules = true

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -1086,11 +1086,8 @@ pub(crate) mod tests {
         assert_eq!(new_alice_dm.group_id, bob_dm.group_id);
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(
-        not(target_arch = "wasm32"),
-        tokio::test(flavor = "multi_thread", worker_threads = 2)
-    )]
+    #[rstest::rstest]
+    #[xmtp_common::test(flavor = "multi_thread")]
     async fn test_sync_welcomes() {
         let alice = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bob = ClientBuilder::new_test_client(&generate_local_wallet()).await;
@@ -1112,11 +1109,8 @@ pub(crate) mod tests {
         assert_eq!(duplicate_received_groups.len(), 0);
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(
-        not(target_arch = "wasm32"),
-        tokio::test(flavor = "multi_thread", worker_threads = 2)
-    )]
+    #[rstest::rstest]
+    #[xmtp_common::test(flavor = "multi_thread")]
     async fn test_sync_all_groups() {
         let alix = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bo = ClientBuilder::new_test_client(&generate_local_wallet()).await;
@@ -1264,11 +1258,8 @@ pub(crate) mod tests {
         assert_eq!(bo_messages2.len(), 2);
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(
-        not(target_arch = "wasm32"),
-        tokio::test(flavor = "multi_thread", worker_threads = 1)
-    )]
+    #[rstest::rstest]
+    #[xmtp_common::test]
     async fn test_welcome_encryption() {
         let client = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let provider = client.mls_provider();
@@ -1285,11 +1276,8 @@ pub(crate) mod tests {
         assert_eq!(decrypted, to_encrypt);
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(
-        not(target_arch = "wasm32"),
-        tokio::test(flavor = "multi_thread", worker_threads = 1)
-    )]
+    #[rstest::rstest]
+    #[xmtp_common::test]
     async fn test_add_remove_then_add_again() {
         let amal = Tester::new().await;
         let bola = Tester::new().await;

--- a/xmtp_mls/src/groups/device_sync/archive.rs
+++ b/xmtp_mls/src/groups/device_sync/archive.rs
@@ -106,6 +106,7 @@ mod tests {
     };
     use xmtp_proto::xmtp::device_sync::{BackupElementSelection, BackupOptions};
 
+    #[rstest::rstest]
     #[xmtp_common::test]
     async fn test_buffer_export_import() {
         use futures::io::BufReader;

--- a/xmtp_mls/src/groups/device_sync/preference_sync.rs
+++ b/xmtp_mls/src/groups/device_sync/preference_sync.rs
@@ -154,6 +154,7 @@ mod tests {
     };
     use xmtp_db::user_preferences::StoredUserPreferences;
 
+    #[rstest::rstest]
     #[xmtp_common::test(unwrap_try = "true")]
     async fn test_hmac_sync() {
         let amal_a = Tester::builder().sync_worker().build().await;

--- a/xmtp_mls/src/groups/device_sync/tests.rs
+++ b/xmtp_mls/src/groups/device_sync/tests.rs
@@ -6,7 +6,9 @@ use xmtp_db::{
     group_message::MsgQueryArgs,
 };
 
+#[rstest::rstest]
 #[xmtp_common::test(unwrap_try = "true")]
+#[cfg_attr(target_arch = "wasm32", ignore)]
 async fn basic_sync() {
     tester!(alix1, sync_server, sync_worker, stream);
     tester!(bo);
@@ -25,6 +27,7 @@ async fn basic_sync() {
     assert_eq!(alix2_dm_msgs[0].decrypted_message_bytes, dm_msg.as_bytes());
 }
 
+#[rstest::rstest]
 #[xmtp_common::test(unwrap_try = "true")]
 #[cfg(not(target_arch = "wasm32"))]
 async fn only_one_payload_sent() {
@@ -47,6 +50,7 @@ async fn only_one_payload_sent() {
     assert_ne!(timeout1.is_ok(), timeout2.is_ok());
 }
 
+#[rstest::rstest]
 #[xmtp_common::test(unwrap_try = "true")]
 async fn test_double_sync_works_fine() {
     tester!(alix1, sync_worker, sync_server);
@@ -74,7 +78,9 @@ async fn test_double_sync_works_fine() {
     alix2.test_talk_in_dm_with(&bo).await?;
 }
 
+#[rstest::rstest]
 #[xmtp_common::test(unwrap_try = "true")]
+#[cfg_attr(target_arch = "wasm32", ignore)]
 async fn test_hmac_and_consent_prefrence_sync() {
     tester!(alix1, sync_worker, sync_server, stream);
     tester!(bo);
@@ -119,7 +125,9 @@ async fn test_hmac_and_consent_prefrence_sync() {
     assert_eq!(alix2_group.consent_state()?, ConsentState::Allowed);
 }
 
+#[rstest::rstest]
 #[xmtp_common::test(unwrap_try = "true")]
+#[cfg_attr(target_arch = "wasm32", ignore)]
 async fn test_only_added_to_correct_groups() {
     use diesel::prelude::*;
     use xmtp_db::schema::groups::dsl;
@@ -189,7 +197,10 @@ async fn test_only_added_to_correct_groups() {
     assert!(alix2_bo_group_denied.is_err());
 }
 
+#[rstest::rstest]
 #[xmtp_common::test(unwrap_try = "true")]
+#[timeout(std::time::Duration::from_secs(15))]
+#[cfg_attr(target_arch = "wasm32", ignore)]
 async fn test_new_devices_not_added_to_old_sync_groups() {
     use diesel::prelude::*;
     use xmtp_db::schema::groups::dsl;

--- a/xmtp_mls/src/groups/device_sync_legacy.rs
+++ b/xmtp_mls/src/groups/device_sync_legacy.rs
@@ -592,7 +592,6 @@ fn encrypt_syncables_with_key(
 
 #[cfg(test)]
 mod tests {
-
     use xmtp_proto::xmtp::device_sync::BackupElementSelection;
 
     use crate::{
@@ -601,7 +600,9 @@ mod tests {
         utils::{LocalTesterBuilder, Tester},
     };
 
+    #[rstest::rstest]
     #[xmtp_common::test(unwrap_try = "true")]
+    #[cfg_attr(target_arch = "wasm32", ignore)]
     async fn v1_sync_still_works() {
         tester!(alix1, sync_worker, sync_server);
         tester!(alix2, from: alix1);

--- a/xmtp_mls/src/groups/tests/mod.rs
+++ b/xmtp_mls/src/groups/tests/mod.rs
@@ -478,12 +478,12 @@ async fn test_create_group_with_member_two_installations_one_malformed_keypackag
 
     // 4) Sync from Alix's side
     group.sync().await.unwrap();
-    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    xmtp_common::time::sleep(std::time::Duration::from_secs(2)).await;
 
     // 5) Bola_1 syncs welcomes and checks for groups
     bola_1.sync_welcomes().await.unwrap();
     bola_2.sync_welcomes().await.unwrap();
-    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    xmtp_common::time::sleep(std::time::Duration::from_secs(2)).await;
 
     let bola_1_groups = bola_1.find_groups(GroupQueryArgs::default()).unwrap();
     let bola_2_groups = bola_2.find_groups(GroupQueryArgs::default()).unwrap();
@@ -631,7 +631,7 @@ async fn test_dm_creation_with_user_two_installations_one_malformed() {
 
     // 5) Bola_1 syncs and confirms it has the DM
     bola_1.sync_welcomes().await.unwrap();
-    // tokio::time::sleep(std::time::Duration::from_secs(4)).await;
+    // xmtp_common::time::sleep(std::time::Duration::from_secs(4)).await;
 
     let bola_groups = bola_1.find_groups(GroupQueryArgs::default()).unwrap();
 
@@ -2501,7 +2501,9 @@ async fn create_membership_update_no_sync(group: &ConcreteMlsGroup) {
  * We need to be safe even in situations where there are multiple
  * intents that do the same thing, leading to conflicts
  */
+#[rstest::rstest]
 #[xmtp_common::test(flavor = "multi_thread")]
+#[cfg_attr(target_arch = "wasm32", ignore)]
 async fn add_missing_installs_reentrancy() {
     let wallet = generate_local_wallet();
     let alix1 = ClientBuilder::new_test_client(&wallet).await;

--- a/xmtp_mls/src/groups/tests/test_key_updates.rs
+++ b/xmtp_mls/src/groups/tests/test_key_updates.rs
@@ -4,7 +4,9 @@ use std::{future::Future, pin::Pin, time::Duration};
 use xmtp_common::{retry_async, Retry};
 use xmtp_db::events::Events;
 
+#[rstest::rstest]
 #[xmtp_common::test(unwrap_try = "true")]
+#[cfg_attr(target_arch = "wasm32", ignore)]
 async fn test_key_rotation_with_optimistic_send() {
     tester!(alix, stream);
     tester!(bo, stream);
@@ -33,7 +35,7 @@ async fn test_key_rotation_with_optimistic_send() {
     join_all(futs).await;
 
     // Wait for the streams to finish.
-    tokio::time::sleep(Duration::from_secs(5)).await;
+    xmtp_common::time::sleep(Duration::from_secs(5)).await;
 
     retry_async!(
         Retry::default(),
@@ -44,7 +46,9 @@ async fn test_key_rotation_with_optimistic_send() {
     assert_eq!(key_updates.len(), 1);
 }
 
+#[rstest::rstest]
 #[xmtp_common::test(unwrap_try = "true")]
+#[cfg_attr(target_arch = "wasm32", ignore)]
 async fn key_update_out_of_epoch() {
     // Have bo join a group and immediately send several optimistic messages.
     // Add enough people to move the epoch ahead 5, then sync to ensure proper delivery.

--- a/xmtp_mls/src/identity_updates.rs
+++ b/xmtp_mls/src/identity_updates.rs
@@ -665,8 +665,8 @@ pub(crate) mod tests {
             .expect("insert should succeed");
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[rstest::rstest]
+    #[xmtp_common::test]
     async fn test_is_member_of_association_state() {
         let wallet = generate_local_wallet();
         let client = ClientBuilder::new_test_client(&wallet).await;
@@ -708,6 +708,7 @@ pub(crate) mod tests {
         assert!(is_member);
     }
 
+    #[rstest::rstest]
     #[xmtp_common::test]
     async fn create_inbox_round_trip() {
         let wallet = generate_local_wallet();
@@ -736,6 +737,7 @@ pub(crate) mod tests {
         assert!(association_state.get(&wallet_ident.into()).is_some())
     }
 
+    #[rstest::rstest]
     #[xmtp_common::test]
     async fn add_association() {
         let wallet = generate_local_wallet();
@@ -841,6 +843,7 @@ pub(crate) mod tests {
         });
     }
 
+    #[rstest::rstest]
     #[xmtp_common::test]
     async fn load_identity_updates_if_needed() {
         let wallet = generate_local_wallet();
@@ -858,6 +861,7 @@ pub(crate) mod tests {
         assert_eq!(filtered.unwrap(), vec!["inbox_1"]);
     }
 
+    #[rstest::rstest]
     #[xmtp_common::test]
     async fn get_installation_diff() {
         let wallet_1 = generate_local_wallet();
@@ -970,6 +974,7 @@ pub(crate) mod tests {
             .contains(&client_2_installation_key.to_vec()));
     }
 
+    #[rstest::rstest]
     #[xmtp_common::test]
     pub async fn revoke_wallet() {
         let recovery_wallet = generate_local_wallet();
@@ -1030,6 +1035,7 @@ pub(crate) mod tests {
         assert_eq!(inbox_ids.len(), 0);
     }
 
+    #[rstest::rstest]
     #[xmtp_common::test]
     pub async fn revoke_installation() {
         let wallet = generate_local_wallet();
@@ -1131,8 +1137,8 @@ pub(crate) mod tests {
         assert_eq!(association_state.installation_ids().len(), 2);
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[rstest::rstest]
+    #[xmtp_common::test]
     pub async fn change_recovery_address() {
         let original_wallet = generate_local_wallet();
         let new_recovery_wallet = generate_local_wallet();

--- a/xmtp_mls/src/lib.rs
+++ b/xmtp_mls/src/lib.rs
@@ -89,6 +89,9 @@ pub struct MlsGroupGuard {
     _permit: tokio::sync::OwnedMutexGuard<()>,
 }
 
+#[cfg(all(test, target_arch = "wasm32"))]
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
 #[cfg_attr(not(target_arch = "wasm32"), ctor::ctor)]
 #[cfg(all(test, not(target_arch = "wasm32")))]
 fn test_setup() {

--- a/xmtp_mls/src/subscriptions/mod.rs
+++ b/xmtp_mls/src/subscriptions/mod.rs
@@ -259,6 +259,18 @@ where
     {
         StreamConversations::new(&self.context, conversation_type).await
     }
+
+    /// Stream conversations but decouple the lifetime of 'self' from the stream.
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub async fn stream_conversations_owned(
+        &self,
+        conversation_type: Option<ConversationType>,
+    ) -> Result<impl Stream<Item = Result<MlsGroup<ApiClient, Db>>> + 'static>
+    where
+        ApiClient: XmtpMlsStreams,
+    {
+        StreamConversations::new_owned(self.context.clone(), conversation_type).await
+    }
 }
 
 impl<ApiClient, Db> Client<ApiClient, Db>

--- a/xmtp_mls/src/subscriptions/stream_all.rs
+++ b/xmtp_mls/src/subscriptions/stream_all.rs
@@ -184,7 +184,7 @@ mod tests {
 
     #[rstest::rstest]
     #[xmtp_common::test]
-    #[timeout(Duration::from_secs(20))]
+    #[timeout(Duration::from_secs(15))]
     #[cfg_attr(target_arch = "wasm32", ignore)]
     async fn test_stream_all_messages_changing_group_list() {
         let alix = ClientBuilder::new_test_client(&generate_local_wallet()).await;
@@ -265,7 +265,6 @@ mod tests {
 
     #[rstest::rstest]
     #[xmtp_common::test]
-    #[timeout(Duration::from_secs(5))]
     async fn test_dm_stream_all_messages() {
         let alix = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let bo = ClientBuilder::new_test_client(&generate_local_wallet()).await;
@@ -350,19 +349,11 @@ mod tests {
     #[timeout(Duration::from_secs(60))]
     #[cfg_attr(target_arch = "wasm32", ignore)]
     async fn test_stream_all_messages_does_not_lose_messages() {
-        let mut replace = xmtp_common::TestLogReplace::default();
         let caro = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let alix = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
         let eve = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
         let bo = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
-        tracing::info!(inbox_id = eve.inbox_id(), installation_id = %eve.installation_id(), "EVE={}", eve.inbox_id());
-        tracing::info!(inbox_id = bo.inbox_id(), installation_id = %bo.installation_id(), "BO={}", bo.inbox_id());
-        tracing::info!(inbox_id = alix.inbox_id(), installation_id = %alix.installation_id(), "ALIX={}", alix.inbox_id());
-        tracing::info!(inbox_id = caro.inbox_id(), installation_id = %caro.installation_id(), "CARO={}", caro.inbox_id());
-        replace.add(caro.inbox_id(), "caro");
-        replace.add(eve.inbox_id(), "eve");
-        replace.add(alix.inbox_id(), "alix");
-        replace.add(bo.inbox_id(), "bo");
+
         let alix_group = alix.create_group(None, None).unwrap();
         alix_group
             .add_members_by_inbox_id(&[caro.inbox_id(), bo.inbox_id()])
@@ -443,7 +434,7 @@ mod tests {
 
     #[rstest::rstest]
     #[xmtp_common::test]
-    #[timeout(Duration::from_secs(10))]
+    #[timeout(Duration::from_secs(20))]
     async fn test_stream_all_messages_detached_group_changes() {
         let caro = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let hale = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);

--- a/xmtp_mls/src/subscriptions/stream_conversations.rs
+++ b/xmtp_mls/src/subscriptions/stream_conversations.rs
@@ -8,6 +8,7 @@ use xmtp_db::{group::ConversationType, refresh_state::EntityKind, XmtpDb};
 use futures::{prelude::stream::Select, Stream};
 use pin_project_lite::pin_project;
 use std::{
+    borrow::Cow,
     collections::HashSet,
     future::Future,
     pin::Pin,
@@ -38,10 +39,18 @@ impl xmtp_common::RetryableError for ConversationStreamError {
     }
 }
 
-#[derive(Debug)]
 pub enum WelcomeOrGroup {
     Group(Vec<u8>),
     Welcome(WelcomeMessage),
+}
+
+impl std::fmt::Debug for WelcomeOrGroup {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Group(arg0) => f.debug_tuple("Group").field(&hex::encode(arg0)).finish(),
+            Self::Welcome(arg0) => f.debug_tuple("Welcome").field(arg0).finish(),
+        }
+    }
 }
 
 pin_project! {
@@ -145,7 +154,7 @@ pin_project! {
     pub struct StreamConversations<'a, ApiClient, Db, Subscription> {
         #[pin] inner: Subscription,
         #[pin] state: ProcessState<'a, ApiClient, Db>,
-        context: &'a Arc<XmtpMlsLocalContext<ApiClient, Db>>,
+        context: Cow<'a, Arc<XmtpMlsLocalContext<ApiClient, Db>>>,
         conversation_type: Option<ConversationType>,
         known_welcome_ids: HashSet<i64>,
     }
@@ -169,7 +178,7 @@ pin_project! {
 type MultiplexedSelect<S, E> = Select<BroadcastGroupStream, SubscriptionStream<S, E>>;
 
 pub(super) type WelcomesApiSubscription<'a, ApiClient> = MultiplexedSelect<
-    <ApiClient as XmtpMlsStreams>::WelcomeMessageStream<'a>,
+    <ApiClient as XmtpMlsStreams>::WelcomeMessageStream,
     <ApiClient as XmtpMlsStreams>::Error,
 >;
 
@@ -211,6 +220,13 @@ where
         context: &'a Arc<XmtpMlsLocalContext<A, D>>,
         conversation_type: Option<ConversationType>,
     ) -> Result<Self> {
+        Self::init(Cow::Borrowed(context), conversation_type).await
+    }
+
+    async fn init(
+        context: Cow<'a, Arc<XmtpMlsLocalContext<A, D>>>,
+        conversation_type: Option<ConversationType>,
+    ) -> Result<Self> {
         let provider = context.mls_provider();
         let conn = provider.db();
         let installation_key = context.installation_public_key();
@@ -228,6 +244,7 @@ where
             BroadcastGroupStream::new(BroadcastStream::new(context.local_events.subscribe()));
 
         let subscription = context
+            .as_ref()
             .api_client
             .subscribe_welcome_messages(installation_key.as_ref(), Some(id_cursor as u64))
             .await?;
@@ -243,6 +260,19 @@ where
             conversation_type,
             state: ProcessState::Waiting,
         })
+    }
+}
+
+impl<A, D> StreamConversations<'static, A, D, WelcomesApiSubscription<'static, A>>
+where
+    A: XmtpApi + XmtpMlsStreams + Send + Sync + 'static,
+    D: XmtpDb + Send + 'static,
+{
+    pub async fn new_owned(
+        context: Arc<XmtpMlsLocalContext<A, D>>,
+        conversation_type: Option<ConversationType>,
+    ) -> Result<Self> {
+        Self::init(Cow::Owned(context), conversation_type).await
     }
 }
 
@@ -270,10 +300,11 @@ where
             Waiting => {
                 match this.inner.poll_next(cx) {
                     Ready(Some(item)) => {
+                        tracing::info!("New Welcome: {:?}", item);
                         let mut this = self.as_mut().project();
                         let future = ProcessWelcomeFuture::new(
                             this.known_welcome_ids.clone(),
-                            this.context.clone(),
+                            this.context.clone().into_owned(),
                             item?,
                             *this.conversation_type,
                         )?;
@@ -398,6 +429,8 @@ mod test {
     use super::*;
     use crate::builder::ClientBuilder;
     use crate::tester;
+    use crate::utils::fixtures::{alix, bo};
+    use crate::utils::FullXmtpClient;
     use xmtp_db::group::GroupQueryArgs;
 
     use futures::StreamExt;
@@ -407,27 +440,41 @@ mod test {
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
     #[rstest::rstest]
+    #[case::two_conversations(2)]
+    #[case::five_conversations(5)]
     #[xmtp_common::test]
-    #[timeout(std::time::Duration::from_secs(5))]
-    async fn test_stream_welcomes() {
-        let alice = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
-        let bob = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
-        let alice_bob_group = alice.create_group(None, None).unwrap();
+    #[timeout(std::time::Duration::from_secs(10))]
+    #[cfg_attr(target_arch = "wasm32", ignore)]
+    #[awt]
+    async fn stream_welcomes(
+        #[future] alix: FullXmtpClient,
+        #[future] bo: FullXmtpClient,
+        #[case] group_size: usize,
+    ) {
+        let mut groups = vec![];
+        let mut stream = StreamConversations::new(&bo.context, None).await.unwrap();
+        for _ in 0..group_size {
+            let alix_bo_group = alix.create_group(None, None).unwrap();
+            groups.push(alix_bo_group.group_id.clone());
+            alix_bo_group
+                .add_members_by_inbox_id(&[bo.inbox_id()])
+                .await
+                .unwrap();
+        }
+        while !groups.is_empty() {
+            let bo_received_groups = stream.next().await.unwrap().unwrap();
+            let index = groups
+                .iter()
+                .position(|group_id| bo_received_groups.group_id == *group_id)
+                .expect("group must be found");
+            groups.remove(index);
+        }
 
-        let mut stream = StreamConversations::new(&bob.context, None).await.unwrap();
-        let group_id = alice_bob_group.group_id.clone();
-        alice_bob_group
-            .add_members_by_inbox_id(&[bob.inbox_id()])
-            .await
-            .unwrap();
-        tracing::info!("WAITING FOR NEXT STREAM ITEM");
-        let bob_received_groups = stream.next().await.unwrap().unwrap();
-        assert_eq!(bob_received_groups.group_id, group_id);
+        assert!(groups.is_empty());
     }
 
     #[rstest::rstest]
     #[xmtp_common::test(unwrap_try = "true")]
-    #[timeout(std::time::Duration::from_secs(5))]
     async fn test_sync_groups_are_not_streamed() {
         tester!(alix, sync_worker);
         let stream = alix.stream_conversations(None).await?;
@@ -444,9 +491,6 @@ mod test {
     #[case(ConversationType::Dm, "Unexpectedly received a Group")]
     #[case(ConversationType::Group, "Unexpectedly received a DM")]
     #[xmtp_common::test]
-    #[timeout(std::time::Duration::from_secs(7))]
-
-    // #[cfg_attr(target_arch = "wasm32", ignore)]
     async fn test_dm_stream_filter(
         #[case] conversation_type: ConversationType,
         #[case] expected: &str,
@@ -485,8 +529,6 @@ mod test {
 
     #[rstest::rstest]
     #[xmtp_common::test]
-    #[timeout(std::time::Duration::from_secs(7))]
-    #[cfg_attr(target_arch = "wasm32", ignore)]
     async fn test_dm_stream_all_conversation_types() {
         let alix = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
         let bo = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);

--- a/xmtp_mls/src/subscriptions/stream_messages.rs
+++ b/xmtp_mls/src/subscriptions/stream_messages.rs
@@ -148,7 +148,7 @@ pin_project! {
 }
 
 pub(super) type MessagesApiSubscription<'a, ApiClient> =
-    <ApiClient as XmtpMlsStreams>::GroupMessageStream<'a>;
+    <ApiClient as XmtpMlsStreams>::GroupMessageStream;
 
 impl<'a, ApiClient, Db>
     StreamGroupMessages<'a, ApiClient, Db, MessagesApiSubscription<'a, ApiClient>>
@@ -400,7 +400,7 @@ where
                 }
                 this.state.as_mut().set(State::Waiting);
                 cx.waker().wake_by_ref();
-                return Poll::Pending;
+                Poll::Pending
             }
         }
     }
@@ -707,6 +707,7 @@ pub mod tests {
     #[rstest]
     #[xmtp_common::test]
     #[timeout(std::time::Duration::from_secs(5))]
+    #[cfg_attr(target_arch = "wasm32", ignore)]
     async fn test_stream_messages() {
         let alice = Arc::new(ClientBuilder::new_test_client(&generate_local_wallet()).await);
         let bob = ClientBuilder::new_test_client(&generate_local_wallet()).await;

--- a/xmtp_mls/src/subscriptions/stream_messages/unit_tests.rs
+++ b/xmtp_mls/src/subscriptions/stream_messages/unit_tests.rs
@@ -256,7 +256,7 @@ async fn test_adding_to_stream_works(#[case] cases: Vec<StreamSession>) {
     )
 ])]
 #[xmtp_common::test]
-fn it_can_add_to_stream_while_busy(#[case] mut cases: Vec<StreamSession>) {
+async fn it_can_add_to_stream_while_busy(#[case] mut cases: Vec<StreamSession>) {
     let group_list = group_list_from_session(&cases);
     let mut sequence = StreamSequenceBuilder::default();
     for case in cases.iter().cloned() {

--- a/xmtp_mls/src/test/mod.rs
+++ b/xmtp_mls/src/test/mod.rs
@@ -8,3 +8,6 @@ pub mod builder;
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
 pub mod builder_native_only;
+
+#[cfg(all(test, target_family = "wasm", target_os = "unknown"))]
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);

--- a/xmtp_mls/src/utils/events.rs
+++ b/xmtp_mls/src/utils/events.rs
@@ -35,6 +35,7 @@ mod tests {
 
     use crate::{configuration::DeviceSyncUrls, tester, utils::events::upload_debug_archive};
 
+    #[rstest::rstest]
     #[xmtp_common::test(unwrap_try = "true")]
     async fn test_debug_pkg() {
         tester!(alix, stream);
@@ -45,7 +46,7 @@ mod tests {
 
         let alix_dm = alix.group(&bo_dm.group_id)?;
         alix_dm.send_message(b"Hello there").await?;
-        tokio::time::sleep(Duration::from_millis(1000)).await;
+        xmtp_common::time::sleep(Duration::from_millis(1000)).await;
         alix_dm.send_message(b"Hello there").await?;
 
         caro.test_talk_in_dm_with(&alix).await?;

--- a/xmtp_mls/src/utils/test/fixtures.rs
+++ b/xmtp_mls/src/utils/test/fixtures.rs
@@ -1,0 +1,31 @@
+use xmtp_cryptography::utils::generate_local_wallet;
+
+use crate::builder::ClientBuilder;
+
+use super::FullXmtpClient;
+use rstest::*;
+
+#[fixture]
+pub async fn alix() -> FullXmtpClient {
+    ClientBuilder::new_test_client_vanilla(&generate_local_wallet()).await
+}
+
+#[fixture]
+pub async fn bo() -> FullXmtpClient {
+    ClientBuilder::new_test_client_vanilla(&generate_local_wallet()).await
+}
+
+#[fixture]
+pub async fn caro() -> FullXmtpClient {
+    ClientBuilder::new_test_client_vanilla(&generate_local_wallet()).await
+}
+
+#[fixture]
+pub async fn eve() -> FullXmtpClient {
+    ClientBuilder::new_test_client_vanilla(&generate_local_wallet()).await
+}
+
+#[fixture]
+pub async fn xmtp_client() -> FullXmtpClient {
+    ClientBuilder::new_test_client_vanilla(&generate_local_wallet()).await
+}

--- a/xmtp_mls/src/utils/test/mod.rs
+++ b/xmtp_mls/src/utils/test/mod.rs
@@ -3,6 +3,9 @@
 #[cfg(any(test, feature = "test-utils"))]
 pub mod tester_utils;
 
+#[cfg(any(test, feature = "test-utils"))]
+pub mod fixtures;
+
 use crate::{
     builder::{ClientBuilder, SyncWorkerMode},
     context::XmtpContextProvider,
@@ -75,6 +78,23 @@ impl ClientBuilder<TestClient> {
             Some(crate::configuration::DeviceSyncUrls::LOCAL_ADDRESS),
             None,
             None,
+            false,
+        )
+        .await
+    }
+
+    /// Test client without anything extra
+    pub async fn new_test_client_vanilla(owner: &impl InboxOwner) -> FullXmtpClient {
+        let api_client = Self::new_api_client().await;
+
+        build_with_verifier(
+            owner,
+            api_client,
+            MockSmartContractSignatureVerifier::new(true),
+            None,
+            Some(SyncWorkerMode::Disabled),
+            None,
+            false,
         )
         .await
     }
@@ -92,6 +112,7 @@ impl ClientBuilder<TestClient> {
             None,
             Some(SyncWorkerMode::Disabled),
             None,
+            true,
         )
         .await
     }
@@ -112,6 +133,7 @@ impl ClientBuilder<TestClient> {
             None,
             Some(SyncWorkerMode::Disabled),
             Some(version),
+            true,
         )
         .await
     }
@@ -129,6 +151,7 @@ impl ClientBuilder<TestClient> {
             None,
             None,
             None,
+            true,
         )
         .await
     }
@@ -149,6 +172,7 @@ impl ClientBuilder<TestClient> {
             Some(history_sync_url),
             None,
             None,
+            true,
         )
         .await
     }
@@ -167,6 +191,7 @@ impl ClientBuilder<TestClient> {
             None,
             None,
             None,
+            true,
         )
         .await
     }
@@ -245,6 +270,7 @@ async fn build_with_verifier<A, V>(
     sync_server_url: Option<&str>,
     sync_worker_mode: Option<SyncWorkerMode>,
     version: Option<VersionInfo>,
+    telemetry: bool,
 ) -> Client<A>
 where
     A: XmtpApi + Send + Sync + 'static,
@@ -270,6 +296,10 @@ where
 
     if let Some(sync_worker_mode) = sync_worker_mode {
         builder = builder.device_sync_worker_mode(sync_worker_mode);
+    }
+
+    if !telemetry {
+        builder = builder.disable_local_telemetry();
     }
 
     let client = builder.build().await.unwrap();

--- a/xmtp_mls/src/utils/test/tester_utils.rs
+++ b/xmtp_mls/src/utils/test/tester_utils.rs
@@ -125,6 +125,7 @@ where
             self.sync_url.as_deref(),
             Some(self.sync_mode),
             None,
+            true,
         )
         .await;
         let client = Arc::new(client);

--- a/xmtp_mls/src/worker/metrics.rs
+++ b/xmtp_mls/src/worker/metrics.rs
@@ -65,7 +65,8 @@ where
     ) -> Result<(), xmtp_common::time::Expired> {
         let metric = self.metrics.lock().entry(metric_key).or_default().clone();
 
-        let result = xmtp_common::time::timeout(Duration::from_secs(5), async {
+        let secs = if cfg!(target_arch = "wasm32") { 15 } else { 5 };
+        let result = xmtp_common::time::timeout(Duration::from_secs(secs), async {
             loop {
                 if metric.load(Ordering::SeqCst) >= count {
                     return;

--- a/xmtp_mls_common/Cargo.toml
+++ b/xmtp_mls_common/Cargo.toml
@@ -13,3 +13,6 @@ xmtp_common.workspace = true
 xmtp_db.workspace = true
 xmtp_id.workspace = true
 xmtp_proto.workspace = true
+
+[target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dev-dependencies]
+wasm-bindgen-test.workspace = true

--- a/xmtp_proto/src/api_client.rs
+++ b/xmtp_proto/src/api_client.rs
@@ -336,45 +336,36 @@ where
 #[cfg(not(target_arch = "wasm32"))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 pub trait XmtpMlsStreams {
-    type GroupMessageStream<'a>: Stream<Item = Result<GroupMessage, Self::Error>> + Send + 'a
-    where
-        Self: 'a;
+    type GroupMessageStream: Stream<Item = Result<GroupMessage, Self::Error>> + Send;
 
-    type WelcomeMessageStream<'a>: Stream<Item = Result<WelcomeMessage, Self::Error>> + Send + 'a
-    where
-        Self: 'a;
+    type WelcomeMessageStream: Stream<Item = Result<WelcomeMessage, Self::Error>> + Send;
     type Error: RetryableError + Send + Sync + 'static;
 
     async fn subscribe_group_messages(
         &self,
         request: SubscribeGroupMessagesRequest,
-    ) -> Result<Self::GroupMessageStream<'_>, Self::Error>;
+    ) -> Result<Self::GroupMessageStream, Self::Error>;
     async fn subscribe_welcome_messages(
         &self,
         request: SubscribeWelcomeMessagesRequest,
-    ) -> Result<Self::WelcomeMessageStream<'_>, Self::Error>;
+    ) -> Result<Self::WelcomeMessageStream, Self::Error>;
 }
 
 #[cfg(target_arch = "wasm32")]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 pub trait XmtpMlsStreams {
-    type GroupMessageStream<'a>: Stream<Item = Result<GroupMessage, Self::Error>> + 'a
-    where
-        Self: 'a;
-
-    type WelcomeMessageStream<'a>: Stream<Item = Result<WelcomeMessage, Self::Error>> + 'a
-    where
-        Self: 'a;
+    type GroupMessageStream: Stream<Item = Result<GroupMessage, Self::Error>>;
+    type WelcomeMessageStream: Stream<Item = Result<WelcomeMessage, Self::Error>>;
     type Error: RetryableError + Send + Sync + 'static;
 
     async fn subscribe_group_messages(
         &self,
         request: SubscribeGroupMessagesRequest,
-    ) -> Result<Self::GroupMessageStream<'_>, Self::Error>;
+    ) -> Result<Self::GroupMessageStream, Self::Error>;
     async fn subscribe_welcome_messages(
         &self,
         request: SubscribeWelcomeMessagesRequest,
-    ) -> Result<Self::WelcomeMessageStream<'_>, Self::Error>;
+    ) -> Result<Self::WelcomeMessageStream, Self::Error>;
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
@@ -385,27 +376,21 @@ where
 {
     type Error = <T as XmtpMlsStreams>::Error;
 
-    type GroupMessageStream<'a>
-        = <T as XmtpMlsStreams>::GroupMessageStream<'a>
-    where
-        Self: 'a;
+    type GroupMessageStream = <T as XmtpMlsStreams>::GroupMessageStream;
 
-    type WelcomeMessageStream<'a>
-        = <T as XmtpMlsStreams>::WelcomeMessageStream<'a>
-    where
-        Self: 'a;
+    type WelcomeMessageStream = <T as XmtpMlsStreams>::WelcomeMessageStream;
 
     async fn subscribe_group_messages(
         &self,
         request: SubscribeGroupMessagesRequest,
-    ) -> Result<Self::GroupMessageStream<'_>, Self::Error> {
+    ) -> Result<Self::GroupMessageStream, Self::Error> {
         (**self).subscribe_group_messages(request).await
     }
 
     async fn subscribe_welcome_messages(
         &self,
         request: SubscribeWelcomeMessagesRequest,
-    ) -> Result<Self::WelcomeMessageStream<'_>, Self::Error> {
+    ) -> Result<Self::WelcomeMessageStream, Self::Error> {
         (**self).subscribe_welcome_messages(request).await
     }
 }
@@ -418,27 +403,21 @@ where
 {
     type Error = <T as XmtpMlsStreams>::Error;
 
-    type GroupMessageStream<'a>
-        = <T as XmtpMlsStreams>::GroupMessageStream<'a>
-    where
-        Self: 'a;
+    type GroupMessageStream = <T as XmtpMlsStreams>::GroupMessageStream;
 
-    type WelcomeMessageStream<'a>
-        = <T as XmtpMlsStreams>::WelcomeMessageStream<'a>
-    where
-        Self: 'a;
+    type WelcomeMessageStream = <T as XmtpMlsStreams>::WelcomeMessageStream;
 
     async fn subscribe_group_messages(
         &self,
         request: SubscribeGroupMessagesRequest,
-    ) -> Result<Self::GroupMessageStream<'_>, Self::Error> {
+    ) -> Result<Self::GroupMessageStream, Self::Error> {
         (**self).subscribe_group_messages(request).await
     }
 
     async fn subscribe_welcome_messages(
         &self,
         request: SubscribeWelcomeMessagesRequest,
-    ) -> Result<Self::WelcomeMessageStream<'_>, Self::Error> {
+    ) -> Result<Self::WelcomeMessageStream, Self::Error> {
         (**self).subscribe_welcome_messages(request).await
     }
 }


### PR DESCRIPTION
### Remove lifetime parameters from stream types in XmtpMlsStreams trait and all implementations to make streams owned rather than borrowed
The changes remove lifetime parameters from stream types across the XMTP messaging system to support WebAssembly environments. Key modifications include:

• Updates the `XmtpMlsStreams` trait in [xmtp_proto/src/api_client.rs](https://github.com/xmtp/libxmtp/pull/2069/files#diff-7e862515880042ad7a89178c4850f4edd3b1a449ebd83515598088bd845fe67b) to change `GroupMessageStream<'a>` and `WelcomeMessageStream<'a>` to owned types without lifetime parameters
• Modifies all trait implementations across API clients in [xmtp_api/src/debug_wrapper.rs](https://github.com/xmtp/libxmtp/pull/2069/files#diff-81637b4ff5b1435723103d8476cf8db1c8db20746454711eb4b908f0ac431434), [xmtp_api_grpc/src/grpc_api_helper.rs](https://github.com/xmtp/libxmtp/pull/2069/files#diff-e1c5d72313904feb4fa68c2c0b84ba01d9dad309ac9f36e4dd7b63e366bde002), and [xmtp_api_http/src/lib.rs](https://github.com/xmtp/libxmtp/pull/2069/files#diff-7e1515ecc32ccaeb4f793f7caf1e1d05f4b47383a19d2e179784d79b9c192bcf) to use owned stream types
• Adds `stream_conversations_owned` method in [xmtp_mls/src/subscriptions/mod.rs](https://github.com/xmtp/libxmtp/pull/2069/files#diff-0f2359cebb61635cf35774bc0c5e5a5f4b8703e982c2f584e8691cef4d4c2e32) that returns streams with `'static` lifetime
• Refactors `StreamConversations` struct in [xmtp_mls/src/subscriptions/stream_conversations.rs](https://github.com/xmtp/libxmtp/pull/2069/files#diff-7c3c0adb77b28c40ac418e970ce3dbf3320238ec155456eebedc187a61878aea) to use `Cow<'a, Arc<XmtpMlsLocalContext<ApiClient, Db>>>` for supporting both borrowed and owned contexts
• Configures WebAssembly test environment with `wasm_bindgen_test_configure!(run_in_dedicated_worker)` and adds WebAssembly-specific dependencies across multiple crates


#### 📍Where to Start
Start with the `XmtpMlsStreams` trait definition in [xmtp_proto/src/api_client.rs](https://github.com/xmtp/libxmtp/pull/2069/files#diff-7e862515880042ad7a89178c4850f4edd3b1a449ebd83515598088bd845fe67b) to understand the core API changes, then examine the trait implementations to see how the lifetime removal is handled across different client types.

----

_[Macroscope](https://app.macroscope.com) summarized 8a135c6._ (Automatic summaries will resume when PR exits draft mode or review begins).