### PR TITLE
Receive re-add commit

### DIFF
--- a/xmtp_configuration/src/common/mls.rs
+++ b/xmtp_configuration/src/common/mls.rs
@@ -40,4 +40,4 @@ pub const SUPER_ADMIN_METADATA_PREFIX: &str = "_";
 pub const HMAC_SALT: &[u8] = b"libXMTP HKDF salt!";
 
 pub const ENABLE_COMMIT_LOG: bool = true;
-pub const MIN_RECOVERY_REQUEST_VERSION: &str = "1.6.1";
+pub const MIN_RECOVERY_REQUEST_VERSION: &str = "1.6.0";

--- a/xmtp_mls/src/groups/group_permissions.rs
+++ b/xmtp_mls/src/groups/group_permissions.rs
@@ -1350,6 +1350,8 @@ pub(crate) mod tests {
     #[cfg(target_arch = "wasm32")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
+    use std::collections::HashSet;
+
     use crate::groups::validated_commit::MutableMetadataValidationInfo;
     use xmtp_common::{rand_string, rand_vec};
     use xmtp_mls_common::group_metadata::DmMembers;
@@ -1441,6 +1443,7 @@ pub(crate) mod tests {
             removed_inboxes: member_removed
                 .map(build_membership_change)
                 .unwrap_or_default(),
+            readded_installations: HashSet::new(),
             metadata_validation_info: MutableMetadataValidationInfo {
                 metadata_field_changes: field_changes,
                 ..Default::default()

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -1471,6 +1471,17 @@ where
         .await
     }
 
+    /// Get the encryption state of the current epoch. Should match for all installations
+    /// in the same epoch.
+    #[cfg(test)]
+    #[allow(unused)]
+    pub(crate) async fn epoch_authenticator(&self) -> Result<Vec<u8>, GroupError> {
+        self.load_mls_group_with_lock_async(|mls_group| {
+            futures::future::ready(Ok(mls_group.epoch_authenticator().as_slice().to_vec()))
+        })
+        .await
+    }
+
     pub async fn cursor(&self) -> Result<[Cursor; 2], GroupError> {
         let db = self.context.db();
         let msgs = db.get_last_cursor_for_originator(

--- a/xmtp_mls/src/groups/tests/mod.rs
+++ b/xmtp_mls/src/groups/tests/mod.rs
@@ -4,6 +4,7 @@ mod test_commit_log_readd_requests;
 mod test_commit_log_remote;
 mod test_consent;
 mod test_dm;
+mod test_extract_readded_installations;
 mod test_key_updates;
 mod test_libxmtp_version;
 #[cfg(not(target_arch = "wasm32"))]

--- a/xmtp_mls/src/groups/tests/test_commit_log_readd_requests.rs
+++ b/xmtp_mls/src/groups/tests/test_commit_log_readd_requests.rs
@@ -157,35 +157,161 @@ async fn test_request_readd_dm() {
 }
 
 #[xmtp_common::test]
-async fn test_readd_installations() {
+async fn test_readd_installation_succeeds() {
     tester!(alix);
     tester!(bo);
+    tester!(caro);
 
-    // Create a group with both members
-    let group = alix
-        .create_group_with_inbox_ids(&[bo.inbox_id()], None, None)
+    let a_group = alix
+        .create_group_with_inbox_ids(&[bo.inbox_id(), caro.inbox_id()], None, None)
         .await
         .unwrap();
 
-    // Bo syncs to join the group
     bo.sync_all_welcomes_and_groups(None).await.unwrap();
+    caro.sync_all_welcomes_and_groups(None).await.unwrap();
+    let b_group = bo.group(&a_group.group_id).unwrap();
+    let c_group = caro.group(&a_group.group_id).unwrap();
 
-    let _bo_group = bo.group(&group.group_id).unwrap();
-
-    // Get Bo's installation ID
     let bo_installation_id = bo.context.installation_id();
-
-    // Verify Bo is currently in the group
-    let members = group.members().await.unwrap();
-    assert_eq!(members.len(), 2);
-
-    // Readd Bo's installation
-    // Note: This is expected to fail until receiver-side validation is implemented
-    let readd_result = group
+    let prev_authenticator = a_group.epoch_authenticator().await.unwrap();
+    assert_eq!(
+        b_group.epoch_authenticator().await.unwrap(),
+        prev_authenticator
+    );
+    a_group
         .readd_installations(vec![bo_installation_id.to_vec()])
-        .await;
+        .await
+        .unwrap();
+    // Verify the commit was applied without erroring on A and C
+    let new_authenticator = a_group.epoch_authenticator().await.unwrap();
+    assert_ne!(prev_authenticator, new_authenticator);
+    c_group.sync().await.unwrap();
+    let c_group_authenticator = c_group.epoch_authenticator().await.unwrap();
+    assert_eq!(c_group_authenticator, new_authenticator);
 
-    // Once validation/receiver side is updated, this call should not error,
-    // and Bo should be able to receive a new welcome for the same group
-    assert!(readd_result.is_err());
+    // Verify welcome was received and applied on B
+    tracing::warn!("Syncing welcomes");
+    bo.sync_welcomes().await.unwrap();
+    assert_eq!(
+        b_group.epoch_authenticator().await.unwrap(),
+        new_authenticator
+    );
+}
+
+#[xmtp_common::test]
+async fn test_readd_bookkeeping() {
+    tester!(alix);
+    tester!(bo);
+    tester!(caro);
+    tester!(devon);
+    let group = alix
+        .create_group_with_inbox_ids(&[bo.inbox_id(), caro.inbox_id()], None, None)
+        .await
+        .unwrap();
+    group
+        .update_admin_list(UpdateAdminListType::AddSuper, bo.inbox_id().to_string())
+        .await
+        .unwrap();
+    group
+        .update_admin_list(UpdateAdminListType::AddSuper, caro.inbox_id().to_string())
+        .await
+        .unwrap();
+    bo.sync_all_welcomes_and_groups(None).await.unwrap();
+    caro.sync_all_welcomes_and_groups(None).await.unwrap();
+    devon.sync_all_welcomes_and_groups(None).await.unwrap();
+
+    let mut a_worker = CommitLogWorker::new(alix.context.clone());
+    // Publishes remote commit log (needed for readd request to be sent)
+    a_worker._tick().await.unwrap();
+
+    let a_conn = alix.context.db();
+    let b_conn = bo.context.db();
+    let c_conn = caro.context.db();
+    let d_conn = devon.context.db();
+    // Simulate a fork
+    a_conn
+        .set_group_commit_log_forked_status(&group.group_id, Some(true))
+        .unwrap();
+
+    // No readd requests yet
+    assert!(
+        !a_conn
+            .is_awaiting_readd(&group.group_id, alix.context.installation_id().as_slice(),)
+            .unwrap()
+    );
+    assert!(
+        !b_conn
+            .is_awaiting_readd(&group.group_id, alix.context.installation_id().as_slice(),)
+            .unwrap()
+    );
+    assert!(
+        !c_conn
+            .is_awaiting_readd(&group.group_id, alix.context.installation_id().as_slice(),)
+            .unwrap()
+    );
+
+    // Should trigger readd requests to be sent
+    a_worker._tick().await.unwrap();
+    // Receive any oneshot messages
+    alix.sync_welcomes().await.unwrap();
+    bo.sync_welcomes().await.unwrap();
+    caro.sync_welcomes().await.unwrap();
+    devon.sync_welcomes().await.unwrap();
+
+    // Everyone except Devon (non-superadmin) sees Alix as awaiting readd
+    assert!(
+        a_conn
+            .is_awaiting_readd(&group.group_id, alix.context.installation_id().as_slice(),)
+            .unwrap()
+    );
+    assert!(
+        b_conn
+            .is_awaiting_readd(&group.group_id, alix.context.installation_id().as_slice(),)
+            .unwrap()
+    );
+    assert!(
+        c_conn
+            .is_awaiting_readd(&group.group_id, alix.context.installation_id().as_slice(),)
+            .unwrap()
+    );
+    assert!(
+        !d_conn
+            .is_awaiting_readd(&group.group_id, alix.context.installation_id().as_slice(),)
+            .unwrap()
+    );
+
+    // Let's say Bo's worker processes it first
+    // TODO: replace with tick() rather than calling readd directly once worker is updated
+    let b_group = bo.group(&group.group_id).unwrap();
+    b_group
+        .readd_installations(vec![alix.context.installation_id().to_vec()])
+        .await
+        .unwrap();
+
+    caro.sync_all_welcomes_and_groups(None).await.unwrap();
+    devon.sync_all_welcomes_and_groups(None).await.unwrap();
+
+    // Everyone should see that Alix is no longer awaiting readd
+    assert!(
+        !b_conn
+            .is_awaiting_readd(&group.group_id, alix.context.installation_id().as_slice(),)
+            .unwrap()
+    );
+    assert!(
+        !c_conn
+            .is_awaiting_readd(&group.group_id, alix.context.installation_id().as_slice(),)
+            .unwrap()
+    );
+    assert!(
+        !d_conn
+            .is_awaiting_readd(&group.group_id, alix.context.installation_id().as_slice(),)
+            .unwrap()
+    );
+
+    alix.sync_welcomes().await.unwrap();
+    assert!(
+        !a_conn
+            .is_awaiting_readd(&group.group_id, alix.context.installation_id().as_slice(),)
+            .unwrap()
+    );
 }

--- a/xmtp_mls/src/groups/tests/test_extract_readded_installations.rs
+++ b/xmtp_mls/src/groups/tests/test_extract_readded_installations.rs
@@ -1,0 +1,180 @@
+use std::collections::HashSet;
+
+use crate::groups::validated_commit::{CommitParticipant, extract_readded_installations};
+
+fn create_test_actor(is_super_admin: bool) -> CommitParticipant {
+    CommitParticipant {
+        inbox_id: "test_inbox".to_string(),
+        installation_id: vec![1, 2, 3],
+        is_creator: false,
+        is_admin: false,
+        is_super_admin,
+    }
+}
+
+#[test]
+fn test_extract_readded_installations_non_super_admin_returns_empty() {
+    let actor = create_test_actor(false);
+    let mut added = HashSet::from([vec![1, 2, 3], vec![4, 5, 6]]);
+    let mut removed = HashSet::from([vec![1, 2, 3], vec![7, 8, 9]]);
+    let mut failed = HashSet::from([vec![4, 5, 6]]);
+
+    let original_added = added.clone();
+    let original_removed = removed.clone();
+    let original_failed = failed.clone();
+
+    let result = extract_readded_installations(&actor, &mut added, &mut removed, &mut failed);
+
+    // Should return empty set
+    assert!(result.is_empty());
+    // Should not modify any of the input sets
+    assert_eq!(added, original_added);
+    assert_eq!(removed, original_removed);
+    assert_eq!(failed, original_failed);
+}
+
+#[test]
+fn test_extract_readded_installations_super_admin_added_and_removed_intersection() {
+    let actor = create_test_actor(true);
+    let mut added = HashSet::from([vec![1, 2, 3], vec![4, 5, 6]]);
+    let mut removed = HashSet::from([vec![1, 2, 3], vec![7, 8, 9]]);
+    let mut failed = HashSet::new();
+
+    let result = extract_readded_installations(&actor, &mut added, &mut removed, &mut failed);
+
+    // Should return the intersection
+    assert_eq!(result, HashSet::from([vec![1, 2, 3]]));
+    // Should remove from both added and removed
+    assert_eq!(added, HashSet::from([vec![4, 5, 6]]));
+    assert_eq!(removed, HashSet::from([vec![7, 8, 9]]));
+    // Failed should remain unchanged
+    assert!(failed.is_empty());
+}
+
+#[test]
+fn test_extract_readded_installations_super_admin_failed_and_removed_intersection() {
+    let actor = create_test_actor(true);
+    let mut added = HashSet::from([vec![1, 2, 3]]);
+    let mut removed = HashSet::from([vec![4, 5, 6], vec![7, 8, 9]]);
+    let mut failed = HashSet::from([vec![4, 5, 6]]);
+
+    let result = extract_readded_installations(&actor, &mut added, &mut removed, &mut failed);
+
+    // Should return the failed/removed intersection
+    assert_eq!(result, HashSet::from([vec![4, 5, 6]]));
+    // Added should remain unchanged
+    assert_eq!(added, HashSet::from([vec![1, 2, 3]]));
+    // Should remove from both removed and failed
+    assert_eq!(removed, HashSet::from([vec![7, 8, 9]]));
+    assert!(failed.is_empty());
+}
+
+#[test]
+fn test_extract_readded_installations_super_admin_both_types_of_readd() {
+    let actor = create_test_actor(true);
+    let mut added = HashSet::from([vec![1, 2, 3], vec![4, 5, 6]]);
+    let mut removed = HashSet::from([vec![1, 2, 3], vec![7, 8, 9], vec![10, 11, 12]]);
+    let mut failed = HashSet::from([vec![7, 8, 9]]);
+
+    let result = extract_readded_installations(&actor, &mut added, &mut removed, &mut failed);
+
+    // Should return both types: added+removed intersection AND failed+removed intersection
+    assert_eq!(result, HashSet::from([vec![1, 2, 3], vec![7, 8, 9]]));
+    // Should remove readded from added
+    assert_eq!(added, HashSet::from([vec![4, 5, 6]]));
+    // Should remove both types from removed
+    assert_eq!(removed, HashSet::from([vec![10, 11, 12]]));
+    // Should remove from failed
+    assert!(failed.is_empty());
+}
+
+#[test]
+fn test_extract_readded_installations_super_admin_no_intersections() {
+    let actor = create_test_actor(true);
+    let mut added = HashSet::from([vec![1, 2, 3]]);
+    let mut removed = HashSet::from([vec![4, 5, 6]]);
+    let mut failed = HashSet::from([vec![7, 8, 9]]);
+
+    let result = extract_readded_installations(&actor, &mut added, &mut removed, &mut failed);
+
+    // Should return empty set when no intersections
+    assert!(result.is_empty());
+    // All sets should remain unchanged
+    assert_eq!(added, HashSet::from([vec![1, 2, 3]]));
+    assert_eq!(removed, HashSet::from([vec![4, 5, 6]]));
+    assert_eq!(failed, HashSet::from([vec![7, 8, 9]]));
+}
+
+#[test]
+fn test_extract_readded_installations_super_admin_empty_sets() {
+    let actor = create_test_actor(true);
+    let mut added = HashSet::new();
+    let mut removed = HashSet::new();
+    let mut failed = HashSet::new();
+
+    let result = extract_readded_installations(&actor, &mut added, &mut removed, &mut failed);
+
+    // Should return empty set
+    assert!(result.is_empty());
+    // All sets should remain empty
+    assert!(added.is_empty());
+    assert!(removed.is_empty());
+    assert!(failed.is_empty());
+}
+
+#[test]
+fn test_extract_readded_installations_super_admin_all_installations_readded() {
+    let actor = create_test_actor(true);
+    let mut added = HashSet::from([vec![1, 2, 3], vec![4, 5, 6]]);
+    let mut removed = HashSet::from([vec![1, 2, 3], vec![4, 5, 6]]);
+    let mut failed = HashSet::new();
+
+    let result = extract_readded_installations(&actor, &mut added, &mut removed, &mut failed);
+
+    // Should return all installations
+    assert_eq!(result, HashSet::from([vec![1, 2, 3], vec![4, 5, 6]]));
+    // Both added and removed should be empty
+    assert!(added.is_empty());
+    assert!(removed.is_empty());
+    assert!(failed.is_empty());
+}
+
+#[test]
+fn test_extract_readded_installations_super_admin_multiple_failed_intersections() {
+    let actor = create_test_actor(true);
+    let mut added = HashSet::new();
+    let mut removed = HashSet::from([vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]]);
+    let mut failed = HashSet::from([vec![1, 2, 3], vec![4, 5, 6]]);
+
+    let result = extract_readded_installations(&actor, &mut added, &mut removed, &mut failed);
+
+    // Should return both failed installations
+    assert_eq!(result, HashSet::from([vec![1, 2, 3], vec![4, 5, 6]]));
+    // Added remains empty
+    assert!(added.is_empty());
+    // Removed should only have non-failed installation
+    assert_eq!(removed, HashSet::from([vec![7, 8, 9]]));
+    // Failed should be empty
+    assert!(failed.is_empty());
+}
+
+#[test]
+fn test_extract_readded_installations_super_admin_overlapping_scenarios() {
+    // Test case where an installation appears in all three sets
+    // This tests the order of operations (added+removed processed before failed+removed)
+    let actor = create_test_actor(true);
+    let mut added = HashSet::from([vec![1, 2, 3]]);
+    let mut removed = HashSet::from([vec![1, 2, 3], vec![4, 5, 6]]);
+    let mut failed = HashSet::from([vec![1, 2, 3], vec![4, 5, 6]]);
+
+    let result = extract_readded_installations(&actor, &mut added, &mut removed, &mut failed);
+
+    // Installation [1,2,3] is in added+removed (counted first)
+    // Installation [4,5,6] is in failed+removed (counted second)
+    assert_eq!(result, HashSet::from([vec![1, 2, 3], vec![4, 5, 6]]));
+    // All sets should be empty
+    assert!(added.is_empty());
+    assert!(removed.is_empty());
+    // 1,2,3 was already intersected against added+removed
+    assert_eq!(failed, HashSet::from([vec![1, 2, 3]]));
+}

--- a/xmtp_mls/src/groups/welcome_sync.rs
+++ b/xmtp_mls/src/groups/welcome_sync.rs
@@ -436,6 +436,8 @@ mod tests {
                         }])
                     });
                 db.expect_update_cursor().returning(|_, _, _| Ok(true));
+                db.expect_update_responded_at_sequence_id()
+                    .returning(|_, _, _| Ok(()));
                 db.expect_insert_or_replace_group().returning(Ok);
             })
             .mem(mem)
@@ -611,6 +613,9 @@ mod tests {
                         assert_eq!(entity, EntityKind::Welcome);
                         Ok(true)
                     });
+                db.expect_update_responded_at_sequence_id()
+                    .once()
+                    .returning(|_, _, _| Ok(()));
                 db.expect_update_cursor()
                     .once()
                     .returning(|_id, entity, cursor| {

--- a/xmtp_mls/src/groups/welcomes/xmtp_welcome.rs
+++ b/xmtp_mls/src/groups/welcomes/xmtp_welcome.rs
@@ -1,6 +1,8 @@
 //! XMTP Welcome Processing
 //! Processes a new welcome from the network
 
+use std::collections::HashSet;
+
 use crate::groups::mls_ext::CommitLogStorer;
 use crate::groups::mls_sync::DeferredEvents;
 use crate::groups::oneshot::Oneshot;
@@ -533,6 +535,12 @@ where
             } else {
                 Cursor::v3_messages(cursor as u64)
             },
+        )?;
+        MlsGroup::<C>::mark_readd_requests_as_responded(
+            &storage,
+            &group.group_id,
+            &HashSet::from([context.installation_id().to_vec()]),
+            cursor,
         )?;
 
         tracing::info!(


### PR DESCRIPTION
This PR:
1. Includes new validation logic for readd commits (in `extract_readded_installations()`)
2. Performs bookkeeping of readd requests once a readd commit or welcome is received (in `mark_readd_requests_as_responded()`). More details in the [XIP](https://community.xmtp.org/t/xip-68-draft-automated-fork-recovery/951#p-2260-receiving-a-readd-request-13).

Unit tests have been updated to verify the receiving side of a readd intent.