### PR TITLE
Implement MLS validation is_commit

### DIFF
--- a/mls_validation_service/src/handlers.rs
+++ b/mls_validation_service/src/handlers.rs
@@ -1,4 +1,5 @@
 use futures::future::{join_all, try_join_all};
+use openmls::framing::ContentType;
 use openmls::prelude::{tls_codec::Deserialize, MlsMessageIn, ProtocolMessage};
 use openmls_rust_crypto::RustCrypto;
 use tonic::{Request, Response, Status};
@@ -83,13 +84,13 @@ impl ValidationApi for ValidationService {
                         group_id: res.group_id,
                         error_message: "".to_string(),
                         is_ok: true,
-                        is_commit: false, //TODO(mkysel): implement commit validation
+                        is_commit: res.is_commit,
                     },
                     Err(e) => ValidateGroupMessageValidationResponse {
                         group_id: "".to_string(),
                         error_message: e,
                         is_ok: false,
-                        is_commit: false, //TODO(mkysel): implement commit validation
+                        is_commit: false,
                     },
                 }
             })
@@ -279,6 +280,7 @@ async fn get_association_state(
 
 struct ValidateGroupMessageResult {
     group_id: String,
+    is_commit: bool,
 }
 
 fn validate_group_message(message: Vec<u8>) -> Result<ValidateGroupMessageResult, String> {
@@ -291,6 +293,7 @@ fn validate_group_message(message: Vec<u8>) -> Result<ValidateGroupMessageResult
 
     Ok(ValidateGroupMessageResult {
         group_id: serialize_group_id(protocol_message.group_id().as_slice()),
+        is_commit: protocol_message.content_type() == ContentType::Commit,
     })
 }
 


### PR DESCRIPTION
### Implement MLS validation is_commit functionality to properly identify and report commit messages in the validation service
The MLS validation service now correctly identifies commit messages by checking the protocol message's content type and setting the `is_commit` field accordingly in [mls_validation_service/src/handlers.rs](https://github.com/xmtp/libxmtp/pull/2166/files#diff-0dac533f49a810d5fa87ed421f8b17340b94fd2c035322cd6b4f9710f5df7f9a). The implementation adds `ContentType` import from `openmls::framing`, modifies the `validate_group_message` function to check for commit content types, adds an `is_commit` field to the `ValidateGroupMessageResult` struct, and updates the response to use the actual validation result instead of a hardcoded false value.

#### 📍Where to Start
Start with the `validate_group_message` function in [mls_validation_service/src/handlers.rs](https://github.com/xmtp/libxmtp/pull/2166/files#diff-0dac533f49a810d5fa87ed421f8b17340b94fd2c035322cd6b4f9710f5df7f9a) to see how commit detection is implemented.

----

_[Macroscope](https://app.macroscope.com) summarized c19c42f._