### PR TITLE
Scaffold query command

### DIFF
--- a/xmtp_debug/src/app.rs
+++ b/xmtp_debug/src/app.rs
@@ -102,7 +102,7 @@ impl App {
                 Generate(g) => generate::Generate::new(g, backend, db).run().await,
                 Send(s) => send::Send::new(s, backend, db).run().await,
                 Inspect(i) => inspect::Inspect::new(i, backend, db).run().await,
-                Query(_q) => todo!(),
+                Query(q) => query::Query::new(q, backend, db).run().await,
                 Info(i) => info::Info::new(i, backend, db).run().await,
                 Export(e) => export::Export::new(e, db, backend).run(),
                 Modify(m) => modify::Modify::new(m, backend, db).run().await,

--- a/xmtp_debug/src/app/query.rs
+++ b/xmtp_debug/src/app/query.rs
@@ -1,1 +1,46 @@
+use crate::args;
+use color_eyre::eyre::Result;
+use std::sync::Arc;
 
+pub struct Query {
+    opts: args::Query,
+    #[allow(unused)]
+    network: args::BackendOpts,
+    #[allow(unused)]
+    store: Arc<redb::Database>,
+}
+
+impl Query {
+    pub fn new(opts: args::Query, network: args::BackendOpts, store: Arc<redb::Database>) -> Self {
+        Self {
+            opts,
+            network,
+            store,
+        }
+    }
+
+    pub async fn run(self) -> Result<()> {
+        match &self.opts {
+            args::Query::Identity(opts) => self.identity(opts).await,
+            args::Query::FetchKeyPackages(opts) => self.fetch_key_packages(opts).await,
+            args::Query::BatchQueryCommitLog(opts) => self.batch_query_commit_log(opts).await,
+        }
+    }
+
+    pub async fn identity(&self, opts: &args::Identity) -> Result<()> {
+        tracing::info!("Fetching identity for inbox: {}", opts.inbox_id);
+        Ok(())
+    }
+
+    pub async fn fetch_key_packages(&self, opts: &args::FetchKeyPackages) -> Result<()> {
+        tracing::info!("Fetching key packages");
+        let _ = opts;
+        Ok(())
+    }
+
+    pub async fn batch_query_commit_log(&self, opts: &args::BatchQueryCommitLog) -> Result<()> {
+        tracing::info!("Batch querying commit log");
+        let _ = opts;
+        Ok(())
+    }
+}

--- a/xmtp_debug/src/args.rs
+++ b/xmtp_debug/src/args.rs
@@ -36,6 +36,7 @@ pub enum Commands {
     Modify(Modify),
     Inspect(Inspect),
     Send(Send),
+    #[command(subcommand)]
     Query(Query),
     Info(InfoOpts),
     Export(ExportOpts),
@@ -132,8 +133,23 @@ pub enum InspectionKind {
 }
 
 /// Query for Information about a Group or Message or User
-#[derive(Args, Debug)]
-pub struct Query {}
+#[derive(Subcommand, Debug, Clone)]
+pub enum Query {
+    Identity(Identity),
+    FetchKeyPackages(FetchKeyPackages),
+    BatchQueryCommitLog(BatchQueryCommitLog),
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct Identity {
+    pub inbox_id: InboxId,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct FetchKeyPackages {}
+
+#[derive(Args, Debug, Clone)]
+pub struct BatchQueryCommitLog {}
 
 /// Print information about the local generated state
 #[derive(Args, Debug)]


### PR DESCRIPTION
### Scaffold the `query` CLI command by wiring `xmtp_debug::app::App::run` to `xmtp_debug::app::query::Query::run` and adding the `identity`, `fetch-key-packages`, and `batch-query-commit-log` subcommands.
- Replace `todo!()` in `xmtp_debug::app::App::run` with `xmtp_debug::app::query::Query::new(q, backend, db).run().await` in [app.rs](https://github.com/xmtp/libxmtp/pull/2363/files#diff-5271efe9f61f1d96b0145caa92d489e6553e2a26818be003b9d68cd745aa5914).
- Introduce `xmtp_debug::app::query::Query` with a constructor and async `run` that dispatches to subcommand handlers in [query.rs](https://github.com/xmtp/libxmtp/pull/2363/files#diff-02228818084d108ca6d2633e4e2238c55e84687068962939d99e4276ebcf11e3).
- Implement stub handlers `identity`, `fetch_key_packages`, and `batch_query_commit_log` that log and return `Ok(())` in [query.rs](https://github.com/xmtp/libxmtp/pull/2363/files#diff-02228818084d108ca6d2633e4e2238c55e84687068962939d99e4276ebcf11e3).
- Update CLI parsing to nest `query` subcommands and add `Identity`, `FetchKeyPackages`, and `BatchQueryCommitLog` args in [args.rs](https://github.com/xmtp/libxmtp/pull/2363/files#diff-f5a20f8b0880b662184dc94120d482df9acbc8ceffc02f7e81c0d6a491d69ec3).

#### 📍Where to Start
Start with the `Commands::Query` match arm in `xmtp_debug::app::App::run` in [xmtp_debug/src/app.rs](https://github.com/xmtp/libxmtp/pull/2363/files#diff-5271efe9f61f1d96b0145caa92d489e6553e2a26818be003b9d68cd745aa5914), then review `xmtp_debug::app::query::Query::run` and its handlers in [xmtp_debug/src/app/query.rs](https://github.com/xmtp/libxmtp/pull/2363/files#diff-02228818084d108ca6d2633e4e2238c55e84687068962939d99e4276ebcf11e3).

----

_[Macroscope](https://app.macroscope.com) summarized 04c418c._