### PR TITLE
Add component-based permission system for app data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12455,9 +12455,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -17776,6 +17776,7 @@ dependencies = [
  "alloy",
  "async-trait",
  "bincode 1.3.3",
+ "bon",
  "bytes",
  "chrono",
  "const-hex",
@@ -17853,6 +17854,7 @@ dependencies = [
 name = "xmtp_mls_common"
 version = "1.10.0"
 dependencies = [
+ "bon",
  "const-hex",
  "openmls",
  "proptest",

--- a/crates/xmtp_mls/Cargo.toml
+++ b/crates/xmtp_mls/Cargo.toml
@@ -59,6 +59,7 @@ dev = ["xmtp_configuration/dev", "xmtp_proto/dev", "xmtp_api_d14n/dev"]
 aes-gcm.workspace = true
 async-trait.workspace = true
 bincode.workspace = true
+bon.workspace = true
 bytes.workspace = true
 derive_builder.workspace = true
 futures = { workspace = true, features = ["alloc", "std"] }

--- a/crates/xmtp_mls_common/Cargo.toml
+++ b/crates/xmtp_mls_common/Cargo.toml
@@ -11,6 +11,7 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
+bon.workspace = true
 hex.workspace = true
 openmls.workspace = true
 prost.workspace = true

--- a/crates/xmtp_mls_common/src/app_data/component_id.rs
+++ b/crates/xmtp_mls_common/src/app_data/component_id.rs
@@ -1,0 +1,398 @@
+use std::fmt;
+use std::io::{Read, Write};
+
+use tls_codec::{Deserialize, Serialize, Size};
+
+// ============================================================================
+// Component ID Ranges
+// ============================================================================
+//
+// ComponentIds occupy the top half of the u16 space (0x8000-0xFFFF).
+// The space is split between XMTP protocol and application use, with
+// immutable ranges at the end of each block (counting down).
+
+/// Start of the component ID space (top half of u16).
+const COMPONENT_RANGE_START: u16 = 0x8000;
+
+// --- XMTP Protocol Range: 0x8000-0xBFFF ---
+const XMTP_RANGE_START: u16 = 0x8000;
+const XMTP_RANGE_END: u16 = 0xBFFF;
+/// Immutable XMTP components: 0xBE00-0xBFFF (512 IDs, counting down).
+const XMTP_IMMUTABLE_START: u16 = 0xBE00;
+
+// --- Application Range: 0xC000-0xFEFF ---
+const APP_RANGE_START: u16 = 0xC000;
+const APP_RANGE_END: u16 = 0xFEFF;
+/// Immutable application components: 0xFD00-0xFEFF (512 IDs, counting down).
+const APP_IMMUTABLE_START: u16 = 0xFD00;
+
+// --- Reserved: 0xFF00-0xFFFF ---
+const COMPONENT_RESERVED_START: u16 = 0xFF00;
+
+// Compile-time invariant checks: if any of the range constants are ever
+// changed in a way that breaks these assumptions, this will fail to build.
+// The validation logic in `ComponentRegistry` relies on these — the ranges
+// must be contiguous, non-overlapping, and immutable subranges must sit at
+// the end of their parent block.
+const _RANGE_INVARIANTS: () = {
+    // The component space starts at exactly the XMTP range.
+    assert!(XMTP_RANGE_START == COMPONENT_RANGE_START);
+    assert!(XMTP_RANGE_START < XMTP_RANGE_END);
+    // XMTP, App, and Reserved are contiguous and non-overlapping.
+    assert!(APP_RANGE_START == XMTP_RANGE_END + 1);
+    assert!(APP_RANGE_START < APP_RANGE_END);
+    assert!(COMPONENT_RESERVED_START == APP_RANGE_END + 1);
+    // Immutable subranges sit strictly inside their parent block, at the end.
+    assert!(XMTP_IMMUTABLE_START > XMTP_RANGE_START);
+    assert!(XMTP_IMMUTABLE_START <= XMTP_RANGE_END);
+    assert!(APP_IMMUTABLE_START > APP_RANGE_START);
+    assert!(APP_IMMUTABLE_START <= APP_RANGE_END);
+};
+
+/// A component identifier in the XMTP app data system.
+///
+/// ComponentIds occupy the top half of the u16 space (`0x8000-0xFFFF`), split
+/// between XMTP protocol use (`0x8000-0xBFFF`) and application-defined
+/// components (`0xC000-0xFEFF`), with `0xFF00-0xFFFF` reserved.
+///
+/// Immutable ranges sit at the end of each block (last 512 IDs, counting down).
+/// Components in these ranges can be written once but never updated or deleted.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ComponentId(u16);
+
+impl ComponentId {
+    // === Hardcoded Component IDs ===
+    // Permissions for these are enforced in code, not in the permissions map.
+
+    /// The component registry. Super admin only.
+    pub const COMPONENT_REGISTRY: Self = Self(0x8000);
+    /// The super admin list. Super admin only.
+    pub const SUPER_ADMIN_LIST: Self = Self(0x8001);
+    /// The admin list. Configurable: super admin only or admin/super admin.
+    pub const ADMIN_LIST: Self = Self(0x8002);
+
+    // === Well-Known Mutable XMTP Component IDs (counting up from 0x8003) ===
+
+    pub const GROUP_MEMBERSHIP: Self = Self(0x8003);
+    pub const GROUP_NAME: Self = Self(0x8004);
+    pub const GROUP_DESCRIPTION: Self = Self(0x8005);
+    pub const GROUP_IMAGE_URL: Self = Self(0x8006);
+    pub const MESSAGE_DISAPPEAR_FROM_NS: Self = Self(0x8007);
+    pub const MESSAGE_DISAPPEAR_IN_NS: Self = Self(0x8008);
+    pub const APP_DATA: Self = Self(0x8009);
+    pub const MIN_SUPPORTED_PROTOCOL_VERSION: Self = Self(0x800A);
+    pub const COMMIT_LOG_SIGNER: Self = Self(0x800B);
+
+    // === Well-Known Immutable XMTP Component IDs (counting down from 0xBFFF) ===
+
+    pub const CONVERSATION_TYPE: Self = Self(0xBFFF);
+    pub const CREATOR_INBOX_ID: Self = Self(0xBFFE);
+    pub const DM_MEMBERS: Self = Self(0xBFFD);
+    pub const ONESHOT_MESSAGE: Self = Self(0xBFFC);
+
+    // === Constructor and Accessors ===
+
+    pub const fn new(id: u16) -> Self {
+        Self(id)
+    }
+
+    pub const fn as_u16(self) -> u16 {
+        self.0
+    }
+
+    // === Range Helpers ===
+
+    /// Returns true if the ID is in the component ID space (top half of u16).
+    /// Note: this includes the reserved range (`0xFF00-0xFFFF`); use
+    /// [`is_reserved`](Self::is_reserved) to distinguish.
+    pub const fn is_in_component_space(self) -> bool {
+        self.0 >= COMPONENT_RANGE_START
+    }
+
+    /// Returns true if the ID is in the XMTP protocol range (`0x8000-0xBFFF`).
+    pub const fn is_xmtp_range(self) -> bool {
+        self.0 >= XMTP_RANGE_START && self.0 <= XMTP_RANGE_END
+    }
+
+    /// Returns true if the ID is in the application range (`0xC000-0xFEFF`).
+    pub const fn is_app_range(self) -> bool {
+        self.0 >= APP_RANGE_START && self.0 <= APP_RANGE_END
+    }
+
+    /// Returns true if the ID is in the reserved range (`0xFF00-0xFFFF`).
+    pub const fn is_reserved(self) -> bool {
+        self.0 >= COMPONENT_RESERVED_START
+    }
+
+    /// Returns true if the ID is in an immutable range.
+    /// Immutable components can be inserted once but never updated or deleted.
+    pub const fn is_immutable(self) -> bool {
+        (self.0 >= XMTP_IMMUTABLE_START && self.0 <= XMTP_RANGE_END)
+            || (self.0 >= APP_IMMUTABLE_START && self.0 <= APP_RANGE_END)
+    }
+
+    /// Returns true if this is one of the hardcoded components whose
+    /// permissions are enforced in code rather than the component registry.
+    pub const fn is_hardcoded(self) -> bool {
+        self.0 == Self::COMPONENT_REGISTRY.0 || self.0 == Self::SUPER_ADMIN_LIST.0
+    }
+
+    /// Returns true if this component has constrained permission values.
+    /// Constrained components can only have their permissions set to the
+    /// proto base policies `AllowIfAdmin` (admin or super admin) or
+    /// `AllowIfSuperAdmin` (super admin only).
+    pub const fn is_constrained(self) -> bool {
+        self.0 == Self::ADMIN_LIST.0
+    }
+}
+
+impl fmt::Debug for ComponentId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ComponentId(0x{:04X})", self.0)
+    }
+}
+
+impl fmt::Display for ComponentId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "0x{:04X}", self.0)
+    }
+}
+
+impl From<u16> for ComponentId {
+    fn from(id: u16) -> Self {
+        Self(id)
+    }
+}
+
+impl From<ComponentId> for u16 {
+    fn from(id: ComponentId) -> Self {
+        id.0
+    }
+}
+
+// === TLS Codec ===
+//
+// ComponentIds are encoded using QUIC variable-length integer encoding
+// (RFC 9000 §16) rather than a fixed `u16`. This is forward-compatible:
+// the underlying type can grow beyond `u16` in the future without breaking
+// the wire format. The encoding uses 1, 2, 4, or 8 bytes depending on
+// magnitude — current IDs (`0x8000-0xFFFF`) take 4 bytes.
+
+/// Number of bytes a QUIC variable-length integer needs to encode `value`.
+///
+/// We delegate to `tls_codec::vlen::write_length` against a fixed-size stack
+/// buffer rather than reimplementing the size table — that way our sizing
+/// can never drift from what `tls_codec` actually emits, even if upstream
+/// boundaries ever change. The 8-byte buffer is the maximum any QUIC vlen
+/// encoding requires (RFC 9000 §16), so the write cannot fail with
+/// `EndOfBuffer`.
+fn vlen_encoding_bytes(value: usize) -> usize {
+    let mut buf = [0u8; 8];
+    let mut slice: &mut [u8] = &mut buf;
+    tls_codec::vlen::write_length(&mut slice, value)
+        .expect("8-byte buffer fits any QUIC vlen encoding")
+}
+
+impl Size for ComponentId {
+    fn tls_serialized_len(&self) -> usize {
+        vlen_encoding_bytes(self.0 as usize)
+    }
+}
+
+impl Serialize for ComponentId {
+    fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, tls_codec::Error> {
+        tls_codec::vlen::write_length(writer, self.0 as usize)
+    }
+}
+
+impl Deserialize for ComponentId {
+    fn tls_deserialize<R: Read>(bytes: &mut R) -> Result<Self, tls_codec::Error>
+    where
+        Self: Sized,
+    {
+        let (value, _len_len) = tls_codec::vlen::read_length(bytes)?;
+        if value > u16::MAX as usize {
+            return Err(tls_codec::Error::DecodingError(format!(
+                "ComponentId value {value} exceeds u16::MAX; this version of \
+                 the library cannot decode IDs larger than 0xFFFF"
+            )));
+        }
+        Ok(Self(value as u16))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tls_codec::{Deserialize, Serialize};
+
+    #[xmtp_common::test]
+    fn test_well_known_ids_are_in_expected_ranges() {
+        // Hardcoded
+        assert!(ComponentId::COMPONENT_REGISTRY.is_hardcoded());
+        assert!(ComponentId::SUPER_ADMIN_LIST.is_hardcoded());
+        assert!(!ComponentId::ADMIN_LIST.is_hardcoded());
+
+        // Constrained
+        assert!(ComponentId::ADMIN_LIST.is_constrained());
+        assert!(!ComponentId::GROUP_NAME.is_constrained());
+
+        // Mutable XMTP
+        assert!(ComponentId::GROUP_MEMBERSHIP.is_xmtp_range());
+        assert!(ComponentId::GROUP_NAME.is_xmtp_range());
+        assert!(!ComponentId::GROUP_NAME.is_immutable());
+        assert!(!ComponentId::GROUP_NAME.is_hardcoded());
+        assert!(ComponentId::MIN_SUPPORTED_PROTOCOL_VERSION.is_xmtp_range());
+        assert!(!ComponentId::MIN_SUPPORTED_PROTOCOL_VERSION.is_immutable());
+        assert!(ComponentId::COMMIT_LOG_SIGNER.is_xmtp_range());
+        assert!(!ComponentId::COMMIT_LOG_SIGNER.is_immutable());
+
+        // Immutable XMTP
+        assert!(ComponentId::CONVERSATION_TYPE.is_immutable());
+        assert!(ComponentId::CREATOR_INBOX_ID.is_immutable());
+        assert!(ComponentId::CONVERSATION_TYPE.is_xmtp_range());
+        assert!(ComponentId::DM_MEMBERS.is_immutable());
+        assert!(ComponentId::DM_MEMBERS.is_xmtp_range());
+        assert!(ComponentId::ONESHOT_MESSAGE.is_immutable());
+        assert!(ComponentId::ONESHOT_MESSAGE.is_xmtp_range());
+    }
+
+    #[xmtp_common::test]
+    fn test_range_boundaries() {
+        // XMTP mutable (just after hardcoded)
+        assert!(ComponentId::new(0x8003).is_xmtp_range());
+        assert!(!ComponentId::new(0x8003).is_immutable());
+
+        // The newest mutable XMTP IDs sit just past APP_DATA at 0x800A and 0x800B.
+        assert!(ComponentId::new(0x800A).is_xmtp_range());
+        assert!(!ComponentId::new(0x800A).is_immutable());
+        assert!(ComponentId::new(0x800B).is_xmtp_range());
+        assert!(!ComponentId::new(0x800B).is_immutable());
+
+        // XMTP immutable boundary
+        assert!(!ComponentId::new(0xBDFF).is_immutable());
+        assert!(ComponentId::new(0xBE00).is_immutable());
+        assert!(ComponentId::new(0xBFFF).is_immutable());
+
+        // The newest immutable XMTP IDs (DM_MEMBERS, ONESHOT_MESSAGE) sit
+        // counting down from 0xBFFF and must fall inside the immutable subrange.
+        assert!(ComponentId::new(0xBFFD).is_immutable());
+        assert!(ComponentId::new(0xBFFC).is_immutable());
+
+        // App mutable
+        assert!(ComponentId::new(0xC000).is_app_range());
+        assert!(!ComponentId::new(0xC000).is_immutable());
+
+        // App immutable boundary
+        assert!(!ComponentId::new(0xFCFF).is_immutable());
+        assert!(ComponentId::new(0xFD00).is_immutable());
+        assert!(ComponentId::new(0xFEFF).is_immutable());
+
+        // Reserved
+        assert!(ComponentId::new(0xFF00).is_reserved());
+        assert!(ComponentId::new(0xFFFF).is_reserved());
+        assert!(!ComponentId::new(0xFEFF).is_reserved());
+    }
+
+    #[xmtp_common::test]
+    fn test_is_in_component_space() {
+        assert!(!ComponentId::new(0x0000).is_in_component_space());
+        assert!(!ComponentId::new(0x7FFF).is_in_component_space());
+        assert!(ComponentId::new(0x8000).is_in_component_space());
+        assert!(ComponentId::new(0xFFFF).is_in_component_space());
+    }
+
+    #[xmtp_common::test]
+    fn test_ranges_are_mutually_exclusive() {
+        // XMTP and App ranges don't overlap
+        for id in [0x8000u16, 0x8500, 0xBFFF] {
+            let c = ComponentId::new(id);
+            assert!(c.is_xmtp_range());
+            assert!(!c.is_app_range());
+            assert!(!c.is_reserved());
+        }
+        for id in [0xC000u16, 0xD000, 0xFEFF] {
+            let c = ComponentId::new(id);
+            assert!(!c.is_xmtp_range());
+            assert!(c.is_app_range());
+            assert!(!c.is_reserved());
+        }
+        for id in [0xFF00u16, 0xFFFF] {
+            let c = ComponentId::new(id);
+            assert!(!c.is_xmtp_range());
+            assert!(!c.is_app_range());
+            assert!(c.is_reserved());
+        }
+    }
+
+    #[xmtp_common::test]
+    fn test_tls_codec_round_trip() {
+        // Round-trip every well-known id and a few representative values from
+        // the various ranges. Component IDs are encoded with QUIC vlen so the
+        // serialized length depends on magnitude.
+        let ids = [
+            ComponentId::new(0x0000),
+            ComponentId::new(0x003F), // last 1-byte vlen value
+            ComponentId::new(0x0040), // first 2-byte vlen value
+            ComponentId::new(0x3FFF), // last 2-byte vlen value
+            ComponentId::new(0x4000), // first 4-byte vlen value
+            ComponentId::COMPONENT_REGISTRY,
+            ComponentId::GROUP_NAME,
+            ComponentId::MIN_SUPPORTED_PROTOCOL_VERSION,
+            ComponentId::COMMIT_LOG_SIGNER,
+            ComponentId::CONVERSATION_TYPE,
+            ComponentId::DM_MEMBERS,
+            ComponentId::ONESHOT_MESSAGE,
+            ComponentId::new(0xFFFF),
+        ];
+        for id in ids {
+            let bytes = id.tls_serialize_detached().unwrap();
+            let deserialized = ComponentId::tls_deserialize_exact(&bytes).unwrap();
+            assert_eq!(id, deserialized, "round trip failed for {id:?}");
+            assert_eq!(
+                bytes.len(),
+                id.tls_serialized_len(),
+                "tls_serialized_len mismatch for {id:?}"
+            );
+        }
+    }
+
+    #[xmtp_common::test]
+    fn test_vlen_encoding_sizes() {
+        // 1-byte vlen: 0..=0x3F
+        assert_eq!(ComponentId::new(0).tls_serialized_len(), 1);
+        assert_eq!(ComponentId::new(0x3F).tls_serialized_len(), 1);
+        // 2-byte vlen: 0x40..=0x3FFF
+        assert_eq!(ComponentId::new(0x40).tls_serialized_len(), 2);
+        assert_eq!(ComponentId::new(0x3FFF).tls_serialized_len(), 2);
+        // 4-byte vlen: 0x4000..
+        assert_eq!(ComponentId::new(0x4000).tls_serialized_len(), 4);
+        assert_eq!(ComponentId::new(0x8000).tls_serialized_len(), 4);
+        assert_eq!(ComponentId::new(0xFFFF).tls_serialized_len(), 4);
+    }
+
+    #[xmtp_common::test]
+    fn test_decode_rejects_value_above_u16_max() {
+        // A QUIC vlen-encoded value of 0x10000 (one past u16::MAX) takes 4
+        // bytes: prefix 0b10 (4-byte) || 0x00_01_00_00.
+        let bytes = [0x80, 0x01, 0x00, 0x00];
+        let result = ComponentId::tls_deserialize_exact(bytes);
+        assert!(matches!(result, Err(tls_codec::Error::DecodingError(_))));
+    }
+
+    #[xmtp_common::test]
+    fn test_ordering() {
+        let a = ComponentId::new(0x8000);
+        let b = ComponentId::new(0x8001);
+        let c = ComponentId::new(0xBFFF);
+        assert!(a < b);
+        assert!(b < c);
+    }
+
+    #[xmtp_common::test]
+    fn test_debug_display() {
+        let id = ComponentId::new(0x8004);
+        assert_eq!(format!("{id:?}"), "ComponentId(0x8004)");
+        assert_eq!(format!("{id}"), "0x8004");
+    }
+}

--- a/crates/xmtp_mls_common/src/app_data/component_permissions.rs
+++ b/crates/xmtp_mls_common/src/app_data/component_permissions.rs
@@ -1,0 +1,93 @@
+use xmtp_proto::xmtp::mls::message_contents::{
+    ComponentPermissions, MetadataPolicy as MetadataPolicyProto,
+};
+
+/// Builder for [`ComponentPermissions`].
+///
+/// Construct via the generated builder rather than positional arguments so
+/// that the three same-typed `MetadataPolicyProto` arguments
+/// (`insert`/`update`/`delete`) can't be accidentally swapped at the call
+/// site:
+///
+/// ```ignore
+/// let perms = component_permissions()
+///     .insert(allow_policy)
+///     .update(admin_only_policy)
+///     .delete(super_admin_only_policy)
+///     .call();
+/// ```
+#[bon::builder]
+pub fn component_permissions(
+    insert: MetadataPolicyProto,
+    update: MetadataPolicyProto,
+    delete: MetadataPolicyProto,
+) -> ComponentPermissions {
+    ComponentPermissions {
+        insert_policy: Some(insert),
+        update_policy: Some(update),
+        delete_policy: Some(delete),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prost::Message;
+    use xmtp_proto::xmtp::mls::message_contents::metadata_policy::{
+        Kind as MetadataPolicyKind, MetadataBasePolicy,
+    };
+
+    fn make_base_policy(base: MetadataBasePolicy) -> MetadataPolicyProto {
+        MetadataPolicyProto {
+            kind: Some(MetadataPolicyKind::Base(base as i32)),
+        }
+    }
+
+    fn allow() -> MetadataPolicyProto {
+        make_base_policy(MetadataBasePolicy::Allow)
+    }
+
+    fn deny() -> MetadataPolicyProto {
+        make_base_policy(MetadataBasePolicy::Deny)
+    }
+
+    fn admin_only() -> MetadataPolicyProto {
+        make_base_policy(MetadataBasePolicy::AllowIfAdmin)
+    }
+
+    #[xmtp_common::test]
+    fn test_permission_encode_decode_round_trip() {
+        let perm = component_permissions()
+            .insert(allow())
+            .update(admin_only())
+            .delete(deny())
+            .call();
+        let bytes = perm.encode_to_vec();
+        let decoded = ComponentPermissions::decode(bytes.as_slice()).unwrap();
+        assert_eq!(perm, decoded);
+    }
+
+    #[xmtp_common::test]
+    fn test_all_deny() {
+        let perm = component_permissions()
+            .insert(deny())
+            .update(deny())
+            .delete(deny())
+            .call();
+        let bytes = perm.encode_to_vec();
+        let decoded = ComponentPermissions::decode(bytes.as_slice()).unwrap();
+        assert_eq!(perm, decoded);
+    }
+
+    #[xmtp_common::test]
+    fn test_builder_sets_all_fields() {
+        let perm = component_permissions()
+            .insert(allow())
+            .update(admin_only())
+            .delete(deny())
+            .call();
+        assert!(perm.insert_policy.is_some());
+        assert!(perm.update_policy.is_some());
+        assert!(perm.delete_policy.is_some());
+    }
+}

--- a/crates/xmtp_mls_common/src/app_data/component_registry.rs
+++ b/crates/xmtp_mls_common/src/app_data/component_registry.rs
@@ -1,0 +1,950 @@
+use crate::tls_map::TlsMap;
+use prost::Message;
+use tls_codec::{Deserialize, Serialize, VLBytes};
+use xmtp_proto::xmtp::mls::message_contents::{
+    ComponentMetadata, ComponentPermissions, ComponentType, MetadataPolicy as MetadataPolicyProto,
+    metadata_policy::{Kind as MetadataPolicyKind, MetadataBasePolicy},
+};
+
+use super::component_id::ComponentId;
+
+/// The operation being performed on a component.
+///
+/// Each variant maps to one of the policy fields in
+/// [`ComponentPermissions`](xmtp_proto::xmtp::mls::message_contents::ComponentPermissions):
+/// `Insert` → `insert_policy`, `Update` → `update_policy`, `Delete` → `delete_policy`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ComponentOp {
+    /// Creating a new value (component does not yet exist).
+    Insert,
+    /// Modifying an existing value.
+    Update,
+    /// Removing a value.
+    Delete,
+}
+
+impl std::fmt::Display for ComponentOp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ComponentOp::Insert => write!(f, "insert"),
+            ComponentOp::Update => write!(f, "update"),
+            ComponentOp::Delete => write!(f, "delete"),
+        }
+    }
+}
+
+/// Helper to construct a [`ComponentMetadata`] from permissions and type.
+pub fn new_component_metadata(
+    permissions: ComponentPermissions,
+    component_type: ComponentType,
+) -> ComponentMetadata {
+    ComponentMetadata {
+        permissions: Some(permissions),
+        component_type: component_type as i32,
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ComponentRegistryError {
+    #[error("component ID {0} is not in the component ID space")]
+    InvalidComponentId(ComponentId),
+    #[error("component ID {0} is in the reserved range")]
+    ReservedRange(ComponentId),
+    #[error("immutable component {0} cannot be modified after initial insert")]
+    ImmutableComponent(ComponentId),
+    #[error("hardcoded component {0} cannot be removed")]
+    HardcodedComponent(ComponentId),
+    #[error("component {0} not found")]
+    NotFound(ComponentId),
+    #[error("component {0} metadata is missing the permissions field")]
+    MissingPermissions(ComponentId),
+    #[error("component {0} metadata is missing the {1} policy field")]
+    MissingPolicyField(ComponentId, ComponentOp),
+    #[error("decode error for component {component_id}: {source}")]
+    DecodeError {
+        component_id: ComponentId,
+        #[source]
+        source: prost::DecodeError,
+    },
+    #[error("tls codec error: {0}")]
+    TlsCodecError(#[from] tls_codec::Error),
+    #[error("constrained component {0} requires AllowIfAdmin or AllowIfSuperAdmin policies")]
+    ConstrainedPolicyViolation(ComponentId),
+}
+
+/// A component registry stored as a `TlsMap<ComponentId, VLBytes>` where each
+/// value is a protobuf-encoded [`ComponentMetadata`] describing the
+/// component's data type and permission policies.
+///
+/// The registry provides deterministic TLS serialization (sorted by ComponentId)
+/// and enforces that hardcoded and reserved component IDs cannot be modified
+/// through this map (their permissions are enforced in code).
+///
+/// Stored at well-known component ID `0x8000` (`ComponentId::COMPONENT_REGISTRY`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ComponentRegistry {
+    inner: TlsMap<ComponentId, VLBytes>,
+}
+
+impl ComponentRegistry {
+    pub fn new() -> Self {
+        Self {
+            inner: TlsMap::new(),
+        }
+    }
+
+    /// Get the metadata for a component, decoding from protobuf bytes.
+    ///
+    /// In practice the decode should never fail after a successful
+    /// [`from_bytes`](Self::from_bytes) or [`set`](Self::set) because both
+    /// validate the bytes are decodable. Returning a `Result` here is
+    /// defense in depth against in-memory corruption or future bugs.
+    pub fn get(
+        &self,
+        id: &ComponentId,
+    ) -> Result<Option<ComponentMetadata>, ComponentRegistryError> {
+        match self.inner.get(id) {
+            Some(bytes) => {
+                let meta = ComponentMetadata::decode(bytes.as_slice()).map_err(|source| {
+                    ComponentRegistryError::DecodeError {
+                        component_id: *id,
+                        source,
+                    }
+                })?;
+                Ok(Some(meta))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Register or update a component's metadata.
+    ///
+    /// For mutable components in the registry, this silently overwrites any
+    /// existing entry — there is no audit log here because the audit trail
+    /// lives in the MLS commit history that produced the change.
+    ///
+    /// Rejects invalid IDs, IDs in the reserved range, hardcoded components
+    /// (whose permissions are enforced in code, not metadata), immutable
+    /// components that already have a registry entry (write-once semantics),
+    /// metadata missing required fields, and constrained components with
+    /// invalid policy values.
+    pub fn set(
+        &mut self,
+        id: ComponentId,
+        meta: ComponentMetadata,
+    ) -> Result<(), ComponentRegistryError> {
+        self.validate_modifiable(&id)?;
+        Self::validate_metadata(&id, &meta)?;
+        let bytes = VLBytes::new(meta.encode_to_vec());
+        self.inner.set(id, bytes);
+        Ok(())
+    }
+
+    /// Remove a component from the registry.
+    ///
+    /// Rejects everything [`set`](Self::set) rejects (invalid IDs, reserved,
+    /// hardcoded, write-once-immutable). Hardcoded components can never be
+    /// in the registry to begin with, so this is just defense in depth.
+    pub fn remove(&mut self, id: &ComponentId) -> Result<(), ComponentRegistryError> {
+        self.validate_modifiable(id)?;
+        self.inner
+            .remove(id)
+            .map_err(|_| ComponentRegistryError::NotFound(*id))?;
+        Ok(())
+    }
+
+    /// Returns true if the registry contains metadata for the given component.
+    pub fn contains(&self, id: &ComponentId) -> bool {
+        self.inner.contains_key(id)
+    }
+
+    /// Returns the number of entries in the registry.
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Returns true if the registry is empty.
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Iterate over component IDs and their decoded metadata.
+    ///
+    /// Each item is a `Result` so that callers can decide how to handle a
+    /// corrupt entry. We never silently drop entries — a permission map is
+    /// security-critical and a missing entry would be a security bug.
+    pub fn iter(
+        &self,
+    ) -> impl Iterator<Item = Result<(ComponentId, ComponentMetadata), ComponentRegistryError>> + '_
+    {
+        self.inner.iter().map(|(&id, bytes)| {
+            let meta = ComponentMetadata::decode(bytes.as_slice()).map_err(|source| {
+                ComponentRegistryError::DecodeError {
+                    component_id: id,
+                    source,
+                }
+            })?;
+            Ok((id, meta))
+        })
+    }
+
+    /// Serialize the entire registry to TLS-encoded bytes.
+    pub fn to_bytes(&self) -> Result<Vec<u8>, ComponentRegistryError> {
+        Ok(self.inner.tls_serialize_detached()?)
+    }
+
+    /// Deserialize a component registry from TLS-encoded bytes.
+    ///
+    /// Validates that every key is in the component ID space, not reserved,
+    /// and not hardcoded, and that every value decodes as a valid
+    /// [`ComponentMetadata`] — peers cannot send us a registry with
+    /// structurally invalid keys or malformed values, nor can they smuggle
+    /// in entries for hardcoded components (whose permissions are enforced
+    /// in code). The decoded values are discarded; we keep the original raw
+    /// bytes so re-serialization is byte-identical to what was received.
+    ///
+    /// Immutability is intentionally not enforced here because it's a
+    /// write-time concern, not a wire-format invariant.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ComponentRegistryError> {
+        let inner: TlsMap<ComponentId, VLBytes> = TlsMap::tls_deserialize_exact(bytes)?;
+        for (id, raw) in inner.iter() {
+            if !id.is_in_component_space() {
+                return Err(ComponentRegistryError::InvalidComponentId(*id));
+            }
+            if id.is_reserved() {
+                return Err(ComponentRegistryError::ReservedRange(*id));
+            }
+            if id.is_hardcoded() {
+                return Err(ComponentRegistryError::HardcodedComponent(*id));
+            }
+            // Eagerly verify the value decodes AND is structurally valid —
+            // fail fast at the wire boundary so callers don't get a partial
+            // failure mid-iteration.
+            let meta = ComponentMetadata::decode(raw.as_slice()).map_err(|source| {
+                ComponentRegistryError::DecodeError {
+                    component_id: *id,
+                    source,
+                }
+            })?;
+            Self::validate_metadata(id, &meta)?;
+        }
+        Ok(Self { inner })
+    }
+
+    /// Validate that the registry entry for `id` can be inserted, updated,
+    /// or removed.
+    ///
+    /// Rejects:
+    /// - IDs outside the component ID space
+    /// - IDs in the reserved range
+    /// - Hardcoded IDs (their permissions are enforced in code; allowing
+    ///   metadata entries here would create a silent disagreement between
+    ///   what the registry says and what `validate_component_write` actually
+    ///   enforces)
+    /// - IDs in immutable ranges that already have an entry (write-once)
+    fn validate_modifiable(&self, id: &ComponentId) -> Result<(), ComponentRegistryError> {
+        if !id.is_in_component_space() {
+            return Err(ComponentRegistryError::InvalidComponentId(*id));
+        }
+        if id.is_reserved() {
+            return Err(ComponentRegistryError::ReservedRange(*id));
+        }
+        if id.is_hardcoded() {
+            return Err(ComponentRegistryError::HardcodedComponent(*id));
+        }
+        if id.is_immutable() && self.inner.contains_key(id) {
+            return Err(ComponentRegistryError::ImmutableComponent(*id));
+        }
+        Ok(())
+    }
+
+    /// Validate that the metadata for a component is structurally complete
+    /// and (for constrained components) uses allowed policy values.
+    ///
+    /// Every component must have:
+    /// - `permissions` set to `Some`
+    /// - All three policy fields (`insert_policy`, `update_policy`,
+    ///   `delete_policy`) set to `Some`
+    ///
+    /// Constrained components (e.g. `ADMIN_LIST`) additionally require each
+    /// policy to be the base policy `AllowIfAdmin` (admin or super admin) or
+    /// `AllowIfSuperAdmin` (super admin only). Combinator policies
+    /// (`AndCondition` / `AnyCondition`) are rejected for constrained
+    /// components.
+    fn validate_metadata(
+        id: &ComponentId,
+        meta: &ComponentMetadata,
+    ) -> Result<(), ComponentRegistryError> {
+        let perms = meta
+            .permissions
+            .as_ref()
+            .ok_or(ComponentRegistryError::MissingPermissions(*id))?;
+
+        for (op, policy) in [
+            (ComponentOp::Insert, &perms.insert_policy),
+            (ComponentOp::Update, &perms.update_policy),
+            (ComponentOp::Delete, &perms.delete_policy),
+        ] {
+            let p = policy
+                .as_ref()
+                .ok_or(ComponentRegistryError::MissingPolicyField(*id, op))?;
+
+            if id.is_constrained() && !Self::is_admin_or_super_admin_policy(p) {
+                return Err(ComponentRegistryError::ConstrainedPolicyViolation(*id));
+            }
+        }
+        Ok(())
+    }
+
+    /// Returns true if the policy is the base policy `AllowIfAdmin`
+    /// (admin or super admin) or `AllowIfSuperAdmin` (super admin only).
+    ///
+    /// All variants are matched explicitly with no catch-all so that adding a
+    /// new `MetadataPolicyKind` variant in the proto forces a compile error
+    /// here, requiring an explicit decision about how it interacts with
+    /// constrained components.
+    fn is_admin_or_super_admin_policy(policy: &MetadataPolicyProto) -> bool {
+        match &policy.kind {
+            Some(MetadataPolicyKind::Base(base)) => {
+                *base == MetadataBasePolicy::AllowIfAdmin as i32
+                    || *base == MetadataBasePolicy::AllowIfSuperAdmin as i32
+            }
+            // Combinator policies are explicitly rejected for constrained
+            // components — even if every leaf is admin-only, the combinator
+            // wrapper itself is not on the constrained-component allowlist.
+            Some(MetadataPolicyKind::AndCondition(_)) => false,
+            Some(MetadataPolicyKind::AnyCondition(_)) => false,
+            None => false,
+        }
+    }
+}
+
+impl Default for ComponentRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+impl ComponentRegistry {
+    /// Test-only constructor that bypasses all validation.
+    ///
+    /// Used to exercise the defense-in-depth code paths in `get` and `iter`
+    /// that handle corrupt in-memory state — paths that the public API can
+    /// never reach because both `set` and `from_bytes` validate eagerly.
+    fn from_inner_for_test(inner: TlsMap<ComponentId, VLBytes>) -> Self {
+        Self { inner }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app_data::component_permissions::component_permissions;
+    use xmtp_proto::xmtp::mls::message_contents::metadata_policy::{AndCondition, AnyCondition};
+
+    fn allow() -> MetadataPolicyProto {
+        MetadataPolicyProto {
+            kind: Some(MetadataPolicyKind::Base(MetadataBasePolicy::Allow as i32)),
+        }
+    }
+
+    fn deny() -> MetadataPolicyProto {
+        MetadataPolicyProto {
+            kind: Some(MetadataPolicyKind::Base(MetadataBasePolicy::Deny as i32)),
+        }
+    }
+
+    fn admin_only() -> MetadataPolicyProto {
+        MetadataPolicyProto {
+            kind: Some(MetadataPolicyKind::Base(
+                MetadataBasePolicy::AllowIfAdmin as i32,
+            )),
+        }
+    }
+
+    /// An `AndCondition` whose leaves are all `AllowIfAdmin`. The combinator
+    /// wrapper itself must still be rejected for constrained components,
+    /// regardless of how admin-y its contents are.
+    fn and_condition_admin_only() -> MetadataPolicyProto {
+        MetadataPolicyProto {
+            kind: Some(MetadataPolicyKind::AndCondition(AndCondition {
+                policies: vec![admin_only(), admin_only()],
+            })),
+        }
+    }
+
+    /// An `AnyCondition` whose leaves are all `AllowIfAdmin`. Same rationale
+    /// as `and_condition_admin_only`.
+    fn any_condition_admin_only() -> MetadataPolicyProto {
+        MetadataPolicyProto {
+            kind: Some(MetadataPolicyKind::AnyCondition(AnyCondition {
+                policies: vec![admin_only(), admin_only()],
+            })),
+        }
+    }
+
+    fn sample_meta() -> ComponentMetadata {
+        new_component_metadata(
+            component_permissions()
+                .insert(allow())
+                .update(admin_only())
+                .delete(deny())
+                .call(),
+            ComponentType::Bytes,
+        )
+    }
+
+    #[xmtp_common::test]
+    fn test_set_and_get() {
+        let mut reg = ComponentRegistry::new();
+        let id = ComponentId::GROUP_NAME;
+        reg.set(id, sample_meta()).unwrap();
+        let meta = reg.get(&id).unwrap().unwrap();
+        assert_eq!(meta, sample_meta());
+    }
+
+    #[xmtp_common::test]
+    fn test_get_missing_returns_none() {
+        let reg = ComponentRegistry::new();
+        assert!(reg.get(&ComponentId::GROUP_NAME).unwrap().is_none());
+    }
+
+    #[xmtp_common::test]
+    fn test_set_overwrites() {
+        let mut reg = ComponentRegistry::new();
+        let id = ComponentId::GROUP_NAME;
+        reg.set(id, sample_meta()).unwrap();
+
+        let new_meta = new_component_metadata(
+            component_permissions()
+                .insert(deny())
+                .update(deny())
+                .delete(deny())
+                .call(),
+            ComponentType::TlsMapBytesBytes,
+        );
+        reg.set(id, new_meta.clone()).unwrap();
+
+        let got = reg.get(&id).unwrap().unwrap();
+        assert_eq!(got, new_meta);
+        assert_eq!(reg.len(), 1);
+    }
+
+    #[xmtp_common::test]
+    fn test_remove() {
+        let mut reg = ComponentRegistry::new();
+        let id = ComponentId::GROUP_NAME;
+        reg.set(id, sample_meta()).unwrap();
+        reg.remove(&id).unwrap();
+        assert!(!reg.contains(&id));
+    }
+
+    #[xmtp_common::test]
+    fn test_remove_missing_returns_error() {
+        let mut reg = ComponentRegistry::new();
+        let result = reg.remove(&ComponentId::GROUP_NAME);
+        assert!(result.is_err());
+    }
+
+    #[xmtp_common::test]
+    fn test_reject_hardcoded_set() {
+        // Hardcoded components must NEVER have a registry entry. Their
+        // permissions are enforced in code by `validate_component_write`,
+        // and a stored entry would create a silent disagreement between the
+        // registry and the actual enforcement path.
+        let mut reg = ComponentRegistry::new();
+        assert!(matches!(
+            reg.set(ComponentId::COMPONENT_REGISTRY, sample_meta()),
+            Err(ComponentRegistryError::HardcodedComponent(_))
+        ));
+        assert!(matches!(
+            reg.set(ComponentId::SUPER_ADMIN_LIST, sample_meta()),
+            Err(ComponentRegistryError::HardcodedComponent(_))
+        ));
+        assert!(reg.is_empty());
+    }
+
+    #[xmtp_common::test]
+    fn test_reject_hardcoded_remove() {
+        // Even though hardcoded entries should never be in the registry, the
+        // remove path still rejects them for defense in depth.
+        let mut reg = ComponentRegistry::new();
+        assert!(matches!(
+            reg.remove(&ComponentId::COMPONENT_REGISTRY),
+            Err(ComponentRegistryError::HardcodedComponent(_))
+        ));
+        assert!(matches!(
+            reg.remove(&ComponentId::SUPER_ADMIN_LIST),
+            Err(ComponentRegistryError::HardcodedComponent(_))
+        ));
+    }
+
+    #[xmtp_common::test]
+    fn test_admin_list_accepts_admin_or_super_admin_policy() {
+        let mut reg = ComponentRegistry::new();
+        let meta = new_component_metadata(
+            component_permissions()
+                .insert(admin_only())
+                .update(admin_only())
+                .delete(admin_only())
+                .call(),
+            ComponentType::Bytes,
+        );
+        assert!(reg.set(ComponentId::ADMIN_LIST, meta).is_ok());
+    }
+
+    #[xmtp_common::test]
+    fn test_admin_list_accepts_super_admin_only_policy() {
+        let mut reg = ComponentRegistry::new();
+        let super_admin_only = MetadataPolicyProto {
+            kind: Some(MetadataPolicyKind::Base(
+                MetadataBasePolicy::AllowIfSuperAdmin as i32,
+            )),
+        };
+        let meta = new_component_metadata(
+            component_permissions()
+                .insert(super_admin_only.clone())
+                .update(super_admin_only.clone())
+                .delete(super_admin_only)
+                .call(),
+            ComponentType::Bytes,
+        );
+        assert!(reg.set(ComponentId::ADMIN_LIST, meta).is_ok());
+    }
+
+    #[xmtp_common::test]
+    fn test_admin_list_rejects_allow_policy() {
+        let mut reg = ComponentRegistry::new();
+        let meta = new_component_metadata(
+            component_permissions()
+                .insert(allow())
+                .update(allow())
+                .delete(allow())
+                .call(),
+            ComponentType::Bytes,
+        );
+        assert!(matches!(
+            reg.set(ComponentId::ADMIN_LIST, meta),
+            Err(ComponentRegistryError::ConstrainedPolicyViolation(_))
+        ));
+    }
+
+    #[xmtp_common::test]
+    fn test_admin_list_rejects_deny_policy() {
+        let mut reg = ComponentRegistry::new();
+        let meta = new_component_metadata(
+            component_permissions()
+                .insert(admin_only())
+                .update(deny())
+                .delete(admin_only())
+                .call(),
+            ComponentType::Bytes,
+        );
+        assert!(matches!(
+            reg.set(ComponentId::ADMIN_LIST, meta),
+            Err(ComponentRegistryError::ConstrainedPolicyViolation(_))
+        ));
+    }
+
+    #[xmtp_common::test]
+    fn test_admin_list_rejects_mixed_invalid_policy() {
+        let mut reg = ComponentRegistry::new();
+        let meta = new_component_metadata(
+            component_permissions()
+                .insert(admin_only())
+                .update(allow())
+                .delete(admin_only())
+                .call(),
+            ComponentType::Bytes,
+        );
+        assert!(matches!(
+            reg.set(ComponentId::ADMIN_LIST, meta),
+            Err(ComponentRegistryError::ConstrainedPolicyViolation(_))
+        ));
+    }
+
+    #[xmtp_common::test]
+    fn test_admin_list_rejects_and_condition_policy() {
+        // Combinator policies must be rejected for constrained components
+        // even when every leaf is admin-only — it's the wrapper itself that's
+        // disallowed, not the contents. Locks in the explicit rejection in
+        // `is_admin_or_super_admin_policy` so a future refactor of that match
+        // can't silently let combinators through.
+        let mut reg = ComponentRegistry::new();
+        let meta = new_component_metadata(
+            component_permissions()
+                .insert(and_condition_admin_only())
+                .update(admin_only())
+                .delete(admin_only())
+                .call(),
+            ComponentType::Bytes,
+        );
+        assert!(matches!(
+            reg.set(ComponentId::ADMIN_LIST, meta),
+            Err(ComponentRegistryError::ConstrainedPolicyViolation(_))
+        ));
+    }
+
+    #[xmtp_common::test]
+    fn test_admin_list_rejects_any_condition_policy() {
+        // Same rationale as `test_admin_list_rejects_and_condition_policy`,
+        // but exercising the `AnyCondition` branch on a different policy slot
+        // so all three slots and both combinator variants are covered across
+        // the constrained-component test cluster.
+        let mut reg = ComponentRegistry::new();
+        let meta = new_component_metadata(
+            component_permissions()
+                .insert(admin_only())
+                .update(any_condition_admin_only())
+                .delete(admin_only())
+                .call(),
+            ComponentType::Bytes,
+        );
+        assert!(matches!(
+            reg.set(ComponentId::ADMIN_LIST, meta),
+            Err(ComponentRegistryError::ConstrainedPolicyViolation(_))
+        ));
+    }
+
+    #[xmtp_common::test]
+    fn test_rejects_missing_permissions() {
+        let mut reg = ComponentRegistry::new();
+        // Construct ComponentMetadata directly (bypassing new_component_metadata)
+        // because the helper doesn't allow `permissions: None` — that's exactly
+        // the negative case we're testing here.
+        let meta = ComponentMetadata {
+            permissions: None,
+            component_type: ComponentType::Bytes as i32,
+        };
+        // Applies to ALL components, not just constrained ones.
+        assert!(matches!(
+            reg.set(ComponentId::GROUP_NAME, meta.clone()),
+            Err(ComponentRegistryError::MissingPermissions(_))
+        ));
+        assert!(matches!(
+            reg.set(ComponentId::ADMIN_LIST, meta),
+            Err(ComponentRegistryError::MissingPermissions(_))
+        ));
+    }
+
+    #[xmtp_common::test]
+    fn test_rejects_missing_policy_field() {
+        let mut reg = ComponentRegistry::new();
+        let meta = new_component_metadata(
+            ComponentPermissions {
+                insert_policy: Some(allow()),
+                update_policy: None, // missing
+                delete_policy: Some(allow()),
+            },
+            ComponentType::Bytes,
+        );
+        // Applies to ALL components, not just constrained ones.
+        assert!(matches!(
+            reg.set(ComponentId::GROUP_NAME, meta),
+            Err(ComponentRegistryError::MissingPolicyField(
+                _,
+                ComponentOp::Update
+            ))
+        ));
+    }
+
+    #[xmtp_common::test]
+    fn test_reject_reserved_set() {
+        let mut reg = ComponentRegistry::new();
+        assert!(matches!(
+            reg.set(ComponentId::new(0xFF00), sample_meta()),
+            Err(ComponentRegistryError::ReservedRange(_))
+        ));
+    }
+
+    #[xmtp_common::test]
+    fn test_reject_invalid_id() {
+        let mut reg = ComponentRegistry::new();
+        assert!(matches!(
+            reg.set(ComponentId::new(0x0001), sample_meta()),
+            Err(ComponentRegistryError::InvalidComponentId(_))
+        ));
+    }
+
+    #[xmtp_common::test]
+    fn test_app_range_allowed() {
+        let mut reg = ComponentRegistry::new();
+        let id = ComponentId::new(0xC000);
+        reg.set(id, sample_meta()).unwrap();
+        assert!(reg.contains(&id));
+    }
+
+    #[xmtp_common::test]
+    fn test_immutable_first_insert_allowed() {
+        // Immutable components can be inserted once.
+        let mut reg = ComponentRegistry::new();
+        let id = ComponentId::new(0xBE00);
+        reg.set(id, sample_meta()).unwrap();
+        assert!(reg.contains(&id));
+    }
+
+    #[xmtp_common::test]
+    fn test_immutable_subsequent_set_rejected() {
+        let mut reg = ComponentRegistry::new();
+        let id = ComponentId::new(0xBE00);
+        reg.set(id, sample_meta()).unwrap();
+        // Second set on the same immutable id is rejected.
+        assert!(matches!(
+            reg.set(id, sample_meta()),
+            Err(ComponentRegistryError::ImmutableComponent(_))
+        ));
+    }
+
+    #[xmtp_common::test]
+    fn test_immutable_remove_rejected() {
+        let mut reg = ComponentRegistry::new();
+        let id = ComponentId::new(0xBE00);
+        reg.set(id, sample_meta()).unwrap();
+        assert!(matches!(
+            reg.remove(&id),
+            Err(ComponentRegistryError::ImmutableComponent(_))
+        ));
+        assert!(reg.contains(&id));
+    }
+
+    #[xmtp_common::test]
+    fn test_tls_round_trip() {
+        let mut reg = ComponentRegistry::new();
+        reg.set(ComponentId::GROUP_NAME, sample_meta()).unwrap();
+        reg.set(
+            ComponentId::GROUP_DESCRIPTION,
+            new_component_metadata(
+                component_permissions()
+                    .insert(deny())
+                    .update(deny())
+                    .delete(deny())
+                    .call(),
+                ComponentType::Bytes,
+            ),
+        )
+        .unwrap();
+
+        let bytes = reg.to_bytes().unwrap();
+        let restored = ComponentRegistry::from_bytes(&bytes).unwrap();
+        assert_eq!(reg, restored);
+    }
+
+    #[xmtp_common::test]
+    fn test_iter() {
+        let mut reg = ComponentRegistry::new();
+        reg.set(ComponentId::GROUP_NAME, sample_meta()).unwrap();
+        reg.set(ComponentId::GROUP_DESCRIPTION, sample_meta())
+            .unwrap();
+
+        let entries: Vec<_> = reg.iter().collect::<Result<Vec<_>, _>>().unwrap();
+        assert_eq!(entries.len(), 2);
+        assert!(entries[0].0 < entries[1].0);
+    }
+
+    #[xmtp_common::test]
+    fn test_empty_registry_round_trip() {
+        let reg = ComponentRegistry::new();
+        let bytes = reg.to_bytes().unwrap();
+        let restored = ComponentRegistry::from_bytes(&bytes).unwrap();
+        assert_eq!(reg, restored);
+        assert!(restored.is_empty());
+    }
+
+    #[xmtp_common::test]
+    fn test_from_bytes_rejects_out_of_space_id() {
+        // Build a TlsMap directly with an out-of-space key (0x0001) and
+        // serialize it, then try to load it as a ComponentRegistry.
+        let mut raw: TlsMap<ComponentId, VLBytes> = TlsMap::new();
+        raw.set(
+            ComponentId::new(0x0001),
+            VLBytes::new(sample_meta().encode_to_vec()),
+        );
+        let bytes = raw.tls_serialize_detached().unwrap();
+        let result = ComponentRegistry::from_bytes(&bytes);
+        assert!(matches!(
+            result,
+            Err(ComponentRegistryError::InvalidComponentId(_))
+        ));
+    }
+
+    #[xmtp_common::test]
+    fn test_from_bytes_rejects_reserved_id() {
+        let mut raw: TlsMap<ComponentId, VLBytes> = TlsMap::new();
+        raw.set(
+            ComponentId::new(0xFF50),
+            VLBytes::new(sample_meta().encode_to_vec()),
+        );
+        let bytes = raw.tls_serialize_detached().unwrap();
+        let result = ComponentRegistry::from_bytes(&bytes);
+        assert!(matches!(
+            result,
+            Err(ComponentRegistryError::ReservedRange(_))
+        ));
+    }
+
+    /// Build a TLS-encoded `TlsMap<ComponentId, VLBytes>` containing a single
+    /// entry. Bypasses `ComponentRegistry::set` so we can construct payloads
+    /// that the public API would refuse to produce.
+    fn raw_bytes_with_entry(id: ComponentId, value: Vec<u8>) -> Vec<u8> {
+        let mut raw: TlsMap<ComponentId, VLBytes> = TlsMap::new();
+        raw.set(id, VLBytes::new(value));
+        raw.tls_serialize_detached().unwrap()
+    }
+
+    #[xmtp_common::test]
+    fn test_from_bytes_rejects_hardcoded_id() {
+        // Peers must not be able to smuggle hardcoded entries past the wire
+        // boundary, since their permissions are enforced in code.
+        let bytes = raw_bytes_with_entry(
+            ComponentId::COMPONENT_REGISTRY,
+            sample_meta().encode_to_vec(),
+        );
+        assert!(matches!(
+            ComponentRegistry::from_bytes(&bytes),
+            Err(ComponentRegistryError::HardcodedComponent(_))
+        ));
+
+        let bytes =
+            raw_bytes_with_entry(ComponentId::SUPER_ADMIN_LIST, sample_meta().encode_to_vec());
+        assert!(matches!(
+            ComponentRegistry::from_bytes(&bytes),
+            Err(ComponentRegistryError::HardcodedComponent(_))
+        ));
+    }
+
+    #[xmtp_common::test]
+    fn test_from_bytes_rejects_missing_permissions() {
+        // A peer ships a metadata entry whose permissions field is None.
+        // The set() path catches this; from_bytes() must catch it too.
+        let meta = ComponentMetadata {
+            permissions: None,
+            component_type: ComponentType::Bytes as i32,
+        };
+        let bytes = raw_bytes_with_entry(ComponentId::GROUP_NAME, meta.encode_to_vec());
+        assert!(matches!(
+            ComponentRegistry::from_bytes(&bytes),
+            Err(ComponentRegistryError::MissingPermissions(_))
+        ));
+    }
+
+    #[xmtp_common::test]
+    fn test_from_bytes_rejects_missing_policy_field() {
+        // Permissions present, but one of the three policy fields is missing.
+        let meta = new_component_metadata(
+            ComponentPermissions {
+                insert_policy: Some(allow()),
+                update_policy: None,
+                delete_policy: Some(allow()),
+            },
+            ComponentType::Bytes,
+        );
+        let bytes = raw_bytes_with_entry(ComponentId::GROUP_NAME, meta.encode_to_vec());
+        assert!(matches!(
+            ComponentRegistry::from_bytes(&bytes),
+            Err(ComponentRegistryError::MissingPolicyField(
+                _,
+                ComponentOp::Update
+            ))
+        ));
+    }
+
+    #[xmtp_common::test]
+    fn test_from_bytes_rejects_constrained_violation() {
+        // A peer ships an ADMIN_LIST entry with an Allow policy, which
+        // violates the constrained-component invariant.
+        let meta = new_component_metadata(
+            component_permissions()
+                .insert(allow())
+                .update(allow())
+                .delete(allow())
+                .call(),
+            ComponentType::Bytes,
+        );
+        let bytes = raw_bytes_with_entry(ComponentId::ADMIN_LIST, meta.encode_to_vec());
+        assert!(matches!(
+            ComponentRegistry::from_bytes(&bytes),
+            Err(ComponentRegistryError::ConstrainedPolicyViolation(_))
+        ));
+    }
+
+    #[xmtp_common::test]
+    fn test_iter_surfaces_decode_error_for_corrupt_value() {
+        // The public API (`set`, `from_bytes`) eagerly validates so this
+        // can't happen via normal use. We construct a registry directly
+        // through the test-only constructor to verify that `iter()` would
+        // surface a structured DecodeError if the in-memory state ever did
+        // get corrupted (in-memory bit flip, future bug, etc.) instead of
+        // panicking or silently dropping the entry.
+        let mut inner: TlsMap<ComponentId, VLBytes> = TlsMap::new();
+        inner.set(
+            ComponentId::GROUP_NAME,
+            VLBytes::new(sample_meta().encode_to_vec()),
+        );
+        inner.set(
+            ComponentId::GROUP_DESCRIPTION,
+            VLBytes::new(vec![0xFF, 0xFF, 0xFF, 0xFF]),
+        );
+        let reg = ComponentRegistry::from_inner_for_test(inner);
+
+        let results: Vec<_> = reg.iter().collect();
+        assert_eq!(results.len(), 2);
+        // The good entry decodes successfully.
+        assert!(matches!(
+            &results[0],
+            Ok((id, _)) if *id == ComponentId::GROUP_NAME
+        ));
+        // The corrupt entry surfaces a structured DecodeError, not a panic
+        // or a silent drop.
+        assert!(matches!(
+            &results[1],
+            Err(ComponentRegistryError::DecodeError { component_id, .. })
+                if *component_id == ComponentId::GROUP_DESCRIPTION
+        ));
+    }
+
+    #[xmtp_common::test]
+    fn test_get_surfaces_decode_error_for_corrupt_value() {
+        // Same defense-in-depth as `test_iter_surfaces_decode_error_*` but
+        // for the single-entry `get` path.
+        let mut inner: TlsMap<ComponentId, VLBytes> = TlsMap::new();
+        inner.set(
+            ComponentId::GROUP_NAME,
+            VLBytes::new(vec![0xFF, 0xFF, 0xFF, 0xFF]),
+        );
+        let reg = ComponentRegistry::from_inner_for_test(inner);
+        assert!(matches!(
+            reg.get(&ComponentId::GROUP_NAME),
+            Err(ComponentRegistryError::DecodeError { .. })
+        ));
+    }
+
+    #[xmtp_common::test]
+    fn test_from_bytes_rejects_malformed_protobuf() {
+        // The key is valid but the value bytes are not a parseable
+        // ComponentMetadata. This is the wire-boundary path for a peer
+        // shipping garbage values.
+        let bytes = raw_bytes_with_entry(ComponentId::GROUP_NAME, vec![0xFF, 0xFF, 0xFF, 0xFF]);
+        assert!(matches!(
+            ComponentRegistry::from_bytes(&bytes),
+            Err(ComponentRegistryError::DecodeError { .. })
+        ));
+    }
+
+    #[xmtp_common::test]
+    fn test_preserves_component_type() {
+        let mut reg = ComponentRegistry::new();
+        let meta = new_component_metadata(
+            component_permissions()
+                .insert(allow())
+                .update(allow())
+                .delete(deny())
+                .call(),
+            ComponentType::TlsMapBytesBytes,
+        );
+        reg.set(ComponentId::GROUP_MEMBERSHIP, meta).unwrap();
+
+        let got = reg.get(&ComponentId::GROUP_MEMBERSHIP).unwrap().unwrap();
+        assert_eq!(got.component_type, ComponentType::TlsMapBytesBytes as i32);
+    }
+}

--- a/crates/xmtp_mls_common/src/app_data/mod.rs
+++ b/crates/xmtp_mls_common/src/app_data/mod.rs
@@ -1,0 +1,4 @@
+pub mod component_id;
+pub mod component_permissions;
+pub mod component_registry;
+pub mod validation;

--- a/crates/xmtp_mls_common/src/app_data/validation.rs
+++ b/crates/xmtp_mls_common/src/app_data/validation.rs
@@ -1,0 +1,647 @@
+use xmtp_proto::xmtp::mls::message_contents::MetadataPolicy as MetadataPolicyProto;
+use xmtp_proto::xmtp::mls::message_contents::metadata_policy::{
+    Kind as MetadataPolicyKind, MetadataBasePolicy,
+};
+
+use super::component_id::ComponentId;
+use super::component_registry::{ComponentOp, ComponentRegistry, ComponentRegistryError};
+
+/// The minimal subset of actor authority needed to evaluate base policies.
+///
+/// Carries only the booleans the policy evaluator inspects (admin and
+/// super-admin status). This crate intentionally does not depend on the
+/// richer `CommitParticipant` type from `xmtp_mls` — callers at the
+/// integration boundary construct an `ActorAuthority` from whatever actor
+/// representation they have.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ActorAuthority {
+    pub is_admin: bool,
+    pub is_super_admin: bool,
+}
+
+/// A change being proposed against a component, used as the input to
+/// [`validate_component_write`].
+///
+/// Carries everything needed to evaluate permissions for a single proposed
+/// write: the component identity, the operation, the actor performing it,
+/// and the raw old/new value bytes when available. Future change-aware base
+/// policies will inspect the value bytes; today's evaluator only looks at
+/// the actor.
+///
+/// `actor` is held by value (`ActorAuthority` is two booleans, smaller than
+/// a pointer), so the lifetime `'a` only constrains the borrowed
+/// `old_value` / `new_value` slices.
+///
+/// Construct via the generated builder so that `old_value` and `new_value`
+/// (which share the same type) can't be accidentally swapped:
+///
+/// ```
+/// # use xmtp_mls_common::app_data::component_id::ComponentId;
+/// # use xmtp_mls_common::app_data::component_registry::ComponentOp;
+/// # use xmtp_mls_common::app_data::validation::{ActorAuthority, ComponentChange};
+/// # let actor = ActorAuthority { is_admin: false, is_super_admin: true };
+/// # let old_bytes = vec![1, 2, 3];
+/// # let new_bytes = vec![4, 5, 6];
+/// let change = ComponentChange::builder()
+///     .component_id(ComponentId::GROUP_NAME)
+///     .op(ComponentOp::Update)
+///     .actor(actor)
+///     .old_value(&old_bytes)
+///     .new_value(&new_bytes)
+///     .build();
+/// ```
+#[derive(Debug, Clone, bon::Builder)]
+pub struct ComponentChange<'a> {
+    pub component_id: ComponentId,
+    pub op: ComponentOp,
+    pub actor: ActorAuthority,
+    pub old_value: Option<&'a [u8]>,
+    pub new_value: Option<&'a [u8]>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ComponentPermissionError {
+    #[error("immutable component {0} does not allow {1}")]
+    ImmutableViolation(ComponentId, ComponentOp),
+    #[error("component {0} requires super admin")]
+    SuperAdminRequired(ComponentId),
+    #[error("no registry entry for component {0}")]
+    NoRegistryEntry(ComponentId),
+    #[error("missing permissions in metadata for component {0}")]
+    MissingPermissions(ComponentId),
+    #[error("missing policy field for component {0} op {1}")]
+    MissingPolicyField(ComponentId, ComponentOp),
+    #[error("invalid policy for component {0} op {1}")]
+    InvalidPolicy(ComponentId, ComponentOp),
+    #[error("permission denied for component {0} op {1}")]
+    PermissionDenied(ComponentId, ComponentOp),
+    #[error("registry error: {0}")]
+    RegistryError(#[from] ComponentRegistryError),
+}
+
+/// Validate whether the change's actor is allowed to perform the proposed
+/// [`ComponentChange`].
+///
+/// Three-layer check:
+/// 1. **Immutability**: Components in immutable ranges reject update and delete
+///    unconditionally — only insert is allowed (and only if the component
+///    doesn't exist yet, which the caller must verify).
+/// 2. **Hardcoded**: The hardcoded components (component registry, super admin
+///    list) have permissions enforced in code: super admin only.
+/// 3. **Registry lookup**: All other components must have an entry in the
+///    component registry. No entry = denied (deny by default).
+pub fn validate_component_write(
+    change: &ComponentChange<'_>,
+    registry: &ComponentRegistry,
+) -> Result<(), ComponentPermissionError> {
+    let component_id = change.component_id;
+    let op = change.op;
+
+    // Layer 1: Immutability check
+    if component_id.is_immutable() && matches!(op, ComponentOp::Update | ComponentOp::Delete) {
+        return Err(ComponentPermissionError::ImmutableViolation(
+            component_id,
+            op,
+        ));
+    }
+
+    // Layer 2: Hardcoded components — always require super admin.
+    // `is_hardcoded()` is the source of truth for which IDs land here:
+    // adding a new hardcoded component is a single-line change to that
+    // function and this branch picks it up automatically.
+    if component_id.is_hardcoded() {
+        return if change.actor.is_super_admin {
+            Ok(())
+        } else {
+            Err(ComponentPermissionError::SuperAdminRequired(component_id))
+        };
+    }
+
+    // Layer 3: Registry lookup (deny by default)
+    let meta = registry
+        .get(&component_id)?
+        .ok_or(ComponentPermissionError::NoRegistryEntry(component_id))?;
+
+    // The registry's `validate_metadata` guarantees that any stored entry
+    // has `permissions: Some` and all three policy fields populated. The
+    // checks below are defensive — they should never fire in practice but
+    // we'd rather return a structured error than panic.
+    let permissions = meta
+        .permissions
+        .ok_or(ComponentPermissionError::MissingPermissions(component_id))?;
+
+    let policy_proto: MetadataPolicyProto = match op {
+        ComponentOp::Insert => permissions.insert_policy,
+        ComponentOp::Update => permissions.update_policy,
+        ComponentOp::Delete => permissions.delete_policy,
+    }
+    .ok_or(ComponentPermissionError::MissingPolicyField(
+        component_id,
+        op,
+    ))?;
+
+    match evaluate_policy_proto(&policy_proto, change) {
+        PolicyOutcome::Allow => Ok(()),
+        PolicyOutcome::Deny => Err(ComponentPermissionError::PermissionDenied(component_id, op)),
+        PolicyOutcome::Invalid => Err(ComponentPermissionError::InvalidPolicy(component_id, op)),
+    }
+}
+
+/// Result of evaluating a [`MetadataPolicyProto`] against a [`ComponentChange`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PolicyOutcome {
+    /// The policy permits the change.
+    Allow,
+    /// The policy denies the change.
+    Deny,
+    /// The policy is malformed (unknown base policy variant, empty combinator,
+    /// missing kind, etc.).
+    Invalid,
+}
+
+impl PolicyOutcome {
+    fn from_bool(allowed: bool) -> Self {
+        if allowed { Self::Allow } else { Self::Deny }
+    }
+}
+
+/// Walk a [`MetadataPolicyProto`] and evaluate it against the actor in a
+/// [`ComponentChange`].
+///
+/// Currently only inspects `change.actor` (matching the existing
+/// `MetadataBasePolicy` semantics). When change-aware base policies are added,
+/// this function will inspect `change.old_value` / `change.new_value` for the
+/// new variants — the field name → component ID mapping that the legacy
+/// `MetadataFieldChange` carried lives in `change.component_id`.
+///
+/// **Combinator semantics:**
+/// - `AndCondition` short-circuits on the first non-`Allow` outcome and
+///   propagates it (so `Deny` or `Invalid` wins over later siblings).
+/// - `AnyCondition` short-circuits on the first `Allow` *or* `Invalid`
+///   outcome — a single malformed sub-policy poisons the whole `OR`. The
+///   alternative ("keep scanning past `Invalid` looking for an `Allow`")
+///   would let a sender hide a structurally broken policy as long as
+///   *some* sibling allowed, which makes the broken policy invisible to
+///   peers and harder to repair. Failing closed on `Invalid` is the
+///   conservative choice.
+/// - Empty `AndCondition` / `AnyCondition` are `Invalid` rather than
+///   vacuously `Allow`/`Deny`.
+fn evaluate_policy_proto(
+    proto: &MetadataPolicyProto,
+    change: &ComponentChange<'_>,
+) -> PolicyOutcome {
+    match &proto.kind {
+        Some(MetadataPolicyKind::Base(base)) => evaluate_base_policy(*base, change.actor),
+        Some(MetadataPolicyKind::AndCondition(and)) => {
+            if and.policies.is_empty() {
+                return PolicyOutcome::Invalid;
+            }
+            for inner in &and.policies {
+                match evaluate_policy_proto(inner, change) {
+                    PolicyOutcome::Allow => continue,
+                    other => return other,
+                }
+            }
+            PolicyOutcome::Allow
+        }
+        Some(MetadataPolicyKind::AnyCondition(any)) => {
+            if any.policies.is_empty() {
+                return PolicyOutcome::Invalid;
+            }
+            for inner in &any.policies {
+                match evaluate_policy_proto(inner, change) {
+                    PolicyOutcome::Allow => return PolicyOutcome::Allow,
+                    PolicyOutcome::Deny => {}
+                    PolicyOutcome::Invalid => return PolicyOutcome::Invalid,
+                }
+            }
+            PolicyOutcome::Deny
+        }
+        None => PolicyOutcome::Invalid,
+    }
+}
+
+fn evaluate_base_policy(base: i32, actor: ActorAuthority) -> PolicyOutcome {
+    let base = match MetadataBasePolicy::try_from(base) {
+        Ok(b) => b,
+        Err(_) => return PolicyOutcome::Invalid,
+    };
+    match base {
+        MetadataBasePolicy::Allow => PolicyOutcome::Allow,
+        MetadataBasePolicy::Deny => PolicyOutcome::Deny,
+        MetadataBasePolicy::AllowIfAdmin => {
+            PolicyOutcome::from_bool(actor.is_admin || actor.is_super_admin)
+        }
+        MetadataBasePolicy::AllowIfSuperAdmin => PolicyOutcome::from_bool(actor.is_super_admin),
+        MetadataBasePolicy::Unspecified => PolicyOutcome::Invalid,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app_data::component_permissions::component_permissions;
+    use crate::app_data::component_registry::new_component_metadata;
+    use xmtp_proto::xmtp::mls::message_contents::{
+        ComponentType, MetadataPolicy as MetadataPolicyProto,
+        metadata_policy::{Kind as MetadataPolicyKind, MetadataBasePolicy},
+    };
+
+    fn make_policy(base: MetadataBasePolicy) -> MetadataPolicyProto {
+        MetadataPolicyProto {
+            kind: Some(MetadataPolicyKind::Base(base as i32)),
+        }
+    }
+
+    fn allow() -> MetadataPolicyProto {
+        make_policy(MetadataBasePolicy::Allow)
+    }
+
+    fn deny() -> MetadataPolicyProto {
+        make_policy(MetadataBasePolicy::Deny)
+    }
+
+    fn admin_only() -> MetadataPolicyProto {
+        make_policy(MetadataBasePolicy::AllowIfAdmin)
+    }
+
+    fn super_admin_only() -> MetadataPolicyProto {
+        make_policy(MetadataBasePolicy::AllowIfSuperAdmin)
+    }
+
+    fn make_actor(is_admin: bool, is_super_admin: bool) -> ActorAuthority {
+        ActorAuthority {
+            is_admin,
+            is_super_admin,
+        }
+    }
+
+    /// Test helper. Constructs a [`ComponentChange`] with no value bytes.
+    /// All current base policies only inspect the actor, so the value bytes
+    /// don't affect any test outcome — they're intentionally untested at
+    /// this layer until change-aware policies are added.
+    fn change<'a>(id: ComponentId, op: ComponentOp, actor: ActorAuthority) -> ComponentChange<'a> {
+        ComponentChange::builder()
+            .component_id(id)
+            .op(op)
+            .actor(actor)
+            .build()
+    }
+
+    fn member() -> ActorAuthority {
+        make_actor(false, false)
+    }
+
+    fn admin() -> ActorAuthority {
+        make_actor(true, false)
+    }
+
+    fn super_admin() -> ActorAuthority {
+        make_actor(true, true)
+    }
+
+    fn setup_registry_with(
+        id: ComponentId,
+        insert: MetadataPolicyProto,
+        update: MetadataPolicyProto,
+        delete: MetadataPolicyProto,
+    ) -> ComponentRegistry {
+        let mut reg = ComponentRegistry::new();
+        reg.set(
+            id,
+            new_component_metadata(
+                component_permissions()
+                    .insert(insert)
+                    .update(update)
+                    .delete(delete)
+                    .call(),
+                ComponentType::Bytes,
+            ),
+        )
+        .unwrap();
+        reg
+    }
+
+    // === Immutability Tests ===
+
+    #[xmtp_common::test]
+    fn test_immutable_insert_allowed() {
+        let id = ComponentId::CONVERSATION_TYPE;
+        let reg = setup_registry_with(id, allow(), deny(), deny());
+        let actor = super_admin();
+        let result = validate_component_write(&change(id, ComponentOp::Insert, actor), &reg);
+        assert!(result.is_ok());
+    }
+
+    #[xmtp_common::test]
+    fn test_immutable_update_rejected() {
+        let id = ComponentId::CONVERSATION_TYPE;
+        let reg = setup_registry_with(id, allow(), allow(), allow());
+        let actor = super_admin();
+        let result = validate_component_write(&change(id, ComponentOp::Update, actor), &reg);
+        assert!(matches!(
+            result,
+            Err(ComponentPermissionError::ImmutableViolation(
+                _,
+                ComponentOp::Update
+            ))
+        ));
+    }
+
+    #[xmtp_common::test]
+    fn test_immutable_delete_rejected() {
+        let id = ComponentId::CONVERSATION_TYPE;
+        let reg = setup_registry_with(id, allow(), allow(), allow());
+        let actor = super_admin();
+        let result = validate_component_write(&change(id, ComponentOp::Delete, actor), &reg);
+        assert!(matches!(
+            result,
+            Err(ComponentPermissionError::ImmutableViolation(
+                _,
+                ComponentOp::Delete
+            ))
+        ));
+    }
+
+    // === Hardcoded Tests ===
+
+    #[xmtp_common::test]
+    fn test_registry_super_admin_allowed() {
+        let reg = ComponentRegistry::new();
+        let actor = super_admin();
+        let result = validate_component_write(
+            &change(ComponentId::COMPONENT_REGISTRY, ComponentOp::Update, actor),
+            &reg,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[xmtp_common::test]
+    fn test_registry_admin_rejected() {
+        let reg = ComponentRegistry::new();
+        let actor = admin();
+        let result = validate_component_write(
+            &change(ComponentId::COMPONENT_REGISTRY, ComponentOp::Update, actor),
+            &reg,
+        );
+        assert!(matches!(
+            result,
+            Err(ComponentPermissionError::SuperAdminRequired(_))
+        ));
+    }
+
+    #[xmtp_common::test]
+    fn test_registry_member_rejected() {
+        let reg = ComponentRegistry::new();
+        let actor = member();
+        let result = validate_component_write(
+            &change(ComponentId::COMPONENT_REGISTRY, ComponentOp::Update, actor),
+            &reg,
+        );
+        assert!(matches!(
+            result,
+            Err(ComponentPermissionError::SuperAdminRequired(_))
+        ));
+    }
+
+    #[xmtp_common::test]
+    fn test_super_admin_list_super_admin_allowed() {
+        let reg = ComponentRegistry::new();
+        let actor = super_admin();
+        let result = validate_component_write(
+            &change(ComponentId::SUPER_ADMIN_LIST, ComponentOp::Insert, actor),
+            &reg,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[xmtp_common::test]
+    fn test_super_admin_list_admin_rejected() {
+        let reg = ComponentRegistry::new();
+        let actor = admin();
+        let result = validate_component_write(
+            &change(ComponentId::SUPER_ADMIN_LIST, ComponentOp::Insert, actor),
+            &reg,
+        );
+        assert!(matches!(
+            result,
+            Err(ComponentPermissionError::SuperAdminRequired(_))
+        ));
+    }
+
+    #[xmtp_common::test]
+    fn test_admin_list_with_admin_policy_admin_allowed() {
+        let reg = setup_registry_with(
+            ComponentId::ADMIN_LIST,
+            admin_only(),
+            admin_only(),
+            admin_only(),
+        );
+        let actor = admin();
+        let result = validate_component_write(
+            &change(ComponentId::ADMIN_LIST, ComponentOp::Insert, actor),
+            &reg,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[xmtp_common::test]
+    fn test_admin_list_with_admin_policy_member_rejected() {
+        let reg = setup_registry_with(
+            ComponentId::ADMIN_LIST,
+            admin_only(),
+            admin_only(),
+            admin_only(),
+        );
+        let actor = member();
+        let result = validate_component_write(
+            &change(ComponentId::ADMIN_LIST, ComponentOp::Insert, actor),
+            &reg,
+        );
+        assert!(matches!(
+            result,
+            Err(ComponentPermissionError::PermissionDenied(_, _))
+        ));
+    }
+
+    #[xmtp_common::test]
+    fn test_admin_list_with_super_admin_policy() {
+        let reg = setup_registry_with(
+            ComponentId::ADMIN_LIST,
+            super_admin_only(),
+            super_admin_only(),
+            super_admin_only(),
+        );
+        let admin_actor = admin();
+        let super_admin_actor = super_admin();
+        // Admin rejected
+        assert!(
+            validate_component_write(
+                &change(ComponentId::ADMIN_LIST, ComponentOp::Insert, admin_actor),
+                &reg,
+            )
+            .is_err()
+        );
+        // Super admin allowed
+        assert!(
+            validate_component_write(
+                &change(
+                    ComponentId::ADMIN_LIST,
+                    ComponentOp::Insert,
+                    super_admin_actor,
+                ),
+                &reg,
+            )
+            .is_ok()
+        );
+    }
+
+    // === Registry Lookup Tests ===
+
+    #[xmtp_common::test]
+    fn test_deny_by_default_no_entry() {
+        let reg = ComponentRegistry::new();
+        let actor = super_admin();
+        let result = validate_component_write(
+            &change(ComponentId::GROUP_NAME, ComponentOp::Insert, actor),
+            &reg,
+        );
+        assert!(matches!(
+            result,
+            Err(ComponentPermissionError::NoRegistryEntry(_))
+        ));
+    }
+
+    #[xmtp_common::test]
+    fn test_insert_allow_policy() {
+        let reg = setup_registry_with(ComponentId::GROUP_NAME, allow(), deny(), deny());
+        let actor = member();
+        let result = validate_component_write(
+            &change(ComponentId::GROUP_NAME, ComponentOp::Insert, actor),
+            &reg,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[xmtp_common::test]
+    fn test_update_admin_only_policy_admin_passes() {
+        let reg = setup_registry_with(ComponentId::GROUP_NAME, allow(), admin_only(), deny());
+        let actor = admin();
+        let result = validate_component_write(
+            &change(ComponentId::GROUP_NAME, ComponentOp::Update, actor),
+            &reg,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[xmtp_common::test]
+    fn test_update_admin_only_policy_member_fails() {
+        let reg = setup_registry_with(ComponentId::GROUP_NAME, allow(), admin_only(), deny());
+        let actor = member();
+        let result = validate_component_write(
+            &change(ComponentId::GROUP_NAME, ComponentOp::Update, actor),
+            &reg,
+        );
+        assert!(matches!(
+            result,
+            Err(ComponentPermissionError::PermissionDenied(
+                _,
+                ComponentOp::Update
+            ))
+        ));
+    }
+
+    #[xmtp_common::test]
+    fn test_delete_deny_policy() {
+        let reg = setup_registry_with(ComponentId::GROUP_NAME, allow(), allow(), deny());
+        let actor = super_admin();
+        let result = validate_component_write(
+            &change(ComponentId::GROUP_NAME, ComponentOp::Delete, actor),
+            &reg,
+        );
+        assert!(matches!(
+            result,
+            Err(ComponentPermissionError::PermissionDenied(
+                _,
+                ComponentOp::Delete
+            ))
+        ));
+    }
+
+    #[xmtp_common::test]
+    fn test_delete_super_admin_only_policy() {
+        let reg = setup_registry_with(
+            ComponentId::GROUP_NAME,
+            allow(),
+            allow(),
+            super_admin_only(),
+        );
+        let actor = super_admin();
+        let result = validate_component_write(
+            &change(ComponentId::GROUP_NAME, ComponentOp::Delete, actor),
+            &reg,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[xmtp_common::test]
+    fn test_different_insert_vs_update_permissions() {
+        // Mimics group membership: anyone can update, only admin can insert
+        let reg = setup_registry_with(
+            ComponentId::GROUP_MEMBERSHIP,
+            admin_only(),
+            allow(),
+            admin_only(),
+        );
+        let member_actor = member();
+        let admin_actor = admin();
+
+        // Member can update
+        assert!(
+            validate_component_write(
+                &change(
+                    ComponentId::GROUP_MEMBERSHIP,
+                    ComponentOp::Update,
+                    member_actor,
+                ),
+                &reg,
+            )
+            .is_ok()
+        );
+
+        // Member cannot insert
+        assert!(
+            validate_component_write(
+                &change(
+                    ComponentId::GROUP_MEMBERSHIP,
+                    ComponentOp::Insert,
+                    member_actor,
+                ),
+                &reg,
+            )
+            .is_err()
+        );
+
+        // Admin can insert
+        assert!(
+            validate_component_write(
+                &change(
+                    ComponentId::GROUP_MEMBERSHIP,
+                    ComponentOp::Insert,
+                    admin_actor,
+                ),
+                &reg,
+            )
+            .is_ok()
+        );
+    }
+
+    #[xmtp_common::test]
+    fn test_app_range_component() {
+        let app_id = ComponentId::new(0xC100);
+        let reg = setup_registry_with(app_id, allow(), allow(), deny());
+        let actor = member();
+        let result = validate_component_write(&change(app_id, ComponentOp::Insert, actor), &reg);
+        assert!(result.is_ok());
+    }
+}

--- a/crates/xmtp_mls_common/src/lib.rs
+++ b/crates/xmtp_mls_common/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod app_data;
 pub mod group;
 pub mod group_metadata;
 pub mod group_mutable_metadata;


### PR DESCRIPTION
Introduces a ComponentId-based permission and registry system that will
replace the current fixed-field PolicySet. Key pieces:

- ComponentId (u16 newtype) with XMTP/App/Immutable/Reserved ranges
- ComponentRegistry (TlsMap<ComponentId, VLBytes>) storing per-component
  metadata: permissions (insert/update/delete) and data type
- Three-layer validation: immutability -> hardcoded -> registry lookup
- Hardcoded: COMPONENT_REGISTRY and SUPER_ADMIN_LIST (super admin only)
- Constrained: ADMIN_LIST (must be AdminOrSuperAdmin or SuperAdmin)
- Deny by default: no registry entry = write rejected

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add component-based permission system for app data in `xmtp_mls_common`
> - Introduces `ComponentId`, a `u16` newtype with well-known constants, range classification helpers (XMTP, app, reserved, immutable, hardcoded), and QUIC variable-length integer TLS serialization/deserialization.
> - Adds `ComponentRegistry`, a `TlsMap`-backed store for component metadata that validates writes, enforces immutability for write-once IDs, and rejects hardcoded/reserved IDs.
> - Implements `validate_component_write` in [validation.rs](https://github.com/xmtp/libxmtp/pull/3413/files#diff-8a1842938cea64924a56d4911d66c58918bf4078c667458b84c5be5a52eb0878), which checks immutability, requires super-admin for hardcoded components, and evaluates insert/update/delete policies from the registry, defaulting to deny.
> - Policy evaluation supports `AndCondition`/`AnyCondition` combinators and base Allow/Deny/Admin/SuperAdmin policies; invalid proto states are treated conservatively as deny.
> - Risk: `from_bytes` eagerly validates all registry entries on deserialization, so malformed or policy-violating persisted data will fail to load.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 34151e2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->