### PR TITLE
put webassembly tests in nix derivation

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -51,4 +51,6 @@ package.tracing = { opt-level = 3, debug = false, debug-assertions = true, overf
 # Optimized test profile for WASM — debug builds produce huge binaries that are expensive to parse in Chrome
 [profile.wasm-test]
 inherits = "test"
-opt-level = 2
+opt-level = "z"
+lto = true
+wasm-opt = ['-O4', '--intrinsic-lowering', '-Os']

--- a/.claude/skills/working-with-nix/shells/wasm.md
+++ b/.claude/skills/working-with-nix/shells/wasm.md
@@ -17,7 +17,6 @@ For WebAssembly builds and testing. Uses `fenix.stable` Rust (not the project-pi
 | `SQLITE_OUT` | SQLite out path | SQLite binaries |
 | `CHROMEDRIVER` | ChromeDriver path | Chrome WebDriver |
 | `WASM_BINDGEN_TEST_TIMEOUT` | `1024` | Test timeout seconds |
-| `WASM_BINDGEN_TEST_ONLY_WEB` | `1` | Web-only tests |
 | `RSTEST_TIMEOUT` | `90` | rstest timeout |
 | `CARGO_PROFILE_TEST_DEBUG` | `0` | Disable debug in tests |
 | `WASM_BINDGEN_TEST_WEBDRIVER_JSON` | Config path | WebDriver config |

--- a/.config/hakari.toml
+++ b/.config/hakari.toml
@@ -36,13 +36,7 @@ third-party = [
   { name = "uniffi" },
   { name = "wasm-bindgen" },
 ]
-workspace-members = [
-  "bindings_wasm",
-  "xmtp_cli",
-  "log_parser",
-  "xmtp-db-tools",
-  "xdbg",
-]
+workspace-members = ["xmtp_cli", "log_parser", "xmtp-db-tools", "xdbg"]
 [final-excludes]
 third-party = [
   { name = "hyper" },
@@ -51,10 +45,4 @@ third-party = [
   { name = "uniffi" },
   { name = "wasm-bindgen" },
 ]
-workspace-members = [
-  "bindings_wasm",
-  "xmtp_cli",
-  "log_parser",
-  "xmtp-db-tools",
-  "xdbg",
-]
+workspace-members = ["xmtp_cli", "log_parser", "xmtp-db-tools", "xdbg"]

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -23,7 +23,6 @@ retries = 3
 [[profile.ci.overrides]]
 filter = 'test(/\btest_can_stream_group_messages_for_updates/)'
 retries = 3
-
 [profile.ci-d14n]
 slow-timeout = "90sec"
 default-filter = "not (test(/\\w*commit_log*/))"

--- a/.github/workflows/test-wasm.yml
+++ b/.github/workflows/test-wasm.yml
@@ -14,13 +14,14 @@ jobs:
         with:
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          sccache: "true"
+          sccache: "false"
+          gc-max-store-size: "10G"
       - uses: taiki-e/install-action@just
       - name: Install dependencies
         run: just wasm install-ci
       - name: Start backend
         run: just backend up
       - name: Run WASM tests
-        run: just wasm test
+        run: just wasm test-ci
       - name: Run WASM integration tests
         run: just wasm test-integration

--- a/.github/workflows/test-workspace.yml
+++ b/.github/workflows/test-workspace.yml
@@ -25,7 +25,7 @@ jobs:
         uses: jwalton/gh-docker-logs@v2
       - name: Run tests (v3 + d14n with coverage)
         # use `nix build` instead of `nix flake check` because we need the resulting coverage
-        run: nix build .#nextest.x86_64-linux.v3 .#nextest.x86_64-linux.d14n
+        run: nix build -L .#nextest.x86_64-linux.v3 .#nextest.x86_64-linux.d14n
 
       - name: merge coverage files
         run: nix run nixpkgs#lcov -- --add-tracefile result/coverage --add-tracefile result-1/coverage --output-file lcov.info

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1881,6 +1881,7 @@ dependencies = [
  "wasm-bindgen-test",
  "wasm-streams",
  "web-sys",
+ "xmtp-workspace-hack",
  "xmtp_api",
  "xmtp_api_d14n",
  "xmtp_common",

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["cdylib", "rlib"]
 
 
 [dependencies]
+xmtp-workspace-hack.workspace = true
 xmtp_common = { workspace = true, features = ["logging"] }
 
 

--- a/bindings/wasm/wasm.just
+++ b/bindings/wasm/wasm.just
@@ -2,6 +2,8 @@ export NIX_DEVSHELL := env("NIX_DEVSHELL", "wasm")
 
 set shell := ["../../dev/nix-shell"]
 
+nix_system := arch() + "-" + if os() == "macos" { "darwin" } else { "linux" }
+
 install:
     yarn
 
@@ -26,25 +28,44 @@ format: install
 
 # Packages that support the WASM target
 
-wasm_packages := "-p xmtp_mls -p xmtp_cryptography -p xmtp_common -p xmtp_api -p xmtp_id -p xmtp_db -p xmtp_api_d14n"
+wasm_packages := "-p xmtp_mls -p xmtp_cryptography -p xmtp_common -p xmtp_api -p xmtp_id -p xmtp_db -p xmtp_api_d14n -p xmtp_content_types"
 
-# Run WASM bindings Rust tests (v3 + d14n)
+# WASM bindings Rust tests (v3 + d14n)
 test: test-v3 test-d14n
 
-# Run WASM bindings Rust tests (v3)
+# WASM bindings Rust tests (v3)
 test-v3:
     XMTP_TEST_LOGGING=false RUST_LOG=off cargo nextest run --locked --profile ci --cargo-profile wasm-test --target wasm32-unknown-unknown \
       {{ wasm_packages }}
 
-# Run WASM bindings Rust tests (d14n)
+# WASM bindings Rust tests (d14n)
 test-d14n:
     XMTP_TEST_LOGGING=false RUST_LOG=off cargo nextest run --locked --profile ci-d14n --cargo-profile wasm-test --target wasm32-unknown-unknown \
       --features d14n \
       {{ wasm_packages }}
 
-# Run WASM JS integration tests
+# nix derivation for wasm v3 tests (no local incremental builds, but uses cachix)
+nix-test-v3:
+    nix run nixpkgs#nix-output-monitor build .#nextest.{{ nix_system }}.wasm-v3
+
+# nix derivation for wasm d14n tests (no local incremental builds, but uses cachix)
+nix-test-d14n:
+    nix run nixpkgs#nix-output-monitor build .#nextest.{{ nix_system }}.wasm-d14n
+
+# nix derivation for v3 and d14n tests
+nix-test: nix-test-v3 nix-test-d14n
+
+# CI version of wasm tests (no local incremental compilation, but uses cachix)
+test-ci:
+    nix build -L .#nextest.{{ nix_system }}.wasm-v3
+    nix build -L .#nextest.{{ nix_system }}.wasm-d14n
+
+# WASM JS integration tests
+[script("bash")]
 test-integration: _build-test install
-    cd {{ source_directory() }} && nix develop .#js --command bash -euc 'yarn tsc --noEmit && yarn vitest run'
+    set -euo pipefail
+    cd {{ source_directory() }}
+    nix develop .#js --command bash -euc 'yarn tsc --noEmit && yarn vitest run'
 
 # Build WASM bindings
 build:

--- a/crates/xmtp_api/src/identity.rs
+++ b/crates/xmtp_api/src/identity.rs
@@ -174,9 +174,6 @@ where
 
 #[cfg(test)]
 pub(crate) mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
     use super::super::test_utils::*;
     use super::GetIdentityUpdatesV2Filter;
     use crate::{ApiClientWrapper, identity::ApiIdentifier};

--- a/crates/xmtp_api/src/mls.rs
+++ b/crates/xmtp_api/src/mls.rs
@@ -359,9 +359,6 @@ where
 
 #[cfg(test)]
 pub mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
     use crate::test_utils::*;
     use crate::*;
 

--- a/crates/xmtp_api_d14n/src/test.rs
+++ b/crates/xmtp_api_d14n/src/test.rs
@@ -8,10 +8,6 @@ pub use traits::*;
 mod definitions;
 pub use definitions::*;
 
-xmtp_common::if_wasm! {
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
-}
-
 xmtp_common::if_native! {
     #[cfg(test)]
     #[ctor::ctor]

--- a/crates/xmtp_common/src/test.rs
+++ b/crates/xmtp_common/src/test.rs
@@ -177,7 +177,6 @@ pub fn logger() {
                     .init();
 
                 console_error_panic_hook::set_once();
-                wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
             });
         },
         native => {

--- a/crates/xmtp_content_types/src/attachment.rs
+++ b/crates/xmtp_content_types/src/attachment.rs
@@ -88,8 +88,6 @@ pub struct Attachment {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
     use super::*;
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]

--- a/crates/xmtp_content_types/src/delete_message.rs
+++ b/crates/xmtp_content_types/src/delete_message.rs
@@ -53,8 +53,6 @@ impl ContentCodec<DeleteMessage> for DeleteMessageCodec {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
     use super::*;
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]

--- a/crates/xmtp_content_types/src/encryption.rs
+++ b/crates/xmtp_content_types/src/encryption.rs
@@ -109,9 +109,6 @@ fn derive_key(secret: &[u8], salt: &[u8]) -> Result<[u8; 32], String> {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
     use super::*;
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]

--- a/crates/xmtp_content_types/src/group_updated.rs
+++ b/crates/xmtp_content_types/src/group_updated.rs
@@ -53,9 +53,6 @@ impl ContentCodec<GroupUpdated> for GroupUpdatedCodec {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
     use super::*;
     use xmtp_common::rand_string;
     use xmtp_proto::xmtp::mls::message_contents::{GroupUpdated, group_updated::Inbox};

--- a/crates/xmtp_content_types/src/leave_request.rs
+++ b/crates/xmtp_content_types/src/leave_request.rs
@@ -56,8 +56,6 @@ impl ContentCodec<LeaveRequest> for LeaveRequestCodec {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
     use super::*;
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]

--- a/crates/xmtp_content_types/src/markdown.rs
+++ b/crates/xmtp_content_types/src/markdown.rs
@@ -60,9 +60,6 @@ impl ContentCodec<String> for MarkdownCodec {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
     use crate::{ContentCodec, markdown::MarkdownCodec};
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]

--- a/crates/xmtp_content_types/src/membership_change.rs
+++ b/crates/xmtp_content_types/src/membership_change.rs
@@ -55,9 +55,6 @@ impl ContentCodec<GroupMembershipChanges> for GroupMembershipChangeCodec {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
     use super::*;
     use xmtp_common::{rand_string, rand_vec};
     use xmtp_proto::xmtp::mls::message_contents::MembershipChange;

--- a/crates/xmtp_content_types/src/multi_remote_attachment.rs
+++ b/crates/xmtp_content_types/src/multi_remote_attachment.rs
@@ -62,9 +62,6 @@ impl ContentCodec<MultiRemoteAttachment> for MultiRemoteAttachmentCodec {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
     use xmtp_proto::xmtp::mls::message_contents::content_types::RemoteAttachmentInfo;
 
     use super::*;

--- a/crates/xmtp_content_types/src/reaction.rs
+++ b/crates/xmtp_content_types/src/reaction.rs
@@ -189,9 +189,6 @@ impl ContentCodec<LegacyReaction> for LegacyReactionCodec {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
     use xmtp_proto::xmtp::mls::message_contents::content_types::{
         ReactionAction, ReactionSchema, ReactionV2,
     };

--- a/crates/xmtp_content_types/src/read_receipt.rs
+++ b/crates/xmtp_content_types/src/read_receipt.rs
@@ -50,8 +50,6 @@ pub struct ReadReceipt {}
 
 #[cfg(test)]
 pub(crate) mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
     use super::*;
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]

--- a/crates/xmtp_content_types/src/remote_attachment.rs
+++ b/crates/xmtp_content_types/src/remote_attachment.rs
@@ -222,8 +222,6 @@ pub type RemoteAttachment = RemoteAttachmentInfo;
 
 #[cfg(test)]
 pub(crate) mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
     use super::*;
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]

--- a/crates/xmtp_content_types/src/reply.rs
+++ b/crates/xmtp_content_types/src/reply.rs
@@ -114,8 +114,6 @@ pub struct Reply {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
     use crate::text::TextCodec;
 
     use super::*;

--- a/crates/xmtp_content_types/src/text.rs
+++ b/crates/xmtp_content_types/src/text.rs
@@ -60,9 +60,6 @@ impl ContentCodec<String> for TextCodec {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
     use crate::{ContentCodec, text::TextCodec};
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]

--- a/crates/xmtp_content_types/src/transaction_reference.rs
+++ b/crates/xmtp_content_types/src/transaction_reference.rs
@@ -113,8 +113,6 @@ pub struct TransactionMetadata {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
     use super::*;
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]

--- a/crates/xmtp_content_types/src/wallet_send_calls.rs
+++ b/crates/xmtp_content_types/src/wallet_send_calls.rs
@@ -89,9 +89,6 @@ pub struct WalletCallMetadata {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
     use super::*;
     use crate::ContentCodec;
 

--- a/crates/xmtp_cryptography/src/lib.rs
+++ b/crates/xmtp_cryptography/src/lib.rs
@@ -19,10 +19,3 @@ pub type Secret = tls_codec::SecretVLBytes; // Byte array with ZeroizeOnDrop
 fn install_rustls_crypto_provider() {
     let _ = rustls::crypto::ring::default_provider().install_default();
 }
-
-#[cfg(test)]
-mod test {
-    // common depends on cryptography
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-}

--- a/crates/xmtp_db/src/encrypted_store/association_state.rs
+++ b/crates/xmtp_db/src/encrypted_store/association_state.rs
@@ -150,9 +150,6 @@ impl<C: ConnectionExt> QueryAssociationStateCache for DbConnection<C> {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
     use super::*;
     use crate::test_utils::with_connection;
     use serde::{Deserialize, Serialize};

--- a/crates/xmtp_db/src/encrypted_store/consent_record.rs
+++ b/crates/xmtp_db/src/encrypted_store/consent_record.rs
@@ -408,11 +408,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{Store, group::tests::generate_group, test_utils::with_connection};
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
     use super::*;
+    use crate::{Store, group::tests::generate_group, test_utils::with_connection};
 
     fn generate_consent_record(
         entity_type: ConsentType,

--- a/crates/xmtp_db/src/encrypted_store/d14n_migration_cutover.rs
+++ b/crates/xmtp_db/src/encrypted_store/d14n_migration_cutover.rs
@@ -103,9 +103,6 @@ impl<C: ConnectionExt> QueryMigrationCutover for DbConnection<C> {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
     use super::*;
     use crate::test_utils::with_connection;
 

--- a/crates/xmtp_db/src/encrypted_store/database/wasm.rs
+++ b/crates/xmtp_db/src/encrypted_store/database/wasm.rs
@@ -51,7 +51,7 @@ pub struct WasmDb {
 pub use sqlite_wasm_vfs::sahpool::{OpfsSAHError, OpfsSAHPoolUtil};
 
 /// Wrapper to allow OpfsSAHPoolUtil in a static OnceCell on wasm (single-threaded).
-pub struct SyncOpfsUtil(Result<OpfsSAHPoolUtil, String>);
+pub struct SyncOpfsUtil(pub Result<OpfsSAHPoolUtil, String>);
 // SAFETY: wasm32 is single-threaded; these are never accessed across threads.
 unsafe impl Send for SyncOpfsUtil {}
 unsafe impl Sync for SyncOpfsUtil {}
@@ -98,7 +98,7 @@ async fn maybe_resize() -> Result<(), PlatformStorageError> {
     Ok(())
 }
 
-async fn init_opfs() -> SyncOpfsUtil {
+pub async fn init_opfs() -> SyncOpfsUtil {
     let cfg = OpfsSAHPoolCfg {
         vfs_name: xmtp_configuration::WASM_VFS_NAME.into(),
         directory: xmtp_configuration::WASM_VFS_DIRECTORY.into(),
@@ -251,103 +251,5 @@ impl XmtpDb for WasmDb {
 
     fn opts(&self) -> &StorageOption {
         &self.opts
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-    use crate::DbConnection;
-    use crate::EncryptedMessageStore;
-    use crate::identity::StoredIdentity;
-
-    pub async fn with_opfs<'a, F, R>(path: impl Into<Option<&'a str>>, f: F) -> R
-    where
-        F: FnOnce(crate::DefaultDbConnection) -> R,
-    {
-        let util = init_opfs().await;
-        let o: Option<&'a str> = path.into();
-        let p = o.map(String::from).unwrap_or(xmtp_common::tmp_path());
-        let db = crate::database::WasmDb::new(&StorageOption::Persistent(p))
-            .await
-            .unwrap();
-        let store = EncryptedMessageStore::new(db).unwrap();
-        let conn = store.conn();
-        let r = f(DbConnection::new(conn));
-        if let SyncOpfsUtil(Ok(u)) = util {
-            u.clear_all().await.unwrap();
-        }
-        r
-    }
-
-    #[allow(unused)]
-    pub async fn with_opfs_async<'a, R>(
-        path: impl Into<Option<&'a str>>,
-        f: impl AsyncFnOnce(crate::DefaultDbConnection) -> R,
-    ) -> R {
-        let util = init_opfs().await;
-        let o: Option<&'a str> = path.into();
-        let p = o.map(String::from).unwrap_or(xmtp_common::tmp_path());
-        let db = crate::database::WasmDb::new(&StorageOption::Persistent(p))
-            .await
-            .unwrap();
-        let store = EncryptedMessageStore::new(db).unwrap();
-        let conn = store.conn();
-        let r = f(DbConnection::new(conn)).await;
-        if let SyncOpfsUtil(Ok(u)) = util {
-            u.clear_all().await.unwrap();
-        }
-        r
-    }
-
-    #[xmtp_common::test]
-    async fn test_opfs() {
-        use crate::traits::Store;
-
-        let path = "test_db";
-        with_opfs(path, |c1| {
-            let intent = StoredIdentity::builder()
-                .inbox_id("test")
-                .installation_keys(vec![0, 1, 1, 1])
-                .credential_bytes(vec![0, 0, 0, 0])
-                .next_key_package_rotation_ns(1)
-                .build()
-                .unwrap();
-            intent.store(&c1).unwrap();
-        })
-        .await;
-    }
-
-    #[xmtp_common::test]
-    async fn opfs_dynamically_resizes() {
-        use xmtp_common::tmp_path as path;
-        init_sqlite().await;
-        if let Some(Ok(util)) = get_sqlite() {
-            util.clear_all().await.unwrap();
-            let current_capacity = util.get_capacity();
-            if current_capacity > 6 {
-                util.reduce_capacity(current_capacity - 6).await.unwrap();
-            }
-        }
-        with_opfs_async(&*path(), async move |_| {
-            with_opfs_async(&*path(), async move |_| {
-                with_opfs_async(&*path(), async move |_| {
-                    with_opfs(&*path(), |_| {
-                        // should have been resized here
-                        if let Some(Ok(util)) = get_sqlite() {
-                            let cap = util.get_capacity();
-                            assert_eq!(cap, 12);
-                        } else {
-                            panic!("opfs failed to init")
-                        }
-                    })
-                    .await
-                })
-                .await
-            })
-            .await
-        })
-        .await
     }
 }

--- a/crates/xmtp_db/src/encrypted_store/group.rs
+++ b/crates/xmtp_db/src/encrypted_store/group.rs
@@ -1335,9 +1335,6 @@ impl DmIdExt for String {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
     pub use super::dms::tests::*;
     use super::*;
 

--- a/crates/xmtp_db/src/encrypted_store/group/dms.rs
+++ b/crates/xmtp_db/src/encrypted_store/group/dms.rs
@@ -103,8 +103,6 @@ impl<C: ConnectionExt> QueryDms for DbConnection<C> {
 
 #[cfg(test)]
 pub(super) mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
     use super::*;
     use crate::{Store, test_utils::with_connection};
     use std::sync::atomic::{AtomicU16, Ordering};

--- a/crates/xmtp_db/src/encrypted_store/group_intent.rs
+++ b/crates/xmtp_db/src/encrypted_store/group_intent.rs
@@ -664,9 +664,6 @@ where
 
 #[cfg(test)]
 pub(crate) mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
     use super::*;
     use crate::{
         Fetch, Store,

--- a/crates/xmtp_db/src/encrypted_store/group_message/messages_newer_than_tests.rs
+++ b/crates/xmtp_db/src/encrypted_store/group_message/messages_newer_than_tests.rs
@@ -1,6 +1,3 @@
-#[cfg(target_arch = "wasm32")]
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
 use super::*;
 use crate::{Store, group::tests::generate_group, test_utils::with_connection};
 use xmtp_common::{assert_ok, rand_vec};

--- a/crates/xmtp_db/src/encrypted_store/group_message/tests.rs
+++ b/crates/xmtp_db/src/encrypted_store/group_message/tests.rs
@@ -1,6 +1,3 @@
-#[cfg(target_arch = "wasm32")]
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
 use super::*;
 use crate::{Store, group::tests::generate_group, prelude::*, test_utils::with_connection};
 use xmtp_common::{assert_err, assert_ok, rand_time, rand_vec};

--- a/crates/xmtp_db/src/encrypted_store/identity.rs
+++ b/crates/xmtp_db/src/encrypted_store/identity.rs
@@ -122,9 +122,6 @@ impl<C: ConnectionExt> QueryIdentity for DbConnection<C> {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
     use super::StoredIdentity;
     use crate::{Store, XmtpTestDb};
     use xmtp_common::rand_vec;

--- a/crates/xmtp_db/src/encrypted_store/identity_update.rs
+++ b/crates/xmtp_db/src/encrypted_store/identity_update.rs
@@ -223,9 +223,6 @@ impl<C: ConnectionExt> QueryIdentityUpdates for DbConnection<C> {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
     use crate::{Store, test_utils::with_connection};
     use xmtp_common::{rand_time, rand_vec};
 

--- a/crates/xmtp_db/src/encrypted_store/key_package_history.rs
+++ b/crates/xmtp_db/src/encrypted_store/key_package_history.rs
@@ -193,8 +193,6 @@ mod tests {
     use crate::prelude::*;
     use crate::test_utils::with_connection;
     use xmtp_common::rand_vec;
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
     #[xmtp_common::test]
     fn test_store_key_package_history_entry() {

--- a/crates/xmtp_db/src/encrypted_store/mod.rs
+++ b/crates/xmtp_db/src/encrypted_store/mod.rs
@@ -515,9 +515,6 @@ impl MigrationHarnessExt for SqliteConnection {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
     use super::*;
     use crate::{Fetch, Store, XmtpTestDb, identity::StoredIdentity};
     use xmtp_common::{rand_vec, tmp_path};

--- a/crates/xmtp_db/src/encrypted_store/refresh_state.rs
+++ b/crates/xmtp_db/src/encrypted_store/refresh_state.rs
@@ -764,9 +764,6 @@ impl<C: ConnectionExt> QueryRefreshState for DbConnection<C> {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
     use super::*;
     use crate::identity_update::StoredIdentityUpdateBuilder;
     use crate::test_utils::with_connection;

--- a/crates/xmtp_db/src/encrypted_store/tasks.rs
+++ b/crates/xmtp_db/src/encrypted_store/tasks.rs
@@ -186,9 +186,6 @@ impl<C: ConnectionExt> QueryTasks for DbConnection<C> {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
     use super::*;
     use crate::test_utils::with_connection;
 

--- a/crates/xmtp_db/src/encrypted_store/user_preferences.rs
+++ b/crates/xmtp_db/src/encrypted_store/user_preferences.rs
@@ -96,8 +96,6 @@ impl StoredUserPreferences {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
     use super::*;
 
     #[xmtp_common::test]

--- a/crates/xmtp_db/src/sql_key_store.rs
+++ b/crates/xmtp_db/src/sql_key_store.rs
@@ -1153,9 +1153,6 @@ impl SqlKeyStore<crate::test_utils::MemoryStorage> {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
     use openmls::group::GroupId;
     use openmls_basic_credential::{SignatureKeyPair, StorageId};
     use openmls_traits::{

--- a/crates/xmtp_db/tests/opfs.rs
+++ b/crates/xmtp_db/tests/opfs.rs
@@ -1,0 +1,98 @@
+xmtp_common::if_wasm! {
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    use xmtp_db::DbConnection;
+    use xmtp_db::EncryptedMessageStore;
+    use xmtp_db::identity::StoredIdentity;
+    use xmtp_db::{StorageOption};
+    use xmtp_db::{init_sqlite, get_sqlite, SyncOpfsUtil, init_opfs};
+
+    pub async fn with_opfs<'a, F, R>(path: impl Into<Option<&'a str>>, f: F) -> R
+    where
+        F: FnOnce(xmtp_db::DefaultDbConnection) -> R,
+    {
+        let util = init_opfs().await;
+        let o: Option<&'a str> = path.into();
+        let p = o.map(String::from).unwrap_or(xmtp_common::tmp_path());
+        let db = xmtp_db::database::WasmDb::new(&StorageOption::Persistent(p))
+            .await
+            .unwrap();
+        let store = EncryptedMessageStore::new(db).unwrap();
+        let conn = store.conn();
+        let r = f(DbConnection::new(conn));
+        if let SyncOpfsUtil(Ok(u)) = util {
+            u.clear_all().await.unwrap();
+        }
+        r
+    }
+
+    #[allow(unused)]
+    pub async fn with_opfs_async<'a, R>(
+        path: impl Into<Option<&'a str>>,
+        f: impl AsyncFnOnce(xmtp_db::DefaultDbConnection) -> R,
+    ) -> R {
+        let util = init_opfs().await;
+        let o: Option<&'a str> = path.into();
+        let p = o.map(String::from).unwrap_or(xmtp_common::tmp_path());
+        let db = xmtp_db::database::WasmDb::new(&StorageOption::Persistent(p))
+            .await
+            .unwrap();
+        let store = EncryptedMessageStore::new(db).unwrap();
+        let conn = store.conn();
+        let r = f(DbConnection::new(conn)).await;
+        if let SyncOpfsUtil(Ok(u)) = util {
+            u.clear_all().await.unwrap();
+        }
+        r
+    }
+
+    #[xmtp_common::test]
+    async fn test_opfs() {
+        use xmtp_db::Store;
+
+        let path = "test_db";
+        with_opfs(path, |c1| {
+            let intent = StoredIdentity::builder()
+                .inbox_id("test")
+                .installation_keys(vec![0, 1, 1, 1])
+                .credential_bytes(vec![0, 0, 0, 0])
+                .next_key_package_rotation_ns(1)
+                .build()
+                .unwrap();
+            intent.store(&c1).unwrap();
+        })
+        .await;
+    }
+
+    #[xmtp_common::test]
+    async fn opfs_dynamically_resizes() {
+        use xmtp_common::tmp_path as path;
+        init_sqlite().await;
+        if let Some(Ok(util)) = get_sqlite() {
+            util.clear_all().await.unwrap();
+            let current_capacity = util.get_capacity();
+            if current_capacity > 6 {
+                util.reduce_capacity(current_capacity - 6).await.unwrap();
+            }
+        }
+        with_opfs_async(&*path(), async move |_| {
+            with_opfs_async(&*path(), async move |_| {
+                with_opfs_async(&*path(), async move |_| {
+                    with_opfs(&*path(), |_| {
+                        // should have been resized here
+                        if let Some(Ok(util)) = get_sqlite() {
+                            let cap = util.get_capacity();
+                            assert_eq!(cap, 12);
+                        } else {
+                            panic!("opfs failed to init")
+                        }
+                    })
+                    .await
+                })
+                .await
+            })
+            .await
+        })
+        .await
+    }
+}

--- a/crates/xmtp_id/src/associations/builder.rs
+++ b/crates/xmtp_id/src/associations/builder.rs
@@ -420,8 +420,6 @@ fn get_signature_text(
 
 #[cfg(test)]
 pub(crate) mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
     use alloy::signers::{Signer, local::PrivateKeySigner};
     use xmtp_cryptography::XmtpInstallationCredential;
 

--- a/crates/xmtp_id/src/associations/member.rs
+++ b/crates/xmtp_id/src/associations/member.rs
@@ -413,9 +413,6 @@ fn sha256_string(input: String) -> String {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
     use super::*;
 
     #[allow(clippy::derivable_impls)]

--- a/crates/xmtp_id/src/associations/mod.rs
+++ b/crates/xmtp_id/src/associations/mod.rs
@@ -116,8 +116,6 @@ pub mod test_defaults {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
     use wasm_bindgen_test::wasm_bindgen_test;
 
     use super::*;

--- a/crates/xmtp_id/src/associations/serialization.rs
+++ b/crates/xmtp_id/src/associations/serialization.rs
@@ -783,9 +783,6 @@ impl From<AccountId> for String {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
     use xmtp_common::{rand_u64, rand_vec};
 
     use super::*;

--- a/crates/xmtp_id/src/associations/state.rs
+++ b/crates/xmtp_id/src/associations/state.rs
@@ -254,9 +254,6 @@ impl AssociationState {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
     use super::*;
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]

--- a/crates/xmtp_id/src/associations/unsigned_actions.rs
+++ b/crates/xmtp_id/src/associations/unsigned_actions.rs
@@ -139,9 +139,6 @@ fn pretty_timestamp(ns_date: u64) -> String {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
     use super::*;
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]

--- a/crates/xmtp_id/src/associations/unverified.rs
+++ b/crates/xmtp_id/src/associations/unverified.rs
@@ -442,9 +442,6 @@ impl UnverifiedLegacyDelegatedSignature {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
     use crate::associations::{member::Identifier, unsigned_actions::UnsignedCreateInbox};
 
     use super::{

--- a/crates/xmtp_id/src/associations/verified_signature.rs
+++ b/crates/xmtp_id/src/associations/verified_signature.rs
@@ -222,9 +222,6 @@ impl VerifiedSignature {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
     use super::*;
     use crate::associations::{
         InstallationKeyContext, MemberIdentifier, SignatureKind,

--- a/crates/xmtp_mls/src/client.rs
+++ b/crates/xmtp_mls/src/client.rs
@@ -1164,9 +1164,6 @@ where
 
 #[cfg(test)]
 pub(crate) mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
     use super::Client;
     use crate::context::XmtpSharedContext;
     use crate::groups::send_message_opts::SendMessageOpts;

--- a/crates/xmtp_mls/src/groups/group_membership.rs
+++ b/crates/xmtp_mls/src/groups/group_membership.rs
@@ -145,9 +145,6 @@ impl MembershipDiffWithKeyPackages {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
     use super::GroupMembership;
 
     #[xmtp_common::test]

--- a/crates/xmtp_mls/src/groups/group_permissions.rs
+++ b/crates/xmtp_mls/src/groups/group_permissions.rs
@@ -1384,9 +1384,6 @@ impl std::fmt::Display for PreconfiguredPolicies {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
     use std::collections::HashSet;
 
     use crate::groups::validated_commit::MutableMetadataValidationInfo;

--- a/crates/xmtp_mls/src/groups/intents.rs
+++ b/crates/xmtp_mls/src/groups/intents.rs
@@ -1010,10 +1010,8 @@ impl TryFrom<Vec<u8>> for PostCommitAction {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use crate::groups::send_message_opts::SendMessageOpts;
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
     use crate::context::XmtpSharedContext;
+    use crate::groups::send_message_opts::SendMessageOpts;
     use openmls::prelude::{ProcessedMessageContent, ProtocolMessage};
     use xmtp_api_d14n::protocol::XmtpQuery;
     use xmtp_cryptography::utils::generate_local_wallet;

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -3911,8 +3911,6 @@ pub(crate) fn decode_staged_commit(
 
 #[cfg(test)]
 pub(crate) mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
     use super::*;
     use crate::{builder::ClientBuilder, utils::TestMlsGroup};

--- a/crates/xmtp_mls/src/groups/subscriptions.rs
+++ b/crates/xmtp_mls/src/groups/subscriptions.rs
@@ -181,9 +181,6 @@ where
 #[cfg(test)]
 pub(crate) mod tests {
     use crate::groups::send_message_opts::SendMessageOpts;
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
     use futures::StreamExt;
     use std::sync::Arc;
 

--- a/crates/xmtp_mls/src/groups/tests/mod.rs
+++ b/crates/xmtp_mls/src/groups/tests/mod.rs
@@ -35,9 +35,6 @@ use xmtp_db::refresh_state::EntityKind;
 use xmtp_id::InboxOwner;
 use xmtp_proto::types::{Cursor, TopicKind};
 
-#[cfg(target_arch = "wasm32")]
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
 use super::group_permissions::PolicySet;
 use crate::context::XmtpSharedContext;
 use crate::groups::intents::QueueIntent;

--- a/crates/xmtp_mls/src/groups/tests/test_group_updated.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_group_updated.rs
@@ -6,9 +6,6 @@ use xmtp_content_types::{ContentCodec, group_updated::GroupUpdatedCodec};
 use xmtp_db::group_message::MsgQueryArgs;
 use xmtp_proto::xmtp::mls::message_contents::{EncodedContent, GroupUpdated};
 
-#[cfg(target_arch = "wasm32")]
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
 /// Decode a GroupUpdated message from encoded bytes
 fn decode_group_updated(encoded_bytes: &[u8]) -> GroupUpdated {
     let encoded_content = EncodedContent::decode(encoded_bytes).expect("Failed to decode content");

--- a/crates/xmtp_mls/src/identity_updates.rs
+++ b/crates/xmtp_mls/src/identity_updates.rs
@@ -709,8 +709,6 @@ pub async fn get_creation_signature_kind(
 #[cfg(test)]
 pub(crate) mod tests {
     #![allow(unused)] // b/c wasm & native
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
     use crate::{
         Client, XmtpApi,
         builder::ClientBuilder,

--- a/crates/xmtp_mls/src/lib.rs
+++ b/crates/xmtp_mls/src/lib.rs
@@ -98,9 +98,6 @@ pub struct MlsGroupGuard {
     _permit: tokio::sync::OwnedMutexGuard<()>,
 }
 
-#[cfg(all(test, target_arch = "wasm32"))]
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
 #[cfg_attr(not(target_arch = "wasm32"), ctor::ctor)]
 #[cfg(all(test, not(target_arch = "wasm32")))]
 fn test_setup() {

--- a/crates/xmtp_mls/src/subscriptions/mod.rs
+++ b/crates/xmtp_mls/src/subscriptions/mod.rs
@@ -597,9 +597,6 @@ pub(crate) mod tests {
     use crate::tester;
     use xmtp_api_d14n::protocol::XmtpQuery;
 
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
     /// A macro for asserting that a stream yields a specific decrypted message.
     ///
     /// # Example

--- a/crates/xmtp_mls/src/subscriptions/stream_all/tests.rs
+++ b/crates/xmtp_mls/src/subscriptions/stream_all/tests.rs
@@ -1,9 +1,6 @@
 use super::*;
 use crate::groups::send_message_opts::SendMessageOpts;
 
-#[cfg(target_arch = "wasm32")]
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
 use crate::subscriptions::stream_messages::stream_stats::StreamWithStats;
 use crate::tester;
 use crate::{assert_msg, builder::ClientBuilder};

--- a/crates/xmtp_mls/src/subscriptions/stream_conversations.rs
+++ b/crates/xmtp_mls/src/subscriptions/stream_conversations.rs
@@ -446,9 +446,6 @@ mod test {
     use futures::StreamExt;
     use xmtp_cryptography::utils::generate_local_wallet;
 
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
     #[xmtp_common::timeout(std::time::Duration::from_secs(10))]
     #[rstest::rstest]
     #[case::two_conversations(2)]

--- a/crates/xmtp_mls/src/test/builder.rs
+++ b/crates/xmtp_mls/src/test/builder.rs
@@ -1,5 +1,3 @@
-#[cfg(target_arch = "wasm32")]
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 use std::sync::atomic::AtomicBool;
 
 use crate::builder::ClientBuilderError;

--- a/crates/xmtp_mls/src/test/mod.rs
+++ b/crates/xmtp_mls/src/test/mod.rs
@@ -8,6 +8,3 @@ pub mod builder;
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
 pub mod builder_native_only;
-
-#[cfg(all(test, target_family = "wasm", target_os = "unknown"))]
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);

--- a/crates/xmtp_mls/src/utils/cleanup_duplicate_updates.rs
+++ b/crates/xmtp_mls/src/utils/cleanup_duplicate_updates.rs
@@ -130,9 +130,6 @@ mod tests {
         group_updated::{Inbox, MetadataFieldChange},
     };
 
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
     #[xmtp_common::test(unwrap_try = true)]
     async fn test_cleanup_works_as_expected() {
         tester!(alix);

--- a/crates/xmtp_mls/src/worker/device_sync/consent_sync.rs
+++ b/crates/xmtp_mls/src/worker/device_sync/consent_sync.rs
@@ -16,9 +16,6 @@ impl<Context: XmtpSharedContext> Client<Context> {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
-
     use crate::{utils::tester::*, worker::device_sync::handle::SyncMetric};
     use xmtp_db::consent_record::{ConsentState, ConsentType, StoredConsentRecord};
 

--- a/crates/xmtp_mls/src/worker/device_sync/message_sync.rs
+++ b/crates/xmtp_mls/src/worker/device_sync/message_sync.rs
@@ -41,8 +41,6 @@ where
 
 #[cfg(test)]
 pub(crate) mod tests {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
     use wasm_bindgen_test::wasm_bindgen_test;
 
     use super::*;

--- a/crates/xmtp_proto/src/lib.rs
+++ b/crates/xmtp_proto/src/lib.rs
@@ -33,9 +33,6 @@ pub mod api {
 
 #[cfg(test)]
 pub mod test {
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
-
     xmtp_common::if_native! {
         #[cfg(test)]
         #[ctor::ctor]

--- a/dev/test/wasm-interactive
+++ b/dev/test/wasm-interactive
@@ -36,7 +36,6 @@ if [[ -z "${IN_NIX_SHELL:-}" ]]; then
   fi
 fi
 
-export WASM_BINDGEN_TEST_ONLY_WEB=1
 # export SPLIT_LINKED_MODULES=1
 export NO_HEADLESS=1
 

--- a/justfile
+++ b/justfile
@@ -6,6 +6,8 @@ mod wasm 'bindings/wasm/wasm.just'
 export NIX_DEVSHELL := env("NIX_DEVSHELL", "default")
 set shell := ["./dev/nix-shell"]
 
+nix_system := arch() + "-" + if os() == "macos" { "darwin" } else { "linux" }
+
 # CI overrides to "cargo llvm-cov nextest --no-fail-fast --no-report" for coverage
 cargo_test := env("CARGO_TEST_CMD", "cargo nextest run")
 
@@ -68,6 +70,12 @@ format:
   just wasm format
 
 # --- TEST ---
+
+# run the nix derivation for v3/d14n tests. no local incremental compilation but does use global cachix.
+nix-test:
+  nix run nixpkgs#nix-output-monitor build .#nextest.{{ nix_system }}.v3
+  nix run nixpkgs#nix-output-monitor build .#nextest.{{ nix_system }}.d14n
+
 
 # `just test`, `just test v3`, `just test d14n`, `just test crate xmtp_mls`
 [script("bash")]

--- a/nix/ci-checks.nix
+++ b/nix/ci-checks.nix
@@ -20,6 +20,8 @@
           {
             v3 = pkgs.callPackage ./package/nextest.nix { };
             d14n = pkgs.callPackage ./package/nextest.nix { d14n = true; };
+            wasm-v3 = pkgs.callPackage ./package/wasm-nextest.nix { };
+            wasm-d14n = pkgs.callPackage ./package/wasm-nextest.nix { d14n = true; };
           }
         )
       );

--- a/nix/lib/shell-common.nix
+++ b/nix/lib/shell-common.nix
@@ -105,7 +105,6 @@ in
     CC_wasm32_unknown_unknown = "${llvmPackages.clang-unwrapped}/bin/clang";
     AR_wasm32_unknown_unknown = "${llvmPackages.bintools-unwrapped}/bin/llvm-ar";
     CFLAGS_wasm32_unknown_unknown = "-I ${llvmPackages.clang-unwrapped.lib}/lib/clang/21/include";
-    WASM_BINDGEN_TEST_ONLY_WEB = 1;
     WASM_BINDGEN_TEST_TIMEOUT = 1024;
     RSTEST_TIMEOUT = 90;
     WASM_BINDGEN_TEST_WEBDRIVER_JSON = webdriverJson;

--- a/nix/package/wasm-nextest.nix
+++ b/nix/package/wasm-nextest.nix
@@ -1,0 +1,110 @@
+# Derivation that runs cargo nextest with llvm-cov on the workspace
+{
+  xmtp,
+  lib,
+  pkg-config,
+  openssl,
+  perl,
+  sqlite,
+  sqlcipher,
+  chromedriver,
+  google-chrome,
+  chromium,
+  stdenv,
+  wasm-bindgen-cli,
+  cargo-nextest,
+  nodejs_24,
+  d14n ? false,
+  ...
+}:
+let
+  inherit (lib.fileset) unions fileFilter;
+  inherit (xmtp) craneLib;
+  inherit (craneLib.fileset) commonCargoSources;
+  root = ./../..;
+  rust-toolchain = xmtp.mkToolchain [ "wasm32-unknown-unknown" ] [ "llvm-tools-preview" ];
+  rust = craneLib.overrideToolchain (p: rust-toolchain);
+
+  src = lib.fileset.toSource {
+    inherit root;
+    fileset = unions [
+      xmtp.filesets.libraries
+      # All bindings and apps cargo sources so the full workspace resolves
+      # with --locked. crane replaces source with dummies for buildDepsOnly.
+      (commonCargoSources (root + /bindings/wasm))
+      # db snapshots
+      (fileFilter (file: file.hasExt "xmtp") (root + /crates/xmtp_mls/tests/assets))
+      (fileFilter (file: file.hasExt "json") (root + /crates))
+    ];
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    openssl
+    perl
+    sqlite
+    sqlcipher
+    wasm-bindgen-cli
+    cargo-nextest
+    nodejs_24
+  ];
+  commonArgs = {
+    inherit src;
+    strictDeps = true;
+    inherit nativeBuildInputs;
+    CARGO_BUILD_TARGET = "wasm32-unknown-unknown";
+    preConfigure = ''
+      export HOME=$TMPDIR
+    '';
+    inherit (xmtp.shellCommon.wasmEnv)
+      CC_wasm32_unknown_unknown
+      AR_wasm32_unknown_unknown
+      CFLAGS_wasm32_unknown_unknown
+      ;
+    CARGO_PROFILE = "wasm-test";
+  };
+
+  d14nTestArgs = if d14n then "--features d14n" else "";
+  wasmPackages = "-p xmtp_mls -p xmtp_cryptography -p xmtp_common -p xmtp_api -p xmtp_id -p xmtp_db -p xmtp_api_d14n -p xmtp_content_types";
+
+  cargoArtifacts = rust.buildDepsOnly (
+    commonArgs
+    // {
+      doCheck = false;
+      buildPhaseCargoCommand = "cargo nextest run --locked --cargo-profile $CARGO_PROFILE --no-run ${wasmPackages}";
+    }
+  );
+in
+rust.cargoNextest (
+  commonArgs
+  // {
+    inherit cargoArtifacts;
+    inherit (xmtp.shellCommon.wasmEnv)
+      CHROMEDRIVER
+      RSTEST_TIMEOUT
+      WASM_BINDGEN_TEST_TIMEOUT
+      WASM_BINDGEN_TEST_WEBDRIVER_JSON
+      ;
+    WASM_BINDGEN_TEST_NO_ORIGIN_ISOLATION = "1";
+    # chromedriver requires home to be editable/set, otherwise it SIGKILLS and fails tests.
+    preBuild = "export HOME=$TMPDIR";
+    nativeBuildInputs =
+      nativeBuildInputs
+      ++ [
+        chromedriver
+      ]
+      ++ lib.optionals stdenv.isDarwin [ google-chrome ]
+      ++ lib.optionals stdenv.isLinux [ chromium ];
+
+    pname = if d14n then "wasm-d14n" else "wasm-v3";
+    partitions = 1;
+    partitionType = "count";
+    cargoNextestPartitionsExtraArgs = "--no-tests=pass";
+    XMTP_TEST_LOGGING = "false";
+    RUST_LOG = "off";
+    cargoExtraArgs = "${d14nTestArgs} ${wasmPackages}";
+    cargoNextestExtraArgs = if d14n then "--profile ci-d14n" else "--profile ci";
+    # most tests query docker
+    __noChroot = true;
+  }
+)

--- a/nix/package/wasm.nix
+++ b/nix/package/wasm.nix
@@ -112,11 +112,6 @@ let
     }
   );
 
-  # this allows re-using build artifacts
-  # nextest-libs = nextest "-E 'kind(lib)'";
-  # nextest-d14n = nextest "--features d14n -E 'kind(lib)'";
-  # nextest-integration = nextest "-E 'package(bindings_wasm)'";
-
   devShell = mkShell (
     commonEnv
     // {
@@ -133,7 +128,6 @@ let
       ++ lib.optionals stdenv.isDarwin [ google-chrome ]
       ++ lib.optionals stdenv.isLinux [ chromium ];
       inherit (xmtp.shellCommon.wasmEnv)
-        WASM_BINDGEN_TEST_ONLY_WEB
         RSTEST_TIMEOUT
         WASM_BINDGEN_TEST_TIMEOUT
         WASM_BINDGEN_TEST_WEBDRIVER_JSON

--- a/nix/shells/local.nix
+++ b/nix/shells/local.nix
@@ -24,6 +24,7 @@
   kotlin-language-server,
   xmtp,
   rust-analyzer,
+  nodejs_24,
   just,
 }:
 let
@@ -66,7 +67,6 @@ mkShell (
       CC_wasm32_unknown_unknown
       AR_wasm32_unknown_unknown
       CFLAGS_wasm32_unknown_unknown
-      WASM_BINDGEN_TEST_ONLY_WEB
       WASM_BINDGEN_TEST_TIMEOUT
       RSTEST_TIMEOUT
       WASM_BINDGEN_TEST_WEBDRIVER_JSON
@@ -89,6 +89,7 @@ mkShell (
         foundry-bin
         sqlcipher
         corepack
+        nodejs_24
 
         # Android
         androidEnv.devComposition.androidsdk


### PR DESCRIPTION
sorry for the churn here @neekolas I wanted  to see if test was any faster

I still don't know why [some test runs seem to take ~20min](https://github.com/xmtp/libxmtp/actions/runs/22782012936/job/66089947080) while others remain comparable to [normal cargo test](https://github.com/xmtp/libxmtp/actions/runs/22742726879/job/65959699595). but maybe some runs just get unlucky and need to retry a really heavy test

both methods seem comparable at ~12min in most cases https://github.com/xmtp/libxmtp/actions/runs/22979045511/job/66714504108

we can also do a similar thing as the workspace tests and use crane.cargoNextTest with the wasm target, which will cache the dependencies for a small speedup


overall nextest is more stable than cargo test anyway



I was able to get all tests other than xmtp_mls to use the nodejs runner, eliminating dependency on chromium/google-chrome for headless tests. xmtp_db tests that rely on opfs (only two) were moved to integration tests and still use a dedicated web worker.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore nextest for WASM tests by removing `run_in_dedicated_worker` configuration
> - Removes `wasm_bindgen_test_configure!(run_in_dedicated_worker)` from all test modules across `xmtp_content_types`, `xmtp_db`, `xmtp_mls`, `xmtp_id`, and related crates, switching WASM tests to the default `wasm_bindgen_test` runner configuration.
> - Adds a new Nix derivation in [wasm-nextest.nix](https://github.com/xmtp/libxmtp/pull/3326/files#diff-760a44deeeef509bc6fc28efa8b2004427bf5484cabb0711a35cfc67aae11c13) that runs `cargo-nextest` for `wasm32-unknown-unknown` with optional `d14n` feature support, and wires it into CI via [ci-checks.nix](https://github.com/xmtp/libxmtp/pull/3326/files#diff-9012eb276afdf1bd8abc7f1b4caa410e84dd90d7eb70c5ebdefe5300aa0d7df5).
> - Moves OPFS tests from inline to an external [tests/opfs.rs](https://github.com/xmtp/libxmtp/pull/3326/files#diff-ea15022a2612eef35acae769718dbff6a45c1ebf273e06bdeaf0681007ff697e) file and exposes `init_opfs` and `SyncOpfsUtil`'s inner field as `pub` to support this.
> - Updates [test-wasm.yml](https://github.com/xmtp/libxmtp/pull/3326/files#diff-790d53f151fb2d7f0f47f8eb830aa62a16e251d28597627ed3f574b87b07688a) to run `just wasm test-ci` and removes `WASM_BINDGEN_TEST_ONLY_WEB` from all dev shells and scripts.
> - Behavioral Change: WASM tests no longer run in a dedicated worker; they use the default `wasm_bindgen_test` browser/worker context.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 71efaff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->