### PR TITLE
Allow setting `app_version` when creating an API client

### DIFF
--- a/bindings_ffi/benches/create_client.rs
+++ b/bindings_ffi/benches/create_client.rs
@@ -58,7 +58,7 @@ fn create_ffi_client(c: &mut Criterion) {
                     let inbox_id = ident.inbox_id(nonce).unwrap();
                     let path = tmp_path();
                     let (url, is_secure) = network_url();
-                    let api = xmtpv3::mls::connect_to_backend(url, is_secure)
+                    let api = xmtpv3::mls::connect_to_backend(url, is_secure, None)
                         .await
                         .unwrap();
                     (
@@ -113,7 +113,7 @@ fn cached_create_ffi_client(c: &mut Criterion) {
     let path = tmp_path();
     let (url, is_secure) = network_url();
     let api = runtime.block_on(async {
-        let api = xmtpv3::mls::connect_to_backend(url.clone(), is_secure)
+        let api = xmtpv3::mls::connect_to_backend(url.clone(), is_secure, None)
             .await
             .unwrap();
         xmtpv3::mls::create_client(

--- a/bindings_ffi/src/mls/test_utils.rs
+++ b/bindings_ffi/src/mls/test_utils.rs
@@ -148,7 +148,7 @@ where
     let inbox_id = ident.inbox_id(nonce).unwrap();
 
     let client = create_client(
-        connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false)
+        connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
             .await
             .unwrap(),
         Some(tmp_path()),

--- a/bindings_node/src/inbox_state.rs
+++ b/bindings_node/src/inbox_state.rs
@@ -91,7 +91,7 @@ pub async fn inbox_state_from_inbox_ids(
   host: String,
   inbox_ids: Vec<String>,
 ) -> Result<Vec<InboxState>> {
-  let api_client = TonicApiClient::create(host, true)
+  let api_client = TonicApiClient::create(&host, true, None::<String>)
     .await
     .map_err(ErrorWrapper::from)?;
 

--- a/bindings_node/src/signatures.rs
+++ b/bindings_node/src/signatures.rs
@@ -53,7 +53,7 @@ pub async fn revoke_installations_signature_request(
   inbox_id: String,
   installation_ids: Vec<Uint8Array>,
 ) -> Result<SignatureRequestHandle> {
-  let api_client = TonicApiClient::create(host, true)
+  let api_client = TonicApiClient::create(host, true, None::<String>)
     .await
     .map_err(ErrorWrapper::from)?;
 
@@ -81,7 +81,7 @@ pub async fn apply_signature_request(
   host: String,
   signature_request: &SignatureRequestHandle,
 ) -> Result<()> {
-  let api_client = TonicApiClient::create(host, true)
+  let api_client = TonicApiClient::create(host, true, None::<String>)
     .await
     .map_err(ErrorWrapper::from)?;
 

--- a/bindings_node/src/test_utils.rs
+++ b/bindings_node/src/test_utils.rs
@@ -65,6 +65,7 @@ pub async fn create_local_toxic_client(
     log_options,
     allow_offline,
     disable_events,
+    None,
   )
   .await?;
   Ok(TestClient { inner: c, proxy })

--- a/bindings_node/test/Client.test.ts
+++ b/bindings_node/test/Client.test.ts
@@ -24,6 +24,15 @@ describe('Client', () => {
     const user = createUser()
     const client = await createClient(user)
     expect(client.isRegistered()).toBe(false)
+    expect(client.appVersion).toBe(null)
+  })
+
+  it('should return client versions', async () => {
+    const user = createUser()
+    const customVersion = 'test'
+    const client = await createClient(user, customVersion)
+    expect(client.appVersion).toBe(customVersion)
+    expect(client.libxmtpVersion()).toBeDefined()
   })
 
   it('should be registered after registration', async () => {

--- a/bindings_node/test/helpers.ts
+++ b/bindings_node/test/helpers.ts
@@ -34,7 +34,7 @@ export const createUser = () => {
 
 export type User = ReturnType<typeof createUser>
 
-export const createClient = async (user: User) => {
+export const createClient = async (user: User, appVersion?: string) => {
   const dbPath = join(__dirname, `${user.uuid}.db3`)
   const inboxId =
     (await getInboxIdForIdentifier(TEST_API_URL, false, {
@@ -59,12 +59,16 @@ export const createClient = async (user: User) => {
     SyncWorkerMode.disabled,
     { level: LogLevel.error },
     undefined,
-    true
+    true,
+    appVersion ?? null
   )
 }
 
-export const createRegisteredClient = async (user: User) => {
-  const client = await createClient(user)
+export const createRegisteredClient = async (
+  user: User,
+  appVersion?: string
+) => {
+  const client = await createClient(user, appVersion)
   if (!client.isRegistered()) {
     const signatureRequest = await client.createInboxSignatureRequest()
     if (signatureRequest) {

--- a/bindings_wasm/src/client.rs
+++ b/bindings_wasm/src/client.rs
@@ -161,7 +161,10 @@ pub async fn create_client(
   init_logging(log_options.unwrap_or_default())?;
   let api_client = XmtpHttpApiClient::new(
     host.clone(),
-    app_version.as_ref().unwrap_or(&"0.0.0".to_string()),
+    app_version
+      .as_ref()
+      .unwrap_or(&"0.0.0".to_string())
+      .to_string(),
   )
   .await?;
 

--- a/bindings_wasm/src/client.rs
+++ b/bindings_wasm/src/client.rs
@@ -159,8 +159,11 @@ pub async fn create_client(
   app_version: Option<String>,
 ) -> Result<Client, JsError> {
   init_logging(log_options.unwrap_or_default())?;
-  let api_client =
-    XmtpHttpApiClient::new(host.clone(), app_version.unwrap_or("0.0.0".to_string())).await?;
+  let api_client = XmtpHttpApiClient::new(
+    host.clone(),
+    app_version.as_ref().unwrap_or(&"0.0.0".to_string()),
+  )
+  .await?;
 
   let storage_option = match db_path {
     Some(path) => StorageOption::Persistent(path),

--- a/bindings_wasm/src/tests/mod.rs
+++ b/bindings_wasm/src/tests/mod.rs
@@ -33,6 +33,7 @@ pub async fn create_test_client(path: Option<String>) -> Client {
     }),
     None,
     None,
+    None,
   )
   .await
   .unwrap();

--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -278,16 +278,18 @@ async fn main() -> color_eyre::eyre::Result<()> {
             let payer = payer.build().await?;
             Arc::new(D14nClient::new(message, payer))
         }
-        (false, Env::Local) => Arc::new(ClientV3::create("http://localhost:5556", false).await?),
+        (false, Env::Local) => {
+            Arc::new(ClientV3::create("http://localhost:5556", false, None).await?)
+        }
         (false, Env::Dev) => {
-            Arc::new(ClientV3::create("https://grpc.dev.xmtp.network:443", true).await?)
+            Arc::new(ClientV3::create("https://grpc.dev.xmtp.network:443", true, None).await?)
         }
         (false, Env::Staging) => {
-            Arc::new(ClientV3::create("https://grpc.dev.xmtp.network:443", true).await?)
+            Arc::new(ClientV3::create("https://grpc.dev.xmtp.network:443", true, None).await?)
         }
-        (false, Env::Production) => {
-            Arc::new(ClientV3::create("https://grpc.production.xmtp.network:443", true).await?)
-        }
+        (false, Env::Production) => Arc::new(
+            ClientV3::create("https://grpc.production.xmtp.network:443", true, None).await?,
+        ),
     };
 
     if let Commands::Register { seed_phrase } = &cli.command {

--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -279,16 +279,21 @@ async fn main() -> color_eyre::eyre::Result<()> {
             Arc::new(D14nClient::new(message, payer))
         }
         (false, Env::Local) => {
-            Arc::new(ClientV3::create("http://localhost:5556", false, None).await?)
+            Arc::new(ClientV3::create("http://localhost:5556", false, None::<String>).await?)
         }
-        (false, Env::Dev) => {
-            Arc::new(ClientV3::create("https://grpc.dev.xmtp.network:443", true, None).await?)
-        }
-        (false, Env::Staging) => {
-            Arc::new(ClientV3::create("https://grpc.dev.xmtp.network:443", true, None).await?)
-        }
+        (false, Env::Dev) => Arc::new(
+            ClientV3::create("https://grpc.dev.xmtp.network:443", true, None::<String>).await?,
+        ),
+        (false, Env::Staging) => Arc::new(
+            ClientV3::create("https://grpc.dev.xmtp.network:443", true, None::<String>).await?,
+        ),
         (false, Env::Production) => Arc::new(
-            ClientV3::create("https://grpc.production.xmtp.network:443", true, None).await?,
+            ClientV3::create(
+                "https://grpc.production.xmtp.network:443",
+                true,
+                None::<String>,
+            )
+            .await?,
         ),
     };
 

--- a/xmtp_api_grpc/src/grpc_api_helper.rs
+++ b/xmtp_api_grpc/src/grpc_api_helper.rs
@@ -37,10 +37,15 @@ pub struct Client {
 }
 
 impl Client {
-    pub async fn create(host: impl ToString, is_secure: bool) -> Result<Self, GrpcBuilderError> {
+    pub async fn create(
+        host: impl ToString,
+        is_secure: bool,
+        app_version: Option<impl ToString>,
+    ) -> Result<Self, GrpcBuilderError> {
         let mut b = Self::builder();
         b.set_tls(is_secure);
         b.set_host(host.to_string());
+        b.set_app_version(app_version.map_or("0.0.0".to_string(), |v| v.to_string()))?;
         b.build().await
     }
 

--- a/xmtp_debug/src/args.rs
+++ b/xmtp_debug/src/args.rs
@@ -276,7 +276,8 @@ impl BackendOpts {
         } else {
             trace!(url = %network, is_secure, "create grpc");
             Ok(Arc::new(
-                crate::GrpcClient::create(network.as_str().to_string(), is_secure, None).await?,
+                crate::GrpcClient::create(network.as_str().to_string(), is_secure, None::<String>)
+                    .await?,
             ))
         }
     }

--- a/xmtp_debug/src/args.rs
+++ b/xmtp_debug/src/args.rs
@@ -276,7 +276,7 @@ impl BackendOpts {
         } else {
             trace!(url = %network, is_secure, "create grpc");
             Ok(Arc::new(
-                crate::GrpcClient::create(network.as_str().to_string(), is_secure).await?,
+                crate::GrpcClient::create(network.as_str().to_string(), is_secure, None).await?,
             ))
         }
     }


### PR DESCRIPTION
### Add optional `app_version` parameter to API client creation functions across bindings and core modules
The changes add an optional `app_version` parameter to API client creation functions throughout the codebase. The `connect_to_backend` function in [bindings_ffi/src/mls.rs](https://github.com/xmtp/libxmtp/pull/2247/files#diff-3a24c3e76565487a710ac9863ac05160128f4f90892e07849b555a6de43a6e8f) now accepts an `Option<String>` for app version and passes it to `TonicApiClient::create()`. Similar modifications are made to client creation functions in Node.js bindings ([bindings_node/src/client.rs](https://github.com/xmtp/libxmtp/pull/2247/files#diff-98dd73d0e8b1dce0a25de3ddbda3a0122baec850f3b6ccbdca525c3370f80f1d)) and WASM bindings ([bindings_wasm/src/client.rs](https://github.com/xmtp/libxmtp/pull/2247/files#diff-4018d4ef72f833b0f071571f93f20e715915d188d98ce9fcd18f7182e111a259)), which also add `app_version()` and `libxmtp_version()` methods to expose version information. The underlying `Client::create` method in [xmtp_api_grpc/src/grpc_api_helper.rs](https://github.com/xmtp/libxmtp/pull/2247/files#diff-e1c5d72313904feb4fa68c2c0b84ba01d9dad309ac9f36e4dd7b63e366bde002) is updated to accept the app version parameter and defaults to "0.0.0" when not provided. All existing call sites are updated to pass `None` for the new parameter, maintaining backward compatibility.

#### 📍Where to Start
Start with the `connect_to_backend` function in [bindings_ffi/src/mls.rs](https://github.com/xmtp/libxmtp/pull/2247/files#diff-3a24c3e76565487a710ac9863ac05160128f4f90892e07849b555a6de43a6e8f) to understand how the new `app_version` parameter is integrated into the API client creation flow.

----

_[Macroscope](https://app.macroscope.com) summarized 3c28807._