### PR TITLE
Upgrade check-swift runner to macOS 15

### DIFF
--- a/.github/workflows/test-bindings-check.yml
+++ b/.github/workflows/test-bindings-check.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
 jobs:
   check-swift:
-    runs-on: warp-macos-13-arm64-6x
+    runs-on: warp-macos-15-arm64-6x
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- Upgrades the `check-swift` CI runner from `warp-macos-13-arm64-6x` to `warp-macos-15-arm64-6x`

## Test plan
- [ ] Verify `check-swift` jobs pass on the new macOS 15 runner for both x86_64 and aarch64 targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Upgrade `check-swift` CI runner from macOS 13 to macOS 15
> Updates the runner label in [test-bindings-check.yml](.github/workflows/test-bindings-check.yml) from `warp-macos-13-arm64-6x` to `warp-macos-15-arm64-6x`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dbf0310.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->