### PR TITLE
Order AssociationState by client timestamp

### DIFF
--- a/bindings_node/src/inbox_state.rs
+++ b/bindings_node/src/inbox_state.rs
@@ -35,27 +35,33 @@ pub struct Lifetime {
 
 impl From<AssociationState> for InboxState {
   fn from(state: AssociationState) -> Self {
-    let ident: Identifier = state.recovery_identifier().clone().into();
-    Self {
-      inbox_id: state.inbox_id().to_string(),
-      recovery_identifier: ident,
-      installations: state
-        .members()
-        .into_iter()
-        .filter_map(|m| match m.identifier {
-          MemberIdentifier::Ethereum(_) => None,
-          MemberIdentifier::Passkey(_) => None,
-          MemberIdentifier::Installation(ident::Installation(key)) => Some(Installation {
-            bytes: Uint8Array::from(key.as_slice()),
-            client_timestamp_ns: m.client_timestamp_ns.map(BigInt::from),
-            id: hex::encode(key),
-          }),
-        })
-        .collect(),
-      identifiers: state.identifiers().into_iter().map(Into::into).collect(),
-    }
+      let ident: Identifier = state.recovery_identifier().clone().into();
+
+      // Collect and sort members by timestamp
+      let mut sorted_members: Vec<_> = state.members().into_iter().collect();
+      sorted_members.sort_by_key(|m| m.client_timestamp_ns.unwrap_or(u64::MAX));
+
+      Self {
+          inbox_id: state.inbox_id().to_string(),
+          recovery_identifier: ident,
+          installations: sorted_members
+              .into_iter()
+              .filter_map(|m| match m.identifier {
+                  MemberIdentifier::Ethereum(_) => None,
+                  MemberIdentifier::Passkey(_) => None,
+                  MemberIdentifier::Installation(ident::Installation(key)) => Some(Installation {
+                      bytes: Uint8Array::from(key.as_slice()),
+                      client_timestamp_ns: m.client_timestamp_ns.map(BigInt::from),
+                      id: hex::encode(key),
+                  }),
+              })
+              .collect(),
+
+          identifiers: state.identifiers().into_iter().map(Into::into).collect(),
+      }
   }
 }
+
 
 impl From<VerifiedLifetime> for Lifetime {
   fn from(lifetime: VerifiedLifetime) -> Self {

--- a/bindings_wasm/src/inbox_state.rs
+++ b/bindings_wasm/src/inbox_state.rs
@@ -57,24 +57,29 @@ impl InboxState {
 
 impl From<AssociationState> for InboxState {
   fn from(state: AssociationState) -> Self {
-    let ident: Identifier = state.recovery_identifier().clone().into();
-    Self {
-      inbox_id: state.inbox_id().to_string(),
-      recovery_identifier: ident,
-      installations: state
-        .members()
-        .into_iter()
-        .filter_map(|m| match m.identifier {
-          MemberIdentifier::Installation(ident::Installation(key)) => Some(Installation {
-            bytes: Uint8Array::from(key.as_slice()),
-            client_timestamp_ns: m.client_timestamp_ns,
-            id: hex::encode(key),
-          }),
-          _ => None,
-        })
-        .collect(),
-      account_identifiers: state.identifiers().into_iter().map(Into::into).collect(),
-    }
+      let ident: Identifier = state.recovery_identifier().clone().into();
+
+      // Collect and sort members by timestamp, placing None timestamps last
+      let mut sorted_members: Vec<_> = state.members().into_iter().collect();
+      sorted_members.sort_by_key(|m| m.client_timestamp_ns.unwrap_or(u64::MAX));
+
+      Self {
+          inbox_id: state.inbox_id().to_string(),
+          recovery_identifier: ident,
+          installations: sorted_members
+              .into_iter()
+              .filter_map(|m| match m.identifier {
+                  MemberIdentifier::Installation(ident::Installation(key)) => Some(Installation {
+                      bytes: Uint8Array::from(key.as_slice()),
+                      client_timestamp_ns: m.client_timestamp_ns,
+                      id: hex::encode(key),
+                  }),
+                  _ => None,
+              })
+              .collect(),
+
+          account_identifiers: state.identifiers().into_iter().map(Into::into).collect(),
+      }
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/xmtp/libxmtp/issues/1752

Ideally when SDKs read the AssociationState of an inboxId they have some way of distinguishing priority, or ordering of associated identifiers. This will help set norms for which address should be used for UI display purposes in cases where multiple identifiers are associated.

So "address to display" resolution for now should be
1. If there is only one address returned in the [inboxState functions](https://github.com/xmtp/xmtp-js/blob/d70e7535ec0635662bda0a6da8c36cd607936736/sdks/node-sdk/src/Client.ts#L516-L522) identifiers Array, use that as the display address. (we expect there always to be at least one, which is the recovery address)
2. If there are two addresses use the one that does not match the recoveryIdentifier
3. If there is more than 2 - we can't distinguish them yet - but we should be able to get in a fix for that soon for you. [Issue created here](https://github.com/xmtp/libxmtp/issues/1752).