### PR TITLE
on close callbacks in bindings

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -1518,6 +1518,7 @@ impl FfiConversations {
                 Ok(c) => callback.on_conversation(Arc::new(c.into())),
                 Err(e) => callback.on_error(e.into()),
             },
+            move || {},
         );
 
         FfiStreamCloser::new(handle)
@@ -1532,6 +1533,7 @@ impl FfiConversations {
                 Ok(c) => callback.on_conversation(Arc::new(c.into())),
                 Err(e) => callback.on_error(e.into()),
             },
+            move || {},
         );
 
         FfiStreamCloser::new(handle)
@@ -1546,6 +1548,7 @@ impl FfiConversations {
                 Ok(c) => callback.on_conversation(Arc::new(c.into())),
                 Err(e) => callback.on_error(e.into()),
             },
+            move || {},
         );
 
         FfiStreamCloser::new(handle)
@@ -1602,6 +1605,7 @@ impl FfiConversations {
                 Ok(m) => message_callback.on_message(m.into()),
                 Err(e) => message_callback.on_error(e.into()),
             },
+            move || {},
         );
 
         FfiStreamCloser::new(handle)
@@ -1610,13 +1614,14 @@ impl FfiConversations {
     /// Get notified when there is a new consent update either locally or is synced from another device
     /// allowing the user to re-render the new state appropriately
     pub async fn stream_consent(&self, callback: Arc<dyn FfiConsentCallback>) -> FfiStreamCloser {
-        let handle =
-            RustXmtpClient::stream_consent_with_callback(self.inner_client.clone(), move |msg| {
-                match msg {
-                    Ok(m) => callback.on_consent_update(m.into_iter().map(Into::into).collect()),
-                    Err(e) => callback.on_error(e.into()),
-                }
-            });
+        let handle = RustXmtpClient::stream_consent_with_callback(
+            self.inner_client.clone(),
+            move |msg| match msg {
+                Ok(m) => callback.on_consent_update(m.into_iter().map(Into::into).collect()),
+                Err(e) => callback.on_error(e.into()),
+            },
+            move || {},
+        );
 
         FfiStreamCloser::new(handle)
     }
@@ -1635,6 +1640,7 @@ impl FfiConversations {
                 ),
                 Err(e) => callback.on_error(e.into()),
             },
+            move || {},
         );
 
         FfiStreamCloser::new(handle)
@@ -2317,13 +2323,15 @@ impl FfiConversation {
     }
 
     pub async fn stream(&self, message_callback: Arc<dyn FfiMessageCallback>) -> FfiStreamCloser {
-        let handle =
-            MlsGroup::stream_with_callback(self.inner.context.clone(), self.id(), move |message| {
-                match message {
-                    Ok(m) => message_callback.on_message(m.into()),
-                    Err(e) => message_callback.on_error(e.into()),
-                }
-            });
+        let handle = MlsGroup::stream_with_callback(
+            self.inner.context.clone(),
+            self.id(),
+            move |message| match message {
+                Ok(m) => message_callback.on_message(m.into()),
+                Err(e) => message_callback.on_error(e.into()),
+            },
+            move || {},
+        );
 
         FfiStreamCloser::new(handle)
     }

--- a/bindings_node/src/conversation.rs
+++ b/bindings_node/src/conversation.rs
@@ -473,20 +473,26 @@ impl Conversation {
   }
 
   #[napi(ts_args_type = "callback: (err: null | Error, result: Message | undefined) => void")]
-  pub fn stream(&self, callback: JsFunction) -> Result<StreamCloser> {
+  pub fn stream(&self, callback: JsFunction, on_close: JsFunction) -> Result<StreamCloser> {
     let tsfn: ThreadsafeFunction<Message, ErrorStrategy::CalleeHandled> =
       callback.create_threadsafe_function(0, |ctx| Ok(vec![ctx.value]))?;
+    let tsfn_on_close: ThreadsafeFunction<(), ErrorStrategy::CalleeHandled> =
+      on_close.create_threadsafe_function(0, |ctx| Ok(vec![ctx.value]))?;
     let stream_closer = MlsGroup::stream_with_callback(
       self.inner_group.context.clone(),
       self.group_id.clone(),
       move |message| {
-        tsfn.call(
+        let status = tsfn.call(
           message
             .map(Message::from)
             .map_err(ErrorWrapper::from)
             .map_err(napi::Error::from),
           ThreadsafeFunctionCallMode::Blocking,
         );
+        tracing::info!("Stream status: {:?}", status);
+      },
+      move || {
+        tsfn_on_close.call(Ok(()), ThreadsafeFunctionCallMode::Blocking);
       },
     );
 

--- a/bindings_node/src/conversations.rs
+++ b/bindings_node/src/conversations.rs
@@ -522,21 +522,29 @@ impl Conversations {
   pub fn stream(
     &self,
     callback: JsFunction,
+    on_close: JsFunction,
     conversation_type: Option<ConversationType>,
   ) -> Result<StreamCloser> {
     let tsfn: ThreadsafeFunction<Conversation, ErrorStrategy::CalleeHandled> =
       callback.create_threadsafe_function(0, |ctx| Ok(vec![ctx.value]))?;
+    let tsfn_on_close: ThreadsafeFunction<(), ErrorStrategy::CalleeHandled> =
+      on_close.create_threadsafe_function(0, |ctx| Ok(vec![ctx.value]))?;
+
     let stream_closer = RustXmtpClient::stream_conversations_with_callback(
       self.inner_client.clone(),
       conversation_type.map(|ct| ct.into()),
       move |convo| {
-        tsfn.call(
+        let status = tsfn.call(
           convo
             .map(Conversation::from)
             .map_err(ErrorWrapper::from)
             .map_err(Error::from),
           ThreadsafeFunctionCallMode::Blocking,
         );
+        tracing::info!("Stream status: {:?}", status);
+      },
+      move || {
+        tsfn_on_close.call(Ok(()), ThreadsafeFunctionCallMode::Blocking);
       },
     );
 
@@ -549,6 +557,7 @@ impl Conversations {
   pub fn stream_all_messages(
     &self,
     callback: JsFunction,
+    on_close: JsFunction,
     conversation_type: Option<ConversationType>,
     consent_states: Option<Vec<ConsentState>>,
   ) -> Result<StreamCloser> {
@@ -558,6 +567,9 @@ impl Conversations {
     );
     let tsfn: ThreadsafeFunction<Message, ErrorStrategy::CalleeHandled> =
       callback.create_threadsafe_function(0, |ctx| Ok(vec![ctx.value]))?;
+    let tsfn_on_close: ThreadsafeFunction<(), ErrorStrategy::CalleeHandled> =
+      on_close.create_threadsafe_function(0, |ctx| Ok(vec![ctx.value]))?;
+
     let inbox_id = self.inner_client.inbox_id().to_string();
     let consents: Option<Vec<XmtpConsentState>> = consent_states.map(|states| {
       states
@@ -599,7 +611,8 @@ impl Conversations {
               inbox_id,
               "[received] calling tsfn callback with successful message"
             );
-            tsfn.call(Ok(transformed_msg), ThreadsafeFunctionCallMode::Blocking);
+            let status = tsfn.call(Ok(transformed_msg), ThreadsafeFunctionCallMode::Blocking);
+            tracing::info!("Stream status: {:?}", status);
           }
           Err(err) => {
             // Just in case the transformation itself fails
@@ -611,40 +624,58 @@ impl Conversations {
           }
         }
       },
+      move || {
+        tsfn_on_close.call(Ok(()), ThreadsafeFunctionCallMode::Blocking);
+      },
     );
 
     Ok(StreamCloser::new(stream_closer))
   }
 
   #[napi(ts_args_type = "callback: (err: null | Error, result: Consent[] | undefined) => void")]
-  pub fn stream_consent(&self, callback: JsFunction) -> Result<StreamCloser> {
+  pub fn stream_consent(&self, callback: JsFunction, on_close: JsFunction) -> Result<StreamCloser> {
     tracing::trace!(inbox_id = self.inner_client.inbox_id(),);
     let tsfn: ThreadsafeFunction<Vec<Consent>, ErrorStrategy::CalleeHandled> =
       callback.create_threadsafe_function(0, |ctx| Ok(vec![ctx.value]))?;
+    let tsfn_on_close: ThreadsafeFunction<(), ErrorStrategy::CalleeHandled> =
+      on_close.create_threadsafe_function(0, |ctx| Ok(vec![ctx.value]))?;
     let inbox_id = self.inner_client.inbox_id().to_string();
-    let stream_closer =
-      RustXmtpClient::stream_consent_with_callback(self.inner_client.clone(), move |message| {
+    let stream_closer = RustXmtpClient::stream_consent_with_callback(
+      self.inner_client.clone(),
+      move |message| {
         tracing::trace!(inbox_id, "[received] calling tsfn callback");
         match message {
           Ok(message) => {
             let msg: Vec<Consent> = message.into_iter().map(Into::into).collect();
-            tsfn.call(Ok(msg), ThreadsafeFunctionCallMode::Blocking);
+            let status = tsfn.call(Ok(msg), ThreadsafeFunctionCallMode::Blocking);
+            tracing::info!("Stream status: {:?}", status);
           }
           Err(e) => {
-            tsfn.call(
+            let status = tsfn.call(
               Err(Error::from(ErrorWrapper::from(e))),
               ThreadsafeFunctionCallMode::Blocking,
             );
+            tracing::info!("Stream status: {:?}", status);
           }
         }
-      });
+      },
+      move || {
+        tsfn_on_close.call(Ok(()), ThreadsafeFunctionCallMode::Blocking);
+      },
+    );
 
     Ok(StreamCloser::new(stream_closer))
   }
 
   #[napi(ts_args_type = "callback: (err: null | Error, result: any[] | undefined) => void")]
-  pub fn stream_preferences(&self, callback: JsFunction) -> Result<StreamCloser> {
+  pub fn stream_preferences(
+    &self,
+    callback: JsFunction,
+    on_close: JsFunction,
+  ) -> Result<StreamCloser> {
     tracing::trace!(inbox_id = self.inner_client.inbox_id(),);
+    let tsfn_on_close: ThreadsafeFunction<(), ErrorStrategy::CalleeHandled> =
+      on_close.create_threadsafe_function(0, |ctx| Ok(vec![ctx.value]))?;
     let tsfn: ThreadsafeFunction<Vec<Tag<UserPreferenceUpdate>>, ErrorStrategy::CalleeHandled> =
       callback.create_threadsafe_function(
         0,
@@ -658,8 +689,9 @@ impl Conversations {
         },
       )?;
     let inbox_id = self.inner_client.inbox_id().to_string();
-    let stream_closer =
-      RustXmtpClient::stream_preferences_with_callback(self.inner_client.clone(), move |message| {
+    let stream_closer = RustXmtpClient::stream_preferences_with_callback(
+      self.inner_client.clone(),
+      move |message| {
         tracing::trace!(inbox_id, "[received] calling tsfn callback");
         match message {
           Ok(message) => {
@@ -667,16 +699,23 @@ impl Conversations {
               .into_iter()
               .map(Tag::<UserPreferenceUpdate>::from)
               .collect();
-            tsfn.call(Ok(msg), ThreadsafeFunctionCallMode::Blocking);
+            let status = tsfn.call(Ok(msg), ThreadsafeFunctionCallMode::Blocking);
+            tracing::info!("Stream status: {:?}", status);
           }
           Err(e) => {
-            tsfn.call(
+            let status = tsfn.call(
               Err(Error::from(ErrorWrapper::from(e))),
               ThreadsafeFunctionCallMode::Blocking,
             );
+            tracing::info!("Stream status: {:?}", status);
           }
         }
-      });
+      },
+      move || {
+        let status = tsfn_on_close.call(Ok(()), ThreadsafeFunctionCallMode::Blocking);
+        tracing::info!("stream on close status {:?}", status);
+      },
+    );
 
     Ok(StreamCloser::new(stream_closer))
   }

--- a/bindings_node/test/Client.test.ts
+++ b/bindings_node/test/Client.test.ts
@@ -378,9 +378,14 @@ describe('Streams', () => {
 
     let messages = new Array()
     client2.conversations().syncAllConversations()
-    let stream = client2.conversations().streamAllMessages((msg) => {
-      messages.push(msg)
-    })
+    let stream = client2.conversations().streamAllMessages(
+      (msg) => {
+        messages.push(msg)
+      },
+      () => {
+        console.log('closed')
+      }
+    )
     await stream.waitForReady()
     group.send(encodeTextMessage('Test1'))
     group.send(encodeTextMessage('Test2'))

--- a/bindings_node/test/Conversation.test.ts
+++ b/bindings_node/test/Conversation.test.ts
@@ -284,10 +284,15 @@ describe.concurrent('Conversation', () => {
     expect(conversations[0].conversation.id()).toBe(conversation.id())
 
     const streamedMessages: string[] = []
-    const stream = conversations[0].conversation.stream((_, message) => {
-      streamedMessages.push(message!.id)
-    })
-
+    const stream = conversations[0].conversation.stream(
+      (_, message) => {
+        streamedMessages.push(message!.id)
+      },
+      () => {
+        console.log('closed')
+      }
+    )
+    await new Promise((resolve) => setTimeout(resolve, 10000))
     const message1 = await conversation.send(encodeTextMessage('gm'))
     const message2 = await conversation.send(encodeTextMessage('gm2'))
 

--- a/bindings_node/test/Conversations.test.ts
+++ b/bindings_node/test/Conversations.test.ts
@@ -458,9 +458,14 @@ describe('Conversations', () => {
     const client3 = await createRegisteredClient(user3)
     const client4 = await createRegisteredClient(user4)
     let groups: Conversation[] = []
-    const stream = client3.conversations().stream((err, convo) => {
-      groups.push(convo!)
-    })
+    const stream = client3.conversations().stream(
+      (err, convo) => {
+        groups.push(convo!)
+      },
+      () => {
+        console.log('closed')
+      }
+    )
     const group1 = await client1.conversations().createGroup([
       {
         identifier: user3.account.address,
@@ -495,9 +500,15 @@ describe('Conversations', () => {
     const client3 = await createRegisteredClient(user3)
     const client4 = await createRegisteredClient(user4)
     let groups: Conversation[] = []
-    const stream = client3.conversations().stream((err, convo) => {
-      groups.push(convo!)
-    }, ConversationType.Group)
+    const stream = client3.conversations().stream(
+      (err, convo) => {
+        groups.push(convo!)
+      },
+      () => {
+        console.log('clossed')
+      },
+      ConversationType.Group
+    )
     const group3 = await client4.conversations().createDm({
       identifier: user3.account.address,
       identifierKind: IdentifierKind.Ethereum,
@@ -532,9 +543,15 @@ describe('Conversations', () => {
     const client3 = await createRegisteredClient(user3)
     const client4 = await createRegisteredClient(user4)
     let groups: Conversation[] = []
-    const stream = client3.conversations().stream((err, convo) => {
-      groups.push(convo!)
-    }, ConversationType.Dm)
+    const stream = client3.conversations().stream(
+      (err, convo) => {
+        groups.push(convo!)
+      },
+      () => {
+        console.log('closed')
+      },
+      ConversationType.Dm
+    )
     const group1 = await client1.conversations().createGroup([
       {
         identifier: user3.account.address,
@@ -590,6 +607,9 @@ describe('Conversations', () => {
       (err, message) => {
         messages.push(message!)
       },
+      () => {
+        console.log('closed')
+      },
       undefined,
       [ConsentState.Allowed, ConsentState.Unknown]
     )
@@ -598,6 +618,9 @@ describe('Conversations', () => {
     const stream2 = client2.conversations().streamAllMessages(
       (err, message) => {
         messages2.push(message!)
+      },
+      () => {
+        console.log('closed')
       },
       undefined,
       [ConsentState.Allowed, ConsentState.Unknown]
@@ -608,6 +631,9 @@ describe('Conversations', () => {
       (err, message) => {
         messages3.push(message!)
       },
+      () => {
+        console.log('closed')
+      },
       undefined,
       [ConsentState.Allowed, ConsentState.Unknown]
     )
@@ -616,6 +642,9 @@ describe('Conversations', () => {
     const stream4 = client4.conversations().streamAllMessages(
       (err, message) => {
         messages4.push(message!)
+      },
+      () => {
+        console.log('closed')
       },
       undefined,
       [ConsentState.Allowed, ConsentState.Unknown]
@@ -686,9 +715,15 @@ describe('Conversations', () => {
     })
 
     let messages: Message[] = []
-    const stream = client1.conversations().streamAllMessages((err, message) => {
-      messages.push(message!)
-    }, ConversationType.Group)
+    const stream = client1.conversations().streamAllMessages(
+      (err, message) => {
+        messages.push(message!)
+      },
+      () => {
+        console.log('closed')
+      },
+      ConversationType.Group
+    )
 
     const groups2 = client2.conversations()
     await groups2.sync()
@@ -744,9 +779,15 @@ describe('Conversations', () => {
     })
 
     let messages: Message[] = []
-    const stream = client1.conversations().streamAllMessages((err, message) => {
-      messages.push(message!)
-    }, ConversationType.Dm)
+    const stream = client1.conversations().streamAllMessages(
+      (err, message) => {
+        messages.push(message!)
+      },
+      () => {
+        console.log('closed')
+      },
+      ConversationType.Dm
+    )
 
     const groups2 = client2.conversations()
     await groups2.sync()

--- a/bindings_node/test/helpers.ts
+++ b/bindings_node/test/helpers.ts
@@ -56,7 +56,7 @@ export const createClient = async (user: User) => {
     undefined,
     undefined,
     SyncWorkerMode.disabled,
-    { level: LogLevel.off },
+    { level: LogLevel.Info },
     undefined,
     true
   )

--- a/bindings_wasm/src/conversation.rs
+++ b/bindings_wasm/src/conversation.rs
@@ -512,6 +512,7 @@ impl Conversation {
         Ok(item) => callback.on_message(item.into()),
         Err(e) => callback.on_error(JsError::from(e)),
       },
+      move || {},
     );
 
     Ok(StreamCloser::new(stream_closer))

--- a/bindings_wasm/src/conversations.rs
+++ b/bindings_wasm/src/conversations.rs
@@ -565,6 +565,7 @@ impl Conversations {
         Ok(item) => callback.on_conversation(item.into()),
         Err(e) => callback.on_error(JsError::from(e)),
       },
+      move || {},
     );
 
     Ok(StreamCloser::new(stream_closer))
@@ -588,37 +589,40 @@ impl Conversations {
         Ok(m) => callback.on_message(m.into()),
         Err(e) => callback.on_error(JsError::from(e)),
       },
+      move || {},
     );
     Ok(StreamCloser::new(stream_closer))
   }
 
   #[wasm_bindgen(js_name = "streamConsent")]
   pub fn stream_consent(&self, callback: StreamCallback) -> Result<StreamCloser, JsError> {
-    let stream_closer =
-      RustXmtpClient::stream_consent_with_callback(self.inner_client.clone(), move |message| {
-        match message {
-          Ok(m) => {
-            let array = m.into_iter().map(Consent::from).collect::<Vec<Consent>>();
-            let value = serde_wasm_bindgen::to_value(&array).unwrap_throw();
-            callback.on_consent_update(value)
-          }
-          Err(e) => callback.on_error(JsError::from(e)),
+    let stream_closer = RustXmtpClient::stream_consent_with_callback(
+      self.inner_client.clone(),
+      move |message| match message {
+        Ok(m) => {
+          let array = m.into_iter().map(Consent::from).collect::<Vec<Consent>>();
+          let value = serde_wasm_bindgen::to_value(&array).unwrap_throw();
+          callback.on_consent_update(value)
         }
-      });
+        Err(e) => callback.on_error(JsError::from(e)),
+      },
+      move || {},
+    );
     Ok(StreamCloser::new(stream_closer))
   }
 
   #[wasm_bindgen(js_name = "streamPreferences")]
   pub fn stream_preferences(&self, callback: StreamCallback) -> Result<StreamCloser, JsError> {
-    let stream_closer =
-      RustXmtpClient::stream_preferences_with_callback(self.inner_client.clone(), move |message| {
-        match message {
-          Ok(m) => {
-            callback.on_user_preference_update(m.into_iter().map(UserPreference::from).collect())
-          }
-          Err(e) => callback.on_error(JsError::from(e)),
+    let stream_closer = RustXmtpClient::stream_preferences_with_callback(
+      self.inner_client.clone(),
+      move |message| match message {
+        Ok(m) => {
+          callback.on_user_preference_update(m.into_iter().map(UserPreference::from).collect())
         }
-      });
+        Err(e) => callback.on_error(JsError::from(e)),
+      },
+      move || {},
+    );
     Ok(StreamCloser::new(stream_closer))
   }
 }

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -586,7 +586,7 @@ where
                     result.err()
                 );
             } else {
-                let (group, _) = result.unwrap();
+                let (group, _) = result.expect("checked for error");
                 // Check the group epoch as well, because we may not have synced the latest is_active state
                 // TODO(rich): Design a better way to detect if incoming welcomes are valid
                 if group.is_active()?


### PR DESCRIPTION
### Add on close callbacks to streaming methods in Node.js bindings for conversation and conversations modules
- Modifies streaming methods in [bindings_node/src/conversation.rs](https://github.com/xmtp/libxmtp/pull/2154/files#diff-d87172f473cc087eb00db1b730396f12f232ebf80aa7cb1b60ed661a8b117886) and [bindings_node/src/conversations.rs](https://github.com/xmtp/libxmtp/pull/2154/files#diff-305d8a9df912ee15a450791cf1af33e26798a0a4877f6a4dc457d291914bc126) to accept an additional `on_close: JsFunction` parameter that creates threadsafe functions called when streams are closed
- Updates streaming methods including `stream`, `stream_all_messages`, `stream_consent`, and `stream_preferences` to pass closure callbacks to their respective underlying streaming functions
- Adds `tracing::info!` logging of stream status after each callback invocation in both modules
- Updates test files [bindings_node/test/Client.test.ts](https://github.com/xmtp/libxmtp/pull/2154/files#diff-32a11487468143d5cfc69e5457f7bfab2f05c4a486fef691bd8796384326c95e), [bindings_node/test/Conversation.test.ts](https://github.com/xmtp/libxmtp/pull/2154/files#diff-b10c8d996e831d6d89def96277ae0395c5e7ed4422f20b01c468f9c411f1e5c0), and [bindings_node/test/Conversations.test.ts](https://github.com/xmtp/libxmtp/pull/2154/files#diff-2d2b8de39b39ebe052b06ef17ea6993a04def81ad8062078d799151ff5580b4d) to include the new required `on_close` callback parameter
- Changes log level from `LogLevel.off` to `LogLevel.Info` in [bindings_node/test/helpers.ts](https://github.com/xmtp/libxmtp/pull/2154/files#diff-6635fc0b611756360d73123e1be725ccb54df88f4c30657346ce555d01bc8601)

#### 📍Where to Start
Start with the `stream` method in [bindings_node/src/conversation.rs](https://github.com/xmtp/libxmtp/pull/2154/files#diff-d87172f473cc087eb00db1b730396f12f232ebf80aa7cb1b60ed661a8b117886) to understand how the `on_close` callback parameter is implemented and integrated with the existing streaming functionality.

----

_[Macroscope](https://app.macroscope.com) summarized f4d6fcb._ (Automatic summaries will resume when PR exits draft mode or review begins).