### PR TITLE
give 'test_db_migrates' 3 retries in ci to fix flakiness

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -16,3 +16,7 @@ fail-fast = false
 [[profile.ci.overrides]]
 platform = 'wasm32-unknown-unkown'
 slow-timeout = "1m"
+# test_db_migrates experiences random failures b/c of 'corrupted double-linked list' coming from glibc/sqlcipher https://github.com/xmtp/libxmtp/issues/2402
+[[profile.ci.overrides]]
+filter = 'test(/\btest_db_migrates/)'
+retries = 3


### PR DESCRIPTION
should fix #2402 


any sqlite database created after september 12 2024 already has a plaintext header. the migration to plaintext would only effect clients created before that date. further, the error this test fails on seems tightly coupled to glibc and sqlicipher rather than something in libxmtp, and is difficult to reproduce locally. therefore it seems safe to simply give this test a few retries, esp as the test still passes, and is only failing b/c of a memory error in stderr.