### PR TITLE
Add new chains for SCW verification

### DIFF
--- a/crates/xmtp_id/src/scw_verifier/chain_urls_default.json
+++ b/crates/xmtp_id/src/scw_verifier/chain_urls_default.json
@@ -7,5 +7,7 @@
   "eip155:42161": "https://arbitrum.llamarpc.com",
   "eip155:59144": "https://linea-rpc.publicnode.com",
   "eip155:480": "https://worldchain-mainnet.g.alchemy.com/public",
-  "eip155:232":"https://rpc.lens.xyz"
+  "eip155:232": "https://rpc.lens.xyz",
+  "eip155:2741": "https://api.mainnet.abs.xyz",
+  "eip155:100": "https://public-gno-mainnet.fastnode.io"
 }


### PR DESCRIPTION
### TL;DR

Added RPC URLs for Arbitrum Stylus and Gnosis Chain networks.

### What changed?

Added two new RPC endpoints to the chain_urls_default.json file:
- eip155:2741: https://api.mainnet.abs.xyz (Abstract)
- eip155:100: https://public-gno-mainnet.fastnode.io (Gnosis Chain)

### Why make this change?

To expand support for additional EVM-compatible networks, specifically Abstract and Gnosis Chain, allowing users to interact with smart contract wallets on these networks.