### PR TITLE
improve nix cache action & add binaries to cache

### DIFF
--- a/.github/workflows/check-ios-android-bindings.yml
+++ b/.github/workflows/check-ios-android-bindings.yml
@@ -28,10 +28,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: nixbuild/nix-quick-install-action@v34
+      - run: nix build --version
+      - uses: nix-community/cache-nix-action@v6
         with:
-          determinate: true
-      - uses: DeterminateSystems/flakehub-cache-action@main
+          primary-key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          paths: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
       - name: Build target
         run: |
           nix develop .#ios --accept-flake-config --command \
@@ -53,14 +60,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - uses: DeterminateSystems/nix-installer-action@main
-        with:
-          determinate: true
-      - uses: DeterminateSystems/flakehub-cache-action@main
+      - uses: nixbuild/nix-quick-install-action@v34
+      - run: nix build --version
       - uses: cachix/cachix-action@v16
         with:
           name: xmtp
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      - uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          paths: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
       - name: check target
         run: |
           nix develop .#android --accept-flake-config --command \

--- a/.github/workflows/fh-cache.yml
+++ b/.github/workflows/fh-cache.yml
@@ -1,3 +1,4 @@
+name: Cache all Nix Outputs
 on:
   workflow_dispatch:
   push:
@@ -9,36 +10,33 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
-  flakehub-publish:
+  build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest] # Define the operating systems for the matrix
-    runs-on: ${{ matrix.os }} # Use the 'os' variable from the matrix for the runner
+        os: [warp-ubuntu-latest-x64-16x, warp-macos-15-arm64-6x]
+    runs-on: ${{ matrix.os }}
     permissions:
       id-token: write
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - uses: wimpysworld/nothing-but-nix@main
-        if: runner.os == 'Linux'
+      - uses: nixbuild/nix-quick-install-action@v34
+      - run: nix build --version
+      - uses: nix-community/cache-nix-action@v6
         with:
-          hatchet-protocol: "cleave"
-      - uses: DeterminateSystems/determinate-nix-action@v3
+          primary-key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          paths: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
       - name: Install omnix
         run: nix profile install nixpkgs#omnix
       - name: build all flake outputs
-        run: om ci run --include-all-dependencies --results=om.json
+        run: om ci run --include-all-dependencies --results=om.json -- --accept-flake-config
       - name: push to cachix
-        if: env.BRANCH_NAME == 'main'
         run: nix run github:juspay/cachix-push -- --cache xmtp --subflake ROOT --prefix "$BRANCH_NAME" < om.json
         env:
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-      - uses: DeterminateSystems/flakehub-cache-action@main
-      - run: om ci run --include-all-dependencies
-      - uses: DeterminateSystems/flakehub-push@main
-        with:
-          visibility: "public"
-          rolling: true
-          name: "xmtp/libxmtp"
-          include-output-paths: true

--- a/.github/workflows/test-webassembly.yml
+++ b/.github/workflows/test-webassembly.yml
@@ -21,8 +21,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
 jobs:
   test:
     name: Test
@@ -33,26 +31,28 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        # sccache beats swatinem/rust-cache most of the time
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@main
-      - name: Run sccache stat for check
-        shell: bash
-        run: ${SCCACHE_PATH} --show-stats
-      - name: Start Docker containers
-        run: |
-          dev/build_validation_service_local
-          dev/docker/up
-      - uses: DeterminateSystems/nix-installer-action@main
-        with:
-          determinate: true
-      - uses: DeterminateSystems/flakehub-cache-action@main
+      - uses: nixbuild/nix-quick-install-action@v34
+      - run: nix build --version
       - uses: cachix/cachix-action@v16
         with:
           name: xmtp
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      #     - uses: nix-community/cache-nix-action@v6
+      #       with:
+      #         primary-key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      #         paths: |
+      #           ~/.cargo/bin/
+      #           ~/.cargo/registry/index/
+      #           ~/.cargo/registry/cache/
+      #           ~/.cargo/git/db/
+      #           target/
       - name: Install omnix
         run: nix profile install nixpkgs#omnix
+
+      - name: Start Docker containers
+        run: |
+          nix build .#docker-mls_validation_service --accept-flake-config
+          dev/docker/up
       - name: run tests
         run: om ci run .#wasm -- --accept-flake-config
       - name: webassembly integration tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6463,10 +6463,11 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.7"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,57 +1,22 @@
 [workspace]
 members = [
   # Applications
-  "apps/cli",
-  "apps/mls_validation_service",
+  "apps/[!android]*",
   # Bindings
-  "bindings/mobile",
-  "bindings/node",
-  "bindings/wasm",
+  "bindings/*",
   # Core crates
-  "crates/db_tools",
-  "crates/wasm_macros",
-  "crates/xmtp_api",
-  "crates/xmtp_api_d14n",
-  "crates/xmtp_api_grpc",
-  "crates/xmtp_archive",
-  "crates/xmtp_common",
-  "crates/xmtp_configuration",
-  "crates/xmtp_content_types",
-  "crates/xmtp_cryptography",
-  "crates/xmtp_db",
-  "crates/xmtp_db_test",
-  "crates/xmtp_debug",
-  "crates/xmtp_id",
-  "crates/xmtp_macro",
-  "crates/xmtp_mls",
-  "crates/xmtp_mls_common",
-  "crates/xmtp_proto",
+  "crates/*",
 ]
 
-# Used when cargo commands in the workspace root, such as `cargo test`, are run without flags.
-# Excludes `bindings/wasm` by default, since those bindings only build for the WASM target.
 default-members = [
   # Applications
-  "apps/cli",
-  "apps/mls_validation_service",
+  "apps/[!android]*",
   # Bindings (excluding wasm - only for wasm32 target)
-  "bindings/mobile",
-  "bindings/node",
+  "bindings/[!wasm]*",
   # Core crates
-  "crates/xmtp_api",
-  "crates/xmtp_api_d14n",
-  "crates/xmtp_api_grpc",
-  "crates/xmtp_common",
-  "crates/xmtp_configuration",
-  "crates/xmtp_content_types",
-  "crates/xmtp_cryptography",
-  "crates/xmtp_db",
-  "crates/xmtp_debug",
-  "crates/xmtp_id",
-  "crates/xmtp_macro",
-  "crates/xmtp_mls",
-  "crates/xmtp_proto",
-]
+  "crates/*",
+] # Used when cargo commands in the workspace root, such as `cargo test`, are run without flags.
+# Excludes `bindings/wasm` by default, since those bindings only build for the WASM target.
 
 # Make the feature resolver explicit.
 # See https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html#details

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,3 +20,4 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     org.label-schema.version=$VERSION \
     org.label-schema.schema-version="1.0" \
     org.opencontainers.image.description="Rust Development Container"
+

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -7,6 +7,7 @@ name = "xmtp_cli"
 readme = "README.md"
 repository = "https://github.com/xmtp/libxmtp"
 version.workspace = true
+description = "cli that can send and receive messages on XMTP"
 
 [[bin]]
 name = "xmtp_cli"

--- a/apps/mls_validation_service/Cargo.toml
+++ b/apps/mls_validation_service/Cargo.toml
@@ -4,6 +4,7 @@ edition = "2024"
 name = "mls_validation_service"
 version.workspace = true
 license.workspace = true
+description = "backend validation service for XMTP"
 
 [[bin]] # Bin to run the Validation Service
 name = "mls-validation-service"

--- a/bindings/mobile/Cargo.toml
+++ b/bindings/mobile/Cargo.toml
@@ -3,6 +3,7 @@ edition = "2024"
 name = "xmtpv3"
 version.workspace = true
 license.workspace = true
+description = "iOS/Android bindings to the XMTP mls libraries"
 
 [lib]
 crate-type = ["lib", "cdylib", "staticlib"]

--- a/bindings/node/Cargo.toml
+++ b/bindings/node/Cargo.toml
@@ -2,6 +2,7 @@
 edition = "2024"
 name = "bindings_node"
 version.workspace = true
+description = "nodeJS bindings to the XMTP mls libraries"
 
 [lints]
 workspace = true

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -2,6 +2,7 @@
 edition = "2024"
 name = "bindings_wasm"
 version.workspace = true
+description = "WebAssembly bindings to the XMTP mls libraries"
 
 [lints]
 workspace = true

--- a/crates/db_tools/Cargo.toml
+++ b/crates/db_tools/Cargo.toml
@@ -3,6 +3,7 @@ name = "xmtp-db-tools"
 edition = "2024"
 license.workspace = true
 version.workspace = true
+description = "migration/SQLite tools for xmtp databases"
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/wasm_macros/Cargo.toml
+++ b/crates/wasm_macros/Cargo.toml
@@ -3,6 +3,7 @@ name = "bindings_wasm_macros"
 license.workspace = true
 version.workspace = true
 edition = "2024"
+description = "utility macros for webassembly bindings"
 
 [lib]
 proc-macro = true

--- a/crates/xmtp_api/Cargo.toml
+++ b/crates/xmtp_api/Cargo.toml
@@ -3,6 +3,7 @@ name = "xmtp_api"
 edition = "2024"
 license.workspace = true
 version.workspace = true
+description = "XMTP Api high level wrapper"
 
 [lints]
 workspace = true

--- a/crates/xmtp_api_d14n/Cargo.toml
+++ b/crates/xmtp_api_d14n/Cargo.toml
@@ -3,6 +3,7 @@ name = "xmtp_api_d14n"
 edition = "2024"
 license.workspace = true
 version.workspace = true
+description = "XMTP Decentralization client implementation according to XIP-49"
 
 [lints]
 workspace = true

--- a/crates/xmtp_api_grpc/Cargo.toml
+++ b/crates/xmtp_api_grpc/Cargo.toml
@@ -3,6 +3,7 @@ edition = "2024"
 license.workspace = true
 name = "xmtp_api_grpc"
 version.workspace = true
+description = "gRPC primitives and traits for native and WebAssembly"
 
 [dependencies]
 async-trait.workspace = true

--- a/crates/xmtp_archive/Cargo.toml
+++ b/crates/xmtp_archive/Cargo.toml
@@ -3,6 +3,7 @@ name = "xmtp_archive"
 edition = "2024"
 license.workspace = true
 version.workspace = true
+description = "archive and backup features for xmtp"
 
 [lints]
 workspace = true

--- a/crates/xmtp_common/Cargo.toml
+++ b/crates/xmtp_common/Cargo.toml
@@ -3,6 +3,7 @@ name = "xmtp_common"
 edition = "2024"
 version.workspace = true
 license.workspace = true
+description = "common utilities"
 
 [dependencies]
 async-trait.workspace = true

--- a/crates/xmtp_common/src/macros.rs
+++ b/crates/xmtp_common/src/macros.rs
@@ -38,7 +38,7 @@ macro_rules! wasm_or_native {
 
 /// Convenience macro to easily evaluate an expression for wasm or native
 /// # Example
-/// ```rust
+/// ```ignore
 /// let path = wasm_or_native_expr! {
 ///     wasm => "wasm".to_string(),
 ///     native => "native".into(),

--- a/crates/xmtp_configuration/Cargo.toml
+++ b/crates/xmtp_configuration/Cargo.toml
@@ -3,6 +3,7 @@ name = "xmtp_configuration"
 edition = "2024"
 license.workspace = true
 version.workspace = true
+description = "global configuration for xmtp crates"
 
 [dependencies]
 openmls.workspace = true

--- a/crates/xmtp_content_types/Cargo.toml
+++ b/crates/xmtp_content_types/Cargo.toml
@@ -3,6 +3,7 @@ edition = "2024"
 name = "xmtp_content_types"
 version.workspace = true
 license.workspace = true
+description = "xmtp content types"
 
 [features]
 test-utils = []

--- a/crates/xmtp_cryptography/Cargo.toml
+++ b/crates/xmtp_cryptography/Cargo.toml
@@ -4,6 +4,7 @@ name = "xmtp_cryptography"
 rust-version = "1.85"
 version.workspace = true
 license.workspace = true
+description = "cryptography primitives for xmtp"
 
 [package.metadata.docs.rs]
 targets = [

--- a/crates/xmtp_db/Cargo.toml
+++ b/crates/xmtp_db/Cargo.toml
@@ -3,6 +3,7 @@ name = "xmtp_db"
 edition = "2024"
 license.workspace = true
 version.workspace = true
+description = "SQLite interface for XMTP"
 
 [lints]
 workspace = true

--- a/crates/xmtp_db_test/Cargo.toml
+++ b/crates/xmtp_db_test/Cargo.toml
@@ -3,6 +3,7 @@ name = "xmtp_db_test"
 edition = "2024"
 license.workspace = true
 version.workspace = true
+description = "local db chaos testing"
 
 [lints]
 workspace = true

--- a/crates/xmtp_id/Cargo.toml
+++ b/crates/xmtp_id/Cargo.toml
@@ -3,6 +3,7 @@ edition = "2024"
 license.workspace = true
 name = "xmtp_id"
 version.workspace = true
+description = "XMTP Identity implementation according to XIP-46"
 
 [lints]
 workspace = true

--- a/crates/xmtp_macro/Cargo.toml
+++ b/crates/xmtp_macro/Cargo.toml
@@ -3,6 +3,7 @@ name = "xmtp_macro"
 edition = "2024"
 license.workspace = true
 version.workspace = true
+description = "XMTP Utility Macros"
 
 [lints]
 workspace = true

--- a/crates/xmtp_mls/Cargo.toml
+++ b/crates/xmtp_mls/Cargo.toml
@@ -3,6 +3,7 @@ edition = "2024"
 license.workspace = true
 name = "xmtp_mls"
 version.workspace = true
+description = "XMTP core MLS Implementation on top of openmls"
 
 [lints]
 workspace = true

--- a/crates/xmtp_mls_common/Cargo.toml
+++ b/crates/xmtp_mls_common/Cargo.toml
@@ -3,6 +3,7 @@ name = "xmtp_mls_common"
 edition = "2024"
 license.workspace = true
 version.workspace = true
+description = "common MLS utilties"
 
 [lints]
 workspace = true

--- a/crates/xmtp_proto/Cargo.toml
+++ b/crates/xmtp_proto/Cargo.toml
@@ -3,6 +3,7 @@ edition = "2024"
 license.workspace = true
 name = "xmtp_proto"
 version.workspace = true
+description = "xmtp protobuf definitions for rust"
 
 [lints]
 workspace = true
@@ -21,6 +22,7 @@ pbjson-types.workspace = true
 pin-project-lite.workspace = true
 prost = { workspace = true, features = ["derive"] }
 prost-types = "0.14"
+rustc-hash.workspace = true
 serde = { workspace = true }
 smallvec.workspace = true
 thiserror.workspace = true
@@ -29,7 +31,6 @@ tonic-prost = "0.14"
 tracing.workspace = true
 xmtp_common.workspace = true
 xmtp_configuration.workspace = true
-rustc-hash.workspace = true
 
 mockall = { workspace = true, optional = true }
 tokio = { workspace = true, default-features = false, features = [

--- a/dev/docker/docker-compose.yml
+++ b/dev/docker/docker-compose.yml
@@ -41,6 +41,7 @@ services:
   validation:
     image: ghcr.io/xmtp/mls-validation-service:main
     platform: linux/amd64
+    pull_policy: never
     build:
       context: ../..
       dockerfile: ./dev/validation_service/local.Dockerfile

--- a/dev/docker/up
+++ b/dev/docker/up
@@ -3,4 +3,20 @@ set -eou pipefail
 script_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 "${script_dir}"/compose pull
-"${script_dir}"/compose up -d --build --remove-orphans --wait --timeout 500
+
+# skip building mls_validation_service if its built in nix
+if [ -f result ] && tar -xOf result manifest.json 2>/dev/null | grep -q "mls-validation-service"; then
+    echo "detected nix validation image, skipping build"
+    "${script_dir}"/compose build --parallel $("${script_dir}"/compose config --services | grep -v "^validation$")
+     docker load -i result
+else
+    echo "Building all services including validation"
+    "${script_dir}"/compose build --parallel
+fi
+
+
+if [ -f result ] && tar -xOf result manifest.json 2>/dev/null | grep -q "mls-validation-service"; then
+  docker load -i result
+fi
+
+"${script_dir}"/compose up -d --remove-orphans --wait --timeout 500

--- a/flake.lock
+++ b/flake.lock
@@ -15,6 +15,21 @@
         "type": "github"
       }
     },
+    "crane_2": {
+      "locked": {
+        "lastModified": 1769287525,
+        "narHash": "sha256-gABuYA6BzoRMLuPaeO5p7SLrpd4qExgkwEmYaYQY4bM=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "0314e365877a85c9e5758f9ea77a9972afbb4c21",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "fenix": {
       "inputs": {
         "nixpkgs": [
@@ -120,16 +135,32 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1769318308,
-        "narHash": "sha256-Mjx6p96Pkefks3+aA+72lu1xVehb6mv2yTUUqmSet6Q=",
+        "lastModified": 1769527094,
+        "narHash": "sha256-xV20Alb7ZGN7qujnsi5lG1NckSUmpIb05H2Xar73TDc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1cd347bf3355fce6c64ab37d3967b4a2cb4b878c",
+        "rev": "afce96367b2e37fc29afb5543573cd49db3357b7",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1769018530,
+        "narHash": "sha256-MJ27Cy2NtBEV5tsK+YraYr2g851f3Fl1LpNHDzDX15c=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "88d3861acdd3d2f0e361767018218e51810df8a1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -141,6 +172,7 @@
         "flake-parts": "flake-parts",
         "foundry": "foundry",
         "nixpkgs": "nixpkgs_2",
+        "rust-flake": "rust-flake",
         "rust-manifest": "rust-manifest"
       }
     },
@@ -161,6 +193,26 @@
         "type": "github"
       }
     },
+    "rust-flake": {
+      "inputs": {
+        "crane": "crane_2",
+        "nixpkgs": "nixpkgs_3",
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1769355540,
+        "narHash": "sha256-HyqRH1wwvZkKIW6R1NnvLb6Ci3AO2e3RfMC2oY5RqAk=",
+        "owner": "juspay",
+        "repo": "rust-flake",
+        "rev": "c416d7d74f184cce749d83b91323ba71e240fbac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "juspay",
+        "repo": "rust-flake",
+        "type": "github"
+      }
+    },
     "rust-manifest": {
       "flake": false,
       "locked": {
@@ -171,6 +223,27 @@
       "original": {
         "type": "file",
         "url": "https://static.rust-lang.org/dist/channel-rust-1.92.0.toml"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "rust-flake",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769222645,
+        "narHash": "sha256-gu6oZ86zLudBZMq8LL1qdtYt/S69GV5keQVXdvBrVSU=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "22da29e7f3d8cff75009cbbcf992c7cb66920cfd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 # Flake Shell for building release artifacts for swift and kotlin
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     fenix = {
       url = "github:nix-community/fenix";
       inputs = { nixpkgs.follows = "nixpkgs"; };
@@ -11,6 +11,7 @@
     crane = {
       url = "github:ipetkov/crane";
     };
+    rust-flake.url = "github:juspay/rust-flake";
     rust-manifest = {
       url = "https://static.rust-lang.org/dist/channel-rust-1.92.0.toml";
       flake = false;
@@ -18,18 +19,18 @@
   };
 
   nixConfig = {
-    extra-trusted-public-keys = "xmtp.cachix.org-1:nFPFrqLQ9kjYQKiWL7gKq6llcNEeaV4iI+Ka1F+Tmq0=";
-    extra-substituters = "https://xmtp.cachix.org";
+    extra-trusted-public-keys = [
+      "xmtp.cachix.org-1:nFPFrqLQ9kjYQKiWL7gKq6llcNEeaV4iI+Ka1F+Tmq0="
+      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+    ];
+    extra-substituters = [
+      "https://xmtp.cachix.org"
+      "https://nix-community.cachix.org"
+    ];
   };
 
   outputs =
-    inputs @ { self
-    , flake-parts
-    , fenix
-    , crane
-    , foundry
-    , ...
-    }:
+    inputs @ { flake-parts, self, crane, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {
       systems = [
         "aarch64-darwin"
@@ -38,39 +39,39 @@
       imports = [
         ./nix/lib
         flake-parts.flakeModules.easyOverlay
+        inputs.rust-flake.flakeModules.default
+        inputs.rust-flake.flakeModules.nixpkgs
+        ./nix/rust-defaults.nix
+        ./nix/rust.nix
       ];
       perSystem =
-        { pkgs
-        , system
-        , ...
-        }:
-        let
-          pkgConfig = {
-            inherit system;
-            # Rust Overlay
-            overlays = [ fenix.overlays.default foundry.overlay self.overlays.default ];
-            config = {
-              android_sdk.accept_license = true;
-              allowUnfree = true;
-            };
-          };
-        in
-        {
-          _module.args.pkgs = import inputs.nixpkgs pkgConfig;
+        { pkgs, lib, self', ... }: {
+          nixpkgs = self.lib.pkgConfig;
           devShells = {
             # shell for general xmtp rust dev
             default = pkgs.callPackage ./nix/libxmtp.nix { };
             # Shell for android builds
             android = pkgs.callPackage ./nix/android.nix { };
-            # Shell for iOS builds
-            ios = pkgs.callPackage ./nix/ios.nix { };
             js = pkgs.callPackage ./nix/js.nix { };
             # the environment bindings_wasm is built in
             wasm = (pkgs.callPackage ./nix/package/wasm.nix { craneLib = crane.mkLib pkgs; }).devShell;
+          } // lib.optionalAttrs pkgs.stdenv.isDarwin {
+            # Shell for iOS builds
+            ios = pkgs.callPackage ./nix/ios.nix { };
           };
           packages.wasm-bindings = (pkgs.callPackage ./nix/package/wasm.nix { craneLib = crane.mkLib pkgs; }).bin;
           packages.wasm-bindgen-cli = pkgs.callPackage ./nix/lib/packages/wasm-bindgen-cli.nix { };
-
+          packages.docker-mls_validation_service = pkgs.dockerTools.buildLayeredImage {
+            name = "ghcr.io/xmtp/mls-validation-service"; # override ghcr images
+            tag = "main";
+            created = "now";
+            config = {
+              Env = [
+                "ANVIL_URL=http://anvil:8545"
+              ];
+              entrypoint = [ "${self'.packages.musl-mls_validation_service}/bin/mls-validation-service" ];
+            };
+          };
         };
     };
 }

--- a/nix/android.nix
+++ b/nix/android.nix
@@ -55,6 +55,7 @@ let
   };
 in
 mkShell {
+  meta.description = "Android Development environment for Android SDK and Emulator";
   OPENSSL_DIR = "${openssl.dev}";
   ANDROID_HOME = androidHome;
   NDK_HOME = "${androidComposition.androidsdk}/libexec/android-sdk/ndk/${builtins.head (lib.lists.reverseList (builtins.split "-" "${androidComposition.ndk-bundle}"))}";

--- a/nix/js.nix
+++ b/nix/js.nix
@@ -15,6 +15,7 @@ let
   inherit (darwin.apple_sdk) frameworks;
 in
 mkShell {
+  meta.description = "Javascript/BrowserSDK Development Environment";
   PLAYWRIGHT_BROWSERS_PATH = "${playwright-driver.browsers}";
   PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS = "true";
   PLAYWRIGHT_VERSION = "${playwright.version}";

--- a/nix/lib/default.nix
+++ b/nix/lib/default.nix
@@ -1,8 +1,8 @@
-{ inputs, ... }: {
+{ inputs, self, ... }: {
   flake.lib = {
     pkgConfig = {
       # Rust Overlay
-      overlays = [ inputs.fenix.overlays.default inputs.foundry.overlay ];
+      overlays = [ inputs.fenix.overlays.default inputs.foundry.overlay self.overlays.default ];
       config = {
         android_sdk.accept_license = true;
         allowUnfree = true;

--- a/nix/lib/filesets.nix
+++ b/nix/lib/filesets.nix
@@ -3,46 +3,50 @@
 }:
 let
   inherit (craneLib.fileset) commonCargoSources;
+  src = ./../..;
   libraries = lib.fileset.unions [
-    ./../../Cargo.toml
-    ./../../Cargo.lock
-    (commonCargoSources ./../../crates/xmtp_api_grpc)
-    (commonCargoSources ./../../crates/xmtp_cryptography)
-    (commonCargoSources ./../../crates/xmtp_id)
-    (commonCargoSources ./../../crates/xmtp_mls)
-    (commonCargoSources ./../../crates/xmtp_api)
-    (commonCargoSources ./../../crates/xmtp_api_d14n)
-    (commonCargoSources ./../../crates/xmtp_proto)
-    (commonCargoSources ./../../crates/xmtp_common)
-    (commonCargoSources ./../../crates/xmtp_content_types)
-    (commonCargoSources ./../../crates/xmtp_configuration)
-    (commonCargoSources ./../../crates/xmtp_macro)
-    (commonCargoSources ./../../crates/xmtp_db)
-    (commonCargoSources ./../../crates/xmtp_db_test)
-    (commonCargoSources ./../../crates/xmtp_archive)
-    (commonCargoSources ./../../crates/xmtp_mls_common)
-    (commonCargoSources ./../../crates/db_tools)
-    ./../../crates/xmtp_id/src/scw_verifier/chain_urls_default.json
-    ./../../crates/xmtp_id/artifact
-    ./../../crates/xmtp_id/src/scw_verifier/signature_validation.hex
-    ./../../crates/xmtp_db/migrations
-    ./../../crates/xmtp_proto/src/gen/proto_descriptor.bin
-    ./../../bindings/mobile/Makefile
-    ./../../webdriver.json
-    ./../../.config/nextest.toml
-    ./../../.cargo/config.toml
+    (src + /Cargo.toml)
+    (src + /Cargo.lock)
+    (src + /bindings)
+    (src + /apps)
+    (src + /crates/xmtp_id/src/scw_verifier/chain_urls_default.json)
+    (src + /crates/xmtp_id/artifact)
+    (src + /crates/xmtp_id/src/scw_verifier/signature_validation.hex)
+    (src + /crates/xmtp_db/migrations)
+    (src + /crates/xmtp_proto/src/gen/proto_descriptor.bin)
+    (src + /webdriver.json)
+    (src + /.cargo/config.toml)
+    (src + /.config/nextest.toml)
+    (commonCargoSources (src + /crates/xmtp_api_grpc))
+    (commonCargoSources (src + /crates/xmtp_cryptography))
+    (commonCargoSources (src + /crates/xmtp_id))
+    (commonCargoSources (src + /crates/xmtp_mls))
+    (commonCargoSources (src + /crates/xmtp_api))
+    (commonCargoSources (src + /crates/xmtp_api_d14n))
+    (commonCargoSources (src + /crates/xmtp_proto))
+    (commonCargoSources (src + /crates/xmtp_common))
+    (commonCargoSources (src + /crates/xmtp_content_types))
+    (commonCargoSources (src + /crates/xmtp_configuration))
+    (commonCargoSources (src + /crates/xmtp_macro))
+    (commonCargoSources (src + /crates/xmtp_db))
+    (commonCargoSources (src + /crates/xmtp_db_test))
+    (commonCargoSources (src + /crates/xmtp_archive))
+    (commonCargoSources (src + /crates/xmtp_mls_common))
+    (commonCargoSources (src + /crates/wasm_macros))
   ];
   binaries = lib.fileset.unions [
-    (commonCargoSources ./../../apps/cli)
-    (commonCargoSources ./../../apps/mls_validation_service)
-    (commonCargoSources ./../../bindings/node)
-    (commonCargoSources ./../../bindings/wasm)
-    (commonCargoSources ./../../crates/wasm_macros)
-    (commonCargoSources ./../../bindings/mobile)
-    (commonCargoSources ./../../crates/xmtp_debug)
+    (src + /bindings/mobile/Makefile)
+    (commonCargoSources (src + /apps/cli))
+    (commonCargoSources (src + /apps/mls_validation_service))
+    (commonCargoSources (src + /apps/android/xmtpv3_example))
+    (commonCargoSources (src + /bindings/node))
+    (commonCargoSources (src + /bindings/wasm))
+    (commonCargoSources (src + /bindings/mobile))
+    (commonCargoSources (src + /crates/xmtp_debug))
+    (commonCargoSources (src + /crates/db_tools))
   ];
   forCrate = crate: lib.fileset.unions [
-    workspace
+    libraries
     crate
   ];
   workspace = lib.fileset.unions [

--- a/nix/lib/packages/wasm-bindgen-cli.nix
+++ b/nix/lib/packages/wasm-bindgen-cli.nix
@@ -31,4 +31,7 @@ rustPlatform.buildRustPackage {
 
   # tests require it to be ran in the wasm-bindgen monorepo
   doCheck = false;
+  meta = {
+    description = "Custom maintained wasm-bindgen-cli package to match Cargo.toml";
+  };
 }

--- a/nix/libxmtp.nix
+++ b/nix/libxmtp.nix
@@ -50,6 +50,9 @@ let
   rust-toolchain = xmtp.mkToolchain [ "wasm32-unknown-unknown" "x86_64-unknown-linux-gnu" ] [ "rust-src" "clippy-preview" "rust-docs" "rustfmt-preview" "llvm-tools-preview" ];
 in
 mkShell {
+  meta = {
+    description = "full libXMTP Development Environment";
+  };
   OPENSSL_DIR = "${openssl.dev}";
   # disable -fzerocallusedregs in clang
   hardeningDisable = [ "zerocallusedregs" "stackprotector" ];

--- a/nix/package/wasm.nix
+++ b/nix/package/wasm.nix
@@ -26,13 +26,19 @@ let
   ];
   rust = craneLib.overrideToolchain (p: rust-toolchain);
 
-  workspaceFileset = lib.fileset.toSource {
+  libraryFileset = lib.fileset.toSource {
     root = ./../..;
-    fileset = (xmtp.filesets { inherit lib craneLib; }).workspace;
+    fileset = (xmtp.filesets { inherit lib craneLib; }).libraries;
+  };
+
+  bindingsFileset = lib.fileset.toSource {
+    root = ./../..;
+    fileset = (xmtp.filesets { inherit lib craneLib; }).forCrate ./../../bindings/wasm;
   };
 
   commonArgs = {
-    src = workspaceFileset;
+    meta.description = "WebAssembly Bindings";
+    src = libraryFileset;
     strictDeps = true;
     # EM_CACHE = "$TMPDIR/.emscripten_cache";
     # we need to set tmpdir for emscripten cache
@@ -67,10 +73,11 @@ let
   bin = rust.buildPackage
     ((commonEnv // commonArgs) // {
       inherit cargoArtifacts;
-      src = workspaceFileset;
+      src = bindingsFileset;
       inherit (rust.crateNameFromCargoToml {
         cargoToml = ./../../bindings/wasm/Cargo.toml;
-      }) pname;
+      })
+        pname;
       inherit (rust.crateNameFromCargoToml {
         cargoToml = ./../../Cargo.toml;
       }) version;

--- a/nix/rust-defaults.nix
+++ b/nix/rust-defaults.nix
@@ -1,0 +1,54 @@
+# Defaults for every crate in the workspace
+# Only autowire crate and clippy by default.
+# Individual crates can override this in rust.nix
+# "Auto Wiring" means that the `rust-flake` module
+# autoscans the repository for rust crates,
+# and automatically uses `crane.dev` to build them.
+# then "wires" the output of the build to
+# nix outputs. EX: Wire the "clippy" output to the flake output under "checks".
+# this allows running nix check .#crate-clippy
+# By default disabled to avoid redoing what other
+# GH Actions are already accomplishing.
+{ inputs, lib, ... }:
+let
+  src = ./..;
+  cargoToml = fromTOML (builtins.readFile (src + "/Cargo.toml"));
+  inherit (import "${inputs.rust-flake}/nix/crate-parser" { inherit lib; }) findCrates;
+
+  cratePaths = findCrates cargoToml.workspace.members src;
+  getCrateName = path:
+    let
+      crateCargoToml = fromTOML (builtins.readFile "${src}/${path}/Cargo.toml");
+    in
+    crateCargoToml.package.name;
+  allCrateNames = map getCrateName cratePaths;
+  # Map from crate name to crate path
+  crateNameToPath = lib.listToAttrs (map
+    (path: {
+      name = getCrateName path;
+      value = path;
+    })
+    cratePaths);
+in
+{
+  perSystem = { pkgs, config, lib, ... }:
+    let
+      src = ./..;
+      craneLib = config.rust-project.crane-lib;
+      workspaceFileset = crate: lib.fileset.toSource {
+        root = ./..;
+        fileset = (pkgs.xmtp.filesets { inherit lib craneLib; }).forCrate crate;
+      };
+    in
+    {
+      # for each crate set the crate output and clippy output
+      # also ensure fileset is correct
+      rust-project.crates = lib.genAttrs allCrateNames
+        (crate: {
+          crane.args.src = lib.mkDefault (workspaceFileset (src + "/${crateNameToPath.${crate}}"));
+          # Use mkDefault so rust.nix can override with normal priority
+          autoWire = lib.mkDefault [ ];
+        });
+    };
+}
+

--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -1,0 +1,71 @@
+# Rust Binaries to expose in nix flake
+{ inputs, ... }:
+{
+  perSystem =
+    { inputs', self', pkgs, config, lib, ... }:
+    let
+      fenix = inputs'.fenix.packages;
+      rust = fenix.fromManifestFile inputs.rust-manifest;
+      toolchain = fenix.combine [
+        (fenix.targets."x86_64-unknown-linux-musl".fromManifestFile
+          inputs.rust-manifest).rust-std
+        rust.defaultToolchain
+        rust."clippy"
+        rust."rust-docs"
+        rust."rustfmt-preview"
+        rust."clippy-preview"
+      ];
+      src = ./..;
+    in
+    {
+      packages.musl-mls_validation_service =
+        config.rust-project.crates.mls_validation_service.crane.outputs.drv.crate.overrideAttrs
+          (old:
+            old // {
+              CARGO_BUILD_TARGET = "x86_64-unknown-linux-musl";
+              CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
+            }
+          );
+      rust-project = {
+        inherit toolchain;
+        # Override the default src to use our workspace fileset which includes
+        # non-Cargo files like proto_descriptor.bin
+        src = lib.fileset.toSource {
+          root = ./..;
+          fileset = (pkgs.xmtp.filesets { inherit lib; craneLib = config.rust-project.crane-lib; }).workspace;
+        };
+        defaults = {
+          perCrate.crane.args = {
+            doCheck = false;
+            nativeBuildInputs = with pkgs;
+              [
+                pkg-config
+                perl
+                openssl
+                sqlite
+                sqlcipher
+              ];
+          };
+        };
+        crates = {
+          "mls_validation_service" = {
+            path = src + /apps/mls_validation_service;
+            autoWire = [ "crate" ];
+          };
+          "xmtp_debug" = {
+            autoWire = [ "crate" ];
+            path = src + /crates/xmtp_debug;
+          };
+          "xmtp_cli" = {
+            path = src + /apps/cli;
+            autoWire = [ "crate" ];
+          };
+          "bindings_wasm" = {
+            # wasm bindings have custom build in wasm.nix
+            autoWire = [ ];
+          };
+        };
+      };
+      packages.default = self'.packages.xdbg;
+    };
+}

--- a/om.yaml
+++ b/om.yaml
@@ -1,6 +1,9 @@
 # CI Configurations for `omnix` these run in github ci or locally
 # `om ci run .#wasm -- --accept-flake-config` to run
 ci:
+  default:
+    omnix:
+      dir: .
   wasm:
     omnix:
       dir: .


### PR DESCRIPTION
this adds the `xdbg` and `xmtp_cli` binaries to https://app.cachix.org/cache/xmtp#pins. building the binaries off main (with `nix build .#xdbg`) will download the already-built artifact rather than rebuild

adds a description to every crate


still need to verify they work (and fixes the broken fh cache on main that's been there for a while) but my `nix flake update` is broken b/c of github outage