### PR TITLE
remove CursorAwareApi trait and reorganize client implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,4 @@ result
 archive.xmtp
 coverage_diff_html/**
 .direnv/**
+om.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8312,7 +8312,6 @@ dependencies = [
 name = "xmtp_api_d14n"
 version = "1.6.0-dev"
 dependencies = [
- "arc-swap",
  "async-trait",
  "chrono",
  "const-hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,6 @@ openmls_basic_credential = { git = "https://github.com/xmtp/openmls", rev = "51f
 openmls_libcrux_crypto = { git = "https://github.com/xmtp/openmls", rev = "51f800df4d56d74fb2dde993f33e320b573df60e" }
 openmls_rust_crypto = { git = "https://github.com/xmtp/openmls", rev = "51f800df4d56d74fb2dde993f33e320b573df60e" }
 openmls_traits = { git = "https://github.com/xmtp/openmls", rev = "51f800df4d56d74fb2dde993f33e320b573df60e" }
-
 owo-colors = { version = "4.1" }
 p256 = { version = "0.13.2", features = ["ecdsa"] }
 parking_lot = "0.12.3"

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -11,7 +11,8 @@ use prost::Message;
 use std::{collections::HashMap, convert::TryInto, sync::Arc};
 use tokio::sync::Mutex;
 use xmtp_api::{ApiClientWrapper, strategies};
-use xmtp_api_d14n::MessageBackendBuilder;
+use xmtp_api_d14n::{MessageBackendBuilder, new_client_with_store};
+use xmtp_api_grpc::error::GrpcError;
 use xmtp_common::time::now_ns;
 use xmtp_common::{AbortHandle, GenericStreamHandle, StreamHandle};
 use xmtp_content_types::attachment::Attachment;
@@ -58,6 +59,7 @@ use xmtp_mls::common::group::GroupMetadataOptions;
 use xmtp_mls::common::group_metadata::GroupMetadata;
 use xmtp_mls::common::group_mutable_metadata::MessageDisappearingSettings;
 use xmtp_mls::common::group_mutable_metadata::MetadataField;
+use xmtp_mls::cursor_store::SqliteCursorStore;
 use xmtp_mls::groups::ConversationDebugInfo;
 use xmtp_mls::groups::device_sync::DeviceSyncError;
 use xmtp_mls::groups::device_sync::archive::ArchiveImporter;
@@ -87,6 +89,7 @@ use xmtp_mls::{
     identity::IdentityStrategy,
     subscriptions::SubscribeError,
 };
+use xmtp_proto::api::ApiClientError;
 use xmtp_proto::api_client::AggregateStats;
 use xmtp_proto::api_client::ApiStats;
 use xmtp_proto::api_client::IdentityStats;
@@ -303,11 +306,19 @@ pub async fn create_client(
         legacy_signed_private_key_proto,
     );
 
+    //TODO:temp_cache_workaround
+    let api_client: xmtp_mls::XmtpApiClient = Arc::unwrap_or_clone(api).0;
+    let sync_api_client: xmtp_mls::XmtpApiClient = Arc::unwrap_or_clone(sync_api).0;
+    let cursor_store = Arc::new(SqliteCursorStore::new(store.db()));
+    // ensure to clone grpc channels but allocate a new type for the cursor store
+    let api_client = new_client_with_store::<ApiClientError<GrpcError>>(
+        api_client.clone(),
+        cursor_store.clone(),
+    )?;
+    let sync_api_client = new_client_with_store(sync_api_client.clone(), cursor_store)?;
+
     let mut builder = xmtp_mls::Client::builder(identity_strategy)
-        .api_clients(
-            Arc::unwrap_or_clone(api).0,
-            Arc::unwrap_or_clone(sync_api).0,
-        )
+        .api_clients(api_client, sync_api_client)
         .enable_api_stats()?
         .enable_api_debug_wrapper()?
         .with_remote_verifier()?

--- a/bindings_node/src/client.rs
+++ b/bindings_node/src/client.rs
@@ -14,6 +14,7 @@ use xmtp_api_d14n::MessageBackendBuilder;
 use xmtp_db::{EncryptedMessageStore, EncryptionKey, NativeDb, StorageOption};
 use xmtp_mls::Client as MlsClient;
 use xmtp_mls::builder::SyncWorkerMode as XmtpSyncWorkerMode;
+use xmtp_mls::cursor_store::SqliteCursorStore;
 use xmtp_mls::groups::MlsGroup;
 use xmtp_mls::identity::IdentityStrategy;
 use xmtp_mls::utils::events::upload_debug_archive;
@@ -169,9 +170,6 @@ pub async fn create_client(
     .app_version(app_version.clone().unwrap_or_default())
     .is_secure(is_secure);
 
-  let api_client = backend.clone().build().map_err(ErrorWrapper::from)?;
-  let sync_api_client = backend.clone().build().map_err(ErrorWrapper::from)?;
-
   let storage_option = match db_path {
     Some(path) => StorageOption::Persistent(path),
     None => StorageOption::Ephemeral,
@@ -203,6 +201,11 @@ pub async fn create_client(
     1,
     None,
   );
+
+  let cursor_store = SqliteCursorStore::new(store.db());
+  backend.cursor_store(cursor_store);
+  let api_client = backend.clone().build().map_err(ErrorWrapper::from)?;
+  let sync_api_client = backend.clone().build().map_err(ErrorWrapper::from)?;
 
   let mut builder = xmtp_mls::Client::builder(identity_strategy)
     .api_clients(api_client, sync_api_client)

--- a/bindings_wasm/src/client.rs
+++ b/bindings_wasm/src/client.rs
@@ -11,6 +11,7 @@ use xmtp_db::{EncryptedMessageStore, EncryptionKey, StorageOption, WasmDb};
 use xmtp_id::associations::Identifier as XmtpIdentifier;
 use xmtp_mls::Client as MlsClient;
 use xmtp_mls::builder::SyncWorkerMode;
+use xmtp_mls::cursor_store::SqliteCursorStore;
 use xmtp_mls::groups::MlsGroup;
 use xmtp_mls::identity::IdentityStrategy;
 use xmtp_mls::utils::events::upload_debug_archive;
@@ -187,15 +188,6 @@ pub async fn create_client(
     .app_version(app_version.clone().unwrap_or_default())
     .is_secure(true);
 
-  let api_client = backend
-    .clone()
-    .build()
-    .map_err(|e| JsError::new(&e.to_string()))?;
-  let sync_api_client = backend
-    .clone()
-    .build()
-    .map_err(|e| JsError::new(&e.to_string()))?;
-
   let storage_option = match db_path {
     Some(path) => StorageOption::Persistent(path),
     None => StorageOption::Ephemeral,
@@ -225,6 +217,16 @@ pub async fn create_client(
     1,
     None,
   );
+
+  backend.cursor_store(SqliteCursorStore::new(store.db()));
+  let api_client = backend
+    .clone()
+    .build()
+    .map_err(|e| JsError::new(&e.to_string()))?;
+  let sync_api_client = backend
+    .clone()
+    .build()
+    .map_err(|e| JsError::new(&e.to_string()))?;
 
   let mut builder = xmtp_mls::Client::builder(identity_strategy)
     .api_clients(api_client, sync_api_client)

--- a/examples/cli/cli-client.rs
+++ b/examples/cli/cli-client.rs
@@ -30,7 +30,7 @@ use tracing_subscriber::{
     Registry,
 };
 use valuable::Valuable;
-use xmtp_api_d14n::protocol::{CursorStore, XmtpQuery};
+use xmtp_api_d14n::protocol::XmtpQuery;
 use xmtp_api_d14n::MessageBackendBuilder;
 use xmtp_common::time::now_ns;
 use xmtp_configuration::{
@@ -53,10 +53,10 @@ use xmtp_mls::context::XmtpSharedContext;
 use xmtp_mls::groups::device_sync_legacy::DeviceSyncContent;
 use xmtp_mls::groups::send_message_opts::SendMessageOptsBuilder;
 use xmtp_mls::groups::GroupError;
+use xmtp_mls::XmtpApi;
 use xmtp_mls::XmtpApiClient;
 use xmtp_mls::{builder::ClientBuilderError, client::ClientError};
 use xmtp_mls::{identity::IdentityStrategy, InboxOwner};
-use xmtp_mls::{CursorAwareApi, XmtpApi};
 use xmtp_proto::types::ApiIdentifier;
 
 #[macro_use]
@@ -498,9 +498,7 @@ async fn main() -> color_eyre::eyre::Result<()> {
     Ok(())
 }
 
-async fn create_client<
-    C: XmtpApi + Clone + XmtpQuery + CursorAwareApi<CursorStore = Arc<dyn CursorStore>> + 'static,
->(
+async fn create_client<C: XmtpApi + Clone + XmtpQuery + 'static>(
     cli: &Cli,
     account: IdentityStrategy,
     grpc: C,
@@ -536,7 +534,7 @@ async fn register<C>(
     client: C,
 ) -> Result<(), CliError>
 where
-    C: Clone + XmtpApi + XmtpQuery + CursorAwareApi<CursorStore = Arc<dyn CursorStore>> + 'static,
+    C: Clone + XmtpApi + XmtpQuery + 'static,
 {
     let w: Wallet = if let Some(seed_phrase) = maybe_seed_phrase {
         Wallet::LocalWallet(

--- a/flake.lock
+++ b/flake.lock
@@ -164,13 +164,13 @@
     "rust-manifest": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-nmjsTmZxqLNvubj4IJlRzXy6iVpncGHL3iJPfx5oE/M=",
+        "narHash": "sha256-Mrw0LDR4i/CDGhDZ10IUTGkFow/+yIJGeBKMIWi/nqg=",
         "type": "file",
-        "url": "https://static.rust-lang.org/dist/channel-rust-1.90.0.toml"
+        "url": "https://static.rust-lang.org/dist/channel-rust-1.91.0.toml"
       },
       "original": {
         "type": "file",
-        "url": "https://static.rust-lang.org/dist/channel-rust-1.90.0.toml"
+        "url": "https://static.rust-lang.org/dist/channel-rust-1.91.0.toml"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -4,15 +4,15 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     fenix = {
       url = "github:nix-community/fenix";
-      inputs = { nixpkgs.follows = "nixpkgs"; };
+      inputs = {nixpkgs.follows = "nixpkgs";};
     };
-    flake-parts = { url = "github:hercules-ci/flake-parts"; };
+    flake-parts = {url = "github:hercules-ci/flake-parts";};
     foundry.url = "github:shazow/foundry.nix/stable";
     crane = {
       url = "github:ipetkov/crane";
     };
     rust-manifest = {
-      url = "https://static.rust-lang.org/dist/channel-rust-1.90.0.toml";
+      url = "https://static.rust-lang.org/dist/channel-rust-1.91.0.toml";
       flake = false;
     };
   };
@@ -22,8 +22,15 @@
     extra-substituters = "https://xmtp.cachix.org";
   };
 
-  outputs = inputs@{ self, flake-parts, fenix, crane, foundry, ... }:
-    flake-parts.lib.mkFlake { inherit inputs; } {
+  outputs = inputs @ {
+    self,
+    flake-parts,
+    fenix,
+    crane,
+    foundry,
+    ...
+  }:
+    flake-parts.lib.mkFlake {inherit inputs;} {
       systems = [
         "aarch64-darwin"
         "x86_64-linux"
@@ -32,33 +39,35 @@
         ./nix/lib
         flake-parts.flakeModules.easyOverlay
       ];
-      perSystem = { pkgs, system, ... }:
-        let
-          pkgConfig = {
-            inherit system;
-            # Rust Overlay
-            overlays = [ fenix.overlays.default foundry.overlay self.overlays.default ];
-            config = {
-              android_sdk.accept_license = true;
-              allowUnfree = true;
-            };
+      perSystem = {
+        pkgs,
+        system,
+        ...
+      }: let
+        pkgConfig = {
+          inherit system;
+          # Rust Overlay
+          overlays = [fenix.overlays.default foundry.overlay self.overlays.default];
+          config = {
+            android_sdk.accept_license = true;
+            allowUnfree = true;
           };
-        in
-        {
-          _module.args.pkgs = import inputs.nixpkgs pkgConfig;
-          devShells = {
-            # shell for general xmtp rust dev
-            default = pkgs.callPackage ./nix/libxmtp.nix { };
-            # Shell for android builds
-            android = pkgs.callPackage ./nix/android.nix { };
-            # Shell for iOS builds
-            ios = pkgs.callPackage ./nix/ios.nix { };
-            js = pkgs.callPackage ./nix/js.nix { };
-            # the environment bindings_wasm is built in
-            wasmBuild = (pkgs.callPackage ./nix/package/wasm.nix { craneLib = crane.mkLib pkgs; }).devShell;
-          };
-          packages.wasm-bindings = (pkgs.callPackage ./nix/package/wasm.nix { craneLib = crane.mkLib pkgs; }).bin;
-          packages.wasm-bindgen-cli = pkgs.callPackage ./nix/lib/packages/wasm-bindgen-cli.nix { };
         };
+      in {
+        _module.args.pkgs = import inputs.nixpkgs pkgConfig;
+        devShells = {
+          # shell for general xmtp rust dev
+          default = pkgs.callPackage ./nix/libxmtp.nix {};
+          # Shell for android builds
+          android = pkgs.callPackage ./nix/android.nix {};
+          # Shell for iOS builds
+          ios = pkgs.callPackage ./nix/ios.nix {};
+          js = pkgs.callPackage ./nix/js.nix {};
+          # the environment bindings_wasm is built in
+          wasmBuild = (pkgs.callPackage ./nix/package/wasm.nix {craneLib = crane.mkLib pkgs;}).devShell;
+        };
+        packages.wasm-bindings = (pkgs.callPackage ./nix/package/wasm.nix {craneLib = crane.mkLib pkgs;}).bin;
+        packages.wasm-bindgen-cli = pkgs.callPackage ./nix/lib/packages/wasm-bindgen-cli.nix {};
+      };
     };
 }

--- a/om.json
+++ b/om.json
@@ -1,1 +1,0 @@
-/nix/store/ddyz71fnzdwfp9i27g0vgapqqnjl50cx-addstringcontext.json

--- a/xmtp_api/src/debug_wrapper.rs
+++ b/xmtp_api/src/debug_wrapper.rs
@@ -5,7 +5,6 @@ use xmtp_common::RetryableError;
 use xmtp_proto::api::HasStats;
 use xmtp_proto::api_client::AggregateStats;
 use xmtp_proto::api_client::ApiStats;
-use xmtp_proto::api_client::CursorAwareApi;
 use xmtp_proto::api_client::IdentityStats;
 use xmtp_proto::mls_v1::GetNewestGroupMessageRequest;
 use xmtp_proto::mls_v1::{
@@ -318,14 +317,6 @@ where
             || self.inner.aggregate_stats(),
         )
         .await
-    }
-}
-
-impl<A: CursorAwareApi> CursorAwareApi for ApiDebugWrapper<A> {
-    type CursorStore = A::CursorStore;
-
-    fn set_cursor_store(&self, store: Self::CursorStore) {
-        <A as CursorAwareApi>::set_cursor_store(&self.inner, store);
     }
 }
 

--- a/xmtp_api/src/lib.rs
+++ b/xmtp_api/src/lib.rs
@@ -8,7 +8,6 @@ pub mod test_utils;
 
 pub mod debug_wrapper;
 pub use debug_wrapper::*;
-use xmtp_proto::api_client::CursorAwareApi;
 
 use std::sync::Arc;
 
@@ -67,27 +66,12 @@ pub struct ApiClientWrapper<ApiClient> {
     pub(crate) inbox_id: Option<String>,
 }
 
-impl<C: CursorAwareApi> CursorAwareApi for ApiClientWrapper<C> {
-    type CursorStore = <C as CursorAwareApi>::CursorStore;
-    fn set_cursor_store(&self, store: Self::CursorStore) {
-        self.api_client.set_cursor_store(store);
-    }
-}
-
 impl<ApiClient> ApiClientWrapper<ApiClient> {
     pub fn new(api_client: ApiClient, retry_strategy: Retry<ExponentialBackoff>) -> Self {
         Self {
             api_client,
             retry_strategy: retry_strategy.into(),
             inbox_id: None,
-        }
-    }
-
-    pub fn attach_debug_wrapper(self) -> ApiClientWrapper<ApiDebugWrapper<ApiClient>> {
-        ApiClientWrapper {
-            api_client: ApiDebugWrapper::new(self.api_client),
-            retry_strategy: self.retry_strategy,
-            inbox_id: self.inbox_id,
         }
     }
 

--- a/xmtp_api/src/mls.rs
+++ b/xmtp_api/src/mls.rs
@@ -369,6 +369,7 @@ pub mod tests {
     use xmtp_api_d14n::MockApiClient;
     use xmtp_api_d14n::MockError;
     use xmtp_api_d14n::V3Client;
+    use xmtp_api_d14n::protocol::NoCursorStore;
     use xmtp_common::FakeMlsApplicationMessage;
     use xmtp_common::Generate;
     use xmtp_common::rand_vec;
@@ -475,7 +476,7 @@ pub mod tests {
     #[xmtp_common::test]
     async fn test_read_group_messages_single_page() {
         let mock_api = MockNetworkClient::default();
-        let mut v3_client = V3Client::new_stateless(mock_api);
+        let mut v3_client = V3Client::new(mock_api, NoCursorStore);
         let group_id = rand_vec::<16>();
         let group_id_clone = group_id.clone();
         // Set expectation for first request with no cursor
@@ -512,7 +513,7 @@ pub mod tests {
     #[xmtp_common::test]
     async fn test_read_group_messages_single_page_xactly_100_results() {
         let mock_api = MockNetworkClient::default();
-        let mut v3_client = V3Client::new_stateless(mock_api);
+        let mut v3_client = V3Client::new(mock_api, NoCursorStore);
         let group_id = rand_vec::<16>();
         let group_id_clone = group_id.clone();
         // Set expectation for first request with no cursor
@@ -549,7 +550,7 @@ pub mod tests {
     #[xmtp_common::test]
     async fn test_read_topic_multi_page() {
         let mock_api = MockNetworkClient::new();
-        let mut v3_client = V3Client::new_stateless(mock_api);
+        let mut v3_client = V3Client::new(mock_api, NoCursorStore);
         let group_id = vec![1, 2, 3, 4];
         let group_id_clone = group_id.clone();
         let group_id_clone2 = group_id.clone();

--- a/xmtp_api_d14n/Cargo.toml
+++ b/xmtp_api_d14n/Cargo.toml
@@ -8,7 +8,6 @@ version.workspace = true
 workspace = true
 
 [dependencies]
-arc-swap.workspace = true
 async-trait.workspace = true
 chrono.workspace = true
 derive_builder.workspace = true

--- a/xmtp_api_d14n/src/definitions.rs
+++ b/xmtp_api_d14n/src/definitions.rs
@@ -1,20 +1,20 @@
-use xmtp_api_grpc::GrpcClient;
-use xmtp_proto::prelude::XmtpMlsStreams;
+use std::sync::Arc;
 
-use crate::{D14nClient, V3Client};
+use xmtp_api_grpc::GrpcClient;
+
+use crate::{
+    D14nClient, MultiNodeClient, V3Client,
+    protocol::{CursorStore, NoCursorStore},
+};
 
 xmtp_common::if_v3! {
-    pub type ApiClient = crate::V3Client<GrpcClient>;
+    pub type ApiClient = crate::V3Client<GrpcClient, NoCursorStore>;
 }
 
 xmtp_common::if_d14n! {
-    pub type ApiClient = crate::D14nClient<GrpcClient, GrpcClient>;
+    pub type ApiClient = crate::D14nClient<GrpcClient, GrpcClient, NoCursorStore>;
 }
 
-pub type D14nGroupStream =
-    <D14nClient<GrpcClient, GrpcClient> as XmtpMlsStreams>::GroupMessageStream;
-pub type D14nWelcomeStream =
-    <D14nClient<GrpcClient, GrpcClient> as XmtpMlsStreams>::WelcomeMessageStream;
+pub type FullD14nClient = D14nClient<MultiNodeClient, GrpcClient, Arc<dyn CursorStore>>;
 
-pub type V3GroupStream = <V3Client<GrpcClient> as XmtpMlsStreams>::GroupMessageStream;
-pub type V3WelcomeStream = <V3Client<GrpcClient> as XmtpMlsStreams>::WelcomeMessageStream;
+pub type FullV3Client = V3Client<GrpcClient, Arc<dyn CursorStore>>;

--- a/xmtp_api_d14n/src/middleware/multi_node_client/client.rs
+++ b/xmtp_api_d14n/src/middleware/multi_node_client/client.rs
@@ -7,6 +7,7 @@ use xmtp_proto::api::{ApiClientError, Client, IsConnectedCheck};
 
 /* MultiNodeClient struct and its implementations */
 
+#[derive(Clone)]
 pub struct MultiNodeClient {
     pub gateway_client: GrpcClient,
     pub inner: OnceCell<GrpcClient>,
@@ -79,7 +80,7 @@ mod tests {
     use super::*;
     use crate::{
         middleware::{MiddlewareBuilder, MultiNodeClientBuilder},
-        protocol::InMemoryCursorStore,
+        protocol::{InMemoryCursorStore, NoCursorStore},
         queries::D14nClient,
     };
     use std::sync::Arc;
@@ -124,11 +125,11 @@ mod tests {
         multi_node_builder.into_client().unwrap()
     }
 
-    fn create_d14n_client() -> D14nClient<MultiNodeClient, GrpcClient> {
+    fn create_d14n_client() -> D14nClient<MultiNodeClient, GrpcClient, NoCursorStore> {
         D14nClient::new(
             create_multinode_client_builder().into_client().unwrap(),
             create_gateway_builder().build().unwrap(),
-            create_in_memory_cursor_store(),
+            NoCursorStore,
         )
         .unwrap()
     }

--- a/xmtp_api_d14n/src/protocol/traits.rs
+++ b/xmtp_api_d14n/src/protocol/traits.rs
@@ -40,6 +40,12 @@ pub use extractor::*;
 mod envelope_collection;
 pub use envelope_collection::*;
 
+mod vector_clock;
+pub use vector_clock::*;
+
+mod full_api;
+pub use full_api::*;
+
 #[derive(thiserror::Error, Debug)]
 pub enum EnvelopeError {
     #[error(transparent)]

--- a/xmtp_api_d14n/src/protocol/traits/cursor_store.rs
+++ b/xmtp_api_d14n/src/protocol/traits/cursor_store.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 use xmtp_common::{MaybeSend, MaybeSync, RetryableError};
 use xmtp_proto::{
     api::ApiClientError,
-    types::{ClockOrdering, Cursor, GlobalCursor, OriginatorId, Topic, TopicKind},
+    types::{Cursor, GlobalCursor, OriginatorId, Topic, TopicKind},
 };
 
 #[derive(thiserror::Error, Debug)]
@@ -79,14 +80,143 @@ pub trait CursorStore: MaybeSend + MaybeSync {
     fn lcc_maybe_missing(&self, topic: &[&Topic]) -> Result<GlobalCursor, CursorStoreError>;
 }
 
-/// common functions w.r.t vector clock types
-pub trait VectorClock {
-    /// Merges another clock into this one by taking the max ordering per node
-    fn dominates(&self, other: &Self) -> bool;
+impl<T: CursorStore> CursorStore for Option<T> {
+    fn lowest_common_cursor(&self, topics: &[&Topic]) -> Result<GlobalCursor, CursorStoreError> {
+        if let Some(c) = self {
+            c.lowest_common_cursor(topics)
+        } else {
+            NoCursorStore.lowest_common_cursor(topics)
+        }
+    }
 
-    /// Returns true if this clock dominates (has seen all updates of) the other
-    fn merge(&mut self, other: &Self);
+    fn latest(&self, topic: &Topic) -> Result<GlobalCursor, CursorStoreError> {
+        if let Some(c) = self {
+            c.latest(topic)
+        } else {
+            NoCursorStore.latest(topic)
+        }
+    }
 
-    /// Compares this clock to another to determine their relative ordering
-    fn compare(&self, other: &Self) -> ClockOrdering;
+    fn latest_per_originator(
+        &self,
+        topic: &Topic,
+        originators: &[&OriginatorId],
+    ) -> Result<GlobalCursor, CursorStoreError> {
+        if let Some(c) = self {
+            c.latest_per_originator(topic, originators)
+        } else {
+            NoCursorStore.latest_per_originator(topic, originators)
+        }
+    }
+
+    fn latest_for_topics(
+        &self,
+        topics: &mut dyn Iterator<Item = &Topic>,
+    ) -> Result<HashMap<Topic, GlobalCursor>, CursorStoreError> {
+        if let Some(c) = self {
+            c.latest_for_topics(topics)
+        } else {
+            NoCursorStore.latest_for_topics(topics)
+        }
+    }
+
+    fn lcc_maybe_missing(&self, topic: &[&Topic]) -> Result<GlobalCursor, CursorStoreError> {
+        if let Some(c) = self {
+            c.lcc_maybe_missing(topic)
+        } else {
+            NoCursorStore.lcc_maybe_missing(topic)
+        }
+    }
+}
+
+impl<T: CursorStore + ?Sized> CursorStore for Arc<T> {
+    fn lowest_common_cursor(&self, topics: &[&Topic]) -> Result<GlobalCursor, CursorStoreError> {
+        (**self).lowest_common_cursor(topics)
+    }
+
+    fn latest(&self, topic: &Topic) -> Result<GlobalCursor, CursorStoreError> {
+        (**self).latest(topic)
+    }
+
+    fn latest_per_originator(
+        &self,
+        topic: &Topic,
+        originators: &[&OriginatorId],
+    ) -> Result<GlobalCursor, CursorStoreError> {
+        (**self).latest_per_originator(topic, originators)
+    }
+
+    fn latest_for_topics(
+        &self,
+        topics: &mut dyn Iterator<Item = &Topic>,
+    ) -> Result<HashMap<Topic, GlobalCursor>, CursorStoreError> {
+        (**self).latest_for_topics(topics)
+    }
+
+    fn lcc_maybe_missing(&self, topic: &[&Topic]) -> Result<GlobalCursor, CursorStoreError> {
+        (**self).lcc_maybe_missing(topic)
+    }
+}
+
+impl<T: CursorStore + ?Sized> CursorStore for Box<T> {
+    fn lowest_common_cursor(&self, topics: &[&Topic]) -> Result<GlobalCursor, CursorStoreError> {
+        (**self).lowest_common_cursor(topics)
+    }
+
+    fn latest(&self, topic: &Topic) -> Result<GlobalCursor, CursorStoreError> {
+        (**self).latest(topic)
+    }
+
+    fn latest_per_originator(
+        &self,
+        topic: &Topic,
+        originators: &[&OriginatorId],
+    ) -> Result<GlobalCursor, CursorStoreError> {
+        (**self).latest_per_originator(topic, originators)
+    }
+
+    fn latest_for_topics(
+        &self,
+        topics: &mut dyn Iterator<Item = &Topic>,
+    ) -> Result<HashMap<Topic, GlobalCursor>, CursorStoreError> {
+        (**self).latest_for_topics(topics)
+    }
+
+    fn lcc_maybe_missing(&self, topic: &[&Topic]) -> Result<GlobalCursor, CursorStoreError> {
+        (**self).lcc_maybe_missing(topic)
+    }
+}
+/// This cursor store always returns 0
+#[derive(Default)]
+pub struct NoCursorStore;
+
+impl CursorStore for NoCursorStore {
+    fn lowest_common_cursor(&self, _: &[&Topic]) -> Result<GlobalCursor, CursorStoreError> {
+        Ok(GlobalCursor::default())
+    }
+
+    fn latest(&self, _: &Topic) -> Result<GlobalCursor, CursorStoreError> {
+        Ok(GlobalCursor::default())
+    }
+
+    fn latest_per_originator(
+        &self,
+        _: &Topic,
+        _: &[&OriginatorId],
+    ) -> Result<GlobalCursor, CursorStoreError> {
+        Ok(GlobalCursor::default())
+    }
+
+    fn latest_for_topics(
+        &self,
+        topics: &mut dyn Iterator<Item = &Topic>,
+    ) -> Result<HashMap<Topic, GlobalCursor>, CursorStoreError> {
+        Ok(HashMap::from_iter(
+            topics.map(|t| (t.clone(), GlobalCursor::default())),
+        ))
+    }
+
+    fn lcc_maybe_missing(&self, _: &[&Topic]) -> Result<GlobalCursor, CursorStoreError> {
+        Ok(GlobalCursor::default())
+    }
 }

--- a/xmtp_api_d14n/src/protocol/traits/full_api.rs
+++ b/xmtp_api_d14n/src/protocol/traits/full_api.rs
@@ -1,0 +1,62 @@
+use std::{any::Any, sync::Arc};
+
+use xmtp_proto::{
+    api::IsConnectedCheck,
+    api_client::{BoxedGroupS, BoxedWelcomeS},
+    prelude::{XmtpIdentityClient, XmtpMlsClient, XmtpMlsStreams},
+};
+
+use crate::{
+    definitions::{FullD14nClient, FullV3Client},
+    protocol::XmtpQuery,
+};
+
+/// A type-erased version of the Xmtp Api in a [`Box`]
+pub type FullXmtpApiBox<Err> = Box<dyn FullXmtpApiT<Err>>;
+/// A type-erased version of the Xntp Api in a [`Arc`]
+pub type FullXmtpApiArc<Err> = Arc<dyn FullXmtpApiT<Err>>;
+
+// TODO: Can remove boxes once switchover to d14n (one client) is complete.
+
+/// Trait combining all other api traits into one
+/// Used for describing the entire XmtpApi from
+/// the client perspective in a single `dyn Trait`
+/// or otherwise requiring the full capabilities
+/// of the API.
+/// Requiring the full capabilities outside of a dyn should generally be avoided
+/// unless the consumer wants to be unnecessarily general/restrictive.
+pub trait FullXmtpApiT<Err>
+where
+    Self: AnyClient
+        + XmtpMlsClient<Error = Err>
+        + XmtpIdentityClient<Error = Err>
+        + XmtpMlsStreams<
+            Error = Err,
+            WelcomeMessageStream = BoxedWelcomeS<Err>,
+            GroupMessageStream = BoxedGroupS<Err>,
+        > + IsConnectedCheck
+        + XmtpQuery<Error = Err>
+        + 'static,
+{
+}
+
+impl<T, Err> FullXmtpApiT<Err> for T where
+    T: AnyClient
+        + XmtpMlsClient<Error = Err>
+        + XmtpIdentityClient<Error = Err>
+        + XmtpMlsStreams<
+            Error = Err,
+            WelcomeMessageStream = BoxedWelcomeS<Err>,
+            GroupMessageStream = BoxedGroupS<Err>,
+        > + IsConnectedCheck
+        + XmtpQuery<Error = Err>
+        + ?Sized
+        + 'static
+{
+}
+
+// TEMP trait
+pub trait AnyClient: Any + 'static {
+    fn downcast_ref_v3client(&self) -> Option<&'_ FullV3Client>;
+    fn downcast_ref_d14nclient(&self) -> Option<&'_ FullD14nClient>;
+}

--- a/xmtp_api_d14n/src/protocol/traits/into_cached.rs
+++ b/xmtp_api_d14n/src/protocol/traits/into_cached.rs
@@ -1,0 +1,4 @@
+pub trait IntoCached {
+    type Output;
+    fn into_cached(&self) -> Self::Output;
+}

--- a/xmtp_api_d14n/src/protocol/traits/vector_clock.rs
+++ b/xmtp_api_d14n/src/protocol/traits/vector_clock.rs
@@ -1,0 +1,13 @@
+use xmtp_proto::types::ClockOrdering;
+
+/// common functions w.r.t vector clock types
+pub trait VectorClock {
+    /// Merges another clock into this one by taking the max ordering per node
+    fn dominates(&self, other: &Self) -> bool;
+
+    /// Returns true if this clock dominates (has seen all updates of) the other
+    fn merge(&mut self, other: &Self);
+
+    /// Compares this clock to another to determine their relative ordering
+    fn compare(&self, other: &Self) -> ClockOrdering;
+}

--- a/xmtp_api_d14n/src/queries/api_stats.rs
+++ b/xmtp_api_d14n/src/queries/api_stats.rs
@@ -1,7 +1,6 @@
 use xmtp_proto::api::HasStats;
 use xmtp_proto::api_client::AggregateStats;
 use xmtp_proto::api_client::ApiStats;
-use xmtp_proto::api_client::CursorAwareApi;
 use xmtp_proto::api_client::IdentityStats;
 use xmtp_proto::api_client::XmtpMlsClient;
 use xmtp_proto::identity_v1;
@@ -221,6 +220,7 @@ impl<C> HasStats for TrackedStatsClient<C> {
     }
 }
 
+#[derive(Clone)]
 pub struct StatsBuilder<Builder> {
     client: Builder,
 }
@@ -284,28 +284,6 @@ where
     }
 }
 
-impl<C> CursorAwareApi for TrackedStatsClient<C>
-where
-    C: CursorAwareApi,
-{
-    type CursorStore = <C as CursorAwareApi>::CursorStore;
-
-    fn set_cursor_store(&self, store: Self::CursorStore) {
-        <C as CursorAwareApi>::set_cursor_store(&self.inner, store);
-    }
-}
-
-impl<Builder> CursorAwareApi for StatsBuilder<Builder>
-where
-    Builder: CursorAwareApi,
-{
-    type CursorStore = <Builder as CursorAwareApi>::CursorStore;
-
-    fn set_cursor_store(&self, store: Self::CursorStore) {
-        <Builder as CursorAwareApi>::set_cursor_store(&self.client, store);
-    }
-}
-
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<C: XmtpQuery> XmtpQuery for TrackedStatsClient<C> {
@@ -323,10 +301,31 @@ impl<C: XmtpQuery> XmtpQuery for TrackedStatsClient<C> {
 #[cfg(any(test, feature = "test-utils"))]
 mod tests {
     #![allow(clippy::unwrap_used)]
+    use crate::XmtpTestClientExt;
+
     use super::*;
     use xmtp_configuration::LOCALHOST;
     use xmtp_proto::ToxicProxies;
     use xmtp_proto::{TestApiBuilder, prelude::XmtpTestClient};
+
+    impl<C> XmtpTestClientExt for TrackedStatsClient<C>
+    where
+        C: XmtpTestClientExt,
+    {
+        fn with_cursor_store(
+            f: impl Fn() -> <Self as XmtpTestClient>::Builder,
+            store: std::sync::Arc<dyn crate::protocol::CursorStore>,
+        ) -> <Self as XmtpTestClient>::Builder {
+            let f = || {
+                let b = f();
+                b.client
+            };
+            StatsBuilder {
+                client: <C as XmtpTestClientExt>::with_cursor_store(f, store),
+            }
+        }
+    }
+
     impl<C> XmtpTestClient for TrackedStatsClient<C>
     where
         C: XmtpTestClient,

--- a/xmtp_api_d14n/src/queries/boxed_streams.rs
+++ b/xmtp_api_d14n/src/queries/boxed_streams.rs
@@ -1,9 +1,9 @@
+use crate::protocol::AnyClient;
 use crate::protocol::XmtpQuery;
 use std::pin::Pin;
 use xmtp_proto::api::HasStats;
 use xmtp_proto::api::IsConnectedCheck;
 use xmtp_proto::api_client::ApiStats;
-use xmtp_proto::api_client::CursorAwareApi;
 use xmtp_proto::api_client::IdentityStats;
 use xmtp_proto::api_client::XmtpMlsClient;
 use xmtp_proto::identity_v1;
@@ -13,7 +13,6 @@ use xmtp_proto::prelude::XmtpMlsStreams;
 use xmtp_proto::types::InstallationId;
 use xmtp_proto::types::WelcomeMessage;
 use xmtp_proto::types::{GroupId, GroupMessage};
-
 /// Wraps an ApiClient to allow turning
 /// a concretely-typed client into type-erased a [`BoxableXmtpApi`]
 /// allowing for the transformation into a type-erased Api Client
@@ -227,10 +226,15 @@ impl<C: XmtpQuery> XmtpQuery for BoxedStreamsClient<C> {
     }
 }
 
-impl<A: CursorAwareApi> CursorAwareApi for BoxedStreamsClient<A> {
-    type CursorStore = A::CursorStore;
+impl<C> AnyClient for BoxedStreamsClient<C>
+where
+    C: AnyClient,
+{
+    fn downcast_ref_v3client(&self) -> Option<&'_ crate::definitions::FullV3Client> {
+        <C as AnyClient>::downcast_ref_v3client(&self.inner)
+    }
 
-    fn set_cursor_store(&self, store: Self::CursorStore) {
-        <A as CursorAwareApi>::set_cursor_store(&self.inner, store);
+    fn downcast_ref_d14nclient(&self) -> Option<&'_ crate::definitions::FullD14nClient> {
+        <C as AnyClient>::downcast_ref_d14nclient(&self.inner)
     }
 }

--- a/xmtp_api_d14n/src/queries/builder.rs
+++ b/xmtp_api_d14n/src/queries/builder.rs
@@ -3,19 +3,19 @@
 use std::sync::Arc;
 use std::time::Duration;
 use thiserror::Error;
-use xmtp_api_grpc::error::GrpcBuilderError;
-use xmtp_api_grpc::{GrpcClient, error::GrpcError};
+use xmtp_api_grpc::GrpcClient;
+use xmtp_api_grpc::error::{GrpcBuilderError, GrpcError};
+use xmtp_common::RetryableError;
 use xmtp_common::{MaybeSend, MaybeSync};
 use xmtp_configuration::MULTI_NODE_TIMEOUT_MS;
 use xmtp_id::scw_verifier::VerifierError;
-use xmtp_proto::api::IsConnectedCheck;
-use xmtp_proto::api_client::CursorAwareApi;
-use xmtp_proto::api_client::{ApiBuilder, BoxedGroupS, BoxedWelcomeS};
-use xmtp_proto::prelude::{XmtpIdentityClient, XmtpMlsClient, XmtpMlsStreams};
-use xmtp_proto::{api::ApiClientError, types::AppVersion};
+use xmtp_proto::api::ApiClientError;
+use xmtp_proto::api_client::ApiBuilder;
+use xmtp_proto::types::AppVersion;
 
-use crate::protocol::{CursorStore, InMemoryCursorStore, XmtpQuery};
+use crate::protocol::{CursorStore, FullXmtpApiArc, FullXmtpApiBox, FullXmtpApiT, NoCursorStore};
 use crate::{D14nClient, MiddlewareBuilder, MultiNodeClientBuilderError, V3Client};
+
 mod impls;
 
 /// Builder to access the backend XMTP API
@@ -39,39 +39,8 @@ pub enum MessageBackendBuilderError {
     MultiNode(#[from] MultiNodeClientBuilderError),
     #[error(transparent)]
     Scw(#[from] VerifierError),
-}
-
-/// A type-erased version of the Xmtp Api in a [`Box`]
-pub type FullXmtpApiBox<E> = Box<dyn FullXmtpApiT<E>>;
-/// A type-erased version of the Xntp Api in a [`Arc`]
-pub type FullXmtpApiArc<E> = Arc<dyn FullXmtpApiT<E>>;
-
-pub trait FullXmtpApiT<Err>
-where
-    Self: XmtpMlsClient<Error = Err>
-        + XmtpIdentityClient<Error = Err>
-        + XmtpMlsStreams<
-            Error = Err,
-            WelcomeMessageStream = BoxedWelcomeS<Err>,
-            GroupMessageStream = BoxedGroupS<Err>,
-        > + IsConnectedCheck
-        + XmtpQuery<Error = Err>
-        + CursorAwareApi<CursorStore = Arc<dyn CursorStore>>,
-{
-}
-
-impl<T, Err> FullXmtpApiT<Err> for T where
-    T: XmtpMlsClient<Error = Err>
-        + XmtpIdentityClient<Error = Err>
-        + XmtpMlsStreams<
-            Error = Err,
-            WelcomeMessageStream = BoxedWelcomeS<Err>,
-            GroupMessageStream = BoxedGroupS<Err>,
-        > + IsConnectedCheck
-        + CursorAwareApi<CursorStore = Arc<dyn CursorStore>>
-        + XmtpQuery<Error = Err>
-        + ?Sized
-{
+    #[error("failed to build stateful local client, cursor store not replaced, type {0}")]
+    CursorStoreNotReplaced(&'static str),
 }
 
 /// Indicates this api implementation can be type-erased
@@ -142,8 +111,7 @@ impl MessageBackendBuilder {
             cursor_store,
         } = self.clone();
         let v3_host = v3_host.ok_or(MessageBackendBuilderError::MissingV3Host)?;
-        let cursor_store =
-            cursor_store.unwrap_or(Arc::new(InMemoryCursorStore::default()) as Arc<_>);
+        let cursor_store = cursor_store.unwrap_or(Arc::new(NoCursorStore) as Arc<dyn CursorStore>);
 
         if let Some(gateway) = gateway_host {
             let mut gateway_client_builder = GrpcClient::builder();
@@ -172,7 +140,29 @@ impl MessageBackendBuilder {
             }
 
             let v3_client = v3_client.build()?;
-            Ok(V3Client::new(v3_client, cursor_store).arced())
+            let v3_client = V3Client::new(v3_client, cursor_store);
+            tracing::info!("V3Client type: {}", std::any::type_name_of_val(&v3_client));
+            Ok(v3_client.arced())
         }
     }
+}
+
+// TODO:d14n: Remove once D14n-only
+/// Temporary standalone to produce a new ApiClient with a cached store
+pub fn new_client_with_store<E>(
+    api: Arc<dyn FullXmtpApiT<E>>,
+    store: Arc<dyn CursorStore>,
+) -> Result<Arc<dyn FullXmtpApiT<ApiClientError<GrpcError>>>, MessageBackendBuilderError>
+where
+    E: RetryableError + 'static,
+{
+    if let Some(c) = super::d14n::d14n_new_with_store(api.clone(), store.clone()) {
+        return Ok(c);
+    }
+    if let Some(c) = super::v3::v3_new_with_store(api.clone(), store) {
+        return Ok(c);
+    }
+    Err(MessageBackendBuilderError::CursorStoreNotReplaced(
+        std::any::type_name_of_val(&api),
+    ))
 }

--- a/xmtp_api_d14n/src/queries/d14n.rs
+++ b/xmtp_api_d14n/src/queries/d14n.rs
@@ -5,227 +5,46 @@ mod streams;
 mod to_dyn_api;
 mod xmtp_query;
 
+mod client;
+use crate::definitions::FullD14nClient;
+use crate::definitions::FullV3Client;
+use crate::protocol::AnyClient;
+pub use client::*;
 use std::sync::Arc;
+use xmtp_api_grpc::error::GrpcError;
+use xmtp_common::RetryableError;
+use xmtp_proto::api::ApiClientError;
 
-use arc_swap::ArcSwap;
-use xmtp_common::{MaybeSend, MaybeSync, RetryableError};
-use xmtp_id::scw_verifier::MultiSmartContractSignatureVerifier;
-use xmtp_id::scw_verifier::VerifierError;
-use xmtp_proto::{
-    api::IsConnectedCheck, api_client::CursorAwareApi, prelude::ApiBuilder, types::AppVersion,
+use crate::{
+    ToDynApi,
+    protocol::{CursorStore, FullXmtpApiT},
 };
 
-use crate::protocol::{CursorStore, InMemoryCursorStore};
-
-#[derive(Clone)]
-pub struct D14nClient<C, G> {
-    message_client: C,
-    gateway_client: G,
-    cursor_store: Arc<ArcSwap<Arc<dyn CursorStore>>>,
-    scw_verifier: Arc<MultiSmartContractSignatureVerifier>,
-}
-
-impl<C, G> D14nClient<C, G> {
-    pub fn new(
-        message_client: C,
-        gateway_client: G,
-        cursor_store: Arc<dyn CursorStore>,
-    ) -> Result<Self, VerifierError> {
-        Ok(Self {
-            message_client,
-            gateway_client,
-            cursor_store: Arc::new(ArcSwap::from_pointee(cursor_store)),
-            scw_verifier: Arc::new(MultiSmartContractSignatureVerifier::new_from_env()?),
-        })
-    }
-
-    pub fn new_stateless(message_client: C, gateway_client: G) -> Result<Self, VerifierError> {
-        Ok(Self {
-            message_client,
-            gateway_client,
-            cursor_store: Arc::new(ArcSwap::from_pointee(
-                Arc::new(InMemoryCursorStore::new()) as Arc<_>
-            )),
-            scw_verifier: Arc::new(MultiSmartContractSignatureVerifier::new_from_env()?),
-        })
-    }
-}
-
-pub struct D14nClientBuilder<Builder1, Builder2> {
-    message_client: Builder1,
-    gateway_client: Builder2,
-    store: Arc<ArcSwap<Arc<dyn CursorStore>>>,
-}
-
-impl<Builder1, Builder2> D14nClientBuilder<Builder1, Builder2> {
-    pub fn new(
-        message_client: Builder1,
-        gateway_client: Builder2,
-        store: Arc<dyn CursorStore>,
-    ) -> Self {
-        Self {
-            message_client,
-            gateway_client,
-            store: Arc::new(ArcSwap::from_pointee(store)),
-        }
-    }
-
-    pub fn new_stateless(message_client: Builder1, gateway_client: Builder2) -> Self {
-        Self {
-            message_client,
-            gateway_client,
-            store: Arc::new(ArcSwap::from_pointee(
-                Arc::new(InMemoryCursorStore::new()) as Arc<_>
-            )),
-        }
-    }
-}
-
-#[derive(thiserror::Error, Debug)]
-pub enum D14nBuilderError<E> {
-    #[error(transparent)]
-    ClientError(E),
-    #[error(transparent)]
-    VerifierError(#[from] VerifierError),
-}
-
-impl<E: RetryableError> RetryableError for D14nBuilderError<E> {
-    fn is_retryable(&self) -> bool {
-        match self {
-            Self::ClientError(e) => e.is_retryable(),
-            Self::VerifierError(v) => v.is_retryable(),
-        }
-    }
-}
-
-impl<E> D14nBuilderError<E> {
-    fn err(e: E) -> Self {
-        Self::ClientError(e)
-    }
-}
-
-impl<Builder1, Builder2> ApiBuilder for D14nClientBuilder<Builder1, Builder2>
+//TODO:temp_cache_workaround
+pub fn d14n_new_with_store<E>(
+    api: Arc<dyn FullXmtpApiT<E>>,
+    store: Arc<dyn CursorStore>,
+) -> Option<Arc<dyn FullXmtpApiT<ApiClientError<GrpcError>>>>
 where
-    Builder1: ApiBuilder<Error = <Builder2 as ApiBuilder>::Error>,
-    Builder2: ApiBuilder,
+    E: RetryableError + 'static,
 {
-    type Output = D14nClient<<Builder1 as ApiBuilder>::Output, <Builder2 as ApiBuilder>::Output>;
-
-    type Error = D14nBuilderError<<Builder1 as ApiBuilder>::Error>;
-
-    fn set_libxmtp_version(&mut self, version: String) -> Result<(), Self::Error> {
-        <Builder1 as ApiBuilder>::set_libxmtp_version(&mut self.message_client, version.clone())
-            .map_err(D14nBuilderError::err)?;
-        <Builder2 as ApiBuilder>::set_libxmtp_version(&mut self.gateway_client, version)
-            .map_err(D14nBuilderError::err)
-    }
-
-    fn set_app_version(&mut self, version: AppVersion) -> Result<(), Self::Error> {
-        <Builder1 as ApiBuilder>::set_app_version(&mut self.message_client, version.clone())
-            .map_err(D14nBuilderError::err)?;
-        <Builder2 as ApiBuilder>::set_app_version(&mut self.gateway_client, version)
-            .map_err(D14nBuilderError::err)
-    }
-
-    fn set_host(&mut self, host: String) {
-        <Builder1 as ApiBuilder>::set_host(&mut self.message_client, host);
-    }
-
-    fn set_gateway(&mut self, gateway: String) {
-        <Builder2 as ApiBuilder>::set_host(&mut self.gateway_client, gateway)
-    }
-
-    fn set_tls(&mut self, tls: bool) {
-        <Builder1 as ApiBuilder>::set_tls(&mut self.message_client, tls);
-        <Builder2 as ApiBuilder>::set_tls(&mut self.gateway_client, tls)
-    }
-
-    fn set_retry(&mut self, retry: xmtp_common::Retry) {
-        <Builder1 as ApiBuilder>::set_retry(&mut self.message_client, retry.clone());
-        <Builder2 as ApiBuilder>::set_retry(&mut self.gateway_client, retry)
-    }
-
-    fn rate_per_minute(&mut self, limit: u32) {
-        <Builder1 as ApiBuilder>::rate_per_minute(&mut self.message_client, limit);
-        <Builder2 as ApiBuilder>::rate_per_minute(&mut self.gateway_client, limit)
-    }
-
-    fn port(&self) -> Result<Option<String>, Self::Error> {
-        <Builder1 as ApiBuilder>::port(&self.message_client).map_err(D14nBuilderError::err)
-    }
-
-    fn host(&self) -> Option<&str> {
-        <Builder1 as ApiBuilder>::host(&self.message_client)
-    }
-
-    fn build(self) -> Result<Self::Output, Self::Error> {
-        Ok(D14nClient {
-            message_client: <Builder1 as ApiBuilder>::build(self.message_client)
-                .map_err(D14nBuilderError::err)?,
-            gateway_client: <Builder2 as ApiBuilder>::build(self.gateway_client)
-                .map_err(D14nBuilderError::err)?,
-            cursor_store: self.store,
-            scw_verifier: Arc::new(MultiSmartContractSignatureVerifier::new_from_env()?),
-        })
+    // create a new type that doesn't point to the given store
+    if let Some(c) = api.as_ref().downcast_ref_d14nclient() {
+        // ensure we clone but not in an Arc<>
+        let mut c: D14nClient<_, _, _> = c.clone();
+        c.cursor_store = store;
+        Some(c.arced())
+    } else {
+        None
     }
 }
 
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-impl<C, G> IsConnectedCheck for D14nClient<C, G>
-where
-    G: IsConnectedCheck,
-    C: IsConnectedCheck,
-{
-    async fn is_connected(&self) -> bool {
-        self.message_client.is_connected().await && self.gateway_client.is_connected().await
+impl AnyClient for FullD14nClient {
+    fn downcast_ref_v3client(&self) -> Option<&'_ FullV3Client> {
+        None
     }
-}
 
-impl<C1: MaybeSend + MaybeSync, C2: MaybeSend + MaybeSync> CursorAwareApi for D14nClient<C1, C2> {
-    type CursorStore = Arc<dyn CursorStore>;
-    fn set_cursor_store(&self, store: Self::CursorStore) {
-        self.cursor_store.store(store.into());
-    }
-}
-
-impl<B1: MaybeSend + MaybeSync, B2: MaybeSend + MaybeSync> CursorAwareApi
-    for D14nClientBuilder<B1, B2>
-{
-    type CursorStore = Arc<dyn CursorStore>;
-
-    fn set_cursor_store(&self, store: Self::CursorStore) {
-        self.store.store(store.into());
-    }
-}
-
-#[cfg(any(test, feature = "test-utils"))]
-mod test {
-    #![allow(clippy::unwrap_used)]
-    use xmtp_configuration::LOCALHOST;
-    use xmtp_proto::{TestApiBuilder, ToxicProxies};
-
-    use super::*;
-    impl<Builder1, Builder2> TestApiBuilder for D14nClientBuilder<Builder1, Builder2>
-    where
-        Builder1: ApiBuilder<Error = <Builder2 as ApiBuilder>::Error> + 'static,
-        Builder2: ApiBuilder + 'static,
-        <Builder1 as ApiBuilder>::Output: xmtp_proto::api::Client + 'static,
-        <Builder2 as ApiBuilder>::Output: xmtp_proto::api::Client + 'static,
-    {
-        async fn with_toxiproxy(&mut self) -> ToxicProxies {
-            let xmtpd_host = <Builder1 as ApiBuilder>::host(&self.message_client).unwrap();
-            let gateway_host = <Builder2 as ApiBuilder>::host(&self.gateway_client).unwrap();
-            let proxies = xmtp_proto::init_toxi(&[xmtpd_host, gateway_host]).await;
-            <Builder1 as ApiBuilder>::set_host(
-                &mut self.message_client,
-                format!("{LOCALHOST}:{}", proxies.ports()[0]),
-            );
-            <Builder2 as ApiBuilder>::set_host(
-                &mut self.gateway_client,
-                format!("{LOCALHOST}:{}", proxies.ports()[1]),
-            );
-            proxies
-        }
+    fn downcast_ref_d14nclient(&self) -> Option<&'_ FullD14nClient> {
+        Some(self)
     }
 }

--- a/xmtp_api_d14n/src/queries/d14n/client.rs
+++ b/xmtp_api_d14n/src/queries/d14n/client.rs
@@ -1,0 +1,190 @@
+use std::sync::Arc;
+
+use xmtp_common::MaybeSend;
+use xmtp_common::MaybeSync;
+use xmtp_common::RetryableError;
+use xmtp_id::scw_verifier::MultiSmartContractSignatureVerifier;
+use xmtp_id::scw_verifier::VerifierError;
+use xmtp_proto::{api::IsConnectedCheck, prelude::ApiBuilder, types::AppVersion};
+
+#[derive(Clone)]
+pub struct D14nClient<C, G, Store> {
+    pub(super) message_client: C,
+    pub(super) gateway_client: G,
+    pub(super) cursor_store: Store,
+    pub(super) scw_verifier: Arc<MultiSmartContractSignatureVerifier>,
+}
+
+impl<C, G, Store> D14nClient<C, G, Store> {
+    pub fn new(
+        message_client: C,
+        gateway_client: G,
+        cursor_store: Store,
+    ) -> Result<Self, VerifierError> {
+        Ok(Self {
+            message_client,
+            gateway_client,
+            cursor_store,
+            scw_verifier: Arc::new(MultiSmartContractSignatureVerifier::new_from_env()?),
+        })
+    }
+}
+
+#[cfg_attr(any(test, feature = "test-utils"), derive(Clone))]
+pub struct D14nClientBuilder<Builder1, Builder2, Store> {
+    message_client: Builder1,
+    gateway_client: Builder2,
+    cursor_store: Store,
+}
+
+impl<Builder1, Builder2, Store> D14nClientBuilder<Builder1, Builder2, Store> {
+    pub fn new(message_client: Builder1, gateway_client: Builder2, cursor_store: Store) -> Self {
+        Self {
+            message_client,
+            gateway_client,
+            cursor_store,
+        }
+    }
+
+    pub fn cursor_store(&mut self, store: Store) -> &mut Self {
+        self.cursor_store = store;
+        self
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum D14nBuilderError<E> {
+    #[error(transparent)]
+    ClientError(E),
+    #[error(transparent)]
+    VerifierError(#[from] VerifierError),
+}
+
+impl<E: RetryableError> RetryableError for D14nBuilderError<E> {
+    fn is_retryable(&self) -> bool {
+        match self {
+            Self::ClientError(e) => e.is_retryable(),
+            Self::VerifierError(v) => v.is_retryable(),
+        }
+    }
+}
+
+impl<E> D14nBuilderError<E> {
+    fn err(e: E) -> Self {
+        Self::ClientError(e)
+    }
+}
+
+impl<Builder1, Builder2, Store> ApiBuilder for D14nClientBuilder<Builder1, Builder2, Store>
+where
+    Builder1: ApiBuilder<Error = <Builder2 as ApiBuilder>::Error>,
+    Builder2: ApiBuilder,
+    Store: MaybeSend + MaybeSync,
+{
+    type Output =
+        D14nClient<<Builder1 as ApiBuilder>::Output, <Builder2 as ApiBuilder>::Output, Store>;
+
+    type Error = D14nBuilderError<<Builder1 as ApiBuilder>::Error>;
+
+    fn set_libxmtp_version(&mut self, version: String) -> Result<(), Self::Error> {
+        <Builder1 as ApiBuilder>::set_libxmtp_version(&mut self.message_client, version.clone())
+            .map_err(D14nBuilderError::err)?;
+        <Builder2 as ApiBuilder>::set_libxmtp_version(&mut self.gateway_client, version)
+            .map_err(D14nBuilderError::err)
+    }
+
+    fn set_app_version(&mut self, version: AppVersion) -> Result<(), Self::Error> {
+        <Builder1 as ApiBuilder>::set_app_version(&mut self.message_client, version.clone())
+            .map_err(D14nBuilderError::err)?;
+        <Builder2 as ApiBuilder>::set_app_version(&mut self.gateway_client, version)
+            .map_err(D14nBuilderError::err)
+    }
+
+    fn set_host(&mut self, host: String) {
+        <Builder1 as ApiBuilder>::set_host(&mut self.message_client, host);
+    }
+
+    fn set_gateway(&mut self, gateway: String) {
+        <Builder2 as ApiBuilder>::set_host(&mut self.gateway_client, gateway)
+    }
+
+    fn set_tls(&mut self, tls: bool) {
+        <Builder1 as ApiBuilder>::set_tls(&mut self.message_client, tls);
+        <Builder2 as ApiBuilder>::set_tls(&mut self.gateway_client, tls)
+    }
+
+    fn set_retry(&mut self, retry: xmtp_common::Retry) {
+        <Builder1 as ApiBuilder>::set_retry(&mut self.message_client, retry.clone());
+        <Builder2 as ApiBuilder>::set_retry(&mut self.gateway_client, retry)
+    }
+
+    fn rate_per_minute(&mut self, limit: u32) {
+        <Builder1 as ApiBuilder>::rate_per_minute(&mut self.message_client, limit);
+        <Builder2 as ApiBuilder>::rate_per_minute(&mut self.gateway_client, limit)
+    }
+
+    fn port(&self) -> Result<Option<String>, Self::Error> {
+        <Builder1 as ApiBuilder>::port(&self.message_client).map_err(D14nBuilderError::err)
+    }
+
+    fn host(&self) -> Option<&str> {
+        <Builder1 as ApiBuilder>::host(&self.message_client)
+    }
+
+    fn build(self) -> Result<Self::Output, Self::Error> {
+        Ok(D14nClient {
+            message_client: <Builder1 as ApiBuilder>::build(self.message_client)
+                .map_err(D14nBuilderError::err)?,
+            gateway_client: <Builder2 as ApiBuilder>::build(self.gateway_client)
+                .map_err(D14nBuilderError::err)?,
+            cursor_store: self.cursor_store,
+            scw_verifier: Arc::new(MultiSmartContractSignatureVerifier::new_from_env()?),
+        })
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl<C, G, Store> IsConnectedCheck for D14nClient<C, G, Store>
+where
+    G: IsConnectedCheck,
+    C: IsConnectedCheck,
+    Store: MaybeSend + MaybeSync,
+{
+    async fn is_connected(&self) -> bool {
+        self.message_client.is_connected().await && self.gateway_client.is_connected().await
+    }
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+mod test {
+    #![allow(clippy::unwrap_used)]
+    use xmtp_configuration::LOCALHOST;
+    use xmtp_proto::{TestApiBuilder, ToxicProxies};
+
+    use crate::protocol::NoCursorStore;
+
+    use super::*;
+    impl<Builder1, Builder2> TestApiBuilder for D14nClientBuilder<Builder1, Builder2, NoCursorStore>
+    where
+        Builder1: ApiBuilder<Error = <Builder2 as ApiBuilder>::Error> + 'static,
+        Builder2: ApiBuilder + 'static,
+        <Builder1 as ApiBuilder>::Output: xmtp_proto::api::Client + 'static,
+        <Builder2 as ApiBuilder>::Output: xmtp_proto::api::Client + 'static,
+    {
+        async fn with_toxiproxy(&mut self) -> ToxicProxies {
+            let xmtpd_host = <Builder1 as ApiBuilder>::host(&self.message_client).unwrap();
+            let gateway_host = <Builder2 as ApiBuilder>::host(&self.gateway_client).unwrap();
+            let proxies = xmtp_proto::init_toxi(&[xmtpd_host, gateway_host]).await;
+            <Builder1 as ApiBuilder>::set_host(
+                &mut self.message_client,
+                format!("{LOCALHOST}:{}", proxies.ports()[0]),
+            );
+            <Builder2 as ApiBuilder>::set_host(
+                &mut self.gateway_client,
+                format!("{LOCALHOST}:{}", proxies.ports()[1]),
+            );
+            proxies
+        }
+    }
+}

--- a/xmtp_api_d14n/src/queries/d14n/identity.rs
+++ b/xmtp_api_d14n/src/queries/d14n/identity.rs
@@ -1,4 +1,5 @@
 use super::D14nClient;
+use crate::protocol::CursorStore;
 use crate::protocol::IdentityUpdateExtractor;
 use crate::protocol::SequencedExtractor;
 use crate::protocol::traits::{Envelope, EnvelopeCollection, Extractor};
@@ -26,12 +27,13 @@ use xmtp_proto::xmtp::xmtpv4::message_api::{
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-impl<C, G, E> XmtpIdentityClient for D14nClient<C, G>
+impl<C, G, Store, E> XmtpIdentityClient for D14nClient<C, G, Store>
 where
     E: std::error::Error + RetryableError + 'static,
     G: Client<Error = E>,
     C: Client<Error = E>,
     ApiClientError<E>: From<ApiClientError<<G as xmtp_proto::api::Client>::Error>> + 'static,
+    Store: CursorStore,
 {
     type Error = ApiClientError<E>;
 

--- a/xmtp_api_d14n/src/queries/d14n/mls.rs
+++ b/xmtp_api_d14n/src/queries/d14n/mls.rs
@@ -3,6 +3,7 @@ use crate::d14n::GetNewestEnvelopes;
 use crate::d14n::PublishClientEnvelopes;
 use crate::d14n::QueryEnvelope;
 use crate::protocol::CollectionExtractor;
+use crate::protocol::CursorStore;
 use crate::protocol::EnvelopeError;
 use crate::protocol::GroupMessageExtractor;
 use crate::protocol::KeyPackagesExtractor;
@@ -33,12 +34,13 @@ use xmtp_proto::xmtp::xmtpv4::message_api::QueryEnvelopesResponse;
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-impl<C, G, E> XmtpMlsClient for D14nClient<C, G>
+impl<C, G, Store, E> XmtpMlsClient for D14nClient<C, G, Store>
 where
     E: RetryableError + 'static,
     G: Client,
     C: Client<Error = E>,
     ApiClientError<E>: From<ApiClientError<<G as xmtp_proto::api::Client>::Error>> + 'static,
+    Store: CursorStore,
 {
     type Error = ApiClientError<E>;
 
@@ -123,7 +125,7 @@ where
         group_id: GroupId,
     ) -> Result<Vec<xmtp_proto::types::GroupMessage>, Self::Error> {
         let topic = TopicKind::GroupMessagesV1.create(&group_id);
-        let lcc = self.cursor_store.load().lowest_common_cursor(&[&topic])?;
+        let lcc = self.cursor_store.lowest_common_cursor(&[&topic])?;
         let response: QueryEnvelopesResponse = QueryEnvelope::builder()
             .topic(topic)
             .last_seen(lcc)
@@ -172,7 +174,7 @@ where
         installation_key: InstallationId,
     ) -> Result<Vec<WelcomeMessage>, Self::Error> {
         let topic = TopicKind::WelcomeMessagesV1.create(installation_key);
-        let lcc = self.cursor_store.load().lowest_common_cursor(&[&topic])?;
+        let lcc = self.cursor_store.lowest_common_cursor(&[&topic])?;
         tracing::info!("querying welcomes @{:?}", lcc);
         let response = QueryEnvelope::builder()
             .topic(topic)

--- a/xmtp_api_d14n/src/queries/d14n/streams.rs
+++ b/xmtp_api_d14n/src/queries/d14n/streams.rs
@@ -1,6 +1,6 @@
 use crate::TryExtractorStream;
 use crate::d14n::SubscribeEnvelopes;
-use crate::protocol::{GroupMessageExtractor, WelcomeMessageExtractor};
+use crate::protocol::{CursorStore, GroupMessageExtractor, WelcomeMessageExtractor};
 use crate::queries::stream;
 
 use super::D14nClient;
@@ -13,12 +13,13 @@ use xmtp_proto::xmtp::xmtpv4::message_api::SubscribeEnvelopesResponse;
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-impl<C, G, E> XmtpMlsStreams for D14nClient<C, G>
+impl<C, G, Store, E> XmtpMlsStreams for D14nClient<C, G, Store>
 where
     C: Client<Error = E>,
     <C as Client>::Stream: 'static,
     G: Client<Error = E>,
     E: RetryableError + 'static,
+    Store: CursorStore,
 {
     type Error = ApiClientError<E>;
 
@@ -42,7 +43,6 @@ where
             .collect::<Vec<_>>();
         let lcc = self
             .cursor_store
-            .load()
             .lcc_maybe_missing(&topics.iter().collect::<Vec<_>>())?;
         tracing::debug!("subscribing to messages @cursor={}", lcc);
         let s = SubscribeEnvelopes::builder()
@@ -98,7 +98,6 @@ where
             .collect::<Vec<_>>();
         let lcc = self
             .cursor_store
-            .load()
             .lowest_common_cursor(&topics.iter().collect::<Vec<_>>())?;
         let s = SubscribeEnvelopes::builder()
             .topics(topics)

--- a/xmtp_api_d14n/src/queries/d14n/to_dyn_api.rs
+++ b/xmtp_api_d14n/src/queries/d14n/to_dyn_api.rs
@@ -1,20 +1,25 @@
-use std::{error::Error, sync::Arc};
+use std::error::Error;
+use std::sync::Arc;
 
 use xmtp_common::RetryableError;
-use xmtp_proto::api::{ApiClientError, Client, IsConnectedCheck};
+use xmtp_proto::api::ApiClientError;
+use xmtp_proto::api::{Client, IsConnectedCheck};
 
-use crate::{BoxedStreamsClient, D14nClient, FullXmtpApiArc, FullXmtpApiBox, ToDynApi};
+use crate::protocol::FullXmtpApiBox;
+use crate::protocol::{AnyClient, FullXmtpApiArc};
+use crate::{BoxedStreamsClient, D14nClient, ToDynApi, protocol::CursorStore};
 
-impl<M, G, E> ToDynApi for D14nClient<M, G>
+impl<M, G, Store, E> ToDynApi for D14nClient<M, G, Store>
 where
     E: Error + RetryableError + 'static,
     G: Client<Error = E> + IsConnectedCheck + 'static,
     M: Client<Error = E> + IsConnectedCheck + 'static,
+    Store: CursorStore + 'static,
     <M as Client>::Stream: 'static,
     <G as Client>::Stream: 'static,
+    Self: AnyClient,
 {
     type Error = ApiClientError<E>;
-
     fn boxed(self) -> FullXmtpApiBox<Self::Error> {
         Box::new(BoxedStreamsClient::new(self))
     }

--- a/xmtp_api_d14n/src/queries/d14n/xmtp_query.rs
+++ b/xmtp_api_d14n/src/queries/d14n/xmtp_query.rs
@@ -9,17 +9,18 @@ use xmtp_proto::{
 use crate::{
     D14nClient,
     d14n::QueryEnvelope,
-    protocol::{XmtpEnvelope, XmtpQuery},
+    protocol::{CursorStore, XmtpEnvelope, XmtpQuery},
 };
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-impl<C, G, E> XmtpQuery for D14nClient<C, G>
+impl<C, G, Store, E> XmtpQuery for D14nClient<C, G, Store>
 where
     C: Client<Error = E>,
     G: Client<Error = E>,
     ApiClientError<E>: From<ApiClientError<<C as Client>::Error>>,
     E: RetryableError + 'static,
+    Store: CursorStore,
 {
     type Error = ApiClientError<E>;
 

--- a/xmtp_api_d14n/src/queries/v3.rs
+++ b/xmtp_api_d14n/src/queries/v3.rs
@@ -1,170 +1,46 @@
-use std::sync::Arc;
-
-use parking_lot::RwLock;
-use xmtp_common::{MaybeSend, MaybeSync};
-use xmtp_proto::api::IsConnectedCheck;
-use xmtp_proto::api_client::CursorAwareApi;
-use xmtp_proto::prelude::ApiBuilder;
-use xmtp_proto::types::AppVersion;
-
-use crate::protocol::{CursorStore, InMemoryCursorStore};
-
 mod identity;
 mod mls;
 mod streams;
 mod to_dyn_api;
 mod xmtp_query;
 
-#[derive(Clone)]
-pub struct V3Client<C> {
-    client: C,
-    cursor_store: Arc<RwLock<Arc<dyn CursorStore>>>,
-}
+mod client;
+use std::sync::Arc;
 
-impl<C> V3Client<C> {
-    pub fn new(client: C, cursor_store: Arc<dyn CursorStore>) -> Self {
-        Self {
-            client,
-            cursor_store: Arc::new(RwLock::new(cursor_store)),
-        }
-    }
+use crate::definitions::FullD14nClient;
+use crate::definitions::FullV3Client;
+use crate::protocol::AnyClient;
+use crate::{
+    ToDynApi,
+    protocol::{CursorStore, FullXmtpApiT},
+};
+pub use client::*;
+use xmtp_api_grpc::error::GrpcError;
+use xmtp_common::RetryableError;
+use xmtp_proto::api::ApiClientError;
 
-    pub fn new_stateless(client: C) -> Self {
-        Self {
-            client,
-            cursor_store: Arc::new(RwLock::new(Arc::new(InMemoryCursorStore::new()) as Arc<_>)),
-        }
-    }
-
-    pub fn builder<T: Default>() -> V3ClientBuilder<T> {
-        V3ClientBuilder::new(
-            T::default(),
-            Arc::new(InMemoryCursorStore::default()) as Arc<_>,
-        )
-    }
-
-    pub fn client_mut(&mut self) -> &mut C {
-        &mut self.client
-    }
-}
-
-pub struct V3ClientBuilder<Builder> {
-    client: Builder,
-    store: Arc<RwLock<Arc<dyn CursorStore>>>,
-}
-
-impl<Builder> V3ClientBuilder<Builder> {
-    pub fn new(client: Builder, store: Arc<dyn CursorStore>) -> Self {
-        Self {
-            client,
-            store: Arc::new(RwLock::new(store)),
-        }
-    }
-
-    pub fn new_stateless(client: Builder) -> Self {
-        Self {
-            client,
-            store: Arc::new(RwLock::new(Arc::new(InMemoryCursorStore::new()) as Arc<_>)),
-        }
-    }
-}
-
-impl<Builder> ApiBuilder for V3ClientBuilder<Builder>
+//TODO:temp_cache_workaround
+pub fn v3_new_with_store<E>(
+    api: Arc<dyn FullXmtpApiT<E>>,
+    store: Arc<dyn CursorStore>,
+) -> Option<Arc<dyn FullXmtpApiT<ApiClientError<GrpcError>>>>
 where
-    Builder: ApiBuilder,
+    E: RetryableError + 'static,
 {
-    type Output = V3Client<<Builder as ApiBuilder>::Output>;
-
-    type Error = <Builder as ApiBuilder>::Error;
-
-    fn set_libxmtp_version(&mut self, version: String) -> Result<(), Self::Error> {
-        <Builder as ApiBuilder>::set_libxmtp_version(&mut self.client, version)
-    }
-
-    fn set_app_version(&mut self, version: AppVersion) -> Result<(), Self::Error> {
-        <Builder as ApiBuilder>::set_app_version(&mut self.client, version)
-    }
-
-    fn set_host(&mut self, host: String) {
-        <Builder as ApiBuilder>::set_host(&mut self.client, host)
-    }
-
-    fn set_tls(&mut self, tls: bool) {
-        <Builder as ApiBuilder>::set_tls(&mut self.client, tls)
-    }
-
-    fn rate_per_minute(&mut self, limit: u32) {
-        <Builder as ApiBuilder>::rate_per_minute(&mut self.client, limit)
-    }
-
-    fn port(&self) -> Result<Option<String>, Self::Error> {
-        <Builder as ApiBuilder>::port(&self.client)
-    }
-
-    fn host(&self) -> Option<&str> {
-        <Builder as ApiBuilder>::host(&self.client)
-    }
-
-    fn build(self) -> Result<Self::Output, Self::Error> {
-        Ok(V3Client {
-            client: <Builder as ApiBuilder>::build(self.client)?,
-            cursor_store: self.store,
-        })
-    }
-
-    fn set_retry(&mut self, retry: xmtp_common::Retry) {
-        <Builder as ApiBuilder>::set_retry(&mut self.client, retry)
+    // create a new type that doesn't point to the given store
+    if let Some(c) = api.as_ref().downcast_ref_v3client() {
+        Some(V3Client::new(c.client.clone(), store).arced())
+    } else {
+        None
     }
 }
 
-impl<C: MaybeSend + MaybeSync> CursorAwareApi for V3Client<C> {
-    type CursorStore = Arc<dyn CursorStore>;
-    fn set_cursor_store(&self, store: Self::CursorStore) {
-        let mut cstore = self.cursor_store.write();
-        *cstore = store;
+impl AnyClient for FullV3Client {
+    fn downcast_ref_v3client(&self) -> Option<&'_ FullV3Client> {
+        Some(self)
     }
-}
 
-impl<B1: ApiBuilder> CursorAwareApi for V3ClientBuilder<B1> {
-    type CursorStore = Arc<dyn CursorStore>;
-
-    fn set_cursor_store(&self, store: Self::CursorStore) {
-        let mut cstore = self.store.write();
-        *cstore = store;
-    }
-}
-
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-impl<C> IsConnectedCheck for V3Client<C>
-where
-    C: IsConnectedCheck,
-{
-    async fn is_connected(&self) -> bool {
-        self.client.is_connected().await
-    }
-}
-
-#[cfg(any(test, feature = "test-utils"))]
-mod test {
-    #![allow(clippy::unwrap_used)]
-    use xmtp_configuration::LOCALHOST;
-    use xmtp_proto::{TestApiBuilder, ToxicProxies};
-
-    use super::*;
-    impl<Builder> TestApiBuilder for V3ClientBuilder<Builder>
-    where
-        Builder: ApiBuilder,
-        <Builder as ApiBuilder>::Output: xmtp_proto::api::Client,
-    {
-        async fn with_toxiproxy(&mut self) -> ToxicProxies {
-            let host = <Builder as ApiBuilder>::host(&self.client).unwrap();
-            let proxies = xmtp_proto::init_toxi(&[host]).await;
-            <Builder as ApiBuilder>::set_host(
-                &mut self.client,
-                format!("{LOCALHOST}:{}", proxies.ports()[0]),
-            );
-            proxies
-        }
+    fn downcast_ref_d14nclient(&self) -> Option<&'_ FullD14nClient> {
+        None
     }
 }

--- a/xmtp_api_d14n/src/queries/v3/client.rs
+++ b/xmtp_api_d14n/src/queries/v3/client.rs
@@ -1,0 +1,127 @@
+use xmtp_common::{MaybeSend, MaybeSync};
+use xmtp_proto::api::IsConnectedCheck;
+use xmtp_proto::prelude::ApiBuilder;
+use xmtp_proto::types::AppVersion;
+
+#[derive(Clone)]
+pub struct V3Client<C, Store> {
+    pub(super) client: C,
+    pub(super) cursor_store: Store,
+}
+
+impl<C, Store> V3Client<C, Store> {
+    pub fn new(client: C, cursor_store: Store) -> Self {
+        Self {
+            client,
+            cursor_store,
+        }
+    }
+
+    pub fn client_mut(&mut self) -> &mut C {
+        &mut self.client
+    }
+}
+
+#[cfg_attr(any(test, feature = "test-utils"), derive(Clone))]
+pub struct V3ClientBuilder<Builder, Store> {
+    client: Builder,
+    store: Store,
+}
+
+impl<Builder, Store> V3ClientBuilder<Builder, Store> {
+    pub fn new(client: Builder, store: Store) -> Self {
+        Self { client, store }
+    }
+
+    pub fn cursor_store(&mut self, store: Store) -> &mut Self {
+        self.store = store;
+        self
+    }
+}
+
+impl<Builder, Store> ApiBuilder for V3ClientBuilder<Builder, Store>
+where
+    Builder: ApiBuilder,
+    Store: MaybeSend + MaybeSync,
+{
+    type Output = V3Client<<Builder as ApiBuilder>::Output, Store>;
+
+    type Error = <Builder as ApiBuilder>::Error;
+
+    fn set_libxmtp_version(&mut self, version: String) -> Result<(), Self::Error> {
+        <Builder as ApiBuilder>::set_libxmtp_version(&mut self.client, version)
+    }
+
+    fn set_app_version(&mut self, version: AppVersion) -> Result<(), Self::Error> {
+        <Builder as ApiBuilder>::set_app_version(&mut self.client, version)
+    }
+
+    fn set_host(&mut self, host: String) {
+        <Builder as ApiBuilder>::set_host(&mut self.client, host)
+    }
+
+    fn set_tls(&mut self, tls: bool) {
+        <Builder as ApiBuilder>::set_tls(&mut self.client, tls)
+    }
+
+    fn rate_per_minute(&mut self, limit: u32) {
+        <Builder as ApiBuilder>::rate_per_minute(&mut self.client, limit)
+    }
+
+    fn port(&self) -> Result<Option<String>, Self::Error> {
+        <Builder as ApiBuilder>::port(&self.client)
+    }
+
+    fn host(&self) -> Option<&str> {
+        <Builder as ApiBuilder>::host(&self.client)
+    }
+
+    fn build(self) -> Result<Self::Output, Self::Error> {
+        Ok(V3Client {
+            client: <Builder as ApiBuilder>::build(self.client)?,
+            cursor_store: self.store,
+        })
+    }
+
+    fn set_retry(&mut self, retry: xmtp_common::Retry) {
+        <Builder as ApiBuilder>::set_retry(&mut self.client, retry)
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl<C, Store> IsConnectedCheck for V3Client<C, Store>
+where
+    C: IsConnectedCheck,
+    Store: MaybeSend + MaybeSync,
+{
+    async fn is_connected(&self) -> bool {
+        self.client.is_connected().await
+    }
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+mod test {
+    #![allow(clippy::unwrap_used)]
+    use xmtp_configuration::LOCALHOST;
+    use xmtp_proto::{TestApiBuilder, ToxicProxies};
+
+    use crate::protocol::NoCursorStore;
+
+    use super::*;
+    impl<Builder> TestApiBuilder for V3ClientBuilder<Builder, NoCursorStore>
+    where
+        Builder: ApiBuilder,
+        <Builder as ApiBuilder>::Output: xmtp_proto::api::Client,
+    {
+        async fn with_toxiproxy(&mut self) -> ToxicProxies {
+            let host = <Builder as ApiBuilder>::host(&self.client).unwrap();
+            let proxies = xmtp_proto::init_toxi(&[host]).await;
+            <Builder as ApiBuilder>::set_host(
+                &mut self.client,
+                format!("{LOCALHOST}:{}", proxies.ports()[0]),
+            );
+            proxies
+        }
+    }
+}

--- a/xmtp_api_d14n/src/queries/v3/identity.rs
+++ b/xmtp_api_d14n/src/queries/v3/identity.rs
@@ -1,3 +1,4 @@
+use crate::protocol::CursorStore;
 use crate::{V3Client, v3::*};
 use xmtp_common::RetryableError;
 use xmtp_proto::api::{ApiClientError, Client, Query};
@@ -7,10 +8,11 @@ use xmtp_proto::xmtp::identity::associations::IdentifierKind;
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-impl<C, E> XmtpIdentityClient for V3Client<C>
+impl<C, Store, E> XmtpIdentityClient for V3Client<C, Store>
 where
     C: Client<Error = E>,
     E: RetryableError + 'static,
+    Store: CursorStore,
 {
     type Error = ApiClientError<E>;
 

--- a/xmtp_api_d14n/src/queries/v3/mls.rs
+++ b/xmtp_api_d14n/src/queries/v3/mls.rs
@@ -1,5 +1,6 @@
 use crate::protocol::{
-    CollectionExtractor, MessageMetadataExtractor, ProtocolEnvelope, V3WelcomeMessageExtractor,
+    CollectionExtractor, CursorStore, MessageMetadataExtractor, ProtocolEnvelope,
+    V3WelcomeMessageExtractor,
 };
 use crate::protocol::{SequencedExtractor, V3GroupMessageExtractor, traits::Extractor};
 use crate::{V3Client, v3::*};
@@ -12,11 +13,12 @@ use xmtp_proto::types::{GroupId, GroupMessageMetadata, InstallationId, TopicKind
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-impl<C, E> XmtpMlsClient for V3Client<C>
+impl<C, Store, E> XmtpMlsClient for V3Client<C, Store>
 where
     E: RetryableError + 'static,
     C: Client<Error = E>,
     ApiClientError<E>: From<ApiClientError<<C as Client>::Error>> + 'static,
+    Store: CursorStore,
 {
     type Error = ApiClientError<E>;
 
@@ -68,7 +70,6 @@ where
         let topic = &TopicKind::GroupMessagesV1.create(&group_id);
         let cursor = self
             .cursor_store
-            .read()
             .latest_per_originator(
                 topic,
                 &[
@@ -130,7 +131,6 @@ where
         let topic = &TopicKind::WelcomeMessagesV1.create(installation_key);
         let id_cursor = self
             .cursor_store
-            .read()
             .latest_for_originator(topic, &Originators::WELCOME_MESSAGES)?
             .sequence_id;
         let endpoint = QueryWelcomeMessages::builder()

--- a/xmtp_api_d14n/src/queries/v3/streams.rs
+++ b/xmtp_api_d14n/src/queries/v3/streams.rs
@@ -1,6 +1,7 @@
+use crate::protocol::CursorStore;
 use crate::{V3Client, v3::*};
-use xmtp_api_grpc::error::GrpcError;
 use xmtp_api_grpc::streams::{TryFromItem, try_from_stream};
+use xmtp_common::RetryableError;
 use xmtp_proto::api::{ApiClientError, Client, QueryStream, XmtpStream};
 use xmtp_proto::api_client::XmtpMlsStreams;
 use xmtp_proto::mls_v1::subscribe_group_messages_request::Filter as GroupSubscribeFilter;
@@ -11,9 +12,11 @@ use xmtp_proto::types::{
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-impl<C> XmtpMlsStreams for V3Client<C>
+impl<C, Store, E> XmtpMlsStreams for V3Client<C, Store>
 where
-    C: Client<Error = GrpcError>,
+    C: Client<Error = E>,
+    E: RetryableError + 'static,
+    Store: CursorStore,
 {
     type GroupMessageStream =
         TryFromItem<XmtpStream<<C as Client>::Stream, V3ProtoGroupMessage>, GroupMessage>;
@@ -21,7 +24,7 @@ where
     type WelcomeMessageStream =
         TryFromItem<XmtpStream<<C as Client>::Stream, V3ProtoWelcomeMessage>, WelcomeMessage>;
 
-    type Error = ApiClientError<GrpcError>;
+    type Error = ApiClientError<E>;
 
     async fn subscribe_group_messages(
         &self,
@@ -31,11 +34,7 @@ where
             .iter()
             .map(|gid| TopicKind::GroupMessagesV1.create(gid))
             .collect::<Vec<_>>();
-
-        let cursors = self
-            .cursor_store
-            .read()
-            .latest_for_topics(&mut topics.iter())?;
+        let cursors = self.cursor_store.latest_for_topics(&mut topics.iter())?;
 
         let mut filters = vec![];
         for topic in &topics {
@@ -91,11 +90,7 @@ where
             .iter()
             .map(|id| TopicKind::WelcomeMessagesV1.create(id))
             .collect::<Vec<_>>();
-
-        let cursors = self
-            .cursor_store
-            .read()
-            .latest_for_topics(&mut topics.iter())?;
+        let cursors = self.cursor_store.latest_for_topics(&mut topics.iter())?;
 
         let mut filters = vec![];
         for topic in &topics {

--- a/xmtp_api_d14n/src/queries/v3/to_dyn_api.rs
+++ b/xmtp_api_d14n/src/queries/v3/to_dyn_api.rs
@@ -1,18 +1,21 @@
 use std::sync::Arc;
 
-use crate::{FullXmtpApiArc, FullXmtpApiBox, ToDynApi};
-use xmtp_api_grpc::error::GrpcError;
+use crate::protocol::{AnyClient, FullXmtpApiArc, FullXmtpApiBox};
+use crate::{ToDynApi, protocol::CursorStore};
+use xmtp_common::RetryableError;
 use xmtp_proto::api::{ApiClientError, Client, IsConnectedCheck};
 
 use crate::{BoxedStreamsClient, V3Client};
 
-impl<C> ToDynApi for V3Client<C>
+impl<C, Store, E> ToDynApi for V3Client<C, Store>
 where
-    C: Client<Error = GrpcError> + IsConnectedCheck + 'static,
+    E: RetryableError + 'static,
+    C: Client<Error = E> + IsConnectedCheck + 'static,
     <C as Client>::Stream: 'static,
+    Store: CursorStore + 'static,
+    Self: AnyClient,
 {
-    type Error = ApiClientError<GrpcError>;
-
+    type Error = ApiClientError<E>;
     fn boxed(self) -> FullXmtpApiBox<Self::Error> {
         Box::new(BoxedStreamsClient::new(self))
     }

--- a/xmtp_api_d14n/src/queries/v3/xmtp_query.rs
+++ b/xmtp_api_d14n/src/queries/v3/xmtp_query.rs
@@ -1,6 +1,6 @@
 use crate::{
     V3Client,
-    protocol::{XmtpEnvelope, XmtpQuery},
+    protocol::{CursorStore, XmtpEnvelope, XmtpQuery},
     v3::{FetchKeyPackages, GetIdentityUpdatesV2, QueryGroupMessages, QueryWelcomeMessages},
 };
 use xmtp_common::RetryableError;
@@ -16,11 +16,12 @@ use xmtp_proto::{
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-impl<C, E> XmtpQuery for V3Client<C>
+impl<C, Store, E> XmtpQuery for V3Client<C, Store>
 where
     C: Client<Error = E>,
     E: RetryableError + 'static,
     ApiClientError<E>: From<ApiClientError<<C as Client>::Error>>,
+    Store: CursorStore,
 {
     type Error = ApiClientError<E>;
     async fn query_at(

--- a/xmtp_api_d14n/src/test/definitions.rs
+++ b/xmtp_api_d14n/src/test/definitions.rs
@@ -1,8 +1,13 @@
 //! type definitions for different backends (mock/v3/d14n)
 
+use std::sync::Arc;
+
 use xmtp_proto::api::mock::MockNetworkClient;
 
-use crate::{D14nClient, TrackedStatsClient, V3Client};
+use crate::{
+    protocol::{CursorStore, NoCursorStore},
+    D14nClient, TrackedStatsClient, V3Client,
+};
 
 /// The Native/Wasm tonic gRPC client
 pub type TestGrpcClient = xmtp_api_grpc::GrpcClient;
@@ -10,15 +15,16 @@ pub type TestGrpcClient = xmtp_api_grpc::GrpcClient;
 pub type ApiError = xmtp_api_grpc::error::GrpcError;
 
 /// test client that speaks only v3
-pub type TestV3Client = TrackedStatsClient<V3Client<TestGrpcClient>>;
+pub type TestV3Client = TrackedStatsClient<V3Client<TestGrpcClient, Arc<dyn CursorStore>>>;
 /// test client that speaks only d14n
-pub type TestD14nClient = TrackedStatsClient<D14nClient<TestGrpcClient, TestGrpcClient>>;
+pub type TestD14nClient =
+    TrackedStatsClient<D14nClient<TestGrpcClient, TestGrpcClient, Arc<dyn CursorStore>>>;
 
 /// V3 client with mock network
-pub type MockV3Client = V3Client<MockNetworkClient>;
+pub type MockV3Client = V3Client<MockNetworkClient, NoCursorStore>;
 
 /// D14n client with mocked networks
-pub type MockD14nClient = D14nClient<MockNetworkClient, MockNetworkClient>;
+pub type MockD14nClient = D14nClient<MockNetworkClient, MockNetworkClient, NoCursorStore>;
 
 xmtp_common::if_d14n! {
     pub type MockClient = MockD14nClient;

--- a/xmtp_api_d14n/src/test/mock_client.rs
+++ b/xmtp_api_d14n/src/test/mock_client.rs
@@ -1,12 +1,9 @@
 use std::pin::Pin;
 
-use crate::protocol::CursorStore;
 use crate::protocol::XmtpQuery;
 use futures::Stream;
 use mockall::mock;
-use std::sync::Arc;
 use xmtp_proto::api::mock::MockApiBuilder;
-use xmtp_proto::api_client::CursorAwareApi;
 use xmtp_proto::api_client::XmtpTestClient;
 use xmtp_proto::{
     api_client::{XmtpIdentityClient, XmtpMlsClient, XmtpMlsStreams},
@@ -134,11 +131,6 @@ mod not_wasm {
             fn create_d14n() -> MockApiBuilder { MockApiBuilder }
             fn create_gateway() -> MockApiBuilder { MockApiBuilder }
         }
-
-        impl CursorAwareApi for ApiClient {
-            type CursorStore = Arc<dyn CursorStore>;
-            fn set_cursor_store(&self, store: <Self as CursorAwareApi>::CursorStore);
-        }
     }
 
     #[async_trait::async_trait]
@@ -216,12 +208,6 @@ mod wasm {
             fn create_dev() -> MockApiBuilder { MockApiBuilder }
             fn create_d14n() -> MockApiBuilder { MockApiBuilder }
             fn create_gateway() -> MockApiBuilder { MockApiBuilder }
-        }
-
-
-        impl CursorAwareApi for ApiClient {
-            type CursorStore = Arc<dyn CursorStore>;
-            fn set_cursor_store(&self, store: <Self as CursorAwareApi>::CursorStore);
         }
     }
 

--- a/xmtp_api_d14n/src/test/test_client.rs
+++ b/xmtp_api_d14n/src/test/test_client.rs
@@ -1,11 +1,29 @@
 //! XmtpTestClient impl for real docker/dev backend
-use crate::{D14nClient, D14nClientBuilder, V3Client, V3ClientBuilder};
+use std::sync::Arc;
+
+use crate::{
+    protocol::{CursorStore, NoCursorStore},
+    D14nClient, D14nClientBuilder, V3Client, V3ClientBuilder,
+};
 use xmtp_proto::{
     api::Client,
     prelude::{ApiBuilder, XmtpTestClient},
 };
 
-impl<C, Payer> XmtpTestClient for D14nClient<C, Payer>
+/// extends the [`XmtpTestClient`] with a cursor store build method
+pub trait XmtpTestClientExt: XmtpTestClient {
+    fn with_cursor_store(
+        _f: impl Fn() -> <Self as XmtpTestClient>::Builder,
+        _store: Arc<dyn CursorStore>,
+    ) -> <Self as XmtpTestClient>::Builder {
+        unimplemented!(
+            "cursor store not available for this type {}",
+            std::any::type_name::<Self>()
+        )
+    }
+}
+
+impl<C, Payer> XmtpTestClientExt for D14nClient<C, Payer, Arc<dyn CursorStore>>
 where
     C: XmtpTestClient + Client,
     Payer: XmtpTestClient + Client,
@@ -14,48 +32,101 @@ where
     <C as XmtpTestClient>::Builder:
         ApiBuilder<Error = <<Payer as XmtpTestClient>::Builder as ApiBuilder>::Error>,
 {
-    type Builder = D14nClientBuilder<C::Builder, Payer::Builder>;
+    fn with_cursor_store(
+        f: impl Fn() -> <Self as XmtpTestClient>::Builder,
+        store: Arc<dyn CursorStore>,
+    ) -> <Self as XmtpTestClient>::Builder {
+        let mut b = f();
+        b.cursor_store(store);
+        b
+    }
+}
+
+impl<C, Payer> XmtpTestClient for D14nClient<C, Payer, Arc<dyn CursorStore>>
+where
+    C: XmtpTestClient + Client,
+    Payer: XmtpTestClient + Client,
+    <<C as XmtpTestClient>::Builder as ApiBuilder>::Output: Client,
+    <<Payer as XmtpTestClient>::Builder as ApiBuilder>::Output: Client,
+    <C as XmtpTestClient>::Builder:
+        ApiBuilder<Error = <<Payer as XmtpTestClient>::Builder as ApiBuilder>::Error>,
+{
+    type Builder = D14nClientBuilder<C::Builder, Payer::Builder, Arc<dyn CursorStore>>;
 
     fn create_local() -> Self::Builder {
-        D14nClientBuilder::new_stateless(
+        D14nClientBuilder::new(
             <C as XmtpTestClient>::create_d14n(),
             <Payer as XmtpTestClient>::create_gateway(),
+            Arc::new(NoCursorStore),
         )
     }
-    fn create_dev() -> Self::Builder {
-        // TODO: Staging
-        panic!("no urls for d14n dev yet");
+    /*
+    fn create_with_store(store: Arc<dyn CursorStore>) -> Self::Builder {
+        D14nClientBuilder::new(
+            <C as XmtpTestClient>::create_d14n(),
+            <Payer as XmtpTestClient>::create_gateway(),
+            store,
+        )
     }
+    */
+
     fn create_gateway() -> Self::Builder {
-        D14nClientBuilder::new_stateless(
+        D14nClientBuilder::new(
             <C as XmtpTestClient>::create_gateway(),
             <Payer as XmtpTestClient>::create_gateway(),
+            Arc::new(NoCursorStore),
         )
     }
     fn create_d14n() -> Self::Builder {
-        D14nClientBuilder::new_stateless(
+        D14nClientBuilder::new(
             <C as XmtpTestClient>::create_d14n(),
             <Payer as XmtpTestClient>::create_gateway(),
+            Arc::new(NoCursorStore),
         )
     }
 }
 
-impl<C> XmtpTestClient for V3Client<C>
+impl<C> XmtpTestClient for V3Client<C, Arc<dyn CursorStore>>
 where
     C: XmtpTestClient + Client,
     <<C as XmtpTestClient>::Builder as ApiBuilder>::Output: Client,
 {
-    type Builder = V3ClientBuilder<C::Builder>;
+    type Builder = V3ClientBuilder<C::Builder, Arc<dyn CursorStore>>;
     fn create_local() -> Self::Builder {
-        V3ClientBuilder::new_stateless(<C as XmtpTestClient>::create_local())
+        V3ClientBuilder::new(
+            <C as XmtpTestClient>::create_local(),
+            Arc::new(NoCursorStore),
+        )
     }
+
     fn create_dev() -> Self::Builder {
-        V3ClientBuilder::new_stateless(<C as XmtpTestClient>::create_dev())
+        V3ClientBuilder::new(<C as XmtpTestClient>::create_dev(), Arc::new(NoCursorStore))
     }
     fn create_gateway() -> Self::Builder {
-        V3ClientBuilder::new_stateless(<C as XmtpTestClient>::create_gateway())
+        V3ClientBuilder::new(
+            <C as XmtpTestClient>::create_gateway(),
+            Arc::new(NoCursorStore),
+        )
     }
     fn create_d14n() -> Self::Builder {
-        V3ClientBuilder::new_stateless(<C as XmtpTestClient>::create_d14n())
+        V3ClientBuilder::new(
+            <C as XmtpTestClient>::create_d14n(),
+            Arc::new(NoCursorStore),
+        )
+    }
+}
+
+impl<C> XmtpTestClientExt for V3Client<C, Arc<dyn CursorStore>>
+where
+    C: XmtpTestClient + Client,
+    <<C as XmtpTestClient>::Builder as ApiBuilder>::Output: Client,
+{
+    fn with_cursor_store(
+        f: impl Fn() -> <Self as XmtpTestClient>::Builder,
+        store: Arc<dyn CursorStore>,
+    ) -> <Self as XmtpTestClient>::Builder {
+        let mut b = f();
+        b.cursor_store(store);
+        b
     }
 }

--- a/xmtp_mls/benches/group_limit.rs
+++ b/xmtp_mls/benches/group_limit.rs
@@ -36,7 +36,6 @@ fn setup() -> (Arc<BenchClient>, Vec<Identity>, Runtime) {
                 ClientBuilder::new_test_builder(&wallet)
                     .await
                     .dev()
-                    .await
                     .build_unchecked()
                     .await,
             )
@@ -45,7 +44,6 @@ fn setup() -> (Arc<BenchClient>, Vec<Identity>, Runtime) {
                 ClientBuilder::new_test_builder(&wallet)
                     .await
                     .local()
-                    .await
                     .build_unchecked()
                     .await,
             )

--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -2,7 +2,6 @@ use crate::{
     GroupCommitLock, StorageError, XmtpApi,
     client::{Client, DeviceSync},
     context::XmtpMlsLocalContext,
-    cursor_store::SqliteCursorStore,
     groups::{
         device_sync::worker::SyncWorker, disappearing_messages::DisappearingMessagesWorker,
         key_package_cleaner_worker::KeyPackagesCleanerWorker,
@@ -33,7 +32,6 @@ use xmtp_db::{
     sql_key_store::SqlKeyStore,
 };
 use xmtp_id::scw_verifier::SmartContractSignatureVerifier;
-use xmtp_proto::api_client::CursorAwareApi;
 
 type ContextParts<Api, S, Db> = Arc<XmtpMlsLocalContext<Api, Db, S>>;
 
@@ -70,11 +68,11 @@ impl From<crate::groups::GroupError> for ClientBuilderError {
 }
 
 pub struct ClientBuilder<ApiClient, S, Db = xmtp_db::DefaultStore> {
-    pub(crate) api_client: Option<ApiClientWrapper<ApiClient>>,
+    pub(crate) api_client: Option<ApiClient>,
     pub(crate) identity: Option<Identity>,
     pub(crate) store: Option<Db>,
     pub(crate) identity_strategy: IdentityStrategy,
-    pub(crate) scw_verifier: Option<Arc<Box<dyn SmartContractSignatureVerifier>>>,
+    pub(crate) scw_verifier: Option<Box<dyn SmartContractSignatureVerifier>>,
     pub(crate) device_sync_server_url: Option<String>,
     pub(crate) device_sync_worker_mode: SyncWorkerMode,
     pub(crate) fork_recovery_opts: Option<ForkRecoveryOpts>,
@@ -83,7 +81,7 @@ pub struct ClientBuilder<ApiClient, S, Db = xmtp_db::DefaultStore> {
     pub(crate) disable_events: bool,
     pub(crate) disable_commit_log_worker: bool,
     pub(crate) mls_storage: Option<S>,
-    pub(crate) sync_api_client: Option<ApiClientWrapper<ApiClient>>,
+    pub(crate) sync_api_client: Option<ApiClient>,
     pub(crate) cursor_store: Option<Arc<dyn CursorStore>>,
     pub(crate) disable_workers: bool,
 }
@@ -164,14 +162,14 @@ where
     pub fn from_client(
         client: Client<ContextParts<ApiClient, S, Db>>,
     ) -> ClientBuilder<ApiClient, S, Db> {
-        let cloned_api: ApiClientWrapper<ApiClient> = client.context.api_client.clone();
-        let cloned_sync_api: ApiClientWrapper<ApiClient> = client.context.sync_api_client.clone();
+        let cloned_api: ApiClient = client.context.api_client.clone().api_client;
+        let cloned_sync_api: ApiClient = client.context.sync_api_client.clone().api_client;
         ClientBuilder {
             api_client: Some(cloned_api),
             identity: Some(client.context.identity.clone()),
             store: Some(client.context.store.clone()),
             identity_strategy: IdentityStrategy::CachedOnly,
-            scw_verifier: Some(client.context.scw_verifier.clone()),
+            scw_verifier: Some(Box::new(client.context.scw_verifier.clone())),
             device_sync_server_url: client.context.device_sync.server_url.clone(),
             device_sync_worker_mode: client.context.device_sync.mode,
             fork_recovery_opts: Some(client.context.fork_recovery_opts.clone()),
@@ -190,11 +188,12 @@ where
     }
 }
 
+// TODO: the return type is temp and
+// will be modified in subsequent PRs
 impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
     pub async fn build(self) -> Result<Client<ContextParts<ApiClient, S, Db>>, ClientBuilderError>
     where
-        ApiClient:
-            XmtpApi + CursorAwareApi<CursorStore = Arc<dyn CursorStore>> + XmtpQuery + 'static,
+        ApiClient: XmtpApi + XmtpQuery + 'static,
         Db: xmtp_db::XmtpDb + 'static,
         S: XmtpMlsStorageProvider + 'static,
     {
@@ -214,8 +213,9 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             disable_commit_log_worker,
             mut mls_storage,
             mut sync_api_client,
-            cursor_store,
+            // cursor_store,
             disable_workers,
+            ..
         } = self;
 
         let api_client = api_client
@@ -247,10 +247,8 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
                 parameter: "mls_storage",
             })?;
 
-        let cursor_store =
-            cursor_store.unwrap_or(Arc::new(SqliteCursorStore::new(store.db())) as Arc<_>);
-        api_client.set_cursor_store(cursor_store.clone());
-        sync_api_client.set_cursor_store(cursor_store.clone());
+        let api_client = ApiClientWrapper::new(api_client, Retry::default());
+        let sync_api_client = ApiClientWrapper::new(sync_api_client, Retry::default());
         let conn = store.db();
         let identity = if let Some(identity) = identity {
             identity
@@ -284,7 +282,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             store,
             api_client,
             version_info,
-            scw_verifier,
+            scw_verifier: Arc::new(scw_verifier),
             mutexes: MutexRegistry::new(),
             mls_commit_lock: Arc::new(GroupCommitLock::new()),
             local_events: tx.clone(),
@@ -479,9 +477,9 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
     }
 
     pub fn api_clients<A>(self, api_client: A, sync_api_client: A) -> ClientBuilder<A, S, Db> {
-        let api_retry = Retry::builder().build();
-        let api_client = ApiClientWrapper::new(api_client, api_retry.clone());
-        let sync_api_client = ApiClientWrapper::new(sync_api_client, api_retry.clone());
+        // let api_retry = Retry::builder().build();
+        // let api_client = ApiClientWrapper::new(api_client, api_retry.clone());
+        // let sync_api_client = ApiClientWrapper::new(sync_api_client, api_retry.clone());
         ClientBuilder {
             api_client: Some(api_client),
             identity: self.identity,
@@ -607,11 +605,9 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
         }
 
         Ok(ClientBuilder {
-            api_client: Some(
-                self.api_client
-                    .expect("checked for none")
-                    .attach_debug_wrapper(),
-            ),
+            api_client: Some(ApiDebugWrapper::new(
+                self.api_client.expect("checked for none"),
+            )),
             identity: self.identity,
             identity_strategy: self.identity_strategy,
             scw_verifier: self.scw_verifier,
@@ -625,11 +621,9 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             disable_events: self.disable_events,
             disable_commit_log_worker: self.disable_commit_log_worker,
             mls_storage: self.mls_storage,
-            sync_api_client: Some(
-                self.sync_api_client
-                    .expect("checked for none")
-                    .attach_debug_wrapper(),
-            ),
+            sync_api_client: Some(ApiDebugWrapper::new(
+                self.sync_api_client.expect("checked for none"),
+            )),
             cursor_store: self.cursor_store,
             disable_workers: self.disable_workers,
         })
@@ -645,11 +639,9 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
         }
 
         Ok(ClientBuilder {
-            api_client: Some(
-                self.api_client
-                    .expect("checked for none")
-                    .map(|a| TrackedStatsClient::new(a)),
-            ),
+            api_client: Some(TrackedStatsClient::new(
+                self.api_client.expect("checked for none"),
+            )),
             identity: self.identity,
             identity_strategy: self.identity_strategy,
             scw_verifier: self.scw_verifier,
@@ -663,11 +655,9 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             disable_events: self.disable_events,
             disable_commit_log_worker: self.disable_commit_log_worker,
             mls_storage: self.mls_storage,
-            sync_api_client: Some(
-                self.sync_api_client
-                    .expect("checked for none")
-                    .map(|a| TrackedStatsClient::new(a)),
-            ),
+            sync_api_client: Some(TrackedStatsClient::new(
+                self.sync_api_client.expect("checked for none"),
+            )),
             cursor_store: self.cursor_store,
             disable_workers: self.disable_workers,
         })
@@ -681,7 +671,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             api_client: self.api_client,
             identity: self.identity,
             identity_strategy: self.identity_strategy,
-            scw_verifier: Some(Arc::new(Box::new(verifier))),
+            scw_verifier: Some(Box::new(verifier)),
             store: self.store,
 
             device_sync_server_url: self.device_sync_server_url,
@@ -715,9 +705,9 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             api_client: self.api_client,
             identity: self.identity,
             identity_strategy: self.identity_strategy,
-            scw_verifier: Some(Arc::new(Box::new(api))),
+            scw_verifier: Some(Box::new(ApiClientWrapper::new(api, Retry::default()))
+                as Box<dyn SmartContractSignatureVerifier>),
             store: self.store,
-
             device_sync_server_url: self.device_sync_server_url,
             device_sync_worker_mode: self.device_sync_worker_mode,
             fork_recovery_opts: self.fork_recovery_opts,

--- a/xmtp_mls/src/definitions.rs
+++ b/xmtp_mls/src/definitions.rs
@@ -2,14 +2,14 @@
 use crate::context::XmtpMlsLocalContext;
 use std::sync::Arc;
 use xmtp_api::ApiDebugWrapper;
-use xmtp_api_d14n::{FullXmtpApiArc, TrackedStatsClient};
+use xmtp_api_d14n::TrackedStatsClient;
+use xmtp_api_d14n::protocol::FullXmtpApiArc;
 use xmtp_api_grpc::error::GrpcError;
 use xmtp_proto::api::ApiClientError;
 
 pub type MlsContext =
     Arc<XmtpMlsLocalContext<WrappedXmtpApiClient, xmtp_db::DefaultStore, xmtp_db::DefaultMlsStore>>;
 
-pub type WrappedXmtpApiClient =
-    ApiDebugWrapper<TrackedStatsClient<FullXmtpApiArc<ApiClientError<GrpcError>>>>;
+pub type WrappedXmtpApiClient = ApiDebugWrapper<TrackedStatsClient<XmtpApiClient>>;
 
 pub type XmtpApiClient = FullXmtpApiArc<ApiClientError<GrpcError>>;

--- a/xmtp_mls/src/test/builder_native_only.rs
+++ b/xmtp_mls/src/test/builder_native_only.rs
@@ -37,8 +37,7 @@ async fn test_remote_is_valid_signature(#[future] docker_smart_wallet: SmartWall
     let xmtp_client = Client::builder(identity_strategy)
         .temp_store()
         .await
-        .local_client()
-        .await
+        .local()
         .default_mls_store()
         .unwrap()
         .with_remote_verifier()
@@ -107,8 +106,7 @@ async fn test_detect_scw_vs_eoa_creation(#[future] docker_smart_wallet: SmartWal
     let scw_client = Client::builder(identity_strategy)
         .temp_store()
         .await
-        .local_client()
-        .await
+        .local()
         .default_mls_store()
         .unwrap()
         .with_remote_verifier()

--- a/xmtp_mls/src/utils/bench/identity_gen.rs
+++ b/xmtp_mls/src/utils/bench/identity_gen.rs
@@ -55,7 +55,6 @@ async fn create_identity(is_dev_network: bool) -> Identity {
         ClientBuilder::new_test_builder(&wallet)
             .await
             .dev()
-            .await
             .build()
             .await
             .unwrap()
@@ -63,7 +62,6 @@ async fn create_identity(is_dev_network: bool) -> Identity {
         ClientBuilder::new_test_builder(&wallet)
             .await
             .local()
-            .await
             .build()
             .await
             .unwrap()

--- a/xmtp_mls/src/utils/test/mod.rs
+++ b/xmtp_mls/src/utils/test/mod.rs
@@ -8,6 +8,7 @@ pub mod fixtures;
 pub mod test_mocks_helpers;
 
 use crate::XmtpApi;
+use crate::cursor_store::SqliteCursorStore;
 use crate::{
     Client, InboxOwner,
     builder::{ClientBuilder, SyncWorkerMode},
@@ -17,12 +18,13 @@ use crate::{
 use alloy::signers::local::PrivateKeySigner;
 use std::{sync::Arc, time::Duration};
 use tokio::sync::Notify;
-use xmtp_api_d14n::protocol::{CursorStore, XmtpQuery};
+use xmtp_api_d14n::XmtpTestClientExt;
+use xmtp_api_d14n::protocol::XmtpQuery;
 use xmtp_common::time::Expired;
 use xmtp_db::{ConnectionExt, DbConnection, XmtpTestDb};
 use xmtp_db::{XmtpMlsStorageProvider, sql_key_store::SqlKeyStore};
 use xmtp_id::associations::{Identifier, test_utils::MockSmartContractSignatureVerifier};
-use xmtp_proto::api_client::{ApiBuilder, CursorAwareApi, XmtpTestClient};
+use xmtp_proto::api_client::{ApiBuilder, XmtpTestClient};
 use xmtp_proto::types::ApiIdentifier;
 
 #[cfg(any(test, feature = "test-utils"))]
@@ -45,30 +47,30 @@ impl<A, S> ClientBuilder<A, S> {
         self.store(xmtp_db::TestDb::create_persistent_store(None).await)
     }
 
-    pub async fn dev(self) -> ClientBuilder<TestClient, S> {
-        let api_client = <TestClient as XmtpTestClient>::create_dev()
-            .build()
-            .unwrap();
-        let sync_api_client = <TestClient as XmtpTestClient>::create_dev()
-            .build()
-            .unwrap();
+    pub fn dev(self) -> ClientBuilder<TestClient, S> {
+        let dev = <TestClient as XmtpTestClient>::create_dev;
+        let s = Arc::new(SqliteCursorStore::new(self.store.as_ref().unwrap().db()));
+        let a = TestClient::with_cursor_store(dev, s.clone());
+        let s = TestClient::with_cursor_store(dev, s);
+        let api_client = a.build().unwrap();
+        let sync_api_client = s.build().unwrap();
         self.api_clients(api_client, sync_api_client)
     }
 
-    pub async fn local(self) -> ClientBuilder<TestClient, S> {
-        let api_client = <TestClient as XmtpTestClient>::create_local()
-            .build()
-            .unwrap();
-        let sync_api_client = <TestClient as XmtpTestClient>::create_local()
-            .build()
-            .unwrap();
+    pub fn local(self) -> ClientBuilder<TestClient, S> {
+        let local = <TestClient as XmtpTestClient>::create_local;
+        let s = Arc::new(SqliteCursorStore::new(self.store.as_ref().unwrap().db()));
+        let a = TestClient::with_cursor_store(local, s.clone());
+        let s = TestClient::with_cursor_store(local, s);
+        let api_client = a.build().unwrap();
+        let sync_api_client = s.build().unwrap();
         self.api_clients(api_client, sync_api_client)
     }
 }
 
 impl<Api, Storage, Db> ClientBuilder<Api, Storage, Db>
 where
-    Api: XmtpApi + CursorAwareApi<CursorStore = Arc<dyn CursorStore>> + XmtpQuery + 'static,
+    Api: XmtpApi + XmtpQuery + 'static,
     Storage: XmtpMlsStorageProvider + 'static,
     Db: xmtp_db::XmtpDb + 'static,
 {
@@ -92,7 +94,6 @@ impl ClientBuilder<TestClient, TestMlsStorage> {
             .default_mls_store()
             .unwrap()
             .local()
-            .await
     }
 
     pub async fn new_test_client(owner: &impl InboxOwner) -> FullXmtpClient {
@@ -121,28 +122,8 @@ impl ClientBuilder<TestClient, TestMlsStorage> {
         let client = Self::new_test_builder(owner)
             .await
             .local()
-            .await
             .device_sync_worker_mode(SyncWorkerMode::Disabled)
             .version(version)
-            .build()
-            .await
-            .unwrap();
-
-        register_client(&client, owner).await;
-        client
-    }
-
-    pub async fn new_test_client_dev(owner: &impl InboxOwner) -> FullXmtpClient {
-        let api_client = <TestClient as XmtpTestClient>::create_dev()
-            .build()
-            .unwrap();
-        let sync_api_client = <TestClient as XmtpTestClient>::create_dev()
-            .build()
-            .unwrap();
-
-        let client = Self::new_test_builder(owner)
-            .await
-            .api_clients(api_client, sync_api_client)
             .build()
             .await
             .unwrap();
@@ -155,17 +136,8 @@ impl ClientBuilder<TestClient, TestMlsStorage> {
         owner: &impl InboxOwner,
         history_sync_url: &str,
     ) -> FullXmtpClient {
-        let api_client = <TestClient as XmtpTestClient>::create_local()
-            .build()
-            .unwrap();
-
-        let sync_api_client = <TestClient as XmtpTestClient>::create_local()
-            .build()
-            .unwrap();
-
         let client = Self::new_test_builder(owner)
             .await
-            .api_clients(api_client, sync_api_client)
             .device_sync_server_url(history_sync_url)
             .build()
             .await
@@ -173,30 +145,6 @@ impl ClientBuilder<TestClient, TestMlsStorage> {
 
         register_client(&client, owner).await;
         client
-    }
-}
-
-impl<ApiClient, Db> ClientBuilder<ApiClient, Db> {
-    pub async fn local_client(self) -> ClientBuilder<TestClient, Db> {
-        self.api_clients(
-            <TestClient as XmtpTestClient>::create_local()
-                .build()
-                .unwrap(),
-            <TestClient as XmtpTestClient>::create_local()
-                .build()
-                .unwrap(),
-        )
-    }
-
-    pub async fn dev_client(self) -> ClientBuilder<TestClient, Db> {
-        self.api_clients(
-            <TestClient as XmtpTestClient>::create_dev()
-                .build()
-                .unwrap(),
-            <TestClient as XmtpTestClient>::create_dev()
-                .build()
-                .unwrap(),
-        )
     }
 }
 

--- a/xmtp_mls/src/utils/test/tester_utils.rs
+++ b/xmtp_mls/src/utils/test/tester_utils.rs
@@ -3,7 +3,7 @@
 use super::FullXmtpClient;
 use async_trait::async_trait;
 use diesel::QueryableByName;
-use xmtp_api_d14n::protocol::InMemoryCursorStore;
+use xmtp_api_d14n::{XmtpTestClientExt, protocol::InMemoryCursorStore};
 use xmtp_configuration::{DeviceSyncUrls, DockerUrls};
 use xmtp_db::{
     ConnectionExt, ReadOnly, TestDb, XmtpTestDb,
@@ -15,6 +15,7 @@ use crate::{
     builder::{ClientBuilder, ForkRecoveryOpts, ForkRecoveryPolicy, SyncWorkerMode},
     client::ClientError,
     context::XmtpSharedContext,
+    cursor_store::SqliteCursorStore,
     groups::device_sync::worker::SyncMetric,
     identity::{Identity, IdentityStrategy},
     subscriptions::SubscribeError,
@@ -186,36 +187,12 @@ where
             replace.add(&ident.to_string(), &format!("{name}_ident"));
         }
 
-        let (mut local_client, mut sync_api_client) = match self.api_endpoint {
-            ApiEndpoint::Local => (TestClient::create_local(), TestClient::create_local()),
-            ApiEndpoint::Dev => (TestClient::create_dev(), TestClient::create_dev()),
-        };
-
-        let mut proxy = None;
-        if self.proxy {
-            proxy = Some(local_client.with_toxiproxy().await);
-            sync_api_client.with_existing_toxi(local_client.host().unwrap());
-        }
-
-        let api_client = local_client.build().unwrap();
-        let sync_api_client = sync_api_client.build().unwrap();
-
         let strategy = match (&self.external_identity, &self.snapshot) {
             (Some(identity), _) => IdentityStrategy::ExternalIdentity(identity.clone()),
             (_, Some(snapshot)) => IdentityStrategy::CachedOnly,
             _ => identity_setup(&self.owner),
         };
-
-        let mut client = Client::builder(strategy.clone())
-            .api_clients(api_client, sync_api_client)
-            .with_disable_events(Some(!self.events))
-            .with_disable_workers(self.disable_workers)
-            .with_scw_verifier(MockSmartContractSignatureVerifier::new(true))
-            .with_device_sync_worker_mode(Some(self.sync_mode))
-            .with_device_sync_server_url(self.sync_url.clone())
-            .maybe_version(self.version.clone())
-            .with_commit_log_worker(self.commit_log_worker)
-            .fork_recovery_opts(self.fork_recovery_opts.clone().unwrap_or_default());
+        let mut client = Client::builder(strategy.clone());
 
         // Setup the database. Snapshots are always ephemeral.
         if self.ephemeral_db || self.snapshot.is_some() {
@@ -233,6 +210,34 @@ where
         } else {
             client = client.temp_store().await;
         }
+
+        let f = match self.api_endpoint {
+            ApiEndpoint::Local => TestClient::create_local,
+            ApiEndpoint::Dev => TestClient::create_dev,
+        };
+        let store = Arc::new(SqliteCursorStore::new(client.store.as_ref().unwrap().db()));
+        let mut local_client = TestClient::with_cursor_store(f, store.clone());
+        let mut sync_api_client = TestClient::with_cursor_store(f, store);
+
+        let mut proxy = None;
+        if self.proxy {
+            proxy = Some(local_client.with_toxiproxy().await);
+            sync_api_client.with_existing_toxi(local_client.host().unwrap());
+        }
+
+        let api_client = local_client.build().unwrap();
+        let sync_api_client = sync_api_client.build().unwrap();
+
+        let mut client = client
+            .api_clients(api_client, sync_api_client)
+            .with_disable_events(Some(!self.events))
+            .with_disable_workers(self.disable_workers)
+            .with_scw_verifier(MockSmartContractSignatureVerifier::new(true))
+            .with_device_sync_worker_mode(Some(self.sync_mode))
+            .with_device_sync_server_url(self.sync_url.clone())
+            .maybe_version(self.version.clone())
+            .with_commit_log_worker(self.commit_log_worker)
+            .fork_recovery_opts(self.fork_recovery_opts.clone().unwrap_or_default());
 
         if self.in_memory_cursors {
             client = client.cursor_store(Arc::new(InMemoryCursorStore::new()) as Arc<_>);

--- a/xmtp_proto/src/api_client.rs
+++ b/xmtp_proto/src/api_client.rs
@@ -35,9 +35,16 @@ xmtp_common::if_test! {
     pub trait XmtpTestClient {
         type Builder: ApiBuilder;
         fn create_local() -> Self::Builder;
-        fn create_d14n() -> Self::Builder;
-        fn create_gateway() -> Self::Builder;
-        fn create_dev() -> Self::Builder;
+
+        fn create_d14n() -> Self::Builder {
+            unimplemented!("d14n not implemented for this test client")
+        }
+        fn create_gateway() -> Self::Builder {
+            unimplemented!("gateway not implemented for this test client")
+        }
+        fn create_dev() -> Self::Builder {
+            unimplemented!("dev not implemented for this test client")
+        }
     }
 }
 
@@ -233,17 +240,4 @@ pub trait ApiBuilder: MaybeSend + MaybeSync {
 
     /// Build the api client
     fn build(self) -> Result<Self::Output, Self::Error>;
-}
-
-/// trait indicating this type may be built in a way that can manage network cursors.
-/// Api Clients may choose their own strategy for managing cursors.
-/// for instance, v3 clients may make assumptions about the centralization of a backend.
-/// d14n clients may be more careful or strategic when choosing cursors.
-/// etc.
-pub trait CursorAwareApi: MaybeSend + MaybeSync {
-    type CursorStore;
-
-    /// set the cursor store for this api
-    /// a cursor indicates a position in a backend network topic
-    fn set_cursor_store(&self, store: Self::CursorStore);
 }

--- a/xmtp_proto/src/api_client/impls.rs
+++ b/xmtp_proto/src/api_client/impls.rs
@@ -396,29 +396,3 @@ where
             .await
     }
 }
-
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-impl<T> CursorAwareApi for Box<T>
-where
-    T: CursorAwareApi + ?Sized,
-{
-    type CursorStore = T::CursorStore;
-
-    fn set_cursor_store(&self, store: Self::CursorStore) {
-        <T as CursorAwareApi>::set_cursor_store(self, store)
-    }
-}
-
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-impl<T> CursorAwareApi for Arc<T>
-where
-    T: CursorAwareApi + ?Sized,
-{
-    type CursorStore = T::CursorStore;
-
-    fn set_cursor_store(&self, store: Self::CursorStore) {
-        <T as CursorAwareApi>::set_cursor_store(self, store)
-    }
-}


### PR DESCRIPTION
This PR introduces a temp hack, `new_client_from_store` that downcasts a `dyn Any` reference to a V3 or D14n client, in order to clone it and switch out  the cursor store.  this ensures that other Arc<dyn> client references are not using a store, and the only store is used by a client.


Future PRs will remove this hack in favor of backend-specific "Client Bundles" that will make it easier to pass around just the client bundles, and  then construct a specific backend strategy (V3/Hybrid/D14n)