### PR TITLE
Fix node release issue

### DIFF
--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -122,8 +122,10 @@ jobs:
       - name: Build target (aarch64)
         if: startsWith(matrix.target, 'aarch64')
         env:
+          CC_aarch64_unknown_linux_gnu: aarch64-linux-gnu-gcc
+          CC_aarch64_unknown_linux_musl: aarch64-linux-gnu-gcc
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: aarch64-linux-gnu-gcc
-          CC: aarch64-linux-gnu-gcc
         working-directory: bindings/node
         run: |
           yarn build:release --target ${{ matrix.target }}


### PR DESCRIPTION
## Bug Summary

I found an issue when publishing Node SDK releases triggered by the addition of Hakari.

## Validation

[Release with this fix applied](https://github.com/xmtp/libxmtp/actions/runs/21970826347)

## More Details

```
  1. The CC: aarch64-linux-gnu-gcc global env var existed since the original workflow was created in June 2024 (commit 43cdf84ee). It was
  always a latent bug.
  2. The cargo-hakari PR (d6cbc1bdc, Feb 11) broke it. That PR added xmtp-workspace-hack as a dependency of every crate in the workspace,
  including bindings/node. The workspace-hack has reqwest (with rustls-tls) in its [build-dependencies] section. That pulls in rustls →
  ring → cc as build-dependencies compiled for the HOST (x86_64).
  3. When cross-compiling for aarch64 on an x86_64 host, build-dependencies are compiled for x86_64. Ring's build.rs runs, uses cc::Build,
  sees TARGET=x86_64-unknown-linux-gnu (set by Cargo for build-deps), and adds the -m64 flag. But then cc looks up the compiler: checks
  CC_x86_64_unknown_linux_gnu (not set), falls back to the global CC=aarch64-linux-gnu-gcc. The aarch64 compiler gets the x86_64-specific
  -m64 flag and fails.

  Before hakari, ring was only a regular dependency (compiled for the target aarch64), so CC=aarch64-linux-gnu-gcc was correct. After
  hakari, ring also became a transitive build-dependency (compiled for the host x86_64), where the global CC pointed to the wrong compiler.

  The fix we applied (using target-specific CC_aarch64_unknown_linux_gnu instead of global CC) is correct — it only affects aarch64 target
  compilations and leaves host compilations free to use the default system compiler.
```