### PR TITLE
Fix decoding of custom content in replies

### DIFF
--- a/xmtp_mls/src/groups/message_list.rs
+++ b/xmtp_mls/src/groups/message_list.rs
@@ -694,4 +694,72 @@ mod tests {
             panic!("Expected reply message");
         }
     }
+
+    #[tokio::test]
+    async fn test_reply_with_custom_inner_content() {
+        let (group, context) = setup_test_group().await;
+        let conn = context.db();
+
+        // Store original message
+        let msg_id = vec![1, 2, 3];
+        let msg_id_hex = msg_id.encode_hex();
+        create_and_store_message(
+            &conn,
+            &group.group_id,
+            msg_id.clone(),
+            TestContentGenerator::text_content("Original message"),
+            0,
+            "sender1",
+        );
+
+        // Create a custom/unknown content type
+        let custom_content_type = ContentTypeId {
+            authority_id: "custom.org".to_string(),
+            type_id: "custom/payload".to_string(),
+            version_major: 1,
+            version_minor: 0,
+        };
+
+        // Store a reply with custom inner content
+        let reply_id = create_and_store_message(
+            &conn,
+            &group.group_id,
+            vec![4, 5, 6],
+            TestContentGenerator::reply_content(
+                &msg_id_hex,
+                custom_content_type,
+                b"custom payload data".to_vec(),
+            ),
+            1000,
+            "replier1",
+        );
+
+        // Query messages
+        let messages = group.find_messages_v2(&MsgQueryArgs::default()).unwrap();
+        assert_message_count(&messages, 2);
+
+        // Find the reply message
+        let reply_msg = find_message_by_id(&messages, &reply_id);
+
+        // Verify the message is decoded as Reply (not Custom)
+        if let MessageBody::Reply(reply) = &reply_msg.content {
+            // The reply should reference the original message
+            assert!(reply.in_reply_to.is_some());
+            let referenced = reply.in_reply_to.as_ref().unwrap();
+            assert_eq!(referenced.metadata.id, msg_id);
+
+            // The inner content should be Custom (since we used an unknown content type)
+            if let MessageBody::Custom(custom) = reply.content.as_ref() {
+                assert_eq!(custom.r#type.as_ref().unwrap().type_id, "custom/payload");
+                assert_eq!(custom.content, b"custom payload data");
+            } else {
+                panic!(
+                    "Expected Custom inner content in Reply, got {:?}",
+                    reply.content
+                );
+            }
+        } else {
+            panic!("Expected Reply message, got {:?}", reply_msg.content);
+        }
+    }
 }

--- a/xmtp_mls/src/messages/decoded_message.rs
+++ b/xmtp_mls/src/messages/decoded_message.rs
@@ -133,7 +133,13 @@ impl TryFrom<EncodedContent> for MessageBody {
             }
             (ReplyCodec::TYPE_ID, ReplyCodec::MAJOR_VERSION) => {
                 let reply = ReplyCodec::decode(value)?;
-                let content: MessageBody = reply.content.try_into()?;
+                // if the inner content uses a custom content type, try_into
+                // will fail. in that case, wrap it as custom content.
+                let content: MessageBody = reply
+                    .content
+                    .clone()
+                    .try_into()
+                    .unwrap_or(MessageBody::Custom(reply.content));
                 Ok(MessageBody::Reply(Reply {
                     in_reply_to: None,
                     content: Box::new(content),


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Fix decoding of `Reply` inner content with unknown types in `xmtp_mls::messages::decoded_message::MessageBody::TryFrom<EncodedContent>` to support custom content in replies
Update `Reply` decoding to fall back to `MessageBody::Custom` when inner content conversion fails and add a tokio test covering a reply with a custom `ContentTypeId`. Key changes in [message_list.rs](https://github.com/xmtp/libxmtp/pull/3003/files#diff-221be37215efcd747a9027eb9b80fd68f4362bf12f87d92219cf09b02d87c468) and [decoded_message.rs](https://github.com/xmtp/libxmtp/pull/3003/files#diff-0f2f8821d2e9aa1d55c1968fcc5258870086f982d88c44b4126c4af508b82763).

#### 📍Where to Start
Start with the `TryFrom<EncodedContent>` implementation for `MessageBody` in [decoded_message.rs](https://github.com/xmtp/libxmtp/pull/3003/files#diff-0f2f8821d2e9aa1d55c1968fcc5258870086f982d88c44b4126c4af508b82763) and then review the `test_reply_with_custom_inner_content` in [message_list.rs](https://github.com/xmtp/libxmtp/pull/3003/files#diff-221be37215efcd747a9027eb9b80fd68f4362bf12f87d92219cf09b02d87c468).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 6e8a0b9.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->