### PR TITLE
Do not drop welcome if consent record already exists

### DIFF
--- a/xmtp_db/src/encrypted_store/consent_record.rs
+++ b/xmtp_db/src/encrypted_store/consent_record.rs
@@ -6,7 +6,7 @@ use super::{
         groups::dsl as groups_dsl,
     },
 };
-use crate::{StorageError, Store, impl_store};
+use crate::{StorageError, impl_store};
 use diesel::{
     backend::Backend,
     deserialize::{self, FromSql, FromSqlRow},
@@ -59,7 +59,7 @@ impl StoredConsentRecord {
 
     /// This function will perform some logic to see if a new group should be auto-consented
     /// or auto-denied based on past consent.
-    pub fn persist_consent<C: ConnectionExt>(
+    pub fn stitch_dm_consent<C: ConnectionExt>(
         conn: &DbConnection<C>,
         group: &StoredGroup,
     ) -> Result<(), StorageError> {
@@ -74,7 +74,7 @@ impl StoredConsentRecord {
                 last_consent.state,
                 hex::encode(&group.id),
             );
-            cr.store(conn)?;
+            conn.insert_newer_consent_record(cr)?;
         }
 
         Ok(())

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -708,7 +708,7 @@ where
             // Replacement can happen in the case that the user has been removed from and subsequently re-added to the group.
             let stored_group = provider.db().insert_or_replace_group(to_store)?;
 
-            StoredConsentRecord::persist_consent(provider.db(), &stored_group)?;
+            StoredConsentRecord::stitch_dm_consent(provider.db(), &stored_group)?;
             track!(
                 "Group Welcome",
                 {

--- a/xmtp_mls/src/groups/tests/test_dm.rs
+++ b/xmtp_mls/src/groups/tests/test_dm.rs
@@ -1,3 +1,4 @@
+use xmtp_db::consent_record::StoredConsentRecord;
 use xmtp_db::consent_record::{ConsentState, ConsentType};
 
 use crate::tester;
@@ -27,4 +28,40 @@ async fn auto_consent_dms_for_new_installations() {
         .get_consent_state(ConsentType::ConversationId, hex::encode(bo2_dm.group_id))
         .await?;
     assert_eq!(consent, ConsentState::Allowed);
+}
+
+/// Test case: If a second installation syncs the consent state for a DM
+/// before processing the welcome, the welcome should succeed rather than
+/// aborting on a unique constraint error.
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_dm_welcome_with_preexisting_consent() {
+    tester!(alix);
+    tester!(bo1);
+    // Alix and bo are talking fine in a DM
+    let (a_group, _) = alix.test_talk_in_dm_with(&bo1).await?;
+
+    tester!(bo2, from: bo1);
+
+    // Mock device sync - the consent record is processed on Bo2 before
+    // the welcome is processed.
+    let cr = StoredConsentRecord::new(
+        ConsentType::ConversationId,
+        ConsentState::Allowed,
+        hex::encode(&a_group.group_id),
+    );
+    bo2.context().db().insert_newer_consent_record(cr)?;
+    // Now bo2 processes the welcome
+    bo1.find_or_create_dm_by_inbox_id(alix.inbox_id(), None)
+        .await?
+        .update_installations()
+        .await?;
+    bo2.sync_welcomes().await?;
+
+    // The welcome should succeed
+    assert_eq!(
+        bo2.find_or_create_dm_by_inbox_id(alix.inbox_id(), None)
+            .await?
+            .group_id,
+        a_group.group_id
+    );
 }


### PR DESCRIPTION
Split out from https://github.com/xmtp/libxmtp/pull/2201. This function is called when processing the Welcome for a DM. Previously, if the consent sync inserted the consent entry before the Welcome for the DM was processed, the call to cr.store(conn)?; would fail with a unique constraint error, because we're trying to insert a consent record that already exists. This would abort processing of the Welcome and lead to a DM sub-group that was never received, causing the appearance of a fork.

Now, when setting the consent state for a DM, if a consent state already exists (e.g. from device sync), we no longer return an error, and process the welcome successfully.