### PR TITLE
remove apps/ from workspace-hack

### DIFF
--- a/.config/hakari.toml
+++ b/.config/hakari.toml
@@ -6,6 +6,8 @@ hakari-package = "xmtp-workspace-hack"
 # Format version for hakari's output. Version 4 requires cargo-hakari 0.9.22 or above.
 dep-format-version = "4"
 
+workspace-hack-line-style = "workspace-dotted"
+
 # Setting workspace.resolver = "2" or higher in the root Cargo.toml is HIGHLY recommended.
 # Hakari works much better with the v2 resolver. (The v2 and v3 resolvers are identical from
 # hakari's perspective, so you're welcome to set either.)
@@ -27,6 +29,7 @@ platforms = [
 
 # Including mio/tokio breaks webassembly builds since net features are mutually exclusive with wasm
 [traversal-excludes]
+workspace-members = ["xmtp_cli", "log_parser", "xdbg", "xmtp-db-tools"]
 third-party = [{ name = "mio" }, { name = "tokio" }]
 [final-excludes]
 workspace-members = ["bindings_wasm"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -911,9 +911,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "annotate-snippets"
-version = "0.12.12"
+version = "0.12.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86cd1c51b95d71dde52bca69ed225008f6ff4c8cc825b08042aa1ef823e1980"
+checksum = "74fc7650eedcb2fee505aad48491529e408f0e854c2d9f63eb86c1361b9b3f93"
 dependencies = [
  "anstyle",
  "memchr",
@@ -3405,6 +3405,12 @@ checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
  "libloading 0.8.9",
 ]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "downcast"
@@ -7002,7 +7008,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "xmtp-workspace-hack",
  "xmtp_common",
  "xmtp_mls",
 ]
@@ -7130,9 +7135,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
@@ -8603,7 +8608,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
- "siphasher 1.0.1",
+ "siphasher 1.0.2",
 ]
 
 [[package]]
@@ -10440,9 +10445,9 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "siphasher"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skia-bindings"
@@ -10857,7 +10862,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "695b5790b3131dafa99b3bbfd25a216edb3d216dad9ca208d4657bfb8f2abc3d"
 dependencies = [
  "kurbo 0.13.0",
- "siphasher 1.0.1",
+ "siphasher 1.0.2",
 ]
 
 [[package]]
@@ -11961,13 +11966,13 @@ dependencies = [
 
 [[package]]
 name = "uds_windows"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
+checksum = "51b70b87d15e91f553711b40df3048faf27a7a04e01e0ddc0cf9309f0af7c2ca"
 dependencies = [
  "memoffset",
  "tempfile",
- "winapi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12284,7 +12289,7 @@ dependencies = [
  "roxmltree",
  "rustybuzz",
  "simplecss",
- "siphasher 1.0.1",
+ "siphasher 1.0.2",
  "strict-num",
  "svgtypes",
  "tiny-skia-path",
@@ -13774,7 +13779,6 @@ dependencies = [
  "url",
  "valuable",
  "vergen-gix",
- "xmtp-workspace-hack",
  "xmtp_api_d14n",
  "xmtp_api_grpc",
  "xmtp_configuration",
@@ -13829,29 +13833,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
+name = "xmtp-db-tools"
+version = "1.9.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "const-hex",
+ "diesel",
+ "diesel_migrations",
+ "dotenvy",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "xmtp_common",
+ "xmtp_db",
+ "xmtp_mls",
+]
+
+[[package]]
 name = "xmtp-workspace-hack"
 version = "0.1.0"
 dependencies = [
  "aead",
  "aes-gcm",
- "aho-corasick",
  "alloy",
  "alloy-core",
  "alloy-json-abi",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-client",
- "alloy-signer-local",
  "alloy-sol-macro",
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
  "alloy-sol-type-parser",
  "alloy-sol-types",
  "alloy-transport-http",
- "anstyle",
- "arrayvec",
  "bitflags 2.10.0",
- "bytemuck",
  "byteorder",
  "bytes",
  "camino",
@@ -13863,15 +13880,11 @@ dependencies = [
  "const-hex",
  "crypto-common",
  "derive_more",
- "derive_more-impl",
  "digest 0.10.7",
- "ecdsa",
  "ed25519-dalek",
  "either",
  "elliptic-curve",
  "errno",
- "fontdue",
- "fontique",
  "form_urlencoded",
  "futures-channel",
  "futures-core",
@@ -13881,36 +13894,21 @@ dependencies = [
  "futures-util",
  "generic-array",
  "getrandom 0.4.1",
- "half",
- "hashbrown 0.14.5",
  "hashbrown 0.15.5",
  "hashbrown 0.16.1",
  "hpke-rs 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.14.32",
  "hyper-util",
- "icu_locale_core",
  "idna",
- "image",
  "indexmap 2.12.1",
  "itertools 0.14.0",
  "js-sys",
  "k256",
  "libcrux-ed25519",
- "linux-raw-sys 0.11.0",
- "litemap",
  "log",
- "lyon_geom",
  "memchr",
- "miniz_oxide",
  "nu-ansi-term",
  "num-traits",
- "num_enum",
- "num_enum_derive",
- "objc2 0.6.4",
- "objc2-core-foundation",
- "objc2-core-text",
- "objc2-foundation 0.3.2",
- "once_cell",
  "openmls",
  "openmls_basic_credential",
  "openmls_memory_storage",
@@ -13918,21 +13916,16 @@ dependencies = [
  "openmls_traits",
  "p256",
  "percent-encoding",
- "portable-atomic",
  "proc-macro2",
- "pulldown-cmark",
  "rand 0.9.2",
  "rand_chacha 0.3.1",
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "read-fonts",
  "regex",
  "regex-automata",
  "regex-syntax",
  "reqwest 0.12.24",
- "rgb",
  "ruint",
- "rustix 1.1.3",
  "rustls",
  "sec1",
  "semver 1.0.27",
@@ -13940,12 +13933,10 @@ dependencies = [
  "serde_core",
  "serde_json",
  "sha1",
- "slotmap",
  "smallvec",
  "syn 2.0.111",
  "sync_wrapper 1.0.2",
  "time",
- "tinystr",
  "tokio-rustls",
  "tokio-stream",
  "tokio-util",
@@ -13955,20 +13946,13 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-core",
- "tracing-serde",
  "tracing-subscriber",
- "ttf-parser 0.25.1",
  "uniffi",
  "uniffi_bindgen",
  "uniffi_core",
- "uuid",
  "wasm-bindgen",
  "winnow",
- "writeable",
- "yeslogic-fontconfig-sys",
  "zerocopy",
- "zerovec",
- "zvariant",
 ]
 
 [[package]]
@@ -14122,7 +14106,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "valuable",
- "xmtp-workspace-hack",
  "xmtp_api",
  "xmtp_api_d14n",
  "xmtp_common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,24 +1,22 @@
 [workspace]
 members = [
   # Applications
-  "apps/[!android]*",
+  "apps/*",
   # Bindings
   "bindings/*",
   # Core crates
   "crates/*",
-  # Core crates
-  "crates/xmtp-workspace-hack",
 ]
+exclude = ["apps/android"]
 
 default-members = [
   # Applications
-  "apps/[!(android)]*",
+  "apps/mls_validation_service",
   # Bindings
   "bindings/*",
   # Core crates
   "crates/*",
-] # Used when cargo commands in the workspace root, such as `cargo test`, are run without flags.
-# Excludes `bindings/wasm` by default, since those bindings only build for the WASM target.
+]
 
 # Make the feature resolver explicit.
 # See https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html#details
@@ -138,6 +136,7 @@ zeroize = "1.8"
 # Internal Crate Dependencies
 bindings-wasm = { path = "bindings/wasm" }
 bindings_wasm_macros = { path = "crates/wasm_macros" }
+xmtp-workspace-hack = "0.1.0"
 xmtp_api = { path = "crates/xmtp_api" }
 xmtp_api_d14n = { path = "crates/xmtp_api_d14n" }
 xmtp_api_grpc = { path = "crates/xmtp_api_grpc" }
@@ -187,6 +186,9 @@ lto = true
 [patch.crates-io]
 diesel = { git = "https://github.com/ephemerahq/diesel", branch = "coda/copy-to-sqlite" }
 diesel_migrations = { git = "https://github.com/ephemerahq/diesel", branch = "coda/copy-to-sqlite" }
+
+[patch.crates-io.xmtp-workspace-hack]
+path = "crates/xmtp-workspace-hack"
 
 [workspace.lints.clippy]
 arc_with_non_send_sync = "allow"

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -37,7 +37,6 @@ tracing-subscriber = { workspace = true, features = [
   "chrono",
 ] }
 valuable = { version = "0.1", features = ["derive"] }
-xmtp-workspace-hack = { version = "0.1", path = "../../crates/xmtp-workspace-hack" }
 xmtp_api = { workspace = true }
 xmtp_api_d14n.workspace = true
 xmtp_common.workspace = true

--- a/apps/db_tools/Cargo.toml
+++ b/apps/db_tools/Cargo.toml
@@ -14,7 +14,6 @@ dotenvy = "0.15.7"
 hex.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["fmt"] }
-xmtp-workspace-hack = { version = "0.1", path = "../../crates/xmtp-workspace-hack" }
 xmtp_common.workspace = true
 xmtp_db.workspace = true
 

--- a/apps/log_parser/Cargo.toml
+++ b/apps/log_parser/Cargo.toml
@@ -17,7 +17,6 @@ slint = "1.14.1"
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["fmt", "env-filter"] }
-xmtp-workspace-hack = { version = "0.1", path = "../../crates/xmtp-workspace-hack" }
 xmtp_common.workspace = true
 xmtp_mls = { workspace = true, features = ["test-utils"] }
 

--- a/apps/mls_validation_service/Cargo.toml
+++ b/apps/mls_validation_service/Cargo.toml
@@ -28,7 +28,7 @@ tonic = { workspace = true }
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter", "ansi"] }
 warp = "0.3.6"
-xmtp-workspace-hack = { version = "0.1", path = "../../crates/xmtp-workspace-hack" }
+xmtp-workspace-hack.workspace = true
 xmtp_common.workspace = true
 xmtp_configuration.workspace = true
 xmtp_cryptography.workspace = true

--- a/apps/xmtp_debug/Cargo.toml
+++ b/apps/xmtp_debug/Cargo.toml
@@ -57,7 +57,6 @@ tracing-subscriber = { workspace = true, features = [
 ] }
 url.workspace = true
 valuable = { version = "0.1", features = ["derive"] }
-xmtp-workspace-hack = { version = "0.1", path = "../../crates/xmtp-workspace-hack" }
 xmtp_api_d14n.workspace = true
 xmtp_api_grpc.workspace = true
 xmtp_configuration.workspace = true

--- a/bindings/mobile/Cargo.toml
+++ b/bindings/mobile/Cargo.toml
@@ -43,7 +43,7 @@ xmtp_proto.workspace = true
 alloy = { workspace = true, optional = true }
 criterion = { workspace = true, optional = true }
 fdlimit = { version = "0.3", optional = true }
-xmtp-workspace-hack = { version = "0.1", path = "../../crates/xmtp-workspace-hack" }
+xmtp-workspace-hack.workspace = true
 
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/bindings/node/Cargo.toml
+++ b/bindings/node/Cargo.toml
@@ -33,8 +33,10 @@ tracing-subscriber = { workspace = true, features = [
   "json",
   "chrono",
 ] }
+xmtp-workspace-hack.workspace = true
 xmtp_api.workspace = true
 xmtp_api_d14n.workspace = true
+xmtp_api_grpc = { workspace = true, optional = true }
 xmtp_common = { workspace = true, features = ["logging"] }
 xmtp_configuration.workspace = true
 xmtp_content_types.workspace = true
@@ -44,10 +46,6 @@ xmtp_id.workspace = true
 xmtp_macro.workspace = true
 xmtp_mls.workspace = true
 xmtp_proto.workspace = true
-
-# For some reason these don't work when added as dev-dependencies
-xmtp-workspace-hack = { version = "0.1", path = "../../crates/xmtp-workspace-hack" }
-xmtp_api_grpc = { workspace = true, optional = true }
 
 [build-dependencies]
 napi-build = "2.0.1"

--- a/crates/wasm_macros/Cargo.toml
+++ b/crates/wasm_macros/Cargo.toml
@@ -15,4 +15,4 @@ workspace = true
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = ["full", "extra-traits"] }
-xmtp-workspace-hack = { version = "0.1", path = "../xmtp-workspace-hack" }
+xmtp-workspace-hack.workspace = true

--- a/crates/xmtp-workspace-hack/Cargo.toml
+++ b/crates/xmtp-workspace-hack/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 edition = "2021"
 description = "workspace-hack package, managed by hakari"
 # You can choose to publish this crate: see https://docs.rs/cargo-hakari/latest/cargo_hakari/publishing.
-publish = false
+publish = ["crates-io"]
 license.workspace = true
 
 # The parts of the file between the BEGIN HAKARI SECTION and END HAKARI SECTION comments
@@ -18,19 +18,15 @@ license.workspace = true
 [dependencies]
 aead = { version = "0.5", default-features = false, features = ["getrandom", "std"] }
 aes-gcm = { version = "0.10", features = ["std"] }
-alloy = { version = "1", default-features = false, features = ["contract", "provider-anvil-node", "rand", "reqwest-rustls-tls", "signer-mnemonic"] }
+alloy = { version = "1", default-features = false, features = ["contract", "provider-anvil-node", "rand", "reqwest-rustls-tls", "signer-local"] }
 alloy-core = { version = "1", default-features = false, features = ["dyn-abi", "json-abi", "rand", "rlp"] }
 alloy-json-abi = { version = "1", default-features = false, features = ["serde_json", "std"] }
 alloy-primitives = { version = "1", default-features = false, features = ["k256", "map", "rand", "rlp", "serde", "std"] }
 alloy-provider = { version = "1", default-features = false, features = ["anvil-node"] }
 alloy-rpc-client = { version = "1", default-features = false, features = ["reqwest"] }
-alloy-signer-local = { version = "1", default-features = false, features = ["mnemonic"] }
 alloy-sol-type-parser = { version = "1", default-features = false, features = ["serde", "std"] }
 alloy-sol-types = { version = "1", default-features = false, features = ["json", "std"] }
 alloy-transport-http = { version = "1", default-features = false, features = ["reqwest", "reqwest-rustls-tls"] }
-anstyle = { version = "1" }
-arrayvec = { version = "0.7", features = ["serde"] }
-bytemuck = { version = "1", default-features = false, features = ["aarch64_simd", "derive", "extern_crate_alloc", "min_const_generics"] }
 bytes = { version = "1", features = ["serde"] }
 camino = { version = "1", default-features = false, features = ["serde1"] }
 chrono = { version = "0.4", features = ["serde"] }
@@ -39,13 +35,11 @@ clap = { version = "4", features = ["derive"] }
 clap_builder = { version = "4", default-features = false, features = ["color", "help", "std", "suggestions", "usage"] }
 const-hex = { version = "1", features = ["core-error", "serde"] }
 crypto-common = { version = "0.1", default-features = false, features = ["getrandom", "std"] }
-derive_more = { version = "2", default-features = false, features = ["add", "add_assign", "as_ref", "deref", "deref_mut", "display", "error", "from", "from_str", "index", "index_mut", "into", "into_iterator", "mul", "not", "std"] }
+derive_more = { version = "2", default-features = false, features = ["add", "add_assign", "as_ref", "deref", "deref_mut", "display", "from", "from_str", "index", "index_mut", "into", "into_iterator", "not", "std"] }
 digest = { version = "0.10", features = ["mac", "oid", "std"] }
-ecdsa = { version = "0.16", features = ["pem", "signing", "std", "verifying"] }
 ed25519-dalek = { version = "2", features = ["digest", "rand_core"] }
 either = { version = "1", features = ["serde", "use_std"] }
 elliptic-curve = { version = "0.13", default-features = false, features = ["ecdh", "hazmat", "jwk", "pem", "std"] }
-fontdue = { version = "0.9", features = ["parallel"] }
 form_urlencoded = { version = "1" }
 futures-channel = { version = "0.3", features = ["sink"] }
 futures-core = { version = "0.3" }
@@ -54,27 +48,19 @@ futures-io = { version = "0.3" }
 futures-timer = { version = "3", default-features = false, features = ["wasm-bindgen"] }
 futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
 generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "zeroize"] }
-half = { version = "2" }
-hashbrown-3575ec1268b04181 = { package = "hashbrown", version = "0.15", features = ["rayon"] }
-hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", default-features = false, features = ["inline-more", "raw"] }
+hashbrown-3575ec1268b04181 = { package = "hashbrown", version = "0.15" }
 hashbrown-986da7b5efc2b80e = { package = "hashbrown", version = "0.16", features = ["serde"] }
 hpke-rs = { version = "0.4", features = ["hazmat", "libcrux", "serialization"] }
-icu_locale_core = { version = "2", default-features = false, features = ["alloc", "zerovec"] }
 idna = { version = "1" }
-image = { version = "0.25" }
 indexmap = { version = "2", features = ["serde"] }
 itertools = { version = "0.14" }
 js-sys = { version = "0.3" }
-k256 = { version = "0.13", features = ["ecdh"] }
+k256 = { version = "0.13", default-features = false, features = ["ecdh", "ecdsa", "std"] }
 libcrux-ed25519 = { version = "0.0.4", default-features = false, features = ["rand"] }
-litemap = { version = "0.8", default-features = false, features = ["alloc"] }
 log = { version = "0.4", default-features = false, features = ["std"] }
-lyon_geom = { version = "1" }
 memchr = { version = "2" }
 nu-ansi-term = { version = "0.50" }
-num-traits = { version = "0.2", features = ["i128", "libm"] }
-num_enum = { version = "0.7" }
-once_cell = { version = "1", features = ["critical-section"] }
+num-traits = { version = "0.2", features = ["libm"] }
 openmls = { git = "https://github.com/xmtp/openmls", rev = "beb0884db264075aef271b96efbd7e9d102ee374", default-features = false, features = ["test-utils"] }
 openmls_basic_credential = { git = "https://github.com/xmtp/openmls", rev = "beb0884db264075aef271b96efbd7e9d102ee374", default-features = false, features = ["clonable", "test-utils"] }
 openmls_memory_storage = { git = "https://github.com/xmtp/openmls", rev = "beb0884db264075aef271b96efbd7e9d102ee374", default-features = false, features = ["test-utils"] }
@@ -82,18 +68,14 @@ openmls_rust_crypto = { git = "https://github.com/xmtp/openmls", rev = "beb0884d
 openmls_traits = { git = "https://github.com/xmtp/openmls", rev = "beb0884db264075aef271b96efbd7e9d102ee374", features = ["test-utils"] }
 p256 = { version = "0.13", features = ["ecdh", "jwk"] }
 percent-encoding = { version = "2" }
-portable-atomic = { version = "1", features = ["critical-section"] }
-pulldown-cmark = { version = "0.13" }
 rand = { version = "0.9", features = ["serde"] }
 rand_chacha-274715c4dabd11b0 = { package = "rand_chacha", version = "0.9" }
 rand_chacha-468e82937335b1c9 = { package = "rand_chacha", version = "0.3" }
 rand_core = { version = "0.9", default-features = false, features = ["os_rng", "serde", "std"] }
-read-fonts = { version = "0.35", default-features = false, features = ["experimental_traverse", "libm"] }
 regex = { version = "1" }
 regex-automata = { version = "0.4", default-features = false, features = ["dfa-build", "dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
 regex-syntax = { version = "0.8" }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
-rgb = { version = "0.8" }
 ruint = { version = "1", default-features = false, features = ["alloy-rlp", "rand-09", "serde", "std"] }
 sec1 = { version = "0.7", features = ["pem", "serde", "std", "subtle"] }
 semver = { version = "1", features = ["serde"] }
@@ -104,44 +86,36 @@ sha1 = { version = "0.10", features = ["compress"] }
 smallvec = { version = "1", default-features = false, features = ["const_new", "serde", "union", "write"] }
 sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
 time = { version = "0.3", features = ["formatting", "local-offset", "parsing"] }
-tinystr = { version = "0.8", default-features = false, features = ["alloc", "zerovec"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = { version = "0.7", features = ["codec", "compat", "io"] }
 toml_datetime = { version = "0.7", features = ["serde"] }
 toml_parser = { version = "1" }
 tonic = { version = "0.14", default-features = false, features = ["codegen"] }
-tracing = { version = "0.1", features = ["log", "release_max_level_debug", "valuable"] }
-tracing-core = { version = "0.1", features = ["valuable"] }
-tracing-serde = { version = "0.2", default-features = false, features = ["valuable"] }
-tracing-subscriber = { version = "0.3", features = ["chrono", "env-filter", "json", "time", "valuable"] }
+tracing = { version = "0.1", features = ["log", "release_max_level_debug"] }
+tracing-core = { version = "0.1" }
+tracing-subscriber = { version = "0.3", features = ["chrono", "env-filter", "json"] }
 uniffi = { version = "0.29", features = ["bindgen-tests", "build", "tokio"] }
 uniffi_bindgen = { version = "0.29", features = ["bindgen-tests"] }
 uniffi_core = { version = "0.29", features = ["tokio"] }
 wasm-bindgen = { version = "0.2" }
 winnow = { version = "0.7", features = ["simd"] }
-writeable = { version = "0.6", default-features = false, features = ["alloc"] }
 zerocopy = { version = "0.8", default-features = false, features = ["derive", "simd"] }
-zerovec = { version = "0.11", default-features = false, features = ["alloc", "derive", "yoke"] }
 
 [build-dependencies]
 aead = { version = "0.5", default-features = false, features = ["getrandom", "std"] }
 aes-gcm = { version = "0.10", features = ["std"] }
-alloy = { version = "1", default-features = false, features = ["contract", "provider-anvil-node", "rand", "reqwest-rustls-tls", "signer-mnemonic"] }
+alloy = { version = "1", default-features = false, features = ["contract", "provider-anvil-node", "rand", "reqwest-rustls-tls", "signer-local"] }
 alloy-core = { version = "1", default-features = false, features = ["dyn-abi", "json-abi", "rand", "rlp"] }
 alloy-json-abi = { version = "1", default-features = false, features = ["serde_json", "std"] }
 alloy-primitives = { version = "1", default-features = false, features = ["k256", "map", "rand", "rlp", "serde", "std"] }
 alloy-provider = { version = "1", default-features = false, features = ["anvil-node"] }
 alloy-rpc-client = { version = "1", default-features = false, features = ["reqwest"] }
-alloy-signer-local = { version = "1", default-features = false, features = ["mnemonic"] }
 alloy-sol-macro = { version = "1", default-features = false, features = ["json"] }
 alloy-sol-macro-expander = { version = "1", default-features = false, features = ["json"] }
 alloy-sol-macro-input = { version = "1", default-features = false, features = ["json"] }
 alloy-sol-type-parser = { version = "1", default-features = false, features = ["serde", "std"] }
 alloy-sol-types = { version = "1", default-features = false, features = ["json", "std"] }
 alloy-transport-http = { version = "1", default-features = false, features = ["reqwest", "reqwest-rustls-tls"] }
-anstyle = { version = "1" }
-arrayvec = { version = "0.7", features = ["serde"] }
-bytemuck = { version = "1", default-features = false, features = ["aarch64_simd", "derive", "extern_crate_alloc", "min_const_generics"] }
 bytes = { version = "1", features = ["serde"] }
 camino = { version = "1", default-features = false, features = ["serde1"] }
 chrono = { version = "0.4", features = ["serde"] }
@@ -150,14 +124,11 @@ clap = { version = "4", features = ["derive"] }
 clap_builder = { version = "4", default-features = false, features = ["color", "help", "std", "suggestions", "usage"] }
 const-hex = { version = "1", features = ["core-error", "serde"] }
 crypto-common = { version = "0.1", default-features = false, features = ["getrandom", "std"] }
-derive_more = { version = "2", default-features = false, features = ["add", "add_assign", "as_ref", "deref", "deref_mut", "display", "error", "from", "from_str", "index", "index_mut", "into", "into_iterator", "mul", "not", "std"] }
-derive_more-impl = { version = "2", features = ["add", "add_assign", "as_ref", "deref", "deref_mut", "display", "error", "from", "from_str", "index", "index_mut", "into", "into_iterator", "mul", "not"] }
+derive_more = { version = "2", default-features = false, features = ["add", "add_assign", "as_ref", "deref", "deref_mut", "display", "from", "from_str", "index", "index_mut", "into", "into_iterator", "not", "std"] }
 digest = { version = "0.10", features = ["mac", "oid", "std"] }
-ecdsa = { version = "0.16", features = ["pem", "signing", "std", "verifying"] }
 ed25519-dalek = { version = "2", features = ["digest", "rand_core"] }
 either = { version = "1", features = ["serde", "use_std"] }
 elliptic-curve = { version = "0.13", default-features = false, features = ["ecdh", "hazmat", "jwk", "pem", "std"] }
-fontdue = { version = "0.9", features = ["parallel"] }
 form_urlencoded = { version = "1" }
 futures-channel = { version = "0.3", features = ["sink"] }
 futures-core = { version = "0.3" }
@@ -166,28 +137,19 @@ futures-io = { version = "0.3" }
 futures-timer = { version = "3", default-features = false, features = ["wasm-bindgen"] }
 futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
 generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "zeroize"] }
-half = { version = "2" }
-hashbrown-3575ec1268b04181 = { package = "hashbrown", version = "0.15", features = ["rayon"] }
-hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", default-features = false, features = ["inline-more", "raw"] }
+hashbrown-3575ec1268b04181 = { package = "hashbrown", version = "0.15" }
 hashbrown-986da7b5efc2b80e = { package = "hashbrown", version = "0.16", features = ["serde"] }
 hpke-rs = { version = "0.4", features = ["hazmat", "libcrux", "serialization"] }
-icu_locale_core = { version = "2", default-features = false, features = ["alloc", "zerovec"] }
 idna = { version = "1" }
-image = { version = "0.25" }
 indexmap = { version = "2", features = ["serde"] }
 itertools = { version = "0.14" }
 js-sys = { version = "0.3" }
-k256 = { version = "0.13", features = ["ecdh"] }
+k256 = { version = "0.13", default-features = false, features = ["ecdh", "ecdsa", "std"] }
 libcrux-ed25519 = { version = "0.0.4", default-features = false, features = ["rand"] }
-litemap = { version = "0.8", default-features = false, features = ["alloc"] }
 log = { version = "0.4", default-features = false, features = ["std"] }
-lyon_geom = { version = "1" }
 memchr = { version = "2" }
 nu-ansi-term = { version = "0.50" }
-num-traits = { version = "0.2", features = ["i128", "libm"] }
-num_enum = { version = "0.7" }
-num_enum_derive = { version = "0.7", default-features = false, features = ["std"] }
-once_cell = { version = "1", features = ["critical-section"] }
+num-traits = { version = "0.2", features = ["libm"] }
 openmls = { git = "https://github.com/xmtp/openmls", rev = "beb0884db264075aef271b96efbd7e9d102ee374", default-features = false, features = ["test-utils"] }
 openmls_basic_credential = { git = "https://github.com/xmtp/openmls", rev = "beb0884db264075aef271b96efbd7e9d102ee374", default-features = false, features = ["clonable", "test-utils"] }
 openmls_memory_storage = { git = "https://github.com/xmtp/openmls", rev = "beb0884db264075aef271b96efbd7e9d102ee374", default-features = false, features = ["test-utils"] }
@@ -195,19 +157,15 @@ openmls_rust_crypto = { git = "https://github.com/xmtp/openmls", rev = "beb0884d
 openmls_traits = { git = "https://github.com/xmtp/openmls", rev = "beb0884db264075aef271b96efbd7e9d102ee374", features = ["test-utils"] }
 p256 = { version = "0.13", features = ["ecdh", "jwk"] }
 percent-encoding = { version = "2" }
-portable-atomic = { version = "1", features = ["critical-section"] }
 proc-macro2 = { version = "1", features = ["span-locations"] }
-pulldown-cmark = { version = "0.13" }
 rand = { version = "0.9", features = ["serde"] }
 rand_chacha-274715c4dabd11b0 = { package = "rand_chacha", version = "0.9" }
 rand_chacha-468e82937335b1c9 = { package = "rand_chacha", version = "0.3" }
 rand_core = { version = "0.9", default-features = false, features = ["os_rng", "serde", "std"] }
-read-fonts = { version = "0.35", default-features = false, features = ["experimental_traverse", "libm"] }
 regex = { version = "1" }
 regex-automata = { version = "0.4", default-features = false, features = ["dfa-build", "dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
 regex-syntax = { version = "0.8" }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
-rgb = { version = "0.8" }
 ruint = { version = "1", default-features = false, features = ["alloy-rlp", "rand-09", "serde", "std"] }
 sec1 = { version = "0.7", features = ["pem", "serde", "std", "subtle"] }
 semver = { version = "1", features = ["serde"] }
@@ -219,106 +177,68 @@ smallvec = { version = "1", default-features = false, features = ["const_new", "
 syn = { version = "2", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
 sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
 time = { version = "0.3", features = ["formatting", "local-offset", "parsing"] }
-tinystr = { version = "0.8", default-features = false, features = ["alloc", "zerovec"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = { version = "0.7", features = ["codec", "compat", "io"] }
 toml_datetime = { version = "0.7", features = ["serde"] }
 toml_parser = { version = "1" }
 tonic = { version = "0.14", default-features = false, features = ["codegen"] }
-tracing = { version = "0.1", features = ["log", "release_max_level_debug", "valuable"] }
-tracing-core = { version = "0.1", features = ["valuable"] }
-tracing-serde = { version = "0.2", default-features = false, features = ["valuable"] }
-tracing-subscriber = { version = "0.3", features = ["chrono", "env-filter", "json", "time", "valuable"] }
+tracing = { version = "0.1", features = ["log", "release_max_level_debug"] }
+tracing-core = { version = "0.1" }
+tracing-subscriber = { version = "0.3", features = ["chrono", "env-filter", "json"] }
 uniffi = { version = "0.29", features = ["bindgen-tests", "build", "tokio"] }
 uniffi_bindgen = { version = "0.29", features = ["bindgen-tests"] }
 uniffi_core = { version = "0.29", features = ["tokio"] }
 wasm-bindgen = { version = "0.2" }
 winnow = { version = "0.7", features = ["simd"] }
-writeable = { version = "0.6", default-features = false, features = ["alloc"] }
 zerocopy = { version = "0.8", default-features = false, features = ["derive", "simd"] }
-zerovec = { version = "0.11", default-features = false, features = ["alloc", "derive", "yoke"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
-aho-corasick = { version = "1" }
 bitflags = { version = "2", default-features = false, features = ["std"] }
 byteorder = { version = "1" }
-fontique = { version = "0.7", features = ["fontconfig-dlopen"] }
 getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 hyper = { version = "0.14", features = ["client", "http1", "http2", "runtime", "server", "stream"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "service"] }
-linux-raw-sys = { version = "0.11", default-features = false, features = ["auxvec", "elf", "errno", "general", "if_ether", "ioctl", "net", "netlink", "no_std", "prctl", "system", "xdp"] }
-miniz_oxide = { version = "0.8", features = ["simd"] }
-proc-macro2 = { version = "1", features = ["span-locations"] }
-rustix = { version = "1", features = ["event", "mm", "net", "pipe", "process", "shm", "system", "time"] }
 rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
-slotmap = { version = "1" }
-syn = { version = "2", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
 tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
 tonic = { version = "0.14", features = ["tls-native-roots", "tls-ring", "tls-webpki-roots"] }
 tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "retry", "timeout"] }
-ttf-parser = { version = "0.25", features = ["gvar-alloc", "no-std-float"] }
-uuid = { version = "1", features = ["fast-rng", "serde", "v4"] }
-yeslogic-fontconfig-sys = { version = "6", default-features = false, features = ["dlopen"] }
-zvariant = { version = "5", features = ["enumflags2", "url"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
-aho-corasick = { version = "1" }
 bitflags = { version = "2", default-features = false, features = ["std"] }
 byteorder = { version = "1" }
 cc = { version = "1", default-features = false, features = ["parallel"] }
-fontique = { version = "0.7", features = ["fontconfig-dlopen"] }
 getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 hyper = { version = "0.14", features = ["client", "http1", "http2", "runtime", "server", "stream"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "service"] }
-linux-raw-sys = { version = "0.11", default-features = false, features = ["auxvec", "elf", "errno", "general", "if_ether", "ioctl", "net", "netlink", "no_std", "prctl", "system", "xdp"] }
-miniz_oxide = { version = "0.8", features = ["simd"] }
-rustix = { version = "1", features = ["event", "mm", "net", "pipe", "process", "shm", "system", "time"] }
 rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
-slotmap = { version = "1" }
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
 tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
 tonic = { version = "0.14", features = ["tls-native-roots", "tls-ring", "tls-webpki-roots"] }
 tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "retry", "timeout"] }
-ttf-parser = { version = "0.25", features = ["gvar-alloc", "no-std-float"] }
-uuid = { version = "1", features = ["fast-rng", "serde", "v4"] }
-yeslogic-fontconfig-sys = { version = "6", default-features = false, features = ["dlopen"] }
-zvariant = { version = "5", features = ["enumflags2", "url"] }
 
 [target.aarch64-apple-darwin.dependencies]
-bitflags = { version = "2", default-features = false, features = ["serde", "std"] }
+bitflags = { version = "2", default-features = false, features = ["std"] }
 byteorder = { version = "1" }
 errno = { version = "0.3" }
 getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 hyper = { version = "0.14", features = ["client", "http1", "http2", "runtime", "server", "stream"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "service"] }
-miniz_oxide = { version = "0.8", features = ["simd"] }
-objc2 = { version = "0.6", features = ["relax-sign-encoding"] }
-objc2-core-foundation = { version = "0.3", default-features = false, features = ["CFArray", "CFAttributedString", "CFBase", "CFBundle", "CFCGTypes", "CFCalendar", "CFCharacterSet", "CFData", "CFDate", "CFDictionary", "CFError", "CFFileSecurity", "CFLocale", "CFMachPort", "CFMessagePort", "CFNumber", "CFRunLoop", "CFSet", "CFStream", "CFString", "CFURL", "CFUserNotification", "objc2", "std"] }
-objc2-core-text = { version = "0.3", default-features = false, features = ["CTFont", "CTFontCollection", "CTFontDescriptor", "CTGlyphInfo", "objc2"] }
-objc2-foundation = { version = "0.3", default-features = false, features = ["NSAffineTransform", "NSAppleEventDescriptor", "NSAppleScript", "NSArray", "NSAttributedString", "NSBundle", "NSCalendar", "NSCharacterSet", "NSCoder", "NSComparisonPredicate", "NSData", "NSDate", "NSDictionary", "NSEnumerator", "NSError", "NSException", "NSExpression", "NSExtensionContext", "NSExtensionRequestHandling", "NSFileManager", "NSFilePresenter", "NSFileVersion", "NSFileWrapper", "NSFormatter", "NSGeometry", "NSIndexPath", "NSIndexSet", "NSItemProvider", "NSKeyValueObserving", "NSLocale", "NSLock", "NSNotification", "NSNull", "NSObjCRuntime", "NSObject", "NSOperation", "NSOrthography", "NSPathUtilities", "NSPredicate", "NSProgress", "NSRange", "NSRunLoop", "NSScriptCommand", "NSScriptObjectSpecifiers", "NSScriptStandardSuiteCommands", "NSSet", "NSSortDescriptor", "NSString", "NSTextCheckingResult", "NSThread", "NSTimeZone", "NSURL", "NSUUID", "NSUndoManager", "NSUserActivity", "NSUserDefaults", "NSValue", "NSZone", "objc2-core-foundation", "std"] }
 rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
-slotmap = { version = "1" }
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
 tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
 tonic = { version = "0.14", features = ["tls-native-roots", "tls-ring", "tls-webpki-roots"] }
 tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "retry", "timeout"] }
 
 [target.aarch64-apple-darwin.build-dependencies]
-bitflags = { version = "2", default-features = false, features = ["serde", "std"] }
+bitflags = { version = "2", default-features = false, features = ["std"] }
 byteorder = { version = "1" }
 cc = { version = "1", default-features = false, features = ["parallel"] }
 errno = { version = "0.3" }
 getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 hyper = { version = "0.14", features = ["client", "http1", "http2", "runtime", "server", "stream"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "service"] }
-miniz_oxide = { version = "0.8", features = ["simd"] }
-objc2 = { version = "0.6", features = ["relax-sign-encoding"] }
-objc2-core-foundation = { version = "0.3", default-features = false, features = ["CFArray", "CFAttributedString", "CFBase", "CFBundle", "CFCGTypes", "CFCalendar", "CFCharacterSet", "CFData", "CFDate", "CFDictionary", "CFError", "CFFileSecurity", "CFLocale", "CFMachPort", "CFMessagePort", "CFNumber", "CFRunLoop", "CFSet", "CFStream", "CFString", "CFURL", "CFUserNotification", "objc2", "std"] }
-objc2-core-text = { version = "0.3", default-features = false, features = ["CTFont", "CTFontCollection", "CTFontDescriptor", "CTGlyphInfo", "objc2"] }
-objc2-foundation = { version = "0.3", default-features = false, features = ["NSAffineTransform", "NSAppleEventDescriptor", "NSAppleScript", "NSArray", "NSAttributedString", "NSBundle", "NSCalendar", "NSCharacterSet", "NSCoder", "NSComparisonPredicate", "NSData", "NSDate", "NSDictionary", "NSEnumerator", "NSError", "NSException", "NSExpression", "NSExtensionContext", "NSExtensionRequestHandling", "NSFileManager", "NSFilePresenter", "NSFileVersion", "NSFileWrapper", "NSFormatter", "NSGeometry", "NSIndexPath", "NSIndexSet", "NSItemProvider", "NSKeyValueObserving", "NSLocale", "NSLock", "NSNotification", "NSNull", "NSObjCRuntime", "NSObject", "NSOperation", "NSOrthography", "NSPathUtilities", "NSPredicate", "NSProgress", "NSRange", "NSRunLoop", "NSScriptCommand", "NSScriptObjectSpecifiers", "NSScriptStandardSuiteCommands", "NSSet", "NSSortDescriptor", "NSString", "NSTextCheckingResult", "NSThread", "NSTimeZone", "NSURL", "NSUUID", "NSUndoManager", "NSUserActivity", "NSUserDefaults", "NSValue", "NSZone", "objc2-core-foundation", "std"] }
 rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
-slotmap = { version = "1" }
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
 tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
 tonic = { version = "0.14", features = ["tls-native-roots", "tls-ring", "tls-webpki-roots"] }
@@ -331,7 +251,6 @@ errno = { version = "0.3" }
 getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 hyper = { version = "0.14", features = ["client", "http1", "http2", "runtime", "server", "stream"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "service"] }
-miniz_oxide = { version = "0.8", features = ["simd"] }
 rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
 tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
@@ -346,7 +265,6 @@ errno = { version = "0.3" }
 getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 hyper = { version = "0.14", features = ["client", "http1", "http2", "runtime", "server", "stream"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "service"] }
-miniz_oxide = { version = "0.8", features = ["simd"] }
 rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
 tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
@@ -360,7 +278,6 @@ errno = { version = "0.3" }
 getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 hyper = { version = "0.14", features = ["client", "http1", "http2", "runtime", "server", "stream"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "service"] }
-miniz_oxide = { version = "0.8", features = ["simd"] }
 rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
 tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
@@ -375,7 +292,6 @@ errno = { version = "0.3" }
 getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 hyper = { version = "0.14", features = ["client", "http1", "http2", "runtime", "server", "stream"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "service"] }
-miniz_oxide = { version = "0.8", features = ["simd"] }
 rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
 tokio-stream = { version = "0.1", default-features = false, features = ["net"] }

--- a/crates/xmtp_api/Cargo.toml
+++ b/crates/xmtp_api/Cargo.toml
@@ -15,7 +15,7 @@ hex.workspace = true
 prost = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
 tracing.workspace = true
-xmtp-workspace-hack = { version = "0.1", path = "../xmtp-workspace-hack" }
+xmtp-workspace-hack.workspace = true
 xmtp_api_d14n = { workspace = true }
 xmtp_common.workspace = true
 xmtp_id.workspace = true

--- a/crates/xmtp_api_d14n/Cargo.toml
+++ b/crates/xmtp_api_d14n/Cargo.toml
@@ -39,7 +39,7 @@ xmtp_proto = { workspace = true }
 ctor = { workspace = true, optional = true }
 mockall = { workspace = true, optional = true }
 wasm-bindgen-test = { workspace = true, optional = true }
-xmtp-workspace-hack = { version = "0.1", path = "../xmtp-workspace-hack" }
+xmtp-workspace-hack.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 openmls = { workspace = true }

--- a/crates/xmtp_api_grpc/Cargo.toml
+++ b/crates/xmtp_api_grpc/Cargo.toml
@@ -21,7 +21,7 @@ xmtp_configuration.workspace = true
 xmtp_proto = { workspace = true }
 
 toxiproxy_rust = { workspace = true, optional = true }
-xmtp-workspace-hack = { version = "0.1", path = "../xmtp-workspace-hack" }
+xmtp-workspace-hack.workspace = true
 
 
 # Anything but iOS, Android & WASM will use either webpki or native.

--- a/crates/xmtp_archive/Cargo.toml
+++ b/crates/xmtp_archive/Cargo.toml
@@ -27,7 +27,7 @@ thiserror.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true
-xmtp-workspace-hack = { version = "0.1", path = "../xmtp-workspace-hack" }
+xmtp-workspace-hack.workspace = true
 xmtp_common.workspace = true
 xmtp_db.workspace = true
 xmtp_mls_common.workspace = true

--- a/crates/xmtp_common/Cargo.toml
+++ b/crates/xmtp_common/Cargo.toml
@@ -30,7 +30,7 @@ tracing-subscriber = { workspace = true, features = [
   "json",
 ], optional = true }
 wasm-bindgen-test = { workspace = true, optional = true }
-xmtp-workspace-hack = { version = "0.1", path = "../xmtp-workspace-hack" }
+xmtp-workspace-hack.workspace = true
 xmtp_cryptography.workspace = true
 xmtp_macro.workspace = true
 

--- a/crates/xmtp_configuration/Cargo.toml
+++ b/crates/xmtp_configuration/Cargo.toml
@@ -8,7 +8,7 @@ description = "global configuration for xmtp crates"
 [dependencies]
 openmls.workspace = true
 url.workspace = true
-xmtp-workspace-hack = { version = "0.1", path = "../xmtp-workspace-hack" }
+xmtp-workspace-hack.workspace = true
 xmtp_common.workspace = true
 xmtp_cryptography.workspace = true
 

--- a/crates/xmtp_content_types/Cargo.toml
+++ b/crates/xmtp_content_types/Cargo.toml
@@ -20,9 +20,7 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
-
-# XMTP/Local
-xmtp-workspace-hack = { version = "0.1", path = "../xmtp-workspace-hack" }
+xmtp-workspace-hack.workspace = true
 xmtp_common.workspace = true
 xmtp_proto.workspace = true
 

--- a/crates/xmtp_cryptography/Cargo.toml
+++ b/crates/xmtp_cryptography/Cargo.toml
@@ -31,7 +31,7 @@ serde = { workspace = true }
 sha2.workspace = true
 thiserror = { workspace = true }
 tls_codec.workspace = true
-xmtp-workspace-hack = { version = "0.1", path = "../xmtp-workspace-hack" }
+xmtp-workspace-hack.workspace = true
 zeroize.workspace = true
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]

--- a/crates/xmtp_db/Cargo.toml
+++ b/crates/xmtp_db/Cargo.toml
@@ -58,10 +58,7 @@ tokio = { workspace = true, optional = true, features = [
   "sync",
 ] }
 toml = { version = "0.8.4", optional = true }
-
-
-# TODO: possibly separate these crates
-xmtp-workspace-hack = { version = "0.1", path = "../xmtp-workspace-hack" }
+xmtp-workspace-hack.workspace = true
 xmtp_content_types.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/crates/xmtp_db_test/Cargo.toml
+++ b/crates/xmtp_db_test/Cargo.toml
@@ -14,6 +14,6 @@ diesel.workspace = true
 parking_lot.workspace = true
 rand.workspace = true
 tracing.workspace = true
-xmtp-workspace-hack = { version = "0.1", path = "../xmtp-workspace-hack" }
+xmtp-workspace-hack.workspace = true
 xmtp_common = { workspace = true, features = ["test-utils"] }
 xmtp_db = { workspace = true, features = ["test-utils"] }

--- a/crates/xmtp_id/Cargo.toml
+++ b/crates/xmtp_id/Cargo.toml
@@ -40,7 +40,7 @@ xmtp_db.workspace = true
 xmtp_proto = { workspace = true, features = [] }
 
 rstest = { workspace = true, optional = true }
-xmtp-workspace-hack = { version = "0.1", path = "../xmtp-workspace-hack" }
+xmtp-workspace-hack.workspace = true
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { workspace = true, features = ["wasm_js"] }
 openmls = { workspace = true, features = ["js"] }

--- a/crates/xmtp_macro/Cargo.toml
+++ b/crates/xmtp_macro/Cargo.toml
@@ -20,7 +20,7 @@ syn = { version = "2.0", default-features = false, features = [
   "full",
   "clone-impls",
 ] }
-xmtp-workspace-hack = { version = "0.1", path = "../xmtp-workspace-hack" }
+xmtp-workspace-hack.workspace = true
 
 [lib]
 proc-macro = true

--- a/crates/xmtp_mls/Cargo.toml
+++ b/crates/xmtp_mls/Cargo.toml
@@ -126,7 +126,7 @@ tracing-subscriber = { workspace = true, features = [
   "json",
   "registry",
 ], optional = true }
-xmtp-workspace-hack = { version = "0.1", path = "../xmtp-workspace-hack" }
+xmtp-workspace-hack.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true, features = [

--- a/crates/xmtp_mls_common/Cargo.toml
+++ b/crates/xmtp_mls_common/Cargo.toml
@@ -14,7 +14,7 @@ openmls.workspace = true
 prost.workspace = true
 serde.workspace = true
 thiserror.workspace = true
-xmtp-workspace-hack = { version = "0.1", path = "../xmtp-workspace-hack" }
+xmtp-workspace-hack.workspace = true
 xmtp_common.workspace = true
 xmtp_configuration.workspace = true
 xmtp_cryptography.workspace = true

--- a/crates/xmtp_proto/Cargo.toml
+++ b/crates/xmtp_proto/Cargo.toml
@@ -36,7 +36,7 @@ tokio = { workspace = true, default-features = false, features = [
   "sync",
 ], optional = true }
 toxiproxy_rust = { workspace = true, optional = true }
-xmtp-workspace-hack = { version = "0.1", path = "../xmtp-workspace-hack" }
+xmtp-workspace-hack.workspace = true
 
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]


### PR DESCRIPTION
keep `mls_validation_service` since its used often in CI

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate `xmtp-workspace-hack` dependency to workspace-level resolution across all crates
> - Replaces per-crate path dependencies on `xmtp-workspace-hack` with `workspace = true` across all crates and bindings, with the crate registered under `[workspace.dependencies]` and `[patch.crates-io]` in [Cargo.toml](https://github.com/xmtp/libxmtp/pull/3286/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542).
> - Excludes `xmtp_cli`, `log_parser`, `xdbg`, and `xmtp-db-tools` from `cargo-hakari` traversal via [.config/hakari.toml](https://github.com/xmtp/libxmtp/pull/3286/files#diff-6ca1bb1e13a357482741fd29eafc6b6306971ba70f5bba83f721c01322849165), using the new `workspace-dotted` line style.
> - Removes the `xmtp-workspace-hack` dependency entirely from the excluded app crates (`apps/cli`, `apps/log_parser`, `apps/xmtp_debug`).
> - Switches the workspace `android` app from a glob exclusion to an explicit `exclude` entry, and narrows `default-members` to `apps/mls_validation_service`.
> - The `xmtp-workspace-hack` crate is now configured as publishable to crates.io, with a reduced set of transitive dependencies (e.g. `alloy` uses `signer-local`, several font/ICU/serde features removed).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e146262.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->