### PR TITLE
check group disappearing settings when set the message expire time

### DIFF
--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -1267,7 +1267,11 @@ where
             Self::conversation_message_disappearing_settings_from_extensions(&mutable_metadata)
                 .ok()?;
 
-        Some(now_ns() + group_disappearing_settings.in_ns)
+        if group_disappearing_settings.is_enabled() {
+            Some(now_ns() + group_disappearing_settings.in_ns)
+        } else {
+            None
+        }
     }
 
     /// This function is idempotent. No need to wrap in a transaction.

--- a/xmtp_mls_common/src/group_mutable_metadata.rs
+++ b/xmtp_mls_common/src/group_mutable_metadata.rs
@@ -88,6 +88,10 @@ impl MessageDisappearingSettings {
     pub fn new(from_ns: i64, in_ns: i64) -> Self {
         Self { from_ns, in_ns }
     }
+
+    pub fn is_enabled(&self) -> bool {
+        self.from_ns > 0 && self.in_ns > 0
+    }
 }
 
 /// Represents the mutable metadata for a group.


### PR DESCRIPTION
In the message disappearing settings, we treat from_ns as always being greater than 0. If it isn’t, we consider the settings disabled. This check needs to be applied when setting the message expiration time during the expiration calculation process.