### PR TITLE
Add readd_status table and query methods

### DIFF
--- a/xmtp_db/migrations/2025-08-28-000637_create_readd_status/down.sql
+++ b/xmtp_db/migrations/2025-08-28-000637_create_readd_status/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE readd_status;

--- a/xmtp_db/migrations/2025-08-28-000637_create_readd_status/up.sql
+++ b/xmtp_db/migrations/2025-08-28-000637_create_readd_status/up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE readd_status (
+    "group_id" BLOB NOT NULL,
+    "installation_id" BLOB NOT NULL,
+    "requested_at_sequence_id" BIGINT,
+    "responded_at_sequence_id" BIGINT,
+    PRIMARY KEY ("group_id", "installation_id")
+);

--- a/xmtp_db/src/encrypted_store/mod.rs
+++ b/xmtp_db/src/encrypted_store/mod.rs
@@ -34,6 +34,7 @@ pub mod store;
 pub mod user_preferences;
 
 pub mod local_commit_log;
+pub mod readd_status;
 pub mod remote_commit_log;
 
 pub use self::db_connection::DbConnection;

--- a/xmtp_db/src/encrypted_store/readd_status.rs
+++ b/xmtp_db/src/encrypted_store/readd_status.rs
@@ -1,0 +1,376 @@
+use diesel::prelude::*;
+
+use super::{
+    DbConnection,
+    schema::readd_status::{self},
+};
+use crate::{ConnectionExt, impl_store};
+
+#[derive(Identifiable, Queryable, Selectable, Insertable, Debug, Clone, PartialEq, Eq)]
+#[diesel(table_name = readd_status)]
+#[diesel(primary_key(group_id, installation_id))]
+pub struct ReaddStatus {
+    pub group_id: Vec<u8>,
+    pub installation_id: Vec<u8>,
+    pub requested_at_sequence_id: Option<i64>,
+    pub responded_at_sequence_id: Option<i64>,
+}
+
+impl_store!(ReaddStatus, readd_status);
+
+pub trait QueryReaddStatus {
+    fn get_readd_status(
+        &self,
+        group_id: &[u8],
+        installation_id: &[u8],
+    ) -> Result<Option<ReaddStatus>, crate::ConnectionError>;
+
+    /// Update the requested_at_sequence_id for a given group_id and installation_id,
+    /// provided it is higher than the current value.
+    /// Inserts the row if it doesn't exist.
+    fn update_requested_at_sequence_id(
+        &self,
+        group_id: &[u8],
+        installation_id: &[u8],
+        sequence_id: i64,
+    ) -> Result<(), crate::ConnectionError>;
+
+    /// Update the responded_at_sequence_id for a given group_id and installation_id,
+    /// provided it is higher than the current value.
+    /// Inserts the row if it doesn't exist.
+    fn update_responded_at_sequence_id(
+        &self,
+        group_id: &[u8],
+        installation_id: &[u8],
+        sequence_id: i64,
+    ) -> Result<(), crate::ConnectionError>;
+}
+
+impl<C: ConnectionExt> QueryReaddStatus for DbConnection<C> {
+    fn get_readd_status(
+        &self,
+        group_id: &[u8],
+        installation_id: &[u8],
+    ) -> Result<Option<ReaddStatus>, crate::ConnectionError> {
+        use super::schema::readd_status::dsl as readd_dsl;
+        use diesel::QueryDsl;
+
+        self.raw_query_read(|conn| {
+            readd_dsl::readd_status
+                .filter(readd_dsl::group_id.eq(group_id))
+                .filter(readd_dsl::installation_id.eq(installation_id))
+                .first::<ReaddStatus>(conn)
+                .optional()
+        })
+    }
+
+    fn update_requested_at_sequence_id(
+        &self,
+        group_id: &[u8],
+        installation_id: &[u8],
+        sequence_id: i64,
+    ) -> Result<(), crate::ConnectionError> {
+        use super::schema::readd_status::dsl as readd_dsl;
+        use diesel::query_dsl::methods::FilterDsl;
+
+        let new_status = super::readd_status::ReaddStatus {
+            group_id: group_id.to_vec(),
+            installation_id: installation_id.to_vec(),
+            requested_at_sequence_id: Some(sequence_id),
+            responded_at_sequence_id: None,
+        };
+
+        self.raw_query_write(|conn| {
+            diesel::insert_into(readd_dsl::readd_status)
+                .values(&new_status)
+                .on_conflict((readd_dsl::group_id, readd_dsl::installation_id))
+                .do_update()
+                .set(readd_dsl::requested_at_sequence_id.eq(sequence_id))
+                .filter(
+                    readd_dsl::requested_at_sequence_id
+                        .is_null()
+                        .or(readd_dsl::requested_at_sequence_id.lt(sequence_id)),
+                )
+                .execute(conn)
+        })?;
+
+        Ok(())
+    }
+
+    fn update_responded_at_sequence_id(
+        &self,
+        group_id: &[u8],
+        installation_id: &[u8],
+        sequence_id: i64,
+    ) -> Result<(), crate::ConnectionError> {
+        use super::schema::readd_status::dsl as readd_dsl;
+        use diesel::query_dsl::methods::FilterDsl;
+
+        let new_status = super::readd_status::ReaddStatus {
+            group_id: group_id.to_vec(),
+            installation_id: installation_id.to_vec(),
+            requested_at_sequence_id: None,
+            responded_at_sequence_id: Some(sequence_id),
+        };
+
+        self.raw_query_write(|conn| {
+            diesel::insert_into(readd_dsl::readd_status)
+                .values(&new_status)
+                .on_conflict((readd_dsl::group_id, readd_dsl::installation_id))
+                .do_update()
+                .set(readd_dsl::responded_at_sequence_id.eq(sequence_id))
+                .filter(
+                    readd_dsl::responded_at_sequence_id
+                        .is_null()
+                        .or(readd_dsl::responded_at_sequence_id.lt(sequence_id)),
+                )
+                .execute(conn)
+        })?;
+
+        Ok(())
+    }
+}
+
+impl<T> QueryReaddStatus for &T
+where
+    T: QueryReaddStatus,
+{
+    fn get_readd_status(
+        &self,
+        group_id: &[u8],
+        installation_id: &[u8],
+    ) -> Result<Option<ReaddStatus>, crate::ConnectionError> {
+        (**self).get_readd_status(group_id, installation_id)
+    }
+
+    fn update_requested_at_sequence_id(
+        &self,
+        group_id: &[u8],
+        installation_id: &[u8],
+        sequence_id: i64,
+    ) -> Result<(), crate::ConnectionError> {
+        (**self).update_requested_at_sequence_id(group_id, installation_id, sequence_id)
+    }
+
+    fn update_responded_at_sequence_id(
+        &self,
+        group_id: &[u8],
+        installation_id: &[u8],
+        sequence_id: i64,
+    ) -> Result<(), crate::ConnectionError> {
+        (**self).update_responded_at_sequence_id(group_id, installation_id, sequence_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Store, test_utils::with_connection};
+
+    #[xmtp_common::test]
+    async fn test_get_readd_status_not_found() {
+        with_connection(|conn| {
+            let group_id = vec![1, 2, 3];
+            let installation_id = vec![4, 5, 6];
+
+            let result = conn.get_readd_status(&group_id, &installation_id).unwrap();
+            assert!(result.is_none());
+        })
+        .await;
+    }
+
+    #[xmtp_common::test]
+    async fn test_store_and_get_readd_status() {
+        with_connection(|conn| {
+            let group_id = vec![1, 2, 3];
+            let installation_id = vec![4, 5, 6];
+
+            let status = ReaddStatus {
+                group_id: group_id.clone(),
+                installation_id: installation_id.clone(),
+                requested_at_sequence_id: Some(100),
+                responded_at_sequence_id: Some(50),
+            };
+
+            // Store the status
+            status.store(conn).unwrap();
+
+            // Retrieve it
+            let retrieved = conn.get_readd_status(&group_id, &installation_id).unwrap();
+            assert!(retrieved.is_some());
+            let retrieved_status = retrieved.unwrap();
+            assert_eq!(retrieved_status.requested_at_sequence_id, Some(100));
+            assert_eq!(retrieved_status.responded_at_sequence_id, Some(50));
+        })
+        .await;
+    }
+
+    #[xmtp_common::test]
+    async fn test_update_requested_at_sequence_id_creates_new() {
+        with_connection(|conn| {
+            let group_id = vec![1, 2, 3];
+            let installation_id = vec![4, 5, 6];
+            let sequence_id = 100;
+
+            // Update on non-existing record should create it
+            conn.update_requested_at_sequence_id(&group_id, &installation_id, sequence_id)
+                .unwrap();
+
+            // Verify it was created
+            let status = conn.get_readd_status(&group_id, &installation_id).unwrap();
+            assert!(status.is_some());
+            let status = status.unwrap();
+            assert_eq!(status.requested_at_sequence_id, Some(sequence_id));
+            assert_eq!(status.responded_at_sequence_id, None);
+        })
+        .await;
+    }
+
+    #[xmtp_common::test]
+    async fn test_update_requested_at_sequence_id_updates_existing() {
+        with_connection(|conn| {
+            let group_id = vec![1, 2, 3];
+            let installation_id = vec![4, 5, 6];
+
+            // Create initial status
+            let initial_status = ReaddStatus {
+                group_id: group_id.clone(),
+                installation_id: installation_id.clone(),
+                requested_at_sequence_id: Some(50),
+                responded_at_sequence_id: Some(25),
+            };
+            initial_status.store(conn).unwrap();
+
+            // Update with higher sequence_id
+            conn.update_requested_at_sequence_id(&group_id, &installation_id, 100)
+                .unwrap();
+
+            // Verify it was updated
+            let status = conn.get_readd_status(&group_id, &installation_id).unwrap();
+            assert!(status.is_some());
+            let status = status.unwrap();
+            assert_eq!(status.requested_at_sequence_id, Some(100));
+            assert_eq!(status.responded_at_sequence_id, Some(25)); // This is preserved by the UPDATE
+        })
+        .await;
+    }
+
+    #[xmtp_common::test]
+    async fn test_update_requested_at_sequence_id_only_updates_if_higher() {
+        with_connection(|conn| {
+            let group_id = vec![1, 2, 3];
+            let installation_id = vec![4, 5, 6];
+
+            // Create initial status with high sequence_id
+            let initial_status = ReaddStatus {
+                group_id: group_id.clone(),
+                installation_id: installation_id.clone(),
+                requested_at_sequence_id: Some(100),
+                responded_at_sequence_id: Some(50),
+            };
+            initial_status.store(conn).unwrap();
+
+            // Try to update with lower sequence_id - this should be ignored
+            conn.update_requested_at_sequence_id(&group_id, &installation_id, 75)
+                .unwrap();
+
+            // Verify it was NOT updated (lower sequence_id should be ignored due to filter)
+            let status = conn.get_readd_status(&group_id, &installation_id).unwrap();
+            assert!(status.is_some());
+            let status = status.unwrap();
+            assert_eq!(status.requested_at_sequence_id, Some(100)); // Should remain unchanged
+            assert_eq!(status.responded_at_sequence_id, Some(50)); // Should remain unchanged
+        })
+        .await;
+    }
+
+    #[xmtp_common::test]
+    async fn test_update_requested_at_sequence_id_updates_from_null() {
+        with_connection(|conn| {
+            let group_id = vec![1, 2, 3];
+            let installation_id = vec![4, 5, 6];
+
+            // Create initial status with null requested_at_sequence_id
+            let initial_status = ReaddStatus {
+                group_id: group_id.clone(),
+                installation_id: installation_id.clone(),
+                requested_at_sequence_id: None,
+                responded_at_sequence_id: Some(25),
+            };
+            initial_status.store(conn).unwrap();
+
+            // Update with any sequence_id (should work since current is null)
+            conn.update_requested_at_sequence_id(&group_id, &installation_id, 50)
+                .unwrap();
+
+            // Verify it was updated
+            let status = conn.get_readd_status(&group_id, &installation_id).unwrap();
+            assert!(status.is_some());
+            let status = status.unwrap();
+            assert_eq!(status.requested_at_sequence_id, Some(50));
+            assert_eq!(status.responded_at_sequence_id, Some(25)); // This is preserved by the UPDATE
+        })
+        .await;
+    }
+
+    #[xmtp_common::test]
+    async fn test_update_responded_at_sequence_id_creates_new() {
+        with_connection(|conn| {
+            let group_id = vec![1, 2, 3];
+            let installation_id = vec![4, 5, 6];
+            let sequence_id = 100;
+
+            // Update on non-existing record should create it
+            conn.update_responded_at_sequence_id(&group_id, &installation_id, sequence_id)
+                .unwrap();
+
+            // Verify it was created
+            let status = conn.get_readd_status(&group_id, &installation_id).unwrap();
+            assert!(status.is_some());
+            let status = status.unwrap();
+            assert_eq!(status.responded_at_sequence_id, Some(sequence_id));
+            assert_eq!(status.requested_at_sequence_id, None);
+        })
+        .await;
+    }
+
+    #[xmtp_common::test]
+    async fn test_update_responded_at_sequence_id_only_updates_if_higher() {
+        with_connection(|conn| {
+            let group_id = vec![1, 2, 3];
+            let installation_id = vec![4, 5, 6];
+
+            // Create initial status with high responded_at_sequence_id
+            let initial_status = ReaddStatus {
+                group_id: group_id.clone(),
+                installation_id: installation_id.clone(),
+                requested_at_sequence_id: Some(50),
+                responded_at_sequence_id: Some(100),
+            };
+            initial_status.store(conn).unwrap();
+
+            // Try to update with lower sequence_id - this should be ignored
+            conn.update_responded_at_sequence_id(&group_id, &installation_id, 75)
+                .unwrap();
+
+            // Verify it was NOT updated (lower sequence_id should be ignored due to filter)
+            let status = conn.get_readd_status(&group_id, &installation_id).unwrap();
+            assert!(status.is_some());
+            let status = status.unwrap();
+            assert_eq!(status.responded_at_sequence_id, Some(100)); // Should remain unchanged
+            assert_eq!(status.requested_at_sequence_id, Some(50)); // Should remain unchanged
+
+            // Now update with a higher sequence_id - this should work
+            conn.update_responded_at_sequence_id(&group_id, &installation_id, 125)
+                .unwrap();
+
+            // Verify it was updated
+            let status = conn.get_readd_status(&group_id, &installation_id).unwrap();
+            assert!(status.is_some());
+            let status = status.unwrap();
+            assert_eq!(status.responded_at_sequence_id, Some(125)); // Should be updated
+            assert_eq!(status.requested_at_sequence_id, Some(50)); // Should remain unchanged
+        })
+        .await;
+    }
+}

--- a/xmtp_db/src/encrypted_store/schema_gen.rs
+++ b/xmtp_db/src/encrypted_store/schema_gen.rs
@@ -177,6 +177,15 @@ diesel::table! {
 }
 
 diesel::table! {
+    readd_status (group_id, installation_id) {
+        group_id -> Binary,
+        installation_id -> Binary,
+        requested_at_sequence_id -> Nullable<BigInt>,
+        responded_at_sequence_id -> Nullable<BigInt>,
+    }
+}
+
+diesel::table! {
     refresh_state (entity_id, entity_kind) {
         entity_id -> Binary,
         entity_kind -> Integer,
@@ -223,6 +232,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     openmls_key_store,
     openmls_key_value,
     processed_device_sync_messages,
+    readd_status,
     refresh_state,
     remote_commit_log,
     user_preferences,

--- a/xmtp_db/src/lib.rs
+++ b/xmtp_db/src/lib.rs
@@ -48,6 +48,7 @@ pub mod prelude {
     pub use super::local_commit_log::QueryLocalCommitLog;
     pub use super::pragmas::Pragmas;
     pub use super::processed_device_sync_messages::QueryDeviceSyncMessages;
+    pub use super::readd_status::QueryReaddStatus;
     pub use super::refresh_state::QueryRefreshState;
     pub use super::remote_commit_log::QueryRemoteCommitLog;
     pub use super::traits::*;

--- a/xmtp_db/src/mock.rs
+++ b/xmtp_db/src/mock.rs
@@ -224,6 +224,10 @@ mock! {
             &self,
         ) -> Result<Vec<Vec<u8>>, crate::ConnectionError>;
 
+        fn get_conversation_ids_for_requesting_readds(
+            &self,
+        ) -> Result<Vec<crate::encrypted_store::group::StoredGroupForReaddRequest>, crate::ConnectionError>;
+
         fn get_conversation_type(&self, group_id: &[u8]) -> Result<ConversationType, crate::ConnectionError>;
 
         fn set_group_commit_log_public_key(
@@ -310,6 +314,28 @@ mock! {
             intent: &crate::group_intent::StoredGroupIntent,
             msg_id: Option<Vec<u8>>,
         ) -> Result<(), StorageError>;
+    }
+
+    impl QueryReaddStatus for DbQuery {
+        fn get_readd_status(
+            &self,
+            group_id: &[u8],
+            installation_id: &[u8],
+        ) -> Result<Option<crate::readd_status::ReaddStatus>, crate::ConnectionError>;
+
+        fn update_requested_at_sequence_id(
+            &self,
+            group_id: &[u8],
+            installation_id: &[u8],
+            sequence_id: i64,
+        ) -> Result<(), crate::ConnectionError>;
+
+        fn update_responded_at_sequence_id(
+            &self,
+            group_id: &[u8],
+            installation_id: &[u8],
+            sequence_id: i64,
+        ) -> Result<(), crate::ConnectionError>;
     }
 
     impl QueryGroupMessage for DbQuery {

--- a/xmtp_db/src/traits.rs
+++ b/xmtp_db/src/traits.rs
@@ -2,6 +2,7 @@ use crate::ConnectionExt;
 use crate::StorageError;
 use crate::association_state::QueryAssociationStateCache;
 use crate::prelude::*;
+use crate::readd_status::QueryReaddStatus;
 
 /// Get an MLS Key store in the context of a transaction
 /// this must only be used within transactions.
@@ -78,6 +79,7 @@ pub trait DbQuery:
     + QueryLocalCommitLog
     + QueryRemoteCommitLog
     + QueryAssociationStateCache
+    + QueryReaddStatus
     + Pragmas
     + crate::ConnectionExt
 {
@@ -102,6 +104,7 @@ impl<T: ?Sized> DbQuery for T where
         + QueryLocalCommitLog
         + QueryRemoteCommitLog
         + QueryAssociationStateCache
+        + QueryReaddStatus
         + Pragmas
         + crate::ConnectionExt
 {


### PR DESCRIPTION
This adds a `readd_status` table, which tracks when readds were requested and responded, and methods for querying/updating it.

This and subsequent PR's follow the [design](https://community.xmtp.org/t/xip-68-draft-automated-fork-recovery/951#p-2260-fork-recovery-10) described in the fork recovery XIP. Feedback on the overall design welcome!