### PR TITLE
Fix batching max size; Preserve not forked state when no new local commits

### DIFF
--- a/xmtp_mls/src/groups/commit_log.rs
+++ b/xmtp_mls/src/groups/commit_log.rs
@@ -572,6 +572,11 @@ where
         let remote_logs =
             conn.get_remote_commit_log_after_cursor(conversation_id, fork_check_remote_cursor)?;
 
+        // If there are no new commits to check, preserve the existing fork status
+        if local_logs.is_empty() {
+            return Ok(conn.get_group_commit_log_forked_status(conversation_id)?);
+        }
+
         let mut is_remote_log_up_to_date = true;
         // Check each local log against remote logs for matching commit_sequence_id
         for local_log in &local_logs {
@@ -681,13 +686,14 @@ where
                 test_result.is_forked = Some(is_forked);
             }
             CommitLogTestFunction::All => {
-                let publish_commit_log_results = self.publish_commit_logs_to_remote().await?;
-                test_result.publish_commit_log_results = Some(publish_commit_log_results);
+                // Order is save; update fork status; publish
                 let save_remote_commit_log_results = self.save_remote_commit_log().await?;
                 test_result.save_remote_commit_log_results = Some(save_remote_commit_log_results);
                 self.update_forked_state().await?;
                 let is_forked = self.get_all_fork_statuses()?;
                 test_result.is_forked = Some(is_forked);
+                let publish_commit_log_results = self.publish_commit_logs_to_remote().await?;
+                test_result.publish_commit_log_results = Some(publish_commit_log_results);
             }
         }
         Ok(test_result)

--- a/xmtp_mls/src/groups/tests/test_commit_log_fork_detection.rs
+++ b/xmtp_mls/src/groups/tests/test_commit_log_fork_detection.rs
@@ -442,7 +442,7 @@ async fn test_commit_log_fork_status_persistence_no_new_commits()
     // First fork detection run - should detect no fork and set status to Some(false)
     let mut worker = CommitLogWorker::new(alix.context.clone());
     let results = worker
-        .run_test(CommitLogTestFunction::CheckForkedState, None)
+        .run_test(CommitLogTestFunction::All, None)
         .await
         .unwrap();
 
@@ -467,7 +467,7 @@ async fn test_commit_log_fork_status_persistence_no_new_commits()
     // Second fork detection run - no new commits have been added
     // This should preserve the existing fork status (Some(false))
     let results_second = worker
-        .run_test(CommitLogTestFunction::CheckForkedState, None)
+        .run_test(CommitLogTestFunction::All, None)
         .await
         .unwrap();
 

--- a/xmtp_mls/src/groups/tests/test_commit_log_remote.rs
+++ b/xmtp_mls/src/groups/tests/test_commit_log_remote.rs
@@ -537,8 +537,9 @@ async fn test_download_commit_log_from_remote() {
 
     let mut commit_log_worker_alix = CommitLogWorker::new(alix.context.clone());
     // Alix publishes commits and saves remote commit log entries
+    // We run the worker twice since publish happens after save
     let alix_test_results = commit_log_worker_alix
-        .run_test(CommitLogTestFunction::All, None)
+        .run_test(CommitLogTestFunction::All, Some(2))
         .await
         .unwrap();
 
@@ -569,9 +570,9 @@ async fn test_download_commit_log_from_remote() {
             .num_entries_published,
         2
     );
-    // We saved results for one conversation
+    // We saved results for one conversation on the second worker run
     assert_eq!(
-        alix_test_results[0]
+        alix_test_results[1]
             .save_remote_commit_log_results
             .as_ref()
             .unwrap()
@@ -581,7 +582,7 @@ async fn test_download_commit_log_from_remote() {
 
     // We should have saved 2 new entries...
     assert_eq!(
-        *alix_test_results[0]
+        *alix_test_results[1]
             .save_remote_commit_log_results
             .as_ref()
             .unwrap()
@@ -603,7 +604,7 @@ async fn test_download_commit_log_from_remote() {
 
     let mut commit_log_worker_alix = CommitLogWorker::new(alix.context.clone());
     let alix_test_results = commit_log_worker_alix
-        .run_test(CommitLogTestFunction::All, None)
+        .run_test(CommitLogTestFunction::All, Some(2))
         .await
         .unwrap();
 
@@ -615,7 +616,7 @@ async fn test_download_commit_log_from_remote() {
 
     // Alix should have saved 2 new entries, while bo should have saved 4
     assert_eq!(
-        alix_test_results[0]
+        alix_test_results[1]
             .save_remote_commit_log_results
             .as_ref()
             .unwrap()
@@ -624,7 +625,7 @@ async fn test_download_commit_log_from_remote() {
     );
 
     assert_eq!(
-        *alix_test_results[0]
+        *alix_test_results[1]
             .save_remote_commit_log_results
             .as_ref()
             .unwrap()


### PR DESCRIPTION
### Fix batching max size in ApiClientWrapper methods and preserve not forked state when no new local commits exist in CommitLogWorker
- `ApiClientWrapper.publish_commit_log` method in [xmtp_api/src/mls.rs](https://github.com/xmtp/libxmtp/pull/2330/files#diff-8d4d4d46a198cd86023448bbca9e16b9f3362affb961b655082166f1a6095476) splits requests into chunks of 10 and publishes each chunk sequentially
- `ApiClientWrapper.query_commit_log` method in [xmtp_api/src/mls.rs](https://github.com/xmtp/libxmtp/pull/2330/files#diff-8d4d4d46a198cd86023448bbca9e16b9f3362affb961b655082166f1a6095476) splits requests into chunks of 20 and concatenates responses from all chunks
- `CommitLogWorker` fork-checking helper method in [xmtp_mls/src/groups/commit_log.rs](https://github.com/xmtp/libxmtp/pull/2330/files#diff-c25dc4d36a6249375b1001e9c4b66e50034909d2fc05025a45476e115429dc3a) returns early with existing forked status when no new local commits are present
- Test coverage added for batching behavior and fork status persistence scenarios

#### 📍Where to Start
Start with the `ApiClientWrapper.publish_commit_log` method in [xmtp_api/src/mls.rs](https://github.com/xmtp/libxmtp/pull/2330/files#diff-8d4d4d46a198cd86023448bbca9e16b9f3362affb961b655082166f1a6095476) to understand the batching implementation changes.

----

_[Macroscope](https://app.macroscope.com) summarized 22944c8._