### PR TITLE
share one `cargoArtifacts` instance across nix builds 

### DIFF
--- a/.config/hakari.toml
+++ b/.config/hakari.toml
@@ -29,20 +29,31 @@ platforms = [
 
 # Including mio/tokio breaks webassembly builds since net features are mutually exclusive with wasm
 [traversal-excludes]
+workspace-members = [
+  "xmtp_cli",
+  "log_parser",
+  "xmtp-db-tools",
+  "xdbg",
+  "error_glossary",
+]
 third-party = [
-  { name = "hyper" },
-  { name = "mio" },
+  { name = "tonic" },
   { name = "tokio" },
   { name = "uniffi" },
   { name = "wasm-bindgen" },
 ]
-workspace-members = ["xmtp_cli", "log_parser", "xmtp-db-tools", "xdbg"]
+
 [final-excludes]
+workspace-members = [
+  "xmtp_cli",
+  "log_parser",
+  "xmtp-db-tools",
+  "xdbg",
+  "error_glossary",
+]
 third-party = [
-  { name = "hyper" },
-  { name = "mio" },
-  { name = "tokio" },
+  { name = "tonic" },
+  { name = "tonic" },
   { name = "uniffi" },
   { name = "wasm-bindgen" },
 ]
-workspace-members = ["xmtp_cli", "log_parser", "xmtp-db-tools", "xdbg"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3793,7 +3793,6 @@ dependencies = [
  "clap",
  "syn 2.0.117",
  "walkdir",
- "xmtp-workspace-hack",
 ]
 
 [[package]]
@@ -5491,14 +5490,14 @@ dependencies = [
 
 [[package]]
 name = "headers"
-version = "0.3.9"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
  "headers-core",
- "http 0.2.12",
+ "http 1.4.0",
  "httpdate",
  "mime",
  "sha1",
@@ -5506,11 +5505,11 @@ dependencies = [
 
 [[package]]
 name = "headers-core"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http 0.2.12",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -7554,24 +7553,6 @@ dependencies = [
  "png 0.17.16",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "multer"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01acbdc23469fd8fe07ab135923371d5f5a422fbf9c522158677c8eb15bc51c2"
-dependencies = [
- "bytes",
- "encoding_rs",
- "futures-util",
- "http 0.2.12",
- "httparse",
- "log",
- "memchr",
- "mime",
- "spin",
- "version_check",
 ]
 
 [[package]]
@@ -11182,12 +11163,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
 name = "spin_on"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11746,18 +11721,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
-]
-
-[[package]]
-name = "tokio-tungstenite"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite",
 ]
 
 [[package]]
@@ -12342,25 +12305,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tungstenite"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http 1.4.0",
- "httparse",
- "log",
- "rand 0.8.5",
- "sha1",
- "thiserror 1.0.69",
- "url",
- "utf-8",
-]
-
-[[package]]
 name = "typed-index-collections"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12759,12 +12703,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12934,20 +12872,21 @@ dependencies = [
 
 [[package]]
 name = "warp"
-version = "0.3.7"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4378d202ff965b011c64817db11d5829506d3404edeadb61f190d111da3f231c"
+checksum = "51d06d9202adc1f15d709c4f4a2069be5428aa912cc025d6f268ac441ab066b0"
 dependencies = [
  "bytes",
- "futures-channel",
  "futures-util",
  "headers",
- "http 0.2.12",
- "hyper 0.14.32",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
  "log",
  "mime",
  "mime_guess",
- "multer",
  "percent-encoding",
  "pin-project",
  "scoped-tls",
@@ -12955,7 +12894,6 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-tungstenite",
  "tokio-util",
  "tower-service",
  "tracing",
@@ -14333,7 +14271,6 @@ dependencies = [
  "alloy-sol-types",
  "alloy-transport-http",
  "bitflags 2.11.0",
- "byteorder",
  "bytes",
  "cc",
  "chrono",
@@ -14358,6 +14295,7 @@ dependencies = [
  "getrandom 0.4.2",
  "hashbrown 0.16.1",
  "hpke-rs",
+ "hyper 1.8.1",
  "hyper-util",
  "idna",
  "indexmap 2.13.0",
@@ -14377,7 +14315,6 @@ dependencies = [
  "percent-encoding",
  "proc-macro2",
  "proptest",
- "quote",
  "rand 0.10.0",
  "rand 0.9.2",
  "rand_chacha 0.10.0",
@@ -14393,7 +14330,6 @@ dependencies = [
  "rustls-pki-types",
  "rustls-webpki",
  "sec1",
- "security-framework-sys",
  "serde",
  "serde_core",
  "serde_json",
@@ -14405,12 +14341,9 @@ dependencies = [
  "syn 2.0.117",
  "sync_wrapper 1.0.2",
  "time",
- "tokio-rustls",
- "tokio-stream",
  "tokio-util",
  "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
- "tonic",
  "tower",
  "tracing",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   # Core crates
   "crates/*",
 ]
+
 exclude = ["apps/android"]
 
 # Default members must be part of workspace hack to maximize cache hits in CI/nix/crane
@@ -74,9 +75,11 @@ indicatif = "0.18"
 itertools = "0.14"
 js-sys = "0.3"
 libcrux-ed25519 = "0.0.7"
+lru = "0.16"
 mockall = { version = "0.14" }
 mockall_double = "0.3.1"
 once_cell = "1.2"
+warp = { version = "0.4", features = ["server"] }
 # This git hash does not point to main because the single line change to it (rusqlite = 0.37) has a conflict
 # with sqlx that doesn't allow cargo to resolve crates and so all of CI fails. To ensure that ongoing changes
 # to main work, we will keep it on a separate branch until this can get resolved. xmtp/openmls/main is currently
@@ -130,7 +133,13 @@ syn = { version = "2.0", features = [
 ] }
 thiserror = "2.0"
 tls_codec = "0.4.1"
-tokio = { version = "1.47.0", default-features = false }
+tokio = { version = "1.47.0", default-features = false, features = [
+  "macros",
+  "rt",
+  "time",
+  "sync",
+  "tracing",
+] }
 tokio-stream = { version = "0.1", default-features = false }
 tokio-util = { version = "0.7", default-features = false, features = [
   "compat",

--- a/apps/error_glossary/Cargo.toml
+++ b/apps/error_glossary/Cargo.toml
@@ -13,4 +13,3 @@ path = "src/main.rs"
 clap.workspace = true
 syn = { version = "2.0", features = ["full", "parsing"] }
 walkdir = "2"
-xmtp-workspace-hack = { version = "0.1", path = "../../crates/xmtp-workspace-hack" }

--- a/apps/mls_validation_service/Cargo.toml
+++ b/apps/mls_validation_service/Cargo.toml
@@ -20,32 +20,30 @@ vergen-gix = { workspace = true, features = ["build"] }
 
 [dependencies]
 alloy.workspace = true
-# used b/c of xmtp_common::async_trait
 async-trait.workspace = true
 clap = { workspace = true, features = ["env"] }
 futures.workspace = true
 hex.workspace = true
-lru = "0.16.0"
+lru.workspace = true
 openmls.workspace = true
 openmls_rust_crypto.workspace = true
 parking_lot.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["signal", "rt-multi-thread"] }
-tonic = { workspace = true, features = ["router"] }
+tonic = { workspace = true, features = ["router", "server"] }
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = [
   "env-filter",
   "ansi",
   "json",
 ] }
-warp = "0.3.6"
+warp.workspace = true
 xmtp-workspace-hack.workspace = true
 xmtp_common.workspace = true
 xmtp_configuration.workspace = true
 xmtp_cryptography.workspace = true
 xmtp_id.workspace = true
 xmtp_proto = { workspace = true, features = ["grpc_server_impls"] }
-
 
 [dev-dependencies]
 rand.workspace = true

--- a/apps/mls_validation_service/src/health_check.rs
+++ b/apps/mls_validation_service/src/health_check.rs
@@ -4,15 +4,16 @@ use warp::Filter;
 
 use crate::wait_for_quit;
 
-pub fn health_check_server(port: u16) -> impl Future<Output = ()> {
+pub async fn health_check_server(port: u16) -> impl Future<Output = ()> {
     let health_route =
         warp::path("health").map(|| warp::reply::with_status("ok", warp::http::StatusCode::OK));
 
-    let (_, health_server) =
-        warp::serve(health_route).bind_with_graceful_shutdown(([0, 0, 0, 0], port), async {
+    warp::serve(health_route)
+        .bind(([0, 0, 0, 0], port))
+        .await
+        .graceful(async {
             wait_for_quit().await;
             info!("HTTP server shutdown signal received");
-        });
-
-    health_server
+        })
+        .run()
 }

--- a/apps/mls_validation_service/src/main.rs
+++ b/apps/mls_validation_service/src/main.rs
@@ -57,7 +57,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("Starting health check on port {:?}", args.health_check_port);
     info!("Cache size: {:?}", args.cache_size);
 
-    let health_server = health_check_server(args.health_check_port as u16);
+    let health_server = health_check_server(args.health_check_port as u16).await;
     tracing::info!("Chain Urls: {:?}", args.chain_urls);
     let verifier = match args.chain_urls {
         Some(path) => MultiSmartContractSignatureVerifier::new_from_file(path)?,

--- a/apps/xmtp_debug/Cargo.toml
+++ b/apps/xmtp_debug/Cargo.toml
@@ -46,7 +46,7 @@ serde_json.workspace = true
 speedy = "0.8"
 tempfile = "3.15"
 thiserror.workspace = true
-tokio = "1.43"
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 tokio-stream.workspace = true
 tracing = { workspace = true, features = ["valuable"] }
 tracing-appender = "0.2"

--- a/bindings/mobile/Cargo.toml
+++ b/bindings/mobile/Cargo.toml
@@ -22,7 +22,7 @@ parking_lot.workspace = true
 prost.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["macros"] }
+tokio.workspace = true
 tracing = { workspace = true, features = ["release_max_level_debug"] }
 tracing-appender = "0.2"
 tracing-subscriber = { workspace = true, features = [

--- a/bindings/node/Cargo.toml
+++ b/bindings/node/Cargo.toml
@@ -10,8 +10,9 @@ publish.workspace = true
 [lints]
 workspace = true
 
+# rlib included so building dependencies for workspace succeeds, but in reality node just uses cdylib
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 async-trait.workspace = true
@@ -28,7 +29,7 @@ napi = { version = "3.4.0", default-features = false, features = [
 napi-derive = "3.3.0"
 prost.workspace = true
 serde_json.workspace = true
-tokio = { workspace = true, features = ["sync"] }
+tokio.workspace = true
 tracing = { workspace = true, features = ["release_max_level_debug"] }
 tracing-subscriber = { workspace = true, features = [
   "env-filter",

--- a/crates/xmtp-workspace-hack/Cargo.toml
+++ b/crates/xmtp-workspace-hack/Cargo.toml
@@ -50,6 +50,7 @@ futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
 generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "zeroize"] }
 hashbrown = { version = "0.16", features = ["serde"] }
 hpke-rs = { version = "0.6", features = ["hazmat", "libcrux", "serialization"] }
+hyper = { version = "1", features = ["http1", "http2", "server"] }
 idna = { version = "1" }
 indexmap = { version = "2", features = ["serde"] }
 itertools = { version = "0.14" }
@@ -65,8 +66,6 @@ openmls_rust_crypto = { git = "https://github.com/xmtp/openmls", rev = "42f1479c
 openmls_traits = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14", features = ["extensions-draft-08", "test-utils"] }
 p256 = { version = "0.13", features = ["ecdh", "jwk"] }
 percent-encoding = { version = "2" }
-proc-macro2 = { version = "1", features = ["span-locations"] }
-quote = { version = "1" }
 rand-274715c4dabd11b0 = { package = "rand", version = "0.9", features = ["serde"] }
 rand-93f6ce9d446188ac = { package = "rand", version = "0.10" }
 rand_chacha-274715c4dabd11b0 = { package = "rand_chacha", version = "0.9" }
@@ -80,21 +79,18 @@ ruint = { version = "1", default-features = false, features = ["alloy-rlp", "ran
 rustc-hash = { version = "2", features = ["rand"] }
 sec1 = { version = "0.7", features = ["pem", "serde", "std", "subtle"] }
 serde = { version = "1", features = ["alloc", "derive", "rc"] }
-serde_core = { version = "1", features = ["alloc", "rc"] }
+serde_core = { version = "1", default-features = false, features = ["alloc", "rc", "result", "std"] }
 serde_json = { version = "1", features = ["alloc", "preserve_order", "raw_value"] }
 serde_spanned = { version = "1", default-features = false, features = ["serde", "std"] }
 sha1 = { version = "0.10", features = ["compress"] }
 sha3 = { version = "0.10", default-features = false, features = ["asm", "std"] }
 slab = { version = "0.4" }
 smallvec = { version = "1", default-features = false, features = ["const_new", "serde", "union", "write"] }
-syn = { version = "2", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
 sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
 time = { version = "0.3", features = ["formatting", "local-offset", "parsing"] }
-tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = { version = "0.7", features = ["codec", "compat", "io"] }
 toml_datetime = { version = "1", features = ["serde"] }
 toml_parser = { version = "1" }
-tonic = { version = "0.14", default-features = false, features = ["codegen", "router"] }
 tracing = { version = "0.1", features = ["log", "release_max_level_debug"] }
 tracing-core = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["chrono", "env-filter", "json"] }
@@ -138,6 +134,7 @@ futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
 generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "zeroize"] }
 hashbrown = { version = "0.16", features = ["serde"] }
 hpke-rs = { version = "0.6", features = ["hazmat", "libcrux", "serialization"] }
+hyper = { version = "1", features = ["http1", "http2", "server"] }
 idna = { version = "1" }
 indexmap = { version = "2", features = ["serde"] }
 itertools = { version = "0.14" }
@@ -154,7 +151,6 @@ openmls_traits = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb067
 p256 = { version = "0.13", features = ["ecdh", "jwk"] }
 percent-encoding = { version = "2" }
 proc-macro2 = { version = "1", features = ["span-locations"] }
-quote = { version = "1" }
 rand-274715c4dabd11b0 = { package = "rand", version = "0.9", features = ["serde"] }
 rand-93f6ce9d446188ac = { package = "rand", version = "0.10" }
 rand_chacha-274715c4dabd11b0 = { package = "rand_chacha", version = "0.9" }
@@ -168,7 +164,7 @@ ruint = { version = "1", default-features = false, features = ["alloy-rlp", "ran
 rustc-hash = { version = "2", features = ["rand"] }
 sec1 = { version = "0.7", features = ["pem", "serde", "std", "subtle"] }
 serde = { version = "1", features = ["alloc", "derive", "rc"] }
-serde_core = { version = "1", features = ["alloc", "rc"] }
+serde_core = { version = "1", default-features = false, features = ["alloc", "rc", "result", "std"] }
 serde_json = { version = "1", features = ["alloc", "preserve_order", "raw_value"] }
 serde_spanned = { version = "1", default-features = false, features = ["serde", "std"] }
 sha1 = { version = "0.10", features = ["compress"] }
@@ -178,11 +174,9 @@ smallvec = { version = "1", default-features = false, features = ["const_new", "
 syn = { version = "2", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
 sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
 time = { version = "0.3", features = ["formatting", "local-offset", "parsing"] }
-tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = { version = "0.7", features = ["codec", "compat", "io"] }
 toml_datetime = { version = "1", features = ["serde"] }
 toml_parser = { version = "1" }
-tonic = { version = "0.14", default-features = false, features = ["codegen", "router"] }
 tracing = { version = "0.1", features = ["log", "release_max_level_debug"] }
 tracing-core = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["chrono", "env-filter", "json"] }
@@ -192,130 +186,104 @@ zerocopy = { version = "0.8", default-features = false, features = ["derive", "s
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 bitflags = { version = "2", default-features = false, features = ["std"] }
-byteorder = { version = "1" }
 getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
-hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "service"] }
+hyper = { version = "1", default-features = false, features = ["client"] }
+hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "server-graceful", "service"] }
 proptest = { version = "1", default-features = false, features = ["bit-set", "timeout"] }
-rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 rustls-pki-types = { version = "1", features = ["std"] }
 rustls-webpki = { version = "0.103", default-features = false, features = ["ring", "std"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
-tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
-tonic = { version = "0.14", features = ["tls-native-roots", "tls-ring", "tls-webpki-roots"] }
-tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "retry", "timeout"] }
+tower = { version = "0.5", default-features = false, features = ["retry", "timeout"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
 bitflags = { version = "2", default-features = false, features = ["std"] }
-byteorder = { version = "1" }
 cc = { version = "1", default-features = false, features = ["parallel"] }
 getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
-hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "service"] }
+hyper = { version = "1", default-features = false, features = ["client"] }
+hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "server-graceful", "service"] }
 proptest = { version = "1", default-features = false, features = ["bit-set", "timeout"] }
-rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 rustls-pki-types = { version = "1", features = ["std"] }
 rustls-webpki = { version = "0.103", default-features = false, features = ["ring", "std"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
-tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
-tonic = { version = "0.14", features = ["tls-native-roots", "tls-ring", "tls-webpki-roots"] }
-tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "retry", "timeout"] }
+tower = { version = "0.5", default-features = false, features = ["retry", "timeout"] }
 
 [target.aarch64-apple-darwin.dependencies]
 bitflags = { version = "2", default-features = false, features = ["std"] }
-byteorder = { version = "1" }
 errno = { version = "0.3" }
 getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
-hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "service"] }
+hyper = { version = "1", default-features = false, features = ["client"] }
+hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "server-graceful", "service"] }
 libc = { version = "0.2" }
 proptest = { version = "1", default-features = false, features = ["bit-set", "timeout"] }
-rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 rustls-pki-types = { version = "1", features = ["std"] }
 rustls-webpki = { version = "0.103", default-features = false, features = ["ring", "std"] }
-security-framework-sys = { version = "2" }
-tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
-tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
-tonic = { version = "0.14", features = ["tls-native-roots", "tls-ring", "tls-webpki-roots"] }
-tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "retry", "timeout"] }
+tower = { version = "0.5", default-features = false, features = ["retry", "timeout"] }
 
 [target.aarch64-apple-darwin.build-dependencies]
 bitflags = { version = "2", default-features = false, features = ["std"] }
-byteorder = { version = "1" }
 cc = { version = "1", default-features = false, features = ["parallel"] }
 errno = { version = "0.3" }
 getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
-hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "service"] }
+hyper = { version = "1", default-features = false, features = ["client"] }
+hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "server-graceful", "service"] }
 libc = { version = "0.2" }
 proptest = { version = "1", default-features = false, features = ["bit-set", "timeout"] }
-rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 rustls-pki-types = { version = "1", features = ["std"] }
 rustls-webpki = { version = "0.103", default-features = false, features = ["ring", "std"] }
-security-framework-sys = { version = "2" }
-tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
-tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
-tonic = { version = "0.14", features = ["tls-native-roots", "tls-ring", "tls-webpki-roots"] }
-tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "retry", "timeout"] }
+tower = { version = "0.5", default-features = false, features = ["retry", "timeout"] }
 
 [target.aarch64-linux-android.dependencies]
 bitflags = { version = "2", default-features = false, features = ["std"] }
-byteorder = { version = "1" }
 errno = { version = "0.3" }
 getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
-hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "service"] }
+hyper = { version = "1", default-features = false, features = ["client"] }
+hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "server-graceful", "service"] }
 libc = { version = "0.2" }
 proptest = { version = "1", default-features = false, features = ["bit-set", "timeout"] }
-rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 rustls-pki-types = { version = "1", features = ["std"] }
 rustls-webpki = { version = "0.103", default-features = false, features = ["ring", "std"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
-tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
-tonic = { version = "0.14", features = ["tls-ring", "tls-webpki-roots"] }
-tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "retry", "timeout"] }
+tower = { version = "0.5", default-features = false, features = ["retry", "timeout"] }
 
 [target.aarch64-linux-android.build-dependencies]
 bitflags = { version = "2", default-features = false, features = ["std"] }
-byteorder = { version = "1" }
 cc = { version = "1", default-features = false, features = ["parallel"] }
 errno = { version = "0.3" }
 getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
-hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "service"] }
+hyper = { version = "1", default-features = false, features = ["client"] }
+hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "server-graceful", "service"] }
 libc = { version = "0.2" }
 proptest = { version = "1", default-features = false, features = ["bit-set", "timeout"] }
-rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 rustls-pki-types = { version = "1", features = ["std"] }
 rustls-webpki = { version = "0.103", default-features = false, features = ["ring", "std"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
-tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
-tonic = { version = "0.14", features = ["tls-ring", "tls-webpki-roots"] }
-tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "retry", "timeout"] }
+tower = { version = "0.5", default-features = false, features = ["retry", "timeout"] }
 
 [target.x86_64-linux-android.dependencies]
 bitflags = { version = "2", default-features = false, features = ["std"] }
-byteorder = { version = "1" }
 errno = { version = "0.3" }
 getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
-hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "service"] }
+hyper = { version = "1", default-features = false, features = ["client"] }
+hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "server-graceful", "service"] }
 proptest = { version = "1", default-features = false, features = ["bit-set", "timeout"] }
-rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 rustls-pki-types = { version = "1", features = ["std"] }
 rustls-webpki = { version = "0.103", default-features = false, features = ["ring", "std"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
-tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
-tonic = { version = "0.14", features = ["tls-ring", "tls-webpki-roots"] }
-tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "retry", "timeout"] }
+tower = { version = "0.5", default-features = false, features = ["retry", "timeout"] }
 
 [target.x86_64-linux-android.build-dependencies]
 bitflags = { version = "2", default-features = false, features = ["std"] }
-byteorder = { version = "1" }
 cc = { version = "1", default-features = false, features = ["parallel"] }
 errno = { version = "0.3" }
 getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
-hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "service"] }
+hyper = { version = "1", default-features = false, features = ["client"] }
+hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "server-graceful", "service"] }
 proptest = { version = "1", default-features = false, features = ["bit-set", "timeout"] }
-rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 rustls-pki-types = { version = "1", features = ["std"] }
 rustls-webpki = { version = "0.103", default-features = false, features = ["ring", "std"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
-tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
-tonic = { version = "0.14", features = ["tls-ring", "tls-webpki-roots"] }
-tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "retry", "timeout"] }
+tower = { version = "0.5", default-features = false, features = ["retry", "timeout"] }
 
 ### END HAKARI SECTION

--- a/crates/xmtp_api/Cargo.toml
+++ b/crates/xmtp_api/Cargo.toml
@@ -38,7 +38,7 @@ xmtp_id = { workspace = true, features = ["test-utils"] }
 xmtp_proto = { workspace = true, features = ["test-utils"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-tokio = { workspace = true, features = ["rt"] }
+tokio = { workspace = true }
 wasm-bindgen-test.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/crates/xmtp_api_grpc/Cargo.toml
+++ b/crates/xmtp_api_grpc/Cargo.toml
@@ -63,10 +63,10 @@ toxiproxy_rust.workspace = true
 xmtp_proto = { workspace = true, features = ["test-utils"] }
 
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dev-dependencies]
-tokio = { workspace = true, features = ["io-util"] }
+tokio = { workspace = true }
 pbjson-types.workspace = true
 tokio-stream.workspace = true
-hyper-util = { version = "0.1" }
+hyper-util.workspace = true
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dev-dependencies]
 getrandom = { workspace = true, features = ["wasm_js"] }

--- a/crates/xmtp_common/Cargo.toml
+++ b/crates/xmtp_common/Cargo.toml
@@ -14,7 +14,7 @@ futures = { workspace = true, features = ["std"] }
 hex.workspace = true
 rand.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["time", "rt"] }
+tokio.workspace = true
 tracing.workspace = true
 web-time.workspace = true
 
@@ -45,7 +45,6 @@ js-sys.workspace = true
 web-sys = { workspace = true, features = ["Window"] }
 wasm-bindgen-futures.workspace = true
 wasm-bindgen.workspace = true
-tokio = { workspace = true, features = ["time", "sync"] }
 tokio_with_wasm = { version = "0.9.0", features = ["full"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -70,17 +69,12 @@ xmtp_cryptography = { workspace = true, features = ["test-utils"] }
 
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-tokio = { workspace = true, features = ["time", "macros", "rt", "sync"] }
+tokio = { workspace = true }
 wasm-bindgen-test.workspace = true
 tracing-wasm = { version = "0.2" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-tokio = { workspace = true, features = [
-  "time",
-  "macros",
-  "rt-multi-thread",
-  "sync",
-] }
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 tracing-forest.workspace = true
 ctor.workspace = true
 parking_lot.workspace = true

--- a/crates/xmtp_db/Cargo.toml
+++ b/crates/xmtp_db/Cargo.toml
@@ -47,12 +47,6 @@ rand.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, optional = true, features = [
-  "macros",
-  "tracing",
-  "rt-multi-thread",
-  "sync",
-] }
 toml = { workspace = true, optional = true }
 tracing.workspace = true
 xmtp-workspace-hack.workspace = true
@@ -85,12 +79,7 @@ xmtp_cryptography.workspace = true
 xmtp_db = { workspace = true, features = ["test-utils"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-tokio = { workspace = true, features = [
-  "macros",
-  "tracing",
-  "rt",
-  "rt-multi-thread",
-] }
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test.workspace = true

--- a/crates/xmtp_id/Cargo.toml
+++ b/crates/xmtp_id/Cargo.toml
@@ -61,7 +61,7 @@ alloy = { workspace = true, features = [
 ] }
 ed25519-dalek = { workspace = true, features = ["digest", "rand_core"] }
 rstest.workspace = true
-tokio = { workspace = true, features = ["macros"] }
+tokio = { workspace = true }
 wasm-bindgen-test.workspace = true
 xmtp_common = { workspace = true, features = ["test-utils"] }
 xmtp_configuration = { workspace = true, features = ["test-utils"] }

--- a/crates/xmtp_macro/Cargo.toml
+++ b/crates/xmtp_macro/Cargo.toml
@@ -21,7 +21,7 @@ xmtp-workspace-hack.workspace = true
 proc-macro = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test.workspace = true

--- a/crates/xmtp_mls/Cargo.toml
+++ b/crates/xmtp_mls/Cargo.toml
@@ -83,6 +83,7 @@ sha2.workspace = true
 thiserror.workspace = true
 time.workspace = true
 tls_codec.workspace = true
+tokio.workspace = true
 tokio-stream = { workspace = true, default-features = false, features = [
   "sync",
 ] }
@@ -132,18 +133,11 @@ tracing-subscriber = { workspace = true, features = [
 ], optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { workspace = true, features = [
-  "macros",
-  "tracing",
-  "rt",
-  "rt-multi-thread",
-] }
 chrono = { workspace = true, features = ["clock"] }
 dyn-clone.workspace = true
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 chrono = { workspace = true, features = ["wasmbind"] }
-tokio = { workspace = true, features = ["macros", "rt", "time"] }
 wasm-bindgen-futures.workspace = true
 web-sys.workspace = true
 
@@ -189,6 +183,7 @@ xmtp_api_grpc = { workspace = true, features = ["test-utils"] }
 ctor.workspace = true
 mockito = "1.6.1"
 tempfile = "3.15.0"
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dev-dependencies]
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }

--- a/crates/xmtp_proto/Cargo.toml
+++ b/crates/xmtp_proto/Cargo.toml
@@ -28,7 +28,7 @@ prost-types = "0.14"
 serde.workspace = true
 smallvec.workspace = true
 thiserror.workspace = true
-tonic = { workspace = true, default-features = false }
+tonic = { workspace = true }
 tonic-prost = "0.14"
 tracing.workspace = true
 url.workspace = true
@@ -37,14 +37,11 @@ xmtp_configuration.workspace = true
 
 # optional
 mockall = { workspace = true, optional = true }
-tokio = { workspace = true, default-features = false, features = [
-  "sync",
-], optional = true }
 toxiproxy_rust = { workspace = true, optional = true }
 xmtp-workspace-hack.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tonic = { workspace = true, features = ["codegen", "server", "channel"] }
+tonic = { workspace = true, features = ["channel"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen-test.workspace = true
@@ -52,11 +49,10 @@ wasm-bindgen-test.workspace = true
 [dev-dependencies]
 mockall.workspace = true
 rstest.workspace = true
-tokio = { workspace = true, default-features = false, features = ["sync"] }
+tokio = { workspace = true }
 toxiproxy_rust.workspace = true
 xmtp_common = { workspace = true, features = ["test-utils"] }
 xmtp_configuration = { workspace = true, features = ["test-utils"] }
-
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 ctor.workspace = true
@@ -80,7 +76,6 @@ test-utils = [
   "xmtp_common/test-utils",
   "xmtp_configuration/test-utils",
   "dep:mockall",
-  "dep:tokio",
   "dep:toxiproxy_rust",
 ]
 grpc_server_impls = ["tonic/codegen"]

--- a/nix/lib/base.nix
+++ b/nix/lib/base.nix
@@ -52,9 +52,34 @@ let
     doCheck = false;
     # Disable zerocallusedregs hardening which can cause issues with cross-compilation.
     hardeningDisable = [ "zerocallusedregs" ];
+    CARGO_BUILD_TARGET = stdenv.hostPlatform.rust.rustcTarget;
+    CARGO_PROFILE = "release";
   };
+
+  # Make cargo artifacts for a derivation building rust code
+  # "rust" is the rust toolchain to use (native or host)
+  # "test" is whether to use "test-utils" feature
+  # "zigbuild" uses "cargo zigbuild" instead of "cargo build"
+  mkCargoArtifacts =
+    rust: test: overrides:
+    let
+      maybeTestFeature = if test then "--features test-utils" else "";
+      overrides' = if overrides == null then { } else overrides;
+    in
+    rust.buildDepsOnly (
+      commonArgs
+      // {
+        buildPhaseCargoCommand = "cargo build ${maybeTestFeature} --profile $CARGO_PROFILE --locked";
+      }
+      // overrides'
+    );
 
 in
 {
-  inherit depsFileset bindingsFileset commonArgs;
+  inherit
+    depsFileset
+    bindingsFileset
+    commonArgs
+    mkCargoArtifacts
+    ;
 }

--- a/nix/lib/default.nix
+++ b/nix/lib/default.nix
@@ -1,4 +1,9 @@
-{ inputs, self, ... }:
+{
+  inputs,
+  self,
+  lib,
+  ...
+}:
 {
   flake.lib = {
     pkgConfig = {
@@ -22,9 +27,24 @@
         allowUnfree = true;
       };
     };
+    mkCrossPkgs =
+      system: targets:
+      lib.genAttrs targets (
+        target:
+        (import inputs.nixpkgs (
+          self.lib.pkgConfig
+          // {
+            localSystem = system;
+            crossSystem = target;
+          }
+        ))
+      );
   };
   perSystem =
-    { pkgs, ... }:
+    {
+      pkgs,
+      ...
+    }:
     let
       craneConfig = final: prev: {
         # add napi builder to crane scope

--- a/nix/lib/filesets.nix
+++ b/nix/lib/filesets.nix
@@ -31,24 +31,19 @@ let
   #
   # Used by both iOS and Android package derivations for consistent caching.
   depsOnly = unions [
+    (src + /Cargo.toml)
     (src + /Cargo.lock)
     (src + /.cargo/config.toml)
     # All Cargo.toml and build.rs files in the workspace
     (fileFilter (file: file.name == "Cargo.toml" || file.name == "build.rs") (src + /crates))
-    (fileFilter (file: file.name == "Cargo.toml" || file.name == "build.rs") (src + /bindings/mobile))
-    # Files referenced by build scripts (e.g., include_bytes!, include_str!).
-    # These are needed at dep-compilation time because build.rs runs then.
-    (src + /crates/xmtp_id/src/scw_verifier/chain_urls_default.json)
-    (src + /crates/xmtp_id/artifact)
-    (src + /crates/xmtp_id/src/scw_verifier/signature_validation.hex)
-    (src + /crates/xmtp_db/migrations)
-    (src + /crates/xmtp_proto/src/gen/proto_descriptor.bin)
+    (fileFilter (file: file.name == "Cargo.toml" || file.name == "build.rs") (src + /bindings))
     apps
   ];
 
   libraries = unions (flatten [
     (src + /Cargo.toml)
     (src + /Cargo.lock)
+    (src + /.cargo/config.toml)
     # include folders for apps/bindings so cargo workspace globs are satisfied
     # One-off files that are needed outside of cargo sources
     (src + /apps/.gitkeep)
@@ -59,7 +54,6 @@ let
     (src + /crates/xmtp_db/migrations)
     (src + /crates/xmtp_proto/src/gen/proto_descriptor.bin)
     (src + /webdriver.json)
-    (src + /.cargo/config.toml)
     (src + /.config/nextest.toml)
     # all crates in `crates/` are treated as required library crates
     (crateSources (src + /crates))

--- a/nix/lib/napiBuild.nix
+++ b/nix/lib/napiBuild.nix
@@ -6,6 +6,7 @@
   cargo-zigbuild,
   stdenv,
   mkCargoDerivation,
+  lib,
 }:
 
 {
@@ -13,6 +14,7 @@
   napiExtraArgs ? "", # Arguments that are generally useful default
   napiGenerateJs ? false, # do not generate JS Glue
   CARGO_PROFILE ? "release",
+  zigBuild ? false,
   ...
 }@origArgs:
 let
@@ -22,10 +24,10 @@ let
     "napiExtraArgs"
     "CARGO_PROFILE"
     "napiGenerateJs"
+    "zigBuild"
   ];
   napiJsArgs = if napiGenerateJs then "--esm" else "--no-js";
-  isGnu = stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isMusl;
-  zigBuild = if isGnu then "-x" else "";
+  useZigBuild = if zigBuild then "-x" else "";
   hostTarget = stdenv.hostPlatform.rust.rustcTarget;
 in
 mkCargoDerivation (
@@ -54,7 +56,7 @@ mkCargoDerivation (
 
         napi build --target-dir target --output-dir $out/dist \
           --platform --profile ${CARGO_PROFILE} \
-          ${napiExtraArgs} ${napiJsArgs} ${zigBuild} \
+          ${napiExtraArgs} ${napiJsArgs} ${useZigBuild} \
           -- --locked
       '';
 
@@ -72,9 +74,11 @@ mkCargoDerivation (
     installPhaseCommand = args.installPhaseCommand or "true";
     doInstallCargoArtifacts = false;
 
-    nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [
-      napi-rs-cli
-      cargo-zigbuild
-    ];
+    nativeBuildInputs =
+      (args.nativeBuildInputs or [ ])
+      ++ [
+        napi-rs-cli
+      ]
+      ++ lib.optionals zigBuild [ cargo-zigbuild ];
   }
 )

--- a/nix/lib/packages/uniffi-bindgen.nix
+++ b/nix/lib/packages/uniffi-bindgen.nix
@@ -6,7 +6,7 @@ let
   inherit (xmtp) base;
   rust-toolchain = p: xmtp.mkToolchain p [ ] [ ];
   rust = xmtp.craneLib.overrideToolchain rust-toolchain;
-  cargoArtifacts = rust.buildDepsOnly base.commonArgs;
+  cargoArtifacts = xmtp.base.mkCargoArtifacts rust false null;
   src = ./../../..;
 in
 rust.buildPackage (

--- a/nix/musl-docker.nix
+++ b/nix/musl-docker.nix
@@ -1,48 +1,22 @@
 # Musl overrides for rust crates, primarily for small docker builds
-_: {
+{ self, ... }:
+{
   perSystem =
     {
       self',
       pkgs,
       lib,
-      config,
+      system,
       ...
     }:
     let
-      muslPkgs = pkgs.pkgsCross.musl64;
-      aarch64Pkgs = pkgs.pkgsCross.aarch64-multiplatform-musl;
+      targets = [
+        "x86_64-unknown-linux-musl"
+        "aarch64-unknown-linux-musl"
+      ];
 
-      commonStatic = old: pkgsCross: {
-        CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
-        OPENSSL_STATIC = "true";
-        OPENSSL_LIB_DIR = "${pkgsCross.pkgsStatic.openssl.out}/lib";
-        OPENSSL_INCLUDE_DIR = "${pkgsCross.pkgsStatic.openssl.dev}/include";
-        OPENSSL_NO_VENDOR = "1";
-        PKG_CONFIG_ALL_STATIC = "true";
-        PKG_CONFIG_PATH = "${pkgsCross.pkgsStatic.openssl.dev}/lib/pkgconfig";
-        depsBuildBuild = (old.depsBuildBuild or [ ]) ++ [ pkgsCross.stdenv.cc ];
-        buildInputs = (old.buildInputs or [ ]) ++ [
-          pkgsCross.pkgsStatic.openssl.dev
-        ];
-      };
-
-      env-musl =
-        old:
-        {
-          CARGO_BUILD_TARGET = "x86_64-unknown-linux-musl";
-          CC_x86_64_unknown_linux_musl = "${muslPkgs.stdenv.cc}/bin/${muslPkgs.stdenv.cc.targetPrefix}cc";
-          CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER = "${muslPkgs.stdenv.cc}/bin/${muslPkgs.stdenv.cc.targetPrefix}cc";
-        }
-        // (commonStatic old muslPkgs);
-
-      env-aarch64-multiplatform =
-        old:
-        {
-          CARGO_BUILD_TARGET = "aarch64-unknown-linux-musl";
-          CC_aarch64_unknown_linux_musl = "${aarch64Pkgs.stdenv.cc}/bin/${aarch64Pkgs.stdenv.cc.targetPrefix}cc";
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER = "${aarch64Pkgs.stdenv.cc}/bin/${aarch64Pkgs.stdenv.cc.targetPrefix}cc";
-        }
-        // (commonStatic old aarch64Pkgs);
+      crossPkgs = self.lib.mkCrossPkgs system targets;
+      mkMlsValidationService = p: p.callPackage ./package/mls_validation_service.nix;
 
       imageCommon = {
         name = "ghcr.io/xmtp/mls-validation-service"; # override ghcr images
@@ -53,30 +27,20 @@ _: {
     {
       packages = {
         mls-validation-service = pkgs.callPackage ./package/mls_validation_service.nix { };
-        mls-validation-service-musl64 = self'.packages.mls-validation-service.overrideAttrs (
-          old: old // (env-musl old)
-        );
         # lib.recursiveUpdate lets imageCommon define other attributes in the `config` namesapce
         validation-service-image = pkgs.dockerTools.buildLayeredImage (
           lib.recursiveUpdate imageCommon {
             config.entrypoint = [
-              "${self'.packages.mls-validation-service-musl64}/bin/mls-validation-service"
+              "${self'.packages.mls-validation-service-x86_64-unknown-linux-musl}/bin/mls-validation-service"
             ];
             architecture = "amd64";
           }
         );
       }
-      // lib.optionalAttrs (pkgs.stdenv.system == "aarch64-linux") {
-        mls-validation-service-aarch64-multiplatform = self'.packages.mls-validation-service.overrideAttrs (
-          old: old // (env-aarch64-multiplatform old)
-        );
-        validation-service-image-aarch64-multiplatform = pkgs.dockerTools.buildLayeredImage (
-          lib.recursiveUpdate imageCommon {
-            config.entrypoint = [
-              "${self'.packages.mls-validation-service-aarch64-multiplatform}/bin/mls-validation-service"
-            ];
-          }
-        );
-      };
+      # create mls validation service for all the cross compilation targets
+      // lib.mapAttrs' (target: crossPkgs: {
+        name = "mls-validation-service-${target}";
+        value = mkMlsValidationService crossPkgs { };
+      }) crossPkgs;
     };
 }

--- a/nix/node-packages.nix
+++ b/nix/node-packages.nix
@@ -1,4 +1,4 @@
-{ inputs, self, ... }:
+{ self, ... }:
 {
   perSystem =
     {
@@ -14,6 +14,8 @@
       # - musl targets use self-contained musl toolchains that work everywhere.
       # - Darwin targets require Apple SDKs, so macOS only.
       # - Windows is excluded (built separately in CI).
+      # linux gnu targets may be enabled once https://docs.determinate.systems/determinate-nix/#linux-builder
+      # rolls out to the public
       linuxGnuTargets = [
         "x86_64-unknown-linux-gnu"
         "aarch64-unknown-linux-gnu"
@@ -34,18 +36,8 @@
         ++ lib.optionals pkgs.stdenv.isLinux linuxGnuTargets
         ++ lib.optionals pkgs.stdenv.isDarwin darwinTargets;
 
-      # overlay glibc for node
-      crossPkgs = lib.genAttrs nodeTargets (
-        target:
-        (import inputs.nixpkgs (
-          self.lib.pkgConfig
-          // {
-            localSystem = system;
-            crossSystem = target;
-          }
-        ))
-      );
-      mkNodeBindings = p: p.callPackage ./package/node-bindings.nix;
+      crossPkgs = self.lib.mkCrossPkgs system nodeTargets;
+      mkNodeBindings = p: p.callPackage ./package/node.nix;
     in
     {
       packages = {

--- a/nix/package/android.nix
+++ b/nix/package/android.nix
@@ -114,13 +114,8 @@ let
     );
 
   # Build dependencies for the native host (needed for uniffi-bindgen)
-  hostCargoArtifacts = rust.buildDepsOnly (
-    commonArgs
-    // {
-      pname = "xmtpv3-android-host-deps";
-      cargoExtraArgs = "-p xmtpv3";
-    }
-  );
+  hostCargoArtifacts = xmtp.base.mkCargoArtifacts rust false null;
+  extension = if stdenv.isDarwin then "dylib" else "so";
 
   # Kotlin bindings (built on host, generates bindings from host library)
   kotlinBindings = rust.buildPackage (
@@ -134,18 +129,13 @@ let
 
       nativeBuildInputs = commonArgs.nativeBuildInputs ++ [ gnused ];
 
-      buildPhaseCargoCommand = ''
-        cargo build --release -p xmtpv3
-      '';
-
       doNotPostBuildInstallCargoBinaries = true;
 
       installPhaseCommand = ''
         mkdir -p $out/kotlin
-
         # Generate Kotlin bindings using uniffi-bindgen
         ${ffi-uniffi-bindgen} generate \
-          --library target/release/libxmtpv3.${if stdenv.isDarwin then "dylib" else "so"} \
+          --library /build/source/target/${stdenv.hostPlatform.rust.rustcTarget}/release/libxmtpv3.${extension} \
           --out-dir $TMPDIR/kotlin-out \
           --language kotlin
 

--- a/nix/package/ios.nix
+++ b/nix/package/ios.nix
@@ -127,18 +127,7 @@ let
       __noChroot = true;
       src = bindingsFileset;
       inherit version;
-      cargoArtifacts = rust.buildDepsOnly (
-        commonArgs
-        // {
-          pname = "xmtpv3-swift-bindings-deps";
-          __noChroot = true;
-          cargoExtraArgs = "-p xmtpv3";
-          buildPhaseCargoCommand = ''
-            ${nativeEnvSetup}
-            cargo build --release -p xmtpv3
-          '';
-        }
-      );
+      cargoArtifacts = xmtp.base.mkCargoArtifacts rust false null;
       cargoExtraArgs = "-p xmtpv3";
       buildPhaseCargoCommand = ''
         ${nativeEnvSetup}

--- a/nix/package/mls_validation_service.nix
+++ b/nix/package/mls_validation_service.nix
@@ -1,80 +1,60 @@
 {
   xmtp,
   lib,
-  openssl,
-  perl,
+  stdenv,
 }:
 let
   inherit (lib.fileset) unions;
-  inherit (xmtp) craneLib;
+  inherit (xmtp) craneLib mkToolchain base;
   inherit (craneLib.fileset) commonCargoSources;
 
-  commonArgs = {
-    strictDeps = true;
-    nativeBuildInputs = [
-      openssl
-      perl
+  rust-toolchain = p: mkToolchain p [ stdenv.hostPlatform.rust.rustcTarget ] [ ];
+  rust = xmtp.craneLib.overrideToolchain rust-toolchain;
+  root = ./../..;
+
+  specialArgs = lib.optionalAttrs stdenv.hostPlatform.isMusl {
+    RUSTFLAGS = "-C target-feature=+crt-static";
+  };
+
+  commonArgs = base.commonArgs // specialArgs;
+
+  src = lib.fileset.toSource {
+    inherit root;
+    fileset = unions [
+      (root + /Cargo.toml)
+      (root + /Cargo.lock)
+      (root + /.cargo/config.toml)
+
+      # Non-cargo files needed by build scripts
+      (root + /crates/xmtp_id/src/scw_verifier/chain_urls_default.json)
+      (root + /crates/xmtp_id/artifact)
+      (root + /crates/xmtp_id/src/scw_verifier/signature_validation.hex)
+      (root + /crates/xmtp_proto/src/gen/proto_descriptor.bin)
+
+      (root + /bindings/.gitkeep)
+      (root + /apps/.gitkeep)
+
+      # Actual source for crates needed to compile mls-validation-service
+      (commonCargoSources (root + /crates/xmtp-workspace-hack))
+      (commonCargoSources (root + /crates/xmtp_common))
+      (commonCargoSources (root + /crates/xmtp_configuration))
+      (commonCargoSources (root + /crates/xmtp_cryptography))
+      (commonCargoSources (root + /crates/xmtp_id))
+      (commonCargoSources (root + /crates/xmtp_proto))
+      (commonCargoSources (root + /crates/xmtp_macro))
+      (commonCargoSources (root + /apps/mls_validation_service))
     ];
   };
 
-  rust-toolchain =
-    p:
-    xmtp.mkToolchain p
-      [
-        "x86_64-unknown-linux-musl"
-        "aarch64-unknown-linux-musl"
-      ]
-      [ ];
-  rust = xmtp.craneLib.overrideToolchain rust-toolchain;
-  root = ./../..;
-  # a full rebuild will be triggered only if these dependencies change.
-  fileset = unions [
-    (root + /Cargo.toml)
-    (root + /Cargo.lock)
-    (root + /apps/.gitkeep)
-    (root + /bindings/.gitkeep)
-
-    (root + /crates/xmtp_id/src/scw_verifier/chain_urls_default.json)
-    (root + /crates/xmtp_id/artifact)
-    (root + /crates/xmtp_id/src/scw_verifier/signature_validation.hex)
-    (root + /crates/xmtp_proto/src/gen/proto_descriptor.bin)
-
-    (commonCargoSources (root + /crates/xmtp-workspace-hack))
-    (commonCargoSources (root + /crates/xmtp_common))
-    (commonCargoSources (root + /crates/xmtp_configuration))
-    (commonCargoSources (root + /crates/xmtp_cryptography))
-    (commonCargoSources (root + /crates/xmtp_id))
-    (commonCargoSources (root + /crates/xmtp_proto))
-    (commonCargoSources (root + /crates/xmtp_macro))
-    (root + /apps/mls_validation_service/Cargo.toml)
-    (root + /apps/mls_validation_service/build.rs)
-  ];
-
-  src = lib.fileset.toSource {
-    inherit root fileset;
-  };
-
-  cargoArtifacts = rust.buildDepsOnly (
-    commonArgs
-    // {
-      inherit src;
-    }
-  );
+  cargoArtifacts = xmtp.base.mkCargoArtifacts rust false specialArgs;
 in
 rust.buildPackage (
   commonArgs
   // {
-    inherit cargoArtifacts;
+    inherit src cargoArtifacts;
     pname = "mls-validation-service";
     cargoExtraArgs = "--bin mls-validation-service";
     version = xmtp.mkVersion rust;
     doCheck = false;
-    src = lib.fileset.toSource {
-      inherit root;
-      fileset = unions [
-        fileset
-        (commonCargoSources (root + /apps/mls_validation_service))
-      ];
-    };
   }
 )

--- a/nix/package/nextest.nix
+++ b/nix/package/nextest.nix
@@ -2,7 +2,6 @@
 {
   xmtp,
   lib,
-  sqlcipher,
   cargo-llvm-cov,
   d14n ? false,
   ...
@@ -29,11 +28,11 @@ let
   };
 
   commonArgs = xmtp.base.commonArgs // {
-    inherit src;
     nativeBuildInputs = xmtp.base.commonArgs.nativeBuildInputs ++ [
       cargo-llvm-cov
     ];
   };
+
   cargoArtifacts = rust.buildDepsOnly (
     commonArgs
     // {
@@ -45,7 +44,7 @@ in
 rust.cargoNextest (
   commonArgs
   // {
-    inherit cargoArtifacts;
+    inherit src cargoArtifacts;
     doCheck = true;
     pnameSuffix = if d14n then "nextest-d14n" else "nextest-v3";
     partitions = 1;

--- a/nix/package/node.nix
+++ b/nix/package/node.nix
@@ -16,6 +16,8 @@ let
   # so it must be used to create the right toolchain for the platform.
   rust-toolchain = p: xmtp.mkToolchain p [ stdenv.hostPlatform.rust.rustcTarget ] [ ];
 
+  isGnu = stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isMusl;
+
   # overrideToolchain accepts a function that accepts `p` a pkg set
   rust = craneLib.overrideToolchain rust-toolchain;
   root = ./../..;
@@ -29,39 +31,32 @@ let
   };
   maybeTestFeature = if test then "--features test-utils" else "";
   version = xmtp.mkVersion rust;
-  targetGlibcVersion = "2.27";
+  targetGlibcVersion = if isGnu then "2.27" else null;
 
-  isGnu = stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isMusl;
-
-  # crossEnv (CC_ vars) will be auto-populated in stdenv b/c using crossSystem in nixpkgs
-  commonArgs =
-    xmtp.base.commonArgs
-    // {
-      inherit src version;
-      # strictDeps breaks darwin build with ring
-      CARGO_PROFILE = "release";
-      # this needs to be set for cargoArtifacts to inherit properly
-      # since napi implicitly sets --target.
-      CARGO_BUILD_TARGET = stdenv.hostPlatform.rust.rustcTarget;
-    }
-    // lib.optionalAttrs stdenv.hostPlatform.isMusl {
+  specialArgs =
+    lib.optionalAttrs stdenv.hostPlatform.isMusl {
       # Use -crt-static to allow cdylib output on musl targets.
       RUSTFLAGS = "-C target-feature=-crt-static";
     }
     // lib.optionalAttrs isGnu {
-      nativeBuildInputs = xmtp.base.commonArgs.nativeBuildInputs ++ [ cargo-zigbuild ];
-      # overwrite build target for linux
+      # overwrite build target for glibc
       CARGO_BUILD_TARGET = "${stdenv.hostPlatform.rust.rustcTarget}.${targetGlibcVersion}";
     };
 
-  cargoArtifacts = rust.buildDepsOnly (
-    commonArgs
+  commonArgs =
+    xmtp.base.commonArgs
     // {
-      buildPhaseCargoCommand = "cargo build -p bindings_node ${maybeTestFeature} --profile $CARGO_PROFILE --locked";
+      inherit version;
     }
+    // specialArgs;
+
+  cargoArtifacts = xmtp.base.mkCargoArtifacts rust test (
+    specialArgs
     // lib.optionalAttrs isGnu {
+      # override everything for glibc compatibility
       preBuild = "export HOME=$TMPDIR";
-      buildPhaseCargoCommand = "cargo zigbuild -p bindings_node ${maybeTestFeature} --profile $CARGO_PROFILE --locked";
+      nativeBuildInputs = xmtp.base.commonArgs.nativeBuildInputs ++ [ cargo-zigbuild ];
+      buildPhaseCargoCommand = "cargo zigbuild ${maybeTestFeature} --profile $CARGO_PROFILE --locked";
     }
   );
 
@@ -69,12 +64,13 @@ in
 rust.napiBuild (
   commonArgs
   // {
-    inherit cargoArtifacts;
+    inherit src cargoArtifacts;
     SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
     NODE_EXTRA_CA_CERTS = "${cacert}/etc/ssl/certs/ca-bundle.crt";
     napiExtraArgs = "-p bindings_node ${maybeTestFeature} --package-json-path ${src}/bindings/node/package.json";
     pname = "bindings-node-js";
     napiGenerateJs = withJs;
+    zigBuild = isGnu;
   }
   // lib.optionalAttrs stdenv.hostPlatform.isMusl {
     # remove nix specific rpaths for compatibility with musl dynamic linker

--- a/nix/package/wasm-nextest.nix
+++ b/nix/package/wasm-nextest.nix
@@ -2,8 +2,6 @@
 {
   xmtp,
   lib,
-  sqlite,
-  sqlcipher,
   chromedriver,
   google-chrome,
   chromium,
@@ -36,7 +34,6 @@ let
   };
 
   commonArgs = base.commonArgs // {
-    inherit src;
     nativeBuildInputs = base.commonArgs.nativeBuildInputs ++ [
       cargo-nextest
       wasm-bindgen-cli
@@ -67,7 +64,7 @@ in
 rust.cargoNextest (
   commonArgs
   // {
-    inherit cargoArtifacts;
+    inherit src cargoArtifacts;
     inherit (xmtp.shellCommon.wasmEnv)
       CHROMEDRIVER
       RSTEST_TIMEOUT

--- a/nix/package/wasm.nix
+++ b/nix/package/wasm.nix
@@ -26,12 +26,6 @@ let
   rust = craneLib.overrideToolchain (p: rust-toolchain);
 
   features = if test then "--features test-utils" else "";
-
-  libraryFileset = lib.fileset.toSource {
-    root = ./../..;
-    fileset = xmtp.filesets.libraries;
-  };
-
   bindingsFileset = lib.fileset.toSource {
     root = ./../..;
     fileset = xmtp.filesets.forCrate ./../../bindings/wasm;
@@ -39,7 +33,6 @@ let
 
   commonArgs = base.commonArgs // {
     meta.description = "WebAssembly Bindings";
-    src = libraryFileset;
     # EM_CACHE = "$TMPDIR/.emscripten_cache";
     # we need to set tmpdir for emscripten cache
     preConfigure = ''
@@ -58,8 +51,6 @@ let
       wasm-bindgen-cli
     ];
     buildInputs = [ sqlite ];
-    doCheck = false;
-    cargoExtraArgs = "--package bindings_wasm ${features}";
     hardeningDisable = [
       "zerocallusedregs"
       "stackprotector"
@@ -77,10 +68,15 @@ let
   };
 
   # enables caching all build time crates
-  cargoArtifacts = rust.buildDepsOnly (commonEnv // commonArgs);
+  cargoArtifacts = rust.buildDepsOnly (
+    (base.commonArgs // commonEnv)
+    // {
+      buildPhaseCargoCommand = "cargo build --package bindings_wasm ${features} --profile $CARGO_PROFILE --locked";
+    }
+  );
 
   bin = rust.buildPackage (
-    (commonEnv // commonArgs)
+    (commonArgs // commonEnv)
     // {
       inherit cargoArtifacts;
       src = bindingsFileset;


### PR DESCRIPTION
shares a single re-usable `cargoArtifacts` workspace instance across as many nix builds as possible. it removes wasm-bindings from workspace hack, but enabled everything else to use a single instance. will speed up all nix builds/cargo tests using crane cargo artifacts. wasm builds should stay the same since artifacts with `-p bindings_wasm` will still cache up to the workspace.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Share a single `cargoArtifacts` instance across Nix builds
> - Introduces `mkCargoArtifacts` helper in [base.nix](https://github.com/xmtp/libxmtp/pull/3353/files#diff-78e27920e7e7f148052510551d065fae07e34ca9a88df0abd2450dedb25668bc) that builds Cargo dependencies once and reuses the result across all Nix package derivations (uniffi-bindgen, Android, iOS, WASM, node bindings, mls-validation-service, nextest).
> - Adds `lib.mkCrossPkgs` in [default.nix](https://github.com/xmtp/libxmtp/pull/3353/files#diff-6fd175d36064b2e9b9371596932bf201514494fc02c317f3f4526243d72991f1) to centralize construction of cross-compiled package sets, replacing per-package ad-hoc cross toolchain setup.
> - Refactors [node.nix](https://github.com/xmtp/libxmtp/pull/3353/files#diff-fa9b6ba547ea5ae35048580f634e5edb6375afb0138fd6fb6e77fef6ee8c357b) (renamed from node-bindings.nix) to detect glibc vs musl and conditionally enable `cargo-zigbuild`; [napiBuild.nix](https://github.com/xmtp/libxmtp/pull/3353/files#diff-97105a706805ee749b47f57d475da65a8dd712cc01c754967d45667181d2ad56) now accepts an explicit `zigBuild` flag instead of auto-detecting.
> - Consolidates workspace `tokio`, `lru`, and `warp` dependencies to shared workspace versions across multiple crates, and updates `xmtp-workspace-hack` accordingly.
> - Upgrades `warp` to 0.4 in `mls_validation_service`, requiring a refactor of the graceful-shutdown API in [health_check.rs](https://github.com/xmtp/libxmtp/pull/3353/files#diff-7d3a52d4d9e357370b7e1918b6fb1cd585c90a97bdf2510784c647b728f2cad2).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b9bfa25.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->