### PR TITLE
Make code cov informational and not blocking PRs for now

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,6 +3,9 @@ coverage:
     project:
       default:
         informational: true
+    patch:
+      default:
+        informational: true
 ignore:
   - "xmtp_proto/src/gen"
   - "xmtp_mls/src/subscriptions/stream_messages/test_case_builder.rs"


### PR DESCRIPTION
Code coverage setup is relatively new, and may not be configured to ignore all benign cases and therefore we do not want to block PRs in many cases for now. Will set the check to informational, which can aid reviewers in identifying important missed coverage.  

See config option here: https://docs.codecov.com/docs/commit-status#informational