### PR TITLE
Ignore unknown fields in proto deserialization

### DIFF
--- a/dev/up
+++ b/dev/up
@@ -29,5 +29,21 @@ else
     echo "rustup is not installed, rust may not be up to date"
 fi
 
+WASM_TARGET="wasm32-unknown-unknown"
+
+if ! rustup target list --installed | grep -q "^$WASM_TARGET$"; then
+    echo "✗ $WASM_TARGET is not installed"
+    echo "Installing $WASM_TARGET..."
+
+    if rustup target add "$WASM_TARGET"; then
+        echo "✓ Successfully installed $WASM_TARGET"
+    else
+        echo "✗ Failed to install $WASM_TARGET"
+        exit 1
+    fi
+else
+    echo "✓ $WASM_TARGET is already installed"
+fi
+
 dev/build_validation_service_local
 dev/docker/up

--- a/xmtp_api_http/src/http_stream.rs
+++ b/xmtp_api_http/src/http_stream.rs
@@ -119,7 +119,7 @@ where
         let mut deser_stream = de.into_iter::<GrpcResponse<R>>();
         while let Some(item) = deser_stream.next() {
             match item {
-                Ok(GrpcResponse::Ok(response)) => self.items.push_back(response.result),
+                Ok(GrpcResponse::Ok(response)) => self.items.push_back(response),
                 Ok(GrpcResponse::SubscriptionItem(item)) => self.items.push_back(item.result),
                 Ok(GrpcResponse::Err(e)) => {
                     return Err(HttpClientError::Grpc(e));

--- a/xmtp_api_http/src/http_stream.rs
+++ b/xmtp_api_http/src/http_stream.rs
@@ -119,7 +119,7 @@ where
         let mut deser_stream = de.into_iter::<GrpcResponse<R>>();
         while let Some(item) = deser_stream.next() {
             match item {
-                Ok(GrpcResponse::Ok(response)) => self.items.push_back(response),
+                Ok(GrpcResponse::Ok(response)) => self.items.push_back(response.result),
                 Ok(GrpcResponse::SubscriptionItem(item)) => self.items.push_back(item.result),
                 Ok(GrpcResponse::Err(e)) => {
                     return Err(HttpClientError::Grpc(e));

--- a/xmtp_api_http/src/util.rs
+++ b/xmtp_api_http/src/util.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(untagged)]
 pub(crate) enum GrpcResponse<T> {
-    Ok(T),
+    Ok(SubscriptionItem<T>),
     Err(ErrorResponse),
     SubscriptionItem(SubscriptionItem<T>),
     Empty {},

--- a/xmtp_api_http/src/util.rs
+++ b/xmtp_api_http/src/util.rs
@@ -7,9 +7,9 @@ use serde::{Deserialize, Serialize};
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(untagged)]
 pub(crate) enum GrpcResponse<T> {
-    Ok(SubscriptionItem<T>),
-    Err(ErrorResponse),
     SubscriptionItem(SubscriptionItem<T>),
+    Ok(T),
+    Err(ErrorResponse),
     Empty {},
 }
 

--- a/xmtp_proto/buf.gen.yaml
+++ b/xmtp_proto/buf.gen.yaml
@@ -13,6 +13,7 @@ plugins:
     out: src/gen
     opt:
       - ignore_unknown_fields=true
+      - preserve_proto_field_names=true
   - plugin: buf.build/community/neoeinstein-tonic:v0.4.1
     out: src/gen
     opt:

--- a/xmtp_proto/buf.gen.yaml
+++ b/xmtp_proto/buf.gen.yaml
@@ -11,6 +11,8 @@ plugins:
       - enable_type_names
   - plugin: buf.build/community/neoeinstein-prost-serde:v0.3.1
     out: src/gen
+    opt:
+      - ignore_unknown_fields=true
   - plugin: buf.build/community/neoeinstein-tonic:v0.4.1
     out: src/gen
     opt:

--- a/xmtp_proto/src/gen/xmtp.device_sync.consent_backup.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.device_sync.consent_backup.serde.rs
@@ -23,7 +23,7 @@ impl serde::Serialize for ConsentSave {
         if self.entity_type != 0 {
             let v = ConsentTypeSave::try_from(self.entity_type)
                 .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", self.entity_type)))?;
-            struct_ser.serialize_field("entityType", &v)?;
+            struct_ser.serialize_field("entity_type", &v)?;
         }
         if self.state != 0 {
             let v = ConsentStateSave::try_from(self.state)
@@ -36,7 +36,7 @@ impl serde::Serialize for ConsentSave {
         if self.consented_at_ns != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("consentedAtNs", ToString::to_string(&self.consented_at_ns).as_str())?;
+            struct_ser.serialize_field("consented_at_ns", ToString::to_string(&self.consented_at_ns).as_str())?;
         }
         struct_ser.end()
     }

--- a/xmtp_proto/src/gen/xmtp.device_sync.consent_backup.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.device_sync.consent_backup.serde.rs
@@ -62,6 +62,7 @@ impl<'de> serde::Deserialize<'de> for ConsentSave {
             State,
             Entity,
             ConsentedAtNs,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -87,7 +88,7 @@ impl<'de> serde::Deserialize<'de> for ConsentSave {
                             "state" => Ok(GeneratedField::State),
                             "entity" => Ok(GeneratedField::Entity),
                             "consentedAtNs" | "consented_at_ns" => Ok(GeneratedField::ConsentedAtNs),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -137,6 +138,9 @@ impl<'de> serde::Deserialize<'de> for ConsentSave {
                             consented_at_ns__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }

--- a/xmtp_proto/src/gen/xmtp.device_sync.content.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.device_sync.content.serde.rs
@@ -31,6 +31,7 @@ impl<'de> serde::Deserialize<'de> for DeviceSyncAcknowledge {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             RequestId,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -53,7 +54,7 @@ impl<'de> serde::Deserialize<'de> for DeviceSyncAcknowledge {
                     {
                         match value {
                             "requestId" | "request_id" => Ok(GeneratedField::RequestId),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -80,6 +81,9 @@ impl<'de> serde::Deserialize<'de> for DeviceSyncAcknowledge {
                                 return Err(serde::de::Error::duplicate_field("requestId"));
                             }
                             request_id__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -142,6 +146,7 @@ impl<'de> serde::Deserialize<'de> for DeviceSyncContent {
             Acknowledge,
             Reply,
             PreferenceUpdates,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -167,7 +172,7 @@ impl<'de> serde::Deserialize<'de> for DeviceSyncContent {
                             "acknowledge" => Ok(GeneratedField::Acknowledge),
                             "reply" => Ok(GeneratedField::Reply),
                             "preferenceUpdates" | "preference_updates" => Ok(GeneratedField::PreferenceUpdates),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -217,6 +222,9 @@ impl<'de> serde::Deserialize<'de> for DeviceSyncContent {
                             content__ = map_.next_value::<::std::option::Option<_>>()?.map(device_sync_content::Content::PreferenceUpdates)
 ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(DeviceSyncContent {
@@ -265,6 +273,7 @@ impl<'de> serde::Deserialize<'de> for DeviceSyncKeyType {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Aes256Gcm,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -287,7 +296,7 @@ impl<'de> serde::Deserialize<'de> for DeviceSyncKeyType {
                     {
                         match value {
                             "aes256Gcm" | "aes_256_gcm" => Ok(GeneratedField::Aes256Gcm),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -314,6 +323,9 @@ impl<'de> serde::Deserialize<'de> for DeviceSyncKeyType {
                                 return Err(serde::de::Error::duplicate_field("aes256Gcm"));
                             }
                             key__ = map_.next_value::<::std::option::Option<::pbjson::private::BytesDeserialize<_>>>()?.map(|x| device_sync_key_type::Key::Aes256Gcm(x.0));
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -403,6 +415,7 @@ impl<'de> serde::Deserialize<'de> for DeviceSyncReply {
             TimestampNs,
             Kind,
             Metadata,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -430,7 +443,7 @@ impl<'de> serde::Deserialize<'de> for DeviceSyncReply {
                             "timestampNs" | "timestamp_ns" => Ok(GeneratedField::TimestampNs),
                             "kind" => Ok(GeneratedField::Kind),
                             "metadata" => Ok(GeneratedField::Metadata),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -494,6 +507,9 @@ impl<'de> serde::Deserialize<'de> for DeviceSyncReply {
                                 return Err(serde::de::Error::duplicate_field("metadata"));
                             }
                             metadata__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -569,6 +585,7 @@ impl<'de> serde::Deserialize<'de> for DeviceSyncRequest {
             PinCode,
             Kind,
             Options,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -594,7 +611,7 @@ impl<'de> serde::Deserialize<'de> for DeviceSyncRequest {
                             "pinCode" | "pin_code" => Ok(GeneratedField::PinCode),
                             "kind" => Ok(GeneratedField::Kind),
                             "options" => Ok(GeneratedField::Options),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -642,6 +659,9 @@ impl<'de> serde::Deserialize<'de> for DeviceSyncRequest {
                                 return Err(serde::de::Error::duplicate_field("options"));
                             }
                             options__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -700,6 +720,7 @@ impl<'de> serde::Deserialize<'de> for HmacKeyUpdate {
         enum GeneratedField {
             Key,
             CycledAtNs,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -723,7 +744,7 @@ impl<'de> serde::Deserialize<'de> for HmacKeyUpdate {
                         match value {
                             "key" => Ok(GeneratedField::Key),
                             "cycledAtNs" | "cycled_at_ns" => Ok(GeneratedField::CycledAtNs),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -761,6 +782,9 @@ impl<'de> serde::Deserialize<'de> for HmacKeyUpdate {
                             cycled_at_ns__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -813,6 +837,7 @@ impl<'de> serde::Deserialize<'de> for PreferenceUpdate {
         enum GeneratedField {
             Consent,
             Hmac,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -836,7 +861,7 @@ impl<'de> serde::Deserialize<'de> for PreferenceUpdate {
                         match value {
                             "consent" => Ok(GeneratedField::Consent),
                             "hmac" => Ok(GeneratedField::Hmac),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -871,6 +896,9 @@ impl<'de> serde::Deserialize<'de> for PreferenceUpdate {
                             }
                             update__ = map_.next_value::<::std::option::Option<_>>()?.map(preference_update::Update::Hmac)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -913,6 +941,7 @@ impl<'de> serde::Deserialize<'de> for PreferenceUpdates {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Updates,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -935,7 +964,7 @@ impl<'de> serde::Deserialize<'de> for PreferenceUpdates {
                     {
                         match value {
                             "updates" => Ok(GeneratedField::Updates),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -962,6 +991,9 @@ impl<'de> serde::Deserialize<'de> for PreferenceUpdates {
                                 return Err(serde::de::Error::duplicate_field("updates"));
                             }
                             updates__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1004,6 +1036,7 @@ impl<'de> serde::Deserialize<'de> for V1UserPreferenceUpdate {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Contents,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1026,7 +1059,7 @@ impl<'de> serde::Deserialize<'de> for V1UserPreferenceUpdate {
                     {
                         match value {
                             "contents" => Ok(GeneratedField::Contents),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1056,6 +1089,9 @@ impl<'de> serde::Deserialize<'de> for V1UserPreferenceUpdate {
                                 Some(map_.next_value::<Vec<::pbjson::private::BytesDeserialize<_>>>()?
                                     .into_iter().map(|x| x.0).collect())
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }

--- a/xmtp_proto/src/gen/xmtp.device_sync.content.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.device_sync.content.serde.rs
@@ -12,7 +12,7 @@ impl serde::Serialize for DeviceSyncAcknowledge {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.device_sync.content.DeviceSyncAcknowledge", len)?;
         if !self.request_id.is_empty() {
-            struct_ser.serialize_field("requestId", &self.request_id)?;
+            struct_ser.serialize_field("request_id", &self.request_id)?;
         }
         struct_ser.end()
     }
@@ -119,7 +119,7 @@ impl serde::Serialize for DeviceSyncContent {
                     struct_ser.serialize_field("reply", v)?;
                 }
                 device_sync_content::Content::PreferenceUpdates(v) => {
-                    struct_ser.serialize_field("preferenceUpdates", v)?;
+                    struct_ser.serialize_field("preference_updates", v)?;
                 }
             }
         }
@@ -252,7 +252,7 @@ impl serde::Serialize for DeviceSyncKeyType {
                 device_sync_key_type::Key::Aes256Gcm(v) => {
                     #[allow(clippy::needless_borrow)]
                     #[allow(clippy::needless_borrows_for_generic_args)]
-                    struct_ser.serialize_field("aes256Gcm", pbjson::private::base64::encode(&v).as_str())?;
+                    struct_ser.serialize_field("aes_256_gcm", pbjson::private::base64::encode(&v).as_str())?;
                 }
             }
         }
@@ -365,18 +365,18 @@ impl serde::Serialize for DeviceSyncReply {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.device_sync.content.DeviceSyncReply", len)?;
         if !self.request_id.is_empty() {
-            struct_ser.serialize_field("requestId", &self.request_id)?;
+            struct_ser.serialize_field("request_id", &self.request_id)?;
         }
         if !self.url.is_empty() {
             struct_ser.serialize_field("url", &self.url)?;
         }
         if let Some(v) = self.encryption_key.as_ref() {
-            struct_ser.serialize_field("encryptionKey", v)?;
+            struct_ser.serialize_field("encryption_key", v)?;
         }
         if self.timestamp_ns != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("timestampNs", ToString::to_string(&self.timestamp_ns).as_str())?;
+            struct_ser.serialize_field("timestamp_ns", ToString::to_string(&self.timestamp_ns).as_str())?;
         }
         if self.kind != 0 {
             let v = super::BackupElementSelection::try_from(self.kind)
@@ -548,10 +548,10 @@ impl serde::Serialize for DeviceSyncRequest {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.device_sync.content.DeviceSyncRequest", len)?;
         if !self.request_id.is_empty() {
-            struct_ser.serialize_field("requestId", &self.request_id)?;
+            struct_ser.serialize_field("request_id", &self.request_id)?;
         }
         if !self.pin_code.is_empty() {
-            struct_ser.serialize_field("pinCode", &self.pin_code)?;
+            struct_ser.serialize_field("pin_code", &self.pin_code)?;
         }
         if self.kind != 0 {
             let v = super::BackupElementSelection::try_from(self.kind)
@@ -699,7 +699,7 @@ impl serde::Serialize for HmacKeyUpdate {
         if self.cycled_at_ns != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("cycledAtNs", ToString::to_string(&self.cycled_at_ns).as_str())?;
+            struct_ser.serialize_field("cycled_at_ns", ToString::to_string(&self.cycled_at_ns).as_str())?;
         }
         struct_ser.end()
     }

--- a/xmtp_proto/src/gen/xmtp.device_sync.event_backup.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.device_sync.event_backup.serde.rs
@@ -163,6 +163,7 @@ impl<'de> serde::Deserialize<'de> for EventSave {
             GroupId,
             Level,
             Icon,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -190,7 +191,7 @@ impl<'de> serde::Deserialize<'de> for EventSave {
                             "groupId" | "group_id" => Ok(GeneratedField::GroupId),
                             "level" => Ok(GeneratedField::Level),
                             "icon" => Ok(GeneratedField::Icon),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -258,6 +259,9 @@ impl<'de> serde::Deserialize<'de> for EventSave {
                                 return Err(serde::de::Error::duplicate_field("icon"));
                             }
                             icon__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }

--- a/xmtp_proto/src/gen/xmtp.device_sync.event_backup.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.device_sync.event_backup.serde.rs
@@ -112,7 +112,7 @@ impl serde::Serialize for EventSave {
         if self.created_at_ns != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("createdAtNs", ToString::to_string(&self.created_at_ns).as_str())?;
+            struct_ser.serialize_field("created_at_ns", ToString::to_string(&self.created_at_ns).as_str())?;
         }
         if !self.event.is_empty() {
             struct_ser.serialize_field("event", &self.event)?;
@@ -125,7 +125,7 @@ impl serde::Serialize for EventSave {
         if let Some(v) = self.group_id.as_ref() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("groupId", pbjson::private::base64::encode(&v).as_str())?;
+            struct_ser.serialize_field("group_id", pbjson::private::base64::encode(&v).as_str())?;
         }
         if self.level != 0 {
             let v = EventLevelSave::try_from(self.level)

--- a/xmtp_proto/src/gen/xmtp.device_sync.group_backup.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.device_sync.group_backup.serde.rs
@@ -332,6 +332,7 @@ impl<'de> serde::Deserialize<'de> for GroupSave {
             Metadata,
             MutableMetadata,
             PausedForVersion,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -368,7 +369,7 @@ impl<'de> serde::Deserialize<'de> for GroupSave {
                             "metadata" => Ok(GeneratedField::Metadata),
                             "mutableMetadata" | "mutable_metadata" => Ok(GeneratedField::MutableMetadata),
                             "pausedForVersion" | "paused_for_version" => Ok(GeneratedField::PausedForVersion),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -510,6 +511,9 @@ impl<'de> serde::Deserialize<'de> for GroupSave {
                             }
                             paused_for_version__ = map_.next_value()?;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(GroupSave {
@@ -566,6 +570,7 @@ impl<'de> serde::Deserialize<'de> for ImmutableMetadataSave {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             CreatorInboxId,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -588,7 +593,7 @@ impl<'de> serde::Deserialize<'de> for ImmutableMetadataSave {
                     {
                         match value {
                             "creatorInboxId" | "creator_inbox_id" => Ok(GeneratedField::CreatorInboxId),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -615,6 +620,9 @@ impl<'de> serde::Deserialize<'de> for ImmutableMetadataSave {
                                 return Err(serde::de::Error::duplicate_field("creatorInboxId"));
                             }
                             creator_inbox_id__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -675,6 +683,7 @@ impl<'de> serde::Deserialize<'de> for MutableMetadataSave {
             Attributes,
             AdminList,
             SuperAdminList,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -699,7 +708,7 @@ impl<'de> serde::Deserialize<'de> for MutableMetadataSave {
                             "attributes" => Ok(GeneratedField::Attributes),
                             "adminList" | "admin_list" => Ok(GeneratedField::AdminList),
                             "superAdminList" | "super_admin_list" => Ok(GeneratedField::SuperAdminList),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -742,6 +751,9 @@ impl<'de> serde::Deserialize<'de> for MutableMetadataSave {
                                 return Err(serde::de::Error::duplicate_field("superAdminList"));
                             }
                             super_admin_list__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }

--- a/xmtp_proto/src/gen/xmtp.device_sync.group_backup.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.device_sync.group_backup.serde.rs
@@ -218,62 +218,62 @@ impl serde::Serialize for GroupSave {
         if self.created_at_ns != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("createdAtNs", ToString::to_string(&self.created_at_ns).as_str())?;
+            struct_ser.serialize_field("created_at_ns", ToString::to_string(&self.created_at_ns).as_str())?;
         }
         if self.membership_state != 0 {
             let v = GroupMembershipStateSave::try_from(self.membership_state)
                 .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", self.membership_state)))?;
-            struct_ser.serialize_field("membershipState", &v)?;
+            struct_ser.serialize_field("membership_state", &v)?;
         }
         if self.installations_last_checked != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("installationsLastChecked", ToString::to_string(&self.installations_last_checked).as_str())?;
+            struct_ser.serialize_field("installations_last_checked", ToString::to_string(&self.installations_last_checked).as_str())?;
         }
         if !self.added_by_inbox_id.is_empty() {
-            struct_ser.serialize_field("addedByInboxId", &self.added_by_inbox_id)?;
+            struct_ser.serialize_field("added_by_inbox_id", &self.added_by_inbox_id)?;
         }
         if let Some(v) = self.welcome_id.as_ref() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("welcomeId", ToString::to_string(&v).as_str())?;
+            struct_ser.serialize_field("welcome_id", ToString::to_string(&v).as_str())?;
         }
         if self.rotated_at_ns != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("rotatedAtNs", ToString::to_string(&self.rotated_at_ns).as_str())?;
+            struct_ser.serialize_field("rotated_at_ns", ToString::to_string(&self.rotated_at_ns).as_str())?;
         }
         if self.conversation_type != 0 {
             let v = ConversationTypeSave::try_from(self.conversation_type)
                 .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", self.conversation_type)))?;
-            struct_ser.serialize_field("conversationType", &v)?;
+            struct_ser.serialize_field("conversation_type", &v)?;
         }
         if let Some(v) = self.dm_id.as_ref() {
-            struct_ser.serialize_field("dmId", v)?;
+            struct_ser.serialize_field("dm_id", v)?;
         }
         if let Some(v) = self.last_message_ns.as_ref() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("lastMessageNs", ToString::to_string(&v).as_str())?;
+            struct_ser.serialize_field("last_message_ns", ToString::to_string(&v).as_str())?;
         }
         if let Some(v) = self.message_disappear_from_ns.as_ref() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("messageDisappearFromNs", ToString::to_string(&v).as_str())?;
+            struct_ser.serialize_field("message_disappear_from_ns", ToString::to_string(&v).as_str())?;
         }
         if let Some(v) = self.message_disappear_in_ns.as_ref() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("messageDisappearInNs", ToString::to_string(&v).as_str())?;
+            struct_ser.serialize_field("message_disappear_in_ns", ToString::to_string(&v).as_str())?;
         }
         if let Some(v) = self.metadata.as_ref() {
             struct_ser.serialize_field("metadata", v)?;
         }
         if let Some(v) = self.mutable_metadata.as_ref() {
-            struct_ser.serialize_field("mutableMetadata", v)?;
+            struct_ser.serialize_field("mutable_metadata", v)?;
         }
         if let Some(v) = self.paused_for_version.as_ref() {
-            struct_ser.serialize_field("pausedForVersion", v)?;
+            struct_ser.serialize_field("paused_for_version", v)?;
         }
         struct_ser.end()
     }
@@ -551,7 +551,7 @@ impl serde::Serialize for ImmutableMetadataSave {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.device_sync.group_backup.ImmutableMetadataSave", len)?;
         if !self.creator_inbox_id.is_empty() {
-            struct_ser.serialize_field("creatorInboxId", &self.creator_inbox_id)?;
+            struct_ser.serialize_field("creator_inbox_id", &self.creator_inbox_id)?;
         }
         struct_ser.end()
     }
@@ -656,10 +656,10 @@ impl serde::Serialize for MutableMetadataSave {
             struct_ser.serialize_field("attributes", &self.attributes)?;
         }
         if !self.admin_list.is_empty() {
-            struct_ser.serialize_field("adminList", &self.admin_list)?;
+            struct_ser.serialize_field("admin_list", &self.admin_list)?;
         }
         if !self.super_admin_list.is_empty() {
-            struct_ser.serialize_field("superAdminList", &self.super_admin_list)?;
+            struct_ser.serialize_field("super_admin_list", &self.super_admin_list)?;
         }
         struct_ser.end()
     }

--- a/xmtp_proto/src/gen/xmtp.device_sync.message_backup.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.device_sync.message_backup.serde.rs
@@ -426,6 +426,7 @@ impl<'de> serde::Deserialize<'de> for GroupMessageSave {
             ReferenceId,
             SequenceId,
             OriginatorId,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -462,7 +463,7 @@ impl<'de> serde::Deserialize<'de> for GroupMessageSave {
                             "referenceId" | "reference_id" => Ok(GeneratedField::ReferenceId),
                             "sequenceId" | "sequence_id" => Ok(GeneratedField::SequenceId),
                             "originatorId" | "originator_id" => Ok(GeneratedField::OriginatorId),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -607,6 +608,9 @@ impl<'de> serde::Deserialize<'de> for GroupMessageSave {
                             originator_id__ = 
                                 map_.next_value::<::std::option::Option<::pbjson::private::NumberDeserialize<_>>>()?.map(|x| x.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }

--- a/xmtp_proto/src/gen/xmtp.device_sync.message_backup.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.device_sync.message_backup.serde.rs
@@ -310,17 +310,17 @@ impl serde::Serialize for GroupMessageSave {
         if !self.group_id.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("groupId", pbjson::private::base64::encode(&self.group_id).as_str())?;
+            struct_ser.serialize_field("group_id", pbjson::private::base64::encode(&self.group_id).as_str())?;
         }
         if !self.decrypted_message_bytes.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("decryptedMessageBytes", pbjson::private::base64::encode(&self.decrypted_message_bytes).as_str())?;
+            struct_ser.serialize_field("decrypted_message_bytes", pbjson::private::base64::encode(&self.decrypted_message_bytes).as_str())?;
         }
         if self.sent_at_ns != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("sentAtNs", ToString::to_string(&self.sent_at_ns).as_str())?;
+            struct_ser.serialize_field("sent_at_ns", ToString::to_string(&self.sent_at_ns).as_str())?;
         }
         if self.kind != 0 {
             let v = GroupMessageKindSave::try_from(self.kind)
@@ -330,44 +330,44 @@ impl serde::Serialize for GroupMessageSave {
         if !self.sender_installation_id.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("senderInstallationId", pbjson::private::base64::encode(&self.sender_installation_id).as_str())?;
+            struct_ser.serialize_field("sender_installation_id", pbjson::private::base64::encode(&self.sender_installation_id).as_str())?;
         }
         if !self.sender_inbox_id.is_empty() {
-            struct_ser.serialize_field("senderInboxId", &self.sender_inbox_id)?;
+            struct_ser.serialize_field("sender_inbox_id", &self.sender_inbox_id)?;
         }
         if self.delivery_status != 0 {
             let v = DeliveryStatusSave::try_from(self.delivery_status)
                 .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", self.delivery_status)))?;
-            struct_ser.serialize_field("deliveryStatus", &v)?;
+            struct_ser.serialize_field("delivery_status", &v)?;
         }
         if self.content_type != 0 {
             let v = ContentTypeSave::try_from(self.content_type)
                 .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", self.content_type)))?;
-            struct_ser.serialize_field("contentType", &v)?;
+            struct_ser.serialize_field("content_type", &v)?;
         }
         if self.version_major != 0 {
-            struct_ser.serialize_field("versionMajor", &self.version_major)?;
+            struct_ser.serialize_field("version_major", &self.version_major)?;
         }
         if self.version_minor != 0 {
-            struct_ser.serialize_field("versionMinor", &self.version_minor)?;
+            struct_ser.serialize_field("version_minor", &self.version_minor)?;
         }
         if !self.authority_id.is_empty() {
-            struct_ser.serialize_field("authorityId", &self.authority_id)?;
+            struct_ser.serialize_field("authority_id", &self.authority_id)?;
         }
         if let Some(v) = self.reference_id.as_ref() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("referenceId", pbjson::private::base64::encode(&v).as_str())?;
+            struct_ser.serialize_field("reference_id", pbjson::private::base64::encode(&v).as_str())?;
         }
         if let Some(v) = self.sequence_id.as_ref() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("sequenceId", ToString::to_string(&v).as_str())?;
+            struct_ser.serialize_field("sequence_id", ToString::to_string(&v).as_str())?;
         }
         if let Some(v) = self.originator_id.as_ref() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("originatorId", ToString::to_string(&v).as_str())?;
+            struct_ser.serialize_field("originator_id", ToString::to_string(&v).as_str())?;
         }
         struct_ser.end()
     }

--- a/xmtp_proto/src/gen/xmtp.device_sync.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.device_sync.serde.rs
@@ -55,6 +55,7 @@ impl<'de> serde::Deserialize<'de> for BackupElement {
             GroupMessage,
             Consent,
             Event,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -81,7 +82,7 @@ impl<'de> serde::Deserialize<'de> for BackupElement {
                             "groupMessage" | "group_message" => Ok(GeneratedField::GroupMessage),
                             "consent" => Ok(GeneratedField::Consent),
                             "event" => Ok(GeneratedField::Event),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -137,6 +138,9 @@ impl<'de> serde::Deserialize<'de> for BackupElement {
                             }
                             element__ = map_.next_value::<::std::option::Option<_>>()?.map(backup_element::Element::Event)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -293,6 +297,7 @@ impl<'de> serde::Deserialize<'de> for BackupMetadataSave {
             ExportedAtNs,
             StartNs,
             EndNs,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -318,7 +323,7 @@ impl<'de> serde::Deserialize<'de> for BackupMetadataSave {
                             "exportedAtNs" | "exported_at_ns" => Ok(GeneratedField::ExportedAtNs),
                             "startNs" | "start_ns" => Ok(GeneratedField::StartNs),
                             "endNs" | "end_ns" => Ok(GeneratedField::EndNs),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -372,6 +377,9 @@ impl<'de> serde::Deserialize<'de> for BackupMetadataSave {
                             end_ns__ = 
                                 map_.next_value::<::std::option::Option<::pbjson::private::NumberDeserialize<_>>>()?.map(|x| x.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -443,6 +451,7 @@ impl<'de> serde::Deserialize<'de> for BackupOptions {
             Elements,
             StartNs,
             EndNs,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -467,7 +476,7 @@ impl<'de> serde::Deserialize<'de> for BackupOptions {
                             "elements" => Ok(GeneratedField::Elements),
                             "startNs" | "start_ns" => Ok(GeneratedField::StartNs),
                             "endNs" | "end_ns" => Ok(GeneratedField::EndNs),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -512,6 +521,9 @@ impl<'de> serde::Deserialize<'de> for BackupOptions {
                             end_ns__ = 
                                 map_.next_value::<::std::option::Option<::pbjson::private::NumberDeserialize<_>>>()?.map(|x| x.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }

--- a/xmtp_proto/src/gen/xmtp.device_sync.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.device_sync.serde.rs
@@ -20,7 +20,7 @@ impl serde::Serialize for BackupElement {
                     struct_ser.serialize_field("group", v)?;
                 }
                 backup_element::Element::GroupMessage(v) => {
-                    struct_ser.serialize_field("groupMessage", v)?;
+                    struct_ser.serialize_field("group_message", v)?;
                 }
                 backup_element::Element::Consent(v) => {
                     struct_ser.serialize_field("consent", v)?;
@@ -260,17 +260,17 @@ impl serde::Serialize for BackupMetadataSave {
         if self.exported_at_ns != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("exportedAtNs", ToString::to_string(&self.exported_at_ns).as_str())?;
+            struct_ser.serialize_field("exported_at_ns", ToString::to_string(&self.exported_at_ns).as_str())?;
         }
         if let Some(v) = self.start_ns.as_ref() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("startNs", ToString::to_string(&v).as_str())?;
+            struct_ser.serialize_field("start_ns", ToString::to_string(&v).as_str())?;
         }
         if let Some(v) = self.end_ns.as_ref() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("endNs", ToString::to_string(&v).as_str())?;
+            struct_ser.serialize_field("end_ns", ToString::to_string(&v).as_str())?;
         }
         struct_ser.end()
     }
@@ -422,12 +422,12 @@ impl serde::Serialize for BackupOptions {
         if let Some(v) = self.start_ns.as_ref() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("startNs", ToString::to_string(&v).as_str())?;
+            struct_ser.serialize_field("start_ns", ToString::to_string(&v).as_str())?;
         }
         if let Some(v) = self.end_ns.as_ref() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("endNs", ToString::to_string(&v).as_str())?;
+            struct_ser.serialize_field("end_ns", ToString::to_string(&v).as_str())?;
         }
         struct_ser.end()
     }

--- a/xmtp_proto/src/gen/xmtp.identity.api.v1.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.identity.api.v1.serde.rs
@@ -110,12 +110,12 @@ impl serde::Serialize for get_identity_updates_request::Request {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.identity.api.v1.GetIdentityUpdatesRequest.Request", len)?;
         if !self.inbox_id.is_empty() {
-            struct_ser.serialize_field("inboxId", &self.inbox_id)?;
+            struct_ser.serialize_field("inbox_id", &self.inbox_id)?;
         }
         if self.sequence_id != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("sequenceId", ToString::to_string(&self.sequence_id).as_str())?;
+            struct_ser.serialize_field("sequence_id", ToString::to_string(&self.sequence_id).as_str())?;
         }
         struct_ser.end()
     }
@@ -328,12 +328,12 @@ impl serde::Serialize for get_identity_updates_response::IdentityUpdateLog {
         if self.sequence_id != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("sequenceId", ToString::to_string(&self.sequence_id).as_str())?;
+            struct_ser.serialize_field("sequence_id", ToString::to_string(&self.sequence_id).as_str())?;
         }
         if self.server_timestamp_ns != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("serverTimestampNs", ToString::to_string(&self.server_timestamp_ns).as_str())?;
+            struct_ser.serialize_field("server_timestamp_ns", ToString::to_string(&self.server_timestamp_ns).as_str())?;
         }
         if let Some(v) = self.update.as_ref() {
             struct_ser.serialize_field("update", v)?;
@@ -462,7 +462,7 @@ impl serde::Serialize for get_identity_updates_response::Response {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.identity.api.v1.GetIdentityUpdatesResponse.Response", len)?;
         if !self.inbox_id.is_empty() {
-            struct_ser.serialize_field("inboxId", &self.inbox_id)?;
+            struct_ser.serialize_field("inbox_id", &self.inbox_id)?;
         }
         if !self.updates.is_empty() {
             struct_ser.serialize_field("updates", &self.updates)?;
@@ -675,7 +675,7 @@ impl serde::Serialize for get_inbox_ids_request::Request {
         if self.identifier_kind != 0 {
             let v = super::super::associations::IdentifierKind::try_from(self.identifier_kind)
                 .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", self.identifier_kind)))?;
-            struct_ser.serialize_field("identifierKind", &v)?;
+            struct_ser.serialize_field("identifier_kind", &v)?;
         }
         struct_ser.end()
     }
@@ -886,12 +886,12 @@ impl serde::Serialize for get_inbox_ids_response::Response {
             struct_ser.serialize_field("identifier", &self.identifier)?;
         }
         if let Some(v) = self.inbox_id.as_ref() {
-            struct_ser.serialize_field("inboxId", v)?;
+            struct_ser.serialize_field("inbox_id", v)?;
         }
         if self.identifier_kind != 0 {
             let v = super::super::associations::IdentifierKind::try_from(self.identifier_kind)
                 .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", self.identifier_kind)))?;
-            struct_ser.serialize_field("identifierKind", &v)?;
+            struct_ser.serialize_field("identifier_kind", &v)?;
         }
         struct_ser.end()
     }
@@ -1010,7 +1010,7 @@ impl serde::Serialize for PublishIdentityUpdateRequest {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.identity.api.v1.PublishIdentityUpdateRequest", len)?;
         if let Some(v) = self.identity_update.as_ref() {
-            struct_ser.serialize_field("identityUpdate", v)?;
+            struct_ser.serialize_field("identity_update", v)?;
         }
         struct_ser.end()
     }
@@ -1187,12 +1187,12 @@ impl serde::Serialize for VerifySmartContractWalletSignatureRequestSignature {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.identity.api.v1.VerifySmartContractWalletSignatureRequestSignature", len)?;
         if !self.account_id.is_empty() {
-            struct_ser.serialize_field("accountId", &self.account_id)?;
+            struct_ser.serialize_field("account_id", &self.account_id)?;
         }
         if let Some(v) = self.block_number.as_ref() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("blockNumber", ToString::to_string(&v).as_str())?;
+            struct_ser.serialize_field("block_number", ToString::to_string(&v).as_str())?;
         }
         if !self.signature.is_empty() {
             #[allow(clippy::needless_borrow)]
@@ -1534,12 +1534,12 @@ impl serde::Serialize for verify_smart_contract_wallet_signatures_response::Vali
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.identity.api.v1.VerifySmartContractWalletSignaturesResponse.ValidationResponse", len)?;
         if self.is_valid {
-            struct_ser.serialize_field("isValid", &self.is_valid)?;
+            struct_ser.serialize_field("is_valid", &self.is_valid)?;
         }
         if let Some(v) = self.block_number.as_ref() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("blockNumber", ToString::to_string(&v).as_str())?;
+            struct_ser.serialize_field("block_number", ToString::to_string(&v).as_str())?;
         }
         if let Some(v) = self.error.as_ref() {
             struct_ser.serialize_field("error", v)?;

--- a/xmtp_proto/src/gen/xmtp.identity.api.v1.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.identity.api.v1.serde.rs
@@ -30,6 +30,7 @@ impl<'de> serde::Deserialize<'de> for GetIdentityUpdatesRequest {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Requests,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -52,7 +53,7 @@ impl<'de> serde::Deserialize<'de> for GetIdentityUpdatesRequest {
                     {
                         match value {
                             "requests" => Ok(GeneratedField::Requests),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -79,6 +80,9 @@ impl<'de> serde::Deserialize<'de> for GetIdentityUpdatesRequest {
                                 return Err(serde::de::Error::duplicate_field("requests"));
                             }
                             requests__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -133,6 +137,7 @@ impl<'de> serde::Deserialize<'de> for get_identity_updates_request::Request {
         enum GeneratedField {
             InboxId,
             SequenceId,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -156,7 +161,7 @@ impl<'de> serde::Deserialize<'de> for get_identity_updates_request::Request {
                         match value {
                             "inboxId" | "inbox_id" => Ok(GeneratedField::InboxId),
                             "sequenceId" | "sequence_id" => Ok(GeneratedField::SequenceId),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -192,6 +197,9 @@ impl<'de> serde::Deserialize<'de> for get_identity_updates_request::Request {
                             sequence_id__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -235,6 +243,7 @@ impl<'de> serde::Deserialize<'de> for GetIdentityUpdatesResponse {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Responses,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -257,7 +266,7 @@ impl<'de> serde::Deserialize<'de> for GetIdentityUpdatesResponse {
                     {
                         match value {
                             "responses" => Ok(GeneratedField::Responses),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -284,6 +293,9 @@ impl<'de> serde::Deserialize<'de> for GetIdentityUpdatesResponse {
                                 return Err(serde::de::Error::duplicate_field("responses"));
                             }
                             responses__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -348,6 +360,7 @@ impl<'de> serde::Deserialize<'de> for get_identity_updates_response::IdentityUpd
             SequenceId,
             ServerTimestampNs,
             Update,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -372,7 +385,7 @@ impl<'de> serde::Deserialize<'de> for get_identity_updates_response::IdentityUpd
                             "sequenceId" | "sequence_id" => Ok(GeneratedField::SequenceId),
                             "serverTimestampNs" | "server_timestamp_ns" => Ok(GeneratedField::ServerTimestampNs),
                             "update" => Ok(GeneratedField::Update),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -417,6 +430,9 @@ impl<'de> serde::Deserialize<'de> for get_identity_updates_response::IdentityUpd
                                 return Err(serde::de::Error::duplicate_field("update"));
                             }
                             update__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -470,6 +486,7 @@ impl<'de> serde::Deserialize<'de> for get_identity_updates_response::Response {
         enum GeneratedField {
             InboxId,
             Updates,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -493,7 +510,7 @@ impl<'de> serde::Deserialize<'de> for get_identity_updates_response::Response {
                         match value {
                             "inboxId" | "inbox_id" => Ok(GeneratedField::InboxId),
                             "updates" => Ok(GeneratedField::Updates),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -527,6 +544,9 @@ impl<'de> serde::Deserialize<'de> for get_identity_updates_response::Response {
                                 return Err(serde::de::Error::duplicate_field("updates"));
                             }
                             updates__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -570,6 +590,7 @@ impl<'de> serde::Deserialize<'de> for GetInboxIdsRequest {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Requests,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -592,7 +613,7 @@ impl<'de> serde::Deserialize<'de> for GetInboxIdsRequest {
                     {
                         match value {
                             "requests" => Ok(GeneratedField::Requests),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -619,6 +640,9 @@ impl<'de> serde::Deserialize<'de> for GetInboxIdsRequest {
                                 return Err(serde::de::Error::duplicate_field("requests"));
                             }
                             requests__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -672,6 +696,7 @@ impl<'de> serde::Deserialize<'de> for get_inbox_ids_request::Request {
         enum GeneratedField {
             Identifier,
             IdentifierKind,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -695,7 +720,7 @@ impl<'de> serde::Deserialize<'de> for get_inbox_ids_request::Request {
                         match value {
                             "identifier" => Ok(GeneratedField::Identifier),
                             "identifierKind" | "identifier_kind" => Ok(GeneratedField::IdentifierKind),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -729,6 +754,9 @@ impl<'de> serde::Deserialize<'de> for get_inbox_ids_request::Request {
                                 return Err(serde::de::Error::duplicate_field("identifierKind"));
                             }
                             identifier_kind__ = Some(map_.next_value::<super::super::associations::IdentifierKind>()? as i32);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -772,6 +800,7 @@ impl<'de> serde::Deserialize<'de> for GetInboxIdsResponse {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Responses,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -794,7 +823,7 @@ impl<'de> serde::Deserialize<'de> for GetInboxIdsResponse {
                     {
                         match value {
                             "responses" => Ok(GeneratedField::Responses),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -821,6 +850,9 @@ impl<'de> serde::Deserialize<'de> for GetInboxIdsResponse {
                                 return Err(serde::de::Error::duplicate_field("responses"));
                             }
                             responses__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -883,6 +915,7 @@ impl<'de> serde::Deserialize<'de> for get_inbox_ids_response::Response {
             Identifier,
             InboxId,
             IdentifierKind,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -907,7 +940,7 @@ impl<'de> serde::Deserialize<'de> for get_inbox_ids_response::Response {
                             "identifier" => Ok(GeneratedField::Identifier),
                             "inboxId" | "inbox_id" => Ok(GeneratedField::InboxId),
                             "identifierKind" | "identifier_kind" => Ok(GeneratedField::IdentifierKind),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -948,6 +981,9 @@ impl<'de> serde::Deserialize<'de> for get_inbox_ids_response::Response {
                                 return Err(serde::de::Error::duplicate_field("identifierKind"));
                             }
                             identifier_kind__ = Some(map_.next_value::<super::super::associations::IdentifierKind>()? as i32);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -993,6 +1029,7 @@ impl<'de> serde::Deserialize<'de> for PublishIdentityUpdateRequest {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             IdentityUpdate,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1015,7 +1052,7 @@ impl<'de> serde::Deserialize<'de> for PublishIdentityUpdateRequest {
                     {
                         match value {
                             "identityUpdate" | "identity_update" => Ok(GeneratedField::IdentityUpdate),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1042,6 +1079,9 @@ impl<'de> serde::Deserialize<'de> for PublishIdentityUpdateRequest {
                                 return Err(serde::de::Error::duplicate_field("identityUpdate"));
                             }
                             identity_update__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1076,6 +1116,7 @@ impl<'de> serde::Deserialize<'de> for PublishIdentityUpdateResponse {
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1096,7 +1137,7 @@ impl<'de> serde::Deserialize<'de> for PublishIdentityUpdateResponse {
                     where
                         E: serde::de::Error,
                     {
-                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                            Ok(GeneratedField::__SkipField__)
                     }
                 }
                 deserializer.deserialize_identifier(GeneratedVisitor)
@@ -1187,6 +1228,7 @@ impl<'de> serde::Deserialize<'de> for VerifySmartContractWalletSignatureRequestS
             BlockNumber,
             Signature,
             Hash,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1212,7 +1254,7 @@ impl<'de> serde::Deserialize<'de> for VerifySmartContractWalletSignatureRequestS
                             "blockNumber" | "block_number" => Ok(GeneratedField::BlockNumber),
                             "signature" => Ok(GeneratedField::Signature),
                             "hash" => Ok(GeneratedField::Hash),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1267,6 +1309,9 @@ impl<'de> serde::Deserialize<'de> for VerifySmartContractWalletSignatureRequestS
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(VerifySmartContractWalletSignatureRequestSignature {
@@ -1311,6 +1356,7 @@ impl<'de> serde::Deserialize<'de> for VerifySmartContractWalletSignaturesRequest
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Signatures,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1333,7 +1379,7 @@ impl<'de> serde::Deserialize<'de> for VerifySmartContractWalletSignaturesRequest
                     {
                         match value {
                             "signatures" => Ok(GeneratedField::Signatures),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1360,6 +1406,9 @@ impl<'de> serde::Deserialize<'de> for VerifySmartContractWalletSignaturesRequest
                                 return Err(serde::de::Error::duplicate_field("signatures"));
                             }
                             signatures__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1402,6 +1451,7 @@ impl<'de> serde::Deserialize<'de> for VerifySmartContractWalletSignaturesRespons
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Responses,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1424,7 +1474,7 @@ impl<'de> serde::Deserialize<'de> for VerifySmartContractWalletSignaturesRespons
                     {
                         match value {
                             "responses" => Ok(GeneratedField::Responses),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1451,6 +1501,9 @@ impl<'de> serde::Deserialize<'de> for VerifySmartContractWalletSignaturesRespons
                                 return Err(serde::de::Error::duplicate_field("responses"));
                             }
                             responses__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1513,6 +1566,7 @@ impl<'de> serde::Deserialize<'de> for verify_smart_contract_wallet_signatures_re
             IsValid,
             BlockNumber,
             Error,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1537,7 +1591,7 @@ impl<'de> serde::Deserialize<'de> for verify_smart_contract_wallet_signatures_re
                             "isValid" | "is_valid" => Ok(GeneratedField::IsValid),
                             "blockNumber" | "block_number" => Ok(GeneratedField::BlockNumber),
                             "error" => Ok(GeneratedField::Error),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1580,6 +1634,9 @@ impl<'de> serde::Deserialize<'de> for verify_smart_contract_wallet_signatures_re
                                 return Err(serde::de::Error::duplicate_field("error"));
                             }
                             error__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }

--- a/xmtp_proto/src/gen/xmtp.identity.associations.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.identity.associations.serde.rs
@@ -21,16 +21,16 @@ impl serde::Serialize for AddAssociation {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.identity.associations.AddAssociation", len)?;
         if let Some(v) = self.new_member_identifier.as_ref() {
-            struct_ser.serialize_field("newMemberIdentifier", v)?;
+            struct_ser.serialize_field("new_member_identifier", v)?;
         }
         if let Some(v) = self.existing_member_signature.as_ref() {
-            struct_ser.serialize_field("existingMemberSignature", v)?;
+            struct_ser.serialize_field("existing_member_signature", v)?;
         }
         if let Some(v) = self.new_member_signature.as_ref() {
-            struct_ser.serialize_field("newMemberSignature", v)?;
+            struct_ser.serialize_field("new_member_signature", v)?;
         }
         if let Some(v) = self.relying_party.as_ref() {
-            struct_ser.serialize_field("relyingParty", v)?;
+            struct_ser.serialize_field("relying_party", v)?;
         }
         struct_ser.end()
     }
@@ -177,24 +177,24 @@ impl serde::Serialize for AssociationState {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.identity.associations.AssociationState", len)?;
         if !self.inbox_id.is_empty() {
-            struct_ser.serialize_field("inboxId", &self.inbox_id)?;
+            struct_ser.serialize_field("inbox_id", &self.inbox_id)?;
         }
         if !self.members.is_empty() {
             struct_ser.serialize_field("members", &self.members)?;
         }
         if !self.recovery_identifier.is_empty() {
-            struct_ser.serialize_field("recoveryIdentifier", &self.recovery_identifier)?;
+            struct_ser.serialize_field("recovery_identifier", &self.recovery_identifier)?;
         }
         if !self.seen_signatures.is_empty() {
-            struct_ser.serialize_field("seenSignatures", &self.seen_signatures.iter().map(pbjson::private::base64::encode).collect::<Vec<_>>())?;
+            struct_ser.serialize_field("seen_signatures", &self.seen_signatures.iter().map(pbjson::private::base64::encode).collect::<Vec<_>>())?;
         }
         if self.recovery_identifier_kind != 0 {
             let v = IdentifierKind::try_from(self.recovery_identifier_kind)
                 .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", self.recovery_identifier_kind)))?;
-            struct_ser.serialize_field("recoveryIdentifierKind", &v)?;
+            struct_ser.serialize_field("recovery_identifier_kind", &v)?;
         }
         if let Some(v) = self.relying_party.as_ref() {
-            struct_ser.serialize_field("relyingParty", v)?;
+            struct_ser.serialize_field("relying_party", v)?;
         }
         struct_ser.end()
     }
@@ -355,10 +355,10 @@ impl serde::Serialize for AssociationStateDiff {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.identity.associations.AssociationStateDiff", len)?;
         if !self.new_members.is_empty() {
-            struct_ser.serialize_field("newMembers", &self.new_members)?;
+            struct_ser.serialize_field("new_members", &self.new_members)?;
         }
         if !self.removed_members.is_empty() {
-            struct_ser.serialize_field("removedMembers", &self.removed_members)?;
+            struct_ser.serialize_field("removed_members", &self.removed_members)?;
         }
         struct_ser.end()
     }
@@ -475,18 +475,18 @@ impl serde::Serialize for ChangeRecoveryAddress {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.identity.associations.ChangeRecoveryAddress", len)?;
         if !self.new_recovery_identifier.is_empty() {
-            struct_ser.serialize_field("newRecoveryIdentifier", &self.new_recovery_identifier)?;
+            struct_ser.serialize_field("new_recovery_identifier", &self.new_recovery_identifier)?;
         }
         if let Some(v) = self.existing_recovery_identifier_signature.as_ref() {
-            struct_ser.serialize_field("existingRecoveryIdentifierSignature", v)?;
+            struct_ser.serialize_field("existing_recovery_identifier_signature", v)?;
         }
         if self.new_recovery_identifier_kind != 0 {
             let v = IdentifierKind::try_from(self.new_recovery_identifier_kind)
                 .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", self.new_recovery_identifier_kind)))?;
-            struct_ser.serialize_field("newRecoveryIdentifierKind", &v)?;
+            struct_ser.serialize_field("new_recovery_identifier_kind", &v)?;
         }
         if let Some(v) = self.relying_party.as_ref() {
-            struct_ser.serialize_field("relyingParty", v)?;
+            struct_ser.serialize_field("relying_party", v)?;
         }
         struct_ser.end()
     }
@@ -630,7 +630,7 @@ impl serde::Serialize for CreateInbox {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.identity.associations.CreateInbox", len)?;
         if !self.initial_identifier.is_empty() {
-            struct_ser.serialize_field("initialIdentifier", &self.initial_identifier)?;
+            struct_ser.serialize_field("initial_identifier", &self.initial_identifier)?;
         }
         if self.nonce != 0 {
             #[allow(clippy::needless_borrow)]
@@ -638,15 +638,15 @@ impl serde::Serialize for CreateInbox {
             struct_ser.serialize_field("nonce", ToString::to_string(&self.nonce).as_str())?;
         }
         if let Some(v) = self.initial_identifier_signature.as_ref() {
-            struct_ser.serialize_field("initialIdentifierSignature", v)?;
+            struct_ser.serialize_field("initial_identifier_signature", v)?;
         }
         if self.initial_identifier_kind != 0 {
             let v = IdentifierKind::try_from(self.initial_identifier_kind)
                 .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", self.initial_identifier_kind)))?;
-            struct_ser.serialize_field("initialIdentifierKind", &v)?;
+            struct_ser.serialize_field("initial_identifier_kind", &v)?;
         }
         if let Some(v) = self.relying_party.as_ref() {
-            struct_ser.serialize_field("relyingParty", v)?;
+            struct_ser.serialize_field("relying_party", v)?;
         }
         struct_ser.end()
     }
@@ -867,7 +867,7 @@ impl serde::Serialize for IdentityAction {
         if let Some(v) = self.kind.as_ref() {
             match v {
                 identity_action::Kind::CreateInbox(v) => {
-                    struct_ser.serialize_field("createInbox", v)?;
+                    struct_ser.serialize_field("create_inbox", v)?;
                 }
                 identity_action::Kind::Add(v) => {
                     struct_ser.serialize_field("add", v)?;
@@ -876,7 +876,7 @@ impl serde::Serialize for IdentityAction {
                     struct_ser.serialize_field("revoke", v)?;
                 }
                 identity_action::Kind::ChangeRecoveryAddress(v) => {
-                    struct_ser.serialize_field("changeRecoveryAddress", v)?;
+                    struct_ser.serialize_field("change_recovery_address", v)?;
                 }
             }
         }
@@ -1017,10 +1017,10 @@ impl serde::Serialize for IdentityUpdate {
         if self.client_timestamp_ns != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("clientTimestampNs", ToString::to_string(&self.client_timestamp_ns).as_str())?;
+            struct_ser.serialize_field("client_timestamp_ns", ToString::to_string(&self.client_timestamp_ns).as_str())?;
         }
         if !self.inbox_id.is_empty() {
-            struct_ser.serialize_field("inboxId", &self.inbox_id)?;
+            struct_ser.serialize_field("inbox_id", &self.inbox_id)?;
         }
         struct_ser.end()
     }
@@ -1144,7 +1144,7 @@ impl serde::Serialize for LegacyDelegatedSignature {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.identity.associations.LegacyDelegatedSignature", len)?;
         if let Some(v) = self.delegated_key.as_ref() {
-            struct_ser.serialize_field("delegatedKey", v)?;
+            struct_ser.serialize_field("delegated_key", v)?;
         }
         if let Some(v) = self.signature.as_ref() {
             struct_ser.serialize_field("signature", v)?;
@@ -1266,17 +1266,17 @@ impl serde::Serialize for Member {
             struct_ser.serialize_field("identifier", v)?;
         }
         if let Some(v) = self.added_by_entity.as_ref() {
-            struct_ser.serialize_field("addedByEntity", v)?;
+            struct_ser.serialize_field("added_by_entity", v)?;
         }
         if let Some(v) = self.client_timestamp_ns.as_ref() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("clientTimestampNs", ToString::to_string(&v).as_str())?;
+            struct_ser.serialize_field("client_timestamp_ns", ToString::to_string(&v).as_str())?;
         }
         if let Some(v) = self.added_on_chain_id.as_ref() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("addedOnChainId", ToString::to_string(&v).as_str())?;
+            struct_ser.serialize_field("added_on_chain_id", ToString::to_string(&v).as_str())?;
         }
         struct_ser.end()
     }
@@ -1413,12 +1413,12 @@ impl serde::Serialize for MemberIdentifier {
         if let Some(v) = self.kind.as_ref() {
             match v {
                 member_identifier::Kind::EthereumAddress(v) => {
-                    struct_ser.serialize_field("ethereumAddress", v)?;
+                    struct_ser.serialize_field("ethereum_address", v)?;
                 }
                 member_identifier::Kind::InstallationPublicKey(v) => {
                     #[allow(clippy::needless_borrow)]
                     #[allow(clippy::needless_borrows_for_generic_args)]
-                    struct_ser.serialize_field("installationPublicKey", pbjson::private::base64::encode(&v).as_str())?;
+                    struct_ser.serialize_field("installation_public_key", pbjson::private::base64::encode(&v).as_str())?;
                 }
                 member_identifier::Kind::Passkey(v) => {
                     struct_ser.serialize_field("passkey", v)?;
@@ -1659,7 +1659,7 @@ impl serde::Serialize for Passkey {
             struct_ser.serialize_field("key", pbjson::private::base64::encode(&self.key).as_str())?;
         }
         if let Some(v) = self.relying_party.as_ref() {
-            struct_ser.serialize_field("relyingParty", v)?;
+            struct_ser.serialize_field("relying_party", v)?;
         }
         struct_ser.end()
     }
@@ -1877,7 +1877,7 @@ impl serde::Serialize for RecoverableEd25519Signature {
         if !self.public_key.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("publicKey", pbjson::private::base64::encode(&self.public_key).as_str())?;
+            struct_ser.serialize_field("public_key", pbjson::private::base64::encode(&self.public_key).as_str())?;
         }
         struct_ser.end()
     }
@@ -1999,7 +1999,7 @@ impl serde::Serialize for RecoverablePasskeySignature {
         if !self.public_key.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("publicKey", pbjson::private::base64::encode(&self.public_key).as_str())?;
+            struct_ser.serialize_field("public_key", pbjson::private::base64::encode(&self.public_key).as_str())?;
         }
         if !self.signature.is_empty() {
             #[allow(clippy::needless_borrow)]
@@ -2009,12 +2009,12 @@ impl serde::Serialize for RecoverablePasskeySignature {
         if !self.authenticator_data.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("authenticatorData", pbjson::private::base64::encode(&self.authenticator_data).as_str())?;
+            struct_ser.serialize_field("authenticator_data", pbjson::private::base64::encode(&self.authenticator_data).as_str())?;
         }
         if !self.client_data_json.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("clientDataJson", pbjson::private::base64::encode(&self.client_data_json).as_str())?;
+            struct_ser.serialize_field("client_data_json", pbjson::private::base64::encode(&self.client_data_json).as_str())?;
         }
         struct_ser.end()
     }
@@ -2156,10 +2156,10 @@ impl serde::Serialize for RevokeAssociation {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.identity.associations.RevokeAssociation", len)?;
         if let Some(v) = self.member_to_revoke.as_ref() {
-            struct_ser.serialize_field("memberToRevoke", v)?;
+            struct_ser.serialize_field("member_to_revoke", v)?;
         }
         if let Some(v) = self.recovery_identifier_signature.as_ref() {
-            struct_ser.serialize_field("recoveryIdentifierSignature", v)?;
+            struct_ser.serialize_field("recovery_identifier_signature", v)?;
         }
         struct_ser.end()
     }
@@ -2269,16 +2269,16 @@ impl serde::Serialize for Signature {
         if let Some(v) = self.signature.as_ref() {
             match v {
                 signature::Signature::Erc191(v) => {
-                    struct_ser.serialize_field("erc191", v)?;
+                    struct_ser.serialize_field("erc_191", v)?;
                 }
                 signature::Signature::Erc6492(v) => {
-                    struct_ser.serialize_field("erc6492", v)?;
+                    struct_ser.serialize_field("erc_6492", v)?;
                 }
                 signature::Signature::InstallationKey(v) => {
-                    struct_ser.serialize_field("installationKey", v)?;
+                    struct_ser.serialize_field("installation_key", v)?;
                 }
                 signature::Signature::DelegatedErc191(v) => {
-                    struct_ser.serialize_field("delegatedErc191", v)?;
+                    struct_ser.serialize_field("delegated_erc_191", v)?;
                 }
                 signature::Signature::Passkey(v) => {
                     struct_ser.serialize_field("passkey", v)?;
@@ -2429,12 +2429,12 @@ impl serde::Serialize for SmartContractWalletSignature {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.identity.associations.SmartContractWalletSignature", len)?;
         if !self.account_id.is_empty() {
-            struct_ser.serialize_field("accountId", &self.account_id)?;
+            struct_ser.serialize_field("account_id", &self.account_id)?;
         }
         if self.block_number != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("blockNumber", ToString::to_string(&self.block_number).as_str())?;
+            struct_ser.serialize_field("block_number", ToString::to_string(&self.block_number).as_str())?;
         }
         if !self.signature.is_empty() {
             #[allow(clippy::needless_borrow)]

--- a/xmtp_proto/src/gen/xmtp.identity.associations.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.identity.associations.serde.rs
@@ -58,6 +58,7 @@ impl<'de> serde::Deserialize<'de> for AddAssociation {
             ExistingMemberSignature,
             NewMemberSignature,
             RelyingParty,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -83,7 +84,7 @@ impl<'de> serde::Deserialize<'de> for AddAssociation {
                             "existingMemberSignature" | "existing_member_signature" => Ok(GeneratedField::ExistingMemberSignature),
                             "newMemberSignature" | "new_member_signature" => Ok(GeneratedField::NewMemberSignature),
                             "relyingParty" | "relying_party" => Ok(GeneratedField::RelyingParty),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -131,6 +132,9 @@ impl<'de> serde::Deserialize<'de> for AddAssociation {
                                 return Err(serde::de::Error::duplicate_field("relyingParty"));
                             }
                             relying_party__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -223,6 +227,7 @@ impl<'de> serde::Deserialize<'de> for AssociationState {
             SeenSignatures,
             RecoveryIdentifierKind,
             RelyingParty,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -250,7 +255,7 @@ impl<'de> serde::Deserialize<'de> for AssociationState {
                             "seenSignatures" | "seen_signatures" => Ok(GeneratedField::SeenSignatures),
                             "recoveryIdentifierKind" | "recovery_identifier_kind" => Ok(GeneratedField::RecoveryIdentifierKind),
                             "relyingParty" | "relying_party" => Ok(GeneratedField::RelyingParty),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -316,6 +321,9 @@ impl<'de> serde::Deserialize<'de> for AssociationState {
                             }
                             relying_party__ = map_.next_value()?;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(AssociationState {
@@ -372,6 +380,7 @@ impl<'de> serde::Deserialize<'de> for AssociationStateDiff {
         enum GeneratedField {
             NewMembers,
             RemovedMembers,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -395,7 +404,7 @@ impl<'de> serde::Deserialize<'de> for AssociationStateDiff {
                         match value {
                             "newMembers" | "new_members" => Ok(GeneratedField::NewMembers),
                             "removedMembers" | "removed_members" => Ok(GeneratedField::RemovedMembers),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -429,6 +438,9 @@ impl<'de> serde::Deserialize<'de> for AssociationStateDiff {
                                 return Err(serde::de::Error::duplicate_field("removedMembers"));
                             }
                             removed_members__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -502,6 +514,7 @@ impl<'de> serde::Deserialize<'de> for ChangeRecoveryAddress {
             ExistingRecoveryIdentifierSignature,
             NewRecoveryIdentifierKind,
             RelyingParty,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -527,7 +540,7 @@ impl<'de> serde::Deserialize<'de> for ChangeRecoveryAddress {
                             "existingRecoveryIdentifierSignature" | "existing_recovery_identifier_signature" => Ok(GeneratedField::ExistingRecoveryIdentifierSignature),
                             "newRecoveryIdentifierKind" | "new_recovery_identifier_kind" => Ok(GeneratedField::NewRecoveryIdentifierKind),
                             "relyingParty" | "relying_party" => Ok(GeneratedField::RelyingParty),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -575,6 +588,9 @@ impl<'de> serde::Deserialize<'de> for ChangeRecoveryAddress {
                                 return Err(serde::de::Error::duplicate_field("relyingParty"));
                             }
                             relying_party__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -660,6 +676,7 @@ impl<'de> serde::Deserialize<'de> for CreateInbox {
             InitialIdentifierSignature,
             InitialIdentifierKind,
             RelyingParty,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -686,7 +703,7 @@ impl<'de> serde::Deserialize<'de> for CreateInbox {
                             "initialIdentifierSignature" | "initial_identifier_signature" => Ok(GeneratedField::InitialIdentifierSignature),
                             "initialIdentifierKind" | "initial_identifier_kind" => Ok(GeneratedField::InitialIdentifierKind),
                             "relyingParty" | "relying_party" => Ok(GeneratedField::RelyingParty),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -743,6 +760,9 @@ impl<'de> serde::Deserialize<'de> for CreateInbox {
                                 return Err(serde::de::Error::duplicate_field("relyingParty"));
                             }
                             relying_party__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -884,6 +904,7 @@ impl<'de> serde::Deserialize<'de> for IdentityAction {
             Add,
             Revoke,
             ChangeRecoveryAddress,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -909,7 +930,7 @@ impl<'de> serde::Deserialize<'de> for IdentityAction {
                             "add" => Ok(GeneratedField::Add),
                             "revoke" => Ok(GeneratedField::Revoke),
                             "changeRecoveryAddress" | "change_recovery_address" => Ok(GeneratedField::ChangeRecoveryAddress),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -958,6 +979,9 @@ impl<'de> serde::Deserialize<'de> for IdentityAction {
                             }
                             kind__ = map_.next_value::<::std::option::Option<_>>()?.map(identity_action::Kind::ChangeRecoveryAddress)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1020,6 +1044,7 @@ impl<'de> serde::Deserialize<'de> for IdentityUpdate {
             Actions,
             ClientTimestampNs,
             InboxId,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1044,7 +1069,7 @@ impl<'de> serde::Deserialize<'de> for IdentityUpdate {
                             "actions" => Ok(GeneratedField::Actions),
                             "clientTimestampNs" | "client_timestamp_ns" => Ok(GeneratedField::ClientTimestampNs),
                             "inboxId" | "inbox_id" => Ok(GeneratedField::InboxId),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1087,6 +1112,9 @@ impl<'de> serde::Deserialize<'de> for IdentityUpdate {
                                 return Err(serde::de::Error::duplicate_field("inboxId"));
                             }
                             inbox_id__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1140,6 +1168,7 @@ impl<'de> serde::Deserialize<'de> for LegacyDelegatedSignature {
         enum GeneratedField {
             DelegatedKey,
             Signature,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1163,7 +1192,7 @@ impl<'de> serde::Deserialize<'de> for LegacyDelegatedSignature {
                         match value {
                             "delegatedKey" | "delegated_key" => Ok(GeneratedField::DelegatedKey),
                             "signature" => Ok(GeneratedField::Signature),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1197,6 +1226,9 @@ impl<'de> serde::Deserialize<'de> for LegacyDelegatedSignature {
                                 return Err(serde::de::Error::duplicate_field("signature"));
                             }
                             signature__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1271,6 +1303,7 @@ impl<'de> serde::Deserialize<'de> for Member {
             AddedByEntity,
             ClientTimestampNs,
             AddedOnChainId,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1296,7 +1329,7 @@ impl<'de> serde::Deserialize<'de> for Member {
                             "addedByEntity" | "added_by_entity" => Ok(GeneratedField::AddedByEntity),
                             "clientTimestampNs" | "client_timestamp_ns" => Ok(GeneratedField::ClientTimestampNs),
                             "addedOnChainId" | "added_on_chain_id" => Ok(GeneratedField::AddedOnChainId),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1348,6 +1381,9 @@ impl<'de> serde::Deserialize<'de> for Member {
                             added_on_chain_id__ = 
                                 map_.next_value::<::std::option::Option<::pbjson::private::NumberDeserialize<_>>>()?.map(|x| x.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1411,6 +1447,7 @@ impl<'de> serde::Deserialize<'de> for MemberIdentifier {
             EthereumAddress,
             InstallationPublicKey,
             Passkey,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1435,7 +1472,7 @@ impl<'de> serde::Deserialize<'de> for MemberIdentifier {
                             "ethereumAddress" | "ethereum_address" => Ok(GeneratedField::EthereumAddress),
                             "installationPublicKey" | "installation_public_key" => Ok(GeneratedField::InstallationPublicKey),
                             "passkey" => Ok(GeneratedField::Passkey),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1475,6 +1512,9 @@ impl<'de> serde::Deserialize<'de> for MemberIdentifier {
                             }
                             kind__ = map_.next_value::<::std::option::Option<_>>()?.map(member_identifier::Kind::Passkey)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1525,6 +1565,7 @@ impl<'de> serde::Deserialize<'de> for MemberMap {
         enum GeneratedField {
             Key,
             Value,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1548,7 +1589,7 @@ impl<'de> serde::Deserialize<'de> for MemberMap {
                         match value {
                             "key" => Ok(GeneratedField::Key),
                             "value" => Ok(GeneratedField::Value),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1582,6 +1623,9 @@ impl<'de> serde::Deserialize<'de> for MemberMap {
                                 return Err(serde::de::Error::duplicate_field("value"));
                             }
                             value__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1636,6 +1680,7 @@ impl<'de> serde::Deserialize<'de> for Passkey {
         enum GeneratedField {
             Key,
             RelyingParty,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1659,7 +1704,7 @@ impl<'de> serde::Deserialize<'de> for Passkey {
                         match value {
                             "key" => Ok(GeneratedField::Key),
                             "relyingParty" | "relying_party" => Ok(GeneratedField::RelyingParty),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1695,6 +1740,9 @@ impl<'de> serde::Deserialize<'de> for Passkey {
                                 return Err(serde::de::Error::duplicate_field("relyingParty"));
                             }
                             relying_party__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1740,6 +1788,7 @@ impl<'de> serde::Deserialize<'de> for RecoverableEcdsaSignature {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Bytes,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1762,7 +1811,7 @@ impl<'de> serde::Deserialize<'de> for RecoverableEcdsaSignature {
                     {
                         match value {
                             "bytes" => Ok(GeneratedField::Bytes),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1791,6 +1840,9 @@ impl<'de> serde::Deserialize<'de> for RecoverableEcdsaSignature {
                             bytes__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1846,6 +1898,7 @@ impl<'de> serde::Deserialize<'de> for RecoverableEd25519Signature {
         enum GeneratedField {
             Bytes,
             PublicKey,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1869,7 +1922,7 @@ impl<'de> serde::Deserialize<'de> for RecoverableEd25519Signature {
                         match value {
                             "bytes" => Ok(GeneratedField::Bytes),
                             "publicKey" | "public_key" => Ok(GeneratedField::PublicKey),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1907,6 +1960,9 @@ impl<'de> serde::Deserialize<'de> for RecoverableEd25519Signature {
                             public_key__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1985,6 +2041,7 @@ impl<'de> serde::Deserialize<'de> for RecoverablePasskeySignature {
             Signature,
             AuthenticatorData,
             ClientDataJson,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2010,7 +2067,7 @@ impl<'de> serde::Deserialize<'de> for RecoverablePasskeySignature {
                             "signature" => Ok(GeneratedField::Signature),
                             "authenticatorData" | "authenticator_data" => Ok(GeneratedField::AuthenticatorData),
                             "clientDataJson" | "client_data_json" => Ok(GeneratedField::ClientDataJson),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2067,6 +2124,9 @@ impl<'de> serde::Deserialize<'de> for RecoverablePasskeySignature {
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(RecoverablePasskeySignature {
@@ -2121,6 +2181,7 @@ impl<'de> serde::Deserialize<'de> for RevokeAssociation {
         enum GeneratedField {
             MemberToRevoke,
             RecoveryIdentifierSignature,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2144,7 +2205,7 @@ impl<'de> serde::Deserialize<'de> for RevokeAssociation {
                         match value {
                             "memberToRevoke" | "member_to_revoke" => Ok(GeneratedField::MemberToRevoke),
                             "recoveryIdentifierSignature" | "recovery_identifier_signature" => Ok(GeneratedField::RecoveryIdentifierSignature),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2178,6 +2239,9 @@ impl<'de> serde::Deserialize<'de> for RevokeAssociation {
                                 return Err(serde::de::Error::duplicate_field("recoveryIdentifierSignature"));
                             }
                             recovery_identifier_signature__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2249,6 +2313,7 @@ impl<'de> serde::Deserialize<'de> for Signature {
             InstallationKey,
             DelegatedErc191,
             Passkey,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2275,7 +2340,7 @@ impl<'de> serde::Deserialize<'de> for Signature {
                             "installationKey" | "installation_key" => Ok(GeneratedField::InstallationKey),
                             "delegatedErc191" | "delegated_erc_191" => Ok(GeneratedField::DelegatedErc191),
                             "passkey" => Ok(GeneratedField::Passkey),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2331,6 +2396,9 @@ impl<'de> serde::Deserialize<'de> for Signature {
                             }
                             signature__ = map_.next_value::<::std::option::Option<_>>()?.map(signature::Signature::Passkey)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2395,6 +2463,7 @@ impl<'de> serde::Deserialize<'de> for SmartContractWalletSignature {
             AccountId,
             BlockNumber,
             Signature,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2419,7 +2488,7 @@ impl<'de> serde::Deserialize<'de> for SmartContractWalletSignature {
                             "accountId" | "account_id" => Ok(GeneratedField::AccountId),
                             "blockNumber" | "block_number" => Ok(GeneratedField::BlockNumber),
                             "signature" => Ok(GeneratedField::Signature),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2464,6 +2533,9 @@ impl<'de> serde::Deserialize<'de> for SmartContractWalletSignature {
                             signature__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }

--- a/xmtp_proto/src/gen/xmtp.identity.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.identity.serde.rs
@@ -31,6 +31,7 @@ impl<'de> serde::Deserialize<'de> for MlsCredential {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             InboxId,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -53,7 +54,7 @@ impl<'de> serde::Deserialize<'de> for MlsCredential {
                     {
                         match value {
                             "inboxId" | "inbox_id" => Ok(GeneratedField::InboxId),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -80,6 +81,9 @@ impl<'de> serde::Deserialize<'de> for MlsCredential {
                                 return Err(serde::de::Error::duplicate_field("inboxId"));
                             }
                             inbox_id__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }

--- a/xmtp_proto/src/gen/xmtp.identity.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.identity.serde.rs
@@ -12,7 +12,7 @@ impl serde::Serialize for MlsCredential {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.identity.MlsCredential", len)?;
         if !self.inbox_id.is_empty() {
-            struct_ser.serialize_field("inboxId", &self.inbox_id)?;
+            struct_ser.serialize_field("inbox_id", &self.inbox_id)?;
         }
         struct_ser.end()
     }

--- a/xmtp_proto/src/gen/xmtp.keystore_api.v1.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.keystore_api.v1.serde.rs
@@ -33,6 +33,7 @@ impl<'de> serde::Deserialize<'de> for CreateAuthTokenRequest {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             TimestampNs,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -55,7 +56,7 @@ impl<'de> serde::Deserialize<'de> for CreateAuthTokenRequest {
                     {
                         match value {
                             "timestampNs" | "timestamp_ns" => Ok(GeneratedField::TimestampNs),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -84,6 +85,9 @@ impl<'de> serde::Deserialize<'de> for CreateAuthTokenRequest {
                             timestamp_ns__ = 
                                 map_.next_value::<::std::option::Option<::pbjson::private::NumberDeserialize<_>>>()?.map(|x| x.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -154,6 +158,7 @@ impl<'de> serde::Deserialize<'de> for CreateInviteRequest {
             Recipient,
             CreatedNs,
             ConsentProof,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -179,7 +184,7 @@ impl<'de> serde::Deserialize<'de> for CreateInviteRequest {
                             "recipient" => Ok(GeneratedField::Recipient),
                             "createdNs" | "created_ns" => Ok(GeneratedField::CreatedNs),
                             "consentProof" | "consent_proof" => Ok(GeneratedField::ConsentProof),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -229,6 +234,9 @@ impl<'de> serde::Deserialize<'de> for CreateInviteRequest {
                                 return Err(serde::de::Error::duplicate_field("consentProof"));
                             }
                             consent_proof__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -284,6 +292,7 @@ impl<'de> serde::Deserialize<'de> for CreateInviteResponse {
         enum GeneratedField {
             Conversation,
             Payload,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -307,7 +316,7 @@ impl<'de> serde::Deserialize<'de> for CreateInviteResponse {
                         match value {
                             "conversation" => Ok(GeneratedField::Conversation),
                             "payload" => Ok(GeneratedField::Payload),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -343,6 +352,9 @@ impl<'de> serde::Deserialize<'de> for CreateInviteResponse {
                             payload__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -386,6 +398,7 @@ impl<'de> serde::Deserialize<'de> for DecryptResponse {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Responses,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -408,7 +421,7 @@ impl<'de> serde::Deserialize<'de> for DecryptResponse {
                     {
                         match value {
                             "responses" => Ok(GeneratedField::Responses),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -435,6 +448,9 @@ impl<'de> serde::Deserialize<'de> for DecryptResponse {
                                 return Err(serde::de::Error::duplicate_field("responses"));
                             }
                             responses__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -486,6 +502,7 @@ impl<'de> serde::Deserialize<'de> for decrypt_response::Response {
         enum GeneratedField {
             Result,
             Error,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -509,7 +526,7 @@ impl<'de> serde::Deserialize<'de> for decrypt_response::Response {
                         match value {
                             "result" => Ok(GeneratedField::Result),
                             "error" => Ok(GeneratedField::Error),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -544,6 +561,9 @@ impl<'de> serde::Deserialize<'de> for decrypt_response::Response {
                             }
                             response__ = map_.next_value::<::std::option::Option<_>>()?.map(decrypt_response::response::Response::Error)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -588,6 +608,7 @@ impl<'de> serde::Deserialize<'de> for decrypt_response::response::Success {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Decrypted,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -610,7 +631,7 @@ impl<'de> serde::Deserialize<'de> for decrypt_response::response::Success {
                     {
                         match value {
                             "decrypted" => Ok(GeneratedField::Decrypted),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -639,6 +660,9 @@ impl<'de> serde::Deserialize<'de> for decrypt_response::response::Success {
                             decrypted__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -681,6 +705,7 @@ impl<'de> serde::Deserialize<'de> for DecryptV1Request {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Requests,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -703,7 +728,7 @@ impl<'de> serde::Deserialize<'de> for DecryptV1Request {
                     {
                         match value {
                             "requests" => Ok(GeneratedField::Requests),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -730,6 +755,9 @@ impl<'de> serde::Deserialize<'de> for DecryptV1Request {
                                 return Err(serde::de::Error::duplicate_field("requests"));
                             }
                             requests__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -801,6 +829,7 @@ impl<'de> serde::Deserialize<'de> for decrypt_v1_request::Request {
             PeerKeys,
             HeaderBytes,
             IsSender,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -826,7 +855,7 @@ impl<'de> serde::Deserialize<'de> for decrypt_v1_request::Request {
                             "peerKeys" | "peer_keys" => Ok(GeneratedField::PeerKeys),
                             "headerBytes" | "header_bytes" => Ok(GeneratedField::HeaderBytes),
                             "isSender" | "is_sender" => Ok(GeneratedField::IsSender),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -877,6 +906,9 @@ impl<'de> serde::Deserialize<'de> for decrypt_v1_request::Request {
                             }
                             is_sender__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(decrypt_v1_request::Request {
@@ -921,6 +953,7 @@ impl<'de> serde::Deserialize<'de> for DecryptV2Request {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Requests,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -943,7 +976,7 @@ impl<'de> serde::Deserialize<'de> for DecryptV2Request {
                     {
                         match value {
                             "requests" => Ok(GeneratedField::Requests),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -970,6 +1003,9 @@ impl<'de> serde::Deserialize<'de> for DecryptV2Request {
                                 return Err(serde::de::Error::duplicate_field("requests"));
                             }
                             requests__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1032,6 +1068,7 @@ impl<'de> serde::Deserialize<'de> for decrypt_v2_request::Request {
             Payload,
             HeaderBytes,
             ContentTopic,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1056,7 +1093,7 @@ impl<'de> serde::Deserialize<'de> for decrypt_v2_request::Request {
                             "payload" => Ok(GeneratedField::Payload),
                             "headerBytes" | "header_bytes" => Ok(GeneratedField::HeaderBytes),
                             "contentTopic" | "content_topic" => Ok(GeneratedField::ContentTopic),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1099,6 +1136,9 @@ impl<'de> serde::Deserialize<'de> for decrypt_v2_request::Request {
                                 return Err(serde::de::Error::duplicate_field("contentTopic"));
                             }
                             content_topic__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1143,6 +1183,7 @@ impl<'de> serde::Deserialize<'de> for EncryptResponse {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Responses,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1165,7 +1206,7 @@ impl<'de> serde::Deserialize<'de> for EncryptResponse {
                     {
                         match value {
                             "responses" => Ok(GeneratedField::Responses),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1192,6 +1233,9 @@ impl<'de> serde::Deserialize<'de> for EncryptResponse {
                                 return Err(serde::de::Error::duplicate_field("responses"));
                             }
                             responses__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1243,6 +1287,7 @@ impl<'de> serde::Deserialize<'de> for encrypt_response::Response {
         enum GeneratedField {
             Result,
             Error,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1266,7 +1311,7 @@ impl<'de> serde::Deserialize<'de> for encrypt_response::Response {
                         match value {
                             "result" => Ok(GeneratedField::Result),
                             "error" => Ok(GeneratedField::Error),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1301,6 +1346,9 @@ impl<'de> serde::Deserialize<'de> for encrypt_response::Response {
                             }
                             response__ = map_.next_value::<::std::option::Option<_>>()?.map(encrypt_response::response::Response::Error)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1354,6 +1402,7 @@ impl<'de> serde::Deserialize<'de> for encrypt_response::response::Success {
         enum GeneratedField {
             Encrypted,
             SenderHmac,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1377,7 +1426,7 @@ impl<'de> serde::Deserialize<'de> for encrypt_response::response::Success {
                         match value {
                             "encrypted" => Ok(GeneratedField::Encrypted),
                             "senderHmac" | "sender_hmac" => Ok(GeneratedField::SenderHmac),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1413,6 +1462,9 @@ impl<'de> serde::Deserialize<'de> for encrypt_response::response::Success {
                             sender_hmac__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1456,6 +1508,7 @@ impl<'de> serde::Deserialize<'de> for EncryptV1Request {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Requests,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1478,7 +1531,7 @@ impl<'de> serde::Deserialize<'de> for EncryptV1Request {
                     {
                         match value {
                             "requests" => Ok(GeneratedField::Requests),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1505,6 +1558,9 @@ impl<'de> serde::Deserialize<'de> for EncryptV1Request {
                                 return Err(serde::de::Error::duplicate_field("requests"));
                             }
                             requests__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1568,6 +1624,7 @@ impl<'de> serde::Deserialize<'de> for encrypt_v1_request::Request {
             Recipient,
             Payload,
             HeaderBytes,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1592,7 +1649,7 @@ impl<'de> serde::Deserialize<'de> for encrypt_v1_request::Request {
                             "recipient" => Ok(GeneratedField::Recipient),
                             "payload" => Ok(GeneratedField::Payload),
                             "headerBytes" | "header_bytes" => Ok(GeneratedField::HeaderBytes),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1638,6 +1695,9 @@ impl<'de> serde::Deserialize<'de> for encrypt_v1_request::Request {
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(encrypt_v1_request::Request {
@@ -1681,6 +1741,7 @@ impl<'de> serde::Deserialize<'de> for EncryptV2Request {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Requests,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1703,7 +1764,7 @@ impl<'de> serde::Deserialize<'de> for EncryptV2Request {
                     {
                         match value {
                             "requests" => Ok(GeneratedField::Requests),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1730,6 +1791,9 @@ impl<'de> serde::Deserialize<'de> for EncryptV2Request {
                                 return Err(serde::de::Error::duplicate_field("requests"));
                             }
                             requests__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1794,6 +1858,7 @@ impl<'de> serde::Deserialize<'de> for encrypt_v2_request::Request {
             Payload,
             HeaderBytes,
             ContentTopic,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1818,7 +1883,7 @@ impl<'de> serde::Deserialize<'de> for encrypt_v2_request::Request {
                             "payload" => Ok(GeneratedField::Payload),
                             "headerBytes" | "header_bytes" => Ok(GeneratedField::HeaderBytes),
                             "contentTopic" | "content_topic" => Ok(GeneratedField::ContentTopic),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1863,6 +1928,9 @@ impl<'de> serde::Deserialize<'de> for encrypt_v2_request::Request {
                                 return Err(serde::de::Error::duplicate_field("contentTopic"));
                             }
                             content_topic__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1981,6 +2049,7 @@ impl<'de> serde::Deserialize<'de> for GetConversationHmacKeysRequest {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Topics,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2003,7 +2072,7 @@ impl<'de> serde::Deserialize<'de> for GetConversationHmacKeysRequest {
                     {
                         match value {
                             "topics" => Ok(GeneratedField::Topics),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2030,6 +2099,9 @@ impl<'de> serde::Deserialize<'de> for GetConversationHmacKeysRequest {
                                 return Err(serde::de::Error::duplicate_field("topics"));
                             }
                             topics__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2073,6 +2145,7 @@ impl<'de> serde::Deserialize<'de> for GetConversationHmacKeysResponse {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             HmacKeys,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2095,7 +2168,7 @@ impl<'de> serde::Deserialize<'de> for GetConversationHmacKeysResponse {
                     {
                         match value {
                             "hmacKeys" | "hmac_keys" => Ok(GeneratedField::HmacKeys),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2124,6 +2197,9 @@ impl<'de> serde::Deserialize<'de> for GetConversationHmacKeysResponse {
                             hmac_keys__ = Some(
                                 map_.next_value::<std::collections::HashMap<_, _>>()?
                             );
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2178,6 +2254,7 @@ impl<'de> serde::Deserialize<'de> for get_conversation_hmac_keys_response::HmacK
         enum GeneratedField {
             ThirtyDayPeriodsSinceEpoch,
             HmacKey,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2201,7 +2278,7 @@ impl<'de> serde::Deserialize<'de> for get_conversation_hmac_keys_response::HmacK
                         match value {
                             "thirtyDayPeriodsSinceEpoch" | "thirty_day_periods_since_epoch" => Ok(GeneratedField::ThirtyDayPeriodsSinceEpoch),
                             "hmacKey" | "hmac_key" => Ok(GeneratedField::HmacKey),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2239,6 +2316,9 @@ impl<'de> serde::Deserialize<'de> for get_conversation_hmac_keys_response::HmacK
                             hmac_key__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2282,6 +2362,7 @@ impl<'de> serde::Deserialize<'de> for get_conversation_hmac_keys_response::HmacK
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Values,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2304,7 +2385,7 @@ impl<'de> serde::Deserialize<'de> for get_conversation_hmac_keys_response::HmacK
                     {
                         match value {
                             "values" => Ok(GeneratedField::Values),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2331,6 +2412,9 @@ impl<'de> serde::Deserialize<'de> for get_conversation_hmac_keys_response::HmacK
                                 return Err(serde::de::Error::duplicate_field("values"));
                             }
                             values__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2373,6 +2457,7 @@ impl<'de> serde::Deserialize<'de> for GetConversationsResponse {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Conversations,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2395,7 +2480,7 @@ impl<'de> serde::Deserialize<'de> for GetConversationsResponse {
                     {
                         match value {
                             "conversations" => Ok(GeneratedField::Conversations),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2422,6 +2507,9 @@ impl<'de> serde::Deserialize<'de> for GetConversationsResponse {
                                 return Err(serde::de::Error::duplicate_field("conversations"));
                             }
                             conversations__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2465,6 +2553,7 @@ impl<'de> serde::Deserialize<'de> for GetKeystoreStatusRequest {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             WalletAddress,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2487,7 +2576,7 @@ impl<'de> serde::Deserialize<'de> for GetKeystoreStatusRequest {
                     {
                         match value {
                             "walletAddress" | "wallet_address" => Ok(GeneratedField::WalletAddress),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2514,6 +2603,9 @@ impl<'de> serde::Deserialize<'de> for GetKeystoreStatusRequest {
                                 return Err(serde::de::Error::duplicate_field("walletAddress"));
                             }
                             wallet_address__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2558,6 +2650,7 @@ impl<'de> serde::Deserialize<'de> for GetKeystoreStatusResponse {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Status,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2580,7 +2673,7 @@ impl<'de> serde::Deserialize<'de> for GetKeystoreStatusResponse {
                     {
                         match value {
                             "status" => Ok(GeneratedField::Status),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2607,6 +2700,9 @@ impl<'de> serde::Deserialize<'de> for GetKeystoreStatusResponse {
                                 return Err(serde::de::Error::duplicate_field("status"));
                             }
                             status__ = Some(map_.next_value::<get_keystore_status_response::KeystoreStatus>()? as i32);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2723,6 +2819,7 @@ impl<'de> serde::Deserialize<'de> for GetPrivatePreferencesTopicIdentifierRespon
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Identifier,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2745,7 +2842,7 @@ impl<'de> serde::Deserialize<'de> for GetPrivatePreferencesTopicIdentifierRespon
                     {
                         match value {
                             "identifier" => Ok(GeneratedField::Identifier),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2772,6 +2869,9 @@ impl<'de> serde::Deserialize<'de> for GetPrivatePreferencesTopicIdentifierRespon
                                 return Err(serde::de::Error::duplicate_field("identifier"));
                             }
                             identifier__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2817,6 +2917,7 @@ impl<'de> serde::Deserialize<'de> for GetRefreshJobRequest {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             JobType,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2839,7 +2940,7 @@ impl<'de> serde::Deserialize<'de> for GetRefreshJobRequest {
                     {
                         match value {
                             "jobType" | "job_type" => Ok(GeneratedField::JobType),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2866,6 +2967,9 @@ impl<'de> serde::Deserialize<'de> for GetRefreshJobRequest {
                                 return Err(serde::de::Error::duplicate_field("jobType"));
                             }
                             job_type__ = Some(map_.next_value::<JobType>()? as i32);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2911,6 +3015,7 @@ impl<'de> serde::Deserialize<'de> for GetRefreshJobResponse {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             LastRunNs,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2933,7 +3038,7 @@ impl<'de> serde::Deserialize<'de> for GetRefreshJobResponse {
                     {
                         match value {
                             "lastRunNs" | "last_run_ns" => Ok(GeneratedField::LastRunNs),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2962,6 +3067,9 @@ impl<'de> serde::Deserialize<'de> for GetRefreshJobResponse {
                             last_run_ns__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3008,6 +3116,7 @@ impl<'de> serde::Deserialize<'de> for InitKeystoreRequest {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             V1,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3030,7 +3139,7 @@ impl<'de> serde::Deserialize<'de> for InitKeystoreRequest {
                     {
                         match value {
                             "v1" => Ok(GeneratedField::V1),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3058,6 +3167,9 @@ impl<'de> serde::Deserialize<'de> for InitKeystoreRequest {
                             }
                             bundle__ = map_.next_value::<::std::option::Option<_>>()?.map(init_keystore_request::Bundle::V1)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3100,6 +3212,7 @@ impl<'de> serde::Deserialize<'de> for InitKeystoreResponse {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Error,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3122,7 +3235,7 @@ impl<'de> serde::Deserialize<'de> for InitKeystoreResponse {
                     {
                         match value {
                             "error" => Ok(GeneratedField::Error),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3149,6 +3262,9 @@ impl<'de> serde::Deserialize<'de> for InitKeystoreResponse {
                                 return Err(serde::de::Error::duplicate_field("error"));
                             }
                             error__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3278,6 +3394,7 @@ impl<'de> serde::Deserialize<'de> for KeystoreError {
         enum GeneratedField {
             Message,
             Code,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3301,7 +3418,7 @@ impl<'de> serde::Deserialize<'de> for KeystoreError {
                         match value {
                             "message" => Ok(GeneratedField::Message),
                             "code" => Ok(GeneratedField::Code),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3335,6 +3452,9 @@ impl<'de> serde::Deserialize<'de> for KeystoreError {
                                 return Err(serde::de::Error::duplicate_field("code"));
                             }
                             code__ = Some(map_.next_value::<ErrorCode>()? as i32);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3378,6 +3498,7 @@ impl<'de> serde::Deserialize<'de> for PrivatePreferencesActionMap {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Actions,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3400,7 +3521,7 @@ impl<'de> serde::Deserialize<'de> for PrivatePreferencesActionMap {
                     {
                         match value {
                             "actions" => Ok(GeneratedField::Actions),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3429,6 +3550,9 @@ impl<'de> serde::Deserialize<'de> for PrivatePreferencesActionMap {
                             actions__ = Some(
                                 map_.next_value::<std::collections::HashMap<_, _>>()?
                             );
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3471,6 +3595,7 @@ impl<'de> serde::Deserialize<'de> for SaveInvitesRequest {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Requests,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3493,7 +3618,7 @@ impl<'de> serde::Deserialize<'de> for SaveInvitesRequest {
                     {
                         match value {
                             "requests" => Ok(GeneratedField::Requests),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3520,6 +3645,9 @@ impl<'de> serde::Deserialize<'de> for SaveInvitesRequest {
                                 return Err(serde::de::Error::duplicate_field("requests"));
                             }
                             requests__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3584,6 +3712,7 @@ impl<'de> serde::Deserialize<'de> for save_invites_request::Request {
             ContentTopic,
             TimestampNs,
             Payload,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3608,7 +3737,7 @@ impl<'de> serde::Deserialize<'de> for save_invites_request::Request {
                             "contentTopic" | "content_topic" => Ok(GeneratedField::ContentTopic),
                             "timestampNs" | "timestamp_ns" => Ok(GeneratedField::TimestampNs),
                             "payload" => Ok(GeneratedField::Payload),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3654,6 +3783,9 @@ impl<'de> serde::Deserialize<'de> for save_invites_request::Request {
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(save_invites_request::Request {
@@ -3697,6 +3829,7 @@ impl<'de> serde::Deserialize<'de> for SaveInvitesResponse {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Responses,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3719,7 +3852,7 @@ impl<'de> serde::Deserialize<'de> for SaveInvitesResponse {
                     {
                         match value {
                             "responses" => Ok(GeneratedField::Responses),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3746,6 +3879,9 @@ impl<'de> serde::Deserialize<'de> for SaveInvitesResponse {
                                 return Err(serde::de::Error::duplicate_field("responses"));
                             }
                             responses__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3797,6 +3933,7 @@ impl<'de> serde::Deserialize<'de> for save_invites_response::Response {
         enum GeneratedField {
             Result,
             Error,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3820,7 +3957,7 @@ impl<'de> serde::Deserialize<'de> for save_invites_response::Response {
                         match value {
                             "result" => Ok(GeneratedField::Result),
                             "error" => Ok(GeneratedField::Error),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3855,6 +3992,9 @@ impl<'de> serde::Deserialize<'de> for save_invites_response::Response {
                             }
                             response__ = map_.next_value::<::std::option::Option<_>>()?.map(save_invites_response::response::Response::Error)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3897,6 +4037,7 @@ impl<'de> serde::Deserialize<'de> for save_invites_response::response::Success {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Conversation,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3919,7 +4060,7 @@ impl<'de> serde::Deserialize<'de> for save_invites_response::response::Success {
                     {
                         match value {
                             "conversation" => Ok(GeneratedField::Conversation),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3946,6 +4087,9 @@ impl<'de> serde::Deserialize<'de> for save_invites_response::response::Success {
                                 return Err(serde::de::Error::duplicate_field("conversation"));
                             }
                             conversation__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3988,6 +4132,7 @@ impl<'de> serde::Deserialize<'de> for SaveV1ConversationsRequest {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Conversations,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4010,7 +4155,7 @@ impl<'de> serde::Deserialize<'de> for SaveV1ConversationsRequest {
                     {
                         match value {
                             "conversations" => Ok(GeneratedField::Conversations),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -4037,6 +4182,9 @@ impl<'de> serde::Deserialize<'de> for SaveV1ConversationsRequest {
                                 return Err(serde::de::Error::duplicate_field("conversations"));
                             }
                             conversations__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -4071,6 +4219,7 @@ impl<'de> serde::Deserialize<'de> for SaveV1ConversationsResponse {
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4091,7 +4240,7 @@ impl<'de> serde::Deserialize<'de> for SaveV1ConversationsResponse {
                     where
                         E: serde::de::Error,
                     {
-                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                            Ok(GeneratedField::__SkipField__)
                     }
                 }
                 deserializer.deserialize_identifier(GeneratedVisitor)
@@ -4150,6 +4299,7 @@ impl<'de> serde::Deserialize<'de> for SelfDecryptRequest {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Requests,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4172,7 +4322,7 @@ impl<'de> serde::Deserialize<'de> for SelfDecryptRequest {
                     {
                         match value {
                             "requests" => Ok(GeneratedField::Requests),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -4199,6 +4349,9 @@ impl<'de> serde::Deserialize<'de> for SelfDecryptRequest {
                                 return Err(serde::de::Error::duplicate_field("requests"));
                             }
                             requests__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -4243,6 +4396,7 @@ impl<'de> serde::Deserialize<'de> for self_decrypt_request::Request {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Payload,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4265,7 +4419,7 @@ impl<'de> serde::Deserialize<'de> for self_decrypt_request::Request {
                     {
                         match value {
                             "payload" => Ok(GeneratedField::Payload),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -4294,6 +4448,9 @@ impl<'de> serde::Deserialize<'de> for self_decrypt_request::Request {
                             payload__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -4336,6 +4493,7 @@ impl<'de> serde::Deserialize<'de> for SelfEncryptRequest {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Requests,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4358,7 +4516,7 @@ impl<'de> serde::Deserialize<'de> for SelfEncryptRequest {
                     {
                         match value {
                             "requests" => Ok(GeneratedField::Requests),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -4385,6 +4543,9 @@ impl<'de> serde::Deserialize<'de> for SelfEncryptRequest {
                                 return Err(serde::de::Error::duplicate_field("requests"));
                             }
                             requests__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -4429,6 +4590,7 @@ impl<'de> serde::Deserialize<'de> for self_encrypt_request::Request {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Payload,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4451,7 +4613,7 @@ impl<'de> serde::Deserialize<'de> for self_encrypt_request::Request {
                     {
                         match value {
                             "payload" => Ok(GeneratedField::Payload),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -4480,6 +4642,9 @@ impl<'de> serde::Deserialize<'de> for self_encrypt_request::Request {
                             payload__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -4522,6 +4687,7 @@ impl<'de> serde::Deserialize<'de> for SelfEncryptResponse {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Responses,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4544,7 +4710,7 @@ impl<'de> serde::Deserialize<'de> for SelfEncryptResponse {
                     {
                         match value {
                             "responses" => Ok(GeneratedField::Responses),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -4571,6 +4737,9 @@ impl<'de> serde::Deserialize<'de> for SelfEncryptResponse {
                                 return Err(serde::de::Error::duplicate_field("responses"));
                             }
                             responses__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -4622,6 +4791,7 @@ impl<'de> serde::Deserialize<'de> for self_encrypt_response::Response {
         enum GeneratedField {
             Result,
             Error,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4645,7 +4815,7 @@ impl<'de> serde::Deserialize<'de> for self_encrypt_response::Response {
                         match value {
                             "result" => Ok(GeneratedField::Result),
                             "error" => Ok(GeneratedField::Error),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -4680,6 +4850,9 @@ impl<'de> serde::Deserialize<'de> for self_encrypt_response::Response {
                             }
                             response__ = map_.next_value::<::std::option::Option<_>>()?.map(self_encrypt_response::response::Response::Error)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -4724,6 +4897,7 @@ impl<'de> serde::Deserialize<'de> for self_encrypt_response::response::Success {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Encrypted,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4746,7 +4920,7 @@ impl<'de> serde::Deserialize<'de> for self_encrypt_response::response::Success {
                     {
                         match value {
                             "encrypted" => Ok(GeneratedField::Encrypted),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -4775,6 +4949,9 @@ impl<'de> serde::Deserialize<'de> for self_encrypt_response::response::Success {
                             encrypted__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -4831,6 +5008,7 @@ impl<'de> serde::Deserialize<'de> for SetRefeshJobRequest {
         enum GeneratedField {
             JobType,
             LastRunNs,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4854,7 +5032,7 @@ impl<'de> serde::Deserialize<'de> for SetRefeshJobRequest {
                         match value {
                             "jobType" | "job_type" => Ok(GeneratedField::JobType),
                             "lastRunNs" | "last_run_ns" => Ok(GeneratedField::LastRunNs),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -4891,6 +5069,9 @@ impl<'de> serde::Deserialize<'de> for SetRefeshJobRequest {
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(SetRefeshJobRequest {
@@ -4925,6 +5106,7 @@ impl<'de> serde::Deserialize<'de> for SetRefreshJobResponse {
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4945,7 +5127,7 @@ impl<'de> serde::Deserialize<'de> for SetRefreshJobResponse {
                     where
                         E: serde::de::Error,
                     {
-                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                            Ok(GeneratedField::__SkipField__)
                     }
                 }
                 deserializer.deserialize_identifier(GeneratedVisitor)
@@ -5025,6 +5207,7 @@ impl<'de> serde::Deserialize<'de> for SignDigestRequest {
             Digest,
             IdentityKey,
             PrekeyIndex,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -5049,7 +5232,7 @@ impl<'de> serde::Deserialize<'de> for SignDigestRequest {
                             "digest" => Ok(GeneratedField::Digest),
                             "identityKey" | "identity_key" => Ok(GeneratedField::IdentityKey),
                             "prekeyIndex" | "prekey_index" => Ok(GeneratedField::PrekeyIndex),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -5091,6 +5274,9 @@ impl<'de> serde::Deserialize<'de> for SignDigestRequest {
                                 return Err(serde::de::Error::duplicate_field("prekeyIndex"));
                             }
                             signer__ = map_.next_value::<::std::option::Option<::pbjson::private::NumberDeserialize<_>>>()?.map(|x| sign_digest_request::Signer::PrekeyIndex(x.0));
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -5134,6 +5320,7 @@ impl<'de> serde::Deserialize<'de> for TopicMap {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Topics,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -5156,7 +5343,7 @@ impl<'de> serde::Deserialize<'de> for TopicMap {
                     {
                         match value {
                             "topics" => Ok(GeneratedField::Topics),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -5185,6 +5372,9 @@ impl<'de> serde::Deserialize<'de> for TopicMap {
                             topics__ = Some(
                                 map_.next_value::<std::collections::HashMap<_, _>>()?
                             );
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -5247,6 +5437,7 @@ impl<'de> serde::Deserialize<'de> for topic_map::TopicData {
             CreatedNs,
             PeerAddress,
             Invitation,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -5271,7 +5462,7 @@ impl<'de> serde::Deserialize<'de> for topic_map::TopicData {
                             "createdNs" | "created_ns" => Ok(GeneratedField::CreatedNs),
                             "peerAddress" | "peer_address" => Ok(GeneratedField::PeerAddress),
                             "invitation" => Ok(GeneratedField::Invitation),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -5314,6 +5505,9 @@ impl<'de> serde::Deserialize<'de> for topic_map::TopicData {
                                 return Err(serde::de::Error::duplicate_field("invitation"));
                             }
                             invitation__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }

--- a/xmtp_proto/src/gen/xmtp.keystore_api.v1.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.keystore_api.v1.serde.rs
@@ -14,7 +14,7 @@ impl serde::Serialize for CreateAuthTokenRequest {
         if let Some(v) = self.timestamp_ns.as_ref() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("timestampNs", ToString::to_string(&v).as_str())?;
+            struct_ser.serialize_field("timestamp_ns", ToString::to_string(&v).as_str())?;
         }
         struct_ser.end()
     }
@@ -129,10 +129,10 @@ impl serde::Serialize for CreateInviteRequest {
         if self.created_ns != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("createdNs", ToString::to_string(&self.created_ns).as_str())?;
+            struct_ser.serialize_field("created_ns", ToString::to_string(&self.created_ns).as_str())?;
         }
         if let Some(v) = self.consent_proof.as_ref() {
-            struct_ser.serialize_field("consentProof", v)?;
+            struct_ser.serialize_field("consent_proof", v)?;
         }
         struct_ser.end()
     }
@@ -794,15 +794,15 @@ impl serde::Serialize for decrypt_v1_request::Request {
             struct_ser.serialize_field("payload", v)?;
         }
         if let Some(v) = self.peer_keys.as_ref() {
-            struct_ser.serialize_field("peerKeys", v)?;
+            struct_ser.serialize_field("peer_keys", v)?;
         }
         if !self.header_bytes.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("headerBytes", pbjson::private::base64::encode(&self.header_bytes).as_str())?;
+            struct_ser.serialize_field("header_bytes", pbjson::private::base64::encode(&self.header_bytes).as_str())?;
         }
         if self.is_sender {
-            struct_ser.serialize_field("isSender", &self.is_sender)?;
+            struct_ser.serialize_field("is_sender", &self.is_sender)?;
         }
         struct_ser.end()
     }
@@ -1041,10 +1041,10 @@ impl serde::Serialize for decrypt_v2_request::Request {
         if !self.header_bytes.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("headerBytes", pbjson::private::base64::encode(&self.header_bytes).as_str())?;
+            struct_ser.serialize_field("header_bytes", pbjson::private::base64::encode(&self.header_bytes).as_str())?;
         }
         if !self.content_topic.is_empty() {
-            struct_ser.serialize_field("contentTopic", &self.content_topic)?;
+            struct_ser.serialize_field("content_topic", &self.content_topic)?;
         }
         struct_ser.end()
     }
@@ -1381,7 +1381,7 @@ impl serde::Serialize for encrypt_response::response::Success {
         if !self.sender_hmac.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("senderHmac", pbjson::private::base64::encode(&self.sender_hmac).as_str())?;
+            struct_ser.serialize_field("sender_hmac", pbjson::private::base64::encode(&self.sender_hmac).as_str())?;
         }
         struct_ser.end()
     }
@@ -1601,7 +1601,7 @@ impl serde::Serialize for encrypt_v1_request::Request {
         if !self.header_bytes.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("headerBytes", pbjson::private::base64::encode(&self.header_bytes).as_str())?;
+            struct_ser.serialize_field("header_bytes", pbjson::private::base64::encode(&self.header_bytes).as_str())?;
         }
         struct_ser.end()
     }
@@ -1831,10 +1831,10 @@ impl serde::Serialize for encrypt_v2_request::Request {
         if !self.header_bytes.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("headerBytes", pbjson::private::base64::encode(&self.header_bytes).as_str())?;
+            struct_ser.serialize_field("header_bytes", pbjson::private::base64::encode(&self.header_bytes).as_str())?;
         }
         if !self.content_topic.is_empty() {
-            struct_ser.serialize_field("contentTopic", &self.content_topic)?;
+            struct_ser.serialize_field("content_topic", &self.content_topic)?;
         }
         struct_ser.end()
     }
@@ -2126,7 +2126,7 @@ impl serde::Serialize for GetConversationHmacKeysResponse {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.keystore_api.v1.GetConversationHmacKeysResponse", len)?;
         if !self.hmac_keys.is_empty() {
-            struct_ser.serialize_field("hmacKeys", &self.hmac_keys)?;
+            struct_ser.serialize_field("hmac_keys", &self.hmac_keys)?;
         }
         struct_ser.end()
     }
@@ -2227,12 +2227,12 @@ impl serde::Serialize for get_conversation_hmac_keys_response::HmacKeyData {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.keystore_api.v1.GetConversationHmacKeysResponse.HmacKeyData", len)?;
         if self.thirty_day_periods_since_epoch != 0 {
-            struct_ser.serialize_field("thirtyDayPeriodsSinceEpoch", &self.thirty_day_periods_since_epoch)?;
+            struct_ser.serialize_field("thirty_day_periods_since_epoch", &self.thirty_day_periods_since_epoch)?;
         }
         if !self.hmac_key.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("hmacKey", pbjson::private::base64::encode(&self.hmac_key).as_str())?;
+            struct_ser.serialize_field("hmac_key", pbjson::private::base64::encode(&self.hmac_key).as_str())?;
         }
         struct_ser.end()
     }
@@ -2534,7 +2534,7 @@ impl serde::Serialize for GetKeystoreStatusRequest {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.keystore_api.v1.GetKeystoreStatusRequest", len)?;
         if !self.wallet_address.is_empty() {
-            struct_ser.serialize_field("walletAddress", &self.wallet_address)?;
+            struct_ser.serialize_field("wallet_address", &self.wallet_address)?;
         }
         struct_ser.end()
     }
@@ -2898,7 +2898,7 @@ impl serde::Serialize for GetRefreshJobRequest {
         if self.job_type != 0 {
             let v = JobType::try_from(self.job_type)
                 .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", self.job_type)))?;
-            struct_ser.serialize_field("jobType", &v)?;
+            struct_ser.serialize_field("job_type", &v)?;
         }
         struct_ser.end()
     }
@@ -2996,7 +2996,7 @@ impl serde::Serialize for GetRefreshJobResponse {
         if self.last_run_ns != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("lastRunNs", ToString::to_string(&self.last_run_ns).as_str())?;
+            struct_ser.serialize_field("last_run_ns", ToString::to_string(&self.last_run_ns).as_str())?;
         }
         struct_ser.end()
     }
@@ -3678,12 +3678,12 @@ impl serde::Serialize for save_invites_request::Request {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.keystore_api.v1.SaveInvitesRequest.Request", len)?;
         if !self.content_topic.is_empty() {
-            struct_ser.serialize_field("contentTopic", &self.content_topic)?;
+            struct_ser.serialize_field("content_topic", &self.content_topic)?;
         }
         if self.timestamp_ns != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("timestampNs", ToString::to_string(&self.timestamp_ns).as_str())?;
+            struct_ser.serialize_field("timestamp_ns", ToString::to_string(&self.timestamp_ns).as_str())?;
         }
         if !self.payload.is_empty() {
             #[allow(clippy::needless_borrow)]
@@ -4981,12 +4981,12 @@ impl serde::Serialize for SetRefeshJobRequest {
         if self.job_type != 0 {
             let v = JobType::try_from(self.job_type)
                 .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", self.job_type)))?;
-            struct_ser.serialize_field("jobType", &v)?;
+            struct_ser.serialize_field("job_type", &v)?;
         }
         if self.last_run_ns != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("lastRunNs", ToString::to_string(&self.last_run_ns).as_str())?;
+            struct_ser.serialize_field("last_run_ns", ToString::to_string(&self.last_run_ns).as_str())?;
         }
         struct_ser.end()
     }
@@ -5178,10 +5178,10 @@ impl serde::Serialize for SignDigestRequest {
         if let Some(v) = self.signer.as_ref() {
             match v {
                 sign_digest_request::Signer::IdentityKey(v) => {
-                    struct_ser.serialize_field("identityKey", v)?;
+                    struct_ser.serialize_field("identity_key", v)?;
                 }
                 sign_digest_request::Signer::PrekeyIndex(v) => {
-                    struct_ser.serialize_field("prekeyIndex", v)?;
+                    struct_ser.serialize_field("prekey_index", v)?;
                 }
             }
         }
@@ -5407,10 +5407,10 @@ impl serde::Serialize for topic_map::TopicData {
         if self.created_ns != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("createdNs", ToString::to_string(&self.created_ns).as_str())?;
+            struct_ser.serialize_field("created_ns", ToString::to_string(&self.created_ns).as_str())?;
         }
         if !self.peer_address.is_empty() {
-            struct_ser.serialize_field("peerAddress", &self.peer_address)?;
+            struct_ser.serialize_field("peer_address", &self.peer_address)?;
         }
         if let Some(v) = self.invitation.as_ref() {
             struct_ser.serialize_field("invitation", v)?;

--- a/xmtp_proto/src/gen/xmtp.message_api.v1.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.message_api.v1.serde.rs
@@ -42,6 +42,7 @@ impl<'de> serde::Deserialize<'de> for AuthData {
         enum GeneratedField {
             WalletAddr,
             CreatedNs,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -65,7 +66,7 @@ impl<'de> serde::Deserialize<'de> for AuthData {
                         match value {
                             "walletAddr" | "wallet_addr" => Ok(GeneratedField::WalletAddr),
                             "createdNs" | "created_ns" => Ok(GeneratedField::CreatedNs),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -101,6 +102,9 @@ impl<'de> serde::Deserialize<'de> for AuthData {
                             created_ns__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -144,6 +148,7 @@ impl<'de> serde::Deserialize<'de> for BatchQueryRequest {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Requests,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -166,7 +171,7 @@ impl<'de> serde::Deserialize<'de> for BatchQueryRequest {
                     {
                         match value {
                             "requests" => Ok(GeneratedField::Requests),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -193,6 +198,9 @@ impl<'de> serde::Deserialize<'de> for BatchQueryRequest {
                                 return Err(serde::de::Error::duplicate_field("requests"));
                             }
                             requests__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -235,6 +243,7 @@ impl<'de> serde::Deserialize<'de> for BatchQueryResponse {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Responses,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -257,7 +266,7 @@ impl<'de> serde::Deserialize<'de> for BatchQueryResponse {
                     {
                         match value {
                             "responses" => Ok(GeneratedField::Responses),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -284,6 +293,9 @@ impl<'de> serde::Deserialize<'de> for BatchQueryResponse {
                                 return Err(serde::de::Error::duplicate_field("responses"));
                             }
                             responses__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -330,6 +342,7 @@ impl<'de> serde::Deserialize<'de> for Cursor {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Index,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -352,7 +365,7 @@ impl<'de> serde::Deserialize<'de> for Cursor {
                     {
                         match value {
                             "index" => Ok(GeneratedField::Index),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -380,6 +393,9 @@ impl<'de> serde::Deserialize<'de> for Cursor {
                             }
                             cursor__ = map_.next_value::<::std::option::Option<_>>()?.map(cursor::Cursor::Index)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -444,6 +460,7 @@ impl<'de> serde::Deserialize<'de> for Envelope {
             ContentTopic,
             TimestampNs,
             Message,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -468,7 +485,7 @@ impl<'de> serde::Deserialize<'de> for Envelope {
                             "contentTopic" | "content_topic" => Ok(GeneratedField::ContentTopic),
                             "timestampNs" | "timestamp_ns" => Ok(GeneratedField::TimestampNs),
                             "message" => Ok(GeneratedField::Message),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -513,6 +530,9 @@ impl<'de> serde::Deserialize<'de> for Envelope {
                             message__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -570,6 +590,7 @@ impl<'de> serde::Deserialize<'de> for IndexCursor {
         enum GeneratedField {
             Digest,
             SenderTimeNs,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -593,7 +614,7 @@ impl<'de> serde::Deserialize<'de> for IndexCursor {
                         match value {
                             "digest" => Ok(GeneratedField::Digest),
                             "senderTimeNs" | "sender_time_ns" => Ok(GeneratedField::SenderTimeNs),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -631,6 +652,9 @@ impl<'de> serde::Deserialize<'de> for IndexCursor {
                             sender_time_ns__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -692,6 +716,7 @@ impl<'de> serde::Deserialize<'de> for PagingInfo {
             Limit,
             Cursor,
             Direction,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -716,7 +741,7 @@ impl<'de> serde::Deserialize<'de> for PagingInfo {
                             "limit" => Ok(GeneratedField::Limit),
                             "cursor" => Ok(GeneratedField::Cursor),
                             "direction" => Ok(GeneratedField::Direction),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -759,6 +784,9 @@ impl<'de> serde::Deserialize<'de> for PagingInfo {
                                 return Err(serde::de::Error::duplicate_field("direction"));
                             }
                             direction__ = Some(map_.next_value::<SortDirection>()? as i32);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -803,6 +831,7 @@ impl<'de> serde::Deserialize<'de> for PublishRequest {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Envelopes,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -825,7 +854,7 @@ impl<'de> serde::Deserialize<'de> for PublishRequest {
                     {
                         match value {
                             "envelopes" => Ok(GeneratedField::Envelopes),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -852,6 +881,9 @@ impl<'de> serde::Deserialize<'de> for PublishRequest {
                                 return Err(serde::de::Error::duplicate_field("envelopes"));
                             }
                             envelopes__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -886,6 +918,7 @@ impl<'de> serde::Deserialize<'de> for PublishResponse {
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -906,7 +939,7 @@ impl<'de> serde::Deserialize<'de> for PublishResponse {
                     where
                         E: serde::de::Error,
                     {
-                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                            Ok(GeneratedField::__SkipField__)
                     }
                 }
                 deserializer.deserialize_identifier(GeneratedVisitor)
@@ -997,6 +1030,7 @@ impl<'de> serde::Deserialize<'de> for QueryRequest {
             StartTimeNs,
             EndTimeNs,
             PagingInfo,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1022,7 +1056,7 @@ impl<'de> serde::Deserialize<'de> for QueryRequest {
                             "startTimeNs" | "start_time_ns" => Ok(GeneratedField::StartTimeNs),
                             "endTimeNs" | "end_time_ns" => Ok(GeneratedField::EndTimeNs),
                             "pagingInfo" | "paging_info" => Ok(GeneratedField::PagingInfo),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1074,6 +1108,9 @@ impl<'de> serde::Deserialize<'de> for QueryRequest {
                                 return Err(serde::de::Error::duplicate_field("pagingInfo"));
                             }
                             paging_info__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1128,6 +1165,7 @@ impl<'de> serde::Deserialize<'de> for QueryResponse {
         enum GeneratedField {
             Envelopes,
             PagingInfo,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1151,7 +1189,7 @@ impl<'de> serde::Deserialize<'de> for QueryResponse {
                         match value {
                             "envelopes" => Ok(GeneratedField::Envelopes),
                             "pagingInfo" | "paging_info" => Ok(GeneratedField::PagingInfo),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1185,6 +1223,9 @@ impl<'de> serde::Deserialize<'de> for QueryResponse {
                                 return Err(serde::de::Error::duplicate_field("pagingInfo"));
                             }
                             paging_info__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1294,6 +1335,7 @@ impl<'de> serde::Deserialize<'de> for SubscribeAllRequest {
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1314,7 +1356,7 @@ impl<'de> serde::Deserialize<'de> for SubscribeAllRequest {
                     where
                         E: serde::de::Error,
                     {
-                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                            Ok(GeneratedField::__SkipField__)
                     }
                 }
                 deserializer.deserialize_identifier(GeneratedVisitor)
@@ -1374,6 +1416,7 @@ impl<'de> serde::Deserialize<'de> for SubscribeRequest {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             ContentTopics,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1396,7 +1439,7 @@ impl<'de> serde::Deserialize<'de> for SubscribeRequest {
                     {
                         match value {
                             "contentTopics" | "content_topics" => Ok(GeneratedField::ContentTopics),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1423,6 +1466,9 @@ impl<'de> serde::Deserialize<'de> for SubscribeRequest {
                                 return Err(serde::de::Error::duplicate_field("contentTopics"));
                             }
                             content_topics__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1486,6 +1532,7 @@ impl<'de> serde::Deserialize<'de> for Token {
             IdentityKey,
             AuthDataBytes,
             AuthDataSignature,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1510,7 +1557,7 @@ impl<'de> serde::Deserialize<'de> for Token {
                             "identityKey" | "identity_key" => Ok(GeneratedField::IdentityKey),
                             "authDataBytes" | "auth_data_bytes" => Ok(GeneratedField::AuthDataBytes),
                             "authDataSignature" | "auth_data_signature" => Ok(GeneratedField::AuthDataSignature),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1553,6 +1600,9 @@ impl<'de> serde::Deserialize<'de> for Token {
                                 return Err(serde::de::Error::duplicate_field("authDataSignature"));
                             }
                             auth_data_signature__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }

--- a/xmtp_proto/src/gen/xmtp.message_api.v1.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.message_api.v1.serde.rs
@@ -15,12 +15,12 @@ impl serde::Serialize for AuthData {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.message_api.v1.AuthData", len)?;
         if !self.wallet_addr.is_empty() {
-            struct_ser.serialize_field("walletAddr", &self.wallet_addr)?;
+            struct_ser.serialize_field("wallet_addr", &self.wallet_addr)?;
         }
         if self.created_ns != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("createdNs", ToString::to_string(&self.created_ns).as_str())?;
+            struct_ser.serialize_field("created_ns", ToString::to_string(&self.created_ns).as_str())?;
         }
         struct_ser.end()
     }
@@ -426,12 +426,12 @@ impl serde::Serialize for Envelope {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.message_api.v1.Envelope", len)?;
         if !self.content_topic.is_empty() {
-            struct_ser.serialize_field("contentTopic", &self.content_topic)?;
+            struct_ser.serialize_field("content_topic", &self.content_topic)?;
         }
         if self.timestamp_ns != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("timestampNs", ToString::to_string(&self.timestamp_ns).as_str())?;
+            struct_ser.serialize_field("timestamp_ns", ToString::to_string(&self.timestamp_ns).as_str())?;
         }
         if !self.message.is_empty() {
             #[allow(clippy::needless_borrow)]
@@ -569,7 +569,7 @@ impl serde::Serialize for IndexCursor {
         if self.sender_time_ns != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("senderTimeNs", ToString::to_string(&self.sender_time_ns).as_str())?;
+            struct_ser.serialize_field("sender_time_ns", ToString::to_string(&self.sender_time_ns).as_str())?;
         }
         struct_ser.end()
     }
@@ -989,20 +989,20 @@ impl serde::Serialize for QueryRequest {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.message_api.v1.QueryRequest", len)?;
         if !self.content_topics.is_empty() {
-            struct_ser.serialize_field("contentTopics", &self.content_topics)?;
+            struct_ser.serialize_field("content_topics", &self.content_topics)?;
         }
         if self.start_time_ns != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("startTimeNs", ToString::to_string(&self.start_time_ns).as_str())?;
+            struct_ser.serialize_field("start_time_ns", ToString::to_string(&self.start_time_ns).as_str())?;
         }
         if self.end_time_ns != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("endTimeNs", ToString::to_string(&self.end_time_ns).as_str())?;
+            struct_ser.serialize_field("end_time_ns", ToString::to_string(&self.end_time_ns).as_str())?;
         }
         if let Some(v) = self.paging_info.as_ref() {
-            struct_ser.serialize_field("pagingInfo", v)?;
+            struct_ser.serialize_field("paging_info", v)?;
         }
         struct_ser.end()
     }
@@ -1144,7 +1144,7 @@ impl serde::Serialize for QueryResponse {
             struct_ser.serialize_field("envelopes", &self.envelopes)?;
         }
         if let Some(v) = self.paging_info.as_ref() {
-            struct_ser.serialize_field("pagingInfo", v)?;
+            struct_ser.serialize_field("paging_info", v)?;
         }
         struct_ser.end()
     }
@@ -1397,7 +1397,7 @@ impl serde::Serialize for SubscribeRequest {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.message_api.v1.SubscribeRequest", len)?;
         if !self.content_topics.is_empty() {
-            struct_ser.serialize_field("contentTopics", &self.content_topics)?;
+            struct_ser.serialize_field("content_topics", &self.content_topics)?;
         }
         struct_ser.end()
     }
@@ -1499,15 +1499,15 @@ impl serde::Serialize for Token {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.message_api.v1.Token", len)?;
         if let Some(v) = self.identity_key.as_ref() {
-            struct_ser.serialize_field("identityKey", v)?;
+            struct_ser.serialize_field("identity_key", v)?;
         }
         if !self.auth_data_bytes.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("authDataBytes", pbjson::private::base64::encode(&self.auth_data_bytes).as_str())?;
+            struct_ser.serialize_field("auth_data_bytes", pbjson::private::base64::encode(&self.auth_data_bytes).as_str())?;
         }
         if let Some(v) = self.auth_data_signature.as_ref() {
-            struct_ser.serialize_field("authDataSignature", v)?;
+            struct_ser.serialize_field("auth_data_signature", v)?;
         }
         struct_ser.end()
     }

--- a/xmtp_proto/src/gen/xmtp.message_contents.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.message_contents.serde.rs
@@ -35,6 +35,7 @@ impl<'de> serde::Deserialize<'de> for Ciphertext {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Aes256GcmHkdfSha256,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -57,7 +58,7 @@ impl<'de> serde::Deserialize<'de> for Ciphertext {
                     {
                         match value {
                             "aes256GcmHkdfSha256" | "aes256_gcm_hkdf_sha256" => Ok(GeneratedField::Aes256GcmHkdfSha256),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -85,6 +86,9 @@ impl<'de> serde::Deserialize<'de> for Ciphertext {
                             }
                             union__ = map_.next_value::<::std::option::Option<_>>()?.map(ciphertext::Union::Aes256GcmHkdfSha256)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -151,6 +155,7 @@ impl<'de> serde::Deserialize<'de> for ciphertext::Aes256gcmHkdfsha256 {
             HkdfSalt,
             GcmNonce,
             Payload,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -175,7 +180,7 @@ impl<'de> serde::Deserialize<'de> for ciphertext::Aes256gcmHkdfsha256 {
                             "hkdfSalt" | "hkdf_salt" => Ok(GeneratedField::HkdfSalt),
                             "gcmNonce" | "gcm_nonce" => Ok(GeneratedField::GcmNonce),
                             "payload" => Ok(GeneratedField::Payload),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -223,6 +228,9 @@ impl<'de> serde::Deserialize<'de> for ciphertext::Aes256gcmHkdfsha256 {
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(ciphertext::Aes256gcmHkdfsha256 {
@@ -266,6 +274,7 @@ impl<'de> serde::Deserialize<'de> for Composite {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Parts,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -288,7 +297,7 @@ impl<'de> serde::Deserialize<'de> for Composite {
                     {
                         match value {
                             "parts" => Ok(GeneratedField::Parts),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -315,6 +324,9 @@ impl<'de> serde::Deserialize<'de> for Composite {
                                 return Err(serde::de::Error::duplicate_field("parts"));
                             }
                             parts__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -366,6 +378,7 @@ impl<'de> serde::Deserialize<'de> for composite::Part {
         enum GeneratedField {
             Part,
             Composite,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -389,7 +402,7 @@ impl<'de> serde::Deserialize<'de> for composite::Part {
                         match value {
                             "part" => Ok(GeneratedField::Part),
                             "composite" => Ok(GeneratedField::Composite),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -424,6 +437,9 @@ impl<'de> serde::Deserialize<'de> for composite::Part {
                             }
                             element__ = map_.next_value::<::std::option::Option<_>>()?.map(composite::part::Element::Composite)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -558,6 +574,7 @@ impl<'de> serde::Deserialize<'de> for ConsentProofPayload {
             Signature,
             Timestamp,
             PayloadVersion,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -582,7 +599,7 @@ impl<'de> serde::Deserialize<'de> for ConsentProofPayload {
                             "signature" => Ok(GeneratedField::Signature),
                             "timestamp" => Ok(GeneratedField::Timestamp),
                             "payloadVersion" | "payload_version" => Ok(GeneratedField::PayloadVersion),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -625,6 +642,9 @@ impl<'de> serde::Deserialize<'de> for ConsentProofPayload {
                                 return Err(serde::de::Error::duplicate_field("payloadVersion"));
                             }
                             payload_version__ = Some(map_.next_value::<ConsentProofPayloadVersion>()? as i32);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -749,6 +769,7 @@ impl<'de> serde::Deserialize<'de> for ContactBundle {
         enum GeneratedField {
             V1,
             V2,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -772,7 +793,7 @@ impl<'de> serde::Deserialize<'de> for ContactBundle {
                         match value {
                             "v1" => Ok(GeneratedField::V1),
                             "v2" => Ok(GeneratedField::V2),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -807,6 +828,9 @@ impl<'de> serde::Deserialize<'de> for ContactBundle {
                             }
                             version__ = map_.next_value::<::std::option::Option<_>>()?.map(contact_bundle::Version::V2)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -850,6 +874,7 @@ impl<'de> serde::Deserialize<'de> for ContactBundleV1 {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             KeyBundle,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -872,7 +897,7 @@ impl<'de> serde::Deserialize<'de> for ContactBundleV1 {
                     {
                         match value {
                             "keyBundle" | "key_bundle" => Ok(GeneratedField::KeyBundle),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -899,6 +924,9 @@ impl<'de> serde::Deserialize<'de> for ContactBundleV1 {
                                 return Err(serde::de::Error::duplicate_field("keyBundle"));
                             }
                             key_bundle__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -942,6 +970,7 @@ impl<'de> serde::Deserialize<'de> for ContactBundleV2 {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             KeyBundle,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -964,7 +993,7 @@ impl<'de> serde::Deserialize<'de> for ContactBundleV2 {
                     {
                         match value {
                             "keyBundle" | "key_bundle" => Ok(GeneratedField::KeyBundle),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -991,6 +1020,9 @@ impl<'de> serde::Deserialize<'de> for ContactBundleV2 {
                                 return Err(serde::de::Error::duplicate_field("keyBundle"));
                             }
                             key_bundle__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1061,6 +1093,7 @@ impl<'de> serde::Deserialize<'de> for ContentTypeId {
             TypeId,
             VersionMajor,
             VersionMinor,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1086,7 +1119,7 @@ impl<'de> serde::Deserialize<'de> for ContentTypeId {
                             "typeId" | "type_id" => Ok(GeneratedField::TypeId),
                             "versionMajor" | "version_major" => Ok(GeneratedField::VersionMajor),
                             "versionMinor" | "version_minor" => Ok(GeneratedField::VersionMinor),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1138,6 +1171,9 @@ impl<'de> serde::Deserialize<'de> for ContentTypeId {
                             version_minor__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1220,6 +1256,7 @@ impl<'de> serde::Deserialize<'de> for ConversationReference {
             CreatedNs,
             Context,
             ConsentProofPayload,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1246,7 +1283,7 @@ impl<'de> serde::Deserialize<'de> for ConversationReference {
                             "createdNs" | "created_ns" => Ok(GeneratedField::CreatedNs),
                             "context" => Ok(GeneratedField::Context),
                             "consentProofPayload" | "consent_proof_payload" => Ok(GeneratedField::ConsentProofPayload),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1303,6 +1340,9 @@ impl<'de> serde::Deserialize<'de> for ConversationReference {
                                 return Err(serde::de::Error::duplicate_field("consentProofPayload"));
                             }
                             consent_proof_payload__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1415,6 +1455,7 @@ impl<'de> serde::Deserialize<'de> for DecodedMessage {
             ContentTopic,
             Conversation,
             ContentBytes,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1444,7 +1485,7 @@ impl<'de> serde::Deserialize<'de> for DecodedMessage {
                             "contentTopic" | "content_topic" => Ok(GeneratedField::ContentTopic),
                             "conversation" => Ok(GeneratedField::Conversation),
                             "contentBytes" | "content_bytes" => Ok(GeneratedField::ContentBytes),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1525,6 +1566,9 @@ impl<'de> serde::Deserialize<'de> for DecodedMessage {
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(DecodedMessage {
@@ -1579,6 +1623,7 @@ impl<'de> serde::Deserialize<'de> for EciesMessage {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             V1,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1601,7 +1646,7 @@ impl<'de> serde::Deserialize<'de> for EciesMessage {
                     {
                         match value {
                             "v1" => Ok(GeneratedField::V1),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1628,6 +1673,9 @@ impl<'de> serde::Deserialize<'de> for EciesMessage {
                                 return Err(serde::de::Error::duplicate_field("v1"));
                             }
                             version__ = map_.next_value::<::std::option::Option<::pbjson::private::BytesDeserialize<_>>>()?.map(|x| ecies_message::Version::V1(x.0));
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1706,6 +1754,7 @@ impl<'de> serde::Deserialize<'de> for EncodedContent {
             Fallback,
             Compression,
             Content,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1732,7 +1781,7 @@ impl<'de> serde::Deserialize<'de> for EncodedContent {
                             "fallback" => Ok(GeneratedField::Fallback),
                             "compression" => Ok(GeneratedField::Compression),
                             "content" => Ok(GeneratedField::Content),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1792,6 +1841,9 @@ impl<'de> serde::Deserialize<'de> for EncodedContent {
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(EncodedContent {
@@ -1841,6 +1893,7 @@ impl<'de> serde::Deserialize<'de> for EncryptedPrivateKeyBundle {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             V1,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1863,7 +1916,7 @@ impl<'de> serde::Deserialize<'de> for EncryptedPrivateKeyBundle {
                     {
                         match value {
                             "v1" => Ok(GeneratedField::V1),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1891,6 +1944,9 @@ impl<'de> serde::Deserialize<'de> for EncryptedPrivateKeyBundle {
                             }
                             version__ = map_.next_value::<::std::option::Option<_>>()?.map(encrypted_private_key_bundle::Version::V1)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1944,6 +2000,7 @@ impl<'de> serde::Deserialize<'de> for EncryptedPrivateKeyBundleV1 {
         enum GeneratedField {
             WalletPreKey,
             Ciphertext,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1967,7 +2024,7 @@ impl<'de> serde::Deserialize<'de> for EncryptedPrivateKeyBundleV1 {
                         match value {
                             "walletPreKey" | "wallet_pre_key" => Ok(GeneratedField::WalletPreKey),
                             "ciphertext" => Ok(GeneratedField::Ciphertext),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2003,6 +2060,9 @@ impl<'de> serde::Deserialize<'de> for EncryptedPrivateKeyBundleV1 {
                                 return Err(serde::de::Error::duplicate_field("ciphertext"));
                             }
                             ciphertext__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2097,6 +2157,7 @@ impl<'de> serde::Deserialize<'de> for FrameAction {
             InstallationSignature,
             InstallationId,
             InboxId,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2124,7 +2185,7 @@ impl<'de> serde::Deserialize<'de> for FrameAction {
                             "installationSignature" | "installation_signature" => Ok(GeneratedField::InstallationSignature),
                             "installationId" | "installation_id" => Ok(GeneratedField::InstallationId),
                             "inboxId" | "inbox_id" => Ok(GeneratedField::InboxId),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2192,6 +2253,9 @@ impl<'de> serde::Deserialize<'de> for FrameAction {
                                 return Err(serde::de::Error::duplicate_field("inboxId"));
                             }
                             inbox_id__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2311,6 +2375,7 @@ impl<'de> serde::Deserialize<'de> for FrameActionBody {
             State,
             Address,
             TransactionId,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2341,7 +2406,7 @@ impl<'de> serde::Deserialize<'de> for FrameActionBody {
                             "state" => Ok(GeneratedField::State),
                             "address" => Ok(GeneratedField::Address),
                             "transactionId" | "transaction_id" => Ok(GeneratedField::TransactionId),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2431,6 +2496,9 @@ impl<'de> serde::Deserialize<'de> for FrameActionBody {
                             }
                             transaction_id__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(FrameActionBody {
@@ -2510,6 +2578,7 @@ impl<'de> serde::Deserialize<'de> for InvitationV1 {
             Context,
             ConsentProof,
             Aes256GcmHkdfSha256,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2535,7 +2604,7 @@ impl<'de> serde::Deserialize<'de> for InvitationV1 {
                             "context" => Ok(GeneratedField::Context),
                             "consentProof" | "consent_proof" => Ok(GeneratedField::ConsentProof),
                             "aes256GcmHkdfSha256" | "aes256_gcm_hkdf_sha256" => Ok(GeneratedField::Aes256GcmHkdfSha256),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2585,6 +2654,9 @@ impl<'de> serde::Deserialize<'de> for InvitationV1 {
                             encryption__ = map_.next_value::<::std::option::Option<_>>()?.map(invitation_v1::Encryption::Aes256GcmHkdfSha256)
 ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(InvitationV1 {
@@ -2632,6 +2704,7 @@ impl<'de> serde::Deserialize<'de> for invitation_v1::Aes256gcmHkdfsha256 {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             KeyMaterial,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2654,7 +2727,7 @@ impl<'de> serde::Deserialize<'de> for invitation_v1::Aes256gcmHkdfsha256 {
                     {
                         match value {
                             "keyMaterial" | "key_material" => Ok(GeneratedField::KeyMaterial),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2683,6 +2756,9 @@ impl<'de> serde::Deserialize<'de> for invitation_v1::Aes256gcmHkdfsha256 {
                             key_material__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2734,6 +2810,7 @@ impl<'de> serde::Deserialize<'de> for invitation_v1::Context {
         enum GeneratedField {
             ConversationId,
             Metadata,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2757,7 +2834,7 @@ impl<'de> serde::Deserialize<'de> for invitation_v1::Context {
                         match value {
                             "conversationId" | "conversation_id" => Ok(GeneratedField::ConversationId),
                             "metadata" => Ok(GeneratedField::Metadata),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2793,6 +2870,9 @@ impl<'de> serde::Deserialize<'de> for invitation_v1::Context {
                             metadata__ = Some(
                                 map_.next_value::<std::collections::HashMap<_, _>>()?
                             );
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2845,6 +2925,7 @@ impl<'de> serde::Deserialize<'de> for Message {
         enum GeneratedField {
             V1,
             V2,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2868,7 +2949,7 @@ impl<'de> serde::Deserialize<'de> for Message {
                         match value {
                             "v1" => Ok(GeneratedField::V1),
                             "v2" => Ok(GeneratedField::V2),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2903,6 +2984,9 @@ impl<'de> serde::Deserialize<'de> for Message {
                             }
                             version__ = map_.next_value::<::std::option::Option<_>>()?.map(message::Version::V2)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2963,6 +3047,7 @@ impl<'de> serde::Deserialize<'de> for MessageHeaderV1 {
             Sender,
             Recipient,
             Timestamp,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2987,7 +3072,7 @@ impl<'de> serde::Deserialize<'de> for MessageHeaderV1 {
                             "sender" => Ok(GeneratedField::Sender),
                             "recipient" => Ok(GeneratedField::Recipient),
                             "timestamp" => Ok(GeneratedField::Timestamp),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3030,6 +3115,9 @@ impl<'de> serde::Deserialize<'de> for MessageHeaderV1 {
                             timestamp__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3085,6 +3173,7 @@ impl<'de> serde::Deserialize<'de> for MessageHeaderV2 {
         enum GeneratedField {
             CreatedNs,
             Topic,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3108,7 +3197,7 @@ impl<'de> serde::Deserialize<'de> for MessageHeaderV2 {
                         match value {
                             "createdNs" | "created_ns" => Ok(GeneratedField::CreatedNs),
                             "topic" => Ok(GeneratedField::Topic),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3144,6 +3233,9 @@ impl<'de> serde::Deserialize<'de> for MessageHeaderV2 {
                                 return Err(serde::de::Error::duplicate_field("topic"));
                             }
                             topic__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3198,6 +3290,7 @@ impl<'de> serde::Deserialize<'de> for MessageV1 {
         enum GeneratedField {
             HeaderBytes,
             Ciphertext,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3221,7 +3314,7 @@ impl<'de> serde::Deserialize<'de> for MessageV1 {
                         match value {
                             "headerBytes" | "header_bytes" => Ok(GeneratedField::HeaderBytes),
                             "ciphertext" => Ok(GeneratedField::Ciphertext),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3257,6 +3350,9 @@ impl<'de> serde::Deserialize<'de> for MessageV1 {
                                 return Err(serde::de::Error::duplicate_field("ciphertext"));
                             }
                             ciphertext__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3331,6 +3427,7 @@ impl<'de> serde::Deserialize<'de> for MessageV2 {
             Ciphertext,
             SenderHmac,
             ShouldPush,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3356,7 +3453,7 @@ impl<'de> serde::Deserialize<'de> for MessageV2 {
                             "ciphertext" => Ok(GeneratedField::Ciphertext),
                             "senderHmac" | "sender_hmac" => Ok(GeneratedField::SenderHmac),
                             "shouldPush" | "should_push" => Ok(GeneratedField::ShouldPush),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3408,6 +3505,9 @@ impl<'de> serde::Deserialize<'de> for MessageV2 {
                                 return Err(serde::de::Error::duplicate_field("shouldPush"));
                             }
                             should_push__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3476,6 +3576,7 @@ impl<'de> serde::Deserialize<'de> for PrivateKey {
             Timestamp,
             PublicKey,
             Secp256k1,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3500,7 +3601,7 @@ impl<'de> serde::Deserialize<'de> for PrivateKey {
                             "timestamp" => Ok(GeneratedField::Timestamp),
                             "publicKey" | "public_key" => Ok(GeneratedField::PublicKey),
                             "secp256k1" => Ok(GeneratedField::Secp256k1),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3544,6 +3645,9 @@ impl<'de> serde::Deserialize<'de> for PrivateKey {
                             }
                             union__ = map_.next_value::<::std::option::Option<_>>()?.map(private_key::Union::Secp256k1)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3590,6 +3694,7 @@ impl<'de> serde::Deserialize<'de> for private_key::Secp256k1 {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Bytes,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3612,7 +3717,7 @@ impl<'de> serde::Deserialize<'de> for private_key::Secp256k1 {
                     {
                         match value {
                             "bytes" => Ok(GeneratedField::Bytes),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3641,6 +3746,9 @@ impl<'de> serde::Deserialize<'de> for private_key::Secp256k1 {
                             bytes__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3692,6 +3800,7 @@ impl<'de> serde::Deserialize<'de> for PrivateKeyBundle {
         enum GeneratedField {
             V1,
             V2,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3715,7 +3824,7 @@ impl<'de> serde::Deserialize<'de> for PrivateKeyBundle {
                         match value {
                             "v1" => Ok(GeneratedField::V1),
                             "v2" => Ok(GeneratedField::V2),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3750,6 +3859,9 @@ impl<'de> serde::Deserialize<'de> for PrivateKeyBundle {
                             }
                             version__ = map_.next_value::<::std::option::Option<_>>()?.map(private_key_bundle::Version::V2)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3802,6 +3914,7 @@ impl<'de> serde::Deserialize<'de> for PrivateKeyBundleV1 {
         enum GeneratedField {
             IdentityKey,
             PreKeys,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3825,7 +3938,7 @@ impl<'de> serde::Deserialize<'de> for PrivateKeyBundleV1 {
                         match value {
                             "identityKey" | "identity_key" => Ok(GeneratedField::IdentityKey),
                             "preKeys" | "pre_keys" => Ok(GeneratedField::PreKeys),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3859,6 +3972,9 @@ impl<'de> serde::Deserialize<'de> for PrivateKeyBundleV1 {
                                 return Err(serde::de::Error::duplicate_field("preKeys"));
                             }
                             pre_keys__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3912,6 +4028,7 @@ impl<'de> serde::Deserialize<'de> for PrivateKeyBundleV2 {
         enum GeneratedField {
             IdentityKey,
             PreKeys,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3935,7 +4052,7 @@ impl<'de> serde::Deserialize<'de> for PrivateKeyBundleV2 {
                         match value {
                             "identityKey" | "identity_key" => Ok(GeneratedField::IdentityKey),
                             "preKeys" | "pre_keys" => Ok(GeneratedField::PreKeys),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3969,6 +4086,9 @@ impl<'de> serde::Deserialize<'de> for PrivateKeyBundleV2 {
                                 return Err(serde::de::Error::duplicate_field("preKeys"));
                             }
                             pre_keys__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -4047,6 +4167,7 @@ impl<'de> serde::Deserialize<'de> for PrivatePreferencesAction {
             DenyGroup,
             AllowInboxId,
             DenyInboxId,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4074,7 +4195,7 @@ impl<'de> serde::Deserialize<'de> for PrivatePreferencesAction {
                             "denyGroup" | "deny_group" => Ok(GeneratedField::DenyGroup),
                             "allowInboxId" | "allow_inbox_id" => Ok(GeneratedField::AllowInboxId),
                             "denyInboxId" | "deny_inbox_id" => Ok(GeneratedField::DenyInboxId),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -4138,6 +4259,9 @@ impl<'de> serde::Deserialize<'de> for PrivatePreferencesAction {
                             message_type__ = map_.next_value::<::std::option::Option<_>>()?.map(private_preferences_action::MessageType::DenyInboxId)
 ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(PrivatePreferencesAction {
@@ -4180,6 +4304,7 @@ impl<'de> serde::Deserialize<'de> for private_preferences_action::AllowAddress {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             WalletAddresses,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4202,7 +4327,7 @@ impl<'de> serde::Deserialize<'de> for private_preferences_action::AllowAddress {
                     {
                         match value {
                             "walletAddresses" | "wallet_addresses" => Ok(GeneratedField::WalletAddresses),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -4229,6 +4354,9 @@ impl<'de> serde::Deserialize<'de> for private_preferences_action::AllowAddress {
                                 return Err(serde::de::Error::duplicate_field("walletAddresses"));
                             }
                             wallet_addresses__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -4272,6 +4400,7 @@ impl<'de> serde::Deserialize<'de> for private_preferences_action::AllowGroup {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             GroupIds,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4294,7 +4423,7 @@ impl<'de> serde::Deserialize<'de> for private_preferences_action::AllowGroup {
                     {
                         match value {
                             "groupIds" | "group_ids" => Ok(GeneratedField::GroupIds),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -4321,6 +4450,9 @@ impl<'de> serde::Deserialize<'de> for private_preferences_action::AllowGroup {
                                 return Err(serde::de::Error::duplicate_field("groupIds"));
                             }
                             group_ids__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -4364,6 +4496,7 @@ impl<'de> serde::Deserialize<'de> for private_preferences_action::AllowInboxId {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             InboxIds,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4386,7 +4519,7 @@ impl<'de> serde::Deserialize<'de> for private_preferences_action::AllowInboxId {
                     {
                         match value {
                             "inboxIds" | "inbox_ids" => Ok(GeneratedField::InboxIds),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -4413,6 +4546,9 @@ impl<'de> serde::Deserialize<'de> for private_preferences_action::AllowInboxId {
                                 return Err(serde::de::Error::duplicate_field("inboxIds"));
                             }
                             inbox_ids__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -4456,6 +4592,7 @@ impl<'de> serde::Deserialize<'de> for private_preferences_action::DenyAddress {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             WalletAddresses,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4478,7 +4615,7 @@ impl<'de> serde::Deserialize<'de> for private_preferences_action::DenyAddress {
                     {
                         match value {
                             "walletAddresses" | "wallet_addresses" => Ok(GeneratedField::WalletAddresses),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -4505,6 +4642,9 @@ impl<'de> serde::Deserialize<'de> for private_preferences_action::DenyAddress {
                                 return Err(serde::de::Error::duplicate_field("walletAddresses"));
                             }
                             wallet_addresses__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -4548,6 +4688,7 @@ impl<'de> serde::Deserialize<'de> for private_preferences_action::DenyGroup {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             GroupIds,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4570,7 +4711,7 @@ impl<'de> serde::Deserialize<'de> for private_preferences_action::DenyGroup {
                     {
                         match value {
                             "groupIds" | "group_ids" => Ok(GeneratedField::GroupIds),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -4597,6 +4738,9 @@ impl<'de> serde::Deserialize<'de> for private_preferences_action::DenyGroup {
                                 return Err(serde::de::Error::duplicate_field("groupIds"));
                             }
                             group_ids__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -4640,6 +4784,7 @@ impl<'de> serde::Deserialize<'de> for private_preferences_action::DenyInboxId {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             InboxIds,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4662,7 +4807,7 @@ impl<'de> serde::Deserialize<'de> for private_preferences_action::DenyInboxId {
                     {
                         match value {
                             "inboxIds" | "inbox_ids" => Ok(GeneratedField::InboxIds),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -4689,6 +4834,9 @@ impl<'de> serde::Deserialize<'de> for private_preferences_action::DenyInboxId {
                                 return Err(serde::de::Error::duplicate_field("inboxIds"));
                             }
                             inbox_ids__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -4735,6 +4883,7 @@ impl<'de> serde::Deserialize<'de> for PrivatePreferencesPayload {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             V1,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4757,7 +4906,7 @@ impl<'de> serde::Deserialize<'de> for PrivatePreferencesPayload {
                     {
                         match value {
                             "v1" => Ok(GeneratedField::V1),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -4785,6 +4934,9 @@ impl<'de> serde::Deserialize<'de> for PrivatePreferencesPayload {
                             }
                             version__ = map_.next_value::<::std::option::Option<_>>()?.map(private_preferences_payload::Version::V1)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -4850,6 +5002,7 @@ impl<'de> serde::Deserialize<'de> for PublicKey {
             Timestamp,
             Signature,
             Secp256k1Uncompressed,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4874,7 +5027,7 @@ impl<'de> serde::Deserialize<'de> for PublicKey {
                             "timestamp" => Ok(GeneratedField::Timestamp),
                             "signature" => Ok(GeneratedField::Signature),
                             "secp256k1Uncompressed" | "secp256k1_uncompressed" => Ok(GeneratedField::Secp256k1Uncompressed),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -4918,6 +5071,9 @@ impl<'de> serde::Deserialize<'de> for PublicKey {
                             }
                             union__ = map_.next_value::<::std::option::Option<_>>()?.map(public_key::Union::Secp256k1Uncompressed)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -4964,6 +5120,7 @@ impl<'de> serde::Deserialize<'de> for public_key::Secp256k1Uncompressed {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Bytes,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4986,7 +5143,7 @@ impl<'de> serde::Deserialize<'de> for public_key::Secp256k1Uncompressed {
                     {
                         match value {
                             "bytes" => Ok(GeneratedField::Bytes),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -5015,6 +5172,9 @@ impl<'de> serde::Deserialize<'de> for public_key::Secp256k1Uncompressed {
                             bytes__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -5067,6 +5227,7 @@ impl<'de> serde::Deserialize<'de> for PublicKeyBundle {
         enum GeneratedField {
             IdentityKey,
             PreKey,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -5090,7 +5251,7 @@ impl<'de> serde::Deserialize<'de> for PublicKeyBundle {
                         match value {
                             "identityKey" | "identity_key" => Ok(GeneratedField::IdentityKey),
                             "preKey" | "pre_key" => Ok(GeneratedField::PreKey),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -5124,6 +5285,9 @@ impl<'de> serde::Deserialize<'de> for PublicKeyBundle {
                                 return Err(serde::de::Error::duplicate_field("preKey"));
                             }
                             pre_key__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -5171,6 +5335,7 @@ impl<'de> serde::Deserialize<'de> for SealedInvitation {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             V1,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -5193,7 +5358,7 @@ impl<'de> serde::Deserialize<'de> for SealedInvitation {
                     {
                         match value {
                             "v1" => Ok(GeneratedField::V1),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -5221,6 +5386,9 @@ impl<'de> serde::Deserialize<'de> for SealedInvitation {
                             }
                             version__ = map_.next_value::<::std::option::Option<_>>()?.map(sealed_invitation::Version::V1)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -5282,6 +5450,7 @@ impl<'de> serde::Deserialize<'de> for SealedInvitationHeaderV1 {
             Sender,
             Recipient,
             CreatedNs,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -5306,7 +5475,7 @@ impl<'de> serde::Deserialize<'de> for SealedInvitationHeaderV1 {
                             "sender" => Ok(GeneratedField::Sender),
                             "recipient" => Ok(GeneratedField::Recipient),
                             "createdNs" | "created_ns" => Ok(GeneratedField::CreatedNs),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -5349,6 +5518,9 @@ impl<'de> serde::Deserialize<'de> for SealedInvitationHeaderV1 {
                             created_ns__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -5404,6 +5576,7 @@ impl<'de> serde::Deserialize<'de> for SealedInvitationV1 {
         enum GeneratedField {
             HeaderBytes,
             Ciphertext,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -5427,7 +5600,7 @@ impl<'de> serde::Deserialize<'de> for SealedInvitationV1 {
                         match value {
                             "headerBytes" | "header_bytes" => Ok(GeneratedField::HeaderBytes),
                             "ciphertext" => Ok(GeneratedField::Ciphertext),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -5463,6 +5636,9 @@ impl<'de> serde::Deserialize<'de> for SealedInvitationV1 {
                                 return Err(serde::de::Error::duplicate_field("ciphertext"));
                             }
                             ciphertext__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -5517,6 +5693,7 @@ impl<'de> serde::Deserialize<'de> for Signature {
         enum GeneratedField {
             EcdsaCompact,
             WalletEcdsaCompact,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -5540,7 +5717,7 @@ impl<'de> serde::Deserialize<'de> for Signature {
                         match value {
                             "ecdsaCompact" | "ecdsa_compact" => Ok(GeneratedField::EcdsaCompact),
                             "walletEcdsaCompact" | "wallet_ecdsa_compact" => Ok(GeneratedField::WalletEcdsaCompact),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -5575,6 +5752,9 @@ impl<'de> serde::Deserialize<'de> for Signature {
                             }
                             union__ = map_.next_value::<::std::option::Option<_>>()?.map(signature::Union::WalletEcdsaCompact)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -5627,6 +5807,7 @@ impl<'de> serde::Deserialize<'de> for signature::EcdsaCompact {
         enum GeneratedField {
             Bytes,
             Recovery,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -5650,7 +5831,7 @@ impl<'de> serde::Deserialize<'de> for signature::EcdsaCompact {
                         match value {
                             "bytes" => Ok(GeneratedField::Bytes),
                             "recovery" => Ok(GeneratedField::Recovery),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -5688,6 +5869,9 @@ impl<'de> serde::Deserialize<'de> for signature::EcdsaCompact {
                             recovery__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -5741,6 +5925,7 @@ impl<'de> serde::Deserialize<'de> for signature::WalletEcdsaCompact {
         enum GeneratedField {
             Bytes,
             Recovery,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -5764,7 +5949,7 @@ impl<'de> serde::Deserialize<'de> for signature::WalletEcdsaCompact {
                         match value {
                             "bytes" => Ok(GeneratedField::Bytes),
                             "recovery" => Ok(GeneratedField::Recovery),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -5802,6 +5987,9 @@ impl<'de> serde::Deserialize<'de> for signature::WalletEcdsaCompact {
                             recovery__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -5863,6 +6051,7 @@ impl<'de> serde::Deserialize<'de> for SignedContent {
             Payload,
             Sender,
             Signature,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -5887,7 +6076,7 @@ impl<'de> serde::Deserialize<'de> for SignedContent {
                             "payload" => Ok(GeneratedField::Payload),
                             "sender" => Ok(GeneratedField::Sender),
                             "signature" => Ok(GeneratedField::Signature),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -5930,6 +6119,9 @@ impl<'de> serde::Deserialize<'de> for SignedContent {
                                 return Err(serde::de::Error::duplicate_field("signature"));
                             }
                             signature__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -5985,6 +6177,7 @@ impl<'de> serde::Deserialize<'de> for SignedEciesCiphertext {
         enum GeneratedField {
             EciesBytes,
             Signature,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -6008,7 +6201,7 @@ impl<'de> serde::Deserialize<'de> for SignedEciesCiphertext {
                         match value {
                             "eciesBytes" | "ecies_bytes" => Ok(GeneratedField::EciesBytes),
                             "signature" => Ok(GeneratedField::Signature),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -6044,6 +6237,9 @@ impl<'de> serde::Deserialize<'de> for SignedEciesCiphertext {
                                 return Err(serde::de::Error::duplicate_field("signature"));
                             }
                             signature__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -6120,6 +6316,7 @@ impl<'de> serde::Deserialize<'de> for signed_ecies_ciphertext::Ecies {
             Iv,
             Mac,
             Ciphertext,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -6145,7 +6342,7 @@ impl<'de> serde::Deserialize<'de> for signed_ecies_ciphertext::Ecies {
                             "iv" => Ok(GeneratedField::Iv),
                             "mac" => Ok(GeneratedField::Mac),
                             "ciphertext" => Ok(GeneratedField::Ciphertext),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -6202,6 +6399,9 @@ impl<'de> serde::Deserialize<'de> for signed_ecies_ciphertext::Ecies {
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(signed_ecies_ciphertext::Ecies {
@@ -6256,6 +6456,7 @@ impl<'de> serde::Deserialize<'de> for SignedPayload {
         enum GeneratedField {
             Payload,
             Signature,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -6279,7 +6480,7 @@ impl<'de> serde::Deserialize<'de> for SignedPayload {
                         match value {
                             "payload" => Ok(GeneratedField::Payload),
                             "signature" => Ok(GeneratedField::Signature),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -6315,6 +6516,9 @@ impl<'de> serde::Deserialize<'de> for SignedPayload {
                                 return Err(serde::de::Error::duplicate_field("signature"));
                             }
                             signature__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -6382,6 +6586,7 @@ impl<'de> serde::Deserialize<'de> for SignedPrivateKey {
             CreatedNs,
             PublicKey,
             Secp256k1,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -6406,7 +6611,7 @@ impl<'de> serde::Deserialize<'de> for SignedPrivateKey {
                             "createdNs" | "created_ns" => Ok(GeneratedField::CreatedNs),
                             "publicKey" | "public_key" => Ok(GeneratedField::PublicKey),
                             "secp256k1" => Ok(GeneratedField::Secp256k1),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -6450,6 +6655,9 @@ impl<'de> serde::Deserialize<'de> for SignedPrivateKey {
                             }
                             union__ = map_.next_value::<::std::option::Option<_>>()?.map(signed_private_key::Union::Secp256k1)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -6496,6 +6704,7 @@ impl<'de> serde::Deserialize<'de> for signed_private_key::Secp256k1 {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Bytes,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -6518,7 +6727,7 @@ impl<'de> serde::Deserialize<'de> for signed_private_key::Secp256k1 {
                     {
                         match value {
                             "bytes" => Ok(GeneratedField::Bytes),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -6547,6 +6756,9 @@ impl<'de> serde::Deserialize<'de> for signed_private_key::Secp256k1 {
                             bytes__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -6600,6 +6812,7 @@ impl<'de> serde::Deserialize<'de> for SignedPublicKey {
         enum GeneratedField {
             KeyBytes,
             Signature,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -6623,7 +6836,7 @@ impl<'de> serde::Deserialize<'de> for SignedPublicKey {
                         match value {
                             "keyBytes" | "key_bytes" => Ok(GeneratedField::KeyBytes),
                             "signature" => Ok(GeneratedField::Signature),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -6659,6 +6872,9 @@ impl<'de> serde::Deserialize<'de> for SignedPublicKey {
                                 return Err(serde::de::Error::duplicate_field("signature"));
                             }
                             signature__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -6712,6 +6928,7 @@ impl<'de> serde::Deserialize<'de> for SignedPublicKeyBundle {
         enum GeneratedField {
             IdentityKey,
             PreKey,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -6735,7 +6952,7 @@ impl<'de> serde::Deserialize<'de> for SignedPublicKeyBundle {
                         match value {
                             "identityKey" | "identity_key" => Ok(GeneratedField::IdentityKey),
                             "preKey" | "pre_key" => Ok(GeneratedField::PreKey),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -6769,6 +6986,9 @@ impl<'de> serde::Deserialize<'de> for SignedPublicKeyBundle {
                                 return Err(serde::de::Error::duplicate_field("preKey"));
                             }
                             pre_key__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -6828,6 +7048,7 @@ impl<'de> serde::Deserialize<'de> for UnsignedPublicKey {
         enum GeneratedField {
             CreatedNs,
             Secp256k1Uncompressed,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -6851,7 +7072,7 @@ impl<'de> serde::Deserialize<'de> for UnsignedPublicKey {
                         match value {
                             "createdNs" | "created_ns" => Ok(GeneratedField::CreatedNs),
                             "secp256k1Uncompressed" | "secp256k1_uncompressed" => Ok(GeneratedField::Secp256k1Uncompressed),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -6888,6 +7109,9 @@ impl<'de> serde::Deserialize<'de> for UnsignedPublicKey {
                             }
                             union__ = map_.next_value::<::std::option::Option<_>>()?.map(unsigned_public_key::Union::Secp256k1Uncompressed)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -6933,6 +7157,7 @@ impl<'de> serde::Deserialize<'de> for unsigned_public_key::Secp256k1Uncompressed
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Bytes,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -6955,7 +7180,7 @@ impl<'de> serde::Deserialize<'de> for unsigned_public_key::Secp256k1Uncompressed
                     {
                         match value {
                             "bytes" => Ok(GeneratedField::Bytes),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -6984,6 +7209,9 @@ impl<'de> serde::Deserialize<'de> for unsigned_public_key::Secp256k1Uncompressed
                             bytes__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }

--- a/xmtp_proto/src/gen/xmtp.message_contents.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.message_contents.serde.rs
@@ -14,7 +14,7 @@ impl serde::Serialize for Ciphertext {
         if let Some(v) = self.union.as_ref() {
             match v {
                 ciphertext::Union::Aes256GcmHkdfSha256(v) => {
-                    struct_ser.serialize_field("aes256GcmHkdfSha256", v)?;
+                    struct_ser.serialize_field("aes256_gcm_hkdf_sha256", v)?;
                 }
             }
         }
@@ -121,12 +121,12 @@ impl serde::Serialize for ciphertext::Aes256gcmHkdfsha256 {
         if !self.hkdf_salt.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("hkdfSalt", pbjson::private::base64::encode(&self.hkdf_salt).as_str())?;
+            struct_ser.serialize_field("hkdf_salt", pbjson::private::base64::encode(&self.hkdf_salt).as_str())?;
         }
         if !self.gcm_nonce.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("gcmNonce", pbjson::private::base64::encode(&self.gcm_nonce).as_str())?;
+            struct_ser.serialize_field("gcm_nonce", pbjson::private::base64::encode(&self.gcm_nonce).as_str())?;
         }
         if !self.payload.is_empty() {
             #[allow(clippy::needless_borrow)]
@@ -551,7 +551,7 @@ impl serde::Serialize for ConsentProofPayload {
         if self.payload_version != 0 {
             let v = ConsentProofPayloadVersion::try_from(self.payload_version)
                 .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", self.payload_version)))?;
-            struct_ser.serialize_field("payloadVersion", &v)?;
+            struct_ser.serialize_field("payload_version", &v)?;
         }
         struct_ser.end()
     }
@@ -855,7 +855,7 @@ impl serde::Serialize for ContactBundleV1 {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.message_contents.ContactBundleV1", len)?;
         if let Some(v) = self.key_bundle.as_ref() {
-            struct_ser.serialize_field("keyBundle", v)?;
+            struct_ser.serialize_field("key_bundle", v)?;
         }
         struct_ser.end()
     }
@@ -951,7 +951,7 @@ impl serde::Serialize for ContactBundleV2 {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.message_contents.ContactBundleV2", len)?;
         if let Some(v) = self.key_bundle.as_ref() {
-            struct_ser.serialize_field("keyBundle", v)?;
+            struct_ser.serialize_field("key_bundle", v)?;
         }
         struct_ser.end()
     }
@@ -1056,16 +1056,16 @@ impl serde::Serialize for ContentTypeId {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.message_contents.ContentTypeId", len)?;
         if !self.authority_id.is_empty() {
-            struct_ser.serialize_field("authorityId", &self.authority_id)?;
+            struct_ser.serialize_field("authority_id", &self.authority_id)?;
         }
         if !self.type_id.is_empty() {
-            struct_ser.serialize_field("typeId", &self.type_id)?;
+            struct_ser.serialize_field("type_id", &self.type_id)?;
         }
         if self.version_major != 0 {
-            struct_ser.serialize_field("versionMajor", &self.version_major)?;
+            struct_ser.serialize_field("version_major", &self.version_major)?;
         }
         if self.version_minor != 0 {
-            struct_ser.serialize_field("versionMinor", &self.version_minor)?;
+            struct_ser.serialize_field("version_minor", &self.version_minor)?;
         }
         struct_ser.end()
     }
@@ -1216,18 +1216,18 @@ impl serde::Serialize for ConversationReference {
             struct_ser.serialize_field("topic", &self.topic)?;
         }
         if !self.peer_address.is_empty() {
-            struct_ser.serialize_field("peerAddress", &self.peer_address)?;
+            struct_ser.serialize_field("peer_address", &self.peer_address)?;
         }
         if self.created_ns != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("createdNs", ToString::to_string(&self.created_ns).as_str())?;
+            struct_ser.serialize_field("created_ns", ToString::to_string(&self.created_ns).as_str())?;
         }
         if let Some(v) = self.context.as_ref() {
             struct_ser.serialize_field("context", v)?;
         }
         if let Some(v) = self.consent_proof_payload.as_ref() {
-            struct_ser.serialize_field("consentProofPayload", v)?;
+            struct_ser.serialize_field("consent_proof_payload", v)?;
         }
         struct_ser.end()
     }
@@ -1395,21 +1395,21 @@ impl serde::Serialize for DecodedMessage {
             struct_ser.serialize_field("id", &self.id)?;
         }
         if !self.message_version.is_empty() {
-            struct_ser.serialize_field("messageVersion", &self.message_version)?;
+            struct_ser.serialize_field("message_version", &self.message_version)?;
         }
         if !self.sender_address.is_empty() {
-            struct_ser.serialize_field("senderAddress", &self.sender_address)?;
+            struct_ser.serialize_field("sender_address", &self.sender_address)?;
         }
         if let Some(v) = self.recipient_address.as_ref() {
-            struct_ser.serialize_field("recipientAddress", v)?;
+            struct_ser.serialize_field("recipient_address", v)?;
         }
         if self.sent_ns != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("sentNs", ToString::to_string(&self.sent_ns).as_str())?;
+            struct_ser.serialize_field("sent_ns", ToString::to_string(&self.sent_ns).as_str())?;
         }
         if !self.content_topic.is_empty() {
-            struct_ser.serialize_field("contentTopic", &self.content_topic)?;
+            struct_ser.serialize_field("content_topic", &self.content_topic)?;
         }
         if let Some(v) = self.conversation.as_ref() {
             struct_ser.serialize_field("conversation", v)?;
@@ -1417,7 +1417,7 @@ impl serde::Serialize for DecodedMessage {
         if !self.content_bytes.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("contentBytes", pbjson::private::base64::encode(&self.content_bytes).as_str())?;
+            struct_ser.serialize_field("content_bytes", pbjson::private::base64::encode(&self.content_bytes).as_str())?;
         }
         struct_ser.end()
     }
@@ -1976,7 +1976,7 @@ impl serde::Serialize for EncryptedPrivateKeyBundleV1 {
         if !self.wallet_pre_key.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("walletPreKey", pbjson::private::base64::encode(&self.wallet_pre_key).as_str())?;
+            struct_ser.serialize_field("wallet_pre_key", pbjson::private::base64::encode(&self.wallet_pre_key).as_str())?;
         }
         if let Some(v) = self.ciphertext.as_ref() {
             struct_ser.serialize_field("ciphertext", v)?;
@@ -2106,25 +2106,25 @@ impl serde::Serialize for FrameAction {
             struct_ser.serialize_field("signature", v)?;
         }
         if let Some(v) = self.signed_public_key_bundle.as_ref() {
-            struct_ser.serialize_field("signedPublicKeyBundle", v)?;
+            struct_ser.serialize_field("signed_public_key_bundle", v)?;
         }
         if !self.action_body.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("actionBody", pbjson::private::base64::encode(&self.action_body).as_str())?;
+            struct_ser.serialize_field("action_body", pbjson::private::base64::encode(&self.action_body).as_str())?;
         }
         if !self.installation_signature.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("installationSignature", pbjson::private::base64::encode(&self.installation_signature).as_str())?;
+            struct_ser.serialize_field("installation_signature", pbjson::private::base64::encode(&self.installation_signature).as_str())?;
         }
         if !self.installation_id.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("installationId", pbjson::private::base64::encode(&self.installation_id).as_str())?;
+            struct_ser.serialize_field("installation_id", pbjson::private::base64::encode(&self.installation_id).as_str())?;
         }
         if !self.inbox_id.is_empty() {
-            struct_ser.serialize_field("inboxId", &self.inbox_id)?;
+            struct_ser.serialize_field("inbox_id", &self.inbox_id)?;
         }
         struct_ser.end()
     }
@@ -2309,10 +2309,10 @@ impl serde::Serialize for FrameActionBody {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.message_contents.FrameActionBody", len)?;
         if !self.frame_url.is_empty() {
-            struct_ser.serialize_field("frameUrl", &self.frame_url)?;
+            struct_ser.serialize_field("frame_url", &self.frame_url)?;
         }
         if self.button_index != 0 {
-            struct_ser.serialize_field("buttonIndex", &self.button_index)?;
+            struct_ser.serialize_field("button_index", &self.button_index)?;
         }
         if self.timestamp != 0 {
             #[allow(clippy::needless_borrow)]
@@ -2320,13 +2320,13 @@ impl serde::Serialize for FrameActionBody {
             struct_ser.serialize_field("timestamp", ToString::to_string(&self.timestamp).as_str())?;
         }
         if !self.opaque_conversation_identifier.is_empty() {
-            struct_ser.serialize_field("opaqueConversationIdentifier", &self.opaque_conversation_identifier)?;
+            struct_ser.serialize_field("opaque_conversation_identifier", &self.opaque_conversation_identifier)?;
         }
         if self.unix_timestamp != 0 {
-            struct_ser.serialize_field("unixTimestamp", &self.unix_timestamp)?;
+            struct_ser.serialize_field("unix_timestamp", &self.unix_timestamp)?;
         }
         if !self.input_text.is_empty() {
-            struct_ser.serialize_field("inputText", &self.input_text)?;
+            struct_ser.serialize_field("input_text", &self.input_text)?;
         }
         if !self.state.is_empty() {
             struct_ser.serialize_field("state", &self.state)?;
@@ -2335,7 +2335,7 @@ impl serde::Serialize for FrameActionBody {
             struct_ser.serialize_field("address", &self.address)?;
         }
         if !self.transaction_id.is_empty() {
-            struct_ser.serialize_field("transactionId", &self.transaction_id)?;
+            struct_ser.serialize_field("transaction_id", &self.transaction_id)?;
         }
         struct_ser.end()
     }
@@ -2545,12 +2545,12 @@ impl serde::Serialize for InvitationV1 {
             struct_ser.serialize_field("context", v)?;
         }
         if let Some(v) = self.consent_proof.as_ref() {
-            struct_ser.serialize_field("consentProof", v)?;
+            struct_ser.serialize_field("consent_proof", v)?;
         }
         if let Some(v) = self.encryption.as_ref() {
             match v {
                 invitation_v1::Encryption::Aes256GcmHkdfSha256(v) => {
-                    struct_ser.serialize_field("aes256GcmHkdfSha256", v)?;
+                    struct_ser.serialize_field("aes256_gcm_hkdf_sha256", v)?;
                 }
             }
         }
@@ -2685,7 +2685,7 @@ impl serde::Serialize for invitation_v1::Aes256gcmHkdfsha256 {
         if !self.key_material.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("keyMaterial", pbjson::private::base64::encode(&self.key_material).as_str())?;
+            struct_ser.serialize_field("key_material", pbjson::private::base64::encode(&self.key_material).as_str())?;
         }
         struct_ser.end()
     }
@@ -2786,7 +2786,7 @@ impl serde::Serialize for invitation_v1::Context {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.message_contents.InvitationV1.Context", len)?;
         if !self.conversation_id.is_empty() {
-            struct_ser.serialize_field("conversationId", &self.conversation_id)?;
+            struct_ser.serialize_field("conversation_id", &self.conversation_id)?;
         }
         if !self.metadata.is_empty() {
             struct_ser.serialize_field("metadata", &self.metadata)?;
@@ -3149,7 +3149,7 @@ impl serde::Serialize for MessageHeaderV2 {
         if self.created_ns != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("createdNs", ToString::to_string(&self.created_ns).as_str())?;
+            struct_ser.serialize_field("created_ns", ToString::to_string(&self.created_ns).as_str())?;
         }
         if !self.topic.is_empty() {
             struct_ser.serialize_field("topic", &self.topic)?;
@@ -3266,7 +3266,7 @@ impl serde::Serialize for MessageV1 {
         if !self.header_bytes.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("headerBytes", pbjson::private::base64::encode(&self.header_bytes).as_str())?;
+            struct_ser.serialize_field("header_bytes", pbjson::private::base64::encode(&self.header_bytes).as_str())?;
         }
         if let Some(v) = self.ciphertext.as_ref() {
             struct_ser.serialize_field("ciphertext", v)?;
@@ -3389,7 +3389,7 @@ impl serde::Serialize for MessageV2 {
         if !self.header_bytes.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("headerBytes", pbjson::private::base64::encode(&self.header_bytes).as_str())?;
+            struct_ser.serialize_field("header_bytes", pbjson::private::base64::encode(&self.header_bytes).as_str())?;
         }
         if let Some(v) = self.ciphertext.as_ref() {
             struct_ser.serialize_field("ciphertext", v)?;
@@ -3397,10 +3397,10 @@ impl serde::Serialize for MessageV2 {
         if let Some(v) = self.sender_hmac.as_ref() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("senderHmac", pbjson::private::base64::encode(&v).as_str())?;
+            struct_ser.serialize_field("sender_hmac", pbjson::private::base64::encode(&v).as_str())?;
         }
         if let Some(v) = self.should_push.as_ref() {
-            struct_ser.serialize_field("shouldPush", v)?;
+            struct_ser.serialize_field("should_push", v)?;
         }
         struct_ser.end()
     }
@@ -3546,7 +3546,7 @@ impl serde::Serialize for PrivateKey {
             struct_ser.serialize_field("timestamp", ToString::to_string(&self.timestamp).as_str())?;
         }
         if let Some(v) = self.public_key.as_ref() {
-            struct_ser.serialize_field("publicKey", v)?;
+            struct_ser.serialize_field("public_key", v)?;
         }
         if let Some(v) = self.union.as_ref() {
             match v {
@@ -3889,10 +3889,10 @@ impl serde::Serialize for PrivateKeyBundleV1 {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.message_contents.PrivateKeyBundleV1", len)?;
         if let Some(v) = self.identity_key.as_ref() {
-            struct_ser.serialize_field("identityKey", v)?;
+            struct_ser.serialize_field("identity_key", v)?;
         }
         if !self.pre_keys.is_empty() {
-            struct_ser.serialize_field("preKeys", &self.pre_keys)?;
+            struct_ser.serialize_field("pre_keys", &self.pre_keys)?;
         }
         struct_ser.end()
     }
@@ -4003,10 +4003,10 @@ impl serde::Serialize for PrivateKeyBundleV2 {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.message_contents.PrivateKeyBundleV2", len)?;
         if let Some(v) = self.identity_key.as_ref() {
-            struct_ser.serialize_field("identityKey", v)?;
+            struct_ser.serialize_field("identity_key", v)?;
         }
         if !self.pre_keys.is_empty() {
-            struct_ser.serialize_field("preKeys", &self.pre_keys)?;
+            struct_ser.serialize_field("pre_keys", &self.pre_keys)?;
         }
         struct_ser.end()
     }
@@ -4116,22 +4116,22 @@ impl serde::Serialize for PrivatePreferencesAction {
         if let Some(v) = self.message_type.as_ref() {
             match v {
                 private_preferences_action::MessageType::AllowAddress(v) => {
-                    struct_ser.serialize_field("allowAddress", v)?;
+                    struct_ser.serialize_field("allow_address", v)?;
                 }
                 private_preferences_action::MessageType::DenyAddress(v) => {
-                    struct_ser.serialize_field("denyAddress", v)?;
+                    struct_ser.serialize_field("deny_address", v)?;
                 }
                 private_preferences_action::MessageType::AllowGroup(v) => {
-                    struct_ser.serialize_field("allowGroup", v)?;
+                    struct_ser.serialize_field("allow_group", v)?;
                 }
                 private_preferences_action::MessageType::DenyGroup(v) => {
-                    struct_ser.serialize_field("denyGroup", v)?;
+                    struct_ser.serialize_field("deny_group", v)?;
                 }
                 private_preferences_action::MessageType::AllowInboxId(v) => {
-                    struct_ser.serialize_field("allowInboxId", v)?;
+                    struct_ser.serialize_field("allow_inbox_id", v)?;
                 }
                 private_preferences_action::MessageType::DenyInboxId(v) => {
-                    struct_ser.serialize_field("denyInboxId", v)?;
+                    struct_ser.serialize_field("deny_inbox_id", v)?;
                 }
             }
         }
@@ -4285,7 +4285,7 @@ impl serde::Serialize for private_preferences_action::AllowAddress {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.message_contents.PrivatePreferencesAction.AllowAddress", len)?;
         if !self.wallet_addresses.is_empty() {
-            struct_ser.serialize_field("walletAddresses", &self.wallet_addresses)?;
+            struct_ser.serialize_field("wallet_addresses", &self.wallet_addresses)?;
         }
         struct_ser.end()
     }
@@ -4381,7 +4381,7 @@ impl serde::Serialize for private_preferences_action::AllowGroup {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.message_contents.PrivatePreferencesAction.AllowGroup", len)?;
         if !self.group_ids.is_empty() {
-            struct_ser.serialize_field("groupIds", &self.group_ids)?;
+            struct_ser.serialize_field("group_ids", &self.group_ids)?;
         }
         struct_ser.end()
     }
@@ -4477,7 +4477,7 @@ impl serde::Serialize for private_preferences_action::AllowInboxId {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.message_contents.PrivatePreferencesAction.AllowInboxId", len)?;
         if !self.inbox_ids.is_empty() {
-            struct_ser.serialize_field("inboxIds", &self.inbox_ids)?;
+            struct_ser.serialize_field("inbox_ids", &self.inbox_ids)?;
         }
         struct_ser.end()
     }
@@ -4573,7 +4573,7 @@ impl serde::Serialize for private_preferences_action::DenyAddress {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.message_contents.PrivatePreferencesAction.DenyAddress", len)?;
         if !self.wallet_addresses.is_empty() {
-            struct_ser.serialize_field("walletAddresses", &self.wallet_addresses)?;
+            struct_ser.serialize_field("wallet_addresses", &self.wallet_addresses)?;
         }
         struct_ser.end()
     }
@@ -4669,7 +4669,7 @@ impl serde::Serialize for private_preferences_action::DenyGroup {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.message_contents.PrivatePreferencesAction.DenyGroup", len)?;
         if !self.group_ids.is_empty() {
-            struct_ser.serialize_field("groupIds", &self.group_ids)?;
+            struct_ser.serialize_field("group_ids", &self.group_ids)?;
         }
         struct_ser.end()
     }
@@ -4765,7 +4765,7 @@ impl serde::Serialize for private_preferences_action::DenyInboxId {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.message_contents.PrivatePreferencesAction.DenyInboxId", len)?;
         if !self.inbox_ids.is_empty() {
-            struct_ser.serialize_field("inboxIds", &self.inbox_ids)?;
+            struct_ser.serialize_field("inbox_ids", &self.inbox_ids)?;
         }
         struct_ser.end()
     }
@@ -4977,7 +4977,7 @@ impl serde::Serialize for PublicKey {
         if let Some(v) = self.union.as_ref() {
             match v {
                 public_key::Union::Secp256k1Uncompressed(v) => {
-                    struct_ser.serialize_field("secp256k1Uncompressed", v)?;
+                    struct_ser.serialize_field("secp256k1_uncompressed", v)?;
                 }
             }
         }
@@ -5202,10 +5202,10 @@ impl serde::Serialize for PublicKeyBundle {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.message_contents.PublicKeyBundle", len)?;
         if let Some(v) = self.identity_key.as_ref() {
-            struct_ser.serialize_field("identityKey", v)?;
+            struct_ser.serialize_field("identity_key", v)?;
         }
         if let Some(v) = self.pre_key.as_ref() {
-            struct_ser.serialize_field("preKey", v)?;
+            struct_ser.serialize_field("pre_key", v)?;
         }
         struct_ser.end()
     }
@@ -5427,7 +5427,7 @@ impl serde::Serialize for SealedInvitationHeaderV1 {
         if self.created_ns != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("createdNs", ToString::to_string(&self.created_ns).as_str())?;
+            struct_ser.serialize_field("created_ns", ToString::to_string(&self.created_ns).as_str())?;
         }
         struct_ser.end()
     }
@@ -5552,7 +5552,7 @@ impl serde::Serialize for SealedInvitationV1 {
         if !self.header_bytes.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("headerBytes", pbjson::private::base64::encode(&self.header_bytes).as_str())?;
+            struct_ser.serialize_field("header_bytes", pbjson::private::base64::encode(&self.header_bytes).as_str())?;
         }
         if let Some(v) = self.ciphertext.as_ref() {
             struct_ser.serialize_field("ciphertext", v)?;
@@ -5666,10 +5666,10 @@ impl serde::Serialize for Signature {
         if let Some(v) = self.union.as_ref() {
             match v {
                 signature::Union::EcdsaCompact(v) => {
-                    struct_ser.serialize_field("ecdsaCompact", v)?;
+                    struct_ser.serialize_field("ecdsa_compact", v)?;
                 }
                 signature::Union::WalletEcdsaCompact(v) => {
-                    struct_ser.serialize_field("walletEcdsaCompact", v)?;
+                    struct_ser.serialize_field("wallet_ecdsa_compact", v)?;
                 }
             }
         }
@@ -6153,7 +6153,7 @@ impl serde::Serialize for SignedEciesCiphertext {
         if !self.ecies_bytes.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("eciesBytes", pbjson::private::base64::encode(&self.ecies_bytes).as_str())?;
+            struct_ser.serialize_field("ecies_bytes", pbjson::private::base64::encode(&self.ecies_bytes).as_str())?;
         }
         if let Some(v) = self.signature.as_ref() {
             struct_ser.serialize_field("signature", v)?;
@@ -6276,7 +6276,7 @@ impl serde::Serialize for signed_ecies_ciphertext::Ecies {
         if !self.ephemeral_public_key.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("ephemeralPublicKey", pbjson::private::base64::encode(&self.ephemeral_public_key).as_str())?;
+            struct_ser.serialize_field("ephemeral_public_key", pbjson::private::base64::encode(&self.ephemeral_public_key).as_str())?;
         }
         if !self.iv.is_empty() {
             #[allow(clippy::needless_borrow)]
@@ -6552,10 +6552,10 @@ impl serde::Serialize for SignedPrivateKey {
         if self.created_ns != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("createdNs", ToString::to_string(&self.created_ns).as_str())?;
+            struct_ser.serialize_field("created_ns", ToString::to_string(&self.created_ns).as_str())?;
         }
         if let Some(v) = self.public_key.as_ref() {
-            struct_ser.serialize_field("publicKey", v)?;
+            struct_ser.serialize_field("public_key", v)?;
         }
         if let Some(v) = self.union.as_ref() {
             match v {
@@ -6788,7 +6788,7 @@ impl serde::Serialize for SignedPublicKey {
         if !self.key_bytes.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("keyBytes", pbjson::private::base64::encode(&self.key_bytes).as_str())?;
+            struct_ser.serialize_field("key_bytes", pbjson::private::base64::encode(&self.key_bytes).as_str())?;
         }
         if let Some(v) = self.signature.as_ref() {
             struct_ser.serialize_field("signature", v)?;
@@ -6903,10 +6903,10 @@ impl serde::Serialize for SignedPublicKeyBundle {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.message_contents.SignedPublicKeyBundle", len)?;
         if let Some(v) = self.identity_key.as_ref() {
-            struct_ser.serialize_field("identityKey", v)?;
+            struct_ser.serialize_field("identity_key", v)?;
         }
         if let Some(v) = self.pre_key.as_ref() {
-            struct_ser.serialize_field("preKey", v)?;
+            struct_ser.serialize_field("pre_key", v)?;
         }
         struct_ser.end()
     }
@@ -7019,12 +7019,12 @@ impl serde::Serialize for UnsignedPublicKey {
         if self.created_ns != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("createdNs", ToString::to_string(&self.created_ns).as_str())?;
+            struct_ser.serialize_field("created_ns", ToString::to_string(&self.created_ns).as_str())?;
         }
         if let Some(v) = self.union.as_ref() {
             match v {
                 unsigned_public_key::Union::Secp256k1Uncompressed(v) => {
-                    struct_ser.serialize_field("secp256k1Uncompressed", v)?;
+                    struct_ser.serialize_field("secp256k1_uncompressed", v)?;
                 }
             }
         }

--- a/xmtp_proto/src/gen/xmtp.mls.api.v1.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.mls.api.v1.serde.rs
@@ -12,7 +12,7 @@ impl serde::Serialize for FetchKeyPackagesRequest {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.mls.api.v1.FetchKeyPackagesRequest", len)?;
         if !self.installation_keys.is_empty() {
-            struct_ser.serialize_field("installationKeys", &self.installation_keys.iter().map(pbjson::private::base64::encode).collect::<Vec<_>>())?;
+            struct_ser.serialize_field("installation_keys", &self.installation_keys.iter().map(pbjson::private::base64::encode).collect::<Vec<_>>())?;
         }
         struct_ser.end()
     }
@@ -111,7 +111,7 @@ impl serde::Serialize for FetchKeyPackagesResponse {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.mls.api.v1.FetchKeyPackagesResponse", len)?;
         if !self.key_packages.is_empty() {
-            struct_ser.serialize_field("keyPackages", &self.key_packages)?;
+            struct_ser.serialize_field("key_packages", &self.key_packages)?;
         }
         struct_ser.end()
     }
@@ -209,7 +209,7 @@ impl serde::Serialize for fetch_key_packages_response::KeyPackage {
         if !self.key_package_tls_serialized.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("keyPackageTlsSerialized", pbjson::private::base64::encode(&self.key_package_tls_serialized).as_str())?;
+            struct_ser.serialize_field("key_package_tls_serialized", pbjson::private::base64::encode(&self.key_package_tls_serialized).as_str())?;
         }
         struct_ser.end()
     }
@@ -310,12 +310,12 @@ impl serde::Serialize for GetIdentityUpdatesRequest {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.mls.api.v1.GetIdentityUpdatesRequest", len)?;
         if !self.account_addresses.is_empty() {
-            struct_ser.serialize_field("accountAddresses", &self.account_addresses)?;
+            struct_ser.serialize_field("account_addresses", &self.account_addresses)?;
         }
         if self.start_time_ns != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("startTimeNs", ToString::to_string(&self.start_time_ns).as_str())?;
+            struct_ser.serialize_field("start_time_ns", ToString::to_string(&self.start_time_ns).as_str())?;
         }
         struct_ser.end()
     }
@@ -525,12 +525,12 @@ impl serde::Serialize for get_identity_updates_response::NewInstallationUpdate {
         if !self.installation_key.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("installationKey", pbjson::private::base64::encode(&self.installation_key).as_str())?;
+            struct_ser.serialize_field("installation_key", pbjson::private::base64::encode(&self.installation_key).as_str())?;
         }
         if !self.credential_identity.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("credentialIdentity", pbjson::private::base64::encode(&self.credential_identity).as_str())?;
+            struct_ser.serialize_field("credential_identity", pbjson::private::base64::encode(&self.credential_identity).as_str())?;
         }
         struct_ser.end()
     }
@@ -644,7 +644,7 @@ impl serde::Serialize for get_identity_updates_response::RevokedInstallationUpda
         if !self.installation_key.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("installationKey", pbjson::private::base64::encode(&self.installation_key).as_str())?;
+            struct_ser.serialize_field("installation_key", pbjson::private::base64::encode(&self.installation_key).as_str())?;
         }
         struct_ser.end()
     }
@@ -747,15 +747,15 @@ impl serde::Serialize for get_identity_updates_response::Update {
         if self.timestamp_ns != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("timestampNs", ToString::to_string(&self.timestamp_ns).as_str())?;
+            struct_ser.serialize_field("timestamp_ns", ToString::to_string(&self.timestamp_ns).as_str())?;
         }
         if let Some(v) = self.kind.as_ref() {
             match v {
                 get_identity_updates_response::update::Kind::NewInstallation(v) => {
-                    struct_ser.serialize_field("newInstallation", v)?;
+                    struct_ser.serialize_field("new_installation", v)?;
                 }
                 get_identity_updates_response::update::Kind::RevokedInstallation(v) => {
-                    struct_ser.serialize_field("revokedInstallation", v)?;
+                    struct_ser.serialize_field("revoked_installation", v)?;
                 }
             }
         }
@@ -1096,12 +1096,12 @@ impl serde::Serialize for group_message::V1 {
         if self.created_ns != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("createdNs", ToString::to_string(&self.created_ns).as_str())?;
+            struct_ser.serialize_field("created_ns", ToString::to_string(&self.created_ns).as_str())?;
         }
         if !self.group_id.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("groupId", pbjson::private::base64::encode(&self.group_id).as_str())?;
+            struct_ser.serialize_field("group_id", pbjson::private::base64::encode(&self.group_id).as_str())?;
         }
         if !self.data.is_empty() {
             #[allow(clippy::needless_borrow)]
@@ -1111,10 +1111,10 @@ impl serde::Serialize for group_message::V1 {
         if !self.sender_hmac.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("senderHmac", pbjson::private::base64::encode(&self.sender_hmac).as_str())?;
+            struct_ser.serialize_field("sender_hmac", pbjson::private::base64::encode(&self.sender_hmac).as_str())?;
         }
         if self.should_push {
-            struct_ser.serialize_field("shouldPush", &self.should_push)?;
+            struct_ser.serialize_field("should_push", &self.should_push)?;
         }
         struct_ser.end()
     }
@@ -1391,10 +1391,10 @@ impl serde::Serialize for group_message_input::V1 {
         if !self.sender_hmac.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("senderHmac", pbjson::private::base64::encode(&self.sender_hmac).as_str())?;
+            struct_ser.serialize_field("sender_hmac", pbjson::private::base64::encode(&self.sender_hmac).as_str())?;
         }
         if self.should_push {
-            struct_ser.serialize_field("shouldPush", &self.should_push)?;
+            struct_ser.serialize_field("should_push", &self.should_push)?;
         }
         struct_ser.end()
     }
@@ -1519,7 +1519,7 @@ impl serde::Serialize for KeyPackageUpload {
         if !self.key_package_tls_serialized.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("keyPackageTlsSerialized", pbjson::private::base64::encode(&self.key_package_tls_serialized).as_str())?;
+            struct_ser.serialize_field("key_package_tls_serialized", pbjson::private::base64::encode(&self.key_package_tls_serialized).as_str())?;
         }
         struct_ser.end()
     }
@@ -1633,7 +1633,7 @@ impl serde::Serialize for PagingInfo {
         if self.id_cursor != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("idCursor", ToString::to_string(&self.id_cursor).as_str())?;
+            struct_ser.serialize_field("id_cursor", ToString::to_string(&self.id_cursor).as_str())?;
         }
         struct_ser.end()
     }
@@ -1760,10 +1760,10 @@ impl serde::Serialize for QueryGroupMessagesRequest {
         if !self.group_id.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("groupId", pbjson::private::base64::encode(&self.group_id).as_str())?;
+            struct_ser.serialize_field("group_id", pbjson::private::base64::encode(&self.group_id).as_str())?;
         }
         if let Some(v) = self.paging_info.as_ref() {
-            struct_ser.serialize_field("pagingInfo", v)?;
+            struct_ser.serialize_field("paging_info", v)?;
         }
         struct_ser.end()
     }
@@ -1879,7 +1879,7 @@ impl serde::Serialize for QueryGroupMessagesResponse {
             struct_ser.serialize_field("messages", &self.messages)?;
         }
         if let Some(v) = self.paging_info.as_ref() {
-            struct_ser.serialize_field("pagingInfo", v)?;
+            struct_ser.serialize_field("paging_info", v)?;
         }
         struct_ser.end()
     }
@@ -1991,10 +1991,10 @@ impl serde::Serialize for QueryWelcomeMessagesRequest {
         if !self.installation_key.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("installationKey", pbjson::private::base64::encode(&self.installation_key).as_str())?;
+            struct_ser.serialize_field("installation_key", pbjson::private::base64::encode(&self.installation_key).as_str())?;
         }
         if let Some(v) = self.paging_info.as_ref() {
-            struct_ser.serialize_field("pagingInfo", v)?;
+            struct_ser.serialize_field("paging_info", v)?;
         }
         struct_ser.end()
     }
@@ -2110,7 +2110,7 @@ impl serde::Serialize for QueryWelcomeMessagesResponse {
             struct_ser.serialize_field("messages", &self.messages)?;
         }
         if let Some(v) = self.paging_info.as_ref() {
-            struct_ser.serialize_field("pagingInfo", v)?;
+            struct_ser.serialize_field("paging_info", v)?;
         }
         struct_ser.end()
     }
@@ -2220,10 +2220,10 @@ impl serde::Serialize for RegisterInstallationRequest {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.mls.api.v1.RegisterInstallationRequest", len)?;
         if let Some(v) = self.key_package.as_ref() {
-            struct_ser.serialize_field("keyPackage", v)?;
+            struct_ser.serialize_field("key_package", v)?;
         }
         if self.is_inbox_id_credential {
-            struct_ser.serialize_field("isInboxIdCredential", &self.is_inbox_id_credential)?;
+            struct_ser.serialize_field("is_inbox_id_credential", &self.is_inbox_id_credential)?;
         }
         struct_ser.end()
     }
@@ -2333,7 +2333,7 @@ impl serde::Serialize for RegisterInstallationResponse {
         if !self.installation_key.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("installationKey", pbjson::private::base64::encode(&self.installation_key).as_str())?;
+            struct_ser.serialize_field("installation_key", pbjson::private::base64::encode(&self.installation_key).as_str())?;
         }
         struct_ser.end()
     }
@@ -2436,10 +2436,10 @@ impl serde::Serialize for RevokeInstallationRequest {
         if !self.installation_key.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("installationKey", pbjson::private::base64::encode(&self.installation_key).as_str())?;
+            struct_ser.serialize_field("installation_key", pbjson::private::base64::encode(&self.installation_key).as_str())?;
         }
         if let Some(v) = self.wallet_signature.as_ref() {
-            struct_ser.serialize_field("walletSignature", v)?;
+            struct_ser.serialize_field("wallet_signature", v)?;
         }
         struct_ser.end()
     }
@@ -2913,12 +2913,12 @@ impl serde::Serialize for subscribe_group_messages_request::Filter {
         if !self.group_id.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("groupId", pbjson::private::base64::encode(&self.group_id).as_str())?;
+            struct_ser.serialize_field("group_id", pbjson::private::base64::encode(&self.group_id).as_str())?;
         }
         if self.id_cursor != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("idCursor", ToString::to_string(&self.id_cursor).as_str())?;
+            struct_ser.serialize_field("id_cursor", ToString::to_string(&self.id_cursor).as_str())?;
         }
         struct_ser.end()
     }
@@ -3130,12 +3130,12 @@ impl serde::Serialize for subscribe_welcome_messages_request::Filter {
         if !self.installation_key.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("installationKey", pbjson::private::base64::encode(&self.installation_key).as_str())?;
+            struct_ser.serialize_field("installation_key", pbjson::private::base64::encode(&self.installation_key).as_str())?;
         }
         if self.id_cursor != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("idCursor", ToString::to_string(&self.id_cursor).as_str())?;
+            struct_ser.serialize_field("id_cursor", ToString::to_string(&self.id_cursor).as_str())?;
         }
         struct_ser.end()
     }
@@ -3250,10 +3250,10 @@ impl serde::Serialize for UploadKeyPackageRequest {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.mls.api.v1.UploadKeyPackageRequest", len)?;
         if let Some(v) = self.key_package.as_ref() {
-            struct_ser.serialize_field("keyPackage", v)?;
+            struct_ser.serialize_field("key_package", v)?;
         }
         if self.is_inbox_id_credential {
-            struct_ser.serialize_field("isInboxIdCredential", &self.is_inbox_id_credential)?;
+            struct_ser.serialize_field("is_inbox_id_credential", &self.is_inbox_id_credential)?;
         }
         struct_ser.end()
     }
@@ -3483,12 +3483,12 @@ impl serde::Serialize for welcome_message::V1 {
         if self.created_ns != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("createdNs", ToString::to_string(&self.created_ns).as_str())?;
+            struct_ser.serialize_field("created_ns", ToString::to_string(&self.created_ns).as_str())?;
         }
         if !self.installation_key.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("installationKey", pbjson::private::base64::encode(&self.installation_key).as_str())?;
+            struct_ser.serialize_field("installation_key", pbjson::private::base64::encode(&self.installation_key).as_str())?;
         }
         if !self.data.is_empty() {
             #[allow(clippy::needless_borrow)]
@@ -3498,12 +3498,12 @@ impl serde::Serialize for welcome_message::V1 {
         if !self.hpke_public_key.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("hpkePublicKey", pbjson::private::base64::encode(&self.hpke_public_key).as_str())?;
+            struct_ser.serialize_field("hpke_public_key", pbjson::private::base64::encode(&self.hpke_public_key).as_str())?;
         }
         if self.wrapper_algorithm != 0 {
             let v = super::super::message_contents::WelcomeWrapperAlgorithm::try_from(self.wrapper_algorithm)
                 .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", self.wrapper_algorithm)))?;
-            struct_ser.serialize_field("wrapperAlgorithm", &v)?;
+            struct_ser.serialize_field("wrapper_algorithm", &v)?;
         }
         struct_ser.end()
     }
@@ -3778,7 +3778,7 @@ impl serde::Serialize for welcome_message_input::V1 {
         if !self.installation_key.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("installationKey", pbjson::private::base64::encode(&self.installation_key).as_str())?;
+            struct_ser.serialize_field("installation_key", pbjson::private::base64::encode(&self.installation_key).as_str())?;
         }
         if !self.data.is_empty() {
             #[allow(clippy::needless_borrow)]
@@ -3788,12 +3788,12 @@ impl serde::Serialize for welcome_message_input::V1 {
         if !self.hpke_public_key.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("hpkePublicKey", pbjson::private::base64::encode(&self.hpke_public_key).as_str())?;
+            struct_ser.serialize_field("hpke_public_key", pbjson::private::base64::encode(&self.hpke_public_key).as_str())?;
         }
         if self.wrapper_algorithm != 0 {
             let v = super::super::message_contents::WelcomeWrapperAlgorithm::try_from(self.wrapper_algorithm)
                 .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", self.wrapper_algorithm)))?;
-            struct_ser.serialize_field("wrapperAlgorithm", &v)?;
+            struct_ser.serialize_field("wrapper_algorithm", &v)?;
         }
         struct_ser.end()
     }

--- a/xmtp_proto/src/gen/xmtp.mls.api.v1.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.mls.api.v1.serde.rs
@@ -31,6 +31,7 @@ impl<'de> serde::Deserialize<'de> for FetchKeyPackagesRequest {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             InstallationKeys,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -53,7 +54,7 @@ impl<'de> serde::Deserialize<'de> for FetchKeyPackagesRequest {
                     {
                         match value {
                             "installationKeys" | "installation_keys" => Ok(GeneratedField::InstallationKeys),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -83,6 +84,9 @@ impl<'de> serde::Deserialize<'de> for FetchKeyPackagesRequest {
                                 Some(map_.next_value::<Vec<::pbjson::private::BytesDeserialize<_>>>()?
                                     .into_iter().map(|x| x.0).collect())
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -126,6 +130,7 @@ impl<'de> serde::Deserialize<'de> for FetchKeyPackagesResponse {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             KeyPackages,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -148,7 +153,7 @@ impl<'de> serde::Deserialize<'de> for FetchKeyPackagesResponse {
                     {
                         match value {
                             "keyPackages" | "key_packages" => Ok(GeneratedField::KeyPackages),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -175,6 +180,9 @@ impl<'de> serde::Deserialize<'de> for FetchKeyPackagesResponse {
                                 return Err(serde::de::Error::duplicate_field("keyPackages"));
                             }
                             key_packages__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -220,6 +228,7 @@ impl<'de> serde::Deserialize<'de> for fetch_key_packages_response::KeyPackage {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             KeyPackageTlsSerialized,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -242,7 +251,7 @@ impl<'de> serde::Deserialize<'de> for fetch_key_packages_response::KeyPackage {
                     {
                         match value {
                             "keyPackageTlsSerialized" | "key_package_tls_serialized" => Ok(GeneratedField::KeyPackageTlsSerialized),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -271,6 +280,9 @@ impl<'de> serde::Deserialize<'de> for fetch_key_packages_response::KeyPackage {
                             key_package_tls_serialized__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -325,6 +337,7 @@ impl<'de> serde::Deserialize<'de> for GetIdentityUpdatesRequest {
         enum GeneratedField {
             AccountAddresses,
             StartTimeNs,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -348,7 +361,7 @@ impl<'de> serde::Deserialize<'de> for GetIdentityUpdatesRequest {
                         match value {
                             "accountAddresses" | "account_addresses" => Ok(GeneratedField::AccountAddresses),
                             "startTimeNs" | "start_time_ns" => Ok(GeneratedField::StartTimeNs),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -384,6 +397,9 @@ impl<'de> serde::Deserialize<'de> for GetIdentityUpdatesRequest {
                             start_time_ns__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -427,6 +443,7 @@ impl<'de> serde::Deserialize<'de> for GetIdentityUpdatesResponse {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Updates,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -449,7 +466,7 @@ impl<'de> serde::Deserialize<'de> for GetIdentityUpdatesResponse {
                     {
                         match value {
                             "updates" => Ok(GeneratedField::Updates),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -476,6 +493,9 @@ impl<'de> serde::Deserialize<'de> for GetIdentityUpdatesResponse {
                                 return Err(serde::de::Error::duplicate_field("updates"));
                             }
                             updates__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -532,6 +552,7 @@ impl<'de> serde::Deserialize<'de> for get_identity_updates_response::NewInstalla
         enum GeneratedField {
             InstallationKey,
             CredentialIdentity,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -555,7 +576,7 @@ impl<'de> serde::Deserialize<'de> for get_identity_updates_response::NewInstalla
                         match value {
                             "installationKey" | "installation_key" => Ok(GeneratedField::InstallationKey),
                             "credentialIdentity" | "credential_identity" => Ok(GeneratedField::CredentialIdentity),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -593,6 +614,9 @@ impl<'de> serde::Deserialize<'de> for get_identity_updates_response::NewInstalla
                             credential_identity__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -639,6 +663,7 @@ impl<'de> serde::Deserialize<'de> for get_identity_updates_response::RevokedInst
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             InstallationKey,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -661,7 +686,7 @@ impl<'de> serde::Deserialize<'de> for get_identity_updates_response::RevokedInst
                     {
                         match value {
                             "installationKey" | "installation_key" => Ok(GeneratedField::InstallationKey),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -690,6 +715,9 @@ impl<'de> serde::Deserialize<'de> for get_identity_updates_response::RevokedInst
                             installation_key__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -754,6 +782,7 @@ impl<'de> serde::Deserialize<'de> for get_identity_updates_response::Update {
             TimestampNs,
             NewInstallation,
             RevokedInstallation,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -778,7 +807,7 @@ impl<'de> serde::Deserialize<'de> for get_identity_updates_response::Update {
                             "timestampNs" | "timestamp_ns" => Ok(GeneratedField::TimestampNs),
                             "newInstallation" | "new_installation" => Ok(GeneratedField::NewInstallation),
                             "revokedInstallation" | "revoked_installation" => Ok(GeneratedField::RevokedInstallation),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -823,6 +852,9 @@ impl<'de> serde::Deserialize<'de> for get_identity_updates_response::Update {
                             kind__ = map_.next_value::<::std::option::Option<_>>()?.map(get_identity_updates_response::update::Kind::RevokedInstallation)
 ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(get_identity_updates_response::Update {
@@ -865,6 +897,7 @@ impl<'de> serde::Deserialize<'de> for get_identity_updates_response::WalletUpdat
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Updates,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -887,7 +920,7 @@ impl<'de> serde::Deserialize<'de> for get_identity_updates_response::WalletUpdat
                     {
                         match value {
                             "updates" => Ok(GeneratedField::Updates),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -914,6 +947,9 @@ impl<'de> serde::Deserialize<'de> for get_identity_updates_response::WalletUpdat
                                 return Err(serde::de::Error::duplicate_field("updates"));
                             }
                             updates__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -960,6 +996,7 @@ impl<'de> serde::Deserialize<'de> for GroupMessage {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             V1,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -982,7 +1019,7 @@ impl<'de> serde::Deserialize<'de> for GroupMessage {
                     {
                         match value {
                             "v1" => Ok(GeneratedField::V1),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1010,6 +1047,9 @@ impl<'de> serde::Deserialize<'de> for GroupMessage {
                             }
                             version__ = map_.next_value::<::std::option::Option<_>>()?.map(group_message::Version::V1)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1106,6 +1146,7 @@ impl<'de> serde::Deserialize<'de> for group_message::V1 {
             Data,
             SenderHmac,
             ShouldPush,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1133,7 +1174,7 @@ impl<'de> serde::Deserialize<'de> for group_message::V1 {
                             "data" => Ok(GeneratedField::Data),
                             "senderHmac" | "sender_hmac" => Ok(GeneratedField::SenderHmac),
                             "shouldPush" | "should_push" => Ok(GeneratedField::ShouldPush),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1206,6 +1247,9 @@ impl<'de> serde::Deserialize<'de> for group_message::V1 {
                             }
                             should_push__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(group_message::V1 {
@@ -1256,6 +1300,7 @@ impl<'de> serde::Deserialize<'de> for GroupMessageInput {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             V1,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1278,7 +1323,7 @@ impl<'de> serde::Deserialize<'de> for GroupMessageInput {
                     {
                         match value {
                             "v1" => Ok(GeneratedField::V1),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1306,6 +1351,9 @@ impl<'de> serde::Deserialize<'de> for GroupMessageInput {
                             }
                             version__ = map_.next_value::<::std::option::Option<_>>()?.map(group_message_input::Version::V1)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1370,6 +1418,7 @@ impl<'de> serde::Deserialize<'de> for group_message_input::V1 {
             Data,
             SenderHmac,
             ShouldPush,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1394,7 +1443,7 @@ impl<'de> serde::Deserialize<'de> for group_message_input::V1 {
                             "data" => Ok(GeneratedField::Data),
                             "senderHmac" | "sender_hmac" => Ok(GeneratedField::SenderHmac),
                             "shouldPush" | "should_push" => Ok(GeneratedField::ShouldPush),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1439,6 +1488,9 @@ impl<'de> serde::Deserialize<'de> for group_message_input::V1 {
                                 return Err(serde::de::Error::duplicate_field("shouldPush"));
                             }
                             should_push__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1486,6 +1538,7 @@ impl<'de> serde::Deserialize<'de> for KeyPackageUpload {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             KeyPackageTlsSerialized,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1508,7 +1561,7 @@ impl<'de> serde::Deserialize<'de> for KeyPackageUpload {
                     {
                         match value {
                             "keyPackageTlsSerialized" | "key_package_tls_serialized" => Ok(GeneratedField::KeyPackageTlsSerialized),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1537,6 +1590,9 @@ impl<'de> serde::Deserialize<'de> for KeyPackageUpload {
                             key_package_tls_serialized__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1600,6 +1656,7 @@ impl<'de> serde::Deserialize<'de> for PagingInfo {
             Direction,
             Limit,
             IdCursor,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1624,7 +1681,7 @@ impl<'de> serde::Deserialize<'de> for PagingInfo {
                             "direction" => Ok(GeneratedField::Direction),
                             "limit" => Ok(GeneratedField::Limit),
                             "idCursor" | "id_cursor" => Ok(GeneratedField::IdCursor),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1669,6 +1726,9 @@ impl<'de> serde::Deserialize<'de> for PagingInfo {
                             id_cursor__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1725,6 +1785,7 @@ impl<'de> serde::Deserialize<'de> for QueryGroupMessagesRequest {
         enum GeneratedField {
             GroupId,
             PagingInfo,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1748,7 +1809,7 @@ impl<'de> serde::Deserialize<'de> for QueryGroupMessagesRequest {
                         match value {
                             "groupId" | "group_id" => Ok(GeneratedField::GroupId),
                             "pagingInfo" | "paging_info" => Ok(GeneratedField::PagingInfo),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1784,6 +1845,9 @@ impl<'de> serde::Deserialize<'de> for QueryGroupMessagesRequest {
                                 return Err(serde::de::Error::duplicate_field("pagingInfo"));
                             }
                             paging_info__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1836,6 +1900,7 @@ impl<'de> serde::Deserialize<'de> for QueryGroupMessagesResponse {
         enum GeneratedField {
             Messages,
             PagingInfo,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1859,7 +1924,7 @@ impl<'de> serde::Deserialize<'de> for QueryGroupMessagesResponse {
                         match value {
                             "messages" => Ok(GeneratedField::Messages),
                             "pagingInfo" | "paging_info" => Ok(GeneratedField::PagingInfo),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1893,6 +1958,9 @@ impl<'de> serde::Deserialize<'de> for QueryGroupMessagesResponse {
                                 return Err(serde::de::Error::duplicate_field("pagingInfo"));
                             }
                             paging_info__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1948,6 +2016,7 @@ impl<'de> serde::Deserialize<'de> for QueryWelcomeMessagesRequest {
         enum GeneratedField {
             InstallationKey,
             PagingInfo,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1971,7 +2040,7 @@ impl<'de> serde::Deserialize<'de> for QueryWelcomeMessagesRequest {
                         match value {
                             "installationKey" | "installation_key" => Ok(GeneratedField::InstallationKey),
                             "pagingInfo" | "paging_info" => Ok(GeneratedField::PagingInfo),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2007,6 +2076,9 @@ impl<'de> serde::Deserialize<'de> for QueryWelcomeMessagesRequest {
                                 return Err(serde::de::Error::duplicate_field("pagingInfo"));
                             }
                             paging_info__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2059,6 +2131,7 @@ impl<'de> serde::Deserialize<'de> for QueryWelcomeMessagesResponse {
         enum GeneratedField {
             Messages,
             PagingInfo,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2082,7 +2155,7 @@ impl<'de> serde::Deserialize<'de> for QueryWelcomeMessagesResponse {
                         match value {
                             "messages" => Ok(GeneratedField::Messages),
                             "pagingInfo" | "paging_info" => Ok(GeneratedField::PagingInfo),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2116,6 +2189,9 @@ impl<'de> serde::Deserialize<'de> for QueryWelcomeMessagesResponse {
                                 return Err(serde::de::Error::duplicate_field("pagingInfo"));
                             }
                             paging_info__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2169,6 +2245,7 @@ impl<'de> serde::Deserialize<'de> for RegisterInstallationRequest {
         enum GeneratedField {
             KeyPackage,
             IsInboxIdCredential,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2192,7 +2269,7 @@ impl<'de> serde::Deserialize<'de> for RegisterInstallationRequest {
                         match value {
                             "keyPackage" | "key_package" => Ok(GeneratedField::KeyPackage),
                             "isInboxIdCredential" | "is_inbox_id_credential" => Ok(GeneratedField::IsInboxIdCredential),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2226,6 +2303,9 @@ impl<'de> serde::Deserialize<'de> for RegisterInstallationRequest {
                                 return Err(serde::de::Error::duplicate_field("isInboxIdCredential"));
                             }
                             is_inbox_id_credential__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2272,6 +2352,7 @@ impl<'de> serde::Deserialize<'de> for RegisterInstallationResponse {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             InstallationKey,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2294,7 +2375,7 @@ impl<'de> serde::Deserialize<'de> for RegisterInstallationResponse {
                     {
                         match value {
                             "installationKey" | "installation_key" => Ok(GeneratedField::InstallationKey),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2323,6 +2404,9 @@ impl<'de> serde::Deserialize<'de> for RegisterInstallationResponse {
                             installation_key__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2377,6 +2461,7 @@ impl<'de> serde::Deserialize<'de> for RevokeInstallationRequest {
         enum GeneratedField {
             InstallationKey,
             WalletSignature,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2400,7 +2485,7 @@ impl<'de> serde::Deserialize<'de> for RevokeInstallationRequest {
                         match value {
                             "installationKey" | "installation_key" => Ok(GeneratedField::InstallationKey),
                             "walletSignature" | "wallet_signature" => Ok(GeneratedField::WalletSignature),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2436,6 +2521,9 @@ impl<'de> serde::Deserialize<'de> for RevokeInstallationRequest {
                                 return Err(serde::de::Error::duplicate_field("walletSignature"));
                             }
                             wallet_signature__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2479,6 +2567,7 @@ impl<'de> serde::Deserialize<'de> for SendGroupMessagesRequest {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Messages,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2501,7 +2590,7 @@ impl<'de> serde::Deserialize<'de> for SendGroupMessagesRequest {
                     {
                         match value {
                             "messages" => Ok(GeneratedField::Messages),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2528,6 +2617,9 @@ impl<'de> serde::Deserialize<'de> for SendGroupMessagesRequest {
                                 return Err(serde::de::Error::duplicate_field("messages"));
                             }
                             messages__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2570,6 +2662,7 @@ impl<'de> serde::Deserialize<'de> for SendWelcomeMessagesRequest {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Messages,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2592,7 +2685,7 @@ impl<'de> serde::Deserialize<'de> for SendWelcomeMessagesRequest {
                     {
                         match value {
                             "messages" => Ok(GeneratedField::Messages),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2619,6 +2712,9 @@ impl<'de> serde::Deserialize<'de> for SendWelcomeMessagesRequest {
                                 return Err(serde::de::Error::duplicate_field("messages"));
                             }
                             messages__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2735,6 +2831,7 @@ impl<'de> serde::Deserialize<'de> for SubscribeGroupMessagesRequest {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Filters,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2757,7 +2854,7 @@ impl<'de> serde::Deserialize<'de> for SubscribeGroupMessagesRequest {
                     {
                         match value {
                             "filters" => Ok(GeneratedField::Filters),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2784,6 +2881,9 @@ impl<'de> serde::Deserialize<'de> for SubscribeGroupMessagesRequest {
                                 return Err(serde::de::Error::duplicate_field("filters"));
                             }
                             filters__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2840,6 +2940,7 @@ impl<'de> serde::Deserialize<'de> for subscribe_group_messages_request::Filter {
         enum GeneratedField {
             GroupId,
             IdCursor,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2863,7 +2964,7 @@ impl<'de> serde::Deserialize<'de> for subscribe_group_messages_request::Filter {
                         match value {
                             "groupId" | "group_id" => Ok(GeneratedField::GroupId),
                             "idCursor" | "id_cursor" => Ok(GeneratedField::IdCursor),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2901,6 +3002,9 @@ impl<'de> serde::Deserialize<'de> for subscribe_group_messages_request::Filter {
                             id_cursor__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2944,6 +3048,7 @@ impl<'de> serde::Deserialize<'de> for SubscribeWelcomeMessagesRequest {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Filters,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2966,7 +3071,7 @@ impl<'de> serde::Deserialize<'de> for SubscribeWelcomeMessagesRequest {
                     {
                         match value {
                             "filters" => Ok(GeneratedField::Filters),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2993,6 +3098,9 @@ impl<'de> serde::Deserialize<'de> for SubscribeWelcomeMessagesRequest {
                                 return Err(serde::de::Error::duplicate_field("filters"));
                             }
                             filters__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3049,6 +3157,7 @@ impl<'de> serde::Deserialize<'de> for subscribe_welcome_messages_request::Filter
         enum GeneratedField {
             InstallationKey,
             IdCursor,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3072,7 +3181,7 @@ impl<'de> serde::Deserialize<'de> for subscribe_welcome_messages_request::Filter
                         match value {
                             "installationKey" | "installation_key" => Ok(GeneratedField::InstallationKey),
                             "idCursor" | "id_cursor" => Ok(GeneratedField::IdCursor),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3110,6 +3219,9 @@ impl<'de> serde::Deserialize<'de> for subscribe_welcome_messages_request::Filter
                             id_cursor__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3163,6 +3275,7 @@ impl<'de> serde::Deserialize<'de> for UploadKeyPackageRequest {
         enum GeneratedField {
             KeyPackage,
             IsInboxIdCredential,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3186,7 +3299,7 @@ impl<'de> serde::Deserialize<'de> for UploadKeyPackageRequest {
                         match value {
                             "keyPackage" | "key_package" => Ok(GeneratedField::KeyPackage),
                             "isInboxIdCredential" | "is_inbox_id_credential" => Ok(GeneratedField::IsInboxIdCredential),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3220,6 +3333,9 @@ impl<'de> serde::Deserialize<'de> for UploadKeyPackageRequest {
                                 return Err(serde::de::Error::duplicate_field("isInboxIdCredential"));
                             }
                             is_inbox_id_credential__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3267,6 +3383,7 @@ impl<'de> serde::Deserialize<'de> for WelcomeMessage {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             V1,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3289,7 +3406,7 @@ impl<'de> serde::Deserialize<'de> for WelcomeMessage {
                     {
                         match value {
                             "v1" => Ok(GeneratedField::V1),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3317,6 +3434,9 @@ impl<'de> serde::Deserialize<'de> for WelcomeMessage {
                             }
                             version__ = map_.next_value::<::std::option::Option<_>>()?.map(welcome_message::Version::V1)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3415,6 +3535,7 @@ impl<'de> serde::Deserialize<'de> for welcome_message::V1 {
             Data,
             HpkePublicKey,
             WrapperAlgorithm,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3442,7 +3563,7 @@ impl<'de> serde::Deserialize<'de> for welcome_message::V1 {
                             "data" => Ok(GeneratedField::Data),
                             "hpkePublicKey" | "hpke_public_key" => Ok(GeneratedField::HpkePublicKey),
                             "wrapperAlgorithm" | "wrapper_algorithm" => Ok(GeneratedField::WrapperAlgorithm),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3515,6 +3636,9 @@ impl<'de> serde::Deserialize<'de> for welcome_message::V1 {
                             }
                             wrapper_algorithm__ = Some(map_.next_value::<super::super::message_contents::WelcomeWrapperAlgorithm>()? as i32);
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(welcome_message::V1 {
@@ -3565,6 +3689,7 @@ impl<'de> serde::Deserialize<'de> for WelcomeMessageInput {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             V1,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3587,7 +3712,7 @@ impl<'de> serde::Deserialize<'de> for WelcomeMessageInput {
                     {
                         match value {
                             "v1" => Ok(GeneratedField::V1),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3615,6 +3740,9 @@ impl<'de> serde::Deserialize<'de> for WelcomeMessageInput {
                             }
                             version__ = map_.next_value::<::std::option::Option<_>>()?.map(welcome_message_input::Version::V1)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3692,6 +3820,7 @@ impl<'de> serde::Deserialize<'de> for welcome_message_input::V1 {
             Data,
             HpkePublicKey,
             WrapperAlgorithm,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3717,7 +3846,7 @@ impl<'de> serde::Deserialize<'de> for welcome_message_input::V1 {
                             "data" => Ok(GeneratedField::Data),
                             "hpkePublicKey" | "hpke_public_key" => Ok(GeneratedField::HpkePublicKey),
                             "wrapperAlgorithm" | "wrapper_algorithm" => Ok(GeneratedField::WrapperAlgorithm),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3771,6 +3900,9 @@ impl<'de> serde::Deserialize<'de> for welcome_message_input::V1 {
                                 return Err(serde::de::Error::duplicate_field("wrapperAlgorithm"));
                             }
                             wrapper_algorithm__ = Some(map_.next_value::<super::super::message_contents::WelcomeWrapperAlgorithm>()? as i32);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }

--- a/xmtp_proto/src/gen/xmtp.mls.database.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.mls.database.serde.rs
@@ -12,7 +12,7 @@ impl serde::Serialize for AccountAddresses {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.mls.database.AccountAddresses", len)?;
         if !self.account_addresses.is_empty() {
-            struct_ser.serialize_field("accountAddresses", &self.account_addresses)?;
+            struct_ser.serialize_field("account_addresses", &self.account_addresses)?;
         }
         struct_ser.end()
     }
@@ -208,7 +208,7 @@ impl serde::Serialize for add_members_data::V1 {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.mls.database.AddMembersData.V1", len)?;
         if let Some(v) = self.addresses_or_installation_ids.as_ref() {
-            struct_ser.serialize_field("addressesOrInstallationIds", v)?;
+            struct_ser.serialize_field("addresses_or_installation_ids", v)?;
         }
         struct_ser.end()
     }
@@ -306,10 +306,10 @@ impl serde::Serialize for AddressesOrInstallationIds {
         if let Some(v) = self.addresses_or_installation_ids.as_ref() {
             match v {
                 addresses_or_installation_ids::AddressesOrInstallationIds::AccountAddresses(v) => {
-                    struct_ser.serialize_field("accountAddresses", v)?;
+                    struct_ser.serialize_field("account_addresses", v)?;
                 }
                 addresses_or_installation_ids::AddressesOrInstallationIds::InstallationIds(v) => {
-                    struct_ser.serialize_field("installationIds", v)?;
+                    struct_ser.serialize_field("installation_ids", v)?;
                 }
             }
         }
@@ -499,7 +499,7 @@ impl serde::Serialize for InstallationIds {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.mls.database.InstallationIds", len)?;
         if !self.installation_ids.is_empty() {
-            struct_ser.serialize_field("installationIds", &self.installation_ids.iter().map(pbjson::private::base64::encode).collect::<Vec<_>>())?;
+            struct_ser.serialize_field("installation_ids", &self.installation_ids.iter().map(pbjson::private::base64::encode).collect::<Vec<_>>())?;
         }
         struct_ser.end()
     }
@@ -763,7 +763,7 @@ impl serde::Serialize for PostCommitAction {
         if let Some(v) = self.kind.as_ref() {
             match v {
                 post_commit_action::Kind::SendWelcomes(v) => {
-                    struct_ser.serialize_field("sendWelcomes", v)?;
+                    struct_ser.serialize_field("send_welcomes", v)?;
                 }
             }
         }
@@ -870,17 +870,17 @@ impl serde::Serialize for post_commit_action::Installation {
         if !self.installation_key.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("installationKey", pbjson::private::base64::encode(&self.installation_key).as_str())?;
+            struct_ser.serialize_field("installation_key", pbjson::private::base64::encode(&self.installation_key).as_str())?;
         }
         if !self.hpke_public_key.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("hpkePublicKey", pbjson::private::base64::encode(&self.hpke_public_key).as_str())?;
+            struct_ser.serialize_field("hpke_public_key", pbjson::private::base64::encode(&self.hpke_public_key).as_str())?;
         }
         if self.welcome_wrapper_algorithm != 0 {
             let v = super::message_contents::WelcomeWrapperAlgorithm::try_from(self.welcome_wrapper_algorithm)
                 .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", self.welcome_wrapper_algorithm)))?;
-            struct_ser.serialize_field("welcomeWrapperAlgorithm", &v)?;
+            struct_ser.serialize_field("welcome_wrapper_algorithm", &v)?;
         }
         struct_ser.end()
     }
@@ -1012,7 +1012,7 @@ impl serde::Serialize for post_commit_action::SendWelcomes {
         if !self.welcome_message.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("welcomeMessage", pbjson::private::base64::encode(&self.welcome_message).as_str())?;
+            struct_ser.serialize_field("welcome_message", pbjson::private::base64::encode(&self.welcome_message).as_str())?;
         }
         struct_ser.end()
     }
@@ -1221,7 +1221,7 @@ impl serde::Serialize for remove_members_data::V1 {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.mls.database.RemoveMembersData.V1", len)?;
         if let Some(v) = self.addresses_or_installation_ids.as_ref() {
-            struct_ser.serialize_field("addressesOrInstallationIds", v)?;
+            struct_ser.serialize_field("addresses_or_installation_ids", v)?;
         }
         struct_ser.end()
     }
@@ -1419,7 +1419,7 @@ impl serde::Serialize for send_message_data::V1 {
         if !self.payload_bytes.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("payloadBytes", pbjson::private::base64::encode(&self.payload_bytes).as_str())?;
+            struct_ser.serialize_field("payload_bytes", pbjson::private::base64::encode(&self.payload_bytes).as_str())?;
         }
         struct_ser.end()
     }
@@ -1622,10 +1622,10 @@ impl serde::Serialize for update_admin_lists_data::V1 {
         if self.admin_list_update_type != 0 {
             let v = AdminListUpdateType::try_from(self.admin_list_update_type)
                 .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", self.admin_list_update_type)))?;
-            struct_ser.serialize_field("adminListUpdateType", &v)?;
+            struct_ser.serialize_field("admin_list_update_type", &v)?;
         }
         if !self.inbox_id.is_empty() {
-            struct_ser.serialize_field("inboxId", &self.inbox_id)?;
+            struct_ser.serialize_field("inbox_id", &self.inbox_id)?;
         }
         struct_ser.end()
     }
@@ -1841,13 +1841,13 @@ impl serde::Serialize for update_group_membership_data::V1 {
         if !self.membership_updates.is_empty() {
             let v: std::collections::HashMap<_, _> = self.membership_updates.iter()
                 .map(|(k, v)| (k, v.to_string())).collect();
-            struct_ser.serialize_field("membershipUpdates", &v)?;
+            struct_ser.serialize_field("membership_updates", &v)?;
         }
         if !self.removed_members.is_empty() {
-            struct_ser.serialize_field("removedMembers", &self.removed_members)?;
+            struct_ser.serialize_field("removed_members", &self.removed_members)?;
         }
         if !self.failed_installations.is_empty() {
-            struct_ser.serialize_field("failedInstallations", &self.failed_installations.iter().map(pbjson::private::base64::encode).collect::<Vec<_>>())?;
+            struct_ser.serialize_field("failed_installations", &self.failed_installations.iter().map(pbjson::private::base64::encode).collect::<Vec<_>>())?;
         }
         struct_ser.end()
     }
@@ -2076,10 +2076,10 @@ impl serde::Serialize for update_metadata_data::V1 {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.mls.database.UpdateMetadataData.V1", len)?;
         if !self.field_name.is_empty() {
-            struct_ser.serialize_field("fieldName", &self.field_name)?;
+            struct_ser.serialize_field("field_name", &self.field_name)?;
         }
         if !self.field_value.is_empty() {
-            struct_ser.serialize_field("fieldValue", &self.field_value)?;
+            struct_ser.serialize_field("field_value", &self.field_value)?;
         }
         struct_ser.end()
     }
@@ -2295,15 +2295,15 @@ impl serde::Serialize for update_permission_data::V1 {
         if self.permission_update_type != 0 {
             let v = PermissionUpdateType::try_from(self.permission_update_type)
                 .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", self.permission_update_type)))?;
-            struct_ser.serialize_field("permissionUpdateType", &v)?;
+            struct_ser.serialize_field("permission_update_type", &v)?;
         }
         if self.permission_policy_option != 0 {
             let v = PermissionPolicyOption::try_from(self.permission_policy_option)
                 .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", self.permission_policy_option)))?;
-            struct_ser.serialize_field("permissionPolicyOption", &v)?;
+            struct_ser.serialize_field("permission_policy_option", &v)?;
         }
         if let Some(v) = self.metadata_field_name.as_ref() {
-            struct_ser.serialize_field("metadataFieldName", v)?;
+            struct_ser.serialize_field("metadata_field_name", v)?;
         }
         struct_ser.end()
     }

--- a/xmtp_proto/src/gen/xmtp.mls.database.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.mls.database.serde.rs
@@ -31,6 +31,7 @@ impl<'de> serde::Deserialize<'de> for AccountAddresses {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             AccountAddresses,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -53,7 +54,7 @@ impl<'de> serde::Deserialize<'de> for AccountAddresses {
                     {
                         match value {
                             "accountAddresses" | "account_addresses" => Ok(GeneratedField::AccountAddresses),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -80,6 +81,9 @@ impl<'de> serde::Deserialize<'de> for AccountAddresses {
                                 return Err(serde::de::Error::duplicate_field("accountAddresses"));
                             }
                             account_addresses__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -126,6 +130,7 @@ impl<'de> serde::Deserialize<'de> for AddMembersData {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             V1,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -148,7 +153,7 @@ impl<'de> serde::Deserialize<'de> for AddMembersData {
                     {
                         match value {
                             "v1" => Ok(GeneratedField::V1),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -176,6 +181,9 @@ impl<'de> serde::Deserialize<'de> for AddMembersData {
                             }
                             version__ = map_.next_value::<::std::option::Option<_>>()?.map(add_members_data::Version::V1)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -219,6 +227,7 @@ impl<'de> serde::Deserialize<'de> for add_members_data::V1 {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             AddressesOrInstallationIds,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -241,7 +250,7 @@ impl<'de> serde::Deserialize<'de> for add_members_data::V1 {
                     {
                         match value {
                             "addressesOrInstallationIds" | "addresses_or_installation_ids" => Ok(GeneratedField::AddressesOrInstallationIds),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -268,6 +277,9 @@ impl<'de> serde::Deserialize<'de> for add_members_data::V1 {
                                 return Err(serde::de::Error::duplicate_field("addressesOrInstallationIds"));
                             }
                             addresses_or_installation_ids__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -321,6 +333,7 @@ impl<'de> serde::Deserialize<'de> for AddressesOrInstallationIds {
         enum GeneratedField {
             AccountAddresses,
             InstallationIds,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -344,7 +357,7 @@ impl<'de> serde::Deserialize<'de> for AddressesOrInstallationIds {
                         match value {
                             "accountAddresses" | "account_addresses" => Ok(GeneratedField::AccountAddresses),
                             "installationIds" | "installation_ids" => Ok(GeneratedField::InstallationIds),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -379,6 +392,9 @@ impl<'de> serde::Deserialize<'de> for AddressesOrInstallationIds {
                             }
                             addresses_or_installation_ids__ = map_.next_value::<::std::option::Option<_>>()?.map(addresses_or_installation_ids::AddressesOrInstallationIds::InstallationIds)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -502,6 +518,7 @@ impl<'de> serde::Deserialize<'de> for InstallationIds {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             InstallationIds,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -524,7 +541,7 @@ impl<'de> serde::Deserialize<'de> for InstallationIds {
                     {
                         match value {
                             "installationIds" | "installation_ids" => Ok(GeneratedField::InstallationIds),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -554,6 +571,9 @@ impl<'de> serde::Deserialize<'de> for InstallationIds {
                                 Some(map_.next_value::<Vec<::pbjson::private::BytesDeserialize<_>>>()?
                                     .into_iter().map(|x| x.0).collect())
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -764,6 +784,7 @@ impl<'de> serde::Deserialize<'de> for PostCommitAction {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             SendWelcomes,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -786,7 +807,7 @@ impl<'de> serde::Deserialize<'de> for PostCommitAction {
                     {
                         match value {
                             "sendWelcomes" | "send_welcomes" => Ok(GeneratedField::SendWelcomes),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -814,6 +835,9 @@ impl<'de> serde::Deserialize<'de> for PostCommitAction {
                             }
                             kind__ = map_.next_value::<::std::option::Option<_>>()?.map(post_commit_action::Kind::SendWelcomes)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -881,6 +905,7 @@ impl<'de> serde::Deserialize<'de> for post_commit_action::Installation {
             InstallationKey,
             HpkePublicKey,
             WelcomeWrapperAlgorithm,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -905,7 +930,7 @@ impl<'de> serde::Deserialize<'de> for post_commit_action::Installation {
                             "installationKey" | "installation_key" => Ok(GeneratedField::InstallationKey),
                             "hpkePublicKey" | "hpke_public_key" => Ok(GeneratedField::HpkePublicKey),
                             "welcomeWrapperAlgorithm" | "welcome_wrapper_algorithm" => Ok(GeneratedField::WelcomeWrapperAlgorithm),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -950,6 +975,9 @@ impl<'de> serde::Deserialize<'de> for post_commit_action::Installation {
                                 return Err(serde::de::Error::duplicate_field("welcomeWrapperAlgorithm"));
                             }
                             welcome_wrapper_algorithm__ = Some(map_.next_value::<super::message_contents::WelcomeWrapperAlgorithm>()? as i32);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1005,6 +1033,7 @@ impl<'de> serde::Deserialize<'de> for post_commit_action::SendWelcomes {
         enum GeneratedField {
             Installations,
             WelcomeMessage,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1028,7 +1057,7 @@ impl<'de> serde::Deserialize<'de> for post_commit_action::SendWelcomes {
                         match value {
                             "installations" => Ok(GeneratedField::Installations),
                             "welcomeMessage" | "welcome_message" => Ok(GeneratedField::WelcomeMessage),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1064,6 +1093,9 @@ impl<'de> serde::Deserialize<'de> for post_commit_action::SendWelcomes {
                             welcome_message__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1111,6 +1143,7 @@ impl<'de> serde::Deserialize<'de> for RemoveMembersData {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             V1,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1133,7 +1166,7 @@ impl<'de> serde::Deserialize<'de> for RemoveMembersData {
                     {
                         match value {
                             "v1" => Ok(GeneratedField::V1),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1161,6 +1194,9 @@ impl<'de> serde::Deserialize<'de> for RemoveMembersData {
                             }
                             version__ = map_.next_value::<::std::option::Option<_>>()?.map(remove_members_data::Version::V1)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1204,6 +1240,7 @@ impl<'de> serde::Deserialize<'de> for remove_members_data::V1 {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             AddressesOrInstallationIds,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1226,7 +1263,7 @@ impl<'de> serde::Deserialize<'de> for remove_members_data::V1 {
                     {
                         match value {
                             "addressesOrInstallationIds" | "addresses_or_installation_ids" => Ok(GeneratedField::AddressesOrInstallationIds),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1253,6 +1290,9 @@ impl<'de> serde::Deserialize<'de> for remove_members_data::V1 {
                                 return Err(serde::de::Error::duplicate_field("addressesOrInstallationIds"));
                             }
                             addresses_or_installation_ids__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1299,6 +1339,7 @@ impl<'de> serde::Deserialize<'de> for SendMessageData {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             V1,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1321,7 +1362,7 @@ impl<'de> serde::Deserialize<'de> for SendMessageData {
                     {
                         match value {
                             "v1" => Ok(GeneratedField::V1),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1349,6 +1390,9 @@ impl<'de> serde::Deserialize<'de> for SendMessageData {
                             }
                             version__ = map_.next_value::<::std::option::Option<_>>()?.map(send_message_data::Version::V1)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1394,6 +1438,7 @@ impl<'de> serde::Deserialize<'de> for send_message_data::V1 {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             PayloadBytes,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1416,7 +1461,7 @@ impl<'de> serde::Deserialize<'de> for send_message_data::V1 {
                     {
                         match value {
                             "payloadBytes" | "payload_bytes" => Ok(GeneratedField::PayloadBytes),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1445,6 +1490,9 @@ impl<'de> serde::Deserialize<'de> for send_message_data::V1 {
                             payload_bytes__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1491,6 +1539,7 @@ impl<'de> serde::Deserialize<'de> for UpdateAdminListsData {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             V1,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1513,7 +1562,7 @@ impl<'de> serde::Deserialize<'de> for UpdateAdminListsData {
                     {
                         match value {
                             "v1" => Ok(GeneratedField::V1),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1541,6 +1590,9 @@ impl<'de> serde::Deserialize<'de> for UpdateAdminListsData {
                             }
                             version__ = map_.next_value::<::std::option::Option<_>>()?.map(update_admin_lists_data::Version::V1)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1595,6 +1647,7 @@ impl<'de> serde::Deserialize<'de> for update_admin_lists_data::V1 {
         enum GeneratedField {
             AdminListUpdateType,
             InboxId,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1618,7 +1671,7 @@ impl<'de> serde::Deserialize<'de> for update_admin_lists_data::V1 {
                         match value {
                             "adminListUpdateType" | "admin_list_update_type" => Ok(GeneratedField::AdminListUpdateType),
                             "inboxId" | "inbox_id" => Ok(GeneratedField::InboxId),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1652,6 +1705,9 @@ impl<'de> serde::Deserialize<'de> for update_admin_lists_data::V1 {
                                 return Err(serde::de::Error::duplicate_field("inboxId"));
                             }
                             inbox_id__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1699,6 +1755,7 @@ impl<'de> serde::Deserialize<'de> for UpdateGroupMembershipData {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             V1,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1721,7 +1778,7 @@ impl<'de> serde::Deserialize<'de> for UpdateGroupMembershipData {
                     {
                         match value {
                             "v1" => Ok(GeneratedField::V1),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1749,6 +1806,9 @@ impl<'de> serde::Deserialize<'de> for UpdateGroupMembershipData {
                             }
                             version__ = map_.next_value::<::std::option::Option<_>>()?.map(update_group_membership_data::Version::V1)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1812,6 +1872,7 @@ impl<'de> serde::Deserialize<'de> for update_group_membership_data::V1 {
             MembershipUpdates,
             RemovedMembers,
             FailedInstallations,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1836,7 +1897,7 @@ impl<'de> serde::Deserialize<'de> for update_group_membership_data::V1 {
                             "membershipUpdates" | "membership_updates" => Ok(GeneratedField::MembershipUpdates),
                             "removedMembers" | "removed_members" => Ok(GeneratedField::RemovedMembers),
                             "failedInstallations" | "failed_installations" => Ok(GeneratedField::FailedInstallations),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1883,6 +1944,9 @@ impl<'de> serde::Deserialize<'de> for update_group_membership_data::V1 {
                                 Some(map_.next_value::<Vec<::pbjson::private::BytesDeserialize<_>>>()?
                                     .into_iter().map(|x| x.0).collect())
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1931,6 +1995,7 @@ impl<'de> serde::Deserialize<'de> for UpdateMetadataData {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             V1,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1953,7 +2018,7 @@ impl<'de> serde::Deserialize<'de> for UpdateMetadataData {
                     {
                         match value {
                             "v1" => Ok(GeneratedField::V1),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1981,6 +2046,9 @@ impl<'de> serde::Deserialize<'de> for UpdateMetadataData {
                             }
                             version__ = map_.next_value::<::std::option::Option<_>>()?.map(update_metadata_data::Version::V1)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2033,6 +2101,7 @@ impl<'de> serde::Deserialize<'de> for update_metadata_data::V1 {
         enum GeneratedField {
             FieldName,
             FieldValue,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2056,7 +2125,7 @@ impl<'de> serde::Deserialize<'de> for update_metadata_data::V1 {
                         match value {
                             "fieldName" | "field_name" => Ok(GeneratedField::FieldName),
                             "fieldValue" | "field_value" => Ok(GeneratedField::FieldValue),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2090,6 +2159,9 @@ impl<'de> serde::Deserialize<'de> for update_metadata_data::V1 {
                                 return Err(serde::de::Error::duplicate_field("fieldValue"));
                             }
                             field_value__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2137,6 +2209,7 @@ impl<'de> serde::Deserialize<'de> for UpdatePermissionData {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             V1,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2159,7 +2232,7 @@ impl<'de> serde::Deserialize<'de> for UpdatePermissionData {
                     {
                         match value {
                             "v1" => Ok(GeneratedField::V1),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2187,6 +2260,9 @@ impl<'de> serde::Deserialize<'de> for UpdatePermissionData {
                             }
                             version__ = map_.next_value::<::std::option::Option<_>>()?.map(update_permission_data::Version::V1)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2252,6 +2328,7 @@ impl<'de> serde::Deserialize<'de> for update_permission_data::V1 {
             PermissionUpdateType,
             PermissionPolicyOption,
             MetadataFieldName,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2276,7 +2353,7 @@ impl<'de> serde::Deserialize<'de> for update_permission_data::V1 {
                             "permissionUpdateType" | "permission_update_type" => Ok(GeneratedField::PermissionUpdateType),
                             "permissionPolicyOption" | "permission_policy_option" => Ok(GeneratedField::PermissionPolicyOption),
                             "metadataFieldName" | "metadata_field_name" => Ok(GeneratedField::MetadataFieldName),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2317,6 +2394,9 @@ impl<'de> serde::Deserialize<'de> for update_permission_data::V1 {
                                 return Err(serde::de::Error::duplicate_field("metadataFieldName"));
                             }
                             metadata_field_name__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }

--- a/xmtp_proto/src/gen/xmtp.mls.message_contents.content_types.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.mls.message_contents.content_types.serde.rs
@@ -273,7 +273,7 @@ impl serde::Serialize for ReactionV2 {
             struct_ser.serialize_field("reference", &self.reference)?;
         }
         if !self.reference_inbox_id.is_empty() {
-            struct_ser.serialize_field("referenceInboxId", &self.reference_inbox_id)?;
+            struct_ser.serialize_field("reference_inbox_id", &self.reference_inbox_id)?;
         }
         if self.action != 0 {
             let v = ReactionAction::try_from(self.action)
@@ -447,7 +447,7 @@ impl serde::Serialize for RemoteAttachmentInfo {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.mls.message_contents.content_types.RemoteAttachmentInfo", len)?;
         if !self.content_digest.is_empty() {
-            struct_ser.serialize_field("contentDigest", &self.content_digest)?;
+            struct_ser.serialize_field("content_digest", &self.content_digest)?;
         }
         if !self.secret.is_empty() {
             #[allow(clippy::needless_borrow)]
@@ -471,7 +471,7 @@ impl serde::Serialize for RemoteAttachmentInfo {
             struct_ser.serialize_field("url", &self.url)?;
         }
         if let Some(v) = self.content_length.as_ref() {
-            struct_ser.serialize_field("contentLength", v)?;
+            struct_ser.serialize_field("content_length", v)?;
         }
         if let Some(v) = self.filename.as_ref() {
             struct_ser.serialize_field("filename", v)?;

--- a/xmtp_proto/src/gen/xmtp.mls.message_contents.content_types.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.mls.message_contents.content_types.serde.rs
@@ -30,6 +30,7 @@ impl<'de> serde::Deserialize<'de> for MultiRemoteAttachment {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Attachments,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -52,7 +53,7 @@ impl<'de> serde::Deserialize<'de> for MultiRemoteAttachment {
                     {
                         match value {
                             "attachments" => Ok(GeneratedField::Attachments),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -79,6 +80,9 @@ impl<'de> serde::Deserialize<'de> for MultiRemoteAttachment {
                                 return Err(serde::de::Error::duplicate_field("attachments"));
                             }
                             attachments__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -309,6 +313,7 @@ impl<'de> serde::Deserialize<'de> for ReactionV2 {
             Action,
             Content,
             Schema,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -335,7 +340,7 @@ impl<'de> serde::Deserialize<'de> for ReactionV2 {
                             "action" => Ok(GeneratedField::Action),
                             "content" => Ok(GeneratedField::Content),
                             "schema" => Ok(GeneratedField::Schema),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -390,6 +395,9 @@ impl<'de> serde::Deserialize<'de> for ReactionV2 {
                                 return Err(serde::de::Error::duplicate_field("schema"));
                             }
                             schema__ = Some(map_.next_value::<ReactionSchema>()? as i32);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -500,6 +508,7 @@ impl<'de> serde::Deserialize<'de> for RemoteAttachmentInfo {
             Url,
             ContentLength,
             Filename,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -529,7 +538,7 @@ impl<'de> serde::Deserialize<'de> for RemoteAttachmentInfo {
                             "url" => Ok(GeneratedField::Url),
                             "contentLength" | "content_length" => Ok(GeneratedField::ContentLength),
                             "filename" => Ok(GeneratedField::Filename),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -613,6 +622,9 @@ impl<'de> serde::Deserialize<'de> for RemoteAttachmentInfo {
                                 return Err(serde::de::Error::duplicate_field("filename"));
                             }
                             filename__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }

--- a/xmtp_proto/src/gen/xmtp.mls.message_contents.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.mls.message_contents.serde.rs
@@ -129,6 +129,7 @@ impl<'de> serde::Deserialize<'de> for ContentTypeId {
             TypeId,
             VersionMajor,
             VersionMinor,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -154,7 +155,7 @@ impl<'de> serde::Deserialize<'de> for ContentTypeId {
                             "typeId" | "type_id" => Ok(GeneratedField::TypeId),
                             "versionMajor" | "version_major" => Ok(GeneratedField::VersionMajor),
                             "versionMinor" | "version_minor" => Ok(GeneratedField::VersionMinor),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -206,6 +207,9 @@ impl<'de> serde::Deserialize<'de> for ContentTypeId {
                             version_minor__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -338,6 +342,7 @@ impl<'de> serde::Deserialize<'de> for DmMembers {
         enum GeneratedField {
             DmMemberOne,
             DmMemberTwo,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -361,7 +366,7 @@ impl<'de> serde::Deserialize<'de> for DmMembers {
                         match value {
                             "dmMemberOne" | "dm_member_one" => Ok(GeneratedField::DmMemberOne),
                             "dmMemberTwo" | "dm_member_two" => Ok(GeneratedField::DmMemberTwo),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -395,6 +400,9 @@ impl<'de> serde::Deserialize<'de> for DmMembers {
                                 return Err(serde::de::Error::duplicate_field("dmMemberTwo"));
                             }
                             dm_member_two__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -474,6 +482,7 @@ impl<'de> serde::Deserialize<'de> for EncodedContent {
             Fallback,
             Compression,
             Content,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -500,7 +509,7 @@ impl<'de> serde::Deserialize<'de> for EncodedContent {
                             "fallback" => Ok(GeneratedField::Fallback),
                             "compression" => Ok(GeneratedField::Compression),
                             "content" => Ok(GeneratedField::Content),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -560,6 +569,9 @@ impl<'de> serde::Deserialize<'de> for EncodedContent {
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(EncodedContent {
@@ -616,6 +628,7 @@ impl<'de> serde::Deserialize<'de> for GroupMembership {
         enum GeneratedField {
             Members,
             FailedInstallations,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -639,7 +652,7 @@ impl<'de> serde::Deserialize<'de> for GroupMembership {
                         match value {
                             "members" => Ok(GeneratedField::Members),
                             "failedInstallations" | "failed_installations" => Ok(GeneratedField::FailedInstallations),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -679,6 +692,9 @@ impl<'de> serde::Deserialize<'de> for GroupMembership {
                                 Some(map_.next_value::<Vec<::pbjson::private::BytesDeserialize<_>>>()?
                                     .into_iter().map(|x| x.0).collect())
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -750,6 +766,7 @@ impl<'de> serde::Deserialize<'de> for GroupMembershipChanges {
             MembersRemoved,
             InstallationsAdded,
             InstallationsRemoved,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -775,7 +792,7 @@ impl<'de> serde::Deserialize<'de> for GroupMembershipChanges {
                             "membersRemoved" | "members_removed" => Ok(GeneratedField::MembersRemoved),
                             "installationsAdded" | "installations_added" => Ok(GeneratedField::InstallationsAdded),
                             "installationsRemoved" | "installations_removed" => Ok(GeneratedField::InstallationsRemoved),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -823,6 +840,9 @@ impl<'de> serde::Deserialize<'de> for GroupMembershipChanges {
                                 return Err(serde::de::Error::duplicate_field("installationsRemoved"));
                             }
                             installations_removed__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -898,6 +918,7 @@ impl<'de> serde::Deserialize<'de> for GroupMetadataV1 {
             CreatorAccountAddress,
             CreatorInboxId,
             DmMembers,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -923,7 +944,7 @@ impl<'de> serde::Deserialize<'de> for GroupMetadataV1 {
                             "creatorAccountAddress" | "creator_account_address" => Ok(GeneratedField::CreatorAccountAddress),
                             "creatorInboxId" | "creator_inbox_id" => Ok(GeneratedField::CreatorInboxId),
                             "dmMembers" | "dm_members" => Ok(GeneratedField::DmMembers),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -971,6 +992,9 @@ impl<'de> serde::Deserialize<'de> for GroupMetadataV1 {
                                 return Err(serde::de::Error::duplicate_field("dmMembers"));
                             }
                             dm_members__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1034,6 +1058,7 @@ impl<'de> serde::Deserialize<'de> for GroupMutableMetadataV1 {
             Attributes,
             AdminList,
             SuperAdminList,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1058,7 +1083,7 @@ impl<'de> serde::Deserialize<'de> for GroupMutableMetadataV1 {
                             "attributes" => Ok(GeneratedField::Attributes),
                             "adminList" | "admin_list" => Ok(GeneratedField::AdminList),
                             "superAdminList" | "super_admin_list" => Ok(GeneratedField::SuperAdminList),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1101,6 +1126,9 @@ impl<'de> serde::Deserialize<'de> for GroupMutableMetadataV1 {
                                 return Err(serde::de::Error::duplicate_field("superAdminList"));
                             }
                             super_admin_list__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1145,6 +1173,7 @@ impl<'de> serde::Deserialize<'de> for GroupMutablePermissionsV1 {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Policies,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1167,7 +1196,7 @@ impl<'de> serde::Deserialize<'de> for GroupMutablePermissionsV1 {
                     {
                         match value {
                             "policies" => Ok(GeneratedField::Policies),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1194,6 +1223,9 @@ impl<'de> serde::Deserialize<'de> for GroupMutablePermissionsV1 {
                                 return Err(serde::de::Error::duplicate_field("policies"));
                             }
                             policies__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1264,6 +1296,7 @@ impl<'de> serde::Deserialize<'de> for GroupUpdated {
             AddedInboxes,
             RemovedInboxes,
             MetadataFieldChanges,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1289,7 +1322,7 @@ impl<'de> serde::Deserialize<'de> for GroupUpdated {
                             "addedInboxes" | "added_inboxes" => Ok(GeneratedField::AddedInboxes),
                             "removedInboxes" | "removed_inboxes" => Ok(GeneratedField::RemovedInboxes),
                             "metadataFieldChanges" | "metadata_field_changes" => Ok(GeneratedField::MetadataFieldChanges),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1338,6 +1371,9 @@ impl<'de> serde::Deserialize<'de> for GroupUpdated {
                             }
                             metadata_field_changes__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(GroupUpdated {
@@ -1383,6 +1419,7 @@ impl<'de> serde::Deserialize<'de> for group_updated::Inbox {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             InboxId,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1405,7 +1442,7 @@ impl<'de> serde::Deserialize<'de> for group_updated::Inbox {
                     {
                         match value {
                             "inboxId" | "inbox_id" => Ok(GeneratedField::InboxId),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1432,6 +1469,9 @@ impl<'de> serde::Deserialize<'de> for group_updated::Inbox {
                                 return Err(serde::de::Error::duplicate_field("inboxId"));
                             }
                             inbox_id__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1493,6 +1533,7 @@ impl<'de> serde::Deserialize<'de> for group_updated::MetadataFieldChange {
             FieldName,
             OldValue,
             NewValue,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1517,7 +1558,7 @@ impl<'de> serde::Deserialize<'de> for group_updated::MetadataFieldChange {
                             "fieldName" | "field_name" => Ok(GeneratedField::FieldName),
                             "oldValue" | "old_value" => Ok(GeneratedField::OldValue),
                             "newValue" | "new_value" => Ok(GeneratedField::NewValue),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1558,6 +1599,9 @@ impl<'de> serde::Deserialize<'de> for group_updated::MetadataFieldChange {
                                 return Err(serde::de::Error::duplicate_field("newValue"));
                             }
                             new_value__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1603,6 +1647,7 @@ impl<'de> serde::Deserialize<'de> for Inbox {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             InboxId,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1625,7 +1670,7 @@ impl<'de> serde::Deserialize<'de> for Inbox {
                     {
                         match value {
                             "inboxId" | "inbox_id" => Ok(GeneratedField::InboxId),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1652,6 +1697,9 @@ impl<'de> serde::Deserialize<'de> for Inbox {
                                 return Err(serde::de::Error::duplicate_field("inboxId"));
                             }
                             inbox_id__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1695,6 +1743,7 @@ impl<'de> serde::Deserialize<'de> for Inboxes {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             InboxIds,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1717,7 +1766,7 @@ impl<'de> serde::Deserialize<'de> for Inboxes {
                     {
                         match value {
                             "inboxIds" | "inbox_ids" => Ok(GeneratedField::InboxIds),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1744,6 +1793,9 @@ impl<'de> serde::Deserialize<'de> for Inboxes {
                                 return Err(serde::de::Error::duplicate_field("inboxIds"));
                             }
                             inbox_ids__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1805,6 +1857,7 @@ impl<'de> serde::Deserialize<'de> for MembershipChange {
             InstallationIds,
             AccountAddress,
             InitiatedByAccountAddress,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1829,7 +1882,7 @@ impl<'de> serde::Deserialize<'de> for MembershipChange {
                             "installationIds" | "installation_ids" => Ok(GeneratedField::InstallationIds),
                             "accountAddress" | "account_address" => Ok(GeneratedField::AccountAddress),
                             "initiatedByAccountAddress" | "initiated_by_account_address" => Ok(GeneratedField::InitiatedByAccountAddress),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1873,6 +1926,9 @@ impl<'de> serde::Deserialize<'de> for MembershipChange {
                                 return Err(serde::de::Error::duplicate_field("initiatedByAccountAddress"));
                             }
                             initiated_by_account_address__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1935,6 +1991,7 @@ impl<'de> serde::Deserialize<'de> for MembershipPolicy {
             Base,
             AndCondition,
             AnyCondition,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1959,7 +2016,7 @@ impl<'de> serde::Deserialize<'de> for MembershipPolicy {
                             "base" => Ok(GeneratedField::Base),
                             "andCondition" | "and_condition" => Ok(GeneratedField::AndCondition),
                             "anyCondition" | "any_condition" => Ok(GeneratedField::AnyCondition),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2000,6 +2057,9 @@ impl<'de> serde::Deserialize<'de> for MembershipPolicy {
                             }
                             kind__ = map_.next_value::<::std::option::Option<_>>()?.map(membership_policy::Kind::AnyCondition)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2042,6 +2102,7 @@ impl<'de> serde::Deserialize<'de> for membership_policy::AndCondition {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Policies,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2064,7 +2125,7 @@ impl<'de> serde::Deserialize<'de> for membership_policy::AndCondition {
                     {
                         match value {
                             "policies" => Ok(GeneratedField::Policies),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2091,6 +2152,9 @@ impl<'de> serde::Deserialize<'de> for membership_policy::AndCondition {
                                 return Err(serde::de::Error::duplicate_field("policies"));
                             }
                             policies__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2133,6 +2197,7 @@ impl<'de> serde::Deserialize<'de> for membership_policy::AnyCondition {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Policies,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2155,7 +2220,7 @@ impl<'de> serde::Deserialize<'de> for membership_policy::AnyCondition {
                     {
                         match value {
                             "policies" => Ok(GeneratedField::Policies),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2182,6 +2247,9 @@ impl<'de> serde::Deserialize<'de> for membership_policy::AnyCondition {
                                 return Err(serde::de::Error::duplicate_field("policies"));
                             }
                             policies__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2322,6 +2390,7 @@ impl<'de> serde::Deserialize<'de> for MetadataPolicy {
             Base,
             AndCondition,
             AnyCondition,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2346,7 +2415,7 @@ impl<'de> serde::Deserialize<'de> for MetadataPolicy {
                             "base" => Ok(GeneratedField::Base),
                             "andCondition" | "and_condition" => Ok(GeneratedField::AndCondition),
                             "anyCondition" | "any_condition" => Ok(GeneratedField::AnyCondition),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2387,6 +2456,9 @@ impl<'de> serde::Deserialize<'de> for MetadataPolicy {
                             }
                             kind__ = map_.next_value::<::std::option::Option<_>>()?.map(metadata_policy::Kind::AnyCondition)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2429,6 +2501,7 @@ impl<'de> serde::Deserialize<'de> for metadata_policy::AndCondition {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Policies,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2451,7 +2524,7 @@ impl<'de> serde::Deserialize<'de> for metadata_policy::AndCondition {
                     {
                         match value {
                             "policies" => Ok(GeneratedField::Policies),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2478,6 +2551,9 @@ impl<'de> serde::Deserialize<'de> for metadata_policy::AndCondition {
                                 return Err(serde::de::Error::duplicate_field("policies"));
                             }
                             policies__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2520,6 +2596,7 @@ impl<'de> serde::Deserialize<'de> for metadata_policy::AnyCondition {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Policies,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2542,7 +2619,7 @@ impl<'de> serde::Deserialize<'de> for metadata_policy::AnyCondition {
                     {
                         match value {
                             "policies" => Ok(GeneratedField::Policies),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2569,6 +2646,9 @@ impl<'de> serde::Deserialize<'de> for metadata_policy::AnyCondition {
                                 return Err(serde::de::Error::duplicate_field("policies"));
                             }
                             policies__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2709,6 +2789,7 @@ impl<'de> serde::Deserialize<'de> for PermissionsUpdatePolicy {
             Base,
             AndCondition,
             AnyCondition,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2733,7 +2814,7 @@ impl<'de> serde::Deserialize<'de> for PermissionsUpdatePolicy {
                             "base" => Ok(GeneratedField::Base),
                             "andCondition" | "and_condition" => Ok(GeneratedField::AndCondition),
                             "anyCondition" | "any_condition" => Ok(GeneratedField::AnyCondition),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2774,6 +2855,9 @@ impl<'de> serde::Deserialize<'de> for PermissionsUpdatePolicy {
                             }
                             kind__ = map_.next_value::<::std::option::Option<_>>()?.map(permissions_update_policy::Kind::AnyCondition)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2816,6 +2900,7 @@ impl<'de> serde::Deserialize<'de> for permissions_update_policy::AndCondition {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Policies,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2838,7 +2923,7 @@ impl<'de> serde::Deserialize<'de> for permissions_update_policy::AndCondition {
                     {
                         match value {
                             "policies" => Ok(GeneratedField::Policies),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2865,6 +2950,9 @@ impl<'de> serde::Deserialize<'de> for permissions_update_policy::AndCondition {
                                 return Err(serde::de::Error::duplicate_field("policies"));
                             }
                             policies__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2907,6 +2995,7 @@ impl<'de> serde::Deserialize<'de> for permissions_update_policy::AnyCondition {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Policies,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2929,7 +3018,7 @@ impl<'de> serde::Deserialize<'de> for permissions_update_policy::AnyCondition {
                     {
                         match value {
                             "policies" => Ok(GeneratedField::Policies),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2956,6 +3045,9 @@ impl<'de> serde::Deserialize<'de> for permissions_update_policy::AnyCondition {
                                 return Err(serde::de::Error::duplicate_field("policies"));
                             }
                             policies__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3084,6 +3176,7 @@ impl<'de> serde::Deserialize<'de> for PlaintextEnvelope {
         enum GeneratedField {
             V1,
             V2,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3107,7 +3200,7 @@ impl<'de> serde::Deserialize<'de> for PlaintextEnvelope {
                         match value {
                             "v1" => Ok(GeneratedField::V1),
                             "v2" => Ok(GeneratedField::V2),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3142,6 +3235,9 @@ impl<'de> serde::Deserialize<'de> for PlaintextEnvelope {
                             }
                             content__ = map_.next_value::<::std::option::Option<_>>()?.map(plaintext_envelope::Content::V2)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3195,6 +3291,7 @@ impl<'de> serde::Deserialize<'de> for plaintext_envelope::V1 {
         enum GeneratedField {
             Content,
             IdempotencyKey,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3218,7 +3315,7 @@ impl<'de> serde::Deserialize<'de> for plaintext_envelope::V1 {
                         match value {
                             "content" => Ok(GeneratedField::Content),
                             "idempotencyKey" | "idempotency_key" => Ok(GeneratedField::IdempotencyKey),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3254,6 +3351,9 @@ impl<'de> serde::Deserialize<'de> for plaintext_envelope::V1 {
                                 return Err(serde::de::Error::duplicate_field("idempotencyKey"));
                             }
                             idempotency_key__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3330,6 +3430,7 @@ impl<'de> serde::Deserialize<'de> for plaintext_envelope::V2 {
             DeviceSyncRequest,
             DeviceSyncReply,
             UserPreferenceUpdate,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3356,7 +3457,7 @@ impl<'de> serde::Deserialize<'de> for plaintext_envelope::V2 {
                             "deviceSyncRequest" | "device_sync_request" => Ok(GeneratedField::DeviceSyncRequest),
                             "deviceSyncReply" | "device_sync_reply" => Ok(GeneratedField::DeviceSyncReply),
                             "userPreferenceUpdate" | "user_preference_update" => Ok(GeneratedField::UserPreferenceUpdate),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3411,6 +3512,9 @@ impl<'de> serde::Deserialize<'de> for plaintext_envelope::V2 {
                             }
                             message_type__ = map_.next_value::<::std::option::Option<_>>()?.map(plaintext_envelope::v2::MessageType::UserPreferenceUpdate)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3500,6 +3604,7 @@ impl<'de> serde::Deserialize<'de> for PolicySet {
             AddAdminPolicy,
             RemoveAdminPolicy,
             UpdatePermissionsPolicy,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3527,7 +3632,7 @@ impl<'de> serde::Deserialize<'de> for PolicySet {
                             "addAdminPolicy" | "add_admin_policy" => Ok(GeneratedField::AddAdminPolicy),
                             "removeAdminPolicy" | "remove_admin_policy" => Ok(GeneratedField::RemoveAdminPolicy),
                             "updatePermissionsPolicy" | "update_permissions_policy" => Ok(GeneratedField::UpdatePermissionsPolicy),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3591,6 +3696,9 @@ impl<'de> serde::Deserialize<'de> for PolicySet {
                                 return Err(serde::de::Error::duplicate_field("updatePermissionsPolicy"));
                             }
                             update_permissions_policy__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -3725,6 +3833,7 @@ impl<'de> serde::Deserialize<'de> for WelcomeWrapperEncryption {
         enum GeneratedField {
             PubKey,
             Algorithm,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3748,7 +3857,7 @@ impl<'de> serde::Deserialize<'de> for WelcomeWrapperEncryption {
                         match value {
                             "pubKey" | "pub_key" => Ok(GeneratedField::PubKey),
                             "algorithm" => Ok(GeneratedField::Algorithm),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -3784,6 +3893,9 @@ impl<'de> serde::Deserialize<'de> for WelcomeWrapperEncryption {
                                 return Err(serde::de::Error::duplicate_field("algorithm"));
                             }
                             algorithm__ = Some(map_.next_value::<WelcomeWrapperAlgorithm>()? as i32);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }

--- a/xmtp_proto/src/gen/xmtp.mls.message_contents.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.mls.message_contents.serde.rs
@@ -92,16 +92,16 @@ impl serde::Serialize for ContentTypeId {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.mls.message_contents.ContentTypeId", len)?;
         if !self.authority_id.is_empty() {
-            struct_ser.serialize_field("authorityId", &self.authority_id)?;
+            struct_ser.serialize_field("authority_id", &self.authority_id)?;
         }
         if !self.type_id.is_empty() {
-            struct_ser.serialize_field("typeId", &self.type_id)?;
+            struct_ser.serialize_field("type_id", &self.type_id)?;
         }
         if self.version_major != 0 {
-            struct_ser.serialize_field("versionMajor", &self.version_major)?;
+            struct_ser.serialize_field("version_major", &self.version_major)?;
         }
         if self.version_minor != 0 {
-            struct_ser.serialize_field("versionMinor", &self.version_minor)?;
+            struct_ser.serialize_field("version_minor", &self.version_minor)?;
         }
         struct_ser.end()
     }
@@ -317,10 +317,10 @@ impl serde::Serialize for DmMembers {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.mls.message_contents.DmMembers", len)?;
         if let Some(v) = self.dm_member_one.as_ref() {
-            struct_ser.serialize_field("dmMemberOne", v)?;
+            struct_ser.serialize_field("dm_member_one", v)?;
         }
         if let Some(v) = self.dm_member_two.as_ref() {
-            struct_ser.serialize_field("dmMemberTwo", v)?;
+            struct_ser.serialize_field("dm_member_two", v)?;
         }
         struct_ser.end()
     }
@@ -607,7 +607,7 @@ impl serde::Serialize for GroupMembership {
             struct_ser.serialize_field("members", &v)?;
         }
         if !self.failed_installations.is_empty() {
-            struct_ser.serialize_field("failedInstallations", &self.failed_installations.iter().map(pbjson::private::base64::encode).collect::<Vec<_>>())?;
+            struct_ser.serialize_field("failed_installations", &self.failed_installations.iter().map(pbjson::private::base64::encode).collect::<Vec<_>>())?;
         }
         struct_ser.end()
     }
@@ -729,16 +729,16 @@ impl serde::Serialize for GroupMembershipChanges {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.mls.message_contents.GroupMembershipChanges", len)?;
         if !self.members_added.is_empty() {
-            struct_ser.serialize_field("membersAdded", &self.members_added)?;
+            struct_ser.serialize_field("members_added", &self.members_added)?;
         }
         if !self.members_removed.is_empty() {
-            struct_ser.serialize_field("membersRemoved", &self.members_removed)?;
+            struct_ser.serialize_field("members_removed", &self.members_removed)?;
         }
         if !self.installations_added.is_empty() {
-            struct_ser.serialize_field("installationsAdded", &self.installations_added)?;
+            struct_ser.serialize_field("installations_added", &self.installations_added)?;
         }
         if !self.installations_removed.is_empty() {
-            struct_ser.serialize_field("installationsRemoved", &self.installations_removed)?;
+            struct_ser.serialize_field("installations_removed", &self.installations_removed)?;
         }
         struct_ser.end()
     }
@@ -881,16 +881,16 @@ impl serde::Serialize for GroupMetadataV1 {
         if self.conversation_type != 0 {
             let v = ConversationType::try_from(self.conversation_type)
                 .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", self.conversation_type)))?;
-            struct_ser.serialize_field("conversationType", &v)?;
+            struct_ser.serialize_field("conversation_type", &v)?;
         }
         if !self.creator_account_address.is_empty() {
-            struct_ser.serialize_field("creatorAccountAddress", &self.creator_account_address)?;
+            struct_ser.serialize_field("creator_account_address", &self.creator_account_address)?;
         }
         if !self.creator_inbox_id.is_empty() {
-            struct_ser.serialize_field("creatorInboxId", &self.creator_inbox_id)?;
+            struct_ser.serialize_field("creator_inbox_id", &self.creator_inbox_id)?;
         }
         if let Some(v) = self.dm_members.as_ref() {
-            struct_ser.serialize_field("dmMembers", v)?;
+            struct_ser.serialize_field("dm_members", v)?;
         }
         struct_ser.end()
     }
@@ -1031,10 +1031,10 @@ impl serde::Serialize for GroupMutableMetadataV1 {
             struct_ser.serialize_field("attributes", &self.attributes)?;
         }
         if let Some(v) = self.admin_list.as_ref() {
-            struct_ser.serialize_field("adminList", v)?;
+            struct_ser.serialize_field("admin_list", v)?;
         }
         if let Some(v) = self.super_admin_list.as_ref() {
-            struct_ser.serialize_field("superAdminList", v)?;
+            struct_ser.serialize_field("super_admin_list", v)?;
         }
         struct_ser.end()
     }
@@ -1259,16 +1259,16 @@ impl serde::Serialize for GroupUpdated {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.mls.message_contents.GroupUpdated", len)?;
         if !self.initiated_by_inbox_id.is_empty() {
-            struct_ser.serialize_field("initiatedByInboxId", &self.initiated_by_inbox_id)?;
+            struct_ser.serialize_field("initiated_by_inbox_id", &self.initiated_by_inbox_id)?;
         }
         if !self.added_inboxes.is_empty() {
-            struct_ser.serialize_field("addedInboxes", &self.added_inboxes)?;
+            struct_ser.serialize_field("added_inboxes", &self.added_inboxes)?;
         }
         if !self.removed_inboxes.is_empty() {
-            struct_ser.serialize_field("removedInboxes", &self.removed_inboxes)?;
+            struct_ser.serialize_field("removed_inboxes", &self.removed_inboxes)?;
         }
         if !self.metadata_field_changes.is_empty() {
-            struct_ser.serialize_field("metadataFieldChanges", &self.metadata_field_changes)?;
+            struct_ser.serialize_field("metadata_field_changes", &self.metadata_field_changes)?;
         }
         struct_ser.end()
     }
@@ -1400,7 +1400,7 @@ impl serde::Serialize for group_updated::Inbox {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.mls.message_contents.GroupUpdated.Inbox", len)?;
         if !self.inbox_id.is_empty() {
-            struct_ser.serialize_field("inboxId", &self.inbox_id)?;
+            struct_ser.serialize_field("inbox_id", &self.inbox_id)?;
         }
         struct_ser.end()
     }
@@ -1502,13 +1502,13 @@ impl serde::Serialize for group_updated::MetadataFieldChange {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.mls.message_contents.GroupUpdated.MetadataFieldChange", len)?;
         if !self.field_name.is_empty() {
-            struct_ser.serialize_field("fieldName", &self.field_name)?;
+            struct_ser.serialize_field("field_name", &self.field_name)?;
         }
         if let Some(v) = self.old_value.as_ref() {
-            struct_ser.serialize_field("oldValue", v)?;
+            struct_ser.serialize_field("old_value", v)?;
         }
         if let Some(v) = self.new_value.as_ref() {
-            struct_ser.serialize_field("newValue", v)?;
+            struct_ser.serialize_field("new_value", v)?;
         }
         struct_ser.end()
     }
@@ -1628,7 +1628,7 @@ impl serde::Serialize for Inbox {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.mls.message_contents.Inbox", len)?;
         if !self.inbox_id.is_empty() {
-            struct_ser.serialize_field("inboxId", &self.inbox_id)?;
+            struct_ser.serialize_field("inbox_id", &self.inbox_id)?;
         }
         struct_ser.end()
     }
@@ -1724,7 +1724,7 @@ impl serde::Serialize for Inboxes {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.mls.message_contents.Inboxes", len)?;
         if !self.inbox_ids.is_empty() {
-            struct_ser.serialize_field("inboxIds", &self.inbox_ids)?;
+            struct_ser.serialize_field("inbox_ids", &self.inbox_ids)?;
         }
         struct_ser.end()
     }
@@ -1826,13 +1826,13 @@ impl serde::Serialize for MembershipChange {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.mls.message_contents.MembershipChange", len)?;
         if !self.installation_ids.is_empty() {
-            struct_ser.serialize_field("installationIds", &self.installation_ids.iter().map(pbjson::private::base64::encode).collect::<Vec<_>>())?;
+            struct_ser.serialize_field("installation_ids", &self.installation_ids.iter().map(pbjson::private::base64::encode).collect::<Vec<_>>())?;
         }
         if !self.account_address.is_empty() {
-            struct_ser.serialize_field("accountAddress", &self.account_address)?;
+            struct_ser.serialize_field("account_address", &self.account_address)?;
         }
         if !self.initiated_by_account_address.is_empty() {
-            struct_ser.serialize_field("initiatedByAccountAddress", &self.initiated_by_account_address)?;
+            struct_ser.serialize_field("initiated_by_account_address", &self.initiated_by_account_address)?;
         }
         struct_ser.end()
     }
@@ -1962,10 +1962,10 @@ impl serde::Serialize for MembershipPolicy {
                     struct_ser.serialize_field("base", &v)?;
                 }
                 membership_policy::Kind::AndCondition(v) => {
-                    struct_ser.serialize_field("andCondition", v)?;
+                    struct_ser.serialize_field("and_condition", v)?;
                 }
                 membership_policy::Kind::AnyCondition(v) => {
-                    struct_ser.serialize_field("anyCondition", v)?;
+                    struct_ser.serialize_field("any_condition", v)?;
                 }
             }
         }
@@ -2361,10 +2361,10 @@ impl serde::Serialize for MetadataPolicy {
                     struct_ser.serialize_field("base", &v)?;
                 }
                 metadata_policy::Kind::AndCondition(v) => {
-                    struct_ser.serialize_field("andCondition", v)?;
+                    struct_ser.serialize_field("and_condition", v)?;
                 }
                 metadata_policy::Kind::AnyCondition(v) => {
-                    struct_ser.serialize_field("anyCondition", v)?;
+                    struct_ser.serialize_field("any_condition", v)?;
                 }
             }
         }
@@ -2760,10 +2760,10 @@ impl serde::Serialize for PermissionsUpdatePolicy {
                     struct_ser.serialize_field("base", &v)?;
                 }
                 permissions_update_policy::Kind::AndCondition(v) => {
-                    struct_ser.serialize_field("andCondition", v)?;
+                    struct_ser.serialize_field("and_condition", v)?;
                 }
                 permissions_update_policy::Kind::AnyCondition(v) => {
-                    struct_ser.serialize_field("anyCondition", v)?;
+                    struct_ser.serialize_field("any_condition", v)?;
                 }
             }
         }
@@ -3270,7 +3270,7 @@ impl serde::Serialize for plaintext_envelope::V1 {
             struct_ser.serialize_field("content", pbjson::private::base64::encode(&self.content).as_str())?;
         }
         if !self.idempotency_key.is_empty() {
-            struct_ser.serialize_field("idempotencyKey", &self.idempotency_key)?;
+            struct_ser.serialize_field("idempotency_key", &self.idempotency_key)?;
         }
         struct_ser.end()
     }
@@ -3382,7 +3382,7 @@ impl serde::Serialize for plaintext_envelope::V2 {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.mls.message_contents.PlaintextEnvelope.V2", len)?;
         if !self.idempotency_key.is_empty() {
-            struct_ser.serialize_field("idempotencyKey", &self.idempotency_key)?;
+            struct_ser.serialize_field("idempotency_key", &self.idempotency_key)?;
         }
         if let Some(v) = self.message_type.as_ref() {
             match v {
@@ -3392,13 +3392,13 @@ impl serde::Serialize for plaintext_envelope::V2 {
                     struct_ser.serialize_field("content", pbjson::private::base64::encode(&v).as_str())?;
                 }
                 plaintext_envelope::v2::MessageType::DeviceSyncRequest(v) => {
-                    struct_ser.serialize_field("deviceSyncRequest", v)?;
+                    struct_ser.serialize_field("device_sync_request", v)?;
                 }
                 plaintext_envelope::v2::MessageType::DeviceSyncReply(v) => {
-                    struct_ser.serialize_field("deviceSyncReply", v)?;
+                    struct_ser.serialize_field("device_sync_reply", v)?;
                 }
                 plaintext_envelope::v2::MessageType::UserPreferenceUpdate(v) => {
-                    struct_ser.serialize_field("userPreferenceUpdate", v)?;
+                    struct_ser.serialize_field("user_preference_update", v)?;
                 }
             }
         }
@@ -3555,22 +3555,22 @@ impl serde::Serialize for PolicySet {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.mls.message_contents.PolicySet", len)?;
         if let Some(v) = self.add_member_policy.as_ref() {
-            struct_ser.serialize_field("addMemberPolicy", v)?;
+            struct_ser.serialize_field("add_member_policy", v)?;
         }
         if let Some(v) = self.remove_member_policy.as_ref() {
-            struct_ser.serialize_field("removeMemberPolicy", v)?;
+            struct_ser.serialize_field("remove_member_policy", v)?;
         }
         if !self.update_metadata_policy.is_empty() {
-            struct_ser.serialize_field("updateMetadataPolicy", &self.update_metadata_policy)?;
+            struct_ser.serialize_field("update_metadata_policy", &self.update_metadata_policy)?;
         }
         if let Some(v) = self.add_admin_policy.as_ref() {
-            struct_ser.serialize_field("addAdminPolicy", v)?;
+            struct_ser.serialize_field("add_admin_policy", v)?;
         }
         if let Some(v) = self.remove_admin_policy.as_ref() {
-            struct_ser.serialize_field("removeAdminPolicy", v)?;
+            struct_ser.serialize_field("remove_admin_policy", v)?;
         }
         if let Some(v) = self.update_permissions_policy.as_ref() {
-            struct_ser.serialize_field("updatePermissionsPolicy", v)?;
+            struct_ser.serialize_field("update_permissions_policy", v)?;
         }
         struct_ser.end()
     }
@@ -3807,7 +3807,7 @@ impl serde::Serialize for WelcomeWrapperEncryption {
         if !self.pub_key.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("pubKey", pbjson::private::base64::encode(&self.pub_key).as_str())?;
+            struct_ser.serialize_field("pub_key", pbjson::private::base64::encode(&self.pub_key).as_str())?;
         }
         if self.algorithm != 0 {
             let v = WelcomeWrapperAlgorithm::try_from(self.algorithm)

--- a/xmtp_proto/src/gen/xmtp.mls_validation.v1.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.mls_validation.v1.serde.rs
@@ -40,6 +40,7 @@ impl<'de> serde::Deserialize<'de> for GetAssociationStateRequest {
         enum GeneratedField {
             OldUpdates,
             NewUpdates,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -63,7 +64,7 @@ impl<'de> serde::Deserialize<'de> for GetAssociationStateRequest {
                         match value {
                             "oldUpdates" | "old_updates" => Ok(GeneratedField::OldUpdates),
                             "newUpdates" | "new_updates" => Ok(GeneratedField::NewUpdates),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -97,6 +98,9 @@ impl<'de> serde::Deserialize<'de> for GetAssociationStateRequest {
                                 return Err(serde::de::Error::duplicate_field("newUpdates"));
                             }
                             new_updates__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -150,6 +154,7 @@ impl<'de> serde::Deserialize<'de> for GetAssociationStateResponse {
         enum GeneratedField {
             AssociationState,
             StateDiff,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -173,7 +178,7 @@ impl<'de> serde::Deserialize<'de> for GetAssociationStateResponse {
                         match value {
                             "associationState" | "association_state" => Ok(GeneratedField::AssociationState),
                             "stateDiff" | "state_diff" => Ok(GeneratedField::StateDiff),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -207,6 +212,9 @@ impl<'de> serde::Deserialize<'de> for GetAssociationStateResponse {
                                 return Err(serde::de::Error::duplicate_field("stateDiff"));
                             }
                             state_diff__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -251,6 +259,7 @@ impl<'de> serde::Deserialize<'de> for ValidateGroupMessagesRequest {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             GroupMessages,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -273,7 +282,7 @@ impl<'de> serde::Deserialize<'de> for ValidateGroupMessagesRequest {
                     {
                         match value {
                             "groupMessages" | "group_messages" => Ok(GeneratedField::GroupMessages),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -300,6 +309,9 @@ impl<'de> serde::Deserialize<'de> for ValidateGroupMessagesRequest {
                                 return Err(serde::de::Error::duplicate_field("groupMessages"));
                             }
                             group_messages__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -345,6 +357,7 @@ impl<'de> serde::Deserialize<'de> for validate_group_messages_request::GroupMess
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             GroupMessageBytesTlsSerialized,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -367,7 +380,7 @@ impl<'de> serde::Deserialize<'de> for validate_group_messages_request::GroupMess
                     {
                         match value {
                             "groupMessageBytesTlsSerialized" | "group_message_bytes_tls_serialized" => Ok(GeneratedField::GroupMessageBytesTlsSerialized),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -396,6 +409,9 @@ impl<'de> serde::Deserialize<'de> for validate_group_messages_request::GroupMess
                             group_message_bytes_tls_serialized__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -438,6 +454,7 @@ impl<'de> serde::Deserialize<'de> for ValidateGroupMessagesResponse {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Responses,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -460,7 +477,7 @@ impl<'de> serde::Deserialize<'de> for ValidateGroupMessagesResponse {
                     {
                         match value {
                             "responses" => Ok(GeneratedField::Responses),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -487,6 +504,9 @@ impl<'de> serde::Deserialize<'de> for ValidateGroupMessagesResponse {
                                 return Err(serde::de::Error::duplicate_field("responses"));
                             }
                             responses__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -548,6 +568,7 @@ impl<'de> serde::Deserialize<'de> for validate_group_messages_response::Validati
             IsOk,
             ErrorMessage,
             GroupId,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -572,7 +593,7 @@ impl<'de> serde::Deserialize<'de> for validate_group_messages_response::Validati
                             "isOk" | "is_ok" => Ok(GeneratedField::IsOk),
                             "errorMessage" | "error_message" => Ok(GeneratedField::ErrorMessage),
                             "groupId" | "group_id" => Ok(GeneratedField::GroupId),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -613,6 +634,9 @@ impl<'de> serde::Deserialize<'de> for validate_group_messages_response::Validati
                                 return Err(serde::de::Error::duplicate_field("groupId"));
                             }
                             group_id__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -658,6 +682,7 @@ impl<'de> serde::Deserialize<'de> for ValidateInboxIdKeyPackagesRequest {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             KeyPackages,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -680,7 +705,7 @@ impl<'de> serde::Deserialize<'de> for ValidateInboxIdKeyPackagesRequest {
                     {
                         match value {
                             "keyPackages" | "key_packages" => Ok(GeneratedField::KeyPackages),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -707,6 +732,9 @@ impl<'de> serde::Deserialize<'de> for ValidateInboxIdKeyPackagesRequest {
                                 return Err(serde::de::Error::duplicate_field("keyPackages"));
                             }
                             key_packages__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -761,6 +789,7 @@ impl<'de> serde::Deserialize<'de> for validate_inbox_id_key_packages_request::Ke
         enum GeneratedField {
             KeyPackageBytesTlsSerialized,
             IsInboxIdCredential,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -784,7 +813,7 @@ impl<'de> serde::Deserialize<'de> for validate_inbox_id_key_packages_request::Ke
                         match value {
                             "keyPackageBytesTlsSerialized" | "key_package_bytes_tls_serialized" => Ok(GeneratedField::KeyPackageBytesTlsSerialized),
                             "isInboxIdCredential" | "is_inbox_id_credential" => Ok(GeneratedField::IsInboxIdCredential),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -820,6 +849,9 @@ impl<'de> serde::Deserialize<'de> for validate_inbox_id_key_packages_request::Ke
                                 return Err(serde::de::Error::duplicate_field("isInboxIdCredential"));
                             }
                             is_inbox_id_credential__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -863,6 +895,7 @@ impl<'de> serde::Deserialize<'de> for ValidateInboxIdKeyPackagesResponse {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Responses,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -885,7 +918,7 @@ impl<'de> serde::Deserialize<'de> for ValidateInboxIdKeyPackagesResponse {
                     {
                         match value {
                             "responses" => Ok(GeneratedField::Responses),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -912,6 +945,9 @@ impl<'de> serde::Deserialize<'de> for ValidateInboxIdKeyPackagesResponse {
                                 return Err(serde::de::Error::duplicate_field("responses"));
                             }
                             responses__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -993,6 +1029,7 @@ impl<'de> serde::Deserialize<'de> for validate_inbox_id_key_packages_response::R
             Credential,
             InstallationPublicKey,
             Expiration,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1019,7 +1056,7 @@ impl<'de> serde::Deserialize<'de> for validate_inbox_id_key_packages_response::R
                             "credential" => Ok(GeneratedField::Credential),
                             "installationPublicKey" | "installation_public_key" => Ok(GeneratedField::InstallationPublicKey),
                             "expiration" => Ok(GeneratedField::Expiration),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1079,6 +1116,9 @@ impl<'de> serde::Deserialize<'de> for validate_inbox_id_key_packages_response::R
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(validate_inbox_id_key_packages_response::Response {
@@ -1125,6 +1165,7 @@ impl<'de> serde::Deserialize<'de> for ValidateKeyPackagesRequest {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             KeyPackages,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1147,7 +1188,7 @@ impl<'de> serde::Deserialize<'de> for ValidateKeyPackagesRequest {
                     {
                         match value {
                             "keyPackages" | "key_packages" => Ok(GeneratedField::KeyPackages),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1174,6 +1215,9 @@ impl<'de> serde::Deserialize<'de> for ValidateKeyPackagesRequest {
                                 return Err(serde::de::Error::duplicate_field("keyPackages"));
                             }
                             key_packages__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1228,6 +1272,7 @@ impl<'de> serde::Deserialize<'de> for validate_key_packages_request::KeyPackage 
         enum GeneratedField {
             KeyPackageBytesTlsSerialized,
             IsInboxIdCredential,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1251,7 +1296,7 @@ impl<'de> serde::Deserialize<'de> for validate_key_packages_request::KeyPackage 
                         match value {
                             "keyPackageBytesTlsSerialized" | "key_package_bytes_tls_serialized" => Ok(GeneratedField::KeyPackageBytesTlsSerialized),
                             "isInboxIdCredential" | "is_inbox_id_credential" => Ok(GeneratedField::IsInboxIdCredential),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1287,6 +1332,9 @@ impl<'de> serde::Deserialize<'de> for validate_key_packages_request::KeyPackage 
                                 return Err(serde::de::Error::duplicate_field("isInboxIdCredential"));
                             }
                             is_inbox_id_credential__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1330,6 +1378,7 @@ impl<'de> serde::Deserialize<'de> for ValidateKeyPackagesResponse {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Responses,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1352,7 +1401,7 @@ impl<'de> serde::Deserialize<'de> for ValidateKeyPackagesResponse {
                     {
                         match value {
                             "responses" => Ok(GeneratedField::Responses),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1379,6 +1428,9 @@ impl<'de> serde::Deserialize<'de> for ValidateKeyPackagesResponse {
                                 return Err(serde::de::Error::duplicate_field("responses"));
                             }
                             responses__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1472,6 +1524,7 @@ impl<'de> serde::Deserialize<'de> for validate_key_packages_response::Validation
             AccountAddress,
             CredentialIdentityBytes,
             Expiration,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1499,7 +1552,7 @@ impl<'de> serde::Deserialize<'de> for validate_key_packages_response::Validation
                             "accountAddress" | "account_address" => Ok(GeneratedField::AccountAddress),
                             "credentialIdentityBytes" | "credential_identity_bytes" => Ok(GeneratedField::CredentialIdentityBytes),
                             "expiration" => Ok(GeneratedField::Expiration),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1567,6 +1620,9 @@ impl<'de> serde::Deserialize<'de> for validate_key_packages_response::Validation
                             expiration__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }

--- a/xmtp_proto/src/gen/xmtp.mls_validation.v1.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.mls_validation.v1.serde.rs
@@ -15,10 +15,10 @@ impl serde::Serialize for GetAssociationStateRequest {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.mls_validation.v1.GetAssociationStateRequest", len)?;
         if !self.old_updates.is_empty() {
-            struct_ser.serialize_field("oldUpdates", &self.old_updates)?;
+            struct_ser.serialize_field("old_updates", &self.old_updates)?;
         }
         if !self.new_updates.is_empty() {
-            struct_ser.serialize_field("newUpdates", &self.new_updates)?;
+            struct_ser.serialize_field("new_updates", &self.new_updates)?;
         }
         struct_ser.end()
     }
@@ -129,10 +129,10 @@ impl serde::Serialize for GetAssociationStateResponse {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.mls_validation.v1.GetAssociationStateResponse", len)?;
         if let Some(v) = self.association_state.as_ref() {
-            struct_ser.serialize_field("associationState", v)?;
+            struct_ser.serialize_field("association_state", v)?;
         }
         if let Some(v) = self.state_diff.as_ref() {
-            struct_ser.serialize_field("stateDiff", v)?;
+            struct_ser.serialize_field("state_diff", v)?;
         }
         struct_ser.end()
     }
@@ -240,7 +240,7 @@ impl serde::Serialize for ValidateGroupMessagesRequest {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.mls_validation.v1.ValidateGroupMessagesRequest", len)?;
         if !self.group_messages.is_empty() {
-            struct_ser.serialize_field("groupMessages", &self.group_messages)?;
+            struct_ser.serialize_field("group_messages", &self.group_messages)?;
         }
         struct_ser.end()
     }
@@ -338,7 +338,7 @@ impl serde::Serialize for validate_group_messages_request::GroupMessage {
         if !self.group_message_bytes_tls_serialized.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("groupMessageBytesTlsSerialized", pbjson::private::base64::encode(&self.group_message_bytes_tls_serialized).as_str())?;
+            struct_ser.serialize_field("group_message_bytes_tls_serialized", pbjson::private::base64::encode(&self.group_message_bytes_tls_serialized).as_str())?;
         }
         struct_ser.end()
     }
@@ -537,13 +537,13 @@ impl serde::Serialize for validate_group_messages_response::ValidationResponse {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.mls_validation.v1.ValidateGroupMessagesResponse.ValidationResponse", len)?;
         if self.is_ok {
-            struct_ser.serialize_field("isOk", &self.is_ok)?;
+            struct_ser.serialize_field("is_ok", &self.is_ok)?;
         }
         if !self.error_message.is_empty() {
-            struct_ser.serialize_field("errorMessage", &self.error_message)?;
+            struct_ser.serialize_field("error_message", &self.error_message)?;
         }
         if !self.group_id.is_empty() {
-            struct_ser.serialize_field("groupId", &self.group_id)?;
+            struct_ser.serialize_field("group_id", &self.group_id)?;
         }
         struct_ser.end()
     }
@@ -663,7 +663,7 @@ impl serde::Serialize for ValidateInboxIdKeyPackagesRequest {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.mls_validation.v1.ValidateInboxIdKeyPackagesRequest", len)?;
         if !self.key_packages.is_empty() {
-            struct_ser.serialize_field("keyPackages", &self.key_packages)?;
+            struct_ser.serialize_field("key_packages", &self.key_packages)?;
         }
         struct_ser.end()
     }
@@ -764,10 +764,10 @@ impl serde::Serialize for validate_inbox_id_key_packages_request::KeyPackage {
         if !self.key_package_bytes_tls_serialized.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("keyPackageBytesTlsSerialized", pbjson::private::base64::encode(&self.key_package_bytes_tls_serialized).as_str())?;
+            struct_ser.serialize_field("key_package_bytes_tls_serialized", pbjson::private::base64::encode(&self.key_package_bytes_tls_serialized).as_str())?;
         }
         if self.is_inbox_id_credential {
-            struct_ser.serialize_field("isInboxIdCredential", &self.is_inbox_id_credential)?;
+            struct_ser.serialize_field("is_inbox_id_credential", &self.is_inbox_id_credential)?;
         }
         struct_ser.end()
     }
@@ -984,10 +984,10 @@ impl serde::Serialize for validate_inbox_id_key_packages_response::Response {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.mls_validation.v1.ValidateInboxIdKeyPackagesResponse.Response", len)?;
         if self.is_ok {
-            struct_ser.serialize_field("isOk", &self.is_ok)?;
+            struct_ser.serialize_field("is_ok", &self.is_ok)?;
         }
         if !self.error_message.is_empty() {
-            struct_ser.serialize_field("errorMessage", &self.error_message)?;
+            struct_ser.serialize_field("error_message", &self.error_message)?;
         }
         if let Some(v) = self.credential.as_ref() {
             struct_ser.serialize_field("credential", v)?;
@@ -995,7 +995,7 @@ impl serde::Serialize for validate_inbox_id_key_packages_response::Response {
         if !self.installation_public_key.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("installationPublicKey", pbjson::private::base64::encode(&self.installation_public_key).as_str())?;
+            struct_ser.serialize_field("installation_public_key", pbjson::private::base64::encode(&self.installation_public_key).as_str())?;
         }
         if self.expiration != 0 {
             #[allow(clippy::needless_borrow)]
@@ -1146,7 +1146,7 @@ impl serde::Serialize for ValidateKeyPackagesRequest {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.mls_validation.v1.ValidateKeyPackagesRequest", len)?;
         if !self.key_packages.is_empty() {
-            struct_ser.serialize_field("keyPackages", &self.key_packages)?;
+            struct_ser.serialize_field("key_packages", &self.key_packages)?;
         }
         struct_ser.end()
     }
@@ -1247,10 +1247,10 @@ impl serde::Serialize for validate_key_packages_request::KeyPackage {
         if !self.key_package_bytes_tls_serialized.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("keyPackageBytesTlsSerialized", pbjson::private::base64::encode(&self.key_package_bytes_tls_serialized).as_str())?;
+            struct_ser.serialize_field("key_package_bytes_tls_serialized", pbjson::private::base64::encode(&self.key_package_bytes_tls_serialized).as_str())?;
         }
         if self.is_inbox_id_credential {
-            struct_ser.serialize_field("isInboxIdCredential", &self.is_inbox_id_credential)?;
+            struct_ser.serialize_field("is_inbox_id_credential", &self.is_inbox_id_credential)?;
         }
         struct_ser.end()
     }
@@ -1470,23 +1470,23 @@ impl serde::Serialize for validate_key_packages_response::ValidationResponse {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.mls_validation.v1.ValidateKeyPackagesResponse.ValidationResponse", len)?;
         if self.is_ok {
-            struct_ser.serialize_field("isOk", &self.is_ok)?;
+            struct_ser.serialize_field("is_ok", &self.is_ok)?;
         }
         if !self.error_message.is_empty() {
-            struct_ser.serialize_field("errorMessage", &self.error_message)?;
+            struct_ser.serialize_field("error_message", &self.error_message)?;
         }
         if !self.installation_id.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("installationId", pbjson::private::base64::encode(&self.installation_id).as_str())?;
+            struct_ser.serialize_field("installation_id", pbjson::private::base64::encode(&self.installation_id).as_str())?;
         }
         if !self.account_address.is_empty() {
-            struct_ser.serialize_field("accountAddress", &self.account_address)?;
+            struct_ser.serialize_field("account_address", &self.account_address)?;
         }
         if !self.credential_identity_bytes.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("credentialIdentityBytes", pbjson::private::base64::encode(&self.credential_identity_bytes).as_str())?;
+            struct_ser.serialize_field("credential_identity_bytes", pbjson::private::base64::encode(&self.credential_identity_bytes).as_str())?;
         }
         if self.expiration != 0 {
             #[allow(clippy::needless_borrow)]

--- a/xmtp_proto/src/gen/xmtp.xmtpv4.envelopes.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.xmtpv4.envelopes.serde.rs
@@ -21,18 +21,18 @@ impl serde::Serialize for AuthenticatedData {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.xmtpv4.envelopes.AuthenticatedData", len)?;
         if let Some(v) = self.target_originator.as_ref() {
-            struct_ser.serialize_field("targetOriginator", v)?;
+            struct_ser.serialize_field("target_originator", v)?;
         }
         if !self.target_topic.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("targetTopic", pbjson::private::base64::encode(&self.target_topic).as_str())?;
+            struct_ser.serialize_field("target_topic", pbjson::private::base64::encode(&self.target_topic).as_str())?;
         }
         if let Some(v) = self.depends_on.as_ref() {
-            struct_ser.serialize_field("dependsOn", v)?;
+            struct_ser.serialize_field("depends_on", v)?;
         }
         if self.is_commit {
-            struct_ser.serialize_field("isCommit", &self.is_commit)?;
+            struct_ser.serialize_field("is_commit", &self.is_commit)?;
         }
         struct_ser.end()
     }
@@ -170,7 +170,7 @@ impl serde::Serialize for BlockchainProof {
         if !self.transaction_hash.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("transactionHash", pbjson::private::base64::encode(&self.transaction_hash).as_str())?;
+            struct_ser.serialize_field("transaction_hash", pbjson::private::base64::encode(&self.transaction_hash).as_str())?;
         }
         struct_ser.end()
     }
@@ -276,22 +276,22 @@ impl serde::Serialize for ClientEnvelope {
         if let Some(v) = self.payload.as_ref() {
             match v {
                 client_envelope::Payload::GroupMessage(v) => {
-                    struct_ser.serialize_field("groupMessage", v)?;
+                    struct_ser.serialize_field("group_message", v)?;
                 }
                 client_envelope::Payload::WelcomeMessage(v) => {
-                    struct_ser.serialize_field("welcomeMessage", v)?;
+                    struct_ser.serialize_field("welcome_message", v)?;
                 }
                 client_envelope::Payload::UploadKeyPackage(v) => {
-                    struct_ser.serialize_field("uploadKeyPackage", v)?;
+                    struct_ser.serialize_field("upload_key_package", v)?;
                 }
                 client_envelope::Payload::IdentityUpdate(v) => {
-                    struct_ser.serialize_field("identityUpdate", v)?;
+                    struct_ser.serialize_field("identity_update", v)?;
                 }
                 client_envelope::Payload::PayerReport(v) => {
-                    struct_ser.serialize_field("payerReport", v)?;
+                    struct_ser.serialize_field("payer_report", v)?;
                 }
                 client_envelope::Payload::PayerReportAttestation(v) => {
-                    struct_ser.serialize_field("payerReportAttestation", v)?;
+                    struct_ser.serialize_field("payer_report_attestation", v)?;
                 }
             }
         }
@@ -458,7 +458,7 @@ impl serde::Serialize for Cursor {
         if !self.node_id_to_sequence_id.is_empty() {
             let v: std::collections::HashMap<_, _> = self.node_id_to_sequence_id.iter()
                 .map(|(k, v)| (k, v.to_string())).collect();
-            struct_ser.serialize_field("nodeIdToSequenceId", &v)?;
+            struct_ser.serialize_field("node_id_to_sequence_id", &v)?;
         }
         struct_ser.end()
     }
@@ -562,15 +562,15 @@ impl serde::Serialize for OriginatorEnvelope {
         if !self.unsigned_originator_envelope.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("unsignedOriginatorEnvelope", pbjson::private::base64::encode(&self.unsigned_originator_envelope).as_str())?;
+            struct_ser.serialize_field("unsigned_originator_envelope", pbjson::private::base64::encode(&self.unsigned_originator_envelope).as_str())?;
         }
         if let Some(v) = self.proof.as_ref() {
             match v {
                 originator_envelope::Proof::OriginatorSignature(v) => {
-                    struct_ser.serialize_field("originatorSignature", v)?;
+                    struct_ser.serialize_field("originator_signature", v)?;
                 }
                 originator_envelope::Proof::BlockchainProof(v) => {
-                    struct_ser.serialize_field("blockchainProof", v)?;
+                    struct_ser.serialize_field("blockchain_proof", v)?;
                 }
             }
         }
@@ -705,16 +705,16 @@ impl serde::Serialize for PayerEnvelope {
         if !self.unsigned_client_envelope.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("unsignedClientEnvelope", pbjson::private::base64::encode(&self.unsigned_client_envelope).as_str())?;
+            struct_ser.serialize_field("unsigned_client_envelope", pbjson::private::base64::encode(&self.unsigned_client_envelope).as_str())?;
         }
         if let Some(v) = self.payer_signature.as_ref() {
-            struct_ser.serialize_field("payerSignature", v)?;
+            struct_ser.serialize_field("payer_signature", v)?;
         }
         if self.target_originator != 0 {
-            struct_ser.serialize_field("targetOriginator", &self.target_originator)?;
+            struct_ser.serialize_field("target_originator", &self.target_originator)?;
         }
         if self.message_retention_days != 0 {
-            struct_ser.serialize_field("messageRetentionDays", &self.message_retention_days)?;
+            struct_ser.serialize_field("message_retention_days", &self.message_retention_days)?;
         }
         struct_ser.end()
     }
@@ -864,25 +864,25 @@ impl serde::Serialize for PayerReport {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.xmtpv4.envelopes.PayerReport", len)?;
         if self.originator_node_id != 0 {
-            struct_ser.serialize_field("originatorNodeId", &self.originator_node_id)?;
+            struct_ser.serialize_field("originator_node_id", &self.originator_node_id)?;
         }
         if self.start_sequence_id != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("startSequenceId", ToString::to_string(&self.start_sequence_id).as_str())?;
+            struct_ser.serialize_field("start_sequence_id", ToString::to_string(&self.start_sequence_id).as_str())?;
         }
         if self.end_sequence_id != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("endSequenceId", ToString::to_string(&self.end_sequence_id).as_str())?;
+            struct_ser.serialize_field("end_sequence_id", ToString::to_string(&self.end_sequence_id).as_str())?;
         }
         if !self.payers_merkle_root.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("payersMerkleRoot", pbjson::private::base64::encode(&self.payers_merkle_root).as_str())?;
+            struct_ser.serialize_field("payers_merkle_root", pbjson::private::base64::encode(&self.payers_merkle_root).as_str())?;
         }
         if !self.active_node_ids.is_empty() {
-            struct_ser.serialize_field("activeNodeIds", &self.active_node_ids)?;
+            struct_ser.serialize_field("active_node_ids", &self.active_node_ids)?;
         }
         struct_ser.end()
     }
@@ -1042,7 +1042,7 @@ impl serde::Serialize for PayerReportAttestation {
         if !self.report_id.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("reportId", pbjson::private::base64::encode(&self.report_id).as_str())?;
+            struct_ser.serialize_field("report_id", pbjson::private::base64::encode(&self.report_id).as_str())?;
         }
         if let Some(v) = self.signature.as_ref() {
             struct_ser.serialize_field("signature", v)?;
@@ -1172,37 +1172,37 @@ impl serde::Serialize for UnsignedOriginatorEnvelope {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.xmtpv4.envelopes.UnsignedOriginatorEnvelope", len)?;
         if self.originator_node_id != 0 {
-            struct_ser.serialize_field("originatorNodeId", &self.originator_node_id)?;
+            struct_ser.serialize_field("originator_node_id", &self.originator_node_id)?;
         }
         if self.originator_sequence_id != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("originatorSequenceId", ToString::to_string(&self.originator_sequence_id).as_str())?;
+            struct_ser.serialize_field("originator_sequence_id", ToString::to_string(&self.originator_sequence_id).as_str())?;
         }
         if self.originator_ns != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("originatorNs", ToString::to_string(&self.originator_ns).as_str())?;
+            struct_ser.serialize_field("originator_ns", ToString::to_string(&self.originator_ns).as_str())?;
         }
         if !self.payer_envelope_bytes.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("payerEnvelopeBytes", pbjson::private::base64::encode(&self.payer_envelope_bytes).as_str())?;
+            struct_ser.serialize_field("payer_envelope_bytes", pbjson::private::base64::encode(&self.payer_envelope_bytes).as_str())?;
         }
         if self.base_fee_picodollars != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("baseFeePicodollars", ToString::to_string(&self.base_fee_picodollars).as_str())?;
+            struct_ser.serialize_field("base_fee_picodollars", ToString::to_string(&self.base_fee_picodollars).as_str())?;
         }
         if self.congestion_fee_picodollars != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("congestionFeePicodollars", ToString::to_string(&self.congestion_fee_picodollars).as_str())?;
+            struct_ser.serialize_field("congestion_fee_picodollars", ToString::to_string(&self.congestion_fee_picodollars).as_str())?;
         }
         if self.expiry_unixtime != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("expiryUnixtime", ToString::to_string(&self.expiry_unixtime).as_str())?;
+            struct_ser.serialize_field("expiry_unixtime", ToString::to_string(&self.expiry_unixtime).as_str())?;
         }
         struct_ser.end()
     }

--- a/xmtp_proto/src/gen/xmtp.xmtpv4.envelopes.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.xmtpv4.envelopes.serde.rs
@@ -60,6 +60,7 @@ impl<'de> serde::Deserialize<'de> for AuthenticatedData {
             TargetTopic,
             DependsOn,
             IsCommit,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -85,7 +86,7 @@ impl<'de> serde::Deserialize<'de> for AuthenticatedData {
                             "targetTopic" | "target_topic" => Ok(GeneratedField::TargetTopic),
                             "dependsOn" | "depends_on" => Ok(GeneratedField::DependsOn),
                             "isCommit" | "is_commit" => Ok(GeneratedField::IsCommit),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -138,6 +139,9 @@ impl<'de> serde::Deserialize<'de> for AuthenticatedData {
                             }
                             is_commit__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(AuthenticatedData {
@@ -185,6 +189,7 @@ impl<'de> serde::Deserialize<'de> for BlockchainProof {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             TransactionHash,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -207,7 +212,7 @@ impl<'de> serde::Deserialize<'de> for BlockchainProof {
                     {
                         match value {
                             "transactionHash" | "transaction_hash" => Ok(GeneratedField::TransactionHash),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -236,6 +241,9 @@ impl<'de> serde::Deserialize<'de> for BlockchainProof {
                             transaction_hash__ = 
                                 Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -321,6 +329,7 @@ impl<'de> serde::Deserialize<'de> for ClientEnvelope {
             IdentityUpdate,
             PayerReport,
             PayerReportAttestation,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -349,7 +358,7 @@ impl<'de> serde::Deserialize<'de> for ClientEnvelope {
                             "identityUpdate" | "identity_update" => Ok(GeneratedField::IdentityUpdate),
                             "payerReport" | "payer_report" => Ok(GeneratedField::PayerReport),
                             "payerReportAttestation" | "payer_report_attestation" => Ok(GeneratedField::PayerReportAttestation),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -420,6 +429,9 @@ impl<'de> serde::Deserialize<'de> for ClientEnvelope {
                             payload__ = map_.next_value::<::std::option::Option<_>>()?.map(client_envelope::Payload::PayerReportAttestation)
 ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(ClientEnvelope {
@@ -465,6 +477,7 @@ impl<'de> serde::Deserialize<'de> for Cursor {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             NodeIdToSequenceId,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -487,7 +500,7 @@ impl<'de> serde::Deserialize<'de> for Cursor {
                     {
                         match value {
                             "nodeIdToSequenceId" | "node_id_to_sequence_id" => Ok(GeneratedField::NodeIdToSequenceId),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -517,6 +530,9 @@ impl<'de> serde::Deserialize<'de> for Cursor {
                                 map_.next_value::<std::collections::HashMap<::pbjson::private::NumberDeserialize<u32>, ::pbjson::private::NumberDeserialize<u64>>>()?
                                     .into_iter().map(|(k,v)| (k.0, v.0)).collect()
                             );
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -581,6 +597,7 @@ impl<'de> serde::Deserialize<'de> for OriginatorEnvelope {
             UnsignedOriginatorEnvelope,
             OriginatorSignature,
             BlockchainProof,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -605,7 +622,7 @@ impl<'de> serde::Deserialize<'de> for OriginatorEnvelope {
                             "unsignedOriginatorEnvelope" | "unsigned_originator_envelope" => Ok(GeneratedField::UnsignedOriginatorEnvelope),
                             "originatorSignature" | "originator_signature" => Ok(GeneratedField::OriginatorSignature),
                             "blockchainProof" | "blockchain_proof" => Ok(GeneratedField::BlockchainProof),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -649,6 +666,9 @@ impl<'de> serde::Deserialize<'de> for OriginatorEnvelope {
                             }
                             proof__ = map_.next_value::<::std::option::Option<_>>()?.map(originator_envelope::Proof::BlockchainProof)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -722,6 +742,7 @@ impl<'de> serde::Deserialize<'de> for PayerEnvelope {
             PayerSignature,
             TargetOriginator,
             MessageRetentionDays,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -747,7 +768,7 @@ impl<'de> serde::Deserialize<'de> for PayerEnvelope {
                             "payerSignature" | "payer_signature" => Ok(GeneratedField::PayerSignature),
                             "targetOriginator" | "target_originator" => Ok(GeneratedField::TargetOriginator),
                             "messageRetentionDays" | "message_retention_days" => Ok(GeneratedField::MessageRetentionDays),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -801,6 +822,9 @@ impl<'de> serde::Deserialize<'de> for PayerEnvelope {
                             message_retention_days__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -889,6 +913,7 @@ impl<'de> serde::Deserialize<'de> for PayerReport {
             EndSequenceId,
             PayersMerkleRoot,
             ActiveNodeIds,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -915,7 +940,7 @@ impl<'de> serde::Deserialize<'de> for PayerReport {
                             "endSequenceId" | "end_sequence_id" => Ok(GeneratedField::EndSequenceId),
                             "payersMerkleRoot" | "payers_merkle_root" => Ok(GeneratedField::PayersMerkleRoot),
                             "activeNodeIds" | "active_node_ids" => Ok(GeneratedField::ActiveNodeIds),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -982,6 +1007,9 @@ impl<'de> serde::Deserialize<'de> for PayerReport {
                                     .into_iter().map(|x| x.0).collect())
                             ;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(PayerReport {
@@ -1038,6 +1066,7 @@ impl<'de> serde::Deserialize<'de> for PayerReportAttestation {
         enum GeneratedField {
             ReportId,
             Signature,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1061,7 +1090,7 @@ impl<'de> serde::Deserialize<'de> for PayerReportAttestation {
                         match value {
                             "reportId" | "report_id" => Ok(GeneratedField::ReportId),
                             "signature" => Ok(GeneratedField::Signature),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1097,6 +1126,9 @@ impl<'de> serde::Deserialize<'de> for PayerReportAttestation {
                                 return Err(serde::de::Error::duplicate_field("signature"));
                             }
                             signature__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1207,6 +1239,7 @@ impl<'de> serde::Deserialize<'de> for UnsignedOriginatorEnvelope {
             BaseFeePicodollars,
             CongestionFeePicodollars,
             ExpiryUnixtime,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1235,7 +1268,7 @@ impl<'de> serde::Deserialize<'de> for UnsignedOriginatorEnvelope {
                             "baseFeePicodollars" | "base_fee_picodollars" => Ok(GeneratedField::BaseFeePicodollars),
                             "congestionFeePicodollars" | "congestion_fee_picodollars" => Ok(GeneratedField::CongestionFeePicodollars),
                             "expiryUnixtime" | "expiry_unixtime" => Ok(GeneratedField::ExpiryUnixtime),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1318,6 +1351,9 @@ impl<'de> serde::Deserialize<'de> for UnsignedOriginatorEnvelope {
                             expiry_unixtime__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }

--- a/xmtp_proto/src/gen/xmtp.xmtpv4.message_api.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.xmtpv4.message_api.serde.rs
@@ -21,10 +21,10 @@ impl serde::Serialize for EnvelopesQuery {
             struct_ser.serialize_field("topics", &self.topics.iter().map(pbjson::private::base64::encode).collect::<Vec<_>>())?;
         }
         if !self.originator_node_ids.is_empty() {
-            struct_ser.serialize_field("originatorNodeIds", &self.originator_node_ids)?;
+            struct_ser.serialize_field("originator_node_ids", &self.originator_node_ids)?;
         }
         if let Some(v) = self.last_seen.as_ref() {
-            struct_ser.serialize_field("lastSeen", v)?;
+            struct_ser.serialize_field("last_seen", v)?;
         }
         struct_ser.end()
     }
@@ -252,7 +252,7 @@ impl serde::Serialize for get_inbox_ids_request::Request {
         if self.identifier_kind != 0 {
             let v = super::super::identity::associations::IdentifierKind::try_from(self.identifier_kind)
                 .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", self.identifier_kind)))?;
-            struct_ser.serialize_field("identifierKind", &v)?;
+            struct_ser.serialize_field("identifier_kind", &v)?;
         }
         struct_ser.end()
     }
@@ -463,12 +463,12 @@ impl serde::Serialize for get_inbox_ids_response::Response {
             struct_ser.serialize_field("identifier", &self.identifier)?;
         }
         if let Some(v) = self.inbox_id.as_ref() {
-            struct_ser.serialize_field("inboxId", v)?;
+            struct_ser.serialize_field("inbox_id", v)?;
         }
         if self.identifier_kind != 0 {
             let v = super::super::identity::associations::IdentifierKind::try_from(self.identifier_kind)
                 .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", self.identifier_kind)))?;
-            struct_ser.serialize_field("identifierKind", &v)?;
+            struct_ser.serialize_field("identifier_kind", &v)?;
         }
         struct_ser.end()
     }
@@ -780,7 +780,7 @@ impl serde::Serialize for get_newest_envelope_response::Response {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.xmtpv4.message_api.GetNewestEnvelopeResponse.Response", len)?;
         if let Some(v) = self.originator_envelope.as_ref() {
-            struct_ser.serialize_field("originatorEnvelope", v)?;
+            struct_ser.serialize_field("originator_envelope", v)?;
         }
         struct_ser.end()
     }
@@ -879,7 +879,7 @@ impl serde::Serialize for LivenessFailure {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.xmtpv4.message_api.LivenessFailure", len)?;
         if self.response_time_ns != 0 {
-            struct_ser.serialize_field("responseTimeNs", &self.response_time_ns)?;
+            struct_ser.serialize_field("response_time_ns", &self.response_time_ns)?;
         }
         if let Some(v) = self.request.as_ref() {
             match v {
@@ -1122,12 +1122,12 @@ impl serde::Serialize for MisbehaviorReport {
         if self.server_time_ns != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("serverTimeNs", ToString::to_string(&self.server_time_ns).as_str())?;
+            struct_ser.serialize_field("server_time_ns", ToString::to_string(&self.server_time_ns).as_str())?;
         }
         if !self.unsigned_misbehavior_report.is_empty() {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("unsignedMisbehaviorReport", pbjson::private::base64::encode(&self.unsigned_misbehavior_report).as_str())?;
+            struct_ser.serialize_field("unsigned_misbehavior_report", pbjson::private::base64::encode(&self.unsigned_misbehavior_report).as_str())?;
         }
         if let Some(v) = self.signature.as_ref() {
             struct_ser.serialize_field("signature", v)?;
@@ -1253,7 +1253,7 @@ impl serde::Serialize for PublishPayerEnvelopesRequest {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.xmtpv4.message_api.PublishPayerEnvelopesRequest", len)?;
         if !self.payer_envelopes.is_empty() {
-            struct_ser.serialize_field("payerEnvelopes", &self.payer_envelopes)?;
+            struct_ser.serialize_field("payer_envelopes", &self.payer_envelopes)?;
         }
         struct_ser.end()
     }
@@ -1349,7 +1349,7 @@ impl serde::Serialize for PublishPayerEnvelopesResponse {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.xmtpv4.message_api.PublishPayerEnvelopesResponse", len)?;
         if !self.originator_envelopes.is_empty() {
-            struct_ser.serialize_field("originatorEnvelopes", &self.originator_envelopes)?;
+            struct_ser.serialize_field("originator_envelopes", &self.originator_envelopes)?;
         }
         struct_ser.end()
     }
@@ -1656,7 +1656,7 @@ impl serde::Serialize for QueryMisbehaviorReportsRequest {
         if self.after_ns != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("afterNs", ToString::to_string(&self.after_ns).as_str())?;
+            struct_ser.serialize_field("after_ns", ToString::to_string(&self.after_ns).as_str())?;
         }
         struct_ser.end()
     }
@@ -2315,10 +2315,10 @@ impl serde::Serialize for UnsignedMisbehaviorReport {
         if self.reporter_time_ns != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
-            struct_ser.serialize_field("reporterTimeNs", ToString::to_string(&self.reporter_time_ns).as_str())?;
+            struct_ser.serialize_field("reporter_time_ns", ToString::to_string(&self.reporter_time_ns).as_str())?;
         }
         if self.misbehaving_node_id != 0 {
-            struct_ser.serialize_field("misbehavingNodeId", &self.misbehaving_node_id)?;
+            struct_ser.serialize_field("misbehaving_node_id", &self.misbehaving_node_id)?;
         }
         if self.r#type != 0 {
             let v = Misbehavior::try_from(self.r#type)
@@ -2326,7 +2326,7 @@ impl serde::Serialize for UnsignedMisbehaviorReport {
             struct_ser.serialize_field("type", &v)?;
         }
         if self.submitted_by_node {
-            struct_ser.serialize_field("submittedByNode", &self.submitted_by_node)?;
+            struct_ser.serialize_field("submitted_by_node", &self.submitted_by_node)?;
         }
         if let Some(v) = self.failure.as_ref() {
             match v {

--- a/xmtp_proto/src/gen/xmtp.xmtpv4.message_api.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.xmtpv4.message_api.serde.rs
@@ -48,6 +48,7 @@ impl<'de> serde::Deserialize<'de> for EnvelopesQuery {
             Topics,
             OriginatorNodeIds,
             LastSeen,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -72,7 +73,7 @@ impl<'de> serde::Deserialize<'de> for EnvelopesQuery {
                             "topics" => Ok(GeneratedField::Topics),
                             "originatorNodeIds" | "originator_node_ids" => Ok(GeneratedField::OriginatorNodeIds),
                             "lastSeen" | "last_seen" => Ok(GeneratedField::LastSeen),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -120,6 +121,9 @@ impl<'de> serde::Deserialize<'de> for EnvelopesQuery {
                             }
                             last_seen__ = map_.next_value()?;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(EnvelopesQuery {
@@ -163,6 +167,7 @@ impl<'de> serde::Deserialize<'de> for GetInboxIdsRequest {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Requests,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -185,7 +190,7 @@ impl<'de> serde::Deserialize<'de> for GetInboxIdsRequest {
                     {
                         match value {
                             "requests" => Ok(GeneratedField::Requests),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -212,6 +217,9 @@ impl<'de> serde::Deserialize<'de> for GetInboxIdsRequest {
                                 return Err(serde::de::Error::duplicate_field("requests"));
                             }
                             requests__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -265,6 +273,7 @@ impl<'de> serde::Deserialize<'de> for get_inbox_ids_request::Request {
         enum GeneratedField {
             Identifier,
             IdentifierKind,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -288,7 +297,7 @@ impl<'de> serde::Deserialize<'de> for get_inbox_ids_request::Request {
                         match value {
                             "identifier" => Ok(GeneratedField::Identifier),
                             "identifierKind" | "identifier_kind" => Ok(GeneratedField::IdentifierKind),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -322,6 +331,9 @@ impl<'de> serde::Deserialize<'de> for get_inbox_ids_request::Request {
                                 return Err(serde::de::Error::duplicate_field("identifierKind"));
                             }
                             identifier_kind__ = Some(map_.next_value::<super::super::identity::associations::IdentifierKind>()? as i32);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -365,6 +377,7 @@ impl<'de> serde::Deserialize<'de> for GetInboxIdsResponse {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Responses,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -387,7 +400,7 @@ impl<'de> serde::Deserialize<'de> for GetInboxIdsResponse {
                     {
                         match value {
                             "responses" => Ok(GeneratedField::Responses),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -414,6 +427,9 @@ impl<'de> serde::Deserialize<'de> for GetInboxIdsResponse {
                                 return Err(serde::de::Error::duplicate_field("responses"));
                             }
                             responses__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -476,6 +492,7 @@ impl<'de> serde::Deserialize<'de> for get_inbox_ids_response::Response {
             Identifier,
             InboxId,
             IdentifierKind,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -500,7 +517,7 @@ impl<'de> serde::Deserialize<'de> for get_inbox_ids_response::Response {
                             "identifier" => Ok(GeneratedField::Identifier),
                             "inboxId" | "inbox_id" => Ok(GeneratedField::InboxId),
                             "identifierKind" | "identifier_kind" => Ok(GeneratedField::IdentifierKind),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -541,6 +558,9 @@ impl<'de> serde::Deserialize<'de> for get_inbox_ids_response::Response {
                                 return Err(serde::de::Error::duplicate_field("identifierKind"));
                             }
                             identifier_kind__ = Some(map_.next_value::<super::super::identity::associations::IdentifierKind>()? as i32);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -585,6 +605,7 @@ impl<'de> serde::Deserialize<'de> for GetNewestEnvelopeRequest {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Topics,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -607,7 +628,7 @@ impl<'de> serde::Deserialize<'de> for GetNewestEnvelopeRequest {
                     {
                         match value {
                             "topics" => Ok(GeneratedField::Topics),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -637,6 +658,9 @@ impl<'de> serde::Deserialize<'de> for GetNewestEnvelopeRequest {
                                 Some(map_.next_value::<Vec<::pbjson::private::BytesDeserialize<_>>>()?
                                     .into_iter().map(|x| x.0).collect())
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -679,6 +703,7 @@ impl<'de> serde::Deserialize<'de> for GetNewestEnvelopeResponse {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Results,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -701,7 +726,7 @@ impl<'de> serde::Deserialize<'de> for GetNewestEnvelopeResponse {
                     {
                         match value {
                             "results" => Ok(GeneratedField::Results),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -728,6 +753,9 @@ impl<'de> serde::Deserialize<'de> for GetNewestEnvelopeResponse {
                                 return Err(serde::de::Error::duplicate_field("results"));
                             }
                             results__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -771,6 +799,7 @@ impl<'de> serde::Deserialize<'de> for get_newest_envelope_response::Response {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             OriginatorEnvelope,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -793,7 +822,7 @@ impl<'de> serde::Deserialize<'de> for get_newest_envelope_response::Response {
                     {
                         match value {
                             "originatorEnvelope" | "originator_envelope" => Ok(GeneratedField::OriginatorEnvelope),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -820,6 +849,9 @@ impl<'de> serde::Deserialize<'de> for get_newest_envelope_response::Response {
                                 return Err(serde::de::Error::duplicate_field("originatorEnvelope"));
                             }
                             originator_envelope__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -885,6 +917,7 @@ impl<'de> serde::Deserialize<'de> for LivenessFailure {
             Subscribe,
             Query,
             Publish,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -910,7 +943,7 @@ impl<'de> serde::Deserialize<'de> for LivenessFailure {
                             "subscribe" => Ok(GeneratedField::Subscribe),
                             "query" => Ok(GeneratedField::Query),
                             "publish" => Ok(GeneratedField::Publish),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -961,6 +994,9 @@ impl<'de> serde::Deserialize<'de> for LivenessFailure {
                             }
                             request__ = map_.next_value::<::std::option::Option<_>>()?.map(liveness_failure::Request::Publish)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1118,6 +1154,7 @@ impl<'de> serde::Deserialize<'de> for MisbehaviorReport {
             ServerTimeNs,
             UnsignedMisbehaviorReport,
             Signature,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1142,7 +1179,7 @@ impl<'de> serde::Deserialize<'de> for MisbehaviorReport {
                             "serverTimeNs" | "server_time_ns" => Ok(GeneratedField::ServerTimeNs),
                             "unsignedMisbehaviorReport" | "unsigned_misbehavior_report" => Ok(GeneratedField::UnsignedMisbehaviorReport),
                             "signature" => Ok(GeneratedField::Signature),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1188,6 +1225,9 @@ impl<'de> serde::Deserialize<'de> for MisbehaviorReport {
                             }
                             signature__ = map_.next_value()?;
                         }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(MisbehaviorReport {
@@ -1232,6 +1272,7 @@ impl<'de> serde::Deserialize<'de> for PublishPayerEnvelopesRequest {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             PayerEnvelopes,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1254,7 +1295,7 @@ impl<'de> serde::Deserialize<'de> for PublishPayerEnvelopesRequest {
                     {
                         match value {
                             "payerEnvelopes" | "payer_envelopes" => Ok(GeneratedField::PayerEnvelopes),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1281,6 +1322,9 @@ impl<'de> serde::Deserialize<'de> for PublishPayerEnvelopesRequest {
                                 return Err(serde::de::Error::duplicate_field("payerEnvelopes"));
                             }
                             payer_envelopes__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1324,6 +1368,7 @@ impl<'de> serde::Deserialize<'de> for PublishPayerEnvelopesResponse {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             OriginatorEnvelopes,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1346,7 +1391,7 @@ impl<'de> serde::Deserialize<'de> for PublishPayerEnvelopesResponse {
                     {
                         match value {
                             "originatorEnvelopes" | "originator_envelopes" => Ok(GeneratedField::OriginatorEnvelopes),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1373,6 +1418,9 @@ impl<'de> serde::Deserialize<'de> for PublishPayerEnvelopesResponse {
                                 return Err(serde::de::Error::duplicate_field("originatorEnvelopes"));
                             }
                             originator_envelopes__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1423,6 +1471,7 @@ impl<'de> serde::Deserialize<'de> for QueryEnvelopesRequest {
         enum GeneratedField {
             Query,
             Limit,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1446,7 +1495,7 @@ impl<'de> serde::Deserialize<'de> for QueryEnvelopesRequest {
                         match value {
                             "query" => Ok(GeneratedField::Query),
                             "limit" => Ok(GeneratedField::Limit),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1482,6 +1531,9 @@ impl<'de> serde::Deserialize<'de> for QueryEnvelopesRequest {
                             limit__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1525,6 +1577,7 @@ impl<'de> serde::Deserialize<'de> for QueryEnvelopesResponse {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Envelopes,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1547,7 +1600,7 @@ impl<'de> serde::Deserialize<'de> for QueryEnvelopesResponse {
                     {
                         match value {
                             "envelopes" => Ok(GeneratedField::Envelopes),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1574,6 +1627,9 @@ impl<'de> serde::Deserialize<'de> for QueryEnvelopesResponse {
                                 return Err(serde::de::Error::duplicate_field("envelopes"));
                             }
                             envelopes__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1619,6 +1675,7 @@ impl<'de> serde::Deserialize<'de> for QueryMisbehaviorReportsRequest {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             AfterNs,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1641,7 +1698,7 @@ impl<'de> serde::Deserialize<'de> for QueryMisbehaviorReportsRequest {
                     {
                         match value {
                             "afterNs" | "after_ns" => Ok(GeneratedField::AfterNs),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1670,6 +1727,9 @@ impl<'de> serde::Deserialize<'de> for QueryMisbehaviorReportsRequest {
                             after_ns__ = 
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1712,6 +1772,7 @@ impl<'de> serde::Deserialize<'de> for QueryMisbehaviorReportsResponse {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Reports,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1734,7 +1795,7 @@ impl<'de> serde::Deserialize<'de> for QueryMisbehaviorReportsResponse {
                     {
                         match value {
                             "reports" => Ok(GeneratedField::Reports),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1761,6 +1822,9 @@ impl<'de> serde::Deserialize<'de> for QueryMisbehaviorReportsResponse {
                                 return Err(serde::de::Error::duplicate_field("reports"));
                             }
                             reports__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1803,6 +1867,7 @@ impl<'de> serde::Deserialize<'de> for SafetyFailure {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Envelopes,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1825,7 +1890,7 @@ impl<'de> serde::Deserialize<'de> for SafetyFailure {
                     {
                         match value {
                             "envelopes" => Ok(GeneratedField::Envelopes),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1852,6 +1917,9 @@ impl<'de> serde::Deserialize<'de> for SafetyFailure {
                                 return Err(serde::de::Error::duplicate_field("envelopes"));
                             }
                             envelopes__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1894,6 +1962,7 @@ impl<'de> serde::Deserialize<'de> for SubmitMisbehaviorReportRequest {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Report,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1916,7 +1985,7 @@ impl<'de> serde::Deserialize<'de> for SubmitMisbehaviorReportRequest {
                     {
                         match value {
                             "report" => Ok(GeneratedField::Report),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -1943,6 +2012,9 @@ impl<'de> serde::Deserialize<'de> for SubmitMisbehaviorReportRequest {
                                 return Err(serde::de::Error::duplicate_field("report"));
                             }
                             report__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -1977,6 +2049,7 @@ impl<'de> serde::Deserialize<'de> for SubmitMisbehaviorReportResponse {
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1997,7 +2070,7 @@ impl<'de> serde::Deserialize<'de> for SubmitMisbehaviorReportResponse {
                     where
                         E: serde::de::Error,
                     {
-                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                            Ok(GeneratedField::__SkipField__)
                     }
                 }
                 deserializer.deserialize_identifier(GeneratedVisitor)
@@ -2056,6 +2129,7 @@ impl<'de> serde::Deserialize<'de> for SubscribeEnvelopesRequest {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Query,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2078,7 +2152,7 @@ impl<'de> serde::Deserialize<'de> for SubscribeEnvelopesRequest {
                     {
                         match value {
                             "query" => Ok(GeneratedField::Query),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2105,6 +2179,9 @@ impl<'de> serde::Deserialize<'de> for SubscribeEnvelopesRequest {
                                 return Err(serde::de::Error::duplicate_field("query"));
                             }
                             query__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2147,6 +2224,7 @@ impl<'de> serde::Deserialize<'de> for SubscribeEnvelopesResponse {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Envelopes,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2169,7 +2247,7 @@ impl<'de> serde::Deserialize<'de> for SubscribeEnvelopesResponse {
                     {
                         match value {
                             "envelopes" => Ok(GeneratedField::Envelopes),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2196,6 +2274,9 @@ impl<'de> serde::Deserialize<'de> for SubscribeEnvelopesResponse {
                                 return Err(serde::de::Error::duplicate_field("envelopes"));
                             }
                             envelopes__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -2286,6 +2367,7 @@ impl<'de> serde::Deserialize<'de> for UnsignedMisbehaviorReport {
             SubmittedByNode,
             Liveness,
             Safety,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2313,7 +2395,7 @@ impl<'de> serde::Deserialize<'de> for UnsignedMisbehaviorReport {
                             "submittedByNode" | "submitted_by_node" => Ok(GeneratedField::SubmittedByNode),
                             "liveness" => Ok(GeneratedField::Liveness),
                             "safety" => Ok(GeneratedField::Safety),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -2380,6 +2462,9 @@ impl<'de> serde::Deserialize<'de> for UnsignedMisbehaviorReport {
                             }
                             failure__ = map_.next_value::<::std::option::Option<_>>()?.map(unsigned_misbehavior_report::Failure::Safety)
 ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }

--- a/xmtp_proto/src/gen/xmtp.xmtpv4.metadata_api.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.xmtpv4.metadata_api.serde.rs
@@ -22,6 +22,7 @@ impl<'de> serde::Deserialize<'de> for GetSyncCursorRequest {
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -42,7 +43,7 @@ impl<'de> serde::Deserialize<'de> for GetSyncCursorRequest {
                     where
                         E: serde::de::Error,
                     {
-                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                            Ok(GeneratedField::__SkipField__)
                     }
                 }
                 deserializer.deserialize_identifier(GeneratedVisitor)
@@ -102,6 +103,7 @@ impl<'de> serde::Deserialize<'de> for GetSyncCursorResponse {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             LatestSync,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -124,7 +126,7 @@ impl<'de> serde::Deserialize<'de> for GetSyncCursorResponse {
                     {
                         match value {
                             "latestSync" | "latest_sync" => Ok(GeneratedField::LatestSync),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -151,6 +153,9 @@ impl<'de> serde::Deserialize<'de> for GetSyncCursorResponse {
                                 return Err(serde::de::Error::duplicate_field("latestSync"));
                             }
                             latest_sync__ = map_.next_value()?;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }

--- a/xmtp_proto/src/gen/xmtp.xmtpv4.metadata_api.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.xmtpv4.metadata_api.serde.rs
@@ -84,7 +84,7 @@ impl serde::Serialize for GetSyncCursorResponse {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.xmtpv4.metadata_api.GetSyncCursorResponse", len)?;
         if let Some(v) = self.latest_sync.as_ref() {
-            struct_ser.serialize_field("latestSync", v)?;
+            struct_ser.serialize_field("latest_sync", v)?;
         }
         struct_ser.end()
     }

--- a/xmtp_proto/src/gen/xmtp.xmtpv4.payer_api.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.xmtpv4.payer_api.serde.rs
@@ -22,6 +22,7 @@ impl<'de> serde::Deserialize<'de> for GetReaderNodeRequest {
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -42,7 +43,7 @@ impl<'de> serde::Deserialize<'de> for GetReaderNodeRequest {
                     where
                         E: serde::de::Error,
                     {
-                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                            Ok(GeneratedField::__SkipField__)
                     }
                 }
                 deserializer.deserialize_identifier(GeneratedVisitor)
@@ -111,6 +112,7 @@ impl<'de> serde::Deserialize<'de> for GetReaderNodeResponse {
         enum GeneratedField {
             ReaderNodeUrl,
             BackupNodeUrls,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -134,7 +136,7 @@ impl<'de> serde::Deserialize<'de> for GetReaderNodeResponse {
                         match value {
                             "readerNodeUrl" | "reader_node_url" => Ok(GeneratedField::ReaderNodeUrl),
                             "backupNodeUrls" | "backup_node_urls" => Ok(GeneratedField::BackupNodeUrls),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -168,6 +170,9 @@ impl<'de> serde::Deserialize<'de> for GetReaderNodeResponse {
                                 return Err(serde::de::Error::duplicate_field("backupNodeUrls"));
                             }
                             backup_node_urls__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -211,6 +216,7 @@ impl<'de> serde::Deserialize<'de> for PublishClientEnvelopesRequest {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Envelopes,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -233,7 +239,7 @@ impl<'de> serde::Deserialize<'de> for PublishClientEnvelopesRequest {
                     {
                         match value {
                             "envelopes" => Ok(GeneratedField::Envelopes),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -260,6 +266,9 @@ impl<'de> serde::Deserialize<'de> for PublishClientEnvelopesRequest {
                                 return Err(serde::de::Error::duplicate_field("envelopes"));
                             }
                             envelopes__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }
@@ -303,6 +312,7 @@ impl<'de> serde::Deserialize<'de> for PublishClientEnvelopesResponse {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             OriginatorEnvelopes,
+            __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -325,7 +335,7 @@ impl<'de> serde::Deserialize<'de> for PublishClientEnvelopesResponse {
                     {
                         match value {
                             "originatorEnvelopes" | "originator_envelopes" => Ok(GeneratedField::OriginatorEnvelopes),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                            _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
                 }
@@ -352,6 +362,9 @@ impl<'de> serde::Deserialize<'de> for PublishClientEnvelopesResponse {
                                 return Err(serde::de::Error::duplicate_field("originatorEnvelopes"));
                             }
                             originator_envelopes__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
                     }
                 }

--- a/xmtp_proto/src/gen/xmtp.xmtpv4.payer_api.serde.rs
+++ b/xmtp_proto/src/gen/xmtp.xmtpv4.payer_api.serde.rs
@@ -87,10 +87,10 @@ impl serde::Serialize for GetReaderNodeResponse {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.xmtpv4.payer_api.GetReaderNodeResponse", len)?;
         if !self.reader_node_url.is_empty() {
-            struct_ser.serialize_field("readerNodeUrl", &self.reader_node_url)?;
+            struct_ser.serialize_field("reader_node_url", &self.reader_node_url)?;
         }
         if !self.backup_node_urls.is_empty() {
-            struct_ser.serialize_field("backupNodeUrls", &self.backup_node_urls)?;
+            struct_ser.serialize_field("backup_node_urls", &self.backup_node_urls)?;
         }
         struct_ser.end()
     }
@@ -293,7 +293,7 @@ impl serde::Serialize for PublishClientEnvelopesResponse {
         }
         let mut struct_ser = serializer.serialize_struct("xmtp.xmtpv4.payer_api.PublishClientEnvelopesResponse", len)?;
         if !self.originator_envelopes.is_empty() {
-            struct_ser.serialize_field("originatorEnvelopes", &self.originator_envelopes)?;
+            struct_ser.serialize_field("originator_envelopes", &self.originator_envelopes)?;
         }
         struct_ser.end()
     }


### PR DESCRIPTION
### Ignore unknown fields in proto deserialization by modifying generated serde code to skip unknown fields instead of returning errors
This pull request modifies the protocol buffer serialization and deserialization code across multiple generated serde files to handle unknown fields gracefully and standardize field naming conventions. The changes include:

- Updates field names in serialization calls from camelCase to snake_case format (e.g., `accountAddresses` to `account_addresses`, `installationIds` to `installation_ids`) across all generated serde files
- Modifies error handling for unknown fields by adding `__SkipField__` variants to field enums and changing from `Err(serde::de::Error::unknown_field())` to `Ok(GeneratedField::__SkipField__)` followed by `map_.next_value::<serde::de::IgnoredAny>()?` to skip unknown values
- Configures the protobuf code generator in [buf.gen.yaml](https://github.com/xmtp/libxmtp/pull/2120/files#diff-7835e3282cecd706b38d62e8294afd9263e08ff65ee872f0570566434c24f225) with `ignore_unknown_fields=true` and `preserve_proto_field_names=true` options
- Updates the development setup script [dev/up](https://github.com/xmtp/libxmtp/pull/2120/files#diff-16426f02e6bce9db2f326db8d2dd685d378a044aaa8b9c456e6426d396837180) to automatically install the `wasm32-unknown-unknown` Rust target if not present

#### 📍Where to Start
Start by reviewing the configuration changes in [buf.gen.yaml](https://github.com/xmtp/libxmtp/pull/2120/files#diff-7835e3282cecd706b38d62e8294afd9263e08ff65ee872f0570566434c24f225) to understand the generator options that drive the field naming and unknown field handling behavior, then examine one of the larger generated files like [xmtp.mls.database.serde.rs](https://github.com/xmtp/libxmtp/pull/2120/files#diff-2e1be42523452214157cb782de9411b93f2a7c54bb2837bdec782622b54b1b64) to see the pattern of changes applied across all serde implementations.



#### Changes since #2120 opened

- Modified `GrpcResponse` enum structure and updated response handling in HTTP stream processing [043296c]
- Restructured `GrpcResponse` enum and updated response handling logic [b72301c]
----

_[Macroscope](https://app.macroscope.com) summarized b72301c._