### PR TITLE
ci: extract slack-notify reusable workflow

### DIFF
--- a/.github/actions/slack-notify/action.yml
+++ b/.github/actions/slack-notify/action.yml
@@ -1,0 +1,25 @@
+name: 'Slack Notify'
+description: 'Send a notification to Slack via webhook'
+inputs:
+  message:
+    description: 'Message text to send'
+    required: true
+  webhook-url:
+    description: 'Slack webhook URL (channel is bound to the webhook)'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Notify Slack
+      env:
+        SLACK_WEBHOOK_URL: ${{ inputs.webhook-url }}
+        MESSAGE: ${{ inputs.message }}
+      run: |
+        if [ -n "$SLACK_WEBHOOK_URL" ]; then
+          curl -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-type: application/json' \
+            --data "$(jq -n --arg text "$MESSAGE" '{text: $text}')"
+        else
+          echo "$MESSAGE"
+        fi
+      shell: bash

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -28,28 +28,14 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Notify Slack
+      - uses: actions/checkout@v6
+      - id: compute
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           IOS_RESULT: ${{ needs.release-ios.result }}
           IOS_VERSION: ${{ needs.release-ios.outputs.version }}
         run: |
-          STATUS="success"
-          if [ "$IOS_RESULT" = "failure" ]; then
-            STATUS="failure"
-          fi
-
-          CHANNEL="#notify-dev-releases"
-          if [ "$STATUS" = "failure" ]; then
-            CHANNEL="#notify-dev-release-failures"
-          fi
-
-          MESSAGE="Dev Release: iOS ${IOS_VERSION:-skipped} - ${IOS_RESULT:-skipped}"
-
-          if [ -n "$SLACK_WEBHOOK_URL" ]; then
-            curl -X POST "$SLACK_WEBHOOK_URL" \
-              -H 'Content-type: application/json' \
-              --data "{\"channel\":\"$CHANNEL\",\"text\":\"$MESSAGE\"}"
-          else
-            echo "$MESSAGE"
-          fi
+          echo "message=Dev Release: iOS ${IOS_VERSION:-skipped} - ${IOS_RESULT:-skipped}" >> "$GITHUB_OUTPUT"
+      - uses: ./.github/actions/slack-notify
+        with:
+          message: ${{ steps.compute.outputs.message }}
+          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -68,34 +68,15 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Notify Slack
+      - uses: actions/checkout@v6
+      - id: compute
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           IOS_RESULT: ${{ needs.release-ios.result }}
           IOS_VERSION: ${{ needs.release-ios.outputs.version }}
           RELEASE_TYPE: ${{ inputs.release-type }}
         run: |
-          STATUS="success"
-          if [ "$IOS_RESULT" = "failure" ]; then
-            STATUS="failure"
-          fi
-
-          if [ "$RELEASE_TYPE" = "final" ]; then
-            CHANNEL="#notify-sdk-releases"
-          else
-            CHANNEL="#notify-dev-releases"
-          fi
-
-          if [ "$STATUS" = "failure" ]; then
-            CHANNEL="#notify-dev-release-failures"
-          fi
-
-          MESSAGE="${RELEASE_TYPE^} Release: iOS ${IOS_VERSION:-skipped} - ${IOS_RESULT:-skipped}"
-
-          if [ -n "$SLACK_WEBHOOK_URL" ]; then
-            curl -X POST "$SLACK_WEBHOOK_URL" \
-              -H 'Content-type: application/json' \
-              --data "{\"channel\":\"$CHANNEL\",\"text\":\"$MESSAGE\"}"
-          else
-            echo "$MESSAGE"
-          fi
+          echo "message=${RELEASE_TYPE^} Release: iOS ${IOS_VERSION:-skipped} - ${IOS_RESULT:-skipped}" >> "$GITHUB_OUTPUT"
+      - uses: ./.github/actions/slack-notify
+        with:
+          message: ${{ steps.compute.outputs.message }}
+          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Create a shared slack-notify.yml reusable workflow for sending
Slack notifications. Migrated dev-release.yml and publish-release.yml
to use it instead of inline curl commands.