### PR TITLE
Add ability to get message metadata statically

### DIFF
--- a/bindings_ffi/src/lib.rs
+++ b/bindings_ffi/src/lib.rs
@@ -80,6 +80,8 @@ pub enum GenericError {
     Expired(#[from] Expired),
     #[error(transparent)]
     BackendBuilder(#[from] MessageBackendBuilderError),
+    #[error(transparent)]
+    Api(#[from] xmtp_api::ApiError),
 }
 
 // this impl allows us to gracefully handle unexpected errors from foreign code without panicking

--- a/bindings_ffi/src/mls.rs
+++ b/bindings_ffi/src/mls.rs
@@ -97,8 +97,8 @@ use xmtp_proto::api::IsConnectedCheck;
 use xmtp_proto::api_client::AggregateStats;
 use xmtp_proto::api_client::ApiStats;
 use xmtp_proto::api_client::IdentityStats;
-use xmtp_proto::types::ApiIdentifier;
 use xmtp_proto::types::Cursor;
+use xmtp_proto::types::{ApiIdentifier, GroupMessageMetadata};
 use xmtp_proto::xmtp::device_sync::{BackupElementSelection, BackupOptions};
 use xmtp_proto::xmtp::mls::message_contents::EncodedContent;
 use xmtp_proto::xmtp::mls::message_contents::content_types::LeaveRequest;
@@ -208,6 +208,47 @@ pub async fn inbox_state_from_inbox_ids(
     });
 
     try_join_all(mapped_futures).await
+}
+
+#[derive(uniffi::Record)]
+pub struct FfiMessageMetadata {
+    pub cursor: FfiCursor,
+    pub created_ns: i64,
+}
+
+impl TryFrom<GroupMessageMetadata> for FfiMessageMetadata {
+    type Error = GenericError;
+
+    fn try_from(metadata: GroupMessageMetadata) -> Result<Self, Self::Error> {
+        Ok(FfiMessageMetadata {
+            cursor: metadata.cursor.into(),
+            created_ns: metadata.created_ns.timestamp_nanos_opt().ok_or_else(|| {
+                GenericError::Generic {
+                    err: "Received a timestamp from the server more than 584 years from 1970"
+                        .to_string(),
+                }
+            })?,
+        })
+    }
+}
+
+#[uniffi::export(async_runtime = "tokio")]
+pub async fn get_newest_message_metadata(
+    api: Arc<XmtpApiClient>,
+    group_ids: Vec<Vec<u8>>,
+) -> Result<HashMap<Vec<u8>, FfiMessageMetadata>, GenericError> {
+    let backend = MessageBackendBuilder::default().from_bundle(api.0.clone())?;
+    let api: ApiClientWrapper<xmtp_mls::XmtpApiClient> =
+        ApiClientWrapper::new(backend, strategies::exponential_cooldown());
+
+    let group_id_refs: Vec<&[u8]> = group_ids.iter().map(|id| id.as_slice()).collect();
+
+    let metadata = api.get_newest_message_metadata(group_id_refs).await?;
+
+    metadata
+        .into_iter()
+        .map(|(k, v)| Ok((k.to_vec(), FfiMessageMetadata::try_from(v)?)))
+        .collect()
 }
 
 /**

--- a/bindings_ffi/src/mls/tests/mod.rs
+++ b/bindings_ffi/src/mls/tests/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     decode_transaction_reference, encode_actions, encode_attachment, encode_intent,
     encode_leave_request, encode_multi_remote_attachment, encode_reaction, encode_read_receipt,
     encode_remote_attachment, encode_reply, encode_text, encode_transaction_reference,
-    get_inbox_id_for_identifier,
+    get_inbox_id_for_identifier, get_newest_message_metadata,
     identity::FfiIdentifier,
     inbox_owner::FfiInboxOwner,
     inbox_state_from_inbox_ids, is_connected,


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add FFI method `mls::get_newest_message_metadata` to fetch static message metadata per group
Introduce `FfiMessageMetadata` and `TryFrom<GroupMessageMetadata>` conversion, add `GenericError::Api` for propagating `xmtp_api::ApiError`, and export async `mls::get_newest_message_metadata` in [bindings_ffi/src/mls.rs](https://github.com/xmtp/libxmtp/pull/2963/files#diff-3a24c3e76565487a710ac9863ac05160128f4f90892e07849b555a6de43a6e8f).

#### 📍Where to Start
Start with the exported function `mls::get_newest_message_metadata` in [bindings_ffi/src/mls.rs](https://github.com/xmtp/libxmtp/pull/2963/files#diff-3a24c3e76565487a710ac9863ac05160128f4f90892e07849b555a6de43a6e8f).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized f20d129.
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->