### PR TITLE
Add deletion for a single message

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -494,6 +494,11 @@ impl FfiXmtpClient {
         Ok(message.into())
     }
 
+    pub fn delete_message(&self, message_id: Vec<u8>) -> Result<u32, GenericError> {
+        let deleted_count = self.inner_client.delete_message(message_id)?;
+        Ok(deleted_count as u32)
+    }
+
     pub async fn can_message(
         &self,
         account_identifiers: Vec<FfiIdentifier>,

--- a/bindings_node/src/client.rs
+++ b/bindings_node/src/client.rs
@@ -404,4 +404,13 @@ impl Client {
         .map_err(ErrorWrapper::from)?,
     )
   }
+
+  #[napi]
+  pub fn delete_message(&self, message_id: Uint8Array) -> Result<u32> {
+    let deleted_count = self
+      .inner_client
+      .delete_message(message_id.to_vec())
+      .map_err(ErrorWrapper::from)?;
+    Ok(deleted_count as u32)
+  }
 }

--- a/bindings_wasm/src/client.rs
+++ b/bindings_wasm/src/client.rs
@@ -404,4 +404,13 @@ impl Client {
       .await
       .map_err(|e| JsError::new(&format!("{e}")))
   }
+
+  #[wasm_bindgen(js_name = deleteMessage)]
+  pub fn delete_message(&self, message_id: Vec<u8>) -> Result<u32, JsError> {
+    let deleted_count = self
+      .inner_client
+      .delete_message(message_id)
+      .map_err(|e| JsError::new(&format!("{e}")))?;
+    Ok(deleted_count as u32)
+  }
 }

--- a/xmtp_db/src/mock.rs
+++ b/xmtp_db/src/mock.rs
@@ -401,6 +401,12 @@ mock! {
         fn delete_expired_messages(&self) -> Result<usize, crate::ConnectionError>;
 
         #[mockall::concretize]
+        fn delete_message_by_id<MessageId: AsRef<[u8]>>(
+            &self,
+            message_id: MessageId,
+        ) -> Result<usize, crate::ConnectionError>;
+
+        #[mockall::concretize]
         fn get_latest_message_times_by_sender<GroupId: AsRef<[u8]>>(
             &self,
             group_id: GroupId,


### PR DESCRIPTION
### TL;DR

Added a new `deleteMessage` API to allow users to delete individual messages by ID.

### What changed?

- Added a `delete_message` method to the XMTP client that takes a message ID and removes it from the database
- Implemented the underlying database functionality in `QueryGroupMessage` trait to delete messages by ID
- Added the method to all client bindings (FFI, Node, WASM) to expose this functionality across platforms
- Added comprehensive tests to verify the functionality works as expected

### How to test?

1. Create a client and send a message
2. Verify the message exists by retrieving it
3. Delete the message using `client.deleteMessage(messageId)`
4. Verify the message no longer exists
5. Try deleting the same message again to confirm idempotency (should return 0)

```javascript
// Example in JavaScript
const message = await conversation.send("Hello");
const messageId = message.id;

// Delete the message
const deletedCount = await client.deleteMessage(messageId);
console.log(`Deleted ${deletedCount} messages`); // Should be 1

// Try to delete again (should be 0)
const secondDeleteCount = await client.deleteMessage(messageId);
console.log(`Deleted ${secondDeleteCount} messages`); // Should be 0
```

### Why make this change?

This feature allows users to delete individual messages from their local database, which is useful for:
- Privacy management
- Data cleanup
- Removing sensitive information
- Supporting message editing workflows (delete and resend)

The implementation is idempotent, meaning it won't error if the message doesn't exist, making it safe to call multiple times.