### PR TITLE
Fix flaky tests

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -33,6 +33,9 @@ jobs:
 
       - uses: ./.github/actions/setup-rust
 
+      - name: Install fontconfig
+        run: sudo apt-get update && sudo apt-get install -y libfontconfig-dev
+
       - name: Invoke cargo doc
         run: ./dev/docs
         id: docgen

--- a/.github/workflows/test-workspace.yml
+++ b/.github/workflows/test-workspace.yml
@@ -25,7 +25,7 @@ jobs:
         uses: jwalton/gh-docker-logs@v2
       - name: Run tests (v3 + d14n with coverage)
         # use `nix build` instead of `nix flake check` because we need the resulting coverage
-        run: nix build .#checks.x86_64-linux.nextest-v3 .#checks.x86_64-linux.nextest-d14n
+        run: nix build .#nextest.x86_64-linux.v3 .#nextest.x86_64-linux.d14n
 
       - name: merge coverage files
         run: nix run nixpkgs#lcov -- --add-tracefile result/coverage --add-tracefile result-1/coverage --output-file lcov.info

--- a/apps/xmtp_debug/src/main.rs
+++ b/apps/xmtp_debug/src/main.rs
@@ -1,4 +1,4 @@
-#![recursion_limit = "256"]
+#![recursion_limit = "512"]
 
 mod app;
 mod args;

--- a/crates/xmtp_mls/src/identity_updates.rs
+++ b/crates/xmtp_mls/src/identity_updates.rs
@@ -797,13 +797,22 @@ pub(crate) mod tests {
             .unwrap();
 
         let conn = client.context.db();
-        let state = client_identity_updates
-            .get_latest_association_state(&conn, client.inbox_id())
-            .await
-            .unwrap();
 
         // The installation, wallet1 address, and the newly associated wallet2 address
-        assert_eq!(state.members().len(), 3);
+        // Use wait_for_eq to handle eventual consistency after apply_signature_request
+        xmtp_common::wait_for_eq(
+            || async {
+                client_identity_updates
+                    .get_latest_association_state(&conn, client.inbox_id())
+                    .await
+                    .unwrap()
+                    .members()
+                    .len()
+            },
+            3,
+        )
+        .await
+        .unwrap();
 
         let api_client = client.context.api();
 

--- a/dev/docker/up
+++ b/dev/docker/up
@@ -2,7 +2,18 @@
 set -eou pipefail
 script_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
-"${script_dir}"/compose pull
+# Retry compose pull up to 3 times to handle transient registry timeouts
+for attempt in 1 2 3; do
+    if "${script_dir}"/compose pull; then
+        break
+    fi
+    if [ "$attempt" -eq 3 ]; then
+        echo "compose pull failed after 3 attempts" >&2
+        exit 1
+    fi
+    echo "compose pull failed (attempt $attempt/3), retrying in 10s..." >&2
+    sleep 10
+done
 
 # skip building mls_validation_service if its built in nix
 if [ -f result ] && tar -xOf result manifest.json 2>/dev/null | grep -q "mls-validation-service"; then

--- a/nix/ci-checks.nix
+++ b/nix/ci-checks.nix
@@ -1,9 +1,26 @@
-# CI checks to ensure all packages and dev shells build
-_: {
-  perSystem =
-    { pkgs, ... }:
-    {
-      checks.nextest-v3 = pkgs.callPackage ./package/nextest.nix { };
-      checks.nextest-d14n = pkgs.callPackage ./package/nextest.nix { d14n = true; };
-    };
+# Nextest derivations for CI test runs.
+# Exposed under a custom `nextest` top-level output so that `om ci run`
+# (via devour-flake) won't try to build them — nextest requires Docker
+# services which aren't available in sandboxed builds.
+# The test-workspace.yml workflow starts Docker first, then builds these
+# directly via `nix build .#nextest.<system>.v3`.
+{ lib, withSystem, ... }:
+{
+  flake.nextest =
+    lib.genAttrs
+      [
+        "aarch64-darwin"
+        "x86_64-linux"
+        "aarch64-linux"
+      ]
+      (
+        system:
+        withSystem system (
+          { pkgs, ... }:
+          {
+            v3 = pkgs.callPackage ./package/nextest.nix { };
+            d14n = pkgs.callPackage ./package/nextest.nix { d14n = true; };
+          }
+        )
+      );
 }

--- a/sdks/ios/Tests/XMTPTests/EnrichedMessagesTests.swift
+++ b/sdks/ios/Tests/XMTPTests/EnrichedMessagesTests.swift
@@ -167,22 +167,23 @@ class EnrichedMessagesTests: XCTestCase {
 		let fixtures = try await fixtures()
 		let group = try await fixtures.alixClient.conversations.newGroup(with: [fixtures.boClient.inboxID])
 
-		// Send messages with delays for timestamp testing
-		var messageTimestamps: [Int64] = []
+		// Send 5 messages
 		for i in 1 ... 5 {
 			try await group.send(content: "Message \(i)")
-			messageTimestamps.append(Int64(Date().timeIntervalSince1970 * 1_000_000_000))
-			if i < 5 {
-				try await Task.sleep(nanoseconds: 100_000_000)
-			}
 		}
 
 		// Test limit
 		let limited = try await group.enrichedMessages(limit: 3)
 		XCTAssertLessThanOrEqual(limited.count, 4) // 3 + possible membership message
 
-		// Test beforeNs (messages before middle timestamp)
-		let middleTimestamp = messageTimestamps[2]
+		// Get actual server timestamps from sent messages
+		let allMessages = try await group.enrichedMessages(direction: .ascending)
+		// Filter to only our sent messages (exclude membership changes)
+		let sentMessages = allMessages.filter { $0.contentTypeId.typeID == "text" }
+		XCTAssertEqual(sentMessages.count, 5)
+
+		// Use the 3rd message's actual sentAtNs as the pivot
+		let middleTimestamp = sentMessages[2].sentAtNs
 		let beforeMessages = try await group.enrichedMessages(beforeNs: middleTimestamp)
 		let afterMessages = try await group.enrichedMessages(afterNs: middleTimestamp)
 


### PR DESCRIPTION
## tl;dr

I had Claude look at some recent test runs on main and propose fixes. 

---

  ## Fix 1: iOS `testPaginationParameters` — Use actual message timestamps

  **File:** `sdks/ios/Tests/XMTPTests/EnrichedMessagesTests.swift`

  **Problem:** Test captures timestamps via `Date()` after `send()`, but `send()` overwrites `sent_at_ns` with the server timestamp. Local clock vs server clock skew
  means `beforeNs` filter finds nothing.

  **Fix:** After sending all 5 messages, query `enrichedMessages(direction: .ascending)` and filter to text messages via `contentTypeId.typeID == "text"`. Use the 3rd
   message's actual `sentAtNs` as the pivot timestamp instead of `Date()`. Removed the `messageTimestamps` array and `Task.sleep` delays (no longer needed).

  ---

  ## Fix 2: WASM `test_is_member_of_association_state` — Add poll/retry

  **File:** `crates/xmtp_mls/src/identity_updates.rs`

  **Problem:** After `apply_signature_request`, the server may not have indexed the update yet. `get_latest_association_state` returns stale data (2 members instead
  of 3).

  **Fix:** Replaced the direct `assert_eq!(state.members().len(), 3)` with `xmtp_common::wait_for_eq` to poll until the state has 3 members (20s timeout). The closure
   calls `get_latest_association_state` and returns `members().len()`. This pattern is already used in the codebase (e.g., `message_sync.rs:125`).

  ---

  ## Fix 3: Cargo Doc — Install `fontconfig`

  **File:** `.github/workflows/deploy-docs.yml`

  **Problem:** `log_parser` depends on `slint` -> `yeslogic-fontconfig-sys` -> system `fontconfig`. CI runner lacks `libfontconfig-dev`.

  **Fix:** Added a step before "Invoke cargo doc" that runs `sudo apt-get update && sudo apt-get install -y libfontconfig-dev`.

  ---

  ## Fix 4: xdbg Docker Push — Bump recursion limit

  **File:** `apps/xmtp_debug/src/main.rs`

  **Problem:** Compiler query depth reaches 130 for the async block in `groups.rs`, exceeding the 256 limit (which was previously sufficient but async nesting has
  grown).

  **Fix:** Changed `#![recursion_limit = "256"]` to `#![recursion_limit = "512"]`.

  ---

  ## Fix 5: Nix CI — Move nextest out of `checks`

  **Files:** `nix/ci-checks.nix`, `.github/workflows/test-workspace.yml`

  **Problem:** `om ci run` evaluates all `checks` via devour-flake, but Docker services aren't available in the Nix build sandbox. Nextest tests fail with connection
  refused.

  **Fix:** Moved nextest derivations from `checks` to a custom top-level `nextest` flake output using flake-parts' `withSystem`. This keeps them accessible via `nix
  build .#nextest.<system>.v3` but invisible to devour-flake. Updated `test-workspace.yml` to reference the new path (`.#nextest.x86_64-linux.v3` /
  `.#nextest.x86_64-linux.d14n`).

  ---

  ## Fix 6: Docker Pull Timeouts — Add retry

  **File:** `dev/docker/up`

  **Problem:** `compose pull` fails on transient `ghcr.io` timeouts, blocking all test suites. No retry mechanism exists.

  **Fix:** Replaced the bare `compose pull` with a retry loop (3 attempts, 10s sleep between retries). On final failure, exits non-zero.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix flaky tests across CI workflows, iOS tests, and identity update assertions
> - Moves nextest derivations from `checks` to a dedicated `nextest` flake output in [ci-checks.nix](https://github.com/xmtp/libxmtp/pull/3315/files#diff-9012eb276afdf1bd8abc7f1b4caa410e84dd90d7eb70c5ebdefe5300aa0d7df5) and updates [test-workspace.yml](https://github.com/xmtp/libxmtp/pull/3315/files#diff-bb6ea121a02e5dd13a93185f52a448c5211138550427916dd66d2d75bc04af34) to match the new paths.
> - Replaces a direct assertion on `get_latest_association_state` with a `wait_for_eq` polling wrapper in [identity_updates.rs](https://github.com/xmtp/libxmtp/pull/3315/files#diff-93f82a1bc3c5238249de128f10cdaca01b706f8b455fde435ca1184739600fde) to handle eventual consistency.
> - Removes artificial sleeps in the iOS `testPaginationParameters` test, using message ordering and content filtering instead.
> - Adds retry logic (3 attempts, 10s delay) to `compose pull` in [dev/docker/up](https://github.com/xmtp/libxmtp/pull/3315/files#diff-c4a1f6ed02b85cec2e690a289e7810fd5639c9abf2f205bba12519957bb06f99) to tolerate transient registry failures.
> - Installs `libfontconfig-dev` before docs generation in [deploy-docs.yml](https://github.com/xmtp/libxmtp/pull/3315/files#diff-87e860af4b9db6c503ed680b6edb6333c6f8d7659f7d1a779a2487466bbc50f6) to fix missing dependency failures.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 929e700.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->