### PR TITLE
Update stream_preferences generated type

### DIFF
--- a/bindings_node/src/conversations.rs
+++ b/bindings_node/src/conversations.rs
@@ -674,9 +674,7 @@ impl Conversations {
     Ok(StreamCloser::new(stream_closer))
   }
 
-  #[napi(
-    ts_args_type = "callback: (err: null | Error, result: any[] | undefined) => void, onClose: () => void"
-  )]
+  #[napi(ts_args_type = "callback: (err: null | Error, result: any) => void, onClose: () => void")]
   pub fn stream_preferences(
     &self,
     callback: JsFunction,


### PR DESCRIPTION
### Update TypeScript type annotation for `stream_preferences` callback parameter in Conversations class from array to single value
Changes the TypeScript type annotation for the callback function parameter in the `stream_preferences` method of the Conversations class in [bindings_node/src/conversations.rs](https://github.com/xmtp/libxmtp/pull/2242/files#diff-305d8a9df912ee15a450791cf1af33e26798a0a4877f6a4dc457d291914bc126). The callback's `result` parameter type changes from `any[] | undefined` to `any`, modifying the expected return type from an array of values or undefined to a single value of any type.

#### 📍Where to Start
Start with the `stream_preferences` method in the Conversations class in [bindings_node/src/conversations.rs](https://github.com/xmtp/libxmtp/pull/2242/files#diff-305d8a9df912ee15a450791cf1af33e26798a0a4877f6a4dc457d291914bc126).

----

_[Macroscope](https://app.macroscope.com) summarized c24a55d._