### PR TITLE
Be less opinionated about a target dir

### DIFF
--- a/bindings_ffi/Makefile
+++ b/bindings_ffi/Makefile
@@ -1,7 +1,7 @@
 PROJECT_NAME = xmtpv3
 WORKSPACE_MANIFEST=$(shell cargo locate-project --workspace --message-format=plain)
 WORKSPACE_PATH=$(shell dirname $(WORKSPACE_MANIFEST))
-TARGET_DIR=$(WORKSPACE_PATH)/target
+TARGET_DIR=$(shell cargo metadata --format-version 1 --no-deps | jq -r '.target_directory')
 
 # Simulator config
 ARCHS_IOS = x86_64-apple-ios aarch64-apple-ios-sim

--- a/bindings_ffi/cross_build.sh
+++ b/bindings_ffi/cross_build.sh
@@ -12,7 +12,7 @@ main() {
   BINARY_PROFILE="release"
   WORKSPACE_MANIFEST="$(cargo locate-project --workspace --message-format=plain)"
   WORKSPACE_PATH="$(dirname $WORKSPACE_MANIFEST)"
-  TARGET_DIR="$WORKSPACE_PATH/target"
+  TARGET_DIR="$(cargo metadata --format-version 1 --no-deps | jq -r '.target_directory')"
   BINDINGS_MANIFEST="$WORKSPACE_PATH/bindings_ffi/Cargo.toml"
   # Go to the workspace root so that the workspace config can be found by cross
   cd $WORKSPACE_PATH
@@ -32,13 +32,13 @@ main() {
   cd $(dirname $BINDINGS_MANIFEST) # cd bindings_ffi
   rm -rf jniLibs/
   mkdir -p jniLibs/armeabi-v7a/ && \
-      cp $WORKSPACE_PATH/target/armv7-linux-androideabi/$BINARY_PROFILE/$LIBRARY_NAME.so jniLibs/armeabi-v7a/$TARGET_NAME.so && \
+      cp ${TARGET_DIR}/armv7-linux-androideabi/$BINARY_PROFILE/$LIBRARY_NAME.so jniLibs/armeabi-v7a/$TARGET_NAME.so && \
     mkdir -p jniLibs/x86/ && \
-      cp $WORKSPACE_PATH/target/i686-linux-android/$BINARY_PROFILE/$LIBRARY_NAME.so jniLibs/x86/$TARGET_NAME.so && \
+      cp ${TARGET_DIR}/i686-linux-android/$BINARY_PROFILE/$LIBRARY_NAME.so jniLibs/x86/$TARGET_NAME.so && \
     mkdir -p jniLibs/x86_64/ && \
-      cp $WORKSPACE_PATH/target/x86_64-linux-android/$BINARY_PROFILE/$LIBRARY_NAME.so jniLibs/x86_64/$TARGET_NAME.so && \
+      cp ${TARGET_DIR}/x86_64-linux-android/$BINARY_PROFILE/$LIBRARY_NAME.so jniLibs/x86_64/$TARGET_NAME.so && \
     mkdir -p jniLibs/arm64-v8a/ && \
-      cp $WORKSPACE_PATH/target/aarch64-linux-android/$BINARY_PROFILE/$LIBRARY_NAME.so jniLibs/arm64-v8a/$TARGET_NAME.so
+      cp ${TARGET_DIR}/aarch64-linux-android/$BINARY_PROFILE/$LIBRARY_NAME.so jniLibs/arm64-v8a/$TARGET_NAME.so
 }
 
 time main

--- a/bindings_ffi/gen_kotlin.sh
+++ b/bindings_ffi/gen_kotlin.sh
@@ -7,7 +7,7 @@ WORKSPACE_MANIFEST="$(cargo locate-project --workspace --message-format=plain)"
 WORKSPACE_PATH="$(dirname $WORKSPACE_MANIFEST)"
 BINDINGS_MANIFEST="$WORKSPACE_PATH/bindings_ffi/Cargo.toml"
 BINDINGS_PATH="$(dirname $BINDINGS_MANIFEST)"
-TARGET_DIR="$WORKSPACE_PATH/target"
+TARGET_DIR="$(cargo metadata --format-version 1 --no-deps | jq -r '.target_directory')"
 XMTP_ANDROID="${1:-$(realpath ../../xmtp-android)}"
 
 if [ ! -d $XMTP_ANDROID ]; then

--- a/dev/build_validation_service_local
+++ b/dev/build_validation_service_local
@@ -42,12 +42,13 @@ fi
 # Build the project
 cargo build --release --package mls_validation_service --features test-utils $TARGET_FLAG
 
+TARGET_DIR="$(cargo metadata --format-version 1 --no-deps | jq -r '.target_directory')"
 # Copy the binary to the cache directory
 mkdir -p .cache
 if [ -n "$TARGET_FLAG" ]; then
-    cp -f ./target/x86_64-unknown-linux-gnu/release/mls-validation-service ./.cache/mls-validation-service
+    cp -f ${TARGET_DIR}/x86_64-unknown-linux-gnu/release/mls-validation-service ./.cache/mls-validation-service
 else
-    cp -f ./target/release/mls-validation-service ./.cache/mls-validation-service
+    cp -f ${TARGET_DIR}/release/mls-validation-service ./.cache/mls-validation-service
 fi
 
 # Build the Docker image

--- a/dev/release-kotlin
+++ b/dev/release-kotlin
@@ -26,7 +26,7 @@ WORKSPACE_MANIFEST="$($CARGO locate-project --workspace --message-format=plain)"
 WORKSPACE_PATH="$(dirname $WORKSPACE_MANIFEST)"
 BINDINGS_MANIFEST="$WORKSPACE_PATH/bindings_ffi/Cargo.toml"
 BINDINGS_PATH="$(dirname $BINDINGS_MANIFEST)"
-TARGET_DIR="$WORKSPACE_PATH/target"
+TARGET_DIR="$(cargo metadata --format-version 1 --no-deps | jq -r '.target_directory')"
 
 # Local script to release android jniLibs with same environment as CI
 if [[ "${OSTYPE}" == "darwin"* ]]; then

--- a/dev/release-swift
+++ b/dev/release-swift
@@ -7,7 +7,7 @@ WORKSPACE_MANIFEST="$(cargo locate-project --workspace --message-format=plain)"
 WORKSPACE_PATH="$(dirname $WORKSPACE_MANIFEST)"
 BINDINGS_MANIFEST="$WORKSPACE_PATH/bindings_ffi/Cargo.toml"
 BINDINGS_PATH="$(dirname $BINDINGS_MANIFEST)"
-TARGET_DIR="$WORKSPACE_PATH/target"
+TARGET_DIR="$(cargo metadata --format-version 1 --no-deps | jq -r '.target_directory')"
 XMTP_SWIFT="${1:-$(realpath ../../libxmtp-swift)}"
 
 if [[ "${OSTYPE}" == "darwin"* ]]; then

--- a/dev/test/big_group.sh
+++ b/dev/test/big_group.sh
@@ -19,11 +19,12 @@ if ! jq --version &>/dev/null; then echo "must install jq"; fi
 INBOX_ID=$1
 NETWORK=${2-"dev"}
 EXPORT=$(mktemp)
-CMD="./target/release/xdbg -b $NETWORK"
+TARGET_DIR="$(cargo metadata --format-version 1 --no-deps | jq -r '.target_directory')"
+CMD="${TARGET_DIR}/release/xdbg -b $NETWORK"
 
 cargo build --release --bin xdbg
 echo "writing groups to $EXPORT"
-./target/release/xdbg --clear
+${TARGET_DIR}/release/xdbg --clear
 $CMD --clear
 $CMD generate --entity identity --amount 25
 $CMD generate --entity group --amount 1 --invite 25


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Resolve TARGET_DIR via `cargo metadata` across FFI build scripts to be less opinionated about workspace paths
Update build and release scripts to read `target_directory` from `cargo metadata --format-version 1 --no-deps` and replace hardcoded `./target` references with `${TARGET_DIR}` in Makefiles and shell scripts, including Android artifact copy steps and binary invocations.

#### 📍Where to Start
Start with TARGET_DIR resolution in [bindings_ffi/Makefile](https://github.com/xmtp/libxmtp/pull/2773/files#diff-eb55fdd940fe432ef7aabc155416ccb9a7a7ce2ca85c03425ee7a7c1a25e2915) and trace usage through [bindings_ffi/cross_build.sh](https://github.com/xmtp/libxmtp/pull/2773/files#diff-02e1410852f12918594f470e2ab9d9069f7014a9109497a0a4f25f78d73cdd15) and [dev/build_validation_service_local](https://github.com/xmtp/libxmtp/pull/2773/files#diff-a202dd31b12026b528ff80d1a2ccd4285602a773667d531e1c42613442858ff3).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 670b0a2. 3 files reviewed, 19 issues evaluated, 18 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>bindings_ffi/cross_build.sh — 0 comments posted, 4 evaluated, 4 filtered</summary>

- [line 14](https://github.com/xmtp/libxmtp/blob/670b0a2fad8a995fce17c3ec47083bdcc8e56157/bindings_ffi/cross_build.sh#L14): Multiple unquoted variable expansions and command arguments risk word-splitting and pathname expansion if paths contain spaces or glob characters, causing incorrect arguments or failures. Affected spots include: `dirname $WORKSPACE_MANIFEST` (line 14), `cd $WORKSPACE_PATH` (line 18), `--manifest-path $BINDINGS_MANIFEST` and `--target-dir $TARGET_DIR` (lines 24–27), `cd $(dirname $BINDINGS_MANIFEST)` (line 32), and `cp ${TARGET_DIR}/.../$LIBRARY_NAME.so` and destinations (lines 35, 37, 39, 41). Quote all variable expansions used as paths/args, e.g., `dirname "$WORKSPACE_MANIFEST"`, `cd "$WORKSPACE_PATH"`, `--manifest-path "$BINDINGS_MANIFEST"`, `cp "$TARGET_DIR/.../$LIBRARY_NAME.so" "jniLibs/.../$TARGET_NAME.so"`. <b>[ Out of scope ]</b>
- [line 15](https://github.com/xmtp/libxmtp/blob/670b0a2fad8a995fce17c3ec47083bdcc8e56157/bindings_ffi/cross_build.sh#L15): Dependency on `jq` is not preflight-checked. If `jq` is missing, `TARGET_DIR="$(cargo metadata ... | jq -r ...)"` will fail with a non-obvious error during command substitution. Add an explicit check (`command -v jq >/dev/null 2>&1 || { echo ...; exit 1; }`) to provide a clear error and consistent failure handling. <b>[ Low confidence ]</b>
- [line 20](https://github.com/xmtp/libxmtp/blob/670b0a2fad8a995fce17c3ec47083bdcc8e56157/bindings_ffi/cross_build.sh#L20): Backticks in the error message on missing `cross` cause unintended command execution: `echo -e "${RED} `cargo-cross` not detected..."` attempts to execute `cargo-cross`. With `set -e`, this fails and aborts the script before printing the message, yielding a confusing, premature exit. Use a plain string or escape/quote the backticks, e.g., `echo -e "${RED} 'cargo-cross' not detected...${NC}"`. <b>[ Low confidence ]</b>
- [line 21](https://github.com/xmtp/libxmtp/blob/670b0a2fad8a995fce17c3ec47083bdcc8e56157/bindings_ffi/cross_build.sh#L21): `exit` is called without a non-zero status in the error path after detecting missing `cross`. If the preceding command substitution did not already abort, `exit` would inherit the previous command’s status, potentially exiting with 0. Explicitly use `exit 1`. <b>[ Out of scope ]</b>
</details>

<details>
<summary>bindings_ffi/gen_kotlin.sh — 0 comments posted, 7 evaluated, 7 filtered</summary>

- [line 1](https://github.com/xmtp/libxmtp/blob/670b0a2fad8a995fce17c3ec47083bdcc8e56157/bindings_ffi/gen_kotlin.sh#L1): Script lacks strict error handling (`set -euo pipefail`). Many commands (e.g., `cd`, `cargo build`, `cargo run`, `sed`, `make`, `unzip`, `cp`) can fail but the script continues, producing inconsistent or partial artifacts. Add `set -euo pipefail` and check critical command exit codes. <b>[ Low confidence ]</b>
- [line 10](https://github.com/xmtp/libxmtp/blob/670b0a2fad8a995fce17c3ec47083bdcc8e56157/bindings_ffi/gen_kotlin.sh#L10): Required external tools are used without availability checks: `jq` (lines 10, 55), `make` (line 34), `unzip` (line 80), `cargo`, `curl`. If any are missing, commands fail and, without strict mode, the script may continue. Add preflight checks (e.g., `command -v jq >/dev/null || { echo "jq required"; exit 1; }`). <b>[ Low confidence ]</b>
- [line 13](https://github.com/xmtp/libxmtp/blob/670b0a2fad8a995fce17c3ec47083bdcc8e56157/bindings_ffi/gen_kotlin.sh#L13): Unquoted variable/path expansions cause word-splitting and globbing, breaking paths with spaces or special chars and risking unintended matches/deletions. Quote variables in tests and commands (e.g., `[ ! -d "$XMTP_ANDROID" ]`, `cd "$WORKSPACE_PATH"`, `rm -rf "$BINDINGS_PATH/src/uniffi"`, `cp -r "$BINDINGS_PATH/src/uniffi/$PROJECT_NAME/jniLibs"/* "$XMTP_ANDROID/library/src/main/jniLibs"`). <b>[ Low confidence ]</b>
- [line 16](https://github.com/xmtp/libxmtp/blob/670b0a2fad8a995fce17c3ec47083bdcc8e56157/bindings_ffi/gen_kotlin.sh#L16): On missing Android directory, the script calls `exit` without a status, which exits with 0 (success) after `echo`. It should `exit 1` to signal failure to callers/CI. <b>[ Out of scope ]</b>
- [line 29](https://github.com/xmtp/libxmtp/blob/670b0a2fad8a995fce17c3ec47083bdcc8e56157/bindings_ffi/gen_kotlin.sh#L29): Platform-specific library extension is hard-coded to `.dylib` in `--library $TARGET_DIR/release/lib$PROJECT_NAME.dylib`, causing failures on non-macOS (Linux expects `.so`). Use the previously computed `LIBFILE` (`lib${PROJECT_NAME}.dylib` vs `lib${PROJECT_NAME}.so`) instead: `--library "$TARGET_DIR/release/$LIBFILE"`. <b>[ Out of scope ]</b>
- [line 40](https://github.com/xmtp/libxmtp/blob/670b0a2fad8a995fce17c3ec47083bdcc8e56157/bindings_ffi/gen_kotlin.sh#L40): `sed -i ''` is BSD/macOS-specific. On GNU sed (typical on Linux), `sed -i ''` often errors. Use a cross-platform approach, e.g., detect OS and use `sed -i ''` on macOS and `sed -i` on Linux, or use temporary files. <b>[ Out of scope ]</b>
- [line 47](https://github.com/xmtp/libxmtp/blob/670b0a2fad8a995fce17c3ec47083bdcc8e56157/bindings_ffi/gen_kotlin.sh#L47): Destination directories may not exist before copying: `$XMTP_ANDROID/library/src/main/java` and `$XMTP_ANDROID/library/src/main/jniLibs`. `cp` will fail or create unexpected files. Ensure `mkdir -p "$XMTP_ANDROID/library/src/main/java"` and `mkdir -p "$XMTP_ANDROID/library/src/main/jniLibs"` before copying. <b>[ Low confidence ]</b>
</details>

<details>
<summary>dev/test/big_group.sh — 0 comments posted, 8 evaluated, 7 filtered</summary>

- [line 11](https://github.com/xmtp/libxmtp/blob/670b0a2fad8a995fce17c3ec47083bdcc8e56157/dev/test/big_group.sh#L11): Documentation contradicts implementation: comments state it creates 150 identities and generates 3 test messages, but the script generates 25 identities and 2 messages. This creates uncertainty about intended behavior and can mislead users. <b>[ Low confidence ]</b>
- [line 17](https://github.com/xmtp/libxmtp/blob/670b0a2fad8a995fce17c3ec47083bdcc8e56157/dev/test/big_group.sh#L17): `jq` dependency check does not exit when missing. If `jq` is not installed, the script only prints "must install jq" and continues, leading to a later hard failure (e.g., at line 22 or 32) under `set -e`. It should exit immediately with a nonzero status after the message. <b>[ Out of scope ]</b>
- [line 19](https://github.com/xmtp/libxmtp/blob/670b0a2fad8a995fce17c3ec47083bdcc8e56157/dev/test/big_group.sh#L19): Required argument `INBOX_ID` is not validated. With `set -u`, invoking the script without an argument will cause an "unbound variable" error at `INBOX_ID=$1` rather than a helpful usage message, terminating the script abruptly. <b>[ Out of scope ]</b>
- [line 21](https://github.com/xmtp/libxmtp/blob/670b0a2fad8a995fce17c3ec47083bdcc8e56157/dev/test/big_group.sh#L21): Temporary file created with `mktemp` is never cleaned up. Moreover, the script starts an infinite loop (`$CMD generate --entity message --amount 2 --loop`), making cleanup unreachable. This leaks temp files on every run. Add a `trap` to remove `$EXPORT` on exit and interrupt (e.g., INT/TERM), and consider finite loops or backgrounding with teardown. <b>[ Low confidence ]</b>
- [line 27](https://github.com/xmtp/libxmtp/blob/670b0a2fad8a995fce17c3ec47083bdcc8e56157/dev/test/big_group.sh#L27): Inconsistent backend flag on `--clear`: line 27 calls `${TARGET_DIR}/release/xdbg --clear` without `-b $NETWORK`, while line 28 calls `$CMD --clear` with the backend. This can clear a different/default backend first, causing unintended data loss or mismatch. It’s also duplicative. <b>[ Low confidence ]</b>
- [line 31](https://github.com/xmtp/libxmtp/blob/670b0a2fad8a995fce17c3ec47083bdcc8e56157/dev/test/big_group.sh#L31): Unquoted file paths: `$EXPORT` and `${TARGET_DIR}` are used unquoted in multiple places (e.g., lines 31–32, 27, 28). If paths contain spaces or glob characters, commands and `jq` will fail or misinterpret arguments. Quote all path expansions. <b>[ Low confidence ]</b>
- [line 32](https://github.com/xmtp/libxmtp/blob/670b0a2fad8a995fce17c3ec47083bdcc8e56157/dev/test/big_group.sh#L32): `GROUP_ID` is not validated after extraction: `GROUP_ID=$(jq -r '.[0].id' $EXPORT)`. If export yields an empty array or missing `id`, `GROUP_ID` may be empty, and the subsequent `modify` command will run with an empty group id, causing confusing failures. Add a check to ensure `GROUP_ID` is non-empty and fail clearly. <b>[ Low confidence ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->