### PR TITLE
DecodedMessage API scaffolding

### DIFF
--- a/bindings_ffi/src/lib.rs
+++ b/bindings_ffi/src/lib.rs
@@ -9,6 +9,7 @@ pub mod worker;
 
 pub use crate::inbox_owner::SigningError;
 pub use logger::{enter_debug_writer, exit_debug_writer};
+pub use message::*;
 pub use mls::*;
 use std::error::Error;
 use xmtp_common::time::Expired;

--- a/bindings_ffi/src/lib.rs
+++ b/bindings_ffi/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod identity;
 pub mod inbox_owner;
 pub mod logger;
+pub mod message;
 pub mod mls;
 pub mod worker;
 

--- a/bindings_ffi/src/message.rs
+++ b/bindings_ffi/src/message.rs
@@ -1,0 +1,577 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::mls::FfiReaction;
+
+use xmtp_content_types::{
+    attachment::Attachment,
+    read_receipt::ReadReceipt,
+    remote_attachment::RemoteAttachment,
+    transaction_reference::{TransactionMetadata, TransactionReference},
+};
+use xmtp_mls::groups::message_list_item::{
+    MessageListItem, MessageListItemContent, Reaction, Reply, Text,
+};
+use xmtp_proto::xmtp::mls::message_contents::content_types::{
+    MultiRemoteAttachment, RemoteAttachmentInfo,
+};
+use xmtp_proto::xmtp::mls::message_contents::{
+    ContentTypeId, EncodedContent, GroupMembershipChanges, GroupUpdated, MembershipChange,
+};
+
+#[derive(uniffi::Record, Clone)]
+pub struct FfiReplyContent {
+    // The original message that this reply is in reply to.
+    // This goes at most one level deep from the original message, and won't happen recursively if there are replies to replies to replies
+    pub in_reply_to: Option<Arc<FfiProcessedMessage>>,
+    pub content: Option<FfiProcessedMessageBody>,
+}
+
+// Create a separate enum for the body of the message, which excludes replies and reactions
+// This prevents circular references
+#[derive(uniffi::Enum, Clone)]
+pub enum FfiProcessedMessageBody {
+    Text(FfiTextContent),
+    Attachment(FfiAttachment),
+    RemoteAttachment(FfiRemoteAttachment),
+    MultiRemoteAttachment(FfiMultiRemoteAttachment),
+    TransactionReference(FfiTransactionReference),
+    GroupUpdated(FfiGroupUpdated),
+    GroupMembershipChanges(FfiGroupMembershipChanges),
+    ReadReceipt(FfiReadReceipt),
+    Custom(FfiEncodedContent),
+}
+
+// Wrap text content in a struct to be consident with other content types
+#[derive(uniffi::Record, Clone)]
+pub struct FfiTextContent {
+    pub content: String,
+}
+
+// FfiReaction is defined in mls.rs with proper enum types for action and schema
+
+#[derive(uniffi::Record, Clone)]
+pub struct FfiAttachment {
+    pub filename: Option<String>,
+    pub mime_type: String,
+    pub size: u64,
+    pub content: String,
+}
+
+#[derive(uniffi::Record, Clone)]
+pub struct FfiRemoteAttachment {
+    pub url: String,
+    pub content_digest: String,
+    pub secret: Vec<u8>,
+    pub salt: Vec<u8>,
+    pub nonce: Vec<u8>,
+    pub size: u64,
+    pub mime_type: String,
+    pub filename: Option<String>,
+}
+
+#[derive(uniffi::Record, Clone)]
+pub struct FfiMultiRemoteAttachment {
+    pub attachments: Vec<FfiRemoteAttachmentInfo>,
+}
+
+#[derive(uniffi::Record, Clone, Default)]
+pub struct FfiRemoteAttachmentInfo {
+    pub url: String,
+    pub content_digest: String,
+    pub secret: Vec<u8>,
+    pub salt: Vec<u8>,
+    pub nonce: Vec<u8>,
+    pub scheme: String,
+    pub content_length: Option<u32>,
+    pub filename: Option<String>,
+}
+
+#[derive(uniffi::Record, Clone, Default)]
+pub struct FfiTransactionMetadata {
+    pub transaction_type: String,
+    pub currency: String,
+    pub amount: f64,
+    pub decimals: u32,
+    pub from_address: String,
+    pub to_address: String,
+}
+
+#[derive(uniffi::Record, Clone)]
+pub struct FfiTransactionReference {
+    pub namespace: Option<String>,
+    pub network_id: String,
+    pub reference: String,
+    pub metadata: Option<FfiTransactionMetadata>,
+}
+
+#[derive(uniffi::Record, Clone)]
+pub struct FfiGroupUpdated {
+    pub initiated_by_inbox_id: String,
+    pub added_inboxes: Vec<FfiInbox>,
+    pub removed_inboxes: Vec<FfiInbox>,
+    pub metadata_field_changes: Vec<FfiMetadataFieldChange>,
+}
+
+#[derive(uniffi::Record, Clone)]
+pub struct FfiInbox {
+    pub inbox_id: String,
+}
+
+#[derive(uniffi::Record, Clone)]
+pub struct FfiMetadataFieldChange {
+    pub field_name: String,
+    pub old_value: Option<String>,
+    pub new_value: Option<String>,
+}
+
+#[derive(uniffi::Record, Clone)]
+pub struct FfiGroupMembershipChanges {
+    pub members_added: Vec<FfiMembershipChange>,
+    pub members_removed: Vec<FfiMembershipChange>,
+    pub installations_added: Vec<FfiMembershipChange>,
+    pub installations_removed: Vec<FfiMembershipChange>,
+}
+
+#[derive(uniffi::Record, Clone)]
+pub struct FfiMembershipChange {
+    pub installation_ids: Vec<Vec<u8>>,
+    pub account_address: String,
+    pub initiated_by_account_address: String,
+}
+
+#[derive(uniffi::Record, Clone)]
+pub struct FfiReadReceipt {
+    pub reference: String,
+    pub reference_inbox_id: Option<String>,
+    pub read_at_ns: i64,
+}
+
+#[derive(uniffi::Record, Clone, Default, Debug, PartialEq)]
+pub struct FfiEncodedContent {
+    pub type_id: Option<FfiContentTypeId>,
+    pub parameters: HashMap<String, String>,
+    pub fallback: Option<String>,
+    pub compression: Option<i32>,
+    pub content: Vec<u8>,
+}
+
+#[derive(uniffi::Record, Clone, Default, Debug, PartialEq)]
+pub struct FfiContentTypeId {
+    pub authority_id: String,
+    pub type_id: String,
+    pub version_major: u32,
+    pub version_minor: u32,
+}
+
+#[derive(uniffi::Enum, Clone)]
+pub enum FfiProcessedMessageContent {
+    Text(FfiTextContent),
+    Reply(FfiReplyContent),
+    Reaction(FfiReaction),
+    Attachment(FfiAttachment),
+    RemoteAttachment(FfiRemoteAttachment),
+    MultiRemoteAttachment(FfiMultiRemoteAttachment),
+    TransactionReference(FfiTransactionReference),
+    GroupUpdated(FfiGroupUpdated),
+    GroupMembershipChanges(FfiGroupMembershipChanges),
+    ReadReceipt(FfiReadReceipt),
+    Custom(FfiEncodedContent),
+}
+
+// Individual From implementations for each content type
+
+impl From<Text> for FfiTextContent {
+    fn from(text: Text) -> Self {
+        FfiTextContent {
+            content: text.content,
+        }
+    }
+}
+
+impl From<Reaction> for FfiReaction {
+    fn from(reaction: Reaction) -> Self {
+        // Convert via ReactionV2 which has the From implementation in mls.rs
+        reaction.reaction.into()
+    }
+}
+
+impl From<Attachment> for FfiAttachment {
+    fn from(attachment: Attachment) -> Self {
+        FfiAttachment {
+            filename: attachment.filename,
+            mime_type: attachment.mime_type,
+            size: attachment.size,
+            content: attachment.content,
+        }
+    }
+}
+
+impl From<FfiAttachment> for Attachment {
+    fn from(ffi: FfiAttachment) -> Self {
+        Attachment {
+            filename: ffi.filename,
+            mime_type: ffi.mime_type,
+            size: ffi.size,
+            content: ffi.content,
+        }
+    }
+}
+
+impl From<RemoteAttachment> for FfiRemoteAttachment {
+    fn from(remote: RemoteAttachment) -> Self {
+        FfiRemoteAttachment {
+            url: remote.url,
+            content_digest: remote.content_digest,
+            secret: remote.secret,
+            salt: remote.salt,
+            nonce: remote.nonce,
+            size: remote.size,
+            mime_type: remote.mime_type,
+            filename: remote.filename,
+        }
+    }
+}
+
+impl From<FfiRemoteAttachment> for RemoteAttachment {
+    fn from(ffi: FfiRemoteAttachment) -> Self {
+        RemoteAttachment {
+            url: ffi.url,
+            content_digest: ffi.content_digest,
+            secret: ffi.secret,
+            salt: ffi.salt,
+            nonce: ffi.nonce,
+            size: ffi.size,
+            mime_type: ffi.mime_type,
+            filename: ffi.filename,
+        }
+    }
+}
+
+impl From<RemoteAttachmentInfo> for FfiRemoteAttachmentInfo {
+    fn from(info: RemoteAttachmentInfo) -> Self {
+        FfiRemoteAttachmentInfo {
+            url: info.url,
+            content_digest: info.content_digest,
+            secret: info.secret,
+            salt: info.salt,
+            nonce: info.nonce,
+            scheme: info.scheme,
+            content_length: info.content_length,
+            filename: info.filename,
+        }
+    }
+}
+
+impl From<FfiRemoteAttachmentInfo> for RemoteAttachmentInfo {
+    fn from(ffi: FfiRemoteAttachmentInfo) -> Self {
+        RemoteAttachmentInfo {
+            url: ffi.url,
+            content_digest: ffi.content_digest,
+            secret: ffi.secret,
+            salt: ffi.salt,
+            nonce: ffi.nonce,
+            scheme: ffi.scheme,
+            content_length: ffi.content_length,
+            filename: ffi.filename,
+        }
+    }
+}
+
+impl From<MultiRemoteAttachment> for FfiMultiRemoteAttachment {
+    fn from(multi: MultiRemoteAttachment) -> Self {
+        FfiMultiRemoteAttachment {
+            attachments: multi.attachments.into_iter().map(|a| a.into()).collect(),
+        }
+    }
+}
+
+impl From<FfiMultiRemoteAttachment> for MultiRemoteAttachment {
+    fn from(ffi: FfiMultiRemoteAttachment) -> Self {
+        MultiRemoteAttachment {
+            attachments: ffi.attachments.into_iter().map(|a| a.into()).collect(),
+        }
+    }
+}
+
+impl From<TransactionMetadata> for FfiTransactionMetadata {
+    fn from(metadata: TransactionMetadata) -> Self {
+        FfiTransactionMetadata {
+            transaction_type: metadata.transaction_type,
+            currency: metadata.currency,
+            amount: metadata.amount,
+            decimals: metadata.decimals,
+            from_address: metadata.from_address,
+            to_address: metadata.to_address,
+        }
+    }
+}
+
+impl From<FfiTransactionMetadata> for TransactionMetadata {
+    fn from(ffi: FfiTransactionMetadata) -> Self {
+        TransactionMetadata {
+            transaction_type: ffi.transaction_type,
+            currency: ffi.currency,
+            amount: ffi.amount,
+            decimals: ffi.decimals,
+            from_address: ffi.from_address,
+            to_address: ffi.to_address,
+        }
+    }
+}
+
+impl From<TransactionReference> for FfiTransactionReference {
+    fn from(tx_ref: TransactionReference) -> Self {
+        FfiTransactionReference {
+            namespace: tx_ref.namespace,
+            network_id: tx_ref.network_id,
+            reference: tx_ref.reference,
+            metadata: tx_ref.metadata.map(|m| m.into()),
+        }
+    }
+}
+
+impl From<FfiTransactionReference> for TransactionReference {
+    fn from(ffi: FfiTransactionReference) -> Self {
+        TransactionReference {
+            namespace: ffi.namespace,
+            network_id: ffi.network_id,
+            reference: ffi.reference,
+            metadata: ffi.metadata.map(|m| m.into()),
+        }
+    }
+}
+
+impl From<GroupUpdated> for FfiGroupUpdated {
+    fn from(updated: GroupUpdated) -> Self {
+        FfiGroupUpdated {
+            initiated_by_inbox_id: updated.initiated_by_inbox_id,
+            added_inboxes: updated
+                .added_inboxes
+                .into_iter()
+                .map(|inbox| FfiInbox {
+                    inbox_id: inbox.inbox_id,
+                })
+                .collect(),
+            removed_inboxes: updated
+                .removed_inboxes
+                .into_iter()
+                .map(|inbox| FfiInbox {
+                    inbox_id: inbox.inbox_id,
+                })
+                .collect(),
+            metadata_field_changes: updated
+                .metadata_field_changes
+                .into_iter()
+                .map(|change| FfiMetadataFieldChange {
+                    field_name: change.field_name,
+                    old_value: change.old_value,
+                    new_value: change.new_value,
+                })
+                .collect(),
+        }
+    }
+}
+
+impl From<GroupMembershipChanges> for FfiGroupMembershipChanges {
+    fn from(changes: GroupMembershipChanges) -> Self {
+        FfiGroupMembershipChanges {
+            members_added: changes
+                .members_added
+                .into_iter()
+                .map(|m| m.into())
+                .collect(),
+            members_removed: changes
+                .members_removed
+                .into_iter()
+                .map(|m| m.into())
+                .collect(),
+            installations_added: changes
+                .installations_added
+                .into_iter()
+                .map(|m| m.into())
+                .collect(),
+            installations_removed: changes
+                .installations_removed
+                .into_iter()
+                .map(|m| m.into())
+                .collect(),
+        }
+    }
+}
+
+impl From<MembershipChange> for FfiMembershipChange {
+    fn from(change: MembershipChange) -> Self {
+        FfiMembershipChange {
+            installation_ids: change.installation_ids,
+            account_address: change.account_address,
+            initiated_by_account_address: change.initiated_by_account_address,
+        }
+    }
+}
+
+impl From<ReadReceipt> for FfiReadReceipt {
+    fn from(receipt: ReadReceipt) -> Self {
+        FfiReadReceipt {
+            reference: receipt.reference,
+            reference_inbox_id: receipt.reference_inbox_id,
+            read_at_ns: receipt.read_at_ns,
+        }
+    }
+}
+
+impl From<FfiReadReceipt> for ReadReceipt {
+    fn from(ffi: FfiReadReceipt) -> Self {
+        ReadReceipt {
+            reference: ffi.reference,
+            reference_inbox_id: ffi.reference_inbox_id,
+            read_at_ns: ffi.read_at_ns,
+        }
+    }
+}
+
+impl From<EncodedContent> for FfiEncodedContent {
+    fn from(encoded: EncodedContent) -> Self {
+        FfiEncodedContent {
+            type_id: encoded.r#type.map(|t| t.into()),
+            parameters: encoded.parameters,
+            fallback: encoded.fallback,
+            compression: encoded.compression,
+            content: encoded.content,
+        }
+    }
+}
+
+impl From<FfiEncodedContent> for EncodedContent {
+    fn from(ffi: FfiEncodedContent) -> Self {
+        EncodedContent {
+            r#type: ffi.type_id.map(|t| t.into()),
+            parameters: ffi.parameters,
+            fallback: ffi.fallback,
+            compression: ffi.compression,
+            content: ffi.content,
+        }
+    }
+}
+
+impl From<ContentTypeId> for FfiContentTypeId {
+    fn from(type_id: ContentTypeId) -> Self {
+        FfiContentTypeId {
+            authority_id: type_id.authority_id,
+            type_id: type_id.type_id,
+            version_major: type_id.version_major as u32,
+            version_minor: type_id.version_minor as u32,
+        }
+    }
+}
+
+impl From<FfiContentTypeId> for ContentTypeId {
+    fn from(ffi: FfiContentTypeId) -> Self {
+        ContentTypeId {
+            authority_id: ffi.authority_id,
+            type_id: ffi.type_id,
+            version_major: ffi.version_major,
+            version_minor: ffi.version_minor,
+        }
+    }
+}
+
+impl From<Reply> for FfiReplyContent {
+    fn from(reply: Reply) -> Self {
+        FfiReplyContent {
+            in_reply_to: reply.in_reply_to.map(|m| Arc::new((*m).into())),
+            content: content_to_optional_body(*reply.content),
+        }
+    }
+}
+
+// Main From implementation for MessageListItemContent using the individual implementations
+
+impl From<MessageListItemContent> for FfiProcessedMessageContent {
+    fn from(content: MessageListItemContent) -> Self {
+        match content {
+            MessageListItemContent::Text(text) => FfiProcessedMessageContent::Text(text.into()),
+            MessageListItemContent::Reply(reply) => FfiProcessedMessageContent::Reply(reply.into()),
+            MessageListItemContent::Reaction(reaction) => {
+                FfiProcessedMessageContent::Reaction(reaction.into())
+            }
+            MessageListItemContent::Attachment(attachment) => {
+                FfiProcessedMessageContent::Attachment(attachment.into())
+            }
+            MessageListItemContent::RemoteAttachment(remote) => {
+                FfiProcessedMessageContent::RemoteAttachment(remote.into())
+            }
+            MessageListItemContent::MultiRemoteAttachment(multi) => {
+                FfiProcessedMessageContent::MultiRemoteAttachment(multi.into())
+            }
+            MessageListItemContent::TransactionReference(tx_ref) => {
+                FfiProcessedMessageContent::TransactionReference(tx_ref.into())
+            }
+            MessageListItemContent::GroupUpdated(updated) => {
+                FfiProcessedMessageContent::GroupUpdated(updated.into())
+            }
+            MessageListItemContent::GroupMembershipChanges(changes) => {
+                FfiProcessedMessageContent::GroupMembershipChanges(changes.into())
+            }
+            MessageListItemContent::ReadReceipt(receipt) => {
+                FfiProcessedMessageContent::ReadReceipt(receipt.into())
+            }
+            MessageListItemContent::Custom(encoded) => {
+                FfiProcessedMessageContent::Custom(encoded.into())
+            }
+        }
+    }
+}
+
+// Helper function to convert MessageListItemContent to Option<FfiProcessedMessageBody>
+pub fn content_to_optional_body(
+    content: MessageListItemContent,
+) -> Option<FfiProcessedMessageBody> {
+    match content {
+        MessageListItemContent::Text(text) => Some(FfiProcessedMessageBody::Text(text.into())),
+        MessageListItemContent::Reply(_) => None,
+        MessageListItemContent::Reaction(_) => None,
+        MessageListItemContent::Attachment(attachment) => {
+            Some(FfiProcessedMessageBody::Attachment(attachment.into()))
+        }
+        MessageListItemContent::RemoteAttachment(remote) => {
+            Some(FfiProcessedMessageBody::RemoteAttachment(remote.into()))
+        }
+        MessageListItemContent::MultiRemoteAttachment(multi) => {
+            Some(FfiProcessedMessageBody::MultiRemoteAttachment(multi.into()))
+        }
+        MessageListItemContent::TransactionReference(tx_ref) => {
+            Some(FfiProcessedMessageBody::TransactionReference(tx_ref.into()))
+        }
+        MessageListItemContent::GroupUpdated(updated) => {
+            Some(FfiProcessedMessageBody::GroupUpdated(updated.into()))
+        }
+        MessageListItemContent::GroupMembershipChanges(changes) => Some(
+            FfiProcessedMessageBody::GroupMembershipChanges(changes.into()),
+        ),
+        MessageListItemContent::ReadReceipt(receipt) => {
+            Some(FfiProcessedMessageBody::ReadReceipt(receipt.into()))
+        }
+        MessageListItemContent::Custom(encoded) => {
+            Some(FfiProcessedMessageBody::Custom(encoded.into()))
+        }
+    }
+}
+
+#[derive(uniffi::Object, Clone)]
+pub struct FfiProcessedMessage {
+    record: MessageListItem,
+}
+
+#[uniffi::export]
+impl FfiProcessedMessage {
+    pub fn content(&self) -> FfiProcessedMessageContent {
+        self.record.content.clone().into()
+    }
+}
+
+impl From<MessageListItem> for FfiProcessedMessage {
+    fn from(item: MessageListItem) -> Self {
+        FfiProcessedMessage { record: item }
+    }
+}

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -1,10 +1,10 @@
 use crate::identity::{FfiCollectionExt, FfiCollectionTryExt, FfiIdentifier};
 pub use crate::inbox_owner::SigningError;
 use crate::logger::init_logger;
-use crate::message::FfiEncodedContent;
+use crate::message::{FfiDeliveryStatus, FfiReactionPayload};
 use crate::worker::FfiSyncWorker;
 use crate::worker::FfiSyncWorkerMode;
-use crate::{FfiSubscribeError, GenericError};
+use crate::{FfiReply, FfiSubscribeError, GenericError};
 use prost::Message;
 use std::{collections::HashMap, convert::TryInto, sync::Arc};
 use tokio::sync::Mutex;
@@ -23,7 +23,6 @@ use xmtp_content_types::remote_attachment::RemoteAttachmentCodec;
 use xmtp_content_types::reply::Reply;
 use xmtp_content_types::reply::ReplyCodec;
 use xmtp_content_types::text::TextCodec;
-use xmtp_content_types::transaction_reference::TransactionMetadata;
 use xmtp_content_types::transaction_reference::TransactionReference;
 use xmtp_content_types::transaction_reference::TransactionReferenceCodec;
 use xmtp_content_types::{encoded_content_to_bytes, ContentCodec};
@@ -36,7 +35,7 @@ use xmtp_db::NativeDb;
 use xmtp_db::{
     consent_record::{ConsentState, ConsentType, StoredConsentRecord},
     group::GroupQueryArgs,
-    group_message::{DeliveryStatus, GroupMessageKind, StoredGroupMessage},
+    group_message::{GroupMessageKind, StoredGroupMessage},
     EncryptedMessageStore, EncryptionKey, StorageOption,
 };
 use xmtp_id::associations::{
@@ -2534,33 +2533,6 @@ impl From<ConversationType> for FfiConversationType {
     }
 }
 
-#[derive(uniffi::Enum, Clone)]
-pub enum FfiDeliveryStatus {
-    Unpublished,
-    Published,
-    Failed,
-}
-
-impl From<DeliveryStatus> for FfiDeliveryStatus {
-    fn from(status: DeliveryStatus) -> Self {
-        match status {
-            DeliveryStatus::Unpublished => FfiDeliveryStatus::Unpublished,
-            DeliveryStatus::Published => FfiDeliveryStatus::Published,
-            DeliveryStatus::Failed => FfiDeliveryStatus::Failed,
-        }
-    }
-}
-
-impl From<FfiDeliveryStatus> for DeliveryStatus {
-    fn from(status: FfiDeliveryStatus) -> Self {
-        match status {
-            FfiDeliveryStatus::Unpublished => DeliveryStatus::Unpublished,
-            FfiDeliveryStatus::Published => DeliveryStatus::Published,
-            FfiDeliveryStatus::Failed => DeliveryStatus::Failed,
-        }
-    }
-}
-
 #[derive(uniffi::Record)]
 pub struct FfiMessageWithReactions {
     pub message: FfiMessage,
@@ -2581,7 +2553,7 @@ impl From<StoredGroupMessageWithReactions> for FfiMessageWithReactions {
 }
 
 #[uniffi::export]
-pub fn encode_reaction(reaction: FfiReaction) -> Result<Vec<u8>, GenericError> {
+pub fn encode_reaction(reaction: FfiReactionPayload) -> Result<Vec<u8>, GenericError> {
     // Convert FfiReaction to Reaction
     let reaction: ReactionV2 = reaction.into();
 
@@ -2599,7 +2571,7 @@ pub fn encode_reaction(reaction: FfiReaction) -> Result<Vec<u8>, GenericError> {
 }
 
 #[uniffi::export]
-pub fn decode_reaction(bytes: Vec<u8>) -> Result<FfiReaction, GenericError> {
+pub fn decode_reaction(bytes: Vec<u8>) -> Result<FfiReactionPayload, GenericError> {
     // Decode bytes into EncodedContent
     let encoded_content = EncodedContent::decode(bytes.as_slice())
         .map_err(|e| GenericError::Generic { err: e.to_string() })?;
@@ -2608,44 +2580,6 @@ pub fn decode_reaction(bytes: Vec<u8>) -> Result<FfiReaction, GenericError> {
     ReactionCodec::decode(encoded_content)
         .map(Into::into)
         .map_err(|e| GenericError::Generic { err: e.to_string() })
-}
-
-#[derive(uniffi::Enum, Clone, Default, PartialEq, Debug)]
-pub enum FfiReactionAction {
-    Unknown,
-    #[default]
-    Added,
-    Removed,
-}
-
-impl From<FfiReactionAction> for i32 {
-    fn from(action: FfiReactionAction) -> Self {
-        match action {
-            FfiReactionAction::Unknown => 0,
-            FfiReactionAction::Added => 1,
-            FfiReactionAction::Removed => 2,
-        }
-    }
-}
-
-#[derive(uniffi::Enum, Clone, Default, PartialEq, Debug)]
-pub enum FfiReactionSchema {
-    Unknown,
-    #[default]
-    Unicode,
-    Shortcode,
-    Custom,
-}
-
-impl From<FfiReactionSchema> for i32 {
-    fn from(schema: FfiReactionSchema) -> Self {
-        match schema {
-            FfiReactionSchema::Unknown => 0,
-            FfiReactionSchema::Unicode => 1,
-            FfiReactionSchema::Shortcode => 2,
-            FfiReactionSchema::Custom => 3,
-        }
-    }
 }
 
 // RemoteAttachmentInfo and MultiRemoteAttachment FFI structures - using types from message module
@@ -3100,12 +3034,12 @@ mod tests {
         revoke_installations,
         worker::FfiSyncWorkerMode,
         FfiAttachment, FfiConsent, FfiConsentEntityType, FfiConsentState, FfiContentType,
-        FfiConversation, FfiConversationCallback, FfiConversationMessageKind, FfiCreateDMOptions,
-        FfiCreateGroupOptions, FfiDirection, FfiGroupPermissionsOptions,
+        FfiConversation, FfiConversationCallback, FfiConversationMessageKind, FfiConversationType,
+        FfiCreateDMOptions, FfiCreateGroupOptions, FfiDirection, FfiGroupPermissionsOptions,
         FfiListConversationsOptions, FfiListMessagesOptions, FfiMessageDisappearingSettings,
         FfiMessageWithReactions, FfiMetadataField, FfiMultiRemoteAttachment, FfiPasskeySignature,
-        FfiPermissionPolicy, FfiPermissionPolicySet, FfiPermissionUpdateType, FfiReaction,
-        FfiReactionAction, FfiReactionSchema, FfiReadReceipt, FfiRemoteAttachment, FfiReply,
+        FfiPermissionPolicy, FfiPermissionPolicySet, FfiPermissionUpdateType, FfiReactionAction,
+        FfiReactionPayload, FfiReactionSchema, FfiReadReceipt, FfiRemoteAttachment, FfiReply,
         FfiSubscribeError, FfiTransactionReference, GenericError,
     };
     use alloy::signers::local::PrivateKeySigner;
@@ -8086,7 +8020,7 @@ mod tests {
         let message_to_react_to = &messages[1];
 
         // Create and send reaction
-        let ffi_reaction = FfiReaction {
+        let ffi_reaction = FfiReactionPayload {
             reference: hex::encode(message_to_react_to.id.clone()),
             reference_inbox_id: alix.inbox_id(),
             action: FfiReactionAction::Added,
@@ -8143,7 +8077,7 @@ mod tests {
     #[tokio::test]
     async fn test_reaction_encode_decode() {
         // Create a test reaction
-        let original_reaction = FfiReaction {
+        let original_reaction = FfiReactionPayload {
             reference: "123abc".to_string(),
             reference_inbox_id: "test_inbox_id".to_string(),
             action: FfiReactionAction::Added,
@@ -8475,8 +8409,7 @@ mod tests {
         let original = FfiAttachment {
             filename: Some("test.txt".to_string()),
             mime_type: "text/plain".to_string(),
-            size: 1024,
-            content: "Hello, World!".to_string(),
+            content: "Hello, World!".as_bytes().to_vec(),
         };
 
         let encoded = encode_attachment(original.clone()).unwrap();
@@ -8484,7 +8417,6 @@ mod tests {
 
         assert_eq!(original.filename, decoded.filename);
         assert_eq!(original.mime_type, decoded.mime_type);
-        assert_eq!(original.size, decoded.size);
         assert_eq!(original.content, decoded.content);
     }
 
@@ -8512,28 +8444,20 @@ mod tests {
 
     #[tokio::test]
     async fn test_read_receipt_roundtrip() {
-        let original = FfiReadReceipt {
-            reference: "0x1234567890abcdef".to_string(),
-            reference_inbox_id: Some("test_inbox_id".to_string()),
-            read_at_ns: 1234567890000000000,
-        };
+        let original = FfiReadReceipt {};
 
         let encoded = encode_read_receipt(original.clone()).unwrap();
-        let decoded = decode_read_receipt(encoded).unwrap();
-
-        assert_eq!(original.reference, decoded.reference);
-        assert_eq!(original.reference_inbox_id, decoded.reference_inbox_id);
-        assert_eq!(original.read_at_ns, decoded.read_at_ns);
+        decode_read_receipt(encoded).unwrap();
     }
 
     #[tokio::test]
     async fn test_remote_attachment_roundtrip() {
         let original = FfiRemoteAttachment {
             filename: Some("remote_file.txt".to_string()),
-            mime_type: "text/plain".to_string(),
-            size: 2048,
+            content_length: 2048,
             url: "https://example.com/file.txt".to_string(),
             content_digest: "sha256:abc123def456".to_string(),
+            scheme: "https".to_string(),
             secret: vec![1, 2, 3, 4, 5],
             nonce: vec![6, 7, 8, 9, 10],
             salt: vec![11, 12, 13, 14, 15],
@@ -8543,8 +8467,7 @@ mod tests {
         let decoded = decode_remote_attachment(encoded).unwrap();
 
         assert_eq!(original.filename, decoded.filename);
-        assert_eq!(original.mime_type, decoded.mime_type);
-        assert_eq!(original.size, decoded.size);
+        assert_eq!(original.content_length, decoded.content_length);
         assert_eq!(original.url, decoded.url);
         assert_eq!(original.content_digest, decoded.content_digest);
         assert_eq!(original.secret, decoded.secret);

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -1,6 +1,7 @@
 use crate::identity::{FfiCollectionExt, FfiCollectionTryExt, FfiIdentifier};
 pub use crate::inbox_owner::SigningError;
 use crate::logger::init_logger;
+use crate::message::FfiEncodedContent;
 use crate::worker::FfiSyncWorker;
 use crate::worker::FfiSyncWorkerMode;
 use crate::{FfiSubscribeError, GenericError};
@@ -11,10 +12,20 @@ use xmtp_api::{strategies, ApiClientWrapper, ApiDebugWrapper, ApiIdentifier};
 use xmtp_api_grpc::grpc_api_helper::Client as TonicApiClient;
 use xmtp_common::time::now_ns;
 use xmtp_common::{AbortHandle, GenericStreamHandle, StreamHandle};
+use xmtp_content_types::attachment::Attachment;
+use xmtp_content_types::attachment::AttachmentCodec;
 use xmtp_content_types::multi_remote_attachment::MultiRemoteAttachmentCodec;
 use xmtp_content_types::reaction::ReactionCodec;
+use xmtp_content_types::read_receipt::ReadReceipt;
+use xmtp_content_types::read_receipt::ReadReceiptCodec;
+use xmtp_content_types::remote_attachment::RemoteAttachment;
+use xmtp_content_types::remote_attachment::RemoteAttachmentCodec;
+use xmtp_content_types::reply::Reply;
+use xmtp_content_types::reply::ReplyCodec;
 use xmtp_content_types::text::TextCodec;
 use xmtp_content_types::transaction_reference::TransactionMetadata;
+use xmtp_content_types::transaction_reference::TransactionReference;
+use xmtp_content_types::transaction_reference::TransactionReferenceCodec;
 use xmtp_content_types::{encoded_content_to_bytes, ContentCodec};
 use xmtp_db::group::ConversationType;
 use xmtp_db::group::DmIdExt;
@@ -79,10 +90,14 @@ use xmtp_proto::api_client::AggregateStats;
 use xmtp_proto::api_client::ApiStats;
 use xmtp_proto::api_client::IdentityStats;
 use xmtp_proto::xmtp::device_sync::{BackupElementSelection, BackupOptions};
-use xmtp_proto::xmtp::mls::message_contents::content_types::{
-    MultiRemoteAttachment, ReactionV2, RemoteAttachmentInfo,
-};
+use xmtp_proto::xmtp::mls::message_contents::content_types::{MultiRemoteAttachment, ReactionV2};
 use xmtp_proto::xmtp::mls::message_contents::EncodedContent;
+
+// Re-export types from message module that are used in public APIs
+pub use crate::message::{
+    FfiAttachment, FfiMultiRemoteAttachment, FfiReadReceipt, FfiRemoteAttachment,
+    FfiTransactionReference,
+};
 
 #[cfg(test)]
 mod test_utils;
@@ -2565,48 +2580,6 @@ impl From<StoredGroupMessageWithReactions> for FfiMessageWithReactions {
     }
 }
 
-#[derive(uniffi::Record, Clone, Default)]
-pub struct FfiReaction {
-    pub reference: String,
-    pub reference_inbox_id: String,
-    pub action: FfiReactionAction,
-    pub content: String,
-    pub schema: FfiReactionSchema,
-}
-
-impl From<FfiReaction> for ReactionV2 {
-    fn from(reaction: FfiReaction) -> Self {
-        ReactionV2 {
-            reference: reaction.reference,
-            reference_inbox_id: reaction.reference_inbox_id,
-            action: reaction.action.into(),
-            content: reaction.content,
-            schema: reaction.schema.into(),
-        }
-    }
-}
-
-impl From<ReactionV2> for FfiReaction {
-    fn from(reaction: ReactionV2) -> Self {
-        FfiReaction {
-            reference: reaction.reference,
-            reference_inbox_id: reaction.reference_inbox_id,
-            action: match reaction.action {
-                1 => FfiReactionAction::Added,
-                2 => FfiReactionAction::Removed,
-                _ => FfiReactionAction::Unknown,
-            },
-            content: reaction.content,
-            schema: match reaction.schema {
-                1 => FfiReactionSchema::Unicode,
-                2 => FfiReactionSchema::Shortcode,
-                3 => FfiReactionSchema::Custom,
-                _ => FfiReactionSchema::Unknown,
-            },
-        }
-    }
-}
-
 #[uniffi::export]
 pub fn encode_reaction(reaction: FfiReaction) -> Result<Vec<u8>, GenericError> {
     // Convert FfiReaction to Reaction
@@ -2675,76 +2648,7 @@ impl From<FfiReactionSchema> for i32 {
     }
 }
 
-#[derive(uniffi::Record, Clone, Default)]
-pub struct FfiRemoteAttachmentInfo {
-    pub secret: Vec<u8>,
-    pub content_digest: String,
-    pub nonce: Vec<u8>,
-    pub scheme: String,
-    pub url: String,
-    pub salt: Vec<u8>,
-    pub content_length: Option<u32>,
-    pub filename: Option<String>,
-}
-
-impl From<FfiRemoteAttachmentInfo> for RemoteAttachmentInfo {
-    fn from(ffi_remote_attachment_info: FfiRemoteAttachmentInfo) -> Self {
-        RemoteAttachmentInfo {
-            content_digest: ffi_remote_attachment_info.content_digest,
-            secret: ffi_remote_attachment_info.secret,
-            nonce: ffi_remote_attachment_info.nonce,
-            salt: ffi_remote_attachment_info.salt,
-            scheme: ffi_remote_attachment_info.scheme,
-            url: ffi_remote_attachment_info.url,
-            content_length: ffi_remote_attachment_info.content_length,
-            filename: ffi_remote_attachment_info.filename,
-        }
-    }
-}
-
-impl From<RemoteAttachmentInfo> for FfiRemoteAttachmentInfo {
-    fn from(remote_attachment_info: RemoteAttachmentInfo) -> Self {
-        FfiRemoteAttachmentInfo {
-            secret: remote_attachment_info.secret,
-            content_digest: remote_attachment_info.content_digest,
-            nonce: remote_attachment_info.nonce,
-            scheme: remote_attachment_info.scheme,
-            url: remote_attachment_info.url,
-            salt: remote_attachment_info.salt,
-            content_length: remote_attachment_info.content_length,
-            filename: remote_attachment_info.filename,
-        }
-    }
-}
-
-#[derive(uniffi::Record, Clone, Default)]
-pub struct FfiMultiRemoteAttachment {
-    pub attachments: Vec<FfiRemoteAttachmentInfo>,
-}
-
-impl From<FfiMultiRemoteAttachment> for MultiRemoteAttachment {
-    fn from(ffi_multi_remote_attachment: FfiMultiRemoteAttachment) -> Self {
-        MultiRemoteAttachment {
-            attachments: ffi_multi_remote_attachment
-                .attachments
-                .into_iter()
-                .map(Into::into)
-                .collect(),
-        }
-    }
-}
-
-impl From<MultiRemoteAttachment> for FfiMultiRemoteAttachment {
-    fn from(multi_remote_attachment: MultiRemoteAttachment) -> Self {
-        FfiMultiRemoteAttachment {
-            attachments: multi_remote_attachment
-                .attachments
-                .into_iter()
-                .map(Into::into)
-                .collect(),
-        }
-    }
-}
+// RemoteAttachmentInfo and MultiRemoteAttachment FFI structures - using types from message module
 
 #[uniffi::export]
 pub fn encode_multi_remote_attachment(
@@ -2780,40 +2684,143 @@ pub fn decode_multi_remote_attachment(
         .map_err(|e| GenericError::Generic { err: e.to_string() })
 }
 
-#[derive(uniffi::Record, Clone, Default)]
-pub struct FfiTransactionMetadata {
-    pub transaction_type: String,
-    pub currency: String,
-    pub amount: f64,
-    pub decimals: u32,
-    pub from_address: String,
-    pub to_address: String,
+// TransactionReference FFI structures - using types from message module
+
+#[uniffi::export]
+pub fn encode_transaction_reference(
+    reference: FfiTransactionReference,
+) -> Result<Vec<u8>, GenericError> {
+    let reference: TransactionReference = reference.into();
+
+    let encoded = TransactionReferenceCodec::encode(reference)
+        .map_err(|e| GenericError::Generic { err: e.to_string() })?;
+
+    let mut buf = Vec::new();
+    encoded
+        .encode(&mut buf)
+        .map_err(|e| GenericError::Generic { err: e.to_string() })?;
+
+    Ok(buf)
 }
 
-impl From<FfiTransactionMetadata> for TransactionMetadata {
-    fn from(f: FfiTransactionMetadata) -> Self {
-        TransactionMetadata {
-            transaction_type: f.transaction_type,
-            currency: f.currency,
-            amount: f.amount,
-            decimals: f.decimals,
-            from_address: f.from_address,
-            to_address: f.to_address,
-        }
-    }
+#[uniffi::export]
+pub fn decode_transaction_reference(
+    bytes: Vec<u8>,
+) -> Result<FfiTransactionReference, GenericError> {
+    let encoded_content = EncodedContent::decode(bytes.as_slice())
+        .map_err(|e| GenericError::Generic { err: e.to_string() })?;
+
+    TransactionReferenceCodec::decode(encoded_content)
+        .map(Into::into)
+        .map_err(|e| GenericError::Generic { err: e.to_string() })
 }
 
-impl From<TransactionMetadata> for FfiTransactionMetadata {
-    fn from(t: TransactionMetadata) -> Self {
-        FfiTransactionMetadata {
-            transaction_type: t.transaction_type,
-            currency: t.currency,
-            amount: t.amount,
-            decimals: t.decimals,
-            from_address: t.from_address,
-            to_address: t.to_address,
-        }
-    }
+// Attachment FFI structures - using FfiAttachment from message module
+
+#[uniffi::export]
+pub fn encode_attachment(attachment: FfiAttachment) -> Result<Vec<u8>, GenericError> {
+    let attachment: Attachment = attachment.into();
+
+    let encoded = AttachmentCodec::encode(attachment)
+        .map_err(|e| GenericError::Generic { err: e.to_string() })?;
+
+    let mut buf = Vec::new();
+    encoded
+        .encode(&mut buf)
+        .map_err(|e| GenericError::Generic { err: e.to_string() })?;
+
+    Ok(buf)
+}
+
+#[uniffi::export]
+pub fn decode_attachment(bytes: Vec<u8>) -> Result<FfiAttachment, GenericError> {
+    let encoded_content = EncodedContent::decode(bytes.as_slice())
+        .map_err(|e| GenericError::Generic { err: e.to_string() })?;
+
+    AttachmentCodec::decode(encoded_content)
+        .map(Into::into)
+        .map_err(|e| GenericError::Generic { err: e.to_string() })
+}
+
+#[uniffi::export]
+pub fn encode_reply(reply: FfiReply) -> Result<Vec<u8>, GenericError> {
+    let reply: Reply = reply.into();
+
+    let encoded =
+        ReplyCodec::encode(reply).map_err(|e| GenericError::Generic { err: e.to_string() })?;
+
+    let mut buf = Vec::new();
+    encoded
+        .encode(&mut buf)
+        .map_err(|e| GenericError::Generic { err: e.to_string() })?;
+
+    Ok(buf)
+}
+
+#[uniffi::export]
+pub fn decode_reply(bytes: Vec<u8>) -> Result<FfiReply, GenericError> {
+    let encoded_content = EncodedContent::decode(bytes.as_slice())
+        .map_err(|e| GenericError::Generic { err: e.to_string() })?;
+
+    ReplyCodec::decode(encoded_content)
+        .map(Into::into)
+        .map_err(|e| GenericError::Generic { err: e.to_string() })
+}
+
+// ReadReceipt FFI structures - using FfiReadReceipt from message module
+
+#[uniffi::export]
+pub fn encode_read_receipt(read_receipt: FfiReadReceipt) -> Result<Vec<u8>, GenericError> {
+    let read_receipt: ReadReceipt = read_receipt.into();
+
+    let encoded = ReadReceiptCodec::encode(read_receipt)
+        .map_err(|e| GenericError::Generic { err: e.to_string() })?;
+
+    let mut buf = Vec::new();
+    encoded
+        .encode(&mut buf)
+        .map_err(|e| GenericError::Generic { err: e.to_string() })?;
+
+    Ok(buf)
+}
+
+#[uniffi::export]
+pub fn decode_read_receipt(bytes: Vec<u8>) -> Result<FfiReadReceipt, GenericError> {
+    let encoded_content = EncodedContent::decode(bytes.as_slice())
+        .map_err(|e| GenericError::Generic { err: e.to_string() })?;
+
+    ReadReceiptCodec::decode(encoded_content)
+        .map(Into::into)
+        .map_err(|e| GenericError::Generic { err: e.to_string() })
+}
+
+// RemoteAttachment FFI structures - using FfiRemoteAttachment from message module
+
+#[uniffi::export]
+pub fn encode_remote_attachment(
+    remote_attachment: FfiRemoteAttachment,
+) -> Result<Vec<u8>, GenericError> {
+    let remote_attachment: RemoteAttachment = remote_attachment.into();
+
+    let encoded = RemoteAttachmentCodec::encode(remote_attachment)
+        .map_err(|e| GenericError::Generic { err: e.to_string() })?;
+
+    let mut buf = Vec::new();
+    encoded
+        .encode(&mut buf)
+        .map_err(|e| GenericError::Generic { err: e.to_string() })?;
+
+    Ok(buf)
+}
+
+#[uniffi::export]
+pub fn decode_remote_attachment(bytes: Vec<u8>) -> Result<FfiRemoteAttachment, GenericError> {
+    let encoded_content = EncodedContent::decode(bytes.as_slice())
+        .map_err(|e| GenericError::Generic { err: e.to_string() })?;
+
+    RemoteAttachmentCodec::decode(encoded_content)
+        .map(Into::into)
+        .map_err(|e| GenericError::Generic { err: e.to_string() })
 }
 
 #[derive(uniffi::Record, Clone)]
@@ -3079,23 +3086,27 @@ mod tests {
         FfiPreferenceUpdate, FfiXmtpClient,
     };
     use crate::{
-        apply_signature_request, connect_to_backend, decode_multi_remote_attachment,
-        decode_reaction, encode_multi_remote_attachment, encode_reaction,
+        apply_signature_request, connect_to_backend, decode_attachment,
+        decode_multi_remote_attachment, decode_reaction, decode_read_receipt,
+        decode_remote_attachment, decode_reply, decode_transaction_reference, encode_attachment,
+        encode_multi_remote_attachment, encode_reaction, encode_read_receipt,
+        encode_remote_attachment, encode_reply, encode_transaction_reference,
         get_inbox_id_for_identifier,
         identity::{FfiIdentifier, FfiIdentifierKind},
         inbox_owner::{FfiInboxOwner, IdentityValidationError, SigningError},
         inbox_state_from_inbox_ids, is_connected,
+        message::{FfiEncodedContent, FfiRemoteAttachmentInfo, FfiTransactionMetadata},
         mls::test_utils::{LocalBuilder, LocalTester},
         revoke_installations,
         worker::FfiSyncWorkerMode,
-        FfiConsent, FfiConsentEntityType, FfiConsentState, FfiContentType, FfiConversation,
-        FfiConversationCallback, FfiConversationMessageKind, FfiConversationType,
-        FfiCreateDMOptions, FfiCreateGroupOptions, FfiDirection, FfiGroupPermissionsOptions,
+        FfiAttachment, FfiConsent, FfiConsentEntityType, FfiConsentState, FfiContentType,
+        FfiConversation, FfiConversationCallback, FfiConversationMessageKind, FfiCreateDMOptions,
+        FfiCreateGroupOptions, FfiDirection, FfiGroupPermissionsOptions,
         FfiListConversationsOptions, FfiListMessagesOptions, FfiMessageDisappearingSettings,
         FfiMessageWithReactions, FfiMetadataField, FfiMultiRemoteAttachment, FfiPasskeySignature,
         FfiPermissionPolicy, FfiPermissionPolicySet, FfiPermissionUpdateType, FfiReaction,
-        FfiReactionAction, FfiReactionSchema, FfiRemoteAttachmentInfo, FfiSubscribeError,
-        GenericError,
+        FfiReactionAction, FfiReactionSchema, FfiReadReceipt, FfiRemoteAttachment, FfiReply,
+        FfiSubscribeError, FfiTransactionReference, GenericError,
     };
     use alloy::signers::local::PrivateKeySigner;
     use futures::future::join_all;
@@ -8431,6 +8442,114 @@ mod tests {
             assert_eq!(decoded.scheme, original.scheme);
             assert_eq!(decoded.url, original.url);
         }
+    }
+
+    #[tokio::test]
+    async fn test_transaction_reference_roundtrip() {
+        let original = FfiTransactionReference {
+            namespace: Some("eip155".to_string()),
+            network_id: "1".to_string(),
+            reference: "0xabc123".to_string(),
+            metadata: Some(FfiTransactionMetadata {
+                transaction_type: "transfer".to_string(),
+                currency: "ETH".to_string(),
+                amount: 0.42,
+                decimals: 18,
+                from_address: "0xfrom".to_string(),
+                to_address: "0xto".to_string(),
+            }),
+        };
+
+        let encoded = encode_transaction_reference(original.clone()).unwrap();
+        let decoded = decode_transaction_reference(encoded).unwrap();
+
+        assert_eq!(original.reference, decoded.reference);
+        assert_eq!(
+            original.metadata.as_ref().unwrap().currency,
+            decoded.metadata.as_ref().unwrap().currency
+        );
+    }
+
+    #[tokio::test]
+    async fn test_attachment_roundtrip() {
+        let original = FfiAttachment {
+            filename: Some("test.txt".to_string()),
+            mime_type: "text/plain".to_string(),
+            size: 1024,
+            content: "Hello, World!".to_string(),
+        };
+
+        let encoded = encode_attachment(original.clone()).unwrap();
+        let decoded = decode_attachment(encoded).unwrap();
+
+        assert_eq!(original.filename, decoded.filename);
+        assert_eq!(original.mime_type, decoded.mime_type);
+        assert_eq!(original.size, decoded.size);
+        assert_eq!(original.content, decoded.content);
+    }
+
+    #[tokio::test]
+    async fn test_reply_roundtrip() {
+        let original = FfiReply {
+            reference: "0x1234567890abcdef".to_string(),
+            reference_inbox_id: Some("test_inbox_id".to_string()),
+            content: FfiEncodedContent {
+                type_id: None,
+                parameters: HashMap::new(),
+                fallback: Some("This is a reply".to_string()),
+                compression: None,
+                content: b"This is a reply".to_vec(),
+            },
+        };
+
+        let encoded = encode_reply(original.clone()).unwrap();
+        let decoded = decode_reply(encoded).unwrap();
+
+        assert_eq!(original.reference, decoded.reference);
+        assert_eq!(original.reference_inbox_id, decoded.reference_inbox_id);
+        assert_eq!(original.content, decoded.content);
+    }
+
+    #[tokio::test]
+    async fn test_read_receipt_roundtrip() {
+        let original = FfiReadReceipt {
+            reference: "0x1234567890abcdef".to_string(),
+            reference_inbox_id: Some("test_inbox_id".to_string()),
+            read_at_ns: 1234567890000000000,
+        };
+
+        let encoded = encode_read_receipt(original.clone()).unwrap();
+        let decoded = decode_read_receipt(encoded).unwrap();
+
+        assert_eq!(original.reference, decoded.reference);
+        assert_eq!(original.reference_inbox_id, decoded.reference_inbox_id);
+        assert_eq!(original.read_at_ns, decoded.read_at_ns);
+    }
+
+    #[tokio::test]
+    async fn test_remote_attachment_roundtrip() {
+        let original = FfiRemoteAttachment {
+            filename: Some("remote_file.txt".to_string()),
+            mime_type: "text/plain".to_string(),
+            size: 2048,
+            url: "https://example.com/file.txt".to_string(),
+            content_digest: "sha256:abc123def456".to_string(),
+            secret: vec![1, 2, 3, 4, 5],
+            nonce: vec![6, 7, 8, 9, 10],
+            salt: vec![11, 12, 13, 14, 15],
+        };
+
+        let encoded = encode_remote_attachment(original.clone()).unwrap();
+        let decoded = decode_remote_attachment(encoded).unwrap();
+
+        assert_eq!(original.filename, decoded.filename);
+        assert_eq!(original.mime_type, decoded.mime_type);
+        assert_eq!(original.size, decoded.size);
+        assert_eq!(original.url, decoded.url);
+        assert_eq!(original.content_digest, decoded.content_digest);
+        assert_eq!(original.secret, decoded.secret);
+        assert_eq!(original.nonce, decoded.nonce);
+        assert_eq!(original.salt, decoded.salt);
     }
 
     #[tokio::test]

--- a/xmtp_mls/src/groups/decoded_message.rs
+++ b/xmtp_mls/src/groups/decoded_message.rs
@@ -1,0 +1,94 @@
+use xmtp_content_types::{
+    attachment::Attachment, read_receipt::ReadReceipt, remote_attachment::RemoteAttachment,
+    transaction_reference::TransactionReference,
+};
+use xmtp_db::group_message::{DeliveryStatus, GroupMessageKind};
+use xmtp_proto::xmtp::mls::message_contents::{
+    ContentTypeId, EncodedContent, GroupMembershipChanges, GroupUpdated,
+    content_types::{MultiRemoteAttachment, ReactionV2},
+};
+
+#[derive(Debug, Clone)]
+pub struct Reply {
+    // The original message that this reply is in reply to.
+    // This goes at most one level deep from the original message, and won't happen recursively if there are replies to replies to replies
+    pub in_reply_to: Option<Box<DecodedMessage>>,
+    pub content: Box<MessageBody>,
+}
+
+#[derive(Debug, Clone)]
+pub enum ReactionAction {
+    Added,
+    Removed,
+}
+
+#[derive(Debug, Clone)]
+pub enum ReactionSchema {
+    Unicode,
+    Shortcode,
+    Custom,
+}
+
+#[derive(Debug, Clone)]
+pub struct Reaction {
+    pub metadata: DecodedMessageMetadata,
+    pub action: ReactionAction,
+    pub content: String,
+    pub schema: ReactionSchema,
+    pub reference: String,
+    pub reference_inbox_id: String,
+}
+
+// Wrap text content in a struct to be consident with other content types
+#[derive(Debug, Clone)]
+pub struct Text {
+    pub content: String,
+}
+
+#[derive(Debug, Clone)]
+pub enum MessageBody {
+    Text(Text),
+    Reply(Reply),
+    Reaction(ReactionV2),
+    Attachment(Attachment),
+    RemoteAttachment(RemoteAttachment),
+    MultiRemoteAttachment(MultiRemoteAttachment),
+    TransactionReference(TransactionReference),
+    GroupUpdated(GroupUpdated),
+    GroupMembershipChanges(GroupMembershipChanges),
+    ReadReceipt(ReadReceipt),
+    Custom(EncodedContent),
+}
+
+#[derive(Debug, Clone)]
+pub struct DecodedMessageMetadata {
+    // The message ID
+    pub id: Vec<u8>,
+    // The group ID
+    pub group_id: Vec<u8>,
+    // The timestamp of the message in nanoseconds
+    pub sent_at_ns: i64,
+    // The kind of message
+    pub kind: GroupMessageKind,
+    // The installation ID of the sender
+    pub sender_installation_id: Vec<u8>,
+    // The inbox ID of the sender
+    pub sender_inbox_id: String,
+    // The delivery status of the message
+    pub delivery_status: DeliveryStatus,
+    // The content type of the message
+    pub content_type: ContentTypeId,
+}
+
+#[derive(Debug, Clone)]
+pub struct DecodedMessage {
+    pub metadata: DecodedMessageMetadata,
+    // The content of the message
+    pub content: MessageBody,
+    // Fallback text for the message
+    pub fallback_text: String,
+    // A list of reactions
+    pub reactions: Vec<Reaction>,
+    // The number of replies to the message available
+    pub num_replies: usize,
+}

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -1,17 +1,15 @@
 pub mod commit_log;
 pub mod commit_log_key;
+pub mod decoded_message;
 pub mod device_sync;
 pub mod device_sync_legacy;
+pub mod disappearing_messages;
 mod error;
 pub mod group_membership;
 pub mod group_permissions;
 pub mod intents;
-pub mod members;
-pub mod welcome_sync;
-
-pub mod disappearing_messages;
 pub mod key_package_cleaner_worker;
-pub mod message_list_item;
+pub mod members;
 pub(super) mod mls_ext;
 pub(super) mod mls_sync;
 pub(super) mod subscriptions;
@@ -19,6 +17,7 @@ pub mod summary;
 #[cfg(test)]
 mod tests;
 pub mod validated_commit;
+pub mod welcome_sync;
 mod welcomes;
 pub use welcomes::*;
 
@@ -228,7 +227,7 @@ impl TryFrom<EncodedContent> for QueryableContentFields {
         let type_id_str = content_type_id.type_id.clone();
 
         let reference_id = match (type_id_str.as_str(), content_type_id.version_major) {
-            (ReplyCodec::TYPE_ID, major) if major == 1 => ReplyCodec::decode(content)
+            (ReplyCodec::TYPE_ID, 1) => ReplyCodec::decode(content)
                 .ok()
                 .and_then(|reply| hex::decode(reply.reference).ok()),
             (ReactionCodec::TYPE_ID, major) if major >= 2 => {

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -11,6 +11,7 @@ pub mod welcome_sync;
 
 pub mod disappearing_messages;
 pub mod key_package_cleaner_worker;
+pub mod message_list_item;
 pub(super) mod mls_ext;
 pub(super) mod mls_sync;
 pub(super) mod subscriptions;
@@ -60,8 +61,12 @@ use xmtp_configuration::{
     CIPHERSUITE, GROUP_MEMBERSHIP_EXTENSION_ID, GROUP_PERMISSIONS_EXTENSION_ID, MAX_GROUP_SIZE,
     MAX_PAST_EPOCHS, MUTABLE_METADATA_EXTENSION_ID, SEND_MESSAGE_UPDATE_INSTALLATIONS_INTERVAL_NS,
 };
-use xmtp_content_types::reaction::{LegacyReaction, ReactionCodec};
+use xmtp_content_types::ContentCodec;
 use xmtp_content_types::should_push;
+use xmtp_content_types::{
+    reaction::{LegacyReaction, ReactionCodec},
+    reply::ReplyCodec,
+};
 use xmtp_cryptography::configuration::ED25519_KEY_LENGTH;
 use xmtp_db::local_commit_log::LocalCommitLog;
 use xmtp_db::prelude::*;
@@ -218,11 +223,14 @@ impl TryFrom<EncodedContent> for QueryableContentFields {
     type Error = prost::DecodeError;
 
     fn try_from(content: EncodedContent) -> Result<Self, Self::Error> {
-        let content_type_id = content.r#type.unwrap_or_default();
+        let content_type_id = content.r#type.clone().unwrap_or_default();
 
         let type_id_str = content_type_id.type_id.clone();
 
         let reference_id = match (type_id_str.as_str(), content_type_id.version_major) {
+            (ReplyCodec::TYPE_ID, major) if major == 1 => ReplyCodec::decode(content)
+                .ok()
+                .and_then(|reply| hex::decode(reply.reference).ok()),
             (ReactionCodec::TYPE_ID, major) if major >= 2 => {
                 ReactionV2::decode(content.content.as_slice())
                     .ok()


### PR DESCRIPTION
## tl;dr

- Scaffolds the new `ProcessedMessage` data structure, which holds replies and fully decoded content
- Adds a ton of FFI converters for content types and associated structs