### PR TITLE
Fix android nix build

### DIFF
--- a/bindings_ffi/gen_kotlin.sh
+++ b/bindings_ffi/gen_kotlin.sh
@@ -25,6 +25,7 @@ cargo run --bin ffi-uniffi-bindgen \
   --features uniffi/cli --release -- \
   generate \
   --library $TARGET_DIR/release/lib$PROJECT_NAME.dylib \
+  --out-dir $BINDINGS_PATH/src \
   --language kotlin
 
 cd $BINDINGS_PATH

--- a/dev/release-kotlin
+++ b/dev/release-kotlin
@@ -55,6 +55,7 @@ $CARGO run --bin ffi-uniffi-bindgen \
   --features uniffi/cli --release -- \
   generate \
   --library $TARGET_DIR/release/$LIB_FILE \
+  --out-dir $BINDINGS_PATH/src \
   --language kotlin
 
 cd $BINDINGS_PATH


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->

<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->

<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->

### Set Kotlin binding generation output to `$BINDINGS_PATH/src` in Android build scripts to fix Android nix build

Add `--out-dir $BINDINGS_PATH/src` to `ffi-uniffi-bindgen generate` in `bindings_ffi/gen_kotlin.sh` and `dev/release-kotlin` so generated Kotlin bindings write to `$BINDINGS_PATH/src`.

#### 📍Where to Start

Start with the `ffi-uniffi-bindgen generate` invocation in [gen_kotlin.sh](https://github.com/xmtp/libxmtp/pull/2694/files#diff-d8f1999f0c459ee064e3b120d9f9de5197496df980cf111dcf5e7e5fb8388920), then review the corresponding change in [dev/release-kotlin](https://github.com/xmtp/libxmtp/pull/2694/files#diff-2de1f06bd2977726c7a621037d5cac1a333eb0af97a891f548c7c6701d562efc).

---

<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 Macroscope summarized a8161ed. 1 file reviewed, 1 issue evaluated, 1 issue filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues

<details>
<summary>bindings_ffi/gen_kotlin.sh — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 13](https://github.com/xmtp/libxmtp/blob/a8161ed219efb07f8a2dcbcecee05e361c12cb98/bindings_ffi/gen_kotlin.sh#L13): Multiple path variables are expanded without quotes (e.g. `XMTP_ANDROID` at line 13, `WORKSPACE_PATH` at line 20, and later `cp` targets), so any valid workspace or Android directory containing spaces causes the script to mis-parse the arguments (e.g. `[ ! -d /Users/me/Dev Projects/xmtp-android ]` → `[: missing ]`) and abort before running the toolchain. Quote these expansions (e.g. `if [ ! -d "$XMTP_ANDROID" ]; then`) everywhere the paths are used to keep the script functional for such installations. **[ Out of scope ]**

</details>

</details>

\<!-- MACROSCOPE_FOOTER_END -->\<!-- Macroscope's pull request summary ends here -->