### PR TITLE
1.5.0 final release versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_node"
-version = "1.5.0-rc3"
+version = "1.5.0"
 dependencies = [
  "chrono",
  "const-hex",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_wasm"
-version = "1.5.0-rc3"
+version = "1.5.0"
 dependencies = [
  "alloy",
  "chrono",
@@ -8401,7 +8401,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api"
-version = "1.5.0-rc3"
+version = "1.5.0"
 dependencies = [
  "async-trait",
  "const-hex",
@@ -8424,7 +8424,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_d14n"
-version = "1.5.0-rc3"
+version = "1.5.0"
 dependencies = [
  "async-trait",
  "const-hex",
@@ -8452,7 +8452,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_grpc"
-version = "1.5.0-rc3"
+version = "1.5.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -8476,7 +8476,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_http"
-version = "1.5.0-rc3"
+version = "1.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8503,7 +8503,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_archive"
-version = "1.5.0-rc3"
+version = "1.5.0"
 dependencies = [
  "aes-gcm",
  "async-compression",
@@ -8530,7 +8530,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_cli"
-version = "1.5.0-rc3"
+version = "1.5.0"
 dependencies = [
  "alloy",
  "chrono",
@@ -8564,7 +8564,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_common"
-version = "1.5.0-rc3"
+version = "1.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8600,7 +8600,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_configuration"
-version = "1.5.0-rc3"
+version = "1.5.0"
 dependencies = [
  "openmls",
  "url",
@@ -8610,7 +8610,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_content_types"
-version = "1.5.0-rc3"
+version = "1.5.0"
 dependencies = [
  "base64 0.22.1",
  "const-hex",
@@ -8626,7 +8626,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_cryptography"
-version = "1.5.0-rc3"
+version = "1.5.0"
 dependencies = [
  "alloy",
  "bincode",
@@ -8650,7 +8650,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_db"
-version = "1.5.0-rc3"
+version = "1.5.0"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -8691,7 +8691,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_db_test"
-version = "1.5.0-rc3"
+version = "1.5.0"
 dependencies = [
  "derive_builder",
  "diesel",
@@ -8704,7 +8704,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_id"
-version = "1.5.0-rc3"
+version = "1.5.0"
 dependencies = [
  "alloy",
  "async-trait",
@@ -8740,7 +8740,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_macro"
-version = "1.5.0-rc3"
+version = "1.5.0"
 dependencies = [
  "num_cpus",
  "proc-macro2",
@@ -8752,7 +8752,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_mls"
-version = "1.5.0-rc3"
+version = "1.5.0"
 dependencies = [
  "aes-gcm",
  "alloy",
@@ -8833,7 +8833,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_mls_common"
-version = "1.5.0-rc3"
+version = "1.5.0"
 dependencies = [
  "const-hex",
  "openmls",
@@ -8851,7 +8851,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_proto"
-version = "1.5.0-rc3"
+version = "1.5.0"
 dependencies = [
  "async-trait",
  "color-eyre",
@@ -8886,7 +8886,7 @@ dependencies = [
 
 [[package]]
 name = "xmtpv3"
-version = "1.5.0-rc3"
+version = "1.5.0"
 dependencies = [
  "alloy",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ resolver = "2"
 
 [workspace.package]
 license = "MIT"
-version = "1.5.0-rc3"
+version = "1.5.0"
 
 [workspace.dependencies]
 aes-gcm = { version = "0.10.3", features = ["std"] }

--- a/bindings_node/package.json
+++ b/bindings_node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/node-bindings",
-  "version": "1.5.0-rc3",
+  "version": "1.5.0",
   "repository": {
     "type": "git",
     "url": "git+https://git@github.com/xmtp/libxmtp.git",

--- a/bindings_wasm/package.json
+++ b/bindings_wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/wasm-bindings",
-  "version": "1.5.0-rc3",
+  "version": "1.5.0",
   "type": "module",
   "license": "MIT",
   "description": "WASM bindings for the libXMTP rust library",


### PR DESCRIPTION
## See full list of updates below:

New Enriched Messages experimental APIs (android/iOS only):
- https://github.com/xmtp/libxmtp/pull/2294
- https://github.com/xmtp/libxmtp/pull/2321
- https://github.com/xmtp/libxmtp/pull/2325
- https://github.com/xmtp/libxmtp/pull/2326
- https://github.com/xmtp/libxmtp/pull/2352

New xmtp_debug query commands
- https://github.com/xmtp/libxmtp/pull/2363
- https://github.com/xmtp/libxmtp/pull/2389
- https://github.com/xmtp/libxmtp/pull/2390

Get Latest message Times by sender (android/iOS only):
- https://github.com/xmtp/libxmtp/pull/2392

Lens chain added to SCW verifier allowlist
- https://github.com/xmtp/libxmtp/pull/2419

Faster syncing of new groups: new welcome message cursor prevents attempts at decrypting old messages 
- https://github.com/xmtp/libxmtp/pull/2088
  
New ethereum crypto functions in libxmtp for replacing ios secp256k dependencies
- https://github.com/xmtp/libxmtp/pull/2408

OpenMLS fix persistence during message processing:
- https://github.com/xmtp/libxmtp/pull/2498

Fix lifetime validation gaps:
- https://github.com/xmtp/libxmtp/pull/2502