### PR TITLE
[WIP] Message subscription overhaul

### DIFF
--- a/xmtp_mls/Cargo.toml
+++ b/xmtp_mls/Cargo.toml
@@ -217,10 +217,6 @@ required-features = ["bench"]
 harness = false
 name = "messages"
 required-features = ["bench"]
-[[bench]]
-harness = false
-name = "sync_conversations"
-required-features = ["bench"]
 
 [[test]]
 harness = true

--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -13,7 +13,8 @@ use crate::{
     utils::{VersionInfo, events::EventWorker},
     worker::WorkerRunner,
 };
-use std::sync::{Arc, atomic::Ordering};
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock, atomic::Ordering};
 use thiserror::Error;
 use tokio::sync::broadcast;
 use tracing::debug;
@@ -246,6 +247,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             },
             workers: workers.clone(),
             sync_api_client,
+            shared_last_streamed: Arc::new(RwLock::new(HashMap::new())),
         });
 
         // register workers

--- a/xmtp_mls/src/groups/tests/test_welcomes.rs
+++ b/xmtp_mls/src/groups/tests/test_welcomes.rs
@@ -67,6 +67,7 @@ async fn test_spoofed_inbox_id() {
         scw_verifier: alix.context.scw_verifier.clone(),
         device_sync: alix.context.device_sync.clone(),
         workers: alix.context.workers.clone(),
+        shared_last_streamed: alix.context.shared_last_streamed.clone(),
     });
     let group = MlsGroup::create_and_insert(
         malicious_context,

--- a/xmtp_mls/src/subscriptions/mod.rs
+++ b/xmtp_mls/src/subscriptions/mod.rs
@@ -505,7 +505,7 @@ pub(crate) mod tests {
         };
     }
 
-    /// A macro for asserting that a stream yields a specific decrypted message.
+    /// A macro for asserting that a stream yields any message
     ///
     /// # Example
     /// ```rust

--- a/xmtp_mls/src/subscriptions/process_message.rs
+++ b/xmtp_mls/src/subscriptions/process_message.rs
@@ -8,9 +8,9 @@
 pub mod factory;
 
 use super::Result;
-use crate::context::XmtpSharedContext;
 use crate::groups::summary::MessageIdentifierBuilder;
-use factory::{GroupDatabase, GroupDb, MessageProcessor, Syncer};
+use crate::{context::XmtpSharedContext, subscriptions::process_message::factory::GroupDatabase};
+use factory::{GroupDb, MessageProcessor, Syncer};
 use xmtp_common::FutureWrapper;
 use xmtp_db::group_message::StoredGroupMessage;
 use xmtp_proto::types::Cursor;
@@ -22,6 +22,7 @@ pub trait ProcessFutureFactory<'a> {
         msg: xmtp_proto::types::GroupMessage,
     ) -> FutureWrapper<'a, Result<ProcessedMessage>>;
     /// Try to retrieve a message
+    #[allow(dead_code)]
     fn retrieve(&self, msg: &xmtp_proto::types::GroupMessage)
     -> Result<Option<StoredGroupMessage>>;
 }
@@ -42,6 +43,7 @@ where
         FutureWrapper::new(future)
     }
     /// Try to retrieve a message
+    #[allow(dead_code)]
     fn retrieve(
         &self,
         msg: &xmtp_proto::types::GroupMessage,

--- a/xmtp_mls/src/subscriptions/stream_all/tests.rs
+++ b/xmtp_mls/src/subscriptions/stream_all/tests.rs
@@ -143,6 +143,7 @@ async fn test_dm_stream_all_messages() {
         .find_or_create_dm_by_inbox_id(bo.inbox_id(), None)
         .await
         .unwrap();
+
     // TODO: This test does not work on web
     // unless these streams are in their own scope.
     // there's probably an issue with the old stream
@@ -163,7 +164,7 @@ async fn test_dm_stream_all_messages() {
             .send_message("second GROUP msg".as_bytes(), SendMessageOpts::default())
             .await
             .unwrap();
-        assert_msg!(stream, "second GROUP msg");
+        assert_msg!(stream, "first GROUP msg");
     }
     {
         // Start a stream with only dms
@@ -180,6 +181,8 @@ async fn test_dm_stream_all_messages() {
             .send_message("second DM msg".as_bytes(), SendMessageOpts::default())
             .await
             .unwrap();
+        futures::pin_mut!(stream);
+        assert_msg!(stream, "first DM msg");
         assert_msg!(stream, "second DM msg");
     }
     // Start a stream with all conversations

--- a/xmtp_mls/src/subscriptions/stream_messages/types.rs
+++ b/xmtp_mls/src/subscriptions/stream_messages/types.rs
@@ -1,10 +1,11 @@
 use std::collections::HashMap;
 
-use crate::subscriptions::SubscribeError;
-use futures::{StreamExt, TryStreamExt, stream};
-use xmtp_api::{ApiClientWrapper, GroupFilter, XmtpApi};
+use xmtp_api::GroupFilter;
 use xmtp_configuration::Originators;
+use xmtp_db::{prelude::QueryRefreshState, refresh_state::EntityKind};
 use xmtp_proto::types::{Cursor, GroupId};
+
+use crate::{context::XmtpSharedContext, subscriptions::SubscribeError};
 
 #[derive(thiserror::Error, Debug)]
 pub enum MessageStreamError {
@@ -14,11 +15,11 @@ pub enum MessageStreamError {
     InvalidPayload,
 }
 
-/// the position of this message in the backend topic
+/// the position of this group in the backend topic
 /// based only upon messages from the stream
 #[derive(Default, Clone, PartialEq, Eq)]
 pub struct MessagePosition {
-    started_at: HashMap<u32, u64>,
+    last_synced: HashMap<u32, u64>,
     /// last mesasage we got from the network
     /// If we get a message before this cursor, we should
     /// check if we synced after that cursor, and should
@@ -30,21 +31,27 @@ pub struct MessagePosition {
 impl std::fmt::Debug for MessagePosition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MessagePosition")
-            .field("started_at", &self.started_at)
+            .field("last_synced", &self.last_synced)
             .field("last_streamed", &self.last_streamed)
             .finish()
     }
 }
 
 impl MessagePosition {
-    pub fn new(cursor: Cursor, started_at: Cursor) -> Self {
-        let mut last_map = HashMap::new();
-        last_map.insert(cursor.originator_id, cursor.sequence_id);
-        let mut started_map = HashMap::new();
-        started_map.insert(started_at.originator_id, started_at.sequence_id);
+    pub fn new(last_synced_cursor: Cursor, last_streamed_cursor: Cursor) -> Self {
+        let mut synced_map = HashMap::new();
+        synced_map.insert(
+            last_synced_cursor.originator_id,
+            last_synced_cursor.sequence_id,
+        );
+        let mut last_streamed_map = HashMap::new();
+        last_streamed_map.insert(
+            last_streamed_cursor.originator_id,
+            last_streamed_cursor.sequence_id,
+        );
         Self {
-            last_streamed: last_map,
-            started_at: started_map,
+            last_streamed: last_streamed_map,
+            last_synced: synced_map,
         }
     }
     /// Updates the cursor position for this message.
@@ -79,58 +86,34 @@ impl MessagePosition {
         self.last_streamed.clone()
     }
 
-    pub(crate) fn started(&self) -> HashMap<u32, u64> {
-        self.started_at.clone()
+    pub(crate) fn synced(&self) -> HashMap<u32, u64> {
+        self.last_synced.clone()
     }
 
-    /// stream started after this cursor
-    pub(crate) fn started_after(&self, cursor: Cursor) -> bool {
-        let sid = self
-            .started_at
-            .get(&cursor.originator_id)
-            .copied()
-            .unwrap_or(0);
-        sid > cursor.sequence_id
-    }
+    // /// stream started after this cursor
+    // pub(crate) fn synced_after(&self, cursor: Cursor) -> bool {
+    //     let sid = self
+    //         .last_synced
+    //         .get(&cursor.originator_id)
+    //         .copied()
+    //         .unwrap_or(0);
+    //     sid > cursor.sequence_id
+    // }
 
-    /// stream started before this cursor
-    pub(crate) fn started_before(&self, cursor: Cursor) -> bool {
-        let sid = self
-            .started_at
-            .get(&cursor.originator_id)
-            .copied()
-            .unwrap_or(0);
-        sid < cursor.sequence_id
-    }
+    // /// last sync before the stream started was before this cursor
+    // pub(crate) fn synced_before(&self, cursor: Cursor) -> bool {
+    //     let sid = self
+    //         .last_synced
+    //         .get(&cursor.originator_id)
+    //         .copied()
+    //         .unwrap_or(0);
+    //     sid < cursor.sequence_id
+    // }
 }
 
 impl std::fmt::Display for MessagePosition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self.last_streamed())
-    }
-}
-
-pub(super) trait Api {
-    /// get the latest message for a cursor
-    async fn query_latest_position(
-        &self,
-        group: &GroupId,
-    ) -> Result<MessagePosition, SubscribeError>;
-}
-
-impl<A> Api for ApiClientWrapper<A>
-where
-    A: XmtpApi,
-{
-    async fn query_latest_position(
-        &self,
-        group: &GroupId,
-    ) -> Result<MessagePosition, SubscribeError> {
-        if let Some(msg) = self.query_latest_group_message(group).await? {
-            Ok(MessagePosition::new(msg.cursor, msg.cursor))
-        } else {
-            Ok(MessagePosition::new(Default::default(), Default::default()))
-        } // there is no cursor for this group yet
     }
 }
 
@@ -140,25 +123,40 @@ pub(super) struct GroupList {
 }
 
 impl GroupList {
-    pub(super) async fn new(list: Vec<GroupId>, api: &impl Api) -> Result<Self, SubscribeError> {
-        let list = stream::iter(list)
-            .map(|group| async {
-                let position = api.query_latest_position(&group).await?;
-                Ok((group, position))
-            })
-            .buffer_unordered(8)
-            .try_fold(HashMap::new(), async move |mut map, (group, position)| {
-                map.insert(group, position);
-                Ok::<_, SubscribeError>(map)
-            })
-            .await?;
-        Ok(Self { list })
+    pub(super) fn new(
+        list: Vec<GroupId>,
+        ctx: &impl XmtpSharedContext,
+    ) -> Result<Self, SubscribeError> {
+        let db = ctx.db();
+        let mut existing_positions = db.get_last_cursor_for_ids(&list, EntityKind::Group)?;
+
+        let mut group_list = HashMap::new();
+
+        for group_id in list {
+            let db_cursor = existing_positions.remove(group_id.as_ref()).unwrap_or(0) as u64;
+
+            // Query shared last_streamed mapping
+            let last_streamed = ctx
+                .get_shared_last_streamed(group_id.as_ref())
+                .unwrap_or(db_cursor); // fallback to db cursor if not found
+
+            let message_position = MessagePosition::new(
+                // TODO:(nm) This will 100% break with decentralization
+                Cursor::v3_messages(db_cursor),     // last_streamed
+                Cursor::v3_messages(last_streamed), // started
+            );
+            group_list.insert(group_id, message_position);
+        }
+
+        Ok(Self { list: group_list })
     }
 
     pub(super) fn filters(&self) -> Vec<GroupFilter> {
         self.list
             .iter()
             .map(|(group_id, cursor)| {
+                // This will be the higher of the DB cursor or the last streamed message
+                // to handle resuming streams
                 let map = cursor.last_streamed();
                 let sid = map
                     .get(&(Originators::MLS_COMMITS as u32))

--- a/xmtp_mls/src/subscriptions/stream_messages/unit_tests.rs
+++ b/xmtp_mls/src/subscriptions/stream_messages/unit_tests.rs
@@ -1,0 +1,318 @@
+use std::task::Poll;
+
+use futures::stream::StreamExt;
+
+use crate::subscriptions::stream_messages::StreamGroupMessages;
+use crate::{subscriptions::stream_messages::test_case_builder::*, test::mock::MockMlsGroup};
+use futures::FutureExt;
+use futures::Stream;
+use rstest::*;
+use std::borrow::Cow;
+
+#[rstest]
+#[case(vec![
+        StreamSession::session(
+            vec![1, 2, 3, 4],
+            vec![
+                MessageCase::found(10, 1, 15),
+                MessageCase::not_found(15, 1, 20),
+                MessageCase::found(20, 1, 25),
+                MessageCase::found(25, 1, 30),
+            ],
+            vec![10, 20, 25]
+        )
+    ])]
+#[case(vec![
+        StreamSession::session(
+            vec![1, 2, 3, 4],
+            vec![
+                MessageCase::found(10, 1, 15),
+                MessageCase::not_found(15, 1, 20),
+                MessageCase::not_found(20, 1, 25),
+                MessageCase::found(25, 1, 30),
+            ],
+            vec![10, 25]
+        )
+    ])]
+#[case::nothing_found(vec![
+        StreamSession::session(
+            vec![1, 2, 3, 4],
+            vec![
+                MessageCase::not_found(10, 1, 15),
+                MessageCase::not_found(15, 1, 20),
+                MessageCase::not_found(20, 1, 25),
+                MessageCase::not_found(25, 1, 30),
+            ],
+            vec![]
+        )
+    ])]
+#[case::first_is_found(vec![
+        StreamSession::session(
+            vec![1, 2, 3, 4],
+            vec![
+                MessageCase::found(10, 1, 15),
+                MessageCase::not_found(15, 1, 20),
+                MessageCase::not_found(20, 1, 25),
+                MessageCase::not_found(25, 1, 30),
+
+            ],
+            vec![10]
+        )
+    ])]
+#[xmtp_common::test]
+async fn it_can_stream_messages(#[case] mut cases: Vec<StreamSession>) {
+    use std::borrow::Cow;
+
+    let group_list = group_list_from_session(&cases);
+    let mut sequence = StreamSequenceBuilder::default();
+    for case in cases.iter().cloned() {
+        sequence.session(case);
+    }
+    let (factory, finished) = sequence.finish();
+    let mut stream = StreamGroupMessages::new_with_factory(
+        Cow::Borrowed(&finished.context),
+        group_list,
+        factory,
+    )
+    .await
+    .unwrap();
+
+    for session in cases.iter_mut() {
+        session.expected.reverse();
+        while !session.expected.is_empty() {
+            let item = stream.next().await.unwrap().unwrap();
+            assert_eq!(
+                item.sequence_id,
+                Some(session.expected.pop().unwrap() as i64)
+            )
+        }
+    }
+
+    // the stream should end
+    #[allow(clippy::never_loop)]
+    while stream.next().await.is_some() {
+        panic!("nothing should be left on the stream");
+    }
+}
+
+#[rstest]
+#[case(vec![
+        StreamSession::session(
+            vec![1, 2, 3, 4],
+            vec![
+                MessageCase::found(1, 1, 0),
+                MessageCase::found(2, 1, 2),
+                MessageCase::found(3, 1, 3),
+                MessageCase::found(4, 1, 5),
+            ],
+            vec![1, 2, 3, 4]
+        ),
+        StreamSession::session(
+            vec![5],
+            vec![
+                MessageCase::found(5, 1, 0),
+                MessageCase::found(6, 5, 7)
+            ],
+            vec![5, 6]
+        )
+    ])]
+#[case(vec![
+        StreamSession::session(
+            vec![1, 2, 3, 4],
+            vec![
+                MessageCase::found(1, 1, 0),
+                MessageCase::found(2, 1, 2),
+                MessageCase::found(3, 1, 3),
+                MessageCase::found(4, 1, 5),
+            ],
+            vec![1, 2, 3, 4]
+        ),
+        StreamSession::session(
+            vec![5, 6, 7],
+            vec![
+                MessageCase::not_found(5, 1, 0),
+                MessageCase::found(6, 1, 0),
+                MessageCase::found(7, 5, 7)
+            ],
+            vec![6, 7]
+        )
+    ])]
+//  #[case(vec![
+//      StreamSession::session(
+//          vec![1, 2, 3, 4],
+//          vec![
+//              MessageCase::found(1, 1, 2),
+//              MessageCase::found(2, 1, 3),
+//              MessageCase::found(3, 1, 4),
+//              MessageCase::not_found(4, 1, 5),
+//          ],
+//          vec![1, 2, 3, 4]
+//      ),
+//      StreamSession::session(
+//          vec![5, 6, 7],
+//          vec![
+//              MessageCase::not_found(5, 1, 6),
+//              MessageCase::found(6, 1, 99),
+//              MessageCase::found(7, 5, 7)
+//          ],
+//          vec![6, 7]
+//      )
+//  ])]
+#[xmtp_common::test]
+async fn test_adding_to_stream_works(#[case] cases: Vec<StreamSession>) {
+    use std::borrow::Cow;
+
+    use xmtp_db::group::ConversationType;
+
+    let group_list = group_list_from_session(&cases);
+    let mut sequence = StreamSequenceBuilder::default();
+    for case in cases.iter().cloned() {
+        sequence.session(case);
+    }
+    let (factory, finished) = sequence.finish();
+    let stream = StreamGroupMessages::new_with_factory(
+        Cow::Borrowed(&finished.context),
+        group_list,
+        factory,
+    )
+    .await
+    .unwrap();
+    let mut stream = std::pin::pin!(stream);
+
+    let mut first = true;
+    for mut session in cases {
+        if !first {
+            // if its not the first session, add the groups
+            for group in session.groups {
+                stream.as_mut().add(MockMlsGroup::new(
+                    finished.context.clone(),
+                    group_id(group.group_id).to_vec(),
+                    None,
+                    ConversationType::Group,
+                    xmtp_common::time::now_ns(),
+                ))
+            }
+        }
+        first = false;
+        session.expected.reverse();
+        while !session.expected.is_empty() {
+            let item = stream.next().await.unwrap().unwrap();
+            let exp = session.expected.pop().unwrap();
+            assert_eq!(item.sequence_id, Some(exp as i64));
+        }
+    }
+}
+
+#[rstest]
+#[case(vec![
+        StreamSession::session(
+            vec![1, 2, 3, 4],
+            vec![
+                MessageCase::found(1, 1, 2),
+                MessageCase::found(2, 1, 3),
+                MessageCase::found(3, 1, 4),
+                MessageCase::processing_for(4, 1, 5, 3),
+            ],
+            vec![1, 2, 3]
+        ),
+        StreamSession::session(
+            vec![5],
+            vec![
+                MessageCase::found(5, 1, 0),
+                MessageCase::found(6, 5, 7)
+            ],
+            vec![4, 5, 6]
+        )
+    ])]
+#[case(vec![
+    StreamSession::session(
+        vec![1, 2, 3, 4],
+        vec![
+            MessageCase::found(1, 1, 2),
+            MessageCase::found(2, 1, 3),
+            MessageCase::found(3, 1, 4),
+            MessageCase::processing_for(4, 1, 5, 3),
+        ],
+        vec![1, 2, 3]
+    ),
+    StreamSession::session(
+        vec![5, 6, 7, 8],
+        vec![
+            MessageCase::found(5, 1, 99),
+            MessageCase::processing_for(6, 8, 10, 3),
+            MessageCase::found(9, 5, 10)
+        ],
+        vec![4, 5, 6, 9]
+    )
+])]
+#[xmtp_common::test]
+async fn it_can_add_to_stream_while_busy(#[case] mut cases: Vec<StreamSession>) {
+    use xmtp_db::group::ConversationType;
+
+    let group_list = group_list_from_session(&cases);
+    let mut sequence = StreamSequenceBuilder::default();
+    for case in cases.iter().cloned() {
+        sequence.session(case);
+    }
+    let (factory, finished) = sequence.finish();
+    let stream = StreamGroupMessages::new_with_factory(
+        Cow::Borrowed(&finished.context),
+        group_list,
+        factory,
+    )
+    .now_or_never()
+    .unwrap()
+    .unwrap();
+    futures::pin_mut!(stream);
+
+    let noop_waker = futures::task::noop_waker();
+    let mut cx = std::task::Context::from_waker(&noop_waker);
+
+    let mut first = true;
+    let cases_length = cases.len();
+    for (i, session) in cases.iter_mut().enumerate() {
+        // if its not the first session, add the groups
+        if !first {
+            tracing::info!("new session!");
+            let pending = stream.as_mut().poll_next(&mut cx);
+            assert!(pending.is_pending());
+            for group in &session.groups {
+                stream.as_mut().add(MockMlsGroup::new(
+                    finished.context.clone(),
+                    group_id(group.group_id).to_vec(),
+                    None,
+                    ConversationType::Group,
+                    xmtp_common::time::now_ns(),
+                ))
+            }
+        }
+        first = false;
+
+        session.expected.reverse();
+        tracing::info!("Expecting {:?} cursors", session.expected);
+        while !session.expected.is_empty() {
+            match stream.as_mut().poll_next(&mut cx) {
+                Poll::Ready(Some(Ok(i))) => {
+                    if let Some(e) = session.expected.pop() {
+                        tracing::info!("got {}", e);
+                        assert_eq!(i.sequence_id, Some(e as i64));
+                    } else {
+                        break;
+                    }
+                }
+                Poll::Ready(None) => {
+                    if cases_length >= i {
+                        break;
+                    } else {
+                        panic!("stream should not finish");
+                    }
+                }
+                Poll::Pending => {
+                    tracing::trace!("session pending");
+                    continue;
+                }
+                e => panic!("Unexpected {:?}", e),
+            }
+        }
+    }
+}

--- a/xmtp_mls/src/test/mock.rs
+++ b/xmtp_mls/src/test/mock.rs
@@ -1,5 +1,6 @@
-use std::sync::Arc;
+use std::collections::HashMap;
 use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, RwLock};
 
 use crate::context::XmtpSharedContext;
 use crate::groups::MlsGroup;
@@ -84,6 +85,7 @@ impl Clone for NewMockContext {
             scw_verifier: self.scw_verifier.clone(),
             device_sync: self.device_sync.clone(),
             workers: self.workers.clone(),
+            shared_last_streamed: self.shared_last_streamed.clone(),
         }
     }
 }
@@ -150,5 +152,32 @@ impl XmtpSharedContext for NewMockContext {
 
     fn sync_api(&self) -> &ApiClientWrapper<Self::ApiClient> {
         &self.sync_api_client
+    }
+
+    fn shared_last_streamed(&self) -> &Arc<RwLock<HashMap<Vec<u8>, u64>>> {
+        &self.shared_last_streamed
+    }
+
+    fn update_shared_last_streamed(&self, group_id: &[u8], cursor: u64) {
+        if let Ok(mut mapping) = self.shared_last_streamed.write() {
+            let group_key = group_id.to_vec();
+
+            // Only update if new cursor is greater than existing
+            if let Some(existing) = mapping.get(&group_key) {
+                if cursor > *existing {
+                    mapping.insert(group_key, cursor);
+                }
+            } else {
+                mapping.insert(group_key, cursor);
+            }
+        }
+    }
+
+    fn get_shared_last_streamed(&self, group_id: &[u8]) -> Option<u64> {
+        if let Ok(mapping) = self.shared_last_streamed.read() {
+            mapping.get(group_id).copied()
+        } else {
+            None
+        }
     }
 }

--- a/xmtp_mls/src/test/mock/generate.rs
+++ b/xmtp_mls/src/test/mock/generate.rs
@@ -1,4 +1,5 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, RwLock};
 
 use xmtp_common::{Generate, rand_vec};
 use xmtp_db::{MemoryStorage, group_message::StoredGroupMessage, sql_key_store::SqlKeyStore};
@@ -33,6 +34,7 @@ pub fn context() -> NewMockContext {
         workers: WorkerRunner::new(),
         mls_storage: SqlKeyStore::new(MemoryStorage::new()),
         sync_api_client: ApiClientWrapper::new(MockApiClient::new(), Default::default()),
+        shared_last_streamed: Arc::new(RwLock::new(HashMap::new())),
     }
 }
 


### PR DESCRIPTION
## tl;dr

- Overhauls streams to return any messages sent after the last sync
- Maintains state of the last seen message - for the lifetime of the client instance - of the last streamed message per group

## Expected usage

This change allows for a much more straightforward sync/stream strategy for most app devs

1. On app startup, sync_all for any conversations you are interested in (allowed, unknown, etc) to move the cursors
2. `stream_all`​ for the same set of conversation filters
3. If the stream is interrupted, just restart it and you will get all missing messages. No need to sync again

## Notes

- This leads to some also-not-super-intuitive behavior. If you receive a message in one stream, you won't receive the same message in another stream that was created after. If both streams were created before the message was sent, you will receive it in both.
- If you call sync before opening a stream, any messages picked up in the sync won't appear in the stream. If you don't sync before, you will get those messages in the stream

## Is this a breaking change?