### PR TITLE
enable migration client

### DIFF
--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -64,7 +64,7 @@ jobs:
           SIGN_KEY: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
           SIGN_PASSWORD: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
           MAVEN_PROFILE_ID: ${{ secrets.MAVEN_PROFILE_ID }}
-        run: nix develop .#android --command ./gradlew :library:build publishToSonatype closeAndReleaseSonatypeStagingRepository
+        run: nix develop .#android --command ./gradlew :library:build publishToSonatype closeAndReleaseSonatypeStagingRepository --info
 
       - name: Tag release
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1991,7 +1991,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_node"
-version = "1.10.0"
+version = "1.10.0-mpre1"
 dependencies = [
  "async-trait",
  "bindings_node",
@@ -2025,7 +2025,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_wasm"
-version = "1.10.0"
+version = "1.10.0-mpre1"
 dependencies = [
  "alloy",
  "async-trait",
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_wasm_macros"
-version = "1.10.0"
+version = "1.10.0-mpre1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4507,7 +4507,7 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "error_glossary"
-version = "1.10.0"
+version = "1.10.0-mpre1"
 dependencies = [
  "clap",
  "syn 2.0.117",
@@ -8721,7 +8721,7 @@ dependencies = [
 
 [[package]]
 name = "log_parser"
-version = "1.10.0"
+version = "1.10.0-mpre1"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9129,7 +9129,7 @@ dependencies = [
 
 [[package]]
 name = "mls_validation_service"
-version = "1.10.0"
+version = "1.10.0-mpre1"
 dependencies = [
  "alloy",
  "async-trait",
@@ -17139,7 +17139,7 @@ checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
 
 [[package]]
 name = "xdbg"
-version = "1.10.0"
+version = "1.10.0-mpre1"
 dependencies = [
  "alloy",
  "chrono",
@@ -17278,7 +17278,7 @@ checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "xmtp-db-tools"
-version = "1.10.0"
+version = "1.10.0-mpre1"
 dependencies = [
  "anyhow",
  "clap",
@@ -17399,7 +17399,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api"
-version = "1.10.0"
+version = "1.10.0-mpre1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -17425,7 +17425,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_d14n"
-version = "1.10.0"
+version = "1.10.0-mpre1"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -17466,7 +17466,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_grpc"
-version = "1.10.0"
+version = "1.10.0-mpre1"
 dependencies = [
  "async-trait",
  "futures",
@@ -17499,7 +17499,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_archive"
-version = "1.10.0"
+version = "1.10.0-mpre1"
 dependencies = [
  "aes-gcm",
  "async-compression",
@@ -17528,7 +17528,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_cli"
-version = "1.10.0"
+version = "1.10.0-mpre1"
 dependencies = [
  "alloy",
  "chrono",
@@ -17561,7 +17561,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_common"
-version = "1.10.0"
+version = "1.10.0-mpre1"
 dependencies = [
  "async-trait",
  "console_error_panic_hook",
@@ -17600,7 +17600,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_configuration"
-version = "1.10.0"
+version = "1.10.0-mpre1"
 dependencies = [
  "openmls",
  "xmtp-workspace-hack",
@@ -17610,7 +17610,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_content_types"
-version = "1.10.0"
+version = "1.10.0-mpre1"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
@@ -17631,7 +17631,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_cryptography"
-version = "1.10.0"
+version = "1.10.0-mpre1"
 dependencies = [
  "alloy",
  "bincode 1.3.3",
@@ -17660,7 +17660,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_db"
-version = "1.10.0"
+version = "1.10.0-mpre1"
 dependencies = [
  "arc-swap",
  "ascii_table",
@@ -17707,7 +17707,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_db_test"
-version = "1.10.0"
+version = "1.10.0-mpre1"
 dependencies = [
  "derive_builder",
  "diesel",
@@ -17721,7 +17721,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_id"
-version = "1.10.0"
+version = "1.10.0-mpre1"
 dependencies = [
  "alloy",
  "async-trait",
@@ -17757,7 +17757,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_macro"
-version = "1.10.0"
+version = "1.10.0-mpre1"
 dependencies = [
  "num_cpus",
  "proc-macro2",
@@ -17770,7 +17770,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_mls"
-version = "1.10.0"
+version = "1.10.0-mpre1"
 dependencies = [
  "aes-gcm",
  "alloy",
@@ -17852,7 +17852,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_mls_common"
-version = "1.10.0"
+version = "1.10.0-mpre1"
 dependencies = [
  "bon",
  "const-hex",
@@ -17874,7 +17874,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_proto"
-version = "1.10.0"
+version = "1.10.0-mpre1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -17916,7 +17916,7 @@ dependencies = [
 
 [[package]]
 name = "xmtpv3"
-version = "1.10.0"
+version = "1.10.0-mpre1"
 dependencies = [
  "alloy",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,9 +228,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85805c194576017df6c11057504e1d60b36f3913f8e365945486931f6ee81e40"
+checksum = "a547705d5c1b42575a0542bae2ba45bc62a6154be86611afaef1c0ab5c38598e"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -251,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.33"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e9e31d834fe25fe991b8884e4b9f0e59db4a97d86e05d1464d6899c013cd62"
+checksum = "84e0378e959aa6a885897522080a990e80eb317f1e9a222a604492ea50e13096"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -262,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dbe4e5e9107bf6854e7550b666ca654ff2027eabf8153913e2e31ac4b089779"
+checksum = "ae8c24c95e90c1608c2d91cff1b451d796474168d3310ccc8b7cd12502ca8169"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -279,7 +279,7 @@ dependencies = [
  "either",
  "k256",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "secp256k1",
  "serde",
  "serde_json",
@@ -289,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88fc7bbfb98cf5605a35aadf0ba43a7d9f1608d6f220d05e4fbd5144d3b0b625"
+checksum = "7d211ad0ef468a70a7a829e49683ff59ad25f02b4ab3764344c4c2663329a52c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -303,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c16fa30b623e40a5b216da00f3b61870f5cbe863b59816ac1ecc2489515a40"
+checksum = "c59d55233ac14aa7fa6bcdcad45ba305e90c556065e0947cd9f243c4469e7c2d"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -393,21 +393,22 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8222b1d88f9a6d03be84b0f5e76bb60cd83991b43ad8ab6477f0e4a7809b98d"
+checksum = "407510740da514b694fecb44d8b3cebdc60d448f70cc5d24743e8ba273448a6e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "borsh",
+ "once_cell",
  "serde",
 ]
 
 [[package]]
 name = "alloy-eips"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb4919fa34b268842f434bfafa9c09136ab7b1a87ce0dd40a61befa35b5408c"
+checksum = "ae69eaa5096b47ffe97e6a5d6bde7e7fa2dec106af22a9315621d11039c3de3c"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -428,9 +429,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e111e22c1a2133e9ebfd9051ea0eaf63559594d2f50d43cbc6762fbb95fc3c2"
+checksum = "39789db0b3f3bbef0e6549c87bc6842b73886ebabee1405b6941685b1cc34083"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -466,9 +467,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b6af6f374c1eeef8ab8dc26232cd440db167322a4207a3debd3d1ee565ca47"
+checksum = "662b525af73e86b2167dae923261c8edf440ba7e1426b30a8b993177bc214c02"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -481,9 +482,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a3f5a7f3678b71d33fcc45b714fab8928dbc647d5aff2145e72032d5c849bb"
+checksum = "c657c2d9751d3c7d94990554b231e5372c3c2e4bad842806280b6151a0d6a05d"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -507,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb50dc1fb0e0b2c8748d5bee1aa7acdd18f9e036311bc93a71d97be624030317"
+checksum = "59e7c4bb0ebbd6d7406d2808968f43c0d5186c69c5e58cedcbee7380f4cd1fcf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -520,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-node-bindings"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85195890fcee519312718dc8418035935ad0d57f57943ca82689732432a702c9"
+checksum = "2e78e79286335697f025dd722e5d0d101f8d8aeecdded71114e2c1f2a02104b6"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks",
@@ -532,7 +533,7 @@ dependencies = [
  "alloy-signer-local",
  "k256",
  "libc",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
@@ -560,7 +561,7 @@ dependencies = [
  "keccak-asm",
  "paste",
  "proptest",
- "rand 0.9.3",
+ "rand 0.9.4",
  "rapidhash",
  "ruint",
  "rustc-hash 2.1.2",
@@ -570,9 +571,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ba5468f78c8893be2d68a7f2fda61753336e5653f006af19781001b5f99e6c"
+checksum = "c4fea0fc2628cdbc851aaa333124f9d8ab9f567ab8d4c20202819db13aa1a534"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -633,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222fd4efff0fb9a25184684742c44fe9fa9a16c4ab5bf97583e71c86598ef8f0"
+checksum = "d5ee7b51752c68fb95f21705e402700750e692b1d21ccc294ac48fadc8655d53"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -656,9 +657,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "974df1e56405c27cb8242381f45d8b212ba9df5006046ccf704764a2a4634366"
+checksum = "8fa76988f54105ad4398828e8aaf1a39b3f07f91fb79091529056689514ee8c2"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-anvil",
@@ -669,9 +670,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06bc10b0dca4f5bfc3cd30ed46eab5d651b5bb2cd300d683bdcdf5d2bfe6e82c"
+checksum = "3d276bea4e92e4991269d31b9abd3e722eed2565b82036478a4416adb8dd4992"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -681,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949c0f16a94ae33cdb1139b8dbf9e34d7f26ebfe97962e2a4d620b5f65f48fe4"
+checksum = "1f1a9a3bda9be7f6515316eb792710532411878bbfc88934973f4b371376b00d"
 dependencies = [
  "alloy-consensus-any",
  "alloy-network-primitives",
@@ -696,9 +697,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc280a41931bd419af86e9e859dd9726b73313aaa2e479b33c0e344f4b892ddb"
+checksum = "dda4ece0050154ab278241aeffade58916b04f38254832e8cb6e4671c6e72ed2"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -717,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4848831ff994c88b1c32b7df9c4c1c3eedea4b535bde5eb3c421ef0bdc5ac052"
+checksum = "beaa5c581a67e2743d95b4849eb9cfeb90866429cdaa6d8f6b75eb988b2d0cd9"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -728,9 +729,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b8ad9890b212e224291024b1aecfeef72127d27a2f6eebc5e347c40275c4bf"
+checksum = "c5da9ae50f9b48d7b4e2e5cde87175257be7e5e56909a7794720597c1d9806f6"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -743,9 +744,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c67d2372aada343130d41e249b59a3cef29b1678dcd3fd80f1c2c4d6b5318f2"
+checksum = "49b794002d57fd2f71b4c87298a41ca24dfc0f2cf6630d95106a477e451747ba"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -755,7 +756,7 @@ dependencies = [
  "coins-bip32",
  "coins-bip39",
  "k256",
- "rand 0.8.5",
+ "rand 0.8.6",
  "thiserror 2.0.18",
  "zeroize",
 ]
@@ -835,9 +836,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b7b755e64ae6b5de0d762ed2c780e072167ea5e542076a559e00314352a0bf"
+checksum = "19dec9bfb59647254afdecbb5ddcddd7ba02edcd48ffa40510bddfbed0be1634"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -858,9 +859,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a29980e69119444ed26b75e7ee5bed2043870f904a64318297e55800db686564"
+checksum = "2035f3c4d6bee20624da2dcf765d469b292398e48d766ffade61b0fcf8b4d45d"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -890,9 +891,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d8228b9236479ff16b03041b64b86c2bd4e53da1caa45d59b5868cd1571131e"
+checksum = "3520337f3d3d063a7fe20f47aaa62d695e3dc0372b34f601560dee24e76988b9"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -907,7 +908,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f2a1bb052857d5dd49572219344a7332b31b76405648eabac5bc68978251bcd"
 dependencies = [
  "android-properties",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cc",
  "jni 0.22.4",
  "libc",
@@ -1247,7 +1248,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1257,7 +1258,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1267,7 +1268,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1337,7 +1338,7 @@ dependencies = [
  "enumflags2",
  "futures-channel",
  "futures-util",
- "rand 0.9.3",
+ "rand 0.9.4",
  "raw-window-handle",
  "serde",
  "serde_repr",
@@ -1359,7 +1360,7 @@ dependencies = [
  "enumflags2",
  "futures-channel",
  "futures-util",
- "rand 0.9.3",
+ "rand 0.9.4",
  "serde",
  "serde_repr",
  "url",
@@ -1807,9 +1808,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -1817,9 +1818,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -1829,9 +1830,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
@@ -1955,7 +1956,7 @@ version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -1975,7 +1976,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -2122,20 +2123,20 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "bitstream-io"
-version = "4.9.0"
+version = "4.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60d4bd9d1db2c6bdf285e223a7fa369d5ce98ec767dec949c6ca62863ce61757"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
 dependencies = [
- "core2",
+ "no_std_io2",
 ]
 
 [[package]]
@@ -2158,10 +2159,10 @@ checksum = "e71cfb73b98eb9f58ee84048aa1bdf4e7497fd20c141b57523499fa066b48fed"
 dependencies = [
  "ash",
  "ash-window",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytemuck",
  "codespan-reporting",
- "glow",
+ "glow 0.16.0",
  "gpu-alloc",
  "gpu-alloc-ash",
  "hidden-trait",
@@ -2476,7 +2477,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "log",
  "polling",
  "rustix 0.38.44",
@@ -2490,7 +2491,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dbf9978365bac10f54d1d4b04f7ce4427e51f71d61f2fe15e3fed5166474df7"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "polling",
  "rustix 1.1.4",
  "slab",
@@ -2653,7 +2654,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2734,9 +2735,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2767,9 +2768,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -2832,7 +2833,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f79398230a6e2c08f5c9760610eb6924b52aa9e7950a619602baba59dcbbdbb2"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "block",
  "cocoa-foundation 0.2.0",
  "core-foundation 0.10.0",
@@ -2862,7 +2863,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e14045fb83be07b5acf1c0884b2180461635b433455fa35d1cd6f17f1450679d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "block",
  "core-foundation 0.10.0",
  "core-graphics-types 0.2.0",
@@ -2908,7 +2909,7 @@ dependencies = [
  "hmac",
  "once_cell",
  "pbkdf2",
- "rand 0.8.5",
+ "rand 0.8.6",
  "sha2",
  "thiserror 1.0.69",
 ]
@@ -3053,9 +3054,9 @@ dependencies = [
 
 [[package]]
 name = "const-field-offset"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fcde4ca1211b5a94b573083c472ee19e86b19a441913f66e1cc5c41daf0255"
+checksum = "9713489fbc45a2d113f58d17448c73115d533ed27fd2f2d0e5e5c69663eaf19b"
 dependencies = [
  "const-field-offset-macro",
  "field-offset",
@@ -3063,9 +3064,9 @@ dependencies = [
 
 [[package]]
 name = "const-field-offset-macro"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5387f5bbc9e9e6c96436ea125afa12614cebf8ac67f49abc08c1e7a891466c90"
+checksum = "9b5dc851b7ea80cc4f69aa28632385ffd3e0f88014d53db3f2e5a781896ca783"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3112,11 +3113,12 @@ dependencies = [
 
 [[package]]
 name = "const_format"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
 dependencies = [
  "const_format_proc_macros",
+ "konst",
 ]
 
 [[package]]
@@ -3222,7 +3224,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.10.0",
  "core-graphics-types 0.2.0",
  "foreign-types",
@@ -3235,7 +3237,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32eb7c354ae9f6d437a6039099ce7ecd049337a8109b23d73e48e8ffba8e9cd5"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "core-graphics-types 0.1.3",
  "foreign-types",
@@ -3259,7 +3261,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.10.0",
  "libc",
 ]
@@ -3270,7 +3272,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e4583956b9806b69f73fcb23aee05eb3620efc282972f08f6a6db7504f8334d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "block",
  "cfg-if",
  "core-foundation 0.10.0",
@@ -3284,8 +3286,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "657f625ff361906f779745d08375ae3cc9fef87a35fba5f22874cf773010daf4"
 dependencies = [
  "hax-lib",
- "pastey 0.2.1",
- "rand 0.9.3",
+ "pastey 0.2.2",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -3315,15 +3317,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "core_maths"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3348,7 +3341,7 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da46a9d5a8905cc538a4a5bceb6a4510de7a51049c5588c0114efce102bcbbe8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "fontdb 0.16.2",
  "log",
  "rangemap",
@@ -3370,53 +3363,6 @@ name = "countme"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
-
-[[package]]
-name = "cpp"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1f6422bf20bc0654eac481a29a03e6d9121ad9f12345a03773b8a76a8701915"
-dependencies = [
- "cpp_macros",
-]
-
-[[package]]
-name = "cpp_build"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f6fed3200ba0708c2adca5f6ed5ae202edd824bd4cbac7935a85edac9bcddce"
-dependencies = [
- "cc",
- "cpp_common",
- "proc-macro2",
- "regex",
- "syn 2.0.117",
- "unicode-xid",
-]
-
-[[package]]
-name = "cpp_common"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7280a73ef92e18d27d2ec3005b57fe0043b51d1b506be86b0bf66f588f9857b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "cpp_macros"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc7fd49a5b246251229ea4d4bf94c8d418689a1f9986ef96e00b64992922169"
-dependencies = [
- "aho-corasick",
- "byteorder",
- "cpp_common",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -3607,30 +3553,14 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.8.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "352d39c2f7bef1d6ad73db6f5160efcaed66d94ef8c6c573a8410c00bf909a98"
+checksum = "83cf0d42651b16c6dfe68685716d18480d18a9c39c62d76e8cf3eb6ed5d8bcbf"
 dependencies = [
- "ctor-proc-macro 0.0.7",
- "dtor 0.3.0",
-]
-
-[[package]]
-name = "ctor"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95d0d11eb38e7642efca359c3cf6eb7b2e528182d09110165de70192b0352775"
-dependencies = [
- "ctor-proc-macro 0.0.12",
- "dtor 0.7.0",
+ "ctor-proc-macro 0.0.13",
+ "dtor 0.8.1",
  "link-section",
 ]
-
-[[package]]
-name = "ctor-lite"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e162d0c2e2068eb736b71e5597eff0b9944e6b973cd9f37b6a288ab9bf20e300"
 
 [[package]]
 name = "ctor-proc-macro"
@@ -3640,15 +3570,9 @@ checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
 
 [[package]]
 name = "ctor-proc-macro"
-version = "0.0.7"
+version = "0.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
-
-[[package]]
-name = "ctor-proc-macro"
-version = "0.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ab264ea985f1bd27887d7b21ea2bb046728e05d11909ca138d700c494730db"
+checksum = "7a949c44fcacbbbb7ada007dc7acb34603dd97cd47de5d054f2b6493ecebb483"
 
 [[package]]
 name = "ctr"
@@ -4092,7 +4016,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "block2 0.6.2",
  "libc",
  "objc2 0.6.4",
@@ -4154,7 +4078,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80bc8c5c6c2941f70a55c15f8d9f00f9710ebda3ffda98075f996a0e6c92756f"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytemuck",
  "drm-ffi",
  "drm-fourcc",
@@ -4212,20 +4136,11 @@ dependencies = [
 
 [[package]]
 name = "dtor"
-version = "0.3.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1057d6c64987086ff8ed0fd3fbf377a6b7d205cc7715868cd401705f715cbe4"
+checksum = "edf234dd1594d6dd434a8fb8cada51ddbbc593e40e4a01556a0b31c62da2775b"
 dependencies = [
- "dtor-proc-macro 0.0.6",
-]
-
-[[package]]
-name = "dtor"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f72721db8027a4e96dd6fb50d2a1d32259c9d3da1b63dee612ccd981e14293"
-dependencies = [
- "dtor-proc-macro 0.0.12",
+ "dtor-proc-macro 0.0.13",
 ]
 
 [[package]]
@@ -4236,15 +4151,9 @@ checksum = "7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055"
 
 [[package]]
 name = "dtor-proc-macro"
-version = "0.0.6"
+version = "0.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
-
-[[package]]
-name = "dtor-proc-macro"
-version = "0.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c98b077c7463d01d22dde8a24378ddf1ca7263dc687cffbed38819ea6c21131"
+checksum = "2647271c92754afcb174e758003cfd1cbf1e43e5a7853d7b1813e63e19e39a73"
 
 [[package]]
 name = "dunce"
@@ -4697,21 +4606,20 @@ dependencies = [
 
 [[package]]
 name = "femtovg"
-version = "0.20.4"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35695993a8264f5dfa8facc135c003965cea40d83705b49e0f8c3a3b632a2171"
+checksum = "727c5dd9d601f3f4ea133b8a6ba37d37ca67ed59781675dc1c9c9f1701e0d197"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytemuck",
  "fnv",
- "glow",
- "image",
+ "glow 0.17.0",
  "imgref",
  "itertools 0.14.0",
  "log",
  "rgb",
  "slotmap",
- "ttf-parser 0.25.1",
+ "swash",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -4777,7 +4685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustc-hex",
  "static_assertions",
 ]
@@ -4872,18 +4780,9 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "font-types"
-version = "0.10.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a654f404bbcbd48ea58c617c2993ee91d1cb63727a37bf2323a4edeed1b8c5"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
-name = "font-types"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d9237c6d82152100c691fb77ea18037b402bcc7257d2c876a4ffac81bc22a1c"
+checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
 dependencies = [
  "bytemuck",
 ]
@@ -4926,36 +4825,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "fontdue"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e57e16b3fe8ff4364c0661fdaac543fb38b29ea9bc9c2f45612d90adf931d2b"
-dependencies = [
- "hashbrown 0.15.5",
- "rayon",
- "ttf-parser 0.21.1",
-]
-
-[[package]]
 name = "fontique"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bbc252c93499b6d3635d692f892a637db0dbb130ce9b32bf20b28e0dcc470b"
+checksum = "23358480a54a886d51b306718d5ca743fdfe238e5df38ef650f4e72f29c5d9e9"
 dependencies = [
- "bytemuck",
  "hashbrown 0.16.1",
- "icu_locale_core",
  "linebender_resource_handle",
  "memmap2",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-text",
  "objc2-foundation 0.3.2",
- "read-fonts 0.35.0",
+ "parlance",
+ "read-fonts",
  "roxmltree 0.21.1",
  "smallvec",
- "windows 0.58.0",
- "windows-core 0.58.0",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
  "yeslogic-fontconfig-sys",
 ]
 
@@ -5209,7 +5096,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce852e998d3ca5e4a97014fb31c940dc5ef344ec7d364984525fd11e8a547e6a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "drm",
  "drm-fourcc",
  "gbm-sys",
@@ -5292,7 +5179,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
  "wasm-bindgen",
@@ -5476,7 +5363,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2409cffa4fe8b303847d5b6ba8df9da9ba65d302fc5ee474ea0cac5afde79840"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bstr",
  "gix-path",
  "libc",
@@ -5615,7 +5502,7 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8546300aee4c65c5862c22a3e321124a69b654a61a8b60de546a9284812b7e2"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bstr",
  "gix-features",
  "gix-path",
@@ -5663,7 +5550,7 @@ version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea6d3e9e11647ba49f441dea0782494cc6d2875ff43fa4ad9094e6957f42051"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bstr",
  "filetime",
  "fnv",
@@ -5786,7 +5673,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed9e0c881933c37a7ef45288d6c5779c4a7b3ad240b4c37657e1d9829eb90085"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bstr",
  "gix-attributes",
  "gix-config-value",
@@ -5867,7 +5754,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91898c83b18c635696f7355d171cfa74a52f38022ff89581f567768935ebc4c8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bstr",
  "gix-commitgraph",
  "gix-date",
@@ -5900,7 +5787,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea9962ed6d9114f7f100efe038752f41283c225bb507a2888903ac593dffa6be"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "gix-path",
  "libc",
  "windows-sys 0.61.2",
@@ -5999,7 +5886,7 @@ version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d052b83d1d1744be95ac6448ac02f95f370a8f6720e466be9ce57146e39f5280"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "gix-commitgraph",
  "gix-date",
  "gix-hash",
@@ -6153,12 +6040,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "glow"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "glutin"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12124de845cacfebedff80e877bb37b5b75c34c5a4c89e47e1cdd67fb6041325"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg_aliases",
  "cgl",
  "dispatch2",
@@ -6235,7 +6134,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "gpu-alloc-types",
 ]
 
@@ -6256,7 +6155,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -6321,7 +6220,7 @@ dependencies = [
  "pin-project",
  "postage",
  "profiling",
- "rand 0.9.3",
+ "rand 0.9.4",
  "raw-window-handle",
  "resvg 0.45.1",
  "schemars 1.2.1",
@@ -6648,14 +6547,14 @@ dependencies = [
 
 [[package]]
 name = "harfrust"
-version = "0.3.2"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c020db12c71d8a12a3fe7607873cade3a01a6287e29d540c8723276221b9d8"
+checksum = "9da2e5ae821f6e96664977bf974d6d6a2d6682f9ccee23e62ec1d134246845f9"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytemuck",
  "core_maths",
- "read-fonts 0.35.0",
+ "read-fonts",
  "smallvec",
 ]
 
@@ -6686,10 +6585,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
- "rayon",
 ]
 
 [[package]]
@@ -6919,7 +6815,7 @@ dependencies = [
  "libcrux-traits",
  "rand 0.10.1",
  "rand_chacha 0.10.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "zeroize",
 ]
 
@@ -6936,9 +6832,9 @@ dependencies = [
  "k256",
  "p256",
  "p384",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "rand_core 0.6.4",
  "sha2",
  "subtle",
@@ -7102,9 +6998,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.8"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.4.0",
  "hyper 1.9.0",
@@ -7169,12 +7065,13 @@ dependencies = [
 
 [[package]]
 name = "i-slint-backend-linuxkms"
-version = "1.15.1"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b8827952ecfbbf76c8cb5bc3388ca9124c34f2b4fe5dffcfe57800d2a484885"
+checksum = "3224c3aa9f3ea568daf38389d0f7ace164eda4d6f1851042eb83750ac43e1a65"
 dependencies = [
  "bytemuck",
  "calloop 0.14.4",
+ "cfg_aliases",
  "drm",
  "gbm",
  "glutin",
@@ -7190,33 +7087,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "i-slint-backend-qt"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9d5db3221f453439ec5ad9b6ac3bb8d2b4825b2f8734f0cde4b67d7336c3da"
-dependencies = [
- "const-field-offset",
- "cpp",
- "cpp_build",
- "i-slint-common",
- "i-slint-core",
- "i-slint-core-macros",
- "lyon_path",
- "pin-project",
- "pin-weak",
- "qttypes",
- "vtable",
-]
-
-[[package]]
 name = "i-slint-backend-selector"
-version = "1.15.1"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce5a7e591a7257096e1f3da1bbb9ad6a140c307d0eee74f008a0b412fdb20dec"
+checksum = "f93c9c4203e0a2c5c396b8f1686160816f73e9b9cadaf3915aa3b888a83448aa"
 dependencies = [
  "cfg-if",
  "i-slint-backend-linuxkms",
- "i-slint-backend-qt",
  "i-slint-backend-winit",
  "i-slint-common",
  "i-slint-core",
@@ -7226,9 +7103,9 @@ dependencies = [
 
 [[package]]
 name = "i-slint-backend-winit"
-version = "1.15.1"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbf4789191740f939c9563b8850379122d7b5c1ceb09f9297b50ad53e408787"
+checksum = "f4df6ec88d452e3c22e418d20c96bc1ccbc9509e81e6596426d3388bf226a5f9"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -7261,10 +7138,11 @@ dependencies = [
  "scoped-tls-hkt",
  "scopeguard",
  "softbuffer",
- "strum 0.27.2",
+ "strum 0.28.0",
  "vtable",
  "wasm-bindgen",
  "web-sys",
+ "webbrowser",
  "windows 0.62.2",
  "winit",
  "zbus",
@@ -7272,25 +7150,29 @@ dependencies = [
 
 [[package]]
 name = "i-slint-common"
-version = "1.15.1"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7659797fd28d4df3ed275ff95bf730bdf4a88d253f07e1ee8d0032d70138c3a"
+checksum = "40cae5cd0a81ce044029ac303256e025f98a4c59495b5189fc22b588da094e01"
 dependencies = [
+ "derive_more 2.1.1",
  "fontique",
- "ttf-parser 0.25.1",
+ "htmlparser",
+ "pulldown-cmark",
+ "skrifa",
 ]
 
 [[package]]
 name = "i-slint-compiler"
-version = "1.15.1"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a6f358d0d5389869d67cd6ab6f5acf98fe31827264a696593e9687213cff682"
+checksum = "a7b7f9834faf2a62cc36f01decc7c683e66bb0861b53511723c3da9ad914d9bb"
 dependencies = [
  "annotate-snippets",
  "by_address",
+ "data-url",
  "derive_more 2.1.1",
- "fontdue",
  "i-slint-common",
+ "icu_normalizer",
  "image",
  "itertools 0.14.0",
  "linked_hash_set",
@@ -7300,32 +7182,35 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rayon",
- "resvg 0.46.0",
+ "resvg 0.47.0",
  "rowan",
  "rspolib",
+ "skrifa",
  "smol_str 0.3.6",
- "strum 0.27.2",
+ "strum 0.28.0",
+ "swash",
  "typed-index-collections",
+ "unicode-segmentation",
  "url",
 ]
 
 [[package]]
 name = "i-slint-core"
-version = "1.15.1"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a95591ff85f8e2ff11c8d26ea8429768c2b77866e0c7e7fd49348f23ad108b5c"
+checksum = "89e4a57afd78d8a1f599a78781dc1413af68545b2bc5ba5e143ecf022c75d5f3"
 dependencies = [
  "auto_enums",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "chrono",
  "clru",
  "const-field-offset",
  "derive_more 2.1.1",
  "euclid",
- "htmlparser",
  "i-slint-common",
  "i-slint-core-macros",
+ "icu_normalizer",
  "image",
  "lyon_algorithms",
  "lyon_extra",
@@ -7337,17 +7222,17 @@ dependencies = [
  "pin-project",
  "pin-weak",
  "portable-atomic",
- "pulldown-cmark",
  "raw-window-handle",
- "resvg 0.46.0",
+ "resvg 0.47.0",
  "rgb",
  "scoped-tls-hkt",
  "scopeguard",
- "skrifa 0.37.0",
+ "skrifa",
  "slab",
- "strum 0.27.2",
+ "strum 0.28.0",
+ "swash",
  "sys-locale",
- "thiserror 2.0.18",
+ "taffy",
  "unicode-linebreak",
  "unicode-script",
  "unicode-segmentation",
@@ -7359,9 +7244,9 @@ dependencies = [
 
 [[package]]
 name = "i-slint-core-macros"
-version = "1.15.1"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc5f2f71682787dd5c6299555c0de635009eb269bbc54d6198e0d225b69fae4"
+checksum = "7931356d5238281e6be994ec15241fb2d9e66359776d53b4bd6b2fdd9c257c6e"
 dependencies = [
  "quote",
  "serde_json",
@@ -7370,15 +7255,15 @@ dependencies = [
 
 [[package]]
 name = "i-slint-renderer-femtovg"
-version = "1.15.1"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb6eccda447999bc6222988500b841b64c953988986af182334e7ba9a30f0edd"
+checksum = "72b28a8f0a7a777e670fbe2af6cbcec4935c37335bc0dab100f73bdc197dfa3a"
 dependencies = [
  "cfg-if",
  "const-field-offset",
  "derive_more 2.1.1",
  "femtovg",
- "glow",
+ "glow 0.17.0",
  "i-slint-common",
  "i-slint-core",
  "i-slint-core-macros",
@@ -7386,23 +7271,23 @@ dependencies = [
  "lyon_path",
  "pin-weak",
  "rgb",
- "ttf-parser 0.25.1",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "i-slint-renderer-skia"
-version = "1.15.1"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64546232c0370f291e65fc92a4f4fc777ea78d5f48467873cb968b1de52e9ab"
+checksum = "d4030ff9eeb1b99fdf9b47472f3a7a582f3bcb57207c9bc07505dc6998abdcbc"
 dependencies = [
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
+ "clru",
  "const-field-offset",
  "derive_more 2.1.1",
- "glow",
+ "glow 0.17.0",
  "glutin",
  "i-slint-common",
  "i-slint-core",
@@ -7417,7 +7302,7 @@ dependencies = [
  "pin-weak",
  "raw-window-handle",
  "raw-window-metal 1.1.0",
- "read-fonts 0.35.0",
+ "read-fonts",
  "scoped-tls-hkt",
  "skia-safe",
  "softbuffer",
@@ -7429,21 +7314,21 @@ dependencies = [
 
 [[package]]
 name = "i-slint-renderer-software"
-version = "1.15.1"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a59be6c34935c4f8e41aa67a63518d5c59219c8eeb1d07af420bed8334fa31d7"
+checksum = "ee8a21285f3a81a8e1b1e7c385eefe89bf9487f53fabfd5b238c68bc895d6013"
 dependencies = [
  "bytemuck",
  "clru",
  "derive_more 2.1.1",
  "euclid",
- "fontdue",
  "i-slint-common",
  "i-slint-core",
  "integer-sqrt",
  "lyon_path",
  "num-traits",
- "skrifa 0.37.0",
+ "skrifa",
+ "swash",
  "zeno",
 ]
 
@@ -7486,6 +7371,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_locale"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5a396343c7208121dc86e35623d3dfe19814a7613cfd14964994cdc9c9a2e26"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_locale_data",
+ "icu_provider",
+ "potential_utf",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
 name = "icu_locale_core"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7498,6 +7398,12 @@ dependencies = [
  "writeable",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_locale_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993"
 
 [[package]]
 name = "icu_normalizer"
@@ -7547,12 +7453,35 @@ checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
+ "serde",
+ "stable_deref_trait",
  "writeable",
  "yoke",
  "zerofrom",
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_segmenter"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0794db0b1a86193ac9c48768d0e6c52c54448e0870ad87907d456ee0dac964"
+dependencies = [
+ "icu_collections",
+ "icu_locale",
+ "icu_provider",
+ "icu_segmenter_data",
+ "potential_utf",
+ "utf8_iter",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_segmenter_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a2c462a4d927d512f5f882a033ddd62f33a05bb9f230d98f736ac3dc85938f"
 
 [[package]]
 name = "id-arena"
@@ -7807,7 +7736,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbdc09524a91f9cacd26f16734ff63d7dc650daffadd2b6f84d17a285bd875a9"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "input-sys",
  "libc",
  "log",
@@ -7978,9 +7907,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
@@ -7993,9 +7922,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8151,7 +8080,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "serde",
  "unicode-segmentation",
 ]
@@ -8171,6 +8100,21 @@ name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "kqueue"
@@ -8206,17 +8150,6 @@ name = "kurbo"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c62026ae44756f8a599ba21140f350303d4f08dcdcc71b5ad9c9bb8128c13c62"
-dependencies = [
- "arrayvec",
- "euclid",
- "smallvec",
-]
-
-[[package]]
-name = "kurbo"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce9729cc38c18d86123ab736fd2e7151763ba226ac2490ec092d1dd148825e32"
 dependencies = [
  "arrayvec",
  "euclid",
@@ -8367,7 +8300,7 @@ checksum = "b65f73ce79337c762eb38bbac91e4c9b9e60cf318e8501b812750c640814d45e"
 dependencies = [
  "libcrux-curve25519",
  "libcrux-p256",
- "rand 0.9.3",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -8446,7 +8379,7 @@ dependencies = [
  "libcrux-p256",
  "libcrux-sha3",
  "libcrux-traits",
- "rand 0.9.3",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -8471,7 +8404,7 @@ dependencies = [
  "libcrux-secrets",
  "libcrux-sha3",
  "libcrux-traits",
- "rand 0.9.3",
+ "rand 0.9.4",
  "tls_codec",
 ]
 
@@ -8556,7 +8489,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e4fa89f3f5e34b47f928b22b1b78395a0d4ec23b1f583db635f128159d65f"
 dependencies = [
  "libcrux-secrets",
- "rand 0.9.3",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -8597,12 +8530,11 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.44"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
 dependencies = [
  "cc",
- "libc",
 ]
 
 [[package]]
@@ -8611,7 +8543,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "libc",
  "plain",
  "redox_syscall 0.7.4",
@@ -8647,9 +8579,9 @@ checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
 
 [[package]]
 name = "link-section"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "468808413fa8bdf0edbe61c2bbc182dfc59885b94f496cf3fb42c9c96b1e0149"
+checksum = "b685d66585d646efe09fec763d796c291049c8b6bf84e04954bffc8748341f0d"
 
 [[package]]
 name = "linked-hash-map"
@@ -8690,7 +8622,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "636860251af8963cc40f6b4baadee105f02e21b28131d76eba8e40ce84ab8064"
 dependencies = [
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
 ]
 
@@ -8751,9 +8683,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
 ]
@@ -9030,7 +8962,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "block",
  "core-graphics-types 0.1.3",
  "foreign-types",
@@ -9060,9 +8992,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.48"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+checksum = "b3627c4272df786b9260cabaa46aec1d59c93ede723d4c3ef646c503816b0640"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -9200,7 +9132,7 @@ dependencies = [
  "hyper-util",
  "log",
  "pin-project-lite",
- "rand 0.9.3",
+ "rand 0.9.4",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -9220,9 +9152,9 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9fec5a4e89860383d778d10563a605838f8f0b2f9303868937e5ff32e86177"
+checksum = "b20e2339ef964849496bd6dab1bcd8ceb7a3a5a268dc64c8b84c833e75d66dab"
 dependencies = [
  "crossbeam-channel",
  "dpi",
@@ -9251,7 +9183,7 @@ checksum = "2b977c445f26e49757f9aca3631c3b8b836942cb278d69a92e7b80d3b24da632"
 dependencies = [
  "arrayvec",
  "bit-set",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg_aliases",
  "codespan-reporting",
  "half",
@@ -9279,12 +9211,12 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "3.8.4"
+version = "3.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb7848c221fb7bb789e02f01875287ebb1e078b92a6566a34de01ef8806e7c2b"
+checksum = "fa73b028610e2b26e9e40bd2c8ff8a98e6d7ed5d67d89ebf4bfd2f992616b024"
 dependencies = [
- "bitflags 2.11.0",
- "ctor 0.8.0",
+ "bitflags 2.11.1",
+ "ctor 0.10.1",
  "futures",
  "napi-build",
  "napi-sys",
@@ -9303,12 +9235,12 @@ checksum = "d376940fd5b723c6893cd1ee3f33abbfd86acb1cd1ec079f3ab04a2a3bc4d3b1"
 
 [[package]]
 name = "napi-derive"
-version = "3.5.3"
+version = "3.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60867ff9a6f76e82350e0c3420cb0736f5866091b61d7d8a024baa54b0ec17dd"
+checksum = "7430702d3cc05cf55f0a2c9e41d991c3b7a53f91e6146a8f282b1bfc7f3fd133"
 dependencies = [
  "convert_case 0.11.0",
- "ctor 0.8.0",
+ "ctor 0.10.1",
  "napi-derive-backend",
  "proc-macro2",
  "quote",
@@ -9317,9 +9249,9 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "5.0.2"
+version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0864cf6a82e2cfb69067374b64c9253d7e910e5b34db833ed7495dda56ccb18"
+checksum = "1ca5a083f2c9b49a0c7d33ec75c083498849c6fcc46f5497317faa39ea77f5d5"
 dependencies = [
  "convert_case 0.11.0",
  "proc-macro2",
@@ -9349,7 +9281,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "jni-sys 0.3.1",
  "log",
  "ndk-sys 0.6.0+11769913",
@@ -9394,7 +9326,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -9406,7 +9338,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -9418,10 +9350,19 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -9470,7 +9411,7 @@ version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "filetime",
  "fsevent-sys",
  "inotify",
@@ -9545,7 +9486,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "smallvec",
  "zeroize",
@@ -9725,7 +9666,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
@@ -9741,7 +9682,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "block2 0.6.2",
  "libc",
  "objc2 0.6.4",
@@ -9762,7 +9703,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
@@ -9775,7 +9716,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "objc2 0.6.4",
  "objc2-foundation 0.3.2",
 ]
@@ -9797,7 +9738,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -9809,7 +9750,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "objc2 0.6.4",
  "objc2-foundation 0.3.2",
 ]
@@ -9820,7 +9761,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "dispatch2",
  "objc2 0.6.4",
 ]
@@ -9831,7 +9772,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "dispatch2",
  "objc2 0.6.4",
  "objc2-core-foundation",
@@ -9878,7 +9819,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -9890,7 +9831,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -9909,7 +9850,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "block2 0.5.1",
  "dispatch",
  "libc",
@@ -9922,7 +9863,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-core-foundation",
@@ -9934,7 +9875,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -9957,7 +9898,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -9969,7 +9910,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-foundation 0.3.2",
@@ -9981,7 +9922,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -9994,7 +9935,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
@@ -10017,7 +9958,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-cloud-kit 0.2.2",
@@ -10038,7 +9979,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-core-foundation",
@@ -10063,7 +10004,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
@@ -10138,7 +10079,7 @@ dependencies = [
  "num",
  "num-bigint-dig",
  "pbkdf2",
- "rand 0.9.3",
+ "rand 0.9.4",
  "serde",
  "sha2",
  "subtle",
@@ -10162,9 +10103,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "open"
-version = "5.3.3"
+version = "5.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+checksum = "9f3bab717c29a857abf75fcef718d441ec7cb2725f937343c734740a985d37fd"
 dependencies = [
  "is-wsl",
  "libc",
@@ -10189,7 +10130,7 @@ dependencies = [
  "openmls_sqlite_storage",
  "openmls_test",
  "openmls_traits",
- "rand 0.9.3",
+ "rand 0.9.4",
  "rayon",
  "serde",
  "serde_bytes",
@@ -10208,7 +10149,7 @@ dependencies = [
  "ed25519-dalek",
  "openmls_traits",
  "p256",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "tls_codec",
 ]
@@ -10229,7 +10170,7 @@ dependencies = [
  "libcrux-traits",
  "openmls_memory_storage",
  "openmls_traits",
- "rand 0.9.3",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "tls_codec",
 ]
@@ -10263,7 +10204,7 @@ dependencies = [
  "openmls_memory_storage",
  "openmls_traits",
  "p256",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "serde",
  "sha2",
@@ -10325,9 +10266,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.113"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
@@ -10344,9 +10285,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbclient"
-version = "0.3.51"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59aed3b33578edcfa1bc96a321d590d31832b6ad55a26f0313362ce687e9abd6"
+checksum = "12c6933ddbbd16539a7672e697bb8d41ac3a4e99ac43eeb40c07236bd7fcb2dd"
 dependencies = [
  "libc",
  "libredox",
@@ -10516,17 +10457,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "parley"
-version = "0.7.0"
+name = "parlance"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ada5338c3a9794af7342e6f765b6e78740db37378aced034d7bf72c96b94ed94"
+checksum = "4b6937eda350acc1a5d05872c3cbf99fe78619c269096e2be3d4a350058639d5"
+
+[[package]]
+name = "parley"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6c00ec192e1a402861526eff91a4b4690a2e5a17a4ae2deb772d72b49daf868"
 dependencies = [
  "fontique",
  "harfrust",
  "hashbrown 0.16.1",
+ "icu_normalizer",
+ "icu_properties",
+ "icu_segmenter",
  "linebender_resource_handle",
- "skrifa 0.37.0",
- "swash",
+ "parlance",
+ "parley_data",
+ "skrifa",
+]
+
+[[package]]
+name = "parley_data"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "232313eddc02ac27f015e8f8eeb7facce8a896116df7e3eda1bfd9f600a9a39d"
+dependencies = [
+ "icu_properties",
 ]
 
 [[package]]
@@ -10552,7 +10512,7 @@ dependencies = [
  "log",
  "p256",
  "passkey-types",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -10585,14 +10545,14 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77144664f6aac5f629d7efa815f5098a054beeeca6ccafee5ec453fd2b0c53f9"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "ciborium",
  "coset",
  "data-encoding",
  "getrandom 0.2.17",
  "hmac",
  "indexmap 2.14.0",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2",
@@ -10615,9 +10575,9 @@ checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "pastey"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
 
 [[package]]
 name = "pathdiff"
@@ -10637,9 +10597,9 @@ dependencies = [
 
 [[package]]
 name = "pathfinder_simd"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf9027960355bf3afff9841918474a81a5f972ac6d226d518060bba758b5ad57"
+checksum = "4500030c302e4af1d423f36f3b958d1aecb6c04184356ed5a833bf6b60435777"
 dependencies = [
  "rustc_version 0.4.1",
 ]
@@ -10786,7 +10746,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -10922,7 +10882,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -10989,9 +10949,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -11019,6 +10979,8 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
+ "serde_core",
+ "writeable",
  "zerovec",
 ]
 
@@ -11190,9 +11152,9 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "num-traits",
- "rand 0.9.3",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -11217,7 +11179,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -11276,9 +11238,9 @@ dependencies = [
 
 [[package]]
 name = "psm"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3852766467df634d74f0b2d7819bf8dc483a0eb2e3b0f50f756f9cfe8b0d18d8"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
 dependencies = [
  "ar_archive_writer",
  "cc",
@@ -11296,7 +11258,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "getopts",
  "memchr",
  "pulldown-cmark-escape",
@@ -11320,9 +11282,9 @@ dependencies = [
 
 [[package]]
 name = "pxfm"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "qoi"
@@ -11331,17 +11293,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
 dependencies = [
  "bytemuck",
-]
-
-[[package]]
-name = "qttypes"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7edf5b38c97ad8900ad2a8418ee44b4adceaa866a4a3405e2f1c909871d7ebd"
-dependencies = [
- "cpp",
- "cpp_build",
- "semver 1.0.28",
 ]
 
 [[package]]
@@ -11414,7 +11365,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.3",
+ "rand 0.9.4",
  "ring",
  "rustc-hash 2.1.2",
  "rustls",
@@ -11480,9 +11431,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -11492,9 +11443,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -11509,7 +11460,7 @@ checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20 0.10.0",
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -11539,7 +11490,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -11563,9 +11514,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -11588,7 +11539,7 @@ version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
 dependencies = [
- "rand 0.9.3",
+ "rand 0.9.4",
  "rustversion",
 ]
 
@@ -11619,7 +11570,7 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand 0.9.3",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "simd_helpers",
  "thiserror 2.0.18",
@@ -11674,9 +11625,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -11694,23 +11645,13 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717cf23b488adf64b9d711329542ba34de147df262370221940dfabc2c91358"
-dependencies = [
- "bytemuck",
- "core_maths",
- "font-types 0.10.1",
-]
-
-[[package]]
-name = "read-fonts"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
 dependencies = [
  "bytemuck",
- "font-types 0.11.2",
+ "core_maths",
+ "font-types",
 ]
 
 [[package]]
@@ -11747,7 +11688,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -11756,7 +11697,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -11803,9 +11744,9 @@ dependencies = [
 
 [[package]]
 name = "refinery"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c427f2572afe5c6cbfa2b1bf40071c89bf1a8539e958ea582842f6f38dcfae"
+checksum = "ee5133e5b207e5703c2a4a9dc9bd8c8f2cc74c4ac04ca5510acaa907012c77ac"
 dependencies = [
  "refinery-core",
  "refinery-macros",
@@ -11813,9 +11754,9 @@ dependencies = [
 
 [[package]]
 name = "refinery-core"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702655abfc67f93a6f735e9fa4ace7d2e580633f8961f28acbfd7583ddce936c"
+checksum = "023a2a96d959c9b5b5da78e965bfdb1363b365bf5e84531a67d0eee827a702a3"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -11833,9 +11774,9 @@ dependencies = [
 
 [[package]]
 name = "refinery-macros"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5145756cdf293b5089dc6b4f103f1a1229cc55d67082c866f8c8289531c4b983"
+checksum = "c56c2e960c8e47c7c5c30ad334afea8b5502da796a59e34d640d6239d876d924"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -11975,15 +11916,15 @@ dependencies = [
  "pico-args",
  "rgb",
  "svgtypes 0.15.3",
- "tiny-skia",
+ "tiny-skia 0.11.4",
  "usvg 0.45.1",
 ]
 
 [[package]]
 name = "resvg"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b563218631706d614e23059436526d005b50ab5f2d506b55a17eb65c5eb83419"
+checksum = "9be183ad6a216aa96f33e4c8033b0988b8b3ea6fd2359d19af5bac4643fd8e81"
 dependencies = [
  "gif",
  "image-webp",
@@ -11991,8 +11932,8 @@ dependencies = [
  "pico-args",
  "rgb",
  "svgtypes 0.16.1",
- "tiny-skia",
- "usvg 0.46.0",
+ "tiny-skia 0.12.0",
+ "usvg 0.47.0",
  "zune-jpeg",
 ]
 
@@ -12167,15 +12108,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3a8fb4672e840a587a66fc577a5491375df51ddb88f2a2c2a792598c326fe14"
 dependencies = [
  "quote",
- "rand 0.8.5",
+ "rand 0.8.6",
  "syn 2.0.117",
 ]
 
 [[package]]
 name = "ruint"
-version = "1.17.2"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
+checksum = "0298da754d1395046b0afdc2f20ee76d29a8ae310cd30ffa84ed42acba9cb12a"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
@@ -12190,8 +12131,8 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types",
  "proptest",
- "rand 0.8.5",
- "rand 0.9.3",
+ "rand 0.8.6",
+ "rand 0.9.4",
  "rlp",
  "ruint-macro",
  "serde_core",
@@ -12211,7 +12152,7 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -12326,7 +12267,7 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 dependencies = [
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -12359,7 +12300,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -12372,7 +12313,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -12381,9 +12322,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -12489,7 +12430,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfb9cf8877777222e4a3bc7eb247e398b56baba500c38c1c46842431adc8b55c"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytemuck",
  "libm",
  "smallvec",
@@ -12506,7 +12447,7 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytemuck",
  "core_maths",
  "log",
@@ -12660,7 +12601,7 @@ dependencies = [
  "log",
  "memmap2",
  "smithay-client-toolkit 0.19.2",
- "tiny-skia",
+ "tiny-skia 0.11.4",
 ]
 
 [[package]]
@@ -12702,7 +12643,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.8.5",
+ "rand 0.8.6",
  "secp256k1-sys",
  "serde",
 ]
@@ -12722,7 +12663,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
@@ -13012,9 +12953,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
  "digest 0.10.7",
  "keccak",
@@ -13166,19 +13107,9 @@ version = "0.90.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a71c01d325d40b1031dee67d251a5e0132e79e2a9ec272149a4f4a0d4b8b3be"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "skia-bindings",
  "windows 0.62.2",
-]
-
-[[package]]
-name = "skrifa"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c31071dedf532758ecf3fed987cdb4bd9509f900e026ab684b4ecb81ea49841"
-dependencies = [
- "bytemuck",
- "read-fonts 0.35.0",
 ]
 
 [[package]]
@@ -13188,7 +13119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fbdfe3d2475fbd7ddd1f3e5cf8288a30eb3e5f95832829570cd88115a7434ac"
 dependencies = [
  "bytemuck",
- "read-fonts 0.37.0",
+ "read-fonts",
 ]
 
 [[package]]
@@ -13199,12 +13130,11 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slint"
-version = "1.15.1"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25b87d458205e79efb30545cae083aec2ccb1b192c46a55ae6d54403cdacb33"
+checksum = "d46bc502cc6b113bfd1a7e9a0876532a9454ff4ee905afe09784eaa2ec3f3f33"
 dependencies = [
  "const-field-offset",
- "i-slint-backend-qt",
  "i-slint-backend-selector",
  "i-slint-common",
  "i-slint-core",
@@ -13221,22 +13151,22 @@ dependencies = [
 
 [[package]]
 name = "slint-build"
-version = "1.15.1"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "064ef470cc8ab046319db94d0727f080fbd05322d07d774eb6de607d97defb8d"
+checksum = "a73854b9adf81fa1600b46df488ffc3796400e8e9b40d504a94a36b55c8f3d0a"
 dependencies = [
  "derive_more 2.1.1",
  "fontique",
  "i-slint-compiler",
  "spin_on",
- "toml_edit 0.24.1+spec-1.1.0",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
 name = "slint-macros"
-version = "1.15.1"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ecc09bbc42c780d5b7ed7d41f7573dfd67343e11cdac27c07b88a8f933958e6"
+checksum = "6d5884e06072c329da7096ad1367eb83b98c78e5313f7ac90d66f90d4acc62ee"
 dependencies = [
  "i-slint-compiler",
  "proc-macro2",
@@ -13274,7 +13204,7 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "calloop 0.13.0",
  "calloop-wayland-source 0.3.0",
  "cursor-icon",
@@ -13299,7 +13229,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0512da38f5e2b31201a93524adb8d3136276fa4fe4aafab4e1f727a82b534cc0"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "calloop 0.14.4",
  "calloop-wayland-source 0.4.1",
  "cursor-icon",
@@ -13382,7 +13312,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -13484,7 +13414,7 @@ version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -13499,9 +13429,9 @@ dependencies = [
 
 [[package]]
 name = "sqlite-wasm-rs"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4206ed3a67690b9c29b77d728f6acc3ce78f16bf846d83c94f76400320181b"
+checksum = "1b2c760607300407ddeaee518acf28c795661b7108c75421303dbefb237d3a36"
 dependencies = [
  "cc",
  "js-sys",
@@ -13533,15 +13463,15 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stacker"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d74a23609d509411d10e2176dc2a4346e3b4aea2e7b1869f19fdedbc71c013"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
 dependencies = [
  "cc",
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13651,6 +13581,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13681,6 +13620,18 @@ name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -13804,10 +13755,16 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "842f3cd369c2ba38966204f983eaa5e54a8e84a7d7159ed36ade2b6c335aae64"
 dependencies = [
- "skrifa 0.40.0",
+ "skrifa",
  "yazi",
  "zeno",
 ]
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
@@ -13912,7 +13869,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "system-configuration-sys 0.6.0",
 ]
@@ -14184,7 +14141,22 @@ dependencies = [
  "cfg-if",
  "log",
  "png 0.17.16",
- "tiny-skia-path",
+ "tiny-skia-path 0.11.4",
+]
+
+[[package]]
+name = "tiny-skia"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47ffee5eaaf5527f630fb0e356b90ebdec84d5d18d937c5e440350f88c5a91ea"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png 0.18.1",
+ "tiny-skia-path 0.12.0",
 ]
 
 [[package]]
@@ -14199,13 +14171,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiny-xlib"
-version = "0.2.4"
+name = "tiny-skia-path"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0324504befd01cab6e0c994f34b2ffa257849ee019d3fb3b64fb2c858887d89e"
+checksum = "edca365c3faccca67d06593c5980fa6c57687de727a03131735bb85f01fdeeb9"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
+name = "tiny-xlib"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a90a0ca3ee6a69f2ad28fd11621a4c3f03b371f366be500b64df260c4ffbafb4"
 dependencies = [
  "as-raw-xcb-connection",
- "ctor-lite",
+ "ctor 0.10.1",
  "libloading 0.8.9",
  "pkg-config",
  "tracing",
@@ -14271,9 +14254,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -14409,7 +14392,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -14455,19 +14438,6 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.24.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01f2eadbbc6b377a847be05f60791ef1058d9f696ecb51d2c07fe911d8569d8e"
-dependencies = [
- "indexmap 2.14.0",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
@@ -14475,7 +14445,8 @@ dependencies = [
  "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.1",
+ "toml_writer",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -14484,7 +14455,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -14620,7 +14591,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http 1.4.0",
@@ -14671,11 +14642,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
+ "symlink",
  "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
@@ -14978,9 +14950,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "typeshare"
@@ -15006,9 +14978,9 @@ dependencies = [
 
 [[package]]
 name = "typewit"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc19094686c694eb41b3b99dcc2f2975d4b078512fa22ae6c63f7ca318bdcff7"
+checksum = "214ca0b2191785cbc06209b9ca1861e048e39b5ba33574b3cedd58363d5bb5f6"
 
 [[package]]
 name = "ucd-trie"
@@ -15381,7 +15353,7 @@ dependencies = [
  "siphasher",
  "strict-num",
  "svgtypes 0.15.3",
- "tiny-skia-path",
+ "tiny-skia-path 0.11.4",
  "unicode-bidi",
  "unicode-script",
  "unicode-vo",
@@ -15390,9 +15362,9 @@ dependencies = [
 
 [[package]]
 name = "usvg"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e419dff010bb12512b0ae9e3d2f318dfbdf0167fde7eb05465134d4e8756076f"
+checksum = "d46cf96c5f498d36b7a9693bc6a7075c0bb9303189d61b2249b0dc3d309c07de"
 dependencies = [
  "base64 0.22.1",
  "data-url",
@@ -15408,7 +15380,8 @@ dependencies = [
  "siphasher",
  "strict-num",
  "svgtypes 0.16.1",
- "tiny-skia-path",
+ "tiny-skia-path 0.12.0",
+ "ttf-parser 0.25.1",
  "unicode-bidi",
  "unicode-script",
  "unicode-vo",
@@ -15435,9 +15408,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -15597,9 +15570,9 @@ dependencies = [
 
 [[package]]
 name = "vtable"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "753be81c38dff787d177b5939af1fa16f72f0d0d21a6b7d74ae56e29cd26f2a6"
+checksum = "5ea953f65593feb5287b022b83c35046d1ff49c7417b6f5851a079d8a231fe31"
 dependencies = [
  "const-field-offset",
  "portable-atomic",
@@ -15609,9 +15582,9 @@ dependencies = [
 
 [[package]]
 name = "vtable-macro"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cfcf6171aa2b0f85718ca5888ca32f6edf61d1849f8e4b3786ad890e5b68f68"
+checksum = "482a37f9777480673d3a99c80ac2edc69f92382230440946855fa27ebc47cba6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -15689,11 +15662,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -15702,7 +15675,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -15857,7 +15830,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver 1.0.28",
@@ -15897,7 +15870,7 @@ version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "rustix 1.1.4",
  "wayland-backend",
  "wayland-scanner",
@@ -15909,7 +15882,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cursor-icon",
  "wayland-backend",
 ]
@@ -15931,7 +15904,7 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -15943,7 +15916,7 @@ version = "0.32.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -15955,7 +15928,7 @@ version = "20250721.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40a1f863128dcaaec790d7b4b396cc9b9a7a079e878e18c47e6c2d2c5a8dcbb1"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols 0.32.12",
@@ -15968,7 +15941,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9567599ef23e09b8dad6e429e5738d4509dfc46b3b21f32841a304d16b29c8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols 0.32.12",
@@ -15981,7 +15954,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23803551115ff9ea9bce586860c5c5a971e360825a0309264102a9495a5ff479"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols 0.31.2",
@@ -15994,7 +15967,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b6d8cf1eb2c1c31ed1f5643c88a6e53538129d4af80030c8cabd1f9fa884d91"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols 0.32.12",
@@ -16007,7 +15980,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols 0.32.12",
@@ -16058,19 +16031,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-root-certs"
-version = "1.0.6"
+name = "webbrowser"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
+dependencies = [
+ "core-foundation 0.10.0",
+ "jni 0.22.4",
+ "log",
+ "ndk-context",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "url",
+ "web-sys",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -16145,16 +16134,6 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
-dependencies = [
- "windows-core 0.58.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -16223,19 +16202,6 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
-dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
@@ -16295,17 +16261,6 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
@@ -16320,17 +16275,6 @@ name = "windows-interface"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -16413,15 +16357,6 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
@@ -16436,16 +16371,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -16799,7 +16724,7 @@ dependencies = [
  "ahash",
  "android-activity",
  "atomic-waker",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "block2 0.5.1",
  "bytemuck",
  "calloop 0.13.0",
@@ -16853,9 +16778,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
@@ -16903,6 +16828,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -16953,7 +16884,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "indexmap 2.14.0",
  "log",
  "serde",
@@ -17009,15 +16940,15 @@ checksum = "beffa227304dbaea3ad6a06ac674f9bc83a3dec3b7f63eeb442de37e7cb6bb01"
 
 [[package]]
 name = "write-fonts"
-version = "0.43.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "886614b5ce857341226aa091f3c285e450683894acaaa7887f366c361efef79d"
+checksum = "f12725b0845073e20b04e79b500dbfb465904d7cbd84883a1f1bbd084debc515"
 dependencies = [
- "font-types 0.10.1",
+ "font-types",
  "indexmap 2.14.0",
- "kurbo 0.12.0",
+ "kurbo 0.13.0",
  "log",
- "read-fonts 0.35.0",
+ "read-fonts",
 ]
 
 [[package]]
@@ -17208,7 +17139,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dcee45f89572d5a65180af3a84e7ddb24f5ea690a6d3aa9de231281544dd7b7"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -17240,7 +17171,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "dlib",
  "log",
  "once_cell",
@@ -17312,7 +17243,7 @@ dependencies = [
  "alloy-sol-type-parser",
  "alloy-sol-types",
  "alloy-transport-http",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytes",
  "cc",
  "chrono",
@@ -17321,6 +17252,7 @@ dependencies = [
  "clap_builder",
  "const-hex",
  "crypto-common",
+ "ctor 0.10.1",
  "derive_more 2.1.1",
  "digest 0.10.7",
  "ed25519-dalek",
@@ -17358,7 +17290,7 @@ dependencies = [
  "proc-macro2",
  "proptest",
  "rand 0.10.1",
- "rand 0.9.3",
+ "rand 0.9.4",
  "rand_chacha 0.10.0",
  "rand_chacha 0.3.1",
  "rand_chacha 0.9.0",
@@ -17393,7 +17325,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "winnow 0.7.15",
- "winnow 1.0.1",
+ "winnow 1.0.2",
  "zerocopy",
 ]
 
@@ -17404,7 +17336,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "const-hex",
- "ctor 0.10.0",
+ "ctor 0.10.1",
  "futures",
  "http 1.4.0",
  "prost",
@@ -17431,7 +17363,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "const-hex",
- "ctor 0.10.0",
+ "ctor 0.10.1",
  "derive_builder",
  "futures",
  "futures-test",
@@ -17567,7 +17499,7 @@ dependencies = [
  "console_error_panic_hook",
  "const-hex",
  "const_panic",
- "ctor 0.10.0",
+ "ctor 0.10.1",
  "fdlimit",
  "futures",
  "getrandom 0.4.2",
@@ -17636,7 +17568,7 @@ dependencies = [
  "alloy",
  "bincode 1.3.3",
  "const-hex",
- "ctor 0.10.0",
+ "ctor 0.10.1",
  "ed25519-dalek",
  "futures-timer",
  "getrandom 0.2.17",
@@ -17667,7 +17599,7 @@ dependencies = [
  "bincode 1.3.3",
  "bon",
  "const-hex",
- "ctor 0.10.0",
+ "ctor 0.10.1",
  "derive_builder",
  "diesel",
  "diesel_migrations",
@@ -17728,7 +17660,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "const-hex",
- "ctor 0.10.0",
+ "ctor 0.10.1",
  "ed25519-dalek",
  "futures",
  "gloo-timers 0.4.0",
@@ -17782,7 +17714,7 @@ dependencies = [
  "const-hex",
  "coset",
  "criterion",
- "ctor 0.10.0",
+ "ctor 0.10.1",
  "derive_builder",
  "diesel",
  "dyn-clone",
@@ -17881,7 +17813,7 @@ dependencies = [
  "chrono",
  "color-eyre",
  "const-hex",
- "ctor 0.10.0",
+ "ctor 0.10.1",
  "derive_builder",
  "ed25519-dalek",
  "futures",
@@ -17923,7 +17855,7 @@ dependencies = [
  "chrono",
  "const-hex",
  "criterion",
- "ctor 0.10.0",
+ "ctor 0.10.1",
  "fdlimit",
  "futures",
  "paranoid-android",
@@ -18211,7 +18143,7 @@ version = "0.14.1-zed"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3898e450f36f852edda72e3f985c34426042c4951790b23b107f93394f9bff5"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "byteorder",
  "core-foundation 0.10.0",
  "core-graphics 0.24.0",
@@ -18291,7 +18223,7 @@ dependencies = [
  "core-graphics-helmer-fork",
  "log",
  "objc",
- "rand 0.8.5",
+ "rand 0.8.6",
  "screencapturekit",
  "screencapturekit-sys",
  "sysinfo",
@@ -18404,6 +18336,7 @@ dependencies = [
  "displaydoc",
  "yoke",
  "zerofrom",
+ "zerovec",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1991,7 +1991,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_node"
-version = "1.10.0-mpre1"
+version = "1.10.0"
 dependencies = [
  "async-trait",
  "bindings_node",
@@ -2025,7 +2025,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_wasm"
-version = "1.10.0-mpre1"
+version = "1.10.0"
 dependencies = [
  "alloy",
  "async-trait",
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "bindings_wasm_macros"
-version = "1.10.0-mpre1"
+version = "1.10.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4507,7 +4507,7 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "error_glossary"
-version = "1.10.0-mpre1"
+version = "1.10.0"
 dependencies = [
  "clap",
  "syn 2.0.117",
@@ -8721,7 +8721,7 @@ dependencies = [
 
 [[package]]
 name = "log_parser"
-version = "1.10.0-mpre1"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9129,7 +9129,7 @@ dependencies = [
 
 [[package]]
 name = "mls_validation_service"
-version = "1.10.0-mpre1"
+version = "1.10.0"
 dependencies = [
  "alloy",
  "async-trait",
@@ -17139,7 +17139,7 @@ checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
 
 [[package]]
 name = "xdbg"
-version = "1.10.0-mpre1"
+version = "1.10.0"
 dependencies = [
  "alloy",
  "chrono",
@@ -17278,7 +17278,7 @@ checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "xmtp-db-tools"
-version = "1.10.0-mpre1"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -17399,7 +17399,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api"
-version = "1.10.0-mpre1"
+version = "1.10.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -17425,7 +17425,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_d14n"
-version = "1.10.0-mpre1"
+version = "1.10.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -17466,7 +17466,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_api_grpc"
-version = "1.10.0-mpre1"
+version = "1.10.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -17499,7 +17499,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_archive"
-version = "1.10.0-mpre1"
+version = "1.10.0"
 dependencies = [
  "aes-gcm",
  "async-compression",
@@ -17528,7 +17528,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_cli"
-version = "1.10.0-mpre1"
+version = "1.10.0"
 dependencies = [
  "alloy",
  "chrono",
@@ -17561,7 +17561,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_common"
-version = "1.10.0-mpre1"
+version = "1.10.0"
 dependencies = [
  "async-trait",
  "console_error_panic_hook",
@@ -17600,7 +17600,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_configuration"
-version = "1.10.0-mpre1"
+version = "1.10.0"
 dependencies = [
  "openmls",
  "xmtp-workspace-hack",
@@ -17610,7 +17610,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_content_types"
-version = "1.10.0-mpre1"
+version = "1.10.0"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
@@ -17631,7 +17631,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_cryptography"
-version = "1.10.0-mpre1"
+version = "1.10.0"
 dependencies = [
  "alloy",
  "bincode 1.3.3",
@@ -17660,7 +17660,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_db"
-version = "1.10.0-mpre1"
+version = "1.10.0"
 dependencies = [
  "arc-swap",
  "ascii_table",
@@ -17707,7 +17707,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_db_test"
-version = "1.10.0-mpre1"
+version = "1.10.0"
 dependencies = [
  "derive_builder",
  "diesel",
@@ -17721,7 +17721,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_id"
-version = "1.10.0-mpre1"
+version = "1.10.0"
 dependencies = [
  "alloy",
  "async-trait",
@@ -17757,7 +17757,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_macro"
-version = "1.10.0-mpre1"
+version = "1.10.0"
 dependencies = [
  "num_cpus",
  "proc-macro2",
@@ -17770,7 +17770,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_mls"
-version = "1.10.0-mpre1"
+version = "1.10.0"
 dependencies = [
  "aes-gcm",
  "alloy",
@@ -17852,7 +17852,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_mls_common"
-version = "1.10.0-mpre1"
+version = "1.10.0"
 dependencies = [
  "bon",
  "const-hex",
@@ -17874,7 +17874,7 @@ dependencies = [
 
 [[package]]
 name = "xmtp_proto"
-version = "1.10.0-mpre1"
+version = "1.10.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -17916,7 +17916,7 @@ dependencies = [
 
 [[package]]
 name = "xmtpv3"
-version = "1.10.0-mpre1"
+version = "1.10.0"
 dependencies = [
  "alloy",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ resolver = "3"
 
 [workspace.package]
 license = "MIT"
-version = "1.10.0"
+version = "1.10.0-mpre1"
 rust-version = "1.94.0"
 publish = false
 edition = "2024"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ resolver = "3"
 
 [workspace.package]
 license = "MIT"
-version = "1.10.0-mpre1"
+version = "1.10.0"
 rust-version = "1.94.0"
 publish = false
 edition = "2024"

--- a/bindings/mobile/src/mls.rs
+++ b/bindings/mobile/src/mls.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use crate::fork_recovery::FfiForkRecoveryOpts;
 use crate::identity::{FfiCollectionExt, FfiCollectionTryExt, FfiIdentifier};
 pub use crate::inbox_owner::SigningError;
@@ -130,9 +132,8 @@ impl XmtpApiClient {
 }
 
 /// connect to the XMTP backend
-/// specifying `gateway_host` enables the D14n backend
-/// and assumes `host` is set to the correct
-/// d14n backend url.
+/// Not specifying `gateway_host` uses the default gateway.
+/// This builds a client that will auto-migrate on D14n cutover date.
 #[uniffi::export(async_runtime = "tokio")]
 pub async fn connect_to_backend(
     v3_host: String,
@@ -141,6 +142,57 @@ pub async fn connect_to_backend(
     app_version: Option<String>,
     auth_callback: Option<Arc<dyn gateway_auth::FfiAuthCallback>>,
     auth_handle: Option<Arc<gateway_auth::FfiAuthHandle>>,
+) -> Result<Arc<XmtpApiClient>, FfiError> {
+    connect_to_backend_internal(
+        v3_host,
+        gateway_host,
+        client_mode,
+        app_version,
+        auth_callback,
+        auth_handle,
+        false,
+    )
+    .await
+}
+
+/// connect to the XMTP backend
+/// specifying `gateway_host` enables the D14n backend
+/// and assumes `host` is set to the correct
+/// d14n backend url. This will exclusively use
+/// v3 or d14n and _will not migrate_. it is
+/// provided for the convenience of testing v3/d14n
+/// but should not be used and will be removed on cutover.
+#[deprecated]
+#[uniffi::export(async_runtime = "tokio")]
+pub async fn connect_to_backend_exclusive(
+    v3_host: String,
+    gateway_host: Option<String>,
+    client_mode: Option<FfiClientMode>,
+    app_version: Option<String>,
+    auth_callback: Option<Arc<dyn gateway_auth::FfiAuthCallback>>,
+    auth_handle: Option<Arc<gateway_auth::FfiAuthHandle>>,
+) -> Result<Arc<XmtpApiClient>, FfiError> {
+    connect_to_backend_internal(
+        v3_host,
+        gateway_host,
+        client_mode,
+        app_version,
+        auth_callback,
+        auth_handle,
+        true,
+    )
+    .await
+}
+
+#[uniffi::export(async_runtime = "tokio")]
+async fn connect_to_backend_internal(
+    v3_host: String,
+    gateway_host: Option<String>,
+    client_mode: Option<FfiClientMode>,
+    app_version: Option<String>,
+    auth_callback: Option<Arc<dyn gateway_auth::FfiAuthCallback>>,
+    auth_handle: Option<Arc<gateway_auth::FfiAuthHandle>>,
+    exclusive: bool,
 ) -> Result<Arc<XmtpApiClient>, FfiError> {
     init_logger();
 
@@ -163,9 +215,11 @@ pub async fn connect_to_backend(
         )
         .readonly(matches!(client_mode, FfiClientMode::Notification))
         .maybe_auth_handle(auth_handle.map(|handle| handle.as_ref().clone().into()));
-    // switch v3/d14n based on presence of gateway host to preserve
-    // previous behavior and avoid breaking changes
-    let client_bundle = client_bundle.build()?;
+    let client_bundle = if exclusive {
+        client_bundle.build_optional_d14n()
+    } else {
+        client_bundle.build()
+    }?;
     let backend = MessageBackendBuilder::default().from_bundle(client_bundle.clone())?;
     let api: ApiClientWrapper<xmtp_mls::XmtpApiClient> =
         ApiClientWrapper::new(backend, strategies::exponential_cooldown());

--- a/bindings/mobile/src/mls.rs
+++ b/bindings/mobile/src/mls.rs
@@ -165,7 +165,7 @@ pub async fn connect_to_backend(
         .maybe_auth_handle(auth_handle.map(|handle| handle.as_ref().clone().into()));
     // switch v3/d14n based on presence of gateway host to preserve
     // previous behavior and avoid breaking changes
-    let client_bundle = client_bundle.build_optional_d14n()?;
+    let client_bundle = client_bundle.build()?;
     let backend = MessageBackendBuilder::default().from_bundle(client_bundle.clone())?;
     let api: ApiClientWrapper<xmtp_mls::XmtpApiClient> =
         ApiClientWrapper::new(backend, strategies::exponential_cooldown());

--- a/bindings/mobile/src/mls/test_utils.rs
+++ b/bindings/mobile/src/mls/test_utils.rs
@@ -147,22 +147,16 @@ impl LocalTester for Tester<PrivateKeySigner, FfiXmtpClient> {
 }
 
 pub async fn connect_to_backend_test() -> Arc<super::XmtpApiClient> {
-    if cfg!(feature = "d14n") {
-        connect_to_backend(
-            GrpcUrls::NODE.to_string(),
-            Some(GrpcUrls::GATEWAY.to_string()),
-            None,
-            None,
-            None,
-            None,
-        )
-        .await
-        .unwrap()
-    } else {
-        connect_to_backend(GrpcUrls::NODE.to_string(), None, None, None, None, None)
-            .await
-            .unwrap()
-    }
+    connect_to_backend(
+        GrpcUrls::NODE.to_string(),
+        Some(GrpcUrls::GATEWAY.to_string()),
+        None,
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap()
 }
 
 async fn create_raw_client<Owner>(builder: &TesterBuilder<Owner>) -> FfiXmtpClient

--- a/bindings/mobile/src/mls/tests/networking.rs
+++ b/bindings/mobile/src/mls/tests/networking.rs
@@ -214,7 +214,7 @@ async fn test_is_connected_after_connect() {
 
     let api = connect_to_backend(
         "http://127.0.0.1:59999".to_string(),
-        Some("http://127.0.0:69999".to_string()),
+        Some("http://127.0.0.1:49999".to_string()),
         None,
         None,
         None,

--- a/bindings/mobile/src/mls/tests/networking.rs
+++ b/bindings/mobile/src/mls/tests/networking.rs
@@ -214,7 +214,7 @@ async fn test_is_connected_after_connect() {
 
     let api = connect_to_backend(
         "http://127.0.0.1:59999".to_string(),
-        None,
+        Some("http://127.0.0:69999".to_string()),
         None,
         None,
         None,

--- a/bindings/node/src/client/backend.rs
+++ b/bindings/node/src/client/backend.rs
@@ -66,12 +66,24 @@ impl BackendBuilder {
       .map_err(|_| napi::Error::from_reason("BackendBuilder lock poisoned"))?
       .take();
 
+    // MigrationXnet: substitute hardcoded xnet hosts when the caller did not
+    // supply their own. Explicit api_url / gateway_host always take precedence.
+    let (mut api_url, mut gateway_host) = (self.api_url.clone(), self.gateway_host.clone());
+    if let Some((v3, gw)) = self.env.xnet_hosts() {
+      if api_url.is_none() {
+        api_url = Some(v3.to_string());
+      }
+      if gateway_host.is_none() {
+        gateway_host = Some(gw.to_string());
+      }
+    }
+
     let app_version = self.app_version.clone().unwrap_or_default();
     let mut builder = ClientBundleBuilder::default();
     builder
       .env(self.env.into())
-      .maybe_v3_host(self.api_url.clone())
-      .maybe_gateway_host(self.gateway_host.clone())
+      .maybe_v3_host(api_url.clone())
+      .maybe_gateway_host(gateway_host.clone())
       .readonly(self.readonly.unwrap_or(false))
       .app_version(app_version.clone())
       .maybe_auth_callback(
@@ -89,7 +101,7 @@ impl BackendBuilder {
       bundle,
       env: self.env,
       v3_host,
-      gateway_host: self.gateway_host.clone(),
+      gateway_host,
       app_version,
     })
   }

--- a/bindings/node/src/client/backend.rs
+++ b/bindings/node/src/client/backend.rs
@@ -80,7 +80,11 @@ impl BackendBuilder {
       .maybe_auth_handle(auth_handle.map(|h: AuthHandle| h.into()));
 
     let v3_host = builder.get_v3_host().map(ToString::to_string);
-    let bundle = builder.build_optional_d14n().map_err(ErrorWrapper::from)?;
+    let bundle = if self.env.is_migration() {
+      builder.build().map_err(ErrorWrapper::from)?
+    } else {
+      builder.build_optional_d14n().map_err(ErrorWrapper::from)?
+    };
     Ok(Backend {
       bundle,
       env: self.env,

--- a/bindings/node/src/client/create_client.rs
+++ b/bindings/node/src/client/create_client.rs
@@ -178,12 +178,15 @@ async fn create_client_inner(
  * Optionally specify a filter for the log level as a string.
  * It can be one of: `debug`, `info`, `warn`, `error` or 'off'.
  * By default, logging is disabled.
+ *
+ * Defaults to creating a Migration-enabled client. if this is not the deisred behavior,
+ * prefer using `create_client_with_backend` to choose the backend explicitly.
  */
 #[allow(clippy::too_many_arguments)]
 #[napi]
 pub async fn create_client(
   v3_host: String,
-  gateway_host: Option<String>,
+  gateway_host: String,
   db: DbOptions,
   inbox_id: String,
   account_identifier: Identifier,
@@ -202,7 +205,7 @@ pub async fn create_client(
   let mut backend = MessageBackendBuilder::default();
   backend
     .v3_host(&v3_host)
-    .maybe_gateway_host(gateway_host)
+    .gateway_host(gateway_host)
     .readonly(matches!(client_mode, ClientMode::Notification))
     .maybe_auth_callback(auth_callback.map(|c| Arc::new(c.clone()) as _))
     .maybe_auth_handle(auth_handle.map(|h| h.clone().into()))
@@ -213,14 +216,8 @@ pub async fn create_client(
 
   let cursor_store = SqliteCursorStore::new(store.db());
   backend.cursor_store(cursor_store);
-  let api_client = backend
-    .clone()
-    .build_optional_d14n()
-    .map_err(ErrorWrapper::from)?;
-  let sync_api_client = backend
-    .clone()
-    .build_optional_d14n()
-    .map_err(ErrorWrapper::from)?;
+  let api_client = backend.clone().build().map_err(ErrorWrapper::from)?;
+  let sync_api_client = backend.clone().build().map_err(ErrorWrapper::from)?;
 
   create_client_inner(
     api_client,

--- a/bindings/node/src/client/options.rs
+++ b/bindings/node/src/client/options.rs
@@ -1,5 +1,5 @@
 use napi_derive::napi;
-use xmtp_configuration::XmtpEnv as CoreXmtpEnv;
+use xmtp_configuration::{GrpcUrlsXnet, XmtpEnv as CoreXmtpEnv};
 use xmtp_mls::builder::DeviceSyncMode as XmtpSyncWorkerMode;
 
 #[napi(string_enum)]
@@ -65,14 +65,31 @@ pub enum XmtpEnv {
   MigrationLocal,
   MigrationStaging,
   MigrationProduction,
+  MigrationXnet,
 }
 
 impl XmtpEnv {
   pub fn is_migration(&self) -> bool {
     matches!(
       self,
-      Self::MigrationLocal | Self::MigrationStaging | Self::MigrationProduction
+      Self::MigrationLocal
+        | Self::MigrationStaging
+        | Self::MigrationProduction
+        | Self::MigrationXnet
     )
+  }
+
+  pub fn is_migration_xnet(&self) -> bool {
+    matches!(self, Self::MigrationXnet)
+  }
+
+  /// Returns `(v3_host, gateway_host)` for `MigrationXnet`, else `None`.
+  pub fn xnet_hosts(&self) -> Option<(&'static str, &'static str)> {
+    if self.is_migration_xnet() {
+      Some((GrpcUrlsXnet::NODE, GrpcUrlsXnet::GATEWAY))
+    } else {
+      None
+    }
   }
 }
 
@@ -89,6 +106,9 @@ impl From<XmtpEnv> for CoreXmtpEnv {
       XmtpEnv::MigrationLocal => Self::Local,
       XmtpEnv::MigrationStaging => Self::TestnetStaging,
       XmtpEnv::MigrationProduction => Self::Production,
+      // MigrationXnet uses runtime-selected hosts (see xnet_hosts); any
+      // env-derived URL is bypassed, so Production is a neutral placeholder.
+      XmtpEnv::MigrationXnet => Self::Production,
     }
   }
 }

--- a/bindings/node/src/client/options.rs
+++ b/bindings/node/src/client/options.rs
@@ -62,6 +62,18 @@ pub enum XmtpEnv {
   TestnetDev,
   Testnet,
   Mainnet,
+  MigrationLocal,
+  MigrationStaging,
+  MigrationProduction,
+}
+
+impl XmtpEnv {
+  pub fn is_migration(&self) -> bool {
+    matches!(
+      self,
+      Self::MigrationLocal | Self::MigrationStaging | Self::MigrationProduction
+    )
+  }
 }
 
 impl From<XmtpEnv> for CoreXmtpEnv {
@@ -74,6 +86,9 @@ impl From<XmtpEnv> for CoreXmtpEnv {
       XmtpEnv::TestnetDev => Self::TestnetDev,
       XmtpEnv::Testnet => Self::Testnet,
       XmtpEnv::Mainnet => Self::Mainnet,
+      XmtpEnv::MigrationLocal => Self::Local,
+      XmtpEnv::MigrationStaging => Self::TestnetStaging,
+      XmtpEnv::MigrationProduction => Self::Production,
     }
   }
 }

--- a/bindings/node/src/test_utils.rs
+++ b/bindings/node/src/test_utils.rs
@@ -36,7 +36,7 @@ pub async fn create_local_toxic_client(
 
   let c = create_client(
     api_addr,
-    None,
+    GrpcUrlsToxic::GATEWAY.to_string(),
     DbOptions::new(db_path, encryption_key, None, None),
     inbox_id,
     account_identifier,

--- a/bindings/node/test/Builder.test.ts
+++ b/bindings/node/test/Builder.test.ts
@@ -22,6 +22,22 @@ describe('BackendBuilder', () => {
     await builder.build()
     await expect(builder.build()).rejects.toThrow('already been consumed')
   })
+
+  it('should build a MigrationXnet Backend with hardcoded xnet hosts', async () => {
+    const backend = await new BackendBuilder(XmtpEnv.MigrationXnet).build()
+    expect(backend.env).toBe(XmtpEnv.MigrationXnet)
+    expect(backend.v3Host).toBe('https://node-go.xmtp.run')
+    expect(backend.gatewayHost).toBe('https://gateway.xmtp.run')
+  })
+
+  it('should let explicit hosts override MigrationXnet defaults', async () => {
+    const backend = await new BackendBuilder(XmtpEnv.MigrationXnet)
+      .setApiUrl('http://localhost:5556')
+      .setGatewayHost('http://localhost:5052')
+      .build()
+    expect(backend.v3Host).toBe('http://localhost:5556')
+    expect(backend.gatewayHost).toBe('http://localhost:5052')
+  })
 })
 
 describe('NapiTestBuilder', () => {

--- a/bindings/wasm/src/client.rs
+++ b/bindings/wasm/src/client.rs
@@ -10,6 +10,7 @@ use tracing_subscriber::{filter, fmt::format::Pretty};
 use tsify::Tsify;
 use wasm_bindgen::{JsValue, prelude::*};
 use xmtp_api_d14n::MessageBackendBuilder;
+use xmtp_configuration::GrpcUrlsXnet;
 use xmtp_db::{EncryptedMessageStore, StorageOption, WasmDb};
 use xmtp_id::associations::Identifier as XmtpIdentifier;
 use xmtp_mls::Client as MlsClient;
@@ -105,14 +106,31 @@ pub enum XmtpEnv {
   MigrationLocal = 7,
   MigrationStaging = 8,
   MigrationProduction = 9,
+  MigrationXnet = 10,
 }
 
 impl XmtpEnv {
   pub fn is_migration(&self) -> bool {
     matches!(
       self,
-      Self::MigrationLocal | Self::MigrationStaging | Self::MigrationProduction
+      Self::MigrationLocal
+        | Self::MigrationStaging
+        | Self::MigrationProduction
+        | Self::MigrationXnet
     )
+  }
+
+  pub fn is_migration_xnet(&self) -> bool {
+    matches!(self, Self::MigrationXnet)
+  }
+
+  /// Returns `(v3_host, gateway_host)` for `MigrationXnet`, else `None`.
+  pub fn xnet_hosts(&self) -> Option<(&'static str, &'static str)> {
+    if self.is_migration_xnet() {
+      Some((GrpcUrlsXnet::NODE, GrpcUrlsXnet::GATEWAY))
+    } else {
+      None
+    }
   }
 }
 
@@ -129,6 +147,8 @@ impl From<XmtpEnv> for xmtp_configuration::XmtpEnv {
       XmtpEnv::MigrationLocal => Self::Local,
       XmtpEnv::MigrationStaging => Self::TestnetStaging,
       XmtpEnv::MigrationProduction => Self::Production,
+      // MigrationXnet uses runtime-selected hosts; Production is a neutral placeholder.
+      XmtpEnv::MigrationXnet => Self::Production,
     }
   }
 }

--- a/bindings/wasm/src/client.rs
+++ b/bindings/wasm/src/client.rs
@@ -102,6 +102,18 @@ pub enum XmtpEnv {
   TestnetDev = 4,
   Testnet = 5,
   Mainnet = 6,
+  MigrationLocal = 7,
+  MigrationStaging = 8,
+  MigrationProduction = 9,
+}
+
+impl XmtpEnv {
+  pub fn is_migration(&self) -> bool {
+    matches!(
+      self,
+      Self::MigrationLocal | Self::MigrationStaging | Self::MigrationProduction
+    )
+  }
 }
 
 impl From<XmtpEnv> for xmtp_configuration::XmtpEnv {
@@ -114,6 +126,9 @@ impl From<XmtpEnv> for xmtp_configuration::XmtpEnv {
       XmtpEnv::TestnetDev => Self::TestnetDev,
       XmtpEnv::Testnet => Self::Testnet,
       XmtpEnv::Mainnet => Self::Mainnet,
+      XmtpEnv::MigrationLocal => Self::Local,
+      XmtpEnv::MigrationStaging => Self::TestnetStaging,
+      XmtpEnv::MigrationProduction => Self::Production,
     }
   }
 }

--- a/bindings/wasm/src/client/backend.rs
+++ b/bindings/wasm/src/client/backend.rs
@@ -38,12 +38,24 @@ impl BackendBuilder {
 
   #[wasm_bindgen]
   pub fn build(mut self) -> Result<Backend, JsError> {
+    // MigrationXnet: substitute hardcoded xnet hosts when the caller did not
+    // supply their own. Explicit api_url / gateway_host always take precedence.
+    let (mut api_url, mut gateway_host) = (self.api_url.clone(), self.gateway_host.clone());
+    if let Some((v3, gw)) = self.env.xnet_hosts() {
+      if api_url.is_none() {
+        api_url = Some(v3.to_string());
+      }
+      if gateway_host.is_none() {
+        gateway_host = Some(gw.to_string());
+      }
+    }
+
     let app_version = self.app_version.clone().unwrap_or_default();
     let mut builder = ClientBundleBuilder::default();
     builder
       .env(self.env.into())
-      .maybe_v3_host(self.api_url.clone())
-      .maybe_gateway_host(self.gateway_host.clone())
+      .maybe_v3_host(api_url.clone())
+      .maybe_gateway_host(gateway_host.clone())
       .readonly(self.readonly.unwrap_or_default())
       .app_version(app_version.clone())
       .maybe_auth_callback(
@@ -66,7 +78,7 @@ impl BackendBuilder {
       bundle,
       env: self.env,
       v3_host,
-      gateway_host: self.gateway_host.clone(),
+      gateway_host,
       app_version: app_version.clone(),
     })
   }

--- a/bindings/wasm/src/client/backend.rs
+++ b/bindings/wasm/src/client/backend.rs
@@ -55,9 +55,13 @@ impl BackendBuilder {
       .maybe_auth_handle(self.auth_handle.take().map(|h| h.handle));
 
     let v3_host = builder.get_v3_host().map(ToString::to_string);
-    let bundle = builder
-      .build_optional_d14n()
-      .map_err(|e| JsError::new(&e.to_string()))?;
+    let bundle = if self.env.is_migration() {
+      builder.build().map_err(|e| JsError::new(&e.to_string()))?
+    } else {
+      builder
+        .build_optional_d14n()
+        .map_err(|e| JsError::new(&e.to_string()))?
+    };
     Ok(Backend {
       bundle,
       env: self.env,

--- a/crates/xmtp-workspace-hack/Cargo.toml
+++ b/crates/xmtp-workspace-hack/Cargo.toml
@@ -36,6 +36,7 @@ clap = { version = "4", features = ["derive", "env"] }
 clap_builder = { version = "4", default-features = false, features = ["color", "env", "help", "std", "suggestions", "usage"] }
 const-hex = { version = "1", features = ["core-error", "serde"] }
 crypto-common = { version = "0.1", default-features = false, features = ["getrandom", "std"] }
+ctor = { version = "0.10" }
 derive_more = { version = "2", default-features = false, features = ["add", "add_assign", "as_ref", "deref", "deref_mut", "display", "from", "from_str", "index", "index_mut", "into", "into_iterator", "not", "std"] }
 digest = { version = "0.10", features = ["mac", "oid", "std"] }
 ed25519-dalek = { version = "2", features = ["digest", "rand_core"] }
@@ -53,7 +54,7 @@ hpke-rs = { version = "0.6", features = ["hazmat", "libcrux", "serialization"] }
 hyper = { version = "1", features = ["http1", "http2", "server"] }
 idna = { version = "1" }
 indexmap = { version = "2", features = ["serde"] }
-itertools = { version = "0.13" }
+itertools = { version = "0.14" }
 k256 = { version = "0.13", default-features = false, features = ["ecdh", "ecdsa", "std"] }
 log = { version = "0.4", default-features = false, features = ["std"] }
 memchr = { version = "2" }
@@ -122,6 +123,7 @@ clap = { version = "4", features = ["derive", "env"] }
 clap_builder = { version = "4", default-features = false, features = ["color", "env", "help", "std", "suggestions", "usage"] }
 const-hex = { version = "1", features = ["core-error", "serde"] }
 crypto-common = { version = "0.1", default-features = false, features = ["getrandom", "std"] }
+ctor = { version = "0.10" }
 derive_more = { version = "2", default-features = false, features = ["add", "add_assign", "as_ref", "deref", "deref_mut", "display", "from", "from_str", "index", "index_mut", "into", "into_iterator", "not", "std"] }
 digest = { version = "0.10", features = ["mac", "oid", "std"] }
 ed25519-dalek = { version = "2", features = ["digest", "rand_core"] }
@@ -139,7 +141,7 @@ hpke-rs = { version = "0.6", features = ["hazmat", "libcrux", "serialization"] }
 hyper = { version = "1", features = ["http1", "http2", "server"] }
 idna = { version = "1" }
 indexmap = { version = "2", features = ["serde"] }
-itertools = { version = "0.13" }
+itertools = { version = "0.14" }
 k256 = { version = "0.13", default-features = false, features = ["ecdh", "ecdsa", "std"] }
 log = { version = "0.4", default-features = false, features = ["std"] }
 memchr = { version = "2" }

--- a/crates/xmtp-workspace-hack/Cargo.toml
+++ b/crates/xmtp-workspace-hack/Cargo.toml
@@ -53,7 +53,7 @@ hpke-rs = { version = "0.6", features = ["hazmat", "libcrux", "serialization"] }
 hyper = { version = "1", features = ["http1", "http2", "server"] }
 idna = { version = "1" }
 indexmap = { version = "2", features = ["serde"] }
-itertools = { version = "0.14" }
+itertools = { version = "0.13" }
 k256 = { version = "0.13", default-features = false, features = ["ecdh", "ecdsa", "std"] }
 log = { version = "0.4", default-features = false, features = ["std"] }
 memchr = { version = "2" }
@@ -139,7 +139,7 @@ hpke-rs = { version = "0.6", features = ["hazmat", "libcrux", "serialization"] }
 hyper = { version = "1", features = ["http1", "http2", "server"] }
 idna = { version = "1" }
 indexmap = { version = "2", features = ["serde"] }
-itertools = { version = "0.14" }
+itertools = { version = "0.13" }
 k256 = { version = "0.13", default-features = false, features = ["ecdh", "ecdsa", "std"] }
 log = { version = "0.4", default-features = false, features = ["std"] }
 memchr = { version = "2" }

--- a/crates/xmtp_configuration/src/common/api.rs
+++ b/crates/xmtp_configuration/src/common/api.rs
@@ -135,6 +135,15 @@ if_native! {
     }
 }
 
+/// GRPC URLS corresponding to the xnet migration environment.
+/// Unlike the other `GrpcUrls*` structs, `NODE` is the same on native and wasm —
+/// the xnet node-go instance is a single public endpoint.
+pub struct GrpcUrlsXnet;
+impl GrpcUrlsXnet {
+    pub const NODE: &'static str = "https://node-go.xmtp.run";
+    pub const GATEWAY: &'static str = "https://gateway.xmtp.run";
+}
+
 // URLs connected to toxiproxy
 pub struct GrpcUrlsToxic;
 impl GrpcUrlsToxic {

--- a/dev/docker/docker-compose.yml
+++ b/dev/docker/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       - --mls-validation.grpc-address=validation:50051
       - --api.enable-mls
       - --wait-for-db=30s
+      - --api.enable-migration
+      - --api.d14n-cutover-ns=9223372036854775807
       # Disable authn until we have reliable support for generating auth tokens
       # - --api.authn.enable
     ports:

--- a/nix/lib/packages/swiftlint.nix
+++ b/nix/lib/packages/swiftlint.nix
@@ -6,7 +6,7 @@
   unzip,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "swiftlint";
   version = "0.62.1";
 

--- a/nix/package/ios.nix
+++ b/nix/package/ios.nix
@@ -97,6 +97,8 @@ let
           mkdir -p $out/${target}
           cp target/${target}/release/libxmtpv3.a $out/${target}/
           cp target/${target}/release/libxmtpv3.dylib $out/${target}/
+        '';
+        postFixup = ''
           install_name_tool -id @rpath/libxmtpv3.dylib $out/${target}/libxmtpv3.dylib
         '';
       }

--- a/nix/package/ios.nix
+++ b/nix/package/ios.nix
@@ -97,8 +97,6 @@ let
           mkdir -p $out/${target}
           cp target/${target}/release/libxmtpv3.a $out/${target}/
           cp target/${target}/release/libxmtpv3.dylib $out/${target}/
-        '';
-        postFixup = ''
           install_name_tool -id @rpath/libxmtpv3.dylib $out/${target}/libxmtpv3.dylib
         '';
       }

--- a/nix/shells/local.nix
+++ b/nix/shells/local.nix
@@ -98,6 +98,7 @@ mkShell (
         kotlin
         ktlint
         jdk17
+        swiftformat
         kotlin-language-server
 
         # Swift

--- a/nix/shells/local.nix
+++ b/nix/shells/local.nix
@@ -98,7 +98,6 @@ mkShell (
         kotlin
         ktlint
         jdk17
-        swiftformat
         kotlin-language-server
 
         # Swift

--- a/sdks/android/library/src/androidTest/java/org/xmtp/android/library/BaseInstrumentedTest.kt
+++ b/sdks/android/library/src/androidTest/java/org/xmtp/android/library/BaseInstrumentedTest.kt
@@ -70,7 +70,7 @@ abstract class BaseInstrumentedTest {
      */
     protected suspend fun createClient(
         account: SigningKey,
-        api: ClientOptions.Api = ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+        api: ClientOptions.Api = ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
         deviceSyncEnabled: Boolean = true,
     ): Client {
         val options = createClientOptions(api, deviceSyncEnabled = deviceSyncEnabled)
@@ -84,7 +84,7 @@ abstract class BaseInstrumentedTest {
      * Returns the 5 standard test clients: alix, bo, caro, davon, eri.
      */
     protected suspend fun createFixtures(
-        api: ClientOptions.Api = ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+        api: ClientOptions.Api = ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
     ): TestFixtures {
         //  Create accounts
         val alixAccount = PrivateKeyBuilder()

--- a/sdks/android/library/src/androidTest/java/org/xmtp/android/library/ClientTest.kt
+++ b/sdks/android/library/src/androidTest/java/org/xmtp/android/library/ClientTest.kt
@@ -37,7 +37,7 @@ class ClientTest : BaseInstrumentedTest() {
         val fakeWallet = PrivateKeyBuilder()
         val options =
             ClientOptions(
-                ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                 appContext = context,
                 dbEncryptionKey = key,
             )
@@ -73,7 +73,7 @@ class ClientTest : BaseInstrumentedTest() {
                 Client.build(
                     client.publicIdentity,
                     ClientOptions(
-                        api = ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                        api = ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                         dbEncryptionKey = dbEncryptionKey,
                         appContext = InstrumentationRegistry.getInstrumentation().targetContext,
                         dbDirectory = dbDir,
@@ -105,7 +105,7 @@ class ClientTest : BaseInstrumentedTest() {
         val fakeWallet = PrivateKeyBuilder()
         val options =
             ClientOptions(
-                ClientOptions.Api(XMTPEnvironment.LOCAL, false, "Testing/0.0.0"),
+                ClientOptions.Api(XMTPEnvironment.LOCAL, false, "Testing/0.0.0", gatewayHost = TestGateway.LOCAL),
                 appContext = context,
                 dbEncryptionKey = key,
             )
@@ -134,7 +134,7 @@ class ClientTest : BaseInstrumentedTest() {
             runBlocking {
                 Client.canMessage(
                     listOf(alixPublicIdentity, notOnNetworkPublicIdentity, boPublicIdentity),
-                    ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                    ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                 )
             }
 
@@ -157,7 +157,7 @@ class ClientTest : BaseInstrumentedTest() {
             runBlocking {
                 Client.inboxStatesForInboxIds(
                     listOf(fixtures.boClient.inboxId, fixtures.caroClient.inboxId),
-                    ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                    ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                 )
             }
         assertEquals(
@@ -182,7 +182,7 @@ class ClientTest : BaseInstrumentedTest() {
                     account = fakeWallet,
                     options =
                         ClientOptions(
-                            ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                            ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                             appContext = context,
                             dbEncryptionKey = key,
                         ),
@@ -194,7 +194,7 @@ class ClientTest : BaseInstrumentedTest() {
                     account = fakeWallet2,
                     options =
                         ClientOptions(
-                            ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                            ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                             appContext = context,
                             dbEncryptionKey = key,
                         ),
@@ -216,7 +216,7 @@ class ClientTest : BaseInstrumentedTest() {
                     account = fakeWallet,
                     options =
                         ClientOptions(
-                            ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                            ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                             appContext = context,
                             dbEncryptionKey = key,
                         ),
@@ -239,7 +239,7 @@ class ClientTest : BaseInstrumentedTest() {
                     account = fakeWallet,
                     options =
                         ClientOptions(
-                            ClientOptions.Api(XMTPEnvironment.DEV, true),
+                            ClientOptions.Api(XMTPEnvironment.DEV, true, gatewayHost = TestGateway.DEV),
                             appContext = context,
                             dbEncryptionKey = key,
                         ),
@@ -262,7 +262,7 @@ class ClientTest : BaseInstrumentedTest() {
                     account = fakeWallet,
                     options =
                         ClientOptions(
-                            ClientOptions.Api(XMTPEnvironment.PRODUCTION, true),
+                            ClientOptions.Api(XMTPEnvironment.PRODUCTION, true, gatewayHost = TestGateway.PRODUCTION),
                             appContext = context,
                             dbEncryptionKey = key,
                         ),
@@ -285,7 +285,7 @@ class ClientTest : BaseInstrumentedTest() {
 
         val opts =
             ClientOptions(
-                ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                 preAuthenticateToInboxCallback = preAuthenticateToInboxCallback,
                 appContext = context,
                 dbEncryptionKey = key,
@@ -311,7 +311,7 @@ class ClientTest : BaseInstrumentedTest() {
                     account = fakeWallet,
                     options =
                         ClientOptions(
-                            ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                            ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                             appContext = context,
                             dbEncryptionKey = key,
                         ),
@@ -323,7 +323,7 @@ class ClientTest : BaseInstrumentedTest() {
                     account = fakeWallet2,
                     options =
                         ClientOptions(
-                            ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                            ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                             appContext = context,
                             dbEncryptionKey = key,
                         ),
@@ -361,7 +361,7 @@ class ClientTest : BaseInstrumentedTest() {
                     account = alixWallet,
                     options =
                         ClientOptions(
-                            ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                            ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                             appContext = context,
                             dbEncryptionKey = key,
                         ),
@@ -373,7 +373,7 @@ class ClientTest : BaseInstrumentedTest() {
                     account = boWallet,
                     options =
                         ClientOptions(
-                            ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                            ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                             appContext = context,
                             dbEncryptionKey = key,
                         ),
@@ -400,7 +400,7 @@ class ClientTest : BaseInstrumentedTest() {
                     account = alixWallet,
                     options =
                         ClientOptions(
-                            ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                            ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                             appContext = context,
                             dbEncryptionKey = key,
                         ),
@@ -413,7 +413,7 @@ class ClientTest : BaseInstrumentedTest() {
                     account = alixWallet,
                     options =
                         ClientOptions(
-                            ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                            ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                             appContext = context,
                             dbEncryptionKey = key,
                             dbDirectory = context.filesDir.absolutePath.toString(),
@@ -427,7 +427,7 @@ class ClientTest : BaseInstrumentedTest() {
                     account = alixWallet,
                     options =
                         ClientOptions(
-                            ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                            ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                             appContext = context,
                             dbEncryptionKey = key,
                             dbDirectory =
@@ -460,7 +460,7 @@ class ClientTest : BaseInstrumentedTest() {
                     account = alixWallet,
                     options =
                         ClientOptions(
-                            ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                            ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                             appContext = context,
                             dbEncryptionKey = key,
                         ),
@@ -471,7 +471,7 @@ class ClientTest : BaseInstrumentedTest() {
                     account = alixWallet,
                     options =
                         ClientOptions(
-                            ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                            ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                             appContext = context,
                             dbEncryptionKey = key,
                             dbDirectory = context.filesDir.absolutePath.toString(),
@@ -485,7 +485,7 @@ class ClientTest : BaseInstrumentedTest() {
                     account = alixWallet,
                     options =
                         ClientOptions(
-                            ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                            ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                             appContext = context,
                             dbEncryptionKey = key,
                             dbDirectory =
@@ -523,13 +523,17 @@ class ClientTest : BaseInstrumentedTest() {
     @Test
     fun testsCanSeeKeyPackageStatus() {
         val fixtures = runBlocking { createFixtures() }
-        runBlocking { Client.connectToApiBackendExclusive(ClientOptions.Api(XMTPEnvironment.LOCAL, true)) }
+        runBlocking {
+            Client.connectToApiBackendExclusive(
+                ClientOptions.Api(XMTPEnvironment.LOCAL, true, gatewayHost = TestGateway.LOCAL),
+            )
+        }
         val inboxState =
             runBlocking {
                 Client
                     .inboxStatesForInboxIds(
                         listOf(fixtures.alixClient.inboxId),
-                        ClientOptions.Api(XMTPEnvironment.LOCAL, true),
+                        ClientOptions.Api(XMTPEnvironment.LOCAL, true, gatewayHost = TestGateway.LOCAL),
                     ).first()
             }
         val installationIds = inboxState.installations.map { it.installationId }
@@ -537,7 +541,7 @@ class ClientTest : BaseInstrumentedTest() {
             runBlocking {
                 Client.keyPackageStatusesForInstallationIds(
                     installationIds,
-                    ClientOptions.Api(XMTPEnvironment.LOCAL, true),
+                    ClientOptions.Api(XMTPEnvironment.LOCAL, true, gatewayHost = TestGateway.LOCAL),
                 )
             }
         for (installationId: String in keyPackageStatus.keys) {
@@ -586,14 +590,14 @@ class ClientTest : BaseInstrumentedTest() {
     //        val inboxState = runBlocking {
     //            Client.inboxStatesForInboxIds(
     //                listOf("f87420435131ea1b911ad66fbe4b626b107f81955da023d049f8aef6636b8e1b"),
-    //                ClientOptions.Api(XMTPEnvironment.DEV, true)
+    //                ClientOptions.Api(XMTPEnvironment.DEV, true, gatewayHost = TestGateway.DEV)
     //            ).first()
     //        }
     //        val installationIds = inboxState.installations.map { it.installationId }
     //        val keyPackageStatus = runBlocking {
     //            Client.keyPackageStatusesForInstallationIds(
     //                installationIds,
-    //                ClientOptions.Api(XMTPEnvironment.DEV, true)
+    //                ClientOptions.Api(XMTPEnvironment.DEV, true, gatewayHost = TestGateway.DEV)
     //            )
     //        }
     //        for (installationId: String in keyPackageStatus.keys) {
@@ -660,7 +664,7 @@ class ClientTest : BaseInstrumentedTest() {
                     account = fixtures.alixAccount,
                     options =
                         ClientOptions(
-                            ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                            ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                             appContext = context,
                             dbEncryptionKey = key,
                         ),
@@ -792,7 +796,7 @@ class ClientTest : BaseInstrumentedTest() {
                     account = alixWallet,
                     options =
                         ClientOptions(
-                            ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                            ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                             appContext = context,
                             dbEncryptionKey = key,
                         ),
@@ -812,7 +816,7 @@ class ClientTest : BaseInstrumentedTest() {
                         ),
                     options =
                         ClientOptions(
-                            ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                            ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                             appContext = context,
                             dbEncryptionKey = badKey,
                         ),
@@ -829,7 +833,7 @@ class ClientTest : BaseInstrumentedTest() {
                     account = alixWallet,
                     options =
                         ClientOptions(
-                            ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                            ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                             appContext = context,
                             dbEncryptionKey = badKey,
                         ),
@@ -845,7 +849,7 @@ class ClientTest : BaseInstrumentedTest() {
         val fakeWallet = PrivateKeyBuilder()
         val options =
             ClientOptions(
-                ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                 appContext = context,
                 dbEncryptionKey = key,
             )
@@ -883,7 +887,7 @@ class ClientTest : BaseInstrumentedTest() {
 
             val options =
                 ClientOptions(
-                    ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                    ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                     appContext = context,
                     dbEncryptionKey = key,
                 )
@@ -923,7 +927,7 @@ class ClientTest : BaseInstrumentedTest() {
                     account = alixWallet,
                     options =
                         ClientOptions(
-                            ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                            ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                             appContext = context,
                             dbEncryptionKey = key,
                         ),
@@ -934,7 +938,7 @@ class ClientTest : BaseInstrumentedTest() {
                     account = alixWallet,
                     options =
                         ClientOptions(
-                            ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                            ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                             appContext = context,
                             dbEncryptionKey = key,
                             dbDirectory = context.filesDir.absolutePath.toString(),
@@ -946,7 +950,7 @@ class ClientTest : BaseInstrumentedTest() {
                         account = alixWallet,
                         options =
                             ClientOptions(
-                                ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                                ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                                 appContext = context,
                                 dbEncryptionKey = key,
                                 dbDirectory =
@@ -1013,7 +1017,7 @@ class ClientTest : BaseInstrumentedTest() {
                         account = fakeWallet,
                         options =
                             ClientOptions(
-                                ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                                ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                                 appContext = context,
                                 dbEncryptionKey = key,
                             ),
@@ -1073,7 +1077,7 @@ class ClientTest : BaseInstrumentedTest() {
                     account = alixWallet,
                     options =
                         ClientOptions(
-                            ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                            ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                             appContext = context,
                             dbEncryptionKey = key,
                         ),
@@ -1122,7 +1126,7 @@ class ClientTest : BaseInstrumentedTest() {
                         account = wallet,
                         options =
                             ClientOptions(
-                                ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                                ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                                 appContext = context,
                                 dbEncryptionKey = encryptionKey,
                                 dbDirectory =
@@ -1146,7 +1150,7 @@ class ClientTest : BaseInstrumentedTest() {
                     account = wallet,
                     options =
                         ClientOptions(
-                            ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                            ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                             appContext = context,
                             dbEncryptionKey = encryptionKey,
                             dbDirectory =
@@ -1163,7 +1167,7 @@ class ClientTest : BaseInstrumentedTest() {
                     account = boWallet,
                     options =
                         ClientOptions(
-                            ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                            ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                             appContext = context,
                             dbEncryptionKey = SecureRandom().generateSeed(32),
                             dbDirectory = File(context.filesDir, "xmtp_bo").absolutePath,
@@ -1194,7 +1198,7 @@ class ClientTest : BaseInstrumentedTest() {
                 account = wallet,
                 options =
                     ClientOptions(
-                        ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                        ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                         appContext = context,
                         dbEncryptionKey = encryptionKey,
                         dbDirectory = File(context.filesDir, "xmtp_db_11").absolutePath,
@@ -1219,7 +1223,7 @@ class ClientTest : BaseInstrumentedTest() {
                         account = wallet,
                         options =
                             ClientOptions(
-                                ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                                ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                                 appContext = context,
                                 dbEncryptionKey = encryptionKey,
                                 dbDirectory =
@@ -1236,7 +1240,7 @@ class ClientTest : BaseInstrumentedTest() {
         val toRevokeId = clients[1].installationId
         runBlocking {
             Client.revokeInstallations(
-                ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                 wallet,
                 clients.first().inboxId,
                 listOf(toRevokeId),
@@ -1255,7 +1259,7 @@ class ClientTest : BaseInstrumentedTest() {
             val key = SecureRandom().generateSeed(32)
             val context = InstrumentationRegistry.getInstrumentation().targetContext
             val alixWallet = PrivateKeyBuilder()
-            val apiOptions = ClientOptions.Api(XMTPEnvironment.LOCAL, false)
+            val apiOptions = ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL)
             val alix =
                 Client.create(
                     account = alixWallet,

--- a/sdks/android/library/src/androidTest/java/org/xmtp/android/library/ClientTest.kt
+++ b/sdks/android/library/src/androidTest/java/org/xmtp/android/library/ClientTest.kt
@@ -523,7 +523,7 @@ class ClientTest : BaseInstrumentedTest() {
     @Test
     fun testsCanSeeKeyPackageStatus() {
         val fixtures = runBlocking { createFixtures() }
-        runBlocking { Client.connectToApiBackend(ClientOptions.Api(XMTPEnvironment.LOCAL, true)) }
+        runBlocking { Client.connectToApiBackendExclusive(ClientOptions.Api(XMTPEnvironment.LOCAL, true)) }
         val inboxState =
             runBlocking {
                 Client
@@ -576,7 +576,7 @@ class ClientTest : BaseInstrumentedTest() {
     //    @Test
     //    fun testsCanSeeInvalidKeyPackageStatusOnDev() {
     //        runBlocking {
-    //            Client.connectToApiBackend(
+    //            Client.connectToApiBackendExclusive(
     //                ClientOptions.Api(
     //                    XMTPEnvironment.DEV,
     //                    true

--- a/sdks/android/library/src/androidTest/java/org/xmtp/android/library/ConversationsTest.kt
+++ b/sdks/android/library/src/androidTest/java/org/xmtp/android/library/ConversationsTest.kt
@@ -340,7 +340,7 @@ class ConversationsTest : BaseInstrumentedTest() {
                     account = eriWallet,
                     options =
                         ClientOptions(
-                            ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                            ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                             appContext = context,
                             dbEncryptionKey = key,
                         ),
@@ -354,7 +354,7 @@ class ConversationsTest : BaseInstrumentedTest() {
                     account = eriWallet,
                     options =
                         ClientOptions(
-                            ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                            ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                             appContext = context,
                             dbEncryptionKey = key,
                             dbDirectory = context.filesDir.absolutePath.toString(),

--- a/sdks/android/library/src/androidTest/java/org/xmtp/android/library/GroupUpdatedTest.kt
+++ b/sdks/android/library/src/androidTest/java/org/xmtp/android/library/GroupUpdatedTest.kt
@@ -210,7 +210,7 @@ class GroupUpdatedTest : BaseInstrumentedTest() {
                 Client.build(
                     alixPublicIdentity,
                     ClientOptions(
-                        api = ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                        api = ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                         dbEncryptionKey = dbEncryptionKey,
                         appContext = context,
                         dbDirectory = alixDbDirectory,

--- a/sdks/android/library/src/androidTest/java/org/xmtp/android/library/HistorySyncTest.kt
+++ b/sdks/android/library/src/androidTest/java/org/xmtp/android/library/HistorySyncTest.kt
@@ -230,7 +230,7 @@ class HistorySyncTest : BaseInstrumentedTest() {
                     account = alixWallet,
                     options =
                         ClientOptions(
-                            ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                            ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                             appContext = context,
                             dbEncryptionKey = dbEncryptionKey,
                             dbDirectory = context.filesDir.absolutePath.toString(),

--- a/sdks/android/library/src/androidTest/java/org/xmtp/android/library/PerformanceTest.kt
+++ b/sdks/android/library/src/androidTest/java/org/xmtp/android/library/PerformanceTest.kt
@@ -150,7 +150,7 @@ class PerformanceTest : BaseInstrumentedTest() {
         val time3 = end3.time - start3.time
         Log.d("PERF", "Built a client with inboxId in ${time3 / 1000.0}s")
 
-        runBlocking { Client.connectToApiBackend(ClientOptions.Api(XMTPEnvironment.DEV, true)) }
+        runBlocking { Client.connectToApiBackendExclusive(ClientOptions.Api(XMTPEnvironment.DEV, true)) }
         val start4 = Date()
         runBlocking {
             Client.create(

--- a/sdks/android/library/src/androidTest/java/org/xmtp/android/library/PerformanceTest.kt
+++ b/sdks/android/library/src/androidTest/java/org/xmtp/android/library/PerformanceTest.kt
@@ -105,7 +105,7 @@ class PerformanceTest : BaseInstrumentedTest() {
                     account = fakeWallet,
                     options =
                         ClientOptions(
-                            ClientOptions.Api(XMTPEnvironment.DEV, true),
+                            ClientOptions.Api(XMTPEnvironment.DEV, true, gatewayHost = TestGateway.DEV),
                             appContext = context,
                             dbEncryptionKey = key,
                         ),
@@ -122,7 +122,7 @@ class PerformanceTest : BaseInstrumentedTest() {
                     fakeWallet.publicIdentity,
                     options =
                         ClientOptions(
-                            ClientOptions.Api(XMTPEnvironment.DEV, true),
+                            ClientOptions.Api(XMTPEnvironment.DEV, true, gatewayHost = TestGateway.DEV),
                             appContext = context,
                             dbEncryptionKey = key,
                         ),
@@ -139,7 +139,7 @@ class PerformanceTest : BaseInstrumentedTest() {
                     fakeWallet.publicIdentity,
                     options =
                         ClientOptions(
-                            ClientOptions.Api(XMTPEnvironment.DEV, true),
+                            ClientOptions.Api(XMTPEnvironment.DEV, true, gatewayHost = TestGateway.DEV),
                             appContext = context,
                             dbEncryptionKey = key,
                         ),
@@ -150,14 +150,18 @@ class PerformanceTest : BaseInstrumentedTest() {
         val time3 = end3.time - start3.time
         Log.d("PERF", "Built a client with inboxId in ${time3 / 1000.0}s")
 
-        runBlocking { Client.connectToApiBackendExclusive(ClientOptions.Api(XMTPEnvironment.DEV, true)) }
+        runBlocking {
+            Client.connectToApiBackendExclusive(
+                ClientOptions.Api(XMTPEnvironment.DEV, true, gatewayHost = TestGateway.DEV),
+            )
+        }
         val start4 = Date()
         runBlocking {
             Client.create(
                 PrivateKeyBuilder(),
                 options =
                     ClientOptions(
-                        ClientOptions.Api(XMTPEnvironment.DEV, true),
+                        ClientOptions.Api(XMTPEnvironment.DEV, true, gatewayHost = TestGateway.DEV),
                         appContext = context,
                         dbEncryptionKey = key,
                     ),

--- a/sdks/android/library/src/androidTest/java/org/xmtp/android/library/SmartContractWalletTest.kt
+++ b/sdks/android/library/src/androidTest/java/org/xmtp/android/library/SmartContractWalletTest.kt
@@ -57,7 +57,7 @@ class SmartContractWalletTest : BaseInstrumentedTest() {
                 Client.build(
                     publicIdentity = davonSCW.publicIdentity,
                     createClientOptions(
-                        ClientOptions.Api(XMTPEnvironment.LOCAL, false),
+                        ClientOptions.Api(XMTPEnvironment.LOCAL, false, gatewayHost = TestGateway.LOCAL),
                         dbDirectory = File(davonSCWClient.dbPath).parent,
                         deviceSyncEnabled = false,
                     ),

--- a/sdks/android/library/src/androidTest/java/org/xmtp/android/library/TestHelpers.kt
+++ b/sdks/android/library/src/androidTest/java/org/xmtp/android/library/TestHelpers.kt
@@ -20,6 +20,17 @@ import org.xmtp.android.library.messages.PrivateKeyBuilder
 import java.math.BigInteger
 import java.security.SecureRandom
 
+object TestGateway {
+    /** Gateway URL for LOCAL env from Android emulator (10.0.2.2 = host localhost) */
+    const val LOCAL = "http://10.0.2.2:5052"
+
+    /** Gateway URL for DEV env */
+    const val DEV = "https://payer.testnet-dev.xmtp.network:443"
+
+    /** Gateway URL for PRODUCTION env */
+    const val PRODUCTION = "https://payer.testnet.xmtp.network:443"
+}
+
 const val ANVIL_TEST_PRIVATE_KEY_1 =
     "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 const val ANVIL_TEST_PRIVATE_KEY_2 =
@@ -122,6 +133,7 @@ class Fixtures(
         ClientOptions.Api(
             XMTPEnvironment.LOCAL,
             isSecure = false,
+            gatewayHost = TestGateway.LOCAL,
         ),
 ) {
     val key = SecureRandom().generateSeed(32)
@@ -164,5 +176,6 @@ fun fixtures(
         ClientOptions.Api(
             XMTPEnvironment.LOCAL,
             isSecure = false,
+            gatewayHost = TestGateway.LOCAL,
         ),
 ): Fixtures = Fixtures(api)

--- a/sdks/android/library/src/main/java/org/xmtp/android/library/Client.kt
+++ b/sdks/android/library/src/main/java/org/xmtp/android/library/Client.kt
@@ -32,6 +32,7 @@ import uniffi.xmtpv3.FfiXmtpClient
 import uniffi.xmtpv3.XmtpApiClient
 import uniffi.xmtpv3.applySignatureRequest
 import uniffi.xmtpv3.connectToBackend
+import uniffi.xmtpv3.connectToBackendExclusive
 import uniffi.xmtpv3.createClient
 import uniffi.xmtpv3.enterDebugWriter
 import uniffi.xmtpv3.exitDebugWriter
@@ -148,8 +149,8 @@ class Client(
                 registry
             }
 
-        private fun ClientOptions.Api.toCacheKey(): String =
-            "${env.getUrl()}|${appVersion ?: "nil"}|${gatewayHost ?: "nil"}"
+        private fun ClientOptions.Api.toCacheKey(exclusive: Boolean = false): String =
+            "${env.getUrl()}|${appVersion ?: "nil"}|${gatewayHost ?: "nil"}|$exclusive"
 
         private val apiClientCache = mutableMapOf<String, XmtpApiClient>()
         private val cacheLock = Mutex()
@@ -252,6 +253,56 @@ class Client(
                 // If not cached or not connected, create a fresh client
                 val newClient =
                     connectToBackend(
+                        api.env.getUrl(),
+                        api.gatewayHost,
+                        FfiClientMode.DEFAULT,
+                        api.appVersion,
+                        null,
+                        null,
+                    )
+                syncApiClientCache[cacheKey] = newClient
+                return@withLock newClient
+            }
+        }
+
+        @Deprecated("This function will be removed on d14n cutover. Use connectToApiBackend instead.")
+        suspend fun connectToApiBackendExclusive(api: ClientOptions.Api): XmtpApiClient {
+            val cacheKey = api.toCacheKey(exclusive = true)
+            return cacheLock.withLock {
+                val cached = apiClientCache[cacheKey]
+
+                if (cached != null && isConnected(cached)) {
+                    return cached
+                }
+
+                // If not cached or not connected, create a fresh client
+                val newClient =
+                    connectToBackendExclusive(
+                        api.env.getUrl(),
+                        api.gatewayHost,
+                        FfiClientMode.DEFAULT,
+                        api.appVersion,
+                        null,
+                        null,
+                    )
+                apiClientCache[cacheKey] = newClient
+                return@withLock newClient
+            }
+        }
+
+        @Deprecated("This function will be removed on d14n cutover. Use connectToSyncApiBackend instead.")
+        suspend fun connectToSyncApiBackendExclusive(api: ClientOptions.Api): XmtpApiClient {
+            val cacheKey = api.toCacheKey(exclusive = true)
+            return syncCacheLock.withLock {
+                val cached = syncApiClientCache[cacheKey]
+
+                if (cached != null && isConnected(cached)) {
+                    return cached
+                }
+
+                // If not cached or not connected, create a fresh client
+                val newClient =
+                    connectToBackendExclusive(
                         api.env.getUrl(),
                         api.gatewayHost,
                         FfiClientMode.DEFAULT,

--- a/sdks/ios/Sources/XMTPTestHelpers/TestHelpers.swift
+++ b/sdks/ios/Sources/XMTPTestHelpers/TestHelpers.swift
@@ -98,7 +98,8 @@
 		@available(iOS 15, *)
 		func fixtures(
 			clientOptions: ClientOptions.Api = ClientOptions.Api(
-				env: XMTPEnvironment.local, isSecure: XMTPEnvironment.local.isSecure
+				env: XMTPEnvironment.local, isSecure: XMTPEnvironment.local.isSecure,
+				gatewayHost: "http://localhost:5052"
 			)
 		) async throws -> Fixtures {
 			try await Fixtures(clientOptions: clientOptions)

--- a/sdks/ios/Sources/XMTPiOS/Client.swift
+++ b/sdks/ios/Sources/XMTPiOS/Client.swift
@@ -173,9 +173,15 @@ public struct ClientOptions {
 
 struct ApiCacheKey {
 	let api: ClientOptions.Api
+	let exclusive: Bool
+
+	init(api: ClientOptions.Api, exclusive: Bool = false) {
+		self.api = api
+		self.exclusive = exclusive
+	}
 
 	var stringValue: String {
-		"\(api.env.url)|\(api.appVersion ?? "nil")|\(api.gatewayHost ?? "nil")"
+		"\(api.env.url)|\(api.appVersion ?? "nil")|\(api.gatewayHost ?? "nil")|\(exclusive)"
 	}
 }
 
@@ -526,6 +532,59 @@ public final class Client {
 		return newClient
 	}
 
+	@available(*, deprecated, message: "This function will be removed on d14n cutover. Use connectToApiBackend instead.")
+	public static func connectToApiBackendExclusive(api: ClientOptions.Api)
+		async throws
+		-> XmtpApiClient
+	{
+		let cacheKey = ApiCacheKey(api: api, exclusive: true).stringValue
+
+		// Check for an existing connected client
+		if let cached = await apiCache.getClient(forKey: cacheKey),
+		   try await isConnected(api: cached)
+		{
+			return cached
+		}
+
+		// Either not cached or not connected; create new client
+		let newClient = try await connectToBackendExclusive(
+			v3Host: api.env.url,
+			gatewayHost: api.gatewayHost,
+			clientMode: FfiClientMode.default,
+			appVersion: api.appVersion,
+			authCallback: nil,
+			authHandle: nil
+		)
+		await apiCache.setClient(newClient, forKey: cacheKey)
+		return newClient
+	}
+
+	@available(*, deprecated, message: "This function will be removed on d14n cutover. Use connectToSyncApiBackend instead.")
+	public static func connectToSyncApiBackendExclusive(api: ClientOptions.Api)
+		async throws
+		-> XmtpApiClient
+	{
+		let cacheKey = ApiCacheKey(api: api, exclusive: true).stringValue
+
+		// Check for an existing connected client
+		if let cached = await apiCache.getSyncClient(forKey: cacheKey),
+		   try await isConnected(api: cached)
+		{
+			return cached
+		}
+
+		// Either not cached or not connected; create new client
+		let newClient = try await connectToBackendExclusive(
+			v3Host: api.env.url,
+			gatewayHost: api.gatewayHost,
+			clientMode: FfiClientMode.default,
+			appVersion: api.appVersion,
+			authCallback: nil,
+			authHandle: nil
+		)
+		await apiCache.setSyncClient(newClient, forKey: cacheKey)
+		return newClient
+	}
 	public static func getOrCreateInboxId(
 		api: ClientOptions.Api, publicIdentity: PublicIdentity
 	) async throws -> InboxId {

--- a/sdks/ios/Sources/XMTPiOS/Client.swift
+++ b/sdks/ios/Sources/XMTPiOS/Client.swift
@@ -559,7 +559,11 @@ public final class Client {
 		return newClient
 	}
 
-	@available(*, deprecated, message: "This function will be removed on d14n cutover. Use connectToSyncApiBackend instead.")
+	@available(
+		*,
+		deprecated,
+		message: "This function will be removed on d14n cutover. Use connectToSyncApiBackend instead."
+	)
 	public static func connectToSyncApiBackendExclusive(api: ClientOptions.Api)
 		async throws
 		-> XmtpApiClient
@@ -585,6 +589,7 @@ public final class Client {
 		await apiCache.setSyncClient(newClient, forKey: cacheKey)
 		return newClient
 	}
+
 	public static func getOrCreateInboxId(
 		api: ClientOptions.Api, publicIdentity: PublicIdentity
 	) async throws -> InboxId {

--- a/sdks/ios/Tests/XMTPTests/ArchiveTests.swift
+++ b/sdks/ios/Tests/XMTPTests/ArchiveTests.swift
@@ -27,7 +27,7 @@ class ArchiveTests: XCTestCase {
 		let alixClient = try await Client.create(
 			account: alix,
 			options: .init(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key,
 				dbDirectory: dbDir1
 			)
@@ -73,7 +73,7 @@ class ArchiveTests: XCTestCase {
 		let alixClient2 = try await Client.create(
 			account: alix,
 			options: .init(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key,
 				dbDirectory: dbDir2
 			)
@@ -118,7 +118,7 @@ class ArchiveTests: XCTestCase {
 		let alixClient = try await Client.create(
 			account: alix,
 			options: .init(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key,
 				dbDirectory: dbDir1
 			)
@@ -141,7 +141,7 @@ class ArchiveTests: XCTestCase {
 		let alixClient2 = try await Client.create(
 			account: alix,
 			options: .init(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key,
 				dbDirectory: dbDir2
 			)

--- a/sdks/ios/Tests/XMTPTests/ClientTests.swift
+++ b/sdks/ios/Tests/XMTPTests/ClientTests.swift
@@ -941,7 +941,11 @@ class ClientTests: XCTestCase {
 
 	func testCanSeeKeyPackageStatus() async throws {
 		let fixtures = try await fixtures()
-		let api = ClientOptions.Api(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052")
+		let api = ClientOptions.Api(
+			env: .local,
+			isSecure: XMTPEnvironment.local.isSecure,
+			gatewayHost: "http://localhost:5052"
+		)
 
 		try await Client.connectToApiBackendExclusive(api: api)
 

--- a/sdks/ios/Tests/XMTPTests/ClientTests.swift
+++ b/sdks/ios/Tests/XMTPTests/ClientTests.swift
@@ -15,7 +15,8 @@ class ClientTests: XCTestCase {
 		let clientOptions = ClientOptions(
 			api: ClientOptions.Api(
 				env: XMTPEnvironment.local, isSecure: XMTPEnvironment.local.isSecure,
-				appVersion: "Testing/0.0.0"
+				appVersion: "Testing/0.0.0",
+				gatewayHost: "http://localhost:5052"
 			),
 			dbEncryptionKey: key
 		)
@@ -33,7 +34,7 @@ class ClientTests: XCTestCase {
 		let client = try await Client.create(
 			account: bo,
 			options: .init(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key
 			)
 		)
@@ -50,7 +51,7 @@ class ClientTests: XCTestCase {
 				notOnNetwork.identity,
 				fixtures.bo.identity,
 			],
-			api: ClientOptions.Api(env: .local, isSecure: XMTPEnvironment.local.isSecure)
+			api: ClientOptions.Api(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052")
 		)
 
 		let expectedResults: [String: Bool] = [
@@ -76,7 +77,7 @@ class ClientTests: XCTestCase {
 				fixtures.alixClient.inboxID,
 				fixtures.boClient.inboxID,
 			],
-			api: ClientOptions.Api(env: .local, isSecure: XMTPEnvironment.local.isSecure)
+			api: ClientOptions.Api(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052")
 		)
 
 		XCTAssertEqual(
@@ -98,7 +99,7 @@ class ClientTests: XCTestCase {
 		var boClient = try await Client.create(
 			account: bo,
 			options: .init(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key
 			)
 		)
@@ -106,7 +107,7 @@ class ClientTests: XCTestCase {
 		let alixClient = try await Client.create(
 			account: alix,
 			options: .init(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key
 			)
 		)
@@ -123,7 +124,7 @@ class ClientTests: XCTestCase {
 		boClient = try await Client.create(
 			account: bo,
 			options: .init(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key
 			)
 		)
@@ -140,7 +141,7 @@ class ClientTests: XCTestCase {
 		let boClient = try await Client.create(
 			account: bo,
 			options: .init(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key
 			)
 		)
@@ -148,7 +149,7 @@ class ClientTests: XCTestCase {
 		let alixClient = try await Client.create(
 			account: alix,
 			options: .init(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key
 			)
 		)
@@ -202,7 +203,7 @@ class ClientTests: XCTestCase {
 		}
 
 		let opts = ClientOptions(
-			api: ClientOptions.Api(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+			api: ClientOptions.Api(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 			preAuthenticateToInboxCallback: preAuthenticateToInboxCallback,
 			dbEncryptionKey: key
 		)
@@ -222,7 +223,7 @@ class ClientTests: XCTestCase {
 		let client = try await Client.create(
 			account: bo,
 			options: .init(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key,
 				dbDirectory: dbDir
 			)
@@ -231,7 +232,7 @@ class ClientTests: XCTestCase {
 		let bundleClient = try await Client.build(
 			publicIdentity: bo.identity,
 			options: .init(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key,
 				dbDirectory: dbDir
 			)
@@ -245,7 +246,7 @@ class ClientTests: XCTestCase {
 			_ = await Client.build(
 				publicIdentity: bo.identity,
 				options: .init(
-					api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+					api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 					dbEncryptionKey: key,
 					dbDirectory: nil
 				)
@@ -263,7 +264,7 @@ class ClientTests: XCTestCase {
 		let boClient = try await Client.create(
 			account: bo,
 			options: .init(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key,
 				dbDirectory: dbDir
 			)
@@ -272,7 +273,7 @@ class ClientTests: XCTestCase {
 		let alixClient = try await Client.create(
 			account: alix,
 			options: .init(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key,
 				dbDirectory: dbDir
 			)
@@ -287,7 +288,7 @@ class ClientTests: XCTestCase {
 			await Client.create(
 				account: bo,
 				options: .init(
-					api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+					api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 					dbEncryptionKey: key2,
 					dbDirectory: dbDir
 				)
@@ -304,7 +305,7 @@ class ClientTests: XCTestCase {
 		let boClient = try await Client.create(
 			account: bo,
 			options: .init(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key
 			)
 		)
@@ -312,7 +313,7 @@ class ClientTests: XCTestCase {
 		let alixClient = try await Client.create(
 			account: alix,
 			options: .init(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key
 			)
 		)
@@ -328,7 +329,7 @@ class ClientTests: XCTestCase {
 		let key = try Crypto.secureRandomBytes(count: 32)
 		let alix = try PrivateKey.generate()
 		let options = ClientOptions(
-			api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+			api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 			dbEncryptionKey: key
 		)
 
@@ -365,7 +366,7 @@ class ClientTests: XCTestCase {
 		let alixClient = try await Client.create(
 			account: alix,
 			options: ClientOptions(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key,
 				dbDirectory: dbDir1
 			)
@@ -374,7 +375,7 @@ class ClientTests: XCTestCase {
 		let alixClient2 = try await Client.create(
 			account: alix,
 			options: ClientOptions(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key,
 				dbDirectory: dbDir2
 			)
@@ -383,7 +384,7 @@ class ClientTests: XCTestCase {
 		let alixClient3 = try await Client.create(
 			account: alix,
 			options: ClientOptions(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key,
 				dbDirectory: dbDir3
 			)
@@ -415,7 +416,7 @@ class ClientTests: XCTestCase {
 		let alixClient = try await Client.create(
 			account: alix,
 			options: ClientOptions(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key,
 				dbDirectory: dbDir1
 			)
@@ -424,7 +425,7 @@ class ClientTests: XCTestCase {
 		let alixClient2 = try await Client.create(
 			account: alix,
 			options: ClientOptions(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key,
 				dbDirectory: dbDir2
 			)
@@ -433,7 +434,7 @@ class ClientTests: XCTestCase {
 		let alixClient3 = try await Client.create(
 			account: alix,
 			options: ClientOptions(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key,
 				dbDirectory: dbDir3
 			)
@@ -624,7 +625,7 @@ class ClientTests: XCTestCase {
 		try fixtures.alixClient.deleteLocalDatabase()
 		let key = try Crypto.secureRandomBytes(count: 32)
 		let options = ClientOptions(
-			api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+			api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 			dbEncryptionKey: key
 		)
 
@@ -655,7 +656,7 @@ class ClientTests: XCTestCase {
 		let key = try Crypto.secureRandomBytes(count: 32)
 		let alix = try PrivateKey.generate()
 		let options = ClientOptions(
-			api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+			api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 			dbEncryptionKey: key
 		)
 
@@ -689,7 +690,7 @@ class ClientTests: XCTestCase {
 		let boWallet = try PrivateKey.generate()
 
 		let options = ClientOptions(
-			api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+			api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 			dbEncryptionKey: key
 		)
 
@@ -738,7 +739,7 @@ class ClientTests: XCTestCase {
 		let alix = try await Client.create(
 			account: alixWallet,
 			options: ClientOptions(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key,
 				dbDirectory: dbDirPath
 			)
@@ -747,7 +748,7 @@ class ClientTests: XCTestCase {
 		let alix2 = try await Client.create(
 			account: alixWallet,
 			options: ClientOptions(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key,
 				dbDirectory: dbDirPath2
 			)
@@ -756,7 +757,7 @@ class ClientTests: XCTestCase {
 		let alix3 = try await Client.create(
 			account: alixWallet,
 			options: ClientOptions(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key,
 				dbDirectory: dbDirPath3
 			)
@@ -831,7 +832,7 @@ class ClientTests: XCTestCase {
 		let client = try await Client.create(
 			account: fakeWallet,
 			options: .init(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key
 			)
 		)
@@ -898,7 +899,7 @@ class ClientTests: XCTestCase {
 		let alix = try await Client.create(
 			account: alixWallet,
 			options: .init(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key
 			)
 		)
@@ -940,7 +941,7 @@ class ClientTests: XCTestCase {
 
 	func testCanSeeKeyPackageStatus() async throws {
 		let fixtures = try await fixtures()
-		let api = ClientOptions.Api(env: .local, isSecure: XMTPEnvironment.local.isSecure)
+		let api = ClientOptions.Api(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052")
 
 		try await Client.connectToApiBackendExclusive(api: api)
 
@@ -1002,7 +1003,7 @@ class ClientTests: XCTestCase {
 		let key = try Crypto.secureRandomBytes(count: 32)
 		let wallet = try PrivateKey.generate()
 		let options = ClientOptions(
-			api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+			api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 			dbEncryptionKey: key
 		)
 
@@ -1058,7 +1059,7 @@ class ClientTests: XCTestCase {
 			let client = try await Client.create(
 				account: wallet,
 				options: ClientOptions(
-					api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+					api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 					dbEncryptionKey: key,
 					dbDirectory: dbDirs[i]
 				)
@@ -1074,7 +1075,7 @@ class ClientTests: XCTestCase {
 			_ = await Client.create(
 				account: wallet,
 				options: ClientOptions(
-					api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+					api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 					dbEncryptionKey: key,
 					dbDirectory: dbDirs[10]
 				)
@@ -1085,7 +1086,7 @@ class ClientTests: XCTestCase {
 		let boClient = try await Client.create(
 			account: boWallet,
 			options: ClientOptions(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: Crypto.secureRandomBytes(count: 32),
 				dbDirectory: boDbDir
 			)
@@ -1117,7 +1118,7 @@ class ClientTests: XCTestCase {
 		let sixthClient = try await Client.create(
 			account: wallet,
 			options: ClientOptions(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key,
 				dbDirectory: dbDirs[11]
 			)
@@ -1142,7 +1143,7 @@ class ClientTests: XCTestCase {
 			let client = try await Client.create(
 				account: wallet,
 				options: ClientOptions(
-					api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+					api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 					dbEncryptionKey: key,
 					dbDirectory: dbDirs[i]
 				)
@@ -1156,7 +1157,7 @@ class ClientTests: XCTestCase {
 		let toRevokeId = clients[1].installationID
 
 		try await Client.revokeInstallations(
-			api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+			api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 			signingKey: wallet,
 			inboxId: XCTUnwrap(clients.first?.inboxID),
 			installationIds: [toRevokeId]
@@ -1181,7 +1182,7 @@ class ClientTests: XCTestCase {
 			let client = try await Client.create(
 				account: wallet,
 				options: ClientOptions(
-					api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+					api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 					dbEncryptionKey: key,
 					dbDirectory: dbDirs[i]
 				)
@@ -1193,14 +1194,14 @@ class ClientTests: XCTestCase {
 			inboxIds: [
 				XCTUnwrap(clients.last?.inboxID),
 			],
-			api: ClientOptions.Api(env: .local, isSecure: XMTPEnvironment.local.isSecure)
+			api: ClientOptions.Api(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052")
 		)
 		XCTAssertEqual(states.first?.installations.count, 5)
 
 		let toRevokeIds = try XCTUnwrap(states.first?.installations.map(\.id))
 
 		try await Client.revokeInstallations(
-			api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+			api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 			signingKey: wallet,
 			inboxId: XCTUnwrap(clients.first?.inboxID),
 			installationIds: toRevokeIds
@@ -1210,7 +1211,7 @@ class ClientTests: XCTestCase {
 			inboxIds: [
 				XCTUnwrap(clients.last?.inboxID),
 			],
-			api: ClientOptions.Api(env: .local, isSecure: XMTPEnvironment.local.isSecure)
+			api: ClientOptions.Api(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052")
 		)
 		XCTAssertEqual(states.first?.installations.count, 0)
 	}
@@ -1226,7 +1227,7 @@ class ClientTests: XCTestCase {
 		let alix = try await Client.create(
 			account: alixWallet,
 			options: ClientOptions(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key,
 				dbDirectory: dbDirPath
 			)
@@ -1235,7 +1236,7 @@ class ClientTests: XCTestCase {
 		let alix2 = try await Client.create(
 			account: alixWallet,
 			options: ClientOptions(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key,
 				dbDirectory: dbDirPath2
 			)
@@ -1244,7 +1245,7 @@ class ClientTests: XCTestCase {
 		let alix3 = try await Client.create(
 			account: alixWallet,
 			options: ClientOptions(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key,
 				dbDirectory: dbDirPath3
 			)
@@ -1254,7 +1255,7 @@ class ClientTests: XCTestCase {
 		XCTAssertEqual(inboxState.installations.count, 3)
 
 		let sigRequest = try await Client.ffiRevokeInstallations(
-			api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+			api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 			publicIdentity: alixWallet.identity,
 			inboxId: alix.inboxID,
 			installationIds: [
@@ -1267,7 +1268,7 @@ class ClientTests: XCTestCase {
 
 		try await sigRequest.addEcdsaSignature(signatureBytes: signedMessage)
 		try await Client.ffiApplySignatureRequest(
-			api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+			api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 			signatureRequest: sigRequest
 		)
 
@@ -1293,7 +1294,7 @@ class ClientTests: XCTestCase {
 		// Call the static method
 		let metadata = try await Client.getNewestMessageMetadata(
 			groupIds: [groupId],
-			api: ClientOptions.Api(env: .local, isSecure: XMTPEnvironment.local.isSecure)
+			api: ClientOptions.Api(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052")
 		)
 
 		// Verify we got metadata for our group

--- a/sdks/ios/Tests/XMTPTests/ClientTests.swift
+++ b/sdks/ios/Tests/XMTPTests/ClientTests.swift
@@ -942,7 +942,7 @@ class ClientTests: XCTestCase {
 		let fixtures = try await fixtures()
 		let api = ClientOptions.Api(env: .local, isSecure: XMTPEnvironment.local.isSecure)
 
-		try await Client.connectToApiBackend(api: api)
+		try await Client.connectToApiBackendExclusive(api: api)
 
 		guard
 			let inboxState = try await Client.inboxStatesForInboxIds(

--- a/sdks/ios/Tests/XMTPTests/ConversationTests.swift
+++ b/sdks/ios/Tests/XMTPTests/ConversationTests.swift
@@ -215,7 +215,7 @@ class ConversationTests: XCTestCase {
 	func testReturnsAllHMACKeys() async throws {
 		let key = try Crypto.secureRandomBytes(count: 32)
 		let opts = ClientOptions(
-			api: ClientOptions.Api(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+			api: ClientOptions.Api(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 			dbEncryptionKey: key
 		)
 		let fixtures = try await fixtures()
@@ -506,7 +506,7 @@ class ConversationTests: XCTestCase {
 	func testReturnsAllTopics() async throws {
 		let key = try Crypto.secureRandomBytes(count: 32)
 		let opts = ClientOptions(
-			api: ClientOptions.Api(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+			api: ClientOptions.Api(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 			dbEncryptionKey: key
 		)
 

--- a/sdks/ios/Tests/XMTPTests/GroupTests.swift
+++ b/sdks/ios/Tests/XMTPTests/GroupTests.swift
@@ -1601,7 +1601,11 @@ class GroupTests: XCTestCase {
 		// Create clients with explicit options so we can reinitialize
 		let key = Data((0 ..< 32).map { _ in UInt8.random(in: 0 ... 255) })
 		let clientOptions = ClientOptions(
-			api: ClientOptions.Api(env: XMTPEnvironment.local, isSecure: XMTPEnvironment.local.isSecure),
+			api: ClientOptions.Api(
+				env: XMTPEnvironment.local,
+				isSecure: XMTPEnvironment.local.isSecure,
+				gatewayHost: "http://localhost:5052"
+			),
 			dbEncryptionKey: key
 		)
 
@@ -1647,7 +1651,11 @@ class GroupTests: XCTestCase {
 
 		// Reinitialize Alix's client from the same database
 		let reinitOptions = ClientOptions(
-			api: ClientOptions.Api(env: XMTPEnvironment.local, isSecure: XMTPEnvironment.local.isSecure),
+			api: ClientOptions.Api(
+				env: XMTPEnvironment.local,
+				isSecure: XMTPEnvironment.local.isSecure,
+				gatewayHost: "http://localhost:5052"
+			),
 			dbEncryptionKey: key,
 			dbDirectory: alixDbDirectory
 		)

--- a/sdks/ios/Tests/XMTPTests/HistorySyncTests.swift
+++ b/sdks/ios/Tests/XMTPTests/HistorySyncTests.swift
@@ -26,7 +26,7 @@ class HistorySyncTests: XCTestCase {
 		let alixClient = try await Client.create(
 			account: alix,
 			options: .init(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key,
 				dbDirectory: dbDir1
 			)
@@ -41,7 +41,7 @@ class HistorySyncTests: XCTestCase {
 		let alixClient2 = try await Client.create(
 			account: alix,
 			options: .init(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key,
 				dbDirectory: dbDir2
 			)
@@ -89,7 +89,7 @@ class HistorySyncTests: XCTestCase {
 		let alixClient = try await Client.create(
 			account: alix,
 			options: .init(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key,
 				dbDirectory: dbDir1
 			)
@@ -104,7 +104,7 @@ class HistorySyncTests: XCTestCase {
 		let alixClient2 = try await Client.create(
 			account: alix,
 			options: .init(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key,
 				dbDirectory: dbDir2
 			)
@@ -145,7 +145,7 @@ class HistorySyncTests: XCTestCase {
 		let alixClient = try await Client.create(
 			account: alix,
 			options: .init(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key,
 				dbDirectory: dbDir1,
 				deviceSyncEnabled: true
@@ -159,7 +159,7 @@ class HistorySyncTests: XCTestCase {
 		let alixClient2 = try await Client.create(
 			account: alix,
 			options: .init(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key,
 				dbDirectory: dbDir2,
 				deviceSyncEnabled: true
@@ -209,7 +209,7 @@ class HistorySyncTests: XCTestCase {
 		let alixClient = try await Client.create(
 			account: alix,
 			options: .init(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key,
 				dbDirectory: dbDir1
 			)
@@ -231,7 +231,7 @@ class HistorySyncTests: XCTestCase {
 		let alixClient2 = try await Client.create(
 			account: alix,
 			options: .init(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key,
 				dbDirectory: dbDir2
 			)
@@ -253,7 +253,7 @@ class HistorySyncTests: XCTestCase {
 		let alixClient = try await Client.create(
 			account: alix,
 			options: .init(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key,
 				dbDirectory: dbDir1
 			)
@@ -268,7 +268,7 @@ class HistorySyncTests: XCTestCase {
 		let alixClient2 = try await Client.create(
 			account: alix,
 			options: .init(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key,
 				dbDirectory: dbDir2
 			)
@@ -316,7 +316,7 @@ class HistorySyncTests: XCTestCase {
 		let alixClient = try await Client.create(
 			account: alix,
 			options: .init(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key,
 				dbDirectory: dbDir1
 			)
@@ -331,7 +331,7 @@ class HistorySyncTests: XCTestCase {
 		let alixClient2 = try await Client.create(
 			account: alix,
 			options: .init(
-				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure),
+				api: .init(env: .local, isSecure: XMTPEnvironment.local.isSecure, gatewayHost: "http://localhost:5052"),
 				dbEncryptionKey: key,
 				dbDirectory: dbDir2
 			)

--- a/sdks/ios/dev/fly/machine-config.json
+++ b/sdks/ios/dev/fly/machine-config.json
@@ -92,7 +92,9 @@
         "--mls-validation.grpc-address=localhost:50051",
         "--api.enable-mls",
         "--wait-for-db=30s",
-        "--api.authn.enable"
+        "--api.authn.enable",
+        "--api.enable-migration",
+        "--api.d14n-cutover-ns=9223372036854775807"
       ],
       "depends_on": [
         { "name": "db", "condition": "healthy" },


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Enable migration client mode across mobile, WASM, and Node SDK bindings
- Adds new `MigrationLocal`, `MigrationStaging`, `MigrationProduction`, and `MigrationXnet` environment variants across Node, WASM, and mobile bindings, with `GrpcUrlsXnet` constants (`https://node-go.xmtp.run`, `https://gateway.xmtp.run`) for the XNet environment.
- Changes the default backend build path from `build_optional_d14n()` to `build()` (migration-capable) in `create_client` (Node) and `connect_to_backend` (mobile); migration environments auto-populate XNet hosts when not explicitly set.
- Introduces `connectToApiBackendExclusive` / `connectToSyncApiBackendExclusive` (iOS and Android) and `connect_to_backend_exclusive` (mobile bindings) as deprecated non-migrating pathways for testing, with cache keys distinguishing exclusive vs. non-exclusive connections.
- Updates all iOS, Android, and Node test fixtures and helpers to pass an explicit `gatewayHost` (local, dev, or production) when constructing `ClientOptions.Api`.
- Enables migration in the local Docker Compose node service and the iOS fly dev machine via `--api.enable-migration` and `--api.d14n-cutover-ns=9223372036854775807`.
- Risk: `create_client` in Node now requires a non-optional `gateway_host`; callers previously omitting it will break.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 41bb1ce.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->