### PR TITLE
feat: add is_d14n() method to XmtpQuery trait

### DIFF
--- a/crates/xmtp_api/src/xmtp_query.rs
+++ b/crates/xmtp_api/src/xmtp_query.rs
@@ -9,6 +9,10 @@ where
 {
     type Error = <C as XmtpQuery>::Error;
 
+    fn is_d14n(&self) -> Result<bool, Self::Error> {
+        <C as XmtpQuery>::is_d14n(&self.api_client)
+    }
+
     async fn query_at(
         &self,
         topic: Topic,

--- a/crates/xmtp_api_d14n/src/protocol/traits/xmtp_query.rs
+++ b/crates/xmtp_api_d14n/src/protocol/traits/xmtp_query.rs
@@ -15,6 +15,13 @@ pub trait XmtpQuery: MaybeSend + MaybeSync {
         topic: Topic,
         at: Option<GlobalCursor>,
     ) -> Result<XmtpEnvelope, Self::Error>;
+
+    /// Whether this client is connected to a d14n network.
+    /// V3 clients return `false` (default). D14n clients return `true`.
+    /// MigrationClients check the migration cutover state.
+    fn is_d14n(&self) -> Result<bool, Self::Error> {
+        Ok(false)
+    }
 }
 
 // hides implementation detail of XmtpEnvelope/traits

--- a/crates/xmtp_api_d14n/src/queries/api_stats.rs
+++ b/crates/xmtp_api_d14n/src/queries/api_stats.rs
@@ -253,6 +253,10 @@ where
 impl<C: XmtpQuery> XmtpQuery for TrackedStatsClient<C> {
     type Error = <C as XmtpQuery>::Error;
 
+    fn is_d14n(&self) -> Result<bool, Self::Error> {
+        <C as XmtpQuery>::is_d14n(&self.inner)
+    }
+
     async fn query_at(
         &self,
         topic: xmtp_proto::types::Topic,

--- a/crates/xmtp_api_d14n/src/queries/boxed_streams.rs
+++ b/crates/xmtp_api_d14n/src/queries/boxed_streams.rs
@@ -212,6 +212,10 @@ where
 impl<C: XmtpQuery> XmtpQuery for BoxedStreamsClient<C> {
     type Error = <C as XmtpQuery>::Error;
 
+    fn is_d14n(&self) -> Result<bool, Self::Error> {
+        <C as XmtpQuery>::is_d14n(&self.inner)
+    }
+
     async fn query_at(
         &self,
         topic: xmtp_proto::types::Topic,

--- a/crates/xmtp_api_d14n/src/queries/builder/impls.rs
+++ b/crates/xmtp_api_d14n/src/queries/builder/impls.rs
@@ -11,6 +11,10 @@ where
 {
     type Error = T::Error;
 
+    fn is_d14n(&self) -> Result<bool, Self::Error> {
+        <T as XmtpQuery>::is_d14n(&**self)
+    }
+
     /// Query every [`Topic`] at [`GlobalCursor`]
     async fn query_at(
         &self,
@@ -27,6 +31,10 @@ where
     T: XmtpQuery + ?Sized,
 {
     type Error = T::Error;
+
+    fn is_d14n(&self) -> Result<bool, Self::Error> {
+        <T as XmtpQuery>::is_d14n(&**self)
+    }
 
     /// Query every [`Topic`] at [`GlobalCursor`]
     async fn query_at(

--- a/crates/xmtp_api_d14n/src/queries/combined/tests.rs
+++ b/crates/xmtp_api_d14n/src/queries/combined/tests.rs
@@ -10,6 +10,7 @@ use xmtp_proto::xmtp::migration::api::v1::FetchD14nCutoverResponse;
 use super::*;
 use crate::V3Client;
 use crate::protocol::InMemoryCursorStore;
+use crate::protocol::XmtpQuery;
 
 /// Wrapper around `Arc<MockNetworkClient>` that also implements [`IsConnectedCheck`].
 /// `Arc<MockNetworkClient>` already implements `Client` + `Clone`.
@@ -271,4 +272,26 @@ async fn write_with_refresh_does_not_retry_on_other_error() {
     assert!(result.is_err());
     // Should only be called once — no retry
     assert_eq!(call_count.load(std::sync::atomic::Ordering::SeqCst), 1);
+}
+
+#[xmtp_common::test(unwrap_try = true)]
+async fn is_d14n_returns_false_before_migration() {
+    let store = InMemoryCursorStore::new();
+    let far_future = xmtp_common::time::now_ns() + CUTOVER_REFRESH_TIME * 10;
+    store.set_cutover_ns(far_future)?;
+
+    let v3 = mock_v3_with_cutover(far_future as u64);
+    let client = build_test_client(v3, TestNetworkClient::new(), store);
+
+    assert!(!client.is_d14n()?);
+}
+
+#[xmtp_common::test(unwrap_try = true)]
+async fn is_d14n_returns_true_after_migration() {
+    let store = InMemoryCursorStore::new();
+    store.set_has_migrated(true)?;
+
+    let client = build_test_client(TestNetworkClient::new(), TestNetworkClient::new(), store);
+
+    assert!(client.is_d14n()?);
 }

--- a/crates/xmtp_api_d14n/src/queries/combined/xmtp_query.rs
+++ b/crates/xmtp_api_d14n/src/queries/combined/xmtp_query.rs
@@ -20,6 +20,10 @@ where
 {
     type Error = ApiClientError;
 
+    fn is_d14n(&self) -> Result<bool, Self::Error> {
+        Ok(self.store.has_migrated()?)
+    }
+
     // WARN query_at is used only in tests so far, so
     // defaulting to XMTPD is no big deal
     // if query_at is used outside of tests it may not have expected behavior

--- a/crates/xmtp_api_d14n/src/queries/d14n/xmtp_query.rs
+++ b/crates/xmtp_api_d14n/src/queries/d14n/xmtp_query.rs
@@ -19,6 +19,10 @@ where
 {
     type Error = ApiClientError;
 
+    fn is_d14n(&self) -> Result<bool, Self::Error> {
+        Ok(true)
+    }
+
     async fn query_at(
         &self,
         topic: Topic,


### PR DESCRIPTION
## Summary

Adds `is_d14n() -> Result<bool, Error>` to the `XmtpQuery` trait so callers can explicitly determine whether a client is connected to a d14n network, without relying on indirect signals like cursor presence.

- **D14nClient** → returns `true`
- **V3Client** → uses default (`false`)
- **MigrationClient** → checks `has_migrated()` from the cursor store
- All wrapper types (BoxedStreams, TrackedStats, Box, Arc, ApiClientWrapper) delegate to inner

## Test plan

- [x] `is_d14n_returns_false_before_migration` — MigrationClient pre-cutover returns false
- [x] `is_d14n_returns_true_after_migration` — MigrationClient post-cutover returns true
- [x] All existing combined/migration client tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `is_d14n()` method to `XmtpQuery` trait to report decentralization status
> - Adds `is_d14n()` as a default method on the `XmtpQuery` trait in [xmtp_query.rs](https://github.com/xmtp/libxmtp/pull/3376/files#diff-9768d19ea0ee8c963c6d1f3d28c00cfa6f276cebef9c0b7beb5b003dea44832c), returning `Ok(false)` by default.
> - `D14nClient` overrides it to return `Ok(true)`; `CombinedClient` delegates to `store.has_migrated()` to reflect cutover state.
> - All delegating wrappers (`TrackedStatsClient`, `BoxedStreamsClient`, builder impls, and the `xmtp_api` wrapper) forward the call to their inner client.
> - Two tests verify the combined client returns `false` before migration and `true` after.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4433d23.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->