### PR TITLE
add a callback for stream close

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -1518,6 +1518,7 @@ impl FfiConversations {
                 Ok(c) => callback.on_conversation(Arc::new(c.into())),
                 Err(e) => callback.on_error(e.into()),
             },
+            move || {},
         );
 
         FfiStreamCloser::new(handle)
@@ -1532,6 +1533,7 @@ impl FfiConversations {
                 Ok(c) => callback.on_conversation(Arc::new(c.into())),
                 Err(e) => callback.on_error(e.into()),
             },
+            move || {},
         );
 
         FfiStreamCloser::new(handle)
@@ -1546,6 +1548,7 @@ impl FfiConversations {
                 Ok(c) => callback.on_conversation(Arc::new(c.into())),
                 Err(e) => callback.on_error(e.into()),
             },
+            move || {},
         );
 
         FfiStreamCloser::new(handle)
@@ -1602,6 +1605,7 @@ impl FfiConversations {
                 Ok(m) => message_callback.on_message(m.into()),
                 Err(e) => message_callback.on_error(e.into()),
             },
+            move || {},
         );
 
         FfiStreamCloser::new(handle)
@@ -1610,13 +1614,14 @@ impl FfiConversations {
     /// Get notified when there is a new consent update either locally or is synced from another device
     /// allowing the user to re-render the new state appropriately
     pub async fn stream_consent(&self, callback: Arc<dyn FfiConsentCallback>) -> FfiStreamCloser {
-        let handle =
-            RustXmtpClient::stream_consent_with_callback(self.inner_client.clone(), move |msg| {
-                match msg {
-                    Ok(m) => callback.on_consent_update(m.into_iter().map(Into::into).collect()),
-                    Err(e) => callback.on_error(e.into()),
-                }
-            });
+        let handle = RustXmtpClient::stream_consent_with_callback(
+            self.inner_client.clone(),
+            move |msg| match msg {
+                Ok(m) => callback.on_consent_update(m.into_iter().map(Into::into).collect()),
+                Err(e) => callback.on_error(e.into()),
+            },
+            move || {},
+        );
 
         FfiStreamCloser::new(handle)
     }
@@ -1635,6 +1640,7 @@ impl FfiConversations {
                 ),
                 Err(e) => callback.on_error(e.into()),
             },
+            move || {},
         );
 
         FfiStreamCloser::new(handle)
@@ -2317,13 +2323,15 @@ impl FfiConversation {
     }
 
     pub async fn stream(&self, message_callback: Arc<dyn FfiMessageCallback>) -> FfiStreamCloser {
-        let handle =
-            MlsGroup::stream_with_callback(self.inner.context.clone(), self.id(), move |message| {
-                match message {
-                    Ok(m) => message_callback.on_message(m.into()),
-                    Err(e) => message_callback.on_error(e.into()),
-                }
-            });
+        let handle = MlsGroup::stream_with_callback(
+            self.inner.context.clone(),
+            self.id(),
+            move |message| match message {
+                Ok(m) => message_callback.on_message(m.into()),
+                Err(e) => message_callback.on_error(e.into()),
+            },
+            move || {},
+        );
 
         FfiStreamCloser::new(handle)
     }

--- a/bindings_node/src/conversation.rs
+++ b/bindings_node/src/conversation.rs
@@ -472,7 +472,9 @@ impl Conversation {
     Ok(group_description)
   }
 
-  #[napi(ts_args_type = "callback: (err: null | Error, result: Message | undefined) => void")]
+  #[napi(
+    ts_args_type = "callback: (err: null | Error, result: Message | undefined) => void, onClose: () => void"
+  )]
   pub fn stream(&self, callback: JsFunction, on_close: JsFunction) -> Result<StreamCloser> {
     let tsfn: ThreadsafeFunction<Message, ErrorStrategy::CalleeHandled> =
       callback.create_threadsafe_function(0, |ctx| Ok(vec![ctx.value]))?;

--- a/bindings_node/src/conversation.rs
+++ b/bindings_node/src/conversation.rs
@@ -473,20 +473,26 @@ impl Conversation {
   }
 
   #[napi(ts_args_type = "callback: (err: null | Error, result: Message | undefined) => void")]
-  pub fn stream(&self, callback: JsFunction) -> Result<StreamCloser> {
+  pub fn stream(&self, callback: JsFunction, on_close: JsFunction) -> Result<StreamCloser> {
     let tsfn: ThreadsafeFunction<Message, ErrorStrategy::CalleeHandled> =
       callback.create_threadsafe_function(0, |ctx| Ok(vec![ctx.value]))?;
+    let tsfn_on_close: ThreadsafeFunction<(), ErrorStrategy::CalleeHandled> =
+      on_close.create_threadsafe_function(0, |ctx| Ok(vec![ctx.value]))?;
     let stream_closer = MlsGroup::stream_with_callback(
       self.inner_group.context.clone(),
       self.group_id.clone(),
       move |message| {
-        tsfn.call(
+        let status = tsfn.call(
           message
             .map(Message::from)
             .map_err(ErrorWrapper::from)
             .map_err(napi::Error::from),
           ThreadsafeFunctionCallMode::Blocking,
         );
+        tracing::info!("Stream status: {:?}", status);
+      },
+      move || {
+        tsfn_on_close.call(Ok(()), ThreadsafeFunctionCallMode::Blocking);
       },
     );
 

--- a/bindings_node/src/conversations.rs
+++ b/bindings_node/src/conversations.rs
@@ -522,21 +522,29 @@ impl Conversations {
   pub fn stream(
     &self,
     callback: JsFunction,
+    on_close: JsFunction,
     conversation_type: Option<ConversationType>,
   ) -> Result<StreamCloser> {
     let tsfn: ThreadsafeFunction<Conversation, ErrorStrategy::CalleeHandled> =
       callback.create_threadsafe_function(0, |ctx| Ok(vec![ctx.value]))?;
+    let tsfn_on_close: ThreadsafeFunction<(), ErrorStrategy::CalleeHandled> =
+      on_close.create_threadsafe_function(0, |ctx| Ok(vec![ctx.value]))?;
+
     let stream_closer = RustXmtpClient::stream_conversations_with_callback(
       self.inner_client.clone(),
       conversation_type.map(|ct| ct.into()),
       move |convo| {
-        tsfn.call(
+        let status = tsfn.call(
           convo
             .map(Conversation::from)
             .map_err(ErrorWrapper::from)
             .map_err(Error::from),
           ThreadsafeFunctionCallMode::Blocking,
         );
+        tracing::info!("Stream status: {:?}", status);
+      },
+      move || {
+        tsfn_on_close.call(Ok(()), ThreadsafeFunctionCallMode::Blocking);
       },
     );
 
@@ -549,6 +557,7 @@ impl Conversations {
   pub fn stream_all_messages(
     &self,
     callback: JsFunction,
+    on_close: JsFunction,
     conversation_type: Option<ConversationType>,
     consent_states: Option<Vec<ConsentState>>,
   ) -> Result<StreamCloser> {
@@ -558,6 +567,9 @@ impl Conversations {
     );
     let tsfn: ThreadsafeFunction<Message, ErrorStrategy::CalleeHandled> =
       callback.create_threadsafe_function(0, |ctx| Ok(vec![ctx.value]))?;
+    let tsfn_on_close: ThreadsafeFunction<(), ErrorStrategy::CalleeHandled> =
+      on_close.create_threadsafe_function(0, |ctx| Ok(vec![ctx.value]))?;
+
     let inbox_id = self.inner_client.inbox_id().to_string();
     let consents: Option<Vec<XmtpConsentState>> = consent_states.map(|states| {
       states
@@ -599,7 +611,8 @@ impl Conversations {
               inbox_id,
               "[received] calling tsfn callback with successful message"
             );
-            tsfn.call(Ok(transformed_msg), ThreadsafeFunctionCallMode::Blocking);
+            let status = tsfn.call(Ok(transformed_msg), ThreadsafeFunctionCallMode::Blocking);
+            tracing::info!("Stream status: {:?}", status);
           }
           Err(err) => {
             // Just in case the transformation itself fails
@@ -611,40 +624,58 @@ impl Conversations {
           }
         }
       },
+      move || {
+        tsfn_on_close.call(Ok(()), ThreadsafeFunctionCallMode::Blocking);
+      },
     );
 
     Ok(StreamCloser::new(stream_closer))
   }
 
   #[napi(ts_args_type = "callback: (err: null | Error, result: Consent[] | undefined) => void")]
-  pub fn stream_consent(&self, callback: JsFunction) -> Result<StreamCloser> {
+  pub fn stream_consent(&self, callback: JsFunction, on_close: JsFunction) -> Result<StreamCloser> {
     tracing::trace!(inbox_id = self.inner_client.inbox_id(),);
     let tsfn: ThreadsafeFunction<Vec<Consent>, ErrorStrategy::CalleeHandled> =
       callback.create_threadsafe_function(0, |ctx| Ok(vec![ctx.value]))?;
+    let tsfn_on_close: ThreadsafeFunction<(), ErrorStrategy::CalleeHandled> =
+      on_close.create_threadsafe_function(0, |ctx| Ok(vec![ctx.value]))?;
     let inbox_id = self.inner_client.inbox_id().to_string();
-    let stream_closer =
-      RustXmtpClient::stream_consent_with_callback(self.inner_client.clone(), move |message| {
+    let stream_closer = RustXmtpClient::stream_consent_with_callback(
+      self.inner_client.clone(),
+      move |message| {
         tracing::trace!(inbox_id, "[received] calling tsfn callback");
         match message {
           Ok(message) => {
             let msg: Vec<Consent> = message.into_iter().map(Into::into).collect();
-            tsfn.call(Ok(msg), ThreadsafeFunctionCallMode::Blocking);
+            let status = tsfn.call(Ok(msg), ThreadsafeFunctionCallMode::Blocking);
+            tracing::info!("Stream status: {:?}", status);
           }
           Err(e) => {
-            tsfn.call(
+            let status = tsfn.call(
               Err(Error::from(ErrorWrapper::from(e))),
               ThreadsafeFunctionCallMode::Blocking,
             );
+            tracing::info!("Stream status: {:?}", status);
           }
         }
-      });
+      },
+      move || {
+        tsfn_on_close.call(Ok(()), ThreadsafeFunctionCallMode::Blocking);
+      },
+    );
 
     Ok(StreamCloser::new(stream_closer))
   }
 
   #[napi(ts_args_type = "callback: (err: null | Error, result: any[] | undefined) => void")]
-  pub fn stream_preferences(&self, callback: JsFunction) -> Result<StreamCloser> {
+  pub fn stream_preferences(
+    &self,
+    callback: JsFunction,
+    on_close: JsFunction,
+  ) -> Result<StreamCloser> {
     tracing::trace!(inbox_id = self.inner_client.inbox_id(),);
+    let tsfn_on_close: ThreadsafeFunction<(), ErrorStrategy::CalleeHandled> =
+      on_close.create_threadsafe_function(0, |ctx| Ok(vec![ctx.value]))?;
     let tsfn: ThreadsafeFunction<Vec<Tag<UserPreferenceUpdate>>, ErrorStrategy::CalleeHandled> =
       callback.create_threadsafe_function(
         0,
@@ -658,8 +689,9 @@ impl Conversations {
         },
       )?;
     let inbox_id = self.inner_client.inbox_id().to_string();
-    let stream_closer =
-      RustXmtpClient::stream_preferences_with_callback(self.inner_client.clone(), move |message| {
+    let stream_closer = RustXmtpClient::stream_preferences_with_callback(
+      self.inner_client.clone(),
+      move |message| {
         tracing::trace!(inbox_id, "[received] calling tsfn callback");
         match message {
           Ok(message) => {
@@ -667,16 +699,23 @@ impl Conversations {
               .into_iter()
               .map(Tag::<UserPreferenceUpdate>::from)
               .collect();
-            tsfn.call(Ok(msg), ThreadsafeFunctionCallMode::Blocking);
+            let status = tsfn.call(Ok(msg), ThreadsafeFunctionCallMode::Blocking);
+            tracing::info!("Stream status: {:?}", status);
           }
           Err(e) => {
-            tsfn.call(
+            let status = tsfn.call(
               Err(Error::from(ErrorWrapper::from(e))),
               ThreadsafeFunctionCallMode::Blocking,
             );
+            tracing::info!("Stream status: {:?}", status);
           }
         }
-      });
+      },
+      move || {
+        let status = tsfn_on_close.call(Ok(()), ThreadsafeFunctionCallMode::Blocking);
+        tracing::info!("stream on close status {:?}", status);
+      },
+    );
 
     Ok(StreamCloser::new(stream_closer))
   }

--- a/bindings_node/src/conversations.rs
+++ b/bindings_node/src/conversations.rs
@@ -517,7 +517,7 @@ impl Conversations {
   }
 
   #[napi(
-    ts_args_type = "callback: (err: Error | null, result: Conversation | undefined) => void, conversationType?: ConversationType"
+    ts_args_type = "callback: (err: Error | null, result: Conversation | undefined) => void, onClose: () => void, conversationType?: ConversationType"
   )]
   pub fn stream(
     &self,
@@ -552,7 +552,7 @@ impl Conversations {
   }
 
   #[napi(
-    ts_args_type = "callback: (err: null | Error, result: Message | undefined) => void, conversationType?: ConversationType, consentStates?: ConsentState[]"
+    ts_args_type = "callback: (err: null | Error, result: Message | undefined) => void, onClose: () => void, conversationType?: ConversationType, consentStates?: ConsentState[]"
   )]
   pub fn stream_all_messages(
     &self,
@@ -632,7 +632,9 @@ impl Conversations {
     Ok(StreamCloser::new(stream_closer))
   }
 
-  #[napi(ts_args_type = "callback: (err: null | Error, result: Consent[] | undefined) => void")]
+  #[napi(
+    ts_args_type = "callback: (err: null | Error, result: Consent[] | undefined) => void, onClose: () => void"
+  )]
   pub fn stream_consent(&self, callback: JsFunction, on_close: JsFunction) -> Result<StreamCloser> {
     tracing::trace!(inbox_id = self.inner_client.inbox_id(),);
     let tsfn: ThreadsafeFunction<Vec<Consent>, ErrorStrategy::CalleeHandled> =
@@ -667,7 +669,9 @@ impl Conversations {
     Ok(StreamCloser::new(stream_closer))
   }
 
-  #[napi(ts_args_type = "callback: (err: null | Error, result: any[] | undefined) => void")]
+  #[napi(
+    ts_args_type = "callback: (err: null | Error, result: any[] | undefined) => void, onClose: () => void"
+  )]
   pub fn stream_preferences(
     &self,
     callback: JsFunction,

--- a/bindings_node/test/Client.test.ts
+++ b/bindings_node/test/Client.test.ts
@@ -378,9 +378,14 @@ describe('Streams', () => {
 
     let messages = new Array()
     client2.conversations().syncAllConversations()
-    let stream = client2.conversations().streamAllMessages((msg) => {
-      messages.push(msg)
-    })
+    let stream = client2.conversations().streamAllMessages(
+      (msg) => {
+        messages.push(msg)
+      },
+      () => {
+        console.log('closed')
+      }
+    )
     await stream.waitForReady()
     group.send(encodeTextMessage('Test1'))
     group.send(encodeTextMessage('Test2'))

--- a/bindings_node/test/Conversation.test.ts
+++ b/bindings_node/test/Conversation.test.ts
@@ -284,10 +284,15 @@ describe.concurrent('Conversation', () => {
     expect(conversations[0].conversation.id()).toBe(conversation.id())
 
     const streamedMessages: string[] = []
-    const stream = conversations[0].conversation.stream((_, message) => {
-      streamedMessages.push(message!.id)
-    })
-
+    const stream = conversations[0].conversation.stream(
+      (_, message) => {
+        streamedMessages.push(message!.id)
+      },
+      () => {
+        console.log('closed')
+      }
+    )
+    await new Promise((resolve) => setTimeout(resolve, 10000))
     const message1 = await conversation.send(encodeTextMessage('gm'))
     const message2 = await conversation.send(encodeTextMessage('gm2'))
 

--- a/bindings_node/test/Conversations.test.ts
+++ b/bindings_node/test/Conversations.test.ts
@@ -462,9 +462,14 @@ describe('Conversations', () => {
     const client3 = await createRegisteredClient(user3)
     const client4 = await createRegisteredClient(user4)
     let groups: Conversation[] = []
-    const stream = client3.conversations().stream((err, convo) => {
-      groups.push(convo!)
-    })
+    const stream = client3.conversations().stream(
+      (err, convo) => {
+        groups.push(convo!)
+      },
+      () => {
+        console.log('closed')
+      }
+    )
     const group1 = await client1.conversations().createGroup([
       {
         identifier: user3.account.address,
@@ -499,9 +504,15 @@ describe('Conversations', () => {
     const client3 = await createRegisteredClient(user3)
     const client4 = await createRegisteredClient(user4)
     let groups: Conversation[] = []
-    const stream = client3.conversations().stream((err, convo) => {
-      groups.push(convo!)
-    }, ConversationType.Group)
+    const stream = client3.conversations().stream(
+      (err, convo) => {
+        groups.push(convo!)
+      },
+      () => {
+        console.log('clossed')
+      },
+      ConversationType.Group
+    )
     const group3 = await client4.conversations().createDm({
       identifier: user3.account.address,
       identifierKind: IdentifierKind.Ethereum,
@@ -536,9 +547,15 @@ describe('Conversations', () => {
     const client3 = await createRegisteredClient(user3)
     const client4 = await createRegisteredClient(user4)
     let groups: Conversation[] = []
-    const stream = client3.conversations().stream((err, convo) => {
-      groups.push(convo!)
-    }, ConversationType.Dm)
+    const stream = client3.conversations().stream(
+      (err, convo) => {
+        groups.push(convo!)
+      },
+      () => {
+        console.log('closed')
+      },
+      ConversationType.Dm
+    )
     const group1 = await client1.conversations().createGroup([
       {
         identifier: user3.account.address,
@@ -594,6 +611,9 @@ describe('Conversations', () => {
       (err, message) => {
         messages.push(message!)
       },
+      () => {
+        console.log('closed')
+      },
       undefined,
       [ConsentState.Allowed, ConsentState.Unknown]
     )
@@ -602,6 +622,9 @@ describe('Conversations', () => {
     const stream2 = client2.conversations().streamAllMessages(
       (err, message) => {
         messages2.push(message!)
+      },
+      () => {
+        console.log('closed')
       },
       undefined,
       [ConsentState.Allowed, ConsentState.Unknown]
@@ -612,6 +635,9 @@ describe('Conversations', () => {
       (err, message) => {
         messages3.push(message!)
       },
+      () => {
+        console.log('closed')
+      },
       undefined,
       [ConsentState.Allowed, ConsentState.Unknown]
     )
@@ -620,6 +646,9 @@ describe('Conversations', () => {
     const stream4 = client4.conversations().streamAllMessages(
       (err, message) => {
         messages4.push(message!)
+      },
+      () => {
+        console.log('closed')
       },
       undefined,
       [ConsentState.Allowed, ConsentState.Unknown]
@@ -690,9 +719,15 @@ describe('Conversations', () => {
     })
 
     let messages: Message[] = []
-    const stream = client1.conversations().streamAllMessages((err, message) => {
-      messages.push(message!)
-    }, ConversationType.Group)
+    const stream = client1.conversations().streamAllMessages(
+      (err, message) => {
+        messages.push(message!)
+      },
+      () => {
+        console.log('closed')
+      },
+      ConversationType.Group
+    )
 
     const groups2 = client2.conversations()
     await groups2.sync()
@@ -748,9 +783,15 @@ describe('Conversations', () => {
     })
 
     let messages: Message[] = []
-    const stream = client1.conversations().streamAllMessages((err, message) => {
-      messages.push(message!)
-    }, ConversationType.Dm)
+    const stream = client1.conversations().streamAllMessages(
+      (err, message) => {
+        messages.push(message!)
+      },
+      () => {
+        console.log('closed')
+      },
+      ConversationType.Dm
+    )
 
     const groups2 = client2.conversations()
     await groups2.sync()

--- a/bindings_wasm/src/conversation.rs
+++ b/bindings_wasm/src/conversation.rs
@@ -512,6 +512,7 @@ impl Conversation {
         Ok(item) => callback.on_message(item.into()),
         Err(e) => callback.on_error(JsError::from(e)),
       },
+      move || {},
     );
 
     Ok(StreamCloser::new(stream_closer))

--- a/bindings_wasm/src/conversations.rs
+++ b/bindings_wasm/src/conversations.rs
@@ -565,6 +565,7 @@ impl Conversations {
         Ok(item) => callback.on_conversation(item.into()),
         Err(e) => callback.on_error(JsError::from(e)),
       },
+      move || {},
     );
 
     Ok(StreamCloser::new(stream_closer))
@@ -588,37 +589,40 @@ impl Conversations {
         Ok(m) => callback.on_message(m.into()),
         Err(e) => callback.on_error(JsError::from(e)),
       },
+      move || {},
     );
     Ok(StreamCloser::new(stream_closer))
   }
 
   #[wasm_bindgen(js_name = "streamConsent")]
   pub fn stream_consent(&self, callback: StreamCallback) -> Result<StreamCloser, JsError> {
-    let stream_closer =
-      RustXmtpClient::stream_consent_with_callback(self.inner_client.clone(), move |message| {
-        match message {
-          Ok(m) => {
-            let array = m.into_iter().map(Consent::from).collect::<Vec<Consent>>();
-            let value = serde_wasm_bindgen::to_value(&array).unwrap_throw();
-            callback.on_consent_update(value)
-          }
-          Err(e) => callback.on_error(JsError::from(e)),
+    let stream_closer = RustXmtpClient::stream_consent_with_callback(
+      self.inner_client.clone(),
+      move |message| match message {
+        Ok(m) => {
+          let array = m.into_iter().map(Consent::from).collect::<Vec<Consent>>();
+          let value = serde_wasm_bindgen::to_value(&array).unwrap_throw();
+          callback.on_consent_update(value)
         }
-      });
+        Err(e) => callback.on_error(JsError::from(e)),
+      },
+      move || {},
+    );
     Ok(StreamCloser::new(stream_closer))
   }
 
   #[wasm_bindgen(js_name = "streamPreferences")]
   pub fn stream_preferences(&self, callback: StreamCallback) -> Result<StreamCloser, JsError> {
-    let stream_closer =
-      RustXmtpClient::stream_preferences_with_callback(self.inner_client.clone(), move |message| {
-        match message {
-          Ok(m) => {
-            callback.on_user_preference_update(m.into_iter().map(UserPreference::from).collect())
-          }
-          Err(e) => callback.on_error(JsError::from(e)),
+    let stream_closer = RustXmtpClient::stream_preferences_with_callback(
+      self.inner_client.clone(),
+      move |message| match message {
+        Ok(m) => {
+          callback.on_user_preference_update(m.into_iter().map(UserPreference::from).collect())
         }
-      });
+        Err(e) => callback.on_error(JsError::from(e)),
+      },
+      move || {},
+    );
     Ok(StreamCloser::new(stream_closer))
   }
 }

--- a/bindings_wasm/src/tests/web.rs
+++ b/bindings_wasm/src/tests/web.rs
@@ -4,6 +4,7 @@ use crate::opfs::Opfs;
 // Only run these tests in a browser.
 wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
+#[ignore]
 #[wasm_bindgen_test]
 pub async fn wipe_client_files() {
   xmtp_db::init_sqlite().await;

--- a/xmtp_mls/src/subscriptions/mod.rs
+++ b/xmtp_mls/src/subscriptions/mod.rs
@@ -267,6 +267,7 @@ where
             + 'static,
         #[cfg(target_arch = "wasm32")] mut convo_callback: impl FnMut(Result<MlsGroup<ApiClient, Db>>)
             + 'static,
+        on_close: impl FnOnce() + Send + 'static,
     ) -> impl StreamHandle<StreamOutput = Result<()>> {
         let (tx, rx) = oneshot::channel();
 
@@ -278,6 +279,7 @@ where
                 convo_callback(convo)
             }
             tracing::debug!("`stream_conversations` stream ended, dropping stream");
+            on_close();
             Ok::<_, SubscribeError>(())
         })
     }
@@ -298,6 +300,22 @@ where
         StreamAllMessages::new(&self.context, conversation_type, consent_state).await
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub async fn stream_all_messages_owned(
+        &self,
+        conversation_type: Option<ConversationType>,
+        consent_state: Option<Vec<ConsentState>>,
+    ) -> Result<impl Stream<Item = Result<StoredGroupMessage>> + 'static> {
+        tracing::debug!(
+            inbox_id = self.inbox_id(),
+            installation_id = %self.context().installation_public_key(),
+            conversation_type = ?conversation_type,
+            "stream all messages"
+        );
+
+        StreamAllMessages::new_owned(self.context.clone(), conversation_type, consent_state).await
+    }
+
     pub fn stream_all_messages_with_callback(
         client: Arc<Client<ApiClient, Db>>,
         conversation_type: Option<ConversationType>,
@@ -306,6 +324,7 @@ where
             + Send
             + 'static,
         #[cfg(target_arch = "wasm32")] mut callback: impl FnMut(Result<StoredGroupMessage>) + 'static,
+        on_close: impl FnOnce() + Send + 'static,
     ) -> impl StreamHandle<StreamOutput = Result<()>> {
         let (tx, rx) = oneshot::channel();
 
@@ -320,6 +339,7 @@ where
                 callback(message)
             }
             tracing::debug!("`stream_all_messages` stream ended, dropping stream");
+            on_close();
             Ok::<_, SubscribeError>(())
         })
     }
@@ -331,6 +351,7 @@ where
             + 'static,
         #[cfg(target_arch = "wasm32")] mut callback: impl FnMut(Result<Vec<StoredConsentRecord>>)
             + 'static,
+        on_close: impl FnOnce() + Send + 'static,
     ) -> impl StreamHandle<StreamOutput = Result<()>> {
         let (tx, rx) = oneshot::channel();
 
@@ -344,6 +365,7 @@ where
                 callback(message)
             }
             tracing::debug!("`stream_consent` stream ended, dropping stream");
+            on_close();
             Ok::<_, SubscribeError>(())
         })
     }
@@ -354,6 +376,7 @@ where
             + Send
             + 'static,
         #[cfg(target_arch = "wasm32")] mut callback: impl FnMut(Result<Vec<PreferenceUpdate>>) + 'static,
+        on_close: impl FnOnce() + Send + 'static,
     ) -> impl StreamHandle<StreamOutput = Result<()>> {
         let (tx, rx) = oneshot::channel();
 
@@ -367,6 +390,7 @@ where
                 callback(message)
             }
             tracing::debug!("`stream_consent` stream ended, dropping stream");
+            on_close();
             Ok::<_, SubscribeError>(())
         })
     }

--- a/xmtp_mls/src/subscriptions/stream_all.rs
+++ b/xmtp_mls/src/subscriptions/stream_all.rs
@@ -2,6 +2,7 @@
 mod tests;
 
 use std::{
+    borrow::Cow,
     pin::Pin,
     sync::Arc,
     task::{ready, Context, Poll},
@@ -37,9 +38,30 @@ pin_project! {
     pub(super) struct StreamAllMessages<'a, ApiClient, Db, Conversations, Messages> {
         #[pin] conversations: Conversations,
         #[pin] messages: Messages,
-        context: &'a XmtpMlsLocalContext<ApiClient, Db>,
+        context: Cow<'a, Arc<XmtpMlsLocalContext<ApiClient, Db>>>,
         conversation_type: Option<ConversationType>,
         sync_groups: Vec<Vec<u8>>
+    }
+}
+
+impl<A, D>
+    StreamAllMessages<
+        'static,
+        A,
+        D,
+        StreamConversations<'static, A, D, WelcomesApiSubscription<'static, A>>,
+        StreamGroupMessages<'static, A, D, MessagesApiSubscription<'static, A>>,
+    >
+where
+    A: XmtpApi + XmtpMlsStreams + Send + Sync + 'static,
+    D: XmtpDb + Send + Sync + 'static,
+{
+    pub async fn new_owned(
+        context: Arc<XmtpMlsLocalContext<A, D>>,
+        conversation_type: Option<ConversationType>,
+        consent_states: Option<Vec<ConsentState>>,
+    ) -> Result<Self> {
+        Self::from_cow(Cow::Owned(context), conversation_type, consent_states).await
     }
 }
 
@@ -60,9 +82,19 @@ where
         conversation_type: Option<ConversationType>,
         consent_states: Option<Vec<ConsentState>>,
     ) -> Result<Self> {
+        Self::from_cow(Cow::Borrowed(context), conversation_type, consent_states).await
+    }
+
+    pub async fn from_cow(
+        context: Cow<'a, Arc<XmtpMlsLocalContext<A, D>>>,
+        conversation_type: Option<ConversationType>,
+        consent_states: Option<Vec<ConsentState>>,
+    ) -> Result<Self> {
         let (active_conversations, sync_groups) = async {
             let provider = context.mls_provider();
-            WelcomeService::new(context.clone()).sync_welcomes().await?;
+            WelcomeService::new(context.as_ref().clone())
+                .sync_welcomes()
+                .await?;
 
             track!(
                 "Message Stream Connect",
@@ -103,10 +135,12 @@ where
         }
         .await?;
 
-        let conversations =
-            super::stream_conversations::StreamConversations::new(context, conversation_type)
-                .await?;
-        let messages = StreamGroupMessages::new(context, active_conversations).await?;
+        let conversations = super::stream_conversations::StreamConversations::from_cow(
+            context.clone(),
+            conversation_type,
+        )
+        .await?;
+        let messages = StreamGroupMessages::from_cow(context.clone(), active_conversations).await?;
 
         Ok(Self {
             context,

--- a/xmtp_mls/src/subscriptions/stream_conversations.rs
+++ b/xmtp_mls/src/subscriptions/stream_conversations.rs
@@ -220,10 +220,10 @@ where
         context: &'a Arc<XmtpMlsLocalContext<A, D>>,
         conversation_type: Option<ConversationType>,
     ) -> Result<Self> {
-        Self::init(Cow::Borrowed(context), conversation_type).await
+        Self::from_cow(Cow::Borrowed(context), conversation_type).await
     }
 
-    async fn init(
+    pub async fn from_cow(
         context: Cow<'a, Arc<XmtpMlsLocalContext<A, D>>>,
         conversation_type: Option<ConversationType>,
     ) -> Result<Self> {
@@ -272,7 +272,7 @@ where
         context: Arc<XmtpMlsLocalContext<A, D>>,
         conversation_type: Option<ConversationType>,
     ) -> Result<Self> {
-        Self::init(Cow::Owned(context), conversation_type).await
+        Self::from_cow(Cow::Owned(context), conversation_type).await
     }
 }
 

--- a/xmtp_mls/src/utils/test/mod.rs
+++ b/xmtp_mls/src/utils/test/mod.rs
@@ -71,6 +71,7 @@ impl ClientBuilder<TestClient> {
             .await
             .unwrap()
     }
+
     pub async fn new_localhost_api_client() -> TestClient {
         <TestClient as XmtpTestClient>::create_local()
             .build()

--- a/xmtp_mls/src/utils/test/tester_utils.rs
+++ b/xmtp_mls/src/utils/test/tester_utils.rs
@@ -222,6 +222,7 @@ where
             None,
             None,
             |_| {},
+            || {},
         );
         let handle = Box::new(handle) as Box<_>;
         self.stream_handle = Some(handle);


### PR DESCRIPTION
### Add on_close callback parameter to stream methods across FFI, Node.js, and WASM bindings for stream close notifications
This change adds `on_close` callback parameters to streaming methods across multiple binding layers to enable notifications when streams are closed. The implementation includes:

- Core streaming infrastructure in [xmtp_mls/src/subscriptions/mod.rs](https://github.com/xmtp/libxmtp/pull/2153/files#diff-0f2359cebb61635cf35774bc0c5e5a5f4b8703e982c2f584e8691cef4d4c2e32) and [xmtp_mls/src/groups/subscriptions.rs](https://github.com/xmtp/libxmtp/pull/2153/files#diff-0ebfb9bab092533d3b4530da36a596278d18995a1454a189bf581249f03e5667) now accepts `on_close` callbacks that are invoked when streams end
- Stream context handling refactored to use `Cow<Arc<XmtpMlsLocalContext>>` in [xmtp_mls/src/subscriptions/stream_all.rs](https://github.com/xmtp/libxmtp/pull/2153/files#diff-4a3d32ed6005867d963b0eae023dc9c1fd8ffd9531413ba572f4287210a18cc1) and [xmtp_mls/src/subscriptions/stream_messages.rs](https://github.com/xmtp/libxmtp/pull/2153/files#diff-ee8c2d1c90650351a2245875b62af09f2c152c29643200276da5743cd59424e7) to support both borrowed and owned contexts
- Node.js bindings in [bindings_node/src/conversations.rs](https://github.com/xmtp/libxmtp/pull/2153/files#diff-305d8a9df912ee15a450791cf1af33e26798a0a4877f6a4dc457d291914bc126) and [bindings_node/src/conversation.rs](https://github.com/xmtp/libxmtp/pull/2153/files#diff-d87172f473cc087eb00db1b730396f12f232ebf80aa7cb1b60ed661a8b117886) implement threadsafe callback handling for `stream`, `stream_all_messages`, `stream_consent`, and `stream_preferences` methods
- FFI and WASM bindings in [bindings_ffi/src/mls.rs](https://github.com/xmtp/libxmtp/pull/2153/files#diff-3a24c3e76565487a710ac9863ac05160128f4f90892e07849b555a6de43a6e8f), [bindings_wasm/src/conversations.rs](https://github.com/xmtp/libxmtp/pull/2153/files#diff-c5fb7781a0d2662984db637d31e1a03c6521210a1717f5594327876c0ecc6500), and [bindings_wasm/src/conversation.rs](https://github.com/xmtp/libxmtp/pull/2153/files#diff-106fd4741a71a89abefb1837cde5785b14100381cea3bf577416671c49bae37e) add empty closure placeholders for the new parameter
- Test files updated to include the new required `on_close` parameter with simple logging callbacks

#### 📍Where to Start
Start with the core streaming functions in [xmtp_mls/src/subscriptions/mod.rs](https://github.com/xmtp/libxmtp/pull/2153/files#diff-0f2359cebb61635cf35774bc0c5e5a5f4b8703e982c2f584e8691cef4d4c2e32), specifically the `stream_conversations_with_callback`, `stream_all_messages_with_callback`, `stream_consent_with_callback`, and `stream_preferences_with_callback` functions to understand how the `on_close` callback parameter is integrated into the streaming architecture.



#### Changes since #2153 opened

- Updated TypeScript type annotations for streaming methods to include missing `onClose` callback parameter [0f26efb]
- Modified test execution behavior in `bindings_wasm` package [eef5fee]
----

_[Macroscope](https://app.macroscope.com) summarized eef5fee._