### PR TITLE
Add Zed editor support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,9 +23,7 @@
     "async-stream": ["stream", "try_stream"]
   },
   "gitlens.blame.ignoreWhitespace": true,
-  "coverage-gutters.coverageFileNames": [
-    "coverage/lcov",
-  ],
+  "coverage-gutters.coverageFileNames": ["coverage/lcov"],
   "coverage-gutters.coverageReportFileName": "coverage/html/index.html",
   "[toml]": {
     "editor.defaultFormatter": "tamasfe.even-better-toml"

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,66 @@
+{
+  "file_types": {
+    "Rust": ["**/*.rs"]
+  },
+  "languages": {
+    "Rust": {
+      "language_servers": ["rust-analyzer"],
+      "format_on_save": "on"
+    },
+    "TypeScript": {
+      "formatter": "prettier"
+    },
+    "JavaScript": {
+      "formatter": "prettier"
+    },
+    "JSON": {
+      "formatter": "prettier"
+    }
+  },
+  "lsp": {
+    "rust-analyzer": {
+      "initialization_options": {
+        "cargo": {
+          "sysroot": "discover",
+          "allTargets": true,
+          "buildScripts": {
+            "enable": true
+          },
+          "features": ["bench", "test-utils"]
+        },
+        "check": {
+          "command": "check",
+          "allTargets": true,
+          "features": ["bench", "test-utils"]
+        },
+        "linkedProjects": ["Cargo.toml"],
+        "procMacro": {
+          "enable": true,
+          "attributes": {
+            "enable": true
+          },
+          "ignored": {
+            "tracing": ["instrument"],
+            "napi-derive": ["napi"],
+            "async-recursion": ["async_recursion"],
+            "ctor": ["ctor"],
+            "tokio": ["test"],
+            "async-stream": ["stream", "try_stream"]
+          }
+        },
+        "diagnostics": {
+          "enable": true,
+          "disabled": [
+            "unlinked-file",
+            "unresolved-macro-call",
+            "unresolved-proc-macro",
+            "macro-error"
+          ]
+        },
+        "files": {
+          "excludeDirs": ["bindings_wasm"]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## tl;dr

- Add support for the Zed editor

## Notes

I just had the Zed LLM try and translate the VSCode editor settings. In my 5 minutes of superficial testing, all the usual Rust Analyzer features seem to be present now. 

Don't take this as a full endorsement of [Zed](https://zed.dev). I haven't tried it long enough to have strong opinions but it does seem very fast.