### PR TITLE
Increase max payload size to 25mb

### DIFF
--- a/xmtp_api/src/mls.rs
+++ b/xmtp_api/src/mls.rs
@@ -371,7 +371,12 @@ pub mod tests {
     use crate::*;
 
     use crate::test_utils::MockError;
+    use xmtp_common::rand_vec;
     use xmtp_proto::api_client::ApiBuilder;
+    use xmtp_proto::mls_v1::{
+        welcome_message_input::{Version as WelcomeVersion, V1 as WelcomeV1},
+        WelcomeMessageInput,
+    };
     use xmtp_proto::xmtp::mls::api::v1::{
         fetch_key_packages_response::KeyPackage, FetchKeyPackagesResponse, PagingInfo,
         QueryGroupMessagesResponse,
@@ -597,5 +602,43 @@ pub mod tests {
         let now = std::time::Instant::now();
         let _second = wrapper.query_group_messages(vec![0, 0], None).await;
         assert!(now.elapsed() > std::time::Duration::from_secs(60));
+    }
+
+    #[xmtp_common::test]
+    #[cfg_attr(feature = "http-api", ignore)]
+    async fn it_should_allow_large_payloads() {
+        let mut client = crate::tests::TestClient::builder();
+        client.set_host("http://localhost:5556".into());
+        client.set_tls(false);
+        client.set_app_version("0.0.0".into()).unwrap();
+        let installation_key = rand_vec::<32>();
+        let hpke_public_key = rand_vec::<32>();
+
+        let c = client.build().await.unwrap();
+        let wrapper = ApiClientWrapper::new(c, Retry::default());
+
+        let mut very_large_payload = vec![];
+        // rand_vec overflows over 1mb, so we break it up
+        for _ in 0..10 {
+            very_large_payload.extend(rand_vec::<900000>());
+        }
+
+        wrapper
+            .send_welcome_messages(&[WelcomeMessageInput {
+                version: Some(WelcomeVersion::V1(WelcomeV1 {
+                    installation_key: installation_key.clone(),
+                    data: very_large_payload,
+                    hpke_public_key: hpke_public_key.clone(),
+                    wrapper_algorithm: 0,
+                })),
+            }])
+            .await
+            .unwrap();
+
+        let messages = wrapper
+            .query_welcome_messages(&installation_key, None)
+            .await
+            .unwrap();
+        assert_eq!(messages.len(), 1);
     }
 }

--- a/xmtp_api_grpc/src/grpc_client.rs
+++ b/xmtp_api_grpc/src/grpc_client.rs
@@ -10,7 +10,7 @@ use xmtp_proto::{
     traits::{ApiClientError, Client},
 };
 
-use crate::{create_tls_channel, GrpcBuilderError, GrpcError};
+use crate::{create_tls_channel, GrpcBuilderError, GrpcError, GRPC_PAYLOAD_LIMIT};
 
 impl From<GrpcError> for ApiClientError<GrpcError> {
     fn from(source: GrpcError) -> ApiClientError<GrpcError> {
@@ -143,7 +143,9 @@ impl ApiBuilder for ClientBuilder {
         };
 
         Ok(GrpcClient {
-            inner: tonic::client::Grpc::new(channel),
+            inner: tonic::client::Grpc::new(channel)
+                .max_decoding_message_size(GRPC_PAYLOAD_LIMIT)
+                .max_encoding_message_size(GRPC_PAYLOAD_LIMIT),
             app_version: self
                 .app_version
                 .unwrap_or(MetadataValue::try_from("0.0.0")?),

--- a/xmtp_api_grpc/src/lib.rs
+++ b/xmtp_api_grpc/src/lib.rs
@@ -6,6 +6,7 @@ mod identity;
 
 pub const LOCALHOST_ADDRESS: &str = "http://localhost:5556";
 pub const DEV_ADDRESS: &str = "https://grpc.dev.xmtp.network:443";
+pub const GRPC_PAYLOAD_LIMIT: usize = 1024 * 1024 * 25;
 
 pub use grpc_api_helper::{Client, GroupMessageStream, WelcomeMessageStream};
 use std::time::Duration;


### PR DESCRIPTION
### TL;DR

Increased gRPC message size limits to support large payloads and added a test to verify this functionality.

### What changed?

- Added a constant `GRPC_MAX_MESSAGE_SIZE` set to 25MB (1024 * 1024 * 25)
- Applied this size limit to gRPC clients in both `grpc_api_helper.rs` and `grpc_client.rs` by setting max encoding and decoding message sizes
- Added a new test `it_should_allow_large_payloads` that verifies the system can handle payloads larger than 1MB

### How to test?

Run the new test that:
1. Creates a very large payload (approximately 9MB)
2. Sends it as a welcome message
3. Verifies the message can be retrieved successfully

```bash
cargo test -p xmtp_api it_should_allow_large_payloads
```

### Why make this change?

The default gRPC message size limit is too small for some use cases. By increasing the limit to 25MB, we can support larger payloads that may be required for certain types of content or operations, particularly for welcome messages that might contain substantial initialization data.