### PR TITLE
repro xmtp-node-go segfault with `cargo nextest run`

### DIFF
--- a/xmtp_api_d14n/q
+++ b/xmtp_api_d14n/q
@@ -1,0 +1,17 @@
+[38;5;3mModified regular file ../xmtp_mls/src/utils/test/tester_utils.rs:[39m
+    ...
+[38;5;1m 211[39m [38;5;2m 211[39m:             client = client.temp_store().await;
+[38;5;1m 212[39m [38;5;2m 212[39m:         }
+[38;5;1m 213[39m [38;5;2m 213[39m: 
+[38;5;1m 214[39m [38;5;2m 214[39m:         let [4m[38;5;1mf[38;5;2m(mut local_client, mut sync_api_client)[24m[39m = match self.api_endpoint {
+[38;5;1m 215[39m [38;5;2m 215[39m:             ApiEndpoint::Local => [4m[38;5;2m([24m[39mTestClient::create_local[4m[38;5;2m(), TestClient::create_local())[24m[39m,
+[38;5;1m 216[39m [38;5;2m 216[39m:             ApiEndpoint::Dev => [4m[38;5;2m([24m[39mTestClient::create_dev[4m[38;5;2m(), TestClient::create_dev())[24m[39m,
+[38;5;1m 217[39m [38;5;2m 217[39m:         };
+[38;5;1m 218[39m     : [4m[38;5;1m        let store = Arc::new(SqliteCursorStore::new(client.store.as_ref().unwrap().db()));[24m[39m
+[38;5;1m 219[39m     : [4m[38;5;1m        let mut local_client = TestClient::with_cursor_store(f, store.clone());[24m[39m
+[38;5;1m 220[39m     : [4m[38;5;1m        let mut sync_api_client = TestClient::with_cursor_store(f, store);[24m[39m
+[38;5;1m 221[39m     : [4m[38;5;1m[24m[39m
+[38;5;1m 222[39m [38;5;2m 218[39m:         let mut proxy = None;
+[38;5;1m 223[39m [38;5;2m 219[39m:         if self.proxy {
+[38;5;1m 224[39m [38;5;2m 220[39m:             proxy = Some(local_client.with_toxiproxy().await);
+    ...

--- a/xmtp_mls/src/utils/test/tester_utils.rs
+++ b/xmtp_mls/src/utils/test/tester_utils.rs
@@ -211,14 +211,10 @@ where
             client = client.temp_store().await;
         }
 
-        let f = match self.api_endpoint {
-            ApiEndpoint::Local => TestClient::create_local,
-            ApiEndpoint::Dev => TestClient::create_dev,
+        let (mut local_client, mut sync_api_client) = match self.api_endpoint {
+            ApiEndpoint::Local => (TestClient::create_local(), TestClient::create_local()),
+            ApiEndpoint::Dev => (TestClient::create_dev(), TestClient::create_dev()),
         };
-        let store = Arc::new(SqliteCursorStore::new(client.store.as_ref().unwrap().db()));
-        let mut local_client = TestClient::with_cursor_store(f, store.clone());
-        let mut sync_api_client = TestClient::with_cursor_store(f, store);
-
         let mut proxy = None;
         if self.proxy {
             proxy = Some(local_client.with_toxiproxy().await);


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Refactor `xmtp_mls::utils::test::tester_utils::build` to instantiate test clients directly to reproduce `xmtp-node-go` segfault with `cargo nextest run`
Replace function-pointer based client construction with direct `TestClient::create_local()` and `TestClient::create_dev()` instantiation in `xmtp_mls::utils::test::tester_utils::build`, removing shared `SqliteCursorStore` wiring; add a textual change log in [q](https://github.com/xmtp/libxmtp/pull/2727/files#diff-389c5f3af764ddc48ef263b30c7266c51a799cf9e5a245cb3f89d3592778512a).

#### 📍Where to Start
Start with the `build` function in [tester_utils.rs](https://github.com/xmtp/libxmtp/pull/2727/files#diff-727ea71bc8afdfdf6f0b1d9813b2e6e46f6fdd647abbc9b56be80bd873034c7d).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 26889d4. 1 file reviewed, 7 issues evaluated, 7 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>xmtp_mls/src/utils/test/tester_utils.rs — 0 comments posted, 7 evaluated, 7 filtered</summary>

- [line 186](https://github.com/xmtp/libxmtp/blob/26889d4f53b2e95fcb29e50303d3559ee5de7ade/xmtp_mls/src/utils/test/tester_utils.rs#L186): Potential panic: `self.owner.get_identifier().unwrap()` can panic if the owner fails to provide an identifier. Since this path is reachable when `self.name` is `Some` and `!self.installation`, this is a runtime crash scenario in tests. Consider handling the error and returning a test error instead of panicking. <b>[ Out of scope ]</b>
- [line 204](https://github.com/xmtp/libxmtp/blob/26889d4f53b2e95fcb29e50303d3559ee5de7ade/xmtp_mls/src/utils/test/tester_utils.rs#L204): Potential panic: `raw_query_write(...).unwrap()` can panic when deserializing a snapshot into the database. This path is reachable when `self.snapshot` is `Some`. Errors during deserialization should be handled and propagated to avoid crashing. <b>[ Out of scope ]</b>
- [line 214](https://github.com/xmtp/libxmtp/blob/26889d4f53b2e95fcb29e50303d3559ee5de7ade/xmtp_mls/src/utils/test/tester_utils.rs#L214): Behavioral contract change: the diff removed injection of a persistent `SqliteCursorStore` into both the local and sync API client builders and no longer sets any cursor store unless `self.in_memory_cursors` is true. This changes externally visible behavior for tests relying on persisted cursors (e.g., lowest common cursor calculations, stream resumption). With `Option<CursorStore>` implemented to fallback to `NoCursorStore`, tests may now run without cursor persistence, causing different message streaming and cursor semantics. Either restore a default persistent cursor store or document the change and update tests accordingly. <b>[ Test / Mock code ]</b>
- [line 221](https://github.com/xmtp/libxmtp/blob/26889d4f53b2e95fcb29e50303d3559ee5de7ade/xmtp_mls/src/utils/test/tester_utils.rs#L221): Potential panic: `local_client.host().unwrap()` can panic if the API builder’s host is not set. This path is reachable when `self.proxy` is true. Replace with proper error handling (e.g., return an error if host is `None`) to avoid crashing tests. <b>[ Out of scope ]</b>
- [line 246](https://github.com/xmtp/libxmtp/blob/26889d4f53b2e95fcb29e50303d3559ee5de7ade/xmtp_mls/src/utils/test/tester_utils.rs#L246): Potential panic: `client.default_mls_store().unwrap().build().await.unwrap()` can panic either on failure to create the default MLS store or to build the client. Both error cases are reachable under misconfiguration or resource failure (e.g., DB errors). Propagate errors instead of panicking. <b>[ Out of scope ]</b>
- [line 263](https://github.com/xmtp/libxmtp/blob/26889d4f53b2e95fcb29e50303d3559ee5de7ade/xmtp_mls/src/utils/test/tester_utils.rs#L263): Potential panic: `worker.wait_for_init().await.unwrap()` can panic if worker initialization fails. This path is reachable when `self.wait_for_init` is true and sync metrics are available. Proper error handling should be used to avoid crashing tests. <b>[ Out of scope ]</b>
- [line 265](https://github.com/xmtp/libxmtp/blob/26889d4f53b2e95fcb29e50303d3559ee5de7ade/xmtp_mls/src/utils/test/tester_utils.rs#L265): Error silently ignored: `client.sync_welcomes().await;` discards the `Result` and any error, potentially leaving the test client in an unsynced or inconsistent state without a visible outcome. At minimum, log the error and/or propagate it to the caller so that the test has defined behavior on failure. <b>[ Out of scope ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->