### PR TITLE
Add OPFS helpers

### DIFF
--- a/bindings_wasm/src/lib.rs
+++ b/bindings_wasm/src/lib.rs
@@ -11,6 +11,7 @@ pub mod identity;
 pub mod inbox_id;
 pub mod inbox_state;
 pub mod messages;
+pub mod opfs;
 pub mod permissions;
 pub mod signatures;
 pub mod streams;

--- a/bindings_wasm/src/opfs.rs
+++ b/bindings_wasm/src/opfs.rs
@@ -1,0 +1,123 @@
+use js_sys::Uint8Array;
+use wasm_bindgen::prelude::*;
+use xmtp_db::database::{SQLITE, init_sqlite};
+
+/// Initialize the OPFS SQLite VFS if not already initialized.
+/// This must be called before using other OPFS functions.
+#[wasm_bindgen(js_name = opfsInit)]
+pub async fn init_opfs() -> Result<(), JsError> {
+  init_sqlite().await;
+  if let Some(Err(e)) = SQLITE.get() {
+    return Err(JsError::new(&format!("Failed to initialize OPFS: {e}")));
+  }
+  Ok(())
+}
+
+/// List all database files stored in OPFS.
+/// Returns an array of file names.
+#[wasm_bindgen(js_name = opfsListFiles)]
+pub async fn list_files() -> Result<Vec<String>, JsError> {
+  init_sqlite().await;
+  match SQLITE.get() {
+    Some(Ok(util)) => Ok(util.list()),
+    Some(Err(e)) => Err(JsError::new(&format!("OPFS not initialized: {e}"))),
+    None => Err(JsError::new("OPFS not initialized")),
+  }
+}
+
+/// Check if a database file exists in OPFS.
+#[wasm_bindgen(js_name = opfsFileExists)]
+pub async fn file_exists(filename: String) -> Result<bool, JsError> {
+  init_sqlite().await;
+  match SQLITE.get() {
+    Some(Ok(util)) => util
+      .exists(&filename)
+      .map_err(|e| JsError::new(&format!("Failed to check file existence: {e}"))),
+    Some(Err(e)) => Err(JsError::new(&format!("OPFS not initialized: {e}"))),
+    None => Err(JsError::new("OPFS not initialized")),
+  }
+}
+
+/// Delete a specific database file from OPFS.
+/// Returns true if the file was deleted, false if it didn't exist.
+/// Note: The database must be closed before calling this function.
+#[wasm_bindgen(js_name = opfsDeleteFile)]
+pub async fn delete_file(filename: String) -> Result<bool, JsError> {
+  init_sqlite().await;
+  match SQLITE.get() {
+    Some(Ok(util)) => util
+      .delete_db(&filename)
+      .map_err(|e| JsError::new(&format!("Failed to delete file: {e}"))),
+    Some(Err(e)) => Err(JsError::new(&format!("OPFS not initialized: {e}"))),
+    None => Err(JsError::new("OPFS not initialized")),
+  }
+}
+
+/// Delete all database files from OPFS.
+/// Note: All databases must be closed before calling this function.
+#[wasm_bindgen(js_name = opfsClearAll)]
+pub async fn clear_all() -> Result<(), JsError> {
+  init_sqlite().await;
+  match SQLITE.get() {
+    Some(Ok(util)) => util
+      .clear_all()
+      .await
+      .map_err(|e| JsError::new(&format!("Failed to clear all files: {e}"))),
+    Some(Err(e)) => Err(JsError::new(&format!("OPFS not initialized: {e}"))),
+    None => Err(JsError::new("OPFS not initialized")),
+  }
+}
+
+/// Get the number of database files stored in OPFS.
+#[wasm_bindgen(js_name = opfsFileCount)]
+pub async fn file_count() -> Result<u32, JsError> {
+  init_sqlite().await;
+  match SQLITE.get() {
+    Some(Ok(util)) => Ok(util.count()),
+    Some(Err(e)) => Err(JsError::new(&format!("OPFS not initialized: {e}"))),
+    None => Err(JsError::new("OPFS not initialized")),
+  }
+}
+
+/// Get the current capacity of the OPFS file pool.
+#[wasm_bindgen(js_name = opfsPoolCapacity)]
+pub async fn pool_capacity() -> Result<u32, JsError> {
+  init_sqlite().await;
+  match SQLITE.get() {
+    Some(Ok(util)) => Ok(util.get_capacity()),
+    Some(Err(e)) => Err(JsError::new(&format!("OPFS not initialized: {e}"))),
+    None => Err(JsError::new("OPFS not initialized")),
+  }
+}
+
+/// Export a database file from OPFS as a byte array.
+/// This can be used to backup or transfer a database.
+/// Note: The database should be closed before exporting for consistency.
+#[wasm_bindgen(js_name = opfsExportDb)]
+pub async fn export_db(filename: String) -> Result<Uint8Array, JsError> {
+  init_sqlite().await;
+  match SQLITE.get() {
+    Some(Ok(util)) => util
+      .export_db(&filename)
+      .map(|data: Vec<u8>| Uint8Array::from(data.as_slice()))
+      .map_err(|e| JsError::new(&format!("Failed to export database: {e}"))),
+    Some(Err(e)) => Err(JsError::new(&format!("OPFS not initialized: {e}"))),
+    None => Err(JsError::new("OPFS not initialized")),
+  }
+}
+
+/// Import a database from a byte array into OPFS.
+/// This will overwrite any existing database with the same name.
+/// The byte array must contain a valid SQLite database.
+/// Note: Any existing database with the same name must be closed before importing.
+#[wasm_bindgen(js_name = opfsImportDb)]
+pub async fn import_db(filename: String, data: Uint8Array) -> Result<(), JsError> {
+  init_sqlite().await;
+  match SQLITE.get() {
+    Some(Ok(util)) => util
+      .import_db(&filename, data.to_vec().as_slice())
+      .map_err(|e| JsError::new(&format!("Failed to import database: {e}"))),
+    Some(Err(e)) => Err(JsError::new(&format!("OPFS not initialized: {e}"))),
+    None => Err(JsError::new("OPFS not initialized")),
+  }
+}

--- a/bindings_wasm/test/opfs.test.ts
+++ b/bindings_wasm/test/opfs.test.ts
@@ -1,0 +1,294 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+// OPFS with Synchronous Access Handles (SAH) requires a Web Worker context.
+// These tests run the OPFS functions inside a dedicated worker.
+
+describe("OPFS File Management", () => {
+  let worker: Worker;
+  let messageId = 0;
+
+  // Helper to call worker methods
+  const callWorker = (method: string, params?: any) => {
+    return new Promise((resolve, reject) => {
+      const id = ++messageId;
+
+      const handler = (event: MessageEvent) => {
+        if (event.data.id === id) {
+          worker.removeEventListener("message", handler);
+          if (event.data.error) {
+            reject(new Error(event.data.error));
+          } else {
+            resolve(event.data.result);
+          }
+        }
+      };
+
+      worker.addEventListener("message", handler);
+      worker.postMessage({ id, method, params });
+    });
+  };
+
+  beforeAll(async () => {
+    // Create worker with module type
+    worker = new Worker(new URL("./opfs.worker.js", import.meta.url), {
+      type: "module",
+    });
+  });
+
+  afterAll(() => {
+    if (worker) {
+      worker.terminate();
+    }
+  });
+
+  beforeEach(async () => {
+    // Clear all files before each test
+    await callWorker("clearAll");
+  });
+
+  describe("Basic OPFS operations", () => {
+    it("should list files (initially empty after clear)", async () => {
+      const files = await callWorker("listFiles");
+      expect(files).toHaveLength(0);
+    });
+
+    it("should report file count as 0 after clear", async () => {
+      const count = await callWorker("fileCount");
+      expect(typeof count).toBe("number");
+      expect(count).toBe(0);
+    });
+
+    it("should report pool capacity", async () => {
+      const capacity = await callWorker("poolCapacity");
+      expect(typeof capacity).toBe("number");
+      expect(capacity).toBeGreaterThanOrEqual(6); // Initial capacity is 6
+    });
+
+    it("should return false for non-existent file", async () => {
+      const exists = await callWorker("fileExists", {
+        filename: "non-existent-db",
+      });
+      expect(exists).toBe(false);
+    });
+
+    it("should return false when deleting non-existent file", async () => {
+      const deleted = await callWorker("deleteFile", {
+        filename: "non-existent-file",
+      });
+      expect(deleted).toBe(false);
+    });
+  });
+
+  describe("OPFS with persistent client", () => {
+    it("should create database file when client is created", async () => {
+      const dbPath = "test-client-db";
+
+      // Create a client with persistent storage
+      const { inboxId } = (await callWorker("createClient", { dbPath })) as {
+        inboxId: string;
+      };
+      expect(inboxId).toBeDefined();
+
+      // Check that files were created
+      const count = await callWorker("fileCount");
+      expect(count).toBeGreaterThan(0);
+
+      // The database should exist
+      const exists = await callWorker("fileExists", { filename: dbPath });
+      expect(exists).toBe(true);
+
+      // List should include the file
+      const files = await callWorker("listFiles");
+      expect(files).toContain(dbPath);
+      expect(files).toHaveLength(1);
+    });
+
+    it("should create multiple database files", async () => {
+      const dbPath1 = "test-client-db-1";
+      const dbPath2 = "test-client-db-2";
+
+      await callWorker("createClient", { dbPath: dbPath1 });
+      await callWorker("createClient", { dbPath: dbPath2 });
+
+      const files = await callWorker("listFiles");
+      expect(files).toContain(dbPath1);
+      expect(files).toContain(dbPath2);
+      expect(files).toHaveLength(2);
+
+      expect(await callWorker("fileExists", { filename: dbPath1 })).toBe(true);
+      expect(await callWorker("fileExists", { filename: dbPath2 })).toBe(true);
+    });
+
+    it("should delete a specific database file", async () => {
+      const dbPath = "test-delete-db";
+
+      await callWorker("createClient", { dbPath });
+      expect(await callWorker("fileExists", { filename: dbPath })).toBe(true);
+
+      // Delete the file
+      const deleted = await callWorker("deleteFile", { filename: dbPath });
+      expect(deleted).toBe(true);
+
+      // Verify it's gone
+      expect(await callWorker("fileExists", { filename: dbPath })).toBe(false);
+
+      const files = await callWorker("listFiles");
+      expect(files).toHaveLength(0);
+    });
+
+    it("should clear all database files", async () => {
+      // Create multiple databases
+      await callWorker("createClient", { dbPath: "clear-test-1" });
+      await callWorker("createClient", { dbPath: "clear-test-2" });
+
+      const countBefore = await callWorker("fileCount");
+      expect(countBefore).toBeGreaterThan(0);
+
+      // Clear all
+      await callWorker("clearAll");
+
+      const countAfter = await callWorker("fileCount");
+      expect(countAfter).toBe(0);
+
+      const files = await callWorker("listFiles");
+      expect(files).toHaveLength(0);
+    });
+  });
+
+  describe("Database export and import", () => {
+    it("should export a database file", async () => {
+      const dbPath = "test-export-db";
+
+      // Create a client with persistent storage
+      await callWorker("createClient", { dbPath });
+
+      // Export the database
+      const data = (await callWorker("exportDb", {
+        filename: dbPath,
+      })) as Uint8Array;
+
+      // Verify we got data back
+      expect(data instanceof Uint8Array).toBe(true);
+      expect(data.length).toBeGreaterThan(0);
+
+      // SQLite databases start with "SQLite format 3\0"
+      const header = String.fromCharCode(...data.slice(0, 16));
+      expect(header).toBe("SQLite format 3\0");
+    });
+
+    it("should import a database file", async () => {
+      const originalDbPath = "test-import-original";
+      const importDbPath = "test-import-new";
+
+      // Create a client to generate a database
+      await callWorker("createClient", { dbPath: originalDbPath });
+
+      // Export the original database
+      const exportedData = await callWorker("exportDb", {
+        filename: originalDbPath,
+      });
+
+      // Import it with a new name
+      await callWorker("importDb", {
+        filename: importDbPath,
+        data: exportedData,
+      });
+
+      // Verify the imported file exists
+      expect(await callWorker("fileExists", { filename: importDbPath })).toBe(
+        true,
+      );
+
+      // Verify we now have both files
+      const files = await callWorker("listFiles");
+      expect(files).toContain(originalDbPath);
+      expect(files).toContain(importDbPath);
+      expect(files).toHaveLength(2);
+    });
+
+    it("should replace database by deleting then importing", async () => {
+      const dbPath = "test-replace-db";
+
+      // Create first client
+      const { inboxId: originalInboxId } = (await callWorker("createClient", {
+        dbPath,
+      })) as {
+        inboxId: string;
+      };
+
+      // Export the original database
+      const exportedData = (await callWorker("exportDb", {
+        filename: dbPath,
+      })) as Uint8Array;
+      const originalSize = exportedData.length;
+
+      // Delete and create a new client with same path (different data)
+      await callWorker("deleteFile", { filename: dbPath });
+      const { inboxId: client2InboxId } = (await callWorker("createClient", {
+        dbPath,
+      })) as {
+        inboxId: string;
+      };
+      expect(client2InboxId).not.toBe(originalInboxId);
+
+      // Delete the new database and import the original
+      await callWorker("deleteFile", { filename: dbPath });
+      await callWorker("importDb", {
+        filename: dbPath,
+        data: exportedData,
+      });
+
+      // Re-export and verify size matches original
+      const restoredData = (await callWorker("exportDb", {
+        filename: dbPath,
+      })) as Uint8Array;
+      expect(restoredData.length).toBe(originalSize);
+    });
+
+    it("should fail to export non-existent database", async () => {
+      await expect(
+        callWorker("exportDb", { filename: "non-existent-db" }),
+      ).rejects.toThrow();
+    });
+
+    it("should fail to import invalid data", async () => {
+      // Try to import garbage data (not a valid SQLite database)
+      const invalidData = [1, 2, 3, 4, 5];
+
+      await expect(
+        callWorker("importDb", {
+          filename: "invalid-import",
+          data: invalidData,
+        }),
+      ).rejects.toThrow();
+    });
+
+    it("should roundtrip export and import", async () => {
+      const originalDbPath = "test-roundtrip-original";
+      const copyDbPath = "test-roundtrip-copy";
+
+      // Create original database
+      await callWorker("createClient", { dbPath: originalDbPath });
+
+      // Export
+      const exportedData = (await callWorker("exportDb", {
+        filename: originalDbPath,
+      })) as Uint8Array;
+
+      // Import as copy
+      await callWorker("importDb", {
+        filename: copyDbPath,
+        data: exportedData,
+      });
+
+      // Export the copy
+      const reExportedData = (await callWorker("exportDb", {
+        filename: copyDbPath,
+      })) as Uint8Array;
+
+      // Verify they match
+      expect(reExportedData.length).toBe(exportedData.length);
+      expect(reExportedData).toEqual(exportedData);
+    });
+  });
+});

--- a/bindings_wasm/test/opfs.worker.js
+++ b/bindings_wasm/test/opfs.worker.js
@@ -1,0 +1,92 @@
+import init, {
+  createTestClient,
+  opfsClearAll,
+  opfsDeleteFile,
+  opfsExportDb,
+  opfsFileCount,
+  opfsFileExists,
+  opfsImportDb,
+  opfsInit,
+  opfsListFiles,
+  opfsPoolCapacity,
+} from "../dist/bindings_wasm";
+
+let initialized = false;
+
+async function ensureInit() {
+  if (!initialized) {
+    await init();
+    await opfsInit();
+    initialized = true;
+  }
+}
+
+const handlers = {
+  async init() {
+    await ensureInit();
+    return { success: true };
+  },
+
+  async listFiles() {
+    await ensureInit();
+    return await opfsListFiles();
+  },
+
+  async fileExists({ filename }) {
+    await ensureInit();
+    return await opfsFileExists(filename);
+  },
+
+  async deleteFile({ filename }) {
+    await ensureInit();
+    return await opfsDeleteFile(filename);
+  },
+
+  async clearAll() {
+    await ensureInit();
+    await opfsClearAll();
+    return { success: true };
+  },
+
+  async fileCount() {
+    await ensureInit();
+    return await opfsFileCount();
+  },
+
+  async poolCapacity() {
+    await ensureInit();
+    return await opfsPoolCapacity();
+  },
+
+  async createClient({ dbPath }) {
+    await ensureInit();
+    const client = await createTestClient(dbPath);
+    return { inboxId: client.inboxId };
+  },
+
+  async exportDb({ filename }) {
+    await ensureInit();
+    return opfsExportDb(filename);
+  },
+
+  async importDb({ filename, data }) {
+    await ensureInit();
+    await opfsImportDb(filename, data);
+    return { success: true };
+  },
+};
+
+self.onmessage = async (event) => {
+  const { id, method, params } = event.data;
+
+  try {
+    if (handlers[method]) {
+      const result = await handlers[method](params || {});
+      self.postMessage({ id, result });
+    } else {
+      self.postMessage({ id, error: `Unknown method: ${method}` });
+    }
+  } catch (error) {
+    self.postMessage({ id, error: error.message || String(error) });
+  }
+};


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Expose OPFS helpers and WebAssembly exports for SQLite OPFS operations in `bindings_wasm/src/opfs.rs` and export module in `bindings_wasm/src/lib.rs`
Add `pub mod opfs` and implement async WebAssembly exports for OPFS init, file listing, existence, deletion, clearing, count, pool capacity, and DB export/import, with tests running in a Web Worker.

#### 📍Where to Start
Start with the OPFS wasm exports in [opfs.rs](https://github.com/xmtp/libxmtp/pull/2981/files#diff-240b8cb26acfcf6e28e1086d5a4490d6627bcf122b1ea4d38d0e76a01112b545), then review the module export in [lib.rs](https://github.com/xmtp/libxmtp/pull/2981/files#diff-0a9c0714652f5796f764ac77ed9cbbb06842016b3344ee5b4ee9fe2ad6373e77) and the worker-based tests in [opfs.test.ts](https://github.com/xmtp/libxmtp/pull/2981/files#diff-1b5de9eedc0adc06ffe8c857dee05aaecb6f647f9a595e164720318ddb5256e0).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 9d4c6a1.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->