### PR TITLE
Noisy stream test

### DIFF
--- a/xmtp_mls/src/subscriptions/stream_messages/stream_stats.rs
+++ b/xmtp_mls/src/subscriptions/stream_messages/stream_stats.rs
@@ -129,6 +129,7 @@ impl<'a, Out> From<&State<'a, Out>> for StreamState {
     }
 }
 
+#[derive(Debug)]
 pub enum StreamStat {
     // the duration is a range of two timestamps in nanos
     Reconnection {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add async DM load tests that create 300 sessions and write alix.db3 plus derive Debug for `subscriptions::stream_messages::stream_stats::StreamStat`
Introduce two async tests in [xmtp_mls/src/groups/tests/test_dm.rs](https://github.com/xmtp/libxmtp/pull/2889/files#diff-e51f03ae12a7ee9c9e33e4444de97f4069ce3b63a6bc308c558743e7ecc4d64a) that stress DM/group interactions, persist a DB snapshot to alix.db3, and run a 100‑second message stats loop; also derive `Debug` for `StreamStat` in [xmtp_mls/src/subscriptions/stream_messages/stream_stats.rs](https://github.com/xmtp/libxmtp/pull/2889/files#diff-6d08e9dcde049e6df7da39c48fe7e63c427b79a98a877927d5337e9aba33bbee).

#### 📍Where to Start
Start with `test_setup_test` and `test_logs_issue` in [xmtp_mls/src/groups/tests/test_dm.rs](https://github.com/xmtp/libxmtp/pull/2889/files#diff-e51f03ae12a7ee9c9e33e4444de97f4069ce3b63a6bc308c558743e7ecc4d64a), then review the `StreamStat` derivation in [xmtp_mls/src/subscriptions/stream_messages/stream_stats.rs](https://github.com/xmtp/libxmtp/pull/2889/files#diff-6d08e9dcde049e6df7da39c48fe7e63c427b79a98a877927d5337e9aba33bbee).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 41b0f30.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->