### PR TITLE
Change streaming cursors to start from last sync

### DIFF
--- a/xmtp_api_d14n/src/protocol/in_memory_cursor_store.rs
+++ b/xmtp_api_d14n/src/protocol/in_memory_cursor_store.rs
@@ -85,17 +85,12 @@ impl CursorStore for InMemoryCursorStore {
             .collect())
     }
 
-    fn latest_maybe_missing_per(
+    fn latest_for_topics(
         &self,
-        topic: &Topic,
-        originators: &[&OriginatorId],
-    ) -> Result<GlobalCursor, super::CursorStoreError> {
-        Ok(self
-            .get_latest(topic)
-            .unwrap_or(&Default::default())
-            .iter()
-            .filter(|(k, _)| originators.contains(k))
-            .map(|(&k, &v)| (k, v))
+        topics: &mut dyn Iterator<Item = &Topic>,
+    ) -> Result<HashMap<Topic, GlobalCursor>, super::CursorStoreError> {
+        Ok(topics
+            .map(|topic| (topic.clone(), self.latest(topic).unwrap_or_default()))
             .collect())
     }
 }

--- a/xmtp_api_d14n/src/protocol/traits/cursor_store.rs
+++ b/xmtp_api_d14n/src/protocol/traits/cursor_store.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use xmtp_common::RetryableError;
 use xmtp_proto::{
     api::ApiClientError,
@@ -67,28 +68,12 @@ pub trait CursorStore: Send + Sync {
         })
     }
 
-    /// A temporary function to get the latest cursor for
-    /// a topic & originator. it may be missing updates.
-    fn latest_maybe_missing_per(
+    /// Get the latest cursor for multiple topics at once.
+    /// Returns a HashMap mapping each topic to its GlobalCursor.
+    fn latest_for_topics(
         &self,
-        topic: &Topic,
-        originator: &[&OriginatorId],
-    ) -> Result<GlobalCursor, CursorStoreError>;
-
-    /// Temporary until reliable streams
-    fn latest_maybe_missing(
-        &self,
-        topic: &Topic,
-        originator: &OriginatorId,
-    ) -> Result<Cursor, CursorStoreError> {
-        let sid = self
-            .latest_maybe_missing_per(topic, &[originator])?
-            .get(originator);
-        Ok(Cursor {
-            originator_id: *originator,
-            sequence_id: sid,
-        })
-    }
+        topics: &mut dyn Iterator<Item = &Topic>,
+    ) -> Result<HashMap<Topic, GlobalCursor>, CursorStoreError>;
 
     // temp until reliable streams
     fn lcc_maybe_missing(&self, topic: &[&Topic]) -> Result<GlobalCursor, CursorStoreError>;

--- a/xmtp_api_d14n/src/queries/v3/streams.rs
+++ b/xmtp_api_d14n/src/queries/v3/streams.rs
@@ -1,7 +1,6 @@
 use crate::{V3Client, v3::*};
 use xmtp_api_grpc::error::GrpcError;
 use xmtp_api_grpc::streams::{TryFromItem, try_from_stream};
-use xmtp_configuration::Originators;
 use xmtp_proto::api::{ApiClientError, Client, QueryStream, XmtpStream};
 use xmtp_proto::api_client::XmtpMlsStreams;
 use xmtp_proto::mls_v1::subscribe_group_messages_request::Filter as GroupSubscribeFilter;
@@ -26,29 +25,26 @@ where
         &self,
         group_ids: &[&GroupId],
     ) -> Result<Self::GroupMessageStream, Self::Error> {
-        let mut filters = vec![];
         let topics = group_ids
             .iter()
             .map(|gid| TopicKind::GroupMessagesV1.create(gid))
             .collect::<Vec<_>>();
-        for topic in topics {
-            let cursor = self
-                .cursor_store
-                .read()
-                .latest_maybe_missing_per(
-                    &topic,
-                    &[
-                        &Originators::APPLICATION_MESSAGES,
-                        &Originators::MLS_COMMITS,
-                    ],
-                )?
-                .max();
+
+        let cursors = self
+            .cursor_store
+            .read()
+            .latest_for_topics(&mut topics.iter())?;
+
+        let mut filters = vec![];
+        for topic in &topics {
+            let cursor = cursors.get(topic).cloned().unwrap_or_default().max();
             tracing::info!("subscribing to {topic} @ {cursor}");
             filters.push(GroupSubscribeFilter {
                 group_id: topic.identifier().to_vec(),
                 id_cursor: cursor,
             })
         }
+
         Ok(try_from_stream(
             SubscribeGroupMessages::builder()
                 .filters(filters)
@@ -62,17 +58,19 @@ where
         &self,
         installations: &[&InstallationId],
     ) -> Result<Self::WelcomeMessageStream, Self::Error> {
-        let mut filters = vec![];
         let topics = installations
             .iter()
             .map(|id| TopicKind::WelcomeMessagesV1.create(id))
             .collect::<Vec<_>>();
-        for topic in topics {
-            let id_cursor = self
-                .cursor_store
-                .read()
-                .latest_maybe_missing_per(&topic, &[&Originators::WELCOME_MESSAGES])?
-                .v3_welcome();
+
+        let cursors = self
+            .cursor_store
+            .read()
+            .latest_for_topics(&mut topics.iter())?;
+
+        let mut filters = vec![];
+        for topic in &topics {
+            let id_cursor = cursors.get(topic).cloned().unwrap_or_default().v3_welcome();
             filters.push(WelcomeSubscribeFilter {
                 installation_key: topic.identifier().to_vec(),
                 id_cursor,

--- a/xmtp_mls/src/cursor_store.rs
+++ b/xmtp_mls/src/cursor_store.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use std::collections::HashMap;
 use xmtp_api_d14n::protocol::{CursorStore, CursorStoreError};
 use xmtp_configuration::Originators;
@@ -96,35 +97,70 @@ where
         }
     }
 
-    fn latest_maybe_missing_per(
+    fn latest_for_topics(
         &self,
-        topic: &Topic,
-        originators: &[&OriginatorId],
-    ) -> Result<GlobalCursor, CursorStoreError> {
-        match topic.kind() {
-            TopicKind::WelcomeMessagesV1 => {
-                let entities = vec![EntityKind::Welcome];
-                self.db
-                    .latest_cursor_combined(topic.identifier(), &entities, Some(originators))
-                    .map_err(|e| CursorStoreError::Other(Box::new(e) as Box<_>))
-            }
-            TopicKind::GroupMessagesV1 => {
-                let entities = vec![EntityKind::ApplicationMessage, EntityKind::CommitMessage];
-                self.db
-                    .latest_cursor_combined(topic.identifier(), &entities, Some(originators))
-                    .map_err(|e| CursorStoreError::Other(Box::new(e) as Box<_>))
-            }
-            TopicKind::IdentityUpdatesV1 => {
-                let sid = self
-                    .db
-                    .get_latest_sequence_id_for_inbox(&hex::encode(topic.identifier()))
-                    .map_err(|e| CursorStoreError::Other(Box::new(e) as Box<_>))?;
-                let mut map = HashMap::new();
-                map.insert(Originators::INBOX_LOG, sid as u64);
-                Ok(GlobalCursor::new(map))
-            }
-            TopicKind::KeyPackagesV1 => Ok(GlobalCursor::default()),
-            _ => Err(CursorStoreError::UnhandledTopicKind(topic.kind())),
-        }
+        topics: &mut dyn Iterator<Item = &Topic>,
+    ) -> Result<HashMap<Topic, GlobalCursor>, CursorStoreError> {
+        // Partition topics by kind
+        let partitions = topics.into_group_map_by(|t| t.kind());
+
+        partitions
+            .into_iter()
+            .map(|(kind, topics_of_kind)| match kind {
+                TopicKind::WelcomeMessagesV1 => {
+                    let identifiers: Vec<_> =
+                        topics_of_kind.iter().map(|t| t.identifier()).collect();
+                    let mut cursors = self
+                        .db
+                        .get_last_cursor_for_ids(&identifiers, &[EntityKind::Welcome])
+                        .map_err(|e| CursorStoreError::Other(Box::new(e) as Box<_>))?;
+
+                    Ok(topics_of_kind
+                        .into_iter()
+                        .map(|topic| {
+                            let cursor = cursors.remove(topic.identifier()).unwrap_or_default();
+                            (topic.clone(), cursor)
+                        })
+                        .collect())
+                }
+                TopicKind::GroupMessagesV1 => {
+                    let identifiers: Vec<_> =
+                        topics_of_kind.iter().map(|t| t.identifier()).collect();
+                    let mut cursors = self
+                        .db
+                        .get_last_cursor_for_ids(
+                            &identifiers,
+                            &[EntityKind::ApplicationMessage, EntityKind::CommitMessage],
+                        )
+                        .map_err(|e| CursorStoreError::Other(Box::new(e) as Box<_>))?;
+
+                    Ok(topics_of_kind
+                        .into_iter()
+                        .map(|topic| {
+                            let cursor = cursors.remove(topic.identifier()).unwrap_or_default();
+                            (topic.clone(), cursor)
+                        })
+                        .collect())
+                }
+                TopicKind::IdentityUpdatesV1 => topics_of_kind
+                    .into_iter()
+                    .map(|topic| {
+                        let sid = self
+                            .db
+                            .get_latest_sequence_id_for_inbox(&hex::encode(topic.identifier()))
+                            .map_err(|e| CursorStoreError::Other(Box::new(e) as Box<_>))?;
+                        let mut map = HashMap::new();
+                        map.insert(Originators::INBOX_LOG, sid as u64);
+                        Ok((topic.clone(), GlobalCursor::new(map)))
+                    })
+                    .collect(),
+                TopicKind::KeyPackagesV1 => Ok(topics_of_kind
+                    .into_iter()
+                    .map(|topic| (topic.clone(), GlobalCursor::default()))
+                    .collect()),
+                _ => Err(CursorStoreError::UnhandledTopicKind(kind)),
+            })
+            .collect::<Result<Vec<HashMap<Topic, GlobalCursor>>, _>>()
+            .map(|results| results.into_iter().flatten().collect())
     }
 }

--- a/xmtp_proto/src/types/topic.rs
+++ b/xmtp_proto/src/types/topic.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::{ConversionError, xmtp::xmtpv4::envelopes::AuthenticatedData};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u8)]
 #[non_exhaustive]
 pub enum TopicKind {


### PR DESCRIPTION
### TL;DR

Refactored cursor store API to efficiently handle multiple topics at once with the new `latest_for_topics` method.

### What changed?

- Replaced `latest_maybe_missing_per` with a more efficient `latest_for_topics` method that handles multiple topics in a single call
- Updated implementations in `InMemoryCursorStore` and MLS cursor store to support batch processing of topics
- Modified the streams implementation to use the new API when subscribing to group and welcome messages
- Made `TopicKind` derive `Hash` to support using it as a key in HashMaps

### How to test?

- Verify that subscribing to group messages and welcome messages works correctly
- Test with multiple topics to ensure the batch processing functions as expected
- Check that cursor retrieval maintains the same behavior as before but with improved efficiency

### Why make this change?

This change improves performance by reducing the number of database calls when working with multiple topics. Instead of making separate calls for each topic, we now batch them together, which is especially beneficial when subscribing to multiple groups or installations simultaneously. The new API is also cleaner and more intuitive for handling collections of topics.