### PR TITLE
Replace busy-wait with a sleep

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -57,7 +57,7 @@
           ]
         },
         "files": {
-          "excludeDirs": ["bindings_wasm"]
+          "exclude": ["bindings_wasm"]
         }
       }
     }

--- a/xmtp_mls/src/subscriptions/stream_all/tests.rs
+++ b/xmtp_mls/src/subscriptions/stream_all/tests.rs
@@ -502,7 +502,7 @@ async fn stream_messages_keeps_track_of_cursor() {
 #[rstest::rstest]
 #[xmtp_common::test]
 #[timeout(Duration::from_secs(20))]
-#[cfg_attr(target_arch = "wasm32", ignore)]
+#[cfg_attr(feature = "d14n", ignore)]
 async fn test_stream_all_messages_filters_conversations_created_after_init() {
     let sender = ClientBuilder::new_test_client(&generate_local_wallet()).await;
     let receiver = ClientBuilder::new_test_client(&generate_local_wallet()).await;

--- a/xmtp_mls/src/worker.rs
+++ b/xmtp_mls/src/worker.rs
@@ -6,7 +6,7 @@ use parking_lot::Mutex;
 use std::fmt::Debug;
 use std::pin::Pin;
 use std::{any::Any, collections::HashMap, hash::Hash, sync::Arc};
-use xmtp_common::{MaybeSend, MaybeSync, StreamHandle, if_native, if_wasm};
+use xmtp_common::{MaybeSend, MaybeSync, StreamHandle, if_native, if_wasm, time::Duration};
 use xmtp_configuration::WORKER_RESTART_DELAY;
 
 pub mod metrics;
@@ -83,7 +83,7 @@ impl WorkerRunner {
         let this = self.clone();
         let handle = xmtp_common::spawn(None, async move {
             while !ctx.identity().is_ready() {
-                xmtp_common::task::yield_now().await;
+                xmtp_common::time::sleep(Duration::from_millis(50)).await;
             }
 
             let mut futs = FuturesUnordered::new();


### PR DESCRIPTION
## tl;dr

- We had a busy-loop waiting for the identity to get registered eating unnecessary CPU. This replaces it with a sleep.
- Fixed zed ignore of wasm folder. Seems like the field changed.