### PR TITLE
Un-gitignore src/bin folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ wasm-pack.log
 
 !xmtp/src/bin/
 !xmtp_mls/src/bin/
+!**/src/bin
 
 # generated
 bindings_swift/Sources


### PR DESCRIPTION
### TL;DR

Update `.gitignore` to prevent ignoring Rust files in src/bin directories. For example `update-schema.rs`

### What changed?

Added a new pattern `!**/src/bin` to the `.gitignore` file to ensure that files in any `src/bin` directory are not ignored by git, regardless of their location in the project structure.

### How to test?

1. Create a new binary file in any `src/bin` directory
2. Run `git status` to verify the file is tracked by git
3. Verify that existing binary files in `xmtp/src/bin/` and `xmtp_mls/src/bin/` are still tracked

### Why make this change?

The previous configuration only explicitly allowed binary files in two specific directories (`xmtp/src/bin/` and `xmtp_mls/src/bin/`). This change generalizes the rule to allow binary files in any `src/bin` directory throughout the project, making it more consistent and future-proof as new modules are added.