### PR TITLE
Add welcomes to local commit log

### DIFF
--- a/xmtp_mls/src/groups/mls_ext/decrypted_welcome.rs
+++ b/xmtp_mls/src/groups/mls_ext/decrypted_welcome.rs
@@ -24,6 +24,7 @@ use super::WrapperAlgorithm;
 pub(crate) struct DecryptedWelcome {
     pub(crate) staged_welcome: StagedWelcome,
     pub(crate) added_by_inbox_id: String,
+    pub(crate) added_by_installation_id: Vec<u8>,
 }
 
 impl DecryptedWelcome {
@@ -61,10 +62,12 @@ impl DecryptedWelcome {
 
         let added_by_credential = BasicCredential::try_from(added_by_node.credential().clone())?;
         let added_by_inbox_id = parse_credential(added_by_credential.identity())?;
+        let added_by_installation_id = added_by_node.signature_key().as_slice().to_vec();
 
         Ok(DecryptedWelcome {
             staged_welcome,
             added_by_inbox_id,
+            added_by_installation_id,
         })
     }
 }

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -610,7 +610,7 @@ where
             let DecryptedWelcome {
                 staged_welcome,
                 added_by_inbox_id,
-                ..
+                added_by_installation_id,
             } = decrypted_welcome;
 
             tracing::debug!(
@@ -629,7 +629,7 @@ where
                 return Err(ProcessIntentError::WelcomeAlreadyProcessed(welcome.id).into());
             }
 
-            let mls_group = staged_welcome.into_group(provider)?;
+            let mls_group = OpenMlsGroup::from_welcome_logged(provider, staged_welcome, &added_by_inbox_id, &added_by_installation_id)?;
             let group_id = mls_group.group_id().to_vec();
             let metadata = extract_group_metadata(&mls_group).map_err(MetadataPermissionsError::from)?;
             let dm_members = metadata.dm_members;


### PR DESCRIPTION
When Welcomes have a cursor pointing to where in the group the newly added installation should sync from (#2088), we should also be able to use this as the `commit_sequence_id` in the local/remote commit log. This would allow a newly added installation to immediately check if they were added into a fork, tackling the viral nature of forks today.

Because we don't have this information yet, we can instead store it with a sequence_id of 0 for local debugging purposes for now. Anything with a sequence_id of 0 won't be uploaded to the remote commit log, and is effectively ignored for the purposes of fork detection.