### PR TITLE
fix(xnet): use remote_ip for otterscan's ERIGON_URL and GUI service URLs

### DIFF
--- a/apps/xnet/gui/src/actions.rs
+++ b/apps/xnet/gui/src/actions.rs
@@ -43,6 +43,10 @@ pub async fn start_service_poller() -> Result<(mpsc::Receiver<Vec<ServiceInfo>>,
     let (tx, rx) = mpsc::channel(4);
     let client = make_toxi_client()?;
 
+    let host = match xnet::Config::load_unchecked().address_mode {
+        xnet::config::AddressMode::Remote(ip) => ip.to_string(),
+        _ => "localhost".to_string(),
+    };
     let handle = tokio::spawn(async move {
         loop {
             tokio::time::sleep(std::time::Duration::from_secs(1)).await;
@@ -59,7 +63,7 @@ pub async fn start_service_poller() -> Result<(mpsc::Receiver<Vec<ServiceInfo>>,
                             .rsplit(':')
                             .next()
                             .and_then(|p| p.parse::<u16>().ok());
-                        let url = port.map(|p| format!("http://localhost:{}", p));
+                        let url = port.map(|p| format!("http://{}:{}", host, p));
                         let status = if proxy.proxy_pack.enabled {
                             "running"
                         } else {
@@ -77,22 +81,22 @@ pub async fn start_service_poller() -> Result<(mpsc::Receiver<Vec<ServiceInfo>>,
                 services.push(ServiceInfo {
                     name: "grafana".into(),
                     status: "running",
-                    external_url: Some("http://localhost:3000".into()),
+                    external_url: Some(format!("http://{}:3000", host)),
                 });
                 services.push(ServiceInfo {
                     name: "otterscan".into(),
                     status: "running",
-                    external_url: Some("http://localhost:5100".into()),
+                    external_url: Some(format!("http://{}:5100", host)),
                 });
                 services.push(ServiceInfo {
                     name: "prometheus".into(),
                     status: "running",
-                    external_url: Some("http://localhost:9090".into()),
+                    external_url: Some(format!("http://{}:9090", host)),
                 });
                 services.push(ServiceInfo {
                     name: "traefik".into(),
                     status: "running",
-                    external_url: Some("http://localhost:8080".into()),
+                    external_url: Some(format!("http://{}:8080", host)),
                 });
                 if tx.send(services).await.is_err() {
                     break;

--- a/apps/xnet/lib/src/app/service_manager.rs
+++ b/apps/xnet/lib/src/app/service_manager.rs
@@ -94,8 +94,14 @@ impl ServiceManager {
         let (gateway, anvil_external_rpc, svcs) = start_d14n(&proxy, dns_ip).await?;
         services.extend(svcs);
 
+        let anvil_host_for_browser = match &config.address_mode {
+            crate::config::AddressMode::Remote(ip) => anvil_external_rpc
+                .to_string()
+                .replace("localhost", &ip.to_string()),
+            _ => anvil_external_rpc.to_string(),
+        };
         let mut otterscan = Otterscan::builder()
-            .anvil_host(anvil_external_rpc.to_string())
+            .anvil_host(anvil_host_for_browser)
             .build();
         otterscan.start(&proxy).await?;
 

--- a/apps/xnet/lib/src/services/otterscan.rs
+++ b/apps/xnet/lib/src/services/otterscan.rs
@@ -16,6 +16,8 @@ use color_eyre::eyre::Result;
 use url::Url;
 
 use crate::{
+    Config,
+    config::AddressMode,
     constants::{Anvil as AnvilConst, Otterscan as OtterscanConst},
     network::XNET_NETWORK_NAME,
     services::{ManagedContainer, Service, ToxiProxy},
@@ -103,9 +105,15 @@ impl Otterscan {
     }
 
     /// URL for external access (direct port binding).
+    /// Uses the remote IP when address_mode is Remote, otherwise localhost.
     pub fn external_url(&self) -> Url {
+        let host = match Config::load_unchecked().address_mode {
+            AddressMode::Remote(ip) => ip.to_string(),
+            _ => "localhost".to_string(),
+        };
         Url::parse(&format!(
-            "http://localhost:{}",
+            "http://{}:{}",
+            host,
             OtterscanConst::EXTERNAL_PORT
         ))
         .expect("valid URL")


### PR DESCRIPTION
  When remote_ip is set, otterscan's browser-side JS was trying to reach
  Anvil at localhost, which fails because the browser runs on a different
  machine. Substitute the remote IP for localhost in the ERIGON_URL passed
  to the otterscan container, and update the GUI service poller to display
  correct URLs for all services in remote mode.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix xnet service URLs and Otterscan's `ERIGON_URL` to use remote IP when in remote address mode
> - Service URLs in [`actions.rs`](https://github.com/xmtp/libxmtp/pull/3456/files#diff-05f1d404d25561fe4e13d28ef53673c38debcd11264fbf3ae23a3e3dbcd20fe7) now use the configured remote IP instead of hardcoded `localhost` when `AddressMode::Remote` is set, affecting all ToxiProxy-derived and fixed services (grafana, otterscan, prometheus, traefik).
> - [`ServiceManager.start`](https://github.com/xmtp/libxmtp/pull/3456/files#diff-94cdc0e922a829f2b19f5d8f94aee1b22e2fd693ba226810ed0be1b6fdeba45c) computes an `anvil_host_for_browser` that substitutes the remote IP for `localhost` and passes it to `Otterscan::builder().anvil_host`, fixing the `ERIGON_URL` environment variable.
> - [`Otterscan.external_url`](https://github.com/xmtp/libxmtp/pull/3456/files#diff-4b273e7124e9c9333a4441894f95a910cb46bb36bb0ee7d7a5590b3ad7a0786d) also applies the same remote IP substitution so the returned URL is reachable from outside the host.
> - Behavioral Change: all emitted `ServiceInfo.external_url` values and Otterscan's `ERIGON_URL` will now reference the remote IP rather than `localhost` when `AddressMode::Remote` is configured.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e9aec33.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->