### PR TITLE
feat(xnet): add traefik_port to TOML config schema making it configurable

### DIFF
--- a/apps/xnet/lib/defaults.toml
+++ b/apps/xnet/lib/defaults.toml
@@ -4,6 +4,7 @@
 use_standard_ports = true
 toxiproxy_port = 8474
 paused = false
+# traefik_port = 80
 
 [migration]
 enable = false

--- a/apps/xnet/lib/src/app/service_manager.rs
+++ b/apps/xnet/lib/src/app/service_manager.rs
@@ -59,7 +59,12 @@ impl ServiceManager {
         proxy.start().await?;
 
         // Start Traefik first so we can get its IP for CoreDNS
-        let mut traefik = Traefik::builder().build();
+        let config = Config::load()?;
+        let mut traefik_builder = Traefik::builder();
+        if let Some(port) = config.traefik_port {
+            traefik_builder = traefik_builder.http_port(port);
+        }
+        let mut traefik = traefik_builder.build();
         traefik.start(&proxy).await?;
 
         // Get Traefik's IP address for CoreDNS container-facing DNS

--- a/apps/xnet/lib/src/config/loadable.rs
+++ b/apps/xnet/lib/src/config/loadable.rs
@@ -49,6 +49,8 @@ pub struct Config {
     pub toxiproxy: ImageConfig,
     /// ToxiProxy port override
     pub toxiproxy_port: Option<u16>,
+    /// Traefik HTTP host port override
+    pub traefik_port: Option<u16>,
     /// Gateway image overrides
     #[builder(default)]
     pub gateway: ImageConfig,
@@ -126,6 +128,7 @@ impl Config {
                 .history(toml.history)
                 .toxiproxy(toml.toxiproxy)
                 .maybe_toxiproxy_port(toml.xnet.toxiproxy_port)
+                .maybe_traefik_port(toml.xnet.traefik_port)
                 .prometheus(toml.prometheus)
                 .grafana(toml.grafana)
                 .address_mode(address_mode)

--- a/apps/xnet/lib/src/config/toml_config.rs
+++ b/apps/xnet/lib/src/config/toml_config.rs
@@ -31,6 +31,8 @@ pub struct ImageConfig {
 pub struct XnetToml {
     pub use_standard_ports: bool,
     pub toxiproxy_port: Option<u16>,
+    /// Override the Traefik HTTP host port (default: 80)
+    pub traefik_port: Option<u16>,
     /// Pause broadcaster contracts on startup (same as `--paused` CLI flag)
     pub paused: bool,
     /// Public IP for remote addressing mode (sslip.io).
@@ -43,6 +45,7 @@ impl Default for XnetToml {
         Self {
             use_standard_ports: true,
             toxiproxy_port: Default::default(),
+            traefik_port: None,
             paused: false,
             remote_ip: None,
         }

--- a/apps/xnet/lib/src/services/traefik.rs
+++ b/apps/xnet/lib/src/services/traefik.rs
@@ -83,6 +83,10 @@ pub struct Traefik {
     #[builder(default = "/tmp/xnet/traefik/dynamic.yml".to_string())]
     dynamic_config_path: String,
 
+    /// The host port for HTTP traffic (default: 80)
+    #[builder(default = TraefikConst::HTTP_PORT)]
+    http_port: u16,
+
     /// Managed container state
     #[builder(default = ManagedContainer::new())]
     container: ManagedContainer,
@@ -119,7 +123,7 @@ impl Traefik {
 
         // Map host ports - expose 80 and 443 for HTTP/gRPC traffic
         let port_bindings = hash_map! {
-            "80/tcp".to_string() => expose(TraefikConst::HTTP_PORT),
+            "80/tcp".to_string() => expose(self.http_port),
             "443/tcp".to_string() => expose(443),
             "8080/tcp".to_string() => expose_127(TraefikConst::DASHBOARD_PORT),
         };
@@ -208,7 +212,7 @@ impl Traefik {
 
     /// Get the Traefik HTTP endpoint.
     pub fn http_url(&self) -> Url {
-        Url::parse(&format!("http://localhost:{}", TraefikConst::HTTP_PORT)).expect("valid URL")
+        Url::parse(&format!("http://localhost:{}", self.http_port)).expect("valid URL")
     }
 
     /// Get the Traefik dashboard URL.
@@ -260,11 +264,11 @@ impl Service for Traefik {
     }
 
     fn port(&self) -> u16 {
-        TraefikConst::HTTP_PORT
+        self.http_port
     }
 
     // Traefik doesn't use ToxiProxy (it's the entry point)
     async fn register(&mut self, _toxiproxy: &ToxiProxy, _: Option<u16>) -> Result<u16> {
-        Ok(TraefikConst::HTTP_PORT)
+        Ok(self.http_port)
     }
 }

--- a/dev/docker/xnet.toml
+++ b/dev/docker/xnet.toml
@@ -3,6 +3,7 @@
 use_standard_ports = true
 toxiproxy_port = 8474
 paused = false
+# traefik_port = 80
 
 [xmtpd]
 image = "ghcr.io/xmtp/xmtpd"


### PR DESCRIPTION
Add optional traefik_port field to XnetToml struct, allowing users to override the Traefik HTTP host port (default: 80) via TOML configuration.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add configurable `traefik_port` to xnet TOML config schema
> - Adds an optional `traefik_port: Option<u16>` field to the TOML config (`xnet.traefik_port`) and propagates it through the config loading pipeline to the `Traefik` service builder.
> - The `Traefik` struct now stores `http_port` and uses it for container port bindings, URL construction, and port accessors instead of the hardcoded constant.
> - Commented example entries are added to [`defaults.toml`](https://github.com/xmtp/libxmtp/pull/3435/files#diff-3f8d515dde694a7ae02f7dc033d32631386432f302cddece9174b41028435728) and [`dev/docker/xnet.toml`](https://github.com/xmtp/libxmtp/pull/3435/files#diff-edf9c38092996d32920d18654b4043ddae7f4242df5374d4b24ab11daca1e94f) to document the new option.
> - Behavioral Change: when `traefik_port` is set in config, Traefik binds to that host port instead of always using port 80.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3cdfb12.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->