### PR TITLE
support d14n in external stream process message/welcome proxies

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -1596,11 +1596,11 @@ impl FfiConversations {
     pub async fn process_streamed_welcome_message(
         &self,
         envelope_bytes: Vec<u8>,
-    ) -> Result<Arc<FfiConversation>, GenericError> {
+    ) -> Result<Vec<Arc<FfiConversation>>, GenericError> {
         self.inner_client
             .process_streamed_welcome_message(envelope_bytes)
             .await
-            .map(|g| Arc::new(g.into()))
+            .map(|list| list.into_iter().map(|g| Arc::new(g.into())).collect())
             .map_err(Into::into)
     }
 
@@ -2423,14 +2423,12 @@ impl FfiConversation {
     pub async fn process_streamed_conversation_message(
         &self,
         envelope_bytes: Vec<u8>,
-    ) -> Result<FfiMessage, FfiSubscribeError> {
+    ) -> Result<Vec<FfiMessage>, FfiSubscribeError> {
         let message = self
             .inner
             .process_streamed_group_message(envelope_bytes)
             .await?;
-        let ffi_message = message.into();
-
-        Ok(ffi_message)
+        Ok(message.into_iter().map(Into::into).collect())
     }
 
     pub async fn list_members(&self) -> Result<Vec<FfiConversationMember>, GenericError> {

--- a/bindings_node/src/conversation.rs
+++ b/bindings_node/src/conversation.rs
@@ -401,7 +401,7 @@ impl Conversation {
   pub async fn process_streamed_group_message(
     &self,
     envelope_bytes: Uint8Array,
-  ) -> Result<Message> {
+  ) -> Result<Vec<Message>> {
     let group = self.create_mls_group();
     let envelope_bytes: Vec<u8> = envelope_bytes.deref().to_vec();
     let message = group
@@ -409,7 +409,7 @@ impl Conversation {
       .await
       .map_err(ErrorWrapper::from)?;
 
-    Ok(message.into())
+    Ok(message.into_iter().map(Into::into).collect())
   }
 
   #[napi]

--- a/bindings_node/src/conversations.rs
+++ b/bindings_node/src/conversations.rs
@@ -494,14 +494,15 @@ impl Conversations {
   pub async fn process_streamed_welcome_message(
     &self,
     envelope_bytes: Uint8Array,
-  ) -> Result<Conversation> {
+  ) -> Result<Vec<Conversation>> {
     let envelope_bytes = envelope_bytes.deref().to_vec();
     let group = self
       .inner_client
       .process_streamed_welcome_message(envelope_bytes)
       .await
       .map_err(ErrorWrapper::from)?;
-    Ok(group.into())
+
+    Ok(group.into_iter().map(Into::into).collect())
   }
 
   #[napi]

--- a/bindings_wasm/src/conversation.rs
+++ b/bindings_wasm/src/conversation.rs
@@ -696,14 +696,13 @@ impl Conversation {
   pub async fn process_streamed_group_message(
     &self,
     #[wasm_bindgen(js_name = envelopeBytes)] envelope_bytes: Uint8Array,
-  ) -> Result<Message, JsError> {
+  ) -> Result<Vec<Message>, JsError> {
     let group = self.to_mls_group();
     let message = group
       .process_streamed_group_message(envelope_bytes.to_vec())
       .await
       .map_err(|e| JsError::new(&format!("{e}")))?;
-
-    Ok(message.into())
+    Ok(message.into_iter().map(Into::into).collect())
   }
 
   #[wasm_bindgen(js_name = updatePermissionPolicy)]

--- a/xmtp_api_d14n/src/queries/mod.rs
+++ b/xmtp_api_d14n/src/queries/mod.rs
@@ -5,7 +5,7 @@ mod client_bundle;
 mod combinators;
 mod combined;
 mod d14n;
-mod stream;
+pub mod stream;
 mod v3;
 
 pub use api_stats::*;

--- a/xmtp_api_d14n/src/queries/stream/ordered.rs
+++ b/xmtp_api_d14n/src/queries/stream/ordered.rs
@@ -107,7 +107,7 @@ where
 mod test {
     use super::*;
     use crate::protocol::{InMemoryCursorStore, test::missing_dependencies};
-    use futures::{FutureExt, StreamExt, stream};
+    use futures::{FutureExt, StreamExt, future, stream};
     use proptest::prelude::*;
     use xmtp_proto::api::VectorClock;
 
@@ -118,7 +118,7 @@ mod test {
         ) {
             let store = InMemoryCursorStore::new();
             let envs = envelopes.envelopes.clone();
-            let s = stream::once(async move { Ok::<_, EnvelopeError>(envs) });
+            let s = stream::once(future::ready(Ok::<_, EnvelopeError>(envs)));
             let ordered_stream = ordered(s, store.clone(), TopicCursor::default());
             futures::pin_mut!(ordered_stream);
 

--- a/xmtp_mls/src/subscriptions/d14n_compat.rs
+++ b/xmtp_mls/src/subscriptions/d14n_compat.rs
@@ -1,0 +1,87 @@
+//! compatibility decoding for v3 or d14n messages
+//! we need this in case we can't tell whether bytes are v3 or d14n.
+//! this will try to decode with v3 first, and if it erros will try to decode
+//! with d14n. returns both errors on failure.
+use prost::Message;
+use std::fmt;
+use xmtp_common::RetryableError;
+use xmtp_proto::xmtp::mls::api::v1::GroupMessage as V3GroupMessage;
+use xmtp_proto::xmtp::mls::api::v1::WelcomeMessage as V3WelcomeMessage;
+use xmtp_proto::xmtp::xmtpv4::message_api::SubscribeEnvelopesResponse;
+
+use crate::subscriptions::SubscribeError;
+
+#[derive(thiserror::Error, Debug)]
+enum D14nCompatDecodeError {
+    #[error(
+        "unable to decode externally streamed message `{}` for v3 or d14n\
+        v3 errored with: {}\n\
+        d14n errored with: {}\n",
+        proto_type,
+        v3,
+        d14n
+    )]
+    FallbackFailure {
+        v3: prost::DecodeError,
+        d14n: prost::DecodeError,
+        proto_type: &'static str,
+    },
+}
+
+impl RetryableError for D14nCompatDecodeError {
+    fn is_retryable(&self) -> bool {
+        false
+    }
+}
+
+impl D14nCompatDecodeError {
+    fn err<T>(v3: prost::DecodeError, d14n: prost::DecodeError) -> SubscribeError {
+        SubscribeError::dyn_err(D14nCompatDecodeError::FallbackFailure {
+            v3,
+            d14n,
+            proto_type: std::any::type_name::<T>(),
+        })
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum V3OrD14n<T> {
+    D14n(SubscribeEnvelopesResponse),
+    V3(T),
+}
+
+fn decode<T: prost::Message + Default + fmt::Debug>(
+    bytes: &[u8],
+) -> Result<V3OrD14n<T>, SubscribeError> {
+    let v3 = T::decode(bytes);
+    if let Ok(v3) = v3 {
+        Ok(V3OrD14n::V3(v3))
+    } else {
+        let d14n = SubscribeEnvelopesResponse::decode(bytes);
+        if let Ok(d14n) = d14n {
+            Ok(V3OrD14n::D14n(d14n))
+        } else {
+            Err(D14nCompatDecodeError::err::<T>(
+                v3.expect_err("checked for OK value"),
+                d14n.expect_err("checked for OK value"),
+            ))
+        }
+    }
+}
+
+/// Decode a welcome message from an opaque blob of bytes.
+/// this should only be used if it is unknown whether the message is v3 or d14n.
+/// this first tries to decode as a [`V3WelcomeMessage`]. If that fails,
+/// it tries to decode as an [`SubscribeEnvelopesResponse`]. if that fails,
+pub fn decode_welcome_message(bytes: &[u8]) -> Result<V3OrD14n<V3WelcomeMessage>, SubscribeError> {
+    decode::<V3WelcomeMessage>(bytes)
+}
+
+/// Decode a group message from an opaque blob of bytes.
+/// this should only be used if it is unknown whether the message is v3 or d14n.
+/// this first tries to decode as a [`V3GroupMessage`]. If that fails,
+/// it tries to decode as an [`SubscribeEnvelopesResponse`]. if that fails,
+/// both decode errors are returned.
+pub fn decode_group_message(bytes: &[u8]) -> Result<V3OrD14n<V3GroupMessage>, SubscribeError> {
+    decode::<V3GroupMessage>(bytes)
+}


### PR DESCRIPTION
closes #2565 


this is a breaking change since it changes the API of `process_streamed_{message|welcome}`

in d14n, this function may return an empty `Vec` if the message was iceboxed instead of returned. It is also possible it returns more than 1 message as well, although currently I think messages in the stream are singular.

this mostly effects the notification code part of an app. In practice, usually only one envelope will be present in the d14n subscription response. Although, it would possible for this to change in the future and silently break clients if not handled correctly now.