### PR TITLE
utilize the more formal d14n types in mls streams

### DIFF
--- a/xmtp_api/src/debug_wrapper.rs
+++ b/xmtp_api/src/debug_wrapper.rs
@@ -16,6 +16,7 @@ use xmtp_proto::types::GroupMessage;
 use xmtp_proto::types::GroupMessageMetadata;
 use xmtp_proto::types::InstallationId;
 use xmtp_proto::types::Topic;
+use xmtp_proto::types::TopicCursor;
 use xmtp_proto::types::WelcomeMessage;
 use xmtp_proto::xmtp::identity::api::v1::GetIdentityUpdatesRequest as GetIdentityUpdatesV2Request;
 use xmtp_proto::xmtp::identity::api::v1::GetIdentityUpdatesResponse as GetIdentityUpdatesV2Response;
@@ -239,7 +240,7 @@ where
 
     async fn subscribe_group_messages_with_cursors(
         &self,
-        groups_with_cursors: &[(&GroupId, GlobalCursor)],
+        groups_with_cursors: &TopicCursor,
     ) -> Result<Self::GroupMessageStream, Self::Error> {
         wrap_err(
             || {

--- a/xmtp_api/src/mls.rs
+++ b/xmtp_api/src/mls.rs
@@ -9,7 +9,7 @@ use xmtp_proto::mls_v1::{
     PublishCommitLogRequest, QueryCommitLogRequest, QueryCommitLogResponse,
 };
 use xmtp_proto::types::{
-    GroupId, GroupMessage, GroupMessageMetadata, InstallationId, WelcomeMessage,
+    GroupId, GroupMessage, GroupMessageMetadata, InstallationId, TopicCursor, WelcomeMessage,
 };
 use xmtp_proto::xmtp::mls::api::v1::{
     FetchKeyPackagesRequest, GroupMessageInput, KeyPackageUpload, SendGroupMessagesRequest,
@@ -252,7 +252,7 @@ where
 
     pub async fn subscribe_group_messages_with_cursors(
         &self,
-        groups_with_cursors: &[(&GroupId, xmtp_proto::types::GlobalCursor)],
+        groups_with_cursors: &TopicCursor,
     ) -> Result<<ApiClient as XmtpMlsStreams>::GroupMessageStream>
     where
         ApiClient: XmtpMlsStreams,

--- a/xmtp_api_d14n/src/queries/api_stats.rs
+++ b/xmtp_api_d14n/src/queries/api_stats.rs
@@ -9,6 +9,7 @@ use xmtp_proto::prelude::ApiBuilder;
 use xmtp_proto::prelude::XmtpIdentityClient;
 use xmtp_proto::prelude::XmtpMlsStreams;
 use xmtp_proto::types::InstallationId;
+use xmtp_proto::types::TopicCursor;
 use xmtp_proto::types::WelcomeMessage;
 use xmtp_proto::types::{GroupId, GroupMessage};
 
@@ -182,7 +183,7 @@ where
 
     async fn subscribe_group_messages_with_cursors(
         &self,
-        groups_with_cursors: &[(&GroupId, xmtp_proto::types::GlobalCursor)],
+        groups_with_cursors: &TopicCursor,
     ) -> Result<Self::GroupMessageStream, Self::Error> {
         self.stats.subscribe_messages.count_request();
         self.inner

--- a/xmtp_api_d14n/src/queries/boxed_streams.rs
+++ b/xmtp_api_d14n/src/queries/boxed_streams.rs
@@ -10,6 +10,7 @@ use xmtp_proto::mls_v1;
 use xmtp_proto::prelude::XmtpIdentityClient;
 use xmtp_proto::prelude::XmtpMlsStreams;
 use xmtp_proto::types::InstallationId;
+use xmtp_proto::types::TopicCursor;
 use xmtp_proto::types::WelcomeMessage;
 use xmtp_proto::types::{GroupId, GroupMessage};
 /// Wraps an ApiClient to allow turning
@@ -162,7 +163,7 @@ where
 
     async fn subscribe_group_messages_with_cursors(
         &self,
-        groups_with_cursors: &[(&GroupId, xmtp_proto::types::GlobalCursor)],
+        groups_with_cursors: &TopicCursor,
     ) -> Result<Self::GroupMessageStream, Self::Error> {
         let s = self
             .inner

--- a/xmtp_api_d14n/src/queries/v3/streams.rs
+++ b/xmtp_api_d14n/src/queries/v3/streams.rs
@@ -7,7 +7,7 @@ use xmtp_proto::api_client::XmtpMlsStreams;
 use xmtp_proto::mls_v1::subscribe_group_messages_request::Filter as GroupSubscribeFilter;
 use xmtp_proto::mls_v1::subscribe_welcome_messages_request::Filter as WelcomeSubscribeFilter;
 use xmtp_proto::types::{
-    GlobalCursor, GroupId, GroupMessage, InstallationId, TopicKind, WelcomeMessage,
+    GroupId, GroupMessage, InstallationId, TopicCursor, TopicKind, WelcomeMessage,
 };
 
 #[xmtp_common::async_trait]
@@ -56,10 +56,10 @@ where
 
     async fn subscribe_group_messages_with_cursors(
         &self,
-        groups_with_cursors: &[(&GroupId, GlobalCursor)],
+        topics: &TopicCursor,
     ) -> Result<Self::GroupMessageStream, Self::Error> {
         let mut filters = vec![];
-        for (group_id, cursor) in groups_with_cursors {
+        for (group_id, cursor) in topics.groups() {
             let id_cursor = cursor.max();
             tracing::debug!(
                 "subscribing to group {} @ cursor {}",

--- a/xmtp_api_d14n/src/test/mock_client.rs
+++ b/xmtp_api_d14n/src/test/mock_client.rs
@@ -7,7 +7,9 @@ use xmtp_proto::api::mock::MockApiBuilder;
 use xmtp_proto::api_client::XmtpTestClient;
 use xmtp_proto::{
     api_client::{XmtpIdentityClient, XmtpMlsClient, XmtpMlsStreams},
-    types::{GroupId, GroupMessage, GroupMessageMetadata, InstallationId, WelcomeMessage},
+    types::{
+        GroupId, GroupMessage, GroupMessageMetadata, InstallationId, TopicCursor, WelcomeMessage,
+    },
     xmtp::{
         identity::api::v1::{
             GetIdentityUpdatesRequest as GetIdentityUpdatesV2Request,
@@ -99,7 +101,7 @@ mock! {
         #[mockall::concretize]
         async fn subscribe_group_messages(&self, group_ids: &[&GroupId]) -> Result<MockGroupStream, MockError>;
         #[mockall::concretize]
-        async fn subscribe_group_messages_with_cursors(&self, groups_with_cursors: &[(&GroupId, xmtp_proto::types::GlobalCursor)]) -> Result<MockGroupStream, MockError>;
+        async fn subscribe_group_messages_with_cursors(&self, groups_with_cursors: &TopicCursor) -> Result<MockGroupStream, MockError>;
         #[mockall::concretize]
         async fn subscribe_welcome_messages(&self, installations: &[&InstallationId]) -> Result<MockWelcomeStream, MockError>;
     }

--- a/xmtp_mls/src/subscriptions/stream_messages.rs
+++ b/xmtp_mls/src/subscriptions/stream_messages.rs
@@ -8,7 +8,6 @@ mod types;
 pub use test_utils::*;
 
 use types::GroupList;
-pub(super) use types::MessagePosition;
 pub use types::MessageStreamError;
 
 use super::{
@@ -29,9 +28,9 @@ use std::{
 };
 use xmtp_common::BoxDynFuture;
 use xmtp_db::group_message::StoredGroupMessage;
-use xmtp_proto::api_client::XmtpMlsStreams;
-use xmtp_proto::types::Cursor;
 use xmtp_proto::types::GroupId;
+use xmtp_proto::types::{Cursor, GlobalCursor};
+use xmtp_proto::{api_client::XmtpMlsStreams, types::TopicCursor};
 
 impl xmtp_common::RetryableError for MessageStreamError {
     fn is_retryable(&self) -> bool {
@@ -235,24 +234,17 @@ where
     #[allow(clippy::type_complexity)]
     async fn subscribe(
         context: Cow<'a, C>,
-        groups_with_positions: Vec<(GroupId, MessagePosition)>,
+        topic_cursor: TopicCursor,
         new_group: Vec<u8>,
     ) -> Result<(
         MessagesApiSubscription<'a, C::ApiClient>,
         Vec<u8>,
         Option<Cursor>,
     )> {
-        use xmtp_proto::types::GlobalCursor;
-
-        let groups_with_cursors: Vec<(&GroupId, GlobalCursor)> = groups_with_positions
-            .iter()
-            .map(|(group_id, position)| (group_id, GlobalCursor::new(position.last_streamed())))
-            .collect();
-
         let stream = context
             .as_ref()
             .api()
-            .subscribe_group_messages_with_cursors(&groups_with_cursors)
+            .subscribe_group_messages_with_cursors(&topic_cursor)
             .await?;
         Ok((
             stream,
@@ -328,13 +320,12 @@ where
                         this.as_mut().set_cursor(group.as_slice(), c)
                     };
                     this.as_mut().project().inner.set(stream);
-                    if let Some(cursor) = this.groups.position(&group) {
-                        tracing::debug!(
-                            "added group_id={} at cursor={} to messages stream",
-                            hex::encode(&group),
-                            cursor
-                        );
-                    }
+                    let position = this.groups.position(&group);
+                    tracing::debug!(
+                        "added group_id={} at cursor={} to messages stream",
+                        hex::encode(&group),
+                        position
+                    );
                 }
                 this.project().state.as_mut().set(State::Waiting);
                 cx.waker().wake_by_ref();
@@ -430,9 +421,8 @@ where
             hex::encode(&group.group_id)
         );
         let this = self.as_mut().project();
-        this.groups
-            .add(&group.group_id, MessagePosition::new(Cursor::new(1, 0u32)));
-        let groups_with_positions = self.groups.groups_with_positions();
+        this.groups.add(&group.group_id, GlobalCursor::default());
+        let groups_with_positions = self.groups.groups_with_positions().clone();
         let future = Self::subscribe(self.context.clone(), groups_with_positions, group.group_id);
         let mut this = self.as_mut().project();
 

--- a/xmtp_mls/src/subscriptions/stream_messages/types.rs
+++ b/xmtp_mls/src/subscriptions/stream_messages/types.rs
@@ -1,6 +1,6 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
-use xmtp_proto::types::{Cursor, GroupId, OriginatorId, SequenceId};
+use xmtp_proto::types::{Cursor, GlobalCursor, GroupId, Topic, TopicCursor};
 
 #[derive(thiserror::Error, Debug)]
 pub enum MessageStreamError {
@@ -10,65 +10,9 @@ pub enum MessageStreamError {
     InvalidPayload,
 }
 
-/// the position of this message in the backend topic
-/// based only upon messages from the stream
-#[derive(Default, Clone, PartialEq, Eq)]
-pub struct MessagePosition {
-    /// last mesasage we got from the network
-    /// If we get a message before this cursor, we should
-    /// check if we synced after that cursor, and should
-    /// prefer retrieving from the database
-    last_streamed: HashMap<OriginatorId, SequenceId>,
-}
-
-impl std::fmt::Debug for MessagePosition {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("MessagePosition")
-            .field("last_streamed", &self.last_streamed)
-            .finish()
-    }
-}
-
-impl MessagePosition {
-    pub fn new(cursor: Cursor) -> Self {
-        let mut last_map = HashMap::new();
-        last_map.insert(cursor.originator_id, cursor.sequence_id);
-        Self {
-            last_streamed: last_map,
-        }
-    }
-    /// Updates the cursor position for this message.
-    ///
-    /// Sets the cursor to a specific position in the message stream, which
-    /// helps track which messages have been processed.
-    ///
-    /// # Arguments
-    /// * `cursor` - The new cursor position to set
-    pub(super) fn set(&mut self, cursor: Cursor) {
-        self.last_streamed
-            .insert(cursor.originator_id, cursor.sequence_id);
-    }
-
-    /// Retrieves the current cursor position.
-    ///
-    /// Returns the cursor position or 0 if no cursor has been set yet.
-    ///
-    /// # Returns
-    /// * `u64` - The current cursor position or 0 if unset
-    pub(crate) fn last_streamed(&self) -> HashMap<u32, u64> {
-        self.last_streamed.clone()
-    }
-}
-
-impl std::fmt::Display for MessagePosition {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self.last_streamed())
-    }
-}
-
 #[derive(Clone, Debug, Default)]
 pub(super) struct GroupList {
-    list: HashMap<GroupId, MessagePosition>,
+    list: TopicCursor,
     // NOTE: if mem is a concern use a bloom filter
     // or create a garbage collection strategy
     seen: HashSet<Cursor>,
@@ -77,7 +21,11 @@ pub(super) struct GroupList {
 impl GroupList {
     pub(super) fn new(list: Vec<GroupId>, seen: HashSet<Cursor>) -> Self {
         Self {
-            list: list.into_iter().map(|g| (g, Default::default())).collect(),
+            list: list
+                .into_iter()
+                .map(Topic::new_group_message)
+                .map(|t| (t, GlobalCursor::default()))
+                .collect(),
             seen,
         }
     }
@@ -92,37 +40,31 @@ impl GroupList {
     }
 
     /// get all groups with their positions
-    pub(super) fn groups_with_positions(&self) -> Vec<(GroupId, MessagePosition)> {
-        self.list
-            .iter()
-            .map(|(id, pos)| (id.clone(), pos.clone()))
-            .collect()
+    pub(super) fn groups_with_positions(&self) -> &TopicCursor {
+        &self.list
     }
 
-    /// get the `MessagePosition` for `group_id`, if any
-    pub(super) fn position(&self, group_id: impl AsRef<[u8]>) -> Option<MessagePosition> {
-        self.list.get(group_id.as_ref()).cloned()
+    /// get the `GlobalCursor` for `group_id`, if any
+    pub(super) fn position(&self, group_id: impl AsRef<[u8]>) -> GlobalCursor {
+        self.list.get_group(group_id).clone()
     }
 
     /// Check whether the group is already being tracked
     pub(super) fn contains(&self, group_id: impl AsRef<[u8]>) -> bool {
-        self.list.contains_key(group_id.as_ref())
+        self.list.contains_group(group_id.as_ref())
     }
 
-    /// add a group at `MessagePosition` to this list
-    pub(super) fn add(&mut self, group: impl AsRef<[u8]>, position: MessagePosition) {
-        self.list.insert(group.as_ref().to_vec().into(), position);
+    /// add a group at `GlobalCursor` to this list
+    pub(super) fn add(&mut self, group: impl AsRef<[u8]>, position: GlobalCursor) {
+        self.list
+            .insert(Topic::new_group_message(group.as_ref().into()), position);
     }
 
     pub(super) fn set(&mut self, group: impl AsRef<[u8]>, cursor: Cursor) {
         self.list
-            .entry(group.as_ref().into())
-            .and_modify(|c| c.set(cursor))
-            .or_insert_with(|| {
-                let mut pos = MessagePosition::default();
-                pos.set(cursor);
-                pos
-            });
+            .group_entry(group)
+            .and_modify(|g| g.apply(&cursor))
+            .or_insert(GlobalCursor::from(cursor));
         self.seen.insert(cursor);
     }
 }

--- a/xmtp_proto/src/api_client.rs
+++ b/xmtp_proto/src/api_client.rs
@@ -7,7 +7,9 @@ use crate::mls_v1::{
     BatchPublishCommitLogRequest, BatchQueryCommitLogRequest, BatchQueryCommitLogResponse,
     GetNewestGroupMessageRequest, PagingInfo,
 };
-use crate::types::{GroupId, GroupMessage, GroupMessageMetadata, InstallationId, WelcomeMessage};
+use crate::types::{
+    GroupId, GroupMessage, GroupMessageMetadata, InstallationId, TopicCursor, WelcomeMessage,
+};
 use crate::xmtp::identity::api::v1::{
     GetIdentityUpdatesRequest as GetIdentityUpdatesV2Request,
     GetIdentityUpdatesResponse as GetIdentityUpdatesV2Response, GetInboxIdsRequest,
@@ -156,7 +158,7 @@ pub trait XmtpMlsStreams: MaybeSend + MaybeSync {
     ) -> Result<Self::GroupMessageStream, Self::Error>;
     async fn subscribe_group_messages_with_cursors(
         &self,
-        groups_with_cursors: &[(&GroupId, crate::types::GlobalCursor)],
+        groups_with_cursors: &TopicCursor,
     ) -> Result<Self::GroupMessageStream, Self::Error>;
     async fn subscribe_welcome_messages(
         &self,

--- a/xmtp_proto/src/api_client/impls.rs
+++ b/xmtp_proto/src/api_client/impls.rs
@@ -1,6 +1,6 @@
 use crate::{
     mls_v1::QueryGroupMessagesResponse,
-    types::{GroupId, GroupMessageMetadata, WelcomeMessage},
+    types::{GroupId, GroupMessageMetadata, TopicCursor, WelcomeMessage},
     xmtp::xmtpv4::{
         envelopes::OriginatorEnvelope,
         message_api::{QueryEnvelopesResponse, SubscribeEnvelopesResponse},
@@ -293,7 +293,7 @@ where
 
     async fn subscribe_group_messages_with_cursors(
         &self,
-        groups_with_cursors: &[(&GroupId, crate::types::GlobalCursor)],
+        groups_with_cursors: &TopicCursor,
     ) -> Result<Self::GroupMessageStream, Self::Error> {
         (**self)
             .subscribe_group_messages_with_cursors(groups_with_cursors)
@@ -328,7 +328,7 @@ where
 
     async fn subscribe_group_messages_with_cursors(
         &self,
-        groups_with_cursors: &[(&GroupId, crate::types::GlobalCursor)],
+        groups_with_cursors: &TopicCursor,
     ) -> Result<Self::GroupMessageStream, Self::Error> {
         (**self)
             .subscribe_group_messages_with_cursors(groups_with_cursors)

--- a/xmtp_proto/src/types/topic.rs
+++ b/xmtp_proto/src/types/topic.rs
@@ -3,7 +3,11 @@ use std::{
     ops::Deref,
 };
 
-use crate::{ConversionError, xmtp::xmtpv4::envelopes::AuthenticatedData};
+use crate::{
+    ConversionError,
+    types::{GroupId, InstallationId},
+    xmtp::xmtpv4::envelopes::AuthenticatedData,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u8)]
@@ -73,6 +77,22 @@ impl Topic {
         Self {
             inner: kind.build(bytes),
         }
+    }
+
+    pub fn new_group_message(group_id: GroupId) -> Self {
+        TopicKind::GroupMessagesV1.create(group_id)
+    }
+
+    pub fn new_identity_update(inbox_id: impl AsRef<[u8]>) -> Self {
+        TopicKind::IdentityUpdatesV1.create(inbox_id)
+    }
+
+    pub fn new_welcome_message(installation_id: InstallationId) -> Self {
+        TopicKind::WelcomeMessagesV1.create(installation_id)
+    }
+
+    pub fn new_key_package(installation_id: InstallationId) -> Self {
+        TopicKind::KeyPackagesV1.create(installation_id)
     }
 
     pub fn kind(&self) -> TopicKind {


### PR DESCRIPTION
the proto types have some extra safety rules around ordering sequence ids to apply either max or least. it also removes some code in the stream that was essentially the new proto type but worse/duplicated

adds some ergonomic helpers/implementations to `TopicCursor` like `FromIterator`/`IntoIterator` and a proxy entry api based on topic