### PR TITLE
test(ios): stabilize flaky disappearing-messages and sync-perf tests

### DIFF
--- a/sdks/ios/Tests/XMTPTests/DmTests.swift
+++ b/sdks/ios/Tests/XMTPTests/DmTests.swift
@@ -353,9 +353,12 @@ class DmTests: XCTestCase {
 	func testDmDisappearingMessages() async throws {
 		let fixtures = try await fixtures()
 
+		// Retention is 5s (long enough that the initial count assertion
+		// below wins the race with the 1s-interval disappearing_messages
+		// worker even on slow CI runners — see issue #3448).
 		let initialSettings = DisappearingMessageSettings(
 			disappearStartingAtNs: 1_000_000_000,
-			retentionDurationInNs: 1_000_000_000 // 1s duration
+			retentionDurationInNs: 5_000_000_000 // 5s duration
 		)
 
 		// Create group with disappearing messages enabled
@@ -378,7 +381,8 @@ class DmTests: XCTestCase {
 		XCTAssertEqual(alixGroupMessagesCount, 2) // memberAdd howdy
 		XCTAssertNotNil(boGroupSettings)
 
-		try await Task.sleep(nanoseconds: 5_000_000_000) // Sleep for 5 seconds
+		// Sleep longer than retention (5s) + worker interval (1s) + buffer.
+		try await Task.sleep(nanoseconds: 8_000_000_000) // Sleep for 8 seconds
 
 		let boGroupMessagesAfterSleep = try await boDm.messages().count
 		let alixGroupMessagesAfterSleep = try await alixDm?.messages().count

--- a/sdks/ios/Tests/XMTPTests/GroupTests.swift
+++ b/sdks/ios/Tests/XMTPTests/GroupTests.swift
@@ -1177,7 +1177,11 @@ class GroupTests: XCTestCase {
 		try fixtures.cleanUpDatabases()
 	}
 
-	func testCanSyncManyGroupsInUnderASecond() async throws {
+	// Formerly testCanSyncManyGroupsInUnderASecond; the hard <1s budget was
+	// not robust to CI runner variance (see issue #3448). The 10s ceiling
+	// still catches order-of-magnitude regressions while tolerating a
+	// loaded macOS runner; strict perf targets belong in dev/bench.
+	func testCanSyncManyGroupsQuickly() async throws {
 		let fixtures = try await fixtures()
 		var groups: [Group] = []
 
@@ -1201,7 +1205,7 @@ class GroupTests: XCTestCase {
 				.syncAllConversations().numEligible
 			let end = Date()
 			print(end.timeIntervalSince(start))
-			XCTAssert(end.timeIntervalSince(start) < 1)
+			XCTAssert(end.timeIntervalSince(start) < 10)
 			XCTAssertEqual(numGroupsSynced, 101)
 		} catch {
 			print("Failed to list groups members: \(error)")
@@ -1234,7 +1238,9 @@ class GroupTests: XCTestCase {
 		try fixtures.cleanUpDatabases()
 	}
 
-	func testCanListManyMembersInParallelInUnderASecond() async throws {
+	// Formerly testCanListManyMembersInParallelInUnderASecond; the hard
+	// <1s budget was not robust to CI runner variance (see issue #3448).
+	func testCanListManyMembersInParallelQuickly() async throws {
 		let fixtures = try await fixtures()
 		var groups: [Group] = []
 
@@ -1249,7 +1255,7 @@ class GroupTests: XCTestCase {
 			_ = try await listMembersInParallel(groups: groups)
 			let end = Date()
 			print(end.timeIntervalSince(start))
-			XCTAssert(end.timeIntervalSince(start) < 1)
+			XCTAssert(end.timeIntervalSince(start) < 10)
 		} catch {
 			print("Failed to list groups members: \(error)")
 			throw error // Rethrow the error to fail the test if group creation fails
@@ -1270,9 +1276,12 @@ class GroupTests: XCTestCase {
 	func testGroupDisappearingMessages() async throws {
 		let fixtures = try await fixtures()
 
+		// Retention is 5s (long enough that the initial count assertion
+		// below wins the race with the 1s-interval disappearing_messages
+		// worker even on slow CI runners — see issue #3448).
 		let initialSettings = DisappearingMessageSettings(
 			disappearStartingAtNs: Int64(Date().timeIntervalSince1970 * 1_000_000_000),
-			retentionDurationInNs: 1_000_000_000 // 1s duration
+			retentionDurationInNs: 5_000_000_000 // 5s duration
 		)
 
 		// Create group with disappearing messages enabled
@@ -1296,7 +1305,8 @@ class GroupTests: XCTestCase {
 		XCTAssertEqual(alixGroupMessagesCount, 2) // memberAdd, howdy
 		XCTAssertNotNil(boGroupSettings)
 
-		try await Task.sleep(nanoseconds: 5_000_000_000) // Sleep for 5 seconds
+		// Sleep longer than retention (5s) + worker interval (1s) + buffer.
+		try await Task.sleep(nanoseconds: 8_000_000_000) // Sleep for 8 seconds
 
 		let boGroupMessagesAfterSleep = try await boGroup.messages().count
 		let alixGroupMessagesAfterSleep = try await alixGroup?.messages().count


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3448

## Summary

Three iOS tests were intermittently failing on CI. All three are test-timing
bugs rather than production bugs, so the fix is confined to the Swift test
files.

- `testDmDisappearingMessages` (`DmTests.swift`) and `testGroupDisappearingMessages` (`GroupTests.swift`) configured `retentionDurationInNs = 1_000_000_000` (1 s), which races the 1 s-interval `disappearing_messages` worker (`crates/xmtp_mls/src/worker/disappearing_messages.rs:12`). Each message's `expire_at_ns` is set to `now_ns() + in_ns` when it is stored (`crates/xmtp_mls/src/groups/mls_sync.rs:1812`, `get_message_expire_at_ns`), so on a loaded WarpBuild macOS ARM64 runner the `send → syncAllConversations → findDm/Group → messages().count` pipeline can exceed 1 s and the worker deletes the message before the initial `count == 2` assertion. `disappearStartingAtNs` does **not** gate expiration — only `in_ns` does (see `MessageDisappearingSettings::is_enabled`). Fix: bump initial `retentionDurationInNs` to 5 s and the post-assertion sleep to 8 s (retention + worker interval + 2 s buffer). The second half of each test (update-to-nil, re-enable with `updatedSettings`) is untouched.
- `testCanSyncManyGroupsInUnderASecond` enforced a hard `XCTAssert(... < 1)` wall-clock budget that is not robust to CI runner variance; on the failing run the whole test took 223 s. Rename to `testCanSyncManyGroupsQuickly` and relax the budget to `< 10` s — still catches order-of-magnitude regressions while tolerating a loaded runner. Strict perf targets belong in `dev/bench`.
- Applied the same rename + relaxation to the sibling `testCanListManyMembersInParallelInUnderASecond` → `testCanListManyMembersInParallelQuickly` because it has the identical pattern and is a latent flake for the same reason.

All correctness assertions (`numEligible == 101`, subsequent `numSynced == 0`, the `count == 1` post-sleep assertions) are preserved.

## Test plan

- [ ] `test-ios` CI job passes on this PR (authoritative — iOS Swift tests cannot be run from the Linux dev environment)
- [ ] `lint-ios` CI job passes (SwiftLint + SwiftFormat)
- [ ] Re-run `test-ios` multiple times to observe disappearance of the three intermittent failures

## Notes for reviewers

- The `disappearing_messages` worker and `get_message_expire_at_ns` are correct; only the test-side timing budgets were at fault. No production code changes.
- Android has equivalent tests (`sdks/android/library/src/androidTest/java/org/xmtp/android/library/{DmTest,GroupTest}.kt`) with the same pattern. They are not currently reported as flaky in #3448 and so are left alone; a follow-up can apply the same fix if they start flaking.

Design notes and EARS requirements were posted as an [issue comment](https://github.com/xmtp/libxmtp/issues/3448#issuecomment-4225343512) for traceability.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stabilize flaky iOS disappearing-messages and sync-perf tests
> - Increases `DisappearingMessageSettings.retentionDurationInNs` from 1s to 5s and extends `Task.sleep` from 5s to 8s in both `testDmDisappearingMessages` and `testGroupDisappearingMessages` to reduce timing-related failures on CI.
> - Relaxes sync and member-listing performance thresholds from <1s to <10s in `testCanSyncManyGroupsQuickly` and `testCanListManyMembersInParallelQuickly` (previously named `...InUnderASecond`) to account for CI variance.
> - Behavioral Change: disappearing-message tests now take ~8s longer to run; sync/member-listing tests accept up to 10× more elapsed time before failing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 073b70e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->