### PR TITLE
ci: trigger Release XNet GUI on flake.nix and nix/rust.nix changes

### DIFF
--- a/.github/workflows/release-xnet-gui.yml
+++ b/.github/workflows/release-xnet-gui.yml
@@ -8,6 +8,8 @@ on:
       - "apps/xnet/gui/**"
       - "apps/xnet/lib/**"
       - "nix/package/xnet-gui.nix"
+      - "nix/rust.nix"
+      - "flake.nix"
       - ".github/workflows/release-xnet-gui.yml"
   workflow_dispatch:
 


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3441

## Summary

- Add `flake.nix` and `nix/rust.nix` to `on.push.paths` in `.github/workflows/release-xnet-gui.yml`.
- Two-line change, no workflow logic modified.

## Why

Issue #3441 reported that `Release XNet GUI` failed at commit `28b3dcd87` with:

```
error: flake does not provide attribute 'packages.aarch64-darwin.xnet-gui',
'legacyPackages.aarch64-darwin.xnet-gui' or 'xnet-gui'
```

The attribute-resolution bug itself is already fixed at HEAD by commit `835ebdebc` (#3439), which moved `xnet-gui` into `legacyPackages` and relies on Nix's `packages → legacyPackages` shorthand fallback. **But** `835ebdebc` only touched `flake.nix` and `nix/rust.nix`, neither of which is in the Release XNet GUI `paths` filter, so the workflow never re-ran to validate the fix on `aarch64-darwin`.

This PR closes that gap. Any future nix restructure that could break `.#xnet-gui` resolution will now re-trigger the release workflow.

## Verified at HEAD

```
$ nix eval .#legacyPackages.aarch64-darwin --apply 'p: builtins.attrNames p'
[ \"xnet-gui\" \"xnet-gui-shell\" ]
$ nix eval --raw .#xnet-gui.drvPath
/nix/store/p6b08a7pk04fqqfwhvrcxy71h9qf2y8l-xnet-gui-1.10.0.drv
```

## Test plan

- [x] YAML parses (validated locally with `yaml.safe_load`)
- [x] `on.push.paths` contains the six expected entries in the expected order
- [x] `workflow_dispatch` trigger preserved
- [x] No workflow step, job, or permissions modified (`git diff --stat` = 1 file, 2 insertions)
- [ ] **End-to-end**: merging this PR will itself trigger `Release XNet GUI` at HEAD (since `.github/workflows/release-xnet-gui.yml` is in its own paths filter), which exercises the `835ebdebc` fix on `aarch64-darwin`. If that job succeeds, the issue is fully resolved.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Trigger Release XNet GUI workflow on `flake.nix` and `nix/rust.nix` changes
> Adds `flake.nix` and `nix/rust.nix` as path triggers in the [release-xnet-gui.yml](.github/workflows/release-xnet-gui.yml) push event, so changes to Nix build inputs automatically kick off a release build.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b12e66d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->