### PR TITLE
Fix performance issue with finding groups

### DIFF
--- a/xmtp_db/migrations/2025-09-12-232253_optimize_dm_deduplication_performance/down.sql
+++ b/xmtp_db/migrations/2025-09-12-232253_optimize_dm_deduplication_performance/down.sql
@@ -1,0 +1,2 @@
+-- Remove the COALESCE expression index
+DROP INDEX IF EXISTS idx_groups_dm_coalesce_last_message;

--- a/xmtp_db/migrations/2025-09-12-232253_optimize_dm_deduplication_performance/up.sql
+++ b/xmtp_db/migrations/2025-09-12-232253_optimize_dm_deduplication_performance/up.sql
@@ -1,0 +1,6 @@
+-- Comprehensive optimization for DM deduplication performance
+-- Creates expression index on COALESCE(dm_id, id) to support the new EXISTS-based deduplication query
+
+-- Primary index on the COALESCE expression with last_message_ns for efficient EXISTS queries
+-- Supports: WHERE COALESCE(dm_id, id) = ? AND last_message_ns > ? pattern
+CREATE INDEX idx_groups_dm_coalesce_last_message ON groups(COALESCE(dm_id, id), last_message_ns DESC);

--- a/xmtp_db/src/encrypted_store/group.rs
+++ b/xmtp_db/src/encrypted_store/group.rs
@@ -502,15 +502,13 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
             .into_boxed();
 
         if !include_duplicate_dms {
-            // Group by dm_id and grab the latest group (conversation stitching)
+            // Fast DM deduplication using EXISTS - avoids expensive window functions
+            // Keep only the latest group for each dm_id (or regular group if not a DM)
             query = query.filter(sql::<diesel::sql_types::Bool>(
-                "id IN (
-                    SELECT id FROM (
-                        SELECT id,
-                            ROW_NUMBER() OVER (PARTITION BY COALESCE(dm_id, id) ORDER BY last_message_ns DESC) AS row_num
-                        FROM groups
-                    ) AS ranked_groups
-                    WHERE row_num = 1
+                "NOT EXISTS (
+                    SELECT 1 FROM groups g2
+                    WHERE COALESCE(g2.dm_id, g2.id) = COALESCE(groups.dm_id, groups.id)
+                    AND (COALESCE(g2.last_message_ns, 0), g2.id) > (COALESCE(groups.last_message_ns, 0), groups.id)
                 )",
             ));
         }

--- a/xmtp_db/src/encrypted_store/group/dms.rs
+++ b/xmtp_db/src/encrypted_store/group/dms.rs
@@ -155,4 +155,120 @@ pub(super) mod tests {
         })
         .await
     }
+
+    #[xmtp_common::test]
+    async fn test_dm_deduplication() {
+        with_connection(|conn| {
+            let now = now_ns();
+            let base_time = now - 1_000_000_000; // 1 second ago
+
+            // Create DM groups with same dm_id but different timestamps
+            let dm_id = "dm:alice:bob";
+
+            // Oldest DM (should be filtered out)
+            let oldest_dm = StoredGroup::builder()
+                .id(rand_vec::<24>())
+                .created_at_ns(base_time)
+                .last_message_ns(base_time)
+                .membership_state(GroupMembershipState::Allowed)
+                .added_by_inbox_id("alice")
+                .dm_id(Some(dm_id.to_string()))
+                .build()
+                .unwrap();
+            oldest_dm.store(conn).unwrap();
+
+            // Middle DM (should be filtered out)
+            let middle_dm = StoredGroup::builder()
+                .id(rand_vec::<24>())
+                .created_at_ns(base_time + 1_000_000)
+                .last_message_ns(base_time + 1_000_000)
+                .membership_state(GroupMembershipState::Allowed)
+                .added_by_inbox_id("bob")
+                .dm_id(Some(dm_id.to_string()))
+                .build()
+                .unwrap();
+            middle_dm.store(conn).unwrap();
+
+            // Latest DM (should be kept)
+            let latest_dm = StoredGroup::builder()
+                .id(rand_vec::<24>())
+                .created_at_ns(base_time + 2_000_000)
+                .last_message_ns(base_time + 2_000_000)
+                .membership_state(GroupMembershipState::Allowed)
+                .added_by_inbox_id("alice")
+                .dm_id(Some(dm_id.to_string()))
+                .build()
+                .unwrap();
+            latest_dm.store(conn).unwrap();
+
+            // Create another DM with different dm_id (should always be kept)
+            let different_dm = StoredGroup::builder()
+                .id(rand_vec::<24>())
+                .created_at_ns(base_time + 500_000)
+                .last_message_ns(base_time + 500_000)
+                .membership_state(GroupMembershipState::Allowed)
+                .added_by_inbox_id("charlie")
+                .dm_id(Some("dm:charlie:dave".to_string()))
+                .build()
+                .unwrap();
+            different_dm.store(conn).unwrap();
+
+            // Create a regular group (non-DM, should always be kept)
+            let regular_group = StoredGroup::builder()
+                .id(rand_vec::<24>())
+                .created_at_ns(base_time + 1_500_000)
+                .last_message_ns(base_time + 1_500_000)
+                .membership_state(GroupMembershipState::Allowed)
+                .added_by_inbox_id("alice")
+                .dm_id(None) // No dm_id = regular group
+                .build()
+                .unwrap();
+            regular_group.store(conn).unwrap();
+
+            // Test with include_duplicate_dms = false (default deduplication)
+            let deduplicated_groups = conn
+                .find_groups(GroupQueryArgs {
+                    include_duplicate_dms: false,
+                    ..Default::default()
+                })
+                .unwrap();
+
+            // Should have 3 groups: latest DM, different DM, and regular group
+            assert_eq!(deduplicated_groups.len(), 3);
+
+            // Verify the latest DM is kept (highest last_message_ns for dm_id)
+            let kept_dm = deduplicated_groups
+                .iter()
+                .find(|g| g.dm_id.as_deref() == Some(dm_id))
+                .expect("Should find the DM group");
+            assert_eq!(kept_dm.id, latest_dm.id);
+            assert_eq!(kept_dm.last_message_ns, Some(base_time + 2_000_000));
+
+            // Verify different DM is kept
+            let kept_different_dm = deduplicated_groups
+                .iter()
+                .find(|g| g.dm_id.as_deref() == Some("dm:charlie:dave"))
+                .expect("Should find the different DM group");
+            assert_eq!(kept_different_dm.id, different_dm.id);
+
+            // Verify regular group is kept
+            let kept_regular = deduplicated_groups
+                .iter()
+                .find(|g| g.dm_id.is_none())
+                .expect("Should find the regular group");
+            assert_eq!(kept_regular.id, regular_group.id);
+
+            // Test with include_duplicate_dms = true (no deduplication)
+            let all_groups = conn
+                .find_groups(GroupQueryArgs {
+                    include_duplicate_dms: true,
+                    ..Default::default()
+                })
+                .unwrap();
+
+            // Should have all 5 groups
+            assert_eq!(all_groups.len(), 5);
+        })
+        .await
+    }
 }


### PR DESCRIPTION
## tl;dr

- After adding some benchmarks for finding groups and building the conversation list, I found a serious perf problem with deduplicating DMs. With 10,000 conversations the simple database query can take over a second!
- This adds a new index, and rewrites the query so that it can use the index

## Results

The same query now takes ~3.5ms. A **450X** improvement