### PR TITLE
fix(nix): drop tcl from sqlite on musl cross hosts to unblock fh-cache

### DIFF
--- a/nix/lib/default.nix
+++ b/nix/lib/default.nix
@@ -45,53 +45,42 @@
             #   mesonFlags = (old.mesonFlags or [ ]) ++ [ "-Dtests=disabled" ];
             # });
           })
-          # tcl 8.6.16 (pinned via nixpkgs 09061f74...) has two cross-compile
-          # bugs when targeting {x86_64,aarch64}-unknown-linux-musl, which
-          # cascade into sqlite -> cargo-package-deps -> bindings-node-js-napi
-          # / mls-validation-service -> devour-output:
+          # tcl 8.6.16 (pinned via nixpkgs 09061f74...) has multiple
+          # cross-compile bugs when targeting *-unknown-linux-musl, and the
+          # Hydra build farm only caches the x86_64-linux build host (not
+          # aarch64-darwin), so builds from a darwin host hit the bugs cold.
+          # See https://github.com/xmtp/libxmtp/issues/3444.
           #
-          #  1. compat/mkstemp.c calls strlen() without including <string.h>.
-          #     gcc 15 promotes -Wimplicit-function-declaration to an error,
-          #     breaking the musl cross-build (seen on x86_64-linux-musl from
-          #     any host).
+          # Symptoms seen in CI on warp-macos-26-arm64-12x:
+          #   * compat/mkstemp.c: strlen() called without <string.h>; gcc 15
+          #     promotes -Wimplicit-function-declaration to an error.
+          #   * unix/configure's `uname -s` = "Darwin" on the build host
+          #     defines TCL_WIDE_CLICKS + MAC_OSX_TCL even when cross-compiling
+          #     to linux-musl, so tclUnixTime.c tries to include
+          #     <mach/mach_time.h> against a linux sysroot.
           #
-          #  2. unix/tcl.m4's SC_CONFIG_SYSTEM macro reads `uname -s` on the
-          #     build host to set tcl_cv_sys_version. When building on a
-          #     Darwin runner (warp-macos-26-arm64-12x) this becomes Darwin-*,
-          #     which selects the MAC_OSX_TCL / MAC_OSX_OBJS code path and
-          #     causes macOS-only headers (mach/mach_time.h, libkern/*) to be
-          #     compiled against a linux-musl sysroot.
+          # Rather than patching tcl itself — which requires fixing both the
+          # generated configure script and the MAC_OSX_SRCS makefile variable,
+          # and is fragile across nixpkgs revisions — we sidestep the build
+          # entirely. sqlite only depends on tcl for its tclsqlite3 extension
+          # and its test harness; libxmtp consumes libsqlite3 directly, so
+          # --disable-tcl is safe. sqlite's autosetup uses the bundled jimsh0.c
+          # for its own code generation when tcl is disabled.
           #
-          # Remove this override when the nixpkgs pin is bumped past a rev
-          # that adds the missing include and honors the autoconf host triple
-          # in SC_CONFIG_SYSTEM.
-          # See https://github.com/xmtp/libxmtp/issues/3444
+          # Override is gated on `hostPlatform.isMusl` so native sqlite on
+          # linux/darwin keeps substituting from cache.nixos.org unchanged.
           (
             final: prev:
-            let
-              patchedTcl86 = prev.tcl-8_6.overrideAttrs (old: {
-                postPatch = (old.postPatch or "") + ''
-                  substituteInPlace compat/mkstemp.c \
-                    --replace-fail '#include <unistd.h>' '#include <unistd.h>
-                  #include <string.h>'
-                '';
-                preConfigure =
-                  (old.preConfigure or "")
-                  + lib.optionalString prev.stdenv.hostPlatform.isLinux ''
-                    # Override tcl's SC_CONFIG_SYSTEM autoconf cache: tcl reads
-                    # `uname -s` from the *build* host (Darwin on CI), which
-                    # would wrongly select the Darwin-* code path when
-                    # cross-compiling to linux-musl. Force it to Linux so the
-                    # configure script does not gate on MAC_OSX_TCL /
-                    # TCL_WIDE_CLICKS and does not try to compile
-                    # tclMacOSXFCmd.c or include mach/mach_time.h.
-                    export tcl_cv_sys_version=Linux
-                  '';
+            prev.lib.optionalAttrs prev.stdenv.hostPlatform.isMusl {
+              sqlite = prev.sqlite.overrideAttrs (old: {
+                configureFlags =
+                  (prev.lib.filter (f: !(prev.lib.hasPrefix "--with-tcl=" f)) old.configureFlags)
+                  ++ [ "--disable-tcl" ];
+                nativeBuildInputs = prev.lib.filter (p: !(prev.lib.hasPrefix "tcl" (p.pname or ""))) (
+                  old.nativeBuildInputs or [ ]
+                );
+                doCheck = false;
               });
-            in
-            {
-              tcl-8_6 = patchedTcl86;
-              tcl = patchedTcl86;
             }
           )
         ];

--- a/nix/lib/default.nix
+++ b/nix/lib/default.nix
@@ -45,6 +45,55 @@
             #   mesonFlags = (old.mesonFlags or [ ]) ++ [ "-Dtests=disabled" ];
             # });
           })
+          # tcl 8.6.16 (pinned via nixpkgs 09061f74...) has two cross-compile
+          # bugs when targeting {x86_64,aarch64}-unknown-linux-musl, which
+          # cascade into sqlite -> cargo-package-deps -> bindings-node-js-napi
+          # / mls-validation-service -> devour-output:
+          #
+          #  1. compat/mkstemp.c calls strlen() without including <string.h>.
+          #     gcc 15 promotes -Wimplicit-function-declaration to an error,
+          #     breaking the musl cross-build (seen on x86_64-linux-musl from
+          #     any host).
+          #
+          #  2. unix/tcl.m4's SC_CONFIG_SYSTEM macro reads `uname -s` on the
+          #     build host to set tcl_cv_sys_version. When building on a
+          #     Darwin runner (warp-macos-26-arm64-12x) this becomes Darwin-*,
+          #     which selects the MAC_OSX_TCL / MAC_OSX_OBJS code path and
+          #     causes macOS-only headers (mach/mach_time.h, libkern/*) to be
+          #     compiled against a linux-musl sysroot.
+          #
+          # Remove this override when the nixpkgs pin is bumped past a rev
+          # that adds the missing include and honors the autoconf host triple
+          # in SC_CONFIG_SYSTEM.
+          # See https://github.com/xmtp/libxmtp/issues/3444
+          (
+            final: prev:
+            let
+              patchedTcl86 = prev.tcl-8_6.overrideAttrs (old: {
+                postPatch = (old.postPatch or "") + ''
+                  substituteInPlace compat/mkstemp.c \
+                    --replace-fail '#include <unistd.h>' '#include <unistd.h>
+                  #include <string.h>'
+                '';
+                preConfigure =
+                  (old.preConfigure or "")
+                  + lib.optionalString prev.stdenv.hostPlatform.isLinux ''
+                    # Override tcl's SC_CONFIG_SYSTEM autoconf cache: tcl reads
+                    # `uname -s` from the *build* host (Darwin on CI), which
+                    # would wrongly select the Darwin-* code path when
+                    # cross-compiling to linux-musl. Force it to Linux so the
+                    # configure script does not gate on MAC_OSX_TCL /
+                    # TCL_WIDE_CLICKS and does not try to compile
+                    # tclMacOSXFCmd.c or include mach/mach_time.h.
+                    export tcl_cv_sys_version=Linux
+                  '';
+              });
+            in
+            {
+              tcl-8_6 = patchedTcl86;
+              tcl = patchedTcl86;
+            }
+          )
         ];
         config = {
           android_sdk.accept_license = true;


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3444

## Summary

The `Cache all Nix Outputs` workflow has been failing repeatedly on the `warp-macos-26-arm64-12x` runner because `tcl 8.6.16` (pinned via nixpkgs rev `09061f74…`) does not cross-compile to `{x86_64,aarch64}-unknown-linux-musl` from a Darwin build host. There are two independent tcl bugs:

1. **`compat/mkstemp.c` is missing `<string.h>`** — `strlen()` is used without a declaration; gcc 15.2.0 promotes `-Wimplicit-function-declaration` to a hard error. Host-independent.
2. **`unix/configure` defines `TCL_WIDE_CLICKS` + `MAC_OSX_TCL` from the build host's `uname -s`** — specifically, `configure.in:557` has an unguarded `` if test "`uname -s`" = "Darwin" `` branch that runs regardless of the `--host` triple. On a Darwin build host it unconditionally defines both macros, and `tclUnixTime.c` then pulls in `<mach/mach_time.h>` against a linux-musl sysroot. Darwin-build-host-only.

The cascade is `tcl → sqlite → cargo-package-deps → bindings-node-js-napi / mls-validation-service → devour-output`.

### Why this only hits CI, not neekolas's laptop

`cache.nixos.org` hosts cross-compile outputs keyed by build-host. Hydra only builds the `x86_64-linux → {x86_64,aarch64}-linux-musl` cross chain, not `aarch64-darwin → *-linux-musl`. A developer on an Apple Silicon Mac who has ever had the target in their local store, uses a remote Linux builder, or populates `/nix/store` via `just backend` / `dev/up` can substitute the result and never touch the compile path. A **cold** macOS build is the only thing that reliably reproduces — which is exactly what #3408 made the fh-cache workflow do (active-build + invalidated WarpBuilds cache + new runner image + fresh `flake.lock`).

### Previous attempt

Commit 4d17631b tried to patch tcl by exporting `tcl_cv_sys_version=Linux` in `preConfigure`, redirecting tcl's `SC_CONFIG_SYSTEM` autoconf macro. That was **incomplete**: the rogue `uname -s` check at `configure.in:557` is a separate code path that the autoconf cache variable does not touch. A correct tcl patch would need to regenerate `configure` with autoreconf or patch both the generated script and the `MAC_OSX_SRCS` makefile variable — fragile across nixpkgs revisions.

## Fix

Rather than fight tcl, sidestep it. `sqlite` only depends on tcl for its `tclsqlite3` extension and its test harness. libxmtp consumes `libsqlite3` directly via `diesel`/`rusqlite`, so `--disable-tcl` is safe. sqlite's autosetup uses the bundled `autosetup/jimsh0.c` for its own code generation when tcl is absent (documented at `autosetup/sqlite-config.tcl:243`).

The new overlay in `nix/lib/default.nix`:

```nix
(
  final: prev:
  prev.lib.optionalAttrs prev.stdenv.hostPlatform.isMusl {
    sqlite = prev.sqlite.overrideAttrs (old: {
      configureFlags =
        (prev.lib.filter (f: !(prev.lib.hasPrefix "--with-tcl=" f)) old.configureFlags)
        ++ [ "--disable-tcl" ];
      nativeBuildInputs = prev.lib.filter (p: !(prev.lib.hasPrefix "tcl" (p.pname or ""))) (
        old.nativeBuildInputs or [ ]
      );
      doCheck = false;
    });
  }
)
```

- Gated on `stdenv.hostPlatform.isMusl` — no-op for every other target.
- Strips `--with-tcl=...` from `configureFlags` and appends `--disable-tcl` (a first-party supported configuration in the nixpkgs sqlite derivation; it's already enabled on `isStatic` at `sqlite/default.nix:85`).
- Filters `tcl*` packages out of `nativeBuildInputs`.
- Disables `doCheck` — sqlite's test suite runs `srctree-check.tcl` via tclsh and would pull tcl back in otherwise.

## Validation (all local)

- **Musl x86_64 cross sqlite:** builds cleanly; closure has zero `tcl` entries (verified via `nix derivation show` — `inputs.drvs` contains no tcl, `env.configureFlags` has only `--disable-tcl`, `env.nativeBuildInputs` has no tcl).
- **Musl aarch64 cross sqlite:** builds cleanly.
- **End-to-end:** `mls-validation-service-x86_64-unknown-linux-musl` (the canonical downstream target in the failing workflow) builds successfully from a cold store. Output: `/nix/store/fybjfq0yjd5dk6hmd9jr2n2ymky4s9v0-mls-validation-service-x86_64-unknown-linux-musl-1.10.0`.
- **Native sqlite invariance:** native drv hashes identical with and without the overlay:
  - `x86_64-linux`: `53j5kr3aq86wnyczwlmlh0a0n48nhnk4-sqlite-3.51.2.drv` (both)
  - `aarch64-darwin`: `9lkza91vfmh6h5f2r3vdg1w04m3ymn0f-sqlite-3.51.2.drv` (both)

  ⇒ non-musl consumers continue to substitute from `cache.nixos.org` with no cache-miss regression.
- `nixfmt-rfc-style` clean on `nix/lib/default.nix`.
- **CI (pending):** the `Cache all Nix Outputs` workflow on `warp-macos-26-arm64-12x` is the only test that exercises the actual cold darwin-host cross path; this PR's CI run is the definitive end-to-end check.

## Test plan

- [x] `nix build` of musl cross sqlite for both x86_64 and aarch64 succeeds locally.
- [x] `nix derivation show` confirms no tcl in the overridden sqlite's `inputs.drvs`, `env.configureFlags`, or `env.nativeBuildInputs`.
- [x] `mls-validation-service-x86_64-unknown-linux-musl` builds end-to-end from a cold store.
- [x] Native sqlite drv hashes unchanged on x86_64-linux and aarch64-darwin (no regression for non-musl consumers).
- [x] `nixfmt-rfc-style` clean.
- [ ] CI `Cache all Nix Outputs` workflow passes on `warp-macos-26-arm64-12x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable TCL in sqlite builds on musl cross hosts
> Adds a Nix overlay in [nix/lib/default.nix](https://github.com/xmtp/libxmtp/pull/3450/files#diff-6fd175d36064b2e9b9371596932bf201514494fc02c317f3f4526243d72991f1) that overrides the `sqlite` derivation when the host platform is musl. The override strips any `--with-tcl=` configure flag, appends `--disable-tcl`, removes tcl-related entries from `nativeBuildInputs`, and sets `doCheck = false`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2d99c88.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->