### PR TITLE
Pull in fixes from OpenMLS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3072,57 +3072,19 @@ dependencies = [
 
 [[package]]
 name = "hpke-rs"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11bd4ee27b79fa1820e72ef8489cc729c87299ec3f7f52b8fc8dcb87cb2d485"
-dependencies = [
- "hpke-rs-crypto 0.2.0",
- "log",
- "serde",
- "tls_codec",
- "zeroize",
-]
-
-[[package]]
-name = "hpke-rs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36874953dfe0223fd877a77b0eefcd84f8da36161b446c6fcb47b8311fa0251a"
 dependencies = [
- "hpke-rs-crypto 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hpke-rs-libcrux 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hpke-rs-rust-crypto 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hpke-rs-crypto",
+ "hpke-rs-libcrux",
+ "hpke-rs-rust-crypto",
  "libcrux-sha3",
  "log",
  "rand_core 0.9.3",
  "serde",
  "tls_codec",
  "zeroize",
-]
-
-[[package]]
-name = "hpke-rs"
-version = "0.3.0"
-source = "git+https://github.com/cryspen/hpke-rs?tag=v0.3.0#6bb771df1f0f3fb76337329f5ebdcbfbfc4099fa"
-dependencies = [
- "hpke-rs-crypto 0.3.0 (git+https://github.com/cryspen/hpke-rs?tag=v0.3.0)",
- "hpke-rs-libcrux 0.3.0 (git+https://github.com/cryspen/hpke-rs?tag=v0.3.0)",
- "hpke-rs-rust-crypto 0.3.0 (git+https://github.com/cryspen/hpke-rs?tag=v0.3.0)",
- "libcrux-sha3",
- "log",
- "rand_core 0.9.3",
- "serde",
- "tls_codec",
- "zeroize",
-]
-
-[[package]]
-name = "hpke-rs-crypto"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c3f1ae0a26c18d6469a70db1217136056261c4a244b09a755bc60bd4e055b67"
-dependencies = [
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3135,60 +3097,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "hpke-rs-crypto"
-version = "0.3.0"
-source = "git+https://github.com/cryspen/hpke-rs?tag=v0.3.0#6bb771df1f0f3fb76337329f5ebdcbfbfc4099fa"
-dependencies = [
- "rand_core 0.9.3",
-]
-
-[[package]]
 name = "hpke-rs-libcrux"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb9f3bdfd7bc6a45f985b47cce25c5409312af06c2dec07a2af2cca5c89579ae"
 dependencies = [
- "hpke-rs-crypto 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libcrux-chacha20poly1305 0.0.3",
+ "hpke-rs-crypto",
+ "libcrux-chacha20poly1305",
  "libcrux-ecdh",
- "libcrux-hkdf 0.0.3",
+ "libcrux-hkdf",
  "libcrux-kem",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
-]
-
-[[package]]
-name = "hpke-rs-libcrux"
-version = "0.3.0"
-source = "git+https://github.com/cryspen/hpke-rs?tag=v0.3.0#6bb771df1f0f3fb76337329f5ebdcbfbfc4099fa"
-dependencies = [
- "hpke-rs-crypto 0.3.0 (git+https://github.com/cryspen/hpke-rs?tag=v0.3.0)",
- "libcrux-chacha20poly1305 0.0.3",
- "libcrux-ecdh",
- "libcrux-hkdf 0.0.3",
- "libcrux-kem",
- "rand 0.9.2",
- "rand_chacha 0.9.0",
- "rand_core 0.9.3",
-]
-
-[[package]]
-name = "hpke-rs-rust-crypto"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08d4500baf0aced746723d3515d08212bdb9d941df6d1aca3d46d1619b2a1cf"
-dependencies = [
- "aes-gcm",
- "chacha20poly1305",
- "hkdf",
- "hpke-rs-crypto 0.2.0",
- "p256",
- "p384",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
- "sha2",
- "x25519-dalek",
 ]
 
 [[package]]
@@ -3200,26 +3121,7 @@ dependencies = [
  "aes-gcm",
  "chacha20poly1305",
  "hkdf",
- "hpke-rs-crypto 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "k256",
- "p256",
- "p384",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
- "sha2",
- "x25519-dalek",
-]
-
-[[package]]
-name = "hpke-rs-rust-crypto"
-version = "0.3.0"
-source = "git+https://github.com/cryspen/hpke-rs?tag=v0.3.0#6bb771df1f0f3fb76337329f5ebdcbfbfc4099fa"
-dependencies = [
- "aes-gcm",
- "chacha20poly1305",
- "hkdf",
- "hpke-rs-crypto 0.3.0 (git+https://github.com/cryspen/hpke-rs?tag=v0.3.0)",
+ "hpke-rs-crypto",
  "k256",
  "p256",
  "p384",
@@ -3801,24 +3703,13 @@ checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libcrux-chacha20poly1305"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78d522fb626847390ea4b776c7eca179ecec363c6c4730b61b0c0feb797b8d92"
-dependencies = [
- "libcrux-hacl-rs 0.0.2",
- "libcrux-macros 0.0.2",
- "libcrux-poly1305 0.0.2",
-]
-
-[[package]]
-name = "libcrux-chacha20poly1305"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b318f5f2b32dfbfd27d1c5a3201d27b2ac7a4b4a4bf15ea754a385e6c294c5"
 dependencies = [
- "libcrux-hacl-rs 0.0.3",
- "libcrux-macros 0.0.3",
- "libcrux-poly1305 0.0.3",
+ "libcrux-hacl-rs",
+ "libcrux-macros",
+ "libcrux-poly1305",
 ]
 
 [[package]]
@@ -3827,8 +3718,8 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5514645ba1ee6c55dd71d62a50cc37ad8aab3f956826001aa8dad17482655c46"
 dependencies = [
- "libcrux-hacl-rs 0.0.3",
- "libcrux-macros 0.0.3",
+ "libcrux-hacl-rs",
+ "libcrux-macros",
 ]
 
 [[package]]
@@ -3844,35 +3735,14 @@ dependencies = [
 
 [[package]]
 name = "libcrux-ed25519"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c23fece0fe97b00dff260eb176becdb0418eee7969952b40f0ce64a4b8edf28"
-dependencies = [
- "libcrux-hacl-rs 0.0.2",
- "libcrux-macros 0.0.2",
- "libcrux-sha2 0.0.2",
- "rand_core 0.9.3",
- "wycheproof",
-]
-
-[[package]]
-name = "libcrux-ed25519"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e684194634af6a661c167af731a0232990f9987eaed46a9ebb1d01d613d04067"
 dependencies = [
- "libcrux-hacl-rs 0.0.3",
- "libcrux-macros 0.0.3",
- "libcrux-sha2 0.0.3",
-]
-
-[[package]]
-name = "libcrux-hacl-rs"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bba0885296a72555a5d77056c39cc9b04edd9ab1afa3025ef3dbd96220705c"
-dependencies = [
- "libcrux-macros 0.0.2",
+ "libcrux-hacl-rs",
+ "libcrux-macros",
+ "libcrux-sha2",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -3881,17 +3751,7 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1134af11da3f24ae8d1a7e2b60ee871c9e3ffd3d8857deaeebab8088b005addd"
 dependencies = [
- "libcrux-macros 0.0.3",
-]
-
-[[package]]
-name = "libcrux-hkdf"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f42b91d695ed80a637c7670bdc7a5a5e11b98493b01266d985a1477bfaa6bd7"
-dependencies = [
- "libcrux-hacl-rs 0.0.2",
- "libcrux-hmac 0.0.2",
+ "libcrux-macros",
 ]
 
 [[package]]
@@ -3900,19 +3760,8 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed7a54a1b453200e8a18205ffbecbb0fee0cce9ec8d0bd635898b7eb2879ac06"
 dependencies = [
- "libcrux-hacl-rs 0.0.3",
- "libcrux-hmac 0.0.3",
-]
-
-[[package]]
-name = "libcrux-hmac"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e478f3208de8b92021a4e97a9590027e2eb115673ad6b1a2ebdf9f367c2b6057"
-dependencies = [
- "libcrux-hacl-rs 0.0.2",
- "libcrux-macros 0.0.2",
- "libcrux-sha2 0.0.2",
+ "libcrux-hacl-rs",
+ "libcrux-hmac",
 ]
 
 [[package]]
@@ -3921,9 +3770,9 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743cdf6149a46b2cd5f62bea237a7c57011e85055486fc031513e1261cc6692e"
 dependencies = [
- "libcrux-hacl-rs 0.0.3",
- "libcrux-macros 0.0.3",
- "libcrux-sha2 0.0.3",
+ "libcrux-hacl-rs",
+ "libcrux-macros",
+ "libcrux-sha2",
 ]
 
 [[package]]
@@ -3945,18 +3794,8 @@ dependencies = [
  "libcrux-ecdh",
  "libcrux-ml-kem",
  "libcrux-sha3",
- "libcrux-traits 0.0.3",
+ "libcrux-traits",
  "rand 0.9.2",
-]
-
-[[package]]
-name = "libcrux-macros"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3021bc24fb679408d4d7175e21cf808f49816c599733ebf4a97e5bd39c3ce7c0"
-dependencies = [
- "quote",
- "syn 2.0.106",
 ]
 
 [[package]]
@@ -3989,9 +3828,9 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b00d21690ebcc7ce1f242e6c4bdadfd8529f9cf2d7b961c0344c9bcb2c82f78f"
 dependencies = [
- "libcrux-hacl-rs 0.0.3",
- "libcrux-macros 0.0.3",
- "libcrux-sha2 0.0.3",
+ "libcrux-hacl-rs",
+ "libcrux-macros",
+ "libcrux-sha2",
 ]
 
 [[package]]
@@ -4005,22 +3844,12 @@ dependencies = [
 
 [[package]]
 name = "libcrux-poly1305"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80143d78ae14ab51ceb2c8a9514fb60af6645d42a9c951bc511792c19c974fca"
-dependencies = [
- "libcrux-hacl-rs 0.0.2",
- "libcrux-macros 0.0.2",
-]
-
-[[package]]
-name = "libcrux-poly1305"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1a2901c5a92bb236cacd3d16bd6654b7f3471eb417bedab85f6225060cd4a03"
 dependencies = [
- "libcrux-hacl-rs 0.0.3",
- "libcrux-macros 0.0.3",
+ "libcrux-hacl-rs",
+ "libcrux-macros",
 ]
 
 [[package]]
@@ -4034,24 +3863,13 @@ dependencies = [
 
 [[package]]
 name = "libcrux-sha2"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "412cf855804ed65212e3d61983d500cea8b9259eff35bb6f8bf03aaf0ac19fbc"
-dependencies = [
- "libcrux-hacl-rs 0.0.2",
- "libcrux-macros 0.0.2",
- "libcrux-traits 0.0.2",
-]
-
-[[package]]
-name = "libcrux-sha2"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91eed3bb0ae073f46ae03c83318013fba6e3302bf3292639417b68e908fec4bf"
 dependencies = [
- "libcrux-hacl-rs 0.0.3",
- "libcrux-macros 0.0.3",
- "libcrux-traits 0.0.3",
+ "libcrux-hacl-rs",
+ "libcrux-macros",
+ "libcrux-traits",
 ]
 
 [[package]]
@@ -4063,15 +3881,6 @@ dependencies = [
  "hax-lib",
  "libcrux-intrinsics",
  "libcrux-platform",
-]
-
-[[package]]
-name = "libcrux-traits"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c487a3fb34361f4f78a9c9dc5eff4ae62ef3ccb69a916af7b524dd288de9db"
-dependencies = [
- "rand 0.9.2",
 ]
 
 [[package]]
@@ -4680,8 +4489,8 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openmls"
-version = "0.6.1"
-source = "git+https://github.com/xmtp/openmls?rev=76829d6c715ed115cf77e9086bac1f7bea15aa8a#76829d6c715ed115cf77e9086bac1f7bea15aa8a"
+version = "0.7.0"
+source = "git+https://github.com/xmtp/openmls?rev=6670113de406d42a8d0205b76961adcf610967ff#6670113de406d42a8d0205b76961adcf610967ff"
 dependencies = [
  "backtrace",
  "fluvio-wasm-timer",
@@ -4697,16 +4506,18 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "serde",
+ "serde_bytes",
  "serde_json",
  "thiserror 2.0.16",
  "tls_codec",
  "wasm-bindgen-test",
+ "zeroize",
 ]
 
 [[package]]
 name = "openmls_basic_credential"
-version = "0.3.0"
-source = "git+https://github.com/xmtp/openmls?rev=76829d6c715ed115cf77e9086bac1f7bea15aa8a#76829d6c715ed115cf77e9086bac1f7bea15aa8a"
+version = "0.4.0"
+source = "git+https://github.com/xmtp/openmls?rev=6670113de406d42a8d0205b76961adcf610967ff#6670113de406d42a8d0205b76961adcf610967ff"
 dependencies = [
  "ed25519-dalek",
  "openmls_traits",
@@ -4719,15 +4530,16 @@ dependencies = [
 [[package]]
 name = "openmls_libcrux_crypto"
 version = "0.2.0"
-source = "git+https://github.com/xmtp/openmls?rev=76829d6c715ed115cf77e9086bac1f7bea15aa8a#76829d6c715ed115cf77e9086bac1f7bea15aa8a"
+source = "git+https://github.com/xmtp/openmls?rev=6670113de406d42a8d0205b76961adcf610967ff#6670113de406d42a8d0205b76961adcf610967ff"
 dependencies = [
- "hpke-rs 0.3.0 (git+https://github.com/cryspen/hpke-rs?tag=v0.3.0)",
- "hpke-rs-crypto 0.3.0 (git+https://github.com/cryspen/hpke-rs?tag=v0.3.0)",
- "hpke-rs-libcrux 0.3.0 (git+https://github.com/cryspen/hpke-rs?tag=v0.3.0)",
- "libcrux-chacha20poly1305 0.0.2",
- "libcrux-ed25519 0.0.2",
- "libcrux-hkdf 0.0.2",
- "libcrux-sha2 0.0.2",
+ "hpke-rs",
+ "hpke-rs-crypto",
+ "hpke-rs-libcrux",
+ "libcrux-chacha20poly1305",
+ "libcrux-ed25519",
+ "libcrux-hkdf",
+ "libcrux-hmac",
+ "libcrux-sha2",
  "openmls_memory_storage",
  "openmls_traits",
  "rand 0.9.2",
@@ -4737,8 +4549,8 @@ dependencies = [
 
 [[package]]
 name = "openmls_memory_storage"
-version = "0.3.0"
-source = "git+https://github.com/xmtp/openmls?rev=76829d6c715ed115cf77e9086bac1f7bea15aa8a#76829d6c715ed115cf77e9086bac1f7bea15aa8a"
+version = "0.4.0"
+source = "git+https://github.com/xmtp/openmls?rev=6670113de406d42a8d0205b76961adcf610967ff#6670113de406d42a8d0205b76961adcf610967ff"
 dependencies = [
  "hex",
  "log",
@@ -4750,17 +4562,17 @@ dependencies = [
 
 [[package]]
 name = "openmls_rust_crypto"
-version = "0.3.0"
-source = "git+https://github.com/xmtp/openmls?rev=76829d6c715ed115cf77e9086bac1f7bea15aa8a#76829d6c715ed115cf77e9086bac1f7bea15aa8a"
+version = "0.4.0"
+source = "git+https://github.com/xmtp/openmls?rev=6670113de406d42a8d0205b76961adcf610967ff#6670113de406d42a8d0205b76961adcf610967ff"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
  "ed25519-dalek",
  "hkdf",
  "hmac",
- "hpke-rs 0.2.0",
- "hpke-rs-crypto 0.2.0",
- "hpke-rs-rust-crypto 0.2.0",
+ "hpke-rs",
+ "hpke-rs-crypto",
+ "hpke-rs-rust-crypto",
  "openmls_memory_storage",
  "openmls_traits",
  "p256",
@@ -4774,8 +4586,8 @@ dependencies = [
 
 [[package]]
 name = "openmls_test"
-version = "0.1.0"
-source = "git+https://github.com/xmtp/openmls?rev=76829d6c715ed115cf77e9086bac1f7bea15aa8a#76829d6c715ed115cf77e9086bac1f7bea15aa8a"
+version = "0.2.0"
+source = "git+https://github.com/xmtp/openmls?rev=6670113de406d42a8d0205b76961adcf610967ff#6670113de406d42a8d0205b76961adcf610967ff"
 dependencies = [
  "ansi_term",
  "openmls_rust_crypto",
@@ -4790,7 +4602,7 @@ dependencies = [
 [[package]]
 name = "openmls_traits"
 version = "0.4.0"
-source = "git+https://github.com/xmtp/openmls?rev=76829d6c715ed115cf77e9086bac1f7bea15aa8a#76829d6c715ed115cf77e9086bac1f7bea15aa8a"
+source = "git+https://github.com/xmtp/openmls?rev=6670113de406d42a8d0205b76961adcf610967ff#6670113de406d42a8d0205b76961adcf610967ff"
 dependencies = [
  "serde",
  "tls_codec",
@@ -8520,17 +8332,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
-name = "wycheproof"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efb3be19abfb206c6adcbdf2007b09b0e8ca1f6530db40c03b42ce8ed4719894"
-dependencies = [
- "data-encoding",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8832,7 +8633,7 @@ dependencies = [
  "const-hex",
  "ed25519-dalek",
  "getrandom 0.3.3",
- "libcrux-ed25519 0.0.3",
+ "libcrux-ed25519",
  "openmls",
  "openmls_basic_credential",
  "openmls_traits",
@@ -8975,7 +8776,7 @@ dependencies = [
  "getrandom 0.3.3",
  "hkdf",
  "hmac",
- "hpke-rs 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hpke-rs",
  "indicatif 0.17.11",
  "itertools 0.14.0",
  "json-patch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,11 +97,11 @@ js-sys = "0.3"
 mockall = { version = "0.13" }
 mockall_double = "0.3.1"
 once_cell = "1.2"
-openmls = { git = "https://github.com/xmtp/openmls", rev = "76829d6c715ed115cf77e9086bac1f7bea15aa8a", default-features = false }
-openmls_basic_credential = { git = "https://github.com/xmtp/openmls", rev = "76829d6c715ed115cf77e9086bac1f7bea15aa8a" }
-openmls_libcrux_crypto = { git = "https://github.com/xmtp/openmls", rev = "76829d6c715ed115cf77e9086bac1f7bea15aa8a" }
-openmls_rust_crypto = { git = "https://github.com/xmtp/openmls", rev = "76829d6c715ed115cf77e9086bac1f7bea15aa8a" }
-openmls_traits = { git = "https://github.com/xmtp/openmls", rev = "76829d6c715ed115cf77e9086bac1f7bea15aa8a" }
+openmls = { git = "https://github.com/xmtp/openmls", rev = "6670113de406d42a8d0205b76961adcf610967ff", default-features = false }
+openmls_basic_credential = { git = "https://github.com/xmtp/openmls", rev = "6670113de406d42a8d0205b76961adcf610967ff" }
+openmls_libcrux_crypto = { git = "https://github.com/xmtp/openmls", rev = "6670113de406d42a8d0205b76961adcf610967ff" }
+openmls_rust_crypto = { git = "https://github.com/xmtp/openmls", rev = "6670113de406d42a8d0205b76961adcf610967ff" }
+openmls_traits = { git = "https://github.com/xmtp/openmls", rev = "6670113de406d42a8d0205b76961adcf610967ff" }
 owo-colors = { version = "4.1" }
 p256 = { version = "0.13.2", features = ["ecdsa"] }
 parking_lot = "0.12.3"

--- a/xmtp_db/src/errors.rs
+++ b/xmtp_db/src/errors.rs
@@ -321,7 +321,9 @@ impl RetryableError<Mls>
     }
 }
 
-impl RetryableError<Mls> for openmls::prelude::ProcessMessageError {
+impl RetryableError<Mls>
+    for openmls::prelude::ProcessMessageError<sql_key_store::SqlKeyStoreError>
+{
     fn is_retryable(&self) -> bool {
         match self {
             Self::GroupStateError(err) => retryable!(err),

--- a/xmtp_mls/src/groups/mls_ext/decrypted_welcome.rs
+++ b/xmtp_mls/src/groups/mls_ext/decrypted_welcome.rs
@@ -1,5 +1,5 @@
 use openmls::{
-    group::{MlsGroupJoinConfig, ProcessedWelcome, StagedWelcome, WireFormatPolicy},
+    group::{MlsGroupJoinConfig, StagedWelcome, WireFormatPolicy},
     prelude::{
         BasicCredential, KeyPackageBundle, KeyPackageRef, MlsMessageBodyIn, MlsMessageIn, Welcome,
     },
@@ -67,15 +67,15 @@ impl DecryptedWelcome {
 
         let join_config = build_group_join_config();
 
-        let processed_welcome =
-            ProcessedWelcome::new_from_welcome(provider, &join_config, welcome.clone())?;
+        let builder = StagedWelcome::build_from_welcome(provider, &join_config, welcome.clone())?;
+        let processed_welcome = builder.processed_welcome();
 
         let psks = processed_welcome.psks();
         if !psks.is_empty() {
             tracing::error!("No PSK support for welcome");
             return Err(GroupError::NoPSKSupport);
         }
-        let staged_welcome = processed_welcome.into_staged_welcome(provider, None)?;
+        let staged_welcome = builder.skip_lifetime_validation().build()?;
 
         let added_by_node = staged_welcome.welcome_sender()?;
 

--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -134,7 +134,9 @@ pub enum GroupMessageProcessingError {
     #[error(transparent)]
     Identity(#[from] IdentityError),
     #[error("openmls process message error: {0}")]
-    OpenMlsProcessMessage(#[from] openmls::prelude::ProcessMessageError),
+    OpenMlsProcessMessage(
+        #[from] openmls::prelude::ProcessMessageError<sql_key_store::SqlKeyStoreError>,
+    ),
     #[error("merge staged commit: {0}")]
     MergeStagedCommit(#[from] openmls::group::MergeCommitError<sql_key_store::SqlKeyStoreError>),
     #[error("TLS Codec error: {0}")]


### PR DESCRIPTION
Updates openMLS dep to include the latest upstream changes. Importantly, includes https://github.com/openmls/openmls/pull/1846, which possibly fixes https://github.com/xmtp/libxmtp/issues/2354

> The gist is that we didn’t persist the private tree correctly, which means that we may keep old secret trees around on clients (depending on sending behaviour), which violates the RFC and of course breaks forward secrecy within the epoch.
In really bad cases this may actually also break functionality (decryption), if a client is passive and the epochs are long (because the forward ratchet limit may be reached).

Changes to libxmtp:
- We were previously pointing directly at https://github.com/xmtp/openmls/pull/43, rather than main. The changes previously hardcoded into that PR have been merged as a config flag in upstream, so that PR no longer needs to merge into main. I believe I've set the corresponding libxmtp flags via the `StagedWelcome` builder in `decrypted_welcome.rs`, but it's worth double-checking @neekolas @mchenani.
   - What I checked: `test_sync_welcomes_when_kp_life_time_ended` fails without my change, fails with my change but without `.skip_lifetime_validation()`, and passes when `.skip_lifetime_validation()` is set.
- The OpenMLS `ProcessMessageError` now takes in a generic, so also updated libxmtp code to reflect this.