### PR TITLE
fix cargo deny advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6419,9 +6419,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"


### PR DESCRIPTION
### Update slab dependency from 0.4.10 to 0.4.11 to fix cargo deny advisory
Updates the `slab` dependency from version 0.4.10 to 0.4.11 in [Cargo.lock](https://github.com/xmtp/libxmtp/pull/2315/files#diff-13ee4b2252c9e516a0547f2891aa2105c3ca71c6d7a1e682c69be97998dfc87e) to address a security advisory identified by cargo deny.

#### 📍Where to Start
Start with the dependency changes in [Cargo.lock](https://github.com/xmtp/libxmtp/pull/2315/files#diff-13ee4b2252c9e516a0547f2891aa2105c3ca71c6d7a1e682c69be97998dfc87e) to review the updated `slab` dependency version and checksum.

----

_[Macroscope](https://app.macroscope.com) summarized ed3604e._