### PR TITLE
(welcomes patch 4/4) update cursor on non-retryable/already processed

### DIFF
--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -17,6 +17,8 @@ pub mod summary;
 #[cfg(test)]
 mod tests;
 pub mod validated_commit;
+mod welcomes;
+pub use welcomes::*;
 
 pub use self::group_permissions::PreconfiguredPolicies;
 use self::{
@@ -27,7 +29,6 @@ use self::{
         AdminListActionType, PermissionPolicyOption, PermissionUpdateType,
         UpdateAdminListIntentData, UpdateMetadataIntentData, UpdatePermissionIntentData,
     },
-    validated_commit::extract_group_membership,
 };
 use crate::groups::{intents::QueueIntent, mls_ext::CommitLogStorer};
 use crate::{GroupCommitLock, context::XmtpSharedContext};
@@ -36,8 +37,6 @@ use crate::{
     configuration::{
         CIPHERSUITE, MAX_GROUP_SIZE, MAX_PAST_EPOCHS, SEND_MESSAGE_UPDATE_INSTALLATIONS_INTERVAL_NS,
     },
-    identity_updates::load_identity_updates,
-    intents::ProcessIntentError,
     subscriptions::LocalEvents,
     utils::id::calculate_message_id,
 };
@@ -45,7 +44,6 @@ use crate::{subscriptions::SyncWorkerEvent, track};
 use device_sync::preference_sync::PreferenceUpdate;
 pub use error::*;
 use intents::{SendMessageIntentData, UpdateGroupMembershipResult};
-use mls_ext::DecryptedWelcome;
 use mls_sync::GroupMessageProcessingError;
 use openmls::{
     credentials::CredentialType,
@@ -55,7 +53,7 @@ use openmls::{
     },
     group::MlsGroupCreateConfig,
     messages::proposals::ProposalType,
-    prelude::{Capabilities, GroupId, MlsGroup as OpenMlsGroup, StagedWelcome, WireFormatPolicy},
+    prelude::{Capabilities, GroupId, MlsGroup as OpenMlsGroup, WireFormatPolicy},
 };
 use openmls_traits::storage::CURRENT_VERSION;
 use prost::Message;
@@ -63,19 +61,13 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::{collections::HashSet, sync::Arc};
 use tokio::sync::Mutex;
-use validated_commit::LibXMTPVersion;
 use xmtp_common::time::now_ns;
-use xmtp_content_types::ContentCodec;
+use xmtp_content_types::reaction::{LegacyReaction, ReactionCodec};
 use xmtp_content_types::should_push;
-use xmtp_content_types::{
-    group_updated::GroupUpdatedCodec,
-    reaction::{LegacyReaction, ReactionCodec},
-};
 use xmtp_db::XmtpMlsStorageProvider;
 use xmtp_db::local_commit_log::LocalCommitLog;
 use xmtp_db::prelude::*;
 use xmtp_db::user_preferences::HmacKey;
-use xmtp_db::xmtp_openmls_provider::{XmtpOpenMlsProvider, XmtpOpenMlsProviderRef};
 use xmtp_db::{Fetch, consent_record::ConsentType};
 use xmtp_db::{
     NotFound, StorageError,
@@ -98,16 +90,14 @@ use xmtp_mls_common::{
     group::{DMMetadataOptions, GroupMetadataOptions},
     group_metadata::{DmMembers, GroupMetadata, GroupMetadataError, extract_group_metadata},
     group_mutable_metadata::{
-        GroupMutableMetadata, GroupMutableMetadataError, MessageDisappearingSettings,
-        MetadataField, extract_group_mutable_metadata,
+        GroupMutableMetadata, GroupMutableMetadataError, MessageDisappearingSettings, MetadataField,
     },
 };
 use xmtp_proto::xmtp::mls::{
     api::v1::welcome_message,
     message_contents::{
-        ContentTypeId, EncodedContent, GroupUpdated, PlaintextEnvelope,
+        EncodedContent, PlaintextEnvelope,
         content_types::ReactionV2,
-        group_updated::Inbox,
         plaintext_envelope::{Content, V1},
     },
 };
@@ -538,291 +528,15 @@ where
         context: Context,
         welcome: &welcome_message::V1,
         cursor_increment: bool,
+        validator: impl ValidateGroupMembership,
     ) -> Result<Self, GroupError> {
-        let conn = &context.db();
-        // Check if this welcome was already processed. Return the existing group if so.
-        if conn.get_last_cursor_for_id(context.installation_id(), EntityKind::Welcome)?
-            >= welcome.id as i64
-        {
-            let group = conn
-                .find_group_by_welcome_id(welcome.id as i64)?
-                // The welcome previously errored out, e.g. HPKE error, so it's not in the DB
-                .ok_or(GroupError::NotFound(NotFound::GroupByWelcome(
-                    welcome.id as i64,
-                )))?;
-            let group = Self::new(
-                context,
-                group.id,
-                group.dm_id,
-                group.conversation_type,
-                group.created_at_ns,
-            );
-
-            tracing::warn!("Skipping old welcome {}", welcome.id);
-            return Ok(group);
-        };
-
-        let mut decrypt_result: Result<DecryptedWelcome, GroupError> =
-            Err(GroupError::UninitializedResult);
-        let transaction_result = context.mls_storage().transaction(|conn| {
-            let mls_storage = conn.key_store();
-            decrypt_result = DecryptedWelcome::from_encrypted_bytes(
-                &XmtpOpenMlsProvider::new(mls_storage),
-                &welcome.hpke_public_key,
-                &welcome.data,
-                welcome.wrapper_algorithm.into(),
-            );
-            Err(StorageError::IntentionalRollback)
-        });
-
-        // TODO: Move cursor forward on non-retriable errors, but not on retriable errors
-        let Err(StorageError::IntentionalRollback) = transaction_result else {
-            return Err(transaction_result?);
-        };
-
-        let DecryptedWelcome { staged_welcome, .. } = decrypt_result?;
-        // Ensure that the list of members in the group's MLS tree matches the list of inboxes specified
-        // in the `GroupMembership` extension.
-        validate_initial_group_membership(&context, &staged_welcome).await?;
-        let group_id = staged_welcome.public_group().group_id();
-        if conn.find_group(group_id.as_slice())?.is_some() {
-            // Fetch the original MLS group, rather than the one from the welcome
-            let result = MlsGroup::new_cached(context.clone(), group_id.as_slice());
-            if result.is_err() {
-                tracing::error!(
-                    "Error fetching group while validating welcome: {:?}",
-                    result.err()
-                );
-            } else {
-                let (group, _) = result.expect("No error");
-                // Check the group epoch as well, because we may not have synced the latest is_active state
-                // TODO(rich): Design a better way to detect if incoming welcomes are valid
-                if group.is_active()?
-                    && staged_welcome
-                        .public_group()
-                        .group_context()
-                        .epoch()
-                        .as_u64()
-                        <= group.epoch().await?
-                {
-                    tracing::error!(
-                        "Skipping welcome {} because we are already in group {}",
-                        welcome.id,
-                        hex::encode(group_id.as_slice())
-                    );
-                    return Err(ProcessIntentError::WelcomeAlreadyProcessed(welcome.id).into());
-                }
-            }
-        }
-
-        context.mls_storage().transaction(|conn| {
-            let storage = conn.key_store();
-            let db = storage.db();
-            let provider = XmtpOpenMlsProviderRef::new(&storage);
-            let decrypted_welcome = DecryptedWelcome::from_encrypted_bytes(
-                &provider,
-                &welcome.hpke_public_key,
-                &welcome.data,
-                welcome.wrapper_algorithm.into(),
-            )?;
-            let DecryptedWelcome {
-                staged_welcome,
-                added_by_inbox_id,
-                added_by_installation_id,
-            } = decrypted_welcome;
-
-            tracing::debug!(
-                "calling update cursor for welcome {}",
-                welcome.id
-            );
-            let requires_processing = {
-                let current_cursor = db.get_last_cursor_for_id(context.installation_id(), EntityKind::Welcome)?;
-                welcome.id > current_cursor as u64
-            };
-            if !requires_processing {
-                tracing::error!("Skipping already processed welcome {}", welcome.id);
-                return Err(ProcessIntentError::WelcomeAlreadyProcessed(welcome.id).into());
-            }
-            if cursor_increment {
-                // TODO: We update the cursor if this welcome decrypts successfully, but if previous welcomes
-                // failed due to retriable errors, this will permanently skip them.
-                db.update_cursor(
-                    context.installation_id(),
-                    EntityKind::Welcome,
-                    welcome.id as i64,
-                )?;
-            }
-
-
-            let mls_group = OpenMlsGroup::from_welcome_logged(&provider, staged_welcome, &added_by_inbox_id, &added_by_installation_id)?;
-            let group_id = mls_group.group_id().to_vec();
-            let metadata = extract_group_metadata(&mls_group).map_err(MetadataPermissionsError::from)?;
-            let dm_members = metadata.dm_members;
-            let conversation_type = metadata.conversation_type;
-            let mutable_metadata = extract_group_mutable_metadata(&mls_group).ok();
-            let disappearing_settings = mutable_metadata.as_ref().and_then(|metadata| {
-                Self::conversation_message_disappearing_settings_from_extensions(metadata).ok()
-            });
-
-            let paused_for_version: Option<String> = mutable_metadata.as_ref().and_then(|metadata| {
-                let min_version = Self::min_protocol_version_from_extensions(metadata);
-                if let Some(min_version) = min_version {
-                    let current_version_str = context.version_info().pkg_version();
-                    let current_version =
-                        LibXMTPVersion::parse(current_version_str).ok()?;
-                    let required_min_version = LibXMTPVersion::parse(&min_version.clone()).ok()?;
-                    if required_min_version > current_version {
-                        tracing::warn!(
-                            "Saving group from welcome as paused since version requirements are not met. \
-                            Group ID: {}, \
-                            Required version: {}, \
-                            Current version: {}",
-                            hex::encode(group_id.clone()),
-                            min_version,
-                            current_version_str
-                        );
-                        Some(min_version)
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                }
-            });
-
-            let mut group = StoredGroup::builder();
-            group.id(group_id)
-                .created_at_ns(now_ns())
-                .added_by_inbox_id(&added_by_inbox_id)
-                .welcome_id(welcome.id as i64)
-                .conversation_type(conversation_type)
-                .dm_id(dm_members.map(String::from))
-                .message_disappear_from_ns(disappearing_settings.as_ref().map(|m| m.from_ns))
-                .message_disappear_in_ns(disappearing_settings.as_ref().map(|m| m.in_ns))
-                .should_publish_commit_log(Self::check_should_publish_commit_log(context.inbox_id().to_string(), mutable_metadata));
-
-
-
-            let to_store = match conversation_type {
-                ConversationType::Group => {
-                    group
-                        .membership_state(GroupMembershipState::Pending)
-                        .paused_for_version(paused_for_version)
-                        .build()?
-                },
-                ConversationType::Dm => {
-                    validate_dm_group(&context, &mls_group, &added_by_inbox_id)?;
-                    group
-                        .membership_state(GroupMembershipState::Pending)
-                        .last_message_ns(welcome.created_ns as i64)
-                        .build()?
-                }
-                ConversationType::Sync => {
-                    // Let the DeviceSync worker know about the presence of a new
-                    // sync group that came in from a welcome.3
-                    let group_id = mls_group.group_id().to_vec();
-                    let _ = context.worker_events().send(SyncWorkerEvent::NewSyncGroupFromWelcome(group_id));
-
-                    group
-                        .membership_state(GroupMembershipState::Allowed)
-                        .build()?
-                },
-            };
-
-            tracing::warn!("storing group with welcome id {}", welcome.id);
-            // Insert or replace the group in the database.
-            // Replacement can happen in the case that the user has been removed from and subsequently re-added to the group.
-            let stored_group = db.insert_or_replace_group(to_store)?;
-
-            StoredConsentRecord::stitch_dm_consent(&db, &stored_group)?;
-            track!(
-                "Group Welcome",
-                {
-                    "conversation_type": stored_group.conversation_type,
-                    "added_by_inbox_id": &stored_group.added_by_inbox_id
-                },
-                group: &stored_group.id
-            );
-
-            // Create a GroupUpdated payload
-                let current_inbox_id = context.inbox_id().to_string();
-                let added_payload = GroupUpdated {
-                    initiated_by_inbox_id: added_by_inbox_id.clone(),
-                    added_inboxes: vec![Inbox {
-                        inbox_id: current_inbox_id.clone(),
-                    }],
-                    removed_inboxes: vec![],
-                    metadata_field_changes: vec![],
-                };
-
-                let encoded_added_payload = GroupUpdatedCodec::encode(added_payload)?;
-                let mut encoded_added_payload_bytes = Vec::new();
-                encoded_added_payload
-                    .encode(&mut encoded_added_payload_bytes)
-                    .map_err(GroupError::EncodeError)?;
-
-                let added_message_id = crate::utils::id::calculate_message_id(
-                    &stored_group.id,
-                    encoded_added_payload_bytes.as_slice(),
-                    &format!("{}_welcome_added", welcome.created_ns),
-                );
-
-                let added_content_type = match encoded_added_payload.r#type {
-                    Some(ct) => ct,
-                    None => {
-                        tracing::warn!(
-                            "Missing content type in encoded added payload, using default values"
-                        );
-                        ContentTypeId {
-                            authority_id: "unknown".to_string(),
-                            type_id: "unknown".to_string(),
-                            version_major: 0,
-                            version_minor: 0,
-                        }
-                    }
-                };
-
-                let added_msg = StoredGroupMessage {
-                    id: added_message_id,
-                    group_id: stored_group.id.clone(),
-                    decrypted_message_bytes: encoded_added_payload_bytes,
-                    sent_at_ns: welcome.created_ns as i64,
-                    kind: GroupMessageKind::MembershipChange,
-                    sender_installation_id: welcome.installation_key.clone(),
-                    sender_inbox_id: added_by_inbox_id,
-                    delivery_status: DeliveryStatus::Published,
-                    content_type: added_content_type.type_id.into(),
-                    version_major: added_content_type.version_major as i32,
-                    version_minor: added_content_type.version_minor as i32,
-                    authority_id: added_content_type.authority_id,
-                    reference_id: None,
-                    sequence_id: Some(welcome.id as i64),
-                    originator_id: None,
-                    expire_at_ns: None,
-                };
-
-                added_msg.store_or_ignore(&db)?;
-
-                tracing::info!(
-                    "[{}]: Created GroupUpdated message for welcome",
-                    current_inbox_id
-                );
-
-            let group = Self::new(
-                context.clone(),
-                stored_group.id,
-                stored_group.dm_id,
-                stored_group.conversation_type,
-                stored_group.created_at_ns,
-            );
-
-            // If this group is created by us - auto-consent to it.
-            if context.inbox_id() == metadata.creator_inbox_id {
-                group.quietly_update_consent_state(ConsentState::Allowed, &db)?;
-            }
-
-            Ok(group)
-        })
+        XmtpWelcome::builder()
+            .context(context)
+            .welcome(welcome)
+            .cursor_increment(cursor_increment)
+            .validator(validator)
+            .process()
+            .await
     }
 
     // Super admin status is only criteria for whether to publish the commit log for now
@@ -2056,58 +1770,6 @@ pub(crate) fn build_group_config(
         .max_past_epochs(MAX_PAST_EPOCHS)
         .use_ratchet_tree_extension(true)
         .build())
-}
-
-/**
- * Ensures that the membership in the MLS tree matches the inboxes specified in the `GroupMembership` extension.
- */
-async fn validate_initial_group_membership(
-    context: impl XmtpSharedContext,
-    staged_welcome: &StagedWelcome,
-) -> Result<(), GroupError> {
-    let db = context.db();
-    tracing::info!("Validating initial group membership");
-    let extensions = staged_welcome.public_group().group_context().extensions();
-    let membership = extract_group_membership(extensions)?;
-    let needs_update = filter_inbox_ids_needing_updates(&db, membership.to_filters().as_slice())?;
-    if !needs_update.is_empty() {
-        let ids = needs_update.iter().map(AsRef::as_ref).collect::<Vec<_>>();
-        load_identity_updates(context.api(), &db, ids.as_slice()).await?;
-    }
-
-    let mut expected_installation_ids = HashSet::<Vec<u8>>::new();
-
-    let identity_updates = crate::identity_updates::IdentityUpdates::new(&context);
-    let futures: Vec<_> = membership
-        .members
-        .iter()
-        .map(|(inbox_id, sequence_id)| {
-            identity_updates.get_association_state(&db, inbox_id, Some(*sequence_id as i64))
-        })
-        .collect();
-
-    let results = futures::future::try_join_all(futures).await?;
-
-    for association_state in results {
-        expected_installation_ids.extend(association_state.installation_ids());
-    }
-
-    let actual_installation_ids: HashSet<Vec<u8>> = staged_welcome
-        .public_group()
-        .members()
-        .map(|member| member.signature_key)
-        .collect();
-
-    // exclude failed installations
-    expected_installation_ids.retain(|id| !membership.failed_installations.contains(id));
-
-    if expected_installation_ids != actual_installation_ids {
-        return Err(GroupError::InvalidGroupMembership);
-    }
-
-    tracing::info!("Group membership validated");
-
-    Ok(())
 }
 
 pub fn filter_inbox_ids_needing_updates<'a>(

--- a/xmtp_mls/src/groups/welcome_sync.rs
+++ b/xmtp_mls/src/groups/welcome_sync.rs
@@ -1,5 +1,7 @@
 use crate::client::ClientError;
 use crate::context::XmtpSharedContext;
+use crate::groups::InitialMembershipValidator;
+use crate::groups::ValidateGroupMembership;
 use crate::groups::{GroupError, MlsGroup};
 use crate::mls_store::MlsStore;
 use futures::stream::{self, FuturesUnordered, StreamExt};
@@ -33,9 +35,15 @@ where
         &self,
         welcome: &welcome_message::V1,
         cursor_increment: bool,
+        validator: impl ValidateGroupMembership,
     ) -> Result<MlsGroup<Context>, GroupError> {
-        let result =
-            MlsGroup::create_from_welcome(self.context.clone(), welcome, cursor_increment).await;
+        let result = MlsGroup::create_from_welcome(
+            self.context.clone(),
+            welcome,
+            cursor_increment,
+            validator,
+        )
+        .await;
 
         match result {
             Ok(mls_group) => Ok(mls_group),
@@ -84,7 +92,10 @@ where
                 };
                 retry_async!(
                     Retry::default(),
-                    (async { self.process_new_welcome(&welcome_v1, true).await })
+                    (async {
+                        let validator = InitialMembershipValidator::new(&self.context);
+                        self.process_new_welcome(&welcome_v1, true, validator).await
+                    })
                 )
                 .ok()
             })
@@ -255,5 +266,293 @@ where
             .await;
 
         Ok(active_group_count.load(Ordering::SeqCst))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::groups::mls_ext::WrapperAlgorithm;
+    use crate::groups::mls_ext::wrap_welcome;
+    use crate::groups::test::NoopValidator;
+    use derive_builder::Builder;
+    use openmls::prelude::MlsMessageOut;
+    use rstest::*;
+    use tls_codec::Serialize;
+    use xmtp_db::StorageError;
+    use xmtp_db::refresh_state::EntityKind;
+    use xmtp_db::sql_key_store::SqlKeyStore;
+    use xmtp_db::{MemoryStorage, mock::MockDbQuery, sql_key_store::mock::MockSqlKeyStore};
+
+    use crate::test::mock::*;
+
+    fn generate_welcome(
+        id: u64,
+        public_key: Vec<u8>,
+        welcome: MlsMessageOut,
+    ) -> welcome_message::V1 {
+        let w = wrap_welcome(
+            &welcome.tls_serialize_detached().unwrap(),
+            &public_key,
+            &WrapperAlgorithm::Curve25519,
+        )
+        .unwrap();
+        welcome_message::V1 {
+            id,
+            created_ns: 0,
+            installation_key: vec![0],
+            data: w,
+            hpke_public_key: public_key,
+            wrapper_algorithm: WrapperAlgorithm::Curve25519.into(),
+            welcome_metadata: vec![0],
+        }
+    }
+
+    #[derive(Builder)]
+    #[builder(
+        pattern = "owned",
+        setter(strip_option),
+        build_fn(name = "inner_build")
+    )]
+    struct TestWelcomeSetup<DbF, TxF, TxF2, V> {
+        database_calls: DbF,
+        transaction_calls: TxF,
+        nested_transaction_calls: TxF2,
+        mem: Arc<SqlKeyStore<MemoryStorage>>,
+        context: NewMockContext,
+        validator: V,
+    }
+
+    impl<DbF, TxF, TxF2, V> TestWelcomeSetup<DbF, TxF, TxF2, V> {
+        fn builder() -> TestWelcomeSetupBuilder<DbF, TxF, TxF2, V> {
+            TestWelcomeSetupBuilder::default()
+        }
+    }
+
+    impl<DbF, TxF, TxF2, V> TestWelcomeSetupBuilder<DbF, TxF, TxF2, V>
+    where
+        DbF: FnMut(&mut MockDbQuery) + Send + 'static,
+        TxF: FnMut(&mut MockDbQuery) + Send + 'static,
+        TxF2: FnMut(&mut MockDbQuery) + Send + 'static,
+        V: ValidateGroupMembership,
+    {
+        fn build(self) -> (impl XmtpSharedContext, impl ValidateGroupMembership) {
+            let this = self.inner_build().unwrap();
+            let mut tx_functions = this.transaction_calls;
+            let mut nested_tx_functions = this.nested_transaction_calls;
+            let mem = &this.mem;
+            // db calls inside of transaction
+            let db = {
+                let mut db = MockDbQuery::new();
+                tx_functions(&mut db);
+                nested_tx_functions(&mut db);
+                Arc::new(db)
+            };
+            let mut mls_store = MockTransactionalKeyStore::default();
+            let db = db.clone();
+            mls_store.expect_key_store().returning({
+                let db = db.clone();
+                let mem = mem.clone();
+                move || {
+                    let mut mls_store = MockTransactionalKeyStore::default();
+                    mls_store.expect_key_store().returning({
+                        let db = db.clone();
+                        let mem = mem.clone();
+                        move || {
+                            let mls_store = MockTransactionalKeyStore::default();
+                            MockSqlKeyStore::new(db.clone(), mls_store, mem.clone())
+                        }
+                    });
+                    MockSqlKeyStore::new(db.clone(), mls_store, mem.clone())
+                }
+            });
+
+            let key_store = MockSqlKeyStore::new(db.clone(), mls_store, mem.clone());
+            let mut context = this.context.replace_mls_store(key_store);
+
+            // db calls outside tx
+            let mut database_calls = this.database_calls;
+            context.store.expect_db().returning({
+                move || {
+                    let mut mock_db = MockDbQuery::new();
+                    database_calls(&mut mock_db);
+                    mock_db
+                }
+            });
+            // after this point everything is immutable
+            (Arc::new(context), this.validator)
+        }
+    }
+
+    #[rstest]
+    #[xmtp_common::test]
+    async fn happy_path(context: NewMockContext) {
+        let mem = Arc::new(SqlKeyStore::new(MemoryStorage::default()));
+        let client = create_mls_client(mem.as_ref());
+        let (kp, mls_welcome) = client.join_group();
+        let network_welcome =
+            generate_welcome(50, kp.hpke_init_key().as_slice().to_vec(), mls_welcome);
+
+        let (context, validator) = TestWelcomeSetup::builder()
+            .validator(NoopValidator)
+            .context(context)
+            .database_calls(|db: &mut MockDbQuery| {
+                db.expect_get_last_cursor_for_id()
+                    .returning(|_id, _entity| Ok(0));
+                db.expect_find_group().returning(|_id| Ok(None));
+            })
+            // outer tx
+            .transaction_calls(|db: &mut MockDbQuery| {
+                db.expect_get_last_cursor_for_id()
+                    .returning(|_id, _entity| Ok(0));
+            })
+            // inner tx
+            .nested_transaction_calls(|db: &mut MockDbQuery| {
+                db.expect_get_last_cursor_for_id()
+                    .returning(|_id, _entity| Ok(0));
+                db.expect_update_cursor().returning(|_, _, _| Ok(true));
+                db.expect_insert_or_replace_group().returning(Ok);
+            })
+            .mem(mem)
+            .build();
+
+        let service = WelcomeService::new(context);
+        let res = service
+            .process_new_welcome(&network_welcome, true, validator)
+            .await;
+        assert!(res.is_ok(), "{}", res.unwrap_err());
+    }
+
+    #[rstest]
+    #[xmtp_common::test]
+    async fn increments_cursor_on_non_retryable_in_tx(context: NewMockContext) {
+        let mem = Arc::new(SqlKeyStore::new(MemoryStorage::default()));
+        let client = create_mls_client(mem.as_ref());
+        let (kp, mls_welcome) = client.join_group();
+        let network_welcome =
+            generate_welcome(50, kp.hpke_init_key().as_slice().to_vec(), mls_welcome);
+
+        let (context, validator) = TestWelcomeSetup::builder()
+            .validator(NoopValidator)
+            .context(context)
+            .nested_transaction_calls(|db: &mut MockDbQuery| {
+                db.expect_get_last_cursor_for_id()
+                    .once()
+                    .returning(|_id, _entity| {
+                        // non-retryable error in transaction
+                        Err(StorageError::DbSerialize)
+                    });
+            })
+            .transaction_calls(|db: &mut MockDbQuery| {
+                db.expect_update_cursor()
+                    .once()
+                    .returning(|_id, entity, cursor| {
+                        assert_eq!(cursor, 50);
+                        assert_eq!(entity, EntityKind::Welcome);
+                        Ok(true)
+                    });
+            })
+            .database_calls(|db: &mut MockDbQuery| {
+                db.expect_get_last_cursor_for_id()
+                    .once()
+                    .returning(|_id, _entity| Ok(0));
+                db.expect_find_group().once().returning(|_id| Ok(None));
+            })
+            .mem(mem)
+            .build();
+
+        let service = WelcomeService::new(context);
+        let res = service
+            .process_new_welcome(&network_welcome, true, validator)
+            .await;
+        assert!(res.is_err(), "{}", res.unwrap_err());
+    }
+
+    /// Validator which always returns a non-retryable error
+    struct NonRetryableValidator;
+    impl ValidateGroupMembership for NonRetryableValidator {
+        async fn check_initial_membership(
+            &self,
+            _welcome: &openmls::prelude::StagedWelcome,
+        ) -> Result<(), GroupError> {
+            Err(GroupError::NoPSKSupport)
+        }
+    }
+
+    struct RetryableValidator;
+    impl ValidateGroupMembership for RetryableValidator {
+        async fn check_initial_membership(
+            &self,
+            _welcome: &openmls::prelude::StagedWelcome,
+        ) -> Result<(), GroupError> {
+            Err(GroupError::LockUnavailable)
+        }
+    }
+
+    #[rstest]
+    #[xmtp_common::test]
+    async fn increments_cursor_on_non_retryable_during_validation(context: NewMockContext) {
+        let mem = Arc::new(SqlKeyStore::new(MemoryStorage::default()));
+        let client = create_mls_client(mem.as_ref());
+        let (kp, mls_welcome) = client.join_group();
+        let network_welcome =
+            generate_welcome(50, kp.hpke_init_key().as_slice().to_vec(), mls_welcome);
+
+        let (context, validator) = TestWelcomeSetup::builder()
+            .validator(NonRetryableValidator)
+            .context(context)
+            .nested_transaction_calls(|_db: &mut MockDbQuery| {})
+            .transaction_calls(|_db: &mut MockDbQuery| ())
+            .database_calls(|db: &mut MockDbQuery| {
+                db.expect_get_last_cursor_for_id()
+                    .once()
+                    .returning(|_id, _entity| Ok(0));
+                db.expect_update_cursor()
+                    .once()
+                    .returning(|_, _, _| Ok(true));
+            })
+            .mem(mem)
+            .build();
+
+        let service = WelcomeService::new(context);
+        let res = service
+            .process_new_welcome(&network_welcome, true, validator)
+            .await;
+        assert!(res.is_err(), "{}", res.unwrap_err());
+    }
+
+    #[rstest]
+    #[case::non_retryable_disallow_cursor(NonRetryableValidator, false)]
+    #[case::retryable_cursor_increment_allowed(RetryableValidator, true)]
+    #[xmtp_common::test]
+    async fn does_not_increment(
+        context: NewMockContext,
+        #[case] validator: impl ValidateGroupMembership,
+        #[case] cursor_increment: bool,
+    ) {
+        let mem = Arc::new(SqlKeyStore::new(MemoryStorage::default()));
+        let client = create_mls_client(mem.as_ref());
+        let (kp, mls_welcome) = client.join_group();
+        let network_welcome =
+            generate_welcome(50, kp.hpke_init_key().as_slice().to_vec(), mls_welcome);
+
+        let (context, validator) = TestWelcomeSetup::builder()
+            .validator(validator)
+            .context(context)
+            .nested_transaction_calls(|_db: &mut MockDbQuery| {})
+            .transaction_calls(|_db: &mut MockDbQuery| {})
+            .database_calls(|db: &mut MockDbQuery| {
+                db.expect_get_last_cursor_for_id()
+                    .once()
+                    .returning(|_id, _entity| Ok(0));
+            })
+            .mem(mem)
+            .build();
+
+        let service = WelcomeService::new(context);
+        let res = service
+            .process_new_welcome(&network_welcome, cursor_increment, validator)
+            .await;
+        assert!(res.is_err(), "{}", res.unwrap_err());
     }
 }

--- a/xmtp_mls/src/groups/welcomes.rs
+++ b/xmtp_mls/src/groups/welcomes.rs
@@ -1,0 +1,5 @@
+mod validated_membership;
+pub use validated_membership::*;
+
+mod xmtp_welcome;
+pub use xmtp_welcome::*;

--- a/xmtp_mls/src/groups/welcomes/validated_membership.rs
+++ b/xmtp_mls/src/groups/welcomes/validated_membership.rs
@@ -1,0 +1,95 @@
+use crate::context::XmtpSharedContext;
+use crate::groups::validated_commit::extract_group_membership;
+use crate::groups::{GroupError, filter_inbox_ids_needing_updates};
+use crate::identity_updates::load_identity_updates;
+use openmls::prelude::StagedWelcome;
+use std::collections::HashSet;
+
+#[allow(async_fn_in_trait)]
+pub trait ValidateGroupMembership {
+    ///
+    /// Ensures that the membership in the MLS tree matches the inboxes specified in the `GroupMembership` extension.
+    ///
+    async fn check_initial_membership(&self, welcome: &StagedWelcome) -> Result<(), GroupError>;
+}
+
+pub struct InitialMembershipValidator<C> {
+    context: C,
+}
+
+impl<C> InitialMembershipValidator<C> {
+    pub fn new(context: C) -> InitialMembershipValidator<C> {
+        Self { context }
+    }
+}
+
+impl<C> ValidateGroupMembership for InitialMembershipValidator<C>
+where
+    C: XmtpSharedContext,
+{
+    async fn check_initial_membership(
+        &self,
+        staged_welcome: &StagedWelcome,
+    ) -> Result<(), GroupError> {
+        let db = self.context.db();
+        tracing::info!("Validating initial group membership");
+        let extensions = staged_welcome.public_group().group_context().extensions();
+        let membership = extract_group_membership(extensions)?;
+        let needs_update =
+            filter_inbox_ids_needing_updates(&db, membership.to_filters().as_slice())?;
+        if !needs_update.is_empty() {
+            let ids = needs_update.iter().map(AsRef::as_ref).collect::<Vec<_>>();
+            load_identity_updates(self.context.api(), &db, ids.as_slice()).await?;
+        }
+
+        let mut expected_installation_ids = HashSet::<Vec<u8>>::new();
+
+        let identity_updates = crate::identity_updates::IdentityUpdates::new(&self.context);
+        let futures: Vec<_> = membership
+            .members
+            .iter()
+            .map(|(inbox_id, sequence_id)| {
+                identity_updates.get_association_state(&db, inbox_id, Some(*sequence_id as i64))
+            })
+            .collect();
+        let results = futures::future::try_join_all(futures).await?;
+
+        for association_state in results {
+            expected_installation_ids.extend(association_state.installation_ids());
+        }
+
+        let actual_installation_ids: HashSet<Vec<u8>> = staged_welcome
+            .public_group()
+            .members()
+            .map(|member| member.signature_key)
+            .collect();
+
+        // exclude failed installations
+        expected_installation_ids.retain(|id| !membership.failed_installations.contains(id));
+
+        if expected_installation_ids != actual_installation_ids {
+            return Err(GroupError::InvalidGroupMembership);
+        }
+
+        tracing::info!("Group membership validated");
+
+        Ok(())
+    }
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test {
+    use super::*;
+
+    #[derive(Default)]
+    pub struct NoopValidator;
+
+    impl ValidateGroupMembership for NoopValidator {
+        async fn check_initial_membership(
+            &self,
+            _welcome: &StagedWelcome,
+        ) -> Result<(), GroupError> {
+            Ok(())
+        }
+    }
+}

--- a/xmtp_mls/src/groups/welcomes/xmtp_welcome.rs
+++ b/xmtp_mls/src/groups/welcomes/xmtp_welcome.rs
@@ -1,0 +1,474 @@
+//! XMTP Welcome Processing
+//! Processes a new welcome from the network
+
+use crate::groups::MetadataPermissionsError;
+use crate::groups::mls_ext::CommitLogStorer;
+use crate::{
+    context::XmtpSharedContext,
+    groups::{
+        GroupError, MlsGroup, ValidateGroupMembership, mls_ext::DecryptedWelcome,
+        validate_dm_group, validated_commit::LibXMTPVersion,
+    },
+    intents::ProcessIntentError,
+    subscriptions::SyncWorkerEvent,
+    track,
+};
+use derive_builder::Builder;
+use openmls::group::MlsGroup as OpenMlsGroup;
+use prost::Message;
+use xmtp_common::RetryableError;
+use xmtp_common::time::now_ns;
+use xmtp_content_types::ContentCodec;
+use xmtp_content_types::group_updated::GroupUpdatedCodec;
+use xmtp_db::{
+    NotFound, StorageError, XmtpOpenMlsProvider, XmtpOpenMlsProviderRef,
+    consent_record::{ConsentState, StoredConsentRecord},
+    group::{ConversationType, GroupMembershipState, StoredGroup},
+    group_message::{DeliveryStatus, GroupMessageKind, StoredGroupMessage},
+    prelude::*,
+    refresh_state::EntityKind,
+};
+use xmtp_mls_common::{
+    group_metadata::extract_group_metadata, group_mutable_metadata::extract_group_mutable_metadata,
+};
+use xmtp_proto::xmtp::mls::{
+    api::v1::welcome_message,
+    message_contents::{ContentTypeId, GroupUpdated, group_updated::Inbox},
+};
+
+#[derive(Builder)]
+#[builder(
+    pattern = "owned",
+    setter(strip_option),
+    build_fn(error = "GroupError", private)
+)]
+pub struct XmtpWelcome<'a, C, V> {
+    context: C,
+    welcome: &'a welcome_message::V1,
+    cursor_increment: bool,
+    validator: V,
+}
+
+impl<'a, C, V> XmtpWelcome<'a, C, V> {
+    pub fn builder() -> XmtpWelcomeBuilder<'a, C, V> {
+        Default::default()
+    }
+}
+
+/// result of a commit
+/// we consider a commit succesful if it either:
+/// - Fails forever (can not be retried)
+/// - returns a valid MLS Group
+enum CommitResult<C> {
+    /// Failed on a non-retryable error
+    FailedForever(GroupError),
+    /// Returns a valid MLS Group
+    Ok(MlsGroup<C>),
+}
+
+impl<C> CommitResult<C> {
+    fn into_result(self) -> Result<MlsGroup<C>, GroupError> {
+        match self {
+            Self::FailedForever(err) => Err(err),
+            Self::Ok(group) => Ok(group),
+        }
+    }
+}
+
+impl<'a, C, V> XmtpWelcomeBuilder<'a, C, V>
+where
+    C: XmtpSharedContext,
+    V: ValidateGroupMembership,
+{
+    pub async fn process(self) -> Result<MlsGroup<C>, GroupError> {
+        let this = self.build()?;
+        let db = this.context.db();
+        if let Some(group) = this.check_if_processed(&db)? {
+            return Ok(group);
+        }
+
+        match this.validate_membership(&db).await {
+            Err(e) if !e.is_retryable() && this.cursor_increment => {
+                tracing::info!(
+                    "detected non-retryable error {e}, incrementing welcome cursor [{}]",
+                    this.welcome.id
+                );
+                this.update_cursor(&db)?;
+                return Err(e);
+            }
+            Err(e) => {
+                return Err(e);
+            }
+            _ => (),
+        }
+        let commit_result = this.commit_and_verify(this.context.mls_storage())?;
+        commit_result.into_result()
+    }
+}
+
+impl<'a, C, V> XmtpWelcome<'a, C, V>
+where
+    C: XmtpSharedContext,
+    V: ValidateGroupMembership,
+{
+    /// Get the last cursor in the database for welcomes
+    fn last_cursor(&self, db: &impl DbQuery) -> Result<i64, StorageError> {
+        db.get_last_cursor_for_id(self.context.installation_id(), EntityKind::Welcome)
+    }
+
+    /// Update the cursor in the database
+    /// returns true if the cursor was updated, otherwise false.
+    fn update_cursor(&self, db: &impl DbQuery) -> Result<bool, StorageError> {
+        db.update_cursor(
+            self.context.installation_id(),
+            EntityKind::Welcome,
+            self.welcome.id as i64,
+        )
+    }
+
+    /// Increment cursor only if the error is not retryable
+    /// Check if the welcome has already been processed
+    /// if the cursor of this welcome is less than the one we have in our local database,
+    /// we can safely return the local cached group as if we had processed it.
+    fn check_if_processed(&self, db: &impl DbQuery) -> Result<Option<MlsGroup<C>>, GroupError> {
+        let context = &self.context;
+
+        // Check if this welcome was already processed. Return the existing group if so.
+        if self.last_cursor(db)? >= self.welcome.id as i64 {
+            let group = db
+                .find_group_by_welcome_id(self.welcome.id as i64)?
+                // The welcome previously errored out, e.g. HPKE error, so it's not in the DB
+                .ok_or(GroupError::NotFound(NotFound::GroupByWelcome(
+                    self.welcome.id as i64,
+                )))?;
+
+            let group = MlsGroup::<_>::new(
+                context.clone(),
+                group.id,
+                group.dm_id,
+                group.conversation_type,
+                group.created_at_ns,
+            );
+
+            tracing::warn!("Skipping old welcome {}", self.welcome.id);
+            return Ok(Some(group));
+        };
+        Ok(None)
+    }
+
+    /// Process the welcome without affecting persistent state.
+    /// Return error if validation fails or if welcome was already processed.
+    async fn validate_membership(&self, db: &impl DbQuery) -> Result<(), GroupError> {
+        let Self { welcome, .. } = self;
+        let mut decrypt_result: Result<DecryptedWelcome, GroupError> =
+            Err(GroupError::UninitializedResult);
+        let transaction_result = self.context.mls_storage().transaction(|conn| {
+            let mls_storage = conn.key_store();
+            decrypt_result = DecryptedWelcome::from_encrypted_bytes(
+                &XmtpOpenMlsProvider::new(mls_storage),
+                &welcome.hpke_public_key,
+                &welcome.data,
+                welcome.wrapper_algorithm.into(),
+            );
+            Err(StorageError::IntentionalRollback)
+        });
+
+        let Err(StorageError::IntentionalRollback) = transaction_result else {
+            return Err(transaction_result?);
+        };
+
+        let DecryptedWelcome { staged_welcome, .. } = decrypt_result?;
+        // Ensure that the list of members in the group's MLS tree matches the list of inboxes specified
+        // in the `GroupMembership` extension.
+        self.validator
+            .check_initial_membership(&staged_welcome)
+            .await?;
+        let group_id = staged_welcome.public_group().group_id();
+        // try to load the group this welcome represents
+        // defensive to avoid race conditions & duplicates
+        if db.find_group(group_id.as_slice())?.is_some() {
+            // Fetch the original MLS group, rather than the one from the welcome
+            let result = MlsGroup::new_cached(self.context.clone(), group_id.as_slice());
+            if result.is_err() {
+                tracing::error!(
+                    "Error fetching group while validating welcome: {:?}",
+                    result.err()
+                );
+            } else {
+                let (group, _) = result.expect("No error");
+                // Check the group epoch as well, because we may not have synced the latest is_active state
+                // TODO(rich): Design a better way to detect if incoming welcomes are valid
+                if group.is_active()?
+                    && staged_welcome
+                        .public_group()
+                        .group_context()
+                        .epoch()
+                        .as_u64()
+                        <= group.epoch().await?
+                {
+                    tracing::error!(
+                        "Skipping welcome {} because we are already in group {}",
+                        welcome.id,
+                        hex::encode(group_id.as_slice())
+                    );
+                    return Err(ProcessIntentError::WelcomeAlreadyProcessed(welcome.id).into());
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Commit the welcome to the local db and memory.
+    /// Verifies the welcome processed succesfully. If it fails on a non-retryable error,
+    /// increments the cursor. Otherwise state must remain as if no transaction occurred.
+    /// Returns an error if group failed to commit.
+    fn commit_and_verify(
+        &self,
+        storage: &impl XmtpMlsStorageProvider,
+    ) -> Result<CommitResult<C>, GroupError> {
+        storage.transaction(|conn| {
+            let storage = conn.key_store();
+            // Savepoint transaction
+            let result = storage.transaction(|conn| self.commit(conn));
+            let db = storage.db();
+            // if we got an error
+            // and the error is not retryable
+            // and cursor increment is enabled
+            // update the cursor
+            match result {
+                Err(err) if !err.is_retryable() && self.cursor_increment => {
+                    tracing::warn!("welcome with cursor_id={} failed with a non-retryable error because of {err}, incrementing cursor", self.welcome.id);
+                    self.update_cursor(&db)?;
+                    // return ok to commit the transaction
+                    Ok(CommitResult::FailedForever(err))
+                },
+                // roll everything back to retry
+                Err(e) => Err(e),
+                Ok(group) => Ok(CommitResult::Ok(group)),
+            }
+        })
+    }
+
+    /// The welcome was validated and we haven't processed yet.
+    /// Can be commited
+    /// Requires a transaction
+    fn commit(&self, tx: &mut impl TransactionalKeyStore) -> Result<MlsGroup<C>, GroupError> {
+        let Self {
+            welcome,
+            cursor_increment,
+            context,
+            ..
+        } = self;
+
+        let storage = tx.key_store();
+        let db = storage.db();
+        let provider = XmtpOpenMlsProviderRef::new(&storage);
+        let decrypted_welcome = DecryptedWelcome::from_encrypted_bytes(
+            &provider,
+            &welcome.hpke_public_key,
+            &welcome.data,
+            welcome.wrapper_algorithm.into(),
+        )?;
+        let DecryptedWelcome {
+            staged_welcome,
+            added_by_inbox_id,
+            added_by_installation_id,
+        } = decrypted_welcome;
+
+        tracing::debug!("calling update cursor for welcome {}", welcome.id);
+        let requires_processing = {
+            let current_cursor = self.last_cursor(&db)?;
+            welcome.id > current_cursor as u64
+        };
+        if !requires_processing {
+            tracing::error!("Skipping already processed welcome {}", welcome.id);
+            return Err(ProcessIntentError::WelcomeAlreadyProcessed(welcome.id).into());
+        }
+        if *cursor_increment {
+            // TODO: We update the cursor if this welcome decrypts successfully, but if previous welcomes
+            // failed due to retriable errors, this will permanently skip them.
+            db.update_cursor(
+                context.installation_id(),
+                EntityKind::Welcome,
+                welcome.id as i64,
+            )?;
+        }
+
+        let mls_group = OpenMlsGroup::from_welcome_logged(
+            &provider,
+            staged_welcome,
+            &added_by_inbox_id,
+            &added_by_installation_id,
+        )?;
+        let group_id = mls_group.group_id().to_vec();
+        let metadata =
+            extract_group_metadata(&mls_group).map_err(MetadataPermissionsError::from)?;
+        let dm_members = metadata.dm_members;
+        let conversation_type = metadata.conversation_type;
+        let mutable_metadata = extract_group_mutable_metadata(&mls_group).ok();
+        let disappearing_settings = mutable_metadata.as_ref().and_then(|metadata| {
+            MlsGroup::<C>::conversation_message_disappearing_settings_from_extensions(metadata).ok()
+        });
+
+        let paused_for_version: Option<String> = mutable_metadata.as_ref().and_then(|metadata| {
+            let min_version = MlsGroup::<C>::min_protocol_version_from_extensions(metadata);
+            if let Some(min_version) = min_version {
+                let current_version_str = context.version_info().pkg_version();
+                let current_version =
+                    LibXMTPVersion::parse(current_version_str).ok()?;
+                let required_min_version = LibXMTPVersion::parse(&min_version.clone()).ok()?;
+                if required_min_version > current_version {
+                    tracing::warn!(
+                        "Saving group from welcome as paused since version requirements are not met. \
+                        Group ID: {}, \
+                        Required version: {}, \
+                        Current version: {}",
+                        hex::encode(group_id.clone()),
+                        min_version,
+                        current_version_str
+                    );
+                    Some(min_version)
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        });
+
+        let mut group = StoredGroup::builder();
+        group
+            .id(group_id)
+            .created_at_ns(now_ns())
+            .added_by_inbox_id(&added_by_inbox_id)
+            .welcome_id(welcome.id as i64)
+            .conversation_type(conversation_type)
+            .dm_id(dm_members.map(String::from))
+            .message_disappear_from_ns(disappearing_settings.as_ref().map(|m| m.from_ns))
+            .message_disappear_in_ns(disappearing_settings.as_ref().map(|m| m.in_ns))
+            .should_publish_commit_log(MlsGroup::<C>::check_should_publish_commit_log(
+                context.inbox_id().to_string(),
+                mutable_metadata,
+            ));
+
+        let to_store = match conversation_type {
+            ConversationType::Group => group
+                .membership_state(GroupMembershipState::Pending)
+                .paused_for_version(paused_for_version)
+                .build()?,
+            ConversationType::Dm => {
+                validate_dm_group(context, &mls_group, &added_by_inbox_id)?;
+                group
+                    .membership_state(GroupMembershipState::Pending)
+                    .last_message_ns(welcome.created_ns as i64)
+                    .build()?
+            }
+            ConversationType::Sync => {
+                // Let the DeviceSync worker know about the presence of a new
+                // sync group that came in from a welcome.3
+                let group_id = mls_group.group_id().to_vec();
+                let _ = context
+                    .worker_events()
+                    .send(SyncWorkerEvent::NewSyncGroupFromWelcome(group_id));
+
+                group
+                    .membership_state(GroupMembershipState::Allowed)
+                    .build()?
+            }
+        };
+
+        tracing::warn!("storing group with welcome id {}", welcome.id);
+        // Insert or replace the group in the database.
+        // Replacement can happen in the case that the user has been removed from and subsequently re-added to the group.
+        let stored_group = db.insert_or_replace_group(to_store)?;
+
+        StoredConsentRecord::stitch_dm_consent(&db, &stored_group)?;
+        track!(
+            "Group Welcome",
+            {
+                "conversation_type": stored_group.conversation_type,
+                "added_by_inbox_id": &stored_group.added_by_inbox_id
+            },
+            group: &stored_group.id
+        );
+
+        // Create a GroupUpdated payload
+        let current_inbox_id = context.inbox_id().to_string();
+        let added_payload = GroupUpdated {
+            initiated_by_inbox_id: added_by_inbox_id.clone(),
+            added_inboxes: vec![Inbox {
+                inbox_id: current_inbox_id.clone(),
+            }],
+            removed_inboxes: vec![],
+            metadata_field_changes: vec![],
+        };
+
+        let encoded_added_payload = GroupUpdatedCodec::encode(added_payload)?;
+        let mut encoded_added_payload_bytes = Vec::new();
+        encoded_added_payload
+            .encode(&mut encoded_added_payload_bytes)
+            .map_err(GroupError::EncodeError)?;
+
+        let added_message_id = crate::utils::id::calculate_message_id(
+            &stored_group.id,
+            encoded_added_payload_bytes.as_slice(),
+            &format!("{}_welcome_added", welcome.created_ns),
+        );
+
+        let added_content_type = match encoded_added_payload.r#type {
+            Some(ct) => ct,
+            None => {
+                tracing::warn!(
+                    "Missing content type in encoded added payload, using default values"
+                );
+                ContentTypeId {
+                    authority_id: "unknown".to_string(),
+                    type_id: "unknown".to_string(),
+                    version_major: 0,
+                    version_minor: 0,
+                }
+            }
+        };
+
+        let added_msg = StoredGroupMessage {
+            id: added_message_id,
+            group_id: stored_group.id.clone(),
+            decrypted_message_bytes: encoded_added_payload_bytes,
+            sent_at_ns: welcome.created_ns as i64,
+            kind: GroupMessageKind::MembershipChange,
+            sender_installation_id: welcome.installation_key.clone(),
+            sender_inbox_id: added_by_inbox_id,
+            delivery_status: DeliveryStatus::Published,
+            content_type: added_content_type.type_id.into(),
+            version_major: added_content_type.version_major as i32,
+            version_minor: added_content_type.version_minor as i32,
+            authority_id: added_content_type.authority_id,
+            reference_id: None,
+            sequence_id: Some(welcome.id as i64),
+            originator_id: None,
+            expire_at_ns: None,
+        };
+
+        added_msg.store_or_ignore(&db)?;
+
+        tracing::info!(
+            "[{}]: Created GroupUpdated message for welcome",
+            current_inbox_id
+        );
+
+        let group = MlsGroup::new(
+            context.clone(),
+            stored_group.id,
+            stored_group.dm_id,
+            stored_group.conversation_type,
+            stored_group.created_at_ns,
+        );
+
+        // If this group is created by us - auto-consent to it.
+        if context.inbox_id() == metadata.creator_inbox_id {
+            group.quietly_update_consent_state(ConsentState::Allowed, &db)?;
+        }
+
+        Ok(group)
+    }
+}


### PR DESCRIPTION
### Refactor welcome message processing to update cursor on non-retryable and already processed welcomes using validator-based architecture
- Extracts welcome message processing logic from `MlsGroup::create_from_welcome` method in [xmtp_mls/src/groups/mod.rs](https://github.com/xmtp/libxmtp/pull/2285/files#diff-c29f56a38916c7410eff8091df1a2e43487ffe20646d96827e846e475f4608d3) into a new `welcomes` module with builder pattern implementation
- Introduces `ValidateGroupMembership` trait and `InitialMembershipValidator` struct in [xmtp_mls/src/groups/welcomes/validated_membership.rs](https://github.com/xmtp/libxmtp/pull/2285/files#diff-579768dc2651f0a38ca6c3c44c72ce03c4b7a5a1bc1dc0460d0958f96e979610) for modular group membership validation
- Implements `XmtpWelcome` and `XmtpWelcomeBuilder` structs in [xmtp_mls/src/groups/welcomes/xmtp_welcome.rs](https://github.com/xmtp/libxmtp/pull/2285/files#diff-a8d5a5fab05f9277d06cce92de1f0806f13f6d3298cf178dcd67f8599f94220e) with comprehensive welcome processing workflow including cursor management
- Updates `process_new_welcome` method signature in [xmtp_mls/src/groups/welcome_sync.rs](https://github.com/xmtp/libxmtp/pull/2285/files#diff-9cc59d04a1f096342f3bf5dbcc01e5bf59b62ca24bc1ede5610cd2cdb78ae910) to accept validator parameter and adds test suite for welcome processing scenarios
- Modifies welcome processing in [xmtp_mls/src/subscriptions/process_welcome.rs](https://github.com/xmtp/libxmtp/pull/2285/files#diff-317c20511a1befc7d46c6761a7addc8b70eb46f1ef84c8b6af03e30c2412b785) to use new validator-based approach

#### 📍Where to Start
Start with the `XmtpWelcome::process` method in [xmtp_mls/src/groups/welcomes/xmtp_welcome.rs](https://github.com/xmtp/libxmtp/pull/2285/files#diff-a8d5a5fab05f9277d06cce92de1f0806f13f6d3298cf178dcd67f8599f94220e) to understand the new welcome processing workflow and cursor management logic.

----

_[Macroscope](https://app.macroscope.com) summarized 14436d4._