### PR TITLE
Ability to clear network stats

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -348,6 +348,10 @@ impl FfiXmtpClient {
         format!("{:?}", aggregate)
     }
 
+    pub fn clear_all_statistics(&self) {
+        self.inner_client.clear_stats()
+    }
+
     pub fn inbox_id(&self) -> InboxId {
         self.inner_client.inbox_id().to_string()
     }
@@ -3390,7 +3394,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn ffi_api_stats_exposed_correctly() {
-        let tester = Tester::builder().sync_worker().sync_server().build().await;
+        let tester = Tester::new().await;
         let client: &FfiXmtpClient = &tester.client;
 
         let bo = Tester::new().await;
@@ -3408,36 +3412,51 @@ mod tests {
             .list(FfiListConversationsOptions::default());
 
         let api_stats = client.api_statistics();
-        assert!(
-            api_stats.send_group_messages >= 1,
-            "Expected at least one group message send"
-        );
-        assert!(
-            api_stats.send_welcome_messages >= 1,
-            "Expected at least one welcome message"
-        );
+        assert!(api_stats.send_group_messages == 1);
+        assert!(api_stats.send_welcome_messages == 1);
 
         let identity_stats = client.api_identity_statistics();
-        assert_eq!(
-            identity_stats.publish_identity_update, 1,
-            "Expected one identity update published"
-        );
-        assert!(
-            identity_stats.get_inbox_ids >= 1,
-            "Expected get_inbox_ids to be called"
-        );
+        assert_eq!(identity_stats.publish_identity_update, 1);
+        assert!(identity_stats.get_inbox_ids >= 1);
 
         let aggregate_str = client.api_aggregate_statistics();
         println!("Aggregate Stats:\n{}", aggregate_str);
 
-        assert!(
-            aggregate_str.contains("UploadKeyPackage"),
-            "Aggregate string should contain API stats"
-        );
-        assert!(
-            aggregate_str.contains("PublishIdentityUpdate"),
-            "Aggregate string should contain identity stats"
-        );
+        assert!(aggregate_str.contains("UploadKeyPackage"));
+        assert!(aggregate_str.contains("PublishIdentityUpdate"));
+
+        client.clear_all_statistics();
+
+        let api_stats = client.api_statistics();
+        assert!(api_stats.send_group_messages == 0);
+        assert!(api_stats.send_welcome_messages == 0);
+
+        let identity_stats = client.api_identity_statistics();
+        assert_eq!(identity_stats.publish_identity_update, 0);
+        assert!(identity_stats.get_inbox_ids == 0);
+
+        let aggregate_str = client.api_aggregate_statistics();
+        println!("Aggregate Stats:\n{}", aggregate_str);
+
+        let _conversation2 = client
+            .conversations()
+            .create_group(
+                vec![bo.account_identifier.clone()],
+                FfiCreateGroupOptions::default(),
+            )
+            .await
+            .unwrap();
+
+        let api_stats = client.api_statistics();
+        assert!(api_stats.send_group_messages == 1);
+        assert!(api_stats.send_welcome_messages == 1);
+
+        let identity_stats = client.api_identity_statistics();
+        assert_eq!(identity_stats.publish_identity_update, 0);
+        assert!(identity_stats.get_inbox_ids == 1);
+
+        let aggregate_str = client.api_aggregate_statistics();
+        println!("Aggregate Stats:\n{}", aggregate_str);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/bindings_node/src/client.rs
+++ b/bindings_node/src/client.rs
@@ -369,6 +369,11 @@ impl Client {
   }
 
   #[napi]
+  pub fn clear_all_statistics(&self) {
+    self.inner_client.clear_stats()
+  }
+
+  #[napi]
   pub async fn upload_debug_archive(&self, server_url: String) -> Result<String> {
     let provider = Arc::new(self.inner_client().mls_provider());
     Ok(

--- a/bindings_wasm/src/client.rs
+++ b/bindings_wasm/src/client.rs
@@ -380,6 +380,11 @@ impl Client {
     format!("{:?}", aggregate)
   }
 
+  #[wasm_bindgen(js_name = clearAllStatistics)]
+  pub fn clear_all_statistics(&self) {
+    self.inner_client.clear_stats()
+  }
+
   #[wasm_bindgen(js_name = uploadDebugArchive)]
   pub async fn upload_debug_archive(&self, server_url: String) -> Result<String, JsError> {
     let provider = Arc::new(self.inner_client().mls_provider());

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -226,6 +226,11 @@ where
         self.context.api().api_client.identity_stats()
     }
 
+    pub fn clear_stats(&self) {
+        self.context.api().api_client.stats().clear();
+        self.context.api().api_client.identity_stats().clear();
+    }
+
     pub fn scw_verifier(&self) -> &Arc<Box<dyn SmartContractSignatureVerifier>> {
         &self.context.scw_verifier
     }

--- a/xmtp_proto/src/api_client.rs
+++ b/xmtp_proto/src/api_client.rs
@@ -104,12 +104,34 @@ pub struct ApiStats {
     pub subscribe_welcomes: Arc<EndpointStats>,
 }
 
+impl ApiStats {
+    pub fn clear(&self) {
+        self.upload_key_package.clear();
+        self.fetch_key_package.clear();
+        self.send_group_messages.clear();
+        self.send_welcome_messages.clear();
+        self.query_group_messages.clear();
+        self.query_welcome_messages.clear();
+        self.subscribe_messages.clear();
+        self.subscribe_welcomes.clear();
+    }
+}
+
 #[derive(Clone, Default, Debug)]
 pub struct IdentityStats {
     pub publish_identity_update: Arc<EndpointStats>,
     pub get_identity_updates_v2: Arc<EndpointStats>,
     pub get_inbox_ids: Arc<EndpointStats>,
     pub verify_smart_contract_wallet_signature: Arc<EndpointStats>,
+}
+
+impl IdentityStats {
+    pub fn clear(&self) {
+        self.publish_identity_update.clear();
+        self.get_identity_updates_v2.clear();
+        self.get_inbox_ids.clear();
+        self.verify_smart_contract_wallet_signature.clear();
+    }
 }
 
 pub struct AggregateStats {
@@ -190,6 +212,9 @@ impl EndpointStats {
 
     pub fn get_count(&self) -> usize {
         self.request_count.load(Ordering::Relaxed)
+    }
+    pub fn clear(&self) {
+        self.request_count.store(0, Ordering::Relaxed)
     }
 }
 


### PR DESCRIPTION
Because we cache the GRPC client on mobile the network stats can get very large quickly and it's hard to tell what the actual network calls were that were being made. This give us better control to be able to clear the stats run an action and see exactly what is happening.