### PR TITLE
Fork fixes

### DIFF
--- a/xmtp_db/src/errors.rs
+++ b/xmtp_db/src/errors.rs
@@ -95,8 +95,8 @@ pub enum NotFound {
     CipherSalt(String),
     #[error("Sync Group for installation {0} not found")]
     SyncGroup(InstallationId),
-    #[error("Key Package Reference not found")]
-    KeyPackageReference,
+    #[error("Key Package Reference {handle} not found", handle = hex::encode(_0))]
+    KeyPackageReference(Vec<u8>),
     #[error("MLS Group Not Found")]
     MlsGroup,
     #[error("Post Quantum Key Pair not found")]

--- a/xmtp_debug/src/app/generate/messages.rs
+++ b/xmtp_debug/src/app/generate/messages.rs
@@ -151,8 +151,8 @@ impl GenerateMessages {
             let client = app::client_from_identity(&identity, &network).await?;
             client.sync_welcomes().await?;
             let group = client.group(&group.id.into())?;
-            group.maybe_update_installations(None).await?;
             group.sync_with_conn().await?;
+            group.maybe_update_installations(None).await?;
             let words = rng.gen_range(0..*max_message_size);
             let words = lipsum::lipsum_words_with_rng(&mut *rng, words as usize);
             let message = content_type::new_message(words);

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -1327,7 +1327,9 @@ pub(crate) mod tests {
             .unwrap();
 
         // Sync Bola's state to get the latest
-        bola_group.sync().await.unwrap();
+        if let Err(err) = bola_group.sync().await {
+            panic!("Error syncing group: {:?}", err);
+        }
         // Find Bola's updated list of messages
         bola_messages = bola_group.find_messages(&MsgQueryArgs::default()).unwrap();
         // Bola should have been able to decrypt the last message

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -1080,7 +1080,6 @@ pub(crate) mod tests {
 
         alice_dm.send_message(b"Welcome from 1").await?;
 
-        bob_dm.update_installations().await?;
         // This message will set bob's dm as the primary DM for all clients
         bob_dm.send_message(b"Bob says hi 1").await?;
         // Alice will sync, pulling in Bob's DM message, which will cause

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -1080,8 +1080,8 @@ pub(crate) mod tests {
 
         alice_dm.send_message(b"Welcome from 1").await?;
 
+        bob_dm.update_installations().await?;
         // This message will set bob's dm as the primary DM for all clients
-        // bob_dm.sync().await?;
         bob_dm.send_message(b"Bob says hi 1").await?;
         // Alice will sync, pulling in Bob's DM message, which will cause
         // a database trigger to update `last_message_ns`, putting bob's DM to the top.

--- a/xmtp_mls/src/groups/device_sync_legacy.rs
+++ b/xmtp_mls/src/groups/device_sync_legacy.rs
@@ -264,8 +264,8 @@ where
         })?;
         for StoredGroup { id, .. } in groups.into_iter() {
             let group = self.mls_store.group(&id)?;
-            group.maybe_update_installations(None).await?;
             Box::pin(group.sync_with_conn()).await?;
+            group.maybe_update_installations(None).await?;
         }
 
         self.metrics

--- a/xmtp_mls/src/groups/error.rs
+++ b/xmtp_mls/src/groups/error.rs
@@ -166,6 +166,8 @@ pub enum GroupError {
     WrapWelcome(#[from] WrapWelcomeError),
     #[error(transparent)]
     UnwrapWelcome(#[from] UnwrapWelcomeError),
+    #[error("Result was not initialized")]
+    UninitializedResult,
 }
 
 impl From<SyncSummary> for GroupError {
@@ -273,7 +275,8 @@ impl RetryableError for GroupError {
             | Self::GroupPausedUntilUpdate(_)
             | Self::GroupInactive
             | Self::FailedToVerifyInstallations
-            | Self::NoWelcomesToSend => false,
+            | Self::NoWelcomesToSend
+            | Self::UninitializedResult => false,
         }
     }
 }

--- a/xmtp_mls/src/groups/mls_ext/decrypted_welcome.rs
+++ b/xmtp_mls/src/groups/mls_ext/decrypted_welcome.rs
@@ -78,7 +78,7 @@ pub(super) fn find_key_package_hash_ref<C: ConnectionExt>(
     Ok(provider
         .storage()
         .read(KEY_PACKAGE_REFERENCES, &serialized_hpke_public_key)?
-        .ok_or(NotFound::KeyPackageReference)?)
+        .ok_or(NotFound::KeyPackageReference(serialized_hpke_public_key))?)
 }
 
 /// For Curve25519 keys, we can just get the private key from the key package bundle

--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -296,7 +296,7 @@ where
         let _mutex = self.mutex.lock().await;
         let mut summary = SyncSummary::default();
 
-        if !self.is_active().map_err(|e| SyncSummary::other(e))? {
+        if !self.is_active().map_err(SyncSummary::other)? {
             return Err(SyncSummary::other(GroupError::GroupInactive));
         }
 

--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -242,8 +242,8 @@ where
                 other_dm.dm_id.clone(),
                 other_dm.created_at_ns,
             );
-            other_dm.maybe_update_installations(None).await?;
             other_dm.sync_with_conn().await?;
+            other_dm.maybe_update_installations(None).await?;
         }
 
         let sync_summary = self.sync_with_conn().await.map_err(GroupError::from)?;
@@ -295,6 +295,10 @@ where
     pub async fn sync_with_conn(&self) -> Result<SyncSummary, SyncSummary> {
         let _mutex = self.mutex.lock().await;
         let mut summary = SyncSummary::default();
+
+        if !self.is_active().map_err(|e| SyncSummary::other(e))? {
+            return Err(SyncSummary::other(GroupError::GroupInactive));
+        }
 
         if let Err(e) = self.handle_group_paused() {
             if matches!(e, GroupError::GroupPausedUntilUpdate(_)) {

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -577,7 +577,7 @@ where
         // in the `GroupMembership` extension.
         validate_initial_group_membership(&context, &staged_welcome).await?;
         let group_id = staged_welcome.public_group().group_id();
-        if let Some(_) = provider.db().find_group(group_id.as_slice())? {
+        if provider.db().find_group(group_id.as_slice())?.is_some() {
             // Fetch the original MLS group, rather than the one from the welcome
             let (group, _) = MlsGroup::new_cached(context.clone(), group_id.as_slice())?;
             // Check the group epoch as well, because we may not have synced the latest is_active state

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -768,12 +768,12 @@ where
         }
 
         self.ensure_not_paused().await?;
+        let update_interval_ns = Some(SEND_MESSAGE_UPDATE_INSTALLATIONS_INTERVAL_NS);
+        self.maybe_update_installations(update_interval_ns).await?;
 
         let message_id = self.prepare_message(message, |now| Self::into_envelope(message, now))?;
 
         self.sync_until_last_intent_resolved().await?;
-        self.maybe_update_installations(Some(SEND_MESSAGE_UPDATE_INSTALLATIONS_INTERVAL_NS))
-            .await?;
 
         // implicitly set group consent state to allowed
         self.update_consent_state(ConsentState::Allowed)?;
@@ -785,9 +785,9 @@ where
     /// which publishes all pending intents and reads them back from the network.
     pub async fn publish_messages(&self) -> Result<(), GroupError> {
         self.ensure_not_paused().await?;
+        let update_interval_ns = Some(SEND_MESSAGE_UPDATE_INSTALLATIONS_INTERVAL_NS);
+        self.maybe_update_installations(update_interval_ns).await?;
         self.sync_until_last_intent_resolved().await?;
-        self.maybe_update_installations(Some(SEND_MESSAGE_UPDATE_INSTALLATIONS_INTERVAL_NS))
-            .await?;
 
         // implicitly set group consent state to allowed
         self.update_consent_state(ConsentState::Allowed)?;

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -617,7 +617,7 @@ where
             });
 
             if let Some(group) = provider.db().find_group(group_id.as_slice())?{
-                if group.membership_state == GroupMembershipState::Allowed {
+                if group.membership_state != GroupMembershipState::Restored && mls_group.is_active() {
                     tracing::warn!("Skipping welcome {} because we are already in group {}", welcome.id, hex::encode(group_id.clone()));
                     return Err(ProcessIntentError::WelcomeAlreadyProcessed(welcome.id).into());
                 }

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -577,13 +577,9 @@ where
         // in the `GroupMembership` extension.
         validate_initial_group_membership(&context, &staged_welcome).await?;
         let group_id = staged_welcome.public_group().group_id();
-        if let Some(stored_group) = provider.db().find_group(group_id.as_slice())? {
+        if let Some(_) = provider.db().find_group(group_id.as_slice())? {
             // Fetch the original MLS group, rather than the one from the welcome
             let (group, _) = MlsGroup::new_cached(context.clone(), group_id.as_slice())?;
-            if group.is_active()? {
-                // Sync the group first to check if we have been removed
-                group.receive().await?;
-            }
             if group.is_active()? {
                 tracing::warn!(
                     "Skipping welcome {} because we are already in group {}",

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -602,7 +602,7 @@ where
                 welcome.id as i64,
             )?;
             if !requires_processing {
-                // TODO(rich): Consider unifying WelcomeAlreadyProcessed logic
+                tracing::error!("Skipping already processed welcome {}", welcome.id);
                 return Err(ProcessIntentError::WelcomeAlreadyProcessed(welcome.id).into());
             }
 
@@ -618,6 +618,7 @@ where
 
             if let Some(group) = provider.db().find_group(group_id.as_slice())?{
                 if group.membership_state == GroupMembershipState::Allowed {
+                    tracing::warn!("Skipping welcome {} because we are already in group {}", welcome.id, hex::encode(group_id.clone()));
                     return Err(ProcessIntentError::WelcomeAlreadyProcessed(welcome.id).into());
                 }
             }

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -581,7 +581,7 @@ where
             // Fetch the original MLS group, rather than the one from the welcome
             let (group, _) = MlsGroup::new_cached(context.clone(), group_id.as_slice())?;
             if group.is_active()? {
-                tracing::warn!(
+                tracing::error!(
                     "Skipping welcome {} because we are already in group {}",
                     welcome.id,
                     hex::encode(group_id.as_slice())

--- a/xmtp_mls/src/groups/welcome_sync.rs
+++ b/xmtp_mls/src/groups/welcome_sync.rs
@@ -52,7 +52,11 @@ where
                         err
                     );
                 } else {
-                    tracing::error!("failed to create group from welcome: {}", err);
+                    tracing::error!(
+                        "failed to create group from welcome created at {}: {}",
+                        welcome.created_ns,
+                        err
+                    );
                 }
 
                 Err(err)

--- a/xmtp_mls/src/groups/welcome_sync.rs
+++ b/xmtp_mls/src/groups/welcome_sync.rs
@@ -125,9 +125,8 @@ where
                         })
                         .await?;
                     if is_active {
-                        group.maybe_update_installations(None).await?;
-
                         group.sync_with_conn().await?;
+                        group.maybe_update_installations(None).await?;
                         active_group_count.fetch_add(1, Ordering::SeqCst);
                     }
 

--- a/xmtp_mls/src/subscriptions/stream_conversations.rs
+++ b/xmtp_mls/src/subscriptions/stream_conversations.rs
@@ -620,9 +620,6 @@ mod test {
             .await
             .unwrap();
         futures::pin_mut!(stream);
-        // TODO(rich): The next welcome to re-add Bo will currently be discarded, unless
-        // we sync first and detect that Bo has been removed from the group.
-        bo.sync_all_welcomes_and_groups(None).await.unwrap();
         alix_group
             .add_members_by_inbox_id(&[bo.inbox_id().to_string()])
             .await

--- a/xmtp_mls/src/subscriptions/stream_conversations.rs
+++ b/xmtp_mls/src/subscriptions/stream_conversations.rs
@@ -620,6 +620,9 @@ mod test {
             .await
             .unwrap();
         futures::pin_mut!(stream);
+        // TODO(rich): The next welcome to re-add Bo will currently be discarded, unless
+        // we sync first and detect that Bo has been removed from the group.
+        bo.sync_all_welcomes_and_groups(None).await.unwrap();
         alix_group
             .add_members_by_inbox_id(&[bo.inbox_id().to_string()])
             .await

--- a/xmtp_mls/src/subscriptions/stream_conversations.rs
+++ b/xmtp_mls/src/subscriptions/stream_conversations.rs
@@ -625,8 +625,10 @@ mod test {
             .await
             .unwrap();
 
-        let group = stream.next().await.unwrap();
-        assert!(group.is_ok());
+        let group_result = stream.next().await.unwrap();
+        if let Err(error) = group_result {
+            panic!("Error streaming group: {:?}", error);
+        }
     }
 
     #[rstest::rstest]

--- a/xmtp_mls/src/worker.rs
+++ b/xmtp_mls/src/worker.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use metrics::WorkerMetrics;
 use parking_lot::Mutex;
+use std::fmt::Debug;
 use std::{any::Any, collections::HashMap, hash::Hash, sync::Arc};
 
 pub mod metrics;
@@ -117,7 +118,7 @@ pub trait Worker {
                         tracing::warn!("Pool disconnected. task will restart on reconnect");
                         break;
                     } else {
-                        tracing::error!("Worker error: {err:?}");
+                        tracing::error!("{:?} worker error: {:?}", self.kind(), err);
                         xmtp_common::time::sleep(WORKER_RESTART_DELAY).await;
                         tracing::info!("Restarting {:?} worker...", self.kind());
                     }


### PR DESCRIPTION
Cherry picks fixes from @mchenani's forking investigation, as well as welcome logging from https://github.com/xmtp/libxmtp/pull/2068.

Changes:

1. Do not allow syncing to proceed on inactive groups (for example, groups received from device sync, or groups that we are no longer a member of)
2. Discard welcomes for groups that we are already active in (for example, if another member of the group sends us a welcome for the group that comes from a past epoch)
3. When syncing, call `maybe_update_installations()` after the sync is complete rather than before - this doesn't 'fix' forks necessarily, but significantly reduces race conditions
4. Additional logging, especially around welcome processing

Changes have been manually tested via Node.js integration tests, as well as existing Rust unit tests. I also tried to write a Rust unit test for (2) but was unable to reproduce - I think this happens only in very special race conditions that I haven't been able to pin down.