### PR TITLE
use retries in nextest by default

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,6 +1,6 @@
 [profile.default]
 default-filter = "not test(test_stream_all_messages_does_not_lose_messages)"
-retries = 0
+retries = { backoff = "exponential", count = 3, delay = "3s", max-delay = "20s", jitter = true }
 status-level = "skip"
 failure-output = "final"
 fail-fast = false
@@ -8,7 +8,6 @@ fail-fast = false
 [profile.ci]
 slow-timeout = "90sec"
 default-filter = "not (test(test_stream_all_messages_does_not_lose_messages)|test(test_can_stream_group_messages_for_updates))"
-retries = 0
 status-level = "skip"
 failure-output = "immediate-final"
 fail-fast = false


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Enable exponential backoff retries for failed tests in the default nextest profile with count 3, initial delay 3s, max-delay 20s, and jitter in [.config/nextest.toml](https://github.com/xmtp/libxmtp/pull/2749/files#diff-3e429424057e0b2a83fafc6e8942f4c05b63f4d977548e51535f8d86be8f9613)
Update the default `profile.default` in `.config/nextest.toml` to use structured retries with exponential backoff and jitter; remove the `retries = 0` line from `profile.ci`.

#### 📍Where to Start
Start with the `profile.default` and `profile.ci` sections in [.config/nextest.toml](https://github.com/xmtp/libxmtp/pull/2749/files#diff-3e429424057e0b2a83fafc6e8942f4c05b63f4d977548e51535f8d86be8f9613).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized c4f88d4.
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->