### PR TITLE
fix aarch64 musl docker image build in github CI & xmtp_cli build

### DIFF
--- a/.github/workflows/fh-cache.yml
+++ b/.github/workflows/fh-cache.yml
@@ -52,7 +52,7 @@ jobs:
             sandbox = relaxed
       - run: nix build --version
       - name: build validation service image
-        run: nix build .#validation-service-image-aarch64-multiplatform
+        run: nix build .#validation-service-image-aarch64-unknown-linux-musl
       - name: push to cachix
         if: github.ref_name == 'main'
         run: nix run nixpkgs#cachix -- push xmtp ./result

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -32,7 +32,7 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 timeago = "0.6.0"
-tokio.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 tracing = { workspace = true, features = ["valuable"] }
 tracing-subscriber = { workspace = true, features = [
   "json",


### PR DESCRIPTION
cache nix was failing b/c of the xmtp_cli feature change:

```
  xmtp_cli>    Compiling xmtp-workspace-hack v0.1.0 (/tmp/nix-build-xmtp_cli-1.10.0.drv-0/source/crates/xmtp-workspace-hack)
  xmtp_cli>    Compiling xmtp_macro v1.10.0 (/tmp/nix-build-xmtp_cli-1.10.0.drv-0/source/crates/xmtp_macro)
  xmtp_cli>    Compiling xmtp_proto v1.10.0 (/tmp/nix-build-xmtp_cli-1.10.0.drv-0/source/crates/xmtp_proto)
  xmtp_cli>    Compiling xmtp_cryptography v1.10.0 (/tmp/nix-build-xmtp_cli-1.10.0.drv-0/source/crates/xmtp_cryptography)
  xmtp_cli>    Compiling xmtp_common v1.10.0 (/tmp/nix-build-xmtp_cli-1.10.0.drv-0/source/crates/xmtp_common)
  xmtp_cli>    Compiling xmtp_configuration v1.10.0 (/tmp/nix-build-xmtp_cli-1.10.0.drv-0/source/crates/xmtp_configuration)
  xmtp_cli>    Compiling xmtp_id v1.10.0 (/tmp/nix-build-xmtp_cli-1.10.0.drv-0/source/crates/xmtp_id)
  xmtp_cli>    Compiling xmtp_content_types v1.10.0 (/tmp/nix-build-xmtp_cli-1.10.0.drv-0/source/crates/xmtp_content_types)
  xmtp_cli>    Compiling xmtp_api_grpc v1.10.0 (/tmp/nix-build-xmtp_cli-1.10.0.drv-0/source/crates/xmtp_api_grpc)
  xmtp_cli>    Compiling xmtp_db v1.10.0 (/tmp/nix-build-xmtp_cli-1.10.0.drv-0/source/crates/xmtp_db)
  xmtp_cli>    Compiling xmtp_api_d14n v1.10.0 (/tmp/nix-build-xmtp_cli-1.10.0.drv-0/source/crates/xmtp_api_d14n)
  xmtp_cli>    Compiling xmtp_api v1.10.0 (/tmp/nix-build-xmtp_cli-1.10.0.drv-0/source/crates/xmtp_api)
  xmtp_cli>    Compiling xmtp_mls_common v1.10.0 (/tmp/nix-build-xmtp_cli-1.10.0.drv-0/source/crates/xmtp_mls_common)
  xmtp_cli>    Compiling xmtp_archive v1.10.0 (/tmp/nix-build-xmtp_cli-1.10.0.drv-0/source/crates/xmtp_archive)
  xmtp_cli>    Compiling xmtp_mls v1.10.0 (/tmp/nix-build-xmtp_cli-1.10.0.drv-0/source/crates/xmtp_mls)
  xmtp_cli>    Compiling xmtp_cli v1.10.0 (/tmp/nix-build-xmtp_cli-1.10.0.drv-0/source/apps/cli)
  xmtp_cli> error: The default runtime flavor is `multi_thread`, but the `rt-multi-thread` feature is disabled.
  xmtp_cli>    --> apps/cli/cli-client.rs:199:1
  xmtp_cli>     |
  xmtp_cli> 199 | #[tokio::main]
  xmtp_cli>     | ^^^^^^^^^^^^^^
  xmtp_cli>     |
  xmtp_cli>     = note: this error originates in the attribute macro `tokio::main` (in Nightly builds, run with -Z macro-backtrace for more info)
  xmtp_cli> 
  xmtp_cli> error: could not compile `xmtp_cli` (bin "xmtp_cli") due to 1 previous error
  error: Cannot build '/nix/store/l7nvrxalr0q1jnsgfi9rfspg1v6shafj-xmtp_cli-1.10.0.drv'.
         Reason: builder failed with exit code 101.
         Output paths:
           /nix/store/9b56a3l5jj6091gzyk52j9mynypsjs9r-xmtp_cli-1.10.0
  error: Cannot build '/nix/store/0y77vbwada911bj6whn0b7bn073nw0sr-devour-output.json.drv'.
         Reason: 1 dependency failed.
         Output paths:
           /nix/store/1n54c6pgnknmqdik48mphi8nhq6bm2nc-devour-output.json
Error: `nix build` failed; exit code: Some(1)

```

the other issue was renaming of the aarch64-musl build to the rustc target, but not changing the github ci action along with that



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix aarch64 musl Docker image build and `xmtp_cli` build in CI
> - Fixes the CI workflow by correcting the Nix build target in [fh-cache.yml](.github/workflows/fh-cache.yml) from `validation-service-image-aarch64-multiplatform` to `validation-service-image-aarch64-unknown-linux-musl`.
> - Adds the `rt-multi-thread` feature to the `tokio` dependency in [apps/cli/Cargo.toml](https://github.com/xmtp/libxmtp/pull/3383/files#diff-c640a6a2f9478e531a7fdf419fc88cce2394055831d2d7dd1ab225c1e6cba8a6) to fix the `xmtp_cli` build.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6057a95.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->