### PR TITLE
fix originator sequence id order in icebox

### DIFF
--- a/xmtp_db/migrations/2025-11-25-213223-0000_make_icebox_depending_fields_non_null/up.sql
+++ b/xmtp_db/migrations/2025-11-25-213223-0000_make_icebox_depending_fields_non_null/up.sql
@@ -7,10 +7,10 @@ DELETE FROM icebox;
 
 -- Step 1: Create the new icebox_dependencies table
 CREATE TABLE icebox_dependencies (
-    envelope_sequence_id BIGINT NOT NULL,
     envelope_originator_id BIGINT NOT NULL,
-    dependency_sequence_id BIGINT NOT NULL,
+    envelope_sequence_id BIGINT NOT NULL,
     dependency_originator_id BIGINT NOT NULL,
+    dependency_sequence_id BIGINT NOT NULL,
     PRIMARY KEY (envelope_originator_id, envelope_sequence_id, dependency_originator_id, dependency_sequence_id),
     -- when an envelope is deleted, also delete its dependency records
     FOREIGN KEY (envelope_originator_id, envelope_sequence_id) REFERENCES icebox(originator_id, sequence_id) ON DELETE CASCADE
@@ -23,8 +23,8 @@ DROP TABLE icebox;
 
 -- Step 4: Create new icebox table with group_id
 CREATE TABLE icebox (
-    sequence_id BIGINT NOT NULL,
     originator_id BIGINT NOT NULL,
+    sequence_id BIGINT NOT NULL,
     group_id BLOB NOT NULL,
     envelope_payload BLOB NOT NULL,
     PRIMARY KEY (originator_id, sequence_id),

--- a/xmtp_db/src/encrypted_store/icebox.rs
+++ b/xmtp_db/src/encrypted_store/icebox.rs
@@ -331,7 +331,7 @@ mod tests {
     use super::*;
 
     fn create_test_group(conn: &impl crate::DbQuery) -> Vec<u8> {
-        let group_id = vec![1u8; 1];
+        let group_id = xmtp_common::rand_vec::<24>();
         let group = StoredGroup {
             id: group_id.clone(),
             created_at_ns: 0,

--- a/xmtp_db/src/encrypted_store/schema_gen.rs
+++ b/xmtp_db/src/encrypted_store/schema_gen.rs
@@ -83,20 +83,20 @@ diesel::table! {
 }
 
 diesel::table! {
-    icebox (sequence_id, originator_id) {
-        sequence_id -> BigInt,
+    icebox (originator_id, sequence_id) {
         originator_id -> BigInt,
+        sequence_id -> BigInt,
         group_id -> Binary,
         envelope_payload -> Binary,
     }
 }
 
 diesel::table! {
-    icebox_dependencies (envelope_sequence_id, envelope_originator_id, dependency_sequence_id, dependency_originator_id) {
-        envelope_sequence_id -> BigInt,
+    icebox_dependencies (envelope_originator_id, envelope_sequence_id, dependency_originator_id, dependency_sequence_id) {
         envelope_originator_id -> BigInt,
-        dependency_sequence_id -> BigInt,
+        envelope_sequence_id -> BigInt,
         dependency_originator_id -> BigInt,
+        dependency_sequence_id -> BigInt,
     }
 }
 


### PR DESCRIPTION
on diesel selects, the sequence and originator ids would be swapped