### PR TITLE
Min sdk is 23 in android

### DIFF
--- a/bindings_ffi/Cargo.toml
+++ b/bindings_ffi/Cargo.toml
@@ -43,7 +43,7 @@ fdlimit = { version = "0.3", optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 paranoid-android = "0.2"
-tracing_android_trace = { version = "0.1", features = ["api_level_29"] }
+tracing_android_trace = "0.1"
 
 [target.'cfg(target_os = "ios")'.dependencies]
 tracing-oslog = "0.2"


### PR DESCRIPTION
Fixes https://github.com/xmtp/xmtp-android/issues/440

We were seeing unsatisfied linker errors because the min sdk is 23.