### PR TITLE
Fix issue with group messages subscription cursors

### DIFF
--- a/xmtp_api/src/debug_wrapper.rs
+++ b/xmtp_api/src/debug_wrapper.rs
@@ -240,6 +240,20 @@ where
         .await
     }
 
+    async fn subscribe_group_messages_with_cursors(
+        &self,
+        groups_with_cursors: &[(&GroupId, GlobalCursor)],
+    ) -> Result<Self::GroupMessageStream, Self::Error> {
+        wrap_err(
+            || {
+                self.inner
+                    .subscribe_group_messages_with_cursors(groups_with_cursors)
+            },
+            || self.inner.aggregate_stats(),
+        )
+        .await
+    }
+
     async fn subscribe_welcome_messages(
         &self,
         installations: &[&InstallationId],

--- a/xmtp_api/src/mls.rs
+++ b/xmtp_api/src/mls.rs
@@ -250,6 +250,23 @@ where
             .map_err(crate::dyn_err)
     }
 
+    pub async fn subscribe_group_messages_with_cursors(
+        &self,
+        groups_with_cursors: &[(&GroupId, xmtp_proto::types::GlobalCursor)],
+    ) -> Result<<ApiClient as XmtpMlsStreams>::GroupMessageStream>
+    where
+        ApiClient: XmtpMlsStreams,
+    {
+        tracing::debug!(
+            inbox_id = self.inbox_id,
+            "subscribing to group messages with cursors"
+        );
+        self.api_client
+            .subscribe_group_messages_with_cursors(groups_with_cursors)
+            .await
+            .map_err(crate::dyn_err)
+    }
+
     pub async fn subscribe_welcome_messages(
         &self,
         installation_key: &InstallationId,

--- a/xmtp_api_d14n/src/queries/api_stats.rs
+++ b/xmtp_api_d14n/src/queries/api_stats.rs
@@ -185,6 +185,16 @@ where
         self.inner.subscribe_group_messages(group_ids).await
     }
 
+    async fn subscribe_group_messages_with_cursors(
+        &self,
+        groups_with_cursors: &[(&GroupId, xmtp_proto::types::GlobalCursor)],
+    ) -> Result<Self::GroupMessageStream, Self::Error> {
+        self.stats.subscribe_messages.count_request();
+        self.inner
+            .subscribe_group_messages_with_cursors(groups_with_cursors)
+            .await
+    }
+
     async fn subscribe_welcome_messages(
         &self,
         installations: &[&InstallationId],

--- a/xmtp_api_d14n/src/queries/boxed_streams.rs
+++ b/xmtp_api_d14n/src/queries/boxed_streams.rs
@@ -167,6 +167,17 @@ where
         Ok(Box::pin(s) as Pin<Box<_>>)
     }
 
+    async fn subscribe_group_messages_with_cursors(
+        &self,
+        groups_with_cursors: &[(&GroupId, xmtp_proto::types::GlobalCursor)],
+    ) -> Result<Self::GroupMessageStream, Self::Error> {
+        let s = self
+            .inner
+            .subscribe_group_messages_with_cursors(groups_with_cursors)
+            .await?;
+        Ok(Box::pin(s) as Pin<Box<_>>)
+    }
+
     async fn subscribe_welcome_messages(
         &self,
         installations: &[&InstallationId],

--- a/xmtp_api_d14n/src/queries/d14n/streams.rs
+++ b/xmtp_api_d14n/src/queries/d14n/streams.rs
@@ -4,10 +4,11 @@ use crate::protocol::{GroupMessageExtractor, WelcomeMessageExtractor};
 use crate::queries::stream;
 
 use super::D14nClient;
+use std::collections::HashMap;
 use xmtp_common::{MaybeSend, RetryableError};
 use xmtp_proto::api::{ApiClientError, Client, QueryStream, XmtpStream};
 use xmtp_proto::api_client::XmtpMlsStreams;
-use xmtp_proto::types::{GroupId, InstallationId, TopicKind};
+use xmtp_proto::types::{GlobalCursor, GroupId, InstallationId, TopicKind};
 use xmtp_proto::xmtp::xmtpv4::message_api::SubscribeEnvelopesResponse;
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
@@ -43,7 +44,41 @@ where
             .cursor_store
             .load()
             .lcc_maybe_missing(&topics.iter().collect::<Vec<_>>())?;
-        tracing::info!("subscribing to messages @cursor={}", lcc);
+        tracing::debug!("subscribing to messages @cursor={}", lcc);
+        let s = SubscribeEnvelopes::builder()
+            .topics(topics)
+            .last_seen(lcc)
+            .build()?
+            .stream(&self.message_client)
+            .await?;
+        Ok(stream::try_extractor(s))
+    }
+
+    async fn subscribe_group_messages_with_cursors(
+        &self,
+        groups_with_cursors: &[(&GroupId, GlobalCursor)],
+    ) -> Result<Self::GroupMessageStream, Self::Error> {
+        let topics = groups_with_cursors
+            .iter()
+            .map(|(gid, _)| TopicKind::GroupMessagesV1.create(gid))
+            .collect::<Vec<_>>();
+
+        // Compute the lowest common cursor from the provided cursors
+        let mut min_clock: HashMap<u32, u64> = HashMap::new();
+        for (_, cursor) in groups_with_cursors {
+            for (&node_id, &seq_id) in cursor.iter() {
+                min_clock
+                    .entry(node_id)
+                    .and_modify(|existing| *existing = (*existing).min(seq_id))
+                    .or_insert(seq_id);
+            }
+        }
+        let lcc = GlobalCursor::new(min_clock);
+
+        tracing::debug!(
+            "subscribing to messages with provided cursors @cursor={}",
+            lcc
+        );
         let s = SubscribeEnvelopes::builder()
             .topics(topics)
             .last_seen(lcc)

--- a/xmtp_api_d14n/src/test/mock_client.rs
+++ b/xmtp_api_d14n/src/test/mock_client.rs
@@ -113,6 +113,8 @@ mod not_wasm {
             #[mockall::concretize]
             async fn subscribe_group_messages(&self, group_ids: &[&GroupId]) -> Result<MockGroupStream, MockError>;
             #[mockall::concretize]
+            async fn subscribe_group_messages_with_cursors(&self, groups_with_cursors: &[(&GroupId, xmtp_proto::types::GlobalCursor)]) -> Result<MockGroupStream, MockError>;
+            #[mockall::concretize]
             async fn subscribe_welcome_messages(&self, installations: &[&InstallationId]) -> Result<MockWelcomeStream, MockError>;
         }
 
@@ -191,6 +193,8 @@ mod wasm {
 
             #[mockall::concretize]
             async fn subscribe_group_messages(&self, group_ids: &[&GroupId]) -> Result<MockGroupStream, MockError>;
+            #[mockall::concretize]
+            async fn subscribe_group_messages_with_cursors(&self, groups_with_cursors: &[(&GroupId, xmtp_proto::types::GlobalCursor)]) -> Result<MockGroupStream, MockError>;
             #[mockall::concretize]
             async fn subscribe_welcome_messages(&self, installations: &[&InstallationId]) -> Result<MockWelcomeStream, MockError>;
         }

--- a/xmtp_mls/src/subscriptions/stream_messages.rs
+++ b/xmtp_mls/src/subscriptions/stream_messages.rs
@@ -215,33 +215,40 @@ where
     ///
     /// # Arguments
     /// * `context` - Reference to the client used for API communication
-    /// * `filters` - Current list of group filters
+    /// * `groups_with_positions` - List of tuples containing group IDs and their current positions
     /// * `new_group` - ID of the new group to add
     ///
     /// # Returns
-    /// * `Result<(MessagesApiSubscription<'a, C>, Vec<u8>, Option<u64>)>` - A tuple containing:
+    /// * `Result<(MessagesApiSubscription<'a, C>, Vec<u8>, Option<Cursor>)>` - A tuple containing:
     ///   - The new message subscription
     ///   - The ID of the newly added group
     ///   - The cursor position for the new group (if available)
     ///
     /// # Errors
     /// May return errors if:
-    /// - Querying the database for the last cursor fails
     /// - Creating the new subscription fails
     #[tracing::instrument(level = "trace", skip(context, new_group), fields(new_group = hex::encode(&new_group)))]
     #[allow(clippy::type_complexity)]
     async fn subscribe(
         context: Cow<'a, C>,
-        filters: Vec<GroupId>,
+        groups_with_positions: Vec<(GroupId, MessagePosition)>,
         new_group: Vec<u8>,
     ) -> Result<(
         MessagesApiSubscription<'a, C::ApiClient>,
         Vec<u8>,
         Option<Cursor>,
     )> {
+        use xmtp_proto::types::GlobalCursor;
+
+        let groups_with_cursors: Vec<(&GroupId, GlobalCursor)> = groups_with_positions
+            .iter()
+            .map(|(group_id, position)| (group_id, GlobalCursor::new(position.last_streamed())))
+            .collect();
+
         let stream = context
+            .as_ref()
             .api()
-            .subscribe_group_messages(&filters.iter().collect::<Vec<_>>())
+            .subscribe_group_messages_with_cursors(&groups_with_cursors)
             .await?;
         Ok((
             stream,
@@ -419,7 +426,8 @@ where
         let this = self.as_mut().project();
         this.groups
             .add(&group.group_id, MessagePosition::new(Cursor::new(1, 0u32)));
-        let future = Self::subscribe(self.context.clone(), self.groups.ids(), group.group_id);
+        let groups_with_positions = self.groups.groups_with_positions();
+        let future = Self::subscribe(self.context.clone(), groups_with_positions, group.group_id);
         let mut this = self.as_mut().project();
         this.state.set(State::Adding {
             future: FutureWrapper::new(future),

--- a/xmtp_mls/src/subscriptions/stream_messages/types.rs
+++ b/xmtp_mls/src/subscriptions/stream_messages/types.rs
@@ -86,8 +86,12 @@ impl GroupList {
         self.seen.contains(&cursor)
     }
 
-    pub(super) fn ids(&self) -> Vec<GroupId> {
-        self.list.keys().cloned().collect()
+    /// get all groups with their positions
+    pub(super) fn groups_with_positions(&self) -> Vec<(GroupId, MessagePosition)> {
+        self.list
+            .iter()
+            .map(|(id, pos)| (id.clone(), pos.clone()))
+            .collect()
     }
 
     /// get the `MessagePosition` for `group_id`, if any

--- a/xmtp_proto/src/api_client.rs
+++ b/xmtp_proto/src/api_client.rs
@@ -162,6 +162,10 @@ pub trait XmtpMlsStreams {
         &self,
         group_ids: &[&GroupId],
     ) -> Result<Self::GroupMessageStream, Self::Error>;
+    async fn subscribe_group_messages_with_cursors(
+        &self,
+        groups_with_cursors: &[(&GroupId, crate::types::GlobalCursor)],
+    ) -> Result<Self::GroupMessageStream, Self::Error>;
     async fn subscribe_welcome_messages(
         &self,
         installations: &[&InstallationId],

--- a/xmtp_proto/src/api_client/impls.rs
+++ b/xmtp_proto/src/api_client/impls.rs
@@ -266,6 +266,15 @@ where
         (**self).subscribe_group_messages(group_ids).await
     }
 
+    async fn subscribe_group_messages_with_cursors(
+        &self,
+        groups_with_cursors: &[(&GroupId, crate::types::GlobalCursor)],
+    ) -> Result<Self::GroupMessageStream, Self::Error> {
+        (**self)
+            .subscribe_group_messages_with_cursors(groups_with_cursors)
+            .await
+    }
+
     async fn subscribe_welcome_messages(
         &self,
         installations: &[&InstallationId],
@@ -291,6 +300,15 @@ where
         group_ids: &[&GroupId],
     ) -> Result<Self::GroupMessageStream, Self::Error> {
         (**self).subscribe_group_messages(group_ids).await
+    }
+
+    async fn subscribe_group_messages_with_cursors(
+        &self,
+        groups_with_cursors: &[(&GroupId, crate::types::GlobalCursor)],
+    ) -> Result<Self::GroupMessageStream, Self::Error> {
+        (**self)
+            .subscribe_group_messages_with_cursors(groups_with_cursors)
+            .await
     }
 
     async fn subscribe_welcome_messages(


### PR DESCRIPTION
### Add support for subscribing to group messages with cursors

This PR adds a new method `subscribe_group_messages_with_cursors` to the `XmtpMlsStreams` trait, allowing clients to subscribe to group messages with specific cursor positions. This enhancement improves message streaming efficiency by enabling precise cursor control when subscribing to multiple groups.

The implementation:
1. Adds the new method to the `XmtpMlsStreams` trait and implements it across all relevant client types
2. Updates the message streaming logic to use the new method when subscribing to multiple groups
3. Modifies the `GroupList` to track groups with their positions rather than just IDs
4. Adds a comprehensive test for concurrent message streaming across multiple groups

#### 📍Where to Start

Start with the `test_stream_all_concurrent_writes` test in [tests.rs](https://github.com/xmtp/libxmtp/pull/2699/files#diff-da36cd09e25a94ff061dc4a491c213ce2a588ec230d68dc46575f927063176c7).