### PR TITLE
fix: compiler errors due to missing trait implementation items if extensions-draft-08 feature is not enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,9 +85,13 @@ openmls = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da981
   "extensions-draft-08",
 ] }
 openmls_basic_credential = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14" }
-openmls_libcrux_crypto = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14" }
+openmls_libcrux_crypto = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14", features = [
+  "extensions-draft-08",
+] }
 openmls_rust_crypto = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14" }
-openmls_traits = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14" }
+openmls_traits = { git = "https://github.com/xmtp/openmls", rev = "42f1479cdb06727da98132dfc2cc3959f2c66a14", features = [
+  "extensions-draft-08",
+] }
 owo-colors = { version = "4.1" }
 p256 = { version = "0.13.2", features = ["ecdsa"] }
 parking_lot = "0.12.3"


### PR DESCRIPTION
# Description

This PR fixes compiler errors due to missing trait implementation items when the extensions-draft-08 feature is not enabled in the relevant mls-crates. The build process will crash because lack of some trait methods that are required when implementing the `StorageProvider` trait. Therefore this PR enables the extensions-draft-08 feature not only for the `openmls` crate itself, but also for the `openmls_libcrux_crypto` and the `openmls_traits crate`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix compiler errors by enabling `extensions-draft-08` feature for crypto dependencies
> Adds the `extensions-draft-08` feature flag to the `openmls_libcrux_crypto` and `openmls_traits` git dependencies in [Cargo.toml](https://github.com/xmtp/libxmtp/pull/3366/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542). Without this flag, required trait implementation items were missing, causing compilation failures.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 95fb1e2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->