### PR TITLE
Fix serialization for actions and intent

### DIFF
--- a/bindings/mobile/src/message.rs
+++ b/bindings/mobile/src/message.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use chrono::{DateTime, Utc};
 use xmtp_content_types::{
     actions::{Action, ActionStyle, Actions},
     attachment::Attachment,
@@ -806,7 +807,7 @@ impl TryFrom<Actions> for FfiActions {
         let actions_id = actions.id.clone();
         let expires_at_ns = match actions.expires_at {
             Some(dt) => {
-                let ns_opt = dt.and_utc().timestamp_nanos_opt();
+                let ns_opt = dt.timestamp_nanos_opt();
                 if ns_opt.is_none() {
                     return Err(GenericError::from(format!(
                         "Actions '{}' expiration timestamp is out of valid range for conversion to nanoseconds",
@@ -832,13 +833,9 @@ impl TryFrom<Actions> for FfiActions {
 
 impl From<FfiActions> for Actions {
     fn from(actions: FfiActions) -> Self {
-        let expires_at = match actions.expires_at_ns {
-            Some(ns) => {
-                let dt = chrono::DateTime::from_timestamp_nanos(ns).naive_utc();
-                Some(dt)
-            }
-            None => None,
-        };
+        let expires_at = actions
+            .expires_at_ns
+            .map(DateTime::<Utc>::from_timestamp_nanos);
 
         Actions {
             id: actions.id,
@@ -856,7 +853,7 @@ impl TryFrom<Action> for FfiAction {
         let action_id = action.id.clone();
         let expires_at_ns = match action.expires_at {
             Some(dt) => {
-                let ns_opt = dt.and_utc().timestamp_nanos_opt();
+                let ns_opt = dt.timestamp_nanos_opt();
                 if ns_opt.is_none() {
                     return Err(GenericError::from(format!(
                         "Action '{}' expiration timestamp is out of valid range for conversion to nanoseconds",
@@ -880,13 +877,9 @@ impl TryFrom<Action> for FfiAction {
 
 impl From<FfiAction> for Action {
     fn from(action: FfiAction) -> Self {
-        let expires_at = match action.expires_at_ns {
-            Some(ns) => {
-                let dt = chrono::DateTime::from_timestamp_nanos(ns).naive_utc();
-                Some(dt)
-            }
-            None => None,
-        };
+        let expires_at = action
+            .expires_at_ns
+            .map(DateTime::<Utc>::from_timestamp_nanos);
 
         Action {
             id: action.id,

--- a/bindings/node/src/content_types/actions.rs
+++ b/bindings/node/src/content_types/actions.rs
@@ -2,7 +2,7 @@ use crate::{
   ErrorWrapper,
   messages::encoded_content::{ContentTypeId, EncodedContent},
 };
-use chrono::DateTime;
+use chrono::{DateTime, Utc};
 use napi::bindgen_prelude::{BigInt, Error, Result};
 use napi_derive::napi;
 use xmtp_content_types::{ContentCodec, actions::ActionsCodec};
@@ -25,7 +25,7 @@ impl TryFrom<xmtp_content_types::actions::Actions> for Actions {
     let actions_id = actions.id.clone();
     let expires_at_ns = match actions.expires_at {
       Some(dt) => {
-        let ns_opt = dt.and_utc().timestamp_nanos_opt();
+        let ns_opt = dt.timestamp_nanos_opt();
         if ns_opt.is_none() {
           return Err(Error::from_reason(format!(
             "Actions '{}' expiration timestamp is out of valid range for conversion to nanoseconds",
@@ -53,7 +53,7 @@ impl From<Actions> for xmtp_content_types::actions::Actions {
   fn from(actions: Actions) -> Self {
     let expires_at = actions
       .expires_at_ns
-      .map(|ns| DateTime::from_timestamp_nanos(ns.get_i64().0).naive_utc());
+      .map(|ns| DateTime::<Utc>::from_timestamp_nanos(ns.get_i64().0));
 
     xmtp_content_types::actions::Actions {
       id: actions.id,
@@ -83,7 +83,7 @@ impl TryFrom<xmtp_content_types::actions::Action> for Action {
     let action_id = action.id.clone();
     let expires_at_ns = match action.expires_at {
       Some(dt) => {
-        let ns_opt = dt.and_utc().timestamp_nanos_opt();
+        let ns_opt = dt.timestamp_nanos_opt();
         if ns_opt.is_none() {
           return Err(Error::from_reason(format!(
             "Action '{}' expiration timestamp is out of valid range for conversion to nanoseconds",
@@ -109,7 +109,7 @@ impl From<Action> for xmtp_content_types::actions::Action {
   fn from(action: Action) -> Self {
     let expires_at = action
       .expires_at_ns
-      .map(|ns| DateTime::from_timestamp_nanos(ns.get_i64().0).naive_utc());
+      .map(|ns| DateTime::<Utc>::from_timestamp_nanos(ns.get_i64().0));
 
     xmtp_content_types::actions::Action {
       id: action.id,

--- a/bindings/wasm/src/content_types/actions.rs
+++ b/bindings/wasm/src/content_types/actions.rs
@@ -1,5 +1,5 @@
 use bindings_wasm_macros::wasm_bindgen_numbered_enum;
-use chrono::DateTime;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use tsify::Tsify;
 use wasm_bindgen::JsError;
@@ -28,7 +28,7 @@ impl TryFrom<xmtp_content_types::actions::Actions> for Actions {
     let actions_id = actions.id.clone();
     let expires_at_ns = match actions.expires_at {
       Some(dt) => {
-        let ns_opt = dt.and_utc().timestamp_nanos_opt();
+        let ns_opt = dt.timestamp_nanos_opt();
         if ns_opt.is_none() {
           return Err(JsError::new(&format!(
             "Actions '{}' expiration timestamp is out of valid range for conversion to nanoseconds",
@@ -54,13 +54,9 @@ impl TryFrom<xmtp_content_types::actions::Actions> for Actions {
 
 impl From<Actions> for xmtp_content_types::actions::Actions {
   fn from(actions: Actions) -> Self {
-    let expires_at = match actions.expires_at_ns {
-      Some(ns) => {
-        let dt = DateTime::from_timestamp_nanos(ns).naive_utc();
-        Some(dt)
-      }
-      None => None,
-    };
+    let expires_at = actions
+      .expires_at_ns
+      .map(DateTime::<Utc>::from_timestamp_nanos);
 
     Self {
       id: actions.id,
@@ -95,7 +91,7 @@ impl TryFrom<xmtp_content_types::actions::Action> for Action {
     let action_id = action.id.clone();
     let expires_at_ns = match action.expires_at {
       Some(dt) => {
-        let ns_opt = dt.and_utc().timestamp_nanos_opt();
+        let ns_opt = dt.timestamp_nanos_opt();
         if ns_opt.is_none() {
           return Err(JsError::new(&format!(
             "Action '{}' expiration timestamp is out of valid range for conversion to nanoseconds",
@@ -119,13 +115,9 @@ impl TryFrom<xmtp_content_types::actions::Action> for Action {
 
 impl From<Action> for xmtp_content_types::actions::Action {
   fn from(action: Action) -> Self {
-    let expires_at = match action.expires_at_ns {
-      Some(ns) => {
-        let dt = DateTime::from_timestamp_nanos(ns).naive_utc();
-        Some(dt)
-      }
-      None => None,
-    };
+    let expires_at = action
+      .expires_at_ns
+      .map(DateTime::<Utc>::from_timestamp_nanos);
 
     Self {
       id: action.id,

--- a/crates/xmtp_content_types/src/actions.rs
+++ b/crates/xmtp_content_types/src/actions.rs
@@ -1,9 +1,38 @@
 use std::collections::HashSet;
 
 use crate::{CodecError, ContentCodec};
-use chrono::NaiveDateTime;
-use serde::{Deserialize, Serialize};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use xmtp_proto::xmtp::mls::message_contents::{ContentTypeId, EncodedContent};
+
+const UTC_MILLIS_FORMAT: &str = "%Y-%m-%dT%H:%M:%S%.3fZ";
+
+mod datetime_utc_millis_option {
+    use super::*;
+
+    pub fn serialize<S>(date: &Option<DateTime<Utc>>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match date {
+            Some(dt) => serializer.serialize_some(&dt.format(UTC_MILLIS_FORMAT).to_string()),
+            None => serializer.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<DateTime<Utc>>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let opt: Option<String> = Option::deserialize(deserializer)?;
+        match opt {
+            Some(s) => DateTime::parse_from_rfc3339(&s)
+                .map(|dt| Some(dt.with_timezone(&Utc)))
+                .map_err(serde::de::Error::custom),
+            None => Ok(None),
+        }
+    }
+}
 
 pub struct ActionsCodec;
 impl ActionsCodec {
@@ -89,16 +118,30 @@ pub struct Actions {
     pub id: String,
     pub description: String,
     pub actions: Vec<Action>,
-    pub expires_at: Option<NaiveDateTime>,
+    #[serde(
+        default,
+        rename = "expiresAt",
+        skip_serializing_if = "Option::is_none",
+        with = "datetime_utc_millis_option"
+    )]
+    pub expires_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct Action {
     pub id: String,
     pub label: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub image_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub style: Option<ActionStyle>,
-    pub expires_at: Option<NaiveDateTime>,
+    #[serde(
+        default,
+        rename = "expiresAt",
+        skip_serializing_if = "Option::is_none",
+        with = "datetime_utc_millis_option"
+    )]
+    pub expires_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -113,7 +156,7 @@ pub enum ActionStyle {
 mod tests {
     use super::{Action, ActionStyle, Actions, ActionsCodec};
     use crate::{CodecError, ContentCodec};
-    use chrono::NaiveDateTime;
+    use chrono::{TimeZone, Utc};
 
     #[xmtp_common::test(unwrap_try = true)]
     fn encode_decode_actions() {
@@ -133,10 +176,10 @@ mod tests {
                     label: "Pork Loin".to_string(),
                     image_url: None,
                     style: None,
-                    expires_at: Some(NaiveDateTime::MIN),
+                    expires_at: Some(Utc.with_ymd_and_hms(2025, 1, 15, 12, 30, 45).unwrap()),
                 },
             ],
-            expires_at: Some(NaiveDateTime::MAX),
+            expires_at: Some(Utc.with_ymd_and_hms(2025, 12, 31, 23, 59, 59).unwrap()),
         };
 
         let encoded = ActionsCodec::encode(actions.clone())?;
@@ -162,5 +205,34 @@ mod tests {
             panic!("Expected an uniqueness encoding error.");
         };
         assert!(reason.contains("unique"));
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn expires_at_serializes_as_utc_with_millis() {
+        let actions = Actions {
+            id: "test".to_string(),
+            description: "Test".to_string(),
+            actions: vec![Action {
+                id: "action1".to_string(),
+                label: "Action 1".to_string(),
+                image_url: None,
+                style: None,
+                expires_at: Some(Utc.with_ymd_and_hms(2025, 6, 15, 10, 30, 45).unwrap()),
+            }],
+            expires_at: Some(Utc.with_ymd_and_hms(2025, 12, 25, 23, 59, 59).unwrap()),
+        };
+
+        let encoded = ActionsCodec::encode(actions)?;
+        let json = String::from_utf8(encoded.content.clone())?;
+
+        // Verify format includes milliseconds (.000) and UTC suffix (Z)
+        assert!(
+            json.contains("2025-06-15T10:30:45.000Z"),
+            "Action expires_at should be formatted with milliseconds and UTC: {json}"
+        );
+        assert!(
+            json.contains("2025-12-25T23:59:59.000Z"),
+            "Actions expires_at should be formatted with milliseconds and UTC: {json}"
+        );
     }
 }

--- a/crates/xmtp_content_types/src/intent.rs
+++ b/crates/xmtp_content_types/src/intent.rs
@@ -69,7 +69,9 @@ impl ContentCodec<Intent> for IntentCodec {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct Intent {
     pub id: String,
+    #[serde(rename = "actionId")]
     pub action_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<HashMap<String, Value>>,
 }
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Serialize actions and intent timestamps as UTC RFC3339 with milliseconds and update converters to use `chrono::DateTime<Utc>` across mobile, Node, and WASM bindings
Switch `expiresAt` to `Option<chrono::DateTime<Utc>>` with RFC3339 millisecond formatting and camelCase in `Actions`/`Action`; update FFI/Node/WASM converters to use `DateTime::<Utc>::from_timestamp_nanos` and `timestamp_nanos_opt`; rename `Intent.action_id` to `actionId` and skip empty option fields; adjust tests for UTC ranges and field names.

#### 📍Where to Start
Start with the `Actions` and `Action` model changes and serde module in [actions.rs](https://github.com/xmtp/libxmtp/pull/3055/files#diff-88b7e00e14c64f8bd2804b894a92968478aa4046d4ca8bf90767d0ab1e8eddad), then review binding converters in [message.rs](https://github.com/xmtp/libxmtp/pull/3055/files#diff-b81bf66a320e19f15bd096a6aa1fc36f3d412496bc9d14247ab6e47ba44619fd), [actions.rs](https://github.com/xmtp/libxmtp/pull/3055/files#diff-cf50a01878ece862748a5177a1546a7abedc861248b1f23f642607363f826011), and [actions.rs](https://github.com/xmtp/libxmtp/pull/3055/files#diff-155f5baf51e4821e4a8d19d3970cdd16a60136f80bbdf6a4d7724e40f82817a9).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 30e666d. 5 files reviewed, 5 issues evaluated, 4 issues filtered, 1 comment posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>crates/xmtp_content_types/src/actions.rs — 0 comments posted, 4 evaluated, 4 filtered</summary>

- [line 8](https://github.com/xmtp/libxmtp/blob/30e666d87748a5d0a0a1b71ebb2df21199fe3156/crates/xmtp_content_types/src/actions.rs#L8): The format string `UTC_MILLIS_FORMAT` uses `%.3f` which requires exactly 3 fractional digits when parsing. If previously serialized data (using `NaiveDateTime`) was stored without a `Z` suffix or with different decimal precision (e.g., microseconds with 6 digits, or no fractional seconds), deserialization using this strict format will fail. This could break backward compatibility with existing persisted data. <b>[ Low confidence ]</b>
- [line 29](https://github.com/xmtp/libxmtp/blob/30e666d87748a5d0a0a1b71ebb2df21199fe3156/crates/xmtp_content_types/src/actions.rs#L29): Serialization and deserialization use incompatible formats: `serialize` formats the date using `UTC_MILLIS_FORMAT` but `deserialize` parses using `parse_from_rfc3339`. Unless `UTC_MILLIS_FORMAT` happens to produce RFC3339-compliant strings, data serialized by this module cannot be successfully deserialized, causing a round-trip failure. <b>[ Low confidence ]</b>
- [line 123](https://github.com/xmtp/libxmtp/blob/30e666d87748a5d0a0a1b71ebb2df21199fe3156/crates/xmtp_content_types/src/actions.rs#L123): The `Actions` struct field `expires_at` now uses `rename = "expiresAt"` for serde serialization, changing the expected JSON field name from `expires_at` (snake_case) to `expiresAt` (camelCase). Combined with `default`, if existing serialized data uses the old `expires_at` field name, deserialization will silently ignore it and set `expires_at` to `None`, causing silent data loss rather than a deserialization error. <b>[ Low confidence ]</b>
- [line 138](https://github.com/xmtp/libxmtp/blob/30e666d87748a5d0a0a1b71ebb2df21199fe3156/crates/xmtp_content_types/src/actions.rs#L138): The `Action` struct similarly changed the `expires_at` field serialization from default snake_case to explicit `rename = "expiresAt"` camelCase. If any code or stored data relies on the previous `expires_at` field name format, deserializing that data will result in `expires_at` being `None` due to the `default` attribute, silently losing the expiration timestamp. <b>[ Low confidence ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->