### PR TITLE
make `Cursor` non-exhaustive

### DIFF
--- a/db_tools/src/tasks/db_bench.rs
+++ b/db_tools/src/tasks/db_bench.rs
@@ -216,15 +216,7 @@ where
             // Delivery status updates (non-destructive operations should be safe to benchmark)
             bench!(
                 self,
-                set_delivery_status_to_published(
-                    &message_id,
-                    0,
-                    Cursor {
-                        sequence_id: 0,
-                        originator_id: 0
-                    },
-                    None
-                )
+                set_delivery_status_to_published(&message_id, 0, Cursor::new(0, 0u32), None)
             )?;
             bench!(self, set_delivery_status_to_failed(&message_id))?;
         }
@@ -403,10 +395,7 @@ where
             update_cursor(
                 group.id.clone(),
                 EntityKind::ApplicationMessage,
-                Cursor {
-                    sequence_id: 0,
-                    originator_id: 0
-                }
+                Cursor::new(0, 0u32)
             )
         )?;
 

--- a/xmtp_api_d14n/src/protocol/extractors/cursor.rs
+++ b/xmtp_api_d14n/src/protocol/extractors/cursor.rs
@@ -40,10 +40,7 @@ impl EnvelopeVisitor<'_> for CursorExtractor {
         &mut self,
         e: &UnsignedOriginatorEnvelope,
     ) -> Result<(), Self::Error> {
-        self.cursor = Some(Cursor {
-            sequence_id: e.originator_sequence_id,
-            originator_id: e.originator_node_id,
-        });
+        self.cursor = Some(Cursor::new(e.originator_sequence_id, e.originator_node_id));
         Ok(())
     }
 

--- a/xmtp_api_d14n/src/protocol/extractors/group_messages.rs
+++ b/xmtp_api_d14n/src/protocol/extractors/group_messages.rs
@@ -55,10 +55,7 @@ impl EnvelopeVisitor<'_> for GroupMessageExtractor {
         &mut self,
         envelope: &UnsignedOriginatorEnvelope,
     ) -> Result<(), Self::Error> {
-        self.cursor = Cursor {
-            originator_id: envelope.originator_node_id,
-            sequence_id: envelope.originator_sequence_id,
-        };
+        self.cursor = Cursor::new(envelope.originator_sequence_id, envelope.originator_node_id);
         self.created_ns = DateTime::from_timestamp_nanos(envelope.originator_ns);
         Ok(())
     }
@@ -121,10 +118,7 @@ impl EnvelopeVisitor<'_> for V3GroupMessageExtractor {
             xmtp_configuration::Originators::APPLICATION_MESSAGES
         };
         group_message
-            .cursor(Cursor {
-                originator_id: originator_node_id,
-                sequence_id: message.id,
-            })
+            .cursor(Cursor::new(message.id, originator_node_id))
             .created_ns(DateTime::from_timestamp_nanos(message.created_ns as i64))
             .sender_hmac(message.sender_hmac.clone())
             .should_push(message.should_push)

--- a/xmtp_api_d14n/src/protocol/extractors/welcomes.rs
+++ b/xmtp_api_d14n/src/protocol/extractors/welcomes.rs
@@ -49,10 +49,7 @@ impl EnvelopeVisitor<'_> for WelcomeMessageExtractor {
         &mut self,
         envelope: &UnsignedOriginatorEnvelope,
     ) -> Result<(), Self::Error> {
-        self.cursor = Cursor {
-            originator_id: envelope.originator_node_id,
-            sequence_id: envelope.originator_sequence_id,
-        };
+        self.cursor = Cursor::new(envelope.originator_sequence_id, envelope.originator_node_id);
         self.created_ns = DateTime::from_timestamp_nanos(envelope.originator_ns);
         Ok(())
     }
@@ -112,10 +109,7 @@ impl EnvelopeVisitor<'_> for V3WelcomeMessageExtractor {
         let originator_node_id = xmtp_configuration::Originators::WELCOME_MESSAGES;
 
         self.welcome_message
-            .cursor(Cursor {
-                originator_id: originator_node_id,
-                sequence_id: message.id,
-            })
+            .cursor(Cursor::new(message.id, originator_node_id))
             .created_ns(DateTime::from_timestamp_nanos(message.created_ns as i64))
             .variant(
                 WelcomeMessageV1::builder()
@@ -135,10 +129,7 @@ impl EnvelopeVisitor<'_> for V3WelcomeMessageExtractor {
     ) -> Result<(), Self::Error> {
         let originator_node_id = xmtp_configuration::Originators::WELCOME_MESSAGES;
         self.welcome_message
-            .cursor(Cursor {
-                originator_id: originator_node_id,
-                sequence_id: message.id,
-            })
+            .cursor(Cursor::new(message.id, originator_node_id))
             .created_ns(DateTime::from_timestamp_nanos(message.created_ns as i64))
             .variant(
                 WelcomePointer::builder()
@@ -184,13 +175,7 @@ mod tests {
         let welcome_message = extractor.get();
 
         let msg = welcome_message.unwrap();
-        assert_eq!(
-            msg.cursor,
-            Cursor {
-                sequence_id: 456,
-                originator_id: 123
-            }
-        );
+        assert_eq!(msg.cursor, Cursor::new(456u64, 123u32));
         assert_eq!(msg.created_ns.timestamp_nanos_opt().unwrap(), 789);
         let v1 = msg.as_v1().unwrap();
         assert_eq!(v1.installation_key, installation_key);

--- a/xmtp_api_d14n/src/protocol/traits/cursor_store.rs
+++ b/xmtp_api_d14n/src/protocol/traits/cursor_store.rs
@@ -71,10 +71,7 @@ pub trait CursorStore: MaybeSend + MaybeSync {
         let sid = self
             .latest_per_originator(topic, &[originator])?
             .get(originator);
-        Ok(Cursor {
-            originator_id: *originator,
-            sequence_id: sid,
-        })
+        Ok(Cursor::new(sid, *originator))
     }
 
     /// Get the latest cursor for multiple topics at once.

--- a/xmtp_api_d14n/src/protocol/utils/test/dependency_resolution_test.rs
+++ b/xmtp_api_d14n/src/protocol/utils/test/dependency_resolution_test.rs
@@ -146,13 +146,7 @@ pub fn create_missing_set(topic: Topic, cursors: Vec<(u32, u64)>) -> HashSet<Mis
     cursors
         .into_iter()
         .map(|(originator_id, sequence_id)| {
-            MissingEnvelope::new(
-                topic.clone(),
-                Cursor {
-                    originator_id,
-                    sequence_id,
-                },
-            )
+            MissingEnvelope::new(topic.clone(), Cursor::new(sequence_id, originator_id))
         })
         .collect()
 }

--- a/xmtp_api_d14n/src/protocol/utils/test/props.rs
+++ b/xmtp_api_d14n/src/protocol/utils/test/props.rs
@@ -63,10 +63,7 @@ pub fn sorted_dependencies(
                             let sequence_id = advance_clock(&total_clock, &originator);
 
                             envelopes.push(TestEnvelope {
-                                cursor: Cursor {
-                                    originator_id: originator,
-                                    sequence_id,
-                                },
+                                cursor: Cursor::new(sequence_id, originator),
                                 depends_on: new_clock,
                             });
                             envelopes

--- a/xmtp_api_d14n/src/queries/d14n/test/send_group_message.rs
+++ b/xmtp_api_d14n/src/queries/d14n/test/send_group_message.rs
@@ -78,10 +78,7 @@ prop_compose! {
 // request containing potentially many group messages
 prop_compose! {
     pub fn cursor_gen()(sid in 0u64..1000, oid in 0u32..40) -> Cursor {
-        Cursor {
-            sequence_id: sid,
-            originator_id: oid
-        }
+        Cursor::new(sid, oid)
     }
 }
 prop_compose! {

--- a/xmtp_db/src/encrypted_store/group.rs
+++ b/xmtp_db/src/encrypted_store/group.rs
@@ -130,10 +130,7 @@ impl StoredGroup {
         if let Some(sequence_id) = self.sequence_id
             && let Some(originator) = self.originator_id
         {
-            return Some(Cursor {
-                sequence_id: sequence_id as u64,
-                originator_id: originator as u32,
-            });
+            return Some(Cursor::new(sequence_id as u64, originator as u32));
         }
         None
     }
@@ -953,10 +950,11 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
                 .select((dsl::sequence_id, dsl::originator_id))
                 .load::<(Option<i64>, Option<i64>)>(conn)?
                 .into_iter()
-                .map(|(seq, orig)| Cursor {
-                    sequence_id: seq.expect("Filtered for not null") as u64,
-                    originator_id: orig.expect("if seq is not null, originator must not be null")
-                        as u32,
+                .map(|(seq, orig)| {
+                    Cursor::new(
+                        seq.expect("Filtered for not null") as u64,
+                        orig.expect("if seq is not null, originator must not be null") as u32,
+                    )
                 })
                 .collect())
         })

--- a/xmtp_db/src/encrypted_store/group_intent.rs
+++ b/xmtp_db/src/encrypted_store/group_intent.rs
@@ -542,10 +542,7 @@ impl<C: ConnectionExt> QueryGroupIntent for DbConnection<C> {
                     (
                         PayloadHash::from(hash),
                         IntentDependency {
-                            cursor: Cursor {
-                                sequence_id: sequence_id as u64,
-                                originator_id: originator_id as u32,
-                            },
+                            cursor: Cursor::new(sequence_id as u64, originator_id as u32),
                             group_id: group_id.into(),
                         },
                     )
@@ -1056,10 +1053,7 @@ pub(crate) mod tests {
             conn.update_cursor(
                 group_id.clone(),
                 EntityKind::CommitMessage,
-                Cursor {
-                    sequence_id: 100,
-                    originator_id: 42,
-                },
+                Cursor::new(100, 42u32),
             )
             .unwrap();
 

--- a/xmtp_db/src/encrypted_store/group_message.rs
+++ b/xmtp_db/src/encrypted_store/group_message.rs
@@ -80,10 +80,7 @@ pub struct StoredGroupMessage {
 
 impl StoredGroupMessage {
     pub fn cursor(&self) -> Cursor {
-        Cursor {
-            sequence_id: self.sequence_id as u64,
-            originator_id: self.originator_id as u32,
-        }
+        Cursor::new(self.sequence_id as u64, self.originator_id as u32)
     }
 }
 
@@ -1327,10 +1324,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
             })?;
 
             for (originator_id, sequence_id) in messages {
-                all_cursors.push(Cursor {
-                    sequence_id: sequence_id as u64,
-                    originator_id: originator_id as u32,
-                });
+                all_cursors.push(Cursor::new(sequence_id as u64, originator_id as u32));
             }
         }
 

--- a/xmtp_db/src/encrypted_store/migration_test/originator_id_refresh_state.rs
+++ b/xmtp_db/src/encrypted_store/migration_test/originator_id_refresh_state.rs
@@ -6,7 +6,7 @@ use crate::group::QueryGroup;
 use crate::identity_update::StoredIdentityUpdate;
 use crate::prelude::QueryIdentityUpdates;
 use crate::{prelude::QueryRefreshState, refresh_state::EntityKind};
-use xmtp_proto::types::Cursor;
+use xmtp_proto::types::{Cursor, OriginatorId, SequenceId};
 
 use super::*;
 
@@ -175,10 +175,10 @@ async fn up_identity_updates() {
         .unwrap();
 
     let cursor = cursor.last().unwrap();
-    let cursor = Cursor {
-        sequence_id: cursor.sequence_id as u64,
-        originator_id: cursor.originator_id as u32,
-    };
+    let cursor = Cursor::new(
+        cursor.sequence_id as SequenceId,
+        cursor.originator_id as OriginatorId,
+    );
     assert_eq!(
         cursor,
         Cursor::inbox_log(2),

--- a/xmtp_db/src/encrypted_store/refresh_state.rs
+++ b/xmtp_db/src/encrypted_store/refresh_state.rs
@@ -343,10 +343,7 @@ impl<C: ConnectionExt> QueryRefreshState for DbConnection<C> {
         let result: Vec<Cursor> = originator_ids
             .iter()
             .map(|originator| match state_map.get(originator) {
-                Some(state) => Cursor {
-                    sequence_id: state.sequence_id as u64,
-                    originator_id: state.originator_id as u32,
-                },
+                Some(state) => Cursor::new(state.sequence_id as u64, state.originator_id as u32),
                 None => Cursor::new(0, *originator),
             })
             .collect();
@@ -791,10 +788,7 @@ pub(crate) mod tests {
             assert_eq!(
                 conn.get_last_cursor_for_originator(&id, kind, Originators::MLS_COMMITS)
                     .unwrap(),
-                Cursor {
-                    sequence_id: 0,
-                    originator_id: Originators::MLS_COMMITS
-                }
+                Cursor::mls_commits(0)
             );
             let entry: Option<RefreshState> = conn
                 .get_refresh_state(&id, kind, Originators::MLS_COMMITS)
@@ -815,10 +809,7 @@ pub(crate) mod tests {
             assert_eq!(
                 conn.get_last_cursor_for_originators(&id, kind, &[0])
                     .unwrap()[0],
-                Cursor {
-                    sequence_id: 0,
-                    originator_id: Originators::MLS_COMMITS
-                }
+                Cursor::mls_commits(0)
             );
             let entry: Option<RefreshState> = conn
                 .get_refresh_state(&id, kind, Originators::MLS_COMMITS)
@@ -842,10 +833,7 @@ pub(crate) mod tests {
             assert_eq!(
                 conn.get_last_cursor_for_originator(&id, entity_kind, Originators::MLS_COMMITS)
                     .unwrap(),
-                Cursor {
-                    sequence_id: 123,
-                    originator_id: Originators::MLS_COMMITS
-                }
+                Cursor::mls_commits(123)
             );
         })
     }

--- a/xmtp_mls/src/groups/tests/mod.rs
+++ b/xmtp_mls/src/groups/tests/mod.rs
@@ -5135,10 +5135,7 @@ async fn non_retryable_error_increments_cursor() {
     // making us actually return the message as already processed, since it loops back to 0,
     // thereby less than group cursor. Thats why we take i64 max before casting to u64, rather than
     // u64::MAX.
-    let new_cursor = Cursor {
-        sequence_id: (i64::MAX - 1_000) as u64,
-        originator_id: Originators::MLS_COMMITS,
-    };
+    let new_cursor = Cursor::mls_commits((i64::MAX - 1_000) as u64);
 
     let message = xmtp_proto::types::GroupMessage {
         cursor: new_cursor,

--- a/xmtp_mls/src/groups/welcome_sync.rs
+++ b/xmtp_mls/src/groups/welcome_sync.rs
@@ -496,34 +496,19 @@ mod tests {
             .context(context)
             .database_calls(|db: &mut MockDbQuery| {
                 db.expect_get_last_cursor_for_originators()
-                    .returning(|_id, _entity, _| {
-                        Ok(vec![Cursor {
-                            sequence_id: 0,
-                            originator_id: Originators::WELCOME_MESSAGES,
-                        }])
-                    });
+                    .returning(|_id, _entity, _| Ok(vec![Cursor::v3_welcomes(0)]));
                 db.expect_find_group().returning(|_id| Ok(None));
             })
             // outer tx
             .transaction_calls(|db: &mut MockDbQuery| {
                 db.expect_get_last_cursor_for_originators()
-                    .returning(|_id, _entity, _| {
-                        Ok(vec![Cursor {
-                            sequence_id: 0,
-                            originator_id: Originators::WELCOME_MESSAGES,
-                        }])
-                    });
+                    .returning(|_id, _entity, _| Ok(vec![Cursor::v3_welcomes(0)]));
             })
             // inner tx
             .nested_transaction_calls(|db: &mut MockDbQuery| {
                 db.expect_find_group().returning(|_id| Ok(None));
                 db.expect_get_last_cursor_for_originators()
-                    .returning(|_id, _entity, _| {
-                        Ok(vec![Cursor {
-                            sequence_id: 0,
-                            originator_id: Originators::WELCOME_MESSAGES,
-                        }])
-                    });
+                    .returning(|_id, _entity, _| Ok(vec![Cursor::v3_welcomes(0)]));
                 db.expect_update_cursor().returning(|_, _, _| Ok(true));
                 db.expect_update_responded_at_sequence_id()
                     .returning(|_, _, _| Ok(()));
@@ -567,13 +552,7 @@ mod tests {
                 db.expect_update_cursor()
                     .once()
                     .returning(|_id, entity, cursor| {
-                        assert_eq!(
-                            cursor,
-                            Cursor {
-                                sequence_id: 50,
-                                originator_id: Originators::WELCOME_MESSAGES
-                            }
-                        );
+                        assert_eq!(cursor, Cursor::v3_welcomes(50));
                         assert_eq!(entity, EntityKind::Welcome);
                         Ok(true)
                     });
@@ -581,12 +560,7 @@ mod tests {
             .database_calls(|db: &mut MockDbQuery| {
                 db.expect_get_last_cursor_for_originators()
                     .once()
-                    .returning(|_id, _entity, _| {
-                        Ok(vec![Cursor {
-                            sequence_id: 0,
-                            originator_id: Originators::WELCOME_MESSAGES,
-                        }])
-                    });
+                    .returning(|_id, _entity, _| Ok(vec![Cursor::v3_welcomes(0)]));
                 db.expect_find_group().once().returning(|_id| Ok(None));
             })
             .mem(mem)
@@ -641,12 +615,7 @@ mod tests {
             .database_calls(|db: &mut MockDbQuery| {
                 db.expect_get_last_cursor_for_originators()
                     .once()
-                    .returning(|_id, _entity, _| {
-                        Ok(vec![Cursor {
-                            sequence_id: 0,
-                            originator_id: Originators::WELCOME_MESSAGES,
-                        }])
-                    });
+                    .returning(|_id, _entity, _| Ok(vec![Cursor::v3_welcomes(0)]));
                 db.expect_update_cursor()
                     .once()
                     .returning(|_, _, _| Ok(true));
@@ -680,12 +649,7 @@ mod tests {
             .nested_transaction_calls(|db: &mut MockDbQuery| {
                 db.expect_find_group().returning(|_id| Ok(None));
                 db.expect_get_last_cursor_for_originators()
-                    .returning(|_id, _entity, _| {
-                        Ok(vec![Cursor {
-                            sequence_id: 0,
-                            originator_id: Originators::WELCOME_MESSAGES,
-                        }])
-                    });
+                    .returning(|_id, _entity, _| Ok(vec![Cursor::v3_welcomes(0)]));
                 db.expect_update_cursor().returning(|_, _, _| Ok(true));
                 db.expect_insert_or_replace_group().returning(Ok);
             })
@@ -693,13 +657,7 @@ mod tests {
                 db.expect_update_cursor()
                     .once()
                     .returning(|_id, entity, cursor| {
-                        assert_eq!(
-                            cursor,
-                            Cursor {
-                                sequence_id: 50,
-                                originator_id: Originators::WELCOME_MESSAGES
-                            }
-                        );
+                        assert_eq!(cursor, Cursor::v3_welcomes(50));
                         assert_eq!(entity, EntityKind::Welcome);
                         Ok(true)
                     });
@@ -709,14 +667,7 @@ mod tests {
                 db.expect_update_cursor()
                     .once()
                     .returning(|_id, entity, cursor| {
-                        let originator_id = 0;
-                        assert_eq!(
-                            cursor,
-                            Cursor {
-                                sequence_id: 10,
-                                originator_id,
-                            }
-                        );
+                        assert_eq!(cursor, Cursor::new(10, 0u32));
                         assert_eq!(entity, EntityKind::CommitMessage);
                         Ok(true)
                     });
@@ -724,12 +675,7 @@ mod tests {
             .database_calls(|db: &mut MockDbQuery| {
                 db.expect_get_last_cursor_for_originators()
                     .once()
-                    .returning(|_id, _entity, _| {
-                        Ok(vec![Cursor {
-                            sequence_id: 0,
-                            originator_id: Originators::WELCOME_MESSAGES,
-                        }])
-                    });
+                    .returning(|_id, _entity, _| Ok(vec![Cursor::v3_welcomes(0)]));
                 db.expect_find_group().once().returning(|_id| Ok(None));
             })
             .mem(mem)
@@ -769,12 +715,7 @@ mod tests {
             .database_calls(|db: &mut MockDbQuery| {
                 db.expect_get_last_cursor_for_originators()
                     .once()
-                    .returning(|_id, _entity, _| {
-                        Ok(vec![Cursor {
-                            sequence_id: 0,
-                            originator_id: Originators::WELCOME_MESSAGES,
-                        }])
-                    });
+                    .returning(|_id, _entity, _| Ok(vec![Cursor::v3_welcomes(0)]));
             })
             .mem(mem)
             .build();
@@ -800,10 +741,7 @@ mod tests {
     ) -> GroupMessageMetadata {
         use chrono::Utc;
         GroupMessageMetadata::builder()
-            .cursor(Cursor {
-                originator_id,
-                sequence_id,
-            })
+            .cursor(Cursor::new(sequence_id, originator_id))
             .created_ns(Utc::now())
             .group_id(group_id)
             .build()

--- a/xmtp_mls/src/subscriptions/process_message.rs
+++ b/xmtp_mls/src/subscriptions/process_message.rs
@@ -131,13 +131,10 @@ mod tests {
         let mut mock_syncer = MockSync::new();
         let mut mock_db = MockGroupDatabase::new();
         let oid = current_message.originator_id();
-        mock_db.expect_last_cursor().times(1).returning(move |_| {
-            Ok(Cursor {
-                sequence_id: 3,
-                originator_id: oid,
-            }
-            .into())
-        });
+        mock_db
+            .expect_last_cursor()
+            .times(1)
+            .returning(move |_| Ok(Cursor::new(3, oid).into()));
         mock_db.expect_msg().times(1).returning(|_, _| Ok(None));
         mock_syncer
             .expect_process()
@@ -177,13 +174,10 @@ mod tests {
         let mut mock_db = MockGroupDatabase::new();
         let oid = current_message.originator_id();
         // the last cursor is
-        mock_db.expect_last_cursor().times(1).returning(move |_| {
-            Ok(Cursor {
-                sequence_id: 50,
-                originator_id: oid,
-            }
-            .into())
-        });
+        mock_db
+            .expect_last_cursor()
+            .times(1)
+            .returning(move |_| Ok(Cursor::new(50, oid).into()));
         mock_db.expect_msg().times(1).returning(|_, _| Ok(None));
         mock_syncer
             .expect_process()
@@ -216,13 +210,10 @@ mod tests {
         let mock_syncer = MockSync::new();
         let mut mock_db = MockGroupDatabase::new();
         let oid = current_message.originator_id();
-        mock_db.expect_last_cursor().times(1).returning(move |_| {
-            Ok(Cursor {
-                sequence_id: 100,
-                originator_id: oid,
-            }
-            .into())
-        });
+        mock_db
+            .expect_last_cursor()
+            .times(1)
+            .returning(move |_| Ok(Cursor::new(100, oid).into()));
         let mocked_m = message.clone();
         mock_db
             .expect_msg()

--- a/xmtp_mls/src/subscriptions/process_welcome.rs
+++ b/xmtp_mls/src/subscriptions/process_welcome.rs
@@ -8,6 +8,8 @@ use crate::{groups::MlsGroup, subscriptions::WelcomeOrGroup};
 use std::collections::HashSet;
 use xmtp_common::{Retry, retry_async};
 use xmtp_db::{consent_record::ConsentState, group::ConversationType, prelude::*};
+use xmtp_proto::types::OriginatorId;
+use xmtp_proto::types::SequenceId;
 use xmtp_proto::types::{Cursor, WelcomeMessage};
 
 /// Future for processing `WelcomeorGroup`
@@ -272,10 +274,7 @@ where
                     && let Some(originator) = maybe_originator
                 {
                     Ok(ProcessWelcomeResult::IgnoreId {
-                        id: Cursor {
-                            sequence_id: id as u64,
-                            originator_id: originator as u32,
-                        },
+                        id: Cursor::new(id as SequenceId, originator as OriginatorId),
                     })
                 } else {
                     Ok(ProcessWelcomeResult::Ignore)

--- a/xmtp_mls/src/subscriptions/stream_conversations.rs
+++ b/xmtp_mls/src/subscriptions/stream_conversations.rs
@@ -19,7 +19,7 @@ use tokio_stream::wrappers::BroadcastStream;
 use xmtp_common::{BoxDynFuture, MaybeSend};
 use xmtp_db::prelude::*;
 use xmtp_proto::api_client::XmtpMlsStreams;
-use xmtp_proto::types::{Cursor, WelcomeMessage};
+use xmtp_proto::types::{Cursor, OriginatorId, SequenceId, WelcomeMessage};
 
 #[derive(thiserror::Error, Debug)]
 pub enum ConversationStreamError {
@@ -399,10 +399,8 @@ where
                 if let Some(id) = maybe_sequence_id
                     && let Some(originator) = maybe_originator
                 {
-                    this.known_welcome_ids.insert(Cursor {
-                        originator_id: originator as u32,
-                        sequence_id: id as u64,
-                    });
+                    this.known_welcome_ids
+                        .insert(Cursor::new(id as SequenceId, originator as OriginatorId));
                 }
                 Some(Ok(group))
             }

--- a/xmtp_mls/src/subscriptions/stream_messages.rs
+++ b/xmtp_mls/src/subscriptions/stream_messages.rs
@@ -28,7 +28,7 @@ use std::{
 };
 use xmtp_common::BoxDynFuture;
 use xmtp_db::group_message::StoredGroupMessage;
-use xmtp_proto::types::{Cursor, GlobalCursor};
+use xmtp_proto::types::{Cursor, GlobalCursor, OriginatorId, SequenceId};
 use xmtp_proto::types::{GroupId, Topic};
 use xmtp_proto::{api_client::XmtpMlsStreams, types::TopicCursor};
 
@@ -259,10 +259,7 @@ where
         Ok((
             stream,
             new_group,
-            Some(Cursor {
-                sequence_id: 1,
-                originator_id: 0,
-            }),
+            Some(Cursor::new(1 as SequenceId, 0 as OriginatorId)),
         ))
     }
 }
@@ -508,10 +505,10 @@ where
             );
             let this = self.as_mut().project();
             if let Some(msg) = processed.message {
-                this.returned.push(Cursor {
-                    sequence_id: msg.sequence_id as u64,
-                    originator_id: msg.originator_id as u32,
-                });
+                this.returned.push(Cursor::new(
+                    msg.sequence_id as SequenceId,
+                    msg.originator_id as OriginatorId,
+                ));
                 self.as_mut()
                     .set_cursor(msg.group_id.as_slice(), processed.next_message);
                 tracing::trace!(

--- a/xmtp_mls/src/test/mock/generate.rs
+++ b/xmtp_mls/src/test/mock/generate.rs
@@ -83,10 +83,7 @@ pub fn generate_errored_summary(error_cursors: &[u64], successful_cursors: &[u64
                     .iter()
                     .copied()
                     .chain(successful_cursors.iter().copied())
-                    .map(|c| Cursor {
-                        sequence_id: c,
-                        originator_id: xmtp_configuration::Originators::APPLICATION_MESSAGES,
-                    }),
+                    .map(Cursor::v3_messages),
             ),
             new_messages: generate_messages_with_ids(successful_cursors)
                 .iter()

--- a/xmtp_proto/src/types/cursor.rs
+++ b/xmtp_proto/src/types/cursor.rs
@@ -9,10 +9,14 @@ use crate::xmtp::xmtpv4;
 
 /// XMTP cursor type
 /// represents a position in an ordered sequence of messages, belonging
+// force use of the `new` constructor w/ non_exhaustive
+// so we retain some control of the internal structure/use of this type
+// and disallow ad-hoc construction
+// while still allowing access to fields with `.field` notation
+#[non_exhaustive]
 #[derive(
     Default, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
 )]
-// _*NOTE:*_ comparing cursors is unsafe/undefined behavior if originator ids are not equal.
 pub struct Cursor {
     pub sequence_id: super::SequenceId,
     pub originator_id: super::OriginatorId,


### PR DESCRIPTION
just a QoL change that removes some lines and allows more assumptions to be made in `Cursor` type implementation