### PR TITLE
Add remote log to debug info

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -1817,6 +1817,7 @@ pub struct FfiConversationDebugInfo {
     pub fork_details: String,
     pub is_commit_log_forked: Option<bool>,
     pub local_commit_log: String,
+    pub remote_commit_log: String,
     pub cursor: i64,
 }
 
@@ -1827,6 +1828,7 @@ impl FfiConversationDebugInfo {
         fork_details: String,
         is_commit_log_forked: Option<bool>,
         local_commit_log: String,
+        remote_commit_log: String,
         cursor: i64,
     ) -> Self {
         Self {
@@ -1835,6 +1837,7 @@ impl FfiConversationDebugInfo {
             fork_details,
             is_commit_log_forked,
             local_commit_log,
+            remote_commit_log,
             cursor,
         }
     }
@@ -1848,6 +1851,7 @@ impl From<ConversationDebugInfo> for FfiConversationDebugInfo {
             value.fork_details,
             value.is_commit_log_forked,
             value.local_commit_log,
+            value.remote_commit_log,
             value.cursor,
         )
     }

--- a/bindings_node/src/conversations.rs
+++ b/bindings_node/src/conversations.rs
@@ -162,6 +162,7 @@ pub struct ConversationDebugInfo {
   pub fork_details: String,
   pub is_commit_log_forked: Option<bool>,
   pub local_commit_log: String,
+  pub remote_commit_log: String,
   pub cursor: i64,
 }
 
@@ -173,6 +174,7 @@ impl From<XmtpConversationDebugInfo> for ConversationDebugInfo {
       fork_details: value.fork_details,
       is_commit_log_forked: value.is_commit_log_forked,
       local_commit_log: value.local_commit_log,
+      remote_commit_log: value.remote_commit_log,
       cursor: value.cursor,
     }
   }

--- a/bindings_wasm/src/conversation.rs
+++ b/bindings_wasm/src/conversation.rs
@@ -689,6 +689,7 @@ impl Conversation {
       fork_details: debug_info.fork_details,
       is_commit_log_forked: debug_info.is_commit_log_forked,
       local_commit_log: debug_info.local_commit_log,
+      remote_commit_log: debug_info.remote_commit_log,
       cursor: debug_info.cursor,
     })?)
   }

--- a/bindings_wasm/src/conversations.rs
+++ b/bindings_wasm/src/conversations.rs
@@ -187,6 +187,9 @@ pub struct ConversationDebugInfo {
   #[wasm_bindgen(js_name = localCommitLog)]
   #[serde(rename = "localCommitLog")]
   pub local_commit_log: String,
+  #[wasm_bindgen(js_name = remoteCommitLog)]
+  #[serde(rename = "remoteCommitLog")]
+  pub remote_commit_log: String,
   #[wasm_bindgen(js_name = cursor)]
   #[serde(rename = "cursor")]
   pub cursor: i64,

--- a/xmtp_db/src/encrypted_store/remote_commit_log.rs
+++ b/xmtp_db/src/encrypted_store/remote_commit_log.rs
@@ -16,6 +16,7 @@ use diesel::{
 };
 
 use serde::{Deserialize, Serialize};
+use xmtp_common::snippet::Snippet;
 use xmtp_proto::xmtp::mls::message_contents::CommitResult as ProtoCommitResult;
 
 #[derive(Insertable, Debug, Clone)]
@@ -31,7 +32,7 @@ pub struct NewRemoteCommitLog {
 
 impl_store!(NewRemoteCommitLog, remote_commit_log);
 
-#[derive(Insertable, Queryable, Debug, Clone)]
+#[derive(Insertable, Queryable, Clone)]
 #[diesel(table_name = remote_commit_log)]
 #[diesel(primary_key(rowid))]
 pub struct RemoteCommitLog {
@@ -77,6 +78,22 @@ impl std::fmt::Debug for CommitResult {
     }
 }
 
+impl std::fmt::Debug for RemoteCommitLog {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "RemoteCommitLog {{ rowid: {:?}, log_sequence_id: {:?}, group_id {:?}, commit_sequence_id: {:?}, commit_result: {:?}, applied_epoch_number: {:?}, applied_epoch_authenticator: {:?} }}",
+            self.rowid,
+            self.log_sequence_id,
+            &self.group_id.snippet(),
+            self.commit_sequence_id,
+            self.commit_result,
+            self.applied_epoch_number,
+            &self.applied_epoch_authenticator.snippet()
+        )
+    }
+}
+
 impl ToSql<Integer, Sqlite> for CommitResult
 where
     i32: ToSql<Integer, Sqlite>,
@@ -118,6 +135,11 @@ impl From<ProtoCommitResult> for CommitResult {
 // the max page size for queries
 pub const MAX_PAGE_SIZE: u32 = 100;
 
+pub enum RemoteCommitLogOrder {
+    AscendingByRowid,
+    DescendingByRowid,
+}
+
 pub trait QueryRemoteCommitLog {
     fn get_latest_remote_log_for_group(
         &self,
@@ -128,6 +150,7 @@ pub trait QueryRemoteCommitLog {
         &self,
         group_id: &[u8],
         after_cursor: i64,
+        order_by: RemoteCommitLogOrder,
     ) -> Result<Vec<RemoteCommitLog>, crate::ConnectionError>;
 }
 
@@ -146,8 +169,9 @@ where
         &self,
         group_id: &[u8],
         after_cursor: i64,
+        order_by: RemoteCommitLogOrder,
     ) -> Result<Vec<RemoteCommitLog>, crate::ConnectionError> {
-        (**self).get_remote_commit_log_after_cursor(group_id, after_cursor)
+        (**self).get_remote_commit_log_after_cursor(group_id, after_cursor, order_by)
     }
 }
 
@@ -170,6 +194,7 @@ impl<C: ConnectionExt> QueryRemoteCommitLog for DbConnection<C> {
         &self,
         group_id: &[u8],
         after_cursor: i64,
+        order: RemoteCommitLogOrder,
     ) -> Result<Vec<RemoteCommitLog>, crate::ConnectionError> {
         // If a group hits more than 2^31 entries on the remote commit log rowid, we will hit this error
         // If we want to address this we can make a new sqlite cursor table/row that stores u64 values
@@ -180,13 +205,14 @@ impl<C: ConnectionExt> QueryRemoteCommitLog for DbConnection<C> {
         }
         let after_cursor: i32 = after_cursor as i32;
 
-        self.raw_query_read(|db| {
-            dsl::remote_commit_log
-                .filter(dsl::group_id.eq(group_id))
-                .filter(dsl::rowid.gt(after_cursor))
-                .filter(dsl::commit_sequence_id.ne(0))
-                .order_by(dsl::rowid.desc())
-                .load(db)
+        let query = dsl::remote_commit_log
+            .filter(dsl::group_id.eq(group_id))
+            .filter(dsl::rowid.gt(after_cursor))
+            .filter(dsl::commit_sequence_id.ne(0));
+
+        self.raw_query_read(|db| match order {
+            RemoteCommitLogOrder::AscendingByRowid => query.order_by(dsl::rowid.asc()).load(db),
+            RemoteCommitLogOrder::DescendingByRowid => query.order_by(dsl::rowid.desc()).load(db),
         })
     }
 }

--- a/xmtp_db/src/mock.rs
+++ b/xmtp_db/src/mock.rs
@@ -2,7 +2,7 @@ use crate::association_state::QueryAssociationStateCache;
 use crate::group::ConversationType;
 use crate::group::StoredGroupCommitLogPublicKey;
 use crate::local_commit_log::{LocalCommitLog, LocalCommitLogOrder};
-use crate::remote_commit_log::RemoteCommitLog;
+use crate::remote_commit_log::{RemoteCommitLog, RemoteCommitLogOrder};
 use std::collections::HashMap;
 use std::sync::Arc;
 use xmtp_proto::xmtp::identity::associations::AssociationState as AssociationStateProto;
@@ -539,6 +539,7 @@ mock! {
             &self,
             group_id: &[u8],
             after_cursor: i64,
+            order_by: RemoteCommitLogOrder,
         ) -> Result<Vec<RemoteCommitLog>, crate::ConnectionError>;
 
     }

--- a/xmtp_mls/src/groups/commit_log.rs
+++ b/xmtp_mls/src/groups/commit_log.rs
@@ -9,6 +9,7 @@ use std::{collections::HashMap, time::Duration};
 use thiserror::Error;
 use xmtp_api::ApiError;
 use xmtp_db::remote_commit_log::RemoteCommitLog;
+use xmtp_db::remote_commit_log::RemoteCommitLogOrder;
 use xmtp_db::{
     DbQuery, StorageError, Store,
     group::StoredGroupCommitLogPublicKey,
@@ -569,8 +570,11 @@ where
             fork_check_local_cursor,
             LocalCommitLogOrder::DescendingByRowid,
         )?;
-        let remote_logs =
-            conn.get_remote_commit_log_after_cursor(conversation_id, fork_check_remote_cursor)?;
+        let remote_logs = conn.get_remote_commit_log_after_cursor(
+            conversation_id,
+            fork_check_remote_cursor,
+            RemoteCommitLogOrder::DescendingByRowid,
+        )?;
 
         // If there are no new commits to check, preserve the existing fork status
         if local_logs.is_empty() {

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -63,7 +63,6 @@ use xmtp_configuration::{
 use xmtp_content_types::reaction::{LegacyReaction, ReactionCodec};
 use xmtp_content_types::should_push;
 use xmtp_cryptography::configuration::ED25519_KEY_LENGTH;
-use xmtp_db::XmtpMlsStorageProvider;
 use xmtp_db::local_commit_log::LocalCommitLog;
 use xmtp_db::prelude::*;
 use xmtp_db::user_preferences::HmacKey;
@@ -74,6 +73,10 @@ use xmtp_db::{
     refresh_state::EntityKind,
 };
 use xmtp_db::{Store, StoreOrIgnore};
+use xmtp_db::{
+    XmtpMlsStorageProvider,
+    remote_commit_log::{RemoteCommitLog, RemoteCommitLogOrder},
+};
 use xmtp_db::{
     consent_record::{ConsentState, StoredConsentRecord},
     group::{ConversationType, GroupMembershipState, StoredGroup},
@@ -176,6 +179,7 @@ pub struct ConversationDebugInfo {
     pub fork_details: String,
     pub is_commit_log_forked: Option<bool>,
     pub local_commit_log: String,
+    pub remote_commit_log: String,
     pub cursor: i64,
 }
 
@@ -1370,10 +1374,19 @@ where
         Ok(self.context.db().get_group_logs(&self.group_id)?)
     }
 
+    pub async fn remote_commit_log(&self) -> Result<Vec<RemoteCommitLog>, GroupError> {
+        Ok(self.context.db().get_remote_commit_log_after_cursor(
+            &self.group_id,
+            0,
+            RemoteCommitLogOrder::AscendingByRowid,
+        )?)
+    }
+
     pub async fn debug_info(&self) -> Result<ConversationDebugInfo, GroupError> {
         let epoch = self.epoch().await?;
         let cursor = self.cursor().await?;
         let commit_log = self.local_commit_log().await?;
+        let remote_commit_log = self.remote_commit_log().await?;
         let db = self.context.db();
 
         let stored_group = match db.find_group(&self.group_id)? {
@@ -1391,6 +1404,7 @@ where
             fork_details: stored_group.fork_details,
             is_commit_log_forked: stored_group.is_commit_log_forked,
             local_commit_log: format!("{:?}", commit_log),
+            remote_commit_log: format!("{:?}", remote_commit_log),
             cursor,
         })
     }


### PR DESCRIPTION
### Include remote commit log in `xmtp_mls::groups::Group.debug_info` via `ConversationDebugInfo` to add remote log to debug info
- Add `remote_commit_log: String` to `ConversationDebugInfo` and include formatted remote log output in `xmtp_mls::groups::Group.debug_info` ([mod.rs](https://github.com/xmtp/libxmtp/pull/2353/files#diff-c29f56a38916c7410eff8091df1a2e43487ffe20646d96827e846e475f4608d3)).
- Introduce `RemoteCommitLogOrder` and update `get_remote_commit_log_after_cursor` to support ascending or descending `rowid` ordering, with a factored core query and a manual redacted `Debug` for `RemoteCommitLog` ([remote_commit_log.rs](https://github.com/xmtp/libxmtp/pull/2353/files#diff-cfcb5baf7f2bdfbb485a1f78af11355094f6dd1c3dc120f9bfe41312c6ee731a)).
- Add `Group.remote_commit_log` to return the full remote commit log in ascending order starting after cursor 0 ([mod.rs](https://github.com/xmtp/libxmtp/pull/2353/files#diff-c29f56a38916c7410eff8091df1a2e43487ffe20646d96827e846e475f4608d3)).
- Propagate `remote_commit_log` through FFI, Node, and WASM bindings: update FFI record/ctor and mapping ([mls.rs](https://github.com/xmtp/libxmtp/pull/2353/files#diff-3a24c3e76565487a710ac9863ac05160128f4f90892e07849b555a6de43a6e8f)); expose on Node object and mapping ([conversations.rs](https://github.com/xmtp/libxmtp/pull/2353/files#diff-305d8a9df912ee15a450791cf1af33e26798a0a4877f6a4dc457d291914bc126)); include on WASM struct and `debug_info` return shape ([conversations.rs](https://github.com/xmtp/libxmtp/pull/2353/files#diff-c5fb7781a0d2662984db637d31e1a03c6521210a1717f5594327876c0ecc6500), [conversation.rs](https://github.com/xmtp/libxmtp/pull/2353/files#diff-106fd4741a71a89abefb1837cde5785b14100381cea3bf577416671c49bae37e)).
- Make the previous implicit descending query explicit in the forked-state updater ([commit_log.rs](https://github.com/xmtp/libxmtp/pull/2353/files#diff-c25dc4d36a6249375b1001e9c4b66e50034909d2fc05025a45476e115429dc3a)); update mocks for new order parameter ([mock.rs](https://github.com/xmtp/libxmtp/pull/2353/files#diff-a33010f529ff112a9cecbe97825a88a6bf662298ee71bca5c5c53c61c2dd7999)).

#### 📍Where to Start
Start with `xmtp_mls::groups::Group.debug_info` and the new `xmtp_mls::groups::Group.remote_commit_log` in [mod.rs](https://github.com/xmtp/libxmtp/pull/2353/files#diff-c29f56a38916c7410eff8091df1a2e43487ffe20646d96827e846e475f4608d3).

----

_[Macroscope](https://app.macroscope.com) summarized 130759b._