### PR TITLE
(Ignore)

### DIFF
--- a/xmtp_mls/src/groups/group_membership.rs
+++ b/xmtp_mls/src/groups/group_membership.rs
@@ -112,6 +112,8 @@ impl From<&GroupMembership> for Vec<u8> {
     }
 }
 
+/// Represents changes to the group membership extension/metadata
+/// Does NOT include installations being removed and readded (see `InstallationDiff`)
 #[derive(Debug, Clone)]
 pub struct MembershipDiff<'inbox_id> {
     pub added_inboxes: Vec<&'inbox_id String>,

--- a/xmtp_mls/src/groups/intents.rs
+++ b/xmtp_mls/src/groups/intents.rs
@@ -294,18 +294,22 @@ pub(crate) struct UpdateGroupMembershipIntentData {
     pub membership_updates: HashMap<String, u64>,
     pub removed_members: Vec<String>,
     pub failed_installations: Vec<Vec<u8>>,
+    pub installations_to_readd: Vec<Vec<u8>>,
 }
 
 impl UpdateGroupMembershipIntentData {
+    // TODO(rich): Does failed_installations need to be accurate here?
     pub fn new(
         membership_updates: HashMap<String, u64>,
         removed_members: Vec<String>,
         failed_installations: Vec<Vec<u8>>,
+        installations_to_readd: Vec<Vec<u8>>,
     ) -> Self {
         Self {
             membership_updates,
             removed_members,
             failed_installations,
+            installations_to_readd,
         }
     }
 
@@ -313,6 +317,7 @@ impl UpdateGroupMembershipIntentData {
         self.membership_updates.is_empty()
             && self.removed_members.is_empty()
             && self.failed_installations.is_empty()
+            && self.installations_to_readd.is_empty()
     }
 
     pub fn apply_to_group_membership(&self, group_membership: &GroupMembership) -> GroupMembership {

--- a/xmtp_mls/src/groups/validated_commit.rs
+++ b/xmtp_mls/src/groups/validated_commit.rs
@@ -384,6 +384,7 @@ impl ValidatedCommit {
 
         // Get the expected diff of installations added and removed based on the difference between the current
         // group membership and the new group membership.
+        // Does not account for readded installations.
         // Also gets back the added and removed inbox ids from the expected diff
         let expected_diff =
             ExpectedDiff::from_staged_commit(context, staged_commit, openmls_group).await?;
@@ -399,6 +400,7 @@ impl ValidatedCommit {
             !added_installations.is_empty() || !removed_installations.is_empty();
 
         // Ensure that the expected diff matches the added/removed installations in the proposals
+        // TODO(rich): Account for readd installations here, apply bookkeeping
         expected_diff_matches_commit(
             &expected_installation_diff,
             added_installations,
@@ -604,6 +606,9 @@ fn get_latest_group_membership(
     extract_group_membership(staged_commit.group_context().extensions())
 }
 
+/// The expected diff of installations added and removed based on the difference between the current
+/// [`GroupMembership`] and the [`GroupMembership`] found in the [`StagedCommit`].
+/// Does not account for readded installations.
 struct ExpectedDiff {
     new_group_membership: GroupMembership,
     expected_installation_diff: InstallationDiff,
@@ -641,6 +646,7 @@ impl ExpectedDiff {
 
     /// Generates an expected diff of installations added and removed based on the difference between the current
     /// [`GroupMembership`] and the [`GroupMembership`] found in the [`StagedCommit`].
+    /// Does not account for readded installations.
     /// This requires loading the Inbox state from the network.
     /// Satisfies Rule 2
     async fn extract_expected_diff(


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add explicit readd handling to membership update flow by extending `xmtp_mls::groups::intents::UpdateGroupMembershipIntentData` and `xmtp_mls::groups::mls_sync::Group::get_membership_update_intent` to accept and process `installations_to_readd`
- Introduce `installations_to_readd` to `xmtp_mls/src/groups/intents.rs` in `UpdateGroupMembershipIntentData`, update its constructor and `is_empty` to treat readds as non-empty
- Extend membership diff computation in [mls_sync.rs](https://github.com/xmtp/libxmtp/pull/2451/files#diff-10f818f7918c8c0b2ed32c4f63e5060050527ed58df00ec081bbecb66065144e) to accept `OpenMlsGroup` and readd lists, forwarding them into `calculate_membership_changes_with_keypackages`
- Add `IdentityUpdates.get_installation_diff_with_readds` in [identity_updates.rs](https://github.com/xmtp/libxmtp/pull/2451/files#diff-cc071a4438743ce4ec352d6294d0ca5e6343d881afd0f7d45127e70badea403d) to include remove-and-readd operations for current members while excluding independently removed installations
- Update application path in [update_group_membership.rs](https://github.com/xmtp/libxmtp/pull/2451/files#diff-4c3361715cd00d671d6aa956c3f0e7f38dc33270c01a5e8d1895ead5e7222659) to pass readds into diff calculation
- Add documentation clarifications in [group_membership.rs](https://github.com/xmtp/libxmtp/pull/2451/files#diff-e5c424e7662af030c6b893fb0771aa6ced5692e399f337b5bb94388a640787fb) and [validated_commit.rs](https://github.com/xmtp/libxmtp/pull/2451/files#diff-779227110741fa6ce78048adfaac1895d306d8fd502dab800774b62aada72365) noting current diffs and validation do not account for readds

#### 📍Where to Start
Start with `calculate_membership_changes_with_keypackages` in [xmtp_mls/src/groups/mls_sync.rs](https://github.com/xmtp/libxmtp/pull/2451/files#diff-10f818f7918c8c0b2ed32c4f63e5060050527ed58df00ec081bbecb66065144e), then follow its use from `Group.get_membership_update_intent` and the call site in [xmtp_mls/src/groups/mls_sync/update_group_membership.rs](https://github.com/xmtp/libxmtp/pull/2451/files#diff-4c3361715cd00d671d6aa956c3f0e7f38dc33270c01a5e8d1895ead5e7222659).

----

_[Macroscope](https://app.macroscope.com) summarized fc087fd._
<!-- Macroscope's pull request summary ends here -->