### PR TITLE
Multi-node client avoid premature builds

### DIFF
--- a/dev/docker/docker-compose-d14n.yml
+++ b/dev/docker/docker-compose-d14n.yml
@@ -26,7 +26,7 @@ services:
   chain:
     platform: linux/amd64
     image: *x-xmtpd-contracts-image
-  register-node:
+  register-node-native:
     platform: linux/amd64
     image: *x-xmtpd-cli-image
     env_file:
@@ -36,19 +36,19 @@ services:
     command:
       [
         "--config-file=/cfg/anvil.json",
-        "--private-key=${REGISTER_NODE_ADMIN_KEY}",
+        "--private-key=${ANVIL_ADMIN_KEY}",
         "--rpc-url=${XMTPD_SETTLEMENT_CHAIN_RPC_URL}",
         "nodes",
         "register",
-        "--owner-address=${REGISTER_NODE_OWNER_ADDRESS}",
-        "--signing-key-pub=${REGISTER_NODE_PUBKEY}",
-        "--http-address=${REGISTER_NODE_HTTP_ADDRESS}",
+        "--owner-address=${REGISTER_NODE_NATIVE_OWNER_ADDRESS}",
+        "--signing-key-pub=${REGISTER_NODE_NATIVE_PUBKEY}",
+        "--http-address=${REGISTER_NODE_NATIVE_HTTP_ADDRESS}",
       ]
     depends_on:
       chain:
         condition: service_started
     restart: on-failure
-  enable-node:
+  enable-node-native:
     platform: linux/amd64
     image: *x-xmtpd-cli-image
     env_file:
@@ -58,7 +58,7 @@ services:
     command:
       [
         "--config-file=/cfg/anvil.json",
-        "--private-key=${REGISTER_NODE_ADMIN_KEY}",
+        "--private-key=${ANVIL_ADMIN_KEY}",
         "--rpc-url=${XMTPD_SETTLEMENT_CHAIN_RPC_URL}",
         "nodes",
         "canonical-network",
@@ -68,10 +68,57 @@ services:
     depends_on:
       chain:
         condition: service_started
-      register-node:
+      register-node-native:
         condition: service_completed_successfully
     restart: on-failure
-  repnode:
+  register-node-wasm:
+    platform: linux/amd64
+    image: *x-xmtpd-cli-image
+    env_file:
+      - local.env
+    volumes:
+      - ../environments/anvil.json:/cfg/anvil.json
+    command:
+      [
+        "--config-file=/cfg/anvil.json",
+        "--private-key=${ANVIL_ADMIN_KEY}",
+        "--rpc-url=${XMTPD_SETTLEMENT_CHAIN_RPC_URL}",
+        "nodes",
+        "register",
+        "--owner-address=${REGISTER_NODE_WASM_OWNER_ADDRESS}",
+        "--signing-key-pub=${REGISTER_NODE_WASM_PUBKEY}",
+        "--http-address=${REGISTER_NODE_WASM_HTTP_ADDRESS}",
+      ]
+    depends_on:
+      chain:
+        condition: service_started
+      register-node-native:
+        condition: service_completed_successfully
+    restart: on-failure
+  enable-node-wasm:
+    platform: linux/amd64
+    image: *x-xmtpd-cli-image
+    env_file:
+      - local.env
+    volumes:
+      - ../environments/anvil.json:/cfg/anvil.json
+    command:
+      [
+        "--config-file=/cfg/anvil.json",
+        "--private-key=${ANVIL_ADMIN_KEY}",
+        "--rpc-url=${XMTPD_SETTLEMENT_CHAIN_RPC_URL}",
+        "nodes",
+        "canonical-network",
+        "--add",
+        "--node-id=200",
+      ]
+    depends_on:
+      chain:
+        condition: service_started
+      register-node-wasm:
+        condition: service_completed_successfully
+    restart: on-failure
+  xmtpd:
     platform: linux/amd64
     image: *x-xmtpd-server-image
     env_file:
@@ -81,7 +128,9 @@ services:
     environment:
       - "XMTPD_CONTRACTS_CONFIG_FILE_PATH=/cfg/anvil.json"
     depends_on:
-      enable-node:
+      enable-node-native:
+        condition: service_completed_successfully
+      enable-node-wasm:
         condition: service_completed_successfully
       replicationdb:
         condition: service_healthy

--- a/dev/docker/envoy.yaml
+++ b/dev/docker/envoy.yaml
@@ -1,12 +1,12 @@
 admin:
   address:
-    socket_address: {address: 0.0.0.0, port_value: 9901}
+    socket_address: { address: 0.0.0.0, port_value: 9901 }
   access_log_path: /dev/stdout
 static_resources:
   listeners:
     - name: v3_listener
       address:
-        socket_address: {address: 0.0.0.0, port_value: 5557}
+        socket_address: { address: 0.0.0.0, port_value: 5557 }
       filter_chains:
         - filters:
             - name: envoy.http_connection_manager
@@ -20,7 +20,7 @@ static_resources:
                     - name: local_service
                       domains: ["*"]
                       routes:
-                        - match: {prefix: "/"}
+                        - match: { prefix: "/" }
                           route:
                             cluster: node-go
                             regex_rewrite:
@@ -50,7 +50,7 @@ static_resources:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
     - name: d14n_listener
       address:
-        socket_address: {address: 0.0.0.0, port_value: 5051}
+        socket_address: { address: 0.0.0.0, port_value: 5051 }
       filter_chains:
         - filters:
             - name: envoy.http_connection_manager
@@ -64,7 +64,7 @@ static_resources:
                     - name: local_service
                       domains: ["*"]
                       routes:
-                        - match: {prefix: "/gateway"}
+                        - match: { prefix: "/gateway" }
                           route:
                             cluster: gateway
                             regex_rewrite:
@@ -75,9 +75,9 @@ static_resources:
                             timeout: 0s
                             max_stream_duration:
                               grpc_timeout_header_max: 0s
-                        - match: {prefix: "/xmtpd"}
+                        - match: { prefix: "/xmtpd" }
                           route:
-                            cluster: repnode
+                            cluster: xmtpd
                             regex_rewrite:
                               pattern:
                                 google_re2: {}
@@ -122,7 +122,7 @@ static_resources:
                     socket_address:
                       address: node
                       port_value: 5556
-    - name: repnode
+    - name: xmtpd
       connect_timeout: 0.25s
       type: LOGICAL_DNS
       typed_extension_protocol_options:
@@ -132,13 +132,13 @@ static_resources:
             http2_protocol_options: {}
       lb_policy: ROUND_ROBIN
       load_assignment:
-        cluster_name: repnode
+        cluster_name: xmtpd
         endpoints:
           - lb_endpoints:
               - endpoint:
                   address:
                     socket_address:
-                      address: repnode
+                      address: xmtpd
                       port_value: 5050
     - name: gateway
       connect_timeout: 0.25s

--- a/dev/docker/local.env
+++ b/dev/docker/local.env
@@ -5,15 +5,20 @@ XMTPD_REPLICATION_ENABLE=true
 XMTPD_INDEXER_ENABLE=true
 XMTPD_SYNC_ENABLE=true
 
-# Register Node Settings
-REGISTER_NODE_OWNER_ADDRESS=0x70997970C51812dc3A010C7d01b50e0d17dc79C8
-REGISTER_NODE_ADMIN_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
-REGISTER_NODE_PUBKEY=0x02ba5734d8f7091719471e7f7ed6b9df170dc70cc661ca05e688601ad984f068b0
+# Node for native tests - Anvil first account
+REGISTER_NODE_NATIVE_OWNER_ADDRESS=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+REGISTER_NODE_NATIVE_PUBKEY=0x038318535b54105d4a7aae60c08fc45f9687181b4fdfc625bd1a753fa7397fed75
+REGISTER_NODE_NATIVE_HTTP_ADDRESS=http://localhost:5050
+
+# Node for wasm tests - Anvil second account
+REGISTER_NODE_WASM_OWNER_ADDRESS=0x70997970C51812dc3A010C7d01b50e0d17dc79C8
+REGISTER_NODE_WASM_PUBKEY=0x02ba5734d8f7091719471e7f7ed6b9df170dc70cc661ca05e688601ad984f068b0
+REGISTER_NODE_WASM_HTTP_ADDRESS=http://localhost:5051/xmtpd
 
 # Compose URLs
 # Note: we are using docker compose variable substitution for commands, not docker container substitution
 # This means that the variables need to be accessible to the compose file, not passed to the container
-REGISTER_NODE_HTTP_ADDRESS=http://repnode:5050
+ANVIL_ADMIN_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 XMTPD_APP_CHAIN_RPC_URL=http://chain:8545
 XMTPD_APP_CHAIN_WSS_URL=ws://chain:8545
 XMTPD_SETTLEMENT_CHAIN_RPC_URL=http://chain:8545

--- a/xmtp_api_d14n/src/middleware/multi_node_client/builder.rs
+++ b/xmtp_api_d14n/src/middleware/multi_node_client/builder.rs
@@ -8,9 +8,9 @@ use xmtp_proto::{api_client::ApiBuilder, types::AppVersion};
 /* MultiNodeClientBuilder struct and its associated errors */
 
 pub struct MultiNodeClientBuilder {
-    pub gateway_builder: Option<ClientBuilder>,
-    pub timeout: Duration,
-    pub node_client_template: ClientBuilder,
+    gateway_builder: Option<ClientBuilder>,
+    timeout: Duration,
+    node_client_template: ClientBuilder,
 }
 
 /// Errors that can occur when building a MultiNodeClient.
@@ -54,7 +54,7 @@ impl MiddlewareBuilder for MultiNodeClientBuilder {
         Ok(())
     }
 
-    fn build(self) -> Result<Self::Output, Self::Error> {
+    fn into_client(self) -> Result<Self::Output, Self::Error> {
         let gateway_builder = self
             .gateway_builder
             .ok_or(MultiNodeClientBuilderError::MissingGatewayBuilder)?;

--- a/xmtp_api_d14n/src/middleware/multi_node_client/client.rs
+++ b/xmtp_api_d14n/src/middleware/multi_node_client/client.rs
@@ -69,50 +69,75 @@ impl Client for MultiNodeClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::D14nClient;
     use crate::middleware::{MiddlewareBuilder, MultiNodeClientBuilder};
     use xmtp_configuration::GrpcUrls;
+    use xmtp_proto::api::Query;
     use xmtp_proto::api_client::ApiBuilder;
+    use xmtp_proto::prelude::XmtpMlsClient;
+    use xmtp_proto::types::GroupId;
+
+    fn is_tls_enabled() -> bool {
+        url::Url::parse(GrpcUrls::GATEWAY)
+            .expect("valid gateway url")
+            .scheme()
+            == "https"
+    }
 
     fn create_gateway_builder() -> ClientBuilder {
-        let mut b = GrpcClient::builder();
-        let url = url::Url::parse(GrpcUrls::GATEWAY).expect("valid gateway url");
-        b.set_host(GrpcUrls::GATEWAY.to_string());
-        b.set_tls(url.scheme() == "https");
-        b
+        let mut gateway_builder = GrpcClient::builder();
+        gateway_builder.set_host(GrpcUrls::GATEWAY.to_string());
+        gateway_builder.set_tls(is_tls_enabled());
+        gateway_builder
     }
 
-    fn make_template(tls: bool) -> xmtp_api_grpc::ClientBuilder {
-        let mut t = GrpcClient::builder();
-        t.set_tls(tls);
+    fn create_multinode_client_builder() -> MultiNodeClientBuilder {
+        let mut multi_node_builder = MultiNodeClientBuilder::default();
+        multi_node_builder
+            .set_gateway_builder(create_gateway_builder())
+            .unwrap();
+        multi_node_builder
+            .set_timeout(Duration::from_millis(1000))
+            .unwrap();
+        multi_node_builder.set_tls(is_tls_enabled());
+        multi_node_builder
+    }
+
+    fn create_multinode_client() -> MultiNodeClient {
+        let multi_node_builder = create_multinode_client_builder();
+        multi_node_builder.into_client().unwrap()
+    }
+
+    fn create_d14n_client() -> D14nClient<MultiNodeClient, GrpcClient> {
+        D14nClient::new(
+            create_multinode_client_builder().into_client().unwrap(),
+            create_gateway_builder().build().unwrap(),
+        )
+    }
+
+    fn create_node_client_template(tls: bool) -> xmtp_api_grpc::ClientBuilder {
+        let mut client_builder = GrpcClient::builder();
+        client_builder.set_tls(tls);
         // host will be overridden per node
-        t.set_host("http://placeholder".to_string());
-        t
+        client_builder.set_host("http://placeholder".to_string());
+        client_builder
     }
 
-    #[tokio::test]
-    async fn builder_ok_when_all_set() {
-        let mut b = MultiNodeClientBuilder::default();
-        b.set_gateway_builder(create_gateway_builder()).unwrap();
-        b.set_timeout(Duration::from_millis(100)).unwrap();
-        let client = <MultiNodeClientBuilder as MiddlewareBuilder>::build(b).expect("build ok");
-        let _ = client; // not used further
-    }
-
-    #[test]
+    #[xmtp_common::test]
     fn tls_guard_accepts_matching_https_tls_true() {
-        let t = make_template(true);
+        let t = create_node_client_template(true);
         validate_tls_guard(&t, "https://example.com:443").expect("should accept");
     }
 
-    #[test]
+    #[xmtp_common::test]
     fn tls_guard_accepts_matching_http_tls_false() {
-        let t = make_template(false);
+        let t = create_node_client_template(false);
         validate_tls_guard(&t, "http://example.com:80").expect("should accept");
     }
 
-    #[test]
+    #[xmtp_common::test]
     fn tls_guard_rejects_https_with_plain_template() {
-        let t = make_template(false);
+        let t = create_node_client_template(false);
         let err = validate_tls_guard(&t, "https://example.com:443")
             .err()
             .unwrap();
@@ -120,9 +145,9 @@ mod tests {
         assert!(msg.contains("tls channel"));
     }
 
-    #[test]
+    #[xmtp_common::test]
     fn tls_guard_rejects_http_with_tls_template() {
-        let t = make_template(true);
+        let t = create_node_client_template(true);
         let err = validate_tls_guard(&t, "http://example.com:80")
             .err()
             .unwrap();
@@ -131,19 +156,13 @@ mod tests {
     }
 
     /// This test also serves as an example of how to use the MultiNodeClientBuilder and D14nClientBuilder.
-    #[tokio::test]
-    async fn d14n_builder_works_with_multinode() {
+    #[xmtp_common::test]
+    async fn build_multinode_as_d14n() {
         use crate::D14nClientBuilder;
         use xmtp_proto::prelude::ApiBuilder;
 
         // 1) Create gateway builder.
-        let mut gateway_builder = GrpcClient::builder();
-        let url = url::Url::parse(GrpcUrls::GATEWAY).expect("valid gateway url");
-        match url.scheme() {
-            "https" => gateway_builder.set_tls(true),
-            _ => gateway_builder.set_tls(false),
-        }
-        gateway_builder.set_host(GrpcUrls::GATEWAY.into());
+        let gateway_builder = create_gateway_builder();
 
         // 2) Configure multi-node builder with the gateway builder.
         let mut multi_node_builder = MultiNodeClientBuilder::default();
@@ -157,12 +176,12 @@ mod tests {
         // Multi-node specific configuration.
         // Set the timeout, used in multi-node client requests to the gateway.
         multi_node_builder
-            .set_timeout(xmtp_common::time::Duration::from_millis(100))
+            .set_timeout(xmtp_common::time::Duration::from_millis(1000))
             .unwrap();
 
         // ApiBuilder methods forward configuration to the node client template.
         // All GrpcClient instances will inherit these settings.
-        multi_node_builder.set_tls(url.scheme() == "https");
+        multi_node_builder.set_tls(is_tls_enabled());
 
         // All ApiBuilder methods are available:
         // multi_node_builder.set_libxmtp_version("1.0.0".into())?;
@@ -171,5 +190,49 @@ mod tests {
         // 3) Build D14n client with both builders
         // D14nClientBuilder.build() will call both builders' build() methods!
         let _d14n = D14nClientBuilder::new(multi_node_builder, gateway_builder);
+    }
+
+    /// This test also serves as an example of how to use the MultiNodeClientBuilder standalone.
+    #[xmtp_common::test]
+    async fn build_multinode_as_standalone() {
+        let gateway_builder = create_gateway_builder();
+
+        let mut multi_node_builder = MultiNodeClientBuilder::default();
+        multi_node_builder
+            .set_gateway_builder(gateway_builder.clone())
+            .expect("gateway set on multi-node");
+        multi_node_builder
+            .set_timeout(xmtp_common::time::Duration::from_millis(100))
+            .unwrap();
+        multi_node_builder.set_tls(is_tls_enabled());
+
+        let _ = multi_node_builder
+            .into_client()
+            .expect("failed to build multi-node client");
+    }
+
+    #[xmtp_common::test]
+    async fn d14n_request_latest_group_message() {
+        let client = create_d14n_client();
+        let id: GroupId = GroupId::from(vec![]);
+        let response = client.query_latest_group_message(id).await;
+
+        match response {
+            Err(e) => {
+                // The query should throw UninitializedFieldError(cursor).
+                let err_str = e.to_string();
+                assert!(err_str.contains("cursor"));
+            }
+            Ok(_) => panic!("expected error for empty group id"),
+        }
+    }
+
+    #[xmtp_common::test]
+    async fn multinode_request_latest_group_message() {
+        use crate::d14n::GetNewestEnvelopes;
+        let client = create_multinode_client();
+        let mut endpoint = GetNewestEnvelopes::builder().topic(vec![]).build().unwrap();
+        let response = endpoint.query(&client).await.unwrap();
+        assert!(!response.results.is_empty());
     }
 }

--- a/xmtp_api_d14n/src/middleware/traits.rs
+++ b/xmtp_api_d14n/src/middleware/traits.rs
@@ -14,5 +14,5 @@ pub trait MiddlewareBuilder {
     fn set_timeout(&mut self, timeout: Duration) -> Result<(), Self::Error>;
 
     /// Build the middleware.
-    fn build(self) -> Result<Self::Output, Self::Error>;
+    fn into_client(self) -> Result<Self::Output, Self::Error>;
 }

--- a/xmtp_configuration/src/common/api.rs
+++ b/xmtp_configuration/src/common/api.rs
@@ -70,6 +70,6 @@ impl GrpcUrls {
 pub struct InternalDockerUrls;
 impl InternalDockerUrls {
     pub const NODE: &'static str = "http://node:5556";
-    pub const XMTPD: &'static str = "http://repnode:5050";
+    pub const XMTPD: &'static str = "http://xmtpd:5050";
     pub const GATEWAY: &'static str = "http://gateway:5052";
 }

--- a/xmtp_configuration/src/test/api.rs
+++ b/xmtp_configuration/src/test/api.rs
@@ -13,7 +13,7 @@ pub fn localhost_to_internal(host_url: &str) -> url::Url {
             url.set_host(Some("node")).unwrap() // the xmtp-go node
         }
         5050 | 5055 => {
-            url.set_host(Some("repnode")).unwrap() // the xmtpd replication node
+            url.set_host(Some("xmtpd")).unwrap() // the xmtpd replication node
         }
         5052 => {
             url.set_host(Some("gateway")).unwrap() // the xmtpd gateway node
@@ -30,8 +30,8 @@ pub fn toxi_port(host_url: &str) -> u16 {
     match url.port().unwrap() {
         5556 => 21100, // node-go
         5555 => 21101, // http REST node-go
-        5050 => 21102, // repnode
-        5055 => 21103, // http REST repnode
+        5050 => 21102, // xmtpd
+        5055 => 21103, // http REST xmtpd
         5052 => 21104, // xmtpd gateway
         _ => panic!("unknown port"),
     }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Provision two nodes and require `xmtpd` to wait for `enable-node-native` and `enable-node-wasm` completion in [docker-compose-d14n.yml](https://github.com/xmtp/libxmtp/pull/2609/files#diff-f3b95b320e721deae58c0f228c225c5dc895a08336200f71f989ac0764d95776) to avoid premature builds
This pull request updates local Docker and Envoy configuration to provision both native and wasm nodes, routes `/xmtpd` to the `xmtpd` cluster, and refactors the multi-node client to construct gateway clients via a `ClientBuilder`. It also adjusts environment variables to split native and wasm registration settings and switches internal references from `repnode` to `xmtpd`.

- Refactor `MultiNodeClientBuilder` to store `ClientBuilder` for the gateway and build via `into_client`, updating trait methods and tests to use a gateway builder; add timeout validation and improved logging in gateway API (https://github.com/xmtp/libxmtp/pull/2609/files#diff-9953570b1c1f76990f2cb32bf39372397f076b95d939a4bc186bd73d479ea3b8)
- Provision `register-node-native`/`enable-node-native` and `register-node-wasm`/`enable-node-wasm` services and gate `xmtpd` startup on both enable steps; use `ANVIL_ADMIN_KEY` and per-node env vars (https://github.com/xmtp/libxmtp/pull/2609/files#diff-f3b95b320e721deae58c0f228c225c5dc895a08336200f71f989ac0764d95776)
- Route `/xmtpd` traffic to the `xmtpd` cluster and rename cluster/endpoints from `repnode` to `xmtpd` (https://github.com/xmtp/libxmtp/pull/2609/files#diff-6a131c8d85877181360fa9bdc98c5e0956510693c8a75ff710f469f7f44c71c1)
- Add native and wasm registration variables and `ANVIL_ADMIN_KEY` in local environment; remove `REGISTER_NODE_HTTP_ADDRESS` (https://github.com/xmtp/libxmtp/pull/2609/files#diff-e38cb3bb4b11354071f335632640f38034c9360d74a49702c65aca2fdfab3f31)
- Update internal URLs and test mappings to `xmtpd` instead of `repnode` (https://github.com/xmtp/libxmtp/pull/2609/files#diff-36857b4809ace5202c54c69e2f89991a8d6652a5de97f414fbc3ac3c0336b928)

#### 📍Where to Start
Start with the `middleware.multi_node_client::MultiNodeClientBuilder::into_client` construction path in [builder.rs](https://github.com/xmtp/libxmtp/pull/2609/files#diff-c3ae7ce19f183873df1c568201e354b80e43bc2b22390124be41c307712e3ee5), then follow gateway client creation and healthcheck flow in [gateway_api.rs](https://github.com/xmtp/libxmtp/pull/2609/files#diff-53183edd36b5e355e56ed3d4998084c9e8e3a59393fee3cb574bc4d17f08c61e).

----

<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 0eeb331. 5 files reviewed, 5 issues evaluated, 5 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>xmtp_api_d14n/src/middleware/multi_node_client/client.rs — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 230](https://github.com/xmtp/libxmtp/blob/0eeb3314cfc91e811ecff5995103c3becd785422/xmtp_api_d14n/src/middleware/multi_node_client/client.rs#L230): Test `multinode_request_latest_group_message` may be flaky or consistently fail: it builds an endpoint with `topic(vec![])` (an empty topic list) and asserts `!response.results.is_empty()`. If the API returns no envelopes for an empty topic set, the test will `unwrap()` and/or `assert!` fail at runtime, causing CI instability. This is a test-only runtime behavior issue. <b>[ Test / Mock code ]</b>
</details>

<details>
<summary>xmtp_api_d14n/src/middleware/multi_node_client/gateway_api.rs — 0 comments posted, 3 evaluated, 3 filtered</summary>

- [line 51](https://github.com/xmtp/libxmtp/blob/0eeb3314cfc91e811ecff5995103c3becd785422/xmtp_api_d14n/src/middleware/multi_node_client/gateway_api.rs#L51): Missing validation that the node client template's TLS configuration matches the URL scheme when building node clients in `get_nodes`. The code sets the host via `client_builder.set_host(url.to_string())` but does not verify or set TLS based on whether the `url` is `http` or `https`. This can lead to TLS mismatch (e.g., TLS disabled for `https` endpoints or enabled for `http` endpoints), causing connection failures or insecure connections at runtime. <b>[ Low confidence ]</b>
- [line 131](https://github.com/xmtp/libxmtp/blob/0eeb3314cfc91e811ecff5995103c3becd785422/xmtp_api_d14n/src/middleware/multi_node_client/gateway_api.rs#L131): Error mapping in `get_fastest_node` changes the externally visible error variant from `MultiNodeClientError::UnhealthyNode { node_id }` to `MultiNodeClientError::GrpcError(e)`. This removes the `node_id` context and changes the error contract. Callers that relied on distinguishing unhealthy nodes or on the presence of `node_id` will now receive a different variant without the node identifier, breaking error handling and observability at runtime. <b>[ Low confidence ]</b>
- [line 158](https://github.com/xmtp/libxmtp/blob/0eeb3314cfc91e811ecff5995103c3becd785422/xmtp_api_d14n/src/middleware/multi_node_client/gateway_api.rs#L158): Possible truncation when converting `timeout.as_millis()` (u128) to `u64` in `MultiNodeClientError::NoResponsiveNodesFound { latency }`. If an extremely large `Duration` is provided (greater than `u64::MAX` milliseconds), the cast `as u64` silently truncates, producing an incorrect latency value in the error. This is a runtime data loss bug on boundary inputs. <b>[ Low confidence ]</b>
</details>

<details>
<summary>xmtp_configuration/src/common/api.rs — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 73](https://github.com/xmtp/libxmtp/blob/0eeb3314cfc91e811ecff5995103c3becd785422/xmtp_configuration/src/common/api.rs#L73): Changed Docker internal URL constant `InternalDockerUrls::XMTPD` from `"http://repnode:5050"` to `"http://xmtpd:5050"`. If existing environments expect the `repnode` container name, this change will cause runtime connection failures when trying to reach the service. The code does not show accompanying changes ensuring the container/service name is updated consistently. <b>[ Low confidence ]</b>
</details>


</details>
<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->