### PR TITLE
fix: repair iOS docs and cargo doc CI builds

### DIFF
--- a/.github/workflows/docs-ios.yml
+++ b/.github/workflows/docs-ios.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           xcode-version: "16.3"
       - name: Build bindings
-        run: nix develop .#ios --command ./sdks/ios/dev/bindings
+        run: ./sdks/ios/dev/bindings
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/docs-ios.yml
+++ b/.github/workflows/docs-ios.yml
@@ -29,7 +29,7 @@ jobs:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "16.0"
+          xcode-version: "16.3"
       - name: Build bindings
         run: nix develop .#ios --command ./sdks/ios/dev/bindings
       - name: Set up Ruby
@@ -48,7 +48,7 @@ jobs:
           bundle add jazzy
       - name: Generate documentation
         working-directory: sdks/ios
-        run: bundle exec jazzy --output ./docs --theme=fullwidth --module=XMTPiOS
+        run: bundle exec jazzy --output ${{ github.workspace }}/sdks/ios/docs --theme=fullwidth --module=XMTPiOS --source-directory ${{ github.workspace }}
       - name: Setup Pages
         uses: actions/configure-pages@v6
       - name: Upload artifact

--- a/dev/docs
+++ b/dev/docs
@@ -2,7 +2,7 @@
 set -eou pipefail
 
 rm -rf ./_site
-cargo doc --workspace --no-deps --exclude bindings_wasm
+cargo doc --workspace --no-deps --exclude bindings_wasm --exclude log_parser
 rm -f target/doc/.lock
 cp -r target/doc _site
 echo "generating site index"


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3428

## Summary

Fixes both broken docs CI workflows on main:

### Deploy Docs (cargo doc) — `deploy-docs.yml`
- **Root cause:** `log_parser` depends on `slint` → `fontique` v0.7.0, which fails to compile on Ubuntu due to `fontconfig_sys` API mismatch
- **Fix:** Exclude `log_parser` from `dev/docs` (`--exclude log_parser`). It's a GUI tool, not an API library — no reason to include it in workspace docs

### iOS Docs (jazzy) — `docs-ios.yml`
- **Root cause 1:** `xcode-version: "16.0"` doesn't support `swift-tools-version: 6.1` (introduced in d49d8557). Swift 6.1 requires Xcode 16.3+
- **Root cause 2:** Jazzy runs from `sdks/ios/` (`working-directory`) but `Package.swift` is at the repo root. `sourcekitten` invokes `swift build` from the wrong directory
- **Fix:** Update Xcode to 16.3 and pass `--source-directory ${{ github.workspace }}` so jazzy finds `Package.swift` at the repo root

## Test plan
- [ ] `deploy-docs.yml` workflow passes (cargo doc succeeds without fontique compilation error)
- [ ] `docs-ios.yml` workflow passes (jazzy finds Package.swift and builds with Xcode 16.3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix iOS docs and cargo doc CI builds
> - Updates the iOS docs workflow to use Xcode 16.3, run the bindings script directly (without a Nix dev shell), and write Jazzy output to an absolute workspace path with `--source-directory` specified.
> - Excludes the `log_parser` crate from `cargo doc` generation in [dev/docs](https://github.com/xmtp/libxmtp/pull/3430/files#diff-99f6b915660b496bb9ff7305e7bb589ce2fd1ce07624095a20d3d690703ae0f8) to fix the cargo doc CI build.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 99f5ecc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->