### PR TITLE
Save intent epoch from construction transaction

### DIFF
--- a/xmtp_mls/src/groups/mls_sync/update_group_membership.rs
+++ b/xmtp_mls/src/groups/mls_sync/update_group_membership.rs
@@ -75,7 +75,7 @@ async fn compute_publish_data_for_group_membership_update(
     signer: impl Signer,
 ) -> Result<PublishIntentData, GroupError> {
     // Use savepoint pattern to create commit without persisting state
-    let ((commit, maybe_welcome_message, _), staged_commit) =
+    let ((commit, maybe_welcome_message, _), staged_commit, group_epoch) =
         generate_commit_with_rollback(context.mls_storage(), openmls_group, |group, provider| {
             group.update_group_membership(
                 provider,
@@ -101,6 +101,7 @@ async fn compute_publish_data_for_group_membership_update(
         post_commit_action: post_commit_action.map(|action| action.to_bytes()),
         staged_commit: Some(staged_commit),
         should_send_push_notification: false,
+        group_epoch,
     })
 }
 

--- a/xmtp_mls/src/groups/tests/mod.rs
+++ b/xmtp_mls/src/groups/tests/mod.rs
@@ -5205,7 +5205,7 @@ async fn test_generate_commit_with_rollback() {
             )
             .unwrap();
             // Simulate mutable metadata update
-            let (_, _) = super::mls_sync::generate_commit_with_rollback(
+            let (_, _, _) = super::mls_sync::generate_commit_with_rollback(
                 group_provider,
                 &mut mls_group,
                 |group, provider| {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Record the group epoch at commit creation and persist it via `mls_sync.Group.sync` using the new `PublishIntentData.group_epoch: u64`
Add `group_epoch` to `PublishIntentData`, propagate it from commit/message creation (including via `mls_sync.generate_commit_with_rollback` now returning `(R, Option<Vec<u8>>, u64)`), and use it when saving published intents instead of reading the current group epoch.

#### 📍Where to Start
Start at `mls_sync.generate_commit_with_rollback` in [xmtp_mls/src/groups/mls_sync.rs](https://github.com/xmtp/libxmtp/pull/2903/files#diff-10f818f7918c8c0b2ed32c4f63e5060050527ed58df00ec081bbecb66065144e), then follow how `group_epoch` flows into `PublishIntentData` and is consumed in `mls_sync.Group.sync`.

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized d52eb98. 2 files reviewed, 5 issues evaluated, 4 issues filtered, 1 comment posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>xmtp_mls/src/groups/mls_sync.rs — 1 comment posted, 4 evaluated, 3 filtered</summary>

- [line 2131](https://github.com/xmtp/libxmtp/blob/d52eb986a468deb83be18c36eaf849dda29fb1e9/xmtp_mls/src/groups/mls_sync.rs#L2131): Intent state is set to `Published` in the database via `db.set_group_intent_published(..)` (lines 2131-2138) before attempting to build and send the network message (`prepare_group_messages` at line 2151 and `api().send_group_messages` at lines 2153-2155). If either message preparation or network send fails, the error propagates (`?`) and the function returns early with the intent already marked `Published`. Because `publish_intents` only selects intents in `ToPublish` state (lines 2083-2087), the intent will not be retried and becomes stuck in `Published` without having been successfully sent, causing a lost publish. Additionally, publish attempt counters and error state are only updated on failures from `get_publish_intent_data` (lines 2098-2115) and are not updated for failures during message preparation or sending, compounding the inconsistency. <b>[ Out of scope ]</b>
- [line 2136](https://github.com/xmtp/libxmtp/blob/d52eb986a468deb83be18c36eaf849dda29fb1e9/xmtp_mls/src/groups/mls_sync.rs#L2136): Potential lossy/overflowing cast: `group_epoch as i64` (line 2136) converts an unsigned epoch value to a signed 64-bit integer. If `group_epoch` exceeds `i64::MAX`, the `as` cast will wrap/two's-complement the value, storing a negative or otherwise incorrect epoch in the database. This can lead to ordering/logic errors wherever the stored epoch is used. There is no guard or checked conversion. <b>[ Previously rejected ]</b>
- [line 2978](https://github.com/xmtp/libxmtp/blob/d52eb986a468deb83be18c36eaf849dda29fb1e9/xmtp_mls/src/groups/mls_sync.rs#L2978): Serialization errors for the staged commit are swallowed and turned into `None`, losing the error cause. The code serializes `openmls_group.pending_commit()` via `xmtp_db::db_serialize`, then uses `.transpose().inspect_err(...).ok().flatten()`, which logs but converts any `Err` into `None`. Callers cannot distinguish "no pending commit" from "serialization failed", violating explicit error reporting and enabling silent data loss. Prefer propagating the serialization error (or returning a distinct error) instead of returning `None`. <b>[ Out of scope ]</b>
</details>

<details>
<summary>xmtp_mls/src/groups/mls_sync/update_group_membership.rs — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 94](https://github.com/xmtp/libxmtp/blob/d52eb986a468deb83be18c36eaf849dda29fb1e9/xmtp_mls/src/groups/mls_sync/update_group_membership.rs#L94): Possible silent data loss: `installations_to_add` is only used when `maybe_welcome_message` is `Some(...)`. If `maybe_welcome_message` is `None` while `installations_to_add` is non-empty, those installations are silently ignored (no error, no warning). This violates the expectation that all provided inputs reach a defined terminal effect. Consider asserting/validating that `installations_to_add` is empty when no welcome is produced, or otherwise emitting an explicit error or handling path. <b>[ Out of scope ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->