### PR TITLE
Don't require strict determinism for yarn

### DIFF
--- a/.github/workflows/fh-cache.yml
+++ b/.github/workflows/fh-cache.yml
@@ -25,6 +25,7 @@ jobs:
           nix_conf: |
             extra-substituters = https://cache.garnix.io https://xmtp.cachix.org
             extra-trusted-public-keys = cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= xmtp.cachix.org-1:nFPFrqLQ9kjYQKiWL7gKq6llcNEeaV4iI+Ka1F+Tmq0=
+            sandbox = relaxed
       - run: nix build --version
       - name: Install omnix
         run: nix profile install nixpkgs#omnix
@@ -48,6 +49,7 @@ jobs:
           nix_conf: |
             extra-substituters = https://cache.garnix.io https://xmtp.cachix.org
             extra-trusted-public-keys = cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= xmtp.cachix.org-1:nFPFrqLQ9kjYQKiWL7gKq6llcNEeaV4iI+Ka1F+Tmq0=
+            sandbox = relaxed
       - run: nix build --version
       - name: build validation service image
         run: nix build .#validation-service-image-aarch64-multiplatform

--- a/bindings/wasm/wasm.just
+++ b/bindings/wasm/wasm.just
@@ -1,10 +1,11 @@
 export NIX_DEVSHELL := env("NIX_DEVSHELL", "default")
+
 set shell := ["../../dev/nix-shell"]
 
 install:
     yarn
 
-# Install JS dependencies (CI - frozen lockfile)
+# Install JS dependencies
 install-ci:
     yarn install --immutable
 
@@ -24,36 +25,37 @@ format: install
     yarn prettier -w .
 
 # Packages that support the WASM target
+
 wasm_packages := "-p xmtp_mls -p xmtp_cryptography -p xmtp_common -p xmtp_api -p xmtp_id -p xmtp_db -p xmtp_api_d14n"
 
-# Run WASM unit tests (v3 + d14n)
+# Run WASM bindings Rust tests (v3 + d14n)
 test: test-v3 test-d14n
 
-# Run WASM v3 unit tests
+# Run WASM bindings Rust tests (v3)
 test-v3:
     XMTP_TEST_LOGGING=false RUST_LOG=off cargo nextest run --locked --profile ci --target wasm32-unknown-unknown \
-      {{wasm_packages}}
+      {{ wasm_packages }}
 
-# Run WASM d14n unit tests
+# Run WASM bindings Rust tests (d14n)
 test-d14n:
     XMTP_TEST_LOGGING=false RUST_LOG=off cargo nextest run --locked --profile ci-d14n --target wasm32-unknown-unknown \
       --features d14n \
-      {{wasm_packages}}
+      {{ wasm_packages }}
 
-# Run WASM integration tests (vitest in browser — needs .#js shell for Playwright)
+# Run WASM JS integration tests
 [script("bash")]
 test-integration: _build-test install
     set -euo pipefail
-    cd {{source_directory()}}
+    cd {{ source_directory() }}
     nix develop .#js --command bash -euc 'yarn tsc --noEmit && yarn vitest run'
 
-# Build WASM bindings (via Nix)
+# Build WASM bindings
 [script("bash")]
 build:
     nix build .#wasm-bindings
 
 [private]
 _build-test:
-  nix build .#wasm-bindings-test
-  mkdir -p {{ justfile_directory() }}/bindings/wasm/dist
-  cp -r result/dist/* {{ justfile_directory() }}/bindings/wasm/dist
+    nix build .#wasm-bindings-test
+    mkdir -p {{ justfile_directory() }}/bindings/wasm/dist
+    cp -r result/dist/* {{ justfile_directory() }}/bindings/wasm/dist


### PR DESCRIPTION
### TL;DR

Added relaxed sandbox configuration to Nix workflows and improved WASM build justfile formatting and comments.

### What changed?

- Added `sandbox = relaxed` configuration to both GitHub Actions workflow jobs in `.github/workflows/fh-cache.yml`
- Updated comments in `bindings/wasm/wasm.just` to be more descriptive (e.g., "Run WASM bindings Rust tests" instead of "Run WASM unit tests")
- Improved formatting and spacing in the justfile with consistent variable interpolation syntax and better organization

### How to test?

- Verify GitHub Actions workflows run successfully with the new Nix sandbox configuration
- Run the justfile commands in the WASM bindings directory to ensure they still function correctly
- Test WASM build and test commands: `just build`, `just test`, `just test-integration`

### Why make this change?

The relaxed sandbox setting allows Nix builds to access additional system resources that may be required for the build process, while the justfile improvements enhance code readability and provide clearer documentation for developers working with WASM bindings.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set Nix sandbox to relaxed in GitHub Actions fh-cache workflow to support deterministic yarn dependencies and normalize Mustache spacing in `bindings/wasm/wasm.just` recipes
> Update [fh-cache.yml](https://github.com/xmtp/libxmtp/pull/3244/files#diff-ce3dd25bde306abc234d96f51a92cb524edcabd8e9e5eeed5eb121f73b32b9e2) to configure `nix-quick-install-action` with `sandbox = relaxed` and normalize Mustache interpolation spacing in `bindings/wasm/wasm.just` recipes.
>
> #### 📍Where to Start
> Start with the `nix_conf` changes in [fh-cache.yml](https://github.com/xmtp/libxmtp/pull/3244/files#diff-ce3dd25bde306abc234d96f51a92cb524edcabd8e9e5eeed5eb121f73b32b9e2), then review the Mustache spacing updates in [wasm.just](https://github.com/xmtp/libxmtp/pull/3244/files#diff-ac72e72c787fb6b9cf78a1335f94561491ac5982dcc56b245df5b90bc15b4617).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9c47c45.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->