### PR TITLE
Make stream_message_deletions async

### DIFF
--- a/bindings_node/src/conversations.rs
+++ b/bindings_node/src/conversations.rs
@@ -729,7 +729,7 @@ impl Conversations {
   }
 
   #[napi]
-  pub fn stream_message_deletions(
+  pub async fn stream_message_deletions(
     &self,
     callback: ThreadsafeFunction<String, ()>,
   ) -> Result<StreamCloser> {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Make `Conversations.stream_message_deletions` in [conversations.rs](https://github.com/xmtp/libxmtp/pull/2890/files#diff-305d8a9df912ee15a450791cf1af33e26798a0a4877f6a4dc457d291914bc126) async to add on_close support for the message deletion stream
Change the N-API method `Conversations.stream_message_deletions` to `async`, returning a `Future` that yields `Result<StreamCloser>` after invoking `RustXmtpClient::stream_message_deletions_with_callback`.

#### 📍Where to Start
Start with the `Conversations::stream_message_deletions` N-API method in [conversations.rs](https://github.com/xmtp/libxmtp/pull/2890/files#diff-305d8a9df912ee15a450791cf1af33e26798a0a4877f6a4dc457d291914bc126).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized abda21c.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->