### PR TITLE
Persist and expose fork detection results

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -1466,6 +1466,7 @@ impl FfiConversations {
                     last_message: conversation_item
                         .last_message
                         .map(|stored_message| stored_message.into()),
+                    is_commit_log_forked: conversation_item.is_commit_log_forked,
                 })
             })
             .collect();
@@ -1490,6 +1491,7 @@ impl FfiConversations {
                     last_message: conversation_item
                         .last_message
                         .map(|stored_message| stored_message.into()),
+                    is_commit_log_forked: conversation_item.is_commit_log_forked,
                 })
             })
             .collect();
@@ -1514,6 +1516,7 @@ impl FfiConversations {
                     last_message: conversation_item
                         .last_message
                         .map(|stored_message| stored_message.into()),
+                    is_commit_log_forked: conversation_item.is_commit_log_forked,
                 })
             })
             .collect();
@@ -1735,6 +1738,7 @@ pub struct FfiConversation {
 pub struct FfiConversationListItem {
     conversation: FfiConversation,
     last_message: Option<FfiMessage>,
+    is_commit_log_forked: Option<bool>,
 }
 
 #[uniffi::export]
@@ -1744,6 +1748,10 @@ impl FfiConversationListItem {
     }
     pub fn last_message(&self) -> Option<FfiMessage> {
         self.last_message.clone()
+    }
+
+    pub fn is_commit_log_forked(&self) -> Option<bool> {
+        self.is_commit_log_forked
     }
 }
 
@@ -1807,6 +1815,7 @@ pub struct FfiConversationDebugInfo {
     pub epoch: u64,
     pub maybe_forked: bool,
     pub fork_details: String,
+    pub is_commit_log_forked: Option<bool>,
     pub local_commit_log: String,
     pub cursor: i64,
 }
@@ -1816,6 +1825,7 @@ impl FfiConversationDebugInfo {
         epoch: u64,
         maybe_forked: bool,
         fork_details: String,
+        is_commit_log_forked: Option<bool>,
         local_commit_log: String,
         cursor: i64,
     ) -> Self {
@@ -1823,6 +1833,7 @@ impl FfiConversationDebugInfo {
             epoch,
             maybe_forked,
             fork_details,
+            is_commit_log_forked,
             local_commit_log,
             cursor,
         }
@@ -1835,6 +1846,7 @@ impl From<ConversationDebugInfo> for FfiConversationDebugInfo {
             value.epoch,
             value.maybe_forked,
             value.fork_details,
+            value.is_commit_log_forked,
             value.local_commit_log,
             value.cursor,
         )

--- a/bindings_node/src/conversations.rs
+++ b/bindings_node/src/conversations.rs
@@ -160,6 +160,7 @@ pub struct ConversationDebugInfo {
   pub epoch: BigInt,
   pub maybe_forked: bool,
   pub fork_details: String,
+  pub is_commit_log_forked: Option<bool>,
   pub local_commit_log: String,
   pub cursor: i64,
 }
@@ -170,6 +171,7 @@ impl From<XmtpConversationDebugInfo> for ConversationDebugInfo {
       epoch: BigInt::from(value.epoch),
       maybe_forked: value.maybe_forked,
       fork_details: value.fork_details,
+      is_commit_log_forked: value.is_commit_log_forked,
       local_commit_log: value.local_commit_log,
       cursor: value.cursor,
     }
@@ -209,6 +211,7 @@ impl From<XmtpUserPreferenceUpdate> for Tag<UserPreferenceUpdate> {
 pub struct ConversationListItem {
   conversation: Conversation,
   last_message: Option<Message>,
+  is_commit_log_forked: Option<bool>,
 }
 
 #[napi]
@@ -221,6 +224,11 @@ impl ConversationListItem {
   #[napi(getter)]
   pub fn last_message(&self) -> Option<Message> {
     self.last_message.clone()
+  }
+
+  #[napi(getter)]
+  pub fn is_commit_log_forked(&self) -> Option<bool> {
+    self.is_commit_log_forked
   }
 }
 
@@ -490,6 +498,7 @@ impl Conversations {
         last_message: conversation_item
           .last_message
           .map(|stored_message| stored_message.into()),
+        is_commit_log_forked: conversation_item.is_commit_log_forked,
       })
       .collect();
 

--- a/bindings_wasm/src/conversation.rs
+++ b/bindings_wasm/src/conversation.rs
@@ -687,6 +687,7 @@ impl Conversation {
       epoch: debug_info.epoch,
       maybe_forked: debug_info.maybe_forked,
       fork_details: debug_info.fork_details,
+      is_commit_log_forked: debug_info.is_commit_log_forked,
       local_commit_log: debug_info.local_commit_log,
       cursor: debug_info.cursor,
     })?)

--- a/bindings_wasm/src/conversations.rs
+++ b/bindings_wasm/src/conversations.rs
@@ -181,6 +181,9 @@ pub struct ConversationDebugInfo {
   #[wasm_bindgen(js_name = forkDetails)]
   #[serde(rename = "forkDetails")]
   pub fork_details: String,
+  #[wasm_bindgen(js_name = isCommitLogForked)]
+  #[serde(rename = "isCommitLogForked")]
+  pub is_commit_log_forked: Option<bool>,
   #[wasm_bindgen(js_name = localCommitLog)]
   #[serde(rename = "localCommitLog")]
   pub local_commit_log: String,
@@ -290,15 +293,22 @@ pub struct ConversationListItem {
   pub conversation: Conversation,
   #[wasm_bindgen(js_name = lastMessage)]
   pub last_message: Option<Message>,
+  #[wasm_bindgen(js_name = isCommitLogForked)]
+  pub is_commit_log_forked: Option<bool>,
 }
 
 #[wasm_bindgen]
 impl ConversationListItem {
   #[wasm_bindgen(constructor)]
-  pub fn new(conversation: Conversation, last_message: Option<Message>) -> Self {
+  pub fn new(
+    conversation: Conversation,
+    last_message: Option<Message>,
+    is_commit_log_forked: Option<bool>,
+  ) -> Self {
     Self {
       conversation,
       last_message,
+      is_commit_log_forked,
     }
   }
 }
@@ -513,6 +523,7 @@ impl Conversations {
         JsValue::from(ConversationListItem::new(
           group.group.into(),
           group.last_message.map(|m| m.into()),
+          group.is_commit_log_forked,
         ))
       })
       .collect();

--- a/xmtp_db/migrations/2025-08-07-025914_add_commit_log_state/down.sql
+++ b/xmtp_db/migrations/2025-08-07-025914_add_commit_log_state/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE groups DROP COLUMN is_commit_log_forked;

--- a/xmtp_db/migrations/2025-08-07-025914_add_commit_log_state/up.sql
+++ b/xmtp_db/migrations/2025-08-07-025914_add_commit_log_state/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE groups ADD COLUMN is_commit_log_forked BOOLEAN;

--- a/xmtp_db/migrations/2025-08-12-223606_add_is_commit_log_forked_to_conversation_list/down.sql
+++ b/xmtp_db/migrations/2025-08-12-223606_add_is_commit_log_forked_to_conversation_list/down.sql
@@ -1,0 +1,66 @@
+DROP VIEW IF EXISTS conversation_list;
+
+CREATE VIEW conversation_list AS
+WITH ranked_messages AS (
+    SELECT
+        gm.group_id,
+        gm.id AS message_id,
+        gm.decrypted_message_bytes,
+        gm.sent_at_ns,
+        gm.kind AS message_kind,
+        gm.sender_installation_id,
+        gm.sender_inbox_id,
+        gm.delivery_status,
+        gm.content_type,
+        gm.version_major,
+        gm.version_minor,
+        gm.authority_id,
+        ROW_NUMBER() OVER (PARTITION BY gm.group_id ORDER BY gm.sent_at_ns DESC) AS row_num
+    FROM
+        group_messages gm
+    WHERE
+        gm.kind = 1
+        AND gm.content_type IN (1, 4, 6, 7, 8, 9)
+)
+/* Filtering for readable content types only or
+content types with a text fallback
+
+Content Types numeric values come from xmtp_mls/src/storage/encrypted_store/group_message.rs
+pub enum ContentType {
+    Unknown = 0,
+    Text = 1,
+    GroupMembershipChange = 2,
+    GroupUpdated = 3,
+    Reaction = 4,
+    ReadReceipt = 5,
+    Reply = 6,
+    Attachment = 7,
+    RemoteAttachment = 8,
+    TransactionReference = 9,
+}*/
+SELECT
+    g.id AS id,
+    g.created_at_ns,
+    g.membership_state,
+    g.installations_last_checked,
+    g.added_by_inbox_id,
+    g.welcome_id,
+    g.dm_id,
+    g.rotated_at_ns,
+    g.conversation_type,
+    rm.message_id,
+    rm.decrypted_message_bytes,
+    rm.sent_at_ns,
+    rm.message_kind,
+    rm.sender_installation_id,
+    rm.sender_inbox_id,
+    rm.delivery_status,
+    rm.content_type,
+    rm.version_major,
+    rm.version_minor,
+    rm.authority_id
+FROM
+    groups g
+    LEFT JOIN ranked_messages rm
+    ON g.id = rm.group_id AND rm.row_num = 1
+ORDER BY COALESCE(rm.sent_at_ns, g.created_at_ns) DESC;

--- a/xmtp_db/migrations/2025-08-12-223606_add_is_commit_log_forked_to_conversation_list/up.sql
+++ b/xmtp_db/migrations/2025-08-12-223606_add_is_commit_log_forked_to_conversation_list/up.sql
@@ -1,0 +1,51 @@
+DROP VIEW IF EXISTS conversation_list;
+
+CREATE VIEW conversation_list AS
+WITH ranked_messages AS (
+    SELECT
+        gm.group_id,
+        gm.id AS message_id,
+        gm.decrypted_message_bytes,
+        gm.sent_at_ns,
+        gm.kind AS message_kind,
+        gm.sender_installation_id,
+        gm.sender_inbox_id,
+        gm.delivery_status,
+        gm.content_type,
+        gm.version_major,
+        gm.version_minor,
+        gm.authority_id,
+        ROW_NUMBER() OVER (PARTITION BY gm.group_id ORDER BY gm.sent_at_ns DESC) AS row_num
+    FROM
+        group_messages gm
+    WHERE
+        gm.kind = 1
+        AND gm.content_type IN (1, 4, 6, 7, 8, 9)
+)
+SELECT
+    g.id AS id,
+    g.created_at_ns,
+    g.membership_state,
+    g.installations_last_checked,
+    g.added_by_inbox_id,
+    g.welcome_id,
+    g.dm_id,
+    g.rotated_at_ns,
+    g.conversation_type,
+    g.is_commit_log_forked,
+    rm.message_id,
+    rm.decrypted_message_bytes,
+    rm.sent_at_ns,
+    rm.message_kind,
+    rm.sender_installation_id,
+    rm.sender_inbox_id,
+    rm.delivery_status,
+    rm.content_type,
+    rm.version_major,
+    rm.version_minor,
+    rm.authority_id
+FROM
+    groups g
+    LEFT JOIN ranked_messages rm
+    ON g.id = rm.group_id AND rm.row_num = 1
+ORDER BY COALESCE(rm.sent_at_ns, g.created_at_ns) DESC;

--- a/xmtp_db/src/encrypted_store/conversation_list.rs
+++ b/xmtp_db/src/encrypted_store/conversation_list.rs
@@ -34,6 +34,8 @@ pub struct ConversationListItem {
     pub rotated_at_ns: i64,
     /// Enum, [`ConversationType`] signifies the group conversation type which extends to who can access it.
     pub conversation_type: ConversationType,
+    /// Whether the commit log for this conversation is forked
+    pub is_commit_log_forked: Option<bool>,
     /// Id of the message. Nullable because not every group has messages.
     pub message_id: Option<Vec<u8>>,
     /// Contents of message after decryption.

--- a/xmtp_db/src/encrypted_store/group/convert.rs
+++ b/xmtp_db/src/encrypted_store/group/convert.rs
@@ -32,6 +32,7 @@ impl TryFrom<GroupSave> for StoredGroup {
             originator_id: None,
             should_publish_commit_log: false, // TODO(cvoell): verify we update when we receive a welcome
             commit_log_public_key: None,
+            is_commit_log_forked: None,
         })
     }
 }

--- a/xmtp_db/src/encrypted_store/schema.rs
+++ b/xmtp_db/src/encrypted_store/schema.rs
@@ -22,6 +22,7 @@ diesel::table! {
     dm_id -> Nullable<Text>,
     rotated_at_ns -> BigInt,
     conversation_type -> Integer,
+    is_commit_log_forked -> Nullable<Bool>,
     message_id -> Nullable<Binary>,
     decrypted_message_bytes -> Nullable<Binary>,
     sent_at_ns -> Nullable<BigInt>,

--- a/xmtp_db/src/encrypted_store/schema_gen.rs
+++ b/xmtp_db/src/encrypted_store/schema_gen.rs
@@ -87,6 +87,7 @@ diesel::table! {
         originator_id -> Nullable<BigInt>,
         should_publish_commit_log -> Bool,
         commit_log_public_key -> Nullable<Binary>,
+        is_commit_log_forked -> Nullable<Bool>,
     }
 }
 

--- a/xmtp_db/src/mock.rs
+++ b/xmtp_db/src/mock.rs
@@ -219,6 +219,10 @@ mock! {
 
         fn get_conversation_ids_for_remote_log_download(&self) -> Result<Vec<StoredGroupCommitLogPublicKey>, crate::ConnectionError>;
 
+        fn get_conversation_ids_for_fork_check(
+            &self,
+        ) -> Result<Vec<Vec<u8>>, crate::ConnectionError>;
+
         fn get_conversation_type(&self, group_id: &[u8]) -> Result<ConversationType, crate::ConnectionError>;
 
         fn set_group_commit_log_public_key(
@@ -226,6 +230,17 @@ mock! {
             group_id: &[u8],
             public_key: &[u8],
         ) -> Result<(), StorageError>;
+
+        fn set_group_commit_log_forked_status(
+            &self,
+            group_id: &[u8],
+            is_forked: Option<bool>,
+        ) -> Result<(), StorageError>;
+
+        fn get_group_commit_log_forked_status(
+            &self,
+            group_id: &[u8],
+        ) -> Result<Option<bool>, StorageError>;
     }
 
     impl QueryGroupVersion for DbQuery {

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -707,6 +707,7 @@ where
                         conversation_item.created_at_ns,
                     ),
                     last_message: message,
+                    is_commit_log_forked: conversation_item.is_commit_log_forked,
                 }
             })
             .collect())

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -152,6 +152,7 @@ where
 pub struct ConversationListItem<Context> {
     pub group: MlsGroup<Context>,
     pub last_message: Option<StoredGroupMessage>,
+    pub is_commit_log_forked: Option<bool>,
 }
 
 impl<Context: XmtpSharedContext> Clone for MlsGroup<Context> {
@@ -173,6 +174,7 @@ pub struct ConversationDebugInfo {
     pub epoch: u64,
     pub maybe_forked: bool,
     pub fork_details: String,
+    pub is_commit_log_forked: Option<bool>,
     pub local_commit_log: String,
     pub cursor: i64,
 }
@@ -1387,6 +1389,7 @@ where
             epoch,
             maybe_forked: stored_group.maybe_forked,
             fork_details: stored_group.fork_details,
+            is_commit_log_forked: stored_group.is_commit_log_forked,
             local_commit_log: format!("{:?}", commit_log),
             cursor,
         })


### PR DESCRIPTION
A few changes:

1. The is_forked() check now returns `None` instead of `false` if the remote log is out-of-date, but otherwise matching.
2. Instead of returning a hash map of values from `check_forked_state()`, we store the fork result in the database
3. We return the fork status in the debug info, and propagate through the bindings