### PR TITLE
fix disappearing messages if it gets disabled

### DIFF
--- a/bindings_wasm/src/conversation.rs
+++ b/bindings_wasm/src/conversation.rs
@@ -729,7 +729,7 @@ mod tests {
       reference_id: None,
       originator_id: None,
       sequence_id: None,
-      message_disappear_in_ns: None,
+      expire_at_ns: None,
     };
     crate::to_value(&stored_message).unwrap();
   }

--- a/bindings_wasm/src/conversation.rs
+++ b/bindings_wasm/src/conversation.rs
@@ -729,6 +729,7 @@ mod tests {
       reference_id: None,
       originator_id: None,
       sequence_id: None,
+      message_disappear_in_ns: None,
     };
     crate::to_value(&stored_message).unwrap();
   }

--- a/xmtp_db/migrations/2025-07-17-111748_add_delete_at_ns_to_group_messages/down.sql
+++ b/xmtp_db/migrations/2025-07-17-111748_add_delete_at_ns_to_group_messages/down.sql
@@ -1,1 +1,1 @@
-ALTER TABLE group_messages DROP COLUMN message_disappear_in_ns;
+ALTER TABLE group_messages DROP COLUMN expire_at_ns;

--- a/xmtp_db/migrations/2025-07-17-111748_add_delete_at_ns_to_group_messages/down.sql
+++ b/xmtp_db/migrations/2025-07-17-111748_add_delete_at_ns_to_group_messages/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE group_messages DROP COLUMN message_disappear_in_ns;

--- a/xmtp_db/migrations/2025-07-17-111748_add_delete_at_ns_to_group_messages/up.sql
+++ b/xmtp_db/migrations/2025-07-17-111748_add_delete_at_ns_to_group_messages/up.sql
@@ -1,1 +1,1 @@
-ALTER TABLE group_messages ADD COLUMN message_disappear_in_ns BIGINT;
+ALTER TABLE group_messages ADD COLUMN expire_at_ns BIGINT;

--- a/xmtp_db/migrations/2025-07-17-111748_add_delete_at_ns_to_group_messages/up.sql
+++ b/xmtp_db/migrations/2025-07-17-111748_add_delete_at_ns_to_group_messages/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE group_messages ADD COLUMN message_disappear_in_ns BIGINT;

--- a/xmtp_db/src/encrypted_store/conversation_list.rs
+++ b/xmtp_db/src/encrypted_store/conversation_list.rs
@@ -206,6 +206,7 @@ pub(crate) mod tests {
                     Some(&group.id),
                     Some(i * 1000),
                     Some(ContentType::Text),
+                    None,
                 );
 
                 message.store(conn).unwrap();
@@ -246,6 +247,7 @@ pub(crate) mod tests {
                 Some(&group_b.id),
                 Some(3000), // Last message timestamp
                 None,
+                None,
             );
             message.store(conn).unwrap();
 
@@ -284,6 +286,7 @@ pub(crate) mod tests {
                 Some(&group.id),
                 Some(1000),
                 Some(ContentType::Text),
+                None,
             );
             first_message.store(conn).unwrap();
 
@@ -304,6 +307,7 @@ pub(crate) mod tests {
                 Some(&group.id),
                 Some(2000),
                 Some(ContentType::Text),
+                None,
             );
             second_message.store(conn).unwrap();
 

--- a/xmtp_db/src/encrypted_store/group_message.rs
+++ b/xmtp_db/src/encrypted_store/group_message.rs
@@ -68,7 +68,7 @@ pub struct StoredGroupMessage {
     pub sequence_id: Option<i64>,
     /// The Originator Node ID
     pub originator_id: Option<i64>,
-    /// When the message expires and must be deleted in NS
+    /// Timestamp (in NS) after which the message must be deleted
     pub expire_at_ns: Option<i64>,
 }
 

--- a/xmtp_db/src/encrypted_store/group_message.rs
+++ b/xmtp_db/src/encrypted_store/group_message.rs
@@ -21,7 +21,6 @@ use diesel::{
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::ops::Sub;
 use xmtp_common::time::now_ns;
 use xmtp_content_types::{
     attachment, group_updated, membership_change, reaction, read_receipt, remote_attachment, reply,

--- a/xmtp_db/src/encrypted_store/group_message/convert.rs
+++ b/xmtp_db/src/encrypted_store/group_message/convert.rs
@@ -27,7 +27,7 @@ impl TryFrom<GroupMessageSave> for StoredGroupMessage {
             reference_id: value.reference_id,
             sequence_id: value.sequence_id,
             originator_id: value.originator_id,
-            message_disappear_in_ns: None,
+            expire_at_ns: None,
         })
     }
 }

--- a/xmtp_db/src/encrypted_store/group_message/convert.rs
+++ b/xmtp_db/src/encrypted_store/group_message/convert.rs
@@ -27,6 +27,7 @@ impl TryFrom<GroupMessageSave> for StoredGroupMessage {
             reference_id: value.reference_id,
             sequence_id: value.sequence_id,
             originator_id: value.originator_id,
+            message_disappear_in_ns: None,
         })
     }
 }

--- a/xmtp_db/src/encrypted_store/group_message/tests.rs
+++ b/xmtp_db/src/encrypted_store/group_message/tests.rs
@@ -30,6 +30,7 @@ pub(crate) fn generate_message(
         reference_id: None,
         sequence_id: None,
         originator_id: None,
+        message_disappear_in_ns: None,
     }
 }
 

--- a/xmtp_db/src/encrypted_store/processed_device_sync_messages.rs
+++ b/xmtp_db/src/encrypted_store/processed_device_sync_messages.rs
@@ -67,9 +67,9 @@ mod tests {
             group2.conversation_type = ConversationType::Sync;
             group2.store(conn)?;
 
-            let message = generate_message(None, Some(&group.id), None, None);
+            let message = generate_message(None, Some(&group.id), None, None, None);
             message.store(conn)?;
-            let message = generate_message(None, Some(&group2.id), None, None);
+            let message = generate_message(None, Some(&group2.id), None, None, None);
             message.store(conn)?;
 
             let unprocessed = conn.unprocessed_sync_group_messages()?;

--- a/xmtp_db/src/encrypted_store/schema_gen.rs
+++ b/xmtp_db/src/encrypted_store/schema_gen.rs
@@ -62,7 +62,7 @@ diesel::table! {
         reference_id -> Nullable<Binary>,
         sequence_id -> Nullable<BigInt>,
         originator_id -> Nullable<BigInt>,
-        message_disappear_in_ns -> Nullable<BigInt>,
+        expire_at_ns -> Nullable<BigInt>,
     }
 }
 

--- a/xmtp_db/src/encrypted_store/schema_gen.rs
+++ b/xmtp_db/src/encrypted_store/schema_gen.rs
@@ -62,6 +62,7 @@ diesel::table! {
         reference_id -> Nullable<Binary>,
         sequence_id -> Nullable<BigInt>,
         originator_id -> Nullable<BigInt>,
+        message_disappear_in_ns -> Nullable<BigInt>,
     }
 }
 

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -736,7 +736,7 @@ where
                         reference_id: None, // conversation_item does not use message reference_id
                         sequence_id: None,
                         originator_id: None,
-                        message_disappear_in_ns: None, //Question: do we need to include this in conversation last message?
+                        expire_at_ns: None, //Question: do we need to include this in conversation last message?
                     });
                     if msg.is_none() {
                         tracing::warn!("tried listing message, but message had missing fields so it was skipped");

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -735,7 +735,8 @@ where
                         authority_id: conversation_item.authority_id?,
                         reference_id: None, // conversation_item does not use message reference_id
                         sequence_id: None,
-                        originator_id: None
+                        originator_id: None,
+                        message_disappear_in_ns: None, //todo: get it from the conversationListItem view
                     });
                     if msg.is_none() {
                         tracing::warn!("tried listing message, but message had missing fields so it was skipped");

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -736,7 +736,7 @@ where
                         reference_id: None, // conversation_item does not use message reference_id
                         sequence_id: None,
                         originator_id: None,
-                        message_disappear_in_ns: None, //todo: get it from the conversationListItem view
+                        message_disappear_in_ns: None, //Question: do we need to include this in conversation last message?
                     });
                     if msg.is_none() {
                         tracing::warn!("tried listing message, but message had missing fields so it was skipped");

--- a/xmtp_mls/src/groups/disappearing_messages.rs
+++ b/xmtp_mls/src/groups/disappearing_messages.rs
@@ -110,7 +110,7 @@ where
     /// Iterate on the list of groups and delete expired messages
     async fn delete_expired_messages(&mut self) -> Result<(), DisappearingMessagesCleanerError> {
         let provider = self.context.mls_provider();
-        match provider.db().delete_expired_messages_2() {
+        match provider.db().delete_expired_messages() {
             Ok(deleted_count) if deleted_count > 0 => {
                 tracing::info!("Successfully deleted {} expired messages", deleted_count);
             }

--- a/xmtp_mls/src/groups/disappearing_messages.rs
+++ b/xmtp_mls/src/groups/disappearing_messages.rs
@@ -110,7 +110,7 @@ where
     /// Iterate on the list of groups and delete expired messages
     async fn delete_expired_messages(&mut self) -> Result<(), DisappearingMessagesCleanerError> {
         let provider = self.context.mls_provider();
-        match provider.db().delete_expired_messages() {
+        match provider.db().delete_expired_messages_2() {
             Ok(deleted_count) if deleted_count > 0 => {
                 tracing::info!("Successfully deleted {} expired messages", deleted_count);
             }

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -778,6 +778,7 @@ where
                     reference_id: None,
                     sequence_id: Some(welcome.id as i64),
                     originator_id: None,
+                    message_disappear_in_ns: None,
                 };
 
                 added_msg.store_or_ignore(provider.db())?;
@@ -972,6 +973,7 @@ where
             reference_id: queryable_content_fields.reference_id,
             sequence_id: None,
             originator_id: None,
+            message_disappear_in_ns: None,
         };
         group_message.store(provider.db())?;
 

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -778,7 +778,7 @@ where
                     reference_id: None,
                     sequence_id: Some(welcome.id as i64),
                     originator_id: None,
-                    message_disappear_in_ns: None,
+                    expire_at_ns: None,
                 };
 
                 added_msg.store_or_ignore(provider.db())?;
@@ -973,7 +973,7 @@ where
             reference_id: queryable_content_fields.reference_id,
             sequence_id: None,
             originator_id: None,
-            message_disappear_in_ns: None,
+            expire_at_ns: None,
         };
         group_message.store(provider.db())?;
 

--- a/xmtp_mls/src/test/mock/generate.rs
+++ b/xmtp_mls/src/test/mock/generate.rs
@@ -144,6 +144,6 @@ pub fn generate_stored_msg(id: u64, group_id: Vec<u8>) -> StoredGroupMessage {
         reference_id: None,
         sequence_id: Some(id as i64),
         originator_id: Some(100),
-        message_disappear_in_ns: None,
+        expire_at_ns: None,
     }
 }

--- a/xmtp_mls/src/test/mock/generate.rs
+++ b/xmtp_mls/src/test/mock/generate.rs
@@ -144,5 +144,6 @@ pub fn generate_stored_msg(id: u64, group_id: Vec<u8>) -> StoredGroupMessage {
         reference_id: None,
         sequence_id: Some(id as i64),
         originator_id: Some(100),
+        message_disappear_in_ns: None,
     }
 }


### PR DESCRIPTION
Issue: if a message sent during the disappearing messages is enabled, if the settings gets disabled, the message never gets deleted.

Why: in the current design, we look at the group settings and then delete the messages accordingly.

Solution: When we want to insert a message, store the disappearing settings with the message upon receiving it.