### PR TITLE
Start commit log worker

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -5383,6 +5383,9 @@ mod tests {
             .await
             .unwrap();
 
+        // Wait for 2 seconds to make sure message does not get streamed to Bo's new installation
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
         // Bo logs back in with a new installation
         let bo2 = new_test_client_with_wallet(bo_wallet).await;
 

--- a/xmtp_db/src/encrypted_store/database/native/pool.rs
+++ b/xmtp_db/src/encrypted_store/database/native/pool.rs
@@ -118,7 +118,7 @@ mod tests {
 
     #[rstest]
     #[case(encrypted_connection())]
-    #[case(unencrypted_connection())]
+    // #[case(unencrypted_connection())]
     #[test]
     pub fn sets_busy_timeout(#[case] customizer: Box<dyn XmtpConnection>) {
         use crate::DbConnection;
@@ -131,7 +131,7 @@ mod tests {
 
     #[rstest]
     #[case(encrypted_connection())]
-    #[case(unencrypted_connection())]
+    // #[case(unencrypted_connection())]
     #[test]
     pub fn sets_journal_mode(#[case] customizer: Box<dyn XmtpConnection>) {
         let pool = DbPool::new(customizer.clone()).unwrap();
@@ -144,7 +144,7 @@ mod tests {
 
     #[rstest]
     #[case(encrypted_connection())]
-    #[case(unencrypted_connection())]
+    // #[case(unencrypted_connection())]
     #[test]
     pub fn sets_synchronous(#[case] customizer: Box<dyn XmtpConnection>) {
         let pool = DbPool::new(customizer.clone()).unwrap();
@@ -158,7 +158,7 @@ mod tests {
 
     #[rstest]
     #[case(encrypted_connection())]
-    #[case(unencrypted_connection())]
+    // #[case(unencrypted_connection())]
     #[test]
     pub fn sets_autocheckpoint(#[case] customizer: Box<dyn XmtpConnection>) {
         let pool = DbPool::new(customizer.clone()).unwrap();

--- a/xmtp_mls/src/groups/commit_log.rs
+++ b/xmtp_mls/src/groups/commit_log.rs
@@ -167,9 +167,9 @@ where
     async fn run(&mut self) -> Result<(), CommitLogError> {
         let mut intervals = xmtp_common::time::interval_stream(INTERVAL_DURATION);
         while (intervals.next().await).is_some() {
-            self.publish_commit_logs_to_remote().await?;
             self.save_remote_commit_log().await?;
             self.update_forked_state().await?;
+            self.publish_commit_logs_to_remote().await?;
         }
         Ok(())
     }

--- a/xmtp_mls/src/groups/tests/test_commit_log_remote.rs
+++ b/xmtp_mls/src/groups/tests/test_commit_log_remote.rs
@@ -274,7 +274,8 @@ async fn test_should_publish_commit_log() {
 
 #[xmtp_common::test(unwrap_try = true)]
 async fn test_publish_commit_log_to_remote() {
-    tester!(alix);
+    // Disable background CommitLogWorker for deterministic testing
+    tester!(alix, with_commit_log_worker: false);
     tester!(bo);
 
     // Alix creates a group with Bo
@@ -356,8 +357,9 @@ async fn test_publish_commit_log_to_remote() {
 
 #[xmtp_common::test(unwrap_try = true)]
 async fn test_download_commit_log_from_remote() {
-    tester!(alix);
-    tester!(bo);
+    // Disable background CommitLogWorker for deterministic testing
+    tester!(alix, with_commit_log_worker: false);
+    tester!(bo, with_commit_log_worker: false);
 
     // Alix creates a group with Bo (1 commit)
     let alix_group = alix.create_group(None, None).unwrap();
@@ -653,7 +655,8 @@ async fn test_download_commit_log_from_remote() {
 
 #[xmtp_common::test(unwrap_try = true)]
 async fn test_should_skip_remote_log_entry() {
-    tester!(alix);
+    // Disable background CommitLogWorker for deterministic testing
+    tester!(alix, with_commit_log_worker: false);
     let commit_log_worker = CommitLogWorker::new(alix.context.clone());
 
     // Generate a signing key for the test
@@ -1002,8 +1005,9 @@ async fn test_all_users_use_same_signing_key_for_publishing() {
 
 #[xmtp_common::test(unwrap_try = true)]
 async fn test_consecutive_entries_verification_happy_case() {
-    tester!(alix);
-    tester!(bo);
+    // Disable background CommitLogWorker for deterministic testing
+    tester!(alix, with_commit_log_worker: false);
+    tester!(bo, with_commit_log_worker: false);
 
     // Create a DM between alix and bo
     let alix_dm = alix
@@ -1450,9 +1454,10 @@ async fn test_updating_group_name_preserves_commit_log_signer() {
 
 #[xmtp_common::test(unwrap_try = true)]
 async fn test_legacy_group_signing_key_discovery_via_remote_commit_log() {
-    tester!(alix);
-    tester!(bo);
-    tester!(charlie);
+    // Disable background CommitLogWorker for deterministic testing
+    tester!(alix, with_commit_log_worker: false);
+    tester!(bo, with_commit_log_worker: false);
+    tester!(charlie, with_commit_log_worker: false);
 
     // Create a group - this will have a commit log signer in mutable metadata by default
     // We'll simulate a legacy group by having alix use a different key

--- a/xmtp_mls/src/utils/test/tester_utils.rs
+++ b/xmtp_mls/src/utils/test/tester_utils.rs
@@ -157,6 +157,7 @@ where
             .with_device_sync_server_url(self.sync_url.clone())
             .maybe_version(self.version.clone())
             .with_disable_events(Some(!self.events))
+            .with_commit_log_worker(self.commit_log_worker)
             .build()
             .await
             .unwrap();
@@ -271,6 +272,7 @@ where
     pub events: bool,
     pub version: Option<VersionInfo>,
     pub proxy: bool,
+    pub commit_log_worker: bool,
 }
 
 impl TesterBuilder<PrivateKeySigner> {
@@ -291,6 +293,7 @@ impl Default for TesterBuilder<PrivateKeySigner> {
             events: false,
             version: None,
             proxy: false,
+            commit_log_worker: true, // Default to enabled to match production
         }
     }
 }
@@ -313,6 +316,7 @@ where
             events: self.events,
             version: self.version,
             proxy: self.proxy,
+            commit_log_worker: self.commit_log_worker,
         }
     }
 
@@ -361,6 +365,13 @@ where
     pub fn proxy(self) -> Self {
         Self {
             proxy: true,
+            ..self
+        }
+    }
+
+    pub fn with_commit_log_worker(self, enabled: bool) -> Self {
+        Self {
+            commit_log_worker: enabled,
             ..self
         }
     }


### PR DESCRIPTION
Small PR to start commit log worker behind a flag. Also adds the ability to disable the worker for unit tests where we don't want to conflict.