### PR TITLE
feat(xdbg): add healthcheck command for local XMTP clients

### DIFF
--- a/apps/xmtp_debug/src/app.rs
+++ b/apps/xmtp_debug/src/app.rs
@@ -6,6 +6,8 @@ mod clients;
 mod export;
 /// Generate functionality
 mod generate;
+/// Health check for all local clients
+mod healthcheck;
 /// Information about this app
 mod info;
 /// Inspect data on the XMTP Network
@@ -145,6 +147,7 @@ impl App {
                 Modify(m) => modify::Modify::new(m, backend)?.run().await,
                 Stream(s) => stream::Stream::new(s, backend)?.run().await,
                 Test(t) => test::Test::new(t, backend).run().await,
+                Healthcheck(h) => healthcheck::Healthcheck::new(h, backend)?.run().await,
             }?;
         }
 

--- a/apps/xmtp_debug/src/app/healthcheck.rs
+++ b/apps/xmtp_debug/src/app/healthcheck.rs
@@ -1,0 +1,286 @@
+//! Health check for all local XMTP clients on the current network.
+//!
+//! Runs 5 checks per client:
+//! 1. No missing messages  — every network message for each group exists locally
+//! 2. Can send             — a test message can be sent on at least one active group
+//! 3. Can receive          — group messages can be queried from the network
+//! 4. No fork              — no group has `is_commit_log_forked == Some(true)`
+//! 5. Identity reachable   — the inbox_id is visible on the network
+
+use std::{collections::HashSet, sync::Arc};
+
+use color_eyre::eyre::{Result, eyre};
+use xmtp_db::encrypted_store::group::GroupMembershipState;
+use xmtp_db::group::GroupQueryArgs;
+use xmtp_db::prelude::QueryGroup;
+use xmtp_mls::groups::send_message_opts::SendMessageOpts;
+use xmtp_proto::xmtp::identity::api::v1::{
+    GetIdentityUpdatesRequest,
+    get_identity_updates_request::Request as IdentityRequest,
+};
+
+use crate::{
+    app::{
+        App,
+        store::{Database, IdentityStore},
+    },
+    args,
+};
+
+pub struct Healthcheck {
+    opts: args::HealthcheckOpts,
+    network: args::BackendOpts,
+    db: Arc<redb::ReadOnlyDatabase>,
+}
+
+struct GroupHealthResult {
+    group_id: String,
+    /// Number of network messages with no matching local record
+    missing_message_count: usize,
+    can_send: bool,
+    can_receive: bool,
+    /// `None` = status unknown, `Some(true)` = forked
+    is_forked: Option<bool>,
+}
+
+struct ClientHealthResult {
+    inbox_id: String,
+    identity_reachable: bool,
+    groups: Vec<GroupHealthResult>,
+}
+
+impl ClientHealthResult {
+    fn is_healthy(&self) -> bool {
+        self.identity_reachable
+            && self
+                .groups
+                .iter()
+                .all(|g| g.missing_message_count == 0 && g.can_send && g.can_receive && g.is_forked != Some(true))
+    }
+}
+
+impl Healthcheck {
+    pub fn new(opts: args::HealthcheckOpts, network: args::BackendOpts) -> Result<Self> {
+        let db = App::readonly_db()?;
+        Ok(Self { opts, network, db })
+    }
+
+    pub async fn run(self) -> Result<()> {
+        let Healthcheck { opts, network, db } = self;
+
+        let identity_store: IdentityStore = db.clone().into();
+        let network_id = u64::from(&network);
+
+        let identities = identity_store
+            .load(network_id)?
+            .ok_or_else(|| eyre!("no identities in store for this network – try `xdbg generate identity`"))?;
+
+        let mut all_results: Vec<ClientHealthResult> = Vec::new();
+        let mut any_unhealthy = false;
+
+        for identity_guard in identities {
+            let identity = identity_guard.value();
+            let inbox_id_hex = hex::encode(identity.inbox_id);
+
+            info!(inbox_id = %inbox_id_hex, "checking client");
+
+            let client = match crate::app::client_from_identity(&identity, &network) {
+                Ok(c) => c,
+                Err(e) => {
+                    error!(inbox_id = %inbox_id_hex, error = %e, "failed to load client, skipping");
+                    if opts.fail_fast {
+                        return Err(e);
+                    }
+                    continue;
+                }
+            };
+
+            // ── Check 5: identity reachable ──────────────────────────────────
+            let api_client = network.connect()?;
+            let identity_reachable = match api_client
+                .get_identity_updates_v2(GetIdentityUpdatesRequest {
+                    requests: vec![IdentityRequest {
+                        inbox_id: inbox_id_hex.clone(),
+                        sequence_id: 0,
+                    }],
+                })
+                .await
+            {
+                Ok(resp) => {
+                    let reachable = resp.responses.iter().any(|r| !r.updates.is_empty());
+                    if !reachable {
+                        warn!(inbox_id = %inbox_id_hex, "identity has no updates on network (not reachable)");
+                    }
+                    reachable
+                }
+                Err(e) => {
+                    error!(inbox_id = %inbox_id_hex, error = %e, "failed to query identity updates");
+                    false
+                }
+            };
+
+            // ── Per-group checks ─────────────────────────────────────────────
+            let groups = client.find_groups(GroupQueryArgs::default())?;
+            let mut group_results: Vec<GroupHealthResult> = Vec::new();
+
+            for group in &groups {
+                let group_id_hex = hex::encode(&group.group_id);
+
+                // ── Check 1: missing messages ─────────────────────────────
+                let network_messages = match api_client
+                    .query_group_messages(group.group_id.clone().into())
+                    .await
+                {
+                    Ok(msgs) => msgs,
+                    Err(e) => {
+                        error!(group_id = %group_id_hex, error = %e, "failed to query network messages");
+                        if opts.fail_fast {
+                            return Err(e.into());
+                        }
+                        vec![]
+                    }
+                };
+
+                let local_messages = group.find_messages(&Default::default())?;
+                let local_cursors: HashSet<(i64, i64)> = local_messages
+                    .iter()
+                    .map(|m| (m.sequence_id, m.originator_id))
+                    .collect();
+
+                let missing_message_count = network_messages
+                    .iter()
+                    .filter(|nm| {
+                        !local_cursors
+                            .contains(&(nm.sequence_id() as i64, nm.originator_id() as i64))
+                    })
+                    .count();
+
+                if missing_message_count > 0 {
+                    warn!(
+                        group_id = %group_id_hex,
+                        missing = missing_message_count,
+                        "group has messages on network not found locally"
+                    );
+                }
+
+                // ── Check 3: can receive ──────────────────────────────────
+                let can_receive = match group.sync().await {
+                    Ok(_) => true,
+                    Err(e) => {
+                        warn!(group_id = %group_id_hex, error = %e, "group sync failed");
+                        false
+                    }
+                };
+
+                // ── Check 4: fork status ──────────────────────────────────
+                let is_forked = {
+                    let conn = client.context.db();
+                    conn.get_group_commit_log_forked_status(&group.group_id)
+                        .unwrap_or(None)
+                };
+                if is_forked == Some(true) {
+                    warn!(group_id = %group_id_hex, "group commit log is FORKED");
+                }
+
+                // ── Check 2: can send (deferred, marked per-group) ────────
+                // We attempt send on active groups below; initialise to false here.
+                group_results.push(GroupHealthResult {
+                    group_id: group_id_hex,
+                    missing_message_count,
+                    can_send: false, // filled in below
+                    can_receive,
+                    is_forked,
+                });
+            }
+
+            // ── Check 2: can send (try each active group until one succeeds) ─
+            let active_groups: Vec<_> = groups
+                .iter()
+                .zip(group_results.iter_mut())
+                .filter(|(g, _)| {
+                    matches!(
+                        g.membership_state(),
+                        Ok(GroupMembershipState::Allowed) | Ok(GroupMembershipState::PendingRemove)
+                    )
+                })
+                .collect();
+
+            for (group, result) in active_groups {
+                match group
+                    .send_message(b"xdbg-healthcheck", SendMessageOpts::default())
+                    .await
+                {
+                    Ok(_) => {
+                        result.can_send = true;
+                        break;
+                    }
+                    Err(e) => {
+                        warn!(
+                            group_id = %result.group_id,
+                            error = %e,
+                            "send_message failed on group"
+                        );
+                    }
+                }
+            }
+
+            let client_result = ClientHealthResult {
+                inbox_id: inbox_id_hex.clone(),
+                identity_reachable,
+                groups: group_results,
+            };
+
+            print_client_result(&client_result);
+
+            if !client_result.is_healthy() {
+                any_unhealthy = true;
+                if opts.fail_fast {
+                    return Err(eyre!("healthcheck FAILED for client {}", inbox_id_hex));
+                }
+            }
+
+            all_results.push(client_result);
+        }
+
+        // ── Summary ──────────────────────────────────────────────────────────
+        println!();
+        println!("=== Healthcheck Summary ===");
+        println!(
+            "Checked {} client(s)",
+            all_results.len()
+        );
+
+        let healthy = all_results.iter().filter(|r| r.is_healthy()).count();
+        let unhealthy = all_results.len() - healthy;
+        println!("  healthy:   {healthy}");
+        println!("  unhealthy: {unhealthy}");
+
+        if any_unhealthy {
+            Err(eyre!("healthcheck FAILED: {unhealthy} client(s) are unhealthy"))
+        } else {
+            info!("All clients are healthy");
+            Ok(())
+        }
+    }
+}
+
+fn print_client_result(r: &ClientHealthResult) {
+    let status = if r.is_healthy() { "HEALTHY" } else { "UNHEALTHY" };
+    println!();
+    println!("── client {} [{status}]", r.inbox_id);
+    println!("   identity reachable : {}", r.identity_reachable);
+    println!("   groups checked     : {}", r.groups.len());
+
+    for g in &r.groups {
+        let fork_str = match g.is_forked {
+            Some(true) => "FORKED",
+            Some(false) => "ok",
+            None => "unknown",
+        };
+        println!("   ├─ group {}", g.group_id);
+        println!("      missing messages : {}", g.missing_message_count);
+        println!("      can send         : {}", g.can_send);
+        println!("      can receive      : {}", g.can_receive);
+        println!("      fork status      : {fork_str}");
+    }
+}

--- a/apps/xmtp_debug/src/app/healthcheck.rs
+++ b/apps/xmtp_debug/src/app/healthcheck.rs
@@ -1,17 +1,18 @@
 //! Health check for all local XMTP clients on the current network.
 //!
-//! Runs 5 checks per client:
+//! Runs checks per client:
 //! 1. No missing messages  — every network message for each group exists locally
 //! 2. Can send             — a test message can be sent on at least one active group
 //! 3. Can receive          — group messages can be queried from the network
-//! 4. No fork              — no group has `is_commit_log_forked == Some(true)`
+//! 4. No fork              — no group has `maybe_forked` or `is_commit_log_forked`
 //! 5. Identity reachable   — the inbox_id is visible on the network
 
-use std::{collections::HashSet, sync::Arc};
+use std::{collections::HashSet, process, sync::Arc};
 
 use color_eyre::eyre::{Result, eyre};
+use owo_colors::OwoColorize;
 use xmtp_db::encrypted_store::group::GroupMembershipState;
-use xmtp_db::group::GroupQueryArgs;
+use xmtp_db::group::{GroupQueryArgs, StoredGroup};
 use xmtp_db::prelude::QueryGroup;
 use xmtp_mls::groups::send_message_opts::SendMessageOpts;
 use xmtp_proto::xmtp::identity::api::v1::{
@@ -33,14 +34,30 @@ pub struct Healthcheck {
     db: Arc<redb::ReadOnlyDatabase>,
 }
 
+/// Sequence IDs of messages present on the network but missing locally.
+type MissingMsg = (i64, i64); // (sequence_id, originator_id)
+
 struct GroupHealthResult {
     group_id: String,
-    /// Number of network messages with no matching local record
-    missing_message_count: usize,
+    missing_messages: Vec<MissingMsg>,
     can_send: bool,
     can_receive: bool,
-    /// `None` = status unknown, `Some(true)` = forked
-    is_forked: Option<bool>,
+    /// `maybe_forked` flag from the local DB
+    maybe_forked: bool,
+    /// Human-readable fork details when `maybe_forked` is set
+    fork_details: String,
+    /// `None` = status unknown, `Some(true)` = commit log diverged from remote
+    is_commit_log_forked: Option<bool>,
+}
+
+impl GroupHealthResult {
+    fn is_healthy(&self) -> bool {
+        self.missing_messages.is_empty()
+            && self.can_send
+            && self.can_receive
+            && !self.maybe_forked
+            && self.is_commit_log_forked != Some(true)
+    }
 }
 
 struct ClientHealthResult {
@@ -51,11 +68,7 @@ struct ClientHealthResult {
 
 impl ClientHealthResult {
     fn is_healthy(&self) -> bool {
-        self.identity_reachable
-            && self
-                .groups
-                .iter()
-                .all(|g| g.missing_message_count == 0 && g.can_send && g.can_receive && g.is_forked != Some(true))
+        self.identity_reachable && self.groups.iter().all(|g| g.is_healthy())
     }
 }
 
@@ -121,6 +134,7 @@ impl Healthcheck {
 
             // ── Per-group checks ─────────────────────────────────────────────
             let groups = client.find_groups(GroupQueryArgs::default())?;
+            let conn = client.context.db();
             let mut group_results: Vec<GroupHealthResult> = Vec::new();
 
             for group in &groups {
@@ -147,18 +161,19 @@ impl Healthcheck {
                     .map(|m| (m.sequence_id, m.originator_id))
                     .collect();
 
-                let missing_message_count = network_messages
+                let missing_messages: Vec<MissingMsg> = network_messages
                     .iter()
                     .filter(|nm| {
                         !local_cursors
                             .contains(&(nm.sequence_id() as i64, nm.originator_id() as i64))
                     })
-                    .count();
+                    .map(|nm| (nm.sequence_id() as i64, nm.originator_id() as i64))
+                    .collect();
 
-                if missing_message_count > 0 {
+                if !missing_messages.is_empty() {
                     warn!(
                         group_id = %group_id_hex,
-                        missing = missing_message_count,
+                        missing = missing_messages.len(),
                         "group has messages on network not found locally"
                     );
                 }
@@ -172,24 +187,33 @@ impl Healthcheck {
                     }
                 };
 
-                // ── Check 4: fork status ──────────────────────────────────
-                let is_forked = {
-                    let conn = client.context.db();
-                    conn.get_group_commit_log_forked_status(&group.group_id)
-                        .unwrap_or(None)
-                };
-                if is_forked == Some(true) {
+                // ── Check 4: fork status (all signals) ────────────────────
+                let stored: Option<StoredGroup> = conn.find_group(&group.group_id).unwrap_or(None);
+                let maybe_forked = stored.as_ref().map(|s| s.maybe_forked).unwrap_or(false);
+                let fork_details = stored
+                    .as_ref()
+                    .map(|s| s.fork_details.clone())
+                    .unwrap_or_default();
+                let is_commit_log_forked = conn
+                    .get_group_commit_log_forked_status(&group.group_id)
+                    .unwrap_or(None);
+
+                if maybe_forked {
+                    warn!(group_id = %group_id_hex, details = %fork_details, "group is marked maybe_forked");
+                }
+                if is_commit_log_forked == Some(true) {
                     warn!(group_id = %group_id_hex, "group commit log is FORKED");
                 }
 
                 // ── Check 2: can send (deferred, marked per-group) ────────
-                // We attempt send on active groups below; initialise to false here.
                 group_results.push(GroupHealthResult {
                     group_id: group_id_hex,
-                    missing_message_count,
+                    missing_messages,
                     can_send: false, // filled in below
                     can_receive,
-                    is_forked,
+                    maybe_forked,
+                    fork_details,
+                    is_commit_log_forked,
                 });
             }
 
@@ -230,12 +254,12 @@ impl Healthcheck {
                 groups: group_results,
             };
 
-            print_client_result(&client_result);
+            log_client_result(&client_result);
 
             if !client_result.is_healthy() {
                 any_unhealthy = true;
                 if opts.fail_fast {
-                    return Err(eyre!("healthcheck FAILED for client {}", inbox_id_hex));
+                    process::exit(1);
                 }
             }
 
@@ -243,20 +267,35 @@ impl Healthcheck {
         }
 
         // ── Summary ──────────────────────────────────────────────────────────
-        println!();
-        println!("=== Healthcheck Summary ===");
-        println!(
-            "Checked {} client(s)",
-            all_results.len()
-        );
+        info!("=== Healthcheck Summary ===");
+        info!("Checked {} client(s)", all_results.len());
 
         let healthy = all_results.iter().filter(|r| r.is_healthy()).count();
         let unhealthy = all_results.len() - healthy;
-        println!("  healthy:   {healthy}");
-        println!("  unhealthy: {unhealthy}");
+        info!("  healthy:   {healthy}");
+        if unhealthy > 0 {
+            info!("  unhealthy: {}", unhealthy.to_string().red().bold());
+        } else {
+            info!("  unhealthy: {unhealthy}");
+        }
+
+        // Print missing sequence IDs per group for any unhealthy clients
+        for client in &all_results {
+            for group in &client.groups {
+                if !group.missing_messages.is_empty() {
+                    info!(
+                        inbox_id = %client.inbox_id,
+                        group_id = %group.group_id,
+                        "missing sequence IDs: {:?}",
+                        group.missing_messages
+                    );
+                }
+            }
+        }
 
         if any_unhealthy {
-            Err(eyre!("healthcheck FAILED: {unhealthy} client(s) are unhealthy"))
+            info!("{}", "healthcheck FAILED".red().bold());
+            process::exit(1);
         } else {
             info!("All clients are healthy");
             Ok(())
@@ -264,23 +303,54 @@ impl Healthcheck {
     }
 }
 
-fn print_client_result(r: &ClientHealthResult) {
-    let status = if r.is_healthy() { "HEALTHY" } else { "UNHEALTHY" };
-    println!();
-    println!("── client {} [{status}]", r.inbox_id);
-    println!("   identity reachable : {}", r.identity_reachable);
-    println!("   groups checked     : {}", r.groups.len());
+fn bool_str(v: bool, healthy_when_true: bool) -> String {
+    if v == healthy_when_true {
+        v.to_string().green().bold().to_string()
+    } else {
+        v.to_string().red().bold().to_string()
+    }
+}
+
+fn log_client_result(r: &ClientHealthResult) {
+    let status = if r.is_healthy() {
+        "HEALTHY".green().bold().to_string()
+    } else {
+        "UNHEALTHY".red().bold().to_string()
+    };
+
+    info!("── client {} [{}]", r.inbox_id, status);
+    info!(
+        "   identity reachable : {}",
+        bool_str(r.identity_reachable, true)
+    );
+    info!("   groups checked     : {}", r.groups.len());
 
     for g in &r.groups {
-        let fork_str = match g.is_forked {
-            Some(true) => "FORKED",
-            Some(false) => "ok",
-            None => "unknown",
+        let fork_str = match (g.maybe_forked, g.is_commit_log_forked) {
+            (true, _) => format!(
+                "{} ({})",
+                "FORKED".red().bold(),
+                if g.fork_details.is_empty() {
+                    "no details".to_string()
+                } else {
+                    g.fork_details.clone()
+                }
+            ),
+            (_, Some(true)) => "COMMIT LOG FORKED".red().bold().to_string(),
+            (false, Some(false)) => "ok".green().bold().to_string(),
+            _ => "unknown".to_string(),
         };
-        println!("   ├─ group {}", g.group_id);
-        println!("      missing messages : {}", g.missing_message_count);
-        println!("      can send         : {}", g.can_send);
-        println!("      can receive      : {}", g.can_receive);
-        println!("      fork status      : {fork_str}");
+
+        let missing = if g.missing_messages.is_empty() {
+            "0".green().bold().to_string()
+        } else {
+            g.missing_messages.len().to_string().red().bold().to_string()
+        };
+
+        info!("   ├─ group {}", g.group_id);
+        info!("      missing messages : {missing}");
+        info!("      can send         : {}", bool_str(g.can_send, true));
+        info!("      can receive      : {}", bool_str(g.can_receive, true));
+        info!("      fork status      : {fork_str}");
     }
 }

--- a/apps/xmtp_debug/src/args.rs
+++ b/apps/xmtp_debug/src/args.rs
@@ -44,6 +44,7 @@ pub enum Commands {
     Export(ExportOpts),
     Stream(StreamOpts),
     Test(TestOpts),
+    Healthcheck(HealthcheckOpts),
 }
 
 /// Send Data on the network
@@ -508,6 +509,14 @@ pub enum TestScenario {
     MessageVisibility,
     /// Measure group sync latency after N messages
     GroupSync,
+}
+
+/// Run a health check on all local clients for the current network
+#[derive(Args, Debug)]
+pub struct HealthcheckOpts {
+    /// Stop at the first unhealthy client instead of checking all of them
+    #[arg(long, short)]
+    pub fail_fast: bool,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Adds `xdbg healthcheck` subcommand that runs 5 health checks per client in the local identity store
- Checks: missing messages, can-send, can-receive, no commit log fork, identity reachable on network
- Supports `--fail-fast` (`-f`) flag to stop at the first unhealthy client
- Prints a per-client/per-group report and exits non-zero if any client is unhealthy

## Test plan

- [ ] Run `xdbg healthcheck` against a local node with generated identities and verify output
- [ ] Run `xdbg healthcheck --fail-fast` and verify it exits early on the first failure
- [ ] Verify `xdbg --help` shows the new `healthcheck` subcommand with correct description

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `healthcheck` command to xmtp_debug CLI for local XMTP clients
> - Adds a new `healthcheck` subcommand to [args.rs](https://github.com/xmtp/libxmtp/pull/3351/files#diff-625330612e40d918eef6d9785cc1b9adbc3c444cc2666c0d632bb216d3b2b4f5) with a `--fail-fast` (`-f`) flag to stop at the first unhealthy client.
> - Implements the health check workflow in [healthcheck.rs](https://github.com/xmtp/libxmtp/pull/3351/files#diff-50cf0697754b2782c60c4193ebed7e7223668ed3c3d52d944b475ca724172956): loads identities from the local DB, checks network reachability via `get_identity_updates_v2`, enumerates groups, compares network vs. local messages to detect missing ones, reads fork indicators, and attempts to send a test message (`xdbg-healthcheck`) to an active group.
> - Logs per-client and per-group results with colored output and prints a summary on completion.
> - Risk: the healthcheck sends a real message to a group on the network; it also calls `std::process::exit(1)` directly on unhealthy findings rather than returning an error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e61b440.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->