### PR TITLE
Create rust functions for replacing swift secp256k dependencies

### DIFF
--- a/bindings_ffi/Cargo.toml
+++ b/bindings_ffi/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 crate-type = ["lib", "cdylib", "staticlib"]
 
 [dependencies]
+alloy.workspace = true
 futures.workspace = true
 hex.workspace = true
 parking_lot.workspace = true
@@ -56,7 +57,6 @@ path = "bindgen/bin.rs"
 required-features = ["uniffi/cli"]
 
 [dev-dependencies]
-alloy.workspace = true
 async-trait.workspace = true
 chrono = { workspace = true }
 ctor.workspace = true

--- a/bindings_ffi/Cargo.toml
+++ b/bindings_ffi/Cargo.toml
@@ -8,7 +8,6 @@ license.workspace = true
 crate-type = ["lib", "cdylib", "staticlib"]
 
 [dependencies]
-alloy.workspace = true
 futures.workspace = true
 hex.workspace = true
 parking_lot.workspace = true
@@ -57,6 +56,7 @@ path = "bindgen/bin.rs"
 required-features = ["uniffi/cli"]
 
 [dev-dependencies]
+alloy.workspace = true
 async-trait.workspace = true
 chrono = { workspace = true }
 ctor.workspace = true

--- a/bindings_ffi/src/crypto.rs
+++ b/bindings_ffi/src/crypto.rs
@@ -1,6 +1,6 @@
-use alloy::primitives::{keccak256, eip191_hash_message, Address, B256};
-use alloy::signers::{SignerSync};
+use alloy::primitives::{eip191_hash_message, keccak256, Address, B256};
 use alloy::signers::local::PrivateKeySigner;
+use alloy::signers::SignerSync;
 use thiserror::Error;
 
 #[derive(Debug, Error, uniffi::Error)]
@@ -16,15 +16,15 @@ pub enum FfiCryptoError {
 }
 
 /// 1) Public key from 32-byte private key.
-/// Returns **65-byte uncompressed** (0x04 || X || Y) to match your Swift.
+///    Returns **65-byte uncompressed** (0x04 || X || Y)
 #[uniffi::export]
 fn secp_generate_public_key(private_key32: Vec<u8>) -> Result<Vec<u8>, FfiCryptoError> {
     if private_key32.len() != 32 {
         return Err(FfiCryptoError::InvalidLength);
     }
-    let signer = PrivateKeySigner::from_slice(&private_key32)
-        .map_err(|_| FfiCryptoError::InvalidKey)?;
-    let xy: [u8; 64] = signer.public_key().into(); // B512 -> [u8; 64] (X||Y) :contentReference[oaicite:3]{index=3}
+    let signer =
+        PrivateKeySigner::from_slice(&private_key32).map_err(|_| FfiCryptoError::InvalidKey)?;
+    let xy: [u8; 64] = signer.public_key().into(); // B512 -> [u8; 64] (X||Y)
     let mut out = Vec::with_capacity(65);
     out.push(0x04);
     out.extend_from_slice(&xy);
@@ -32,28 +32,38 @@ fn secp_generate_public_key(private_key32: Vec<u8>) -> Result<Vec<u8>, FfiCrypto
 }
 
 /// 2) Recoverable ECDSA (Ethereum-style).
-/// Returns **65 bytes r||s||v**, with **v in {0,1}** (parity bit).
-/// - if `hashing == true`: keccak256(message) then sign_hash
-/// - else: `msg` must be a 32-byte prehash
+///    Returns **65 bytes r||s||v**, with **v in {0,1}** (parity bit).
+///    - if `hashing == true`: keccak256(message) then sign_hash
+///    - else: `msg` must be a 32-byte prehash
 #[uniffi::export]
-fn secp_sign_recoverable(msg: Vec<u8>, private_key32: Vec<u8>, hashing: bool) -> Result<Vec<u8>, FfiCryptoError> {
-    if private_key32.len() != 32 { return Err(FfiCryptoError::InvalidLength); }
-    let signer = PrivateKeySigner::from_slice(&private_key32)
-        .map_err(|_| FfiCryptoError::InvalidKey)?;
+fn secp_sign_recoverable(
+    msg: Vec<u8>,
+    private_key32: Vec<u8>,
+    hashing: bool,
+) -> Result<Vec<u8>, FfiCryptoError> {
+    if private_key32.len() != 32 {
+        return Err(FfiCryptoError::InvalidLength);
+    }
+    let signer =
+        PrivateKeySigner::from_slice(&private_key32).map_err(|_| FfiCryptoError::InvalidKey)?;
 
     let digest: B256 = if hashing {
-        keccak256(&msg)                     // Keccak-256 (Ethereum) :contentReference[oaicite:4]{index=4}
+        keccak256(&msg) // Keccak-256 (Ethereum)
     } else {
-        if msg.len() != 32 { return Err(FfiCryptoError::InvalidLength); }
+        if msg.len() != 32 {
+            return Err(FfiCryptoError::InvalidLength);
+        }
         B256::from_slice(&msg)
     };
 
-    let sig = signer.sign_hash_sync(&digest).map_err(|_| FfiCryptoError::SignFailure)?; // :contentReference[oaicite:5]{index=5}
+    let sig = signer
+        .sign_hash_sync(&digest)
+        .map_err(|_| FfiCryptoError::SignFailure)?;
 
     // Compose 65 bytes manually to ensure v={0,1}
     let r = sig.r().to_be_bytes::<32>();
     let s = sig.s().to_be_bytes::<32>();
-    let v_byte = if sig.v() { 1u8 } else { 0u8 }; // parity bit as 0/1 :contentReference[oaicite:6]{index=6}
+    let v_byte = if sig.v() { 1u8 } else { 0u8 }; // parity bit as 0/1
 
     let mut out = Vec::with_capacity(65);
     out.extend_from_slice(&r);
@@ -70,12 +80,87 @@ fn ethereum_address_from_pubkey(pubkey: Vec<u8>) -> String {
         64 => &pubkey[..],
         _ => return "0x".to_string(),
     };
-    let addr = Address::from_raw_public_key(xy);   // derives keccak(XY)[12..] :contentReference[oaicite:7]{index=7}
-    format!("{addr:?}") // lowercased 0x… (Debug prints raw lower-hex without checksum) :contentReference[oaicite:8]{index=8}
+    let addr = Address::from_raw_public_key(xy); // derives keccak(XY)[12..]
+    format!("{addr:?}") // lowercased 0x… (Debug prints raw lower-hex without checksum)
 }
 
 /// 4) EIP-191 personal message hash: keccak256("\x19Ethereum Signed Message:\n{len}" || message)
 #[uniffi::export]
 fn ethereum_hash_personal(message: String) -> Result<Vec<u8>, FfiCryptoError> {
-    Ok(eip191_hash_message(message).to_vec()) // 32 bytes :contentReference[oaicite:9]{index=9}
+    Ok(eip191_hash_message(message).to_vec()) // 32 bytes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_secp_generate_public_key_and_address() {
+        // Pre-calculated test constants
+        let private_key = "90b7388a7427358cb7fc7e9042805b1942eae47ee783e627a989719da35e76fb";
+        let expected_ethereum_address = "0x34dd95109B587ca90778Cde5e2Dd87E022453699"; // Replace with actual calculated address
+
+        // Convert private key from hex string to bytes
+        let private_key_bytes = hex::decode(private_key).expect("Valid hex private key");
+
+        // Generate public key from private key
+        let public_key = secp_generate_public_key(private_key_bytes)
+            .expect("Should generate public key successfully");
+
+        // Verify public key is 65 bytes and starts with 0x04
+        assert_eq!(public_key.len(), 65);
+        assert_eq!(public_key[0], 0x04);
+
+        // Generate Ethereum address from public key
+        let generated_address = ethereum_address_from_pubkey(public_key);
+
+        // Verify the generated address matches our expected address
+        assert_eq!(
+            generated_address.to_lowercase(),
+            expected_ethereum_address.to_lowercase()
+        );
+
+        // Also test with 64-byte public key (without 0x04 prefix)
+        let public_key_64 = secp_generate_public_key(hex::decode(private_key).unwrap())
+            .expect("Should generate public key")[1..]
+            .to_vec(); // Remove 0x04 prefix
+
+        let address_from_64_bytes = ethereum_address_from_pubkey(public_key_64);
+        assert_eq!(
+            address_from_64_bytes.to_lowercase(),
+            expected_ethereum_address.to_lowercase()
+        );
+    }
+
+    #[test]
+    fn test_secp_sign_recoverable_with_known_values() {
+        // Pre-calculated test constants
+        let private_key = "90b7388a7427358cb7fc7e9042805b1942eae47ee783e627a989719da35e76fb";
+        let message = "test message";
+
+        let private_key_bytes = hex::decode(private_key).expect("Valid hex private key");
+        let message_bytes = message.as_bytes().to_vec();
+
+        // Test with hashing enabled
+        let signature =
+            secp_sign_recoverable(message_bytes.clone(), private_key_bytes.clone(), true)
+                .expect("Should sign successfully with hashing");
+
+        // Verify signature is 65 bytes
+        assert_eq!(signature.len(), 65);
+
+        // Verify recovery ID is 0 or 1
+        let recovery_id = signature[64];
+        assert!(recovery_id == 0 || recovery_id == 1);
+
+        // Test with hashing disabled (message must be 32 bytes)
+        let hash = ethereum_hash_personal(message.to_string()).expect("Should hash message");
+
+        let signature_no_hash = secp_sign_recoverable(hash, private_key_bytes, false)
+            .expect("Should sign pre-hashed message");
+
+        assert_eq!(signature_no_hash.len(), 65);
+        let recovery_id_no_hash = signature_no_hash[64];
+        assert!(recovery_id_no_hash == 0 || recovery_id_no_hash == 1);
+    }
 }

--- a/bindings_ffi/src/crypto.rs
+++ b/bindings_ffi/src/crypto.rs
@@ -28,9 +28,6 @@ impl From<ethereum::EthereumCryptoError> for FfiCryptoError {
 ///    Returns **65-byte uncompressed** (0x04 || X || Y)
 #[uniffi::export]
 fn secp_generate_public_key(private_key32: Vec<u8>) -> Result<Vec<u8>, FfiCryptoError> {
-    if private_key32.len() != 32 {
-        return Err(FfiCryptoError::InvalidLength);
-    }
     let private_key_array: [u8; 32] = private_key32
         .try_into()
         .map_err(|_| FfiCryptoError::InvalidLength)?;
@@ -48,9 +45,6 @@ fn secp_sign_recoverable(
     private_key32: Vec<u8>,
     hashing: bool,
 ) -> Result<Vec<u8>, FfiCryptoError> {
-    if private_key32.len() != 32 {
-        return Err(FfiCryptoError::InvalidLength);
-    }
     let private_key_array: [u8; 32] = private_key32
         .try_into()
         .map_err(|_| FfiCryptoError::InvalidLength)?;

--- a/bindings_ffi/src/crypto.rs
+++ b/bindings_ffi/src/crypto.rs
@@ -1,0 +1,81 @@
+use alloy::primitives::{keccak256, eip191_hash_message, Address, B256};
+use alloy::signers::{SignerSync};
+use alloy::signers::local::PrivateKeySigner;
+use thiserror::Error;
+
+#[derive(Debug, Error, uniffi::Error)]
+pub enum FfiCryptoError {
+    #[error("invalid length")]
+    InvalidLength,
+    #[error("invalid key")]
+    InvalidKey,
+    #[error("signing failure")]
+    SignFailure,
+    #[error("pubkey decompress failure")]
+    DecompressFailure,
+}
+
+/// 1) Public key from 32-byte private key.
+/// Returns **65-byte uncompressed** (0x04 || X || Y) to match your Swift.
+#[uniffi::export]
+fn secp_generate_public_key(private_key32: Vec<u8>) -> Result<Vec<u8>, FfiCryptoError> {
+    if private_key32.len() != 32 {
+        return Err(FfiCryptoError::InvalidLength);
+    }
+    let signer = PrivateKeySigner::from_slice(&private_key32)
+        .map_err(|_| FfiCryptoError::InvalidKey)?;
+    let xy: [u8; 64] = signer.public_key().into(); // B512 -> [u8; 64] (X||Y) :contentReference[oaicite:3]{index=3}
+    let mut out = Vec::with_capacity(65);
+    out.push(0x04);
+    out.extend_from_slice(&xy);
+    Ok(out)
+}
+
+/// 2) Recoverable ECDSA (Ethereum-style).
+/// Returns **65 bytes r||s||v**, with **v in {0,1}** (parity bit).
+/// - if `hashing == true`: keccak256(message) then sign_hash
+/// - else: `msg` must be a 32-byte prehash
+#[uniffi::export]
+fn secp_sign_recoverable(msg: Vec<u8>, private_key32: Vec<u8>, hashing: bool) -> Result<Vec<u8>, FfiCryptoError> {
+    if private_key32.len() != 32 { return Err(FfiCryptoError::InvalidLength); }
+    let signer = PrivateKeySigner::from_slice(&private_key32)
+        .map_err(|_| FfiCryptoError::InvalidKey)?;
+
+    let digest: B256 = if hashing {
+        keccak256(&msg)                     // Keccak-256 (Ethereum) :contentReference[oaicite:4]{index=4}
+    } else {
+        if msg.len() != 32 { return Err(FfiCryptoError::InvalidLength); }
+        B256::from_slice(&msg)
+    };
+
+    let sig = signer.sign_hash_sync(&digest).map_err(|_| FfiCryptoError::SignFailure)?; // :contentReference[oaicite:5]{index=5}
+
+    // Compose 65 bytes manually to ensure v={0,1}
+    let r = sig.r().to_be_bytes::<32>();
+    let s = sig.s().to_be_bytes::<32>();
+    let v_byte = if sig.v() { 1u8 } else { 0u8 }; // parity bit as 0/1 :contentReference[oaicite:6]{index=6}
+
+    let mut out = Vec::with_capacity(65);
+    out.extend_from_slice(&r);
+    out.extend_from_slice(&s);
+    out.push(v_byte);
+    Ok(out)
+}
+
+/// 3) Ethereum address from public key (accepts 65-byte 0x04||XY or 64-byte XY).
+#[uniffi::export]
+fn ethereum_address_from_pubkey(pubkey: Vec<u8>) -> String {
+    let xy = match pubkey.len() {
+        65 if pubkey[0] == 0x04 => &pubkey[1..],
+        64 => &pubkey[..],
+        _ => return "0x".to_string(),
+    };
+    let addr = Address::from_raw_public_key(xy);   // derives keccak(XY)[12..] :contentReference[oaicite:7]{index=7}
+    format!("{addr:?}") // lowercased 0x… (Debug prints raw lower-hex without checksum) :contentReference[oaicite:8]{index=8}
+}
+
+/// 4) EIP-191 personal message hash: keccak256("\x19Ethereum Signed Message:\n{len}" || message)
+#[uniffi::export]
+fn ethereum_hash_personal(message: String) -> Result<Vec<u8>, FfiCryptoError> {
+    Ok(eip191_hash_message(message).to_vec()) // 32 bytes :contentReference[oaicite:9]{index=9}
+}

--- a/bindings_ffi/src/lib.rs
+++ b/bindings_ffi/src/lib.rs
@@ -6,6 +6,7 @@ pub mod logger;
 pub mod message;
 pub mod mls;
 pub mod worker;
+pub mod crypto;
 
 pub use crate::inbox_owner::SigningError;
 pub use logger::{enter_debug_writer, exit_debug_writer};

--- a/bindings_ffi/src/lib.rs
+++ b/bindings_ffi/src/lib.rs
@@ -1,12 +1,12 @@
 #![recursion_limit = "256"]
 #![warn(clippy::unwrap_used)]
+pub mod crypto;
 pub mod identity;
 pub mod inbox_owner;
 pub mod logger;
 pub mod message;
 pub mod mls;
 pub mod worker;
-pub mod crypto;
 
 pub use crate::inbox_owner::SigningError;
 pub use logger::{enter_debug_writer, exit_debug_writer};

--- a/xmtp_cryptography/src/ethereum.rs
+++ b/xmtp_cryptography/src/ethereum.rs
@@ -1,0 +1,212 @@
+use alloy::primitives::{eip191_hash_message, keccak256, Address, B256};
+use alloy::signers::local::PrivateKeySigner;
+use alloy::signers::SignerSync;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum EthereumCryptoError {
+    #[error("invalid length")]
+    InvalidLength,
+    #[error("invalid key")]
+    InvalidKey,
+    #[error("signing failure")]
+    SignFailure,
+    #[error("pubkey decompress failure")]
+    DecompressFailure,
+}
+
+/// Generate uncompressed public key (65 bytes: 0x04 || X || Y) from 32-byte private key
+pub fn public_key_uncompressed(private_key32: &[u8; 32]) -> Result<[u8; 65], EthereumCryptoError> {
+    let signer =
+        PrivateKeySigner::from_slice(private_key32).map_err(|_| EthereumCryptoError::InvalidKey)?;
+    let xy: [u8; 64] = signer.public_key().into(); // B512 -> [u8; 64] (X||Y)
+
+    let mut out = [0u8; 65];
+    out[0] = 0x04;
+    out[1..].copy_from_slice(&xy);
+    Ok(out)
+}
+
+/// Generate raw XY coordinates (64 bytes) from 32-byte private key
+pub fn public_key_xy(private_key32: &[u8; 32]) -> Result<[u8; 64], EthereumCryptoError> {
+    let signer =
+        PrivateKeySigner::from_slice(private_key32).map_err(|_| EthereumCryptoError::InvalidKey)?;
+    Ok(signer.public_key().into())
+}
+
+/// Recoverable ECDSA signing (Ethereum-style)
+/// Returns 65 bytes: r||s||v where v ∈ {0,1} (parity bit)
+/// - if `hashing == true`: keccak256(message) then sign_hash
+/// - else: `msg` must be a 32-byte prehash
+pub fn sign_recoverable(
+    msg: &[u8],
+    private_key32: &[u8; 32],
+    hashing: bool,
+) -> Result<[u8; 65], EthereumCryptoError> {
+    let signer =
+        PrivateKeySigner::from_slice(private_key32).map_err(|_| EthereumCryptoError::InvalidKey)?;
+
+    let digest: B256 = if hashing {
+        keccak256(msg) // Keccak-256 (Ethereum)
+    } else {
+        if msg.len() != 32 {
+            return Err(EthereumCryptoError::InvalidLength);
+        }
+        B256::from_slice(msg)
+    };
+
+    let sig = signer
+        .sign_hash_sync(&digest)
+        .map_err(|_| EthereumCryptoError::SignFailure)?;
+
+    // Compose 65 bytes manually to ensure v={0,1}
+    let r = sig.r().to_be_bytes::<32>();
+    let s = sig.s().to_be_bytes::<32>();
+    let v_byte = if sig.v() { 1u8 } else { 0u8 }; // parity bit as 0/1
+
+    let mut out = [0u8; 65];
+    out[0..32].copy_from_slice(&r);
+    out[32..64].copy_from_slice(&s);
+    out[64] = v_byte;
+    Ok(out)
+}
+
+/// Derive Ethereum address from public key (accepts 65-byte 0x04||XY or 64-byte XY)
+pub fn address_from_pubkey(pubkey: &[u8]) -> Result<String, EthereumCryptoError> {
+    let xy = match pubkey.len() {
+        65 if pubkey[0] == 0x04 => &pubkey[1..],
+        64 => pubkey,
+        _ => return Err(EthereumCryptoError::InvalidLength),
+    };
+
+    let addr = Address::from_raw_public_key(xy); // derives keccak(XY)[12..]
+    Ok(format!("{addr:?}")) // lowercased 0x… (Debug prints raw lower-hex without checksum)
+}
+
+/// EIP-191 personal message hash: keccak256("\x19Ethereum Signed Message:\n{len}" || message)
+pub fn hash_personal(message: &str) -> [u8; 32] {
+    eip191_hash_message(message).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_public_key_generation_and_address() {
+        // Pre-calculated test constants
+        let private_key = "90b7388a7427358cb7fc7e9042805b1942eae47ee783e627a989719da35e76fb";
+        let expected_ethereum_address = "0x34dd95109b587ca90778cde5e2dd87e022453699";
+
+        // Convert private key from hex string to bytes
+        let private_key_bytes: [u8; 32] = hex::decode(private_key)
+            .expect("Valid hex private key")
+            .try_into()
+            .expect("32 bytes");
+
+        // Test uncompressed public key generation
+        let public_key_65 = public_key_uncompressed(&private_key_bytes)
+            .expect("Should generate public key successfully");
+
+        // Verify public key is 65 bytes and starts with 0x04
+        assert_eq!(public_key_65.len(), 65);
+        assert_eq!(public_key_65[0], 0x04);
+
+        // Test XY coordinates generation
+        let public_key_64 =
+            public_key_xy(&private_key_bytes).expect("Should generate XY coordinates");
+        assert_eq!(public_key_64.len(), 64);
+
+        // Verify XY matches the uncompressed key (minus prefix)
+        assert_eq!(&public_key_65[1..], &public_key_64[..]);
+
+        // Generate Ethereum address from 65-byte public key
+        let address_from_65 =
+            address_from_pubkey(&public_key_65).expect("Should derive address from 65-byte key");
+        assert_eq!(
+            address_from_65.to_lowercase(),
+            expected_ethereum_address.to_lowercase()
+        );
+
+        // Generate Ethereum address from 64-byte public key
+        let address_from_64 =
+            address_from_pubkey(&public_key_64).expect("Should derive address from 64-byte key");
+        assert_eq!(
+            address_from_64.to_lowercase(),
+            expected_ethereum_address.to_lowercase()
+        );
+    }
+
+    #[test]
+    fn test_sign_recoverable_with_known_values() {
+        // Pre-calculated test constants
+        let private_key = "90b7388a7427358cb7fc7e9042805b1942eae47ee783e627a989719da35e76fb";
+        let message = "test message";
+
+        let private_key_bytes: [u8; 32] = hex::decode(private_key)
+            .expect("Valid hex private key")
+            .try_into()
+            .expect("32 bytes");
+        let message_bytes = message.as_bytes();
+
+        // Test with hashing enabled
+        let signature = sign_recoverable(message_bytes, &private_key_bytes, true)
+            .expect("Should sign successfully with hashing");
+
+        // Verify signature is 65 bytes
+        assert_eq!(signature.len(), 65);
+
+        // Verify recovery ID is 0 or 1
+        let recovery_id = signature[64];
+        assert!(recovery_id == 0 || recovery_id == 1);
+
+        // Test with hashing disabled (message must be 32 bytes)
+        let hash = hash_personal(message);
+
+        let signature_no_hash = sign_recoverable(&hash, &private_key_bytes, false)
+            .expect("Should sign pre-hashed message");
+
+        assert_eq!(signature_no_hash.len(), 65);
+        let recovery_id_no_hash = signature_no_hash[64];
+        assert!(recovery_id_no_hash == 0 || recovery_id_no_hash == 1);
+    }
+
+    #[test]
+    fn test_hash_personal() {
+        let message = "test message";
+        let hash = hash_personal(message);
+
+        // Should always return 32 bytes
+        assert_eq!(hash.len(), 32);
+
+        // Should be deterministic
+        let hash2 = hash_personal(message);
+        assert_eq!(hash, hash2);
+
+        // Different messages should produce different hashes
+        let different_hash = hash_personal("different message");
+        assert_ne!(hash, different_hash);
+    }
+
+    #[test]
+    fn test_invalid_inputs() {
+        // Should fail with invalid key length (simulated by all zeros which is invalid)
+        let zero_key = [0u8; 32];
+        assert!(public_key_uncompressed(&zero_key).is_err());
+        assert!(public_key_xy(&zero_key).is_err());
+        assert!(sign_recoverable(b"test", &zero_key, true).is_err());
+
+        // Test invalid pubkey lengths for address derivation
+        assert!(address_from_pubkey(&[0u8; 63]).is_err()); // Too short
+        assert!(address_from_pubkey(&[0u8; 66]).is_err()); // Too long
+
+        // Test invalid 65-byte key (wrong prefix)
+        let mut invalid_65 = [0u8; 65];
+        invalid_65[0] = 0x03; // Wrong prefix
+        assert!(address_from_pubkey(&invalid_65).is_err());
+
+        // Test sign_recoverable with wrong hash length when hashing=false
+        let valid_key = [1u8; 32];
+        assert!(sign_recoverable(&[0u8; 31], &valid_key, false).is_err()); // Wrong hash length
+    }
+}

--- a/xmtp_cryptography/src/ethereum.rs
+++ b/xmtp_cryptography/src/ethereum.rs
@@ -3,6 +3,14 @@ use alloy::signers::local::PrivateKeySigner;
 use alloy::signers::SignerSync;
 use thiserror::Error;
 
+// Constants for secp256k1 and Ethereum cryptography
+const UNCOMPRESSED_PUBKEY_PREFIX: u8 = 0x04;
+const PUBKEY_UNCOMPRESSED_LEN: usize = 65;
+const PUBKEY_XY_LEN: usize = 64;
+const PRIVATE_KEY_LEN: usize = 32;
+const SIGNATURE_LEN: usize = 65;
+const HASH_LEN: usize = 32;
+
 #[derive(Debug, Error)]
 pub enum EthereumCryptoError {
     #[error("invalid length")]
@@ -16,19 +24,33 @@ pub enum EthereumCryptoError {
 }
 
 /// Generate uncompressed public key (65 bytes: 0x04 || X || Y) from 32-byte private key
-pub fn public_key_uncompressed(private_key32: &[u8; 32]) -> Result<[u8; 65], EthereumCryptoError> {
+pub fn public_key_uncompressed(
+    private_key32: &[u8; PRIVATE_KEY_LEN],
+) -> Result<[u8; PUBKEY_UNCOMPRESSED_LEN], EthereumCryptoError> {
+    // Check for zero key - mathematically invalid for secp256k1
+    if private_key32.iter().all(|&b| b == 0) {
+        return Err(EthereumCryptoError::InvalidKey);
+    }
+
     let signer =
         PrivateKeySigner::from_slice(private_key32).map_err(|_| EthereumCryptoError::InvalidKey)?;
-    let xy: [u8; 64] = signer.public_key().into(); // B512 -> [u8; 64] (X||Y)
+    let xy: [u8; PUBKEY_XY_LEN] = signer.public_key().into(); // B512 -> [u8; 64] (X||Y)
 
-    let mut out = [0u8; 65];
-    out[0] = 0x04;
+    let mut out = [0u8; PUBKEY_UNCOMPRESSED_LEN];
+    out[0] = UNCOMPRESSED_PUBKEY_PREFIX;
     out[1..].copy_from_slice(&xy);
     Ok(out)
 }
 
 /// Generate raw XY coordinates (64 bytes) from 32-byte private key
-pub fn public_key_xy(private_key32: &[u8; 32]) -> Result<[u8; 64], EthereumCryptoError> {
+pub fn public_key_xy(
+    private_key32: &[u8; PRIVATE_KEY_LEN],
+) -> Result<[u8; PUBKEY_XY_LEN], EthereumCryptoError> {
+    // Check for zero key - mathematically invalid for secp256k1
+    if private_key32.iter().all(|&b| b == 0) {
+        return Err(EthereumCryptoError::InvalidKey);
+    }
+
     let signer =
         PrivateKeySigner::from_slice(private_key32).map_err(|_| EthereumCryptoError::InvalidKey)?;
     Ok(signer.public_key().into())
@@ -40,16 +62,21 @@ pub fn public_key_xy(private_key32: &[u8; 32]) -> Result<[u8; 64], EthereumCrypt
 /// - else: `msg` must be a 32-byte prehash
 pub fn sign_recoverable(
     msg: &[u8],
-    private_key32: &[u8; 32],
+    private_key32: &[u8; PRIVATE_KEY_LEN],
     hashing: bool,
-) -> Result<[u8; 65], EthereumCryptoError> {
+) -> Result<[u8; SIGNATURE_LEN], EthereumCryptoError> {
+    // Check for zero key - mathematically invalid for secp256k1
+    if private_key32.iter().all(|&b| b == 0) {
+        return Err(EthereumCryptoError::InvalidKey);
+    }
+
     let signer =
         PrivateKeySigner::from_slice(private_key32).map_err(|_| EthereumCryptoError::InvalidKey)?;
 
     let digest: B256 = if hashing {
         keccak256(msg) // Keccak-256 (Ethereum)
     } else {
-        if msg.len() != 32 {
+        if msg.len() != HASH_LEN {
             return Err(EthereumCryptoError::InvalidLength);
         }
         B256::from_slice(msg)
@@ -64,18 +91,18 @@ pub fn sign_recoverable(
     let s = sig.s().to_be_bytes::<32>();
     let v_byte = if sig.v() { 1u8 } else { 0u8 }; // parity bit as 0/1
 
-    let mut out = [0u8; 65];
-    out[0..32].copy_from_slice(&r);
-    out[32..64].copy_from_slice(&s);
-    out[64] = v_byte;
+    let mut out = [0u8; SIGNATURE_LEN];
+    out[0..HASH_LEN].copy_from_slice(&r);
+    out[HASH_LEN..PUBKEY_XY_LEN].copy_from_slice(&s);
+    out[PUBKEY_XY_LEN] = v_byte;
     Ok(out)
 }
 
 /// Derive Ethereum address from public key (accepts 65-byte 0x04||XY or 64-byte XY)
 pub fn address_from_pubkey(pubkey: &[u8]) -> Result<String, EthereumCryptoError> {
     let xy = match pubkey.len() {
-        65 if pubkey[0] == 0x04 => &pubkey[1..],
-        64 => pubkey,
+        PUBKEY_UNCOMPRESSED_LEN if pubkey[0] == UNCOMPRESSED_PUBKEY_PREFIX => &pubkey[1..],
+        PUBKEY_XY_LEN => pubkey,
         _ => return Err(EthereumCryptoError::InvalidLength),
     };
 
@@ -84,7 +111,7 @@ pub fn address_from_pubkey(pubkey: &[u8]) -> Result<String, EthereumCryptoError>
 }
 
 /// EIP-191 personal message hash: keccak256("\x19Ethereum Signed Message:\n{len}" || message)
-pub fn hash_personal(message: &str) -> [u8; 32] {
+pub fn hash_personal(message: &str) -> [u8; HASH_LEN] {
     eip191_hash_message(message).into()
 }
 
@@ -99,7 +126,7 @@ mod tests {
         let expected_ethereum_address = "0x34dd95109b587ca90778cde5e2dd87e022453699";
 
         // Convert private key from hex string to bytes
-        let private_key_bytes: [u8; 32] = hex::decode(private_key)
+        let private_key_bytes: [u8; PRIVATE_KEY_LEN] = hex::decode(private_key)
             .expect("Valid hex private key")
             .try_into()
             .expect("32 bytes");
@@ -109,13 +136,13 @@ mod tests {
             .expect("Should generate public key successfully");
 
         // Verify public key is 65 bytes and starts with 0x04
-        assert_eq!(public_key_65.len(), 65);
-        assert_eq!(public_key_65[0], 0x04);
+        assert_eq!(public_key_65.len(), PUBKEY_UNCOMPRESSED_LEN);
+        assert_eq!(public_key_65[0], UNCOMPRESSED_PUBKEY_PREFIX);
 
         // Test XY coordinates generation
         let public_key_64 =
             public_key_xy(&private_key_bytes).expect("Should generate XY coordinates");
-        assert_eq!(public_key_64.len(), 64);
+        assert_eq!(public_key_64.len(), PUBKEY_XY_LEN);
 
         // Verify XY matches the uncompressed key (minus prefix)
         assert_eq!(&public_key_65[1..], &public_key_64[..]);
@@ -143,7 +170,7 @@ mod tests {
         let private_key = "90b7388a7427358cb7fc7e9042805b1942eae47ee783e627a989719da35e76fb";
         let message = "test message";
 
-        let private_key_bytes: [u8; 32] = hex::decode(private_key)
+        let private_key_bytes: [u8; PRIVATE_KEY_LEN] = hex::decode(private_key)
             .expect("Valid hex private key")
             .try_into()
             .expect("32 bytes");
@@ -154,10 +181,10 @@ mod tests {
             .expect("Should sign successfully with hashing");
 
         // Verify signature is 65 bytes
-        assert_eq!(signature.len(), 65);
+        assert_eq!(signature.len(), SIGNATURE_LEN);
 
         // Verify recovery ID is 0 or 1
-        let recovery_id = signature[64];
+        let recovery_id = signature[PUBKEY_XY_LEN];
         assert!(recovery_id == 0 || recovery_id == 1);
 
         // Test with hashing disabled (message must be 32 bytes)
@@ -166,8 +193,8 @@ mod tests {
         let signature_no_hash = sign_recoverable(&hash, &private_key_bytes, false)
             .expect("Should sign pre-hashed message");
 
-        assert_eq!(signature_no_hash.len(), 65);
-        let recovery_id_no_hash = signature_no_hash[64];
+        assert_eq!(signature_no_hash.len(), SIGNATURE_LEN);
+        let recovery_id_no_hash = signature_no_hash[PUBKEY_XY_LEN];
         assert!(recovery_id_no_hash == 0 || recovery_id_no_hash == 1);
     }
 
@@ -177,7 +204,7 @@ mod tests {
         let hash = hash_personal(message);
 
         // Should always return 32 bytes
-        assert_eq!(hash.len(), 32);
+        assert_eq!(hash.len(), HASH_LEN);
 
         // Should be deterministic
         let hash2 = hash_personal(message);
@@ -190,23 +217,30 @@ mod tests {
 
     #[test]
     fn test_invalid_inputs() {
-        // Should fail with invalid key length (simulated by all zeros which is invalid)
-        let zero_key = [0u8; 32];
+        // Test invalid private keys
+        let zero_key = [0u8; PRIVATE_KEY_LEN]; // All zeros - mathematically invalid
         assert!(public_key_uncompressed(&zero_key).is_err());
         assert!(public_key_xy(&zero_key).is_err());
         assert!(sign_recoverable(b"test", &zero_key, true).is_err());
 
+        // Test maximum value key (also invalid for secp256k1)
+        let max_key = [0xFFu8; PRIVATE_KEY_LEN];
+        assert!(public_key_uncompressed(&max_key).is_err());
+        assert!(public_key_xy(&max_key).is_err());
+        assert!(sign_recoverable(b"test", &max_key, true).is_err());
+
         // Test invalid pubkey lengths for address derivation
-        assert!(address_from_pubkey(&[0u8; 63]).is_err()); // Too short
-        assert!(address_from_pubkey(&[0u8; 66]).is_err()); // Too long
+        assert!(address_from_pubkey(&[0u8; PUBKEY_XY_LEN - 1]).is_err()); // Too short
+        assert!(address_from_pubkey(&[0u8; PUBKEY_UNCOMPRESSED_LEN + 1]).is_err()); // Too long
 
         // Test invalid 65-byte key (wrong prefix)
-        let mut invalid_65 = [0u8; 65];
+        let mut invalid_65 = [0u8; PUBKEY_UNCOMPRESSED_LEN];
         invalid_65[0] = 0x03; // Wrong prefix
         assert!(address_from_pubkey(&invalid_65).is_err());
 
         // Test sign_recoverable with wrong hash length when hashing=false
-        let valid_key = [1u8; 32];
-        assert!(sign_recoverable(&[0u8; 31], &valid_key, false).is_err()); // Wrong hash length
+        let valid_key = [1u8; PRIVATE_KEY_LEN];
+        assert!(sign_recoverable(&[0u8; HASH_LEN - 1], &valid_key, false).is_err());
+        // Wrong hash length
     }
 }

--- a/xmtp_cryptography/src/lib.rs
+++ b/xmtp_cryptography/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod basic_credential;
 pub mod configuration;
+pub mod ethereum;
 pub mod hash;
 pub mod rand;
 pub mod signature;


### PR DESCRIPTION
### Expose UniFFI Ethereum cryptography functions in bindings_ffi to replace Swift secp256k dependencies, adding 32-byte private key to 65-byte uncompressed public key derivation, 65-byte r||s||v recoverable signing, address derivation, and EIP-191 hashing
This change adds an Ethereum cryptography module and corresponding UniFFI exports that perform key derivation, recoverable signing, address derivation, and personal message hashing, with typed error handling and FFI-safe mappings.

- Introduce `xmtp_cryptography::ethereum` with `public_key_uncompressed`, `sign_recoverable`, `address_from_pubkey`, and `hash_personal`, returning fixed-size outputs with `EthereumCryptoError` ([ethereum.rs](https://github.com/xmtp/libxmtp/pull/2408/files#diff-012d5f771a0561a93c38bef97b1b20e22c2ab35460932e31204c263f01c32344)).
- Add `bindings_ffi::crypto` FFI wrappers `ethereum_generate_public_key`, `ethereum_sign_recoverable`, `ethereum_address_from_pubkey`, and `ethereum_hash_personal`, with `FfiCryptoError` and error mapping from `EthereumCryptoError` ([crypto.rs](https://github.com/xmtp/libxmtp/pull/2408/files#diff-5d8650eac8d3f9fc1e5178c908a4ac2a497ae4e216dd67876574418b8d19e097)).
- Export modules in [lib.rs](https://github.com/xmtp/libxmtp/pull/2408/files#diff-0e2132770c0bc812288d3b424edfe89d11228d634b0ff81daa82220fe528d69e) and [lib.rs](https://github.com/xmtp/libxmtp/pull/2408/files#diff-e043c187f5699741c6db54201bdd7267066f3d5727a55d4855063828d6161e11).

#### 📍Where to Start
Start with the FFI entry points in [crypto.rs](https://github.com/xmtp/libxmtp/pull/2408/files#diff-5d8650eac8d3f9fc1e5178c908a4ac2a497ae4e216dd67876574418b8d19e097), then follow the implementations in [ethereum.rs](https://github.com/xmtp/libxmtp/pull/2408/files#diff-012d5f771a0561a93c38bef97b1b20e22c2ab35460932e31204c263f01c32344).



#### Changes since #2408 opened

- Updated Rust documentation for `ethereum_sign_recoverable` FFI export function [7c83f32]
- Modified cryptographic function signatures to use zeroizing private keys [84f2c75]
- Added internal helper functions and zeroizing utility [84f2c75]
- Updated test suite for zeroizing private key API [84f2c75]
----

_[Macroscope](https://app.macroscope.com) summarized 84f2c75._