### PR TITLE
Add new gh action for updating libxmtp bindings in xmtp-ios repo

### DIFF
--- a/.github/workflows/update-xmtp-ios.yml
+++ b/.github/workflows/update-xmtp-ios.yml
@@ -1,0 +1,171 @@
+name: Update XMTP iOS Repository
+on:
+  push:
+    tags:
+      - "swift-bindings-*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to use (e.g. swift-bindings-0.1.0.abc1234)"
+        required: true
+      xmtp_ios_branch:
+        description: "xmtp-ios branch to base PR off of (default: main)"
+        required: false
+        default: "main"
+
+jobs:
+  update-xmtp-ios:
+    runs-on: warp-macos-13-arm64-6x
+    steps:
+      - name: Checkout libxmtp
+        uses: actions/checkout@v5
+        with:
+          path: libxmtp
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref }}
+
+      - name: Checkout xmtp-ios
+        uses: actions/checkout@v5
+        with:
+          repository: xmtp/xmtp-ios
+          path: xmtp-ios
+          token: ${{ secrets.LIBXMTP_SWIFT_PAT }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.xmtp_ios_branch || 'main' }}
+
+      - name: Get version and SHA
+        id: version_info
+        run: |
+          cd libxmtp
+          # Get the original version from cargo metadata
+          ORIG_VERSION=$(cargo metadata --manifest-path bindings_ffi/Cargo.toml --format-version 1 | jq -r '.packages[] | select(.name == "xmtpv3") | .version')
+
+          # Extract the major version and add 3 to it
+          MAJOR_VERSION=$(echo $ORIG_VERSION | cut -d. -f1)
+          NEW_MAJOR=$((MAJOR_VERSION + 3))
+
+          # Replace the major version in the original version string
+          VERSION=$(echo $ORIG_VERSION | sed "s/^$MAJOR_VERSION/$NEW_MAJOR/")
+
+          # Get the tag - either from the push event or from workflow_dispatch input
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            # Find the swift-bindings-* tag on the current commit
+            COMMIT_SHA=$(git rev-parse HEAD)
+            SWIFT_TAG=$(git tag --points-at $COMMIT_SHA | grep "^swift-bindings-" | head -n 1)
+            
+            # If no swift-bindings-* tag found, fall back to github.ref_name
+            if [[ -z "$SWIFT_TAG" ]]; then
+              TAG="${{ github.ref_name }}"
+            else
+              TAG="$SWIFT_TAG"
+            fi
+          fi
+
+          # Extract version and SHA from tag
+          VERSION_INPUT=$(echo $TAG | sed 's/swift-bindings-//' | cut -d. -f1-3)
+          SHA7=$(echo $TAG | cut -d. -f4)
+          RELEASE_TAG="${TAG}"
+
+          # If version contains "dev", append the git commit SHA
+          if [[ "$VERSION" == *"dev"* ]]; then
+            VERSION="${VERSION}.${SHA7}"
+          fi
+
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "sha7=${SHA7}" >> $GITHUB_OUTPUT
+          echo "release_tag=${RELEASE_TAG}" >> $GITHUB_OUTPUT
+
+      - name: Create branch in xmtp-ios
+        run: |
+          cd xmtp-ios
+          git config user.name "GitHub Actions Bot"
+          git config user.email "actions@github.com"
+          git checkout -b update-to-${{ steps.version_info.outputs.release_tag }}
+
+      - name: Update XMTP.podspec
+        run: |
+          cd xmtp-ios
+          VERSION="${{ steps.version_info.outputs.version }}"
+
+          # Update version in podspec
+          sed -i '' "s/s.version *= *'[^']*'/s.version          = '${VERSION}'/" XMTP.podspec
+
+          # Verify podspec
+          pod spec lint XMTP.podspec || echo "Podspec validation failed but continuing"
+
+      - name: Get checksum from release
+        id: get_checksum
+        env:
+          GH_TOKEN: ${{ secrets.LIBXMTP_SWIFT_PAT }}
+        run: |
+          # Fetch the checksum from the release description
+          RELEASE_TAG="${{ steps.version_info.outputs.release_tag }}"
+          CHECKSUM=$(gh api repos/xmtp/libxmtp/releases/tags/$RELEASE_TAG --jq '.body' | grep -o 'Checksum of LibXMTPSwiftFFI.zip: [a-f0-9]*' | cut -d' ' -f4)
+
+          # Verify we got a valid checksum
+          if [[ ! $CHECKSUM =~ ^[a-f0-9]+$ ]]; then
+            echo "Failed to extract valid checksum from release description"
+            exit 1
+          fi
+
+          echo "checksum=${CHECKSUM}" >> $GITHUB_OUTPUT
+
+      - name: Update Package.swift
+        run: |
+          cd xmtp-ios
+          RELEASE_URL="https://github.com/xmtp/libxmtp/releases/download/${{ steps.version_info.outputs.release_tag }}/LibXMTPSwiftFFI.zip"
+          CHECKSUM="${{ steps.get_checksum.outputs.checksum }}"
+
+          # Update URL and checksum in Package.swift
+          sed -i '' "s|url: \"https://github.com/xmtp/libxmtp/releases/download/.*\"|url: \"${RELEASE_URL}\"|" Package.swift
+          sed -i '' "s|checksum: \"[a-f0-9]*\"|checksum: \"${CHECKSUM}\"|" Package.swift
+
+      - name: Download and extract Swift sources
+        run: |
+          # Download the LibXMTPSwiftFFI.zip file
+          RELEASE_URL="https://github.com/xmtp/libxmtp/releases/download/${{ steps.version_info.outputs.release_tag }}/LibXMTPSwiftFFI.zip"
+          curl -L -o LibXMTPSwiftFFI.zip "$RELEASE_URL"
+          
+          # Extract the zip file
+          unzip LibXMTPSwiftFFI.zip
+          
+          # Verify the expected structure exists
+          if [[ ! -f "Sources/LibXMTP/xmtpv3.swift" ]]; then
+            echo "Error: Expected Swift source file not found in extracted archive"
+            echo "Archive contents:"
+            find . -name "*.swift" -type f
+            exit 1
+          fi
+          
+          # Copy the Swift source file to xmtp-ios
+          mkdir -p xmtp-ios/Sources/XMTPiOS/Libxmtp
+          cp Sources/LibXMTP/xmtpv3.swift xmtp-ios/Sources/XMTPiOS/Libxmtp/
+          
+          # Clean up the downloaded and extracted files
+          rm -rf LibXMTPSwiftFFI.zip Sources LibXMTPSwiftFFI.xcframework LICENSE
+
+      - name: Commit and push changes
+        run: |
+          cd xmtp-ios
+          git add -A
+          git commit -m "Update to libxmtp ${{ steps.version_info.outputs.version }}"
+          git push origin update-to-${{ steps.version_info.outputs.release_tag }}
+
+      - name: Create PR
+        env:
+          GH_TOKEN: ${{ secrets.LIBXMTP_SWIFT_PAT }}
+        run: |
+          BASE_BRANCH="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.xmtp_ios_branch || 'main' }}"
+          gh pr create --repo xmtp/xmtp-ios \
+            --base "${BASE_BRANCH}" \
+            --head update-to-${{ steps.version_info.outputs.release_tag }} \
+            --title "Update to libxmtp ${{ steps.version_info.outputs.version }}" \
+            --body "This PR updates the iOS bindings to libxmtp version ${{ steps.version_info.outputs.version }}. 
+            
+          Changes:
+          - Updated XMTP.podspec version to ${{ steps.version_info.outputs.version }}
+          - Updated binary URLs in Package.swift to point to the new release
+          - Updated checksum in Package.swift
+          - Updated Swift source file (xmtpv3.swift) from the new release
+          
+          Base branch: ${BASE_BRANCH}"


### PR DESCRIPTION
Inputs 
- libxmtp tag with swift bindings release
- xmtp-ios branch name (or empty to default to `main`

Generates:
PR in xmtp-ios for updating the libxmtp reference in xmtp-ios




### Add a GitHub Actions workflow in [update-xmtp-ios.yml](https://github.com/xmtp/libxmtp/pull/2496/files#diff-dcceb95781152767c2f46b9a180c00ca0f22e0ffbe1a02562ab54eff20045970) to update xmtp-ios bindings on tags matching 'swift-bindings-*' or manual dispatch for updating libxmtp bindings in xmtp-ios repo
Introduce a macOS ARM64 GitHub Actions workflow that checks out `libxmtp` at a tag and `xmtp-ios` at a base branch, derives a version from Cargo metadata (including a major bump by 3 and appending the commit SHA for `dev` versions), updates `XMTP.podspec` and `Package.swift`, fetches the release checksum and binary, copies `Sources/LibXMTP/xmtpv3.swift` into the iOS repo, commits the changes on a new branch, and opens a pull request. Key steps, paths, and edits are defined in [update-xmtp-ios.yml](https://github.com/xmtp/libxmtp/pull/2496/files#diff-dcceb95781152767c2f46b9a180c00ca0f22e0ffbe1a02562ab54eff20045970).

#### 📍Where to Start
Start with the workflow definition in [update-xmtp-ios.yml](https://github.com/xmtp/libxmtp/pull/2496/files#diff-dcceb95781152767c2f46b9a180c00ca0f22e0ffbe1a02562ab54eff20045970), focusing on the steps that compute the derived version, update `XMTP.podspec` and `Package.swift`, and create the pull request.

----

_[Macroscope](https://app.macroscope.com) summarized 4dc7897._