### PR TITLE
Simplify cursor store

### DIFF
--- a/crates/xmtp_api_d14n/src/protocol/in_memory_cursor_store.rs
+++ b/crates/xmtp_api_d14n/src/protocol/in_memory_cursor_store.rs
@@ -60,25 +60,18 @@ impl CursorStore for InMemoryCursorStore {
     fn latest(
         &self,
         topic: &xmtp_proto::types::Topic,
+        originators: Option<&[&OriginatorId]>,
     ) -> Result<GlobalCursor, crate::protocol::CursorStoreError> {
-        Ok(self
-            .get_latest(topic)
-            .cloned()
-            .unwrap_or_else(GlobalCursor::default))
-    }
-
-    fn latest_per_originator(
-        &self,
-        topic: &xmtp_proto::types::Topic,
-        originators: &[&OriginatorId],
-    ) -> Result<GlobalCursor, crate::protocol::CursorStoreError> {
-        Ok(self
-            .get_latest(topic)
-            .unwrap_or(&Default::default())
-            .iter()
-            .filter(|(k, _)| originators.contains(k))
-            .map(|(&k, &v)| (k, v))
-            .collect())
+        let cursor = self.get_latest(topic).cloned().unwrap_or_default();
+        if let Some(oids) = originators {
+            Ok(cursor
+                .iter()
+                .filter(|(k, _)| oids.contains(k))
+                .map(|(&k, &v)| (k, v))
+                .collect())
+        } else {
+            Ok(cursor)
+        }
     }
 
     fn latest_for_topics(
@@ -86,7 +79,7 @@ impl CursorStore for InMemoryCursorStore {
         topics: &mut dyn Iterator<Item = &Topic>,
     ) -> Result<HashMap<Topic, GlobalCursor>, super::CursorStoreError> {
         Ok(topics
-            .map(|topic| (topic.clone(), self.latest(topic).unwrap_or_default()))
+            .map(|topic| (topic.clone(), self.latest(topic, None).unwrap_or_default()))
             .collect())
     }
 

--- a/crates/xmtp_api_d14n/src/protocol/traits/cursor_store.rs
+++ b/crates/xmtp_api_d14n/src/protocol/traits/cursor_store.rs
@@ -46,86 +46,94 @@ impl From<CursorStoreError> for ApiClientError {
 /// _NOTE:_, implementations decide retry strategy. the exact implementation of persistence (or lack)
 /// is up to implementors. functions are assumed to be idempotent & atomic.
 pub trait CursorStore: MaybeSend + MaybeSync {
-    /// get the highest sequence id for a topic, regardless of originator
-    fn latest(&self, topic: &Topic) -> Result<GlobalCursor, CursorStoreError>;
-
-    /// Get the latest cursor for each originator
-    fn latest_per_originator(
+    /// Return the highest sequence id seen for each originator on a given topic.
+    ///
+    /// Pass `None` for `originators` to return cursors for all known originators (used by d14n
+    /// callers that subscribe to every originator). Pass `Some(&[...])` to restrict the result
+    /// to specific originators (used by v3 callers that only care about e.g. commits + app
+    /// messages).
+    fn latest(
         &self,
         topic: &Topic,
-        originators: &[&OriginatorId],
+        originators: Option<&[&OriginatorId]>,
     ) -> Result<GlobalCursor, CursorStoreError>;
 
+    /// Convenience wrapper around [`latest`](Self::latest) that returns a single [`Cursor`] for
+    /// one originator. Used when a caller needs the sequence id for exactly one originator on a
+    /// topic (e.g. welcome messages on v3).
     fn latest_for_originator(
         &self,
         topic: &Topic,
         originator: &OriginatorId,
     ) -> Result<Cursor, CursorStoreError> {
-        let sid = self
-            .latest_per_originator(topic, &[originator])?
-            .get(originator);
+        let sid = self.latest(topic, Some(&[originator]))?.get(originator);
         Ok(Cursor::new(sid, *originator))
     }
 
-    /// Get the latest cursor for multiple topics at once.
-    /// Returns a HashMap mapping each topic to its GlobalCursor.
+    /// Batch version of [`latest`](Self::latest) — returns the latest cursor for every topic in
+    /// the iterator, without originator filtering. Used when subscribing to many group topics at
+    /// once so that the stream can resume from the right position per-topic.
     fn latest_for_topics(
         &self,
         topics: &mut dyn Iterator<Item = &Topic>,
     ) -> Result<HashMap<Topic, GlobalCursor>, CursorStoreError>;
 
-    /// find dependencies of each locally-stored intent payload hash
+    /// Look up the cursor that each locally-published intent depends on, keyed by the intent's
+    /// payload hash. The returned cursors are attached as `depends_on` metadata when publishing
+    /// group messages so that the ordering layer can enforce causal delivery.
     fn find_message_dependencies(
         &self,
         hashes: &[&[u8]],
     ) -> Result<HashMap<Vec<u8>, Cursor>, CursorStoreError>;
 
-    /// ice envelopes that cannot yet be processed
+    /// Stash envelopes whose causal dependencies have not yet been seen (the "icebox").
+    /// They will be retried later when [`resolve_children`](Self::resolve_children) finds that
+    /// their parent cursors have arrived.
     fn ice(&self, orphans: Vec<OrphanedEnvelope>) -> Result<(), CursorStoreError>;
 
-    /// try to resolve any children that may depend on [`Cursor`]
+    /// Check the icebox for envelopes whose causal dependencies are now satisfied by the given
+    /// cursors. Returns the envelopes that are ready to be processed, removing them from the
+    /// icebox.
     fn resolve_children(
         &self,
         cursors: &[Cursor],
     ) -> Result<Vec<OrphanedEnvelope>, CursorStoreError>;
 
-    /// Update the d14n migration cutover timestamp (nanoseconds)
+    /// Set the d14n migration cutover timestamp (nanoseconds since epoch). Messages with a
+    /// server timestamp at or after this value should be fetched from the d14n network instead
+    /// of v3.
     fn set_cutover_ns(&self, cutover_ns: i64) -> Result<(), CursorStoreError>;
 
-    /// Get the d14n migration cutover timestamp (nanoseconds)
+    /// Get the d14n migration cutover timestamp (nanoseconds since epoch).
+    /// Returns `i64::MAX` when no cutover has been set yet.
     fn get_cutover_ns(&self) -> Result<i64, CursorStoreError>;
 
-    /// Get the last time we checked for migration cutover (nanoseconds)
+    /// Get the last time (nanoseconds since epoch) we polled the network for a migration
+    /// cutover update. Used to throttle how often we check.
     fn get_last_checked_ns(&self) -> Result<i64, CursorStoreError>;
 
-    /// Update the last time we checked for migration cutover (nanoseconds)
+    /// Record the current time (nanoseconds since epoch) as the last migration-cutover check.
     fn set_last_checked_ns(&self, last_checked_ns: i64) -> Result<(), CursorStoreError>;
 
-    /// Check whether the d14n migration has already been completed
+    /// Returns `true` if the d14n migration has been fully completed and the client should
+    /// operate exclusively against the d14n network.
     fn has_migrated(&self) -> Result<bool, CursorStoreError>;
 
-    /// Mark the d14n migration as completed
+    /// Mark the d14n migration as completed (or not). Once set to `true`, the client stops
+    /// querying v3 endpoints entirely.
     fn set_has_migrated(&self, has_migrated: bool) -> Result<(), CursorStoreError>;
 }
 
 impl<T: CursorStore> CursorStore for Option<T> {
-    fn latest(&self, topic: &Topic) -> Result<GlobalCursor, CursorStoreError> {
-        if let Some(c) = self {
-            c.latest(topic)
-        } else {
-            NoCursorStore.latest(topic)
-        }
-    }
-
-    fn latest_per_originator(
+    fn latest(
         &self,
         topic: &Topic,
-        originators: &[&OriginatorId],
+        originators: Option<&[&OriginatorId]>,
     ) -> Result<GlobalCursor, CursorStoreError> {
         if let Some(c) = self {
-            c.latest_per_originator(topic, originators)
+            c.latest(topic, originators)
         } else {
-            NoCursorStore.latest_per_originator(topic, originators)
+            NoCursorStore.latest(topic, originators)
         }
     }
 
@@ -219,16 +227,12 @@ impl<T: CursorStore> CursorStore for Option<T> {
 }
 
 impl<T: CursorStore + ?Sized> CursorStore for &T {
-    fn latest(&self, topic: &Topic) -> Result<GlobalCursor, CursorStoreError> {
-        (**self).latest(topic)
-    }
-
-    fn latest_per_originator(
+    fn latest(
         &self,
         topic: &Topic,
-        originators: &[&OriginatorId],
+        originators: Option<&[&OriginatorId]>,
     ) -> Result<GlobalCursor, CursorStoreError> {
-        (**self).latest_per_originator(topic, originators)
+        (**self).latest(topic, originators)
     }
 
     fn latest_for_topics(
@@ -282,16 +286,12 @@ impl<T: CursorStore + ?Sized> CursorStore for &T {
 }
 
 impl<T: CursorStore + ?Sized> CursorStore for Arc<T> {
-    fn latest(&self, topic: &Topic) -> Result<GlobalCursor, CursorStoreError> {
-        (**self).latest(topic)
-    }
-
-    fn latest_per_originator(
+    fn latest(
         &self,
         topic: &Topic,
-        originators: &[&OriginatorId],
+        originators: Option<&[&OriginatorId]>,
     ) -> Result<GlobalCursor, CursorStoreError> {
-        (**self).latest_per_originator(topic, originators)
+        (**self).latest(topic, originators)
     }
 
     fn latest_for_topics(
@@ -345,16 +345,12 @@ impl<T: CursorStore + ?Sized> CursorStore for Arc<T> {
 }
 
 impl<T: CursorStore + ?Sized> CursorStore for Box<T> {
-    fn latest(&self, topic: &Topic) -> Result<GlobalCursor, CursorStoreError> {
-        (**self).latest(topic)
-    }
-
-    fn latest_per_originator(
+    fn latest(
         &self,
         topic: &Topic,
-        originators: &[&OriginatorId],
+        originators: Option<&[&OriginatorId]>,
     ) -> Result<GlobalCursor, CursorStoreError> {
-        (**self).latest_per_originator(topic, originators)
+        (**self).latest(topic, originators)
     }
 
     fn latest_for_topics(
@@ -412,14 +408,10 @@ impl<T: CursorStore + ?Sized> CursorStore for Box<T> {
 pub struct NoCursorStore;
 
 impl CursorStore for NoCursorStore {
-    fn latest(&self, _: &Topic) -> Result<GlobalCursor, CursorStoreError> {
-        Ok(GlobalCursor::default())
-    }
-
-    fn latest_per_originator(
+    fn latest(
         &self,
         _: &Topic,
-        _: &[&OriginatorId],
+        _: Option<&[&OriginatorId]>,
     ) -> Result<GlobalCursor, CursorStoreError> {
         Ok(GlobalCursor::default())
     }

--- a/crates/xmtp_api_d14n/src/queries/d14n/mls.rs
+++ b/crates/xmtp_api_d14n/src/queries/d14n/mls.rs
@@ -138,7 +138,7 @@ where
         group_id: GroupId,
     ) -> Result<Vec<xmtp_proto::types::GroupMessage>, Self::Error> {
         let topic = TopicKind::GroupMessagesV1.create(&group_id);
-        let cursor = self.cursor_store.latest(&topic)?;
+        let cursor = self.cursor_store.latest(&topic, None)?;
         tracing::debug!(%topic, %cursor, "querying messages");
         let mut topic_cursor = TopicCursor::default();
         topic_cursor.insert(topic.clone(), cursor.clone());
@@ -192,7 +192,7 @@ where
         installation_key: InstallationId,
     ) -> Result<Vec<WelcomeMessage>, Self::Error> {
         let topic = TopicKind::WelcomeMessagesV1.create(installation_key);
-        let cursor = self.cursor_store.latest(&topic)?;
+        let cursor = self.cursor_store.latest(&topic, None)?;
         tracing::info!("querying welcomes @{:?}", cursor);
         let response = QueryEnvelope::builder()
             .topic(topic)

--- a/crates/xmtp_api_d14n/src/queries/d14n/streams.rs
+++ b/crates/xmtp_api_d14n/src/queries/d14n/streams.rs
@@ -102,7 +102,7 @@ where
             .collect::<Vec<_>>();
         let mut topic_cursor = TopicCursor::default();
         for topic in &topics {
-            let cursor = self.cursor_store.latest(topic)?;
+            let cursor = self.cursor_store.latest(topic, None)?;
             tracing::debug!(
                 "subscribing to welcome messages for topic {} @cursor={}",
                 topic,

--- a/crates/xmtp_api_d14n/src/queries/d14n/test/send_group_message.rs
+++ b/crates/xmtp_api_d14n/src/queries/d14n/test/send_group_message.rs
@@ -106,14 +106,10 @@ pub struct TestCursorStore {
 }
 
 impl CursorStore for TestCursorStore {
-    fn latest(&self, _: &Topic) -> Result<GlobalCursor, CursorStoreError> {
-        unreachable!()
-    }
-
-    fn latest_per_originator(
+    fn latest(
         &self,
         _: &Topic,
-        _: &[&OriginatorId],
+        _: Option<&[&OriginatorId]>,
     ) -> Result<GlobalCursor, CursorStoreError> {
         unreachable!()
     }

--- a/crates/xmtp_api_d14n/src/queries/v3/mls.rs
+++ b/crates/xmtp_api_d14n/src/queries/v3/mls.rs
@@ -66,12 +66,12 @@ where
         let topic = &TopicKind::GroupMessagesV1.create(&group_id);
         let cursor = self
             .cursor_store
-            .latest_per_originator(
+            .latest(
                 topic,
-                &[
+                Some(&[
                     &Originators::APPLICATION_MESSAGES,
                     &Originators::MLS_COMMITS,
-                ],
+                ]),
             )?
             .max();
         let endpoint = QueryGroupMessages::builder()

--- a/crates/xmtp_db/src/encrypted_store/refresh_state.rs
+++ b/crates/xmtp_db/src/encrypted_store/refresh_state.rs
@@ -2,14 +2,12 @@ use std::collections::HashMap;
 
 use diesel::{
     backend::Backend,
-    connection::DefaultLoadingMode,
     deserialize::{self, FromSql, FromSqlRow},
     expression::AsExpression,
     prelude::*,
     serialize::{self, IsNull, Output, ToSql},
-    sql_types::{BigInt, Binary, Integer},
+    sql_types::Integer,
 };
-use itertools::Itertools;
 use xmtp_configuration::Originators;
 use xmtp_proto::types::{Cursor, GlobalCursor, OriginatorId};
 
@@ -111,15 +109,6 @@ pub struct RefreshState {
 
 impl_store_or_ignore!(RefreshState, refresh_state);
 
-#[derive(QueryableByName, Selectable)]
-#[diesel(check_for_backend(Sqlite), table_name = super::schema::refresh_state)]
-struct SingleCursor {
-    #[diesel(sql_type = Integer)]
-    originator_id: i32,
-    #[diesel(sql_type = BigInt)]
-    sequence_id: i64,
-}
-
 /// Helper function to convert rows of (entity_id, originator_id, sequence_id) into a HashMap
 /// where each entity_id maps to a GlobalCursor containing all its originator->sequence_id pairs.
 /// Null sequence_id values are coalesced to 0.
@@ -185,13 +174,6 @@ pub trait QueryRefreshState {
         originators: Option<&[&OriginatorId]>,
     ) -> Result<GlobalCursor, StorageError>;
 
-    fn latest_cursor_combined<Id: AsRef<[u8]>>(
-        &self,
-        entity_id: Id,
-        entities: &[EntityKind],
-        originators: Option<&[&OriginatorId]>,
-    ) -> Result<GlobalCursor, StorageError>;
-
     fn get_remote_log_cursors(
         &self,
         conversation_ids: &[&Vec<u8>],
@@ -248,15 +230,6 @@ impl<T: QueryRefreshState> QueryRefreshState for &'_ T {
         originators: Option<&[&OriginatorId]>,
     ) -> Result<GlobalCursor, StorageError> {
         (**self).latest_cursor_for_id(entity_id, entities, originators)
-    }
-
-    fn latest_cursor_combined<Id: AsRef<[u8]>>(
-        &self,
-        entity_id: Id,
-        entities: &[EntityKind],
-        originators: Option<&[&OriginatorId]>,
-    ) -> Result<GlobalCursor, StorageError> {
-        (**self).latest_cursor_combined(entity_id, entities, originators)
     }
 }
 
@@ -462,109 +435,6 @@ impl<C: ConnectionExt> QueryRefreshState for DbConnection<C> {
                 .into_iter()
                 .filter_map(|(orig_id, seq_id)| seq_id.map(|seq| (orig_id as u32, seq as u64)))
                 .collect::<GlobalCursor>())
-        })?;
-
-        Ok(cursor_map)
-    }
-
-    // _NOTE:_ TEMP until reliable streams
-    // and cursor can be updated from streams
-    fn latest_cursor_combined<Id: AsRef<[u8]>>(
-        &self,
-        entity_id: Id,
-        entities: &[EntityKind],
-        originators: Option<&[&OriginatorId]>,
-    ) -> Result<GlobalCursor, StorageError> {
-        let entity_ref = entity_id.as_ref();
-
-        // Build entity_kind placeholders for refresh_state
-        let entity_kind_placeholders = entities.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
-
-        // Map EntityKind to GroupMessageKind
-        let group_message_kinds: Vec<i32> = entities
-            .iter()
-            .filter_map(|e| match e {
-                EntityKind::ApplicationMessage => Some(1), // GroupMessageKind::Application
-                EntityKind::CommitMessage => Some(2),      // GroupMessageKind::MembershipChange
-                _ => None,
-            })
-            .collect();
-
-        // Build a query that unions refresh_state and (optionally) group_messages
-        let mut query = if group_message_kinds.is_empty() {
-            format!(
-                "SELECT originator_id, MAX(sequence_id) AS sequence_id
-                FROM (
-                    SELECT originator_id, sequence_id
-                    FROM refresh_state
-                    WHERE entity_id = ? AND entity_kind IN ({})",
-                entity_kind_placeholders
-            )
-        } else {
-            let kind_placeholders = group_message_kinds
-                .iter()
-                .map(|_| "?")
-                .collect::<Vec<_>>()
-                .join(", ");
-            format!(
-                "SELECT originator_id, MAX(sequence_id) AS sequence_id
-                FROM (
-                    SELECT originator_id, sequence_id
-                    FROM refresh_state
-                    WHERE entity_id = ? AND entity_kind IN ({})
-                    UNION ALL
-                    SELECT originator_id, sequence_id
-                    FROM group_messages
-                    WHERE group_id = ? AND kind IN ({})",
-                entity_kind_placeholders, kind_placeholders
-            )
-        };
-
-        // Add originator filter if provided
-        if let Some(oids) = originators {
-            let originator_placeholders = oids.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
-            query.push_str(&format!(
-                "
-            ) WHERE originator_id IN ({})
-            GROUP BY originator_id",
-                originator_placeholders
-            ));
-        } else {
-            query.push_str(
-                "
-            ) GROUP BY originator_id",
-            );
-        }
-
-        let cursor_map = self.raw_query_read(|conn| {
-            let mut q = diesel::sql_query(query).into_boxed();
-
-            // Bind entity_id for refresh_state
-            q = q.bind::<Binary, _>(entity_ref);
-
-            // Bind entity_kinds for refresh_state
-            for kind in entities {
-                q = q.bind::<Integer, _>(*kind);
-            }
-
-            // Bind group_id and group_message_kinds for group_messages (only when UNION clause is present)
-            if !group_message_kinds.is_empty() {
-                q = q.bind::<Binary, _>(entity_ref);
-                for kind in &group_message_kinds {
-                    q = q.bind::<Integer, _>(*kind);
-                }
-            }
-
-            // Bind originators if provided
-            if let Some(oids) = originators {
-                for oid in oids {
-                    q = q.bind::<Integer, _>(**oid as i32);
-                }
-            }
-
-            q.load_iter::<SingleCursor, DefaultLoadingMode>(conn)?
-                .map_ok(|c| (c.originator_id as u32, c.sequence_id as u64))
-                .collect::<QueryResult<GlobalCursor>>()
         })?;
 
         Ok(cursor_map)

--- a/crates/xmtp_db/src/mock.rs
+++ b/crates/xmtp_db/src/mock.rs
@@ -626,14 +626,6 @@ mock! {
             originators: Option<&[&xmtp_proto::types::OriginatorId]>
         ) -> Result<xmtp_proto::types::GlobalCursor, StorageError>;
 
-        #[mockall::concretize]
-        fn latest_cursor_combined<Id: AsRef<[u8]>>(
-            &self,
-            entity_id: Id,
-            entities: &[crate::refresh_state::EntityKind],
-            originators: Option<&[&xmtp_proto::types::OriginatorId]>,
-        ) -> Result<GlobalCursor, StorageError>;
-
     }
 
     impl QueryIdentityUpdates for DbQuery {

--- a/crates/xmtp_mls/src/cursor_store.rs
+++ b/crates/xmtp_mls/src/cursor_store.rs
@@ -34,50 +34,22 @@ where
         + MaybeSend
         + MaybeSync,
 {
-    fn latest(&self, topic: &Topic) -> Result<GlobalCursor, CursorStoreError> {
-        match topic.kind() {
-            TopicKind::WelcomeMessagesV1 => {
-                let ids = vec![EntityKind::Welcome];
-                self.db
-                    .latest_cursor_for_id(topic.identifier(), &ids, None)
-                    .map_err(CursorStoreError::other)
-            }
-            TopicKind::GroupMessagesV1 => {
-                let ids = vec![EntityKind::ApplicationMessage, EntityKind::CommitMessage];
-                self.db
-                    .latest_cursor_for_id(topic.identifier(), &ids, None)
-                    .map_err(CursorStoreError::other)
-            }
-            TopicKind::IdentityUpdatesV1 => {
-                let sid = self
-                    .db
-                    .get_latest_sequence_id_for_inbox(&hex::encode(topic.identifier()))
-                    .map_err(CursorStoreError::other)?;
-                let mut map = GlobalCursor::default();
-                map.insert(Originators::INBOX_LOG, sid as u64);
-                Ok(map)
-            }
-            TopicKind::KeyPackagesV1 => Ok(GlobalCursor::default()),
-            _ => Err(CursorStoreError::UnhandledTopicKind(topic.kind())),
-        }
-    }
-
-    fn latest_per_originator(
+    fn latest(
         &self,
         topic: &Topic,
-        originators: &[&OriginatorId],
+        originators: Option<&[&OriginatorId]>,
     ) -> Result<GlobalCursor, CursorStoreError> {
         match topic.kind() {
             TopicKind::WelcomeMessagesV1 => {
                 let entities = vec![EntityKind::Welcome];
                 self.db
-                    .latest_cursor_for_id(topic.identifier(), &entities, Some(originators))
+                    .latest_cursor_for_id(topic.identifier(), &entities, originators)
                     .map_err(CursorStoreError::other)
             }
             TopicKind::GroupMessagesV1 => {
                 let entities = vec![EntityKind::ApplicationMessage, EntityKind::CommitMessage];
                 self.db
-                    .latest_cursor_for_id(topic.identifier(), &entities, Some(originators))
+                    .latest_cursor_for_id(topic.identifier(), &entities, originators)
                     .map_err(CursorStoreError::other)
             }
             TopicKind::IdentityUpdatesV1 => {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Simplify `CursorStore` trait by merging `latest` and `latest_per_originator` into a single method
- Replaces the two-method API (`latest` and `latest_per_originator`) with a single `latest(topic, originators: Option<&[&OriginatorId]>)` on the `CursorStore` trait in [cursor_store.rs](https://github.com/xmtp/libxmtp/pull/3314/files#diff-8e97be8c00cd75a758e53fca0215669354dbada839ccd400d4e1aeda275d3262).
- Passing `None` returns the full `GlobalCursor`; passing `Some(&[...])` filters to the specified originators — equivalent to the old `latest_per_originator`.
- Updates all implementations (`InMemoryCursorStore`, `DbCursorStore`, `NoCursorStore`, and wrapper impls for `Arc`, `Box`, `Option`, `&T`) and all call sites in [mls.rs](https://github.com/xmtp/libxmtp/pull/3314/files#diff-cc985f17612804e1556bdef7f028694c7f422db3d9fec66b4dfe5a7b1df967a0), [streams.rs](https://github.com/xmtp/libxmtp/pull/3314/files#diff-c2d1b2a25d9a5d66dc9a2c86cd3ba045329e44e01db8eb15bb25c7db8ad88f15), and [v3/mls.rs](https://github.com/xmtp/libxmtp/pull/3314/files#diff-80fdce43dc75756529d260150c00dde3ec3699c9edfe79a9dbfe7edd00d2476b).
- Removes the now-unused `latest_cursor_combined` method from `QueryRefreshState` in [refresh_state.rs](https://github.com/xmtp/libxmtp/pull/3314/files#diff-8b4b704a1951b4927fb09bedfebcd65145cb69667a2b4116ac7dd2a1b0ea9e69).

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5cd09ea.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->