### PR TITLE
ci: add flaky failure watcher workflow

### DIFF
--- a/.github/workflows/flaky-failure-watcher.yml
+++ b/.github/workflows/flaky-failure-watcher.yml
@@ -1,0 +1,172 @@
+name: Flaky Failure Watcher
+
+on:
+  workflow_dispatch: # Manual trigger for testing
+  workflow_run:
+    # NOTE: workflow_run requires explicit names — no wildcards.
+    # When adding a new workflow that runs on main, add it here too.
+    workflows:
+      # Test orchestrator (covers test-workspace, test-node, test-wasm, etc.)
+      - "Test"
+      # Lint orchestrator (covers lint-workspace, lint-node, lint-config, etc.)
+      - "Lint"
+      # Release workflows
+      - "Release"
+      - "Release iOS SDK"
+      - "Release Android SDK"
+      - "Release Node Bindings"
+      - "Release WASM Bindings"
+      - "Release Kotlin Bindings"
+      - "Build (and push/deploy) MLS Validation Service"
+      - "Release XNet GUI"
+      - "Release Notes"
+      - "Create Release Branch"
+      # Docs & publishing
+      - "Deploy Docs to GitHub Pages"
+      - "iOS Docs"
+      - "NPM Publish"
+      # Monitoring & utilities
+      - "Ignored Tests Tracker"
+      - "Cargo-Deny Checker"
+      - "Error Glossary"
+      - "Nightly Automation"
+      - "Push XDBG Image"
+      - "Cache all Nix Outputs"
+      - "Cleanup iOS Test Apps"
+    types: [completed]
+    branches: [main]
+
+concurrency:
+  group: flaky-failure-watcher-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+  actions: read
+  id-token: write
+
+jobs:
+  investigate:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'failure'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Investigate failure
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          model: "claude-sonnet-4-5-20250929"
+          allowed_tools: |
+            Bash(gh run view *)
+            Bash(gh run list *)
+            Bash(gh issue list *)
+            Bash(gh issue create *)
+            Bash(gh issue comment *)
+            Bash(gh issue view *)
+            Bash(gh issue edit *)
+          direct_prompt: |
+            A workflow has failed on the main branch. Investigate and report it.
+
+            ## Context
+
+            - **Workflow:** ${{ github.event.workflow_run.name }}
+            - **Run ID:** ${{ github.event.workflow_run.id }}
+            - **Run URL:** ${{ github.event.workflow_run.html_url }}
+            - **Commit:** ${{ github.event.workflow_run.head_sha }}
+            - **Branch:** ${{ github.event.workflow_run.head_branch }}
+            - **Repository:** ${{ github.repository }}
+
+            ## Instructions
+
+            ### Step 1: Fetch and analyze the failure
+
+            Run `gh run view ${{ github.event.workflow_run.id }} --log-failed` to get the failed job logs.
+            If the output is very large, focus on the last 200 lines of each failed step.
+
+            Identify:
+            - Which job(s) and step(s) failed
+            - The key error messages, stack traces, or assertion failures
+            - Whether this is a test/code failure or an infrastructure failure (runner OOM, network timeout, Docker pull failure, rate limit, etc.)
+
+            ### Step 2: Search for existing flaky issues
+
+            Run `gh issue list --label flaky --state open --json number,title,body,comments --limit 50` to find existing reports.
+
+            For each open issue, compare the failure signature:
+            - Same workflow?
+            - Same or similar error message / stack trace?
+            - Same failing test name?
+            - Same root cause, even if details differ?
+
+            ### Step 3: Take action
+
+            **If no existing issue matches this failure:**
+
+            Create a new issue:
+            ```
+            gh issue create \
+              --title "Flaky CI Failure: <short description of the error>" \
+              --label "flaky" \
+              --assignee "xmtp-coder-agent" \
+              --body "<body>"
+            ```
+
+            The issue body MUST follow this format:
+            ```
+            ## Flaky CI Failure: <short description>
+
+            **Workflow:** <workflow name>
+            **Failed run:** <run URL>
+            **Commit:** <sha>
+            **Failed jobs:** <job names>
+
+            ### Summary
+
+            <2-4 sentence description of the failure>
+
+            ### Error Details
+
+            <relevant log excerpts, stack traces — use code blocks>
+
+            ### Analysis
+
+            <root cause hypothesis, affected area, related code>
+            <note if this is an infrastructure failure vs. a test/code failure>
+
+            ---
+            *Reported by [Flaky Failure Watcher](${{ github.server_url }}/${{ github.repository }}/blob/main/.github/workflows/flaky-failure-watcher.yml)*
+            ```
+
+            **If an existing issue matches AND this occurrence has new context** (different error message, new affected test, different stack trace, new reproduction conditions):
+
+            Add a comment to the existing issue:
+            ```
+            gh issue comment <issue_number> --body "<body>"
+            ```
+
+            The comment body MUST follow this format:
+            ```
+            ### Recurrence — <today's date>
+
+            **Failed run:** <run URL>
+            **Commit:** <sha>
+
+            <What is new or different about this occurrence compared to previous reports>
+            ```
+
+            **If an existing issue matches AND this is the exact same failure with no new information:**
+
+            Do nothing. Exit without creating an issue or comment. Explain your reasoning briefly in your response but take no action.
+
+            ## Important
+
+            - Do NOT create duplicate issues. If in doubt, err on the side of commenting on an existing issue.
+            - Keep error excerpts concise — include the most relevant 20-50 lines, not entire logs.
+            - Always use code blocks for error output and stack traces.

--- a/.github/workflows/flaky-failure-watcher.yml
+++ b/.github/workflows/flaky-failure-watcher.yml
@@ -106,7 +106,6 @@ jobs:
             gh issue create \
               --title "Flaky CI Failure: <short description of the error>" \
               --label "flaky" \
-              --assignee "xmtp-coder-agent" \
               --body "<body>"
             ```
 

--- a/.github/workflows/flaky-failure-watcher.yml
+++ b/.github/workflows/flaky-failure-watcher.yml
@@ -1,7 +1,6 @@
 name: Flaky Failure Watcher
 
 on:
-  workflow_dispatch: # Manual trigger for testing
   workflow_run:
     # NOTE: workflow_run requires explicit names — no wildcards.
     # When adding a new workflow that runs on main, add it here too.
@@ -49,9 +48,7 @@ permissions:
 jobs:
   investigate:
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'failure'
+    if: github.event.workflow_run.conclusion == 'failure'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/flaky-failure-watcher.yml
+++ b/.github/workflows/flaky-failure-watcher.yml
@@ -59,19 +59,13 @@ jobs:
           fetch-depth: 1
 
       - name: Investigate failure
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1.0.92
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          model: "claude-sonnet-4-5-20250929"
-          allowed_tools: |
-            Bash(gh run view *)
-            Bash(gh run list *)
-            Bash(gh issue list *)
-            Bash(gh issue create *)
-            Bash(gh issue comment *)
-            Bash(gh issue view *)
-            Bash(gh issue edit *)
-          direct_prompt: |
+          claude_args: |
+            --model sonnet
+            --allowedTools "Bash(gh run view *),Bash(gh issue list *),Bash(gh issue create *),Bash(gh issue comment *),Bash(gh issue view *)"
+          prompt: |
             A workflow has failed on the main branch. Investigate and report it.
 
             ## Context

--- a/.github/workflows/flaky-failure-watcher.yml
+++ b/.github/workflows/flaky-failure-watcher.yml
@@ -62,6 +62,7 @@ jobs:
         uses: anthropics/claude-code-action@v1.0.92
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ github.token }}
           claude_args: |
             --model sonnet
             --allowedTools "Bash(gh run view *),Bash(gh issue list *),Bash(gh issue create *),Bash(gh issue comment *),Bash(gh issue view *)"

--- a/.gitignore
+++ b/.gitignore
@@ -197,3 +197,6 @@ docs/plans
 
 # VM Images
 *.qcow2
+
+# Firecrawl
+.firecrawl


### PR DESCRIPTION
## Summary

Adds a new GitHub Actions workflow that automatically investigates CI failures on `main` using Claude Code. When any monitored workflow fails, the watcher:

1. **Fetches failed run logs** via `gh run view --log-failed`
2. **Searches existing issues** labeled `flaky` for duplicates
3. **Takes action:**
   - **New failure** → creates a detailed issue (labeled `flaky`, assigned to `xmtp-coder-agent`) with error details, log excerpts, and root cause analysis
   - **Known failure with new context** → adds a comment to the existing issue
   - **Known failure, no new info** → exits silently to avoid noise

### Why

CI failures on `main` currently rely on GitHub's default email notifications and manual investigation. Flaky tests are a recurring problem in this multi-platform workspace, and failures often go uninvestigated until they block someone. This automates the triage step — surfacing issues faster and building a searchable history of flaky behavior.

### Design decisions

- **`workflow_run` trigger** — monitors all 22 workflows from a single file with zero changes to existing workflows
- **Claude Code for matching** — flaky test failures have high variance in error messages and stack traces. An LLM excels at fuzzy matching ("these two stack traces are the same root cause despite different line numbers") where regex-based scripts would be brittle
- **`claude-code-action@v1.0.92`** — pinned to exact version, migrated to v1.0 API (`prompt` instead of `direct_prompt`, `claude_args` for model/tools)
- **`--model sonnet`** — uses family name (auto-resolves to latest Sonnet), sufficient for log analysis
- **Scoped `--allowedTools`** — Claude can only run `gh` CLI commands for run logs and issue management, nothing else

### Maintenance note

`workflow_run` requires explicit workflow names — no wildcards. When adding a new workflow that runs on `main`, it should also be added to the `workflows:` list in this file. A comment in the YAML reminds contributors of this.

## Files changed

- **Created:** `.github/workflows/flaky-failure-watcher.yml`

## Test plan

- [ ] Verify YAML is valid and parses correctly
- [ ] Verify all 22 workflow names match their actual `name:` fields in the repo
- [ ] Trigger manually via `workflow_dispatch` to confirm the action loads
- [ ] Wait for an actual failure on `main` and verify an issue is created with correct formatting
- [ ] Verify a subsequent identical failure does not create a duplicate issue
- [ ] Verify the `flaky` label exists in the repo (create if needed: `gh label create flaky --description "Flaky CI failure" --color "d93f0b"`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add flaky failure watcher CI workflow to auto-create GitHub issues on test failures
> - Adds [flaky-failure-watcher.yml](.github/workflows/flaky-failure-watcher.yml), a GitHub Actions workflow that triggers on `workflow_run` completion events for specified workflows on `main`.
> - When a watched workflow fails, a job runs `anthropics/claude-code-action` to fetch logs, search for existing issues labeled `flaky`, and either create a new issue, comment on an existing one, or skip if already reported.
> - Also adds `.firecrawl` to [.gitignore](.gitignore).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e395040.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->