### PR TITLE
Validate MLS credentials when receiving Welcome

### DIFF
--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -257,11 +257,24 @@ impl RetryableError for IntentResolutionError {
 }
 
 #[derive(Debug)]
-struct PublishIntentData {
+pub(crate) struct PublishIntentData {
     staged_commit: Option<Vec<u8>>,
     post_commit_action: Option<Vec<u8>>,
     payload_to_publish: Vec<u8>,
     should_send_push_notification: bool,
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+impl PublishIntentData {
+    #[allow(dead_code)]
+    pub fn post_commit_data(&self) -> Option<Vec<u8>> {
+        self.post_commit_action.clone()
+    }
+
+    #[allow(dead_code)]
+    pub fn staged_commit(&self) -> Option<Vec<u8>> {
+        self.staged_commit.clone()
+    }
 }
 
 impl<Context> MlsGroup<Context>
@@ -2312,7 +2325,7 @@ where
      * Callers may also include a list of added or removed inboxes
      */
     #[tracing::instrument(level = "trace", skip_all)]
-    pub(super) async fn get_membership_update_intent(
+    pub(crate) async fn get_membership_update_intent(
         &self,
         inbox_ids_to_add: &[InboxIdRef<'_>],
         inbox_ids_to_remove: &[InboxIdRef<'_>],
@@ -2714,7 +2727,9 @@ fn get_and_clear_pending_commit(
     Ok(commit)
 }
 
-fn decode_staged_commit(data: &[u8]) -> Result<StagedCommit, GroupMessageProcessingError> {
+pub(crate) fn decode_staged_commit(
+    data: &[u8],
+) -> Result<StagedCommit, GroupMessageProcessingError> {
     Ok(xmtp_db::db_deserialize(data)?)
 }
 

--- a/xmtp_mls/src/groups/mls_sync/update_group_membership.rs
+++ b/xmtp_mls/src/groups/mls_sync/update_group_membership.rs
@@ -13,7 +13,7 @@ use openmls_traits::signatures::Signer;
 // Takes UpdateGroupMembershipIntentData and applies it to the openmls group
 // returning the commit and post_commit_action
 #[tracing::instrument(level = "trace", skip_all)]
-pub(super) async fn apply_update_group_membership_intent(
+pub(crate) async fn apply_update_group_membership_intent(
     context: &impl XmtpSharedContext,
     openmls_group: &mut OpenMlsGroup,
     intent_data: UpdateGroupMembershipIntentData,

--- a/xmtp_mls/src/groups/tests/test_welcomes.rs
+++ b/xmtp_mls/src/groups/tests/test_welcomes.rs
@@ -1,6 +1,21 @@
+use std::sync::Arc;
+
+use crate::context::XmtpMlsLocalContext;
+use crate::context::XmtpSharedContext;
+use crate::groups::GroupError;
+use crate::groups::MlsGroup;
+use crate::groups::group_permissions::PolicySet;
+use crate::groups::intents::PostCommitAction;
+use crate::groups::mls_sync::decode_staged_commit;
+use crate::groups::mls_sync::update_group_membership::apply_update_group_membership_intent;
+use crate::identity::create_credential;
 use crate::tester;
+use xmtp_db::XmtpOpenMlsProviderRef;
+use xmtp_db::group::ConversationType;
+use xmtp_db::group_message::MsgQueryArgs;
 use xmtp_db::prelude::QueryRefreshState;
 use xmtp_db::refresh_state::EntityKind;
+use xmtp_mls_common::group::GroupMetadataOptions;
 
 #[xmtp_common::test(unwrap_try = true)]
 async fn test_welcome_cursor() {
@@ -22,4 +37,108 @@ async fn test_welcome_cursor() {
         .get_refresh_state(&group.group_id, EntityKind::Group)??;
 
     assert!(alix2_refresh_state.cursor > 0);
+}
+
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_spoofed_inbox_id() {
+    // In this scenario, Alix is malicious but Bo is not
+    tester!(alix);
+    tester!(bo);
+    tester!(caro);
+
+    // Our goal is simply to create a group with a credential where the inbox ID (openMLS credential)
+    // does not match the installation ID (openMLS signing key)
+    // To do this via libxmtp without re-implementing everything, we need to reach into some internals
+    let malicious_credential = create_credential("spoofed_inbox_id").unwrap();
+    let mut malicious_identity = alix.context.identity.clone();
+    malicious_identity.credential = malicious_credential;
+    let malicious_context = Arc::new(XmtpMlsLocalContext {
+        identity: malicious_identity,
+        api_client: alix.context.api_client.clone(),
+        sync_api_client: alix.context.sync_api_client.clone(),
+        store: alix.context.store.clone(),
+        mls_storage: alix.context.mls_storage.clone(),
+        mutexes: alix.context.mutexes.clone(),
+        mls_commit_lock: alix.context.mls_commit_lock.clone(),
+        version_info: alix.context.version_info.clone(),
+        local_events: alix.context.local_events.clone(),
+        worker_events: alix.context.worker_events.clone(),
+        scw_verifier: alix.context.scw_verifier.clone(),
+        device_sync: alix.context.device_sync.clone(),
+        workers: alix.context.workers.clone(),
+    });
+    let group = MlsGroup::create_and_insert(
+        malicious_context,
+        ConversationType::Group,
+        PolicySet::default(),
+        GroupMetadataOptions::default(),
+        None,
+    )?;
+
+    // Now we send a welcome from this group. To disable validation on Alix's side (as Alix is malicious),
+    // we reach into some internals.
+    let intent = group
+        .get_membership_update_intent(&[bo.inbox_id()], &[])
+        .await?;
+    let signer = &group.context.identity().installation_keys;
+    let context = &group.context;
+    let send_welcome_action = group
+        .load_mls_group_with_lock_async(|mut openmls_group| async move {
+            let publish_intent_data =
+                apply_update_group_membership_intent(&context, &mut openmls_group, intent, signer)
+                    .await?
+                    .unwrap();
+            let post_commit_action = PostCommitAction::from_bytes(
+                publish_intent_data.post_commit_data().unwrap().as_slice(),
+            )?;
+            let PostCommitAction::SendWelcomes(action) = post_commit_action;
+            let staged_commit = publish_intent_data.staged_commit().unwrap();
+            openmls_group.merge_staged_commit(
+                &XmtpOpenMlsProviderRef::new(context.mls_storage()),
+                decode_staged_commit(staged_commit.as_slice())?,
+            )?;
+
+            Ok::<_, GroupError>(action)
+        })
+        .await?;
+    group.send_welcomes(send_welcome_action, None).await?;
+
+    // We want Bo to reject this welcome, because the inbox ID is spoofed
+    tracing::info!("Bo is receiving now");
+    let groups = bo.sync_welcomes().await?;
+    if !groups.is_empty() {
+        // Test is already failed if we reach this point, the rest of the test explores
+        // how this can be abused
+        tracing::error!("We should reject a welcome with spoofed credentials, test failed");
+
+        let bo_group = &groups[0];
+        let added_by_inbox_id = bo_group.added_by_inbox_id()?;
+        // Bo thinks they were added by spoofed_inbox_id
+        tracing::error!(
+            "Bo thinks they were added by inbox id: {}",
+            added_by_inbox_id
+        );
+
+        // Alix sends a message using their spoofed inbox ID
+        group
+            .send_message("Message from spoofed inbox id".as_bytes())
+            .await?;
+        bo_group.sync().await?;
+        let bo_msgs = bo_group.find_messages(&MsgQueryArgs::default())?;
+        tracing::error!(
+            "Bo received a message from {}",
+            bo_msgs.first().unwrap().sender_inbox_id
+        );
+
+        // Bo and other members can continue to interact with this group as if nothing is wrong
+        bo_group.send_message("hi".as_bytes()).await?;
+        bo_group.add_members_by_inbox_id(&[caro.inbox_id()]).await?;
+        let caro_groups = caro.sync_welcomes().await?;
+        let caro_group = caro_groups.first().unwrap();
+        caro_group.sync().await?;
+        caro_group.send_message("hi".as_bytes()).await?;
+        bo_group.sync().await?;
+
+        panic!("Test failed");
+    }
 }

--- a/xmtp_mls/src/groups/welcomes/validated_membership.rs
+++ b/xmtp_mls/src/groups/welcomes/validated_membership.rs
@@ -1,9 +1,10 @@
 use crate::context::XmtpSharedContext;
 use crate::groups::validated_commit::extract_group_membership;
 use crate::groups::{GroupError, filter_inbox_ids_needing_updates};
+use crate::identity::parse_credential;
 use crate::identity_updates::load_identity_updates;
-use openmls::prelude::StagedWelcome;
-use std::collections::HashSet;
+use openmls::prelude::{BasicCredential, StagedWelcome};
+use std::collections::{HashMap, HashSet};
 
 #[allow(async_fn_in_trait)]
 pub trait ValidateGroupMembership {
@@ -42,8 +43,6 @@ where
             load_identity_updates(self.context.api(), &db, ids.as_slice()).await?;
         }
 
-        let mut expected_installation_ids = HashSet::<Vec<u8>>::new();
-
         let identity_updates = crate::identity_updates::IdentityUpdates::new(&self.context);
         let futures: Vec<_> = membership
             .members
@@ -54,22 +53,49 @@ where
             .collect();
         let results = futures::future::try_join_all(futures).await?;
 
+        let mut expected_members = HashMap::<String, HashSet<Vec<u8>>>::new();
         for association_state in results {
-            expected_installation_ids.extend(association_state.installation_ids());
+            expected_members.insert(
+                association_state.inbox_id().to_string(),
+                HashSet::from_iter(association_state.installation_ids()),
+            );
         }
 
-        let actual_installation_ids: HashSet<Vec<u8>> = staged_welcome
-            .public_group()
-            .members()
-            .map(|member| member.signature_key)
-            .collect();
-
-        // exclude failed installations
-        expected_installation_ids.retain(|id| !membership.failed_installations.contains(id));
-
-        if expected_installation_ids != actual_installation_ids {
-            return Err(GroupError::InvalidGroupMembership);
+        for member in staged_welcome.public_group().members() {
+            let basic_credential = BasicCredential::try_from(member.credential.clone())?;
+            let claimed_inbox_id = parse_credential(basic_credential.identity())?;
+            let Some(installation_ids) = expected_members.get_mut(&claimed_inbox_id) else {
+                tracing::error!(
+                    claimed_inbox_id = claimed_inbox_id,
+                    "Inbox ID not found in expected members",
+                );
+                return Err(GroupError::InvalidGroupMembership);
+            };
+            if !installation_ids.contains(&member.signature_key) {
+                tracing::error!(
+                    claimed_inbox_id = claimed_inbox_id,
+                    installation_id = hex::encode(member.signature_key),
+                    "Installation ID not found in expected members for inbox ID",
+                );
+                return Err(GroupError::InvalidGroupMembership);
+            }
+            installation_ids.remove(&member.signature_key);
         }
+        for installation_set in expected_members.values() {
+            for remaining_installation_id in installation_set {
+                if !membership
+                    .failed_installations
+                    .contains(remaining_installation_id)
+                {
+                    tracing::error!(
+                        installation_id = hex::encode(remaining_installation_id),
+                        "Installation ID in expected members not found in ratchet tree",
+                    );
+                    return Err(GroupError::InvalidGroupMembership);
+                }
+            }
+        }
+        // TODO: Is it an error if there are 'failed installations' that are not in the expected members list?
 
         tracing::info!("Group membership validated");
 


### PR DESCRIPTION
See unit test in `test_welcomes.rs` for clearest explanation.

When we receive a ratchet tree from a Welcome, we validate that the set of installations in the tree matches the group metadata. However, each installation in the tree also holds a credential referencing the inbox ID it claims to be a part of. We are not currently validating this linkage between inbox ID and installation ID when receiving a Welcome.

To run this test against main:
```
git fetch
git checkout 09-29-fix_spoofed_welcome
# This undoes the fix. Modify the path below to the correct path for your machine
git checkout main -- '~/libxmtp/xmtp_mls/src/groups/welcomes/validated_membership.rs'
cargo test -- test_spoofed_inbox_id
```