### PR TITLE
Add Lens Chain support (mainnet 232)

### DIFF
--- a/xmtp_id/src/scw_verifier/chain_urls_default.json
+++ b/xmtp_id/src/scw_verifier/chain_urls_default.json
@@ -6,5 +6,6 @@
   "eip155:8453": "https://base.llamarpc.com",
   "eip155:42161": "https://arbitrum.llamarpc.com",
   "eip155:59144": "https://linea-rpc.publicnode.com",
-  "eip155:480": "https://worldchain-mainnet.g.alchemy.com/public"
+  "eip155:480": "https://worldchain-mainnet.g.alchemy.com/public",
+  "eip155:232":"https://rpc.lens.xyz"
 }


### PR DESCRIPTION
**What**
Add Lens Chain to the SCW verifier allowlist so libxmtp can validate EIP-1271 signatures for Lens v3 smart accounts.

**Changes**
`xmtp_id/src/scw_verifier/chain_urls_default.json`
  - `eip155:232` → `https://rpc.lens.xyz` (Lens Chain Mainnet)

**Why**
XMTP needs an RPC per chain to call isValidSignature on SCWs. 
Adding Lens enables per-profile (SCW) inboxes for Lens v3 identities on LC.