### PR TITLE
Add gateway service

### DIFF
--- a/dev/docker/docker-compose-d14n.yml
+++ b/dev/docker/docker-compose-d14n.yml
@@ -9,6 +9,13 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+  redis:
+    image: redis:7
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
   chain:
     platform: linux/amd64
     image: ghcr.io/xmtp/contracts:v0.4.3
@@ -34,9 +41,20 @@ services:
       register-node:
         condition: service_completed_successfully
     restart: on-failure
+  xmtpd-gateway:
+    platform: linux/amd64
+    image: ghcr.io/xmtp/xmtpd-gateway:sha-af9c1ad
+    env_file:
+      - local.env
+    depends_on:
+      redis:
+        condition: service_healthy
+    ports:
+      - 5150:5050
+      - 5155:5055
   repnode:
     platform: linux/amd64
-    image: ghcr.io/xmtp/xmtpd:sha-f8358a1
+    image: ghcr.io/xmtp/xmtpd:sha-af9c1ad
     env_file:
       - local.env
     depends_on:

--- a/dev/docker/local.env
+++ b/dev/docker/local.env
@@ -21,3 +21,4 @@ XMTPD_APP_CHAIN_RPC_URL=ws://chain:8545
 XMTPD_DB_WRITER_CONNECTION_STRING=postgres://postgres:xmtp@replicationdb:5432/postgres?sslmode=disable
 XMTPD_SETTLEMENT_CHAIN_RPC_URL=ws://chain:8545
 XMTPD_MLS_VALIDATION_GRPC_ADDRESS=http://validation:50051
+XMTPD_REDIS_URL=redis://redis:6379/0

--- a/xmtp_api_d14n/src/lib.rs
+++ b/xmtp_api_d14n/src/lib.rs
@@ -84,7 +84,7 @@ pub mod tests {
         fn create_local_d14n() -> Self::Builder {
             D14nClientBuilder::new(
                 <C as XmtpTestClient>::create_local_d14n(),
-                <Payer as XmtpTestClient>::create_local_d14n(),
+                <Payer as XmtpTestClient>::create_local_payer(),
             )
         }
     }

--- a/xmtp_api_grpc/src/grpc_api_helper.rs
+++ b/xmtp_api_grpc/src/grpc_api_helper.rs
@@ -343,7 +343,7 @@ mod test {
 
         fn create_local_payer() -> Self::Builder {
             let mut client = Client::builder();
-            client.set_host("http://localhost:5050".into());
+            client.set_host("http://localhost:5150".into());
             client.set_tls(false);
             client
         }

--- a/xmtp_api_grpc/src/grpc_client.rs
+++ b/xmtp_api_grpc/src/grpc_client.rs
@@ -185,7 +185,7 @@ mod test {
 
         fn create_local_payer() -> Self::Builder {
             let mut client = GrpcClient::builder();
-            client.set_host("http://localhost:5050".into());
+            client.set_host("http://localhost:5150".into());
             client.set_tls(false);
             client
         }

--- a/xmtp_api_http/src/constants.rs
+++ b/xmtp_api_http/src/constants.rs
@@ -3,6 +3,7 @@ pub struct ApiUrls;
 impl ApiUrls {
     pub const LOCAL_ADDRESS: &'static str = "http://localhost:5555";
     pub const LOCAL_D14N_ADDRESS: &'static str = "http://localhost:5055";
+    pub const LOCAL_PAYER_ADDRESS: &'static str = "http://localhost:5155";
     pub const DEV_ADDRESS: &'static str = "https://dev.xmtp.network:443";
     pub const PRODUCTION_ADDRESS: &'static str = "https://production.xmtp.network";
 }

--- a/xmtp_api_http/src/util.rs
+++ b/xmtp_api_http/src/util.rs
@@ -53,7 +53,7 @@ impl xmtp_proto::api_client::XmtpTestClient for crate::XmtpHttpApiClient {
         use xmtp_proto::api_client::ApiBuilder;
         let mut api = crate::XmtpHttpApiClient::builder();
         // payer has same address as d14n locally
-        api.set_host(crate::constants::ApiUrls::LOCAL_D14N_ADDRESS.into());
+        api.set_host(crate::constants::ApiUrls::LOCAL_PAYER_ADDRESS.into());
         api.set_libxmtp_version(env!("CARGO_PKG_VERSION").into())
             .unwrap();
         api.set_app_version("0.0.0".into()).unwrap();

--- a/xmtp_debug/src/args.rs
+++ b/xmtp_debug/src/args.rs
@@ -378,7 +378,7 @@ mod tests {
             "--url",
             "http://localhost:5050",
             "--payer-url",
-            "http://localhost:5050",
+            "http://localhost:5150",
         ]);
         assert!(opts.is_ok());
     }
@@ -404,7 +404,7 @@ mod tests {
 
     #[test]
     fn payer_url_only_is_valid_but_maybe_warning() {
-        let opts = parse_backend_args(&["--payer-url", "http://localhost:5050"]);
+        let opts = parse_backend_args(&["--payer-url", "http://localhost:5150"]);
         assert!(opts.is_ok());
     }
 
@@ -416,7 +416,7 @@ mod tests {
             "--url",
             "http://localhost:5050",
             "--payer-url",
-            "http://localhost:5050",
+            "http://localhost:5150",
         ]);
         assert!(opts.is_err());
     }

--- a/xmtp_debug/src/constants.rs
+++ b/xmtp_debug/src/constants.rs
@@ -26,7 +26,7 @@ pub static XMTP_STAGING_PAYER: LazyLock<Url> =
 pub static XMTP_DEV_PAYER: LazyLock<Url> =
     LazyLock::new(|| Url::parse("https://payer.testnet-dev.xmtp.network:443").unwrap());
 pub static XMTP_LOCAL_PAYER: LazyLock<Url> =
-    LazyLock::new(|| Url::parse("http://localhost:5050").unwrap());
+    LazyLock::new(|| Url::parse("http://localhost:5150").unwrap());
 
 pub static TMPDIR: LazyLock<TempDir> = LazyLock::<TempDir>::new(|| TempDir::new().unwrap());
 pub const STORAGE_PREFIX: &str = "xdbg";


### PR DESCRIPTION
### Add gateway service with Redis dependency and update client configurations to use new port mappings
- Adds a new `xmtpd-gateway` service to [dev/docker/docker-compose-d14n.yml](https://github.com/xmtp/libxmtp/pull/2268/files#diff-f3b95b320e721deae58c0f228c225c5dc895a08336200f71f989ac0764d95776) with port mappings 5150:5050 and 5155:5055, along with a Redis service for data storage
- Updates client test configurations across multiple files to use port 5150 instead of 5050 for payer service connections
- Introduces `LOCAL_PAYER_ADDRESS` constant in [xmtp_api_http/src/constants.rs](https://github.com/xmtp/libxmtp/pull/2268/files#diff-1e436e02a612ecb349c9de83e4c1d65bda176a4a94787bb7314b242064eb56f3) pointing to `http://localhost:5155`
- Modifies `XmtpTestClient::create_local_d14n` method in [xmtp_api_d14n/src/lib.rs](https://github.com/xmtp/libxmtp/pull/2268/files#diff-681fccc9f3c92bb252163b40c3e36f4eb3042f3d2fb13c944510e7c1ea5f62ba) to use `create_local_payer` for the second parameter
- Adds `XMTPD_REDIS_URL` environment variable in [dev/docker/local.env](https://github.com/xmtp/libxmtp/pull/2268/files#diff-e38cb3bb4b11354071f335632640f38034c9360d74a49702c65aca2fdfab3f31)

#### 📍Where to Start
Start with the Docker Compose configuration in [dev/docker/docker-compose-d14n.yml](https://github.com/xmtp/libxmtp/pull/2268/files#diff-f3b95b320e721deae58c0f228c225c5dc895a08336200f71f989ac0764d95776) to understand the new service architecture and port mappings.

----

_[Macroscope](https://app.macroscope.com) summarized 5e65d4b._ (Automatic summaries will resume when PR exits draft mode or review begins).