### PR TITLE
v1.5.4 Release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_node"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "chrono",
  "const-hex",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_wasm"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "alloy",
  "chrono",
@@ -8401,7 +8401,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "async-trait",
  "const-hex",
@@ -8424,7 +8424,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_d14n"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "async-trait",
  "const-hex",
@@ -8452,7 +8452,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_grpc"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "async-trait",
  "futures",
@@ -8476,7 +8476,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_http"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8503,7 +8503,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_archive"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "aes-gcm",
  "async-compression",
@@ -8530,7 +8530,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_cli"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "alloy",
  "chrono",
@@ -8564,7 +8564,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_common"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8600,7 +8600,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_configuration"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "openmls",
  "url",
@@ -8610,7 +8610,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_content_types"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "base64 0.22.1",
  "const-hex",
@@ -8626,7 +8626,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_cryptography"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "alloy",
  "bincode",
@@ -8650,7 +8650,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_db"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -8691,7 +8691,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_db_test"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "derive_builder",
  "diesel",
@@ -8704,7 +8704,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_id"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "alloy",
  "async-trait",
@@ -8740,7 +8740,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_macro"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "num_cpus",
  "proc-macro2",
@@ -8752,7 +8752,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_mls"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "aes-gcm",
  "alloy",
@@ -8833,7 +8833,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_mls_common"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "const-hex",
  "openmls",
@@ -8851,7 +8851,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_proto"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "async-trait",
  "color-eyre",
@@ -8886,7 +8886,7 @@ dependencies = [
 
 [[package]]
 name = "xmtpv3"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "alloy",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ resolver = "2"
 
 [workspace.package]
 license = "MIT"
-version = "1.5.3"
+version = "1.5.4"
 
 [workspace.dependencies]
 aes-gcm = { version = "0.10.3", features = ["std"] }

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -129,7 +129,7 @@ pub async fn connect_to_backend(
         host,
         is_secure
     );
-    let api_client = TonicApiClient::create(&host, is_secure, app_version).await?;
+    let api_client = TonicApiClient::create(&host, is_secure, app_version)?;
     Ok(Arc::new(XmtpApiClient(api_client)))
 }
 
@@ -181,8 +181,7 @@ pub async fn revoke_installations(
     );
     let ident = recovery_identifier.try_into()?;
 
-    let signature_request =
-        revoke_installations_with_verifier(&ident, inbox_id, installation_ids).await?;
+    let signature_request = revoke_installations_with_verifier(&ident, inbox_id, installation_ids)?;
 
     Ok(Arc::new(FfiSignatureRequest {
         inner: Arc::new(tokio::sync::Mutex::new(signature_request)),
@@ -3129,6 +3128,7 @@ mod tests {
         sync::{futures::OwnedNotified, Notify},
         time::error::Elapsed,
     };
+    use xmtp_api::ApiClientWrapper;
     use xmtp_common::tmp_path;
     use xmtp_common::{time::now_ns, wait_for_ge};
     use xmtp_common::{wait_for_eq, wait_for_ok};
@@ -9621,7 +9621,13 @@ mod tests {
 
         assert!(connected, "Expected API client to report as connected");
 
-        let result = connect_to_backend("http://127.0.0.1:59999".to_string(), false, None).await;
+        let api = connect_to_backend("http://127.0.0.1:59999".to_string(), false, None)
+            .await
+            .unwrap();
+        let api = ApiClientWrapper::new(api.0.clone(), Default::default());
+        let result = api
+            .query_group_messages(xmtp_common::rand_vec::<16>(), None)
+            .await;
         assert!(result.is_err(), "Expected connection to fail");
     }
 

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -4472,7 +4472,6 @@ mod tests {
             .is_err());
     }
 
-    // Looks like this test might be a separate issue
     #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
     async fn test_can_stream_group_messages_for_updates() {
         let alix = Tester::new().await;
@@ -9794,5 +9793,42 @@ mod tests {
                 hex::encode(group.id())
             );
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
+    async fn test_overlapping_streams() {
+        let alix = Tester::new().await;
+        let bo = Tester::new().await;
+
+        let message_callbacks = Arc::new(RustStreamCallback::default());
+        let conversation_callbacks = Arc::new(RustStreamCallback::default());
+        // Stream all group messages
+        let stream_messages = bo.conversations().stream(message_callbacks.clone()).await;
+        // Stream all groups
+        let stream_conversations = bo
+            .conversations()
+            .stream(conversation_callbacks.clone())
+            .await;
+        stream_messages.wait_for_ready().await;
+        stream_conversations.wait_for_ready().await;
+
+        // Create group and send first message
+        let alix_group = alix
+            .conversations()
+            .create_group(
+                vec![bo.account_identifier.clone()],
+                FfiCreateGroupOptions::default(),
+            )
+            .await
+            .unwrap();
+
+        alix_group.send("hi".into()).await.unwrap();
+
+        // The group should be received in both streams without erroring
+        message_callbacks.wait_for_delivery(None).await.unwrap();
+        conversation_callbacks
+            .wait_for_delivery(None)
+            .await
+            .unwrap();
     }
 }

--- a/bindings_node/package.json
+++ b/bindings_node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/node-bindings",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "repository": {
     "type": "git",
     "url": "git+https://git@github.com/xmtp/libxmtp.git",

--- a/bindings_node/src/client.rs
+++ b/bindings_node/src/client.rs
@@ -156,11 +156,9 @@ pub async fn create_client(
 
   init_logging(log_options.unwrap_or_default())?;
   let api_client = TonicApiClient::create(&host, is_secure, app_version.as_ref())
-    .await
     .map_err(|_| Error::from_reason("Error creating Tonic API client"))?;
 
   let sync_api_client = TonicApiClient::create(&host, is_secure, app_version.as_ref())
-    .await
     .map_err(|_| Error::from_reason("Error creating Tonic API client"))?;
 
   let storage_option = match db_path {

--- a/bindings_node/src/inbox_id.rs
+++ b/bindings_node/src/inbox_id.rs
@@ -16,9 +16,8 @@ pub async fn get_inbox_id_for_identifier(
   is_secure: bool,
   identifier: Identifier,
 ) -> Result<Option<String>> {
-  let client = TonicApiClient::create(&host, is_secure, None::<String>)
-    .await
-    .map_err(ErrorWrapper::from)?;
+  let client =
+    TonicApiClient::create(&host, is_secure, None::<String>).map_err(ErrorWrapper::from)?;
   // api rate limit cooldown period
   let api_client = ApiClientWrapper::new(client, strategies::exponential_cooldown());
 
@@ -73,9 +72,8 @@ async fn is_member_of_association_state(
   inbox_id: &str,
   identifier: &MemberIdentifier,
 ) -> Result<bool> {
-  let api_client = TonicApiClient::create(host, true, None::<String>)
-    .await
-    .map_err(ErrorWrapper::from)?;
+  let api_client =
+    TonicApiClient::create(host, true, None::<String>).map_err(ErrorWrapper::from)?;
   let api_client = ApiClientWrapper::new(Arc::new(api_client), strategies::exponential_cooldown());
 
   let is_member = xmtp_mls::identity_updates::is_member_of_association_state(

--- a/bindings_node/src/inbox_state.rs
+++ b/bindings_node/src/inbox_state.rs
@@ -91,9 +91,8 @@ pub async fn inbox_state_from_inbox_ids(
   host: String,
   inbox_ids: Vec<String>,
 ) -> Result<Vec<InboxState>> {
-  let api_client = TonicApiClient::create(&host, true, None::<String>)
-    .await
-    .map_err(ErrorWrapper::from)?;
+  let api_client =
+    TonicApiClient::create(&host, true, None::<String>).map_err(ErrorWrapper::from)?;
 
   let api = ApiClientWrapper::new(Arc::new(api_client), strategies::exponential_cooldown());
   let scw_verifier =

--- a/bindings_node/src/signatures.rs
+++ b/bindings_node/src/signatures.rs
@@ -53,9 +53,8 @@ pub async fn revoke_installations_signature_request(
   inbox_id: String,
   installation_ids: Vec<Uint8Array>,
 ) -> Result<SignatureRequestHandle> {
-  let api_client = TonicApiClient::create(host, true, None::<String>)
-    .await
-    .map_err(ErrorWrapper::from)?;
+  let api_client =
+    TonicApiClient::create(host, true, None::<String>).map_err(ErrorWrapper::from)?;
 
   let api = ApiClientWrapper::new(Arc::new(api_client), strategies::exponential_cooldown());
   let scw_verifier =
@@ -65,9 +64,8 @@ pub async fn revoke_installations_signature_request(
   let ident = recovery_identifier.try_into()?;
   let ids: Vec<Vec<u8>> = installation_ids.into_iter().map(|i| i.to_vec()).collect();
 
-  let signature_request = revoke_installations_with_verifier(&ident, &inbox_id, ids)
-    .await
-    .map_err(ErrorWrapper::from)?;
+  let signature_request =
+    revoke_installations_with_verifier(&ident, &inbox_id, ids).map_err(ErrorWrapper::from)?;
 
   Ok(SignatureRequestHandle {
     inner: Arc::new(tokio::sync::Mutex::new(signature_request)),
@@ -81,9 +79,8 @@ pub async fn apply_signature_request(
   host: String,
   signature_request: &SignatureRequestHandle,
 ) -> Result<()> {
-  let api_client = TonicApiClient::create(host, true, None::<String>)
-    .await
-    .map_err(ErrorWrapper::from)?;
+  let api_client =
+    TonicApiClient::create(host, true, None::<String>).map_err(ErrorWrapper::from)?;
 
   let api = ApiClientWrapper::new(Arc::new(api_client), strategies::exponential_cooldown());
   let scw_verifier =

--- a/bindings_wasm/package.json
+++ b/bindings_wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/wasm-bindings",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "type": "module",
   "license": "MIT",
   "description": "WASM bindings for the libXMTP rust library",

--- a/bindings_wasm/src/signatures.rs
+++ b/bindings_wasm/src/signatures.rs
@@ -66,7 +66,6 @@ pub async fn revoke_installations_signature_request(
   let ids: Vec<Vec<u8>> = installation_ids.into_iter().map(|i| i.to_vec()).collect();
 
   let sig_req = revoke_installations_with_verifier(&ident, &inbox_id, ids)
-    .await
     .map_err(|e| JsError::new(&e.to_string()))?;
 
   Ok(SignatureRequestHandle {

--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -241,63 +241,66 @@ async fn main() -> color_eyre::eyre::Result<()> {
             let mut message = GrpcClient::builder();
             message.set_host("http://localhost:5050".into());
             message.set_tls(false);
-            let message = message.build().await?;
+            let message = message.build()?;
             let mut payer = GrpcClient::builder();
             payer.set_host("http://localhost:5052".into());
             payer.set_tls(false);
-            let payer = payer.build().await?;
+            let payer = payer.build()?;
             Arc::new(D14nClient::new(message, payer))
         }
         (true, Env::Production) => {
             let mut message = GrpcClient::builder();
             message.set_host("https://grpc.testnet.xmtp.network:443".into());
             message.set_tls(false);
-            let message = message.build().await?;
+            let message = message.build()?;
             let mut payer = GrpcClient::builder();
             payer.set_host("https://payer.testnet.xmtp.network:443".into());
             payer.set_tls(true);
-            let payer = payer.build().await?;
+            let payer = payer.build()?;
             Arc::new(D14nClient::new(message, payer))
         }
         (true, Env::Staging) => {
             let mut message = GrpcClient::builder();
             message.set_host("https://grpc.testnet-staging.xmtp.network:443".into());
             message.set_tls(false);
-            let message = message.build().await?;
+            let message = message.build()?;
             let mut payer = GrpcClient::builder();
             payer.set_host("https://payer.testnet-staging.xmtp.network:443".into());
             payer.set_tls(true);
-            let payer = payer.build().await?;
+            let payer = payer.build()?;
             Arc::new(D14nClient::new(message, payer))
         }
         (true, Env::Dev) => {
             let mut message = GrpcClient::builder();
             message.set_host("https://grpc.testnet-dev.xmtp.network:443".into());
             message.set_tls(false);
-            let message = message.build().await?;
+            let message = message.build()?;
             let mut payer = GrpcClient::builder();
             payer.set_host("https://payer.testnet-dev.xmtp.network:443".into());
             payer.set_tls(true);
-            let payer = payer.build().await?;
+            let payer = payer.build()?;
             Arc::new(D14nClient::new(message, payer))
         }
-        (false, Env::Local) => {
-            Arc::new(ClientV3::create("http://localhost:5556", false, None::<String>).await?)
-        }
-        (false, Env::Dev) => Arc::new(
-            ClientV3::create("https://grpc.dev.xmtp.network:443", true, None::<String>).await?,
-        ),
-        (false, Env::Staging) => Arc::new(
-            ClientV3::create("https://grpc.dev.xmtp.network:443", true, None::<String>).await?,
-        ),
-        (false, Env::Production) => Arc::new(
-            ClientV3::create(
-                "https://grpc.production.xmtp.network:443",
-                true,
-                None::<String>,
-            )
-            .await?,
-        ),
+        (false, Env::Local) => Arc::new(ClientV3::create(
+            "http://localhost:5556",
+            false,
+            None::<String>,
+        )?),
+        (false, Env::Dev) => Arc::new(ClientV3::create(
+            "https://grpc.dev.xmtp.network:443",
+            true,
+            None::<String>,
+        )?),
+        (false, Env::Staging) => Arc::new(ClientV3::create(
+            "https://grpc.dev.xmtp.network:443",
+            true,
+            None::<String>,
+        )?),
+        (false, Env::Production) => Arc::new(ClientV3::create(
+            "https://grpc.production.xmtp.network:443",
+            true,
+            None::<String>,
+        )?),
     };
 
     if let Commands::Register { seed_phrase } = &cli.command {

--- a/xmtp_api/src/mls.rs
+++ b/xmtp_api/src/mls.rs
@@ -644,7 +644,7 @@ pub mod tests {
         client.set_tls(false);
         client.rate_per_minute(1);
         let _ = client.set_app_version("999.999.999".into());
-        let c = client.build().await.unwrap();
+        let c = client.build().unwrap();
         let wrapper = ApiClientWrapper::new(c, Retry::default());
         let _first = wrapper.query_group_messages(vec![0, 0], None).await;
         let now = std::time::Instant::now();
@@ -662,7 +662,7 @@ pub mod tests {
         let installation_key = rand_vec::<32>();
         let hpke_public_key = rand_vec::<32>();
 
-        let c = client.build().await.unwrap();
+        let c = client.build().unwrap();
         let wrapper = ApiClientWrapper::new(c, Retry::default());
 
         let mut very_large_payload = vec![];
@@ -701,7 +701,7 @@ pub mod tests {
         client.set_tls(false);
         client.set_app_version("0.0.0".into()).unwrap();
 
-        let c = client.build().await.unwrap();
+        let c = client.build().unwrap();
         let wrapper = ApiClientWrapper::new(c, Retry::default());
 
         let group_id = rand_vec::<32>();
@@ -743,7 +743,7 @@ pub mod tests {
         client.set_tls(false);
         client.set_app_version("0.0.0".into()).unwrap();
 
-        let c = client.build().await.unwrap();
+        let c = client.build().unwrap();
         let wrapper = ApiClientWrapper::new(c, Retry::default());
 
         let group_id = rand_vec::<32>();

--- a/xmtp_api_d14n/src/endpoints/d14n/get_inbox_ids.rs
+++ b/xmtp_api_d14n/src/endpoints/d14n/get_inbox_ids.rs
@@ -75,7 +75,7 @@ mod test {
     #[xmtp_common::test]
     async fn test_get_inbox_ids() {
         let client = crate::TestClient::create_local_d14n();
-        let client = client.build().await.unwrap();
+        let client = client.build().unwrap();
 
         let endpoint = GetInboxIds::builder()
             .addresses(vec![

--- a/xmtp_api_d14n/src/endpoints/d14n/get_newest_envelopes.rs
+++ b/xmtp_api_d14n/src/endpoints/d14n/get_newest_envelopes.rs
@@ -59,7 +59,7 @@ mod test {
         use crate::d14n::GetNewestEnvelopes;
 
         let client = crate::TestClient::create_local_d14n();
-        let client = client.build().await.unwrap();
+        let client = client.build().unwrap();
 
         let endpoint = GetNewestEnvelopes::builder().topic(vec![]).build().unwrap();
         assert!(endpoint.query(&client).await.is_ok());

--- a/xmtp_api_d14n/src/endpoints/d14n/get_nodes.rs
+++ b/xmtp_api_d14n/src/endpoints/d14n/get_nodes.rs
@@ -1,0 +1,58 @@
+use derive_builder::Builder;
+use prost::Message;
+use prost::bytes::Bytes;
+use std::borrow::Cow;
+use xmtp_proto::api::{BodyError, Endpoint};
+use xmtp_proto::xmtp::xmtpv4::payer_api::{GetNodesRequest, GetNodesResponse};
+
+#[derive(Debug, Builder, Default)]
+#[builder(setter(strip_option), build_fn(error = "BodyError"))]
+pub struct GetNodes {}
+
+impl GetNodes {
+    pub fn builder() -> GetNodesBuilder {
+        Default::default()
+    }
+}
+
+impl Endpoint for GetNodes {
+    type Output = GetNodesResponse;
+
+    fn grpc_endpoint(&self) -> Cow<'static, str> {
+        xmtp_proto::path_and_query::<GetNodesRequest>()
+    }
+
+    fn body(&self) -> Result<Bytes, BodyError> {
+        Ok(GetNodesRequest {}.encode_to_vec().into())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::d14n::GetNodes;
+    use xmtp_proto::prelude::*;
+
+    #[xmtp_common::test]
+    fn test_file_descriptor() {
+        let pnq = xmtp_proto::path_and_query::<GetNodesRequest>();
+        println!("{}", pnq);
+    }
+
+    #[xmtp_common::test]
+    async fn test_get_nodes() {
+        let mut endpoint = GetNodes::builder().build().unwrap();
+        let gateway_client = crate::TestClient::create_gateway();
+        let client = gateway_client.build().unwrap();
+        assert!(endpoint.query(&client).await.is_ok());
+    }
+
+    #[xmtp_common::test]
+    async fn test_get_nodes_unimplemented() {
+        // xmtpd doesn't implement the GetNodes endpoint
+        let mut endpoint = GetNodes::builder().build().unwrap();
+        let xmtpd_client = crate::TestClient::create_d14n();
+        let client = xmtpd_client.build().unwrap();
+        assert!(endpoint.query(&client).await.is_err());
+    }
+}

--- a/xmtp_api_d14n/src/endpoints/d14n/health_check.rs
+++ b/xmtp_api_d14n/src/endpoints/d14n/health_check.rs
@@ -1,0 +1,74 @@
+use derive_builder::Builder;
+use prost::Message;
+use prost::bytes::Bytes;
+use std::borrow::Cow;
+use xmtp_proto::api::{BodyError, Endpoint};
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HealthCheckRequest {
+    #[prost(string, tag = "1")]
+    pub service: String,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HealthCheckResponse {
+    #[prost(enumeration = "ServingStatus", tag = "1")]
+    pub status: i32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum ServingStatus {
+    Unknown = 0,
+    Serving = 1,
+    NotServing = 2,
+    ServiceUnknown = 3,
+}
+
+#[derive(Debug, Builder, Default)]
+#[builder(setter(strip_option), build_fn(error = "BodyError"))]
+pub struct HealthCheck {
+    #[builder(setter(into), default)]
+    service: String,
+}
+
+impl HealthCheck {
+    pub fn builder() -> HealthCheckBuilder {
+        Default::default()
+    }
+}
+
+impl Endpoint for HealthCheck {
+    type Output = HealthCheckResponse;
+
+    fn grpc_endpoint(&self) -> Cow<'static, str> {
+        Cow::from("/grpc.health.v1.Health/Check")
+    }
+
+    fn body(&self) -> Result<Bytes, BodyError> {
+        Ok(HealthCheckRequest {
+            service: self.service.clone(),
+        }
+        .encode_to_vec()
+        .into())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::d14n::HealthCheck;
+    use xmtp_proto::prelude::*;
+
+    #[xmtp_common::test]
+    async fn test_health_check() {
+        let mut endpoint = HealthCheck::builder().build().unwrap();
+
+        let xmtpd_client = crate::TestClient::create_d14n();
+        let client = xmtpd_client.build().unwrap();
+        assert!(endpoint.query(&client).await.is_ok());
+
+        let gateway_client = crate::TestClient::create_gateway();
+        let client = gateway_client.build().unwrap();
+        assert!(endpoint.query(&client).await.is_ok());
+    }
+}

--- a/xmtp_api_d14n/src/endpoints/d14n/publish_client_envelopes.rs
+++ b/xmtp_api_d14n/src/endpoints/d14n/publish_client_envelopes.rs
@@ -58,7 +58,7 @@ mod test {
         use xmtp_proto::xmtp::xmtpv4::envelopes::ClientEnvelope;
 
         let client = crate::TestClient::create_local_d14n();
-        let client = client.build().await.unwrap();
+        let client = client.build().unwrap();
 
         let endpoint = PublishClientEnvelopes::builder()
             .envelopes(vec![ClientEnvelope::default()])

--- a/xmtp_api_d14n/src/endpoints/d14n/query_envelopes.rs
+++ b/xmtp_api_d14n/src/endpoints/d14n/query_envelopes.rs
@@ -110,7 +110,7 @@ mod test {
         use crate::d14n::QueryEnvelopes;
 
         let client = crate::TestClient::create_local_d14n();
-        let client = client.build().await.unwrap();
+        let client = client.build().unwrap();
 
         let endpoint = QueryEnvelopes::builder()
             .envelopes(EnvelopesQuery {

--- a/xmtp_api_d14n/src/endpoints/d14n/subscribe_envelopes.rs
+++ b/xmtp_api_d14n/src/endpoints/d14n/subscribe_envelopes.rs
@@ -1,0 +1,81 @@
+use derive_builder::Builder;
+use prost::Message;
+use prost::bytes::Bytes;
+use std::borrow::Cow;
+use xmtp_proto::api::{BodyError, Endpoint};
+use xmtp_proto::xmtp::xmtpv4::message_api::SubscribeEnvelopesRequest;
+use xmtp_proto::xmtp::xmtpv4::message_api::{EnvelopesQuery, SubscribeEnvelopesResponse};
+
+/// Query a single thing
+#[derive(Debug, Builder, Default, Clone)]
+#[builder(build_fn(error = "BodyError"))]
+pub struct SubscribeEnvelopes {
+    envelopes: EnvelopesQuery,
+}
+
+impl SubscribeEnvelopes {
+    pub fn builder() -> SubscribeEnvelopesBuilder {
+        Default::default()
+    }
+}
+
+impl Endpoint for SubscribeEnvelopes {
+    type Output = SubscribeEnvelopesResponse;
+    fn grpc_endpoint(&self) -> Cow<'static, str> {
+        xmtp_proto::path_and_query::<SubscribeEnvelopesRequest>()
+    }
+
+    fn body(&self) -> Result<Bytes, BodyError> {
+        let query = SubscribeEnvelopesRequest {
+            query: Some(self.envelopes.clone()),
+        };
+        tracing::debug!("{:?}", query);
+        Ok(query.encode_to_vec().into())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use xmtp_proto::{
+        api::QueryStreamExt as _, prelude::*, xmtp::xmtpv4::message_api::SubscribeEnvelopesResponse,
+    };
+
+    #[xmtp_common::test]
+    fn test_file_descriptor() {
+        use xmtp_proto::xmtp::xmtpv4::message_api::SubscribeEnvelopesRequest;
+        let pnq = xmtp_proto::path_and_query::<SubscribeEnvelopesRequest>();
+        println!("{}", pnq);
+    }
+
+    #[xmtp_common::test]
+    fn test_grpc_endpoint_returns_correct_path() {
+        let endpoint = SubscribeEnvelopes::default();
+        assert_eq!(
+            endpoint.grpc_endpoint(),
+            "/xmtp.xmtpv4.message_api.ReplicationApi/SubscribeEnvelopes"
+        );
+    }
+
+    #[xmtp_common::test]
+    async fn test_subscribe_envelopes() {
+        use crate::d14n::SubscribeEnvelopes;
+
+        let client = crate::TestClient::create_d14n();
+        let client = client.build().unwrap();
+
+        let mut endpoint = SubscribeEnvelopes::builder()
+            .envelopes(EnvelopesQuery {
+                topics: vec![vec![]],
+                originator_node_ids: vec![],
+                last_seen: None,
+            })
+            .build()
+            .unwrap();
+        let rsp = endpoint
+            .subscribe::<SubscribeEnvelopesResponse>(&client)
+            .await
+            .inspect_err(|e| tracing::info!("{:?}", e));
+        assert!(rsp.is_ok());
+    }
+}

--- a/xmtp_api_d14n/src/endpoints/v3/identity/get_identity_updates_v2.rs
+++ b/xmtp_api_d14n/src/endpoints/v3/identity/get_identity_updates_v2.rs
@@ -52,7 +52,7 @@ mod test {
     #[xmtp_common::test]
     async fn test_get_identity_updates_v2() {
         let client = crate::TestClient::create_local();
-        let client = client.build().await.unwrap();
+        let client = client.build().unwrap();
         let endpoint = GetIdentityUpdatesV2::builder()
             .requests(vec![Request {
                 inbox_id: "".to_string(),

--- a/xmtp_api_d14n/src/endpoints/v3/identity/get_inbox_ids.rs
+++ b/xmtp_api_d14n/src/endpoints/v3/identity/get_inbox_ids.rs
@@ -75,7 +75,7 @@ mod test {
     #[xmtp_common::test]
     async fn test_get_inbox_ids() {
         let client = crate::TestClient::create_local();
-        let client = client.build().await.unwrap();
+        let client = client.build().unwrap();
         let endpoint = GetInboxIds::builder()
             .addresses(vec![
                 "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045".to_string(),

--- a/xmtp_api_d14n/src/endpoints/v3/identity/publish_identity_update.rs
+++ b/xmtp_api_d14n/src/endpoints/v3/identity/publish_identity_update.rs
@@ -57,7 +57,7 @@ mod test {
         use xmtp_proto::xmtp::identity::associations::IdentityUpdate;
 
         let client = crate::TestClient::create_local();
-        let client = client.build().await.unwrap();
+        let client = client.build().unwrap();
         let endpoint = PublishIdentityUpdate::builder()
             .identity_update(Some(IdentityUpdate {
                 actions: vec![],

--- a/xmtp_api_d14n/src/endpoints/v3/identity/verify_smart_contract_wallet_signatures.rs
+++ b/xmtp_api_d14n/src/endpoints/v3/identity/verify_smart_contract_wallet_signatures.rs
@@ -54,7 +54,7 @@ mod test {
     #[xmtp_common::test]
     async fn test_verify_smart_contract_wallet_signatures() {
         let client = crate::TestClient::create_local();
-        let client = client.build().await.unwrap();
+        let client = client.build().unwrap();
         let endpoint = VerifySmartContractWalletSignatures::builder()
             .signatures(vec![VerifySmartContractWalletSignatureRequestSignature {
                 account_id: "".into(),

--- a/xmtp_api_d14n/src/endpoints/v3/mls/fetch_key_packages.rs
+++ b/xmtp_api_d14n/src/endpoints/v3/mls/fetch_key_packages.rs
@@ -52,7 +52,7 @@ mod test {
     #[xmtp_common::test]
     async fn test_fetch_key_packages() {
         let client = crate::TestClient::create_local();
-        let client = client.build().await.unwrap();
+        let client = client.build().unwrap();
         let endpoint = FetchKeyPackages::builder()
             .installation_keys(vec![vec![1, 2, 3]])
             .build()

--- a/xmtp_api_d14n/src/endpoints/v3/mls/publish_commit_log.rs
+++ b/xmtp_api_d14n/src/endpoints/v3/mls/publish_commit_log.rs
@@ -53,7 +53,7 @@ mod test {
     // TODO: fix test
     async fn test_publish_commit_log() {
         let client = crate::TestClient::create_local();
-        let client = client.build().await.unwrap();
+        let client = client.build().unwrap();
         let endpoint = PublishCommitLog::builder()
             .commit_log_entries(vec![PublishCommitLogRequest::default()])
             .build()

--- a/xmtp_api_d14n/src/endpoints/v3/mls/query_group_messages.rs
+++ b/xmtp_api_d14n/src/endpoints/v3/mls/query_group_messages.rs
@@ -57,7 +57,7 @@ mod test {
     #[xmtp_common::test]
     async fn test_get_identity_updates_v2() {
         let client = crate::TestClient::create_local();
-        let client = client.build().await.unwrap();
+        let client = client.build().unwrap();
         let endpoint = QueryGroupMessages::builder()
             .group_id(vec![1, 2, 3])
             .build()

--- a/xmtp_api_d14n/src/endpoints/v3/mls/query_welcome_messages.rs
+++ b/xmtp_api_d14n/src/endpoints/v3/mls/query_welcome_messages.rs
@@ -60,7 +60,7 @@ mod test {
     #[xmtp_common::test]
     async fn test_get_identity_updates_v2() {
         let client = crate::TestClient::create_local();
-        let client = client.build().await.unwrap();
+        let client = client.build().unwrap();
         let endpoint = QueryWelcomeMessages::builder()
             .installation_key(vec![1, 2, 3])
             .build()

--- a/xmtp_api_d14n/src/endpoints/v3/mls/send_group_messages.rs
+++ b/xmtp_api_d14n/src/endpoints/v3/mls/send_group_messages.rs
@@ -52,7 +52,7 @@ mod test {
     #[xmtp_common::test]
     async fn test_send_group_messages() {
         let client = crate::TestClient::create_local();
-        let client = client.build().await.unwrap();
+        let client = client.build().unwrap();
         let endpoint = SendGroupMessages::builder()
             .messages(vec![GroupMessageInput::default()])
             .build()

--- a/xmtp_api_d14n/src/endpoints/v3/mls/send_welcome_messages.rs
+++ b/xmtp_api_d14n/src/endpoints/v3/mls/send_welcome_messages.rs
@@ -57,7 +57,7 @@ mod test {
             version: Some(welcome_message_input::Version::V1(Default::default())),
         };
         let client = crate::TestClient::create_local();
-        let client = client.build().await.unwrap();
+        let client = client.build().unwrap();
         let endpoint = SendWelcomeMessages::builder()
             .messages(vec![welcome_message])
             .build()

--- a/xmtp_api_d14n/src/endpoints/v3/mls/upload_key_package.rs
+++ b/xmtp_api_d14n/src/endpoints/v3/mls/upload_key_package.rs
@@ -54,7 +54,7 @@ mod test {
     #[xmtp_common::test]
     async fn test_get_identity_updates_v2() {
         let client = crate::TestClient::create_local();
-        let client = client.build().await.unwrap();
+        let client = client.build().unwrap();
         let endpoint = UploadKeyPackage::builder()
             .key_package(Some(KeyPackageUpload {
                 key_package_tls_serialized: vec![1, 2, 3],

--- a/xmtp_api_d14n/src/queries/d14n.rs
+++ b/xmtp_api_d14n/src/queries/d14n.rs
@@ -77,10 +77,10 @@ where
         <Builder1 as ApiBuilder>::port(&self.message_client)
     }
 
-    async fn build(self) -> Result<Self::Output, Self::Error> {
+    fn build(self) -> Result<Self::Output, Self::Error> {
         Ok(D14nClient::new(
-            <Builder1 as ApiBuilder>::build(self.message_client).await?,
-            <Builder2 as ApiBuilder>::build(self.payer_client).await?,
+            <Builder1 as ApiBuilder>::build(self.message_client)?,
+            <Builder2 as ApiBuilder>::build(self.payer_client)?,
         ))
     }
 

--- a/xmtp_api_d14n/src/queries/v3.rs
+++ b/xmtp_api_d14n/src/queries/v3.rs
@@ -64,10 +64,8 @@ where
         <Builder as ApiBuilder>::port(&self.client)
     }
 
-    async fn build(self) -> Result<Self::Output, Self::Error> {
-        Ok(V3Client::new(
-            <Builder as ApiBuilder>::build(self.client).await?,
-        ))
+    fn build(self) -> Result<Self::Output, Self::Error> {
+        Ok(V3Client::new(<Builder as ApiBuilder>::build(self.client)?))
     }
 
     fn host(&self) -> Option<&str> {

--- a/xmtp_api_grpc/src/grpc_client.rs
+++ b/xmtp_api_grpc/src/grpc_client.rs
@@ -137,17 +137,14 @@ impl ApiBuilder for ClientBuilder {
         }
     }
 
-    async fn build(self) -> Result<Self::Output, Self::Error> {
+    fn build(self) -> Result<Self::Output, Self::Error> {
         let host = self.host.ok_or(GrpcBuilderError::MissingHostUrl)?;
         tracing::info!("building GrpcClient with host {}", &host);
         let channel = match self.tls_channel {
-            true => create_tls_channel(host, self.limit.unwrap_or(5000)).await?,
-            false => {
-                Channel::from_shared(host)?
-                    .rate_limit(self.limit.unwrap_or(5000), Duration::from_secs(60))
-                    .connect()
-                    .await?
-            }
+            true => create_tls_channel(host, self.limit.unwrap_or(5000))?,
+            false => Channel::from_shared(host)?
+                .rate_limit(self.limit.unwrap_or(5000), Duration::from_secs(60))
+                .connect_lazy(),
         };
 
         Ok(GrpcClient {

--- a/xmtp_api_grpc/src/grpc_client/client.rs
+++ b/xmtp_api_grpc/src/grpc_client/client.rs
@@ -1,0 +1,323 @@
+//! The genneric gRPC Client
+//! Generic over a inner "Channel".
+//! The  inner channel must implement a tower service to implicitly
+//! implement the gRPC Service
+
+use crate::{
+    GrpcService,
+    error::{GrpcBuilderError, GrpcError},
+    streams::EscapableTonicStream,
+};
+use futures::Stream;
+use pin_project_lite::pin_project;
+use prost::bytes::Bytes;
+use std::{
+    pin::Pin,
+    task::{Context, Poll, ready},
+};
+use tonic::{
+    Status,
+    client::Grpc,
+    metadata::{self, MetadataMap, MetadataValue},
+};
+use xmtp_configuration::GRPC_PAYLOAD_LIMIT;
+use xmtp_proto::{
+    api::{ApiClientError, Client},
+    api_client::ApiBuilder,
+    codec::TransparentCodec,
+    types::AppVersion,
+};
+
+impl From<GrpcError> for ApiClientError<GrpcError> {
+    fn from(source: GrpcError) -> ApiClientError<GrpcError> {
+        ApiClientError::Client { source }
+    }
+}
+
+/// Private trait to convert type to an HTTP Response
+trait ToHttp {
+    type Body;
+    fn to_http(self) -> http::Response<Self::Body>;
+}
+
+/// Convert a tonic Response to a generic HTTP response
+impl<T> ToHttp for tonic::Response<T> {
+    type Body = T;
+
+    fn to_http(self) -> http::Response<Self::Body> {
+        let (metadata, body, extensions) = self.into_parts();
+        let mut response = http::Response::new(body);
+        if cfg!(target_arch = "wasm32") {
+            *response.version_mut() = http::version::Version::HTTP_11;
+        } else {
+            *response.version_mut() = http::version::Version::HTTP_2;
+        }
+        *response.headers_mut() = metadata.into_headers();
+        *response.extensions_mut() = extensions;
+        response
+    }
+}
+
+#[derive(Clone)]
+pub struct GrpcClient {
+    inner: tonic::client::Grpc<crate::GrpcService>,
+    app_version: MetadataValue<metadata::Ascii>,
+    libxmtp_version: MetadataValue<metadata::Ascii>,
+}
+
+impl GrpcClient {
+    pub fn new(
+        service: crate::GrpcService,
+        app_version: MetadataValue<metadata::Ascii>,
+        libxmtp_version: MetadataValue<metadata::Ascii>,
+    ) -> Self {
+        Self {
+            inner: tonic::client::Grpc::new(service),
+            app_version,
+            libxmtp_version,
+        }
+    }
+
+    /// Builds a tonic request from a body and a generic HTTP Request
+    fn build_tonic_request(
+        &self,
+        request: http::request::Builder,
+        body: Bytes,
+    ) -> Result<tonic::Request<Bytes>, Status> {
+        let request = request
+            .body(body)
+            .map_err(|e| tonic::Status::from_error(Box::new(e)))?;
+        let (parts, body) = request.into_parts();
+        let mut tonic_request = tonic::Request::from_parts(
+            MetadataMap::from_headers(parts.headers),
+            parts.extensions,
+            body,
+        );
+        let metadata = tonic_request.metadata_mut();
+        // must be lowercase otherwise panics
+        metadata.append("x-app-version", self.app_version.clone());
+        metadata.append("x-libxmtp-version", self.libxmtp_version.clone());
+        Ok(tonic_request)
+    }
+
+    async fn wait_for_ready(&self, client: &mut Grpc<GrpcService>) -> Result<(), Status> {
+        client.ready().await.map_err(|e| {
+            tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {e}"))
+        })?;
+        Ok(())
+    }
+}
+
+pin_project! {
+    /// A stream of bytes from a GRPC Network Source
+    pub struct GrpcStream {
+        #[pin] inner: crate::streams::NonBlocking
+    }
+}
+
+impl From<crate::streams::NonBlocking> for GrpcStream {
+    fn from(value: crate::streams::NonBlocking) -> GrpcStream {
+        GrpcStream { inner: value }
+    }
+}
+
+// just a more convenient way to map the stream type to
+// something more customized to the trait, without playing around with getting the
+// generics right on nested futures combinators.
+impl Stream for GrpcStream {
+    type Item = Result<Bytes, GrpcError>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+        let item = ready!(this.inner.poll_next(cx));
+        Poll::Ready(item.map(|i| i.map_err(GrpcError::from)))
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl Client for GrpcClient {
+    type Error = GrpcError;
+    type Stream = GrpcStream;
+
+    async fn request(
+        &self,
+        request: http::request::Builder,
+        path: http::uri::PathAndQuery,
+        body: Bytes,
+    ) -> Result<http::Response<Bytes>, ApiClientError<Self::Error>> {
+        let client = &mut self.inner.clone();
+        self.wait_for_ready(client).await.map_err(GrpcError::from)?;
+        let request = self
+            .build_tonic_request(request, body)
+            .map_err(GrpcError::from)?;
+        let codec = TransparentCodec::default();
+        let response = client
+            .unary(request, path, codec)
+            .await
+            .map_err(GrpcError::from)?;
+
+        Ok(response.to_http())
+    }
+
+    async fn stream(
+        &self,
+        request: http::request::Builder,
+        path: http::uri::PathAndQuery,
+        body: Bytes,
+    ) -> Result<http::Response<Self::Stream>, ApiClientError<Self::Error>> {
+        let this = self.clone();
+        // client requires to be moved so it lives long enough for streaming response future.
+        let response = async move {
+            let mut client = this.inner.clone();
+            this.wait_for_ready(&mut client).await?;
+            let request = this.build_tonic_request(request, body)?;
+            let codec = TransparentCodec::default();
+            client.server_streaming(request, path, codec).await
+        };
+        let req = crate::streams::NonBlockingStreamRequest::new(Box::pin(response) as Pin<Box<_>>);
+        let response = crate::streams::send(req).await.map_err(GrpcError::from)?;
+        let response = response.map(|body| GrpcStream {
+            inner: EscapableTonicStream::new(body),
+        });
+        Ok(response.to_http().map(Into::into))
+    }
+}
+
+impl GrpcClient {
+    pub fn builder() -> ClientBuilder {
+        ClientBuilder::default()
+    }
+}
+
+#[derive(Default)]
+pub struct ClientBuilder {
+    pub host: Option<String>,
+    /// version of the app
+    pub app_version: Option<MetadataValue<metadata::Ascii>>,
+    /// Version of the libxmtp core library
+    pub libxmtp_version: Option<MetadataValue<metadata::Ascii>>,
+    /// Whether or not the channel should use TLS
+    pub tls_channel: bool,
+    /// Rate per minute
+    pub limit: Option<u64>,
+}
+
+impl ApiBuilder for ClientBuilder {
+    type Output = GrpcClient;
+    type Error = GrpcBuilderError;
+
+    fn set_libxmtp_version(&mut self, version: String) -> Result<(), Self::Error> {
+        self.libxmtp_version = Some(MetadataValue::try_from(&version)?);
+        Ok(())
+    }
+
+    fn set_app_version(&mut self, version: AppVersion) -> Result<(), Self::Error> {
+        self.app_version = Some(MetadataValue::try_from(&version)?);
+        Ok(())
+    }
+
+    fn set_host(&mut self, host: String) {
+        self.host = Some(host);
+    }
+
+    fn set_tls(&mut self, tls: bool) {
+        self.tls_channel = tls;
+    }
+
+    fn rate_per_minute(&mut self, limit: u32) {
+        self.limit = Some(limit.into());
+    }
+
+    fn port(&self) -> Result<Option<String>, Self::Error> {
+        if let Some(h) = &self.host {
+            let u = url::Url::parse(h)?;
+            Ok(u.port().map(|u| u.to_string()))
+        } else {
+            Err(GrpcBuilderError::MissingHostUrl)
+        }
+    }
+
+    fn host(&self) -> Option<&str> {
+        self.host.as_deref()
+    }
+
+    fn build(self) -> Result<Self::Output, Self::Error> {
+        let host = self.host.ok_or(GrpcBuilderError::MissingHostUrl)?;
+        let channel = crate::GrpcService::new(host, self.limit, self.tls_channel)?;
+        Ok(GrpcClient {
+            inner: tonic::client::Grpc::new(channel)
+                .max_decoding_message_size(GRPC_PAYLOAD_LIMIT)
+                .max_encoding_message_size(GRPC_PAYLOAD_LIMIT),
+            app_version: self
+                .app_version
+                .unwrap_or(MetadataValue::try_from("0.0.0")?),
+            libxmtp_version: self.libxmtp_version.unwrap_or(MetadataValue::try_from(
+                env!("CARGO_PKG_VERSION").to_string(),
+            )?),
+        })
+    }
+
+    // this client does not do retries
+    fn set_retry(&mut self, _retry: xmtp_common::Retry) {}
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+mod test {
+    use super::*;
+    use xmtp_configuration::GrpcUrls;
+    use xmtp_configuration::LOCALHOST;
+    use xmtp_proto::{TestApiBuilder, ToxicProxies, api_client::XmtpTestClient};
+
+    impl XmtpTestClient for GrpcClient {
+        type Builder = ClientBuilder;
+
+        fn create_local() -> Self::Builder {
+            let mut client = GrpcClient::builder();
+            let url = url::Url::parse(GrpcUrls::NODE).unwrap();
+            match url.scheme() {
+                "https" => client.set_tls(true),
+                _ => client.set_tls(false),
+            }
+            client.set_host(GrpcUrls::NODE.into());
+            client
+        }
+
+        fn create_d14n() -> Self::Builder {
+            let mut client = GrpcClient::builder();
+            let url = url::Url::parse(GrpcUrls::XMTPD).unwrap();
+            match url.scheme() {
+                "https" => client.set_tls(true),
+                _ => client.set_tls(false),
+            }
+            client.set_host(GrpcUrls::XMTPD.into());
+            client
+        }
+
+        fn create_gateway() -> Self::Builder {
+            let mut gateway = GrpcClient::builder();
+            let url = url::Url::parse(GrpcUrls::GATEWAY).unwrap();
+            match url.scheme() {
+                "https" => gateway.set_tls(true),
+                _ => gateway.set_tls(false),
+            }
+            gateway.set_host(GrpcUrls::GATEWAY.into());
+            gateway
+        }
+
+        fn create_dev() -> Self::Builder {
+            let mut client = GrpcClient::builder();
+            client.set_host(GrpcUrls::NODE_DEV.into());
+            client.set_tls(true);
+            client
+        }
+    }
+
+    impl TestApiBuilder for ClientBuilder {
+        async fn with_toxiproxy(&mut self) -> ToxicProxies {
+            let proxy = xmtp_proto::init_toxi(&[self.host().unwrap()]).await;
+            self.set_host(format!("{LOCALHOST}:{}", proxy.port(0)));
+            proxy
+        }
+    }
+}

--- a/xmtp_api_grpc/src/grpc_client/wasm.rs
+++ b/xmtp_api_grpc/src/grpc_client/wasm.rs
@@ -1,0 +1,42 @@
+use crate::error::GrpcBuilderError;
+use http::Request;
+use std::task::{Context, Poll};
+use tonic::{body::Body, client::GrpcService};
+use tonic_web_wasm_client::{
+    options::{FetchOptions, ReferrerPolicy},
+    Client,
+};
+use tower::Service;
+
+#[derive(Debug, Clone)]
+pub struct GrpcWebService {
+    inner: Client,
+}
+
+impl GrpcWebService {
+    pub fn new(
+        host: String,
+        _limit: Option<u64>,
+        _is_secure: bool,
+    ) -> Result<Self, GrpcBuilderError> {
+        let options =
+            FetchOptions::default().referrer_policy(ReferrerPolicy::StrictOriginWhenCrossOrigin);
+        Ok(Self {
+            inner: Client::new_with_options(host, options),
+        })
+    }
+}
+
+impl Service<Request<Body>> for GrpcWebService {
+    type Response = <Client as Service<Request<Body>>>::Response;
+    type Error = <Client as GrpcService<Body>>::Error;
+    type Future = <Client as GrpcService<Body>>::Future;
+
+    fn poll_ready(&mut self, ctx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        <Client as Service<Request<Body>>>::poll_ready(&mut self.inner, ctx)
+    }
+
+    fn call(&mut self, request: Request<Body>) -> Self::Future {
+        <Client as Service<Request<Body>>>::call(&mut self.inner, request)
+    }
+}

--- a/xmtp_api_http/src/lib.rs
+++ b/xmtp_api_http/src/lib.rs
@@ -84,7 +84,7 @@ impl XmtpHttpApiClient {
         let mut b = Self::builder();
         b.set_host(host_url);
         b.set_app_version(app_version)?;
-        b.build().await
+        b.build()
     }
 
     /// Wait for any rate limit
@@ -199,7 +199,7 @@ impl ApiBuilder for XmtpHttpApiClientBuilder {
         Ok(Url::parse(&self.host_url)?.port().map(|u| u.to_string()))
     }
 
-    async fn build(mut self) -> Result<Self::Output, Self::Error> {
+    fn build(mut self) -> Result<Self::Output, Self::Error> {
         let libxmtp_version = self
             .libxmtp_version
             .unwrap_or(env!("CARGO_PKG_VERSION").to_string());
@@ -626,7 +626,7 @@ pub mod tests {
         client
             .set_libxmtp_version(env!("CARGO_PKG_VERSION").into())
             .unwrap();
-        let client = client.build().await.unwrap();
+        let client = client.build().unwrap();
         let result = client
             .upload_key_package(UploadKeyPackageRequest {
                 is_inbox_id_credential: false,
@@ -659,7 +659,7 @@ pub mod tests {
         client
             .set_libxmtp_version(env!("CARGO_PKG_VERSION").into())
             .unwrap();
-        let client = client.build().await.unwrap();
+        let client = client.build().unwrap();
         let result = client
             .get_inbox_ids(GetInboxIdsRequest {
                 requests: vec![Request {

--- a/xmtp_db/src/encrypted_store/group.rs
+++ b/xmtp_db/src/encrypted_store/group.rs
@@ -780,7 +780,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
         })?;
 
         if maybe_inserted_group.is_none() {
-            let existing_group: StoredGroup =
+            let mut existing_group: StoredGroup =
                 self.raw_query_read(|conn| dsl::groups.find(&group.id).first(conn))?;
             // A restored group should be overwritten
             if matches!(
@@ -813,6 +813,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
                             .set(dsl::welcome_id.eq(group.welcome_id))
                             .execute(c)
                     })?;
+                    existing_group.welcome_id = group.welcome_id;
                 }
                 Ok(existing_group)
             }

--- a/xmtp_debug/src/args.rs
+++ b/xmtp_debug/src/args.rs
@@ -289,18 +289,19 @@ impl BackendOpts {
             let mut payer = GrpcClient::builder();
             payer.set_host(payer_host.to_string());
             payer.set_tls(is_secure);
-            let payer = payer.build().await?;
+            let payer = payer.build()?;
             let mut message = GrpcClient::builder();
             message.set_host(network.to_string());
             message.set_tls(is_secure);
-            let message = message.build().await?;
+            let message = message.build()?;
             Ok(Arc::new(D14nClient::new(message, payer)))
         } else {
             trace!(url = %network, is_secure, "create grpc");
-            Ok(Arc::new(
-                crate::GrpcClient::create(network.as_str().to_string(), is_secure, None::<String>)
-                    .await?,
-            ))
+            Ok(Arc::new(crate::GrpcClient::create(
+                network.as_str().to_string(),
+                is_secure,
+                None::<String>,
+            )?))
         }
     }
 }

--- a/xmtp_mls/src/groups/welcome_sync.rs
+++ b/xmtp_mls/src/groups/welcome_sync.rs
@@ -4,6 +4,7 @@ use crate::groups::InitialMembershipValidator;
 use crate::groups::ValidateGroupMembership;
 use crate::groups::XmtpWelcome;
 use crate::groups::{GroupError, MlsGroup};
+use crate::intents::ProcessIntentError;
 use crate::mls_store::MlsStore;
 use futures::stream::{self, FuturesUnordered, StreamExt};
 use std::sync::{
@@ -54,9 +55,13 @@ where
 
                 if matches!(err, GroupError::Storage(Duplicate(WelcomeId(_)))) {
                     tracing::warn!(
-                        "failed to create group from welcome due to duplicate welcome ID: {}",
+                        welcome_id = welcome.id,
+                        "Welcome ID already stored: {}",
                         err
                     );
+                    return Err(GroupError::ProcessIntent(
+                        ProcessIntentError::WelcomeAlreadyProcessed(welcome.id),
+                    ));
                 } else {
                     tracing::error!(
                         "failed to create group from welcome created at {}: {}",

--- a/xmtp_mls/src/identity_updates.rs
+++ b/xmtp_mls/src/identity_updates.rs
@@ -116,7 +116,7 @@ pub async fn get_association_state_with_verifier(
 }
 
 /// Revoke the given installations from the association state for the client's inbox
-pub async fn revoke_installations_with_verifier(
+pub fn revoke_installations_with_verifier(
     identifier: &Identifier,
     inbox_id: &str,
     installation_ids: Vec<Vec<u8>>,
@@ -415,8 +415,7 @@ where
             &current_state.recovery_identifier().clone(),
             inbox_id,
             installation_ids,
-        )
-        .await?;
+        )?;
 
         let _ = self
             .context

--- a/xmtp_mls/src/test/builder.rs
+++ b/xmtp_mls/src/test/builder.rs
@@ -213,11 +213,9 @@ async fn test_client_creation() {
             .api_clients(
                 <TestClient as XmtpTestClient>::create_local()
                     .build()
-                    .await
                     .unwrap(),
                 <TestClient as XmtpTestClient>::create_local()
                     .build()
-                    .await
                     .unwrap(),
             )
             .default_mls_store()
@@ -259,11 +257,9 @@ async fn test_turn_local_telemetry_off() {
         .api_clients(
             <TestClient as XmtpTestClient>::create_local()
                 .build()
-                .await
                 .unwrap(),
             <TestClient as XmtpTestClient>::create_local()
                 .build()
-                .await
                 .unwrap(),
         )
         .default_mls_store()
@@ -302,11 +298,9 @@ async fn test_2nd_time_client_creation() {
         .api_clients(
             <TestClient as XmtpTestClient>::create_local()
                 .build()
-                .await
                 .unwrap(),
             <TestClient as XmtpTestClient>::create_local()
                 .build()
-                .await
                 .unwrap(),
         )
         .default_mls_store()
@@ -322,11 +316,9 @@ async fn test_2nd_time_client_creation() {
         .api_clients(
             <TestClient as XmtpTestClient>::create_local()
                 .build()
-                .await
                 .unwrap(),
             <TestClient as XmtpTestClient>::create_local()
                 .build()
-                .await
                 .unwrap(),
         )
         .default_mls_store()
@@ -349,11 +341,9 @@ async fn test_2nd_time_client_creation() {
     .api_clients(
         <TestClient as XmtpTestClient>::create_local()
             .build()
-            .await
             .unwrap(),
         <TestClient as XmtpTestClient>::create_local()
             .build()
-            .await
             .unwrap(),
     )
     .default_mls_store()
@@ -372,11 +362,9 @@ async fn test_2nd_time_client_creation() {
         .api_clients(
             <TestClient as XmtpTestClient>::create_local()
                 .build()
-                .await
                 .unwrap(),
             <TestClient as XmtpTestClient>::create_local()
                 .build()
-                .await
                 .unwrap(),
         )
         .default_mls_store()
@@ -614,11 +602,9 @@ async fn identity_persistence_test() {
     .api_clients(
         <TestClient as XmtpTestClient>::create_local()
             .build()
-            .await
             .unwrap(),
         <TestClient as XmtpTestClient>::create_local()
             .build()
-            .await
             .unwrap(),
     )
     .store(store_a)
@@ -645,11 +631,9 @@ async fn identity_persistence_test() {
     .api_clients(
         <TestClient as XmtpTestClient>::create_local()
             .build()
-            .await
             .unwrap(),
         <TestClient as XmtpTestClient>::create_local()
             .build()
-            .await
             .unwrap(),
     )
     .store(store_b)
@@ -687,11 +671,9 @@ async fn identity_persistence_test() {
         .api_clients(
             <TestClient as XmtpTestClient>::create_local()
                 .build()
-                .await
                 .unwrap(),
             <TestClient as XmtpTestClient>::create_local()
                 .build()
-                .await
                 .unwrap(),
         )
         .store(store_d)

--- a/xmtp_mls/src/utils/bench/clients.rs
+++ b/xmtp_mls/src/utils/bench/clients.rs
@@ -25,13 +25,11 @@ pub async fn new_unregistered_client(history_sync: bool) -> (BenchClient, Privat
         tracing::info!("Using Dev GRPC");
         <TestApiClient as XmtpTestClient>::create_dev()
             .build()
-            .await
             .unwrap()
     } else {
         tracing::info!("Using Local GRPC");
         <TestApiClient as XmtpTestClient>::create_local()
             .build()
-            .await
             .unwrap()
     };
 
@@ -39,13 +37,11 @@ pub async fn new_unregistered_client(history_sync: bool) -> (BenchClient, Privat
         tracing::info!("Using Dev GRPC");
         <TestApiClient as XmtpTestClient>::create_dev()
             .build()
-            .await
             .unwrap()
     } else {
         tracing::info!("Using Local GRPC");
         <TestApiClient as XmtpTestClient>::create_local()
             .build()
-            .await
             .unwrap()
     };
 
@@ -108,13 +104,11 @@ pub async fn create_client_from_identity(
         tracing::info!("Using Dev GRPC");
         <TestApiClient as XmtpTestClient>::create_dev()
             .build()
-            .await
             .unwrap()
     } else {
         tracing::info!("Using Local GRPC");
         <TestApiClient as XmtpTestClient>::create_local()
             .build()
-            .await
             .unwrap()
     };
 
@@ -122,13 +116,11 @@ pub async fn create_client_from_identity(
         tracing::info!("Using Dev GRPC");
         <TestApiClient as XmtpTestClient>::create_dev()
             .build()
-            .await
             .unwrap()
     } else {
         tracing::info!("Using Local GRPC");
         <TestApiClient as XmtpTestClient>::create_local()
             .build()
-            .await
             .unwrap()
     };
 

--- a/xmtp_mls/src/utils/test/mod.rs
+++ b/xmtp_mls/src/utils/test/mod.rs
@@ -63,11 +63,9 @@ impl<A, S> ClientBuilder<A, S> {
     pub async fn dev(self) -> ClientBuilder<TestClient, S> {
         let api_client = <TestClient as XmtpTestClient>::create_dev()
             .build()
-            .await
             .unwrap();
         let sync_api_client = <TestClient as XmtpTestClient>::create_dev()
             .build()
-            .await
             .unwrap();
         self.api_clients(api_client, sync_api_client)
     }
@@ -75,11 +73,9 @@ impl<A, S> ClientBuilder<A, S> {
     pub async fn local(self) -> ClientBuilder<TestClient, S> {
         let api_client = <TestClient as XmtpTestClient>::create_local()
             .build()
-            .await
             .unwrap();
         let sync_api_client = <TestClient as XmtpTestClient>::create_local()
             .build()
-            .await
             .unwrap();
         self.api_clients(api_client, sync_api_client)
     }
@@ -158,11 +154,9 @@ impl ClientBuilder<TestClient, TestMlsStorage> {
     pub async fn new_test_client_dev(owner: &impl InboxOwner) -> FullXmtpClient {
         let api_client = <TestClient as XmtpTestClient>::create_dev()
             .build()
-            .await
             .unwrap();
         let sync_api_client = <TestClient as XmtpTestClient>::create_dev()
             .build()
-            .await
             .unwrap();
 
         let client = Self::new_test_builder(owner)
@@ -182,12 +176,10 @@ impl ClientBuilder<TestClient, TestMlsStorage> {
     ) -> FullXmtpClient {
         let api_client = <TestClient as XmtpTestClient>::create_local()
             .build()
-            .await
             .unwrap();
 
         let sync_api_client = <TestClient as XmtpTestClient>::create_local()
             .build()
-            .await
             .unwrap();
 
         let client = Self::new_test_builder(owner)
@@ -208,11 +200,9 @@ impl<ApiClient, Db> ClientBuilder<ApiClient, Db> {
         self.api_clients(
             <TestClient as XmtpTestClient>::create_local()
                 .build()
-                .await
                 .unwrap(),
             <TestClient as XmtpTestClient>::create_local()
                 .build()
-                .await
                 .unwrap(),
         )
     }
@@ -221,11 +211,9 @@ impl<ApiClient, Db> ClientBuilder<ApiClient, Db> {
         self.api_clients(
             <TestClient as XmtpTestClient>::create_dev()
                 .build()
-                .await
                 .unwrap(),
             <TestClient as XmtpTestClient>::create_dev()
                 .build()
-                .await
                 .unwrap(),
         )
     }

--- a/xmtp_mls/src/utils/test/tester_utils.rs
+++ b/xmtp_mls/src/utils/test/tester_utils.rs
@@ -150,8 +150,8 @@ where
             local_client.host(),
             sync_api_client.host()
         );
-        let api_client = local_client.build().await.unwrap();
-        let sync_api_client = sync_api_client.build().await.unwrap();
+        let api_client = local_client.build().unwrap();
+        let sync_api_client = sync_api_client.build().unwrap();
         let client = ClientBuilder::new_test_builder(&self.owner)
             .await
             .api_clients(api_client, sync_api_client)

--- a/xmtp_mls/tests/chaos.rs
+++ b/xmtp_mls/tests/chaos.rs
@@ -26,8 +26,8 @@ async fn chaos_demo() {
     let alix = Client::builder(new_identity(&owner))
         .store(store)
         .api_clients(
-            TestClient::create_local().build().await.unwrap(),
-            TestClient::create_local().build().await.unwrap(),
+            TestClient::create_local().build().unwrap(),
+            TestClient::create_local().build().unwrap(),
         )
         .default_mls_store()
         .unwrap()

--- a/xmtp_proto/src/api_client.rs
+++ b/xmtp_proto/src/api_client.rs
@@ -599,7 +599,7 @@ pub trait ApiBuilder {
 
     #[allow(async_fn_in_trait)]
     /// Build the api client
-    async fn build(self) -> Result<Self::Output, Self::Error>;
+    fn build(self) -> Result<Self::Output, Self::Error>;
 }
 
 #[cfg(any(test, feature = "test-utils"))]

--- a/xmtp_proto/src/traits.rs
+++ b/xmtp_proto/src/traits.rs
@@ -253,7 +253,7 @@ pub mod mock {
             Ok(None)
         }
 
-        async fn build(self) -> Result<Self::Output, Self::Error> {
+        fn build(self) -> Result<Self::Output, Self::Error> {
             Ok(MockClient)
         }
 

--- a/xmtp_proto/src/traits/mock.rs
+++ b/xmtp_proto/src/traits/mock.rs
@@ -1,0 +1,130 @@
+use super::*;
+use crate::{ToxicProxies, prelude::*, types::AppVersion};
+
+pub struct TestEndpoint;
+impl Endpoint for TestEndpoint {
+    type Output = ();
+
+    fn grpc_endpoint(&self) -> std::borrow::Cow<'static, str> {
+        Cow::Borrowed("")
+    }
+
+    fn body(&self) -> Result<bytes::Bytes, crate::api::BodyError> {
+        Ok(vec![].into())
+    }
+}
+
+pub struct MockStream;
+pub struct MockApiBuilder;
+impl ApiBuilder for MockApiBuilder {
+    type Output = MockNetworkClient;
+    type Error = MockError;
+    fn set_libxmtp_version(&mut self, _version: String) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn set_app_version(&mut self, _version: AppVersion) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn set_host(&mut self, _host: String) {}
+    fn set_gateway(&mut self, _host: String) {}
+    fn set_tls(&mut self, _tls: bool) {}
+    fn rate_per_minute(&mut self, _limit: u32) {}
+
+    fn port(&self) -> Result<Option<String>, Self::Error> {
+        Ok(None)
+    }
+
+    fn build(self) -> Result<Self::Output, Self::Error> {
+        Ok(MockNetworkClient::default())
+    }
+
+    fn host(&self) -> Option<&str> {
+        None
+    }
+
+    fn set_retry(&mut self, _retry: xmtp_common::Retry) {}
+}
+
+impl crate::TestApiBuilder for MockApiBuilder {
+    async fn with_toxiproxy(&mut self) -> ToxicProxies {
+        unimplemented!()
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum MockError {
+    #[error("retryable mock error")]
+    ARetryableError,
+    #[error("non retryable mock error")]
+    ANonRetryableError,
+}
+
+impl xmtp_common::RetryableError for MockError {
+    fn is_retryable(&self) -> bool {
+        match self {
+            Self::ARetryableError => true,
+            Self::ANonRetryableError => false,
+        }
+    }
+}
+
+type Repeat = Box<dyn Send + FnMut() -> Result<prost::bytes::Bytes, MockError>>;
+type MockStreamT = futures::stream::RepeatWith<Repeat>;
+#[cfg(not(target_arch = "wasm32"))]
+mockall::mock! {
+    pub NetworkClient {}
+
+    #[async_trait::async_trait]
+    impl Client for NetworkClient {
+        type Error = MockError;
+        type Stream = MockStreamT;
+        async fn request(
+            &self,
+            request: http::request::Builder,
+            path: http::uri::PathAndQuery,
+            body: Bytes,
+        ) -> Result<http::Response<Bytes>, ApiClientError<MockError>>;
+
+        async fn stream(
+            &self,
+            request: http::request::Builder,
+            path: http::uri::PathAndQuery,
+            body: Bytes,
+        ) -> Result<http::Response<MockStreamT>, ApiClientError<MockError>>;
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+mockall::mock! {
+    pub NetworkClient {}
+
+    #[async_trait::async_trait(?Send)]
+    impl Client for NetworkClient {
+        type Error = MockError;
+        type Stream = MockStreamT;
+        async fn request(
+            &self,
+            request: http::request::Builder,
+            path: http::uri::PathAndQuery,
+            body: Bytes,
+        ) -> Result<http::Response<Bytes>, ApiClientError<MockError>>;
+
+        async fn stream(
+            &self,
+            request: http::request::Builder,
+            path: http::uri::PathAndQuery,
+            body: Bytes,
+        ) -> Result<http::Response<MockStreamT>, ApiClientError<MockError>>;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[xmtp_common::test]
+    fn test_grpc_endpoint_returns_empty_string() {
+        let endpoint = TestEndpoint;
+        assert_eq!(endpoint.grpc_endpoint(), "");
+    }
+}


### PR DESCRIPTION
- Patch release to include a bug fix for conversation streaming
- [pr](https://github.com/xmtp/libxmtp/pull/2552) defer grpc connection until first api request by using [`connect_lazy`](https://docs.rs/tonic/latest/tonic/transport/struct.Endpoint.html#method.connect_lazy)