### PR TITLE
fix: conflicting ReactionV2 import in module

### DIFF
--- a/xmtp_content_types/src/reaction.rs
+++ b/xmtp_content_types/src/reaction.rs
@@ -90,7 +90,7 @@ pub(crate) mod tests {
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
     use xmtp_proto::xmtp::mls::message_contents::content_types::{
-        ReactionAction, ReactionSchema, ReactionV2,
+        ReactionAction, ReactionSchema,
     };
 
     use serde_json::json;


### PR DESCRIPTION
Rust doesn't allow importing the same name from different places in the same module, even if the paths are identical.
the second `ReactionV2` import was causing a conflict and has been removed.
