### PR TITLE
Clean up cargo.toml files and upgrade some deps

### DIFF
--- a/.config/hakari.toml
+++ b/.config/hakari.toml
@@ -29,7 +29,13 @@ platforms = [
 
 # Including mio/tokio breaks webassembly builds since net features are mutually exclusive with wasm
 [traversal-excludes]
-third-party = [{ name = "mio" }, { name = "tokio" }, { name = "hyper" }]
+third-party = [
+  { name = "hyper" },
+  { name = "mio" },
+  { name = "tokio" },
+  { name = "uniffi" },
+  { name = "wasm-bindgen" },
+]
 workspace-members = [
   "bindings_wasm",
   "xmtp_cli",
@@ -38,7 +44,13 @@ workspace-members = [
   "xdbg",
 ]
 [final-excludes]
-third-party = [{ name = "mio" }, { name = "tokio" }, { name = "hyper" }]
+third-party = [
+  { name = "hyper" },
+  { name = "mio" },
+  { name = "tokio" },
+  { name = "uniffi" },
+  { name = "wasm-bindgen" },
+]
 workspace-members = [
   "bindings_wasm",
   "xmtp_cli",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,6 +210,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,9 +249,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f374d3c6d729268bbe2d0e0ff992bb97898b2df756691a62ee1d5f0506bc39"
+checksum = "6d9d22005bf31b018f31ef9ecadb5d2c39cf4f6acc8db0456f72c815f3d7f757"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -859,13 +868,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-trie"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d7fd448ab0a017de542de1dcca7a58e7019fe0e7a34ed3f9543ebddf6aceffa"
+checksum = "3f14b5d9b2c2173980202c6ff470d96e7c5e202c65a9f67884ad565226df7fbb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "arrayvec",
  "derive_more",
  "nybbles",
  "serde",
@@ -1035,7 +1043,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot 0.12.5",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -1260,9 +1268,6 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "as-raw-xcb-connection"
@@ -1312,9 +1317,9 @@ dependencies = [
 
 [[package]]
 name = "askama"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4744ed2eef2645831b441d8f5459689ade2ab27c854488fbab1fbe94fce1a7"
+checksum = "f75363874b771be265f4ffe307ca705ef6f3baa19011c149da8674a87f1b75c4"
 dependencies = [
  "askama_derive",
  "itoa",
@@ -1325,9 +1330,9 @@ dependencies = [
 
 [[package]]
 name = "askama_derive"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d661e0f57be36a5c14c48f78d09011e67e0cb618f269cca9f2fd8d15b68c46ac"
+checksum = "129397200fe83088e8a68407a8e2b1f826cf0086b21ccdb866a722c8bcd3a94f"
 dependencies = [
  "askama_parser",
  "basic-toml",
@@ -1342,9 +1347,9 @@ dependencies = [
 
 [[package]]
 name = "askama_parser"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf315ce6524c857bb129ff794935cf6d42c82a6cff60526fe2a63593de4d0d4f"
+checksum = "d6ab5630b3d5eaf232620167977f95eb51f3432fc76852328774afbd242d4358"
 dependencies = [
  "memchr",
  "serde",
@@ -1795,26 +1800,6 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
-dependencies = [
- "bitflags 2.11.0",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -2069,7 +2054,7 @@ version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d314cc62af2b6b0c65780555abb4d02a03dd3b799cd42419044f0c38d99738c0"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -2434,7 +2419,7 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
- "libloading",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -2602,7 +2587,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2734,18 +2719,18 @@ dependencies = [
 
 [[package]]
 name = "convert_case"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "convert_case"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -2953,10 +2938,11 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
@@ -2965,6 +2951,7 @@ dependencies = [
  "itertools 0.13.0",
  "num-traits",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
@@ -2977,9 +2964,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.6.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools 0.13.0",
@@ -3184,6 +3171,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3213,6 +3210,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3230,6 +3240,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -3464,7 +3485,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3502,7 +3523,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
- "libloading",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -3797,7 +3818,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5264,7 +5285,7 @@ dependencies = [
  "glutin_egl_sys",
  "glutin_glx_sys",
  "glutin_wgl_sys",
- "libloading",
+ "libloading 0.8.9",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
@@ -5730,9 +5751,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b229d73f5803b562cc26e4da0396c8610a4ee209f4fac8fa4f8d709166dc45"
+checksum = "8655f91cd07f2b9d0c24137bd650fe69617773435ee5ec83022377777ce65ef1"
 dependencies = [
  "subtle",
  "typenum",
@@ -5832,7 +5853,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -5974,7 +5995,7 @@ dependencies = [
  "resvg",
  "rowan",
  "rspolib",
- "smol_str 0.3.2",
+ "smol_str 0.3.6",
  "strum 0.27.2",
  "typed-index-collections",
  "url",
@@ -6130,7 +6151,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -6259,9 +6280,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.25.9"
+version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
@@ -6277,8 +6298,8 @@ dependencies = [
  "rayon",
  "rgb",
  "tiff",
- "zune-core 0.5.1",
- "zune-jpeg 0.5.12",
+ "zune-core",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -6566,7 +6587,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6758,9 +6779,9 @@ checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libcrux-aead"
@@ -7043,6 +7064,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7199,9 +7230,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lyon_algorithms"
-version = "1.0.16"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c0829e28c4f336396f250d850c3987e16ce6db057ffe047ce0dd54aab6b647"
+checksum = "9815fac08e6fd96733a11dce4f9d15a3f338e96a2e2311ee21e1b738efc2bc0f"
 dependencies = [
  "lyon_path",
  "num-traits",
@@ -7209,19 +7240,19 @@ dependencies = [
 
 [[package]]
 name = "lyon_extra"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ca94c7bf1e2557c2798989c43416822c12fc5dcc5e17cc3307ef0e71894a955"
+checksum = "7755f08423275157ad1680aaecc9ccb7e0cc633da3240fea2d1522935cc15c72"
 dependencies = [
  "lyon_path",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "lyon_geom"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e260b6de923e6e47adfedf6243013a7a874684165a6a277594ee3906021b2343"
+checksum = "4336502e29e32af93cf2dad2214ed6003c17ceb5bd499df77b1de663b9042b92"
 dependencies = [
  "arrayvec",
  "euclid",
@@ -7230,9 +7261,9 @@ dependencies = [
 
 [[package]]
 name = "lyon_path"
-version = "1.0.16"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aeca86bcfd632a15984ba029b539ffb811e0a70bf55e814ef8b0f54f506fdeb"
+checksum = "5c463f9c428b7fc5ec885dcd39ce4aa61e29111d0e33483f6f98c74e89d8621e"
 dependencies = [
  "lyon_geom",
  "num-traits",
@@ -7475,9 +7506,9 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
+checksum = "f58d964098a5f9c6b63d0798e5372fd04708193510a7af313c22e9f29b7b620b"
 dependencies = [
  "cfg-if",
  "downcast",
@@ -7489,9 +7520,9 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
+checksum = "ca41ce716dda6a9be188b385aa78ee5260fc25cd3802cb2a8afdc6afbe6b6dbf"
 dependencies = [
  "cfg-if",
  "proc-macro2",
@@ -7537,9 +7568,9 @@ dependencies = [
 
 [[package]]
 name = "moxcms"
-version = "0.7.11"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
@@ -7590,12 +7621,13 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "napi"
-version = "3.4.0"
+version = "3.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a1135cfe16ca43ac82ac05858554fc39c037d8e4592f2b4a83d7ef8e822f43"
+checksum = "e6944d0bf100571cd6e1a98a316cdca262deb6fccf8d93f5ae1502ca3fc88bd3"
 dependencies = [
  "bitflags 2.11.0",
  "ctor",
+ "futures",
  "napi-build",
  "napi-sys",
  "nohash-hasher",
@@ -7607,17 +7639,17 @@ dependencies = [
 
 [[package]]
 name = "napi-build"
-version = "2.2.4"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae82775d1b06f3f07efd0666e59bbc175da8383bc372051031d7a447e94fbea"
+checksum = "d376940fd5b723c6893cd1ee3f33abbfd86acb1cd1ec079f3ab04a2a3bc4d3b1"
 
 [[package]]
 name = "napi-derive"
-version = "3.3.0"
+version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78665d6bdf10e9a4e6b38123efb0f66962e6197c1aea2f07cff3f159a374696d"
+checksum = "2c914b5e420182bfb73504e0607592cdb8e2e21437d450883077669fb72a114d"
 dependencies = [
- "convert_case 0.8.0",
+ "convert_case 0.11.0",
  "ctor",
  "napi-derive-backend",
  "proc-macro2",
@@ -7627,11 +7659,11 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "3.0.0"
+version = "5.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d55d01423e7264de3acc13b258fa48ca7cf38a4d25db848908ec3c1304a85a"
+checksum = "f0864cf6a82e2cfb69067374b64c9253d7e910e5b34db833ed7495dda56ccb18"
 dependencies = [
- "convert_case 0.8.0",
+ "convert_case 0.11.0",
  "proc-macro2",
  "quote",
  "semver 1.0.27",
@@ -7640,11 +7672,11 @@ dependencies = [
 
 [[package]]
 name = "napi-sys"
-version = "3.0.1"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ed8f0e23a62a3ce0fbb6527cdc056e9282ddd9916b068c46f8923e18eed5ee6"
+checksum = "8eb602b84d7c1edae45e50bbf1374696548f36ae179dfa667f577e384bb90c2b"
 dependencies = [
- "libloading",
+ "libloading 0.9.0",
 ]
 
 [[package]]
@@ -7747,7 +7779,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7850,9 +7882,9 @@ dependencies = [
 
 [[package]]
 name = "nybbles"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5676b5c379cf5b03da1df2b3061c4a4e2aa691086a56ac923e08c143f53f59"
+checksum = "0d49ff0c0d00d4a502b39df9af3a525e1efeb14b9dabb5bb83335284c1309210"
 dependencies = [
  "alloy-rlp",
  "cfg-if",
@@ -8457,7 +8489,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8495,6 +8527,16 @@ checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
 dependencies = [
  "elliptic-curve",
  "primeorder",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -8699,9 +8741,9 @@ checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
 name = "pbjson"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898bac3fa00d0ba57a4e8289837e965baa2dee8c3749f3b11d45a64b4223d9c3"
+checksum = "e8edd1efdd8ab23ba9cb9ace3d9987a72663d5d7c9f74fa00b51d6213645cf6c"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -8709,9 +8751,9 @@ dependencies = [
 
 [[package]]
 name = "pbjson-build"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af22d08a625a2213a78dbb0ffa253318c5c79ce3133d32d296655a7bdfb02095"
+checksum = "2ed4d5c6ae95e08ac768883c8401cf0e8deb4e6e1d6a4e1fd3d2ec4f0ec63200"
 dependencies = [
  "heck 0.5.0",
  "itertools 0.14.0",
@@ -8721,9 +8763,9 @@ dependencies = [
 
 [[package]]
 name = "pbjson-types"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e748e28374f10a330ee3bb9f29b828c0ac79831a32bab65015ad9b661ead526"
+checksum = "a14e2757d877c0f607a82ce1b8560e224370f159d66c5d52eb55ea187ef0350e"
 dependencies = [
  "bytes",
  "chrono",
@@ -8828,7 +8870,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
- "siphasher 1.0.2",
+ "siphasher",
 ]
 
 [[package]]
@@ -9206,7 +9248,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -9347,7 +9389,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -9356,9 +9398,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -9384,9 +9426,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9572,9 +9614,9 @@ dependencies = [
 
 [[package]]
 name = "ravif"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef69c1990ceef18a116855938e74793a5f7496ee907562bd0857b6ac734ab285"
+checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
 dependencies = [
  "avif-serialize",
  "imgref",
@@ -9636,9 +9678,9 @@ dependencies = [
 
 [[package]]
 name = "redb"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae323eb086579a3769daa2c753bb96deb95993c534711e0dbe881b5192906a06"
+checksum = "ef99362319c782aa4639ad3a306b64c3bb90e12874e99b8df124cb679d988611"
 dependencies = [
  "libc",
  "log",
@@ -9800,7 +9842,6 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
- "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -9820,6 +9861,44 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -9829,7 +9908,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -9846,7 +9924,7 @@ dependencies = [
  "svgtypes",
  "tiny-skia",
  "usvg",
- "zune-jpeg 0.5.12",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -10111,7 +10189,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10150,6 +10228,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -10215,9 +10320,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -10499,15 +10604,6 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_spanned"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
@@ -10723,12 +10819,6 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
-
-[[package]]
-name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
@@ -10739,7 +10829,7 @@ version = "0.90.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f6f96e00735f14a781aac8a6870c862b8cc831df6d8e4ad77ab78e11411b9af"
 dependencies = [
- "bindgen 0.72.1",
+ "bindgen",
  "cc",
  "flate2",
  "heck 0.5.0",
@@ -10922,12 +11012,12 @@ dependencies = [
 
 [[package]]
 name = "smol_str"
-version = "0.3.2"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9676b89cd56310a87b93dec47b11af744f34d5fc9f367b829474eec0a891350d"
+checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
 dependencies = [
  "borsh",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -10945,7 +11035,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11159,7 +11249,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "695b5790b3131dafa99b3bbfd25a216edb3d216dad9ca208d4657bfb8f2abc3d"
 dependencies = [
  "kurbo 0.13.0",
- "siphasher 1.0.2",
+ "siphasher",
 ]
 
 [[package]]
@@ -11293,7 +11383,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11387,16 +11477,16 @@ dependencies = [
 
 [[package]]
 name = "tiff"
-version = "0.10.3"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9605de7fee8d9551863fd692cce7637f548dbd9db9180fcc07ccc6d26c336f"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
 dependencies = [
  "fax",
  "flate2",
  "half",
  "quick-error 2.0.1",
  "weezl",
- "zune-jpeg 0.4.21",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -11434,9 +11524,9 @@ dependencies = [
 
 [[package]]
 name = "timeago"
-version = "0.4.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1710e589de0a76aaf295cd47a6699f6405737dbfd3cf2b75c92d000b548d0e6"
+checksum = "e86660b0935ca5912eb155f5b3794e2f8f1a09d8c00c9efd5c1075ca26403638"
 dependencies = [
  "chrono",
  "isolang",
@@ -11476,7 +11566,7 @@ checksum = "0324504befd01cab6e0c994f34b2ffa257849ee019d3fb3b64fb2c858887d89e"
 dependencies = [
  "as-raw-xcb-connection",
  "ctor-lite",
- "libloading",
+ "libloading 0.8.9",
  "pkg-config",
  "tracing",
 ]
@@ -11618,9 +11708,9 @@ dependencies = [
 
 [[package]]
 name = "tokio_with_wasm"
-version = "0.8.8"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34e40fbbbd95441133fe9483f522db15dbfd26dc636164ebd8f2dd28759a6aa6"
+checksum = "ef3ce6a8f5b5190dfe4851db6c969e8360a262759e16a0b75dfc43af19d97a86"
 dependencies = [
  "js-sys",
  "tokio",
@@ -11632,33 +11722,12 @@ dependencies = [
 
 [[package]]
 name = "tokio_with_wasm_proc"
-version = "0.8.8"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01145a2c788d6aae4cd653afec1e8332534d7d783d01897cefcafe4428de992"
+checksum = "1d8aa1d26c1550eef93cfb2dafadc145b3220432dae8d156b5ba485880594ffe"
 dependencies = [
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -11669,7 +11738,7 @@ checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap 2.13.0",
  "serde_core",
- "serde_spanned 1.0.4",
+ "serde_spanned",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -11677,12 +11746,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.6.11"
+name = "toml"
+version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+checksum = "399b1124a3c9e16766831c6bba21e50192572cdd98706ea114f9502509686ffc"
 dependencies = [
- "serde",
+ "indexmap 2.13.0",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 1.0.0+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -11701,20 +11776,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap 2.13.0",
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow",
 ]
 
 [[package]]
@@ -11750,12 +11811,6 @@ checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -11836,9 +11891,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-web-wasm-client"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898cd44be5e23e59d2956056538f1d6b3c5336629d384ffd2d92e76f87fb98ff"
+checksum = "e8e21e20b94f808d6f2244a5d960d02c28dd82066abddd2f27019bac0535f310"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -12025,15 +12080,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-oslog"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528bdd1f0e27b5dd9a4ededf154e824b0532731e4af73bb531de46276e0aab1e"
+checksum = "d76902d2a8d5f9f55a81155c08971734071968c90f2d9bfe645fe700579b2950"
 dependencies = [
- "bindgen 0.70.1",
  "cc",
  "cfg-if",
- "once_cell",
- "parking_lot 0.12.5",
  "tracing-core",
  "tracing-subscriber",
 ]
@@ -12201,9 +12253,9 @@ dependencies = [
 
 [[package]]
 name = "typed-index-collections"
-version = "3.3.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd393dbd1e7b23e0cab7396570309b4068aa504e9dac2cd41d827583b4e9ab7"
+checksum = "898160f1dfd383b4e92e17f0512a7d62f3c51c44937b23b6ffc3a1614a8eaccd"
 dependencies = [
  "bincode 2.0.1",
  "serde",
@@ -12269,7 +12321,7 @@ checksum = "51b70b87d15e91f553711b40df3048faf27a7a04e01e0ddc0cf9309f0af7c2ca"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12379,9 +12431,9 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "uniffi"
-version = "0.29.5"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3291800a6b06569f7d3e15bdb6dc235e0f0c8bd3eb07177f430057feb076415f"
+checksum = "b8c6dec3fc6645f71a16a3fa9ff57991028153bd194ca97f4b55e610c73ce66a"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -12394,9 +12446,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.29.5"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a04b99fa7796eaaa7b87976a0dbdd1178dc1ee702ea00aca2642003aef9b669e"
+checksum = "4ed0150801958d4825da56a41c71f000a457ac3a4613fa9647df78ac4b6b6881"
 dependencies = [
  "anyhow",
  "askama",
@@ -12411,7 +12463,7 @@ dependencies = [
  "serde",
  "tempfile",
  "textwrap",
- "toml 0.5.11",
+ "toml 0.9.12+spec-1.1.0",
  "uniffi_internal_macros",
  "uniffi_meta",
  "uniffi_pipeline",
@@ -12421,9 +12473,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.29.5"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025a05cba02ee22b6624ac3d257e59c7395319ea8fe1aae33a7cdb4e2a3016cc"
+checksum = "b78fd9271a4c2e85bd2c266c5a9ede1fac676eb39fd77f636c27eaf67426fd5f"
 dependencies = [
  "anyhow",
  "camino",
@@ -12432,9 +12484,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_core"
-version = "0.29.5"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38a9a27529ccff732f8efddb831b65b1e07f7dea3fd4cacd4a35a8c4b253b98"
+checksum = "b0ef62e69762fbb9386dcb6c87cd3dd05d525fa8a3a579a290892e60ddbda47e"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -12445,9 +12497,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_internal_macros"
-version = "0.29.5"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09acd2ce09c777dd65ee97c251d33c8a972afc04873f1e3b21eb3492ade16933"
+checksum = "98f51ebca0d9a4b2aa6c644d5ede45c56f73906b96403c08a1985e75ccb64a01"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -12458,9 +12510,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.29.5"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5596f178c4f7aafa1a501c4e0b96236a96bc2ef92bdb453d83e609dad0040152"
+checksum = "db9d12529f1223d014fd501e5f29ca0884d15d6ed5ddddd9f506e55350327dc3"
 dependencies = [
  "camino",
  "fs-err",
@@ -12469,27 +12521,27 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.117",
- "toml 0.5.11",
+ "toml 0.9.12+spec-1.1.0",
  "uniffi_meta",
 ]
 
 [[package]]
 name = "uniffi_meta"
-version = "0.29.5"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beadc1f460eb2e209263c49c4f5b19e9a02e00a3b2b393f78ad10d766346ecff"
+checksum = "9df6d413db2827c68588f8149d30d49b71d540d46539e435b23a7f7dbd4d4f86"
 dependencies = [
  "anyhow",
- "siphasher 0.3.11",
+ "siphasher",
  "uniffi_internal_macros",
  "uniffi_pipeline",
 ]
 
 [[package]]
 name = "uniffi_pipeline"
-version = "0.29.5"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd76b3ac8a2d964ca9fce7df21c755afb4c77b054a85ad7a029ad179cc5abb8a"
+checksum = "a806dddc8208f22efd7e95a5cdf88ed43d0f3271e8f63b47e757a8bbdb43b63a"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -12500,9 +12552,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_testing"
-version = "0.29.5"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de559b1c057a704080f320c204dfe611c68034c801fc9b86a83d36b565ca7482"
+checksum = "4802bed208a296657eef3451a961a6502e1d7aa8930b4b0cd952ed4f81a3957e"
 dependencies = [
  "anyhow",
  "camino",
@@ -12513,9 +12565,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.29.5"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4319cf905911d70d5b97ce0f46f101619a22e9a189c8c46d797a9955e9233716"
+checksum = "0d1a7339539bf6f6fa3e9b534dece13f778bda2d54b1a6d4e40b4d6090ac26e7"
 dependencies = [
  "anyhow",
  "textwrap",
@@ -12587,7 +12639,7 @@ dependencies = [
  "roxmltree",
  "rustybuzz",
  "simplecss",
- "siphasher 1.0.2",
+ "siphasher",
  "strict-num",
  "svgtypes",
  "tiny-skia-path",
@@ -12808,11 +12860,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
- "wit-bindgen 0.46.0",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -12821,7 +12873,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -12946,9 +12998,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -13139,6 +13191,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13184,7 +13245,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13826,12 +13887,6 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
-
-[[package]]
-name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
@@ -14007,7 +14062,7 @@ dependencies = [
  "as-raw-xcb-connection",
  "gethostname",
  "libc",
- "libloading",
+ "libloading 0.8.9",
  "once_cell",
  "rustix 1.1.4",
  "x11rb-protocol",
@@ -14059,7 +14114,7 @@ checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
 
 [[package]]
 name = "xdbg"
-version = "0.1.0"
+version = "1.9.0"
 dependencies = [
  "alloy",
  "chrono",
@@ -14192,7 +14247,6 @@ dependencies = [
  "bitflags 2.11.0",
  "byteorder",
  "bytes",
- "camino",
  "cc",
  "chrono",
  "cipher",
@@ -14211,7 +14265,6 @@ dependencies = [
  "futures-core",
  "futures-executor",
  "futures-io",
- "futures-timer",
  "futures-util",
  "generic-array",
  "getrandom 0.4.2",
@@ -14221,7 +14274,6 @@ dependencies = [
  "idna",
  "indexmap 2.13.0",
  "itertools 0.14.0",
- "js-sys",
  "k256",
  "libc",
  "libcrux-ed25519",
@@ -14246,15 +14298,17 @@ dependencies = [
  "regex",
  "regex-automata",
  "regex-syntax",
- "reqwest 0.12.28",
  "ruint",
  "rustc-hash 2.1.1",
  "rustls",
+ "rustls-pki-types",
+ "rustls-webpki",
  "sec1",
- "semver 1.0.27",
+ "security-framework-sys",
  "serde",
  "serde_core",
  "serde_json",
+ "serde_spanned",
  "sha1",
  "sha3 0.10.8",
  "slab",
@@ -14266,6 +14320,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-stream",
  "tokio-util",
+ "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
  "tonic",
  "tower",
@@ -14273,11 +14328,7 @@ dependencies = [
  "tracing-core",
  "tracing-subscriber",
  "typenum",
- "uniffi",
- "uniffi_bindgen",
- "uniffi_core",
  "url",
- "wasm-bindgen",
  "winnow",
  "zerocopy",
 ]
@@ -14291,7 +14342,6 @@ dependencies = [
  "const-hex",
  "ctor",
  "futures",
- "futures-timer",
  "http 1.4.0",
  "prost",
  "thiserror 2.0.18",
@@ -14321,7 +14371,6 @@ dependencies = [
  "derive_builder",
  "futures",
  "futures-test",
- "futures-timer",
  "http 1.4.0",
  "hyper 1.8.1",
  "impl-trait-for-tuples",
@@ -14398,7 +14447,7 @@ dependencies = [
  "openmls",
  "pin-project",
  "prost",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "serde_json",
  "sha2",
  "thiserror 2.0.18",
@@ -14524,7 +14573,9 @@ dependencies = [
  "alloy",
  "bincode 1.3.3",
  "const-hex",
+ "ctor",
  "ed25519-dalek",
+ "futures-timer",
  "getrandom 0.2.17",
  "getrandom 0.3.4",
  "getrandom 0.4.2",
@@ -14534,6 +14585,7 @@ dependencies = [
  "openmls_traits",
  "rand 0.10.0",
  "rand_chacha 0.10.0",
+ "rustls",
  "serde",
  "sha2",
  "thiserror 2.0.18",
@@ -14558,7 +14610,6 @@ dependencies = [
  "diesel_migrations",
  "dyn-clone",
  "futures",
- "futures-timer",
  "itertools 0.14.0",
  "libsqlite3-sys",
  "mockall",
@@ -14576,7 +14627,7 @@ dependencies = [
  "sqlite-wasm-vfs",
  "thiserror 2.0.18",
  "tokio",
- "toml 0.8.23",
+ "toml 1.0.6+spec-1.1.0",
  "tracing",
  "wasm-bindgen",
  "wasm-bindgen-test",
@@ -14617,7 +14668,6 @@ dependencies = [
  "ctor",
  "ed25519-dalek",
  "futures",
- "getrandom 0.4.2",
  "gloo-timers 0.3.0",
  "openmls",
  "openmls_traits",
@@ -14675,9 +14725,7 @@ dependencies = [
  "futures",
  "futures-executor",
  "futures-test",
- "futures-timer",
  "futures-util",
- "getrandom 0.4.2",
  "hkdf",
  "hmac",
  "hpke-rs",
@@ -14698,7 +14746,7 @@ dependencies = [
  "prost",
  "public-suffix",
  "rand 0.10.0",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "rstest",
  "rstest_reuse",
  "serde",
@@ -14909,9 +14957,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.13.2"
+version = "5.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfeff997a0aaa3eb20c4652baf788d2dfa6d2839a0ead0b3ff69ce2f9c4bdd1"
+checksum = "ca82f95dbd3943a40a53cfded6c2d0a2ca26192011846a1810c4256ef92c60bc"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -14968,9 +15016,9 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.13.2"
+version = "5.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bbd5a90dbe8feee5b13def448427ae314ccd26a49cac47905cafefb9ff846f1"
+checksum = "897e79616e84aac4b2c46e9132a4f63b93105d54fe8c0e8f6bffc21fa8d49222"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -15012,18 +15060,18 @@ checksum = "6df3dc4292935e51816d896edcd52aa30bc297907c26167fec31e2b0c6a32524"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -15147,12 +15195,6 @@ dependencies = [
 
 [[package]]
 name = "zune-core"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
-
-[[package]]
-name = "zune-core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
@@ -15168,27 +15210,18 @@ dependencies = [
 
 [[package]]
 name = "zune-jpeg"
-version = "0.4.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
-dependencies = [
- "zune-core 0.4.12",
-]
-
-[[package]]
-name = "zune-jpeg"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "410e9ecef634c709e3831c2cfdb8d9c32164fae1c67496d5b68fff728eec37fe"
 dependencies = [
- "zune-core 0.5.1",
+ "zune-core",
 ]
 
 [[package]]
 name = "zvariant"
-version = "5.9.2"
+version = "5.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b64ef4f40c7951337ddc7023dd03528a57a3ce3408ee9da5e948bd29b232c4"
+checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
 dependencies = [
  "endi",
  "enumflags2",
@@ -15201,9 +15234,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "5.9.2"
+version = "5.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "484d5d975eb7afb52cc6b929c13d3719a20ad650fea4120e6310de3fc55e415c"
+checksum = "5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,9 @@ resolver = "3"
 [workspace.package]
 license = "MIT"
 version = "1.9.0"
-rust-version = "1.93.0"
+rust-version = "1.94.0"
+publish = false
+edition = "2024"
 
 [workspace.dependencies]
 aes-gcm = { version = "0.10.3", features = ["std"] }
@@ -47,7 +49,7 @@ color-eyre = "0.6"
 console_error_panic_hook = "0.1"
 const_format = "0.2"
 const_panic = "0.2"
-criterion = { version = "0.7", features = ["html_reports", "async_tokio"] }
+criterion = { version = "0.8.2", features = ["html_reports", "async_tokio"] }
 ctor = "0.6"
 derive_builder = "0.20"
 diesel = { version = "2.3", default-features = false }
@@ -64,11 +66,14 @@ gloo-timers = "0.3"
 hex = { package = "const-hex", version = "1.14" }
 hkdf = "0.12.3"
 hpke-rs = { version = "0.6", features = ["hazmat", "serialization", "libcrux"] }
+http = "1.2"
+hyper = { version = "1.7", default-features = false }
+hyper-util = "0.1"
 indicatif = "0.18"
 itertools = "0.14"
 js-sys = "0.3"
 libcrux-ed25519 = "0.0.6"
-mockall = { version = "0.13" }
+mockall = { version = "0.14" }
 mockall_double = "0.3.1"
 once_cell = "1.2"
 openmls = { git = "https://github.com/xmtp/openmls", rev = "382a4649ae4e937ce933adb259e26d6381745731", default-features = false }
@@ -79,26 +84,39 @@ openmls_traits = { git = "https://github.com/xmtp/openmls", rev = "382a4649ae4e9
 owo-colors = { version = "4.1" }
 p256 = { version = "0.13.2", features = ["ecdsa"] }
 parking_lot = "0.12.3"
-pbjson = "0.8"
-pbjson-types = "0.8"
+pbjson = "0.9"
+pbjson-types = "0.9"
 pin-project = "1.1"
-proptest = { version = "1.9", default-features = false }
+proc-macro2 = "1.0"
+proptest = { version = "1.9", default-features = false, features = ["std"] }
 prost = { version = "0.14", default-features = false }
 prost-types = { version = "0.14", default-features = false }
-# updating crates are blocked on https://github.com/dalek-cryptography/curve25519-dalek/pull/729
+quote = "1.0"
 rand = "0.10.0"
 rand_chacha = "0.10.0"
 regex = "1.10.4"
-reqwest = { version = "0.12.12", default-features = false, features = [
-  "rustls-tls",
+reqwest = { version = "0.13.2", default-features = false, features = [
+  "rustls-no-provider",
   "json",
   "stream",
 ] }
 rstest = "0.26"
 rstest_reuse = "0.7.0"
-serde = { version = "1.0", default-features = false }
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
+serde-wasm-bindgen = "0.6.5"
+serde_bytes = "0.11"
 serde_json = { version = "1.0", default-features = false }
 sha2 = "0.10.8"
+syn = { version = "2.0", features = [
+  "parsing",
+  "proc-macro",
+  "derive",
+  "printing",
+  "full",
+  "clone-impls",
+  "extra-traits",
+] }
 thiserror = "2.0"
 tls_codec = "0.4.1"
 tokio = { version = "1.47.0", default-features = false }
@@ -106,18 +124,23 @@ tokio-stream = { version = "0.1", default-features = false }
 tokio-util = { version = "0.7", default-features = false, features = [
   "compat",
 ] }
+toml = "1.0.1"
 tonic = { version = "0.14", default-features = false }
-tonic-web-wasm-client = "0.8"
+tonic-web-wasm-client = "0.9"
 tower = { version = "0.5", default-features = false }
 toxiproxy_rust = { git = "https://github.com/ephemeraHQ/toxiproxy_rust.git" }
 tracing = { version = "0.1", features = ["log"] }
 tracing-forest = { version = "0.3", features = ["chrono"] }
 tracing-logfmt = "0.3"
 tracing-subscriber = { version = "0.3", default-features = false }
+tracing-web = "0.1"
 trait-variant = "0.1.2"
+tsify = { version = "0.5", default-features = false, features = ["js"] }
 url = "2.5.0"
 uuid = "1.12"
+valuable = { version = "0.1", features = ["derive"] }
 vergen-gix = "9.1"
+wasm-streams = "0.5"
 # zstd = { default-features = false, version = "0.13" } # needed to enable wasm feature for async-compression
 
 # Any changes here need to be made with corresponding changes in .github/workflows
@@ -134,7 +157,7 @@ zeroize = "1.8"
 # Internal Crate Dependencies
 bindings-wasm = { path = "bindings/wasm" }
 bindings_wasm_macros = { path = "crates/wasm_macros" }
-xmtp-workspace-hack = "0.1.0"
+xmtp-workspace-hack = { path = "crates/xmtp-workspace-hack" }
 xmtp_api = { path = "crates/xmtp_api" }
 xmtp_api_d14n = { path = "crates/xmtp_api_d14n" }
 xmtp_api_grpc = { path = "crates/xmtp_api_grpc" }

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -1,13 +1,18 @@
 [package]
 default-run = "xmtp_cli"
-edition = "2024"
 keywords = ["xmtp", "messaging", "web3", "group-chat"]
-license.workspace = true
 name = "xmtp_cli"
+description = "cli that can send and receive messages on XMTP"
 readme = "README.md"
 repository = "https://github.com/xmtp/libxmtp"
+license.workspace = true
 version.workspace = true
-description = "cli that can send and receive messages on XMTP"
+rust-version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "xmtp_cli"
@@ -20,13 +25,13 @@ clap.workspace = true
 color-eyre = "0.6"
 futures.workspace = true
 hex.workspace = true
-openmls = { workspace = true }
+openmls.workspace = true
 owo-colors.workspace = true
 prost.workspace = true
-serde = { workspace = true, features = ["derive"] }
+serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-timeago = "0.4.1"
+timeago = "0.6.0"
 tokio.workspace = true
 tracing = { workspace = true, features = ["valuable"] }
 tracing-subscriber = { workspace = true, features = [
@@ -36,14 +41,14 @@ tracing-subscriber = { workspace = true, features = [
   "ansi",
   "chrono",
 ] }
-valuable = { version = "0.1", features = ["derive"] }
-xmtp_api = { workspace = true }
+valuable.workspace = true
+xmtp_api.workspace = true
 xmtp_api_d14n.workspace = true
 xmtp_common.workspace = true
 xmtp_configuration.workspace = true
-xmtp_content_types = { workspace = true }
-xmtp_cryptography = { workspace = true }
-xmtp_db = { workspace = true }
-xmtp_id = { workspace = true }
-xmtp_mls = { workspace = true }
-xmtp_proto = { workspace = true }
+xmtp_content_types.workspace = true
+xmtp_cryptography.workspace = true
+xmtp_db.workspace = true
+xmtp_id.workspace = true
+xmtp_mls.workspace = true
+xmtp_proto.workspace = true

--- a/apps/db_tools/Cargo.toml
+++ b/apps/db_tools/Cargo.toml
@@ -1,9 +1,14 @@
 [package]
 name = "xmtp-db-tools"
-edition = "2024"
+description = "migration/SQLite tools for xmtp databases"
 license.workspace = true
 version.workspace = true
-description = "migration/SQLite tools for xmtp databases"
+rust-version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 anyhow.workspace = true
@@ -20,9 +25,6 @@ xmtp_db.workspace = true
 [dev-dependencies]
 tokio.workspace = true
 xmtp_mls = { workspace = true, features = ["test-utils"] }
-
-[lints]
-workspace = true
 
 [features]
 default = []

--- a/apps/log_parser/Cargo.toml
+++ b/apps/log_parser/Cargo.toml
@@ -1,8 +1,14 @@
 [package]
 name = "log_parser"
-edition = "2024"
+description = "log parser for xmtp"
 license.workspace = true
 version.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 anyhow.workspace = true
@@ -22,9 +28,6 @@ xmtp_mls = { workspace = true, features = ["test-utils"] }
 
 [build-dependencies]
 slint-build = "1.14.1"
-
-[lints]
-workspace = true
 
 [dev-dependencies]
 tokio.workspace = true

--- a/apps/mls_validation_service/Cargo.toml
+++ b/apps/mls_validation_service/Cargo.toml
@@ -1,10 +1,15 @@
 [package]
-build = "build.rs"
-edition = "2024"
 name = "mls_validation_service"
-version.workspace = true
-license.workspace = true
 description = "backend validation service for XMTP"
+build = "build.rs"
+license.workspace = true
+version.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
 
 [[bin]] # Bin to run the Validation Service
 name = "mls-validation-service"
@@ -17,14 +22,14 @@ vergen-gix = { workspace = true, features = ["build"] }
 alloy.workspace = true
 async-trait.workspace = true
 clap.workspace = true
-futures = { workspace = true }
+futures.workspace = true
 lru = "0.16.0"
-openmls = { workspace = true }
-openmls_rust_crypto = { workspace = true }
+openmls.workspace = true
+openmls_rust_crypto.workspace = true
 parking_lot.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["signal", "rt-multi-thread"] }
-tonic = { workspace = true }
+tonic.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter", "ansi"] }
 warp = "0.3.6"
@@ -38,7 +43,7 @@ xmtp_proto = { workspace = true, features = ["grpc_server_impls"] }
 
 
 [dev-dependencies]
-rand = { workspace = true }
+rand.workspace = true
 rstest.workspace = true
 xmtp_common = { workspace = true, features = ["test-utils"] }
 xmtp_configuration = { workspace = true, features = ["test-utils"] }

--- a/apps/mls_validation_service/src/main.rs
+++ b/apps/mls_validation_service/src/main.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 mod cached_signature_verifier;
 mod config;
 mod handlers;

--- a/apps/xmtp_debug/Cargo.toml
+++ b/apps/xmtp_debug/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "xdbg"
 description = "Debug and Inspection Tool for the XMTP Network"
-edition = "2024"
-version = "0.1.0"
 license.workspace = true
+version.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true
@@ -37,8 +39,8 @@ owo-colors.workspace = true
 prost.workspace = true
 rand.workspace = true
 redb = { version = "3.1", features = ["logging"] }
-serde = { workspace = true, features = ["derive"] }
-serde_json = "1.0"
+serde.workspace = true
+serde_json.workspace = true
 speedy = "0.8"
 tempfile = "3.15"
 thiserror.workspace = true

--- a/bindings/mobile/Cargo.toml
+++ b/bindings/mobile/Cargo.toml
@@ -1,9 +1,14 @@
 [package]
-edition = "2024"
 name = "xmtpv3"
-version.workspace = true
-license.workspace = true
 description = "iOS/Android bindings to the XMTP mls libraries"
+license.workspace = true
+version.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
 
 [lib]
 crate-type = ["lib", "cdylib", "staticlib"]
@@ -26,7 +31,7 @@ tracing-subscriber = { workspace = true, features = [
   "fmt",
   "json",
 ] }
-uniffi = { version = "0.29.0", default-features = false, features = ["tokio"] }
+uniffi = { version = "0.31.0", default-features = false, features = ["tokio"] }
 xmtp_api.workspace = true
 xmtp_api_d14n.workspace = true
 xmtp_api_grpc.workspace = true
@@ -51,10 +56,10 @@ paranoid-android = "0.2"
 tracing_android_trace = "0.1"
 
 [target.'cfg(target_os = "ios")'.dependencies]
-tracing-oslog = "0.2"
+tracing-oslog = "0.3"
 
 [build-dependencies]
-uniffi = { version = "0.29.0", features = ["build"] }
+uniffi = { version = "0.31.0", features = ["build"] }
 vergen-gix = { workspace = true, features = ["build"] }
 
 [[bin]]
@@ -70,12 +75,12 @@ required-features = ["uniffi/cli"]
 [dev-dependencies]
 alloy.workspace = true
 async-trait.workspace = true
-chrono = { workspace = true }
+chrono.workspace = true
 ctor.workspace = true
-fdlimit = { workspace = true }
+fdlimit.workspace = true
 rand.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }
-uniffi = { version = "0.29.0", features = ["bindgen-tests"] }
+uniffi = { version = "0.31.0", features = ["bindgen-tests"] }
 uuid = { workspace = true, features = ["v4", "fast-rng"] }
 xmtp_api_grpc = { workspace = true, features = ["test-utils"] }
 xmtp_archive = { workspace = true, features = ["test-utils"] }
@@ -102,6 +107,3 @@ dev = ["xmtp_configuration/dev", "xmtp_mls/dev"]
 harness = false
 name = "create_client"
 required-features = ["bench"]
-
-[lints]
-workspace = true

--- a/bindings/node/Cargo.toml
+++ b/bindings/node/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
-edition = "2024"
 name = "bindings_node"
-version.workspace = true
 description = "nodeJS bindings to the XMTP mls libraries"
 license.workspace = true
+version.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
-edition = "2024"
 name = "bindings_wasm"
-version.workspace = true
 description = "WebAssembly bindings to the XMTP mls libraries"
 license.workspace = true
+version.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true
@@ -17,6 +19,7 @@ xmtp_common = { workspace = true, features = ["logging"] }
 
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
+alloy = { workspace = true, optional = true }
 async-trait.workspace = true
 bindings_wasm_macros.workspace = true
 chrono.workspace = true
@@ -26,18 +29,19 @@ hex.workspace = true
 js-sys.workspace = true
 pin-project.workspace = true
 prost.workspace = true
-serde = { workspace = true, features = ["derive"] }
-serde-wasm-bindgen = "0.6.5"
-serde_bytes = "0.11"
+serde.workspace = true
+serde-wasm-bindgen.workspace = true
+serde_bytes.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tracing = { workspace = true, features = ["release_max_level_debug"] }
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
-tracing-web = "0.1"
-tsify = { version = "0.5", default-features = false, features = ["js"] }
+tracing-web.workspace = true
+tsify.workspace = true
 wasm-bindgen.workspace = true
 wasm-bindgen-futures.workspace = true
-wasm-streams = { version = "0.4" }
+wasm-bindgen-test = { workspace = true, optional = true }
+wasm-streams.workspace = true
 web-sys = { workspace = true, features = [
   "Window",
   "DomException",
@@ -52,16 +56,12 @@ xmtp_cryptography.workspace = true
 xmtp_db.workspace = true
 xmtp_id.workspace = true
 xmtp_macro.workspace = true
-xmtp_mls = { workspace = true }
-xmtp_proto = { workspace = true }
-
-alloy = { workspace = true, optional = true }
-wasm-bindgen-test = { workspace = true, optional = true }
-
+xmtp_mls.workspace = true
+xmtp_proto.workspace = true
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dev-dependencies]
 alloy.workspace = true
-chrono = { workspace = true }
+chrono.workspace = true
 tokio.workspace = true
 wasm-bindgen-test.workspace = true
 xmtp_common = { workspace = true, features = ["test-utils"] }

--- a/bindings/wasm/src/lib.rs
+++ b/bindings/wasm/src/lib.rs
@@ -1,6 +1,5 @@
-#![recursion_limit = "256"]
-
 //! This crate only compiles for webassembly
+#![recursion_limit = "256"]
 
 xmtp_common::if_wasm! {
     pub mod client;

--- a/crates/wasm_macros/Cargo.toml
+++ b/crates/wasm_macros/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "bindings_wasm_macros"
+description = "utility macros for webassembly bindings"
 license.workspace = true
 version.workspace = true
-edition = "2024"
-description = "utility macros for webassembly bindings"
+rust-version.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [lib]
 proc-macro = true
@@ -12,7 +14,7 @@ proc-macro = true
 workspace = true
 
 [dependencies]
-proc-macro2 = "1.0"
-quote = "1.0"
-syn = { version = "2.0", features = ["full", "extra-traits"] }
+proc-macro2.workspace = true
+quote.workspace = true
+syn.workspace = true
 xmtp-workspace-hack.workspace = true

--- a/crates/xmtp-workspace-hack/Cargo.toml
+++ b/crates/xmtp-workspace-hack/Cargo.toml
@@ -4,12 +4,14 @@
 
 [package]
 name = "xmtp-workspace-hack"
-version = "0.1.0"
-edition = "2021"
 description = "workspace-hack package, managed by hakari"
+license.workspace = true
+# must stay at 0.1.0 so that `cargo hakari manage-deps` doesn't want to update all the crates dependencies
+version = "0.1.0"
+rust-version.workspace = true
+edition.workspace = true
 # You can choose to publish this crate: see https://docs.rs/cargo-hakari/latest/cargo_hakari/publishing.
 publish = ["crates-io"]
-license.workspace = true
 
 # The parts of the file between the BEGIN HAKARI SECTION and END HAKARI SECTION comments
 # are managed by hakari.
@@ -28,7 +30,6 @@ alloy-sol-type-parser = { version = "1", default-features = false, features = ["
 alloy-sol-types = { version = "1", default-features = false, features = ["json", "std"] }
 alloy-transport-http = { version = "1", default-features = false, features = ["reqwest", "reqwest-rustls-tls"] }
 bytes = { version = "1", features = ["serde"] }
-camino = { version = "1", default-features = false, features = ["serde1"] }
 chrono = { version = "0.4", features = ["serde"] }
 cipher = { version = "0.4", default-features = false, features = ["zeroize"] }
 clap = { version = "4", features = ["derive"] }
@@ -45,7 +46,6 @@ futures-channel = { version = "0.3", features = ["sink"] }
 futures-core = { version = "0.3" }
 futures-executor = { version = "0.3" }
 futures-io = { version = "0.3" }
-futures-timer = { version = "3", default-features = false, features = ["wasm-bindgen"] }
 futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
 generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "zeroize"] }
 hashbrown = { version = "0.16", features = ["serde"] }
@@ -53,7 +53,6 @@ hpke-rs = { version = "0.6", features = ["hazmat", "libcrux", "serialization"] }
 idna = { version = "1" }
 indexmap = { version = "2", features = ["serde"] }
 itertools = { version = "0.14" }
-js-sys = { version = "0.3" }
 k256 = { version = "0.13", default-features = false, features = ["ecdh", "ecdsa", "std"] }
 libcrux-ed25519 = { version = "0.0.6", default-features = false, features = ["rand"] }
 log = { version = "0.4", default-features = false, features = ["std"] }
@@ -76,14 +75,13 @@ rand_core = { version = "0.9", default-features = false, features = ["os_rng", "
 regex = { version = "1" }
 regex-automata = { version = "0.4", default-features = false, features = ["dfa-build", "dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
 regex-syntax = { version = "0.8" }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 ruint = { version = "1", default-features = false, features = ["alloy-rlp", "rand-09", "serde", "std"] }
 rustc-hash = { version = "2", features = ["rand"] }
 sec1 = { version = "0.7", features = ["pem", "serde", "std", "subtle"] }
-semver = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["alloc", "derive", "rc"] }
-serde_core = { version = "1", features = ["alloc", "rc"] }
-serde_json = { version = "1", features = ["alloc", "preserve_order", "raw_value", "unbounded_depth"] }
+serde_core = { version = "1", default-features = false, features = ["alloc", "rc", "result", "std"] }
+serde_json = { version = "1", features = ["alloc", "preserve_order", "raw_value"] }
+serde_spanned = { version = "1", default-features = false, features = ["serde", "std"] }
 sha1 = { version = "0.10", features = ["compress"] }
 sha3 = { version = "0.10", default-features = false, features = ["asm", "std"] }
 slab = { version = "0.4" }
@@ -93,17 +91,14 @@ sync_wrapper = { version = "1", default-features = false, features = ["futures"]
 time = { version = "0.3", features = ["formatting", "local-offset", "parsing"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = { version = "0.7", features = ["codec", "compat", "io"] }
+toml_datetime = { version = "1", features = ["serde"] }
 toml_parser = { version = "1" }
 tonic = { version = "0.14", default-features = false, features = ["codegen"] }
 tracing = { version = "0.1", features = ["log", "release_max_level_debug"] }
 tracing-core = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["chrono", "env-filter", "json"] }
 typenum = { version = "1", default-features = false, features = ["const-generics"] }
-uniffi = { version = "0.29", features = ["bindgen-tests", "build", "tokio"] }
-uniffi_bindgen = { version = "0.29", features = ["bindgen-tests"] }
-uniffi_core = { version = "0.29", features = ["tokio"] }
 url = { version = "2", features = ["serde"] }
-wasm-bindgen = { version = "0.2" }
 winnow = { version = "0.7", features = ["simd"] }
 zerocopy = { version = "0.8", default-features = false, features = ["derive", "simd"] }
 
@@ -123,7 +118,6 @@ alloy-sol-type-parser = { version = "1", default-features = false, features = ["
 alloy-sol-types = { version = "1", default-features = false, features = ["json", "std"] }
 alloy-transport-http = { version = "1", default-features = false, features = ["reqwest", "reqwest-rustls-tls"] }
 bytes = { version = "1", features = ["serde"] }
-camino = { version = "1", default-features = false, features = ["serde1"] }
 chrono = { version = "0.4", features = ["serde"] }
 cipher = { version = "0.4", default-features = false, features = ["zeroize"] }
 clap = { version = "4", features = ["derive"] }
@@ -140,7 +134,6 @@ futures-channel = { version = "0.3", features = ["sink"] }
 futures-core = { version = "0.3" }
 futures-executor = { version = "0.3" }
 futures-io = { version = "0.3" }
-futures-timer = { version = "3", default-features = false, features = ["wasm-bindgen"] }
 futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
 generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "zeroize"] }
 hashbrown = { version = "0.16", features = ["serde"] }
@@ -148,7 +141,6 @@ hpke-rs = { version = "0.6", features = ["hazmat", "libcrux", "serialization"] }
 idna = { version = "1" }
 indexmap = { version = "2", features = ["serde"] }
 itertools = { version = "0.14" }
-js-sys = { version = "0.3" }
 k256 = { version = "0.13", default-features = false, features = ["ecdh", "ecdsa", "std"] }
 libcrux-ed25519 = { version = "0.0.6", default-features = false, features = ["rand"] }
 log = { version = "0.4", default-features = false, features = ["std"] }
@@ -172,14 +164,13 @@ rand_core = { version = "0.9", default-features = false, features = ["os_rng", "
 regex = { version = "1" }
 regex-automata = { version = "0.4", default-features = false, features = ["dfa-build", "dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
 regex-syntax = { version = "0.8" }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 ruint = { version = "1", default-features = false, features = ["alloy-rlp", "rand-09", "serde", "std"] }
 rustc-hash = { version = "2", features = ["rand"] }
 sec1 = { version = "0.7", features = ["pem", "serde", "std", "subtle"] }
-semver = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["alloc", "derive", "rc"] }
-serde_core = { version = "1", features = ["alloc", "rc"] }
-serde_json = { version = "1", features = ["alloc", "preserve_order", "raw_value", "unbounded_depth"] }
+serde_core = { version = "1", default-features = false, features = ["alloc", "rc", "result", "std"] }
+serde_json = { version = "1", features = ["alloc", "preserve_order", "raw_value"] }
+serde_spanned = { version = "1", default-features = false, features = ["serde", "std"] }
 sha1 = { version = "0.10", features = ["compress"] }
 sha3 = { version = "0.10", default-features = false, features = ["asm", "std"] }
 slab = { version = "0.4" }
@@ -190,17 +181,14 @@ sync_wrapper = { version = "1", default-features = false, features = ["futures"]
 time = { version = "0.3", features = ["formatting", "local-offset", "parsing"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = { version = "0.7", features = ["codec", "compat", "io"] }
+toml_datetime = { version = "1", features = ["serde"] }
 toml_parser = { version = "1" }
 tonic = { version = "0.14", default-features = false, features = ["codegen"] }
 tracing = { version = "0.1", features = ["log", "release_max_level_debug"] }
 tracing-core = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["chrono", "env-filter", "json"] }
 typenum = { version = "1", default-features = false, features = ["const-generics"] }
-uniffi = { version = "0.29", features = ["bindgen-tests", "build", "tokio"] }
-uniffi_bindgen = { version = "0.29", features = ["bindgen-tests"] }
-uniffi_core = { version = "0.29", features = ["tokio"] }
 url = { version = "2", features = ["serde"] }
-wasm-bindgen = { version = "0.2" }
 winnow = { version = "0.7", features = ["simd"] }
 zerocopy = { version = "0.8", default-features = false, features = ["derive", "simd"] }
 
@@ -210,6 +198,9 @@ byteorder = { version = "1" }
 getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "service"] }
 rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls-pki-types = { version = "1", features = ["std"] }
+rustls-webpki = { version = "0.103", default-features = false, features = ["ring", "std"] }
+serde_core = { version = "1" }
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
 tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
 tonic = { version = "0.14", features = ["tls-native-roots", "tls-ring", "tls-webpki-roots"] }
@@ -222,6 +213,9 @@ cc = { version = "1", default-features = false, features = ["parallel"] }
 getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "service"] }
 rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls-pki-types = { version = "1", features = ["std"] }
+rustls-webpki = { version = "0.103", default-features = false, features = ["ring", "std"] }
+serde_core = { version = "1" }
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
 tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
 tonic = { version = "0.14", features = ["tls-native-roots", "tls-ring", "tls-webpki-roots"] }
@@ -235,6 +229,10 @@ getrandom = { version = "0.4", default-features = false, features = ["std", "sys
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "service"] }
 libc = { version = "0.2" }
 rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls-pki-types = { version = "1", features = ["std"] }
+rustls-webpki = { version = "0.103", default-features = false, features = ["ring", "std"] }
+security-framework-sys = { version = "2" }
+serde_core = { version = "1" }
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
 tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
 tonic = { version = "0.14", features = ["tls-native-roots", "tls-ring", "tls-webpki-roots"] }
@@ -249,6 +247,10 @@ getrandom = { version = "0.4", default-features = false, features = ["std", "sys
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "service"] }
 libc = { version = "0.2" }
 rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls-pki-types = { version = "1", features = ["std"] }
+rustls-webpki = { version = "0.103", default-features = false, features = ["ring", "std"] }
+security-framework-sys = { version = "2" }
+serde_core = { version = "1" }
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
 tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
 tonic = { version = "0.14", features = ["tls-native-roots", "tls-ring", "tls-webpki-roots"] }
@@ -262,6 +264,9 @@ getrandom = { version = "0.4", default-features = false, features = ["std", "sys
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "service"] }
 libc = { version = "0.2" }
 rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls-pki-types = { version = "1", features = ["std"] }
+rustls-webpki = { version = "0.103", default-features = false, features = ["ring", "std"] }
+serde_core = { version = "1" }
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
 tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
 tonic = { version = "0.14", features = ["tls-ring", "tls-webpki-roots"] }
@@ -276,6 +281,9 @@ getrandom = { version = "0.4", default-features = false, features = ["std", "sys
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "service"] }
 libc = { version = "0.2" }
 rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls-pki-types = { version = "1", features = ["std"] }
+rustls-webpki = { version = "0.103", default-features = false, features = ["ring", "std"] }
+serde_core = { version = "1" }
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
 tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
 tonic = { version = "0.14", features = ["tls-ring", "tls-webpki-roots"] }
@@ -288,6 +296,9 @@ errno = { version = "0.3" }
 getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "service"] }
 rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls-pki-types = { version = "1", features = ["std"] }
+rustls-webpki = { version = "0.103", default-features = false, features = ["ring", "std"] }
+serde_core = { version = "1" }
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
 tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
 tonic = { version = "0.14", features = ["tls-ring", "tls-webpki-roots"] }
@@ -301,6 +312,9 @@ errno = { version = "0.3" }
 getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "service"] }
 rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls-pki-types = { version = "1", features = ["std"] }
+rustls-webpki = { version = "0.103", default-features = false, features = ["ring", "std"] }
+serde_core = { version = "1" }
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
 tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
 tonic = { version = "0.14", features = ["tls-ring", "tls-webpki-roots"] }

--- a/crates/xmtp_api/Cargo.toml
+++ b/crates/xmtp_api/Cargo.toml
@@ -1,31 +1,32 @@
 [package]
 name = "xmtp_api"
-edition = "2024"
+description = "XMTP Api high level wrapper"
 license.workspace = true
 version.workspace = true
-description = "XMTP Api high level wrapper"
+rust-version.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true
 
 [dependencies]
 async-trait.workspace = true
-futures = { workspace = true }
+futures.workspace = true
 hex.workspace = true
 prost = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
 tracing.workspace = true
 xmtp-workspace-hack.workspace = true
-xmtp_api_d14n = { workspace = true }
+xmtp_api_d14n.workspace = true
 xmtp_common.workspace = true
 xmtp_id.workspace = true
-xmtp_proto = { workspace = true }
+xmtp_proto.workspace = true
 
 
 # test utils
 [dev-dependencies]
 chrono.workspace = true
-futures-timer.workspace = true
 http = "1.2"
 tls_codec.workspace = true
 xmtp_api_d14n = { workspace = true, features = ["test-utils"] }

--- a/crates/xmtp_api_d14n/Cargo.toml
+++ b/crates/xmtp_api_d14n/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "xmtp_api_d14n"
-edition = "2024"
+description = "XMTP Decentralization client implementation according to XIP-49"
 license.workspace = true
 version.workspace = true
-description = "XMTP Decentralization client implementation according to XIP-49"
+rust-version.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true
@@ -15,39 +17,33 @@ chrono.workspace = true
 derive_builder.workspace = true
 futures.workspace = true
 hex.workspace = true
-http = "1.2"
-hyper = { version = "1.7", default-features = false }
+http.workspace = true
+hyper.workspace = true
 impl-trait-for-tuples = "0.2"
 itertools.workspace = true
-openmls_rust_crypto = { workspace = true }
+openmls.workspace = true
+openmls_rust_crypto.workspace = true
 parking_lot.workspace = true
 pbjson-types.workspace = true
 pin-project.workspace = true
 prost.workspace = true
 regex.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true }
+tokio.workspace = true
 tracing.workspace = true
 url.workspace = true
-xmtp_api_grpc = { workspace = true }
+xmtp-workspace-hack.workspace = true
+xmtp_api_grpc.workspace = true
 xmtp_common.workspace = true
-xmtp_configuration = { workspace = true }
+xmtp_configuration.workspace = true
 xmtp_cryptography.workspace = true
-xmtp_id = { workspace = true }
-xmtp_proto = { workspace = true }
+xmtp_id.workspace = true
+xmtp_proto.workspace = true
 
 # Test Utils
 ctor = { workspace = true, optional = true }
 mockall = { workspace = true, optional = true }
 wasm-bindgen-test = { workspace = true, optional = true }
-xmtp-workspace-hack.workspace = true
-
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-openmls = { workspace = true }
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-openmls = { workspace = true, features = ["js"] }
-
 
 [dev-dependencies]
 futures-test.workspace = true
@@ -69,10 +65,7 @@ proptest = { workspace = true, features = [
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test.workspace = true
-# needed for rstest
-futures-timer = { workspace = true, features = ["wasm-bindgen"] }
-proptest = { workspace = true, features = ["std"] }
-
+proptest.workspace = true
 
 [features]
 test-utils = [

--- a/crates/xmtp_api_grpc/Cargo.toml
+++ b/crates/xmtp_api_grpc/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
-edition = "2024"
-license.workspace = true
 name = "xmtp_api_grpc"
-version.workspace = true
 description = "gRPC primitives and traits for native and WebAssembly"
+license.workspace = true
+version.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [dependencies]
 async-trait.workspace = true
@@ -14,14 +16,13 @@ http-body-util.workspace = true
 pin-project.workspace = true
 prost = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
+toxiproxy_rust = { workspace = true, optional = true }
 tracing.workspace = true
 url.workspace = true
+xmtp-workspace-hack.workspace = true
 xmtp_common.workspace = true
 xmtp_configuration.workspace = true
-xmtp_proto = { workspace = true }
-
-toxiproxy_rust = { workspace = true, optional = true }
-xmtp-workspace-hack.workspace = true
+xmtp_proto.workspace = true
 
 
 # Anything but iOS, Android & WASM will use either webpki or native.
@@ -44,21 +45,21 @@ tonic = { workspace = true, features = [
 
 
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
-hyper = "1.6"
+hyper = { workspace = true, features = ["default"] }
 tower = { workspace = true, default-features = true }
 
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 tonic-web-wasm-client.workspace = true
-tonic = { workspace = true }
-hyper = { version = "1.6", default-features = false }
-tower = { workspace = true }
+tonic.workspace = true
+hyper.workspace = true
+tower.workspace = true
 
 
 [dev-dependencies]
 futures-test.workspace = true
 rstest.workspace = true
-toxiproxy_rust = { workspace = true }
+toxiproxy_rust.workspace = true
 xmtp_proto = { workspace = true, features = ["test-utils"] }
 
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dev-dependencies]

--- a/crates/xmtp_archive/Cargo.toml
+++ b/crates/xmtp_archive/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "xmtp_archive"
-edition = "2024"
+description = "archive and backup features for xmtp"
 license.workspace = true
 version.workspace = true
-description = "archive and backup features for xmtp"
+rust-version.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/crates/xmtp_common/Cargo.toml
+++ b/crates/xmtp_common/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "xmtp_common"
-edition = "2024"
-version.workspace = true
-license.workspace = true
 description = "common utilities"
+license.workspace = true
+version.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [dependencies]
 async-trait.workspace = true
@@ -44,7 +46,7 @@ web-sys = { workspace = true, features = ["Window"] }
 wasm-bindgen-futures.workspace = true
 wasm-bindgen.workspace = true
 tokio = { workspace = true, features = ["time", "sync"] }
-tokio_with_wasm = { version = "0.8.7", features = ["full"] }
+tokio_with_wasm = { version = "0.9.0", features = ["full"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio-stream = { workspace = true, features = ["time"] }
@@ -56,7 +58,7 @@ once_cell.workspace = true
 owo-colors.workspace = true
 parking_lot.workspace = true
 thiserror.workspace = true
-toxiproxy_rust = { workspace = true }
+toxiproxy_rust.workspace = true
 tracing-subscriber = { workspace = true, features = [
   "fmt",
   "env-filter",
@@ -81,7 +83,7 @@ tokio = { workspace = true, features = [
 ] }
 tracing-forest.workspace = true
 ctor.workspace = true
-parking_lot = { workspace = true }
+parking_lot.workspace = true
 
 [features]
 logging = ["dep:tracing-subscriber"]

--- a/crates/xmtp_configuration/Cargo.toml
+++ b/crates/xmtp_configuration/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "xmtp_configuration"
-edition = "2024"
+description = "global configuration for xmtp crates"
 license.workspace = true
 version.workspace = true
-description = "global configuration for xmtp crates"
+rust-version.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [dependencies]
 openmls.workspace = true

--- a/crates/xmtp_content_types/Cargo.toml
+++ b/crates/xmtp_content_types/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
-edition = "2024"
 name = "xmtp_content_types"
-version.workspace = true
-license.workspace = true
 description = "xmtp content types"
+license.workspace = true
+version.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [features]
 test-utils = []

--- a/crates/xmtp_cryptography/Cargo.toml
+++ b/crates/xmtp_cryptography/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
-edition = "2024"
 name = "xmtp_cryptography"
-rust-version = "1.85"
-version.workspace = true
-license.workspace = true
 description = "cryptography primitives for xmtp"
+license.workspace = true
+version.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [package.metadata.docs.rs]
 targets = [
@@ -25,15 +26,20 @@ libcrux-ed25519.workspace = true
 openmls.workspace = true
 openmls_basic_credential.workspace = true
 openmls_traits.workspace = true
-rand = { workspace = true }
+rand.workspace = true
 rand_chacha.workspace = true
-serde = { workspace = true }
+serde.workspace = true
 sha2.workspace = true
-thiserror = { workspace = true }
+thiserror.workspace = true
 tls_codec.workspace = true
 xmtp-workspace-hack.workspace = true
 zeroize.workspace = true
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+ctor.workspace = true
+rustls.workspace = true
+
+# All wasm specific dependencies should go here as a single place to enable wasm features since all crates depend on this crate
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 getrandom = { workspace = true, features = ["wasm_js"] }
 # Force getrandom 0.3 to enable wasm_js
@@ -42,6 +48,7 @@ getrandom_03 = { package = "getrandom", version = "0.3", features = [
 ] }
 getrandom_02 = { package = "getrandom", version = "0.2", features = ["js"] }
 openmls = { workspace = true, features = ["js"] }
+futures-timer = { workspace = true, features = ["wasm-bindgen"] }
 
 [features]
 # Expose private keys in addition to public

--- a/crates/xmtp_cryptography/src/lib.rs
+++ b/crates/xmtp_cryptography/src/lib.rs
@@ -7,11 +7,17 @@ pub mod signature;
 pub mod utils;
 
 pub use basic_credential::*;
+pub use openmls;
 
 pub type Secret = tls_codec::SecretVLBytes; // Byte array with ZeroizeOnDrop
 
-pub mod openmls {
-    pub use openmls::*;
+// When upgrading to reqwest 0.13 and disabling the default aws-lc-rs crypto provider
+// some tests fail without initializing the ring crypto provider. Doing this here because
+// it is crypto related and all crates depend on this crate.
+#[cfg(not(target_arch = "wasm32"))]
+#[ctor::ctor]
+fn install_rustls_crypto_provider() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
 }
 
 #[cfg(test)]

--- a/crates/xmtp_db/Cargo.toml
+++ b/crates/xmtp_db/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "xmtp_db"
-edition = "2024"
+description = "SQLite interface for XMTP"
 license.workspace = true
 version.workspace = true
-description = "SQLite interface for XMTP"
+rust-version.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true
@@ -17,6 +19,9 @@ required-features = ["update-schema"]
 
 [dependencies]
 arc-swap.workspace = true
+ascii_table = { version = "5", optional = true, features = [
+  "auto_table_width",
+] }
 bincode.workspace = true
 bon.workspace = true
 ctor.workspace = true
@@ -28,38 +33,34 @@ diesel = { workspace = true, features = [
   "serde_json",
 ] }
 diesel_migrations = { workspace = true, features = ["sqlite"] }
+futures = { workspace = true, optional = true }
 hex.workspace = true
 itertools.workspace = true
+mockall = { workspace = true, optional = true }
 openmls.workspace = true
 openmls_basic_credential.workspace = true
 openmls_rust_crypto.workspace = true
-openmls_traits = { workspace = true }
+openmls_traits.workspace = true
 parking_lot.workspace = true
 prost.workspace = true
 rand.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-tracing.workspace = true
-xmtp_common.workspace = true
-xmtp_configuration.workspace = true
-xmtp_proto.workspace = true
-zeroize.workspace = true
-
-ascii_table = { version = "5", optional = true, features = [
-  "auto_table_width",
-] }
-futures = { workspace = true, optional = true }
-mockall = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true, features = [
   "macros",
   "tracing",
   "rt-multi-thread",
   "sync",
 ] }
-toml = { version = "0.8.4", optional = true }
+toml = { workspace = true, optional = true }
+tracing.workspace = true
 xmtp-workspace-hack.workspace = true
+xmtp_common.workspace = true
+xmtp_configuration.workspace = true
 xmtp_content_types.workspace = true
+xmtp_proto.workspace = true
+zeroize.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 libsqlite3-sys = { version = "0.35", features = [
@@ -73,14 +74,12 @@ sqlite-wasm-rs = { version = "0.5", default-features = false }
 sqlite-wasm-vfs = "0.2"
 tokio.workspace = true
 web-sys = { workspace = true, features = ["DomException"] }
-wasm-bindgen = { workspace = true }
+wasm-bindgen.workspace = true
 
 
 [dev-dependencies]
-ascii_table = { version = "5", features = ["auto_table_width"] }
 futures.workspace = true
-futures-timer.workspace = true
-mockall = { workspace = true }
+mockall.workspace = true
 rstest.workspace = true
 xmtp_cryptography.workspace = true
 xmtp_db = { workspace = true, features = ["test-utils"] }

--- a/crates/xmtp_db_test/Cargo.toml
+++ b/crates/xmtp_db_test/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "xmtp_db_test"
-edition = "2024"
+description = "local db chaos testing"
 license.workspace = true
 version.workspace = true
-description = "local db chaos testing"
+rust-version.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/crates/xmtp_id/Cargo.toml
+++ b/crates/xmtp_id/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
-edition = "2024"
-license.workspace = true
 name = "xmtp_id"
-version.workspace = true
 description = "XMTP Identity implementation according to XIP-46"
+license.workspace = true
+version.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true
@@ -23,30 +25,24 @@ chrono.workspace = true
 ed25519-dalek = { workspace = true, features = ["digest"] }
 futures.workspace = true
 hex.workspace = true
+openmls.workspace = true
 openmls_traits.workspace = true
 p256.workspace = true
 prost.workspace = true
 regex.workspace = true
+rstest = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 url = { workspace = true, features = ["serde"] }
+xmtp-workspace-hack.workspace = true
 xmtp_common.workspace = true
-xmtp_configuration = { workspace = true }
+xmtp_configuration.workspace = true
 xmtp_cryptography.workspace = true
 xmtp_db.workspace = true
-xmtp_proto = { workspace = true, features = [] }
-
-rstest = { workspace = true, optional = true }
-xmtp-workspace-hack.workspace = true
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { workspace = true, features = ["wasm_js"] }
-openmls = { workspace = true, features = ["js"] }
-
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-openmls.workspace = true
+xmtp_proto.workspace = true
 
 [dev-dependencies]
 alloy = { workspace = true, features = [
@@ -67,7 +63,7 @@ rstest.workspace = true
 tokio = { workspace = true, features = ["macros"] }
 wasm-bindgen-test.workspace = true
 xmtp_common = { workspace = true, features = ["test-utils"] }
-xmtp_configuration.workspace = true
+xmtp_configuration = { workspace = true, features = ["test-utils"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 gloo-timers.workspace = true

--- a/crates/xmtp_macro/Cargo.toml
+++ b/crates/xmtp_macro/Cargo.toml
@@ -1,25 +1,20 @@
 [package]
 name = "xmtp_macro"
-edition = "2024"
+description = "XMTP Utility Macros"
 license.workspace = true
 version.workspace = true
-description = "XMTP Utility Macros"
+rust-version.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true
 
 [dependencies]
 num_cpus = "1.17"
-proc-macro2 = "1.0"
-quote = "1.0"
-syn = { version = "2.0", default-features = false, features = [
-  "parsing",
-  "proc-macro",
-  "derive",
-  "printing",
-  "full",
-  "clone-impls",
-] }
+proc-macro2.workspace = true
+quote.workspace = true
+syn.workspace = true
 xmtp-workspace-hack.workspace = true
 
 [lib]

--- a/crates/xmtp_mls/Cargo.toml
+++ b/crates/xmtp_mls/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
-edition = "2024"
-license.workspace = true
 name = "xmtp_mls"
-version.workspace = true
 description = "XMTP core MLS Implementation on top of openmls"
+license.workspace = true
+version.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true
@@ -65,21 +67,22 @@ hex.workspace = true
 hkdf.workspace = true
 hpke-rs.workspace = true
 itertools.workspace = true
-openmls_libcrux_crypto = { workspace = true }
-openmls_rust_crypto = { workspace = true }
-openmls_traits = { workspace = true }
+openmls.workspace = true
+openmls_libcrux_crypto.workspace = true
+openmls_rust_crypto.workspace = true
+openmls_traits.workspace = true
 owo-colors.workspace = true
 parking_lot.workspace = true
 pin-project.workspace = true
 prost = { workspace = true, features = ["derive"] }
-rand = { workspace = true }
-reqwest = { workspace = true }
+rand.workspace = true
+reqwest.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 sha2.workspace = true
-thiserror = { workspace = true }
+thiserror.workspace = true
 time.workspace = true
-tls_codec = { workspace = true }
+tls_codec.workspace = true
 tokio-stream = { workspace = true, default-features = false, features = [
   "sync",
 ] }
@@ -89,19 +92,20 @@ trait-variant.workspace = true
 zeroize.workspace = true
 
 # XMTP/Local
-xmtp_api = { workspace = true }
-xmtp_api_d14n = { workspace = true }
-xmtp_api_grpc = { workspace = true }
+xmtp-workspace-hack.workspace = true
+xmtp_api.workspace = true
+xmtp_api_d14n.workspace = true
+xmtp_api_grpc.workspace = true
 xmtp_archive.workspace = true
 xmtp_common.workspace = true
 xmtp_configuration.workspace = true
 xmtp_content_types.workspace = true
-xmtp_cryptography = { workspace = true }
+xmtp_cryptography.workspace = true
 xmtp_db.workspace = true
 xmtp_id.workspace = true
 xmtp_macro.workspace = true
 xmtp_mls_common.workspace = true
-xmtp_proto = { workspace = true }
+xmtp_proto.workspace = true
 
 # Optional/Features
 alloy = { workspace = true, optional = true }
@@ -126,7 +130,6 @@ tracing-subscriber = { workspace = true, features = [
   "json",
   "registry",
 ], optional = true }
-xmtp-workspace-hack.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true, features = [
@@ -137,39 +140,34 @@ tokio = { workspace = true, features = [
 ] }
 chrono = { workspace = true, features = ["clock"] }
 dyn-clone.workspace = true
-openmls.workspace = true
-
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 chrono = { workspace = true, features = ["wasmbind"] }
-getrandom = { workspace = true }
-openmls = { workspace = true, features = ["js"] }
 tokio = { workspace = true, features = ["macros", "rt", "time"] }
 wasm-bindgen-futures.workspace = true
 web-sys.workspace = true
 
 [dev-dependencies]
 alloy.workspace = true
-coset = { version = "0.3" }
+coset = "0.3"
 diesel = { workspace = true, features = [
   "returning_clauses_for_sqlite_3_35",
   "sqlite",
   "32-column-tables",
 ] }
-fdlimit = { workspace = true }
-futures-executor = { version = "0.3" }
+fdlimit.workspace = true
+futures-executor = "0.3"
 futures-test = "0.3.31"
-futures-timer.workspace = true
 mockall.workspace = true
 once_cell.workspace = true
 openmls = { workspace = true, features = ["test-utils"] }
 openmls_basic_credential.workspace = true
-passkey = { version = "0.4" }
-public-suffix = { version = "0.1.2" }
+passkey = "0.4"
+public-suffix = "0.1.2"
 rstest = { workspace = true, features = ["async-timeout"] }
-rstest_reuse = { workspace = true }
-toxiproxy_rust = { workspace = true }
-url = { workspace = true }
+rstest_reuse.workspace = true
+toxiproxy_rust.workspace = true
+url.workspace = true
 wasm-bindgen-test.workspace = true
 xmtp_api = { workspace = true, features = ["test-utils"] }
 xmtp_api_d14n = { workspace = true, features = ["test-utils"] }
@@ -181,24 +179,20 @@ xmtp_content_types = { path = "../xmtp_content_types", features = [
 ] }
 xmtp_db = { workspace = true, features = ["test-utils"] }
 xmtp_db_test.workspace = true
-xmtp_id = { path = "../xmtp_id", features = ["test-utils"] }
+xmtp_id = { workspace = true, features = ["test-utils"] }
 xmtp_proto = { workspace = true, features = ["test-utils"] }
 # Required for traced_test! macro
-tracing-subscriber = { workspace = true }
+tracing-subscriber.workspace = true
 xmtp_api_grpc = { workspace = true, features = ["test-utils"] }
-
 
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dev-dependencies]
 ctor.workspace = true
 mockito = "1.6.1"
-openmls = { workspace = true }
 tempfile = "3.15.0"
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dev-dependencies]
-openmls = { workspace = true, features = ["js"] }
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 wasm-bindgen-test.workspace = true
-futures-timer = { version = "3.0.3", features = ["wasm-bindgen"] }
 
 [[bench]]
 harness = false

--- a/crates/xmtp_mls/src/subscriptions/stream_messages/types.rs
+++ b/crates/xmtp_mls/src/subscriptions/stream_messages/types.rs
@@ -28,6 +28,7 @@ impl GroupList {
     }
 
     /// get the size of the group list
+    #[allow(unused)]
     pub(super) fn len(&self) -> usize {
         self.list.len()
     }

--- a/crates/xmtp_mls_common/Cargo.toml
+++ b/crates/xmtp_mls_common/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "xmtp_mls_common"
-edition = "2024"
+description = "common MLS utilties"
 license.workspace = true
 version.workspace = true
-description = "common MLS utilties"
+rust-version.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/crates/xmtp_proto/Cargo.toml
+++ b/crates/xmtp_proto/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
-edition = "2024"
-license.workspace = true
 name = "xmtp_proto"
-version.workspace = true
 description = "xmtp protobuf definitions for rust"
+license.workspace = true
+version.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true
@@ -14,15 +16,16 @@ bytes.workspace = true
 chrono.workspace = true
 derive_builder.workspace = true
 ed25519-dalek.workspace = true
-futures = { workspace = true }
+futures.workspace = true
 hex.workspace = true
 http = "1.2"
+openmls.workspace = true
 pbjson.workspace = true
 pbjson-types.workspace = true
 pin-project.workspace = true
 prost = { workspace = true, features = ["derive"] }
 prost-types = "0.14"
-serde = { workspace = true }
+serde.workspace = true
 smallvec.workspace = true
 thiserror.workspace = true
 tonic = { workspace = true, default-features = false }
@@ -39,20 +42,17 @@ tokio = { workspace = true, default-features = false, features = [
 toxiproxy_rust = { workspace = true, optional = true }
 xmtp-workspace-hack.workspace = true
 
-
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-openmls = { workspace = true }
 tonic = { workspace = true, features = ["codegen", "server", "channel"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-openmls = { workspace = true, features = ["js"] }
-wasm-bindgen-test = { workspace = true }
+wasm-bindgen-test.workspace = true
 
 [dev-dependencies]
-mockall = { workspace = true }
+mockall.workspace = true
 rstest.workspace = true
 tokio = { workspace = true, default-features = false, features = ["sync"] }
-toxiproxy_rust = { workspace = true }
+toxiproxy_rust.workspace = true
 xmtp_common = { workspace = true, features = ["test-utils"] }
 xmtp_configuration = { workspace = true, features = ["test-utils"] }
 
@@ -66,7 +66,7 @@ walkdir = "2.5"
 color-eyre.workspace = true
 relative-path = "2"
 xshell = "0.2"
-pbjson-build = "0.8"
+pbjson-build = "0.9"
 tonic = { workspace = true, features = ["codegen"] }
 # this puts protoc on path with std::env::set_var("PROTOC", protobuf_src::protoc());
 # but takes forever to compile

--- a/docs/nix-setup.md
+++ b/docs/nix-setup.md
@@ -94,13 +94,13 @@ sudo nix run nixpkgs#cachix -- use xmtp
 
 ## Available Dev Shells
 
-| Shell     | Command                | Description                                       |
-| --------- | ---------------------- | ------------------------------------------------- |
-| `default` | `nix develop`          | General Rust development for libxmtp               |
-| `android` | `nix develop .#android`| Android cross-compilation (NDK, cargo-ndk)         |
-| `ios`     | `nix develop .#ios`    | iOS/Swift builds (macOS only)                      |
-| `js`      | `nix develop .#js`     | Node.js bindings development                       |
-| `wasm`    | `nix develop .#wasm`   | WebAssembly builds (wasm-pack, wasm-bindgen)       |
+| Shell     | Command                 | Description                                  |
+| --------- | ----------------------- | -------------------------------------------- |
+| `default` | `nix develop`           | General Rust development for libxmtp         |
+| `android` | `nix develop .#android` | Android cross-compilation (NDK, cargo-ndk)   |
+| `ios`     | `nix develop .#ios`     | iOS/Swift builds (macOS only)                |
+| `js`      | `nix develop .#js`      | Node.js bindings development                 |
+| `wasm`    | `nix develop .#wasm`    | WebAssembly builds (wasm-pack, wasm-bindgen) |
 
 ## Common Commands
 
@@ -120,7 +120,7 @@ nix flake show
 
 ## How Nix is Used in This Repo
 
-- **Reproducible Rust toolchain** — Rust 1.92.0 is pinned via
+- **Reproducible Rust toolchain** — Rust 1.94.0 is pinned via
   [fenix](https://github.com/nix-community/fenix), ensuring every developer and
   CI runner uses the exact same compiler
 - **Platform-specific cross-compilation** — dedicated dev shells provide


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Upgrade workspace dependencies and bump rust-version to 1.94.0
- Bumps `rust-version` from 1.93.0 to 1.94.0 and sets `edition = 2024` across the workspace, with all crates adopting workspace-inherited metadata fields.
- Updates key dependencies: `uniffi` to 0.31.0, `reqwest` to 0.13.2 (with `rustls-no-provider`), `criterion` to 0.8.2, `mockall` to 0.14, `pbjson`/`pbjson-types` to 0.9, and `tokio_with_wasm` to 0.9.0.
- Adds a `ctor`-initialized function in [xmtp_cryptography/src/lib.rs](https://github.com/xmtp/libxmtp/pull/3306/files#diff-a075887b8d87bf780924d062938b4ae965cef3f87b354fd35e3179f5f59b60b5) that installs the `rustls` ring crypto provider at startup on non-wasm targets.
- Adds `proc-macro2`, `quote`, `syn`, `http`, `hyper`, `hyper-util`, and several wasm-related crates (`serde-wasm-bindgen`, `tsify`, `wasm-streams`, `tracing-web`) to the workspace dependency table.
- Behavioral Change: `reqwest` now uses `rustls-no-provider` instead of a bundled TLS provider, requiring the ring provider to be installed explicitly (handled by the new `install_rustls_crypto_provider` init hook).

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized aedaa4d.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->