### PR TITLE
Upgrade xmtpd Docker images

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -27,7 +27,7 @@ retries = 3
 slow-timeout = "90sec"
 default-filter = "not (test(/\\w*commit_log*/))"
 # inherits = "ci" not supported until latest nextest release
-failure-output = "never"
+failure-output = "immediate-final"
 fail-fast = false
 
 [[profile.ci-d14n.overrides]]

--- a/dev/docker/docker-compose-d14n.yml
+++ b/dev/docker/docker-compose-d14n.yml
@@ -1,7 +1,7 @@
-x-xmtpd-server-image: &x-xmtpd-server-image ghcr.io/xmtp/xmtpd:sha-695b07e
-x-xmtpd-gateway-image: &x-xmtpd-gateway-image ghcr.io/xmtp/xmtpd-gateway:sha-695b07e
-x-xmtpd-cli-image: &x-xmtpd-cli-image ghcr.io/xmtp/xmtpd-cli:sha-695b07e
-x-xmtpd-contracts-image: &x-xmtpd-contracts-image ghcr.io/xmtp/contracts:v2025.12.12-1
+x-xmtpd-server-image: &x-xmtpd-server-image ghcr.io/xmtp/xmtpd:sha-7609754
+x-xmtpd-gateway-image: &x-xmtpd-gateway-image ghcr.io/xmtp/xmtpd-gateway:sha-7609754
+x-xmtpd-cli-image: &x-xmtpd-cli-image ghcr.io/xmtp/xmtpd-cli:sha-7609754
+x-xmtpd-contracts-image: &x-xmtpd-contracts-image ghcr.io/xmtp/contracts:v2026.02.10-1
 x-postgres-image: &x-postgres-image postgres:16
 x-redis-image: &x-redis-image redis:7-alpine
 
@@ -94,6 +94,7 @@ services:
       - local.env
     environment:
       - "XMTPD_CONTRACTS_ENVIRONMENT=anvil"
+      - "XMTPD_API_ORIGINATOR_CACHE_TTL=5s"
     depends_on:
       enable-node-native:
         condition: service_completed_successfully


### PR DESCRIPTION
## tl;dr

- Upgrades to the latest and greatest docker images for xmtpd

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update xmtpd server, gateway, and CLI image tags to `02-18-add_subscribetopicenvelopes_api` and bump contracts image to `2026.02.10-1` in [docker-compose-d14n.yml](https://github.com/xmtp/libxmtp/pull/3229/files#diff-f3b95b320e721deae58c0f228c225c5dc895a08336200f71f989ac0764d95776)
> Switch image anchors in [docker-compose-d14n.yml](https://github.com/xmtp/libxmtp/pull/3229/files#diff-f3b95b320e721deae58c0f228c225c5dc895a08336200f71f989ac0764d95776) to new tags for xmtpd server, gateway, and CLI, and advance the contracts image tag to `2026.02.10-1`.
>
> #### 📍Where to Start
> Start with the image anchor definitions in [docker-compose-d14n.yml](https://github.com/xmtp/libxmtp/pull/3229/files#diff-f3b95b320e721deae58c0f228c225c5dc895a08336200f71f989ac0764d95776).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2736eff. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->