### PR TITLE
Fix unnecessary error and warning logs

### DIFF
--- a/xmtp_mls/src/groups/commit_log.rs
+++ b/xmtp_mls/src/groups/commit_log.rs
@@ -358,6 +358,9 @@ where
         // Step 3 save the remote commit log entries to the local saved remote commit log
         let mut save_remote_commit_log_results = HashMap::new();
         for response in query_commit_log_responses {
+            if response.commit_log_entries.is_empty() {
+                continue;
+            }
             let group_id = response.group_id.clone();
             let mut consensus_public_key: Option<Vec<u8>> = conversation_id_to_public_key
                 .get(&group_id)

--- a/xmtp_mls/src/groups/welcomes/xmtp_welcome.rs
+++ b/xmtp_mls/src/groups/welcomes/xmtp_welcome.rs
@@ -227,7 +227,7 @@ where
                         .as_u64()
                         <= group.epoch().await?
                 {
-                    tracing::error!(
+                    tracing::warn!(
                         "Skipping welcome {} because we are already in group {}",
                         welcome.id,
                         hex::encode(group_id.as_slice())
@@ -417,7 +417,7 @@ where
             }
         };
 
-        tracing::warn!("storing group with welcome id {}", welcome.id);
+        tracing::info!("storing group with welcome id {}", welcome.id);
         // Insert or replace the group in the database.
         // Replacement can happen in the case that the user has been removed from and subsequently re-added to the group.
         let stored_group = db.insert_or_replace_group(to_store)?;


### PR DESCRIPTION
We are getting warning log messages of the form "No valid signature found in commit log response" from `derive_consensus_public_key()`.

I think this is happening when the response is empty, which is totally fine. Adding this to shortcut a bunch of logic that doesn't need to happen, including emitting this log.

Also adjusted log level for other logs I noticed from bug reports, so that devs viewing these logs get the right context.