### PR TITLE
ci: add optional sccache to setup-nix action

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -7,6 +7,10 @@ inputs:
   cachix-auth-token:
     description: 'Cachix auth token for xmtp cache'
     required: false
+  sccache:
+    description: 'Enable sccache with GitHub Actions cache backend'
+    required: false
+    default: 'false'
 runs:
   using: 'composite'
   steps:
@@ -24,3 +28,12 @@ runs:
       if: ${{ inputs.cachix-auth-token == '' }}
       with:
         name: xmtp
+    - name: Setup sccache
+      if: ${{ inputs.sccache == 'true' }}
+      uses: mozilla-actions/sccache-action@v0.0.9
+    - name: Configure sccache env
+      if: ${{ inputs.sccache == 'true' }}
+      run: |
+        echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+        echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+      shell: bash

--- a/.github/workflows/check-ios-android-bindings.yml
+++ b/.github/workflows/check-ios-android-bindings.yml
@@ -16,9 +16,6 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
-env:
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
 jobs:
   check-swift:
     runs-on: warp-macos-13-arm64-6x
@@ -38,8 +35,7 @@ jobs:
         with:
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
+          sccache: 'true'
       - name: Build target
         run: |
           nix develop .#ios --command \
@@ -65,8 +61,7 @@ jobs:
         with:
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
+          sccache: 'true'
       - name: check target
         run: |
           nix develop .#android --command \

--- a/.github/workflows/test-webassembly.yml
+++ b/.github/workflows/test-webassembly.yml
@@ -24,8 +24,6 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
 jobs:
   wasm-ci:
     name: WASM CI
@@ -40,8 +38,7 @@ jobs:
         with:
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
+          sccache: 'true'
       - name: Install omnix
         run: nix profile install nixpkgs#omnix
 
@@ -65,8 +62,7 @@ jobs:
         with:
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
+          sccache: 'true'
       - name: Start Docker containers
         run: |
           nix build .#docker-mls_validation_service


### PR DESCRIPTION
Add sccache input to the setup-nix composite action. When enabled,
it runs mozilla-actions/sccache-action and sets SCCACHE_GHA_ENABLED
and RUSTC_WRAPPER env vars automatically.

Migrated check-ios-android-bindings and test-webassembly workflows
to use this instead of manual sccache setup.