### PR TITLE
Add constructor to SendMessageOpts

### DIFF
--- a/bindings_wasm/src/conversation.rs
+++ b/bindings_wasm/src/conversation.rs
@@ -33,6 +33,14 @@ pub struct SendMessageOpts {
   pub should_push: bool,
 }
 
+#[wasm_bindgen]
+impl SendMessageOpts {
+  #[wasm_bindgen(constructor)]
+  pub fn new(should_push: bool) -> Self {
+    Self { should_push }
+  }
+}
+
 impl From<SendMessageOpts> for xmtp_mls::groups::send_message_opts::SendMessageOpts {
   fn from(opts: SendMessageOpts) -> Self {
     xmtp_mls::groups::send_message_opts::SendMessageOpts {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add a WebAssembly/JavaScript constructor `bindings_wasm.conversation.SendMessageOpts::new(should_push: bool)` in [conversation.rs](https://github.com/xmtp/libxmtp/pull/2671/files#diff-106fd4741a71a89abefb1837cde5785b14100381cea3bf577416671c49bae37e)
Introduce a `#[wasm_bindgen(constructor)]` for `bindings_wasm.conversation.SendMessageOpts` that initializes `should_push` via `new(should_push: bool)` in [conversation.rs](https://github.com/xmtp/libxmtp/pull/2671/files#diff-106fd4741a71a89abefb1837cde5785b14100381cea3bf577416671c49bae37e).

#### 📍Where to Start
Start with the wasm-bindgen `impl` block for `bindings_wasm.conversation.SendMessageOpts` and the `new(should_push: bool)` constructor in [conversation.rs](https://github.com/xmtp/libxmtp/pull/2671/files#diff-106fd4741a71a89abefb1837cde5785b14100381cea3bf577416671c49bae37e).

----

<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 55fbcde. 1 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
No issues evaluated.


</details>
<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->