### PR TITLE
Fix dylib install_name

### DIFF
--- a/bindings/mobile/Makefile
+++ b/bindings/mobile/Makefile
@@ -50,18 +50,21 @@ $(ARCHS_IOS): %:
 	mkdir -p build/$@
 	mv $(TARGET_DIR)/$@/release/$(LIB) build/$@/$(LIB)
 	mv $(TARGET_DIR)/$@/release/$(DYLIB) build/$@/$(DYLIB)
+	install_name_tool -id @rpath/$(DYLIB) build/$@/$(DYLIB)
 
 $(ARCHS_MAC): %:
 	cargo build --target $@ --target-dir $(TARGET_DIR) --release --no-default-features
 	mkdir -p build/$@
 	mv $(TARGET_DIR)/$@/release/$(LIB) build/$@/$(LIB)
 	mv $(TARGET_DIR)/$@/release/$(DYLIB) build/$@/$(DYLIB)
+	install_name_tool -id @rpath/$(DYLIB) build/$@/$(DYLIB)
 
 aarch64-apple-ios:
 	IPHONEOS_DEPLOYMENT_TARGET=14 cargo build --target $@ --target-dir $(TARGET_DIR) --release
 	mkdir -p build/$@
 	mv $(TARGET_DIR)/$@/release/$(LIB) build/$@/$(LIB)
 	mv $(TARGET_DIR)/$@/release/$(DYLIB) build/$@/$(DYLIB)
+	install_name_tool -id @rpath/$(DYLIB) build/$@/$(DYLIB)
 
 $(LIB): $(ARCHS_IOS) $(ARCHS_MAC) aarch64-apple-ios
 $(DYLIB): $(ARCHS_IOS) $(ARCHS_MAC) aarch64-apple-ios
@@ -114,6 +117,7 @@ frameworkdyn: lipodyn
 	mkdir -p build/swift
 	chmod -R u+w build/swift/LibXMTPSwiftFFIDynamic.xcframework 2>/dev/null || true
 	rm -rf build/swift/LibXMTPSwiftFFIDynamic.xcframework
+	install_name_tool -id @rpath/$(DYLIB) $(NIX_OUT)/aarch64-apple-ios/$(DYLIB) 2>/dev/null || true
 	xcodebuild -create-xcframework \
 		-library $(NIX_OUT)/aarch64-apple-ios/$(DYLIB) \
 		-headers $(SWIFT_OUT)/include/libxmtp/ \


### PR DESCRIPTION
Fixes libxmtpv3.dylib shipping with a hardcoded CI install_name.

---

Apps linking LibXMTPSwiftFFIDynamic crash on launch with:

```
dyld: Library not loaded: /Users/runner/work/libxmtp/libxmtp/target/aarch64-apple-ios/release/deps/libxmtpv3.dylib
```

And App Store Connect rejects uploads with:

```
Invalid Swift Support. The files libswiftCompatibilitySpan.dylib aren't at the expected location /Payload/App.app/Frameworks.
```