### PR TITLE
feat(ios): expose contentTypes include-filter on message query methods

### DIFF
--- a/sdks/ios/Sources/XMTPiOS/Conversation.swift
+++ b/sdks/ios/Sources/XMTPiOS/Conversation.swift
@@ -294,17 +294,18 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 	/// Reactions, replies, and other associated metadata are returned as separate messages
 	/// and are not linked to their parent messages.
 	///
-	/// For UI rendering, consider using ``enrichedMessages(limit:beforeNs:afterNs:direction:deliveryStatus:excludeContentTypes:excludeSenderInboxIds:sortBy:insertedAfterNs:insertedBeforeNs:)``
+	/// For UI rendering, consider using ``enrichedMessages(limit:beforeNs:afterNs:direction:deliveryStatus:contentTypes:excludeContentTypes:excludeSenderInboxIds:sortBy:insertedAfterNs:insertedBeforeNs:)``
 	/// instead,
 	/// which provides messages with enriched metadata automatically included.
 	///
-	/// - SeeAlso: ``enrichedMessages(limit:beforeNs:afterNs:direction:deliveryStatus:excludeContentTypes:excludeSenderInboxIds:sortBy:insertedAfterNs:insertedBeforeNs:)``
+	/// - SeeAlso: ``enrichedMessages(limit:beforeNs:afterNs:direction:deliveryStatus:contentTypes:excludeContentTypes:excludeSenderInboxIds:sortBy:insertedAfterNs:insertedBeforeNs:)``
 	public func messages(
 		limit: Int? = nil,
 		beforeNs: Int64? = nil,
 		afterNs: Int64? = nil,
 		direction: SortDirection? = .descending,
 		deliveryStatus: MessageDeliveryStatus = .all,
+		contentTypes: [StandardContentType]? = nil,
 		excludeContentTypes: [StandardContentType]? = nil,
 		excludeSenderInboxIds: [String]? = nil,
 		sortBy: MessageSortBy? = nil,
@@ -316,6 +317,7 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 			try await group.messages(
 				beforeNs: beforeNs, afterNs: afterNs, limit: limit,
 				direction: direction, deliveryStatus: deliveryStatus,
+				contentTypes: contentTypes,
 				excludeContentTypes: excludeContentTypes,
 				excludeSenderInboxIds: excludeSenderInboxIds,
 				sortBy: sortBy,
@@ -326,6 +328,7 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 			try await dm.messages(
 				beforeNs: beforeNs, afterNs: afterNs, limit: limit,
 				direction: direction, deliveryStatus: deliveryStatus,
+				contentTypes: contentTypes,
 				excludeContentTypes: excludeContentTypes,
 				excludeSenderInboxIds: excludeSenderInboxIds,
 				sortBy: sortBy,
@@ -360,6 +363,7 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 		afterNs: Int64? = nil,
 		direction: SortDirection? = .descending,
 		deliveryStatus: MessageDeliveryStatus = .all,
+		contentTypes: [StandardContentType]? = nil,
 		excludeContentTypes: [StandardContentType]? = nil,
 		excludeSenderInboxIds: [String]? = nil,
 		sortBy: MessageSortBy? = nil,
@@ -371,6 +375,7 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 			try await group.messagesWithReactions(
 				beforeNs: beforeNs, afterNs: afterNs, limit: limit,
 				direction: direction, deliveryStatus: deliveryStatus,
+				contentTypes: contentTypes,
 				excludeContentTypes: excludeContentTypes,
 				excludeSenderInboxIds: excludeSenderInboxIds,
 				sortBy: sortBy,
@@ -381,6 +386,7 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 			try await dm.messagesWithReactions(
 				beforeNs: beforeNs, afterNs: afterNs, limit: limit,
 				direction: direction, deliveryStatus: deliveryStatus,
+				contentTypes: contentTypes,
 				excludeContentTypes: excludeContentTypes,
 				excludeSenderInboxIds: excludeSenderInboxIds,
 				sortBy: sortBy,
@@ -397,20 +403,21 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 	/// this information.
 	///
 	/// **Recommended for UI rendering.** This method provides better performance and
-	/// simpler code compared to ``messages(limit:beforeNs:afterNs:direction:deliveryStatus:excludeContentTypes:excludeSenderInboxIds:sortBy:insertedAfterNs:insertedBeforeNs:)``
+	/// simpler code compared to ``messages(limit:beforeNs:afterNs:direction:deliveryStatus:contentTypes:excludeContentTypes:excludeSenderInboxIds:sortBy:insertedAfterNs:insertedBeforeNs:)``
 	/// when displaying conversations.
 	///
 	/// When handling content types, use the generic `content<T>()` method with the
 	/// appropriate type for reactions and replies.
 	///
 	/// - Returns: Array of `DecodedMessageV2` with enriched metadata.
-	/// - SeeAlso: ``messages(limit:beforeNs:afterNs:direction:deliveryStatus:excludeContentTypes:excludeSenderInboxIds:sortBy:insertedAfterNs:insertedBeforeNs:)``
+	/// - SeeAlso: ``messages(limit:beforeNs:afterNs:direction:deliveryStatus:contentTypes:excludeContentTypes:excludeSenderInboxIds:sortBy:insertedAfterNs:insertedBeforeNs:)``
 	public func enrichedMessages(
 		limit: Int? = nil,
 		beforeNs: Int64? = nil,
 		afterNs: Int64? = nil,
 		direction: SortDirection? = .descending,
 		deliveryStatus: MessageDeliveryStatus = .all,
+		contentTypes: [StandardContentType]? = nil,
 		excludeContentTypes: [StandardContentType]? = nil,
 		excludeSenderInboxIds: [String]? = nil,
 		sortBy: MessageSortBy? = nil,
@@ -422,6 +429,7 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 			try await group.enrichedMessages(
 				beforeNs: beforeNs, afterNs: afterNs, limit: limit,
 				direction: direction, deliveryStatus: deliveryStatus,
+				contentTypes: contentTypes,
 				excludeContentTypes: excludeContentTypes,
 				excludeSenderInboxIds: excludeSenderInboxIds,
 				sortBy: sortBy,
@@ -432,6 +440,7 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 			try await dm.enrichedMessages(
 				beforeNs: beforeNs, afterNs: afterNs, limit: limit,
 				direction: direction, deliveryStatus: deliveryStatus,
+				contentTypes: contentTypes,
 				excludeContentTypes: excludeContentTypes,
 				excludeSenderInboxIds: excludeSenderInboxIds,
 				sortBy: sortBy,
@@ -445,6 +454,7 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 		beforeNs: Int64? = nil,
 		afterNs: Int64? = nil,
 		deliveryStatus: MessageDeliveryStatus = .all,
+		contentTypes: [StandardContentType]? = nil,
 		excludeContentTypes: [StandardContentType]? = nil,
 		excludeSenderInboxIds: [String]? = nil,
 		insertedAfterNs: Int64? = nil,
@@ -454,6 +464,7 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 		case let .group(group):
 			try group.countMessages(
 				beforeNs: beforeNs, afterNs: afterNs, deliveryStatus: deliveryStatus,
+				contentTypes: contentTypes,
 				excludeContentTypes: excludeContentTypes,
 				excludeSenderInboxIds: excludeSenderInboxIds,
 				insertedAfterNs: insertedAfterNs,
@@ -462,6 +473,7 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 		case let .dm(dm):
 			try dm.countMessages(
 				beforeNs: beforeNs, afterNs: afterNs, deliveryStatus: deliveryStatus,
+				contentTypes: contentTypes,
 				excludeContentTypes: excludeContentTypes,
 				excludeSenderInboxIds: excludeSenderInboxIds,
 				insertedAfterNs: insertedAfterNs,

--- a/sdks/ios/Sources/XMTPiOS/Dm.swift
+++ b/sdks/ios/Sources/XMTPiOS/Dm.swift
@@ -325,17 +325,18 @@ public struct Dm: Identifiable, Equatable, Hashable {
 	/// Reactions, replies, and other associated metadata are returned as separate messages
 	/// and are not linked to their parent messages.
 	///
-	/// For UI rendering, consider using ``enrichedMessages(beforeNs:afterNs:limit:direction:deliveryStatus:excludeContentTypes:excludeSenderInboxIds:sortBy:insertedAfterNs:insertedBeforeNs:)``
+	/// For UI rendering, consider using ``enrichedMessages(beforeNs:afterNs:limit:direction:deliveryStatus:contentTypes:excludeContentTypes:excludeSenderInboxIds:sortBy:insertedAfterNs:insertedBeforeNs:)``
 	/// instead,
 	/// which provides messages with enriched metadata automatically included.
 	///
-	/// - SeeAlso: ``enrichedMessages(beforeNs:afterNs:limit:direction:deliveryStatus:excludeContentTypes:excludeSenderInboxIds:sortBy:insertedAfterNs:insertedBeforeNs:)``
+	/// - SeeAlso: ``enrichedMessages(beforeNs:afterNs:limit:direction:deliveryStatus:contentTypes:excludeContentTypes:excludeSenderInboxIds:sortBy:insertedAfterNs:insertedBeforeNs:)``
 	public func messages(
 		beforeNs: Int64? = nil,
 		afterNs: Int64? = nil,
 		limit: Int? = nil,
 		direction: SortDirection? = .descending,
 		deliveryStatus: MessageDeliveryStatus = .all,
+		contentTypes: [StandardContentType]? = nil,
 		excludeContentTypes: [StandardContentType]? = nil,
 		excludeSenderInboxIds: [String]? = nil,
 		sortBy: MessageSortBy? = nil,
@@ -389,6 +390,7 @@ public struct Dm: Identifiable, Equatable, Hashable {
 		}
 
 		options.direction = direction
+		options.contentTypes = contentTypes
 		options.excludeContentTypes = excludeContentTypes
 		options.excludeSenderInboxIds = excludeSenderInboxIds
 		options.sortBy = sortBy?.toFfi()
@@ -407,6 +409,7 @@ public struct Dm: Identifiable, Equatable, Hashable {
 		limit: Int? = nil,
 		direction: SortDirection? = .descending,
 		deliveryStatus: MessageDeliveryStatus = .all,
+		contentTypes: [StandardContentType]? = nil,
 		excludeContentTypes: [StandardContentType]? = nil,
 		excludeSenderInboxIds: [String]? = nil,
 		sortBy: MessageSortBy? = nil,
@@ -449,6 +452,7 @@ public struct Dm: Identifiable, Equatable, Hashable {
 		}
 
 		options.direction = direction
+		options.contentTypes = contentTypes
 		options.excludeContentTypes = excludeContentTypes
 		options.excludeSenderInboxIds = excludeSenderInboxIds
 		options.sortBy = sortBy?.toFfi()
@@ -466,6 +470,7 @@ public struct Dm: Identifiable, Equatable, Hashable {
 	/// Count the number of messages in the conversation according to the provided filters
 	public func countMessages(
 		beforeNs: Int64? = nil, afterNs: Int64? = nil, deliveryStatus: MessageDeliveryStatus = .all,
+		contentTypes: [StandardContentType]? = nil,
 		excludeContentTypes: [StandardContentType]? = nil,
 		excludeSenderInboxIds: [String]? = nil,
 		insertedAfterNs: Int64? = nil,
@@ -478,7 +483,7 @@ public struct Dm: Identifiable, Equatable, Hashable {
 				limit: nil,
 				deliveryStatus: deliveryStatus.toFfi(),
 				direction: .descending,
-				contentTypes: nil,
+				contentTypes: contentTypes,
 				excludeContentTypes: excludeContentTypes,
 				excludeSenderInboxIds: excludeSenderInboxIds,
 				sortBy: nil,
@@ -495,20 +500,21 @@ public struct Dm: Identifiable, Equatable, Hashable {
 	/// this information.
 	///
 	/// **Recommended for UI rendering.** This method provides better performance and
-	/// simpler code compared to ``messages(beforeNs:afterNs:limit:direction:deliveryStatus:excludeContentTypes:excludeSenderInboxIds:sortBy:insertedAfterNs:insertedBeforeNs:)``
+	/// simpler code compared to ``messages(beforeNs:afterNs:limit:direction:deliveryStatus:contentTypes:excludeContentTypes:excludeSenderInboxIds:sortBy:insertedAfterNs:insertedBeforeNs:)``
 	/// when displaying conversations.
 	///
 	/// When handling content types, use the generic `content<T>()` method with the
 	/// appropriate type for reactions and replies.
 	///
 	/// - Returns: Array of `DecodedMessageV2` with enriched metadata.
-	/// - SeeAlso: ``messages(beforeNs:afterNs:limit:direction:deliveryStatus:excludeContentTypes:excludeSenderInboxIds:sortBy:insertedAfterNs:insertedBeforeNs:)``
+	/// - SeeAlso: ``messages(beforeNs:afterNs:limit:direction:deliveryStatus:contentTypes:excludeContentTypes:excludeSenderInboxIds:sortBy:insertedAfterNs:insertedBeforeNs:)``
 	public func enrichedMessages(
 		beforeNs: Int64? = nil,
 		afterNs: Int64? = nil,
 		limit: Int? = nil,
 		direction: SortDirection? = .descending,
 		deliveryStatus: MessageDeliveryStatus = .all,
+		contentTypes: [StandardContentType]? = nil,
 		excludeContentTypes: [StandardContentType]? = nil,
 		excludeSenderInboxIds: [String]? = nil,
 		sortBy: MessageSortBy? = nil,
@@ -562,6 +568,7 @@ public struct Dm: Identifiable, Equatable, Hashable {
 		}
 
 		options.direction = direction
+		options.contentTypes = contentTypes
 		options.excludeContentTypes = excludeContentTypes
 		options.excludeSenderInboxIds = excludeSenderInboxIds
 		options.sortBy = sortBy?.toFfi()

--- a/sdks/ios/Sources/XMTPiOS/Group.swift
+++ b/sdks/ios/Sources/XMTPiOS/Group.swift
@@ -542,17 +542,18 @@ public struct Group: Identifiable, Equatable, Hashable {
 	/// Reactions, replies, and other associated metadata are returned as separate messages
 	/// and are not linked to their parent messages.
 	///
-	/// For UI rendering, consider using ``enrichedMessages(beforeNs:afterNs:limit:direction:deliveryStatus:excludeContentTypes:excludeSenderInboxIds:sortBy:insertedAfterNs:insertedBeforeNs:)``
+	/// For UI rendering, consider using ``enrichedMessages(beforeNs:afterNs:limit:direction:deliveryStatus:contentTypes:excludeContentTypes:excludeSenderInboxIds:sortBy:insertedAfterNs:insertedBeforeNs:)``
 	/// instead,
 	/// which provides messages with enriched metadata automatically included.
 	///
-	/// - SeeAlso: ``enrichedMessages(beforeNs:afterNs:limit:direction:deliveryStatus:excludeContentTypes:excludeSenderInboxIds:sortBy:insertedAfterNs:insertedBeforeNs:)``
+	/// - SeeAlso: ``enrichedMessages(beforeNs:afterNs:limit:direction:deliveryStatus:contentTypes:excludeContentTypes:excludeSenderInboxIds:sortBy:insertedAfterNs:insertedBeforeNs:)``
 	public func messages(
 		beforeNs: Int64? = nil,
 		afterNs: Int64? = nil,
 		limit: Int? = nil,
 		direction: SortDirection? = .descending,
 		deliveryStatus: MessageDeliveryStatus = .all,
+		contentTypes: [StandardContentType]? = nil,
 		excludeContentTypes: [StandardContentType]? = nil,
 		excludeSenderInboxIds: [String]? = nil,
 		sortBy: MessageSortBy? = nil,
@@ -606,6 +607,7 @@ public struct Group: Identifiable, Equatable, Hashable {
 		}
 
 		options.direction = direction
+		options.contentTypes = contentTypes
 		options.excludeContentTypes = excludeContentTypes
 		options.excludeSenderInboxIds = excludeSenderInboxIds
 		options.sortBy = sortBy?.toFfi()
@@ -624,6 +626,7 @@ public struct Group: Identifiable, Equatable, Hashable {
 		limit: Int? = nil,
 		direction: SortDirection? = .descending,
 		deliveryStatus: MessageDeliveryStatus = .all,
+		contentTypes: [StandardContentType]? = nil,
 		excludeContentTypes: [StandardContentType]? = nil,
 		excludeSenderInboxIds: [String]? = nil,
 		sortBy: MessageSortBy? = nil,
@@ -677,6 +680,7 @@ public struct Group: Identifiable, Equatable, Hashable {
 		}
 
 		options.direction = direction
+		options.contentTypes = contentTypes
 		options.excludeContentTypes = excludeContentTypes
 		options.excludeSenderInboxIds = excludeSenderInboxIds
 		options.sortBy = sortBy?.toFfi()
@@ -699,20 +703,21 @@ public struct Group: Identifiable, Equatable, Hashable {
 	/// this information.
 	///
 	/// **Recommended for UI rendering.** This method provides better performance and
-	/// simpler code compared to ``messages(beforeNs:afterNs:limit:direction:deliveryStatus:excludeContentTypes:excludeSenderInboxIds:sortBy:insertedAfterNs:insertedBeforeNs:)``
+	/// simpler code compared to ``messages(beforeNs:afterNs:limit:direction:deliveryStatus:contentTypes:excludeContentTypes:excludeSenderInboxIds:sortBy:insertedAfterNs:insertedBeforeNs:)``
 	/// when displaying conversations.
 	///
 	/// When handling content types, use the generic `content<T>()` method with the
 	/// appropriate type for reactions and replies.
 	///
 	/// - Returns: Array of `DecodedMessageV2` with enriched metadata.
-	/// - SeeAlso: ``messages(beforeNs:afterNs:limit:direction:deliveryStatus:excludeContentTypes:excludeSenderInboxIds:sortBy:insertedAfterNs:insertedBeforeNs:)``
+	/// - SeeAlso: ``messages(beforeNs:afterNs:limit:direction:deliveryStatus:contentTypes:excludeContentTypes:excludeSenderInboxIds:sortBy:insertedAfterNs:insertedBeforeNs:)``
 	public func enrichedMessages(
 		beforeNs: Int64? = nil,
 		afterNs: Int64? = nil,
 		limit: Int? = nil,
 		direction: SortDirection? = .descending,
 		deliveryStatus: MessageDeliveryStatus = .all,
+		contentTypes: [StandardContentType]? = nil,
 		excludeContentTypes: [StandardContentType]? = nil,
 		excludeSenderInboxIds: [String]? = nil,
 		sortBy: MessageSortBy? = nil,
@@ -766,6 +771,7 @@ public struct Group: Identifiable, Equatable, Hashable {
 		}
 
 		options.direction = direction
+		options.contentTypes = contentTypes
 		options.excludeContentTypes = excludeContentTypes
 		options.excludeSenderInboxIds = excludeSenderInboxIds
 		options.sortBy = sortBy?.toFfi()
@@ -780,6 +786,7 @@ public struct Group: Identifiable, Equatable, Hashable {
 
 	public func countMessages(
 		beforeNs: Int64? = nil, afterNs: Int64? = nil, deliveryStatus: MessageDeliveryStatus = .all,
+		contentTypes: [StandardContentType]? = nil,
 		excludeContentTypes: [StandardContentType]? = nil,
 		excludeSenderInboxIds: [String]? = nil,
 		insertedAfterNs: Int64? = nil,
@@ -792,7 +799,7 @@ public struct Group: Identifiable, Equatable, Hashable {
 				limit: nil,
 				deliveryStatus: deliveryStatus.toFfi(),
 				direction: .descending,
-				contentTypes: nil,
+				contentTypes: contentTypes,
 				excludeContentTypes: excludeContentTypes,
 				excludeSenderInboxIds: excludeSenderInboxIds,
 				sortBy: nil,


### PR DESCRIPTION
## Summary

The `FfiListMessagesOptions.contentTypes` field is fully supported by the Rust FFI layer but was never wired through in the Swift SDK. The `excludeContentTypes` parameter was exposed, but the include-filter was always hardcoded to `nil`.

## Changes

Adds a `contentTypes: [StandardContentType]? = nil` parameter to the following methods on `Group`, `Dm`, and `Conversation`:

- `messages()`
- `messagesWithReactions()`
- `enrichedMessages()`
- `countMessages()`

The parameter is passed through to `FfiListMessagesOptions.contentTypes`.

## Backward Compatibility

Fully backward-compatible — all existing call sites continue to work unchanged since the new parameter defaults to `nil`.

## Example Usage

```swift
// Get only text messages
let texts = try await group.messages(contentTypes: [.text])

// Get only custom/unknown content types  
let custom = try await dm.messages(contentTypes: [.unknown])

// Combine with existing exclude filter
let filtered = try await conversation.messages(
    contentTypes: [.text, .reply],
    excludeContentTypes: [.readReceipt]
)
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose `contentTypes` filter parameter on iOS message query methods
> Adds an optional `contentTypes: [StandardContentType]?` parameter to `messages`, `messagesWithReactions`, `enrichedMessages`, and `countMessages` on `Group`, `Dm`, and `Conversation`. When provided, the parameter is forwarded to `FfiListMessagesOptions` to filter results by content type; passing `nil` preserves existing behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 67422e9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->