### PR TITLE
Add exclude_content_types list messages option

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -2099,6 +2099,26 @@ pub struct FfiListMessagesOptions {
     pub delivery_status: Option<FfiDeliveryStatus>,
     pub direction: Option<FfiDirection>,
     pub content_types: Option<Vec<FfiContentType>>,
+    pub exclude_content_types: Option<Vec<FfiContentType>>,
+}
+
+impl From<FfiListMessagesOptions> for MsgQueryArgs {
+    fn from(opts: FfiListMessagesOptions) -> Self {
+        MsgQueryArgs {
+            kind: None,
+            sent_before_ns: opts.sent_before_ns,
+            sent_after_ns: opts.sent_after_ns,
+            limit: opts.limit,
+            delivery_status: opts.delivery_status.map(Into::into),
+            direction: opts.direction.map(Into::into),
+            content_types: opts
+                .content_types
+                .map(|types| types.into_iter().map(Into::into).collect()),
+            exclude_content_types: opts
+                .exclude_content_types
+                .map(|types| types.into_iter().map(Into::into).collect()),
+        }
+    }
 }
 
 #[derive(uniffi::Enum, Clone)]
@@ -2228,28 +2248,9 @@ impl FfiConversation {
         &self,
         opts: FfiListMessagesOptions,
     ) -> Result<Vec<FfiMessage>, GenericError> {
-        let delivery_status = opts.delivery_status.map(|status| status.into());
-        let direction = opts.direction.map(|dir| dir.into());
-        let kind = match self.conversation_type() {
-            FfiConversationType::Group => None,
-            FfiConversationType::Dm => None,
-            FfiConversationType::Sync => None,
-            FfiConversationType::Oneshot => None,
-        };
-
         let messages: Vec<FfiMessage> = self
             .inner
-            .find_messages(&MsgQueryArgs {
-                sent_before_ns: opts.sent_before_ns,
-                sent_after_ns: opts.sent_after_ns,
-                limit: opts.limit,
-                kind,
-                delivery_status,
-                direction,
-                content_types: opts
-                    .content_types
-                    .map(|types| types.into_iter().map(Into::into).collect()),
-            })?
+            .find_messages(&opts.into())?
             .into_iter()
             .map(|msg| msg.into())
             .collect();
@@ -2258,19 +2259,7 @@ impl FfiConversation {
     }
 
     pub fn count_messages(&self, opts: FfiListMessagesOptions) -> Result<i64, GenericError> {
-        let delivery_status = opts.delivery_status.map(|status| status.into());
-
-        let count = self.inner.count_messages(&MsgQueryArgs {
-            sent_before_ns: opts.sent_before_ns,
-            sent_after_ns: opts.sent_after_ns,
-            kind: None,
-            delivery_status,
-            limit: None,
-            direction: None,
-            content_types: opts
-                .content_types
-                .map(|types| types.into_iter().map(Into::into).collect()),
-        })?;
+        let count = self.inner.count_messages(&opts.into())?;
 
         Ok(count)
     }
@@ -2279,28 +2268,9 @@ impl FfiConversation {
         &self,
         opts: FfiListMessagesOptions,
     ) -> Result<Vec<FfiMessageWithReactions>, GenericError> {
-        let delivery_status = opts.delivery_status.map(|status| status.into());
-        let direction = opts.direction.map(|dir| dir.into());
-        let kind = match self.conversation_type() {
-            FfiConversationType::Group => None,
-            FfiConversationType::Dm => None,
-            FfiConversationType::Sync => None,
-            FfiConversationType::Oneshot => None,
-        };
-
         let messages: Vec<FfiMessageWithReactions> = self
             .inner
-            .find_messages_with_reactions(&MsgQueryArgs {
-                sent_before_ns: opts.sent_before_ns,
-                sent_after_ns: opts.sent_after_ns,
-                kind,
-                delivery_status,
-                limit: opts.limit,
-                direction,
-                content_types: opts
-                    .content_types
-                    .map(|types| types.into_iter().map(Into::into).collect()),
-            })?
+            .find_messages_with_reactions(&opts.into())?
             .into_iter()
             .map(|msg| msg.into())
             .collect();
@@ -2311,28 +2281,9 @@ impl FfiConversation {
         &self,
         opts: FfiListMessagesOptions,
     ) -> Result<Vec<Arc<FfiDecodedMessage>>, GenericError> {
-        let delivery_status = opts.delivery_status.map(|status| status.into());
-        let direction = opts.direction.map(|dir| dir.into());
-        let kind = match self.conversation_type() {
-            FfiConversationType::Group => None,
-            FfiConversationType::Dm => None,
-            FfiConversationType::Sync => None,
-            FfiConversationType::Oneshot => None,
-        };
-
         let messages: Vec<Arc<FfiDecodedMessage>> = self
             .inner
-            .find_messages_v2(&MsgQueryArgs {
-                sent_before_ns: opts.sent_before_ns,
-                sent_after_ns: opts.sent_after_ns,
-                kind,
-                delivery_status,
-                limit: opts.limit,
-                direction,
-                content_types: opts
-                    .content_types
-                    .map(|types| types.into_iter().map(Into::into).collect()),
-            })?
+            .find_messages_v2(&opts.into())?
             .into_iter()
             .map(|msg| Arc::new(msg.into()))
             .collect();

--- a/bindings_node/src/message.rs
+++ b/bindings_node/src/message.rs
@@ -85,6 +85,7 @@ pub struct ListMessagesOptions {
   pub delivery_status: Option<DeliveryStatus>,
   pub direction: Option<SortDirection>,
   pub content_types: Option<Vec<ContentType>>,
+  pub exclude_content_types: Option<Vec<ContentType>>,
   pub kind: Option<GroupMessageKind>,
 }
 
@@ -95,6 +96,9 @@ impl From<ListMessagesOptions> for MsgQueryArgs {
     let content_types = opts
       .content_types
       .map(|types| types.into_iter().map(Into::into).collect());
+    let exclude_content_types = opts
+      .exclude_content_types
+      .map(|types| types.into_iter().map(Into::into).collect());
 
     MsgQueryArgs {
       sent_before_ns: opts.sent_before_ns,
@@ -103,6 +107,7 @@ impl From<ListMessagesOptions> for MsgQueryArgs {
       limit: opts.limit,
       direction,
       content_types,
+      exclude_content_types,
       kind: opts.kind.map(Into::into),
     }
   }

--- a/bindings_wasm/src/messages.rs
+++ b/bindings_wasm/src/messages.rs
@@ -83,6 +83,8 @@ impl From<SortDirection> for XmtpSortDirection {
 pub struct ListMessagesOptions {
   #[wasm_bindgen(js_name = contentTypes)]
   pub content_types: Option<Vec<ContentType>>,
+  #[wasm_bindgen(js_name = excludeContentTypes)]
+  pub exclude_content_types: Option<Vec<ContentType>>,
   #[wasm_bindgen(js_name = sentBeforeNs)]
   pub sent_before_ns: Option<i64>,
   #[wasm_bindgen(js_name = sentAfterNs)]
@@ -103,6 +105,9 @@ impl From<ListMessagesOptions> for MsgQueryArgs {
       limit: opts.limit,
       direction: opts.direction.map(Into::into),
       kind: opts.kind.map(Into::into),
+      exclude_content_types: opts
+        .exclude_content_types
+        .map(|t| t.into_iter().map(Into::into).collect()),
       content_types: opts
         .content_types
         .map(|t| t.into_iter().map(Into::into).collect()),
@@ -112,6 +117,7 @@ impl From<ListMessagesOptions> for MsgQueryArgs {
 
 #[wasm_bindgen]
 impl ListMessagesOptions {
+  #[allow(clippy::too_many_arguments)]
   #[wasm_bindgen(constructor)]
   pub fn new(
     sent_before_ns: Option<i64>,
@@ -120,6 +126,7 @@ impl ListMessagesOptions {
     delivery_status: Option<DeliveryStatus>,
     direction: Option<SortDirection>,
     content_types: Option<Vec<ContentType>>,
+    exclude_content_types: Option<Vec<ContentType>>,
     kind: Option<GroupMessageKind>,
   ) -> Self {
     Self {
@@ -129,6 +136,7 @@ impl ListMessagesOptions {
       delivery_status,
       direction,
       content_types,
+      exclude_content_types,
       kind,
     }
   }

--- a/xmtp_db/src/encrypted_store/group_message.rs
+++ b/xmtp_db/src/encrypted_store/group_message.rs
@@ -287,6 +287,8 @@ pub struct MsgQueryArgs {
     pub direction: Option<SortDirection>,
     #[builder(default = None)]
     pub content_types: Option<Vec<ContentType>>,
+    #[builder(default = None)]
+    pub exclude_content_types: Option<Vec<ContentType>>,
 }
 
 impl MsgQueryArgs {
@@ -595,6 +597,10 @@ macro_rules! apply_message_filters {
 
         if let Some(content_types) = &$args.content_types {
             query = query.filter(dsl::content_type.eq_any(content_types));
+        }
+
+        if let Some(exclude_content_types) = &$args.exclude_content_types {
+            query = query.filter(dsl::content_type.ne_all(exclude_content_types));
         }
 
         query

--- a/xmtp_db/src/encrypted_store/group_message/tests.rs
+++ b/xmtp_db/src/encrypted_store/group_message/tests.rs
@@ -46,6 +46,78 @@ async fn it_does_not_error_on_empty_messages() {
 }
 
 #[xmtp_common::test]
+async fn test_exclude_content_types_filter() {
+    with_connection(|conn| {
+        let group = generate_group(None);
+        group.store(conn).unwrap();
+
+        // Create messages with different content types
+        let messages = vec![
+            generate_message(
+                None,
+                Some(&group.id),
+                Some(1_000),
+                Some(ContentType::Text),
+                None,
+                None,
+            ),
+            generate_message(
+                None,
+                Some(&group.id),
+                Some(2_000),
+                Some(ContentType::Text),
+                None,
+                None,
+            ),
+            generate_message(
+                None,
+                Some(&group.id),
+                Some(3_000),
+                Some(ContentType::Reaction),
+                None,
+                None,
+            ),
+            generate_message(
+                None,
+                Some(&group.id),
+                Some(4_000),
+                Some(ContentType::ReadReceipt),
+                None,
+                None,
+            ),
+            generate_message(
+                None,
+                Some(&group.id),
+                Some(5_000),
+                Some(ContentType::Attachment),
+                None,
+                None,
+            ),
+        ];
+        assert_ok!(messages.store(conn));
+
+        // Test excluding reactions and read receipts
+        let exclude_args = MsgQueryArgs {
+            exclude_content_types: Some(vec![ContentType::Reaction, ContentType::ReadReceipt]),
+            ..Default::default()
+        };
+
+        let filtered_messages = conn.get_group_messages(&group.id, &exclude_args).unwrap();
+        assert_eq!(filtered_messages.len(), 3); // 2 Text + 1 Attachment
+        assert!(
+            filtered_messages
+                .iter()
+                .all(|m| m.content_type != ContentType::Reaction
+                    && m.content_type != ContentType::ReadReceipt)
+        );
+
+        let count = conn.count_group_messages(&group.id, &exclude_args).unwrap();
+        assert_eq!(count, 3);
+    })
+    .await
+}
+
+#[xmtp_common::test]
 async fn it_gets_messages() {
     with_connection(|conn| {
         let group = generate_group(None);

--- a/xmtp_mls/src/groups/message_list.rs
+++ b/xmtp_mls/src/groups/message_list.rs
@@ -27,18 +27,9 @@ where
 
 fn filter_out_hidden_message_types_from_query(query: &MsgQueryArgs) -> MsgQueryArgs {
     let mut new_query = query.clone();
-    // Get the list of all content types, or use the provided one
-    let mut content_types = match new_query.content_types {
-        Some(types) => types,
-        None => DbContentType::all(),
-    };
+    let hidden_message_types = vec![DbContentType::Reaction, DbContentType::ReadReceipt];
 
-    let hidden_message_types = [DbContentType::Reaction, DbContentType::ReadReceipt];
-
-    // Remove reaction content types
-    content_types.retain(|ct| !hidden_message_types.contains(ct));
-
-    new_query.content_types = Some(content_types);
+    new_query.exclude_content_types = Some(hidden_message_types);
     new_query
 }
 
@@ -631,60 +622,5 @@ mod tests {
         } else {
             panic!("Expected reply message");
         }
-    }
-
-    #[test]
-    fn test_filter_out_hidden_message_types_from_query() {
-        // Test with no content_types specified (should use all types minus hidden)
-        let query = MsgQueryArgs::default();
-        let filtered = filter_out_hidden_message_types_from_query(&query);
-
-        assert!(filtered.content_types.is_some());
-        let types = filtered.content_types.unwrap();
-        assert!(!types.contains(&DbContentType::Reaction));
-        assert!(!types.contains(&DbContentType::ReadReceipt));
-        assert!(types.contains(&DbContentType::Text));
-        assert!(types.contains(&DbContentType::Attachment));
-        assert!(types.contains(&DbContentType::Reply));
-
-        // Test with specific content_types including hidden ones
-        let query_with_types = MsgQueryArgs::builder()
-            .content_types(Some(vec![
-                DbContentType::Text,
-                DbContentType::Reaction,
-                DbContentType::Attachment,
-                DbContentType::ReadReceipt,
-                DbContentType::Reply,
-            ]))
-            .build()
-            .unwrap();
-        let filtered = filter_out_hidden_message_types_from_query(&query_with_types);
-
-        assert!(filtered.content_types.is_some());
-        let types = filtered.content_types.unwrap();
-        assert_eq!(types.len(), 3);
-        assert!(types.contains(&DbContentType::Text));
-        assert!(types.contains(&DbContentType::Attachment));
-        assert!(types.contains(&DbContentType::Reply));
-        assert!(!types.contains(&DbContentType::Reaction));
-        assert!(!types.contains(&DbContentType::ReadReceipt));
-
-        // Test with only non-hidden types (should remain unchanged)
-        let query_no_hidden = MsgQueryArgs::builder()
-            .content_types(Some(vec![
-                DbContentType::Text,
-                DbContentType::Attachment,
-                DbContentType::RemoteAttachment,
-            ]))
-            .build()
-            .unwrap();
-        let filtered = filter_out_hidden_message_types_from_query(&query_no_hidden);
-
-        assert!(filtered.content_types.is_some());
-        let types = filtered.content_types.unwrap();
-        assert_eq!(types.len(), 3);
-        assert!(types.contains(&DbContentType::Text));
-        assert!(types.contains(&DbContentType::Attachment));
-        assert!(types.contains(&DbContentType::RemoteAttachment));
     }
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add excludeContentTypes filtering to message listing across FFI, Node, WASM bindings and database query layer to support excluding specific content types

This change introduces an `exclude_content_types` option to message listing APIs across FFI, Node, and WASM bindings, wires the option through conversions into `MsgQueryArgs`, and applies a corresponding exclusion filter at the database layer. It also updates message query construction to use `From<FfiListMessagesOptions>` and adjusts internal filtering to use exclusions instead of inclusion lists for hidden types.

- Add `exclude_content_types` to `FfiListMessagesOptions` and convert it into `MsgQueryArgs`, updating `FfiConversation` query methods to use `opts.into()` in [mls.rs](https://github.com/xmtp/libxmtp/pull/2566/files#diff-3a24c3e76565487a710ac9863ac05160128f4f90892e07849b555a6de43a6e8f)
- Add `exclude_content_types` to Node `ListMessagesOptions` and map to `MsgQueryArgs.exclude_content_types` in [message.rs](https://github.com/xmtp/libxmtp/pull/2566/files#diff-d24e9207b4d19821d0848c0e599148cb9923d62786d4ee2084507e99a66b3706)
- Add `exclude_content_types` to WASM `ListMessagesOptions`, expose as `excludeContentTypes`, include constructor parameter, and map to `MsgQueryArgs` in [messages.rs](https://github.com/xmtp/libxmtp/pull/2566/files#diff-656f175128bb72479c5c70b869912be3f5c66d56f2f3f1c2e4fad5febe22a85f)
- Extend `MsgQueryArgs` with optional `exclude_content_types` and apply `dsl::content_type.ne_all(...)` filtering in the `apply_message_filters` macro in [group_message.rs](https://github.com/xmtp/libxmtp/pull/2566/files#diff-f81cb97873c6ce33f85646f59ec1ea72f8574b06550596ec29a4ac58c2353373)
- Add database test `test_exclude_content_types_filter` validating exclusion behavior in [group_message/tests.rs](https://github.com/xmtp/libxmtp/pull/2566/files#diff-95173998137eab23659b05e775352bbe1c88466c6ca984420fdcb8e0269cb0c4)
- Update hidden message filtering to set `exclude_content_types` for `Reaction` and `ReadReceipt` in [message_list.rs](https://github.com/xmtp/libxmtp/pull/2566/files#diff-221be37215efcd747a9027eb9b80fd68f4362bf12f87d92219cf09b02d87c468)

#### 📍Where to Start

Start with the `apply_message_filters` macro and `MsgQueryArgs` changes in [group_message.rs](https://github.com/xmtp/libxmtp/pull/2566/files#diff-f81cb97873c6ce33f85646f59ec1ea72f8574b06550596ec29a4ac58c2353373), then follow the `exclude_content_types` propagation from bindings via the `From<FfiListMessagesOptions>` conversion in [mls.rs](https://github.com/xmtp/libxmtp/pull/2566/files#diff-3a24c3e76565487a710ac9863ac05160128f4f90892e07849b555a6de43a6e8f).

---


<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 3f895bf. 4 files reviewed, 3 issues evaluated, 3 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>bindings_node/src/message.rs — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 99](https://github.com/xmtp/libxmtp/blob/3f895bfc750fcaec1f0e3aea4c870f3ed340a608/bindings_node/src/message.rs#L99): No deduplication or validation of `exclude_content_types` is performed before building and applying query filters. Passing a vector with duplicate `ContentType` values results in redundant SQL conditions (`<>` against the same value multiple times) and potentially larger bind payloads, which degrade performance and can increase the chance of hitting parameter limits in some databases. While semantics remain the same, a simple normalization (e.g., converting to a `HashSet` then back to a `Vec`) would enforce uniqueness and reduce unnecessary work. This matters at runtime for large or user-supplied lists. <b>[ Code style ]</b>
</details>

<details>
<summary>xmtp_db/src/encrypted_store/group_message.rs — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 602](https://github.com/xmtp/libxmtp/blob/3f895bfc750fcaec1f0e3aea4c870f3ed340a608/xmtp_db/src/encrypted_store/group_message.rs#L602): Using `dsl::content_type.ne_all(exclude_content_types)` in the query filter may produce backend-specific SQL that is unsupported on certain databases (e.g., SQLite). Diesel's `ne_all` corresponds to the SQL `<> ALL (...)` operator, which is not supported by SQLite and some other backends. If this project (file `xmtp_db/src/encrypted_store/group_message.rs`) targets SQLite (as the path name strongly suggests), this will lead to a runtime SQL error when executing the query against SQLite. To ensure cross-backend compatibility, prefer generating a `NOT IN (...)` style condition (e.g., via `diesel::dsl::not(eq_any(...))` or building an `AND` chain of `content_type.ne(...)` comparisons) instead of `ne_all`. <b>[ Low confidence ]</b>
</details>

<details>
<summary>xmtp_mls/src/groups/message_list.rs — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 32](https://github.com/xmtp/libxmtp/blob/3f895bfc750fcaec1f0e3aea4c870f3ed340a608/xmtp_mls/src/groups/message_list.rs#L32): Behavioral contract change: `filter_out_hidden_message_types_from_query` previously normalized the query by setting `content_types` to the known non-hidden types (derived from `DbContentType::all()` and retaining only non-hidden ones). After the change, it instead sets `exclude_content_types` to the hidden types and leaves `content_types` unchanged (potentially `None`). This alters the selection semantics for unknown or newly introduced content types. Previously, only the explicitly enumerated non-hidden (known) types were returned; unknown/unregistered types would be excluded because they were not in the allowed list. Now, any content type not in the hidden list will pass (including unknown/new types). This is a contract parity break that can cause previously unseen/unsupported content types to be returned to callers, potentially exposing messages that should have been filtered until recognized. If this widening of results is intentional, it should be explicitly documented and coordinated across consumers; otherwise, it is a runtime behavioral bug. <b>[ Invalidated by documentation search ]</b>
</details>


</details>
<!-- MACROSCOPE_FOOTER_END -->\
<!-- Macroscope's pull request summary ends here -->