### PR TITLE
Use grpc payload limit for welcome chunk calculation

### DIFF
--- a/xmtp_mls/src/configuration.rs
+++ b/xmtp_mls/src/configuration.rs
@@ -35,6 +35,10 @@ pub const MAX_INSTALLATIONS_PER_INBOX: usize = 5;
 
 pub const MAX_PAST_EPOCHS: usize = 3;
 
+/// the max amount of data that can be sent in one gRPC call
+/// should match GRPC_PAYLOAD_LIMIT in xmtp_api_grpc crate
+pub const GRPC_DATA_LIMIT: usize = 1024 * 1024 * 25;
+
 pub const CREATE_PQ_KEY_PACKAGE_EXTENSION: bool = true;
 
 // If a metadata field name starts with this character,

--- a/xmtp_mls/src/configuration.rs
+++ b/xmtp_mls/src/configuration.rs
@@ -35,10 +35,6 @@ pub const MAX_INSTALLATIONS_PER_INBOX: usize = 5;
 
 pub const MAX_PAST_EPOCHS: usize = 3;
 
-/// the max amount of data that can be sent in one gRPC call
-/// we leave 5 * 1024 * 1024 as extra buffer room
-pub const GRPC_DATA_LIMIT: usize = 45 * 1024 * 1024;
-
 pub const CREATE_PQ_KEY_PACKAGE_EXTENSION: bool = true;
 
 // If a metadata field name starts with this character,

--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -17,9 +17,7 @@ use crate::{
     configuration::sync_update_installations_interval_ns, identity_updates::IdentityUpdates,
 };
 use crate::{
-    configuration::{
-        GRPC_DATA_LIMIT, HMAC_SALT, MAX_GROUP_SIZE, MAX_INTENT_PUBLISH_ATTEMPTS, MAX_PAST_EPOCHS,
-    },
+    configuration::{HMAC_SALT, MAX_GROUP_SIZE, MAX_INTENT_PUBLISH_ATTEMPTS, MAX_PAST_EPOCHS},
     context::XmtpMlsLocalContext,
     groups::{
         device_sync_legacy::DeviceSyncContent, intents::UpdateMetadataIntentData,
@@ -46,6 +44,7 @@ use crate::{
     verified_key_package_v2::{KeyPackageVerificationError, VerifiedKeyPackageV2},
 };
 use xmtp_api::XmtpApi;
+use xmtp_api_grpc::GRPC_PAYLOAD_LIMIT;
 use xmtp_db::{
     events::EventLevel,
     group::{ConversationType, StoredGroup},
@@ -2247,7 +2246,7 @@ where
 
         let welcome = welcomes.first().ok_or(GroupError::NoWelcomesToSend)?;
 
-        let chunk_size = GRPC_DATA_LIMIT
+        let chunk_size = GRPC_PAYLOAD_LIMIT
             / welcome
                 .version
                 .as_ref()
@@ -2258,7 +2257,7 @@ where
                         w
                     }
                 })
-                .unwrap_or(GRPC_DATA_LIMIT / MAX_GROUP_SIZE);
+                .unwrap_or(GRPC_PAYLOAD_LIMIT / MAX_GROUP_SIZE);
 
         tracing::debug!("welcome chunk_size={chunk_size}");
         let api = self.context.api();

--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -17,7 +17,9 @@ use crate::{
     configuration::sync_update_installations_interval_ns, identity_updates::IdentityUpdates,
 };
 use crate::{
-    configuration::{HMAC_SALT, MAX_GROUP_SIZE, MAX_INTENT_PUBLISH_ATTEMPTS, MAX_PAST_EPOCHS},
+    configuration::{
+        GRPC_DATA_LIMIT, HMAC_SALT, MAX_GROUP_SIZE, MAX_INTENT_PUBLISH_ATTEMPTS, MAX_PAST_EPOCHS,
+    },
     context::XmtpMlsLocalContext,
     groups::{
         device_sync_legacy::DeviceSyncContent, intents::UpdateMetadataIntentData,
@@ -44,7 +46,6 @@ use crate::{
     verified_key_package_v2::{KeyPackageVerificationError, VerifiedKeyPackageV2},
 };
 use xmtp_api::XmtpApi;
-use xmtp_api_grpc::GRPC_PAYLOAD_LIMIT;
 use xmtp_db::{
     events::EventLevel,
     group::{ConversationType, StoredGroup},
@@ -2246,7 +2247,7 @@ where
 
         let welcome = welcomes.first().ok_or(GroupError::NoWelcomesToSend)?;
 
-        let chunk_size = GRPC_PAYLOAD_LIMIT
+        let chunk_size = GRPC_DATA_LIMIT
             / welcome
                 .version
                 .as_ref()
@@ -2257,7 +2258,7 @@ where
                         w
                     }
                 })
-                .unwrap_or(GRPC_PAYLOAD_LIMIT / MAX_GROUP_SIZE);
+                .unwrap_or(GRPC_DATA_LIMIT / MAX_GROUP_SIZE);
 
         tracing::debug!("welcome chunk_size={chunk_size}");
         let api = self.context.api();


### PR DESCRIPTION
### Replace local GRPC_DATA_LIMIT constant with GRPC_PAYLOAD_LIMIT from xmtp_api_grpc module for welcome chunk calculation in MlsSync.send_welcome_messages
The code removes the local `GRPC_DATA_LIMIT` constant (45MB) from [xmtp_mls/src/configuration.rs](https://github.com/xmtp/libxmtp/pull/2174/files#diff-80e1437765f38906f066439ad9805b99205fb55f992bceb400a9d091628b6942) and updates [xmtp_mls/src/groups/mls_sync.rs](https://github.com/xmtp/libxmtp/pull/2174/files#diff-10f818f7918c8c0b2ed32c4f63e5060050527ed58df00ec081bbecb66065144e) to import and use `GRPC_PAYLOAD_LIMIT` from the `xmtp_api_grpc` module instead. The `MlsSync.send_welcome_messages` method now uses the imported constant for calculating chunk sizes when sending welcome messages.

#### 📍Where to Start
Start with the `MlsSync.send_welcome_messages` method in [xmtp_mls/src/groups/mls_sync.rs](https://github.com/xmtp/libxmtp/pull/2174/files#diff-10f818f7918c8c0b2ed32c4f63e5060050527ed58df00ec081bbecb66065144e) to see how the new `GRPC_PAYLOAD_LIMIT` constant is used for chunk size calculations.



#### Changes since #2174 opened

- Added new gRPC payload limit constant to configuration module [0b3e237]
- Replaced external gRPC payload limit dependency with local constant in MLS sync [0b3e237]
----

_[Macroscope](https://app.macroscope.com) summarized 0b3e237._