### PR TITLE
remove unimplemented in d14n

### DIFF
--- a/xmtp_api_d14n/src/queries/d14n/mls.rs
+++ b/xmtp_api_d14n/src/queries/d14n/mls.rs
@@ -20,6 +20,7 @@ use xmtp_proto::api::EndpointExt;
 use xmtp_proto::api::{ApiClientError, Query};
 use xmtp_proto::api_client::XmtpMlsClient;
 use xmtp_proto::mls_v1;
+use xmtp_proto::mls_v1::BatchQueryCommitLogResponse;
 use xmtp_proto::types::GroupId;
 use xmtp_proto::types::InstallationId;
 use xmtp_proto::types::TopicKind;
@@ -189,20 +190,19 @@ where
             .collect::<Result<_, _>>()?)
     }
 
-    // TODO(cvoell): implement
     #[tracing::instrument(level = "debug", skip_all)]
     async fn publish_commit_log(
         &self,
         _request: mls_v1::BatchPublishCommitLogRequest,
     ) -> Result<(), Self::Error> {
-        unimplemented!();
+        Ok(())
     }
 
-    // TODO(cvoell): implement
     async fn query_commit_log(
         &self,
         _request: mls_v1::BatchQueryCommitLogRequest,
     ) -> Result<mls_v1::BatchQueryCommitLogResponse, Self::Error> {
-        unimplemented!();
+        tracing::debug!("commit log disabled for d14n");
+        Ok(BatchQueryCommitLogResponse { responses: vec![] })
     }
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Remove `unimplemented!()` in `xmtp_api_d14n::mls::Client.publish_commit_log` and `xmtp_api_d14n::mls::Client.query_commit_log` to prevent panics
Replace `unimplemented!()` in `publish_commit_log` with `Ok(())` and in `query_commit_log` with a debug log and an empty `mls_v1::BatchQueryCommitLogResponse` in [mls.rs](https://github.com/xmtp/libxmtp/pull/2651/files#diff-b41f084fe8fd9295035f4b6d73b1318093b6475f1f923e681a880e6ba94a2f20).

#### 📍Where to Start
Start with the `Client` methods `publish_commit_log` and `query_commit_log` in [mls.rs](https://github.com/xmtp/libxmtp/pull/2651/files#diff-b41f084fe8fd9295035f4b6d73b1318093b6475f1f923e681a880e6ba94a2f20).

----
<!-- MACROSCOPE_FOOTER_START -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 7f32046.

<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->