### PR TITLE
dont use ephemeral port range for toxiproxy

### DIFF
--- a/dev/docker/docker-compose.yml
+++ b/dev/docker/docker-compose.yml
@@ -79,7 +79,12 @@ services:
     image: ghcr.io/shopify/toxiproxy:2.12.0
     ports:
       - 8474:8474
-      - 40000-40100:40000-40100
+      - 6010:6010
+      - 6020:6020
+      - 6030:6030
+      - 6040:6040
+      - 6050:6050
+      - 6060:6060
     networks:
       - proxynet
     depends_on:

--- a/dev/docker/toxiproxy/config.json
+++ b/dev/docker/toxiproxy/config.json
@@ -1,37 +1,37 @@
 [
   {
     "name": "node-go",
-    "listen": "[::]:40010",
+    "listen": "[::]:6010",
     "upstream": "node:5556",
     "enabled": true
   },
   {
     "name": "grpc-web",
-    "listen": "[::]:40020",
+    "listen": "[::]:6020",
     "upstream": "node-web:5557",
     "enabled": true
   },
   {
     "name": "xmtpd",
-    "listen": "[::]:40030",
+    "listen": "[::]:6030",
     "upstream": "xmtpd:5050",
     "enabled": true
   },
   {
     "name": "gateway",
-    "listen": "[::]:40040",
+    "listen": "[::]:6040",
     "upstream": "xmtpd:5052",
     "enabled": true
   },
   {
     "name": "history-server",
-    "listen": "[::]:40050",
+    "listen": "[::]:6050",
     "upstream": "history-server:5558",
     "enabled": true
   },
   {
     "name": "anvil",
-    "listen": "[::]:40060",
+    "listen": "[::]:6060",
     "upstream": "anvil:8545",
     "enabled": true
   }

--- a/xmtp_configuration/src/common/api.rs
+++ b/xmtp_configuration/src/common/api.rs
@@ -124,15 +124,15 @@ impl GrpcUrlsProduction {
 pub struct GrpcUrlsToxic;
 impl GrpcUrlsToxic {
     /// URL to ToxiProxy version of NODE-GO
-    pub const NODE: &'static str = "http://localhost:40010";
+    pub const NODE: &'static str = "http://localhost:6010";
     /// URL to ToxiProxy version of NODE-GO Grpc Web
-    pub const NODE_WEB: &'static str = "http://localhost:40020";
+    pub const NODE_WEB: &'static str = "http://localhost:6020";
     /// URL to ToxiProxy version of XMTPD
-    pub const XMTPD: &'static str = "http://localhost:40030";
+    pub const XMTPD: &'static str = "http://localhost:6030";
     /// URL to ToxiProxy version of Payer Gateway
-    pub const GATEWAY: &'static str = "http://localhost:40040";
+    pub const GATEWAY: &'static str = "http://localhost:6040";
     /// Url to ToxiProxy version of History Server
-    pub const HISTORY_SERVER: &'static str = "http://localhost:40050";
+    pub const HISTORY_SERVER: &'static str = "http://localhost:6050";
     /// Url to ToxiProxy version of Anvil
-    pub const ANVIL: &'static str = "http://localhost:40060";
+    pub const ANVIL: &'static str = "http://localhost:6060";
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Pin Toxiproxy to fixed ports 6010–6060 across Docker and `GrpcUrlsToxic` to avoid ephemeral port range
Switch Toxiproxy from a 40000–40100 range to explicit ports 6010–6060 and update service URLs accordingly. Key edits are in [docker-compose.yml](https://github.com/xmtp/libxmtp/pull/2787/files#diff-6a25daaa729d7279e0cda8eb92399f1a82d4a91f961e1955bb5745e9c99f3c6e), [config.json](https://github.com/xmtp/libxmtp/pull/2787/files#diff-6188f88cea9763b26b3aaff796da6cdce4ce8b03996aa6870b8fcd2bb17bd81b), and [api.rs](https://github.com/xmtp/libxmtp/pull/2787/files#diff-39a51878d920f382b984f1a8d7c230f21c4e27d6d87fab53c0c1646c77d863a0).

#### 📍Where to Start
Start with the `GrpcUrlsToxic` constants in [api.rs](https://github.com/xmtp/libxmtp/pull/2787/files#diff-39a51878d920f382b984f1a8d7c230f21c4e27d6d87fab53c0c1646c77d863a0) to verify client URLs, then review Toxiproxy listeners in [config.json](https://github.com/xmtp/libxmtp/pull/2787/files#diff-6188f88cea9763b26b3aaff796da6cdce4ce8b03996aa6870b8fcd2bb17bd81b) and port mappings in [docker-compose.yml](https://github.com/xmtp/libxmtp/pull/2787/files#diff-6a25daaa729d7279e0cda8eb92399f1a82d4a91f961e1955bb5745e9c99f3c6e).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized b32b93f.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->