### PR TITLE
Add gh CLI to Nix dev shell

### DIFF
--- a/nix/lib/shell-common.nix
+++ b/nix/lib/shell-common.nix
@@ -33,6 +33,7 @@
   flamegraph,
   cargo-flamegraph,
   inferno,
+  gh,
   jq,
   curl,
   graphite-cli,
@@ -160,6 +161,7 @@ in
 
   # Miscellaneous dev convenience tools
   miscDevTools = [
+    gh
     jq
     curl
     graphite-cli


### PR DESCRIPTION
## Summary
- Adds the GitHub CLI (`gh`) to the `miscDevTools` list in `nix/lib/shell-common.nix`
- This makes `gh` available in all local Nix dev shells (default, rust, etc.)

Resolves https://github.com/xmtp/libxmtp/issues/3381

## Verification
- `nix eval .#devShells.x86_64-linux.default.buildInputs` confirms `gh-2.86.0` is included
- Change is minimal: two lines added (parameter declaration + list entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `gh` CLI to Nix dev shell
> Adds the GitHub CLI (`gh`) as a parameter in [shell-common.nix](https://github.com/xmtp/libxmtp/pull/3384/files#diff-1f86dcadca00cc4a528e235290e0cda34a83dc00a67559c6db6d4b2008d4b24c) and includes it in the `miscDevTools` list alongside `jq`, `curl`, and `graphite-cli`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ae50d31.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->