### PR TITLE
Add more retryable error types for SCW verification

### DIFF
--- a/xmtp_id/src/scw_verifier/mod.rs
+++ b/xmtp_id/src/scw_verifier/mod.rs
@@ -43,6 +43,9 @@ impl RetryableError for VerifierError {
     fn is_retryable(&self) -> bool {
         use VerifierError::*;
         match self {
+            Io(_) => true,
+            NoVerifier => true,
+            Provider(_) => true,
             Other(o) => o.is_retryable(),
             _ => false,
         }


### PR DESCRIPTION
## tl;dr

I noticed some error types that should be retryable. Because pretty much everyone uses the RemoteSignatureVerifier (which always returns Other) I don't think it matters right now. But good to correct these things when you see them anyways.