### PR TITLE
Static Revocation Node & Browser

### DIFF
--- a/bindings_node/src/client.rs
+++ b/bindings_node/src/client.rs
@@ -36,10 +36,6 @@ impl Client {
   pub fn inner_client(&self) -> &Arc<RustXmtpClient> {
     &self.inner_client
   }
-
-  pub fn signature_requests(&self) -> &Arc<Mutex<HashMap<SignatureRequestType, SignatureRequest>>> {
-    &self.signature_requests
-  }
 }
 
 #[napi(string_enum)]


### PR DESCRIPTION
Adds the ability to revoke an installation statically without having access to the installation.
This is more complicated in the node and browser sdk since they don't use a sign request object.