### PR TITLE
Adds conversation_type to MlsGroup struct in favor of reading group metadata state for conversation_type

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -1719,7 +1719,7 @@ impl TryFrom<PreferenceUpdate> for FfiPreferenceUpdate {
 #[derive(uniffi::Object, Clone)]
 pub struct FfiConversation {
     inner: RustMlsGroup,
-    conversation_type: FfiConversationType,
+    pub conversation_type: FfiConversationType,
 }
 
 #[derive(uniffi::Object)]

--- a/bindings_node/src/conversation.rs
+++ b/bindings_node/src/conversation.rs
@@ -118,6 +118,7 @@ impl Conversation {
       self.inner_group.context.clone(),
       self.group_id.clone(),
       self.dm_id.clone(),
+      self.inner_group.conversation_type,
       self.created_at_ns,
     )
   }

--- a/bindings_wasm/src/conversation.rs
+++ b/bindings_wasm/src/conversation.rs
@@ -124,6 +124,7 @@ impl Conversation {
       self.inner_group.context.clone(),
       self.group_id.clone(),
       self.dm_id.clone(),
+      self.inner_group.conversation_type,
       self.created_at_ns,
     )
   }

--- a/xmtp_db/src/encrypted_store/group.rs
+++ b/xmtp_db/src/encrypted_store/group.rs
@@ -222,7 +222,10 @@ pub trait QueryGroup<C: ConnectionExt> {
     /// Get conversation IDs for all conversations that require a remote commit log publish (DMs and groups where user is super admin, excluding sync groups)
     fn get_conversation_ids_for_remote_log(&self) -> Result<Vec<Vec<u8>>, crate::ConnectionError>;
 
-    fn get_conversation_type(&self, group_id: &[u8]) -> Result<ConversationType, crate::ConnectionError>;
+    fn get_conversation_type(
+        &self,
+        group_id: &[u8],
+    ) -> Result<ConversationType, crate::ConnectionError>;
 }
 
 impl<C: ConnectionExt> QueryGroup<C> for DbConnection<C> {
@@ -665,8 +668,13 @@ impl<C: ConnectionExt> QueryGroup<C> for DbConnection<C> {
         self.raw_query_read(|conn| query.load::<Vec<u8>>(conn))
     }
 
-    fn get_conversation_type(&self, group_id: &[u8]) -> Result<ConversationType, crate::ConnectionError> {
-        let query = dsl::groups.filter(dsl::id.eq(group_id)).select(dsl::conversation_type);
+    fn get_conversation_type(
+        &self,
+        group_id: &[u8],
+    ) -> Result<ConversationType, crate::ConnectionError> {
+        let query = dsl::groups
+            .filter(dsl::id.eq(group_id))
+            .select(dsl::conversation_type);
         let conversation_type = self.raw_query_read(|conn| query.first(conn))?;
         Ok(conversation_type)
     }

--- a/xmtp_db/src/encrypted_store/group.rs
+++ b/xmtp_db/src/encrypted_store/group.rs
@@ -221,6 +221,8 @@ pub trait QueryGroup<C: ConnectionExt> {
 
     /// Get conversation IDs for all conversations that require a remote commit log publish (DMs and groups where user is super admin, excluding sync groups)
     fn get_conversation_ids_for_remote_log(&self) -> Result<Vec<Vec<u8>>, crate::ConnectionError>;
+
+    fn get_conversation_type(&self, group_id: &[u8]) -> Result<ConversationType, crate::ConnectionError>;
 }
 
 impl<C: ConnectionExt> QueryGroup<C> for DbConnection<C> {
@@ -661,6 +663,12 @@ impl<C: ConnectionExt> QueryGroup<C> for DbConnection<C> {
             .order(dsl::created_at_ns.asc());
 
         self.raw_query_read(|conn| query.load::<Vec<u8>>(conn))
+    }
+
+    fn get_conversation_type(&self, group_id: &[u8]) -> Result<ConversationType, crate::ConnectionError> {
+        let query = dsl::groups.filter(dsl::id.eq(group_id)).select(dsl::conversation_type);
+        let conversation_type = self.raw_query_read(|conn| query.first(conn))?;
+        Ok(conversation_type)
     }
 }
 

--- a/xmtp_db/src/mock.rs
+++ b/xmtp_db/src/mock.rs
@@ -1,9 +1,9 @@
+use crate::group::ConversationType;
 use crate::local_commit_log::LocalCommitLog;
 use std::sync::{
     Arc,
     atomic::{AtomicBool, Ordering},
 };
-use crate::group::ConversationType;
 
 use diesel::prelude::SqliteConnection;
 use mockall::mock;

--- a/xmtp_db/src/mock.rs
+++ b/xmtp_db/src/mock.rs
@@ -3,6 +3,7 @@ use std::sync::{
     Arc,
     atomic::{AtomicBool, Ordering},
 };
+use crate::group::ConversationType;
 
 use diesel::prelude::SqliteConnection;
 use mockall::mock;
@@ -225,6 +226,7 @@ mock! {
 
         fn has_duplicate_dm(&self, group_id: &[u8]) -> Result<bool, crate::ConnectionError>;
         fn get_conversation_ids_for_remote_log(&self) -> Result<Vec<Vec<u8>>, crate::ConnectionError>;
+        fn get_conversation_type(&self, group_id: &[u8]) -> Result<ConversationType, crate::ConnectionError>;
     }
 
     impl<C: ConnectionExt + 'static> QueryGroupVersion<C> for DbQuery<C> {

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -438,6 +438,7 @@ where
         let group: MlsGroup<Context> = MlsGroup::create_and_insert(
             self.context.clone(),
             GroupMembershipState::Allowed,
+            ConversationType::Group,
             permissions_policy_set.unwrap_or_default(),
             opts.unwrap_or_default(),
         )?;
@@ -550,6 +551,7 @@ where
                 self.context.clone(),
                 group.id,
                 group.dm_id,
+                group.conversation_type,
                 group.created_at_ns,
             ));
         }
@@ -574,7 +576,15 @@ where
         let conn = self.context.db();
         let stored_group = conn.fetch_stitched(group_id)?;
         stored_group
-            .map(|g| MlsGroup::new(self.context.clone(), g.id, g.dm_id, g.created_at_ns))
+            .map(|g| {
+                MlsGroup::new(
+                    self.context.clone(),
+                    g.id,
+                    g.dm_id,
+                    g.conversation_type,
+                    g.created_at_ns,
+                )
+            })
             .ok_or(NotFound::GroupById(group_id.to_vec()))
             .map_err(Into::into)
     }
@@ -621,6 +631,7 @@ where
             self.context.clone(),
             group.id,
             group.dm_id,
+            group.conversation_type,
             group.created_at_ns,
         ))
     }
@@ -687,6 +698,7 @@ where
                         self.context.clone(),
                         conversation_item.id,
                         conversation_item.dm_id,
+                        conversation_item.conversation_type,
                         conversation_item.created_at_ns,
                     ),
                     last_message: message,
@@ -788,7 +800,15 @@ where
             .db()
             .all_sync_groups()?
             .into_iter()
-            .map(|g| MlsGroup::new(self.context.clone(), g.id, g.dm_id, g.created_at_ns))
+            .map(|g| {
+                MlsGroup::new(
+                    self.context.clone(),
+                    g.id,
+                    g.dm_id,
+                    g.conversation_type,
+                    g.created_at_ns,
+                )
+            })
             .collect();
         let active_groups_count = self.sync_all_groups(groups).await?;
 

--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -284,6 +284,7 @@ where
                 self.context.clone(),
                 other_dm.id,
                 other_dm.dm_id.clone(),
+                other_dm.conversation_type,
                 other_dm.created_at_ns,
             );
             other_dm.sync_with_conn().await?;

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -1454,8 +1454,8 @@ where
 
     /// Retrieves the conversation type of the group from the group's metadata extension.
     pub async fn conversation_type(&self) -> Result<ConversationType, GroupError> {
-        let metadata = self.metadata().await?;
-        Ok(metadata.conversation_type)
+        let conversation_type = self.context.db().get_conversation_type(&self.group_id)?;
+        Ok(conversation_type)
     }
 
     /// Updates the admin list of the group and syncs the changes to the network.

--- a/xmtp_mls/src/groups/tests/mod.rs
+++ b/xmtp_mls/src/groups/tests/mod.rs
@@ -1210,6 +1210,7 @@ async fn test_removed_members_cannot_send_message_to_others() {
         bola.context.clone(),
         amal_group.group_id.clone(),
         amal_group.dm_id.clone(),
+        amal_group.conversation_type,
         amal_group.created_at_ns,
     );
     bola_group

--- a/xmtp_mls/src/groups/welcome_sync.rs
+++ b/xmtp_mls/src/groups/welcome_sync.rs
@@ -150,7 +150,15 @@ where
         let groups = db
             .all_sync_groups()?
             .into_iter()
-            .map(|g| MlsGroup::new(self.context.clone(), g.id, g.dm_id, g.created_at_ns))
+            .map(|g| {
+                MlsGroup::new(
+                    self.context.clone(),
+                    g.id,
+                    g.dm_id,
+                    g.conversation_type,
+                    g.created_at_ns,
+                )
+            })
             .collect();
         let active_groups_count = self.sync_all_groups(groups).await?;
 
@@ -180,7 +188,15 @@ where
 
         let groups: Vec<MlsGroup<Context>> = conversations
             .into_iter()
-            .map(|c| MlsGroup::new(self.context.clone(), c.id, c.dm_id, c.created_at_ns))
+            .map(|c| {
+                MlsGroup::new(
+                    self.context.clone(),
+                    c.id,
+                    c.dm_id,
+                    c.conversation_type,
+                    c.created_at_ns,
+                )
+            })
             .collect();
 
         let success_count = self.sync_groups_in_batches(groups, 10).await?;

--- a/xmtp_mls/src/mls_store.rs
+++ b/xmtp_mls/src/mls_store.rs
@@ -146,6 +146,7 @@ where
                     self.context.clone(),
                     stored_group.id,
                     stored_group.dm_id,
+                    stored_group.conversation_type,
                     stored_group.created_at_ns,
                 )
             })
@@ -160,7 +161,15 @@ where
         let conn = self.context.db();
         let stored_group: Option<StoredGroup> = conn.fetch(group_id)?;
         stored_group
-            .map(|g| MlsGroup::new(self.context.clone(), g.id, g.dm_id, g.created_at_ns))
+            .map(|g| {
+                MlsGroup::new(
+                    self.context.clone(),
+                    g.id,
+                    g.dm_id,
+                    g.conversation_type,
+                    g.created_at_ns,
+                )
+            })
             .ok_or(NotFound::GroupById(group_id.clone()))
             .map_err(Into::into)
     }

--- a/xmtp_mls/src/subscriptions/process_message/factory.rs
+++ b/xmtp_mls/src/subscriptions/process_message/factory.rs
@@ -11,6 +11,7 @@ use crate::subscriptions::process_message::MessageIdentifierBuilder;
 use crate::subscriptions::SubscribeError;
 use tracing::Instrument;
 use xmtp_common::{retry_async, Retry};
+use xmtp_db::group::ConversationType;
 use xmtp_db::prelude::*;
 use xmtp_db::{group_message::StoredGroupMessage, refresh_state::EntityKind, StorageError};
 use xmtp_proto::mls_v1::group_message;
@@ -107,6 +108,7 @@ where
             self.0.clone(),
             msg.group_id.clone(),
             None,
+            ConversationType::Sync,
             msg.created_ns as i64,
         );
         match group.sync_with_conn().await {

--- a/xmtp_mls/src/subscriptions/process_message/factory.rs
+++ b/xmtp_mls/src/subscriptions/process_message/factory.rs
@@ -108,7 +108,7 @@ where
             self.0.clone(),
             msg.group_id.clone(),
             None,
-            ConversationType::Sync,
+            ConversationType::Group,
             msg.created_ns as i64,
         );
         match group.sync_with_conn().await {

--- a/xmtp_mls/src/subscriptions/process_welcome.rs
+++ b/xmtp_mls/src/subscriptions/process_welcome.rs
@@ -319,6 +319,7 @@ where
                 self.context.clone(),
                 group.id,
                 group.dm_id,
+                group.conversation_type,
                 group.created_at_ns,
             ),
             id,

--- a/xmtp_mls/src/subscriptions/stream_messages/unit_tests.rs
+++ b/xmtp_mls/src/subscriptions/stream_messages/unit_tests.rs
@@ -188,6 +188,8 @@ async fn it_can_stream_messages(#[case] mut cases: Vec<StreamSession>) {
 async fn test_adding_to_stream_works(#[case] cases: Vec<StreamSession>) {
     use std::borrow::Cow;
 
+    use xmtp_db::group::ConversationType;
+
     let group_list = group_list_from_session(&cases);
     let mut sequence = StreamSequenceBuilder::default();
     for case in cases.iter().cloned() {
@@ -212,6 +214,7 @@ async fn test_adding_to_stream_works(#[case] cases: Vec<StreamSession>) {
                     finished.context.clone(),
                     group_id(group.group_id).to_vec(),
                     None,
+                    ConversationType::Group,
                     xmtp_common::time::now_ns(),
                 ))
             }
@@ -270,6 +273,8 @@ async fn test_adding_to_stream_works(#[case] cases: Vec<StreamSession>) {
 ])]
 #[xmtp_common::test]
 async fn it_can_add_to_stream_while_busy(#[case] mut cases: Vec<StreamSession>) {
+    use xmtp_db::group::ConversationType;
+
     let group_list = group_list_from_session(&cases);
     let mut sequence = StreamSequenceBuilder::default();
     for case in cases.iter().cloned() {
@@ -302,6 +307,7 @@ async fn it_can_add_to_stream_while_busy(#[case] mut cases: Vec<StreamSession>) 
                     finished.context.clone(),
                     group_id(group.group_id).to_vec(),
                     None,
+                    ConversationType::Group,
                     xmtp_common::time::now_ns(),
                 ))
             }


### PR DESCRIPTION
See iOS repro test PR this was tested against for performance:

https://github.com/xmtp/xmtp-ios/pull/542

got this three times in a row on my repro before this libxmtp update:
```
syncAllConversations() ▸ 65.385 s for 1201 convos

=== TIMING STATISTICS ===
conversations.list() ▸ avg: 1.465s, max: 50.721s (43 calls)
messages() ▸ avg: 0.002s, max: 0.005s (43 calls)
findConversation() ▸ avg: 0.001s, max: 0.003s (43 calls)
updateConsent() ▸ avg: 0.000s, max: 0.001s (43 calls)
=== END ===
```

and then after conversations.list() never hit the high max again:
```
conversations.list() ▸ avg: 0.017s, max: 0.039s (1698 calls)
messages() ▸ avg: 0.001s, max: 0.013s (1698 calls)
findConversation() ▸ avg: 0.000s, max: 0.006s (1698 calls)
updateConsent() ▸ avg: 0.000s, max: 0.006s (1698 calls)
```

### Store conversation type as field in MlsGroup struct instead of retrieving from group state metadata
The `MlsGroup` struct now stores `conversation_type` as a direct field rather than retrieving it asynchronously from metadata. The `conversation_type()` method changes from an async method that queries metadata to a synchronous method that returns the stored field. All `MlsGroup` creation methods across the codebase are updated to accept and pass the `conversation_type` parameter. The `FfiConversation.conversation_type()` method in [bindings_ffi/src/mls.rs](https://github.com/xmtp/libxmtp/pull/2249/files#diff-3a24c3e76565487a710ac9863ac05160128f4f90892e07849b555a6de43a6e8f) becomes synchronous and directly returns the stored value. A new `get_conversation_type()` method is added to the `QueryGroup` trait in [xmtp_db/src/encrypted_store/group.rs](https://github.com/xmtp/libxmtp/pull/2249/files#diff-e3d4940853a1045db514d5c1a48581d9ef53da4ba45a7cb8387c72c99c475b5a) to retrieve conversation types directly from the database.

#### 📍Where to Start
Start with the `MlsGroup` struct definition and its `conversation_type()` method in [xmtp_mls/src/groups/mod.rs](https://github.com/xmtp/libxmtp/pull/2249/files#diff-c29f56a38916c7410eff8091df1a2e43487ffe20646d96827e846e475f4608d3) to understand how the conversation type field is now stored and accessed.



#### Changes since #2249 opened

- Added conversation_type parameter to MlsGroup constructor call [0c65c4a]
- Changed conversation type parameter in MlsGroup initialization during message recovery [ee2d364]
----

_[Macroscope](https://app.macroscope.com) summarized ee2d364._