### PR TITLE
kp rotation hotfix

### DIFF
--- a/xmtp_db/src/encrypted_store/identity.rs
+++ b/xmtp_db/src/encrypted_store/identity.rs
@@ -49,9 +49,8 @@ pub trait QueryIdentity<C: ConnectionExt> {
 
 impl<C: ConnectionExt> QueryIdentity<C> for DbConnection<C> {
     fn queue_key_package_rotation(&self) -> Result<(), StorageError> {
-        let rotate_at_ns = now_ns() + KEY_PACKAGE_QUEUE_INTERVAL_NS;
-
         self.raw_query_write(|conn| {
+            let rotate_at_ns = now_ns() + KEY_PACKAGE_QUEUE_INTERVAL_NS;
             diesel::update(dsl::identity)
                 .filter(dsl::next_key_package_rotation_ns.gt(rotate_at_ns))
                 .set(dsl::next_key_package_rotation_ns.eq(rotate_at_ns))
@@ -69,8 +68,8 @@ impl<C: ConnectionExt> QueryIdentity<C> for DbConnection<C> {
     ) -> Result<(), StorageError> {
         use crate::schema::identity::dsl;
 
-        let queue_interval_ns = now_ns() - KEY_PACKAGE_QUEUE_INTERVAL_NS;
         self.raw_query_write(|conn| {
+            let queue_interval_ns = now_ns() - KEY_PACKAGE_QUEUE_INTERVAL_NS;
             diesel::update(dsl::identity)
                 .filter(
                     dsl::next_key_package_rotation_ns


### PR DESCRIPTION
probably not a full fix but should make this more resistant to locking. `raw_query_write` goes to get a lock from write connection. seems like experience says that those locks can take a bit of time to resolve, possibly preventing reset