### PR TITLE
Clean up config.toml

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,18 +1,16 @@
-[target.wasm32-unknown-unknown]
-runner = 'wasm-bindgen-test-runner'
-rustflags = ['--cfg', 'getrandom_backend="wasm_js"']
-
 [alias]
-b = "build"
-c = "check"
-r = "run"
-t = "test"
-xdbg = "run --release --bin xdbg --"
+xdbg = "run --bin xdbg --"
 xli = "run --bin xmtp_cli --"
 update-schema = "run --bin update-schema --features update-schema"
 
-[build]
+# see: https://github.com/rust-lang/cargo/issues/5376#issuecomment-2163350032 
+# We use this instead of [build] because target.*.rustflags are merged by default
+[target."cfg(all())"]
 rustflags = ["--cfg", "tracing_unstable"]
+
+[target.wasm32-unknown-unknown]
+runner = 'wasm-bindgen-test-runner'
+rustflags = ['--cfg', 'getrandom_backend="wasm_js"']
 
 [target.aarch64-linux-android]
 rustflags = ["-Clink-arg=-Wl,-z,max-page-size=16384"]


### PR DESCRIPTION
Remove aliases.
Use target.rustflags to make use of merging.
Order target flags from most generic to least.