### PR TITLE
functions for saving the remote commit log

### DIFF
--- a/xmtp_db/src/encrypted_store/group.rs
+++ b/xmtp_db/src/encrypted_store/group.rs
@@ -595,11 +595,13 @@ impl<C: ConnectionExt> DbConnection<C> {
         self.raw_query_read(|conn| query.load::<Vec<u8>>(conn))
     }
 
+    // All dms and groups that are note sync groups or rejected
     pub fn get_conversation_ids_for_remote_log_download(
         &self,
     ) -> Result<Vec<Vec<u8>>, crate::ConnectionError> {
         let query = dsl::groups
             .filter(dsl::conversation_type.ne(ConversationType::Sync))
+            .filter(dsl::membership_state.ne(GroupMembershipState::Rejected))
             .select(dsl::id);
 
         self.raw_query_read(|conn| query.load::<Vec<u8>>(conn))

--- a/xmtp_db/src/encrypted_store/group.rs
+++ b/xmtp_db/src/encrypted_store/group.rs
@@ -673,7 +673,6 @@ impl<C: ConnectionExt> QueryGroup<C> for DbConnection<C> {
                         .eq(ConversationType::Group)
                         .and(dsl::should_publish_commit_log.eq(true))),
             )
-            .filter(dsl::membership_state.ne(GroupMembershipState::Rejected))
             .select(dsl::id)
             .order(dsl::created_at_ns.asc());
 
@@ -686,7 +685,6 @@ impl<C: ConnectionExt> QueryGroup<C> for DbConnection<C> {
     ) -> Result<Vec<Vec<u8>>, crate::ConnectionError> {
         let query = dsl::groups
             .filter(dsl::conversation_type.ne(ConversationType::Sync))
-            .filter(dsl::membership_state.ne(GroupMembershipState::Rejected))
             .select(dsl::id);
 
         self.raw_query_read(|conn| query.load::<Vec<u8>>(conn))

--- a/xmtp_db/src/encrypted_store/mod.rs
+++ b/xmtp_db/src/encrypted_store/mod.rs
@@ -38,6 +38,7 @@ pub mod remote_commit_log;
 pub use self::db_connection::DbConnection;
 pub use diesel::sqlite::{Sqlite, SqliteConnection};
 use openmls_traits::OpenMlsProvider;
+use prost::DecodeError;
 use xmtp_common::{RetryableError, retryable};
 
 use super::{StorageError, xmtp_openmls_provider::XmtpOpenMlsProvider};
@@ -89,6 +90,8 @@ pub enum ConnectionError {
     Database(#[from] diesel::result::Error),
     #[error(transparent)]
     Platform(#[from] PlatformStorageError),
+    #[error(transparent)]
+    DecodeError(#[from] DecodeError),
 }
 
 impl RetryableError for ConnectionError {
@@ -96,6 +99,7 @@ impl RetryableError for ConnectionError {
         match self {
             Self::Database(d) => retryable!(d),
             Self::Platform(n) => retryable!(n),
+            Self::DecodeError(_) => false,
         }
     }
 }

--- a/xmtp_db/src/encrypted_store/refresh_state.rs
+++ b/xmtp_db/src/encrypted_store/refresh_state.rs
@@ -18,7 +18,8 @@ use crate::{
 pub enum EntityKind {
     Welcome = 1,
     Group = 2,
-    PublishedCommitLog = 3,
+    CommitLogUpload = 3, // Last local entry we uploaded to the remote commit log
+    CommitLogDownload = 4, // Last remote entry we downloaded from the remote commit log
 }
 
 impl std::fmt::Display for EntityKind {
@@ -27,7 +28,8 @@ impl std::fmt::Display for EntityKind {
         match self {
             Welcome => write!(f, "welcome"),
             Group => write!(f, "group"),
-            PublishedCommitLog => write!(f, "commit_log"),
+            CommitLogUpload => write!(f, "commit_log_upload"),
+            CommitLogDownload => write!(f, "commit_log_download"),
         }
     }
 }
@@ -50,7 +52,8 @@ where
         match i32::from_sql(bytes)? {
             1 => Ok(EntityKind::Welcome),
             2 => Ok(EntityKind::Group),
-            3 => Ok(EntityKind::PublishedCommitLog),
+            3 => Ok(EntityKind::CommitLogUpload),
+            4 => Ok(EntityKind::CommitLogDownload),
             x => Err(format!("Unrecognized variant {}", x).into()),
         }
     }

--- a/xmtp_mls/src/groups/commit_log.rs
+++ b/xmtp_mls/src/groups/commit_log.rs
@@ -371,7 +371,7 @@ where
         let mut latest_download_cursor = 0;
         let mut latest_sequence_id = 0;
         for entry in commit_log_response.commit_log_entries {
-            // TODO(cam): we will have to decrypt here 
+            // TODO(cam): we will have to decrypt here
             let log_entry =
                 PlaintextCommitLogEntry::decode(entry.encrypted_commit_log_entry.as_slice())?;
             RemoteCommitLog {

--- a/xmtp_mls/src/groups/commit_log.rs
+++ b/xmtp_mls/src/groups/commit_log.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 
 /// Interval at which the CommitLogWorker runs to publish commit log entries.
-pub const INTERVAL_DURATION: Duration = Duration::from_secs(5);
+pub const INTERVAL_DURATION: Duration = Duration::from_secs(60 * 5); // 5 minutes
 
 #[derive(Clone)]
 pub struct Factory<Context> {
@@ -299,6 +299,8 @@ where
         // Step 1 is to collect a list of remote log cursors for all conversations and convert them into query log requests
         let remote_log_cursors =
             conn.get_remote_log_cursors(conversation_ids_for_remote_log_download.as_slice())?;
+        // For now we will rely on next iteration of the worker to download the next batch of commit log entries
+        // if there is more than MAX_PAGE_SIZE entries to download per group
         let query_log_requests: Vec<QueryCommitLogRequest> = remote_log_cursors
             .iter()
             .map(|(conversation_id, cursor)| QueryCommitLogRequest {

--- a/xmtp_mls/src/groups/commit_log.rs
+++ b/xmtp_mls/src/groups/commit_log.rs
@@ -371,6 +371,7 @@ where
         let mut latest_download_cursor = 0;
         let mut latest_sequence_id = 0;
         for entry in commit_log_response.commit_log_entries {
+            // TODO(cam): we will have to decrypt here 
             let log_entry =
                 PlaintextCommitLogEntry::decode(entry.encrypted_commit_log_entry.as_slice())?;
             RemoteCommitLog {

--- a/xmtp_mls/src/groups/tests/test_remote_commit_log.rs
+++ b/xmtp_mls/src/groups/tests/test_remote_commit_log.rs
@@ -163,7 +163,7 @@ async fn test_publish_commit_log_to_remote() {
     let last_commit_log_entry = commit_log_entries.last().unwrap();
     // Verify that the local cursor has now been updated to the last commit log entry's sequence id
     assert_eq!(
-        last_commit_log_entry.commit_sequence_id,
+        last_commit_log_entry.rowid as i64,
         published_commit_log_cursor
     );
 

--- a/xmtp_mls/src/groups/tests/test_remote_commit_log.rs
+++ b/xmtp_mls/src/groups/tests/test_remote_commit_log.rs
@@ -1,4 +1,4 @@
-use crate::groups::commit_log::CommitLogWorker;
+use crate::groups::commit_log::{CommitLogTestFunction, CommitLogWorker};
 use crate::{context::XmtpContextProvider, tester};
 use prost::Message;
 use rand::Rng;
@@ -137,14 +137,16 @@ async fn test_publish_commit_log_to_remote() {
         .db()
         .get_last_cursor_for_id(
             &alix_group.group_id,
-            xmtp_db::refresh_state::EntityKind::PublishedCommitLog,
+            xmtp_db::refresh_state::EntityKind::CommitLogUpload,
         )
         .unwrap();
     assert_eq!(published_commit_log_cursor, 0);
 
     // Alix runs the commit log worker, which will publish the commit log entry to the remote commit log
     let mut commit_log_worker = CommitLogWorker::new(alix.context.clone());
-    let result = commit_log_worker.run_test(Some(1)).await;
+    let result = commit_log_worker
+        .run_test(CommitLogTestFunction::PublishCommitLogsToRemote, Some(1))
+        .await;
     assert!(result.is_ok());
 
     let published_commit_log_cursor = alix
@@ -152,7 +154,7 @@ async fn test_publish_commit_log_to_remote() {
         .db()
         .get_last_cursor_for_id(
             &alix_group.group_id,
-            xmtp_db::refresh_state::EntityKind::PublishedCommitLog,
+            xmtp_db::refresh_state::EntityKind::CommitLogUpload,
         )
         .unwrap();
     assert!(published_commit_log_cursor > 0);

--- a/xmtp_mls/src/groups/tests/test_remote_commit_log.rs
+++ b/xmtp_mls/src/groups/tests/test_remote_commit_log.rs
@@ -187,3 +187,310 @@ async fn test_publish_commit_log_to_remote() {
         last_commit_log_entry.commit_sequence_id as u64
     );
 }
+
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_download_commit_log_from_remote() {
+    tester!(alix);
+    tester!(bo);
+
+    let alix_group = alix.create_group(None, None).unwrap();
+    alix_group
+        .add_members_by_inbox_id(&[bo.inbox_id()])
+        .await
+        .unwrap();
+
+    alix_group
+        .update_group_name("foo".to_string())
+        .await
+        .unwrap();
+    alix_group
+        .update_group_name("bar".to_string())
+        .await
+        .unwrap();
+
+    bo.sync_all_welcomes_and_groups(None).await.unwrap();
+    let binding = bo.find_groups(GroupQueryArgs::default()).unwrap();
+    let bo_group = binding.first().unwrap();
+    bo_group.sync().await.unwrap();
+    bo_group
+        .update_group_name("bo group name".to_string())
+        .await
+        .unwrap();
+    alix_group.sync().await.unwrap();
+
+    // Before Alix publishes commits upload commit cursor should be 0 for both groups:
+    let alix_group_1_cursor = alix
+        .provider
+        .db()
+        .get_last_cursor_for_id(
+            &alix_group.group_id,
+            xmtp_db::refresh_state::EntityKind::CommitLogUpload,
+        )
+        .unwrap();
+    assert_eq!(alix_group_1_cursor, 0);
+
+    // Verify that publish works as expected
+    let mut commit_log_worker = CommitLogWorker::new(alix.context.clone());
+    let test_results = commit_log_worker
+        .run_test(CommitLogTestFunction::PublishCommitLogsToRemote, Some(1))
+        .await
+        .unwrap();
+    // We only ran the worker one time
+    assert_eq!(test_results.len(), 1);
+    // We published commit log entries for one group
+    assert_eq!(
+        test_results[0]
+            .publish_commit_log_results
+            .as_ref()
+            .unwrap()
+            .len(),
+        1
+    );
+    // We have saved zero remote commit log entries so far
+    assert!(test_results[0].save_remote_commit_log_results.is_none());
+
+    // Running for bo and charlie should have no publish commit log results since they are not super admins
+    let mut commit_log_worker = CommitLogWorker::new(bo.context.clone());
+    let bo_test_results = commit_log_worker
+        .run_test(CommitLogTestFunction::PublishCommitLogsToRemote, Some(1))
+        .await
+        .unwrap();
+    assert_eq!(bo_test_results.len(), 1);
+    assert!(bo_test_results[0]
+        .publish_commit_log_results
+        .as_ref()
+        .unwrap()
+        .is_empty());
+
+    // Verify the number of commits published results for alix group 1
+    assert_eq!(
+        test_results[0].publish_commit_log_results.clone().unwrap()[0].conversation_id,
+        alix_group.group_id
+    );
+    assert_eq!(
+        test_results[0].publish_commit_log_results.clone().unwrap()[0].num_entries_published,
+        4
+    );
+
+    // After Alix publishes commits upload commit cursor should be equal to publish results last rowid for both groups:
+    let alix_group_1_cursor = alix
+        .provider
+        .db()
+        .get_last_cursor_for_id(
+            &alix_group.group_id,
+            xmtp_db::refresh_state::EntityKind::CommitLogUpload,
+        )
+        .unwrap();
+
+    let alix_group1_publish_result_upload_cursor =
+        test_results[0].publish_commit_log_results.clone().unwrap()[0].last_entry_published_rowid;
+    assert_eq!(
+        alix_group_1_cursor,
+        alix_group1_publish_result_upload_cursor
+    );
+
+    // Verify that when we save remote commit log entries for alix and bo, that we get the same results
+    let mut commit_log_worker_alix = CommitLogWorker::new(alix.context.clone());
+    let alix_test_results = commit_log_worker_alix
+        .run_test(CommitLogTestFunction::SaveRemoteCommitLog, None)
+        .await
+        .unwrap();
+    let mut commit_log_worker_bo = CommitLogWorker::new(bo.context.clone());
+    let bo_test_results = commit_log_worker_bo
+        .run_test(CommitLogTestFunction::SaveRemoteCommitLog, None)
+        .await
+        .unwrap();
+    assert_eq!(alix_test_results.len(), 1);
+    assert_eq!(
+        alix_test_results[0]
+            .save_remote_commit_log_results
+            .as_ref()
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(
+        alix_test_results[0]
+            .save_remote_commit_log_results
+            .as_ref()
+            .unwrap()[0]
+            .conversation_id,
+        alix_group.group_id
+    );
+    assert_eq!(
+        alix_test_results[0]
+            .save_remote_commit_log_results
+            .as_ref()
+            .unwrap()[0]
+            .num_entries_saved,
+        4
+    );
+
+    assert_eq!(bo_test_results.len(), 1);
+    assert_eq!(
+        bo_test_results[0]
+            .save_remote_commit_log_results
+            .as_ref()
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(
+        bo_test_results[0]
+            .save_remote_commit_log_results
+            .as_ref()
+            .unwrap()[0]
+            .conversation_id,
+        bo_group.group_id
+    );
+    assert_eq!(
+        bo_test_results[0]
+            .save_remote_commit_log_results
+            .as_ref()
+            .unwrap()[0]
+            .num_entries_saved,
+        4
+    );
+
+    // Verify that cursor works as expected for saving new remote commit log entries
+    alix_group
+        .update_group_name("one".to_string())
+        .await
+        .unwrap();
+    alix_group
+        .update_group_name("two".to_string())
+        .await
+        .unwrap();
+    alix_group.sync().await.unwrap();
+    bo_group.sync().await.unwrap();
+
+    let mut commit_log_worker_alix = CommitLogWorker::new(alix.context.clone());
+    let alix_test_results = commit_log_worker_alix
+        .run_test(CommitLogTestFunction::All, None)
+        .await
+        .unwrap();
+
+    // Alix should only have saved 2 new remote commit log entries
+    assert_eq!(
+        alix_test_results[0]
+            .publish_commit_log_results
+            .as_ref()
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(
+        alix_test_results[0]
+            .publish_commit_log_results
+            .as_ref()
+            .unwrap()[0]
+            .conversation_id,
+        alix_group.group_id
+    );
+    assert_eq!(
+        alix_test_results[0]
+            .publish_commit_log_results
+            .as_ref()
+            .unwrap()[0]
+            .num_entries_published,
+        2
+    );
+    assert_eq!(
+        alix_test_results[0]
+            .save_remote_commit_log_results
+            .as_ref()
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(
+        alix_test_results[0]
+            .save_remote_commit_log_results
+            .as_ref()
+            .unwrap()[0]
+            .conversation_id,
+        alix_group.group_id
+    );
+    assert_eq!(
+        alix_test_results[0]
+            .save_remote_commit_log_results
+            .as_ref()
+            .unwrap()[0]
+            .num_entries_saved,
+        2
+    );
+
+    alix_group
+        .update_group_name("three".to_string())
+        .await
+        .unwrap();
+    alix_group
+        .update_group_name("four".to_string())
+        .await
+        .unwrap();
+    alix_group.sync().await.unwrap();
+    bo_group.sync().await.unwrap();
+
+    let mut commit_log_worker_alix = CommitLogWorker::new(alix.context.clone());
+    let alix_test_results = commit_log_worker_alix
+        .run_test(CommitLogTestFunction::All, None)
+        .await
+        .unwrap();
+
+    let mut commit_log_worker_bo = CommitLogWorker::new(bo.context.clone());
+    let bo_test_results = commit_log_worker_bo
+        .run_test(CommitLogTestFunction::All, None)
+        .await
+        .unwrap();
+
+    // Alix should have saved 2 new entries, while bo should have saved 4
+    assert_eq!(
+        alix_test_results[0]
+            .save_remote_commit_log_results
+            .as_ref()
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(
+        alix_test_results[0]
+            .save_remote_commit_log_results
+            .as_ref()
+            .unwrap()[0]
+            .conversation_id,
+        alix_group.group_id
+    );
+    assert_eq!(
+        alix_test_results[0]
+            .save_remote_commit_log_results
+            .as_ref()
+            .unwrap()[0]
+            .num_entries_saved,
+        2
+    );
+
+    assert_eq!(
+        bo_test_results[0]
+            .save_remote_commit_log_results
+            .as_ref()
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(
+        bo_test_results[0]
+            .save_remote_commit_log_results
+            .as_ref()
+            .unwrap()[0]
+            .conversation_id,
+        bo_group.group_id
+    );
+    assert_eq!(
+        bo_test_results[0]
+            .save_remote_commit_log_results
+            .as_ref()
+            .unwrap()[0]
+            .num_entries_saved,
+        4
+    );
+}


### PR DESCRIPTION
See tracking issue https://github.com/xmtp/libxmtp/issues/2102

### Add functions for saving the remote commit log by implementing separate upload and download operations for commit logs in the XMTP database and MLS groups
- Splits commit log operations into separate upload and download workflows by renaming `QueryGroup::get_conversation_ids_for_remote_log()` to `get_conversation_ids_for_remote_log_publish()` and adding `get_conversation_ids_for_remote_log_download()` in [xmtp_db/src/encrypted_store/group.rs](https://github.com/xmtp/libxmtp/pull/2244/files#diff-e3d4940853a1045db514d5c1a48581d9ef53da4ba45a7cb8387c72c99c475b5a)
- Replaces `EntityKind::PublishedCommitLog` with `EntityKind::CommitLogUpload` and adds `EntityKind::CommitLogDownload` to distinguish between upload and download cursor tracking in [xmtp_db/src/encrypted_store/refresh_state.rs](https://github.com/xmtp/libxmtp/pull/2244/files#diff-3eb320843309b9973b2ceaf8240120758bd1f2524b263d9a6b869b33266804ea)
- Implements `CommitLogWorker::save_remote_commit_log()` method to query, download, and store remote commit log entries locally with cursor management in [xmtp_mls/src/groups/commit_log.rs](https://github.com/xmtp/libxmtp/pull/2244/files#diff-c25dc4d36a6249375b1001e9c4b66e50034909d2fc05025a45476e115429dc3a)
- Adds `RemoteCommitLog` store functionality and `From<ProtoCommitResult>` conversion with MAX_PAGE_SIZE constant of 100 for pagination in [xmtp_db/src/encrypted_store/remote_commit_log.rs](https://github.com/xmtp/libxmtp/pull/2244/files#diff-cfcb5baf7f2bdfbb485a1f78af11355094f6dd1c3dc120f9bfe41312c6ee731a)
- Extends `ConnectionError` enum with `DecodeError` variant for `prost::DecodeError` handling in [xmtp_db/src/encrypted_store/mod.rs](https://github.com/xmtp/libxmtp/pull/2244/files#diff-7c11a42d3a8d1e571eea6a833dfe388063c036317c4d7a6fbce207fbb3beb387)

#### 📍Where to Start
Start with the `save_remote_commit_log()` method in [xmtp_mls/src/groups/commit_log.rs](https://github.com/xmtp/libxmtp/pull/2244/files#diff-c25dc4d36a6249375b1001e9c4b66e50034909d2fc05025a45476e115429dc3a) to understand the main workflow for downloading and saving remote commit logs.



#### Changes since #2244 opened

- Removed membership state filters from database queries in QueryGroup implementation [44c832a]
----

_[Macroscope](https://app.macroscope.com) summarized 44c832a._