### PR TITLE
Fix consent regression

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -6967,7 +6967,7 @@ mod tests {
         // Wait for alix_a to send out the consent on the sync group
         alix_a
             .worker()
-            .wait(SyncMetric::ConsentSent, 2)
+            .wait(SyncMetric::ConsentSent, 3)
             .await
             .unwrap();
         // Have alix_b sync the sync group
@@ -8386,7 +8386,7 @@ mod tests {
             .update_consent_state(FfiConsentState::Denied)
             .unwrap();
         alix.worker()
-            .wait(SyncMetric::ConsentSent, 2)
+            .wait(SyncMetric::ConsentSent, 3)
             .await
             .unwrap();
 


### PR DESCRIPTION
When we send a message, and then try to resolve its intent upon receiving it, we try to find the message's identifier so that we can update its delivery status. Before https://github.com/xmtp/libxmtp/pull/2201, if no message identifier was found, the intent was set to `COMMITTED` [here](https://github.com/xmtp/libxmtp/blob/121493aa7df5407a67a021f6927d77769e31a32b/xmtp_mls/src/groups/mls_sync.rs#L726-L727). After #2201, we set the intent state to `ERROR`.

I thought there was no normal case where no message identifier was found for a sent message, but it turns out we are still sending legacy device sync/consent payloads for which no message identifier is expected (in addition to normal device sync payloads). This in turn caused a regression in the node tests. I'm a little puzzled by why these legacy payloads should make any difference, but in any case from a principled point of view we should maintain the existing behavior.