### PR TITLE
longer sleep for stream tests

### DIFF
--- a/bindings_node/test/Conversations.test.ts
+++ b/bindings_node/test/Conversations.test.ts
@@ -761,6 +761,8 @@ describe('Conversations', () => {
       identifierKind: IdentifierKind.Ethereum,
     })
 
+    await sleep(2000)
+
     let messages: Message[] = []
     const stream = client1.conversations().streamAllMessages(
       (err, message) => {
@@ -824,6 +826,8 @@ describe('Conversations', () => {
       identifier: user4.account.address,
       identifierKind: IdentifierKind.Ethereum,
     })
+
+    await sleep(2000)
 
     let messages: Message[] = []
     const stream = client1.conversations().streamAllMessages(


### PR DESCRIPTION
### Increase sleep durations in stream tests from 1000ms to 2000ms and add explicit 2000ms delay in Conversations test suite
This pull request modifies sleep durations in the [Conversations.test.ts](https://github.com/xmtp/libxmtp/pull/2239/files#diff-2d2b8de39b39ebe052b06ef17ea6993a04def81ad8062078d799151ff5580b4d) test file to address timing issues in stream tests. The changes increase one `sleep()` call from 1000ms to 2000ms and add an explicit 2000ms parameter to another `sleep()` call that previously had no specified duration.

#### 📍Where to Start
Start with the modified `sleep()` calls in [Conversations.test.ts](https://github.com/xmtp/libxmtp/pull/2239/files#diff-2d2b8de39b39ebe052b06ef17ea6993a04def81ad8062078d799151ff5580b4d) to review the timing adjustments made to the test cases.



#### Changes since #2239 opened

- Added a 2-second delay in conversation streaming test [31c7497]
- Added 2-second delays before streaming messages in conversation tests [98d7da5]
----

_[Macroscope](https://app.macroscope.com) summarized 98d7da5._