### PR TITLE
build: update checkout action to v5

### DIFF
--- a/.github/workflows/cargo-deny-checker.yml
+++ b/.github/workflows/cargo-deny-checker.yml
@@ -16,7 +16,7 @@ jobs:
           - licenses
           - sources
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       # Install Rust toolchain
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/check-ios-android-bindings.yml
+++ b/.github/workflows/check-ios-android-bindings.yml
@@ -26,7 +26,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - uses: DeterminateSystems/nix-installer-action@main
         with:
           determinate: true
@@ -51,7 +51,7 @@ jobs:
           # Can also run android emulator here after cloning xmtp-android
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - uses: DeterminateSystems/nix-installer-action@main
         with:
           determinate: true

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/.github/workflows/deploy-validation-server.yml
+++ b/.github/workflows/deploy-validation-server.yml
@@ -18,7 +18,7 @@ jobs:
       digest: ${{ steps.push.outputs.digest }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Log in to the container registry
         uses: docker/login-action@v3
@@ -52,7 +52,7 @@ jobs:
         environment: [dev, production, testnet-staging]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Deploy to ${{ matrix.environment }}
         uses: xmtp-labs/terraform-deployer@v1

--- a/.github/workflows/lint-node-bindings.yaml
+++ b/.github/workflows/lint-node-bindings.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/lint-toml.yml
+++ b/.github/workflows/lint-toml.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install Taplo
         env:
           version: "0.9.3"

--- a/.github/workflows/lint-wasm-bindings.yaml
+++ b/.github/workflows/lint-wasm-bindings.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Update rust toolchains
         run: |
           rustup update

--- a/.github/workflows/lint-workspace.yaml
+++ b/.github/workflows/lint-workspace.yaml
@@ -36,7 +36,7 @@ jobs:
     runs-on: warp-ubuntu-latest-x64-16x
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Update rust toolchains
         run: rustup update
       - name: Cache

--- a/.github/workflows/nightly-protos.yml
+++ b/.github/workflows/nightly-protos.yml
@@ -10,7 +10,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: bufbuild/buf-setup-action@v1.50.0
       - name: Update rust toolchains
         run: rustup update

--- a/.github/workflows/push-xbg.yml
+++ b/.github/workflows/push-xbg.yml
@@ -18,7 +18,7 @@ jobs:
       digest: ${{ steps.push.outputs.digest }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Log in to the container registry
         uses: docker/login-action@v3

--- a/.github/workflows/release-kotlin-bindings-nix.yml
+++ b/.github/workflows/release-kotlin-bindings-nix.yml
@@ -23,7 +23,7 @@ jobs:
             output_target: arm64-v8a
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Cache
         uses: Swatinem/rust-cache@v2
         with:
@@ -56,7 +56,7 @@ jobs:
     runs-on: warp-ubuntu-latest-x64-16x
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Download artifacts
         uses: actions/download-artifact@v5
         with:

--- a/.github/workflows/release-kotlin-bindings.yml
+++ b/.github/workflows/release-kotlin-bindings.yml
@@ -23,7 +23,7 @@ jobs:
             output_target: arm64-v8a
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Update rust toolchains, add target
         run: |
           rustup update
@@ -55,7 +55,7 @@ jobs:
     runs-on: warp-ubuntu-latest-x64-16x
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Download artifacts
         uses: actions/download-artifact@v5
         with:

--- a/.github/workflows/release-mls-validation-service.yml
+++ b/.github/workflows/release-mls-validation-service.yml
@@ -16,7 +16,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Log in to the container registry
         uses: docker/login-action@v3

--- a/.github/workflows/release-node-bindings.yml
+++ b/.github/workflows/release-node-bindings.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Check versions are in sync
         run: |
@@ -45,7 +45,7 @@ jobs:
             output_target: linux-arm64-musl
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Update rust toolchains, add target
         run: |
@@ -143,7 +143,7 @@ jobs:
             output_target: darwin-arm64
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Update rust toolchains, add target
         run: |
@@ -204,7 +204,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Update rust toolchains
         run: |
@@ -276,7 +276,7 @@ jobs:
     needs: [build-linux, build-macos, build-windows]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download build artifacts
         uses: actions/download-artifact@v5

--- a/.github/workflows/release-swift-bindings-nix.yml
+++ b/.github/workflows/release-swift-bindings-nix.yml
@@ -15,7 +15,7 @@ jobs:
           - aarch64-apple-darwin
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install Nix
         uses: cachix/install-nix-action@v31
         with:
@@ -42,7 +42,7 @@ jobs:
     runs-on: warp-macos-13-arm64-6x
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - uses: DeterminateSystems/magic-nix-cache-action@v13
       - name: Cache
         uses: Swatinem/rust-cache@v2
@@ -70,7 +70,7 @@ jobs:
     runs-on: warp-macos-13-arm64-6x
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Download artifacts
         uses: actions/download-artifact@v5
         with:

--- a/.github/workflows/release-swift-bindings.yml
+++ b/.github/workflows/release-swift-bindings.yml
@@ -15,7 +15,7 @@ jobs:
           - aarch64-apple-darwin
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Update rust toolchains, add target
         run: |
           rustup update
@@ -44,7 +44,7 @@ jobs:
     runs-on: warp-macos-13-arm64-6x
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Update rust toolchains, add target
         run: |
           rustup update
@@ -72,7 +72,7 @@ jobs:
     runs-on: warp-macos-13-arm64-6x
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Download artifacts
         uses: actions/download-artifact@v5
         with:

--- a/.github/workflows/release-wasm-bindings.yml
+++ b/.github/workflows/release-wasm-bindings.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Update rust toolchains, add target
         run: |
           rustup update

--- a/.github/workflows/test-ffi-bindings.yml
+++ b/.github/workflows/test-ffi-bindings.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: warp-ubuntu-latest-x64-16x
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Update rust toolchains
         run: rustup update
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/test-node-bindings.yml
+++ b/.github/workflows/test-node-bindings.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: warp-ubuntu-latest-x64-16x
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Update rust toolchains
         run: rustup update
       - name: Cache

--- a/.github/workflows/test-webassembly.yml
+++ b/.github/workflows/test-webassembly.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - uses: taiki-e/install-action@wasm-bindgen
       - name: Cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/test-workspace.yml
+++ b/.github/workflows/test-workspace.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: warp-ubuntu-latest-x64-16x
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
       - name: Cache

--- a/.github/workflows/update-swift-repo.yml
+++ b/.github/workflows/update-swift-repo.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: warp-macos-13-arm64-6x
     steps:
       - name: Checkout libxmtp
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: libxmtp
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref }}
 
       - name: Checkout libxmtp-swift
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: xmtp/libxmtp-swift
           path: libxmtp-swift


### PR DESCRIPTION
GitHub-hosted runners now use Node 24, so actions/checkout@v5 is required. Minimum runner version v2.327.1. Workflows only updated—no functional changes.

See: https://github.com/actions/checkout/releases/tag/v5.0.0