### PR TITLE
Never log messages

### DIFF
--- a/bindings_ffi/src/mls/tests/content_types.rs
+++ b/bindings_ffi/src/mls/tests/content_types.rs
@@ -298,8 +298,13 @@ async fn test_long_messages() {
         .await
         .unwrap();
 
-    let data = xmtp_common::rand_vec::<100000>();
-    dm.send(data.clone(), FfiSendMessageOpts::default())
+    let mut data = String::new();
+    let mut i = 0;
+    while data.len() < 100_000 {
+        data.push_str(&format!("{i:4}: This is a test message that is really long for testing purposes and should be truncated if ever logged in tests\n"));
+        i += 1;
+    }
+    dm.send(data.as_bytes().to_vec(), FfiSendMessageOpts::default())
         .await
         .unwrap();
 
@@ -314,7 +319,7 @@ async fn test_long_messages() {
         .find_messages(FfiListMessagesOptions::default())
         .await
         .unwrap();
-    assert!(bo_msgs.iter().any(|msg| msg.content.eq(&data)));
+    assert!(bo_msgs.iter().any(|msg| msg.content.eq(data.as_bytes())));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/xmtp_mls/src/groups/mod.rs
+++ b/xmtp_mls/src/groups/mod.rs
@@ -594,10 +594,10 @@ where
     }
 
     /// Send a message on this users XMTP [`Client`](crate::client::Client).
-    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", skip(self), fields(who = self.context.inbox_id(), message = %String::from_utf8_lossy(message))))]
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", skip_all, fields(who = self.context.inbox_id(), message = %String::from_utf8_lossy(&message[..message.len().min(100)]))))]
     #[cfg_attr(
         not(any(test, feature = "test-utils")),
-        tracing::instrument(level = "trace", skip(self))
+        tracing::instrument(level = "trace", skip_all)
     )]
     pub async fn send_message(
         &self,


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Limit logging and make long message test deterministic by truncating `xmtp_mls::groups::Group::send_message` logs to 100 bytes and switching `bindings_ffi/src/mls/tests/content_types.rs` to a repeated-string payload
Update `xmtp_mls::groups::Group::send_message` tracing to `skip_all` and, in test builds, log only the first 100 bytes via `from_utf8_lossy`. Make the long message test use a deterministic repeated `String` and assert against `data.as_bytes()`.

#### 📍Where to Start
Start with the tracing changes on `send_message` in [xmtp_mls/src/groups/mod.rs](https://github.com/xmtp/libxmtp/pull/2851/files#diff-c29f56a38916c7410eff8091df1a2e43487ffe20646d96827e846e475f4608d3), then review the test update in [bindings_ffi/src/mls/tests/content_types.rs](https://github.com/xmtp/libxmtp/pull/2851/files#diff-40021fb6f383ce8d7372ae4bb8e7274f74e7fc144925a68d2b91988f002ba582).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 045e8a2.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->