### PR TITLE
Fix permissions for release notes generator

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -98,6 +98,10 @@ jobs:
 
   release-notes:
     needs: create-branch
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
     uses: ./.github/workflows/release-notes.yml
     with:
       release-branch: release/${{ inputs.version }}

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -20,6 +20,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix permissions for release notes generator CI jobs
Adds `id-token: write` to both the `release-notes` job in [create-release-branch.yml](https://github.com/xmtp/libxmtp/pull/3264/files#diff-5fc90fff784d5ed4d963200e6dd124a507c9d12f0de1f5c06437f73b16f2633c) and the `update-release-notes` job in [release-notes.yml](https://github.com/xmtp/libxmtp/pull/3264/files#diff-42244398366244a59eb9bb95d4d4f8f8657297b9e8e5bf3a815f3e8cca374ce1), enabling OIDC token requests. The `create-release-branch` workflow also gains explicit `contents: write` and `pull-requests: write` permissions that were previously missing.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3560906.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->