### PR TITLE
ci: extract npm-publish reusable workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,109 @@
+name: NPM Publish
+
+on:
+  workflow_call:
+    inputs:
+      package-dir:
+        description: 'Path to the npm package directory'
+        required: true
+        type: string
+      tag-prefix:
+        description: 'Prefix for git tags (e.g., node-bindings, wasm-bindings)'
+        required: true
+        type: string
+      artifact-pattern:
+        description: 'Pattern for downloading build artifacts (optional)'
+        required: false
+        type: string
+      artifact-path:
+        description: 'Path to download artifacts to (required if artifact-pattern is set)'
+        required: false
+        type: string
+
+jobs:
+  publish:
+    permissions:
+      id-token: write
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download build artifacts
+        if: ${{ inputs.artifact-pattern != '' }}
+        uses: actions/download-artifact@v7
+        with:
+          pattern: ${{ inputs.artifact-pattern }}
+          merge-multiple: true
+          path: ${{ inputs.artifact-path }}
+
+      - name: Setup node
+        uses: ./.github/actions/setup-node
+        with:
+          cache-dependency-path: "${{ inputs.package-dir }}/yarn.lock"
+
+      - name: Install dependencies
+        working-directory: ${{ inputs.package-dir }}
+        run: yarn
+
+      - name: Update version for dev releases
+        working-directory: ${{ inputs.package-dir }}
+        run: |
+          # Read the current version from package.json
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+
+          # Check if this is a dev version
+          if [[ "$PACKAGE_VERSION" == *"dev"* ]]; then
+            GIT_HASH=$(git log -1 --pretty=format:"%h")
+
+            # Create a new version string with the git hash
+            NEW_VERSION="${PACKAGE_VERSION}.${GIT_HASH}"
+
+            # Update package.json with the new version
+            npm version "$NEW_VERSION" --no-git-tag-version
+
+            echo "Updated version to $NEW_VERSION for publishing"
+          else
+            echo "Not a dev version, keeping original version: $PACKAGE_VERSION"
+          fi
+
+      - name: Determine NPM tag
+        id: npm-tag
+        working-directory: ${{ inputs.package-dir }}
+        run: |
+          # Read the current version from package.json
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+
+          # Set the tag based on whether it's a dev version
+          if [[ "$PACKAGE_VERSION" == *"dev"* ]]; then
+            echo "tag=prerelease" >> $GITHUB_OUTPUT
+          else
+            echo "tag=latest" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Git Tag for Dev Releases
+        if: contains(steps.npm-tag.outputs.tag, 'prerelease')
+        run: |
+          # Read the current version from package.json
+          PACKAGE_VERSION=$(node -p "require('./${{ inputs.package-dir }}/package.json').version")
+
+          # Create and push the tag
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git tag -a "${{ inputs.tag-prefix }}-${PACKAGE_VERSION}" -m "${{ inputs.tag-prefix }} version ${PACKAGE_VERSION}"
+          git push origin "${{ inputs.tag-prefix }}-${PACKAGE_VERSION}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update npm to latest
+        run: npm install -g npm@latest
+
+      - name: Publish to NPM
+        uses: JS-DevTools/npm-publish@v4
+        with:
+          package: ${{ inputs.package-dir }}
+          tag: ${{ steps.npm-tag.outputs.tag }}
+          dry-run: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-node-bindings.yml
+++ b/.github/workflows/release-node-bindings.yml
@@ -236,88 +236,11 @@ jobs:
           retention-days: 1
 
   publish:
-    permissions:
-      id-token: write
-      contents: write
-    runs-on: ubuntu-latest
     needs: [build-linux, build-macos, build-windows]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@v7
-        with:
-          pattern: bindings_node_*
-          merge-multiple: true
-          path: bindings/node/dist
-
-      - name: Setup node
-        uses: ./.github/actions/setup-node
-        with:
-          cache-dependency-path: "bindings/node/yarn.lock"
-
-      - name: Install dependencies
-        working-directory: bindings/node
-        run: yarn
-
-      - name: Update version for dev releases
-        working-directory: bindings/node
-        run: |
-          # Read the current version from package.json
-          PACKAGE_VERSION=$(node -p "require('./package.json').version")
-
-          # Check if this is a dev version
-          if [[ "$PACKAGE_VERSION" == *"dev"* ]]; then
-            GIT_HASH=$(git log -1 --pretty=format:"%h")
-
-            # Create a new version string with the git hash
-            NEW_VERSION="${PACKAGE_VERSION}.${GIT_HASH}"
-
-            # Update package.json with the new version
-            npm version "$NEW_VERSION" --no-git-tag-version
-
-            echo "Updated version to $NEW_VERSION for publishing"
-          else
-            echo "Not a dev version, keeping original version: $PACKAGE_VERSION"
-          fi
-
-      - name: Determine NPM tag
-        id: npm-tag
-        working-directory: bindings/node
-        run: |
-          # Read the current version from package.json
-          PACKAGE_VERSION=$(node -p "require('./package.json').version")
-
-          # Set the tag based on whether it's a dev version
-          if [[ "$PACKAGE_VERSION" == *"dev"* ]]; then
-            echo "tag=prerelease" >> $GITHUB_OUTPUT
-          else
-            echo "tag=latest" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Create Git Tag for Dev Releases
-        if: contains(steps.npm-tag.outputs.tag, 'prerelease')
-        run: |
-          # Read the current version from package.json
-          PACKAGE_VERSION=$(node -p "require('./bindings/node/package.json').version")
-
-          # Create and push the tag
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git tag -a "node-bindings-${PACKAGE_VERSION}" -m "Node bindings version ${PACKAGE_VERSION}"
-          git push origin "node-bindings-${PACKAGE_VERSION}"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Update npm to latest
-        run: npm install -g npm@latest
-
-      - name: Publish to NPM
-        uses: JS-DevTools/npm-publish@v4
-        with:
-          package: bindings/node
-          tag: ${{ steps.npm-tag.outputs.tag }}
-          dry-run: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: ./.github/workflows/npm-publish.yml
+    with:
+      package-dir: bindings/node
+      tag-prefix: node-bindings
+      artifact-pattern: bindings_node_*
+      artifact-path: bindings/node/dist
+    secrets: inherit

--- a/.github/workflows/release-wasm-bindings.yml
+++ b/.github/workflows/release-wasm-bindings.yml
@@ -4,10 +4,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
 jobs:
-  release:
-    permissions:
-      id-token: write
-      contents: write
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -51,59 +48,22 @@ jobs:
         run: |
           source ../../emsdk/emsdk_env.sh
           yarn build
-      - name: Update version for dev releases
-        working-directory: bindings/wasm
-        run: |
-          # Read the current version from package.json
-          PACKAGE_VERSION=$(node -p "require('./package.json').version")
-
-          # Check if this is a dev version
-          if [[ "$PACKAGE_VERSION" == *"dev"* ]]; then
-            GIT_HASH=$(git log -1 --pretty=format:"%h")
-
-            # Create a new version string with the git hash
-            NEW_VERSION="${PACKAGE_VERSION}.${GIT_HASH}"
-
-            # Update package.json with the new version
-            npm version "$NEW_VERSION" --no-git-tag-version
-
-            echo "Updated version to $NEW_VERSION for publishing"
-          else
-            echo "Not a dev version, keeping original version: $PACKAGE_VERSION"
-          fi
-      - name: Determine NPM tag
-        id: npm-tag
-        working-directory: bindings/wasm
-        run: |
-          # Read the current version from package.json
-          PACKAGE_VERSION=$(node -p "require('./package.json').version")
-
-          # Set the tag based on whether it's a dev version
-          if [[ "$PACKAGE_VERSION" == *"dev"* ]]; then
-            echo "tag=prerelease" >> $GITHUB_OUTPUT
-          else
-            echo "tag=latest" >> $GITHUB_OUTPUT
-          fi
-      - name: Create Git Tag for Dev Releases
-        if: contains(steps.npm-tag.outputs.tag, 'prerelease')
-        run: |
-          # Read the current version from package.json
-          PACKAGE_VERSION=$(node -p "require('./bindings/wasm/package.json').version")
-
-          # Create and push the tag
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git tag -a "wasm-bindings-${PACKAGE_VERSION}" -m "WASM bindings version ${PACKAGE_VERSION}"
-          git push origin "wasm-bindings-${PACKAGE_VERSION}"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Update npm to latest
-        run: npm install -g npm@latest
-      - name: Publish to NPM
-        uses: JS-DevTools/npm-publish@v4
+      - name: Upload build output
+        uses: actions/upload-artifact@v6
         with:
-          package: bindings/wasm
-          tag: ${{ steps.npm-tag.outputs.tag }}
-          dry-run: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          name: wasm_build
+          path: |
+            bindings/wasm/dist
+            bindings/wasm/package.json
+            bindings/wasm/yarn.lock
+          retention-days: 1
+
+  publish:
+    needs: [build]
+    uses: ./.github/workflows/npm-publish.yml
+    with:
+      package-dir: bindings/wasm
+      tag-prefix: wasm-bindings
+      artifact-pattern: wasm_build
+      artifact-path: bindings/wasm
+    secrets: inherit


### PR DESCRIPTION
Create a shared npm-publish.yml reusable workflow that handles:
- Version update for dev releases (git hash suffix)
- NPM tag determination (prerelease vs latest)
- Git tag creation for dev releases
- npm publish via JS-DevTools/npm-publish@v4

Migrated release-node-bindings.yml and release-wasm-bindings.yml
to use it, eliminating ~100 lines of duplicated publish logic.