### PR TITLE
Refactor sync group creation

### DIFF
--- a/xmtp_db/src/encrypted_store/group/convert.rs
+++ b/xmtp_db/src/encrypted_store/group/convert.rs
@@ -1,41 +1,8 @@
 use super::*;
 use xmtp_proto::ConversionError;
-use xmtp_proto::xmtp::device_sync::group_backup::{
-    ConversationTypeSave, GroupMembershipStateSave, GroupSave,
-};
+use xmtp_proto::xmtp::device_sync::group_backup::{ConversationTypeSave, GroupMembershipStateSave};
 
 use xmtp_proto::xmtp::mls::message_contents::ConversationType as ConversationTypeProto;
-
-impl TryFrom<GroupSave> for StoredGroup {
-    type Error = ConversionError;
-    fn try_from(value: GroupSave) -> Result<Self, Self::Error> {
-        let membership_state = value.membership_state().try_into()?;
-        let conversation_type = value.conversation_type().try_into()?;
-
-        Ok(Self {
-            id: value.id,
-            created_at_ns: value.created_at_ns,
-            membership_state,
-            installations_last_checked: value.installations_last_checked,
-            added_by_inbox_id: value.added_by_inbox_id,
-            welcome_id: value.welcome_id,
-            rotated_at_ns: value.rotated_at_ns,
-            conversation_type,
-            dm_id: value.dm_id,
-            last_message_ns: value.last_message_ns,
-            message_disappear_from_ns: value.message_disappear_from_ns,
-            message_disappear_in_ns: value.message_disappear_in_ns,
-            paused_for_version: None, // TODO: Add this to the backup
-            maybe_forked: false,
-            fork_details: String::new(),
-            sequence_id: None,
-            originator_id: None,
-            should_publish_commit_log: false, // TODO(cvoell): verify we update when we receive a welcome
-            commit_log_public_key: None,
-            is_commit_log_forked: None,
-        })
-    }
-}
 
 impl TryFrom<GroupMembershipStateSave> for GroupMembershipState {
     type Error = ConversionError;

--- a/xmtp_mls/src/groups/device_sync/archive.rs
+++ b/xmtp_mls/src/groups/device_sync/archive.rs
@@ -6,8 +6,11 @@ use crate::{
 use futures::StreamExt;
 pub use xmtp_archive::*;
 use xmtp_db::{
-    StoreOrIgnore, consent_record::StoredConsentRecord, group::GroupMembershipState,
-    group_message::StoredGroupMessage, prelude::*,
+    StoreOrIgnore,
+    consent_record::StoredConsentRecord,
+    group::{ConversationType, GroupMembershipState},
+    group_message::StoredGroupMessage,
+    prelude::*,
 };
 use xmtp_mls_common::group::GroupMetadataOptions;
 use xmtp_proto::xmtp::device_sync::{BackupElement, backup_element::Element};
@@ -51,6 +54,7 @@ fn insert(element: BackupElement, context: &impl XmtpSharedContext) -> Result<()
                 context,
                 Some(&save.id),
                 GroupMembershipState::Restored,
+                ConversationType::Group,
                 PolicySet::default(),
                 GroupMetadataOptions {
                     name: attributes.get("group_name").cloned(),

--- a/xmtp_mls/src/groups/tests/test_commit_log_remote.rs
+++ b/xmtp_mls/src/groups/tests/test_commit_log_remote.rs
@@ -11,8 +11,8 @@ use prost::Message;
 use rand::Rng;
 use xmtp_db::MlsProviderExt;
 use xmtp_db::consent_record::ConsentState;
-use xmtp_db::group::GroupMembershipState;
 use xmtp_db::group::GroupQueryArgs;
+use xmtp_db::group::{ConversationType, GroupMembershipState};
 use xmtp_db::group_message::MsgQueryArgs;
 use xmtp_db::local_commit_log::{CommitType, LocalCommitLog};
 use xmtp_db::prelude::*;
@@ -111,6 +111,7 @@ async fn test_device_sync_mutable_metadata_is_overwritten() {
         &bo.context,
         Some(&a.group_id),
         GroupMembershipState::Restored,
+        ConversationType::Group,
         PolicySet::default(),
         GroupMetadataOptions {
             ..Default::default()


### PR DESCRIPTION
I need to create a new group type, and wanted to understand what exactly all of the differences are between the 'sync' and 'regular' group creation logic so that I could emulate it for the new type.

It turns out there's not much difference. Given we will now have 3 non-DM group types, I think it might be better to merge their group creation logic and explicitly mark out the differences in code, as there's risk of unexplained assumptions/differences over time if we duplicate the implementations.