### PR TITLE
remove xmtp_db dependency from xmtp_id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14881,7 +14881,6 @@ dependencies = [
  "xmtp_common",
  "xmtp_configuration",
  "xmtp_cryptography",
- "xmtp_db",
  "xmtp_proto",
 ]
 

--- a/crates/xmtp_db/src/encrypted_store/identity_cache.rs
+++ b/crates/xmtp_db/src/encrypted_store/identity_cache.rs
@@ -10,7 +10,10 @@ use diesel::sql_types::Integer;
 use diesel::{Insertable, Queryable};
 use diesel::{prelude::*, serialize};
 use serde::{Deserialize, Serialize};
+use std::any::type_name;
 use std::collections::HashMap;
+use xmtp_proto::ConversionError;
+use xmtp_proto::xmtp::identity::associations::IdentifierKind;
 
 #[derive(Insertable, Queryable, Debug, Clone, Deserialize, Serialize)]
 #[diesel(table_name = identity_cache)]
@@ -30,68 +33,108 @@ pub enum StoredIdentityKind {
     Passkey = 2,
 }
 
+impl TryFrom<IdentifierKind> for StoredIdentityKind {
+    type Error = xmtp_proto::ConversionError;
+    fn try_from(kind: IdentifierKind) -> Result<Self, Self::Error> {
+        match kind {
+            IdentifierKind::Ethereum => Ok(StoredIdentityKind::Ethereum),
+            IdentifierKind::Passkey => Ok(StoredIdentityKind::Passkey),
+            IdentifierKind::Unspecified => {
+                Err(ConversionError::Unspecified("IdentifierKind::Unspecified"))
+            }
+        }
+    }
+}
+
+impl TryFrom<i32> for StoredIdentityKind {
+    type Error = ConversionError;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(StoredIdentityKind::Ethereum),
+            2 => Ok(StoredIdentityKind::Passkey),
+            v => Err(ConversionError::InvalidValue {
+                item: type_name::<StoredIdentityKind>(),
+                expected: "a integer value of `1` or `2`",
+                got: v.to_string(),
+            }),
+        }
+    }
+}
+
+impl From<&StoredIdentityKind> for i32 {
+    fn from(value: &StoredIdentityKind) -> Self {
+        use StoredIdentityKind::*;
+        match value {
+            Ethereum => 1,
+            Passkey => 2,
+        }
+    }
+}
+
+impl From<StoredIdentityKind> for IdentifierKind {
+    fn from(value: StoredIdentityKind) -> Self {
+        use StoredIdentityKind::*;
+        match value {
+            Ethereum => IdentifierKind::Ethereum,
+            Passkey => IdentifierKind::Passkey,
+        }
+    }
+}
+
 impl_store!(IdentityCache, identity_cache);
 impl_fetch!(IdentityCache, identity_cache);
 
 pub trait QueryIdentityCache {
     /// Returns a HashMap of WalletAddress -> InboxId
-    fn fetch_cached_inbox_ids<T>(
+    fn fetch_cached_inbox_ids(
         &self,
-        identifiers: &[T],
-    ) -> Result<HashMap<String, String>, StorageError>
-    where
-        T: std::fmt::Display,
-        for<'a> &'a T: Into<StoredIdentityKind>;
+        identifiers: &[(Address, StoredIdentityKind)],
+    ) -> Result<HashMap<String, String>, StorageError>;
 
-    fn cache_inbox_id<T, S>(&self, identifier: &T, inbox_id: S) -> Result<(), StorageError>
-    where
-        T: std::fmt::Display,
-        S: ToString,
-        for<'a> &'a T: Into<StoredIdentityKind>;
+    fn cache_inbox_id<S: ToString>(
+        &self,
+        kind: StoredIdentityKind,
+        identity: String,
+        inbox_id: S,
+    ) -> Result<(), StorageError>;
 }
 
 impl<G> QueryIdentityCache for &G
 where
     G: QueryIdentityCache,
 {
-    fn fetch_cached_inbox_ids<T>(
+    fn fetch_cached_inbox_ids(
         &self,
-        identifiers: &[T],
-    ) -> Result<HashMap<String, String>, StorageError>
-    where
-        T: std::fmt::Display,
-        for<'a> &'a T: Into<StoredIdentityKind>,
-    {
+        identifiers: &[(Address, StoredIdentityKind)],
+    ) -> Result<HashMap<String, String>, StorageError> {
         (**self).fetch_cached_inbox_ids(identifiers)
     }
 
-    fn cache_inbox_id<T, S>(&self, identifier: &T, inbox_id: S) -> Result<(), StorageError>
-    where
-        T: std::fmt::Display,
-        S: ToString,
-        for<'a> &'a T: Into<StoredIdentityKind>,
-    {
-        (**self).cache_inbox_id(identifier, inbox_id)
+    fn cache_inbox_id<S: ToString>(
+        &self,
+        kind: StoredIdentityKind,
+        identity: String,
+        inbox_id: S,
+    ) -> Result<(), StorageError> {
+        (**self).cache_inbox_id(kind, identity, inbox_id)
     }
 }
 
+type Address = String;
+
 impl<C: ConnectionExt> QueryIdentityCache for DbConnection<C> {
     /// Returns a HashMap of WalletAddress -> InboxId
-    fn fetch_cached_inbox_ids<T>(
+    fn fetch_cached_inbox_ids(
         &self,
-        identifiers: &[T],
-    ) -> Result<HashMap<String, String>, StorageError>
-    where
-        T: std::fmt::Display,
-        for<'a> &'a T: Into<StoredIdentityKind>,
-    {
+        identifiers: &[(Address, StoredIdentityKind)],
+    ) -> Result<HashMap<String, String>, StorageError> {
         use crate::encrypted_store::schema::identity_cache::*;
 
         let mut conditions = identity_cache::table.into_boxed();
 
-        for ident in identifiers {
-            let addr = (&ident).to_string();
-            let kind: StoredIdentityKind = ident.into();
+        for (addr, ident) in identifiers {
+            let kind: i32 = ident.into();
             let cond = identity.eq(addr).and(identity_kind.eq(kind));
             conditions = conditions.or_filter(cond);
         }
@@ -104,16 +147,16 @@ impl<C: ConnectionExt> QueryIdentityCache for DbConnection<C> {
         Ok(result)
     }
 
-    fn cache_inbox_id<T, S>(&self, identifier: &T, inbox_id: S) -> Result<(), StorageError>
-    where
-        T: std::fmt::Display,
-        S: ToString,
-        for<'a> &'a T: Into<StoredIdentityKind>,
-    {
+    fn cache_inbox_id<S: ToString>(
+        &self,
+        kind: StoredIdentityKind,
+        identity: String,
+        inbox_id: S,
+    ) -> Result<(), StorageError> {
         IdentityCache {
             inbox_id: inbox_id.to_string(),
-            identity: identifier.to_string(),
-            identity_kind: identifier.into(),
+            identity,
+            identity_kind: kind,
         }
         .store(self)
     }
@@ -152,34 +195,15 @@ pub(crate) mod tests {
     #[derive(Clone)]
     struct MockIdentity {
         identity: String,
-        kind: u8,
         inbox_id: String,
     }
 
     impl MockIdentity {
-        fn create(kind: u8) -> Self {
+        fn create() -> Self {
             Self {
                 identity: xmtp_common::rand_hexstring(),
                 inbox_id: xmtp_common::rand_string::<32>(),
-                kind,
             }
-        }
-    }
-
-    impl<'a> From<&'a MockIdentity> for StoredIdentityKind {
-        fn from(identity: &'a MockIdentity) -> StoredIdentityKind {
-            match identity.kind {
-                0 => StoredIdentityKind::Ethereum,
-                1 => StoredIdentityKind::Ethereum,
-                2 => StoredIdentityKind::Passkey,
-                _ => panic!("unknown kind"),
-            }
-        }
-    }
-
-    impl std::fmt::Display for MockIdentity {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            f.write_str(&self.identity)
         }
     }
 
@@ -207,27 +231,36 @@ pub(crate) mod tests {
     }
 
     // Test storing and fetching multiple wallet addresses with multiple keys
-    // TODO:insipx: will need to fix & store identity kind
     #[xmtp_common::test]
     fn test_fetch_and_store_identity_cache() {
         with_connection(|conn| {
-            let ident1 = MockIdentity::create(0);
-            let ident2 = MockIdentity::create(0);
+            let ident1 = MockIdentity::create();
+            let ident2 = MockIdentity::create();
 
-            conn.cache_inbox_id(&ident1, &ident1.inbox_id).unwrap();
-            let idents = &[ident1.clone(), ident2];
+            conn.cache_inbox_id(
+                StoredIdentityKind::Ethereum,
+                ident1.identity.clone(),
+                &ident1.inbox_id,
+            )
+            .unwrap();
+
+            let idents = &[
+                (ident1.identity.clone(), StoredIdentityKind::Ethereum),
+                (ident2.identity.clone(), StoredIdentityKind::Ethereum),
+            ];
             let stored_wallets = conn.fetch_cached_inbox_ids(idents).unwrap();
 
             // Verify that 1 entries are fetched
             assert_eq!(stored_wallets.len(), 1);
 
             // Verify it's the correct inbox_id
-            let cached_inbox_id = stored_wallets.get(&format!("{}", idents[0])).unwrap();
+            let cached_inbox_id = stored_wallets.get(&idents[0].0).unwrap();
             assert_eq!(*cached_inbox_id, ident1.inbox_id);
 
             // Fetch wallets with a non-existent list of inbox_ids
+            let ident = MockIdentity::create();
             let non_existent_wallets = conn
-                .fetch_cached_inbox_ids(&[MockIdentity::create(1)])
+                .fetch_cached_inbox_ids(&[(ident.identity, StoredIdentityKind::Ethereum)])
                 .unwrap_or_default();
             assert!(
                 non_existent_wallets.is_empty(),

--- a/crates/xmtp_db/src/mock.rs
+++ b/crates/xmtp_db/src/mock.rs
@@ -507,25 +507,18 @@ mock! {
     }
 
     impl QueryIdentityCache for DbQuery {
-        #[mockall::concretize]
-        fn fetch_cached_inbox_ids<T>(
+        fn fetch_cached_inbox_ids(
             &self,
-            identifiers: &[T],
-        ) -> Result<std::collections::HashMap<String, String>, StorageError>
-        where
-            T: std::fmt::Display,
-            for<'a> &'a T: Into<crate::identity_cache::StoredIdentityKind>;
+            identifiers: &[(String, crate::identity_cache::StoredIdentityKind)],
+        ) -> Result<HashMap<String, String>, StorageError>;
 
         #[mockall::concretize]
-        fn cache_inbox_id<T, S>(
+        fn cache_inbox_id<S: ToString>(
             &self,
-            identifier: &T,
+            kind: crate::identity_cache::StoredIdentityKind,
+            identity: String,
             inbox_id: S,
-        ) -> Result<(), StorageError>
-        where
-            T: std::fmt::Display,
-            S: ToString,
-            for<'a> &'a T: Into<crate::identity_cache::StoredIdentityKind>;
+        ) -> Result<(), StorageError>;
     }
 
     impl QueryKeyPackageHistory for DbQuery {

--- a/crates/xmtp_id/Cargo.toml
+++ b/crates/xmtp_id/Cargo.toml
@@ -43,7 +43,6 @@ xmtp-workspace-hack.workspace = true
 xmtp_common.workspace = true
 xmtp_configuration.workspace = true
 xmtp_cryptography.workspace = true
-xmtp_db.workspace = true
 xmtp_proto.workspace = true
 
 [dev-dependencies]

--- a/crates/xmtp_id/src/associations/member.rs
+++ b/crates/xmtp_id/src/associations/member.rs
@@ -7,7 +7,6 @@ use std::{
     hash::Hash,
 };
 use xmtp_cryptography::{XmtpInstallationCredential, signature::IdentifierValidationError};
-use xmtp_db::identity_cache::StoredIdentityKind;
 use xmtp_proto::types::ApiIdentifier;
 use xmtp_proto::{
     ConversionError,
@@ -35,15 +34,17 @@ pub enum Identifier {
     Passkey(ident::Passkey),
 }
 
-impl From<&Identifier> for StoredIdentityKind {
-    fn from(ident: &Identifier) -> Self {
-        match ident {
-            Identifier::Ethereum(_) => Self::Ethereum,
-            Identifier::Passkey(_) => Self::Passkey,
-        }
+impl From<Identifier> for i32 {
+    fn from(value: Identifier) -> Self {
+        IdentifierKind::from(value).into()
     }
 }
 
+impl From<&Identifier> for i32 {
+    fn from(value: &Identifier) -> Self {
+        IdentifierKind::from(value).into()
+    }
+}
 impl MemberIdentifier {
     pub fn sanitize(self) -> Result<Self, IdentifierValidationError> {
         let ident = match self {

--- a/crates/xmtp_id/src/associations/state.rs
+++ b/crates/xmtp_id/src/associations/state.rs
@@ -3,22 +3,15 @@
 //! or[`MemberKind::Installation`]. A diff between two states can be calculated to determine
 //! a change of membership between two periods of time. [XIP-46](https://github.com/xmtp/XIPs/pull/53)
 
-use std::{
-    collections::{HashMap, HashSet},
-    fmt::{Debug, Write},
-};
-
-use prost::Message;
-use xmtp_db::association_state::StoredAssociationState;
-use xmtp_proto::{
-    ConversionError, xmtp::identity::associations::AssociationState as AssociationStateProto,
-};
-
 use super::{
     AssociationError, MemberIdentifier, MemberKind, ident,
     member::{Identifier, Member},
 };
 use crate::InboxIdRef;
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::{Debug, Write},
+};
 
 #[derive(Debug, Clone)]
 pub struct AssociationStateDiff {
@@ -101,14 +94,6 @@ impl TryFrom<MemberIdentifier> for Identifier {
             }
         };
         Ok(ident)
-    }
-}
-
-impl TryFrom<StoredAssociationState> for AssociationState {
-    type Error = ConversionError;
-
-    fn try_from(stored_state: StoredAssociationState) -> Result<Self, Self::Error> {
-        AssociationStateProto::decode(stored_state.state.as_slice())?.try_into()
     }
 }
 

--- a/crates/xmtp_id/src/associations/unverified.rs
+++ b/crates/xmtp_id/src/associations/unverified.rs
@@ -11,18 +11,8 @@ use super::{
     },
     verified_signature::VerifiedSignature,
 };
-use crate::associations::AssociationError;
 use futures::future::try_join_all;
-use xmtp_db::identity_update::StoredIdentityUpdate;
 use xmtp_proto::xmtp::message_contents::SignedPublicKey as LegacySignedPublicKeyProto;
-
-impl TryFrom<StoredIdentityUpdate> for UnverifiedIdentityUpdate {
-    type Error = AssociationError;
-
-    fn try_from(update: StoredIdentityUpdate) -> Result<Self, Self::Error> {
-        Ok(UnverifiedIdentityUpdate::try_from(update.payload)?)
-    }
-}
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct UnverifiedIdentityUpdate {

--- a/crates/xmtp_mls/src/client.rs
+++ b/crates/xmtp_mls/src/client.rs
@@ -23,6 +23,7 @@ use crate::{
         enrichment::{EnrichMessageError, enrich_messages},
     },
 };
+use itertools::Itertools;
 use openmls::prelude::tls_codec::Error as TlsCodecError;
 use std::{collections::HashMap, sync::Arc};
 use thiserror::Error;
@@ -39,6 +40,7 @@ use xmtp_db::{
     group::{ConversationType, GroupMembershipState, GroupQueryArgs},
     group_message::StoredGroupMessage,
     identity::StoredIdentity,
+    identity_cache::StoredIdentityKind,
 };
 use xmtp_db::{group::GroupQueryOrderBy, prelude::*};
 use xmtp_id::key_package::{KeyPackageVerificationError, VerifiedKeyPackageV2};
@@ -56,11 +58,12 @@ use xmtp_mls_common::{
     group_metadata::DmMembers,
     group_mutable_metadata::MessageDisappearingSettings,
 };
-use xmtp_proto::types::InstallationId;
 use xmtp_proto::{
+    ConversionError,
     api::HasStats,
     api_client::{ApiStats, IdentityStats},
 };
+use xmtp_proto::{types::InstallationId, xmtp::identity::associations::IdentifierKind};
 
 /// Enum representing the network the Client is connected to
 #[derive(Clone, Copy, Default, Debug)]
@@ -162,6 +165,11 @@ pub enum ClientError {
     /// Failed to enrich message content. Not retryable.
     #[error(transparent)]
     EnrichMessage(#[from] EnrichMessageError),
+    /// Conversion Error
+    ///
+    /// Data type failed to convert. Not retryable.
+    #[error(transparent)]
+    Conversion(#[from] xmtp_proto::ConversionError),
 }
 
 impl ClientError {
@@ -372,7 +380,16 @@ where
         conn: &impl DbQuery,
         identifiers: &[Identifier],
     ) -> Result<Vec<Option<String>>, ClientError> {
-        let mut cached_inbox_ids = conn.fetch_cached_inbox_ids(identifiers)?;
+        let ids: Vec<(String, StoredIdentityKind)> = identifiers
+            .iter()
+            .map(|i| {
+                Ok::<_, ConversionError>((
+                    i.clone().to_string(),
+                    StoredIdentityKind::try_from(IdentifierKind::from(i))?,
+                ))
+            })
+            .try_collect()?;
+        let mut cached_inbox_ids = conn.fetch_cached_inbox_ids(&ids)?;
         let mut new_inbox_ids = HashMap::default();
 
         let missing: Vec<_> = identifiers

--- a/crates/xmtp_mls/src/identity.rs
+++ b/crates/xmtp_mls/src/identity.rs
@@ -1,3 +1,6 @@
+mod identity_ext;
+pub use identity_ext::*;
+
 use crate::XmtpApi;
 use crate::groups::mls_ext::WelcomePointersExtension;
 use crate::identity_updates::{get_association_state_with_verifier, load_identity_updates};

--- a/crates/xmtp_mls/src/identity/identity_ext.rs
+++ b/crates/xmtp_mls/src/identity/identity_ext.rs
@@ -1,0 +1,15 @@
+use xmtp_db::identity_update::StoredIdentityUpdate;
+use xmtp_id::associations::{AssociationError, unverified::UnverifiedIdentityUpdate};
+
+/// Extension trait for Identity types defined in [xmtp_id]
+/// mostly helpful to glue together different parts of the codebase without introducing unnecessary
+/// dependencies in other crates
+pub trait IdentityExt {
+    fn to_unverified(self) -> Result<UnverifiedIdentityUpdate, AssociationError>;
+}
+
+impl IdentityExt for StoredIdentityUpdate {
+    fn to_unverified(self) -> Result<UnverifiedIdentityUpdate, AssociationError> {
+        Ok(UnverifiedIdentityUpdate::try_from(self.payload)?)
+    }
+}

--- a/crates/xmtp_mls/src/identity_updates.rs
+++ b/crates/xmtp_mls/src/identity_updates.rs
@@ -3,7 +3,7 @@ use crate::{
     client::ClientError,
     context::XmtpSharedContext,
     groups::group_membership::{GroupMembership, MembershipDiff},
-    identity::IdentityError,
+    identity::{IdentityError, IdentityExt},
     subscriptions::SyncWorkerEvent,
 };
 use futures::{StreamExt, future::try_join_all, stream::FuturesUnordered};
@@ -106,7 +106,7 @@ pub async fn get_association_state_with_verifier(
     let unverified_updates = updates
         .into_iter()
         // deserialize identity update payload
-        .map(UnverifiedIdentityUpdate::try_from)
+        .map(StoredIdentityUpdate::to_unverified)
         .collect::<Result<Vec<UnverifiedIdentityUpdate>, AssociationError>>()?;
     let updates = verify_updates(unverified_updates, scw_verifier).await?;
 
@@ -281,7 +281,7 @@ where
 
         let unverified_incremental_updates: Vec<UnverifiedIdentityUpdate> = incremental_updates
             .into_iter()
-            .map(|update| update.try_into())
+            .map(|update| update.to_unverified())
             .collect::<Result<Vec<UnverifiedIdentityUpdate>, AssociationError>>()?;
 
         let incremental_updates =
@@ -699,7 +699,7 @@ pub async fn get_creation_signature_kind(
         .first()
         .ok_or_else(|| ClientError::Identity(IdentityError::RequiredIdentityNotFound))?;
 
-    let unverified_update: UnverifiedIdentityUpdate = first_update.clone().try_into()?;
+    let unverified_update: UnverifiedIdentityUpdate = first_update.clone().to_unverified()?;
 
     let verified = unverified_update.to_verified(scw_verifier).await?;
 


### PR DESCRIPTION
more aggressively uses `xmtp_proto` types to interface between xmtp_id and xmtp_mls. it's not ideal but can be improved on in the future, and gives crates better isolation/less circular deps.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `xmtp_db` dependency from `xmtp_id` crate
> - Moves DB-coupled conversions out of `xmtp_id` by introducing a local `IdentityExt` extension trait in `xmtp_mls` that converts `StoredIdentityUpdate` to `UnverifiedIdentityUpdate`, replacing `TryFrom` impls that lived in `xmtp_id`.
> - Removes `TryFrom<StoredAssociationState>` and `TryFrom<StoredIdentityUpdate>` from [state.rs](https://github.com/xmtp/libxmtp/pull/3319/files#diff-28c8036fc6aed70d438d1cc7104190865fe06f6707820bcd7f1ca1fdab59b785) and [unverified.rs](https://github.com/xmtp/libxmtp/pull/3319/files#diff-ab0d2508e6ed4923e14495e8c7899190c414c6c4a968c2c04a60dbf8c4b59a96), and removes the `xmtp_db` entry from [xmtp_id/Cargo.toml](https://github.com/xmtp/libxmtp/pull/3319/files#diff-c07dba054a2a9b925c64ded3c4b7f5dee14d43e6ce24ce7fa115f48ad5afcba0).
> - Refactors `QueryIdentityCache` trait to use concrete `(String, StoredIdentityKind)` pairs instead of generic Display/Into bounds, and adds type conversions between `StoredIdentityKind`, `IdentifierKind`, and `i32`.
> - `XmtpClient::find_inbox_ids_from_identifiers` now returns `ClientError::Conversion` if any identifier maps to an unsupported `IdentifierKind`, where previously conversion was infallible.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2d5a4b9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->