### PR TITLE
Add Reply encoding/decoding to WASM and node bindings

### DIFF
--- a/bindings_node/src/content_types/reply.rs
+++ b/bindings_node/src/content_types/reply.rs
@@ -94,7 +94,7 @@ pub fn decode_reply(bytes: Uint8Array) -> Result<Reply> {
     XmtpEncodedContent::decode(bytes.to_vec().as_slice()).map_err(ErrorWrapper::from)?;
 
   // Use ReplyCodec to decode and convert to Reply
-  let reply = ReplyCodec::decode(encoded_content.clone()).map_err(ErrorWrapper::from)?;
+  let reply = ReplyCodec::decode(encoded_content).map_err(ErrorWrapper::from)?;
 
   Ok(Reply {
     content: reply.content.into(),

--- a/bindings_wasm/src/content_types/reply.rs
+++ b/bindings_wasm/src/content_types/reply.rs
@@ -110,8 +110,7 @@ pub fn decode_reply(bytes: Uint8Array) -> Result<Reply, JsError> {
     .map_err(|e| JsError::new(&format!("{}", e)))?;
 
   // Use ReplyCodec to decode and convert to Reply
-  let reply =
-    ReplyCodec::decode(encoded_content.clone()).map_err(|e| JsError::new(&format!("{}", e)))?;
+  let reply = ReplyCodec::decode(encoded_content).map_err(|e| JsError::new(&format!("{}", e)))?;
 
   Ok(Reply {
     content: reply.content.into(),


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add Reply encoding and decoding to Node N-API and WASM bindings for reply content payloads
Introduce a `Reply` data type for bindings and add `encode_reply`/`decode_reply` (`bindings_node`) and `encodeReply`/`decodeReply` (`bindings_wasm`) functions using `ReplyCodec` and `prost::Message` for protobuf serialization.

#### 📍Where to Start
Start with the `encode_reply` and `decode_reply` functions in [reply.rs](https://github.com/xmtp/libxmtp/pull/2812/files#diff-35a43d839fa5c2df803ef932010c54b7aa978eda560031c0363f560f133abf18), then review the WASM equivalents `encodeReply` and `decodeReply` in [reply.rs](https://github.com/xmtp/libxmtp/pull/2812/files#diff-abd3eac6969dda886f8326651fd6f3abc88f8766cb6ff9ebf9cf743b78939e6c).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 0e39785.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->