### PR TITLE
fix: reset intent to ToPublish when send_group_messages fails

### DIFF
--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -2419,6 +2419,8 @@ where
                                     intent_kind = ?kind,
                                     err = ?err
                                 );
+                                // Reset so the next retry re-encrypts at the current epoch.
+                                let _ = db.set_group_intent_to_publish(intent.id);
                                 return Err(err)?;
                             }
                             (kind, Ok(_)) => {


### PR DESCRIPTION
## Summary

When `send_group_messages()` fails (e.g. server-side epoch rejection), the intent is left stranded in `Published` state. On retry, `publish_intents()` only queries for `ToPublish` intents, so it never finds the stranded intent. `receive()` also has nothing to process since the rejected message was never stored on the network. The intent is stuck forever, causing **silent message loss**.

## How we found this

We run AI agents on XMTP via [convos-cli](https://github.com/xmtplabs/convos-cli) (`@xmtp/node-sdk@5.3.0`). An agent joins a group, sends a welcome message — it appears fine. The user asks the agent to do something. The agent responds — the message never appears.

From the agent's side, everything looks normal: `sendText()` resolves, local DB shows `deliveryStatus: PUBLISHED`, the CLI emits a `sent` confirmation. But the other group member never sees the message. No error is surfaced anywhere.

We ruled out reply content types, profile updates, binary crashes. Then we pulled the app-side debug log:

```
LocalCommitLog {
  commit_sequence_id: 27782061,
  commit_result: WrongEpoch,
  error_message: Some("OldEpoch(0, 1)"),
}
```

The agent encrypted a message at epoch 0, but the group had already advanced to epoch 1 (from a `KeyUpdate`). Every subsequent message was silently lost.

## Why we suspected the retry path was broken

Seeing `OldEpoch(0, 1)` — only 1 epoch behind — we expected the SDK to handle this automatically. `send_message()` calls `sync_until_last_intent_resolved()`, which retries up to 3 times. When `receive()` detects a `WrongEpoch` on an own-message intent, it resets the intent to `ToPublish` via `stage_and_validate_intent()`, so the next iteration can re-encrypt at the correct epoch. A 1-epoch gap is well within `MAX_PAST_EPOCHS` (3).

So if the retry logic works, a transient epoch mismatch should self-heal. But it wasn't healing. That meant the retry path was being bypassed entirely.

We traced the intent state machine through `publish_intents()` → `send_group_messages()` → `receive()` and found the gap: the recovery path in `receive()` only works when the network **accepts** the stale ciphertext (stores it, returns it during the receive query, where `stage_and_validate_intent` can detect and reset it). But when the network **rejects** the stale ciphertext outright during `send_group_messages()`, the message is never stored on the node — `receive()` never sees it — and the intent's existing recovery path is never triggered.

Meanwhile, `publish_intents()` had already transitioned the intent from `ToPublish` → `Published` (before the API call). After the API rejection, the error propagates but the intent state is not rolled back. On the next retry:

- `publish_intents()` queries `WHERE state = ToPublish` → finds nothing (intent is `Published`)
- `receive()` queries the node → finds nothing (rejected message not stored)
- The intent is stranded in `Published`, invisible to both paths
- All 3 retries spin doing nothing → `SyncFailedToWait`

## The fix

Reset the intent from `Published` back to `ToPublish` when `send_group_messages()` returns an error. The next retry re-encrypts at the now-current epoch and re-publishes.

### Before (broken)
```
ToPublish → [encrypt + Published] → [send fails] → Published (STRANDED)
  retry: publish_intents skips it, receive has nothing → SyncFailedToWait
```

### After (fixed)
```
ToPublish → [encrypt + Published] → [send fails] → ToPublish (RESET)
  retry: publish_intents finds it → re-encrypt at current epoch → success
```

### Why this is safe

- `set_group_intent_to_publish()` guards with `WHERE state = Published` — matches exactly
- Reset clears `payload_hash`, `staged_commit`, `published_in_epoch` — forces fresh encryption
- Works for all intent kinds (SendMessage, commits, metadata updates)
- Existing `publish_attempts` counter still provides a circuit breaker

Fixes #2993

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reset intent to `ToPublish` state when `send_group_messages` fails during group sync
> When publishing a commit fails in [`mls_sync.rs`](https://github.com/xmtp/libxmtp/pull/3292/files#diff-160aadcd7de477c1116260a79601a0548842f3bd91bf16bd8443debb66ce6684), the intent is now reset to `ToPublish` before returning the error. This ensures the next retry re-encrypts and republishes at the current epoch rather than using stale encrypted data.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 15a38e5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->