### PR TITLE
Bump version of XMTPD and use new CLI

### DIFF
--- a/dev/docker/docker-compose-d14n.yml
+++ b/dev/docker/docker-compose-d14n.yml
@@ -1,6 +1,13 @@
+x-xmtpd-server-image: &x-xmtpd-server-image ghcr.io/xmtp/xmtpd:sha-56c39d6
+x-xmtpd-gateway-image: &x-xmtpd-gateway-image ghcr.io/xmtp/xmtpd-gateway:sha-56c39d6
+x-xmtpd-cli-image: &x-xmtpd-cli-image ghcr.io/xmtp/xmtpd-cli:sha-56c39d6
+x-xmtpd-contracts-image: &x-xmtpd-contracts-image ghcr.io/xmtp/contracts:v0.5.5
+x-postgres-image: &x-postgres-image postgres:16
+x-redis-image: &x-redis-image redis:7-alpine
+
 services:
   redis:
-    image: redis:7-alpine
+    image: *x-redis-image
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s
@@ -8,7 +15,7 @@ services:
       retries: 3
       start_period: 5s
   replicationdb:
-    image: postgres:16
+    image: *x-postgres-image
     environment:
       POSTGRES_PASSWORD: xmtp
     healthcheck:
@@ -18,23 +25,44 @@ services:
       retries: 5
   chain:
     platform: linux/amd64
-    image: ghcr.io/xmtp/contracts:v0.5.2
+    image: *x-xmtpd-contracts-image
   register-node:
     platform: linux/amd64
-    image: ghcr.io/xmtp/xmtpd-cli:sha-7538ae5
+    image: *x-xmtpd-cli-image
     env_file:
       - local.env
-    command: ["register-node", "--http-address=${REGISTER_NODE_HTTP_ADDRESS}", "--node-owner-address=${REGISTER_NODE_OWNER_ADDRESS}", "--admin.private-key=${REGISTER_NODE_ADMIN_KEY}", "--node-signing-key-pub=${REGISTER_NODE_PUBKEY}"]
+    volumes:
+      - ../environments/anvil.json:/cfg/anvil.json
+    command:
+      [
+        "--config-file=/cfg/anvil.json",
+        "--private-key=${REGISTER_NODE_ADMIN_KEY}",
+        "--rpc-url=${XMTPD_SETTLEMENT_CHAIN_RPC_URL}",
+        "nodes", "register",
+        "--owner-address=${REGISTER_NODE_OWNER_ADDRESS}",
+        "--signing-key-pub=${REGISTER_NODE_PUBKEY}",
+        "--http-address=${REGISTER_NODE_HTTP_ADDRESS}"
+      ]
     depends_on:
       chain:
         condition: service_started
     restart: on-failure
   enable-node:
     platform: linux/amd64
-    image: ghcr.io/xmtp/xmtpd-cli:sha-7538ae5
+    image: *x-xmtpd-cli-image
     env_file:
       - local.env
-    command: ["add-node-to-network", "--admin.private-key=${REGISTER_NODE_ADMIN_KEY}", "--node-id=100"]
+    volumes:
+      - ../environments/anvil.json:/cfg/anvil.json
+    command:
+      [
+        "--config-file=/cfg/anvil.json",
+        "--private-key=${REGISTER_NODE_ADMIN_KEY}",
+        "--rpc-url=${XMTPD_SETTLEMENT_CHAIN_RPC_URL}",
+        "nodes", "canonical-network",
+        "--add",
+        "--node-id=100"
+      ]
     depends_on:
       chain:
         condition: service_started
@@ -43,9 +71,13 @@ services:
     restart: on-failure
   repnode:
     platform: linux/amd64
-    image: ghcr.io/xmtp/xmtpd:sha-7538ae5
+    image: *x-xmtpd-server-image
     env_file:
       - local.env
+    volumes:
+      - ../environments/anvil.json:/cfg/anvil.json
+    environment:
+      - "XMTPD_CONTRACTS_CONFIG_FILE_PATH=/cfg/anvil.json"
     depends_on:
       enable-node:
         condition: service_completed_successfully
@@ -56,9 +88,13 @@ services:
       - 5055:5055
   gateway:
     platform: linux/amd64
-    image: ghcr.io/xmtp/xmtpd-gateway:sha-7538ae5
+    image: *x-xmtpd-gateway-image
     env_file:
       - local.env
+    volumes:
+      - ../environments/anvil.json:/cfg/anvil.json
+    environment:
+      - "XMTPD_CONTRACTS_CONFIG_FILE_PATH=/cfg/anvil.json"
     depends_on:
       redis:
         condition: service_healthy

--- a/dev/docker/local.env
+++ b/dev/docker/local.env
@@ -1,7 +1,6 @@
 # Replication Node Configuration
 XMTPD_SIGNER_PRIVATE_KEY=0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
 XMTPD_PAYER_PRIVATE_KEY=0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
-XMTPD_CONTRACTS_CONFIG_JSON={"appChainDeploymentBlock":0,"appChainFactory":"0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512","appChainGateway":"0x0000000000000000000000000000000000000000","appChainId":31337,"appChainParameterRegistry":"0x1aF9c0a400767fA5156F11D125014974517d1b71","deployer":"0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266","distributionManager":"0x644024442d659Db13dCc84C785D040065c666A77","feeToken":"0x8bC46814343DAb8Ef394311f1b9A064f2a9E38b8","groupMessageBroadcaster":"0xB86b994859Fe97b2A23236EF9548041671db6718","identityUpdateBroadcaster":"0x08AEB6338Fd56dF6343B01C72576379E6b184078","nodeRegistry":"0x5CBdf3Db993931B7DED3b116489764ee25052442","payerRegistry":"0x28A39815cc3E5c91Cac463C08907C792A57113D4","payerReportManager":"0x0bA60F0d5eccA31A76644e708afcA506EaF9da23","rateRegistry":"0x94d4DaC20c2CFBc588B495B31f71d007B62F0da0","settlementChainDeploymentBlock":0,"settlementChainFactory":"0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512","settlementChainGateway":"0x0000000000000000000000000000000000000000","settlementChainId":31337,"settlementChainParameterRegistry":"0x1aF9c0a400767fA5156F11D125014974517d1b71","underlyingFeeToken":"0x20d28A690751f90Cd24D9EAaCF5dcDBD794fE6A5"}
 XMTPD_REPLICATION_ENABLE=true
 XMTPD_INDEXER_ENABLE=true
 XMTPD_SYNC_ENABLE=true
@@ -15,8 +14,10 @@ REGISTER_NODE_PUBKEY=0x02ba5734d8f7091719471e7f7ed6b9df170dc70cc661ca05e688601ad
 # Note: we are using docker compose variable substitution for commands, not docker container substitution
 # This means that the variables need to be accessible to the compose file, not passed to the container
 REGISTER_NODE_HTTP_ADDRESS=http://repnode:5050
+XMTPD_APP_CHAIN_RPC_URL=http://chain:8545
 XMTPD_APP_CHAIN_WSS_URL=ws://chain:8545
-XMTPD_DB_WRITER_CONNECTION_STRING=postgres://postgres:xmtp@replicationdb:5432/postgres?sslmode=disable
+XMTPD_SETTLEMENT_CHAIN_RPC_URL=http://chain:8545
 XMTPD_SETTLEMENT_CHAIN_WSS_URL=ws://chain:8545
+XMTPD_DB_WRITER_CONNECTION_STRING=postgres://postgres:xmtp@replicationdb:5432/postgres?sslmode=disable
 XMTPD_MLS_VALIDATION_GRPC_ADDRESS=http://validation:50051
 XMTPD_REDIS_URL="redis://redis:6379/0"

--- a/dev/environments/anvil.json
+++ b/dev/environments/anvil.json
@@ -1,0 +1,22 @@
+{
+  "appChainDeploymentBlock": 0,
+  "appChainFactory": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
+  "appChainGateway": "0x0000000000000000000000000000000000000000",
+  "appChainId": 31337,
+  "appChainParameterRegistry": "0x83aD99435C03Fb0578B20c25e4Df69fcc5F5e2a8",
+  "deployer": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+  "distributionManager": "0xE5D692F4c2218681be871814308a5bF31b0fd3df",
+  "feeToken": "0xB56cc4D36aCBaABa136F2aB4bE0CBe0F8C705AEd",
+  "groupMessageBroadcaster": "0xf73b19777c7133dEa8a7C4BA0Af4D262C4acF59e",
+  "identityUpdateBroadcaster": "0x3A467A50B06E97bb24A368a3D1930891C9c530Cb",
+  "nodeRegistry": "0xC513d81c8b24ec211BCeb038E55b04Ed18532847",
+  "payerRegistry": "0x825944Ce505949160cd3B9359A39b97e4609CF26",
+  "payerReportManager": "0x88D71d88cc3559b21A4d958D8E8dC76d0a07412E",
+  "rateRegistry": "0x43F5e7895A5446114aCc6922cd6f1dF4c66c75C4",
+  "settlementChainDeploymentBlock": 0,
+  "settlementChainFactory": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
+  "settlementChainGateway": "0x0000000000000000000000000000000000000000",
+  "settlementChainId": 31337,
+  "settlementChainParameterRegistry": "0x83aD99435C03Fb0578B20c25e4Df69fcc5F5e2a8",
+  "underlyingFeeToken": "0x2BbdCA34b3751c43F96bBDef2E26b509669F4f6f"
+}


### PR DESCRIPTION
### Update dev stack in [docker-compose-d14n.yml](https://github.com/xmtp/libxmtp/pull/2439/files#diff-f3b95b320e721deae58c0f228c225c5dc895a08336200f71f989ac0764d95776) to bump XMTPD images to sha-56c39d6 and contracts to v0.5.5 and use the new CLI for `register-node` and `enable-node` commands
- Add image anchors and update service images in [docker-compose-d14n.yml](https://github.com/xmtp/libxmtp/pull/2439/files#diff-f3b95b320e721deae58c0f228c225c5dc895a08336200f71f989ac0764d95776), bumping xmtpd-related images to `sha-56c39d6` and contracts to `v0.5.5`.
- Replace legacy commands with new CLI invocations for `register-node` (`nodes register` with `--config-file`, `--private-key`, `--rpc-url`, `--owner`, `--signing-key-pub`, `--http-address`) and `enable-node` (`nodes canonical-network --add --node-id=100`) in [docker-compose-d14n.yml](https://github.com/xmtp/libxmtp/pull/2439/files#diff-f3b95b320e721deae58c0f228c225c5dc895a08336200f71f989ac0764d95776).
- Mount `dev/environments/anvil.json` at `/cfg/anvil.json` and set `XMTPD_CONTRACTS_CONFIG_FILE_PATH=/cfg/anvil.json` for `repnode` and `gateway` in [docker-compose-d14n.yml](https://github.com/xmtp/libxmtp/pull/2439/files#diff-f3b95b320e721deae58c0f228c225c5dc895a08336200f71f989ac0764d95776).
- Remove `XMTPD_CONTRACTS_CONFIG_JSON` and add `XMTPD_APP_CHAIN_RPC_URL` and `XMTPD_SETTLEMENT_CHAIN_RPC_URL` in [local.env](https://github.com/xmtp/libxmtp/pull/2439/files#diff-e38cb3bb4b11354071f335632640f38034c9360d74a49702c65aca2fdfab3f31).
- Add contracts configuration file [anvil.json](https://github.com/xmtp/libxmtp/pull/2439/files#diff-88c3cfe1e54eada0ee89bd90b61152ffa372ae06e03cd28131ab004db20e7075) for local development.

#### 📍Where to Start
Start with the updated service definitions and CLI commands for `register-node` and `enable-node` in [docker-compose-d14n.yml](https://github.com/xmtp/libxmtp/pull/2439/files#diff-f3b95b320e721deae58c0f228c225c5dc895a08336200f71f989ac0764d95776).

----

_[Macroscope](https://app.macroscope.com) summarized 5c29204._