### PR TITLE
make unwrap_try boolean literal

### DIFF
--- a/xmtp_db/src/encrypted_store/consent_record.rs
+++ b/xmtp_db/src/encrypted_store/consent_record.rs
@@ -336,7 +336,7 @@ mod tests {
         }
     }
 
-    #[xmtp_common::test(unwrap_try = "true")]
+    #[xmtp_common::test(unwrap_try = true)]
     async fn find_consent_by_dm_id() {
         with_connection(|conn| {
             let mut g = generate_group(None);

--- a/xmtp_db/src/encrypted_store/events.rs
+++ b/xmtp_db/src/encrypted_store/events.rs
@@ -166,7 +166,7 @@ mod tests {
         with_connection,
     };
 
-    #[xmtp_common::test(unwrap_try = "true")]
+    #[xmtp_common::test(unwrap_try = true)]
     // A client build event should clear old events.
     async fn clear_old_events() {
         with_connection(|conn| {

--- a/xmtp_db/src/encrypted_store/icebox.rs
+++ b/xmtp_db/src/encrypted_store/icebox.rs
@@ -123,7 +123,7 @@ mod tests {
         ]
     }
 
-    #[xmtp_common::test(unwrap_try = "true")]
+    #[xmtp_common::test(unwrap_try = true)]
     async fn icebox_dependency_chain() {
         with_connection(|conn| {
             let ice = iced();
@@ -138,7 +138,7 @@ mod tests {
         .await
     }
 
-    #[xmtp_common::test(unwrap_try = "true")]
+    #[xmtp_common::test(unwrap_try = true)]
     async fn test_icebox_wrong_originator() {
         with_connection(|conn| {
             // Break the chain by unsetting the originator.
@@ -157,7 +157,7 @@ mod tests {
         .await
     }
 
-    #[xmtp_common::test(unwrap_try = "true")]
+    #[xmtp_common::test(unwrap_try = true)]
     async fn test_icebox_wrong_sequence() {
         with_connection(|conn| {
             // Break the chain by unsetting the originator.
@@ -176,7 +176,7 @@ mod tests {
         .await
     }
 
-    #[xmtp_common::test(unwrap_try = "true")]
+    #[xmtp_common::test(unwrap_try = true)]
     async fn test_icebox_depending_fields_xor() {
         with_connection(|conn| {
             // Test to ensure that if one dependency field is set, they both are.

--- a/xmtp_db/src/encrypted_store/processed_device_sync_messages.rs
+++ b/xmtp_db/src/encrypted_store/processed_device_sync_messages.rs
@@ -56,7 +56,7 @@ mod tests {
         test_utils::with_connection,
     };
 
-    #[xmtp_common::test(unwrap_try = "true")]
+    #[xmtp_common::test(unwrap_try = true)]
     async fn it_marks_as_processed() {
         with_connection(|conn| {
             let mut group = generate_group(None);

--- a/xmtp_macro/src/lib.rs
+++ b/xmtp_macro/src/lib.rs
@@ -126,7 +126,7 @@ fn transform_question_marks(tokens: proc_macro::TokenStream) -> proc_macro::Toke
 struct Attributes {
     r#async: bool,
     flavor: Option<syn::LitStr>,
-    unwrap_try: Option<syn::LitStr>,
+    unwrap_try: Option<syn::LitBool>,
 }
 
 impl Attributes {
@@ -138,9 +138,7 @@ impl Attributes {
     }
 
     fn unwrap_try(&self) -> bool {
-        self.unwrap_try
-            .as_ref()
-            .is_some_and(|v| v.value() == "true")
+        self.unwrap_try.as_ref().is_some_and(|v| v.value())
     }
 }
 

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -1511,7 +1511,7 @@ pub(crate) mod tests {
         assert_eq!(conversations[0].group_id, dm1.group_id);
     }
 
-    #[xmtp_common::test(unwrap_try = "true")]
+    #[xmtp_common::test(unwrap_try = true)]
     async fn should_stream_consent() {
         let alix = Tester::builder().sync_worker().build().await;
         let bo = Tester::new().await;

--- a/xmtp_mls/src/groups/device_sync/archive.rs
+++ b/xmtp_mls/src/groups/device_sync/archive.rs
@@ -166,7 +166,7 @@ mod tests {
         assert_eq!(messages.len(), 1);
     }
 
-    #[xmtp_common::test(unwrap_try = "true")]
+    #[xmtp_common::test(unwrap_try = true)]
     #[cfg(not(target_arch = "wasm32"))]
     async fn test_file_backup() {
         use crate::tester;

--- a/xmtp_mls/src/groups/device_sync/preference_sync.rs
+++ b/xmtp_mls/src/groups/device_sync/preference_sync.rs
@@ -155,7 +155,7 @@ mod tests {
     use xmtp_db::user_preferences::StoredUserPreferences;
 
     #[rstest::rstest]
-    #[xmtp_common::test(unwrap_try = "true")]
+    #[xmtp_common::test(unwrap_try = true)]
     async fn test_hmac_sync() {
         let amal_a = Tester::builder().sync_worker().build().await;
         let amal_b = amal_a.builder.build().await;

--- a/xmtp_mls/src/groups/device_sync/tests.rs
+++ b/xmtp_mls/src/groups/device_sync/tests.rs
@@ -7,7 +7,7 @@ use xmtp_db::{
 };
 
 #[rstest::rstest]
-#[xmtp_common::test(unwrap_try = "true")]
+#[xmtp_common::test(unwrap_try = true)]
 #[cfg_attr(target_arch = "wasm32", ignore)]
 async fn basic_sync() {
     tester!(alix1, sync_server, sync_worker, stream);
@@ -28,7 +28,7 @@ async fn basic_sync() {
 }
 
 #[rstest::rstest]
-#[xmtp_common::test(unwrap_try = "true")]
+#[xmtp_common::test(unwrap_try = true)]
 #[cfg(not(target_arch = "wasm32"))]
 async fn only_one_payload_sent() {
     use std::time::Duration;
@@ -51,7 +51,7 @@ async fn only_one_payload_sent() {
 }
 
 #[rstest::rstest]
-#[xmtp_common::test(unwrap_try = "true")]
+#[xmtp_common::test(unwrap_try = true)]
 async fn test_double_sync_works_fine() {
     tester!(alix1, sync_worker, sync_server);
     tester!(bo);
@@ -79,7 +79,7 @@ async fn test_double_sync_works_fine() {
 }
 
 #[rstest::rstest]
-#[xmtp_common::test(unwrap_try = "true")]
+#[xmtp_common::test(unwrap_try = true)]
 #[cfg_attr(target_arch = "wasm32", ignore)]
 async fn test_hmac_and_consent_prefrence_sync() {
     tester!(alix1, sync_worker, sync_server, stream);
@@ -126,7 +126,7 @@ async fn test_hmac_and_consent_prefrence_sync() {
 }
 
 #[rstest::rstest]
-#[xmtp_common::test(unwrap_try = "true")]
+#[xmtp_common::test(unwrap_try = true)]
 #[cfg_attr(target_arch = "wasm32", ignore)]
 async fn test_only_added_to_correct_groups() {
     use diesel::prelude::*;
@@ -198,7 +198,7 @@ async fn test_only_added_to_correct_groups() {
 }
 
 #[rstest::rstest]
-#[xmtp_common::test(unwrap_try = "true")]
+#[xmtp_common::test(unwrap_try = true)]
 #[timeout(std::time::Duration::from_secs(15))]
 #[cfg_attr(target_arch = "wasm32", ignore)]
 async fn test_new_devices_not_added_to_old_sync_groups() {

--- a/xmtp_mls/src/groups/device_sync_legacy.rs
+++ b/xmtp_mls/src/groups/device_sync_legacy.rs
@@ -601,7 +601,7 @@ mod tests {
     };
 
     #[rstest::rstest]
-    #[xmtp_common::test(unwrap_try = "true")]
+    #[xmtp_common::test(unwrap_try = true)]
     #[cfg_attr(target_arch = "wasm32", ignore)]
     async fn v1_sync_still_works() {
         tester!(alix1, sync_worker, sync_server);

--- a/xmtp_mls/src/groups/tests/test_consent.rs
+++ b/xmtp_mls/src/groups/tests/test_consent.rs
@@ -2,7 +2,7 @@ use xmtp_db::consent_record::ConsentState;
 
 use crate::tester;
 
-#[xmtp_common::test(unwrap_try = "true")]
+#[xmtp_common::test(unwrap_try = true)]
 async fn test_auto_consent_to_own_group() {
     tester!(alix1);
 

--- a/xmtp_mls/src/groups/tests/test_dm.rs
+++ b/xmtp_mls/src/groups/tests/test_dm.rs
@@ -5,7 +5,7 @@ use crate::tester;
 /// Test case: If two users are talking in a DM, and one user
 /// creates a new installation and creates a new DM before being
 /// welcomed into the old DM, that new DM group should be consented.
-#[xmtp_common::test(unwrap_try = "true")]
+#[xmtp_common::test(unwrap_try = true)]
 async fn auto_consent_dms_for_new_installations() {
     tester!(alix);
     tester!(bo1);

--- a/xmtp_mls/src/groups/tests/test_key_updates.rs
+++ b/xmtp_mls/src/groups/tests/test_key_updates.rs
@@ -5,7 +5,7 @@ use xmtp_common::{retry_async, Retry};
 use xmtp_db::events::Events;
 
 #[rstest::rstest]
-#[xmtp_common::test(unwrap_try = "true")]
+#[xmtp_common::test(unwrap_try = true)]
 #[cfg_attr(target_arch = "wasm32", ignore)]
 async fn test_key_rotation_with_optimistic_send() {
     tester!(alix, stream);
@@ -47,7 +47,7 @@ async fn test_key_rotation_with_optimistic_send() {
 }
 
 #[rstest::rstest]
-#[xmtp_common::test(unwrap_try = "true")]
+#[xmtp_common::test(unwrap_try = true)]
 #[cfg_attr(target_arch = "wasm32", ignore)]
 async fn key_update_out_of_epoch() {
     // Have bo join a group and immediately send several optimistic messages.

--- a/xmtp_mls/src/subscriptions/stream_conversations.rs
+++ b/xmtp_mls/src/subscriptions/stream_conversations.rs
@@ -473,7 +473,7 @@ mod test {
     }
 
     #[rstest::rstest]
-    #[xmtp_common::test(unwrap_try = "true")]
+    #[xmtp_common::test(unwrap_try = true)]
     async fn test_sync_groups_are_not_streamed() {
         tester!(alix, sync_worker);
         let stream = alix.stream_conversations(None).await?;

--- a/xmtp_mls/src/test/builder.rs
+++ b/xmtp_mls/src/test/builder.rs
@@ -223,7 +223,7 @@ async fn test_client_creation() {
     }
 }
 
-#[xmtp_common::test(unwrap_try = "true")]
+#[xmtp_common::test(unwrap_try = true)]
 async fn test_turn_local_telemetry_off() {
     let (legacy_key, legacy_account_address) = generate_random_legacy_key().await;
     let legacy_ident = Identifier::eth(&legacy_account_address).unwrap();

--- a/xmtp_mls/src/utils/events.rs
+++ b/xmtp_mls/src/utils/events.rs
@@ -36,7 +36,7 @@ mod tests {
     use crate::{configuration::DeviceSyncUrls, tester, utils::events::upload_debug_archive};
 
     #[rstest::rstest]
-    #[xmtp_common::test(unwrap_try = "true")]
+    #[xmtp_common::test(unwrap_try = true)]
     async fn test_debug_pkg() {
         tester!(alix, stream);
         tester!(bo);


### PR DESCRIPTION
### Change `unwrap_try` parameter type from string literal to boolean literal in `xmtp_common::test` macro and update all test function calls across the codebase
This change modifies the `xmtp_common::test` macro implementation to accept boolean literals instead of string literals for the `unwrap_try` parameter. The core change occurs in [xmtp_macro/src/lib.rs](https://github.com/xmtp/libxmtp/pull/2099/files#diff-0cb1b255666b7b161837f8c41c7d6adc3fffd5cb3e3eef3928235b4f7d23ce7e) where the `Attributes` struct's `unwrap_try` field type changes from `Option<syn::LitStr>` to `Option<syn::LitBool>`, and the corresponding method implementation is updated to use the boolean value directly. All test functions across multiple files are updated to pass `true` instead of `"true"` for the `unwrap_try` parameter, including files in the `xmtp_db`, `xmtp_mls` modules and their subdirectories.

#### 📍Where to Start
Start with the `Attributes` struct and its `unwrap_try()` method in [xmtp_macro/src/lib.rs](https://github.com/xmtp/libxmtp/pull/2099/files#diff-0cb1b255666b7b161837f8c41c7d6adc3fffd5cb3e3eef3928235b4f7d23ce7e) to understand the core macro implementation change.

----

_[Macroscope](https://app.macroscope.com) summarized 0c1f980._