### PR TITLE
Add expire_at_ns field to all exposed message types

### DIFF
--- a/bindings_ffi/src/message.rs
+++ b/bindings_ffi/src/message.rs
@@ -366,6 +366,7 @@ pub struct FfiDecodedMessageMetadata {
     pub content_type: FfiContentTypeId,
     pub conversation_id: Vec<u8>,
     pub inserted_at_ns: i64,
+    pub expires_at_ns: Option<i64>,
 }
 
 #[derive(uniffi::Enum, Clone, Debug)]
@@ -1022,6 +1023,7 @@ impl From<DecodedMessageMetadata> for FfiDecodedMessageMetadata {
             sender_inbox_id: metadata.sender_inbox_id,
             content_type: metadata.content_type.into(),
             inserted_at_ns: metadata.inserted_at_ns,
+            expires_at_ns: metadata.expires_at_ns,
         }
     }
 }
@@ -1184,6 +1186,7 @@ pub struct FfiDecodedMessage {
     delivery_status: FfiDeliveryStatus,
     num_replies: u64,
     inserted_at_ns: i64,
+    expires_at_ns: Option<i64>,
 }
 
 #[uniffi::export]
@@ -1249,6 +1252,10 @@ impl FfiDecodedMessage {
     pub fn inserted_at_ns(&self) -> i64 {
         self.inserted_at_ns
     }
+
+    pub fn expires_at_ns(&self) -> Option<i64> {
+        self.expires_at_ns
+    }
 }
 
 impl From<DecodedMessage> for FfiDecodedMessage {
@@ -1277,6 +1284,7 @@ impl From<DecodedMessage> for FfiDecodedMessage {
                 .collect(),
             num_replies: item.num_replies as u64,
             inserted_at_ns: metadata.inserted_at_ns,
+            expires_at_ns: metadata.expires_at_ns,
         }
     }
 }

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -3207,6 +3207,7 @@ pub struct FfiMessage {
     pub sequence_id: u64,
     pub originator_id: u32,
     pub inserted_at_ns: i64,
+    pub expire_at_ns: Option<i64>,
 }
 
 impl From<StoredGroupMessage> for FfiMessage {
@@ -3222,6 +3223,7 @@ impl From<StoredGroupMessage> for FfiMessage {
             sequence_id: msg.sequence_id as u64,
             originator_id: msg.originator_id as u32,
             inserted_at_ns: msg.inserted_at_ns,
+            expire_at_ns: msg.expire_at_ns,
         }
     }
 }

--- a/bindings_node/src/enriched_message.rs
+++ b/bindings_node/src/enriched_message.rs
@@ -21,6 +21,7 @@ pub struct DecodedMessage {
   pub fallback: Option<String>,
   pub delivery_status: DeliveryStatus,
   pub num_replies: i64,
+  pub expires_at_ns: Option<i64>,
 }
 
 #[napi]
@@ -61,6 +62,7 @@ impl TryFrom<XmtpDecodedMessage> for DecodedMessage {
       fallback: msg.fallback_text.clone(),
       delivery_status: msg.metadata.delivery_status.into(),
       num_replies: msg.num_replies as i64,
+      expires_at_ns: msg.metadata.expires_at_ns,
       inner: Box::new(msg),
     })
   }

--- a/bindings_wasm/src/enriched_message.rs
+++ b/bindings_wasm/src/enriched_message.rs
@@ -30,6 +30,7 @@ pub struct DecodedMessage {
   pub reactions: Vec<DecodedMessage>,
   pub delivery_status: DeliveryStatus,
   pub num_replies: i64,
+  pub expires_at_ns: Option<i64>,
 }
 
 impl TryFrom<XmtpDecodedMessage> for DecodedMessage {
@@ -52,6 +53,7 @@ impl TryFrom<XmtpDecodedMessage> for DecodedMessage {
       reactions: reactions?,
       delivery_status: msg.metadata.delivery_status.into(),
       num_replies: msg.num_replies as i64,
+      expires_at_ns: msg.metadata.expires_at_ns,
     })
   }
 }

--- a/xmtp_mls/src/messages/decoded_message.rs
+++ b/xmtp_mls/src/messages/decoded_message.rs
@@ -80,6 +80,8 @@ pub struct DecodedMessageMetadata {
     pub content_type: ContentTypeId,
     // Time in nanoseconds the message was inserted into the database
     pub inserted_at_ns: i64,
+    // Timestamp (in NS) after which the message must be deleted
+    pub expires_at_ns: Option<i64>,
 }
 
 #[derive(Debug, Clone)]
@@ -205,6 +207,7 @@ impl TryFrom<StoredGroupMessage> for DecodedMessage {
             delivery_status: value.delivery_status,
             content_type: content_type_id,
             inserted_at_ns: value.inserted_at_ns,
+            expires_at_ns: value.expire_at_ns,
         };
 
         // For now, we'll set default values for reactions and replies


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add an optional expires_at_ns timestamp to decoded message metadata across FFI, Node, WASM, and core models to support message expiry
Introduce an `Option<i64>` `expires_at_ns` field in decoded message metadata and propagate it through FFI records/objects, Node/WASM `DecodedMessage`, and core `DecodedMessageMetadata`, including accessors and conversions.

#### 📍Where to Start
Start with the metadata source in `TryFrom<StoredGroupMessage>` for `DecodedMessage` in [xmtp_mls/src/messages/decoded_message.rs](https://github.com/xmtp/libxmtp/pull/2961/files#diff-0f2f8821d2e9aa1d55c1968fcc5258870086f982d88c44b4126c4af508b82763), then follow the propagation through FFI in [bindings_ffi/src/message.rs](https://github.com/xmtp/libxmtp/pull/2961/files#diff-ebd102a369643d46ce058998aa216b3d38724c782b29b2d20f6140ae7acdd691) and bindings in [bindings_node/src/enriched_message.rs](https://github.com/xmtp/libxmtp/pull/2961/files#diff-069aa1dc210e0db231132158678646035e65b64523ccc1d3b339f78fd65e152b) and [bindings_wasm/src/enriched_message.rs](https://github.com/xmtp/libxmtp/pull/2961/files#diff-3d693324935629dc94ef8d172b3a96feb937055dfe69d53111aff74a9e854ef8).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized f1a0654.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->