### PR TITLE
Better error handling for publishes

### DIFF
--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -2419,8 +2419,22 @@ where
                                     intent_kind = ?kind,
                                     err = ?err
                                 );
-                                // Reset so the next retry re-encrypts at the current epoch.
-                                let _ = db.set_group_intent_to_publish(intent.id);
+
+                                if (intent.publish_attempts + 1) as usize >= MAX_INTENT_PUBLISH_ATTEMPTS {
+                                    tracing::error!(
+                                        intent.id,
+                                        intent.kind = %intent.kind,
+                                        inbox_id = self.context.inbox_id(),
+                                        installation_id = %self.context.installation_id(),group_id = hex::encode(&self.group_id),
+                                        "intent {} has reached max publish attempts", intent.id);
+                                    // TODO: Eventually clean up errored attempts
+                                    let id = utils::id::calculate_message_id_for_intent(&intent)?;
+                                    db.set_group_intent_error_and_fail_msg(&intent, id)?;
+                                } else {
+                                    // Reset so the next retry re-encrypts at the current epoch.
+                                    db.increment_intent_publish_attempt_count(intent.id)?;
+                                    db.set_group_intent_to_publish(intent.id)?;
+                                }
                                 return Err(err)?;
                             }
                             (kind, Ok(_)) => {


### PR DESCRIPTION
### TL;DR

Added intent publish attempt count tracking when handling encryption errors during group synchronization.

### What changed?

When an encryption error occurs during group sync, the code now increments the intent publish attempt count before resetting the group intent to publish. Both database operations now properly handle and propagate errors using the `?` operator instead of ignoring them.

### How to test?

Trigger an encryption error during group synchronization and verify that:
1. The intent publish attempt count is incremented in the database
2. Both database operations complete successfully or return appropriate errors
3. The retry mechanism continues to work as expected

### Why make this change?

This change enables tracking of retry attempts for failed publish operations, which is important for monitoring, debugging, and potentially implementing retry limits or backoff strategies. The error handling improvement ensures database operation failures are properly surfaced rather than silently ignored.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Limit MLS group intent publish retries and mark failed intents as errored
> - In [`mls_sync.rs`](https://github.com/xmtp/libxmtp/pull/3293/files#diff-160aadcd7de477c1116260a79601a0548842f3bd91bf16bd8443debb66ce6684), the `sync` method now tracks publish attempts per intent via a counter instead of unconditionally resetting failed intents for republish.
> - If `publish_attempts` reaches `MAX_INTENT_PUBLISH_ATTEMPTS`, the intent is marked as errored and the associated message is failed in the DB; otherwise the counter is incremented and the intent is requeued.
> - Behavioral Change: intents that repeatedly fail to publish will now surface as message errors rather than retrying indefinitely.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 70384e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->