### PR TITLE
share+cache ffi-uniffi-bindgen between android and ios nix builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,21 @@ messaging protocol, such as cryptography, networking, and language bindings.
 
 ## Development
 
+Adding Dependencies
+
+- adding dependencies will require re-generating the `workspace-hack` crate,
+  which can be done with:
+
+```bash
+nix develop --command cargo hakari generate
+```
+
+to verify correctness you can optionally run
+
+```bash
+nix develop --command cargo hakari verify
+```
+
 Start Docker Desktop.
 
 - To install other dependencies and start background services:

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
   };
 
   outputs =
-    inputs @ { flake-parts, self, crane, ... }:
+    inputs @ { flake-parts, self, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {
       systems = [
         "aarch64-darwin"
@@ -65,13 +65,13 @@
               inherit (pkgs.xmtp) androidEnv;
             in
             {
+              inherit (pkgs.xmtp) ffi-uniffi-bindgen;
               wasm-bindings = (pkgs.callPackage ./nix/package/wasm.nix { }).bin;
               wasm-bindgen-cli = pkgs.callPackage ./nix/lib/packages/wasm-bindgen-cli.nix { };
               # Android bindings (.so libraries + Kotlin bindings)
               android-libs = android.aggregate;
               # Android bindings - host-matching target only (fast dev/CI builds)
               android-libs-fast = (android.mkAndroid [ androidEnv.hostAndroidTarget ]).aggregate;
-
               docker-mls_validation_service = pkgs.dockerTools.buildLayeredImage {
                 name = "ghcr.io/xmtp/mls-validation-service"; # override ghcr images
                 tag = "main";

--- a/nix/lib/default.nix
+++ b/nix/lib/default.nix
@@ -18,6 +18,7 @@
         mobile = pkgs.callPackage ./mobile-common.nix { };
         androidEnv = pkgs.callPackage ./android-env.nix { };
         iosEnv = pkgs.callPackage ./ios-env.nix { };
+        ffi-uniffi-bindgen = pkgs.callPackage ./packages/uniffi-bindgen.nix { };
       };
       wasm-bindgen-cli = pkgs.callPackage ./packages/wasm-bindgen-cli.nix { };
       swiftformat = pkgs.callPackage ./packages/swiftformat.nix { };

--- a/nix/lib/packages/uniffi-bindgen.nix
+++ b/nix/lib/packages/uniffi-bindgen.nix
@@ -1,0 +1,21 @@
+{ xmtp
+, lib
+}:
+let
+  inherit (xmtp) mobile;
+  rust-toolchain = xmtp.mkToolchain [ ] [ ];
+  rust = xmtp.craneLib.overrideToolchain (p: rust-toolchain);
+  cargoArtifacts = rust.buildDepsOnly mobile.commonArgs;
+  src = ./../../..;
+in
+rust.buildPackage
+  (mobile.commonArgs // {
+    inherit cargoArtifacts;
+    pname = "ffi-uniffi-bindgen";
+    cargoExtraArgs = "-p xmtpv3 --bin ffi-uniffi-bindgen --features uniffi/cli";
+    version = xmtp.mobile.mkVersion rust;
+    src = lib.fileset.toSource {
+      root = src;
+      fileset = xmtp.filesets.forCrate (src + /bindings/mobile);
+    };
+  })

--- a/nix/package/android.nix
+++ b/nix/package/android.nix
@@ -28,7 +28,7 @@ let
   # Use build composition (minimal - no emulator needed for CI builds)
   androidComposition = androidEnv.composeBuildPackages;
   androidPaths = androidEnv.mkAndroidPaths androidComposition;
-
+  ffi-uniffi-bindgen = "${xmtp.ffi-uniffi-bindgen}/bin/ffi-uniffi-bindgen";
 
 
   # Rust toolchain with Android cross-compilation targets
@@ -131,7 +131,7 @@ let
       mkdir -p $out/kotlin
 
       # Generate Kotlin bindings using uniffi-bindgen
-      cargo run -p xmtpv3 --bin ffi-uniffi-bindgen --release --features uniffi/cli generate \
+      ${ffi-uniffi-bindgen} generate \
         --library target/release/libxmtpv3.${if stdenv.isDarwin then "dylib" else "so"} \
         --out-dir $TMPDIR/kotlin-out \
         --language kotlin

--- a/nix/package/ios.nix
+++ b/nix/package/ios.nix
@@ -34,7 +34,7 @@ let
   craneLib = xmtp.craneLib.overrideScope (_: _: {
     inherit stdenv;
   });
-
+  ffi-uniffi-bindgen = "${xmtp.ffi-uniffi-bindgen}/bin/ffi-uniffi-bindgen";
   # Rust toolchain with iOS/macOS cross-compilation targets.
   # No clippy/rustfmt — this is a build-only toolchain (the dev shell adds those).
   # overrideToolchain tells crane to use our custom fenix-based toolchain instead
@@ -143,7 +143,7 @@ let
       #   - xmtpv3.swift: Swift source with all public API types and functions
       #   - xmtpv3FFI.h: C header for the FFI layer
       #   - xmtpv3FFI.modulemap: Clang module map (renamed to module.modulemap)
-      cargo run -p xmtpv3 --bin ffi-uniffi-bindgen --release --features uniffi/cli generate \
+      ${ffi-uniffi-bindgen} generate \
         --library target/release/libxmtpv3.a \
         --out-dir $TMPDIR/swift-out \
         --language swift


### PR DESCRIPTION
just splits the ffi-uniffi-bindgen cli tool to its own derivation enabling caching and reuse across ios and android