### PR TITLE
clearer contextual tracing for tests

### DIFF
--- a/common/src/test.rs
+++ b/common/src/test.rs
@@ -96,8 +96,7 @@ where
                 fmt::layer()
                     .compact()
                     .with_ansi(true)
-                    .with_thread_ids(true)
-                    .with_target(true)
+                    .without_time()
                     .with_test_writer()
                     .fmt_fields({
                         format::debug_fn(move |writer, field, value| {

--- a/xmtp_db/src/encrypted_store/group.rs
+++ b/xmtp_db/src/encrypted_store/group.rs
@@ -746,7 +746,6 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
     }
 
     fn insert_or_replace_group(&self, group: StoredGroup) -> Result<StoredGroup, StorageError> {
-        tracing::info!("Trying to insert group");
         let maybe_inserted_group: Option<StoredGroup> = self.raw_query_write(|conn| {
             diesel::insert_into(dsl::groups)
                 .values(&group)
@@ -793,7 +792,6 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
                 Ok(existing_group)
             }
         } else {
-            tracing::info!("Group is inserted");
             Ok(self.raw_query_read(|c| dsl::groups.find(group.id).first(c))?)
         }
     }

--- a/xmtp_mls/src/groups/device_sync_legacy/preference_sync_legacy.rs
+++ b/xmtp_mls/src/groups/device_sync_legacy/preference_sync_legacy.rs
@@ -105,6 +105,11 @@ pub(crate) fn process_incoming_preference_update(
 impl LegacyUserPreferenceUpdate {
     /// Send a preference update through the sync group for other devices to consume
     /// Returns updates synced
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(who = device_sync.context.inbox_id()), skip_all))]
+    #[cfg_attr(
+        not(any(test, feature = "test-utils")),
+        tracing::instrument(level = "trace", skip_all)
+    )]
     pub(crate) async fn v1_sync_across_devices<C: XmtpSharedContext>(
         updates: Vec<Self>,
         device_sync: &DeviceSyncClient<C>,

--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -337,7 +337,8 @@ where
     /// Sync from the network with the 'conn' (local database).
     /// must return a summary of all messages synced, whether they were
     /// successful or not.
-    #[tracing::instrument(skip_all)]
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(fields(who = %self.context.inbox_id())))]
+    #[cfg_attr(not(any(test, feature = "test-utils")), tracing::instrument(skip_all))]
     pub async fn sync_with_conn(&self) -> Result<SyncSummary, SyncSummary> {
         let _mutex = self.mutex.lock().await;
         let mut summary = SyncSummary::default();
@@ -393,7 +394,11 @@ where
         }
     }
 
-    #[tracing::instrument(skip_all, level = "trace")]
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(who = %self.context.inbox_id()), skip_all))]
+    #[cfg_attr(
+        not(any(test, feature = "test-utils")),
+        tracing::instrument(level = "trace", skip_all)
+    )]
     pub(super) async fn sync_until_last_intent_resolved(&self) -> Result<SyncSummary, GroupError> {
         let intents = self.context.db().find_group_intents(
             self.group_id.clone(),
@@ -423,7 +428,11 @@ where
      *
      * This method will retry up to `xmtp_configuration::MAX_GROUP_SYNC_RETRIES` times.
      */
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(who = %self.context.inbox_id()), skip(self)))]
+    #[cfg_attr(
+        not(any(test, feature = "test-utils")),
+        tracing::instrument(level = "trace", skip(self))
+    )]
     pub(super) async fn sync_until_intent_resolved(
         &self,
         intent_id: ID,
@@ -1268,7 +1277,14 @@ where
     /// * `trust_message_order` - Controls whether to allow epoch increments from commits and msg cursor increments.
     ///   Set to `true` when processing messages from trusted ordered sources (queries), and `false` when
     ///   processing from potentially out-of-order sources like streams.
-    #[tracing::instrument(skip(self, envelope), level = "trace")]
+    #[cfg_attr(
+        any(test, feature = "test-utils"),
+        tracing::instrument(level = "info", skip(self, envelope))
+    )]
+    #[cfg_attr(
+        not(any(test, feature = "test-utils")),
+        tracing::instrument(level = "trace", skip_all)
+    )]
     pub(crate) async fn process_message(
         &self,
         envelope: &GroupMessageV1,
@@ -2249,6 +2265,11 @@ where
      * This is designed to handle cases where existing members have added a new installation to their inbox or revoked an installation
      * and the group has not been updated to include it.
      */
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(who = %self.context.inbox_id()), skip_all))]
+    #[cfg_attr(
+        not(any(test, feature = "test-utils")),
+        tracing::instrument(level = "trace", skip_all)
+    )]
     pub(super) async fn add_missing_installations(&self) -> Result<(), GroupError> {
         let intent_data = self.get_membership_update_intent(&[], &[]).await?;
 

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -623,7 +623,11 @@ where
     }
 
     /// Send a message on this users XMTP [`Client`].
-    #[tracing::instrument(skip_all, level = "trace")]
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", skip(self), fields(who = self.context.inbox_id(), message = %String::from_utf8_lossy(message))))]
+    #[cfg_attr(
+        not(any(test, feature = "test-utils")),
+        tracing::instrument(level = "trace", skip(self))
+    )]
     pub async fn send_message(&self, message: &[u8]) -> Result<Vec<u8>, GroupError> {
         if !self.is_active()? {
             tracing::warn!("Unable to send a message on an inactive group.");
@@ -646,6 +650,11 @@ where
 
     /// Publish all unpublished messages. This happens by calling `sync_until_last_intent_resolved`
     /// which publishes all pending intents and reads them back from the network.
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(who = self.context.inbox_id()), skip(self)))]
+    #[cfg_attr(
+        not(any(test, feature = "test-utils")),
+        tracing::instrument(level = "trace", skip(self))
+    )]
     pub async fn publish_messages(&self) -> Result<(), GroupError> {
         self.ensure_not_paused().await?;
         let update_interval_ns = Some(SEND_MESSAGE_UPDATE_INSTALLATIONS_INTERVAL_NS);
@@ -829,7 +838,11 @@ where
             .await
     }
 
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", skip_all, fields(who = %self.context.inbox_id(), inbox_ids = ?inbox_ids.as_ref().iter().map(|i| i.as_ref()).collect::<Vec<_>>())))]
+    #[cfg_attr(
+        not(any(test, feature = "test-utils")),
+        tracing::instrument(level = "trace", skip_all)
+    )]
     pub async fn add_members_by_inbox_id<S: AsIdRef>(
         &self,
         inbox_ids: impl AsRef<[S]>,
@@ -908,6 +921,11 @@ where
     ///
     /// # Returns
     /// A `Result` indicating success or failure of the operation.
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", skip_all, fields(who = %self.context.inbox_id(), inbox_ids = ?inbox_ids)))]
+    #[cfg_attr(
+        not(any(test, feature = "test-utils")),
+        tracing::instrument(level = "trace", skip_all)
+    )]
     pub async fn remove_members_by_inbox_id(
         &self,
         inbox_ids: &[InboxIdRef<'_>],
@@ -934,6 +952,11 @@ where
 
     /// Updates the name of the group. Will error if the user does not have the appropriate permissions
     /// to perform these updates.
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(who = %self.context.inbox_id()), skip(self)))]
+    #[cfg_attr(
+        not(any(test, feature = "test-utils")),
+        tracing::instrument(level = "trace", skip(self))
+    )]
     pub async fn update_group_name(&self, group_name: String) -> Result<(), GroupError> {
         self.ensure_not_paused().await?;
 
@@ -956,6 +979,11 @@ where
     }
 
     /// Updates min version of the group to match this client's version.
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(who = %self.context.inbox_id()), skip(self)))]
+    #[cfg_attr(
+        not(any(test, feature = "test-utils")),
+        tracing::instrument(level = "trace", skip(self))
+    )]
     pub async fn update_group_min_version_to_match_self(&self) -> Result<(), GroupError> {
         self.ensure_not_paused().await?;
         let version = self.context.version_info().pkg_version();
@@ -1003,6 +1031,11 @@ where
     }
 
     /// Updates the permission policy of the group. This requires super admin permissions.
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(who = %self.context.inbox_id()), skip(self)))]
+    #[cfg_attr(
+        not(any(test, feature = "test-utils")),
+        tracing::instrument(level = "trace", skip(self))
+    )]
     pub async fn update_permission_policy(
         &self,
         permission_update_type: PermissionUpdateType,
@@ -1051,6 +1084,11 @@ where
     }
 
     /// Updates the description of the group.
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(who = %self.context.inbox_id()), skip(self)))]
+    #[cfg_attr(
+        not(any(test, feature = "test-utils")),
+        tracing::instrument(level = "trace", skip(self))
+    )]
     pub async fn update_group_description(
         &self,
         group_description: String,
@@ -1090,6 +1128,11 @@ where
     }
 
     /// Updates the image URL (square) of the group.
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(who = %self.context.inbox_id()), skip(self)))]
+    #[cfg_attr(
+        not(any(test, feature = "test-utils")),
+        tracing::instrument(level = "trace", skip(self))
+    )]
     pub async fn update_group_image_url_square(
         &self,
         group_image_url_square: String,
@@ -1154,6 +1197,11 @@ where
         .await
     }
 
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(who = %self.context.inbox_id()), skip(self)))]
+    #[cfg_attr(
+        not(any(test, feature = "test-utils")),
+        tracing::instrument(level = "trace", skip(self))
+    )]
     async fn update_conversation_message_disappear_from_ns(
         &self,
         expire_from_ms: i64,
@@ -1172,6 +1220,11 @@ where
         Ok(())
     }
 
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(who = %self.context.inbox_id()), skip(self)))]
+    #[cfg_attr(
+        not(any(test, feature = "test-utils")),
+        tracing::instrument(level = "trace", skip(self))
+    )]
     async fn update_conversation_message_disappear_in_ns(
         &self,
         expire_in_ms: i64,
@@ -1266,6 +1319,11 @@ where
     }
 
     /// Updates the admin list of the group and syncs the changes to the network.
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(who = %self.context.inbox_id()), skip(self)))]
+    #[cfg_attr(
+        not(any(test, feature = "test-utils")),
+        tracing::instrument(level = "trace", skip(self))
+    )]
     pub async fn update_admin_list(
         &self,
         action_type: UpdateAdminListType,
@@ -1396,6 +1454,11 @@ where
     }
 
     /// Update this installation's leaf key in the group by creating a key update commit
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(who = %self.context.inbox_id()), skip(self)))]
+    #[cfg_attr(
+        not(any(test, feature = "test-utils")),
+        tracing::instrument(level = "trace", skip(self))
+    )]
     pub async fn key_update(&self) -> Result<(), GroupError> {
         let intent = QueueIntent::key_update().queue(self)?;
         let _ = self.sync_until_intent_resolved(intent.id).await?;

--- a/xmtp_mls/src/groups/tests/mod.rs
+++ b/xmtp_mls/src/groups/tests/mod.rs
@@ -22,7 +22,8 @@ use crate::groups::{
     MAX_GROUP_DESCRIPTION_LENGTH, MAX_GROUP_IMAGE_URL_LENGTH, MAX_GROUP_NAME_LENGTH,
 };
 use crate::tester;
-use crate::utils::{TestMlsGroup, Tester, VersionInfo};
+use crate::utils::fixtures::{alix, bola, caro};
+use crate::utils::{ClientTester, TestMlsGroup, Tester, VersionInfo};
 use crate::{
     builder::ClientBuilder,
     groups::{
@@ -39,6 +40,7 @@ use crate::{
 use diesel::connection::SimpleConnection;
 use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl};
 use futures::future::join_all;
+use rstest::*;
 use std::sync::Arc;
 use wasm_bindgen_test::wasm_bindgen_test;
 use xmtp_common::RetryableError;
@@ -2701,11 +2703,14 @@ async fn respect_allow_epoch_increment() {
     );
 }
 
+#[rstest]
 #[xmtp_common::test]
-async fn test_get_and_set_consent() {
-    let alix = ClientBuilder::new_test_client(&generate_local_wallet()).await;
-    let bola = ClientBuilder::new_test_client(&generate_local_wallet()).await;
-    let caro = ClientBuilder::new_test_client(&generate_local_wallet()).await;
+#[awt]
+async fn test_get_and_set_consent(
+    #[future] alix: ClientTester,
+    #[future] bola: ClientTester,
+    #[future] caro: ClientTester,
+) {
     let alix_group = alix.create_group(None, None).unwrap();
 
     // group consent state should be allowed if user created it
@@ -2759,8 +2764,8 @@ async fn test_get_and_set_consent() {
 async fn test_max_past_epochs() {
     // Create group with two members
     let bo_wallet = generate_local_wallet();
-    let alix = ClientBuilder::new_test_client(&generate_local_wallet()).await;
-    let bo = ClientBuilder::new_test_client(&bo_wallet).await;
+    let alix = ClientBuilder::new_test_client_vanilla(&generate_local_wallet()).await;
+    let bo = ClientBuilder::new_test_client_vanilla(&bo_wallet).await;
     let alix_group = alix
         .create_group_with_members(&[bo_wallet.identifier()], None, None)
         .await

--- a/xmtp_mls/src/subscriptions/stream_all/tests.rs
+++ b/xmtp_mls/src/subscriptions/stream_all/tests.rs
@@ -3,13 +3,11 @@ use super::*;
 #[cfg(target_arch = "wasm32")]
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
+use crate::utils::ClientTester;
 use crate::{assert_msg, builder::ClientBuilder};
 use crate::{
     tester,
-    utils::{
-        FullXmtpClient,
-        fixtures::{bo, eve},
-    },
+    utils::fixtures::{bo, eve},
 };
 use futures::StreamExt;
 use rstest::*;
@@ -395,8 +393,8 @@ async fn test_stream_all_messages_filters_by_consent_state(
 #[xmtp_common::test]
 #[awt]
 async fn stream_messages_keeps_track_of_cursor(
-    #[future] bo: FullXmtpClient,
-    #[future] eve: FullXmtpClient,
+    #[future] bo: ClientTester,
+    #[future] eve: ClientTester,
 ) {
     tester!(alice);
     let group = alice.create_group(None, None).unwrap();

--- a/xmtp_mls/src/subscriptions/stream_conversations.rs
+++ b/xmtp_mls/src/subscriptions/stream_conversations.rs
@@ -394,12 +394,12 @@ where
 
 #[cfg(test)]
 mod test {
+    use crate::utils::ClientTester;
     use std::sync::Arc;
 
     use super::*;
     use crate::builder::ClientBuilder;
     use crate::tester;
-    use crate::utils::FullXmtpClient;
     use crate::utils::fixtures::{alix, bo};
     use xmtp_db::group::GroupQueryArgs;
 
@@ -416,8 +416,8 @@ mod test {
     #[timeout(std::time::Duration::from_secs(5))]
     #[awt]
     async fn stream_welcomes(
-        #[future] alix: FullXmtpClient,
-        #[future] bo: FullXmtpClient,
+        #[future] alix: ClientTester,
+        #[future] bo: ClientTester,
         #[case] group_size: usize,
     ) {
         let mut groups = vec![];
@@ -646,7 +646,7 @@ mod test {
     #[xmtp_common::test]
     #[timeout(std::time::Duration::from_secs(120))]
     #[awt]
-    async fn test_many_concurrent_dm_invites(#[future] alix: FullXmtpClient, #[case] dms: usize) {
+    async fn test_many_concurrent_dm_invites(#[future] alix: ClientTester, #[case] dms: usize) {
         let alix_inbox_id = Arc::new(alix.inbox_id().to_string());
         let mut clients = vec![];
         for _ in 0..dms {

--- a/xmtp_mls/src/utils/test/fixtures.rs
+++ b/xmtp_mls/src/utils/test/fixtures.rs
@@ -1,28 +1,36 @@
 use xmtp_cryptography::utils::generate_local_wallet;
 
-use crate::builder::ClientBuilder;
+use crate::{
+    builder::ClientBuilder,
+    utils::{ClientTester, LocalTesterBuilder, Tester},
+};
 
 use super::FullXmtpClient;
 use rstest::*;
 
 #[fixture]
-pub async fn alix() -> FullXmtpClient {
-    ClientBuilder::new_test_client_vanilla(&generate_local_wallet()).await
+pub async fn alix() -> ClientTester {
+    Tester::builder().with_name("alix").build().await
 }
 
 #[fixture]
-pub async fn bo() -> FullXmtpClient {
-    ClientBuilder::new_test_client_vanilla(&generate_local_wallet()).await
+pub async fn bo() -> ClientTester {
+    Tester::builder().with_name("bo").build().await
 }
 
 #[fixture]
-pub async fn caro() -> FullXmtpClient {
-    ClientBuilder::new_test_client_vanilla(&generate_local_wallet()).await
+pub async fn bola() -> ClientTester {
+    Tester::builder().with_name("bo").build().await
 }
 
 #[fixture]
-pub async fn eve() -> FullXmtpClient {
-    ClientBuilder::new_test_client_vanilla(&generate_local_wallet()).await
+pub async fn caro() -> ClientTester {
+    Tester::builder().with_name("caro").build().await
+}
+
+#[fixture]
+pub async fn eve() -> ClientTester {
+    Tester::builder().with_name("eve").build().await
 }
 
 #[fixture]

--- a/xmtp_mls/src/utils/test/mod.rs
+++ b/xmtp_mls/src/utils/test/mod.rs
@@ -14,6 +14,7 @@ use crate::{
     context::{XmtpMlsLocalContext, XmtpSharedContext},
     identity::IdentityStrategy,
 };
+use alloy::signers::local::PrivateKeySigner;
 use std::{sync::Arc, time::Duration};
 use tokio::sync::Notify;
 use xmtp_api::ApiIdentifier;
@@ -30,6 +31,8 @@ pub type TestMlsStorage = SqlKeyStore<xmtp_db::DefaultDbConnection>;
 pub type TestXmtpMlsContext =
     Arc<XmtpMlsLocalContext<TestClient, xmtp_db::DefaultStore, TestMlsStorage>>;
 pub type FullXmtpClient = Client<TestXmtpMlsContext>;
+/// Default Client Tester type
+pub type ClientTester = Tester<PrivateKeySigner, FullXmtpClient>;
 pub type TestMlsGroup = crate::groups::MlsGroup<TestXmtpMlsContext>;
 
 #[cfg(not(any(feature = "http-api", target_arch = "wasm32", feature = "d14n")))]


### PR DESCRIPTION
adds some contextual tracing on the INFO level only when compiled for tests/test-utils. this makes `CONTEXTUAL=1` output clearer for each action a client is taking. For instance, it will now show who is taking an action ( i.e `add_members_by_inbox_id | who: "alix" | members ["bo", "caro"]`) and nest the codepath accordingly. Also, adds some utility to TesterUtils to more easily add "names" to a client, so that they may be replaced in the resulting test log output (ie replace hex inbox_id/installation with "alice"/"alix_installation" etc.)

Moves fixtures to return a "Tester" instead of a "FullXmtpClient"