### PR TITLE
try to drop the stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7150,7 +7150,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 [[package]]
 name = "toxiproxy_rust"
 version = "0.1.6"
-source = "git+https://github.com/ephemeraHQ/toxiproxy_rust.git#7620d968f41052c979cf228fa661ce6a4fa2c7fc"
+source = "git+https://github.com/ephemeraHQ/toxiproxy_rust.git#b82f61cbc44a2ddcca0bcfd31f0406df7fc16af8"
 dependencies = [
  "http 0.2.12",
  "lazy_static",

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -922,8 +922,10 @@ where
     #[tracing::instrument(level = "trace", skip_all)]
     pub async fn add_members(
         &self,
-        account_identifiers: &[Identifier],
+        account_identifiers: impl AsRef<[Identifier]>,
     ) -> Result<UpdateGroupMembershipResult, GroupError> {
+        let account_identifiers = account_identifiers.as_ref();
+
         // Fetch the associated inbox_ids
         let requests = account_identifiers.iter().map(Into::into).collect();
         let inbox_id_map: HashMap<Identifier, String> = self
@@ -961,10 +963,14 @@ where
     #[tracing::instrument(level = "trace", skip_all)]
     pub async fn add_members_by_inbox_id<S: AsIdRef>(
         &self,
-        inbox_ids: &[S],
+        inbox_ids: impl AsRef<[S]>,
     ) -> Result<UpdateGroupMembershipResult, GroupError> {
         self.ensure_not_paused().await?;
-        let ids = inbox_ids.iter().map(AsIdRef::as_ref).collect::<Vec<&str>>();
+        let ids = inbox_ids
+            .as_ref()
+            .iter()
+            .map(AsIdRef::as_ref)
+            .collect::<Vec<&str>>();
         let intent_data = self
             .get_membership_update_intent(ids.as_slice(), &[])
             .await?;

--- a/xmtp_mls/src/test/group_test_utils.rs
+++ b/xmtp_mls/src/test/group_test_utils.rs
@@ -48,4 +48,13 @@ where
 
         Ok(msg)
     }
+
+    pub fn test_last_message_eq(&self, msg_bytes: &[u8]) -> Result<bool, TestError> {
+        let mut msgs = self.find_messages(&MsgQueryArgs::default())?;
+        let Some(last_msg) = msgs.pop() else {
+            return Ok(false);
+        };
+
+        Ok(last_msg.decrypted_message_bytes == msg_bytes)
+    }
 }


### PR DESCRIPTION
### Add network drop testing for message streaming to verify stream recovery after network interruptions
- Adds `test_stream_drop` function in [xmtp_mls/src/groups/tests/test_network.rs](https://github.com/xmtp/libxmtp/pull/2139/files#diff-3742641c9b865413afba7465b49dafac0867c4962ea7a1a51f0910106e280ec5) that tests message streaming behavior when network connections are dropped and restored with a 5-second wait period
- Updates `Group.add_members` and `Group.add_members_by_inbox_id` method signatures in [xmtp_mls/src/groups/mod.rs](https://github.com/xmtp/libxmtp/pull/2139/files#diff-c29f56a38916c7410eff8091df1a2e43487ffe20646d96827e846e475f4608d3) to accept generic types implementing `AsRef` trait instead of slice references
- Adds `TestClient.test_talk_in_new_group_with` helper method in [xmtp_mls/src/test/client_test_utils.rs](https://github.com/xmtp/libxmtp/pull/2139/files#diff-664975b3d51264a0f18911f4b21966826096629c12dc2671e9a68ad3d7a65d3d) for creating groups with multiple members and verifying message delivery
- Adds `TestGroup.test_last_message_eq` helper method in [xmtp_mls/src/test/group_test_utils.rs](https://github.com/xmtp/libxmtp/pull/2139/files#diff-bd87b3da8fc22d3a8ba473cc0e90c7553e6999558f2bbeca1d017b8cef940633) for checking if the last message matches expected content
- Updates `toxiproxy_rust` dependency commit hash in [Cargo.lock](https://github.com/xmtp/libxmtp/pull/2139/files#diff-13ee4b2252c9e516a0547f2891aa2105c3ca71c6d7a1e682c69be97998dfc87e)

#### 📍Where to Start
Start with the `test_stream_drop` function in [xmtp_mls/src/groups/tests/test_network.rs](https://github.com/xmtp/libxmtp/pull/2139/files#diff-3742641c9b865413afba7465b49dafac0867c4962ea7a1a51f0910106e280ec5) to understand the main network drop testing functionality.

----

_[Macroscope](https://app.macroscope.com) summarized 5b732cd._