### PR TITLE
Tweak the proxy port range to be out of the ephemeral port range

### DIFF
--- a/dev/docker/docker-compose.yml
+++ b/dev/docker/docker-compose.yml
@@ -52,6 +52,6 @@ services:
     image: ghcr.io/shopify/toxiproxy:2.12.0
     ports:
       - 8474:8474
-      - 40000-40100:40000-40100
+      - 21100-21200:21100-21200
     depends_on:
       - node

--- a/xmtp_mls/src/utils/test/tester_utils.rs
+++ b/xmtp_mls/src/utils/test/tester_utils.rs
@@ -50,7 +50,7 @@ use xmtp_id::{
 use xmtp_proto::prelude::XmtpTestClient;
 
 static TOXIPROXY: OnceCell<toxiproxy_rust::client::Client> = OnceCell::const_new();
-static TOXI_PORT: AtomicUsize = AtomicUsize::new(40000);
+static TOXI_PORT: AtomicUsize = AtomicUsize::new(21100);
 
 /// A test client wrapper that auto-exposes all of the usual component access boilerplate.
 /// Makes testing easier and less repetetive.


### PR DESCRIPTION
### Change toxiproxy service port range from 40000-40100 to 21100-21200 to move out of the ephemeral port range
The toxiproxy service port configuration is updated in both Docker Compose and Rust test utilities to use port range 21100-21200 instead of 40000-40100. The changes modify the port mapping in [dev/docker/docker-compose.yml](https://github.com/xmtp/libxmtp/pull/2141/files#diff-6a25daaa729d7279e0cda8eb92399f1a82d4a91f961e1955bb5745e9c99f3c6e) and update the `TOXI_PORT` starting value in [xmtp_mls/src/utils/test/tester_utils.rs](https://github.com/xmtp/libxmtp/pull/2141/files#diff-727ea71bc8afdfdf6f0b1d9813b2e6e46f6fdd647abbc9b56be80bd873034c7d) to maintain consistency between the Docker configuration and test code.

#### 📍Where to Start
Start with the toxiproxy service configuration in [dev/docker/docker-compose.yml](https://github.com/xmtp/libxmtp/pull/2141/files#diff-6a25daaa729d7279e0cda8eb92399f1a82d4a91f961e1955bb5745e9c99f3c6e) to understand the port range change.

----

_[Macroscope](https://app.macroscope.com) summarized 9a02590._