### PR TITLE
Bump node to 1.6.3-rc1

### DIFF
--- a/bindings_node/package.json
+++ b/bindings_node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/node-bindings",
-  "version": "1.6.3",
+  "version": "1.6.3-rc1",
   "repository": {
     "type": "git",
     "url": "git+https://git@github.com/xmtp/libxmtp.git",


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Set `bindings_node/package.json` version to 1.6.3 to bump node
Update the `version` field in [package.json](https://github.com/xmtp/libxmtp/pull/2881/files#diff-bc8be8e755c9188d5b1c3402b397741f9151dad43d877a181f31003052d10b99) from `1.7.0-dev` to `1.6.3`.

#### 📍Where to Start
Start with the `version` field change in [package.json](https://github.com/xmtp/libxmtp/pull/2881/files#diff-bc8be8e755c9188d5b1c3402b397741f9151dad43d877a181f31003052d10b99).

<!-- Macroscope's changelog starts here -->
#### Changes since #2881 opened

- Updated version in package manifest [0ebd6d4]
<!-- Macroscope's changelog ends here -->

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 85552ab.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->