### PR TITLE
fix webassembly compile with tonic-build proto

### DIFF
--- a/xmtp_proto/build.rs
+++ b/xmtp_proto/build.rs
@@ -1,6 +1,62 @@
 use std::env;
 use std::path::PathBuf;
 
+fn codegen_configure(builder: tonic_build::Builder) -> tonic_build::Builder {
+    builder
+        .client_mod_attribute(
+            "xmtp.identity.api.v1",
+            r#"#[cfg(not(target_arch = "wasm32"))]"#,
+        )
+        .client_mod_attribute(
+            "xmtp.message_api.v1",
+            r#"#[cfg(not(target_arch = "wasm32"))]"#,
+        )
+        .client_mod_attribute("xmtp.mls.api.v1", r#"#[cfg(not(target_arch = "wasm32"))]"#)
+        .client_mod_attribute(
+            "xmtp.mls_validation.v1",
+            r#"#[cfg(not(target_arch = "wasm32"))]"#,
+        )
+        .client_mod_attribute("xmtp.xmtpv4", r#"#[cfg(not(target_arch = "wasm32"))]"#)
+        .client_mod_attribute(
+            "xmtp.xmtpv4.payer_api",
+            r#"#[cfg(not(target_arch = "wasm32"))]"#,
+        )
+        .client_mod_attribute(
+            "xmtp.xmtpv4.message_api",
+            r#"#[cfg(not(target_arch = "wasm32"))]"#,
+        )
+        .client_mod_attribute(
+            "xmtp.xmtpv4.metadata_api",
+            r#"#[cfg(not(target_arch = "wasm32"))]"#,
+        )
+        .server_mod_attribute(
+            "xmtp.identity.api.v1",
+            r#"#[cfg(not(target_arch = "wasm32"))]"#,
+        )
+        .server_mod_attribute(
+            "xmtp.mls_validation.v1",
+            r#"#[cfg(not(target_arch = "wasm32"))]"#,
+        )
+        .server_mod_attribute(
+            "xmtp.message_api.v1",
+            r#"#[cfg(not(target_arch = "wasm32"))]"#,
+        )
+        .server_mod_attribute("xmtp.mls.api.v1", r#"#[cfg(not(target_arch = "wasm32"))]"#)
+        .server_mod_attribute("xmtp.xmtpv4", r#"#[cfg(not(target_arch = "wasm32"))]"#)
+        .server_mod_attribute(
+            "xmtp.xmtpv4.payer_api",
+            r#"#[cfg(not(target_arch = "wasm32"))]"#,
+        )
+        .server_mod_attribute(
+            "xmtp.xmtpv4.message_api",
+            r#"#[cfg(not(target_arch = "wasm32"))]"#,
+        )
+        .server_mod_attribute(
+            "xmtp.xmtpv4.metadata_api",
+            r#"#[cfg(not(target_arch = "wasm32"))]"#,
+        )
+}
+
 fn main() {
     let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR not set"));
     let descriptor_path = out_dir.join("descriptor.bin");
@@ -32,7 +88,9 @@ fn main() {
             .extern_path(".google.protobuf", "::pbjson_types");
 
         // Compile with tonic
-        tonic_build::configure()
+        let builder = tonic_build::configure();
+        let builder = codegen_configure(builder);
+        builder
             .out_dir("src/gen") // optional: customize output dir
             .compile_protos_with_config(config, &[proto], include_paths)
             .unwrap_or_else(|e| panic!("Failed to generate descriptor set for {proto}: {e}"));
@@ -87,7 +145,9 @@ fn main() {
         .extern_path(".google.protobuf", "::pbjson_types");
 
     // Compile with tonic
-    tonic_build::configure()
+    let builder = tonic_build::configure();
+    let builder = codegen_configure(builder);
+    builder
         .out_dir("src/gen") // optional: customize output dir
         .compile_protos_with_config(config, proto_files, include_paths)
         .expect("Failed to compile protos");

--- a/xmtp_proto/src/gen/xmtp.identity.api.v1.rs
+++ b/xmtp_proto/src/gen/xmtp.identity.api.v1.rs
@@ -308,6 +308,7 @@ impl ::prost::Name for GetInboxIdsResponse {
     }
 }
 /// Generated client implementations.
+#[cfg(not(target_arch = "wasm32"))]
 pub mod identity_api_client {
     #![allow(
         unused_variables,
@@ -524,6 +525,7 @@ pub mod identity_api_client {
     }
 }
 /// Generated server implementations.
+#[cfg(not(target_arch = "wasm32"))]
 pub mod identity_api_server {
     #![allow(
         unused_variables,

--- a/xmtp_proto/src/gen/xmtp.message_api.v1.rs
+++ b/xmtp_proto/src/gen/xmtp.message_api.v1.rs
@@ -272,6 +272,7 @@ impl SortDirection {
     }
 }
 /// Generated client implementations.
+#[cfg(not(target_arch = "wasm32"))]
 pub mod message_api_client {
     #![allow(
         unused_variables,
@@ -517,6 +518,7 @@ pub mod message_api_client {
     }
 }
 /// Generated server implementations.
+#[cfg(not(target_arch = "wasm32"))]
 pub mod message_api_server {
     #![allow(
         unused_variables,

--- a/xmtp_proto/src/gen/xmtp.mls.api.v1.rs
+++ b/xmtp_proto/src/gen/xmtp.mls.api.v1.rs
@@ -863,6 +863,7 @@ impl SortDirection {
     }
 }
 /// Generated client implementations.
+#[cfg(not(target_arch = "wasm32"))]
 pub mod mls_api_client {
     #![allow(
         unused_variables,
@@ -1283,6 +1284,7 @@ pub mod mls_api_client {
     }
 }
 /// Generated server implementations.
+#[cfg(not(target_arch = "wasm32"))]
 pub mod mls_api_server {
     #![allow(
         unused_variables,

--- a/xmtp_proto/src/gen/xmtp.mls_validation.v1.rs
+++ b/xmtp_proto/src/gen/xmtp.mls_validation.v1.rs
@@ -316,6 +316,7 @@ impl ::prost::Name for GetAssociationStateResponse {
     }
 }
 /// Generated client implementations.
+#[cfg(not(target_arch = "wasm32"))]
 pub mod validation_api_client {
     #![allow(
         unused_variables,
@@ -536,6 +537,7 @@ pub mod validation_api_client {
     }
 }
 /// Generated server implementations.
+#[cfg(not(target_arch = "wasm32"))]
 pub mod validation_api_server {
     #![allow(
         unused_variables,

--- a/xmtp_proto/src/gen/xmtp.xmtpv4.message_api.rs
+++ b/xmtp_proto/src/gen/xmtp.xmtpv4.message_api.rs
@@ -270,6 +270,7 @@ impl ::prost::Name for GetNewestEnvelopeResponse {
     }
 }
 /// Generated client implementations.
+#[cfg(not(target_arch = "wasm32"))]
 pub mod replication_api_client {
     #![allow(
         unused_variables,
@@ -509,6 +510,7 @@ pub mod replication_api_client {
     }
 }
 /// Generated server implementations.
+#[cfg(not(target_arch = "wasm32"))]
 pub mod replication_api_server {
     #![allow(
         unused_variables,
@@ -1135,6 +1137,7 @@ impl Misbehavior {
     }
 }
 /// Generated client implementations.
+#[cfg(not(target_arch = "wasm32"))]
 pub mod misbehavior_api_client {
     #![allow(
         unused_variables,
@@ -1286,6 +1289,7 @@ pub mod misbehavior_api_client {
     }
 }
 /// Generated server implementations.
+#[cfg(not(target_arch = "wasm32"))]
 pub mod misbehavior_api_server {
     #![allow(
         unused_variables,

--- a/xmtp_proto/src/gen/xmtp.xmtpv4.metadata_api.rs
+++ b/xmtp_proto/src/gen/xmtp.xmtpv4.metadata_api.rs
@@ -29,6 +29,7 @@ impl ::prost::Name for GetSyncCursorResponse {
     }
 }
 /// Generated client implementations.
+#[cfg(not(target_arch = "wasm32"))]
 pub mod metadata_api_client {
     #![allow(
         unused_variables,
@@ -181,6 +182,7 @@ pub mod metadata_api_client {
     }
 }
 /// Generated server implementations.
+#[cfg(not(target_arch = "wasm32"))]
 pub mod metadata_api_server {
     #![allow(
         unused_variables,

--- a/xmtp_proto/src/gen/xmtp.xmtpv4.payer_api.rs
+++ b/xmtp_proto/src/gen/xmtp.xmtpv4.payer_api.rs
@@ -65,6 +65,7 @@ impl ::prost::Name for GetReaderNodeResponse {
     }
 }
 /// Generated client implementations.
+#[cfg(not(target_arch = "wasm32"))]
 pub mod payer_api_client {
     #![allow(
         unused_variables,
@@ -215,6 +216,7 @@ pub mod payer_api_client {
     }
 }
 /// Generated server implementations.
+#[cfg(not(target_arch = "wasm32"))]
 pub mod payer_api_server {
     #![allow(
         unused_variables,


### PR DESCRIPTION
### Fix WebAssembly compilation by excluding gRPC client and server modules from `tonic-build` proto generation when targeting `wasm32` architecture
Adds conditional compilation attributes `#[cfg(not(target_arch = "wasm32"))]` to exclude gRPC client and server implementations when targeting WebAssembly architecture. The changes modify the build process in [xmtp_proto/build.rs](https://github.com/xmtp/libxmtp/pull/2181/files#diff-2511e632129c71a3adda2e13392b62286e73afe93f6b07b66d38e51e3b050880) by introducing a `codegen_configure` function that configures `tonic_build::Builder` with client and server module attributes for XMTP API modules. Generated proto files are updated to include the conditional compilation directives on their respective client and server modules across identity, message, MLS, validation, replication, misbehavior, metadata, and payer APIs.

#### 📍Where to Start
Start with the `codegen_configure` function in [xmtp_proto/build.rs](https://github.com/xmtp/libxmtp/pull/2181/files#diff-2511e632129c71a3adda2e13392b62286e73afe93f6b07b66d38e51e3b050880) to understand how the conditional compilation attributes are configured during the build process.

----

_[Macroscope](https://app.macroscope.com) summarized a123a6e._