### PR TITLE
use nix for cargo nextest in ci

### DIFF
--- a/.github/workflows/test-workspace.yml
+++ b/.github/workflows/test-workspace.yml
@@ -15,7 +15,8 @@ jobs:
         with:
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          sccache: "true"
+          sccache: "false"
+          gc-max-store-size: "5G"
       - uses: taiki-e/install-action@just
       - name: Start backend
         run: just backend up
@@ -23,9 +24,11 @@ jobs:
         if: failure()
         uses: jwalton/gh-docker-logs@v2
       - name: Run tests (v3 + d14n with coverage)
-        run: just test
-      - name: Generate coverage report
-        run: nix develop .#rust --command cargo llvm-cov report --output-path lcov.info --lcov
+        # use `nix build` instead of `nix flake check` because we need the resulting coverage
+        run: nix build .#checks.x86_64-linux.nextest-v3 .#checks.x86_64-linux.nextest-d14n
+
+      - name: merge coverage files
+        run: nix run nixpkgs#lcov -- --add-tracefile result/coverage --add-tracefile result-1/coverage --output-file lcov.info
       - name: Upload coverage
         uses: codecov/codecov-action@v5
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
 ]
 exclude = ["apps/android"]
 
+# Default members must be part of workspace hack to maximize cache hits in CI/nix/crane
 default-members = [
   # Applications
   "apps/mls_validation_service",

--- a/apps/mls_validation_service/src/cached_signature_verifier.rs
+++ b/apps/mls_validation_service/src/cached_signature_verifier.rs
@@ -70,19 +70,19 @@ mod tests {
         MultiSmartContractSignatureVerifier, SmartContractSignatureVerifier, ValidationResponse,
         VerifierError,
     };
-    use xmtp_id::utils::test::{SignatureWithNonce, SmartWalletContext, smart_wallet};
+    use xmtp_id::utils::test::{SignatureWithNonce, SmartWalletContext, docker_smart_wallet};
 
     #[rstest::rstest]
     #[timeout(Duration::from_secs(60))]
     #[tokio::test]
-    async fn test_is_valid_signature(#[future] smart_wallet: SmartWalletContext) {
+    async fn test_is_valid_signature(#[future] docker_smart_wallet: SmartWalletContext) {
         let SmartWalletContext {
             factory,
             owner0: owner,
             sw,
             sw_address,
             ..
-        } = smart_wallet.await;
+        } = docker_smart_wallet.await;
         let chain_id = factory.provider().get_chain_id().await.unwrap();
         let hash = B256::random();
         let replay_safe_hash = sw.replaySafeHash(hash).call().await.unwrap();

--- a/apps/mls_validation_service/src/handlers.rs
+++ b/apps/mls_validation_service/src/handlers.rs
@@ -318,14 +318,13 @@ mod tests {
     use xmtp_common::{rand_string, rand_u64};
     use xmtp_configuration::CIPHERSUITE;
     use xmtp_cryptography::XmtpInstallationCredential;
-    use xmtp_id::utils::test::smart_wallet;
     use xmtp_id::{
         associations::{
             Identifier,
             test_utils::{MockSmartContractSignatureVerifier, WalletTestExt},
             unverified::{UnverifiedAction, UnverifiedIdentityUpdate},
         },
-        utils::test::{SignatureWithNonce, SmartWalletContext},
+        utils::test::{SignatureWithNonce, SmartWalletContext, docker_smart_wallet},
     };
     use xmtp_proto::xmtp::{
         identity::{
@@ -494,14 +493,14 @@ mod tests {
     #[rstest::rstest]
     #[timeout(std::time::Duration::from_secs(30))]
     #[tokio::test]
-    async fn test_validate_scw(#[future] smart_wallet: SmartWalletContext) {
+    async fn test_validate_scw(#[future] docker_smart_wallet: SmartWalletContext) {
         let SmartWalletContext {
             owner0: wallet,
             factory,
             sw,
             sw_address,
             ..
-        } = smart_wallet.await;
+        } = docker_smart_wallet.await;
 
         let provider = factory.provider();
         let chain_id = provider.get_chain_id().await.unwrap();

--- a/bindings/mobile/build.rs
+++ b/bindings/mobile/build.rs
@@ -11,6 +11,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     let build = BuildBuilder::all_build()?;
     let git = GixBuilder::default()
         .sha(true)
+        .branch(true)
+        .commit_date(true)
         .commit_timestamp(true)
         .build()?;
 

--- a/bindings/mobile/src/lib.rs
+++ b/bindings/mobile/src/lib.rs
@@ -190,7 +190,12 @@ fn stringify_error_chain<T: Error>(error: &T) -> String {
 
 #[uniffi::export]
 pub fn get_version_info() -> String {
-    include_str!("../libxmtp-version.txt").to_string()
+    format!(
+        "Version: {}\nBranch: {}\nDate: {}",
+        env!("VERGEN_GIT_SHA"),
+        env!("VERGEN_GIT_BRANCH"),
+        env!("VERGEN_GIT_COMMIT_DATE")
+    )
 }
 
 #[cfg(test)]

--- a/bindings/mobile/src/logger.rs
+++ b/bindings/mobile/src/logger.rs
@@ -383,7 +383,7 @@ mod test_logger {
         .unwrap();
         let rand_nums = hex::encode(xmtp_common::rand_vec::<100>());
         tracing::info!("test log");
-        tracing::trace!(rand_nums);
+        tracing::debug!(rand_nums);
         tracing::info!("test log");
         exit_debug_writer().unwrap();
 

--- a/crates/xmtp_id/src/scw_verifier/chain_rpc_verifier.rs
+++ b/crates/xmtp_id/src/scw_verifier/chain_rpc_verifier.rs
@@ -100,7 +100,7 @@ impl SmartContractSignatureVerifier for RpcSmartContractWalletVerifier {
 #[cfg(all(test, not(target_arch = "wasm32")))]
 pub(crate) mod tests {
     #![allow(clippy::unwrap_used)]
-    use crate::utils::test::{SignatureWithNonce, SmartWalletContext, smart_wallet};
+    use crate::utils::test::{SignatureWithNonce, SmartWalletContext, docker_smart_wallet};
 
     use super::*;
     use alloy::dyn_abi::SolType;
@@ -112,14 +112,14 @@ pub(crate) mod tests {
     #[rstest::rstest]
     #[timeout(Duration::from_secs(30))]
     #[tokio::test]
-    async fn test_coinbase_smart_wallet(#[future] smart_wallet: SmartWalletContext) {
+    async fn test_coinbase_smart_wallet(#[future] docker_smart_wallet: SmartWalletContext) {
         let SmartWalletContext {
             factory,
             sw,
             owner0,
             owner1,
             sw_address,
-        } = smart_wallet.await;
+        } = docker_smart_wallet.await;
         let provider = factory.provider();
         let chain_id = provider.get_chain_id().await.unwrap();
         let hash = B256::random();
@@ -171,14 +171,14 @@ pub(crate) mod tests {
     #[rstest::rstest]
     #[timeout(Duration::from_secs(60))]
     #[tokio::test]
-    async fn test_smart_wallet_time_travel(#[future] smart_wallet: SmartWalletContext) {
+    async fn test_smart_wallet_time_travel(#[future] docker_smart_wallet: SmartWalletContext) {
         let SmartWalletContext {
             factory,
             sw,
             owner1,
             sw_address,
             ..
-        } = smart_wallet.await;
+        } = docker_smart_wallet.await;
 
         let provider = factory.provider();
         let verifier = RpcSmartContractWalletVerifier::new_from_provider(provider.clone());
@@ -230,14 +230,14 @@ pub(crate) mod tests {
     #[rstest::rstest]
     #[timeout(Duration::from_secs(60))]
     #[tokio::test]
-    async fn test_is_valid_signature(#[future] smart_wallet: SmartWalletContext) {
+    async fn test_is_valid_signature(#[future] docker_smart_wallet: SmartWalletContext) {
         let SmartWalletContext {
             factory,
             sw,
             owner0: owner,
             sw_address,
             ..
-        } = smart_wallet.await;
+        } = docker_smart_wallet.await;
         let provider = factory.provider();
         let chain_id = provider.get_chain_id().await.unwrap();
         let hash = B256::random();

--- a/crates/xmtp_id/src/utils/test.rs
+++ b/crates/xmtp_id/src/utils/test.rs
@@ -41,12 +41,6 @@ pub async fn fund_user(user: PrivateKeySigner, anvil: impl AnvilApi<Ethereum>) {
 
 #[cfg(not(target_arch = "wasm32"))]
 #[fixture]
-pub async fn smart_wallet(#[future] spawned_provider: EthereumProvider) -> SmartWalletContext {
-    deploy_wallets(spawned_provider.await).await
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-#[fixture]
 pub async fn docker_smart_wallet(
     #[future] docker_provider: EthereumProvider,
 ) -> SmartWalletContext {

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,7 @@
   nixConfig = {
     http-connections = 128;
     max-substitution-jobs = 128;
+    sandbox = "relaxed";
   };
 
   inputs = {

--- a/nix/ci-checks.nix
+++ b/nix/ci-checks.nix
@@ -1,16 +1,9 @@
 # CI checks to ensure all packages and dev shells build
 _: {
   perSystem =
-    { self', pkgs, ... }:
+    { pkgs, ... }:
     {
-      checks.all-packages = pkgs.linkFarm "all-packages" {
-        inherit (self'.packages)
-          wasm-bindings
-          wasm-bindgen-cli
-          mls_validation_service
-          wasm-bindings-test
-          ;
-      };
-      checks.dev-shells = pkgs.linkFarm "dev-shells" self'.devShells;
+      checks.nextest-v3 = pkgs.callPackage ./package/nextest.nix { };
+      checks.nextest-d14n = pkgs.callPackage ./package/nextest.nix { d14n = true; };
     };
 }

--- a/nix/lib/default.nix
+++ b/nix/lib/default.nix
@@ -37,6 +37,7 @@
           nodeEnv = pkgs.callPackage ./node-env.nix { };
           ffi-uniffi-bindgen = pkgs.callPackage ./packages/uniffi-bindgen.nix { };
           shellCommon = pkgs.callPackage ./shell-common.nix { };
+          mkVersion = import ./mkVersion.nix;
         };
         wasm-bindgen-cli = pkgs.callPackage ./packages/wasm-bindgen-cli.nix { };
         swiftformat = pkgs.callPackage ./packages/swiftformat.nix { };

--- a/nix/lib/filesets.nix
+++ b/nix/lib/filesets.nix
@@ -4,7 +4,7 @@
 }:
 let
   inherit (xmtp.craneLib.fileset) commonCargoSources;
-  inherit (lib.fileset) unions;
+  inherit (lib.fileset) unions fileFilter;
   inherit (lib.lists) flatten;
   src = ./../..;
   # List directores in a folder and apply `commonCargoSources`
@@ -18,7 +18,7 @@ let
 
   # must match default-members in root Cargo.toml
   apps = unions [
-    (lib.fileset.fileFilter (file: file.name == "Cargo.toml" || file.name == "build.rs") (
+    (fileFilter (file: file.name == "Cargo.toml" || file.name == "build.rs") (
       src + /apps/mls_validation_service
     ))
   ];
@@ -34,7 +34,8 @@ let
     (src + /Cargo.lock)
     (src + /.cargo/config.toml)
     # All Cargo.toml and build.rs files in the workspace
-    (lib.fileset.fileFilter (file: file.name == "Cargo.toml" || file.name == "build.rs") src)
+    (fileFilter (file: file.name == "Cargo.toml" || file.name == "build.rs") (src + /crates))
+    (fileFilter (file: file.name == "Cargo.toml" || file.name == "build.rs") (src + /bindings/mobile))
     # Files referenced by build scripts (e.g., include_bytes!, include_str!).
     # These are needed at dep-compilation time because build.rs runs then.
     (src + /crates/xmtp_id/src/scw_verifier/chain_urls_default.json)
@@ -42,14 +43,16 @@ let
     (src + /crates/xmtp_id/src/scw_verifier/signature_validation.hex)
     (src + /crates/xmtp_db/migrations)
     (src + /crates/xmtp_proto/src/gen/proto_descriptor.bin)
+    apps
   ];
+
   libraries = unions (flatten [
     (src + /Cargo.toml)
     (src + /Cargo.lock)
     # include folders for apps/bindings so cargo workspace globs are satisfied
-    (src + /bindings/.gitkeep)
-    (src + /apps/.gitkeep)
     # One-off files that are needed outside of cargo sources
+    (src + /apps/.gitkeep)
+    (src + /bindings/.gitkeep)
     (src + /crates/xmtp_id/src/scw_verifier/chain_urls_default.json)
     (src + /crates/xmtp_id/artifact)
     (src + /crates/xmtp_id/src/scw_verifier/signature_validation.hex)

--- a/nix/lib/mkVersion.nix
+++ b/nix/lib/mkVersion.nix
@@ -1,0 +1,7 @@
+# Version extracted from workspace Cargo.toml — use this instead of calling
+# crateNameFromCargoToml multiple times in each derivation.
+# Note: This requires the caller to pass in a crane instance with the right toolchain.
+rust:
+(rust.crateNameFromCargoToml {
+  cargoToml = ./../../Cargo.toml;
+}).version

--- a/nix/lib/mobile-common.nix
+++ b/nix/lib/mobile-common.nix
@@ -50,13 +50,4 @@ let
 in
 {
   inherit depsFileset bindingsFileset commonArgs;
-
-  # Version extracted from workspace Cargo.toml — use this instead of calling
-  # crateNameFromCargoToml multiple times in each derivation.
-  # Note: This requires the caller to pass in a crane instance with the right toolchain.
-  mkVersion =
-    rust:
-    (rust.crateNameFromCargoToml {
-      cargoToml = ./../../Cargo.toml;
-    }).version;
 }

--- a/nix/lib/packages/uniffi-bindgen.nix
+++ b/nix/lib/packages/uniffi-bindgen.nix
@@ -15,7 +15,7 @@ rust.buildPackage (
     inherit cargoArtifacts;
     pname = "ffi-uniffi-bindgen";
     cargoExtraArgs = "-p xmtpv3 --bin ffi-uniffi-bindgen --features uniffi/cli";
-    version = xmtp.mobile.mkVersion rust;
+    version = xmtp.mkVersion rust;
     src = lib.fileset.toSource {
       root = src;
       fileset = xmtp.filesets.forCrate (src + /bindings/mobile);

--- a/nix/package/android.nix
+++ b/nix/package/android.nix
@@ -36,7 +36,7 @@ let
   rust = craneLib.overrideToolchain (p: rust-toolchain);
 
   # Extract version once for use throughout the file
-  version = mobile.mkVersion rust;
+  version = xmtp.mkVersion rust;
 
   # Inherit shared config
   inherit (mobile) bindingsFileset;
@@ -78,7 +78,7 @@ let
         buildPhaseCargoCommand = ''
           cargo ndk --platform 23 -t ${target} \
             --manifest-path ./bindings/mobile/Cargo.toml \
-            -- build --release
+            -- build --release --locked
         '';
       }
     );

--- a/nix/package/ios.nix
+++ b/nix/package/ios.nix
@@ -46,7 +46,7 @@ let
   rust = craneLib.overrideToolchain (p: rust-toolchain);
 
   # Extract version once for use throughout the file
-  version = mobile.mkVersion rust;
+  version = xmtp.mkVersion rust;
 
   # Inherit shared config
   inherit (mobile) commonArgs bindingsFileset;
@@ -83,7 +83,7 @@ let
           # via xcode-select and sets DEVELOPER_DIR, SDKROOT, CC/CXX, and bindgen args.
           buildPhaseCargoCommand = ''
             ${envSetup}
-            cargo build --release --target ${target} -p xmtpv3
+            cargo build --locked --release --target ${target} -p xmtpv3
           '';
         }
       );

--- a/nix/package/nextest.nix
+++ b/nix/package/nextest.nix
@@ -1,0 +1,68 @@
+# Derivation that runs cargo nextest with llvm-cov on the workspace
+{
+  xmtp,
+  lib,
+  pkg-config,
+  openssl,
+  perl,
+  sqlite,
+  sqlcipher,
+  cargo-llvm-cov,
+  d14n ? false,
+  ...
+}:
+let
+  inherit (lib.fileset) unions fileFilter;
+  inherit (xmtp) craneLib;
+  inherit (craneLib.fileset) commonCargoSources;
+  root = ./../..;
+  rust-toolchain = xmtp.mkToolchain [ ] [ "llvm-tools-preview" ];
+  rust = craneLib.overrideToolchain (p: rust-toolchain);
+
+  src = lib.fileset.toSource {
+    inherit root;
+    fileset = unions [
+      xmtp.filesets.libraries
+      # include xmtpv3 tests
+      (commonCargoSources (root + /bindings/mobile))
+      (commonCargoSources (root + /apps/mls_validation_service))
+      # db snapshots
+      (fileFilter (file: file.hasExt "xmtp") (root + /crates/xmtp_mls/tests/assets))
+      (fileFilter (file: file.hasExt "json") (root + /crates))
+    ];
+  };
+
+  commonArgs = {
+    strictDeps = true;
+    nativeBuildInputs = [
+      pkg-config
+      openssl
+      perl
+      sqlite
+      sqlcipher
+      cargo-llvm-cov
+    ];
+  };
+  cargoArtifacts = rust.buildDepsOnly (
+    commonArgs
+    // {
+      src = craneLib.cleanCargoSource root;
+      buildPhaseCargoCommand = "cargo llvm-cov --locked --profile $CARGO_PROFILE --no-report";
+    }
+  );
+
+in
+rust.cargoNextest (
+  commonArgs
+  // {
+    inherit cargoArtifacts src;
+    partitions = 1;
+    partitionType = "count";
+    cargoNextestPartitionsExtraArgs = "--no-tests=pass";
+    cargoExtraArgs = if d14n then "--features d14n" else "";
+    cargoNextestExtraArgs = if d14n then "--profile ci-d14n" else "--profile ci";
+    withLlvmCov = true;
+    # most tests query docker
+    __noChroot = true;
+  }
+)

--- a/nix/package/node.nix
+++ b/nix/package/node.nix
@@ -13,7 +13,7 @@ let
 
   rust-toolchain = xmtp.mkToolchain nodeEnv.nodeTargets [ ];
   rust = craneLib.overrideToolchain (p: rust-toolchain);
-  version = mobile.mkVersion rust;
+  version = xmtp.mkVersion rust;
 
   bindingsFileset = lib.fileset.toSource {
     root = ./../..;

--- a/nix/package/wasm.nix
+++ b/nix/package/wasm.nix
@@ -99,12 +99,7 @@ let
         })
         pname
         ;
-      inherit
-        (rust.crateNameFromCargoToml {
-          cargoToml = ./../../Cargo.toml;
-        })
-        version
-        ;
+      version = xmtp.mkVersion rust;
       buildPhaseCargoCommand = ''
         mkdir -p $out/dist
         cargoBuildLog=$(mktemp cargoBuildLogXXXX.json)


### PR DESCRIPTION
- caches builds so if library crates do not change, does not need to run tests if previous run succeeded or failed
- view CI output natively in terminal with colored output `nix log github:xmtp/libxmtp/your_branch#checks.x86_64-linux.nextest` or `nix log github:xmtp/libxmtp/your_branch#checks.x86_64-linux.nextest-d14n`
- does not require downloading/loading entire devshell, tests run with exact minimum dependencies required
- reuse workspace dependencies from other builds


this cuts down on two slow parts of CI:
- downloading of devshell dependencies from cachix
- compiling dependencies for tests

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Run cargo nextest with llvm-cov coverage via Nix in CI
> - Replaces `just test` + `cargo llvm-cov report` in CI with two Nix-driven checks: `nextest-v3` and `nextest-d14n`, defined in [nix/package/nextest.nix](https://github.com/xmtp/libxmtp/pull/3308/files#diff-aa45367a8dcf70261a484bcc1f097c399301d2c6819f730c07781fb8936eed8a) and wired up in [nix/ci-checks.nix](https://github.com/xmtp/libxmtp/pull/3308/files#diff-9012eb276afdf1bd8abc7f1b4caa410e84dd90d7eb70c5ebdefe5300aa0d7df5).
> - Each check runs `cargo nextest` with `llvm-cov` for a distinct feature profile; CI merges the resulting lcov files before uploading to Codecov.
> - Consolidates version retrieval across all Nix packages into a shared `xmtp.mkVersion` helper in [nix/lib/mkVersion.nix](https://github.com/xmtp/libxmtp/pull/3308/files#diff-7040edc488a743770e3d82f69e7bc04f3677bd953b42a601054e924d4fdf4e29), replacing per-package inline lookups.
> - Removes the `smart_wallet` rstest fixture, replacing it with `docker_smart_wallet` across SCW-related tests.
> - Risk: `flake.nix` sets `sandbox = "relaxed"`, which loosens Nix sandbox restrictions for all builds in this flake.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bbb1fb7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->