### PR TITLE
add experimental ryow for identities in xdbg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3210,6 +3210,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8336,6 +8342,7 @@ dependencies = [
  "fdlimit",
  "fs_extra",
  "futures",
+ "humantime",
  "indicatif",
  "itertools 0.14.0",
  "k256",
@@ -8353,6 +8360,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.16",
  "tokio",
+ "tokio-stream",
  "tracing",
  "tracing-appender",
  "tracing-logfmt",
@@ -8361,6 +8369,7 @@ dependencies = [
  "valuable",
  "vergen-git2",
  "xmtp_api_d14n",
+ "xmtp_api_grpc",
  "xmtp_configuration",
  "xmtp_cryptography",
  "xmtp_db",

--- a/xmtp_debug/Cargo.toml
+++ b/xmtp_debug/Cargo.toml
@@ -25,6 +25,7 @@ fdlimit.workspace = true
 fs_extra = "1.3"
 futures.workspace = true
 hex.workspace = true
+humantime = "2.3"
 indicatif.workspace = true
 itertools.workspace = true
 k256 = "0.13"
@@ -42,6 +43,7 @@ speedy = "0.8"
 tempfile = "3.15"
 thiserror.workspace = true
 tokio = "1.43"
+tokio-stream.workspace = true
 tracing = { workspace = true, features = ["valuable"] }
 tracing-appender = "0.2"
 tracing-logfmt.workspace = true
@@ -56,6 +58,7 @@ tracing-subscriber = { workspace = true, features = [
 url.workspace = true
 valuable = { version = "0.1", features = ["derive"] }
 xmtp_api_d14n.workspace = true
+xmtp_api_grpc.workspace = true
 xmtp_configuration.workspace = true
 xmtp_cryptography = { workspace = true, features = ["exposed-keys"] }
 xmtp_db.workspace = true

--- a/xmtp_debug/src/app/generate.rs
+++ b/xmtp_debug/src/app/generate.rs
@@ -29,6 +29,7 @@ impl Generate {
             invite,
             message_opts,
             concurrency,
+            ryow,
             ..
         } = opts;
 
@@ -53,7 +54,7 @@ impl Generate {
             Identity => {
                 let db = App::db()?;
                 GenerateIdentity::new(db.into(), network)
-                    .create_identities(amount, *concurrency)
+                    .create_identities(amount, *concurrency, ryow)
                     .await?;
                 info!("identities generated");
                 Ok(())

--- a/xmtp_debug/src/app/generate/identity.rs
+++ b/xmtp_debug/src/app/generate/identity.rs
@@ -1,11 +1,20 @@
 use std::{collections::HashSet, sync::Arc};
 
+use crate::app::register_client;
 use crate::app::store::{Database, IdentityStore};
 use crate::app::{self, types::Identity};
 use crate::args;
 
-use color_eyre::eyre::{self, Result, bail};
+use color_eyre::eyre::{self, Result, WrapErr, bail, eyre};
+use futures::{FutureExt, StreamExt, TryFutureExt, TryStreamExt, future, stream};
 use indicatif::{ProgressBar, ProgressStyle};
+use openmls_rust_crypto::RustCrypto;
+use tokio::sync::Mutex;
+use tokio::time::timeout;
+use xmtp_api_d14n::d14n::SubscribeEnvelopes;
+use xmtp_api_d14n::protocol::{CollectionExtractor, Extractor, KeyPackagesExtractor};
+use xmtp_proto::api::QueryStreamExt;
+use xmtp_proto::types::{InstallationId, TopicKind};
 
 /// Identity Generation
 pub struct GenerateIdentity {
@@ -31,127 +40,167 @@ impl GenerateIdentity {
             .map(|i| i.map(|i| Ok(i.value()))))
     }
 
-    /// Create identities if they don't already exist.
-    /// creates specified `identities` on the
-    /// gRPC local docker or development node and saves them to a file.
-    /// `identities.generated`/`dev-identities.generated`. Uses this file for subsequent runs if
-    /// node still has those identities.
-    #[allow(unused)]
-    pub async fn create_identities_if_dont_exist(
+    pub async fn create_identities(
         &self,
         n: usize,
-        client: &crate::DbgClient,
+        concurrency: usize,
+        ryow: bool,
     ) -> Result<Vec<Identity>> {
-        let connection = client.context.store().db();
-        if let Some(mut identities) = self.load_identities()? {
-            let first = identities.next().ok_or(eyre::eyre!("Does not exist"))??;
-
-            let state = client
-                .identity_updates()
-                .get_latest_association_state(&connection, &hex::encode(first.inbox_id))
-                .await?;
-            info!("Found generated identities, checking for registration on backend...",);
-            // we assume that if the first identity is registered, they all are
-            if !state.members().is_empty() {
-                return identities.collect::<Result<Vec<Identity>, _>>();
-            } else {
-                warn!(
-                    "No identities found for network {}, clearing orphans and re-instantiating",
-                    &url::Url::from(self.network.clone())
-                );
-                self.identity_store.clear_network(&self.network)?;
+        let style = ProgressStyle::with_template("{bar} {pos}/{len} elapsed {elapsed} | {msg}");
+        let bar = ProgressBar::new(n as u64)
+            .with_style(style.unwrap())
+            .with_message("generating identities");
+        // simple task to keep the bar elapsed time moving
+        tokio::spawn({
+            let b = bar.clone();
+            async move {
+                let s = tokio_stream::wrappers::IntervalStream::new(tokio::time::interval(
+                    std::time::Duration::from_millis(100),
+                ));
+                futures::pin_mut!(s);
+                while s.next().await.is_some() {
+                    b.tick();
+                }
             }
-        }
-        info!("Could not find identities to load, creating new identities");
-        let identities = self.create_identities(n, 10).await?;
-        self.identity_store
-            .set_all(identities.as_slice(), &self.network)?;
-        Ok(identities)
-    }
-
-    pub async fn create_identities(&self, n: usize, concurrency: usize) -> Result<Vec<Identity>> {
-        let mut identities: Vec<Identity> = Vec::with_capacity(n);
-
-        let style = ProgressStyle::with_template(
-            "{bar} {pos}/{len} elapsed {elapsed} remaining {eta_precise}",
-        );
-        let bar = ProgressBar::new(n as u64).with_style(style.unwrap());
-        let mut set: tokio::task::JoinSet<Result<_, eyre::Error>> = tokio::task::JoinSet::new();
-
+        });
         let network = &self.network;
 
         let semaphore = Arc::new(tokio::sync::Semaphore::new(concurrency));
+        let s = Arc::new(Mutex::new(SubscribeEnvelopes::builder()));
 
-        for _ in 0..n {
-            let bar_pointer = bar.clone();
-            let network = network.clone();
-            let semaphore = semaphore.clone();
-            set.spawn(async move {
-                let _permit = semaphore.acquire().await?;
-                let wallet = crate::app::generate_wallet();
-                // TODO: maybe create all new clients in a temp directory
-                // then copy + store at the same time
-                // in case CLI is exited before finishing
-                let user = app::new_registered_client(network, Some(&wallet)).await?;
-                bar_pointer.inc(1);
-                Identity::from_libxmtp(user.identity(), wallet)
-            });
-
-            if set.len() == app::get_fdlimit()
-                && let Some(identity) = set.join_next().await
-            {
-                match identity {
-                    Ok(identity) => {
-                        identities.push(identity?);
+        tracing::info!("creating clients");
+        let clients = stream::iter((0..n).collect::<Vec<_>>())
+            .map(|_| {
+                tokio::spawn({
+                    let sem = semaphore.clone();
+                    let s = s.clone();
+                    let network = network.clone();
+                    let bar_pointer = bar.clone();
+                    async move {
+                        let _permit = sem.acquire().await?;
+                        let wallet = crate::app::generate_wallet();
+                        let c = app::new_unregistered_client(&network, Some(&wallet)).await?;
+                        bar_pointer
+                            .set_message(format!("generated client {}", c.identity().inbox_id()));
+                        let mut s = s.lock().await;
+                        s.topic(TopicKind::KeyPackagesV1.create(c.identity().installation_id()));
+                        bar_pointer.inc(1);
+                        Ok::<_, eyre::Report>((c, wallet))
                     }
-                    Err(e) => {
-                        error!("{}", e.to_string());
+                })
+                .map_err(|_| eyre!("failed to create client"))
+            })
+            .buffer_unordered(concurrency)
+            .try_collect::<Vec<_>>()
+            .await?
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()?;
+
+        bar.finish();
+        bar.reset();
+
+        let s = Arc::into_inner(s).expect("only one reference exists after tasks finish");
+        let mut s = Mutex::into_inner(s);
+        // try to read a key package for each installation id we created
+        // only for D14n
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let read_writes = if network.d14n && ryow {
+            let n = network.clone();
+            let mut needed_installations = clients
+                .clone()
+                .iter()
+                .map(|(c, _)| c.context.installation_id())
+                .collect::<HashSet<_>>();
+            tokio::spawn(async move {
+                let api = n.xmtpd()?;
+                let mut s = s.last_seen(None).build()?;
+                let s = s.subscribe(&api).await?;
+                let bar_ref = bar.clone();
+                let _ = tx.send(());
+                bar_ref.set_message("waiting for identities to be written");
+                futures::pin_mut!(s);
+                while let Some(kp) = timeout(n.ryow_timeout.into(), s.try_next()).await.wrap_err("timeout reached for reading writes on key package published")?? {
+                    // TODO: we can deserialize key packages in extractors possibly
+                    let extractor =
+                        CollectionExtractor::new(kp.envelopes, KeyPackagesExtractor::new());
+                    let key_packages = extractor.get()?;
+                    let key_packages = key_packages
+                        .into_iter()
+                        .map(|kp| {
+                            let inst = xmtp_mls::verified_key_package_v2::VerifiedKeyPackageV2::from_bytes(
+                                &RustCrypto::default(),
+                                kp.key_package_tls_serialized.as_slice(),
+                            )?
+                            .installation_public_key;
+                            Ok(InstallationId::try_from(inst)?)
+                        })
+                        .inspect(|v| { let _ = v.as_ref().inspect(|v| { bar_ref.set_message(format!("got key package for installation {}", v)); }); })
+                        .collect::<Result<HashSet<_>, eyre::Report>>()?;
+                    bar.inc(key_packages.len() as u64);
+                    needed_installations = needed_installations.difference(&key_packages).copied().collect();
+                    if needed_installations.is_empty() {
+                        break;
                     }
                 }
-            }
-        }
+                Ok(())
+            })
+            .map_err(|_| eyre!("failed to read own writes"))
+            .map(|s| s.flatten())
+            .boxed()
+        } else {
+            let _ = tx.send(());
+            future::ready(Ok(())).boxed()
+        };
+        // ensure our ryow task is spawned
+        let _ = rx.await;
 
-        while let Some(identity) = set.join_next().await {
-            match identity {
-                Ok(identity) => {
-                    identities.push(identity?);
-                }
-                Err(e) => {
-                    error!("{}", e.to_string());
-                }
-            }
-        }
+        let identities = stream::iter(clients.into_iter().map(Ok))
+            .map_ok(|(c, wallet)| {
+                tokio::spawn({
+                    let sem = semaphore.clone();
+                    async move {
+                        let _permit = sem.acquire().await?;
+                        let identity = Identity::from_libxmtp(c.identity(), wallet.clone())?;
+                        register_client(&c, wallet.into_alloy()).await?;
+                        Ok(identity)
+                    }
+                })
+                .map_err(|_| eyre!("failed to register identities"))
+            })
+            .try_buffer_unordered(concurrency)
+            .map(|j| j.flatten())
+            .try_collect::<Vec<Identity>>()
+            .await?;
 
         self.identity_store
             .set_all(identities.as_slice(), &self.network)?;
 
-        bar.finish();
-        bar.reset();
-        let mut set: tokio::task::JoinSet<Result<_, eyre::Error>> = tokio::task::JoinSet::new();
-        // ensure all the identities are registered
+        //TODO: this can be removed once we're d14n-only
         let tmp = Arc::new(app::temp_client(network, None).await?);
         let conn = Arc::new(tmp.context.store().db());
-        let bar_ref = bar.clone();
-        let future = |inbox_id: [u8; 32]| async move {
-            let id = hex::encode(inbox_id);
-            trace!(inbox_id = id, "getting association state");
-            let state = tmp
-                .identity_updates()
-                .get_latest_association_state(&conn, &id)
-                .await?;
-            bar_ref.inc(1);
-            Ok(state)
-        };
-
-        identities.as_slice().iter().for_each(|i| {
-            set.spawn(future.clone()(i.inbox_id));
-        });
-        bar.finish_and_clear();
-        let states = set.join_all().await;
-        info!(
-            total_states = states.len(),
-            "ensuring identities registered & latest association state loaded..."
-        );
+        let states = stream::iter(identities.iter().copied().map(Ok))
+            .map_ok(|identity| {
+                let tmp = tmp.clone();
+                let conn = conn.clone();
+                tokio::spawn({
+                    let sem = semaphore.clone();
+                    async move {
+                        let _permit = sem.acquire().await?;
+                        let id = hex::encode(identity.inbox_id);
+                        trace!(inbox_id = id, "getting association state");
+                        let state = tmp
+                            .identity_updates()
+                            .get_latest_association_state(&conn, &id)
+                            .await?;
+                        Ok(state)
+                    }
+                })
+                .map_err(|_| eyre!("failed to register identities"))
+            })
+            .try_buffer_unordered(concurrency)
+            .map(|j| j.flatten())
+            .collect::<Vec<_>>()
+            .await;
         let errs = states
             .into_iter()
             .filter_map(|s| s.err())
@@ -166,6 +215,7 @@ impl GenerateIdentity {
             }
             bail!("Error generation failed");
         }
+        read_writes.await?;
         Ok(identities)
     }
 }

--- a/xmtp_debug/src/app/store.rs
+++ b/xmtp_debug/src/app/store.rs
@@ -146,6 +146,8 @@ pub trait Database<Key, Value> {
     where
         Value: redb::Value + 'static;
 
+    #[allow(unused)]
+    /// Clear all items on a network
     fn clear_network(&self, network: impl Into<u64>) -> Result<()>;
 
     /// Modify a single value by removing and re-inserting
@@ -191,6 +193,8 @@ pub trait TrackMetadata {
         network: u64,
         n: u32,
     ) -> Result<()>;
+    // decrement a metadata item
+    #[allow(unused)]
     fn decrement<'a>(
         &self,
         store: impl Into<MetadataStore<'a>>,

--- a/xmtp_debug/src/app/types.rs
+++ b/xmtp_debug/src/app/types.rs
@@ -50,7 +50,9 @@ impl<'a> From<&'a Identity> for EthereumWallet {
 
 /// Identity specific to this debug CLI Tool.
 /// An installation key and a eth address
-#[derive(valuable::Valuable, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Readable, Writable)]
+#[derive(
+    valuable::Valuable, Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Readable, Writable,
+)]
 pub struct Identity {
     pub inbox_id: [u8; 32],
     pub installation_key: [u8; 32],

--- a/xmtp_debug/src/args.rs
+++ b/xmtp_debug/src/args.rs
@@ -3,10 +3,17 @@ use clap::{Args, Parser, Subcommand, ValueEnum};
 use clap_verbosity_flag::{InfoLevel, Verbosity};
 use color_eyre::eyre;
 use std::path::PathBuf;
+use xmtp_configuration::{MULTI_NODE_TIMEOUT_MS, PAYER_WRITE_FILTER};
 use xxhash_rust::xxh3;
 mod types;
+use std::time::Duration;
 pub use types::*;
-use xmtp_api_d14n::MessageBackendBuilder;
+use xmtp_api_d14n::{MessageBackendBuilder, MiddlewareBuilder, ReadWriteClient};
+use xmtp_api_grpc::GrpcClient;
+use xmtp_proto::{
+    api::Client,
+    prelude::{ApiBuilder, NetConnectConfig},
+};
 
 /// Debug & Generate data on the XMTP Network
 #[derive(Parser, Debug)]
@@ -70,6 +77,10 @@ pub struct Generate {
     /// Defaults to the number of available CPU cores if not specified.
     #[arg(long, short, default_value_t = Concurrency::default())]
     pub concurrency: Concurrency,
+    /// enable reading publishes from the backend
+    /// _NOTE:_ feature is experimental
+    #[arg(long, short)]
+    pub ryow: bool,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -273,6 +284,13 @@ pub struct BackendOpts {
     /// Enable the decentralization backend
     #[arg(short, long)]
     pub d14n: bool,
+    /// Timeout for reading writes to the decentralized backend
+    #[arg(long, short, default_value_t = default_ryow_timeout())]
+    pub ryow_timeout: humantime::Duration,
+}
+
+fn default_ryow_timeout() -> humantime::Duration {
+    "5s".parse::<humantime::Duration>().unwrap()
 }
 
 impl BackendOpts {
@@ -328,6 +346,31 @@ impl BackendOpts {
             trace!(url = %network, is_secure, "create grpc");
             Ok(builder.build()?)
         }
+    }
+
+    pub fn xmtpd(&self) -> eyre::Result<impl Client> {
+        let network = self.network_url();
+        let is_secure = network.scheme() == "https";
+
+        let mut gateway_client_builder = GrpcClient::builder();
+        gateway_client_builder.set_host(self.xmtpd_gateway_url()?.to_string());
+        gateway_client_builder.set_tls(is_secure);
+        let mut node_builder = GrpcClient::builder();
+        node_builder.set_tls(is_secure);
+
+        let mut multi_node = xmtp_api_d14n::middleware::MultiNodeClientBuilder::default();
+        multi_node.set_timeout(Duration::from_millis(MULTI_NODE_TIMEOUT_MS))?;
+        multi_node.set_gateway_builder(gateway_client_builder.clone())?;
+        multi_node.set_node_client_builder(node_builder)?;
+        let multi_node = multi_node.build()?;
+
+        let gateway_client = gateway_client_builder.build()?;
+        let rw = ReadWriteClient::builder()
+            .read(multi_node)
+            .write(gateway_client)
+            .filter(PAYER_WRITE_FILTER)
+            .build()?;
+        Ok(rw)
     }
 }
 

--- a/xmtp_debug/src/main.rs
+++ b/xmtp_debug/src/main.rs
@@ -14,6 +14,8 @@ pub type MlsContext =
 type DbgClientApi = xmtp_mls::XmtpApiClient;
 type DbgClient = xmtp_mls::client::Client<MlsContext>;
 
+const XDBG_ID_NONCE: u64 = 1;
+
 #[macro_use]
 extern crate tracing;
 

--- a/xmtp_proto/src/types/ids.rs
+++ b/xmtp_proto/src/types/ids.rs
@@ -5,7 +5,7 @@ use hex::FromHexError;
 
 use crate::ConversionError;
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct InstallationId([u8; 32]);
 
 impl InstallationId {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add experimental RYOW to identity generation and gate it behind `--ryow` with `BackendOpts.ryow_timeout=5s`, using `main::XDBG_ID_NONCE=1` in `xdbg`
Introduce optional RYOW flow in identity generation, refactor client creation to return unregistered clients, and add a decentralized read/write API builder in `BackendOpts`.

#### 📍Where to Start
Start with `GenerateIdentity::create_identities` in [xmtp_debug/src/app/generate/identity.rs](https://github.com/xmtp/libxmtp/pull/2743/files#diff-5810cc3f49b5afa472f60492ce4999aadf64464660c04f8251d27b1e6abfcf1c).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized c468102. 8 files reviewed, 7 issues evaluated, 7 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>xmtp_debug/src/app/clients.rs — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 68](https://github.com/xmtp/libxmtp/blob/c468102940a781f44de355d32d06e14e7a0fe011/xmtp_debug/src/app/clients.rs#L68): `new_client_inner` is documented as "Create a new client + Identity & register it" but the implementation no longer registers the client (the call to `register_client(&client, wallet).await?` was removed). This breaks contract parity: callers expecting a registered/ready identity will now get an unregistered client, causing operations gated by `ensure_identity_ready()` to fail at runtime (e.g., group creation, DM creation, sync). Either restore registration or update all callers and documentation to reflect the unregistered behavior. <b>[ Low confidence ]</b>
</details>

<details>
<summary>xmtp_debug/src/app/generate.rs — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 42](https://github.com/xmtp/libxmtp/blob/c468102940a781f44de355d32d06e14e7a0fe011/xmtp_debug/src/app/generate.rs#L42): `run` forwards `concurrency` without validation. If the CLI-supplied `concurrency` is 0, downstream code (e.g., identity generation) will panic in `buffer_unordered(0)` or hang on `Semaphore::new(0)`. Add a guard in `run` (e.g., clamp to at least 1) or validate in argument parsing. <b>[ Already posted ]</b>
</details>

<details>
<summary>xmtp_debug/src/app/generate/identity.rs — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 54](https://github.com/xmtp/libxmtp/blob/c468102940a781f44de355d32d06e14e7a0fe011/xmtp_debug/src/app/generate/identity.rs#L54): Spawned progress-bar ticker task never terminates, causing a leaked background task. The `tokio::spawn` loop built from `IntervalStream::new(tokio::time::interval(...))` runs indefinitely (`while s.next().await.is_some()`), and there is no cancellation or join on this task. Even after `bar.finish()`/`bar.reset()`, the task continues ticking forever, retaining the progress bar’s internal state and consuming CPU. Add a cancellation signal or scope the task to end when the function exits or when generation completes. <b>[ Already posted ]</b>
- [line 68](https://github.com/xmtp/libxmtp/blob/c468102940a781f44de355d32d06e14e7a0fe011/xmtp_debug/src/app/generate/identity.rs#L68): `concurrency` is not validated to be > 0, which can cause runtime failures: (1) `tokio::sync::Semaphore::new(concurrency)` with 0 permits makes every `acquire().await` wait forever, hanging tasks; (2) `buffer_unordered(concurrency)` is called with `concurrency`, and a zero-sized buffer causes a panic per futures’ contract. Validate and clamp `concurrency` to at least 1 before using it. Occurs at both client creation and registration pipelines. <b>[ Already posted ]</b>
</details>

<details>
<summary>xmtp_debug/src/args.rs — 0 comments posted, 3 evaluated, 3 filtered</summary>

- [line 356](https://github.com/xmtp/libxmtp/blob/c468102940a781f44de355d32d06e14e7a0fe011/xmtp_debug/src/args.rs#L356): `xmtpd()` unconditionally requires a gateway URL by calling `self.xmtpd_gateway_url()?` and then builds a multi-node/gateway-based client. If `--d14n` is not set and no `--xmtpd-gateway-url` is provided, this returns an error ("No gateway for V3"), while `connect()` handles the non-d14n case without requiring a gateway. This asymmetry can cause unexpected runtime failures for configurations that otherwise work with `connect()`. Either guard on `self.d14n` and fall back to a non-gateway client, or document that `xmtpd()` requires a gateway. <b>[ Low confidence ]</b>
- [line 357](https://github.com/xmtp/libxmtp/blob/c468102940a781f44de355d32d06e14e7a0fe011/xmtp_debug/src/args.rs#L357): TLS enablement for the gateway client is derived from the `network_url` scheme instead of the gateway URL scheme. `is_secure` is computed from `network.scheme()` (line 353) and then applied to `gateway_client_builder.set_tls(is_secure)` (line 357). When the user supplies `--url` and `--xmtpd-gateway-url` with differing schemes (e.g., HTTPS network and HTTP gateway, or vice versa), the gateway `GrpcClient` will negotiate TLS incorrectly, causing connection failures or insecure connections. Fix by deriving TLS for the gateway from `self.xmtpd_gateway_url()?.scheme()` and (optionally) for node clients from the appropriate node/gateway context rather than reusing `network.scheme()`. <b>[ Already posted ]</b>
- [line 362](https://github.com/xmtp/libxmtp/blob/c468102940a781f44de355d32d06e14e7a0fe011/xmtp_debug/src/args.rs#L362): `set_timeout(Duration::from_millis(MULTI_NODE_TIMEOUT_MS))` forwards a constant without validation. If `MULTI_NODE_TIMEOUT_MS` is zero, `MultiNodeClientBuilder::build()` will return `InvalidTimeout`, causing a runtime error. Given the constant is external configuration, validate it or use a safe default > 0. <b>[ Low confidence ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->