### PR TITLE
fix originator id and sequence id on transcript message from welcome

### DIFF
--- a/xmtp_db/src/encrypted_store/group_message.rs
+++ b/xmtp_db/src/encrypted_store/group_message.rs
@@ -78,6 +78,15 @@ pub struct StoredGroupMessage {
     pub expire_at_ns: Option<i64>,
 }
 
+impl StoredGroupMessage {
+    pub fn cursor(&self) -> Cursor {
+        Cursor {
+            sequence_id: self.sequence_id as u64,
+            originator_id: self.originator_id as u32,
+        }
+    }
+}
+
 // Separate Insertable struct that excludes inserted_at_ns to let the database set it
 #[derive(Debug, Clone, Insertable)]
 #[diesel(table_name = group_messages)]

--- a/xmtp_mls/src/groups/tests/test_welcomes.rs
+++ b/xmtp_mls/src/groups/tests/test_welcomes.rs
@@ -11,6 +11,8 @@ use crate::groups::mls_sync::decode_staged_commit;
 use crate::groups::mls_sync::update_group_membership::apply_update_group_membership_intent;
 use crate::identity::create_credential;
 use crate::tester;
+use xmtp_configuration::Originators;
+use xmtp_db::DbQuery;
 use xmtp_db::XmtpOpenMlsProviderRef;
 use xmtp_db::group::ConversationType;
 use xmtp_db::group_message::MsgQueryArgs;
@@ -40,6 +42,97 @@ async fn test_welcome_cursor() {
 
     assert_eq!(alix2_refresh_state.len(), 1);
     assert!(*alix2_refresh_state.values().last().unwrap() > 0);
+}
+
+#[track_caller]
+fn assert_cursors(db: &impl DbQuery, db2: &impl DbQuery, group_id: &[u8]) {
+    let msg = db
+        .get_group_messages(group_id, &Default::default())
+        .unwrap();
+    let msg = msg.last().unwrap();
+    let cursor = db
+        .get_last_cursor_for_ids(&[&group_id], &[EntityKind::CommitMessage])
+        .unwrap()
+        .values()
+        .next()
+        .unwrap()
+        .cursor(&Originators::MLS_COMMITS);
+
+    assert_eq!(
+        msg.cursor(),
+        cursor,
+        "local cursor state of commits must be consistent"
+    );
+
+    let other_msg = db2
+        .get_group_messages(group_id, &Default::default())
+        .unwrap();
+    let other_msg = other_msg.last().unwrap();
+    assert_eq!(
+        msg.cursor(),
+        other_msg.cursor(),
+        "GroupMessage must equal group message of db2"
+    );
+    let other_cursor = db2
+        .get_last_cursor_for_ids(&[&group_id], &[EntityKind::CommitMessage])
+        .unwrap()
+        .values()
+        .next()
+        .unwrap()
+        .cursor(&Originators::MLS_COMMITS);
+    assert_eq!(
+        cursor, other_cursor,
+        "commit entry in refresh state cursor store must be equal"
+    );
+}
+
+// it is very important for this behavior to be true,
+// in order to maintain dependency consistency in d14n
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_inviting_members_results_in_consistent_state() {
+    use EntityKind::CommitMessage;
+    tester!(alix);
+    tester!(bo);
+    tester!(caro);
+
+    let alix_group = alix
+        .create_group_with_inbox_ids(&[bo.inbox_id()], None, None)
+        .await?;
+    let group_id = &alix_group.group_id;
+    assert_cursors(&alix.db(), &alix.db(), group_id);
+
+    let bo_group = bo.sync_welcomes().await?.pop()?;
+    assert_cursors(&alix.db(), &bo.db(), group_id);
+
+    alix_group
+        .add_members_by_inbox_id(&[caro.inbox_id()])
+        .await?;
+
+    let caro_group = caro.sync_welcomes().await?.pop()?;
+    alix_group.sync().await?;
+    assert_cursors(&caro.db(), &caro.db(), group_id);
+    assert_cursors(&caro.db(), &alix.db(), group_id);
+
+    // ensure all groups have the latest
+    bo_group.sync().await?;
+    alix_group.sync().await?;
+    caro_group.sync().await?;
+    assert_cursors(&caro.db(), &caro.db(), group_id);
+    assert_cursors(&caro.db(), &bo.db(), group_id);
+    assert_cursors(&caro.db(), &alix.db(), group_id);
+
+    // alix has the membership commit
+    let alix_commit = alix
+        .db()
+        .get_last_cursor_for_ids(&[group_id], &[CommitMessage])?;
+    let bo_commit = bo
+        .db()
+        .get_last_cursor_for_ids(&[group_id], &[CommitMessage])?;
+    let caro_commit = caro
+        .db()
+        .get_last_cursor_for_ids(&[group_id], &[CommitMessage])?;
+    assert_eq!(bo_commit, caro_commit);
+    assert_eq!(alix_commit, bo_commit);
 }
 
 #[xmtp_common::test(unwrap_try = true)]

--- a/xmtp_mls/src/groups/welcomes/xmtp_welcome.rs
+++ b/xmtp_mls/src/groups/welcomes/xmtp_welcome.rs
@@ -22,6 +22,7 @@ use openmls::group::MlsGroup as OpenMlsGroup;
 use prost::Message;
 use xmtp_common::RetryableError;
 use xmtp_common::time::now_ns;
+use xmtp_configuration::Originators;
 use xmtp_content_types::ContentCodec;
 use xmtp_content_types::group_updated::GroupUpdatedCodec;
 use xmtp_db::{
@@ -463,6 +464,11 @@ where
             }
         });
 
+        let cursor = welcome_metadata
+            .map(|m| m.message_cursor as i64)
+            .unwrap_or_default();
+
+        // this is the commit that brought us into the group
         let added_msg = StoredGroupMessage {
             id: added_message_id,
             group_id: stored_group.id.clone(),
@@ -477,8 +483,8 @@ where
             version_minor: added_content_type.version_minor as i32,
             authority_id: added_content_type.authority_id,
             reference_id: None,
-            sequence_id: welcome.sequence_id() as i64,
-            originator_id: welcome.originator_id() as i64,
+            sequence_id: cursor,
+            originator_id: Originators::MLS_COMMITS as i64,
             expire_at_ns: None,
             inserted_at_ns: 0, // Will be set by database
         };
@@ -503,10 +509,6 @@ where
             group.quietly_update_consent_state(ConsentState::Allowed, &db)?;
         }
 
-        // Set the message cursor
-        let cursor = welcome_metadata
-            .map(|m| m.message_cursor as i64)
-            .unwrap_or_default();
         db.update_cursor(
             &group.group_id,
             EntityKind::CommitMessage,

--- a/xmtp_proto/src/types/global_cursor.rs
+++ b/xmtp_proto/src/types/global_cursor.rs
@@ -49,6 +49,14 @@ impl GlobalCursor {
         self.inner.get(originator).copied().unwrap_or(0)
     }
 
+    /// get the full [`super::Cursor`] that belongs to this [`OriginatorId``
+    pub fn cursor(&self, originator: &OriginatorId) -> super::Cursor {
+        super::Cursor {
+            originator_id: *originator,
+            sequence_id: self.get(originator),
+        }
+    }
+
     /// Get the max sequence id across all originator ids
     pub fn max(&self) -> SequenceId {
         self.inner.values().copied().max().unwrap_or(0)


### PR DESCRIPTION
originator and sequence id were being taken from the welcome for the group message, when the cursor on the metadata represents the last commit of the group. it was being set correctly in `refresh_state`, but we should try to make our tables consistent between each other so this fixes the transcript message on the `group_messages` table.

it will be helpful when setting dependencies that the group messages table also holds commits as well as refresh state, as a defensive measure against races
