### PR TITLE
increase max installations to 15

### DIFF
--- a/xmtp_mls/src/configuration.rs
+++ b/xmtp_mls/src/configuration.rs
@@ -31,7 +31,7 @@ pub const SEND_MESSAGE_UPDATE_INSTALLATIONS_INTERVAL_NS: i64 = 5 * NS_IN_SEC;
 
 pub const MAX_GROUP_SIZE: usize = 250;
 
-pub const MAX_INSTALLATIONS_PER_INBOX: usize = 5;
+pub const MAX_INSTALLATIONS_PER_INBOX: usize = 15;
 
 pub const MAX_PAST_EPOCHS: usize = 3;
 


### PR DESCRIPTION
### Increase `MAX_INSTALLATIONS_PER_INBOX` constant from 5 to 15 in xmtp_mls configuration
The `MAX_INSTALLATIONS_PER_INBOX` constant in [xmtp_mls/src/configuration.rs](https://github.com/xmtp/libxmtp/pull/2236/files#diff-80e1437765f38906f066439ad9805b99205fb55f992bceb400a9d091628b6942) is modified from 5 to 15, tripling the maximum number of installations that can be associated with a single inbox.

#### 📍Where to Start
Start with the `MAX_INSTALLATIONS_PER_INBOX` constant definition in [xmtp_mls/src/configuration.rs](https://github.com/xmtp/libxmtp/pull/2236/files#diff-80e1437765f38906f066439ad9805b99205fb55f992bceb400a9d091628b6942).

----

_[Macroscope](https://app.macroscope.com) summarized 17b41c9._