### PR TITLE
update to latest openmls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1964,9 +1964,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67773048316103656a637612c4a62477603b777d91d9c62ff2290f9cde178fdb"
+checksum = "59c9b8bdf64ee849747c1b12eb861d21aa47fa161564f48332f1afe2373bf899"
 dependencies = [
  "ctor-proc-macro",
  "dtor",
@@ -1974,9 +1974,9 @@ dependencies = [
 
 [[package]]
 name = "ctor-proc-macro"
-version = "0.0.6"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
+checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "ctr"
@@ -4451,8 +4451,8 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openmls"
-version = "0.7.0"
-source = "git+https://github.com/xmtp/openmls?rev=d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0#d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0"
+version = "0.7.1"
+source = "git+https://github.com/xmtp/openmls?rev=51f800df4d56d74fb2dde993f33e320b573df60e#51f800df4d56d74fb2dde993f33e320b573df60e"
 dependencies = [
  "backtrace",
  "fluvio-wasm-timer",
@@ -4478,8 +4478,8 @@ dependencies = [
 
 [[package]]
 name = "openmls_basic_credential"
-version = "0.4.0"
-source = "git+https://github.com/xmtp/openmls?rev=d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0#d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0"
+version = "0.4.1"
+source = "git+https://github.com/xmtp/openmls?rev=51f800df4d56d74fb2dde993f33e320b573df60e#51f800df4d56d74fb2dde993f33e320b573df60e"
 dependencies = [
  "ed25519-dalek",
  "openmls_traits",
@@ -4491,8 +4491,8 @@ dependencies = [
 
 [[package]]
 name = "openmls_libcrux_crypto"
-version = "0.2.0"
-source = "git+https://github.com/xmtp/openmls?rev=d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0#d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0"
+version = "0.2.1"
+source = "git+https://github.com/xmtp/openmls?rev=51f800df4d56d74fb2dde993f33e320b573df60e#51f800df4d56d74fb2dde993f33e320b573df60e"
 dependencies = [
  "hpke-rs",
  "hpke-rs-crypto",
@@ -4511,8 +4511,8 @@ dependencies = [
 
 [[package]]
 name = "openmls_memory_storage"
-version = "0.4.0"
-source = "git+https://github.com/xmtp/openmls?rev=d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0#d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0"
+version = "0.4.1"
+source = "git+https://github.com/xmtp/openmls?rev=51f800df4d56d74fb2dde993f33e320b573df60e#51f800df4d56d74fb2dde993f33e320b573df60e"
 dependencies = [
  "hex",
  "log",
@@ -4524,8 +4524,8 @@ dependencies = [
 
 [[package]]
 name = "openmls_rust_crypto"
-version = "0.4.0"
-source = "git+https://github.com/xmtp/openmls?rev=d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0#d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0"
+version = "0.4.1"
+source = "git+https://github.com/xmtp/openmls?rev=51f800df4d56d74fb2dde993f33e320b573df60e#51f800df4d56d74fb2dde993f33e320b573df60e"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -4548,8 +4548,8 @@ dependencies = [
 
 [[package]]
 name = "openmls_test"
-version = "0.2.0"
-source = "git+https://github.com/xmtp/openmls?rev=d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0#d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0"
+version = "0.2.1"
+source = "git+https://github.com/xmtp/openmls?rev=51f800df4d56d74fb2dde993f33e320b573df60e#51f800df4d56d74fb2dde993f33e320b573df60e"
 dependencies = [
  "ansi_term",
  "openmls_rust_crypto",
@@ -4563,8 +4563,8 @@ dependencies = [
 
 [[package]]
 name = "openmls_traits"
-version = "0.4.0"
-source = "git+https://github.com/xmtp/openmls?rev=d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0#d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0"
+version = "0.4.1"
+source = "git+https://github.com/xmtp/openmls?rev=51f800df4d56d74fb2dde993f33e320b573df60e#51f800df4d56d74fb2dde993f33e320b573df60e"
 dependencies = [
  "serde",
  "tls_codec",
@@ -8370,7 +8370,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "const-hex",
- "ctor 0.5.0",
+ "ctor 0.6.0",
  "futures",
  "futures-timer",
  "http 1.3.1",
@@ -8395,7 +8395,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "const-hex",
- "ctor 0.5.0",
+ "ctor 0.6.0",
  "derive_builder",
  "futures",
  "futures-test",
@@ -8520,7 +8520,7 @@ dependencies = [
  "async-trait",
  "console_error_panic_hook",
  "const-hex",
- "ctor 0.5.0",
+ "ctor 0.6.0",
  "fdlimit",
  "futures",
  "getrandom 0.3.3",
@@ -8605,7 +8605,7 @@ dependencies = [
  "arc-swap",
  "bincode",
  "const-hex",
- "ctor 0.5.0",
+ "ctor 0.6.0",
  "derive_builder",
  "diesel",
  "diesel_migrations",
@@ -8662,7 +8662,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "const-hex",
- "ctor 0.5.0",
+ "ctor 0.6.0",
  "ed25519-dalek",
  "futures",
  "getrandom 0.3.3",
@@ -8713,7 +8713,7 @@ dependencies = [
  "const-hex",
  "coset",
  "criterion",
- "ctor 0.5.0",
+ "ctor 0.6.0",
  "derive_builder",
  "diesel",
  "dyn-clone",
@@ -8807,7 +8807,7 @@ dependencies = [
  "chrono",
  "color-eyre",
  "const-hex",
- "ctor 0.5.0",
+ "ctor 0.6.0",
  "derive_builder",
  "ed25519-dalek",
  "futures",
@@ -8846,7 +8846,7 @@ dependencies = [
  "chrono",
  "const-hex",
  "criterion",
- "ctor 0.5.0",
+ "ctor 0.6.0",
  "fdlimit",
  "futures",
  "paranoid-android",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,19 +64,19 @@ async-compression = { default-features = false, version = "0.4", features = [
 ] }
 async-trait = "0.1.77"
 base64 = "0.22"
-bincode = "1.3"
+bincode = { version = "1.3" }
 bytes = "1.9"
 chrono = "0.4.38"
 color-eyre = "0.6"
 console_error_panic_hook = "0.1"
 const_format = "0.2"
-ctor = "0.5"
+ctor = "0.6"
 criterion = { version = "0.7", features = ["html_reports", "async_tokio"] }
 derive_builder = "0.20"
 diesel = { version = "2.3", default-features = false }
 diesel_migrations = { version = "2.2", default-features = false }
 dyn-clone = "1"
-ed25519-dalek = { version = "2.1.1", features = ["zeroize"] }
+ed25519-dalek = { version = "2.2", features = ["zeroize"] }
 fdlimit = "0.3"
 futures = { version = "0.3.30", default-features = false }
 futures-test = { version = "0.3" }
@@ -96,11 +96,11 @@ js-sys = "0.3"
 mockall = { version = "0.13" }
 mockall_double = "0.3.1"
 once_cell = "1.2"
-openmls = { git = "https://github.com/xmtp/openmls", rev = "d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0", default-features = false }
-openmls_basic_credential = { git = "https://github.com/xmtp/openmls", rev = "d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0" }
-openmls_libcrux_crypto = { git = "https://github.com/xmtp/openmls", rev = "d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0" }
-openmls_rust_crypto = { git = "https://github.com/xmtp/openmls", rev = "d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0" }
-openmls_traits = { git = "https://github.com/xmtp/openmls", rev = "d85aa56bdaf7f3754e425508ee2d3c39f6f37aa0" }
+openmls = { git = "https://github.com/xmtp/openmls", rev = "51f800df4d56d74fb2dde993f33e320b573df60e", default-features = false }
+openmls_basic_credential = { git = "https://github.com/xmtp/openmls", rev = "51f800df4d56d74fb2dde993f33e320b573df60e" }
+openmls_libcrux_crypto = { git = "https://github.com/xmtp/openmls", rev = "51f800df4d56d74fb2dde993f33e320b573df60e" }
+openmls_rust_crypto = { git = "https://github.com/xmtp/openmls", rev = "51f800df4d56d74fb2dde993f33e320b573df60e" }
+openmls_traits = { git = "https://github.com/xmtp/openmls", rev = "51f800df4d56d74fb2dde993f33e320b573df60e" }
 
 owo-colors = { version = "4.1" }
 p256 = { version = "0.13.2", features = ["ecdsa"] }

--- a/xmtp_archive/src/exporter.rs
+++ b/xmtp_archive/src/exporter.rs
@@ -5,6 +5,7 @@ use async_compression::futures::write::ZstdEncoder;
 use futures::{pin_mut, task::Context};
 use futures_util::{AsyncRead, AsyncWriteExt};
 use prost::Message;
+#[allow(deprecated)]
 use sha2::digest::{generic_array::GenericArray, typenum};
 use std::{future::Future, io, pin::Pin, sync::Arc, task::Poll};
 use xmtp_db::prelude::*;
@@ -24,6 +25,7 @@ pub struct ArchiveExporter {
     encoder_finished: bool,
 
     cipher: AesGcm<Aes256, typenum::U12, typenum::U16>,
+    #[allow(deprecated)]
     nonce: GenericArray<u8, typenum::U12>,
 
     // Used to write the nonce, contains the same data as nonce.
@@ -105,7 +107,9 @@ impl ArchiveExporter {
             zstd_encoder: ZstdEncoder::new(Vec::new()),
             encoder_finished: false,
 
+            #[allow(deprecated)]
             cipher: Aes256Gcm::new(GenericArray::from_slice(key)),
+            #[allow(deprecated)]
             nonce: GenericArray::clone_from_slice(&nonce),
             nonce_buffer,
         }

--- a/xmtp_archive/src/importer.rs
+++ b/xmtp_archive/src/importer.rs
@@ -5,6 +5,7 @@ use async_compression::futures::bufread::ZstdDecoder;
 use futures::{FutureExt, Stream, StreamExt};
 use futures_util::{AsyncBufRead, AsyncReadExt};
 use prost::Message;
+#[allow(deprecated)]
 use sha2::digest::{generic_array::GenericArray, typenum};
 use std::{pin::Pin, task::Poll};
 use xmtp_proto::xmtp::device_sync::{BackupElement, backup_element::Element};
@@ -18,6 +19,7 @@ pub struct ArchiveImporter {
     decoder: ZstdDecoder<Pin<Box<dyn AsyncBufRead + Send>>>,
 
     cipher: AesGcm<Aes256, typenum::U12, typenum::U16>,
+    #[allow(deprecated)]
     nonce: GenericArray<u8, typenum::U12>,
 }
 
@@ -80,7 +82,9 @@ impl ArchiveImporter {
             decoded: vec![],
             metadata: BackupMetadata::default(),
 
+            #[allow(deprecated)]
             cipher: Aes256Gcm::new(GenericArray::from_slice(key)),
+            #[allow(deprecated)]
             nonce: GenericArray::from(nonce),
         };
 

--- a/xmtp_cryptography/src/hash.rs
+++ b/xmtp_cryptography/src/hash.rs
@@ -2,6 +2,7 @@ use sha2::{Digest, Sha256};
 
 /// Sha256 is used in places where cryptographic security is not required, as sha256 has a
 /// significant speed improvement over Keccak.
+#[allow(deprecated)]
 pub fn sha256_bytes(bytes: &[u8]) -> Vec<u8> {
     let k = Sha256::digest(bytes);
 

--- a/xmtp_debug/src/app/types.rs
+++ b/xmtp_debug/src/app/types.rs
@@ -20,6 +20,7 @@ pub struct EthereumWallet(SigningKey<k256::Secp256k1>);
 
 impl EthereumWallet {
     pub fn into_alloy(self) -> PrivateKeySigner {
+        #[allow(deprecated)]
         PrivateKeySigner::from_slice(self.0.to_bytes().as_slice()).expect("Should never fail")
     }
 
@@ -80,6 +81,7 @@ impl Identity {
         let mut inbox_id = [0u8; 32];
         let mut eth_key = [0u8; 32];
         hex::decode_to_slice(identity.inbox_id.clone(), &mut inbox_id)?;
+        #[allow(deprecated)]
         eth_key.copy_from_slice(wallet.0.to_bytes().as_slice());
         Ok(Identity {
             inbox_id,

--- a/xmtp_mls/src/groups/device_sync_legacy.rs
+++ b/xmtp_mls/src/groups/device_sync_legacy.rs
@@ -8,6 +8,7 @@ use crate::context::XmtpSharedContext;
 use crate::subscriptions::SyncWorkerEvent;
 use crate::worker::metrics::WorkerMetrics;
 use crate::{Client, subscriptions::LocalEvents};
+#[allow(deprecated)]
 use aes_gcm::aead::generic_array::GenericArray;
 use aes_gcm::{
     Aes256Gcm,
@@ -346,7 +347,9 @@ where
         let (nonce, ciphertext) = payload.split_at(NONCE_SIZE);
 
         // Create a cipher instance
+        #[allow(deprecated)]
         let cipher = Aes256Gcm::new(GenericArray::from_slice(enc_key));
+        #[allow(deprecated)]
         let nonce_array = GenericArray::from_slice(nonce);
 
         // Decrypt the ciphertext
@@ -590,7 +593,9 @@ fn encrypt_syncables_with_key(
     let mut result = generate_nonce().to_vec();
 
     // create a cipher instance
+    #[allow(deprecated)]
     let cipher = Aes256Gcm::new(GenericArray::from_slice(enc_key_bytes));
+    #[allow(deprecated)]
     let nonce_array = GenericArray::from_slice(&result);
 
     // encrypt the payload and append to the result


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Update OpenMLS-related crates to latest git revision and bump `ctor` to 0.6.0 across cryptography, archive, debug, and MLS modules
Update dependency specifications and suppress deprecation warnings introduced by upstream crate changes. The manifest and lockfile reflect version bumps and new git revisions for OpenMLS-related crates, and code paths that construct `Aes256Gcm` ciphers and `GenericArray` nonces add `#[allow(deprecated)]` to build cleanly with the updated dependencies.

- Bump `ctor` from 0.5.0/0.5 to 0.6.0 and update `ed25519-dalek` from 2.1.1 to 2.2 in [Cargo.toml](https://github.com/xmtp/libxmtp/pull/2627/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542); update OpenMLS crates to git revision `51f800df...` and regenerate [Cargo.lock](https://github.com/xmtp/libxmtp/pull/2627/files#diff-13ee4b2252c9e516a0547f2891aa2105c3ca71c6d7a1e682c69be97998dfc87e)
- Add `#[allow(deprecated)]` around `Aes256Gcm::new` and `GenericArray` nonce initialization in `xmtp_archive` importer/exporter and `xmtp_mls` device sync code
- Add `#[allow(deprecated)]` on `xmtp_cryptography` SHA-256 helper and `xmtp_debug` wallet and identity conversions

#### 📍Where to Start
Start with dependency updates in [Cargo.toml](https://github.com/xmtp/libxmtp/pull/2627/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542), then review deprecation suppressions beginning at `xmtp_archive::ArchiveExporter::new` in [xmtp_archive/src/exporter.rs](https://github.com/xmtp/libxmtp/pull/2627/files#diff-c899c9f156611fda78b570f021f76ebc24773dc399c18d8ce4b3265c128a8b84) and `xmtp_archive::ArchiveImporter::load` in [xmtp_archive/src/importer.rs](https://github.com/xmtp/libxmtp/pull/2627/files#diff-0e79c2974c3ca5b8fb5e966441719563b12265320b65b3d447aa7876613beb90).

----



<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 9e12e14. 5 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
No issues evaluated.


</details>
<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->