### PR TITLE
Transaction references encode and decode

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -2760,6 +2760,101 @@ pub fn decode_multi_remote_attachment(
         .map_err(|e| GenericError::Generic { err: e.to_string() })
 }
 
+#[derive(uniffi::Record, Clone, Default)]
+pub struct FfiTransactionMetadata {
+    pub transaction_type: String,
+    pub currency: String,
+    pub amount: f64,
+    pub decimals: u32,
+    pub from_address: String,
+    pub to_address: String,
+}
+
+impl From<FfiTransactionMetadata> for TransactionMetadata {
+    fn from(f: FfiTransactionMetadata) -> Self {
+        TransactionMetadata {
+            transaction_type: f.transaction_type,
+            currency: f.currency,
+            amount: f.amount,
+            decimals: f.decimals,
+            from_address: f.from_address,
+            to_address: f.to_address,
+        }
+    }
+}
+
+impl From<TransactionMetadata> for FfiTransactionMetadata {
+    fn from(t: TransactionMetadata) -> Self {
+        FfiTransactionMetadata {
+            transaction_type: t.transaction_type,
+            currency: t.currency,
+            amount: t.amount,
+            decimals: t.decimals,
+            from_address: t.from_address,
+            to_address: t.to_address,
+        }
+    }
+}
+
+#[derive(uniffi::Record, Clone, Default)]
+pub struct FfiTransactionReference {
+    pub namespace: Option<String>,
+    pub network_id: String,
+    pub reference: String,
+    pub metadata: Option<FfiTransactionMetadata>,
+}
+
+impl From<FfiTransactionReference> for TransactionReference {
+    fn from(f: FfiTransactionReference) -> Self {
+        TransactionReference {
+            namespace: f.namespace,
+            network_id: f.network_id,
+            reference: f.reference,
+            metadata: f.metadata.map(Into::into),
+        }
+    }
+}
+
+impl From<TransactionReference> for FfiTransactionReference {
+    fn from(t: TransactionReference) -> Self {
+        FfiTransactionReference {
+            namespace: t.namespace,
+            network_id: t.network_id,
+            reference: t.reference,
+            metadata: t.metadata.map(Into::into),
+        }
+    }
+}
+
+#[uniffi::export]
+pub fn encode_transaction_reference(
+    reference: FfiTransactionReference,
+) -> Result<Vec<u8>, GenericError> {
+    let reference: TransactionReference = reference.into();
+
+    let encoded = TransactionReferenceCodec::encode(reference)
+        .map_err(|e| GenericError::Generic { err: e.to_string() })?;
+
+    let mut buf = Vec::new();
+    encoded
+        .encode(&mut buf)
+        .map_err(|e| GenericError::Generic { err: e.to_string() })?;
+
+    Ok(buf)
+}
+
+#[uniffi::export]
+pub fn decode_transaction_reference(
+    bytes: Vec<u8>,
+) -> Result<FfiTransactionReference, GenericError> {
+    let encoded_content = EncodedContent::decode(bytes.as_slice())
+        .map_err(|e| GenericError::Generic { err: e.to_string() })?;
+
+    TransactionReferenceCodec::decode(encoded_content)
+        .map(Into::into)
+        .map_err(|e| GenericError::Generic { err: e.to_string() })
+}
+
 #[derive(uniffi::Record, Clone)]
 pub struct FfiMessage {
     pub id: Vec<u8>,
@@ -3024,8 +3119,8 @@ mod tests {
     };
     use crate::{
         apply_signature_request, connect_to_backend, decode_multi_remote_attachment,
-        decode_reaction, encode_multi_remote_attachment, encode_reaction,
-        get_inbox_id_for_identifier,
+        decode_reaction, decode_transaction_reference, encode_multi_remote_attachment,
+        encode_reaction, encode_transaction_reference, get_inbox_id_for_identifier,
         identity::{FfiIdentifier, FfiIdentifierKind},
         inbox_owner::{FfiInboxOwner, IdentityValidationError, SigningError},
         inbox_state_from_inbox_ids, is_connected,
@@ -3039,7 +3134,7 @@ mod tests {
         FfiMessageWithReactions, FfiMetadataField, FfiMultiRemoteAttachment, FfiPasskeySignature,
         FfiPermissionPolicy, FfiPermissionPolicySet, FfiPermissionUpdateType, FfiReaction,
         FfiReactionAction, FfiReactionSchema, FfiRemoteAttachmentInfo, FfiSubscribeError,
-        GenericError,
+        FfiTransactionMetadata, FfiTransactionReference, GenericError,
     };
     use alloy::signers::local::PrivateKeySigner;
     use futures::future::join_all;
@@ -8150,6 +8245,32 @@ mod tests {
             assert_eq!(decoded.scheme, original.scheme);
             assert_eq!(decoded.url, original.url);
         }
+    }
+
+    #[tokio::test]
+    async fn test_transaction_reference_roundtrip() {
+        let original = FfiTransactionReference {
+            namespace: Some("eip155".to_string()),
+            network_id: "1".to_string(),
+            reference: "0xabc123".to_string(),
+            metadata: Some(FfiTransactionMetadata {
+                transaction_type: "transfer".to_string(),
+                currency: "ETH".to_string(),
+                amount: 0.42,
+                decimals: 18,
+                from_address: "0xfrom".to_string(),
+                to_address: "0xto".to_string(),
+            }),
+        };
+
+        let encoded = encode_transaction_reference(original.clone()).unwrap();
+        let decoded = decode_transaction_reference(encoded).unwrap();
+
+        assert_eq!(original.reference, decoded.reference);
+        assert_eq!(
+            original.metadata.as_ref().unwrap().currency,
+            decoded.metadata.as_ref().unwrap().currency
+        );
     }
 
     #[tokio::test]

--- a/xmtp_content_types/src/transaction_reference.rs
+++ b/xmtp_content_types/src/transaction_reference.rs
@@ -1,6 +1,120 @@
+use std::collections::HashMap;
+
+use crate::{CodecError, ContentCodec};
+use serde::{Deserialize, Serialize};
+
+use xmtp_proto::xmtp::mls::message_contents::{ContentTypeId, EncodedContent};
+
 pub struct TransactionReferenceCodec {}
 
 /// Legacy content type id at https://github.com/xmtp/xmtp-js/blob/main/content-types/content-type-transaction-reference/src/TransactionReference.ts
 impl TransactionReferenceCodec {
+    const AUTHORITY_ID: &'static str = "xmtp.org";
     pub const TYPE_ID: &'static str = "transactionReference";
 }
+
+impl ContentCodec<TransactionReference> for TransactionReferenceCodec {
+    fn content_type() -> ContentTypeId {
+        ContentTypeId {
+            authority_id: Self::AUTHORITY_ID.to_string(),
+            type_id: Self::TYPE_ID.to_string(),
+            version_major: 1,
+            version_minor: 0,
+        }
+    }
+
+    fn encode(data: TransactionReference) -> Result<EncodedContent, CodecError> {
+        let json = serde_json::to_vec(&data)
+            .map_err(|e| CodecError::Encode(format!("JSON encode error: {}", e)))?;
+
+        Ok(EncodedContent {
+            r#type: Some(Self::content_type()),
+            parameters: HashMap::new(),
+            fallback: Some(Self::fallback(&data)),
+            compression: None,
+            content: json,
+        })
+    }
+
+    fn decode(encoded: EncodedContent) -> Result<TransactionReference, CodecError> {
+        serde_json::from_slice(&encoded.content)
+            .map_err(|e| CodecError::Decode(format!("JSON decode error: {}", e)))
+    }
+}
+
+impl TransactionReferenceCodec {
+    fn fallback(content: &TransactionReference) -> String {
+        if !content.reference.is_empty() {
+            format!(
+                "[Crypto transaction] Use a blockchain explorer to learn more using the transaction hash: {}",
+                content.reference
+            )
+        } else {
+            "Crypto transaction".to_string()
+        }
+    }
+}
+
+/// The main content type for transaction references
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct TransactionReference {
+    /// Optional namespace for the network (e.g., "eip155")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub namespace: Option<String>,
+
+    /// Network ID (as string to allow hex or decimal)
+    pub network_id: String,
+
+    /// Transaction hash
+    pub reference: String,
+
+    /// Optional metadata for the transaction
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<TransactionMetadata>,
+}
+
+/// Metadata attached to the transaction reference
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct TransactionMetadata {
+    pub transaction_type: String,
+    pub currency: String,
+    pub amount: f64,
+    pub decimals: u32,
+    pub from_address: String,
+    pub to_address: String,
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+    use super::*;
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    fn test_encode_decode_transaction_reference() {
+        let tx = TransactionReference {
+            namespace: Some("eip155".to_string()),
+            network_id: "1".to_string(),
+            reference: "0xabc123".to_string(),
+            metadata: Some(TransactionMetadata {
+                transaction_type: "payment".to_string(),
+                currency: "ETH".to_string(),
+                amount: 1.2345,
+                decimals: 18,
+                from_address: "0xsender".to_string(),
+                to_address: "0xrecipient".to_string(),
+            }),
+        };
+
+        let encoded = TransactionReferenceCodec::encode(tx.clone()).unwrap();
+        let decoded = TransactionReferenceCodec::decode(encoded).unwrap();
+
+        assert_eq!(decoded.reference, tx.reference);
+        assert_eq!(
+            decoded.metadata.as_ref().unwrap().currency,
+            "ETH".to_string()
+        );
+    }
+}
+


### PR DESCRIPTION
Adds the Transaction reference encode and decode to the ffi bindings so we can support them in swift and kotlin similar to javascript.
https://github.com/xmtp/xmtp-js/tree/main/content-types/content-type-transaction-reference