### PR TITLE
Commit log worker setup

### DIFF
--- a/xmtp_api/src/mls.rs
+++ b/xmtp_api/src/mls.rs
@@ -367,12 +367,12 @@ where
             .map_err(crate::dyn_err)
     }
 
-    pub async fn publish_commit_log(&self, commit_log: Vec<PlaintextCommitLogEntry>) -> Result<()> {
+    pub async fn publish_commit_log(&self, commit_log: &[PlaintextCommitLogEntry]) -> Result<()> {
         tracing::debug!(inbox_id = self.inbox_id, "publishing commit log");
         self.api_client
             .publish_commit_log(BatchPublishCommitLogRequest {
                 requests: commit_log
-                    .into_iter()
+                    .iter()
                     .map(convert_plaintext_to_publish_request)
                     .collect(),
             })
@@ -400,7 +400,7 @@ where
 
 /// TODO(cvoell): Encrypt the commit log entry instead of just encoding to bytes
 pub fn convert_plaintext_to_publish_request(
-    entry: PlaintextCommitLogEntry,
+    entry: &PlaintextCommitLogEntry,
 ) -> PublishCommitLogRequest {
     PublishCommitLogRequest {
         group_id: entry.group_id.clone(),

--- a/xmtp_db/src/encrypted_store/group.rs
+++ b/xmtp_db/src/encrypted_store/group.rs
@@ -6,7 +6,6 @@ use super::{
     schema::groups::{self, dsl},
 };
 use crate::NotFound;
-use crate::encrypted_store::schema_gen::local_commit_log::dsl as local_commit_log_dsl;
 use crate::{DuplicateItem, StorageError, Store, impl_fetch, impl_store, impl_store_or_ignore};
 use derive_builder::Builder;
 use diesel::{
@@ -592,19 +591,6 @@ impl<C: ConnectionExt> DbConnection<C> {
             .order(dsl::created_at_ns.asc());
 
         self.raw_query_read(|conn| query.load::<Vec<u8>>(conn))
-    }
-
-    pub fn get_local_commit_log_cursor(
-        &self,
-        group_id: &[u8],
-    ) -> Result<Option<i64>, crate::ConnectionError> {
-        let query = local_commit_log_dsl::local_commit_log
-            .filter(local_commit_log_dsl::group_id.eq(group_id))
-            .select(local_commit_log_dsl::commit_sequence_id)
-            .order(local_commit_log_dsl::commit_sequence_id.desc())
-            .limit(1);
-
-        self.raw_query_read(|conn| query.first::<i64>(conn).optional())
     }
 }
 

--- a/xmtp_db/src/encrypted_store/local_commit_log.rs
+++ b/xmtp_db/src/encrypted_store/local_commit_log.rs
@@ -140,9 +140,11 @@ impl<C: ConnectionExt> DbConnection<C> {
         group_id: &[u8],
         after_cursor: i64,
     ) -> Result<Vec<LocalCommitLog>, crate::ConnectionError> {
-        // convert i64 to i32 and log an error if it's greater than i32::MAX
+        // i64 cursor is populated by i32 local_commit_log rowid value, so we should never hit this error
         if after_cursor > i32::MAX as i64 {
-            tracing::error!("Commit log cursor is greater than i32::MAX, converting to i32");
+            return Err(crate::ConnectionError::Database(
+                diesel::result::Error::QueryBuilderError("Cursor value exceeds i32::MAX".into()),
+            ));
         }
         let after_cursor = after_cursor as i32;
 

--- a/xmtp_db/src/encrypted_store/refresh_state.rs
+++ b/xmtp_db/src/encrypted_store/refresh_state.rs
@@ -18,6 +18,7 @@ use crate::{
 pub enum EntityKind {
     Welcome = 1,
     Group = 2,
+    CommitLog = 3,
 }
 
 impl std::fmt::Display for EntityKind {
@@ -26,6 +27,7 @@ impl std::fmt::Display for EntityKind {
         match self {
             Welcome => write!(f, "welcome"),
             Group => write!(f, "group"),
+            CommitLog => write!(f, "commit_log"),
         }
     }
 }
@@ -48,6 +50,7 @@ where
         match i32::from_sql(bytes)? {
             1 => Ok(EntityKind::Welcome),
             2 => Ok(EntityKind::Group),
+            3 => Ok(EntityKind::CommitLog),
             x => Err(format!("Unrecognized variant {}", x).into()),
         }
     }

--- a/xmtp_db/src/encrypted_store/refresh_state.rs
+++ b/xmtp_db/src/encrypted_store/refresh_state.rs
@@ -18,7 +18,7 @@ use crate::{
 pub enum EntityKind {
     Welcome = 1,
     Group = 2,
-    CommitLog = 3,
+    PublishedCommitLog = 3,
 }
 
 impl std::fmt::Display for EntityKind {
@@ -27,7 +27,7 @@ impl std::fmt::Display for EntityKind {
         match self {
             Welcome => write!(f, "welcome"),
             Group => write!(f, "group"),
-            CommitLog => write!(f, "commit_log"),
+            PublishedCommitLog => write!(f, "commit_log"),
         }
     }
 }
@@ -50,7 +50,7 @@ where
         match i32::from_sql(bytes)? {
             1 => Ok(EntityKind::Welcome),
             2 => Ok(EntityKind::Group),
-            3 => Ok(EntityKind::CommitLog),
+            3 => Ok(EntityKind::PublishedCommitLog),
             x => Err(format!("Unrecognized variant {}", x).into()),
         }
     }

--- a/xmtp_mls/src/groups/commit_log.rs
+++ b/xmtp_mls/src/groups/commit_log.rs
@@ -1,0 +1,133 @@
+use futures::StreamExt;
+use std::{sync::Arc, time::Duration};
+use thiserror::Error;
+use tokio::sync::OnceCell;
+use xmtp_api::ApiError;
+use xmtp_db::{local_commit_log::LocalCommitLog, StorageError, XmtpDb};
+use xmtp_proto::{
+    api_client::trait_impls::XmtpApi, xmtp::mls::message_contents::PlaintextCommitLogEntry,
+};
+
+use crate::{
+    context::{XmtpContextProvider, XmtpMlsLocalContext, XmtpSharedContext},
+    worker::{BoxedWorker, NeedsDbReconnect, Worker, WorkerFactory, WorkerKind, WorkerResult},
+};
+
+/// Interval at which the CommitLogWorker runs to publish commit log entries.
+pub const INTERVAL_DURATION: Duration = Duration::from_secs(5);
+
+#[derive(Clone)]
+pub struct Factory<ApiClient, Db> {
+    context: Arc<XmtpMlsLocalContext<ApiClient, Db>>,
+}
+
+impl<ApiClient, Db> WorkerFactory for Factory<ApiClient, Db>
+where
+    ApiClient: XmtpApi + 'static,
+    Db: XmtpDb + 'static,
+{
+    fn kind(&self) -> WorkerKind {
+        WorkerKind::CommitLog
+    }
+
+    fn create(
+        &self,
+        metrics: Option<crate::worker::DynMetrics>,
+    ) -> (BoxedWorker, Option<crate::worker::DynMetrics>) {
+        (
+            Box::new(CommitLogWorker::new(self.context.clone())) as Box<_>,
+            metrics,
+        )
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum CommitLogError {
+    #[error("generic storage error: {0}")]
+    Storage(#[from] StorageError),
+    #[error("generic api error: {0}")]
+    Api(#[from] ApiError),
+}
+
+impl NeedsDbReconnect for CommitLogError {
+    fn needs_db_reconnect(&self) -> bool {
+        match self {
+            Self::Storage(s) => s.db_needs_connection(),
+            Self::Api(_api_error) => false,
+        }
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl<ApiClient, Db> Worker for CommitLogWorker<ApiClient, Db>
+where
+    ApiClient: XmtpApi + 'static,
+    Db: XmtpDb + 'static + Send,
+{
+    fn kind(&self) -> WorkerKind {
+        WorkerKind::CommitLog
+    }
+
+    async fn run_tasks(&mut self) -> WorkerResult<()> {
+        self.run().await.map_err(|e| Box::new(e) as Box<_>)
+    }
+
+    fn factory<C>(context: C) -> impl WorkerFactory + 'static
+    where
+        Self: Sized,
+        C: XmtpSharedContext,
+        <C as XmtpSharedContext>::Db: 'static,
+        <C as XmtpSharedContext>::ApiClient: 'static,
+    {
+        let context = context.context_ref().clone();
+        Factory { context }
+    }
+}
+
+pub struct CommitLogWorker<ApiClient, Db> {
+    context: Arc<XmtpMlsLocalContext<ApiClient, Db>>,
+    #[allow(dead_code)]
+    init: OnceCell<()>,
+}
+
+impl<ApiClient, Db> CommitLogWorker<ApiClient, Db>
+where
+    ApiClient: XmtpApi + 'static,
+    Db: XmtpDb + 'static,
+{
+    pub fn new(context: Arc<XmtpMlsLocalContext<ApiClient, Db>>) -> Self {
+        Self {
+            context,
+            init: OnceCell::new(),
+        }
+    }
+}
+
+impl<ApiClient, Db> CommitLogWorker<ApiClient, Db>
+where
+    ApiClient: XmtpApi + 'static,
+    Db: XmtpDb + 'static,
+{
+    async fn run(&mut self) -> Result<(), CommitLogError> {
+        let mut intervals = xmtp_common::time::interval_stream(INTERVAL_DURATION);
+        while (intervals.next().await).is_some() {
+            self.publish_local_commit_log().await?;
+        }
+        Ok(())
+    }
+
+    async fn publish_local_commit_log(&mut self) -> Result<(), CommitLogError> {
+        let _provider = self.context.mls_provider();
+        let _conn = _provider.db();
+
+        // TODO: query commit log entries for relevant group_ids here using `conn.get_group_logs`
+        let _commit_log_entries: Vec<LocalCommitLog> = vec![]; //conn.get_group_logs()?;
+
+        // Publish commit log entries to the API
+        let api = self.context.api();
+        let plaintext_commit_log_entries: Vec<PlaintextCommitLogEntry> = vec![]; // TODO: convert commit_log_entries to plaintext_commit_log_entries
+        api.publish_commit_log(plaintext_commit_log_entries).await?;
+        Ok(())
+    }
+}

--- a/xmtp_mls/src/groups/commit_log.rs
+++ b/xmtp_mls/src/groups/commit_log.rs
@@ -1,9 +1,9 @@
 use futures::StreamExt;
-use std::{sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 use thiserror::Error;
 use tokio::sync::OnceCell;
 use xmtp_api::ApiError;
-use xmtp_db::{local_commit_log::LocalCommitLog, StorageError, XmtpDb};
+use xmtp_db::{StorageError, XmtpDb};
 use xmtp_proto::{
     api_client::trait_impls::XmtpApi, xmtp::mls::message_contents::PlaintextCommitLogEntry,
 };
@@ -47,6 +47,8 @@ pub enum CommitLogError {
     Storage(#[from] StorageError),
     #[error("generic api error: {0}")]
     Api(#[from] ApiError),
+    #[error("connection error: {0}")]
+    Connection(#[from] xmtp_db::ConnectionError),
 }
 
 impl NeedsDbReconnect for CommitLogError {
@@ -54,6 +56,7 @@ impl NeedsDbReconnect for CommitLogError {
         match self {
             Self::Storage(s) => s.db_needs_connection(),
             Self::Api(_api_error) => false,
+            Self::Connection(_connection_error) => true, // TODO(cam): verify this is correct
         }
     }
 }
@@ -112,22 +115,107 @@ where
     async fn run(&mut self) -> Result<(), CommitLogError> {
         let mut intervals = xmtp_common::time::interval_stream(INTERVAL_DURATION);
         while (intervals.next().await).is_some() {
-            self.publish_local_commit_log().await?;
+            self.publish_commit_logs_to_remote().await?;
         }
         Ok(())
     }
 
-    async fn publish_local_commit_log(&mut self) -> Result<(), CommitLogError> {
-        let _provider = self.context.mls_provider();
-        let _conn = _provider.db();
+    /// Test-only version that runs without infinite loop
+    #[cfg(test)]
+    pub async fn run_test(&mut self, iterations: Option<usize>) -> Result<(), CommitLogError> {
+        match iterations {
+            Some(n) => {
+                // Run exactly n times
+                for _ in 0..n {
+                    self.publish_commit_logs_to_remote().await?;
+                }
+            }
+            None => {
+                // Run once
+                self.publish_commit_logs_to_remote().await?;
+            }
+        }
+        Ok(())
+    }
 
-        // TODO: query commit log entries for relevant group_ids here using `conn.get_group_logs`
-        let _commit_log_entries: Vec<LocalCommitLog> = vec![]; //conn.get_group_logs()?;
+    async fn publish_commit_logs_to_remote(&mut self) -> Result<(), CommitLogError> {
+        let provider = self.context.mls_provider();
+        let conn = provider.db();
 
-        // Publish commit log entries to the API
+        // Step 1 is to get the list of all group_id for dms and for groups where we are a super admin
+        let conversation_ids_for_remote_log = conn.get_conversation_ids_for_remote_log()?;
+
+        // Step 2 is to check if for each `conversation_id` for remote log whether its `refresh_state` cursor is lower than the local commit log sequence id.
+        // If so - save cursor we should publish from to `cursor_map`
+        let mut cursor_map: HashMap<Vec<u8>, Option<i64>> = HashMap::new();
+        for conversation_id in conversation_ids_for_remote_log {
+            let local_commit_log_cursor = conn
+                .get_local_commit_log_cursor(&conversation_id)
+                .ok()
+                .flatten();
+            let remote_commit_log_cursor = conn
+                .get_last_cursor_for_id(
+                    &conversation_id,
+                    xmtp_db::refresh_state::EntityKind::CommitLog,
+                )
+                .ok();
+
+            match (local_commit_log_cursor, remote_commit_log_cursor) {
+                (Some(local_commit_log_cursor), Some(remote_commit_log_cursor)) => {
+                    if local_commit_log_cursor > remote_commit_log_cursor {
+                        // We have new commits that have not been published to remote commit log yet
+                        cursor_map.insert(conversation_id, Some(remote_commit_log_cursor));
+                    } else {
+                        cursor_map.insert(conversation_id, None); // Remote log is up to date with local commit log
+                    }
+                }
+                (Some(_local_commit_log_cursor), None) => {
+                    cursor_map.insert(conversation_id, Some(0)); // We have not published to the remote log yet, publish from the beginning
+                }
+                _ => {
+                    tracing::warn!("No local commit log for conversation id: {:?} which should be published to remote commit log", conversation_id);
+                    cursor_map.insert(conversation_id, None); // No local commit log to publish
+                }
+            }
+        }
+
+        // Step 3 is to publish any new local commit logs and to update relevant cursors
         let api = self.context.api();
-        let plaintext_commit_log_entries: Vec<PlaintextCommitLogEntry> = vec![]; // TODO: convert commit_log_entries to plaintext_commit_log_entries
-        api.publish_commit_log(plaintext_commit_log_entries).await?;
+        for (conversation_id, cursor) in cursor_map {
+            if let Some(cursor) = cursor {
+                // Local commit log entries are returned sorted in ascending order of `commit_sequence_id`
+                let sorted_local_commit_log_entries =
+                    conn.get_group_logs_after_cursor(&conversation_id, cursor)?;
+                let plaintext_commit_log_entries: Vec<PlaintextCommitLogEntry> =
+                    sorted_local_commit_log_entries
+                        .iter()
+                        .map(PlaintextCommitLogEntry::from)
+                        .collect();
+                // Publish commit log entries to the API
+                let result = api.publish_commit_log(plaintext_commit_log_entries).await;
+
+                if result.is_ok() {
+                    let last_entry = sorted_local_commit_log_entries.last();
+                    if let Some(last_entry) = last_entry {
+                        // If publish is successful, update the cursor to the last entry's `commit_sequence_id`
+
+                        conn.update_cursor(
+                            &conversation_id,
+                            xmtp_db::refresh_state::EntityKind::CommitLog,
+                            last_entry.commit_sequence_id,
+                        )?;
+                    } else {
+                        tracing::error!(
+                            "No last entry found for conversation id: {:?}",
+                            conversation_id
+                        );
+                    }
+                } else {
+                    // In this case we do not update the cursor, so next worker iteration will try again
+                    tracing::error!("Failed to publish commit log entries to remote commit log for conversation id: {:?}", conversation_id);
+                }
+            }
+        }
         Ok(())
     }
 }

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -1,3 +1,4 @@
+pub mod commit_log;
 pub mod device_sync;
 pub mod device_sync_legacy;
 mod error;

--- a/xmtp_mls/src/worker.rs
+++ b/xmtp_mls/src/worker.rs
@@ -15,6 +15,7 @@ pub enum WorkerKind {
     DisappearingMessages,
     KeyPackageCleaner,
     Event,
+    CommitLog,
 }
 
 #[derive(Clone, Default)]


### PR DESCRIPTION
See tracking issue: https://github.com/xmtp/libxmtp/issues/2102

* Note this PR does not actually start the worker for clients yet. It just includes the worker logic, remote log publish criteria and tests. 

### Add CommitLogWorker that publishes commit log entries to API every 5 seconds in MLS groups
Creates a new `CommitLogWorker` in [xmtp_mls/src/groups/commit_log.rs](https://github.com/xmtp/libxmtp/pull/2186/files#diff-c25dc4d36a6249375b1001e9c4b66e50034909d2fc05025a45476e115429dc3a) that runs at 5-second intervals to publish commit log entries to an API. The implementation includes a `Factory` struct for creating worker instances, `CommitLogError` enum for error handling, and `Worker` trait implementation. 

#### 📍Where to Start
Start with the `CommitLogWorker` struct and its `Worker` trait implementation in [xmtp_mls/src/groups/commit_log.rs](https://github.com/xmtp/libxmtp/pull/2186/files#diff-c25dc4d36a6249375b1001e9c4b66e50034909d2fc05025a45476e115429dc3a).

----

_[Macroscope](https://app.macroscope.com) summarized ed3afd4._ (Automatic summaries will resume when PR exits draft mode or review begins).