### PR TITLE
add JS integration tests to CI for webassembly bindings

### DIFF
--- a/.github/workflows/release-wasm-bindings.yml
+++ b/.github/workflows/release-wasm-bindings.yml
@@ -25,7 +25,6 @@ jobs:
         run: |
           chmod +x dev/sync-versions.sh
           ./dev/sync-versions.sh
-          
           # Check if there are any changes after syncing versions
           if [[ -n $(git status --porcelain) ]]; then
             echo "::error::Version mismatch detected! Please run 'dev/sync-versions.sh' locally, commit the changes before releasing bindings_wasm"
@@ -62,57 +61,31 @@ jobs:
         run: |
           source ./../emsdk/emsdk_env.sh
           yarn build
-
       - name: Generate version
         working-directory: bindings_wasm
         run: yarn generate:version
-
       - name: Update version for dev releases
         working-directory: bindings_wasm
-        run: |
-          # Read the current version from package.json
-          PACKAGE_VERSION=$(node -p "require('./package.json').version")
-          
-          # Check if this is a dev version
-          if [[ "$PACKAGE_VERSION" == *"dev"* ]]; then
-            # Read the git commit hash from version.json
-            if [ -f "dist/version.json" ]; then
-              GIT_HASH=$(node -p "require('./dist/version.json').version")
-              
-              # Create a new version string with the git hash
-              NEW_VERSION="${PACKAGE_VERSION}.${GIT_HASH}"
-              
-              # Update package.json with the new version
-              npm version "$NEW_VERSION" --no-git-tag-version
-              
-              echo "Updated version to $NEW_VERSION for publishing"
-            else
-              echo "Warning: dist/version.json not found, using original version"
-            fi
-          else
-            echo "Not a dev version, keeping original version: $PACKAGE_VERSION"
-          fi
-
+        run: ./dev/ci/release/wasm/update_versions
       - name: Determine NPM tag
         id: npm-tag
         working-directory: bindings_wasm
         run: |
           # Read the current version from package.json
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
-          
+
           # Set the tag based on whether it's a dev version
           if [[ "$PACKAGE_VERSION" == *"dev"* ]]; then
             echo "tag=prerelease" >> $GITHUB_OUTPUT
           else
             echo "tag=latest" >> $GITHUB_OUTPUT
           fi
-
       - name: Create Git Tag for Dev Releases
         if: contains(steps.npm-tag.outputs.tag, 'prerelease')
         run: |
           # Read the current version from package.json
           PACKAGE_VERSION=$(node -p "require('./bindings_wasm/package.json').version")
-          
+
           # Create and push the tag
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
@@ -120,7 +93,6 @@ jobs:
           git push origin "wasm-bindings-${PACKAGE_VERSION}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Publish to NPM
         uses: JS-DevTools/npm-publish@v3
         with:

--- a/.github/workflows/test-webassembly.yml
+++ b/.github/workflows/test-webassembly.yml
@@ -14,6 +14,7 @@ on:
       - "xmtp_content_types/**"
       - "xmtp_api_http/src/**"
       - "xmtp_proto/**"
+      - "bindings_wasm/**"
       - "Cargo.toml"
       - "Cargo.lock"
       - ".cargo/**"
@@ -51,21 +52,21 @@ jobs:
           ./emsdk activate latest
       - name: Build WebAssembly Packages
         env:
-          RUSTFLAGS: --cfg tracing_unstable -Ctarget-feature=+bulk-memory,+mutable-globals,+atomics --cfg getrandom_backend="wasm_js"
+          RUSTFLAGS: --cfg tracing_unstable -Ctarget-feature=+bulk-memory,+mutable-globals --cfg getrandom_backend="wasm_js"
         run: |
           source ./emsdk/emsdk_env.sh
           cargo build --locked --tests --release --target wasm32-unknown-unknown -p xmtp_id -p xmtp_mls -p xmtp_api_http -p xmtp_cryptography -p xmtp_common -p bindings_wasm -p xmtp_api_d14n -p xmtp_db
       - name: test libraries
         env:
-          RUSTFLAGS: --cfg tracing_unstable -Ctarget-feature=+bulk-memory,+mutable-globals,+atomics --cfg getrandom_backend="wasm_js"
+          RUSTFLAGS: --cfg tracing_unstable -Ctarget-feature=+bulk-memory,+mutable-globals --cfg getrandom_backend="wasm_js"
           CHROMEDRIVER: "chromedriver"
         run: |
-          cargo test --locked --release --target wasm32-unknown-unknown -p xmtp_mls -p xmtp_id -p xmtp_api_http -p xmtp_cryptography -p xmtp_api -p bindings_wasm -p xmtp_api_d14n -p xmtp_db -- \
+          cargo test --locked --release --target wasm32-unknown-unknown -p xmtp_id -p xmtp_api_http -p xmtp_cryptography -p xmtp_api -p bindings_wasm -p xmtp_api_d14n -p xmtp_db -- \
             --skip encrypted_store::group_message::tests::it_cannot_insert_message_without_group \
         working-directory: ./
       - name: test xmtp_mls client
         env:
-          RUSTFLAGS: --cfg tracing_unstable -Ctarget-feature=+bulk-memory,+mutable-globals,+atomics --cfg getrandom_backend="wasm_js"
+          RUSTFLAGS: --cfg tracing_unstable -Ctarget-feature=+bulk-memory,+mutable-globals --cfg getrandom_backend="wasm_js"
           CHROMEDRIVER: "chromedriver"
         run: |
           cargo test --locked --release --target wasm32-unknown-unknown -p xmtp_mls -- \
@@ -74,8 +75,21 @@ jobs:
         working-directory: ./
       - name: test xmtp_mls subscriptions
         env:
-          RUSTFLAGS: --cfg tracing_unstable -Ctarget-feature=+bulk-memory,+mutable-globals,+atomics --cfg getrandom_backend="wasm_js"
+          RUSTFLAGS: --cfg tracing_unstable -Ctarget-feature=+bulk-memory,+mutable-globals --cfg getrandom_backend="wasm_js"
           CHROMEDRIVER: "chromedriver"
         run: |
           cargo test --locked --release --target wasm32-unknown-unknown -p xmtp_mls -- subscriptions::
         working-directory: ./
+      - name: yarn install
+        working-directory: bindings_wasm
+        run: |
+          yarn
+      - working-directory: bindings_wasm/tests/integration/browser
+        run: |
+          yarn
+      - name: webassembly integration tests
+        working-directory: bindings_wasm/tests/integration/browser
+        run: |
+          source ./../../../../emsdk/emsdk_env.sh
+          yarn playwright install
+          yarn test

--- a/bindings_wasm/tests/integration/browser/vite.config.mjs
+++ b/bindings_wasm/tests/integration/browser/vite.config.mjs
@@ -12,7 +12,7 @@ const vitestConfig = defineVitestConfig({
     browser: {
       provider: "playwright",
       enabled: true,
-      headless: false,
+      headless: true,
       screenshotFailures: false,
       instances: [
         {

--- a/dev/ci/release/wasm/update_versions
+++ b/dev/ci/release/wasm/update_versions
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -eou pipefail
+
+# Read the current version from package.json
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+
+          # Check if this is a dev version
+          if [[ "$PACKAGE_VERSION" == *"dev"* ]]; then
+            # Read the git commit hash from version.json
+            if [ -f "dist/version.json" ]; then
+              GIT_HASH=$(node -p "require('./dist/version.json').version")
+
+              # Create a new version string with the git hash
+              NEW_VERSION="${PACKAGE_VERSION}.${GIT_HASH}"
+
+              # Update package.json with the new version
+              npm version "$NEW_VERSION" --no-git-tag-version
+
+              echo "Updated version to $NEW_VERSION for publishing"
+            else
+              echo "Warning: dist/version.json not found, using original version"
+            fi
+          else
+            echo "Not a dev version, keeping original version: $PACKAGE_VERSION"
+          fi


### PR DESCRIPTION
### Add WebAssembly integration tests using Playwright and extract version update logic to separate script
- Adds Playwright-based integration tests for WebAssembly bindings in the GitHub Actions workflow [.github/workflows/test-webassembly.yml](https://github.com/xmtp/libxmtp/pull/2098/files#diff-e212b3a87660ba5a2af651d8b2f8be1c9bd5c974e093340424374f679fae4ebd)
- Extracts inline version update script from [.github/workflows/release-wasm-bindings.yml](https://github.com/xmtp/libxmtp/pull/2098/files#diff-8ac8fedf1ee50dabf3d48a77190d2741d37b10bc75e0ef6382d42bfadd092fe3) to separate executable script [dev/ci/release/wasm/update_versions](https://github.com/xmtp/libxmtp/pull/2098/files#diff-6d54963447234a2d96b170c99026467508d3e2b42367564fdb3c5df41f77891a)
- Removes `+atomics` from RUSTFLAGS in WebAssembly compilation configuration
- Configures browser tests to run in headless mode in [bindings_wasm/tests/integration/browser/vite.config.mjs](https://github.com/xmtp/libxmtp/pull/2098/files#diff-8675d7292dcc2db4913f94f8b1a0da027ff9c9bbeae6b58285daed559df52756)
- Updates workflow triggers to include `bindings_wasm/**` path changes

#### 📍Where to Start
Start with the new integration test steps added at the end of [.github/workflows/test-webassembly.yml](https://github.com/xmtp/libxmtp/pull/2098/files#diff-e212b3a87660ba5a2af651d8b2f8be1c9bd5c974e093340424374f679fae4ebd), specifically the yarn install and Playwright test execution steps.

----

_[Macroscope](https://app.macroscope.com) summarized a1ff649._