### PR TITLE
Switch tester to ephemeral_db by default

### DIFF
--- a/xmtp_mls/src/utils/test/tester_utils.rs
+++ b/xmtp_mls/src/utils/test/tester_utils.rs
@@ -404,7 +404,7 @@ impl Default for TesterBuilder<PrivateKeySigner> {
             commit_log_worker: true, // Default to enabled to match production
             installation: false,
             in_memory_cursors: false,
-            ephemeral_db: false,
+            ephemeral_db: true,
             triggers: false,
             api_endpoint: ApiEndpoint::Local,
             external_identity: None,
@@ -491,7 +491,8 @@ where
 
     pub fn snapshot(mut self, snapshot: Arc<Vec<u8>>) -> Self {
         self.snapshot = Some(snapshot);
-        self.ephemeral_db()
+        self.ephemeral_db = true;
+        self
     }
 
     pub fn snapshot_file(mut self, snapshot_path: impl Into<PathBuf>) -> Self {
@@ -569,8 +570,8 @@ where
         self
     }
 
-    pub fn ephemeral_db(mut self) -> Self {
-        self.ephemeral_db = true;
+    pub fn persistent_db(mut self) -> Self {
+        self.ephemeral_db = false;
         self
     }
 
@@ -791,7 +792,7 @@ mod tests {
 
     #[xmtp_common::test(unwrap_try = true)]
     async fn test_snapshots() {
-        tester!(alix, ephemeral_db);
+        tester!(alix);
         let g = alix.create_group(None, None)?;
         let snap = Arc::new(alix.db_snapshot());
         tester!(alix2, snapshot: snap);


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Set `TesterBuilder<PrivateKeySigner>::default` to use ephemeral_db by default in [tester_utils.rs](https://github.com/xmtp/libxmtp/pull/2800/files#diff-727ea71bc8afdfdf6f0b1d9813b2e6e46f6fdd647abbc9b56be80bd873034c7d)
Switch the default `ephemeral_db` to `true`, add `TesterBuilder::persistent_db` to opt into persistence, and adjust `TesterBuilder::snapshot` to set `ephemeral_db = true` directly, with tests updated to rely on the new default.

#### 📍Where to Start
Start with the `Default` impl and builder methods in [tester_utils.rs](https://github.com/xmtp/libxmtp/pull/2800/files#diff-727ea71bc8afdfdf6f0b1d9813b2e6e46f6fdd647abbc9b56be80bd873034c7d), focusing on `TesterBuilder<PrivateKeySigner>::default`, `TesterBuilder::snapshot`, and `TesterBuilder::persistent_db`.

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 1799c74.
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->