### PR TITLE
[ci] fix flakehub build

### DIFF
--- a/nix/lib/filesets.nix
+++ b/nix/lib/filesets.nix
@@ -21,7 +21,6 @@ let
     (commonCargoSources ./../../xmtp_db_test)
     (commonCargoSources ./../../xmtp_archive)
     (commonCargoSources ./../../xmtp_mls_common)
-    (commonCargoSources ./../../benches)
     ./../../xmtp_id/src/scw_verifier/chain_urls_default.json
     ./../../xmtp_id/artifact
     ./../../xmtp_id/src/scw_verifier/signature_validation.hex


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Remove `./../../benches` from Nix fileset in [filesets.nix](https://github.com/xmtp/libxmtp/pull/2752/files#diff-970fd78649df159fe6b5acddb6270d9a775268b4c4f790952f2baace3ba5f04c) to fix FlakeHub build
The benches source entry is removed from the Nix fileset in [filesets.nix](https://github.com/xmtp/libxmtp/pull/2752/files#diff-970fd78649df159fe6b5acddb6270d9a775268b4c4f790952f2baace3ba5f04c), excluding `./../../benches` from derivation inputs.

#### 📍Where to Start
Start with the fileset definition in [filesets.nix](https://github.com/xmtp/libxmtp/pull/2752/files#diff-970fd78649df159fe6b5acddb6270d9a775268b4c4f790952f2baace3ba5f04c).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 4baefa3.
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->