### PR TITLE
Faster Installation Diffing

### DIFF
--- a/xmtp_mls/src/identity_updates.rs
+++ b/xmtp_mls/src/identity_updates.rs
@@ -6,7 +6,7 @@ use crate::{
     identity::IdentityError,
     subscriptions::SyncWorkerEvent,
 };
-use futures::future::try_join_all;
+use futures::{StreamExt, future::try_join_all, stream::FuturesUnordered};
 use std::collections::{HashMap, HashSet};
 use thiserror::Error;
 use xmtp_common::{Retry, RetryableError, retry_async, retryable};
@@ -518,24 +518,30 @@ where
         let mut added_installations: HashSet<Vec<u8>> = HashSet::new();
         let mut removed_installations: HashSet<Vec<u8>> = HashSet::new();
 
-        // TODO: Do all of this in parallel
+        let mut futs = FuturesUnordered::new();
         for inbox_id in added_and_updated_members {
-            let starting_sequence_id = match old_group_membership.get(inbox_id) {
-                Some(0) => None,
-                Some(i) => Some(*i as i64),
-                None => None,
-            };
-            let state_diff = self
-                .get_association_state_diff(
-                    conn,
-                    inbox_id.as_str(),
-                    starting_sequence_id,
-                    new_group_membership.get(inbox_id).map(|i| *i as i64),
-                )
-                .await?;
+            futs.push(async move {
+                let starting_sequence_id = match old_group_membership.get(inbox_id) {
+                    Some(0) => None,
+                    Some(i) => Some(*i as i64),
+                    None => None,
+                };
+                let state_diff = self
+                    .get_association_state_diff(
+                        conn,
+                        inbox_id.as_str(),
+                        starting_sequence_id,
+                        new_group_membership.get(inbox_id).map(|i| *i as i64),
+                    )
+                    .await?;
 
-            added_installations.extend(state_diff.new_installations());
-            removed_installations.extend(state_diff.removed_installations());
+                Ok::<_, InstallationDiffError>(state_diff)
+            });
+        }
+        while let Some(result) = futs.next().await {
+            let diff = result?;
+            added_installations.extend(diff.new_installations());
+            removed_installations.extend(diff.removed_installations());
         }
 
         for inbox_id in membership_diff.removed_inboxes.iter() {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Run installation diffing concurrently by parallelizing `identity_updates::installation_diff` state calculations in [identity_updates.rs](https://github.com/xmtp/libxmtp/pull/2966/files#diff-cc071a4438743ce4ec352d6294d0ca5e6343d881afd0f7d45127e70badea403d)
Convert sequential `get_association_state_diff` calls to concurrent tasks using `FuturesUnordered` and `StreamExt::next`, merging results as they complete in [identity_updates.rs](https://github.com/xmtp/libxmtp/pull/2966/files#diff-cc071a4438743ce4ec352d6294d0ca5e6343d881afd0f7d45127e70badea403d).

#### 📍Where to Start
Start with the `installation_diff` function refactor in [identity_updates.rs](https://github.com/xmtp/libxmtp/pull/2966/files#diff-cc071a4438743ce4ec352d6294d0ca5e6343d881afd0f7d45127e70badea403d), focusing on the `FuturesUnordered` construction and the result reduction loop.

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 248d75f.
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->