### PR TITLE
ignore generated code in coverage report

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "xmtp_proto/src/gen"


### PR DESCRIPTION
### Configure Codecov to ignore coverage for generated sources under xmtp_proto/src/gen in [codecov.yml](https://github.com/xmtp/libxmtp/pull/2526/files#diff-3e878d9bdc47f29a0ab909a7db939acf08d2d2f1aaba81e6f897b32361fa40db)
Add a Codecov configuration that excludes generated sources from coverage by specifying an ignore pattern.

- Add ignore rule for `xmtp_proto/src/gen` in [codecov.yml](https://github.com/xmtp/libxmtp/pull/2526/files#diff-3e878d9bdc47f29a0ab909a7db939acf08d2d2f1aaba81e6f897b32361fa40db)

#### 📍Where to Start
Start with the ignore configuration in [codecov.yml](https://github.com/xmtp/libxmtp/pull/2526/files#diff-3e878d9bdc47f29a0ab909a7db939acf08d2d2f1aaba81e6f897b32361fa40db).

----

_[Macroscope](https://app.macroscope.com) summarized 8968a95._ (Automatic summaries will resume when PR exits draft mode or review begins).