### PR TITLE
Ensure actions and intent are backwards-compatible

### DIFF
--- a/crates/xmtp_content_types/src/actions.rs
+++ b/crates/xmtp_content_types/src/actions.rs
@@ -120,6 +120,7 @@ pub struct Actions {
     pub actions: Vec<Action>,
     #[serde(
         default,
+        alias = "expires_at",
         rename = "expiresAt",
         skip_serializing_if = "Option::is_none",
         with = "datetime_utc_millis_option"
@@ -131,12 +132,17 @@ pub struct Actions {
 pub struct Action {
     pub id: String,
     pub label: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        alias = "image_url",
+        rename = "imageUrl",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub image_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub style: Option<ActionStyle>,
     #[serde(
         default,
+        alias = "expires_at",
         rename = "expiresAt",
         skip_serializing_if = "Option::is_none",
         with = "datetime_utc_millis_option"

--- a/crates/xmtp_content_types/src/intent.rs
+++ b/crates/xmtp_content_types/src/intent.rs
@@ -69,7 +69,7 @@ impl ContentCodec<Intent> for IntentCodec {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct Intent {
     pub id: String,
-    #[serde(rename = "actionId")]
+    #[serde(rename = "actionId", alias = "action_id")]
     pub action_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<HashMap<String, Value>>,


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add serde aliases to `actions::Actions.expires_at`, `actions::Action.image_url` and `actions::Action.expires_at`, and `intent::Intent.action_id` to ensure backwards-compatible JSON keys
Introduce serde `alias` for snake_case keys while retaining camelCase `rename`, and change `actions::Action.image_url` serialization to `imageUrl`.

#### 📍Where to Start
Start with the struct attribute changes in [actions.rs](https://github.com/xmtp/libxmtp/pull/3060/files#diff-88b7e00e14c64f8bd2804b894a92968478aa4046d4ca8bf90767d0ab1e8eddad), then review `Intent` in [intent.rs](https://github.com/xmtp/libxmtp/pull/3060/files#diff-87269de9c06c4b55b14aecc7e68d2f4bb2e0a5328f3e18266a55ff861087082f).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized fa0633e.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->