### PR TITLE
avoid cloning TopicCursor on every streamed message

### DIFF
--- a/xmtp_api_d14n/src/protocol/traits/cursor_store.rs
+++ b/xmtp_api_d14n/src/protocol/traits/cursor_store.rs
@@ -223,6 +223,53 @@ impl<T: CursorStore + ?Sized> CursorStore for &T {
     }
 }
 
+impl<T: CursorStore + ?Sized> CursorStore for &mut T {
+    fn lowest_common_cursor(&self, topics: &[&Topic]) -> Result<GlobalCursor, CursorStoreError> {
+        (**self).lowest_common_cursor(topics)
+    }
+
+    fn latest(&self, topic: &Topic) -> Result<GlobalCursor, CursorStoreError> {
+        (**self).latest(topic)
+    }
+
+    fn latest_per_originator(
+        &self,
+        topic: &Topic,
+        originators: &[&OriginatorId],
+    ) -> Result<GlobalCursor, CursorStoreError> {
+        (**self).latest_per_originator(topic, originators)
+    }
+
+    fn latest_for_topics(
+        &self,
+        topics: &mut dyn Iterator<Item = &Topic>,
+    ) -> Result<HashMap<Topic, GlobalCursor>, CursorStoreError> {
+        (**self).latest_for_topics(topics)
+    }
+
+    fn lcc_maybe_missing(&self, topic: &[&Topic]) -> Result<GlobalCursor, CursorStoreError> {
+        (**self).lcc_maybe_missing(topic)
+    }
+
+    fn find_message_dependencies(
+        &self,
+        hashes: &[&[u8]],
+    ) -> Result<HashMap<Vec<u8>, Cursor>, CursorStoreError> {
+        (**self).find_message_dependencies(hashes)
+    }
+
+    fn ice(&self, orphans: Vec<OrphanedEnvelope>) -> Result<(), CursorStoreError> {
+        (**self).ice(orphans)
+    }
+
+    fn resolve_children(
+        &self,
+        cursors: &[Cursor],
+    ) -> Result<Vec<OrphanedEnvelope>, CursorStoreError> {
+        (**self).resolve_children(cursors)
+    }
+}
+
 impl<T: CursorStore + ?Sized> CursorStore for Arc<T> {
     fn lowest_common_cursor(&self, topics: &[&Topic]) -> Result<GlobalCursor, CursorStoreError> {
         (**self).lowest_common_cursor(topics)

--- a/xmtp_api_d14n/src/queries/combinators/ordered_query.rs
+++ b/xmtp_api_d14n/src/queries/combinators/ordered_query.rs
@@ -39,12 +39,10 @@ where
             .envelopes(envelopes)
             .resolver(&self.resolver)
             .store(&self.store)
-            // todo: maybe no clone here?
-            .topic_cursor(self.topic_cursor.clone())
+            .topic_cursor(&mut self.topic_cursor)
             .build()?;
         ordering.order().await.map_err(ApiClientError::other)?;
-        let (envelopes, _) = ordering.into_parts();
-        Ok(envelopes)
+        Ok(ordering.into_envelopes())
     }
 }
 

--- a/xmtp_api_d14n/src/queries/d14n/mls.rs
+++ b/xmtp_api_d14n/src/queries/d14n/mls.rs
@@ -141,6 +141,9 @@ where
         group_id: GroupId,
     ) -> Result<Vec<xmtp_proto::types::GroupMessage>, Self::Error> {
         let topic = TopicKind::GroupMessagesV1.create(&group_id);
+        // lcc will be the topic cursor since only querying for a single topic.
+        // if querying for more than on topic, must do another "latest_for_topic"
+        // query to get correct topic cursor.
         let lcc = self.cursor_store.lowest_common_cursor(&[&topic])?;
         let mut topic_cursor = TopicCursor::default();
         topic_cursor.insert(topic.clone(), lcc.clone());

--- a/xmtp_api_d14n/src/queries/stream/ordered.rs
+++ b/xmtp_api_d14n/src/queries/stream/ordered.rs
@@ -89,16 +89,15 @@ where
             None => return Poll::Ready(None),
         };
         let envelopes = item?;
+        let this = self.as_mut().project();
         let mut ordering = Ordered::builder()
             .envelopes(envelopes)
             .resolver(TypedNoopResolver::<T>::new())
-            .topic_cursor(self.topic_cursor.clone())
-            .store(&self.cursor_store)
+            .topic_cursor(this.topic_cursor)
+            .store(this.cursor_store)
             .build()?;
         ordering.order_offline().map_err(OrderedStreamError::from)?;
-        let (envelopes, mut new_cursor) = ordering.into_parts();
-        let this = self.as_mut().project();
-        std::mem::swap(this.topic_cursor, &mut new_cursor);
+        let envelopes = ordering.into_envelopes();
         Poll::Ready(Some(Ok(envelopes)))
     }
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Update `protocol.order.Ordered` to borrow and mutate `TopicCursor` in place to avoid cloning during streaming
Refactor ordering to pass a mutable borrowed `TopicCursor` through `Ordered`, remove `Clone` and `into_parts`, add `CursorStore` impl for `&mut T`, and update query/stream code paths to use `into_envelopes` and in-place cursor mutation. Key changes are centered in [order.rs](https://github.com/xmtp/libxmtp/pull/2936/files#diff-78b9f275c691ca4b70a53c2a710b84b741cf86e28ac909dc8b250cbe9b61ed1e).

#### 📍Where to Start
Start with `Ordered` and its builder in [order.rs](https://github.com/xmtp/libxmtp/pull/2936/files#diff-78b9f275c691ca4b70a53c2a710b84b741cf86e28ac909dc8b250cbe9b61ed1e), then follow `OrderedQuery::query` in [ordered_query.rs](https://github.com/xmtp/libxmtp/pull/2936/files#diff-a7f3188e32afea719721f5098f8f9cbde6c110942050e65a7abf44fd2218d0fe) and `OrderedStream::poll_next` in [ordered.rs](https://github.com/xmtp/libxmtp/pull/2936/files#diff-59cd7abcfecc1658fc695f54e7da04f764862629dabf0aa0e4fafc684c6e732e).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 6ab5ce5.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->