### PR TITLE
simplify ApiBuilder traits

### DIFF
--- a/xmtp_api/src/mls.rs
+++ b/xmtp_api/src/mls.rs
@@ -366,16 +366,22 @@ pub mod tests {
     use crate::*;
 
     use prost::Message;
+    use xmtp_api_d14n::D14nClient;
     use xmtp_api_d14n::MockApiClient;
     use xmtp_api_d14n::MockError;
+    use xmtp_api_d14n::ReadWriteClient;
     use xmtp_api_d14n::V3Client;
     use xmtp_api_d14n::protocol::NoCursorStore;
+    use xmtp_api_grpc::GrpcClient;
     use xmtp_common::FakeMlsApplicationMessage;
     use xmtp_common::Generate;
     use xmtp_common::rand_vec;
+    use xmtp_configuration::GrpcUrls;
+    use xmtp_configuration::PAYER_WRITE_FILTER;
     use xmtp_cryptography::openmls::prelude::MlsMessageOut;
     use xmtp_proto::api::mock::MockNetworkClient;
     use xmtp_proto::api_client::ApiBuilder;
+    use xmtp_proto::api_client::NetConnectConfig;
     use xmtp_proto::api_client::XmtpTestClient;
     use xmtp_proto::mls_v1::PagingInfo;
     use xmtp_proto::mls_v1::QueryGroupMessagesRequest;
@@ -649,11 +655,24 @@ pub mod tests {
     #[xmtp_common::test]
     #[ignore]
     async fn it_should_rate_limit() {
-        let mut client = crate::test_utils::DefaultTestClientCreator::create();
-        client.rate_per_minute(1);
-        let _ = client.set_app_version("999.999.999".into());
-        let c = client.build().unwrap();
-        let wrapper = ApiClientWrapper::new(c, Retry::default());
+        let mut builder = GrpcClient::builder();
+        builder.rate_per_minute(1);
+        builder.set_app_version("999.999.999".into()).unwrap();
+
+        let mut gateway = builder.clone();
+        gateway.set_host(GrpcUrls::GATEWAY.into());
+        let mut xmtpd = builder.clone();
+        xmtpd.set_host(GrpcUrls::XMTPD.into());
+        let xmtpd = xmtpd.build().unwrap();
+        let gateway = gateway.build().unwrap();
+        let rw = ReadWriteClient::builder()
+            .read(xmtpd)
+            .write(gateway)
+            .filter(PAYER_WRITE_FILTER)
+            .build()
+            .unwrap();
+        let d14n = D14nClient::new(rw, NoCursorStore).unwrap();
+        let wrapper = ApiClientWrapper::new(d14n, Retry::default());
         let _first = wrapper.query_group_messages(vec![0, 0].into()).await;
         let now = std::time::Instant::now();
         let _second = wrapper.query_group_messages(vec![0, 0].into()).await;
@@ -663,8 +682,7 @@ pub mod tests {
     #[xmtp_common::test]
     #[cfg_attr(any(target_arch = "wasm32"), ignore)]
     async fn it_should_allow_large_payloads() {
-        let mut client = crate::test_utils::DefaultTestClientCreator::create();
-        client.set_app_version("0.0.0".into()).unwrap();
+        let client = crate::test_utils::DefaultTestClientCreator::create();
         let installation_key = rand_vec::<32>();
         let hpke_public_key = rand_vec::<32>();
 
@@ -702,8 +720,7 @@ pub mod tests {
     async fn test_publish_commit_log_batching_with_local_server() {
         // This test verifies that publish batching works correctly with a local server
         // It should handle 11 publish requests without hitting API limits
-        let mut client = crate::test_utils::DefaultTestClientCreator::create();
-        client.set_app_version("0.0.0".into()).unwrap();
+        let client = crate::test_utils::DefaultTestClientCreator::create();
 
         let c = client.build().unwrap();
         let wrapper = ApiClientWrapper::new(c, Retry::default());
@@ -745,8 +762,7 @@ pub mod tests {
     async fn test_query_commit_log_batching_with_local_server() {
         // This test verifies that query batching works correctly with a local server
         // It should handle 21 query requests without hitting API limits
-        let mut client = crate::test_utils::DefaultTestClientCreator::create();
-        client.set_app_version("0.0.0".into()).unwrap();
+        let client = crate::test_utils::DefaultTestClientCreator::create();
 
         let c = client.build().unwrap();
         let wrapper = ApiClientWrapper::new(c, Retry::default());

--- a/xmtp_api_d14n/src/middleware/multi_node_client/builder.rs
+++ b/xmtp_api_d14n/src/middleware/multi_node_client/builder.rs
@@ -4,7 +4,7 @@ use tokio::sync::OnceCell;
 use xmtp_api_grpc::{ClientBuilder, GrpcClient, error::GrpcBuilderError};
 use xmtp_common::time::Duration;
 use xmtp_configuration::MULTI_NODE_TIMEOUT_MS;
-use xmtp_proto::{api_client::ApiBuilder, types::AppVersion};
+use xmtp_proto::api_client::ApiBuilder;
 
 /* MultiNodeClientBuilder struct and its associated errors */
 
@@ -42,36 +42,19 @@ impl Default for MultiNodeClientBuilder {
 // Implement the MiddlewareBuilder trait for MultiNodeClientBuilder.
 // This defines how to build a MultiNodeClient from a MultiNodeClientBuilder.
 impl MiddlewareBuilder for MultiNodeClientBuilder {
-    type Output = MultiNodeClient;
-    type Error = MultiNodeClientBuilderError;
-
     fn set_gateway_builder(&mut self, gateway_builder: ClientBuilder) -> Result<(), Self::Error> {
         self.gateway_builder = Some(gateway_builder);
+        Ok(())
+    }
+
+    fn set_node_client_builder(&mut self, node_builder: ClientBuilder) -> Result<(), Self::Error> {
+        self.node_client_template = node_builder;
         Ok(())
     }
 
     fn set_timeout(&mut self, timeout: Duration) -> Result<(), Self::Error> {
         self.timeout = timeout;
         Ok(())
-    }
-
-    fn into_client(self) -> Result<Self::Output, Self::Error> {
-        let gateway_builder = self
-            .gateway_builder
-            .ok_or(MultiNodeClientBuilderError::MissingGatewayBuilder)?;
-
-        if self.timeout.is_zero() {
-            return Err(MultiNodeClientBuilderError::InvalidTimeout);
-        }
-
-        let gateway_client = gateway_builder.build()?;
-
-        Ok(MultiNodeClient {
-            gateway_client,
-            inner: OnceCell::new(),
-            timeout: self.timeout,
-            node_client_template: self.node_client_template,
-        })
     }
 }
 
@@ -80,41 +63,6 @@ impl MiddlewareBuilder for MultiNodeClientBuilder {
 impl ApiBuilder for MultiNodeClientBuilder {
     type Output = MultiNodeClient;
     type Error = MultiNodeClientBuilderError;
-
-    fn set_libxmtp_version(&mut self, version: String) -> Result<(), Self::Error> {
-        ClientBuilder::set_libxmtp_version(&mut self.node_client_template, version)?;
-        Ok(())
-    }
-
-    fn set_app_version(&mut self, version: AppVersion) -> Result<(), Self::Error> {
-        ClientBuilder::set_app_version(&mut self.node_client_template, version)?;
-        Ok(())
-    }
-
-    /// No-op: node hosts are discovered dynamically via the gateway.
-    fn set_host(&mut self, _: String) {}
-
-    fn set_tls(&mut self, tls: bool) {
-        ClientBuilder::set_tls(&mut self.node_client_template, tls);
-    }
-
-    fn set_retry(&mut self, retry: xmtp_common::Retry) {
-        ClientBuilder::set_retry(&mut self.node_client_template, retry);
-    }
-
-    fn rate_per_minute(&mut self, limit: u32) {
-        ClientBuilder::rate_per_minute(&mut self.node_client_template, limit);
-    }
-
-    fn port(&self) -> Result<Option<String>, Self::Error> {
-        ClientBuilder::port(&self.node_client_template)
-            .map(|_| None)
-            .map_err(Into::into)
-    }
-
-    fn host(&self) -> Option<&str> {
-        ClientBuilder::host(&self.node_client_template)
-    }
 
     fn build(self) -> Result<Self::Output, Self::Error> {
         let gateway_builder = self

--- a/xmtp_api_d14n/src/middleware/multi_node_client/client.rs
+++ b/xmtp_api_d14n/src/middleware/multi_node_client/client.rs
@@ -87,7 +87,7 @@ mod tests {
     use std::sync::Arc;
     use xmtp_configuration::{GrpcUrls, PAYER_WRITE_FILTER};
     use xmtp_proto::api::Query;
-    use xmtp_proto::api_client::ApiBuilder;
+    use xmtp_proto::api_client::{ApiBuilder, NetConnectConfig};
     use xmtp_proto::prelude::XmtpMlsClient;
     use xmtp_proto::types::GroupId;
 
@@ -109,27 +109,35 @@ mod tests {
         gateway_builder
     }
 
+    fn create_node_builder() -> ClientBuilder {
+        let mut node_builder = GrpcClient::builder();
+        node_builder.set_tls(is_tls_enabled());
+        node_builder
+    }
+
     fn create_multinode_client_builder() -> MultiNodeClientBuilder {
         let mut multi_node_builder = MultiNodeClientBuilder::default();
         multi_node_builder
             .set_gateway_builder(create_gateway_builder())
             .unwrap();
         multi_node_builder
+            .set_node_client_builder(create_node_builder())
+            .unwrap();
+        multi_node_builder
             .set_timeout(Duration::from_millis(1000))
             .unwrap();
-        multi_node_builder.set_tls(is_tls_enabled());
         multi_node_builder
     }
 
     fn create_multinode_client() -> MultiNodeClient {
         let multi_node_builder = create_multinode_client_builder();
-        multi_node_builder.into_client().unwrap()
+        multi_node_builder.build().unwrap()
     }
 
     fn create_d14n_client()
     -> D14nClient<ReadWriteClient<MultiNodeClient, GrpcClient>, NoCursorStore> {
         let rw = ReadWriteClient::builder()
-            .read(create_multinode_client_builder().into_client().unwrap())
+            .read(create_multinode_client_builder().build().unwrap())
             .write(create_gateway_builder().build().unwrap())
             .filter(PAYER_WRITE_FILTER)
             .build()
@@ -185,6 +193,7 @@ mod tests {
 
         // 1) Create gateway builder.
         let gateway_builder = create_gateway_builder();
+        let node_builder = create_node_builder();
 
         // 2) Configure multi-node builder with the gateway builder.
         let mut multi_node_builder = MultiNodeClientBuilder::default();
@@ -195,22 +204,22 @@ mod tests {
             .set_gateway_builder(gateway_builder.clone())
             .expect("gateway set on multi-node");
 
+        multi_node_builder
+            .set_node_client_builder(node_builder)
+            .expect("node set on multi-node");
+
         // Multi-node specific configuration.
         // Set the timeout, used in multi-node client requests to the gateway.
         multi_node_builder
             .set_timeout(xmtp_common::time::Duration::from_millis(1000))
             .unwrap();
 
-        // ApiBuilder methods forward configuration to the node client template.
-        // All GrpcClient instances will inherit these settings.
-        multi_node_builder.set_tls(is_tls_enabled());
-
         // All ApiBuilder methods are available:
         // multi_node_builder.set_libxmtp_version("1.0.0".into())?;
         // multi_node_builder.set_retry(Retry::default());
 
         let cursor_store = create_in_memory_cursor_store();
-        let multi_node_client = multi_node_builder.into_client().unwrap();
+        let multi_node_client = multi_node_builder.build().unwrap();
         let gateway_client = gateway_builder.build().unwrap();
 
         let rw = ReadWriteClient::builder()
@@ -227,18 +236,22 @@ mod tests {
     #[xmtp_common::test]
     async fn build_multinode_as_standalone() {
         let gateway_builder = create_gateway_builder();
-
+        let node_builder = create_node_builder();
         let mut multi_node_builder = MultiNodeClientBuilder::default();
         multi_node_builder
             .set_gateway_builder(gateway_builder.clone())
             .expect("gateway set on multi-node");
+
+        multi_node_builder
+            .set_node_client_builder(node_builder)
+            .expect("node set on multi-node");
+
         multi_node_builder
             .set_timeout(xmtp_common::time::Duration::from_millis(100))
             .unwrap();
-        multi_node_builder.set_tls(is_tls_enabled());
 
         let _ = multi_node_builder
-            .into_client()
+            .build()
             .expect("failed to build multi-node client");
     }
 

--- a/xmtp_api_d14n/src/middleware/multi_node_client/gateway_api.rs
+++ b/xmtp_api_d14n/src/middleware/multi_node_client/gateway_api.rs
@@ -10,7 +10,7 @@ use xmtp_common::{
     time::{Duration, Instant},
 };
 use xmtp_proto::api::Query;
-use xmtp_proto::api_client::ApiBuilder;
+use xmtp_proto::prelude::{ApiBuilder, NetConnectConfig};
 use xmtp_proto::{ApiEndpoint, api::ApiClientError};
 
 /// Get the nodes from the gateway server and build the clients for each node.

--- a/xmtp_api_d14n/src/middleware/read_write_client/client.rs
+++ b/xmtp_api_d14n/src/middleware/read_write_client/client.rs
@@ -83,7 +83,7 @@ where
 
 xmtp_common::if_test! {
     use derive_builder::UninitializedFieldError;
-    use xmtp_proto::prelude::{ApiBuilder};
+    use xmtp_proto::prelude::ApiBuilder;
     #[allow(clippy::unwrap_used)]
     impl<R, W> ReadWriteClientBuilder<R, W>
     where

--- a/xmtp_api_d14n/src/middleware/read_write_client/test.rs
+++ b/xmtp_api_d14n/src/middleware/read_write_client/test.rs
@@ -25,40 +25,8 @@ where
 {
     type Output = ReadWriteClient<BRead::Output, BWrite::Output>;
     type Error = ();
-    fn set_libxmtp_version(&mut self, _: String) -> Result<(), Self::Error> {
-        unimplemented!("no way to set host for a client that needs 2 hosts")
-    }
-
-    fn set_app_version(&mut self, _: xmtp_proto::types::AppVersion) -> Result<(), Self::Error> {
-        unimplemented!("no way to set host for a client that needs 2 hosts")
-    }
-
-    fn set_host(&mut self, _host: String) {
-        unimplemented!("no way to set host for a client that needs 2 hosts")
-    }
-
-    fn set_tls(&mut self, _: bool) {
-        unimplemented!("no way to set host for a client that needs 2 hosts")
-    }
-
-    fn rate_per_minute(&mut self, _: u32) {
-        unimplemented!("no way to set host for a client that needs 2 hosts")
-    }
-
-    fn port(&self) -> Result<Option<String>, Self::Error> {
-        unimplemented!("no way to set host for a client that needs 2 hosts")
-    }
-
-    fn host(&self) -> Option<&str> {
-        unimplemented!("no way to set host for a client that needs 2 hosts")
-    }
-
     fn build(self) -> Result<Self::Output, Self::Error> {
         let c = self.build_builder().unwrap();
         Ok(c)
-    }
-
-    fn set_retry(&mut self, _: xmtp_common::Retry) {
-        unimplemented!("no way to set host for a client that needs 2 hosts")
     }
 }

--- a/xmtp_api_d14n/src/middleware/traits.rs
+++ b/xmtp_api_d14n/src/middleware/traits.rs
@@ -1,18 +1,15 @@
 use xmtp_api_grpc::ClientBuilder;
 use xmtp_common::time::Duration;
+use xmtp_proto::prelude::ApiBuilder;
 
 /* Middleware trait */
 
-pub trait MiddlewareBuilder {
-    type Output;
-    type Error;
-
+pub trait MiddlewareBuilder: ApiBuilder {
     /// Set the gateway builder for node discovery.
     fn set_gateway_builder(&mut self, gateway_builder: ClientBuilder) -> Result<(), Self::Error>;
+    /// Set the default builder for xmtpd nodes
+    fn set_node_client_builder(&mut self, node_builder: ClientBuilder) -> Result<(), Self::Error>;
 
     /// Set the timeout for node discovery.
     fn set_timeout(&mut self, timeout: Duration) -> Result<(), Self::Error>;
-
-    /// Build the middleware.
-    fn into_client(self) -> Result<Self::Output, Self::Error>;
 }

--- a/xmtp_api_d14n/src/queries/api_stats.rs
+++ b/xmtp_api_d14n/src/queries/api_stats.rs
@@ -8,7 +8,6 @@ use xmtp_proto::mls_v1;
 use xmtp_proto::prelude::ApiBuilder;
 use xmtp_proto::prelude::XmtpIdentityClient;
 use xmtp_proto::prelude::XmtpMlsStreams;
-use xmtp_proto::types::AppVersion;
 use xmtp_proto::types::InstallationId;
 use xmtp_proto::types::WelcomeMessage;
 use xmtp_proto::types::{GroupId, GroupMessage};
@@ -245,42 +244,10 @@ where
 
     type Error = <Builder as ApiBuilder>::Error;
 
-    fn set_libxmtp_version(&mut self, version: String) -> Result<(), Self::Error> {
-        <Builder as ApiBuilder>::set_libxmtp_version(&mut self.client, version)
-    }
-
-    fn set_app_version(&mut self, version: AppVersion) -> Result<(), Self::Error> {
-        <Builder as ApiBuilder>::set_app_version(&mut self.client, version)
-    }
-
-    fn set_host(&mut self, host: String) {
-        <Builder as ApiBuilder>::set_host(&mut self.client, host)
-    }
-
-    fn set_tls(&mut self, tls: bool) {
-        <Builder as ApiBuilder>::set_tls(&mut self.client, tls)
-    }
-
-    fn rate_per_minute(&mut self, limit: u32) {
-        <Builder as ApiBuilder>::rate_per_minute(&mut self.client, limit)
-    }
-
-    fn port(&self) -> Result<Option<String>, Self::Error> {
-        <Builder as ApiBuilder>::port(&self.client)
-    }
-
-    fn host(&self) -> Option<&str> {
-        <Builder as ApiBuilder>::host(&self.client)
-    }
-
     fn build(self) -> Result<Self::Output, Self::Error> {
         Ok(TrackedStatsClient::new(<Builder as ApiBuilder>::build(
             self.client,
         )?))
-    }
-
-    fn set_retry(&mut self, retry: xmtp_common::Retry) {
-        <Builder as ApiBuilder>::set_retry(&mut self.client, retry)
     }
 }
 

--- a/xmtp_api_d14n/src/queries/builder.rs
+++ b/xmtp_api_d14n/src/queries/builder.rs
@@ -10,7 +10,7 @@ use xmtp_common::{MaybeSend, MaybeSync};
 use xmtp_configuration::{MULTI_NODE_TIMEOUT_MS, PAYER_WRITE_FILTER};
 use xmtp_id::scw_verifier::VerifierError;
 use xmtp_proto::api::ApiClientError;
-use xmtp_proto::api_client::ApiBuilder;
+use xmtp_proto::prelude::{ApiBuilder, NetConnectConfig};
 use xmtp_proto::types::AppVersion;
 
 use crate::protocol::{CursorStore, FullXmtpApiArc, FullXmtpApiBox, FullXmtpApiT, NoCursorStore};
@@ -129,8 +129,10 @@ impl MessageBackendBuilder {
 
             let mut multi_node = crate::middleware::MultiNodeClientBuilder::default();
             multi_node.set_timeout(Duration::from_millis(MULTI_NODE_TIMEOUT_MS))?;
-            multi_node.set_tls(is_secure);
             multi_node.set_gateway_builder(gateway_client_builder.clone())?;
+            let mut template = GrpcClient::builder();
+            template.set_tls(is_secure);
+            multi_node.set_node_client_builder(template)?;
 
             let gateway_client = gateway_client_builder.build()?;
             let multi_node = multi_node.build()?;

--- a/xmtp_api_d14n/src/queries/d14n/test_client.rs
+++ b/xmtp_api_d14n/src/queries/d14n/test_client.rs
@@ -8,7 +8,6 @@ use xmtp_proto::api_client::ToxicProxies;
 use xmtp_proto::api_client::ToxicTestClient;
 use xmtp_proto::prelude::ApiBuilder;
 use xmtp_proto::prelude::XmtpTestClient;
-use xmtp_proto::types::AppVersion;
 
 use crate::ReadWriteClientBuilder;
 use crate::{ReadWriteClient, XmtpTestClientExt, protocol::NoCursorStore};
@@ -82,37 +81,6 @@ where
 {
     type Output = D14nClient<ReadWriteClient<BRead::Output, BWrite::Output>, Store>;
     type Error = <BRead as ApiBuilder>::Error;
-    fn set_libxmtp_version(&mut self, _: String) -> Result<(), Self::Error> {
-        unimplemented!("no way to set host for a client that needs 2 hosts")
-    }
-
-    fn set_app_version(&mut self, _: AppVersion) -> Result<(), Self::Error> {
-        unimplemented!("no way to set host for a client that needs 2 hosts")
-    }
-
-    fn set_host(&mut self, _host: String) {
-        unimplemented!("no way to set host for a client that needs 2 hosts")
-    }
-
-    fn set_tls(&mut self, _: bool) {
-        unimplemented!("no way to set host for a client that needs 2 hosts")
-    }
-
-    fn set_retry(&mut self, _: xmtp_common::Retry) {
-        unimplemented!("no way to set host for a client that needs 2 hosts")
-    }
-
-    fn rate_per_minute(&mut self, _: u32) {
-        unimplemented!("no way to set host for a client that needs 2 hosts")
-    }
-
-    fn port(&self) -> Result<Option<String>, Self::Error> {
-        unimplemented!("no way to set host for a client that needs 2 hosts")
-    }
-
-    fn host(&self) -> Option<&str> {
-        unimplemented!("no way to set host for a client that needs 2 hosts")
-    }
 
     fn build(self) -> Result<Self::Output, Self::Error> {
         Ok(D14nClient {

--- a/xmtp_api_d14n/src/queries/v3/client.rs
+++ b/xmtp_api_d14n/src/queries/v3/client.rs
@@ -1,7 +1,6 @@
 use xmtp_common::{MaybeSend, MaybeSync};
 use xmtp_proto::api::IsConnectedCheck;
 use xmtp_proto::prelude::ApiBuilder;
-use xmtp_proto::types::AppVersion;
 
 #[derive(Clone)]
 pub struct V3Client<C, Store> {
@@ -47,44 +46,11 @@ where
     type Output = V3Client<<Builder as ApiBuilder>::Output, Store>;
 
     type Error = <Builder as ApiBuilder>::Error;
-
-    fn set_libxmtp_version(&mut self, version: String) -> Result<(), Self::Error> {
-        <Builder as ApiBuilder>::set_libxmtp_version(&mut self.client, version)
-    }
-
-    fn set_app_version(&mut self, version: AppVersion) -> Result<(), Self::Error> {
-        <Builder as ApiBuilder>::set_app_version(&mut self.client, version)
-    }
-
-    fn set_host(&mut self, host: String) {
-        <Builder as ApiBuilder>::set_host(&mut self.client, host)
-    }
-
-    fn set_tls(&mut self, tls: bool) {
-        <Builder as ApiBuilder>::set_tls(&mut self.client, tls)
-    }
-
-    fn rate_per_minute(&mut self, limit: u32) {
-        <Builder as ApiBuilder>::rate_per_minute(&mut self.client, limit)
-    }
-
-    fn port(&self) -> Result<Option<String>, Self::Error> {
-        <Builder as ApiBuilder>::port(&self.client)
-    }
-
-    fn host(&self) -> Option<&str> {
-        <Builder as ApiBuilder>::host(&self.client)
-    }
-
     fn build(self) -> Result<Self::Output, Self::Error> {
         Ok(V3Client {
             client: <Builder as ApiBuilder>::build(self.client)?,
             cursor_store: self.store,
         })
-    }
-
-    fn set_retry(&mut self, retry: xmtp_common::Retry) {
-        <Builder as ApiBuilder>::set_retry(&mut self.client, retry)
     }
 }
 

--- a/xmtp_api_grpc/src/grpc_client/client.rs
+++ b/xmtp_api_grpc/src/grpc_client/client.rs
@@ -23,7 +23,7 @@ use xmtp_common::Retry;
 use xmtp_configuration::GRPC_PAYLOAD_LIMIT;
 use xmtp_proto::{
     api::{ApiClientError, Client, IsConnectedCheck},
-    api_client::ApiBuilder,
+    api_client::{ApiBuilder, NetConnectConfig},
     codec::TransparentCodec,
     types::AppVersion,
 };
@@ -215,10 +215,7 @@ pub struct ClientBuilder {
     pub retry: Option<Retry>,
 }
 
-impl ApiBuilder for ClientBuilder {
-    type Output = crate::GrpcClient;
-    type Error = GrpcBuilderError;
-
+impl NetConnectConfig for ClientBuilder {
     fn set_libxmtp_version(&mut self, version: String) -> Result<(), Self::Error> {
         self.libxmtp_version = Some(MetadataValue::try_from(&version)?);
         Ok(())
@@ -254,6 +251,15 @@ impl ApiBuilder for ClientBuilder {
         self.host.as_deref()
     }
 
+    fn set_retry(&mut self, retry: xmtp_common::Retry) {
+        self.retry = Some(retry);
+    }
+}
+
+impl ApiBuilder for ClientBuilder {
+    type Output = crate::GrpcClient;
+    type Error = GrpcBuilderError;
+
     fn build(self) -> Result<Self::Output, Self::Error> {
         let host = self.host.ok_or(GrpcBuilderError::MissingHostUrl)?;
         let channel = crate::GrpcService::new(host, self.limit, self.tls_channel)?;
@@ -268,10 +274,6 @@ impl ApiBuilder for ClientBuilder {
                 env!("CARGO_PKG_VERSION").to_string(),
             )?),
         })
-    }
-
-    fn set_retry(&mut self, retry: xmtp_common::Retry) {
-        self.retry = Some(retry);
     }
 }
 
@@ -302,7 +304,7 @@ pub mod tests {
     use crate::grpc_client::test::DevNodeGoClient;
     use prost::Message;
     use xmtp_proto::api_client::ApiBuilder;
-    use xmtp_proto::prelude::XmtpTestClient;
+    use xmtp_proto::prelude::{NetConnectConfig, XmtpTestClient};
     use xmtp_proto::types::AppVersion;
     use xmtp_proto::xmtp::message_api::v1::PublishRequest;
 

--- a/xmtp_api_grpc/src/grpc_client/test/clients.rs
+++ b/xmtp_api_grpc/src/grpc_client/test/clients.rs
@@ -2,7 +2,7 @@ use toxiproxy_rust::TOXIPROXY;
 use xmtp_configuration::{GrpcUrls, GrpcUrlsDev, GrpcUrlsLocal, GrpcUrlsToxic};
 use xmtp_proto::{
     api_client::{ToxicProxies, ToxicTestClient, XmtpTestClient},
-    prelude::ApiBuilder,
+    prelude::NetConnectConfig,
 };
 
 use crate::{ClientBuilder, GrpcClient};

--- a/xmtp_proto/src/api_client.rs
+++ b/xmtp_proto/src/api_client.rs
@@ -192,11 +192,11 @@ pub trait XmtpIdentityClient: MaybeSend + MaybeSync {
     ) -> Result<VerifySmartContractWalletSignaturesResponse, Self::Error>;
 }
 
-/// Build an API from its parts for the XMTP Backend
-pub trait ApiBuilder: MaybeSend + MaybeSync {
-    type Output: MaybeSend + MaybeSync;
-    type Error: MaybeSend + MaybeSync + std::fmt::Debug;
-
+/// describe how to create a single network
+/// connection.
+/// Implement this trait if your type connects to a single
+/// network channel/connection (like gRPc or HTTP)
+pub trait NetConnectConfig: ApiBuilder + MaybeSend + MaybeSync {
     /// set the libxmtp version (required)
     fn set_libxmtp_version(&mut self, version: String) -> Result<(), Self::Error>;
 
@@ -220,7 +220,12 @@ pub trait ApiBuilder: MaybeSend + MaybeSync {
 
     /// Host of the builder
     fn host(&self) -> Option<&str>;
+}
 
+/// Build an API from its parts for the XMTP Backend
+pub trait ApiBuilder: MaybeSend + MaybeSync {
+    type Output: MaybeSend + MaybeSync;
+    type Error: MaybeSend + MaybeSync + std::fmt::Debug;
     /// Build the api client
     fn build(self) -> Result<Self::Output, Self::Error>;
 }

--- a/xmtp_proto/src/lib.rs
+++ b/xmtp_proto/src/lib.rs
@@ -49,7 +49,8 @@ pub mod prelude {
         pub use super::api_client::XmtpTestClient;
     }
     pub use super::api_client::{
-        ApiBuilder, ArcedXmtpApi, BoxedXmtpApi, XmtpIdentityClient, XmtpMlsClient, XmtpMlsStreams,
+        ApiBuilder, ArcedXmtpApi, BoxedXmtpApi, NetConnectConfig, XmtpIdentityClient,
+        XmtpMlsClient, XmtpMlsStreams,
     };
     pub use super::traits::{ApiClientError, Client, Endpoint, Query, QueryStream};
 }

--- a/xmtp_proto/src/traits/mock.rs
+++ b/xmtp_proto/src/traits/mock.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{prelude::*, types::AppVersion};
+use crate::{api_client::NetConnectConfig, prelude::*, types::AppVersion};
 
 pub struct TestEndpoint;
 impl Endpoint for TestEndpoint {
@@ -19,6 +19,13 @@ pub struct MockApiBuilder;
 impl ApiBuilder for MockApiBuilder {
     type Output = MockNetworkClient;
     type Error = MockError;
+
+    fn build(self) -> Result<Self::Output, Self::Error> {
+        Ok(MockNetworkClient::default())
+    }
+}
+
+impl NetConnectConfig for MockApiBuilder {
     fn set_libxmtp_version(&mut self, _version: String) -> Result<(), Self::Error> {
         Ok(())
     }
@@ -31,10 +38,6 @@ impl ApiBuilder for MockApiBuilder {
 
     fn port(&self) -> Result<Option<String>, Self::Error> {
         Ok(None)
-    }
-
-    fn build(self) -> Result<Self::Output, Self::Error> {
-        Ok(MockNetworkClient::default())
     }
 
     fn host(&self) -> Option<&str> {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Reduce `ApiBuilder` to `build()` and move connection configuration to `NetConnectConfig` across gRPC, d14n multi-node, and test builders
Consolidate builder traits by introducing `NetConnectConfig` for connection settings and limiting `ApiBuilder` to `build()`, updating multi-node and read/write client builders to use `set_node_client_builder`, and replacing `into_client()` with `build()`; adjust tests to construct explicit `GrpcClient` builders and update rate-limit setup.

#### 📍Where to Start
Start with trait changes in `ApiBuilder` and `NetConnectConfig` in [xmtp_proto/src/api_client.rs](https://github.com/xmtp/libxmtp/pull/2714/files#diff-7e862515880042ad7a89178c4850f4edd3b1a449ebd83515598088bd845fe67b), then review the `MultiNodeClientBuilder` updates in [xmtp_api_d14n/src/middleware/multi_node_client/builder.rs](https://github.com/xmtp/libxmtp/pull/2714/files#diff-c3ae7ce19f183873df1c568201e354b80e43bc2b22390124be41c307712e3ee5).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized aa01cfc. 34 files reviewed, 41 issues evaluated, 41 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>common/src/test.rs — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 34](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/common/src/test.rs#L34): `toxiproxy_test` uses `unwrap()` on `TOXIPROXY.reset().await` at line 34. If `reset()` returns an `Err`, this will panic at runtime, abruptly terminating the test instead of providing a controlled error or propagating a `Result`. Replace `unwrap()` with proper error handling (e.g., `?` to return a `Result`, or map the error) to avoid unintended panics. <b>[ Low confidence ]</b>
</details>

<details>
<summary>xmtp_api/src/mls.rs — 0 comments posted, 6 evaluated, 6 filtered</summary>

- [line 660](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_api/src/mls.rs#L660): Unchecked unwrap on `builder.set_app_version("999.999.999".into()).unwrap();` can panic at runtime if version parsing/validation fails under certain configurations. In tests, this causes non-deterministic failure rather than a controlled error. <b>[ Code style ]</b>
- [line 666](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_api/src/mls.rs#L666): Unchecked unwrap on building the `xmtpd` client: `let xmtpd = xmtpd.build().unwrap();` can panic at runtime if client configuration or environment (e.g., DNS, TLS, credentials) is invalid. In a networked test, this produces non-deterministic failures. <b>[ Code style ]</b>
- [line 667](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_api/src/mls.rs#L667): Unchecked unwrap on building the `gateway` client: `let gateway = gateway.build().unwrap();` can panic under invalid configuration/environment, causing non-deterministic test failures. <b>[ Code style ]</b>
- [line 673](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_api/src/mls.rs#L673): Unchecked unwrap on building the `ReadWriteClient`: `... .build().unwrap();` can panic if either read or write client is invalid or the filter configuration causes an error, yielding non-deterministic test failure. <b>[ Code style ]</b>
- [line 674](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_api/src/mls.rs#L674): Unchecked unwrap on constructing `D14nClient`: `let d14n = D14nClient::new(rw, NoCursorStore).unwrap();` can panic if initialization fails (e.g., invalid `rw` setup), causing non-deterministic test failure. <b>[ Code style ]</b>
- [line 679](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_api/src/mls.rs#L679): The timing assertion `assert!(now.elapsed() > std::time::Duration::from_secs(60));` can spuriously fail. The reference `now` is taken after the first awaited call (`_first`) completes, but many rate limiters enforce spacing based on request start time or allow exactly 60 seconds. If the limiter measures from the first request start, the second call’s enforced wait will be approximately `60s - first_call_duration`, making the measured `now.elapsed()` less than 60 seconds even when the limiter is functioning correctly. Also, requiring strict `>` rather than `>=` makes the test flaky if the delay is exactly 60 seconds. <b>[ Test / Mock code ]</b>
</details>

<details>
<summary>xmtp_api_d14n/src/middleware/multi_node_client/client.rs — 0 comments posted, 20 evaluated, 20 filtered</summary>

- [line 119](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_api_d14n/src/middleware/multi_node_client/client.rs#L119): Removal of `set_tls(is_tls_enabled())` in tests can cause runtime connection failures if TLS configuration is required by the selected gateways/nodes or if the default differs from previous behavior. This is an externally visible contract change for how clients are configured during tests, potentially breaking connectivity or security expectations. <b>[ Test / Mock code ]</b>
- [line 121](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_api_d14n/src/middleware/multi_node_client/client.rs#L121): `set_gateway_builder(...).unwrap()` may panic at runtime if `set_gateway_builder` returns `Err` (e.g., invalid builder state or duplicate/illegal configuration). There is no guard or fallback here; a reachable error path will hard-terminate rather than report an error. <b>[ Low confidence ]</b>
- [line 124](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_api_d14n/src/middleware/multi_node_client/client.rs#L124): `set_node_client_builder(...).unwrap()` may panic at runtime if `set_node_client_builder` returns `Err`. Given the diff also adds another call to `set_node_client_builder` in tests, the second call can return `Err` (e.g., "already set"), making this panic reachable. <b>[ Low confidence ]</b>
- [line 124](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_api_d14n/src/middleware/multi_node_client/client.rs#L124): Duplicate configuration of `node_client_builder` across paths: this function sets it, and the diff shows tests calling `set_node_client_builder(...)` again on the same builder, which can return `Err` (e.g., "already set") and then `unwrap()` will panic. This is a newly reachable failure introduced by the diff. <b>[ Low confidence ]</b>
- [line 127](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_api_d14n/src/middleware/multi_node_client/client.rs#L127): `set_timeout(Duration::from_millis(1000)).unwrap()` may panic at runtime if the builder rejects the timeout (e.g., too small or invalid in current configuration). There is no error handling or fallback. <b>[ Low confidence ]</b>
- [line 139](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_api_d14n/src/middleware/multi_node_client/client.rs#L139): Switching from passing separate `MultiNodeClient` and `GrpcClient` to wrapping them in `ReadWriteClient<MultiNodeClient, GrpcClient>` may alter initialization and error-propagation semantics for `D14nClient::new`. Without explicit parity checks, this can change how reads/writes are performed or validated at runtime. <b>[ Test / Mock code ]</b>
- [line 140](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_api_d14n/src/middleware/multi_node_client/client.rs#L140): `create_multinode_client_builder().build().unwrap()` will panic if `build()` returns `Err`. In tests this is a runtime termination rather than graceful handling; there is no guard ensuring the builder cannot fail, so any misconfiguration or transient failure will crash the test. <b>[ Test / Mock code ]</b>
- [line 141](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_api_d14n/src/middleware/multi_node_client/client.rs#L141): `create_gateway_builder().build().unwrap()` will panic if `build()` returns `Err`. There is no guard or fallback; any failure crashes the test. <b>[ Test / Mock code ]</b>
- [line 142](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_api_d14n/src/middleware/multi_node_client/client.rs#L142): Adding `.filter(PAYER_WRITE_FILTER)` changes external behavior: writes that previously succeeded may now be filtered. This is a contract-parity change for the constructed `D14nClient`, with no visible documentation or fallback, potentially causing silent write suppression or unexpected test failures. <b>[ Test / Mock code ]</b>
- [line 144](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_api_d14n/src/middleware/multi_node_client/client.rs#L144): `ReadWriteClient::builder().build().unwrap()` will panic if RW client assembly fails (e.g., invalid read/write pairing or filter incompatibility). No error propagation or fallback is provided. <b>[ Test / Mock code ]</b>
- [line 145](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_api_d14n/src/middleware/multi_node_client/client.rs#L145): `D14nClient::new(rw, NoCursorStore).unwrap()` will panic if client initialization fails (e.g., invalid RW client or cursor store wiring). No error handling path exists. <b>[ Test / Mock code ]</b>
- [line 201](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_api_d14n/src/middleware/multi_node_client/client.rs#L201): Removed explicit TLS configuration (`set_tls(is_tls_enabled())`) from the multi-node builder. If TLS is required by the environment or defaults to disabled, subsequent network operations may fail or run insecurely. This is a behavior change introduced by the diff and can cause runtime failures at build or request time. <b>[ Test / Mock code ]</b>
- [line 204](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_api_d14n/src/middleware/multi_node_client/client.rs#L204): `set_gateway_builder(...).expect("gateway set on multi-node")` will panic if `set_gateway_builder` returns `Err`. In test runs this causes an abrupt termination instead of a controlled failure path. If the `gateway_builder` is misconfigured or invalid, this is a reachable runtime panic. <b>[ Test / Mock code ]</b>
- [line 208](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_api_d14n/src/middleware/multi_node_client/client.rs#L208): `set_node_client_builder(node_builder).expect("node set on multi-node")` will panic if `set_node_client_builder` returns `Err` (e.g., invalid `node_builder`). This is a reachable runtime panic. <b>[ Test / Mock code ]</b>
- [line 214](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_api_d14n/src/middleware/multi_node_client/client.rs#L214): Aggressive 1000ms timeout (`set_timeout(Duration::from_millis(1000))`) may cause flaky failures under normal network latency, leading to intermittent panics via `unwrap()` on timeout error during multi-node gateway requests. <b>[ Test / Mock code ]</b>
- [line 215](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_api_d14n/src/middleware/multi_node_client/client.rs#L215): `set_timeout(...).unwrap()` will panic if the timeout configuration returns `Err` (e.g., invalid duration or internal validation). This yields abrupt termination during test setup. <b>[ Test / Mock code ]</b>
- [line 222](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_api_d14n/src/middleware/multi_node_client/client.rs#L222): `multi_node_builder.build().unwrap()` will panic if building the multi-node client fails (e.g., missing configuration or invalid builders). This is a reachable runtime panic during test execution. <b>[ Test / Mock code ]</b>
- [line 223](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_api_d14n/src/middleware/multi_node_client/client.rs#L223): `gateway_builder.build().unwrap()` will panic if the gateway client build fails (e.g., TLS/config changes). This is a reachable runtime panic. <b>[ Test / Mock code ]</b>
- [line 230](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_api_d14n/src/middleware/multi_node_client/client.rs#L230): `ReadWriteClient::builder().build().unwrap()` will panic if the composite client fails to build (e.g., due to incompatible `read`/`write` clients or `filter`). This is a reachable runtime panic. <b>[ Test / Mock code ]</b>
- [line 233](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_api_d14n/src/middleware/multi_node_client/client.rs#L233): `D14nClient::new(rw, cursor_store).unwrap()` will panic if constructing the `D14nClient` fails (e.g., invalid `rw` or `cursor_store`). This is a reachable runtime panic at test time. <b>[ Test / Mock code ]</b>
</details>

<details>
<summary>xmtp_api_d14n/src/queries/builder.rs — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 135](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_api_d14n/src/queries/builder.rs#L135): In `MessageBackendBuilder::build`, when the `gateway_host` is set (d14n path), the `app_version` is applied to `gateway_client_builder` via `set_app_version`, but it is not applied to the node client template (`template`) that is passed to `multi_node.set_node_client_builder(template)?`. This causes requests sent via the multi-node node clients to omit the provided `app_version` metadata, while V3 path and the gateway client include it. This is an externally visible contract parity mismatch and can lead to inconsistent behavior (e.g., analytics, rate limits, feature flags keyed on app version) between gateway and node requests. <b>[ Low confidence ]</b>
</details>

<details>
<summary>xmtp_api_d14n/src/queries/d14n/identity.rs — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 135](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_api_d14n/src/queries/d14n/identity.rs#L135): `get_inbox_ids` constructs `identity_v1::GetInboxIdsResponse` but sets `identifier_kind` for every response to `IdentifierKind::Ethereum as i32` regardless of the actual identifier kind. This silently corrupts the response for passkey identifiers and breaks contract parity with the upstream `GetInboxIdsResponseV4`. The correct behavior is to preserve the kind per-item (Ethereum vs Passkey) based on the source response or the original request mapping. <b>[ Out of scope ]</b>
</details>

<details>
<summary>xmtp_api_d14n/src/test/traits.rs — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 8](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_api_d14n/src/test/traits.rs#L8): The default implementation of `with_cursor_store` unconditionally calls `unimplemented!`, which panics at runtime whenever invoked. There is no guard restricting invocation to an initialization path, nor a fallback or error return. Any type that implements `XmtpTestClientExt` and uses `with_cursor_store` will crash, violating the method's implied contract to return a `<Self as XmtpTestClient>::Builder`. If this functionality is intentionally unsupported for some types, prefer returning a `Result` with a descriptive error, gating the method behind a feature, or omitting the method from unsupported types to avoid runtime termination. <b>[ Test / Mock code ]</b>
</details>

<details>
<summary>xmtp_api_grpc/src/grpc_client/test/clients.rs — 0 comments posted, 4 evaluated, 4 filtered</summary>

- [line 12](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_api_grpc/src/grpc_client/test/clients.rs#L12): `build_client` uses `url::Url::parse(host).unwrap()` at runtime. If `host` is not a valid URL, this will panic and crash the process instead of returning a recoverable error. Replace `unwrap()` with proper error handling and propagate an error from `build_client` or validate inputs before parsing. <b>[ Test / Mock code ]</b>
- [line 144](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_api_grpc/src/grpc_client/test/clients.rs#L144): `ToxicXmtpdClient::proxies` calls `TOXIPROXY.find_proxy("xmtpd").await.unwrap()`. If the proxy is missing or the call fails, this will panic at runtime. Prefer handling the `Result` and returning an error (e.g., via a fallible async method) or propagate via test failure without panicking. <b>[ Test / Mock code ]</b>
- [line 152](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_api_grpc/src/grpc_client/test/clients.rs#L152): `ToxicNodeGoClient::proxies` uses `TOXIPROXY.find_proxy("node-go").await.unwrap()`. A missing proxy or error will panic. Handle the `Result` and surface a controlled error instead of panicking. <b>[ Test / Mock code ]</b>
- [line 160](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_api_grpc/src/grpc_client/test/clients.rs#L160): `ToxicGatewayClient::proxies` uses `TOXIPROXY.find_proxy("gateway").await.unwrap()`. If the proxy lookup fails, it panics. Prefer handling the error and returning a controlled failure for tests. <b>[ Test / Mock code ]</b>
</details>

<details>
<summary>xmtp_configuration/src/common/api.rs — 0 comments posted, 3 evaluated, 3 filtered</summary>

- [line 44](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_configuration/src/common/api.rs#L44): Under the `dev` feature, `GrpcUrls` maps `NODE` to `GrpcUrlsDev::NODE` but `XMTPD` and `GATEWAY` to `GrpcUrlsStaging` (lines 44–47). This contradicts the module-level contract stating that passing the `dev` feature uses the dev environment. Mixing staging endpoints for `XMTPD`/`GATEWAY` with dev for `NODE` can lead to misrouted traffic and inconsistent environment selection. Align all `GrpcUrls` constants under `dev` to `GrpcUrlsDev`. <b>[ Low confidence ]</b>
- [line 105](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_configuration/src/common/api.rs#L105): `GrpcUrlsStaging` defines `NODE` to dev endpoints instead of staging (lines 105–111): WASM uses `"https://api.dev.xmtp.network:5558"` and native uses `"https://grpc.dev.xmtp.network:443"`. These should point to staging equivalents to avoid environment inconsistency and misrouting when `GrpcUrlsStaging` is selected. <b>[ Low confidence ]</b>
- [line 111](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_configuration/src/common/api.rs#L111): Duplicate environment inconsistency for `GrpcUrlsStaging` native variant (lines 109–113 in code object 9): `NODE` is set to `"https://grpc.dev.xmtp.network:443"` instead of a staging endpoint. Align with staging to avoid misconfiguration. <b>[ Low confidence ]</b>
</details>

<details>
<summary>xmtp_mls/src/utils/test/mod.rs — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 42](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_mls/src/utils/test/mod.rs#L42): `ClientBuilder::dev` calls `self.store.as_ref().unwrap().db()` which will panic if `store` is `None`. There is no guard ensuring `store` is set before this method is invoked. Replace `unwrap()` with an error-returning path (e.g., `ok_or` returning a `ClientBuilderError`) or ensure a visible guard before use. <b>[ Test / Mock code ]</b>
- [line 51](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_mls/src/utils/test/mod.rs#L51): `ClientBuilder::local` calls `self.store.as_ref().unwrap().db()` which will panic if `store` is `None`. There is no guard ensuring `store` is set before this method is invoked. Prefer returning a `ClientBuilderError` or adding a guard. <b>[ Test / Mock code ]</b>
</details>

<details>
<summary>xmtp_mls/src/utils/test/tester_utils.rs — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 237](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_mls/src/utils/test/tester_utils.rs#L237): `TesterBuilder::build` uses `unimplemented!("toxiproxy not supported on dev")` for `(ApiEndpoint::Dev, true)` match arm. If a tester is configured with `api_endpoint=Dev` and `proxy=true`, this will panic at runtime. Consider returning a descriptive error instead of panicking. <b>[ Test / Mock code ]</b>
- [line 284](https://github.com/xmtp/libxmtp/blob/aa01cfc5fb58f72148fe4b12d9abf733334dc8a7/xmtp_mls/src/utils/test/tester_utils.rs#L284): `TesterBuilder::build` silently ignores errors from `client.sync_welcomes().await;`. If `sync_welcomes` returns an error, it is discarded with no logging or handling, potentially leaving the tester in an inconsistent state. Capture the result and handle/log errors explicitly. <b>[ Test / Mock code ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->