### PR TITLE
Fix lint warnings

### DIFF
--- a/common/src/test.rs
+++ b/common/src/test.rs
@@ -99,14 +99,14 @@ where
                     .fmt_fields({
                         format::debug_fn(move |writer, field, value| {
                             if field.name() == "message" {
-                                let mut message = format!("{:?}", value);
+                                let mut message = format!("{value:?}");
                                 let ids = REPLACE_IDS.lock();
                                 for (id, name) in ids.iter() {
                                     message = message.replace(id, name);
                                     message = message.replace(&crate::fmt::truncate_hex(id), name);
                                 }
 
-                                write!(writer, "{}", message)?;
+                                write!(writer, "{message}")?;
                             }
                             Ok(())
                         })
@@ -181,7 +181,7 @@ pub fn rand_hexstring() -> String {
         .map(|_| hex_chars.chars().choose(&mut rng).unwrap())
         .collect();
 
-    format!("0x{}", v)
+    format!("0x{v}")
 }
 
 pub fn rand_account_address() -> String {

--- a/common/src/test/logger.rs
+++ b/common/src/test/logger.rs
@@ -116,10 +116,10 @@ impl Contextual {
         if inner_duration > 0.0 {
             let base_duration = span.base_duration().as_nanos() as f64;
             let percent_base_of_root_duration = 100.0 * base_duration / root_duration;
-            write!(writer, "{:.2}% / ", percent_base_of_root_duration)?;
+            write!(writer, "{percent_base_of_root_duration:.2}% / ")?;
         }
 
-        write!(writer, "{:.2}% ]", percent_total_of_root_duration)?;
+        write!(writer, "{percent_total_of_root_duration:.2}% ]")?;
         for (n, field) in span.fields().iter().enumerate() {
             let ids = super::REPLACE_IDS.lock();
             let mut message = field.value().to_string();
@@ -201,11 +201,11 @@ impl fmt::Display for DurationDisplay {
         let mut t = self.0;
         for unit in ["ns", "µs", "ms", "s"] {
             if t < 10.0 {
-                return write!(f, "{:.2}{}", t, unit);
+                return write!(f, "{t:.2}{unit}");
             } else if t < 100.0 {
-                return write!(f, "{:.1}{}", t, unit);
+                return write!(f, "{t:.1}{unit}");
             } else if t < 1000.0 {
-                return write!(f, "{:.0}{}", t, unit);
+                return write!(f, "{t:.0}{unit}");
             }
             t /= 1000.0;
         }


### PR DESCRIPTION
### Update string formatting syntax to use modern Rust format string syntax in test modules to fix lint warnings
Updates string formatting calls in test modules to use modern Rust syntax that allows direct variable references within format strings. The changes replace older `format!("{:?}", value)` patterns with `format!("{value:?}")` syntax in [common/src/test.rs](https://github.com/xmtp/libxmtp/pull/2145/files#diff-5629102e1ed515ba434c7d22d250cf5d93f10345ca0797171e23dc3de2f4ad26) and [common/src/test/logger.rs](https://github.com/xmtp/libxmtp/pull/2145/files#diff-cc195c8854f8dcc72d74729c7a38cb1f6404ee329f41663b68e80d4ae8c252c6). This includes updates to `format!`, `write!` macro calls, and `DurationDisplay` implementation formatting.

#### 📍Where to Start
Start with the string formatting changes in [common/src/test.rs](https://github.com/xmtp/libxmtp/pull/2145/files#diff-5629102e1ed515ba434c7d22d250cf5d93f10345ca0797171e23dc3de2f4ad26) as it contains the simpler formatting updates before reviewing the more complex `DurationDisplay` implementation changes in [common/src/test/logger.rs](https://github.com/xmtp/libxmtp/pull/2145/files#diff-cc195c8854f8dcc72d74729c7a38cb1f6404ee329f41663b68e80d4ae8c252c6).

----

_[Macroscope](https://app.macroscope.com) summarized 9f31a90._