### PR TITLE
defer grpc connection to first api request

### DIFF
--- a/bindings_node/src/client.rs
+++ b/bindings_node/src/client.rs
@@ -156,11 +156,9 @@ pub async fn create_client(
 
   init_logging(log_options.unwrap_or_default())?;
   let api_client = TonicApiClient::create(&host, is_secure, app_version.as_ref())
-    .await
     .map_err(|_| Error::from_reason("Error creating Tonic API client"))?;
 
   let sync_api_client = TonicApiClient::create(&host, is_secure, app_version.as_ref())
-    .await
     .map_err(|_| Error::from_reason("Error creating Tonic API client"))?;
 
   let storage_option = match db_path {

--- a/bindings_node/src/inbox_id.rs
+++ b/bindings_node/src/inbox_id.rs
@@ -16,9 +16,8 @@ pub async fn get_inbox_id_for_identifier(
   is_secure: bool,
   identifier: Identifier,
 ) -> Result<Option<String>> {
-  let client = TonicApiClient::create(&host, is_secure, None::<String>)
-    .await
-    .map_err(ErrorWrapper::from)?;
+  let client =
+    TonicApiClient::create(&host, is_secure, None::<String>).map_err(ErrorWrapper::from)?;
   // api rate limit cooldown period
   let api_client = ApiClientWrapper::new(client, strategies::exponential_cooldown());
 
@@ -73,9 +72,8 @@ async fn is_member_of_association_state(
   inbox_id: &str,
   identifier: &MemberIdentifier,
 ) -> Result<bool> {
-  let api_client = TonicApiClient::create(host, true, None::<String>)
-    .await
-    .map_err(ErrorWrapper::from)?;
+  let api_client =
+    TonicApiClient::create(host, true, None::<String>).map_err(ErrorWrapper::from)?;
   let api_client = ApiClientWrapper::new(Arc::new(api_client), strategies::exponential_cooldown());
 
   let is_member = xmtp_mls::identity_updates::is_member_of_association_state(

--- a/bindings_node/src/inbox_state.rs
+++ b/bindings_node/src/inbox_state.rs
@@ -91,9 +91,8 @@ pub async fn inbox_state_from_inbox_ids(
   host: String,
   inbox_ids: Vec<String>,
 ) -> Result<Vec<InboxState>> {
-  let api_client = TonicApiClient::create(&host, true, None::<String>)
-    .await
-    .map_err(ErrorWrapper::from)?;
+  let api_client =
+    TonicApiClient::create(&host, true, None::<String>).map_err(ErrorWrapper::from)?;
 
   let api = ApiClientWrapper::new(Arc::new(api_client), strategies::exponential_cooldown());
   let scw_verifier =

--- a/bindings_node/src/signatures.rs
+++ b/bindings_node/src/signatures.rs
@@ -48,15 +48,14 @@ pub fn verify_signed_with_public_key(
 
 #[allow(dead_code)]
 #[napi]
-pub async fn revoke_installations_signature_request(
+pub fn revoke_installations_signature_request(
   host: String,
   recovery_identifier: Identifier,
   inbox_id: String,
   installation_ids: Vec<Uint8Array>,
 ) -> Result<SignatureRequestHandle> {
-  let api_client = TonicApiClient::create(host, true, None::<String>)
-    .await
-    .map_err(ErrorWrapper::from)?;
+  let api_client =
+    TonicApiClient::create(host, true, None::<String>).map_err(ErrorWrapper::from)?;
 
   let api = ApiClientWrapper::new(Arc::new(api_client), strategies::exponential_cooldown());
   let scw_verifier =
@@ -66,9 +65,8 @@ pub async fn revoke_installations_signature_request(
   let ident = recovery_identifier.try_into()?;
   let ids: Vec<Vec<u8>> = installation_ids.into_iter().map(|i| i.to_vec()).collect();
 
-  let signature_request = revoke_installations_with_verifier(&ident, &inbox_id, ids)
-    .await
-    .map_err(ErrorWrapper::from)?;
+  let signature_request =
+    revoke_installations_with_verifier(&ident, &inbox_id, ids).map_err(ErrorWrapper::from)?;
 
   Ok(SignatureRequestHandle {
     inner: Arc::new(tokio::sync::Mutex::new(signature_request)),
@@ -82,9 +80,8 @@ pub async fn apply_signature_request(
   host: String,
   signature_request: &SignatureRequestHandle,
 ) -> Result<()> {
-  let api_client = TonicApiClient::create(host, true, None::<String>)
-    .await
-    .map_err(ErrorWrapper::from)?;
+  let api_client =
+    TonicApiClient::create(host, true, None::<String>).map_err(ErrorWrapper::from)?;
 
   let api = ApiClientWrapper::new(Arc::new(api_client), strategies::exponential_cooldown());
   let scw_verifier =

--- a/bindings_wasm/src/client.rs
+++ b/bindings_wasm/src/client.rs
@@ -159,9 +159,9 @@ pub async fn create_client(
   app_version: Option<String>,
 ) -> Result<Client, JsError> {
   init_logging(log_options.unwrap_or_default())?;
-  let api_client = TonicApiClient::create(host.clone(), true, app_version.clone()).await?;
+  let api_client = TonicApiClient::create(host.clone(), true, app_version.clone())?;
 
-  let sync_api_client = TonicApiClient::create(host.clone(), true, app_version.clone()).await?;
+  let sync_api_client = TonicApiClient::create(host.clone(), true, app_version.clone())?;
 
   let storage_option = match db_path {
     Some(path) => StorageOption::Persistent(path),

--- a/bindings_wasm/src/inbox_id.rs
+++ b/bindings_wasm/src/inbox_id.rs
@@ -10,7 +10,7 @@ pub async fn get_inbox_id_for_identifier(
   #[wasm_bindgen(js_name = accountIdentifier)] account_identifier: Identifier,
 ) -> Result<Option<String>, JsError> {
   let api_client = ApiClientWrapper::new(
-    TonicApiClient::create(host.clone(), true, "0.0.0".into()).await?,
+    TonicApiClient::create(host.clone(), true, "0.0.0".into())?,
     strategies::exponential_cooldown(),
   );
 

--- a/bindings_wasm/src/inbox_state.rs
+++ b/bindings_wasm/src/inbox_state.rs
@@ -125,9 +125,8 @@ pub async fn inbox_state_from_inbox_ids(
   host: String,
   inbox_ids: Vec<String>,
 ) -> Result<Vec<InboxState>, JsError> {
-  let api_client = TonicApiClient::create(host, true, "0.0.0".into())
-    .await
-    .map_err(|e| JsError::new(&e.to_string()))?;
+  let api_client =
+    TonicApiClient::create(host, true, "0.0.0".into()).map_err(|e| JsError::new(&e.to_string()))?;
 
   let api = ApiClientWrapper::new(Arc::new(api_client), strategies::exponential_cooldown());
   let scw_verifier =

--- a/bindings_wasm/src/signatures.rs
+++ b/bindings_wasm/src/signatures.rs
@@ -46,15 +46,14 @@ pub fn verify_signed_with_public_key(
 }
 
 #[wasm_bindgen(js_name = revokeInstallationsSignatureRequest)]
-pub async fn revoke_installations_signature_request(
+pub fn revoke_installations_signature_request(
   host: String,
   recovery_identifier: Identifier,
   inbox_id: String,
   installation_ids: Vec<Uint8Array>,
 ) -> Result<SignatureRequestHandle, JsError> {
-  let api_client = TonicApiClient::create(host, true, "0.0.0".into())
-    .await
-    .map_err(|e| JsError::new(&e.to_string()))?;
+  let api_client =
+    TonicApiClient::create(host, true, "0.0.0".into()).map_err(|e| JsError::new(&e.to_string()))?;
 
   let api = ApiClientWrapper::new(Arc::new(api_client), strategies::exponential_cooldown());
   let scw_verifier =
@@ -65,7 +64,6 @@ pub async fn revoke_installations_signature_request(
   let ids: Vec<Vec<u8>> = installation_ids.into_iter().map(|i| i.to_vec()).collect();
 
   let sig_req = revoke_installations_with_verifier(&ident, &inbox_id, ids)
-    .await
     .map_err(|e| JsError::new(&e.to_string()))?;
 
   Ok(SignatureRequestHandle {
@@ -79,9 +77,8 @@ pub async fn apply_signature_request(
   host: String,
   signature_request: &SignatureRequestHandle,
 ) -> Result<(), JsError> {
-  let api_client = TonicApiClient::create(host, true, "0.0.0".into())
-    .await
-    .map_err(|e| JsError::new(&e.to_string()))?;
+  let api_client =
+    TonicApiClient::create(host, true, "0.0.0".into()).map_err(|e| JsError::new(&e.to_string()))?;
 
   let api = ApiClientWrapper::new(Arc::new(api_client), strategies::exponential_cooldown());
   let scw_verifier = Arc::new(RemoteSignatureVerifier::new(api.clone()));

--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -241,63 +241,66 @@ async fn main() -> color_eyre::eyre::Result<()> {
             let mut message = GrpcClient::builder();
             message.set_host("http://localhost:5050".into());
             message.set_tls(false);
-            let message = message.build().await?;
+            let message = message.build()?;
             let mut gateway = GrpcClient::builder();
             gateway.set_host("http://localhost:5052".into());
             gateway.set_tls(false);
-            let gateway = gateway.build().await?;
+            let gateway = gateway.build()?;
             Arc::new(D14nClient::new(message, gateway))
         }
         (true, Env::Production) => {
             let mut message = GrpcClient::builder();
             message.set_host("https://grpc.testnet.xmtp.network:443".into());
             message.set_tls(false);
-            let message = message.build().await?;
+            let message = message.build()?;
             let mut gateway = GrpcClient::builder();
             gateway.set_host("https://payer.testnet.xmtp.network:443".into());
             gateway.set_tls(true);
-            let gateway = gateway.build().await?;
+            let gateway = gateway.build()?;
             Arc::new(D14nClient::new(message, gateway))
         }
         (true, Env::Staging) => {
             let mut message = GrpcClient::builder();
             message.set_host("https://grpc.testnet-staging.xmtp.network:443".into());
             message.set_tls(false);
-            let message = message.build().await?;
+            let message = message.build()?;
             let mut gateway = GrpcClient::builder();
             gateway.set_host("https://payer.testnet-staging.xmtp.network:443".into());
             gateway.set_tls(true);
-            let gateway = gateway.build().await?;
+            let gateway = gateway.build()?;
             Arc::new(D14nClient::new(message, gateway))
         }
         (true, Env::Dev) => {
             let mut message = GrpcClient::builder();
             message.set_host("https://grpc.testnet-dev.xmtp.network:443".into());
             message.set_tls(false);
-            let message = message.build().await?;
+            let message = message.build()?;
             let mut gateway = GrpcClient::builder();
             gateway.set_host("https://payer.testnet-dev.xmtp.network:443".into());
             gateway.set_tls(true);
-            let gateway = gateway.build().await?;
+            let gateway = gateway.build()?;
             Arc::new(D14nClient::new(message, gateway))
         }
-        (false, Env::Local) => {
-            Arc::new(ClientV3::create("http://localhost:5556", false, None::<String>).await?)
-        }
-        (false, Env::Dev) => Arc::new(
-            ClientV3::create("https://grpc.dev.xmtp.network:443", true, None::<String>).await?,
-        ),
-        (false, Env::Staging) => Arc::new(
-            ClientV3::create("https://grpc.dev.xmtp.network:443", true, None::<String>).await?,
-        ),
-        (false, Env::Production) => Arc::new(
-            ClientV3::create(
-                "https://grpc.production.xmtp.network:443",
-                true,
-                None::<String>,
-            )
-            .await?,
-        ),
+        (false, Env::Local) => Arc::new(ClientV3::create(
+            "http://localhost:5556",
+            false,
+            None::<String>,
+        )?),
+        (false, Env::Dev) => Arc::new(ClientV3::create(
+            "https://grpc.dev.xmtp.network:443",
+            true,
+            None::<String>,
+        )?),
+        (false, Env::Staging) => Arc::new(ClientV3::create(
+            "https://grpc.dev.xmtp.network:443",
+            true,
+            None::<String>,
+        )?),
+        (false, Env::Production) => Arc::new(ClientV3::create(
+            "https://grpc.production.xmtp.network:443",
+            true,
+            None::<String>,
+        )?),
     };
 
     if let Commands::Register { seed_phrase } = &cli.command {

--- a/xmtp_api/src/mls.rs
+++ b/xmtp_api/src/mls.rs
@@ -644,7 +644,7 @@ pub mod tests {
         client.set_tls(false);
         client.rate_per_minute(1);
         let _ = client.set_app_version("999.999.999".into());
-        let c = client.build().await.unwrap();
+        let c = client.build().unwrap();
         let wrapper = ApiClientWrapper::new(c, Retry::default());
         let _first = wrapper.query_group_messages(vec![0, 0], None).await;
         let now = std::time::Instant::now();
@@ -662,7 +662,7 @@ pub mod tests {
         let installation_key = rand_vec::<32>();
         let hpke_public_key = rand_vec::<32>();
 
-        let c = client.build().await.unwrap();
+        let c = client.build().unwrap();
         let wrapper = ApiClientWrapper::new(c, Retry::default());
 
         let mut very_large_payload = vec![];
@@ -701,7 +701,7 @@ pub mod tests {
         client.set_tls(false);
         client.set_app_version("0.0.0".into()).unwrap();
 
-        let c = client.build().await.unwrap();
+        let c = client.build().unwrap();
         let wrapper = ApiClientWrapper::new(c, Retry::default());
 
         let group_id = rand_vec::<32>();
@@ -746,7 +746,7 @@ pub mod tests {
         client.set_tls(false);
         client.set_app_version("0.0.0".into()).unwrap();
 
-        let c = client.build().await.unwrap();
+        let c = client.build().unwrap();
         let wrapper = ApiClientWrapper::new(c, Retry::default());
 
         let group_id = rand_vec::<32>();

--- a/xmtp_api_d14n/src/endpoints/d14n/get_inbox_ids.rs
+++ b/xmtp_api_d14n/src/endpoints/d14n/get_inbox_ids.rs
@@ -79,7 +79,7 @@ mod test {
     #[xmtp_common::test]
     async fn test_get_inbox_ids() {
         let client = crate::TestClient::create_d14n();
-        let client = client.build().await.unwrap();
+        let client = client.build().unwrap();
 
         let endpoint = GetInboxIds::builder()
             .addresses(vec![

--- a/xmtp_api_d14n/src/endpoints/d14n/get_newest_envelopes.rs
+++ b/xmtp_api_d14n/src/endpoints/d14n/get_newest_envelopes.rs
@@ -64,7 +64,7 @@ mod test {
         use crate::d14n::GetNewestEnvelopes;
 
         let client = crate::TestClient::create_d14n();
-        let client = client.build().await.unwrap();
+        let client = client.build().unwrap();
 
         let endpoint = GetNewestEnvelopes::builder().topic(vec![]).build().unwrap();
         api::ignore(endpoint).query(&client).await.unwrap();

--- a/xmtp_api_d14n/src/endpoints/d14n/get_nodes.rs
+++ b/xmtp_api_d14n/src/endpoints/d14n/get_nodes.rs
@@ -43,7 +43,7 @@ mod test {
     async fn test_get_nodes() {
         let mut endpoint = GetNodes::builder().build().unwrap();
         let gateway_client = crate::TestClient::create_gateway();
-        let client = gateway_client.build().await.unwrap();
+        let client = gateway_client.build().unwrap();
         assert!(endpoint.query(&client).await.is_ok());
     }
 
@@ -52,7 +52,7 @@ mod test {
         // xmtpd doesn't implement the GetNodes endpoint
         let mut endpoint = GetNodes::builder().build().unwrap();
         let xmtpd_client = crate::TestClient::create_d14n();
-        let client = xmtpd_client.build().await.unwrap();
+        let client = xmtpd_client.build().unwrap();
         assert!(endpoint.query(&client).await.is_err());
     }
 }

--- a/xmtp_api_d14n/src/endpoints/d14n/health_check.rs
+++ b/xmtp_api_d14n/src/endpoints/d14n/health_check.rs
@@ -64,11 +64,11 @@ mod test {
         let mut endpoint = HealthCheck::builder().build().unwrap();
 
         let xmtpd_client = crate::TestClient::create_d14n();
-        let client = xmtpd_client.build().await.unwrap();
+        let client = xmtpd_client.build().unwrap();
         assert!(endpoint.query(&client).await.is_ok());
 
         let gateway_client = crate::TestClient::create_gateway();
-        let client = gateway_client.build().await.unwrap();
+        let client = gateway_client.build().unwrap();
         assert!(endpoint.query(&client).await.is_ok());
     }
 }

--- a/xmtp_api_d14n/src/endpoints/d14n/publish_client_envelopes.rs
+++ b/xmtp_api_d14n/src/endpoints/d14n/publish_client_envelopes.rs
@@ -71,7 +71,7 @@ mod test {
         use xmtp_proto::xmtp::xmtpv4::envelopes::ClientEnvelope;
 
         let client = crate::TestClient::create_gateway();
-        let client = client.build().await.unwrap();
+        let client = client.build().unwrap();
 
         let aad = AuthenticatedData {
             target_topic: TopicKind::GroupMessagesV1.build(&rand_vec::<16>()),

--- a/xmtp_api_d14n/src/endpoints/d14n/query_envelopes.rs
+++ b/xmtp_api_d14n/src/endpoints/d14n/query_envelopes.rs
@@ -118,7 +118,7 @@ mod test {
         use crate::d14n::QueryEnvelopes;
 
         let client = crate::TestClient::create_d14n();
-        let client = client.build().await.unwrap();
+        let client = client.build().unwrap();
 
         let endpoint = QueryEnvelopes::builder()
             .envelopes(EnvelopesQuery {
@@ -146,7 +146,7 @@ mod test {
         use crate::d14n::QueryEnvelope;
 
         let client = crate::TestClient::create_d14n();
-        let client = client.build().await.unwrap();
+        let client = client.build().unwrap();
 
         let endpoint = QueryEnvelope::builder().topic(vec![]).build().unwrap();
         let err = api::ignore(endpoint).query(&client).await.unwrap_err();

--- a/xmtp_api_d14n/src/endpoints/d14n/subscribe_envelopes.rs
+++ b/xmtp_api_d14n/src/endpoints/d14n/subscribe_envelopes.rs
@@ -62,7 +62,7 @@ mod test {
         use crate::d14n::SubscribeEnvelopes;
 
         let client = crate::TestClient::create_d14n();
-        let client = client.build().await.unwrap();
+        let client = client.build().unwrap();
 
         let mut endpoint = SubscribeEnvelopes::builder()
             .envelopes(EnvelopesQuery {

--- a/xmtp_api_d14n/src/endpoints/v3/identity/get_identity_updates_v2.rs
+++ b/xmtp_api_d14n/src/endpoints/v3/identity/get_identity_updates_v2.rs
@@ -58,7 +58,7 @@ mod test {
     #[xmtp_common::test]
     async fn test_get_identity_updates_v2() {
         let client = crate::TestClient::create_local();
-        let client = client.build().await.unwrap();
+        let client = client.build().unwrap();
         let mut endpoint = GetIdentityUpdatesV2::builder()
             .requests(vec![Request {
                 inbox_id: "".to_string(),

--- a/xmtp_api_d14n/src/endpoints/v3/identity/get_inbox_ids.rs
+++ b/xmtp_api_d14n/src/endpoints/v3/identity/get_inbox_ids.rs
@@ -79,7 +79,7 @@ mod test {
     #[xmtp_common::test]
     async fn test_get_inbox_ids() {
         let client = crate::TestClient::create_local();
-        let client = client.build().await.unwrap();
+        let client = client.build().unwrap();
         let mut endpoint = GetInboxIds::builder()
             .addresses(vec![
                 "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045".to_string(),

--- a/xmtp_api_d14n/src/endpoints/v3/identity/publish_identity_update.rs
+++ b/xmtp_api_d14n/src/endpoints/v3/identity/publish_identity_update.rs
@@ -61,7 +61,7 @@ mod test {
         use xmtp_proto::xmtp::identity::associations::IdentityUpdate;
 
         let client = crate::TestClient::create_local();
-        let client = client.build().await.unwrap();
+        let client = client.build().unwrap();
         let mut endpoint = PublishIdentityUpdate::builder()
             .identity_update(Some(IdentityUpdate {
                 actions: vec![],

--- a/xmtp_api_d14n/src/endpoints/v3/identity/verify_smart_contract_wallet_signatures.rs
+++ b/xmtp_api_d14n/src/endpoints/v3/identity/verify_smart_contract_wallet_signatures.rs
@@ -59,7 +59,7 @@ mod test {
     #[xmtp_common::test]
     async fn test_verify_smart_contract_wallet_signatures() {
         let client = crate::TestClient::create_local();
-        let client = client.build().await.unwrap();
+        let client = client.build().unwrap();
         let endpoint = VerifySmartContractWalletSignatures::builder()
             .signatures(vec![VerifySmartContractWalletSignatureRequestSignature {
                 account_id: "".into(),

--- a/xmtp_api_d14n/src/endpoints/v3/mls/fetch_key_packages.rs
+++ b/xmtp_api_d14n/src/endpoints/v3/mls/fetch_key_packages.rs
@@ -58,7 +58,7 @@ mod test {
     #[xmtp_common::test]
     async fn test_fetch_key_packages() {
         let client = crate::TestClient::create_local();
-        let client = client.build().await.unwrap();
+        let client = client.build().unwrap();
         let mut endpoint = FetchKeyPackages::builder()
             .installation_keys(vec![vec![1, 2, 3]])
             .build()

--- a/xmtp_api_d14n/src/endpoints/v3/mls/publish_commit_log.rs
+++ b/xmtp_api_d14n/src/endpoints/v3/mls/publish_commit_log.rs
@@ -59,7 +59,7 @@ mod test {
     #[xmtp_common::test]
     async fn test_publish_commit_log() {
         let client = crate::TestClient::create_local();
-        let client = client.build().await.unwrap();
+        let client = client.build().unwrap();
         let endpoint = PublishCommitLog::builder()
             .commit_log_entries(vec![PublishCommitLogRequest {
                 group_id: rand_vec::<16>(),

--- a/xmtp_api_d14n/src/endpoints/v3/mls/query_commit_log.rs
+++ b/xmtp_api_d14n/src/endpoints/v3/mls/query_commit_log.rs
@@ -58,7 +58,7 @@ mod test {
     #[xmtp_common::test]
     async fn test_query_commit_log() {
         let client = crate::TestClient::create_local();
-        let client = client.build().await.unwrap();
+        let client = client.build().unwrap();
         let endpoint = QueryCommitLog::builder()
             .query_log_requests(vec![QueryCommitLogRequest {
                 group_id: rand_vec::<16>(),

--- a/xmtp_api_d14n/src/endpoints/v3/mls/query_group_messages.rs
+++ b/xmtp_api_d14n/src/endpoints/v3/mls/query_group_messages.rs
@@ -61,7 +61,7 @@ mod test {
     #[xmtp_common::test]
     async fn test_query_group_messages() {
         let client = crate::TestClient::create_local();
-        let client = client.build().await.unwrap();
+        let client = client.build().unwrap();
         let mut endpoint = QueryGroupMessages::builder()
             .group_id(vec![1, 2, 3])
             .build()

--- a/xmtp_api_d14n/src/endpoints/v3/mls/query_welcome_messages.rs
+++ b/xmtp_api_d14n/src/endpoints/v3/mls/query_welcome_messages.rs
@@ -63,7 +63,7 @@ mod test {
     #[xmtp_common::test]
     async fn test_query_welcome_messages() {
         let client = crate::TestClient::create_local();
-        let client = client.build().await.unwrap();
+        let client = client.build().unwrap();
         let mut endpoint = QueryWelcomeMessages::builder()
             .installation_key(vec![1, 2, 3])
             .build()

--- a/xmtp_api_d14n/src/endpoints/v3/mls/send_group_messages.rs
+++ b/xmtp_api_d14n/src/endpoints/v3/mls/send_group_messages.rs
@@ -57,7 +57,7 @@ mod test {
     #[xmtp_common::test]
     async fn test_send_group_messages() {
         let client = crate::TestClient::create_local();
-        let client = client.build().await.unwrap();
+        let client = client.build().unwrap();
         let endpoint = SendGroupMessages::builder()
             .messages(vec![GroupMessageInput::default()])
             .build()

--- a/xmtp_api_d14n/src/endpoints/v3/mls/send_welcome_messages.rs
+++ b/xmtp_api_d14n/src/endpoints/v3/mls/send_welcome_messages.rs
@@ -62,7 +62,7 @@ mod test {
             version: Some(welcome_message_input::Version::V1(Default::default())),
         };
         let client = crate::TestClient::create_local();
-        let client = client.build().await.unwrap();
+        let client = client.build().unwrap();
         let endpoint = SendWelcomeMessages::builder()
             .messages(vec![welcome_message])
             .build()

--- a/xmtp_api_d14n/src/endpoints/v3/mls/upload_key_package.rs
+++ b/xmtp_api_d14n/src/endpoints/v3/mls/upload_key_package.rs
@@ -59,7 +59,7 @@ mod test {
     #[xmtp_common::test]
     async fn test_upload_key_package() {
         let client = crate::TestClient::create_local();
-        let client = client.build().await.unwrap();
+        let client = client.build().unwrap();
         let endpoint = UploadKeyPackage::builder()
             .key_package(Some(KeyPackageUpload {
                 key_package_tls_serialized: vec![1, 2, 3],

--- a/xmtp_api_d14n/src/queries/d14n.rs
+++ b/xmtp_api_d14n/src/queries/d14n.rs
@@ -86,10 +86,10 @@ where
         <Builder1 as ApiBuilder>::host(&self.message_client)
     }
 
-    async fn build(self) -> Result<Self::Output, Self::Error> {
+    fn build(self) -> Result<Self::Output, Self::Error> {
         Ok(D14nClient::new(
-            <Builder1 as ApiBuilder>::build(self.message_client).await?,
-            <Builder2 as ApiBuilder>::build(self.gateway_client).await?,
+            <Builder1 as ApiBuilder>::build(self.message_client)?,
+            <Builder2 as ApiBuilder>::build(self.gateway_client)?,
         ))
     }
 }

--- a/xmtp_api_d14n/src/queries/v3.rs
+++ b/xmtp_api_d14n/src/queries/v3.rs
@@ -72,10 +72,8 @@ where
         <Builder as ApiBuilder>::host(&self.client)
     }
 
-    async fn build(self) -> Result<Self::Output, Self::Error> {
-        Ok(V3Client::new(
-            <Builder as ApiBuilder>::build(self.client).await?,
-        ))
+    fn build(self) -> Result<Self::Output, Self::Error> {
+        Ok(V3Client::new(<Builder as ApiBuilder>::build(self.client)?))
     }
 }
 

--- a/xmtp_api_grpc/src/grpc_client/client.rs
+++ b/xmtp_api_grpc/src/grpc_client/client.rs
@@ -242,9 +242,9 @@ impl ApiBuilder for ClientBuilder {
         self.host.as_deref()
     }
 
-    async fn build(self) -> Result<Self::Output, Self::Error> {
+    fn build(self) -> Result<Self::Output, Self::Error> {
         let host = self.host.ok_or(GrpcBuilderError::MissingHostUrl)?;
-        let channel = crate::GrpcService::new(host, self.limit, self.tls_channel).await?;
+        let channel = crate::GrpcService::new(host, self.limit, self.tls_channel)?;
         Ok(GrpcClient {
             inner: tonic::client::Grpc::new(channel)
                 .max_decoding_message_size(GRPC_PAYLOAD_LIMIT)

--- a/xmtp_api_grpc/src/grpc_client/native.rs
+++ b/xmtp_api_grpc/src/grpc_client/native.rs
@@ -4,7 +4,6 @@ use std::time::Duration;
 use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
 use tonic::{body::Body, client::GrpcService};
 use tower::Service;
-use tracing::Instrument;
 
 use std::task::{Context, Poll};
 
@@ -14,18 +13,15 @@ pub struct NativeGrpcService {
 }
 
 impl NativeGrpcService {
-    pub async fn new(
+    pub fn new(
         host: String,
         limit: Option<u64>,
         is_secure: bool,
     ) -> Result<Self, GrpcBuilderError> {
         let channel = match is_secure {
-            true => create_tls_channel(host, limit.unwrap_or(5000)).await?,
-            false => {
-                apply_channel_options(Channel::from_shared(host)?, limit.unwrap_or(5000))
-                    .connect()
-                    .await?
-            }
+            true => create_tls_channel(host, limit.unwrap_or(5000))?,
+            false => apply_channel_options(Channel::from_shared(host)?, limit.unwrap_or(5000))
+                .connect_lazy(),
         };
 
         Ok(Self { inner: channel })
@@ -77,14 +73,10 @@ pub(crate) fn apply_channel_options(endpoint: Endpoint, limit: u64) -> Endpoint 
 }
 
 #[tracing::instrument(level = "trace", skip_all)]
-pub async fn create_tls_channel(address: String, limit: u64) -> Result<Channel, GrpcBuilderError> {
-    let span = tracing::debug_span!("grpc_connect", address);
+pub fn create_tls_channel(address: String, limit: u64) -> Result<Channel, GrpcBuilderError> {
     let channel = apply_channel_options(Channel::from_shared(address)?, limit)
         .tls_config(ClientTlsConfig::new().with_enabled_roots())?
-        .connect()
-        .instrument(span)
-        .await?;
-
+        .connect_lazy();
     Ok(channel)
 }
 #[cfg(test)]
@@ -115,7 +107,7 @@ pub mod tests {
         let libxmtp_version = "0.0.1".to_string();
         client.set_app_version(app_version.clone().into()).unwrap();
         client.set_libxmtp_version(libxmtp_version.clone()).unwrap();
-        let client = client.build().await.unwrap();
+        let client = client.build().unwrap();
         let request = client.build_request(PublishRequest { envelopes: vec![] });
 
         assert_eq!(

--- a/xmtp_api_grpc/src/grpc_client/wasm.rs
+++ b/xmtp_api_grpc/src/grpc_client/wasm.rs
@@ -14,7 +14,7 @@ pub struct GrpcWebService {
 }
 
 impl GrpcWebService {
-    pub async fn new(
+    pub fn new(
         host: String,
         _limit: Option<u64>,
         _is_secure: bool,

--- a/xmtp_debug/src/args.rs
+++ b/xmtp_debug/src/args.rs
@@ -289,18 +289,19 @@ impl BackendOpts {
             let mut gateway = GrpcClient::builder();
             gateway.set_host(xmtpd_gateway_host.to_string());
             gateway.set_tls(gateway_is_secure);
-            let gateway = gateway.build().await?;
+            let gateway = gateway.build()?;
             let mut message = GrpcClient::builder();
             message.set_host(network.to_string());
             message.set_tls(is_secure);
-            let message = message.build().await?;
+            let message = message.build()?;
             Ok(Arc::new(D14nClient::new(message, gateway)))
         } else {
             trace!(url = %network, is_secure, "create grpc");
-            Ok(Arc::new(
-                crate::GrpcClient::create(network.as_str().to_string(), is_secure, None::<String>)
-                    .await?,
-            ))
+            Ok(Arc::new(crate::GrpcClient::create(
+                network.as_str().to_string(),
+                is_secure,
+                None::<String>,
+            )?))
         }
     }
 }

--- a/xmtp_mls/src/identity_updates.rs
+++ b/xmtp_mls/src/identity_updates.rs
@@ -116,7 +116,7 @@ pub async fn get_association_state_with_verifier(
 }
 
 /// Revoke the given installations from the association state for the client's inbox
-pub async fn revoke_installations_with_verifier(
+pub fn revoke_installations_with_verifier(
     identifier: &Identifier,
     inbox_id: &str,
     installation_ids: Vec<Vec<u8>>,
@@ -415,8 +415,7 @@ where
             &current_state.recovery_identifier().clone(),
             inbox_id,
             installation_ids,
-        )
-        .await?;
+        )?;
 
         let _ = self
             .context

--- a/xmtp_mls/src/test/builder.rs
+++ b/xmtp_mls/src/test/builder.rs
@@ -213,11 +213,9 @@ async fn test_client_creation() {
             .api_clients(
                 <TestClient as XmtpTestClient>::create_local()
                     .build()
-                    .await
                     .unwrap(),
                 <TestClient as XmtpTestClient>::create_local()
                     .build()
-                    .await
                     .unwrap(),
             )
             .default_mls_store()
@@ -259,11 +257,9 @@ async fn test_turn_local_telemetry_off() {
         .api_clients(
             <TestClient as XmtpTestClient>::create_local()
                 .build()
-                .await
                 .unwrap(),
             <TestClient as XmtpTestClient>::create_local()
                 .build()
-                .await
                 .unwrap(),
         )
         .default_mls_store()
@@ -302,11 +298,9 @@ async fn test_2nd_time_client_creation() {
         .api_clients(
             <TestClient as XmtpTestClient>::create_local()
                 .build()
-                .await
                 .unwrap(),
             <TestClient as XmtpTestClient>::create_local()
                 .build()
-                .await
                 .unwrap(),
         )
         .default_mls_store()
@@ -322,11 +316,9 @@ async fn test_2nd_time_client_creation() {
         .api_clients(
             <TestClient as XmtpTestClient>::create_local()
                 .build()
-                .await
                 .unwrap(),
             <TestClient as XmtpTestClient>::create_local()
                 .build()
-                .await
                 .unwrap(),
         )
         .default_mls_store()
@@ -349,11 +341,9 @@ async fn test_2nd_time_client_creation() {
     .api_clients(
         <TestClient as XmtpTestClient>::create_local()
             .build()
-            .await
             .unwrap(),
         <TestClient as XmtpTestClient>::create_local()
             .build()
-            .await
             .unwrap(),
     )
     .default_mls_store()
@@ -372,11 +362,9 @@ async fn test_2nd_time_client_creation() {
         .api_clients(
             <TestClient as XmtpTestClient>::create_local()
                 .build()
-                .await
                 .unwrap(),
             <TestClient as XmtpTestClient>::create_local()
                 .build()
-                .await
                 .unwrap(),
         )
         .default_mls_store()
@@ -614,11 +602,9 @@ async fn identity_persistence_test() {
     .api_clients(
         <TestClient as XmtpTestClient>::create_local()
             .build()
-            .await
             .unwrap(),
         <TestClient as XmtpTestClient>::create_local()
             .build()
-            .await
             .unwrap(),
     )
     .store(store_a)
@@ -645,11 +631,9 @@ async fn identity_persistence_test() {
     .api_clients(
         <TestClient as XmtpTestClient>::create_local()
             .build()
-            .await
             .unwrap(),
         <TestClient as XmtpTestClient>::create_local()
             .build()
-            .await
             .unwrap(),
     )
     .store(store_b)
@@ -687,11 +671,9 @@ async fn identity_persistence_test() {
         .api_clients(
             <TestClient as XmtpTestClient>::create_local()
                 .build()
-                .await
                 .unwrap(),
             <TestClient as XmtpTestClient>::create_local()
                 .build()
-                .await
                 .unwrap(),
         )
         .store(store_d)

--- a/xmtp_mls/src/utils/bench/clients.rs
+++ b/xmtp_mls/src/utils/bench/clients.rs
@@ -25,13 +25,11 @@ pub async fn new_unregistered_client(history_sync: bool) -> (BenchClient, Privat
         tracing::info!("Using Dev GRPC");
         <TestApiClient as XmtpTestClient>::create_dev()
             .build()
-            .await
             .unwrap()
     } else {
         tracing::info!("Using Local GRPC");
         <TestApiClient as XmtpTestClient>::create_local()
             .build()
-            .await
             .unwrap()
     };
 
@@ -39,13 +37,11 @@ pub async fn new_unregistered_client(history_sync: bool) -> (BenchClient, Privat
         tracing::info!("Using Dev GRPC");
         <TestApiClient as XmtpTestClient>::create_dev()
             .build()
-            .await
             .unwrap()
     } else {
         tracing::info!("Using Local GRPC");
         <TestApiClient as XmtpTestClient>::create_local()
             .build()
-            .await
             .unwrap()
     };
 
@@ -108,13 +104,11 @@ pub async fn create_client_from_identity(
         tracing::info!("Using Dev GRPC");
         <TestApiClient as XmtpTestClient>::create_dev()
             .build()
-            .await
             .unwrap()
     } else {
         tracing::info!("Using Local GRPC");
         <TestApiClient as XmtpTestClient>::create_local()
             .build()
-            .await
             .unwrap()
     };
 
@@ -122,13 +116,11 @@ pub async fn create_client_from_identity(
         tracing::info!("Using Dev GRPC");
         <TestApiClient as XmtpTestClient>::create_dev()
             .build()
-            .await
             .unwrap()
     } else {
         tracing::info!("Using Local GRPC");
         <TestApiClient as XmtpTestClient>::create_local()
             .build()
-            .await
             .unwrap()
     };
 

--- a/xmtp_mls/src/utils/test/mod.rs
+++ b/xmtp_mls/src/utils/test/mod.rs
@@ -53,11 +53,9 @@ impl<A, S> ClientBuilder<A, S> {
     pub async fn dev(self) -> ClientBuilder<TestClient, S> {
         let api_client = <TestClient as XmtpTestClient>::create_dev()
             .build()
-            .await
             .unwrap();
         let sync_api_client = <TestClient as XmtpTestClient>::create_dev()
             .build()
-            .await
             .unwrap();
         self.api_clients(api_client, sync_api_client)
     }
@@ -65,11 +63,9 @@ impl<A, S> ClientBuilder<A, S> {
     pub async fn local(self) -> ClientBuilder<TestClient, S> {
         let api_client = <TestClient as XmtpTestClient>::create_local()
             .build()
-            .await
             .unwrap();
         let sync_api_client = <TestClient as XmtpTestClient>::create_local()
             .build()
-            .await
             .unwrap();
         self.api_clients(api_client, sync_api_client)
     }
@@ -148,11 +144,9 @@ impl ClientBuilder<TestClient, TestMlsStorage> {
     pub async fn new_test_client_dev(owner: &impl InboxOwner) -> FullXmtpClient {
         let api_client = <TestClient as XmtpTestClient>::create_dev()
             .build()
-            .await
             .unwrap();
         let sync_api_client = <TestClient as XmtpTestClient>::create_dev()
             .build()
-            .await
             .unwrap();
 
         let client = Self::new_test_builder(owner)
@@ -172,12 +166,10 @@ impl ClientBuilder<TestClient, TestMlsStorage> {
     ) -> FullXmtpClient {
         let api_client = <TestClient as XmtpTestClient>::create_local()
             .build()
-            .await
             .unwrap();
 
         let sync_api_client = <TestClient as XmtpTestClient>::create_local()
             .build()
-            .await
             .unwrap();
 
         let client = Self::new_test_builder(owner)
@@ -198,11 +190,9 @@ impl<ApiClient, Db> ClientBuilder<ApiClient, Db> {
         self.api_clients(
             <TestClient as XmtpTestClient>::create_local()
                 .build()
-                .await
                 .unwrap(),
             <TestClient as XmtpTestClient>::create_local()
                 .build()
-                .await
                 .unwrap(),
         )
     }
@@ -211,11 +201,9 @@ impl<ApiClient, Db> ClientBuilder<ApiClient, Db> {
         self.api_clients(
             <TestClient as XmtpTestClient>::create_dev()
                 .build()
-                .await
                 .unwrap(),
             <TestClient as XmtpTestClient>::create_dev()
                 .build()
-                .await
                 .unwrap(),
         )
     }

--- a/xmtp_mls/src/utils/test/tester_utils.rs
+++ b/xmtp_mls/src/utils/test/tester_utils.rs
@@ -150,8 +150,8 @@ where
             local_client.host(),
             sync_api_client.host()
         );
-        let api_client = local_client.build().await.unwrap();
-        let sync_api_client = sync_api_client.build().await.unwrap();
+        let api_client = local_client.build().unwrap();
+        let sync_api_client = sync_api_client.build().unwrap();
         let client = ClientBuilder::new_test_builder(&self.owner)
             .await
             .api_clients(api_client, sync_api_client)

--- a/xmtp_mls/tests/chaos.rs
+++ b/xmtp_mls/tests/chaos.rs
@@ -26,8 +26,8 @@ async fn chaos_demo() {
     let alix = Client::builder(new_identity(&owner))
         .store(store)
         .api_clients(
-            TestClient::create_local().build().await.unwrap(),
-            TestClient::create_local().build().await.unwrap(),
+            TestClient::create_local().build().unwrap(),
+            TestClient::create_local().build().unwrap(),
         )
         .default_mls_store()
         .unwrap()

--- a/xmtp_proto/src/api_client.rs
+++ b/xmtp_proto/src/api_client.rs
@@ -188,5 +188,5 @@ pub trait ApiBuilder {
 
     #[allow(async_fn_in_trait)]
     /// Build the api client
-    async fn build(self) -> Result<Self::Output, Self::Error>;
+    fn build(self) -> Result<Self::Output, Self::Error>;
 }

--- a/xmtp_proto/src/traits/mock.rs
+++ b/xmtp_proto/src/traits/mock.rs
@@ -34,7 +34,7 @@ impl ApiBuilder for MockApiBuilder {
         Ok(None)
     }
 
-    async fn build(self) -> Result<Self::Output, Self::Error> {
+    fn build(self) -> Result<Self::Output, Self::Error> {
         Ok(MockNetworkClient::default())
     }
 


### PR DESCRIPTION
this will ensure that if a client is built in `offline` mode, no network resources will be touched until the first real api request. offline client builds should speed up as a result.