### PR TITLE
AddWalletSendCalls

### DIFF
--- a/xmtp_content_types/src/compatibility_test.rs
+++ b/xmtp_content_types/src/compatibility_test.rs
@@ -87,6 +87,11 @@ fn decode_and_reencode(
             let content = AttachmentCodec::decode(encoded_content.clone())?;
             Ok(AttachmentCodec::encode(content)?)
         }
+        "walletSendCalls" => {
+            use crate::wallet_send_calls::WalletSendCallsCodec;
+            let content = WalletSendCallsCodec::decode(encoded_content.clone())?;
+            Ok(WalletSendCallsCodec::encode(content)?)
+        }
         _ => Err(format!("Unsupported content type: {content_type}").into()),
     }
 }
@@ -112,7 +117,7 @@ fn integration_test() {
             .expect("Missing encodedContent field");
 
         // Skip content types that don't have codec implementations yet
-        if matches!(content_type, "walletSendCalls" | "markdown") {
+        if matches!(content_type, "markdown") {
             continue;
         }
 
@@ -160,7 +165,10 @@ fn integration_test() {
         }
 
         // Verify JSON equality for content types that store JSON
-        if matches!(content_type, "transactionReference" | "reaction") {
+        if matches!(
+            content_type,
+            "transactionReference" | "reaction" | "walletSendCalls"
+        ) {
             verify_json_content_equality(
                 content_type,
                 &encoded_content.content,

--- a/xmtp_content_types/src/lib.rs
+++ b/xmtp_content_types/src/lib.rs
@@ -9,6 +9,7 @@ pub mod reply;
 pub mod text;
 pub mod transaction_reference;
 mod utils;
+pub mod wallet_send_calls;
 
 use prost::Message;
 use thiserror::Error;
@@ -42,6 +43,7 @@ pub enum ContentType {
     RemoteAttachment,
     MultiRemoteAttachment,
     TransactionReference,
+    WalletSendCalls,
     DeviceSyncMessage,
 }
 
@@ -66,6 +68,7 @@ impl TryFrom<&str> for ContentType {
             transaction_reference::TransactionReferenceCodec::TYPE_ID => {
                 Ok(Self::TransactionReference)
             }
+            wallet_send_calls::WalletSendCallsCodec::TYPE_ID => Ok(Self::WalletSendCalls),
             _ => Err(format!("Unknown content type ID: {type_id}")),
         }
     }
@@ -86,6 +89,7 @@ pub fn should_push(content_type_id: String) -> bool {
             ContentType::RemoteAttachment => true,
             ContentType::MultiRemoteAttachment => true,
             ContentType::TransactionReference => true,
+            ContentType::WalletSendCalls => true,
             ContentType::DeviceSyncMessage => false,
         }
     } else {

--- a/xmtp_content_types/src/wallet_send_calls.rs
+++ b/xmtp_content_types/src/wallet_send_calls.rs
@@ -1,0 +1,125 @@
+use std::collections::HashMap;
+
+use crate::{CodecError, ContentCodec};
+use serde::{Deserialize, Serialize};
+use xmtp_proto::xmtp::mls::message_contents::{ContentTypeId, EncodedContent};
+
+pub struct WalletSendCallsCodec {}
+
+impl WalletSendCallsCodec {
+    const AUTHORITY_ID: &'static str = "xmtp.org";
+    pub const TYPE_ID: &'static str = "walletSendCalls";
+    pub const MAJOR_VERSION: u32 = 1;
+    pub const MINOR_VERSION: u32 = 0;
+
+    fn fallback(content: &WalletSendCalls) -> String {
+        let json = serde_json::to_string(content).unwrap_or_else(|_| "{}".to_string());
+        format!("[Transaction request generated]: {}", json)
+    }
+}
+
+impl ContentCodec<WalletSendCalls> for WalletSendCallsCodec {
+    fn content_type() -> ContentTypeId {
+        ContentTypeId {
+            authority_id: Self::AUTHORITY_ID.to_string(),
+            type_id: Self::TYPE_ID.to_string(),
+            version_major: Self::MAJOR_VERSION,
+            version_minor: Self::MINOR_VERSION,
+        }
+    }
+
+    fn encode(content: WalletSendCalls) -> Result<EncodedContent, CodecError> {
+        let json = serde_json::to_vec(&content)
+            .map_err(|e| CodecError::Encode(format!("JSON encode error: {e}")))?;
+
+        Ok(EncodedContent {
+            r#type: Some(Self::content_type()),
+            parameters: HashMap::new(),
+            fallback: Some(Self::fallback(&content)),
+            compression: None,
+            content: json,
+        })
+    }
+
+    fn decode(encoded: EncodedContent) -> Result<WalletSendCalls, CodecError> {
+        serde_json::from_slice(&encoded.content)
+            .map_err(|e| CodecError::Decode(format!("JSON decode error: {e}")))
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct WalletSendCalls {
+    pub version: String,
+    #[serde(rename = "chainId")]
+    pub chain_id: String,
+    pub from: String,
+    pub calls: Vec<WalletCall>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capabilities: Option<HashMap<String, String>>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct WalletCall {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub to: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gas: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<WalletCallMetadata>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct WalletCallMetadata {
+    pub description: String,
+    #[serde(rename = "transactionType")]
+    pub transaction_type: String,
+    #[serde(flatten)]
+    pub extra: HashMap<String, String>,
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use super::*;
+    use crate::ContentCodec;
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    fn test_encode_decode_wallet_send_calls() {
+        let params = WalletSendCalls {
+            version: "1".to_string(),
+            chain_id: "0x1".to_string(),
+            from: "0xsender".to_string(),
+            calls: vec![WalletCall {
+                to: Some("0xrecipient".to_string()),
+                data: Some("0xdeadbeef".to_string()),
+                value: Some("0x0".to_string()),
+                gas: Some("0x5208".to_string()),
+                metadata: Some(WalletCallMetadata {
+                    description: "Send funds".to_string(),
+                    transaction_type: "transfer".to_string(),
+                    extra: HashMap::from([("note".to_string(), "test".to_string())]),
+                }),
+            }],
+            capabilities: Some(HashMap::from([("foo".to_string(), "bar".to_string())])),
+        };
+
+        let encoded = WalletSendCallsCodec::encode(params.clone()).unwrap();
+        let decoded = WalletSendCallsCodec::decode(encoded).unwrap();
+
+        assert_eq!(decoded.version, params.version);
+        assert_eq!(decoded.chain_id, params.chain_id);
+        assert_eq!(decoded.from, params.from);
+        assert_eq!(decoded.calls.len(), 1);
+        assert_eq!(
+            decoded.calls[0].metadata.as_ref().unwrap().transaction_type,
+            "transfer"
+        );
+    }
+}

--- a/xmtp_db/src/encrypted_store/group_message.rs
+++ b/xmtp_db/src/encrypted_store/group_message.rs
@@ -24,7 +24,7 @@ use std::collections::HashMap;
 use xmtp_common::time::now_ns;
 use xmtp_content_types::{
     attachment, group_updated, membership_change, reaction, read_receipt, remote_attachment, reply,
-    text, transaction_reference,
+    text, transaction_reference, wallet_send_calls,
 };
 
 mod convert;
@@ -131,6 +131,7 @@ pub enum ContentType {
     Attachment = 7,
     RemoteAttachment = 8,
     TransactionReference = 9,
+    WalletSendCalls = 10,
 }
 
 impl ContentType {
@@ -146,6 +147,7 @@ impl ContentType {
             ContentType::Attachment,
             ContentType::RemoteAttachment,
             ContentType::TransactionReference,
+            ContentType::WalletSendCalls,
         ]
     }
 }
@@ -163,6 +165,7 @@ impl std::fmt::Display for ContentType {
             Self::RemoteAttachment => remote_attachment::RemoteAttachmentCodec::TYPE_ID,
             Self::Reply => reply::ReplyCodec::TYPE_ID,
             Self::TransactionReference => transaction_reference::TransactionReferenceCodec::TYPE_ID,
+            Self::WalletSendCalls => wallet_send_calls::WalletSendCallsCodec::TYPE_ID,
         };
 
         write!(f, "{}", as_string)
@@ -181,6 +184,7 @@ impl From<String> for ContentType {
             attachment::AttachmentCodec::TYPE_ID => Self::Attachment,
             remote_attachment::RemoteAttachmentCodec::TYPE_ID => Self::RemoteAttachment,
             transaction_reference::TransactionReferenceCodec::TYPE_ID => Self::TransactionReference,
+            wallet_send_calls::WalletSendCallsCodec::TYPE_ID => Self::WalletSendCalls,
             _ => Self::Unknown,
         }
     }
@@ -212,6 +216,7 @@ where
             7 => Ok(ContentType::Attachment),
             8 => Ok(ContentType::RemoteAttachment),
             9 => Ok(ContentType::TransactionReference),
+            10 => Ok(ContentType::WalletSendCalls),
             x => Err(format!("Unrecognized variant {}", x).into()),
         }
     }

--- a/xmtp_db/src/encrypted_store/group_message/convert.rs
+++ b/xmtp_db/src/encrypted_store/group_message/convert.rs
@@ -138,6 +138,7 @@ impl From<ContentType> for ContentTypeSave {
             ContentType::Text => Self::Text,
             ContentType::TransactionReference => Self::TransactionReference,
             ContentType::Unknown => Self::Unknown,
+            _ => Self::Unknown,
         }
     }
 }

--- a/xmtp_mls/src/groups/decoded_message.rs
+++ b/xmtp_mls/src/groups/decoded_message.rs
@@ -7,6 +7,7 @@ use xmtp_content_types::read_receipt::ReadReceiptCodec;
 use xmtp_content_types::remote_attachment::RemoteAttachmentCodec;
 use xmtp_content_types::reply::ReplyCodec;
 use xmtp_content_types::transaction_reference::TransactionReferenceCodec;
+use xmtp_content_types::wallet_send_calls::{WalletSendCalls, WalletSendCallsCodec};
 use xmtp_content_types::{CodecError, ContentCodec};
 use xmtp_content_types::{
     attachment::{Attachment, AttachmentCodec},
@@ -48,6 +49,7 @@ pub enum MessageBody {
     TransactionReference(TransactionReference),
     GroupUpdated(GroupUpdated),
     ReadReceipt(ReadReceipt),
+    WalletSendCalls(WalletSendCalls),
     Custom(EncodedContent),
 }
 
@@ -138,6 +140,10 @@ impl TryFrom<EncodedContent> for MessageBody {
             (ReadReceiptCodec::TYPE_ID, ReadReceiptCodec::MAJOR_VERSION) => {
                 let read_receipt = ReadReceiptCodec::decode(value)?;
                 Ok(MessageBody::ReadReceipt(read_receipt))
+            }
+            (WalletSendCallsCodec::TYPE_ID, WalletSendCallsCodec::MAJOR_VERSION) => {
+                let wallet_send_calls = WalletSendCallsCodec::decode(value)?;
+                Ok(MessageBody::WalletSendCalls(wallet_send_calls))
             }
 
             _ => Err(CodecError::CodecNotFound(content_type.clone()).into()),


### PR DESCRIPTION
### TL;DR

Added support for the WalletSendCalls content type to enable wallet transaction requests in messages.

### What changed?

- Implemented the `WalletSendCalls` content type and related data structures
- Added FFI bindings for the new content type to make it accessible across language boundaries
- Integrated the new content type with the existing message decoding/encoding system
- Added serialization/deserialization support for the wallet transaction request format
- Updated compatibility tests to handle the new content type

### How to test?

1. Create a `WalletSendCalls` message with transaction details:
2. Encode and send the message
3. Verify that the message can be properly decoded on the receiving end
4. Run the compatibility tests to ensure the new content type works with existing systems

### Why make this change?

This change enables direct wallet transaction requests within the messaging system, allowing users to request cryptocurrency transfers or smart contract interactions from other users. This functionality is essential for web3 applications that combine messaging with blockchain transactions, creating a more seamless user experience for financial interactions between users.