### PR TITLE
add flags for adding members & changing description

### DIFF
--- a/dev/test/big_group_chaos.sh
+++ b/dev/test/big_group_chaos.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# USAGE: ./big_group.sh <INBOX_ID> [NETWORK]
+#   INBOX_ID: Required - The inbox ID to add to the external group
+#   NETWORK:  Optional - Network to use (default: "dev")
+#
+# Example: ./big_group.sh fbeb081944df5ef3f26de65f05ada28c781ac3086f0a7ccff2751ede994ebfc9
+# Example: ./big_group.sh fbeb081944df5ef3f26de65f05ada28c781ac3086f0a7ccff2751ede994ebfc9 dev
+#
+# Keep in mind the inbox id must already exist on the network you're trying to add it to.
+#
+# This script generates test data by creating 150 identities, 1 group with all identities,
+# adds the specified inbox to that group, and generates 3 test messages in a loop every second.
+# Requires: jq, cargo, and the xdbg binary to be buildable.
+
+set -eou pipefail
+
+if ! jq --version &>/dev/null; then echo "must install jq"; fi
+
+INBOX_ID=$1
+NETWORK=${2-"dev"}
+EXPORT=$(mktemp)
+TARGET_DIR="$(cargo metadata --format-version 1 --no-deps | jq -r '.target_directory')"
+CMD="${TARGET_DIR}/release/xdbg -b $NETWORK"
+
+cargo build --release --bin xdbg
+echo "writing groups to $EXPORT"
+${TARGET_DIR}/release/xdbg --clear
+$CMD --clear
+$CMD generate --entity identity --amount 250
+$CMD generate --entity group --amount 1 --invite 10
+$CMD export --entity group --out $EXPORT
+GROUP_ID=$(jq -r '.[0].id' $EXPORT)
+echo "group has id $GROUP_ID"
+$CMD modify --inbox-id $INBOX_ID add-external $GROUP_ID
+# generate 2 message every 1000 milliseconds, and add a new member (up to 200 members) + change the grp description
+$CMD generate --entity message --amount 2 --interval 1000 --loop --add-and-change-description --add-up-to 200

--- a/xmtp_debug/src/app.rs
+++ b/xmtp_debug/src/app.rs
@@ -26,6 +26,7 @@ mod types;
 use clap::CommandFactory;
 use color_eyre::eyre::{self, Result};
 use directories::ProjectDirs;
+use redb::DatabaseError;
 use std::{fs, path::PathBuf, sync::Arc};
 use xmtp_db::{EncryptedMessageStore, StorageOption};
 use xmtp_id::InboxOwner;
@@ -54,7 +55,32 @@ impl App {
     }
 
     fn readonly_db() -> Result<Arc<redb::ReadOnlyDatabase>> {
-        Ok(Arc::new(redb::ReadOnlyDatabase::open(Self::redb()?)?))
+        match redb::ReadOnlyDatabase::open(Self::redb()?) {
+            // if the db is corrupted attempt a repair
+            Err(DatabaseError::RepairAborted) => {
+                let integrity = {
+                    let mut rw = redb::Database::open(Self::redb()?)?;
+                    rw.check_integrity()
+                };
+                match integrity {
+                    // db is ok can be reopened
+                    Ok(true) => Self::readonly_db(),
+                    // db was broken but is repaired
+                    Ok(false) => Self::readonly_db(),
+                    Err(DatabaseError::DatabaseAlreadyOpen) => {
+                        tracing::warn!(
+                            "db repair attempted but cannot continue because opened in a different process."
+                        );
+                        Err(DatabaseError::DatabaseAlreadyOpen.into())
+                    }
+                    Err(_) => {
+                        panic!("db file corrupted & unrecoverable. run `xdbg --clear` to restart")
+                    }
+                }
+            }
+            Ok(db) => Ok(Arc::new(db)),
+            Err(e) => Err(e.into()),
+        }
     }
 
     fn db() -> Result<Arc<redb::Database>> {
@@ -95,7 +121,7 @@ impl App {
             clear,
             ..
         } = opts;
-        debug!(fdlimit = get_fdlimit());
+        info!(fdlimit = get_fdlimit(), "setting fdlimit");
 
         if cmd.is_none() && !clear {
             AppOpts::command().print_help()?;

--- a/xmtp_debug/src/app/generate.rs
+++ b/xmtp_debug/src/app/generate.rs
@@ -45,8 +45,8 @@ impl Generate {
                 Ok(())
             }
             Message => {
-                GenerateMessages::new(network, message_opts)?
-                    .run(amount, *concurrency)
+                GenerateMessages::new(network, message_opts, *concurrency)?
+                    .run(amount)
                     .await?;
                 info!("messages generated");
                 Ok(())

--- a/xmtp_debug/src/app/generate/groups.rs
+++ b/xmtp_debug/src/app/generate/groups.rs
@@ -112,6 +112,11 @@ impl GenerateGroups {
             .into_iter()
             .collect::<Result<Vec<_>, eyre::Report>>()?;
         self.group_store.set_all(groups.as_slice(), &self.network)?;
+        // ensure cleanup for each client
+        for client in clients.values() {
+            let client = client.lock().await;
+            client.release_db_connection()?;
+        }
         Ok(groups)
     }
 }

--- a/xmtp_debug/src/app/modify.rs
+++ b/xmtp_debug/src/app/modify.rs
@@ -88,10 +88,9 @@ impl Modify {
                 group_store.set(local_group, &network)?;
             }
             AddExternal => {
-                if inbox_id.is_none() {
+                let Some(inbox_id) = inbox_id else {
                     bail!("Inbox ID to add must be specificied")
-                }
-                let inbox_id = inbox_id.expect("Checked for none");
+                };
                 group
                     .add_members_by_inbox_id(&[hex::encode(*inbox_id)])
                     .await
@@ -102,6 +101,7 @@ impl Modify {
                 info!(
                     inbox_id = hex::encode(*inbox_id),
                     group_id = hex::encode(local_group.id),
+                    added_by = hex::encode(identity.inbox_id),
                     "Member added as Super Admin"
                 );
             }

--- a/xmtp_debug/src/app/store.rs
+++ b/xmtp_debug/src/app/store.rs
@@ -126,7 +126,7 @@ pub trait DeriveKey<Key> {
 pub trait Database<Key, Value> {
     /// get length of items in db.
     fn len(&self, network: impl Into<u64>) -> Result<usize>;
-    #[allow(unused)]
+
     /// store only `value` to disk
     fn set(&self, value: Value, network: impl Into<u64>) -> Result<()> {
         Database::set_all(self, &[value], network)

--- a/xmtp_debug/src/app/types.rs
+++ b/xmtp_debug/src/app/types.rs
@@ -177,7 +177,7 @@ impl redb::Value for Identity {
 
 /// Group specific to this debug CLI Tool.
 /// Number of members in group
-#[derive(Debug, Hash, PartialEq, Eq, valuable::Valuable, Readable, Writable)]
+#[derive(Debug, Hash, Clone, PartialEq, Eq, valuable::Valuable, Readable, Writable)]
 pub struct Group {
     /// user that created group
     pub created_by: InboxId,

--- a/xmtp_debug/src/args.rs
+++ b/xmtp_debug/src/args.rs
@@ -94,6 +94,18 @@ pub struct MessageGenerateOpts {
     /// Max variable message size, in words.
     #[arg(long, short, default_value = "100")]
     pub max_message_size: u32,
+    /// on every interval, adds a new member to the group and changes the group description in
+    /// addition to sending a message
+    #[arg(long, short)]
+    pub add_and_change_description: bool,
+    /// on every interval, changes the group description in addition to sending a message
+    #[arg(long, short)]
+    pub change_description: bool,
+    /// specify how many identities to add up to
+    /// requires `add_or_change_description`.
+    /// does nothing unless add_or_change_description is set
+    #[arg(long, short, default_value = "100")]
+    pub add_up_to: u32,
 }
 
 /// Modify state of local clients & groups


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add CLI flags to xmtp_debug to add group members up to a limit and change group descriptions during message generation, and switch client creation to unencrypted sqlite with explicit registration and `XDBG_ID_NONCE = 1` inbox derivation
Introduce message-generation options to mutate groups (member adds and description changes) with writable DB, add `--ryow` for identity creation reads, and refactor client lifecycle to create unregistered clients on unencrypted sqlite then register explicitly; include readonly DB repair on `RepairAborted`.

#### 📍Where to Start
Start with the CLI options and execution flow in `GenerateMessages` and identity creation in `GenerateIdentity.create_identities` in [xmtp_debug/src/app/generate/messages.rs](https://github.com/xmtp/libxmtp/pull/2795/files#diff-eeaf742c78c261e05257950d12daa2ec07c1dfe459a732f2ee1484f184da9371) and [xmtp_debug/src/app/generate/identity.rs](https://github.com/xmtp/libxmtp/pull/2795/files#diff-5810cc3f49b5afa472f60492ce4999aadf64464660c04f8251d27b1e6abfcf1c), then review DB open/repair in `App.readonly_db` in [xmtp_debug/src/app.rs](https://github.com/xmtp/libxmtp/pull/2795/files#diff-5271efe9f61f1d96b0145caa92d489e6553e2a26818be003b9d68cd745aa5914).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized d19998d. 13 files reviewed, 27 issues evaluated, 19 issues filtered, 3 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>dev/test/big_group_chaos.sh — 0 comments posted, 6 evaluated, 5 filtered</summary>

- [line 17](https://github.com/xmtp/libxmtp/blob/d19998d4ea77463b07762048b54cb7eb774e7d4f/dev/test/big_group_chaos.sh#L17): `jq` availability check does not exit on failure. If `jq` is not installed, the script only echoes "must install jq" and continues, later failing unpredictably when `jq` is used (e.g., on `cargo metadata | jq ...`). Add an explicit `exit 1` (or `return 1`) after the message. <b>[ Already posted ]</b>
- [line 19](https://github.com/xmtp/libxmtp/blob/d19998d4ea77463b07762048b54cb7eb774e7d4f/dev/test/big_group_chaos.sh#L19): Referencing `INBOX_ID=$1` under `set -u` causes the script to terminate with an uninformative "unbound variable" error when no argument is provided. Add an explicit usage/argument guard (e.g., check `$# -ge 1` and print usage with a clear exit code). <b>[ Already posted ]</b>
- [line 21](https://github.com/xmtp/libxmtp/blob/d19998d4ea77463b07762048b54cb7eb774e7d4f/dev/test/big_group_chaos.sh#L21): Temporary file created with `mktemp` is never cleaned up. This leaks a file on disk, and because the script then runs an infinite `--loop`, the file will persist until manual cleanup. Add a trap (e.g., `trap 'rm -f "$EXPORT"' EXIT INT TERM`) to guarantee cleanup on all exit paths. <b>[ Low confidence ]</b>
- [line 27](https://github.com/xmtp/libxmtp/blob/d19998d4ea77463b07762048b54cb7eb774e7d4f/dev/test/big_group_chaos.sh#L27): Network inconsistency on first `--clear`: `${TARGET_DIR}/release/xdbg --clear` omits the `-b $NETWORK` argument used elsewhere. This may clear the wrong/default network before operating on the intended one. Use the same command including the selected network for all operations. <b>[ Low confidence ]</b>
- [line 32](https://github.com/xmtp/libxmtp/blob/d19998d4ea77463b07762048b54cb7eb774e7d4f/dev/test/big_group_chaos.sh#L32): `GROUP_ID` extraction does not validate presence. `GROUP_ID=$(jq -r '.[0].id' "$EXPORT")` yields empty when the export is empty or unexpected; the script proceeds to `add-external` with an empty group id. Add a check to ensure `GROUP_ID` is non-empty and fail clearly if not. <b>[ Low confidence ]</b>
</details>

<details>
<summary>xmtp_debug/src/app.rs — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 67](https://github.com/xmtp/libxmtp/blob/d19998d4ea77463b07762048b54cb7eb774e7d4f/xmtp_debug/src/app.rs#L67): `readonly_db()` can recurse indefinitely and eventually stack overflow if `redb::ReadOnlyDatabase::open(...)` keeps returning `Err(DatabaseError::RepairAborted)` even after `check_integrity()` returns `Ok(true)` or `Ok(false)`, because both those branches call `Self::readonly_db()` again without changing state or adding a termination condition. <b>[ Low confidence ]</b>
- [line 70](https://github.com/xmtp/libxmtp/blob/d19998d4ea77463b07762048b54cb7eb774e7d4f/xmtp_debug/src/app.rs#L70): The special handling for `Err(DatabaseError::DatabaseAlreadyOpen)` inside the `match integrity { ... }` is likely ineffective because `redb::Database::open(Self::redb()?)?` uses `?`, so any `DatabaseAlreadyOpen` error from `open()` propagates early and never reaches the `match` over the result of `rw.check_integrity()`. As a result, the intended warning path (`tracing::warn!(...)`) won’t run, and the function returns the error without the log. <b>[ Low confidence ]</b>
</details>

<details>
<summary>xmtp_debug/src/app/clients.rs — 1 comment posted, 3 evaluated, 1 filtered</summary>

- [line 143](https://github.com/xmtp/libxmtp/blob/d19998d4ea77463b07762048b54cb7eb774e7d4f/xmtp_debug/src/app/clients.rs#L143): `existing_client_inner` converts `db_path` to a `String` with `into_string().unwrap()`. If the path is not valid UTF-8 (possible on some systems), this will panic, aborting the process. Use fallible conversion and return an error (`map_err`/`WrapErr`) instead of `unwrap`. <b>[ Already posted ]</b>
</details>

<details>
<summary>xmtp_debug/src/app/generate/groups.rs — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 50](https://github.com/xmtp/libxmtp/blob/d19998d4ea77463b07762048b54cb7eb774e7d4f/xmtp_debug/src/app/generate/groups.rs#L50): `ProgressStyle::with_template(...).unwrap()` can panic at runtime if the template is invalid. This causes abrupt termination in a non-initialization path while effects are ongoing (spawning tasks, DB access). Prefer handling the error and returning a visible failure. <b>[ Already posted ]</b>
- [line 115](https://github.com/xmtp/libxmtp/blob/d19998d4ea77463b07762048b54cb7eb774e7d4f/xmtp_debug/src/app/generate/groups.rs#L115): `create_groups(...)` leaks DB connections on error paths. If any spawned task fails or any step before `self.group_store.set_all(...)` returns `Err`, the function returns early via `?` and the cleanup loop calling `client.release_db_connection()?` is skipped, leaving connections open. All exit paths after resource acquisition must perform exactly one paired cleanup. <b>[ Low confidence ]</b>
</details>

<details>
<summary>xmtp_debug/src/app/generate/identity.rs — 0 comments posted, 4 evaluated, 2 filtered</summary>

- [line 51](https://github.com/xmtp/libxmtp/blob/d19998d4ea77463b07762048b54cb7eb774e7d4f/xmtp_debug/src/app/generate/identity.rs#L51): `ProgressStyle::with_template(...).unwrap()` can panic at runtime if the template is invalid. In `create_identities`, this occurs when building the progress bar: `style.unwrap()`; replace with graceful handling (e.g., `?` with error propagation) to avoid unintended termination. <b>[ Already posted ]</b>
- [line 54](https://github.com/xmtp/libxmtp/blob/d19998d4ea77463b07762048b54cb7eb774e7d4f/xmtp_debug/src/app/generate/identity.rs#L54): Background tick task spawned for the progress bar is never cancelled or awaited, causing an orphaned task that continues running indefinitely: the task loops `while s.next().await.is_some() { b.tick(); }` without an exit signal. This can leak and continue ticking after the function returns, especially on early error returns. <b>[ Low confidence ]</b>
</details>

<details>
<summary>xmtp_debug/src/app/generate/messages.rs — 1 comment posted, 5 evaluated, 4 filtered</summary>

- [line 221](https://github.com/xmtp/libxmtp/blob/d19998d4ea77463b07762048b54cb7eb774e7d4f/xmtp_debug/src/app/generate/messages.rs#L221): `ProgressStyle::with_template(...).unwrap()` can panic at runtime if the template is invalid. In `send_many_messages`, this occurs when building the progress bar: `style.unwrap()`; replace with graceful handling to avoid unintended termination. <b>[ Already posted ]</b>
- [line 221](https://github.com/xmtp/libxmtp/blob/d19998d4ea77463b07762048b54cb7eb774e7d4f/xmtp_debug/src/app/generate/messages.rs#L221): `ProgressStyle::with_template(...).unwrap()` can panic at runtime if the template is invalid or if the library rejects it. Panics are not guarded and will abort message generation. Replace `unwrap()` with `?` and propagate an error, or default to a safe style on failure. <b>[ Already posted ]</b>
- [line 247](https://github.com/xmtp/libxmtp/blob/d19998d4ea77463b07762048b54cb7eb774e7d4f/xmtp_debug/src/app/generate/messages.rs#L247): `send_many_messages` misclassifies task outcomes and silently discards inner errors. `JoinSet::join_all()` returns `Vec<Result<T, JoinError>>` where `T` is `Result<(), eyre::Error>`. The code filters with `r.is_err()` and logs only `JoinError`s, ignoring `Ok(Err(e))` (task returned an error). It also counts successes using `r.is_ok()` which treats both `Ok(Ok(()))` and `Ok(Err(e))` as successes, inflating the success count and hiding real failures. Fix by inspecting the inner `Result` within the `Ok` case, e.g., iterate and match `Ok(Ok(_))` vs `Ok(Err(e))` and handle/log appropriately. <b>[ Already posted ]</b>
- [line 247](https://github.com/xmtp/libxmtp/blob/d19998d4ea77463b07762048b54cb7eb774e7d4f/xmtp_debug/src/app/generate/messages.rs#L247): `send_many_messages` misclassifies and silently ignores inner task errors when computing the number of messages sent. It only treats `JoinError` as failures: `let errors = res.iter().filter(|r| r.is_err())...`, but ignores `Err(eyre::Error)` returned from tasks. Then it counts all `is_ok()` joins as successes, even if the inner result is `Err`, leading to an incorrect success count and silent failure. It should inspect the inner `Result` from each `Ok` join outcome. <b>[ Already posted ]</b>
</details>

<details>
<summary>xmtp_debug/src/app/modify.rs — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 55](https://github.com/xmtp/libxmtp/blob/d19998d4ea77463b07762048b54cb7eb774e7d4f/xmtp_debug/src/app/modify.rs#L55): Remove path unconditionally decrements `local_group.member_size` and may underflow or become inconsistent if the member is not present. The code does `local_group.member_size -= 1;` before verifying the member existed, and uses `retain` to filter. If the member was not found, size is decremented incorrectly; if size is 0, subtraction can underflow (panic in debug, wrap in release). Decrement only when an element was actually removed, and guard against underflow. <b>[ Already posted ]</b>
- [line 75](https://github.com/xmtp/libxmtp/blob/d19998d4ea77463b07762048b54cb7eb774e7d4f/xmtp_debug/src/app/modify.rs#L75): AddRandom path selects an identity that is already a member and then decrements `member_size` instead of incrementing, leading to duplicates and incorrect counts. The filter `filter(|identity| members.contains(&identity.inbox_id))` chooses only existing members, and then `local_group.member_size -= 1;` reduces the count before pushing the same inbox id again. This yields duplicate entries and an incorrect, possibly underflowing, `member_size`. The filter should exclude existing members (`!members.contains...`) and `member_size` should be incremented when a new member is added. <b>[ Already posted ]</b>
</details>

<details>
<summary>xmtp_debug/src/app/types.rs — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 79](https://github.com/xmtp/libxmtp/blob/d19998d4ea77463b07762048b54cb7eb774e7d4f/xmtp_debug/src/app/types.rs#L79): Extremely unsafe layout transmutation between `xmtp_mls::identity::Identity` and a local `ForeignIdentity` via `std::mem::transmute` (both ref and owned) relies on identical private layout, which is undefined behavior if the layout ever differs. In `from_libxmtp`, a `&xmtp_mls::identity::Identity` is transmuted to `&ForeignIdentity` and fields are read; in `impl From<Identity> for xmtp_mls::identity::Identity`, a constructed `ForeignIdentity` is transmuted into the external type. This is unsound unless the exact representation is guaranteed by the external crate, which is not established here. Replace with safe accessors/constructors or explicit, versioned FFI representations. <b>[ Out of scope ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->