### PR TITLE
Put commit and clear pending commit in a transaction

### DIFF
--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -1731,17 +1731,23 @@ where
                     metadata_intent.field_value,
                 )?;
 
-                let (commit, _, _) = openmls_group.update_group_context_extensions(
-                    &provider,
-                    mutable_metadata_extensions,
-                    &self.context().identity.installation_keys,
-                )?;
+                let provider = self.mls_provider();
+                let (commit, staged_commit) = provider.transaction(|provider| {
+                    let (commit, _, _) = openmls_group.update_group_context_extensions(
+                        &provider,
+                        mutable_metadata_extensions,
+                        &self.context().identity.installation_keys,
+                    )?;
+                    let staged_commit = get_and_clear_pending_commit(openmls_group, provider)?;
+
+                    Ok::<_, GroupError>((commit, staged_commit))
+                })?;
 
                 let commit_bytes = commit.tls_serialize_detached()?;
 
                 Ok(Some(PublishIntentData {
                     payload_to_publish: commit_bytes,
-                    staged_commit: get_and_clear_pending_commit(openmls_group, provider)?,
+                    staged_commit,
                     post_commit_action: None,
                     should_send_push_notification: intent.should_push,
                 }))


### PR DESCRIPTION
### Wrap commit and clear pending commit operations in transactions for MLS group operations in mls_sync.rs
Refactors MLS group operations to use transaction patterns for atomicity and consistency. The changes include:

• Wraps `IntentKind::KeyUpdate`, `IntentKind::MetadataUpdate`, `IntentKind::UpdateAdminList`, and `IntentKind::UpdatePermission` handlers with `provider.transaction()` calls
• Modifies `update_group_membership` and `update_group_membership_intent` functions to execute operations within single transactions
• Changes `failed_installations` from `Vec<Vec<u8>>` to `HashSet<Vec<u8>>` in `calculate_membership_changes_with_keypackages` function and uses HashSet intersection operations

All changes are contained within [mls_sync.rs](https://github.com/xmtp/libxmtp/pull/2073/files#diff-10f818f7918c8c0b2ed32c4f63e5060050527ed58df00ec081bbecb66065144e).

#### 📍Where to Start
Start with the `IntentKind::KeyUpdate` handler in [mls_sync.rs](https://github.com/xmtp/libxmtp/pull/2073/files#diff-10f818f7918c8c0b2ed32c4f63e5060050527ed58df00ec081bbecb66065144e) to see the transaction pattern implementation.

----

_[Macroscope](https://app.macroscope.com) summarized 9e01186._