### PR TITLE
switch with_connection to be sync with now_or_never

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8710,6 +8710,7 @@ dependencies = [
  "diesel",
  "diesel_migrations",
  "dyn-clone",
+ "futures",
  "futures-timer",
  "itertools 0.14.0",
  "libsqlite3-sys",

--- a/xmtp_db/Cargo.toml
+++ b/xmtp_db/Cargo.toml
@@ -44,6 +44,7 @@ xmtp_configuration.workspace = true
 xmtp_proto.workspace = true
 zeroize.workspace = true
 
+futures = { workspace = true, optional = true }
 mockall = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true, features = [
   "macros",
@@ -94,6 +95,7 @@ wasm-bindgen-test.workspace = true
 [features]
 update-schema = ["dep:toml"]
 test-utils = [
+  "dep:futures",
   "xmtp_common/test-utils",
   "dep:mockall",
   "xmtp_configuration/test-utils",

--- a/xmtp_db/src/encrypted_store/association_state.rs
+++ b/xmtp_db/src/encrypted_store/association_state.rs
@@ -176,7 +176,7 @@ pub(crate) mod tests {
     }
 
     #[xmtp_common::test]
-    async fn test_batch_read() {
+    fn test_batch_read() {
         with_connection(|conn| {
             let mock = AssociationStateProto {
                 inbox_id: "test_id1".into(),
@@ -223,6 +223,5 @@ pub(crate) mod tests {
                 .collect::<Vec<MockState>>();
             assert_eq!(no_results.len(), 0);
         })
-        .await
     }
 }

--- a/xmtp_db/src/encrypted_store/consent_record.rs
+++ b/xmtp_db/src/encrypted_store/consent_record.rs
@@ -428,7 +428,7 @@ mod tests {
     }
 
     #[xmtp_common::test(unwrap_try = true)]
-    async fn find_consent_by_dm_id() {
+    fn find_consent_by_dm_id() {
         with_connection(|conn| {
             let mut g = generate_group(None);
             g.dm_id = Some("dm:alpha:beta".to_string());
@@ -446,11 +446,10 @@ mod tests {
             assert_eq!(records.len(), 1);
             assert_eq!(records.pop()?, cr);
         })
-        .await;
     }
 
     #[xmtp_common::test]
-    async fn insert_and_read() {
+    fn insert_and_read() {
         with_connection(|conn| {
             let inbox_id = "inbox_1";
             let consent_record = generate_consent_record(
@@ -511,6 +510,5 @@ mod tests {
             // ensure the db matches the state of what was returned
             assert_eq!(db_cr.state, existing.state);
         })
-        .await
     }
 }

--- a/xmtp_db/src/encrypted_store/conversation_list.rs
+++ b/xmtp_db/src/encrypted_store/conversation_list.rs
@@ -259,7 +259,7 @@ pub(crate) mod tests {
     use crate::test_utils::with_connection;
 
     #[xmtp_common::test]
-    async fn test_single_group_multiple_messages() {
+    fn test_single_group_multiple_messages() {
         with_connection(|conn| {
             // Create a group
             let group = generate_group(None);
@@ -294,11 +294,10 @@ pub(crate) mod tests {
                 "Last message should be the most recent one"
             );
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn test_three_groups_specific_ordering() {
+    fn test_three_groups_specific_ordering() {
         with_connection(|conn| {
             // Create three groups
             let group_a = generate_group_with_created_at(None, 5000); // Created after last message
@@ -338,11 +337,10 @@ pub(crate) mod tests {
                 "Group created before the last message with no messages should come last"
             );
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn test_group_with_newer_message_update() {
+    fn test_group_with_newer_message_update() {
         with_connection(|conn| {
             // Create a group
             let group = generate_group(None);
@@ -391,11 +389,10 @@ pub(crate) mod tests {
                 "Last message should now match the second (newest) message"
             );
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn test_find_conversations_by_consent_state() {
+    fn test_find_conversations_by_consent_state() {
         with_connection(|conn| {
             let test_group_1 = generate_group(Some(GroupMembershipState::Allowed));
             test_group_1.store(conn).unwrap();
@@ -484,11 +481,10 @@ pub(crate) mod tests {
                 .unwrap();
             assert_eq!(empty_array_results.len(), 3);
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn test_find_conversations_default_excludes_denied() {
+    fn test_find_conversations_default_excludes_denied() {
         with_connection(|conn| {
             // Create three groups: one allowed, one denied, one unknown (no consent)
             let allowed_group = generate_group(Some(GroupMembershipState::Allowed));
@@ -527,11 +523,10 @@ pub(crate) mod tests {
             assert!(returned_ids.contains(&&unknown_group.id));
             assert!(!returned_ids.contains(&&denied_group.id));
         })
-        .await
     }
 
     #[xmtp_common::test(unwrap_try = true)]
-    async fn test_unknown_content_type_is_present() {
+    fn test_unknown_content_type_is_present() {
         with_connection(|conn| {
             let dm = generate_dm(None);
             dm.store(conn)?;
@@ -553,11 +548,10 @@ pub(crate) mod tests {
             // Message id should be present
             assert!(conv[0].message_id.is_some());
         })
-        .await;
     }
 
     #[xmtp_common::test]
-    async fn test_last_activity_after_ns_filter() {
+    fn test_last_activity_after_ns_filter() {
         with_connection(|conn| {
             // Create groups with specific creation times
             let group1 = generate_group_with_created_at(None, 1000);
@@ -638,11 +632,10 @@ pub(crate) mod tests {
                 .unwrap();
             assert_eq!(results.len(), 3, "Should return all groups");
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn test_last_activity_before_ns_filter() {
+    fn test_last_activity_before_ns_filter() {
         with_connection(|conn| {
             // Create groups with specific creation times
             let group1 = generate_group_with_created_at(None, 1000);
@@ -723,11 +716,10 @@ pub(crate) mod tests {
                 .unwrap();
             assert_eq!(results.len(), 3, "Should return all groups");
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn test_activity_filters_combined_with_limit() {
+    fn test_activity_filters_combined_with_limit() {
         with_connection(|conn| {
             // Create multiple groups with different activity times
             let mut groups = Vec::new();
@@ -772,6 +764,5 @@ pub(crate) mod tests {
                 "Second should be second most recent"
             );
         })
-        .await
     }
 }

--- a/xmtp_db/src/encrypted_store/events.rs
+++ b/xmtp_db/src/encrypted_store/events.rs
@@ -203,7 +203,7 @@ mod tests {
 
     #[xmtp_common::test(unwrap_try = true)]
     // A client build event should clear old events.
-    async fn clear_old_events() {
+    fn clear_old_events() {
         with_connection(|conn| {
             let details: HashMap<String, String> = HashMap::default();
             Events {
@@ -234,6 +234,5 @@ mod tests {
             let all = Events::all_events(conn)?;
             assert_eq!(all.len(), 0);
         })
-        .await;
     }
 }

--- a/xmtp_db/src/encrypted_store/group.rs
+++ b/xmtp_db/src/encrypted_store/group.rs
@@ -1409,7 +1409,7 @@ pub(crate) mod tests {
     }
 
     #[xmtp_common::test]
-    async fn test_it_stores_group() {
+    fn test_it_stores_group() {
         with_connection(|conn| {
             let test_group = generate_group(None);
 
@@ -1420,11 +1420,10 @@ pub(crate) mod tests {
                 test_group
             );
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn test_it_fetches_group() {
+    fn test_it_fetches_group() {
         with_connection(|conn| {
             let test_group = generate_group(None);
 
@@ -1438,11 +1437,10 @@ pub(crate) mod tests {
             let fetched_group: Option<StoredGroup> = conn.fetch(&test_group.id).unwrap();
             assert_eq!(fetched_group, Some(test_group));
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn test_it_updates_group_membership_state() {
+    fn test_it_updates_group_membership_state() {
         with_connection(|conn| {
             let test_group = generate_group(Some(GroupMembershipState::Pending));
 
@@ -1459,7 +1457,6 @@ pub(crate) mod tests {
                 }
             );
         })
-        .await
     }
 
     #[xmtp_common::test]
@@ -1584,7 +1581,7 @@ pub(crate) mod tests {
     }
 
     #[xmtp_common::test]
-    async fn test_new_group_has_correct_purpose() {
+    fn test_new_group_has_correct_purpose() {
         with_connection(|conn| {
             let test_group = generate_group(None);
 
@@ -1600,11 +1597,10 @@ pub(crate) mod tests {
             let conversation_type = fetched_group.unwrap().conversation_type;
             assert_eq!(conversation_type, ConversationType::Group);
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn test_find_groups_by_consent_state() {
+    fn test_find_groups_by_consent_state() {
         with_connection(|conn| {
             let test_group_1 = generate_group(Some(GroupMembershipState::Allowed));
             test_group_1.store(conn).unwrap();
@@ -1691,11 +1687,10 @@ pub(crate) mod tests {
                 .unwrap();
             assert_eq!(empty_array_results.len(), 3);
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn test_get_sequence_ids() {
+    fn test_get_sequence_ids() {
         with_connection(|conn| {
             let mls_groups = [
                 generate_group_with_welcome(None, Some(30)),
@@ -1715,11 +1710,10 @@ pub(crate) mod tests {
                     .collect::<Vec<u64>>()
             );
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn test_find_group_default_excludes_denied() {
+    fn test_find_group_default_excludes_denied() {
         with_connection(|conn| {
             // Create three groups: one allowed, one denied, one unknown (no consent)
             let allowed_group = generate_group(Some(GroupMembershipState::Allowed));
@@ -1756,11 +1750,10 @@ pub(crate) mod tests {
             assert!(returned_ids.contains(&&unknown_group.id));
             assert!(!returned_ids.contains(&&denied_group.id));
         })
-        .await
     }
 
     #[xmtp_common::test(unwrap_try = true)]
-    async fn test_get_conversation_ids_for_remote_log_publish() {
+    fn test_get_conversation_ids_for_remote_log_publish() {
         with_connection(|conn| {
             let mut group1 = generate_group(None);
             let mut group2 = generate_group(None);
@@ -1801,11 +1794,10 @@ pub(crate) mod tests {
                 group3.commit_log_public_key
             );
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn test_get_conversation_ids_for_remote_log_publish_with_consent() {
+    fn test_get_conversation_ids_for_remote_log_publish_with_consent() {
         with_connection(|conn| {
             // Create groups: one with Allowed consent, one with Denied consent, one with no consent
             let mut allowed_group = generate_group(None);
@@ -1840,11 +1832,10 @@ pub(crate) mod tests {
             assert_eq!(commit_log_keys.len(), 1);
             assert_eq!(commit_log_keys[0].id, allowed_group.id);
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn test_get_conversation_ids_for_remote_log_download_with_consent() {
+    fn test_get_conversation_ids_for_remote_log_download_with_consent() {
         with_connection(|conn| {
             // Create groups: one with Allowed consent, one with Denied consent, one with no consent
             let allowed_group = generate_group(None);
@@ -1887,11 +1878,10 @@ pub(crate) mod tests {
             assert_eq!(conversation_ids.len(), 1);
             assert_eq!(conversation_ids[0].id, allowed_group.id);
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn test_get_conversation_ids_for_responding_readds() {
+    fn test_get_conversation_ids_for_responding_readds() {
         with_connection(|conn| {
             // Create test groups
             let group_id_1 = vec![1, 2, 3];
@@ -1995,6 +1985,5 @@ pub(crate) mod tests {
             assert_eq!(group3_result.conversation_type, ConversationType::Group);
             assert_eq!(group3_result.created_at_ns, 3000);
         })
-        .await
     }
 }

--- a/xmtp_db/src/encrypted_store/group/dms.rs
+++ b/xmtp_db/src/encrypted_store/group/dms.rs
@@ -126,7 +126,7 @@ pub(super) mod tests {
     }
 
     #[xmtp_common::test]
-    async fn test_dm_stitching() {
+    fn test_dm_stitching() {
         with_connection(|conn| {
             StoredGroup::builder()
                 .id(rand_vec::<24>())
@@ -153,11 +153,10 @@ pub(super) mod tests {
 
             assert_eq!(all_groups.len(), 1);
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn test_dm_deduplication() {
+    fn test_dm_deduplication() {
         with_connection(|conn| {
             let now = now_ns();
             let base_time = now - 1_000_000_000; // 1 second ago
@@ -269,6 +268,5 @@ pub(super) mod tests {
             // Should have all 5 groups
             assert_eq!(all_groups.len(), 5);
         })
-        .await
     }
 }

--- a/xmtp_db/src/encrypted_store/group_intent.rs
+++ b/xmtp_db/src/encrypted_store/group_intent.rs
@@ -620,7 +620,7 @@ pub(crate) mod tests {
     }
 
     #[xmtp_common::test]
-    async fn test_store_and_fetch() {
+    fn test_store_and_fetch() {
         let group_id = rand_vec::<24>();
         let data = rand_vec::<24>();
         let kind = IntentKind::UpdateGroupMembership;
@@ -649,11 +649,10 @@ pub(crate) mod tests {
 
             assert_eq!(fetched.id, id);
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn test_query() {
+    fn test_query() {
         let group_id = rand_vec::<24>();
 
         let test_intents: Vec<NewGroupIntent> = vec![
@@ -728,11 +727,10 @@ pub(crate) mod tests {
             results = conn.find_group_intents(group_id, None, None).unwrap();
             assert_eq!(results.len(), 3);
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn find_by_payload_hash() {
+    fn find_by_payload_hash() {
         let group_id = rand_vec::<24>();
 
         with_connection(|conn| {
@@ -771,11 +769,10 @@ pub(crate) mod tests {
             assert_eq!(find_result.id, intent.id);
             assert_eq!(find_result.published_in_epoch, Some(1));
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn test_happy_path_state_transitions() {
+    fn test_happy_path_state_transitions() {
         let group_id = rand_vec::<24>();
 
         with_connection(|conn| {
@@ -818,11 +815,10 @@ pub(crate) mod tests {
             // Make sure we haven't lost the payload hash
             assert_eq!(intent.payload_hash, Some(payload_hash.clone()));
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn test_republish_state_transition() {
+    fn test_republish_state_transition() {
         let group_id = rand_vec::<24>();
 
         with_connection(|conn| {
@@ -863,11 +859,10 @@ pub(crate) mod tests {
             assert!(intent.payload_hash.is_none());
             assert!(intent.post_commit_data.is_none());
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn test_invalid_state_transition() {
+    fn test_invalid_state_transition() {
         let group_id = rand_vec::<24>();
 
         with_connection(|conn| {
@@ -899,11 +894,10 @@ pub(crate) mod tests {
                 StorageError::NotFound(_)
             ));
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn test_increment_publish_attempts() {
+    fn test_increment_publish_attempts() {
         let group_id = rand_vec::<24>();
         with_connection(|conn| {
             insert_group(conn, group_id.clone());
@@ -927,6 +921,5 @@ pub(crate) mod tests {
             intent = find_first_intent(conn, group_id.clone());
             assert_eq!(intent.publish_attempts, 2);
         })
-        .await
     }
 }

--- a/xmtp_db/src/encrypted_store/group_message/messages_newer_than_tests.rs
+++ b/xmtp_db/src/encrypted_store/group_message/messages_newer_than_tests.rs
@@ -34,7 +34,7 @@ fn generate_message_with_cursor(
 }
 
 #[xmtp_common::test]
-async fn test_messages_newer_than_basic() {
+fn test_messages_newer_than_basic() {
     use std::collections::HashMap;
     use xmtp_proto::types::GlobalCursor;
 
@@ -74,11 +74,10 @@ async fn test_messages_newer_than_basic() {
                 .any(|c| c.originator_id == 2 && c.sequence_id == 25)
         );
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn test_messages_newer_than_new_originator() {
+fn test_messages_newer_than_new_originator() {
     use std::collections::HashMap;
     use xmtp_proto::types::GlobalCursor;
 
@@ -116,11 +115,10 @@ async fn test_messages_newer_than_new_originator() {
                 .any(|c| c.originator_id == 2 && c.sequence_id == 10)
         );
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn test_messages_newer_than_multiple_groups() {
+fn test_messages_newer_than_multiple_groups() {
     use std::collections::HashMap;
     use xmtp_proto::types::GlobalCursor;
 
@@ -156,11 +154,10 @@ async fn test_messages_newer_than_multiple_groups() {
         assert!(newer.iter().any(|c| c.sequence_id == 20)); // from group1
         assert!(newer.iter().any(|c| c.sequence_id == 15)); // from group2
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn test_messages_newer_than_batching() {
+fn test_messages_newer_than_batching() {
     use std::collections::HashMap;
     use xmtp_proto::types::GlobalCursor;
 
@@ -193,11 +190,10 @@ async fn test_messages_newer_than_batching() {
         // Should get all 150 messages
         assert_eq!(newer.len(), 150);
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn test_messages_newer_than_empty_cursor() {
+fn test_messages_newer_than_empty_cursor() {
     use std::collections::HashMap;
     use xmtp_proto::types::GlobalCursor;
 
@@ -221,11 +217,10 @@ async fn test_messages_newer_than_empty_cursor() {
 
         assert_eq!(newer.len(), 3);
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn test_messages_newer_than_no_new_messages() {
+fn test_messages_newer_than_no_new_messages() {
     use std::collections::HashMap;
     use xmtp_proto::types::GlobalCursor;
 
@@ -251,11 +246,10 @@ async fn test_messages_newer_than_no_new_messages() {
 
         assert_eq!(newer.len(), 0);
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn test_messages_newer_than_mixed_originators() {
+fn test_messages_newer_than_mixed_originators() {
     use std::collections::HashMap;
     use xmtp_proto::types::GlobalCursor;
 
@@ -310,11 +304,10 @@ async fn test_messages_newer_than_mixed_originators() {
                 .any(|c| c.originator_id == 3 && c.sequence_id == 4)
         );
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn test_messages_newer_than_empty_groups() {
+fn test_messages_newer_than_empty_groups() {
     use std::collections::HashMap;
     use xmtp_proto::types::GlobalCursor;
 
@@ -331,11 +324,10 @@ async fn test_messages_newer_than_empty_groups() {
 
         assert_eq!(newer.len(), 0);
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn test_messages_newer_than_per_group_cursors() {
+fn test_messages_newer_than_per_group_cursors() {
     use std::collections::HashMap;
     use xmtp_proto::types::GlobalCursor;
 
@@ -385,5 +377,4 @@ async fn test_messages_newer_than_per_group_cursors() {
         // Should NOT include group 1's message with sequence_id 50 (< 100)
         assert!(!newer.iter().any(|c| c.sequence_id == 50));
     })
-    .await
 }

--- a/xmtp_db/src/encrypted_store/group_message/tests.rs
+++ b/xmtp_db/src/encrypted_store/group_message/tests.rs
@@ -35,16 +35,15 @@ pub(crate) fn generate_message(
 }
 
 #[xmtp_common::test]
-async fn it_does_not_error_on_empty_messages() {
+fn it_does_not_error_on_empty_messages() {
     with_connection(|conn| {
         let id = vec![0x0];
         assert_eq!(conn.get_group_message(id).unwrap(), None);
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn test_exclude_content_types_filter() {
+fn test_exclude_content_types_filter() {
     with_connection(|conn| {
         let group = generate_group(None);
         group.store(conn).unwrap();
@@ -112,11 +111,10 @@ async fn test_exclude_content_types_filter() {
         let count = conn.count_group_messages(&group.id, &exclude_args).unwrap();
         assert_eq!(count, 3);
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn it_gets_messages() {
+fn it_gets_messages() {
     with_connection(|conn| {
         let group = generate_group(None);
         let message = generate_message(None, Some(&group.id), None, None, None, None);
@@ -131,11 +129,10 @@ async fn it_gets_messages() {
             message.decrypted_message_bytes
         );
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn it_cannot_insert_message_without_group() {
+fn it_cannot_insert_message_without_group() {
     use diesel::result::DatabaseErrorKind::ForeignKeyViolation;
     with_connection(|conn| {
         let message = generate_message(None, None, None, None, None, None);
@@ -147,11 +144,10 @@ async fn it_cannot_insert_message_without_group() {
             ))
         );
     })
-    .await;
 }
 
 #[xmtp_common::test]
-async fn it_gets_many_messages() {
+fn it_gets_many_messages() {
     use crate::encrypted_store::schema::group_messages::dsl;
 
     with_connection(|conn| {
@@ -182,11 +178,10 @@ async fn it_gets_many_messages() {
             msg.sent_at_ns
         });
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn it_gets_messages_by_time() {
+fn it_gets_messages_by_time() {
     with_connection(|conn| {
         let group = generate_group(None);
         group.store(conn).unwrap();
@@ -233,11 +228,10 @@ async fn it_gets_messages_by_time() {
             .unwrap();
         assert_eq!(messages.len(), 2);
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn it_deletes_middle_message_by_expiration_time() {
+fn it_deletes_middle_message_by_expiration_time() {
     with_connection(|conn| {
         let mut group = generate_group(None);
 
@@ -295,11 +289,10 @@ async fn it_deletes_middle_message_by_expiration_time() {
                 .any(|msg| msg.sent_at_ns == 2_000_000_000_000_000_000)
         ); // Message 3
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn it_gets_messages_by_kind() {
+fn it_gets_messages_by_kind() {
     with_connection(|conn| {
         let group = generate_group(None);
         group.store(conn).unwrap();
@@ -354,11 +347,10 @@ async fn it_gets_messages_by_kind() {
             .unwrap();
         assert_eq!(membership_changes.len(), 15);
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn it_orders_messages_by_sent() {
+fn it_orders_messages_by_sent() {
     with_connection(|conn| {
         let group = generate_group(None);
         group.store(conn).unwrap();
@@ -407,11 +399,10 @@ async fn it_orders_messages_by_sent() {
         assert_eq!(messages_desc[2].sent_at_ns, 10_000);
         assert_eq!(messages_desc[3].sent_at_ns, 1_000);
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn it_gets_messages_by_content_type() {
+fn it_gets_messages_by_content_type() {
     with_connection(|conn| {
         let group = generate_group(None);
         group.store(conn).unwrap();
@@ -490,11 +481,10 @@ async fn it_gets_messages_by_content_type() {
         assert_eq!(updated_messages[0].content_type, ContentType::GroupUpdated);
         assert_eq!(updated_messages[0].sent_at_ns, 3_000);
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn it_dedupes_group_updated_messages_from_dm_by_default() {
+fn it_dedupes_group_updated_messages_from_dm_by_default() {
     with_connection(|conn| {
         // Create a DM group
         let mut group = generate_group(None);
@@ -580,7 +570,6 @@ async fn it_dedupes_group_updated_messages_from_dm_by_default() {
         );
         assert_eq!(messages_with_group_updated[0].sent_at_ns, 5_000);
     })
-    .await
 }
 
 pub(crate) fn generate_message_with_reference<C: ConnectionExt>(
@@ -614,7 +603,7 @@ pub(crate) fn generate_message_with_reference<C: ConnectionExt>(
 }
 
 #[xmtp_common::test]
-async fn test_inbound_relations_with_results() {
+fn test_inbound_relations_with_results() {
     with_connection(|conn| {
         let group = generate_group(None);
         group.store(conn).unwrap();
@@ -686,11 +675,10 @@ async fn test_inbound_relations_with_results() {
         // msg3 should not be in inbound_relations
         assert!(!inbound_relations.contains_key(&msg3.id));
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn test_relations_when_no_references_exist() {
+fn test_relations_when_no_references_exist() {
     with_connection(|conn| {
         let group = generate_group(None);
         group.store(conn).unwrap();
@@ -742,11 +730,10 @@ async fn test_relations_when_no_references_exist() {
             "No outbound relations should exist"
         );
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn test_inbound_relations_no_main_query_results() {
+fn test_inbound_relations_no_main_query_results() {
     with_connection(|conn| {
         let group = generate_group(None);
         group.store(conn).unwrap();
@@ -766,11 +753,10 @@ async fn test_inbound_relations_no_main_query_results() {
 
         assert_eq!(inbound_relations.len(), 0);
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn test_inbound_relations_with_limit() {
+fn test_inbound_relations_with_limit() {
     with_connection(|conn| {
         let group = generate_group(None);
         group.store(conn).unwrap();
@@ -818,11 +804,10 @@ async fn test_inbound_relations_with_limit() {
         let msg1_reactions = inbound_relations.get(&msg1.id).unwrap();
         assert!(msg1_reactions.len() <= 3); // Limited to 3
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn test_relations_with_content_type_filters() {
+fn test_relations_with_content_type_filters() {
     with_connection(|conn| {
         let group = generate_group(None);
         group.store(conn).unwrap();
@@ -923,11 +908,10 @@ async fn test_relations_with_content_type_filters() {
         assert!(outbound_relations.contains_key(&text_msg.id));
         assert!(!outbound_relations.contains_key(&attachment_msg.id));
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn test_outbound_relations_with_results() {
+fn test_outbound_relations_with_results() {
     with_connection(|conn| {
         let group = generate_group(None);
         group.store(conn).unwrap();
@@ -986,11 +970,10 @@ async fn test_outbound_relations_with_results() {
         assert!(outbound_relations.contains_key(&original_msg1.id));
         assert!(outbound_relations.contains_key(&original_msg2.id));
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn test_outbound_relations_no_main_query_results() {
+fn test_outbound_relations_no_main_query_results() {
     with_connection(|conn| {
         let group = generate_group(None);
         group.store(conn).unwrap();
@@ -1033,11 +1016,10 @@ async fn test_outbound_relations_no_main_query_results() {
 
         assert_eq!(outbound_relations.len(), 0);
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn test_outbound_relations_with_limit() {
+fn test_outbound_relations_with_limit() {
     with_connection(|conn| {
         let group = generate_group(None);
         group.store(conn).unwrap();
@@ -1092,11 +1074,10 @@ async fn test_outbound_relations_with_limit() {
 
         assert_eq!(outbound_relations.len(), 2); // Limited to 2
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn test_both_inbound_and_outbound_relations() {
+fn test_both_inbound_and_outbound_relations() {
     with_connection(|conn| {
         let group = generate_group(None);
         group.store(conn).unwrap();
@@ -1175,11 +1156,10 @@ async fn test_both_inbound_and_outbound_relations() {
         assert_eq!(outbound_relations.len(), 1);
         assert!(outbound_relations.contains_key(&original.id));
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn test_relation_filters_none_behavior() {
+fn test_relation_filters_none_behavior() {
     with_connection(|conn| {
         let group = generate_group(None);
         group.store(conn).unwrap();
@@ -1276,11 +1256,10 @@ async fn test_relation_filters_none_behavior() {
         );
         assert!(outbound_relations.contains_key(&msg1.id));
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn test_complex_relation_chain() {
+fn test_complex_relation_chain() {
     with_connection(|conn| {
         let group = generate_group(None);
         group.store(conn).unwrap();
@@ -1349,11 +1328,10 @@ async fn test_complex_relation_chain() {
         assert!(content_types.contains(&ContentType::Reply));
         assert!(content_types.contains(&ContentType::Reaction));
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn test_inbound_relation_counts() {
+fn test_inbound_relation_counts() {
     with_connection(|conn| {
         let group = generate_group(None);
         group.store(conn).unwrap();
@@ -1440,11 +1418,10 @@ async fn test_inbound_relation_counts() {
         assert_eq!(reply_counts.get(&msg2.id).unwrap(), &3); // 3 replies
         assert!(!reply_counts.contains_key(&msg3.id)); // No replies
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn test_get_latest_message_times_by_sender_single_sender() {
+fn test_get_latest_message_times_by_sender_single_sender() {
     with_connection(|conn| {
         let group = generate_group(None);
         group.store(conn).unwrap();
@@ -1488,11 +1465,10 @@ async fn test_get_latest_message_times_by_sender_single_sender() {
         assert_eq!(latest_times.len(), 1);
         assert_eq!(latest_times.get(&sender_id).unwrap(), &5000);
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn test_get_latest_message_times_by_sender_multiple_senders() {
+fn test_get_latest_message_times_by_sender_multiple_senders() {
     with_connection(|conn| {
         let group = generate_group(None);
         group.store(conn).unwrap();
@@ -1560,11 +1536,10 @@ async fn test_get_latest_message_times_by_sender_multiple_senders() {
         assert_eq!(latest_times.get(&sender2_id).unwrap(), &8000);
         assert_eq!(latest_times.get(&sender3_id).unwrap(), &3000);
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn test_get_latest_message_times_by_sender_empty_results() {
+fn test_get_latest_message_times_by_sender_empty_results() {
     with_connection(|conn| {
         let group = generate_group(None);
         group.store(conn).unwrap();
@@ -1596,11 +1571,10 @@ async fn test_get_latest_message_times_by_sender_empty_results() {
 
         assert_eq!(latest_times.len(), 0);
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn test_get_latest_message_times_by_sender_dm_group() {
+fn test_get_latest_message_times_by_sender_dm_group() {
     with_connection(|conn| {
         // Create multiple DM groups that share the same dm_id
         let shared_dm_id = "dm_123".to_string();
@@ -1706,11 +1680,10 @@ async fn test_get_latest_message_times_by_sender_dm_group() {
         assert_eq!(latest_times_group3.len(), 1);
         assert_eq!(latest_times_group3.get(&sender_id).unwrap(), &6000);
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn test_count_group_messages() {
+fn test_count_group_messages() {
     with_connection(|conn| {
         let group = generate_group(None);
         group.store(conn).unwrap();
@@ -1939,11 +1912,10 @@ async fn test_count_group_messages() {
             1
         );
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn test_count_group_messages_dm_vs_regular_groups() {
+fn test_count_group_messages_dm_vs_regular_groups() {
     with_connection(|conn| {
         // Test DM group behavior
         let mut dm_group = generate_group(None);
@@ -2051,11 +2023,10 @@ async fn test_count_group_messages_dm_vs_regular_groups() {
             2
         );
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn test_count_group_messages_empty_groups() {
+fn test_count_group_messages_empty_groups() {
     with_connection(|conn| {
         let group = generate_group(None);
         group.store(conn).unwrap();
@@ -2092,11 +2063,10 @@ async fn test_count_group_messages_empty_groups() {
             0
         );
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn test_get_latest_message_times_by_sender_mixed_content_types() {
+fn test_get_latest_message_times_by_sender_mixed_content_types() {
     with_connection(|conn| {
         let group = generate_group(None);
         group.store(conn).unwrap();
@@ -2190,11 +2160,10 @@ async fn test_get_latest_message_times_by_sender_mixed_content_types() {
         assert_eq!(latest_times_both.get(&sender1_id).unwrap(), &8000); // Latest overall
         assert_eq!(latest_times_both.get(&sender2_id).unwrap(), &6000); // Latest text
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn it_deletes_message_by_id() {
+fn it_deletes_message_by_id() {
     with_connection(|conn| {
         let group = generate_group(None);
         assert_ok!(group.store(conn));
@@ -2226,11 +2195,10 @@ async fn it_deletes_message_by_id() {
             "Deleting non-existent message should return 0"
         );
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn test_exclude_sender_inbox_ids_filter() {
+fn test_exclude_sender_inbox_ids_filter() {
     with_connection(|conn| {
         let group = generate_group(None);
         group.store(conn).unwrap();
@@ -2364,11 +2332,10 @@ async fn test_exclude_sender_inbox_ids_filter() {
                 .all(|m| m.sender_inbox_id != sender1 && m.sent_at_ns > 2_000)
         );
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn test_sort_by_sent_at() {
+fn test_sort_by_sent_at() {
     with_connection(|conn| {
         let group = generate_group(None);
         group.store(conn).unwrap();
@@ -2405,12 +2372,11 @@ async fn test_sort_by_sent_at() {
         assert_eq!(desc_messages[1].sent_at_ns, 2000);
         assert_eq!(desc_messages[2].sent_at_ns, 1000);
     })
-    .await
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 #[xmtp_common::test]
-async fn test_sort_by_inserted_at() {
+fn test_sort_by_inserted_at() {
     with_connection(|conn| {
         let group = generate_group(None);
         group.store(conn).unwrap();
@@ -2449,12 +2415,11 @@ async fn test_sort_by_inserted_at() {
         assert!(inserted2 > inserted1);
         assert!(inserted3 > inserted2);
     })
-    .await
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 #[xmtp_common::test]
-async fn test_inserted_after_filter() {
+fn test_inserted_after_filter() {
     with_connection(|conn| {
         let group = generate_group(None);
         group.store(conn).unwrap();
@@ -2512,12 +2477,11 @@ async fn test_inserted_after_filter() {
             );
         }
     })
-    .await
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 #[xmtp_common::test]
-async fn test_inserted_before_filter() {
+fn test_inserted_before_filter() {
     with_connection(|conn| {
         let group = generate_group(None);
         group.store(conn).unwrap();
@@ -2563,12 +2527,11 @@ async fn test_inserted_before_filter() {
         assert_eq!(before_messages[1].sent_at_ns, 2000);
         assert_eq!(before_messages[2].sent_at_ns, 3000);
     })
-    .await
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 #[xmtp_common::test]
-async fn test_inserted_at_based_pagination() {
+fn test_inserted_at_based_pagination() {
     with_connection(|conn| {
         let group = generate_group(None);
         group.store(conn).unwrap();
@@ -2626,11 +2589,10 @@ async fn test_inserted_at_based_pagination() {
         let unique_ids: std::collections::HashSet<_> = all_page_ids.iter().collect();
         assert_eq!(all_page_ids.len(), unique_ids.len());
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn test_inserted_at_populated_in_all_queries() {
+fn test_inserted_at_populated_in_all_queries() {
     with_connection(|conn| {
         let group = generate_group(None);
         group.store(conn).unwrap();
@@ -2654,11 +2616,10 @@ async fn test_inserted_at_populated_in_all_queries() {
         assert_eq!(sync_messages.len(), 1);
         assert!(sync_messages[0].inserted_at_ns > 0);
     })
-    .await
 }
 
 #[xmtp_common::test]
-async fn test_expired_messages_excluded_from_queries() {
+fn test_expired_messages_excluded_from_queries() {
     with_connection(|conn| {
         let group = generate_group(None);
         group.store(conn).unwrap();
@@ -2725,5 +2686,4 @@ async fn test_expired_messages_excluded_from_queries() {
             "Should exclude expired message"
         );
     })
-    .await
 }

--- a/xmtp_db/src/encrypted_store/icebox.rs
+++ b/xmtp_db/src/encrypted_store/icebox.rs
@@ -124,7 +124,7 @@ mod tests {
     }
 
     #[xmtp_common::test(unwrap_try = true)]
-    async fn icebox_dependency_chain() {
+    fn icebox_dependency_chain() {
         with_connection(|conn| {
             let ice = iced();
             ice.iter().for_each(|i| i.store(conn)?);
@@ -135,11 +135,10 @@ mod tests {
             let dep_chain = Icebox::forward_dep_chain(conn, 39, 2)?;
             assert_eq!(dep_chain, ice.into_iter().rev().collect::<Vec<_>>());
         })
-        .await
     }
 
     #[xmtp_common::test(unwrap_try = true)]
-    async fn test_icebox_wrong_originator() {
+    fn test_icebox_wrong_originator() {
         with_connection(|conn| {
             // Break the chain by unsetting the originator.
             let mut ice = iced();
@@ -154,11 +153,10 @@ mod tests {
             let dep_chain = Icebox::forward_dep_chain(conn, 39, 1)?;
             assert_eq!(dep_chain, vec![leftover]);
         })
-        .await
     }
 
     #[xmtp_common::test(unwrap_try = true)]
-    async fn test_icebox_wrong_sequence() {
+    fn test_icebox_wrong_sequence() {
         with_connection(|conn| {
             // Break the chain by unsetting the originator.
             let mut ice = iced();
@@ -173,11 +171,10 @@ mod tests {
             let dep_chain = Icebox::forward_dep_chain(conn, 38, 2)?;
             assert_eq!(dep_chain, vec![leftover]);
         })
-        .await
     }
 
     #[xmtp_common::test(unwrap_try = true)]
-    async fn test_icebox_depending_fields_xor() {
+    fn test_icebox_depending_fields_xor() {
         with_connection(|conn| {
             // Test to ensure that if one dependency field is set, they both are.
             let mut ice = Icebox {
@@ -199,6 +196,5 @@ mod tests {
             let result = ice.store(conn);
             assert!(result.is_ok());
         })
-        .await
     }
 }

--- a/xmtp_db/src/encrypted_store/identity_cache.rs
+++ b/xmtp_db/src/encrypted_store/identity_cache.rs
@@ -185,7 +185,7 @@ pub(crate) mod tests {
 
     // Test storing duplicated wallets (same inbox_id and wallet_address)
     #[xmtp_common::test]
-    async fn test_store_duplicated_wallets() {
+    fn test_store_duplicated_wallets() {
         with_connection(|conn| {
             let entry1 = IdentityCache {
                 inbox_id: "test_dup".to_string(),
@@ -204,13 +204,12 @@ pub(crate) mod tests {
                 "Duplicated wallet stored without error, expected failure"
             );
         })
-        .await
     }
 
     // Test storing and fetching multiple wallet addresses with multiple keys
     // TODO:insipx: will need to fix & store identity kind
     #[xmtp_common::test]
-    async fn test_fetch_and_store_identity_cache() {
+    fn test_fetch_and_store_identity_cache() {
         with_connection(|conn| {
             let ident1 = MockIdentity::create(0);
             let ident2 = MockIdentity::create(0);
@@ -235,6 +234,5 @@ pub(crate) mod tests {
                 "Expected no wallets, found some"
             );
         })
-        .await
     }
 }

--- a/xmtp_db/src/encrypted_store/identity_update.rs
+++ b/xmtp_db/src/encrypted_store/identity_update.rs
@@ -213,7 +213,7 @@ pub(crate) mod tests {
     }
 
     #[xmtp_common::test]
-    async fn insert_and_read() {
+    fn insert_and_read() {
         with_connection(|conn| {
             let inbox_id = "inbox_1";
             let update_1 = build_update(inbox_id, 1);
@@ -234,11 +234,10 @@ pub(crate) mod tests {
             let second_update = all_updates.last().unwrap();
             assert_eq!(second_update.payload, update_2_payload);
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn test_filter() {
+    fn test_filter() {
         with_connection(|conn| {
             let inbox_id = "inbox_1";
             let update_1 = build_update(inbox_id, 1);
@@ -267,11 +266,10 @@ pub(crate) mod tests {
             assert_eq!(only_update_2.len(), 1);
             assert_eq!(only_update_2[0].sequence_id, 2);
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn test_get_latest_sequence_id() {
+    fn test_get_latest_sequence_id() {
         with_connection(|conn| {
             let inbox_1 = "inbox_1";
             let inbox_2 = "inbox_2";
@@ -303,11 +301,10 @@ pub(crate) mod tests {
                 None
             );
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn get_single_sequence_id() {
+    fn get_single_sequence_id() {
         with_connection(|conn| {
             let inbox_id = "inbox_1";
             let update = build_update(inbox_id, 1);
@@ -320,6 +317,5 @@ pub(crate) mod tests {
                 .expect("query should work");
             assert_eq!(sequence_id, 2);
         })
-        .await
     }
 }

--- a/xmtp_db/src/encrypted_store/key_package_history.rs
+++ b/xmtp_db/src/encrypted_store/key_package_history.rs
@@ -197,7 +197,7 @@ mod tests {
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
     #[xmtp_common::test]
-    async fn test_store_key_package_history_entry() {
+    fn test_store_key_package_history_entry() {
         with_connection(|conn| {
             let hash_ref = rand_vec::<24>();
             let post_quantum_public_key = rand_vec::<32>();
@@ -221,11 +221,10 @@ mod tests {
                 .unwrap();
             assert!(all_entries.is_empty());
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn test_store_multiple() {
+    fn test_store_multiple() {
         with_connection(|conn| {
             let post_quantum_public_key = rand_vec::<32>();
             let hash_ref1 = rand_vec::<24>();
@@ -257,6 +256,5 @@ mod tests {
                 .unwrap();
             assert_eq!(earlier_entries.len(), 2);
         })
-        .await
     }
 }

--- a/xmtp_db/src/encrypted_store/pending_remove.rs
+++ b/xmtp_db/src/encrypted_store/pending_remove.rs
@@ -125,7 +125,7 @@ mod tests {
     use crate::{StoreOrIgnore, with_connection};
 
     #[xmtp_common::test(unwrap_try = true)]
-    async fn test_add_pending_remove() {
+    fn test_add_pending_remove() {
         with_connection(|conn| {
             // Break the chain by unsetting the originator.
             PendingRemove {
@@ -139,11 +139,10 @@ mod tests {
             let users = conn.get_pending_remove_users(&[1]).unwrap();
             assert_eq!(users.len(), 0);
         })
-        .await
     }
 
     #[xmtp_common::test(unwrap_try = true)]
-    async fn test_delete_pending_remove_user() {
+    fn test_delete_pending_remove_user() {
         with_connection(|conn| {
             // Break the chain by unsetting the originator.
             PendingRemove {
@@ -177,6 +176,5 @@ mod tests {
                 .unwrap();
             assert_eq!(deleted_users, 0usize);
         })
-        .await
     }
 }

--- a/xmtp_db/src/encrypted_store/processed_device_sync_messages.rs
+++ b/xmtp_db/src/encrypted_store/processed_device_sync_messages.rs
@@ -71,7 +71,7 @@ mod tests {
     };
 
     #[xmtp_common::test(unwrap_try = true)]
-    async fn it_marks_as_processed() {
+    fn it_marks_as_processed() {
         with_connection(|conn| {
             let mut group = generate_group(None);
             group.conversation_type = ConversationType::Sync;
@@ -97,6 +97,5 @@ mod tests {
             let unprocessed = conn.unprocessed_sync_group_messages()?;
             assert_eq!(unprocessed.len(), 1);
         })
-        .await;
     }
 }

--- a/xmtp_db/src/encrypted_store/readd_status.rs
+++ b/xmtp_db/src/encrypted_store/readd_status.rs
@@ -301,7 +301,7 @@ mod tests {
     use crate::{Store, test_utils::with_connection};
 
     #[xmtp_common::test]
-    async fn test_get_readd_status_not_found() {
+    fn test_get_readd_status_not_found() {
         with_connection(|conn| {
             let group_id = vec![1, 2, 3];
             let installation_id = vec![4, 5, 6];
@@ -309,11 +309,10 @@ mod tests {
             let result = conn.get_readd_status(&group_id, &installation_id).unwrap();
             assert!(result.is_none());
         })
-        .await;
     }
 
     #[xmtp_common::test]
-    async fn test_store_and_get_readd_status() {
+    fn test_store_and_get_readd_status() {
         with_connection(|conn| {
             let group_id = vec![1, 2, 3];
             let installation_id = vec![4, 5, 6];
@@ -335,11 +334,10 @@ mod tests {
             assert_eq!(retrieved_status.requested_at_sequence_id, Some(100));
             assert_eq!(retrieved_status.responded_at_sequence_id, Some(50));
         })
-        .await;
     }
 
     #[xmtp_common::test]
-    async fn test_update_requested_at_sequence_id_creates_new() {
+    fn test_update_requested_at_sequence_id_creates_new() {
         with_connection(|conn| {
             let group_id = vec![1, 2, 3];
             let installation_id = vec![4, 5, 6];
@@ -356,11 +354,10 @@ mod tests {
             assert_eq!(status.requested_at_sequence_id, Some(sequence_id));
             assert_eq!(status.responded_at_sequence_id, None);
         })
-        .await;
     }
 
     #[xmtp_common::test]
-    async fn test_update_requested_at_sequence_id_updates_existing() {
+    fn test_update_requested_at_sequence_id_updates_existing() {
         with_connection(|conn| {
             let group_id = vec![1, 2, 3];
             let installation_id = vec![4, 5, 6];
@@ -385,11 +382,10 @@ mod tests {
             assert_eq!(status.requested_at_sequence_id, Some(100));
             assert_eq!(status.responded_at_sequence_id, Some(25)); // This is preserved by the UPDATE
         })
-        .await;
     }
 
     #[xmtp_common::test]
-    async fn test_update_requested_at_sequence_id_only_updates_if_higher() {
+    fn test_update_requested_at_sequence_id_only_updates_if_higher() {
         with_connection(|conn| {
             let group_id = vec![1, 2, 3];
             let installation_id = vec![4, 5, 6];
@@ -414,11 +410,10 @@ mod tests {
             assert_eq!(status.requested_at_sequence_id, Some(100)); // Should remain unchanged
             assert_eq!(status.responded_at_sequence_id, Some(50)); // Should remain unchanged
         })
-        .await;
     }
 
     #[xmtp_common::test]
-    async fn test_update_requested_at_sequence_id_updates_from_null() {
+    fn test_update_requested_at_sequence_id_updates_from_null() {
         with_connection(|conn| {
             let group_id = vec![1, 2, 3];
             let installation_id = vec![4, 5, 6];
@@ -443,7 +438,6 @@ mod tests {
             assert_eq!(status.requested_at_sequence_id, Some(50));
             assert_eq!(status.responded_at_sequence_id, Some(25)); // This is preserved by the UPDATE
         })
-        .await;
     }
 
     #[xmtp_common::test]
@@ -464,11 +458,10 @@ mod tests {
             assert_eq!(status.responded_at_sequence_id, Some(sequence_id));
             assert_eq!(status.requested_at_sequence_id, None);
         })
-        .await;
     }
 
     #[xmtp_common::test]
-    async fn test_update_responded_at_sequence_id_only_updates_if_higher() {
+    fn test_update_responded_at_sequence_id_only_updates_if_higher() {
         with_connection(|conn| {
             let group_id = vec![1, 2, 3];
             let installation_id = vec![4, 5, 6];
@@ -504,11 +497,10 @@ mod tests {
             assert_eq!(status.responded_at_sequence_id, Some(125)); // Should be updated
             assert_eq!(status.requested_at_sequence_id, Some(50)); // Should remain unchanged
         })
-        .await;
     }
 
     #[xmtp_common::test]
-    async fn test_is_awaiting_readd_no_status() {
+    fn test_is_awaiting_readd_no_status() {
         with_connection(|conn| {
             let group_id = vec![1, 2, 3];
             let installation_id = vec![4, 5, 6];
@@ -517,11 +509,10 @@ mod tests {
             let result = conn.is_awaiting_readd(&group_id, &installation_id).unwrap();
             assert!(!result);
         })
-        .await;
     }
 
     #[xmtp_common::test]
-    async fn test_is_awaiting_readd_no_request() {
+    fn test_is_awaiting_readd_no_request() {
         with_connection(|conn| {
             let group_id = vec![1, 2, 3];
             let installation_id = vec![4, 5, 6];
@@ -540,11 +531,10 @@ mod tests {
             let result = conn.is_awaiting_readd(&group_id, &installation_id).unwrap();
             assert!(!result);
         })
-        .await;
     }
 
     #[xmtp_common::test]
-    async fn test_is_awaiting_readd_request_pending() {
+    fn test_is_awaiting_readd_request_pending() {
         with_connection(|conn| {
             let group_id = vec![1, 2, 3];
             let installation_id = vec![4, 5, 6];
@@ -563,11 +553,10 @@ mod tests {
             let result = conn.is_awaiting_readd(&group_id, &installation_id).unwrap();
             assert!(result);
         })
-        .await;
     }
 
     #[xmtp_common::test]
-    async fn test_is_awaiting_readd_request_fulfilled() {
+    fn test_is_awaiting_readd_request_fulfilled() {
         with_connection(|conn| {
             let group_id = vec![1, 2, 3];
             let installation_id = vec![4, 5, 6];
@@ -586,11 +575,10 @@ mod tests {
             let result = conn.is_awaiting_readd(&group_id, &installation_id).unwrap();
             assert!(!result);
         })
-        .await;
     }
 
     #[xmtp_common::test]
-    async fn test_is_awaiting_readd_equal_sequence_ids() {
+    fn test_is_awaiting_readd_equal_sequence_ids() {
         with_connection(|conn| {
             let group_id = vec![1, 2, 3];
             let installation_id = vec![4, 5, 6];
@@ -611,11 +599,10 @@ mod tests {
             let result = conn.is_awaiting_readd(&group_id, &installation_id).unwrap();
             assert!(result);
         })
-        .await;
     }
 
     #[xmtp_common::test]
-    async fn test_is_awaiting_readd_no_responded_at() {
+    fn test_is_awaiting_readd_no_responded_at() {
         with_connection(|conn| {
             let group_id = vec![1, 2, 3];
             let installation_id = vec![4, 5, 6];
@@ -634,11 +621,10 @@ mod tests {
             let result = conn.is_awaiting_readd(&group_id, &installation_id).unwrap();
             assert!(result);
         })
-        .await;
     }
 
     #[xmtp_common::test]
-    async fn test_delete_other_readd_statuses() {
+    fn test_delete_other_readd_statuses() {
         with_connection(|conn| {
             let group_id = vec![1, 2, 3];
             let keep_installation_id = vec![10, 11, 12];
@@ -704,11 +690,10 @@ mod tests {
             let different_group_check = conn.get_readd_status(&[4, 5, 6], &[40, 41, 42]).unwrap();
             assert!(different_group_check.is_some());
         })
-        .await;
     }
 
     #[xmtp_common::test]
-    async fn test_get_readds_awaiting_response() {
+    fn test_get_readds_awaiting_response() {
         with_connection(|conn| {
             let group_id = vec![1, 2, 3];
             let self_installation_id = vec![10, 11, 12];
@@ -797,6 +782,5 @@ mod tests {
                 assert!(requested_at >= responded_at);
             }
         })
-        .await;
     }
 }

--- a/xmtp_db/src/encrypted_store/refresh_state.rs
+++ b/xmtp_db/src/encrypted_store/refresh_state.rs
@@ -780,7 +780,7 @@ pub(crate) mod tests {
     use rstest::rstest;
 
     #[xmtp_common::test]
-    async fn get_cursor_with_no_existing_state() {
+    fn get_cursor_with_no_existing_state() {
         with_connection(|conn| {
             let id = vec![1, 2, 3];
             let kind = EntityKind::ApplicationMessage;
@@ -801,11 +801,10 @@ pub(crate) mod tests {
                 .unwrap();
             assert!(entry.is_some());
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn get_cursor_with_no_existing_state_originator() {
+    fn get_cursor_with_no_existing_state_originator() {
         with_connection(|conn| {
             let id = vec![1, 2, 3];
             let kind = EntityKind::ApplicationMessage;
@@ -826,11 +825,10 @@ pub(crate) mod tests {
                 .unwrap();
             assert!(entry.is_some());
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn get_timestamp_with_existing_state() {
+    fn get_timestamp_with_existing_state() {
         with_connection(|conn| {
             let id = vec![1, 2, 3];
             let entity_kind = EntityKind::Welcome;
@@ -850,11 +848,10 @@ pub(crate) mod tests {
                 }
             );
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn update_timestamp_when_bigger() {
+    fn update_timestamp_when_bigger() {
         with_connection(|conn| {
             let id = vec![1, 2, 3];
             let entity_kind = EntityKind::ApplicationMessage;
@@ -878,11 +875,10 @@ pub(crate) mod tests {
                 .unwrap();
             assert_eq!(entry.unwrap().sequence_id, 124);
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn dont_update_timestamp_when_smaller() {
+    fn dont_update_timestamp_when_smaller() {
         with_connection(|conn| {
             let entity_id = vec![1, 2, 3];
             let entity_kind = EntityKind::Welcome;
@@ -908,11 +904,10 @@ pub(crate) mod tests {
                 .unwrap();
             assert_eq!(entry.unwrap().sequence_id, 123);
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn allow_installation_and_welcome_same_id() {
+    fn allow_installation_and_welcome_same_id() {
         with_connection(|conn| {
             let entity_id = vec![1, 2, 3];
             let welcome_state = RefreshState {
@@ -947,7 +942,6 @@ pub(crate) mod tests {
                 .unwrap();
             assert_eq!(group_state_retrieved.sequence_id, 456);
         })
-        .await
     }
 
     // Helper function to create and store a RefreshState
@@ -1041,7 +1035,6 @@ pub(crate) mod tests {
                 assert!(state.is_some(), "Originator {} should be persisted", orig);
             }
         })
-        .await
     }
 
     #[rstest]
@@ -1121,7 +1114,6 @@ pub(crate) mod tests {
                 );
             }
         })
-        .await
     }
 
     #[rstest]
@@ -1213,11 +1205,10 @@ pub(crate) mod tests {
                 );
             }
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn lowest_common_cursor_empty_topics() {
+    fn lowest_common_cursor_empty_topics() {
         with_connection(|conn| {
             create_state(conn, &[1, 2, 3], EntityKind::ApplicationMessage, 0, 100);
             create_identity_update(conn, 1, 100);
@@ -1232,11 +1223,10 @@ pub(crate) mod tests {
                 }
             }
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn lowest_common_cursor_no_matching_states() {
+    fn lowest_common_cursor_no_matching_states() {
         with_connection(|conn| {
             let topics = [
                 TopicKind::GroupMessagesV1.create(vec![99, 99, 99]),
@@ -1249,18 +1239,16 @@ pub(crate) mod tests {
             let cursor = conn.lowest_common_cursor(&topic_refs).unwrap();
             assert_eq!(cursor.len(), 0);
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn get_last_cursor_for_ids_empty() {
+    fn get_last_cursor_for_ids_empty() {
         with_connection(|conn| {
             let ids: Vec<Vec<u8>> = vec![];
             let entities = vec![EntityKind::ApplicationMessage];
             let result = conn.get_last_cursor_for_ids(&ids, &entities).unwrap();
             assert!(result.is_empty());
         })
-        .await
     }
 
     #[xmtp_common::test]
@@ -1281,11 +1269,10 @@ pub(crate) mod tests {
             let cursor = result.get(&id).expect("Should have cursor for id");
             assert_eq!(cursor.get(&10), 456);
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn get_last_cursor_for_ids_multiple_mixed() {
+    fn get_last_cursor_for_ids_multiple_mixed() {
         with_connection(|conn| {
             let entity_kind = EntityKind::ApplicationMessage;
 
@@ -1311,11 +1298,10 @@ pub(crate) mod tests {
             assert_eq!(result.get(&id3).unwrap().get(&10), 300);
             assert!(!result.contains_key(&id4));
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn get_last_cursor_for_ids_exactly_900() {
+    fn get_last_cursor_for_ids_exactly_900() {
         with_connection(|conn| {
             let entity_kind = EntityKind::ApplicationMessage;
 
@@ -1336,11 +1322,10 @@ pub(crate) mod tests {
                 assert_eq!(result.get(id).unwrap().get(&10), idx as u64);
             }
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn get_last_cursor_for_ids_over_900() {
+    fn get_last_cursor_for_ids_over_900() {
         with_connection(|conn| {
             let entity_kind = EntityKind::ApplicationMessage;
 
@@ -1366,11 +1351,10 @@ pub(crate) mod tests {
                 );
             }
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn get_last_cursor_for_ids_over_1800() {
+    fn get_last_cursor_for_ids_over_1800() {
         with_connection(|conn| {
             let entity_kind = EntityKind::ApplicationMessage;
 
@@ -1396,11 +1380,10 @@ pub(crate) mod tests {
                 );
             }
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn get_last_cursor_for_ids_different_entity_kinds() {
+    fn get_last_cursor_for_ids_different_entity_kinds() {
         with_connection(|conn| {
             let id1 = vec![1, 2, 3];
             let id2 = vec![4, 5, 6];
@@ -1429,6 +1412,5 @@ pub(crate) mod tests {
             assert_eq!(result.get(&id1).unwrap().get(&10), 200);
             assert!(!result.contains_key(&id2));
         })
-        .await
     }
 }

--- a/xmtp_db/src/encrypted_store/tasks.rs
+++ b/xmtp_db/src/encrypted_store/tasks.rs
@@ -200,32 +200,29 @@ pub(crate) mod tests {
     use crate::test_utils::with_connection;
 
     #[xmtp_common::test]
-    async fn get_tasks_returns_empty_list_initially() {
+    fn get_tasks_returns_empty_list_initially() {
         with_connection(|conn| {
             let tasks = conn.get_tasks().unwrap();
             assert!(tasks.is_empty());
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn update_task_returns_error_when_not_found() {
+    fn update_task_returns_error_when_not_found() {
         with_connection(|conn| {
             // Try to update a task that doesn't exist
             let result = conn.update_task(999, 5, 1000, 2000);
             // The update should fail when the task doesn't exist
             assert!(result.is_err());
         })
-        .await
     }
 
     #[xmtp_common::test]
-    async fn delete_task_returns_false_when_not_found() {
+    fn delete_task_returns_false_when_not_found() {
         with_connection(|conn| {
             let deleted = conn.delete_task(999).unwrap();
             assert!(!deleted);
         })
-        .await
     }
 
     // Generate a random task data for testing to ensure that the hashes are unique
@@ -248,7 +245,7 @@ pub(crate) mod tests {
     }
 
     #[xmtp_common::test]
-    async fn all_task_operations_work_together() {
+    fn all_task_operations_work_together() {
         with_connection(|conn| {
             let now = xmtp_common::time::now_ns();
 
@@ -378,6 +375,5 @@ pub(crate) mod tests {
             let deleted_again = conn.delete_task(task1_id).unwrap();
             assert!(!deleted_again);
         })
-        .await
     }
 }

--- a/xmtp_db/src/encrypted_store/user_preferences.rs
+++ b/xmtp_db/src/encrypted_store/user_preferences.rs
@@ -99,7 +99,7 @@ mod tests {
     use super::*;
 
     #[xmtp_common::test]
-    async fn test_insert_and_update_preferences() {
+    fn test_insert_and_update_preferences() {
         crate::test_utils::with_connection(|conn| {
             let pref = StoredUserPreferences::load(conn).unwrap();
             // by default, there is no key
@@ -124,6 +124,5 @@ mod tests {
                 .unwrap();
             assert_eq!(result.len(), 1);
         })
-        .await;
     }
 }


### PR DESCRIPTION
this is mostly a QoL pr since i noticed the wasm ephemeral db builds completely synchronously. this makes using some test utils more flexible, like making it possible to use proptest for db queries (not used yet)