### PR TITLE
Receive readd requests

### DIFF
--- a/xmtp_mls/src/groups/oneshot.rs
+++ b/xmtp_mls/src/groups/oneshot.rs
@@ -1,11 +1,15 @@
 use super::{GroupError, MlsGroup, PreconfiguredPolicies};
 use crate::context::XmtpSharedContext;
-use openmls::group::StagedWelcome;
-use xmtp_db::group::ConversationType;
+use xmtp_common::snippet::Snippet;
+use xmtp_db::{
+    MlsProviderExt, XmtpMlsStorageProvider, group::ConversationType, prelude::QueryReaddStatus,
+};
 use xmtp_mls_common::{group::GroupMetadataOptions, group_metadata::GroupMetadata};
-use xmtp_proto::xmtp::mls::message_contents::OneshotMessage;
+use xmtp_proto::xmtp::mls::message_contents::{OneshotMessage, oneshot_message};
 
-impl<Context: XmtpSharedContext> MlsGroup<Context> {
+pub struct Oneshot {}
+
+impl Oneshot {
     /// Creates a oneshot group with the given message and adds the specified inbox IDs to it.
     ///
     /// A oneshot group is a special type of group that contains a single message and is used
@@ -19,13 +23,13 @@ impl<Context: XmtpSharedContext> MlsGroup<Context> {
     ///
     /// # Returns
     /// An error if sending failed, otherwise nothing
-    pub async fn send_oneshot_message(
-        context: Context,
+    pub async fn send_message<C: XmtpSharedContext>(
+        context: C,
         inbox_ids: Vec<&str>,
         oneshot_message: OneshotMessage,
     ) -> Result<(), GroupError> {
         // Create a oneshot group with the oneshot message
-        let group = Self::create_and_insert(
+        let group = MlsGroup::<C>::create_and_insert(
             context.clone(),
             ConversationType::Oneshot,
             PreconfiguredPolicies::default().to_policy_set(),
@@ -42,24 +46,46 @@ impl<Context: XmtpSharedContext> MlsGroup<Context> {
         Ok(())
     }
 
-    pub fn process_oneshot_message(
-        _context: Context,
-        _message: OneshotMessage,
+    pub fn process_message(
+        provider: &impl MlsProviderExt,
+        _sender_inbox_id: String,
+        sender_installation_id: Vec<u8>,
+        message: OneshotMessage,
     ) -> Result<(), GroupError> {
-        // TODO(rich): Handle oneshot message
+        match message.message_type {
+            Some(oneshot_message::MessageType::ReaddRequest(readd_request)) => {
+                tracing::info!(
+                    group_id = readd_request.group_id.snippet(),
+                    sender_installation_id = sender_installation_id.snippet(),
+                    latest_commit_sequence_id = readd_request.latest_commit_sequence_id,
+                    "Received readd request for group"
+                );
+                provider.key_store().db().update_requested_at_sequence_id(
+                    readd_request.group_id.as_slice(),
+                    &sender_installation_id,
+                    readd_request.latest_commit_sequence_id as i64,
+                )?;
+            }
+            _ => {
+                tracing::warn!(
+                    "Oneshot message {:?} is not a recognized message type",
+                    message.message_type
+                );
+            }
+        }
         Ok(())
     }
 
-    pub fn process_oneshot_welcome(
-        context: Context,
+    pub fn process_welcome(
+        provider: &impl MlsProviderExt,
         id: u64,
-        _welcome: StagedWelcome,
+        sender_inbox_id: String,
+        sender_installation_id: Vec<u8>,
         metadata: GroupMetadata,
     ) -> Result<(), GroupError> {
         tracing::info!("Processing oneshot welcome");
         if let Some(message) = metadata.oneshot_message {
-            // TODO(rich): Extract welcome sender from StagedWelcome
-            Self::process_oneshot_message(context, message)?;
+            Self::process_message(provider, sender_inbox_id, sender_installation_id, message)?;
         } else {
             tracing::warn!("Oneshot group welcome {} does not have oneshot message", id);
         }
@@ -76,21 +102,47 @@ mod tests {
 
     #[tokio::test]
     async fn test_receive_oneshot_message_via_syncing() {
+        use xmtp_db::prelude::QueryReaddStatus;
+
         tester!(alix);
         tester!(bo);
         tester!(caro);
 
+        let group_id = vec![1, 2, 3, 4];
+        let latest_commit_sequence_id = 42;
+
+        // Verify that Bo and Caro have no readd status for Alix initially
+        let bo_initial_status = bo
+            .context
+            .db()
+            .get_readd_status(&group_id, alix.context.installation_id().as_slice())
+            .expect("Failed to query readd status");
+        assert!(
+            bo_initial_status.is_none(),
+            "Bo should not have readd status for Alix initially"
+        );
+
+        let caro_initial_status = caro
+            .context
+            .db()
+            .get_readd_status(&group_id, alix.context.installation_id().as_slice())
+            .expect("Failed to query readd status");
+        assert!(
+            caro_initial_status.is_none(),
+            "Caro should not have readd status for Alix initially"
+        );
+
         // Create a test oneshot message (using ReaddRequest as example)
         let readd_request = ReaddRequest {
-            group_id: vec![1, 2, 3, 4],
-            latest_commit_sequence_id: 0,
+            group_id: group_id.clone(),
+            latest_commit_sequence_id,
         };
         let oneshot_message = OneshotMessage {
             message_type: Some(MessageType::ReaddRequest(readd_request.clone())),
         };
 
         // Send the oneshot message
-        MlsGroup::send_oneshot_message(
+        Oneshot::send_message(
             alix.context.clone(),
             vec![bo.inbox_id(), caro.inbox_id()],
             oneshot_message.clone(),
@@ -98,13 +150,49 @@ mod tests {
         .await
         .expect("Failed to send oneshot message");
 
+        // Bo syncs welcomes
         bo.sync_welcomes().await.expect("Failed to sync welcomes");
-        // TODO(rich): Persist to DB when receiving oneshot message, then validate it is in the DB here
-        // For now, just validate the message structure
-        assert!(oneshot_message.message_type.is_some());
-        if let Some(MessageType::ReaddRequest(request)) = oneshot_message.message_type {
-            assert_eq!(request.group_id, vec![1, 2, 3, 4]);
-        }
+
+        // Verify that Bo now has readd status for Alix with the correct sequence ID
+        let bo_status = bo
+            .context
+            .db()
+            .get_readd_status(&group_id, alix.context.installation_id().as_slice())
+            .expect("Failed to query readd status")
+            .expect("Bo should have readd status for Alix after syncing");
+
+        assert_eq!(
+            bo_status.requested_at_sequence_id,
+            Some(latest_commit_sequence_id as i64),
+            "Bo should have requested_at_sequence_id set to {}",
+            latest_commit_sequence_id
+        );
+        assert_eq!(
+            bo_status.responded_at_sequence_id, None,
+            "Bo should not have responded_at_sequence_id set"
+        );
+
+        // Caro syncs welcomes
+        caro.sync_welcomes().await.expect("Failed to sync welcomes");
+
+        // Verify that Caro now has readd status for Alix with the correct sequence ID
+        let caro_status = caro
+            .context
+            .db()
+            .get_readd_status(&group_id, alix.context.installation_id().as_slice())
+            .expect("Failed to query readd status")
+            .expect("Caro should have readd status for Alix after syncing");
+
+        assert_eq!(
+            caro_status.requested_at_sequence_id,
+            Some(latest_commit_sequence_id as i64),
+            "Caro should have requested_at_sequence_id set to {}",
+            latest_commit_sequence_id
+        );
+        assert_eq!(
+            caro_status.responded_at_sequence_id, None,
+            "Caro should not have responded_at_sequence_id set"
+        );
     }
 
     #[tokio::test]
@@ -122,7 +210,7 @@ mod tests {
         };
 
         // Alix sends the oneshot message to Bo
-        MlsGroup::send_oneshot_message(alix.context.clone(), vec![bo.inbox_id()], oneshot_message)
+        Oneshot::send_message(alix.context.clone(), vec![bo.inbox_id()], oneshot_message)
             .await
             .expect("Failed to send oneshot message");
 
@@ -163,7 +251,7 @@ mod tests {
         };
 
         // Alix sends the oneshot message to Bo
-        MlsGroup::send_oneshot_message(alix.context.clone(), vec![bo.inbox_id()], oneshot_message)
+        Oneshot::send_message(alix.context.clone(), vec![bo.inbox_id()], oneshot_message)
             .await
             .expect("Failed to send oneshot message");
 
@@ -216,7 +304,7 @@ mod tests {
         };
 
         // Alix sends the oneshot message to Bo
-        MlsGroup::send_oneshot_message(alix.context.clone(), vec![bo.inbox_id()], oneshot_message)
+        Oneshot::send_message(alix.context.clone(), vec![bo.inbox_id()], oneshot_message)
             .await
             .expect("Failed to send oneshot message");
 

--- a/xmtp_mls/src/groups/welcomes/xmtp_welcome.rs
+++ b/xmtp_mls/src/groups/welcomes/xmtp_welcome.rs
@@ -3,6 +3,7 @@
 
 use crate::groups::mls_ext::CommitLogStorer;
 use crate::groups::mls_sync::DeferredEvents;
+use crate::groups::oneshot::Oneshot;
 use crate::groups::{MetadataPermissionsError, mls_sync};
 use crate::{
     context::XmtpSharedContext,
@@ -332,7 +333,13 @@ where
             extract_group_metadata(staged_welcome.public_group().group_context().extensions())
                 .map_err(MetadataPermissionsError::from)?;
         if metadata.conversation_type == ConversationType::Oneshot {
-            MlsGroup::process_oneshot_welcome(context, welcome.id, staged_welcome, metadata)?;
+            Oneshot::process_welcome(
+                &provider,
+                welcome.id,
+                added_by_inbox_id,
+                added_by_installation_id,
+                metadata,
+            )?;
             return Ok(None);
         }
         let mls_group = OpenMlsGroup::from_welcome_logged(


### PR DESCRIPTION
This processes readd requests as part of the oneshot welcome processing flow. We use a state-driven approach where we simply update the `readd_status` table when the readd request is received, and rely on the worker to later respond to it. This helps keep the welcome processing flow light and avoid blocking more critical message processing.

This and subsequent PR's follow the [design](https://community.xmtp.org/t/xip-68-draft-automated-fork-recovery/951#p-2260-fork-recovery-10) described in the fork recovery XIP. Feedback on the overall design welcome!