### PR TITLE
chore: update readme for env file docker port

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,3 @@
 **/node_modules
 **/.build/**
 **/build/**
-rust-toolchain.toml

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@
 
 ## Requirements
 
-- Install [Rustup](https://rustup.rs/)
-- Install [Docker](https://www.docker.com/get-started/)
-- Install
-  [Foundry](https://book.getfoundry.sh/getting-started/installation#using-foundryup)
+- [Rustup](https://rustup.rs/)
+- [Docker](https://www.docker.com/get-started/)
+- [Foundry](https://book.getfoundry.sh/getting-started/installation#using-foundryup)
+- [just](https://github.com/casey/just) (optional for testing)
 
 ## Development
 
@@ -48,7 +48,7 @@ Start Docker Desktop.
 - To install other dependencies and start background services:
 
   ```bash
-  dev/up
+  ./dev/up
   ```
 
   Specifically, this command creates and runs an XMTP node in Docker Desktop.
@@ -84,16 +84,22 @@ Start Docker Desktop.
   just wasm test
   ```
 
+ Note: If the tests fail with "bind() failed: Cannot assign requested address," Chrome is unable to bind to IPv6 and will fall back to IPv4. Although this should be a warning, Chromedriver currently logs this message as SEVERE, which halts the wasm-bindgen-test. You can optionally disable the Chromedriver logs output to prevent this.
+
+  ```bash
+  CHROMEDRIVER_ARGS="--log-level=OFF" just wasm test
+  ```
+
 - To run WebAssembly tests interactively for a package, for example, `xmtp_mls`:
 
   ```bash
-  dev/test/wasm-interactive xmtp_mls
+  ./dev/test/wasm-interactive xmtp_mls
   ```
 
 - To run browser SDK tests:
 
   ```bash
-  dev/test/browser-sdk
+  ./dev/test/browser-sdk
   ```
 
 ## Tips & Tricks
@@ -177,8 +183,8 @@ nix develop     # Enter the default dev shell
 To temporarily disable/enable direnv without uninstalling anything:
 
 ```bash
-dev/direnv-down  # Disable direnv auto-activation
-dev/direnv-up    # Re-enable direnv
+./dev/direnv-down  # Disable direnv auto-activation
+./dev/direnv-up    # Re-enable direnv
 ```
 
 See [docs/nix-setup.md](docs/nix-setup.md) for the full setup guide, including

--- a/dev/docker/docker-compose-d14n.yml
+++ b/dev/docker/docker-compose-d14n.yml
@@ -33,7 +33,7 @@ services:
     networks:
       - proxynet
     ports:
-      - 5432:5432
+      - "${REPLICATION_DB_PORT:-127.0.0.1:5432}:5432"
 
   chain:
     platform: linux/amd64

--- a/dev/docker/local.env
+++ b/dev/docker/local.env
@@ -33,3 +33,6 @@ XMTPD_REFLECTION_ENABLE=true
 
 # Log level
 XMTPD_LOG_LEVEL="debug"
+
+# Replication DB Port (optional - use if default port 5432 conflicts)
+# REPLICATION_DB_PORT=127.0.0.1:15432


### PR DESCRIPTION
This commit introduces a new environment variable suggestion for binding the PostgreSQL Docker port into a different one, if the user already has a running instance.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bind replicationdb Docker port to localhost by default and update README
> - Changes the `replicationdb` port mapping in [docker-compose-d14n.yml](https://github.com/xmtp/libxmtp/pull/3232/files#diff-f3b95b320e721deae58c0f228c225c5dc895a08336200f71f989ac0764d95776) from `5432:5432` to `${REPLICATION_DB_PORT:-127.0.0.1:5432}:5432`, restricting the default bind to localhost instead of all interfaces.
> - Documents the optional `REPLICATION_DB_PORT` override in [local.env](https://github.com/xmtp/libxmtp/pull/3232/files#diff-e38cb3bb4b11354071f335632640f38034c9360d74a49702c65aca2fdfab3f31).
> - Updates [README.md](https://github.com/xmtp/libxmtp/pull/3232/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) with corrected dev script paths, optional `just` dependency, and Chromedriver log-level guidance for wasm-bindgen tests.
> - Removes `rust-toolchain.toml` from [.dockerignore](https://github.com/xmtp/libxmtp/pull/3232/files#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5) so it is included in the Docker build context.
> - Behavioral Change: the replicationdb port is no longer exposed on all network interfaces by default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4106e07.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->