### PR TITLE
update diesel to v2.3.0, remove git patches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2203,8 +2203,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.2.4"
-source = "git+https://github.com/diesel-rs/diesel?branch=master#0e9ae48cb59d580e374d1153d0f60f19509c4826"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8496eeb328dce26ee9d9b73275d396d9bddb433fa30106cf6056dd8c3c2764c"
 dependencies = [
  "diesel_derives",
  "downcast-rs",
@@ -2217,8 +2218,9 @@ dependencies = [
 
 [[package]]
 name = "diesel_derives"
-version = "2.2.0"
-source = "git+https://github.com/diesel-rs/diesel?branch=master#0e9ae48cb59d580e374d1153d0f60f19509c4826"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09af0e983035368439f1383011cd87c46f41da81d0f21dc3727e2857d5a43c8e"
 dependencies = [
  "diesel_table_macro_syntax",
  "dsl_auto_type",
@@ -2229,8 +2231,9 @@ dependencies = [
 
 [[package]]
 name = "diesel_migrations"
-version = "2.2.0"
-source = "git+https://github.com/diesel-rs/diesel?branch=master#0e9ae48cb59d580e374d1153d0f60f19509c4826"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee060f709c3e3b1cadd83fcd0f61711f7a8cf493348f758d3a1c1147d70b3c97"
 dependencies = [
  "diesel",
  "migrations_internals",
@@ -2239,8 +2242,9 @@ dependencies = [
 
 [[package]]
 name = "diesel_table_macro_syntax"
-version = "0.2.0"
-source = "git+https://github.com/diesel-rs/diesel?branch=master#0e9ae48cb59d580e374d1153d0f60f19509c4826"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe2444076b48641147115697648dc743c2c00b61adade0f01ce67133c7babe8c"
 dependencies = [
  "syn 2.0.106",
 ]
@@ -2312,10 +2316,11 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 
 [[package]]
 name = "dsl_auto_type"
-version = "0.1.0"
-source = "git+https://github.com/diesel-rs/diesel?branch=master#0e9ae48cb59d580e374d1153d0f60f19509c4826"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd122633e4bef06db27737f21d3738fb89c8f6d5360d6d9d7635dda142a7757e"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.21.3",
  "either",
  "heck 0.5.0",
  "proc-macro2",
@@ -4053,8 +4058,9 @@ dependencies = [
 
 [[package]]
 name = "migrations_internals"
-version = "2.2.0"
-source = "git+https://github.com/diesel-rs/diesel?branch=master#0e9ae48cb59d580e374d1153d0f60f19509c4826"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36c791ecdf977c99f45f23280405d7723727470f6689a5e6dbf513ac547ae10d"
 dependencies = [
  "serde",
  "toml 0.9.5",
@@ -4062,8 +4068,9 @@ dependencies = [
 
 [[package]]
 name = "migrations_macros"
-version = "2.2.0"
-source = "git+https://github.com/diesel-rs/diesel?branch=master#0e9ae48cb59d580e374d1153d0f60f19509c4826"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36fc5ac76be324cfd2d3f2cf0fdf5d5d3c4f14ed8aaebadb09e304ba42282703"
 dependencies = [
  "migrations_internals",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ const_format = "0.2"
 ctor = "0.5"
 criterion = { version = "0.7", features = ["html_reports", "async_tokio"] }
 derive_builder = "0.20"
-diesel = { version = "2.2", default-features = false }
+diesel = { version = "2.3", default-features = false }
 diesel_migrations = { version = "2.2", default-features = false }
 dyn-clone = "1"
 ed25519-dalek = { version = "2.1.1", features = ["zeroize"] }
@@ -197,9 +197,6 @@ lto = true
 # are made public for third-party dependencies: https://github.com/diesel-rs/diesel/pull/4236
 # (cfg-specific patche support does not exist)
 [patch.crates-io]
-diesel = { git = "https://github.com/diesel-rs/diesel", branch = "master" }
-diesel_derives = { git = "https://github.com/diesel-rs/diesel", branch = "master" }
-diesel_migrations = { git = "https://github.com/diesel-rs/diesel", branch = "master" }
 tracing-forest = { git = "https://github.com/QnnOkabayashi/tracing-forest", branch = "main" }
 
 [workspace.lints.clippy]


### PR DESCRIPTION
[diesel 2.3.0](https://github.com/diesel-rs/diesel/releases/tag/v2.3.0) includes wasm support via sqlite-wasm, so we no longer require a dependency on the git patch for `main`

closes #2465 