### PR TITLE
fix(xmtp_api_d14n): retry GetNodes to absorb transient DNS failures

### DIFF
--- a/crates/xmtp_api_d14n/src/middleware/multi_node_client/gateway_api.rs
+++ b/crates/xmtp_api_d14n/src/middleware/multi_node_client/gateway_api.rs
@@ -6,7 +6,7 @@ use futures::StreamExt;
 use std::collections::HashMap;
 use xmtp_api_grpc::{ClientBuilder, GrpcClient};
 use xmtp_common::time::{Duration, Instant};
-use xmtp_proto::api::{Client, Query};
+use xmtp_proto::api::{retry, Client, Query};
 use xmtp_proto::prelude::{ApiBuilder, NetConnectConfig};
 use xmtp_proto::{ApiEndpoint, api::ApiClientError};
 
@@ -15,8 +15,7 @@ pub(super) async fn get_nodes<C: Client>(
     gateway_client: &C,
     template: &ClientBuilder,
 ) -> Result<HashMap<u32, GrpcClient>, ApiClientError> {
-    let response = GetNodes::builder()
-        .build()?
+    let response = retry(GetNodes::builder().build()?)
         .query(gateway_client)
         .await
         .map_err(|e| {
@@ -156,4 +155,46 @@ pub async fn get_fastest_node(
     tracing::info!("chosen node is {} with latency {}ms", node_id, latency);
 
     Ok(client)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prost::Message;
+    use prost::bytes;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use xmtp_api_grpc::GrpcClient;
+    use xmtp_proto::api::ApiClientError;
+    use xmtp_proto::api::mock::{MockError, MockNetworkClient};
+    use xmtp_proto::xmtp::xmtpv4::payer_api::GetNodesResponse;
+
+    fn encoded_nodes_response() -> bytes::Bytes {
+        let mut nodes = HashMap::new();
+        nodes.insert(1u32, "http://localhost:65535".to_string());
+        bytes::Bytes::from(GetNodesResponse { nodes }.encode_to_vec())
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn retry_get_nodes_recovers_from_transient_failure() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let response = encoded_nodes_response();
+
+        let mut mock = MockNetworkClient::new();
+        mock.expect_request().returning(move |_, _, _| {
+            let n = counter.fetch_add(1, Ordering::SeqCst);
+            if n == 0 {
+                Err(ApiClientError::client(MockError::ARetryableError))
+            } else {
+                Ok(http::Response::new(response.clone()))
+            }
+        });
+
+        let clients = get_nodes(&mock, &GrpcClient::builder())
+            .await
+            .expect("get_nodes should recover from a single transient failure");
+        assert_eq!(clients.len(), 1, "expected one built client");
+        assert!(clients.contains_key(&1), "expected node id 1 in clients");
+    }
 }

--- a/crates/xmtp_api_d14n/src/middleware/multi_node_client/gateway_api.rs
+++ b/crates/xmtp_api_d14n/src/middleware/multi_node_client/gateway_api.rs
@@ -197,4 +197,26 @@ mod tests {
         assert_eq!(clients.len(), 1, "expected one built client");
         assert!(clients.contains_key(&1), "expected node id 1 in clients");
     }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn retry_get_nodes_exhausts_budget_on_repeated_transient_failure() {
+        let mut mock = MockNetworkClient::new();
+        mock.expect_request()
+            .returning(|_, _, _| Err(ApiClientError::client(MockError::ARetryableError)));
+
+        let err = get_nodes(&mock, &GrpcClient::builder())
+            .await
+            .expect_err("get_nodes should give up after exhausting the retry budget");
+
+        // The gRPC path is attached by the query layer before get_nodes can re-tag it,
+        // so the error contains the gRPC path rather than the ApiEndpoint display name.
+        let expected_tag = "/xmtp.xmtpv4.payer_api.PayerApi/GetNodes";
+        let err_string = err.to_string();
+        assert!(
+            err_string.contains(expected_tag),
+            "expected endpoint tag {:?} in error, got: {}",
+            expected_tag,
+            err_string,
+        );
+    }
 }

--- a/crates/xmtp_api_d14n/src/middleware/multi_node_client/gateway_api.rs
+++ b/crates/xmtp_api_d14n/src/middleware/multi_node_client/gateway_api.rs
@@ -219,4 +219,17 @@ mod tests {
             err_string,
         );
     }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn retry_get_nodes_fails_fast_on_non_retryable_error() {
+        let mut mock = MockNetworkClient::new();
+        mock.expect_request()
+            .times(1)
+            .returning(|_, _, _| Err(ApiClientError::client(MockError::ANonRetryableError)));
+
+        let err = get_nodes(&mock, &GrpcClient::builder())
+            .await
+            .expect_err("get_nodes should not retry non-retryable errors");
+        let _ = err; // assertion is enforced by mockall's `.times(1)` on Drop
+    }
 }

--- a/crates/xmtp_api_d14n/src/middleware/multi_node_client/gateway_api.rs
+++ b/crates/xmtp_api_d14n/src/middleware/multi_node_client/gateway_api.rs
@@ -6,7 +6,7 @@ use futures::StreamExt;
 use std::collections::HashMap;
 use xmtp_api_grpc::{ClientBuilder, GrpcClient};
 use xmtp_common::time::{Duration, Instant};
-use xmtp_proto::api::{retry, Client, Query};
+use xmtp_proto::api::{self, Client, Query};
 use xmtp_proto::prelude::{ApiBuilder, NetConnectConfig};
 use xmtp_proto::{ApiEndpoint, api::ApiClientError};
 
@@ -15,7 +15,7 @@ pub(super) async fn get_nodes<C: Client>(
     gateway_client: &C,
     template: &ClientBuilder,
 ) -> Result<HashMap<u32, GrpcClient>, ApiClientError> {
-    let response = retry(GetNodes::builder().build()?)
+    let response = api::retry(GetNodes::builder().build()?)
         .query(gateway_client)
         .await
         .map_err(|e| {

--- a/crates/xmtp_api_d14n/src/middleware/multi_node_client/gateway_api.rs
+++ b/crates/xmtp_api_d14n/src/middleware/multi_node_client/gateway_api.rs
@@ -161,7 +161,7 @@ pub async fn get_fastest_node(
 mod tests {
     use super::*;
     use prost::Message;
-    use prost::bytes;
+    use prost::bytes::Bytes;
     use std::collections::HashMap;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -170,10 +170,10 @@ mod tests {
     use xmtp_proto::api::mock::{MockError, MockNetworkClient};
     use xmtp_proto::xmtp::xmtpv4::payer_api::GetNodesResponse;
 
-    fn encoded_nodes_response() -> bytes::Bytes {
+    fn encoded_nodes_response() -> Bytes {
         let mut nodes = HashMap::new();
         nodes.insert(1u32, "http://localhost:65535".to_string());
-        bytes::Bytes::from(GetNodesResponse { nodes }.encode_to_vec())
+        Bytes::from(GetNodesResponse { nodes }.encode_to_vec())
     }
 
     #[xmtp_common::test(unwrap_try = true)]


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3402

## Summary

`xdbg generate messages` was failing intermittently with `failed to lookup address information` errors at the gateway's `GetNodes` call. The call site in `MultiNodeClient::init_inner` issued `GetNodes::query(gateway_client)` without the retry combinator, so a single transient DNS blip aborted the whole operation.

This wraps the call in `api::retry(...)` inside `get_nodes` at `crates/xmtp_api_d14n/src/middleware/multi_node_client/gateway_api.rs`, mirroring the same pattern already used by `build_node_clients` at `crates/xmtp_api_d14n/src/queries/mod.rs:40`. DNS/transport errors are already classified as retryable by `GrpcError`, so wrapping the call is sufficient — no error-classification changes are needed.

## Changes

- **Production fix (one call site):** `get_nodes` now calls `api::retry(GetNodes::builder().build()?).query(gateway_client)` so transient transport failures go through the default `ExponentialBackoff` retry budget before surfacing.
- The existing `map_err` closure (log + `ApiEndpoint::GetNodes` tag) is preserved verbatim, so error reporting semantics are unchanged.
- **Three new unit tests** in `gateway_api.rs` using `MockNetworkClient`:
  - `retry_get_nodes_recovers_from_transient_failure` — first call returns `ARetryableError`, second call returns a valid encoded `GetNodesResponse`; asserts `get_nodes` returns the built clients.
  - `retry_get_nodes_exhausts_budget_on_repeated_transient_failure` — every call returns `ARetryableError`; asserts the final error contains the `GetNodes` gRPC path.
  - `retry_get_nodes_fails_fast_on_non_retryable_error` — uses mockall `.times(1)` to enforce that a non-retryable error is not retried.

Non-goals: no changes to `HealthCheck`/`get_fastest_node` (multi-node fan-out already provides resilience there), no changes to the default retry strategy, no caching changes.

## Test plan

- [x] `just test crate xmtp_api_d14n` — 151 passed, 2 skipped
- [x] `just lint-rust` — clippy `-Dwarnings`, `cargo fmt --check`, `cargo hakari` all clean
- [x] `just lint-config` — taplo + nixfmt clean
- [x] Three new retry tests pass
- [ ] (Optional, manual) `cargo xdbg -d -x https://payer.testnet-dev.xmtp.network:443 generate --entity message --amount 50` — reproducer from the issue

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retry `GetNodes` requests to handle transient DNS failures in `gateway_api`
> Wraps the `GetNodes` query in `api::retry()` in [`gateway_api.rs`](https://github.com/xmtp/libxmtp/pull/3449/files#diff-48435ec435f0bc9a9928d3606a7ce5a4e7abf5449e88f89c4e100df160ba55dc) so transient failures are retried before propagating an error. Adds three tests covering recovery from a single transient error, exhaustion of the retry budget, and fast-fail behavior for non-retryable errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fdbeef8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->