### PR TITLE
prune icebox after processing messages

### DIFF
--- a/xmtp_db/src/mock.rs
+++ b/xmtp_db/src/mock.rs
@@ -782,6 +782,8 @@ mock! {
             &self,
             orphans: Vec<OrphanedEnvelope>,
         ) -> Result<usize, crate::ConnectionError>;
+
+        fn prune_icebox(&self) -> Result<usize, crate::ConnectionError>;
     }
 
     impl crate::migrations::QueryMigrations for DbQuery {

--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -1764,6 +1764,7 @@ where
     ) -> Result<MessageIdentifier, GroupMessageProcessingError> {
         let message = match process_result {
             Ok(m) => {
+                self.context.db().prune_icebox()?;
                 tracing::info!(
                     "Transaction completed successfully: process for group [{}] envelope cursor[{}]",
                     &envelope.group_id,


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Prune icebox entries after message processing by adding `QueryIcebox::prune_icebox` and invoking it in `groups::mls_sync::post_process_message`
Add `QueryIcebox::prune_icebox` to remove entries at or below the group's refresh cursor, implement it for database connections and mocks, and call it after successful message processing in [mls_sync.rs](https://github.com/xmtp/libxmtp/pull/2969/files#diff-10f818f7918c8c0b2ed32c4f63e5060050527ed58df00ec081bbecb66065144e).

#### 📍Where to Start
Start with the `post_process_message` flow in [mls_sync.rs](https://github.com/xmtp/libxmtp/pull/2969/files#diff-10f818f7918c8c0b2ed32c4f63e5060050527ed58df00ec081bbecb66065144e), then review `QueryIcebox::prune_icebox` in [icebox.rs](https://github.com/xmtp/libxmtp/pull/2969/files#diff-015edee4b874f40f0db8cdb344e1cd3bccf7d162977a16c5d1a0b740365416d0).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized ac98a83. 2 files reviewed, 2 issues evaluated, 1 issue filtered, 1 comment posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>xmtp_mls/src/groups/mls_sync.rs — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 1767](https://github.com/xmtp/libxmtp/blob/ac98a83c2c49d8d083f3f0c7a1bc3074bc0a7aa2/xmtp_mls/src/groups/mls_sync.rs#L1767): The `prune_icebox()?` call in the success path can cause a successfully processed message to appear as failed. If the message is processed correctly but `prune_icebox()` fails, the error is propagated via `?`, causing the function to return an error and discard the valid `MessageIdentifier` in `m`. This could lead to the caller retrying message processing unnecessarily, potentially receiving a `MessageAlreadyProcessed` error or other inconsistent state. The pruning operation is cleanup/maintenance and its failure should not cause an already-successful message processing to fail. <b>[ Already posted ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->