### PR TITLE
fix(nix): pass pkgs to mkToolchain in xnet-gui

### DIFF
--- a/nix/package/xnet-gui.nix
+++ b/nix/package/xnet-gui.nix
@@ -27,8 +27,8 @@
 }:
 let
   src = ./../..;
-  rust-toolchain = xmtp.mkToolchain [ "x86_64-unknown-linux-musl" ] [ ];
-  rust = xmtp.craneLib.overrideToolchain (p: rust-toolchain);
+  rust-toolchain = p: xmtp.mkToolchain p [ "x86_64-unknown-linux-musl" ] [ ];
+  rust = xmtp.craneLib.overrideToolchain rust-toolchain;
 
   commonArgs = {
     description = "xNet GUI";


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3429

## Summary

The `fh-cache.yml` workflow has been failing on main with:

```
error: Dependency is not of a valid type: element 1 of depsBuildBuild for cargo-git-https://github.com/ephemerahq/diesel-aadf3e1f81cd7caf34e2b9acda707ec72d43660e
```

Root-caused to `nix/package/xnet-gui.nix` (introduced in #3141).

## Root Cause

`xmtp.mkToolchain` has signature `p: targets: components:` — it takes `pkgs` as the first argument. The previous call:

```nix
rust-toolchain = xmtp.mkToolchain [ "x86_64-unknown-linux-musl" ] [ ];
rust = xmtp.craneLib.overrideToolchain (p: rust-toolchain);
```

passed the target list as `p`, leaving `rust-toolchain` as a **partially-applied function** rather than a toolchain derivation. Combined with `strictDeps = true`, crane's `vendorCargoDeps` produced a `cargo-git-*` derivation whose `depsBuildBuild` contained the broken toolchain value, which `mkDerivation`'s dependency type check rejected.

The error trace (via `--show-trace`) goes:
```
devShells.xnet-gui → xnet-gui-1.10.0 → xnet-gui-deps-1.10.0
  → vendor-cargo-deps → linkLockedDeps
  → cargo-git-https-github.com-ephemerahq-diesel-...
  → depsBuildBuild check fails
```

## Fix

Apply the same `p:` wrapper pattern already used in `nix/package/android.nix`:

```nix
rust-toolchain = p: xmtp.mkToolchain p [ "x86_64-unknown-linux-musl" ] [ ];
rust = xmtp.craneLib.overrideToolchain rust-toolchain;
```

so crane invokes `rust-toolchain` with the correct `pkgs`.

## Test plan

- [x] Reproduced the error locally with `om ci run --include-all-dependencies`
- [x] `nix eval .#packages.x86_64-linux.xnet-gui` — succeeds
- [x] `nix eval .#devShells.x86_64-linux.xnet-gui` — succeeds
- [x] `nix flake show --all-systems` — all outputs evaluate cleanly
- [x] Other devShells (rust, default, android, js, wasm) still evaluate
- [x] `nixfmt --check nix/package/xnet-gui.nix` — passes
- [ ] Full `fh-cache.yml` workflow passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `mkToolchain` call in `xnet-gui` to pass `pkgs` argument
> In [xnet-gui.nix](https://github.com/xmtp/libxmtp/pull/3432/files#diff-783d0f9e5e1e584f2a85dcfab332404187b262711ed0a82d8ddfe622af91b1a4), `rust-toolchain` was a fixed value rather than a function, so `pkgs` was never forwarded to `xmtp.mkToolchain`. This converts `rust-toolchain` into a function accepting `p` and passing it to `xmtp.mkToolchain`, then passes that function directly to `xmtp.craneLib.overrideToolchain`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a3eca4f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->