### PR TITLE
add child resolution & ice to `CursorStore` trait

### DIFF
--- a/xmtp_api_d14n/src/protocol/traits/sort.rs
+++ b/xmtp_api_d14n/src/protocol/traits/sort.rs
@@ -1,7 +1,4 @@
-use xmtp_proto::{
-    api::VectorClock,
-    types::{GlobalCursor, TopicCursor},
-};
+use xmtp_proto::types::{GlobalCursor, TopicCursor};
 
 use crate::protocol::{Envelope, EnvelopeError};
 

--- a/xmtp_api_d14n/src/protocol/utils/test/props.rs
+++ b/xmtp_api_d14n/src/protocol/utils/test/props.rs
@@ -2,10 +2,7 @@ use super::TestEnvelope;
 use itertools::Itertools;
 use proptest::prelude::*;
 use proptest::sample::subsequence;
-use xmtp_proto::{
-    api::VectorClock,
-    types::{Cursor, GlobalCursor, OriginatorId, SequenceId},
-};
+use xmtp_proto::types::{Cursor, GlobalCursor, OriginatorId, SequenceId};
 
 // Advance the clock for a given originator
 fn advance_clock(base: &GlobalCursor, originator: &OriginatorId) -> SequenceId {

--- a/xmtp_api_d14n/src/queries/d14n/test/send_group_message.rs
+++ b/xmtp_api_d14n/src/queries/d14n/test/send_group_message.rs
@@ -139,4 +139,18 @@ impl CursorStore for TestCursorStore {
     ) -> Result<HashMap<Vec<u8>, Cursor>, CursorStoreError> {
         Ok(self.dependencies.clone())
     }
+
+    fn ice(
+        &self,
+        _orphans: Vec<xmtp_proto::types::OrphanedEnvelope>,
+    ) -> Result<(), CursorStoreError> {
+        unreachable!()
+    }
+
+    fn resolve_children(
+        &self,
+        _cursors: &[Cursor],
+    ) -> Result<Vec<xmtp_proto::types::OrphanedEnvelope>, CursorStoreError> {
+        unreachable!()
+    }
 }

--- a/xmtp_mls/src/cursor_store.rs
+++ b/xmtp_mls/src/cursor_store.rs
@@ -5,6 +5,7 @@ use xmtp_common::{MaybeSend, MaybeSync};
 use xmtp_configuration::Originators;
 use xmtp_db::{
     group_intent::IntentDependency,
+    icebox::QueryIcebox,
     identity_update::QueryIdentityUpdates,
     prelude::{QueryGroupIntent, QueryRefreshState},
     refresh_state::EntityKind,
@@ -24,7 +25,12 @@ impl<Db> SqliteCursorStore<Db> {
 
 impl<Db> CursorStore for SqliteCursorStore<Db>
 where
-    Db: QueryRefreshState + QueryIdentityUpdates + QueryGroupIntent + MaybeSend + MaybeSync,
+    Db: QueryRefreshState
+        + QueryIdentityUpdates
+        + QueryGroupIntent
+        + QueryIcebox
+        + MaybeSend
+        + MaybeSync,
 {
     fn lowest_common_cursor(&self, topics: &[&Topic]) -> Result<GlobalCursor, CursorStoreError> {
         self.db
@@ -60,9 +66,9 @@ where
                     .db
                     .get_latest_sequence_id_for_inbox(&hex::encode(topic.identifier()))
                     .map_err(CursorStoreError::other)?;
-                let mut map = HashMap::new();
+                let mut map = GlobalCursor::default();
                 map.insert(Originators::INBOX_LOG, sid as u64);
-                Ok(GlobalCursor::new(map))
+                Ok(map)
             }
             TopicKind::KeyPackagesV1 => Ok(GlobalCursor::default()),
             _ => Err(CursorStoreError::UnhandledTopicKind(topic.kind())),
@@ -92,9 +98,9 @@ where
                     .db
                     .get_latest_sequence_id_for_inbox(&hex::encode(topic.identifier()))
                     .map_err(CursorStoreError::other)?;
-                let mut map = HashMap::new();
+                let mut map = GlobalCursor::default();
                 map.insert(Originators::INBOX_LOG, sid as u64);
-                Ok(GlobalCursor::new(map))
+                Ok(map)
             }
             TopicKind::KeyPackagesV1 => Ok(GlobalCursor::default()),
             _ => Err(CursorStoreError::UnhandledTopicKind(topic.kind())),
@@ -153,9 +159,9 @@ where
                             .db
                             .get_latest_sequence_id_for_inbox(&hex::encode(topic.identifier()))
                             .map_err(CursorStoreError::other)?;
-                        let mut map = HashMap::new();
+                        let mut map = GlobalCursor::default();
                         map.insert(Originators::INBOX_LOG, sid as u64);
-                        Ok((topic.clone(), GlobalCursor::new(map)))
+                        Ok((topic.clone(), map))
                     })
                     .collect(),
                 TopicKind::KeyPackagesV1 => Ok(topics_of_kind
@@ -184,5 +190,22 @@ where
             .into_iter()
             .map(|(h, d)| (h, d.cursor))
             .collect())
+    }
+
+    fn ice(
+        &self,
+        orphans: Vec<xmtp_proto::types::OrphanedEnvelope>,
+    ) -> Result<(), CursorStoreError> {
+        self.db.ice(orphans).map_err(CursorStoreError::other)?;
+        Ok(())
+    }
+
+    fn resolve_children(
+        &self,
+        cursors: &[Cursor],
+    ) -> Result<Vec<xmtp_proto::types::OrphanedEnvelope>, CursorStoreError> {
+        self.db
+            .future_dependents(cursors)
+            .map_err(CursorStoreError::other)
     }
 }

--- a/xmtp_mls/src/groups/welcome_sync.rs
+++ b/xmtp_mls/src/groups/welcome_sync.rs
@@ -729,9 +729,9 @@ mod tests {
 
     // Helper functions for filter_groups_with_new_messages tests
     fn make_cursor(originator_id: u32, sequence_id: u64) -> GlobalCursor {
-        let mut map = HashMap::new();
+        let mut map = GlobalCursor::default();
         map.insert(originator_id, sequence_id);
-        GlobalCursor::new(map)
+        map
     }
 
     fn make_message_metadata(
@@ -807,10 +807,10 @@ mod tests {
         let orig_2 = 200;
 
         let mut last_synced = HashMap::new();
-        let mut cursor_map = HashMap::new();
+        let mut cursor_map = GlobalCursor::default();
         cursor_map.insert(orig_1, 10);
         cursor_map.insert(orig_2, 20);
-        last_synced.insert(group_id.clone(), GlobalCursor::new(cursor_map));
+        last_synced.insert(group_id.clone(), cursor_map);
 
         let mut latest = HashMap::new();
         latest.insert(

--- a/xmtp_mls/src/subscriptions/stream_messages/types.rs
+++ b/xmtp_mls/src/subscriptions/stream_messages/types.rs
@@ -1,9 +1,6 @@
 use std::collections::HashSet;
 
-use xmtp_proto::{
-    api::VectorClock,
-    types::{Cursor, GlobalCursor, Topic, TopicCursor},
-};
+use xmtp_proto::types::{Cursor, GlobalCursor, Topic, TopicCursor};
 
 #[derive(thiserror::Error, Debug)]
 pub enum MessageStreamError {

--- a/xmtp_proto/src/types/global_cursor.rs
+++ b/xmtp_proto/src/types/global_cursor.rs
@@ -9,22 +9,23 @@ use crate::{
 use core::fmt;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     fmt::Write,
     ops::{Deref, DerefMut},
 };
 use xmtp_configuration::Originators;
 
-/// a cursor which represents the position across many nodes in the network
+/// a cursor backed by a [`BTreeMap`].
+/// represents the position across many nodes in the network
 /// a.k.a vector clock
-#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Default, Debug, Clone, Hash, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GlobalCursor {
-    inner: HashMap<OriginatorId, SequenceId>,
+    inner: BTreeMap<OriginatorId, SequenceId>,
 }
 
 impl GlobalCursor {
-    /// Construct a new cursor from a HashMap
-    pub fn new(map: HashMap<OriginatorId, SequenceId>) -> Self {
+    /// Construct a new cursor from a BTreeMap
+    pub fn new(map: BTreeMap<OriginatorId, SequenceId>) -> Self {
         Self { inner: map }
     }
 
@@ -32,6 +33,22 @@ impl GlobalCursor {
     pub fn has_seen(&self, other: &super::Cursor) -> bool {
         let sid = self.get(&other.originator_id);
         sid >= other.sequence_id
+    }
+
+    /// creates a from a [`HashMap`], internally converting to a [`BTreeMap`]
+    pub fn with_hashmap(map: HashMap<OriginatorId, SequenceId>) -> Self {
+        Self {
+            inner: BTreeMap::from_iter(map),
+        }
+    }
+
+    /// Apply a singular cursor to 'Self'
+    pub fn apply(&mut self, cursor: &super::Cursor) {
+        let _ = self
+            .inner
+            .entry(cursor.originator_id)
+            .and_modify(|sid| *sid = (*sid).max(cursor.sequence_id))
+            .or_insert(cursor.sequence_id);
     }
 
     /// apply a cursor to `Self`, and take the lowest value of SequenceId between
@@ -118,14 +135,14 @@ impl fmt::Display for GlobalCursor {
 
 impl FromIterator<(OriginatorId, SequenceId)> for GlobalCursor {
     fn from_iter<T: IntoIterator<Item = (OriginatorId, SequenceId)>>(iter: T) -> Self {
-        GlobalCursor::new(HashMap::from_iter(iter))
+        GlobalCursor::new(BTreeMap::from_iter(iter))
     }
 }
 
 impl From<Cursor> for GlobalCursor {
     fn from(value: Cursor) -> Self {
         GlobalCursor {
-            inner: value.node_id_to_sequence_id,
+            inner: BTreeMap::from_iter(value.node_id_to_sequence_id),
         }
     }
 }
@@ -133,7 +150,7 @@ impl From<Cursor> for GlobalCursor {
 impl From<GlobalCursor> for Cursor {
     fn from(value: GlobalCursor) -> Self {
         Cursor {
-            node_id_to_sequence_id: value.inner,
+            node_id_to_sequence_id: HashMap::from_iter(value.inner),
         }
     }
 }
@@ -176,21 +193,21 @@ impl TryFrom<Cursor> for crate::types::Cursor {
 
 impl From<crate::types::Cursor> for GlobalCursor {
     fn from(value: crate::types::Cursor) -> Self {
-        let mut map = HashMap::new();
+        let mut map = BTreeMap::new();
         map.insert(value.originator_id, value.sequence_id);
         GlobalCursor { inner: map }
     }
 }
 
-impl From<HashMap<OriginatorId, SequenceId>> for GlobalCursor {
-    fn from(value: HashMap<OriginatorId, SequenceId>) -> Self {
+impl From<BTreeMap<OriginatorId, SequenceId>> for GlobalCursor {
+    fn from(value: BTreeMap<OriginatorId, SequenceId>) -> Self {
         GlobalCursor { inner: value }
     }
 }
 
 impl IntoIterator for GlobalCursor {
     type Item = (OriginatorId, SequenceId);
-    type IntoIter = <HashMap<OriginatorId, SequenceId> as IntoIterator>::IntoIter;
+    type IntoIter = <BTreeMap<OriginatorId, SequenceId> as IntoIterator>::IntoIter;
 
     fn into_iter(self) -> Self::IntoIter {
         self.inner.into_iter()
@@ -199,7 +216,7 @@ impl IntoIterator for GlobalCursor {
 
 impl<'a> IntoIterator for &'a GlobalCursor {
     type Item = (&'a OriginatorId, &'a SequenceId);
-    type IntoIter = std::collections::hash_map::Iter<'a, OriginatorId, SequenceId>;
+    type IntoIter = std::collections::btree_map::Iter<'a, OriginatorId, SequenceId>;
     fn into_iter(self) -> Self::IntoIter {
         self.inner.iter()
     }
@@ -207,7 +224,7 @@ impl<'a> IntoIterator for &'a GlobalCursor {
 
 impl<'a> IntoIterator for &'a mut GlobalCursor {
     type Item = (&'a OriginatorId, &'a mut SequenceId);
-    type IntoIter = std::collections::hash_map::IterMut<'a, OriginatorId, SequenceId>;
+    type IntoIter = std::collections::btree_map::IterMut<'a, OriginatorId, SequenceId>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.inner.iter_mut()
@@ -215,7 +232,7 @@ impl<'a> IntoIterator for &'a mut GlobalCursor {
 }
 
 impl Deref for GlobalCursor {
-    type Target = HashMap<OriginatorId, SequenceId>;
+    type Target = BTreeMap<OriginatorId, SequenceId>;
 
     fn deref(&self) -> &Self::Target {
         &self.inner
@@ -234,6 +251,12 @@ impl<C: Into<super::Cursor>> Extend<C> for GlobalCursor {
             let c: super::Cursor = c.into();
             (c.originator_id, c.sequence_id)
         }))
+    }
+}
+
+impl From<HashMap<OriginatorId, SequenceId>> for GlobalCursor {
+    fn from(value: HashMap<OriginatorId, SequenceId>) -> Self {
+        GlobalCursor::with_hashmap(value)
     }
 }
 

--- a/xmtp_proto/src/types/orphaned_envelope.rs
+++ b/xmtp_proto/src/types/orphaned_envelope.rs
@@ -5,7 +5,7 @@ use crate::types::{Cursor, GlobalCursor, GroupId};
 use bytes::Bytes;
 
 /// An envelope whose parent dependencies have not yet been seen
-#[derive(Builder, Clone, Debug)]
+#[derive(Builder, Clone, Debug, Hash, PartialEq, Eq)]
 #[builder(setter(into), build_fn(error = "ConversionError"))]
 pub struct OrphanedEnvelope {
     // the cursor of this envelope
@@ -27,5 +27,11 @@ impl OrphanedEnvelope {
     ///  turn this envelope back into its parts
     pub fn into_payload(self) -> Bytes {
         self.payload
+    }
+
+    /// check if we are dependant on [`Cursor`]
+    pub fn is_child_of(&self, cursor: &Cursor) -> bool {
+        self.depends_on.contains_key(&cursor.originator_id)
+            && self.depends_on.get(&cursor.originator_id) == cursor.sequence_id
     }
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add child resolution and ICE handling by extending `CursorStore` with `ice` and `resolve_children` across in-memory, SQL, and wrapper implementations
Extend `CursorStore` with `ice` and `resolve_children`, add an in-memory icebox in `InMemoryCursorStore`, delegate persistence/lookup in the SQLite store, and switch `GlobalCursor` to `BTreeMap` with merge via `apply`. Update callers to construct and return `GlobalCursor` directly.

#### 📍Where to Start
Start with the trait changes in [cursor_store.rs](https://github.com/xmtp/libxmtp/pull/2869/files#diff-028daad07b57a99602b70e297432f143b84633ff46fa3f2b9851f6b476260eae), then review the in-memory implementation in [in_memory_cursor_store.rs](https://github.com/xmtp/libxmtp/pull/2869/files#diff-81e05c4cbc4c5877da996a1302449b85dde8e85a96338b80953cbc520363c6c2) and the SQLite store in [cursor_store.rs](https://github.com/xmtp/libxmtp/pull/2869/files#diff-92939812065b708096075a08e83053a96bbb0d48d2a13d665eba3336c85740ca).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 0972aaf. 9 files reviewed, 6 issues evaluated, 6 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>xmtp_db/src/encrypted_store/refresh_state.rs — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 133](https://github.com/xmtp/libxmtp/blob/0972aaf951c6484cd66aee375a5c8819c1079685/xmtp_db/src/encrypted_store/refresh_state.rs#L133): rows_to_global_cursor_map performs unchecked signed-to-unsigned integer casts that can silently wrap negative database values, yielding incorrect OriginatorId and SequenceId. Specifically, `originator_id as u32` and `sequence_id.unwrap_or(0) as u64` will wrap if `originator_id` or `sequence_id` are negative, producing large unsigned values instead of rejecting invalid input. This can corrupt the resulting `GlobalCursor` (e.g., mapping to the wrong originator or an enormous sequence), leading to incorrect cursor computations downstream. Validate non-negativity before casting, or return an error on invalid rows. <b>[ Previously rejected ]</b>
- [line 706](https://github.com/xmtp/libxmtp/blob/0972aaf951c6484cd66aee375a5c8819c1079685/xmtp_db/src/encrypted_store/refresh_state.rs#L706): latest_cursor_combined may generate invalid SQL when `entities` contains no kinds that map to `group_messages` (i.e., neither `EntityKind::ApplicationMessage` nor `EntityKind::CommitMessage`). In that case `group_message_kinds` becomes an empty Vec, producing `kind IN ()` in the constructed SQL, which is a syntax error in SQLite. This is reachable if callers pass, e.g., only `EntityKind::Welcome`. Ensure you guard against an empty `group_message_kinds` (e.g., omit the `group_messages` branch or use a false predicate) before constructing the placeholders. <b>[ Out of scope ]</b>
</details>

<details>
<summary>xmtp_mls/src/cursor_store.rs — 0 comments posted, 4 evaluated, 4 filtered</summary>

- [line 70](https://github.com/xmtp/libxmtp/blob/0972aaf951c6484cd66aee375a5c8819c1079685/xmtp_mls/src/cursor_store.rs#L70): `sid` from the database is cast to `u64` with `as` without validating non-negativity. If `sid` is negative (e.g., due to DB corruption or unexpected input), it will wrap to a very large `u64`, corrupting the cursor and causing incorrect behavior (e.g., dominance/missing comparisons). Validate `sid >= 0` and return an error or clamp, or change the DB/API to return an unsigned type. <b>[ Previously rejected ]</b>
- [line 101](https://github.com/xmtp/libxmtp/blob/0972aaf951c6484cd66aee375a5c8819c1079685/xmtp_mls/src/cursor_store.rs#L101): `sid` is cast to `u64` without validating non-negativity in `latest_per_originator` for identity updates, which can wrap negatives to huge values and corrupt cursor semantics. Validate or use an unsigned type. <b>[ Previously rejected ]</b>
- [line 163](https://github.com/xmtp/libxmtp/blob/0972aaf951c6484cd66aee375a5c8819c1079685/xmtp_mls/src/cursor_store.rs#L163): Potential integer wrap: `sid` from `get_latest_sequence_id_for_inbox(...)` is cast with `as u64` without validation. If `sid` is negative, the cast will wrap to a very large `u64`, producing an incorrect `GlobalCursor` value and potentially causing downstream logic to skip messages. Validate that `sid >= 0` and either clamp, normalize, or return an error before inserting into the `GlobalCursor`. Affected line: `map.insert(Originators::INBOX_LOG, sid as u64);`. <b>[ Previously rejected ]</b>
- [line 163](https://github.com/xmtp/libxmtp/blob/0972aaf951c6484cd66aee375a5c8819c1079685/xmtp_mls/src/cursor_store.rs#L163): `sid` is cast to `u64` without validation in `latest_for_topics` for `IdentityUpdatesV1`, which can wrap negative SIDs and produce incorrect `GlobalCursor` values. Validate `sid` or return an error if negative. <b>[ Previously rejected ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->