### PR TITLE
feat(xnet): auto-discover xmtpd databases in PgAdmin via Docker labels

### DIFF
--- a/apps/xnet/lib/src/app/service_manager.rs
+++ b/apps/xnet/lib/src/app/service_manager.rs
@@ -75,14 +75,14 @@ impl ServiceManager {
         // Create Traefik config manager (loads existing routes from file)
         let traefik_config = TraefikConfig::new(traefik.dynamic_config_path())?;
 
-        // Start monitoring services (Prometheus + Grafana + PgAdmin) in parallel
+        // Start monitoring services (Prometheus + Grafana) in parallel.
+        // PgAdmin is started AFTER xmtpd nodes — see below.
         let mut prometheus = Prometheus::builder().build();
         let mut grafana = Grafana::builder().build();
-        let mut pgadmin = PgAdmin::builder().build();
+        let pgadmin = PgAdmin::builder().build();
         let launch = vec![
             prometheus.start(&proxy).boxed(),
             grafana.start(&proxy).boxed(),
-            pgadmin.start(&proxy).boxed(),
         ];
         futures::future::try_join_all(launch).await?;
 
@@ -169,6 +169,13 @@ impl ServiceManager {
             }
         }
 
+        // Start PgAdmin AFTER xmtpd nodes so it can discover their
+        // ReplicationDb containers via Docker labels (xnet.pgadmin=true).
+        // Dependency chain: ReplicationDb (labels) → PgAdmin (scans labels)
+        let mut pgadmin = pgadmin;
+        pgadmin.start(&this.proxy).await?;
+        this.pgadmin = pgadmin;
+
         Ok(this)
     }
 
@@ -239,8 +246,10 @@ impl ServiceManager {
         // Update Prometheus scrape targets with the new node
         self.prometheus.update_targets(&self.nodes)?;
 
-        // Update PgAdmin servers.json with the new node's replication DB
-        self.pgadmin.update_servers(&self.nodes)?;
+        // Rescan Docker labels to pick up the new node's ReplicationDb.
+        // PgAdmin discovers databases via xnet.pgadmin=true container labels,
+        // so it doesn't need to know about Xmtpd directly.
+        self.pgadmin.discover_databases().await?;
 
         Ok(())
     }

--- a/apps/xnet/lib/src/app/service_manager.rs
+++ b/apps/xnet/lib/src/app/service_manager.rs
@@ -172,9 +172,7 @@ impl ServiceManager {
         // Start PgAdmin AFTER xmtpd nodes so it can discover their
         // ReplicationDb containers via Docker labels (xnet.pgadmin=true).
         // Dependency chain: ReplicationDb (labels) → PgAdmin (scans labels)
-        let mut pgadmin = pgadmin;
-        pgadmin.start(&this.proxy).await?;
-        this.pgadmin = pgadmin;
+        this.pgadmin.start(&this.proxy).await?;
 
         Ok(this)
     }

--- a/apps/xnet/lib/src/services.rs
+++ b/apps/xnet/lib/src/services.rs
@@ -29,7 +29,6 @@ pub use coredns::CoreDns;
 pub use gateway::Gateway;
 pub use grafana::Grafana;
 pub use history::HistoryServer;
-use map_macro::hash_map;
 pub use mlsdb::MlsDb;
 pub use node_go::NodeGo;
 pub use otterscan::Otterscan;
@@ -250,9 +249,9 @@ pub async fn create_and_start_container(
         .and_then(|h| h.port_bindings.clone())
         .map(|p| p.keys().cloned().collect());
     config.exposed_ports = exposed;
-    config.labels = Some(hash_map! {
-        "com.xmtp.network".to_string() => "xnet".to_string()
-    });
+    let mut labels = config.labels.take().unwrap_or_default();
+    labels.insert("com.xmtp.network".to_string(), "xnet".to_string());
+    config.labels = Some(labels);
     let response = docker
         .create_container(Some(options.build()), config)
         .await?;

--- a/apps/xnet/lib/src/services/pgadmin.rs
+++ b/apps/xnet/lib/src/services/pgadmin.rs
@@ -1,31 +1,48 @@
 //! PgAdmin 4 web UI for browsing PostgreSQL databases.
 //!
 //! Runs the `dpage/pgadmin4` Docker container with a pre-configured `servers.json`
-//! that lists all known databases on the xnet network. Uses direct port binding
-//! (no ToxiProxy).
+//! that lists all known databases on the xnet network.
+//!
+//! ## Database Discovery
+//!
+//! PgAdmin discovers databases in two ways:
+//! - **Static databases**: `xnet-db` (V3) and `xnet-mlsdb` (MLS) are always included.
+//! - **Dynamic databases**: Any Docker container with the label `xnet.pgadmin=true`
+//!   is automatically added. The container must also have labels:
+//!   - `xnet.pgadmin.name` — display name in PgAdmin UI
+//!   - `xnet.pgadmin.host` — Docker network hostname
+//!   - `xnet.pgadmin.port` — database port
+//!
+//! ## Dependency Chain
+//!
+//! PgAdmin must start AFTER any services whose databases should appear at startup.
+//! Currently this means xmtpd nodes (which create labeled ReplicationDb containers).
+//! See `ServiceManager::start()` for the ordering.
+//! For databases added at runtime, call `discover_databases()` to rescan.
 
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 
 use async_trait::async_trait;
+use bollard::Docker;
 use bollard::models::{ContainerCreateBody, HostConfig, PortBinding};
-use bollard::query_parameters::CreateContainerOptionsBuilder;
+use bollard::query_parameters::{CreateContainerOptionsBuilder, ListContainersOptionsBuilder};
 use bon::Builder;
 use color_eyre::eyre::Result;
 use url::Url;
 
 use crate::{
-    constants::{
-        MlsDb as MlsDbConst, PgAdmin as PgAdminConst, ReplicationDb as ReplicationDbConst,
-        V3Db as V3DbConst,
-    },
+    constants::{MlsDb as MlsDbConst, PgAdmin as PgAdminConst, V3Db as V3DbConst},
     network::XNET_NETWORK_NAME,
-    services::{ManagedContainer, Service, ToxiProxy, Xmtpd},
+    services::{ManagedContainer, Service, ToxiProxy},
 };
 
 /// Host directory for PgAdmin configuration files.
 const PGADMIN_DIR: &str = "/tmp/xnet/pgadmin";
+
+/// Docker label that marks a container as a PgAdmin-discoverable database.
+const PGADMIN_LABEL: &str = "xnet.pgadmin";
 
 /// Manages a PgAdmin 4 Docker container.
 #[derive(Builder)]
@@ -47,13 +64,16 @@ pub struct PgAdmin {
 impl PgAdmin {
     /// Start the PgAdmin container.
     ///
-    /// Writes a `servers.json` with the static databases, then starts
-    /// PgAdmin with direct port binding (5600:80).
+    /// Scans Docker for labeled database containers and writes `servers.json`,
+    /// then starts PgAdmin with direct port binding (5600:80).
+    ///
+    /// **Dependency:** Must be called AFTER xmtpd nodes have started, so their
+    /// ReplicationDb containers (with `xnet.pgadmin=true` labels) exist to scan.
     pub async fn start(&mut self, _toxiproxy: &ToxiProxy) -> Result<()> {
         fs::create_dir_all(PGADMIN_DIR)?;
 
-        // Write initial servers.json with static databases
-        self.write_servers(&[])?;
+        // Discover labeled database containers and write servers.json
+        self.discover_databases().await?;
 
         let options = CreateContainerOptionsBuilder::default().name(PgAdminConst::CONTAINER_NAME);
 
@@ -103,22 +123,59 @@ impl PgAdmin {
             .await
     }
 
-    /// Regenerate `servers.json` with static DBs plus any xmtpd replication DBs.
+    /// Discover databases by scanning Docker for containers with `xnet.pgadmin=true`.
     ///
-    /// PgAdmin reads this file at startup. If the container is already running,
-    /// changes take effect on the next restart.
-    pub fn update_servers(&self, nodes: &[Xmtpd]) -> Result<()> {
-        self.write_servers(nodes)
+    /// Regenerates `servers.json` with static databases plus any discovered containers.
+    /// Call this after adding new xmtpd nodes at runtime.
+    pub async fn discover_databases(&self) -> Result<()> {
+        let docker = Docker::connect_with_socket_defaults()?;
+
+        // Query Docker for containers on the xnet network with the pgadmin label
+        let mut filters = HashMap::new();
+        filters.insert("label".to_string(), vec![format!("{}=true", PGADMIN_LABEL)]);
+        filters.insert("network".to_string(), vec![XNET_NETWORK_NAME.to_string()]);
+
+        let options = ListContainersOptionsBuilder::default()
+            .filters(&filters)
+            .build();
+        let containers = docker.list_containers(Some(options)).await?;
+
+        // Extract database entries from container labels
+        let mut discovered = Vec::new();
+        for container in &containers {
+            let labels = match &container.labels {
+                Some(l) => l,
+                None => continue,
+            };
+
+            let name = match labels.get("xnet.pgadmin.name") {
+                Some(n) => n.clone(),
+                None => continue,
+            };
+            let host = match labels.get("xnet.pgadmin.host") {
+                Some(h) => h.clone(),
+                None => continue,
+            };
+            let port: u16 = match labels.get("xnet.pgadmin.port") {
+                Some(p) => p.parse().unwrap_or(5432),
+                None => 5432,
+            };
+
+            discovered.push(DiscoveredDb { name, host, port });
+        }
+
+        self.write_servers(&discovered)?;
+        Ok(())
     }
 
-    /// Write the servers.json file.
-    fn write_servers(&self, nodes: &[Xmtpd]) -> Result<()> {
+    /// Write the servers.json file with static databases and discovered databases.
+    fn write_servers(&self, discovered: &[DiscoveredDb]) -> Result<()> {
         let servers_path = Path::new(PGADMIN_DIR).join("servers.json");
 
         let mut server_id = 0u32;
         let mut entries = Vec::new();
 
-        // Static databases
+        // Static databases (always present)
         server_id += 1;
         entries.push(format!(
             r#"    "{}": {{
@@ -151,16 +208,12 @@ impl PgAdmin {
             5432
         ));
 
-        // Dynamic replication databases (one per xmtpd node)
-        for node in nodes {
+        // Discovered databases (from Docker labels)
+        for db in discovered {
             server_id += 1;
-            let db_name = format!(
-                "xmtpd-db-{}",
-                node.container_name().trim_start_matches("xnet-")
-            );
             entries.push(format!(
                 r#"    "{}": {{
-      "Name": "{} (Replication)",
+      "Name": "{}",
       "Group": "XNET",
       "Host": "{}",
       "Port": {},
@@ -168,7 +221,7 @@ impl PgAdmin {
       "Username": "postgres",
       "SSLMode": "disable"
     }}"#,
-                server_id, db_name, db_name, 5432
+                server_id, db.name, db.host, db.port
             ));
         }
 
@@ -197,6 +250,16 @@ impl PgAdmin {
     pub fn is_running(&self) -> bool {
         self.container.is_running()
     }
+}
+
+/// A database discovered from Docker container labels.
+struct DiscoveredDb {
+    /// Display name for PgAdmin UI (from `xnet.pgadmin.name` label)
+    name: String,
+    /// Docker network hostname (from `xnet.pgadmin.host` label)
+    host: String,
+    /// Database port (from `xnet.pgadmin.port` label)
+    port: u16,
 }
 
 #[async_trait]

--- a/apps/xnet/lib/src/services/pgadmin.rs
+++ b/apps/xnet/lib/src/services/pgadmin.rs
@@ -30,6 +30,7 @@ use bollard::models::{ContainerCreateBody, HostConfig, PortBinding};
 use bollard::query_parameters::{CreateContainerOptionsBuilder, ListContainersOptionsBuilder};
 use bon::Builder;
 use color_eyre::eyre::Result;
+use serde::Serialize;
 use url::Url;
 
 use crate::{
@@ -173,59 +174,56 @@ impl PgAdmin {
         let servers_path = Path::new(PGADMIN_DIR).join("servers.json");
 
         let mut server_id = 0u32;
-        let mut entries = Vec::new();
+        let mut servers = HashMap::new();
 
         // Static databases (always present)
         server_id += 1;
-        entries.push(format!(
-            r#"    "{}": {{
-      "Name": "xnet-db (V3)",
-      "Group": "XNET",
-      "Host": "{}",
-      "Port": {},
-      "MaintenanceDB": "postgres",
-      "Username": "postgres",
-      "SSLMode": "prefer"
-    }}"#,
-            server_id,
-            V3DbConst::CONTAINER_NAME,
-            5432
-        ));
+        servers.insert(
+            server_id.to_string(),
+            PgAdminServer {
+                name: "xnet-db (V3)".to_string(),
+                group: "XNET".to_string(),
+                host: V3DbConst::CONTAINER_NAME.to_string(),
+                port: 5432,
+                maintenance_db: "postgres".to_string(),
+                username: "postgres".to_string(),
+                ssl_mode: "prefer".to_string(),
+            },
+        );
 
         server_id += 1;
-        entries.push(format!(
-            r#"    "{}": {{
-      "Name": "xnet-mlsdb (MLS)",
-      "Group": "XNET",
-      "Host": "{}",
-      "Port": {},
-      "MaintenanceDB": "postgres",
-      "Username": "postgres",
-      "SSLMode": "prefer"
-    }}"#,
-            server_id,
-            MlsDbConst::CONTAINER_NAME,
-            5432
-        ));
+        servers.insert(
+            server_id.to_string(),
+            PgAdminServer {
+                name: "xnet-mlsdb (MLS)".to_string(),
+                group: "XNET".to_string(),
+                host: MlsDbConst::CONTAINER_NAME.to_string(),
+                port: 5432,
+                maintenance_db: "postgres".to_string(),
+                username: "postgres".to_string(),
+                ssl_mode: "disable".to_string(),
+            },
+        );
 
         // Discovered databases (from Docker labels)
         for db in discovered {
             server_id += 1;
-            entries.push(format!(
-                r#"    "{}": {{
-      "Name": "{}",
-      "Group": "XNET",
-      "Host": "{}",
-      "Port": {},
-      "MaintenanceDB": "postgres",
-      "Username": "postgres",
-      "SSLMode": "disable"
-    }}"#,
-                server_id, db.name, db.host, db.port
-            ));
+            servers.insert(
+                server_id.to_string(),
+                PgAdminServer {
+                    name: db.name.clone(),
+                    group: "XNET".to_string(),
+                    host: db.host.clone(),
+                    port: db.port,
+                    maintenance_db: "postgres".to_string(),
+                    username: "postgres".to_string(),
+                    ssl_mode: "disable".to_string(),
+                },
+            );
         }
 
-        let json = format!("{{\n  \"Servers\": {{\n{}\n  }}\n}}", entries.join(",\n"));
+        let wrapper = PgAdminServersFile { servers };
+        let json = serde_json::to_string_pretty(&wrapper)?;
         fs::write(&servers_path, json)?;
 
         Ok(())
@@ -260,6 +258,32 @@ struct DiscoveredDb {
     host: String,
     /// Database port (from `xnet.pgadmin.port` label)
     port: u16,
+}
+
+/// Top-level structure for PgAdmin's `servers.json` file.
+#[derive(Serialize)]
+struct PgAdminServersFile {
+    #[serde(rename = "Servers")]
+    servers: HashMap<String, PgAdminServer>,
+}
+
+/// A single server entry in PgAdmin's `servers.json`.
+#[derive(Serialize)]
+struct PgAdminServer {
+    #[serde(rename = "Name")]
+    name: String,
+    #[serde(rename = "Group")]
+    group: String,
+    #[serde(rename = "Host")]
+    host: String,
+    #[serde(rename = "Port")]
+    port: u16,
+    #[serde(rename = "MaintenanceDB")]
+    maintenance_db: String,
+    #[serde(rename = "Username")]
+    username: String,
+    #[serde(rename = "SSLMode")]
+    ssl_mode: String,
 }
 
 #[async_trait]

--- a/apps/xnet/lib/src/services/replication_db.rs
+++ b/apps/xnet/lib/src/services/replication_db.rs
@@ -1,5 +1,7 @@
 //! PostgreSQL (ReplicationDb) container management for D14n.
 
+use std::collections::HashMap;
+
 use crate::types::XmtpdNode;
 use async_trait::async_trait;
 use bollard::{
@@ -42,8 +44,21 @@ impl ReplicationDb {
         let name = self.name();
         let options = CreateContainerOptionsBuilder::default().name(&name);
 
+        let mut labels = HashMap::new();
+        labels.insert("xnet.pgadmin".to_string(), "true".to_string());
+        labels.insert(
+            "xnet.pgadmin.name".to_string(),
+            format!("{} (Replication)", name),
+        );
+        labels.insert("xnet.pgadmin.host".to_string(), name.clone());
+        labels.insert(
+            "xnet.pgadmin.port".to_string(),
+            ReplicationDbConst::PORT.to_string(),
+        );
+
         let config = ContainerCreateBody {
             image: Some(self.image.clone()),
+            labels: Some(labels),
             env: Some(vec![
                 format!("POSTGRES_PASSWORD={}", ReplicationDbConst::PASSWORD),
                 format!("PGPORT={}", ReplicationDbConst::PORT),


### PR DESCRIPTION

  ## Summary

  - **Fix label merging**: `create_and_start_container` now merges Docker labels instead of overwriting, so individual services can set their own labels
  - **Self-describing ReplicationDb containers**: Each ReplicationDb sets `xnet.pgadmin.*` labels (name, host, port) on its Docker container
  - **PgAdmin label scanning**: Rewrites PgAdmin to discover databases by scanning Docker for containers with `xnet.pgadmin=true` instead of deriving names from `&[Xmtpd]` refs (which had a hostname mismatch bug)
  - **Startup reorder**: PgAdmin now starts after xmtpd nodes so labels exist at scan time. Dynamic adds trigger a rescan via `discover_databases()`

  ## Motivation

  xmtpd changed their postgres database naming (no longer appending a hash). The old approach derived container names from `Xmtpd::container_name()` which didn't match the actual `ReplicationDb` container names, causing PgAdmin entries to point at wrong hosts. The new label-based approach is correct by construction — PgAdmin reads metadata
  directly from the containers it discovers.

  ## Dependency chain

  ReplicationDb (sets labels) → PgAdmin (scans labels at startup)

  Documented in code comments in both `pgadmin.rs` and `service_manager.rs`.

  ## Test plan

  - [ ] `just lint` passes
  - [ ] `just check crate xnet-lib` compiles
  - [ ] Start xnet with xmtpd nodes in TOML config, verify PgAdmin at localhost:5600 shows replication DBs
  - [ ] Add a node at runtime via CLI, verify PgAdmin picks it up after rescan

  🤖 Generated with [Claude Code](https://claude.com/claude-code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Auto-discover xmtpd ReplicationDb containers in PgAdmin via Docker labels
> - `ReplicationDb` containers now set Docker labels (`xnet.pgadmin=true`, `xnet.pgadmin.name/host/port`) so PgAdmin can discover them automatically.
> - `PgAdmin.discover_databases()` scans Docker at startup and on `add_xmtpd` calls, filtering by label and network, then writes a structured `servers.json` via serde serialization instead of manual string formatting.
> - `PgAdmin` now starts after xmtpd nodes are created (rather than in parallel with Prometheus/Grafana) so labels are present when the initial scan runs.
> - Container creation in `create_and_start_container` now merges the `com.xmtp.network=xnet` label into existing labels instead of overwriting them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized db0fca8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->