### PR TITLE
Add benchmarks for group listing

### DIFF
--- a/xmtp_mls/Cargo.toml
+++ b/xmtp_mls/Cargo.toml
@@ -213,6 +213,11 @@ harness = false
 name = "identity"
 required-features = ["bench"]
 
+[[bench]]
+harness = false
+name = "groups"
+required-features = ["bench"]
+
 [[test]]
 harness = true
 name = "chaos"

--- a/xmtp_mls/benches/groups.rs
+++ b/xmtp_mls/benches/groups.rs
@@ -1,0 +1,187 @@
+//! Benchmarks for group finding and listing operations with shared setup
+//!
+//! This version shares the expensive setup between benchmark samples to reduce total runtime.
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use std::{hint::black_box, sync::Arc, time::Duration};
+use tokio::runtime::{Builder, Runtime};
+use tracing::{Instrument, trace_span};
+use xmtp_common::bench::{self, BENCH_ROOT_SPAN};
+use xmtp_db::group::GroupQueryArgs;
+use xmtp_mls::utils::bench::{GroupBenchSetup, new_client, setup_groups_with_messages};
+
+pub const GROUP_COUNTS: [usize; 4] = [10, 100, 1000, 10000];
+pub const TARGET_GROUPS: usize = 10;
+pub const SAMPLE_SIZE: usize = 10;
+
+fn setup_runtime() -> Runtime {
+    Builder::new_multi_thread()
+        .enable_time()
+        .enable_io()
+        .thread_name("xmtp-bencher")
+        .build()
+        .unwrap()
+}
+
+/// Shared setup for all benchmarks - creates client and groups once per GROUP_COUNT
+async fn setup_benchmark(total_groups: usize) -> Arc<GroupBenchSetup> {
+    let client = new_client(false).await;
+    let setup = setup_groups_with_messages(client, total_groups, TARGET_GROUPS).await;
+    Arc::new(setup)
+}
+
+fn bench_find_groups(c: &mut Criterion) {
+    bench::logger();
+    let mut benchmark_group = c.benchmark_group("find_groups_shared");
+    benchmark_group.sample_size(SAMPLE_SIZE);
+    // Increase measurement time to handle the expensive setup
+    benchmark_group.measurement_time(Duration::from_secs(30));
+    benchmark_group.warm_up_time(Duration::from_secs(3));
+
+    let runtime = Arc::new(setup_runtime());
+
+    for &total_groups in GROUP_COUNTS.iter() {
+        benchmark_group.throughput(Throughput::Elements(TARGET_GROUPS as u64));
+
+        // Setup once per GROUP_COUNT - completely outside the benchmark
+        let setup = runtime.block_on(setup_benchmark(total_groups));
+        let runtime_clone = runtime.clone();
+
+        benchmark_group.bench_function(
+            BenchmarkId::new("find_10_groups", total_groups),
+            move |b| {
+                let span = trace_span!(BENCH_ROOT_SPAN, total_groups);
+                let setup = setup.clone();
+                let runtime = runtime_clone.clone();
+
+                b.iter(|| {
+                    runtime.block_on(
+                        async {
+                            let groups = setup
+                                .client
+                                .find_groups(GroupQueryArgs {
+                                    limit: Some(TARGET_GROUPS as i64),
+                                    ..Default::default()
+                                })
+                                .unwrap();
+
+                            assert!(groups.len() >= TARGET_GROUPS.min(total_groups));
+                            black_box(groups);
+                        }
+                        .instrument(span.clone()),
+                    )
+                });
+            },
+        );
+    }
+
+    benchmark_group.finish();
+}
+
+fn bench_list_conversations(c: &mut Criterion) {
+    bench::logger();
+    let mut benchmark_group = c.benchmark_group("list_conversations_shared");
+    benchmark_group.sample_size(SAMPLE_SIZE);
+    // Increase measurement time to handle the expensive setup
+    benchmark_group.measurement_time(Duration::from_secs(30));
+    benchmark_group.warm_up_time(Duration::from_secs(3));
+
+    let runtime = Arc::new(setup_runtime());
+
+    for &total_groups in GROUP_COUNTS.iter() {
+        benchmark_group.throughput(Throughput::Elements(TARGET_GROUPS as u64));
+
+        // Setup once per GROUP_COUNT - completely outside the benchmark
+        let setup = runtime.block_on(setup_benchmark(total_groups));
+        let runtime_clone = runtime.clone();
+
+        benchmark_group.bench_function(
+            BenchmarkId::new("list_10_conversations", total_groups),
+            move |b| {
+                let span = trace_span!(BENCH_ROOT_SPAN, total_groups);
+                let setup = setup.clone();
+                let runtime = runtime_clone.clone();
+
+                b.iter(|| {
+                    runtime.block_on(
+                        async {
+                            let conversations = setup
+                                .client
+                                .list_conversations(GroupQueryArgs {
+                                    limit: Some(TARGET_GROUPS as i64),
+                                    ..Default::default()
+                                })
+                                .unwrap();
+
+                            assert!(conversations.len() >= TARGET_GROUPS.min(total_groups));
+                            black_box(conversations);
+                        }
+                        .instrument(span.clone()),
+                    )
+                });
+            },
+        );
+    }
+
+    benchmark_group.finish();
+}
+
+fn bench_find_groups_with_filters(c: &mut Criterion) {
+    bench::logger();
+    let mut benchmark_group = c.benchmark_group("find_groups_with_filters_shared");
+    benchmark_group.sample_size(SAMPLE_SIZE);
+    // Increase measurement time to handle the expensive setup
+    benchmark_group.measurement_time(Duration::from_secs(30));
+    benchmark_group.warm_up_time(Duration::from_secs(3));
+
+    let runtime = Arc::new(setup_runtime());
+
+    for &total_groups in GROUP_COUNTS.iter() {
+        benchmark_group.throughput(Throughput::Elements(TARGET_GROUPS as u64));
+
+        // Setup once per GROUP_COUNT - completely outside the benchmark
+        let setup = runtime.block_on(setup_benchmark(total_groups));
+        let created_after_ns = setup.target_groups[0].created_at_ns - 1000;
+        let runtime_clone = runtime.clone();
+
+        benchmark_group.bench_function(
+            BenchmarkId::new("find_10_groups_filtered", total_groups),
+            move |b| {
+                let span = trace_span!(BENCH_ROOT_SPAN, total_groups);
+                let setup = setup.clone();
+                let runtime = runtime_clone.clone();
+
+                b.iter(|| {
+                    runtime.block_on(
+                        async {
+                            let groups = setup
+                                .client
+                                .find_groups(GroupQueryArgs {
+                                    limit: Some(TARGET_GROUPS as i64),
+                                    created_after_ns: Some(created_after_ns),
+                                    ..Default::default()
+                                })
+                                .unwrap();
+
+                            assert!(!groups.is_empty());
+                            black_box(groups);
+                        }
+                        .instrument(span.clone()),
+                    )
+                });
+            },
+        );
+    }
+
+    benchmark_group.finish();
+}
+
+criterion_group!(
+    name = groups;
+    config = Criterion::default()
+        .sample_size(SAMPLE_SIZE)
+        .measurement_time(Duration::from_secs(30))
+        .warm_up_time(Duration::from_secs(3));
+    targets = bench_find_groups, bench_list_conversations, bench_find_groups_with_filters
+);
+criterion_main!(groups);

--- a/xmtp_mls/src/utils/bench/clients.rs
+++ b/xmtp_mls/src/utils/bench/clients.rs
@@ -93,3 +93,61 @@ pub async fn new_client(history_sync: bool) -> BenchClient {
     client.register_identity(signature_request).await.unwrap();
     client
 }
+
+/// Create a client from a pre-generated identity
+pub async fn create_client_from_identity(
+    identity: &super::Identity,
+    is_dev_network: bool,
+) -> BenchClient {
+    let _ = fdlimit::raise_fd_limit();
+
+    let nonce = 1;
+    let inbox_id = identity.inbox_id.clone();
+
+    let api_client = if is_dev_network {
+        tracing::info!("Using Dev GRPC");
+        <TestApiClient as XmtpTestClient>::create_dev()
+            .build()
+            .await
+            .unwrap()
+    } else {
+        tracing::info!("Using Local GRPC");
+        <TestApiClient as XmtpTestClient>::create_local()
+            .build()
+            .await
+            .unwrap()
+    };
+
+    let sync_api_client = if is_dev_network {
+        tracing::info!("Using Dev GRPC");
+        <TestApiClient as XmtpTestClient>::create_dev()
+            .build()
+            .await
+            .unwrap()
+    } else {
+        tracing::info!("Using Local GRPC");
+        <TestApiClient as XmtpTestClient>::create_local()
+            .build()
+            .await
+            .unwrap()
+    };
+
+    let client = crate::Client::builder(IdentityStrategy::new(
+        inbox_id,
+        identity.identifier.clone(),
+        nonce,
+        None,
+    ));
+
+    client
+        .temp_store()
+        .await
+        .api_clients(api_client, sync_api_client)
+        .with_remote_verifier()
+        .unwrap()
+        .default_mls_store()
+        .unwrap()
+        .build()
+        .await
+        .unwrap()
+}

--- a/xmtp_mls/src/utils/bench/groups.rs
+++ b/xmtp_mls/src/utils/bench/groups.rs
@@ -1,0 +1,72 @@
+//! Group benchmark utilities
+
+use crate::groups::MlsGroup;
+use crate::utils::TestXmtpMlsContext;
+use indicatif::{ProgressBar, ProgressStyle};
+
+use super::{BenchClient, Identity};
+
+/// Setup data for group benchmarks
+pub struct GroupBenchSetup {
+    pub client: BenchClient,
+    pub target_groups: Vec<MlsGroup<TestXmtpMlsContext>>,
+    pub total_groups: usize,
+}
+
+/// Create a specified number of groups with one message each using optimistic sends
+/// Returns the client and a list of the target groups to find
+pub async fn setup_groups_with_messages(
+    client: BenchClient,
+    total_groups: usize,
+    target_groups: usize,
+) -> GroupBenchSetup {
+    let style =
+        ProgressStyle::with_template("{bar} {pos}/{len} elapsed {elapsed} remaining {eta_precise}");
+    let bar = ProgressBar::new(total_groups as u64).with_style(style.unwrap());
+    bar.set_message("Creating groups and sending messages");
+
+    let mut all_groups = Vec::with_capacity(total_groups);
+    let mut target_group_list = Vec::with_capacity(target_groups);
+
+    // Create all groups and send one message to each (using optimistic send)
+    for i in 0..total_groups {
+        let group = client.create_group(None, None).unwrap();
+
+        // Send a message to the group using optimistic send (no network round trip)
+        group
+            .send_message_optimistic(format!("Test message {}", i).as_bytes())
+            .unwrap();
+
+        // Keep track of the first `target_groups` groups as our targets
+        if i < target_groups {
+            target_group_list.push(group.clone());
+        }
+
+        all_groups.push(group);
+        bar.inc(1);
+    }
+
+    bar.finish_with_message("Groups created and messages sent");
+
+    GroupBenchSetup {
+        client,
+        target_groups: target_group_list,
+        total_groups,
+    }
+}
+
+/// Create multiple clients with pre-generated identities for group operations
+pub async fn setup_clients_from_identities(
+    identities: &[Identity],
+    is_dev_network: bool,
+) -> Vec<BenchClient> {
+    let mut clients = Vec::with_capacity(identities.len());
+
+    for identity in identities.iter().take(100) {
+        // Limit to avoid resource issues
+        let client = super::clients::create_client_from_identity(identity, is_dev_network).await;
+        clients.push(client);
+    }
+
+    clients
+}

--- a/xmtp_mls/src/utils/bench/mod.rs
+++ b/xmtp_mls/src/utils/bench/mod.rs
@@ -14,6 +14,9 @@ pub mod re_export {
     pub use crate::groups::mls_ext::{WrapperAlgorithm, wrap_welcome};
 }
 
+pub mod groups;
+pub use groups::*;
+
 #[derive(Debug, Error)]
 pub enum BenchError {
     #[error(transparent)]


### PR DESCRIPTION
### Add Criterion benchmarks for group listing by introducing a 'groups' bench target and measuring `client.find_groups` and `client.list_conversations` with a limit of 10
This change adds a new Criterion benchmark target and utilities to measure group listing operations. It introduces a multi-threaded Tokio runtime for benchmarks, shared dataset setup that pre-populates groups with messages, and three benchmarks covering unfiltered and filtered group queries. Key files include the new bench configuration, benchmark implementations, and utilities for creating clients and groups.

- Add a `[[bench]]` target named `groups` in [Cargo.toml](https://github.com/xmtp/libxmtp/pull/2453/files#diff-059eacd406dc20809ba996685ce8d6e42f5d6bc8d1c52d486d55c5c1765c5e1d) with `harness = false` and gated behind the `bench` feature
- Implement benchmarks in [groups.rs](https://github.com/xmtp/libxmtp/pull/2453/files#diff-4b3c39c3ade9105c161863054a2d4f6aace1b943d33c9ecdae9d6d092604db6f) for `client.find_groups` (limit 10), `client.list_conversations` (limit 10), and `client.find_groups` with `created_after_ns` filter, using a shared async setup and custom Criterion settings
- Add bench utilities in [clients.rs](https://github.com/xmtp/libxmtp/pull/2453/files#diff-9f60500855205f40ce291cefafe552a0d55928d665b60f3eafdf230c9227eaa4) to create `BenchClient` instances from identities targeting dev or local endpoints
- Add group setup utilities in [groups.rs](https://github.com/xmtp/libxmtp/pull/2453/files#diff-653450b882988a2e97453be401ee5de455829b755730a380ecc1d285c201edda) to create groups, send one optimistic message per group, and return a `GroupBenchSetup`
- Export bench utilities via [mod.rs](https://github.com/xmtp/libxmtp/pull/2453/files#diff-5007516e5e5bb22c607391565a606018cd96d751469f9eb0ed2ecbaf2b5289b5)

#### 📍Where to Start
Start with the benchmark definitions and runtime/setup flow in [groups.rs](https://github.com/xmtp/libxmtp/pull/2453/files#diff-4b3c39c3ade9105c161863054a2d4f6aace1b943d33c9ecdae9d6d092604db6f), then review the shared setup utilities in [groups.rs](https://github.com/xmtp/libxmtp/pull/2453/files#diff-653450b882988a2e97453be401ee5de455829b755730a380ecc1d285c201edda) and client creation in [clients.rs](https://github.com/xmtp/libxmtp/pull/2453/files#diff-9f60500855205f40ce291cefafe552a0d55928d665b60f3eafdf230c9227eaa4).

----

_[Macroscope](https://app.macroscope.com) summarized 8ec2d74._