### PR TITLE
1.6 Release Candidate 3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_node"
-version = "1.6.0-dev"
+version = "1.6.1-rc3"
 dependencies = [
  "chrono",
  "const-hex",
@@ -1238,7 +1238,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_wasm"
-version = "1.6.0-dev"
+version = "1.6.1-rc3"
 dependencies = [
  "alloy",
  "chrono",
@@ -4082,7 +4082,7 @@ dependencies = [
 
 [[package]]
 name = "mls_validation_service"
-version = "1.6.0-dev"
+version = "1.6.1-rc3"
 dependencies = [
  "alloy",
  "async-trait",
@@ -8259,7 +8259,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api"
-version = "1.6.0-dev"
+version = "1.6.1-rc3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8283,7 +8283,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_d14n"
-version = "1.6.0-dev"
+version = "1.6.1-rc3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8319,7 +8319,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_grpc"
-version = "1.6.0-dev"
+version = "1.6.1-rc3"
 dependencies = [
  "async-trait",
  "futures",
@@ -8349,7 +8349,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_archive"
-version = "1.6.0-dev"
+version = "1.6.1-rc3"
 dependencies = [
  "aes-gcm",
  "async-compression",
@@ -8375,7 +8375,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_cli"
-version = "1.6.0-dev"
+version = "1.6.1-rc3"
 dependencies = [
  "alloy",
  "chrono",
@@ -8408,7 +8408,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_common"
-version = "1.6.0-dev"
+version = "1.6.1-rc3"
 dependencies = [
  "async-trait",
  "console_error_panic_hook",
@@ -8443,7 +8443,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_configuration"
-version = "1.6.0-dev"
+version = "1.6.1-rc3"
 dependencies = [
  "openmls",
  "url",
@@ -8453,7 +8453,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_content_types"
-version = "1.6.0-dev"
+version = "1.6.1-rc3"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -8470,7 +8470,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_cryptography"
-version = "1.6.0-dev"
+version = "1.6.1-rc3"
 dependencies = [
  "alloy",
  "bincode",
@@ -8494,7 +8494,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_db"
-version = "1.6.0-dev"
+version = "1.6.1-rc3"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -8536,7 +8536,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_db_test"
-version = "1.6.0-dev"
+version = "1.6.1-rc3"
 dependencies = [
  "derive_builder",
  "diesel",
@@ -8549,7 +8549,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_id"
-version = "1.6.0-dev"
+version = "1.6.1-rc3"
 dependencies = [
  "alloy",
  "async-trait",
@@ -8584,7 +8584,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_macro"
-version = "1.6.0-dev"
+version = "1.6.1-rc3"
 dependencies = [
  "num_cpus",
  "proc-macro2",
@@ -8596,7 +8596,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_mls"
-version = "1.6.0-dev"
+version = "1.6.1-rc3"
 dependencies = [
  "aes-gcm",
  "alloy",
@@ -8677,7 +8677,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_mls_common"
-version = "1.6.0-dev"
+version = "1.6.1-rc3"
 dependencies = [
  "const-hex",
  "openmls",
@@ -8695,7 +8695,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_proto"
-version = "1.6.0-dev"
+version = "1.6.1-rc3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8734,7 +8734,7 @@ dependencies = [
 
 [[package]]
 name = "xmtpv3"
-version = "1.6.0-dev"
+version = "1.6.1-rc3"
 dependencies = [
  "alloy",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ resolver = "2"
 
 [workspace.package]
 license = "MIT"
-version = "1.6.0-dev"
+version = "1.6.1-rc3"
 
 [workspace.dependencies]
 aes-gcm = { version = "0.10.3", features = ["std"] }

--- a/bindings_node/package.json
+++ b/bindings_node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/node-bindings",
-  "version": "1.6.0-dev",
+  "version": "1.6.1-rc3",
   "repository": {
     "type": "git",
     "url": "git+https://git@github.com/xmtp/libxmtp.git",

--- a/bindings_wasm/package.json
+++ b/bindings_wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/wasm-bindings",
-  "version": "1.6.0-dev",
+  "version": "1.6.1-rc3",
   "type": "module",
   "license": "MIT",
   "description": "WASM bindings for the libXMTP rust library",


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Bump workspace and package versions to 1.6.1-rc3 for the 1.6 Release Candidate 3 across Rust and JS bindings
Update version identifiers to `1.6.1-rc3` in the workspace manifest, lockfile, and Node/WASM package manifests. Key files: [Cargo.toml](https://github.com/xmtp/libxmtp/pull/2748/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542), [Cargo.lock](https://github.com/xmtp/libxmtp/pull/2748/files#diff-13ee4b2252c9e516a0547f2891aa2105c3ca71c6d7a1e682c69be97998dfc87e), [bindings_node/package.json](https://github.com/xmtp/libxmtp/pull/2748/files#diff-bc8be8e755c9188d5b1c3402b397741f9151dad43d877a181f31003052d10b99), and [bindings_wasm/package.json](https://github.com/xmtp/libxmtp/pull/2748/files#diff-4a621639e0561b5b01c30ab7fa75cc2b67c54dad6763ecabda35df8e2b16b14e).

#### 📍Where to Start
Start with the workspace version in [Cargo.toml](https://github.com/xmtp/libxmtp/pull/2748/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542), then verify propagated entries in [Cargo.lock](https://github.com/xmtp/libxmtp/pull/2748/files#diff-13ee4b2252c9e516a0547f2891aa2105c3ca71c6d7a1e682c69be97998dfc87e) and the package versions in [bindings_node/package.json](https://github.com/xmtp/libxmtp/pull/2748/files#diff-bc8be8e755c9188d5b1c3402b397741f9151dad43d877a181f31003052d10b99) and [bindings_wasm/package.json](https://github.com/xmtp/libxmtp/pull/2748/files#diff-4a621639e0561b5b01c30ab7fa75cc2b67c54dad6763ecabda35df8e2b16b14e).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 9bb3ba0.
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->