### PR TITLE
Fix node and wasm bindings release actions

### DIFF
--- a/.github/workflows/release-node-bindings.yml
+++ b/.github/workflows/release-node-bindings.yml
@@ -301,10 +301,6 @@ jobs:
         working-directory: bindings_node
         run: yarn
 
-      - name: Generate version
-        working-directory: bindings_node
-        run: yarn generate:version
-
       - name: Update version for dev releases
         working-directory: bindings_node
         run: |
@@ -313,20 +309,15 @@ jobs:
 
           # Check if this is a dev version
           if [[ "$PACKAGE_VERSION" == *"dev"* ]]; then
-            # Read the git commit hash from version.json
-            if [ -f "dist/version.json" ]; then
-              GIT_HASH=$(node -p "require('./dist/version.json').version")
-              
-              # Create a new version string with the git hash
-              NEW_VERSION="${PACKAGE_VERSION}.${GIT_HASH}"
-              
-              # Update package.json with the new version
-              npm version "$NEW_VERSION" --no-git-tag-version
-              
-              echo "Updated version to $NEW_VERSION for publishing"
-            else
-              echo "Warning: dist/version.json not found, using original version"
-            fi
+            GIT_HASH=$(git log -1 --pretty=format:"%h")
+            
+            # Create a new version string with the git hash
+            NEW_VERSION="${PACKAGE_VERSION}.${GIT_HASH}"
+            
+            # Update package.json with the new version
+            npm version "$NEW_VERSION" --no-git-tag-version
+            
+            echo "Updated version to $NEW_VERSION for publishing"
           else
             echo "Not a dev version, keeping original version: $PACKAGE_VERSION"
           fi

--- a/.github/workflows/release-wasm-bindings.yml
+++ b/.github/workflows/release-wasm-bindings.yml
@@ -61,9 +61,6 @@ jobs:
         run: |
           source ./../emsdk/emsdk_env.sh
           yarn build
-      - name: Generate version
-        working-directory: bindings_wasm
-        run: yarn generate:version
       - name: Update version for dev releases
         working-directory: bindings_wasm
         run: |
@@ -72,20 +69,15 @@ jobs:
 
           # Check if this is a dev version
           if [[ "$PACKAGE_VERSION" == *"dev"* ]]; then
-            # Read the git commit hash from version.json
-            if [ -f "dist/version.json" ]; then
-              GIT_HASH=$(node -p "require('./dist/version.json').version")
+            GIT_HASH=$(git log -1 --pretty=format:"%h")
 
-              # Create a new version string with the git hash
-              NEW_VERSION="${PACKAGE_VERSION}.${GIT_HASH}"
+            # Create a new version string with the git hash
+            NEW_VERSION="${PACKAGE_VERSION}.${GIT_HASH}"
 
-              # Update package.json with the new version
-              npm version "$NEW_VERSION" --no-git-tag-version
+            # Update package.json with the new version
+            npm version "$NEW_VERSION" --no-git-tag-version
 
-              echo "Updated version to $NEW_VERSION for publishing"
-            else
-              echo "Warning: dist/version.json not found, using original version"
-            fi
+            echo "Updated version to $NEW_VERSION for publishing"
           else
             echo "Not a dev version, keeping original version: $PACKAGE_VERSION"
           fi


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Fix release workflows for node and wasm bindings by appending the latest git short hash to dev package versions using `git log` in [.github/workflows/release-node-bindings.yml](https://github.com/xmtp/libxmtp/pull/2793/files#diff-0c04063335c6f5d23180cdad4da9b8bc5a4cc7dc2890c690e61a973220ba0ec3) and [.github/workflows/release-wasm-bindings.yml](https://github.com/xmtp/libxmtp/pull/2793/files#diff-8ac8fedf1ee50dabf3d48a77190d2741d37b10bc75e0ef6382d42bfadd092fe3)
Replace version file usage with `git log -1 --pretty=format:"%h"` and update dev versions via `npm version --no-git-tag-version`; remove `yarn generate:version` in both release workflows.

#### 📍Where to Start
Start with the dev release update steps in [.github/workflows/release-node-bindings.yml](https://github.com/xmtp/libxmtp/pull/2793/files#diff-0c04063335c6f5d23180cdad4da9b8bc5a4cc7dc2890c690e61a973220ba0ec3) and [.github/workflows/release-wasm-bindings.yml](https://github.com/xmtp/libxmtp/pull/2793/files#diff-8ac8fedf1ee50dabf3d48a77190d2741d37b10bc75e0ef6382d42bfadd092fe3), focusing on the version computation and `npm version` commands.

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 4123afd.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->