### PR TITLE
remove type definition for default connection type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,9 +81,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "1.0.17"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d1aecf3cab3d0e7383064ce488616434b4ade10d8904dff422e74203c712f"
+checksum = "0093d23bf026b580c1f66ed3a053d8209c104a446c5264d3ad99587f6edef24e"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -533,7 +533,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -739,6 +739,15 @@ name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "anstream"
@@ -1677,7 +1686,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4340,7 +4349,7 @@ dependencies = [
  "openmls_rust_crypto",
  "parking_lot 0.12.4",
  "rand 0.8.5",
- "rstest",
+ "rstest 0.25.0",
  "thiserror 2.0.12",
  "tokio",
  "tonic",
@@ -4672,14 +4681,24 @@ name = "openmls"
 version = "0.6.1"
 source = "git+https://github.com/xmtp/openmls?rev=b18f5ca4cfc15a390fa914980267cc5028fc6b60#b18f5ca4cfc15a390fa914980267cc5028fc6b60"
 dependencies = [
+ "backtrace",
  "fluvio-wasm-timer",
  "getrandom 0.2.16",
+ "itertools 0.14.0",
  "log",
+ "once_cell",
+ "openmls_basic_credential",
+ "openmls_memory_storage",
+ "openmls_rust_crypto",
+ "openmls_test",
  "openmls_traits",
+ "rand 0.8.5",
  "rayon",
  "serde",
+ "serde_json",
  "thiserror 2.0.12",
  "tls_codec",
+ "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -4719,6 +4738,7 @@ name = "openmls_memory_storage"
 version = "0.3.0"
 source = "git+https://github.com/xmtp/openmls?rev=b18f5ca4cfc15a390fa914980267cc5028fc6b60#b18f5ca4cfc15a390fa914980267cc5028fc6b60"
 dependencies = [
+ "hex",
  "log",
  "openmls_traits",
  "serde",
@@ -4748,6 +4768,21 @@ dependencies = [
  "sha2",
  "thiserror 2.0.12",
  "tls_codec",
+]
+
+[[package]]
+name = "openmls_test"
+version = "0.1.0"
+source = "git+https://github.com/xmtp/openmls?rev=b18f5ca4cfc15a390fa914980267cc5028fc6b60#b18f5ca4cfc15a390fa914980267cc5028fc6b60"
+dependencies = [
+ "ansi_term",
+ "openmls_rust_crypto",
+ "openmls_traits",
+ "proc-macro2",
+ "quote",
+ "rstest 0.24.0",
+ "rstest_reuse",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -5413,8 +5448,8 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.13.0",
+ "heck 0.5.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -5434,7 +5469,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.102",
@@ -5826,14 +5861,44 @@ dependencies = [
 
 [[package]]
 name = "rstest"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03e905296805ab93e13c1ec3a03f4b6c4f35e9498a3d5fa96dc626d22c03cd89"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros 0.24.0",
+ "rustc_version 0.4.1",
+]
+
+[[package]]
+name = "rstest"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
 dependencies = [
  "futures-timer",
  "futures-util",
- "rstest_macros",
+ "rstest_macros 0.25.0",
  "rustc_version 0.4.1",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef0053bbffce09062bee4bcc499b0fbe7a57b879f1efe088d6d8d4c7adcdef9b"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version 0.4.1",
+ "syn 2.0.102",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -7151,7 +7216,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 [[package]]
 name = "toxiproxy_rust"
 version = "0.1.6"
-source = "git+https://github.com/ephemeraHQ/toxiproxy_rust.git#7620d968f41052c979cf228fa661ce6a4fa2c7fc"
+source = "git+https://github.com/ephemeraHQ/toxiproxy_rust.git#b82f61cbc44a2ddcca0bcfd31f0406df7fc16af8"
 dependencies = [
  "http 0.2.12",
  "lazy_static",
@@ -8064,7 +8129,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8763,7 +8828,7 @@ dependencies = [
  "p256",
  "prost",
  "regex",
- "rstest",
+ "rstest 0.25.0",
  "serde",
  "serde_json",
  "sha2",
@@ -8833,7 +8898,7 @@ dependencies = [
  "public-suffix",
  "rand 0.8.5",
  "reqwest 0.12.19",
- "rstest",
+ "rstest 0.25.0",
  "rstest_reuse",
  "serde",
  "serde_json",

--- a/deny.toml
+++ b/deny.toml
@@ -3,6 +3,7 @@ ignore = [
   { id = "RUSTSEC-2024-0384", reason = "need to upgrade openmls" },
   { id = "RUSTSEC-2024-0436", reason = "required by uniffi" },
   { id = "RUSTSEC-2024-0370", reason = "proc-macro-error is a dependency of libcrux" },
+  { id = "RUSTSEC-2021-0139", reason = "ansi_term is only used in tests" },
 ]
 
 # This rustsec can be added to ignore list if using mls `test_utils` for tests

--- a/nix/libxmtp.nix
+++ b/nix/libxmtp.nix
@@ -11,8 +11,8 @@
 , gnuplot
 , flamegraph
 , cargo-flamegraph
-, cargo-udeps
 , cargo-nextest
+, cargo-deny
 , inferno
 , openssl
 , sqlcipher
@@ -81,7 +81,7 @@ mkShell ({
       # tokio-console
       gnuplot
       flamegraph
-      cargo-udeps
+      cargo-deny
       cargo-flamegraph
       cargo-nextest
       inferno

--- a/xmtp_archive/src/exporter.rs
+++ b/xmtp_archive/src/exporter.rs
@@ -40,9 +40,9 @@ pub(super) enum Stage {
 
 impl ArchiveExporter {
     #[cfg(not(target_arch = "wasm32"))]
-    pub async fn export_to_file(
+    pub async fn export_to_file<C: 'static + Send + Sync + ConnectionExt>(
         options: BackupOptions,
-        provider: XmtpOpenMlsProvider,
+        provider: XmtpOpenMlsProvider<C>,
         path: impl AsRef<std::path::Path>,
         key: &[u8],
     ) -> Result<(), crate::ArchiveError> {

--- a/xmtp_db/Cargo.toml
+++ b/xmtp_db/Cargo.toml
@@ -20,7 +20,6 @@ ctor.workspace = true
 derive_builder.workspace = true
 diesel_migrations = { workspace = true, features = ["sqlite"] }
 hex.workspace = true
-mockall.workspace = true
 openmls.workspace = true
 openmls_basic_credential.workspace = true
 openmls_rust_crypto.workspace = true
@@ -36,6 +35,7 @@ xmtp_common.workspace = true
 xmtp_proto.workspace = true
 zeroize.workspace = true
 
+mockall = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true, features = [
   "macros",
   "tracing",
@@ -76,6 +76,7 @@ wasm-bindgen = { workspace = true }
 
 [dev-dependencies]
 futures-timer.workspace = true
+mockall = { workspace = true }
 xmtp_common = { workspace = true, features = ["test-utils"] }
 xmtp_cryptography.workspace = true
 
@@ -92,4 +93,4 @@ wasm-bindgen-test.workspace = true
 
 [features]
 update-schema = ["dep:toml"]
-test-utils = ["xmtp_common/test-utils"]
+test-utils = ["xmtp_common/test-utils", "dep:mockall"]

--- a/xmtp_db/src/encrypted_store/database.rs
+++ b/xmtp_db/src/encrypted_store/database.rs
@@ -20,27 +20,12 @@ use super::{ConnectionExt, TransactionGuard};
 pub mod wasm_exports {
     pub type RawDbConnection = diesel::prelude::SqliteConnection;
     pub type DefaultDatabase = super::wasm::WasmDb;
-
-    pub(super) type DefaultConnectionInner =
-        super::PersistentOrMem<super::wasm::WasmDbConnection, super::wasm::WasmDbConnection>;
-
-    pub type DefaultConnection = std::sync::Arc<DefaultConnectionInner>;
 }
 
 #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 pub mod native_exports {
     pub type DefaultDatabase = super::native::NativeDb;
     pub use super::native::EncryptedConnection;
-    /// The 'inner' default connection
-    /// 'DefaultConnection' is preferred here
-    pub(super) type DefaultConnectionInner = super::PersistentOrMem<
-        super::native::NativeDbConnection,
-        super::native::EphemeralDbConnection,
-    >;
-
-    // the native module already defines this
-    // pub type RawDbConnection = native::RawDbConnection;
-    pub type DefaultConnection = std::sync::Arc<DefaultConnectionInner>;
 }
 
 #[derive(Debug)]
@@ -90,6 +75,20 @@ where
         match self {
             Self::Persistent(p) => p.is_in_transaction(),
             Self::Mem(m) => m.is_in_transaction(),
+        }
+    }
+
+    fn disconnect(&self) -> Result<(), crate::ConnectionError> {
+        match self {
+            Self::Persistent(p) => p.disconnect(),
+            Self::Mem(m) => m.disconnect(),
+        }
+    }
+
+    fn reconnect(&self) -> Result<(), crate::ConnectionError> {
+        match self {
+            Self::Persistent(p) => p.reconnect(),
+            Self::Mem(m) => m.reconnect(),
         }
     }
 }

--- a/xmtp_db/src/encrypted_store/db_connection.rs
+++ b/xmtp_db/src/encrypted_store/db_connection.rs
@@ -4,11 +4,8 @@ use std::fmt;
 use super::{ConnectionExt, TransactionGuard};
 
 /// A wrapper for RawDbConnection that houses all XMTP DB operations.
-/// Uses a [`Mutex]` internally for interior mutability, so that the connection
-/// and transaction state can be shared between the OpenMLS Provider and
-/// native XMTP operations
-pub struct DbConnection<C = crate::DefaultConnection> {
-    conn: C,
+pub struct DbConnection<C> {
+    pub(super) conn: C,
 }
 
 impl<C> DbConnection<C> {
@@ -68,6 +65,14 @@ where
 
     fn is_in_transaction(&self) -> bool {
         self.conn.is_in_transaction()
+    }
+
+    fn disconnect(&self) -> Result<(), crate::ConnectionError> {
+        self.conn.disconnect()
+    }
+
+    fn reconnect(&self) -> Result<(), crate::ConnectionError> {
+        self.conn.reconnect()
     }
 }
 

--- a/xmtp_db/src/encrypted_store/events.rs
+++ b/xmtp_db/src/encrypted_store/events.rs
@@ -132,7 +132,9 @@ impl Events {
         })
     }
 
-    pub fn all_events(db: &DbConnection) -> Result<Vec<Self>, crate::ConnectionError> {
+    pub fn all_events<C: ConnectionExt>(
+        db: &DbConnection<C>,
+    ) -> Result<Vec<Self>, crate::ConnectionError> {
         db.raw_query_read(|db| dsl::events.load(db))
     }
 
@@ -148,7 +150,9 @@ impl Events {
         db.raw_query_read(|db| query.load(db))
     }
 
-    pub fn key_updates(db: &DbConnection) -> Result<Vec<Self>, crate::ConnectionError> {
+    pub fn key_updates<C: ConnectionExt>(
+        db: &DbConnection<C>,
+    ) -> Result<Vec<Self>, crate::ConnectionError> {
         db.raw_query_read(|db| {
             let query = dsl::events.filter(diesel::dsl::sql::<diesel::sql_types::Bool>(
                 "jsonb_extract(details, '$.intent_kind') = 'KeyUpdate'",

--- a/xmtp_db/src/encrypted_store/group_intent.rs
+++ b/xmtp_db/src/encrypted_store/group_intent.rs
@@ -117,7 +117,7 @@ impl std::fmt::Debug for StoredGroupIntent {
 
 impl_fetch!(StoredGroupIntent, group_intents, ID);
 
-impl Delete<StoredGroupIntent> for DbConnection {
+impl<C: ConnectionExt> Delete<StoredGroupIntent> for DbConnection<C> {
     type Key = ID;
     fn delete(&self, key: ID) -> Result<usize, StorageError> {
         Ok(self.raw_query_write(|raw_conn| {
@@ -433,7 +433,7 @@ pub(crate) mod tests {
     };
     use xmtp_common::rand_vec;
 
-    fn insert_group(conn: &DbConnection, group_id: Vec<u8>) {
+    fn insert_group<C: ConnectionExt>(conn: &DbConnection<C>, group_id: Vec<u8>) {
         StoredGroup::builder()
             .id(group_id)
             .created_at_ns(100)
@@ -464,7 +464,10 @@ pub(crate) mod tests {
         }
     }
 
-    fn find_first_intent(conn: &DbConnection, group_id: group::ID) -> StoredGroupIntent {
+    fn find_first_intent<C: ConnectionExt>(
+        conn: &DbConnection<C>,
+        group_id: group::ID,
+    ) -> StoredGroupIntent {
         conn.raw_query_read(|raw_conn| {
             dsl::group_intents
                 .filter(dsl::group_id.eq(group_id))

--- a/xmtp_db/src/encrypted_store/icebox.rs
+++ b/xmtp_db/src/encrypted_store/icebox.rs
@@ -1,4 +1,4 @@
-use super::db_connection::DbConnection;
+use super::{ConnectionExt, db_connection::DbConnection};
 use crate::{impl_store, schema::icebox};
 use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -28,8 +28,8 @@ pub struct Icebox {
 impl_store!(Icebox, icebox);
 
 impl Icebox {
-    pub fn backward_dep_chain(
-        conn: &DbConnection,
+    pub fn backward_dep_chain<C: ConnectionExt>(
+        conn: &DbConnection<C>,
         sequence_id: i64,
         originator_id: i64,
     ) -> Result<Vec<Self>, crate::ConnectionError> {
@@ -59,8 +59,8 @@ impl Icebox {
         conn.raw_query_read(|conn| query.load(conn))
     }
 
-    pub fn forward_dep_chain(
-        conn: &DbConnection,
+    pub fn forward_dep_chain<C: ConnectionExt>(
+        conn: &DbConnection<C>,
         sequence_id: i64,
         originator_id: i64,
     ) -> Result<Vec<Self>, crate::ConnectionError> {

--- a/xmtp_db/src/encrypted_store/key_store_entry.rs
+++ b/xmtp_db/src/encrypted_store/key_store_entry.rs
@@ -14,7 +14,7 @@ pub struct StoredKeyStoreEntry {
 impl_fetch!(StoredKeyStoreEntry, openmls_key_store, Vec<u8>);
 impl_store!(StoredKeyStoreEntry, openmls_key_store);
 
-impl Delete<StoredKeyStoreEntry> for DbConnection {
+impl<C: ConnectionExt> Delete<StoredKeyStoreEntry> for DbConnection<C> {
     type Key = Vec<u8>;
     fn delete(&self, key: Vec<u8>) -> Result<usize, StorageError> where {
         use super::schema::openmls_key_store::dsl::*;

--- a/xmtp_db/src/encrypted_store/mod.rs
+++ b/xmtp_db/src/encrypted_store/mod.rs
@@ -128,6 +128,9 @@ pub trait ConnectionExt {
         Self: Sized;
 
     fn is_in_transaction(&self) -> bool;
+
+    fn disconnect(&self) -> Result<(), ConnectionError>;
+    fn reconnect(&self) -> Result<(), ConnectionError>;
 }
 
 impl<C> ConnectionExt for &C
@@ -159,6 +162,14 @@ where
     fn is_in_transaction(&self) -> bool {
         <C as ConnectionExt>::is_in_transaction(self)
     }
+
+    fn disconnect(&self) -> Result<(), ConnectionError> {
+        <C as ConnectionExt>::disconnect(self)
+    }
+
+    fn reconnect(&self) -> Result<(), ConnectionError> {
+        <C as ConnectionExt>::reconnect(self)
+    }
 }
 
 impl<C> ConnectionExt for Arc<C>
@@ -189,6 +200,14 @@ where
 
     fn is_in_transaction(&self) -> bool {
         <C as ConnectionExt>::is_in_transaction(self)
+    }
+
+    fn disconnect(&self) -> Result<(), ConnectionError> {
+        <C as ConnectionExt>::disconnect(self)
+    }
+
+    fn reconnect(&self) -> Result<(), ConnectionError> {
+        <C as ConnectionExt>::reconnect(self)
     }
 }
 
@@ -332,12 +351,12 @@ macro_rules! impl_store_or_ignore {
     };
 }
 
-impl<T> Store<DbConnection> for Vec<T>
+impl<T, C> Store<DbConnection<C>> for Vec<T>
 where
-    T: Store<DbConnection>,
+    T: Store<DbConnection<C>>,
 {
     type Output = ();
-    fn store(&self, into: &DbConnection) -> Result<Self::Output, StorageError> {
+    fn store(&self, into: &DbConnection<C>) -> Result<Self::Output, StorageError> {
         for item in self {
             item.store(into)?;
         }

--- a/xmtp_db/src/mock.rs
+++ b/xmtp_db/src/mock.rs
@@ -11,10 +11,23 @@ use parking_lot::Mutex;
 
 use crate::{ConnectionError, ConnectionExt, TransactionGuard};
 
+#[derive(Clone)]
 pub struct MockConnection {
     inner: Arc<Mutex<SqliteConnection>>,
     in_transaction: Arc<AtomicBool>,
     transaction_lock: Arc<Mutex<()>>,
+}
+
+impl std::fmt::Debug for MockConnection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "MockConnection")
+    }
+}
+
+impl AsRef<MockConnection> for MockConnection {
+    fn as_ref(&self) -> &MockConnection {
+        self
+    }
 }
 
 // TODO: We should use diesels test transaction
@@ -53,6 +66,14 @@ impl ConnectionExt for MockConnection {
 
     fn is_in_transaction(&self) -> bool {
         self.in_transaction.load(Ordering::SeqCst)
+    }
+
+    fn disconnect(&self) -> Result<(), ConnectionError> {
+        Ok(())
+    }
+
+    fn reconnect(&self) -> Result<(), ConnectionError> {
+        Ok(())
     }
 }
 /*

--- a/xmtp_db/src/sql_key_store.rs
+++ b/xmtp_db/src/sql_key_store.rs
@@ -26,7 +26,7 @@ struct StorageData {
     value_bytes: Vec<u8>,
 }
 
-pub struct SqlKeyStore<C = crate::DefaultConnection> {
+pub struct SqlKeyStore<C> {
     // Directly wrap the DbConnection which is a SqliteConnection in this case
     conn: DbConnection<C>,
 }
@@ -40,6 +40,10 @@ impl<C> SqlKeyStore<C> {
 
     pub fn db(&self) -> &DbConnection<C> {
         &self.conn
+    }
+
+    pub fn with_connection(db: DbConnection<C>) -> Self {
+        Self { conn: db }
     }
 }
 

--- a/xmtp_db/src/test_utils.rs
+++ b/xmtp_db/src/test_utils.rs
@@ -44,6 +44,8 @@ pub use wasm::*;
 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
 mod wasm {
     use super::*;
+    use crate::{PersistentOrMem, WasmDbConnection};
+    use std::sync::Arc;
 
     impl XmtpTestDb for super::TestDb {
         async fn create_ephemeral_store() -> EncryptedMessageStore<crate::DefaultDatabase> {
@@ -74,7 +76,9 @@ mod wasm {
     /// Test harness that loads an Ephemeral store.
     pub async fn with_connection<F, R>(fun: F) -> R
     where
-        F: FnOnce(&crate::DbConnection) -> R,
+        F: FnOnce(
+            &crate::DbConnection<Arc<PersistentOrMem<WasmDbConnection, WasmDbConnection>>>,
+        ) -> R,
     {
         let db = crate::database::WasmDb::new(&StorageOption::Ephemeral)
             .await
@@ -87,7 +91,9 @@ mod wasm {
     /// Test harness that loads an Ephemeral store.
     pub async fn with_connection_async<F, T, R>(fun: F) -> R
     where
-        F: FnOnce(crate::DbConnection) -> T,
+        F: FnOnce(
+            crate::DbConnection<Arc<PersistentOrMem<WasmDbConnection, WasmDbConnection>>>,
+        ) -> T,
         T: Future<Output = R>,
     {
         let db = crate::database::WasmDb::new(&StorageOption::Ephemeral)
@@ -119,6 +125,10 @@ mod wasm {
 pub use native::*;
 #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 mod native {
+    use std::sync::Arc;
+
+    use crate::{EphemeralDbConnection, NativeDbConnection, PersistentOrMem};
+
     use super::*;
 
     impl XmtpTestDb for super::TestDb {
@@ -144,7 +154,9 @@ mod native {
     /// Test harness that loads an Ephemeral store.
     pub async fn with_connection<F, R>(fun: F) -> R
     where
-        F: FnOnce(&crate::DbConnection) -> R,
+        F: FnOnce(
+            &crate::DbConnection<Arc<PersistentOrMem<NativeDbConnection, EphemeralDbConnection>>>,
+        ) -> R,
     {
         let opts = StorageOption::Ephemeral;
         let db = crate::database::NativeDb::new_unencrypted(&opts).unwrap();
@@ -156,7 +168,9 @@ mod native {
     /// Test harness that loads an Ephemeral store.
     pub async fn with_connection_async<F, T, R>(fun: F) -> R
     where
-        F: FnOnce(crate::DbConnection) -> T,
+        F: FnOnce(
+            crate::DbConnection<Arc<PersistentOrMem<NativeDbConnection, EphemeralDbConnection>>>,
+        ) -> T,
         T: Future<Output = R>,
     {
         let opts = StorageOption::Ephemeral;

--- a/xmtp_db/src/xmtp_openmls_provider.rs
+++ b/xmtp_db/src/xmtp_openmls_provider.rs
@@ -5,7 +5,7 @@ use diesel::connection::TransactionManager;
 use openmls_rust_crypto::RustCrypto;
 use openmls_traits::OpenMlsProvider;
 
-pub struct XmtpOpenMlsProvider<C = crate::DefaultConnection> {
+pub struct XmtpOpenMlsProvider<C> {
     crypto: RustCrypto,
     key_store: SqlKeyStore<C>,
 }
@@ -15,6 +15,13 @@ impl<C> XmtpOpenMlsProvider<C> {
         Self {
             crypto: RustCrypto::default(),
             key_store: SqlKeyStore::new(conn),
+        }
+    }
+
+    pub fn with_connection(conn: DbConnection<C>) -> Self {
+        Self {
+            crypto: RustCrypto::default(),
+            key_store: SqlKeyStore::with_connection(conn),
         }
     }
 }
@@ -67,7 +74,7 @@ where
     }
 }
 
-impl XmtpOpenMlsProvider {
+impl<C> XmtpOpenMlsProvider<C> {
     pub fn new_crypto() -> RustCrypto {
         RustCrypto::default()
     }

--- a/xmtp_db_test/src/chaos.rs
+++ b/xmtp_db_test/src/chaos.rs
@@ -287,4 +287,12 @@ where
     fn is_in_transaction(&self) -> bool {
         self.db.is_in_transaction()
     }
+
+    fn disconnect(&self) -> Result<(), xmtp_db::ConnectionError> {
+        self.db.disconnect()
+    }
+
+    fn reconnect(&self) -> Result<(), xmtp_db::ConnectionError> {
+        self.db.reconnect()
+    }
 }

--- a/xmtp_db_test/src/lib.rs
+++ b/xmtp_db_test/src/lib.rs
@@ -3,8 +3,6 @@ use xmtp_db::{ConnectionError, DbConnection, DefaultDatabase, StorageOption, Xmt
 
 pub mod chaos;
 
-pub type ChaosConnection = chaos::ChaosConnection<xmtp_db::DefaultConnection>;
-
 #[derive(Clone)]
 pub struct ChaosDb<Db = DefaultDatabase>
 where

--- a/xmtp_mls/Cargo.toml
+++ b/xmtp_mls/Cargo.toml
@@ -153,6 +153,7 @@ futures-test = "0.3.31"
 futures-timer.workspace = true
 mockall.workspace = true
 once_cell.workspace = true
+openmls = { workspace = true, features = ["test-utils"] }
 openmls_basic_credential.workspace = true
 passkey = { version = "0.4" }
 public-suffix = { version = "0.1.2" }

--- a/xmtp_mls/src/groups/device_sync_legacy.rs
+++ b/xmtp_mls/src/groups/device_sync_legacy.rs
@@ -204,9 +204,9 @@ where
     }
 
     #[cfg(test)]
-    async fn v1_get_latest_sync_reply(
+    async fn v1_get_latest_sync_reply<C: xmtp_db::ConnectionExt>(
         &self,
-        provider: &XmtpOpenMlsProvider,
+        provider: &XmtpOpenMlsProvider<C>,
         kind: BackupElementSelection,
     ) -> Result<Option<(StoredGroupMessage, DeviceSyncReplyProto)>, DeviceSyncError> {
         let sync_group = self.get_sync_group().await?;

--- a/xmtp_mls/src/groups/mls_ext/welcome_wrapper.rs
+++ b/xmtp_mls/src/groups/mls_ext/welcome_wrapper.rs
@@ -147,8 +147,8 @@ mod tests {
 
     use super::*;
 
-    fn find_key_package_private_key(
-        provider: &XmtpOpenMlsProvider,
+    fn find_key_package_private_key<C: xmtp_db::ConnectionExt>(
+        provider: &XmtpOpenMlsProvider<C>,
         hpke_public_key: &[u8],
         wrapper_algorithm: WrapperAlgorithm,
     ) -> Vec<u8> {

--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -1,6 +1,6 @@
 use super::{
     build_extensions_for_admin_lists_update, build_extensions_for_metadata_update,
-    build_extensions_for_permissions_update, build_group_membership_extension,
+    build_extensions_for_permissions_update,
     intents::{
         Installation, IntentError, PostCommitAction, SendMessageIntentData, SendWelcomesAction,
         UpdateAdminListIntentData, UpdateGroupMembershipIntentData, UpdatePermissionIntentData,
@@ -77,7 +77,7 @@ use openmls::{
     treesync::LeafNodeParameters,
 };
 use openmls::{framing::WireFormat, prelude::BasicCredentialError};
-use openmls_traits::{signatures::Signer, OpenMlsProvider};
+use openmls_traits::OpenMlsProvider;
 use prost::bytes::Bytes;
 use prost::Message;
 use sha2::Sha256;
@@ -110,6 +110,8 @@ use xmtp_proto::xmtp::mls::{
         GroupUpdated, PlaintextEnvelope,
     },
 };
+mod update_group_membership;
+use update_group_membership::apply_update_group_membership_intent;
 
 #[derive(Debug, Error)]
 pub enum GroupMessageProcessingError {
@@ -2634,91 +2636,6 @@ where
         )
         .await
         .map_err(Into::into)
-}
-
-// Takes UpdateGroupMembershipIntentData and applies it to the openmls group
-// returning the commit and post_commit_action
-#[tracing::instrument(level = "trace", skip_all)]
-async fn apply_update_group_membership_intent<ApiClient, Db>(
-    context: &Arc<XmtpMlsLocalContext<ApiClient, Db>>,
-    openmls_group: &mut OpenMlsGroup,
-    intent_data: UpdateGroupMembershipIntentData,
-    signer: impl Signer,
-) -> Result<Option<PublishIntentData>, GroupError>
-where
-    ApiClient: XmtpApi,
-    Db: XmtpDb,
-{
-    let provider = context.mls_provider();
-    let extensions: Extensions = openmls_group.extensions().clone();
-    let old_group_membership = extract_group_membership(&extensions)?;
-    let new_group_membership = intent_data.apply_to_group_membership(&old_group_membership);
-    let membership_diff = old_group_membership.diff(&new_group_membership);
-
-    let changes_with_kps = calculate_membership_changes_with_keypackages(
-        context.clone(),
-        &new_group_membership,
-        &old_group_membership,
-    )
-    .await?;
-    let leaf_nodes_to_remove: Vec<LeafNodeIndex> =
-        get_removed_leaf_nodes(openmls_group, &changes_with_kps.removed_installations);
-
-    if leaf_nodes_to_remove.contains(&openmls_group.own_leaf_index()) {
-        tracing::info!("Cannot remove own leaf node");
-        return Ok(None);
-    }
-
-    if leaf_nodes_to_remove.is_empty()
-        && changes_with_kps.new_key_packages.is_empty()
-        && membership_diff.updated_inboxes.is_empty()
-    {
-        return Ok(None);
-    }
-
-    // Update the extensions to have the new GroupMembership
-    let mut new_extensions = extensions.clone();
-
-    new_extensions.add_or_replace(build_group_membership_extension(&new_group_membership));
-
-    let result = provider.transaction(|provider| {
-        // Create the commit
-        let (commit, maybe_welcome_message, _) = openmls_group.update_group_membership(
-            &provider,
-            &signer,
-            &changes_with_kps.new_key_packages,
-            &leaf_nodes_to_remove,
-            new_extensions,
-        )?;
-
-        let post_commit_action = match maybe_welcome_message {
-            Some(welcome_message) => Some(PostCommitAction::from_welcome(
-                welcome_message,
-                changes_with_kps.new_installations,
-            )?),
-            None => None,
-        };
-
-        let staged_commit = get_and_clear_pending_commit(openmls_group, provider)?
-            .ok_or_else(|| GroupError::MissingPendingCommit)?;
-
-        Ok::<_, GroupError>((commit, post_commit_action, staged_commit))
-    });
-
-    let (commit, post_commit_action, staged_commit) = match result {
-        Ok(res) => res,
-        Err(e) => {
-            openmls_group.reload(&provider)?;
-            return Err(e);
-        }
-    };
-
-    Ok(Some(PublishIntentData {
-        payload_to_publish: commit.tls_serialize_detached()?,
-        post_commit_action: post_commit_action.map(|action| action.to_bytes()),
-        staged_commit: Some(staged_commit),
-        should_send_push_notification: false,
-    }))
 }
 
 fn get_removed_leaf_nodes(

--- a/xmtp_mls/src/groups/mls_sync/update_group_membership.rs
+++ b/xmtp_mls/src/groups/mls_sync/update_group_membership.rs
@@ -1,0 +1,91 @@
+use super::*;
+use crate::context::XmtpContextProvider;
+use crate::context::XmtpSharedContext;
+use crate::groups::{
+    build_group_membership_extension,
+    intents::{PostCommitAction, UpdateGroupMembershipIntentData},
+    validated_commit::extract_group_membership,
+    GroupError,
+};
+use openmls::{
+    extensions::Extensions,
+    prelude::{tls_codec::Serialize, LeafNodeIndex, MlsGroup as OpenMlsGroup},
+};
+use openmls_traits::signatures::Signer;
+use xmtp_db::MlsProviderExt;
+
+// Takes UpdateGroupMembershipIntentData and applies it to the openmls group
+// returning the commit and post_commit_action
+#[tracing::instrument(level = "trace", skip_all)]
+pub async fn apply_update_group_membership_intent<Context>(
+    context: Context,
+    openmls_group: &mut OpenMlsGroup,
+    intent_data: UpdateGroupMembershipIntentData,
+    signer: impl Signer,
+) -> Result<Option<PublishIntentData>, GroupError>
+where
+    Context: XmtpSharedContext + XmtpContextProvider,
+{
+    let provider = context.mls_provider();
+    let extensions: Extensions = openmls_group.extensions().clone();
+    let old_group_membership = extract_group_membership(&extensions)?;
+    let new_group_membership = intent_data.apply_to_group_membership(&old_group_membership);
+    let membership_diff = old_group_membership.diff(&new_group_membership);
+
+    let changes_with_kps = calculate_membership_changes_with_keypackages(
+        XmtpSharedContext::context_ref(&context).clone(),
+        &new_group_membership,
+        &old_group_membership,
+    )
+    .await?;
+    let leaf_nodes_to_remove: Vec<LeafNodeIndex> =
+        get_removed_leaf_nodes(openmls_group, &changes_with_kps.removed_installations);
+
+    if leaf_nodes_to_remove.contains(&openmls_group.own_leaf_index()) {
+        tracing::info!("Cannot remove own leaf node");
+        return Ok(None);
+    }
+
+    if leaf_nodes_to_remove.is_empty()
+        && changes_with_kps.new_key_packages.is_empty()
+        && membership_diff.updated_inboxes.is_empty()
+    {
+        return Ok(None);
+    }
+
+    // Update the extensions to have the new GroupMembership
+    let mut new_extensions = extensions.clone();
+
+    new_extensions.add_or_replace(build_group_membership_extension(&new_group_membership));
+
+    let (commit, post_commit_action, staged_commit) = provider.transaction(|provider| {
+        // Create the commit
+        let (commit, maybe_welcome_message, _) = openmls_group.update_group_membership(
+            &provider,
+            &signer,
+            &changes_with_kps.new_key_packages,
+            &leaf_nodes_to_remove,
+            new_extensions,
+        )?;
+
+        let post_commit_action = match maybe_welcome_message {
+            Some(welcome_message) => Some(PostCommitAction::from_welcome(
+                welcome_message,
+                changes_with_kps.new_installations,
+            )?),
+            None => None,
+        };
+
+        let staged_commit = get_and_clear_pending_commit(openmls_group, provider)?
+            .ok_or_else(|| GroupError::MissingPendingCommit)?;
+
+        Ok::<_, GroupError>((commit, post_commit_action, staged_commit))
+    })?;
+
+    Ok(Some(PublishIntentData {
+        payload_to_publish: commit.tls_serialize_detached()?,
+        post_commit_action: post_commit_action.map(|action| action.to_bytes()),
+        staged_commit: Some(staged_commit),
+        should_send_push_notification: false,
+    }))
+}

--- a/xmtp_mls/src/groups/tests/mod.rs
+++ b/xmtp_mls/src/groups/tests/mod.rs
@@ -77,12 +77,12 @@ async fn get_latest_message(group: &ConcreteMlsGroup) -> StoredGroupMessage {
 // Adds a member to the group without the usual validations on group membership
 // Used for testing adversarial scenarios
 #[cfg(not(target_arch = "wasm32"))]
-async fn force_add_member(
+async fn force_add_member<C: xmtp_db::ConnectionExt>(
     sender_client: &FullXmtpClient,
     new_member_client: &FullXmtpClient,
     sender_group: &ConcreteMlsGroup,
     sender_mls_group: &mut openmls::prelude::MlsGroup,
-    sender_provider: &XmtpOpenMlsProvider,
+    sender_provider: &XmtpOpenMlsProvider<C>,
 ) {
     use crate::{
         configuration::CREATE_PQ_KEY_PACKAGE_EXTENSION, groups::mls_ext::WrapperAlgorithm,
@@ -1054,7 +1054,7 @@ async fn test_key_update() {
         .unwrap();
     assert_eq!(messages.len(), 2);
 
-    let provider: XmtpOpenMlsProvider = client.context.db().into();
+    let provider: XmtpOpenMlsProvider<_> = client.context.db().into();
     let pending_commit_is_none = group
         .load_mls_group_with_lock(&provider, |mls_group| {
             Ok(mls_group.pending_commit().is_none())
@@ -1216,7 +1216,7 @@ async fn test_add_missing_installations() {
 
     assert_eq!(group.members().await.unwrap().len(), 2);
 
-    let provider: XmtpOpenMlsProvider = amal.mls_provider();
+    let provider = amal.mls_provider();
     // Finished with setup
 
     // add a second installation for amal using the same wallet

--- a/xmtp_mls/src/mls_store.rs
+++ b/xmtp_mls/src/mls_store.rs
@@ -109,7 +109,7 @@ where
             .fetch_key_packages(installation_ids.clone())
             .await?;
 
-        let crypto_provider = XmtpOpenMlsProvider::new_crypto();
+        let crypto_provider = XmtpOpenMlsProvider::<()>::new_crypto();
 
         let results: HashMap<Vec<u8>, Result<VerifiedKeyPackageV2, KeyPackageVerificationError>> =
             key_package_results

--- a/xmtp_mls/src/utils/events.rs
+++ b/xmtp_mls/src/utils/events.rs
@@ -16,7 +16,7 @@ use xmtp_archive::exporter::ArchiveExporter;
 use xmtp_common::time::now_ns;
 use xmtp_db::{
     events::{EventLevel, Events, EVENTS_ENABLED},
-    StorageError, Store, XmtpDb, XmtpOpenMlsProvider,
+    ConnectionExt, StorageError, Store, XmtpDb, XmtpOpenMlsProvider,
 };
 use xmtp_proto::xmtp::device_sync::{BackupElementSelection, BackupOptions};
 
@@ -359,8 +359,8 @@ where
     }
 }
 
-pub async fn upload_debug_archive(
-    provider: &Arc<XmtpOpenMlsProvider>,
+pub async fn upload_debug_archive<C: 'static + Send + Sync + ConnectionExt>(
+    provider: &Arc<XmtpOpenMlsProvider<C>>,
     device_sync_server_url: Option<impl AsRef<str>>,
 ) -> Result<String, DeviceSyncError> {
     let provider = provider.clone();

--- a/xmtp_mls/src/utils/test/tester_utils.rs
+++ b/xmtp_mls/src/utils/test/tester_utils.rs
@@ -60,7 +60,7 @@ where
 {
     pub builder: TesterBuilder<Owner>,
     pub client: Arc<Client>,
-    pub provider: Arc<XmtpOpenMlsProvider>,
+    pub provider: Arc<XmtpOpenMlsProvider<<xmtp_db::DefaultStore as xmtp_db::XmtpDb>::Connection>>,
     pub worker: Option<Arc<WorkerMetrics<SyncMetric>>>,
     pub stream_handle: Option<Box<dyn StreamHandle<StreamOutput = Result<(), SubscribeError>>>>,
     pub proxy: Option<Proxy>,
@@ -226,6 +226,12 @@ where
         );
         let handle = Box::new(handle) as Box<_>;
         self.stream_handle = Some(handle);
+    }
+
+    fn provider(
+        &self,
+    ) -> XmtpOpenMlsProvider<<xmtp_db::DefaultStore as xmtp_db::XmtpDb>::Connection> {
+        self.client.mls_provider()
     }
 }
 


### PR DESCRIPTION
### Remove type definition for default connection type and make database connection handling generic across XMTP components
This pull request removes the `DefaultConnectionInner` and `DefaultConnection` type definitions and makes database connection handling generic across XMTP components. The changes convert structs like `XmtpOpenMlsProvider`, `SqlKeyStore`, and `DbConnection` from using concrete connection types to being generic over any type implementing the `ConnectionExt` trait. The `ConnectionExt` trait is extended with new `disconnect()` and `reconnect()` methods that are implemented across all connection types including native, WASM, mock, and chaos connections. Functions throughout the codebase are updated to accept generic connection parameters rather than concrete types, improving flexibility in database connection management.

#### 📍Where to Start
Start with the `ConnectionExt` trait definition in [xmtp_db/src/encrypted_store/mod.rs](https://github.com/xmtp/libxmtp/pull/2118/files#diff-7c11a42d3a8d1e571eea6a833dfe388063c036317c4d7a6fbce207fbb3beb387) to understand the new trait methods, then examine the removal of type definitions in [xmtp_db/src/encrypted_store/database.rs](https://github.com/xmtp/libxmtp/pull/2118/files#diff-9f8d2de22d0a8889381d9e0bd7a4c3cf5be3ffc583d7ad07548c2deb498253af).

----

_[Macroscope](https://app.macroscope.com) summarized 08b4283._