### PR TITLE
reorg bindings/wasm to remove wasm workarounds

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,27 +1,40 @@
 {
-  "rust-analyzer.cargo.sysroot": "discover",
-  "rust-analyzer.check.command": "check",
-  "rust-analyzer.linkedProjects": ["Cargo.toml"],
-  "rust-analyzer.cargo.allTargets": true,
-  "rust-analyzer.procMacro.enable": true,
-  "rust-analyzer.diagnostics.enable": true,
-  "rust-analyzer.diagnostics.disabled": [
-    "unlinked-file",
-    "unresolved-macro-call",
-    "unresolved-proc-macro",
-    "macro-error"
-  ],
-  "rust-analyzer.cargo.buildScripts.enable": true,
-  "rust-analyzer.files.exclude": ["bindings/wasm/**"],
-  "rust-analyzer.procMacro.attributes.enable": true,
-  "rust-analyzer.procMacro.ignored": {
-    "tracing": ["instrument"],
-    "napi-derive": ["napi"],
-    "async-recursion": ["async_recursion"],
-    "ctor": ["ctor"],
-    "tokio": ["test"],
-    "async-stream": ["stream", "try_stream"]
-  },
+    "rust-analyzer": {
+        "linkedProjects": [
+            "Cargo.toml"
+        ],
+        "cargo": {
+            "sysroot": "discover",
+            "allTargets": true,
+            "buildScripts": {
+                "enable": true
+            },
+        },
+        "procMacro": {
+            "enable": true,
+            "attributes.enable": true,
+            "ignored": {
+                "tracing": ["instrument"],
+                "napi-derive": ["napi"],
+                "async-recursion": ["async_recursion"],
+                "ctor": ["ctor"],
+                "tokio": ["test"],
+                "async-stream": ["stream", "try_stream"]
+            }
+        },
+        "diagnostics": {
+            "enable": true,
+            "disabled": [
+                "unlinked-file",
+                "unresolved-macro-call",
+                "unresolved-proc-macro",
+                "macro-error"
+            ]
+        },
+        "check": {
+            "command": "clippy"
+        },
+    },
   "gitlens.blame.ignoreWhitespace": true,
   "coverage-gutters.coverageFileNames": ["coverage/lcov"],
   "coverage-gutters.coverageReportFileName": "coverage/html/index.html",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1328,6 +1328,7 @@ dependencies = [
  "const-hex",
  "futures",
  "js-sys",
+ "owo-colors",
  "pin-project",
  "prost",
  "serde",
@@ -9850,8 +9851,6 @@ dependencies = [
  "uniffi_bindgen",
  "uniffi_core",
  "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
  "winnow",
  "zerocopy",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ members = [
 default-members = [
   # Applications
   "apps/[!(android)]*",
-  # Bindings (excluding wasm - only for wasm32 target)
-  "bindings/[!(wasm)]*",
+  # Bindings
+  "bindings/*",
   # Core crates
   "crates/*",
 ] # Used when cargo commands in the workspace root, such as `cargo test`, are run without flags.

--- a/bindings/wasm/.vscode/settings.json
+++ b/bindings/wasm/.vscode/settings.json
@@ -4,6 +4,18 @@
   "rust-analyzer.cargo.target": "wasm32-unknown-unknown",
   "rust-analyzer.procMacro.enable": true,
   "rust-analyzer.diagnostics.enable": true,
+  "rust-analyzer.files.exclude": ["crates/xmtp-workspace-hack"],
+  "rust-analyzer.files.watcherExclude": ["crates/xmtp-workspace-hack"],
+  "rust-analyzer.check.workspace": false,
+  "rust-analyzer.check.overrideCommand": [
+    "cargo",
+    "check",
+    "--target",
+    "wasm32-unknown-unknown",
+    "-p",
+    "bindings_wasm",
+    "--message-format=json"
+  ],
   "rust-analyzer.diagnostics.disabled": [
     "unlinked-file",
     "unresolved-macro-call",

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -11,7 +11,12 @@ workspace = true
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+
 [dependencies]
+xmtp_common = { workspace = true, features = ["logging"] }
+
+
+[target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 async-trait.workspace = true
 bindings_wasm_macros.workspace = true
 chrono.workspace = true
@@ -40,7 +45,6 @@ web-sys = { workspace = true, features = [
 ] }
 xmtp_api.workspace = true
 xmtp_api_d14n.workspace = true
-xmtp_common = { workspace = true, features = ["logging"] }
 xmtp_content_types.workspace = true
 xmtp_cryptography.workspace = true
 xmtp_db.workspace = true
@@ -53,7 +57,7 @@ wasm-bindgen-test = { workspace = true, optional = true }
 xmtp_configuration = { workspace = true, optional = true }
 
 
-[dev-dependencies]
+[target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dev-dependencies]
 alloy.workspace = true
 chrono = { workspace = true }
 tokio.workspace = true
@@ -61,6 +65,9 @@ wasm-bindgen-test.workspace = true
 xmtp_common = { workspace = true, features = ["test-utils"] }
 xmtp_configuration.workspace = true
 xmtp_mls = { workspace = true, features = ["test-utils"] }
+
+[build-dependencies]
+owo-colors.workspace = true
 
 [features]
 test-utils = [

--- a/bindings/wasm/build.rs
+++ b/bindings/wasm/build.rs
@@ -1,0 +1,30 @@
+use owo_colors::OwoColorize;
+
+fn main() {
+  let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+  let target_family = std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap_or_default();
+
+  if target_family != "wasm" {
+    println!(
+      "{}",
+      format!(
+        "This crate only supports WebAssembly targets with unknown target family. \
+             Got target family: '{}'. Expected: 'wasm'. An empty build will be created.",
+        target_family
+      )
+      .red()
+    );
+  }
+
+  if target_os != "unknown" {
+    println!(
+      "{}",
+      format!(
+        "This crate only supports WebAssembly targets. \
+             Got target os: '{}'. Expected: 'unknown'. An empty build will be created.",
+        target_os
+      )
+      .red()
+    );
+  }
+}

--- a/bindings/wasm/src/errors.rs
+++ b/bindings/wasm/src/errors.rs
@@ -1,0 +1,66 @@
+pub use bindings_wasm_macros::wasm_bindgen_numbered_enum;
+use serde_wasm_bindgen::Serializer;
+use wasm_bindgen::{JsError, JsValue};
+use xmtp_common::ErrorCode;
+
+/// Wrapper for errors that implement ErrorCode trait.
+/// Prefixes the error message with the error code.
+///
+/// Format: `[ErrorType::Variant] error message`
+///
+/// JavaScript usage:
+/// ```js
+/// try {
+///   await client.doSomething();
+/// } catch (e) {
+///   console.log(e.message); // "[ErrorType::Variant] error message"
+/// }
+/// ```
+#[derive(Debug)]
+pub struct ErrorWrapper<E>(pub E)
+where
+  E: ErrorCode;
+
+impl<T: ErrorCode> std::fmt::Display for ErrorWrapper<T> {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    std::fmt::Display::fmt(&self.0, f)
+  }
+}
+
+impl<T> From<T> for ErrorWrapper<T>
+where
+  T: ErrorCode,
+{
+  fn from(err: T) -> ErrorWrapper<T> {
+    ErrorWrapper(err)
+  }
+}
+
+impl<T: ErrorCode> ErrorWrapper<T> {
+  /// Converts any error implementing `ErrorCode` into a `JsError` with
+  /// the `[ErrorCode] message` format and a `.code` property.
+  pub(crate) fn js(e: T) -> JsError {
+    ErrorWrapper(e).into()
+  }
+}
+
+impl<T: ErrorCode> From<ErrorWrapper<T>> for JsError {
+  fn from(e: ErrorWrapper<T>) -> JsError {
+    let code = e.0.error_code();
+    let js_error = JsError::new(&format!("[{}] {}", code, e.0));
+    let js_value: JsValue = js_error.clone().into();
+    let _ = js_sys::Reflect::set(
+      &js_value,
+      &JsValue::from_str("code"),
+      &JsValue::from_str(code),
+    );
+    js_error
+  }
+}
+
+/// Converts a Rust value into a [`JsValue`].
+pub(crate) fn to_value<T: serde::ser::Serialize + ?Sized>(
+  value: &T,
+) -> Result<JsValue, serde_wasm_bindgen::Error> {
+  value.serialize(&Serializer::new().serialize_large_number_types_as_bigints(true))
+}

--- a/bindings/wasm/src/lib.rs
+++ b/bindings/wasm/src/lib.rs
@@ -1,88 +1,31 @@
-pub use bindings_wasm_macros::wasm_bindgen_numbered_enum;
+//! This crate only compiles for webassembly
 
-pub mod client;
-pub mod consent_state;
-pub mod content_types;
-pub mod conversation;
-pub mod conversations;
-pub mod device_sync;
-pub mod encoded_content;
-pub mod enriched_message;
-pub mod identity;
-pub mod inbox_id;
-pub mod inbox_state;
-pub mod messages;
-pub mod opfs;
-pub mod permissions;
-pub mod signatures;
-pub mod streams;
-mod user_preferences;
+xmtp_common::if_wasm! {
+    pub mod client;
+    pub mod consent_state;
+    pub mod content_types;
+    pub mod conversation;
+    pub mod conversations;
+    pub mod device_sync;
+    pub mod encoded_content;
+    pub mod enriched_message;
+    pub mod identity;
+    pub mod inbox_id;
+    pub mod inbox_state;
+    pub mod messages;
+    pub mod opfs;
+    pub mod permissions;
+    pub mod signatures;
+    pub mod streams;
+    mod user_preferences;
+    pub mod errors;
+    pub use errors::*;
+    #[cfg(any(test, feature = "test-utils"))]
+    pub mod tests;
+}
 
-use serde_wasm_bindgen::Serializer;
-use wasm_bindgen::{JsError, JsValue};
-use xmtp_common::ErrorCode;
-
-/// Wrapper for errors that implement ErrorCode trait.
-/// Prefixes the error message with the error code.
-///
-/// Format: `[ErrorType::Variant] error message`
-///
-/// JavaScript usage:
-/// ```js
-/// try {
-///   await client.doSomething();
-/// } catch (e) {
-///   console.log(e.message); // "[ErrorType::Variant] error message"
-/// }
-/// ```
-#[derive(Debug)]
-pub struct ErrorWrapper<E>(pub E)
-where
-  E: ErrorCode;
-
-impl<T: ErrorCode> std::fmt::Display for ErrorWrapper<T> {
-  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    std::fmt::Display::fmt(&self.0, f)
+pub fn lib() {
+  if !cfg!(target_os = "unknown") && !cfg!(target_family = "wasm") {
+    panic!("only webassembly is supported")
   }
 }
-
-impl<T> From<T> for ErrorWrapper<T>
-where
-  T: ErrorCode,
-{
-  fn from(err: T) -> ErrorWrapper<T> {
-    ErrorWrapper(err)
-  }
-}
-
-impl<T: ErrorCode> ErrorWrapper<T> {
-  /// Converts any error implementing `ErrorCode` into a `JsError` with
-  /// the `[ErrorCode] message` format and a `.code` property.
-  pub(crate) fn js(e: T) -> JsError {
-    ErrorWrapper(e).into()
-  }
-}
-
-impl<T: ErrorCode> From<ErrorWrapper<T>> for JsError {
-  fn from(e: ErrorWrapper<T>) -> JsError {
-    let code = e.0.error_code();
-    let js_error = JsError::new(&format!("[{}] {}", code, e.0));
-    let js_value: JsValue = js_error.clone().into();
-    let _ = js_sys::Reflect::set(
-      &js_value,
-      &JsValue::from_str("code"),
-      &JsValue::from_str(code),
-    );
-    js_error
-  }
-}
-
-/// Converts a Rust value into a [`JsValue`].
-pub(crate) fn to_value<T: serde::ser::Serialize + ?Sized>(
-  value: &T,
-) -> Result<JsValue, serde_wasm_bindgen::Error> {
-  value.serialize(&Serializer::new().serialize_large_number_types_as_bigints(true))
-}
-
-#[cfg(any(test, feature = "test-utils"))]
-pub mod tests;

--- a/crates/xmtp-workspace-hack/Cargo.toml
+++ b/crates/xmtp-workspace-hack/Cargo.toml
@@ -101,7 +101,6 @@ uniffi = { version = "0.29", features = ["bindgen-tests", "build", "tokio"] }
 uniffi_bindgen = { version = "0.29", features = ["bindgen-tests"] }
 uniffi_core = { version = "0.29", features = ["tokio"] }
 wasm-bindgen = { version = "0.2" }
-wasm-bindgen-futures = { version = "0.4" }
 winnow = { version = "0.7", features = ["simd"] }
 zerocopy = { version = "0.8", default-features = false, features = ["derive", "simd"] }
 
@@ -196,7 +195,6 @@ uniffi = { version = "0.29", features = ["bindgen-tests", "build", "tokio"] }
 uniffi_bindgen = { version = "0.29", features = ["bindgen-tests"] }
 uniffi_core = { version = "0.29", features = ["tokio"] }
 wasm-bindgen = { version = "0.2" }
-wasm-bindgen-futures = { version = "0.4" }
 winnow = { version = "0.7", features = ["simd"] }
 zerocopy = { version = "0.8", default-features = false, features = ["derive", "simd"] }
 
@@ -211,7 +209,6 @@ tokio-rustls = { version = "0.26", default-features = false, features = ["loggin
 tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
 tonic = { version = "0.14", features = ["tls-native-roots", "tls-ring", "tls-webpki-roots"] }
 tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "retry", "timeout"] }
-web-sys = { version = "0.3", features = ["AbortSignal", "DomException", "MessageEvent", "QueuingStrategy", "ReadableByteStreamController", "ReadableStream", "ReadableStreamByobReader", "ReadableStreamByobRequest", "ReadableStreamDefaultController", "ReadableStreamDefaultReader", "ReadableStreamGetReaderOptions", "ReadableStreamReadResult", "ReadableStreamReaderMode", "ReadableStreamType", "ReadableWritablePair", "StreamPipeOptions", "TransformStream", "TransformStreamDefaultController", "Transformer", "UnderlyingSink", "UnderlyingSource", "Window", "Worker", "WritableStream", "WritableStreamDefaultController", "WritableStreamDefaultWriter", "console"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
 bitflags = { version = "2", default-features = false, features = ["std"] }
@@ -225,7 +222,6 @@ tokio-rustls = { version = "0.26", default-features = false, features = ["loggin
 tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
 tonic = { version = "0.14", features = ["tls-native-roots", "tls-ring", "tls-webpki-roots"] }
 tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "retry", "timeout"] }
-web-sys = { version = "0.3", features = ["AbortSignal", "DomException", "MessageEvent", "QueuingStrategy", "ReadableByteStreamController", "ReadableStream", "ReadableStreamByobReader", "ReadableStreamByobRequest", "ReadableStreamDefaultController", "ReadableStreamDefaultReader", "ReadableStreamGetReaderOptions", "ReadableStreamReadResult", "ReadableStreamReaderMode", "ReadableStreamType", "ReadableWritablePair", "StreamPipeOptions", "TransformStream", "TransformStreamDefaultController", "Transformer", "UnderlyingSink", "UnderlyingSource", "Window", "Worker", "WritableStream", "WritableStreamDefaultController", "WritableStreamDefaultWriter", "console"] }
 
 [target.aarch64-apple-darwin.dependencies]
 bitflags = { version = "2", default-features = false, features = ["std"] }
@@ -239,7 +235,6 @@ tokio-rustls = { version = "0.26", default-features = false, features = ["loggin
 tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
 tonic = { version = "0.14", features = ["tls-native-roots", "tls-ring", "tls-webpki-roots"] }
 tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "retry", "timeout"] }
-web-sys = { version = "0.3", features = ["AbortSignal", "DomException", "MessageEvent", "QueuingStrategy", "ReadableByteStreamController", "ReadableStream", "ReadableStreamByobReader", "ReadableStreamByobRequest", "ReadableStreamDefaultController", "ReadableStreamDefaultReader", "ReadableStreamGetReaderOptions", "ReadableStreamReadResult", "ReadableStreamReaderMode", "ReadableStreamType", "ReadableWritablePair", "StreamPipeOptions", "TransformStream", "TransformStreamDefaultController", "Transformer", "UnderlyingSink", "UnderlyingSource", "Window", "Worker", "WritableStream", "WritableStreamDefaultController", "WritableStreamDefaultWriter", "console"] }
 
 [target.aarch64-apple-darwin.build-dependencies]
 bitflags = { version = "2", default-features = false, features = ["std"] }
@@ -254,7 +249,6 @@ tokio-rustls = { version = "0.26", default-features = false, features = ["loggin
 tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
 tonic = { version = "0.14", features = ["tls-native-roots", "tls-ring", "tls-webpki-roots"] }
 tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "retry", "timeout"] }
-web-sys = { version = "0.3", features = ["AbortSignal", "DomException", "MessageEvent", "QueuingStrategy", "ReadableByteStreamController", "ReadableStream", "ReadableStreamByobReader", "ReadableStreamByobRequest", "ReadableStreamDefaultController", "ReadableStreamDefaultReader", "ReadableStreamGetReaderOptions", "ReadableStreamReadResult", "ReadableStreamReaderMode", "ReadableStreamType", "ReadableWritablePair", "StreamPipeOptions", "TransformStream", "TransformStreamDefaultController", "Transformer", "UnderlyingSink", "UnderlyingSource", "Window", "Worker", "WritableStream", "WritableStreamDefaultController", "WritableStreamDefaultWriter", "console"] }
 
 [target.aarch64-linux-android.dependencies]
 bitflags = { version = "2", default-features = false, features = ["std"] }
@@ -268,7 +262,6 @@ tokio-rustls = { version = "0.26", default-features = false, features = ["loggin
 tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
 tonic = { version = "0.14", features = ["tls-ring", "tls-webpki-roots"] }
 tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "retry", "timeout"] }
-web-sys = { version = "0.3", features = ["AbortSignal", "DomException", "MessageEvent", "QueuingStrategy", "ReadableByteStreamController", "ReadableStream", "ReadableStreamByobReader", "ReadableStreamByobRequest", "ReadableStreamDefaultController", "ReadableStreamDefaultReader", "ReadableStreamGetReaderOptions", "ReadableStreamReadResult", "ReadableStreamReaderMode", "ReadableStreamType", "ReadableWritablePair", "StreamPipeOptions", "TransformStream", "TransformStreamDefaultController", "Transformer", "UnderlyingSink", "UnderlyingSource", "Window", "Worker", "WritableStream", "WritableStreamDefaultController", "WritableStreamDefaultWriter", "console"] }
 
 [target.aarch64-linux-android.build-dependencies]
 bitflags = { version = "2", default-features = false, features = ["std"] }
@@ -283,7 +276,6 @@ tokio-rustls = { version = "0.26", default-features = false, features = ["loggin
 tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
 tonic = { version = "0.14", features = ["tls-ring", "tls-webpki-roots"] }
 tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "retry", "timeout"] }
-web-sys = { version = "0.3", features = ["AbortSignal", "DomException", "MessageEvent", "QueuingStrategy", "ReadableByteStreamController", "ReadableStream", "ReadableStreamByobReader", "ReadableStreamByobRequest", "ReadableStreamDefaultController", "ReadableStreamDefaultReader", "ReadableStreamGetReaderOptions", "ReadableStreamReadResult", "ReadableStreamReaderMode", "ReadableStreamType", "ReadableWritablePair", "StreamPipeOptions", "TransformStream", "TransformStreamDefaultController", "Transformer", "UnderlyingSink", "UnderlyingSource", "Window", "Worker", "WritableStream", "WritableStreamDefaultController", "WritableStreamDefaultWriter", "console"] }
 
 [target.x86_64-linux-android.dependencies]
 bitflags = { version = "2", default-features = false, features = ["std"] }
@@ -297,7 +289,6 @@ tokio-rustls = { version = "0.26", default-features = false, features = ["loggin
 tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
 tonic = { version = "0.14", features = ["tls-ring", "tls-webpki-roots"] }
 tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "retry", "timeout"] }
-web-sys = { version = "0.3", features = ["AbortSignal", "DomException", "MessageEvent", "QueuingStrategy", "ReadableByteStreamController", "ReadableStream", "ReadableStreamByobReader", "ReadableStreamByobRequest", "ReadableStreamDefaultController", "ReadableStreamDefaultReader", "ReadableStreamGetReaderOptions", "ReadableStreamReadResult", "ReadableStreamReaderMode", "ReadableStreamType", "ReadableWritablePair", "StreamPipeOptions", "TransformStream", "TransformStreamDefaultController", "Transformer", "UnderlyingSink", "UnderlyingSource", "Window", "Worker", "WritableStream", "WritableStreamDefaultController", "WritableStreamDefaultWriter", "console"] }
 
 [target.x86_64-linux-android.build-dependencies]
 bitflags = { version = "2", default-features = false, features = ["std"] }
@@ -312,6 +303,5 @@ tokio-rustls = { version = "0.26", default-features = false, features = ["loggin
 tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
 tonic = { version = "0.14", features = ["tls-ring", "tls-webpki-roots"] }
 tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "retry", "timeout"] }
-web-sys = { version = "0.3", features = ["AbortSignal", "DomException", "MessageEvent", "QueuingStrategy", "ReadableByteStreamController", "ReadableStream", "ReadableStreamByobReader", "ReadableStreamByobRequest", "ReadableStreamDefaultController", "ReadableStreamDefaultReader", "ReadableStreamGetReaderOptions", "ReadableStreamReadResult", "ReadableStreamReaderMode", "ReadableStreamType", "ReadableWritablePair", "StreamPipeOptions", "TransformStream", "TransformStreamDefaultController", "Transformer", "UnderlyingSink", "UnderlyingSource", "Window", "Worker", "WritableStream", "WritableStreamDefaultController", "WritableStreamDefaultWriter", "console"] }
 
 ### END HAKARI SECTION

--- a/crates/xmtp_api_d14n/src/queries/client_bundle.rs
+++ b/crates/xmtp_api_d14n/src/queries/client_bundle.rs
@@ -23,6 +23,7 @@ pub enum ClientKind {
     V3,
     Hybrid,
 }
+
 impl std::fmt::Display for ClientKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         use ClientKind::*;


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Include `bindings/wasm` in the default workspace and gate its modules to `wasm32-unknown-unknown` while removing local wasm workarounds
Add a build script to `bindings/wasm`, move error utilities into a new `errors` module, gate client modules behind `xmtp_common::if_wasm!`, add `pub fn lib()` that panics off-wasm, switch workspace checks to `clippy`, and update workspace membership to include `bindings/wasm`.

#### 📍Where to Start
Start with the new build gating and module layout in [lib.rs](https://github.com/xmtp/libxmtp/pull/3249/files#diff-29d485118fbc27f3c76ab732057cf517b0c66f3bc0e4b4ee1c389fea360f30c4), then review the build script in [build.rs](https://github.com/xmtp/libxmtp/pull/3249/files#diff-e949b137ab7989a06cc6f4bdbd366dfc610e6dfe47283fb2f96db620e563aa7f) and the new error utilities in [errors.rs](https://github.com/xmtp/libxmtp/pull/3249/files#diff-ed9dbd007ff198aa587f1020dc5881bdbb578ff72331c087dbdcda970ff98e48).

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a007ec.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->