### PR TITLE
add lukso / network 42 support

### DIFF
--- a/crates/xmtp_id/src/scw_verifier/chain_urls_default.json
+++ b/crates/xmtp_id/src/scw_verifier/chain_urls_default.json
@@ -1,14 +1,14 @@
 {
   "eip155:1": "https://eth.llamarpc.com",
   "eip155:10": "https://rpc.ankr.com/optimism",
+  "eip155:42": "https://42.rpc.thirdweb.com",
+  "eip155:100": "https://public-gno-mainnet.fastnode.io",
   "eip155:137": "https://polygon.llamarpc.com",
+  "eip155:232": "https://rpc.lens.xyz",
   "eip155:324": "https://mainnet.era.zksync.io",
+  "eip155:480": "https://worldchain-mainnet.g.alchemy.com/public",
+  "eip155:2741": "https://api.mainnet.abs.xyz",
   "eip155:8453": "https://base.llamarpc.com",
   "eip155:42161": "https://arbitrum.llamarpc.com",
-  "eip155:59144": "https://linea-rpc.publicnode.com",
-  "eip155:480": "https://worldchain-mainnet.g.alchemy.com/public",
-  "eip155:232": "https://rpc.lens.xyz",
-  "eip155:2741": "https://api.mainnet.abs.xyz",
-  "eip155:100": "https://public-gno-mainnet.fastnode.io",
-  "eip155:42": "https://42.rpc.thirdweb.com"
+  "eip155:59144": "https://linea-rpc.publicnode.com"
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add default RPC mapping for `eip155:42` in `crates/xmtp_id/src/scw_verifier/chain_urls_default.json` to support Lukso / network 42
Add `eip155:42` → https://42.rpc.thirdweb.com and reorder existing chain URL entries in [chain_urls_default.json](https://github.com/xmtp/libxmtp/pull/3240/files#diff-f492e34448589ad4e2913307eeaffba5309570d7a025ee1cfa3d17b4f8c474bb).

#### 📍Where to Start
Start with the updated mappings in [chain_urls_default.json](https://github.com/xmtp/libxmtp/pull/3240/files#diff-f492e34448589ad4e2913307eeaffba5309570d7a025ee1cfa3d17b4f8c474bb).

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized c592c74.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->