### PR TITLE
Make Sync GRPC Channel

### DIFF
--- a/bindings_ffi/benches/create_client.rs
+++ b/bindings_ffi/benches/create_client.rs
@@ -58,11 +58,15 @@ fn create_ffi_client(c: &mut Criterion) {
                     let inbox_id = ident.inbox_id(nonce).unwrap();
                     let path = tmp_path();
                     let (url, is_secure) = network_url();
-                    let api = xmtpv3::mls::connect_to_backend(url, is_secure, None)
+                    let api = xmtpv3::mls::connect_to_backend(url.clone(), is_secure, None)
+                        .await
+                        .unwrap();
+                    let sync_api = xmtpv3::mls::connect_to_backend(url, is_secure, None)
                         .await
                         .unwrap();
                     (
                         api,
+                        sync_api,
                         inbox_id,
                         wallet.identifier(),
                         nonce,
@@ -71,10 +75,11 @@ fn create_ffi_client(c: &mut Criterion) {
                     )
                 })
             },
-            |(api, inbox_id, ident, nonce, path, span)| async move {
+            |(api, sync_api, inbox_id, ident, nonce, path, span)| async move {
                 let ffi_ident: FfiIdentifier = ident.into();
                 xmtpv3::mls::create_client(
                     api,
+                    sync_api,
                     Some(path),
                     Some(vec![0u8; 32]),
                     &inbox_id,
@@ -118,6 +123,7 @@ fn cached_create_ffi_client(c: &mut Criterion) {
             .unwrap();
         xmtpv3::mls::create_client(
             api.clone(),
+            api.clone(),
             Some(path.clone()),
             Some(vec![0u8; 32]),
             &inbox_id.clone(),
@@ -152,6 +158,7 @@ fn cached_create_ffi_client(c: &mut Criterion) {
             |(api, inbox_id, ident, nonce, path, history_sync, span)| async move {
                 let ffi_ident: FfiIdentifier = ident.into();
                 xmtpv3::mls::create_client(
+                    api.clone(),
                     api,
                     Some(path),
                     Some(vec![0u8; 32]),

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -218,6 +218,7 @@ pub async fn apply_signature_request(
 pub async fn create_client(
     api: Arc<XmtpApiClient>,
     sync_api: Arc<XmtpApiClient>,
+    publish_api: Arc<XmtpApiClient>,
     db: Option<String>,
     encryption_key: Option<Vec<u8>>,
     inbox_id: &InboxId,
@@ -269,6 +270,7 @@ pub async fn create_client(
         .api_clients(
             Arc::unwrap_or_clone(api).0,
             Arc::unwrap_or_clone(sync_api).0,
+            Arc::unwrap_or_clone(publish_api).0,
         )
         .enable_api_debug_wrapper()?
         .with_remote_verifier()?

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -218,6 +218,7 @@ pub async fn apply_signature_request(
 #[uniffi::export(async_runtime = "tokio")]
 pub async fn create_client(
     api: Arc<XmtpApiClient>,
+    sync_api: Arc<XmtpApiClient>,
     db: Option<String>,
     encryption_key: Option<Vec<u8>>,
     inbox_id: &InboxId,
@@ -266,7 +267,7 @@ pub async fn create_client(
     );
 
     let mut builder = xmtp_mls::Client::builder(identity_strategy)
-        .api_client(Arc::unwrap_or_clone(api).0)
+        .api_client(Arc::unwrap_or_clone(api).0, Arc::unwrap_or_clone(sync_api).0)
         .enable_api_debug_wrapper()?
         .with_remote_verifier()?
         .with_allow_offline(allow_offline)
@@ -1338,10 +1339,7 @@ impl FfiConversations {
             .create_group(group_permissions, Some(metadata_options))?;
         let duration: std::time::Duration = start.elapsed();
 
-        log::info!(
-            "Lopi: Created inner group in {:?}",
-            duration
-        );
+        log::info!("Lopi: Created inner group in {:?}", duration);
 
         Ok(Arc::new(convo.into()))
     }
@@ -1385,10 +1383,7 @@ impl FfiConversations {
         let convo = self.create_group_optimistic(opts)?;
         let duration: std::time::Duration = start.elapsed();
 
-        log::info!(
-            "Lopi: Created group in {:?}",
-            duration
-        );
+        log::info!("Lopi: Created group in {:?}", duration);
 
         let start = Instant::now();
         if !inbox_ids.is_empty() {
@@ -1398,10 +1393,7 @@ impl FfiConversations {
         };
         let duration: std::time::Duration = start.elapsed();
 
-        log::info!(
-            "Lopi: Add members to group in {:?}",
-            duration
-        );
+        log::info!("Lopi: Add members to group in {:?}", duration);
 
         Ok(convo)
     }
@@ -3325,6 +3317,9 @@ mod tests {
             connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
                 .await
                 .unwrap(),
+            connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
+                .await
+                .unwrap(),
             Some(tmp_path()),
             Some([0u8; 32].to_vec()),
             &inbox_id,
@@ -3357,6 +3352,9 @@ mod tests {
         let inbox_id = ident.inbox_id(nonce).unwrap();
 
         let client = create_client(
+            connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
+                .await
+                .unwrap(),
             connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
                 .await
                 .unwrap(),
@@ -3428,6 +3426,9 @@ mod tests {
             connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
                 .await
                 .unwrap(),
+            connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
+                .await
+                .unwrap(),
             Some(tmp_path()),
             None,
             &inbox_id,
@@ -3458,6 +3459,9 @@ mod tests {
             connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
                 .await
                 .unwrap(),
+            connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
+                .await
+                .unwrap(),
             Some(path.clone()),
             None,
             &inbox_id,
@@ -3477,6 +3481,9 @@ mod tests {
         drop(client_a);
 
         let client_b = create_client(
+            connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
+                .await
+                .unwrap(),
             connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
                 .await
                 .unwrap(),
@@ -3518,6 +3525,9 @@ mod tests {
             connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
                 .await
                 .unwrap(),
+            connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
+                .await
+                .unwrap(),
             Some(path.clone()),
             Some(key),
             &inbox_id,
@@ -3538,6 +3548,9 @@ mod tests {
         other_key[31] = 1;
 
         let result_errored = create_client(
+            connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
+                .await
+                .unwrap(),
             connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
                 .await
                 .unwrap(),
@@ -3591,6 +3604,9 @@ mod tests {
                 .unwrap();
         let client = create_client(
             connection.clone(),
+            connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
+                .await
+                .unwrap(),
             Some(path.clone()),
             Some(key.clone()),
             &inbox_id,
@@ -3631,6 +3647,9 @@ mod tests {
 
         let build = create_client(
             connection.clone(),
+            connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
+                .await
+                .unwrap(),
             Some(path.clone()),
             Some(key.clone()),
             &inbox_id,

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -3800,6 +3800,9 @@ mod tests {
             connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
                 .await
                 .unwrap(),
+            connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
+                .await
+                .unwrap(),
             Some(path.clone()),
             Some(key),
             &inbox_id,
@@ -3919,6 +3922,9 @@ mod tests {
             connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
                 .await
                 .unwrap(),
+            connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
+                .await
+                .unwrap(),
             Some(path.clone()),
             Some(key),
             &inbox_id,
@@ -4014,6 +4020,9 @@ mod tests {
             connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
                 .await
                 .unwrap(),
+            connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
+                .await
+                .unwrap(),
             Some(path.clone()),
             None, // encryption_key
             &inbox_id,
@@ -4045,6 +4054,9 @@ mod tests {
         let path = tmp_path();
 
         let client_amal = create_client(
+            connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
+                .await
+                .unwrap(),
             connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
                 .await
                 .unwrap(),
@@ -4088,6 +4100,9 @@ mod tests {
         );
 
         let client_bola = create_client(
+            connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
+                .await
+                .unwrap(),
             connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
                 .await
                 .unwrap(),
@@ -7364,6 +7379,9 @@ mod tests {
             connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
                 .await
                 .unwrap(),
+            connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
+                .await
+                .unwrap(),
             Some(tmp_path()),
             Some(xmtp_db::EncryptedMessageStore::<()>::generate_enc_key().into()),
             &wallet_a_inbox_id,
@@ -7403,6 +7421,9 @@ mod tests {
 
         let ffi_ident: FfiIdentifier = wallet_b.identifier().into();
         let client_b = create_client(
+            connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
+                .await
+                .unwrap(),
             connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
                 .await
                 .unwrap(),
@@ -7486,6 +7507,9 @@ mod tests {
             connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
                 .await
                 .unwrap(),
+            connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
+                .await
+                .unwrap(),
             Some(tmp_path()),
             Some(xmtp_db::EncryptedMessageStore::<()>::generate_enc_key().into()),
             &client_b_inbox_id,
@@ -7524,6 +7548,9 @@ mod tests {
             connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
                 .await
                 .unwrap(),
+            connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
+                .await
+                .unwrap(),
             Some(tmp_path()),
             Some(xmtp_db::EncryptedMessageStore::<()>::generate_enc_key().into()),
             &wallet_a_inbox_id,
@@ -7549,6 +7576,9 @@ mod tests {
             connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
                 .await
                 .unwrap(),
+            connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
+                .await
+                .unwrap(),
             Some(tmp_path()),
             Some(xmtp_db::EncryptedMessageStore::<()>::generate_enc_key().into()),
             &wallet_b_inbox_id,
@@ -7568,6 +7598,9 @@ mod tests {
         // Step 3: Wallet B creates a second client for inbox_id B
         let ffi_ident: FfiIdentifier = wallet_b.identifier().into();
         let _client_b2 = create_client(
+            connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
+                .await
+                .unwrap(),
             connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
                 .await
                 .unwrap(),
@@ -7601,6 +7634,9 @@ mod tests {
         // Step 5: Wallet B tries to create another new client for inbox_id B, but it fails
         let ffi_ident: FfiIdentifier = wallet_b.identifier().into();
         let client_b3 = create_client(
+            connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
+                .await
+                .unwrap(),
             connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
                 .await
                 .unwrap(),
@@ -8882,6 +8918,9 @@ mod tests {
         let path = tmp_path();
         let key = static_enc_key().to_vec();
         let client = create_client(
+            connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
+                .await
+                .unwrap(),
             connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
                 .await
                 .unwrap(),

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -266,7 +266,10 @@ pub async fn create_client(
     );
 
     let mut builder = xmtp_mls::Client::builder(identity_strategy)
-        .api_clients(Arc::unwrap_or_clone(api).0, Arc::unwrap_or_clone(sync_api).0)
+        .api_clients(
+            Arc::unwrap_or_clone(api).0,
+            Arc::unwrap_or_clone(sync_api).0,
+        )
         .enable_api_debug_wrapper()?
         .with_remote_verifier()?
         .with_allow_offline(allow_offline)

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -218,7 +218,6 @@ pub async fn apply_signature_request(
 pub async fn create_client(
     api: Arc<XmtpApiClient>,
     sync_api: Arc<XmtpApiClient>,
-    publish_api: Arc<XmtpApiClient>,
     db: Option<String>,
     encryption_key: Option<Vec<u8>>,
     inbox_id: &InboxId,
@@ -270,7 +269,6 @@ pub async fn create_client(
         .api_clients(
             Arc::unwrap_or_clone(api).0,
             Arc::unwrap_or_clone(sync_api).0,
-            Arc::unwrap_or_clone(publish_api).0,
         )
         .enable_api_debug_wrapper()?
         .with_remote_verifier()?

--- a/bindings_ffi/src/mls/test_utils.rs
+++ b/bindings_ffi/src/mls/test_utils.rs
@@ -151,6 +151,9 @@ where
         connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
             .await
             .unwrap(),
+        connect_to_backend(xmtp_api_grpc::LOCALHOST_ADDRESS.to_string(), false, None)
+            .await
+            .unwrap(),
         Some(tmp_path()),
         Some(xmtp_db::EncryptedMessageStore::<()>::generate_enc_key().into()),
         &inbox_id,

--- a/bindings_node/src/client.rs
+++ b/bindings_node/src/client.rs
@@ -159,6 +159,10 @@ pub async fn create_client(
     .await
     .map_err(|_| Error::from_reason("Error creating Tonic API client"))?;
 
+  let sync_api_client = TonicApiClient::create(&host, is_secure, app_version.as_ref())
+    .await
+    .map_err(|_| Error::from_reason("Error creating Tonic API client"))?;
+
   let storage_option = match db_path {
     Some(path) => StorageOption::Persistent(path),
     None => StorageOption::Ephemeral,
@@ -193,7 +197,7 @@ pub async fn create_client(
 
   let mut builder = match device_sync_server_url {
     Some(url) => xmtp_mls::Client::builder(identity_strategy)
-      .api_client(api_client)
+      .api_clients(api_client, sync_api_client)
       .enable_api_debug_wrapper()
       .map_err(ErrorWrapper::from)?
       .with_remote_verifier()
@@ -204,7 +208,7 @@ pub async fn create_client(
       .device_sync_server_url(&url),
 
     None => xmtp_mls::Client::builder(identity_strategy)
-      .api_client(api_client)
+      .api_clients(api_client, sync_api_client)
       .enable_api_debug_wrapper()
       .map_err(ErrorWrapper::from)?
       .with_remote_verifier()

--- a/bindings_wasm/src/client.rs
+++ b/bindings_wasm/src/client.rs
@@ -168,6 +168,15 @@ pub async fn create_client(
   )
   .await?;
 
+  let sync_api_client = XmtpHttpApiClient::new(
+    host.clone(),
+    app_version
+      .as_ref()
+      .unwrap_or(&"0.0.0".to_string())
+      .to_string(),
+  )
+  .await?;
+
   let storage_option = match db_path {
     Some(path) => StorageOption::Persistent(path),
     None => StorageOption::Ephemeral,
@@ -200,7 +209,7 @@ pub async fn create_client(
 
   let mut builder = match device_sync_server_url {
     Some(url) => xmtp_mls::Client::builder(identity_strategy)
-      .api_client(api_client)
+      .api_clients(api_client, sync_api_client)
       .enable_api_debug_wrapper()?
       .with_remote_verifier()?
       .with_allow_offline(allow_offline)
@@ -208,7 +217,7 @@ pub async fn create_client(
       .store(store)
       .device_sync_server_url(&url),
     None => xmtp_mls::Client::builder(identity_strategy)
-      .api_client(api_client)
+      .api_clients(api_client, sync_api_client)
       .enable_api_debug_wrapper()?
       .with_remote_verifier()?
       .with_allow_offline(allow_offline)

--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -536,7 +536,7 @@ async fn create_client<C: XmtpApi + Clone + 'static>(
 > {
     let msg_store = get_encrypted_store(&cli.db).await?;
     let builder = xmtp_mls::Client::builder(account).store(msg_store);
-    let mut builder = builder.api_client(grpc);
+    let mut builder = builder.api_clients(grpc.clone(), grpc);
 
     builder = match (cli.testnet, &cli.env) {
         (false, Env::Local) => builder.device_sync_server_url(DeviceSyncUrls::LOCAL_ADDRESS),

--- a/xmtp_debug/src/app/clients.rs
+++ b/xmtp_debug/src/app/clients.rs
@@ -84,7 +84,7 @@ async fn new_client_inner(
         nonce,
         None,
     ))
-    .api_client(api)
+    .api_clients(api.clone(), api)
     .default_mls_store()?
     .with_remote_verifier()?
     .store(EncryptedMessageStore::new(db)?)
@@ -137,7 +137,7 @@ async fn existing_client_inner(
         error!(db_path = %(&db_path.as_path().display()), "{e}");
     }
     let client = xmtp_mls::Client::builder(IdentityStrategy::CachedOnly)
-        .api_client(api)
+        .api_clients(api.clone(), api)
         .with_remote_verifier()?
         .store(store?)
         .default_mls_store()?

--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -76,7 +76,6 @@ pub struct ClientBuilder<ApiClient, S, Db = xmtp_db::DefaultStore> {
     disable_events: bool,
     mls_storage: Option<S>,
     sync_api_client: Option<ApiClientWrapper<ApiClient>>,
-    publish_api_client: Option<ApiClientWrapper<ApiClient>>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -111,7 +110,6 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             disable_events: true,
             mls_storage: None,
             sync_api_client: None,
-            publish_api_client: None,
         }
     }
 }
@@ -128,7 +126,6 @@ where
     ) -> ClientBuilder<ApiClient, S, Db> {
         let cloned_api: ApiClientWrapper<ApiClient> = client.context.api_client.clone();
         let cloned_sync_api: ApiClientWrapper<ApiClient> = client.context.sync_api_client.clone();
-        let cloned_publish_api: ApiClientWrapper<ApiClient> = client.context.publish_api_client.clone();
         ClientBuilder {
             api_client: Some(cloned_api),
             identity: Some(client.context.identity.clone()),
@@ -145,7 +142,6 @@ where
             disable_events: false,
             mls_storage: Some(client.context.mls_storage.clone()),
             sync_api_client: Some(cloned_sync_api),
-            publish_api_client: Some(cloned_publish_api),
         }
     }
 }
@@ -171,7 +167,6 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             disable_events,
             mut mls_storage,
             mut sync_api_client,
-            mut publish_api_client,
             ..
         } = self;
 
@@ -186,12 +181,6 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
                 .take()
                 .ok_or(ClientBuilderError::MissingParameter {
                     parameter: "sync_api_client",
-                })?;
-        let publish_api_client =
-            publish_api_client
-                .take()
-                .ok_or(ClientBuilderError::MissingParameter {
-                    parameter: "publish_api_client",
                 })?;
 
         let scw_verifier = scw_verifier
@@ -254,7 +243,6 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             },
             workers: workers.clone(),
             sync_api_client,
-            publish_api_client,
         });
 
         // register workers
@@ -313,7 +301,6 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             disable_events: self.disable_events,
             mls_storage: self.mls_storage,
             sync_api_client: self.sync_api_client,
-            publish_api_client: self.publish_api_client,
         }
     }
 
@@ -347,7 +334,6 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             )),
             store: self.store,
             sync_api_client: self.sync_api_client,
-            publish_api_client: self.publish_api_client,
         })
     }
 
@@ -365,7 +351,6 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             disable_events: self.disable_events,
             mls_storage: Some(mls_storage),
             sync_api_client: self.sync_api_client,
-            publish_api_client: self.publish_api_client,
         }
     }
 
@@ -397,11 +382,10 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
         }
     }
 
-    pub fn api_clients<A>(self, api_client: A, sync_api_client: A, publish_api_client: A) -> ClientBuilder<A, S, Db> {
+    pub fn api_clients<A>(self, api_client: A, sync_api_client: A) -> ClientBuilder<A, S, Db> {
         let api_retry = Retry::builder().build();
         let api_client = ApiClientWrapper::new(api_client, api_retry.clone());
         let sync_api_client = ApiClientWrapper::new(sync_api_client, api_retry.clone());
-        let publish_api_client = ApiClientWrapper::new(publish_api_client, api_retry.clone());
         ClientBuilder {
             api_client: Some(api_client),
             identity: self.identity,
@@ -415,7 +399,6 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             disable_events: self.disable_events,
             mls_storage: self.mls_storage,
             sync_api_client: Some(sync_api_client),
-            publish_api_client: Some(publish_api_client),
         }
     }
 
@@ -525,11 +508,6 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
                     .expect("checked for none")
                     .attach_debug_wrapper(),
             ),
-            publish_api_client: Some(
-                self.publish_api_client
-                    .expect("checked for none")
-                    .attach_debug_wrapper(),
-            ),
         })
     }
 
@@ -551,7 +529,6 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             disable_events: self.disable_events,
             mls_storage: self.mls_storage,
             sync_api_client: self.sync_api_client,
-            publish_api_client: self.publish_api_client,
         }
     }
 
@@ -584,7 +561,6 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             disable_events: self.disable_events,
             mls_storage: self.mls_storage,
             sync_api_client: self.sync_api_client,
-            publish_api_client: self.publish_api_client,
         })
     }
 }

--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -75,6 +75,7 @@ pub struct ClientBuilder<ApiClient, S, Db = xmtp_db::DefaultStore> {
     allow_offline: bool,
     disable_events: bool,
     mls_storage: Option<S>,
+    sync_api_client: Option<ApiClientWrapper<ApiClient>>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -108,6 +109,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             #[cfg(test)]
             disable_events: true,
             mls_storage: None,
+            sync_api_client: None,
         }
     }
 }
@@ -122,7 +124,8 @@ where
     pub fn from_client(
         client: Client<ContextParts<ApiClient, S, Db>>,
     ) -> ClientBuilder<ApiClient, S, Db> {
-        let cloned_api = client.context.api_client.clone();
+        let cloned_api: ApiClientWrapper<ApiClient> = client.context.api_client.clone();
+        let cloned_sync_api: ApiClientWrapper<ApiClient> = client.context.sync_api_client.clone();
         ClientBuilder {
             api_client: Some(cloned_api),
             identity: Some(client.context.identity.clone()),
@@ -138,6 +141,7 @@ where
             #[cfg(not(test))]
             disable_events: false,
             mls_storage: Some(client.context.mls_storage.clone()),
+            sync_api_client: Some(cloned_sync_api),
         }
     }
 }
@@ -162,6 +166,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             allow_offline,
             disable_events,
             mut mls_storage,
+            mut sync_api_client,
             ..
         } = self;
 
@@ -169,6 +174,13 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             .take()
             .ok_or(ClientBuilderError::MissingParameter {
                 parameter: "api_client",
+            })?;
+
+        let sync_api_client = sync_api_client
+            .take()
+            // .or_else(|| Some(api_client.clone()))
+            .ok_or(ClientBuilderError::MissingParameter {
+                parameter: "sync_api_client (fallback to api_client also failed)",
             })?;
 
         let scw_verifier = scw_verifier
@@ -230,6 +242,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
                 mode: device_sync_worker_mode,
             },
             workers: workers.clone(),
+            sync_api_client,
         });
 
         // register workers
@@ -287,6 +300,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             allow_offline: self.allow_offline,
             disable_events: self.disable_events,
             mls_storage: self.mls_storage,
+            sync_api_client: self.sync_api_client,
         }
     }
 
@@ -319,6 +333,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
                     .db(),
             )),
             store: self.store,
+            sync_api_client: self.sync_api_client,
         })
     }
 
@@ -335,6 +350,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             allow_offline: self.allow_offline,
             disable_events: self.disable_events,
             mls_storage: Some(mls_storage),
+            sync_api_client: self.sync_api_client,
         }
     }
 
@@ -366,9 +382,10 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
         }
     }
 
-    pub fn api_client<A>(self, api_client: A) -> ClientBuilder<A, S, Db> {
+    pub fn api_client<A>(self, api_client: A, sync_api_client: A) -> ClientBuilder<A, S, Db> {
         let api_retry = Retry::builder().build();
-        let api_client = ApiClientWrapper::new(api_client, api_retry);
+        let api_client = ApiClientWrapper::new(api_client, api_retry.clone());
+        let sync_api_client = ApiClientWrapper::new(sync_api_client, api_retry.clone());
         ClientBuilder {
             api_client: Some(api_client),
             identity: self.identity,
@@ -381,6 +398,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             allow_offline: self.allow_offline,
             disable_events: self.disable_events,
             mls_storage: self.mls_storage,
+            sync_api_client: Some(sync_api_client),
         }
     }
 
@@ -485,6 +503,11 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             allow_offline: self.allow_offline,
             disable_events: self.disable_events,
             mls_storage: self.mls_storage,
+            sync_api_client: Some(
+                self.sync_api_client
+                    .expect("checked for none")
+                    .attach_debug_wrapper(),
+            ),
         })
     }
 
@@ -505,6 +528,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             allow_offline: self.allow_offline,
             disable_events: self.disable_events,
             mls_storage: self.mls_storage,
+            sync_api_client: self.sync_api_client,
         }
     }
 
@@ -536,6 +560,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             allow_offline: self.allow_offline,
             disable_events: self.disable_events,
             mls_storage: self.mls_storage,
+            sync_api_client: self.sync_api_client,
         })
     }
 }

--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -178,9 +178,8 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
 
         let sync_api_client = sync_api_client
             .take()
-            // .or_else(|| Some(api_client.clone()))
             .ok_or(ClientBuilderError::MissingParameter {
-                parameter: "sync_api_client (fallback to api_client also failed)",
+                parameter: "sync_api_client",
             })?;
 
         let scw_verifier = scw_verifier
@@ -382,7 +381,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
         }
     }
 
-    pub fn api_client<A>(self, api_client: A, sync_api_client: A) -> ClientBuilder<A, S, Db> {
+    pub fn api_clients<A>(self, api_client: A, sync_api_client: A) -> ClientBuilder<A, S, Db> {
         let api_retry = Retry::builder().build();
         let api_client = ApiClientWrapper::new(api_client, api_retry.clone());
         let sync_api_client = ApiClientWrapper::new(sync_api_client, api_retry.clone());

--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -176,11 +176,12 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
                 parameter: "api_client",
             })?;
 
-        let sync_api_client = sync_api_client
-            .take()
-            .ok_or(ClientBuilderError::MissingParameter {
-                parameter: "sync_api_client",
-            })?;
+        let sync_api_client =
+            sync_api_client
+                .take()
+                .ok_or(ClientBuilderError::MissingParameter {
+                    parameter: "sync_api_client",
+                })?;
 
         let scw_verifier = scw_verifier
             .take()

--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -76,6 +76,7 @@ pub struct ClientBuilder<ApiClient, S, Db = xmtp_db::DefaultStore> {
     disable_events: bool,
     mls_storage: Option<S>,
     sync_api_client: Option<ApiClientWrapper<ApiClient>>,
+    publish_api_client: Option<ApiClientWrapper<ApiClient>>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -110,6 +111,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             disable_events: true,
             mls_storage: None,
             sync_api_client: None,
+            publish_api_client: None,
         }
     }
 }
@@ -126,6 +128,7 @@ where
     ) -> ClientBuilder<ApiClient, S, Db> {
         let cloned_api: ApiClientWrapper<ApiClient> = client.context.api_client.clone();
         let cloned_sync_api: ApiClientWrapper<ApiClient> = client.context.sync_api_client.clone();
+        let cloned_publish_api: ApiClientWrapper<ApiClient> = client.context.publish_api_client.clone();
         ClientBuilder {
             api_client: Some(cloned_api),
             identity: Some(client.context.identity.clone()),
@@ -142,6 +145,7 @@ where
             disable_events: false,
             mls_storage: Some(client.context.mls_storage.clone()),
             sync_api_client: Some(cloned_sync_api),
+            publish_api_client: Some(cloned_publish_api),
         }
     }
 }
@@ -167,6 +171,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             disable_events,
             mut mls_storage,
             mut sync_api_client,
+            mut publish_api_client,
             ..
         } = self;
 
@@ -181,6 +186,12 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
                 .take()
                 .ok_or(ClientBuilderError::MissingParameter {
                     parameter: "sync_api_client",
+                })?;
+        let publish_api_client =
+            publish_api_client
+                .take()
+                .ok_or(ClientBuilderError::MissingParameter {
+                    parameter: "publish_api_client",
                 })?;
 
         let scw_verifier = scw_verifier
@@ -243,6 +254,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             },
             workers: workers.clone(),
             sync_api_client,
+            publish_api_client,
         });
 
         // register workers
@@ -301,6 +313,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             disable_events: self.disable_events,
             mls_storage: self.mls_storage,
             sync_api_client: self.sync_api_client,
+            publish_api_client: self.publish_api_client,
         }
     }
 
@@ -334,6 +347,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             )),
             store: self.store,
             sync_api_client: self.sync_api_client,
+            publish_api_client: self.publish_api_client,
         })
     }
 
@@ -351,6 +365,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             disable_events: self.disable_events,
             mls_storage: Some(mls_storage),
             sync_api_client: self.sync_api_client,
+            publish_api_client: self.publish_api_client,
         }
     }
 
@@ -382,10 +397,11 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
         }
     }
 
-    pub fn api_clients<A>(self, api_client: A, sync_api_client: A) -> ClientBuilder<A, S, Db> {
+    pub fn api_clients<A>(self, api_client: A, sync_api_client: A, publish_api_client: A) -> ClientBuilder<A, S, Db> {
         let api_retry = Retry::builder().build();
         let api_client = ApiClientWrapper::new(api_client, api_retry.clone());
         let sync_api_client = ApiClientWrapper::new(sync_api_client, api_retry.clone());
+        let publish_api_client = ApiClientWrapper::new(publish_api_client, api_retry.clone());
         ClientBuilder {
             api_client: Some(api_client),
             identity: self.identity,
@@ -399,6 +415,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             disable_events: self.disable_events,
             mls_storage: self.mls_storage,
             sync_api_client: Some(sync_api_client),
+            publish_api_client: Some(publish_api_client),
         }
     }
 
@@ -508,6 +525,11 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
                     .expect("checked for none")
                     .attach_debug_wrapper(),
             ),
+            publish_api_client: Some(
+                self.publish_api_client
+                    .expect("checked for none")
+                    .attach_debug_wrapper(),
+            ),
         })
     }
 
@@ -529,6 +551,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             disable_events: self.disable_events,
             mls_storage: self.mls_storage,
             sync_api_client: self.sync_api_client,
+            publish_api_client: self.publish_api_client,
         }
     }
 
@@ -561,6 +584,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             disable_events: self.disable_events,
             mls_storage: self.mls_storage,
             sync_api_client: self.sync_api_client,
+            publish_api_client: self.publish_api_client,
         })
     }
 }

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -447,10 +447,7 @@ where
         )?;
         let duration: std::time::Duration = start.elapsed();
 
-        tracing::info!(
-            "Lopi: Created MLS and inserted in {:?}",
-            duration
-        );
+        tracing::info!("Lopi: Created MLS and inserted in {:?}", duration);
 
         // notify streams of our new group
         let _ = self

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -19,7 +19,6 @@ use crate::{
     worker::{metrics::WorkerMetrics, WorkerRunner},
 };
 use openmls::prelude::tls_codec::Error as TlsCodecError;
-use std::time::Instant;
 use std::{collections::HashMap, sync::Arc};
 use thiserror::Error;
 use tokio::sync::broadcast;
@@ -436,7 +435,6 @@ where
         opts: Option<GroupMetadataOptions>,
     ) -> Result<MlsGroup<Context>, ClientError> {
         tracing::info!("creating group");
-        let start = Instant::now();
 
         let group: MlsGroup<Context> = MlsGroup::create_and_insert(
             self.context.clone(),
@@ -445,9 +443,6 @@ where
             permissions_policy_set.unwrap_or_default(),
             opts.unwrap_or_default(),
         )?;
-        let duration: std::time::Duration = start.elapsed();
-
-        tracing::info!("Lopi: Created MLS and inserted in {:?}", duration);
 
         // notify streams of our new group
         let _ = self

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -19,6 +19,7 @@ use crate::{
     worker::{metrics::WorkerMetrics, WorkerRunner},
 };
 use openmls::prelude::tls_codec::Error as TlsCodecError;
+use std::time::Instant;
 use std::{collections::HashMap, sync::Arc};
 use thiserror::Error;
 use tokio::sync::broadcast;
@@ -435,6 +436,8 @@ where
         opts: Option<GroupMetadataOptions>,
     ) -> Result<MlsGroup<Context>, ClientError> {
         tracing::info!("creating group");
+        let start = Instant::now();
+
         let group: MlsGroup<Context> = MlsGroup::create_and_insert(
             self.context.clone(),
             GroupMembershipState::Allowed,
@@ -442,6 +445,12 @@ where
             permissions_policy_set.unwrap_or_default(),
             opts.unwrap_or_default(),
         )?;
+        let duration: std::time::Duration = start.elapsed();
+
+        tracing::info!(
+            "Lopi: Created MLS and inserted in {:?}",
+            duration
+        );
 
         // notify streams of our new group
         let _ = self

--- a/xmtp_mls/src/context.rs
+++ b/xmtp_mls/src/context.rs
@@ -31,6 +31,7 @@ pub struct XmtpMlsLocalContext<ApiClient, Db, S> {
     pub(crate) identity: Identity,
     /// The XMTP Api Client
     pub(crate) api_client: ApiClientWrapper<ApiClient>,
+    pub(crate) sync_api_client: ApiClientWrapper<ApiClient>, // sync-only channel
     /// XMTP Local Storage
     pub(crate) store: Db,
     pub(crate) mls_storage: S,
@@ -138,6 +139,7 @@ where
     fn context_ref(&self) -> &Self::ContextReference;
     fn db(&self) -> <Self::Db as XmtpDb>::DbQuery;
     fn api(&self) -> &ApiClientWrapper<Self::ApiClient>;
+    fn sync_api(&self) -> &ApiClientWrapper<Self::ApiClient>;
     fn scw_verifier(&self) -> Arc<Box<dyn SmartContractSignatureVerifier>>;
 
     fn device_sync(&self) -> &DeviceSync;
@@ -198,6 +200,10 @@ where
 
     fn api(&self) -> &ApiClientWrapper<Self::ApiClient> {
         &self.api_client
+    }
+
+    fn sync_api(&self) -> &ApiClientWrapper<Self::ApiClient> {
+        &self.sync_api_client
     }
 
     fn scw_verifier(&self) -> Arc<Box<dyn SmartContractSignatureVerifier>> {
@@ -262,6 +268,10 @@ where
 
     fn api(&self) -> &ApiClientWrapper<Self::ApiClient> {
         <T as XmtpSharedContext>::api(self)
+    }
+
+    fn sync_api(&self) -> &ApiClientWrapper<Self::ApiClient> {
+        <T as XmtpSharedContext>::sync_api(self)
     }
 
     fn scw_verifier(&self) -> Arc<Box<dyn SmartContractSignatureVerifier>> {

--- a/xmtp_mls/src/context.rs
+++ b/xmtp_mls/src/context.rs
@@ -32,6 +32,7 @@ pub struct XmtpMlsLocalContext<ApiClient, Db, S> {
     /// The XMTP Api Client
     pub(crate) api_client: ApiClientWrapper<ApiClient>,
     pub(crate) sync_api_client: ApiClientWrapper<ApiClient>, // sync-only channel
+    pub(crate) publish_api_client: ApiClientWrapper<ApiClient>, // sync-only channel
     /// XMTP Local Storage
     pub(crate) store: Db,
     pub(crate) mls_storage: S,
@@ -140,6 +141,7 @@ where
     fn db(&self) -> <Self::Db as XmtpDb>::DbQuery;
     fn api(&self) -> &ApiClientWrapper<Self::ApiClient>;
     fn sync_api(&self) -> &ApiClientWrapper<Self::ApiClient>;
+    fn publish_api(&self) -> &ApiClientWrapper<Self::ApiClient>;
     fn scw_verifier(&self) -> Arc<Box<dyn SmartContractSignatureVerifier>>;
 
     fn device_sync(&self) -> &DeviceSync;
@@ -204,6 +206,10 @@ where
 
     fn sync_api(&self) -> &ApiClientWrapper<Self::ApiClient> {
         &self.sync_api_client
+    }
+
+    fn publish_api(&self) -> &ApiClientWrapper<Self::ApiClient> {
+        &self.publish_api_client
     }
 
     fn scw_verifier(&self) -> Arc<Box<dyn SmartContractSignatureVerifier>> {
@@ -272,6 +278,10 @@ where
 
     fn sync_api(&self) -> &ApiClientWrapper<Self::ApiClient> {
         <T as XmtpSharedContext>::sync_api(self)
+    }
+
+    fn publish_api(&self) -> &ApiClientWrapper<Self::ApiClient> {
+        <T as XmtpSharedContext>::publish_api(self)
     }
 
     fn scw_verifier(&self) -> Arc<Box<dyn SmartContractSignatureVerifier>> {

--- a/xmtp_mls/src/context.rs
+++ b/xmtp_mls/src/context.rs
@@ -32,7 +32,6 @@ pub struct XmtpMlsLocalContext<ApiClient, Db, S> {
     /// The XMTP Api Client
     pub(crate) api_client: ApiClientWrapper<ApiClient>,
     pub(crate) sync_api_client: ApiClientWrapper<ApiClient>, // sync-only channel
-    pub(crate) publish_api_client: ApiClientWrapper<ApiClient>, // sync-only channel
     /// XMTP Local Storage
     pub(crate) store: Db,
     pub(crate) mls_storage: S,
@@ -141,7 +140,6 @@ where
     fn db(&self) -> <Self::Db as XmtpDb>::DbQuery;
     fn api(&self) -> &ApiClientWrapper<Self::ApiClient>;
     fn sync_api(&self) -> &ApiClientWrapper<Self::ApiClient>;
-    fn publish_api(&self) -> &ApiClientWrapper<Self::ApiClient>;
     fn scw_verifier(&self) -> Arc<Box<dyn SmartContractSignatureVerifier>>;
 
     fn device_sync(&self) -> &DeviceSync;
@@ -206,10 +204,6 @@ where
 
     fn sync_api(&self) -> &ApiClientWrapper<Self::ApiClient> {
         &self.sync_api_client
-    }
-
-    fn publish_api(&self) -> &ApiClientWrapper<Self::ApiClient> {
-        &self.publish_api_client
     }
 
     fn scw_verifier(&self) -> Arc<Box<dyn SmartContractSignatureVerifier>> {
@@ -278,10 +272,6 @@ where
 
     fn sync_api(&self) -> &ApiClientWrapper<Self::ApiClient> {
         <T as XmtpSharedContext>::sync_api(self)
-    }
-
-    fn publish_api(&self) -> &ApiClientWrapper<Self::ApiClient> {
-        <T as XmtpSharedContext>::publish_api(self)
     }
 
     fn scw_verifier(&self) -> Arc<Box<dyn SmartContractSignatureVerifier>> {

--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -1966,7 +1966,7 @@ where
 
                         let messages = self.prepare_group_messages(vec![(payload_slice, should_send_push_notification)])?;
                         self.context
-                            .api()
+                            .publish_api()
                             .send_group_messages(messages)
                             .await?;
 

--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -1966,7 +1966,7 @@ where
 
                         let messages = self.prepare_group_messages(vec![(payload_slice, should_send_push_notification)])?;
                         self.context
-                            .publish_api()
+                            .api()
                             .send_group_messages(messages)
                             .await?;
 

--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -82,7 +82,7 @@ use sha2::Sha256;
 use std::{
     collections::{HashMap, HashSet},
     mem::{discriminant, Discriminant},
-    ops::RangeInclusive,
+    ops::RangeInclusive, time::Instant,
 };
 use thiserror::Error;
 use tracing::debug;
@@ -364,7 +364,14 @@ where
 
         // Even if receiving fails, we continue to post_commit
         // Errors are collected in the summary.
+        let start = Instant::now();
         let result = self.receive().await;
+        let duration = start.elapsed();
+
+        tracing::info!(
+            "Lopi: sync with conn receive in {:?}",
+            duration
+        );
         track_err!("Receive messages", &result, group: &self.group_id);
         match result {
             Ok(s) => summary.add_process(s),
@@ -376,7 +383,14 @@ where
             }
         }
 
+        let start = Instant::now();
         let result = self.post_commit().await;
+        let duration = start.elapsed();
+
+        tracing::info!(
+            "Lopi: sync with conn post commit in {:?}",
+            duration
+        );
         track_err!("Post commit", &result, group: &self.group_id);
         if let Err(e) = result {
             tracing::error!("post commit error {e:?}",);
@@ -1721,10 +1735,26 @@ where
     #[tracing::instrument(skip_all, level = "trace")]
     pub(super) async fn receive(&self) -> Result<ProcessSummary, GroupError> {
         let db = self.context.db();
+
+        let start = Instant::now();
         let messages = MlsStore::new(self.context.clone())
             .query_group_messages(&self.group_id, &db)
-            .await?;
+            .await?;        
+        let duration = start.elapsed();
+
+        tracing::info!(
+            "Lopi: query messages in {:?}",
+            duration
+        );
+
+        let start = Instant::now();
         let summary = self.process_messages(messages).await;
+        let duration = start.elapsed();
+
+        tracing::info!(
+            "Lopi: sync with conn recieve process messages in {:?}",
+            duration
+        );
 
         track!(
             "Fetched messages",

--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -83,7 +83,6 @@ use std::{
     collections::{HashMap, HashSet},
     mem::{discriminant, Discriminant},
     ops::RangeInclusive,
-    time::Instant,
 };
 use thiserror::Error;
 use tracing::debug;

--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -82,7 +82,8 @@ use sha2::Sha256;
 use std::{
     collections::{HashMap, HashSet},
     mem::{discriminant, Discriminant},
-    ops::RangeInclusive, time::Instant,
+    ops::RangeInclusive,
+    time::Instant,
 };
 use thiserror::Error;
 use tracing::debug;
@@ -368,10 +369,7 @@ where
         let result = self.receive().await;
         let duration = start.elapsed();
 
-        tracing::info!(
-            "Lopi: sync with conn receive in {:?}",
-            duration
-        );
+        tracing::info!("Lopi: sync with conn receive in {:?}", duration);
         track_err!("Receive messages", &result, group: &self.group_id);
         match result {
             Ok(s) => summary.add_process(s),
@@ -387,10 +385,7 @@ where
         let result = self.post_commit().await;
         let duration = start.elapsed();
 
-        tracing::info!(
-            "Lopi: sync with conn post commit in {:?}",
-            duration
-        );
+        tracing::info!("Lopi: sync with conn post commit in {:?}", duration);
         track_err!("Post commit", &result, group: &self.group_id);
         if let Err(e) = result {
             tracing::error!("post commit error {e:?}",);
@@ -1739,13 +1734,10 @@ where
         let start = Instant::now();
         let messages = MlsStore::new(self.context.clone())
             .query_group_messages(&self.group_id, &db)
-            .await?;        
+            .await?;
         let duration = start.elapsed();
 
-        tracing::info!(
-            "Lopi: query messages in {:?}",
-            duration
-        );
+        tracing::info!("Lopi: query messages in {:?}", duration);
 
         let start = Instant::now();
         let summary = self.process_messages(messages).await;

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -59,7 +59,7 @@ use openmls::{
 };
 use openmls_traits::storage::CURRENT_VERSION;
 use prost::Message;
-use std::collections::HashMap;
+use std::{collections::HashMap, time::Instant};
 use std::future::Future;
 use std::{collections::HashSet, sync::Arc};
 use tokio::sync::Mutex;
@@ -391,7 +391,16 @@ where
         );
 
         // Consent state defaults to allowed when the user creates the group
+        let start = Instant::now();
+
         new_group.update_consent_state(ConsentState::Allowed)?;
+
+        let duration: std::time::Duration = start.elapsed();
+
+        tracing::info!(
+            "Lopi: Update consent state in {:?}",
+            duration
+        );
         Ok(new_group)
     }
 
@@ -1092,7 +1101,16 @@ where
         &self,
         inbox_ids: impl AsRef<[S]>,
     ) -> Result<UpdateGroupMembershipResult, GroupError> {
+        let start = Instant::now();
+
         self.ensure_not_paused().await?;
+
+        let duration: std::time::Duration = start.elapsed();
+
+        tracing::info!(
+            "Lopi: Ensure not paused in {:?}",
+            duration
+        );
         let ids = inbox_ids
             .as_ref()
             .iter()
@@ -1115,8 +1133,16 @@ where
         let intent =
             self.queue_intent(IntentKind::UpdateGroupMembership, intent_data.into(), false)?;
 
+        let start = Instant::now();
+
         self.sync_until_intent_resolved(intent.id).await?;
 
+        let duration: std::time::Duration = start.elapsed();
+
+        tracing::info!(
+            "Lopi: sync until resolved in {:?}",
+            duration
+        );
         track!(
             "Group Membership Change",
             {

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -59,8 +59,8 @@ use openmls::{
 };
 use openmls_traits::storage::CURRENT_VERSION;
 use prost::Message;
-use std::{collections::HashMap, time::Instant};
 use std::future::Future;
+use std::{collections::HashMap, time::Instant};
 use std::{collections::HashSet, sync::Arc};
 use tokio::sync::Mutex;
 use validated_commit::LibXMTPVersion;
@@ -397,10 +397,7 @@ where
 
         let duration: std::time::Duration = start.elapsed();
 
-        tracing::info!(
-            "Lopi: Update consent state in {:?}",
-            duration
-        );
+        tracing::info!("Lopi: Update consent state in {:?}", duration);
         Ok(new_group)
     }
 
@@ -1107,10 +1104,7 @@ where
 
         let duration: std::time::Duration = start.elapsed();
 
-        tracing::info!(
-            "Lopi: Ensure not paused in {:?}",
-            duration
-        );
+        tracing::info!("Lopi: Ensure not paused in {:?}", duration);
         let ids = inbox_ids
             .as_ref()
             .iter()
@@ -1139,10 +1133,7 @@ where
 
         let duration: std::time::Duration = start.elapsed();
 
-        tracing::info!(
-            "Lopi: sync until resolved in {:?}",
-            duration
-        );
+        tracing::info!("Lopi: sync until resolved in {:?}", duration);
         track!(
             "Group Membership Change",
             {

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -391,13 +391,8 @@ where
         );
 
         // Consent state defaults to allowed when the user creates the group
-        let start = Instant::now();
-
         new_group.update_consent_state(ConsentState::Allowed)?;
 
-        let duration: std::time::Duration = start.elapsed();
-
-        tracing::info!("Lopi: Update consent state in {:?}", duration);
         Ok(new_group)
     }
 
@@ -1098,13 +1093,8 @@ where
         &self,
         inbox_ids: impl AsRef<[S]>,
     ) -> Result<UpdateGroupMembershipResult, GroupError> {
-        let start = Instant::now();
-
         self.ensure_not_paused().await?;
 
-        let duration: std::time::Duration = start.elapsed();
-
-        tracing::info!("Lopi: Ensure not paused in {:?}", duration);
         let ids = inbox_ids
             .as_ref()
             .iter()
@@ -1127,13 +1117,7 @@ where
         let intent =
             self.queue_intent(IntentKind::UpdateGroupMembership, intent_data.into(), false)?;
 
-        let start = Instant::now();
-
         self.sync_until_intent_resolved(intent.id).await?;
-
-        let duration: std::time::Duration = start.elapsed();
-
-        tracing::info!("Lopi: sync until resolved in {:?}", duration);
         track!(
             "Group Membership Change",
             {

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -59,8 +59,8 @@ use openmls::{
 };
 use openmls_traits::storage::CURRENT_VERSION;
 use prost::Message;
+use std::collections::HashMap;
 use std::future::Future;
-use std::{collections::HashMap, time::Instant};
 use std::{collections::HashSet, sync::Arc};
 use tokio::sync::Mutex;
 use validated_commit::LibXMTPVersion;

--- a/xmtp_mls/src/groups/welcome_sync.rs
+++ b/xmtp_mls/src/groups/welcome_sync.rs
@@ -180,11 +180,7 @@ where
         }
         let duration: std::time::Duration = start.elapsed();
 
-        tracing::info!(
-            "Lopi: sync welcomes in {:?}",
-            duration
-        );
-
+        tracing::info!("Lopi: sync welcomes in {:?}", duration);
 
         let query_args = GroupQueryArgs {
             consent_states,
@@ -197,10 +193,7 @@ where
         let conversations = db.fetch_conversation_list(query_args)?;
         let duration: std::time::Duration = start.elapsed();
 
-        tracing::info!(
-            "Lopi: fetch convos in {:?}",
-            duration
-        );
+        tracing::info!("Lopi: fetch convos in {:?}", duration);
 
         let groups: Vec<MlsGroup<Context>> = conversations
             .into_iter()
@@ -219,10 +212,7 @@ where
         let success_count = self.sync_groups_in_batches(groups, 10).await?;
         let duration: std::time::Duration = start.elapsed();
 
-        tracing::info!(
-            "Lopi: sync groups in batches in {:?}",
-            duration
-        );
+        tracing::info!("Lopi: sync groups in batches in {:?}", duration);
         Ok(success_count)
     }
 
@@ -258,26 +248,20 @@ where
                                 tracing::warn!(?err, "sync_with_conn failed");
                                 failed_group_count.fetch_add(1, Ordering::SeqCst);
                                 return;
-                            }                            
+                            }
                             let duration: std::time::Duration = start.elapsed();
-                    
-                            tracing::info!(
-                                "Lopi: sync with conn in {:?}",
-                                duration
-                            );
+
+                            tracing::info!("Lopi: sync with conn in {:?}", duration);
 
                             let start = Instant::now();
                             if let Err(err) = group.maybe_update_installations(None).await {
                                 tracing::warn!(?err, "maybe_update_installations failed");
                                 failed_group_count.fetch_add(1, Ordering::SeqCst);
                                 return;
-                            }                            
+                            }
                             let duration: std::time::Duration = start.elapsed();
-                    
-                            tracing::info!(
-                                "Lopi: maybe update in {:?}",
-                                duration
-                            );
+
+                            tracing::info!("Lopi: maybe update in {:?}", duration);
 
                             active_group_count.fetch_add(1, Ordering::SeqCst);
                         }

--- a/xmtp_mls/src/groups/welcome_sync.rs
+++ b/xmtp_mls/src/groups/welcome_sync.rs
@@ -7,6 +7,7 @@ use std::sync::{
     atomic::{AtomicUsize, Ordering},
     Arc,
 };
+use std::time::Instant;
 use xmtp_common::{retry_async, Retry};
 use xmtp_db::{consent_record::ConsentState, group::GroupQueryArgs, prelude::*};
 use xmtp_proto::xmtp::mls::api::v1::{welcome_message, WelcomeMessage};
@@ -173,9 +174,17 @@ where
     ) -> Result<usize, GroupError> {
         let db = self.context.db();
 
+        let start = Instant::now();
         if let Err(err) = self.sync_welcomes().await {
             tracing::warn!(?err, "sync_welcomes failed, continuing with group sync");
         }
+        let duration: std::time::Duration = start.elapsed();
+
+        tracing::info!(
+            "Lopi: sync welcomes in {:?}",
+            duration
+        );
+
 
         let query_args = GroupQueryArgs {
             consent_states,
@@ -184,7 +193,14 @@ where
             ..GroupQueryArgs::default()
         };
 
+        let start = Instant::now();
         let conversations = db.fetch_conversation_list(query_args)?;
+        let duration: std::time::Duration = start.elapsed();
+
+        tracing::info!(
+            "Lopi: fetch convos in {:?}",
+            duration
+        );
 
         let groups: Vec<MlsGroup<Context>> = conversations
             .into_iter()
@@ -199,8 +215,14 @@ where
             })
             .collect();
 
+        let start = Instant::now();
         let success_count = self.sync_groups_in_batches(groups, 10).await?;
+        let duration: std::time::Duration = start.elapsed();
 
+        tracing::info!(
+            "Lopi: sync groups in batches in {:?}",
+            duration
+        );
         Ok(success_count)
     }
 
@@ -231,17 +253,31 @@ where
 
                     match is_active_res {
                         Ok(is_active) if is_active => {
+                            let start = Instant::now();
                             if let Err(err) = group.sync_with_conn().await {
                                 tracing::warn!(?err, "sync_with_conn failed");
                                 failed_group_count.fetch_add(1, Ordering::SeqCst);
                                 return;
-                            }
+                            }                            
+                            let duration: std::time::Duration = start.elapsed();
+                    
+                            tracing::info!(
+                                "Lopi: sync with conn in {:?}",
+                                duration
+                            );
 
+                            let start = Instant::now();
                             if let Err(err) = group.maybe_update_installations(None).await {
                                 tracing::warn!(?err, "maybe_update_installations failed");
                                 failed_group_count.fetch_add(1, Ordering::SeqCst);
                                 return;
-                            }
+                            }                            
+                            let duration: std::time::Duration = start.elapsed();
+                    
+                            tracing::info!(
+                                "Lopi: maybe update in {:?}",
+                                duration
+                            );
 
                             active_group_count.fetch_add(1, Ordering::SeqCst);
                         }

--- a/xmtp_mls/src/mls_store.rs
+++ b/xmtp_mls/src/mls_store.rs
@@ -87,7 +87,7 @@ where
 
         let messages = self
             .context
-            .api()
+            .sync_api()
             .query_group_messages(group_id.to_vec(), Some(id_cursor as u64))
             .await?;
 

--- a/xmtp_mls/src/test/builder.rs
+++ b/xmtp_mls/src/test/builder.rs
@@ -209,7 +209,11 @@ async fn test_client_creation() {
         let result = Client::builder(test_case.strategy)
             .temp_store()
             .await
-            .api_client(
+            .api_clients(
+                <TestClient as XmtpTestClient>::create_local()
+                    .build()
+                    .await
+                    .unwrap(),
                 <TestClient as XmtpTestClient>::create_local()
                     .build()
                     .await
@@ -251,7 +255,11 @@ async fn test_turn_local_telemetry_off() {
     let store = xmtp_db::TestDb::create_persistent_store(None).await;
     let client = Client::builder(identity_strategy.clone())
         .store(store)
-        .api_client(
+        .api_clients(
+            <TestClient as XmtpTestClient>::create_local()
+                .build()
+                .await
+                .unwrap(),
             <TestClient as XmtpTestClient>::create_local()
                 .build()
                 .await
@@ -290,7 +298,11 @@ async fn test_2nd_time_client_creation() {
 
     let client1 = Client::builder(identity_strategy.clone())
         .store(store.clone())
-        .api_client(
+        .api_clients(
+            <TestClient as XmtpTestClient>::create_local()
+                .build()
+                .await
+                .unwrap(),
             <TestClient as XmtpTestClient>::create_local()
                 .build()
                 .await
@@ -306,7 +318,11 @@ async fn test_2nd_time_client_creation() {
 
     let client2 = Client::builder(IdentityStrategy::CachedOnly)
         .store(store.clone())
-        .api_client(
+        .api_clients(
+            <TestClient as XmtpTestClient>::create_local()
+                .build()
+                .await
+                .unwrap(),
             <TestClient as XmtpTestClient>::create_local()
                 .build()
                 .await
@@ -329,7 +345,11 @@ async fn test_2nd_time_client_creation() {
         None,
     ))
     .store(store.clone())
-    .api_client(
+    .api_clients(
+        <TestClient as XmtpTestClient>::create_local()
+            .build()
+            .await
+            .unwrap(),
         <TestClient as XmtpTestClient>::create_local()
             .build()
             .await
@@ -348,7 +368,11 @@ async fn test_2nd_time_client_creation() {
     let client4 = Client::builder(identity_strategy)
         .temp_store()
         .await
-        .api_client(
+        .api_clients(
+            <TestClient as XmtpTestClient>::create_local()
+                .build()
+                .await
+                .unwrap(),
             <TestClient as XmtpTestClient>::create_local()
                 .build()
                 .await
@@ -582,7 +606,11 @@ async fn identity_persistence_test() {
         nonce,
         None,
     ))
-    .api_client(
+    .api_clients(
+        <TestClient as XmtpTestClient>::create_local()
+            .build()
+            .await
+            .unwrap(),
         <TestClient as XmtpTestClient>::create_local()
             .build()
             .await
@@ -609,7 +637,11 @@ async fn identity_persistence_test() {
         nonce,
         None,
     ))
-    .api_client(
+    .api_clients(
+        <TestClient as XmtpTestClient>::create_local()
+            .build()
+            .await
+            .unwrap(),
         <TestClient as XmtpTestClient>::create_local()
             .build()
             .await
@@ -647,7 +679,11 @@ async fn identity_persistence_test() {
     // Use cached only strategy
     let store_d = xmtp_db::TestDb::create_persistent_store(Some(tmpdb.clone())).await;
     let client_d = Client::builder(IdentityStrategy::CachedOnly)
-        .api_client(
+        .api_clients(
+            <TestClient as XmtpTestClient>::create_local()
+                .build()
+                .await
+                .unwrap(),
             <TestClient as XmtpTestClient>::create_local()
                 .build()
                 .await

--- a/xmtp_mls/src/test/mock.rs
+++ b/xmtp_mls/src/test/mock.rs
@@ -68,6 +68,7 @@ impl Clone for NewMockContext {
         Self {
             identity: self.identity.clone(),
             api_client: self.api_client.clone(),
+            sync_api_client: self.sync_api_client.clone(),
             store: self.store.clone(),
             mls_storage: self.mls_storage.clone(),
             mutexes: self.mutexes.clone(),
@@ -140,5 +141,9 @@ impl XmtpSharedContext for NewMockContext {
 
     fn mutexes(&self) -> &MutexRegistry {
         &self.mutexes
+    }
+
+    fn sync_api(&self) -> &ApiClientWrapper<Self::ApiClient> {
+        &self.sync_api_client
     }
 }

--- a/xmtp_mls/src/test/mock/generate.rs
+++ b/xmtp_mls/src/test/mock/generate.rs
@@ -31,6 +31,7 @@ pub fn context() -> NewMockContext {
         },
         workers: WorkerRunner::new(),
         mls_storage: SqlKeyStore::new(MemoryStorage::new()),
+        sync_api_client: ApiClientWrapper::new(MockApiClient::new(), Default::default()),
     }
 }
 

--- a/xmtp_mls/src/utils/bench/clients.rs
+++ b/xmtp_mls/src/utils/bench/clients.rs
@@ -34,6 +34,20 @@ pub async fn new_unregistered_client(history_sync: bool) -> (BenchClient, Privat
             .unwrap()
     };
 
+    let sync_api_client = if is_dev_network {
+        tracing::info!("Using Dev GRPC");
+        <TestApiClient as XmtpTestClient>::create_dev()
+            .build()
+            .await
+            .unwrap()
+    } else {
+        tracing::info!("Using Local GRPC");
+        <TestApiClient as XmtpTestClient>::create_local()
+            .build()
+            .await
+            .unwrap()
+    };
+
     let client = crate::Client::builder(IdentityStrategy::new(
         inbox_id,
         wallet.identifier(),
@@ -44,7 +58,7 @@ pub async fn new_unregistered_client(history_sync: bool) -> (BenchClient, Privat
     let mut client = client
         .temp_store()
         .await
-        .api_client(api_client)
+        .api_clients(api_client, sync_api_client)
         .with_remote_verifier()
         .unwrap()
         .default_mls_store()

--- a/xmtp_mls/src/utils/test/mod.rs
+++ b/xmtp_mls/src/utils/test/mod.rs
@@ -62,7 +62,11 @@ impl<A, S> ClientBuilder<A, S> {
             .build()
             .await
             .unwrap();
-        self.api_client(api_client)
+        let sync_api_client = <TestClient as XmtpTestClient>::create_dev()
+            .build()
+            .await
+            .unwrap();
+        self.api_clients(api_client, sync_api_client)
     }
 
     pub async fn local(self) -> ClientBuilder<TestClient, S> {
@@ -70,7 +74,11 @@ impl<A, S> ClientBuilder<A, S> {
             .build()
             .await
             .unwrap();
-        self.api_client(api_client)
+        let sync_api_client = <TestClient as XmtpTestClient>::create_local()
+            .build()
+            .await
+            .unwrap();
+        self.api_clients(api_client, sync_api_client)
     }
 }
 
@@ -160,10 +168,14 @@ impl ClientBuilder<TestClient, TestMlsStorage> {
             .build()
             .await
             .unwrap();
+        let sync_api_client = <TestClient as XmtpTestClient>::create_dev()
+            .build()
+            .await
+            .unwrap();
 
         let client = Self::new_test_builder(owner)
             .await
-            .api_client(api_client)
+            .api_clients(api_client, sync_api_client)
             .build()
             .await
             .unwrap();
@@ -181,9 +193,14 @@ impl ClientBuilder<TestClient, TestMlsStorage> {
             .await
             .unwrap();
 
+        let sync_api_client = <TestClient as XmtpTestClient>::create_local()
+            .build()
+            .await
+            .unwrap();
+
         let client = Self::new_test_builder(owner)
             .await
-            .api_client(api_client)
+            .api_clients(api_client, sync_api_client)
             .device_sync_server_url(history_sync_url)
             .build()
             .await
@@ -196,7 +213,11 @@ impl ClientBuilder<TestClient, TestMlsStorage> {
 
 impl<ApiClient, Db> ClientBuilder<ApiClient, Db> {
     pub async fn local_client(self) -> ClientBuilder<TestClient, Db> {
-        self.api_client(
+        self.api_clients(
+            <TestClient as XmtpTestClient>::create_local()
+                .build()
+                .await
+                .unwrap(),
             <TestClient as XmtpTestClient>::create_local()
                 .build()
                 .await
@@ -205,7 +226,11 @@ impl<ApiClient, Db> ClientBuilder<ApiClient, Db> {
     }
 
     pub async fn dev_client(self) -> ClientBuilder<TestClient, Db> {
-        self.api_client(
+        self.api_clients(
+            <TestClient as XmtpTestClient>::create_dev()
+                .build()
+                .await
+                .unwrap(),
             <TestClient as XmtpTestClient>::create_dev()
                 .build()
                 .await

--- a/xmtp_mls/src/utils/test/tester_utils.rs
+++ b/xmtp_mls/src/utils/test/tester_utils.rs
@@ -166,9 +166,11 @@ where
         }
 
         let api_client = ClientBuilder::new_custom_api_client(&format!("http://{api_addr}")).await;
+        let sync_api_client =
+            ClientBuilder::new_custom_api_client(&format!("http://{api_addr}")).await;
         let client = ClientBuilder::new_test_builder(&self.owner)
             .await
-            .api_client(api_client)
+            .api_clients(api_client, sync_api_client)
             .with_device_sync_worker_mode(Some(self.sync_mode))
             .with_device_sync_server_url(self.sync_url.clone())
             .maybe_version(self.version.clone())

--- a/xmtp_mls/tests/chaos.rs
+++ b/xmtp_mls/tests/chaos.rs
@@ -25,7 +25,10 @@ async fn chaos_demo() {
     let (chaos, store) = ChaosDb::builder(store).error_frequency(0.0).build();
     let alix = Client::builder(new_identity(&owner))
         .store(store)
-        .api_client(TestClient::create_local().build().await.unwrap())
+        .api_clients(
+            TestClient::create_local().build().await.unwrap(),
+            TestClient::create_local().build().await.unwrap(),
+        )
         .default_mls_store()
         .unwrap()
         .with_remote_verifier()


### PR DESCRIPTION
SyncAll can take up a lot of GRPC threads and cause large queue delays for other functions like send message. Lets move sync to it's own GRPC channel so that it doesn't block the main channel actions.
Confirmed SyncAll improved from 60s to .6s for 200 groups and dms.