### PR TITLE
Fix bug with load_mls_group_with_lock

### DIFF
--- a/xmtp_mls/src/groups/intents.rs
+++ b/xmtp_mls/src/groups/intents.rs
@@ -1006,7 +1006,7 @@ pub(crate) mod tests {
 
         let storage = group.context.mls_storage();
         let decrypted_message = group
-            .load_mls_group_with_lock(storage, |mut mls_group| {
+            .load_mls_group(storage, |mut mls_group| {
                 Ok(mls_group
                     .process_message(&XmtpOpenMlsProviderRef::new(storage), mls_message.clone())
                     .unwrap())

--- a/xmtp_mls/src/groups/members.rs
+++ b/xmtp_mls/src/groups/members.rs
@@ -35,7 +35,7 @@ where
     pub async fn members(&self) -> Result<Vec<GroupMember>, GroupError> {
         let db = self.context.db();
         let storage = self.context.mls_storage();
-        let group_membership = self.load_mls_group_with_lock(storage, |mls_group| {
+        let group_membership = self.load_mls_group(storage, |mls_group| {
             Ok(extract_group_membership(mls_group.extensions())?)
         })?;
         let requests = group_membership

--- a/xmtp_mls/src/groups/tests/mod.rs
+++ b/xmtp_mls/src/groups/tests/mod.rs
@@ -8,6 +8,8 @@ mod test_extract_readded_installations;
 mod test_key_updates;
 mod test_libxmtp_version;
 #[cfg(not(target_arch = "wasm32"))]
+mod test_mls_group_lock;
+#[cfg(not(target_arch = "wasm32"))]
 mod test_network;
 mod test_send_message_opts;
 mod test_welcome_pointers;
@@ -305,7 +307,7 @@ async fn test_add_member_conflict() {
     // Check Amal's MLS group state.
     let amal_db = amal.context.db();
     let amal_members_len = amal_group
-        .load_mls_group_with_lock(amal.context.mls_storage(), |mls_group| {
+        .load_mls_group(amal.context.mls_storage(), |mls_group| {
             Ok(mls_group.members().count())
         })
         .unwrap();
@@ -315,7 +317,7 @@ async fn test_add_member_conflict() {
     // Check Bola's MLS group state.
     let bola_db = bola.context.db();
     let bola_members_len = bola_group
-        .load_mls_group_with_lock(amal.context.mls_storage(), |mls_group| {
+        .load_mls_group(amal.context.mls_storage(), |mls_group| {
             Ok(mls_group.members().count())
         })
         .unwrap();

--- a/xmtp_mls/src/groups/tests/test_mls_group_lock.rs
+++ b/xmtp_mls/src/groups/tests/test_mls_group_lock.rs
@@ -1,0 +1,147 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::context::XmtpSharedContext;
+use crate::groups::GroupError;
+use crate::tester;
+
+#[xmtp_common::test]
+async fn test_load_mls_group_with_lock_returns_error_when_locked() {
+    tester!(alix);
+
+    let group = alix.create_group(None, None).unwrap();
+    let group_clone = group.clone();
+
+    // Acquire the lock in a background task and hold it
+    let (done_tx, done_rx) = tokio::sync::oneshot::channel::<()>();
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel::<()>();
+
+    let handle = tokio::spawn(async move {
+        group_clone
+            .load_mls_group_with_lock_async(|_mls_group| async move {
+                // Signal that the lock is held
+                let _ = ready_tx.send(());
+                // Hold the lock until signaled to release
+                let _ = done_rx.await;
+                Ok::<_, GroupError>(())
+            })
+            .await
+            .unwrap();
+    });
+
+    // Wait for the lock to be acquired
+    ready_rx.await.unwrap();
+
+    // Now try to use load_mls_group_with_lock - it should return LockUnavailable error
+    let storage = alix.context.mls_storage();
+    let result = group.load_mls_group_with_lock(storage, |_mls_group| Ok(()));
+
+    // The sync version uses try_lock, so it should fail with LockUnavailable
+    assert!(
+        matches!(result, Err(GroupError::LockUnavailable)),
+        "Expected LockUnavailable error, got: {:?}",
+        result
+    );
+
+    // Release the lock
+    let _ = done_tx.send(());
+    handle.await.unwrap();
+}
+
+/// Test that `load_mls_group_with_lock_async` waits for the lock to be released
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_load_mls_group_with_lock_async_waits_for_lock() {
+    tester!(alix);
+
+    let group = alix.create_group(None, None)?;
+
+    // Clone what we need for the spawned task
+    let group_id = group.group_id.clone();
+    let commit_lock = alix.context.mls_commit_lock().clone();
+
+    // Track execution order
+    let execution_order = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let execution_order_clone = execution_order.clone();
+
+    // Acquire the lock in a background task and hold it briefly
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel::<()>();
+
+    let handle = tokio::spawn(async move {
+        // Acquire the lock
+        let _guard = commit_lock.get_lock_async(group_id).await;
+        execution_order_clone.lock().unwrap().push(1);
+        // Signal that the lock is held
+        let _ = ready_tx.send(());
+        // Hold the lock for a short time
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        execution_order_clone.lock().unwrap().push(2);
+        // Lock is released when _guard is dropped
+    });
+
+    // Wait for the lock to be acquired
+    ready_rx.await.unwrap();
+
+    // Now try to use load_mls_group_with_lock_async - it should wait
+    let execution_order_clone2 = execution_order.clone();
+    let result: Result<(), GroupError> = group
+        .load_mls_group_with_lock_async(|_mls_group| async move {
+            execution_order_clone2.lock().unwrap().push(3);
+            Ok(())
+        })
+        .await;
+
+    assert!(result.is_ok(), "Expected success, got: {:?}", result);
+
+    handle.await.unwrap();
+
+    // Verify execution order: first task should complete (1, 2) before second task runs (3)
+    let order = execution_order.lock().unwrap();
+    assert_eq!(
+        *order,
+        vec![1, 2, 3],
+        "Expected execution order [1, 2, 3], got {:?}",
+        *order
+    );
+}
+
+/// Test that concurrent calls to load_mls_group_with_lock on different groups work independently
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_load_mls_group_with_lock_different_groups_independent() {
+    tester!(alix);
+
+    let group1 = alix.create_group(None, None)?;
+    let group2 = alix.create_group(None, None)?;
+    let group1_clone = group1.clone();
+
+    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel::<()>();
+
+    let handle = tokio::spawn(async move {
+        group1_clone
+            .load_mls_group_with_lock_async(|_mls_group| async move {
+                let _ = ready_tx.send(());
+                let _ = rx.await;
+                Ok::<_, GroupError>(())
+            })
+            .await
+            .unwrap();
+    });
+
+    ready_rx.await.unwrap();
+
+    // group1 should be locked
+    let storage = alix.context.mls_storage();
+    let result1 = group1.load_mls_group(storage, |_| Ok(()));
+    assert!(matches!(result1, Err(GroupError::LockUnavailable)));
+
+    // group2 should NOT be locked - it's a different group
+    let result2 = group2.load_mls_group(storage, |_| Ok(()));
+    assert!(
+        result2.is_ok(),
+        "group2 should not be locked: {:?}",
+        result2
+    );
+
+    let _ = tx.send(());
+    handle.await.unwrap();
+}

--- a/xmtp_mls/src/subscriptions/stream_messages/types.rs
+++ b/xmtp_mls/src/subscriptions/stream_messages/types.rs
@@ -87,6 +87,7 @@ impl GroupList {
     }
 
     /// get the size of the group list
+    #[allow(dead_code)]
     pub(super) fn len(&self) -> usize {
         self.list.len()
     }

--- a/xmtp_mls/src/test/client_test_utils.rs
+++ b/xmtp_mls/src/test/client_test_utils.rs
@@ -93,14 +93,10 @@ where
         let other_epoch = other_sync_group.epoch().await?;
         assert_eq!(epoch, other_epoch);
 
-        let ratchet_tree =
-            sync_group.load_mls_group_with_lock(self.context.mls_storage(), |g| {
-                Ok(g.export_ratchet_tree())
-            })?;
+        let ratchet_tree = sync_group
+            .load_mls_group(self.context.mls_storage(), |g| Ok(g.export_ratchet_tree()))?;
         let other_ratchet_tree = other_sync_group
-            .load_mls_group_with_lock(other.context.mls_storage(), |g| {
-                Ok(g.export_ratchet_tree())
-            })?;
+            .load_mls_group(other.context.mls_storage(), |g| Ok(g.export_ratchet_tree()))?;
         assert_eq!(ratchet_tree, other_ratchet_tree);
         let sync_group_verified = format!(
             "verified [{}] has same sync group as [{}]",


### PR DESCRIPTION
## tl;dr

- Fixes a bug where `load_mls_group_with_lock` does not return an error or wait if the group is already locked (synchronously or asynchronously)
- Replaces a lot of usage of `load_mls_group_with_lock` with `load_mls_group`...which does basically the same thing as the old version but more honestly.

## The issue

Previously `load_mls_group_with_lock` would call `get_lock_sync`, which returns an error. But it ignored the result and wouldn't return if it failed. That means that if anyone had already acquired the lock, it would do nothing.

If you were the only lock holder you _could_ block someone from calling `load_mls_group_with_lock_async`, which does successfully wait until the lock was released. But even that would only respect the first caller of `load_mls_group_with_lock`, so it isn't a functional semaphore or `RwLock`​ either.

## Why not just fix the bug?

I decided to change to the new `load_mls_group` in most cases for a few reasons.

1. The current implementation would have had a ton of lock errors if it actually worked. We call methods that call `load_mls_group_with_lock` from inside the callbacks to `load_mls_group_with_lock_async`
2. Most of the calls to `load_mls_group_with_lock` are for read-only data. If an app wants to call `group.members()` they don't want (and can't) coordinate their calls around whether or not we are syncing or receiving messages from a stream. If this lock actually worked it would make our SDKs extremely flaky since we would be returning lock errors everywhere. 

## So, this is safe?

I'm not so sure. We have to thoroughly audit all usage of any method that previously called any of the methods that relied on `load_mls_group_with_lock` and make sure that they shouldn't actually be taking out a lock (and erroring if one isn't available) or using the async method and waiting until the lock becomes available. We generally use `load_mls_group_with_lock_async` for heavy lifting...but maybe not exclusively. So we shouldn't merge this without some more investigation tomorrow.

## Other notes

- I kept the callback format for `load_mls_group`​...but I probably should just make it a regular function.