### PR TITLE
[streams] set state on error after future process

### DIFF
--- a/xmtp_mls/src/subscriptions/process_message/factory.rs
+++ b/xmtp_mls/src/subscriptions/process_message/factory.rs
@@ -104,6 +104,7 @@ where
             msg.cursor,
             epoch,
         );
+
         group
             .process_message(msg, false)
             .instrument(tracing::debug_span!("process_message"))

--- a/xmtp_mls/src/subscriptions/stream_messages.rs
+++ b/xmtp_mls/src/subscriptions/stream_messages.rs
@@ -272,11 +272,11 @@ where
         cx: &mut std::task::Context<'_>,
     ) -> Poll<Option<Self::Item>> {
         use ProjectState::*;
-        let mut this = self.as_mut().project();
-        let state = this.state.as_mut().project();
-        match state {
+        let mut this = self.as_mut();
+        match this.as_mut().project().state.as_mut().project() {
             Waiting => {
                 tracing::trace!("stream messages in waiting state");
+                let this = self.as_mut().project();
                 if let Some(group) = this.add_queue.pop_front() {
                     self.as_mut().resolve_group_additions(group);
                     cx.waker().wake_by_ref();
@@ -315,21 +315,20 @@ where
             }
             Adding { future } => {
                 tracing::trace!("stream messages in adding state");
-                let (stream, group, cursor) = ready!(future.poll(cx))?;
-                let this = self.as_mut();
-                if let Some(c) = cursor {
-                    this.set_cursor(group.as_slice(), c)
-                };
-                let mut this = self.as_mut().project();
-                this.inner.set(stream);
-                if let Some(cursor) = this.groups.position(&group) {
-                    tracing::debug!(
-                        "added group_id={} at cursor={} to messages stream",
-                        hex::encode(&group),
-                        cursor
-                    );
+                if let Ok((stream, group, cursor)) = ready!(future.poll(cx)) {
+                    if let Some(c) = cursor {
+                        this.as_mut().set_cursor(group.as_slice(), c)
+                    };
+                    this.as_mut().project().inner.set(stream);
+                    if let Some(cursor) = this.groups.position(&group) {
+                        tracing::debug!(
+                            "added group_id={} at cursor={} to messages stream",
+                            hex::encode(&group),
+                            cursor
+                        );
+                    }
                 }
-                this.state.as_mut().set(State::Waiting);
+                this.project().state.as_mut().set(State::Waiting);
                 cx.waker().wake_by_ref();
                 Poll::Pending
             }
@@ -492,14 +491,14 @@ where
     ) -> Poll<Option<<Self as Stream>::Item>> {
         use ProjectState::*;
         if let Processing { future, .. } = self.as_mut().project().state.project() {
-            let processed = ready!(future.poll(cx))?;
+            let processed = ready!(future.poll(cx))
+                .inspect_err(|_| self.as_mut().project().state.set(State::Waiting))?;
             tracing::trace!(
                 "message @cursor=[{}] finished processing",
                 processed.tried_to_process
             );
-            let mut this = self.as_mut().project();
+            let this = self.as_mut().project();
             if let Some(msg) = processed.message {
-                this.state.set(State::Waiting);
                 this.returned.push(Cursor {
                     sequence_id: msg.sequence_id as u64,
                     originator_id: msg.originator_id as u32,
@@ -512,9 +511,9 @@ where
                     processed.tried_to_process,
                     self.returned.len()
                 );
+                self.as_mut().project().state.set(State::Waiting);
                 return Poll::Ready(Some(Ok(msg)));
             } else {
-                this.state.set(State::Waiting);
                 self.as_mut()
                     .set_cursor(processed.group_id.as_slice(), processed.next_message);
                 tracing::trace!(
@@ -523,6 +522,7 @@ where
                     processed.tried_to_process,
                     processed.next_message
                 );
+                self.as_mut().project().state.set(State::Waiting);
                 cx.waker().wake_by_ref();
                 return Poll::Pending;
             }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Set `StreamGroupMessages` state to `Waiting` on add/processing future error after future process in [stream_messages.rs](https://github.com/xmtp/libxmtp/pull/2734/files#diff-ee8c2d1c90650351a2245875b62af09f2c152c29643200276da5743cd59424e7)
Adjust error handling in `StreamGroupMessages.poll_next` to return `Poll::Pending` and set state to `Waiting` when the add future errors, and update `StreamGroupMessages.resolve_futures` to set state to `Waiting` on processing future errors while still propagating the error.

#### 📍Where to Start
Start with the `StreamGroupMessages.poll_next` implementation in [stream_messages.rs](https://github.com/xmtp/libxmtp/pull/2734/files#diff-ee8c2d1c90650351a2245875b62af09f2c152c29643200276da5743cd59424e7), then review `StreamGroupMessages.resolve_futures` in the same file.

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 17a32da. 2 files reviewed, 4 issues evaluated, 4 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>xmtp_mls/src/subscriptions/process_message/factory.rs — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 99](https://github.com/xmtp/libxmtp/blob/17a32da17c962b9d2d9fd05ed86c101f8259f429/xmtp_mls/src/subscriptions/process_message/factory.rs#L99): Potential mismanagement of a cache/lock guard: `MlsGroup::new_cached(self.0.clone(), &msg.group_id)?` returns a tuple and the code intentionally discards the second element via `(group, _)` at line 99. If the second element is a cache pin or lock guard required to maintain invariants while operating on `group`, dropping it immediately can permit concurrent mutation of the cached group state during subsequent `await` points (`group.epoch().await?` and `group.process_message(...).await`), leading to data races at the logical level, inconsistent reads, or processing against a stale/changed epoch. This violates mutual-exclusion and adjacency constraints after introducing the cached group resource and can cause subtle runtime bugs even though Rust prevents memory unsafety. The fix is to retain the guard for the duration of all operations that require the cache to remain stable (e.g., bind it to a local variable and keep it alive until after `process_message` completes). <b>[ Out of scope ]</b>
</details>

<details>
<summary>xmtp_mls/src/subscriptions/stream_messages.rs — 0 comments posted, 3 evaluated, 3 filtered</summary>

- [line 318](https://github.com/xmtp/libxmtp/blob/17a32da17c962b9d2d9fd05ed86c101f8259f429/xmtp_mls/src/subscriptions/stream_messages.rs#L318): In the `Adding` state, errors from `future.poll(cx)` are silently swallowed and the state is unconditionally transitioned back to `Waiting`. Specifically, the code `if let Ok((stream, group, cursor)) = ready!(future.poll(cx)) { ... }` handles only the `Ok` case, and regardless of whether it is `Ok` or `Err`, the following lines `this.project().state.as_mut().set(State::Waiting); cx.waker().wake_by_ref(); Poll::Pending` execute. When the future resolves to `Err`, the error is discarded (no logging, no propagation), the `Adding` future is dropped, and the state is reset to `Waiting` without establishing an inner stream or maintaining any invariant indicating failure. This change deviates from the prior behavior using `?` (which presumably propagated/handled the error), and can lead to silent failure, lost diagnostics, and potentially inconsistent higher-level state because a failed addition will appear as a successful transition back to `Waiting` without any record of the failure. All exit paths after effects (state change) should preserve invariants and report outcomes; here, the error path is neither reported nor handled, and the state machine may continue as if success or no-op occurred. <b>[ Low confidence ]</b>
- [line 466](https://github.com/xmtp/libxmtp/blob/17a32da17c962b9d2d9fd05ed86c101f8259f429/xmtp_mls/src/subscriptions/stream_messages.rs#L466): Implementation contradicts documentation: The docstring explicitly states "When in replay mode, delegates to `resolve_replaying`", but the function only proceeds when `state` matches `Processing` and otherwise returns `Poll::Pending` without delegating to any replay handler. If `Replay` state is reachable, this mismatch can lead to stalling or skipping replay logic, creating uncertainty about the intended behavior. Either implement delegation to `resolve_replaying` when in replay mode or update the documentation to match actual behavior. <b>[ Out of scope ]</b>
- [line 503](https://github.com/xmtp/libxmtp/blob/17a32da17c962b9d2d9fd05ed86c101f8259f429/xmtp_mls/src/subscriptions/stream_messages.rs#L503): Unsafe numeric casts when constructing `Cursor`: `msg.sequence_id as u64` and `msg.originator_id as u32` perform unchecked conversions that can wrap or truncate negative or out-of-range values. If `msg.sequence_id` is signed or larger than `u64`, or `msg.originator_id` exceeds `u32` range, this can silently corrupt the cursor (ordering, uniqueness) and break downstream invariants. At minimum, validate ranges before casting, or change the `Cursor` fields to match the source types to avoid lossy conversion. <b>[ Out of scope ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->