### PR TITLE
One more dylib rpath fix

### DIFF
--- a/bindings/mobile/Makefile
+++ b/bindings/mobile/Makefile
@@ -114,6 +114,7 @@ frameworkdyn: lipodyn
 	mkdir -p build/swift
 	chmod -R u+w build/swift/LibXMTPSwiftFFIDynamic.xcframework 2>/dev/null || true
 	rm -rf build/swift/LibXMTPSwiftFFIDynamic.xcframework
+	install_name_tool -id @rpath/libxmtpv3.dylib $(NIX_OUT)/aarch64-apple-ios/$(DYLIB)
 	xcodebuild -create-xcframework \
 		-library $(NIX_OUT)/aarch64-apple-ios/$(DYLIB) \
 		-headers $(SWIFT_OUT)/include/libxmtp/ \


### PR DESCRIPTION
## tl;dr

Lines up our Nix-based implementation with the one-off dylib hacks we were using pre-Nix to make sure everything points to the `rpath` location

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix dylib rpath install name in `frameworkdyn` make target
> Adds an `install_name_tool` call in [bindings/mobile/Makefile](https://github.com/xmtp/libxmtp/pull/3300/files#diff-58ed044ef90474aad2e3dcfc986075fabd1333479c864a518f9e9756dfa0cd3e) to set the install name of `libxmtpv3.dylib` to `@rpath/libxmtpv3.dylib` before the xcodebuild step. This ensures the dynamic loader resolves the dylib correctly at runtime using rpath-relative lookup.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5d13c6c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->