### PR TITLE
Ensure latest npm before publishing

### DIFF
--- a/.github/workflows/release-node-bindings.yml
+++ b/.github/workflows/release-node-bindings.yml
@@ -359,6 +359,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Update npm to latest
+        run: npm install -g npm@latest
+
       - name: Publish to NPM
         uses: JS-DevTools/npm-publish@v4
         with:

--- a/.github/workflows/release-wasm-bindings.yml
+++ b/.github/workflows/release-wasm-bindings.yml
@@ -115,6 +115,8 @@ jobs:
           git push origin "wasm-bindings-${PACKAGE_VERSION}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update npm to latest
+        run: npm install -g npm@latest
       - name: Publish to NPM
         uses: JS-DevTools/npm-publish@v4
         with:


### PR DESCRIPTION
### Install latest npm before publish steps in .github/workflows/release-node-bindings.yml and .github/workflows/release-wasm-bindings.yml
This change inserts a step in two release workflows to update npm to the latest version immediately before the publish step.

- Add a global npm update step before publish in [release-node-bindings.yml](https://github.com/xmtp/libxmtp/pull/2511/files#diff-0c04063335c6f5d23180cdad4da9b8bc5a4cc7dc2890c690e61a973220ba0ec3)
- Add a global npm update step before publish in [release-wasm-bindings.yml](https://github.com/xmtp/libxmtp/pull/2511/files#diff-8ac8fedf1ee50dabf3d48a77190d2741d37b10bc75e0ef6382d42bfadd092fe3)

#### 📍Where to Start
Start with the publish job steps in [release-node-bindings.yml](https://github.com/xmtp/libxmtp/pull/2511/files#diff-0c04063335c6f5d23180cdad4da9b8bc5a4cc7dc2890c690e61a973220ba0ec3) and [release-wasm-bindings.yml](https://github.com/xmtp/libxmtp/pull/2511/files#diff-8ac8fedf1ee50dabf3d48a77190d2741d37b10bc75e0ef6382d42bfadd092fe3) to review the newly added npm update step placed immediately before the publish step.

----

_[Macroscope](https://app.macroscope.com) summarized a2b47e8._