### PR TITLE
fix(xnet): resolve TraefikBuilder typestate mismatch breaking cargo doc

### DIFF
--- a/apps/xnet/lib/src/app/service_manager.rs
+++ b/apps/xnet/lib/src/app/service_manager.rs
@@ -60,11 +60,9 @@ impl ServiceManager {
 
         // Start Traefik first so we can get its IP for CoreDNS
         let config = Config::load()?;
-        let mut traefik_builder = Traefik::builder();
-        if let Some(port) = config.traefik_port {
-            traefik_builder = traefik_builder.http_port(port);
-        }
-        let mut traefik = traefik_builder.build();
+        let mut traefik = Traefik::builder()
+            .maybe_http_port(config.traefik_port)
+            .build();
         traefik.start(&proxy).await?;
 
         // Get Traefik's IP address for CoreDNS container-facing DNS


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3436

## Summary

Commit 8baf463 added a configurable `traefik_port` via a conditional `mut` reassignment on `TraefikBuilder`, which broke `cargo doc` on `xnet-lib` and cascaded into the **Deploy Docs to GitHub Pages** and **Release XNet GUI** workflows.

`TraefikBuilder` uses the `bon` typestate pattern — calling `.http_port(port)` returns `TraefikBuilder<SetHttpPort>`, which cannot be assigned back to a variable of type `TraefikBuilder<Empty>`.

## Fix

Use the auto-generated `maybe_http_port` setter on the builder to consume `Option<u16>` in a single chained expression, preserving the typestate. This mirrors the pattern already used in `apps/xnet/lib/src/config/loadable.rs` for `maybe_traefik_port`, `maybe_v3_port`, `maybe_toxiproxy_port`, and `maybe_xmtpd_env`.

Before:
```rust
let mut traefik_builder = Traefik::builder();
if let Some(port) = config.traefik_port {
    traefik_builder = traefik_builder.http_port(port);
}
let mut traefik = traefik_builder.build();
```

After:
```rust
let mut traefik = Traefik::builder()
    .maybe_http_port(config.traefik_port)
    .build();
```

## Test plan

- [x] `cargo check -p xnet-lib` succeeds
- [x] `cargo doc --no-deps -p xnet-lib` succeeds
- [x] `cargo fmt -p xnet-lib -- --check` clean
- [ ] Verify full `cargo doc --workspace --no-deps --exclude bindings_wasm --exclude log_parser` (the exact failing CI command) succeeds in CI
- [ ] Verify `nix build .#xnet-gui` succeeds in CI

Note: clippy reports two pre-existing lints in `config/address_mode.rs` and `xmtpd_cli.rs` that are unrelated to this change (identical code exists on `main`) and are left for a separate PR per the repo's "don't clean up surrounding code in a bug fix" policy.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `TraefikBuilder` typestate mismatch in `ServiceManager` to restore `cargo doc`
> Replaces conditional `http_port` calls on the `TraefikBuilder` with a single chained expression using a new `maybe_http_port` method in [service_manager.rs](https://github.com/xmtp/libxmtp/pull/3442/files#diff-94cdc0e922a829f2b19f5d8f94aee1b22e2fd693ba226810ed0be1b6fdeba45c). The previous pattern of mutating the builder inside an `if let` block caused a typestate mismatch that broke `cargo doc`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 100f1ce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->