### PR TITLE
Is Connected Check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8525,6 +8525,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tonic",
+ "tower 0.5.2",
  "tracing",
  "uuid",
  "xmtp_common",

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -116,10 +116,9 @@ pub async fn connect_to_backend(
     Ok(Arc::new(XmtpApiClient(api_client)))
 }
 
-#[uniffi::export]
-pub fn is_connected(api: Arc<XmtpApiClient>) -> bool {
-    let mut api = Arc::unwrap_or_clone(api);
-    api.0.is_connected()
+#[uniffi::export(async_runtime = "tokio")]
+pub async fn is_connected(api: Arc<XmtpApiClient>) -> bool {
+    api.0.is_connected().await
 }
 
 /**
@@ -8885,7 +8884,7 @@ mod tests {
             .await
             .expect("should connect to local grpc server");
 
-        let connected = is_connected(api_backend);
+        let connected = is_connected(api_backend).await;
 
         assert!(connected, "Expected API client to report as connected");
 

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -116,9 +116,16 @@ pub async fn connect_to_backend(
     Ok(Arc::new(XmtpApiClient(api_client)))
 }
 
+#[uniffi::export]
+pub fn is_connected(api: Arc<XmtpApiClient>) -> bool {
+    let mut api = Arc::unwrap_or_clone(api);
+    api.0.is_connected()
+}
+
 /**
  * Static Get the inbox state for each `inbox_id`.
  */
+#[uniffi::export(async_runtime = "tokio")]
 pub async fn inbox_state_from_inbox_ids(
     api: Arc<XmtpApiClient>,
     inbox_ids: Vec<String>,
@@ -3006,7 +3013,7 @@ mod tests {
         get_inbox_id_for_identifier,
         identity::{FfiIdentifier, FfiIdentifierKind},
         inbox_owner::{FfiInboxOwner, IdentityValidationError, SigningError},
-        inbox_state_from_inbox_ids,
+        inbox_state_from_inbox_ids, is_connected,
         mls::test_utils::{LocalBuilder, LocalTester},
         revoke_installations,
         worker::FfiSyncWorkerMode,
@@ -8870,5 +8877,19 @@ mod tests {
             ffi_identities, expected_order,
             "FFI identifiers are not ordered by creation timestamp"
         );
+    }
+
+    #[tokio::test]
+    async fn test_is_connected_after_connect() {
+        let api_backend = connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false)
+            .await
+            .expect("should connect to local grpc server");
+
+        let connected = is_connected(api_backend);
+
+        assert!(connected, "Expected API client to report as connected");
+
+        let result = connect_to_backend("http://127.0.0.1:59999".to_string(), false).await;
+        assert!(result.is_err(), "Expected connection to fail");
     }
 }

--- a/xmtp_api_grpc/Cargo.toml
+++ b/xmtp_api_grpc/Cargo.toml
@@ -11,10 +11,10 @@ http = "1.2"
 prost = { workspace = true, features = ["prost-derive"] }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["macros", "time"] }
+tower = "0.5.2"
 tracing.workspace = true
 xmtp_common.workspace = true
 xmtp_proto = { path = "../xmtp_proto", features = ["proto_full", "convert"] }
-tower = "0.5.2"
 
 # Anything but iOS and Android will use either webpki or native.
 # If native certs are not found, it will fallback to webpki

--- a/xmtp_api_grpc/Cargo.toml
+++ b/xmtp_api_grpc/Cargo.toml
@@ -14,6 +14,7 @@ tokio = { workspace = true, features = ["macros", "time"] }
 tracing.workspace = true
 xmtp_common.workspace = true
 xmtp_proto = { path = "../xmtp_proto", features = ["proto_full", "convert"] }
+tower = "0.5.2"
 
 # Anything but iOS and Android will use either webpki or native.
 # If native certs are not found, it will fallback to webpki

--- a/xmtp_api_grpc/src/grpc_api_helper.rs
+++ b/xmtp_api_grpc/src/grpc_api_helper.rs
@@ -60,11 +60,8 @@ impl Client {
         ClientBuilder::default()
     }
 
-    pub fn is_connected(&mut self) -> bool {
-        self.channel
-            .ready()
-            .now_or_never()
-            .is_some_and(|r| r.is_ok())
+    pub async fn is_connected(&self) -> bool {
+        self.channel.clone().ready().await.is_ok()
     }
 }
 

--- a/xmtp_api_grpc/src/grpc_api_helper.rs
+++ b/xmtp_api_grpc/src/grpc_api_helper.rs
@@ -2,7 +2,7 @@ use std::pin::Pin;
 use std::time::Duration;
 
 use crate::{create_tls_channel, GrpcBuilderError, GrpcError, GRPC_PAYLOAD_LIMIT};
-use futures::{FutureExt, Stream, StreamExt};
+use futures::{Stream, StreamExt};
 use tonic::{metadata::MetadataValue, transport::Channel, Request};
 use tower::ServiceExt;
 use xmtp_proto::api_client::AggregateStats;


### PR DESCRIPTION
Add a `isConnectedCheck` to the grpc api client so that we can force a reconnection if the cached client is broken.