### PR TITLE
Add readd intent

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -48,10 +48,10 @@ jobs:
             - Security concerns
             - Test coverage
 
-            Be constructive and helpful in your feedback.
             Do not repeat what has already been commented on by others, including the author.
             Do not comment on, or repeat TODO comments.
             Keep feedback concise, and limited to the most important points, if any.
+            Please include the date and time of the review in the comment.
           # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
           use_sticky_comment: true
 # Optional: Customize review based on file types

--- a/xmtp_db/src/encrypted_store/group_intent.rs
+++ b/xmtp_db/src/encrypted_store/group_intent.rs
@@ -32,6 +32,7 @@ pub enum IntentKind {
     UpdateGroupMembership = 4,
     UpdateAdminList = 5,
     UpdatePermission = 6,
+    ReaddInstallations = 7,
 }
 
 impl std::fmt::Display for IntentKind {
@@ -43,6 +44,7 @@ impl std::fmt::Display for IntentKind {
             IntentKind::UpdateGroupMembership => "UpdateGroupMembership",
             IntentKind::UpdateAdminList => "UpdateAdminList",
             IntentKind::UpdatePermission => "UpdatePermission",
+            IntentKind::ReaddInstallations => "ReaddInstallations",
         };
         write!(f, "{}", description)
     }
@@ -529,6 +531,7 @@ where
             4 => Ok(IntentKind::UpdateGroupMembership),
             5 => Ok(IntentKind::UpdateAdminList),
             6 => Ok(IntentKind::UpdatePermission),
+            7 => Ok(IntentKind::ReaddInstallations),
             x => Err(format!("Unrecognized variant {}", x).into()),
         }
     }

--- a/xmtp_mls/src/groups/intents.rs
+++ b/xmtp_mls/src/groups/intents.rs
@@ -17,13 +17,15 @@ use xmtp_common::types::Address;
 use xmtp_mls_common::group_mutable_metadata::MetadataField;
 use xmtp_proto::xmtp::mls::database::{
     AccountAddresses, AddressesOrInstallationIds as AddressesOrInstallationIdsProtoWrapper,
-    InstallationIds, PostCommitAction as PostCommitActionProto, SendMessageData,
-    UpdateAdminListsData, UpdateGroupMembershipData, UpdateMetadataData, UpdatePermissionData,
+    InstallationIds, PostCommitAction as PostCommitActionProto, ReaddInstallationsData,
+    SendMessageData, UpdateAdminListsData, UpdateGroupMembershipData, UpdateMetadataData,
+    UpdatePermissionData,
     addresses_or_installation_ids::AddressesOrInstallationIds as AddressesOrInstallationIdsProto,
     post_commit_action::{
         Installation as InstallationProto, Kind as PostCommitActionKind,
         SendWelcomes as SendWelcomesProto,
     },
+    readd_installations_data::{V1 as ReaddInstallationsV1, Version as ReaddInstallationsVersion},
     send_message_data::{V1 as SendMessageV1, Version as SendMessageVersion},
     update_admin_lists_data::{V1 as UpdateAdminListsV1, Version as UpdateAdminListsVersion},
     update_group_membership_data::{
@@ -623,6 +625,63 @@ impl TryFrom<Vec<u8>> for UpdatePermissionIntentData {
     }
 }
 
+pub(crate) struct ReaddInstallationsIntentData {
+    pub readded_installations: Vec<Vec<u8>>,
+}
+
+impl ReaddInstallationsIntentData {
+    pub fn new(readded_installations: Vec<Vec<u8>>) -> Self {
+        Self {
+            readded_installations,
+        }
+    }
+}
+
+impl From<ReaddInstallationsIntentData> for Vec<u8> {
+    fn from(intent: ReaddInstallationsIntentData) -> Self {
+        let mut buf = Vec::new();
+        ReaddInstallationsData {
+            version: Some(ReaddInstallationsVersion::V1(ReaddInstallationsV1 {
+                readded_installations: intent.readded_installations,
+            })),
+        }
+        .encode(&mut buf)
+        .expect("encode error");
+
+        buf
+    }
+}
+
+impl TryFrom<Vec<u8>> for ReaddInstallationsIntentData {
+    type Error = IntentError;
+
+    fn try_from(data: Vec<u8>) -> Result<Self, Self::Error> {
+        if let ReaddInstallationsData {
+            version: Some(ReaddInstallationsVersion::V1(v1)),
+        } = ReaddInstallationsData::decode(data.as_slice())?
+        {
+            Ok(Self::new(v1.readded_installations))
+        } else {
+            Err(IntentError::MissingPayload)
+        }
+    }
+}
+
+impl TryFrom<&[u8]> for ReaddInstallationsIntentData {
+    type Error = IntentError;
+
+    fn try_from(data: &[u8]) -> Result<Self, Self::Error> {
+        if let ReaddInstallationsData {
+            version: Some(ReaddInstallationsVersion::V1(v1)),
+        } = ReaddInstallationsData::decode(data)?
+        {
+            Ok(Self::new(v1.readded_installations))
+        } else {
+            Err(IntentError::MissingPayload)
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum PostCommitAction {
     SendWelcomes(SendWelcomesAction),
@@ -810,6 +869,19 @@ pub(crate) mod tests {
             UpdateMetadataIntentData::try_from(as_bytes).unwrap();
 
         assert_eq!(intent.field_value, restored_intent.field_value);
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn test_serialize_readd_installations() {
+        let readded_installations = vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]];
+
+        let intent = ReaddInstallationsIntentData::new(readded_installations.clone());
+
+        let as_bytes: Vec<u8> = intent.into();
+        let restored_intent: ReaddInstallationsIntentData = as_bytes.try_into().unwrap();
+
+        assert_eq!(readded_installations, restored_intent.readded_installations);
     }
 
     #[xmtp_common::test]

--- a/xmtp_mls/src/groups/intents/queue.rs
+++ b/xmtp_mls/src/groups/intents/queue.rs
@@ -142,6 +142,12 @@ impl QueueIntent {
         this
     }
 
+    pub fn readd_installations() -> QueueIntentBuilder {
+        let mut this = QueueIntent::builder();
+        this.kind = Some(IntentKind::ReaddInstallations);
+        this
+    }
+
     fn builder() -> QueueIntentBuilder {
         QueueIntentBuilder::default()
     }

--- a/xmtp_mls/src/groups/tests/test_commit_log_readd_requests.rs
+++ b/xmtp_mls/src/groups/tests/test_commit_log_readd_requests.rs
@@ -155,3 +155,37 @@ async fn test_request_readd_dm() {
             .unwrap()
     );
 }
+
+#[xmtp_common::test]
+async fn test_readd_installations() {
+    tester!(alix);
+    tester!(bo);
+
+    // Create a group with both members
+    let group = alix
+        .create_group_with_inbox_ids(&[bo.inbox_id()], None, None)
+        .await
+        .unwrap();
+
+    // Bo syncs to join the group
+    bo.sync_all_welcomes_and_groups(None).await.unwrap();
+
+    let _bo_group = bo.group(&group.group_id).unwrap();
+
+    // Get Bo's installation ID
+    let bo_installation_id = bo.context.installation_id();
+
+    // Verify Bo is currently in the group
+    let members = group.members().await.unwrap();
+    assert_eq!(members.len(), 2);
+
+    // Readd Bo's installation
+    // Note: This is expected to fail until receiver-side validation is implemented
+    let readd_result = group
+        .readd_installations(vec![bo_installation_id.to_vec()])
+        .await;
+
+    // Once validation/receiver side is updated, this call should not error,
+    // and Bo should be able to receive a new welcome for the same group
+    assert!(readd_result.is_err());
+}


### PR DESCRIPTION
This implements the publish flow for a `readd_installations` method (which will be called in upstack PR's).

Once published, the readd commit will fail current validation logic once received. Updating the validation logic (which is a breaking change) is tackled in the next two PR's. Therefore, the unit test currently asserts that the method will error.