### PR TITLE
Tag correct commit when generating swift bindings

### DIFF
--- a/.github/workflows/release-swift-bindings.yml
+++ b/.github/workflows/release-swift-bindings.yml
@@ -156,6 +156,7 @@ jobs:
         with:
           name: Swift-Bindings-${{ steps.version.outputs.value }}.${{ steps.slug.outputs.sha7 }}
           tag_name: swift-bindings-${{ steps.version.outputs.value }}.${{ steps.slug.outputs.sha7 }}
+          target_commitish: ${{ github.sha }}
           files: |
             LibXMTPSwiftFFI*.zip
             LibXMTPSwiftFFI*.sha256


### PR DESCRIPTION
Recent updates to swift release caused us to create tags that were pointing to the wrong git commit. 

This did not affect downstream SDKs since tagged releases had uploaded artifacts from the correct commit hash, but tags being on the wrong commit should be fixed before next stable release to avoid confusion. 