### PR TITLE
Rework Send Sync bounds to be applied on traits instead of impls to avoid unsafe impls in wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,3 +206,4 @@ diesel_migrations = { git = "https://github.com/ephemerahq/diesel", branch = "co
 
 [workspace.lints.clippy]
 uninlined_format_args = "allow"
+arc_with_non_send_sync = "allow"

--- a/bindings_node/src/streams.rs
+++ b/bindings_node/src/streams.rs
@@ -18,7 +18,7 @@ pub struct StreamCloser {
 
 impl StreamCloser {
   pub fn new(
-    handle: impl XmtpStreamHandle<StreamOutput = Result<(), SubscribeError>> + Send + Sync + 'static,
+    handle: impl XmtpStreamHandle<StreamOutput = Result<(), SubscribeError>> + 'static,
   ) -> Self {
     let abort = handle.abort_handle();
     Self {

--- a/bindings_wasm/src/client.rs
+++ b/bindings_wasm/src/client.rs
@@ -252,7 +252,6 @@ pub async fn create_client(
 
   Ok(Client {
     account_identifier,
-    #[allow(clippy::arc_with_non_send_sync)]
     inner_client: Arc::new(xmtp_client),
     app_version,
   })

--- a/common/src/retry.rs
+++ b/common/src/retry.rs
@@ -17,6 +17,7 @@
 //! ```
 
 use crate::time::Duration;
+use crate::{MaybeSend, MaybeSync};
 use rand::Rng;
 use std::error::Error;
 use std::sync::Arc;
@@ -36,17 +37,13 @@ pub fn arc_retryable_to_error(retryable: Arc<dyn RetryableError>) -> Arc<dyn Err
     retryable
 }
 
-#[cfg(not(target_arch = "wasm32"))]
-pub type BoxedRetry = Retry<Box<dyn Strategy + Send + Sync>>;
-
-#[cfg(target_arch = "wasm32")]
 pub type BoxedRetry = Retry<Box<dyn Strategy>>;
 
 pub struct NotSpecialized;
 
 /// Specifies which errors are retryable.
 /// All Errors are not retryable by-default.
-pub trait RetryableError<SP = NotSpecialized>: std::error::Error {
+pub trait RetryableError<SP = NotSpecialized>: std::error::Error + MaybeSend + MaybeSync {
     fn is_retryable(&self) -> bool;
 }
 
@@ -108,7 +105,7 @@ impl<S: Strategy + 'static> Retry<S> {
 }
 
 /// The strategy interface
-pub trait Strategy {
+pub trait Strategy: MaybeSend + MaybeSync {
     /// A time that this retry should backoff
     /// Returns None when we should no longer backoff,
     /// despite possibly being below attempts

--- a/common/src/wasm.rs
+++ b/common/src/wasm.rs
@@ -11,11 +11,11 @@ pub use tokio::*;
 crate::if_wasm! {
     /// Marker trait to determine whether a type implements `Send` or not.
     pub trait MaybeSend {}
-    impl<T> MaybeSend for T {}
+    impl<T: ?Sized> MaybeSend for T {}
 
     /// Marker trait to determine whether a type implements `Send` or not.
     pub trait MaybeSync {}
-    impl<T> MaybeSync for T {}
+    impl<T: ?Sized> MaybeSync for T {}
 
     /// Global Marker trait for WebAssembly
     pub trait Wasm {}
@@ -24,20 +24,26 @@ crate::if_wasm! {
     pub struct StreamWrapper<'a, I> {
         inner: Pin<Box<dyn Stream<Item = I> + 'a>>,
     }
+
+    pub type BoxDynError = Box<dyn std::error::Error>;
+
 }
 
 crate::if_native! {
     /// Marker trait to determine whether a type implements `Send` or not.
     pub trait MaybeSend: Send {}
-    impl<T: Send> MaybeSend for T {}
+    impl<T: Send + ?Sized> MaybeSend for T {}
 
     /// Marker trait to determine whether a type implements `Sync` or not.
-    pub trait MaybeSync {}
-    impl<T: Sync> MaybeSync for T {}
+    pub trait MaybeSync: Sync {}
+    impl<T: Sync + ?Sized> MaybeSync for T {}
 
     pub struct StreamWrapper<'a, I> {
         inner: Pin<Box<dyn Stream<Item = I> + Send + 'a>>,
     }
+
+    pub type BoxDynError = Box<dyn std::error::Error + Send + Sync>;
+
 }
 
 impl<I> Stream for StreamWrapper<'_, I> {

--- a/xmtp_api/src/debug_wrapper.rs
+++ b/xmtp_api/src/debug_wrapper.rs
@@ -54,7 +54,7 @@ async fn wrap_err<T, R, F, E>(
 where
     R: FnOnce() -> F,
     F: Future<Output = Result<T, ApiClientError<E>>>,
-    E: std::error::Error + RetryableError + Send + Sync + 'static,
+    E: RetryableError + 'static,
 {
     let res = req().await;
     if let Err(e) = res {
@@ -98,8 +98,8 @@ where
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl<A, E> XmtpMlsClient for ApiDebugWrapper<A>
 where
-    A: XmtpMlsClient<Error = ApiClientError<E>> + Send + Sync,
-    E: std::error::Error + RetryableError + Send + Sync + 'static,
+    A: XmtpMlsClient<Error = ApiClientError<E>>,
+    E: RetryableError + 'static,
     A: HasStats,
 {
     type Error = ApiClientError<E>;
@@ -219,8 +219,8 @@ where
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl<A, E> XmtpMlsStreams for ApiDebugWrapper<A>
 where
-    A: XmtpMlsStreams<Error = ApiClientError<E>> + Send + Sync + 'static,
-    E: std::error::Error + RetryableError + Send + Sync + 'static,
+    A: XmtpMlsStreams<Error = ApiClientError<E>>,
+    E: RetryableError + 'static,
     A: HasStats,
 {
     type GroupMessageStream = <A as XmtpMlsStreams>::GroupMessageStream;
@@ -270,8 +270,8 @@ where
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl<A, E> XmtpIdentityClient for ApiDebugWrapper<A>
 where
-    A: XmtpIdentityClient<Error = ApiClientError<E>> + Send + Sync,
-    E: std::error::Error + RetryableError + Send + Sync + 'static,
+    A: XmtpIdentityClient<Error = ApiClientError<E>>,
+    E: RetryableError + 'static,
     A: HasStats,
 {
     type Error = ApiClientError<E>;

--- a/xmtp_api/src/identity.rs
+++ b/xmtp_api/src/identity.rs
@@ -63,7 +63,7 @@ where
     ) -> Result<impl Iterator<Item = (String, Vec<T>)>>
     where
         T: TryFrom<IdentityUpdateLog>,
-        <T as TryFrom<IdentityUpdateLog>>::Error: RetryableError + Send + Sync + 'static,
+        <T as TryFrom<IdentityUpdateLog>>::Error: RetryableError + 'static,
     {
         if filters.is_empty() {
             return Ok(vec![].into_iter());

--- a/xmtp_api/src/lib.rs
+++ b/xmtp_api/src/lib.rs
@@ -29,14 +29,14 @@ pub mod strategies {
 }
 
 // Erases Api Error type (which may be Http or Grpc)
-pub fn dyn_err(e: impl RetryableError + Send + Sync + 'static) -> ApiError {
+pub fn dyn_err(e: impl RetryableError + 'static) -> ApiError {
     ApiError::Api(Box::new(e))
 }
 
 #[derive(Debug, thiserror::Error)]
 pub enum ApiError {
     #[error("api client error {0}")]
-    Api(Box<dyn RetryableError + Send + Sync>),
+    Api(Box<dyn RetryableError>),
     #[error(
         "mismatched number of results, key packages {} != installation_keys {}",
         .key_packages,

--- a/xmtp_api/src/scw_verifier.rs
+++ b/xmtp_api/src/scw_verifier.rs
@@ -11,7 +11,7 @@ use xmtp_proto::xmtp::identity::api::v1::VerifySmartContractWalletSignaturesResp
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl<C> SmartContractSignatureVerifier for ApiClientWrapper<C>
 where
-    C: Send + Sync + XmtpIdentityClient,
+    C: XmtpIdentityClient,
 {
     /// Verifies an ERC-6492<https://eips.ethereum.org/EIPS/eip-6492> signature.
     ///

--- a/xmtp_api_d14n/src/middleware/multi_node_client/errors.rs
+++ b/xmtp_api_d14n/src/middleware/multi_node_client/errors.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 use xmtp_api_grpc::error::GrpcError;
-use xmtp_common::RetryableError;
+use xmtp_common::{MaybeSend, MaybeSync, RetryableError};
 use xmtp_proto::api::{ApiClientError, BodyError};
 
 /// Errors that can occur during multi-node client operations.
@@ -31,7 +31,7 @@ pub enum MultiNodeClientError {
 /// Required by the Client trait implementation, as request and stream can return MultiNodeClientError.
 impl<E> From<MultiNodeClientError> for ApiClientError<E>
 where
-    E: std::error::Error + Send + Sync + 'static,
+    E: std::error::Error + MaybeSend + MaybeSync + 'static,
 {
     fn from(value: MultiNodeClientError) -> ApiClientError<E> {
         ApiClientError::<E>::Other(Box::new(value))

--- a/xmtp_api_d14n/src/protocol/traits.rs
+++ b/xmtp_api_d14n/src/protocol/traits.rs
@@ -53,7 +53,7 @@ pub enum EnvelopeError {
     // for extractors defined outside of this crate or
     // generic implementations like Tuples
     #[error("{0}")]
-    DynError(Box<dyn RetryableError + Send + Sync>),
+    DynError(Box<dyn RetryableError>),
 }
 
 impl RetryableError for EnvelopeError {

--- a/xmtp_api_d14n/src/protocol/traits/cursor_store.rs
+++ b/xmtp_api_d14n/src/protocol/traits/cursor_store.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use xmtp_common::RetryableError;
+use xmtp_common::{MaybeSend, MaybeSync, RetryableError};
 use xmtp_proto::{
     api::ApiClientError,
     types::{ClockOrdering, Cursor, GlobalCursor, OriginatorId, Topic, TopicKind},
@@ -14,7 +14,7 @@ pub enum CursorStoreError {
     #[error("the store cannot handle topic of kind {0}")]
     UnhandledTopicKind(TopicKind),
     #[error("{0}")]
-    Other(Box<dyn RetryableError + Send + Sync>),
+    Other(Box<dyn RetryableError>),
 }
 
 impl RetryableError for CursorStoreError {
@@ -36,7 +36,7 @@ impl<E: std::error::Error> From<CursorStoreError> for ApiClientError<E> {
 /// Trait defining how cursors should be stored, updated, and fetched
 /// _NOTE:_, implementations decide retry strategy. the exact implementation of persistence (or lack)
 /// is up to implementors. functions are assumed to be idempotent & atomic.
-pub trait CursorStore: Send + Sync {
+pub trait CursorStore: MaybeSend + MaybeSync {
     // /// Get the last seen cursor per originator
     // fn last_seen(&self, topic: &Topic) -> Result<GlobalCursor, Self::Error>;
 

--- a/xmtp_api_d14n/src/protocol/traits/envelope_collection.rs
+++ b/xmtp_api_d14n/src/protocol/traits/envelope_collection.rs
@@ -1,10 +1,12 @@
 //! Traits and blanket implementations representing a collection of [`Envelope`]'s
+use xmtp_common::{MaybeSend, MaybeSync};
+
 use super::*;
 
 // TODO: Maybe we can do something with Iterators and Extractors
 // to avoid the Combinators like `CollectionExtractor`?
 /// A Generic Higher-Level Collection of Envelopes
-pub trait EnvelopeCollection<'env> {
+pub trait EnvelopeCollection<'env>: MaybeSend + MaybeSync {
     /// Get the topic for an envelope
     fn topics(&self) -> Result<Vec<Topic>, EnvelopeError>;
     /// Get the payload for an envelope
@@ -29,7 +31,7 @@ pub trait EnvelopeCollection<'env> {
 
 impl<'env, T> EnvelopeCollection<'env> for Vec<T>
 where
-    T: ProtocolEnvelope<'env> + std::fmt::Debug,
+    T: ProtocolEnvelope<'env> + std::fmt::Debug + MaybeSend + MaybeSync,
 {
     fn topics(&self) -> Result<Vec<Topic>, EnvelopeError> {
         self.iter()

--- a/xmtp_api_d14n/src/protocol/traits/xmtp_query.rs
+++ b/xmtp_api_d14n/src/protocol/traits/xmtp_query.rs
@@ -1,12 +1,14 @@
 //! XmtpQuery allows accessing the network while bypassing any local cursor cache.
+use xmtp_common::{MaybeSend, MaybeSync};
+
 use super::*;
 
 // XMTP Query queries the network for any envelopes
 /// matching the cursor criteria given.
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-pub trait XmtpQuery: Send + Sync {
-    type Error: RetryableError + Send + Sync + 'static;
+pub trait XmtpQuery: MaybeSend + MaybeSync {
+    type Error: RetryableError + 'static;
     /// Query every [`Topic`] at [`GlobalCursor`]
     async fn query_at(
         &self,
@@ -18,11 +20,11 @@ pub trait XmtpQuery: Send + Sync {
 // hides implementation detail of XmtpEnvelope/traits
 /// Envelopes from the XMTP Network received from a general [`XmtpQuery`]
 pub struct XmtpEnvelope {
-    inner: Box<dyn EnvelopeCollection<'static> + Send + Sync>,
+    inner: Box<dyn EnvelopeCollection<'static>>,
 }
 
 impl XmtpEnvelope {
-    pub fn new(envelope: impl EnvelopeCollection<'static> + Send + Sync + 'static) -> Self {
+    pub fn new(envelope: impl EnvelopeCollection<'static> + 'static) -> Self {
         Self {
             inner: Box::new(envelope) as Box<_>,
         }

--- a/xmtp_api_d14n/src/queries/api_stats.rs
+++ b/xmtp_api_d14n/src/queries/api_stats.rs
@@ -38,7 +38,7 @@ impl<C> TrackedStatsClient<C> {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<C> XmtpMlsClient for TrackedStatsClient<C>
 where
-    C: Send + Sync + XmtpMlsClient,
+    C: XmtpMlsClient,
 {
     type Error = <C as XmtpMlsClient>::Error;
 
@@ -126,7 +126,7 @@ where
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<C> XmtpIdentityClient for TrackedStatsClient<C>
 where
-    C: Send + Sync + XmtpIdentityClient,
+    C: XmtpIdentityClient,
 {
     type Error = <C as XmtpIdentityClient>::Error;
 
@@ -171,7 +171,7 @@ where
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<C> XmtpMlsStreams for TrackedStatsClient<C>
 where
-    C: Send + Sync + XmtpMlsStreams,
+    C: XmtpMlsStreams,
 {
     type GroupMessageStream = <C as XmtpMlsStreams>::GroupMessageStream;
     type WelcomeMessageStream = <C as XmtpMlsStreams>::WelcomeMessageStream;

--- a/xmtp_api_d14n/src/queries/boxed_streams.rs
+++ b/xmtp_api_d14n/src/queries/boxed_streams.rs
@@ -1,5 +1,5 @@
+use crate::protocol::XmtpQuery;
 use std::pin::Pin;
-
 use xmtp_proto::api::HasStats;
 use xmtp_proto::api::IsConnectedCheck;
 use xmtp_proto::api_client::ApiStats;
@@ -13,8 +13,6 @@ use xmtp_proto::prelude::XmtpMlsStreams;
 use xmtp_proto::types::InstallationId;
 use xmtp_proto::types::WelcomeMessage;
 use xmtp_proto::types::{GroupId, GroupMessage};
-
-use crate::protocol::XmtpQuery;
 
 /// Wraps an ApiClient to allow turning
 /// a concretely-typed client into type-erased a [`BoxableXmtpApi`]
@@ -34,7 +32,7 @@ impl<C> BoxedStreamsClient<C> {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<C> XmtpMlsClient for BoxedStreamsClient<C>
 where
-    C: Send + Sync + XmtpMlsClient,
+    C: XmtpMlsClient,
 {
     type Error = <C as XmtpMlsClient>::Error;
 
@@ -112,7 +110,7 @@ where
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<C> XmtpIdentityClient for BoxedStreamsClient<C>
 where
-    C: Send + Sync + XmtpIdentityClient,
+    C: XmtpIdentityClient,
 {
     type Error = <C as XmtpIdentityClient>::Error;
 
@@ -151,7 +149,7 @@ where
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<C> XmtpMlsStreams for BoxedStreamsClient<C>
 where
-    C: Send + Sync + XmtpMlsStreams,
+    C: XmtpMlsStreams,
     C::GroupMessageStream: 'static,
     C::WelcomeMessageStream: 'static,
 {
@@ -208,7 +206,7 @@ where
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<C> IsConnectedCheck for BoxedStreamsClient<C>
 where
-    C: IsConnectedCheck + Send + Sync,
+    C: IsConnectedCheck,
 {
     async fn is_connected(&self) -> bool {
         self.inner.is_connected().await

--- a/xmtp_api_d14n/src/queries/combined.rs
+++ b/xmtp_api_d14n/src/queries/combined.rs
@@ -16,8 +16,8 @@ pub struct CombinedD14nClient<C, D> {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<C, D> XmtpMlsClient for CombinedD14nClient<C, D>
 where
-    C: Send + Sync + XmtpMlsClient,
-    D: Send + Sync + XmtpMlsClient<Error = C::Error>,
+    C: XmtpMlsClient,
+    D: XmtpMlsClient<Error = C::Error>,
 {
     type Error = <C as XmtpMlsClient>::Error;
 
@@ -97,8 +97,8 @@ where
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<C, D> XmtpIdentityClient for CombinedD14nClient<C, D>
 where
-    C: Send + Sync + XmtpIdentityClient,
-    D: Send + Sync + XmtpIdentityClient<Error = C::Error>,
+    C: XmtpIdentityClient,
+    D: XmtpIdentityClient<Error = C::Error>,
 {
     type Error = <C as XmtpIdentityClient>::Error;
 

--- a/xmtp_api_d14n/src/queries/d14n/identity.rs
+++ b/xmtp_api_d14n/src/queries/d14n/identity.rs
@@ -1,20 +1,16 @@
-use std::collections::HashMap;
-
 use super::D14nClient;
 use crate::protocol::IdentityUpdateExtractor;
 use crate::protocol::SequencedExtractor;
 use crate::protocol::traits::{Envelope, EnvelopeCollection, Extractor};
 use crate::{d14n::PublishClientEnvelopes, d14n::QueryEnvelopes, endpoints::d14n::GetInboxIds};
 use itertools::Itertools;
+use std::collections::HashMap;
 use xmtp_common::RetryableError;
 use xmtp_configuration::Originators;
 use xmtp_id::associations::AccountId;
-use xmtp_id::scw_verifier::SmartContractSignatureVerifier;
-use xmtp_id::scw_verifier::VerifierError;
+use xmtp_id::scw_verifier::{SmartContractSignatureVerifier, VerifierError};
 use xmtp_proto::ConversionError;
-use xmtp_proto::api;
-use xmtp_proto::api::Client;
-use xmtp_proto::api::{ApiClientError, Query};
+use xmtp_proto::api::{self, ApiClientError, Client, Query};
 use xmtp_proto::api_client::XmtpIdentityClient;
 use xmtp_proto::identity_v1;
 use xmtp_proto::identity_v1::VerifySmartContractWalletSignatureRequestSignature;
@@ -32,9 +28,9 @@ use xmtp_proto::xmtp::xmtpv4::message_api::{
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<C, G, E> XmtpIdentityClient for D14nClient<C, G>
 where
-    E: std::error::Error + RetryableError + Send + Sync + 'static,
-    G: Send + Sync + Client<Error = E>,
-    C: Send + Sync + Client<Error = E>,
+    E: std::error::Error + RetryableError + 'static,
+    G: Client<Error = E>,
+    C: Client<Error = E>,
     ApiClientError<E>: From<ApiClientError<<G as xmtp_proto::api::Client>::Error>> + 'static,
 {
     type Error = ApiClientError<E>;

--- a/xmtp_api_d14n/src/queries/d14n/mls.rs
+++ b/xmtp_api_d14n/src/queries/d14n/mls.rs
@@ -35,9 +35,9 @@ use xmtp_proto::xmtp::xmtpv4::message_api::QueryEnvelopesResponse;
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<C, G, E> XmtpMlsClient for D14nClient<C, G>
 where
-    E: std::error::Error + RetryableError + Send + Sync + 'static,
-    G: Send + Sync + Client,
-    C: Send + Sync + Client<Error = E>,
+    E: RetryableError + 'static,
+    G: Client,
+    C: Client<Error = E>,
     ApiClientError<E>: From<ApiClientError<<G as xmtp_proto::api::Client>::Error>> + 'static,
 {
     type Error = ApiClientError<E>;

--- a/xmtp_api_d14n/src/queries/d14n/streams.rs
+++ b/xmtp_api_d14n/src/queries/d14n/streams.rs
@@ -5,7 +5,7 @@ use crate::queries::stream;
 
 use super::D14nClient;
 use std::collections::HashMap;
-use xmtp_common::{MaybeSend, RetryableError};
+use xmtp_common::RetryableError;
 use xmtp_proto::api::{ApiClientError, Client, QueryStream, XmtpStream};
 use xmtp_proto::api_client::XmtpMlsStreams;
 use xmtp_proto::types::{GlobalCursor, GroupId, InstallationId, TopicKind};
@@ -15,10 +15,10 @@ use xmtp_proto::xmtp::xmtpv4::message_api::SubscribeEnvelopesResponse;
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<C, G, E> XmtpMlsStreams for D14nClient<C, G>
 where
-    C: Send + Sync + Client<Error = E>,
-    <C as Client>::Stream: MaybeSend + 'static,
-    G: Send + Sync + Client<Error = E>,
-    E: std::error::Error + RetryableError + Send + Sync + 'static,
+    C: Client<Error = E>,
+    <C as Client>::Stream: 'static,
+    G: Client<Error = E>,
+    E: RetryableError + 'static,
 {
     type Error = ApiClientError<E>;
 

--- a/xmtp_api_d14n/src/queries/d14n/to_dyn_api.rs
+++ b/xmtp_api_d14n/src/queries/d14n/to_dyn_api.rs
@@ -7,9 +7,9 @@ use crate::{BoxedStreamsClient, D14nClient, FullXmtpApiArc, FullXmtpApiBox, ToDy
 
 impl<M, G, E> ToDynApi for D14nClient<M, G>
 where
-    E: Error + RetryableError + Send + Sync + 'static,
-    G: Send + Sync + Client<Error = E> + IsConnectedCheck + 'static,
-    M: Send + Sync + Client<Error = E> + IsConnectedCheck + 'static,
+    E: Error + RetryableError + 'static,
+    G: Client<Error = E> + IsConnectedCheck + 'static,
+    M: Client<Error = E> + IsConnectedCheck + 'static,
     <M as Client>::Stream: 'static,
     <G as Client>::Stream: 'static,
 {

--- a/xmtp_api_d14n/src/queries/d14n/xmtp_query.rs
+++ b/xmtp_api_d14n/src/queries/d14n/xmtp_query.rs
@@ -17,9 +17,9 @@ use crate::{
 impl<C, G, E> XmtpQuery for D14nClient<C, G>
 where
     C: Client<Error = E>,
-    G: Client<Error = <C as Client>::Error>,
-    ApiClientError<E>: From<ApiClientError<<C as Client>::Error>> + Send + Sync + 'static,
-    E: RetryableError,
+    G: Client<Error = E>,
+    ApiClientError<E>: From<ApiClientError<<C as Client>::Error>>,
+    E: RetryableError + 'static,
 {
     type Error = ApiClientError<E>;
 

--- a/xmtp_api_d14n/src/queries/mod.rs
+++ b/xmtp_api_d14n/src/queries/mod.rs
@@ -20,7 +20,7 @@ mod builder;
 pub use builder::*;
 
 use std::error::Error as StdError;
-use xmtp_common::{RetryableError, retryable};
+use xmtp_common::{MaybeSend, MaybeSync, RetryableError, retryable};
 use xmtp_proto::{
     ConversionError,
     api::{ApiClientError, BodyError},
@@ -40,7 +40,7 @@ pub enum QueryError<E: StdError> {
 
 impl<E> From<crate::protocol::EnvelopeError> for ApiClientError<E>
 where
-    E: StdError + Send + Sync,
+    E: StdError + MaybeSend + MaybeSync,
 {
     fn from(e: crate::protocol::EnvelopeError) -> ApiClientError<E> {
         ApiClientError::Other(Box::new(e))

--- a/xmtp_api_d14n/src/queries/v3.rs
+++ b/xmtp_api_d14n/src/queries/v3.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use parking_lot::RwLock;
+use xmtp_common::{MaybeSend, MaybeSync};
 use xmtp_proto::api::IsConnectedCheck;
 use xmtp_proto::api_client::CursorAwareApi;
 use xmtp_proto::prelude::ApiBuilder;
@@ -116,7 +117,7 @@ where
     }
 }
 
-impl<C> CursorAwareApi for V3Client<C> {
+impl<C: MaybeSend + MaybeSync> CursorAwareApi for V3Client<C> {
     type CursorStore = Arc<dyn CursorStore>;
     fn set_cursor_store(&self, store: Self::CursorStore) {
         let mut cstore = self.cursor_store.write();
@@ -137,7 +138,7 @@ impl<B1: ApiBuilder> CursorAwareApi for V3ClientBuilder<B1> {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<C> IsConnectedCheck for V3Client<C>
 where
-    C: IsConnectedCheck + Send + Sync,
+    C: IsConnectedCheck,
 {
     async fn is_connected(&self) -> bool {
         self.client.is_connected().await

--- a/xmtp_api_d14n/src/queries/v3/identity.rs
+++ b/xmtp_api_d14n/src/queries/v3/identity.rs
@@ -9,8 +9,8 @@ use xmtp_proto::xmtp::identity::associations::IdentifierKind;
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<C, E> XmtpIdentityClient for V3Client<C>
 where
-    C: Send + Sync + Client<Error = E>,
-    E: std::error::Error + RetryableError + Send + Sync + 'static,
+    C: Client<Error = E>,
+    E: RetryableError + 'static,
 {
     type Error = ApiClientError<E>;
 

--- a/xmtp_api_d14n/src/queries/v3/mls.rs
+++ b/xmtp_api_d14n/src/queries/v3/mls.rs
@@ -14,9 +14,9 @@ use xmtp_proto::types::{GroupId, GroupMessageMetadata, InstallationId, TopicKind
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<C, E> XmtpMlsClient for V3Client<C>
 where
-    E: std::error::Error + RetryableError + Send + Sync + 'static,
-    C: Send + Sync + Client<Error = E>,
-    ApiClientError<E>: From<ApiClientError<<C as Client>::Error>> + Send + Sync + 'static,
+    E: RetryableError + 'static,
+    C: Client<Error = E>,
+    ApiClientError<E>: From<ApiClientError<<C as Client>::Error>> + 'static,
 {
     type Error = ApiClientError<E>;
 

--- a/xmtp_api_d14n/src/queries/v3/streams.rs
+++ b/xmtp_api_d14n/src/queries/v3/streams.rs
@@ -13,7 +13,7 @@ use xmtp_proto::types::{
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<C> XmtpMlsStreams for V3Client<C>
 where
-    C: Send + Sync + Client<Error = GrpcError>,
+    C: Client<Error = GrpcError>,
 {
     type GroupMessageStream =
         TryFromItem<XmtpStream<<C as Client>::Stream, V3ProtoGroupMessage>, GroupMessage>;

--- a/xmtp_api_d14n/src/queries/v3/to_dyn_api.rs
+++ b/xmtp_api_d14n/src/queries/v3/to_dyn_api.rs
@@ -8,7 +8,7 @@ use crate::{BoxedStreamsClient, V3Client};
 
 impl<C> ToDynApi for V3Client<C>
 where
-    C: Send + Sync + Client<Error = GrpcError> + IsConnectedCheck + 'static,
+    C: Client<Error = GrpcError> + IsConnectedCheck + 'static,
     <C as Client>::Stream: 'static,
 {
     type Error = ApiClientError<GrpcError>;

--- a/xmtp_api_d14n/src/queries/v3/xmtp_query.rs
+++ b/xmtp_api_d14n/src/queries/v3/xmtp_query.rs
@@ -19,8 +19,8 @@ use xmtp_proto::{
 impl<C, E> XmtpQuery for V3Client<C>
 where
     C: Client<Error = E>,
-    E: std::error::Error + RetryableError + Send + Sync,
-    ApiClientError<E>: From<ApiClientError<<C as Client>::Error>> + Send + Sync + 'static,
+    E: RetryableError + 'static,
+    ApiClientError<E>: From<ApiClientError<<C as Client>::Error>>,
 {
     type Error = ApiClientError<E>;
     async fn query_at(

--- a/xmtp_api_grpc/src/grpc_client.rs
+++ b/xmtp_api_grpc/src/grpc_client.rs
@@ -10,13 +10,6 @@ xmtp_common::if_wasm! {
     mod wasm;
     pub use wasm::*;
     pub type GrpcService = wasm::GrpcWebService;
-    // it's better to take the hit and unsafe impl send on the client
-    // rather then infect a Send bound into all the rest of the code
-    // that depends on a client.
-    // When web supports threads (and therefore JsValue must become Send & Sync),
-    // we can delete this.
-    unsafe impl Send for GrpcWebService { }
-    unsafe impl Sync for GrpcWebService { }
 }
 
 xmtp_common::if_native! {

--- a/xmtp_archive/src/exporter.rs
+++ b/xmtp_archive/src/exporter.rs
@@ -49,7 +49,7 @@ impl ArchiveExporter {
         key: &[u8],
     ) -> Result<(), crate::ArchiveError>
     where
-        D: DbQuery + Send + Sync + 'static,
+        D: DbQuery + 'static,
     {
         let mut exporter = Self::new(options, db, key);
         exporter.write_to_file(path).await?;
@@ -93,7 +93,7 @@ impl ArchiveExporter {
 
     pub fn new<D>(options: BackupOptions, db: D, key: &[u8]) -> Self
     where
-        D: DbQuery + Send + Sync + 'static,
+        D: DbQuery + 'static,
     {
         let mut nonce_buffer = BACKUP_VERSION.to_le_bytes().to_vec();
         let nonce = xmtp_common::rand_array::<NONCE_SIZE>();

--- a/xmtp_db/src/encrypted_store/database/native.rs
+++ b/xmtp_db/src/encrypted_store/database/native.rs
@@ -15,7 +15,7 @@ use diesel::{
 use parking_lot::Mutex;
 use std::sync::Arc;
 use thiserror::Error;
-use xmtp_common::{RetryableError, retryable};
+use xmtp_common::{BoxDynError, RetryableError, retryable};
 use xmtp_configuration::BUSY_TIMEOUT;
 
 use pool::*;
@@ -177,7 +177,7 @@ pub enum PlatformStorageError {
     #[error(transparent)]
     DieselConnect(#[from] diesel::ConnectionError),
     #[error(transparent)]
-    Boxed(#[from] Box<dyn std::error::Error + Send + Sync>),
+    Boxed(#[from] BoxDynError),
 }
 
 impl RetryableError for PlatformStorageError {

--- a/xmtp_db/src/encrypted_store/database/wasm.rs
+++ b/xmtp_db/src/encrypted_store/database/wasm.rs
@@ -20,8 +20,6 @@ pub enum PlatformStorageError {
     #[error(transparent)]
     DieselResult(#[from] diesel::result::Error),
 }
-unsafe impl Send for PlatformStorageError {}
-unsafe impl Sync for PlatformStorageError {}
 
 impl xmtp_common::RetryableError for PlatformStorageError {
     fn is_retryable(&self) -> bool {
@@ -196,9 +194,6 @@ impl ConnectionExt for WasmDbConnection {
         Ok(())
     }
 }
-
-unsafe impl Send for WasmDbConnection {}
-unsafe impl Sync for WasmDbConnection {}
 
 impl XmtpDb for WasmDb {
     type Connection = Arc<PersistentOrMem<WasmDbConnection, WasmDbConnection>>;

--- a/xmtp_db/src/errors.rs
+++ b/xmtp_db/src/errors.rs
@@ -5,7 +5,7 @@ use super::{
     refresh_state::EntityKind,
     sql_key_store::{self, SqlKeyStoreError},
 };
-use xmtp_common::{RetryableError, retryable};
+use xmtp_common::{BoxDynError, RetryableError, retryable};
 use xmtp_proto::types::{Cursor, InstallationId};
 
 pub struct Mls;
@@ -17,7 +17,7 @@ pub enum StorageError {
     #[error(transparent)]
     DieselResult(#[from] diesel::result::Error),
     #[error("Error migrating database {0}")]
-    MigrationError(#[from] Box<dyn std::error::Error + Send + Sync>),
+    MigrationError(#[from] BoxDynError),
     #[error(transparent)]
     NotFound(#[from] NotFound),
     #[error(transparent)]

--- a/xmtp_db/src/traits.rs
+++ b/xmtp_db/src/traits.rs
@@ -4,6 +4,7 @@ use crate::association_state::QueryAssociationStateCache;
 use crate::pending_remove::QueryPendingRemove;
 use crate::prelude::*;
 use crate::readd_status::QueryReaddStatus;
+use xmtp_common::{MaybeSend, MaybeSync};
 
 /// Get an MLS Key store in the context of a transaction
 /// this must only be used within transactions.
@@ -62,7 +63,9 @@ pub trait IntoConnection {
 }
 
 pub trait DbQuery:
-    ReadOnly
+    MaybeSend
+    + MaybeSync
+    + ReadOnly
     + QueryConsentRecord
     + QueryConversationList
     + QueryDms
@@ -89,7 +92,9 @@ pub trait DbQuery:
 }
 
 impl<T: ?Sized> DbQuery for T where
-    T: ReadOnly
+    T: MaybeSend
+        + MaybeSync
+        + ReadOnly
         + QueryConsentRecord
         + QueryConversationList
         + QueryDms

--- a/xmtp_db/src/xmtp_openmls_provider.rs
+++ b/xmtp_db/src/xmtp_openmls_provider.rs
@@ -6,6 +6,7 @@ use openmls_rust_crypto::RustCrypto;
 use openmls_traits::OpenMlsProvider;
 use openmls_traits::storage::CURRENT_VERSION;
 use openmls_traits::storage::{Entity, StorageProvider};
+use xmtp_common::{MaybeSend, MaybeSync};
 
 /// Convenience super trait to constrain the storage provider to a
 /// specific error type and version
@@ -14,7 +15,7 @@ use openmls_traits::storage::{Entity, StorageProvider};
 // constraining the error type here will avoid leaking
 // the associated type parameter, so we don't need to define it on every function.
 pub trait XmtpMlsStorageProvider:
-    StorageProvider<CURRENT_VERSION, Error = SqlKeyStoreError>
+    MaybeSend + MaybeSync + StorageProvider<CURRENT_VERSION, Error = SqlKeyStoreError>
 {
     /// An Opaque Database connection type. Can be anything.
     type Connection: ConnectionExt;

--- a/xmtp_db_test/src/lib.rs
+++ b/xmtp_db_test/src/lib.rs
@@ -24,7 +24,6 @@ impl<Db: XmtpDb> ChaosDb<Db> {
 impl<Db> XmtpDb for ChaosDb<Db>
 where
     Db: XmtpDb,
-    <Db as XmtpDb>::Connection: Send + Sync,
 {
     type Connection = Arc<chaos::ChaosConnection<Db::Connection>>;
     type DbQuery = DbConnection<Self::Connection>;
@@ -77,7 +76,7 @@ impl<Db> ChaosDbBuilder<Db> {
 impl<Db> ChaosDbBuilder<Db>
 where
     Db: XmtpDb + Clone,
-    <Db as XmtpDb>::Connection: Clone + Send + Sync,
+    <Db as XmtpDb>::Connection: Clone,
 {
     /// Build the EncryptedMessageStore with Chaos
     /// Returns a tuple of (ChaosConnection, EncryptedMessageStore)

--- a/xmtp_id/src/lib.rs
+++ b/xmtp_id/src/lib.rs
@@ -13,6 +13,7 @@ use associations::{
 };
 use openmls_traits::types::CryptoError;
 use thiserror::Error;
+use xmtp_common::{MaybeSend, MaybeSync};
 use xmtp_cryptography::signature::{IdentifierValidationError, SignatureError, h160addr_to_string};
 
 #[derive(Debug, Error)]
@@ -66,7 +67,7 @@ impl TryFrom<IdentityUpdateLog> for InboxUpdate {
     }
 }
 
-pub trait AsIdRef: Send + Sync {
+pub trait AsIdRef: MaybeSend + MaybeSync {
     fn as_ref(&'_ self) -> InboxIdRef<'_>;
 }
 

--- a/xmtp_id/src/scw_verifier/remote_signature_verifier.rs
+++ b/xmtp_id/src/scw_verifier/remote_signature_verifier.rs
@@ -24,7 +24,7 @@ impl<ApiClient> RemoteSignatureVerifier<ApiClient> {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl<C> SmartContractSignatureVerifier for RemoteSignatureVerifier<C>
 where
-    C: XmtpIdentityClient + Send + Sync,
+    C: XmtpIdentityClient,
 {
     async fn is_valid_signature(
         &self,

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -241,7 +241,7 @@ pub async fn inbox_addresses_with_verifier<ApiClient: XmtpApi>(
 
 impl<Context> Client<Context>
 where
-    Context: XmtpSharedContext + Send + Sync + 'static,
+    Context: XmtpSharedContext + 'static,
 {
     /// Reconnect to the client's database if it has previously been released
     pub fn reconnect_db(&self) -> Result<(), ClientError> {

--- a/xmtp_mls/src/context.rs
+++ b/xmtp_mls/src/context.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use tokio::sync::broadcast;
 use xmtp_api::{ApiClientWrapper, XmtpApi};
 use xmtp_api_d14n::protocol::XmtpQuery;
+use xmtp_common::{MaybeSend, MaybeSync};
 use xmtp_db::XmtpDb;
 use xmtp_db::XmtpMlsStorageProvider;
 use xmtp_db::xmtp_openmls_provider::XmtpOpenMlsProviderRef;
@@ -51,7 +52,7 @@ impl<ApiClient, Db, S> XmtpMlsLocalContext<ApiClient, Db, S>
 where
     Db: XmtpDb,
     ApiClient: XmtpApi,
-    S: XmtpMlsStorageProvider + Send + Sync,
+    S: XmtpMlsStorageProvider,
 {
     /// get a reference to the monolithic Database object where
     /// higher-level queries are defined
@@ -158,12 +159,12 @@ impl<ApiClient, Db, S> XmtpMlsLocalContext<ApiClient, Db, S> {
 
 pub trait XmtpSharedContext
 where
-    Self: Send + Sync + Sized + Clone,
+    Self: MaybeSend + MaybeSync + Sized + Clone,
 {
     type Db: XmtpDb;
     type ApiClient: XmtpApi + XmtpQuery;
-    type MlsStorage: Send + Sync + XmtpMlsStorageProvider;
-    type ContextReference: Clone + Sized;
+    type MlsStorage: XmtpMlsStorageProvider;
+    type ContextReference: MaybeSend + MaybeSync + Clone + Sized;
 
     fn context_ref(&self) -> &Self::ContextReference;
     fn db(&self) -> <Self::Db as XmtpDb>::DbQuery;
@@ -215,7 +216,7 @@ impl<XApiClient, XDb, XMls> XmtpSharedContext for Arc<XmtpMlsLocalContext<XApiCl
 where
     XApiClient: XmtpApi + XmtpQuery,
     XDb: XmtpDb,
-    XMls: Send + Sync + XmtpMlsStorageProvider,
+    XMls: XmtpMlsStorageProvider,
 {
     type Db = XDb;
     type ApiClient = XApiClient;

--- a/xmtp_mls/src/cursor_store.rs
+++ b/xmtp_mls/src/cursor_store.rs
@@ -1,6 +1,7 @@
 use itertools::Itertools;
 use std::collections::HashMap;
 use xmtp_api_d14n::protocol::{CursorStore, CursorStoreError};
+use xmtp_common::{MaybeSend, MaybeSync};
 use xmtp_configuration::Originators;
 use xmtp_db::{
     identity_update::QueryIdentityUpdates, prelude::QueryRefreshState, refresh_state::EntityKind,
@@ -20,7 +21,7 @@ impl<Db> SqliteCursorStore<Db> {
 
 impl<Db> CursorStore for SqliteCursorStore<Db>
 where
-    Db: QueryRefreshState + QueryIdentityUpdates + Send + Sync,
+    Db: QueryRefreshState + QueryIdentityUpdates + MaybeSend + MaybeSync,
 {
     fn lowest_common_cursor(&self, topics: &[&Topic]) -> Result<GlobalCursor, CursorStoreError> {
         self.db

--- a/xmtp_mls/src/groups/commit_log.rs
+++ b/xmtp_mls/src/groups/commit_log.rs
@@ -59,7 +59,7 @@ pub struct Factory<Context> {
 
 impl<Context> WorkerFactory for Factory<Context>
 where
-    Context: XmtpSharedContext + Send + Sync + 'static,
+    Context: XmtpSharedContext + 'static,
 {
     fn kind(&self) -> WorkerKind {
         WorkerKind::CommitLog
@@ -158,8 +158,7 @@ where
 
     fn factory<C>(context: C) -> impl WorkerFactory + 'static
     where
-        Self: Sized,
-        C: XmtpSharedContext + Send + Sync + 'static,
+        C: XmtpSharedContext + 'static,
     {
         Factory { context }
     }

--- a/xmtp_mls/src/groups/device_sync/worker.rs
+++ b/xmtp_mls/src/groups/device_sync/worker.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 use futures::TryFutureExt;
 use owo_colors::OwoColorize;
-use std::{any::Any, sync::Arc};
+use std::sync::Arc;
 use tokio::sync::{OnceCell, broadcast};
 #[cfg(not(target_arch = "wasm32"))]
 use tokio_util::compat::TokioAsyncReadCompatExt;
@@ -80,7 +80,7 @@ struct Factory<Context> {
 
 impl<Context> WorkerFactory for Factory<Context>
 where
-    Context: XmtpSharedContext + Send + Sync + 'static,
+    Context: XmtpSharedContext + 'static,
 {
     fn create(&self, metrics: Option<DynMetrics>) -> (BoxedWorker, Option<DynMetrics>) {
         let worker = SyncWorker::new(self.context.clone(), metrics);
@@ -104,14 +104,13 @@ where
         WorkerKind::DeviceSync
     }
 
-    fn metrics(&self) -> Option<Arc<dyn Any + Send + Sync>> {
+    fn metrics(&self) -> Option<DynMetrics> {
         Some(self.metrics.clone())
     }
 
     fn factory<C>(context: C) -> impl WorkerFactory + 'static
     where
-        Self: Sized,
-        C: XmtpSharedContext + Send + Sync + 'static,
+        C: XmtpSharedContext + 'static,
     {
         Factory { context }
     }

--- a/xmtp_mls/src/groups/disappearing_messages.rs
+++ b/xmtp_mls/src/groups/disappearing_messages.rs
@@ -36,7 +36,7 @@ struct Factory<Context> {
 
 impl<Context> WorkerFactory for Factory<Context>
 where
-    Context: XmtpSharedContext + Send + Sync + 'static,
+    Context: XmtpSharedContext + 'static,
 {
     fn create(
         &self,
@@ -68,7 +68,7 @@ where
     fn factory<C>(context: C) -> impl WorkerFactory + 'static
     where
         Self: Sized,
-        C: XmtpSharedContext + Send + Sync + 'static,
+        C: XmtpSharedContext + 'static,
     {
         Factory { context }
     }

--- a/xmtp_mls/src/groups/key_package_cleaner_worker.rs
+++ b/xmtp_mls/src/groups/key_package_cleaner_worker.rs
@@ -27,7 +27,7 @@ pub struct Factory<Context> {
 
 impl<Context> WorkerFactory for Factory<Context>
 where
-    Context: XmtpSharedContext + Send + Sync + 'static,
+    Context: XmtpSharedContext + 'static,
 {
     fn kind(&self) -> WorkerKind {
         WorkerKind::KeyPackageCleaner
@@ -87,7 +87,7 @@ where
     fn factory<C>(context: C) -> impl WorkerFactory + 'static
     where
         Self: Sized,
-        C: Send + Sync + XmtpSharedContext + 'static,
+        C: XmtpSharedContext + 'static,
     {
         Factory { context }
     }

--- a/xmtp_mls/src/groups/pending_self_remove_worker.rs
+++ b/xmtp_mls/src/groups/pending_self_remove_worker.rs
@@ -39,7 +39,7 @@ struct Factory<Context> {
 
 impl<Context> WorkerFactory for Factory<Context>
 where
-    Context: XmtpSharedContext + Send + Sync + 'static,
+    Context: XmtpSharedContext + 'static,
 {
     fn kind(&self) -> WorkerKind {
         WorkerKind::PendingSelfRemove
@@ -71,7 +71,7 @@ where
     fn factory<C>(context: C) -> impl WorkerFactory + 'static
     where
         Self: Sized,
-        C: XmtpSharedContext + Send + Sync + 'static,
+        C: XmtpSharedContext + 'static,
     {
         Factory {
             context: context.clone(),

--- a/xmtp_mls/src/groups/subscriptions.rs
+++ b/xmtp_mls/src/groups/subscriptions.rs
@@ -19,7 +19,7 @@ use xmtp_proto::{types::GroupId, xmtp::mls::api::v1::GroupMessage};
 
 impl<Context> MlsGroup<Context>
 where
-    Context: Send + Sync + XmtpSharedContext,
+    Context: XmtpSharedContext,
 {
     /// External proxy for `process_stream_entry`
     /// Converts some `SubscribeError` variants to an Option, if they are inconsequential.
@@ -56,7 +56,7 @@ where
     where
         Context: 'static,
         Context::ApiClient: XmtpMlsStreams + 'static,
-        Context::Db: Send + Sync + 'static,
+        Context::Db: 'static,
     {
         StreamGroupMessages::new_owned(self.context.clone(), vec![self.group_id.clone().into()])
             .await
@@ -69,9 +69,8 @@ where
         on_close: impl FnOnce() + MaybeSend + 'static,
     ) -> impl StreamHandle<StreamOutput = Result<()>>
     where
-        Context: Send + Sync + 'static,
+        Context: 'static,
         Context::ApiClient: XmtpMlsStreams + 'static,
-        Context::MlsStorage: Send + Sync,
     {
         stream_messages_with_callback(
             context.clone(),
@@ -92,9 +91,8 @@ pub(crate) fn stream_messages_with_callback<Context>(
     on_close: impl FnOnce() + MaybeSend + 'static,
 ) -> impl StreamHandle<StreamOutput = Result<()>>
 where
-    Context: Sync + Send + XmtpSharedContext + 'static,
+    Context: XmtpSharedContext + 'static,
     Context::ApiClient: XmtpMlsStreams + 'static,
-    Context::MlsStorage: Send + Sync,
 {
     let (tx, rx) = oneshot::channel();
 

--- a/xmtp_mls/src/identity_updates.rs
+++ b/xmtp_mls/src/identity_updates.rs
@@ -623,7 +623,7 @@ pub async fn is_member_of_association_state<Client>(
     scw_verifier: Option<Box<dyn SmartContractSignatureVerifier>>,
 ) -> Result<bool, ClientError>
 where
-    Client: XmtpMlsClient + XmtpIdentityClient + Clone + Send + Sync,
+    Client: XmtpMlsClient + XmtpIdentityClient + Clone,
 {
     let filters = vec![GetIdentityUpdatesV2Filter {
         inbox_id: inbox_id.to_string(),

--- a/xmtp_mls/src/subscriptions/process_message.rs
+++ b/xmtp_mls/src/subscriptions/process_message.rs
@@ -28,7 +28,7 @@ pub trait ProcessFutureFactory<'a> {
 
 impl<'a, Context> ProcessFutureFactory<'a> for ProcessMessageFuture<Context>
 where
-    Context: Send + Sync + XmtpSharedContext + 'a,
+    Context: XmtpSharedContext + 'a,
 {
     fn create(
         &self,

--- a/xmtp_mls/src/subscriptions/stream_all.rs
+++ b/xmtp_mls/src/subscriptions/stream_all.rs
@@ -48,8 +48,8 @@ impl<Context>
         StreamGroupMessages<'static, Context, MessagesApiSubscription<'static, Context::ApiClient>>,
     >
 where
-    Context: Clone + XmtpSharedContext + Send + Sync + 'static,
-    Context::ApiClient: XmtpMlsStreams + Send + Sync + 'static,
+    Context: Clone + XmtpSharedContext + 'static,
+    Context::ApiClient: XmtpMlsStreams + 'static,
 {
     pub async fn new_owned(
         context: Context,
@@ -68,8 +68,8 @@ impl<'a, Context>
         StreamGroupMessages<'a, Context, MessagesApiSubscription<'a, Context::ApiClient>>,
     >
 where
-    Context: Clone + XmtpSharedContext + Send + Sync + 'a,
-    Context::ApiClient: XmtpMlsStreams + Send + Sync + 'a,
+    Context: Clone + XmtpSharedContext + 'a,
+    Context::ApiClient: XmtpMlsStreams + 'a,
 {
     pub async fn new(
         context: &'a Context,

--- a/xmtp_mls/src/subscriptions/stream_conversations.rs
+++ b/xmtp_mls/src/subscriptions/stream_conversations.rs
@@ -16,7 +16,7 @@ use std::{
     task::{Poll, ready},
 };
 use tokio_stream::wrappers::BroadcastStream;
-use xmtp_common::FutureWrapper;
+use xmtp_common::{FutureWrapper, MaybeSend};
 use xmtp_db::prelude::*;
 use xmtp_proto::api_client::XmtpMlsStreams;
 use xmtp_proto::types::{Cursor, WelcomeMessage};
@@ -116,8 +116,8 @@ impl<S, E> SubscriptionStream<S, E> {
 
 impl<S, E> Stream for SubscriptionStream<S, E>
 where
-    S: Stream<Item = std::result::Result<WelcomeMessage, E>>,
-    E: xmtp_common::RetryableError + Send + Sync + 'static,
+    S: Stream<Item = std::result::Result<WelcomeMessage, E>> + MaybeSend,
+    E: xmtp_common::RetryableError + 'static,
 {
     type Item = Result<WelcomeOrGroup>;
 

--- a/xmtp_mls/src/subscriptions/stream_messages.rs
+++ b/xmtp_mls/src/subscriptions/stream_messages.rs
@@ -113,8 +113,8 @@ where
 impl<C> StreamGroupMessages<'static, C, MessagesApiSubscription<'static, C::ApiClient>>
 where
     C: XmtpSharedContext + 'static,
-    C::ApiClient: XmtpMlsStreams + Send + Sync + 'static,
-    C::Db: Send + 'static,
+    C::ApiClient: XmtpMlsStreams + 'static,
+    C::Db: 'static,
 {
     pub async fn new_owned(context: C, groups: Vec<GroupId>) -> Result<Self> {
         let f = ProcessMessageFuture::new(context.clone());

--- a/xmtp_mls/src/tasks.rs
+++ b/xmtp_mls/src/tasks.rs
@@ -119,7 +119,7 @@ where
     fn factory<C>(context: C) -> impl WorkerFactory + 'static
     where
         Self: Sized,
-        C: XmtpSharedContext + Send + Sync + 'static,
+        C: XmtpSharedContext + 'static,
     {
         Factory { context }
     }

--- a/xmtp_mls/src/utils/events.rs
+++ b/xmtp_mls/src/utils/events.rs
@@ -299,7 +299,7 @@ pub struct Factory<Context> {
 
 impl<Context> WorkerFactory for Factory<Context>
 where
-    Context: XmtpSharedContext + Send + Sync + 'static,
+    Context: XmtpSharedContext + 'static,
 {
     fn create(
         &self,
@@ -344,7 +344,7 @@ where
     fn factory<C>(context: C) -> impl WorkerFactory + 'static
     where
         Self: Sized,
-        C: XmtpSharedContext + Send + Sync + 'static,
+        C: XmtpSharedContext + 'static,
     {
         Factory { context }
     }
@@ -359,7 +359,7 @@ where
 }
 
 pub async fn upload_debug_archive(
-    db: impl DbQuery + Send + Sync + 'static,
+    db: impl DbQuery + 'static,
     device_sync_server_url: Option<impl AsRef<str>>,
 ) -> Result<String, DeviceSyncError> {
     let device_sync_server_url = device_sync_server_url

--- a/xmtp_mls/src/utils/test/mod.rs
+++ b/xmtp_mls/src/utils/test/mod.rs
@@ -68,14 +68,9 @@ impl<A, S> ClientBuilder<A, S> {
 
 impl<Api, Storage, Db> ClientBuilder<Api, Storage, Db>
 where
-    Api: XmtpApi
-        + CursorAwareApi<CursorStore = Arc<dyn CursorStore>>
-        + XmtpQuery
-        + 'static
-        + Send
-        + Sync,
-    Storage: XmtpMlsStorageProvider + 'static + Send + Sync,
-    Db: xmtp_db::XmtpDb + 'static + Send + Sync,
+    Api: XmtpApi + CursorAwareApi<CursorStore = Arc<dyn CursorStore>> + XmtpQuery + 'static,
+    Storage: XmtpMlsStorageProvider + 'static,
+    Db: xmtp_db::XmtpDb + 'static,
 {
     pub async fn build_unchecked(self) -> Client<Arc<XmtpMlsLocalContext<Api, Db, Storage>>> {
         self.build().await.unwrap()

--- a/xmtp_proto/src/api_client/impls.rs
+++ b/xmtp_proto/src/api_client/impls.rs
@@ -93,7 +93,7 @@ impl std::fmt::Debug for AggregateStats {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<T> XmtpMlsClient for Box<T>
 where
-    T: XmtpMlsClient + Sync + ?Sized,
+    T: XmtpMlsClient + ?Sized,
 {
     type Error = <T as XmtpMlsClient>::Error;
 
@@ -172,7 +172,7 @@ where
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<T> XmtpMlsClient for Arc<T>
 where
-    T: XmtpMlsClient + Sync + ?Sized + Send,
+    T: XmtpMlsClient + ?Sized,
 {
     type Error = <T as XmtpMlsClient>::Error;
 
@@ -287,7 +287,7 @@ where
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<T> XmtpMlsStreams for Arc<T>
 where
-    T: XmtpMlsStreams + Sync + ?Sized + Send,
+    T: XmtpMlsStreams + ?Sized,
 {
     type Error = <T as XmtpMlsStreams>::Error;
 
@@ -323,7 +323,7 @@ where
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<T> XmtpIdentityClient for Box<T>
 where
-    T: XmtpIdentityClient + Send + Sync + ?Sized,
+    T: XmtpIdentityClient + ?Sized,
 {
     type Error = <T as XmtpIdentityClient>::Error;
 
@@ -362,7 +362,7 @@ where
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<T> XmtpIdentityClient for Arc<T>
 where
-    T: XmtpIdentityClient + Send + Sync + ?Sized,
+    T: XmtpIdentityClient + ?Sized,
 {
     type Error = <T as XmtpIdentityClient>::Error;
 

--- a/xmtp_proto/src/traits/combinators/retry.rs
+++ b/xmtp_proto/src/traits/combinators/retry.rs
@@ -1,7 +1,8 @@
 use std::marker::PhantomData;
 
 use xmtp_common::{
-    ExponentialBackoff, Retry, RetryableError, Strategy as RetryStrategy, retry_async,
+    ExponentialBackoff, MaybeSend, MaybeSync, Retry, RetryableError, Strategy as RetryStrategy,
+    retry_async,
 };
 
 use crate::api::{ApiClientError, Client, Endpoint, Pageable, Query, QueryRaw};
@@ -39,7 +40,7 @@ where
     E: Query<C>,
     C: Client,
     C::Error: RetryableError,
-    S: RetryStrategy + Send + Sync,
+    S: RetryStrategy,
 {
     type Output = E::Output;
     async fn query(&mut self, client: &C) -> Result<Self::Output, ApiClientError<C::Error>> {
@@ -57,7 +58,7 @@ where
     E: Endpoint,
     C: Client,
     C::Error: RetryableError,
-    S: RetryStrategy + Send + Sync,
+    S: RetryStrategy,
 {
     async fn query_raw(&mut self, client: &C) -> Result<bytes::Bytes, ApiClientError<C::Error>> {
         retry_async!(
@@ -74,7 +75,7 @@ pub struct RetrySpecialized<Spec> {
 impl<E, Spec> Endpoint<RetrySpecialized<Spec>> for RetryQuery<E>
 where
     E: Endpoint<Spec>,
-    Spec: Send + Sync,
+    Spec: MaybeSend + MaybeSync,
 {
     type Output = <E as Endpoint<Spec>>::Output;
 

--- a/xmtp_proto/src/traits/combinators/v3_paged.rs
+++ b/xmtp_proto/src/traits/combinators/v3_paged.rs
@@ -1,5 +1,6 @@
 use std::marker::PhantomData;
 
+use xmtp_common::{MaybeSend, MaybeSync};
 use xmtp_configuration::MAX_PAGE_SIZE;
 
 use crate::{
@@ -24,7 +25,6 @@ where
     C: Client,
     C::Error: std::error::Error,
     T: Default + prost::Message + Paged + 'static,
-    <T as Paged>::Message: Send + Sync,
 {
     type Output = Vec<<T as Paged>::Message>;
     async fn query(
@@ -59,7 +59,9 @@ pub struct V3PagedSpecialized<S> {
     _marker: PhantomData<S>,
 }
 
-impl<S, E: Endpoint<S>, T: Send + Sync> Endpoint<V3PagedSpecialized<S>> for V3Paged<E, T> {
+impl<S, E: Endpoint<S>, T: MaybeSend + MaybeSync> Endpoint<V3PagedSpecialized<S>>
+    for V3Paged<E, T>
+{
     type Output = <E as Endpoint<S>>::Output;
 
     fn grpc_endpoint(&self) -> std::borrow::Cow<'static, str> {

--- a/xmtp_proto/src/traits/query.rs
+++ b/xmtp_proto/src/traits/query.rs
@@ -9,7 +9,7 @@ use crate::{
     prelude::ApiClientError,
 };
 
-pub(super) async fn request<C: Client + Send + Sync>(
+pub(super) async fn request<C: Client>(
     client: &C,
     endpoint: &mut impl Endpoint,
 ) -> Result<http::Response<Bytes>, ApiClientError<C::Error>> {
@@ -27,9 +27,8 @@ pub(super) async fn request<C: Client + Send + Sync>(
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<Q, C> Query<C> for Q
 where
-    Q: QueryRaw<C> + Endpoint + Send + Sync,
-    C: Client + Sync + Send,
-    C::Error: std::error::Error,
+    Q: QueryRaw<C> + Endpoint,
+    C: Client,
     <Q as Endpoint>::Output: Default + prost::Message + 'static,
 {
     type Output = <Q as Endpoint>::Output;
@@ -45,9 +44,8 @@ where
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<E, C> QueryRaw<C> for E
 where
-    E: Endpoint + Send + Sync,
-    C: Client + Sync + Send,
-    C::Error: std::error::Error,
+    E: Endpoint,
+    C: Client,
 {
     async fn query_raw(&mut self, client: &C) -> Result<bytes::Bytes, ApiClientError<C::Error>> {
         let rsp = request(client, self).await?;
@@ -60,9 +58,8 @@ where
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<E, T, C> QueryStream<T, C> for E
 where
-    E: Endpoint + Send + Sync,
-    C: Client + Sync + Send,
-    C::Error: std::error::Error,
+    E: Endpoint,
+    C: Client,
     T: Default + prost::Message + 'static,
 {
     async fn stream(


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Apply Send/Sync constraints on traits and remove Send/Sync bounds from impls across `xmtp_*` crates to avoid unsafe impls on wasm
Relax Send/Sync bounds from impls and propagate `MaybeSend`/`MaybeSync` onto core traits and error types, unifying worker spawning, stream handles, and API client traits for wasm by eliminating unsafe Send/Sync impls and cfg splits; add `BoxDynError` where needed and introduce a non-retryable `ApiClientError::OtherUnretryable`.

#### 📍Where to Start
Start with the trait bound changes in `common` and `xmtp_proto` to see the new `MaybeSend`/`MaybeSync` foundation: review `RetryableError` and stream handle changes in [common/src/retry.rs](https://github.com/xmtp/libxmtp/pull/2716/files#diff-1fc729bbb038af084238293889e90354fb5eca3dfd6641183f6afcacfd945c24) and [common/src/stream_handles.rs](https://github.com/xmtp/libxmtp/pull/2716/files#diff-afc279a63ab19e2fc8affd22da405474e5d582ccdcdf0496b31125162ee74b02), then the API trait updates in [xmtp_proto/src/api_client.rs](https://github.com/xmtp/libxmtp/pull/2716/files#diff-7e862515880042ad7a89178c4850f4edd3b1a449ebd83515598088bd845fe67b) and [xmtp_proto/src/traits.rs](https://github.com/xmtp/libxmtp/pull/2716/files#diff-a040511e61519da940d7c0956bd7917a6a8d2ce1a929d3b4b8978cc7084befb5). After that, examine worker unification in [xmtp_mls/src/worker.rs](https://github.com/xmtp/libxmtp/pull/2716/files#diff-ea560e63ca633c03d1189957b9efca26de6aa33294f42c116a574e5bf259ce23).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 1d16a56. 52 files reviewed, 48 issues evaluated, 45 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>common/src/stream_handles.rs — 0 comments posted, 3 evaluated, 3 filtered</summary>

- [line 142](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/common/src/stream_handles.rs#L142): `AbortHandle::is_finished` for `CloseHandle` returns `self.0.is_closed()`, which reports whether the `mpsc::Receiver` was dropped, not whether the task/future has completed or a close signal was processed. During normal completion, the result is sent on the `oneshot` and the task ends, which drops the receiver and makes `is_closed()` return true. However, if a close signal was sent (`end()` called) but the spawned task has not yet processed it (buffer full or not polled yet), `is_finished()` will still return false despite a termination being in progress. Conversely, if the handle is dropped without closing (see previous issue), `is_finished()` may never become true even though the handle is gone and the task may be stuck forever. This can mislead callers relying on `is_finished()` to reflect completion state and cause incorrect control flow or resource management. <b>[ Low confidence ]</b>
- [line 205](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/common/src/stream_handles.rs#L205): Dropping a `WasmStreamHandle` without calling `end()` leaks the spawned task: when the `mpsc::Sender` (`closer`) is dropped, `CloserHandle::poll` returns `Poll::Pending` on `Poll::Ready(None)` and the `select` never resolves via the closer branch. If the `future` also never completes, the spawned task will stay alive for the duration of the program, never sending on the `oneshot` result channel, and cannot be cancelled anymore because the handle was dropped. This is a lifecycle/cancellation bug: dropping the handle commonly implies cancellation, but here it guarantees the opposite (task retention). The code path is reachable whenever a caller drops the handle without explicitly calling `end()`. <b>[ Low confidence ]</b>
- [line 278](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/common/src/stream_handles.rs#L278): Infinite recursion in `impl AbortHandle for tokio::task::AbortHandle` for method `is_finished`: the implementation `fn is_finished(&self) -> bool { self.is_finished() }` calls itself, causing unbounded recursion and a stack overflow at runtime whenever `AbortHandle::is_finished` is invoked. If the intent was to forward to an inherent method on `tokio::task::AbortHandle`, it must use fully-qualified syntax (e.g., `<tokio::task::AbortHandle>::is_finished(self)`), and such an inherent method must actually exist. If there is no inherent `is_finished` on Tokio's type, this method should be implemented using a correct runtime check or removed. <b>[ Out of scope ]</b>
</details>

<details>
<summary>xmtp_api/src/debug_wrapper.rs — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 70](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_api/src/debug_wrapper.rs#L70): Double-wrapping errors that already include stats: when `req().await` returns `Err(ApiClientError::ErrorWithStats { .. })`, the catch-all arm `e => Err(ApiClientError::ErrorWithStats { e: Box::new(e), stats: stats(), })` will wrap the existing `ErrorWithStats` inside a new `ErrorWithStats`, causing nested error structures and duplicated stats. This can lead to confusing and ever-growing error nesting if upstream callers re-apply `wrap_err`, and violates at-most-once addition of stats. A dedicated match arm should return `Err(err)` unchanged for `ApiClientError::ErrorWithStats { .. }`, similar to the handling for `ClientWithEndpointAndStats`. <b>[ Out of scope ]</b>
</details>

<details>
<summary>xmtp_api_d14n/src/middleware/multi_node_client/gateway_api.rs — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 187](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_api_d14n/src/middleware/multi_node_client/gateway_api.rs#L187): TLS detection in `validate_tls_guard` treats only the `https` scheme as TLS by checking `url.scheme() == "https"`. This misclassifies other valid TLS URL schemes (e.g., `grpcs`, potentially `wss` if supported by the system) as non-TLS. As a result, node URLs that are legitimately secured but use a different TLS-denoting scheme will be rejected with `MultiNodeClientError::TlsChannelMismatch`, even though the template's `tls_channel` is correctly set to require TLS. This can cause all node clients to fail to build if the gateway returns such URLs. Consider recognizing a broader set of TLS schemes or explicitly mapping supported schemes to TLS/non-TLS. <b>[ Low confidence ]</b>
</details>

<details>
<summary>xmtp_api_d14n/src/protocol/traits/cursor_store.rs — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 64](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_api_d14n/src/protocol/traits/cursor_store.rs#L64): The default implementation of `latest_for_originator` silently assumes that `latest_per_originator(topic, &[originator])` will always include the requested `originator`. It immediately reads `sid` via `GlobalCursor::get(originator)` and constructs a `Cursor` without validating presence. If the implementor returns a `GlobalCursor` that does not contain the given `originator` (which is plausible under this trait’s contract, e.g., missing data or partial results), this path can either: (a) return a default/zero sequence ID (if `get` returns a default), silently misrepresenting state; or (b) panic (if `get` expects presence). Either outcome is a runtime bug: missing originators must be explicitly handled (e.g., returning `CursorStoreError` or a documented fallback) rather than silently defaulting or panicking. <b>[ Out of scope ]</b>
</details>

<details>
<summary>xmtp_api_d14n/src/queries/d14n/identity.rs — 0 comments posted, 3 evaluated, 3 filtered</summary>

- [line 96](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_api_d14n/src/queries/d14n/identity.rs#L96): In `get_identity_updates_v2`, the method only returns responses for inbox IDs that have at least one update. Requested inbox IDs that have zero updates are omitted entirely. If the external API contract expects a response entry for every requested inbox ID (with an empty `updates` list when there are none), this omission creates ambiguity and forces callers to infer absence vs zero updates from missing entries. <b>[ Out of scope ]</b>
- [line 134](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_api_d14n/src/queries/d14n/identity.rs#L134): In `get_inbox_ids`, every mapped response sets `identifier_kind` to `IdentifierKind::Ethereum` regardless of the actual identifier kind. This silently mislabels passkey-derived inbox IDs (and any future kinds) as Ethereum. The mapping at `responses: res.responses.iter().map(...)` should preserve the kind returned by the V4 response or be derived consistently from the original request, rather than hardcoding `IdentifierKind::Ethereum` for all entries. <b>[ Out of scope ]</b>
- [line 162](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_api_d14n/src/queries/d14n/identity.rs#L162): In `verify_smart_contract_wallet_signatures`, a single verifier error (`self.scw_verifier.is_valid_signature(...).await`) aborts the entire batch with a top-level error, discarding any other signature validations. The response type supports per-signature `error` in `ValidationResponse`, suggesting the API may expect partial results even when some validations fail. Current behavior prevents returning per-item errors for the failing signature(s) and any successful validations for others, which can break batch semantics. <b>[ Out of scope ]</b>
</details>

<details>
<summary>xmtp_api_d14n/src/queries/d14n/mls.rs — 0 comments posted, 3 evaluated, 3 filtered</summary>

- [line 90](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_api_d14n/src/queries/d14n/mls.rs#L90): `send_group_messages` performs per-envelope publishing in a loop without transactional guarantees or compensating actions (lines 90-97). If any publish fails mid-loop, earlier messages have already been published, and the method returns an error with a partially applied effect. This can leave the system in an inconsistent state relative to the caller's expectation of "send all or error" and provides no visibility about which messages succeeded. A similar issue exists in `send_welcome_messages` (lines 109-116). Until batch publishing is implemented, this path should either document and surface partial successes (e.g., per-message results) or add best-effort retries/compensation to reduce inconsistency. <b>[ Low confidence ]</b>
- [line 109](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_api_d14n/src/queries/d14n/mls.rs#L109): `send_welcome_messages` also performs per-envelope publishing in a loop (lines 109-116) with the same partial side-effect behavior as `send_group_messages`. A failure mid-loop returns an error after some messages have already been published, with no per-message result reporting. This duplicates the consistency risk described above. <b>[ Low confidence ]</b>
- [line 157](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_api_d14n/src/queries/d14n/mls.rs#L157): `query_latest_group_message` returns `Err` when the newest envelope exists as a response object but contains no inner message, instead of returning `Ok(None)`. The function only checks `response.results.is_empty()` (line 157) and then unconditionally calls `accept` and `get` on `GroupMessageExtractor` for the first response (lines 160-166). If the first `Response` has `originator_envelope: None` (a reachable case, as evidenced by tests for similar extractors), `GroupMessageExtractor` is likely to surface an `EnvelopeError` rather than a `None` value. This violates the external contract implied by the method's `Result<Option<GroupMessage>, _>` return type, which should use `None` to represent absence of a message. The method needs to detect and return `Ok(None)` when the inner envelope is missing, not just when `results` is empty. <b>[ Low confidence ]</b>
</details>

<details>
<summary>xmtp_api_d14n/src/queries/d14n/streams.rs — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 39](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_api_d14n/src/queries/d14n/streams.rs#L39): All three subscription methods (`subscribe_group_messages`, `subscribe_group_messages_with_cursors`, and `subscribe_welcome_messages`) accept slices (`group_ids`, `groups_with_cursors`, `installations`) without validating that they are non-empty. If an empty slice is passed, the code constructs `topics` as an empty `Vec` and proceeds to build a `SubscribeEnvelopes` request with empty topics and, in the with-cursors path, an empty `GlobalCursor`. Depending on the contract of `SubscribeEnvelopes::builder().topics(...)` and the downstream service, this can yield a malformed subscription (rejected by the builder, by the client, or by the server) or undefined behavior (e.g., an error or a stream that never yields). The current implementation does not provide a defined terminal state or explicit error for empty inputs, making this a reachable runtime path with ambiguous outcomes. <b>[ Out of scope ]</b>
- [line 66](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_api_d14n/src/queries/d14n/streams.rs#L66): In `subscribe_group_messages_with_cursors`, the code comment says "Compute the lowest common cursor from the provided cursors", but the implementation builds `min_clock` over the union of all node IDs across cursors, taking the per-node minimum sequence ID. A 'common' cursor would typically be defined over the intersection of node IDs present in all provided cursors. Using the union contradicts the comment and could produce a `GlobalCursor` containing nodes that are not common to all topics, which may be semantically incorrect for consumers expecting a truly 'common' cursor and may be rejected or mishandled downstream. This contradiction creates uncertainty about intended behavior and risks incorrect or malformed subscriptions. <b>[ Out of scope ]</b>
</details>

<details>
<summary>xmtp_api_d14n/src/queries/d14n/xmtp_query.rs — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 33](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_api_d14n/src/queries/d14n/xmtp_query.rs#L33): The handling of `at: Option<GlobalCursor>` uses `unwrap_or_default()` when `None` is passed, forcing a non-absent `GlobalCursor` into the query via `.last_seen(at.unwrap_or_default())`. This silently converts "no cursor" into a specific default cursor value. If `GlobalCursor::default()` is not semantically equivalent to "no cursor" (e.g., it represents the beginning of history or some sentinel that changes query semantics), this can cause incorrect query ranges, excessive data retrieval, or missed results compared to omitting `last_seen`. This violates the principle of preserving the caller's intent for `None` as absent and can lead to subtle runtime misbehavior rather than a clear, handled fallback. <b>[ Low confidence ]</b>
- [line 34](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_api_d14n/src/queries/d14n/xmtp_query.rs#L34): The call `.limit(MAX_PAGE_SIZE)` blindly applies a global constant without validating bounds or ensuring it is within the server/API’s acceptable range. If `MAX_PAGE_SIZE` is zero, negative (if type permits), or exceeds the maximum allowed by the API, the query may fail at runtime (server-side rejection) or behave unexpectedly (e.g., zero results). There is no explicit guard or fallback to a safe default, making this path prone to runtime errors dependent on configuration. <b>[ Low confidence ]</b>
</details>

<details>
<summary>xmtp_api_d14n/src/queries/v3/identity.rs — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 44](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_api_d14n/src/queries/v3/identity.rs#L44): In `get_inbox_ids`, requests with `identifier_kind` values other than `IdentifierKind::Ethereum` or `IdentifierKind::Passkey` are silently dropped. The code filters to addresses and passkeys only and ignores all other kinds without error or visible outcome: `filter(|r| r.identifier_kind == IdentifierKind::Ethereum as i32)` and `filter(|r| r.identifier_kind == IdentifierKind::Passkey as i32)`. If the input includes other supported or future `IdentifierKind` variants, those entries will be lost, producing incomplete results without any explicit failure or warning. This violates the requirement to ensure every input reaches a defined terminal state and to avoid silently discarding cases that are not proven unreachable by guards. The method should either explicitly reject unknown kinds with a clear error or handle them appropriately, rather than dropping them. <b>[ Out of scope ]</b>
</details>

<details>
<summary>xmtp_api_d14n/src/queries/v3/xmtp_query.rs — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 87](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_api_d14n/src/queries/v3/xmtp_query.rs#L87): `unreachable!()` in the default match arm for `topic.kind()` will cause a runtime panic if a `TopicKind` other than the explicitly handled ones (`GroupMessagesV1`, `WelcomeMessagesV1`, `IdentityUpdatesV1`, `KeyPackagesV1`) is passed. There is no guard in this function ensuring that only those four kinds are ever supplied, and per the contract you must treat inputs as reachable unless a concrete guard exists. This makes the function prone to crashing at runtime when new or unexpected topic kinds appear. Replace `unreachable!()` with a defined error outcome or a graceful fallback so that every input reaches a defined terminal state without runtime termination. <b>[ Out of scope ]</b>
</details>

<details>
<summary>xmtp_archive/src/export_stream.rs — 0 comments posted, 3 evaluated, 2 filtered</summary>

- [line 66](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_archive/src/export_stream.rs#L66): `BatchExportStream::next` reverses the order of elements within each batch because it stores the entire batch in `self.buffer` and then yields elements using `self.buffer.pop()`. If `R::backup_records` returns elements in a semantically ordered sequence (e.g., chronological), popping from the end reverses that order, potentially violating ordering constraints (the code already comments that order matters for certain elements). Consider using `remove(0)` or pushing into the buffer in reverse so that `pop()` preserves the intended order. <b>[ Low confidence ]</b>
- [line 150](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_archive/src/export_stream.rs#L150): `self.cursor` uses `i64` and is increased by `R::BATCH_SIZE` each iteration without bounds checks. Over extremely long runs, this can overflow, causing wrap-around to negative values in release builds and leading to undefined paging behavior (potential infinite loops, missed or duplicated ranges). Consider using checked arithmetic (`checked_add`) with a clear error or termination when nearing limits. <b>[ Low confidence ]</b>
</details>

<details>
<summary>xmtp_archive/src/exporter.rs — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 54](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_archive/src/exporter.rs#L54): Unchecked `key` length can cause a runtime panic when constructing the cipher in `Self::new(options, db, key)`. The `new` method calls `Aes256Gcm::new(GenericArray::from_slice(key))`, which requires a 32-byte key; if `key.len() != 32`, `GenericArray::from_slice` panics at runtime. `export_to_file` does not validate `key` before calling `new`, so callers can trigger a panic rather than a recoverable error. To fix, enforce the key length (e.g., return an error if `key.len() != 32`) before calling `new`. <b>[ Low confidence ]</b>
</details>

<details>
<summary>xmtp_db/src/encrypted_store/mod.rs — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 249](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_db/src/encrypted_store/mod.rs#L249): Potential panic due to unchecked indexing into `sqlite_version` vector. In `init`, after executing `sql_query("SELECT sqlite_version() AS version").load::<SqliteVersion>(conn)?;`, the code immediately logs `sqlite_version[0].version` without verifying that the result set is non-empty. If the query returns zero rows (e.g., due to an unexpected driver behavior, misconfiguration, or a different SQLite build), this will result in an out-of-bounds index and panic at runtime. Add an explicit check for `sqlite_version.is_empty()` and handle it gracefully (e.g., return a meaningful error or fallback log). <b>[ Out of scope ]</b>
</details>

<details>
<summary>xmtp_db_test/src/chaos.rs — 0 comments posted, 2 evaluated, 1 filtered</summary>

- [line 167](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_db_test/src/chaos.rs#L167): `static_start_transaction_hook` and `start_transaction_hook` registrations are never executed. While the code defines `STATIC_TRANSACTION_START_HOOK` and `TRANSACTION_START_HOOK` and provides methods to register these hooks, there is no call site that actually runs them (no `run_static_hooks(STATIC_TRANSACTION_START_HOOK)` or `run_hook(TRANSACTION_START_HOOK)` anywhere). The only executed hooks in this implementation are read/write pre/post hooks. This leads to a functional mismatch: users registering transaction start hooks will observe that they never fire. To fix, ensure that the transaction start hooks are invoked at the appropriate time (e.g., in a transaction-starting method) or explicitly remove/deprecate the unused APIs. <b>[ Low confidence ]</b>
</details>

<details>
<summary>xmtp_db_test/src/lib.rs — 0 comments posted, 3 evaluated, 3 filtered</summary>

- [line 90](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_db_test/src/lib.rs#L90): Unconditional `unwrap()` on `self.db.init()` can panic at runtime if initialization fails. This occurs during builder construction and there is no error propagation nor cleanup for any partially-initialized resources. If `init()` opens connections or allocates resources, a panic here can leave them in an indeterminate state without a paired `disconnect`/cleanup. Consider returning a `Result` and handling failure paths explicitly. <b>[ Out of scope ]</b>
- [line 96](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_db_test/src/lib.rs#L96): Unconditional `unwrap()` on `chaos::ChaosConnection::builder().db(self.db.conn()).error_frequency(self.error_frequency).build()` can panic at runtime if the chaos builder rejects the provided configuration (e.g., invalid `error_frequency` range or a failing underlying `conn()`). There is no input validation for `error_frequency` (e.g., negative, >1, or NaN), and no graceful error propagation. <b>[ Out of scope ]</b>
- [line 105](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_db_test/src/lib.rs#L105): Unconditional `unwrap()` on `EncryptedMessageStore::<ChaosDb<Db>>::builder().db(chaos_db).build()` can panic if the store builder fails (e.g., due to invalid DB configuration or missing dependencies). This builder returns `Result` and the code discards error handling, risking a runtime crash and lack of cleanup for allocated resources. <b>[ Out of scope ]</b>
</details>

<details>
<summary>xmtp_id/src/scw_verifier/mod.rs — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 33](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_id/src/scw_verifier/mod.rs#L33): The `MalformedEipUrl` error message (`#[error("URLs must be preceded with eip144:")]`) is misleading and contradicts the implementation. The code treats `id` as an EIP-155 chain ID string like `"eip155:1"`, not a URL, and it uses the `eip155` namespace rather than `eip144`. This creates confusion about the expected input format and may lead to misdiagnosis when the error is emitted. <b>[ Out of scope ]</b>
- [line 183](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_id/src/scw_verifier/mod.rs#L183): Fragile parsing of chain ID in `MultiSmartContractSignatureVerifier::upgrade`: `let eip_id = id.split(":").nth(1).ok_or(VerifierError::MalformedEipUrl)?;` assumes exactly one `:` in `id` (e.g., `"eip155:1"`). If `id` contains zero or multiple colons (e.g., user-provided IDs via `add_verifier` like `"namespace:eip155:1"`), `nth(1)` will produce the wrong segment or error. This can lead to constructing the wrong environment variable name (`CHAIN_RPC_{eip_id}`) or spuriously returning `MalformedEipUrl`. There is no validation that the prefix is `eip155`, and no robust split. A safer approach is to validate the namespace and split only once at the first colon. <b>[ Out of scope ]</b>
</details>

<details>
<summary>xmtp_mls/src/builder.rs — 0 comments posted, 3 evaluated, 3 filtered</summary>

- [line 271](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_mls/src/builder.rs#L271): Inconsistent use of normalized vs. raw identity values. The code logs `identity.inbox_id()` (method) and later passes `identity.inbox_id.as_str()` (field) to `load_identity_updates`. If the method `inbox_id()` applies normalization/transformation (e.g., canonicalization, trimming, case-folding) while the raw field `inbox_id` does not, this creates a subtle inconsistency where different forms of the value are used for logging and for API/DB operations. At data-conversion boundaries, the canonicalized form should be used consistently. Using the raw field directly can lead to lookup failures or divergence if the method is intended to supply the canonical value. <b>[ Out of scope ]</b>
- [line 297](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_mls/src/builder.rs#L297): Potential strong reference cycle causing resource leaks: `context` stores a clone of `workers` (`context.workers: workers.clone()`), and each `register_new_worker::<...>(context.clone())` likely causes `WorkerRunner` to retain a strong `Arc` to `context` for executing work. If `WorkerRunner` holds strong references to the passed `context` (common in worker registries), then `context -> workers` and `workers -> context` creates a cycle that prevents both from being dropped when the `Client` is dropped, leaking threads/resources. Without an explicit teardown or use of `Weak` references inside `WorkerRunner`, this is a runtime leak risk. <b>[ Out of scope ]</b>
- [line 309](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_mls/src/builder.rs#L309): Global `EVENTS_ENABLED` is set to `true` when `!disable_events`, but there is no corresponding reset or teardown anywhere in `build` for later clients that might specify `disable_events = true`. This persistent mutation of a global flag can cause subsequent `Client` instances in the same process to observe events being enabled even when they requested events to be disabled, violating per-client configuration and leading to inconsistent behavior across instances. Since the flag is set only when `!disable_workers` as well, a later client constructed with `disable_workers = true` cannot unset the flag, further compounding the inconsistency. This is a runtime configuration leak across instances, not a compile-time issue. <b>[ Out of scope ]</b>
</details>

<details>
<summary>xmtp_mls/src/groups/subscriptions.rs — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 110](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_mls/src/groups/subscriptions.rs#L110): The readiness oneshot (`tx`) is only sent on successful stream creation, and never sent in the failure path. If the `StreamHandle` or surrounding infrastructure expects to receive a readiness signal (either a successful `send(())` or an explicit error) to transition state, omitting `tx.send(())` on failure can lead to a mismatch or race conditions in the handle's lifecycle. Specifically, on error at lines `104..107`, the code calls `on_close()` and returns without sending a readiness signal. Depending on `StreamHandle` semantics, callers awaiting readiness may not receive the intended signal, and could be left in an inconsistent state. <b>[ Low confidence ]</b>
- [line 116](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_mls/src/groups/subscriptions.rs#L116): Errors during stream setup and termination are silently swallowed and never propagated via the returned `StreamHandle`'s `StreamOutput`. In the failure path when `StreamGroupMessages::new` returns `Err`, the code logs a warning, calls `on_close()`, and then returns `Ok(())` instead of an error. In the normal termination path after the stream ends, it also returns `Ok(())`. As a result, callers cannot distinguish between a normal stream completion and an error-induced closure, which can lead to silent data loss and prevent appropriate retries or error handling by the caller. <b>[ Low confidence ]</b>
</details>

<details>
<summary>xmtp_mls/src/subscriptions/mod.rs — 0 comments posted, 12 evaluated, 11 filtered</summary>

- [line 330](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_mls/src/subscriptions/mod.rs#L330): Readiness signal is never sent when `client.stream_conversations(...)` fails, which can leave the associated `rx` in `xmtp_common::spawn(Some(rx), ...)` permanently pending. The code only calls `tx.send(())` after successfully creating and pinning the stream (line 338). In the early error path (lines 330–335), it logs, calls `on_close()`, and returns without sending on `tx`. If `xmtp_common::spawn` relies on this readiness signal to mark the task as started or to unblock the handle, the caller may observe a hung or unclosable stream handle, or other startup synchronization issues. <b>[ Low confidence ]</b>
- [line 332](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_mls/src/subscriptions/mod.rs#L332): On the error path when creating the stream fails (e.g., `client.stream_conversations(...).await` or `StreamAllMessages::new(...).await` returns `Err`), `on_close` is invoked but the 'ready' oneshot (`tx`) is never signaled. Although `tx` will be dropped when the future returns, depending on how `xmtp_common::spawn` and the associated `StreamHandle` use this channel, the handle may temporarily await readiness and only observe a cancellation after the task exits. If the handle expects a positive ready signal to transition, this can lead to a brief hang or racey behavior. To make readiness signaling unambiguous, consider sending an explicit terminal signal on the ready channel (e.g., using a separate error path) or document that a dropped `tx` indicates initialization failure. <b>[ Out of scope ]</b>
- [line 340](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_mls/src/subscriptions/mod.rs#L340): User-supplied callbacks `convo_callback`, `callback` (for messages), `callback` (for consent), and `callback` (for preferences) are invoked without panic containment. If a callback panics, the async task will unwind and terminate immediately, and `on_close` will not be invoked. This violates the implied cleanup invariant that `on_close` is called exactly once when the stream terminates, and can leave external state in an inconsistent or hanging state (e.g., user expecting a close notification). Consider wrapping callback invocations in `std::panic::catch_unwind` (with `AssertUnwindSafe` as needed) to ensure `on_close` is invoked even on callback panic, or clearly document that panic in callbacks forfeits `on_close` execution. <b>[ Out of scope ]</b>
- [line 343](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_mls/src/subscriptions/mod.rs#L343): `on_close()` is not guaranteed to be invoked on all termination paths. Specifically, if `convo_callback` panics (line 340) or the task is cancelled externally (e.g., via the returned `StreamHandle`), the async task will unwind or be aborted and the code path that calls `on_close()` (line 343) will not execute, violating at-most-once and terminal notification guarantees. There is no `catch_unwind` or scoped guard to ensure `on_close` runs on panic/cancellation. This can leave FFI callers (see example usage) without a closure notification, breaking lifecycle contracts. <b>[ Low confidence ]</b>
- [line 343](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_mls/src/subscriptions/mod.rs#L343): `on_close` is called after the stream ends, but there is no guard against multiple terminal events or duplicated `on_close` calls if upstream stream mistakenly yields `None` followed by further items due to a bug or cancellation/resumption. While typical `Stream` contracts prevent this, defensive coding could ensure `on_close` is at-most-once by tracking a closed flag to avoid double invocation if future changes introduce re-entrancy. As written, current paths appear single-invocation, but lack explicit at-most-once guard. <b>[ Out of scope ]</b>
- [line 343](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_mls/src/subscriptions/mod.rs#L343): Lifecycle callback `on_close` is not guaranteed to run on task cancellation. The async task is spawned via `xmtp_common::spawn` with a `oneshot::Receiver` for a start signal, but there is no explicit cancellation token checked inside the loop. If the `StreamHandle` cancels the task (e.g., by dropping/aborting the spawned future), the future may be terminated without reaching the end-of-stream path that calls `on_close`. This can leave clients without a close notification on cancellation. To preserve lifecycle contract parity, ensure cancellation invokes `on_close` exactly once, either by using a cancellation-aware stream that yields a terminal event, adding an explicit cancellation listener in the task, or arranging for the spawning mechanism to invoke `on_close` on cancellation. <b>[ Out of scope ]</b>
- [line 344](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_mls/src/subscriptions/mod.rs#L344): The returned stream output is always `Ok(())` regardless of whether the stream fails to be created (lines 330–335) or ends due to an error later. This function logs and delegates per-conversation errors via `convo_callback`, but it does not propagate any error through the `StreamHandle<StreamOutput = Result<()>>`. If downstream code relies on the `StreamHandle` emitting `Err(...)` on failure to create or premature termination, this suppresses error signaling and can lead to silent failures from the perspective of the handle consumer. <b>[ Code style ]</b>
- [line 402](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_mls/src/subscriptions/mod.rs#L402): The readiness `oneshot` signal (`tx.send(())`) is only sent on the success path after the stream is created and pinned. On the error path when `StreamAllMessages::new` fails, `tx` is dropped without sending any explicit error or success signal, leaving the receiver with a closed channel. If upstream waits specifically for a positive readiness signal to proceed, this asymmetric signaling can produce ambiguous outcomes and potentially hang or mis-handle startup (depending on how `xmtp_common::spawn` and the caller interpret a closed `rx`). To preserve a defined terminal state and explicit outcome for the readiness handshake, send an explicit error or a distinct signal on failure rather than dropping the channel silently. <b>[ Low confidence ]</b>
- [line 408](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_mls/src/subscriptions/mod.rs#L408): The `on_close` callback is not guaranteed to be invoked on all exit paths: if the `callback` passed to `stream_all_messages_with_callback` panics during message handling, the async task will unwind and terminate without calling `on_close`. This violates the invariant that cleanup callbacks fire exactly once on completion or failure, and can leave upstream state waiting for a close signal indefinitely. A scoped guard (e.g., a `Drop`-based guard) or `catch_unwind` wrapper around the callback dispatch is needed to ensure `on_close` is invoked even if the `callback` panics. <b>[ Low confidence ]</b>
- [line 425](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_mls/src/subscriptions/mod.rs#L425): The result of `tx.send(())` from the `oneshot::channel` is ignored. If the receiver side `rx` is dropped early (e.g., due to an error or a miscoordination in `xmtp_common::spawn`), `send` will return `Err(())`. Ignoring this can lead to a readiness coordination mismatch: the returned `StreamHandle` might be waiting for the readiness signal or might observe a cancellation while the task continues processing. At best it's harmless, but at worst it can cause the handle to never become "ready" or to proceed with incorrect assumptions, depending on how `spawn(Some(rx), ...)` uses `rx`. This is a runtime coordination bug risk. <b>[ Previously rejected ]</b>
- [line 430](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_mls/src/subscriptions/mod.rs#L430): `on_close` is only invoked after the `while let Some(message)` loop completes. If the task is cancelled (e.g., the returned `StreamHandle`/closer is dropped or closed) or if the user-provided `callback` panics, the future is dropped and the code after the loop does not run. In those cases, `on_close` will never be called, breaking the expected cleanup/notification contract and causing the JS-side `on_close` to be skipped (as shown in example usage). This violates the requirement that callbacks be consumed exactly once and that cleanup happen on all exit paths, including cancellation or panic. <b>[ Low confidence ]</b>
</details>

<details>
<summary>xmtp_mls/src/utils/test/mod.rs — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 76](https://github.com/xmtp/libxmtp/blob/1d16a56cb5a134b85fde2dbb35b06df8e194c4e1/xmtp_mls/src/utils/test/mod.rs#L76): The method `build_unchecked` calls `self.build().await.unwrap()` at runtime. If `self.build()` returns an `Err`, `unwrap()` will panic, causing abrupt termination. Because this is executed after awaiting an async operation, there is a risk that partial resources created by `build()` (e.g., connections or handles) are left without cleanup on the panic path. This helper is not guarded by `#[cfg(test)]`, so it is available in non-test builds as well. Prefer returning the `Result` or using an explicit error handling path to avoid panicking, or clearly constrain the function to test-only usage where panic is acceptable pre-effect. If panicking is intended, ensure `build()` performs no effects prior to returning `Err` to avoid leaks. <b>[ Code style ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->