### PR TITLE
Enable extensions-draft-08 feature on openmls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3893,6 +3893,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fancy_constructor"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5476,6 +5488,15 @@ dependencies = [
  "foldhash 0.2.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -8319,7 +8340,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 [[package]]
 name = "openmls"
 version = "0.8.1"
-source = "git+https://github.com/xmtp/openmls?rev=382a4649ae4e937ce933adb259e26d6381745731#382a4649ae4e937ce933adb259e26d6381745731"
+source = "git+https://github.com/xmtp/openmls?rev=42f1479cdb06727da98132dfc2cc3959f2c66a14#42f1479cdb06727da98132dfc2cc3959f2c66a14"
 dependencies = [
  "backtrace",
  "fluvio-wasm-timer",
@@ -8328,8 +8349,10 @@ dependencies = [
  "log",
  "once_cell",
  "openmls_basic_credential",
+ "openmls_libcrux_crypto",
  "openmls_memory_storage",
  "openmls_rust_crypto",
+ "openmls_sqlite_storage",
  "openmls_test",
  "openmls_traits",
  "rand 0.9.2",
@@ -8346,7 +8369,7 @@ dependencies = [
 [[package]]
 name = "openmls_basic_credential"
 version = "0.5.0"
-source = "git+https://github.com/xmtp/openmls?rev=382a4649ae4e937ce933adb259e26d6381745731#382a4649ae4e937ce933adb259e26d6381745731"
+source = "git+https://github.com/xmtp/openmls?rev=42f1479cdb06727da98132dfc2cc3959f2c66a14#42f1479cdb06727da98132dfc2cc3959f2c66a14"
 dependencies = [
  "ed25519-dalek",
  "openmls_traits",
@@ -8359,7 +8382,7 @@ dependencies = [
 [[package]]
 name = "openmls_libcrux_crypto"
 version = "0.3.1"
-source = "git+https://github.com/xmtp/openmls?rev=382a4649ae4e937ce933adb259e26d6381745731#382a4649ae4e937ce933adb259e26d6381745731"
+source = "git+https://github.com/xmtp/openmls?rev=42f1479cdb06727da98132dfc2cc3959f2c66a14#42f1479cdb06727da98132dfc2cc3959f2c66a14"
 dependencies = [
  "hpke-rs",
  "hpke-rs-crypto",
@@ -8380,7 +8403,7 @@ dependencies = [
 [[package]]
 name = "openmls_memory_storage"
 version = "0.5.0"
-source = "git+https://github.com/xmtp/openmls?rev=382a4649ae4e937ce933adb259e26d6381745731#382a4649ae4e937ce933adb259e26d6381745731"
+source = "git+https://github.com/xmtp/openmls?rev=42f1479cdb06727da98132dfc2cc3959f2c66a14#42f1479cdb06727da98132dfc2cc3959f2c66a14"
 dependencies = [
  "hex",
  "log",
@@ -8393,7 +8416,7 @@ dependencies = [
 [[package]]
 name = "openmls_rust_crypto"
 version = "0.5.1"
-source = "git+https://github.com/xmtp/openmls?rev=382a4649ae4e937ce933adb259e26d6381745731#382a4649ae4e937ce933adb259e26d6381745731"
+source = "git+https://github.com/xmtp/openmls?rev=42f1479cdb06727da98132dfc2cc3959f2c66a14#42f1479cdb06727da98132dfc2cc3959f2c66a14"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -8415,9 +8438,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "openmls_sqlite_storage"
+version = "0.2.0"
+source = "git+https://github.com/xmtp/openmls?rev=42f1479cdb06727da98132dfc2cc3959f2c66a14#42f1479cdb06727da98132dfc2cc3959f2c66a14"
+dependencies = [
+ "log",
+ "openmls_traits",
+ "refinery",
+ "rusqlite",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "openmls_test"
 version = "0.2.1"
-source = "git+https://github.com/xmtp/openmls?rev=382a4649ae4e937ce933adb259e26d6381745731#382a4649ae4e937ce933adb259e26d6381745731"
+source = "git+https://github.com/xmtp/openmls?rev=42f1479cdb06727da98132dfc2cc3959f2c66a14#42f1479cdb06727da98132dfc2cc3959f2c66a14"
 dependencies = [
  "ansi_term",
  "openmls_rust_crypto",
@@ -8432,7 +8468,7 @@ dependencies = [
 [[package]]
 name = "openmls_traits"
 version = "0.5.0"
-source = "git+https://github.com/xmtp/openmls?rev=382a4649ae4e937ce933adb259e26d6381745731#382a4649ae4e937ce933adb259e26d6381745731"
+source = "git+https://github.com/xmtp/openmls?rev=42f1479cdb06727da98132dfc2cc3959f2c66a14#42f1479cdb06727da98132dfc2cc3959f2c66a14"
 dependencies = [
  "serde",
  "tls_codec",
@@ -9799,6 +9835,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "refinery"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c427f2572afe5c6cbfa2b1bf40071c89bf1a8539e958ea582842f6f38dcfae"
+dependencies = [
+ "refinery-core",
+ "refinery-macros",
+]
+
+[[package]]
+name = "refinery-core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702655abfc67f93a6f735e9fa4ace7d2e580633f8961f28acbfd7583ddce936c"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "log",
+ "regex",
+ "rusqlite",
+ "serde",
+ "siphasher",
+ "thiserror 2.0.18",
+ "time",
+ "toml 0.8.23",
+ "url",
+ "walkdir",
+]
+
+[[package]]
+name = "refinery-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5145756cdf293b5089dc6b4f103f1a1229cc55d67082c866f8c8289531c4b983"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "refinery-core",
+ "regex",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10165,6 +10245,20 @@ name = "ruint-macro"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
+
+[[package]]
+name = "rusqlite"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
+dependencies = [
+ "bitflags 2.11.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
 
 [[package]]
 name = "rustc-demangle"
@@ -10645,6 +10739,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -11777,13 +11880,25 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap 2.13.0",
  "serde_core",
- "serde_spanned",
+ "serde_spanned 1.0.4",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -11798,11 +11913,20 @@ checksum = "399b1124a3c9e16766831c6bba21e50192572cdd98706ea114f9502509686ffc"
 dependencies = [
  "indexmap 2.13.0",
  "serde_core",
- "serde_spanned",
+ "serde_spanned 1.0.4",
  "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -11821,6 +11945,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow",
 ]
 
 [[package]]
@@ -11856,6 +11994,12 @@ checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -14356,7 +14500,7 @@ dependencies = [
  "serde",
  "serde_core",
  "serde_json",
- "serde_spanned",
+ "serde_spanned 1.0.4",
  "sha1",
  "sha3 0.10.8",
  "slab",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,11 +77,17 @@ libcrux-ed25519 = "0.0.6"
 mockall = { version = "0.14" }
 mockall_double = "0.3.1"
 once_cell = "1.2"
-openmls = { git = "https://github.com/xmtp/openmls", rev = "382a4649ae4e937ce933adb259e26d6381745731", default-features = false }
-openmls_basic_credential = { git = "https://github.com/xmtp/openmls", rev = "382a4649ae4e937ce933adb259e26d6381745731" }
-openmls_libcrux_crypto = { git = "https://github.com/xmtp/openmls", rev = "382a4649ae4e937ce933adb259e26d6381745731" }
-openmls_rust_crypto = { git = "https://github.com/xmtp/openmls", rev = "382a4649ae4e937ce933adb259e26d6381745731" }
-openmls_traits = { git = "https://github.com/xmtp/openmls", rev = "382a4649ae4e937ce933adb259e26d6381745731" }
+# This git hash does not point to main because the single line change to it (rusqlite = 0.37) has a conflict
+# with sqlx that doesn't allow cargo to resolve crates and so all of CI fails. To ensure that ongoing changes
+# to main work, we will keep it on a separate branch until this can get resolved. xmtp/openmls/main is currently
+# at 382a4649ae4e937ce933adb259e26d6381745731
+openmls = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14", default-features = false, features = [
+  "extensions-draft-08",
+] }
+openmls_basic_credential = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14" }
+openmls_libcrux_crypto = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14" }
+openmls_rust_crypto = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14" }
+openmls_traits = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14" }
 owo-colors = { version = "4.1" }
 p256 = { version = "0.13.2", features = ["ecdsa"] }
 parking_lot = "0.12.3"

--- a/crates/xmtp-workspace-hack/Cargo.toml
+++ b/crates/xmtp-workspace-hack/Cargo.toml
@@ -59,11 +59,11 @@ log = { version = "0.4", default-features = false, features = ["std"] }
 memchr = { version = "2" }
 nu-ansi-term = { version = "0.50" }
 num-traits = { version = "0.2", features = ["libm"] }
-openmls = { git = "https://github.com/xmtp/openmls", rev = "382a4649ae4e937ce933adb259e26d6381745731", default-features = false, features = ["test-utils"] }
-openmls_basic_credential = { git = "https://github.com/xmtp/openmls", rev = "382a4649ae4e937ce933adb259e26d6381745731", default-features = false, features = ["clonable", "test-utils"] }
-openmls_memory_storage = { git = "https://github.com/xmtp/openmls", rev = "382a4649ae4e937ce933adb259e26d6381745731", default-features = false, features = ["test-utils"] }
-openmls_rust_crypto = { git = "https://github.com/xmtp/openmls", rev = "382a4649ae4e937ce933adb259e26d6381745731", default-features = false, features = ["test-utils"] }
-openmls_traits = { git = "https://github.com/xmtp/openmls", rev = "382a4649ae4e937ce933adb259e26d6381745731", features = ["test-utils"] }
+openmls = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14", default-features = false, features = ["extensions-draft-08", "test-utils"] }
+openmls_basic_credential = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14", default-features = false, features = ["clonable", "test-utils"] }
+openmls_memory_storage = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14", default-features = false, features = ["extensions-draft-08", "test-utils"] }
+openmls_rust_crypto = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14", default-features = false, features = ["test-utils"] }
+openmls_traits = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14", features = ["extensions-draft-08", "test-utils"] }
 p256 = { version = "0.13", features = ["ecdh", "jwk"] }
 percent-encoding = { version = "2" }
 proc-macro2 = { version = "1", features = ["span-locations"] }
@@ -150,11 +150,11 @@ log = { version = "0.4", default-features = false, features = ["std"] }
 memchr = { version = "2" }
 nu-ansi-term = { version = "0.50" }
 num-traits = { version = "0.2", features = ["libm"] }
-openmls = { git = "https://github.com/xmtp/openmls", rev = "382a4649ae4e937ce933adb259e26d6381745731", default-features = false, features = ["test-utils"] }
-openmls_basic_credential = { git = "https://github.com/xmtp/openmls", rev = "382a4649ae4e937ce933adb259e26d6381745731", default-features = false, features = ["clonable", "test-utils"] }
-openmls_memory_storage = { git = "https://github.com/xmtp/openmls", rev = "382a4649ae4e937ce933adb259e26d6381745731", default-features = false, features = ["test-utils"] }
-openmls_rust_crypto = { git = "https://github.com/xmtp/openmls", rev = "382a4649ae4e937ce933adb259e26d6381745731", default-features = false, features = ["test-utils"] }
-openmls_traits = { git = "https://github.com/xmtp/openmls", rev = "382a4649ae4e937ce933adb259e26d6381745731", features = ["test-utils"] }
+openmls = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14", default-features = false, features = ["extensions-draft-08", "test-utils"] }
+openmls_basic_credential = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14", default-features = false, features = ["clonable", "test-utils"] }
+openmls_memory_storage = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14", default-features = false, features = ["extensions-draft-08", "test-utils"] }
+openmls_rust_crypto = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14", default-features = false, features = ["test-utils"] }
+openmls_traits = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14", features = ["extensions-draft-08", "test-utils"] }
 p256 = { version = "0.13", features = ["ecdh", "jwk"] }
 percent-encoding = { version = "2" }
 proc-macro2 = { version = "1", features = ["span-locations"] }

--- a/crates/xmtp_db/src/sql_key_store.rs
+++ b/crates/xmtp_db/src/sql_key_store.rs
@@ -364,6 +364,9 @@ const QUEUED_PROPOSAL_LABEL: &[u8] = b"QueuedProposal";
 const PROPOSAL_QUEUE_REFS_LABEL: &[u8] = b"ProposalQueueRefs";
 const RESUMPTION_PSK_STORE_LABEL: &[u8] = b"ResumptionPskStore";
 
+// related to ApplicationExportTree
+const APPLICATION_EXPORT_TREE_LABEL: &[u8] = b"ApplicationExportTree";
+
 impl<C> StorageProvider<CURRENT_VERSION> for SqlKeyStore<C>
 where
     C: ConnectionExt,
@@ -1063,6 +1066,44 @@ where
         let key = bincode::serialize(&(group_id, proposal_ref))?;
         self.delete::<CURRENT_VERSION>(QUEUED_PROPOSAL_LABEL, &key)
     }
+
+    fn write_application_export_tree<
+        GroupId: traits::GroupId<CURRENT_VERSION>,
+        ApplicationExportTree: traits::ApplicationExportTree<CURRENT_VERSION>,
+    >(
+        &self,
+        group_id: &GroupId,
+        application_export_tree: &ApplicationExportTree,
+    ) -> Result<(), Self::Error> {
+        let key = build_key::<CURRENT_VERSION, &GroupId>(APPLICATION_EXPORT_TREE_LABEL, group_id)?;
+        self.write::<CURRENT_VERSION>(
+            APPLICATION_EXPORT_TREE_LABEL,
+            &key,
+            &bincode::serialize(application_export_tree)?,
+        )
+    }
+
+    fn application_export_tree<
+        GroupId: traits::GroupId<CURRENT_VERSION>,
+        ApplicationExportTree: traits::ApplicationExportTree<CURRENT_VERSION>,
+    >(
+        &self,
+        group_id: &GroupId,
+    ) -> Result<Option<ApplicationExportTree>, Self::Error> {
+        let key = build_key::<CURRENT_VERSION, &GroupId>(APPLICATION_EXPORT_TREE_LABEL, group_id)?;
+        self.read(APPLICATION_EXPORT_TREE_LABEL, &key)
+    }
+
+    fn delete_application_export_tree<
+        GroupId: traits::GroupId<CURRENT_VERSION>,
+        ApplicationExportTree: traits::ApplicationExportTree<CURRENT_VERSION>,
+    >(
+        &self,
+        group_id: &GroupId,
+    ) -> Result<(), Self::Error> {
+        let key = build_key::<CURRENT_VERSION, &GroupId>(APPLICATION_EXPORT_TREE_LABEL, group_id)?;
+        self.delete::<CURRENT_VERSION>(APPLICATION_EXPORT_TREE_LABEL, &key)
+    }
 }
 
 /// Build a key with version and label.
@@ -1318,5 +1359,131 @@ pub(crate) mod tests {
         // Read group state
         let group_state: Option<GroupState> = provider.storage().group_state(&group_id).unwrap();
         assert_eq!(GroupState(77), group_state.unwrap());
+    }
+
+    #[xmtp_common::test]
+    async fn application_export_tree() {
+        let store = crate::TestDb::create_persistent_store(None).await;
+        let conn = store.conn();
+        let store = SqlKeyStore::new(conn);
+        let provider = XmtpOpenMlsProvider::new(store);
+
+        #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+        struct AppExportTree {
+            nodes: Vec<Vec<u8>>,
+            leaf_count: u32,
+            root_hash: [u8; 32],
+        }
+        impl traits::ApplicationExportTree<CURRENT_VERSION> for AppExportTree {}
+        impl Entity<CURRENT_VERSION> for AppExportTree {}
+
+        fn random_tree(rand: &impl openmls_traits::random::OpenMlsRand) -> AppExportTree {
+            let leaf_count = 3 + (rand.random_vec(1).unwrap()[0] % 10) as u32;
+            let nodes: Vec<Vec<u8>> = (0..leaf_count)
+                .map(|_| rand.random_vec(64).unwrap())
+                .collect();
+            AppExportTree {
+                nodes,
+                leaf_count,
+                root_hash: xmtp_common::rand_array(),
+            }
+        }
+
+        let group_id_1 = GroupId::random(provider.rand());
+        let group_id_2 = GroupId::random(provider.rand());
+        let tree_1 = random_tree(provider.rand());
+        let tree_2 = random_tree(provider.rand());
+
+        // Read before write should return None
+        let result: Option<AppExportTree> = provider
+            .storage()
+            .application_export_tree(&group_id_1)
+            .unwrap();
+        assert!(result.is_none());
+
+        // Write tree for group 1
+        provider
+            .storage()
+            .write_application_export_tree(&group_id_1, &tree_1)
+            .unwrap();
+
+        // Read back group 1
+        let result: Option<AppExportTree> = provider
+            .storage()
+            .application_export_tree(&group_id_1)
+            .unwrap();
+        assert_eq!(result.unwrap(), tree_1);
+
+        // Group 2 should still be None
+        let result: Option<AppExportTree> = provider
+            .storage()
+            .application_export_tree(&group_id_2)
+            .unwrap();
+        assert!(result.is_none());
+
+        // Write tree for group 2
+        provider
+            .storage()
+            .write_application_export_tree(&group_id_2, &tree_2)
+            .unwrap();
+        let result: Option<AppExportTree> = provider
+            .storage()
+            .application_export_tree(&group_id_2)
+            .unwrap();
+        assert_eq!(result.unwrap(), tree_2);
+
+        // Overwrite group 1 with new data
+        let tree_1_updated = random_tree(provider.rand());
+        provider
+            .storage()
+            .write_application_export_tree(&group_id_1, &tree_1_updated)
+            .unwrap();
+        let result: Option<AppExportTree> = provider
+            .storage()
+            .application_export_tree(&group_id_1)
+            .unwrap();
+        assert_eq!(result.unwrap(), tree_1_updated);
+
+        // Group 2 should be unaffected
+        let result: Option<AppExportTree> = provider
+            .storage()
+            .application_export_tree(&group_id_2)
+            .unwrap();
+        assert_eq!(result.unwrap(), tree_2);
+
+        // Delete group 1
+        provider
+            .storage()
+            .delete_application_export_tree::<GroupId, AppExportTree>(&group_id_1)
+            .unwrap();
+        let result: Option<AppExportTree> = provider
+            .storage()
+            .application_export_tree(&group_id_1)
+            .unwrap();
+        assert!(result.is_none());
+
+        // Group 2 should still exist
+        let result: Option<AppExportTree> = provider
+            .storage()
+            .application_export_tree(&group_id_2)
+            .unwrap();
+        assert_eq!(result.unwrap(), tree_2);
+
+        // Delete group 2
+        provider
+            .storage()
+            .delete_application_export_tree::<GroupId, AppExportTree>(&group_id_2)
+            .unwrap();
+        let result: Option<AppExportTree> = provider
+            .storage()
+            .application_export_tree(&group_id_2)
+            .unwrap();
+        assert!(result.is_none());
+
+        // Deleting again should not error
+        provider
+            .storage()
+            .delete_application_export_tree::<GroupId, AppExportTree>(&group_id_1)
+            .unwrap();
     }
 }

--- a/crates/xmtp_db/src/sql_key_store/mock.rs
+++ b/crates/xmtp_db/src/sql_key_store/mock.rs
@@ -728,4 +728,41 @@ impl StorageProvider<CURRENT_VERSION> for MockSqlKeyStore {
         self.in_memory
             .remove_proposal::<GroupId, ProposalRef>(group_id, proposal_ref)
     }
+
+    fn write_application_export_tree<
+        GroupId: traits::GroupId<CURRENT_VERSION>,
+        ApplicationExportTree: traits::ApplicationExportTree<CURRENT_VERSION>,
+    >(
+        &self,
+        group_id: &GroupId,
+        application_export_tree: &ApplicationExportTree,
+    ) -> Result<(), Self::Error> {
+        self.in_memory
+            .write_application_export_tree::<GroupId, ApplicationExportTree>(
+                group_id,
+                application_export_tree,
+            )
+    }
+
+    fn application_export_tree<
+        GroupId: traits::GroupId<CURRENT_VERSION>,
+        ApplicationExportTree: traits::ApplicationExportTree<CURRENT_VERSION>,
+    >(
+        &self,
+        group_id: &GroupId,
+    ) -> Result<Option<ApplicationExportTree>, Self::Error> {
+        self.in_memory
+            .application_export_tree::<GroupId, ApplicationExportTree>(group_id)
+    }
+
+    fn delete_application_export_tree<
+        GroupId: traits::GroupId<CURRENT_VERSION>,
+        ApplicationExportTree: traits::ApplicationExportTree<CURRENT_VERSION>,
+    >(
+        &self,
+        group_id: &GroupId,
+    ) -> Result<(), Self::Error> {
+        self.in_memory
+            .delete_application_export_tree::<GroupId, ApplicationExportTree>(group_id)
+    }
 }

--- a/crates/xmtp_mls/src/groups/validated_commit.rs
+++ b/crates/xmtp_mls/src/groups/validated_commit.rs
@@ -15,7 +15,7 @@ use openmls::{
     credentials::{BasicCredential, Credential as OpenMlsCredential, errors::BasicCredentialError},
     extensions::{Extension, Extensions, UnknownExtension},
     group::{GroupContext, MlsGroup as OpenMlsGroup, QueuedProposal, StagedCommit},
-    messages::proposals::Proposal,
+    messages::proposals::{Proposal, ProposalType},
     prelude::{LeafNodeIndex, Sender},
     treesync::LeafNode,
 };
@@ -90,14 +90,10 @@ pub enum CommitValidationError {
     InstallationDiff(#[from] InstallationDiffError),
     #[error("Failed to parse group mutable permissions: {0}")]
     GroupMutablePermissions(#[from] GroupMutablePermissionsError),
-    #[error("PSKs are not support")]
+    #[error("PSKs are not supported")]
     NoPSKSupport,
-    #[error("External init proposals are not supported")]
-    ExternalInitProposalNotSupported,
-    #[error("ReInit proposals are not supported")]
-    ReInitProposalNotSupported,
-    #[error("SelfRemove proposals are not supported")]
-    SelfRemoveProposalNotSupported,
+    #[error("Unsupported proposal type: {0:?}")]
+    UnsupportedProposalType(ProposalType),
     #[error(transparent)]
     StorageError(#[from] StorageError),
     #[error("Exceeded max characters for this field. Must be under: {length}")]
@@ -1265,6 +1261,9 @@ pub fn validate_proposal(
         }
     };
 
+    let unsupported_error =
+        || CommitValidationError::UnsupportedProposalType(proposal.proposal().proposal_type());
+
     // Validate based on proposal type
     match proposal.proposal() {
         Proposal::Add(add_proposal) => {
@@ -1414,24 +1413,42 @@ pub fn validate_proposal(
                 return Err(CommitValidationError::InsufficientPermissions);
             }
         }
-        Proposal::Update(_) => {
-            // Update proposals (key updates) are always allowed for the member themselves
+        Proposal::Update(update_proposal) => {
+            // Update proposals are allowed for the member themselves, but the new leaf node's
+            // credential must match the proposer's identity to prevent identity swaps.
+            let new_inbox_id = inbox_id_from_credential(update_proposal.leaf_node().credential())?;
+            if new_inbox_id != proposer.inbox_id {
+                tracing::warn!(
+                    proposer_inbox_id = %proposer.inbox_id,
+                    proposer_installation_id = hex::encode(&proposer.installation_id),
+                    leaf_index = ?proposal.sender(),
+                    new_inbox_id = %new_inbox_id,
+                    new_installation_id = hex::encode(update_proposal.leaf_node().signature_key().as_slice()),
+                    "Update proposal rejected: new leaf node credential does not match proposer"
+                );
+                return Err(CommitValidationError::ActorNotMember);
+            }
         }
         Proposal::PreSharedKey(_) => {
-            // PSK proposals are not supported
-            return Err(CommitValidationError::NoPSKSupport);
+            return Err(unsupported_error());
         }
         Proposal::ReInit(_) => {
-            return Err(CommitValidationError::ReInitProposalNotSupported);
+            return Err(unsupported_error());
         }
         Proposal::ExternalInit(_) => {
-            return Err(CommitValidationError::ExternalInitProposalNotSupported);
+            return Err(unsupported_error());
         }
         Proposal::Custom(_) => {
-            // Custom proposals - allow by default, will be validated at commit time
+            return Err(unsupported_error());
+        }
+        Proposal::AppDataUpdate(_) => {
+            return Err(unsupported_error());
+        }
+        Proposal::AppEphemeral(_) => {
+            return Err(unsupported_error());
         }
         Proposal::SelfRemove => {
-            return Err(CommitValidationError::SelfRemoveProposalNotSupported);
+            return Err(unsupported_error());
         }
     }
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Enable `extensions-draft-08` feature on openmls and add `ApplicationExportTree` storage support
- Updates all openmls-related git dependencies to rev `42f1479cdb06727da98132dfc2cc3959f2c66a14` and enables the `extensions-draft-08` feature flag on openmls in [Cargo.toml](https://github.com/xmtp/libxmtp/pull/3311/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542) and [xmtp-workspace-hack/Cargo.toml](https://github.com/xmtp/libxmtp/pull/3311/files#diff-d376defcdc6ba9d6bc902fe0f3e91f5d4b09191e5bcc2776cf4fdf65e467df65).
- Adds `write_application_export_tree`, `application_export_tree`, and `delete_application_export_tree` to `SqlKeyStore` in [sql_key_store.rs](https://github.com/xmtp/libxmtp/pull/3311/files#diff-8634bcb374db4ae6216e2c4af6aa38e77aaffe5e5249bb0ac7f0d2bfd4975d35), with matching mock implementations in [mock.rs](https://github.com/xmtp/libxmtp/pull/3311/files#diff-8a08dcbf72dc12c9ca95b0348d4404dfe4dbb15da5cb51df698a2407fb1884ae).
- Consolidates unsupported-proposal error variants in `CommitValidationError` into a single `UnsupportedProposalType(ProposalType)` variant, and adds explicit rejection for `Custom`, `AppDataUpdate`, and `AppEphemeral` proposal types in [validated_commit.rs](https://github.com/xmtp/libxmtp/pull/3311/files#diff-233994c0ec18d23d0636e849849a3500e44611a4f64c6fffb1d0931aa1461ed6).
- Adds a credential inbox_id check for `Update` proposals, rejecting the proposal with `ActorNotMember` if the new leaf node credential does not match the proposer.
- Risk: `Custom` proposals that were previously allowed are now rejected as `UnsupportedProposalType`, which is a breaking behavioral change for any callers relying on custom proposal handling.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3029264.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->