### PR TITLE
auth callback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8411,6 +8411,7 @@ dependencies = [
 name = "xmtp_api_d14n"
 version = "1.7.0-dev"
 dependencies = [
+ "arc-swap",
  "async-trait",
  "chrono",
  "const-hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,9 +180,9 @@ panic = "unwind"
 strip = "none"
 
 [profile.dev]
-# Disabling debug info speeds up builds a bunch,
-# and we don't rely on it for debugging that much.
-debug = 0
+# Disabling full debug info speeds up builds
+# and this only affects local crates, all dependencies have this disabled.
+debug = "line-tables-only"
 
 [profile.bench]
 debug = true

--- a/common/src/macros.rs
+++ b/common/src/macros.rs
@@ -92,3 +92,11 @@ macro_rules! if_only_test {
         $item
     )*}
 }
+
+#[macro_export]
+macro_rules! if_not_test {
+    ($($item:item)*) => {$(
+        #[cfg(not(any(test, feature = "test-utils")))]
+        $item
+    )*}
+}

--- a/xmtp_api_d14n/Cargo.toml
+++ b/xmtp_api_d14n/Cargo.toml
@@ -8,6 +8,7 @@ version.workspace = true
 workspace = true
 
 [dependencies]
+arc-swap.workspace = true
 async-trait.workspace = true
 chrono.workspace = true
 derive_builder.workspace = true

--- a/xmtp_api_d14n/src/lib.rs
+++ b/xmtp_api_d14n/src/lib.rs
@@ -7,8 +7,9 @@ pub mod queries;
 pub use queries::*;
 
 pub mod middleware;
-pub mod protocol;
 pub use middleware::*;
+
+pub mod protocol;
 
 pub mod definitions;
 

--- a/xmtp_api_d14n/src/middleware/auth.rs
+++ b/xmtp_api_d14n/src/middleware/auth.rs
@@ -1,0 +1,468 @@
+use arc_swap::ArcSwap;
+use prost::bytes::Bytes;
+use std::sync::Arc;
+use tokio::sync::OnceCell;
+use xmtp_common::{BoxDynError, MaybeSend, MaybeSync};
+use xmtp_proto::api::{ApiClientError, Client, IsConnectedCheck};
+
+xmtp_common::if_not_test! {
+    use xmtp_common::time::now_secs;
+}
+// override now so we don't ahve flaky tests
+xmtp_common::if_test! {
+    fn now_secs() -> i64 {
+        1_000_000
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Credential {
+    name: http::header::HeaderName,
+    value: http::header::HeaderValue,
+    expires_at_seconds: i64,
+}
+
+impl Credential {
+    pub fn new(
+        name: Option<http::header::HeaderName>,
+        value: http::header::HeaderValue,
+        expires_at_seconds: i64,
+    ) -> Self {
+        Self {
+            name: name.unwrap_or(http::header::AUTHORIZATION),
+            value,
+            expires_at_seconds,
+        }
+    }
+}
+
+#[derive(Default)]
+struct AuthInner {
+    handle: OnceCell<ArcSwap<Credential>>,
+    mutex: tokio::sync::Mutex<()>,
+}
+
+#[derive(Default, Clone)]
+pub struct AuthHandle {
+    inner: Arc<AuthInner>,
+}
+
+impl AuthHandle {
+    pub fn new() -> Self {
+        Self::default()
+    }
+    pub async fn set(&self, credential: Credential) {
+        let mut new = Some(credential);
+        let inner = self
+            .inner
+            .handle
+            .get_or_init(|| async {
+                ArcSwap::from_pointee(new.take().expect("Credential not set"))
+            })
+            .await;
+        if let Some(new) = new {
+            inner.store(Arc::new(new));
+        }
+    }
+    pub fn id(&self) -> usize {
+        Arc::as_ptr(&self.inner) as usize
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+pub trait AuthCallback: MaybeSend + MaybeSync {
+    async fn on_auth_required(&self) -> Result<Credential, BoxDynError>;
+}
+
+/// Middleware for adding authentication headers to requests.
+///
+/// This middleware will add authentication headers to requests if a callback or handle is provided.
+///
+/// If a callback is provided, it will be called to get the credential when it is expired.
+/// If a handle is provided, it can be used to set the credential.
+///
+/// If only providing a handle, then expired credentials will still be used until the credential is set.
+///
+/// If creating multiple clients, if they share the same handle, then the credential will be shared between them
+/// resulting in less auth callbacks. Auth callbacks are debounced internally to prevent excessive calls.
+#[derive(Clone)]
+pub struct AuthMiddleware<C> {
+    inner: C,
+    handle: AuthHandle,
+    callback: Option<Arc<dyn AuthCallback>>,
+}
+
+impl<C> AuthMiddleware<C> {
+    #[track_caller]
+    pub fn new(
+        inner: C,
+        callback: Option<Arc<dyn AuthCallback>>,
+        handle: Option<AuthHandle>,
+    ) -> Self {
+        assert!(
+            callback.is_some() || handle.is_some(),
+            "Either a callback or a handle must be provided"
+        );
+        Self {
+            inner,
+            handle: handle.unwrap_or_default(),
+            callback,
+        }
+    }
+    async fn get_credential(&self) -> Result<Option<&ArcSwap<Credential>>, BoxDynError> {
+        let arc_swap = if let Some(callback) = &self.callback {
+            let arc_swap = self
+                .handle
+                .inner
+                .handle
+                .get_or_try_init(|| async {
+                    let credential = callback.on_auth_required().await?;
+                    let arc_swap = ArcSwap::from_pointee(credential);
+                    Ok::<_, BoxDynError>(arc_swap)
+                })
+                .await?;
+            Some(arc_swap)
+        } else {
+            self.handle.inner.handle.get()
+        };
+
+        let Some(arc_swap) = arc_swap else {
+            return Err("No auth callback provided and no credentials set. Please set credentials by calling `AuthHandle::set`.".into());
+        };
+
+        let needs_refresh = || arc_swap.load().expires_at_seconds <= now_secs();
+
+        if let Some(callback) = &self.callback
+            && needs_refresh()
+        {
+            // Multiple threads may be racing to run this, so this may require a lock in the future.
+            let _guard = self.handle.inner.mutex.lock().await;
+            // after acquiring the lock, we need to check again if the credential needs to be refreshed so that
+            // if another thread has already refreshed the credential, we don't need to do it again.
+            if needs_refresh() {
+                let new_header = callback.on_auth_required().await?;
+                arc_swap.store(Arc::new(new_header));
+            }
+        }
+        Ok(Some(arc_swap))
+    }
+    async fn modify_request<E: std::error::Error>(
+        &self,
+        mut request: http::request::Builder,
+    ) -> Result<http::request::Builder, ApiClientError<E>> {
+        let maybe_credential = self
+            .get_credential()
+            .await
+            .map_err(ApiClientError::<E>::OtherUnretryable)?;
+        if let Some(credential) = maybe_credential {
+            let credential = credential.load();
+            request = request.header(credential.name.clone(), credential.value.clone());
+        }
+        Ok(request)
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl<C: Client> Client for AuthMiddleware<C> {
+    type Error = C::Error;
+
+    type Stream = C::Stream;
+
+    async fn request(
+        &self,
+        request: http::request::Builder,
+        path: http::uri::PathAndQuery,
+        body: Bytes,
+    ) -> Result<http::Response<Bytes>, ApiClientError<Self::Error>> {
+        let request = self.modify_request(request).await?;
+        self.inner.request(request, path, body).await
+    }
+
+    async fn stream(
+        &self,
+        request: http::request::Builder,
+        path: http::uri::PathAndQuery,
+        body: Bytes,
+    ) -> Result<http::Response<Self::Stream>, ApiClientError<Self::Error>> {
+        let request = self.modify_request(request).await?;
+        self.inner.stream(request, path, body).await
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl<C: IsConnectedCheck> IsConnectedCheck for AuthMiddleware<C> {
+    async fn is_connected(&self) -> bool {
+        self.inner.is_connected().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use futures::StreamExt;
+
+    fn credential(offset: i64) -> Credential {
+        let random_name = xmtp_common::rand_string::<16>().to_lowercase();
+        let header_name =
+            http::header::HeaderName::try_from(format!("x-test-header-{random_name}")).unwrap();
+        let random = xmtp_common::rand_string::<16>();
+        let header_value = http::header::HeaderValue::try_from(format!("Bearer {random}")).unwrap();
+        let now = now_secs();
+        Credential::new(Some(header_name), header_value.clone(), now + offset)
+    }
+
+    #[xmtp_common::test]
+    async fn test_auth_handle() {
+        let credential = credential(0);
+        let auth_handle = AuthHandle::new();
+        auth_handle.set(credential.clone()).await;
+        let inner = auth_handle
+            .inner
+            .handle
+            .get()
+            .map(|c| c.load_full())
+            .unwrap();
+        assert_eq!(inner.name, credential.name);
+        assert_eq!(inner.value, credential.value);
+        assert_eq!(inner.expires_at_seconds, credential.expires_at_seconds);
+    }
+
+    struct TestClient {
+        expected_credential: Option<Credential>,
+    }
+
+    impl TestClient {
+        pub fn new(expected_credential: Option<Credential>) -> Self {
+            Self {
+                expected_credential,
+            }
+        }
+    }
+
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+    impl Client for TestClient {
+        type Error = core::convert::Infallible;
+        type Stream = futures::stream::Once<
+            core::pin::Pin<Box<dyn Future<Output = Result<Bytes, Self::Error>> + Send + Sync>>,
+        >;
+
+        async fn request(
+            &self,
+            request: http::request::Builder,
+            _path: http::uri::PathAndQuery,
+            body: Bytes,
+        ) -> Result<http::Response<Bytes>, ApiClientError<Self::Error>> {
+            let headers = request.headers_ref().unwrap();
+            if let Some(expected_credential) = &self.expected_credential {
+                assert_eq!(
+                    headers.get(&expected_credential.name).unwrap(),
+                    &expected_credential.value
+                );
+            } else {
+                assert!(headers.is_empty());
+            }
+            Ok(http::Response::new(body))
+        }
+
+        async fn stream(
+            &self,
+            request: http::request::Builder,
+            _path: http::uri::PathAndQuery,
+            body: Bytes,
+        ) -> Result<http::Response<Self::Stream>, ApiClientError<Self::Error>> {
+            let headers = request.headers_ref().unwrap();
+            if let Some(expected_credential) = &self.expected_credential {
+                assert_eq!(
+                    headers.get(&expected_credential.name).unwrap(),
+                    &expected_credential.value
+                );
+            } else {
+                assert!(headers.is_empty());
+            }
+            Ok(http::Response::new(futures::stream::once(Box::pin(
+                async move { Ok::<_, Self::Error>(body) },
+            ))))
+        }
+    }
+
+    impl<C: Client> AuthMiddleware<C> {
+        pub async fn make_requests(&self, expected: Result<(), String>) {
+            let request = http::request::Builder::new();
+            let path = http::uri::PathAndQuery::from_static("/");
+            let body = Bytes::new();
+            let result = self.request(request, path.clone(), body.clone()).await;
+            match (&expected, result) {
+                (Ok(()), Ok(response)) => {
+                    assert_eq!(response.status(), http::StatusCode::OK);
+                }
+                (Err(e), Ok(response)) => {
+                    panic!("Expected error: {e}, got response: {response:?}");
+                }
+                (Ok(()), Err(e)) => {
+                    panic!("Expected Ok, got error: {e}");
+                }
+                (Err(e), Err(res)) => {
+                    assert_eq!(e, &res.to_string());
+                }
+            }
+
+            let request = http::request::Builder::new();
+            let result = self.stream(request, path, body).await;
+            match (&expected, result) {
+                (Ok(()), Ok(response)) => {
+                    assert_eq!(response.status(), http::StatusCode::OK);
+                }
+                (Err(e), Ok(_)) => {
+                    panic!("Expected error: {e}, got Ok");
+                }
+                (Ok(()), Err(e)) => {
+                    panic!("Expected Ok, got error: {e}");
+                }
+                (Err(e), Err(res)) => {
+                    assert_eq!(e, &res.to_string());
+                }
+            }
+        }
+    }
+
+    struct TestCallback {
+        inner: Credential,
+        count: Arc<std::sync::atomic::AtomicI64>,
+    }
+
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+    impl AuthCallback for TestCallback {
+        async fn on_auth_required(&self) -> Result<Credential, BoxDynError> {
+            // Add sleeps so we can test concurrent requests
+            xmtp_common::time::sleep(std::time::Duration::from_millis(10)).await;
+            let mut credential = self.inner.clone();
+            xmtp_common::time::sleep(std::time::Duration::from_millis(10)).await;
+            let count = self.count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            xmtp_common::time::sleep(std::time::Duration::from_millis(10)).await;
+            credential.expires_at_seconds += count;
+            xmtp_common::time::sleep(std::time::Duration::from_millis(10)).await;
+            tracing::debug!("credential: {credential:?}, {}, {count}", now_secs());
+            Ok(credential.clone())
+        }
+    }
+
+    impl TestCallback {
+        pub fn new(credential: Credential, count: Arc<std::sync::atomic::AtomicI64>) -> Self {
+            Self {
+                inner: credential,
+                count,
+            }
+        }
+    }
+
+    // Only run this test on native where we can catch the panic
+    // This should never panic in practice because we only create auth middleware if there is a callback or handle.
+    xmtp_common::if_native! {
+        #[xmtp_common::test]
+        async fn test_auth_middleware_no_callback_or_handle() {
+            // expect a panic when creating the middleware without a callback or handle
+            std::panic::catch_unwind(|| {
+                AuthMiddleware::new(TestClient::new(None), None, None);
+            })
+            .unwrap_err();
+        }
+    }
+
+    #[xmtp_common::test]
+    async fn test_auth_middleware_with_no_callback_and_handle() {
+        let credential = credential(0);
+        let auth_handle = AuthHandle::new();
+        let mut middleware =
+            AuthMiddleware::new(TestClient::new(None), None, Some(auth_handle.clone()));
+        middleware
+            .make_requests(Err("No auth callback provided and no credentials set. Please set credentials by calling `AuthHandle::set`.".into()))
+            .await;
+
+        auth_handle.set(credential.clone()).await;
+        middleware.inner.expected_credential = Some(credential.clone());
+        middleware.make_requests(Ok(())).await;
+    }
+
+    #[xmtp_common::test]
+    async fn test_auth_middleware_with_callback_and_no_handle() {
+        let credential = credential(-1);
+        let count = Arc::new(std::sync::atomic::AtomicI64::new(0));
+        let callback = TestCallback::new(credential.clone(), count.clone());
+        let middleware = AuthMiddleware::new(
+            TestClient::new(Some(credential.clone())),
+            Some(Arc::new(callback)),
+            None,
+        );
+        middleware.make_requests(Ok(())).await;
+        middleware.make_requests(Ok(())).await;
+        middleware.make_requests(Ok(())).await;
+        // 3 calls are expected because the credential starts out being one
+        // second past expiry, then the second of expiry, then has one
+        // second until expiry, so it doesn't need to be refreshed.
+        assert_eq!(count.load(std::sync::atomic::Ordering::SeqCst), 3);
+    }
+
+    #[xmtp_common::test]
+    async fn test_auth_middleware_with_callback_and_handle() {
+        let cred = credential(-1);
+        let count = Arc::new(std::sync::atomic::AtomicI64::new(0));
+        let auth_handle = AuthHandle::new();
+        let callback = TestCallback::new(cred.clone(), count.clone());
+        let mut middleware = AuthMiddleware::new(
+            TestClient::new(Some(cred.clone())),
+            Some(Arc::new(callback)),
+            Some(auth_handle.clone()),
+        );
+        middleware.make_requests(Ok(())).await;
+        middleware.make_requests(Ok(())).await;
+        middleware.make_requests(Ok(())).await;
+        assert_eq!(count.load(std::sync::atomic::Ordering::SeqCst), 3);
+        let handle_credential = credential(1);
+        auth_handle.set(handle_credential.clone()).await;
+        middleware.inner.expected_credential = Some(handle_credential.clone());
+        middleware.make_requests(Ok(())).await;
+        assert_eq!(count.load(std::sync::atomic::Ordering::SeqCst), 3);
+        auth_handle.set(cred.clone()).await;
+        middleware.inner.expected_credential = Some(cred.clone());
+        middleware.make_requests(Ok(())).await;
+        middleware.make_requests(Ok(())).await;
+        middleware.make_requests(Ok(())).await;
+        assert_eq!(count.load(std::sync::atomic::Ordering::SeqCst), 4);
+    }
+
+    #[xmtp_common::test]
+    async fn test_auth_middleware_with_callback_and_handle_concurrent_requests() {
+        let cred = credential(-1);
+        let count = Arc::new(std::sync::atomic::AtomicI64::new(0));
+        let auth_handle = AuthHandle::new();
+        let mut middlewares = vec![];
+        for _ in 0..10 {
+            let middleware = AuthMiddleware::new(
+                TestClient::new(Some(cred.clone())),
+                Some(Arc::new(TestCallback::new(cred.clone(), count.clone()))),
+                Some(auth_handle.clone()),
+            );
+            middlewares.push(middleware);
+        }
+
+        let mut tasks = middlewares
+            .iter()
+            .map(|middleware| async {
+                middleware.make_requests(Ok(())).await;
+                middleware.make_requests(Ok(())).await;
+                middleware.make_requests(Ok(())).await;
+            })
+            .collect::<futures::stream::FuturesUnordered<_>>();
+
+        while let Some(task) = tasks.next().await {
+            let () = task;
+        }
+        assert_eq!(count.load(std::sync::atomic::Ordering::SeqCst), 3);
+    }
+}

--- a/xmtp_api_d14n/src/middleware/mod.rs
+++ b/xmtp_api_d14n/src/middleware/mod.rs
@@ -1,3 +1,6 @@
+mod auth;
+pub use auth::{AuthCallback, AuthHandle, AuthMiddleware, Credential};
+
 mod multi_node_client;
 pub use multi_node_client::{
     MultiNodeClient, MultiNodeClientBuilder, MultiNodeClientBuilderError, MultiNodeClientError,

--- a/xmtp_proto/src/traits/boxed_client.rs
+++ b/xmtp_proto/src/traits/boxed_client.rs
@@ -38,11 +38,7 @@ pub trait BoxClientT<Err>:
 }
 
 impl<T, Err> BoxClientT<Err> for T where
-    T: ?Sized
-        + MaybeSend
-        + MaybeSync
-        + IsConnectedCheck
-        + Client<Error = Err, Stream = BoxedStreamT<Err>>
+    T: ?Sized + IsConnectedCheck + Client<Error = Err, Stream = BoxedStreamT<Err>>
 {
 }
 
@@ -101,7 +97,7 @@ where
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<T> IsConnectedCheck for BoxedClient<T>
 where
-    T: ?Sized + MaybeSend + MaybeSync + IsConnectedCheck,
+    T: ?Sized + IsConnectedCheck,
 {
     /// Check if a client is connected
     async fn is_connected(&self) -> bool {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add auth callback middleware to wrap the gateway client and inject `Authorization` headers with expiry refresh in `xmtp_api_d14n`
Introduce `AuthMiddleware<C>` with `AuthCallback`, `AuthHandle`, and `Credential` to attach and refresh auth headers; wire this into `ClientBundleBuilder::build` to wrap the gateway client when auth options are provided; add `if_not_test` macro and adjust `ReadWriteClient` connectivity to run checks concurrently.

#### 📍Where to Start
Start with the `AuthMiddleware<C>` flow and `AuthCallback` contract in [auth.rs](https://github.com/xmtp/libxmtp/pull/2717/files#diff-2d05c8cb8d97afc26c2e9d0c316aa4ccff7060cdaaa6a6020cd461b38dc21d60), then see how it is applied in `ClientBundleBuilder::build` in [client_bundle.rs](https://github.com/xmtp/libxmtp/pull/2717/files#diff-7d621dd69d7509f1d5e9f4acf817df6a6b43c455bdb8c64f58493a2907325c24).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized eb2dcbd.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->