### PR TITLE
cutover queries

### DIFF
--- a/crates/xmtp_db/migrations/2026-02-04-203357-0000_d14n_migration_cutover/down.sql
+++ b/crates/xmtp_db/migrations/2026-02-04-203357-0000_d14n_migration_cutover/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE d14n_migration_cutover;

--- a/crates/xmtp_db/migrations/2026-02-04-203357-0000_d14n_migration_cutover/up.sql
+++ b/crates/xmtp_db/migrations/2026-02-04-203357-0000_d14n_migration_cutover/up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE d14n_migration_cutover (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    cutover_ns BIGINT NOT NULL DEFAULT 9223372036854775807,
+    last_checked_ns BIGINT NOT NULL DEFAULT 0,
+    has_migrated BOOL NOT NULL DEFAULT FALSE
+);
+
+INSERT INTO d14n_migration_cutover (id, cutover_ns, last_checked_ns, has_migrated)
+VALUES (1, 9223372036854775807, 0, FALSE);

--- a/crates/xmtp_db/src/encrypted_store/d14n_migration_cutover.rs
+++ b/crates/xmtp_db/src/encrypted_store/d14n_migration_cutover.rs
@@ -1,0 +1,168 @@
+use super::{
+    ConnectionExt,
+    db_connection::DbConnection,
+    schema::d14n_migration_cutover::{self, dsl},
+};
+use crate::StorageError;
+use diesel::prelude::*;
+
+#[derive(Identifiable, Insertable, Queryable, AsChangeset, Debug, Clone)]
+#[diesel(table_name = d14n_migration_cutover)]
+#[diesel(primary_key(id))]
+pub struct StoredMigrationCutover {
+    pub id: i32,
+    pub cutover_ns: i64,
+    pub last_checked_ns: i64,
+    pub has_migrated: bool,
+}
+
+impl Default for StoredMigrationCutover {
+    fn default() -> Self {
+        Self {
+            id: 1,
+            cutover_ns: i64::MAX,
+            last_checked_ns: 0,
+            has_migrated: false,
+        }
+    }
+}
+
+pub trait QueryMigrationCutover {
+    fn get_migration_cutover(&self) -> Result<StoredMigrationCutover, StorageError>;
+
+    fn set_cutover_ns(&self, cutover_ns: i64) -> Result<(), StorageError>;
+
+    fn get_last_checked_ns(&self) -> Result<i64, StorageError>;
+
+    fn set_last_checked_ns(&self, last_checked_ns: i64) -> Result<(), StorageError>;
+
+    fn set_has_migrated(&self, has_migrated: bool) -> Result<(), StorageError>;
+}
+
+impl<T: QueryMigrationCutover> QueryMigrationCutover for &T {
+    fn get_migration_cutover(&self) -> Result<StoredMigrationCutover, StorageError> {
+        (**self).get_migration_cutover()
+    }
+
+    fn set_cutover_ns(&self, cutover_ns: i64) -> Result<(), StorageError> {
+        (**self).set_cutover_ns(cutover_ns)
+    }
+
+    fn get_last_checked_ns(&self) -> Result<i64, StorageError> {
+        (**self).get_last_checked_ns()
+    }
+
+    fn set_last_checked_ns(&self, last_checked_ns: i64) -> Result<(), StorageError> {
+        (**self).set_last_checked_ns(last_checked_ns)
+    }
+
+    fn set_has_migrated(&self, has_migrated: bool) -> Result<(), StorageError> {
+        (**self).set_has_migrated(has_migrated)
+    }
+}
+
+impl<C: ConnectionExt> QueryMigrationCutover for DbConnection<C> {
+    fn get_migration_cutover(&self) -> Result<StoredMigrationCutover, StorageError> {
+        let result =
+            self.raw_query_read(|conn| dsl::d14n_migration_cutover.first(conn).optional())?;
+        Ok(result.unwrap_or_default())
+    }
+
+    fn set_cutover_ns(&self, cutover_ns: i64) -> Result<(), StorageError> {
+        self.raw_query_write(|conn| {
+            diesel::update(dsl::d14n_migration_cutover.find(1))
+                .set(d14n_migration_cutover::cutover_ns.eq(cutover_ns))
+                .execute(conn)
+        })?;
+        Ok(())
+    }
+
+    fn get_last_checked_ns(&self) -> Result<i64, StorageError> {
+        let cutover = self.get_migration_cutover()?;
+        Ok(cutover.last_checked_ns)
+    }
+
+    fn set_last_checked_ns(&self, last_checked_ns: i64) -> Result<(), StorageError> {
+        self.raw_query_write(|conn| {
+            diesel::update(dsl::d14n_migration_cutover.find(1))
+                .set(d14n_migration_cutover::last_checked_ns.eq(last_checked_ns))
+                .execute(conn)
+        })?;
+        Ok(())
+    }
+
+    fn set_has_migrated(&self, has_migrated: bool) -> Result<(), StorageError> {
+        self.raw_query_write(|conn| {
+            diesel::update(dsl::d14n_migration_cutover.find(1))
+                .set(d14n_migration_cutover::has_migrated.eq(has_migrated))
+                .execute(conn)
+        })?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use super::*;
+    use crate::test_utils::with_connection;
+
+    #[xmtp_common::test]
+    fn test_default_migration_cutover() {
+        with_connection(|conn| {
+            let cutover = conn.get_migration_cutover().unwrap();
+            assert_eq!(cutover.cutover_ns, i64::MAX);
+            assert_eq!(cutover.last_checked_ns, 0);
+            assert!(!cutover.has_migrated);
+        })
+    }
+
+    #[xmtp_common::test]
+    fn test_set_cutover_ns() {
+        with_connection(|conn| {
+            let timestamp = 1_700_000_000_000_000_000i64;
+            conn.set_cutover_ns(timestamp).unwrap();
+
+            let cutover = conn.get_migration_cutover().unwrap();
+            assert_eq!(cutover.cutover_ns, timestamp);
+            assert_eq!(cutover.last_checked_ns, 0);
+            assert!(!cutover.has_migrated);
+        })
+    }
+
+    #[xmtp_common::test]
+    fn test_set_last_checked_ns() {
+        with_connection(|conn| {
+            let timestamp = 1_700_000_000_000_000_000i64;
+            conn.set_last_checked_ns(timestamp).unwrap();
+
+            let cutover = conn.get_migration_cutover().unwrap();
+            assert_eq!(cutover.cutover_ns, i64::MAX);
+            assert_eq!(cutover.last_checked_ns, timestamp);
+            assert!(!cutover.has_migrated);
+        })
+    }
+
+    #[xmtp_common::test]
+    fn test_get_last_checked_ns() {
+        with_connection(|conn| {
+            let timestamp = 1_700_000_000_000_000_000i64;
+            conn.set_last_checked_ns(timestamp).unwrap();
+
+            let last_checked = conn.get_last_checked_ns().unwrap();
+            assert_eq!(last_checked, timestamp);
+        })
+    }
+
+    #[xmtp_common::test]
+    fn test_set_has_migrated() {
+        with_connection(|conn| {
+            conn.set_has_migrated(true).unwrap();
+
+            let cutover = conn.get_migration_cutover().unwrap();
+            assert!(cutover.has_migrated);
+        })
+    }
+}

--- a/crates/xmtp_db/src/encrypted_store/mod.rs
+++ b/crates/xmtp_db/src/encrypted_store/mod.rs
@@ -13,6 +13,7 @@
 pub mod association_state;
 pub mod consent_record;
 pub mod conversation_list;
+pub mod d14n_migration_cutover;
 pub mod database;
 pub mod db_connection;
 pub mod group;

--- a/crates/xmtp_db/src/encrypted_store/schema_gen.rs
+++ b/crates/xmtp_db/src/encrypted_store/schema_gen.rs
@@ -18,6 +18,15 @@ diesel::table! {
 }
 
 diesel::table! {
+    d14n_migration_cutover (id) {
+        id -> Integer,
+        cutover_ns -> BigInt,
+        last_checked_ns -> BigInt,
+        has_migrated -> Bool,
+    }
+}
+
+diesel::table! {
     group_intents (id) {
         id -> Integer,
         kind -> Integer,
@@ -263,6 +272,7 @@ diesel::joinable!(message_deletions -> group_messages (id));
 diesel::allow_tables_to_appear_in_same_query!(
     association_state,
     consent_records,
+    d14n_migration_cutover,
     group_intents,
     group_messages,
     groups,

--- a/crates/xmtp_db/src/lib.rs
+++ b/crates/xmtp_db/src/lib.rs
@@ -36,6 +36,7 @@ pub mod prelude {
     pub use super::association_state::QueryAssociationStateCache;
     pub use super::consent_record::QueryConsentRecord;
     pub use super::conversation_list::QueryConversationList;
+    pub use super::d14n_migration_cutover::QueryMigrationCutover;
     pub use super::group::QueryDms;
     pub use super::group::QueryGroup;
     pub use super::group::QueryGroupVersion;

--- a/crates/xmtp_db/src/mock.rs
+++ b/crates/xmtp_db/src/mock.rs
@@ -825,6 +825,18 @@ mock! {
 
         fn run_pending_migrations(&self) -> Result<Vec<String>, crate::ConnectionError>;
     }
+    impl crate::d14n_migration_cutover::QueryMigrationCutover for DbQuery {
+        fn get_migration_cutover(&self) -> Result<crate::d14n_migration_cutover::StoredMigrationCutover, StorageError>;
+
+        fn set_cutover_ns(&self, cutover_ns: i64) -> Result<(), StorageError>;
+
+        fn get_last_checked_ns(&self) -> Result<i64, StorageError>;
+
+        fn set_last_checked_ns(&self, last_checked_ns: i64) -> Result<(), StorageError>;
+
+        fn set_has_migrated(&self, has_migrated: bool) -> Result<(), StorageError>;
+    }
+
     impl crate::message_deletion::QueryMessageDeletion for DbQuery {
         fn get_message_deletion(
             &self,

--- a/crates/xmtp_db/src/traits.rs
+++ b/crates/xmtp_db/src/traits.rs
@@ -1,6 +1,7 @@
 use crate::ConnectionExt;
 use crate::StorageError;
 use crate::association_state::QueryAssociationStateCache;
+use crate::d14n_migration_cutover::QueryMigrationCutover;
 use crate::icebox::QueryIcebox;
 use crate::message_deletion::QueryMessageDeletion;
 use crate::pending_remove::QueryPendingRemove;
@@ -90,6 +91,7 @@ pub trait DbQuery:
     + QueryPendingRemove
     + QueryIcebox
     + QueryMessageDeletion
+    + QueryMigrationCutover
     + Pragmas
     + crate::ConnectionExt
 {
@@ -121,6 +123,7 @@ impl<T: ?Sized> DbQuery for T where
         + QueryPendingRemove
         + QueryIcebox
         + QueryMessageDeletion
+        + QueryMigrationCutover
         + Pragmas
         + crate::ConnectionExt
 {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add migration cutover table and implement `QueryMigrationCutover` on `DbConnection` for d14n cutover queries in [d14n_migration_cutover.rs](https://github.com/xmtp/libxmtp/pull/3243/files#diff-905bba8f173695be37a0574d31e0bb7b28bc3adb5b8bbd8d14cbf50021d226dd)
Introduce a singleton `d14n_migration_cutover` table with defaults and add `QueryMigrationCutover` methods on `DbConnection` to read and update `cutover_ns` (default `i64::MAX`), `last_checked_ns` (default `0`), and `has_migrated` in [up.sql](https://github.com/xmtp/libxmtp/pull/3243/files#diff-b524efa47e0c2b24e34b10478747caf7cb911d1cc4d10ad5f73606d1882e2f55), [down.sql](https://github.com/xmtp/libxmtp/pull/3243/files#diff-41705a83d7776fb59b8329a09cadececa3b5c668be28e20c2c3e5a84246ca607), and [d14n_migration_cutover.rs](https://github.com/xmtp/libxmtp/pull/3243/files#diff-905bba8f173695be37a0574d31e0bb7b28bc3adb5b8bbd8d14cbf50021d226dd).

#### 📍Where to Start
Start with the `QueryMigrationCutover` trait and its `DbConnection<C>` impl in [d14n_migration_cutover.rs](https://github.com/xmtp/libxmtp/pull/3243/files#diff-905bba8f173695be37a0574d31e0bb7b28bc3adb5b8bbd8d14cbf50021d226dd).

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4046cae.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->