### PR TITLE
Fix lifetime validation gaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4490,7 +4490,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 [[package]]
 name = "openmls"
 version = "0.7.0"
-source = "git+https://github.com/xmtp/openmls?rev=6670113de406d42a8d0205b76961adcf610967ff#6670113de406d42a8d0205b76961adcf610967ff"
+source = "git+https://github.com/xmtp/openmls?rev=ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08#ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08"
 dependencies = [
  "backtrace",
  "fluvio-wasm-timer",
@@ -4517,7 +4517,7 @@ dependencies = [
 [[package]]
 name = "openmls_basic_credential"
 version = "0.4.0"
-source = "git+https://github.com/xmtp/openmls?rev=6670113de406d42a8d0205b76961adcf610967ff#6670113de406d42a8d0205b76961adcf610967ff"
+source = "git+https://github.com/xmtp/openmls?rev=ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08#ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08"
 dependencies = [
  "ed25519-dalek",
  "openmls_traits",
@@ -4530,7 +4530,7 @@ dependencies = [
 [[package]]
 name = "openmls_libcrux_crypto"
 version = "0.2.0"
-source = "git+https://github.com/xmtp/openmls?rev=6670113de406d42a8d0205b76961adcf610967ff#6670113de406d42a8d0205b76961adcf610967ff"
+source = "git+https://github.com/xmtp/openmls?rev=ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08#ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08"
 dependencies = [
  "hpke-rs",
  "hpke-rs-crypto",
@@ -4550,7 +4550,7 @@ dependencies = [
 [[package]]
 name = "openmls_memory_storage"
 version = "0.4.0"
-source = "git+https://github.com/xmtp/openmls?rev=6670113de406d42a8d0205b76961adcf610967ff#6670113de406d42a8d0205b76961adcf610967ff"
+source = "git+https://github.com/xmtp/openmls?rev=ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08#ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08"
 dependencies = [
  "hex",
  "log",
@@ -4563,7 +4563,7 @@ dependencies = [
 [[package]]
 name = "openmls_rust_crypto"
 version = "0.4.0"
-source = "git+https://github.com/xmtp/openmls?rev=6670113de406d42a8d0205b76961adcf610967ff#6670113de406d42a8d0205b76961adcf610967ff"
+source = "git+https://github.com/xmtp/openmls?rev=ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08#ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -4587,7 +4587,7 @@ dependencies = [
 [[package]]
 name = "openmls_test"
 version = "0.2.0"
-source = "git+https://github.com/xmtp/openmls?rev=6670113de406d42a8d0205b76961adcf610967ff#6670113de406d42a8d0205b76961adcf610967ff"
+source = "git+https://github.com/xmtp/openmls?rev=ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08#ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08"
 dependencies = [
  "ansi_term",
  "openmls_rust_crypto",
@@ -4602,7 +4602,7 @@ dependencies = [
 [[package]]
 name = "openmls_traits"
 version = "0.4.0"
-source = "git+https://github.com/xmtp/openmls?rev=6670113de406d42a8d0205b76961adcf610967ff#6670113de406d42a8d0205b76961adcf610967ff"
+source = "git+https://github.com/xmtp/openmls?rev=ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08#ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08"
 dependencies = [
  "serde",
  "tls_codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4490,7 +4490,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 [[package]]
 name = "openmls"
 version = "0.7.0"
-source = "git+https://github.com/xmtp/openmls?rev=ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08#ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08"
+source = "git+https://github.com/xmtp/openmls?rev=d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0#d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0"
 dependencies = [
  "backtrace",
  "fluvio-wasm-timer",
@@ -4517,7 +4517,7 @@ dependencies = [
 [[package]]
 name = "openmls_basic_credential"
 version = "0.4.0"
-source = "git+https://github.com/xmtp/openmls?rev=ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08#ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08"
+source = "git+https://github.com/xmtp/openmls?rev=d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0#d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0"
 dependencies = [
  "ed25519-dalek",
  "openmls_traits",
@@ -4530,7 +4530,7 @@ dependencies = [
 [[package]]
 name = "openmls_libcrux_crypto"
 version = "0.2.0"
-source = "git+https://github.com/xmtp/openmls?rev=ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08#ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08"
+source = "git+https://github.com/xmtp/openmls?rev=d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0#d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0"
 dependencies = [
  "hpke-rs",
  "hpke-rs-crypto",
@@ -4550,7 +4550,7 @@ dependencies = [
 [[package]]
 name = "openmls_memory_storage"
 version = "0.4.0"
-source = "git+https://github.com/xmtp/openmls?rev=ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08#ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08"
+source = "git+https://github.com/xmtp/openmls?rev=d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0#d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0"
 dependencies = [
  "hex",
  "log",
@@ -4563,7 +4563,7 @@ dependencies = [
 [[package]]
 name = "openmls_rust_crypto"
 version = "0.4.0"
-source = "git+https://github.com/xmtp/openmls?rev=ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08#ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08"
+source = "git+https://github.com/xmtp/openmls?rev=d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0#d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -4587,7 +4587,7 @@ dependencies = [
 [[package]]
 name = "openmls_test"
 version = "0.2.0"
-source = "git+https://github.com/xmtp/openmls?rev=ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08#ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08"
+source = "git+https://github.com/xmtp/openmls?rev=d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0#d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0"
 dependencies = [
  "ansi_term",
  "openmls_rust_crypto",
@@ -4602,7 +4602,7 @@ dependencies = [
 [[package]]
 name = "openmls_traits"
 version = "0.4.0"
-source = "git+https://github.com/xmtp/openmls?rev=ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08#ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08"
+source = "git+https://github.com/xmtp/openmls?rev=d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0#d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0"
 dependencies = [
  "serde",
  "tls_codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,11 +97,11 @@ js-sys = "0.3"
 mockall = { version = "0.13" }
 mockall_double = "0.3.1"
 once_cell = "1.2"
-openmls = { git = "https://github.com/xmtp/openmls", rev = "6670113de406d42a8d0205b76961adcf610967ff", default-features = false }
-openmls_basic_credential = { git = "https://github.com/xmtp/openmls", rev = "6670113de406d42a8d0205b76961adcf610967ff" }
-openmls_libcrux_crypto = { git = "https://github.com/xmtp/openmls", rev = "6670113de406d42a8d0205b76961adcf610967ff" }
-openmls_rust_crypto = { git = "https://github.com/xmtp/openmls", rev = "6670113de406d42a8d0205b76961adcf610967ff" }
-openmls_traits = { git = "https://github.com/xmtp/openmls", rev = "6670113de406d42a8d0205b76961adcf610967ff" }
+openmls = { git = "https://github.com/xmtp/openmls", rev = "ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08", default-features = false }
+openmls_basic_credential = { git = "https://github.com/xmtp/openmls", rev = "ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08" }
+openmls_libcrux_crypto = { git = "https://github.com/xmtp/openmls", rev = "ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08" }
+openmls_rust_crypto = { git = "https://github.com/xmtp/openmls", rev = "ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08" }
+openmls_traits = { git = "https://github.com/xmtp/openmls", rev = "ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08" }
 owo-colors = { version = "4.1" }
 p256 = { version = "0.13.2", features = ["ecdsa"] }
 parking_lot = "0.12.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,11 +97,11 @@ js-sys = "0.3"
 mockall = { version = "0.13" }
 mockall_double = "0.3.1"
 once_cell = "1.2"
-openmls = { git = "https://github.com/xmtp/openmls", rev = "ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08", default-features = false }
-openmls_basic_credential = { git = "https://github.com/xmtp/openmls", rev = "ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08" }
-openmls_libcrux_crypto = { git = "https://github.com/xmtp/openmls", rev = "ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08" }
-openmls_rust_crypto = { git = "https://github.com/xmtp/openmls", rev = "ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08" }
-openmls_traits = { git = "https://github.com/xmtp/openmls", rev = "ef01de5f0f3cbc99f58dd55d5a38e5722d2e1e08" }
+openmls = { git = "https://github.com/xmtp/openmls", rev = "d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0", default-features = false }
+openmls_basic_credential = { git = "https://github.com/xmtp/openmls", rev = "d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0" }
+openmls_libcrux_crypto = { git = "https://github.com/xmtp/openmls", rev = "d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0" }
+openmls_rust_crypto = { git = "https://github.com/xmtp/openmls", rev = "d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0" }
+openmls_traits = { git = "https://github.com/xmtp/openmls", rev = "d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0" }
 owo-colors = { version = "4.1" }
 p256 = { version = "0.13.2", features = ["ecdsa"] }
 parking_lot = "0.12.3"

--- a/xmtp_api_d14n/src/protocol/extractors.rs
+++ b/xmtp_api_d14n/src/protocol/extractors.rs
@@ -365,7 +365,11 @@ impl EnvelopeVisitor<'_> for TopicExtractor {
         let kp_in: KeyPackageIn =
             KeyPackageIn::tls_deserialize_exact(upload.key_package_tls_serialized.as_slice())?;
         let rust_crypto = RustCrypto::default();
-        let kp = kp_in.validate(&rust_crypto, super::MLS_PROTOCOL_VERSION)?;
+        let kp = kp_in.validate(
+            &rust_crypto,
+            super::MLS_PROTOCOL_VERSION,
+            openmls::prelude::LeafNodeLifetimePolicy::Verify,
+        )?;
         let installation_key = kp.leaf_node().signature_key().as_slice();
         self.topic = Some(TopicKind::KeyPackagesV1.build(installation_key));
         Ok(())

--- a/xmtp_mls/src/verified_key_package_v2.rs
+++ b/xmtp_mls/src/verified_key_package_v2.rs
@@ -68,7 +68,11 @@ impl VerifiedKeyPackageV2 {
         data: &[u8],
     ) -> Result<Self, KeyPackageVerificationError> {
         let kp_in: KeyPackageIn = KeyPackageIn::tls_deserialize_exact(data)?;
-        let kp = kp_in.validate(crypto_provider, MLS_PROTOCOL_VERSION)?;
+        let kp = kp_in.validate(
+            crypto_provider,
+            MLS_PROTOCOL_VERSION,
+            openmls::prelude::LeafNodeLifetimePolicy::Verify,
+        )?;
 
         kp.try_into()
     }

--- a/xmtp_proto/src/v4_utils.rs
+++ b/xmtp_proto/src/v4_utils.rs
@@ -89,7 +89,11 @@ pub fn get_key_package_topic(key_package: &KeyPackageUpload) -> Result<Vec<u8>, 
     let kp_in: KeyPackageIn =
         KeyPackageIn::tls_deserialize_exact(key_package.key_package_tls_serialized.as_slice())?;
     let rust_crypto = RustCrypto::default();
-    let kp = kp_in.validate(&rust_crypto, MLS_PROTOCOL_VERSION)?;
+    let kp = kp_in.validate(
+        &rust_crypto,
+        MLS_PROTOCOL_VERSION,
+        openmls::prelude::LeafNodeLifetimePolicy::Verify,
+    )?;
     let installation_key = kp.leaf_node().signature_key().as_slice();
     Ok(build_key_package_topic(installation_key))
 }


### PR DESCRIPTION
More details in https://github.com/xmtp/openmls/pull/45. This is pointing to that PR for now, but will modify to point to main once it is landed.

I've set `LeafNodeLifetimePolicy::Verify` everywhere for now, because that matches the existing behavior. We may well find we want to change it.