### PR TITLE
auth ffi bindings

### DIFF
--- a/.github/workflows/release-wasm-bindings.yml
+++ b/.github/workflows/release-wasm-bindings.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install wasm-bindgen
         uses: taiki-e/install-action@v2
         with:
-          tool: wasm-bindgen@0.2.104
+          tool: wasm-bindgen@0.2.105
       - name: Setup node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/test-webassembly.yml
+++ b/.github/workflows/test-webassembly.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install wasm-bindgen
         uses: taiki-e/install-action@v2
         with:
-          tool: wasm-bindgen@0.2.104
+          tool: wasm-bindgen@0.2.105
       - name: Cache
         uses: Swatinem/rust-cache@v2
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1215,6 +1215,8 @@ dependencies = [
 name = "bindings_node"
 version = "1.7.0-dev"
 dependencies = [
+ "async-trait",
+ "bindings_node",
  "chrono",
  "const-hex",
  "futures",
@@ -1245,6 +1247,7 @@ name = "bindings_wasm"
 version = "1.7.0-dev"
 dependencies = [
  "alloy",
+ "async-trait",
  "chrono",
  "console_error_panic_hook",
  "const-hex",
@@ -1727,7 +1730,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3312,7 +3315,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -3630,9 +3633,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.81"
+version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
+checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -5175,7 +5178,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -5258,7 +5261,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "thiserror 2.0.16",
  "tokio",
  "tracing",
@@ -5295,9 +5298,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7789,9 +7792,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.104"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
+checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -7801,24 +7804,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
- "wasm-bindgen-shared",
-]
-
-[[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.54"
+version = "0.4.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e038d41e478cc73bae0ff9b36c60cff1c98b8f38f8d7e8061e79ee63608ac5c"
+checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -7829,9 +7818,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.104"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
+checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7839,31 +7828,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.104"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
+checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.104"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
+checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e381134e148c1062f965a42ed1f5ee933eef2927c3f70d1812158f711d39865"
+checksum = "bfc379bfb624eb59050b509c13e77b4eb53150c350db69628141abce842f2373"
 dependencies = [
  "js-sys",
  "minicov",
@@ -7874,9 +7863,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b673bca3298fe582aeef8352330ecbad91849f85090805582400850f8270a2e8"
+checksum = "085b2df989e1e6f9620c1311df6c996e83fe16f57792b272ce1e024ac16a90f1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7912,9 +7901,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.81"
+version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
+checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,7 +144,7 @@ url = "2.5.0"
 uuid = "1.12"
 vergen-git2 = "1.0.2"
 # Any changes here need to be made with corresponding changes in .github/workflows
-wasm-bindgen = "=0.2.104"
+wasm-bindgen = "=0.2.105"
 wasm-bindgen-futures = "0.4.51"
 wasm-bindgen-test = "0.3.51"
 web-sys = "0.3"

--- a/bindings_ffi/Cargo.toml
+++ b/bindings_ffi/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 crate-type = ["lib", "cdylib", "staticlib"]
 
 [dependencies]
+async-trait.workspace = true
 chrono.workspace = true
 futures.workspace = true
 hex.workspace = true

--- a/bindings_ffi/src/inbox_owner.rs
+++ b/bindings_ffi/src/inbox_owner.rs
@@ -1,4 +1,5 @@
 use crate::identity::FfiIdentifier;
+use xmtp_common::{MaybeSend, MaybeSync};
 use xmtp_cryptography::signature::{IdentifierValidationError, SignatureError};
 use xmtp_id::associations::{
     Identifier,
@@ -26,7 +27,7 @@ impl From<uniffi::UnexpectedUniFFICallbackError> for SigningError {
 
 // A simplified InboxOwner passed to Rust across the FFI boundary
 #[uniffi::export(with_foreign)]
-pub trait FfiInboxOwner: Send + Sync {
+pub trait FfiInboxOwner: MaybeSend + MaybeSync {
     fn get_identifier(&self) -> Result<FfiIdentifier, IdentityValidationError>;
     fn sign(&self, text: String) -> Result<Vec<u8>, SigningError>;
 }

--- a/bindings_ffi/src/lib.rs
+++ b/bindings_ffi/src/lib.rs
@@ -42,7 +42,7 @@ pub enum GenericError {
     GroupMutablePermissions(
         #[from] xmtp_mls::groups::group_permissions::GroupMutablePermissionsError,
     ),
-    #[error("Generic {err}")]
+    #[error("{err}")]
     Generic { err: String },
     #[error(transparent)]
     SignatureRequestError(#[from] xmtp_id::associations::builder::SignatureRequestError),
@@ -80,6 +80,13 @@ pub enum GenericError {
     Expired(#[from] Expired),
     #[error(transparent)]
     BackendBuilder(#[from] MessageBackendBuilderError),
+}
+
+// this impl allows us to gracefully handle unexpected errors from foreign code without panicking
+impl From<uniffi::UnexpectedUniFFICallbackError> for GenericError {
+    fn from(e: uniffi::UnexpectedUniFFICallbackError) -> Self {
+        Self::Generic { err: e.to_string() }
+    }
 }
 
 #[derive(uniffi::Error, thiserror::Error, Debug)]

--- a/bindings_ffi/src/mls/gateway_auth.rs
+++ b/bindings_ffi/src/mls/gateway_auth.rs
@@ -1,0 +1,88 @@
+use xmtp_api_d14n::AuthHandle;
+use xmtp_common::BoxDynError;
+
+use crate::GenericError;
+use std::sync::Arc;
+
+#[derive(uniffi::Record)]
+pub struct FfiCredential {
+    name: Option<String>,
+    value: String,
+    expires_at_seconds: i64,
+}
+
+#[derive(uniffi::Object, Clone, Default)]
+pub struct FfiAuthHandle {
+    handle: AuthHandle,
+}
+
+#[uniffi::export(async_runtime = "tokio")]
+impl FfiAuthHandle {
+    #[uniffi::constructor]
+    pub fn new() -> Self {
+        Self {
+            handle: AuthHandle::new(),
+        }
+    }
+    pub async fn set(&self, credential: FfiCredential) -> Result<(), GenericError> {
+        let credential = credential.try_into()?;
+        self.handle.set(credential).await;
+        Ok(())
+    }
+    pub fn id(&self) -> u64 {
+        self.handle.id() as u64
+    }
+}
+
+impl From<FfiAuthHandle> for xmtp_api_d14n::AuthHandle {
+    fn from(handle: FfiAuthHandle) -> Self {
+        handle.handle
+    }
+}
+
+#[uniffi::export(with_foreign)]
+#[async_trait::async_trait]
+pub trait FfiAuthCallback: Send + Sync + 'static {
+    async fn on_auth_required(&self) -> Result<FfiCredential, GenericError>;
+}
+
+impl TryFrom<FfiCredential> for xmtp_api_d14n::Credential {
+    type Error = GenericError;
+    fn try_from(ffi_auth: FfiCredential) -> Result<Self, Self::Error> {
+        let credential = xmtp_api_d14n::Credential::new(
+            ffi_auth
+                .name
+                .map(|n| {
+                    n.as_str().try_into().map_err(|_| GenericError::Generic {
+                        err: format!("Invalid header name for credential: {n}"),
+                    })
+                })
+                .transpose()?,
+            (&ffi_auth.value)
+                .try_into()
+                .map_err(|_| GenericError::Generic {
+                    err: "Invalid header value for credential".into(),
+                })?,
+            ffi_auth.expires_at_seconds,
+        );
+        Ok(credential)
+    }
+}
+
+pub(crate) struct FfiAuthCallbackBridge {
+    callback: Arc<dyn FfiAuthCallback>,
+}
+
+impl FfiAuthCallbackBridge {
+    pub fn new(callback: Arc<dyn FfiAuthCallback>) -> Self {
+        Self { callback }
+    }
+}
+
+#[async_trait::async_trait]
+impl xmtp_api_d14n::AuthCallback for FfiAuthCallbackBridge {
+    async fn on_auth_required(&self) -> Result<xmtp_api_d14n::Credential, BoxDynError> {
+        let ffi_auth = self.callback.on_auth_required().await?;
+        ffi_auth.try_into().map_err(Into::into)
+    }
+}

--- a/bindings_ffi/src/mls/test_utils.rs
+++ b/bindings_ffi/src/mls/test_utils.rs
@@ -154,11 +154,13 @@ pub async fn connect_to_backend_test() -> Arc<super::XmtpApiClient> {
             Some(GrpcUrls::GATEWAY.to_string()),
             false,
             None,
+            None,
+            None,
         )
         .await
         .unwrap()
     } else {
-        connect_to_backend(GrpcUrls::NODE.to_string(), None, false, None)
+        connect_to_backend(GrpcUrls::NODE.to_string(), None, false, None, None, None)
             .await
             .unwrap()
     }

--- a/bindings_ffi/src/mls/tests/networking.rs
+++ b/bindings_ffi/src/mls/tests/networking.rs
@@ -223,9 +223,16 @@ async fn test_is_connected_after_connect() {
 
     assert!(connected, "Expected API client to report as connected");
 
-    let api = connect_to_backend("http://127.0.0.1:59999".to_string(), None, false, None)
-        .await
-        .unwrap();
+    let api = connect_to_backend(
+        "http://127.0.0.1:59999".to_string(),
+        None,
+        false,
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
     let backend = MessageBackendBuilder::default()
         .from_bundle(api.0.clone())
         .unwrap();

--- a/bindings_node/Cargo.toml
+++ b/bindings_node/Cargo.toml
@@ -10,9 +10,11 @@ workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
+async-trait.workspace = true
 chrono = { workspace = true, features = ["serde"] }
 futures.workspace = true
 hex.workspace = true
+# Default enable napi4 feature, see https://nodejs.org/api/n-api.html#node-api-version-matrix
 napi = { version = "3.4.0", default-features = false, features = [
   "napi6",
   "async",
@@ -37,9 +39,9 @@ xmtp_cryptography.workspace = true
 xmtp_db.workspace = true
 xmtp_id.workspace = true
 xmtp_mls.workspace = true
-xmtp_proto = { workspace = true, features = [] }
+xmtp_proto.workspace = true
 
-toxiproxy_rust = { workspace = true, optional = true }
+# For some reason these don't work when added as dev-dependencies
 xmtp_api_grpc = { workspace = true, optional = true }
 xmtp_configuration = { workspace = true, optional = true }
 
@@ -47,20 +49,19 @@ xmtp_configuration = { workspace = true, optional = true }
 napi-build = "2.0.1"
 
 [dev-dependencies]
-chrono = { workspace = true }
+# Add self as dev dependency to automatically enable the test-utils feature
+bindings_node = { path = ".", features = ["test-utils"] }
+chrono.workspace = true
 toxiproxy_rust.workspace = true
-xmtp_api_grpc.workspace = true
-xmtp_configuration.workspace = true
-xmtp_proto = { workspace = true, features = ["test-utils"] }
 
 [package.metadata.cross.build.env]
 volumes = ["__LIB12_DEP=../"]
 
 [features]
 test-utils = [
-  "xmtp_mls/test-utils",
-  "dep:toxiproxy_rust",
-  "xmtp_proto/test-utils",
-  "dep:xmtp_configuration",
   "dep:xmtp_api_grpc",
+  "dep:xmtp_configuration",
+  "xmtp_api_grpc/test-utils",
+  "xmtp_mls/test-utils",
+  "xmtp_proto/test-utils",
 ]

--- a/bindings_node/src/client.rs
+++ b/bindings_node/src/client.rs
@@ -20,6 +20,8 @@ use xmtp_mls::identity::IdentityStrategy;
 use xmtp_mls::utils::events::upload_debug_archive;
 use xmtp_proto::api_client::AggregateStats;
 
+mod gateway_auth;
+
 pub type RustXmtpClient = MlsClient<xmtp_mls::MlsContext>;
 pub type RustMlsGroup = MlsGroup<xmtp_mls::MlsContext>;
 static LOGGER_INIT: std::sync::OnceLock<Result<()>> = std::sync::OnceLock::new();
@@ -166,6 +168,8 @@ pub async fn create_client(
   disable_events: Option<bool>,
   app_version: Option<String>,
   nonce: Option<BigInt>,
+  auth_callback: Option<&gateway_auth::FfiAuthCallback>,
+  auth_handle: Option<&gateway_auth::FfiAuthHandle>,
 ) -> Result<Client> {
   let root_identifier = account_identifier.clone();
   init_logging(log_options.unwrap_or_default())?;
@@ -173,6 +177,8 @@ pub async fn create_client(
   backend
     .v3_host(&v3_host)
     .maybe_gateway_host(gateway_host)
+    .maybe_auth_callback(auth_callback.map(|c| Arc::new(c.clone()) as _))
+    .maybe_auth_handle(auth_handle.map(|h| h.clone().into()))
     .app_version(app_version.clone().unwrap_or_default())
     .is_secure(is_secure);
 

--- a/bindings_node/src/client/gateway_auth.rs
+++ b/bindings_node/src/client/gateway_auth.rs
@@ -1,0 +1,95 @@
+use std::sync::Arc;
+
+use napi::{bindgen_prelude::Promise, threadsafe_function::ThreadsafeFunction};
+use napi_derive::napi;
+use xmtp_common::BoxDynError;
+
+#[napi(object, constructor)]
+pub struct FfiCredential {
+  pub name: Option<String>,
+  pub value: String,
+  pub expires_at_seconds: i64,
+}
+
+impl TryFrom<FfiCredential> for xmtp_api_d14n::Credential {
+  type Error = super::Error;
+  fn try_from(credential: FfiCredential) -> Result<Self, Self::Error> {
+    Ok(xmtp_api_d14n::Credential::new(
+      credential
+        .name
+        .map(|n| n.try_into())
+        .transpose()
+        .map_err(|_| {
+          super::Error::new(
+            napi::Status::InvalidArg,
+            "Invalid header name for credential",
+          )
+        })?,
+      credential.value.try_into().map_err(|_| {
+        super::Error::new(
+          napi::Status::InvalidArg,
+          "Invalid header value for credential",
+        )
+      })?,
+      credential.expires_at_seconds,
+    ))
+  }
+}
+
+#[napi]
+#[derive(Default, Clone)]
+pub struct FfiAuthHandle {
+  handle: xmtp_api_d14n::AuthHandle,
+}
+
+#[napi]
+impl FfiAuthHandle {
+  #[napi(constructor)]
+  pub fn new() -> Self {
+    Self {
+      handle: xmtp_api_d14n::AuthHandle::new(),
+    }
+  }
+
+  #[napi]
+  pub async fn set(&self, credential: FfiCredential) -> Result<(), super::Error> {
+    self.handle.set(credential.try_into()?).await;
+    Ok(())
+  }
+
+  #[napi]
+  pub fn id(&self) -> usize {
+    self.handle.id()
+  }
+}
+
+impl From<FfiAuthHandle> for xmtp_api_d14n::AuthHandle {
+  fn from(handle: FfiAuthHandle) -> Self {
+    handle.handle
+  }
+}
+
+#[napi]
+#[derive(Clone)]
+pub struct FfiAuthCallback {
+  callback: Arc<ThreadsafeFunction<(), Promise<FfiCredential>>>,
+}
+
+#[napi]
+impl FfiAuthCallback {
+  #[napi(constructor, ts_args_type = "callback: () => Promise<FfiCredential>")]
+  pub fn new(callback: ThreadsafeFunction<(), Promise<FfiCredential>>) -> Self {
+    Self {
+      callback: Arc::new(callback),
+    }
+  }
+}
+
+#[async_trait::async_trait]
+impl xmtp_api_d14n::AuthCallback for FfiAuthCallback {
+  async fn on_auth_required(&self) -> Result<xmtp_api_d14n::Credential, BoxDynError> {
+    let promise = self.callback.call_async(Ok(())).await?;
+    let credential = promise.await?;
+    Ok(credential.try_into()?)
+  }
+}

--- a/bindings_node/src/lib.rs
+++ b/bindings_node/src/lib.rs
@@ -15,8 +15,9 @@ mod message;
 mod permissions;
 mod signatures;
 mod streams;
-#[cfg(any(test, feature = "test-utils"))]
-pub mod test_utils;
+xmtp_common::if_test! {
+  pub mod test_utils;
+}
 
 use napi::bindgen_prelude::Error;
 

--- a/bindings_node/src/test_utils.rs
+++ b/bindings_node/src/test_utils.rs
@@ -47,6 +47,8 @@ pub async fn create_local_toxic_client(
     disable_events,
     None,
     None,
+    None,
+    None,
   )
   .await?;
   Ok(TestClient { inner: c, proxy })

--- a/bindings_wasm/Cargo.toml
+++ b/bindings_wasm/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+async-trait.workspace = true
 chrono.workspace = true
 console_error_panic_hook.workspace = true
 futures.workspace = true

--- a/bindings_wasm/src/client.rs
+++ b/bindings_wasm/src/client.rs
@@ -25,6 +25,8 @@ use crate::inbox_state::InboxState;
 pub type RustXmtpClient = MlsClient<xmtp_mls::MlsContext>;
 pub type RustMlsGroup = MlsGroup<xmtp_mls::MlsContext>;
 
+pub mod gateway_auth;
+
 #[wasm_bindgen]
 pub struct Client {
   account_identifier: Identifier,
@@ -180,14 +182,21 @@ pub async fn create_client(
   app_version: Option<String>,
   gateway_host: Option<String>,
   nonce: Option<u64>,
+  auth_callback: Option<gateway_auth::AuthCallback>,
+  auth_handle: Option<gateway_auth::AuthHandle>,
 ) -> Result<Client, JsError> {
   init_logging(log_options.unwrap_or_default())?;
+  tracing::info!(host, gateway_host, "Creating client in rust");
   let mut backend = MessageBackendBuilder::default();
+  let is_secure =
+    host.starts_with("https") && gateway_host.as_ref().is_none_or(|h| h.starts_with("https"));
   backend
     .v3_host(&host)
     .maybe_gateway_host(gateway_host)
     .app_version(app_version.clone().unwrap_or_default())
-    .is_secure(true);
+    .is_secure(is_secure)
+    .maybe_auth_callback(auth_callback.map(|c| Arc::new(c) as _))
+    .maybe_auth_handle(auth_handle.map(|h| h.handle));
 
   let storage_option = match db_path {
     Some(path) => StorageOption::Persistent(path),

--- a/bindings_wasm/src/client/gateway_auth.rs
+++ b/bindings_wasm/src/client/gateway_auth.rs
@@ -1,0 +1,88 @@
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::*;
+use xmtp_common::BoxDynError;
+
+#[wasm_bindgen]
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Credential {
+  name: Option<String>,
+  value: String,
+  expires_at_seconds: i64,
+}
+
+#[wasm_bindgen]
+impl Credential {
+  #[wasm_bindgen(constructor)]
+  pub fn new(name: Option<String>, value: String, expires_at_seconds: i64) -> Self {
+    Self {
+      name,
+      value,
+      expires_at_seconds,
+    }
+  }
+}
+
+impl TryFrom<Credential> for xmtp_api_d14n::Credential {
+  type Error = BoxDynError;
+  fn try_from(credential: Credential) -> Result<Self, Self::Error> {
+    Ok(xmtp_api_d14n::Credential::new(
+      credential.name.map(|n| n.try_into()).transpose()?,
+      credential.value.try_into()?,
+      credential.expires_at_seconds,
+    ))
+  }
+}
+
+#[wasm_bindgen]
+extern "C" {
+  pub type AuthCallback;
+
+  #[wasm_bindgen(catch, method)]
+  pub async fn on_auth_required(this: &AuthCallback) -> Result<JsValue, JsValue>;
+}
+
+#[async_trait::async_trait(?Send)]
+impl xmtp_api_d14n::AuthCallback for AuthCallback {
+  async fn on_auth_required(&self) -> Result<xmtp_api_d14n::Credential, BoxDynError> {
+    let cred: JsValue = self.on_auth_required().await.map_err(|e| {
+      let result = serde_wasm_bindgen::from_value::<serde_json::Value>(e);
+      if let Ok(value) = result {
+        let is_empty = value.is_null()
+          || (value.is_object() && value.as_object().unwrap().is_empty())
+          || (value.is_array() && value.as_array().unwrap().is_empty());
+        if !is_empty {
+          return format!("Auth callback failed: {value}");
+        }
+      }
+      "Auth callback failed with unknown error".to_string()
+    })?;
+    let cred: Credential = serde_wasm_bindgen::from_value(cred)
+      .map_err(|e| format!("Failed to parse credential from auth callback: {e}"))?;
+    Ok(cred.try_into()?)
+  }
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Default)]
+pub struct AuthHandle {
+  pub(crate) handle: xmtp_api_d14n::AuthHandle,
+}
+
+#[wasm_bindgen]
+impl AuthHandle {
+  #[wasm_bindgen(constructor)]
+  pub fn new() -> Self {
+    Self {
+      handle: xmtp_api_d14n::AuthHandle::new(),
+    }
+  }
+  pub async fn set(&self, credential: Credential) -> Result<(), JsError> {
+    let cred =
+      xmtp_api_d14n::Credential::try_from(credential).map_err(|e| JsError::new(&e.to_string()))?;
+    self.handle.set(cred).await;
+    Ok(())
+  }
+  pub fn id(&self) -> usize {
+    self.handle.id()
+  }
+}

--- a/bindings_wasm/src/tests/mod.rs
+++ b/bindings_wasm/src/tests/mod.rs
@@ -1,6 +1,7 @@
 mod web;
 
 use crate::client::LogLevel;
+use crate::client::gateway_auth::{AuthCallback, AuthHandle};
 use crate::client::{Client, LogOptions, create_client};
 use crate::inbox_id::generate_inbox_id;
 use alloy::signers::SignerSync;
@@ -36,6 +37,8 @@ pub async fn create_test_client(path: Option<String>) -> Client {
     None,
     None,
     None,
+    None,
+    None,
   )
   .await
   .unwrap();
@@ -48,4 +51,48 @@ pub async fn create_test_client(path: Option<String>) -> Client {
     .unwrap();
   client.register_identity(request).await.unwrap();
   client
+}
+
+#[wasm_bindgen(js_name = createAuthTestClient)]
+pub async fn create_auth_test_client(
+  auth_callback: Option<AuthCallback>,
+  auth_handle: Option<AuthHandle>,
+) -> Result<Client, JsError> {
+  // crate::opfs::Opfs::wipe_files().await.unwrap();
+  let wallet = generate_local_wallet();
+  let account_address = wallet.get_identifier().unwrap_throw();
+  let host = GrpcUrls::NODE.to_string();
+  let inbox_id = generate_inbox_id(account_address.clone().into(), None);
+  let mut client = create_client(
+    host.clone(),
+    inbox_id.unwrap(),
+    account_address.into(),
+    None,
+    None,
+    None,
+    Some(crate::client::DeviceSyncWorkerMode::Disabled),
+    Some(LogOptions {
+      structured: false,
+      performance: true,
+      level: Some(LogLevel::Trace),
+    }),
+    None,
+    None,
+    None,
+    Some(GrpcUrls::GATEWAY.to_string()),
+    None,
+    auth_callback,
+    auth_handle,
+  )
+  .await?;
+  let request = client
+    .create_inbox_signature_request()?
+    .ok_or(JsError::new("Failed to create inbox signature request"))?;
+  let text = request.signature_text().await?;
+  let signature = wallet.sign_message_sync(text.as_bytes())?;
+  request
+    .add_ecdsa_signature(Uint8Array::from(signature.as_bytes().as_slice()))
+    .await?;
+  client.register_identity(request).await?;
+  Ok(client)
 }

--- a/xmtp_api_d14n/src/middleware/auth.rs
+++ b/xmtp_api_d14n/src/middleware/auth.rs
@@ -5,14 +5,12 @@ use tokio::sync::OnceCell;
 use xmtp_common::{BoxDynError, MaybeSend, MaybeSync};
 use xmtp_proto::api::{ApiClientError, Client, IsConnectedCheck};
 
-xmtp_common::if_not_test! {
-    use xmtp_common::time::now_secs;
-}
-// override now so we don't ahve flaky tests
-xmtp_common::if_test! {
-    fn now_secs() -> i64 {
-        1_000_000
-    }
+#[cfg(not(test))]
+use xmtp_common::time::now_secs;
+// override now_secs so we don't have flaky tests
+#[cfg(test)]
+fn now_secs() -> i64 {
+    1_000_000
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -348,7 +346,7 @@ mod tests {
             credential.expires_at_seconds += count;
             xmtp_common::time::sleep(std::time::Duration::from_millis(10)).await;
             tracing::debug!("credential: {credential:?}, {}, {count}", now_secs());
-            Ok(credential.clone())
+            Ok(credential)
         }
     }
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add gateway auth FFI bindings and update Node/WASM clients to accept `auth_callback` and `auth_handle` for backend connection
Introduce FFI types and bridges for gateway authentication across Rust, Node, and WASM clients; extend `bindings_ffi::mls::connect_to_backend`, `bindings_node::client::create_client`, and `bindings_wasm::client::create_client` to accept optional `auth_callback` and `auth_handle`; convert unexpected UniFFI callback errors into `GenericError`; relax `FfiInboxOwner` bounds to `MaybeSend`/`MaybeSync`; add browser and wasm tests for auth flows; and bump `wasm-bindgen` to `0.2.105`.

#### 📍Where to Start
Start with the gateway auth FFI surface in [bindings_ffi/src/mls/gateway_auth.rs](https://github.com/xmtp/libxmtp/pull/2718/files#diff-1b8321c9f1800f27e80e9580be5e94cc7086add5b5964a3e23b6fd07d7493bb3), then follow its use in `bindings_ffi::mls::connect_to_backend` in [bindings_ffi/src/mls.rs](https://github.com/xmtp/libxmtp/pull/2718/files#diff-3a24c3e76565487a710ac9863ac05160128f4f90892e07849b555a6de43a6e8f), `bindings_node::client::create_client` in [bindings_node/src/client.rs](https://github.com/xmtp/libxmtp/pull/2718/files#diff-98dd73d0e8b1dce0a25de3ddbda3a0122baec850f3b6ccbdca525c3370f80f1d), and `bindings_wasm::client::create_client` in [bindings_wasm/src/client.rs](https://github.com/xmtp/libxmtp/pull/2718/files#diff-4018d4ef72f833b0f071571f93f20e715915d188d98ce9fcd18f7182e111a259).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized b456131.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->