### PR TITLE
Update versions for v1.4.0-rc1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_node"
-version = "1.4.0-dev"
+version = "1.4.0-rc1"
 dependencies = [
  "chrono",
  "const-hex",
@@ -1242,7 +1242,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_wasm"
-version = "1.4.0-dev"
+version = "1.4.0-rc1"
 dependencies = [
  "alloy",
  "chrono",
@@ -8537,7 +8537,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api"
-version = "1.4.0-dev"
+version = "1.4.0-rc1"
 dependencies = [
  "async-trait",
  "const-hex",
@@ -8559,7 +8559,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_d14n"
-version = "1.4.0-dev"
+version = "1.4.0-rc1"
 dependencies = [
  "async-trait",
  "const-hex",
@@ -8587,7 +8587,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_grpc"
-version = "1.4.0-dev"
+version = "1.4.0-rc1"
 dependencies = [
  "async-trait",
  "futures",
@@ -8611,7 +8611,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_http"
-version = "1.4.0-dev"
+version = "1.4.0-rc1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8638,7 +8638,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_archive"
-version = "1.4.0-dev"
+version = "1.4.0-rc1"
 dependencies = [
  "aes-gcm",
  "async-compression",
@@ -8665,7 +8665,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_cli"
-version = "1.4.0-dev"
+version = "1.4.0-rc1"
 dependencies = [
  "alloy",
  "chrono",
@@ -8699,7 +8699,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_common"
-version = "1.4.0-dev"
+version = "1.4.0-rc1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8735,7 +8735,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_configuration"
-version = "1.4.0-dev"
+version = "1.4.0-rc1"
 dependencies = [
  "openmls",
  "url",
@@ -8745,7 +8745,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_content_types"
-version = "1.4.0-dev"
+version = "1.4.0-rc1"
 dependencies = [
  "prost",
  "serde",
@@ -8760,7 +8760,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_cryptography"
-version = "1.4.0-dev"
+version = "1.4.0-rc1"
 dependencies = [
  "alloy",
  "bincode",
@@ -8784,7 +8784,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_db"
-version = "1.4.0-dev"
+version = "1.4.0-rc1"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -8825,7 +8825,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_db_test"
-version = "1.4.0-dev"
+version = "1.4.0-rc1"
 dependencies = [
  "derive_builder",
  "diesel",
@@ -8838,7 +8838,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_id"
-version = "1.4.0-dev"
+version = "1.4.0-rc1"
 dependencies = [
  "alloy",
  "async-trait",
@@ -8874,7 +8874,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_macro"
-version = "1.4.0-dev"
+version = "1.4.0-rc1"
 dependencies = [
  "num_cpus",
  "proc-macro2",
@@ -8886,7 +8886,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_mls"
-version = "1.4.0-dev"
+version = "1.4.0-rc1"
 dependencies = [
  "aes-gcm",
  "alloy",
@@ -8966,7 +8966,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_mls_common"
-version = "1.4.0-dev"
+version = "1.4.0-rc1"
 dependencies = [
  "const-hex",
  "openmls",
@@ -8984,7 +8984,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_proto"
-version = "1.4.0-dev"
+version = "1.4.0-rc1"
 dependencies = [
  "async-trait",
  "const-hex",
@@ -9012,7 +9012,7 @@ dependencies = [
 
 [[package]]
 name = "xmtpv3"
-version = "1.4.0-dev"
+version = "1.4.0-rc1"
 dependencies = [
  "alloy",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ resolver = "2"
 
 [workspace.package]
 license = "MIT"
-version = "1.4.0-dev"
+version = "1.4.0-rc1"
 
 [workspace.dependencies]
 alloy = { version = "1.0", default-features = false }

--- a/bindings_node/package.json
+++ b/bindings_node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/node-bindings",
-  "version": "1.4.0-dev",
+  "version": "1.4.0-rc1",
   "repository": {
     "type": "git",
     "url": "git+https://git@github.com/xmtp/libxmtp.git",

--- a/bindings_wasm/package.json
+++ b/bindings_wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/wasm-bindings",
-  "version": "1.4.0-dev",
+  "version": "1.4.0-rc1",
   "type": "module",
   "license": "MIT",
   "description": "WASM bindings for the libXMTP rust library",


### PR DESCRIPTION
### Update workspace package versions from 1.4.0-dev to 1.4.0-rc1 for release candidate preparation
This pull request updates version numbers across the workspace from `1.4.0-dev` to `1.4.0-rc1` in preparation for the release candidate. The changes affect:

- [Cargo.toml](https://github.com/xmtp/libxmtp/pull/2323/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542) workspace package version
- [Cargo.lock](https://github.com/xmtp/libxmtp/pull/2323/files#diff-13ee4b2252c9e516a0547f2891aa2105c3ca71c6d7a1e682c69be97998dfc87e) lockfile with updated versions for `bindings_node`, `bindings_wasm`, and `xmtp_*` packages
- [bindings_node/package.json](https://github.com/xmtp/libxmtp/pull/2323/files#diff-bc8be8e755c9188d5b1c3402b397741f9151dad43d877a181f31003052d10b99) version field
- [bindings_wasm/package.json](https://github.com/xmtp/libxmtp/pull/2323/files#diff-4a621639e0561b5b01c30ab7fa75cc2b67c54dad6763ecabda35df8e2b16b14e) version field

#### 📍Where to Start
Start with the workspace version change in [Cargo.toml](https://github.com/xmtp/libxmtp/pull/2323/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542) to understand the primary version update that propagates to all other files.

----

_[Macroscope](https://app.macroscope.com) summarized 3e67cc2._