### PR TITLE
Revert "enable quantum key packages (#2113)"

### DIFF
--- a/xmtp_mls/src/configuration.rs
+++ b/xmtp_mls/src/configuration.rs
@@ -37,7 +37,7 @@ pub const MAX_PAST_EPOCHS: usize = 3;
 /// we leave 5 * 1024 * 1024 as extra buffer room
 pub const GRPC_DATA_LIMIT: usize = 45 * 1024 * 1024;
 
-pub const CREATE_PQ_KEY_PACKAGE_EXTENSION: bool = true;
+pub const CREATE_PQ_KEY_PACKAGE_EXTENSION: bool = false;
 
 // If a metadata field name starts with this character,
 // and it does not have a policy set, it is a super admin only field


### PR DESCRIPTION
@mchenani and @humanagent have been observing HPKE errors with this changeset that disappear without this changeset. Reverting for now.

This reverts commit 4776864d63349a26090e345f33ace32f7a3b2452.