### PR TITLE
Share commit log key via mutable metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8968,6 +8968,7 @@ dependencies = [
 name = "xmtp_mls_common"
 version = "1.4.0-dev"
 dependencies = [
+ "const-hex",
  "openmls",
  "prost",
  "serde",

--- a/xmtp_mls/src/groups/commit_log.rs
+++ b/xmtp_mls/src/groups/commit_log.rs
@@ -357,12 +357,12 @@ where
         let mut save_remote_commit_log_results = HashMap::new();
         for response in query_commit_log_responses {
             let group_id = response.group_id.clone();
-            // TODO(rich): Make sure there are no race conditions here
             let mut consensus_public_key: Option<Vec<u8>> = conversation_id_to_public_key
                 .get(&group_id)
                 .and_then(Option::clone);
             if consensus_public_key.is_none() {
-                consensus_public_key = derive_consensus_public_key(&self.context, &response)?;
+                consensus_public_key =
+                    derive_consensus_public_key(&self.context, &response).await?;
             }
             let num_entries = self.save_remote_commit_log_entries_and_update_cursors(
                 conn,

--- a/xmtp_mls/src/groups/intents.rs
+++ b/xmtp_mls/src/groups/intents.rs
@@ -213,6 +213,13 @@ impl UpdateMetadataIntentData {
             field_value: min_version,
         }
     }
+
+    pub fn new_update_commit_log_signer(commit_log_signer: xmtp_cryptography::Secret) -> Self {
+        Self {
+            field_name: MetadataField::CommitLogSigner.to_string(),
+            field_value: hex::encode(commit_log_signer.as_slice()),
+        }
+    }
 }
 
 impl From<UpdateMetadataIntentData> for Vec<u8> {

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -970,6 +970,27 @@ where
         Ok(())
     }
 
+    /// Updates the commit log signer of the group. Will error if the user does not have the appropriate permissions
+    /// to perform these updates.
+    pub async fn update_commit_log_signer(
+        &self,
+        commit_log_signer: xmtp_cryptography::Secret,
+    ) -> Result<(), GroupError> {
+        self.ensure_not_paused().await?;
+
+        if self.metadata().await?.conversation_type == ConversationType::Dm {
+            return Err(MetadataPermissionsError::DmGroupMetadataForbidden.into());
+        }
+        let intent_data: Vec<u8> =
+            UpdateMetadataIntentData::new_update_commit_log_signer(commit_log_signer).into();
+        let intent = QueueIntent::metadata_update()
+            .data(intent_data)
+            .queue(self)?;
+
+        let _ = self.sync_until_intent_resolved(intent.id).await?;
+        Ok(())
+    }
+
     fn min_protocol_version_from_extensions(
         mutable_metadata: &GroupMutableMetadata,
     ) -> Option<String> {
@@ -1638,7 +1659,6 @@ pub fn build_extensions_for_metadata_update(
         attributes,
         existing_metadata.admin_list,
         existing_metadata.super_admin_list,
-        existing_metadata.commit_log_signer,
     )
     .try_into()?;
     let unknown_gc_extension = UnknownExtension(new_mutable_metadata);
@@ -1739,13 +1759,8 @@ pub fn build_extensions_for_admin_lists_update(
             super_admin_list.retain(|x| x != &admin_lists_update.inbox_id)
         }
     }
-    let new_mutable_metadata: Vec<u8> = GroupMutableMetadata::new(
-        attributes,
-        admin_list,
-        super_admin_list,
-        existing_metadata.commit_log_signer,
-    )
-    .try_into()?;
+    let new_mutable_metadata: Vec<u8> =
+        GroupMutableMetadata::new(attributes, admin_list, super_admin_list).try_into()?;
     let unknown_gc_extension = UnknownExtension(new_mutable_metadata);
     let extension = Extension::Unknown(MUTABLE_METADATA_EXTENSION_ID, unknown_gc_extension);
     let mut extensions = group.extensions().clone();

--- a/xmtp_mls/src/groups/tests/mod.rs
+++ b/xmtp_mls/src/groups/tests/mod.rs
@@ -1441,7 +1441,7 @@ async fn test_group_mutable_data() {
     amal_group.sync().await.unwrap();
 
     let group_mutable_metadata = amal_group.mutable_metadata().unwrap();
-    assert!(group_mutable_metadata.attributes.len().eq(&3));
+    assert!(group_mutable_metadata.attributes.len().eq(&4));
     assert!(
         group_mutable_metadata
             .attributes

--- a/xmtp_mls_common/Cargo.toml
+++ b/xmtp_mls_common/Cargo.toml
@@ -8,6 +8,7 @@ version.workspace = true
 workspace = true
 
 [dependencies]
+hex.workspace = true
 openmls.workspace = true
 prost.workspace = true
 serde.workspace = true


### PR DESCRIPTION
Shares the commit log key via the mutable metadata once we've determined the consensus public key.

I decided to turn the commit log key into an attribute rather than a top-level field of the mutable metadata to simplify things.