### PR TITLE
Sort and paginate by inserted_at

### DIFF
--- a/bindings_ffi/src/message.rs
+++ b/bindings_ffi/src/message.rs
@@ -347,6 +347,7 @@ pub struct FfiDecodedMessageMetadata {
     pub sender_inbox_id: String,
     pub content_type: FfiContentTypeId,
     pub conversation_id: Vec<u8>,
+    pub inserted_at_ns: i64,
 }
 
 #[derive(uniffi::Enum, Clone, Debug)]
@@ -896,6 +897,7 @@ impl From<DecodedMessageMetadata> for FfiDecodedMessageMetadata {
             conversation_id: metadata.group_id,
             sender_inbox_id: metadata.sender_inbox_id,
             content_type: metadata.content_type.into(),
+            inserted_at_ns: metadata.inserted_at_ns,
         }
     }
 }
@@ -1051,6 +1053,7 @@ pub struct FfiDecodedMessage {
     reactions: Vec<Arc<FfiDecodedMessage>>,
     delivery_status: FfiDeliveryStatus,
     num_replies: u64,
+    inserted_at_ns: i64,
 }
 
 #[uniffi::export]
@@ -1112,6 +1115,10 @@ impl FfiDecodedMessage {
     pub fn reaction_count(&self) -> u64 {
         self.reactions.len() as u64
     }
+
+    pub fn inserted_at_ns(&self) -> i64 {
+        self.inserted_at_ns
+    }
 }
 
 impl From<DecodedMessage> for FfiDecodedMessage {
@@ -1139,6 +1146,7 @@ impl From<DecodedMessage> for FfiDecodedMessage {
                 .map(Arc::new)
                 .collect(),
             num_replies: item.num_replies as u64,
+            inserted_at_ns: metadata.inserted_at_ns,
         }
     }
 }

--- a/bindings_wasm/src/conversation.rs
+++ b/bindings_wasm/src/conversation.rs
@@ -795,6 +795,7 @@ mod tests {
       group_id: xmtp_common::rand_vec::<32>(),
       decrypted_message_bytes: xmtp_common::rand_vec::<32>(),
       sent_at_ns: 1738354508964432000,
+      inserted_at_ns: 1738354508964432000,
       kind: GroupMessageKind::Application,
       sender_installation_id: xmtp_common::rand_vec::<32>(),
       sender_inbox_id: String::from("test"),

--- a/bindings_wasm/src/messages.rs
+++ b/bindings_wasm/src/messages.rs
@@ -3,7 +3,8 @@ use prost::Message as ProstMessage;
 use wasm_bindgen::prelude::wasm_bindgen;
 use xmtp_db::group_message::{
   DeliveryStatus as XmtpDeliveryStatus, GroupMessageKind as XmtpGroupMessageKind, MsgQueryArgs,
-  SortDirection as XmtpSortDirection, StoredGroupMessage, StoredGroupMessageWithReactions,
+  SortBy as XmtpMessageSortBy, SortDirection as XmtpSortDirection, StoredGroupMessage,
+  StoredGroupMessageWithReactions,
 };
 use xmtp_proto::xmtp::mls::message_contents::EncodedContent as XmtpEncodedContent;
 
@@ -78,6 +79,22 @@ impl From<SortDirection> for XmtpSortDirection {
   }
 }
 
+#[wasm_bindgen]
+#[derive(Clone)]
+pub enum MessageSortBy {
+  SentAt,
+  InsertedAt,
+}
+
+impl From<MessageSortBy> for XmtpMessageSortBy {
+  fn from(sort_by: MessageSortBy) -> Self {
+    match sort_by {
+      MessageSortBy::SentAt => XmtpMessageSortBy::SentAt,
+      MessageSortBy::InsertedAt => XmtpMessageSortBy::InsertedAt,
+    }
+  }
+}
+
 #[wasm_bindgen(getter_with_clone)]
 #[derive(Default)]
 pub struct ListMessagesOptions {
@@ -96,6 +113,12 @@ pub struct ListMessagesOptions {
   pub kind: Option<GroupMessageKind>,
   #[wasm_bindgen(js_name = excludeSenderInboxIds)]
   pub exclude_sender_inbox_ids: Option<Vec<String>>,
+  #[wasm_bindgen(js_name = sortBy)]
+  pub sort_by: Option<MessageSortBy>,
+  #[wasm_bindgen(js_name = insertedAfterNs)]
+  pub inserted_after_ns: Option<i64>,
+  #[wasm_bindgen(js_name = insertedBeforeNs)]
+  pub inserted_before_ns: Option<i64>,
 }
 
 impl From<ListMessagesOptions> for MsgQueryArgs {
@@ -114,6 +137,9 @@ impl From<ListMessagesOptions> for MsgQueryArgs {
         .content_types
         .map(|t| t.into_iter().map(Into::into).collect()),
       exclude_sender_inbox_ids: opts.exclude_sender_inbox_ids,
+      sort_by: opts.sort_by.map(Into::into),
+      inserted_after_ns: opts.inserted_after_ns,
+      inserted_before_ns: opts.inserted_before_ns,
     }
   }
 }
@@ -132,6 +158,9 @@ impl ListMessagesOptions {
     exclude_content_types: Option<Vec<ContentType>>,
     kind: Option<GroupMessageKind>,
     exclude_sender_inbox_ids: Option<Vec<String>>,
+    sort_by: Option<MessageSortBy>,
+    inserted_after_ns: Option<i64>,
+    inserted_before_ns: Option<i64>,
   ) -> Self {
     Self {
       sent_before_ns,
@@ -143,6 +172,9 @@ impl ListMessagesOptions {
       exclude_content_types,
       kind,
       exclude_sender_inbox_ids,
+      sort_by,
+      inserted_after_ns,
+      inserted_before_ns,
     }
   }
 }

--- a/xmtp_db/migrations/2025-11-15-232503_add_inserted_at_ns_to_group_messages/down.sql
+++ b/xmtp_db/migrations/2025-11-15-232503_add_inserted_at_ns_to_group_messages/down.sql
@@ -1,0 +1,120 @@
+-- Reverse the migration by recreating the table without inserted_at_ns
+
+-- Step 0: Drop views that depend on group_messages table
+DROP VIEW IF EXISTS conversation_list;
+
+-- Step 1: Drop the trigger
+DROP TRIGGER IF EXISTS msg_inserted;
+
+-- Step 2: Rename current table
+ALTER TABLE group_messages RENAME TO group_messages_new;
+
+-- Step 3: Recreate original table without inserted_at_ns
+CREATE TABLE group_messages (
+    id BLOB PRIMARY KEY NOT NULL,
+    group_id BLOB NOT NULL,
+    decrypted_message_bytes BLOB NOT NULL,
+    sent_at_ns BIGINT NOT NULL,
+    kind INTEGER NOT NULL DEFAULT 1,
+    sender_installation_id BLOB NOT NULL,
+    sender_inbox_id TEXT NOT NULL,
+    delivery_status INTEGER NOT NULL DEFAULT 0,
+    content_type INTEGER NOT NULL DEFAULT 0,
+    version_major INTEGER NOT NULL DEFAULT 0,
+    version_minor INTEGER NOT NULL DEFAULT 0,
+    authority_id TEXT NOT NULL,
+    reference_id BLOB,
+    originator_id BIGINT NOT NULL,
+    sequence_id BIGINT NOT NULL,
+    expire_at_ns BIGINT,
+    FOREIGN KEY (group_id) REFERENCES groups(id)
+);
+
+-- Step 4: Copy data back (excluding inserted_at_ns)
+INSERT INTO group_messages (
+    id, group_id, decrypted_message_bytes, sent_at_ns, kind,
+    sender_installation_id, sender_inbox_id, delivery_status,
+    content_type, version_major, version_minor, authority_id,
+    reference_id, originator_id, sequence_id, expire_at_ns
+)
+SELECT
+    id, group_id, decrypted_message_bytes, sent_at_ns, kind,
+    sender_installation_id, sender_inbox_id, delivery_status,
+    content_type, version_major, version_minor, authority_id,
+    reference_id, originator_id, sequence_id, expire_at_ns
+FROM group_messages_new;
+
+-- Step 5: Drop new table
+DROP TABLE group_messages_new;
+
+-- Step 6: Recreate original indexes (that existed before the up migration ran)
+CREATE INDEX group_messages_sent_at_sort ON group_messages(group_id, sent_at_ns);
+CREATE INDEX group_messages_reference_id ON group_messages(reference_id);
+
+-- Step 7: Recreate trigger
+CREATE TRIGGER msg_inserted AFTER INSERT ON group_messages FOR EACH ROW BEGIN
+UPDATE groups
+SET
+    last_message_ns = NEW.sent_at_ns
+WHERE
+    id = NEW.group_id
+    AND (
+        last_message_ns IS NULL
+        OR NEW.sent_at_ns > last_message_ns
+    );
+END;
+
+-- Step 8: Recreate conversation_list view
+CREATE VIEW conversation_list AS
+WITH ranked_messages AS (
+    SELECT
+        gm.group_id,
+        gm.id AS message_id,
+        gm.decrypted_message_bytes,
+        gm.sent_at_ns,
+        gm.kind AS message_kind,
+        gm.sender_installation_id,
+        gm.sender_inbox_id,
+        gm.delivery_status,
+        gm.content_type,
+        gm.version_major,
+        gm.version_minor,
+        gm.authority_id,
+        gm.sequence_id,
+        gm.originator_id,
+        ROW_NUMBER() OVER (PARTITION BY gm.group_id ORDER BY gm.sent_at_ns DESC) AS row_num
+    FROM
+        group_messages gm
+    WHERE
+        gm.kind = 1
+        AND gm.content_type IN (0, 1, 4, 6, 7, 8, 9, 10)
+)
+SELECT
+    g.id AS id,
+    g.created_at_ns,
+    g.membership_state,
+    g.installations_last_checked,
+    g.added_by_inbox_id,
+    g.sequence_id as welcome_sequence_id,
+    g.dm_id,
+    g.rotated_at_ns,
+    g.conversation_type,
+    g.is_commit_log_forked,
+    rm.message_id,
+    rm.decrypted_message_bytes,
+    rm.sent_at_ns,
+    rm.message_kind,
+    rm.sender_installation_id,
+    rm.sender_inbox_id,
+    rm.delivery_status,
+    rm.content_type,
+    rm.version_major,
+    rm.version_minor,
+    rm.authority_id,
+    rm.sequence_id,
+    rm.originator_id
+FROM
+    groups g
+    LEFT JOIN ranked_messages rm
+    ON g.id = rm.group_id AND rm.row_num = 1
+ORDER BY COALESCE(rm.sent_at_ns, g.created_at_ns) DESC;

--- a/xmtp_db/migrations/2025-11-15-232503_add_inserted_at_ns_to_group_messages/up.sql
+++ b/xmtp_db/migrations/2025-11-15-232503_add_inserted_at_ns_to_group_messages/up.sql
@@ -1,0 +1,131 @@
+-- Add inserted_at_ns column to group_messages table using table recreation
+-- This allows us to use a DEFAULT clause with a function, which isn't allowed with ALTER TABLE ADD COLUMN
+
+-- Step 0: Drop views that depend on group_messages table
+DROP VIEW IF EXISTS conversation_list;
+
+-- Step 1: Rename existing table
+ALTER TABLE group_messages RENAME TO group_messages_old;
+
+-- Step 2: Create new table with inserted_at_ns column and DEFAULT clause
+-- Use database time with microsecond precision, convert to nanoseconds
+-- strftime('%s%f', 'now') gives Unix timestamp in seconds + fractional seconds (6 decimal places = microseconds)
+-- We multiply by 1000 to convert microseconds to nanoseconds
+CREATE TABLE group_messages (
+    id BLOB PRIMARY KEY NOT NULL,
+    group_id BLOB NOT NULL,
+    decrypted_message_bytes BLOB NOT NULL,
+    sent_at_ns BIGINT NOT NULL,
+    kind INTEGER NOT NULL DEFAULT 1,
+    sender_installation_id BLOB NOT NULL,
+    sender_inbox_id TEXT NOT NULL,
+    delivery_status INTEGER NOT NULL DEFAULT 0,
+    content_type INTEGER NOT NULL DEFAULT 0,
+    version_major INTEGER NOT NULL DEFAULT 0,
+    version_minor INTEGER NOT NULL DEFAULT 0,
+    authority_id TEXT NOT NULL,
+    reference_id BLOB,
+    originator_id BIGINT NOT NULL,
+    sequence_id BIGINT NOT NULL,
+    inserted_at_ns BIGINT NOT NULL DEFAULT (
+        CAST(strftime('%s','now') AS INTEGER) * 1000000000 +
+        CAST(strftime('%f','now') * 1000000 AS INTEGER) * 1000
+   ),
+    expire_at_ns BIGINT,
+    FOREIGN KEY (group_id) REFERENCES groups(id)
+);
+
+-- Step 3: Copy data from old table to new table
+-- For existing rows, use sent_at_ns as the inserted_at_ns value (migration of the concept)
+-- New inserts will use the DEFAULT clause to get current database time
+INSERT INTO group_messages (
+    id, group_id, decrypted_message_bytes, sent_at_ns, kind,
+    sender_installation_id, sender_inbox_id, delivery_status,
+    content_type, version_major, version_minor, authority_id,
+    reference_id, originator_id, sequence_id, inserted_at_ns, expire_at_ns
+)
+SELECT
+    id, group_id, decrypted_message_bytes, sent_at_ns, kind,
+    sender_installation_id, sender_inbox_id, delivery_status,
+    content_type, version_major, version_minor, authority_id,
+    reference_id, originator_id, sequence_id,
+    sent_at_ns AS inserted_at_ns,  -- Migrate sent_at_ns to inserted_at_ns for existing rows
+    expire_at_ns
+FROM group_messages_old;
+
+-- Step 4: Drop old table
+DROP TABLE group_messages_old;
+
+-- Step 5: Recreate indexes that existed before this migration
+CREATE INDEX group_messages_sent_at_sort ON group_messages(group_id, sent_at_ns);
+CREATE INDEX group_messages_reference_id ON group_messages(reference_id);
+
+-- Add new indexes
+CREATE INDEX group_messages_inserted_at_sort ON group_messages(group_id, inserted_at_ns);
+-- Step 6: Recreate trigger that updates group.last_message_ns on insert
+CREATE TRIGGER msg_inserted AFTER INSERT ON group_messages FOR EACH ROW BEGIN
+UPDATE groups
+SET
+    last_message_ns = NEW.sent_at_ns
+WHERE
+    id = NEW.group_id
+    AND (
+        last_message_ns IS NULL
+        OR NEW.sent_at_ns > last_message_ns
+    );
+END;
+
+-- Step 7: Recreate conversation_list view
+CREATE VIEW conversation_list AS
+WITH ranked_messages AS (
+    SELECT
+        gm.group_id,
+        gm.id AS message_id,
+        gm.decrypted_message_bytes,
+        gm.sent_at_ns,
+        gm.kind AS message_kind,
+        gm.sender_installation_id,
+        gm.sender_inbox_id,
+        gm.delivery_status,
+        gm.content_type,
+        gm.version_major,
+        gm.version_minor,
+        gm.authority_id,
+        gm.sequence_id,
+        gm.originator_id,
+        ROW_NUMBER() OVER (PARTITION BY gm.group_id ORDER BY gm.sent_at_ns DESC) AS row_num
+    FROM
+        group_messages gm
+    WHERE
+        gm.kind = 1
+        AND gm.content_type IN (0, 1, 4, 6, 7, 8, 9, 10) -- 10 is added here
+)
+SELECT
+    g.id AS id,
+    g.created_at_ns,
+    g.membership_state,
+    g.installations_last_checked,
+    g.added_by_inbox_id,
+    g.sequence_id as welcome_sequence_id,
+    g.dm_id,
+    g.rotated_at_ns,
+    g.conversation_type,
+    g.is_commit_log_forked,
+    rm.message_id,
+    rm.decrypted_message_bytes,
+    rm.sent_at_ns,
+    rm.message_kind,
+    rm.sender_installation_id,
+    rm.sender_inbox_id,
+    rm.delivery_status,
+    rm.content_type,
+    rm.version_major,
+    rm.version_minor,
+    rm.authority_id,
+    rm.sequence_id,
+    rm.originator_id
+FROM
+    groups g
+    LEFT JOIN ranked_messages rm
+    ON g.id = rm.group_id AND rm.row_num = 1
+ORDER BY COALESCE(rm.sent_at_ns, g.created_at_ns) DESC;

--- a/xmtp_db/src/encrypted_store/group_message.rs
+++ b/xmtp_db/src/encrypted_store/group_message.rs
@@ -9,11 +9,12 @@ use super::{
         groups::dsl as groups_dsl,
     },
 };
-use crate::{impl_fetch, impl_store, impl_store_or_ignore};
+use crate::impl_fetch;
 use derive_builder::Builder;
 use diesel::{
     backend::Backend,
     deserialize::{self, FromSql, FromSqlRow},
+    dsl::sql as diesel_sql,
     expression::AsExpression,
     prelude::*,
     serialize::{self, IsNull, Output, ToSql},
@@ -34,18 +35,7 @@ pub mod messages_newer_than_tests;
 #[cfg(test)]
 pub mod tests;
 
-#[derive(
-    Debug,
-    Clone,
-    Serialize,
-    Deserialize,
-    Insertable,
-    Identifiable,
-    Queryable,
-    Eq,
-    PartialEq,
-    QueryableByName,
-)]
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Identifiable, Eq, PartialEq)]
 #[diesel(table_name = group_messages)]
 #[diesel(primary_key(id))]
 #[diesel(check_for_backend(Sqlite))]
@@ -77,12 +67,61 @@ pub struct StoredGroupMessage {
     pub authority_id: String,
     /// The ID of a referenced message
     pub reference_id: Option<Vec<u8>>,
-    /// Timestamp (in NS) after which the message must be deleted
-    pub expire_at_ns: Option<i64>,
-    /// The Message SequenceId
-    pub sequence_id: i64,
     /// The Originator Node ID
     pub originator_id: i64,
+    /// The Message SequenceId
+    pub sequence_id: i64,
+    /// Time in nanoseconds the message was inserted into the database
+    /// This field is automatically set by the database
+    pub inserted_at_ns: i64,
+    /// Timestamp (in NS) after which the message must be deleted
+    pub expire_at_ns: Option<i64>,
+}
+
+// Separate Insertable struct that excludes inserted_at_ns to let the database set it
+#[derive(Debug, Clone, Insertable)]
+#[diesel(table_name = group_messages)]
+struct NewStoredGroupMessage {
+    pub id: Vec<u8>,
+    pub group_id: Vec<u8>,
+    pub decrypted_message_bytes: Vec<u8>,
+    pub sent_at_ns: i64,
+    pub kind: GroupMessageKind,
+    pub sender_installation_id: Vec<u8>,
+    pub sender_inbox_id: String,
+    pub delivery_status: DeliveryStatus,
+    pub content_type: ContentType,
+    pub version_major: i32,
+    pub version_minor: i32,
+    pub authority_id: String,
+    pub reference_id: Option<Vec<u8>>,
+    pub originator_id: i64,
+    pub sequence_id: i64,
+    // inserted_at_ns is NOT included - let database set it
+    pub expire_at_ns: Option<i64>,
+}
+
+impl From<&StoredGroupMessage> for NewStoredGroupMessage {
+    fn from(msg: &StoredGroupMessage) -> Self {
+        Self {
+            id: msg.id.clone(),
+            group_id: msg.group_id.clone(),
+            decrypted_message_bytes: msg.decrypted_message_bytes.clone(),
+            sent_at_ns: msg.sent_at_ns,
+            kind: msg.kind,
+            sender_installation_id: msg.sender_installation_id.clone(),
+            sender_inbox_id: msg.sender_inbox_id.clone(),
+            delivery_status: msg.delivery_status,
+            content_type: msg.content_type,
+            version_major: msg.version_major,
+            version_minor: msg.version_minor,
+            authority_id: msg.authority_id.clone(),
+            reference_id: msg.reference_id.clone(),
+            originator_id: msg.originator_id,
+            sequence_id: msg.sequence_id,
+            expire_at_ns: msg.expire_at_ns,
+        }
+    }
 }
 
 pub struct StoredGroupMessageWithReactions {
@@ -96,6 +135,13 @@ pub enum SortDirection {
     #[default]
     Ascending,
     Descending,
+}
+
+#[derive(Clone, Debug, PartialEq, Default)]
+pub enum SortBy {
+    #[default]
+    SentAt,
+    InsertedAt,
 }
 
 #[repr(i32)]
@@ -274,8 +320,43 @@ where
 }
 
 impl_fetch!(StoredGroupMessage, group_messages, Vec<u8>);
-impl_store!(StoredGroupMessage, group_messages);
-impl_store_or_ignore!(StoredGroupMessage, group_messages);
+
+// Custom store implementation that uses NewStoredGroupMessage to exclude inserted_at_ns
+impl<C> crate::Store<C> for StoredGroupMessage
+where
+    C: crate::ConnectionExt,
+{
+    type Output = ();
+    fn store(&self, into: &C) -> Result<(), crate::StorageError> {
+        let new_msg = NewStoredGroupMessage::from(self);
+        into.raw_query_write::<_, _>(|conn| {
+            diesel::insert_into(group_messages::table)
+                .values(&new_msg)
+                .execute(conn)
+                .map(|_| ())
+        })
+        .map_err(Into::into)
+    }
+}
+
+// Custom store_or_ignore implementation that uses NewStoredGroupMessage
+impl<C> crate::StoreOrIgnore<C> for StoredGroupMessage
+where
+    C: crate::ConnectionExt,
+{
+    type Output = ();
+
+    fn store_or_ignore(&self, into: &C) -> Result<(), crate::StorageError> {
+        let new_msg = NewStoredGroupMessage::from(self);
+        into.raw_query_write(|conn| {
+            diesel::insert_or_ignore_into(group_messages::table)
+                .values(&new_msg)
+                .execute(conn)
+                .map(|_| ())
+        })
+        .map_err(Into::into)
+    }
+}
 
 #[derive(Default, Clone, Builder)]
 #[builder(setter(into))]
@@ -298,6 +379,12 @@ pub struct MsgQueryArgs {
     pub exclude_content_types: Option<Vec<ContentType>>,
     #[builder(default = None)]
     pub exclude_sender_inbox_ids: Option<Vec<String>>,
+    #[builder(default = None)]
+    pub sort_by: Option<SortBy>,
+    #[builder(default = None)]
+    pub inserted_after_ns: Option<i64>,
+    #[builder(default = None)]
+    pub inserted_before_ns: Option<i64>,
 }
 
 impl MsgQueryArgs {
@@ -628,6 +715,14 @@ macro_rules! apply_message_filters {
             query = query.filter(dsl::sender_inbox_id.ne_all(exclude_sender_inbox_ids));
         }
 
+        if let Some(inserted_after_ns) = $args.inserted_after_ns {
+            query = query.filter(dsl::inserted_at_ns.gt(inserted_after_ns));
+        }
+
+        if let Some(inserted_before_ns) = $args.inserted_before_ns {
+            query = query.filter(dsl::inserted_at_ns.lt(inserted_before_ns));
+        }
+
         query
     }};
 }
@@ -657,10 +752,26 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
         // Apply common filters using macro
         query = apply_message_filters!(query, args);
 
-        // Apply ordering
-        query = match args.direction.as_ref().unwrap_or(&SortDirection::Ascending) {
-            SortDirection::Ascending => query.order(dsl::sent_at_ns.asc()),
-            SortDirection::Descending => query.order(dsl::sent_at_ns.desc()),
+        // Apply ordering with a rowid tie-break to ensure indexes get used when sorting.
+        query = match (
+            args.sort_by.clone().unwrap_or_default(),
+            args.direction.clone().unwrap_or_default(),
+        ) {
+            (SortBy::SentAt, SortDirection::Ascending) => {
+                query.order((dsl::sent_at_ns.asc(), diesel_sql::<Integer>("rowid").asc()))
+            }
+            (SortBy::SentAt, SortDirection::Descending) => query.order((
+                dsl::sent_at_ns.desc(),
+                diesel_sql::<Integer>("rowid").desc(),
+            )),
+            (SortBy::InsertedAt, SortDirection::Ascending) => query.order((
+                dsl::inserted_at_ns.asc(),
+                diesel_sql::<Integer>("rowid").asc(),
+            )),
+            (SortBy::InsertedAt, SortDirection::Descending) => query.order((
+                dsl::inserted_at_ns.desc(),
+                diesel_sql::<Integer>("rowid").desc(),
+            )),
         };
 
         if let Some(limit) = args.limit {
@@ -764,7 +875,6 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
             .left_join(groups::table)
             .filter(groups::conversation_type.ne_all(ConversationType::virtual_types()))
             .filter(group_messages::kind.eq(GroupMessageKind::Application))
-            .select(group_messages::all_columns)
             .order_by(group_messages::id)
             .into_boxed();
 
@@ -776,7 +886,12 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
         }
 
         query = query.limit(limit.unwrap_or(100)).offset(offset);
-        self.raw_query_read(|conn| query.load::<StoredGroupMessage>(conn))
+
+        self.raw_query_read(|conn| {
+            query
+                .select(group_messages::all_columns)
+                .load::<StoredGroupMessage>(conn)
+        })
     }
 
     /// Query for group messages with their reactions
@@ -826,7 +941,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
         };
 
         let reactions: Vec<StoredGroupMessage> =
-            self.raw_query_read(|conn| reactions_query.load(conn))?;
+            self.raw_query_read(|conn| reactions_query.load::<StoredGroupMessage>(conn))?;
 
         // Group reactions by parent message id
         let mut reactions_by_reference: HashMap<Vec<u8>, Vec<StoredGroupMessage>> = HashMap::new();
@@ -887,7 +1002,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
         }
 
         let raw_inbound_relations: Vec<StoredGroupMessage> =
-            self.raw_query_read(|conn| inbound_relations_query.load(conn))?;
+            self.raw_query_read(|conn| inbound_relations_query.load::<StoredGroupMessage>(conn))?;
 
         for inbound_reference in raw_inbound_relations {
             if let Some(reference_id) = &inbound_reference.reference_id {
@@ -912,7 +1027,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
             .into_boxed();
 
         let raw_outbound_references: Vec<StoredGroupMessage> =
-            self.raw_query_read(|conn| outbound_references_query.load(conn))?;
+            self.raw_query_read(|conn| outbound_references_query.load::<StoredGroupMessage>(conn))?;
 
         Ok(raw_outbound_references
             .into_iter()
@@ -978,7 +1093,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
         self.raw_query_read(|conn| {
             dsl::group_messages
                 .filter(dsl::id.eq(id.as_ref()))
-                .first(conn)
+                .first::<StoredGroupMessage>(conn)
                 .optional()
         })
     }
@@ -991,7 +1106,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
         self.raw_query_write(|conn| {
             dsl::group_messages
                 .filter(dsl::id.eq(id.as_ref()))
-                .first(conn)
+                .first::<StoredGroupMessage>(conn)
                 .optional()
         })
     }
@@ -1005,7 +1120,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
             dsl::group_messages
                 .filter(dsl::group_id.eq(group_id.as_ref()))
                 .filter(dsl::sent_at_ns.eq(&timestamp))
-                .first(conn)
+                .first::<StoredGroupMessage>(conn)
                 .optional()
         })
     }
@@ -1020,7 +1135,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
                 .filter(dsl::group_id.eq(group_id.as_ref()))
                 .filter(dsl::sequence_id.eq(cursor.sequence_id as i64))
                 .filter(dsl::originator_id.eq(cursor.originator_id as i64))
-                .first(conn)
+                .first::<StoredGroupMessage>(conn)
                 .optional()
         })
     }
@@ -1036,7 +1151,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
             .offset(offset);
 
         // Using write connection here to avoid potential race-conditions
-        self.raw_query_write(|conn| query.load(conn))
+        self.raw_query_write(|conn| query.load::<StoredGroupMessage>(conn))
     }
 
     fn set_delivery_status_to_published<MessageId: AsRef<[u8]>>(

--- a/xmtp_db/src/encrypted_store/group_message/convert.rs
+++ b/xmtp_db/src/encrypted_store/group_message/convert.rs
@@ -31,6 +31,7 @@ impl TryFrom<GroupMessageSave> for StoredGroupMessage {
                 .originator_id
                 .unwrap_or(Originators::APPLICATION_MESSAGES.into()),
             expire_at_ns: None,
+            inserted_at_ns: 0, // Will be set by database
         })
     }
 }

--- a/xmtp_db/src/encrypted_store/group_message/messages_newer_than_tests.rs
+++ b/xmtp_db/src/encrypted_store/group_message/messages_newer_than_tests.rs
@@ -26,6 +26,7 @@ fn generate_message_with_cursor(
         version_minor: 0,
         authority_id: "unknown".to_string(),
         reference_id: None,
+        inserted_at_ns: sent_at_ns,
         sequence_id,
         originator_id,
         expire_at_ns: None,

--- a/xmtp_db/src/encrypted_store/migration_test/add_inserted_at_ns.rs
+++ b/xmtp_db/src/encrypted_store/migration_test/add_inserted_at_ns.rs
@@ -1,0 +1,136 @@
+use diesel::QueryableByName;
+use diesel::sql_types::{BigInt, Blob, Integer, Nullable, Text};
+use std::time::Instant;
+
+use super::*;
+
+/// Helper function to insert a group message before the migration
+/// (without the inserted_at_ns field)
+fn insert_message_before_migration(db: impl ConnectionExt, group_id: &[u8], payload: Vec<u8>) {
+    db.raw_query_write(|conn| {
+        sql_query(
+            r#"
+            INSERT INTO group_messages (
+                id, group_id, decrypted_message_bytes, sent_at_ns, kind,
+                sender_installation_id, sender_inbox_id, delivery_status,
+                content_type, version_major, version_minor, authority_id,
+                reference_id, originator_id, sequence_id
+            )
+            VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+        "#,
+        )
+        .bind::<Blob, _>(xmtp_common::rand_vec::<32>())
+        .bind::<Blob, _>(group_id)
+        .bind::<Blob, _>(payload)
+        .bind::<BigInt, _>(xmtp_common::rand_i64())
+        .bind::<Integer, _>(1) // kind: application message
+        .bind::<Blob, _>(xmtp_common::rand_vec::<32>())
+        .bind::<Text, _>("test_inbox")
+        .bind::<Integer, _>(2) // delivery_status
+        .bind::<Integer, _>(0) // content_type
+        .bind::<Integer, _>(0) // version_major
+        .bind::<Integer, _>(0) // version_minor
+        .bind::<Text, _>("authority")
+        .bind::<Nullable<Blob>, _>(None::<Vec<u8>>) // reference_id
+        .bind::<BigInt, _>(0) // originator_id
+        .bind::<BigInt, _>(xmtp_common::rand_i64()) // sequence_id
+        .execute(conn)?;
+        Ok(())
+    })
+    .unwrap();
+}
+
+/// Helper function to create a group before the migration
+fn insert_group_before_migration(db: impl ConnectionExt, group_id: &[u8]) {
+    db.raw_query_write(|conn| {
+        sql_query(
+            r#"
+            INSERT INTO groups (
+                id, created_at_ns, membership_state, installations_last_checked,
+                added_by_inbox_id, rotated_at_ns, conversation_type
+            )
+            VALUES($1, $2, $3, $4, $5, $6, $7)
+        "#,
+        )
+        .bind::<Blob, _>(group_id)
+        .bind::<BigInt, _>(0)
+        .bind::<Integer, _>(2)
+        .bind::<BigInt, _>(0)
+        .bind::<Text, _>("test_inbox")
+        .bind::<BigInt, _>(0)
+        .bind::<Integer, _>(1)
+        .execute(conn)?;
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[xmtp_common::test]
+async fn migration_performance_10k_messages() {
+    let db = crate::TestDb::create_database(None).await;
+
+    // Migrate to the migration right before add_inserted_at_ns_to_group_messages
+    migrate_before(
+        db.conn(),
+        "2025-11-15-232503_add_inserted_at_ns_to_group_messages",
+    );
+
+    // Create a test group
+    let group_id = vec![1, 2, 3, 4, 5];
+    insert_group_before_migration(db.conn(), &group_id);
+
+    // Insert 10,000 messages with 500-byte payload each
+    tracing::info!("Inserting 10,000 test messages with 500-byte payloads...");
+    let payload = vec![0u8; 500];
+    for i in 0..10_000 {
+        if i % 1000 == 0 {
+            tracing::info!("Inserted {} messages", i);
+        }
+        insert_message_before_migration(db.conn(), &group_id, payload.clone());
+    }
+    tracing::info!("Finished inserting test messages");
+
+    // Time the migration
+    let start = Instant::now();
+    tracing::info!("Starting migration...");
+
+    // Run just the add_inserted_at_ns migration
+    db.conn()
+        .raw_query_write(|conn| {
+            conn.run_next_migration(MIGRATIONS).unwrap();
+            Ok(())
+        })
+        .unwrap();
+
+    let duration = start.elapsed();
+    tracing::info!("Migration completed in {:?}", duration);
+
+    // Assert the migration took less than 1 second
+    assert!(
+        duration.as_secs() < 1,
+        "Migration took {:?}, which exceeds the 1 second limit",
+        duration
+    );
+
+    // Verify the migration worked correctly by checking a few messages have inserted_at_ns
+    #[derive(QueryableByName)]
+    struct CountResult {
+        #[diesel(sql_type = BigInt)]
+        count: i64,
+    }
+
+    let result: CountResult = db
+        .conn()
+        .raw_query_read(|conn| {
+            sql_query(
+                "SELECT COUNT(*) as count FROM group_messages WHERE inserted_at_ns IS NOT NULL",
+            )
+            .get_result(conn)
+        })
+        .unwrap();
+
+    assert_eq!(
+        result.count, 10_000,
+        "All 10,000 messages should have inserted_at_ns set"
+    );
+}

--- a/xmtp_db/src/encrypted_store/migration_test/mod.rs
+++ b/xmtp_db/src/encrypted_store/migration_test/mod.rs
@@ -5,6 +5,8 @@ use diesel::migration::MigrationSource;
 
 use super::*;
 
+#[cfg(not(target_arch = "wasm32"))]
+mod add_inserted_at_ns;
 mod originator_id_refresh_state;
 mod update_dm_trigger;
 

--- a/xmtp_db/src/encrypted_store/schema_gen.rs
+++ b/xmtp_db/src/encrypted_store/schema_gen.rs
@@ -58,13 +58,14 @@ diesel::table! {
         sender_inbox_id -> Text,
         delivery_status -> Integer,
         content_type -> Integer,
-        version_minor -> Integer,
         version_major -> Integer,
+        version_minor -> Integer,
         authority_id -> Text,
         reference_id -> Nullable<Binary>,
-        expire_at_ns -> Nullable<BigInt>,
-        sequence_id -> BigInt,
         originator_id -> BigInt,
+        sequence_id -> BigInt,
+        inserted_at_ns -> BigInt,
+        expire_at_ns -> Nullable<BigInt>,
     }
 }
 

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -796,6 +796,7 @@ where
                         sequence_id: conversation_item.sequence_id?,
                         originator_id: conversation_item.originator_id?,
                         expire_at_ns: None, //Question: do we need to include this in conversation last message?
+                        inserted_at_ns: 0, // Not used for conversation list display
                     });
                     if msg.is_none() {
                         tracing::warn!("tried listing message, but message had missing fields so it was skipped");

--- a/xmtp_mls/src/groups/message_list.rs
+++ b/xmtp_mls/src/groups/message_list.rs
@@ -88,6 +88,7 @@ mod tests {
             sequence_id: 0,
             originator_id: Originators::APPLICATION_MESSAGES.into(),
             expire_at_ns: None,
+            inserted_at_ns: 0,
         }
     }
 
@@ -130,6 +131,7 @@ mod tests {
             sequence_id: 0,
             originator_id: Originators::APPLICATION_MESSAGES.into(),
             expire_at_ns: None,
+            inserted_at_ns: 0,
         }
     }
 

--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -1082,6 +1082,7 @@ where
                             sequence_id: cursor.sequence_id as i64,
                             originator_id: cursor.originator_id as i64,
                             expire_at_ns: Self::get_message_expire_at_ns(mls_group),
+                            inserted_at_ns: 0, // Will be set by database
                         };
                         message.store_or_ignore(&storage.db())?;
                         // make sure internal id is on return type after its stored successfully
@@ -2010,6 +2011,7 @@ where
             sequence_id: cursor.sequence_id as i64,
             originator_id: cursor.originator_id as i64,
             expire_at_ns: None,
+            inserted_at_ns: 0, // Will be set by database
         };
         msg.store_or_ignore(&storage.db())?;
         Ok(Some(msg))

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -720,6 +720,7 @@ where
             sequence_id: 0,
             originator_id: 0,
             expire_at_ns: None,
+            inserted_at_ns: 0, // Will be set by database
         };
         group_message.store(&self.context.db())?;
 

--- a/xmtp_mls/src/groups/welcomes/xmtp_welcome.rs
+++ b/xmtp_mls/src/groups/welcomes/xmtp_welcome.rs
@@ -480,6 +480,7 @@ where
             sequence_id: welcome.sequence_id() as i64,
             originator_id: welcome.originator_id() as i64,
             expire_at_ns: None,
+            inserted_at_ns: 0, // Will be set by database
         };
 
         added_msg.store_or_ignore(&db)?;

--- a/xmtp_mls/src/messages/decoded_message.rs
+++ b/xmtp_mls/src/messages/decoded_message.rs
@@ -76,6 +76,8 @@ pub struct DecodedMessageMetadata {
     pub delivery_status: DeliveryStatus,
     // The content type of the message
     pub content_type: ContentTypeId,
+    // Time in nanoseconds the message was inserted into the database
+    pub inserted_at_ns: i64,
 }
 
 #[derive(Debug, Clone)]
@@ -196,6 +198,7 @@ impl TryFrom<StoredGroupMessage> for DecodedMessage {
             sender_inbox_id: value.sender_inbox_id,
             delivery_status: value.delivery_status,
             content_type: content_type_id,
+            inserted_at_ns: value.inserted_at_ns,
         };
 
         // For now, we'll set default values for reactions and replies

--- a/xmtp_mls/src/test/mock/generate.rs
+++ b/xmtp_mls/src/test/mock/generate.rs
@@ -127,5 +127,6 @@ pub fn generate_stored_msg(cursor: Cursor, group_id: Vec<u8>) -> StoredGroupMess
         sequence_id: cursor.sequence_id as i64,
         originator_id: cursor.originator_id as i64,
         expire_at_ns: None,
+        inserted_at_ns: 0,
     }
 }


### PR DESCRIPTION
### TL;DR

Added `inserted_at_ns` field to messages to track when they were added to the database, enabling insertion-time based sorting and pagination.

Default all existing rows to use their `sent_at_ns`​ as their `inserted_at_ns`​ in the absence of anything more accurate.

### Notes

We initially talked about using the built in `rowid`​ for this sort. There are a few problems:  
1\. Takes a ton of diesel gymnastics to expose the rowid and query by it. Not pretty.

1. `rowid`​ can change in a vacuum, mangling the sort order. We don't have an integer primary key and don't want one here![CleanShot 2025-10-24 at 17.28.58@2x.png](https://app.graphite.dev/user-attachments/assets/3be25fff-654a-401e-8c0f-61f9dbbd8e2c.png)

The migration for this was a bit of a journey. Turns out SQLite does not allow you to create a default value with a function on an existing table, only on new table creation. I didn't want to have to pass in `now_ns`​ every time you save a message. Especially since you might actually insert in a slightly different order from when you create the timestamps. Feels more sensible to let SQLite handle this for us.

I added a benchmark on doing this migration for 10k 500 byte messages and it was <100ms, which I think is in the range of acceptable. One time pain to get a better schema.

### What changed?

- Added `inserted_at_ns` field to `StoredGroupMessage` and related message structures
- Created a database migration to add the column to the `group_messages` table
- Added new `SortBy` enum with `SentAt` and `InsertedAt` options
- Extended `MsgQueryArgs` with `sort_by`, `inserted_after`, and `inserted_before` parameters
- Updated FFI bindings to expose the new field and query parameters
- Modified message storage to let the database set the `inserted_at_ns` value automatically
- Added comprehensive tests for the new sorting and filtering capabilities

### How to test?

1. Use the new query parameters to sort messages by insertion time:
2. Implement cursor-based pagination using the `inserted_at_ns` field:

### Why make this change?

This change addresses several important use cases:

1. **Reliable pagination**: Using `inserted_at_ns` for pagination provides a stable ordering that won't change when messages are added or removed, unlike offset-based pagination.
2. **Chronological insertion order**: Some applications need to display messages in the order they were received by the client, not by their sent timestamp.
3. **Sync efficiency**: The new fields enable more efficient syncing by allowing clients to request only messages inserted after their last sync time.
4. **Conflict resolution**: When multiple messages have the same sent timestamp, insertion time provides a deterministic ordering.