### PR TITLE
ci: use taiki-e for taplo installation

### DIFF
--- a/.github/workflows/lint-toml.yml
+++ b/.github/workflows/lint-toml.yml
@@ -16,14 +16,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Install Taplo
-        env:
-          version: "0.9.3"
-        run: |
-          curl -Ls "https://github.com/tamasfe/taplo/releases/download/${{ env.version }}/taplo-full-linux-x86_64.gz" | \
-          gzip -d > taplo && \
-          chmod +x taplo && \
-          sudo mv taplo /usr/local/bin/taplo
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: taplo-cli@0.9.3
       - name: Run format check
         run: taplo format --check --diff
       - name: Run validation check

--- a/.github/workflows/nightly-protos.yml
+++ b/.github/workflows/nightly-protos.yml
@@ -19,14 +19,9 @@ jobs:
           sudo apt-get install -y protobuf-compiler
       - name: Generate Protos
         run: dev/gen_protos.sh
-      - name: Install Taplo
-        env:
-          version: "0.9.3"
-        run: |
-          curl -Ls "https://github.com/tamasfe/taplo/releases/download/${{ env.version }}/taplo-full-linux-x86_64.gz" | \
-          gzip -d > taplo && \
-          chmod +x taplo && \
-          sudo mv taplo /usr/local/bin/taplo
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: taplo-cli@0.9.3
       - name: Run format check
         run: taplo format
       - name: Create Pull Request


### PR DESCRIPTION
Replace manual curl-based taplo install with taiki-e/install-action
in lint-toml.yml and nightly-protos.yml. This is consistent with
how other tools (nextest, cargo-llvm-cov, cargo-ndk) are installed
and provides automatic download caching.