### PR TITLE
Commit log flag

### DIFF
--- a/xmtp_mls/src/configuration.rs
+++ b/xmtp_mls/src/configuration.rs
@@ -41,6 +41,11 @@ pub const GRPC_DATA_LIMIT: usize = 1024 * 1024 * 25;
 
 pub const CREATE_PQ_KEY_PACKAGE_EXTENSION: bool = true;
 
+#[cfg(not(test))]
+pub const ENABLE_COMMIT_LOG: bool = false;
+#[cfg(test)]
+pub const ENABLE_COMMIT_LOG: bool = true;
+
 // If a metadata field name starts with this character,
 // and it does not have a policy set, it is a super admin only field
 pub const SUPER_ADMIN_METADATA_PREFIX: &str = "_";

--- a/xmtp_mls/src/groups/mls_ext/mls_ext_merge_staged_commit.rs
+++ b/xmtp_mls/src/groups/mls_ext/mls_ext_merge_staged_commit.rs
@@ -28,19 +28,21 @@ impl MergeStagedCommitAndLog for MlsGroup {
         let last_epoch_authenticator = self.epoch_authenticator().as_slice().to_vec();
         self.merge_staged_commit(&provider, staged_commit)?;
 
-        NewLocalCommitLog {
-            group_id: self.group_id().to_vec(),
-            commit_sequence_id: sequence_id,
-            last_epoch_authenticator,
-            commit_result: CommitResult::Success,
-            applied_epoch_number: self.epoch().as_u64() as i64,
-            applied_epoch_authenticator: self.epoch_authenticator().as_slice().to_vec(),
-            sender_inbox_id: Some(validated_commit.actor_inbox_id()),
-            sender_installation_id: Some(validated_commit.actor_installation_id()),
-            commit_type: Some(format!("{}", validated_commit.debug_commit_type())),
-            error_message: None,
+        if crate::configuration::ENABLE_COMMIT_LOG {
+            NewLocalCommitLog {
+                group_id: self.group_id().to_vec(),
+                commit_sequence_id: sequence_id,
+                last_epoch_authenticator,
+                commit_result: CommitResult::Success,
+                applied_epoch_number: self.epoch().as_u64() as i64,
+                applied_epoch_authenticator: self.epoch_authenticator().as_slice().to_vec(),
+                sender_inbox_id: Some(validated_commit.actor_inbox_id()),
+                sender_installation_id: Some(validated_commit.actor_installation_id()),
+                commit_type: Some(format!("{}", validated_commit.debug_commit_type())),
+                error_message: None,
+            }
+            .store(provider.db())?;
         }
-        .store(provider.db())?;
 
         Ok(())
     }

--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -1600,6 +1600,9 @@ where
         mls_message_in: MlsMessageIn,
         error: &GroupMessageProcessingError,
     ) -> Result<(), StorageError> {
+        if !crate::configuration::ENABLE_COMMIT_LOG {
+            return Ok(());
+        }
         if error.is_retryable() {
             return Ok(());
         }


### PR DESCRIPTION
Disables the commit log for now, so that we don't have incomplete data on production clients when the feature is eventually released.

This PR enables the feature flag for tests only. There are pros and cons of this approach.
- Pro: Allows us to write unit tests against the commit log as we develop the feature
- Con: If we regress something when the flag is turned off, we won't catch it via unit test

To mitigate the con, I think we can just be careful that changes outside of the flag don't depend on logic inside the flag. We can also run the unit test with the flag off as a sanity check before landing a PR.

In the long-term, there's probably work we can do to make an INIT_ONCE config object that holds the flags, and allow specific tests to override it, rather than enabling the flag across all unit tests. There's various other places in the codebase that could use this too.