### PR TITLE
Release v1.4.0 final updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_node"
-version = "1.4.0-dev"
+version = "1.4.0"
 dependencies = [
  "chrono",
  "const-hex",
@@ -1242,7 +1242,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_wasm"
-version = "1.4.0-dev"
+version = "1.4.0"
 dependencies = [
  "alloy",
  "chrono",
@@ -8537,7 +8537,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api"
-version = "1.4.0-dev"
+version = "1.4.0"
 dependencies = [
  "async-trait",
  "const-hex",
@@ -8559,7 +8559,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_d14n"
-version = "1.4.0-dev"
+version = "1.4.0"
 dependencies = [
  "async-trait",
  "const-hex",
@@ -8587,7 +8587,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_grpc"
-version = "1.4.0-dev"
+version = "1.4.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -8611,7 +8611,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_http"
-version = "1.4.0-dev"
+version = "1.4.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8638,7 +8638,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_archive"
-version = "1.4.0-dev"
+version = "1.4.0"
 dependencies = [
  "aes-gcm",
  "async-compression",
@@ -8665,7 +8665,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_cli"
-version = "1.4.0-dev"
+version = "1.4.0"
 dependencies = [
  "alloy",
  "chrono",
@@ -8699,7 +8699,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_common"
-version = "1.4.0-dev"
+version = "1.4.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8735,7 +8735,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_configuration"
-version = "1.4.0-dev"
+version = "1.4.0"
 dependencies = [
  "openmls",
  "url",
@@ -8745,7 +8745,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_content_types"
-version = "1.4.0-dev"
+version = "1.4.0"
 dependencies = [
  "prost",
  "serde",
@@ -8760,7 +8760,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_cryptography"
-version = "1.4.0-dev"
+version = "1.4.0"
 dependencies = [
  "alloy",
  "bincode",
@@ -8784,7 +8784,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_db"
-version = "1.4.0-dev"
+version = "1.4.0"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -8825,7 +8825,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_db_test"
-version = "1.4.0-dev"
+version = "1.4.0"
 dependencies = [
  "derive_builder",
  "diesel",
@@ -8838,7 +8838,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_id"
-version = "1.4.0-dev"
+version = "1.4.0"
 dependencies = [
  "alloy",
  "async-trait",
@@ -8874,7 +8874,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_macro"
-version = "1.4.0-dev"
+version = "1.4.0"
 dependencies = [
  "num_cpus",
  "proc-macro2",
@@ -8886,7 +8886,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_mls"
-version = "1.4.0-dev"
+version = "1.4.0"
 dependencies = [
  "aes-gcm",
  "alloy",
@@ -8966,7 +8966,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_mls_common"
-version = "1.4.0-dev"
+version = "1.4.0"
 dependencies = [
  "const-hex",
  "openmls",
@@ -8984,7 +8984,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_proto"
-version = "1.4.0-dev"
+version = "1.4.0"
 dependencies = [
  "async-trait",
  "const-hex",
@@ -9012,7 +9012,7 @@ dependencies = [
 
 [[package]]
 name = "xmtpv3"
-version = "1.4.0-dev"
+version = "1.4.0"
 dependencies = [
  "alloy",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_node"
-version = "1.4.0-rc2"
+version = "1.4.0-dev"
 dependencies = [
  "chrono",
  "const-hex",
@@ -1242,7 +1242,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_wasm"
-version = "1.4.0-rc2"
+version = "1.4.0-dev"
 dependencies = [
  "alloy",
  "chrono",
@@ -8537,7 +8537,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api"
-version = "1.4.0-rc2"
+version = "1.4.0-dev"
 dependencies = [
  "async-trait",
  "const-hex",
@@ -8559,7 +8559,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_d14n"
-version = "1.4.0-rc2"
+version = "1.4.0-dev"
 dependencies = [
  "async-trait",
  "const-hex",
@@ -8587,7 +8587,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_grpc"
-version = "1.4.0-rc2"
+version = "1.4.0-dev"
 dependencies = [
  "async-trait",
  "futures",
@@ -8611,7 +8611,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_http"
-version = "1.4.0-rc2"
+version = "1.4.0-dev"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8638,7 +8638,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_archive"
-version = "1.4.0-rc2"
+version = "1.4.0-dev"
 dependencies = [
  "aes-gcm",
  "async-compression",
@@ -8665,7 +8665,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_cli"
-version = "1.4.0-rc2"
+version = "1.4.0-dev"
 dependencies = [
  "alloy",
  "chrono",
@@ -8699,7 +8699,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_common"
-version = "1.4.0-rc2"
+version = "1.4.0-dev"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8735,7 +8735,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_configuration"
-version = "1.4.0-rc2"
+version = "1.4.0-dev"
 dependencies = [
  "openmls",
  "url",
@@ -8745,7 +8745,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_content_types"
-version = "1.4.0-rc2"
+version = "1.4.0-dev"
 dependencies = [
  "prost",
  "serde",
@@ -8760,7 +8760,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_cryptography"
-version = "1.4.0-rc2"
+version = "1.4.0-dev"
 dependencies = [
  "alloy",
  "bincode",
@@ -8784,7 +8784,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_db"
-version = "1.4.0-rc2"
+version = "1.4.0-dev"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -8825,7 +8825,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_db_test"
-version = "1.4.0-rc2"
+version = "1.4.0-dev"
 dependencies = [
  "derive_builder",
  "diesel",
@@ -8838,7 +8838,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_id"
-version = "1.4.0-rc2"
+version = "1.4.0-dev"
 dependencies = [
  "alloy",
  "async-trait",
@@ -8874,7 +8874,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_macro"
-version = "1.4.0-rc2"
+version = "1.4.0-dev"
 dependencies = [
  "num_cpus",
  "proc-macro2",
@@ -8886,7 +8886,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_mls"
-version = "1.4.0-rc2"
+version = "1.4.0-dev"
 dependencies = [
  "aes-gcm",
  "alloy",
@@ -8966,7 +8966,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_mls_common"
-version = "1.4.0-rc2"
+version = "1.4.0-dev"
 dependencies = [
  "const-hex",
  "openmls",
@@ -8984,7 +8984,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_proto"
-version = "1.4.0-rc2"
+version = "1.4.0-dev"
 dependencies = [
  "async-trait",
  "const-hex",
@@ -9012,7 +9012,7 @@ dependencies = [
 
 [[package]]
 name = "xmtpv3"
-version = "1.4.0-rc2"
+version = "1.4.0-dev"
 dependencies = [
  "alloy",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ resolver = "2"
 
 [workspace.package]
 license = "MIT"
-version = "1.4.0-rc2"
+version = "1.4.0-dev"
 
 [workspace.dependencies]
 alloy = { version = "1.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ resolver = "2"
 
 [workspace.package]
 license = "MIT"
-version = "1.4.0-dev"
+version = "1.4.0"
 
 [workspace.dependencies]
 alloy = { version = "1.0", default-features = false }

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -6372,6 +6372,153 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
+    async fn test_disappearing_messages_with_0_from_ns_settings() {
+        let alix = new_test_client().await;
+        let alix_provider = alix.inner_client.context.mls_provider();
+        let bola = new_test_client().await;
+        let bola_provider = bola.inner_client.context.mls_provider();
+
+        // Step 1: Create a group
+        let alix_group = alix
+            .conversations()
+            .create_group(
+                vec![bola.account_identifier.clone()],
+                FfiCreateGroupOptions::default(),
+            )
+            .await
+            .unwrap();
+
+        // Step 2: Send a message and sync
+        alix_group
+            .send("Msg 1 from group".as_bytes().to_vec())
+            .await
+            .unwrap();
+        alix_group.sync().await.unwrap();
+
+        // Step 3: Verify initial messages
+        let mut alix_messages = alix_group
+            .find_messages(FfiListMessagesOptions::default())
+            .await
+            .unwrap();
+        assert_eq!(alix_messages.len(), 2);
+
+        // Step 4: Set disappearing settings to 5ns after the latest message and from ns 0
+        let disappearing_settings = FfiMessageDisappearingSettings::new(0, 5);
+        alix_group
+            .update_conversation_message_disappearing_settings(disappearing_settings.clone())
+            .await
+            .unwrap();
+        alix_group.sync().await.unwrap();
+
+        // Verify the settings were applied and the settings is not enabled
+        let group_from_db = alix
+            .inner_client
+            .context
+            .db()
+            .find_group(&alix_group.id())
+            .unwrap();
+        assert_eq!(
+            group_from_db
+                .clone()
+                .unwrap()
+                .message_disappear_from_ns
+                .unwrap(),
+            disappearing_settings.from_ns
+        );
+        assert_eq!(
+            group_from_db.unwrap().message_disappear_in_ns.unwrap(),
+            disappearing_settings.in_ns
+        );
+        assert!(!alix_group
+            .is_conversation_message_disappearing_enabled()
+            .unwrap());
+
+        bola.conversations()
+            .sync_all_conversations(None)
+            .await
+            .unwrap();
+
+        let bola_group_from_db = bola_provider
+            .key_store()
+            .db()
+            .find_group(&alix_group.id())
+            .unwrap();
+        assert_eq!(
+            bola_group_from_db
+                .clone()
+                .unwrap()
+                .message_disappear_from_ns
+                .unwrap(),
+            disappearing_settings.from_ns
+        );
+        assert_eq!(
+            bola_group_from_db.unwrap().message_disappear_in_ns.unwrap(),
+            disappearing_settings.in_ns
+        );
+        assert!(!alix_group
+            .is_conversation_message_disappearing_enabled()
+            .unwrap());
+
+        // Step 5: Send additional messages
+        for msg in &["Msg 2 from group", "Msg 3 from group", "Msg 4 from group"] {
+            alix_group.send(msg.as_bytes().to_vec()).await.unwrap();
+        }
+        alix_group.sync().await.unwrap();
+
+        // Step 6: Verify total message count before cleanup
+        alix_messages = alix_group
+            .find_messages(FfiListMessagesOptions::default())
+            .await
+            .unwrap();
+        let msg_counts_before_cleanup = alix_messages.len();
+
+        // Wait for cleanup to complete
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+        // Step 8: Disable disappearing messages
+        alix_group
+            .remove_conversation_message_disappearing_settings()
+            .await
+            .unwrap();
+        alix_group.sync().await.unwrap();
+
+        // Verify disappearing settings are disabled
+        let group_from_db = alix_provider
+            .key_store()
+            .db()
+            .find_group(&alix_group.id())
+            .unwrap();
+        assert_eq!(
+            group_from_db
+                .clone()
+                .unwrap()
+                .message_disappear_from_ns
+                .unwrap(),
+            0
+        );
+        assert!(!alix_group
+            .is_conversation_message_disappearing_enabled()
+            .unwrap());
+
+        assert_eq!(group_from_db.unwrap().message_disappear_in_ns.unwrap(), 0);
+
+        // Step 9: Send another message
+        alix_group
+            .send("Msg 5 from group".as_bytes().to_vec())
+            .await
+            .unwrap();
+
+        // Step 10: Verify messages after cleanup
+        alix_messages = alix_group
+            .find_messages(FfiListMessagesOptions::default())
+            .await
+            .unwrap();
+        // messages before cleanup + 1 message added for metadataUpdate + 1 message added for 1 normal message
+        assert_eq!(msg_counts_before_cleanup + 2, alix_messages.len());
+        // 3 messages got deleted, then two messages got added for metadataUpdate and one normal messaged added later
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
     async fn test_set_disappearing_messages_when_creating_group() {
         let alix = new_test_client().await;
         let alix_provider = alix.inner_client.context.mls_provider();

--- a/bindings_node/package.json
+++ b/bindings_node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/node-bindings",
-  "version": "1.4.0-dev",
+  "version": "1.4.0",
   "repository": {
     "type": "git",
     "url": "git+https://git@github.com/xmtp/libxmtp.git",

--- a/bindings_node/package.json
+++ b/bindings_node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/node-bindings",
-  "version": "1.4.0-rc2",
+  "version": "1.4.0-dev",
   "repository": {
     "type": "git",
     "url": "git+https://git@github.com/xmtp/libxmtp.git",

--- a/bindings_wasm/package.json
+++ b/bindings_wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/wasm-bindings",
-  "version": "1.4.0-dev",
+  "version": "1.4.0",
   "type": "module",
   "license": "MIT",
   "description": "WASM bindings for the libXMTP rust library",

--- a/bindings_wasm/package.json
+++ b/bindings_wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/wasm-bindings",
-  "version": "1.4.0-rc2",
+  "version": "1.4.0-dev",
   "type": "module",
   "license": "MIT",
   "description": "WASM bindings for the libXMTP rust library",

--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -1258,7 +1258,11 @@ where
             Self::conversation_message_disappearing_settings_from_extensions(&mutable_metadata)
                 .ok()?;
 
-        Some(now_ns() + group_disappearing_settings.in_ns)
+        if group_disappearing_settings.is_enabled() {
+            Some(now_ns() + group_disappearing_settings.in_ns)
+        } else {
+            None
+        }
     }
 
     /// This function is idempotent. No need to wrap in a transaction.

--- a/xmtp_mls_common/src/group_mutable_metadata.rs
+++ b/xmtp_mls_common/src/group_mutable_metadata.rs
@@ -88,6 +88,10 @@ impl MessageDisappearingSettings {
     pub fn new(from_ns: i64, in_ns: i64) -> Self {
         Self { from_ns, in_ns }
     }
+
+    pub fn is_enabled(&self) -> bool {
+        self.from_ns > 0 && self.in_ns > 0
+    }
 }
 
 /// Represents the mutable metadata for a group.


### PR DESCRIPTION
Final release 1.4 PR incorporates the following two changes from `main` to the 1.4 release branch. 

- Do not log application message errors on commit log [#2370 ](https://github.com/xmtp/libxmtp/pull/2370)
- Verify disappearing message settings before calculating msg expiration time:  [#2361](https://github.com/xmtp/libxmtp/pull/2361)
----

_[Macroscope](https://app.macroscope.com) summarized 76f919b._