### PR TITLE
feat(xnet): add resolve_port() to unify XMTPD port assignment logic

### DIFF
--- a/apps/xnet/lib/src/app/run.rs
+++ b/apps/xnet/lib/src/app/run.rs
@@ -112,13 +112,36 @@ impl App {
             .await?;
         }
 
+        if add.use_standard_port {
+            // Check all registered ToxiProxy proxies, not just mgr.nodes() which
+            // only contains nodes started in the current session. Nodes whose proxy
+            // already existed at startup are skipped by ServiceManager::start() and
+            // never added to self.nodes, so we must query ToxiProxy directly.
+            let standard_port = crate::constants::Xmtpd::GRPC_PORT;
+            let existing_proxies = mgr.proxy.list_proxies().await?;
+            for proxy in existing_proxies.values() {
+                let listen = &proxy.proxy_pack.listen;
+                let port: u16 = listen
+                    .rsplit(':')
+                    .next()
+                    .and_then(|p| p.parse().ok())
+                    .unwrap_or(0);
+                if port == standard_port {
+                    return Err(eyre!(
+                        "cannot add node with --use-standard-port: port {} is already in use by an existing proxy",
+                        standard_port
+                    ));
+                }
+            }
+        }
+
         let cli = XmtpdCli::builder().toxiproxy(mgr.proxy.clone());
         let mut output = self.cli_output.lock().await;
         let gateway = mgr
             .gateway
             .external_url()
             .ok_or_eyre("no url for gateway")?;
-        let mut xmtpd = XmtpdNode::new(gateway.as_str()).await?;
+        let mut xmtpd = XmtpdNode::new(gateway.as_str(), add.use_standard_port).await?;
         cli.clone()
             .build()
             .register(&mgr, &mut *output, &xmtpd)

--- a/apps/xnet/lib/src/app/service_manager.rs
+++ b/apps/xnet/lib/src/app/service_manager.rs
@@ -10,10 +10,9 @@ use crate::{
     network::{Network, XNET_NETWORK_NAME},
     services::{
         self, CoreDns, Gateway, Grafana, NodeGo, Otterscan, PgAdmin, Prometheus, ReplicationDb,
-        Service, ToxiProxy, Traefik, TraefikConfig, Xmtpd, allocate_xmtpd_port,
-        create_and_start_container,
+        Service, ToxiProxy, Traefik, TraefikConfig, Xmtpd, create_and_start_container,
     },
-    types::XmtpdNode,
+    types::{XmtpdNode, resolve_port},
     xmtpd_cli::XmtpdCli,
 };
 use bollard::{
@@ -127,6 +126,7 @@ impl ServiceManager {
             migrator,
             name,
             enable,
+            use_standard_port,
         } in config.xmtpd_nodes
         {
             id += XmtpdConst::NODE_ID_INCREMENT;
@@ -139,11 +139,7 @@ impl ServiceManager {
                 continue;
             }
             let node = XmtpdNode::builder();
-            let node = if let Some(p) = port {
-                node.port(p)
-            } else {
-                node.port(allocate_xmtpd_port()?)
-            };
+            let node = node.port(resolve_port(use_standard_port, port)?);
             let node = if let Some(n) = name {
                 node.name(n)
             } else {

--- a/apps/xnet/lib/src/config/args.rs
+++ b/apps/xnet/lib/src/config/args.rs
@@ -62,6 +62,9 @@ pub struct AddNode {
     /// make this node a migrator node
     #[arg(long, short)]
     pub migrator: bool,
+    /// assign this node the standard XMTPD gRPC port (5050) instead of an allocated port
+    #[arg(long)]
+    pub use_standard_port: bool,
 }
 
 #[derive(Args, Debug, Copy, Clone)]

--- a/apps/xnet/lib/src/config/loadable.rs
+++ b/apps/xnet/lib/src/config/loadable.rs
@@ -17,6 +17,31 @@ use super::toml_config::{ImageConfig, MigrationConfig, NodeToml, TomlConfig};
 
 static CONF: OnceLock<Config> = OnceLock::new();
 
+/// Validate the node slice from TOML configuration.
+///
+/// Rules:
+/// - At most one node may have `use_standard_port = true`
+/// - A node cannot have both `use_standard_port = true` and an explicit `port`
+pub fn validate_node_toml(nodes: &[NodeToml]) -> Result<()> {
+    let standard_port_count = nodes.iter().filter(|n| n.use_standard_port).count();
+    if standard_port_count > 1 {
+        color_eyre::eyre::bail!(
+            "at most one node may have `use_standard_port = true`, found {}",
+            standard_port_count
+        );
+    }
+    for node in nodes {
+        if node.use_standard_port && node.port.is_some() {
+            let name = node.name.as_deref().unwrap_or("<unnamed>");
+            color_eyre::eyre::bail!(
+                "node '{}': cannot set both `use_standard_port = true` and an explicit `port`",
+                name
+            );
+        }
+    }
+    Ok(())
+}
+
 #[derive(Builder, Debug, Clone)]
 #[builder(on(String, into), derive(Debug))]
 pub struct Config {
@@ -153,6 +178,9 @@ impl Config {
                     }
                 }
             }
+
+            // Validate node configuration
+            validate_node_toml(&c.xmtpd_nodes)?;
 
             CONF.set(c)
                 .map_err(|_| eyre!("Config already initialized"))?;

--- a/apps/xnet/lib/src/config/toml_config.rs
+++ b/apps/xnet/lib/src/config/toml_config.rs
@@ -75,6 +75,7 @@ pub struct NodeToml {
     pub name: Option<String>,
     pub port: Option<u16>,
     pub migrator: bool,
+    pub use_standard_port: bool,
 }
 
 #[derive(Deserialize, Default, Debug)]

--- a/apps/xnet/lib/src/config/toml_config_test.rs
+++ b/apps/xnet/lib/src/config/toml_config_test.rs
@@ -20,3 +20,92 @@ fn paused_parses_false_explicit() {
     let config: TomlConfig = toml::from_str(toml_str).unwrap();
     assert!(!config.xnet.paused);
 }
+
+#[test]
+fn node_use_standard_port_defaults_to_false() {
+    let toml_str = "[[xmtpd.nodes]]\nenable = true\n";
+    let config: TomlConfig = toml::from_str(toml_str).unwrap();
+    assert!(!config.xmtpd.nodes[0].use_standard_port);
+}
+
+#[test]
+fn node_use_standard_port_parses_true() {
+    let toml_str = "[[xmtpd.nodes]]\nenable = true\nuse_standard_port = true\n";
+    let config: TomlConfig = toml::from_str(toml_str).unwrap();
+    assert!(config.xmtpd.nodes[0].use_standard_port);
+}
+
+#[test]
+fn validation_rejects_two_standard_port_nodes() {
+    use crate::config::loadable::validate_node_toml;
+    use crate::config::toml_config::NodeToml;
+    let nodes = vec![
+        NodeToml {
+            enable: true,
+            use_standard_port: true,
+            ..Default::default()
+        },
+        NodeToml {
+            enable: true,
+            use_standard_port: true,
+            ..Default::default()
+        },
+    ];
+    let result = validate_node_toml(&nodes);
+    assert!(result.is_err());
+    let msg = format!("{}", result.unwrap_err());
+    assert!(msg.contains("at most one"));
+}
+
+#[test]
+fn validation_rejects_standard_port_with_explicit_port() {
+    use crate::config::loadable::validate_node_toml;
+    use crate::config::toml_config::NodeToml;
+    let nodes = vec![NodeToml {
+        enable: true,
+        use_standard_port: true,
+        port: Some(9000),
+        name: Some("alice".into()),
+        ..Default::default()
+    }];
+    let result = validate_node_toml(&nodes);
+    assert!(result.is_err());
+    let msg = format!("{}", result.unwrap_err());
+    assert!(msg.contains("cannot set both"));
+}
+
+#[test]
+fn validation_allows_one_standard_port_node() {
+    use crate::config::loadable::validate_node_toml;
+    use crate::config::toml_config::NodeToml;
+    let nodes = vec![
+        NodeToml {
+            enable: true,
+            use_standard_port: true,
+            ..Default::default()
+        },
+        NodeToml {
+            enable: true,
+            ..Default::default()
+        },
+    ];
+    assert!(validate_node_toml(&nodes).is_ok());
+}
+
+#[test]
+fn validation_allows_zero_standard_port_nodes() {
+    use crate::config::loadable::validate_node_toml;
+    use crate::config::toml_config::NodeToml;
+    let nodes = vec![
+        NodeToml {
+            enable: true,
+            port: Some(3000),
+            ..Default::default()
+        },
+        NodeToml {
+            enable: true,
+            ..Default::default()
+        },
+    ];
+    assert!(validate_node_toml(&nodes).is_ok());
+}

--- a/apps/xnet/lib/src/types.rs
+++ b/apps/xnet/lib/src/types.rs
@@ -23,18 +23,30 @@ pub struct XmtpdNode {
     name: String,
 }
 
+/// Determine the port for an XMTPD node.
+///
+/// Rules:
+/// - `use_standard_port=true` + explicit port → error
+/// - `use_standard_port=true` + no port       → 5050 (XmtpdConst::GRPC_PORT)
+/// - `use_standard_port=false` + explicit port → use that port
+/// - `use_standard_port=false` + no port       → allocate from range 8150-8200
+pub fn resolve_port(use_standard_port: bool, port: Option<u16>) -> Result<u16> {
+    match (use_standard_port, port) {
+        (true, Some(_)) => color_eyre::eyre::bail!(
+            "cannot set both `use_standard_port` and an explicit `port` for the same node"
+        ),
+        (true, None) => Ok(XmtpdConst::GRPC_PORT),
+        (false, Some(p)) => Ok(p),
+        (false, None) => allocate_xmtpd_port(),
+    }
+}
+
 impl XmtpdNode {
-    pub async fn new(gateway_host: &str) -> Result<Self> {
+    pub async fn new(gateway_host: &str, use_standard_port: bool) -> Result<Self> {
         let config = Config::load()?;
         let next_id = Self::get_next_id(gateway_host).await?;
-        // if its the first node use the standard 5050 for compatibility
-        let port = if config.use_standard_ports && next_id == XmtpdConst::NODE_ID_INCREMENT {
-            5050
-        } else {
-            allocate_xmtpd_port()?
-        };
+        let port = resolve_port(use_standard_port, None)?;
 
-        let config = Config::load()?;
         let num_ids = next_id / XmtpdConst::NODE_ID_INCREMENT;
         let base_idx = num_ids as usize * 3 + 1;
         Ok(Self {
@@ -100,5 +112,44 @@ impl XmtpdNode {
         let nodes = GetNodes::builder().build()?.query(&grpc).await?;
         let ids = nodes.nodes.keys().max();
         Ok(ids.unwrap_or(&0) + XmtpdConst::NODE_ID_INCREMENT)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_port_standard_port_none_returns_5050() {
+        let result = resolve_port(true, None).unwrap();
+        assert_eq!(result, XmtpdConst::GRPC_PORT);
+    }
+
+    #[test]
+    fn resolve_port_auto_allocates_in_range() {
+        use crate::constants::ToxiProxy as ToxiProxyConst;
+        let result = resolve_port(false, None).unwrap();
+        assert!(
+            result >= ToxiProxyConst::XMTPD_PORT_RANGE.0
+                && result < ToxiProxyConst::XMTPD_PORT_RANGE.1,
+            "allocated port {} not in range {}..{}",
+            result,
+            ToxiProxyConst::XMTPD_PORT_RANGE.0,
+            ToxiProxyConst::XMTPD_PORT_RANGE.1,
+        );
+    }
+
+    #[test]
+    fn resolve_port_explicit_port_returns_that_port() {
+        let result = resolve_port(false, Some(9999)).unwrap();
+        assert_eq!(result, 9999);
+    }
+
+    #[test]
+    fn resolve_port_standard_port_and_explicit_errors() {
+        let result = resolve_port(true, Some(9999));
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(msg.contains("cannot set both"));
     }
 }


### PR DESCRIPTION
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `resolve_port()` to unify XMTPD gRPC port assignment logic
> - Adds `resolve_port(use_standard_port, port)` in [types.rs](https://github.com/xmtp/libxmtp/pull/3454/files#diff-26d0ac38565bf43543557c49d723b1f779aa69a2e5599f54857691da15559874) to centralize port selection: returns the standard gRPC port (5050) when requested, an explicit port if provided, or allocates one automatically.
> - Adds `--use-standard-port` CLI flag to `AddNode` and a `use_standard_port` field to `NodeToml`, replacing the previous implicit first-node/config detection in `XmtpdNode::new`.
> - Adds validation in [loadable.rs](https://github.com/xmtp/libxmtp/pull/3454/files#diff-97cd35bbd7e21d56fe283057fa9ad3bad66ebd1e45be2a1d62ef48416f6529a8) that rejects configs where more than one node sets `use_standard_port = true` or a node sets both `use_standard_port` and an explicit port.
> - When `--use-standard-port` is requested at runtime, `App::up` checks existing ToxiProxy proxies and errors if any already listens on port 5050.
> - Behavioral Change: `XmtpdNode::new` now requires an explicit `use_standard_port` argument instead of inferring port assignment from global config state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2605a0e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->