### PR TITLE
Minor fix to update xmtp-ios workflow

### DIFF
--- a/.github/workflows/update-xmtp-ios.yml
+++ b/.github/workflows/update-xmtp-ios.yml
@@ -88,7 +88,7 @@ jobs:
           VERSION="${{ steps.version_info.outputs.version }}"
 
           # Update version in podspec
-          sed -i '' "s/s.version *= *'[^']*'/s.version          = '${VERSION}'/" XMTP.podspec
+          sed -i '' "s/spec.version *= *\"[^\"]*\"/spec.version      = \"${VERSION}\"/" XMTP.podspec
 
           # Verify podspec
           pod spec lint XMTP.podspec || echo "Podspec validation failed but continuing"


### PR DESCRIPTION
### Update the .github/workflows/update-xmtp-ios.yml workflow to modify XMTP.podspec lines matching spec.version = "..." for the stated minor fix
The workflow in [update-xmtp-ios.yml](https://github.com/xmtp/libxmtp/pull/2499/files#diff-dcceb95781152767c2f46b9a180c00ca0f22e0ffbe1a02562ab54eff20045970) changes the `sed` command to target `spec.version = "..."` with adjusted spacing, replacing the previous match on `s.version = '...'` in `XMTP.podspec`.

#### 📍Where to Start
Start with the shell step that runs `sed` in [update-xmtp-ios.yml](https://github.com/xmtp/libxmtp/pull/2499/files#diff-dcceb95781152767c2f46b9a180c00ca0f22e0ffbe1a02562ab54eff20045970).

----

_[Macroscope](https://app.macroscope.com) summarized c2dd690._