### PR TITLE
Refactor node bindings according to style guide

### DIFF
--- a/bindings/node/src/client/consent_state.rs
+++ b/bindings/node/src/client/consent_state.rs
@@ -18,6 +18,7 @@ impl Client {
       .set_consent_states(&stored_records)
       .await
       .map_err(ErrorWrapper::from)?;
+
     Ok(())
   }
 

--- a/bindings/node/src/client/identity.rs
+++ b/bindings/node/src/client/identity.rs
@@ -52,7 +52,7 @@ impl Client {
   }
 
   #[napi]
-  pub async fn find_inbox_id_by_identity(&self, identifier: Identifier) -> Result<Option<String>> {
+  pub async fn get_inbox_id_by_identity(&self, identifier: Identifier) -> Result<Option<String>> {
     let conn = self.inner_client().context.store().db();
 
     let inbox_id = self

--- a/bindings/node/src/client/inbox_state.rs
+++ b/bindings/node/src/client/inbox_state.rs
@@ -9,10 +9,10 @@ use xmtp_id::InboxId;
 #[napi]
 impl Client {
   #[napi]
-  pub async fn addresses_from_inbox_id(
+  pub async fn fetch_inbox_states_by_inbox_ids(
     &self,
-    refresh_from_network: bool,
     inbox_ids: Vec<String>,
+    refresh_from_network: bool,
   ) -> Result<Vec<InboxState>> {
     let state = self
       .inner_client
@@ -42,22 +42,10 @@ impl Client {
   }
 
   #[napi]
-  pub async fn get_latest_inbox_state(&self, inbox_id: String) -> Result<InboxState> {
-    let conn = self.inner_client().context.store().db();
-    let state = self
-      .inner_client()
-      .identity_updates()
-      .get_latest_association_state(&conn, &inbox_id)
-      .await
-      .map_err(ErrorWrapper::from)?;
-    Ok(state.into())
-  }
-
-  #[napi]
   pub async fn fetch_inbox_updates_count(
     &self,
-    refresh_from_network: bool,
     inbox_ids: Vec<String>,
+    refresh_from_network: bool,
   ) -> Result<HashMap<InboxId, u32>> {
     let ids = inbox_ids.iter().map(AsRef::as_ref).collect();
     let res = self
@@ -79,12 +67,12 @@ impl Client {
   }
 
   /**
-   * Get key package statuses for a list of installation IDs.
+   * Fetch key package statuses from the network for a list of installation IDs.
    *
    * Returns a JavaScript Object mapping installation ID strings to KeyPackageStatus objects.
    */
   #[napi]
-  pub async fn get_key_package_statuses_for_installation_ids(
+  pub async fn fetch_key_package_statuses_by_installation_ids(
     &self,
     installation_ids: Vec<String>,
   ) -> Result<HashMap<String, KeyPackageStatus>> {

--- a/bindings/node/src/conversation/dm.rs
+++ b/bindings/node/src/conversation/dm.rs
@@ -17,7 +17,7 @@ impl Conversation {
   }
 
   #[napi]
-  pub async fn find_duplicate_dms(&self) -> Result<Vec<Conversation>> {
+  pub async fn duplicate_dms(&self) -> Result<Vec<Conversation>> {
     let group = self.create_mls_group();
     let dms = group.find_duplicate_dms().map_err(ErrorWrapper::from)?;
     let conversations: Vec<Conversation> = dms.into_iter().map(Into::into).collect();

--- a/bindings/node/src/conversation/hmac_key.rs
+++ b/bindings/node/src/conversation/hmac_key.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 #[napi]
 impl Conversation {
   #[napi]
-  pub fn get_hmac_keys(&self) -> Result<HashMap<String, Vec<HmacKey>>> {
+  pub fn hmac_keys(&self) -> Result<HashMap<String, Vec<HmacKey>>> {
     let group = self.create_mls_group();
 
     let dms = group.find_duplicate_dms().map_err(ErrorWrapper::from)?;

--- a/bindings/node/src/conversation/membership.rs
+++ b/bindings/node/src/conversation/membership.rs
@@ -111,7 +111,7 @@ impl Conversation {
   }
 
   #[napi]
-  pub fn admin_list(&self) -> Result<Vec<String>> {
+  pub fn list_admins(&self) -> Result<Vec<String>> {
     let group = self.create_mls_group();
 
     let admin_list = group.admin_list().map_err(ErrorWrapper::from)?;
@@ -120,7 +120,7 @@ impl Conversation {
   }
 
   #[napi]
-  pub fn super_admin_list(&self) -> Result<Vec<String>> {
+  pub fn list_super_admins(&self) -> Result<Vec<String>> {
     let group = self.create_mls_group();
 
     let super_admin_list = group.super_admin_list().map_err(ErrorWrapper::from)?;
@@ -130,13 +130,13 @@ impl Conversation {
 
   #[napi]
   pub fn is_admin(&self, inbox_id: String) -> Result<bool> {
-    let admin_list = self.admin_list().map_err(ErrorWrapper::from)?;
+    let admin_list = self.list_admins().map_err(ErrorWrapper::from)?;
     Ok(admin_list.contains(&inbox_id))
   }
 
   #[napi]
   pub fn is_super_admin(&self, inbox_id: String) -> Result<bool> {
-    let super_admin_list = self.super_admin_list().map_err(ErrorWrapper::from)?;
+    let super_admin_list = self.list_super_admins().map_err(ErrorWrapper::from)?;
     Ok(super_admin_list.contains(&inbox_id))
   }
 

--- a/bindings/node/src/conversation/messages.rs
+++ b/bindings/node/src/conversation/messages.rs
@@ -58,7 +58,7 @@ impl Conversation {
   }
 
   #[napi]
-  pub async fn find_messages(&self, opts: Option<ListMessagesOptions>) -> Result<Vec<Message>> {
+  pub async fn list_messages(&self, opts: Option<ListMessagesOptions>) -> Result<Vec<Message>> {
     let opts = opts.unwrap_or_default();
     let group = self.create_mls_group();
     let opts = MsgQueryArgs { ..opts.into() };
@@ -100,7 +100,7 @@ impl Conversation {
   }
 
   #[napi]
-  pub async fn find_enriched_messages(
+  pub async fn list_enriched_messages(
     &self,
     opts: Option<ListMessagesOptions>,
   ) -> Result<Vec<DecodedMessage>> {
@@ -117,7 +117,7 @@ impl Conversation {
   }
 
   #[napi]
-  pub async fn get_last_read_times(&self) -> Result<HashMap<String, i64>> {
+  pub async fn last_read_times(&self) -> Result<HashMap<String, i64>> {
     let group = self.create_mls_group();
     let times = group.get_last_read_times().map_err(ErrorWrapper::from)?;
     Ok(times)

--- a/bindings/node/src/conversations/dm.rs
+++ b/bindings/node/src/conversations/dm.rs
@@ -25,8 +25,8 @@ impl CreateDMOptions {
 
 #[napi]
 impl Conversations {
-  #[napi(js_name = "createDmByIdentity")]
-  pub async fn find_or_create_dm_by_identity(
+  #[napi]
+  pub async fn create_dm_by_identity(
     &self,
     account_identity: Identifier,
     options: Option<CreateDMOptions>,
@@ -43,8 +43,8 @@ impl Conversations {
     Ok(convo.into())
   }
 
-  #[napi(js_name = "createDm")]
-  pub async fn find_or_create_dm(
+  #[napi]
+  pub async fn create_dm(
     &self,
     inbox_id: String,
     options: Option<CreateDMOptions>,
@@ -59,10 +59,10 @@ impl Conversations {
   }
 
   #[napi]
-  pub fn find_dm_by_target_inbox_id(&self, target_inbox_id: String) -> Result<Conversation> {
+  pub fn get_dm_by_inbox_id(&self, inbox_id: String) -> Result<Conversation> {
     let convo = self
       .inner_client
-      .dm_group_from_target_inbox(target_inbox_id)
+      .dm_group_from_target_inbox(inbox_id)
       .map_err(ErrorWrapper::from)?;
 
     Ok(convo.into())

--- a/bindings/node/src/conversations/hmac_key.rs
+++ b/bindings/node/src/conversations/hmac_key.rs
@@ -9,7 +9,7 @@ use xmtp_db::group::GroupQueryArgs;
 #[napi]
 impl Conversations {
   #[napi]
-  pub fn get_hmac_keys(&self) -> Result<HashMap<String, Vec<HmacKey>>> {
+  pub fn hmac_keys(&self) -> Result<HashMap<String, Vec<HmacKey>>> {
     let inner = self.inner_client.as_ref();
     let conversations = inner
       .find_groups(GroupQueryArgs {

--- a/bindings/node/src/conversations/messages.rs
+++ b/bindings/node/src/conversations/messages.rs
@@ -10,7 +10,7 @@ use std::ops::Deref;
 #[napi]
 impl Conversations {
   #[napi]
-  pub fn find_message_by_id(&self, message_id: String) -> Result<Message> {
+  pub fn get_message_by_id(&self, message_id: String) -> Result<Message> {
     let message_id = hex::decode(message_id).map_err(ErrorWrapper::from)?;
 
     let message = self
@@ -22,7 +22,7 @@ impl Conversations {
   }
 
   #[napi]
-  pub fn find_enriched_message_by_id(&self, message_id: String) -> Result<DecodedMessage> {
+  pub fn get_enriched_message_by_id(&self, message_id: String) -> Result<DecodedMessage> {
     let message_id = hex::decode(message_id).map_err(ErrorWrapper::from)?;
 
     let message = self

--- a/bindings/node/src/conversations/mod.rs
+++ b/bindings/node/src/conversations/mod.rs
@@ -148,7 +148,7 @@ impl Conversations {
   }
 
   #[napi]
-  pub fn find_group_by_id(&self, group_id: String) -> Result<Conversation> {
+  pub fn get_conversation_by_id(&self, group_id: String) -> Result<Conversation> {
     let group_id = hex::decode(group_id).map_err(ErrorWrapper::from)?;
 
     let group = self
@@ -170,7 +170,7 @@ impl Conversations {
   }
 
   #[napi]
-  pub async fn sync_all_conversations(
+  pub async fn sync_all(
     &self,
     consent_states: Option<Vec<ConsentState>>,
   ) -> Result<GroupSyncSummary> {

--- a/bindings/node/src/inbox_id.rs
+++ b/bindings/node/src/inbox_id.rs
@@ -11,7 +11,7 @@ use xmtp_id::associations::MemberIdentifier;
 use xmtp_proto::types::ApiIdentifier;
 
 #[napi]
-pub async fn get_inbox_id_for_identifier(
+pub async fn get_inbox_id_by_identity(
   v3_host: String,
   gateway_host: Option<String>,
   is_secure: bool,

--- a/bindings/node/src/inbox_state.rs
+++ b/bindings/node/src/inbox_state.rs
@@ -85,7 +85,7 @@ impl From<VerifiedKeyPackageV2> for KeyPackageStatus {
 
 #[allow(dead_code)]
 #[napi]
-pub async fn inbox_state_from_inbox_ids(
+pub async fn fetch_inbox_states_by_inbox_ids(
   v3_host: String,
   gateway_host: Option<String>,
   inbox_ids: Vec<String>,

--- a/bindings/node/test/Conversation.test.ts
+++ b/bindings/node/test/Conversation.test.ts
@@ -23,7 +23,7 @@ describe.concurrent('Conversation', () => {
     const newName = 'foo'
     await conversation.updateGroupName(newName)
     expect(conversation.groupName()).toBe(newName)
-    const messages = await conversation.findMessages()
+    const messages = await conversation.listMessages()
     expect(messages.length).toBe(2)
 
     await client2.conversations().sync()
@@ -35,7 +35,7 @@ describe.concurrent('Conversation', () => {
     await conversation2.sync()
     expect(conversation2.id()).toBe(conversation.id())
     expect(conversation2.groupName()).toBe(newName)
-    const messages2 = await conversation2.findMessages()
+    const messages2 = await conversation2.listMessages()
     expect(messages2.length).toBe(2)
   })
 
@@ -53,7 +53,7 @@ describe.concurrent('Conversation', () => {
     const imageUrl = 'https://foo/bar.jpg'
     await conversation.updateGroupImageUrlSquare(imageUrl)
     expect(conversation.groupImageUrlSquare()).toBe(imageUrl)
-    const messages = await conversation.findMessages()
+    const messages = await conversation.listMessages()
     expect(messages.length).toBe(2)
 
     await client2.conversations().sync()
@@ -65,7 +65,7 @@ describe.concurrent('Conversation', () => {
     await conversation2.sync()
     expect(conversation2.id()).toBe(conversation.id())
     expect(conversation2.groupImageUrlSquare()).toBe(imageUrl)
-    const messages2 = await conversation2.findMessages()
+    const messages2 = await conversation2.listMessages()
     expect(messages2.length).toBe(2)
   })
 
@@ -83,7 +83,7 @@ describe.concurrent('Conversation', () => {
     const newDescription = 'foo'
     await conversation.updateGroupDescription(newDescription)
     expect(conversation.groupDescription()).toBe(newDescription)
-    const messages = await conversation.findMessages()
+    const messages = await conversation.listMessages()
     expect(messages.length).toBe(2)
 
     await client2.conversations().sync()
@@ -95,7 +95,7 @@ describe.concurrent('Conversation', () => {
     await conversation2.sync()
     expect(conversation2.id()).toBe(conversation.id())
     expect(conversation2.groupDescription()).toBe(newDescription)
-    const messages2 = await conversation2.findMessages()
+    const messages2 = await conversation2.listMessages()
     expect(messages2.length).toBe(2)
   })
 
@@ -206,7 +206,7 @@ describe.concurrent('Conversation', () => {
 
     await conversation.sendText('gm')
 
-    const messages = await conversation.findMessages()
+    const messages = await conversation.listMessages()
     expect(messages.length).toBe(2)
 
     await client2.conversations().sync()
@@ -218,7 +218,7 @@ describe.concurrent('Conversation', () => {
     await conversation2.sync()
     expect(conversation2.id()).toBe(conversation.id())
 
-    const messages2 = await conversation2.findMessages()
+    const messages2 = await conversation2.listMessages()
     expect(messages2.length).toBe(2)
   })
 
@@ -236,7 +236,7 @@ describe.concurrent('Conversation', () => {
 
     await conversation.sendText('gm', true)
 
-    const messages = await conversation.findMessages()
+    const messages = await conversation.listMessages()
     expect(messages.length).toBe(2)
 
     await client2.conversations().sync()
@@ -249,13 +249,13 @@ describe.concurrent('Conversation', () => {
     await conversation2.sync()
     expect(conversation2.id()).toBe(conversation.id())
 
-    const messages2 = await conversation2.findMessages()
+    const messages2 = await conversation2.listMessages()
     expect(messages2.length).toBe(1)
 
     await conversation.publishMessages()
     await conversation2.sync()
 
-    const messages4 = await conversation2.findMessages()
+    const messages4 = await conversation2.listMessages()
     expect(messages4.length).toBe(2)
   })
 
@@ -308,20 +308,20 @@ describe.concurrent('Conversation', () => {
     ])
 
     expect(conversation.isSuperAdmin(client1.inboxId())).toBe(true)
-    expect(conversation.superAdminList().length).toBe(1)
-    expect(conversation.superAdminList()).toContain(client1.inboxId())
+    expect(conversation.listSuperAdmins().length).toBe(1)
+    expect(conversation.listSuperAdmins()).toContain(client1.inboxId())
     expect(conversation.isAdmin(client1.inboxId())).toBe(false)
     expect(conversation.isAdmin(client2.inboxId())).toBe(false)
-    expect(conversation.adminList().length).toBe(0)
+    expect(conversation.listAdmins().length).toBe(0)
 
     await conversation.addAdmin(client2.inboxId())
     expect(conversation.isAdmin(client2.inboxId())).toBe(true)
-    expect(conversation.adminList().length).toBe(1)
-    expect(conversation.adminList()).toContain(client2.inboxId())
+    expect(conversation.listAdmins().length).toBe(1)
+    expect(conversation.listAdmins()).toContain(client2.inboxId())
 
     await conversation.removeAdmin(client2.inboxId())
     expect(conversation.isAdmin(client2.inboxId())).toBe(false)
-    expect(conversation.adminList().length).toBe(0)
+    expect(conversation.listAdmins().length).toBe(0)
   })
 
   it('should add and remove super admins', async () => {
@@ -338,19 +338,19 @@ describe.concurrent('Conversation', () => {
 
     expect(conversation.isSuperAdmin(client1.inboxId())).toBe(true)
     expect(conversation.isSuperAdmin(client2.inboxId())).toBe(false)
-    expect(conversation.superAdminList().length).toBe(1)
-    expect(conversation.superAdminList()).toContain(client1.inboxId())
+    expect(conversation.listSuperAdmins().length).toBe(1)
+    expect(conversation.listSuperAdmins()).toContain(client1.inboxId())
 
     await conversation.addSuperAdmin(client2.inboxId())
     expect(conversation.isSuperAdmin(client2.inboxId())).toBe(true)
-    expect(conversation.superAdminList().length).toBe(2)
-    expect(conversation.superAdminList()).toContain(client1.inboxId())
-    expect(conversation.superAdminList()).toContain(client2.inboxId())
+    expect(conversation.listSuperAdmins().length).toBe(2)
+    expect(conversation.listSuperAdmins()).toContain(client1.inboxId())
+    expect(conversation.listSuperAdmins()).toContain(client2.inboxId())
 
     await conversation.removeSuperAdmin(client2.inboxId())
     expect(conversation.isSuperAdmin(client2.inboxId())).toBe(false)
-    expect(conversation.superAdminList().length).toBe(1)
-    expect(conversation.superAdminList()).toContain(client1.inboxId())
+    expect(conversation.listSuperAdmins().length).toBe(1)
+    expect(conversation.listSuperAdmins()).toContain(client1.inboxId())
   })
 
   it('should manage group consent state', async () => {
@@ -374,14 +374,14 @@ describe.concurrent('Conversation', () => {
     expect(dmGroup).toBeDefined()
 
     await client2.conversations().sync()
-    const group2 = client2.conversations().findGroupById(group.id())
+    const group2 = client2.conversations().getConversationById(group.id())
     expect(group2).toBeDefined()
     expect(group2!.consentState()).toBe(ConsentState.Unknown)
     await group2!.sendText('gm!')
     expect(group2!.consentState()).toBe(ConsentState.Allowed)
 
     await client3.conversations().sync()
-    const dmGroup2 = client3.conversations().findGroupById(dmGroup.id())
+    const dmGroup2 = client3.conversations().getConversationById(dmGroup.id())
     expect(dmGroup2).toBeDefined()
     expect(dmGroup2!.consentState()).toBe(ConsentState.Unknown)
     await dmGroup2!.sendText('gm!')
@@ -474,7 +474,7 @@ describe.concurrent('Conversation', () => {
         identifierKind: IdentifierKind.Ethereum,
       },
     ])
-    const hmacKeys = group.getHmacKeys()
+    const hmacKeys = group.hmacKeys()
     expect(hmacKeys).toBeDefined()
     let keys = hmacKeys[group.id()]
     expect(keys.length).toBe(3)

--- a/bindings/node/test/Conversations.test.ts
+++ b/bindings/node/test/Conversations.test.ts
@@ -60,7 +60,7 @@ describe('Conversations', () => {
       updateMessageDisappearingPolicy: 2,
     })
     expect(group.addedByInboxId()).toBe(client1.inboxId())
-    expect((await group.findMessages()).length).toBe(1)
+    expect((await group.listMessages()).length).toBe(1)
     const members = await group.listMembers()
     expect(members.length).toBe(2)
     const memberInboxIds = members.map((member) => member.inboxId)
@@ -239,7 +239,7 @@ describe('Conversations', () => {
       updateMessageDisappearingPolicy: 0,
     })
     expect(group.addedByInboxId()).toBe(client1.inboxId())
-    expect((await group.findMessages()).length).toBe(1)
+    expect((await group.listMessages()).length).toBe(1)
     const members = await group.listMembers()
     expect(members.length).toBe(2)
     const memberInboxIds = members.map((member) => member.inboxId)
@@ -286,11 +286,11 @@ describe('Conversations', () => {
         .length
     ).toBe(0)
 
-    const dm1 = client1.conversations().findDmByTargetInboxId(client2.inboxId())
+    const dm1 = client1.conversations().getDmByInboxId(client2.inboxId())
     expect(dm1).toBeDefined()
     expect(dm1!.id()).toBe(group.id())
 
-    const dm2 = client2.conversations().findDmByTargetInboxId(client1.inboxId())
+    const dm2 = client2.conversations().getDmByInboxId(client1.inboxId())
     expect(dm2).toBeDefined()
     expect(dm2!.id()).toBe(group.id())
   })
@@ -308,7 +308,7 @@ describe('Conversations', () => {
     ])
     expect(group).toBeDefined()
     expect(group.id()).toBeDefined()
-    const foundGroup = client1.conversations().findGroupById(group.id())
+    const foundGroup = client1.conversations().getConversationById(group.id())
     expect(foundGroup).toBeDefined()
     expect(foundGroup!.id()).toBe(group.id())
   })
@@ -327,7 +327,7 @@ describe('Conversations', () => {
     const messageId = await group.sendText('gm!')
     expect(messageId).toBeDefined()
 
-    const message = client1.conversations().findMessageById(messageId)
+    const message = client1.conversations().getMessageById(messageId)
     expect(message).toBeDefined()
     expect(message!.id).toBe(messageId)
   })
@@ -935,7 +935,7 @@ describe('Conversations', () => {
       identifier: user2.account.address,
       identifierKind: IdentifierKind.Ethereum,
     })
-    const hmacKeys = client1.conversations().getHmacKeys()
+    const hmacKeys = client1.conversations().hmacKeys()
     expect(hmacKeys).toBeDefined()
     const keys = Object.keys(hmacKeys)
     expect(keys.length).toBe(2)
@@ -1002,22 +1002,22 @@ describe('Conversations', () => {
     await group1.addMembers([client2.inboxId()])
     await group1.sendText('gm3')
 
-    const messages1 = await group1.findMessages()
+    const messages1 = await group1.listMessages()
     expect(messages1.length).toBe(6)
 
     await client2.conversations().sync()
-    const group2 = client2.conversations().findGroupById(group1.id())
+    const group2 = client2.conversations().getConversationById(group1.id())
     await group2.sync()
-    const messages2 = await group2.findMessages()
+    const messages2 = await group2.listMessages()
     expect(messages2.length).toBe(3)
     expect(messages2[0].content.type).toEqual(contentTypeGroupUpdated())
     expect(messages2[1].content.type).toEqual(contentTypeGroupUpdated())
     expect(messages2[2].content.type).toEqual(contentTypeText())
 
     await client3.conversations().sync()
-    const group3 = client3.conversations().findGroupById(group1.id())
+    const group3 = client3.conversations().getConversationById(group1.id())
     await group3.sync()
-    const messages3 = await group3.findMessages()
+    const messages3 = await group3.listMessages()
     expect(messages3.length).toBe(6)
     expect(messages3[0].content.type).toEqual(contentTypeGroupUpdated())
     expect(messages3[1].content.type).toEqual(contentTypeText())
@@ -1027,9 +1027,9 @@ describe('Conversations', () => {
     expect(messages3[5].content.type).toEqual(contentTypeText())
 
     await client2_2.conversations().sync()
-    const group4 = client2_2.conversations().findGroupById(group1.id())
+    const group4 = client2_2.conversations().getConversationById(group1.id())
     await group4.sync()
-    const messages4 = await group4.findMessages()
+    const messages4 = await group4.listMessages()
     expect(messages4.length).toBe(3)
     expect(messages4[0].content.type).toEqual(contentTypeGroupUpdated())
     expect(messages4[1].content.type).toEqual(contentTypeGroupUpdated())

--- a/bindings/node/test/EnrichedMessage.test.ts
+++ b/bindings/node/test/EnrichedMessage.test.ts
@@ -34,7 +34,7 @@ describe.concurrent('EnrichedMessage', () => {
     await client2.conversations().sync()
     const conversation2 = client2
       .conversations()
-      .findGroupById(conversation.id())
+      .getConversationById(conversation.id())
     return { user1, user2, client1, client2, conversation, conversation2 }
   }
 
@@ -45,7 +45,7 @@ describe.concurrent('EnrichedMessage', () => {
       await conversation.sendText('Hello World')
       await conversation.sendText('Second message')
 
-      const messages = await conversation.findEnrichedMessages()
+      const messages = await conversation.listEnrichedMessages()
       expect(messages.length).toEqual(3)
 
       const textMessages = messages.filter((m) => m.content.text !== null)
@@ -71,7 +71,7 @@ describe.concurrent('EnrichedMessage', () => {
       await conversation.sendText('Message 2')
       await conversation.sendText('Message 3')
 
-      const limitedMessages = await conversation.findEnrichedMessages({
+      const limitedMessages = await conversation.listEnrichedMessages({
         limit: 2,
         direction: SortDirection.Descending,
       })
@@ -80,7 +80,7 @@ describe.concurrent('EnrichedMessage', () => {
       )
       expect(limitedTextMessages.length).toBe(2)
 
-      const allMessages = await conversation.findEnrichedMessages()
+      const allMessages = await conversation.listEnrichedMessages()
       const allTextMessages = allMessages.filter((m) => m.content.text !== null)
       expect(allTextMessages.length).toEqual(3)
     })
@@ -92,7 +92,7 @@ describe.concurrent('EnrichedMessage', () => {
 
       await conversation.sendText('Test')
 
-      const messages = await conversation.findEnrichedMessages()
+      const messages = await conversation.listEnrichedMessages()
 
       expect(messages.length).toEqual(2)
       // Messages should have kinds defined
@@ -112,7 +112,7 @@ describe.concurrent('EnrichedMessage', () => {
 
         await conversation2.sync()
 
-        const messages = await conversation2.findEnrichedMessages()
+        const messages = await conversation2.listEnrichedMessages()
         const textMessage = messages.find((m) => m.id === messageId)
         expect(textMessage).toBeDefined()
         expect(textMessage!.content.type).toBe(DecodedMessageContentType.Text)
@@ -135,7 +135,7 @@ describe.concurrent('EnrichedMessage', () => {
 
         await conversation2.sync()
 
-        const messages = await conversation2.findEnrichedMessages()
+        const messages = await conversation2.listEnrichedMessages()
         const markdownMessage = messages.find((m) => m.id === messageId)
         expect(markdownMessage).toBeDefined()
         expect(markdownMessage!.content.type).toBe(
@@ -169,7 +169,7 @@ describe.concurrent('EnrichedMessage', () => {
         await conversation2.sync()
 
         // Reactions are attached to parent messages in enriched messages
-        const messages = await conversation2.findEnrichedMessages()
+        const messages = await conversation2.listEnrichedMessages()
         const textMessage = messages.find((m) => m.id === textMessageId)
         expect(textMessage).toBeDefined()
         expect(textMessage!.reactions.length).toBe(1)
@@ -220,7 +220,7 @@ describe.concurrent('EnrichedMessage', () => {
 
         await conversation2.sync()
 
-        const messages = await conversation2.findEnrichedMessages()
+        const messages = await conversation2.listEnrichedMessages()
         const textMessage = messages.find((m) => m.id === textMessageId)
         expect(textMessage).toBeDefined()
         // After removal, the reactions array should reflect the removal
@@ -251,7 +251,7 @@ describe.concurrent('EnrichedMessage', () => {
 
         await conversation2.sync()
 
-        const messages = await conversation2.findEnrichedMessages()
+        const messages = await conversation2.listEnrichedMessages()
         const textMessage = messages.find((m) => m.id === textMessageId)
         const reaction = textMessage!.reactions.find((r) => r.id === reactionId)
         expect(reaction).toBeDefined()
@@ -277,7 +277,7 @@ describe.concurrent('EnrichedMessage', () => {
 
         await conversation2.sync()
 
-        const messages = await conversation2.findEnrichedMessages()
+        const messages = await conversation2.listEnrichedMessages()
         const textMessage = messages.find((m) => m.id === textMessageId)
         const reaction = textMessage!.reactions.find((r) => r.id === reactionId)
         expect(reaction).toBeDefined()
@@ -302,7 +302,7 @@ describe.concurrent('EnrichedMessage', () => {
 
         await conversation2.sync()
 
-        const messages = await conversation2.findEnrichedMessages()
+        const messages = await conversation2.listEnrichedMessages()
         const replyMessage = messages.find((m) => m.id === replyId)
         expect(replyMessage).toBeDefined()
         expect(replyMessage!.content.type).toBe(DecodedMessageContentType.Reply)
@@ -332,7 +332,7 @@ describe.concurrent('EnrichedMessage', () => {
 
         await conversation2.sync()
 
-        const messages = await conversation2.findEnrichedMessages()
+        const messages = await conversation2.listEnrichedMessages()
         const replyMessage = messages.find((m) => m.id === replyId)
         expect(replyMessage).toBeDefined()
         expect(replyMessage!.content.reply?.inReplyTo).toBeDefined()
@@ -357,7 +357,7 @@ describe.concurrent('EnrichedMessage', () => {
 
         await conversation2.sync()
 
-        const messages = await conversation2.findEnrichedMessages()
+        const messages = await conversation2.listEnrichedMessages()
         const replyMessage = messages.find((m) => m.id === replyId)
         expect(replyMessage).toBeDefined()
         expect(replyMessage!.content.type).toBe(DecodedMessageContentType.Reply)
@@ -384,7 +384,7 @@ describe.concurrent('EnrichedMessage', () => {
 
         await conversation2.sync()
 
-        const messages = await conversation2.findEnrichedMessages()
+        const messages = await conversation2.listEnrichedMessages()
         const attachmentMessage = messages.find((m) => m.id === attachmentId)
         expect(attachmentMessage).toBeDefined()
         expect(attachmentMessage!.content.type).toBe(
@@ -416,7 +416,7 @@ describe.concurrent('EnrichedMessage', () => {
 
         await conversation2.sync()
 
-        const messages = await conversation2.findEnrichedMessages()
+        const messages = await conversation2.listEnrichedMessages()
         const attachmentMessage = messages.find((m) => m.id === attachmentId)
         expect(attachmentMessage).toBeDefined()
         expect(attachmentMessage!.content.attachment?.filename).toBeUndefined()
@@ -447,7 +447,7 @@ describe.concurrent('EnrichedMessage', () => {
 
         await conversation2.sync()
 
-        const messages = await conversation2.findEnrichedMessages()
+        const messages = await conversation2.listEnrichedMessages()
         const remoteAttachmentMessage = messages.find(
           (m) => m.id === remoteAttachmentId
         )
@@ -497,7 +497,7 @@ describe.concurrent('EnrichedMessage', () => {
 
         await conversation2.sync()
 
-        const messages = await conversation2.findEnrichedMessages()
+        const messages = await conversation2.listEnrichedMessages()
         const remoteAttachmentMessage = messages.find(
           (m) => m.id === remoteAttachmentId
         )
@@ -543,7 +543,7 @@ describe.concurrent('EnrichedMessage', () => {
 
         await conversation2.sync()
 
-        const messages = await conversation2.findEnrichedMessages()
+        const messages = await conversation2.listEnrichedMessages()
         const multiRemoteAttachmentMessage = messages.find(
           (m) => m.id === multiRemoteAttachmentId
         )
@@ -595,7 +595,7 @@ describe.concurrent('EnrichedMessage', () => {
 
         await conversation2.sync()
 
-        const messages = await conversation2.findEnrichedMessages()
+        const messages = await conversation2.listEnrichedMessages()
         const multiRemoteAttachmentMessage = messages.find(
           (m) => m.id === multiRemoteAttachmentId
         )
@@ -615,7 +615,7 @@ describe.concurrent('EnrichedMessage', () => {
         expect(receiptId).toBeDefined()
 
         // Read receipts are excluded from enriched messages by design
-        const messages = await conversation.findEnrichedMessages()
+        const messages = await conversation.listEnrichedMessages()
         const receiptMessage = messages.find((m) => m.id === receiptId)
         expect(receiptMessage).toBeUndefined()
       })
@@ -637,7 +637,7 @@ describe.concurrent('EnrichedMessage', () => {
 
         await conversation2.sync()
 
-        const messages = await conversation2.findEnrichedMessages()
+        const messages = await conversation2.listEnrichedMessages()
         const transactionReferenceMessage = messages.find(
           (m) => m.id === transactionReferenceId
         )
@@ -676,7 +676,7 @@ describe.concurrent('EnrichedMessage', () => {
 
         await conversation2.sync()
 
-        const messages = await conversation2.findEnrichedMessages()
+        const messages = await conversation2.listEnrichedMessages()
         const transactionReferenceMessage = messages.find(
           (m) => m.id === transactionReferenceId
         )
@@ -703,7 +703,7 @@ describe.concurrent('EnrichedMessage', () => {
 
         await conversation2.sync()
 
-        const messages = await conversation2.findEnrichedMessages()
+        const messages = await conversation2.listEnrichedMessages()
         const transactionReferenceMessage = messages.find(
           (m) => m.id === transactionReferenceId
         )
@@ -734,7 +734,7 @@ describe.concurrent('EnrichedMessage', () => {
 
         await conversation2.sync()
 
-        const messages = await conversation2.findEnrichedMessages()
+        const messages = await conversation2.listEnrichedMessages()
         const transactionReferenceMessage = messages.find(
           (m) => m.id === transactionReferenceId
         )
@@ -780,7 +780,7 @@ describe.concurrent('EnrichedMessage', () => {
 
         await conversation2.sync()
 
-        const messages = await conversation2.findEnrichedMessages()
+        const messages = await conversation2.listEnrichedMessages()
         const walletSendCallsMessage = messages.find(
           (m) => m.id === walletSendCallsId
         )
@@ -832,7 +832,7 @@ describe.concurrent('EnrichedMessage', () => {
 
         await conversation2.sync()
 
-        const messages = await conversation2.findEnrichedMessages()
+        const messages = await conversation2.listEnrichedMessages()
         const walletSendCallsMessage = messages.find(
           (m) => m.id === walletSendCallsId
         )
@@ -877,7 +877,7 @@ describe.concurrent('EnrichedMessage', () => {
 
         await conversation2.sync()
 
-        const messages = await conversation2.findEnrichedMessages()
+        const messages = await conversation2.listEnrichedMessages()
         const walletSendCallsMessage = messages.find(
           (m) => m.id === walletSendCallsId
         )
@@ -970,7 +970,7 @@ describe.concurrent('EnrichedMessage', () => {
 
         await conversation2.sync()
 
-        const messages = await conversation2.findEnrichedMessages()
+        const messages = await conversation2.listEnrichedMessages()
         const actionsMessage = messages.find((m) => m.id === actionsId)
         expect(actionsMessage).toBeDefined()
         expect(actionsMessage!.content.type).toBe(
@@ -1024,7 +1024,7 @@ describe.concurrent('EnrichedMessage', () => {
 
         await conversation2.sync()
 
-        const messages = await conversation2.findEnrichedMessages()
+        const messages = await conversation2.listEnrichedMessages()
         const actionsMessage = messages.find((m) => m.id === actionsId)
         expect(actionsMessage).toBeDefined()
         expect(actionsMessage!.content.actions?.actions[0].style).toBe(
@@ -1062,7 +1062,7 @@ describe.concurrent('EnrichedMessage', () => {
 
         await conversation2.sync()
 
-        const messages = await conversation2.findEnrichedMessages()
+        const messages = await conversation2.listEnrichedMessages()
         const actionsMessage = messages.find((m) => m.id === actionsId)
         expect(actionsMessage).toBeDefined()
         expect(actionsMessage!.content.actions?.expiresAtNs).toBeDefined()
@@ -1091,7 +1091,7 @@ describe.concurrent('EnrichedMessage', () => {
 
         await conversation2.sync()
 
-        const messages = await conversation2.findEnrichedMessages()
+        const messages = await conversation2.listEnrichedMessages()
         const actionsMessage = messages.find((m) => m.id === actionsId)
         expect(actionsMessage).toBeDefined()
         expect(actionsMessage!.content.actions?.actions[0].imageUrl).toBe(
@@ -1114,7 +1114,7 @@ describe.concurrent('EnrichedMessage', () => {
 
         await conversation2.sync()
 
-        const messages = await conversation2.findEnrichedMessages()
+        const messages = await conversation2.listEnrichedMessages()
         const intentMessage = messages.find((m) => m.id === intentId)
         expect(intentMessage).toBeDefined()
         expect(intentMessage!.content.type).toBe(
@@ -1144,7 +1144,7 @@ describe.concurrent('EnrichedMessage', () => {
 
         await conversation2.sync()
 
-        const messages = await conversation2.findEnrichedMessages()
+        const messages = await conversation2.listEnrichedMessages()
         const intentMessage = messages.find((m) => m.id === intentId)
         expect(intentMessage).toBeDefined()
         expect(intentMessage!.content.intent?.metadata).toBeDefined()
@@ -1180,7 +1180,7 @@ describe.concurrent('EnrichedMessage', () => {
           },
         ])
 
-        const messages = await conversation.findEnrichedMessages()
+        const messages = await conversation.listEnrichedMessages()
         const groupUpdatedMessages = messages.filter(
           (m) => m.content.groupUpdated !== null
         )
@@ -1221,7 +1221,7 @@ describe.concurrent('EnrichedMessage', () => {
 
         await conversation.removeMembers([client2.inboxId()])
 
-        const messages = await conversation.findEnrichedMessages()
+        const messages = await conversation.listEnrichedMessages()
         const groupUpdatedMessages = messages.filter(
           (m) => m.content.groupUpdated !== null
         )
@@ -1255,7 +1255,7 @@ describe.concurrent('EnrichedMessage', () => {
 
         await conversation.updateGroupName('New Group Name')
 
-        const messages = await conversation.findEnrichedMessages()
+        const messages = await conversation.listEnrichedMessages()
         const groupUpdatedMessages = messages.filter(
           (m) => m.content.groupUpdated !== null
         )

--- a/bindings/node/test/helpers.ts
+++ b/bindings/node/test/helpers.ts
@@ -8,7 +8,7 @@ import {
   createClient as create,
   createLocalToxicClient,
   generateInboxId,
-  getInboxIdForIdentifier,
+  getInboxIdByIdentity,
   IdentifierKind,
   LogLevel,
   SyncWorkerMode,
@@ -38,7 +38,7 @@ export type User = ReturnType<typeof createUser>
 export const createClient = async (user: User, appVersion?: string) => {
   const dbPath = join(__dirname, `${user.uuid}.db3`)
   const inboxId =
-    (await getInboxIdForIdentifier(TEST_API_URL, undefined, false, {
+    (await getInboxIdByIdentity(TEST_API_URL, undefined, false, {
       identifier: user.account.address,
       identifierKind: IdentifierKind.Ethereum,
     })) ||
@@ -86,7 +86,7 @@ export const createRegisteredClient = async (
 export const createToxicClient = async (user: User) => {
   const dbPath = join(__dirname, `${user.uuid}.db3`)
   const inboxId =
-    (await getInboxIdForIdentifier(TEST_API_URL, undefined, false, {
+    (await getInboxIdByIdentity(TEST_API_URL, undefined, false, {
       identifier: user.account.address,
       identifierKind: IdentifierKind.Ethereum,
     })) ||

--- a/bindings/node/test/inboxId.test.ts
+++ b/bindings/node/test/inboxId.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { createRegisteredClient, createUser, TEST_API_URL } from '@test/helpers'
 import {
   generateInboxId,
-  getInboxIdForIdentifier,
+  getInboxIdByIdentity,
   IdentifierKind,
   isAddressAuthorized,
   isInstallationAuthorized,
@@ -19,33 +19,23 @@ describe('generateInboxId', () => {
   })
 })
 
-describe('getInboxIdForIdentifier', () => {
+describe('getInboxIdByIdentity', () => {
   it('should return `null` inbox ID for unregistered address', async () => {
     const user = createUser()
-    const inboxId = await getInboxIdForIdentifier(
-      TEST_API_URL,
-      undefined,
-      false,
-      {
-        identifier: user.account.address,
-        identifierKind: IdentifierKind.Ethereum,
-      }
-    )
+    const inboxId = await getInboxIdByIdentity(TEST_API_URL, undefined, false, {
+      identifier: user.account.address,
+      identifierKind: IdentifierKind.Ethereum,
+    })
     expect(inboxId).toBe(null)
   })
 
   it('should return inbox ID for registered address', async () => {
     const user = createUser()
     const client = await createRegisteredClient(user)
-    const inboxId = await getInboxIdForIdentifier(
-      TEST_API_URL,
-      undefined,
-      false,
-      {
-        identifier: user.account.address,
-        identifierKind: IdentifierKind.Ethereum,
-      }
-    )
+    const inboxId = await getInboxIdByIdentity(TEST_API_URL, undefined, false, {
+      identifier: user.account.address,
+      identifierKind: IdentifierKind.Ethereum,
+    })
     expect(inboxId).toBe(client.inboxId())
   })
 })


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Refactor Node bindings to follow the style guide by renaming and reordering methods across `Client`, `Conversation`, and `Conversations`, and removing `Client.get_latest_inbox_state`
Rename Node-facing methods to `get_`/`list_`/`fetch_` patterns, reorder parameters to `(inboxIds, refreshFromNetwork)`, and remove `Client.get_latest_inbox_state`; update tests to match API changes.

#### 📍Where to Start
Start with API rename and parameter changes in `Client` methods in [identity.rs](https://github.com/xmtp/libxmtp/pull/3043/files#diff-53dd8bfe77b4b9ddac2f25c413f6e213c8f0221be46150142cf413e4f3e6a948) and [inbox_state.rs](https://github.com/xmtp/libxmtp/pull/3043/files#diff-670e69119b5b6dcd5383a9a5605ef95a342b404c888844a8d52ac4347ba65b24), then review conversation-level renames in [messages.rs](https://github.com/xmtp/libxmtp/pull/3043/files#diff-bcbbce5ac284be8b7bbf08637f0cd0eeb992fb7e96e2513adce00839714f923e) and [membership.rs](https://github.com/xmtp/libxmtp/pull/3043/files#diff-f55657593183ce185513ecf5cf4f0247bf88454195a2bbdd49b282011125063c).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 4894eee.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->