### PR TITLE
fix aarch64-linux build breaking ci

### DIFF
--- a/nix/package/wasm.nix
+++ b/nix/package/wasm.nix
@@ -13,9 +13,11 @@
   xmtp,
   chromedriver,
   google-chrome,
+  chromium,
   corepack,
   pkg-config,
   cargo-nextest,
+  stdenv,
 }:
 let
   inherit (xmtp) craneLib;
@@ -121,11 +123,15 @@ let
       inputsFrom = [ commonArgs ];
       buildInputs = [
         rust-toolchain
-        google-chrome
         chromedriver
         corepack
         cargo-nextest
-      ];
+      ]
+      # chromium unsupported on darwin
+      # google-chrome unsupported on aarch64-linux
+      # Firefox compiles from scratch on everything but x86_64 (unreliable build)
+      ++ lib.optionals stdenv.isDarwin [ google-chrome ]
+      ++ lib.optionals stdenv.isLinux [ chromium ];
 
       SQLITE = "${sqlite.dev}";
       SQLITE_OUT = "${sqlite.out}";


### PR DESCRIPTION
```
 evaluation warning: crane will use a placeholder value since `name` cannot be found in /nix/store/xb3asc012680rpkkkcfg8p02xr0c8fwp-Cargo.toml
                      to silence this warning consider one of the following:
                      - setting `pname = "...";` in the derivation arguments explicitly
                      - setting `package.name = "..."` or `package.metadata.crane.name` = "..." or `workspace.metadata.crane.name` = "..." in the root Cargo.toml
                      - explicitly looking up the values from a different Cargo.toml via
                        `craneLib.crateNameFromCargoToml { cargoToml = ./path/to/Cargo.toml; }`
  
                      To find the source of this warning, rerun nix with:
                      `NIX_ABORT_ON_WARN=1 nix --option pure-eval false --show-trace ...`
  evaluation warning: crane will use a placeholder value since `name` cannot be found in /nix/store/xb3asc012680rpkkkcfg8p02xr0c8fwp-Cargo.toml
                      to silence this warning consider one of the following:
                      - setting `pname = "...";` in the derivation arguments explicitly
                      - setting `package.name = "..."` or `package.metadata.crane.name` = "..." or `workspace.metadata.crane.name` = "..." in the root Cargo.toml
                      - explicitly looking up the values from a different Cargo.toml via
                        `craneLib.crateNameFromCargoToml { cargoToml = ./path/to/Cargo.toml; }`
  
                      To find the source of this warning, rerun nix with:
                      `NIX_ABORT_ON_WARN=1 nix --option pure-eval false --show-trace ...`
  error:
         … while calling the 'derivationStrict' builtin
           at <nix/derivation-internal.nix>:37:12:
             36|
             37|   strict = derivationStrict drvAttrs;
               |            ^
             38|
  
         … while evaluating derivation 'devour-output.json'
           whose name attribute is located at /nix/store/qjqzr7905xxv3rv70z7mkpp06lalnzzb-source/pkgs/stdenv/generic/make-derivation.nix:300:7
  
         … while evaluating attribute 'text' of derivation 'devour-output.json'
           at /nix/store/qjqzr7905xxv3rv70z7mkpp06lalnzzb-source/pkgs/build-support/trivial-builders/default.nix:148:17:
            147|     runCommand name
            148|       { inherit text executable checkPhase allowSubstitutes preferLocalBuild;
               |                 ^
            149|         passAsFile = [ "text" ];
  
         (stack trace truncated; use '--show-trace' to show the full, detailed trace)
  
         error: Package ‘google-chrome-144.0.7559.96’ in /nix/store/3cykcmnpiqdskv7sxkzcrn1x2lir4z5v-source/pkgs/by-name/go/google-chrome/package.nix:335 is not available on the requested hostPlatform:
           hostPlatform.system = "aarch64-linux"
           package.meta.platforms = [
             "x86_64-darwin"
             "aarch64-darwin"
             "x86_64-linux"
           ]
           package.meta.badPlatforms = [ ]
         , refusing to evaluate.
  
         a) To temporarily allow packages that are unsupported for this system, you can use an environment variable
            for a single invocation of the nix tools.
  
              $ export NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1
  
            Note: When using `nix shell`, `nix build`, `nix develop`, etc with a flake,
                  then pass `--impure` in order to allow use of environment variables.
  
         b) For `nixos-rebuild` you can set
           { nixpkgs.config.allowUnsupportedSystem = true; }
         in configuration.nix to override this.
  
         c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
           { allowUnsupportedSystem = true; }
         to ~/.config/nixpkgs/config.nix.
Error: `nix build` failed; exit code: Some(1)

```