### PR TITLE
Order all workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,9 +56,10 @@ license = "MIT"
 version = "1.5.0-dev"
 
 [workspace.dependencies]
-alloy = { version = "1.0", default-features = false }
 aes-gcm = { version = "0.10.3", features = ["std"] }
+alloy = { version = "1.0", default-features = false }
 anyhow = "1.0"
+arc-swap = "1.7"
 async-compression = { default-features = false, version = "0.4", features = [
   "futures-io",
   "zstd",
@@ -66,45 +67,54 @@ async-compression = { default-features = false, version = "0.4", features = [
 async-trait = "0.1.77"
 base64 = "0.22"
 bincode = "1.3"
+bytes = "1.9"
 chrono = "0.4.38"
+color-eyre = "0.6"
 console_error_panic_hook = "0.1"
 const_format = "0.2"
-criterion = { version = "0.7", features = ["html_reports", "async_tokio"] }
-toxiproxy_rust = { git = "https://github.com/ephemeraHQ/toxiproxy_rust.git" }
-p256 = { version = "0.13.2", features = ["ecdsa"] }
 ctor = "0.5"
+criterion = { version = "0.7", features = ["html_reports", "async_tokio"] }
+derive_builder = "0.20"
 diesel = { version = "2.2", default-features = false }
 diesel_migrations = { version = "2.2", default-features = false }
 dyn-clone = "1"
 ed25519-dalek = { version = "2.1.1", features = ["zeroize"] }
 fdlimit = "0.3"
-rstest = "0.26"
-rstest_reuse = "0.7.0"
 futures = { version = "0.3.30", default-features = false }
+futures-timer = { version = "3.0", features = ["wasm-bindgen"] }
 futures-util = { version = "0.3", default-features = false, features = ["io"] }
 getrandom = { version = "0.3", default-features = false }
-derive_builder = "0.20"
-arc-swap = "1.7"
 gloo-timers = "0.3"
 hex = { package = "const-hex", version = "1.14" }
 hkdf = "0.12.3"
+itertools = "0.14"
 js-sys = "0.3"
 mockall = { version = "0.13" }
+mockall_double = "0.3.1"
 once_cell = "1.2"
 openmls = { git = "https://github.com/xmtp/openmls", rev = "76829d6c715ed115cf77e9086bac1f7bea15aa8a", default-features = false }
 openmls_basic_credential = { git = "https://github.com/xmtp/openmls", rev = "76829d6c715ed115cf77e9086bac1f7bea15aa8a" }
 openmls_libcrux_crypto = { git = "https://github.com/xmtp/openmls", rev = "76829d6c715ed115cf77e9086bac1f7bea15aa8a" }
 openmls_rust_crypto = { git = "https://github.com/xmtp/openmls", rev = "76829d6c715ed115cf77e9086bac1f7bea15aa8a" }
 openmls_traits = { git = "https://github.com/xmtp/openmls", rev = "76829d6c715ed115cf77e9086bac1f7bea15aa8a" }
+owo-colors = { version = "4.1" }
+p256 = { version = "0.13.2", features = ["ecdsa"] }
 parking_lot = "0.12.3"
 pbjson = "0.8"
 pbjson-types = "0.8"
+pin-project-lite = "0.2"
 prost = { version = "0.14", default-features = false }
 prost-types = { version = "0.14", default-features = false }
 # updating crates are blocked on https://github.com/dalek-cryptography/curve25519-dalek/pull/729
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 regex = "1.10.4"
+reqwest = { version = "0.12.12", default-features = false, features = [
+  "json",
+  "stream",
+] }
+rstest = "0.26"
+rstest_reuse = "0.7.0"
 serde = { version = "1.0", default-features = false }
 serde_json = { version = "1.0", default-features = false }
 sha2 = "0.10.8"
@@ -115,50 +125,40 @@ tokio-stream = { version = "0.1", default-features = false }
 tokio-util = { version = "0.7", default-features = false, features = [
   "compat",
 ] }
-uuid = "1.12"
-vergen-git2 = "1.0.2"
-web-time = "1.1"
-bytes = "1.9"
-pin-project-lite = "0.2"
-reqwest = { version = "0.12.12", default-features = false, features = [
-  "json",
-  "stream",
-] }
-itertools = "0.14"
 tonic = { version = "0.14", default-features = false }
+trait-variant = "0.1.2"
 tracing = { version = "0.1", features = ["log"] }
 tracing-logfmt = "0.3"
 tracing-subscriber = { version = "0.3", default-features = false }
-trait-variant = "0.1.2"
+toxiproxy_rust = { git = "https://github.com/ephemeraHQ/toxiproxy_rust.git" }
 url = "2.5.0"
+uuid = "1.12"
+vergen-git2 = "1.0.2"
 wasm-bindgen = "=0.2.100"
 wasm-bindgen-futures = "0.4.50"
 wasm-bindgen-test = "0.3.50"
 web-sys = "0.3"
+web-time = "1.1"
 zeroize = "1.8"
-futures-timer = { version = "3.0", features = ["wasm-bindgen"] }
-mockall_double = "0.3.1"
-owo-colors = { version = "4.1" }
-color-eyre = "0.6"
 
 # Internal Crate Dependencies
+bindings-wasm = { path = "bindings_wasm" }
 xmtp_api = { path = "xmtp_api" }
 xmtp_api_d14n = { path = "xmtp_api_d14n" }
 xmtp_api_grpc = { path = "xmtp_api_grpc" }
 xmtp_api_http = { path = "xmtp_api_http" }
 xmtp_archive = { path = "xmtp_archive" }
 xmtp_common = { path = "common" }
-xmtp_mls_common = { path = "xmtp_mls_common" }
+xmtp_configuration = { path = "xmtp_configuration" }
 xmtp_content_types = { path = "xmtp_content_types" }
 xmtp_cryptography = { path = "xmtp_cryptography" }
-xmtp_id = { path = "xmtp_id" }
-xmtp_mls = { path = "xmtp_mls" }
-xmtp_proto = { path = "xmtp_proto" }
-xmtp_macro = { path = "xmtp_macro" }
 xmtp_db = { path = "xmtp_db" }
 xmtp_db_test = { path = "xmtp_db_test" }
-xmtp_configuration = { path = "xmtp_configuration" }
-bindings-wasm = { path = "bindings_wasm" }
+xmtp_id = { path = "xmtp_id" }
+xmtp_macro = { path = "xmtp_macro" }
+xmtp_mls = { path = "xmtp_mls" }
+xmtp_mls_common = { path = "xmtp_mls_common" }
+xmtp_proto = { path = "xmtp_proto" }
 
 [profile.dbg]
 inherits = "dev"


### PR DESCRIPTION
### Reconfigure `reqwest` to disable default features and use `hyper-tls` while ordering all workspace dependencies
- Configure `reqwest` in [Cargo.toml](https://github.com/xmtp/libxmtp/pull/2373/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542) with `default-features = false` and features `["json", "stream"]`, switching the TLS backend to `hyper-tls`.
- Regenerate [Cargo.lock](https://github.com/xmtp/libxmtp/pull/2373/files#diff-13ee4b2252c9e516a0547f2891aa2105c3ca71c6d7a1e682c69be97998dfc87e) to reflect dependency changes, removing `hyper-rustls` and related transitive packages.
- Update [config.toml](https://github.com/xmtp/libxmtp/pull/2373/files#diff-9a4f3e4537ebb7474452d131b0d969d89a51286f4269aac5ef268e712be17268) to set `rustflags` under `target."cfg(all())"` with `--cfg tracing_unstable`, retain the WASM runner and `getrandom_backend` flags, and change the `cargo xdbg` alias to run the debug binary instead of the release binary.

#### 📍Where to Start
Start with the `reqwest` configuration changes in [Cargo.toml](https://github.com/xmtp/libxmtp/pull/2373/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542), then review `rustflags` and alias updates in [.cargo/config.toml](https://github.com/xmtp/libxmtp/pull/2373/files#diff-9a4f3e4537ebb7474452d131b0d969d89a51286f4269aac5ef268e712be17268).

----

_[Macroscope](https://app.macroscope.com) summarized fc6ec2d._