### PR TITLE
pin rust to 1.88 in nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -165,13 +165,13 @@
     "rust-manifest": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-BwfxWd/E8gpnXoKsucFXhMbevMlVgw3l0becLkIcWCU=",
+        "narHash": "sha256-YZfjbpqCYQFG1qLl2zMyFq2nFwmB2aFo5DSOCaBtGLY=",
         "type": "file",
-        "url": "https://static.rust-lang.org/dist/channel-rust-stable.toml"
+        "url": "https://static.rust-lang.org/dist/channel-rust-1.88.0.toml"
       },
       "original": {
         "type": "file",
-        "url": "https://static.rust-lang.org/dist/channel-rust-stable.toml"
+        "url": "https://static.rust-lang.org/dist/channel-rust-1.88.0.toml"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
       url = "github:ipetkov/crane";
     };
     rust-manifest = {
-      url = "https://static.rust-lang.org/dist/channel-rust-stable.toml";
+      url = "https://static.rust-lang.org/dist/channel-rust-1.88.0.toml";
       flake = false;
     };
   };


### PR DESCRIPTION
### Pin Rust toolchain to version 1.88.0 in Nix flake configuration
Changes the Rust manifest URL in the Nix flake from the stable channel to a specific version (1.88.0), updating both [flake.nix](https://github.com/xmtp/libxmtp/pull/2155/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0) and [flake.lock](https://github.com/xmtp/libxmtp/pull/2155/files#diff-216b2b7bfde9416c79d133bacb031e95702a20bdedb548c0b055c837aa4f6a9c) to reference `https://static.rust-lang.org/dist/channel-rust-1.88.0.toml` instead of the stable channel manifest.

#### 📍Where to Start
Start with the inputs section in [flake.nix](https://github.com/xmtp/libxmtp/pull/2155/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0) where the Rust manifest URL has been changed.

----

_[Macroscope](https://app.macroscope.com) summarized 0e04aaa._