### PR TITLE
Use new node go image

### DIFF
--- a/dev/docker/docker-compose.yml
+++ b/dev/docker/docker-compose.yml
@@ -1,8 +1,7 @@
 version: "3.8"
 services:
   node:
-    # image: xmtp/node-go@sha256:fba4c5f02203d90f25c91982fa1343d1d73c6bfbc3e3da16bd2ccbeef0a0f0f1
-    image: xmtp/node-go:latest
+    image: ghcr.io/xmtp/node-go:main
     platform: linux/amd64
     environment:
       - GOWAKU-NODEKEY=8a30dcb604b0b53627a5adc054dbf434b446628d4bd1eccc681d223f0550ce67


### PR DESCRIPTION
### Update Docker Compose node service to use new node go image from GitHub Container Registry
The Docker image reference for the `node` service in [dev/docker/docker-compose.yml](https://github.com/xmtp/libxmtp/pull/2169/files#diff-6a25daaa729d7279e0cda8eb92399f1a82d4a91f961e1955bb5745e9c99f3c6e) changes from `xmtp/node-go:latest` to `ghcr.io/xmtp/node-go:main`, switching from Docker Hub to GitHub Container Registry and replacing the `latest` tag with `main`.

#### 📍Where to Start
Start with the `node` service configuration in [dev/docker/docker-compose.yml](https://github.com/xmtp/libxmtp/pull/2169/files#diff-6a25daaa729d7279e0cda8eb92399f1a82d4a91f961e1955bb5745e9c99f3c6e).

----

_[Macroscope](https://app.macroscope.com) summarized a2e4700._