### PR TITLE
remove suspected race condition in `StreamGroupMessages::add()`

### DIFF
--- a/xmtp_mls/src/subscriptions/stream_all.rs
+++ b/xmtp_mls/src/subscriptions/stream_all.rs
@@ -192,10 +192,7 @@ where
         if let Some(group) = ready!(this.conversations.poll_next(cx)) {
             let group_result = group?;
             this.messages.as_mut().add(group_result);
-
             cx.waker().wake_by_ref();
-
-            return Poll::Pending;
         }
         Poll::Pending
     }


### PR DESCRIPTION
since `add()` is external to `StreamGroupMessages`, it could be possible that we access a codepath with an incorrect state transition if the add() is lined up while processing a message

this PR removes the call to `resolve_group_additions` in `add()`. instead, all group additions are acted on at only one place, in `fn poll_next(`


I removed `skip()` because we get the same effect by just queueing the future immediately again, so that we can call next_message() in `waiting`

I don't know if using the `waker` like this is "correct". If you google it, the sentiment seems to be against using a `waker` like this. However, if we poll the underlying stream then we have to immediately act on the Poll::Ready, which becomes pretty complicated in a stream impl.

