### PR TITLE
encrypt welcome messages with single context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3086,11 +3086,28 @@ dependencies = [
 [[package]]
 name = "hpke-rs"
 version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36874953dfe0223fd877a77b0eefcd84f8da36161b446c6fcb47b8311fa0251a"
+dependencies = [
+ "hpke-rs-crypto 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hpke-rs-libcrux 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hpke-rs-rust-crypto 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libcrux-sha3",
+ "log",
+ "rand_core 0.9.3",
+ "serde",
+ "tls_codec",
+ "zeroize",
+]
+
+[[package]]
+name = "hpke-rs"
+version = "0.3.0"
 source = "git+https://github.com/cryspen/hpke-rs?tag=v0.3.0#6bb771df1f0f3fb76337329f5ebdcbfbfc4099fa"
 dependencies = [
- "hpke-rs-crypto 0.3.0",
- "hpke-rs-libcrux",
- "hpke-rs-rust-crypto 0.3.0",
+ "hpke-rs-crypto 0.3.0 (git+https://github.com/cryspen/hpke-rs?tag=v0.3.0)",
+ "hpke-rs-libcrux 0.3.0 (git+https://github.com/cryspen/hpke-rs?tag=v0.3.0)",
+ "hpke-rs-rust-crypto 0.3.0 (git+https://github.com/cryspen/hpke-rs?tag=v0.3.0)",
  "libcrux-sha3",
  "log",
  "rand_core 0.9.3",
@@ -3111,6 +3128,15 @@ dependencies = [
 [[package]]
 name = "hpke-rs-crypto"
 version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51ffd304e06803f90f2e56a24a6910f19b8516f842d7b72a436c51026279876"
+dependencies = [
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "hpke-rs-crypto"
+version = "0.3.0"
 source = "git+https://github.com/cryspen/hpke-rs?tag=v0.3.0#6bb771df1f0f3fb76337329f5ebdcbfbfc4099fa"
 dependencies = [
  "rand_core 0.9.3",
@@ -3119,9 +3145,25 @@ dependencies = [
 [[package]]
 name = "hpke-rs-libcrux"
 version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb9f3bdfd7bc6a45f985b47cce25c5409312af06c2dec07a2af2cca5c89579ae"
+dependencies = [
+ "hpke-rs-crypto 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libcrux-chacha20poly1305 0.0.3",
+ "libcrux-ecdh",
+ "libcrux-hkdf 0.0.3",
+ "libcrux-kem",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "hpke-rs-libcrux"
+version = "0.3.0"
 source = "git+https://github.com/cryspen/hpke-rs?tag=v0.3.0#6bb771df1f0f3fb76337329f5ebdcbfbfc4099fa"
 dependencies = [
- "hpke-rs-crypto 0.3.0",
+ "hpke-rs-crypto 0.3.0 (git+https://github.com/cryspen/hpke-rs?tag=v0.3.0)",
  "libcrux-chacha20poly1305 0.0.3",
  "libcrux-ecdh",
  "libcrux-hkdf 0.0.3",
@@ -3152,12 +3194,32 @@ dependencies = [
 [[package]]
 name = "hpke-rs-rust-crypto"
 version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff7dc0df494528a0b90005bb511c117453c6a89cd8819f6cf311d0f4446dcf45"
+dependencies = [
+ "aes-gcm",
+ "chacha20poly1305",
+ "hkdf",
+ "hpke-rs-crypto 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k256",
+ "p256",
+ "p384",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+ "sha2",
+ "x25519-dalek",
+]
+
+[[package]]
+name = "hpke-rs-rust-crypto"
+version = "0.3.0"
 source = "git+https://github.com/cryspen/hpke-rs?tag=v0.3.0#6bb771df1f0f3fb76337329f5ebdcbfbfc4099fa"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
  "hkdf",
- "hpke-rs-crypto 0.3.0",
+ "hpke-rs-crypto 0.3.0 (git+https://github.com/cryspen/hpke-rs?tag=v0.3.0)",
  "k256",
  "p256",
  "p384",
@@ -4659,9 +4721,9 @@ name = "openmls_libcrux_crypto"
 version = "0.2.0"
 source = "git+https://github.com/xmtp/openmls?rev=76829d6c715ed115cf77e9086bac1f7bea15aa8a#76829d6c715ed115cf77e9086bac1f7bea15aa8a"
 dependencies = [
- "hpke-rs 0.3.0",
- "hpke-rs-crypto 0.3.0",
- "hpke-rs-libcrux",
+ "hpke-rs 0.3.0 (git+https://github.com/cryspen/hpke-rs?tag=v0.3.0)",
+ "hpke-rs-crypto 0.3.0 (git+https://github.com/cryspen/hpke-rs?tag=v0.3.0)",
+ "hpke-rs-libcrux 0.3.0 (git+https://github.com/cryspen/hpke-rs?tag=v0.3.0)",
  "libcrux-chacha20poly1305 0.0.2",
  "libcrux-ed25519 0.0.2",
  "libcrux-hkdf 0.0.2",
@@ -8913,6 +8975,7 @@ dependencies = [
  "getrandom 0.3.3",
  "hkdf",
  "hmac",
+ "hpke-rs 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "indicatif 0.17.11",
  "itertools 0.14.0",
  "json-patch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,11 @@ getrandom = { version = "0.3", default-features = false }
 gloo-timers = "0.3"
 hex = { package = "const-hex", version = "1.14" }
 hkdf = "0.12.3"
+hpke-rs = { version = "0.3.0", features = [
+  "hazmat",
+  "serialization",
+  "libcrux",
+] }
 itertools = "0.14"
 js-sys = "0.3"
 mockall = { version = "0.13" }

--- a/xmtp_mls/Cargo.toml
+++ b/xmtp_mls/Cargo.toml
@@ -63,6 +63,7 @@ futures = { workspace = true, features = ["alloc", "std"] }
 futures-util.workspace = true
 hex.workspace = true
 hkdf.workspace = true
+hpke-rs.workspace = true
 itertools.workspace = true
 json-patch = "4"
 openmls_libcrux_crypto = { workspace = true }

--- a/xmtp_mls/benches/crypto.rs
+++ b/xmtp_mls/benches/crypto.rs
@@ -50,7 +50,7 @@ fn bench_encrypt_welcome_curve25519(c: &mut Criterion) {
                     OsRng.fill_bytes(payload.as_mut_slice());
                     (payload, keypair.public)
                 },
-                |(payload, key)| wrap_welcome(&payload, &key, &WrapperAlgorithm::Curve25519),
+                |(payload, key)| wrap_welcome(&payload, &[], &key, &WrapperAlgorithm::Curve25519),
                 BatchSize::SmallInput,
             )
         });
@@ -80,7 +80,7 @@ fn bench_encrypt_welcome_post_quantum(c: &mut Criterion) {
                     (payload, keypair.public)
                 },
                 |(payload, key)| {
-                    wrap_welcome(&payload, &key, &WrapperAlgorithm::XWingMLKEM768Draft6)
+                    wrap_welcome(&payload, &[], &key, &WrapperAlgorithm::XWingMLKEM768Draft6)
                 },
                 BatchSize::SmallInput,
             )

--- a/xmtp_mls/src/groups/mls_ext/mls_ext_wrapper_encryption.rs
+++ b/xmtp_mls/src/groups/mls_ext/mls_ext_wrapper_encryption.rs
@@ -22,6 +22,20 @@ impl WrapperAlgorithm {
             WrapperAlgorithm::XWingMLKEM768Draft6 => POST_QUANTUM_CIPHERSUITE,
         }
     }
+    // hardcoded because the functions to do the translations are private
+    // and placed here so that any changes to the this algorithm will have to be handled
+    pub fn to_hpke_config(&self) -> hpke_rs::Hpke<hpke_rs::libcrux::HpkeLibcrux> {
+        let kem = match self {
+            Self::Curve25519 => hpke_rs::hpke_types::KemAlgorithm::DhKem25519,
+            Self::XWingMLKEM768Draft6 => hpke_rs::hpke_types::KemAlgorithm::XWingDraft06,
+        };
+        hpke_rs::Hpke::<hpke_rs::libcrux::HpkeLibcrux>::new(
+            hpke_rs::Mode::Base,
+            kem,
+            hpke_rs::hpke_types::KdfAlgorithm::HkdfSha256,
+            hpke_rs::hpke_types::AeadAlgorithm::ChaCha20Poly1305,
+        )
+    }
 }
 
 impl From<WrapperAlgorithm> for WrapperAlgorithmProto {

--- a/xmtp_mls/src/groups/mls_ext/welcome_wrapper.rs
+++ b/xmtp_mls/src/groups/mls_ext/welcome_wrapper.rs
@@ -1,10 +1,7 @@
 use super::WrapperAlgorithm;
-use openmls::ciphersuite::hpke::{Error as OpenmlsHpkeError, encrypt_with_label};
-use openmls::prelude::hpke::decrypt_with_label;
-use openmls::prelude::{Ciphersuite, tls_codec::Error as TlsCodecError};
-use openmls_libcrux_crypto::CryptoProvider as LibcruxCryptoProvider;
-use openmls_rust_crypto::RustCrypto;
-use openmls_traits::{crypto::OpenMlsCrypto, types::HpkeCiphertext};
+use openmls::ciphersuite::hpke::Error as OpenmlsHpkeError;
+use openmls::prelude::tls_codec::Error as TlsCodecError;
+use openmls_traits::types::HpkeCiphertext;
 use thiserror::Error;
 use tls_codec::{Deserialize, Serialize};
 use xmtp_common::RetryableError;
@@ -43,95 +40,96 @@ impl RetryableError for UnwrapWelcomeError {
 /// Wrap a message in an outer layer of encryption using
 /// the specified [WrapperAlgorithm].
 /// The algorithm and public key type MUST match
+///
+/// For the XWingMLKEM768Draft6 algorithm, the openmls_welcome and welcome_metadata are wrapped using the same HPKE public key
+/// and the first vec returned is the HpkeCiphertext with tls serialization. The second vec is just ciphertext.
 pub fn wrap_welcome(
-    unwrapped_welcome: &[u8],
+    openmls_welcome: &[u8],
+    welcome_metadata: &[u8],
     hpke_public_key: &[u8],
     wrapper_algorithm: &WrapperAlgorithm,
-) -> Result<Vec<u8>, WrapWelcomeError> {
-    match wrapper_algorithm {
-        // I am taking the conservative approach here and not changing the crypto provider
-        // for Curve25519 even if Libcrux supports it.
+) -> Result<(Vec<u8>, Vec<u8>), WrapWelcomeError> {
+    // The following implementation is the same as calling openmls_libcrux_crypto::CryptoProvider::hpke_seal(...)
+    // but uses the context to encrypt multiple messages at once using the same context
+    // because openmls only supports one shot messages.
 
-        // Once we move everything to Libcrux this can be removed.
-        WrapperAlgorithm::Curve25519 => wrap_welcome_inner(
-            &RustCrypto::default(),
-            unwrapped_welcome,
-            hpke_public_key,
-            wrapper_algorithm.to_mls_ciphersuite(),
-        ),
-        WrapperAlgorithm::XWingMLKEM768Draft6 => wrap_welcome_inner(
-            &LibcruxCryptoProvider::new().expect(
-                "Failed to create LibcruxCryptoProvider because of insufficient randomness",
-            ),
-            unwrapped_welcome,
-            hpke_public_key,
-            wrapper_algorithm.to_mls_ciphersuite(),
-        ),
-    }
-}
+    let context = openmls::prelude::hpke::EncryptContext::new(WELCOME_HPKE_LABEL, vec![].into());
+    let info = context.tls_serialize_detached()?;
+    let aad = &[];
 
-fn wrap_welcome_inner(
-    crypto_provider: &impl OpenMlsCrypto,
-    unwrapped_welcome: &[u8],
-    hpke_public_key: &[u8],
-    ciphersuite: Ciphersuite,
-) -> Result<Vec<u8>, WrapWelcomeError> {
-    Ok(encrypt_with_label(
-        hpke_public_key,
-        WELCOME_HPKE_LABEL,
-        &[],
-        unwrapped_welcome,
-        ciphersuite,
-        crypto_provider,
-    )?
-    .tls_serialize_detached()?)
+    let map_hpke_error = |e| match e {
+        hpke_rs::HpkeError::InvalidConfig => openmls::prelude::CryptoError::SenderSetupError,
+        _ => openmls::prelude::CryptoError::HpkeEncryptionError,
+    };
+
+    let pk_r = hpke_rs::HpkePublicKey::new(hpke_public_key.to_vec());
+    let mut config = wrapper_algorithm.to_hpke_config();
+
+    let (enc, mut ctxt) = config
+        .setup_sender(&pk_r, &info, None, None, None)
+        .map_err(map_hpke_error)?;
+
+    let encrypted_welcome = ctxt
+        .seal(aad, openmls_welcome)
+        .map(|ct| HpkeCiphertext {
+            kem_output: enc.into(),
+            ciphertext: ct.into(),
+        })
+        .map_err(map_hpke_error)?;
+    let encrypted_welcome_metadata = ctxt.seal(aad, welcome_metadata).map_err(map_hpke_error)?;
+
+    Ok((
+        encrypted_welcome.tls_serialize_detached()?,
+        encrypted_welcome_metadata,
+    ))
 }
 
 /// Unwrap a message that was wrapped using the specified [WrapperAlgorithm].
 /// The algorithm and private key type MUST match.
 pub fn unwrap_welcome(
     wrapped_welcome: &[u8],
+    wrapped_welcome_metadata: &[u8],
     private_key: &[u8],
     wrapper_algorithm: WrapperAlgorithm,
-) -> Result<Vec<u8>, UnwrapWelcomeError> {
+) -> Result<(Vec<u8>, Vec<u8>), UnwrapWelcomeError> {
     let ciphertext = HpkeCiphertext::tls_deserialize_exact(wrapped_welcome)?;
 
-    match wrapper_algorithm {
-        // I am taking the conservative approach here and not changing the crypto provider
-        // for Curve25519 even if Libcrux supports it.
+    // The following implementation is the same as calling openmls_libcrux_crypto::CryptoProvider::hpke_open(...)
+    // but uses the context to decrypt multiple messages at once using the same context
+    // because openmls only supports one shot messages.
 
-        // Once we move everything to Libcrux this can be removed.
-        WrapperAlgorithm::Curve25519 => unwrap_welcome_inner(
-            &RustCrypto::default(),
-            &ciphertext,
-            private_key,
-            wrapper_algorithm.to_mls_ciphersuite(),
-        ),
-        WrapperAlgorithm::XWingMLKEM768Draft6 => unwrap_welcome_inner(
-            &LibcruxCryptoProvider::new().expect(
-                "Failed to create LibcruxCryptoProvider because of insufficient randomness",
-            ),
-            &ciphertext,
-            private_key,
-            wrapper_algorithm.to_mls_ciphersuite(),
-        ),
-    }
-}
+    let context = openmls::prelude::hpke::EncryptContext::new(WELCOME_HPKE_LABEL, vec![].into());
+    let info = context.tls_serialize_detached()?;
+    let aad = &[];
 
-fn unwrap_welcome_inner(
-    crypto_provider: &impl OpenMlsCrypto,
-    ciphertext: &HpkeCiphertext,
-    private_key: &[u8],
-    wrapper_ciphersuite: Ciphersuite,
-) -> Result<Vec<u8>, UnwrapWelcomeError> {
-    Ok(decrypt_with_label(
-        private_key,
-        WELCOME_HPKE_LABEL,
-        &[],
-        ciphertext,
-        wrapper_ciphersuite,
-        crypto_provider,
-    )?)
+    let config = wrapper_algorithm.to_hpke_config();
+
+    let sk_r = hpke_rs::HpkePrivateKey::new(private_key.to_vec());
+
+    let map_hpke_error = |_| openmls::ciphersuite::hpke::Error::DecryptionFailed;
+
+    let mut ctxt = config
+        .setup_receiver(
+            ciphertext.kem_output.as_ref(),
+            &sk_r,
+            &info,
+            None,
+            None,
+            None,
+        )
+        .map_err(map_hpke_error)?;
+
+    let welcome = ctxt
+        .open(aad, ciphertext.ciphertext.as_ref())
+        .map_err(map_hpke_error)?;
+    let welcome_metadata = if wrapped_welcome_metadata.is_empty() {
+        vec![]
+    } else {
+        ctxt.open(aad, wrapped_welcome_metadata)
+            .map_err(map_hpke_error)?
+    };
+
+    Ok((welcome, welcome_metadata))
 }
 
 #[cfg(test)]
@@ -169,20 +167,30 @@ mod tests {
         let private_key =
             find_key_package_private_key(&provider, hpke_public_key, WrapperAlgorithm::Curve25519);
 
-        let to_encrypt = vec![1, 2, 3];
+        let to_encrypt = xmtp_common::rand_vec::<1000>();
+        let to_encrypt_metadata = xmtp_common::rand_vec::<32>();
 
         // Encryption doesn't require any details about the sender, so we can test using one client
         let wrapped = wrap_welcome(
             to_encrypt.as_slice(),
+            to_encrypt_metadata.as_slice(),
             hpke_public_key,
             &WrapperAlgorithm::Curve25519,
         )
         .unwrap();
 
-        let unwrapped =
-            unwrap_welcome(&wrapped, &private_key, WrapperAlgorithm::Curve25519).unwrap();
+        assert_ne!(&to_encrypt, &wrapped.0);
+        assert_ne!(&to_encrypt_metadata, &wrapped.1);
 
-        assert_eq!(unwrapped, to_encrypt);
+        let unwrapped = unwrap_welcome(
+            &wrapped.0,
+            &wrapped.1,
+            &private_key,
+            WrapperAlgorithm::Curve25519,
+        )
+        .unwrap();
+
+        assert_eq!(unwrapped, (to_encrypt, to_encrypt_metadata));
     }
 
     #[xmtp_common::test]
@@ -200,22 +208,208 @@ mod tests {
             &pq_pub_key,
             WrapperAlgorithm::XWingMLKEM768Draft6,
         );
-        let to_encrypt = vec![1, 2, 3];
+        let to_encrypt = xmtp_common::rand_vec::<1000>();
+        let to_encrypt_metadata = xmtp_common::rand_vec::<32>();
+
+        // Test error handling
+        wrap_welcome(
+            to_encrypt.as_slice(),
+            to_encrypt_metadata.as_slice(),
+            &pq_pub_key[..pq_pub_key.len().saturating_sub(1)],
+            &WrapperAlgorithm::XWingMLKEM768Draft6,
+        )
+        .unwrap_err();
 
         let wrapped = wrap_welcome(
             to_encrypt.as_slice(),
+            to_encrypt_metadata.as_slice(),
             &pq_pub_key,
             &WrapperAlgorithm::XWingMLKEM768Draft6,
         )
         .unwrap();
 
+        assert_ne!(&to_encrypt, &wrapped.0);
+        assert_ne!(&to_encrypt_metadata, &wrapped.1);
+
         let unwrapped = unwrap_welcome(
-            &wrapped,
+            &wrapped.0,
+            &wrapped.1,
             &private_key,
             WrapperAlgorithm::XWingMLKEM768Draft6,
         )
         .unwrap();
 
-        assert_eq!(unwrapped, to_encrypt);
+        assert_eq!(unwrapped, (to_encrypt.clone(), to_encrypt_metadata));
+
+        let unwrapped = unwrap_welcome(
+            &wrapped.0,
+            &[],
+            &private_key,
+            WrapperAlgorithm::XWingMLKEM768Draft6,
+        )
+        .unwrap();
+
+        assert_eq!(unwrapped, (to_encrypt, vec![]));
+
+        unwrap_welcome(
+            &unwrapped.0,
+            &unwrapped.1,
+            &private_key[..private_key.len().saturating_sub(1)],
+            WrapperAlgorithm::XWingMLKEM768Draft6,
+        )
+        .unwrap_err();
+    }
+
+    fn wrap_welcome_inner(
+        crypto_provider: &impl openmls_traits::crypto::OpenMlsCrypto,
+        unwrapped_welcome: &[u8],
+        hpke_public_key: &[u8],
+        ciphersuite: openmls::prelude::Ciphersuite,
+    ) -> Result<Vec<u8>, WrapWelcomeError> {
+        Ok(openmls::prelude::hpke::encrypt_with_label(
+            hpke_public_key,
+            WELCOME_HPKE_LABEL,
+            &[],
+            unwrapped_welcome,
+            ciphersuite,
+            crypto_provider,
+        )?
+        .tls_serialize_detached()?)
+    }
+
+    fn unwrap_welcome_inner(
+        crypto_provider: &impl openmls_traits::crypto::OpenMlsCrypto,
+        ciphertext: &HpkeCiphertext,
+        private_key: &[u8],
+        wrapper_ciphersuite: openmls::prelude::Ciphersuite,
+    ) -> Result<Vec<u8>, UnwrapWelcomeError> {
+        Ok(openmls::prelude::hpke::decrypt_with_label(
+            private_key,
+            WELCOME_HPKE_LABEL,
+            &[],
+            ciphertext,
+            wrapper_ciphersuite,
+            crypto_provider,
+        )?)
+    }
+    #[xmtp_common::test]
+    async fn round_trip_xwing_mlkem512_current_to_previous_and_back() {
+        let client = ClientBuilder::new_test_client(&generate_local_wallet()).await;
+        let provider = client.context.mls_provider();
+
+        let NewKeyPackageResult {
+            pq_pub_key: maybe_pq_pub_key,
+            ..
+        } = client.identity().new_key_package(&provider, true).unwrap();
+        let pq_pub_key = maybe_pq_pub_key.unwrap();
+        let private_key = find_key_package_private_key(
+            &provider,
+            &pq_pub_key,
+            WrapperAlgorithm::XWingMLKEM768Draft6,
+        );
+
+        let to_encrypt = xmtp_common::rand_vec::<1000>();
+        let to_encrypt_metadata = xmtp_common::rand_vec::<32>();
+
+        // Test the current code to previous code round trip
+        {
+            let wrapped = wrap_welcome(
+                &to_encrypt,
+                &to_encrypt_metadata,
+                &pq_pub_key,
+                &WrapperAlgorithm::XWingMLKEM768Draft6,
+            )
+            .unwrap();
+
+            assert_ne!(to_encrypt_metadata, wrapped.1);
+
+            let unwrapped = unwrap_welcome_inner(
+                &openmls_libcrux_crypto::CryptoProvider::new().unwrap(),
+                &HpkeCiphertext::tls_deserialize_exact(&wrapped.0).unwrap(),
+                &private_key,
+                WrapperAlgorithm::XWingMLKEM768Draft6.to_mls_ciphersuite(),
+            )
+            .unwrap();
+
+            assert_eq!(unwrapped, to_encrypt);
+        }
+
+        // Test the previous code to current code round trip
+        {
+            let wrapped = wrap_welcome_inner(
+                &openmls_libcrux_crypto::CryptoProvider::new().unwrap(),
+                &to_encrypt,
+                &pq_pub_key,
+                WrapperAlgorithm::XWingMLKEM768Draft6.to_mls_ciphersuite(),
+            )
+            .unwrap();
+
+            let unwrapped = unwrap_welcome(
+                &wrapped,
+                &[],
+                &private_key,
+                WrapperAlgorithm::XWingMLKEM768Draft6,
+            )
+            .unwrap();
+
+            assert_eq!(unwrapped, (to_encrypt, vec![]));
+        }
+    }
+
+    #[xmtp_common::test]
+    async fn round_trip_curve_25519_current_to_previous_and_back() {
+        let client = ClientBuilder::new_test_client(&generate_local_wallet()).await;
+        let provider = client.context.mls_provider();
+
+        let NewKeyPackageResult { key_package, .. } =
+            client.identity().new_key_package(&provider, false).unwrap();
+
+        let hpke_public_key = key_package.hpke_init_key().as_slice();
+
+        let private_key =
+            find_key_package_private_key(&provider, hpke_public_key, WrapperAlgorithm::Curve25519);
+        let to_encrypt = xmtp_common::rand_vec::<1000>();
+        let to_encrypt_metadata = xmtp_common::rand_vec::<32>();
+
+        // Test the current code to previous code round trip
+        {
+            let wrapped = wrap_welcome(
+                &to_encrypt,
+                &to_encrypt_metadata,
+                hpke_public_key,
+                &WrapperAlgorithm::Curve25519,
+            )
+            .unwrap();
+
+            assert_ne!(to_encrypt_metadata, wrapped.1);
+
+            let unwrapped = unwrap_welcome_inner(
+                // Use old crypto provider to match previous code
+                &openmls_rust_crypto::RustCrypto::default(),
+                &HpkeCiphertext::tls_deserialize_exact(&wrapped.0).unwrap(),
+                &private_key,
+                WrapperAlgorithm::Curve25519.to_mls_ciphersuite(),
+            )
+            .unwrap();
+
+            assert_eq!(unwrapped, to_encrypt);
+        }
+
+        // Test the previous code to current code round trip
+        {
+            let wrapped = wrap_welcome_inner(
+                // Use old crypto provider to match previous code
+                &openmls_rust_crypto::RustCrypto::default(),
+                &to_encrypt,
+                hpke_public_key,
+                WrapperAlgorithm::Curve25519.to_mls_ciphersuite(),
+            )
+            .unwrap();
+
+            let unwrapped =
+                unwrap_welcome(&wrapped, &[], &private_key, WrapperAlgorithm::Curve25519).unwrap();
+
+            assert_eq!(unwrapped, (to_encrypt, vec![]));
+        }
     }
 }

--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -2418,24 +2418,20 @@ where
                     let welcome_metadata = WelcomeMetadata {
                         message_cursor: message_cursor.unwrap_or(0) as u64,
                     };
-                    let wrapped_welcome_metadata = wrap_welcome(
-                        &welcome_metadata.encode_to_vec(),
-                        &installation.hpke_public_key,
-                        &algorithm,
-                    )?;
-
-                    let wrapped_welcome = wrap_welcome(
+                    let welcome_metadata_bytes = welcome_metadata.encode_to_vec();
+                    let (data, welcome_metadata) = wrap_welcome(
                         &action.welcome_message,
+                        &welcome_metadata_bytes,
                         &installation.hpke_public_key,
                         &algorithm,
                     )?;
                     Ok(WelcomeMessageInput {
                         version: Some(WelcomeMessageInputVersion::V1(WelcomeMessageInputV1 {
                             installation_key,
-                            data: wrapped_welcome,
+                            data,
                             hpke_public_key: installation.hpke_public_key,
                             wrapper_algorithm: algorithm.into(),
-                            welcome_metadata: wrapped_welcome_metadata,
+                            welcome_metadata,
                         })),
                     })
                 },

--- a/xmtp_mls/src/groups/welcome_sync.rs
+++ b/xmtp_mls/src/groups/welcome_sync.rs
@@ -293,36 +293,25 @@ mod tests {
         welcome: MlsMessageOut,
         message_cursor: Option<u64>,
     ) -> welcome_message::V1 {
-        let w = wrap_welcome(
+        let (data, welcome_metadata) = wrap_welcome(
             &welcome.tls_serialize_detached().unwrap(),
+            &WelcomeMetadata {
+                message_cursor: message_cursor.unwrap_or(0),
+            }
+            .encode_to_vec(),
             &public_key,
             &WrapperAlgorithm::Curve25519,
         )
         .unwrap();
 
-        let wrapped_welcome_metadata: Vec<u8> = if let Some(cursor) = message_cursor {
-            let welcome_metadata = WelcomeMetadata {
-                message_cursor: cursor,
-            }
-            .encode_to_vec();
-            wrap_welcome(
-                &welcome_metadata,
-                &public_key,
-                &WrapperAlgorithm::Curve25519,
-            )
-            .unwrap()
-        } else {
-            Vec::new()
-        };
-
         welcome_message::V1 {
             id,
             created_ns: 0,
             installation_key: vec![0],
-            data: w,
+            data,
             hpke_public_key: public_key,
             wrapper_algorithm: WrapperAlgorithm::Curve25519.into(),
-            welcome_metadata: wrapped_welcome_metadata,
+            welcome_metadata,
         }
     }
 


### PR DESCRIPTION
### Encrypt welcome and metadata in xmtp_mls under a single HPKE context using `xmtp_mls::groups::mls_ext::welcome_wrapper::wrap_welcome` and `unwrap_welcome` with hpke-rs 0.3.0
- Replace OpenMLS label-based dual encryption with hpke-rs single-context encryption for welcome and metadata in `xmtp_mls::groups::mls_ext::welcome_wrapper::wrap_welcome` and `xmtp_mls::groups::mls_ext::welcome_wrapper::unwrap_welcome` using `Mode::Base`, `HkdfSha256`, and `ChaCha20Poly1305` KDF/AEAD with DhKem25519 or XWingDraft06; update tests and add interop checks in [xmtp_mls/src/groups/mls_ext/welcome_wrapper.rs](https://github.com/xmtp/libxmtp/pull/2488/files#diff-7cabf530b48420f823a104e7fe4a10cf51a4d5cc16d8d683979f25630c5c0aeb).
- Add `hpke-rs = 0.3.0` with features `hazmat`, `serialization`, `libcrux` in [Cargo.toml](https://github.com/xmtp/libxmtp/pull/2488/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542) and wire it in [xmtp_mls/Cargo.toml](https://github.com/xmtp/libxmtp/pull/2488/files#diff-059eacd406dc20809ba996685ce8d6e42f5d6bc8d1c52d486d55c5c1765c5e1d); update [Cargo.lock](https://github.com/xmtp/libxmtp/pull/2488/files#diff-13ee4b2252c9e516a0547f2891aa2105c3ca71c6d7a1e682c69be97998dfc87e).
- Introduce `WrapperAlgorithm::to_hpke_config` in [xmtp_mls/src/groups/mls_ext/mls_ext_wrapper_encryption.rs](https://github.com/xmtp/libxmtp/pull/2488/files#diff-a1ea837836b6914ac4631f90bec5e206e7e1ec7975ac0f688fe3239ddcc2be3c).
- Switch `DecryptedWelcome::from_encrypted_bytes` to single-context unwrap and metadata parse fallback in [xmtp_mls/src/groups/mls_ext/decrypted_welcome.rs](https://github.com/xmtp/libxmtp/pull/2488/files#diff-9825b13d685491fae6f92c0a816a683e6cdd5e91b0d39963afd2c1247b295cb2).
- Consolidate welcome wrapping in `Group::sync` in [xmtp_mls/src/groups/mls_sync.rs](https://github.com/xmtp/libxmtp/pull/2488/files#diff-10f818f7918c8c0b2ed32c4f63e5060050527ed58df00ec081bbecb66065144e) and adjust test helper in [xmtp_mls/src/groups/welcome_sync.rs](https://github.com/xmtp/libxmtp/pull/2488/files#diff-9cc59d04a1f096342f3bf5dbcc01e5bf59b62ca24bc1ede5610cd2cdb78ae910).
- Update benches to pass metadata parameter in [xmtp_mls/benches/crypto.rs](https://github.com/xmtp/libxmtp/pull/2488/files#diff-8168362d69e3651955cc1cc995100a3b21db167caab3b0a8bf541718e86b850e).

#### 📍Where to Start
Start with the HPKE implementation and new API in `wrap_welcome`/`unwrap_welcome` in [xmtp_mls/src/groups/mls_ext/welcome_wrapper.rs](https://github.com/xmtp/libxmtp/pull/2488/files#diff-7cabf530b48420f823a104e7fe4a10cf51a4d5cc16d8d683979f25630c5c0aeb).

----

_[Macroscope](https://app.macroscope.com) summarized fb75e55._