### PR TITLE
set dependencies in send message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8511,6 +8511,7 @@ dependencies = [
  "tracing",
  "url",
  "wasm-bindgen-test",
+ "xmtp_api_d14n",
  "xmtp_api_grpc",
  "xmtp_common",
  "xmtp_configuration",

--- a/xmtp_api_d14n/Cargo.toml
+++ b/xmtp_api_d14n/Cargo.toml
@@ -51,9 +51,8 @@ hex.workspace = true
 mockall.workspace = true
 rstest.workspace = true
 tokio.workspace = true
-xmtp_api_grpc = { workspace = true, features = ["test-utils"] }
-xmtp_common = { workspace = true, features = ["test-utils"] }
-xmtp_proto = { workspace = true, features = ["test-utils"] }
+# add self to auto enable test utils
+xmtp_api_d14n = { path = ".", features = ["test-utils"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 ctor.workspace = true
@@ -74,6 +73,8 @@ proptest = { workspace = true, features = ["std"] }
 [features]
 test-utils = [
   "xmtp_api_grpc/test-utils",
+  "xmtp_common/test-utils",
+  "xmtp_proto/test-utils",
   "dep:mockall",
   "dep:ctor",
   "dep:wasm-bindgen-test",

--- a/xmtp_api_d14n/proptest-regressions/queries/d14n/mls.txt
+++ b/xmtp_api_d14n/proptest-regressions/queries/d14n/mls.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 5d814d53ef778e88d34a7aabaa7e5262f87062e79ef5df9d50a35f3363c2c3b5 # shrinks to generated = TestRequest { request: SendGroupMessagesRequest { messages: [] }, dependencies: {} }

--- a/xmtp_api_d14n/src/protocol/extractors/data.rs
+++ b/xmtp_api_d14n/src/protocol/extractors/data.rs
@@ -1,5 +1,6 @@
 //! Extractor for an MLS Data field
 //! useful for verifing a message has been read or maybe duplicates.
+use xmtp_common::sha256_bytes;
 use xmtp_proto::ConversionError;
 use xmtp_proto::mls_v1::group_message_input::V1 as GroupMessageV1;
 use xmtp_proto::mls_v1::welcome_message_input::V1 as WelcomeMessageV1;
@@ -19,13 +20,20 @@ impl MlsDataExtractor {
     pub fn new() -> Self {
         Default::default()
     }
+
+    pub fn get_sha256(self) -> <Self as Extractor>::Output {
+        let data = self.get()?;
+        // should be a smallvec type, or a [u8; 32];
+        Ok(sha256_bytes(&data))
+    }
 }
+
 impl Extractor for MlsDataExtractor {
     type Output = Result<Vec<u8>, ConversionError>;
 
     fn get(self) -> Self::Output {
         self.data.ok_or(ConversionError::Missing {
-            item: "data",
+            item: "MlsDataEnvelope",
             r#type: std::any::type_name::<Vec<u8>>(),
         })
     }

--- a/xmtp_api_d14n/src/protocol/impls/protocol_envelopes.rs
+++ b/xmtp_api_d14n/src/protocol/impls/protocol_envelopes.rs
@@ -10,7 +10,7 @@ use xmtp_proto::mls_v1::subscribe_welcome_messages_request::Filter as SubscribeW
 use xmtp_proto::mls_v1::{
     SubscribeGroupMessagesRequest, SubscribeWelcomeMessagesRequest, welcome_message,
 };
-use xmtp_proto::types::Topic;
+use xmtp_proto::types::{Cursor, Topic};
 use xmtp_proto::xmtp::xmtpv4::message_api::{
     SubscribeEnvelopesResponse, get_newest_envelope_response,
 };
@@ -478,8 +478,16 @@ impl EnvelopeCollection<'_> for SubscribeEnvelopesResponse {
         self.envelopes.topics()
     }
 
+    fn cursors(&self) -> Result<Vec<Cursor>, EnvelopeError> {
+        self.envelopes.cursors()
+    }
+
     fn payloads(&self) -> Result<Vec<Payload>, EnvelopeError> {
         self.envelopes.payloads()
+    }
+
+    fn sha256_hashes(&self) -> Result<Vec<Vec<u8>>, EnvelopeError> {
+        self.envelopes.sha256_hashes()
     }
 
     fn client_envelopes(&self) -> Result<Vec<ClientEnvelope>, EnvelopeError> {
@@ -522,8 +530,16 @@ impl EnvelopeCollection<'_> for SubscribeGroupMessagesRequest {
         self.filters.topics()
     }
 
+    fn cursors(&self) -> Result<Vec<Cursor>, EnvelopeError> {
+        self.filters.cursors()
+    }
+
     fn payloads(&self) -> Result<Vec<Payload>, EnvelopeError> {
         self.filters.payloads()
+    }
+
+    fn sha256_hashes(&self) -> Result<Vec<Vec<u8>>, EnvelopeError> {
+        self.filters.sha256_hashes()
     }
 
     fn client_envelopes(&self) -> Result<Vec<ClientEnvelope>, EnvelopeError> {
@@ -565,8 +581,16 @@ impl EnvelopeCollection<'_> for SubscribeWelcomeMessagesRequest {
         self.filters.topics()
     }
 
+    fn cursors(&self) -> Result<Vec<Cursor>, EnvelopeError> {
+        self.filters.cursors()
+    }
+
     fn payloads(&self) -> Result<Vec<Payload>, EnvelopeError> {
         self.filters.payloads()
+    }
+
+    fn sha256_hashes(&self) -> Result<Vec<Vec<u8>>, EnvelopeError> {
+        self.filters.sha256_hashes()
     }
 
     fn client_envelopes(&self) -> Result<Vec<ClientEnvelope>, EnvelopeError> {

--- a/xmtp_api_d14n/src/protocol/in_memory_cursor_store.rs
+++ b/xmtp_api_d14n/src/protocol/in_memory_cursor_store.rs
@@ -1,7 +1,7 @@
-use crate::protocol::{CursorStore, VectorClock};
+use crate::protocol::{CursorStore, CursorStoreError, VectorClock};
 use std::collections::HashMap;
 use std::fmt;
-use xmtp_proto::types::{GlobalCursor, OriginatorId, Topic};
+use xmtp_proto::types::{Cursor, GlobalCursor, OriginatorId, Topic};
 
 #[derive(Default, Clone)]
 pub struct InMemoryCursorStore {
@@ -92,6 +92,16 @@ impl CursorStore for InMemoryCursorStore {
         Ok(topics
             .map(|topic| (topic.clone(), self.latest(topic).unwrap_or_default()))
             .collect())
+    }
+
+    fn find_message_dependencies(
+        &self,
+        hash: &[&[u8]],
+    ) -> Result<HashMap<Vec<u8>, Cursor>, super::CursorStoreError> {
+        // in mem does not keep track of deps/commits
+        Err(CursorStoreError::NoDependenciesFound(
+            hash.iter().map(hex::encode).collect(),
+        ))
     }
 }
 

--- a/xmtp_api_d14n/src/protocol/sort/timestamp.rs
+++ b/xmtp_api_d14n/src/protocol/sort/timestamp.rs
@@ -113,6 +113,10 @@ mod tests {
         fn depends_on(&self) -> Result<Option<xmtp_proto::types::GlobalCursor>, EnvelopeError> {
             unreachable!()
         }
+
+        fn sha256_hash(&self) -> Result<Vec<u8>, EnvelopeError> {
+            unreachable!()
+        }
     }
 
     prop_compose! {

--- a/xmtp_api_d14n/src/protocol/traits/envelope_collection.rs
+++ b/xmtp_api_d14n/src/protocol/traits/envelope_collection.rs
@@ -1,5 +1,6 @@
 //! Traits and blanket implementations representing a collection of [`Envelope`]'s
 use xmtp_common::{MaybeSend, MaybeSync};
+use xmtp_proto::types::Cursor;
 
 use super::*;
 
@@ -9,8 +10,12 @@ use super::*;
 pub trait EnvelopeCollection<'env>: MaybeSend + MaybeSync {
     /// Get the topic for an envelope
     fn topics(&self) -> Result<Vec<Topic>, EnvelopeError>;
+    /// get the cursors for each envelope
+    fn cursors(&self) -> Result<Vec<Cursor>, EnvelopeError>;
     /// Get the payload for an envelope
     fn payloads(&self) -> Result<Vec<Payload>, EnvelopeError>;
+    /// get the data field for each envelope as a sha256 hash
+    fn sha256_hashes(&self) -> Result<Vec<Vec<u8>>, EnvelopeError>;
     /// Build the ClientEnvelope
     fn client_envelopes(&self) -> Result<Vec<ClientEnvelope>, EnvelopeError>;
     /// Try to get a group message from this Envelope
@@ -39,10 +44,22 @@ where
             .collect::<Result<Vec<Topic>, _>>()
     }
 
+    fn cursors(&self) -> Result<Vec<Cursor>, EnvelopeError> {
+        self.iter()
+            .map(|t| t.cursor())
+            .collect::<Result<Vec<Cursor>, _>>()
+    }
+
     fn payloads(&self) -> Result<Vec<Payload>, EnvelopeError> {
         self.iter()
             .map(|t| t.payload())
             .collect::<Result<Vec<Payload>, _>>()
+    }
+
+    fn sha256_hashes(&self) -> Result<Vec<Vec<u8>>, EnvelopeError> {
+        self.iter()
+            .map(|t| t.sha256_hash())
+            .collect::<Result<Vec<Vec<u8>>, _>>()
     }
 
     fn client_envelopes(&self) -> Result<Vec<ClientEnvelope>, EnvelopeError> {

--- a/xmtp_api_d14n/src/protocol/traits/visitor.rs
+++ b/xmtp_api_d14n/src/protocol/traits/visitor.rs
@@ -113,12 +113,12 @@ pub trait EnvelopeVisitor<'env> {
         tracing::trace!("noop_visit_client");
         Ok(())
     }
-    /// Visit the GroupMessageInput type
+    /// Visit the GroupMessageVersion type
     fn visit_group_message_version(&mut self, _m: &GroupMessageVersion) -> Result<(), Self::Error> {
         tracing::trace!("noop_visit_group_message_version");
         Ok(())
     }
-    /// Visit the WelcomeMessageInput containing the welcome message version
+    /// Visit the GroupMessageInput containing the welcome message version
     fn visit_group_message_input(&mut self, _m: &GroupMessageInput) -> Result<(), Self::Error> {
         tracing::trace!("noop_visit_group_message_input");
         Ok(())

--- a/xmtp_api_d14n/src/protocol/traits/xmtp_query.rs
+++ b/xmtp_api_d14n/src/protocol/traits/xmtp_query.rs
@@ -1,5 +1,6 @@
 //! XmtpQuery allows accessing the network while bypassing any local cursor cache.
 use xmtp_common::{MaybeSend, MaybeSync};
+use xmtp_proto::types::Cursor;
 
 use super::*;
 
@@ -33,6 +34,10 @@ impl XmtpEnvelope {
         self.inner.len()
     }
 
+    pub fn cursors(&self) -> Result<Vec<Cursor>, EnvelopeError> {
+        self.inner.cursors()
+    }
+
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }
@@ -48,5 +53,9 @@ impl XmtpEnvelope {
             .into_iter()
             .flatten()
             .collect())
+    }
+
+    pub fn client_envelopes(&self) -> Result<Vec<ClientEnvelope>, EnvelopeError> {
+        self.inner.client_envelopes()
     }
 }

--- a/xmtp_api_d14n/src/protocol/utils/test/test_envelope.rs
+++ b/xmtp_api_d14n/src/protocol/utils/test/test_envelope.rs
@@ -82,4 +82,8 @@ impl Envelope<'_> for TestEnvelope {
     fn depends_on(&self) -> Result<Option<xmtp_proto::types::GlobalCursor>, EnvelopeError> {
         Ok(Some(self.depends_on.clone()))
     }
+
+    fn sha256_hash(&self) -> Result<Vec<u8>, EnvelopeError> {
+        unreachable!()
+    }
 }

--- a/xmtp_api_d14n/src/queries/d14n.rs
+++ b/xmtp_api_d14n/src/queries/d14n.rs
@@ -9,3 +9,6 @@ xmtp_common::if_test! {
     mod test_client;
 }
 pub use client::*;
+
+#[cfg(test)]
+mod test;

--- a/xmtp_api_d14n/src/queries/d14n/client.rs
+++ b/xmtp_api_d14n/src/queries/d14n/client.rs
@@ -22,7 +22,30 @@ impl<C, Store> D14nClient<C, Store> {
         })
     }
 }
+xmtp_common::if_test! {
+    use xmtp_proto::api::mock::MockNetworkClient;
+    use crate::protocol::NoCursorStore;
 
+    impl crate::MockD14nClient {
+        pub fn new_mock() -> Self {
+            Self {
+                client: MockNetworkClient::new(),
+                cursor_store: NoCursorStore,
+                scw_verifier: Arc::new(MultiSmartContractSignatureVerifier::new_from_env().expect("scw failed")),
+            }
+        }
+    }
+    impl<S> D14nClient<MockNetworkClient, S> {
+        pub fn new_mock_with_store(store: S) -> Self {
+        Self {
+            client: MockNetworkClient::new(),
+            cursor_store: store,
+            scw_verifier: Arc::new(MultiSmartContractSignatureVerifier::new_from_env().expect("scw failed")),
+        }
+    }
+}
+
+}
 #[xmtp_common::async_trait]
 impl<C, Store> IsConnectedCheck for D14nClient<C, Store>
 where

--- a/xmtp_api_d14n/src/queries/d14n/test.rs
+++ b/xmtp_api_d14n/src/queries/d14n/test.rs
@@ -1,0 +1,2 @@
+mod send_group_message;
+pub use send_group_message::*;

--- a/xmtp_api_d14n/src/queries/d14n/test/send_group_message.rs
+++ b/xmtp_api_d14n/src/queries/d14n/test/send_group_message.rs
@@ -1,0 +1,145 @@
+use std::collections::HashMap;
+
+use openmls::prelude::MlsMessageOut;
+use openmls::prelude::tls_codec::Serialize;
+use openmls::test_utils::frankenstein::FrankenFramedContentBody;
+use openmls::test_utils::frankenstein::FrankenMlsMessage;
+use openmls::test_utils::frankenstein::FrankenMlsMessageBody;
+use openmls::test_utils::frankenstein::FrankenPublicMessage;
+use proptest::collection;
+use proptest::prelude::*;
+use xmtp_common::FakeMlsApplicationMessage;
+use xmtp_common::Generate;
+use xmtp_common::sha256_bytes;
+use xmtp_proto::types::Cursor;
+use xmtp_proto::types::GlobalCursor;
+use xmtp_proto::types::OriginatorId;
+use xmtp_proto::types::Topic;
+use xmtp_proto::xmtp::mls::api::v1::GroupMessageInput;
+use xmtp_proto::xmtp::mls::api::v1::SendGroupMessagesRequest;
+use xmtp_proto::xmtp::mls::api::v1::group_message_input;
+
+use crate::protocol::CursorStore;
+use crate::protocol::CursorStoreError;
+
+#[derive(Clone)]
+pub struct TestRequest {
+    pub request: SendGroupMessagesRequest,
+    pub dependencies: HashMap<Vec<u8>, Cursor>,
+}
+
+impl std::fmt::Debug for TestRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TestRequest")
+            .field("request", &self.request);
+        for (hash, cursor) in self.dependencies.iter() {
+            write!(f, "[{}/{}]", hex::encode(hash), cursor)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct MessageWithDependency {
+    pub request: GroupMessageInput,
+    pub hash: [u8; 32],
+}
+
+prop_compose! {
+    fn group_message()(data in collection::vec(any::<u8>(), 32), group_id in collection::vec(any::<u8>(), 16)) -> MessageWithDependency {
+        let mut msg = FrankenPublicMessage::generate();
+        msg.content.group_id = group_id.into();
+        msg.content.body = FrankenFramedContentBody::Application(data.into());
+        let message = FakeMlsApplicationMessage {
+            inner: FrankenMlsMessage {
+                version: 1,
+                body: FrankenMlsMessageBody::PublicMessage(msg)
+            }
+        };
+        let out: MlsMessageOut = message.into();
+        let out = out.tls_serialize_detached().unwrap();
+        let hash = sha256_bytes(&out);
+        let input = GroupMessageInput {
+            version: Some(group_message_input::Version::V1(group_message_input::V1 {
+                data: out,
+                sender_hmac: vec![],
+                should_push: false,
+            })),
+        };
+        let mut buffer = [0u8; 32];
+        buffer.copy_from_slice(&hash);
+        MessageWithDependency {
+            request: input,
+            hash: buffer,
+        }
+    }
+}
+
+// request containing potentially many group messages
+prop_compose! {
+    pub fn cursor_gen()(sid in 0u64..1000, oid in 0u32..40) -> Cursor {
+        Cursor {
+            sequence_id: sid,
+            originator_id: oid
+        }
+    }
+}
+prop_compose! {
+    pub fn group_message_request(length: usize)
+        (msgs in collection::vec(group_message(), 0..length))
+        (cursors in collection::hash_set(cursor_gen(), msgs.len()), msgs in Just(msgs)) -> TestRequest {
+        let messages: Vec<GroupMessageInput> = msgs.iter().map(|m| m.request.clone()).collect();
+        let map = msgs
+            .iter()
+            .map(|m| m.hash.to_vec()).zip(cursors)
+            .collect::<HashMap<_, _>>();
+        TestRequest {
+            request: SendGroupMessagesRequest {
+                messages
+            },
+            dependencies: map
+        }
+    }
+}
+
+type DataHash = Vec<u8>;
+#[derive(Default, Clone)]
+pub struct TestCursorStore {
+    pub dependencies: HashMap<DataHash, Cursor>,
+}
+
+impl CursorStore for TestCursorStore {
+    fn lowest_common_cursor(&self, _: &[&Topic]) -> Result<GlobalCursor, CursorStoreError> {
+        unreachable!()
+    }
+
+    fn latest(&self, _: &Topic) -> Result<GlobalCursor, CursorStoreError> {
+        unreachable!()
+    }
+
+    fn latest_per_originator(
+        &self,
+        _: &Topic,
+        _: &[&OriginatorId],
+    ) -> Result<GlobalCursor, CursorStoreError> {
+        unreachable!()
+    }
+
+    fn latest_for_topics(
+        &self,
+        _: &mut dyn Iterator<Item = &Topic>,
+    ) -> Result<HashMap<Topic, GlobalCursor>, CursorStoreError> {
+        unreachable!()
+    }
+
+    fn lcc_maybe_missing(&self, _: &[&Topic]) -> Result<GlobalCursor, CursorStoreError> {
+        unreachable!()
+    }
+
+    fn find_message_dependencies(
+        &self,
+        _hashes: &[&[u8]],
+    ) -> Result<HashMap<Vec<u8>, Cursor>, CursorStoreError> {
+        Ok(self.dependencies.clone())
+    }
+}

--- a/xmtp_configuration/src/common/d14n.rs
+++ b/xmtp_configuration/src/common/d14n.rs
@@ -10,6 +10,8 @@ impl Originators {
     /// Key Packages
     pub const INSTALLATIONS: u32 = 13;
     pub const REMOTE_COMMIT_LOG: u32 = 100;
+    /// the "default" originator for local and tests
+    pub const DEFAULT: u32 = 100;
 }
 
 pub const PAYER_WRITE_FILTER: &str = "xmtp.xmtpv4.payer_api.PayerApi";

--- a/xmtp_db/src/encrypted_store/group_intent/types.rs
+++ b/xmtp_db/src/encrypted_store/group_intent/types.rs
@@ -70,3 +70,9 @@ impl<'a> From<&'a [u8]> for PayloadHashRef<'a> {
         PayloadHashRef(Cow::from(value))
     }
 }
+
+impl<'a> From<PayloadHashRef<'a>> for Vec<u8> {
+    fn from(value: PayloadHashRef<'a>) -> Vec<u8> {
+        value.0.into_owned()
+    }
+}

--- a/xmtp_db/src/mock.rs
+++ b/xmtp_db/src/mock.rs
@@ -278,9 +278,10 @@ mock! {
             to_save: crate::group_intent::NewGroupIntent,
         ) -> Result<crate::group_intent::StoredGroupIntent, crate::ConnectionError>;
 
-        fn find_group_intents(
+        #[mockall::concretize]
+        fn find_group_intents<Id: AsRef<[u8]>>(
             &self,
-            group_id: Vec<u8>,
+            group_id: Id,
             allowed_states: Option<Vec<crate::group_intent::IntentState>>,
             allowed_kinds: Option<Vec<crate::group_intent::IntentKind>>,
         ) -> Result<Vec<crate::group_intent::StoredGroupIntent>, crate::ConnectionError>;

--- a/xmtp_mls/src/groups/tests/mod.rs
+++ b/xmtp_mls/src/groups/tests/mod.rs
@@ -14,6 +14,10 @@ mod test_send_message_opts;
 mod test_welcome_pointers;
 mod test_welcomes;
 
+xmtp_common::if_d14n! {
+    mod test_message_dependencies;
+}
+
 use crate::groups::send_message_opts::SendMessageOpts;
 use chrono::DateTime;
 use openmls::prelude::MlsMessageIn;
@@ -5019,6 +5023,7 @@ async fn non_retryable_error_increments_cursor() {
         sender_hmac: vec![],
         should_push: false,
         payload_hash: vec![],
+        depends_on: Default::default(),
     };
 
     let res = group.process_message(&message, true).await;

--- a/xmtp_mls/src/groups/tests/test_message_dependencies.rs
+++ b/xmtp_mls/src/groups/tests/test_message_dependencies.rs
@@ -1,0 +1,162 @@
+use xmtp_api_d14n::protocol::{XmtpEnvelope, XmtpQuery};
+use xmtp_db::prelude::QueryGroupMessage;
+use xmtp_proto::types::{Cursor, TopicKind};
+
+use crate::groups::MlsGroup;
+use crate::utils::test::MlsGroupExt;
+use crate::{context::XmtpSharedContext, tester};
+
+// gets all messages on a group topic
+async fn get_messages(context: &impl XmtpSharedContext, group_id: &[u8]) -> XmtpEnvelope {
+    context
+        .api()
+        .query_at(TopicKind::GroupMessagesV1.create(group_id), None)
+        .await
+        .unwrap()
+}
+
+fn message_debug(env: &XmtpEnvelope) -> String {
+    env.group_messages().unwrap().into_iter().enumerate().fold(
+        String::new(),
+        |mut acc, (i, msg)| {
+            acc.push_str(&i.to_string());
+            acc.push_str(" --");
+            acc.push_str(&msg.to_string());
+            acc.push('\n');
+            acc
+        },
+    )
+}
+
+fn db_message_debug(db: impl QueryGroupMessage, id: &[u8]) -> String {
+    db.get_group_messages(id, &Default::default())
+        .unwrap()
+        .into_iter()
+        .enumerate()
+        .fold(String::new(), |mut acc, (i, msg)| {
+            acc.push_str(&i.to_string());
+            acc.push_str(" --");
+            acc.push_str(&msg.cursor().to_string());
+            acc.push('\n');
+            acc
+        })
+}
+
+async fn sync<C: XmtpSharedContext>(groups: &[&MlsGroup<C>]) {
+    for g in groups {
+        let _ = g.sync().await.unwrap();
+    }
+}
+
+// ensure `dependant` depends on `commit`
+#[track_caller]
+fn assert_depends_on(env: &XmtpEnvelope, dependant: usize, commit: usize) {
+    let client_envelopes = env.client_envelopes().unwrap();
+    let cursors = env.cursors().unwrap();
+    let depends_on_cursor: Cursor = client_envelopes[dependant]
+        .aad
+        .as_ref()
+        .unwrap()
+        .depends_on
+        .as_ref()
+        .unwrap()
+        .clone()
+        .try_into()
+        .unwrap();
+    assert_eq!(
+        depends_on_cursor,
+        cursors[commit],
+        "dependant envelope {} does not have a dependency on {}\n{}",
+        client_envelopes[dependant].aad.as_ref().unwrap(),
+        cursors[commit],
+        message_debug(env)
+    );
+}
+
+#[track_caller]
+fn assert_no_dependant(env: &XmtpEnvelope, msg: usize) {
+    let client_envelopes = env.client_envelopes().unwrap();
+    let depends_on = &client_envelopes[msg].aad.as_ref().unwrap().depends_on;
+    assert!(depends_on.is_none())
+}
+
+#[xmtp_common::test(unwrap_try = true)]
+async fn messages_have_dependencies() {
+    tester!(alix);
+    tester!(bo);
+
+    let alix_group = alix.create_group(None, None)?;
+    let group_id = alix_group.group_id.clone();
+    alix_group.invite(&bo).await?;
+    let messages = get_messages(&alix.context, &group_id).await;
+    // no messages have been sent in group yet. alix about to process first commit alix
+    // sends(inviting bo)
+    assert_no_dependant(&messages, 0);
+    let bo_group = bo.sync_welcomes().await?.pop()?;
+    assert_eq!(bo_group.group_id, group_id);
+    bo_group.send_msg(b"2").await;
+    let messages = get_messages(&alix.context, &group_id).await;
+    // bos key update depends on the first commit (group invite)
+    assert_depends_on(&messages, 1, 0);
+    // bos message depends on the key update in the group
+    assert_depends_on(&messages, 2, 1);
+}
+
+#[xmtp_common::test(unwrap_try = true)]
+async fn messages_dependencies_out_of_order_invites() {
+    tester!(alix, with_name: "alix");
+    tester!(bo, with_name: "bo");
+    tester!(caro, with_name: "caro");
+
+    let alix_group = alix
+        .create_group_with_inbox_ids(&[bo.inbox_id()], None, None) // message 0
+        .await?;
+    let group_id = alix_group.group_id.clone();
+    let messages = get_messages(&alix.context, &group_id).await;
+    assert_no_dependant(&messages, 0);
+    let bo_group = bo.sync_welcomes().await?.pop()?;
+    assert_eq!(bo_group.group_id, group_id);
+    bo_group.send_msg(b"2").await; // message 1 (key update) and 2 (application)
+
+    let messages = get_messages(&alix.context, &group_id).await;
+    // bos key update depends on the first commit (group invite)
+    assert_depends_on(&messages, 1, 0);
+    // bos message depends on the key update in the group
+    assert_depends_on(&messages, 2, 1);
+
+    bo_group.invite(&caro).await?; // message 3
+    // alix's message has a dependency on the first commit in the group (adding bo)
+    // we haven't seen commit adding caro yet.
+    alix_group.send_msg(b"3").await; // message 4 (caro will not see)
+    let messages = get_messages(&alix.context, &group_id).await;
+    // bos add member commit depends on key update
+    assert_depends_on(&messages, 3, 1);
+    // alixs send message depends on first commit
+    assert_depends_on(&messages, 4, 0);
+    let caro_group = caro.sync_welcomes().await?.pop()?;
+    caro_group.send_msg(b"4").await; // message 5 (application)
+    let messages = get_messages(&alix.context, &group_id).await;
+    // caro depends on bos commit
+    assert_depends_on(&messages, 5, 3);
+    // now everyone should be synced to the latest state
+    // this will make alix do a key update as well
+    sync(&[&alix_group, &bo_group, &caro_group]).await;
+    let messages = get_messages(&alix.context, &group_id).await;
+    assert_depends_on(&messages, 5, 3);
+    alix_group.send_msg(b"5").await; // message 7
+    sync(&[&alix_group, &bo_group, &caro_group]).await;
+    let messages = get_messages(&alix.context, &group_id).await;
+    assert_depends_on(&messages, 6, 5);
+    assert_depends_on(&messages, 7, 5);
+    // alixs new message depends on bos commit adding caro
+
+    println!("\n====NETWORK====");
+    let messages = get_messages(&alix.context, &group_id).await;
+    println!("{}", message_debug(&messages));
+    println!("\n====ALIX====");
+    println!("{}", db_message_debug(alix.db(), &group_id));
+    println!("\n====CARO====");
+    println!("{}", db_message_debug(caro.db(), &group_id));
+    println!("\n====BO====");
+    println!("{}", db_message_debug(bo.db(), &group_id));
+}

--- a/xmtp_mls/src/utils/test/mod.rs
+++ b/xmtp_mls/src/utils/test/mod.rs
@@ -6,6 +6,8 @@ pub mod tester_utils;
 #[cfg(any(test, feature = "test-utils"))]
 pub mod fixtures;
 pub mod test_mocks_helpers;
+mod tester_utils_trait_ext;
+pub use tester_utils_trait_ext::*;
 
 use crate::XmtpApi;
 use crate::cursor_store::SqliteCursorStore;

--- a/xmtp_mls/src/utils/test/tester_utils.rs
+++ b/xmtp_mls/src/utils/test/tester_utils.rs
@@ -7,7 +7,7 @@ use crate::{
     client::ClientError,
     context::XmtpSharedContext,
     cursor_store::SqliteCursorStore,
-    groups::device_sync::worker::SyncMetric,
+    groups::{GroupError, device_sync::worker::SyncMetric, intents::UpdateGroupMembershipResult},
     identity::{Identity, IdentityStrategy},
     subscriptions::SubscribeError,
     utils::{

--- a/xmtp_mls/src/utils/test/tester_utils_trait_ext.rs
+++ b/xmtp_mls/src/utils/test/tester_utils_trait_ext.rs
@@ -1,0 +1,28 @@
+use crate::{
+    Client,
+    context::XmtpSharedContext,
+    groups::{GroupError, MlsGroup, intents::UpdateGroupMembershipResult},
+};
+
+#[allow(async_fn_in_trait)]
+pub trait MlsGroupExt: Sized {
+    async fn invite<C2: XmtpSharedContext>(
+        &self,
+        other: &Client<C2>,
+    ) -> Result<UpdateGroupMembershipResult, GroupError>;
+
+    async fn send_msg(&self, m: &[u8]);
+}
+
+impl<C: XmtpSharedContext> MlsGroupExt for MlsGroup<C> {
+    async fn invite<C2: XmtpSharedContext>(
+        &self,
+        other: &Client<C2>,
+    ) -> Result<UpdateGroupMembershipResult, GroupError> {
+        self.add_members_by_inbox_id(&[other.inbox_id()]).await
+    }
+
+    async fn send_msg(&self, m: &[u8]) {
+        let _ = self.send_message(m, Default::default()).await.unwrap();
+    }
+}

--- a/xmtp_proto/src/gen/xmtp.xmtpv4.envelopes.rs
+++ b/xmtp_proto/src/gen/xmtp.xmtpv4.envelopes.rs
@@ -36,9 +36,8 @@ pub struct NodeSignature {
     #[prost(uint32, tag = "1")]
     pub node_id: u32,
     #[prost(message, optional, tag = "2")]
-    pub signature: ::core::option::Option<
-        super::super::identity::associations::RecoverableEcdsaSignature,
-    >,
+    pub signature:
+        ::core::option::Option<super::super::identity::associations::RecoverableEcdsaSignature>,
 }
 impl ::prost::Name for NodeSignature {
     const NAME: &'static str = "NodeSignature";
@@ -148,9 +147,8 @@ pub struct PayerEnvelope {
     #[prost(bytes = "vec", tag = "1")]
     pub unsigned_client_envelope: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "2")]
-    pub payer_signature: ::core::option::Option<
-        super::super::identity::associations::RecoverableEcdsaSignature,
-    >,
+    pub payer_signature:
+        ::core::option::Option<super::super::identity::associations::RecoverableEcdsaSignature>,
     #[prost(uint32, tag = "3")]
     pub target_originator: u32,
     #[prost(uint32, tag = "4")]
@@ -226,9 +224,7 @@ pub mod originator_envelope {
     #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
     pub enum Proof {
         #[prost(message, tag = "2")]
-        OriginatorSignature(
-            super::super::super::identity::associations::RecoverableEcdsaSignature,
-        ),
+        OriginatorSignature(super::super::super::identity::associations::RecoverableEcdsaSignature),
         #[prost(message, tag = "3")]
         BlockchainProof(super::BlockchainProof),
     }

--- a/xmtp_proto/src/impls.rs
+++ b/xmtp_proto/src/impls.rs
@@ -1,8 +1,10 @@
+use crate::types::GlobalCursor;
 /// implementations for some generated types
 use crate::xmtp::mls::api::v1::welcome_message::Version;
 use crate::xmtp::mls::message_contents::{
     WelcomePointeeEncryptionAeadType, WelcomePointeeEncryptionAeadTypesExtension,
 };
+use crate::xmtp::xmtpv4::envelopes::AuthenticatedData;
 use crate::xmtp::xmtpv4::envelopes::client_envelope::Payload;
 
 impl std::fmt::Display for Payload {
@@ -15,6 +17,22 @@ impl std::fmt::Display for Payload {
             Payload::PayerReport(_) => write!(f, "Payload::PayerReport"),
             Payload::PayerReportAttestation(_) => write!(f, "Payload::PayerReportAttestation"),
         }
+    }
+}
+
+impl std::fmt::Display for AuthenticatedData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(d) = &self.depends_on {
+            let cursor: GlobalCursor = d.clone().into();
+            write!(f, "aad[{} -> {}]", hex::encode(&self.target_topic), cursor)?;
+        } else {
+            write!(
+                f,
+                "aad[{} -> (no dependency)]",
+                hex::encode(&self.target_topic)
+            )?;
+        }
+        Ok(())
     }
 }
 

--- a/xmtp_proto/src/types/cursor.rs
+++ b/xmtp_proto/src/types/cursor.rs
@@ -1,7 +1,9 @@
 //! xmtp message cursor type and implementations
 use serde::{Deserialize, Serialize};
-use std::fmt;
+use std::{collections::HashMap, fmt};
 use xmtp_configuration::Originators;
+
+use crate::xmtp::xmtpv4;
 
 /// XMTP cursor type
 /// represents a position in an ordered sequence of messages, belonging
@@ -67,7 +69,11 @@ impl Cursor {
 
 impl fmt::Display for Cursor {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "[sid({}):oid({})]", self.sequence_id, self.originator_id)
+        write!(
+            f,
+            "[sid({:6}):oid({:3})]",
+            self.sequence_id, self.originator_id
+        )
     }
 }
 
@@ -77,6 +83,16 @@ impl xmtp_common::Generate for Cursor {
         Cursor {
             sequence_id: xmtp_common::rand_u64(),
             originator_id: openmls::test_utils::random_u32(),
+        }
+    }
+}
+
+impl From<Cursor> for xmtpv4::envelopes::Cursor {
+    fn from(value: Cursor) -> Self {
+        let mut map = HashMap::new();
+        map.insert(value.originator_id, value.sequence_id);
+        xmtpv4::envelopes::Cursor {
+            node_id_to_sequence_id: map,
         }
     }
 }

--- a/xmtp_proto/src/types/group_message.rs
+++ b/xmtp_proto/src/types/group_message.rs
@@ -1,5 +1,5 @@
 use super::{Cursor, GroupId};
-use crate::ConversionError;
+use crate::{ConversionError, types::GlobalCursor};
 use chrono::Utc;
 use derive_builder::Builder;
 use openmls::prelude::ContentType;
@@ -23,6 +23,8 @@ pub struct GroupMessage {
     /// Payload hash of the message
     /// TODO: make payload hash constant array
     pub payload_hash: Vec<u8>,
+    #[builder(default)]
+    pub depends_on: GlobalCursor,
 }
 
 impl GroupMessage {
@@ -60,19 +62,21 @@ impl xmtp_common::Generate for GroupMessage {
             sender_hmac: xmtp_common::rand_vec::<2>(),
             should_push: true,
             payload_hash: xmtp_common::rand_vec::<32>(),
+            depends_on: GlobalCursor::default(),
         }
     }
 }
 
 impl std::fmt::Display for GroupMessage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "GroupMessage {{ cursor {}, created at {}, group {} }}",
+        let s = format!(
+            "GroupMessage {{ cursor {}, depends on {}, created at {:10}, group {:16} }}",
             self.cursor,
-            self.created_ns.time(),
+            self.depends_on,
+            self.created_ns.time().format("%H:%M:%S%.6f").to_string(),
             self.group_id
-        )
+        );
+        write!(f, "{}", s)
     }
 }
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Annotate group message send with dependency cursors and add SHA-256 hashing across d14n envelopes in `xmtp_api_d14n` and `xmtp_mls`
Implement dependency resolution for group message publish by computing payload SHA-256s and setting `AAD.depends_on` in `XmtpMlsClient::send_group_messages`, add `CursorStore::find_message_dependencies`, propagate cursors and hashes through `Envelope`, `EnvelopeCollection`, and extractors, and extend SQLite cursor store to return dependency cursors.

#### 📍Where to Start
Start with dependency injection and AAD setting in `XmtpMlsClient::send_group_messages` in [mls.rs](https://github.com/xmtp/libxmtp/pull/2788/files#diff-b41f084fe8fd9295035f4b6d73b1318093b6475f1f923e681a880e6ba94a2f20), then review the `CursorStore` extensions in [cursor_store.rs](https://github.com/xmtp/libxmtp/pull/2788/files#diff-028daad07b57a99602b70e297432f143b84633ff46fa3f2b9851f6b476260eae) and the SQLite implementation in [cursor_store.rs](https://github.com/xmtp/libxmtp/pull/2788/files#diff-92939812065b708096075a08e83053a96bbb0d48d2a13d665eba3336c85740ca).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized d2ad8ec.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->