### PR TITLE
try decrease rebuilds for mls-validation-service in CI

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: "Enable sccache with GitHub Actions cache backend"
     required: false
     default: "false"
+  with-warpbuild-cache:
+    description: "whether to enable the warpbuild nix cache"
+    required: false
+    default: "true"
   gc-max-store-size:
     description: "Max Nix store size before garbage collection (e.g. 5G, 10G). Only applies on WarpBuild runners."
     required: false
@@ -24,6 +28,7 @@ runs:
         extra_nix_config: |
           accept-flake-config = true
     - uses: ./.github/actions/setup-nix-cache
+      if: ${{ inputs.with-warpbuild-cache == 'true' }}
       with:
         gc-max-store-size: ${{ inputs.gc-max-store-size }}
     - uses: cachix/cachix-action@v16

--- a/.github/workflows/test-workspace.yml
+++ b/.github/workflows/test-workspace.yml
@@ -16,7 +16,7 @@ jobs:
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           sccache: "false"
-          gc-max-store-size: "5G"
+          with-warpbuild-cache: "false"
       - uses: taiki-e/install-action@just
       - name: Start backend
         run: just backend up

--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,6 @@ om.json
 
 # Superpowers
 docs/plans
+
+# VM Images
+*.qcow2

--- a/nix/musl-docker.nix
+++ b/nix/musl-docker.nix
@@ -52,9 +52,10 @@ _: {
     in
     {
       packages = {
-        mls-validation-service-musl64 =
-          config.rust-project.crates.mls_validation_service.crane.outputs.drv.crate.overrideAttrs
-            (old: old // (env-musl old));
+        mls-validation-service = pkgs.callPackage ./package/mls_validation_service.nix { };
+        mls-validation-service-musl64 = self'.packages.mls-validation-service.overrideAttrs (
+          old: old // (env-musl old)
+        );
         # lib.recursiveUpdate lets imageCommon define other attributes in the `config` namesapce
         validation-service-image = pkgs.dockerTools.buildLayeredImage (
           lib.recursiveUpdate imageCommon {
@@ -66,9 +67,9 @@ _: {
         );
       }
       // lib.optionalAttrs (pkgs.stdenv.system == "aarch64-linux") {
-        mls-validation-service-aarch64-multiplatform =
-          config.rust-project.crates.mls_validation_service.crane.outputs.drv.crate.overrideAttrs
-            (old: old // (env-aarch64-multiplatform old));
+        mls-validation-service-aarch64-multiplatform = self'.packages.mls-validation-service.overrideAttrs (
+          old: old // (env-aarch64-multiplatform old)
+        );
         validation-service-image-aarch64-multiplatform = pkgs.dockerTools.buildLayeredImage (
           lib.recursiveUpdate imageCommon {
             config.entrypoint = [

--- a/nix/package/mls_validation_service.nix
+++ b/nix/package/mls_validation_service.nix
@@ -1,0 +1,79 @@
+{
+  xmtp,
+  lib,
+  openssl,
+  perl,
+}:
+let
+  inherit (lib.fileset) unions;
+  inherit (xmtp) craneLib;
+  inherit (craneLib.fileset) commonCargoSources;
+
+  commonArgs = {
+    strictDeps = true;
+    nativeBuildInputs = [
+      openssl
+      perl
+    ];
+  };
+
+  rust-toolchain =
+    xmtp.mkToolchain
+      [
+        "x86_64-unknown-linux-musl"
+        "aarch64-unknown-linux-musl"
+      ]
+      [ ];
+  rust = xmtp.craneLib.overrideToolchain (p: rust-toolchain);
+  root = ./../..;
+  # a full rebuild will be triggered only if these dependencies change.
+  fileset = unions [
+    (root + /Cargo.toml)
+    (root + /Cargo.lock)
+    (root + /apps/.gitkeep)
+    (root + /bindings/.gitkeep)
+
+    (root + /crates/xmtp_id/src/scw_verifier/chain_urls_default.json)
+    (root + /crates/xmtp_id/artifact)
+    (root + /crates/xmtp_id/src/scw_verifier/signature_validation.hex)
+    (root + /crates/xmtp_proto/src/gen/proto_descriptor.bin)
+
+    (commonCargoSources (root + /crates/xmtp-workspace-hack))
+    (commonCargoSources (root + /crates/xmtp_common))
+    (commonCargoSources (root + /crates/xmtp_configuration))
+    (commonCargoSources (root + /crates/xmtp_cryptography))
+    (commonCargoSources (root + /crates/xmtp_id))
+    (commonCargoSources (root + /crates/xmtp_proto))
+    (commonCargoSources (root + /crates/xmtp_macro))
+    (root + /apps/mls_validation_service/Cargo.toml)
+    (root + /apps/mls_validation_service/build.rs)
+  ];
+
+  src = lib.fileset.toSource {
+    inherit root fileset;
+  };
+
+  cargoArtifacts = rust.buildDepsOnly (
+    commonArgs
+    // {
+      inherit src;
+    }
+  );
+in
+rust.buildPackage (
+  commonArgs
+  // {
+    inherit cargoArtifacts;
+    pname = "mls-validation-service";
+    cargoExtraArgs = "--bin mls-validation-service";
+    version = xmtp.mkVersion rust;
+    doCheck = false;
+    src = lib.fileset.toSource {
+      inherit root;
+      fileset = unions [
+        fileset
+        (commonCargoSources (root + /apps/mls_validation_service))
+      ];
+    };
+  }
+)

--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -39,10 +39,6 @@ _: {
           };
         };
         crates = {
-          "mls_validation_service" = {
-            path = src + /apps/mls_validation_service;
-            autoWire = [ "crate" ];
-          };
           "xmtp_debug" = {
             autoWire = [ "crate" ];
             path = src + /apps/xmtp_debug;


### PR DESCRIPTION
- narrower fileset
- remove xmtp_db and xmtp_mls dependencies in validation service to increase cache hits
- technically means validation service doesn't need OpenSSL or any system dependencies anymore, but still pulled in bc of workspace hack

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Decrease CI rebuilds for `mls-validation-service` by replacing auto-wired crate with a custom Nix derivation
> - Removes `mls_validation_service` from the auto-wired crates map in [nix/rust.nix](https://github.com/xmtp/libxmtp/pull/3320/files#diff-a5a9476af3372b35857e511049d910a1a12f43dc1e0cbec2091b1867a9bb132b) and introduces a standalone derivation in [nix/package/mls_validation_service.nix](https://github.com/xmtp/libxmtp/pull/3320/files#diff-9a922ce2dc6f11757e441d0902a00c1e9263ea4cf17bc5bf9e8f63f8114cec02) that builds deps separately via `buildDepsOnly`, giving Nix more granular caching.
> - Updates [nix/musl-docker.nix](https://github.com/xmtp/libxmtp/pull/3320/files#diff-4532091642057600d9511d47fc6c282ef03f1234c1e2bce79ccc9e23149e40a9) to derive the musl and aarch64 variants via `overrideAttrs` on the new base package instead of referencing the crane output directly.
> - Adds a `with-warpbuild-cache` input (default `true`) to the [setup-nix action](https://github.com/xmtp/libxmtp/pull/3320/files#diff-d6d03b00722cea2a21415f2e41951abebd36b521b485d7e4fc9fbb4a3c0195dc) and sets it to `false` in the Rust workspace test job to avoid WarpBuild cache overhead during those runs.
> - Adds `*.qcow2` to [.gitignore](https://github.com/xmtp/libxmtp/pull/3320/files#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f1c73eb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->