### PR TITLE
add streams to xmtp-debug

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -26,7 +26,7 @@ filter = 'test(/\btest_can_stream_group_messages_for_updates/)'
 retries = 3
 
 [profile.ci-d14n]
-default-filter = "not (test(/\\w*commit_log*/)|test(case_2_onehundred_dms)|test(rapidfire_duplicate_create)|test(test_can_sync_all_groups)|test(test_static_revoke_fails_with_non_recovery_identity)|test(test_stream_consent)|test(test_sync_100_allowed_groups_performance)|test(test_stream_all_dm_messages))"
+default-filter = "not (test(/\\w*commit_log*/)|test(case_2_onehundred_dms)|test(case_1_five_dms)|test(rapidfire_duplicate_create)|test(test_can_sync_all_groups)|test(test_static_revoke_fails_with_non_recovery_identity)|test(test_stream_consent)|test(test_sync_100_allowed_groups_performance)|test(test_stream_all_dm_messages))"
 status-level = "skip"
 failure-output = "immediate-final"
 fail-fast = false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,9 +69,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "1.0.30"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e2a5d689ccd182f1d138a61f081841b905034e0089f5278f6c200f2bcdab00a"
+checksum = "ae62e633fa48b4190af5e841eb05179841bb8b713945103291e2c0867037c0d1"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -103,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.0.30"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d213580c17d239ae83c0d897ac3315db7cda83d2d4936a9823cc3517552f2e24"
+checksum = "b9b151e38e42f1586a01369ec52a6934702731d07e8509a7307331b09f6c46dc"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -122,15 +122,16 @@ dependencies = [
  "rand 0.8.5",
  "secp256k1",
  "serde",
+ "serde_json",
  "serde_with",
  "thiserror 2.0.16",
 ]
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.0.30"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81443e3b8dccfeac7cd511aced15928c97ff253f4177acbb97de97178e543f6c"
+checksum = "6e2d5e8668ef6215efdb7dcca6f22277b4e483a5650e05f5de22b2350971f4b8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -142,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.0.30"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de217ab604f1bcfa2e3b0aff86d50812d5931d47522f9f0a949cc263ec2d108e"
+checksum = "630288cf4f3a34a8c6bc75c03dce1dbd47833138f65f37d53a1661eafc96b83f"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -228,9 +229,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.0.30"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a15b4b0f6bab47aae017d52bb5a739bda381553c09fb9918b7172721ef5f5de"
+checksum = "e5434834adaf64fa20a6fb90877bc1d33214c41b055cc49f82189c98614368cc"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -250,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.0.30"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ba1cbc25a07e0142e8875fcbe80e1fdb02be8160ae186b90f4b9a69a72ed2b"
+checksum = "919a8471cfbed7bcd8cf1197a57dda583ce0e10c6385f6ff4e8b41304b223392"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -288,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.0.30"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8882ec8e4542cfd02aadc6dccbe90caa73038f60016d936734eb6ced53d2167"
+checksum = "d7c69f6c9c68a1287c9d5ff903d0010726934de0dac10989be37b75a29190d55"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -303,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.0.30"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d6d87d588bda509881a7a66ae77c86514bd1193ac30fbff0e0f24db95eb5a5"
+checksum = "8eaf2ae05219e73e0979cb2cf55612aafbab191d130f203079805eaf881cca58"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -329,9 +330,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.0.30"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b14fa9ba5774e0b30ae6a04176d998211d516c8af69c9c530af7c6c42a8c508"
+checksum = "e58f4f345cef483eab7374f2b6056973c7419ffe8ad35e994b7a7f5d8e0c7ba4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -342,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-node-bindings"
-version = "1.0.30"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d82efad69266f38e1ef3c6fbfe2f86fa7aec3cf4726368a64914ff5f7a37a0d"
+checksum = "61321a0dbc084c2c9f2b07aa34f10db7ac80065c01721e567e5426d882c73de6"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks",
@@ -391,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.0.30"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "475a5141313c3665b75d818be97d5fa3eb5e0abb7e832e9767edd94746db28e3"
+checksum = "de2597751539b1cc8fe4204e5325f9a9ed83fcacfb212018dfcfa7877e76de21"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -454,9 +455,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.0.30"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25289674cd8c58fcca2568b5350423cb0dd7bca8c596c5e2869bfe4c5c57ed14"
+checksum = "edf8eb8be597cfa8c312934d2566ec4516f066d69164f9212d7a148979fdcfd8"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -477,9 +478,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.0.30"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39676beaa50db545cf15447fc94ec5513b64e85a48357a0625b9a04aef08a910"
+checksum = "339af7336571dd39ae3a15bde08ae6a647e62f75350bd415832640268af92c06"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-anvil",
@@ -490,9 +491,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.0.30"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c8cad42fa936000be72ab80fcd97386a6a226c35c2989212756da9e76c1521"
+checksum = "83d98fb386a462e143f5efa64350860af39950c49e7c0cbdba419c16793116ef"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -502,9 +503,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.0.30"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01bac57c987c93773787619e20f89167db74d460a2d1d40f591d94fb7c22c379"
+checksum = "fbde0801a32d21c5f111f037bee7e22874836fba7add34ed4a6919932dd7cf23"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -513,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.0.30"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd1e1b4dcdf13eaa96343e5c0dafc2d2e8ce5d20b90347169d46a1df0dec210"
+checksum = "361cd87ead4ba7659bda8127902eda92d17fa7ceb18aba1676f7be10f7222487"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -525,7 +526,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -534,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.0.30"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1b3b1078b8775077525bc9fe9f6577e815ceaecd6c412a4f3b4d8aa2836e8f6"
+checksum = "64600fc6c312b7e0ba76f73a381059af044f4f21f43e07f51f1fa76c868fe302"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -545,9 +546,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.0.30"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10ab1b8d4649bf7d0db8ab04e31658a6cc20364d920795484d886c35bed3bab4"
+checksum = "5772858492b26f780468ae693405f895d6a27dea6e3eab2c36b6217de47c2647"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -560,9 +561,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.0.30"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bdeec36c8d9823102b571b3eab8b323e053dc19c12da14a9687bd474129bf2a"
+checksum = "f4195b803d0a992d8dbaab2ca1986fc86533d4bc80967c0cce7668b26ad99ef9"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -652,9 +653,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.0.30"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce5129146a76ca6139a19832c75ad408857a56bcd18cd2c684183b8eacd78d8"
+checksum = "025a940182bddaeb594c26fe3728525ae262d0806fe6a4befdf5d7bc13d54bce"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -676,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.0.30"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2379d998f46d422ec8ef2b61603bc28cda931e5e267aea1ebe71f62da61d101"
+checksum = "e3b5064d1e1e1aabc918b5954e7fb8154c39e77ec6903a581b973198b26628fa"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -707,9 +708,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.0.30"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b5becb9c269a7d05a2f28d549f86df5a5dbc923e2667eff84fdecac8cda534c"
+checksum = "f8e52276fdb553d3c11563afad2898f4085165e4093604afe3d78b69afbf408f"
 dependencies = [
  "alloy-primitives",
  "darling 0.21.3",
@@ -1692,7 +1693,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1949,6 +1950,27 @@ dependencies = [
  "generic-array",
  "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2275,7 +2297,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2444,7 +2466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2567,21 +2589,6 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -3246,22 +3253,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper 1.7.0",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3279,7 +3270,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -4061,17 +4052,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mini-internal"
-version = "0.1.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c74ab4f1a0c0ab045260ee4727b23c00cc17e5eff5095262d08eef8c3c8d49"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
 name = "minicov"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4086,17 +4066,6 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "miniserde"
-version = "0.1.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ec68bf2ad170a53a6efa92c3df7187968d6e475fe7a935725868154074ca0f"
-dependencies = [
- "itoa",
- "mini-internal",
- "ryu",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -4279,23 +4248,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "427802e8ec3a734331fec1035594a210ce1ff4dc5bc1950530920ab717964ea3"
 dependencies = [
  "libloading",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework 2.11.1",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -4567,32 +4519,6 @@ source = "git+https://github.com/xmtp/openmls?rev=51f800df4d56d74fb2dde993f33e32
 dependencies = [
  "serde",
  "tls_codec",
-]
-
-[[package]]
-name = "openssl"
-version = "0.10.73"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
-dependencies = [
- "bitflags 2.9.4",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
 ]
 
 [[package]]
@@ -5199,8 +5125,8 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "once_cell",
@@ -5222,7 +5148,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -5394,11 +5320,12 @@ dependencies = [
 
 [[package]]
 name = "redb"
-version = "2.6.3"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eca1e9d98d5a7e9002d0013e18d5a9b000aee942eb134883a82f06ebffb6c01"
+checksum = "ae323eb086579a3769daa2c753bb96deb95993c534711e0dbe881b5192906a06"
 dependencies = [
  "libc",
+ "log",
 ]
 
 [[package]]
@@ -5544,20 +5471,16 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.7.0",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
- "tokio-native-tls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -5770,7 +5693,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5797,7 +5720,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.4.0",
+ "security-framework",
 ]
 
 [[package]]
@@ -5965,19 +5888,6 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.9.4",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b369d18893388b345804dc0007963c99b7d665ae71d275812d828c6f089640"
@@ -6034,10 +5944,11 @@ checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -6062,10 +5973,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6522,7 +6442,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6736,16 +6656,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -7948,7 +7858,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -8316,20 +8226,23 @@ dependencies = [
  "color-eyre",
  "const-hex",
  "const_format",
+ "csv",
  "directories",
  "ecdsa",
  "fdlimit",
  "fs_extra",
+ "futures",
  "indicatif",
  "k256",
  "lipsum",
- "miniserde",
  "num_cpus",
  "openmls",
  "owo-colors",
  "prost",
  "rand 0.8.5",
  "redb",
+ "serde",
+ "serde_json",
  "speedy",
  "tempfile",
  "thiserror 2.0.16",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ version = "1.6.0-dev"
 
 [workspace.dependencies]
 aes-gcm = { version = "0.10.3", features = ["std"] }
-alloy = { version = "=1.0.30", default-features = false } # upgrading to 1.0.41 makes CI scw test take infinite time
+alloy = { version = "1.0", default-features = false }
 anyhow = "1.0"
 arc-swap = "1.7"
 async-compression = { default-features = false, version = "0.4", features = [

--- a/mls_validation_service/src/cached_signature_verifier.rs
+++ b/mls_validation_service/src/cached_signature_verifier.rs
@@ -66,22 +66,24 @@ mod tests {
     use alloy::primitives::{B256, U256};
     use alloy::providers::Provider;
     use alloy::signers::Signer;
+    use std::time::Duration;
     use xmtp_id::scw_verifier::{
         MultiSmartContractSignatureVerifier, SmartContractSignatureVerifier, ValidationResponse,
         VerifierError,
     };
-    use xmtp_id::utils::test::{SignatureWithNonce, SmartWalletContext, docker_smart_wallet};
+    use xmtp_id::utils::test::{SignatureWithNonce, SmartWalletContext, smart_wallet};
 
     #[rstest::rstest]
+    #[timeout(Duration::from_secs(60))]
     #[tokio::test]
-    async fn test_is_valid_signature(#[future] docker_smart_wallet: SmartWalletContext) {
+    async fn test_is_valid_signature(#[future] smart_wallet: SmartWalletContext) {
         let SmartWalletContext {
             factory,
             owner0: owner,
             sw,
             sw_address,
             ..
-        } = docker_smart_wallet.await;
+        } = smart_wallet.await;
         let chain_id = factory.provider().get_chain_id().await.unwrap();
         let hash = B256::random();
         let replay_safe_hash = sw.replaySafeHash(hash).call().await.unwrap();

--- a/mls_validation_service/src/handlers.rs
+++ b/mls_validation_service/src/handlers.rs
@@ -315,13 +315,14 @@ mod tests {
     use xmtp_common::{rand_string, rand_u64};
     use xmtp_configuration::CIPHERSUITE;
     use xmtp_cryptography::XmtpInstallationCredential;
+    use xmtp_id::utils::test::smart_wallet;
     use xmtp_id::{
         associations::{
             Identifier,
             test_utils::{MockSmartContractSignatureVerifier, WalletTestExt},
             unverified::{UnverifiedAction, UnverifiedIdentityUpdate},
         },
-        utils::test::{SignatureWithNonce, SmartWalletContext, docker_smart_wallet},
+        utils::test::{SignatureWithNonce, SmartWalletContext},
     };
     use xmtp_proto::xmtp::{
         identity::{
@@ -487,14 +488,14 @@ mod tests {
     #[rstest::rstest]
     #[timeout(std::time::Duration::from_secs(30))]
     #[tokio::test]
-    async fn test_validate_scw(#[future] docker_smart_wallet: SmartWalletContext) {
+    async fn test_validate_scw(#[future] smart_wallet: SmartWalletContext) {
         let SmartWalletContext {
             owner0: wallet,
             factory,
             sw,
             sw_address,
             ..
-        } = docker_smart_wallet.await;
+        } = smart_wallet.await;
 
         let provider = factory.provider();
         let chain_id = provider.get_chain_id().await.unwrap();

--- a/xmtp_debug/Cargo.toml
+++ b/xmtp_debug/Cargo.toml
@@ -18,21 +18,24 @@ clap = { version = "4.5.20", features = ["derive"] }
 clap-verbosity-flag = "3.0"
 color-eyre.workspace = true
 const_format.workspace = true
+csv = "1.4"
 directories = "6.0"
 ecdsa = "0.16"
 fdlimit.workspace = true
 fs_extra = "1.3"
+futures.workspace = true
 hex.workspace = true
 indicatif = "0.18"
 k256 = "0.13"
 lipsum = "0.9"
-miniserde = "0.1"
 num_cpus = "1.16.0"
 openmls.workspace = true
 owo-colors.workspace = true
 prost.workspace = true
 rand = { workspace = true, features = ["small_rng"] }
-redb = "2.6"
+redb = { version = "3.1", features = ["logging"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = "1.0"
 speedy = "0.8"
 tempfile = "3.15"
 thiserror.workspace = true

--- a/xmtp_debug/src/app/clients.rs
+++ b/xmtp_debug/src/app/clients.rs
@@ -42,6 +42,7 @@ pub async fn temp_client(
     .await
 }
 
+/// Get the XMTP Client from an [`Identity`]
 pub async fn client_from_identity(
     identity: &Identity,
     network: &args::BackendOpts,

--- a/xmtp_debug/src/app/generate.rs
+++ b/xmtp_debug/src/app/generate.rs
@@ -1,6 +1,4 @@
-use std::sync::Arc;
-
-use crate::args;
+use crate::{app::App, args};
 mod groups;
 mod identity;
 mod messages;
@@ -13,31 +11,32 @@ use color_eyre::eyre::Result;
 
 #[derive(Debug)]
 pub struct Generate {
-    db: Arc<redb::Database>,
     opts: args::Generate,
     network: args::BackendOpts,
 }
 
 impl Generate {
-    pub fn new(opts: args::Generate, network: args::BackendOpts, db: Arc<redb::Database>) -> Self {
-        Self { opts, network, db }
+    pub fn new(opts: args::Generate, network: args::BackendOpts) -> Self {
+        Self { opts, network }
     }
 
     pub async fn run(self) -> Result<()> {
         use args::EntityKind::*;
-        let Generate { db, opts, network } = self;
+        let Generate { opts, network } = self;
         let args::Generate {
             entity,
             amount,
             invite,
             message_opts,
             concurrency,
+            ..
         } = opts;
 
         info!(?concurrency, "using concurrency");
 
         match entity {
             Group => {
+                let db = App::db()?;
                 GenerateGroups::new(db, network)
                     .create_groups(amount, invite.unwrap_or(0), *concurrency)
                     .await?;
@@ -45,13 +44,14 @@ impl Generate {
                 Ok(())
             }
             Message => {
-                GenerateMessages::new(db, network, message_opts)
+                GenerateMessages::new(network, message_opts)?
                     .run(amount, *concurrency)
                     .await?;
                 info!("messages generated");
                 Ok(())
             }
             Identity => {
+                let db = App::db()?;
                 GenerateIdentity::new(db.into(), network)
                     .create_identities(amount, *concurrency)
                     .await?;

--- a/xmtp_debug/src/app/generate/groups.rs
+++ b/xmtp_debug/src/app/generate/groups.rs
@@ -12,7 +12,6 @@ use std::sync::Arc;
 pub struct GenerateGroups {
     group_store: GroupStore<'static>,
     identity_store: IdentityStore<'static>,
-    // metadata_store: MetadataStore<'static>,
     network: args::BackendOpts,
 }
 

--- a/xmtp_debug/src/app/generate/messages.rs
+++ b/xmtp_debug/src/app/generate/messages.rs
@@ -1,8 +1,9 @@
+use crate::app::App;
 use crate::app::identity_lock::get_identity_lock;
 use crate::{
     app::{
         self,
-        store::{Database, GroupStore, IdentityStore, MetadataStore, RandomDatabase},
+        store::{Database, GroupStore, IdentityStore, RandomDatabase},
     },
     args,
 };
@@ -32,18 +33,24 @@ enum MessageSendError {
 }
 
 pub struct GenerateMessages {
-    db: Arc<redb::Database>,
     network: args::BackendOpts,
     opts: args::MessageGenerateOpts,
+    identity_store: IdentityStore<'static>,
+    group_store: GroupStore<'static>,
 }
 
 impl GenerateMessages {
-    pub fn new(
-        db: Arc<redb::Database>,
-        network: args::BackendOpts,
-        opts: args::MessageGenerateOpts,
-    ) -> Self {
-        Self { db, network, opts }
+    pub fn new(network: args::BackendOpts, opts: args::MessageGenerateOpts) -> Result<Self> {
+        let (identity_store, group_store) = {
+            let db = App::readonly_db()?;
+            (db.clone().into(), db.into())
+        };
+        Ok(Self {
+            network,
+            opts,
+            identity_store,
+            group_store,
+        })
     }
 
     pub async fn run(self, n: usize, concurrency: usize) -> Result<()> {
@@ -52,26 +59,19 @@ impl GenerateMessages {
             r#loop, interval, ..
         } = self.opts;
 
-        self.send_many_messages(self.db.clone(), n, concurrency)
-            .await?;
+        self.send_many_messages(n, concurrency).await?;
 
         if r#loop {
             loop {
                 info!(time = ?std::time::Instant::now(), amount = n, "sending messages");
                 tokio::time::sleep(*interval).await;
-                self.send_many_messages(self.db.clone(), n, concurrency)
-                    .await?;
+                self.send_many_messages(n, concurrency).await?;
             }
         }
         Ok(())
     }
 
-    async fn send_many_messages(
-        &self,
-        db: Arc<redb::Database>,
-        n: usize,
-        concurrency: usize,
-    ) -> Result<usize> {
+    async fn send_many_messages(&self, n: usize, concurrency: usize) -> Result<usize> {
         let Self { network, opts, .. } = self;
 
         let style = ProgressStyle::with_template(
@@ -82,15 +82,16 @@ impl GenerateMessages {
         let semaphore = Arc::new(tokio::sync::Semaphore::new(concurrency));
 
         let mut set: tokio::task::JoinSet<Result<(), eyre::Error>> = tokio::task::JoinSet::new();
+        let stores = (self.identity_store.clone(), self.group_store.clone());
         for _ in 0..n {
             let bar_pointer = bar.clone();
-            let d = db.clone();
             let n = network.clone();
             let opts = opts.clone();
+            let (identity, group) = stores.clone();
             let semaphore = semaphore.clone();
             set.spawn(async move {
                 let _permit = semaphore.acquire().await?;
-                Self::send_message(&d.clone().into(), &d.clone().into(), n, opts).await?;
+                Self::send_message(&group, &identity, n, opts).await?;
                 bar_pointer.inc(1);
                 Ok(())
             });
@@ -115,11 +116,6 @@ impl GenerateMessages {
             .into_iter()
             .filter(|r| r.is_ok())
             .collect::<Vec<Result<_, _>>>();
-        let key = crate::meta_key!(network);
-        let meta_db: MetadataStore = db.into();
-        meta_db.modify(key, |meta| {
-            meta.messages += msgs_sent.len() as u32;
-        })?;
         Ok(msgs_sent.len())
     }
 

--- a/xmtp_debug/src/app/info.rs
+++ b/xmtp_debug/src/app/info.rs
@@ -1,8 +1,8 @@
 //! Get information about xdbg storage
 
+use crate::app::App;
 use crate::app::store::{Database, MetadataStore};
 use crate::args;
-use std::sync::Arc;
 use valuable::Valuable;
 
 use color_eyre::eyre::Result;
@@ -14,12 +14,13 @@ pub struct Info {
 }
 
 impl Info {
-    pub fn new(opts: args::InfoOpts, network: args::BackendOpts, db: Arc<redb::Database>) -> Self {
-        Self {
+    pub fn new(opts: args::InfoOpts, network: args::BackendOpts) -> Result<Self> {
+        let db = App::readonly_db()?;
+        Ok(Self {
             opts,
             network,
             metadata_store: db.into(),
-        }
+        })
     }
 
     pub async fn run(self) -> Result<()> {
@@ -50,7 +51,7 @@ impl Info {
         info!(
             metadata.identities,
             metadata.groups,
-            metadata.messages,
+            // metadata.messages,
             project = crate::app::App::data_directory()?.as_value(),
             sqlite = sqlite_stores.as_value(),
             sqlite_size = %format!("{db_dir_size}MB"),

--- a/xmtp_debug/src/app/inspect.rs
+++ b/xmtp_debug/src/app/inspect.rs
@@ -3,20 +3,23 @@ use std::sync::Arc;
 use valuable::Valuable;
 
 use crate::{
-    app,
-    app::store::{Database, IdentityStore},
+    app::{
+        self, App,
+        store::{Database, IdentityStore},
+    },
     args,
 };
 
 pub struct Inspect {
-    db: Arc<redb::Database>,
+    db: Arc<redb::ReadOnlyDatabase>,
     opts: args::Inspect,
     network: args::BackendOpts,
 }
 
 impl Inspect {
-    pub fn new(opts: args::Inspect, network: args::BackendOpts, db: Arc<redb::Database>) -> Self {
-        Self { opts, network, db }
+    pub fn new(opts: args::Inspect, network: args::BackendOpts) -> Result<Self> {
+        let db = App::readonly_db()?;
+        Ok(Self { opts, network, db })
     }
 
     pub async fn run(self) -> Result<()> {

--- a/xmtp_debug/src/app/modify.rs
+++ b/xmtp_debug/src/app/modify.rs
@@ -5,7 +5,7 @@ use xmtp_mls::groups::UpdateAdminListType;
 
 use crate::{
     app::{
-        self,
+        self, App,
         store::{Database, GroupStore, IdentityStore},
     },
     args,
@@ -18,8 +18,9 @@ pub struct Modify {
 }
 
 impl Modify {
-    pub fn new(opts: args::Modify, network: args::BackendOpts, db: Arc<redb::Database>) -> Self {
-        Self { opts, network, db }
+    pub fn new(opts: args::Modify, network: args::BackendOpts) -> Result<Self> {
+        let db = App::db()?;
+        Ok(Self { opts, network, db })
     }
 
     pub async fn run(self) -> Result<()> {

--- a/xmtp_debug/src/app/query.rs
+++ b/xmtp_debug/src/app/query.rs
@@ -1,23 +1,17 @@
 use crate::args;
 use color_eyre::eyre::Result;
-use std::{collections::HashSet, sync::Arc};
+use std::collections::HashSet;
 use xmtp_mls::context::XmtpSharedContext;
 
 pub struct Query {
     opts: args::Query,
     #[allow(unused)]
     network: args::BackendOpts,
-    #[allow(unused)]
-    store: Arc<redb::Database>,
 }
 
 impl Query {
-    pub fn new(opts: args::Query, network: args::BackendOpts, store: Arc<redb::Database>) -> Self {
-        Self {
-            opts,
-            network,
-            store,
-        }
+    pub fn new(opts: args::Query, network: args::BackendOpts) -> Result<Self> {
+        Ok(Self { opts, network })
     }
 
     pub async fn run(self) -> Result<()> {

--- a/xmtp_debug/src/app/send.rs
+++ b/xmtp_debug/src/app/send.rs
@@ -1,22 +1,22 @@
 use std::sync::Arc;
 
-use crate::args;
+use crate::{app::App, args};
 use color_eyre::eyre::{Result, eyre};
 use rand::prelude::*;
 use xmtp_mls::groups::send_message_opts::SendMessageOptsBuilder;
 
 use super::store::{Database, GroupStore, IdentityStore};
 
-#[derive(Debug)]
 pub struct Send {
-    db: Arc<redb::Database>,
+    db: Arc<redb::ReadOnlyDatabase>,
     opts: args::Send,
     network: args::BackendOpts,
 }
 
 impl Send {
-    pub fn new(opts: args::Send, network: args::BackendOpts, db: Arc<redb::Database>) -> Self {
-        Self { opts, network, db }
+    pub fn new(opts: args::Send, network: args::BackendOpts) -> Result<Self> {
+        let db = App::readonly_db()?;
+        Ok(Self { opts, network, db })
     }
 
     pub async fn run(self) -> Result<()> {

--- a/xmtp_debug/src/app/store/groups.rs
+++ b/xmtp_debug/src/app/store/groups.rs
@@ -45,7 +45,16 @@ impl From<Arc<redb::Database>> for GroupStore<'_> {
     }
 }
 
-#[derive(Debug)]
+impl From<Arc<redb::ReadOnlyDatabase>> for GroupStore<'_> {
+    fn from(value: Arc<redb::ReadOnlyDatabase>) -> Self {
+        GroupStore {
+            db: super::DatabaseOrTransaction::ReadOnly(value),
+            store: GroupStorage,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct GroupStorage;
 
 impl<'a> super::TableProvider<'a, GroupKey, Group> for GroupStorage {

--- a/xmtp_debug/src/app/store/identity.rs
+++ b/xmtp_debug/src/app/store/identity.rs
@@ -15,10 +15,19 @@ const TABLE: TableDefinition<IdentityKey, Identity> = TableDefinition::new(NAMES
 pub type IdentityKey = super::NetworkKey<32>;
 pub type IdentityStore<'a> = super::KeyValueStore<'a, IdentityStorage>;
 
-impl From<Arc<redb::Database>> for IdentityStore<'static> {
+impl From<Arc<redb::Database>> for IdentityStore<'_> {
     fn from(value: Arc<redb::Database>) -> Self {
         IdentityStore {
             db: super::DatabaseOrTransaction::Db(value),
+            store: IdentityStorage,
+        }
+    }
+}
+
+impl From<Arc<redb::ReadOnlyDatabase>> for IdentityStore<'_> {
+    fn from(value: Arc<redb::ReadOnlyDatabase>) -> Self {
+        IdentityStore {
+            db: super::DatabaseOrTransaction::ReadOnly(value),
             store: IdentityStorage,
         }
     }
@@ -42,7 +51,7 @@ impl super::DeriveKey<IdentityKey> for &Identity {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct IdentityStorage;
 
 impl<'a> super::TableProvider<'a, IdentityKey, Identity> for IdentityStorage {

--- a/xmtp_debug/src/app/store/metadata.rs
+++ b/xmtp_debug/src/app/store/metadata.rs
@@ -113,3 +113,12 @@ impl From<Arc<redb::Database>> for MetadataStore<'static> {
         }
     }
 }
+
+impl From<Arc<redb::ReadOnlyDatabase>> for MetadataStore<'static> {
+    fn from(value: Arc<redb::ReadOnlyDatabase>) -> Self {
+        MetadataStore {
+            db: super::DatabaseOrTransaction::ReadOnly(value),
+            store: MetadataStorage,
+        }
+    }
+}

--- a/xmtp_debug/src/app/stream.rs
+++ b/xmtp_debug/src/app/stream.rs
@@ -1,0 +1,153 @@
+use color_eyre::eyre::{Result, bail, eyre};
+use futures::stream::StreamExt;
+use rand::{SeedableRng as _, rngs::SmallRng, seq::IteratorRandom};
+use serde::Serialize;
+use std::{fs, io::Write, sync::Arc};
+use xmtp_db::group::StoredGroup;
+
+use crate::{
+    app::{
+        self, App,
+        store::{Database, IdentityStore},
+    },
+    args::{self, FormatKind, StreamOpts},
+};
+
+pub struct Stream {
+    db: Arc<redb::ReadOnlyDatabase>,
+    opts: args::StreamOpts,
+    network: args::BackendOpts,
+}
+
+impl Stream {
+    pub fn new(opts: StreamOpts, network: args::BackendOpts) -> Result<Self> {
+        let db = App::readonly_db()?;
+        Ok(Self { opts, network, db })
+    }
+
+    pub async fn run(self) -> Result<()> {
+        let Stream { db, opts, network } = self;
+        let identity_store: IdentityStore = db.clone().into();
+        let args::StreamOpts {
+            inbox,
+            ref kind,
+            out,
+            format,
+        } = opts;
+        let rng = &mut SmallRng::from_entropy();
+        let identity = if let Some(inbox_id) = inbox {
+            let key = (u64::from(&network), *inbox_id);
+            let identity = identity_store.get(key.into())?;
+            if identity.is_none() {
+                bail!("No local identity with inbox_id=[{}]", inbox_id);
+            }
+            identity.expect("checked for some")
+        } else {
+            identity_store
+                .load(&network)?
+                .ok_or(eyre!("No identitites in store"))?
+                .map(|i| i.value())
+                .choose(rng)
+                .ok_or(eyre!("Identity not found"))?
+        };
+        let client = app::client_from_identity(&identity, &network).await?;
+
+        let mut buffer: Box<dyn Write> = if let Some(p) = out {
+            Box::new(fs::File::create(p)?)
+        } else {
+            Box::new(std::io::stdout())
+        };
+
+        match kind {
+            args::StreamKind::Conversations => {
+                let s = client.stream_conversations(None, false).await?;
+                tokio::pin!(s);
+                while let Some(Ok(group)) = s.as_mut().next().await {
+                    let stored: StoredGroup = group.load()?;
+                    let item = Conversation {
+                        group_id: hex::encode(&stored.id),
+                        dm_id: stored.dm_id.unwrap_or("".to_string()),
+                        conversation_type: stored.conversation_type as i32,
+                        created_at: stored.created_at_ns,
+                        maybe_forked: stored.maybe_forked,
+                        fork_details: stored.fork_details,
+                        sequence_id: stored.sequence_id.unwrap_or(0),
+                        originator_id: stored.originator_id.unwrap_or(0),
+                        added_by: stored.added_by_inbox_id,
+                        group_name: group.group_name()?,
+                        group_description: group.group_description()?,
+                    };
+                    write(&format, buffer.as_mut(), &item)?;
+                }
+            }
+            args::StreamKind::Messages => {
+                let s = client.stream_all_messages(None, None).await?;
+                tokio::pin!(s);
+                while let Some(Ok(message)) = s.as_mut().next().await {
+                    let item = Message {
+                        contents: String::from_utf8_lossy(&message.decrypted_message_bytes)
+                            .to_string(),
+                        sender: message.sender_inbox_id,
+                        receiver: hex::encode(identity.inbox_id),
+                        timestamp: message.sent_at_ns,
+                        sequence_id: message.sequence_id,
+                        originator_id: message.originator_id,
+                        group_id: hex::encode(&message.group_id),
+                        expire_at: message.expire_at_ns.unwrap_or(0),
+                        content_type: message.content_type as i32,
+                        version_major: message.version_major,
+                        version_minor: message.version_minor,
+                        authority_id: message.authority_id,
+                    };
+                    write(&format, buffer.as_mut(), &item)?;
+                }
+            }
+        };
+        Ok(())
+    }
+}
+
+fn write(format: &FormatKind, writer: &mut dyn Write, s: &impl Serialize) -> Result<()> {
+    use FormatKind::*;
+    match format {
+        Json => {
+            serde_json::to_writer(writer, s)?;
+        }
+        Csv => {
+            let mut csv_writer = csv::Writer::from_writer(writer);
+            csv_writer.serialize(s)?;
+        }
+    }
+    Ok(())
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct Conversation {
+    group_id: String,
+    dm_id: String,
+    conversation_type: i32,
+    created_at: i64,
+    maybe_forked: bool,
+    fork_details: String,
+    sequence_id: i64,
+    originator_id: i64,
+    added_by: String,
+    group_name: String,
+    group_description: String,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct Message {
+    contents: String,
+    sender: String,
+    receiver: String,
+    timestamp: i64,
+    sequence_id: i64,
+    originator_id: i64,
+    group_id: String,
+    expire_at: i64,
+    content_type: i32,
+    version_major: i32,
+    version_minor: i32,
+    authority_id: String,
+}

--- a/xmtp_debug/src/args.rs
+++ b/xmtp_debug/src/args.rs
@@ -36,6 +36,7 @@ pub enum Commands {
     Query(Query),
     Info(InfoOpts),
     Export(ExportOpts),
+    Stream(StreamOpts),
 }
 
 /// Send Data on the network
@@ -174,6 +175,43 @@ pub struct ExportOpts {
     /// File to write to
     #[arg(long, short)]
     pub out: Option<PathBuf>,
+}
+
+/// Stream messages and conversations
+#[derive(Args, Debug)]
+pub struct StreamOpts {
+    /// Indicate the Inbox to stream messages from.
+    /// Defaults to a randomly chosen identity
+    #[arg(long, short)]
+    pub inbox: Option<InboxId>,
+    /// Indicate the kind of stream.
+    #[arg(long, short)]
+    pub kind: StreamKind,
+    /// Indicate format that should be used.
+    #[arg(long, short)]
+    pub format: FormatKind,
+    /// optionally indicate a file to write to.
+    /// Defaults to stdout
+    #[arg(long, short)]
+    pub out: Option<PathBuf>,
+}
+
+#[derive(ValueEnum, Debug, Default, Clone, Copy)]
+pub enum FormatKind {
+    /// output in a JSON Format
+    Json,
+    /// output in a CSV Format
+    #[default]
+    Csv,
+}
+
+#[derive(ValueEnum, Debug, Default, Clone, Copy)]
+pub enum StreamKind {
+    /// Stream only new conversations for this inbox id
+    Conversations,
+    /// Stream only messages for this inbox id
+    #[default]
+    Messages,
 }
 
 #[derive(ValueEnum, Debug, Clone)]

--- a/xmtp_debug/src/args/types.rs
+++ b/xmtp_debug/src/args/types.rs
@@ -1,5 +1,7 @@
 use std::time::Duration;
 
+use color_eyre::eyre::ensure;
+
 #[derive(Debug, Clone)]
 pub struct InboxId([u8; 32]);
 
@@ -27,7 +29,7 @@ impl std::str::FromStr for InboxId {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct GroupId([u8; 16]);
 
 impl std::fmt::Display for GroupId {
@@ -51,6 +53,17 @@ impl std::str::FromStr for GroupId {
         let mut slice = [0u8; 16];
         hex::decode_to_slice(s, &mut slice)?;
         Ok(GroupId(slice))
+    }
+}
+
+impl TryFrom<Vec<u8>> for GroupId {
+    type Error = color_eyre::eyre::Error;
+
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        ensure!(value.len() == 16, "a group id must be 16 bytes long");
+        let mut id = [0u8; 16];
+        id.copy_from_slice(value.as_slice());
+        Ok(GroupId(id))
     }
 }
 

--- a/xmtp_debug/src/traits.rs
+++ b/xmtp_debug/src/traits.rs
@@ -1,0 +1,14 @@
+pub trait IsReadOnly {
+    fn is_read_only(&self) -> bool;
+}
+
+impl<T> IsReadOnly for Option<T>
+where
+    T: IsReadOnly,
+{
+    fn is_read_only(&self) -> bool {
+        if let Some(ref v) = self {
+            v.is_read_only()
+        }
+    }
+}

--- a/xmtp_id/src/scw_verifier/chain_rpc_verifier.rs
+++ b/xmtp_id/src/scw_verifier/chain_rpc_verifier.rs
@@ -101,25 +101,26 @@ impl SmartContractSignatureVerifier for RpcSmartContractWalletVerifier {
 #[cfg(all(test, not(target_arch = "wasm32")))]
 pub(crate) mod tests {
     #![allow(clippy::unwrap_used)]
-    use crate::utils::test::{SignatureWithNonce, SmartWalletContext, docker_smart_wallet};
+    use crate::utils::test::{SignatureWithNonce, SmartWalletContext, smart_wallet};
 
     use super::*;
     use alloy::dyn_abi::SolType;
     use alloy::primitives::{B256, U256};
     use alloy::providers::ext::AnvilApi;
     use alloy::signers::Signer;
+    use std::time::Duration;
 
     #[rstest::rstest]
-    #[timeout(std::time::Duration::from_secs(30))]
+    #[timeout(Duration::from_secs(30))]
     #[tokio::test]
-    async fn test_coinbase_smart_wallet(#[future] docker_smart_wallet: SmartWalletContext) {
+    async fn test_coinbase_smart_wallet(#[future] smart_wallet: SmartWalletContext) {
         let SmartWalletContext {
             factory,
             sw,
             owner0,
             owner1,
             sw_address,
-        } = docker_smart_wallet.await;
+        } = smart_wallet.await;
         let provider = factory.provider();
         let chain_id = provider.get_chain_id().await.unwrap();
         let hash = B256::random();
@@ -169,15 +170,16 @@ pub(crate) mod tests {
     }
 
     #[rstest::rstest]
+    #[timeout(Duration::from_secs(60))]
     #[tokio::test]
-    async fn test_smart_wallet_time_travel(#[future] docker_smart_wallet: SmartWalletContext) {
+    async fn test_smart_wallet_time_travel(#[future] smart_wallet: SmartWalletContext) {
         let SmartWalletContext {
             factory,
             sw,
             owner1,
             sw_address,
             ..
-        } = docker_smart_wallet.await;
+        } = smart_wallet.await;
 
         let provider = factory.provider();
         let verifier = RpcSmartContractWalletVerifier::new_from_provider(provider.clone());
@@ -227,15 +229,16 @@ pub(crate) mod tests {
 
     // Testing ERC-6492 with deployed / undeployed coinbase smart wallet(ERC-1271) contracts, and EOA.
     #[rstest::rstest]
+    #[timeout(Duration::from_secs(60))]
     #[tokio::test]
-    async fn test_is_valid_signature(#[future] docker_smart_wallet: SmartWalletContext) {
+    async fn test_is_valid_signature(#[future] smart_wallet: SmartWalletContext) {
         let SmartWalletContext {
             factory,
             sw,
             owner0: owner,
             sw_address,
             ..
-        } = docker_smart_wallet.await;
+        } = smart_wallet.await;
         let provider = factory.provider();
         let chain_id = provider.get_chain_id().await.unwrap();
         let hash = B256::random();

--- a/xmtp_id/src/utils/test.rs
+++ b/xmtp_id/src/utils/test.rs
@@ -55,6 +55,8 @@ pub async fn docker_smart_wallet(
 
 #[cfg(not(target_arch = "wasm32"))]
 async fn deploy_wallets(provider: EthereumProvider) -> SmartWalletContext {
+    use std::time::Duration;
+
     let EthereumProvider {
         provider,
         owner0,
@@ -79,6 +81,8 @@ async fn deploy_wallets(provider: EthereumProvider) -> SmartWalletContext {
         .send()
         .await
         .unwrap()
+        .with_required_confirmations(1)
+        .with_timeout(Some(Duration::from_secs(30)))
         .watch()
         .await
         .unwrap();

--- a/xmtp_mls/Cargo.toml
+++ b/xmtp_mls/Cargo.toml
@@ -73,7 +73,7 @@ pin-project-lite.workspace = true
 prost = { workspace = true, features = ["derive"] }
 rand = { workspace = true }
 reqwest = { workspace = true }
-serde = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 sha2.workspace = true
 thiserror = { workspace = true }

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -768,6 +768,17 @@ where
         Ok(latest_read_receipt)
     }
 
+    /// Load the group reference stored in the local database
+    pub fn load(&self) -> Result<StoredGroup, StorageError> {
+        let conn = self.context.db();
+        if let Some(group) = conn.find_group(&self.group_id)? {
+            Ok(group)
+        } else {
+            tracing::error!("group {} does not exist", hex::encode(&self.group_id));
+            Err(NotFound::GroupById(self.group_id.to_vec()).into())
+        }
+    }
+
     ///
     /// Add members to the group by account address
     ///

--- a/xmtp_mls/src/test/builder_native_only.rs
+++ b/xmtp_mls/src/test/builder_native_only.rs
@@ -1,6 +1,7 @@
 use crate::builder::ClientBuilder;
 use crate::{client::Client, identity::IdentityStrategy};
 use alloy::{dyn_abi::SolType, primitives::U256, providers::Provider, signers::Signer};
+use std::time::Duration;
 use xmtp_cryptography::utils::generate_local_wallet;
 use xmtp_id::associations::Identifier;
 use xmtp_id::utils::test::{SmartWalletContext, docker_smart_wallet};
@@ -10,6 +11,7 @@ use xmtp_id::{
 };
 
 #[rstest::rstest]
+#[timeout(Duration::from_secs(60))]
 #[tokio::test]
 async fn test_remote_is_valid_signature(#[future] docker_smart_wallet: SmartWalletContext) {
     let SmartWalletContext {
@@ -71,6 +73,7 @@ async fn test_remote_is_valid_signature(#[future] docker_smart_wallet: SmartWall
 }
 
 #[rstest::rstest]
+#[timeout(Duration::from_secs(60))]
 #[tokio::test]
 async fn test_detect_scw_vs_eoa_creation(#[future] docker_smart_wallet: SmartWalletContext) {
     let SmartWalletContext {


### PR DESCRIPTION
closes xmtp/xmtpd/issues/1259

this pr updates to `redb` 0.3.1, which added support for multi-process reading of a database. This enabled message generation and xdbg streaming using the same `redb` database



```bash

./xdbg stream -k messages -f csv # defaults to csv

./xdbg stream -k messages -f json

./xdbg stream -k conversations
```

Help:

```bash

❯ ./target/release/xdbg stream --help
Stream messages and conversations

Usage: xdbg stream [OPTIONS] --kind <KIND> --format <FORMAT>

Options:
  -i, --inbox <INBOX>
          Indicate the Inbox to stream messages from. Defaults to a randomly chosen identity

  -k, --kind <KIND>
          Indicate the kind of stream

          Possible values:
          - conversations: Stream only new conversations for this inbox id
          - messages:      Stream only messages for this inbox id

  -f, --format <FORMAT>
          Indicate format that should be used

          Possible values:
          - json: output in a JSON Format
          - csv:  output in a CSV Format

  -o, --out <OUT>
          optionally indicate a file to write to. Defaults to stdout

  -v, --verbose...
          Increase logging verbosity

  -q, --quiet...
          Decrease logging verbosity

  -h, --help
          Print help (see a summary with '-h')

```