### PR TITLE
Graphite Test

### DIFF
--- a/graphite-demo/server.js
+++ b/graphite-demo/server.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+// Fake data for the activity feed
+const activityFeed = [
+  {
+    id: 1000,
+    title: 'New Photo Uploaded',
+    body: 'Alice uploaded a new photo to her album.'
+  },
+  {
+    id: 2000,
+    title: 'Comment on Post',
+    body: "Bob commented on Charlie's post."
+  },
+  {
+    id: 13,
+    title: 'Status Update',
+    body: 'Charlie updated their status: "Excited about the new project!"'
+  }
+];
+
+app.get('/feed', (req, res) => {
+  res.json(activityFeed);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
### Add an activity feed API by starting a server in graphite-demo/server.js listening on port 3000 and serving a static JSON array at GET /feed
- Create an application and define a static `activityFeed` array in [server.js](https://github.com/xmtp/libxmtp/pull/2360/files#diff-d5c3b928f53ccb3225ebe5a3d21d3f7bd256109576695e5eb29abcf0419d1865)
- Register `app.get('/feed')` to respond with `res.json(activityFeed)`
- Start the process with `app.listen(3000)` and log a startup message

#### 📍Where to Start
Start with the `app.get('/feed')` route in [server.js](https://github.com/xmtp/libxmtp/pull/2360/files#diff-d5c3b928f53ccb3225ebe5a3d21d3f7bd256109576695e5eb29abcf0419d1865), then review the application initialization and `app.listen(3000)`.

----

_[Macroscope](https://app.macroscope.com) summarized 994fa4f._