### PR TITLE
wasm-interactive: setup required tools

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -12,7 +12,11 @@ rustflags = ["--cfg", "tracing_unstable"]
 
 [target.wasm32-unknown-unknown]
 runner = 'wasm-bindgen-test-runner'
-rustflags = ['--cfg', 'getrandom_backend="wasm_js"']
+rustflags = [
+  '--cfg',
+  'getrandom_backend="wasm_js"',
+  '-Ctarget-feature=+bulk-memory,+mutable-globals',
+]
 
 [target.aarch64-linux-android]
 rustflags = ["-Clink-arg=-Wl,-z,max-page-size=16384"]

--- a/.github/workflows/lint-wasm-bindings.yaml
+++ b/.github/workflows/lint-wasm-bindings.yaml
@@ -12,7 +12,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
-  RUSTFLAGS: --cfg tracing_unstable -Ctarget-feature=+bulk-memory,+mutable-globals --cfg getrandom_backend="wasm_js"
   CARGO_PROFILE_TEST_DEBUG: 0
 jobs:
   lint:

--- a/.github/workflows/test-webassembly.yml
+++ b/.github/workflows/test-webassembly.yml
@@ -53,31 +53,23 @@ jobs:
           ./emsdk install latest
           ./emsdk activate latest
       - name: Build WebAssembly Packages
-        env:
-          RUSTFLAGS: --cfg tracing_unstable -Ctarget-feature=+bulk-memory,+mutable-globals --cfg getrandom_backend="wasm_js"
         run: |
           source ./emsdk/emsdk_env.sh
           cargo build --locked --tests --release --target wasm32-unknown-unknown -p xmtp_id -p xmtp_mls -p xmtp_cryptography -p xmtp_common -p bindings_wasm -p xmtp_api_d14n -p xmtp_db
       - name: test libraries
         env:
-          RUSTFLAGS: --cfg tracing_unstable -Ctarget-feature=+bulk-memory,+mutable-globals --cfg getrandom_backend="wasm_js"
           CHROMEDRIVER: "chromedriver"
         run: |
-          cargo test --locked --release --target wasm32-unknown-unknown -p xmtp_id -p xmtp_cryptography -p xmtp_api -p bindings_wasm -p xmtp_api_d14n -p xmtp_db -- \
-            --skip encrypted_store::group_message::tests::it_cannot_insert_message_without_group \
+          cargo test --locked --release --target wasm32-unknown-unknown -p xmtp_id -p xmtp_cryptography -p xmtp_api -p bindings_wasm -p xmtp_api_d14n -p xmtp_db
         working-directory: ./
       - name: test xmtp_mls client
         env:
-          RUSTFLAGS: --cfg tracing_unstable -Ctarget-feature=+bulk-memory,+mutable-globals --cfg getrandom_backend="wasm_js"
           CHROMEDRIVER: "chromedriver"
         run: |
-          cargo test --locked --release --target wasm32-unknown-unknown -p xmtp_mls -- \
-            --skip encrypted_store::group_message::tests::it_cannot_insert_message_without_group \
-            --skip subscriptions::
+          cargo test --locked --release --target wasm32-unknown-unknown -p xmtp_mls -- --skip subscriptions::
         working-directory: ./
       - name: test xmtp_mls subscriptions
         env:
-          RUSTFLAGS: --cfg tracing_unstable -Ctarget-feature=+bulk-memory,+mutable-globals --cfg getrandom_backend="wasm_js"
           CHROMEDRIVER: "chromedriver"
         run: |
           cargo test --locked --release --target wasm32-unknown-unknown -p xmtp_mls -- subscriptions::

--- a/common/src/retry.rs
+++ b/common/src/retry.rs
@@ -310,7 +310,7 @@ impl Retry {
 ///     Err(MyError::Retryable)
 /// }
 ///
-/// #[tokio::main]
+/// #[tokio::main(flavor = "current_thread")]
 /// async fn main() -> Result<(), MyError> {
 ///
 ///     let (tx, mut rx) = mpsc::channel(3);

--- a/dev/test/wasm
+++ b/dev/test/wasm
@@ -1,17 +1,20 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eou pipefail
 
-export RUSTFLAGS="-Ctarget-feature=+bulk-memory,+mutable-globals --cfg getrandom_backend=\"wasm_js\"${RUSTFLAGS:+ $RUSTFLAGS}"
+PACKAGE="${1:-}"
+if [[ -n "${PACKAGE}" ]]; then
+  PACKAGE=" -p ${PACKAGE}"
+else
+  PACKAGE=" --workspace --exclude xdbg --exclude xmtpv3 --exclude bindings_node --exclude mls_validation_service --exclude xmtp_cli --exclude xmtp_api_grpc --exclude xmtp_proto"
+fi
 
-PACKAGE=${1:-}
-TESTS=${2:-}
+TESTS="${2:-}"
 
-RUST_LOG=off \
-WASM_BINDGEN_SPLIT_LINKED_MODULES=1 \
-WASM_BINDGEN_TEST_ONLY_WEB=1 \
-WASM_BINDGEN_TEST_TIMEOUT=180 \
-RSTEST_TIMEOUT=60 \
-cargo test --locked --release --target wasm32-unknown-unknown \
-  -p $PACKAGE -- \
-  --skip encrypted_store::group_message::tests::it_cannot_insert_message_without_group \
+export RUST_LOG=off
+export WASM_BINDGEN_TEST_ONLY_WEB=1
+export WASM_BINDGEN_SPLIT_LINKED_MODULES=1
+export WASM_BINDGEN_TEST_TIMEOUT=180
+export RSTEST_TIMEOUT=60
+cargo test --locked --release --target wasm32-unknown-unknown --timings \
+  $PACKAGE -- \
   $TESTS

--- a/dev/test/wasm-interactive
+++ b/dev/test/wasm-interactive
@@ -1,23 +1,42 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eou pipefail
 
-RED='\033[0;31m'
-NC='\033[0m' # No Color
-
-if [ -z "${1:-}" ]; then
-  echo -e "${RED}First argument must be package to test -- EX: \`test-wasm-interactive xmtp_mls\`${NC}"
-  exit
+PACKAGE="${1:-}"
+if [[ -n "${PACKAGE}" ]]; then
+  PACKAGE=" -p ${PACKAGE}"
+else
+  PACKAGE=" --workspace --exclude xdbg --exclude xmtpv3 --exclude bindings_node --exclude mls_validation_service --exclude xmtp_cli --exclude xmtp_api_grpc"
 fi
 
-PACKAGE=$1
-TESTS=${2:-}
+TESTS="${2:-}"
 
-export RUSTFLAGS="-Ctarget-feature=+bulk-memory,+mutable-globals --cfg getrandom_backend=\"wasm_js\"${RUSTFLAGS:=}"
+# Setup required tools
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  LLVM="$(brew list | grep -E "^llvm$" || true)"
+  if [[ -z "${LLVM}" ]]; then
+    echo "Installing llvm"
+    brew install llvm
+    echo "Add llvm environment variables to your shell"
+    exit 1
+  fi
+fi
+
+WASM_BINDGEN_CLI="$(which wasm-bindgen-test-runner 2>/dev/null || true)"
+if [[ -z "${WASM_BINDGEN_CLI}" ]]; then
+  echo "Installing wasm-bindgen-cli"
+  cargo install wasm-bindgen-cli
+fi
+
+WASM_TARGET="$(rustup target list --installed | grep wasm32-unknown-unknown 2>/dev/null || true)"
+if [[ -z "${WASM_TARGET}" ]]; then
+  echo "Adding wasm32-unknown-unknown target"
+  rustup target add wasm32-unknown-unknown
+fi
+
 export WASM_BINDGEN_TEST_ONLY_WEB=1
 # export SPLIT_LINKED_MODULES=1
 export NO_HEADLESS=1
 
 cargo test --target wasm32-unknown-unknown --release \
   -p $PACKAGE -- \
-  --skip xmtp_mls::storage::encrypted_store::group_message::tests::it_cannot_insert_message_without_group \
   $TESTS

--- a/dev/test/wasm-nextest
+++ b/dev/test/wasm-nextest
@@ -1,13 +1,21 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eou pipefail
 
-export RUSTFLAGS="-Ctarget-feature=+bulk-memory,+mutable-globals --cfg getrandom_backend=\"wasm_js\"${RUSTFLAGS:=}"
+# Setup required tools
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  CHROMEDRIVER="$(which chromedriver 2>/dev/null || true)"
+  if [[ -z "${CHROMEDRIVER}" ]]; then
+    echo "Installing chromedriver"
+    brew install chromedriver
+  fi
+fi
 
-WASM_BINDGEN_TEST_ONLY_WEB=1 \
-  WASM_BINDGEN_TEST_TIMEOUT=180 \
-  CHROMEDRIVER="chromedriver" \
-  cargo nextest run \
+export WASM_BINDGEN_TEST_ONLY_WEB=1
+export WASM_BINDGEN_TEST_TIMEOUT=180
+export CHROMEDRIVER="chromedriver"
+
+cargo nextest run \
   --profile ci \
-  --workspace -E 'platform(target) and not test(it_cannot_insert_message_without_group)' \
+  --workspace -E 'platform(target)' \
   --target wasm32-unknown-unknown --release \
   --exclude xdbg --exclude xmtpv3 --exclude bindings_node --exclude mls_validation_service --exclude xmtp_cli --exclude xmtp_api_grpc

--- a/nix/package/bindings_wasm.nix
+++ b/nix/package/bindings_wasm.nix
@@ -44,7 +44,6 @@ let
     buildInputs = [ zstd sqlite ];
     doCheck = false;
     cargoExtraArgs = "--workspace --exclude xmtpv3 --exclude bindings_node --exclude xmtp_cli --exclude xdbg --exclude mls_validation_service --exclude xmtp_api_grpc";
-    RUSTFLAGS = [ "--cfg" "tracing_unstable" "--cfg" "getrandom_backend=\"wasm_js\"" "-C" "target-feature=+bulk-memory,+mutable-globals" ];
     CARGO_BUILD_TARGET = "wasm32-unknown-unknown";
     hardeningDisable = [ "zerocallusedregs" "stackprotector" ];
     NIX_DEBUG = 1;


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Configure WebAssembly builds and CI to use `wasm32-unknown-unknown` with `bulk-memory` and `mutable-globals` and set up interactive test tooling in [config.toml](https://github.com/xmtp/libxmtp/pull/2670/files#diff-9a4f3e4537ebb7474452d131b0d969d89a51286f4269aac5ef268e712be17268) and wasm test scripts
Update repository and CI to compile `wasm32-unknown-unknown` with required target features and run previously skipped tests while adding interactive tooling checks.

- Set `-Ctarget-feature=+bulk-memory,+mutable-globals` and keep `cfg(getrandom_backend="wasm_js")` for `wasm32-unknown-unknown` in [.cargo/config.toml](https://github.com/xmtp/libxmtp/pull/2670/files#diff-9a4f3e4537ebb7474452d131b0d969d89a51286f4269aac5ef268e712be17268)
- Remove `RUSTFLAGS` from GitHub workflows in [lint-wasm-bindings.yaml](https://github.com/xmtp/libxmtp/pull/2670/files#diff-8503ea5378cb726c00d369e265f15de261b11bab9e7b84c167956c106069faf5) and [test-webassembly.yml](https://github.com/xmtp/libxmtp/pull/2670/files#diff-e212b3a87660ba5a2af651d8b2f8be1c9bd5c974e093340424374f679fae4ebd)
- Run previously skipped tests and streamline test args in WebAssembly CI steps in [test-webassembly.yml](https://github.com/xmtp/libxmtp/pull/2670/files#diff-e212b3a87660ba5a2af651d8b2f8be1c9bd5c974e093340424374f679fae4ebd)
- Add prerequisite checks and interactive options to `dev/test/wasm-interactive` and remove `RUSTFLAGS` usage in `dev/test/wasm` and `dev/test/wasm-nextest`
- Drop `RUSTFLAGS` from Nix derivation in [bindings_wasm.nix](https://github.com/xmtp/libxmtp/pull/2670/files#diff-67bbf1549288197b5f7163ab1f48ba05e1344cb448c4603d2bf0246531fb203b)
- Refactor `it_cannot_insert_message_without_group` to use `test_utils::with_connection` in [`xmtp_db::encrypted_store::group_message::tests`](https://github.com/xmtp/libxmtp/pull/2670/files#diff-95173998137eab23659b05e775352bbe1c88466c6ca984420fdcb8e0269cb0c4)

#### 📍Where to Start
Start with the `wasm32-unknown-unknown` target configuration in [.cargo/config.toml](https://github.com/xmtp/libxmtp/pull/2670/files#diff-9a4f3e4537ebb7474452d131b0d969d89a51286f4269aac5ef268e712be17268), then review CI changes in [test-webassembly.yml](https://github.com/xmtp/libxmtp/pull/2670/files#diff-e212b3a87660ba5a2af651d8b2f8be1c9bd5c974e093340424374f679fae4ebd) to see test behavior updates, and finally check the interactive setup flow in [dev/test/wasm-interactive](https://github.com/xmtp/libxmtp/pull/2670/files#diff-a548137672c6c5f2fe85ca8b8d3268f9a393039c740902c241b37c7a6da36c9b).

----
<!-- MACROSCOPE_FOOTER_START -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 209c637.

<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->