### PR TITLE
impl RetryableError for !

### DIFF
--- a/common/src/retry.rs
+++ b/common/src/retry.rs
@@ -65,6 +65,12 @@ impl<E: RetryableError> RetryableError for Box<E> {
     }
 }
 
+impl RetryableError for core::convert::Infallible {
+    fn is_retryable(&self) -> bool {
+        unreachable!()
+    }
+}
+
 /// Options to specify how to retry a function
 #[derive(Debug, Clone)]
 pub struct Retry<S = ExponentialBackoff> {


### PR DESCRIPTION
### Implement `RetryableError` for the never type (`!`) by adding an implementation for `core::convert::Infallible` in [retry.rs](https://github.com/xmtp/libxmtp/pull/2368/files#diff-1fc729bbb038af084238293889e90354fb5eca3dfd6641183f6afcacfd945c24)
Add an `impl` of `RetryableError` for `core::convert::Infallible` in [common/src/retry.rs](https://github.com/xmtp/libxmtp/pull/2368/files#diff-1fc729bbb038af084238293889e90354fb5eca3dfd6641183f6afcacfd945c24), defining `RetryableError::is_retryable` with `unreachable!()`.

#### 📍Where to Start
Start with the `impl RetryableError for core::convert::Infallible` block in [common/src/retry.rs](https://github.com/xmtp/libxmtp/pull/2368/files#diff-1fc729bbb038af084238293889e90354fb5eca3dfd6641183f6afcacfd945c24), focusing on the `is_retryable` method.

----

_[Macroscope](https://app.macroscope.com) summarized fee93a3._