### PR TITLE
fix webassembly test `bindings_wasm` decodeText clash

### DIFF
--- a/bindings_wasm/src/content_types/text.rs
+++ b/bindings_wasm/src/content_types/text.rs
@@ -19,7 +19,7 @@ impl From<xmtp_mls::messages::decoded_message::Text> for TextContent {
   }
 }
 
-#[wasm_bindgen(js_name = "encodeText")]
+#[wasm_bindgen(js_name = "encodeXmtpText")]
 pub fn encode_text(text: String) -> Result<Uint8Array, JsError> {
   // Use TextCodec to encode the text
   let encoded = TextCodec::encode(text).map_err(|e| JsError::new(&format!("{}", e)))?;
@@ -33,7 +33,10 @@ pub fn encode_text(text: String) -> Result<Uint8Array, JsError> {
   Ok(Uint8Array::from(buf.as_slice()))
 }
 
-#[wasm_bindgen(js_name = "decodeText")]
+// `decode` conflicts with some wasm function in bindgen/tests/somewhere
+// breaking `bindings_wasm` tests
+// PR: https://github.com/xmtp/libxmtp/pull/2863
+#[wasm_bindgen(js_name = "decodeXmtpText")]
 pub fn decode_text(bytes: Uint8Array) -> Result<String, JsError> {
   // Decode bytes into EncodedContent
   let encoded_content = EncodedContent::decode(bytes.to_vec().as_slice())


### PR DESCRIPTION
bindings_wasm `decodeText` clashes with another declared function. I'm not sure if it was a function declared in bindgen or just the test runner, but changing `decodeText` to `decodeXmtpText` fixed it. In our code, i only found a single `decodeText`. I changed `encodeText` to `encodeXmtpText` for consistency

Error message ci/local tests failing with:

```
Uncaught SyntaxError: redeclaration of function decodeText
```

it looks like some internal bindgen/js glue code, here is the function its conflicting with for historical purposes (from the sourcemap in console).
mostly i'm surprised these functions are not prefixed with `__` to avoid clashes like this
```js
function getUint8ArrayMemory0() {
    if (cachedUint8ArrayMemory0 === null || cachedUint8ArrayMemory0.byteLength === 0) {
        cachedUint8ArrayMemory0 = new Uint8Array(wasm.memory.buffer);
    }
    return cachedUint8ArrayMemory0;
}

let cachedTextDecoder = new TextDecoder('utf-8', { ignoreBOM: true, fatal: true });

cachedTextDecoder.decode();

const MAX_SAFARI_DECODE_BYTES = 2146435072;
let numBytesDecoded = 0;
function decodeText(ptr, len) {
    numBytesDecoded += len;
    if (numBytesDecoded >= MAX_SAFARI_DECODE_BYTES) {
        cachedTextDecoder = new TextDecoder('utf-8', { ignoreBOM: true, fatal: true });
        cachedTextDecoder.decode();
        numBytesDecoded = len;
    }
    return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
}

function getStringFromWasm0(ptr, len) {
    ptr = ptr >>> 0;
    return decodeText(ptr, len);
}

```