### PR TITLE
add exponential backoff to `sync_until_intent_resolved`

### DIFF
--- a/common/src/event_logging.rs
+++ b/common/src/event_logging.rs
@@ -41,7 +41,7 @@ pub enum Event {
     #[context(group_id)]
     GroupSyncStart,
     /// Attempting to sync group.
-    #[context(group_id, attempt)]
+    #[context(group_id, attempt, backoff)]
     GroupSyncAttempt,
     /// Group sync complete.
     #[context(group_id, summary, success)]

--- a/xmtp_configuration/src/common/mls.rs
+++ b/xmtp_configuration/src/common/mls.rs
@@ -47,3 +47,14 @@ pub const MIN_RECOVERY_REQUEST_VERSION: &str = "1.6.0";
 // ingested by the nodes and stored. There is a slight penalty for egress data, but the amount needed
 // to be stored can be 100x less than using regular welcome messages.
 pub const INSTALLATION_THRESHOLD_FOR_WELCOME_POINTER_SENDING: usize = 2;
+
+// Exponential Backoff constants for Intent Sync
+// for max group sync retries of 3 and a max jitter of 25ms with a 50ms base, the maximum possible
+// wait is 2025ms (2.025s) well under the 10s limit
+
+/// the base backoff time that is multiplied by 3
+pub const SYNC_BACKOFF_WAIT_MS: u16 = 50;
+/// the total wait for all attempts
+pub const SYNC_BACKOFF_TOTAL_WAIT_MAX_SECS: u16 = 10;
+/// jitter time between attempts in ms
+pub const SYNC_JITTER_MS: u16 = 25;

--- a/xmtp_mls/src/groups/mls_sync.rs
+++ b/xmtp_mls/src/groups/mls_sync.rs
@@ -60,14 +60,19 @@ use std::{
     collections::{HashMap, HashSet, VecDeque},
     mem::{Discriminant, discriminant},
     ops::RangeInclusive,
+    time::Duration,
 };
 use thiserror::Error;
 use tracing::debug;
 use update_group_membership::apply_update_group_membership_intent;
-use xmtp_common::{Event, Retry, RetryableError, log_event, retry_async, time::now_ns};
+use xmtp_common::{
+    Event, ExponentialBackoff, Retry, RetryableError, Strategy, log_event, retry_async,
+    time::now_ns,
+};
 use xmtp_configuration::{
-    GRPC_PAYLOAD_LIMIT, HMAC_SALT, MAX_GROUP_SIZE, MAX_INTENT_PUBLISH_ATTEMPTS, MAX_PAST_EPOCHS,
-    SYNC_UPDATE_INSTALLATIONS_INTERVAL_NS,
+    GRPC_PAYLOAD_LIMIT, HMAC_SALT, MAX_GROUP_SIZE, MAX_GROUP_SYNC_RETRIES,
+    MAX_INTENT_PUBLISH_ATTEMPTS, MAX_PAST_EPOCHS, SYNC_BACKOFF_TOTAL_WAIT_MAX_SECS,
+    SYNC_BACKOFF_WAIT_MS, SYNC_JITTER_MS, SYNC_UPDATE_INSTALLATIONS_INTERVAL_NS,
 };
 use xmtp_content_types::{CodecError, ContentCodec, group_updated::GroupUpdatedCodec};
 use xmtp_db::group::GroupMembershipState;
@@ -484,13 +489,26 @@ where
         let mut summary = SyncSummary::default();
         let db = self.context.db();
 
+        let time_spent = xmtp_common::time::Instant::now();
+        let backoff = ExponentialBackoff::builder()
+            .duration(Duration::from_millis(SYNC_BACKOFF_WAIT_MS.into()))
+            .total_wait_max(Duration::from_secs(SYNC_BACKOFF_TOTAL_WAIT_MAX_SECS.into()))
+            .max_jitter(Duration::from_millis(SYNC_JITTER_MS.into()))
+            .build();
+
         // Return the last error to the caller if we fail to sync
-        for attempt in 0..xmtp_configuration::MAX_GROUP_SYNC_RETRIES {
+        for attempt in 0..MAX_GROUP_SYNC_RETRIES {
+            let wait_for = backoff
+                .backoff(attempt + 1, time_spent)
+                .unwrap_or(Duration::from_millis(50));
+
             log_event!(
                 Event::GroupSyncAttempt,
                 group_id = hex::encode(&self.group_id),
-                attempt
+                attempt,
+                backoff = ?wait_for
             );
+
             match self.sync_with_conn().await {
                 Ok(s) => summary.extend(s),
                 Err(s) => {
@@ -540,6 +558,9 @@ where
                     summary.add_other(GroupError::Storage(err));
                 }
             };
+            if attempt + 1 < MAX_GROUP_SYNC_RETRIES {
+                xmtp_common::time::sleep(wait_for).await;
+            }
         }
         Err(GroupError::SyncFailedToWait(Box::new(summary)))
     }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add exponential backoff with jitter to group intent sync retries in `xmtp_mls::groups::mls_sync::Group::sync_until_intent_resolved_inner`, logging `backoff` per attempt and bounding total wait by `SYNC_BACKOFF_TOTAL_WAIT_MAX_SECS`
Introduce configurable exponential backoff for group sync retries, add `backoff` to `Event::GroupSyncAttempt` logs, and set buffered output with explicit flush in stream run.

#### 📍Where to Start
Start at `Group::sync_until_intent_resolved_inner` in [xmtp_mls/src/groups/mls_sync.rs](https://github.com/xmtp/libxmtp/pull/2985/files#diff-10f818f7918c8c0b2ed32c4f63e5060050527ed58df00ec081bbecb66065144e).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized f1219a2.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->