### PR TITLE
Handle stream closing in WASM bindings

### DIFF
--- a/bindings_wasm/src/conversation.rs
+++ b/bindings_wasm/src/conversation.rs
@@ -505,6 +505,7 @@ impl Conversation {
 
   #[wasm_bindgen(js_name = stream)]
   pub fn stream(&self, callback: StreamCallback) -> Result<StreamCloser, JsError> {
+    let on_close_cb = callback.clone();
     let stream_closer = MlsGroup::stream_with_callback(
       self.inner_group.context.clone(),
       self.group_id.clone(),
@@ -512,7 +513,7 @@ impl Conversation {
         Ok(item) => callback.on_message(item.into()),
         Err(e) => callback.on_error(JsError::from(e)),
       },
-      move || callback.on_close(),
+      move || on_close_cb.on_close(),
     );
 
     Ok(StreamCloser::new(stream_closer))

--- a/bindings_wasm/src/conversation.rs
+++ b/bindings_wasm/src/conversation.rs
@@ -512,7 +512,7 @@ impl Conversation {
         Ok(item) => callback.on_message(item.into()),
         Err(e) => callback.on_error(JsError::from(e)),
       },
-      move || {},
+      move || callback.on_close(),
     );
 
     Ok(StreamCloser::new(stream_closer))

--- a/bindings_wasm/src/conversations.rs
+++ b/bindings_wasm/src/conversations.rs
@@ -564,6 +564,7 @@ impl Conversations {
     callback: StreamCallback,
     conversation_type: Option<ConversationType>,
   ) -> Result<StreamCloser, JsError> {
+    let on_close_cb = callback.clone();
     let stream_closer = RustXmtpClient::stream_conversations_with_callback(
       self.inner_client.clone(),
       conversation_type.map(Into::into),
@@ -571,7 +572,7 @@ impl Conversations {
         Ok(item) => callback.on_conversation(item.into()),
         Err(e) => callback.on_error(JsError::from(e)),
       },
-      move || callback.on_close(),
+      move || on_close_cb.on_close(),
     );
 
     Ok(StreamCloser::new(stream_closer))
@@ -587,6 +588,7 @@ impl Conversations {
     let consents: Option<Vec<XmtpConsentState>> =
       consent_states.map(|states| states.into_iter().map(|state| state.into()).collect());
 
+    let on_close_cb = callback.clone();
     let stream_closer = RustXmtpClient::stream_all_messages_with_callback(
       self.inner_client.clone(),
       conversation_type.map(Into::into),
@@ -595,13 +597,14 @@ impl Conversations {
         Ok(m) => callback.on_message(m.into()),
         Err(e) => callback.on_error(JsError::from(e)),
       },
-      move || callback.on_close(),
+      move || on_close_cb.on_close(),
     );
     Ok(StreamCloser::new(stream_closer))
   }
 
   #[wasm_bindgen(js_name = "streamConsent")]
   pub fn stream_consent(&self, callback: StreamCallback) -> Result<StreamCloser, JsError> {
+    let on_close_cb = callback.clone();
     let stream_closer = RustXmtpClient::stream_consent_with_callback(
       self.inner_client.clone(),
       move |message| match message {
@@ -612,13 +615,14 @@ impl Conversations {
         }
         Err(e) => callback.on_error(JsError::from(e)),
       },
-      move || callback.on_close(),
+      move || on_close_cb.on_close(),
     );
     Ok(StreamCloser::new(stream_closer))
   }
 
   #[wasm_bindgen(js_name = "streamPreferences")]
   pub fn stream_preferences(&self, callback: StreamCallback) -> Result<StreamCloser, JsError> {
+    let on_close_cb = callback.clone();
     let stream_closer = RustXmtpClient::stream_preferences_with_callback(
       self.inner_client.clone(),
       move |message| match message {
@@ -627,7 +631,7 @@ impl Conversations {
         }
         Err(e) => callback.on_error(JsError::from(e)),
       },
-      move || callback.on_close(),
+      move || on_close_cb.on_close(),
     );
     Ok(StreamCloser::new(stream_closer))
   }

--- a/bindings_wasm/src/conversations.rs
+++ b/bindings_wasm/src/conversations.rs
@@ -571,7 +571,7 @@ impl Conversations {
         Ok(item) => callback.on_conversation(item.into()),
         Err(e) => callback.on_error(JsError::from(e)),
       },
-      move || {},
+      move || callback.on_close(),
     );
 
     Ok(StreamCloser::new(stream_closer))
@@ -595,7 +595,7 @@ impl Conversations {
         Ok(m) => callback.on_message(m.into()),
         Err(e) => callback.on_error(JsError::from(e)),
       },
-      move || {},
+      move || callback.on_close(),
     );
     Ok(StreamCloser::new(stream_closer))
   }
@@ -612,7 +612,7 @@ impl Conversations {
         }
         Err(e) => callback.on_error(JsError::from(e)),
       },
-      move || {},
+      move || callback.on_close(),
     );
     Ok(StreamCloser::new(stream_closer))
   }
@@ -627,7 +627,7 @@ impl Conversations {
         }
         Err(e) => callback.on_error(JsError::from(e)),
       },
-      move || {},
+      move || callback.on_close(),
     );
     Ok(StreamCloser::new(stream_closer))
   }

--- a/bindings_wasm/src/streams.rs
+++ b/bindings_wasm/src/streams.rs
@@ -19,6 +19,7 @@ type StreamHandle = Box<GenericStreamHandle<Result<(), XmtpSubscribeError>>>;
 
 #[wasm_bindgen]
 extern "C" {
+  #[derive(Clone)]
   pub type StreamCallback;
 
   /// Js Fn to call on an item

--- a/bindings_wasm/src/streams.rs
+++ b/bindings_wasm/src/streams.rs
@@ -37,6 +37,9 @@ extern "C" {
   /// Js Fn to call on error
   #[wasm_bindgen(structural, method)]
   pub fn on_error(this: &StreamCallback, error: JsError);
+
+  #[wasm_bindgen(structural, method)]
+  pub fn on_close(this: &StreamCallback);
 }
 
 #[wasm_bindgen]

--- a/xmtp_mls/src/groups/subscriptions.rs
+++ b/xmtp_mls/src/groups/subscriptions.rs
@@ -70,7 +70,8 @@ where
         #[cfg(not(target_arch = "wasm32"))] callback: impl FnMut(Result<StoredGroupMessage>)
             + Send
             + 'static,
-        on_close: impl FnOnce() + Send + 'static,
+        #[cfg(target_arch = "wasm32")] on_close: impl FnOnce() + 'static,
+        #[cfg(not(target_arch = "wasm32"))] on_close: impl FnOnce() + Send + 'static,
     ) -> impl StreamHandle<StreamOutput = Result<()>>
     where
         ApiClient: 'static,
@@ -99,7 +100,8 @@ pub(crate) fn stream_messages_with_callback<ApiClient, Db>(
     #[cfg(not(target_arch = "wasm32"))] mut callback: impl FnMut(Result<StoredGroupMessage>)
         + Send
         + 'static,
-    on_close: impl FnOnce() + Send + 'static,
+    #[cfg(target_arch = "wasm32")] on_close: impl FnOnce() + 'static,
+    #[cfg(not(target_arch = "wasm32"))] on_close: impl FnOnce() + Send + 'static,
 ) -> impl StreamHandle<StreamOutput = Result<()>>
 where
     ApiClient: XmtpApi + XmtpMlsStreams + 'static,

--- a/xmtp_mls/src/subscriptions/mod.rs
+++ b/xmtp_mls/src/subscriptions/mod.rs
@@ -268,7 +268,8 @@ where
             + 'static,
         #[cfg(target_arch = "wasm32")] mut convo_callback: impl FnMut(Result<MlsGroup<ApiClient, Db>>)
             + 'static,
-        on_close: impl FnOnce() + Send + 'static,
+        #[cfg(target_arch = "wasm32")] on_close: impl FnOnce() + 'static,
+        #[cfg(not(target_arch = "wasm32"))] on_close: impl FnOnce() + Send + 'static,
     ) -> impl StreamHandle<StreamOutput = Result<()>> {
         let (tx, rx) = oneshot::channel();
 
@@ -325,7 +326,8 @@ where
             + Send
             + 'static,
         #[cfg(target_arch = "wasm32")] mut callback: impl FnMut(Result<StoredGroupMessage>) + 'static,
-        on_close: impl FnOnce() + Send + 'static,
+        #[cfg(target_arch = "wasm32")] on_close: impl FnOnce() + 'static,
+        #[cfg(not(target_arch = "wasm32"))] on_close: impl FnOnce() + Send + 'static,
     ) -> impl StreamHandle<StreamOutput = Result<()>> {
         let (tx, rx) = oneshot::channel();
 
@@ -352,7 +354,8 @@ where
             + 'static,
         #[cfg(target_arch = "wasm32")] mut callback: impl FnMut(Result<Vec<StoredConsentRecord>>)
             + 'static,
-        on_close: impl FnOnce() + Send + 'static,
+        #[cfg(target_arch = "wasm32")] on_close: impl FnOnce() + 'static,
+        #[cfg(not(target_arch = "wasm32"))] on_close: impl FnOnce() + Send + 'static,
     ) -> impl StreamHandle<StreamOutput = Result<()>> {
         let (tx, rx) = oneshot::channel();
 
@@ -377,7 +380,8 @@ where
             + Send
             + 'static,
         #[cfg(target_arch = "wasm32")] mut callback: impl FnMut(Result<Vec<PreferenceUpdate>>) + 'static,
-        on_close: impl FnOnce() + Send + 'static,
+        #[cfg(target_arch = "wasm32")] on_close: impl FnOnce() + 'static,
+        #[cfg(not(target_arch = "wasm32"))] on_close: impl FnOnce() + Send + 'static,
     ) -> impl StreamHandle<StreamOutput = Result<()>> {
         let (tx, rx) = oneshot::channel();
 


### PR DESCRIPTION
# Summary

- Added `on_close` callback to `StreamCallback`
- Applied WASM-specified annotations for `on_close` in streaming methods
- Added call to new `on_close` callback in WASM streaming methods

This has been tested in a browser environment.