### PR TITLE
Expose fork recovery configuration to SDK's

### DIFF
--- a/bindings_ffi/benches/create_client.rs
+++ b/bindings_ffi/benches/create_client.rs
@@ -74,6 +74,7 @@ fn create_ffi_client(c: &mut Criterion) {
                     None,
                     None,
                     None,
+                    None,
                 )
                 .instrument(span)
                 .await
@@ -115,6 +116,7 @@ fn cached_create_ffi_client(c: &mut Criterion) {
             None,
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -148,6 +150,7 @@ fn cached_create_ffi_client(c: &mut Criterion) {
                     nonce,
                     None,
                     Some(history_sync),
+                    None,
                     None,
                     None,
                     None,

--- a/bindings_ffi/src/fork_recovery.rs
+++ b/bindings_ffi/src/fork_recovery.rs
@@ -1,0 +1,48 @@
+use xmtp_mls::builder::{ForkRecoveryOpts, ForkRecoveryPolicy};
+
+#[derive(uniffi::Enum, Debug)]
+pub enum FfiForkRecoveryPolicy {
+    None,
+    AllowlistedGroups,
+    All,
+}
+
+impl From<FfiForkRecoveryPolicy> for ForkRecoveryPolicy {
+    fn from(policy: FfiForkRecoveryPolicy) -> Self {
+        match policy {
+            FfiForkRecoveryPolicy::None => ForkRecoveryPolicy::None,
+            FfiForkRecoveryPolicy::AllowlistedGroups => ForkRecoveryPolicy::AllowlistedGroups,
+            FfiForkRecoveryPolicy::All => ForkRecoveryPolicy::All,
+        }
+    }
+}
+
+// Please see docs for more information.
+#[derive(uniffi::Record, Debug)]
+pub struct FfiForkRecoveryOpts {
+    // These two params are used to roll out the fork recovery feature.
+    pub enable_recovery_requests: FfiForkRecoveryPolicy,
+    pub groups_to_request_recovery: Vec<String>,
+    // Emergency switch to disable fork recovery responses (do not set in normal operation)
+    pub disable_recovery_responses: Option<bool>,
+    // Interval at which to run the fork recovery worker (do not set in normal operation)
+    // After a 'bad' commit is made, fork recovery can be expected to take up to 4x this interval
+    // to complete end-to-end, assuming both the super admin and forked installation are online
+    // and streaming welcomes.
+    // This can be overriden for end-to-end/manual testing purposes.
+    // If the interval duration is less than the time it takes for a single tick of the worker to
+    // complete, the worker will wait for the first tick to complete before the next tick begins.
+    // Worth considering if any strange behavior is observed with low intervals.
+    pub worker_interval_ns: Option<u64>,
+}
+
+impl From<FfiForkRecoveryOpts> for ForkRecoveryOpts {
+    fn from(opts: FfiForkRecoveryOpts) -> Self {
+        Self {
+            enable_recovery_requests: opts.enable_recovery_requests.into(),
+            groups_to_request_recovery: opts.groups_to_request_recovery,
+            disable_recovery_responses: opts.disable_recovery_responses.unwrap_or(false),
+            worker_interval_ns: opts.worker_interval_ns,
+        }
+    }
+}

--- a/bindings_ffi/src/lib.rs
+++ b/bindings_ffi/src/lib.rs
@@ -1,6 +1,7 @@
 #![recursion_limit = "256"]
 #![warn(clippy::unwrap_used)]
 pub mod crypto;
+pub mod fork_recovery;
 pub mod identity;
 pub mod inbox_owner;
 pub mod logger;

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -1,3 +1,4 @@
+use crate::fork_recovery::FfiForkRecoveryOpts;
 use crate::identity::{FfiCollectionExt, FfiCollectionTryExt, FfiIdentifier};
 pub use crate::inbox_owner::SigningError;
 use crate::logger::init_logger;
@@ -264,6 +265,7 @@ pub async fn create_client(
     device_sync_mode: Option<FfiSyncWorkerMode>,
     allow_offline: Option<bool>,
     disable_events: Option<bool>,
+    fork_recovery_opts: Option<FfiForkRecoveryOpts>,
 ) -> Result<Arc<FfiXmtpClient>, GenericError> {
     let ident = account_identifier.clone();
     init_logger();
@@ -315,6 +317,10 @@ pub async fn create_client(
 
     if let Some(sync_worker_mode) = device_sync_mode {
         builder = builder.device_sync_worker_mode(sync_worker_mode.into());
+    }
+
+    if let Some(fork_recovery_opts) = fork_recovery_opts {
+        builder = builder.fork_recovery_opts(fork_recovery_opts.into());
     }
 
     if let Some(url) = &device_sync_server_url {
@@ -3455,6 +3461,7 @@ mod tests {
             sync_worker_mode,
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -3486,6 +3493,7 @@ mod tests {
             nonce,
             None,
             sync_server_url,
+            None,
             None,
             None,
             None,
@@ -3553,6 +3561,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -3582,6 +3591,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -3598,6 +3608,7 @@ mod tests {
             &inbox_id,
             ffi_inbox_owner.identifier(),
             nonce,
+            None,
             None,
             None,
             None,
@@ -3640,6 +3651,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -3657,6 +3669,7 @@ mod tests {
             &inbox_id,
             ffi_inbox_owner.identifier(),
             nonce,
+            None,
             None,
             None,
             None,
@@ -3710,6 +3723,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -3750,6 +3764,7 @@ mod tests {
             None,
             None,
             Some(true),
+            None,
             None,
         )
         .await
@@ -3921,6 +3936,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -4039,6 +4055,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -4133,6 +4150,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -4161,6 +4179,7 @@ mod tests {
             &amal_inbox_id,
             amal.identifier(),
             nonce,
+            None,
             None,
             None,
             None,
@@ -4203,6 +4222,7 @@ mod tests {
             &bola_inbox_id,
             bola.identifier(),
             nonce,
+            None,
             None,
             None,
             None,
@@ -7883,6 +7903,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -7921,6 +7942,7 @@ mod tests {
             nonce,
             None,
             Some(HISTORY_SYNC_URL.to_string()),
+            None,
             None,
             None,
             None,
@@ -8009,6 +8031,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .await;
 
@@ -8046,6 +8069,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -8070,6 +8094,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -8088,6 +8113,7 @@ mod tests {
             1,
             None,
             Some(HISTORY_SYNC_URL.to_string()),
+            None,
             None,
             None,
             None,
@@ -8120,6 +8146,7 @@ mod tests {
             1,
             None,
             Some(HISTORY_SYNC_URL.to_string()),
+            None,
             None,
             None,
             None,
@@ -9771,6 +9798,7 @@ mod tests {
             &inbox_id,
             ffi_inbox_owner.identifier(),
             nonce,
+            None,
             None,
             None,
             None,

--- a/bindings_ffi/src/mls/test_utils.rs
+++ b/bindings_ffi/src/mls/test_utils.rs
@@ -182,6 +182,7 @@ where
         Some(builder.sync_mode.into()),
         None,
         None,
+        None,
     )
     .await
     .unwrap();

--- a/common/src/hex.rs
+++ b/common/src/hex.rs
@@ -1,0 +1,52 @@
+pub trait NormalizeHex {
+    fn normalize_hex(&self) -> String;
+}
+
+impl NormalizeHex for str {
+    fn normalize_hex(&self) -> String {
+        let lower = self.to_lowercase();
+        lower.strip_prefix("0x").unwrap_or(&lower).to_string()
+    }
+}
+
+impl NormalizeHex for String {
+    fn normalize_hex(&self) -> String {
+        self.as_str().normalize_hex()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_hex_str_with_mixed_case_prefix() {
+        assert_eq!("0xABCDEF".normalize_hex(), "abcdef");
+        assert_eq!("0XAbCdEf".normalize_hex(), "abcdef");
+        assert_eq!("0xAbC123".normalize_hex(), "abc123");
+    }
+
+    #[test]
+    fn test_normalize_hex_str_without_prefix() {
+        assert_eq!("abcdef".normalize_hex(), "abcdef");
+        assert_eq!("123456".normalize_hex(), "123456");
+        assert_eq!("ABCDEF".normalize_hex(), "abcdef");
+        assert_eq!("AbCdEf".normalize_hex(), "abcdef");
+    }
+
+    #[test]
+    fn test_normalize_hex_str_already_normalized() {
+        assert_eq!("abcdef123456".normalize_hex(), "abcdef123456");
+        assert_eq!("0".normalize_hex(), "0");
+        assert_eq!("ff".normalize_hex(), "ff");
+    }
+
+    #[test]
+    fn test_normalize_hex_str_edge_cases() {
+        assert_eq!("".normalize_hex(), "");
+        assert_eq!("0x".normalize_hex(), "");
+        assert_eq!("0X".normalize_hex(), "");
+        assert_eq!("x".normalize_hex(), "x");
+        assert_eq!("0".normalize_hex(), "0");
+    }
+}

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -24,6 +24,7 @@ pub mod stream_handles;
 pub use stream_handles::*;
 
 pub mod fmt;
+pub mod hex;
 pub mod snippet;
 pub mod time;
 pub mod types;

--- a/xmtp_configuration/src/prod/mls.rs
+++ b/xmtp_configuration/src/prod/mls.rs
@@ -3,6 +3,3 @@ use xmtp_common::{NS_IN_DAY, NS_IN_HOUR};
 pub const SYNC_UPDATE_INSTALLATIONS_INTERVAL_NS: i64 = NS_IN_HOUR / 2; // 30 min
 
 pub const KEYS_EXPIRATION_INTERVAL_NS: i64 = NS_IN_DAY; // 1 day
-
-pub const ENABLE_RECOVERY_REQUESTS: bool = false;
-pub const ENABLE_RECOVERY_RESPONSES: bool = false;

--- a/xmtp_configuration/src/test/mls.rs
+++ b/xmtp_configuration/src/test/mls.rs
@@ -5,6 +5,3 @@ use xmtp_common::NS_IN_SEC;
 pub const SYNC_UPDATE_INSTALLATIONS_INTERVAL_NS: i64 = NS_IN_SEC; // 1 Second
 
 pub const KEYS_EXPIRATION_INTERVAL_NS: i64 = 3 * NS_IN_SEC; //3 seconds
-
-pub const ENABLE_RECOVERY_REQUESTS: bool = true;
-pub const ENABLE_RECOVERY_RESPONSES: bool = true;

--- a/xmtp_mls/src/groups/tests/test_commit_log_readd_requests.rs
+++ b/xmtp_mls/src/groups/tests/test_commit_log_readd_requests.rs
@@ -1,4 +1,5 @@
 use crate::{
+    context::XmtpSharedContext,
     groups::{UpdateAdminListType, commit_log::CommitLogWorker},
     tester,
 };
@@ -6,7 +7,7 @@ use xmtp_db::{consent_record::ConsentState, group::QueryGroup, prelude::QueryRea
 
 #[xmtp_common::test]
 async fn test_request_readd() {
-    tester!(alix);
+    tester!(alix, enable_fork_recovery_requests);
     tester!(bo);
     tester!(caro);
     let group = alix
@@ -100,7 +101,7 @@ async fn test_request_readd() {
 
 #[xmtp_common::test]
 async fn test_request_readd_dm() {
-    tester!(alix);
+    tester!(alix, enable_fork_recovery_requests);
     tester!(bo);
     let dm = alix
         .find_or_create_dm_by_inbox_id(bo.inbox_id().to_string(), None)
@@ -206,7 +207,7 @@ async fn test_readd_installation_succeeds() {
 
 #[xmtp_common::test]
 async fn test_readd_bookkeeping() {
-    tester!(alix);
+    tester!(alix, enable_fork_recovery_requests);
     tester!(bo);
     tester!(caro);
     tester!(devon);
@@ -324,6 +325,93 @@ async fn test_readd_bookkeeping() {
     assert!(
         !a_conn
             .is_awaiting_readd(&group.group_id, alix.context.installation_id().as_slice(),)
+            .unwrap()
+    );
+}
+
+#[xmtp_common::test]
+async fn test_request_readd_with_allowlisted_groups() {
+    // Step 1: Bo creates a group
+    tester!(bo);
+    tester!(caro);
+
+    let group = bo
+        .create_group_with_inbox_ids(&[caro.inbox_id()], None, None)
+        .await
+        .unwrap();
+
+    let group_id = group.group_id.clone();
+    let group_id_hex = hex::encode(&group_id);
+    let unnormalized_group_id = "0x".to_owned() + &group_id_hex.to_uppercase();
+
+    // Step 2: Create Alix with that group ID in the allowlist
+    tester!(alix, enable_fork_recovery_requests_for: vec![unnormalized_group_id]);
+
+    // Step 3: Bo adds Alix to the group
+    group
+        .add_members_by_inbox_id(&[alix.inbox_id().to_string()])
+        .await
+        .unwrap();
+
+    alix.sync_all_welcomes_and_groups(None).await.unwrap();
+    caro.sync_all_welcomes_and_groups(None).await.unwrap();
+
+    // Fork detection and recovery does not operate on non-consented groups
+    let a_group = alix.group(&group_id).unwrap();
+    a_group.update_consent_state(ConsentState::Allowed).unwrap();
+    let c_group = caro.group(&group_id).unwrap();
+    c_group.update_consent_state(ConsentState::Allowed).unwrap();
+
+    // Upload remote commit log on Bo's end
+    let mut b_worker = CommitLogWorker::new(bo.context.clone());
+    b_worker._tick().await.unwrap();
+    // Download remote commit log on Alix's end - we need the latest remote commit sequence ID for readd request to be sent
+    let mut a_worker = CommitLogWorker::new(alix.context.clone());
+    a_worker._tick().await.unwrap();
+
+    let a_conn = alix.context.db();
+    let b_conn = bo.context.db();
+    let c_conn = caro.context.db();
+
+    // Simulate a fork
+    a_conn
+        .set_group_commit_log_forked_status(&group_id, Some(true))
+        .unwrap();
+
+    // No readd requests yet
+    assert!(
+        !a_conn
+            .is_awaiting_readd(&group_id, alix.context.installation_id().as_slice(),)
+            .unwrap()
+    );
+    assert!(
+        !b_conn
+            .is_awaiting_readd(&group_id, alix.context.installation_id().as_slice(),)
+            .unwrap()
+    );
+
+    // Should trigger readd requests to be sent for this allowlisted group
+    a_worker._tick().await.unwrap();
+    // Receive any oneshot messages
+    bo.sync_welcomes().await.unwrap();
+    caro.sync_welcomes().await.unwrap();
+
+    // Alix should have recorded a readd request since the group is allowlisted
+    assert!(
+        a_conn
+            .is_awaiting_readd(&group_id, alix.context.installation_id().as_slice(),)
+            .unwrap()
+    );
+    // Bo is a superadmin so should have recorded the request
+    assert!(
+        b_conn
+            .is_awaiting_readd(&group_id, alix.context.installation_id().as_slice(),)
+            .unwrap()
+    );
+    // Caro is not a superadmin so should not have received the request
+    assert!(
+        !c_conn
+            .is_awaiting_readd(&group_id, alix.context.installation_id().as_slice(),)
             .unwrap()
     );
 }

--- a/xmtp_mls/src/groups/tests/test_welcomes.rs
+++ b/xmtp_mls/src/groups/tests/test_welcomes.rs
@@ -68,6 +68,7 @@ async fn test_spoofed_inbox_id() {
         worker_events: alix.context.worker_events.clone(),
         scw_verifier: alix.context.scw_verifier.clone(),
         device_sync: alix.context.device_sync.clone(),
+        fork_recovery_opts: alix.context.fork_recovery_opts.clone(),
         workers: alix.context.workers.clone(),
     });
     let group = MlsGroup::create_and_insert(

--- a/xmtp_mls/src/test/mock.rs
+++ b/xmtp_mls/src/test/mock.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
+use crate::builder::ForkRecoveryOpts;
 use crate::context::XmtpSharedContext;
 use crate::groups::MlsGroup;
 use crate::groups::summary::SyncSummary;
@@ -83,6 +84,7 @@ impl Clone for NewMockContext {
             worker_events: self.worker_events.clone(),
             scw_verifier: self.scw_verifier.clone(),
             device_sync: self.device_sync.clone(),
+            fork_recovery_opts: self.fork_recovery_opts.clone(),
             workers: self.workers.clone(),
         }
     }
@@ -114,6 +116,10 @@ impl XmtpSharedContext for NewMockContext {
 
     fn device_sync(&self) -> &DeviceSync {
         &self.device_sync
+    }
+
+    fn fork_recovery_opts(&self) -> &ForkRecoveryOpts {
+        &self.fork_recovery_opts
     }
 
     fn mls_storage(&self) -> &Self::MlsStorage {

--- a/xmtp_mls/src/test/mock/generate.rs
+++ b/xmtp_mls/src/test/mock/generate.rs
@@ -30,6 +30,7 @@ pub fn context() -> NewMockContext {
             server_url: None,
             mode: SyncWorkerMode::Disabled,
         },
+        fork_recovery_opts: Default::default(),
         workers: WorkerRunner::new(),
         mls_storage: SqlKeyStore::new(MemoryStorage::new()),
         sync_api_client: ApiClientWrapper::new(MockApiClient::new(), Default::default()),


### PR DESCRIPTION
This PR adds SDK configuration flags for the fork recovery feature. The flags are described inline as well as in the notion doc.