### PR TITLE
Add DB disconnect and reconnect to Node.js bindings

### DIFF
--- a/bindings_node/src/client.rs
+++ b/bindings_node/src/client.rs
@@ -445,4 +445,22 @@ impl Client {
 
     Ok(message.into())
   }
+
+  #[napi]
+  pub fn release_db_connection(&self) -> Result<()> {
+    self
+      .inner_client
+      .release_db_connection()
+      .map_err(ErrorWrapper::from)?;
+    Ok(())
+  }
+
+  #[napi]
+  pub async fn db_reconnect(&self) -> Result<()> {
+    self
+      .inner_client
+      .reconnect_db()
+      .map_err(ErrorWrapper::from)?;
+    Ok(())
+  }
 }

--- a/bindings_node/test/Client.test.ts
+++ b/bindings_node/test/Client.test.ts
@@ -366,6 +366,26 @@ describe('Client', () => {
       verifySignedWithPublicKey(text, signature, new Uint8Array())
     ).toThrow()
   })
+
+  it('should release and reconnect database connection', async () => {
+    const user = createUser()
+    const client = await createRegisteredClient(user)
+
+    // Verify database operations work initially
+    expect(() => client.conversations().list()).not.toThrow()
+
+    // Release the database connection
+    client.releaseDbConnection()
+
+    // Verify database operations fail when connection is released
+    expect(() => client.conversations().list()).toThrow()
+
+    // Reconnect the database
+    await client.dbReconnect()
+
+    // Verify database operations work again after reconnecting
+    expect(() => client.conversations().list()).not.toThrow()
+  })
 })
 
 describe('Streams', () => {


### PR DESCRIPTION
### TL;DR

Added database connection management capabilities to the Node.js bindings.

### What changed?

- Added two new methods to the Node.js client:
  - `releaseDbConnection()`: Allows explicitly releasing the database connection
  - `dbReconnect()`: Provides a way to reconnect to the database after releasing the connection

### How to test?

The PR includes a new test case that:
1. Creates a client and verifies database operations work
2. Releases the database connection and confirms operations fail
3. Reconnects to the database and verifies operations work again

### Why make this change?

These methods provide more control over database connection management, which can be useful for:
- Explicitly releasing resources when they're no longer needed
- Handling connection issues by allowing manual reconnection
- Supporting scenarios where connections need to be temporarily closed and reopened