### PR TITLE
Adds release issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-template.md
+++ b/.github/ISSUE_TEMPLATE/release-template.md
@@ -12,7 +12,9 @@ assignees: ''
 
 ## Included in this release
 - Feature 1
+  - Needs docs: Yes/No
 - Feature 2
+  - Needs docs: Yes/No
 - Bugfix 1
 - Bugfix 2
 


### PR DESCRIPTION
### Add a GitHub Issues release template to coordinate releases with a one-week target date range in .github/ISSUE_TEMPLATE/release-template.md
Introduce a new issue template at [release-template.md](https://github.com/xmtp/libxmtp/pull/2387/files#diff-af86880ff76202c002c80c236eeb1a26eb62a720b135ab0e24e61548fca35ba4) that sets template metadata (name 'Release Template', about text, default title format, empty labels and assignees) and defines sections for Target Release Date (with a one-week range hint), Included in this release (placeholders for features and bugfixes), and a Release Checklist covering verifying features merged to `main`, linking documentation, and linking SDK versions.

#### 📍Where to Start
Start with the new issue template in [release-template.md](https://github.com/xmtp/libxmtp/pull/2387/files#diff-af86880ff76202c002c80c236eeb1a26eb62a720b135ab0e24e61548fca35ba4).



#### Changes since #2387 opened

- Added documentation tracking fields to release issue template [9d26971]
----

_[Macroscope](https://app.macroscope.com) summarized 9d26971._