### PR TITLE
Bump MLS version and stop pushing to infra

### DIFF
--- a/.github/workflows/deploy-validation-server.yml
+++ b/.github/workflows/deploy-validation-server.yml
@@ -42,24 +42,3 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
-  deploy:
-    name: Deploy new images to infra
-    runs-on: ubuntu-latest
-    needs: push_to_registry
-    strategy:
-      matrix:
-        environment: [dev, production, testnet-staging]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Deploy to ${{ matrix.environment }}
-        uses: xmtp-labs/terraform-deployer@v1
-        with:
-          terraform-token: ${{ secrets.TERRAFORM_TOKEN }}
-          terraform-org: xmtp
-          terraform-workspace: ${{ matrix.environment }}
-          variable-name: validation_service_image
-          variable-value: "ghcr.io/xmtp/mls-validation-service@${{ needs.push_to_registry.outputs.digest }}"
-          variable-value-required-prefix: "ghcr.io/xmtp/mls-validation-service@sha256:"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4146,7 +4146,7 @@ dependencies = [
 
 [[package]]
 name = "mls_validation_service"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "alloy",
  "anyhow",

--- a/mls_validation_service/Cargo.toml
+++ b/mls_validation_service/Cargo.toml
@@ -3,7 +3,7 @@ build = "build.rs"
 edition = "2021"
 license.workspace = true
 name = "mls_validation_service"
-version = "0.1.4"
+version = "0.1.5"
 
 [[bin]] # Bin to run the Validation Service
 name = "mls-validation-service"


### PR DESCRIPTION
Our infra deploy stack is something like 26 elements deep. Most commits are unrelated to the MLS validation service so triggering a new redeploy (which takes 10 minutes) in 3 different environments is not the best use of our time.

I released 0.1.4 from main today and will pin that version in all environments. If we ever introduce a breaking change, we can do it manually or use the auto-generated from-main SHA versions.