### PR TITLE
add memory profiling tests for dm broadcasting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2322,6 +2322,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "dhat"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
+dependencies = [
+ "backtrace",
+ "lazy_static",
+ "mintex",
+ "parking_lot 0.12.5",
+ "rustc-hash 1.1.0",
+ "serde",
+ "serde_json",
+ "thousands",
+]
+
+[[package]]
 name = "diesel"
 version = "2.3.2"
 source = "git+https://github.com/ephemerahq/diesel?branch=coda%2Fcopy-to-sqlite#99e3e5d2ed3bec84e7c3867af6724dc96a882fd3"
@@ -4282,6 +4298,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "memprofile"
+version = "1.8.0-dev"
+dependencies = [
+ "alloy",
+ "color-eyre",
+ "dhat",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "xmtp_common",
+ "xmtp_id",
+ "xmtp_mls",
+ "xshell",
+]
+
+[[package]]
 name = "migrations_internals"
 version = "2.3.0"
 source = "git+https://github.com/ephemerahq/diesel?branch=coda%2Fcopy-to-sqlite#99e3e5d2ed3bec84e7c3867af6724dc96a882fd3"
@@ -4340,6 +4373,12 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
+
+[[package]]
+name = "mintex"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
 
 [[package]]
 name = "mio"
@@ -6802,6 +6841,12 @@ dependencies = [
  "quote",
  "syn 2.0.111",
 ]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "thread_local"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
   "crates/xmtp_mls",
   "crates/xmtp_mls_common",
   "crates/xmtp_proto",
+  "crates/memprofile",
 ]
 
 # Used when cargo commands in the workspace root, such as `cargo test`, are run without flags.
@@ -85,6 +86,7 @@ ctor = "0.6"
 criterion = { version = "0.7", features = ["html_reports", "async_tokio"] }
 derive_builder = "0.20"
 diesel = { version = "2.3", default-features = false }
+dhat = { version = "0.3" }
 diesel_migrations = { version = "2.2", default-features = false }
 dyn-clone = "1"
 ed25519-dalek = { version = "2.2", features = ["zeroize"] }
@@ -164,6 +166,7 @@ web-time = "1.1"
 zeroize = "1.8"
 smallvec = { version = "1.15", features = ["union"] }
 http-body-util = { version = "0.1" }
+xshell = { version = "0.2" }
 
 # Internal Crate Dependencies
 bindings-wasm = { path = "bindings/wasm" }

--- a/crates/memprofile/Cargo.toml
+++ b/crates/memprofile/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "memprofile"
+edition = "2024"
+license.workspace = true
+version.workspace = true
+
+[dependencies]
+alloy.workspace = true
+color-eyre.workspace = true
+dhat.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+xmtp_common.workspace = true
+xmtp_id = { workspace = true, features = ["test-utils"] }
+xmtp_mls = { workspace = true, features = ["test-utils"] }
+xshell.workspace = true
+
+
+[[test]]
+harness = true
+name = "dm_broadcast"
+
+[lints]
+workspace = true

--- a/crates/memprofile/src/lib.rs
+++ b/crates/memprofile/src/lib.rs
@@ -1,0 +1,4 @@
+//! This should remain empty
+//! this crate houses mem profile integration tests.
+//! each integration test must be its own file to create an isolated memory environment
+

--- a/crates/memprofile/tests/dm_broadcast.rs
+++ b/crates/memprofile/tests/dm_broadcast.rs
@@ -1,0 +1,106 @@
+//! Tests for heap profile high water marks
+//! each memtest must be in its own integration test file to avoid
+//! interference and false statistics
+//!
+use std::{io::pipe, path::PathBuf, process::Command};
+
+use alloy::primitives::Address;
+use color_eyre::eyre::{OptionExt, Result, eyre};
+use dhat::HeapStats;
+use xmtp_id::associations::{Identifier, ident};
+use xmtp_mls::tester;
+use xshell::{Shell, cmd};
+
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+fn get_ids() -> Result<Vec<Address>> {
+    let sh = Shell::new()?;
+    let xdbg = xdbg()?;
+    let (in_reader, in_writer) = pipe()?;
+    let (out_reader, out_writer) = pipe()?;
+
+    tracing::info!("getting ids");
+    let mut xdbg_cmd: Command = cmd!(sh, "{xdbg} export --entity identity").into();
+    let mut xdbg_child = xdbg_cmd.stdout(in_writer).spawn()?;
+
+    let _jq = Command::new("jq")
+        .arg("[.[].ethereum_address]")
+        .stdin(in_reader)
+        .stdout(out_writer)
+        .spawn()?;
+    drop(xdbg_cmd);
+    xdbg_child.wait()?;
+    serde_json::from_reader(&out_reader).map_err(Into::into)
+}
+
+// use xdbg to generate `size` identities
+// using xdbg as to not effect the memory calculations of `dhat`, since `xdbg` is out of this process.
+// it will also conveniently re-use identities if they already exist.
+fn create_watchers(size: usize) -> Result<Vec<Address>> {
+    let sh = Shell::new()?;
+    let xdbg = xdbg()?;
+
+    let ids = get_ids()?;
+    if ids.len() >= size {
+        return Ok(ids.into_iter().take(size).collect());
+    }
+    let size_str = (size - ids.len()).to_string();
+    let mut c: Command = cmd!(sh, "{xdbg} generate --entity identity --amount {size_str}").into();
+    let mut c = c.spawn()?;
+    c.wait()?;
+    let ids: Vec<_> = get_ids()?;
+    if ids.len() < size {
+        return Err(eyre!("not enough ids"));
+    }
+    Ok(ids)
+}
+
+/// Get xdbg binary from /target if it exists, otherwise compile it then get it.
+fn xdbg() -> Result<PathBuf> {
+    let sh = Shell::new()?;
+    let workspace = cmd!(
+        sh,
+        "cargo locate-project --workspace --message-format=plain"
+    )
+    .read()?;
+    let xdbg = PathBuf::from(workspace)
+        .parent()
+        .ok_or_eyre("no parent of libxmtp manifest")?
+        .join("target")
+        .join("release")
+        .join("xdbg");
+    if !xdbg.exists() {
+        cmd!(sh, "cargo build --release -p xdbg").run()?;
+    }
+    Ok(xdbg)
+}
+
+/// ensure dm broadcasting uses a reasonable amount of memory
+#[tokio::test]
+async fn memtest_dm_broadcast() -> Result<()> {
+    let _profiler = dhat::Profiler::builder().testing().build();
+
+    // fork out to xdbg to create/reuse clients, and run cmds out of the process,
+    // minimizing any memory the allocator picks up from test setup.
+    let ids = create_watchers(300)?;
+    tracing::info!("got {} ids", ids.len());
+
+    for watcher in ids {
+        // create a new client for each broadcast
+        tester!(broadcaster);
+        let dm = broadcaster
+            .find_or_create_dm_by_identity(
+                Identifier::Ethereum(ident::Ethereum(watcher.to_string().to_ascii_lowercase())),
+                None,
+            )
+            .await?;
+        dm.send_message(b"BROADCAST MESSAGE", Default::default())
+            .await?;
+    }
+    // ensure that dm broadcast stayed under 100MB
+    let stats = HeapStats::get();
+    println!("{:?}", stats);
+    dhat::assert!(stats.max_bytes < (100 * 1024 * 1024));
+    Ok(())
+}

--- a/crates/xmtp_debug/src/app.rs
+++ b/crates/xmtp_debug/src/app.rs
@@ -161,9 +161,9 @@ static FDLIMIT: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
 fn get_fdlimit() -> usize {
     *FDLIMIT.get_or_init(|| {
         if let Ok(fdlimit::Outcome::LimitRaised { to, .. }) = fdlimit::raise_fd_limit() {
-            if to > 512 {
+            if to > 1024 {
                 // we can go higher but 1024 seems reasonable
-                512
+                1024
             } else {
                 to as usize
             }

--- a/crates/xmtp_mls/Cargo.toml
+++ b/crates/xmtp_mls/Cargo.toml
@@ -137,7 +137,6 @@ chrono = { workspace = true, features = ["clock"] }
 dyn-clone.workspace = true
 openmls.workspace = true
 
-
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 chrono = { workspace = true, features = ["wasmbind"] }
 getrandom = { workspace = true }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add `memprofile` crate and a `dm_broadcast` test that asserts DM broadcasting heap usage stays below 100 MiB using `dhat::Alloc`
Introduce memory profiling tests for DM broadcasting with a new `memprofile` crate, set the global allocator to `dhat::Alloc`, and add a tokio test that checks `max_bytes < 100 MiB`; adjust `xmtp_debug` export to always emit `[]` and raise fd limit to 1024.

#### 📍Where to Start
Start with the `dm_broadcast` test in [dm_broadcast.rs](https://github.com/xmtp/libxmtp/pull/3062/files#diff-8a048d5ad32588bb981136e6a0359fb8bba5f573c76373a9a03197928a427d99).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized cf0ec21.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->