### PR TITLE
Use AsyncFnOnce instead of two type parameters for load_mls_group_with_lock_async

### DIFF
--- a/crates/xmtp_mls/src/groups/commit_log.rs
+++ b/crates/xmtp_mls/src/groups/commit_log.rs
@@ -840,7 +840,7 @@ where
             .collect::<HashSet<_>>();
 
         let (unverified, verified) = mls_group
-            .load_mls_group_with_lock_async(|openmls_group| async move {
+            .load_mls_group_with_lock_async(async |openmls_group| {
                 let mut verified = HashSet::new();
                 for member in openmls_group.members() {
                     if unverified.contains(&member.signature_key) {

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -1689,7 +1689,7 @@ where
             }
         }
 
-        self.load_mls_group_with_lock_async(|mut mls_group| async move {
+        self.load_mls_group_with_lock_async(async |mut mls_group| {
             // ensure we are processing a private message
             match &envelope.message {
                 ProtocolMessage::PrivateMessage(_) => (),
@@ -2282,7 +2282,7 @@ where
     #[tracing::instrument]
     pub(super) async fn publish_intents(&self) -> Result<(), GroupError> {
         let db = self.context.db();
-        self.load_mls_group_with_lock_async(|mut mls_group| async move {
+        self.load_mls_group_with_lock_async(async |mut mls_group| {
             let intents = db.find_group_intents(
                 self.group_id.clone(),
                 Some(vec![IntentState::ToPublish]),
@@ -2664,7 +2664,7 @@ where
         inbox_ids_to_add: &[InboxIdRef<'_>],
         inbox_ids_to_remove: &[InboxIdRef<'_>],
     ) -> Result<UpdateGroupMembershipIntentData, GroupError> {
-        self.load_mls_group_with_lock_async(|mls_group| async move {
+        self.load_mls_group_with_lock_async(async |mls_group| {
             let existing_group_membership = extract_group_membership(mls_group.extensions())?;
             // TODO:nm prevent querying for updates on members who are being removed
             let mut inbox_ids = existing_group_membership.inbox_ids();

--- a/crates/xmtp_mls/src/groups/mod.rs
+++ b/crates/xmtp_mls/src/groups/mod.rs
@@ -47,7 +47,6 @@ use crate::{client::ClientError, subscriptions::LocalEvents, utils::id::calculat
 use device_sync::preference_sync::PreferenceUpdate;
 pub use error::*;
 use intents::{SendMessageIntentData, UpdateGroupMembershipResult};
-use mls_sync::GroupMessageProcessingError;
 use openmls::{
     credentials::CredentialType,
     extensions::{
@@ -58,10 +57,8 @@ use openmls::{
     messages::proposals::ProposalType,
     prelude::{Capabilities, GroupId, MlsGroup as OpenMlsGroup, WireFormatPolicy},
 };
-use openmls_traits::storage::CURRENT_VERSION;
 use prost::Message;
 use std::collections::HashMap;
-use std::future::Future;
 use std::{collections::HashSet, sync::Arc};
 use tokio::sync::Mutex;
 use xmtp_common::{Event, fmt::ShortHex, log_event, time::now_ns};
@@ -380,21 +377,12 @@ where
 
     // Load the stored OpenMLS group from the OpenMLS provider's keystore
     #[tracing::instrument(level = "trace", skip(operation))]
-    pub(crate) async fn load_mls_group_with_lock_async<F, E, R, Fut>(
+    pub(crate) async fn load_mls_group_with_lock_async<R, E>(
         &self,
-        operation: F,
+        operation: impl AsyncFnOnce(OpenMlsGroup) -> Result<R, E>,
     ) -> Result<R, E>
     where
-        F: FnOnce(OpenMlsGroup) -> Fut,
-        Fut: Future<Output = Result<R, E>>,
-        E:
-            From<GroupMessageProcessingError>
-                + From<crate::StorageError>
-                + From<
-                    <Context::MlsStorage as openmls_traits::storage::StorageProvider<
-                        CURRENT_VERSION,
-                    >>::Error,
-                >,
+        E: From<crate::StorageError> + From<xmtp_db::sql_key_store::SqlKeyStoreError>,
     {
         let mls_storage = self.context.mls_storage();
         // Get the group ID for locking
@@ -1934,10 +1922,8 @@ where
 
     /// Get the current epoch number of the group.
     pub async fn epoch(&self) -> Result<u64, GroupError> {
-        self.load_mls_group_with_lock_async(|mls_group| {
-            futures::future::ready(Ok(mls_group.epoch().as_u64()))
-        })
-        .await
+        self.load_mls_group_with_lock_async(async |mls_group| Ok(mls_group.epoch().as_u64()))
+            .await
     }
 
     /// Get the encryption state of the current epoch. Should match for all installations
@@ -1945,8 +1931,8 @@ where
     #[cfg(test)]
     #[allow(unused)]
     pub(crate) async fn epoch_authenticator(&self) -> Result<Vec<u8>, GroupError> {
-        self.load_mls_group_with_lock_async(|mls_group| {
-            futures::future::ready(Ok(mls_group.epoch_authenticator().as_slice().to_vec()))
+        self.load_mls_group_with_lock_async(async |mls_group| {
+            Ok(mls_group.epoch_authenticator().as_slice().to_vec())
         })
         .await
     }
@@ -2053,12 +2039,10 @@ where
 
     /// Get the `GroupMetadata` of the group.
     pub async fn metadata(&self) -> Result<GroupMetadata, GroupError> {
-        self.load_mls_group_with_lock_async(|mls_group| {
-            futures::future::ready(
-                extract_group_metadata(mls_group.extensions())
-                    .map_err(MetadataPermissionsError::from)
-                    .map_err(Into::into),
-            )
+        self.load_mls_group_with_lock_async(async |mls_group| {
+            extract_group_metadata(mls_group.extensions())
+                .map_err(MetadataPermissionsError::from)
+                .map_err(Into::into)
         })
         .await
     }

--- a/crates/xmtp_mls/src/groups/tests/mod.rs
+++ b/crates/xmtp_mls/src/groups/tests/mod.rs
@@ -5083,7 +5083,7 @@ async fn test_generate_commit_with_rollback() {
     let in_generate_commit_before_hash_mut = &mut in_generate_commit_before_hash;
     let in_generate_commit_after_hash_mut = &mut in_generate_commit_after_hash;
     group
-        .load_mls_group_with_lock_async(|mut mls_group| async move {
+        .load_mls_group_with_lock_async(async |mut mls_group| {
             let extensions = super::build_extensions_for_metadata_update(
                 &mls_group,
                 "foo".to_string(),

--- a/crates/xmtp_mls/src/groups/tests/test_welcome_pointers.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_welcome_pointers.rs
@@ -576,7 +576,7 @@ async fn test_welcome_pointer_task_retry_resolution() {
     let signer = &group.context.identity().installation_keys;
     let context = &group.context;
     let send_welcome_action = group
-        .load_mls_group_with_lock_async(|mut openmls_group| async move {
+        .load_mls_group_with_lock_async(async |mut openmls_group| {
             let publish_intent_data =
                 crate::groups::mls_sync::update_group_membership::apply_update_group_membership_intent(&context, &mut openmls_group, intent, signer)
                     .await?

--- a/crates/xmtp_mls/src/groups/tests/test_welcomes.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_welcomes.rs
@@ -179,7 +179,7 @@ async fn test_spoofed_inbox_id() {
     let signer = &group.context.identity().installation_keys;
     let context = &group.context;
     let send_welcome_action = group
-        .load_mls_group_with_lock_async(|mut openmls_group| async move {
+        .load_mls_group_with_lock_async(async |mut openmls_group| {
             let publish_intent_data =
                 apply_update_group_membership_intent(&context, &mut openmls_group, intent, signer)
                     .await?

--- a/crates/xmtp_mls/src/groups/welcome_sync.rs
+++ b/crates/xmtp_mls/src/groups/welcome_sync.rs
@@ -165,7 +165,7 @@ where
                         self.context.inbox_id()
                     );
                     let is_active = group
-                        .load_mls_group_with_lock_async(|mls_group| async move {
+                        .load_mls_group_with_lock_async(async |mls_group| {
                             Ok::<bool, GroupError>(mls_group.is_active())
                         })
                         .await?;
@@ -299,7 +299,7 @@ where
                     tracing::info!(inbox_id, "[{}] syncing group", inbox_id);
 
                     let is_active_res = group
-                        .load_mls_group_with_lock_async(|mls_group| async move {
+                        .load_mls_group_with_lock_async(async |mls_group| {
                             Ok::<bool, GroupError>(mls_group.is_active())
                         })
                         .await;

--- a/crates/xmtp_mls/src/subscriptions/mod.rs
+++ b/crates/xmtp_mls/src/subscriptions/mod.rs
@@ -618,7 +618,7 @@ pub(crate) mod tests {
 
         // Get the welcome messages and encode the first one as V3 protobuf
         let welcomes = envelope.welcome_messages()?;
-        assert!(welcomes.len() > 0, "Should have at least one welcome");
+        assert!(!welcomes.is_empty(), "Should have at least one welcome");
 
         let welcome = &welcomes[0];
         let v1 = welcome.as_v1().expect("Should be a V1 welcome");


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Adopt `AsyncFnOnce` in `crates/xmtp_mls/src/groups/mod.rs::load_mls_group_with_lock_async` to accept async closures for group operations
Refactor `load_mls_group_with_lock_async` to take an `AsyncFnOnce` and update all call sites to pass async closures; remove unused imports and minor test assertion cleanup. See core changes in [mod.rs](https://github.com/xmtp/libxmtp/pull/3044/files#diff-c27dd00cf700fd888b75fdbd19738462c2549fdc881dad70f8e61c979d440966).

#### 📍Where to Start
Start with the refactored `load_mls_group_with_lock_async` in [crates/xmtp_mls/src/groups/mod.rs](https://github.com/xmtp/libxmtp/pull/3044/files#diff-c27dd00cf700fd888b75fdbd19738462c2549fdc881dad70f8e61c979d440966), then review updated call sites in `mls_sync`, `commit_log`, and `welcome_sync`.

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized f0646ac.
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->