### PR TITLE
Improved commit log error handling

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,6 +23,7 @@
     "tokio": ["test"],
     "async-stream": ["stream", "try_stream"]
   },
+  "gitlens.blame.ignoreWhitespace": true,
   "[toml]": {
     "editor.defaultFormatter": "tamasfe.even-better-toml"
   },

--- a/xmtp_mls/src/groups/mls_ext/commit_log_storer.rs
+++ b/xmtp_mls/src/groups/mls_ext/commit_log_storer.rs
@@ -1,10 +1,13 @@
 use crate::groups::GroupError;
 use crate::groups::{mls_sync::GroupMessageProcessingError, validated_commit::ValidatedCommit};
 use crate::identity::Identity;
+use crate::StorageError;
 use openmls::group::{MlsGroup, MlsGroupCreateConfig, StagedCommit};
 use openmls::prelude::CredentialWithKey;
+use openmls::prelude::GroupEpoch;
 use openmls::prelude::GroupId;
 use openmls::prelude::StagedWelcome;
+use openmls::schedule::EpochAuthenticator;
 use xmtp_db::{
     local_commit_log::{CommitType, NewLocalCommitLog},
     remote_commit_log::CommitResult,
@@ -41,6 +44,20 @@ pub trait CommitLogStorer: std::marker::Sized {
         validated_commit: &ValidatedCommit,
         sequence_id: i64,
     ) -> Result<(), GroupMessageProcessingError>;
+
+    /// Marks a commit as failed in the commit log.
+    /// Only call this when the status of the commit is final.
+    /// Specifically, do not call this for retryable errors, or
+    /// VersionTooLow/GroupPaused errors.
+    fn mark_failed_commit_logged<Db: ConnectionExt>(
+        provider: &XmtpOpenMlsProvider<Db>,
+        group_id: &[u8],
+        commit_sequence_id: u64,
+        commit_epoch: GroupEpoch,
+        error: &GroupMessageProcessingError,
+        last_epoch_number: GroupEpoch,
+        last_epoch_authenticator: &EpochAuthenticator,
+    ) -> Result<(), StorageError>;
 }
 
 impl CommitLogStorer for MlsGroup {
@@ -122,6 +139,7 @@ impl CommitLogStorer for MlsGroup {
         sender_inbox_id: &str,
         sender_installation_id: &[u8],
     ) -> Result<Self, GroupError> {
+        // Failed welcomes do not need to be added to the commit log
         let mls_group = welcome.into_group(provider)?;
 
         if crate::configuration::ENABLE_COMMIT_LOG {
@@ -170,6 +188,54 @@ impl CommitLogStorer for MlsGroup {
             .store(provider.db())?;
         }
 
+        Ok(())
+    }
+
+    fn mark_failed_commit_logged<Db: ConnectionExt>(
+        provider: &XmtpOpenMlsProvider<Db>,
+        group_id: &[u8],
+        commit_sequence_id: u64,
+        commit_epoch: GroupEpoch,
+        error: &GroupMessageProcessingError,
+        last_epoch_number: GroupEpoch,
+        last_epoch_authenticator: &EpochAuthenticator,
+    ) -> Result<(), StorageError> {
+        if !crate::configuration::ENABLE_COMMIT_LOG {
+            return Ok(());
+        }
+        let conn = provider.db();
+        let mut maybe_recently_welcomed = true;
+        // Latest log may not exist if a client upgraded from a version without local commit logs
+        if let Some(latest_log) = conn.get_latest_log_for_group(group_id)? {
+            // Because we don't increment the cursor for non-retryable errors, we may have already logged this commit
+            if latest_log.commit_sequence_id == commit_sequence_id as i64
+                && latest_log.commit_result != CommitResult::Success
+            {
+                return Ok(());
+            }
+            if latest_log.commit_type != Some(CommitType::Welcome.to_string()) {
+                maybe_recently_welcomed = false;
+            }
+        }
+        // If we've recently joined the group, we may get a bunch of wrong epoch errors
+        // until we 'catch up' to the commit that spawned the welcome. We can ignore these for now.
+        if commit_epoch.as_u64() <= last_epoch_number.as_u64() && maybe_recently_welcomed {
+            return Ok(());
+        }
+
+        NewLocalCommitLog {
+            group_id: group_id.to_vec(),
+            commit_sequence_id: commit_sequence_id as i64,
+            last_epoch_authenticator: last_epoch_authenticator.as_slice().to_vec(),
+            commit_result: error.commit_result(),
+            applied_epoch_number: last_epoch_number.as_u64() as i64,
+            applied_epoch_authenticator: last_epoch_authenticator.as_slice().to_vec(),
+            error_message: Some(format!("{:?}", error)),
+            sender_inbox_id: None,
+            sender_installation_id: None,
+            commit_type: None,
+        }
+        .store(conn)?;
         Ok(())
     }
 }


### PR DESCRIPTION
Changes include:
1. After joining a group from a Welcome message, do not add errored commit log entries for commits sent before the installation joined the group. When we get an epoch error, we do this by checking if the last entry was a Welcome, or if there is no previous entry. Worth noting:
     1. Even if we implement logic to add a cursor to Welcomes and only sync from that cursor onwards, we cannot rely on old clients populating this cursor when they send us a Welcome
     1. When we get an epoch error, we can check if the last commit log entry is a Welcome to determine whether to ignore it, but we can't rely on that entry being present - the client may have received a Welcome on an older version, and not have written that entry to the log.
2. Populate the `epoch_number` and `epoch_authenticator` for error commit logs from the actual group state, rather than inferring it from the most recent entry

We also need to be careful about how we handle Welcomes that are readds (for example, as part of automated fork recovery, or after leaving and re-joining the group). I chose not to clear the local commit log on a readd, so that we have a clearer audit trail for debugging. Instead, when comparing the local commit log with the remote commit log, we can stop comparing when we reach the most recent Welcome. I've updated the XIP to describe this.

Next PR will add more unit tests for errors, and have some light refactoring.