### PR TITLE
clean up send and sync on worker

### DIFF
--- a/xmtp_mls/Cargo.toml
+++ b/xmtp_mls/Cargo.toml
@@ -30,7 +30,6 @@ test-utils = [
   "dep:public-suffix",
   "dep:futures-executor",
   "dep:mockall",
-  "dep:rstest",
 ]
 bench = [
   "test-utils",
@@ -74,6 +73,7 @@ tokio-stream = { workspace = true, default-features = false, features = [
 ] }
 tokio-util.workspace = true
 tracing.workspace = true
+trait-variant.workspace = true
 xmtp_archive.workspace = true
 xmtp_common.workspace = true
 xmtp_mls_common.workspace = true
@@ -102,7 +102,6 @@ xmtp_api_http = { path = "../xmtp_api_http", optional = true }
 criterion = { workspace = true, optional = true }
 hmac = "0.12.1"
 indicatif = { version = "0.17", optional = true }
-rstest = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, features = [
   "env-filter",
   "fmt",
@@ -110,7 +109,6 @@ tracing-subscriber = { workspace = true, features = [
   "json",
   "registry",
 ], optional = true }
-
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true, features = [
@@ -149,7 +147,7 @@ once_cell.workspace = true
 openmls_basic_credential.workspace = true
 passkey = { version = "0.4" }
 public-suffix = { version = "0.1.2" }
-rstest = { workspace = true }
+rstest = { workspace = true, features = ["async-timeout"] }
 rstest_reuse = { workspace = true }
 url = { workspace = true }
 wasm-bindgen-test.workspace = true

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -4,6 +4,7 @@ use crate::{
     groups::{
         device_sync::{
             preference_sync::{PreferenceSyncService, PreferenceUpdate},
+            worker::SyncMetric,
             DeviceSyncClient,
         },
         group_permissions::PolicySet,
@@ -16,6 +17,7 @@ use crate::{
     subscriptions::{LocalEventError, LocalEvents},
     utils::VersionInfo,
     verified_key_package_v2::{KeyPackageVerificationError, VerifiedKeyPackageV2},
+    worker::{metrics::WorkerMetrics, WorkerRunner},
     XmtpApi,
 };
 use openmls::prelude::tls_codec::Error as TlsCodecError;
@@ -148,6 +150,7 @@ impl From<&str> for ClientError {
 pub struct Client<ApiClient, Db = xmtp_db::DefaultStore> {
     pub context: Arc<XmtpMlsLocalContext<ApiClient, Db>>,
     pub(crate) local_events: broadcast::Sender<LocalEvents>,
+    pub(crate) workers: WorkerRunner,
 }
 
 impl<XApiClient: XmtpApi, XDb: XmtpDb> XmtpContextProvider for Client<XApiClient, XDb> {
@@ -192,6 +195,7 @@ impl<ApiClient, Db> Clone for Client<ApiClient, Db> {
         Self {
             context: self.context.clone(),
             local_events: self.local_events.clone(),
+            workers: self.workers.clone(),
         }
     }
 }
@@ -248,12 +252,17 @@ where
     /// Reconnect to the client's database if it has previously been released
     pub fn reconnect_db(&self) -> Result<(), ClientError> {
         self.context.store.reconnect().map_err(StorageError::from)?;
-
-        for manager in self.context.workers.lock().values() {
-            manager.spawn();
-        }
-
+        self.workers.spawn();
         Ok(())
+    }
+
+    /// yields until the sync worker notifies that it is initialized and running.
+    pub async fn wait_for_sync_worker_init(&self) {
+        self.workers.wait_for_sync_worker_init().await;
+    }
+
+    pub fn worker_metrics(&self) -> Option<Arc<WorkerMetrics<SyncMetric>>> {
+        self.workers.sync_metrics()
     }
 }
 
@@ -298,7 +307,7 @@ where
     }
 
     pub fn device_sync(&self) -> DeviceSyncClient<ApiClient, Db> {
-        DeviceSyncClient::new(self.context.clone())
+        DeviceSyncClient::new(self.context.clone(), self.workers.sync_metrics())
     }
     /// Calls the server to look up the `inbox_id` associated with a given identifier
     pub async fn find_inbox_id_from_identifier(
@@ -413,8 +422,8 @@ where
             let _ = self
                 .local_events
                 .send(LocalEvents::PreferencesChanged(updates.clone()));
-            PreferenceSyncService::new(self.context.clone())
-                .sync_preferences(updates)
+            PreferenceSyncService::<ApiClient, Db>::new()
+                .sync_preferences(updates, &self.device_sync())
                 .await?;
         }
 

--- a/xmtp_mls/src/groups/device_sync/worker.rs
+++ b/xmtp_mls/src/groups/device_sync/worker.rs
@@ -4,16 +4,20 @@ use super::{
 };
 use crate::{
     client::ClientError,
-    context::{XmtpContextProvider, XmtpMlsLocalContext},
+    context::{XmtpContextProvider, XmtpMlsLocalContext, XmtpSharedContext},
     groups::{
         device_sync::{archive::insert_importer, default_archive_options},
-        device_sync_legacy::DeviceSyncContent,
+        device_sync_legacy::{
+            preference_sync_legacy::LegacyUserPreferenceUpdate, DeviceSyncContent,
+        },
         GroupError,
     },
     subscriptions::{LocalEvents, StreamMessages, SubscribeError, SyncWorkerEvent},
-    worker::{metrics::WorkerMetrics, Worker, WorkerKind},
+    worker::{
+        metrics::WorkerMetrics, BoxedWorker, Worker, WorkerFactory, WorkerKind, WorkerResult,
+    },
 };
-use futures::{Stream, StreamExt};
+use futures::{Stream, StreamExt, TryFutureExt};
 use std::{any::Any, pin::Pin, sync::Arc};
 use tokio::sync::OnceCell;
 #[cfg(not(target_arch = "wasm32"))]
@@ -47,7 +51,6 @@ pub struct SyncWorker<ApiClient, Db> {
     #[allow(clippy::type_complexity)]
     stream: Pin<Box<dyn Stream<Item = Result<LocalEvents, SubscribeError>> + Send + Sync>>,
     init: OnceCell<()>,
-
     metrics: Arc<WorkerMetrics<SyncMetric>>,
 }
 
@@ -59,25 +62,39 @@ where
     pub fn new(context: &Arc<XmtpMlsLocalContext<ApiClient, Db>>) -> Self {
         let receiver = context.local_events.subscribe();
         let stream = Box::pin(receiver.stream_sync_messages());
-        let client = DeviceSyncClient::new(context.clone());
+        let metrics = Arc::new(WorkerMetrics::new());
+        let client = DeviceSyncClient::new(context.clone(), Some(metrics.clone()));
+
         Self {
             client,
             stream,
             init: OnceCell::new(),
-            metrics: Arc::new(WorkerMetrics::new()),
+            metrics,
         }
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+struct Factory<ApiClient, Db> {
+    context: Arc<XmtpMlsLocalContext<ApiClient, Db>>,
+}
+
+impl<ApiClient, Db> WorkerFactory for Factory<ApiClient, Db>
+where
+    ApiClient: XmtpApi + 'static,
+    Db: XmtpDb + 'static,
+{
+    fn create(&self) -> BoxedWorker {
+        Box::new(SyncWorker::new(&self.context)) as Box<_>
+    }
+}
+
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<ApiClient, Db> Worker for SyncWorker<ApiClient, Db>
 where
     ApiClient: XmtpApi + 'static,
     Db: XmtpDb + 'static,
 {
-    type Error = DeviceSyncError;
-
     fn kind(&self) -> WorkerKind {
         WorkerKind::DeviceSync
     }
@@ -86,7 +103,28 @@ where
         Some(self.metrics.clone())
     }
 
-    async fn run_tasks(&mut self) -> Result<(), Self::Error> {
+    fn factory<C>(context: C) -> impl WorkerFactory + 'static
+    where
+        Self: Sized,
+        C: XmtpSharedContext,
+        <C as XmtpSharedContext>::Db: 'static,
+        <C as XmtpSharedContext>::ApiClient: 'static,
+    {
+        let context = context.context_ref().clone();
+        Factory { context }
+    }
+
+    async fn run_tasks(&mut self) -> WorkerResult<()> {
+        self.run().map_err(|e| Box::new(e) as Box<_>).await
+    }
+}
+
+impl<ApiClient, Db> SyncWorker<ApiClient, Db>
+where
+    ApiClient: XmtpApi + 'static,
+    Db: XmtpDb + 'static,
+{
+    async fn run(&mut self) -> Result<(), DeviceSyncError> {
         // Wait for the identity to be ready & verified before doing anything
         while !self.client.context.identity().is_ready() {
             xmtp_common::yield_().await
@@ -123,13 +161,7 @@ where
         }
         Ok(())
     }
-}
 
-impl<ApiClient, Db> SyncWorker<ApiClient, Db>
-where
-    ApiClient: XmtpApi + 'static,
-    Db: XmtpDb + 'static,
-{
     //// Ideally called when the client is registered.
     //// Will auto-send a sync request if sync group is created.
     #[instrument(level = "trace", skip_all)]
@@ -182,7 +214,7 @@ where
             .increment_metric(SyncMetric::SyncGroupWelcomesProcessed);
 
         // Cycle the HMAC
-        self.client.preference_sync.cycle_hmac().await?;
+        self.client.preference_sync.cycle_hmac(&self.client).await?;
 
         Ok(())
     }
@@ -198,10 +230,27 @@ where
         &self,
         updates: Vec<PreferenceUpdate>,
     ) -> Result<(), DeviceSyncError> {
-        self.client
+        let (updates, legacy_updates) = self
+            .client
             .preference_sync
-            .sync_preferences(updates)
+            .sync_preferences(updates, &self.client)
             .await?;
+
+        let sync_group = self.client.get_sync_group().await?;
+        legacy_updates.iter().for_each(|u| match u {
+            LegacyUserPreferenceUpdate::ConsentUpdate(_) => {
+                tracing::info!("Sent consent to group_id: {:?}", sync_group.group_id);
+                self.metrics.increment_metric(SyncMetric::V1ConsentSent)
+            }
+            LegacyUserPreferenceUpdate::HmacKeyUpdate { .. } => {
+                self.metrics.increment_metric(SyncMetric::V1HmacSent)
+            }
+        });
+
+        updates.iter().for_each(|update| match update {
+            PreferenceUpdate::Consent(_) => self.metrics.increment_metric(SyncMetric::ConsentSent),
+            PreferenceUpdate::Hmac { .. } => self.metrics.increment_metric(SyncMetric::HmacSent),
+        });
         Ok(())
     }
 

--- a/xmtp_mls/src/groups/device_sync_legacy.rs
+++ b/xmtp_mls/src/groups/device_sync_legacy.rs
@@ -268,7 +268,7 @@ where
             Box::pin(group.sync_with_conn()).await?;
         }
 
-        if let Some(handle) = self.worker_metrics() {
+        if let Some(handle) = &self.sync_metrics {
             handle.increment_metric(SyncMetric::V1PayloadProcessed);
         }
 

--- a/xmtp_mls/src/groups/device_sync_legacy/preference_sync_legacy.rs
+++ b/xmtp_mls/src/groups/device_sync_legacy/preference_sync_legacy.rs
@@ -92,7 +92,7 @@ where
         updates.extend(changed);
     }
 
-    if let Some(handle) = context.worker_metrics() {
+    if let Some(handle) = context.workers.sync_metrics() {
         updates.iter().for_each(|u| match u {
             PreferenceUpdate::Consent(_) => handle.increment_metric(SyncMetric::V1ConsentReceived),
             PreferenceUpdate::Hmac { .. } => handle.increment_metric(SyncMetric::V1HmacReceived),
@@ -104,11 +104,11 @@ where
 
 impl LegacyUserPreferenceUpdate {
     /// Send a preference update through the sync group for other devices to consume
+    /// Returns updates synced
     pub(crate) async fn v1_sync_across_devices<C: XmtpApi, Db: XmtpDb>(
         updates: Vec<Self>,
-        context: Arc<XmtpMlsLocalContext<C, Db>>,
-    ) -> Result<(), ClientError> {
-        let device_sync = DeviceSyncClient::new(context.clone());
+        device_sync: &DeviceSyncClient<C, Db>,
+    ) -> Result<Vec<Self>, ClientError> {
         let sync_group = device_sync.get_sync_group().await?;
 
         tracing::info!(
@@ -134,19 +134,7 @@ impl LegacyUserPreferenceUpdate {
         // sync_group.publish_intents(&provider).await?;
         sync_group.sync_until_last_intent_resolved().await?;
 
-        if let Some(handle) = context.worker_metrics() {
-            updates.iter().for_each(|u| match u {
-                LegacyUserPreferenceUpdate::ConsentUpdate(_) => {
-                    tracing::info!("Sent consent to group_id: {:?}", sync_group.group_id);
-                    handle.increment_metric(SyncMetric::V1ConsentSent)
-                }
-                LegacyUserPreferenceUpdate::HmacKeyUpdate { .. } => {
-                    handle.increment_metric(SyncMetric::V1HmacSent)
-                }
-            });
-        }
-
-        Ok(())
+        Ok(updates)
     }
 }
 

--- a/xmtp_mls/src/groups/disappearing_messages.rs
+++ b/xmtp_mls/src/groups/disappearing_messages.rs
@@ -1,7 +1,8 @@
-use crate::worker::{NeedsDbReconnect, Worker};
-use crate::Client;
-use crate::{client::ClientError, worker::WorkerKind};
-use futures::StreamExt;
+use crate::context::{XmtpContextProvider, XmtpMlsLocalContext, XmtpSharedContext};
+use crate::worker::{BoxedWorker, NeedsDbReconnect, Worker, WorkerFactory};
+use crate::worker::{WorkerKind, WorkerResult};
+use futures::{StreamExt, TryFutureExt};
+use std::sync::Arc;
 use std::time::Duration;
 use thiserror::Error;
 use tokio::sync::OnceCell;
@@ -15,44 +16,60 @@ pub const INTERVAL_DURATION: Duration = Duration::from_secs(1);
 pub enum DisappearingMessagesCleanerError {
     #[error("storage error: {0}")]
     Storage(#[from] StorageError),
-    #[error("client error: {0}")]
-    Client(#[from] ClientError),
 }
 
 impl NeedsDbReconnect for DisappearingMessagesCleanerError {
     fn needs_db_reconnect(&self) -> bool {
         match self {
             Self::Storage(s) => s.db_needs_connection(),
-            Self::Client(s) => s.db_needs_connection(),
         }
     }
 }
 
 pub struct DisappearingMessagesWorker<ApiClient, Db> {
-    client: Client<ApiClient, Db>,
+    context: Arc<XmtpMlsLocalContext<ApiClient, Db>>,
     #[allow(dead_code)]
     init: OnceCell<()>,
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+struct Factory<ApiClient, Db> {
+    context: Arc<XmtpMlsLocalContext<ApiClient, Db>>,
+}
+
+impl<ApiClient, Db> WorkerFactory for Factory<ApiClient, Db>
+where
+    ApiClient: XmtpApi + 'static,
+    Db: XmtpDb + 'static,
+{
+    fn create(&self) -> BoxedWorker {
+        Box::new(DisappearingMessagesWorker::new(self.context.clone())) as Box<_>
+    }
+}
+
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<ApiClient, Db> Worker for DisappearingMessagesWorker<ApiClient, Db>
 where
     ApiClient: XmtpApi + 'static,
     Db: xmtp_db::XmtpDb + 'static,
 {
-    type Error = DisappearingMessagesCleanerError;
-
     fn kind(&self) -> WorkerKind {
         WorkerKind::DisappearingMessages
     }
 
-    async fn run_tasks(&mut self) -> Result<(), Self::Error> {
-        let mut intervals = xmtp_common::time::interval_stream(INTERVAL_DURATION);
-        while (intervals.next().await).is_some() {
-            self.delete_expired_messages().await?;
-        }
-        Ok(())
+    async fn run_tasks(&mut self) -> WorkerResult<()> {
+        self.run().map_err(|e| Box::new(e) as Box<_>).await
+    }
+
+    fn factory<C>(context: C) -> impl WorkerFactory + 'static
+    where
+        Self: Sized,
+        C: XmtpSharedContext,
+        <C as XmtpSharedContext>::Db: 'static,
+        <C as XmtpSharedContext>::ApiClient: 'static,
+    {
+        let context = context.context_ref().clone();
+        Factory { context }
     }
 }
 
@@ -61,9 +78,9 @@ where
     ApiClient: XmtpApi + 'static,
     Db: XmtpDb + 'static,
 {
-    pub fn new(client: Client<ApiClient, Db>) -> Self {
+    pub fn new(context: Arc<XmtpMlsLocalContext<ApiClient, Db>>) -> Self {
         Self {
-            client,
+            context,
             init: OnceCell::new(),
         }
     }
@@ -74,9 +91,17 @@ where
     ApiClient: XmtpApi + 'static,
     Db: XmtpDb + 'static,
 {
+    async fn run(&mut self) -> Result<(), DisappearingMessagesCleanerError> {
+        let mut intervals = xmtp_common::time::interval_stream(INTERVAL_DURATION);
+        while (intervals.next().await).is_some() {
+            self.delete_expired_messages().await?;
+        }
+        Ok(())
+    }
+
     /// Iterate on the list of groups and delete expired messages
     async fn delete_expired_messages(&mut self) -> Result<(), DisappearingMessagesCleanerError> {
-        let provider = self.client.mls_provider();
+        let provider = self.context.mls_provider();
         match provider.db().delete_expired_messages() {
             Ok(deleted_count) if deleted_count > 0 => {
                 tracing::info!("Successfully deleted {} expired messages", deleted_count);

--- a/xmtp_mls/src/groups/key_package_cleaner_worker.rs
+++ b/xmtp_mls/src/groups/key_package_cleaner_worker.rs
@@ -1,9 +1,15 @@
+use crate::context::XmtpContextProvider;
+use crate::context::XmtpMlsLocalContext;
+use crate::context::XmtpSharedContext;
 use crate::identity::IdentityError;
-use crate::worker::{Worker, WorkerKind};
-use crate::Client;
-use crate::{client::ClientError, worker::NeedsDbReconnect};
+use crate::worker::BoxedWorker;
+use crate::worker::NeedsDbReconnect;
+use crate::worker::WorkerResult;
+use crate::worker::{Worker, WorkerFactory, WorkerKind};
 use futures::StreamExt;
+use futures::TryFutureExt;
 use openmls_traits::storage::StorageProvider;
+use std::sync::Arc;
 use std::time::Duration;
 use thiserror::Error;
 use tokio::sync::OnceCell;
@@ -13,60 +19,79 @@ use xmtp_proto::api_client::trait_impls::XmtpApi;
 /// Interval at which the KeyPackagesCleanerWorker runs to delete expired messages.
 pub const INTERVAL_DURATION: Duration = Duration::from_secs(5);
 
+#[derive(Clone)]
+pub struct Factory<ApiClient, Db> {
+    context: Arc<XmtpMlsLocalContext<ApiClient, Db>>,
+}
+
+impl<ApiClient, Db> WorkerFactory for Factory<ApiClient, Db>
+where
+    ApiClient: XmtpApi + 'static,
+    Db: XmtpDb + 'static,
+{
+    fn create(&self) -> BoxedWorker {
+        Box::new(KeyPackagesCleanerWorker::new(self.context.clone())) as Box<_>
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum KeyPackagesCleanerError {
     #[error("storage error: {0}")]
     Storage(#[from] StorageError),
-    #[error("client error: {0}")]
-    Client(#[from] ClientError),
+    #[error("identity error: {0}")]
+    Identity(#[from] IdentityError),
 }
 
 impl NeedsDbReconnect for KeyPackagesCleanerError {
     fn needs_db_reconnect(&self) -> bool {
         match self {
             Self::Storage(s) => s.db_needs_connection(),
-            Self::Client(s) => s.db_needs_connection(),
+            Self::Identity(s) => s.needs_db_reconnect(),
         }
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<ApiClient, Db> Worker for KeyPackagesCleanerWorker<ApiClient, Db>
 where
-    ApiClient: XmtpApi + 'static + Send + Sync,
-    Db: XmtpDb + 'static + Send + Sync,
+    ApiClient: XmtpApi + 'static,
+    Db: XmtpDb + 'static + Send,
 {
-    type Error = KeyPackagesCleanerError;
-
     fn kind(&self) -> WorkerKind {
         WorkerKind::KeyPackageCleaner
     }
 
-    async fn run_tasks(&mut self) -> Result<(), Self::Error> {
-        let mut intervals = xmtp_common::time::interval_stream(INTERVAL_DURATION);
-        while (intervals.next().await).is_some() {
-            self.delete_expired_key_packages().await?;
-            self.rotate_last_key_package_if_needed().await?;
-        }
-        Ok(())
+    async fn run_tasks(&mut self) -> WorkerResult<()> {
+        self.run().map_err(|e| Box::new(e) as Box<_>).await
+    }
+
+    fn factory<C>(context: C) -> impl WorkerFactory + 'static
+    where
+        Self: Sized,
+        C: XmtpSharedContext,
+        <C as XmtpSharedContext>::Db: 'static,
+        <C as XmtpSharedContext>::ApiClient: 'static,
+    {
+        let context = context.context_ref().clone();
+        Factory { context }
     }
 }
 
 pub struct KeyPackagesCleanerWorker<ApiClient, Db> {
-    client: Client<ApiClient, Db>,
+    context: Arc<XmtpMlsLocalContext<ApiClient, Db>>,
     #[allow(dead_code)]
     init: OnceCell<()>,
 }
 
 impl<ApiClient, Db> KeyPackagesCleanerWorker<ApiClient, Db>
 where
-    ApiClient: XmtpApi + Send + Sync + 'static,
-    Db: XmtpDb + Send + Sync + 'static,
+    ApiClient: XmtpApi + 'static,
+    Db: XmtpDb + 'static,
 {
-    pub fn new(client: Client<ApiClient, Db>) -> Self {
+    pub fn new(context: Arc<XmtpMlsLocalContext<ApiClient, Db>>) -> Self {
         Self {
-            client,
+            context,
             init: OnceCell::new(),
         }
     }
@@ -74,13 +99,22 @@ where
 
 impl<ApiClient, Db> KeyPackagesCleanerWorker<ApiClient, Db>
 where
-    ApiClient: XmtpApi + Send + Sync + 'static,
-    Db: XmtpDb + Send + Sync + 'static,
+    ApiClient: XmtpApi + 'static,
+    Db: XmtpDb + 'static,
 {
+    async fn run(&mut self) -> Result<(), KeyPackagesCleanerError> {
+        let mut intervals = xmtp_common::time::interval_stream(INTERVAL_DURATION);
+        while (intervals.next().await).is_some() {
+            self.delete_expired_key_packages()?;
+            self.rotate_last_key_package_if_needed().await?;
+        }
+        Ok(())
+    }
+
     /// Delete a key package from the local database.
     pub(crate) fn delete_key_package(&self, hash_ref: Vec<u8>) -> Result<(), IdentityError> {
         let openmls_hash_ref = crate::identity::deserialize_key_package_hash_ref(&hash_ref)?;
-        self.client
+        self.context
             .mls_provider()
             .key_store()
             .delete_key_package(&openmls_hash_ref)?;
@@ -89,8 +123,8 @@ where
     }
 
     /// Delete all the expired keys
-    async fn delete_expired_key_packages(&mut self) -> Result<(), KeyPackagesCleanerError> {
-        let provider = self.client.mls_provider();
+    fn delete_expired_key_packages(&mut self) -> Result<(), KeyPackagesCleanerError> {
+        let provider = self.context.mls_provider();
         let conn = provider.db();
 
         match conn.get_expired_key_packages() {
@@ -125,11 +159,14 @@ where
 
     /// Check if we need to rotate the keys and upload new keypackage if the las one rotate in has passed
     async fn rotate_last_key_package_if_needed(&mut self) -> Result<(), KeyPackagesCleanerError> {
-        let provider = self.client.mls_provider();
+        let provider = self.context.mls_provider();
         let conn = provider.db();
 
         if conn.is_identity_needs_rotation()? {
-            self.client.rotate_and_upload_key_package().await?;
+            self.context
+                .identity()
+                .rotate_and_upload_key_package(&provider, self.context.api())
+                .await?;
             return Ok(());
         }
 

--- a/xmtp_mls/src/identity.rs
+++ b/xmtp_mls/src/identity.rs
@@ -1,4 +1,5 @@
 use crate::configuration::CIPHERSUITE;
+use crate::worker::NeedsDbReconnect;
 use crate::{verified_key_package_v2::KeyPackageVerificationError, XmtpApi};
 use openmls::prelude::hash_ref::HashReference;
 use openmls::prelude::OpenMlsCrypto;
@@ -221,6 +222,15 @@ pub enum IdentityError {
     AddressValidation(#[from] IdentifierValidationError),
     #[error(transparent)]
     Db(#[from] xmtp_db::ConnectionError),
+}
+
+impl NeedsDbReconnect for IdentityError {
+    fn needs_db_reconnect(&self) -> bool {
+        match self {
+            Self::StorageError(s) => s.db_needs_connection(),
+            _ => false,
+        }
+    }
 }
 
 impl RetryableError for IdentityError {

--- a/xmtp_mls/src/identity_updates.rs
+++ b/xmtp_mls/src/identity_updates.rs
@@ -2,7 +2,7 @@ use crate::{
     client::ClientError,
     context::{XmtpContextProvider, XmtpMlsLocalContext},
     groups::{
-        device_sync::preference_sync::PreferenceSyncService,
+        device_sync::{preference_sync::PreferenceSyncService, DeviceSyncClient},
         group_membership::{GroupMembership, MembershipDiff},
     },
     XmtpApi,
@@ -355,8 +355,8 @@ where
             )
         }
 
-        PreferenceSyncService::new(self.context.clone())
-            .cycle_hmac()
+        PreferenceSyncService::<ApiClient, Db>::new()
+            .cycle_hmac(&DeviceSyncClient::new(self.context.clone(), None))
             .await?;
         Ok(builder.build())
     }

--- a/xmtp_mls/src/worker.rs
+++ b/xmtp_mls/src/worker.rs
@@ -1,10 +1,10 @@
 use crate::{
-    configuration::WORKER_RESTART_DELAY, context::XmtpMlsLocalContext,
+    configuration::WORKER_RESTART_DELAY, context::XmtpSharedContext,
     groups::device_sync::worker::SyncMetric,
 };
 use metrics::WorkerMetrics;
 use parking_lot::Mutex;
-use std::{any::Any, fmt::Debug, hash::Hash, marker::PhantomData, sync::Arc};
+use std::{any::Any, collections::HashMap, hash::Hash, sync::Arc};
 
 pub mod metrics;
 
@@ -15,161 +15,154 @@ pub enum WorkerKind {
     KeyPackageCleaner,
 }
 
-#[cfg(not(target_arch = "wasm32"))]
-pub(crate) trait WorkerManager: Send + Sync {
-    fn sync_metrics(&self) -> Option<Arc<WorkerMetrics<SyncMetric>>>;
-    fn spawn(&self) -> WorkerKind;
+#[derive(Clone)]
+pub struct WorkerRunner {
+    pub metrics: Arc<Mutex<HashMap<WorkerKind, Arc<dyn Any + Send + Sync>>>>,
+    factories: Vec<DynFactory>,
 }
 
-#[cfg(target_arch = "wasm32")]
-pub(crate) trait WorkerManager {
-    fn sync_metrics(&self) -> Option<Arc<WorkerMetrics<SyncMetric>>>;
-    fn spawn(&self) -> WorkerKind;
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-impl<W> WorkerManager for WorkerRunner<W>
-where
-    W: Worker + Send + Sync + 'static,
-    <W as Worker>::Error: Send,
-{
-    fn sync_metrics(&self) -> Option<Arc<WorkerMetrics<SyncMetric>>> {
-        self.metrics.lock().clone().and_then(|m| m.downcast().ok())
-    }
-
-    fn spawn(&self) -> WorkerKind {
-        let mut worker = (self.create_fn)();
-        *self.metrics.lock() = worker.metrics().map(|a| a as Arc<_>);
-        let kind = worker.kind();
-
-        xmtp_common::spawn(None, async move {
-            loop {
-                if let Err(err) = worker.run_tasks().await {
-                    if err.needs_db_reconnect() {
-                        tracing::warn!("Pool disconnected. task will restart on reconnect");
-                        break;
-                    } else {
-                        tracing::error!("Worker error: {err:?}");
-                        xmtp_common::time::sleep(WORKER_RESTART_DELAY).await;
-                        tracing::info!("Restarting sync worker...");
-                    }
-                }
-            }
-        });
-
-        kind
+impl WorkerRunner {
+    pub fn new() -> Self {
+        Self {
+            metrics: Arc::new(Mutex::new(HashMap::new())),
+            factories: Vec::new(),
+        }
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-impl<W> WorkerManager for WorkerRunner<W>
-where
-    W: Worker + 'static,
-{
-    fn sync_metrics(&self) -> Option<Arc<WorkerMetrics<SyncMetric>>> {
-        self.metrics.lock().clone().and_then(|m| m.downcast().ok())
-    }
-
-    fn spawn(&self) -> WorkerKind {
-        let mut worker = (self.create_fn)();
-        *self.metrics.lock() = worker.metrics().map(|a| a as Arc<_>);
-        let kind = worker.kind();
-
-        xmtp_common::spawn(None, async move {
-            loop {
-                if let Err(err) = worker.run_tasks().await {
-                    if err.needs_db_reconnect() {
-                        tracing::warn!("Pool disconnected. task will restart on reconnect");
-                        break;
-                    } else {
-                        tracing::error!("Worker error: {err:?}");
-                        xmtp_common::time::sleep(WORKER_RESTART_DELAY).await;
-                        tracing::info!("Restarting sync worker...");
-                    }
-                }
-            }
-        });
-
-        kind
+impl WorkerRunner {
+    pub fn sync_metrics(&self) -> Option<Arc<WorkerMetrics<SyncMetric>>> {
+        if let Some(metrics) = self.metrics.lock().get(&WorkerKind::DeviceSync) {
+            Some(metrics.clone().downcast().ok()?)
+        } else {
+            None
+        }
     }
 }
 
-pub struct WorkerRunner<W> {
-    pub metrics: Arc<Mutex<Option<Arc<dyn Any + Send + Sync>>>>,
-    #[cfg(not(target_arch = "wasm32"))]
-    create_fn: Box<dyn Fn() -> W + Send + Sync>,
-    #[cfg(target_arch = "wasm32")]
-    create_fn: Box<dyn Fn() -> W>,
-    _worker: PhantomData<W>,
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-impl<W> WorkerRunner<W>
-where
-    W: Worker + Send + Sync + 'static,
-    <W as Worker>::Error: Send,
-{
-    pub fn register_new_worker<ApiClient, Db, F>(
-        context: &Arc<XmtpMlsLocalContext<ApiClient, Db>>,
-        create_fn: F,
-    ) where
-        F: Fn() -> W + Send + Sync + 'static,
-        W: Worker + 'static,
+impl WorkerRunner {
+    pub fn register_new_worker<W: Worker, C>(&mut self, ctx: C)
+    where
+        C: XmtpSharedContext,
+        <C as XmtpSharedContext>::Db: 'static,
+        <C as XmtpSharedContext>::ApiClient: 'static,
     {
-        let create_fn = Box::new(create_fn);
+        let factory = W::factory(ctx);
+        self.factories.push(Arc::new(factory))
+    }
 
-        let metrics = Arc::new(Mutex::default());
-        let runner = Box::new(WorkerRunner {
-            metrics: metrics.clone(),
-            create_fn,
-            _worker: PhantomData::<W>,
-        });
+    pub fn spawn(&self) {
+        for factory in &self.factories {
+            let worker = factory.create();
+            if let Some(metrics) = worker.metrics() {
+                let mut m = self.metrics.lock();
+                m.insert(worker.kind(), metrics);
+            }
+            worker.spawn()
+        }
+    }
 
-        let kind = runner.spawn();
-
-        context.workers.lock().insert(kind, runner as Box<_>);
+    pub async fn wait_for_sync_worker_init(&self) {
+        if let Some(handle) = self.sync_metrics() {
+            let _ = handle.wait_for_init().await;
+        }
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-impl<W> WorkerRunner<W>
-where
-    W: Worker + 'static,
-{
-    pub fn register_new_worker<ApiClient, Db, F>(
-        context: &Arc<XmtpMlsLocalContext<ApiClient, Db>>,
-        create_fn: F,
-    ) where
-        F: Fn() -> W + 'static,
-        W: Worker + 'static,
-    {
-        let create_fn = Box::new(create_fn);
+pub type WorkerResult<T> = Result<T, Box<dyn NeedsDbReconnect>>;
 
-        let metrics = Arc::new(Mutex::default());
-        let runner = Box::new(WorkerRunner {
-            metrics: metrics.clone(),
-            create_fn,
-            _worker: PhantomData::<W>,
-        });
-
-        let kind = runner.spawn();
-
-        context.workers.lock().insert(kind, runner as Box<_>);
-    }
-}
-
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 pub trait Worker {
-    type Error: NeedsDbReconnect + Debug;
-
     fn kind(&self) -> WorkerKind;
-    async fn run_tasks(&mut self) -> Result<(), Self::Error>;
+
+    async fn run_tasks(&mut self) -> Result<(), Box<dyn NeedsDbReconnect>>;
+
     fn metrics(&self) -> Option<Arc<dyn Any + Send + Sync>> {
         None
     }
+
+    fn factory<C>(context: C) -> impl WorkerFactory + 'static
+    where
+        Self: Sized,
+        C: XmtpSharedContext,
+        <C as XmtpSharedContext>::Db: 'static,
+        <C as XmtpSharedContext>::ApiClient: 'static;
+
+    /// Box the worker, erasing its type
+    fn boxed(self) -> Box<dyn Worker>
+    where
+        Self: Sized + 'static,
+    {
+        Box::new(self) as Box<_>
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn spawn(mut self: Box<Self>)
+    where
+        Self: Send + Sync + 'static,
+    {
+        xmtp_common::spawn(None, async move {
+            loop {
+                if let Err(err) = self.run_tasks().await {
+                    if err.needs_db_reconnect() {
+                        // drop the worker
+                        tracing::warn!("Pool disconnected. task will restart on reconnect");
+                        break;
+                    } else {
+                        tracing::error!("Worker error: {err:?}");
+                        xmtp_common::time::sleep(WORKER_RESTART_DELAY).await;
+                        tracing::info!("Restarting sync worker...");
+                    }
+                }
+            }
+        });
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    fn spawn(mut self: Box<Self>)
+    where
+        Self: 'static,
+    {
+        xmtp_common::spawn(None, async move {
+            loop {
+                if let Err(err) = self.run_tasks().await {
+                    if err.needs_db_reconnect() {
+                        // drop the worker
+                        tracing::warn!("Pool disconnected. task will restart on reconnect");
+                        break;
+                    } else {
+                        tracing::error!("Worker error: {err:?}");
+                        xmtp_common::time::sleep(WORKER_RESTART_DELAY).await;
+                        tracing::info!("Restarting sync worker...");
+                    }
+                }
+            }
+        });
+    }
 }
 
-pub trait NeedsDbReconnect {
+#[cfg_attr(not(target_arch = "wasm32"), trait_variant::make(NeedsDbReconnect: Send + Sync))]
+#[cfg_attr(target_arch = "wasm32", trait_variant::make(NeedsDbReconnect: xmtp_common::Wasm))]
+pub trait LocalNeedsDbReconnect: std::error::Error {
     fn needs_db_reconnect(&self) -> bool;
 }
+
+#[cfg_attr(not(target_arch = "wasm32"), trait_variant::make(WorkerFactory: Send + Sync))]
+#[cfg_attr(target_arch = "wasm32", trait_variant::make(WorkerFactory: xmtp_common::Wasm))]
+pub trait LocalWorkerFactory {
+    /// Create a new worker
+    fn create(&self) -> BoxedWorker;
+}
+
+#[cfg(target_arch = "wasm32")]
+pub type BoxedWorker = Box<dyn Worker>;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub type BoxedWorker = Box<dyn Worker + Send + Sync>;
+
+#[cfg(target_arch = "wasm32")]
+pub type DynFactory = Arc<dyn WorkerFactory>;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub type DynFactory = Arc<dyn WorkerFactory + Send + Sync>;


### PR DESCRIPTION
### Refactor worker management system to use factory pattern and centralized WorkerRunner in xmtp_mls client
- Replaces closure-based worker creation with a factory pattern using new `WorkerFactory` trait and `Factory` structs for each worker type
- Changes `WorkerRunner` to store worker factories and metrics directly instead of using HashMap-based worker management
- Modifies `Client` struct to include a `workers` field and centralizes worker registration during client building in [builder.rs](https://github.com/xmtp/libxmtp/pull/2089/files#diff-2df8df9acb5405ca5c2dde2487e92ffc9a7daf6be38dd075a2a2d4878cc35ce6)
- Updates worker trait implementations to return boxed errors and removes associated `Error` types
- Changes workers to store context references instead of client references and adds platform-specific variations using `trait_variant`
- Modifies `DeviceSyncClient` and preference sync services to handle metrics directly rather than accessing them through context

#### 📍Where to Start
Start with the `WorkerRunner` struct and its methods in [worker.rs](https://github.com/xmtp/libxmtp/pull/2089/files#diff-ea560e63ca633c03d1189957b9efca26de6aa33294f42c116a574e5bf259ce23) to understand the new factory-based worker management system.

----

_[Macroscope](https://app.macroscope.com) summarized b5726d4._