### PR TITLE
Enable file logs from multiple processes

### DIFF
--- a/bindings_ffi/src/logger.rs
+++ b/bindings_ffi/src/logger.rs
@@ -290,9 +290,12 @@ fn enable_debug_file_inner(
     let commit_sha = option_env!("VERGEN_GIT_SHA").unwrap_or("unknown");
     let process_id = std::process::id();
     let process_suffix = process_type.to_str();
-    
+
     let file_appender = RollingFileAppender::builder()
-        .filename_prefix(format!("libxmtp-v{}.{}.{}.{}.log", version, commit_sha, process_suffix, process_id))
+        .filename_prefix(format!(
+            "libxmtp-v{}.{}.{}.{}.log",
+            version, commit_sha, process_suffix, process_id
+        ))
         .rotation(rotation.into())
         .max_log_files(max_files as usize)
         .build(&directory)?;


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Require process type and add PID to debug file log names via `bindings_ffi::logger.enter_debug_writer` and `bindings_ffi::logger.enter_debug_writer_with_level` to enable file logs from multiple processes
Introduce `bindings_ffi::logger::FfiProcessType` and propagate a `process_type` argument through FFI logging entrypoints; update filename prefix formatting in `enable_debug_file_inner` to include version, commit SHA, process type, and process ID; update tests to pass `FfiProcessType::Main`.

#### 📍Where to Start
Start with the FFI surface changes in [logger.rs](https://github.com/xmtp/libxmtp/pull/2870/files#diff-4bbabc172ad0589d5364e814aa0311a1792f06663618c2bbb82fe06fe62e418a), beginning at `enter_debug_writer` and `enter_debug_writer_with_level`, then follow into `enable_debug_file_inner`.

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 12ac3f1. 1 file reviewed, 3 issues evaluated, 3 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>bindings_ffi/src/logger.rs — 0 comments posted, 3 evaluated, 3 filtered</summary>

- [line 272](https://github.com/xmtp/libxmtp/blob/12ac3f17de8ffc69f94c0836119ce406db973490/bindings_ffi/src/logger.rs#L272): `enter_debug_writer_with_level` uses a non-atomic check-then-set on the `FILE_INITIALIZED` flag with `Ordering::Relaxed`, allowing multiple threads to simultaneously pass the `false` check and enter `enable_debug_file_inner`. This violates at-most-once initialization and enables overlapping enable/exit sequences. Because inputs are FFI-exposed, concurrent calls are reachable. Use a compare-and-swap on the atomic or a global mutex to serialize enter/exit/enable. <b>[ Low confidence ]</b>
- [line 287](https://github.com/xmtp/libxmtp/blob/12ac3f17de8ffc69f94c0836119ce406db973490/bindings_ffi/src/logger.rs#L287): Race between concurrent `enter_debug_writer_with_level` calls can leave the logger writer pointing at a `NonBlocking` whose `WorkerGuard` has already been dropped, causing logs to be silently lost. Interleaving: Thread A calls `enable_debug_file_inner`, creates `(non_blocking_A, worker_A)`. Before A updates the writer via `LOGGER.modify`, Thread B calls `exit_debug_writer` (from its own `enable_debug_file_inner`), which sets the writer to empty and drops `worker_A` via `WORKER.get().lock().take()`. A then sets the writer to `non_blocking_A`, but its worker is gone, so log writes will not be persisted. Serialize `exit + setup + swap-writer` in a single critical section or store the new worker before any other thread can drop it and ensure you never point the writer to a non-blocking without a live guard. <b>[ Out of scope ]</b>
- [line 391](https://github.com/xmtp/libxmtp/blob/12ac3f17de8ffc69f94c0836119ce406db973490/bindings_ffi/src/logger.rs#L391): Test flakiness: `test_file_appender` asserts `entries.len() == 1` after writing and exiting. Depending on the rolling appender’s rotation policy and platform-specific temp dir behavior, multiple files (e.g., staging, partial rotations, or hidden files) may be present, causing nondeterministic failures. The test should locate the expected prefix and assert contents rather than a strict count. <b>[ Test / Mock code ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->