### PR TITLE
update rust to 1.92 and fix 1.92 rust clippy

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1763511871,
-        "narHash": "sha256-KKZWi+ij7oT0Ag8yC6MQkzfHGcytyjMJDD+47ZV1YNU=",
+        "lastModified": 1765145449,
+        "narHash": "sha256-aBVHGWWRzSpfL++LubA0CwOOQ64WNLegrYHwsVuVN7A=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "099f9014bc8d0cd6e445470ea1df0fd691d5a548",
+        "rev": "69f538cdce5955fcd47abfed4395dc6d5194c1c5",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1763707297,
-        "narHash": "sha256-Bd9VGavwFBLpyU4pjiWfv73gUibNj8dc3xmOW8ff3bI=",
+        "lastModified": 1765435813,
+        "narHash": "sha256-C6tT7K1Lx6VsYw1BY5S3OavtapUvEnDQtmQB5DSgbCc=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "7c2d3a165a4a080fdcb6c191d8f9768281c99f75",
+        "rev": "6399553b7a300c77e7f07342904eb696a5b6bf9d",
         "type": "github"
       },
       "original": {
@@ -41,11 +41,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1762980239,
-        "narHash": "sha256-8oNVE8TrD19ulHinjaqONf9QWCKK+w4url56cdStMpM=",
+        "lastModified": 1763759067,
+        "narHash": "sha256-LlLt2Jo/gMNYAwOgdRQBrsRoOz7BPRkzvNaI/fzXi2Q=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "52a2caecc898d0b46b2b905f058ccc5081f842da",
+        "rev": "2cccadc7357c0ba201788ae99c4dfa90728ef5e0",
         "type": "github"
       },
       "original": {
@@ -75,11 +75,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1761901832,
-        "narHash": "sha256-/01qznpB/Smmy1srjhUz89wM146S6AYMGJeiIcsm0/Q=",
+        "lastModified": 1763975537,
+        "narHash": "sha256-s/he6rna4VArSdBffTAgcYTsodb4QyfR6E4noRg4t48=",
         "owner": "shazow",
         "repo": "foundry.nix",
-        "rev": "c2d2e814e79ed9937bd6a6238f5bb206d8048e96",
+        "rev": "85455ab02f1cedbdb2079f428d0297abea952eb2",
         "type": "github"
       },
       "original": {
@@ -120,11 +120,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1763618868,
-        "narHash": "sha256-v5afmLjn/uyD9EQuPBn7nZuaZVV9r+JerayK/4wvdWA=",
+        "lastModified": 1765270179,
+        "narHash": "sha256-g2a4MhRKu4ymR4xwo+I+auTknXt/+j37Lnf0Mvfl1rE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a8d610af3f1a5fb71e23e08434d8d61a466fc942",
+        "rev": "677fbe97984e7af3175b6c121f3c39ee5c8d62c9",
         "type": "github"
       },
       "original": {
@@ -147,11 +147,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1763648203,
-        "narHash": "sha256-/WJdebbRD+m5vr2xy/bJdCpqd7YHSMapjuXAM/0lvtA=",
+        "lastModified": 1765400135,
+        "narHash": "sha256-D3+4hfNwUhG0fdCpDhOASLwEQ1jKuHi4mV72up4kLQM=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "eaaa2da9fbbfd7a79ff501e0563351cb2004574a",
+        "rev": "fface27171988b3d605ef45cf986c25533116f7e",
         "type": "github"
       },
       "original": {
@@ -164,13 +164,13 @@
     "rust-manifest": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-Mrw0LDR4i/CDGhDZ10IUTGkFow/+yIJGeBKMIWi/nqg=",
+        "narHash": "sha256-k2SXTFvaEZPgDVPvB4IfLj7aQqE4S2J9Jr8XUgY+msM=",
         "type": "file",
-        "url": "https://static.rust-lang.org/dist/channel-rust-1.91.0.toml"
+        "url": "https://static.rust-lang.org/dist/channel-rust-1.92.0.toml"
       },
       "original": {
         "type": "file",
-        "url": "https://static.rust-lang.org/dist/channel-rust-1.91.0.toml"
+        "url": "https://static.rust-lang.org/dist/channel-rust-1.92.0.toml"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
       url = "github:ipetkov/crane";
     };
     rust-manifest = {
-      url = "https://static.rust-lang.org/dist/channel-rust-1.91.0.toml";
+      url = "https://static.rust-lang.org/dist/channel-rust-1.92.0.toml";
       flake = false;
     };
   };

--- a/xmtp_mls/src/groups/tests/mod.rs
+++ b/xmtp_mls/src/groups/tests/mod.rs
@@ -3458,7 +3458,6 @@ async fn test_optimistic_send() {
 
     let text = messages
         .iter()
-        .cloned()
         .map(|m| String::from_utf8_lossy(&m.decrypted_message_bytes).to_string())
         .collect::<Vec<String>>();
     assert_eq!(
@@ -3481,7 +3480,6 @@ async fn test_optimistic_send() {
 
     let delivery = messages
         .iter()
-        .cloned()
         .map(|m| m.delivery_status)
         .collect::<Vec<DeliveryStatus>>();
     assert_eq!(
@@ -3500,7 +3498,6 @@ async fn test_optimistic_send() {
     let messages = bola_group.find_messages(&MsgQueryArgs::default()).unwrap();
     let delivery = messages
         .iter()
-        .cloned()
         .map(|m| m.delivery_status)
         .collect::<Vec<DeliveryStatus>>();
     assert_eq!(


### PR DESCRIPTION
unblocks CI failures on a bunch of PRs