### PR TITLE
fix flakehub

### DIFF
--- a/.github/workflows/fh-cache.yml
+++ b/.github/workflows/fh-cache.yml
@@ -1,5 +1,4 @@
 on:
-  pull_request:
   workflow_dispatch:
   push:
     branches:
@@ -39,6 +38,7 @@ jobs:
       - run: om ci run --include-all-dependencies
       - uses: DeterminateSystems/flakehub-push@main
         with:
-          name: DeterminateSystems/flakehub-push
+          visibility: "public"
           rolling: true
-          visibility: public
+          name: "xmtp/libxmtp"
+          include-output-paths: true


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Update fh-cache workflow to fix FlakeHub by replacing shell step with `DeterminateSystems/flakehub-push@main` and removing `pull_request` trigger in [.github/workflows/fh-cache.yml](https://github.com/xmtp/libxmtp/pull/2685/files#diff-ce3dd25bde306abc234d96f51a92cb524edcabd8e9e5eeed5eb121f73b32b9e2)
- Replace shell step `om ci run --include-all-dependencies` with `DeterminateSystems/flakehub-push@main` in [.github/workflows/fh-cache.yml](https://github.com/xmtp/libxmtp/pull/2685/files#diff-ce3dd25bde306abc234d96f51a92cb524edcabd8e9e5eeed5eb121f73b32b9e2)
- Remove `pull_request` from the workflow `on:` triggers in [.github/workflows/fh-cache.yml](https://github.com/xmtp/libxmtp/pull/2685/files#diff-ce3dd25bde306abc234d96f51a92cb524edcabd8e9e5eeed5eb121f73b32b9e2)
- Update action inputs: set `name` to `xmtp/libxmtp`, set `visibility` to `"public"`, and add `include-output-paths: true`

#### 📍Where to Start
Start with the workflow definition in [.github/workflows/fh-cache.yml](https://github.com/xmtp/libxmtp/pull/2685/files#diff-ce3dd25bde306abc234d96f51a92cb524edcabd8e9e5eeed5eb121f73b32b9e2), focusing on the job step invoking `DeterminateSystems/flakehub-push@main` and the `on:` trigger changes.

----

<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 2b9e738. 0 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
No issues evaluated.


</details>
<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->