### PR TITLE
proptest d14n-ordered stream

### DIFF
--- a/xmtp_api_d14n/proptest-regressions/queries/stream/ordered.txt
+++ b/xmtp_api_d14n/proptest-regressions/queries/stream/ordered.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 54b4e5cd94ba34e3a7fab6b8944891b750609d31c6797f334542d49f559c086a # shrinks to envelopes = EnvelopesWithMissing { removed: [TestEnvelope { sequence_id: 1, originator_id: 10, depends_on: GlobalCursor { inner: {} } }], envelopes: [TestEnvelope { sequence_id: 2, originator_id: 10, depends_on: GlobalCursor { inner: {10: 1} } }, TestEnvelope { sequence_id: 3, originator_id: 10, depends_on: GlobalCursor { inner: {10: 2} } }, TestEnvelope { sequence_id: 1, originator_id: 20, depends_on: GlobalCursor { inner: {10: 3} } }, TestEnvelope { sequence_id: 1, originator_id: 30, depends_on: GlobalCursor { inner: {10: 3, 20: 1} } }, TestEnvelope { sequence_id: 2, originator_id: 20, depends_on: GlobalCursor { inner: {20: 1} } }, TestEnvelope { sequence_id: 2, originator_id: 30, depends_on: GlobalCursor { inner: {30: 1} } }, TestEnvelope { sequence_id: 4, originator_id: 10, depends_on: GlobalCursor { inner: {10: 3, 20: 2, 30: 2} } }, TestEnvelope { sequence_id: 3, originator_id: 30, depends_on: GlobalCursor { inner: {10: 4, 20: 2, 30: 2} } }, TestEnvelope { sequence_id: 3, originator_id: 20, depends_on: GlobalCursor { inner: {10: 4, 20: 2, 30: 3} } }] }

--- a/xmtp_api_d14n/src/protocol/mod.rs
+++ b/xmtp_api_d14n/src/protocol/mod.rs
@@ -24,3 +24,6 @@ mod order;
 pub use order::*;
 
 mod utils;
+
+#[cfg(test)]
+pub use utils::test;


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add proptest regression for ordered stream and expose `crate::protocol::test` during tests to validate stream ordering d14n
Add a regression seed file for the ordered stream property test and introduce a test-only re-export `crate::protocol::test`. Implement a proptest `orders_stream_and_ices_missing` in [xmtp_api_d14n/src/queries/stream/ordered.rs](https://github.com/xmtp/libxmtp/pull/2933/files#diff-59cd7abcfecc1658fc695f54e7da04f764862629dabf0aa0e4fafc684c6e732e) that verifies topic clock dominance and asserts non-empty icebox when dependencies are missing.

#### 📍Where to Start
Start with the `orders_stream_and_ices_missing` property test in [xmtp_api_d14n/src/queries/stream/ordered.rs](https://github.com/xmtp/libxmtp/pull/2933/files#diff-59cd7abcfecc1658fc695f54e7da04f764862629dabf0aa0e4fafc684c6e732e).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 0c8cf67.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->