### PR TITLE
fix(id): propagate SCW verifier retryability through signature errors

### DIFF
--- a/crates/xmtp_id/src/associations/signature.rs
+++ b/crates/xmtp_id/src/associations/signature.rs
@@ -4,7 +4,7 @@ use prost::Message;
 use sha2::{Digest as _, Sha512};
 use std::array::TryFromSliceError;
 use thiserror::Error;
-use xmtp_common::ErrorCode;
+use xmtp_common::{ErrorCode, RetryableError};
 use xmtp_cryptography::{
     CredentialSign, CredentialVerify, SignerError, SigningContextProvider,
     XmtpInstallationCredential,
@@ -89,6 +89,19 @@ pub enum SignatureError {
     /// Ethereum signature parsing failed. Not retryable.
     #[error(transparent)]
     Signature(#[from] alloy::primitives::SignatureError),
+}
+
+impl RetryableError for SignatureError {
+    fn is_retryable(&self) -> bool {
+        match self {
+            // Smart contract wallet verification goes through an RPC provider;
+            // transient provider/IO failures must surface as retryable so the
+            // welcome sync path does not permanently advance the cursor past
+            // welcomes involving SCW users. See xmtp/libxmtp#3394.
+            SignatureError::VerifierError(e) => e.is_retryable(),
+            _ => false,
+        }
+    }
 }
 
 /// Xmtp Installation Credential for Specialized for XMTP Identity
@@ -336,10 +349,46 @@ pub fn to_lower_s(sig_bytes: &[u8]) -> Result<Vec<u8>, SignatureError> {
 #[cfg(test)]
 mod tests {
     use super::to_lower_s;
+    use super::SignatureError;
+    use crate::scw_verifier::VerifierError;
     use alloy::signers::k256::ecdsa::Signature as K256Signature;
     use alloy::signers::k256::elliptic_curve::scalar::IsHigh;
     use alloy::signers::{SignerSync, local::LocalSigner};
     use wasm_bindgen_test::wasm_bindgen_test;
+    use xmtp_common::RetryableError;
+
+    #[xmtp_common::test]
+    fn test_signature_error_verifier_retryable_propagates() {
+        // Retryable verifier error (NoVerifier) should make SignatureError retryable.
+        let err = SignatureError::VerifierError(VerifierError::NoVerifier(
+            "eip155:1".to_string(),
+        ));
+        assert!(
+            err.is_retryable(),
+            "SignatureError wrapping a retryable VerifierError must be retryable"
+        );
+    }
+
+    #[xmtp_common::test]
+    fn test_signature_error_verifier_non_retryable_propagates() {
+        // Non-retryable verifier error (MalformedEipUrl) should stay non-retryable.
+        let err = SignatureError::VerifierError(VerifierError::MalformedEipUrl);
+        assert!(
+            !err.is_retryable(),
+            "SignatureError wrapping a non-retryable VerifierError must not be retryable"
+        );
+    }
+
+    #[xmtp_common::test]
+    fn test_signature_error_non_verifier_variants_not_retryable() {
+        // Terminal crypto/parse failures are never retryable.
+        assert!(!SignatureError::Invalid.is_retryable());
+        assert!(!SignatureError::InvalidPublicKey.is_retryable());
+        assert!(!SignatureError::InvalidClientData.is_retryable());
+        assert!(
+            !SignatureError::MalformedLegacyKey("missing field".to_string()).is_retryable(),
+        );
+    }
 
     #[xmtp_common::test]
     fn test_to_lower_s() {

--- a/crates/xmtp_id/src/associations/signature.rs
+++ b/crates/xmtp_id/src/associations/signature.rs
@@ -348,8 +348,8 @@ pub fn to_lower_s(sig_bytes: &[u8]) -> Result<Vec<u8>, SignatureError> {
 
 #[cfg(test)]
 mod tests {
-    use super::to_lower_s;
     use super::SignatureError;
+    use super::to_lower_s;
     use crate::scw_verifier::VerifierError;
     use alloy::signers::k256::ecdsa::Signature as K256Signature;
     use alloy::signers::k256::elliptic_curve::scalar::IsHigh;
@@ -360,9 +360,7 @@ mod tests {
     #[xmtp_common::test]
     fn test_signature_error_verifier_retryable_propagates() {
         // Retryable verifier error (NoVerifier) should make SignatureError retryable.
-        let err = SignatureError::VerifierError(VerifierError::NoVerifier(
-            "eip155:1".to_string(),
-        ));
+        let err = SignatureError::VerifierError(VerifierError::NoVerifier("eip155:1".to_string()));
         assert!(
             err.is_retryable(),
             "SignatureError wrapping a retryable VerifierError must be retryable"
@@ -385,9 +383,7 @@ mod tests {
         assert!(!SignatureError::Invalid.is_retryable());
         assert!(!SignatureError::InvalidPublicKey.is_retryable());
         assert!(!SignatureError::InvalidClientData.is_retryable());
-        assert!(
-            !SignatureError::MalformedLegacyKey("missing field".to_string()).is_retryable(),
-        );
+        assert!(!SignatureError::MalformedLegacyKey("missing field".to_string()).is_retryable(),);
     }
 
     #[xmtp_common::test]

--- a/crates/xmtp_mls/src/client.rs
+++ b/crates/xmtp_mls/src/client.rs
@@ -210,6 +210,10 @@ impl xmtp_common::RetryableError for ClientError {
             ClientError::Api(api_error) => retryable!(api_error),
             ClientError::Storage(storage_error) => retryable!(storage_error),
             ClientError::Db(db) => retryable!(db),
+            // SCW verification errors carry retryability through SignatureError;
+            // transient RPC provider failures must not advance the welcome cursor.
+            // See xmtp/libxmtp#3394.
+            ClientError::SignatureValidation(e) => retryable!(e),
             ClientError::Generic(err) => err.contains("database is locked"),
             ClientError::EnvelopesNotYetVisible { .. } => true,
             _ => false,
@@ -1229,6 +1233,29 @@ pub(crate) mod tests {
         let members = group.members().await.unwrap();
         // The three installations should count as two members
         assert_eq!(members.len(), 2);
+    }
+
+    #[xmtp_common::test]
+    fn test_client_error_signature_validation_retryability_propagates() {
+        use xmtp_common::RetryableError;
+        use xmtp_id::associations::signature::SignatureError;
+        use xmtp_id::scw_verifier::VerifierError;
+
+        // A retryable verifier error (transient RPC failure) must surface as
+        // retryable at the ClientError layer so the welcome sync path does not
+        // advance the cursor past welcomes involving SCW users. See xmtp/libxmtp#3394.
+        let retryable = super::ClientError::SignatureValidation(SignatureError::VerifierError(
+            VerifierError::NoVerifier("eip155:1".to_string()),
+        ));
+        assert!(retryable.is_retryable());
+
+        // A terminal verifier error (malformed input) must remain non-retryable
+        // so we don't spin forever on bad data.
+        let non_retryable =
+            super::ClientError::SignatureValidation(SignatureError::VerifierError(
+                VerifierError::MalformedEipUrl,
+            ));
+        assert!(!non_retryable.is_retryable());
     }
 
     #[xmtp_common::test]

--- a/crates/xmtp_mls/src/client.rs
+++ b/crates/xmtp_mls/src/client.rs
@@ -1251,10 +1251,9 @@ pub(crate) mod tests {
 
         // A terminal verifier error (malformed input) must remain non-retryable
         // so we don't spin forever on bad data.
-        let non_retryable =
-            super::ClientError::SignatureValidation(SignatureError::VerifierError(
-                VerifierError::MalformedEipUrl,
-            ));
+        let non_retryable = super::ClientError::SignatureValidation(SignatureError::VerifierError(
+            VerifierError::MalformedEipUrl,
+        ));
         assert!(!non_retryable.is_retryable());
     }
 


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3394

## Summary

Smart Contract Wallet (ERC-1271/6492) verification provider errors were mapped to non-retryable `ClientError::SignatureValidation`, so the welcome sync path (`cursor_increment=true`) advanced the welcome cursor and permanently skipped welcomes on any transient RPC provider failure. Groups with at least one SCW user could silently drop invites during RPC outages, pruned archive nodes, or misconfigured providers.

`VerifierError` already classifies its variants correctly — `Provider`, `Io`, and `NoVerifier` are retryable — but the retryability signal was being dropped when the error was wrapped in `SignatureError` and then `ClientError::SignatureValidation`.

## Changes

**`crates/xmtp_id/src/associations/signature.rs`**
- Add `impl RetryableError for SignatureError` that delegates the `VerifierError` variant to `VerifierError::is_retryable()`. All other variants remain non-retryable — they are terminal cryptographic/parse failures where retrying cannot change the outcome.
- Add unit tests covering retryable propagation, non-retryable propagation, and non-verifier variants.

**`crates/xmtp_mls/src/client.rs`**
- Add `ClientError::SignatureValidation(e) => retryable!(e)` arm in the `is_retryable` match so the signal reaches the welcome cursor guard in `xmtp_welcome.rs`.
- Add a unit test verifying the delegation (both a retryable and non-retryable path).

## Behavior

With this change, when the welcome sync path encounters a transient SCW verification error it will bubble up as retryable, the existing guard at `xmtp_welcome.rs:107` will not advance the cursor, and the welcome will be reprocessed on the next sync. Terminal verification failures (e.g. `VerifierError::MalformedEipUrl`, `UnexpectedERC6492Result`) remain non-retryable and advance the cursor as before, so we don't spin forever on bad data.

The streaming path (`cursor_increment=false`) is unchanged — it was never affected by this bug.

## Test plan

- [x] Added unit tests in `signature.rs` for retryable / non-retryable / non-verifier variants
- [x] Added a unit test in `client.rs` for `ClientError::SignatureValidation` delegation
- [ ] CI: `just lint` / cargo clippy
- [ ] CI: `just test crate xmtp_id` and `just test crate xmtp_mls`
- [ ] CI: WASM + node + bindings builds

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Propagate SCW verifier retryability through `SignatureError` and `ClientError`
> - `SignatureError::VerifierError` now implements `RetryableError`, returning the inner error's retryability instead of always returning `false`.
> - `ClientError::SignatureValidation` now propagates retryability via `retryable!(e)` in [client.rs](https://github.com/xmtp/libxmtp/pull/3445/files#diff-74086c32ace91ebbc5bca31e480e4e33cfd9f03bb70c4a8fdbcca16ddfcdf52f); previously this variant was unhandled and defaulted to non-retryable.
> - Both changes are covered by new unit tests in [signature.rs](https://github.com/xmtp/libxmtp/pull/3445/files#diff-09f89481d8b7852671ee9482149addf7d7c14f85a72c5343b094305a60863450) and [client.rs](https://github.com/xmtp/libxmtp/pull/3445/files#diff-74086c32ace91ebbc5bca31e480e4e33cfd9f03bb70c4a8fdbcca16ddfcdf52f).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 57675d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->