### PR TITLE
Do not log application message errors on commit log

### DIFF
--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -1415,8 +1415,9 @@ where
                     intent.kind
                 );
 
-                let message = message.into();
-                let maybe_validated_commit = self
+                let message: ProtocolMessage = message.into();
+                let message_type = message.content_type();
+                let validation_result = self
                     .stage_and_validate_intent(mls_group, &intent, &message, envelope)
                     .await;
 
@@ -1451,10 +1452,10 @@ where
                         identifier.previously_processed(true);
                         return Ok(());
                     }
-                    let result: Result<Option<Vec<u8>>, IntentResolutionError> = match maybe_validated_commit {
+                    let result: Result<Option<Vec<u8>>, IntentResolutionError> = match validation_result {
                         Err(err) => Err(err),
-                        Ok(commit) => {
-                            self.process_own_message(mls_group, commit, &intent, &message, envelope, &storage)
+                        Ok(validated_intent) => {
+                            self.process_own_message(mls_group, validated_intent, &intent, &message, envelope, &storage)
                         }
                     };
                     let (next_intent_state, internal_message_id) = match result {
@@ -1464,7 +1465,8 @@ where
                                 return Err(err.processing_error);
                             }
                             // TODO(rich): Add log_err! macro/trait for swallowing errors
-                            if let Err(accounting_error) = mls_group.mark_failed_commit_logged(&provider, cursor, message.epoch(), &err.processing_error) {
+                            if message_type == MlsContentType::Commit
+                                && let Err(accounting_error) = mls_group.mark_failed_commit_logged(&provider, cursor, message.epoch(), &err.processing_error) {
                                 tracing::error!("Error inserting commit entry for failed self commit: {}", accounting_error);
                             }
                             (err.next_intent_state, None)


### PR DESCRIPTION
@cameronvoell performed some thorough validation that revealed that application message intents are throwing an `IntentAlreadyProcessed` error when read back from the network, and these errors are then being logged in the local commit log.

This fix is part 1, which prevents us from logging application message errors to the local commit log. Unit test fails before this change and passes after.

~I'll fix the root cause of why messages produce an `IntentAlreadyProcessed` error in the next PR.~ I'm not able to reproduce the `IntentAlreadyProcessed` via unit tests. I think these errors were thrown during validation on an emulator because multiple threads were processing the same payload, so the first thread would succeed and the second thread failed. If that theory is correct, there's nothing to fix - just trying to work out how to prove that this is what's happening.