### PR TITLE
enable quantum key packages

### DIFF
--- a/xmtp_mls/src/configuration.rs
+++ b/xmtp_mls/src/configuration.rs
@@ -37,7 +37,7 @@ pub const MAX_PAST_EPOCHS: usize = 3;
 /// we leave 5 * 1024 * 1024 as extra buffer room
 pub const GRPC_DATA_LIMIT: usize = 45 * 1024 * 1024;
 
-pub const CREATE_PQ_KEY_PACKAGE_EXTENSION: bool = false;
+pub const CREATE_PQ_KEY_PACKAGE_EXTENSION: bool = true;
 
 // If a metadata field name starts with this character,
 // and it does not have a policy set, it is a super admin only field


### PR DESCRIPTION
### Enable quantum key packages by changing CREATE_PQ_KEY_PACKAGE_EXTENSION constant from false to true in XMTP MLS configuration
Changes the `CREATE_PQ_KEY_PACKAGE_EXTENSION` constant value from `false` to `true` in [configuration.rs](https://github.com/xmtp/libxmtp/pull/2113/files#diff-80e1437765f38906f066439ad9805b99205fb55f992bceb400a9d091628b6942), which activates post-quantum key package extension creation in the XMTP MLS implementation.

#### 📍Where to Start
Start with the `CREATE_PQ_KEY_PACKAGE_EXTENSION` constant definition in [configuration.rs](https://github.com/xmtp/libxmtp/pull/2113/files#diff-80e1437765f38906f066439ad9805b99205fb55f992bceb400a9d091628b6942).

----

_[Macroscope](https://app.macroscope.com) summarized f681bff._