### PR TITLE
Add creation signature kind to more methods

### DIFF
--- a/xmtp_mls/src/identity_updates.rs
+++ b/xmtp_mls/src/identity_updates.rs
@@ -3,6 +3,7 @@ use crate::{
     client::ClientError,
     context::XmtpSharedContext,
     groups::group_membership::{GroupMembership, MembershipDiff},
+    identity::IdentityError,
     subscriptions::SyncWorkerEvent,
 };
 use futures::future::try_join_all;
@@ -660,6 +661,25 @@ where
     ))?;
 
     Ok(association_state.get(identifier).is_some())
+}
+
+#[tracing::instrument(level = "trace", skip_all)]
+pub async fn get_creation_signature_kind(
+    conn: &impl xmtp_db::DbQuery,
+    scw_verifier: impl SmartContractSignatureVerifier,
+    inbox_id: InboxIdRef<'_>,
+) -> Result<Option<xmtp_id::associations::SignatureKind>, ClientError> {
+    let updates = conn.get_identity_updates(inbox_id, None, None)?;
+
+    let first_update = updates
+        .first()
+        .ok_or_else(|| ClientError::Identity(IdentityError::RequiredIdentityNotFound))?;
+
+    let unverified_update: UnverifiedIdentityUpdate = first_update.clone().try_into()?;
+
+    let verified = unverified_update.to_verified(scw_verifier).await?;
+
+    Ok(verified.creation_signature_kind())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### TL;DR

Added creation signature kind to inbox state information to help identify how an inbox was created.

_This isn't an ideal implementation, but the real version is substantially more disruptive, so I have created a cleanup ticket_ [_here](https://github.com/xmtp/libxmtp/issues/2583)._

### What changed?

- Modified `inbox_state_from_inbox_ids` to include the creation signature kind in the returned `FfiInboxState` objects
- Added a new utility function `get_creation_signature_kind` in the identity_updates module that extracts the signature kind from the first identity update
- Made `FfiSignatureKind` derive `PartialEq` to support equality comparisons
- Added a test case to verify the creation signature kind is correctly populated

### How to test?

Run the existing test case that has been updated to verify the creation signature kind:

```
#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
async fn test_inbox_state_from_inbox_ids() {
    // Test will now verify that the creation signature kind is correctly set to FfiSignatureKind::Erc191
}
```

### Why make this change?

This change provides additional context about how an inbox was created (e.g., using an ERC-191 signature or another method), which is useful for clients to understand the authentication method used for inbox creation. This information helps with security verification and user experience by allowing applications to display appropriate information about the inbox's origin.