### PR TITLE
feat: add Abstract for scw verification

### DIFF
--- a/xmtp_id/src/scw_verifier/chain_urls_default.json
+++ b/xmtp_id/src/scw_verifier/chain_urls_default.json
@@ -7,5 +7,6 @@
   "eip155:42161": "https://arbitrum.llamarpc.com",
   "eip155:59144": "https://linea-rpc.publicnode.com",
   "eip155:480": "https://worldchain-mainnet.g.alchemy.com/public",
-  "eip155:232":"https://rpc.lens.xyz"
+  "eip155:232":"https://rpc.lens.xyz",
+  "eip155:2741": "https://api.mainnet.abs.xyz"
 }


### PR DESCRIPTION
Add Abstract to the SCW verifier allowlist so libxmtp can validate EIP-1271 signatures for Abstract Global Wallet smart accounts.

**Changes**
xmtp_id/src/scw_verifier/chain_urls_default.json

eip155:2741 → https://api.mainnet.abs.xyz (Abstract Mainnet)

**Why**
XMTP needs an RPC per chain to call isValidSignature on SCWs.
Adding Abstract enables inboxes for Abstract Global Wallets (AGW) on Abstract.