### PR TITLE
fix worker restart on db connection drop not sleeping

### DIFF
--- a/xmtp_db/src/errors.rs
+++ b/xmtp_db/src/errors.rs
@@ -64,9 +64,13 @@ impl StorageError {
 
     #[cfg(not(target_arch = "wasm32"))]
     pub fn db_needs_connection(&self) -> bool {
+        use StorageError::*;
         matches!(
             self,
-            Self::Platform(crate::database::native::PlatformStorageError::PoolNeedsConnection)
+            Platform(crate::PlatformStorageError::PoolNeedsConnection)
+                | Connection(crate::ConnectionError::Platform(
+                    crate::PlatformStorageError::PoolNeedsConnection,
+                ))
         )
     }
 }

--- a/xmtp_mls/src/worker.rs
+++ b/xmtp_mls/src/worker.rs
@@ -161,7 +161,7 @@ pub trait Worker: MaybeSend + MaybeSync + 'static {
                 if let Err(err) = self.run_tasks().await {
                     if err.needs_db_reconnect() {
                         // drop the worker
-                        tracing::warn!("Pool disconnected. task will restart on reconnect");
+                        tracing::debug!("pool disconnected. task will restart on reconnect");
                         break;
                     } else {
                         tracing::error!("{:?} worker error: {:?}", self.kind(), err);


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Fix worker restart sleep by making `xmtp_db::errors::StorageError::db_needs_connection` match both platform and connection-wrapped pool disconnects
Broaden `xmtp_db::errors::StorageError::db_needs_connection` to return `true` for `Platform(PoolNeedsConnection)` and `Connection(Platform(PoolNeedsConnection))`, and lower the worker reconnect log to debug in [worker.rs](https://github.com/xmtp/libxmtp/pull/2897/files#diff-ea560e63ca633c03d1189957b9efca26de6aa33294f42c116a574e5bf259ce23).

#### 📍Where to Start
Start with `StorageError::db_needs_connection` in [errors.rs](https://github.com/xmtp/libxmtp/pull/2897/files#diff-c28554f6385bb1e08c2ed9656a3618cd1f29d58e5b8dc8729b083e84078261c8), then review the logging change in `Worker::spawn` in [worker.rs](https://github.com/xmtp/libxmtp/pull/2897/files#diff-ea560e63ca633c03d1189957b9efca26de6aa33294f42c116a574e5bf259ce23).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 2b4d733.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->