### PR TITLE
Pin nix version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
   "features": {
     "ghcr.io/devcontainers/features/nix:1": {
       "multiUser": false,
+      "version": "2.34.1",
       "packages": "nix-direnv",
       "extraNixConfig": "experimental-features = nix-command flakes,accept-flake-config = true,build-users-group =,extra-substituters = https://xmtp.cachix.org https://cache.garnix.io,extra-trusted-public-keys = xmtp.cachix.org-1:nFPFrqLQ9kjYQKiWL7gKq6llcNEeaV4iI+Ka1F+Tmq0= cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g=",
     },


### PR DESCRIPTION
### TL;DR

Pin Nix to version 2.34.1 in the devcontainer configuration. The automatic version had a hash mismatch problem with the devcontainer feature. It seems that it was updated upstream and the hash doesn't match the expectation of the Docker image.

### What changed?

Added a specific version constraint (`"version": "2.34.1"`) to the Nix feature configuration in the devcontainer setup.

### How to test?

1. Rebuild the devcontainer
2. Verify that Nix version 2.34.1 is installed by running `nix --version` in the container

### Why make this change?

Pinning the Nix version ensures consistent behavior across different development environments and prevents potential issues that could arise from automatic updates to newer Nix versions.

<!-- Macroscope's pull request summary starts here -->

<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->

<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->

> [!NOTE]
> ### Pin nix version to 2.34.1 in devcontainer config
>
> Sets an explicit `version` field to `2.34.1` in [devcontainer.json](https://github.com/xmtp/libxmtp/pull/3356/files#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686) to lock the nix version used in the dev environment.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8ba6e3e.</sup>
>
> <!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->

<!-- Macroscope's pull request summary ends here -->