### PR TITLE
Fix DeletedMessage serialization

### DIFF
--- a/bindings/wasm/src/content_types/deleted_message.rs
+++ b/bindings/wasm/src/content_types/deleted_message.rs
@@ -1,20 +1,20 @@
+use bindings_wasm_macros::wasm_bindgen_numbered_enum;
 use serde::{Deserialize, Serialize};
-use wasm_bindgen::prelude::wasm_bindgen;
+use tsify::Tsify;
 
-#[wasm_bindgen]
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(rename_all = "camelCase")]
 pub struct DeletedMessage {
-  #[wasm_bindgen(getter_with_clone, js_name = "deletedBy")]
   pub deleted_by: DeletedBy,
-  #[wasm_bindgen(getter_with_clone, js_name = "adminInboxId")]
+  #[serde(skip_serializing_if = "Option::is_none")]
   pub admin_inbox_id: Option<String>,
 }
 
-#[wasm_bindgen]
-#[derive(Clone, Copy, Serialize, Deserialize)]
+#[wasm_bindgen_numbered_enum]
 pub enum DeletedBy {
-  Sender,
-  Admin,
+  Sender = 0,
+  Admin = 1,
 }
 
 impl From<xmtp_mls::messages::decoded_message::DeletedBy> for DeletedMessage {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Fix DeletedMessage serialization by switching `content_types::deleted_message::DeletedMessage` to Tsify-based WASM ABI with camelCase fields and numeric `content_types::deleted_message::DeletedBy` discriminants (Sender=0, Admin=1) in [deleted_message.rs](https://github.com/xmtp/libxmtp/pull/3063/files#diff-67316f921145b17f5f593e331dbcdfde7aa74e9b052110a8e619e802dfbccaf9)
Replace `#[wasm_bindgen]` with Tsify for `DeletedMessage` and apply `#[serde(rename_all = "camelCase")]`, omit `adminInboxId` when `None`, and convert `DeletedBy` to `#[wasm_bindgen_numbered_enum]` with explicit values.

#### 📍Where to Start
Start with the `DeletedMessage` struct and `DeletedBy` enum in [deleted_message.rs](https://github.com/xmtp/libxmtp/pull/3063/files#diff-67316f921145b17f5f593e331dbcdfde7aa74e9b052110a8e619e802dfbccaf9).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized d374ac7. 1 file reviewed, 2 issues evaluated, 1 issue filtered, 1 comment posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>bindings/wasm/src/content_types/deleted_message.rs — 1 comment posted, 2 evaluated, 1 filtered</summary>

- [line 7](https://github.com/xmtp/libxmtp/blob/d374ac784aee8876fdaab5c185e9e2a6a211d1fd/bindings/wasm/src/content_types/deleted_message.rs#L7): The addition of `#[serde(rename_all = "camelCase")]` changes the serialization format from snake_case (`deleted_by`, `admin_inbox_id`) to camelCase (`deletedBy`, `adminInboxId`). Any existing serialized data or external consumers expecting the old snake_case format will fail to deserialize or parse correctly, causing a backwards compatibility break. <b>[ Low confidence ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->