### PR TITLE
Make inbox the default for DM creation

### DIFF
--- a/bindings/mobile/src/mls.rs
+++ b/bindings/mobile/src/mls.rs
@@ -1646,7 +1646,7 @@ impl FfiConversations {
         let target_identity = target_identity.try_into()?;
         log::info!("creating dm with target address: {target_identity:?}",);
         self.inner_client
-            .find_or_create_dm(target_identity, Some(opts.into_dm_metadata_options()))
+            .find_or_create_dm_by_identity(target_identity, Some(opts.into_dm_metadata_options()))
             .await
             .map(|g| Arc::new(g.into()))
             .map_err(Into::into)
@@ -1659,7 +1659,7 @@ impl FfiConversations {
     ) -> Result<Arc<FfiConversation>, GenericError> {
         log::info!("creating dm with target inbox_id: {}", inbox_id);
         self.inner_client
-            .find_or_create_dm_by_inbox_id(inbox_id, Some(opts.into_dm_metadata_options()))
+            .find_or_create_dm(inbox_id, Some(opts.into_dm_metadata_options()))
             .await
             .map(|g| Arc::new(g.into()))
             .map_err(Into::into)

--- a/bindings/node/src/conversations/dm.rs
+++ b/bindings/node/src/conversations/dm.rs
@@ -33,7 +33,7 @@ impl Conversations {
   ) -> Result<Conversation> {
     let convo = self
       .inner_client
-      .find_or_create_dm(
+      .find_or_create_dm_by_identity(
         account_identity.try_into()?,
         options.map(|opt| opt.into_dm_metadata_options()),
       )
@@ -51,7 +51,7 @@ impl Conversations {
   ) -> Result<Conversation> {
     let convo = self
       .inner_client
-      .find_or_create_dm_by_inbox_id(inbox_id, options.map(|opt| opt.into_dm_metadata_options()))
+      .find_or_create_dm(inbox_id, options.map(|opt| opt.into_dm_metadata_options()))
       .await
       .map_err(ErrorWrapper::from)?;
 

--- a/bindings/wasm/src/conversations.rs
+++ b/bindings/wasm/src/conversations.rs
@@ -424,7 +424,7 @@ impl Conversations {
   ) -> Result<Conversation, JsError> {
     let convo = self
       .inner_client
-      .find_or_create_dm(
+      .find_or_create_dm_by_identity(
         account_identifier.try_into()?,
         options.map(|opt| opt.into_dm_metadata_options()),
       )
@@ -442,7 +442,7 @@ impl Conversations {
   ) -> Result<Conversation, JsError> {
     let convo = self
       .inner_client
-      .find_or_create_dm_by_inbox_id(inbox_id, options.map(|opt| opt.into_dm_metadata_options()))
+      .find_or_create_dm(inbox_id, options.map(|opt| opt.into_dm_metadata_options()))
       .await
       .map_err(|e| JsError::new(format!("{}", e).as_str()))?;
 

--- a/crates/db_tools/src/tasks/clear_messages.rs
+++ b/crates/db_tools/src/tasks/clear_messages.rs
@@ -35,9 +35,7 @@ mod tests {
         tester!(alix, disable_workers);
         tester!(bo);
 
-        let bo_alix_dm = bo
-            .find_or_create_dm_by_inbox_id(alix.inbox_id(), None)
-            .await?;
+        let bo_alix_dm = bo.find_or_create_dm(alix.inbox_id(), None).await?;
         bo_alix_dm
             .send_message(b"Hello there", Default::default())
             .await?;
@@ -82,9 +80,7 @@ mod tests {
         tester!(alix, disable_workers);
         tester!(bo);
 
-        let dm = alix
-            .find_or_create_dm_by_inbox_id(bo.inbox_id(), None)
-            .await?;
+        let dm = alix.find_or_create_dm(bo.inbox_id(), None).await?;
         dm.send_message(b"Message 1", Default::default()).await?;
         dm.send_message(b"Message 2", Default::default()).await?;
 

--- a/crates/xmtp_mls/src/client.rs
+++ b/crates/xmtp_mls/src/client.rs
@@ -613,7 +613,7 @@ where
     }
 
     /// Find or create a Direct Message with the default settings
-    pub async fn find_or_create_dm(
+    pub async fn find_or_create_dm_by_identity(
         &self,
         target_identity: Identifier,
         opts: Option<DMMetadataOptions>,
@@ -630,11 +630,11 @@ where
             }
         };
 
-        self.find_or_create_dm_by_inbox_id(inbox_id, opts).await
+        self.find_or_create_dm(inbox_id, opts).await
     }
 
     /// Find or create a Direct Message by inbox_id with the default settings
-    pub async fn find_or_create_dm_by_inbox_id(
+    pub async fn find_or_create_dm(
         &self,
         inbox_id: impl AsIdRef,
         opts: Option<DMMetadataOptions>,
@@ -1775,7 +1775,7 @@ pub(crate) mod tests {
 
         // First call should create a new DM
         let dm1 = client1
-            .find_or_create_dm_by_inbox_id(client2.inbox_id().to_string(), None)
+            .find_or_create_dm(client2.inbox_id().to_string(), None)
             .await
             .unwrap();
 
@@ -1792,7 +1792,7 @@ pub(crate) mod tests {
 
         // Second call should find the existing DM
         let dm2 = client1
-            .find_or_create_dm_by_inbox_id(client2.inbox_id().to_string(), None)
+            .find_or_create_dm(client2.inbox_id().to_string(), None)
             .await
             .unwrap();
 

--- a/crates/xmtp_mls/src/groups/device_sync/archive.rs
+++ b/crates/xmtp_mls/src/groups/device_sync/archive.rs
@@ -265,9 +265,7 @@ mod tests {
         tester!(alix, disable_workers);
         tester!(bo, disable_workers);
 
-        let alix_bo_dm = alix
-            .find_or_create_dm_by_inbox_id(bo.inbox_id(), None)
-            .await?;
+        let alix_bo_dm = alix.find_or_create_dm(bo.inbox_id(), None).await?;
         alix_bo_dm
             .send_message(b"old group", Default::default())
             .await?;
@@ -300,9 +298,7 @@ mod tests {
         let mut importer = ArchiveImporter::load(reader, &key).await?;
         insert_importer(&mut importer, &alix2.context).await?;
 
-        let alix2_bo_dm = alix2
-            .find_or_create_dm_by_inbox_id(bo.inbox_id(), None)
-            .await?;
+        let alix2_bo_dm = alix2.find_or_create_dm(bo.inbox_id(), None).await?;
         assert_ne!(alix_bo_dm.group_id, alix2_bo_dm.group_id);
         let mut msgs = alix2_bo_dm.find_messages(&MsgQueryArgs::default())?;
         assert_eq!(msgs.len(), 2);

--- a/crates/xmtp_mls/src/groups/device_sync/tests.rs
+++ b/crates/xmtp_mls/src/groups/device_sync/tests.rs
@@ -278,9 +278,7 @@ async fn test_only_added_to_correct_groups() {
     let bo_group_unknown = bo
         .create_group_with_members(&[alix1.inbox_id()], None, None)
         .await?;
-    let bo_dm = bo
-        .find_or_create_dm_by_inbox_id(alix1.inbox_id(), None)
-        .await?;
+    let bo_dm = bo.find_or_create_dm(alix1.inbox_id(), None).await?;
 
     alix1.sync_welcomes().await?;
     let alix_bo_group_denied = alix1.group(&bo_group_denied.group_id)?;

--- a/crates/xmtp_mls/src/groups/tests/mod.rs
+++ b/crates/xmtp_mls/src/groups/tests/mod.rs
@@ -413,11 +413,11 @@ async fn test_dm_stitching() {
     let bo = Tester::new().await;
 
     let bo_dm = bo
-        .find_or_create_dm_by_inbox_id(alix.inbox_id().to_string(), None)
+        .find_or_create_dm(alix.inbox_id().to_string(), None)
         .await
         .unwrap();
     let alix_dm = alix
-        .find_or_create_dm_by_inbox_id(bo.inbox_id().to_string(), None)
+        .find_or_create_dm(bo.inbox_id().to_string(), None)
         .await
         .unwrap();
 
@@ -681,7 +681,7 @@ async fn test_dm_creation_with_user_two_installations_one_malformed() {
 
     // 3) Amal creates a DM group targeting Bola
     let amal_dm = amal
-        .find_or_create_dm_by_inbox_id(bola_1.inbox_id().to_string(), None)
+        .find_or_create_dm(bola_1.inbox_id().to_string(), None)
         .await
         .unwrap();
 
@@ -789,7 +789,9 @@ async fn test_dm_creation_with_user_all_malformed_installations() {
 
     // 3) Attempt to create the DM group, which should fail
 
-    let result = amal.find_or_create_dm(bola_wallet.identifier(), None).await;
+    let result = amal
+        .find_or_create_dm_by_identity(bola_wallet.identifier(), None)
+        .await;
 
     // 4) Ensure DM creation fails with the correct error
     assert!(result.is_err());
@@ -1117,7 +1119,7 @@ async fn test_self_remove_dm_must_fail() {
 
     // Amal creates a dm group with bola
     let amal_dm = amal
-        .find_or_create_dm_by_inbox_id(bola.inbox_id().to_string(), None)
+        .find_or_create_dm(bola.inbox_id().to_string(), None)
         .await
         .unwrap();
     amal_dm.sync().await.unwrap();
@@ -3431,7 +3433,7 @@ async fn test_dm_creation() {
 
     // Amal creates a dm group targeting bola
     let amal_dm = amal
-        .find_or_create_dm_by_inbox_id(bola.inbox_id().to_string(), None)
+        .find_or_create_dm(bola.inbox_id().to_string(), None)
         .await
         .unwrap();
 
@@ -4243,7 +4245,7 @@ async fn test_app_data_in_dm() {
 
     // Create a DM
     let dm = amal
-        .find_or_create_dm_by_inbox_id(bola.inbox_id().to_string(), None)
+        .find_or_create_dm(bola.inbox_id().to_string(), None)
         .await
         .unwrap();
 

--- a/crates/xmtp_mls/src/groups/tests/test_commit_log_readd_requests.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_commit_log_readd_requests.rs
@@ -104,7 +104,7 @@ async fn test_request_readd_dm() {
     tester!(alix, enable_fork_recovery_requests);
     tester!(bo);
     let dm = alix
-        .find_or_create_dm_by_inbox_id(bo.inbox_id().to_string(), None)
+        .find_or_create_dm(bo.inbox_id().to_string(), None)
         .await
         .unwrap();
     bo.sync_all_welcomes_and_groups(None).await.unwrap();

--- a/crates/xmtp_mls/src/groups/tests/test_commit_log_remote.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_commit_log_remote.rs
@@ -59,9 +59,7 @@ async fn test_commit_log_signer_on_group_creation() {
     tester!(alix);
     tester!(bo);
 
-    let a = alix
-        .find_or_create_dm_by_inbox_id(bo.inbox_id(), None)
-        .await?;
+    let a = alix.find_or_create_dm(bo.inbox_id(), None).await?;
     let b = bo.sync_welcomes().await?.first()?.to_owned();
     let a_metadata = a.mutable_metadata()?;
     let b_metadata = b.mutable_metadata()?;
@@ -938,9 +936,7 @@ async fn test_all_users_use_same_signing_key_for_publishing() {
     tester!(bo);
 
     // Create a DM between alix and bo
-    let alix_dm = alix
-        .find_or_create_dm_by_inbox_id(bo.inbox_id(), None)
-        .await?;
+    let alix_dm = alix.find_or_create_dm(bo.inbox_id(), None).await?;
     let bo_dm = bo.sync_welcomes().await?.first()?.to_owned();
 
     // Both parties make commits to generate entries for publishing
@@ -1022,9 +1018,7 @@ async fn test_consecutive_entries_verification_happy_case() {
     tester!(bo, with_commit_log_worker: false);
 
     // Create a DM between alix and bo
-    let alix_dm = alix
-        .find_or_create_dm_by_inbox_id(bo.inbox_id(), None)
-        .await?;
+    let alix_dm = alix.find_or_create_dm(bo.inbox_id(), None).await?;
     let bo_dm = bo.sync_welcomes().await?.first()?.to_owned();
 
     // Sync messages to bo

--- a/crates/xmtp_mls/src/groups/tests/test_dm.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_dm.rs
@@ -19,9 +19,7 @@ async fn auto_consent_dms_for_new_installations() {
     tester!(bo2, from: bo1);
 
     // Bo creates a new installation and immediately creates a new DM with alix
-    let bo2_dm = bo2
-        .find_or_create_dm_by_inbox_id(alix.inbox_id(), None)
-        .await?;
+    let bo2_dm = bo2.find_or_create_dm(alix.inbox_id(), None).await?;
 
     // Alix pulls down the new DM from bo
     alix.sync_welcomes().await?;
@@ -54,7 +52,7 @@ async fn test_dm_welcome_with_preexisting_consent() {
     );
     bo2.context.db().insert_newer_consent_record(cr)?;
     // Now bo2 processes the welcome
-    bo1.find_or_create_dm_by_inbox_id(alix.inbox_id(), None)
+    bo1.find_or_create_dm(alix.inbox_id(), None)
         .await?
         .update_installations()
         .await?;
@@ -62,9 +60,7 @@ async fn test_dm_welcome_with_preexisting_consent() {
 
     // The welcome should succeed
     assert_eq!(
-        bo2.find_or_create_dm_by_inbox_id(alix.inbox_id(), None)
-            .await?
-            .group_id,
+        bo2.find_or_create_dm(alix.inbox_id(), None).await?.group_id,
         a_group.group_id
     );
 }

--- a/crates/xmtp_mls/src/groups/tests/test_message_disappearing_settings.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_message_disappearing_settings.rs
@@ -7,12 +7,8 @@ async fn test_disappearing_message_update_message_in_group() {
     tester!(alix);
     tester!(bo);
 
-    let alix_bo_dm = alix
-        .find_or_create_dm_by_inbox_id(bo.inbox_id(), None)
-        .await?;
-    let _bo_alix_dm = bo
-        .find_or_create_dm_by_inbox_id(alix.inbox_id(), None)
-        .await?;
+    let alix_bo_dm = alix.find_or_create_dm(bo.inbox_id(), None).await?;
+    let _bo_alix_dm = bo.find_or_create_dm(alix.inbox_id(), None).await?;
 
     alix_bo_dm
         .update_conversation_message_disappear_from_ns(10)

--- a/crates/xmtp_mls/src/identity.rs
+++ b/crates/xmtp_mls/src/identity.rs
@@ -1094,7 +1094,7 @@ mod tests {
 
             // Create a DM from Amal -> Bola
             // This should use Bola's XWingMLKEM512 key package
-            amal.find_or_create_dm_by_inbox_id(
+            amal.find_or_create_dm(
                 bola.inbox_id().to_string(),
                 Some(DMMetadataOptions::default()),
             )

--- a/crates/xmtp_mls/src/subscriptions/stream_all/tests.rs
+++ b/crates/xmtp_mls/src/subscriptions/stream_all/tests.rs
@@ -39,7 +39,7 @@ async fn test_stream_all_messages_changing_group_list() {
         .unwrap();
     assert_msg!(stream, "first");
     let bo_group = bo
-        .find_or_create_dm(caro_wallet.identifier(), None)
+        .find_or_create_dm_by_identity(caro_wallet.identifier(), None)
         .await
         .unwrap();
 
@@ -121,10 +121,7 @@ async fn test_dm_stream_all_messages() {
     let alix_group = alix.create_group(None, None).unwrap();
     alix_group.add_members(&[bo.inbox_id()]).await.unwrap();
 
-    let alix_dm = alix
-        .find_or_create_dm_by_inbox_id(bo.inbox_id(), None)
-        .await
-        .unwrap();
+    let alix_dm = alix.find_or_create_dm(bo.inbox_id(), None).await.unwrap();
     {
         // start a stream with only group messages
         let stream = bo
@@ -524,7 +521,7 @@ async fn test_stream_all_messages_filters_new_group_when_dm_only() {
 
     // Create initial DM
     let dm = sender
-        .find_or_create_dm(receiver_wallet.identifier(), None)
+        .find_or_create_dm_by_identity(receiver_wallet.identifier(), None)
         .await
         .unwrap();
 

--- a/crates/xmtp_mls/src/subscriptions/stream_conversations.rs
+++ b/crates/xmtp_mls/src/subscriptions/stream_conversations.rs
@@ -493,7 +493,7 @@ mod test {
             .unwrap();
         futures::pin_mut!(stream);
 
-        alix.find_or_create_dm_by_inbox_id(bo.inbox_id().to_string(), None)
+        alix.find_or_create_dm(bo.inbox_id().to_string(), None)
             .await
             .unwrap();
 
@@ -528,7 +528,7 @@ mod test {
         let stream = alix.stream_conversations(None, false).await.unwrap();
         futures::pin_mut!(stream);
 
-        alix.find_or_create_dm_by_inbox_id(davon.inbox_id().to_string(), None)
+        alix.find_or_create_dm(davon.inbox_id().to_string(), None)
             .await
             .unwrap();
         let group = stream.next().await.unwrap();
@@ -536,7 +536,7 @@ mod test {
         groups.push(group.unwrap());
 
         let dm = eri
-            .find_or_create_dm_by_inbox_id(alix.inbox_id().to_string(), None)
+            .find_or_create_dm(alix.inbox_id().to_string(), None)
             .await
             .unwrap();
         dm.add_members(&[alix.inbox_id()]).await.unwrap();
@@ -622,7 +622,7 @@ mod test {
 
         // First DM - should stream
         let dm1 = client1
-            .find_or_create_dm_by_inbox_id(client2.inbox_id().to_string(), None)
+            .find_or_create_dm(client2.inbox_id().to_string(), None)
             .await
             .unwrap();
 
@@ -632,7 +632,7 @@ mod test {
 
         // Create a second DM with same participants — triggers duplicate logic
         let dm2 = client2
-            .find_or_create_dm_by_inbox_id(client1.inbox_id().to_string(), None)
+            .find_or_create_dm(client1.inbox_id().to_string(), None)
             .await
             .unwrap();
 
@@ -667,7 +667,7 @@ mod test {
                 let c = client.clone();
                 async move {
                     xmtp_common::time::sleep(std::time::Duration::from_millis(100)).await;
-                    let dm = c.find_or_create_dm_by_inbox_id(id.as_ref(), None).await?;
+                    let dm = c.find_or_create_dm(id.as_ref(), None).await?;
                     dm.send_message(b"hi", SendMessageOpts::default()).await?;
                     Ok::<_, crate::client::ClientError>(())
                 }

--- a/crates/xmtp_mls/src/test/builder_native_only.rs
+++ b/crates/xmtp_mls/src/test/builder_native_only.rs
@@ -569,7 +569,7 @@ async fn test_operations_fail_when_not_ready() {
     // Try to create a DM - should fail with UninitializedIdentity
     let target_wallet = generate_local_wallet();
     let find_or_create_dm_result = client
-        .find_or_create_dm(target_wallet.identifier(), None)
+        .find_or_create_dm_by_identity(target_wallet.identifier(), None)
         .await;
     assert!(
         find_or_create_dm_result.is_err(),

--- a/crates/xmtp_mls/src/test/client_test_utils.rs
+++ b/crates/xmtp_mls/src/test/client_test_utils.rs
@@ -51,14 +51,10 @@ where
         other: &Self,
     ) -> Result<(MlsGroup<Context>, String), TestError> {
         self.sync_welcomes().await?;
-        let dm = self
-            .find_or_create_dm_by_inbox_id(other.inbox_id(), None)
-            .await?;
+        let dm = self.find_or_create_dm(other.inbox_id(), None).await?;
 
         other.sync_welcomes().await?;
-        let other_dm = other
-            .find_or_create_dm_by_inbox_id(self.inbox_id(), None)
-            .await?;
+        let other_dm = other.find_or_create_dm(self.inbox_id(), None).await?;
 
         // Since the other client synced welcomes before creating a DM
         // the group_id should be the same.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Make identity-based inbox the default for DM creation by renaming and re-routing `client::Client::find_or_create_dm_by_identity` and `client::Client::find_or_create_dm` across mobile, Node, and WASM bindings
Switch DM creation to inbox-as-default by renaming `client::Client::find_or_create_dm_by_identity` (identity input) and `client::Client::find_or_create_dm` (inbox_id input), updating bindings and tests to call the correct method based on identity vs inbox_id.

#### 📍Where to Start
Start with the method renames and routing in `client::Client` in [crates/xmtp_mls/src/client.rs](https://github.com/xmtp/libxmtp/pull/3042/files#diff-74086c32ace91ebbc5bca31e480e4e33cfd9f03bb70c4a8fdbcca16ddfcdf52f).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 15ab5a1.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->