### PR TITLE
Improve test logs and tester ergonomics

### DIFF
--- a/crates/xmtp_common/src/test.rs
+++ b/crates/xmtp_common/src/test.rs
@@ -120,7 +120,9 @@ where
                 fmt::layer()
                     .compact()
                     .with_ansi(true)
-                    .without_time()
+                    .with_file(true)
+                    .with_line_number(true)
+                    .with_target(false)
                     .with_test_writer()
                     .fmt_fields({
                         format::debug_fn(move |writer, field, value| {
@@ -130,8 +132,13 @@ where
                                 let mut message = format!("{value:?}");
                                 let ids = REPLACE_IDS.lock();
                                 for (id, name) in ids.iter() {
-                                    message = message.replace(id, name);
-                                    message = message.replace(&crate::fmt::truncate_hex(id), name);
+                                    if message.contains(id) {
+                                        message = message.replace(id, name);
+                                    }
+                                    let truncate_hex = crate::fmt::truncate_hex(id);
+                                    if message.contains(&truncate_hex) {
+                                        message = message.replace(&truncate_hex, name);
+                                    }
                                 }
                                 write!(writer, "{message}")?;
                             }

--- a/crates/xmtp_mls/src/utils/test/tester_utils.rs
+++ b/crates/xmtp_mls/src/utils/test/tester_utils.rs
@@ -831,13 +831,13 @@ impl UserValidationMethod for PkUserValidationMethod {
 #[macro_export]
 macro_rules! tester {
     ($name:ident, from: $existing:expr $(, $k:ident $(: $v:expr)?)*) => {
-        tester!(@process $existing.builder.clone() ; $name $(, $k $(: $v)?)*)
+        $crate::tester!(@process $existing.builder.clone() ; $name $(, $k $(: $v)?)*)
     };
 
     ($name:ident $(, $k:ident $(: $v:expr)?)*) => {
         let builder = $crate::utils::TesterBuilder::new();
         let builder = builder.with_name(stringify!($name));
-        tester!(@process builder ; $name $(, $k $(: $v)?)*)
+        $crate::tester!(@process builder ; $name $(, $k $(: $v)?)*)
     };
 
     (@process $builder:expr ; $name:ident) => {
@@ -851,11 +851,11 @@ macro_rules! tester {
     };
 
     (@process $builder:expr ; $name:ident, $key:ident: $value:expr $(, $k:ident $(: $v:expr)?)*) => {
-        tester!(@process $builder.$key($value) ; $name $(, $k $(: $v)?)*)
+        $crate::tester!(@process $builder.$key($value) ; $name $(, $k $(: $v)?)*)
     };
 
     (@process $builder:expr ; $name:ident, $key:ident $(, $k:ident $(: $v:expr)?)*) => {
-        tester!(@process $builder.$key() ; $name $(, $k $(: $v)?)*)
+        $crate::tester!(@process $builder.$key() ; $name $(, $k $(: $v)?)*)
     };
 }
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Improve test log output to include file and line numbers in xmtp_common
- Updates the default fmt layer in [test.rs](https://github.com/xmtp/libxmtp/pull/3052/files#diff-834604dd2b3a7c6ca152bec61a1c221bca12edb51649fb97c4961c06c5a472c7) to emit file and line numbers and suppress the target field; the explicit `without_time()` call is removed.
- Fixes macro hygiene in [tester_utils.rs](https://github.com/xmtp/libxmtp/pull/3052/files#diff-f9501ede5ef5d686b4c51a16efb8046e9c1f4019214fb1ba76797d6058924b88) by qualifying recursive `tester!` invocations with `$crate::` to ensure correct crate resolution.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized b079322.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->