### PR TITLE
Remove dynamic library bindings from update xmtp-ios PR

### DIFF
--- a/.github/workflows/update-xmtp-ios.yml
+++ b/.github/workflows/update-xmtp-ios.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to use (e.g. swift-bindings-0.1.0.abc1234 or swift-bindings-dynamic-0.1.0.abc1234)"
+        description: "Tag to use (e.g. swift-bindings-0.1.0.abc1234)"
         required: true
       xmtp_ios_branch:
         description: "xmtp-ios branch to base PR off of (default: main)"
@@ -103,8 +103,6 @@ jobs:
           # Fetch the static checksum from the release description
           RELEASE_TAG="${{ steps.version_info.outputs.release_tag }}"
           STATIC_CHECKSUM=$(gh release --repo xmtp/libxmtp view $RELEASE_TAG --json assets --jq '.assets[] | select(.name == "LibXMTPSwiftFFI.sha256") | .url')
-          DYNAMIC_CHECKSUM=$(gh release --repo xmtp/libxmtp view $RELEASE_TAG --json assets --jq '.assets[] | select(.name == "LibXMTPSwiftFFIDynamic.sha256") | .url')
-          DYNAMIC_CHECKSUM=$(curl -s -L "$DYNAMIC_CHECKSUM")
           STATIC_CHECKSUM=$(curl -s -L "$STATIC_CHECKSUM")
 
           # Verify we got a valid static checksum
@@ -113,14 +111,7 @@ jobs:
             exit 1
           fi
 
-          # Verify we got a valid dynamic checksum
-          if [[ ! $DYNAMIC_CHECKSUM =~ ^[a-f0-9]+$ ]]; then
-            echo "Failed to extract valid dynamic checksum from release description"
-            exit 1
-          fi
-
           echo "static_checksum=${STATIC_CHECKSUM}" >> $GITHUB_OUTPUT
-          echo "dynamic_checksum=${DYNAMIC_CHECKSUM}" >> $GITHUB_OUTPUT
       - name: Update Package.swift
         env:
           GH_TOKEN: ${{ secrets.LIBXMTP_SWIFT_PAT }}
@@ -128,21 +119,13 @@ jobs:
           cd xmtp-ios
           RELEASE_TAG="${{ steps.version_info.outputs.release_tag }}"
           STATIC_RELEASE_URL=$(gh release --repo xmtp/libxmtp view $RELEASE_TAG --json assets -q '.assets[] | select(.name == "LibXMTPSwiftFFI.zip") | .url')
-          DYN_RELEASE_URL=$(gh release --repo xmtp/libxmtp view $RELEASE_TAG --json assets -q '.assets[] | select(.name == "LibXMTPSwiftFFIDynamic.zip") | .url')
           STATIC_CHECKSUM="${{ steps.get_checksums.outputs.static_checksum }}"
-          DYNAMIC_CHECKSUM="${{ steps.get_checksums.outputs.dynamic_checksum }}"
 
           # Update static binary target (LibXMTPSwiftFFI)
           # Find and replace the URL for LibXMTPSwiftFFI
           sed -i '' "/name: \"LibXMTPSwiftFFI\"/,/checksum:/ {
             s|\"https://github.com/xmtp/libxmtp/releases/download/[^\"]*\"|\"${STATIC_RELEASE_URL}\"|
             s|checksum:[[:space:]]*\"[a-f0-9]*\"|checksum: \"${STATIC_CHECKSUM}\"|
-          }" Package.swift
-          # Update dynamic binary target (LibXMTPSwiftFFIDynamic)
-          # Find and replace the URL for LibXMTPSwiftFFIDynamic
-          sed -i '' "/name: \"LibXMTPSwiftFFIDynamic\"/,/checksum:/ {
-            s|\"https://github.com/xmtp/libxmtp/releases/download/[^\"]*\"|\"${DYN_RELEASE_URL}\"|
-            s|checksum:[[:space:]]*\"[a-f0-9]*\"|checksum: \"${DYNAMIC_CHECKSUM}\"|
           }" Package.swift
       - name: Download and extract Swift sources
         env:
@@ -151,7 +134,6 @@ jobs:
           RELEASE_TAG="${{ steps.version_info.outputs.release_tag }}"
           # Download the static LibXMTPSwiftFFI.zip file
           STATIC_RELEASE_URL=$(gh release --repo xmtp/libxmtp view $RELEASE_TAG --json assets -q '.assets[] | select(.name == "LibXMTPSwiftFFI.zip") | .url')
-          DYN_RELEASE_URL=$(gh release --repo xmtp/libxmtp view $RELEASE_TAG --json assets -q '.assets[] | select(.name == "LibXMTPSwiftFFIDynamic.zip") | .url')
 
           curl -L -o LibXMTPSwiftFFI.zip "$STATIC_RELEASE_URL"
 
@@ -170,29 +152,8 @@ jobs:
           mkdir -p xmtp-ios/Sources/XMTPiOS/Libxmtp
           cp Sources/LibXMTP/xmtpv3.swift xmtp-ios/Sources/XMTPiOS/Libxmtp/
 
-          # Clean up the static extracted files
+          # Clean up the extracted files
           rm -rf LibXMTPSwiftFFI.zip Sources LibXMTPSwiftFFI.xcframework LICENSE
-
-          # Download the dynamic LibXMTPSwiftFFIDynamic.zip file
-          curl -L -o LibXMTPSwiftFFIDynamic.zip "$DYN_RELEASE_URL"
-
-          # Extract the dynamic zip file
-          unzip -q LibXMTPSwiftFFIDynamic.zip
-
-          # Verify the expected structure exists for dynamic
-          if [[ ! -f "Sources/LibXMTP/Dynamic/xmtpv3.swift" ]]; then
-            echo "Error: Expected dynamic Swift source file not found in extracted archive"
-            echo "Archive contents:"
-            find . -name "*.swift" -type f
-            exit 1
-          fi
-
-          # Copy the dynamic Swift source file to xmtp-ios
-          mkdir -p xmtp-ios/Sources/XMTPiOSDynamic/Libxmtp
-          cp Sources/LibXMTP/Dynamic/xmtpv3.swift xmtp-ios/Sources/XMTPiOSDynamic/Libxmtp/
-
-          # Clean up the dynamic extracted files
-          rm -rf LibXMTPSwiftFFIDynamic.zip Sources LibXMTPSwiftFFIDynamic.xcframework LICENSE
 
       - name: Commit and push changes
         run: |
@@ -214,8 +175,7 @@ jobs:
 
           Changes:
           - Updated XMTP.podspec version to ${{ steps.version_info.outputs.version }}
-          - Updated static binary (LibXMTPSwiftFFI) URL and checksum in Package.swift
-          - Updated dynamic binary (LibXMTPSwiftFFIDynamic) URL and checksum in Package.swift
-          - Updated Swift source files (xmtpv3.swift) for both static and dynamic bindings
+          - Updated binary (LibXMTPSwiftFFI) URL and checksum in Package.swift
+          - Updated Swift source file (xmtpv3.swift)
 
           Base branch: ${BASE_BRANCH}"


### PR DESCRIPTION
Dynamic library package will be pulled from separate release action in xmtp-ios. See https://github.com/xmtp/xmtp-ios/pull/640