### PR TITLE
Explicitly kill workers on drop

### DIFF
--- a/xmtp_mls/src/groups/message_list.rs
+++ b/xmtp_mls/src/groups/message_list.rs
@@ -65,7 +65,7 @@ mod tests {
         let client = ClientBuilder::new_test_client(&generate_local_wallet()).await;
         let group = client.create_group(None, Default::default()).unwrap();
 
-        (group, client.context)
+        (group, client.context.clone())
     }
 
     fn create_test_message(


### PR DESCRIPTION
### Cancel all workers when dropping `client::Client<Context>` via `WorkerRunner::cancel_all` to ensure explicit worker shutdown
- Add a `Drop` implementation for `client::Client<Context>` that calls `self.workers.cancel_all()` in [client.rs](https://github.com/xmtp/libxmtp/pull/2454/files#diff-3c0189371525b6aae3be7e5a7b5b5682204ef341fb2744fc876148c5ecab8642).
- Introduce cooperative cancellation for workers by adding a `tokio_util::sync::CancellationToken` to `worker::WorkerRunner`, passing child tokens to each worker in `WorkerRunner::spawn`, and exposing `WorkerRunner::cancel_all` and `WorkerRunner::is_cancelled` in [worker.rs](https://github.com/xmtp/libxmtp/pull/2454/files#diff-ea560e63ca633c03d1189957b9efca26de6aa33294f42c116a574e5bf259ce23).
- Update the `worker::Worker` trait `spawn` signature (wasm and non-wasm) to accept a `CancellationToken` and select on cancellation during task loops and restart delays in [worker.rs](https://github.com/xmtp/libxmtp/pull/2454/files#diff-ea560e63ca633c03d1189957b9efca26de6aa33294f42c116a574e5bf259ce23).
- Add an async test `test_worker_cancellation_on_drop` validating cancellation on client drop in [client.rs](https://github.com/xmtp/libxmtp/pull/2454/files#diff-3c0189371525b6aae3be7e5a7b5b5682204ef341fb2744fc876148c5ecab8642).
- Adjust test helper to return a cloned client context in [message_list.rs](https://github.com/xmtp/libxmtp/pull/2454/files#diff-221be37215efcd747a9027eb9b80fd68f4362bf12f87d92219cf09b02d87c468).

#### 📍Where to Start
Start with the `Drop` implementation for `client::Client<Context>` in [client.rs](https://github.com/xmtp/libxmtp/pull/2454/files#diff-3c0189371525b6aae3be7e5a7b5b5682204ef341fb2744fc876148c5ecab8642), then review `worker::WorkerRunner` and `worker::Worker` changes in [worker.rs](https://github.com/xmtp/libxmtp/pull/2454/files#diff-ea560e63ca633c03d1189957b9efca26de6aa33294f42c116a574e5bf259ce23).

----

_[Macroscope](https://app.macroscope.com) summarized 25c9587._