### PR TITLE
android tracing filter

### DIFF
--- a/bindings/mobile/Cargo.toml
+++ b/bindings/mobile/Cargo.toml
@@ -23,7 +23,7 @@ prost.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["macros"] }
-tracing = { workspace = true, features = ["release_max_level_debug"] }
+tracing = { workspace = true, features = ["release_max_level_trace"] }
 tracing-appender = "0.2"
 tracing-subscriber = { workspace = true, features = [
   "registry",

--- a/bindings/mobile/src/logger.rs
+++ b/bindings/mobile/src/logger.rs
@@ -18,6 +18,8 @@ use tracing_subscriber::{
     registry::LookupSpan, registry::Registry, reload, util::SubscriberInitExt,
 };
 
+const ANDROID_TRACING_FILTER: &str = "xmtp_mls::groups::send_message=TRACE,xmtp_mls::groups::send_message_optimistic=TRACE,xmtp_mls::mls_sync=DEBUG,xmtp_api_d14n=DEBUG";
+
 #[cfg(target_os = "android")]
 pub use android::*;
 #[cfg(target_os = "android")]
@@ -28,7 +30,7 @@ mod android {
         S: Subscriber + for<'a> LookupSpan<'a>,
     {
         use tracing_subscriber::EnvFilter;
-        let api_calls_filter = EnvFilter::builder().parse_lossy("xmtp_api=debug");
+        let api_calls_filter = EnvFilter::builder().parse(ANDROID_TRACING_FILTER);
         let libxmtp_filter = xmtp_common::filter_directive("debug");
 
         vec![
@@ -397,5 +399,12 @@ mod test_logger {
             assert!(contents.contains(&rand_nums));
             std::fs::remove_file(entry.as_ref().unwrap().path()).unwrap();
         }
+    }
+
+    #[test]
+    fn android_tracing_filter_works() {
+        let _ = EnvFilter::builder().parse(
+            "xmtp_mls::groups::send_message=TRACE,xmtp_mls::groups::send_message_optimistic=TRACE,xmtp_mls::mls_sync=DEBUG,xmtp_api_d14n=DEBUG"
+        ).unwrap();
     }
 }

--- a/crates/xmtp-workspace-hack/Cargo.toml
+++ b/crates/xmtp-workspace-hack/Cargo.toml
@@ -18,302 +18,834 @@ publish = ["crates-io"]
 
 ### BEGIN HAKARI SECTION
 [dependencies]
-aead = { version = "0.5", default-features = false, features = ["getrandom", "std"] }
+aead = { version = "0.5", default-features = false, features = [
+  "getrandom",
+  "std",
+] }
 aes-gcm = { version = "0.10", features = ["std"] }
-alloy = { version = "1", default-features = false, features = ["contract", "provider-anvil-node", "rand", "reqwest-rustls-tls", "signer-local"] }
-alloy-core = { version = "1", default-features = false, features = ["dyn-abi", "json-abi", "rand", "rlp"] }
-alloy-json-abi = { version = "1", default-features = false, features = ["serde_json", "std"] }
-alloy-primitives = { version = "1", default-features = false, features = ["k256", "map", "rand", "rlp", "serde", "std"] }
-alloy-provider = { version = "1", default-features = false, features = ["anvil-node"] }
-alloy-rpc-client = { version = "1", default-features = false, features = ["reqwest"] }
-alloy-sol-type-parser = { version = "1", default-features = false, features = ["serde", "std"] }
-alloy-sol-types = { version = "1", default-features = false, features = ["json", "std"] }
-alloy-transport-http = { version = "1", default-features = false, features = ["reqwest", "reqwest-rustls-tls"] }
+alloy = { version = "1", default-features = false, features = [
+  "contract",
+  "provider-anvil-node",
+  "rand",
+  "reqwest-rustls-tls",
+  "signer-local",
+] }
+alloy-core = { version = "1", default-features = false, features = [
+  "dyn-abi",
+  "json-abi",
+  "rand",
+  "rlp",
+] }
+alloy-json-abi = { version = "1", default-features = false, features = [
+  "serde_json",
+  "std",
+] }
+alloy-primitives = { version = "1", default-features = false, features = [
+  "k256",
+  "map",
+  "rand",
+  "rlp",
+  "serde",
+  "std",
+] }
+alloy-provider = { version = "1", default-features = false, features = [
+  "anvil-node",
+] }
+alloy-rpc-client = { version = "1", default-features = false, features = [
+  "reqwest",
+] }
+alloy-sol-type-parser = { version = "1", default-features = false, features = [
+  "serde",
+  "std",
+] }
+alloy-sol-types = { version = "1", default-features = false, features = [
+  "json",
+  "std",
+] }
+alloy-transport-http = { version = "1", default-features = false, features = [
+  "reqwest",
+  "reqwest-rustls-tls",
+] }
 bytes = { version = "1", features = ["serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 cipher = { version = "0.4", default-features = false, features = ["zeroize"] }
 clap = { version = "4", features = ["derive", "env"] }
-clap_builder = { version = "4", default-features = false, features = ["color", "env", "help", "std", "suggestions", "usage"] }
+clap_builder = { version = "4", default-features = false, features = [
+  "color",
+  "env",
+  "help",
+  "std",
+  "suggestions",
+  "usage",
+] }
 const-hex = { version = "1", features = ["core-error", "serde"] }
-crypto-common = { version = "0.1", default-features = false, features = ["getrandom", "std"] }
-derive_more = { version = "2", default-features = false, features = ["add", "add_assign", "as_ref", "deref", "deref_mut", "display", "from", "from_str", "index", "index_mut", "into", "into_iterator", "not", "std"] }
+crypto-common = { version = "0.1", default-features = false, features = [
+  "getrandom",
+  "std",
+] }
+derive_more = { version = "2", default-features = false, features = [
+  "add",
+  "add_assign",
+  "as_ref",
+  "deref",
+  "deref_mut",
+  "display",
+  "from",
+  "from_str",
+  "index",
+  "index_mut",
+  "into",
+  "into_iterator",
+  "not",
+  "std",
+] }
 digest = { version = "0.10", features = ["mac", "oid", "std"] }
 ed25519-dalek = { version = "2", features = ["digest", "rand_core"] }
 either = { version = "1", features = ["serde", "use_std"] }
-elliptic-curve = { version = "0.13", default-features = false, features = ["ecdh", "hazmat", "jwk", "pem", "std"] }
+elliptic-curve = { version = "0.13", default-features = false, features = [
+  "ecdh",
+  "hazmat",
+  "jwk",
+  "pem",
+  "std",
+] }
 form_urlencoded = { version = "1" }
 futures-channel = { version = "0.3", features = ["sink"] }
 futures-core = { version = "0.3" }
 futures-executor = { version = "0.3" }
 futures-io = { version = "0.3" }
 futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
-generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "zeroize"] }
+generic-array = { version = "0.14", default-features = false, features = [
+  "more_lengths",
+  "zeroize",
+] }
 hashbrown = { version = "0.16", features = ["serde"] }
 hpke-rs = { version = "0.6", features = ["hazmat", "libcrux", "serialization"] }
 idna = { version = "1" }
 indexmap = { version = "2", features = ["serde"] }
 itertools = { version = "0.14" }
-k256 = { version = "0.13", default-features = false, features = ["ecdh", "ecdsa", "std"] }
-libcrux-ed25519 = { version = "0.0.6", default-features = false, features = ["rand"] }
+k256 = { version = "0.13", default-features = false, features = [
+  "ecdh",
+  "ecdsa",
+  "std",
+] }
+libcrux-ed25519 = { version = "0.0.6", default-features = false, features = [
+  "rand",
+] }
 log = { version = "0.4", default-features = false, features = ["std"] }
 memchr = { version = "2" }
 nu-ansi-term = { version = "0.50" }
 num-traits = { version = "0.2", features = ["libm"] }
-openmls = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14", default-features = false, features = ["extensions-draft-08", "test-utils"] }
-openmls_basic_credential = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14", default-features = false, features = ["clonable", "test-utils"] }
-openmls_memory_storage = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14", default-features = false, features = ["extensions-draft-08", "test-utils"] }
-openmls_rust_crypto = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14", default-features = false, features = ["test-utils"] }
-openmls_traits = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14", features = ["extensions-draft-08", "test-utils"] }
+openmls = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14", default-features = false, features = [
+  "extensions-draft-08",
+  "test-utils",
+] }
+openmls_basic_credential = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14", default-features = false, features = [
+  "clonable",
+  "test-utils",
+] }
+openmls_memory_storage = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14", default-features = false, features = [
+  "extensions-draft-08",
+  "test-utils",
+] }
+openmls_rust_crypto = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14", default-features = false, features = [
+  "test-utils",
+] }
+openmls_traits = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14", features = [
+  "extensions-draft-08",
+  "test-utils",
+] }
 p256 = { version = "0.13", features = ["ecdh", "jwk"] }
 percent-encoding = { version = "2" }
 proc-macro2 = { version = "1", features = ["span-locations"] }
 quote = { version = "1" }
-rand-274715c4dabd11b0 = { package = "rand", version = "0.9", features = ["serde"] }
+rand-274715c4dabd11b0 = { package = "rand", version = "0.9", features = [
+  "serde",
+] }
 rand-93f6ce9d446188ac = { package = "rand", version = "0.10" }
 rand_chacha-274715c4dabd11b0 = { package = "rand_chacha", version = "0.9" }
 rand_chacha-468e82937335b1c9 = { package = "rand_chacha", version = "0.3" }
 rand_chacha-93f6ce9d446188ac = { package = "rand_chacha", version = "0.10" }
-rand_core = { version = "0.9", default-features = false, features = ["os_rng", "serde", "std"] }
+rand_core = { version = "0.9", default-features = false, features = [
+  "os_rng",
+  "serde",
+  "std",
+] }
 regex = { version = "1" }
-regex-automata = { version = "0.4", default-features = false, features = ["dfa-build", "dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
+regex-automata = { version = "0.4", default-features = false, features = [
+  "dfa-build",
+  "dfa-onepass",
+  "hybrid",
+  "meta",
+  "nfa-backtrack",
+  "perf-inline",
+  "perf-literal",
+  "std",
+  "unicode",
+] }
 regex-syntax = { version = "0.8" }
-ruint = { version = "1", default-features = false, features = ["alloy-rlp", "rand-09", "serde", "std"] }
+ruint = { version = "1", default-features = false, features = [
+  "alloy-rlp",
+  "rand-09",
+  "serde",
+  "std",
+] }
 rustc-hash = { version = "2", features = ["rand"] }
 sec1 = { version = "0.7", features = ["pem", "serde", "std", "subtle"] }
 serde = { version = "1", features = ["alloc", "derive", "rc"] }
 serde_core = { version = "1", features = ["alloc", "rc"] }
-serde_json = { version = "1", features = ["alloc", "preserve_order", "raw_value"] }
-serde_spanned = { version = "1", default-features = false, features = ["serde", "std"] }
+serde_json = { version = "1", features = [
+  "alloc",
+  "preserve_order",
+  "raw_value",
+] }
+serde_spanned = { version = "1", default-features = false, features = [
+  "serde",
+  "std",
+] }
 sha1 = { version = "0.10", features = ["compress"] }
 sha3 = { version = "0.10", default-features = false, features = ["asm", "std"] }
 slab = { version = "0.4" }
-smallvec = { version = "1", default-features = false, features = ["const_new", "serde", "union", "write"] }
-subtle = { version = "2", default-features = false, features = ["const-generics", "i128"] }
-syn = { version = "2", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
-sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
+smallvec = { version = "1", default-features = false, features = [
+  "const_new",
+  "serde",
+  "union",
+  "write",
+] }
+subtle = { version = "2", default-features = false, features = [
+  "const-generics",
+  "i128",
+] }
+syn = { version = "2", features = [
+  "extra-traits",
+  "fold",
+  "full",
+  "visit",
+  "visit-mut",
+] }
+sync_wrapper = { version = "1", default-features = false, features = [
+  "futures",
+] }
 time = { version = "0.3", features = ["formatting", "local-offset", "parsing"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = { version = "0.7", features = ["codec", "compat", "io"] }
 toml_datetime = { version = "1", features = ["serde"] }
 toml_parser = { version = "1" }
-tonic = { version = "0.14", default-features = false, features = ["codegen", "router"] }
-tracing = { version = "0.1", features = ["log", "release_max_level_debug"] }
+tonic = { version = "0.14", default-features = false, features = [
+  "codegen",
+  "router",
+] }
+tracing = { version = "0.1", features = ["log"] }
 tracing-core = { version = "0.1" }
-tracing-subscriber = { version = "0.3", features = ["chrono", "env-filter", "json"] }
-typenum = { version = "1", default-features = false, features = ["const-generics"] }
+tracing-subscriber = { version = "0.3", features = [
+  "chrono",
+  "env-filter",
+  "json",
+] }
+typenum = { version = "1", default-features = false, features = [
+  "const-generics",
+] }
 url = { version = "2", features = ["serde"] }
 winnow = { version = "0.7", features = ["simd"] }
-zerocopy = { version = "0.8", default-features = false, features = ["derive", "simd"] }
+zerocopy = { version = "0.8", default-features = false, features = [
+  "derive",
+  "simd",
+] }
 
 [build-dependencies]
-aead = { version = "0.5", default-features = false, features = ["getrandom", "std"] }
+aead = { version = "0.5", default-features = false, features = [
+  "getrandom",
+  "std",
+] }
 aes-gcm = { version = "0.10", features = ["std"] }
-alloy = { version = "1", default-features = false, features = ["contract", "provider-anvil-node", "rand", "reqwest-rustls-tls", "signer-local"] }
-alloy-core = { version = "1", default-features = false, features = ["dyn-abi", "json-abi", "rand", "rlp"] }
-alloy-json-abi = { version = "1", default-features = false, features = ["serde_json", "std"] }
-alloy-primitives = { version = "1", default-features = false, features = ["k256", "map", "rand", "rlp", "serde", "std"] }
-alloy-provider = { version = "1", default-features = false, features = ["anvil-node"] }
-alloy-rpc-client = { version = "1", default-features = false, features = ["reqwest"] }
-alloy-sol-macro = { version = "1", default-features = false, features = ["json"] }
-alloy-sol-macro-expander = { version = "1", default-features = false, features = ["json"] }
-alloy-sol-macro-input = { version = "1", default-features = false, features = ["json"] }
-alloy-sol-type-parser = { version = "1", default-features = false, features = ["serde", "std"] }
-alloy-sol-types = { version = "1", default-features = false, features = ["json", "std"] }
-alloy-transport-http = { version = "1", default-features = false, features = ["reqwest", "reqwest-rustls-tls"] }
+alloy = { version = "1", default-features = false, features = [
+  "contract",
+  "provider-anvil-node",
+  "rand",
+  "reqwest-rustls-tls",
+  "signer-local",
+] }
+alloy-core = { version = "1", default-features = false, features = [
+  "dyn-abi",
+  "json-abi",
+  "rand",
+  "rlp",
+] }
+alloy-json-abi = { version = "1", default-features = false, features = [
+  "serde_json",
+  "std",
+] }
+alloy-primitives = { version = "1", default-features = false, features = [
+  "k256",
+  "map",
+  "rand",
+  "rlp",
+  "serde",
+  "std",
+] }
+alloy-provider = { version = "1", default-features = false, features = [
+  "anvil-node",
+] }
+alloy-rpc-client = { version = "1", default-features = false, features = [
+  "reqwest",
+] }
+alloy-sol-macro = { version = "1", default-features = false, features = [
+  "json",
+] }
+alloy-sol-macro-expander = { version = "1", default-features = false, features = [
+  "json",
+] }
+alloy-sol-macro-input = { version = "1", default-features = false, features = [
+  "json",
+] }
+alloy-sol-type-parser = { version = "1", default-features = false, features = [
+  "serde",
+  "std",
+] }
+alloy-sol-types = { version = "1", default-features = false, features = [
+  "json",
+  "std",
+] }
+alloy-transport-http = { version = "1", default-features = false, features = [
+  "reqwest",
+  "reqwest-rustls-tls",
+] }
 bytes = { version = "1", features = ["serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 cipher = { version = "0.4", default-features = false, features = ["zeroize"] }
 clap = { version = "4", features = ["derive", "env"] }
-clap_builder = { version = "4", default-features = false, features = ["color", "env", "help", "std", "suggestions", "usage"] }
+clap_builder = { version = "4", default-features = false, features = [
+  "color",
+  "env",
+  "help",
+  "std",
+  "suggestions",
+  "usage",
+] }
 const-hex = { version = "1", features = ["core-error", "serde"] }
-crypto-common = { version = "0.1", default-features = false, features = ["getrandom", "std"] }
-derive_more = { version = "2", default-features = false, features = ["add", "add_assign", "as_ref", "deref", "deref_mut", "display", "from", "from_str", "index", "index_mut", "into", "into_iterator", "not", "std"] }
+crypto-common = { version = "0.1", default-features = false, features = [
+  "getrandom",
+  "std",
+] }
+derive_more = { version = "2", default-features = false, features = [
+  "add",
+  "add_assign",
+  "as_ref",
+  "deref",
+  "deref_mut",
+  "display",
+  "from",
+  "from_str",
+  "index",
+  "index_mut",
+  "into",
+  "into_iterator",
+  "not",
+  "std",
+] }
 digest = { version = "0.10", features = ["mac", "oid", "std"] }
 ed25519-dalek = { version = "2", features = ["digest", "rand_core"] }
 either = { version = "1", features = ["serde", "use_std"] }
-elliptic-curve = { version = "0.13", default-features = false, features = ["ecdh", "hazmat", "jwk", "pem", "std"] }
+elliptic-curve = { version = "0.13", default-features = false, features = [
+  "ecdh",
+  "hazmat",
+  "jwk",
+  "pem",
+  "std",
+] }
 form_urlencoded = { version = "1" }
 futures-channel = { version = "0.3", features = ["sink"] }
 futures-core = { version = "0.3" }
 futures-executor = { version = "0.3" }
 futures-io = { version = "0.3" }
 futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
-generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "zeroize"] }
+generic-array = { version = "0.14", default-features = false, features = [
+  "more_lengths",
+  "zeroize",
+] }
 hashbrown = { version = "0.16", features = ["serde"] }
 hpke-rs = { version = "0.6", features = ["hazmat", "libcrux", "serialization"] }
 idna = { version = "1" }
 indexmap = { version = "2", features = ["serde"] }
 itertools = { version = "0.14" }
-k256 = { version = "0.13", default-features = false, features = ["ecdh", "ecdsa", "std"] }
-libcrux-ed25519 = { version = "0.0.6", default-features = false, features = ["rand"] }
+k256 = { version = "0.13", default-features = false, features = [
+  "ecdh",
+  "ecdsa",
+  "std",
+] }
+libcrux-ed25519 = { version = "0.0.6", default-features = false, features = [
+  "rand",
+] }
 log = { version = "0.4", default-features = false, features = ["std"] }
 memchr = { version = "2" }
 nu-ansi-term = { version = "0.50" }
 num-traits = { version = "0.2", features = ["libm"] }
-openmls = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14", default-features = false, features = ["extensions-draft-08", "test-utils"] }
-openmls_basic_credential = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14", default-features = false, features = ["clonable", "test-utils"] }
-openmls_memory_storage = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14", default-features = false, features = ["extensions-draft-08", "test-utils"] }
-openmls_rust_crypto = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14", default-features = false, features = ["test-utils"] }
-openmls_traits = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14", features = ["extensions-draft-08", "test-utils"] }
+openmls = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14", default-features = false, features = [
+  "extensions-draft-08",
+  "test-utils",
+] }
+openmls_basic_credential = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14", default-features = false, features = [
+  "clonable",
+  "test-utils",
+] }
+openmls_memory_storage = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14", default-features = false, features = [
+  "extensions-draft-08",
+  "test-utils",
+] }
+openmls_rust_crypto = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14", default-features = false, features = [
+  "test-utils",
+] }
+openmls_traits = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14", features = [
+  "extensions-draft-08",
+  "test-utils",
+] }
 p256 = { version = "0.13", features = ["ecdh", "jwk"] }
 percent-encoding = { version = "2" }
 proc-macro2 = { version = "1", features = ["span-locations"] }
 quote = { version = "1" }
-rand-274715c4dabd11b0 = { package = "rand", version = "0.9", features = ["serde"] }
+rand-274715c4dabd11b0 = { package = "rand", version = "0.9", features = [
+  "serde",
+] }
 rand-93f6ce9d446188ac = { package = "rand", version = "0.10" }
 rand_chacha-274715c4dabd11b0 = { package = "rand_chacha", version = "0.9" }
 rand_chacha-468e82937335b1c9 = { package = "rand_chacha", version = "0.3" }
 rand_chacha-93f6ce9d446188ac = { package = "rand_chacha", version = "0.10" }
-rand_core = { version = "0.9", default-features = false, features = ["os_rng", "serde", "std"] }
+rand_core = { version = "0.9", default-features = false, features = [
+  "os_rng",
+  "serde",
+  "std",
+] }
 regex = { version = "1" }
-regex-automata = { version = "0.4", default-features = false, features = ["dfa-build", "dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
+regex-automata = { version = "0.4", default-features = false, features = [
+  "dfa-build",
+  "dfa-onepass",
+  "hybrid",
+  "meta",
+  "nfa-backtrack",
+  "perf-inline",
+  "perf-literal",
+  "std",
+  "unicode",
+] }
 regex-syntax = { version = "0.8" }
-ruint = { version = "1", default-features = false, features = ["alloy-rlp", "rand-09", "serde", "std"] }
+ruint = { version = "1", default-features = false, features = [
+  "alloy-rlp",
+  "rand-09",
+  "serde",
+  "std",
+] }
 rustc-hash = { version = "2", features = ["rand"] }
 sec1 = { version = "0.7", features = ["pem", "serde", "std", "subtle"] }
 serde = { version = "1", features = ["alloc", "derive", "rc"] }
 serde_core = { version = "1", features = ["alloc", "rc"] }
-serde_json = { version = "1", features = ["alloc", "preserve_order", "raw_value"] }
-serde_spanned = { version = "1", default-features = false, features = ["serde", "std"] }
+serde_json = { version = "1", features = [
+  "alloc",
+  "preserve_order",
+  "raw_value",
+] }
+serde_spanned = { version = "1", default-features = false, features = [
+  "serde",
+  "std",
+] }
 sha1 = { version = "0.10", features = ["compress"] }
 sha3 = { version = "0.10", default-features = false, features = ["asm", "std"] }
 slab = { version = "0.4" }
-smallvec = { version = "1", default-features = false, features = ["const_new", "serde", "union", "write"] }
-subtle = { version = "2", default-features = false, features = ["const-generics", "i128"] }
-syn = { version = "2", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
-sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
+smallvec = { version = "1", default-features = false, features = [
+  "const_new",
+  "serde",
+  "union",
+  "write",
+] }
+subtle = { version = "2", default-features = false, features = [
+  "const-generics",
+  "i128",
+] }
+syn = { version = "2", features = [
+  "extra-traits",
+  "fold",
+  "full",
+  "visit",
+  "visit-mut",
+] }
+sync_wrapper = { version = "1", default-features = false, features = [
+  "futures",
+] }
 time = { version = "0.3", features = ["formatting", "local-offset", "parsing"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = { version = "0.7", features = ["codec", "compat", "io"] }
 toml_datetime = { version = "1", features = ["serde"] }
 toml_parser = { version = "1" }
-tonic = { version = "0.14", default-features = false, features = ["codegen", "router"] }
-tracing = { version = "0.1", features = ["log", "release_max_level_debug"] }
+tonic = { version = "0.14", default-features = false, features = [
+  "codegen",
+  "router",
+] }
+tracing = { version = "0.1", features = ["log"] }
 tracing-core = { version = "0.1" }
-tracing-subscriber = { version = "0.3", features = ["chrono", "env-filter", "json"] }
-typenum = { version = "1", default-features = false, features = ["const-generics"] }
+tracing-subscriber = { version = "0.3", features = [
+  "chrono",
+  "env-filter",
+  "json",
+] }
+typenum = { version = "1", default-features = false, features = [
+  "const-generics",
+] }
 url = { version = "2", features = ["serde"] }
 winnow = { version = "0.7", features = ["simd"] }
-zerocopy = { version = "0.8", default-features = false, features = ["derive", "simd"] }
+zerocopy = { version = "0.8", default-features = false, features = [
+  "derive",
+  "simd",
+] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 bitflags = { version = "2", default-features = false, features = ["std"] }
 byteorder = { version = "1" }
-getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
-hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "service"] }
-rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+getrandom = { version = "0.4", default-features = false, features = [
+  "std",
+  "sys_rng",
+] }
+hyper-util = { version = "0.1", features = [
+  "client-legacy",
+  "client-proxy",
+  "server-auto",
+  "service",
+] }
+rustls = { version = "0.23", default-features = false, features = [
+  "logging",
+  "ring",
+  "std",
+  "tls12",
+] }
 rustls-pki-types = { version = "1", features = ["std"] }
-rustls-webpki = { version = "0.103", default-features = false, features = ["ring", "std"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
+rustls-webpki = { version = "0.103", default-features = false, features = [
+  "ring",
+  "std",
+] }
+tokio-rustls = { version = "0.26", default-features = false, features = [
+  "logging",
+  "ring",
+  "tls12",
+] }
 tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
-tonic = { version = "0.14", features = ["tls-native-roots", "tls-ring", "tls-webpki-roots"] }
-tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "retry", "timeout"] }
+tonic = { version = "0.14", features = [
+  "tls-native-roots",
+  "tls-ring",
+  "tls-webpki-roots",
+] }
+tower = { version = "0.5", default-features = false, features = [
+  "balance",
+  "buffer",
+  "limit",
+  "load-shed",
+  "retry",
+  "timeout",
+] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
 bitflags = { version = "2", default-features = false, features = ["std"] }
 byteorder = { version = "1" }
 cc = { version = "1", default-features = false, features = ["parallel"] }
-getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
-hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "service"] }
-rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+getrandom = { version = "0.4", default-features = false, features = [
+  "std",
+  "sys_rng",
+] }
+hyper-util = { version = "0.1", features = [
+  "client-legacy",
+  "client-proxy",
+  "server-auto",
+  "service",
+] }
+rustls = { version = "0.23", default-features = false, features = [
+  "logging",
+  "ring",
+  "std",
+  "tls12",
+] }
 rustls-pki-types = { version = "1", features = ["std"] }
-rustls-webpki = { version = "0.103", default-features = false, features = ["ring", "std"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
+rustls-webpki = { version = "0.103", default-features = false, features = [
+  "ring",
+  "std",
+] }
+tokio-rustls = { version = "0.26", default-features = false, features = [
+  "logging",
+  "ring",
+  "tls12",
+] }
 tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
-tonic = { version = "0.14", features = ["tls-native-roots", "tls-ring", "tls-webpki-roots"] }
-tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "retry", "timeout"] }
+tonic = { version = "0.14", features = [
+  "tls-native-roots",
+  "tls-ring",
+  "tls-webpki-roots",
+] }
+tower = { version = "0.5", default-features = false, features = [
+  "balance",
+  "buffer",
+  "limit",
+  "load-shed",
+  "retry",
+  "timeout",
+] }
 
 [target.aarch64-apple-darwin.dependencies]
 bitflags = { version = "2", default-features = false, features = ["std"] }
 byteorder = { version = "1" }
 errno = { version = "0.3" }
-getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
-hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "service"] }
+getrandom = { version = "0.4", default-features = false, features = [
+  "std",
+  "sys_rng",
+] }
+hyper-util = { version = "0.1", features = [
+  "client-legacy",
+  "client-proxy",
+  "server-auto",
+  "service",
+] }
 libc = { version = "0.2" }
-rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls = { version = "0.23", default-features = false, features = [
+  "logging",
+  "ring",
+  "std",
+  "tls12",
+] }
 rustls-pki-types = { version = "1", features = ["std"] }
-rustls-webpki = { version = "0.103", default-features = false, features = ["ring", "std"] }
+rustls-webpki = { version = "0.103", default-features = false, features = [
+  "ring",
+  "std",
+] }
 security-framework-sys = { version = "2" }
-tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
+tokio-rustls = { version = "0.26", default-features = false, features = [
+  "logging",
+  "ring",
+  "tls12",
+] }
 tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
-tonic = { version = "0.14", features = ["tls-native-roots", "tls-ring", "tls-webpki-roots"] }
-tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "retry", "timeout"] }
+tonic = { version = "0.14", features = [
+  "tls-native-roots",
+  "tls-ring",
+  "tls-webpki-roots",
+] }
+tower = { version = "0.5", default-features = false, features = [
+  "balance",
+  "buffer",
+  "limit",
+  "load-shed",
+  "retry",
+  "timeout",
+] }
 
 [target.aarch64-apple-darwin.build-dependencies]
 bitflags = { version = "2", default-features = false, features = ["std"] }
 byteorder = { version = "1" }
 cc = { version = "1", default-features = false, features = ["parallel"] }
 errno = { version = "0.3" }
-getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
-hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "service"] }
+getrandom = { version = "0.4", default-features = false, features = [
+  "std",
+  "sys_rng",
+] }
+hyper-util = { version = "0.1", features = [
+  "client-legacy",
+  "client-proxy",
+  "server-auto",
+  "service",
+] }
 libc = { version = "0.2" }
-rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls = { version = "0.23", default-features = false, features = [
+  "logging",
+  "ring",
+  "std",
+  "tls12",
+] }
 rustls-pki-types = { version = "1", features = ["std"] }
-rustls-webpki = { version = "0.103", default-features = false, features = ["ring", "std"] }
+rustls-webpki = { version = "0.103", default-features = false, features = [
+  "ring",
+  "std",
+] }
 security-framework-sys = { version = "2" }
-tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
+tokio-rustls = { version = "0.26", default-features = false, features = [
+  "logging",
+  "ring",
+  "tls12",
+] }
 tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
-tonic = { version = "0.14", features = ["tls-native-roots", "tls-ring", "tls-webpki-roots"] }
-tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "retry", "timeout"] }
+tonic = { version = "0.14", features = [
+  "tls-native-roots",
+  "tls-ring",
+  "tls-webpki-roots",
+] }
+tower = { version = "0.5", default-features = false, features = [
+  "balance",
+  "buffer",
+  "limit",
+  "load-shed",
+  "retry",
+  "timeout",
+] }
 
 [target.aarch64-linux-android.dependencies]
 bitflags = { version = "2", default-features = false, features = ["std"] }
 byteorder = { version = "1" }
 errno = { version = "0.3" }
-getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
-hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "service"] }
+getrandom = { version = "0.4", default-features = false, features = [
+  "std",
+  "sys_rng",
+] }
+hyper-util = { version = "0.1", features = [
+  "client-legacy",
+  "client-proxy",
+  "server-auto",
+  "service",
+] }
 libc = { version = "0.2" }
-rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls = { version = "0.23", default-features = false, features = [
+  "logging",
+  "ring",
+  "std",
+  "tls12",
+] }
 rustls-pki-types = { version = "1", features = ["std"] }
-rustls-webpki = { version = "0.103", default-features = false, features = ["ring", "std"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
+rustls-webpki = { version = "0.103", default-features = false, features = [
+  "ring",
+  "std",
+] }
+tokio-rustls = { version = "0.26", default-features = false, features = [
+  "logging",
+  "ring",
+  "tls12",
+] }
 tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
 tonic = { version = "0.14", features = ["tls-ring", "tls-webpki-roots"] }
-tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "retry", "timeout"] }
+tower = { version = "0.5", default-features = false, features = [
+  "balance",
+  "buffer",
+  "limit",
+  "load-shed",
+  "retry",
+  "timeout",
+] }
 
 [target.aarch64-linux-android.build-dependencies]
 bitflags = { version = "2", default-features = false, features = ["std"] }
 byteorder = { version = "1" }
 cc = { version = "1", default-features = false, features = ["parallel"] }
 errno = { version = "0.3" }
-getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
-hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "service"] }
+getrandom = { version = "0.4", default-features = false, features = [
+  "std",
+  "sys_rng",
+] }
+hyper-util = { version = "0.1", features = [
+  "client-legacy",
+  "client-proxy",
+  "server-auto",
+  "service",
+] }
 libc = { version = "0.2" }
-rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls = { version = "0.23", default-features = false, features = [
+  "logging",
+  "ring",
+  "std",
+  "tls12",
+] }
 rustls-pki-types = { version = "1", features = ["std"] }
-rustls-webpki = { version = "0.103", default-features = false, features = ["ring", "std"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
+rustls-webpki = { version = "0.103", default-features = false, features = [
+  "ring",
+  "std",
+] }
+tokio-rustls = { version = "0.26", default-features = false, features = [
+  "logging",
+  "ring",
+  "tls12",
+] }
 tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
 tonic = { version = "0.14", features = ["tls-ring", "tls-webpki-roots"] }
-tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "retry", "timeout"] }
+tower = { version = "0.5", default-features = false, features = [
+  "balance",
+  "buffer",
+  "limit",
+  "load-shed",
+  "retry",
+  "timeout",
+] }
 
 [target.x86_64-linux-android.dependencies]
 bitflags = { version = "2", default-features = false, features = ["std"] }
 byteorder = { version = "1" }
 errno = { version = "0.3" }
-getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
-hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "service"] }
-rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+getrandom = { version = "0.4", default-features = false, features = [
+  "std",
+  "sys_rng",
+] }
+hyper-util = { version = "0.1", features = [
+  "client-legacy",
+  "client-proxy",
+  "server-auto",
+  "service",
+] }
+rustls = { version = "0.23", default-features = false, features = [
+  "logging",
+  "ring",
+  "std",
+  "tls12",
+] }
 rustls-pki-types = { version = "1", features = ["std"] }
-rustls-webpki = { version = "0.103", default-features = false, features = ["ring", "std"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
+rustls-webpki = { version = "0.103", default-features = false, features = [
+  "ring",
+  "std",
+] }
+tokio-rustls = { version = "0.26", default-features = false, features = [
+  "logging",
+  "ring",
+  "tls12",
+] }
 tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
 tonic = { version = "0.14", features = ["tls-ring", "tls-webpki-roots"] }
-tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "retry", "timeout"] }
+tower = { version = "0.5", default-features = false, features = [
+  "balance",
+  "buffer",
+  "limit",
+  "load-shed",
+  "retry",
+  "timeout",
+] }
 
 [target.x86_64-linux-android.build-dependencies]
 bitflags = { version = "2", default-features = false, features = ["std"] }
 byteorder = { version = "1" }
 cc = { version = "1", default-features = false, features = ["parallel"] }
 errno = { version = "0.3" }
-getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
-hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "service"] }
-rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+getrandom = { version = "0.4", default-features = false, features = [
+  "std",
+  "sys_rng",
+] }
+hyper-util = { version = "0.1", features = [
+  "client-legacy",
+  "client-proxy",
+  "server-auto",
+  "service",
+] }
+rustls = { version = "0.23", default-features = false, features = [
+  "logging",
+  "ring",
+  "std",
+  "tls12",
+] }
 rustls-pki-types = { version = "1", features = ["std"] }
-rustls-webpki = { version = "0.103", default-features = false, features = ["ring", "std"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
+rustls-webpki = { version = "0.103", default-features = false, features = [
+  "ring",
+  "std",
+] }
+tokio-rustls = { version = "0.26", default-features = false, features = [
+  "logging",
+  "ring",
+  "tls12",
+] }
 tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
 tonic = { version = "0.14", features = ["tls-ring", "tls-webpki-roots"] }
-tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "retry", "timeout"] }
+tower = { version = "0.5", default-features = false, features = [
+  "balance",
+  "buffer",
+  "limit",
+  "load-shed",
+  "retry",
+  "timeout",
+] }
 
 ### END HAKARI SECTION


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add Android-specific tracing filter for `send_message` and MLS sync paths
- Replaces the single `xmtp_api=debug` directive with a multi-target filter defined in the new `ANDROID_TRACING_FILTER` constant in [logger.rs](https://github.com/xmtp/libxmtp/pull/3358/files#diff-9d8abec9a152321af4b2de4c3e41865e58cdcc8b6ac56aa49c772ba6321aad33), enabling TRACE for `xmtp_mls::groups::send_message` and `send_message_optimistic`, and DEBUG for `xmtp_mls::mls_sync` and `xmtp_api_d14n`.
- Raises the compile-time tracing ceiling in [bindings/mobile/Cargo.toml](https://github.com/xmtp/libxmtp/pull/3358/files#diff-e69537bf3f87bfe7986ed8487446dd8bcb6724e9cea2d59f49123f146939f242) from `release_max_level_debug` to `release_max_level_trace` so TRACE-level events are not elided at compile time in release builds.
- Behavioral Change: Android release builds will now emit TRACE-level log events for the send message code paths, which may increase log volume on device.

<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized a4d5b38. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>

### 🗂️ Filtered Issues

</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->