### PR TITLE
move content type fallback text to ffis

### DIFF
--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -3139,6 +3139,12 @@ pub fn decode_leave_request(bytes: Vec<u8>) -> Result<FfiLeaveRequest, GenericEr
         .map_err(|e| GenericError::Generic { err: e.to_string() })
 }
 
+// LeaveRequest FFI fallback function
+#[uniffi::export]
+pub fn leave_request_fallback() -> String {
+    LeaveRequestCodec::FALLBACK_TEXT.to_string()
+}
+
 #[uniffi::export]
 pub fn decode_group_updated(bytes: Vec<u8>) -> Result<FfiGroupUpdated, GenericError> {
     let encoded_content = EncodedContent::decode(bytes.as_slice())

--- a/xmtp_content_types/src/leave_request.rs
+++ b/xmtp_content_types/src/leave_request.rs
@@ -18,6 +18,11 @@ impl LeaveRequestCodec {
     pub const MINOR_VERSION: u32 = 0;
 }
 
+impl LeaveRequestCodec {
+    /// Fallback text shown when the leave request content cannot be decoded
+    pub const FALLBACK_TEXT: &'static str = "A member has requested leaving the group";
+}
+
 impl ContentCodec<LeaveRequest> for LeaveRequestCodec {
     fn content_type() -> ContentTypeId {
         ContentTypeId {
@@ -36,7 +41,7 @@ impl ContentCodec<LeaveRequest> for LeaveRequestCodec {
         Ok(EncodedContent {
             r#type: Some(LeaveRequestCodec::content_type()),
             parameters: HashMap::new(),
-            fallback: None,
+            fallback: Some(LeaveRequestCodec::FALLBACK_TEXT.to_string()),
             compression: None,
             content: buf,
         })


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Expose leave request fallback text via `bindings_ffi::mls::leave_request_fallback` and set `xmtp_content_types::leave_request::LeaveRequestCodec::encode` to populate `EncodedContent.fallback`
Add `LeaveRequestCodec::FALLBACK_TEXT` and use it in `encode` to set `EncodedContent.fallback`; add a UniFFI function `leave_request_fallback()` that returns the fallback text via FFI in [bindings_ffi/src/mls.rs](https://github.com/xmtp/libxmtp/pull/2952/files#diff-3a24c3e76565487a710ac9863ac05160128f4f90892e07849b555a6de43a6e8f) and [xmtp_content_types/src/leave_request.rs](https://github.com/xmtp/libxmtp/pull/2952/files#diff-67d8cf386920d12a812ecb868102e2c1c873c3fcc8f2e3925831ed8af0e852d8).

#### 📍Where to Start
Start with the UniFFI export `leave_request_fallback()` in [bindings_ffi/src/mls.rs](https://github.com/xmtp/libxmtp/pull/2952/files#diff-3a24c3e76565487a710ac9863ac05160128f4f90892e07849b555a6de43a6e8f), then review `LeaveRequestCodec::FALLBACK_TEXT` and its use in `encode` in [xmtp_content_types/src/leave_request.rs](https://github.com/xmtp/libxmtp/pull/2952/files#diff-67d8cf386920d12a812ecb868102e2c1c873c3fcc8f2e3925831ed8af0e852d8).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 932d1c1.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->