### PR TITLE
add icebox to `OrderedEnvelopeCollection` implementation

### DIFF
--- a/xmtp_api_d14n/src/protocol/order.rs
+++ b/xmtp_api_d14n/src/protocol/order.rs
@@ -1,13 +1,14 @@
 use std::collections::HashSet;
 
 use crate::protocol::{
-    Envelope, EnvelopeError, OrderedEnvelopeCollection, ResolutionError, ResolveDependencies,
-    Resolved, Sort, sort, types::MissingEnvelope,
+    CursorStore, Envelope, EnvelopeError, OrderedEnvelopeCollection, ResolutionError,
+    ResolveDependencies, Resolved, Sort, sort, types::RequiredDependency,
 };
 use derive_builder::Builder;
 use itertools::Itertools;
+use tracing::Level;
 use xmtp_proto::api::VectorClock;
-use xmtp_proto::types::TopicCursor;
+use xmtp_proto::types::{Cursor, OrphanedEnvelope, TopicCursor};
 
 /// Order dependencies of `Self` according to [XIP](https://github.com/xmtp/XIPs/blob/main/XIPs/xip-49-decentralized-backend.md#335-cross-originator-message-ordering)
 /// If dependencies are missing, this ordering will try to resolve them
@@ -15,90 +16,125 @@ use xmtp_proto::types::TopicCursor;
 /// construct this strategy with [`Ordered::builder`]
 #[derive(Debug, Clone, Builder)]
 #[builder(setter(strip_option), build_fn(error = "EnvelopeError"))]
-pub struct Ordered<T, R> {
+pub struct Ordered<T, R, S> {
     envelopes: Vec<T>,
     resolver: R,
     topic_cursor: TopicCursor,
+    store: S,
 }
 
-impl<T, R> Ordered<T, R> {
+impl<T, R, S> Ordered<T, R, S>
+where
+    S: CursorStore,
+    R: ResolveDependencies<ResolvedEnvelope = T>,
+    T: Envelope<'static> + prost::Message + Default,
+{
+    /// get the missing dependencies in the form of a [`RequiredDependency`]
+    fn required_dependencies(
+        &mut self,
+        missing: &[T],
+    ) -> Result<HashSet<RequiredDependency>, EnvelopeError> {
+        missing
+            .iter()
+            .map(|e| {
+                let dependencies = e.depends_on()?.unwrap_or(Default::default());
+                let topic = e.topic()?;
+                let topic_clock = self.topic_cursor.get_or_default(&topic);
+                let need = topic_clock.missing(&dependencies);
+                let needed_by = e.cursor()?;
+                Ok(need
+                    .into_iter()
+                    .map(move |c| RequiredDependency::new(topic.clone(), c, needed_by)))
+            })
+            .flatten_ok()
+            .try_collect()
+    }
+
+    // convenient internal proxy to causal sorting
+    fn causal_sort(&mut self) -> Result<Option<Vec<T>>, EnvelopeError> {
+        sort::causal(&mut self.envelopes, &mut self.topic_cursor).sort()
+    }
+
+    // convenient internal proxy to timestamp sort
+    fn timestamp_sort(&mut self) -> Result<(), EnvelopeError> {
+        // timestamp sort never returns missing envelopes
+        let _ = sort::timestamp(&mut self.envelopes).sort()?;
+        Ok(())
+    }
+
+    /// try to find any lost children and re-apply them to the
+    /// end of the envelopes list before any resolution occurs
+    fn recover_lost_children(&mut self) -> Result<(), EnvelopeError> {
+        let cursors: Vec<_> = self.envelopes.iter().map(|e| e.cursor()).try_collect()?;
+        let children = self.store.resolve_children(&cursors)?;
+        if !children.is_empty() {
+            tracing::info!("recovered {} children", children.len());
+            if tracing::enabled!(Level::TRACE) {
+                for child in &children {
+                    tracing::trace!(
+                        "recovered child@{} dependant on parent@{} for group@{}",
+                        &child.cursor,
+                        &child.depends_on,
+                        &child.group_id
+                    );
+                }
+            }
+        }
+        let cursors: HashSet<Cursor> = HashSet::from_iter(cursors);
+        let mut envelopes: Vec<T> = children
+            .into_iter()
+            // ensure we don't re-add duplicates from the db
+            .filter(|o| !cursors.contains(&o.cursor))
+            .map(OrphanedEnvelope::into_payload)
+            .map(T::decode)
+            .try_collect()?;
+        // ensure we append them to the list so that the sorting
+        // adds the parent envelopes to the topic cursor before the orphans
+        self.envelopes.append(&mut envelopes);
+        Ok(())
+    }
+}
+
+impl<T, R, S> Ordered<T, R, S> {
     pub fn into_parts(self) -> (Vec<T>, TopicCursor) {
         (self.envelopes, self.topic_cursor)
     }
 }
 
-impl<T: Clone, R: Clone> Ordered<T, R> {
-    pub fn builder() -> OrderedBuilder<T, R> {
+impl<T: Clone, R: Clone, S: Clone> Ordered<T, R, S> {
+    pub fn builder() -> OrderedBuilder<T, R, S> {
         OrderedBuilder::default()
     }
 }
 
 #[xmtp_common::async_trait]
-impl<T, R> OrderedEnvelopeCollection for Ordered<T, R>
+impl<T, R, S> OrderedEnvelopeCollection for Ordered<T, R, S>
 where
-    T: Envelope<'static>,
+    T: Envelope<'static> + prost::Message + Default,
     R: ResolveDependencies<ResolvedEnvelope = T>,
+    S: CursorStore,
 {
+    // NOTE:
+    // In the case where a child has multiple dependants, and one is still missing:
+    // 1.) child is recovered
+    // 2.) child is added to "missing"
+    // 3.) resolution of missing is attempted
+    // 4.) child re-iced if resolution failed
     async fn order(&mut self) -> Result<(), ResolutionError> {
-        let Self {
-            envelopes,
-            resolver,
-            topic_cursor,
-        } = self;
-        sort::timestamp(envelopes).sort()?;
-        while let Some(mut missing) = sort::causal(envelopes, topic_cursor).sort()? {
-            let cursors = missing
-                .iter()
-                .map(|e| {
-                    let dependencies = e.depends_on()?.unwrap_or(Default::default());
-                    let topic = e.topic()?;
-                    let topic_clock = topic_cursor.get_or_default(&topic);
-                    let need = topic_clock.missing(&dependencies);
-                    Ok(need
-                        .into_iter()
-                        .map(|c| MissingEnvelope::new(topic.clone(), c))
-                        .collect::<HashSet<MissingEnvelope>>())
-                })
-                .flatten_ok()
-                .collect::<Result<HashSet<MissingEnvelope>, EnvelopeError>>()?;
-            let Resolved {
-                resolved,
-                unresolved,
-            } = resolver.resolve(cursors).await?;
+        self.recover_lost_children()?;
+        self.timestamp_sort()?;
+        while let Some(mut missing) = self.causal_sort()? {
+            let needed_envelopes = self.required_dependencies(&missing)?;
+            let Resolved { mut resolved, .. } = self.resolver.resolve(needed_envelopes).await?;
             if resolved.is_empty() {
-                // if we cant resolve anything, break the loop
+                let orphans = missing.into_iter().map(|e| e.orphan()).try_collect()?;
+                self.store.ice(orphans)?;
                 break;
             }
-            if let Some(unresolved) = unresolved {
-                let unresolved = unresolved
-                    .into_iter()
-                    .map(|m| m.cursor)
-                    .collect::<HashSet<_>>();
-                // if the resolver fails to resolve some envelopes, ignore them.
-                // delete unresolved envelopes from missing envelopes list.
-                // cannot use retain directly b/c cursor returns Result<>.
-                // see https://github.com/xmtp/libxmtp/issues/2691
-                // TODO:2691
-                let mut to_remove = HashSet::new();
-                for (i, m) in missing.iter().enumerate() {
-                    if unresolved.contains(&m.cursor()?) {
-                        to_remove.insert(i);
-                    }
-                }
-                let mut i = 0;
-                // or, retain all resolved envelopes
-                missing.retain(|_m| {
-                    let resolved = to_remove.contains(&i);
-                    i += 1;
-                    !resolved
-                });
-            }
-            // apply missing before resolved, so that the resolved
-            // are applied to the topic cursor before the missing dependencies.
-            // todo: maybe `VecDeque` better here?
-            envelopes.splice(0..0, missing.into_iter());
-            envelopes.splice(0..0, resolved.into_iter());
-            sort::timestamp(envelopes).sort()?;
+            self.envelopes.append(&mut resolved);
+            self.envelopes.append(&mut missing);
+            self.recover_lost_children()?;
+            self.timestamp_sort()?;
         }
         Ok(())
     }
@@ -107,7 +143,10 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::protocol::utils::test::{EnvelopesWithMissing, TestEnvelope, missing_dependencies};
+    use crate::protocol::{
+        NoCursorStore,
+        utils::test::{EnvelopesWithMissing, TestEnvelope, missing_dependencies},
+    };
     use futures::FutureExt;
     use proptest::{prelude::*, sample::subsequence};
     use xmtp_proto::types::OriginatorId;
@@ -125,16 +164,16 @@ mod test {
 
         async fn resolve(
             &self,
-            missing: HashSet<MissingEnvelope>,
+            missing: HashSet<RequiredDependency>,
         ) -> Result<Resolved<TestEnvelope>, ResolutionError> {
+            let missing_cursors = missing.iter().map(|m| m.cursor).collect::<HashSet<_>>();
             // Return envelopes that match the missing set
             let resolved = self
                 .available
                 .iter()
                 .filter(|env| {
-                    let cursor = env.cursor().unwrap();
-                    let topic = env.topic().unwrap();
-                    missing.contains(&MissingEnvelope::new(topic, cursor))
+                    let cursor = env.cursor();
+                    missing_cursors.contains(&cursor)
                 })
                 .cloned()
                 .collect::<Vec<_>>();
@@ -179,6 +218,7 @@ mod test {
             let mut ordered = Ordered::builder()
                 .envelopes(missing.envelopes)
                 .resolver(resolver)
+                .store(NoCursorStore)
                 .topic_cursor(TopicCursor::default())
                 .build()
                 .unwrap();
@@ -192,7 +232,7 @@ mod test {
 
             // Check that no envelope in the result depends on an unavailable removed envelope
             for envelope in &result {
-                let depends_on = envelope.depends_on().unwrap().unwrap_or_default();
+                let depends_on = envelope.depends_on();
                 let topic = envelope.topic().unwrap();
                 let topic_clock = topic_cursor.get_or_default(&topic);
 
@@ -209,7 +249,7 @@ mod test {
                         );
                     }
                 } else {
-                    panic!("topic clock should always be complete at conclusion of ordering. {} does not dominate envelope {} depending on {}", topic_clock, envelope.cursor, depends_on);
+                    panic!("topic clock should always be complete at conclusion of ordering. {} does not dominate envelope {} depending on {}", topic_clock, envelope.cursor(), depends_on);
                 }
             }
 
@@ -225,7 +265,7 @@ mod test {
                     "Result does not contain {}", available_env
                 );
                 // If it's in the result, verify its dependencies are satisfied
-                let depends_on = available_env.depends_on().unwrap().unwrap_or_default();
+                let depends_on = available_env.depends_on();
                 let topic = available_env.topic().unwrap();
                 let topic_clock = topic_cursor.get_or_default(&topic);
 

--- a/xmtp_api_d14n/src/protocol/resolve/network_backoff.rs
+++ b/xmtp_api_d14n/src/protocol/resolve/network_backoff.rs
@@ -2,7 +2,9 @@ use std::collections::HashSet;
 
 use crate::{
     d14n::QueryEnvelope,
-    protocol::{Envelope, ResolutionError, ResolveDependencies, Resolved, types::MissingEnvelope},
+    protocol::{
+        Envelope, ResolutionError, ResolveDependencies, Resolved, types::RequiredDependency,
+    },
 };
 use itertools::Itertools;
 use tracing::warn;
@@ -42,7 +44,7 @@ where
     /// * `HashSet<Self::ResolvedEnvelope>`: The list of envelopes which were resolved.
     async fn resolve(
         &self,
-        mut missing: HashSet<MissingEnvelope>,
+        mut missing: HashSet<RequiredDependency>,
     ) -> Result<Resolved<Self::ResolvedEnvelope>, ResolutionError> {
         let mut attempts = 0;
         let time_spent = xmtp_common::time::Instant::now();
@@ -83,7 +85,7 @@ where
 }
 
 /// Get the LCC and topics from a list of missing envelopes
-fn lcc(missing: &HashSet<MissingEnvelope>) -> (Vec<Topic>, GlobalCursor) {
+fn lcc(missing: &HashSet<RequiredDependency>) -> (Vec<Topic>, GlobalCursor) {
     // get the lcc by first getting lowest Cursor
     // per topic, then merging the global cursor of every topic into
     // one.
@@ -120,7 +122,11 @@ mod tests {
         let mut client = MockNetworkClient::new();
         let topic = Topic::new(TopicKind::GroupMessagesV1, vec![1, 2, 3]);
 
-        let missing = test::create_missing_set(topic.clone(), vec![(1, 10), (2, 20)]);
+        let missing = test::create_missing_set(
+            topic.clone(),
+            vec![Cursor::new(10, 1u32), Cursor::new(20, 2u32)],
+            vec![Cursor::new(11, 1u32), Cursor::new(21, 2u32)],
+        );
 
         let envelope1 = TestEnvelopeBuilder::new()
             .with_originator_node_id(1)
@@ -149,8 +155,16 @@ mod tests {
         let mut client = MockNetworkClient::new();
         let topic = Topic::new(TopicKind::GroupMessagesV1, vec![1, 2, 3]);
 
-        let missing = test::create_missing_set(topic.clone(), vec![(1, 10), (2, 20)]);
-        let expected_unresolved = test::create_missing_set(topic.clone(), vec![(2, 20)]);
+        let missing = test::create_missing_set(
+            topic.clone(),
+            vec![Cursor::new(10, 1u32), Cursor::new(20, 2u32)],
+            vec![Cursor::new(11, 1u32), Cursor::new(21, 2u32)],
+        );
+        let expected_unresolved = test::create_missing_set(
+            topic.clone(),
+            vec![Cursor::new(20, 2u32)],
+            vec![Cursor::new(21, 2u32)],
+        );
 
         // Only return one of the two requested envelopes
         let envelope1 = TestEnvelopeBuilder::new()

--- a/xmtp_api_d14n/src/protocol/sort/causal.rs
+++ b/xmtp_api_d14n/src/protocol/sort/causal.rs
@@ -122,7 +122,7 @@ mod tests {
                 "{envelope} has no dependency that is missing. missing & removed: {:?}",
                 missing_and_removed
                     .iter()
-                    .map(|e| e.cursor.to_string())
+                    .map(|e| e.cursor().to_string())
                     .collect::<Vec<_>>()
             );
         }
@@ -133,15 +133,15 @@ mod tests {
                 "{envelope} depends on a missing or removed dependency in \nremoved: {:?}, \nmissing: {:?} but it was marked as sorted,\n sorted {:?}",
                 removed
                     .iter()
-                    .map(|e| e.cursor.to_string())
+                    .map(|e| e.cursor().to_string())
                     .collect::<Vec<_>>(),
                 missing
                     .iter()
-                    .map(|e| e.cursor.to_string())
+                    .map(|e| e.cursor().to_string())
                     .collect::<Vec<_>>(),
                 sorted
                     .iter()
-                    .map(|e| e.cursor.to_string())
+                    .map(|e| e.cursor().to_string())
                     .collect::<Vec<_>>(),
             );
         }

--- a/xmtp_api_d14n/src/protocol/sort/timestamp.rs
+++ b/xmtp_api_d14n/src/protocol/sort/timestamp.rs
@@ -96,16 +96,6 @@ mod tests {
             unreachable!()
         }
 
-        fn consume<E>(&self, _extractor: E) -> Result<E::Output, crate::protocol::EnvelopeError>
-        where
-            Self: Sized,
-            for<'a> crate::protocol::EnvelopeError:
-                From<<E as crate::protocol::EnvelopeVisitor<'a>>::Error>,
-            for<'a> E: crate::protocol::EnvelopeVisitor<'a> + crate::protocol::Extractor,
-        {
-            unreachable!()
-        }
-
         fn cursor(&self) -> Result<xmtp_proto::types::Cursor, EnvelopeError> {
             unreachable!()
         }

--- a/xmtp_api_d14n/src/protocol/traits.rs
+++ b/xmtp_api_d14n/src/protocol/traits.rs
@@ -65,6 +65,10 @@ pub enum EnvelopeError {
     NotFound(&'static str),
     #[error(transparent)]
     MissingBuilderField(#[from] UninitializedFieldError),
+    #[error(transparent)]
+    Store(#[from] CursorStoreError),
+    #[error(transparent)]
+    Decode(#[from] prost::DecodeError),
     // for extractors defined outside of this crate or
     // generic implementations like Tuples
     #[error("{0}")]
@@ -80,6 +84,8 @@ impl RetryableError for EnvelopeError {
             Self::DynError(d) => retryable!(d),
             Self::NotFound(_) => false,
             Self::MissingBuilderField(_) => false,
+            Self::Store(s) => retryable!(s),
+            Self::Decode(_) => true,
         }
     }
 }

--- a/xmtp_api_d14n/src/protocol/traits/cursor_store.rs
+++ b/xmtp_api_d14n/src/protocol/traits/cursor_store.rs
@@ -318,7 +318,7 @@ impl<T: CursorStore + ?Sized> CursorStore for Box<T> {
 }
 
 /// This cursor store always returns 0
-#[derive(Default)]
+#[derive(Default, Copy, Clone)]
 pub struct NoCursorStore;
 
 impl CursorStore for NoCursorStore {

--- a/xmtp_api_d14n/src/protocol/traits/dependency_resolution.rs
+++ b/xmtp_api_d14n/src/protocol/traits/dependency_resolution.rs
@@ -4,16 +4,16 @@ use derive_builder::UninitializedFieldError;
 use xmtp_common::{MaybeSend, MaybeSync, RetryableError};
 use xmtp_proto::api::BodyError;
 
-use crate::protocol::{Envelope, EnvelopeError, types::MissingEnvelope};
+use crate::protocol::{CursorStoreError, Envelope, EnvelopeError, types::RequiredDependency};
 
 pub struct Resolved<E> {
     pub resolved: Vec<E>,
     /// list of envelopes that could not be resolved with this strategy
-    pub unresolved: Option<HashSet<MissingEnvelope>>,
+    pub unresolved: Option<HashSet<RequiredDependency>>,
 }
 
 impl<E> Resolved<E> {
-    pub fn new(envelopes: Vec<E>, unresolved: Option<HashSet<MissingEnvelope>>) -> Self {
+    pub fn new(envelopes: Vec<E>, unresolved: Option<HashSet<RequiredDependency>>) -> Self {
         Self {
             resolved: envelopes,
             unresolved,
@@ -31,7 +31,7 @@ pub trait ResolveDependencies: MaybeSend + MaybeSync {
     /// * `Vec<Self::ResolvedEnvelope>`: The list of envelopes which were resolved.
     async fn resolve(
         &self,
-        missing: HashSet<MissingEnvelope>,
+        missing: HashSet<RequiredDependency>,
     ) -> Result<Resolved<Self::ResolvedEnvelope>, ResolutionError>;
 }
 
@@ -43,7 +43,7 @@ where
     type ResolvedEnvelope = T::ResolvedEnvelope;
     async fn resolve(
         &self,
-        missing: HashSet<MissingEnvelope>,
+        missing: HashSet<RequiredDependency>,
     ) -> Result<Resolved<Self::ResolvedEnvelope>, ResolutionError> {
         <T as ResolveDependencies>::resolve(*self, missing).await
     }
@@ -55,7 +55,10 @@ pub struct NoopResolver;
 #[xmtp_common::async_trait]
 impl ResolveDependencies for NoopResolver {
     type ResolvedEnvelope = ();
-    async fn resolve(&self, m: HashSet<MissingEnvelope>) -> Result<Resolved<()>, ResolutionError> {
+    async fn resolve(
+        &self,
+        m: HashSet<RequiredDependency>,
+    ) -> Result<Resolved<()>, ResolutionError> {
         Ok(Resolved {
             resolved: vec![],
             unresolved: Some(m),
@@ -75,6 +78,8 @@ pub enum ResolutionError {
     Build(#[from] UninitializedFieldError),
     #[error("Resolution failed  to find all missing dependant envelopes")]
     ResolutionFailed,
+    #[error(transparent)]
+    Store(#[from] CursorStoreError),
 }
 
 impl RetryableError for ResolutionError {
@@ -86,6 +91,7 @@ impl RetryableError for ResolutionError {
             Api(a) => a.is_retryable(),
             Build(_) => false,
             ResolutionFailed => false,
+            Store(s) => s.is_retryable(),
         }
     }
 }

--- a/xmtp_api_d14n/src/protocol/traits/envelopes.rs
+++ b/xmtp_api_d14n/src/protocol/traits/envelopes.rs
@@ -63,12 +63,6 @@ pub trait Envelope<'env>: std::fmt::Debug + MaybeSend + MaybeSync {
     fn group_message(&self) -> Result<Option<GroupMessage>, EnvelopeError>;
     /// Try to get a welcome message
     fn welcome_message(&self) -> Result<Option<WelcomeMessage>, EnvelopeError>;
-    /// consume this envelope by extracting its contents with extractor `E`
-    fn consume<E>(&self, extractor: E) -> Result<E::Output, EnvelopeError>
-    where
-        Self: Sized,
-        for<'a> EnvelopeError: From<<E as EnvelopeVisitor<'a>>::Error>,
-        for<'a> E: EnvelopeVisitor<'a> + Extractor;
 }
 
 // Allows us to call these methods straight on the protobuf types without any
@@ -148,16 +142,6 @@ where
             }),
             payload: Some(payload),
         })
-    }
-
-    fn consume<E>(&self, mut extractor: E) -> Result<E::Output, EnvelopeError>
-    where
-        Self: Sized,
-        for<'a> E: EnvelopeVisitor<'a> + Extractor,
-        for<'a> EnvelopeError: From<<E as EnvelopeVisitor<'a>>::Error>,
-    {
-        self.accept(&mut extractor)?;
-        Ok(extractor.get())
     }
 
     fn group_message(&self) -> Result<Option<GroupMessage>, EnvelopeError> {

--- a/xmtp_api_d14n/src/protocol/types.rs
+++ b/xmtp_api_d14n/src/protocol/types.rs
@@ -1,3 +1,3 @@
 //! Types specific to the xmtp d14n implementation
-mod missing_envelope;
-pub use missing_envelope::*;
+mod required_dependency;
+pub use required_dependency::*;

--- a/xmtp_api_d14n/src/protocol/types/required_dependency.rs
+++ b/xmtp_api_d14n/src/protocol/types/required_dependency.rs
@@ -1,22 +1,27 @@
 use xmtp_proto::types::{Cursor, Topic};
 
 /// An envelope that is depended on by another envelope,
-/// but is missing from our local database or from a network call
+/// but is so far missing from the local database or the network
 /// see [`ResolveDependencies`](crate::protocol::ResolveDependencies) and
 /// [`Sort`](crate::protocol::Sort)
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct MissingEnvelope {
+pub struct RequiredDependency {
+    pub needed_by: Cursor,
     pub topic: Topic,
     pub cursor: Cursor,
 }
 
-impl MissingEnvelope {
-    pub fn new(topic: Topic, cursor: Cursor) -> Self {
-        Self { topic, cursor }
+impl RequiredDependency {
+    pub fn new(topic: Topic, cursor: Cursor, needed_by: Cursor) -> Self {
+        Self {
+            topic,
+            cursor,
+            needed_by,
+        }
     }
 }
 
-impl std::fmt::Display for MissingEnvelope {
+impl std::fmt::Display for RequiredDependency {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}/{}", self.cursor, self.topic)
     }

--- a/xmtp_api_d14n/src/protocol/utils/test/dependency_resolution_test.rs
+++ b/xmtp_api_d14n/src/protocol/utils/test/dependency_resolution_test.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use crate::protocol::{ResolveDependencies, types::MissingEnvelope};
+use crate::protocol::{ResolveDependencies, types::RequiredDependency};
 use xmtp_proto::types::{Cursor, Topic};
 
 /// Test that all missing envelopes are found immediately on the first resolution attempt.
@@ -22,7 +22,7 @@ use xmtp_proto::types::{Cursor, Topic};
 /// * If there are any unresolved envelopes remaining
 pub async fn test_resolve_all_found_immediately<R>(
     resolver: &R,
-    missing: HashSet<MissingEnvelope>,
+    missing: HashSet<RequiredDependency>,
     expected_count: usize,
 ) where
     R: ResolveDependencies,
@@ -64,9 +64,9 @@ pub async fn test_resolve_all_found_immediately<R>(
 /// * If the unresolved set doesn't match `expected_unresolved`
 pub async fn test_resolve_partial_resolution<R>(
     resolver: &R,
-    missing: HashSet<MissingEnvelope>,
+    missing: HashSet<RequiredDependency>,
     expected_resolved_count: usize,
-    expected_unresolved: HashSet<MissingEnvelope>,
+    expected_unresolved: HashSet<RequiredDependency>,
 ) where
     R: ResolveDependencies,
 {
@@ -141,12 +141,21 @@ where
 /// * `cursors` - List of (originator_id, sequence_id) pairs
 ///
 /// # Returns
-/// A `HashSet` of `MissingEnvelope` instances
-pub fn create_missing_set(topic: Topic, cursors: Vec<(u32, u64)>) -> HashSet<MissingEnvelope> {
+/// A `HashSet` of `RequiredDependency` instances
+pub fn create_missing_set(
+    topic: Topic,
+    cursors: Vec<Cursor>,
+    needed_by: Vec<Cursor>,
+) -> HashSet<RequiredDependency> {
+    // required for zip to work correctly
+    assert_eq!(
+        cursors.len(),
+        needed_by.len(),
+        "cursors and needed_by length must be equal for correct dependency configuration"
+    );
     cursors
         .into_iter()
-        .map(|(originator_id, sequence_id)| {
-            MissingEnvelope::new(topic.clone(), Cursor::new(sequence_id, originator_id))
-        })
+        .zip(needed_by)
+        .map(|(cursor, needed_by)| RequiredDependency::new(topic.clone(), cursor, needed_by))
         .collect()
 }

--- a/xmtp_api_d14n/src/protocol/utils/test/props.rs
+++ b/xmtp_api_d14n/src/protocol/utils/test/props.rs
@@ -2,7 +2,7 @@ use super::TestEnvelope;
 use itertools::Itertools;
 use proptest::prelude::*;
 use proptest::sample::subsequence;
-use xmtp_proto::types::{Cursor, GlobalCursor, OriginatorId, SequenceId};
+use xmtp_proto::types::{GlobalCursor, OriginatorId, SequenceId};
 
 // Advance the clock for a given originator
 fn advance_clock(base: &GlobalCursor, originator: &OriginatorId) -> SequenceId {
@@ -34,15 +34,15 @@ pub fn sorted_dependencies(
                             let mut envelopes = envelopes_clone.clone();
                             let total_clock: GlobalCursor = envelopes_clone
                                 .iter()
-                                .map(|e| (e.cursor.originator_id, e.cursor.sequence_id))
+                                .map(|e| (e.cursor().originator_id, e.cursor().sequence_id))
                                 .into_grouping_map()
                                 .max()
                                 .into();
                             let mut base = GlobalCursor::default();
                             envelopes_clone
                                 .iter()
-                                .filter(|e| e.cursor.originator_id == originator)
-                                .map(|e| e.cursor)
+                                .filter(|e| e.cursor().originator_id == originator)
+                                .map(|e| e.cursor())
                                 .for_each(|c| base.apply(&c));
 
                             let new_clock = if envelopes_subset.is_empty() {
@@ -50,8 +50,8 @@ pub fn sorted_dependencies(
                                 // same originator id
                                 base
                             } else {
-                                for cursor in envelopes_subset.iter().map(|e| &e.cursor) {
-                                    base.apply(cursor);
+                                for cursor in envelopes_subset.iter().map(|e| e.cursor()) {
+                                    base.apply(&cursor);
                                 }
                                 base
                             };
@@ -59,10 +59,7 @@ pub fn sorted_dependencies(
                             // Advance clock for this originator
                             let sequence_id = advance_clock(&total_clock, &originator);
 
-                            envelopes.push(TestEnvelope {
-                                cursor: Cursor::new(sequence_id, originator),
-                                depends_on: new_clock,
-                            });
+                            envelopes.push(TestEnvelope::new(sequence_id, originator, new_clock));
                             envelopes
                         },
                     )

--- a/xmtp_api_d14n/src/protocol/utils/test/test_envelope.rs
+++ b/xmtp_api_d14n/src/protocol/utils/test/test_envelope.rs
@@ -2,23 +2,46 @@ use crate::protocol::{Envelope, EnvelopeError};
 use chrono::Utc;
 use std::sync::LazyLock;
 use xmtp_proto::types::{Cursor, GlobalCursor, Topic, TopicKind};
+use xmtp_proto::xmtp::xmtpv4;
 use xmtp_proto::xmtp::xmtpv4::envelopes::ClientEnvelope;
 use xmtp_proto::xmtp::xmtpv4::envelopes::client_envelope::Payload;
 
 static TOPIC: LazyLock<Topic> =
     LazyLock::new(|| Topic::new(TopicKind::GroupMessagesV1, vec![0, 1, 2]));
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, PartialEq, prost::Message)]
 pub struct TestEnvelope {
-    pub cursor: Cursor,
-    pub depends_on: GlobalCursor,
+    #[prost(uint64, tag = "1")]
+    sequence_id: u64,
+    #[prost(uint32, tag = "2")]
+    originator_id: u32,
+    #[prost(message, tag = "3")]
+    depends_on: Option<xmtpv4::envelopes::Cursor>,
+}
+
+impl TestEnvelope {
+    pub fn new(sequence_id: u64, originator_id: u32, depends_on: GlobalCursor) -> Self {
+        Self {
+            sequence_id,
+            originator_id,
+            depends_on: Some(depends_on.into()),
+        }
+    }
+
+    pub fn cursor(&self) -> Cursor {
+        Cursor::new(self.sequence_id, self.originator_id)
+    }
+
+    pub fn depends_on(&self) -> GlobalCursor {
+        self.depends_on.clone().unwrap().into()
+    }
 }
 
 impl TestEnvelope {
     pub fn has_dependency_on(&self, other: &TestEnvelope) -> bool {
-        let originator = other.cursor.originator_id;
-        let depends_on_sid = self.depends_on.get(&originator);
-        depends_on_sid == other.cursor.sequence_id
+        let originator = other.cursor().originator_id;
+        let depends_on_sid = self.depends_on().get(&originator);
+        depends_on_sid == other.cursor().sequence_id
     }
 
     pub fn has_dependency_on_any(&self, other: &[TestEnvelope]) -> bool {
@@ -28,7 +51,12 @@ impl TestEnvelope {
 
 impl std::fmt::Display for TestEnvelope {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "cursor {} depends on {}", &self.cursor, &self.depends_on)
+        write!(
+            f,
+            "cursor {} depends on {}",
+            &self.cursor(),
+            &self.depends_on()
+        )
     }
 }
 
@@ -44,8 +72,8 @@ impl Envelope<'_> for TestEnvelope {
     fn timestamp(&self) -> Option<chrono::DateTime<Utc>> {
         // Create a deterministic timestamp based on originator_id and sequence_id
         // This ensures envelopes can be sorted by timestamp in tests
-        let nanos = (self.cursor.originator_id as i64 * 1_000_000_000)
-            + (self.cursor.sequence_id as i64 * 1000);
+        let nanos = (self.cursor().originator_id as i64 * 1_000_000_000)
+            + (self.cursor().sequence_id as i64 * 1000);
         chrono::DateTime::from_timestamp_nanos(nanos).into()
     }
 
@@ -65,22 +93,12 @@ impl Envelope<'_> for TestEnvelope {
         unreachable!()
     }
 
-    fn consume<E>(&self, _extractor: E) -> Result<E::Output, crate::protocol::EnvelopeError>
-    where
-        Self: Sized,
-        for<'a> crate::protocol::EnvelopeError:
-            From<<E as crate::protocol::EnvelopeVisitor<'a>>::Error>,
-        for<'a> E: crate::protocol::EnvelopeVisitor<'a> + crate::protocol::Extractor,
-    {
-        unreachable!()
-    }
-
     fn cursor(&self) -> Result<xmtp_proto::types::Cursor, EnvelopeError> {
-        Ok(self.cursor)
+        Ok(self.cursor())
     }
 
     fn depends_on(&self) -> Result<Option<xmtp_proto::types::GlobalCursor>, EnvelopeError> {
-        Ok(Some(self.depends_on.clone()))
+        Ok(Some(self.depends_on.clone().unwrap().into()))
     }
 
     fn sha256_hash(&self) -> Result<Vec<u8>, EnvelopeError> {

--- a/xmtp_api_d14n/src/queries/combinators.rs
+++ b/xmtp_api_d14n/src/queries/combinators.rs
@@ -2,22 +2,24 @@
 
 use xmtp_proto::{api::Endpoint, api_client::Paged, types::TopicCursor};
 
-use crate::protocol::ResolveDependencies;
+use crate::protocol::{CursorStore, ResolveDependencies};
 
 mod ordered_query;
 
 pub trait D14nCombinatorExt<S>: Endpoint<S> {
-    fn ordered<R>(
+    fn ordered<R, Store>(
         self,
         resolver: R,
         topic_cursor: TopicCursor,
-    ) -> ordered_query::OrderedQuery<Self, R, <Self as Endpoint<S>>::Output>
+        store: Store,
+    ) -> ordered_query::OrderedQuery<Self, R, <Self as Endpoint<S>>::Output, Store>
     where
         Self: Sized + Endpoint<S>,
         <Self as Endpoint<S>>::Output: Paged,
         R: ResolveDependencies,
+        Store: CursorStore,
     {
-        ordered_query::ordered(self, resolver, topic_cursor)
+        ordered_query::ordered(self, resolver, topic_cursor, store)
     }
 }
 

--- a/xmtp_api_d14n/src/queries/combinators/ordered_query.rs
+++ b/xmtp_api_d14n/src/queries/combinators/ordered_query.rs
@@ -7,24 +7,28 @@ use xmtp_proto::{
     types::TopicCursor,
 };
 
-use crate::protocol::{Ordered, OrderedEnvelopeCollection, ProtocolEnvelope, ResolveDependencies};
+use crate::protocol::{
+    CursorStore, Ordered, OrderedEnvelopeCollection, ProtocolEnvelope, ResolveDependencies,
+};
 
-pub struct OrderedQuery<E, R, T> {
+pub struct OrderedQuery<E, R, T, S> {
     endpoint: E,
     resolver: R,
     topic_cursor: TopicCursor,
+    store: S,
     _marker: PhantomData<T>,
 }
 
 #[xmtp_common::async_trait]
-impl<E, C, R, T> Query<C> for OrderedQuery<E, R, T>
+impl<E, C, R, T, S> Query<C> for OrderedQuery<E, R, T, S>
 where
     E: Query<C, Output = T>,
     C: Client,
     C::Error: RetryableError,
     R: ResolveDependencies<ResolvedEnvelope = <T as Paged>::Message> + Clone,
     T: Default + prost::Message + Paged + 'static,
-    for<'a> T::Message: ProtocolEnvelope<'a> + Clone,
+    S: CursorStore,
+    for<'a> T::Message: ProtocolEnvelope<'a> + prost::Message + Default + Clone,
 {
     type Output = Vec<T::Message>;
     async fn query(&mut self, client: &C) -> Result<Self::Output, ApiClientError<C::Error>> {
@@ -34,6 +38,7 @@ where
         let mut ordering = Ordered::builder()
             .envelopes(envelopes)
             .resolver(&self.resolver)
+            .store(&self.store)
             // todo: maybe no clone here?
             .topic_cursor(self.topic_cursor.clone())
             .build()?;
@@ -43,15 +48,17 @@ where
     }
 }
 
-pub fn ordered<E, R, T>(
+pub fn ordered<E, R, T, S>(
     endpoint: E,
     resolver: R,
     topic_cursor: TopicCursor,
-) -> OrderedQuery<E, R, T> {
-    OrderedQuery::<E, R, T> {
+    store: S,
+) -> OrderedQuery<E, R, T, S> {
+    OrderedQuery::<E, R, T, S> {
         endpoint,
         resolver,
         topic_cursor,
+        store,
         _marker: PhantomData,
     }
 }

--- a/xmtp_api_d14n/src/queries/d14n/mls.rs
+++ b/xmtp_api_d14n/src/queries/d14n/mls.rs
@@ -150,7 +150,7 @@ where
             .last_seen(lcc)
             .limit(MAX_PAGE_SIZE)
             .build()?
-            .ordered(resolver, topic_cursor)
+            .ordered(resolver, topic_cursor, &self.cursor_store)
             .query(&self.client)
             .await?;
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add icebox support by requiring a `CursorStore` in `protocol.order.Ordered` and icing unresolved orphans during `OrderedEnvelopeCollection::order`
Introduce a store-backed ordering flow that recovers children, sorts by timestamp/causal order, requests dependencies as `RequiredDependency`, and ices unresolved orphans in the store; update resolver and traits to accept `RequiredDependency` and propagate store/decode errors. Core changes center on `protocol.order.Ordered` and dependent combinators/resolvers, with `Envelope` dropping `consume` and tests updated accordingly.

#### 📍Where to Start
Start with the `OrderedEnvelopeCollection for Ordered::order` implementation in [order.rs](https://github.com/xmtp/libxmtp/pull/2882/files#diff-78b9f275c691ca4b70a53c2a710b84b741cf86e28ac909dc8b250cbe9b61ed1e), then review `required_dependencies`, `recover_lost_children`, and the resolver changes in [network_backoff.rs](https://github.com/xmtp/libxmtp/pull/2882/files#diff-de7799794fbc3300554d0474e251ec4117a5b0773a085ba0f94dd6f863c2f51e).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 38c66a7. 12 files reviewed, 3 issues evaluated, 3 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>xmtp_api_d14n/src/protocol/order.rs — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 176](https://github.com/xmtp/libxmtp/blob/38c66a77f1f1dd3dd9d73354b1e6508ad6e1b859/xmtp_api_d14n/src/protocol/order.rs#L176): The filter logic change reduces matching precision: the old code matched envelopes by BOTH `topic` AND `cursor` using `MissingEnvelope::new(topic, cursor)`, but the new code only matches by `cursor` alone. This could cause the resolver to return envelopes with matching cursors but incorrect topics, potentially masking bugs where topic matching is important. If `RequiredDependency` contains topic information that should be used for matching, it's being ignored. <b>[ Previously rejected ]</b>
</details>

<details>
<summary>xmtp_api_d14n/src/protocol/resolve/network_backoff.rs — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 53](https://github.com/xmtp/libxmtp/blob/38c66a77f1f1dd3dd9d73354b1e6508ad6e1b859/xmtp_api_d14n/src/protocol/resolve/network_backoff.rs#L53): The `resolve` function sleeps before making the first network query. On the first iteration with `attempts = 0`, `self.backoff.backoff(0, time_spent)` returns `Some(duration)` (base duration + jitter), causing an unnecessary delay before any query attempt. The first resolution attempt should be made immediately without sleeping. <b>[ Out of scope ]</b>
</details>

<details>
<summary>xmtp_api_d14n/src/protocol/traits.rs — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 88](https://github.com/xmtp/libxmtp/blob/38c66a77f1f1dd3dd9d73354b1e6508ad6e1b859/xmtp_api_d14n/src/protocol/traits.rs#L88): In `is_retryable()` for `EnvelopeError`, `Self::Decode(_) => true` marks `prost::DecodeError` as retryable. However, decode errors indicate malformed protobuf bytes, and retrying a decode operation on the same malformed bytes will produce the same error. This is inconsistent with the rationale documented in `ConversionError`'s `is_retryable()` implementation which explicitly states that conversions are not retryable because "the bytes are static". This could cause infinite retry loops or wasted retry attempts on permanently failing operations. <b>[ Already posted ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->