### PR TITLE
use warpbuild cache to save /nix/store

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -19,8 +19,17 @@ runs:
         github_access_token: ${{ inputs.github-token }}
         extra_nix_config: |
           accept-flake-config = true
-          extra-substituters = https://cache.garnix.io
-          extra-trusted-public-keys = cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g=
+    - name: Nix store cache (WarpBuild)
+      if: startsWith(runner.name, 'warp-')
+      uses: WarpBuilds/cache@v1
+      with:
+        path: |
+          /nix/store
+          /nix/var/nix/db
+          /nix/var/nix/profiles
+        key: nix-store-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('flake.lock') }}
+        restore-keys: |
+          nix-store-${{ runner.os }}-${{ runner.arch }}-
     - uses: cachix/cachix-action@v16
       if: ${{ inputs.cachix-auth-token != '' }}
       with:


### PR DESCRIPTION
save /nix/store to warpbuild cache keyed on `flake.lock`. this should save time downloading from cachix on local disk cache hits

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cache /nix/store on WarpBuild runners using WarpBuilds/cache
> - Adds a conditional step in [action.yml](https://github.com/xmtp/libxmtp/pull/3259/files#diff-d6d03b00722cea2a21415f2e41951abebd36b521b485d7e4fc9fbb4a3c0195dc) that runs only on runners whose name starts with `warp-`, caching `/nix/store`, `/nix/var/nix/db`, and `/nix/var/nix/profiles` via `WarpBuilds/cache@v1`.
> - Cache key is scoped by OS, architecture, and `flake.lock` hash, with a prefix-based restore fallback.
> - Removes the `cache.garnix.io` substituter and trusted public key from the Nix install config.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 491ee00.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->