### PR TITLE
Fix IsConnectedCheck for MultiNodeClient

### DIFF
--- a/xmtp_api_d14n/src/middleware/multi_node_client/client.rs
+++ b/xmtp_api_d14n/src/middleware/multi_node_client/client.rs
@@ -70,7 +70,7 @@ impl Client for MultiNodeClient {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl IsConnectedCheck for MultiNodeClient {
     async fn is_connected(&self) -> bool {
-        self.gateway_client.is_connected().await && self.inner.get().unwrap().is_connected().await
+        self.gateway_client.is_connected().await
     }
 }
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Fix `MultiNodeClient.IsConnectedCheck.is_connected` to report connectivity based solely on `gateway_client.is_connected()` in [client.rs](https://github.com/xmtp/libxmtp/pull/2630/files#diff-5582cac2865f86ae193e821dea1243bc37b7b30a8311fa92004dc6d39577ec1c)
Update the connectivity check in `MultiNodeClient.IsConnectedCheck.is_connected` to return the result of `gateway_client.is_connected()` and remove the call to `inner.get().unwrap().is_connected().await` in [client.rs](https://github.com/xmtp/libxmtp/pull/2630/files#diff-5582cac2865f86ae193e821dea1243bc37b7b30a8311fa92004dc6d39577ec1c). This change eliminates the `unwrap` on `inner` and restricts the check to the gateway client.

#### 📍Where to Start
Start with the `is_connected` method inside `MultiNodeClient.IsConnectedCheck` in [client.rs](https://github.com/xmtp/libxmtp/pull/2630/files#diff-5582cac2865f86ae193e821dea1243bc37b7b30a8311fa92004dc6d39577ec1c).

----

<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 5c4bfe1. 1 files reviewed, 2 issues evaluated, 2 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>xmtp_api_d14n/src/middleware/multi_node_client/client.rs — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 73](https://github.com/xmtp/libxmtp/blob/5c4bfe1804b3bc5de5e3b8b27165e398a04a18ad/xmtp_api_d14n/src/middleware/multi_node_client/client.rs#L73): The `IsConnectedCheck` implementation for `MultiNodeClient` was changed to return only `self.gateway_client.is_connected().await`. Previously it required both `gateway_client` and the inner client (`self.inner.get().unwrap().is_connected().await`) to be connected. This weakens the connectivity invariant and can return `true` when the gateway is connected but the inner client is disconnected or missing, leading to false positives and allowing downstream operations to proceed under an incorrect assumption of full connectivity. <b>[ Low confidence ]</b>
- [line 73](https://github.com/xmtp/libxmtp/blob/5c4bfe1804b3bc5de5e3b8b27165e398a04a18ad/xmtp_api_d14n/src/middleware/multi_node_client/client.rs#L73): By removing `self.inner.get().unwrap().is_connected().await`, the code no longer enforces the prior invariant that `self.inner.get()` must be `Some`. Previously, an unexpected `None` would panic immediately, signaling a deployment-invalid state pre-effect. Now, `is_connected()` can return the gateway's status even if the inner client is `None`, silently masking misconfiguration and allowing later operations to fail deeper in the call chain. This degrades failure visibility and may cause inconsistent health reporting. <b>[ Low confidence ]</b>
</details>


</details>
<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->