### PR TITLE
1.5.1 npm publish updates

### DIFF
--- a/.github/workflows/release-node-bindings.yml
+++ b/.github/workflows/release-node-bindings.yml
@@ -14,7 +14,7 @@ jobs:
         run: |
           chmod +x dev/sync-versions.sh
           ./dev/sync-versions.sh
-          
+
           # Check if there are any changes after syncing versions
           if [[ -n $(git status --porcelain) ]]; then
             echo "::error::Version mismatch detected! Please run 'dev/sync-versions.sh' locally, commit the changes before releasing bindings_node"
@@ -310,7 +310,7 @@ jobs:
         run: |
           # Read the current version from package.json
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
-          
+
           # Check if this is a dev version
           if [[ "$PACKAGE_VERSION" == *"dev"* ]]; then
             # Read the git commit hash from version.json
@@ -337,7 +337,7 @@ jobs:
         run: |
           # Read the current version from package.json
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
-          
+
           # Set the tag based on whether it's a dev version
           if [[ "$PACKAGE_VERSION" == *"dev"* ]]; then
             echo "tag=prerelease" >> $GITHUB_OUTPUT
@@ -350,7 +350,7 @@ jobs:
         run: |
           # Read the current version from package.json
           PACKAGE_VERSION=$(node -p "require('./bindings_node/package.json').version")
-          
+
           # Create and push the tag
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
@@ -362,7 +362,6 @@ jobs:
       - name: Publish to NPM
         uses: JS-DevTools/npm-publish@v4
         with:
-          token: ${{ secrets.NPM_TOKEN }}
           package: bindings_node
           tag: ${{ steps.npm-tag.outputs.tag }}
           dry-run: false

--- a/.github/workflows/release-node-bindings.yml
+++ b/.github/workflows/release-node-bindings.yml
@@ -359,6 +359,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Update npm to latest
+        run: npm install -g npm@latest
+
       - name: Publish to NPM
         uses: JS-DevTools/npm-publish@v4
         with:

--- a/.github/workflows/release-wasm-bindings.yml
+++ b/.github/workflows/release-wasm-bindings.yml
@@ -118,7 +118,6 @@ jobs:
       - name: Publish to NPM
         uses: JS-DevTools/npm-publish@v4
         with:
-          token: ${{ secrets.NPM_TOKEN }}
           package: bindings_wasm
           tag: ${{ steps.npm-tag.outputs.tag }}
           dry-run: false

--- a/.github/workflows/release-wasm-bindings.yml
+++ b/.github/workflows/release-wasm-bindings.yml
@@ -115,6 +115,8 @@ jobs:
           git push origin "wasm-bindings-${PACKAGE_VERSION}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update npm to latest
+        run: npm install -g npm@latest
       - name: Publish to NPM
         uses: JS-DevTools/npm-publish@v4
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_node"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "chrono",
  "const-hex",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_wasm"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "alloy",
  "chrono",
@@ -8401,7 +8401,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "async-trait",
  "const-hex",
@@ -8424,7 +8424,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_d14n"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "async-trait",
  "const-hex",
@@ -8452,7 +8452,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_grpc"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "async-trait",
  "futures",
@@ -8476,7 +8476,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_http"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8503,7 +8503,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_archive"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "aes-gcm",
  "async-compression",
@@ -8530,7 +8530,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_cli"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "alloy",
  "chrono",
@@ -8564,7 +8564,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_common"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8600,7 +8600,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_configuration"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "openmls",
  "url",
@@ -8610,7 +8610,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_content_types"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "base64 0.22.1",
  "const-hex",
@@ -8626,7 +8626,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_cryptography"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "alloy",
  "bincode",
@@ -8650,7 +8650,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_db"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -8691,7 +8691,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_db_test"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "derive_builder",
  "diesel",
@@ -8704,7 +8704,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_id"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "alloy",
  "async-trait",
@@ -8740,7 +8740,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_macro"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "num_cpus",
  "proc-macro2",
@@ -8752,7 +8752,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_mls"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "aes-gcm",
  "alloy",
@@ -8833,7 +8833,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_mls_common"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "const-hex",
  "openmls",
@@ -8851,7 +8851,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_proto"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "async-trait",
  "color-eyre",
@@ -8886,7 +8886,7 @@ dependencies = [
 
 [[package]]
 name = "xmtpv3"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "alloy",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ resolver = "2"
 
 [workspace.package]
 license = "MIT"
-version = "1.5.0"
+version = "1.5.1"
 
 [workspace.dependencies]
 aes-gcm = { version = "0.10.3", features = ["std"] }

--- a/bindings_node/package.json
+++ b/bindings_node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/node-bindings",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "repository": {
     "type": "git",
     "url": "git+https://git@github.com/xmtp/libxmtp.git",

--- a/bindings_wasm/package.json
+++ b/bindings_wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/wasm-bindings",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "type": "module",
   "license": "MIT",
   "description": "WASM bindings for the libXMTP rust library",


### PR DESCRIPTION
### Update release workflows to install npm@latest and publish 1.5.1 packages for Node and WASM bindings
- Add an "Update npm to latest" step (`npm install -g npm@latest`) to [release-node-bindings.yml](https://github.com/xmtp/libxmtp/pull/2512/files#diff-0c04063335c6f5d23180cdad4da9b8bc5a4cc7dc2890c690e61a973220ba0ec3) and [release-wasm-bindings.yml](https://github.com/xmtp/libxmtp/pull/2512/files#diff-8ac8fedf1ee50dabf3d48a77190d2741d37b10bc75e0ef6382d42bfadd092fe3)

- Remove the `token: ${{ secrets.NPM_TOKEN }}` input from the "Publish to NPM" step in both workflows

- Bump workspace and package versions from 1.5.0 to 1.5.1 in [Cargo.toml](https://github.com/xmtp/libxmtp/pull/2512/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542), [Cargo.lock](https://github.com/xmtp/libxmtp/pull/2512/files#diff-13ee4b2252c9e516a0547f2891aa2105c3ca71c6d7a1e682c69be97998dfc87e), [bindings_node/package.json](https://github.com/xmtp/libxmtp/pull/2512/files#diff-bc8be8e755c9188d5b1c3402b397741f9151dad43d877a181f31003052d10b99), and [bindings_wasm/package.json](https://github.com/xmtp/libxmtp/pull/2512/files#diff-4a621639e0561b5b01c30ab7fa75cc2b67c54dad6763ecabda35df8e2b16b14e)

- Adjust whitespace in [release-node-bindings.yml](https://github.com/xmtp/libxmtp/pull/2512/files#diff-0c04063335c6f5d23180cdad4da9b8bc5a4cc7dc2890c690e61a973220ba0ec3)

#### 📍Where to Start
Start with the workflow changes in [release-node-bindings.yml](https://github.com/xmtp/libxmtp/pull/2512/files#diff-0c04063335c6f5d23180cdad4da9b8bc5a4cc7dc2890c690e61a973220ba0ec3), then review [release-wasm-bindings.yml](https://github.com/xmtp/libxmtp/pull/2512/files#diff-8ac8fedf1ee50dabf3d48a77190d2741d37b10bc75e0ef6382d42bfadd092fe3) to confirm identical publish steps.

----

_[Macroscope](https://app.macroscope.com) summarized 6b26847._