### PR TITLE
Move events from static to part of context

### DIFF
--- a/xmtp_mls/src/builder.rs
+++ b/xmtp_mls/src/builder.rs
@@ -275,6 +275,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
 
         let (local_events, _) = broadcast::channel(32);
         let (worker_tx, _) = broadcast::channel(32);
+        let (events, _) = broadcast::channel(32);
         let mut workers = WorkerRunner::new();
         let context = Arc::new(XmtpMlsLocalContext {
             identity,
@@ -287,6 +288,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             mls_commit_lock: Arc::new(GroupCommitLock::new()),
             local_events: local_events.clone(),
             worker_events: worker_tx.clone(),
+            events,
             device_sync: DeviceSync {
                 server_url: device_sync_server_url,
                 mode: device_sync_worker_mode,
@@ -352,7 +354,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
         if let Err(err) = Events::clear_old_events(&client.db()) {
             tracing::warn!("ClientEvents clear old events: {err:?}");
         }
-        track!("Client Build");
+        track!(&client.context, "Client Build");
 
         Ok(client)
     }

--- a/xmtp_mls/src/client.rs
+++ b/xmtp_mls/src/client.rs
@@ -515,6 +515,7 @@ where
             .send(LocalEvents::NewGroup(group.group_id.clone()));
 
         track!(
+            &self.context,
             "Group Create",
             {
                 "conversation_type": ConversationType::Group

--- a/xmtp_mls/src/context.rs
+++ b/xmtp_mls/src/context.rs
@@ -20,6 +20,7 @@ use xmtp_api_d14n::protocol::XmtpQuery;
 use xmtp_common::{MaybeSend, MaybeSync};
 use xmtp_db::XmtpDb;
 use xmtp_db::XmtpMlsStorageProvider;
+use xmtp_db::events::Events;
 use xmtp_db::xmtp_openmls_provider::XmtpOpenMlsProviderRef;
 use xmtp_id::scw_verifier::SmartContractSignatureVerifier;
 use xmtp_id::{InboxIdRef, associations::builder::SignatureRequest};
@@ -45,6 +46,7 @@ pub struct XmtpMlsLocalContext<ApiClient, Db, S> {
     pub(crate) version_info: VersionInfo,
     pub(crate) local_events: broadcast::Sender<LocalEvents>,
     pub(crate) worker_events: broadcast::Sender<SyncWorkerEvent>,
+    pub(crate) events: broadcast::Sender<Events>,
     pub(crate) scw_verifier: Arc<Box<dyn SmartContractSignatureVerifier>>,
     pub(crate) device_sync: DeviceSync,
     pub(crate) fork_recovery_opts: ForkRecoveryOpts,
@@ -116,6 +118,7 @@ impl<ApiClient, Db, S> XmtpMlsLocalContext<ApiClient, Db, S> {
             version_info: self.version_info,
             local_events: self.local_events,
             worker_events: self.worker_events,
+            events: self.events,
             scw_verifier: self.scw_verifier,
             device_sync: self.device_sync,
             fork_recovery_opts: self.fork_recovery_opts,
@@ -216,6 +219,7 @@ where
     fn version_info(&self) -> &VersionInfo;
     fn worker_events(&self) -> &broadcast::Sender<SyncWorkerEvent>;
     fn local_events(&self) -> &broadcast::Sender<LocalEvents>;
+    fn events(&self) -> &broadcast::Sender<Events>;
     fn task_channels(&self) -> &TaskWorkerChannels;
     fn sync_metrics(&self) -> Option<Arc<WorkerMetrics<SyncMetric>>>;
     fn mls_commit_lock(&self) -> &Arc<GroupCommitLock>;
@@ -281,6 +285,10 @@ where
 
     fn local_events(&self) -> &broadcast::Sender<LocalEvents> {
         &self.local_events
+    }
+
+    fn events(&self) -> &broadcast::Sender<Events> {
+        &self.events
     }
 
     fn mls_commit_lock(&self) -> &Arc<GroupCommitLock> {
@@ -366,6 +374,10 @@ where
 
     fn local_events(&self) -> &broadcast::Sender<LocalEvents> {
         <T as XmtpSharedContext>::local_events(self)
+    }
+
+    fn events(&self) -> &broadcast::Sender<Events> {
+        <T as XmtpSharedContext>::events(self)
     }
 
     fn mls_commit_lock(&self) -> &Arc<GroupCommitLock> {

--- a/xmtp_mls/src/groups/intents/queue.rs
+++ b/xmtp_mls/src/groups/intents/queue.rs
@@ -181,6 +181,7 @@ impl QueueIntent {
             conn.update_rotated_at_ns(group.group_id.clone())?;
 
             track!(
+                &group.context,
                 "Queue Intent",
                 { "intent_kind": intent_kind },
                 group: &group.group_id

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -566,7 +566,7 @@ where
         // Consent state defaults to allowed when the user creates the group
         new_group.update_consent_state(ConsentState::Allowed)?;
 
-        track!("Group Create", { "conversation_type": ConversationType::Dm }, group: &new_group.group_id);
+        track!(context, "Group Create", { "conversation_type": ConversationType::Dm }, group: &new_group.group_id);
 
         Ok(new_group)
     }
@@ -868,6 +868,7 @@ where
 
         self.sync_until_intent_resolved(intent.id).await?;
         track!(
+            &self.context,
             "Group Membership Change",
             {
                 "added": ids,
@@ -933,6 +934,7 @@ where
         let _ = self.sync_until_intent_resolved(intent.id).await?;
 
         track!(
+            &self.context,
             "Group Membership Change",
             {
                 "added": (),
@@ -983,6 +985,7 @@ where
         let _ = self.sync_until_intent_resolved(intent.id).await?;
 
         track!(
+            &self.context,
             "Readd Installations",
             {
                 "installations": installations

--- a/xmtp_mls/src/groups/tests/test_welcomes.rs
+++ b/xmtp_mls/src/groups/tests/test_welcomes.rs
@@ -66,6 +66,7 @@ async fn test_spoofed_inbox_id() {
         version_info: alix.context.version_info.clone(),
         local_events: alix.context.local_events.clone(),
         worker_events: alix.context.worker_events.clone(),
+        events: alix.context.events.clone(),
         scw_verifier: alix.context.scw_verifier.clone(),
         device_sync: alix.context.device_sync.clone(),
         fork_recovery_opts: alix.context.fork_recovery_opts.clone(),

--- a/xmtp_mls/src/groups/welcomes/xmtp_welcome.rs
+++ b/xmtp_mls/src/groups/welcomes/xmtp_welcome.rs
@@ -422,6 +422,7 @@ where
 
         StoredConsentRecord::stitch_dm_consent(&db, &stored_group)?;
         track!(
+            &self.context,
             "Group Welcome",
             {
                 "conversation_type": stored_group.conversation_type,

--- a/xmtp_mls/src/subscriptions/stream_all.rs
+++ b/xmtp_mls/src/subscriptions/stream_all.rs
@@ -88,6 +88,7 @@ where
                 .await?;
 
             track!(
+                context.as_ref(),
                 "Message Stream Connect",
                 {
                     "conversation_type": conversation_type,

--- a/xmtp_mls/src/test/mock.rs
+++ b/xmtp_mls/src/test/mock.rs
@@ -83,6 +83,7 @@ impl Clone for NewMockContext {
             version_info: self.version_info.clone(),
             local_events: self.local_events.clone(),
             worker_events: self.worker_events.clone(),
+            events: self.events.clone(),
             scw_verifier: self.scw_verifier.clone(),
             device_sync: self.device_sync.clone(),
             fork_recovery_opts: self.fork_recovery_opts.clone(),
@@ -142,6 +143,10 @@ impl XmtpSharedContext for NewMockContext {
 
     fn local_events(&self) -> &broadcast::Sender<crate::subscriptions::LocalEvents> {
         &self.local_events
+    }
+
+    fn events(&self) -> &broadcast::Sender<xmtp_db::events::Events> {
+        &self.events
     }
 
     fn mls_commit_lock(&self) -> &Arc<crate::GroupCommitLock> {

--- a/xmtp_mls/src/test/mock/generate.rs
+++ b/xmtp_mls/src/test/mock/generate.rs
@@ -14,8 +14,9 @@ use rstest::*;
 
 #[fixture]
 pub fn context() -> NewMockContext {
-    let (tx, _) = tokio::sync::broadcast::channel(32);
-    let (worker_tx, _) = tokio::sync::broadcast::channel(32);
+    let (local_events, _) = tokio::sync::broadcast::channel(32);
+    let (worker_events, _) = tokio::sync::broadcast::channel(32);
+    let (events, _) = tokio::sync::broadcast::channel(32);
     XmtpMlsLocalContext {
         identity: Identity::mock_identity(),
         api_client: ApiClientWrapper::new(MockApiClient::new(), Default::default()),
@@ -23,8 +24,9 @@ pub fn context() -> NewMockContext {
         mutexes: MutexRegistry::new(),
         mls_commit_lock: Default::default(),
         version_info: VersionInfo::default(),
-        local_events: tx,
-        worker_events: worker_tx,
+        local_events,
+        worker_events,
+        events,
         scw_verifier: Arc::new(Box::new(MockSmartContractSignatureVerifier::new(true))),
         device_sync: DeviceSync {
             server_url: None,


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Route event tracking through per-context channels and require a context parameter across tracking macros in `xmtp_mls`
Replace the global event channel with a per-context `broadcast::Sender<Events>`, add `events()` to `XmtpSharedContext`, wire the sender in `XmtpMlsLocalContext`, and update all `track!`, `track_err!`, and `track_request!` call sites to pass a context reference. Event workers now subscribe via `context.events()`.

#### 📍Where to Start
Start with the event system changes in [`xmtp_mls/src/utils/events.rs`](https://github.com/xmtp/libxmtp/pull/2774/files#diff-ce9fefe703e71aaec834943a4dedd35e7e57e445e09a2238fe0a6b6de6ba3338), then review the context trait and struct updates in [`xmtp_mls/src/context.rs`](https://github.com/xmtp/libxmtp/pull/2774/files#diff-dec1fc3de5dd13f41fcf44c4d5b4d1dbb7f4fb2652ead1eda88879ec391f454d) and the builder wiring in [`xmtp_mls/src/builder.rs`](https://github.com/xmtp/libxmtp/pull/2774/files#diff-2df8df9acb5405ca5c2dde2487e92ffc9a7daf6be38dd075a2a2d4878cc35ce6).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 56efdb2.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->