### PR TITLE
allow dependabot for claude

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,5 +1,4 @@
 name: Claude Code Review
-
 on:
   pull_request:
     types: [opened, synchronize]
@@ -9,7 +8,6 @@ on:
     #   - "src/**/*.tsx"
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
-
 jobs:
   claude-review:
     # Optional: Filter by PR author
@@ -17,28 +15,25 @@ jobs:
     #   github.event.pull_request.user.login == 'external-contributor' ||
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
       issues: read
       id-token: write
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-
+          allowed_bots: |
+            dependabot[bot]
           model: "claude-opus-4-1-20250805"
-
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |
             Please review this pull request and provide feedback on:
@@ -52,28 +47,27 @@ jobs:
             Do not repeat what has already been commented on by others, including the author.
             Do not comment on, or repeat TODO comments.
             Keep feedback concise, and limited to the most important points, if any.
-
           # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
           use_sticky_comment: true
 
-          # Optional: Customize review based on file types
-          # direct_prompt: |
-          #   Review this PR focusing on:
-          #   - For TypeScript files: Type safety and proper interface usage
-          #   - For API endpoints: Security, input validation, and error handling
-          #   - For React components: Performance, accessibility, and best practices
-          #   - For tests: Coverage, edge cases, and test quality
+# Optional: Customize review based on file types
+# direct_prompt: |
+#   Review this PR focusing on:
+#   - For TypeScript files: Type safety and proper interface usage
+#   - For API endpoints: Security, input validation, and error handling
+#   - For React components: Performance, accessibility, and best practices
+#   - For tests: Coverage, edge cases, and test quality
 
-          # Optional: Different prompts for different authors
-          # direct_prompt: |
-          #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' &&
-          #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
-          #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
+# Optional: Different prompts for different authors
+# direct_prompt: |
+#   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' &&
+#   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
+#   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
 
-          # Optional: Add specific tools for running tests or linting
-          # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
+# Optional: Add specific tools for running tests or linting
+# allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
 
-          # Optional: Skip review for certain conditions
-          # if: |
-          #   !contains(github.event.pull_request.title, '[skip-review]') &&
-          #   !contains(github.event.pull_request.title, '[WIP]')
+# Optional: Skip review for certain conditions
+# if: |
+#   !contains(github.event.pull_request.title, '[skip-review]') &&
+#   !contains(github.event.pull_request.title, '[WIP]')


### PR DESCRIPTION
### Allow Claude code review workflow to run on PRs from `dependabot[bot]` in [.github/workflows/claude-code-review.yml](https://github.com/xmtp/libxmtp/pull/2456/files#diff-27456786e30ce9b1fa39c43f4e26f41177ee995f0a650d6d5aba7a826efbfe30)
Update the Claude code review GitHub Actions workflow to include an `allowed_bots` input with `dependabot[bot]`, and adjust comment placement by moving guidance comments out of the `with:` section while removing a few blank lines in [.github/workflows/claude-code-review.yml](https://github.com/xmtp/libxmtp/pull/2456/files#diff-27456786e30ce9b1fa39c43f4e26f41177ee995f0a650d6d5aba7a826efbfe30).

#### 📍Where to Start
Start with the `with:` inputs block of the Claude code review action in [.github/workflows/claude-code-review.yml](https://github.com/xmtp/libxmtp/pull/2456/files#diff-27456786e30ce9b1fa39c43f4e26f41177ee995f0a650d6d5aba7a826efbfe30).

----

_[Macroscope](https://app.macroscope.com) summarized 28fd01b._