### PR TITLE
Refactor RemoteAttachment

### DIFF
--- a/bindings/mobile/src/mls.rs
+++ b/bindings/mobile/src/mls.rs
@@ -3134,7 +3134,7 @@ pub fn decode_read_receipt(bytes: Vec<u8>) -> Result<FfiReadReceipt, GenericErro
 pub fn encode_remote_attachment(
     remote_attachment: FfiRemoteAttachment,
 ) -> Result<Vec<u8>, GenericError> {
-    let remote_attachment: RemoteAttachment = remote_attachment.try_into()?;
+    let remote_attachment: RemoteAttachment = remote_attachment.into();
 
     let encoded = RemoteAttachmentCodec::encode(remote_attachment)
         .map_err(|e| GenericError::Generic { err: e.to_string() })?;

--- a/bindings/mobile/src/mls/tests/content_types.rs
+++ b/bindings/mobile/src/mls/tests/content_types.rs
@@ -136,7 +136,7 @@ async fn test_multi_remote_attachment_encode_decode() {
     // Create a test attachment
     let original_attachment = FfiMultiRemoteAttachment {
         attachments: vec![
-            FfiRemoteAttachmentInfo {
+            FfiRemoteAttachment {
                 filename: Some("test1.jpg".to_string()),
                 content_length: Some(1000),
                 secret: vec![1, 2, 3],
@@ -146,7 +146,7 @@ async fn test_multi_remote_attachment_encode_decode() {
                 scheme: "https".to_string(),
                 url: "https://example.com/test1.jpg".to_string(),
             },
-            FfiRemoteAttachmentInfo {
+            FfiRemoteAttachment {
                 filename: Some("test2.pdf".to_string()),
                 content_length: Some(2000),
                 secret: vec![4, 5, 6],
@@ -261,7 +261,7 @@ async fn test_read_receipt_roundtrip() {
 async fn test_remote_attachment_roundtrip() {
     let original = FfiRemoteAttachment {
         filename: Some("remote_file.txt".to_string()),
-        content_length: 2048,
+        content_length: Some(2048),
         url: "https://example.com/file.txt".to_string(),
         content_digest: "sha256:abc123def456".to_string(),
         scheme: "https".to_string(),

--- a/bindings/mobile/src/mls/tests/mod.rs
+++ b/bindings/mobile/src/mls/tests/mod.rs
@@ -28,7 +28,7 @@ use crate::{
     inbox_state_from_inbox_ids, is_connected,
     message::{
         FfiEncodedContent, FfiGroupUpdated, FfiInbox, FfiLeaveRequest, FfiMetadataFieldChange,
-        FfiRemoteAttachmentInfo, FfiTransactionMetadata,
+        FfiTransactionMetadata,
     },
     mls::{
         MessageBackendBuilder,

--- a/bindings/node/src/content_types/decoded_message_content.rs
+++ b/bindings/node/src/content_types/decoded_message_content.rs
@@ -232,9 +232,7 @@ impl TryFrom<MessageBody> for DecodedMessageContent {
       MessageBody::Reply(r) => DecodedMessageContentInner::Reply(r.into()),
       MessageBody::Reaction(r) => DecodedMessageContentInner::Reaction(r.into()),
       MessageBody::Attachment(a) => DecodedMessageContentInner::Attachment(a.into()),
-      MessageBody::RemoteAttachment(ra) => {
-        DecodedMessageContentInner::RemoteAttachment(ra.try_into()?)
-      }
+      MessageBody::RemoteAttachment(ra) => DecodedMessageContentInner::RemoteAttachment(ra.into()),
       MessageBody::MultiRemoteAttachment(mra) => {
         DecodedMessageContentInner::MultiRemoteAttachment(mra.into())
       }

--- a/bindings/node/src/content_types/multi_remote_attachment.rs
+++ b/bindings/node/src/content_types/multi_remote_attachment.rs
@@ -1,75 +1,16 @@
+use super::remote_attachment::RemoteAttachment;
 use crate::ErrorWrapper;
 use crate::messages::encoded_content::{ContentTypeId, EncodedContent};
-use napi::bindgen_prelude::{Result, Uint8Array};
+use napi::bindgen_prelude::Result;
 use napi_derive::napi;
 use xmtp_content_types::ContentCodec;
 use xmtp_content_types::multi_remote_attachment::MultiRemoteAttachmentCodec;
-use xmtp_proto::xmtp::mls::message_contents::content_types::{
-  MultiRemoteAttachment as XmtpMultiRemoteAttachment,
-  RemoteAttachmentInfo as XmtpRemoteAttachmentInfo,
-};
-
-#[napi(object)]
-pub struct RemoteAttachmentInfo {
-  pub secret: Uint8Array,
-  pub content_digest: String,
-  pub nonce: Uint8Array,
-  pub scheme: String,
-  pub url: String,
-  pub salt: Uint8Array,
-  pub content_length: Option<u32>,
-  pub filename: Option<String>,
-}
-
-impl Clone for RemoteAttachmentInfo {
-  fn clone(&self) -> Self {
-    Self {
-      secret: Uint8Array::from(self.secret.to_vec()),
-      content_digest: self.content_digest.clone(),
-      nonce: Uint8Array::from(self.nonce.to_vec()),
-      scheme: self.scheme.clone(),
-      url: self.url.clone(),
-      salt: Uint8Array::from(self.salt.to_vec()),
-      content_length: self.content_length,
-      filename: self.filename.clone(),
-    }
-  }
-}
-
-impl From<RemoteAttachmentInfo> for XmtpRemoteAttachmentInfo {
-  fn from(remote_attachment_info: RemoteAttachmentInfo) -> Self {
-    XmtpRemoteAttachmentInfo {
-      content_digest: remote_attachment_info.content_digest,
-      secret: remote_attachment_info.secret.to_vec(),
-      nonce: remote_attachment_info.nonce.to_vec(),
-      salt: remote_attachment_info.salt.to_vec(),
-      scheme: remote_attachment_info.scheme,
-      url: remote_attachment_info.url,
-      content_length: remote_attachment_info.content_length,
-      filename: remote_attachment_info.filename,
-    }
-  }
-}
-
-impl From<XmtpRemoteAttachmentInfo> for RemoteAttachmentInfo {
-  fn from(remote_attachment_info: XmtpRemoteAttachmentInfo) -> Self {
-    RemoteAttachmentInfo {
-      secret: remote_attachment_info.secret.into(),
-      content_digest: remote_attachment_info.content_digest,
-      nonce: remote_attachment_info.nonce.into(),
-      scheme: remote_attachment_info.scheme,
-      url: remote_attachment_info.url,
-      salt: remote_attachment_info.salt.into(),
-      content_length: remote_attachment_info.content_length,
-      filename: remote_attachment_info.filename,
-    }
-  }
-}
+use xmtp_proto::xmtp::mls::message_contents::content_types::MultiRemoteAttachment as XmtpMultiRemoteAttachment;
 
 #[napi(object)]
 #[derive(Clone)]
 pub struct MultiRemoteAttachment {
-  pub attachments: Vec<RemoteAttachmentInfo>,
+  pub attachments: Vec<RemoteAttachment>,
 }
 
 impl From<MultiRemoteAttachment> for XmtpMultiRemoteAttachment {

--- a/bindings/wasm/src/content_types/decoded_message_content.rs
+++ b/bindings/wasm/src/content_types/decoded_message_content.rs
@@ -59,9 +59,9 @@ impl TryFrom<MessageBody> for DecodedMessageContent {
       }),
       MessageBody::Reaction(r) => Ok(DecodedMessageContent::Reaction { content: r.into() }),
       MessageBody::ReadReceipt(rr) => Ok(DecodedMessageContent::ReadReceipt { content: rr.into() }),
-      MessageBody::RemoteAttachment(ra) => Ok(DecodedMessageContent::RemoteAttachment {
-        content: ra.try_into()?,
-      }),
+      MessageBody::RemoteAttachment(ra) => {
+        Ok(DecodedMessageContent::RemoteAttachment { content: ra.into() })
+      }
       MessageBody::Reply(r) => Ok(DecodedMessageContent::Reply {
         content: Box::new(r.try_into()?),
       }),

--- a/bindings/wasm/src/content_types/multi_remote_attachment.rs
+++ b/bindings/wasm/src/content_types/multi_remote_attachment.rs
@@ -1,3 +1,4 @@
+use super::remote_attachment::RemoteAttachment;
 use crate::encoded_content::{ContentTypeId, EncodedContent};
 use serde::{Deserialize, Serialize};
 use tsify::Tsify;
@@ -5,69 +6,12 @@ use wasm_bindgen::JsError;
 use wasm_bindgen::prelude::wasm_bindgen;
 use xmtp_content_types::ContentCodec;
 use xmtp_content_types::multi_remote_attachment::MultiRemoteAttachmentCodec;
-use xmtp_proto::xmtp::mls::message_contents::content_types::{
-  MultiRemoteAttachment as XmtpMultiRemoteAttachment,
-  RemoteAttachmentInfo as XmtpRemoteAttachmentInfo,
-};
-
-#[derive(Clone, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
-#[serde(rename_all = "camelCase")]
-pub struct RemoteAttachmentInfo {
-  #[serde(with = "serde_bytes")]
-  #[tsify(type = "Uint8Array")]
-  pub secret: Vec<u8>,
-  pub content_digest: String,
-  #[serde(with = "serde_bytes")]
-  #[tsify(type = "Uint8Array")]
-  pub nonce: Vec<u8>,
-  pub scheme: String,
-  pub url: String,
-  #[serde(with = "serde_bytes")]
-  #[tsify(type = "Uint8Array")]
-  pub salt: Vec<u8>,
-  #[serde(skip_serializing_if = "Option::is_none")]
-  #[tsify(optional)]
-  pub content_length: Option<u32>,
-  #[serde(skip_serializing_if = "Option::is_none")]
-  #[tsify(optional)]
-  pub filename: Option<String>,
-}
-
-impl From<RemoteAttachmentInfo> for XmtpRemoteAttachmentInfo {
-  fn from(info: RemoteAttachmentInfo) -> Self {
-    XmtpRemoteAttachmentInfo {
-      content_digest: info.content_digest,
-      secret: info.secret,
-      nonce: info.nonce,
-      salt: info.salt,
-      scheme: info.scheme,
-      url: info.url,
-      content_length: info.content_length,
-      filename: info.filename,
-    }
-  }
-}
-
-impl From<XmtpRemoteAttachmentInfo> for RemoteAttachmentInfo {
-  fn from(info: XmtpRemoteAttachmentInfo) -> Self {
-    RemoteAttachmentInfo {
-      secret: info.secret,
-      content_digest: info.content_digest,
-      nonce: info.nonce,
-      scheme: info.scheme,
-      url: info.url,
-      salt: info.salt,
-      content_length: info.content_length,
-      filename: info.filename,
-    }
-  }
-}
+use xmtp_proto::xmtp::mls::message_contents::content_types::MultiRemoteAttachment as XmtpMultiRemoteAttachment;
 
 #[derive(Clone, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 pub struct MultiRemoteAttachment {
-  pub attachments: Vec<RemoteAttachmentInfo>,
+  pub attachments: Vec<RemoteAttachment>,
 }
 
 impl From<MultiRemoteAttachment> for XmtpMultiRemoteAttachment {

--- a/crates/xmtp_content_types/src/test_utils.rs
+++ b/crates/xmtp_content_types/src/test_utils.rs
@@ -44,7 +44,7 @@ impl TestContentGenerator {
             salt: b"test-salt".to_vec(),
             nonce: b"test-nonce".to_vec(),
             scheme: "https".to_string(),
-            content_length: 100,
+            content_length: Some(100),
         };
         RemoteAttachmentCodec::encode(remote_attachment)
             .expect("Failed to encode remote attachment")


### PR DESCRIPTION
# Summary

Removed `RemoteAttachment` struct in favor of `RemoteAttachmentInfo` for compatibility between single and multi remote attachment content types. `RemoteAttachment` is now an alias of `RemoteAttachmentInfo`. This changes the `content_length` field from `usize` to `Option<u32>` to match the proto definition. I'm not sure why `content_length` is optional in the proto.

This change makes the content, its type, and decryption of single and multi remote attachments compatible. This is technically a breaking change since there's now a hard limit to `content_length`. However, in practice, this is likely not an issue as most attachments are less than 4GB.