### PR TITLE
batch installations in device sync

### DIFF
--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -116,6 +116,10 @@ const MAX_GROUP_DESCRIPTION_LENGTH: usize = 1000;
 const MAX_GROUP_NAME_LENGTH: usize = 100;
 const MAX_GROUP_IMAGE_URL_LENGTH: usize = 2048;
 
+/// An LibXMTP MlsGroup
+/// _NOTE:_ The Eq implementation compares GroupId, so a dm group with the same identity will be
+/// different.
+/// the Hash implementation hashes the GroupID
 pub struct MlsGroup<Context> {
     pub group_id: Vec<u8>,
     pub dm_id: Option<String>,
@@ -124,6 +128,20 @@ pub struct MlsGroup<Context> {
     mls_commit_lock: Arc<GroupCommitLock>,
     mutex: Arc<Mutex<()>>,
 }
+
+impl<C> std::hash::Hash for MlsGroup<C> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.group_id.hash(state);
+    }
+}
+
+impl<C> PartialEq for MlsGroup<C> {
+    fn eq(&self, other: &Self) -> bool {
+        self.group_id == other.group_id
+    }
+}
+
+impl<C> Eq for MlsGroup<C> {}
 
 impl<Context> std::fmt::Debug for MlsGroup<Context>
 where


### PR DESCRIPTION
### Replace direct group processing with queue-based intent system in DeviceSync.add_new_installation_to_groups method for batch installations
The `DeviceSync.add_new_installation_to_groups` method in [device_sync.rs](https://github.com/xmtp/libxmtp/pull/2253/files#diff-fe691b22a6268a0ff6ae46b00e693850b30ea7ced6afe483ee9c97602aaddde2) changes from processing groups in chunks of 10 with direct `add_missing_installations()` calls to using a queue-based approach with `QueueIntent::builder()` for membership updates. The `MlsGroup` struct in [mod.rs](https://github.com/xmtp/libxmtp/pull/2253/files#diff-c29f56a38916c7410eff8091df1a2e43487ffe20646d96827e846e475f4608d3) implements `Hash`, `PartialEq`, and `Eq` traits to enable storage in `HashSet` collections, with equality and hashing based on the `group_id` field.

#### 📍Where to Start
Start with the `add_new_installation_to_groups` method in [device_sync.rs](https://github.com/xmtp/libxmtp/pull/2253/files#diff-fe691b22a6268a0ff6ae46b00e693850b30ea7ced6afe483ee9c97602aaddde2) to understand the core change from direct processing to queue-based intents.

----

_[Macroscope](https://app.macroscope.com) summarized 259d2d7._ (Automatic summaries will resume when PR exits draft mode or review begins).