### PR TITLE
hpke-rs 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1828,7 +1828,7 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94950e87ea550d6d68f1993f3e7bebc8cb7235157bff84337d46195c3aa0b3f0"
 dependencies = [
- "hax-lib 0.3.4",
+ "hax-lib",
  "pastey",
  "rand 0.9.2",
 ]
@@ -2957,38 +2957,13 @@ dependencies = [
 
 [[package]]
 name = "hax-lib"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61933dbb676f11311378720e1ee97a511813edb7044255381ba0d625cac6be7b"
-dependencies = [
- "hax-lib-macros 0.2.0",
- "num-bigint",
- "num-traits",
-]
-
-[[package]]
-name = "hax-lib"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bf40682e31dc3961209a4657f6fe7c412879b59f212bac3d14bd7ece5af76a3"
 dependencies = [
- "hax-lib-macros 0.3.4",
+ "hax-lib-macros",
  "num-bigint",
  "num-traits",
-]
-
-[[package]]
-name = "hax-lib-macros"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a8d32921c3f535e973f72053d20bc8c7f74028911a269748440952157807"
-dependencies = [
- "hax-lib-macros-types 0.2.0",
- "paste",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
 ]
 
 [[package]]
@@ -2997,24 +2972,11 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e33a5a4ff169bcc4e9189f4bace3ed22d03fcd8e52eee90a00b7b1e2621cb490"
 dependencies = [
- "hax-lib-macros-types 0.3.4",
+ "hax-lib-macros-types",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
-]
-
-[[package]]
-name = "hax-lib-macros-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5a22f64cb35f8363892df6285e7edbe96885cd660d85bfd6765c95886647b77"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "serde_json",
- "uuid",
 ]
 
 [[package]]
@@ -3123,13 +3085,14 @@ dependencies = [
 
 [[package]]
 name = "hpke-rs"
-version = "0.2.1-alpha.1"
-source = "git+https://github.com/cryspen/hpke-rs?tag=v0.2.1-alpha.1#510ad9af413842f185dc430870ad1c8dab6a1642"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36874953dfe0223fd877a77b0eefcd84f8da36161b446c6fcb47b8311fa0251a"
 dependencies = [
- "hpke-rs-crypto 0.3.0-alpha.1",
- "hpke-rs-libcrux 0.2.0-alpha.1",
- "hpke-rs-rust-crypto 0.3.0-alpha.1",
- "libcrux-sha3 0.0.2",
+ "hpke-rs-crypto 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hpke-rs-libcrux 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hpke-rs-rust-crypto 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libcrux-sha3",
  "log",
  "rand_core 0.9.3",
  "serde",
@@ -3142,10 +3105,10 @@ name = "hpke-rs"
 version = "0.3.0"
 source = "git+https://github.com/cryspen/hpke-rs?tag=v0.3.0#6bb771df1f0f3fb76337329f5ebdcbfbfc4099fa"
 dependencies = [
- "hpke-rs-crypto 0.3.0",
- "hpke-rs-libcrux 0.3.0",
- "hpke-rs-rust-crypto 0.3.0",
- "libcrux-sha3 0.0.3",
+ "hpke-rs-crypto 0.3.0 (git+https://github.com/cryspen/hpke-rs?tag=v0.3.0)",
+ "hpke-rs-libcrux 0.3.0 (git+https://github.com/cryspen/hpke-rs?tag=v0.3.0)",
+ "hpke-rs-rust-crypto 0.3.0 (git+https://github.com/cryspen/hpke-rs?tag=v0.3.0)",
+ "libcrux-sha3",
  "log",
  "rand_core 0.9.3",
  "serde",
@@ -3164,8 +3127,9 @@ dependencies = [
 
 [[package]]
 name = "hpke-rs-crypto"
-version = "0.3.0-alpha.1"
-source = "git+https://github.com/cryspen/hpke-rs?tag=v0.2.1-alpha.1#510ad9af413842f185dc430870ad1c8dab6a1642"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51ffd304e06803f90f2e56a24a6910f19b8516f842d7b72a436c51026279876"
 dependencies = [
  "rand_core 0.9.3",
 ]
@@ -3180,10 +3144,11 @@ dependencies = [
 
 [[package]]
 name = "hpke-rs-libcrux"
-version = "0.2.0-alpha.1"
-source = "git+https://github.com/cryspen/hpke-rs?tag=v0.2.1-alpha.1#510ad9af413842f185dc430870ad1c8dab6a1642"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb9f3bdfd7bc6a45f985b47cce25c5409312af06c2dec07a2af2cca5c89579ae"
 dependencies = [
- "hpke-rs-crypto 0.3.0-alpha.1",
+ "hpke-rs-crypto 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libcrux-chacha20poly1305 0.0.3",
  "libcrux-ecdh",
  "libcrux-hkdf 0.0.3",
@@ -3198,7 +3163,7 @@ name = "hpke-rs-libcrux"
 version = "0.3.0"
 source = "git+https://github.com/cryspen/hpke-rs?tag=v0.3.0#6bb771df1f0f3fb76337329f5ebdcbfbfc4099fa"
 dependencies = [
- "hpke-rs-crypto 0.3.0",
+ "hpke-rs-crypto 0.3.0 (git+https://github.com/cryspen/hpke-rs?tag=v0.3.0)",
  "libcrux-chacha20poly1305 0.0.3",
  "libcrux-ecdh",
  "libcrux-hkdf 0.0.3",
@@ -3228,13 +3193,14 @@ dependencies = [
 
 [[package]]
 name = "hpke-rs-rust-crypto"
-version = "0.3.0-alpha.1"
-source = "git+https://github.com/cryspen/hpke-rs?tag=v0.2.1-alpha.1#510ad9af413842f185dc430870ad1c8dab6a1642"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff7dc0df494528a0b90005bb511c117453c6a89cd8819f6cf311d0f4446dcf45"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
  "hkdf",
- "hpke-rs-crypto 0.3.0-alpha.1",
+ "hpke-rs-crypto 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "k256",
  "p256",
  "p384",
@@ -3253,7 +3219,7 @@ dependencies = [
  "aes-gcm",
  "chacha20poly1305",
  "hkdf",
- "hpke-rs-crypto 0.3.0",
+ "hpke-rs-crypto 0.3.0 (git+https://github.com/cryspen/hpke-rs?tag=v0.3.0)",
  "k256",
  "p256",
  "p384",
@@ -3962,21 +3928,12 @@ dependencies = [
 
 [[package]]
 name = "libcrux-intrinsics"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f764ef781467a75b92f4df575911f1cdcf77a7beb316d8054a233fed53a7ab"
-dependencies = [
- "hax-lib 0.2.0",
-]
-
-[[package]]
-name = "libcrux-intrinsics"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d3b41dcbc21a5fb7efbbb5af7405b2e79c4bfe443924e90b13afc0080318d31"
 dependencies = [
  "core-models",
- "hax-lib 0.3.4",
+ "hax-lib",
 ]
 
 [[package]]
@@ -3987,7 +3944,7 @@ checksum = "eefe0e9579f058b99995cbaf918de3cbab90c4d2dde544fe75247fb027ff5af9"
 dependencies = [
  "libcrux-ecdh",
  "libcrux-ml-kem",
- "libcrux-sha3 0.0.3",
+ "libcrux-sha3",
  "libcrux-traits 0.0.3",
  "rand 0.9.2",
 ]
@@ -4018,11 +3975,11 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d368d3e8d6a74e277178d54921eca112a1e6b7837d7d8bc555091acb5d817f5"
 dependencies = [
- "hax-lib 0.3.4",
- "libcrux-intrinsics 0.0.3",
+ "hax-lib",
+ "libcrux-intrinsics",
  "libcrux-platform",
  "libcrux-secrets",
- "libcrux-sha3 0.0.3",
+ "libcrux-sha3",
  "rand 0.9.2",
 ]
 
@@ -4072,7 +4029,7 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "332737e629fe6ba7547f5c0f90559eac865d5dbecf98138ffae8f16ab8cbe33f"
 dependencies = [
- "hax-lib 0.3.4",
+ "hax-lib",
 ]
 
 [[package]]
@@ -4099,23 +4056,12 @@ dependencies = [
 
 [[package]]
 name = "libcrux-sha3"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3678ede46c5b5e7d5c0035065f8b9575fb67b6df405a88778ddb89cfb71d8fed"
-dependencies = [
- "hax-lib 0.2.0",
- "libcrux-intrinsics 0.0.2",
- "libcrux-platform",
-]
-
-[[package]]
-name = "libcrux-sha3"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29d95de4257eafdfaf3bffecadb615219b0ca920c553722b3646d32dde76c797"
 dependencies = [
- "hax-lib 0.3.4",
- "libcrux-intrinsics 0.0.3",
+ "hax-lib",
+ "libcrux-intrinsics",
  "libcrux-platform",
 ]
 
@@ -4775,9 +4721,9 @@ name = "openmls_libcrux_crypto"
 version = "0.2.0"
 source = "git+https://github.com/xmtp/openmls?rev=76829d6c715ed115cf77e9086bac1f7bea15aa8a#76829d6c715ed115cf77e9086bac1f7bea15aa8a"
 dependencies = [
- "hpke-rs 0.3.0",
- "hpke-rs-crypto 0.3.0",
- "hpke-rs-libcrux 0.3.0",
+ "hpke-rs 0.3.0 (git+https://github.com/cryspen/hpke-rs?tag=v0.3.0)",
+ "hpke-rs-crypto 0.3.0 (git+https://github.com/cryspen/hpke-rs?tag=v0.3.0)",
+ "hpke-rs-libcrux 0.3.0 (git+https://github.com/cryspen/hpke-rs?tag=v0.3.0)",
  "libcrux-chacha20poly1305 0.0.2",
  "libcrux-ed25519 0.0.2",
  "libcrux-hkdf 0.0.2",
@@ -5411,30 +5357,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
  "toml_edit",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]
@@ -9053,7 +8975,7 @@ dependencies = [
  "getrandom 0.3.3",
  "hkdf",
  "hmac",
- "hpke-rs 0.2.1-alpha.1",
+ "hpke-rs 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "indicatif 0.17.11",
  "itertools 0.14.0",
  "json-patch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ getrandom = { version = "0.3", default-features = false }
 gloo-timers = "0.3"
 hex = { package = "const-hex", version = "1.14" }
 hkdf = "0.12.3"
-hpke-rs-xmtp = { version = "0.2.1-alpha.1", git = "https://github.com/cryspen/hpke-rs", tag = "v0.2.1-alpha.1", package = "hpke-rs", features = [
+hpke-rs = { version = "0.3.0", features = [
   "hazmat",
   "serialization",
   "libcrux",

--- a/xmtp_mls/Cargo.toml
+++ b/xmtp_mls/Cargo.toml
@@ -63,7 +63,7 @@ futures = { workspace = true, features = ["alloc", "std"] }
 futures-util.workspace = true
 hex.workspace = true
 hkdf.workspace = true
-hpke-rs-xmtp.workspace = true
+hpke-rs.workspace = true
 itertools.workspace = true
 json-patch = "4"
 openmls_libcrux_crypto = { workspace = true }

--- a/xmtp_mls/src/groups/mls_ext/mls_ext_wrapper_encryption.rs
+++ b/xmtp_mls/src/groups/mls_ext/mls_ext_wrapper_encryption.rs
@@ -24,17 +24,15 @@ impl WrapperAlgorithm {
     }
     // hardcoded because the functions to do the translations are private
     // and placed here so that any changes to the this algorithm will have to be handled
-    pub fn to_hpke_config(&self) -> hpke_rs_xmtp::Hpke<hpke_rs_xmtp::libcrux::HpkeLibcrux> {
+    pub fn to_hpke_config(&self) -> hpke_rs::Hpke<hpke_rs::libcrux::HpkeLibcrux> {
         match self {
             Self::Curve25519 => unimplemented!(),
-            Self::XWingMLKEM768Draft6 => {
-                hpke_rs_xmtp::Hpke::<hpke_rs_xmtp::libcrux::HpkeLibcrux>::new(
-                    hpke_rs_xmtp::Mode::Base,
-                    hpke_rs_xmtp::hpke_types::KemAlgorithm::XWingDraft06,
-                    hpke_rs_xmtp::hpke_types::KdfAlgorithm::HkdfSha256,
-                    hpke_rs_xmtp::hpke_types::AeadAlgorithm::ChaCha20Poly1305,
-                )
-            }
+            Self::XWingMLKEM768Draft6 => hpke_rs::Hpke::<hpke_rs::libcrux::HpkeLibcrux>::new(
+                hpke_rs::Mode::Base,
+                hpke_rs::hpke_types::KemAlgorithm::XWingDraft06,
+                hpke_rs::hpke_types::KdfAlgorithm::HkdfSha256,
+                hpke_rs::hpke_types::AeadAlgorithm::ChaCha20Poly1305,
+            ),
         }
     }
 }

--- a/xmtp_mls/src/groups/mls_ext/welcome_wrapper.rs
+++ b/xmtp_mls/src/groups/mls_ext/welcome_wrapper.rs
@@ -80,13 +80,13 @@ pub fn wrap_welcome(
             let mut config = wrapper_algorithm.to_hpke_config();
 
             let map_hpke_error = |e| match e {
-                hpke_rs_xmtp::HpkeError::InvalidConfig => {
+                hpke_rs::HpkeError::InvalidConfig => {
                     openmls::prelude::CryptoError::SenderSetupError
                 }
                 _ => openmls::prelude::CryptoError::HpkeEncryptionError,
             };
 
-            let pk_r = hpke_rs_xmtp::HpkePublicKey::new(hpke_public_key.to_vec());
+            let pk_r = hpke_rs::HpkePublicKey::new(hpke_public_key.to_vec());
 
             let (enc, mut ctxt) = config
                 .setup_sender(&pk_r, &info, None, None, None)
@@ -163,7 +163,7 @@ pub fn unwrap_welcome(
 
             let config = wrapper_algorithm.to_hpke_config();
 
-            let sk_r = hpke_rs_xmtp::HpkePrivateKey::new(private_key.to_vec());
+            let sk_r = hpke_rs::HpkePrivateKey::new(private_key.to_vec());
 
             let map_hpke_error = |_| openmls::ciphersuite::hpke::Error::DecryptionFailed;
 


### PR DESCRIPTION
### Switch xmtp_mls HPKE integration to use registry `hpke-rs` 0.3.0 across manifests and encryption wrappers
This change replaces the git-pinned HPKE dependency with the crates.io release and updates call sites to the new crate path. It adjusts manifests and lockfile entries to use `hpke-rs` 0.3.0 and aligns dependent crates accordingly.

- Update dependency from alias `hpke-rs-xmtp` (git tag v0.2.1-alpha.1) to registry `hpke-rs = 0.3.0` with features `hazmat`, `serialization`, and `libcrux` in [Cargo.toml](https://github.com/xmtp/libxmtp/pull/2489/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542)
- Align workspace dependency in [xmtp_mls/Cargo.toml](https://github.com/xmtp/libxmtp/pull/2489/files#diff-059eacd406dc20809ba996685ce8d6e42f5d6bc8d1c52d486d55c5c1765c5e1d) to `hpke-rs`
- Migrate encryption wrappers to the `hpke_rs` path in [xmtp_mls/src/groups/mls_ext/mls_ext_wrapper_encryption.rs](https://github.com/xmtp/libxmtp/pull/2489/files#diff-a1ea837836b6914ac4631f90bec5e206e7e1ec7975ac0f688fe3239ddcc2be3c) and [xmtp_mls/src/groups/mls_ext/welcome_wrapper.rs](https://github.com/xmtp/libxmtp/pull/2489/files#diff-7cabf530b48420f823a104e7fe4a10cf51a4d5cc16d8d683979f25630c5c0aeb), including construction of `Hpke::<libcrux::HpkeLibcrux>` with `Mode::Base`, `KemAlgorithm::XWingDraft06`, `KdfAlgorithm::HkdfSha256`, and `AeadAlgorithm::ChaCha20Poly1305`
- Normalize and clean dependency resolutions in [Cargo.lock](https://github.com/xmtp/libxmtp/pull/2489/files#diff-13ee4b2252c9e516a0547f2891aa2105c3ca71c6d7a1e682c69be97998dfc87e) to remove obsolete entries and point to registry packages

#### 📍Where to Start
Start with the `WrapperAlgorithm::to_hpke_config` changes in [xmtp_mls/src/groups/mls_ext/mls_ext_wrapper_encryption.rs](https://github.com/xmtp/libxmtp/pull/2489/files#diff-a1ea837836b6914ac4631f90bec5e206e7e1ec7975ac0f688fe3239ddcc2be3c), then review `wrap_welcome` and `unwrap_welcome` in [xmtp_mls/src/groups/mls_ext/welcome_wrapper.rs](https://github.com/xmtp/libxmtp/pull/2489/files#diff-7cabf530b48420f823a104e7fe4a10cf51a4d5cc16d8d683979f25630c5c0aeb).

----

_[Macroscope](https://app.macroscope.com) summarized 960fd61._ (Automatic summaries will resume when PR exits draft mode or review begins).