### PR TITLE
Set the minimum protocol version as part of readd intent

### DIFF
--- a/xmtp_configuration/src/common/mls.rs
+++ b/xmtp_configuration/src/common/mls.rs
@@ -38,3 +38,6 @@ pub const CREATE_PQ_KEY_PACKAGE_EXTENSION: bool = true;
 // and it does not have a policy set, it is a super admin only field
 pub const SUPER_ADMIN_METADATA_PREFIX: &str = "_";
 pub const HMAC_SALT: &[u8] = b"libXMTP HKDF salt!";
+
+pub const ENABLE_COMMIT_LOG: bool = true;
+pub const MIN_RECOVERY_REQUEST_VERSION: &str = "1.6.1";

--- a/xmtp_configuration/src/prod/mls.rs
+++ b/xmtp_configuration/src/prod/mls.rs
@@ -4,5 +4,4 @@ pub const SYNC_UPDATE_INSTALLATIONS_INTERVAL_NS: i64 = NS_IN_HOUR / 2; // 30 min
 
 pub const KEYS_EXPIRATION_INTERVAL_NS: i64 = NS_IN_DAY; // 1 day
 
-pub const ENABLE_COMMIT_LOG: bool = true;
 pub const ENABLE_RECOVERY_REQUESTS: bool = false;

--- a/xmtp_configuration/src/test/mls.rs
+++ b/xmtp_configuration/src/test/mls.rs
@@ -6,5 +6,4 @@ pub const SYNC_UPDATE_INSTALLATIONS_INTERVAL_NS: i64 = NS_IN_SEC; // 1 Second
 
 pub const KEYS_EXPIRATION_INTERVAL_NS: i64 = 3 * NS_IN_SEC; //3 seconds
 
-pub const ENABLE_COMMIT_LOG: bool = true;
 pub const ENABLE_RECOVERY_REQUESTS: bool = true;

--- a/xmtp_mls/src/groups/tests/mod.rs
+++ b/xmtp_mls/src/groups/tests/mod.rs
@@ -5,6 +5,7 @@ mod test_commit_log_remote;
 mod test_consent;
 mod test_dm;
 mod test_key_updates;
+mod test_libxmtp_version;
 #[cfg(not(target_arch = "wasm32"))]
 mod test_network;
 mod test_send_message_opts;

--- a/xmtp_mls/src/groups/tests/test_libxmtp_version.rs
+++ b/xmtp_mls/src/groups/tests/test_libxmtp_version.rs
@@ -1,0 +1,116 @@
+use crate::groups::validated_commit::{CommitValidationError, LibXMTPVersion};
+
+#[test]
+fn test_parse_and_compare_basic_versions() {
+    let v1_0_0 = LibXMTPVersion::parse("1.0.0").unwrap();
+    let v1_0_1 = LibXMTPVersion::parse("1.0.1").unwrap();
+    let v1_1_0 = LibXMTPVersion::parse("1.1.0").unwrap();
+    let v2_0_0 = LibXMTPVersion::parse("2.0.0").unwrap();
+
+    // Test patch version comparison
+    assert!(v1_0_0 < v1_0_1);
+    assert!(v1_0_1 > v1_0_0);
+
+    // Test minor version comparison
+    assert!(v1_0_1 < v1_1_0);
+    assert!(v1_1_0 > v1_0_1);
+
+    // Test major version comparison
+    assert!(v1_1_0 < v2_0_0);
+    assert!(v2_0_0 > v1_1_0);
+
+    // Test equality
+    let v1_0_0_dup = LibXMTPVersion::parse("1.0.0").unwrap();
+    assert_eq!(v1_0_0, v1_0_0_dup);
+}
+
+#[test]
+fn test_parse_and_compare_with_suffixes() {
+    let v1_0_0 = LibXMTPVersion::parse("1.0.0").unwrap();
+    let v1_0_0_alpha = LibXMTPVersion::parse("1.0.0-alpha").unwrap();
+    let v1_0_0_beta = LibXMTPVersion::parse("1.0.0-beta").unwrap();
+    let v1_0_0_rc1 = LibXMTPVersion::parse("1.0.0-rc1").unwrap();
+    let v1_0_1_alpha = LibXMTPVersion::parse("1.0.1-alpha").unwrap();
+
+    // Versions with suffixes compare lexicographically by suffix after version parts
+    assert!(v1_0_0_alpha < v1_0_0_beta);
+    assert!(v1_0_0_beta < v1_0_0_rc1);
+
+    // Version without suffix (None) is less than version with suffix (Some)
+    // because None < Some in Rust's default Ord implementation
+    // NOTE: this does not match semver comparison
+    assert!(v1_0_0 < v1_0_0_alpha);
+    assert!(v1_0_0 < v1_0_0_beta);
+
+    // Numeric parts take precedence over suffix
+    assert!(v1_0_0 < v1_0_1_alpha);
+    assert!(v1_0_0_rc1 < v1_0_1_alpha);
+}
+
+#[test]
+fn test_parse_and_compare_zero_versions() {
+    let v0_0_0 = LibXMTPVersion::parse("0.0.0").unwrap();
+    let v0_0_1 = LibXMTPVersion::parse("0.0.1").unwrap();
+    let v0_1_0 = LibXMTPVersion::parse("0.1.0").unwrap();
+    let v1_0_0 = LibXMTPVersion::parse("1.0.0").unwrap();
+
+    assert!(v0_0_0 < v0_0_1);
+    assert!(v0_0_1 < v0_1_0);
+    assert!(v0_1_0 < v1_0_0);
+}
+
+#[test]
+fn test_parse_and_compare_complex_suffixes() {
+    let v1_2_3_alpha1 = LibXMTPVersion::parse("1.2.3-alpha1").unwrap();
+    let v1_2_3_alpha2 = LibXMTPVersion::parse("1.2.3-alpha2").unwrap();
+    let v1_2_3_beta = LibXMTPVersion::parse("1.2.3-beta").unwrap();
+    let v1_2_3_dev = LibXMTPVersion::parse("1.2.3-dev").unwrap();
+    let v1_2_3_snapshot = LibXMTPVersion::parse("1.2.3-snapshot").unwrap();
+
+    // Lexicographic ordering of suffixes
+    assert!(v1_2_3_alpha1 < v1_2_3_alpha2);
+    assert!(v1_2_3_alpha2 < v1_2_3_beta);
+    assert!(v1_2_3_beta < v1_2_3_dev);
+    assert!(v1_2_3_dev < v1_2_3_snapshot);
+}
+
+#[test]
+fn test_parse_invalid_format() {
+    let result = LibXMTPVersion::parse("1.0");
+    assert!(matches!(
+        result,
+        Err(CommitValidationError::InvalidVersionFormat(_))
+    ));
+    let result = LibXMTPVersion::parse("1.0.0.0");
+    assert!(matches!(
+        result,
+        Err(CommitValidationError::InvalidVersionFormat(_))
+    ));
+    let result = LibXMTPVersion::parse("1.x.0");
+    assert!(matches!(
+        result,
+        Err(CommitValidationError::InvalidVersionFormat(_))
+    ));
+
+    let result = LibXMTPVersion::parse("a.b.c");
+    assert!(matches!(
+        result,
+        Err(CommitValidationError::InvalidVersionFormat(_))
+    ));
+    let result = LibXMTPVersion::parse("1..0");
+    assert!(matches!(
+        result,
+        Err(CommitValidationError::InvalidVersionFormat(_))
+    ));
+    let result = LibXMTPVersion::parse("");
+    assert!(matches!(
+        result,
+        Err(CommitValidationError::InvalidVersionFormat(_))
+    ));
+}
+
+#[test]
+fn test_parse_suffix_only() {
+    let result = LibXMTPVersion::parse("1.0.0-");
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
This PR sets the 'group min version' before performing a readd commit.
This pauses the group for older libxmtp versions until they have upgraded. This is necessary because we need to update the commit validation logic for readd commits (implemented in the next PR). If we do not set the minimum version of the group before doing this, older libxmtp versions will be forked relative to newer libxmtp versions when they receive a readd commit.

I also noticed that the existing logic for comparing libxmtp versions does not match semver comparison. I don't think this is necessarily a bad thing, but I added unit tests and some documentation to make sure it doesn't trip anybody up.

Note that both this PR and the previous PR are safe to land individually, because the `readd_installations()` method is not currently being called in production. 

**It is important that the remaining PR's in this stack are shipped in libxmtp 1.6. If this feature is moved to a later release than 1.6, the version flag here must be updated.**