### PR TITLE
Remove device sync message content from logs

### DIFF
--- a/xmtp_mls/src/groups/device_sync/worker.rs
+++ b/xmtp_mls/src/groups/device_sync/worker.rs
@@ -250,9 +250,17 @@ where
         for (msg, content) in unprocessed_messages.clone().iter_with_content() {
             let is_external = msg.sender_installation_id != installation_id;
 
+            let msg_type = match &content {
+                ContentProto::Request(_) => "Request",
+                ContentProto::Reply(_) => "Reply",
+                ContentProto::PreferenceUpdates(_) => "PreferenceUpdates",
+                ContentProto::Acknowledge(_) => "Acknowledge",
+            };
+
             tracing::info!(
-                "Message content: (external: {is_external}) id={}, {content:?}",
-                xmtp_common::fmt::truncate_hex(hex::encode(&msg.id))
+                "Message content: (external: {is_external}) id={}, type={}",
+                xmtp_common::fmt::truncate_hex(hex::encode(&msg.id)),
+                msg_type
             );
 
             if let Err(err) = self.process_message(handle, &msg, content).await {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Change `xmtp_mls::groups::device_sync::worker::process_new_sync_group_messages` info log to print message type string and remove message content
Introduce a local `msg_type` by matching `ContentProto` variants and update the `tracing::info!` call to log `id` and type instead of `{content:?}` in [xmtp_mls/src/groups/device_sync/worker.rs](https://github.com/xmtp/libxmtp/pull/2872/files#diff-0cb027fe20ae820904d14b0c7f33a82233e4b67af67d1cea0335eb0dab01acb0).

#### 📍Where to Start
Start with `process_new_sync_group_messages` in [xmtp_mls/src/groups/device_sync/worker.rs](https://github.com/xmtp/libxmtp/pull/2872/files#diff-0cb027fe20ae820904d14b0c7f33a82233e4b67af67d1cea0335eb0dab01acb0).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized b3f80fd.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->