### PR TITLE
Worker interval tweaks

### DIFF
--- a/xmtp_mls/src/groups/commit_log.rs
+++ b/xmtp_mls/src/groups/commit_log.rs
@@ -215,7 +215,7 @@ where
     async fn run(&mut self) -> Result<(), CommitLogError> {
         let mut worker_interval = DEFAULT_INTERVAL_DURATION;
         if let Some(interval) = self.context.fork_recovery_opts().worker_interval_ns {
-            worker_interval = Duration::from_nanos(interval);
+            worker_interval = Duration::from_nanos(interval).max(Duration::from_secs(2));
         }
         let mut intervals = xmtp_common::time::interval_stream(worker_interval);
         while (intervals.next().await).is_some() {
@@ -682,7 +682,7 @@ where
         Ok(())
     }
 
-    /// Send readd requests for all forked conversations  
+    /// Send readd requests for all forked conversations
     async fn send_outgoing_readd_requests(&mut self) -> Result<(), CommitLogError> {
         if self.context.fork_recovery_opts().enable_recovery_requests == ForkRecoveryPolicy::None {
             return Ok(());

--- a/xmtp_mls/src/groups/pending_self_remove_worker.rs
+++ b/xmtp_mls/src/groups/pending_self_remove_worker.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 use xmtp_db::{StorageError, prelude::*};
 
 /// Interval at which the PendingSelfRemoveWorker runs to remove the members want requested SelfRemove.
-pub const INTERVAL_DURATION: Duration = Duration::from_secs(1);
+pub const INTERVAL_DURATION: Duration = Duration::from_secs(2);
 
 #[derive(Debug, Error)]
 pub enum PendingSelfRemoveWorkerError {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Enforce a 2-second minimum tick interval for `xmtp_mls::groups::CommitLogWorker::run` and change `xmtp_mls::groups::pending_self_remove_worker::INTERVAL_DURATION` to 2 seconds to tweak worker intervals
Set the commit log worker’s derived interval to at least 2 seconds in [xmtp_mls/src/groups/commit_log.rs](https://github.com/xmtp/libxmtp/pull/2728/files#diff-c25dc4d36a6249375b1001e9c4b66e50034909d2fc05025a45476e115429dc3a) and update the pending self-remove worker’s `INTERVAL_DURATION` constant to 2 seconds in [xmtp_mls/src/groups/pending_self_remove_worker.rs](https://github.com/xmtp/libxmtp/pull/2728/files#diff-43bcc9597a35d2a8e7e3c031e1407266941aff569a722c56ca2713f1318eab49).

#### 📍Where to Start
Start with the interval selection in `xmtp_mls::groups::CommitLogWorker::run` in [xmtp_mls/src/groups/commit_log.rs](https://github.com/xmtp/libxmtp/pull/2728/files#diff-c25dc4d36a6249375b1001e9c4b66e50034909d2fc05025a45476e115429dc3a), then review the `INTERVAL_DURATION` change in [xmtp_mls/src/groups/pending_self_remove_worker.rs](https://github.com/xmtp/libxmtp/pull/2728/files#diff-43bcc9597a35d2a8e7e3c031e1407266941aff569a722c56ca2713f1318eab49).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 79a0e36. 2 files reviewed, 1 issue evaluated, 1 issue filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>xmtp_mls/src/groups/commit_log.rs — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 733](https://github.com/xmtp/libxmtp/blob/79a0e366c99046939604db7c3404411fb6ecd37f/xmtp_mls/src/groups/commit_log.rs#L733): `send_outgoing_readd_requests` always returns `Ok(())` even when `request_readd` fails for one or more groups. Errors from `request_readd` are logged and then silently ignored (`continue`), and the function completes with `Ok(())`. This can mislead callers into believing all readd requests were successfully sent and processed when, in fact, some or all may have failed. If best-effort behavior is intended, the function’s return type and contract should reflect that (e.g., return a summary of successes/failures or change the signature to not use `Result`). Otherwise, propagate errors (e.g., return `Err` if any `request_readd` call fails, or accumulate and return a composite error). <b>[ Out of scope ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->