### PR TITLE
readd xdbg to workspace default members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ exclude = ["apps/android"]
 default-members = [
   # Applications
   "apps/mls_validation_service",
+  "apps/xmtp_debug",
   # Bindings
   "bindings/*",
   # Core crates


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Re-add `apps/xmtp_debug` to workspace default members in `Cargo.toml`
> Adds `apps/xmtp_debug` back to the `default-members` array in [Cargo.toml](https://github.com/xmtp/libxmtp/pull/3305/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542), so workspace-level `cargo` commands run without an explicit `-p` flag include this package.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e452cbb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->


this re-enables `cargo xdbg`