### PR TITLE
stitch dms grouped based on ordered group ids

### DIFF
--- a/xmtp_db/src/encrypted_store/conversation_list.rs
+++ b/xmtp_db/src/encrypted_store/conversation_list.rs
@@ -95,7 +95,7 @@ impl<C: ConnectionExt> QueryConversationList<C> for DbConnection<C> {
                 "id IN (
                     SELECT id FROM (
                         SELECT id,
-                            ROW_NUMBER() OVER (PARTITION BY COALESCE(dm_id, id) ORDER BY last_message_ns DESC) AS row_num
+                            ROW_NUMBER() OVER (PARTITION BY dm_id ORDER BY id DESC) AS row_num
                         FROM groups
                     ) AS ranked_groups
                     WHERE row_num = 1

--- a/xmtp_db/src/test_utils.rs
+++ b/xmtp_db/src/test_utils.rs
@@ -16,6 +16,9 @@ pub trait XmtpTestDb {
     async fn create_persistent_store(
         path: Option<String>,
     ) -> EncryptedMessageStore<crate::DefaultDatabase>;
+    /// Create an empty unencrypted database
+    /// does no validation and does not run migrations.
+    async fn create_unencrypted_persistent_store(path: Option<String>) -> crate::DefaultStore;
     /// Create an empty database
     /// does no validation and does not run migrations.
     async fn create_database(path: Option<String>) -> crate::DefaultDatabase;
@@ -150,6 +153,13 @@ mod native {
             let path = path.unwrap_or(xmtp_common::tmp_path());
             let opts = StorageOption::Persistent(path.to_string());
             let db = crate::database::NativeDb::new(&opts, [0u8; 32]).unwrap();
+            EncryptedMessageStore::new(db).expect("constructing message store failed.")
+        }
+
+        async fn create_unencrypted_persistent_store(path: Option<String>) -> crate::DefaultStore {
+            let path = path.unwrap_or(xmtp_common::tmp_path());
+            let opts = StorageOption::Persistent(path.to_string());
+            let db = crate::database::NativeDb::new_unencrypted(&opts).unwrap();
             EncryptedMessageStore::new(db).expect("constructing message store failed.")
         }
 


### PR DESCRIPTION
In the current implementation, DM stitching groups all conversations and sorts them by the timestamp of the last message, which can yield different “stitched” groups for different users. This change instead orders grouped DMs by their group ID—since that ID is the same for all participants, everyone will see the same stitched DM.
closes #2267