### PR TITLE
Fix: Include Unknown Content Types In Conversation List

### DIFF
--- a/xmtp_db/migrations/2025-10-28-175920-0000_update_conversation_list_for_unknown_content_types/up.sql
+++ b/xmtp_db/migrations/2025-10-28-175920-0000_update_conversation_list_for_unknown_content_types/up.sql
@@ -1,0 +1,57 @@
+DROP VIEW IF EXISTS conversation_list;
+-- DROP TRIGGER IF EXISTS msg_inserted;
+--
+--- rebuild views with sequence/originators
+CREATE VIEW conversation_list AS
+WITH ranked_messages AS (
+    SELECT
+        gm.group_id,
+        gm.id AS message_id,
+        gm.decrypted_message_bytes,
+        gm.sent_at_ns,
+        gm.kind AS message_kind,
+        gm.sender_installation_id,
+        gm.sender_inbox_id,
+        gm.delivery_status,
+        gm.content_type,
+        gm.version_major,
+        gm.version_minor,
+        gm.authority_id,
+        gm.sequence_id,
+        gm.originator_id,
+        ROW_NUMBER() OVER (PARTITION BY gm.group_id ORDER BY gm.sent_at_ns DESC) AS row_num
+    FROM
+        group_messages gm
+    WHERE
+        gm.kind = 1
+        AND gm.content_type IN (0, 1, 4, 6, 7, 8, 9)
+)
+SELECT
+    g.id AS id,
+    g.created_at_ns,
+    g.membership_state,
+    g.installations_last_checked,
+    g.added_by_inbox_id,
+    g.sequence_id as welcome_sequence_id,
+    g.dm_id,
+    g.rotated_at_ns,
+    g.conversation_type,
+    g.is_commit_log_forked,
+    rm.message_id,
+    rm.decrypted_message_bytes,
+    rm.sent_at_ns,
+    rm.message_kind,
+    rm.sender_installation_id,
+    rm.sender_inbox_id,
+    rm.delivery_status,
+    rm.content_type,
+    rm.version_major,
+    rm.version_minor,
+    rm.authority_id,
+    rm.sequence_id,
+    rm.originator_id
+FROM
+    groups g
+    LEFT JOIN ranked_messages rm
+    ON g.id = rm.group_id AND rm.row_num = 1
+ORDER BY COALESCE(rm.sent_at_ns, g.created_at_ns) DESC;

--- a/xmtp_db/src/encrypted_store/conversation_list.rs
+++ b/xmtp_db/src/encrypted_store/conversation_list.rs
@@ -254,6 +254,7 @@ pub(crate) mod tests {
     };
     use crate::group::{GroupMembershipState, GroupQueryArgs, GroupQueryOrderBy};
     use crate::group_message::ContentType;
+    use crate::group_message::tests::generate_message;
     use crate::prelude::*;
     use crate::test_utils::with_connection;
 
@@ -527,6 +528,32 @@ pub(crate) mod tests {
             assert!(!returned_ids.contains(&&denied_group.id));
         })
         .await
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn test_unknown_content_type_is_present() {
+        with_connection(|conn| {
+            let dm = generate_dm(None);
+            dm.store(conn)?;
+
+            let m = generate_message(
+                None,
+                Some(&dm.id),
+                Some(5000),
+                Some(ContentType::Unknown),
+                None,
+                None,
+            );
+            m.store(conn)?;
+
+            let conv = conn.fetch_conversation_list(GroupQueryArgs {
+                ..Default::default()
+            })?;
+
+            // Message id should be present
+            assert!(conv[0].message_id.is_some());
+        })
+        .await;
     }
 
     #[xmtp_common::test]

--- a/xmtp_db/src/encrypted_store/group/dms.rs
+++ b/xmtp_db/src/encrypted_store/group/dms.rs
@@ -112,14 +112,14 @@ pub(super) mod tests {
 
     /// Generate a test dm group
     pub fn generate_dm(state: Option<GroupMembershipState>) -> StoredGroup {
+        let target = TARGET_INBOX_ID.fetch_add(1, Ordering::SeqCst).to_string();
         StoredGroup::builder()
             .id(rand_vec::<24>())
             .created_at_ns(now_ns())
             .membership_state(state.unwrap_or(GroupMembershipState::Allowed))
             .added_by_inbox_id("placeholder_address")
             .dm_id(format!(
-                "dm:placeholder_inbox_id_1:placeholder_inbox_id_{}",
-                TARGET_INBOX_ID.fetch_add(1, Ordering::SeqCst)
+                "dm:placeholder_inbox_id_1:placeholder_inbox_id_{target}",
             ))
             .build()
             .unwrap()


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Update conversation_list view to include the latest kind=1 message with content types 0, 1, 4, 6, 7, 8, 9 and include groups without messages to fix unknown content types in conversation list
Add a migration that recreates `conversation_list` to select the most recent `group_messages` entry per `group_id` (using `ROW_NUMBER` over `sent_at_ns` desc), filter by `gm.kind = 1` and `gm.content_type in (0, 1, 4, 6, 7, 8, 9)`, left-join to `groups`, and order by `COALESCE(latest sent_at_ns, group created_at_ns)` desc. Add a test that stores `ContentType::Unknown` in a DM and asserts the conversation list returns a message. Adjust the DM test helper to avoid multiple `TARGET_INBOX_ID` increments.

#### 📍Where to Start
Start with the migration defining the `conversation_list` view in [up.sql](https://github.com/xmtp/libxmtp/pull/2695/files#diff-496c28b3898b7897460335162241f23d9df8bd92f50979978ec5fc0f0bc50304), then review the test in [conversation_list.rs](https://github.com/xmtp/libxmtp/pull/2695/files#diff-43c6f0ad2f26bb0197d1ff728e66b5c5d3ec2409a4bcb8739cd08122eadd2b7d) that validates `ContentType::Unknown` handling.

----

<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 8ae50ec. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
No issues evaluated.


</details>
<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->