### PR TITLE
Move to separate messages folder and add message_v2

### DIFF
--- a/bindings_ffi/gen_kotlin.sh
+++ b/bindings_ffi/gen_kotlin.sh
@@ -77,4 +77,4 @@ cd src/uniffi/$PROJECT_NAME/
 unzip -o LibXMTPKotlinFFI.zip
 cd ../../..
 
-cp -r $BINDINGS_PATH/src/uniffi/$PROJECT_NAME/jniLibs/* ~/XMTP/xmtp-android/library/src/main/jniLibs
+cp -r $BINDINGS_PATH/src/uniffi/$PROJECT_NAME/jniLibs/* $XMTP_ANDROID/library/src/main/jniLibs

--- a/bindings_ffi/src/message.rs
+++ b/bindings_ffi/src/message.rs
@@ -10,7 +10,7 @@ use xmtp_content_types::{
     wallet_send_calls::{WalletCall, WalletCallMetadata, WalletSendCalls},
 };
 use xmtp_db::group_message::{DeliveryStatus, GroupMessageKind};
-use xmtp_mls::groups::decoded_message::{
+use xmtp_mls::messages::decoded_message::{
     DecodedMessage, DecodedMessageMetadata, MessageBody, Reply as ProcessedReply, Text,
 };
 use xmtp_proto::xmtp::mls::message_contents::content_types::{

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -489,6 +489,11 @@ impl FfiXmtpClient {
         Ok(message.into())
     }
 
+    pub fn message_v2(&self, message_id: Vec<u8>) -> Result<FfiDecodedMessage, GenericError> {
+        let message = self.inner_client.message_v2(message_id)?;
+        Ok(message.into())
+    }
+
     pub async fn can_message(
         &self,
         account_identifiers: Vec<FfiIdentifier>,

--- a/xmtp_mls/src/groups/error.rs
+++ b/xmtp_mls/src/groups/error.rs
@@ -4,6 +4,7 @@ use super::mls_sync::GroupMessageProcessingError;
 use super::summary::SyncSummary;
 use super::{intents::IntentError, validated_commit::CommitValidationError};
 use crate::identity::IdentityError;
+use crate::messages::enrichment::EnrichMessageError;
 use crate::mls_store::MlsStoreError;
 use crate::{
     client::ClientError, identity_updates::InstallationDiffError, intents::ProcessIntentError,
@@ -175,6 +176,8 @@ pub enum GroupError {
     Diesel(#[from] xmtp_db::diesel::result::Error),
     #[error(transparent)]
     UninitializedField(#[from] derive_builder::UninitializedFieldError),
+    #[error(transparent)]
+    EnrichMessage(#[from] EnrichMessageError),
 }
 
 impl From<SyncSummary> for GroupError {
@@ -263,6 +266,7 @@ impl RetryableError for GroupError {
             Self::WrapWelcome(e) => e.is_retryable(),
             Self::UnwrapWelcome(e) => e.is_retryable(),
             Self::Diesel(e) => e.is_retryable(),
+            Self::EnrichMessage(e) => e.is_retryable(),
             Self::NotFound(_)
             | Self::UserLimitExceeded
             | Self::InvalidGroupMembership

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -1,6 +1,5 @@
 pub mod commit_log;
 pub mod commit_log_key;
-pub mod decoded_message;
 pub mod device_sync;
 pub mod device_sync_legacy;
 pub mod disappearing_messages;

--- a/xmtp_mls/src/lib.rs
+++ b/xmtp_mls/src/lib.rs
@@ -8,6 +8,7 @@ pub mod groups;
 pub mod identity;
 pub mod identity_updates;
 mod intents;
+pub mod messages;
 pub mod mls_store;
 mod mutex_registry;
 pub mod subscriptions;

--- a/xmtp_mls/src/messages/decoded_message.rs
+++ b/xmtp_mls/src/messages/decoded_message.rs
@@ -1,4 +1,5 @@
 use crate::groups::GroupError;
+use crate::messages::enrichment::EnrichMessageError;
 use prost::Message;
 use xmtp_content_types::group_updated::GroupUpdatedCodec;
 use xmtp_content_types::multi_remote_attachment::MultiRemoteAttachmentCodec;
@@ -152,7 +153,7 @@ impl TryFrom<EncodedContent> for MessageBody {
 }
 
 impl TryFrom<StoredGroupMessage> for DecodedMessage {
-    type Error = GroupError;
+    type Error = EnrichMessageError;
 
     fn try_from(value: StoredGroupMessage) -> Result<Self, Self::Error> {
         // Decode the message content from the stored bytes

--- a/xmtp_mls/src/messages/enrichment.rs
+++ b/xmtp_mls/src/messages/enrichment.rs
@@ -1,0 +1,168 @@
+use crate::messages::decoded_message::{DecodedMessage, MessageBody};
+use hex::ToHexExt;
+use std::collections::HashMap;
+use thiserror::Error;
+use xmtp_common::RetryableError;
+use xmtp_db::DbQuery;
+use xmtp_db::group_message::{
+    ContentType as DbContentType, RelationCounts, RelationQuery, StoredGroupMessage,
+};
+
+#[derive(Debug, Error)]
+pub enum EnrichMessageError {
+    #[error("DB error: {0}")]
+    DbConnection(#[from] xmtp_db::ConnectionError),
+    #[error("Decode error: {0}")]
+    CodecError(#[from] xmtp_content_types::CodecError),
+    #[error("Decode error: {0}")]
+    DecodeError(#[from] prost::DecodeError),
+}
+
+impl RetryableError for EnrichMessageError {
+    fn is_retryable(&self) -> bool {
+        match self {
+            Self::DbConnection(e) => e.is_retryable(),
+            Self::CodecError(_) => false,
+            Self::DecodeError(_) => false,
+        }
+    }
+}
+
+// Mapping of reactions, keyed by the ID of the message being reacted to.
+type ReactionMap = HashMap<Vec<u8>, Vec<DecodedMessage>>;
+// Mapping of referenced messages, keyed by ID
+type ReferencedMessageMap = HashMap<Vec<u8>, DecodedMessage>;
+
+pub fn enrich_messages(
+    conn: impl DbQuery,
+    group_id: &[u8],
+    messages: Vec<StoredGroupMessage>,
+) -> Result<Vec<DecodedMessage>, EnrichMessageError> {
+    let initial_message_ids: Vec<&[u8]> = messages.iter().map(|m| m.id.as_ref()).collect();
+
+    let reference_ids: Vec<&[u8]> = messages
+        .iter()
+        .filter_map(|m| m.reference_id.as_deref())
+        .collect();
+
+    let mut relations = get_relations(conn, group_id, &initial_message_ids, &reference_ids)?;
+
+    let messages: Vec<DecodedMessage> = messages
+        .into_iter()
+        .filter_map(|stored_message| {
+            let mut decoded = DecodedMessage::try_from(stored_message)
+                .inspect_err(|err| tracing::warn!("Failed to decode message {:?}", err))
+                .ok()?;
+
+            decoded.reactions = relations
+                .reactions
+                .remove(&decoded.metadata.id)
+                .unwrap_or_default();
+
+            decoded.num_replies = relations
+                .reply_counts
+                .get(&decoded.metadata.id)
+                .cloned()
+                .unwrap_or(0);
+
+            if let MessageBody::Reply(mut reply_body) = decoded.content {
+                let _ = hex::decode(&reply_body.reference_id)
+                    .inspect_err(|err| {
+                        tracing::warn!("could not parse reference ID as hex: {:?}", err)
+                    })
+                    .inspect(|id| {
+                        let in_reply_to = relations.referenced_messages.get(id).cloned();
+                        reply_body.in_reply_to = in_reply_to.map(Box::new);
+                    });
+                decoded.content = MessageBody::Reply(reply_body);
+            }
+
+            Some(decoded)
+        })
+        .collect();
+
+    Ok(messages)
+}
+
+fn get_relations(
+    conn: impl DbQuery,
+    group_id: &[u8],
+    message_ids: &[&[u8]],
+    reference_ids: &[&[u8]],
+) -> Result<GetRelationsResults, EnrichMessageError> {
+    if message_ids.is_empty() {
+        return Ok(GetRelationsResults {
+            reactions: HashMap::new(),
+            referenced_messages: HashMap::new(),
+            reply_counts: HashMap::new(),
+        });
+    }
+
+    let reactions_relations_query = RelationQuery::builder()
+        .content_types(Some(vec![DbContentType::Reaction]))
+        .build()
+        .unwrap_or_default();
+
+    let replies_count_query = RelationQuery::builder()
+        .content_types(Some(vec![DbContentType::Reply]))
+        .build()
+        .unwrap_or_default();
+
+    let reactions = conn.get_inbound_relations(group_id, message_ids, reactions_relations_query)?;
+    let referenced_messages = conn.get_outbound_relations(group_id, reference_ids)?;
+    let reply_counts =
+        conn.get_inbound_relation_counts(group_id, message_ids, replies_count_query)?;
+
+    Ok(GetRelationsResults {
+        reactions: get_reactions(reactions),
+        referenced_messages: get_referenced_messages(referenced_messages),
+        reply_counts,
+    })
+}
+
+struct GetRelationsResults {
+    reactions: ReactionMap,
+    referenced_messages: ReferencedMessageMap,
+    reply_counts: RelationCounts,
+}
+
+fn get_referenced_messages(messages: HashMap<Vec<u8>, StoredGroupMessage>) -> ReferencedMessageMap {
+    messages
+        .into_iter()
+        .filter_map(|(id, stored_message)| {
+            let message_id = id.clone();
+            DecodedMessage::try_from(stored_message)
+                .inspect_err(|err| {
+                    tracing::warn!(
+                        "Failed to decode reply root message with ID {} {:?}",
+                        message_id.encode_hex(),
+                        err
+                    );
+                })
+                .map(|decoded| (id, decoded))
+                .ok()
+        })
+        .collect()
+}
+
+fn get_reactions(messages: HashMap<Vec<u8>, Vec<StoredGroupMessage>>) -> ReactionMap {
+    messages
+        .into_iter()
+        .map(|(id, reaction_messages)| {
+            let mapped_reactions: Vec<DecodedMessage> = reaction_messages
+                .into_iter()
+                .filter_map(|stored_msg| {
+                    DecodedMessage::try_from(stored_msg)
+                        .inspect_err(|err| {
+                            tracing::warn!(
+                                "Failed to decode message categorized as Reaction: {:?}",
+                                err
+                            );
+                        })
+                        .ok()
+                })
+                .collect();
+            (id, mapped_reactions)
+        })
+        .collect()
+}

--- a/xmtp_mls/src/messages/mod.rs
+++ b/xmtp_mls/src/messages/mod.rs
@@ -1,0 +1,2 @@
+pub mod decoded_message;
+pub mod enrichment;


### PR DESCRIPTION
# Refactor Message Handling in MLS Module

This PR refactors the message handling code in the MLS module by:

1. Moving the `decoded_message.rs` file from `groups/` to a new `messages/` module
2. Creating a new `enrichment.rs` file in the `messages/` module that extracts message enrichment logic from `message_list.rs`
3. Adding a new `message_v2()` method to the client that returns an enriched `DecodedMessage`
4. Adding a new `EnrichMessageError` type to handle errors specific to message enrichment
5. Updating import paths across the codebase to reflect the new module structure

These changes improve code organization by separating message handling concerns from group management logic, making the codebase more maintainable.