### PR TITLE
stream tests

### DIFF
--- a/crates/xmtp_api_d14n/src/queries/combined/streams.rs
+++ b/crates/xmtp_api_d14n/src/queries/combined/streams.rs
@@ -149,3 +149,189 @@ where
         })))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::tests::{FakeNetworkError, TestNetworkClient, build_test_client};
+    use super::*;
+    use crate::protocol::InMemoryCursorStore;
+    use futures::StreamExt;
+
+    fn migration_error() -> ApiClientError {
+        ApiClientError::client(FakeNetworkError(
+            "XMTP V3 streaming is no longer available. Please upgrade your client to XMTP D14N."
+                .to_string(),
+        ))
+    }
+
+    fn other_error() -> ApiClientError {
+        ApiClientError::client(FakeNetworkError("some unrelated error".to_string()))
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn stream_fallback_yields_v3_items_without_error() {
+        let store = InMemoryCursorStore::new();
+        let client = build_test_client(TestNetworkClient::new(), TestNetworkClient::new(), store);
+
+        let v3_stream: BoxDynStream<'static, Result<i32, ApiClientError>> =
+            Box::pin(futures::stream::iter(vec![Ok(1), Ok(2), Ok(3)]));
+
+        let fallback_stream = client.with_d14n_fallback(v3_stream, || async {
+            panic!("d14n factory should not be called when v3 stream succeeds")
+        });
+        futures::pin_mut!(fallback_stream);
+
+        let items: Vec<i32> = fallback_stream.map(|r| r.unwrap()).collect().await;
+
+        assert_eq!(items, vec![1, 2, 3]);
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn stream_fallback_switches_on_migration_error() {
+        let store = InMemoryCursorStore::new();
+        let client = build_test_client(TestNetworkClient::new(), TestNetworkClient::new(), store);
+
+        let v3_stream: BoxDynStream<'static, Result<i32, ApiClientError>> =
+            Box::pin(futures::stream::iter(vec![Ok(1), Err(migration_error())]));
+
+        let fallback_stream = client.with_d14n_fallback(v3_stream, || async {
+            let d14n: BoxDynStream<'static, Result<i32, ApiClientError>> =
+                Box::pin(futures::stream::iter(vec![Ok(10), Ok(11)]));
+            Ok(d14n)
+        });
+        futures::pin_mut!(fallback_stream);
+
+        let item = fallback_stream.next().await.unwrap();
+        assert_eq!(item.unwrap(), 1);
+
+        let item = fallback_stream.next().await.unwrap();
+        assert!(item.is_err());
+
+        let item = fallback_stream.next().await.unwrap();
+        assert_eq!(item.unwrap(), 10);
+
+        let item = fallback_stream.next().await.unwrap();
+        assert_eq!(item.unwrap(), 11);
+
+        assert!(fallback_stream.next().await.is_none());
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn stream_fallback_does_not_switch_on_non_migration_error() {
+        let store = InMemoryCursorStore::new();
+        let client = build_test_client(TestNetworkClient::new(), TestNetworkClient::new(), store);
+
+        let v3_stream: BoxDynStream<'static, Result<i32, ApiClientError>> =
+            Box::pin(futures::stream::iter(vec![Ok(1), Err(other_error())]));
+
+        let fallback_stream = client.with_d14n_fallback(v3_stream, || async {
+            panic!("d14n factory should not be called for non-migration errors")
+        });
+        futures::pin_mut!(fallback_stream);
+
+        let item = fallback_stream.next().await.unwrap();
+        assert_eq!(item.unwrap(), 1);
+
+        let item = fallback_stream.next().await.unwrap();
+        assert!(item.is_err());
+
+        assert!(fallback_stream.next().await.is_none());
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn stream_fallback_empty_v3_stream() {
+        let store = InMemoryCursorStore::new();
+        let client = build_test_client(TestNetworkClient::new(), TestNetworkClient::new(), store);
+
+        let v3_stream: BoxDynStream<'static, Result<i32, ApiClientError>> =
+            Box::pin(futures::stream::empty());
+
+        let fallback_stream = client.with_d14n_fallback(v3_stream, || async {
+            panic!("d14n factory should not be called for empty stream")
+        });
+        futures::pin_mut!(fallback_stream);
+
+        assert!(fallback_stream.next().await.is_none());
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn stream_fallback_d14n_factory_error() {
+        let store = InMemoryCursorStore::new();
+        let client = build_test_client(TestNetworkClient::new(), TestNetworkClient::new(), store);
+
+        let v3_stream: BoxDynStream<'static, Result<i32, ApiClientError>> =
+            Box::pin(futures::stream::iter(vec![Err(migration_error())]));
+
+        let fallback_stream = client.with_d14n_fallback(v3_stream, || async {
+            Err::<BoxDynStream<'static, Result<i32, ApiClientError>>, _>(other_error())
+        });
+        futures::pin_mut!(fallback_stream);
+
+        let item = fallback_stream.next().await.unwrap();
+        assert!(item.is_err());
+
+        let item = fallback_stream.next().await.unwrap();
+        assert!(item.is_err());
+
+        assert!(fallback_stream.next().await.is_none());
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn stream_fallback_migration_error_mid_stream() {
+        let store = InMemoryCursorStore::new();
+        let client = build_test_client(TestNetworkClient::new(), TestNetworkClient::new(), store);
+
+        let v3_stream: BoxDynStream<'static, Result<i32, ApiClientError>> =
+            Box::pin(futures::stream::iter(vec![
+                Ok(1),
+                Ok(2),
+                Ok(3),
+                Err(migration_error()),
+                Ok(99),
+            ]));
+
+        let fallback_stream = client.with_d14n_fallback(v3_stream, || async {
+            let d14n: BoxDynStream<'static, Result<i32, ApiClientError>> =
+                Box::pin(futures::stream::iter(vec![Ok(20), Ok(21)]));
+            Ok(d14n)
+        });
+        futures::pin_mut!(fallback_stream);
+
+        assert_eq!(fallback_stream.next().await.unwrap().unwrap(), 1);
+        assert_eq!(fallback_stream.next().await.unwrap().unwrap(), 2);
+        assert_eq!(fallback_stream.next().await.unwrap().unwrap(), 3);
+
+        let item = fallback_stream.next().await.unwrap();
+        assert!(item.is_err());
+
+        assert_eq!(fallback_stream.next().await.unwrap().unwrap(), 20);
+        assert_eq!(fallback_stream.next().await.unwrap().unwrap(), 21);
+
+        assert!(fallback_stream.next().await.is_none());
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn stream_fallback_multiple_non_migration_errors_no_switch() {
+        let store = InMemoryCursorStore::new();
+        let client = build_test_client(TestNetworkClient::new(), TestNetworkClient::new(), store);
+
+        let v3_stream: BoxDynStream<'static, Result<i32, ApiClientError>> =
+            Box::pin(futures::stream::iter(vec![
+                Ok(1),
+                Err(other_error()),
+                Ok(2),
+                Err(other_error()),
+            ]));
+
+        let fallback_stream = client.with_d14n_fallback(v3_stream, || async {
+            panic!("d14n factory should not be called for non-migration errors")
+        });
+        futures::pin_mut!(fallback_stream);
+
+        assert_eq!(fallback_stream.next().await.unwrap().unwrap(), 1);
+        assert!(fallback_stream.next().await.unwrap().is_err());
+        assert_eq!(fallback_stream.next().await.unwrap().unwrap(), 2);
+        assert!(fallback_stream.next().await.unwrap().is_err());
+        assert!(fallback_stream.next().await.is_none());
+    }
+}

--- a/crates/xmtp_api_d14n/src/queries/combined/tests.rs
+++ b/crates/xmtp_api_d14n/src/queries/combined/tests.rs
@@ -14,14 +14,14 @@ use crate::protocol::InMemoryCursorStore;
 /// Wrapper around `Arc<MockNetworkClient>` that also implements [`IsConnectedCheck`].
 /// `Arc<MockNetworkClient>` already implements `Client` + `Clone`.
 #[derive(Clone)]
-struct TestNetworkClient(Arc<MockNetworkClient>);
+pub(super) struct TestNetworkClient(Arc<MockNetworkClient>);
 
 impl TestNetworkClient {
-    fn new() -> Self {
+    pub(super) fn new() -> Self {
         Self(Arc::new(MockNetworkClient::new()))
     }
 
-    fn from_mock(mock: MockNetworkClient) -> Self {
+    pub(super) fn from_mock(mock: MockNetworkClient) -> Self {
         Self(Arc::new(mock))
     }
 }
@@ -54,13 +54,13 @@ impl IsConnectedCheck for TestNetworkClient {
     }
 }
 
-type TestMigrationClient =
+pub(super) type TestMigrationClient =
     MigrationClient<TestNetworkClient, TestNetworkClient, InMemoryCursorStore>;
 
 /// Build a `MigrationClient` for testing by constructing fields directly.
 /// `v3_client` and `xmtpd_client` are `XmtpApiClient` (type-erased `Arc<dyn ...>`),
 /// built from two separate `V3Client` instances so we can compare pointers.
-fn build_test_client(
+pub(super) fn build_test_client(
     v3: TestNetworkClient,
     d14n: TestNetworkClient,
     store: InMemoryCursorStore,
@@ -79,7 +79,7 @@ fn build_test_client(
 
 /// Create a `TestNetworkClient` that returns a `FetchD14nCutoverResponse` with the given
 /// `timestamp_ns` when `request()` is called.
-fn mock_v3_with_cutover(timestamp_ns: u64) -> TestNetworkClient {
+pub(super) fn mock_v3_with_cutover(timestamp_ns: u64) -> TestNetworkClient {
     let mut mock = MockNetworkClient::new();
     let body = FetchD14nCutoverResponse { timestamp_ns }.encode_to_vec();
     mock.expect_request()
@@ -90,7 +90,7 @@ fn mock_v3_with_cutover(timestamp_ns: u64) -> TestNetworkClient {
 /// A retryable error type for constructing migration-matching errors.
 #[derive(Debug, thiserror::Error)]
 #[error("{0}")]
-struct FakeNetworkError(String);
+pub(super) struct FakeNetworkError(pub(super) String);
 
 impl RetryableError for FakeNetworkError {
     fn is_retryable(&self) -> bool {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add stream tests for `MigrationClient.with_d14n_fallback` behavior
- Adds seven async tests in [streams.rs](https://github.com/xmtp/libxmtp/pull/3298/files#diff-2cdc5c15ac1deb552a4234c3c4381e39aba1dcf659f6a6ae27449a5be726f819) covering `MigrationClient.with_d14n_fallback` across scenarios: successful v3 streams, migration error triggering d14n fallback, non-migration errors (no fallback), empty streams, mid-stream migration errors, and factory errors.
- Makes test helpers (`TestNetworkClient`, `TestMigrationClient`, `build_test_client`, `FakeNetworkError`, etc.) in [tests.rs](https://github.com/xmtp/libxmtp/pull/3298/files#diff-199afcf90f95c7be1185f20399f5609f91af62e9ef20d24822e3e5c437dc915a) `pub(super)` so the new stream test module can reuse them.
- Adds `migration_error` and `other_error` helper constructors in the stream test module to build typed errors for test setup.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 536600c.</sup>
<!-- Macroscope's review summary ends here -->
<!-- Macroscope's pull request summary ends here -->