### PR TITLE
Update codecs to include should_push, adjust fallbacks

### DIFF
--- a/xmtp_content_types/src/attachment.rs
+++ b/xmtp_content_types/src/attachment.rs
@@ -15,6 +15,18 @@ impl AttachmentCodec {
     pub const MINOR_VERSION: u32 = 0;
 }
 
+impl AttachmentCodec {
+    fn fallback(content: &Attachment) -> Option<String> {
+        Some(format!(
+            "Can't display {}. This app doesn't support attachments.",
+            content
+                .filename
+                .clone()
+                .unwrap_or("this content".to_string())
+        ))
+    }
+}
+
 impl ContentCodec<Attachment> for AttachmentCodec {
     fn content_type() -> ContentTypeId {
         ContentTypeId {
@@ -39,7 +51,7 @@ impl ContentCodec<Attachment> for AttachmentCodec {
         Ok(EncodedContent {
             r#type: Some(Self::content_type()),
             parameters,
-            fallback: Some(fallback),
+            fallback,
             compression: None,
             content: data.content,
         })
@@ -54,15 +66,9 @@ impl ContentCodec<Attachment> for AttachmentCodec {
             content: encoded.content,
         })
     }
-}
 
-impl AttachmentCodec {
-    fn fallback(content: &Attachment) -> String {
-        if let Some(filename) = &content.filename {
-            format!("[Attachment] {filename}")
-        } else {
-            "[Attachment]".to_string()
-        }
+    fn should_push() -> bool {
+        true
     }
 }
 

--- a/xmtp_content_types/src/group_updated.rs
+++ b/xmtp_content_types/src/group_updated.rs
@@ -45,6 +45,10 @@ impl ContentCodec<GroupUpdated> for GroupUpdatedCodec {
 
         Ok(decoded)
     }
+
+    fn should_push() -> bool {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/xmtp_content_types/src/intent.rs
+++ b/xmtp_content_types/src/intent.rs
@@ -14,6 +14,12 @@ impl IntentCodec {
     pub const MINOR_VERSION: u32 = 0;
 }
 
+impl IntentCodec {
+    fn fallback(intent: &Intent) -> Option<String> {
+        Some(format!("User selected action: {}", intent.action_id))
+    }
+}
+
 impl ContentCodec<Intent> for IntentCodec {
     fn content_type() -> ContentTypeId {
         ContentTypeId {
@@ -40,12 +46,10 @@ impl ContentCodec<Intent> for IntentCodec {
         let intent_json = serde_json::to_vec(&intent)
             .map_err(|e| CodecError::Encode(format!("Unable to serialize intent. {e:?}")))?;
 
-        let fallback = format!("User selected action: {}", intent.action_id);
-
         Ok(EncodedContent {
             r#type: Some(Self::content_type()),
             content: intent_json,
-            fallback: Some(fallback),
+            fallback: Self::fallback(&intent),
             ..Default::default()
         })
     }
@@ -55,6 +59,10 @@ impl ContentCodec<Intent> for IntentCodec {
             .map_err(|e| CodecError::Decode(format!("Unable to deserialize intent. {e:?}")))?;
 
         Ok(intent)
+    }
+
+    fn should_push() -> bool {
+        true
     }
 }
 

--- a/xmtp_content_types/src/leave_request.rs
+++ b/xmtp_content_types/src/leave_request.rs
@@ -48,6 +48,10 @@ impl ContentCodec<LeaveRequest> for LeaveRequestCodec {
 
         Ok(decoded)
     }
+
+    fn should_push() -> bool {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/xmtp_content_types/src/lib.rs
+++ b/xmtp_content_types/src/lib.rs
@@ -87,6 +87,7 @@ pub trait ContentCodec<T> {
     fn content_type() -> ContentTypeId;
     fn encode(content: T) -> Result<EncodedContent, CodecError>;
     fn decode(content: EncodedContent) -> Result<T, CodecError>;
+    fn should_push() -> bool;
 }
 
 pub fn encoded_content_to_bytes(content: EncodedContent) -> Vec<u8> {

--- a/xmtp_content_types/src/membership_change.rs
+++ b/xmtp_content_types/src/membership_change.rs
@@ -47,6 +47,10 @@ impl ContentCodec<GroupMembershipChanges> for GroupMembershipChangeCodec {
 
         Ok(decoded)
     }
+
+    fn should_push() -> bool {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/xmtp_content_types/src/multi_remote_attachment.rs
+++ b/xmtp_content_types/src/multi_remote_attachment.rs
@@ -15,6 +15,15 @@ impl MultiRemoteAttachmentCodec {
     pub const MINOR_VERSION: u32 = 0;
 }
 
+impl MultiRemoteAttachmentCodec {
+    fn fallback(_: &MultiRemoteAttachment) -> Option<String> {
+        Some(
+            "Can't display this content. This app doesn't support multiple remote attachments."
+                .to_string(),
+        )
+    }
+}
+
 impl ContentCodec<MultiRemoteAttachment> for MultiRemoteAttachmentCodec {
     fn content_type() -> ContentTypeId {
         ContentTypeId {
@@ -33,9 +42,7 @@ impl ContentCodec<MultiRemoteAttachment> for MultiRemoteAttachmentCodec {
         Ok(EncodedContent {
             r#type: Some(MultiRemoteAttachmentCodec::content_type()),
             parameters: HashMap::new(),
-            fallback: Some(
-                "Can’t display. This app doesn’t support multi remote attachments.".to_string(),
-            ),
+            fallback: Self::fallback(&data),
             compression: None,
             content: buf,
         })
@@ -46,6 +53,10 @@ impl ContentCodec<MultiRemoteAttachment> for MultiRemoteAttachmentCodec {
             .map_err(|e| CodecError::Decode(e.to_string()))?;
 
         Ok(decoded)
+    }
+
+    fn should_push() -> bool {
+        true
     }
 }
 

--- a/xmtp_content_types/src/reaction.rs
+++ b/xmtp_content_types/src/reaction.rs
@@ -19,6 +19,20 @@ impl ReactionCodec {
     pub const MINOR_VERSION: u32 = 0;
 }
 
+impl ReactionCodec {
+    fn fallback(content: &ReactionV2) -> Option<String> {
+        let (action, prepos) = if content.action == ReactionAction::Removed as i32 {
+            ("Removed", "from")
+        } else {
+            ("Reacted with", "to")
+        };
+        Some(format!(
+            "{} \"{}\" {} an earlier message",
+            action, content.content, prepos
+        ))
+    }
+}
+
 impl ContentCodec<ReactionV2> for ReactionCodec {
     fn content_type() -> ContentTypeId {
         ContentTypeId {
@@ -37,7 +51,7 @@ impl ContentCodec<ReactionV2> for ReactionCodec {
         Ok(EncodedContent {
             r#type: Some(ReactionCodec::content_type()),
             parameters: HashMap::new(),
-            fallback: None,
+            fallback: Self::fallback(&data),
             compression: None,
             content: buf,
         })
@@ -48,6 +62,10 @@ impl ContentCodec<ReactionV2> for ReactionCodec {
             .map_err(|e| CodecError::Decode(e.to_string()))?;
 
         Ok(decoded)
+    }
+
+    fn should_push() -> bool {
+        false
     }
 }
 
@@ -122,6 +140,20 @@ impl LegacyReactionCodec {
     pub const MINOR_VERSION: u32 = 0;
 }
 
+impl LegacyReactionCodec {
+    fn fallback(content: &LegacyReaction) -> Option<String> {
+        let (action, prepos) = if content.action == "removed" {
+            ("Removed", "from")
+        } else {
+            ("Reacted with", "to")
+        };
+        Some(format!(
+            "{} \"{}\" {} an earlier message",
+            action, content.content, prepos
+        ))
+    }
+}
+
 impl ContentCodec<LegacyReaction> for LegacyReactionCodec {
     fn content_type() -> ContentTypeId {
         ContentTypeId {
@@ -137,7 +169,7 @@ impl ContentCodec<LegacyReaction> for LegacyReactionCodec {
         Ok(EncodedContent {
             r#type: Some(LegacyReactionCodec::content_type()),
             parameters: std::collections::HashMap::new(),
-            fallback: None,
+            fallback: Self::fallback(&data),
             compression: None,
             content: json.into_bytes(),
         })
@@ -148,6 +180,10 @@ impl ContentCodec<LegacyReaction> for LegacyReactionCodec {
             .map_err(|e| CodecError::Decode(e.to_string()))?;
 
         Ok(decoded)
+    }
+
+    fn should_push() -> bool {
+        false
     }
 }
 

--- a/xmtp_content_types/src/read_receipt.rs
+++ b/xmtp_content_types/src/read_receipt.rs
@@ -38,6 +38,10 @@ impl ContentCodec<ReadReceipt> for ReadReceiptCodec {
     fn decode(_: EncodedContent) -> Result<ReadReceipt, CodecError> {
         Ok(ReadReceipt {})
     }
+
+    fn should_push() -> bool {
+        false
+    }
 }
 
 /// The main content type for read receipts

--- a/xmtp_content_types/src/remote_attachment.rs
+++ b/xmtp_content_types/src/remote_attachment.rs
@@ -15,6 +15,18 @@ impl RemoteAttachmentCodec {
     pub const MINOR_VERSION: u32 = 0;
 }
 
+impl RemoteAttachmentCodec {
+    fn fallback(content: &RemoteAttachment) -> Option<String> {
+        Some(format!(
+            "Can't display {}. This app doesn't support remote attachments.",
+            content
+                .filename
+                .clone()
+                .unwrap_or("this content".to_string())
+        ))
+    }
+}
+
 impl ContentCodec<RemoteAttachment> for RemoteAttachmentCodec {
     fn content_type() -> ContentTypeId {
         ContentTypeId {
@@ -26,6 +38,7 @@ impl ContentCodec<RemoteAttachment> for RemoteAttachmentCodec {
     }
 
     fn encode(data: RemoteAttachment) -> Result<EncodedContent, CodecError> {
+        let fallback = Self::fallback(&data);
         let mut parameters = [
             ("contentDigest", data.content_digest),
             ("salt", hex::encode(data.salt)),
@@ -45,7 +58,7 @@ impl ContentCodec<RemoteAttachment> for RemoteAttachmentCodec {
         Ok(EncodedContent {
             r#type: Some(Self::content_type()),
             parameters,
-            fallback: None,
+            fallback,
             compression: None,
             content: data.url.into_bytes(),
         })
@@ -81,6 +94,10 @@ impl ContentCodec<RemoteAttachment> for RemoteAttachmentCodec {
             scheme,
             content_length,
         })
+    }
+
+    fn should_push() -> bool {
+        true
     }
 }
 

--- a/xmtp_content_types/src/text.rs
+++ b/xmtp_content_types/src/text.rs
@@ -52,6 +52,10 @@ impl ContentCodec<String> for TextCodec {
             .map_err(|utf8_err| CodecError::Decode(utf8_err.to_string()))?;
         Ok(text.to_string())
     }
+
+    fn should_push() -> bool {
+        true
+    }
 }
 
 #[cfg(test)]

--- a/xmtp_content_types/src/transaction_reference.rs
+++ b/xmtp_content_types/src/transaction_reference.rs
@@ -15,6 +15,19 @@ impl TransactionReferenceCodec {
     pub const MINOR_VERSION: u32 = 0;
 }
 
+impl TransactionReferenceCodec {
+    fn fallback(content: &TransactionReference) -> Option<String> {
+        if !content.reference.is_empty() {
+            Some(format!(
+                "[Crypto transaction] Use a blockchain explorer to learn more using the transaction hash: {}",
+                content.reference
+            ))
+        } else {
+            Some("Crypto transaction".to_string())
+        }
+    }
+}
+
 impl ContentCodec<TransactionReference> for TransactionReferenceCodec {
     fn content_type() -> ContentTypeId {
         ContentTypeId {
@@ -32,7 +45,7 @@ impl ContentCodec<TransactionReference> for TransactionReferenceCodec {
         Ok(EncodedContent {
             r#type: Some(Self::content_type()),
             parameters: HashMap::new(),
-            fallback: Some(Self::fallback(&data)),
+            fallback: Self::fallback(&data),
             compression: None,
             content: json,
         })
@@ -42,18 +55,9 @@ impl ContentCodec<TransactionReference> for TransactionReferenceCodec {
         serde_json::from_slice(&encoded.content)
             .map_err(|e| CodecError::Decode(format!("JSON decode error: {e}")))
     }
-}
 
-impl TransactionReferenceCodec {
-    fn fallback(content: &TransactionReference) -> String {
-        if !content.reference.is_empty() {
-            format!(
-                "[Crypto transaction] Use a blockchain explorer to learn more using the transaction hash: {}",
-                content.reference
-            )
-        } else {
-            "Crypto transaction".to_string()
-        }
+    fn should_push() -> bool {
+        true
     }
 }
 

--- a/xmtp_content_types/src/wallet_send_calls.rs
+++ b/xmtp_content_types/src/wallet_send_calls.rs
@@ -11,10 +11,12 @@ impl WalletSendCallsCodec {
     pub const TYPE_ID: &'static str = "walletSendCalls";
     pub const MAJOR_VERSION: u32 = 1;
     pub const MINOR_VERSION: u32 = 0;
+}
 
-    fn fallback(content: &WalletSendCalls) -> String {
+impl WalletSendCallsCodec {
+    fn fallback(content: &WalletSendCalls) -> Option<String> {
         let json = serde_json::to_string(content).unwrap_or_else(|_| "{}".to_string());
-        format!("[Transaction request generated]: {}", json)
+        Some(format!("[Transaction request generated]: {}", json))
     }
 }
 
@@ -35,7 +37,7 @@ impl ContentCodec<WalletSendCalls> for WalletSendCallsCodec {
         Ok(EncodedContent {
             r#type: Some(Self::content_type()),
             parameters: HashMap::new(),
-            fallback: Some(Self::fallback(&content)),
+            fallback: Self::fallback(&content),
             compression: None,
             content: json,
         })
@@ -44,6 +46,10 @@ impl ContentCodec<WalletSendCalls> for WalletSendCallsCodec {
     fn decode(encoded: EncodedContent) -> Result<WalletSendCalls, CodecError> {
         serde_json::from_slice(&encoded.content)
             .map_err(|e| CodecError::Decode(format!("JSON decode error: {e}")))
+    }
+
+    fn should_push() -> bool {
+        true
     }
 }
 


### PR DESCRIPTION
# Summary

- Added `should_push` to `ContentCodec` trait
- Adjusted fallbacks to match JS content types