### PR TITLE
Add CA Certs to XDBG docker image so it can resolve HTTPS

### DIFF
--- a/dev/xdbg/Dockerfile
+++ b/dev/xdbg/Dockerfile
@@ -5,6 +5,9 @@ COPY .git /.git
 RUN cargo build --release --package xdbg
 
 FROM debian:bullseye-slim
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates libssl1.1 \
+ && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /code/target/release/xdbg /usr/local/bin/xdbg
 ENV RUST_LOG=info
 ENTRYPOINT ["xdbg"]


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add CA certificates and `libssl1.1` to the `dev/xdbg` Docker runtime image to resolve HTTPS
Add a `RUN` step in [dev/xdbg/Dockerfile](https://github.com/xmtp/libxmtp/pull/2735/files#diff-ee22323cd498da3d730abf406d8e39dcbf1aa77ef2e436bd458a2a960f55df50) to `apt-get update`, install `ca-certificates` and `libssl1.1` with `--no-install-recommends`, and remove apt lists to reduce layer size.

#### 📍Where to Start
Start with the runtime image stage changes in [dev/xdbg/Dockerfile](https://github.com/xmtp/libxmtp/pull/2735/files#diff-ee22323cd498da3d730abf406d8e39dcbf1aa77ef2e436bd458a2a960f55df50), focusing on the added `RUN` step that installs `ca-certificates` and `libssl1.1`.

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 5a10f0d. 0 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
No issues evaluated.


</details><!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->