### PR TITLE
Refactor multi remote attachment content type in node bindings

### DIFF
--- a/bindings_node/src/content_types/decoded_message_content.rs
+++ b/bindings_node/src/content_types/decoded_message_content.rs
@@ -7,7 +7,7 @@ use super::attachment::Attachment;
 use super::group_updated::GroupUpdated;
 use super::intent::Intent;
 use super::leave_request::LeaveRequest;
-use super::multi_remote_attachment::MultiRemoteAttachmentPayload;
+use super::multi_remote_attachment::MultiRemoteAttachment;
 use super::reaction::Reaction;
 use super::read_receipt::ReadReceipt;
 use super::remote_attachment::RemoteAttachment;
@@ -44,7 +44,7 @@ pub enum DecodedMessageContentInner {
   Reaction(Reaction),
   Attachment(Attachment),
   RemoteAttachment(RemoteAttachment),
-  MultiRemoteAttachment(MultiRemoteAttachmentPayload),
+  MultiRemoteAttachment(MultiRemoteAttachment),
   TransactionReference(TransactionReference),
   GroupUpdated(GroupUpdated),
   ReadReceipt(ReadReceipt),
@@ -139,7 +139,7 @@ impl DecodedMessageContent {
   }
 
   #[napi(getter)]
-  pub fn multi_remote_attachment(&self) -> Option<MultiRemoteAttachmentPayload> {
+  pub fn multi_remote_attachment(&self) -> Option<MultiRemoteAttachment> {
     match &self.inner {
       DecodedMessageContentInner::MultiRemoteAttachment(mra) => Some(mra.clone()),
       _ => None,

--- a/bindings_node/src/content_types/multi_remote_attachment.rs
+++ b/bindings_node/src/content_types/multi_remote_attachment.rs
@@ -22,6 +22,21 @@ pub struct RemoteAttachmentInfo {
   pub filename: Option<String>,
 }
 
+impl Clone for RemoteAttachmentInfo {
+  fn clone(&self) -> Self {
+    Self {
+      secret: Uint8Array::from(self.secret.to_vec()),
+      content_digest: self.content_digest.clone(),
+      nonce: Uint8Array::from(self.nonce.to_vec()),
+      scheme: self.scheme.clone(),
+      url: self.url.clone(),
+      salt: Uint8Array::from(self.salt.to_vec()),
+      content_length: self.content_length,
+      filename: self.filename.clone(),
+    }
+  }
+}
+
 impl From<RemoteAttachmentInfo> for XmtpRemoteAttachmentInfo {
   fn from(remote_attachment_info: RemoteAttachmentInfo) -> Self {
     XmtpRemoteAttachmentInfo {
@@ -53,6 +68,7 @@ impl From<XmtpRemoteAttachmentInfo> for RemoteAttachmentInfo {
 }
 
 #[napi(object)]
+#[derive(Clone)]
 pub struct MultiRemoteAttachment {
   pub attachments: Vec<RemoteAttachmentInfo>,
 }
@@ -95,55 +111,4 @@ pub fn encode_multi_remote_attachment(
       .map_err(ErrorWrapper::from)?
       .into(),
   )
-}
-
-// Additional types for enriched messages using Vec<u8> instead of Uint8Array
-#[derive(Clone)]
-#[napi(object)]
-pub struct RemoteAttachmentInfoPayload {
-  pub url: String,
-  pub content_digest: String,
-  pub secret: Vec<u8>,
-  pub salt: Vec<u8>,
-  pub nonce: Vec<u8>,
-  pub scheme: String,
-  pub content_length: Option<u32>,
-  pub filename: Option<String>,
-}
-
-impl From<xmtp_proto::xmtp::mls::message_contents::content_types::RemoteAttachmentInfo>
-  for RemoteAttachmentInfoPayload
-{
-  fn from(
-    info: xmtp_proto::xmtp::mls::message_contents::content_types::RemoteAttachmentInfo,
-  ) -> Self {
-    Self {
-      url: info.url,
-      content_digest: info.content_digest,
-      secret: info.secret,
-      salt: info.salt,
-      nonce: info.nonce,
-      scheme: info.scheme,
-      content_length: info.content_length,
-      filename: info.filename,
-    }
-  }
-}
-
-#[derive(Clone)]
-#[napi(object)]
-pub struct MultiRemoteAttachmentPayload {
-  pub attachments: Vec<RemoteAttachmentInfoPayload>,
-}
-
-impl From<xmtp_proto::xmtp::mls::message_contents::content_types::MultiRemoteAttachment>
-  for MultiRemoteAttachmentPayload
-{
-  fn from(
-    multi: xmtp_proto::xmtp::mls::message_contents::content_types::MultiRemoteAttachment,
-  ) -> Self {
-    Self {
-      attachments: multi.attachments.into_iter().map(|a| a.into()).collect(),
-    }
-  }
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Refactor node bindings to return `MultiRemoteAttachment` from `DecodedMessageContent.multi_remote_attachment` for multi remote attachment content type
Replace payload types with napi objects by switching `DecodedMessageContentInner::MultiRemoteAttachment` and the `DecodedMessageContent.multi_remote_attachment` getter to use `MultiRemoteAttachment`, and implement deep `Clone` for `RemoteAttachmentInfo` with new `Uint8Array` buffers; remove `*Payload` structs and their conversions in [bindings_node/src/content_types/multi_remote_attachment.rs](https://github.com/xmtp/libxmtp/pull/2976/files#diff-feb4013acf7b81cfe17012c3d7aa2df6f46c483e197ce090628d4db2e7310872) and update usage in [bindings_node/src/content_types/decoded_message_content.rs](https://github.com/xmtp/libxmtp/pull/2976/files#diff-1115046d4fb5ff9dab2b1f3c8ac9034af1c70345f6b9868028e4f45fe9221052).

#### 📍Where to Start
Start with the `DecodedMessageContent.multi_remote_attachment` getter and the `DecodedMessageContentInner` enum changes in [bindings_node/src/content_types/decoded_message_content.rs](https://github.com/xmtp/libxmtp/pull/2976/files#diff-1115046d4fb5ff9dab2b1f3c8ac9034af1c70345f6b9868028e4f45fe9221052), then review the `RemoteAttachmentInfo` `Clone` impl and removal of payload types in [bindings_node/src/content_types/multi_remote_attachment.rs](https://github.com/xmtp/libxmtp/pull/2976/files#diff-feb4013acf7b81cfe17012c3d7aa2df6f46c483e197ce090628d4db2e7310872).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized b7abe07.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->