### PR TITLE
Fix nightly protos action

### DIFF
--- a/.github/workflows/nightly-protos.yml
+++ b/.github/workflows/nightly-protos.yml
@@ -14,6 +14,10 @@ jobs:
       - uses: bufbuild/buf-setup-action@v1.50.0
       - name: Update rust toolchains
         run: rustup update
+      - name: Install protoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
       - name: Cache
         uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Install protobuf-compiler in the nightly protos GitHub Actions workflow to fix the nightly protos action in [.github/workflows/nightly-protos.yml](https://github.com/xmtp/libxmtp/pull/2595/files#diff-739757e9d513ca6b233c09042b04919efe99c2992441eebf9d6486af8e5709a1)
Add an installation step for `protoc` in the nightly protos workflow by running `sudo apt-get update` and `sudo apt-get install -y protobuf-compiler` before the cache step in [.github/workflows/nightly-protos.yml](https://github.com/xmtp/libxmtp/pull/2595/files#diff-739757e9d513ca6b233c09042b04919efe99c2992441eebf9d6486af8e5709a1).

#### 📍Where to Start
Start with the job steps in [.github/workflows/nightly-protos.yml](https://github.com/xmtp/libxmtp/pull/2595/files#diff-739757e9d513ca6b233c09042b04919efe99c2992441eebf9d6486af8e5709a1), focusing on the newly added `apt-get` installation step placed before the cache configuration.

----

<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized df0b701. 1 files reviewed, 1 issues evaluated, 1 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>.github/workflows/nightly-protos.yml — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 32](https://github.com/xmtp/libxmtp/blob/df0b70118f456f1b1500ab2739b08a48adf2d8cf/.github/workflows/nightly-protos.yml#L32): The `Install Taplo` step downloads from a release tag constructed as `https://github.com/tamasfe/taplo/releases/download/${{ env.version }}/...` with `env.version` set to `"0.9.3"`. Taplo's releases are typically tagged with a leading `v` (e.g., `v0.9.3`). If the repository expects `v0.9.3`, this URL will 404, causing `curl` to download an HTML error page which `gzip -d` will fail to decompress, and the step will fail. To avoid the runtime failure, either set `version: "v0.9.3"` or adjust the URL to include the `v` prefix when needed. <b>[ Out of scope ]</b>
</details>


</details>
<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->