### PR TITLE
Notify when messages disappear

### DIFF
--- a/bindings_wasm/src/conversations.rs
+++ b/bindings_wasm/src/conversations.rs
@@ -677,4 +677,19 @@ impl Conversations {
     );
     Ok(StreamCloser::new(stream_closer))
   }
+
+  #[wasm_bindgen(js_name = "streamMessageDeletions")]
+  pub fn stream_message_deletions(
+    &self,
+    callback: StreamCallback,
+  ) -> Result<StreamCloser, JsError> {
+    let stream_closer = RustXmtpClient::stream_message_deletions_with_callback(
+      self.inner_client.clone(),
+      move |message| match message {
+        Ok(message_id) => callback.on_message_deleted(message_id),
+        Err(e) => callback.on_error(JsError::from(e)),
+      },
+    );
+    Ok(StreamCloser::new(stream_closer))
+  }
 }

--- a/bindings_wasm/src/streams.rs
+++ b/bindings_wasm/src/streams.rs
@@ -35,6 +35,9 @@ extern "C" {
   #[wasm_bindgen(structural, method)]
   pub fn on_conversation(this: &StreamCallback, item: Conversation);
 
+  #[wasm_bindgen(structural, method)]
+  pub fn on_message_deleted(this: &StreamCallback, message_id: Vec<u8>);
+
   /// Js Fn to call on error
   #[wasm_bindgen(structural, method)]
   pub fn on_error(this: &StreamCallback, error: JsError);

--- a/xmtp_db/src/encrypted_store/group_message/tests.rs
+++ b/xmtp_db/src/encrypted_store/group_message/tests.rs
@@ -268,8 +268,9 @@ async fn it_deletes_middle_message_by_expiration_time() {
         ];
         assert_ok!(messages.store(conn));
 
-        let result = conn.delete_expired_messages().unwrap();
-        assert_eq!(result, 1); // Ensure exactly 1 message is deleted
+        let deleted_message_ids = conn.delete_expired_messages().unwrap();
+        assert_eq!(deleted_message_ids.len(), 1); // Ensure exactly 1 message is deleted
+        assert_eq!(deleted_message_ids[0], messages[1].id); // Verify the correct message (middle one with expiration) was deleted
 
         let remaining_messages = conn
             .get_group_messages(

--- a/xmtp_db/src/mock.rs
+++ b/xmtp_db/src/mock.rs
@@ -470,7 +470,7 @@ mock! {
             msg_id: &MessageId,
         ) -> Result<usize, crate::ConnectionError>;
 
-        fn delete_expired_messages(&self) -> Result<usize, crate::ConnectionError>;
+        fn delete_expired_messages(&self) -> Result<Vec<Vec<u8>>, crate::ConnectionError>;
 
         #[mockall::concretize]
         fn delete_message_by_id<MessageId: AsRef<[u8]>>(

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -720,7 +720,15 @@ where
     /// Returns the number of messages deleted (0 or 1)
     pub fn delete_message(&self, message_id: Vec<u8>) -> Result<usize, ClientError> {
         let conn = self.context.db();
-        Ok(conn.delete_message_by_id(&message_id)?)
+        let num_deleted = conn.delete_message_by_id(&message_id)?;
+        // Fire a local event if the message was successfully deleted
+        if num_deleted > 0 {
+            let _ = self.context.local_events().send(
+                crate::subscriptions::LocalEvents::MessageDeleted(message_id),
+            );
+        }
+
+        Ok(num_deleted)
     }
 
     /// Query for groups with optional filters


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add message deletion event streaming across FFI, Node, and WASM and emit `subscriptions::LocalEvents::MessageDeleted` from database and client paths to notify when messages disappear
Introduce a local `subscriptions::LocalEvents::MessageDeleted` event and stream it to FFI, Node, and WASM via new `stream_message_deletions` methods; database deletions now return deleted message IDs (`Vec<Vec<u8>>`) and the disappearing messages worker and client emit a deletion event per ID.

#### 📍Where to Start
Start with `subscriptions::stream_message_deletions_with_callback` in [xmtp_mls/src/subscriptions/mod.rs](https://github.com/xmtp/libxmtp/pull/2692/files#diff-0f2359cebb61635cf35774bc0c5e5a5f4b8703e982c2f584e8691cef4d4c2e32), then review the database return-type change in [xmtp_db/src/encrypted_store/group_message.rs](https://github.com/xmtp/libxmtp/pull/2692/files#diff-f81cb97873c6ce33f85646f59ec1ea72f8574b06550596ec29a4ac58c2353373) and the FFI/Node/WASM `stream_message_deletions` handlers.

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 03de1b0.
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->