### PR TITLE
Use newer warpbuild runner

### DIFF
--- a/.github/workflows/release-swift-bindings-nix.yml
+++ b/.github/workflows/release-swift-bindings-nix.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
 jobs:
   build-macos:
-    runs-on: warp-macos-13-arm64-6x
+    runs-on: warp-macos-15-arm64-12x
     strategy:
       fail-fast: false
       matrix:
@@ -39,7 +39,7 @@ jobs:
           path: target/${{ matrix.target }}/release/libxmtpv3.a
           retention-days: 1
   swift:
-    runs-on: warp-macos-13-arm64-6x
+    runs-on: warp-macos-15-arm64-12x
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -67,7 +67,7 @@ jobs:
           retention-days: 1
   package-swift:
     needs: [build-macos, swift]
-    runs-on: warp-macos-13-arm64-6x
+    runs-on: warp-macos-15-arm64-12x
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/release-swift-bindings.yml
+++ b/.github/workflows/release-swift-bindings.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
 jobs:
   build-macos:
-    runs-on: warp-macos-13-arm64-6x
+    runs-on: warp-macos-15-arm64-12x
     strategy:
       fail-fast: false
       matrix:
@@ -23,6 +23,7 @@ jobs:
       - name: Cache
         uses: Swatinem/rust-cache@v2
         with:
+          prefix-key: "macos-15"
           workspaces: |
             .
             bindings_ffi
@@ -31,8 +32,19 @@ jobs:
       - name: Build target
         env:
           CROSS_NO_WARNINGS: "0"
-          IPHONEOS_DEPLOYMENT_TARGET: 10
+          IPHONEOS_DEPLOYMENT_TARGET: "10"
         run: |
+          # Set up SDK and clang paths based on target
+          if [[ "${{ matrix.target }}" == *"-ios-sim"* ]]; then
+            export SDKROOT=$(xcrun --sdk iphonesimulator --show-sdk-path)
+            export BINDGEN_EXTRA_CLANG_ARGS="--target=arm64-apple-ios-simulator -isysroot $SDKROOT"
+          elif [[ "${{ matrix.target }}" == *"-ios" ]]; then
+            export SDKROOT=$(xcrun --sdk iphoneos --show-sdk-path)
+            export BINDGEN_EXTRA_CLANG_ARGS="--target=arm64-apple-ios -isysroot $SDKROOT"
+          elif [[ "${{ matrix.target }}" == "x86_64-apple-ios" ]]; then
+            export SDKROOT=$(xcrun --sdk iphonesimulator --show-sdk-path)
+            export BINDGEN_EXTRA_CLANG_ARGS="--target=x86_64-apple-ios-simulator -isysroot $SDKROOT"
+          fi
           cross build --release --target ${{ matrix.target }} --manifest-path bindings_ffi/Cargo.toml
       - name: Upload binary
         uses: actions/upload-artifact@v5
@@ -43,7 +55,7 @@ jobs:
             target/${{ matrix.target }}/release/libxmtpv3.dylib
           retention-days: 1
   swift:
-    runs-on: warp-macos-13-arm64-6x
+    runs-on: warp-macos-15-arm64-12x
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -77,7 +89,7 @@ jobs:
           retention-days: 1
   package-swift:
     needs: [build-macos, swift]
-    runs-on: warp-macos-13-arm64-6x
+    runs-on: warp-macos-15-arm64-12x
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -102,7 +114,7 @@ jobs:
           if-no-files-found: error
   package-swift-dynamic:
     needs: [build-macos, swift]
-    runs-on: warp-macos-13-arm64-6x
+    runs-on: warp-macos-15-arm64-12x
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -127,7 +139,7 @@ jobs:
           if-no-files-found: error
   create-release:
     needs: [package-swift, package-swift-dynamic]
-    runs-on: warp-macos-13-arm64-6x
+    runs-on: warp-macos-15-arm64-12x
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/update-xmtp-ios.yml
+++ b/.github/workflows/update-xmtp-ios.yml
@@ -18,7 +18,7 @@ permissions:
   id-token: write
 jobs:
   update-xmtp-ios:
-    runs-on: warp-macos-13-arm64-6x
+    runs-on: warp-macos-15-arm64-6x
     steps:
       - name: Checkout libxmtp
         uses: actions/checkout@v5


### PR DESCRIPTION
## tl;dr

The MacOS 13 runner is quite slow. We don't need it. Upgrading to 15 lets us use M4 chips, which are about 4X faster than the MacOS 13 Intel chips. Does require a bit of a dance to set the right environment variables. 