### PR TITLE
Add AppData metadata field

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -2258,6 +2258,7 @@ pub struct FfiCreateGroupOptions {
     pub group_description: Option<String>,
     pub custom_permission_policy_set: Option<FfiPermissionPolicySet>,
     pub message_disappearing_settings: Option<FfiMessageDisappearingSettings>,
+    pub app_data: Option<String>,
 }
 
 impl FfiCreateGroupOptions {
@@ -2269,6 +2270,7 @@ impl FfiCreateGroupOptions {
             message_disappearing_settings: self
                 .message_disappearing_settings
                 .map(|settings| settings.into()),
+            app_data: self.app_data,
         }
     }
 }
@@ -2491,6 +2493,16 @@ impl FfiConversation {
     pub fn group_name(&self) -> Result<String, GenericError> {
         let group_name = self.inner.group_name()?;
         Ok(group_name)
+    }
+
+    pub async fn update_app_data(&self, app_data: String) -> Result<(), GenericError> {
+        self.inner.update_app_data(app_data).await?;
+        Ok(())
+    }
+
+    pub fn app_data(&self) -> Result<String, GenericError> {
+        let app_data = self.inner.app_data()?;
+        Ok(app_data)
     }
 
     pub async fn update_group_image_url_square(

--- a/bindings_ffi/src/mls/tests/group_management.rs
+++ b/bindings_ffi/src/mls/tests/group_management.rs
@@ -40,6 +40,7 @@ async fn test_create_group_with_metadata() {
                 message_disappearing_settings: Some(
                     conversation_message_disappearing_settings.clone(),
                 ),
+                app_data: None,
             },
         )
         .await
@@ -311,6 +312,7 @@ async fn test_group_creation_custom_permissions() {
         group_description: Some("A test group".to_string()),
         custom_permission_policy_set: Some(custom_permissions),
         message_disappearing_settings: None,
+        app_data: None,
     };
 
     let alix_group = alix
@@ -433,6 +435,7 @@ async fn test_group_creation_custom_permissions_fails_when_invalid() {
         group_description: Some("A test group".to_string()),
         custom_permission_policy_set: Some(custom_permissions_invalid_1),
         message_disappearing_settings: None,
+        app_data: None,
     };
 
     let results_1 = alix
@@ -452,6 +455,7 @@ async fn test_group_creation_custom_permissions_fails_when_invalid() {
         group_description: Some("A test group".to_string()),
         custom_permission_policy_set: Some(custom_permissions_valid.clone()),
         message_disappearing_settings: None,
+        app_data: None,
     };
 
     let results_2 = alix
@@ -471,6 +475,7 @@ async fn test_group_creation_custom_permissions_fails_when_invalid() {
         group_description: Some("A test group".to_string()),
         custom_permission_policy_set: Some(custom_permissions_valid.clone()),
         message_disappearing_settings: None,
+        app_data: None,
     };
 
     let results_3 = alix
@@ -490,6 +495,7 @@ async fn test_group_creation_custom_permissions_fails_when_invalid() {
         group_description: Some("A test group".to_string()),
         custom_permission_policy_set: Some(custom_permissions_valid),
         message_disappearing_settings: None,
+        app_data: None,
     };
 
     let results_4 = alix
@@ -1015,6 +1021,7 @@ async fn test_set_disappearing_messages_when_creating_group() {
                 group_description: Some("group description".to_string()),
                 custom_permission_policy_set: None,
                 message_disappearing_settings: Some(disappearing_settings.clone()),
+                app_data: None,
             },
         )
         .await

--- a/bindings_node/src/conversation.rs
+++ b/bindings_node/src/conversation.rs
@@ -476,6 +476,27 @@ impl Conversation {
   }
 
   #[napi]
+  pub async fn update_app_data(&self, app_data: String) -> Result<()> {
+    let group = self.create_mls_group();
+
+    group
+      .update_app_data(app_data)
+      .await
+      .map_err(ErrorWrapper::from)?;
+
+    Ok(())
+  }
+
+  #[napi]
+  pub fn app_data(&self) -> Result<String> {
+    let group = self.create_mls_group();
+
+    let app_data = group.app_data().map_err(ErrorWrapper::from)?;
+
+    Ok(app_data)
+  }
+
+  #[napi]
   pub async fn update_group_image_url_square(&self, group_image_url_square: String) -> Result<()> {
     let group = self.create_mls_group();
 

--- a/bindings_node/src/conversations.rs
+++ b/bindings_node/src/conversations.rs
@@ -268,6 +268,7 @@ pub struct CreateGroupOptions {
   pub group_description: Option<String>,
   pub custom_permission_policy_set: Option<PermissionPolicySet>,
   pub message_disappearing_settings: Option<MessageDisappearingSettings>,
+  pub app_data: Option<String>,
 }
 
 impl CreateGroupOptions {
@@ -279,6 +280,7 @@ impl CreateGroupOptions {
       message_disappearing_settings: self
         .message_disappearing_settings
         .map(|settings| settings.into()),
+      app_data: self.app_data,
     }
   }
 }
@@ -322,6 +324,7 @@ impl Conversations {
       group_description: None,
       custom_permission_policy_set: None,
       message_disappearing_settings: None,
+      app_data: None,
     });
 
     if let Some(GroupPermissionsOptions::CustomPolicy) = options.permissions {

--- a/bindings_wasm/src/conversation.rs
+++ b/bindings_wasm/src/conversation.rs
@@ -502,6 +502,29 @@ impl Conversation {
     Ok(group_name)
   }
 
+  #[wasm_bindgen(js_name = updateAppData)]
+  pub async fn update_app_data(&self, app_data: String) -> Result<(), JsError> {
+    let group = self.to_mls_group();
+
+    group
+      .update_app_data(app_data)
+      .await
+      .map_err(|e| JsError::new(&format!("{e}")))?;
+
+    Ok(())
+  }
+
+  #[wasm_bindgen(js_name = appData)]
+  pub fn app_data(&self) -> Result<String, JsError> {
+    let group = self.to_mls_group();
+
+    let app_data = group
+      .app_data()
+      .map_err(|e| JsError::new(&format!("{e}")))?;
+
+    Ok(app_data)
+  }
+
   #[wasm_bindgen(js_name = updateGroupImageUrlSquare)]
   pub async fn update_group_image_url_square(
     &self,

--- a/bindings_wasm/src/conversations.rs
+++ b/bindings_wasm/src/conversations.rs
@@ -255,6 +255,8 @@ pub struct CreateGroupOptions {
   pub custom_permission_policy_set: Option<PermissionPolicySet>,
   #[wasm_bindgen(js_name = messageDisappearingSettings)]
   pub message_disappearing_settings: Option<MessageDisappearingSettings>,
+  #[wasm_bindgen(js_name = appData)]
+  pub app_data: Option<String>,
 }
 
 #[wasm_bindgen]
@@ -268,6 +270,7 @@ impl CreateGroupOptions {
     group_description: Option<String>,
     custom_permission_policy_set: Option<PermissionPolicySet>,
     message_disappearing_settings: Option<MessageDisappearingSettings>,
+    app_data: Option<String>,
   ) -> Self {
     Self {
       permissions,
@@ -276,6 +279,7 @@ impl CreateGroupOptions {
       group_description,
       custom_permission_policy_set,
       message_disappearing_settings,
+      app_data,
     }
   }
 }
@@ -289,6 +293,7 @@ impl CreateGroupOptions {
       message_disappearing_settings: self
         .message_disappearing_settings
         .map(|settings| settings.into()),
+      app_data: self.app_data,
     }
   }
 }
@@ -387,6 +392,7 @@ impl Conversations {
       group_description: None,
       custom_permission_policy_set: None,
       message_disappearing_settings: None,
+      app_data: None,
     });
 
     if let Some(GroupPermissionsOptions::CustomPolicy) = options.permissions {

--- a/xmtp_mls/src/groups/intents.rs
+++ b/xmtp_mls/src/groups/intents.rs
@@ -214,6 +214,13 @@ impl UpdateMetadataIntentData {
         }
     }
 
+    pub fn new_update_app_data(app_data: String) -> Self {
+        Self {
+            field_name: MetadataField::AppData.to_string(),
+            field_value: app_data,
+        }
+    }
+
     pub fn new_update_conversation_message_disappear_from_ns(from_ns: i64) -> Self {
         Self {
             field_name: MetadataField::MessageDisappearFromNS.to_string(),

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -118,6 +118,7 @@ use xmtp_proto::{
 const MAX_GROUP_DESCRIPTION_LENGTH: usize = 1000;
 const MAX_GROUP_NAME_LENGTH: usize = 100;
 const MAX_GROUP_IMAGE_URL_LENGTH: usize = 2048;
+const MAX_APP_DATA_LENGTH: usize = 8192;
 
 /// An LibXMTP MlsGroup
 /// _NOTE:_ The Eq implementation compares [`GroupId`], so a dm group with the same identity will be
@@ -1250,6 +1251,31 @@ where
         Ok(())
     }
 
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", fields(who = %self.context.inbox_id()), skip(self)))]
+    #[cfg_attr(
+        not(any(test, feature = "test-utils")),
+        tracing::instrument(level = "trace", skip(self))
+    )]
+    pub async fn update_app_data(&self, app_data: String) -> Result<(), GroupError> {
+        self.ensure_not_paused().await?;
+
+        if app_data.len() > MAX_APP_DATA_LENGTH {
+            return Err(GroupError::TooManyCharacters {
+                length: MAX_APP_DATA_LENGTH,
+            });
+        }
+        if self.metadata().await?.conversation_type == ConversationType::Dm {
+            return Err(MetadataPermissionsError::DmGroupMetadataForbidden.into());
+        }
+        let intent_data: Vec<u8> = UpdateMetadataIntentData::new_update_app_data(app_data).into();
+        let intent = QueueIntent::metadata_update()
+            .data(intent_data)
+            .queue(self)?;
+
+        let _ = self.sync_until_intent_resolved(intent.id).await?;
+        Ok(())
+    }
+
     /// Updates min version of the group to match this client's version.
     /// Not publicly exposed because:
     /// - Setting the min version to pre-release versions may not behave as expected
@@ -1371,6 +1397,21 @@ where
             .get(&MetadataField::GroupName.to_string())
         {
             Some(group_name) => Ok(group_name.clone()),
+            None => Err(MetadataPermissionsError::from(
+                GroupMutableMetadataError::MissingExtension,
+            )
+            .into()),
+        }
+    }
+
+    /// Retrieves the app_data field from the group's mutable metadata extension
+    pub fn app_data(&self) -> Result<String, GroupError> {
+        let mutable_metadata = self.mutable_metadata()?;
+        match mutable_metadata
+            .attributes
+            .get(&MetadataField::AppData.to_string())
+        {
+            Some(app_data) => Ok(app_data.clone()),
             None => Err(MetadataPermissionsError::from(
                 GroupMutableMetadataError::MissingExtension,
             )

--- a/xmtp_mls/src/groups/tests/mod.rs
+++ b/xmtp_mls/src/groups/tests/mod.rs
@@ -33,7 +33,8 @@ use crate::context::XmtpSharedContext;
 use crate::groups::intents::QueueIntent;
 use crate::groups::{DmValidationError, GroupLeaveValidationError, MetadataPermissionsError};
 use crate::groups::{
-    MAX_GROUP_DESCRIPTION_LENGTH, MAX_GROUP_IMAGE_URL_LENGTH, MAX_GROUP_NAME_LENGTH,
+    MAX_APP_DATA_LENGTH, MAX_GROUP_DESCRIPTION_LENGTH, MAX_GROUP_IMAGE_URL_LENGTH,
+    MAX_GROUP_NAME_LENGTH,
 };
 use crate::tester;
 use crate::utils::fixtures::{alix, bola, caro};
@@ -2425,6 +2426,7 @@ async fn test_group_options() {
                 image_url_square: Some("url".to_string()),
                 description: Some("group description".to_string()),
                 message_disappearing_settings: Some(expected_group_message_disappearing_settings),
+                app_data: None,
             }),
         )
         .unwrap();
@@ -2505,7 +2507,7 @@ async fn test_group_mutable_data() {
     amal_group.sync().await.unwrap();
 
     let group_mutable_metadata = amal_group.mutable_metadata().unwrap();
-    assert!(group_mutable_metadata.attributes.len().eq(&4));
+    assert!(group_mutable_metadata.attributes.len().eq(&5));
     assert!(
         group_mutable_metadata
             .attributes
@@ -4109,10 +4111,18 @@ async fn test_respects_character_limits_for_group_metadata() {
         matches!(result, Err(GroupError::TooManyCharacters { length }) if length == MAX_GROUP_IMAGE_URL_LENGTH)
     );
 
+    // Verify that updating the app data with an excessive length fails
+    let overlong_app_data = "d".repeat(MAX_APP_DATA_LENGTH + 1);
+    let result = amal_group.update_app_data(overlong_app_data).await;
+    assert!(
+        matches!(result, Err(GroupError::TooManyCharacters { length }) if length == MAX_APP_DATA_LENGTH)
+    );
+
     // Verify updates with valid lengths are successful
     let valid_name = "Valid Group Name".to_string();
     let valid_description = "Valid group description within limit.".to_string();
     let valid_image_url = "http://example.com/image.png".to_string();
+    let valid_app_data = "Valid app data content".to_string();
 
     amal_group
         .update_group_name(valid_name.clone())
@@ -4124,6 +4134,10 @@ async fn test_respects_character_limits_for_group_metadata() {
         .unwrap();
     amal_group
         .update_group_image_url_square(valid_image_url.clone())
+        .await
+        .unwrap();
+    amal_group
+        .update_app_data(valid_app_data.clone())
         .await
         .unwrap();
 
@@ -4153,6 +4167,117 @@ async fn test_respects_character_limits_for_group_metadata() {
             .unwrap(),
         &valid_image_url
     );
+    assert_eq!(
+        metadata
+            .attributes
+            .get(&MetadataField::AppData.to_string())
+            .unwrap(),
+        &valid_app_data
+    );
+}
+
+#[xmtp_common::test]
+async fn test_update_app_data() {
+    tester!(amal);
+
+    let policy_set = Some(PreconfiguredPolicies::AdminsOnly.to_policy_set());
+    let amal_group = amal.create_group(policy_set, None).unwrap();
+    amal_group.sync().await.unwrap();
+
+    // Update app data with a valid value
+    let app_data = "Test application data".to_string();
+    amal_group.update_app_data(app_data.clone()).await.unwrap();
+    amal_group.sync().await.unwrap();
+
+    // Verify the app data was updated using the getter
+    let retrieved_app_data = amal_group.app_data().unwrap();
+    assert_eq!(retrieved_app_data, app_data);
+
+    // Update with maximum allowed size (8KB)
+    let max_size_data = "x".repeat(MAX_APP_DATA_LENGTH);
+    amal_group
+        .update_app_data(max_size_data.clone())
+        .await
+        .unwrap();
+    amal_group.sync().await.unwrap();
+
+    let retrieved_max_data = amal_group.app_data().unwrap();
+    assert_eq!(retrieved_max_data, max_size_data);
+}
+
+#[xmtp_common::test]
+async fn test_app_data_in_dm() {
+    tester!(amal);
+    tester!(bola);
+
+    // Create a DM
+    let dm = amal
+        .find_or_create_dm_by_inbox_id(bola.inbox_id().to_string(), None)
+        .await
+        .unwrap();
+
+    // Verify that updating app_data on a DM fails
+    let result = dm.update_app_data("test data".to_string()).await;
+    assert!(matches!(
+        result,
+        Err(GroupError::MetadataPermissionsError(
+            MetadataPermissionsError::DmGroupMetadataForbidden
+        ))
+    ));
+}
+
+#[xmtp_common::test]
+async fn test_create_group_with_app_data() {
+    tester!(amal);
+
+    let initial_app_data = "Initial app data from options".to_string();
+
+    // Create a group with app_data set through GroupMetadataOptions
+    let group = amal
+        .create_group(
+            None,
+            Some(GroupMetadataOptions {
+                name: Some("Test Group".to_string()),
+                description: Some("Test Description".to_string()),
+                image_url_square: None,
+                message_disappearing_settings: None,
+                app_data: Some(initial_app_data.clone()),
+            }),
+        )
+        .unwrap();
+
+    group.sync().await.unwrap();
+
+    // Verify the app_data was set correctly
+    let retrieved_app_data = group.app_data().unwrap();
+    assert_eq!(retrieved_app_data, initial_app_data);
+
+    // Verify we can also update it
+    let updated_app_data = "Updated app data".to_string();
+    group
+        .update_app_data(updated_app_data.clone())
+        .await
+        .unwrap();
+    group.sync().await.unwrap();
+
+    let final_app_data = group.app_data().unwrap();
+    assert_eq!(final_app_data, updated_app_data);
+}
+
+#[xmtp_common::test]
+async fn test_create_group_with_default_app_data() {
+    tester!(amal);
+
+    // Create a group without specifying app_data (should default to empty string)
+    let group = amal
+        .create_group(None, Some(GroupMetadataOptions::default()))
+        .unwrap();
+
+    group.sync().await.unwrap();
+
+    // Verify the app_data defaults to empty string
+    let retrieved_app_data = group.app_data().unwrap();
+    assert_eq!(retrieved_app_data, "");
 }
 
 fn increment_patch_version(version: &str) -> Option<String> {

--- a/xmtp_mls/src/groups/validated_commit.rs
+++ b/xmtp_mls/src/groups/validated_commit.rs
@@ -1,5 +1,6 @@
 use super::{
-    MAX_GROUP_DESCRIPTION_LENGTH, MAX_GROUP_IMAGE_URL_LENGTH, MAX_GROUP_NAME_LENGTH,
+    MAX_APP_DATA_LENGTH, MAX_GROUP_DESCRIPTION_LENGTH, MAX_GROUP_IMAGE_URL_LENGTH,
+    MAX_GROUP_NAME_LENGTH,
     group_membership::{GroupMembership, MembershipDiff},
     group_permissions::{
         GroupMutablePermissions, GroupMutablePermissionsError, extract_group_permissions,
@@ -349,6 +350,13 @@ impl ValidatedCommit {
                     {
                         return Err(CommitValidationError::TooManyCharacters {
                             length: MAX_GROUP_IMAGE_URL_LENGTH,
+                        });
+                    }
+                    val if val == MetadataField::AppData.as_str()
+                        && new_value.len() > MAX_APP_DATA_LENGTH =>
+                    {
+                        return Err(CommitValidationError::TooManyCharacters {
+                            length: MAX_APP_DATA_LENGTH,
                         });
                     }
                     _ => {}

--- a/xmtp_mls_common/src/group.rs
+++ b/xmtp_mls_common/src/group.rs
@@ -6,6 +6,7 @@ pub struct GroupMetadataOptions {
     pub image_url_square: Option<String>,
     pub description: Option<String>,
     pub message_disappearing_settings: Option<MessageDisappearingSettings>,
+    pub app_data: Option<String>,
 }
 
 #[derive(Default, Clone)]

--- a/xmtp_mls_common/src/group_mutable_metadata.rs
+++ b/xmtp_mls_common/src/group_mutable_metadata.rs
@@ -48,6 +48,7 @@ pub enum MetadataField {
     MessageDisappearInNS,
     MinimumSupportedProtocolVersion,
     CommitLogSigner,
+    AppData,
 }
 
 impl MetadataField {
@@ -62,6 +63,7 @@ impl MetadataField {
             MetadataField::MinimumSupportedProtocolVersion => "minimum_supported_protocol_version",
             // Uses SUPER_ADMIN_METADATA_PREFIX ("_") to make this field super-admin only
             MetadataField::CommitLogSigner => "_commit_log_signer",
+            MetadataField::AppData => "app_data",
         }
     }
 }
@@ -146,6 +148,10 @@ impl GroupMutableMetadata {
             MetadataField::GroupImageUrlSquare.to_string(),
             opts.image_url_square
                 .unwrap_or_else(|| DEFAULT_GROUP_IMAGE_URL_SQUARE.to_string()),
+        );
+        attributes.insert(
+            MetadataField::AppData.to_string(),
+            opts.app_data.unwrap_or_default(),
         );
 
         if let Some(message_disappearing_settings) = opts.message_disappearing_settings {
@@ -234,6 +240,7 @@ impl GroupMutableMetadata {
             MetadataField::MessageDisappearFromNS,
             MetadataField::MessageDisappearInNS,
             MetadataField::MinimumSupportedProtocolVersion,
+            MetadataField::AppData,
         ]
     }
 


### PR DESCRIPTION
### TL;DR

Added support for app data in MLS conversations, allowing applications to store custom data with conversations.

### What changed?

- Added `update_app_data` and `app_data` methods to the `FfiConversation` and `MlsGroup` classes
- Implemented a new `MetadataField::AppData` enum value for storing application-specific data
- Set a maximum length limit of 8192 characters for app data
- Added validation to prevent app data from being set on DM conversations
- Created tests to verify app data functionality, character limits, and DM restrictions

### How to test?

1. Create a new group conversation:
   ```rust
   let group = client.create_group(None, None).unwrap();
   ```

2. Update the app data:
   ```rust
   group.update_app_data("Custom application data".to_string()).await.unwrap();
   ```

3. Retrieve the app data:
   ```rust
   let data = group.app_data().unwrap();
   assert_eq!(data, "Custom application data");
   ```

4. Verify that app data cannot be set on DM conversations:
   ```rust
   let dm = client.find_or_create_dm_by_inbox_id(recipient_id, None).await.unwrap();
   let result = dm.update_app_data("test data".to_string()).await;
   assert!(matches!(result, Err(GroupError::MetadataPermissionsError(_))));
   ```

### Why make this change?

This change enables applications to store custom metadata with conversations, providing flexibility for client applications to maintain application-specific state or configuration data alongside conversations. The 8KB limit allows for reasonably sized data while preventing abuse.