### PR TITLE
nix: add gh CLI to every dev shell via shellCommon.basicCliTools

### DIFF
--- a/nix/js.nix
+++ b/nix/js.nix
@@ -11,6 +11,7 @@
   playwright,
   lib,
   mkShell,
+  xmtp,
 }:
 
 mkShell {
@@ -30,6 +31,7 @@ mkShell {
     playwright-driver.browsers
     corepack
   ]
+  ++ xmtp.shellCommon.basicCliTools
   ++ lib.optionals stdenv.isDarwin [
     darwin.cctools
   ];

--- a/nix/lib/shell-common.nix
+++ b/nix/lib/shell-common.nix
@@ -150,9 +150,16 @@ in
   ]
   ++ lib.optionals isLinux [ rr ];
 
+  # Basic CLI tools every dev shell should include.
+  # Keep this list minimal — these are promoted out of miscDevTools so they are
+  # available in focused shells (rust, android, wasm, js) that intentionally
+  # exclude the broader convenience toolset.
+  basicCliTools = [
+    gh
+  ];
+
   # Miscellaneous dev convenience tools
   miscDevTools = [
-    gh
     jq
     curl
     graphite-cli

--- a/nix/package/wasm.nix
+++ b/nix/package/wasm.nix
@@ -109,6 +109,7 @@ let
         chromedriver
         corepack
       ]
+      ++ xmtp.shellCommon.basicCliTools
       # chromium unsupported on darwin
       # google-chrome unsupported on aarch64-linux
       # Firefox compiles from scratch on everything but x86_64 (unreliable build)

--- a/nix/shells/android.nix
+++ b/nix/shells/android.nix
@@ -48,6 +48,7 @@ mkShell (
         jdk17
         gnused
       ]
+      ++ shellCommon.basicCliTools
       ++ lib.optionals androidEnv.hasEmulator [
         androidEnv.emulator
       ]

--- a/nix/shells/ios.nix
+++ b/nix/shells/ios.nix
@@ -49,6 +49,7 @@ mkShell {
     swiftformat
     swiftlint
   ]
+  ++ xmtp.shellCommon.basicCliTools
   ++ lib.optionals isDarwin [
     darwin.cctools
   ];

--- a/nix/shells/local.nix
+++ b/nix/shells/local.nix
@@ -112,6 +112,7 @@ mkShell (
       ++ shellCommon.lintTools
       # Debug & profiling
       ++ shellCommon.debugTools
+      ++ shellCommon.basicCliTools
       ++ shellCommon.miscDevTools
       # Emulator (not available on aarch64-linux)
       ++ lib.optionals androidEnv.hasEmulator [

--- a/nix/shells/rust.nix
+++ b/nix/shells/rust.nix
@@ -1,6 +1,7 @@
 # Focused Rust dev shell for crates/ and bindings/ work.
 # Supports: dev/lint, dev/lint-rust, cargo test, cargo nextest, WASM checks.
-# Does NOT include debugging/profiling tools or convenience packages — see local.nix.
+# Does NOT include debugging/profiling tools or broader convenience packages — see local.nix.
+# Does include shellCommon.basicCliTools (e.g. gh) so GitHub workflows remain usable.
 {
   stdenv,
   darwin,
@@ -49,6 +50,7 @@ mkShell {
     ++ shellCommon.cargoCiTools
     ++ shellCommon.protoTools
     ++ shellCommon.lintTools
+    ++ shellCommon.basicCliTools
     ++ lib.optionals isDarwin [
       darwin.cctools
     ];


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3440

## Summary

Extends the GitHub CLI (`gh`) to all dev shells, not just the full `local` (default) shell.

## Context

PR #3384 previously added `gh` to `shellCommon.miscDevTools` and the PR description claimed it would be available in "all local Nix dev shells (default, rust, etc.)". In practice, only `local.nix` consumes `miscDevTools` — so the focused `rust`, `android`, `ios`, `js`, and `wasm` shells still lacked `gh`. Issue #3440 reports this gap.

## Verification

Before (on `main`):

```
default: HAS gh
rust: NO gh
android: NO gh
js: NO gh
wasm: NO gh
```

After (on this branch):

```
default: HAS gh
rust: HAS gh
android: HAS gh
js: HAS gh
wasm: HAS gh
```

Verification commands used:

\`\`\`
nix eval --raw .#devShells.x86_64-linux.<shell>.buildInputs \\
  --apply 'inputs: builtins.concatStringsSep "\n" (map (x: x.name or x.pname or "unknown") inputs)' \\
  | grep '^gh-'
\`\`\`

All affected dev shell derivations still evaluate cleanly (\`nix eval .#devShells.x86_64-linux.<shell>.drvPath\`).

## Change

- Introduces \`shellCommon.basicCliTools\` in \`nix/lib/shell-common.nix\`, a minimal list (currently just \`gh\`) intended as a universal baseline.
- Moves \`gh\` out of \`miscDevTools\` into \`basicCliTools\` so the broader convenience set (\`jq\`, \`curl\`, \`graphite-cli\`, \`toxiproxy\`) stays opt-in, matching the focused shells' intent.
- Wires \`basicCliTools\` into \`local.nix\`, \`rust.nix\`, \`android.nix\`, \`ios.nix\`, \`js.nix\`, and the \`wasm\` devShell in \`nix/package/wasm.nix\`.
- \`local.nix\` still receives \`miscDevTools\`, so \`jq\`, \`curl\`, \`graphite-cli\`, and \`toxiproxy\` remain available there as before.

## Test plan

- [x] \`taplo format --check\`, \`taplo check\`, \`nixfmt --check\`, and \`treefmt\` via \`just lint-config\` all pass
- [x] \`nix eval\` for every affected devShell succeeds
- [x] \`gh-2.88.1\` now appears in \`buildInputs\` of default, rust, android, js, and wasm shells
- [ ] CI (flake checks, platform-specific builds)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `gh` CLI to all dev shells via `shellCommon.basicCliTools`
> - Introduces a new `basicCliTools` attribute in [shell-common.nix](https://github.com/xmtp/libxmtp/pull/3443/files#diff-1f86dcadca00cc4a528e235290e0cda34a83dc00a67559c6db6d4b2008d4b24c) containing `gh`, and removes `gh` from `miscDevTools`.
> - Adds `basicCliTools` to all dev shells: JS, WASM, Android, iOS, local, and Rust.
> - Behavioral Change: shells that previously included only `miscDevTools` no longer get `gh` implicitly; it must now come from `basicCliTools`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f0087b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->