### PR TITLE
Flaky test fix: basic_sync

### DIFF
--- a/xmtp_mls/src/groups/device_sync/tests.rs
+++ b/xmtp_mls/src/groups/device_sync/tests.rs
@@ -11,14 +11,22 @@ use xmtp_db::{
 #[xmtp_common::test(unwrap_try = true)]
 #[cfg_attr(target_arch = "wasm32", ignore)]
 async fn basic_sync() {
-    tester!(alix1, sync_server, sync_worker, stream);
+    tester!(alix1, sync_server, sync_worker);
     tester!(bo);
     // Talk with bo
     let (dm, dm_msg) = alix1.test_talk_in_dm_with(&bo).await?;
     // Create a second client for alix
     tester!(alix2, from: alix1);
 
+    alix1.sync_all_welcomes_and_groups(None).await?;
+    alix1
+        .worker()
+        .register_interest(SyncMetric::PayloadSent, 1)
+        .wait()
+        .await?;
+
     // Have alix2 receive payload and process it
+    alix2.sync_all_welcomes_and_groups(None).await?;
     alix2
         .worker()
         .register_interest(SyncMetric::PayloadProcessed, 1)


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Stabilize `groups::device_sync::tests::basic_sync` by removing the tester stream and explicitly calling `alix1.sync_all_welcomes_and_groups(None)` and `alix2.sync_all_welcomes_and_groups(None)` with waits for `SyncMetric::PayloadSent` (1) and `SyncMetric::PayloadProcessed` (1)
Updates the test to invoke explicit sync on `alix1` and `alix2` and to wait on `worker().register_interest` for `SyncMetric::PayloadSent` and `SyncMetric::PayloadProcessed` instead of using the tester-provided stream in [tests.rs](https://github.com/xmtp/libxmtp/pull/2975/files#diff-d875949860660d989ef34c14d3c75b1cc8670b5b98aa12b3c20d1bded65a6f96).

#### 📍Where to Start
Start in `groups::device_sync::tests::basic_sync` within [tests.rs](https://github.com/xmtp/libxmtp/pull/2975/files#diff-d875949860660d989ef34c14d3c75b1cc8670b5b98aa12b3c20d1bded65a6f96), focusing on the new explicit sync calls and metric waits.

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 0ab0bdb.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->