### PR TITLE
fix claude key param in gh action

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,7 +35,7 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@beta
         with:
-          claude_code_oauth_token: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           
           model: "claude-opus-4-1-20250805"
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,7 +34,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@beta
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
_Macroscope is automatically generating a summary of this pull request..._

<picture>
<source media="(prefers-color-scheme: dark)" srcset="https://prasso.ai/static/prassoai-pr-loader-small-dark-no-text.gif">
<img src="https://prasso.ai/static/prassoai-pr-loader-small-light-no-text.gif" alt="_Macroscope is automatically generating a summary of this pull request..._">
</picture>