### PR TITLE
refactor(xnet): add TOML flags to disable V3, D14n, and monitoring services

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -42,6 +42,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_bots: |
             dependabot[bot]
+            macroscopeapp[bot]
           model: "claude-sonnet-4-5-20250929"
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18012,6 +18012,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "tempfile",
  "tokio",
  "toml 0.9.12+spec-1.1.0",
  "toxiproxy_rust",

--- a/apps/xmtp_debug/src/args.rs
+++ b/apps/xmtp_debug/src/args.rs
@@ -320,6 +320,11 @@ pub struct BackendOpts {
     /// Enable the decentralization backend
     #[arg(short, long)]
     pub d14n: bool,
+    /// Connect reads directly to a single xmtpd node for D14n, bypassing MultiNodeClient
+    /// gateway discovery. Writes still route through --xmtpd-gateway-url.
+    /// Requires --d14n.
+    #[arg(long, requires = "d14n")]
+    pub d14n_host: Option<url::Url>,
     /// Use the perf gateway (closest-node selection) instead of the default gateway.
     /// Requires --d14n.
     #[arg(short, long, requires = "d14n")]
@@ -378,24 +383,9 @@ impl BackendOpts {
     }
 
     pub fn connect(&self) -> eyre::Result<crate::DbgClientApi> {
-        let network = self.network_url();
         let mut builder = MessageBackendBuilder::default();
-        builder.v3_host(network.as_str());
-        if self.enable_migration {
-            let xmtpd_gateway_host = self.xmtpd_gateway_url()?;
-            trace!(url = %network, xmtpd_gateway = %xmtpd_gateway_host,  "create grpc");
-            return Ok(builder.gateway_host(xmtpd_gateway_host.as_str()).build()?);
-        }
-        if self.d14n {
-            let xmtpd_gateway_host = self.xmtpd_gateway_url()?;
-            trace!(url = %network, xmtpd_gateway = %xmtpd_gateway_host,  "create grpc");
-            Ok(builder
-                .gateway_host(xmtpd_gateway_host.as_str())
-                .build_d14n()?)
-        } else {
-            trace!(url = %network,  "create grpc");
-            Ok(builder.build_v3()?)
-        }
+        let bundle = self.client_bundle()?;
+        Ok(builder.from_bundle(bundle)?)
     }
 
     pub fn client_bundle(&self) -> eyre::Result<xmtp_mls::XmtpClientBundle> {
@@ -409,8 +399,8 @@ impl BackendOpts {
         }
         if self.d14n {
             let xmtpd_gateway_host = self.xmtpd_gateway_url()?;
-            trace!(url = %network, xmtpd_gateway = %xmtpd_gateway_host, "create grpc");
             Ok(builder
+                .maybe_xmtpd_host(self.d14n_host.clone())
                 .gateway_host(xmtpd_gateway_host.as_str())
                 .build_d14n()?)
         } else {

--- a/apps/xmtp_debug/src/args.rs
+++ b/apps/xmtp_debug/src/args.rs
@@ -320,6 +320,11 @@ pub struct BackendOpts {
     /// Enable the decentralization backend
     #[arg(short, long)]
     pub d14n: bool,
+    /// Connect reads directly to a single xmtpd node for D14n, bypassing MultiNodeClient
+    /// gateway discovery. Writes still route through --xmtpd-gateway-url.
+    /// Requires --d14n.
+    #[arg(long, requires = "d14n")]
+    pub d14n_host: Option<url::Url>,
     /// Use the perf gateway (closest-node selection) instead of the default gateway.
     /// Requires --d14n.
     #[arg(short, long, requires = "d14n")]
@@ -388,12 +393,20 @@ impl BackendOpts {
         }
         if self.d14n {
             let xmtpd_gateway_host = self.xmtpd_gateway_url()?;
-            trace!(url = %network, xmtpd_gateway = %xmtpd_gateway_host,  "create grpc");
-            Ok(builder
-                .gateway_host(xmtpd_gateway_host.as_str())
-                .build_d14n()?)
+            if let Some(ref d14n_host) = self.d14n_host {
+                trace!(d14n_host = %d14n_host, xmtpd_gateway = %xmtpd_gateway_host, "create single-node d14n grpc");
+                Ok(builder
+                    .v3_host(d14n_host.as_str())
+                    .gateway_host(xmtpd_gateway_host.as_str())
+                    .build_d14n_single()?)
+            } else {
+                trace!(url = %network, xmtpd_gateway = %xmtpd_gateway_host, "create grpc");
+                Ok(builder
+                    .gateway_host(xmtpd_gateway_host.as_str())
+                    .build_d14n()?)
+            }
         } else {
-            trace!(url = %network,  "create grpc");
+            trace!(url = %network, "create grpc");
             Ok(builder.build_v3()?)
         }
     }
@@ -409,10 +422,18 @@ impl BackendOpts {
         }
         if self.d14n {
             let xmtpd_gateway_host = self.xmtpd_gateway_url()?;
-            trace!(url = %network, xmtpd_gateway = %xmtpd_gateway_host, "create grpc");
-            Ok(builder
-                .gateway_host(xmtpd_gateway_host.as_str())
-                .build_d14n()?)
+            if let Some(ref d14n_host) = self.d14n_host {
+                trace!(d14n_host = %d14n_host, xmtpd_gateway = %xmtpd_gateway_host, "create single-node d14n grpc");
+                Ok(builder
+                    .v3_host(d14n_host.as_str())
+                    .gateway_host(xmtpd_gateway_host.as_str())
+                    .build_d14n_single()?)
+            } else {
+                trace!(url = %network, xmtpd_gateway = %xmtpd_gateway_host, "create grpc");
+                Ok(builder
+                    .gateway_host(xmtpd_gateway_host.as_str())
+                    .build_d14n()?)
+            }
         } else {
             trace!(url = %network, "create grpc");
             Ok(builder.build_v3()?)

--- a/apps/xnet/README.md
+++ b/apps/xnet/README.md
@@ -150,8 +150,21 @@ XNet can be configured via a `xnet.toml` file. Below are the default values:
 ```toml
 [xnet]
 use_standard_ports = true
-toxiproxy_port = 8474
 paused = false
+enable_v3 = true
+enable_d14n = true
+enable_monitoring = true
+
+[traefik]
+image = "traefik"
+version = "v3.2"
+port = 80
+https_port = 443
+
+[toxiproxy]
+image = "ghcr.io/shopify/toxiproxy"
+version = "2.12.0"
+port = 8474
 
 [migration]
 enable = false
@@ -159,7 +172,7 @@ migration_timestamp = 2_147_483_647
 
 [xmtpd]
 image = "ghcr.io/xmtp/xmtpd"
-version = "sha-695b07e"
+version = "sha-f72e436"
 
 [v3]
 image = "ghcr.io/xmtp/node-go"
@@ -168,7 +181,7 @@ port = 5556
 
 [gateway]
 image = "ghcr.io/xmtp/xmtpd-gateway"
-version = "sha-695b07e"
+version = "sha-f72e436"
 
 [validation]
 image = "ghcr.io/xmtp/mls-validation-service"
@@ -182,9 +195,13 @@ version = "main"
 image = "ghcr.io/xmtp/message-history-server"
 version = "main"
 
-[toxiproxy]
-image = "ghcr.io/shopify/toxiproxy"
-version = "2.12.0"
+[prometheus]
+image = "prom/prometheus"
+version = "latest"
+
+[grafana]
+image = "ghcr.io/xmtp/grafana-xmtpd"
+version = "latest"
 
 ## No XMTPD nodes are included by default, but can be added like this:
 # [[xmtpd.nodes]]
@@ -198,3 +215,16 @@ version = "2.12.0"
 ```
 
 </details>
+
+### Disabling Services
+
+For CI or lightweight testing, you can disable service groups:
+
+```toml
+[xnet]
+enable_v3 = false         # Disable V3 stack (V3Db, MlsDb, NodeGo)
+enable_d14n = false       # Disable D14n stack (Redis, Gateway, XMTPD nodes)
+enable_monitoring = false # Disable Prometheus, Grafana, PgAdmin, Otterscan
+```
+
+Anvil, Validation, and History are shared dependencies that start whenever either V3 or D14n is enabled.

--- a/apps/xnet/gui/src/actions.rs
+++ b/apps/xnet/gui/src/actions.rs
@@ -43,10 +43,13 @@ pub async fn start_service_poller() -> Result<(mpsc::Receiver<Vec<ServiceInfo>>,
     let (tx, rx) = mpsc::channel(4);
     let client = make_toxi_client()?;
 
-    let host = match xnet::Config::load_unchecked().address_mode {
-        xnet::config::AddressMode::Remote(ip) => ip.to_string(),
-        _ => "localhost".to_string(),
+    let config = xnet::Config::load_unchecked();
+    let host = match &config.address_mode {
+        xnet::config::AddressMode::RemoteDomain(domain) => domain.clone(),
+        xnet::config::AddressMode::Local => "localhost".to_string(),
     };
+    let enable_monitoring = config.enable_monitoring;
+    let need_shared = config.enable_v3 || config.enable_d14n;
     let handle = tokio::spawn(async move {
         loop {
             tokio::time::sleep(std::time::Duration::from_secs(1)).await;
@@ -78,21 +81,26 @@ pub async fn start_service_poller() -> Result<(mpsc::Receiver<Vec<ServiceInfo>>,
                     .collect();
                 services.sort_by(|a, b| a.name.cmp(&b.name));
                 // Add non-ToxiProxy services with fixed localhost ports
-                services.push(ServiceInfo {
-                    name: "grafana".into(),
-                    status: "running",
-                    external_url: Some(format!("http://{}:3000", host)),
-                });
-                services.push(ServiceInfo {
-                    name: "otterscan".into(),
-                    status: "running",
-                    external_url: Some(format!("http://{}:5100", host)),
-                });
-                services.push(ServiceInfo {
-                    name: "prometheus".into(),
-                    status: "running",
-                    external_url: Some(format!("http://{}:9090", host)),
-                });
+                // Only show monitoring services if monitoring is enabled
+                if enable_monitoring {
+                    services.push(ServiceInfo {
+                        name: "grafana".into(),
+                        status: "running",
+                        external_url: Some(format!("http://{}:3000", host)),
+                    });
+                    if need_shared {
+                        services.push(ServiceInfo {
+                            name: "otterscan".into(),
+                            status: "running",
+                            external_url: Some(format!("http://{}:5100", host)),
+                        });
+                    }
+                    services.push(ServiceInfo {
+                        name: "prometheus".into(),
+                        status: "running",
+                        external_url: Some(format!("http://{}:9090", host)),
+                    });
+                }
                 services.push(ServiceInfo {
                     name: "traefik".into(),
                     status: "running",
@@ -108,10 +116,10 @@ pub async fn start_service_poller() -> Result<(mpsc::Receiver<Vec<ServiceInfo>>,
     Ok((rx, handle.abort_handle()))
 }
 
-pub async fn execute_up(paused: bool) -> Result<()> {
+pub async fn execute_up() -> Result<()> {
     let _ = xnet::Config::load()?;
     tracing::info!("up");
-    App::parse()?.up(paused).await?;
+    App::parse()?.up(false).await?;
     Ok(())
 }
 
@@ -145,6 +153,15 @@ pub async fn execute_add_node() -> Result<NodeInfo> {
 }
 
 pub async fn execute_add_migrator() -> Result<NodeInfo> {
+    // Pause broadcaster contracts before adding a migrator node
+    let mgr = ServiceManager::start().await?;
+    let rpc = mgr
+        .anvil_rpc_url()
+        .ok_or_else(|| color_eyre::eyre::eyre!("Anvil not running"))?;
+    xnet::contracts::set_broadcasters_paused(rpc.as_str(), xnet::constants::Anvil::ADMIN_KEY, true)
+        .await?;
+    tracing::info!("broadcaster contracts paused for migrator node");
+
     let node = App::parse()?
         .add_node(&AddNode {
             migrator: true,
@@ -165,8 +182,11 @@ pub async fn execute_add_migrator() -> Result<NodeInfo> {
 
 pub async fn execute_activate_d14n() -> Result<()> {
     let mut mgr = ServiceManager::start().await?;
+    let rpc = mgr
+        .anvil_rpc_url()
+        .ok_or_else(|| color_eyre::eyre::eyre!("Anvil not running"))?;
     xnet::contracts::set_broadcasters_paused(
-        mgr.anvil_rpc_url().as_str(),
+        rpc.as_str(),
         xnet::constants::Anvil::ADMIN_KEY,
         false,
     )
@@ -303,6 +323,8 @@ pub async fn start_cutover_poller() -> Result<(mpsc::Receiver<u64>, AbortHandle)
     let mgr = ServiceManager::start().await?;
     let url = mgr
         .node_go
+        .as_ref()
+        .ok_or_else(|| color_eyre::eyre::eyre!("node-go not available (V3 disabled)"))?
         .external_grpc_url()
         .ok_or_else(|| color_eyre::eyre::eyre!("node-go gRPC URL not available"))?;
     let grpc = GrpcClient::create(url).map_err(|e| color_eyre::eyre::eyre!("{}", e))?;

--- a/apps/xnet/gui/src/actions.rs
+++ b/apps/xnet/gui/src/actions.rs
@@ -45,7 +45,7 @@ pub async fn start_service_poller() -> Result<(mpsc::Receiver<Vec<ServiceInfo>>,
 
     let config = xnet::Config::load_unchecked();
     let host = match &config.address_mode {
-        xnet::config::AddressMode::Remote(ip) => ip.to_string(),
+        xnet::config::AddressMode::RemoteIp(ip) => ip.to_string(),
         _ => "localhost".to_string(),
     };
     let enable_monitoring = config.enable_monitoring;

--- a/apps/xnet/gui/src/actions.rs
+++ b/apps/xnet/gui/src/actions.rs
@@ -46,7 +46,8 @@ pub async fn start_service_poller() -> Result<(mpsc::Receiver<Vec<ServiceInfo>>,
     let config = xnet::Config::load_unchecked();
     let host = match &config.address_mode {
         xnet::config::AddressMode::RemoteIp(ip) => ip.to_string(),
-        _ => "localhost".to_string(),
+        xnet::config::AddressMode::RemoteDomain(domain) => domain.clone(),
+        xnet::config::AddressMode::Local => "localhost".to_string(),
     };
     let enable_monitoring = config.enable_monitoring;
     let need_shared = config.enable_v3 || config.enable_d14n;

--- a/apps/xnet/gui/src/actions.rs
+++ b/apps/xnet/gui/src/actions.rs
@@ -135,7 +135,12 @@ pub async fn execute_delete() -> Result<()> {
 }
 
 pub async fn execute_add_node() -> Result<NodeInfo> {
-    let node = App::parse()?.add_node(&AddNode { migrator: false, use_standard_port: false }).await?;
+    let node = App::parse()?
+        .add_node(&AddNode {
+            migrator: false,
+            use_standard_port: false,
+        })
+        .await?;
     let config = xnet::Config::load()?;
     Ok(NodeInfo {
         id: *node.id(),
@@ -154,15 +159,16 @@ pub async fn execute_add_migrator() -> Result<NodeInfo> {
     let rpc = mgr
         .anvil_rpc_url()
         .ok_or_else(|| color_eyre::eyre::eyre!("Anvil not running"))?;
-    xnet::contracts::set_broadcasters_paused(
-        rpc.as_str(),
-        xnet::constants::Anvil::ADMIN_KEY,
-        true,
-    )
-    .await?;
+    xnet::contracts::set_broadcasters_paused(rpc.as_str(), xnet::constants::Anvil::ADMIN_KEY, true)
+        .await?;
     tracing::info!("broadcaster contracts paused for migrator node");
 
-    let node = App::parse()?.add_node(&AddNode { migrator: true, use_standard_port: false }).await?;
+    let node = App::parse()?
+        .add_node(&AddNode {
+            migrator: true,
+            use_standard_port: false,
+        })
+        .await?;
     let config = xnet::Config::load()?;
     Ok(NodeInfo {
         id: *node.id(),

--- a/apps/xnet/gui/src/actions.rs
+++ b/apps/xnet/gui/src/actions.rs
@@ -43,10 +43,13 @@ pub async fn start_service_poller() -> Result<(mpsc::Receiver<Vec<ServiceInfo>>,
     let (tx, rx) = mpsc::channel(4);
     let client = make_toxi_client()?;
 
-    let host = match xnet::Config::load_unchecked().address_mode {
+    let config = xnet::Config::load_unchecked();
+    let host = match &config.address_mode {
         xnet::config::AddressMode::Remote(ip) => ip.to_string(),
         _ => "localhost".to_string(),
     };
+    let enable_monitoring = config.enable_monitoring;
+    let need_shared = config.enable_v3 || config.enable_d14n;
     let handle = tokio::spawn(async move {
         loop {
             tokio::time::sleep(std::time::Duration::from_secs(1)).await;
@@ -78,21 +81,26 @@ pub async fn start_service_poller() -> Result<(mpsc::Receiver<Vec<ServiceInfo>>,
                     .collect();
                 services.sort_by(|a, b| a.name.cmp(&b.name));
                 // Add non-ToxiProxy services with fixed localhost ports
-                services.push(ServiceInfo {
-                    name: "grafana".into(),
-                    status: "running",
-                    external_url: Some(format!("http://{}:3000", host)),
-                });
-                services.push(ServiceInfo {
-                    name: "otterscan".into(),
-                    status: "running",
-                    external_url: Some(format!("http://{}:5100", host)),
-                });
-                services.push(ServiceInfo {
-                    name: "prometheus".into(),
-                    status: "running",
-                    external_url: Some(format!("http://{}:9090", host)),
-                });
+                // Only show monitoring services if monitoring is enabled
+                if enable_monitoring {
+                    services.push(ServiceInfo {
+                        name: "grafana".into(),
+                        status: "running",
+                        external_url: Some(format!("http://{}:3000", host)),
+                    });
+                    if need_shared {
+                        services.push(ServiceInfo {
+                            name: "otterscan".into(),
+                            status: "running",
+                            external_url: Some(format!("http://{}:5100", host)),
+                        });
+                    }
+                    services.push(ServiceInfo {
+                        name: "prometheus".into(),
+                        status: "running",
+                        external_url: Some(format!("http://{}:9090", host)),
+                    });
+                }
                 services.push(ServiceInfo {
                     name: "traefik".into(),
                     status: "running",
@@ -165,8 +173,11 @@ pub async fn execute_add_migrator() -> Result<NodeInfo> {
 
 pub async fn execute_activate_d14n() -> Result<()> {
     let mut mgr = ServiceManager::start().await?;
+    let rpc = mgr
+        .anvil_rpc_url()
+        .ok_or_else(|| color_eyre::eyre::eyre!("Anvil not running"))?;
     xnet::contracts::set_broadcasters_paused(
-        mgr.anvil_rpc_url().as_str(),
+        rpc.as_str(),
         xnet::constants::Anvil::ADMIN_KEY,
         false,
     )
@@ -303,6 +314,8 @@ pub async fn start_cutover_poller() -> Result<(mpsc::Receiver<u64>, AbortHandle)
     let mgr = ServiceManager::start().await?;
     let url = mgr
         .node_go
+        .as_ref()
+        .ok_or_else(|| color_eyre::eyre::eyre!("node-go not available (V3 disabled)"))?
         .external_grpc_url()
         .ok_or_else(|| color_eyre::eyre::eyre!("node-go gRPC URL not available"))?;
     let grpc = GrpcClient::create(url).map_err(|e| color_eyre::eyre::eyre!("{}", e))?;

--- a/apps/xnet/gui/src/actions.rs
+++ b/apps/xnet/gui/src/actions.rs
@@ -116,10 +116,10 @@ pub async fn start_service_poller() -> Result<(mpsc::Receiver<Vec<ServiceInfo>>,
     Ok((rx, handle.abort_handle()))
 }
 
-pub async fn execute_up(paused: bool) -> Result<()> {
+pub async fn execute_up() -> Result<()> {
     let _ = xnet::Config::load()?;
     tracing::info!("up");
-    App::parse()?.up(paused).await?;
+    App::parse()?.up(false).await?;
     Ok(())
 }
 
@@ -134,12 +134,7 @@ pub async fn execute_delete() -> Result<()> {
 }
 
 pub async fn execute_add_node() -> Result<NodeInfo> {
-    let node = App::parse()?
-        .add_node(&AddNode {
-            migrator: false,
-            use_standard_port: false,
-        })
-        .await?;
+    let node = App::parse()?.add_node(&AddNode { migrator: false, use_standard_port: false }).await?;
     let config = xnet::Config::load()?;
     Ok(NodeInfo {
         id: *node.id(),
@@ -153,12 +148,20 @@ pub async fn execute_add_node() -> Result<NodeInfo> {
 }
 
 pub async fn execute_add_migrator() -> Result<NodeInfo> {
-    let node = App::parse()?
-        .add_node(&AddNode {
-            migrator: true,
-            use_standard_port: false,
-        })
-        .await?;
+    // Pause broadcaster contracts before adding a migrator node
+    let mgr = ServiceManager::start().await?;
+    let rpc = mgr
+        .anvil_rpc_url()
+        .ok_or_else(|| color_eyre::eyre::eyre!("Anvil not running"))?;
+    xnet::contracts::set_broadcasters_paused(
+        rpc.as_str(),
+        xnet::constants::Anvil::ADMIN_KEY,
+        true,
+    )
+    .await?;
+    tracing::info!("broadcaster contracts paused for migrator node");
+
+    let node = App::parse()?.add_node(&AddNode { migrator: true, use_standard_port: false }).await?;
     let config = xnet::Config::load()?;
     Ok(NodeInfo {
         id: *node.id(),

--- a/apps/xnet/gui/src/views/root.rs
+++ b/apps/xnet/gui/src/views/root.rs
@@ -13,7 +13,6 @@ use gpui::{
     deferred, div, hsla, prelude::*, px, rgb,
 };
 use gpui_component::button::{Button, ButtonCustomVariant, ButtonVariant, ButtonVariants};
-use gpui_component::checkbox::Checkbox;
 use gpui_component::input::InputState;
 use gpui_component::{Disableable, Sizable};
 use gpui_tokio_bridge::Tokio;
@@ -37,8 +36,6 @@ pub struct RootView {
     state: AppState,
     /// Whether a background operation is in-flight (disables buttons).
     busy: bool,
-    /// Whether to pause broadcaster contracts on startup (--paused flag).
-    paused_on_up: bool,
     /// Scroll handle for the log panel so we can auto-scroll to bottom.
     log_scroll: ScrollHandle,
     /// Startup dependency check state.
@@ -60,7 +57,6 @@ impl RootView {
         Self {
             state: AppState::new(),
             busy: false,
-            paused_on_up: false,
             log_scroll: ScrollHandle::new(),
             setup: SetupChecks::new(),
             toxics: ToxicsState::new(),
@@ -224,15 +220,10 @@ impl RootView {
         }
         self.busy = true;
         self.state.network_status = NetworkStatus::Starting;
-        let paused = self.paused_on_up;
-        if paused {
-            info!("Starting services with broadcasters paused…");
-        } else {
-            info!("Starting services…");
-        }
+        info!("Starting services…");
         cx.notify();
 
-        let result = Tokio::spawn(cx, actions::execute_up(paused));
+        let result = Tokio::spawn(cx, actions::execute_up());
 
         cx.spawn(async |this: WeakEntity<Self>, cx: &mut AsyncApp| {
             let result = result.await?;
@@ -394,7 +385,7 @@ impl RootView {
             return;
         }
         self.busy = true;
-        info!("Registering new XMTPD migrator…");
+        info!("Pausing broadcasters and registering new XMTPD migrator…");
         cx.notify();
 
         let result = Tokio::spawn(cx, actions::execute_add_migrator());
@@ -644,18 +635,6 @@ impl RootView {
                 .active(rgb(0xBE94F5).into()),
         );
 
-        let entity = cx.entity().downgrade();
-        let paused_checkbox = Checkbox::new("chk-paused")
-            .label("Paused")
-            .small()
-            .checked(self.paused_on_up)
-            .on_click(move |checked, _window, cx| {
-                let _ = entity.update(cx, |view, cx| {
-                    view.paused_on_up = *checked;
-                    cx.notify();
-                });
-            });
-
         div()
             .flex()
             .flex_row()
@@ -671,7 +650,6 @@ impl RootView {
                 cx,
                 |view, _, _, cx| view.action_up(cx),
             ))
-            .child(paused_checkbox)
             .child(self.make_clickable_button(
                 "btn-down",
                 "Down",

--- a/apps/xnet/lib/Cargo.toml
+++ b/apps/xnet/lib/Cargo.toml
@@ -49,6 +49,9 @@ xmtp_api_grpc.workspace = true
 xmtp_common.workspace = true
 xmtp_proto.workspace = true
 
+[dev-dependencies]
+tempfile = "3"
+
 [build-dependencies]
 vergen-gix = { workspace = true, features = ["build"] }
 

--- a/apps/xnet/lib/defaults.toml
+++ b/apps/xnet/lib/defaults.toml
@@ -2,9 +2,21 @@
 # Commented configuration is an example
 [xnet]
 use_standard_ports = true
-toxiproxy_port = 8474
 paused = false
-# traefik_port = 80
+enable_v3 = true
+enable_d14n = true
+enable_monitoring = true
+
+[traefik]
+image = "traefik"
+version = "v3.2"
+port = 80
+https_port = 443
+
+[toxiproxy]
+image = "ghcr.io/shopify/toxiproxy"
+version = "2.12.0"
+port = 8474
 
 [migration]
 enable = false
@@ -35,9 +47,13 @@ version = "main"
 image = "ghcr.io/xmtp/message-history-server"
 version = "main"
 
-[toxiproxy]
-image = "ghcr.io/shopify/toxiproxy"
-version = "2.12.0"
+[prometheus]
+image = "prom/prometheus"
+version = "latest"
+
+[grafana]
+image = "ghcr.io/xmtp/grafana-xmtpd"
+version = "latest"
 
 # [[xmtpd.nodes]]
 # enable = true

--- a/apps/xnet/lib/src/app/run.rs
+++ b/apps/xnet/lib/src/app/run.rs
@@ -4,15 +4,13 @@ use crate::{
     app::service_manager::ServiceManager,
     config::{AddNode, AppArgs, Node},
     network::Network,
-    services::{self, Service, ToxiProxy},
+    node_provisioner::NodeProvisioner,
     types::XmtpdNode,
-    xmtpd_cli::XmtpdCli,
 };
 use chrono::{DateTime, Local, TimeZone};
 use clap::Parser;
 use color_eyre::eyre::{OptionExt, Result, eyre};
-use futures::FutureExt;
-use tokio::{runtime::EnterGuard, sync::Mutex};
+use tokio::sync::Mutex;
 use xmtp_api_d14n::d14n::{FetchD14nCutover, GetNodes};
 use xmtp_proto::{prelude::Query, xmtp::migration::api::v1::FetchD14nCutoverResponse};
 
@@ -49,18 +47,8 @@ impl App {
     }
 
     pub async fn up(&self, cli_paused: bool) -> Result<()> {
-        let network = Network::new().await?;
-        let mgr = ServiceManager::start().await?;
-        let config = Config::load()?;
-        let paused = cli_paused || config.paused;
-        if paused {
-            crate::contracts::set_broadcasters_paused(
-                mgr.anvil_rpc_url().as_str(),
-                crate::constants::Anvil::ADMIN_KEY,
-                true,
-            )
-            .await?;
-        }
+        let _network = Network::new().await?;
+        let _mgr = ServiceManager::start_paused(cli_paused).await?;
         Ok(())
     }
 
@@ -79,85 +67,23 @@ impl App {
     pub async fn add_node(&self, add: &AddNode) -> Result<XmtpdNode> {
         let mut mgr = ServiceManager::start().await?;
 
-        if add.migrator {
-            // Broadcaster contracts must be paused before adding a migrator node.
-            // If they're unpaused, d14n has been activated and migrators can't be added.
-            let statuses =
-                crate::contracts::get_broadcaster_pause_status(mgr.anvil_rpc_url().as_str())
-                    .await?;
-            let all_paused = statuses.iter().all(|(_, paused)| *paused);
-            if !all_paused {
-                return Err(eyre!(
-                    "Cannot add migrator node: broadcaster contracts are unpaused. \
-                     Run `xnet up --paused` first, or d14n has already been activated."
-                ));
-            }
-
-            // Set the new node's migration payer as the payload bootstrapper
-            let gateway_url = mgr
-                .gateway
-                .external_url()
-                .ok_or_eyre("no url for gateway")?;
-            let node_id = crate::types::XmtpdNode::get_next_id(gateway_url.as_str()).await?;
-            let config = Config::load()?;
-            let num_ids = node_id / crate::constants::Xmtpd::NODE_ID_INCREMENT;
-            let base_idx = num_ids as usize * 3 + 1;
-            let migration_payer = &config.signers[base_idx + 2];
-            let bootstrapper_addr = migration_payer.address();
-            crate::contracts::set_payload_bootstrapper(
-                mgr.anvil_rpc_url().as_str(),
-                crate::constants::Anvil::ADMIN_KEY,
-                bootstrapper_addr,
-            )
-            .await?;
-        }
-
-        if add.use_standard_port {
-            // Check all registered ToxiProxy proxies, not just mgr.nodes() which
-            // only contains nodes started in the current session. Nodes whose proxy
-            // already existed at startup are skipped by ServiceManager::start() and
-            // never added to self.nodes, so we must query ToxiProxy directly.
-            let standard_port = crate::constants::Xmtpd::GRPC_PORT;
-            let existing_proxies = mgr.proxy.list_proxies().await?;
-            for proxy in existing_proxies.values() {
-                let listen = &proxy.proxy_pack.listen;
-                let port: u16 = listen
-                    .rsplit(':')
-                    .next()
-                    .and_then(|p| p.parse().ok())
-                    .unwrap_or(0);
-                if port == standard_port {
-                    return Err(eyre!(
-                        "cannot add node with --use-standard-port: port {} is already in use by an existing proxy",
-                        standard_port
-                    ));
-                }
-            }
-        }
-
-        let cli = XmtpdCli::builder().toxiproxy(mgr.proxy.clone());
-        let mut output = self.cli_output.lock().await;
-        let gateway = mgr
-            .gateway
-            .external_url()
-            .ok_or_eyre("no url for gateway")?;
-        let mut xmtpd = XmtpdNode::new(gateway.as_str(), add.use_standard_port).await?;
-        cli.clone()
+        let node = NodeProvisioner::builder()
+            .migrator(add.migrator)
+            .use_standard_port(add.use_standard_port)
             .build()
-            .register(&mgr, &mut *output, &xmtpd)
+            .provision(&mut mgr)
             .await?;
-        cli.build().enable(&mut xmtpd, &mut *output).await?;
-        if add.migrator {
-            mgr.add_xmtpd_with_migrator(xmtpd.clone()).await?;
-        } else {
-            mgr.add_xmtpd(xmtpd.clone()).await?;
-        }
-        Ok(xmtpd)
+
+        Ok(node)
     }
 
     pub async fn gateway_url(&self) -> Result<url::Url> {
         let mgr = ServiceManager::start().await?;
-        mgr.gateway.external_url().ok_or_eyre("no url for gateway")
+        mgr.gateway
+            .as_ref()
+            .ok_or_eyre("Gateway not running (enable_d14n required)")?
+            .external_url()
+            .ok_or_eyre("no url for gateway")
     }
 
     pub async fn addresses(&self) -> Result<()> {
@@ -166,6 +92,8 @@ impl App {
         let mgr = ServiceManager::start().await?;
         let gateway_url = mgr
             .gateway
+            .as_ref()
+            .ok_or_eyre("Gateway not running")?
             .external_url()
             .ok_or_eyre("gateway not running")?;
         let grpc =
@@ -221,12 +149,9 @@ impl App {
     pub async fn activate_d14n(&self) -> Result<()> {
         use crate::constants::Anvil as AnvilConst;
         let mut mgr = ServiceManager::start().await?;
-        crate::contracts::set_broadcasters_paused(
-            mgr.anvil_rpc_url().as_str(),
-            AnvilConst::ADMIN_KEY,
-            false,
-        )
-        .await?;
+        let rpc = mgr.anvil_rpc_url().ok_or_eyre("Anvil not running")?;
+        crate::contracts::set_broadcasters_paused(rpc.as_str(), AnvilConst::ADMIN_KEY, false)
+            .await?;
         mgr.remove_migrators().await?;
         Ok(())
     }
@@ -239,8 +164,8 @@ impl App {
         ServiceManager::print_port_allocations();
 
         let mgr = ServiceManager::start().await?;
-        let statuses =
-            crate::contracts::get_broadcaster_pause_status(mgr.anvil_rpc_url().as_str()).await?;
+        let rpc = mgr.anvil_rpc_url().ok_or_eyre("Anvil not running")?;
+        let statuses = crate::contracts::get_broadcaster_pause_status(rpc.as_str()).await?;
 
         println!();
         let mut table = AsciiTable::default();
@@ -293,9 +218,13 @@ impl App {
                     Some(u) => u.clone(),
                     None => {
                         let mgr = ServiceManager::start().await?;
-                        mgr.node_go.external_grpc_url().ok_or_eyre(
-                            "node-go has no external gRPC URL (ToxiProxy port not configured)",
-                        )?
+                        mgr.node_go
+                            .as_ref()
+                            .ok_or_eyre("node-go not running (enable_v3 required)")?
+                            .external_grpc_url()
+                            .ok_or_eyre(
+                                "node-go has no external gRPC URL (ToxiProxy port not configured)",
+                            )?
                     }
                 };
                 let client = xmtp_api_grpc::GrpcClient::create(url).map_err(|e| eyre!("{}", e))?;

--- a/apps/xnet/lib/src/app/run.rs
+++ b/apps/xnet/lib/src/app/run.rs
@@ -4,15 +4,13 @@ use crate::{
     app::service_manager::ServiceManager,
     config::{AddNode, AppArgs, Node},
     network::Network,
-    services::{self, Service, ToxiProxy},
+    node_provisioner::NodeProvisioner,
     types::XmtpdNode,
-    xmtpd_cli::XmtpdCli,
 };
 use chrono::{DateTime, Local, TimeZone};
 use clap::Parser;
 use color_eyre::eyre::{OptionExt, Result, eyre};
-use futures::FutureExt;
-use tokio::{runtime::EnterGuard, sync::Mutex};
+use tokio::sync::Mutex;
 use xmtp_api_d14n::d14n::{FetchD14nCutover, GetNodes};
 use xmtp_proto::{prelude::Query, xmtp::migration::api::v1::FetchD14nCutoverResponse};
 
@@ -80,85 +78,14 @@ impl App {
     pub async fn add_node(&self, add: &AddNode) -> Result<XmtpdNode> {
         let mut mgr = ServiceManager::start().await?;
 
-        if add.migrator {
-            // Broadcaster contracts must be paused before adding a migrator node.
-            // If they're unpaused, d14n has been activated and migrators can't be added.
-            let rpc = mgr.anvil_rpc_url().ok_or_eyre("Anvil not running")?;
-            let statuses = crate::contracts::get_broadcaster_pause_status(rpc.as_str()).await?;
-            let all_paused = statuses.iter().all(|(_, paused)| *paused);
-            if !all_paused {
-                return Err(eyre!(
-                    "Cannot add migrator node: broadcaster contracts are unpaused. \
-                     Run `xnet up --paused` first, or d14n has already been activated."
-                ));
-            }
-
-            // Set the new node's migration payer as the payload bootstrapper
-            let gateway_url = mgr
-                .gateway
-                .as_ref()
-                .ok_or_eyre("Gateway not running")?
-                .external_url()
-                .ok_or_eyre("no url for gateway")?;
-            let node_id = crate::types::XmtpdNode::get_next_id(gateway_url.as_str()).await?;
-            let config = Config::load()?;
-            let num_ids = node_id / crate::constants::Xmtpd::NODE_ID_INCREMENT;
-            let base_idx = num_ids as usize * 3 + 1;
-            let migration_payer = &config.signers[base_idx + 2];
-            let bootstrapper_addr = migration_payer.address();
-            crate::contracts::set_payload_bootstrapper(
-                mgr.anvil_rpc_url()
-                    .ok_or_eyre("Anvil not running")?
-                    .as_str(),
-                crate::constants::Anvil::ADMIN_KEY,
-                bootstrapper_addr,
-            )
-            .await?;
-        }
-
-        if add.use_standard_port {
-            // Check all registered ToxiProxy proxies, not just mgr.nodes() which
-            // only contains nodes started in the current session. Nodes whose proxy
-            // already existed at startup are skipped by ServiceManager::start() and
-            // never added to self.nodes, so we must query ToxiProxy directly.
-            let standard_port = crate::constants::Xmtpd::GRPC_PORT;
-            let existing_proxies = mgr.proxy.list_proxies().await?;
-            for proxy in existing_proxies.values() {
-                let listen = &proxy.proxy_pack.listen;
-                let port: u16 = listen
-                    .rsplit(':')
-                    .next()
-                    .and_then(|p| p.parse().ok())
-                    .unwrap_or(0);
-                if port == standard_port {
-                    return Err(eyre!(
-                        "cannot add node with --use-standard-port: port {} is already in use by an existing proxy",
-                        standard_port
-                    ));
-                }
-            }
-        }
-
-        let cli = XmtpdCli::builder().toxiproxy(mgr.proxy.clone());
-        let mut output = self.cli_output.lock().await;
-        let gateway = mgr
-            .gateway
-            .as_ref()
-            .ok_or_eyre("Gateway not running")?
-            .external_url()
-            .ok_or_eyre("no url for gateway")?;
-        let mut xmtpd = XmtpdNode::new(gateway.as_str(), add.use_standard_port).await?;
-        cli.clone()
+        let node = NodeProvisioner::builder()
+            .migrator(add.migrator)
+            .use_standard_port(add.use_standard_port)
             .build()
-            .register(&mgr, &mut *output, &xmtpd)
+            .provision(&mut mgr)
             .await?;
-        cli.build().enable(&mut xmtpd, &mut *output).await?;
-        if add.migrator {
-            mgr.add_xmtpd_with_migrator(xmtpd.clone()).await?;
-        } else {
-            mgr.add_xmtpd(xmtpd.clone()).await?;
-        }
-        Ok(xmtpd)
+
+        Ok(node)
     }
 
     pub async fn gateway_url(&self) -> Result<url::Url> {

--- a/apps/xnet/lib/src/app/run.rs
+++ b/apps/xnet/lib/src/app/run.rs
@@ -54,8 +54,9 @@ impl App {
         let config = Config::load()?;
         let paused = cli_paused || config.paused;
         if paused {
+            let rpc = mgr.anvil_rpc_url().ok_or_eyre("Anvil not running")?;
             crate::contracts::set_broadcasters_paused(
-                mgr.anvil_rpc_url().as_str(),
+                rpc.as_str(),
                 crate::constants::Anvil::ADMIN_KEY,
                 true,
             )
@@ -82,9 +83,8 @@ impl App {
         if add.migrator {
             // Broadcaster contracts must be paused before adding a migrator node.
             // If they're unpaused, d14n has been activated and migrators can't be added.
-            let statuses =
-                crate::contracts::get_broadcaster_pause_status(mgr.anvil_rpc_url().as_str())
-                    .await?;
+            let rpc = mgr.anvil_rpc_url().ok_or_eyre("Anvil not running")?;
+            let statuses = crate::contracts::get_broadcaster_pause_status(rpc.as_str()).await?;
             let all_paused = statuses.iter().all(|(_, paused)| *paused);
             if !all_paused {
                 return Err(eyre!(
@@ -96,6 +96,8 @@ impl App {
             // Set the new node's migration payer as the payload bootstrapper
             let gateway_url = mgr
                 .gateway
+                .as_ref()
+                .ok_or_eyre("Gateway not running")?
                 .external_url()
                 .ok_or_eyre("no url for gateway")?;
             let node_id = crate::types::XmtpdNode::get_next_id(gateway_url.as_str()).await?;
@@ -105,7 +107,9 @@ impl App {
             let migration_payer = &config.signers[base_idx + 2];
             let bootstrapper_addr = migration_payer.address();
             crate::contracts::set_payload_bootstrapper(
-                mgr.anvil_rpc_url().as_str(),
+                mgr.anvil_rpc_url()
+                    .ok_or_eyre("Anvil not running")?
+                    .as_str(),
                 crate::constants::Anvil::ADMIN_KEY,
                 bootstrapper_addr,
             )
@@ -139,6 +143,8 @@ impl App {
         let mut output = self.cli_output.lock().await;
         let gateway = mgr
             .gateway
+            .as_ref()
+            .ok_or_eyre("Gateway not running")?
             .external_url()
             .ok_or_eyre("no url for gateway")?;
         let mut xmtpd = XmtpdNode::new(gateway.as_str(), add.use_standard_port).await?;
@@ -157,7 +163,11 @@ impl App {
 
     pub async fn gateway_url(&self) -> Result<url::Url> {
         let mgr = ServiceManager::start().await?;
-        mgr.gateway.external_url().ok_or_eyre("no url for gateway")
+        mgr.gateway
+            .as_ref()
+            .ok_or_eyre("Gateway not running (enable_d14n required)")?
+            .external_url()
+            .ok_or_eyre("no url for gateway")
     }
 
     pub async fn addresses(&self) -> Result<()> {
@@ -166,6 +176,8 @@ impl App {
         let mgr = ServiceManager::start().await?;
         let gateway_url = mgr
             .gateway
+            .as_ref()
+            .ok_or_eyre("Gateway not running")?
             .external_url()
             .ok_or_eyre("gateway not running")?;
         let grpc =
@@ -221,12 +233,9 @@ impl App {
     pub async fn activate_d14n(&self) -> Result<()> {
         use crate::constants::Anvil as AnvilConst;
         let mut mgr = ServiceManager::start().await?;
-        crate::contracts::set_broadcasters_paused(
-            mgr.anvil_rpc_url().as_str(),
-            AnvilConst::ADMIN_KEY,
-            false,
-        )
-        .await?;
+        let rpc = mgr.anvil_rpc_url().ok_or_eyre("Anvil not running")?;
+        crate::contracts::set_broadcasters_paused(rpc.as_str(), AnvilConst::ADMIN_KEY, false)
+            .await?;
         mgr.remove_migrators().await?;
         Ok(())
     }
@@ -239,8 +248,8 @@ impl App {
         ServiceManager::print_port_allocations();
 
         let mgr = ServiceManager::start().await?;
-        let statuses =
-            crate::contracts::get_broadcaster_pause_status(mgr.anvil_rpc_url().as_str()).await?;
+        let rpc = mgr.anvil_rpc_url().ok_or_eyre("Anvil not running")?;
+        let statuses = crate::contracts::get_broadcaster_pause_status(rpc.as_str()).await?;
 
         println!();
         let mut table = AsciiTable::default();
@@ -293,9 +302,13 @@ impl App {
                     Some(u) => u.clone(),
                     None => {
                         let mgr = ServiceManager::start().await?;
-                        mgr.node_go.external_grpc_url().ok_or_eyre(
-                            "node-go has no external gRPC URL (ToxiProxy port not configured)",
-                        )?
+                        mgr.node_go
+                            .as_ref()
+                            .ok_or_eyre("node-go not running (enable_v3 required)")?
+                            .external_grpc_url()
+                            .ok_or_eyre(
+                                "node-go has no external gRPC URL (ToxiProxy port not configured)",
+                            )?
                     }
                 };
                 let client = xmtp_api_grpc::GrpcClient::create(url).map_err(|e| eyre!("{}", e))?;

--- a/apps/xnet/lib/src/app/run.rs
+++ b/apps/xnet/lib/src/app/run.rs
@@ -46,20 +46,9 @@ impl App {
         Self::new(args.clone())
     }
 
-    pub async fn up(&self, cli_paused: bool) -> Result<()> {
+    pub async fn up(&self, _cli_paused: bool) -> Result<()> {
         let network = Network::new().await?;
-        let mgr = ServiceManager::start().await?;
-        let config = Config::load()?;
-        let paused = cli_paused || config.paused;
-        if paused {
-            let rpc = mgr.anvil_rpc_url().ok_or_eyre("Anvil not running")?;
-            crate::contracts::set_broadcasters_paused(
-                rpc.as_str(),
-                crate::constants::Anvil::ADMIN_KEY,
-                true,
-            )
-            .await?;
-        }
+        let _mgr = ServiceManager::start().await?;
         Ok(())
     }
 

--- a/apps/xnet/lib/src/app/run.rs
+++ b/apps/xnet/lib/src/app/run.rs
@@ -46,9 +46,20 @@ impl App {
         Self::new(args.clone())
     }
 
-    pub async fn up(&self, _cli_paused: bool) -> Result<()> {
-        let network = Network::new().await?;
-        let _mgr = ServiceManager::start().await?;
+    pub async fn up(&self, cli_paused: bool) -> Result<()> {
+        let _network = Network::new().await?;
+        let mgr = ServiceManager::start().await?;
+        if cli_paused
+            && let Some(rpc) = mgr.anvil_rpc_url()
+        {
+            crate::contracts::set_broadcasters_paused(
+                rpc.as_str(),
+                crate::constants::Anvil::ADMIN_KEY,
+                true,
+            )
+            .await?;
+            info!("broadcaster contracts paused via --paused flag");
+        }
         Ok(())
     }
 

--- a/apps/xnet/lib/src/app/run.rs
+++ b/apps/xnet/lib/src/app/run.rs
@@ -48,18 +48,7 @@ impl App {
 
     pub async fn up(&self, cli_paused: bool) -> Result<()> {
         let _network = Network::new().await?;
-        let mgr = ServiceManager::start().await?;
-        if cli_paused
-            && let Some(rpc) = mgr.anvil_rpc_url()
-        {
-            crate::contracts::set_broadcasters_paused(
-                rpc.as_str(),
-                crate::constants::Anvil::ADMIN_KEY,
-                true,
-            )
-            .await?;
-            info!("broadcaster contracts paused via --paused flag");
-        }
+        let _mgr = ServiceManager::start_paused(cli_paused).await?;
         Ok(())
     }
 

--- a/apps/xnet/lib/src/app/service_manager.rs
+++ b/apps/xnet/lib/src/app/service_manager.rs
@@ -1,19 +1,16 @@
 //! Stateful service manager
 //! network is hardcoded to XNET_NETWORK_NAME
 use std::collections::HashMap;
-use std::io::stdout;
 
 use crate::{
     Config,
-    config::NodeToml,
-    constants::Xmtpd as XmtpdConst,
     network::{Network, XNET_NETWORK_NAME},
+    node_provisioner::NodeProvisioner,
     services::{
         self, CoreDns, Gateway, Grafana, NodeGo, Otterscan, PgAdmin, Prometheus, ReplicationDb,
         Service, ToxiProxy, Traefik, TraefikConfig, Xmtpd, create_and_start_container,
     },
-    types::{XmtpdNode, resolve_port},
-    xmtpd_cli::XmtpdCli,
+    types::XmtpdNode,
 };
 use bollard::{
     Docker,
@@ -29,80 +26,148 @@ use futures::FutureExt;
 /// Starts services in the right order
 /// and keeps a list of running services
 pub struct ServiceManager {
+    // Always required (infrastructure)
     pub coredns: CoreDns,
     pub traefik: Traefik,
     pub traefik_config: TraefikConfig,
     pub proxy: ToxiProxy,
-    pub gateway: Gateway,
-    pub node_go: NodeGo,
-    services: Vec<Box<dyn Service>>,
-    otterscan: Otterscan,
-    prometheus: Prometheus,
-    grafana: Grafana,
-    pgadmin: PgAdmin,
+
+    // V3 stack (None when enable_v3 = false)
+    pub node_go: Option<NodeGo>,
+    v3_services: Vec<Box<dyn Service>>,
+
+    // D14n stack (None when enable_d14n = false)
+    pub gateway: Option<Gateway>,
+    d14n_services: Vec<Box<dyn Service>>,
+
+    // Shared — starts when either V3 or D14n is enabled
+    anvil_rpc_url: Option<url::Url>,
+    shared_services: Vec<Box<dyn Service>>,
+
+    // Monitoring (None when enable_monitoring = false)
+    prometheus: Option<Prometheus>,
+    grafana: Option<Grafana>,
+    pgadmin: Option<PgAdmin>,
+    otterscan: Option<Otterscan>,
+
     nodes: Vec<Xmtpd>,
-    /// Anvil RPC URL for funding node wallets and contract calls
-    anvil_rpc_url: url::Url,
 }
 
 impl ServiceManager {
-    pub fn anvil_rpc_url(&self) -> &url::Url {
-        &self.anvil_rpc_url
+    pub fn anvil_rpc_url(&self) -> Option<&url::Url> {
+        self.anvil_rpc_url.as_ref()
     }
 
     /// starts services if not already started
     /// if running connects to them.
     pub async fn start() -> Result<Self> {
-        // Start ToxiProxy first (other services may register with it)
+        Self::start_paused(false).await
+    }
+
+    /// Like [`start`](Self::start) but also pauses broadcaster contracts when
+    /// `cli_paused` is true (before node provisioning).
+    pub async fn start_paused(cli_paused: bool) -> Result<Self> {
+        let config = Config::load()?;
+
+        // Phase 1: Infrastructure (always)
         let mut proxy = ToxiProxy::builder().build()?;
         proxy.start().await?;
 
-        // Start Traefik first so we can get its IP for CoreDNS
-        let config = Config::load()?;
         let mut traefik = Traefik::builder()
             .maybe_http_port(config.traefik_port)
             .build();
         traefik.start(&proxy).await?;
 
-        // Get Traefik's IP address for CoreDNS container-facing DNS
         let traefik_ip = traefik.container_ip().await?;
 
-        // Start CoreDNS with Traefik's IP
         let mut coredns = CoreDns::builder().traefik_ip(traefik_ip).build();
         coredns.start(&proxy).await?;
 
-        // Create Traefik config manager (loads existing routes from file)
         let traefik_config = TraefikConfig::new(traefik.dynamic_config_path())?;
+        if !config.extra_traefik_routes.is_empty() {
+            traefik_config.set_extra_routes(config.extra_traefik_routes.clone())?;
+        }
 
-        // Start monitoring services (Prometheus + Grafana) in parallel.
-        // PgAdmin is started AFTER xmtpd nodes — see below.
-        let mut prometheus = Prometheus::builder().build();
-        let mut grafana = Grafana::builder().build();
-        let pgadmin = PgAdmin::builder().build();
-        let launch = vec![
-            prometheus.start(&proxy).boxed(),
-            grafana.start(&proxy).boxed(),
-        ];
-        futures::future::try_join_all(launch).await?;
-
-        let mut services = Vec::new();
-        info!("starting v3");
-        let (node_go, svcs) = start_v3(&proxy).await?;
-        services.extend(svcs);
-        let dns_ip = coredns.container_ip().await?;
-        let (gateway, anvil_external_rpc, svcs) = start_d14n(&proxy, dns_ip).await?;
-        services.extend(svcs);
-
-        let anvil_host_for_browser = match &config.address_mode {
-            crate::config::AddressMode::Remote(ip) => anvil_external_rpc
-                .to_string()
-                .replace("localhost", &ip.to_string()),
-            _ => anvil_external_rpc.to_string(),
+        // Phase 2: Monitoring — Prometheus + Grafana (conditional)
+        // PgAdmin is started AFTER xmtpd nodes so it can discover their
+        // ReplicationDb containers via Docker labels (xnet.pgadmin=true).
+        let (prometheus, grafana, pgadmin) = if config.enable_monitoring {
+            let mut p = Prometheus::builder().build();
+            let mut g = Grafana::builder().build();
+            let pa = PgAdmin::builder().build();
+            let launch = vec![p.start(&proxy).boxed(), g.start(&proxy).boxed()];
+            futures::future::try_join_all(launch).await?;
+            (Some(p), Some(g), Some(pa))
+        } else {
+            (None, None, None)
         };
-        let mut otterscan = Otterscan::builder()
-            .anvil_host(anvil_host_for_browser)
-            .build();
-        otterscan.start(&proxy).await?;
+
+        // Phase 3: Shared services — Anvil, Validation, History
+        // These are needed by both V3 and D14n stacks
+        let need_shared = config.enable_v3 || config.enable_d14n;
+        let (anvil_rpc_url, anvil_proxy_host, shared_services) = if need_shared {
+            let shared = start_shared_services(&proxy).await?;
+            (
+                Some(shared.anvil_rpc_url),
+                Some(shared.anvil_proxy_host),
+                shared.services,
+            )
+        } else {
+            (None, None, vec![])
+        };
+
+        // Phase 4: V3 (conditional)
+        let (node_go, v3_services) = if config.enable_v3 {
+            info!("starting v3");
+            let (ng, svcs) = start_v3(&proxy).await?;
+            (Some(ng), svcs)
+        } else {
+            (None, vec![])
+        };
+
+        // Phase 5: D14n — Redis + Gateway (conditional)
+        let dns_ip = coredns.container_ip().await?;
+        let (gateway, d14n_services) = if config.enable_d14n {
+            let host = anvil_proxy_host
+                .as_ref()
+                .expect("anvil must be running when d14n is enabled");
+            let anvil_rpc = anvil_rpc_url.as_ref().unwrap();
+            let (gw, svcs) = start_d14n(&proxy, dns_ip.clone(), host.clone(), anvil_rpc).await?;
+            (Some(gw), svcs)
+        } else {
+            (None, vec![])
+        };
+
+        // Phase 6: Otterscan (needs monitoring AND shared services)
+        let otterscan = if config.enable_monitoring && need_shared {
+            let anvil_rpc = anvil_rpc_url.as_ref().unwrap();
+            let anvil_host_for_browser = match &config.address_mode {
+                crate::config::AddressMode::RemoteDomain(domain) => {
+                    anvil_rpc.to_string().replace("localhost", domain)
+                }
+                crate::config::AddressMode::Local => anvil_rpc.to_string(),
+            };
+            let mut ot = Otterscan::builder()
+                .anvil_host(anvil_host_for_browser)
+                .build();
+            ot.start(&proxy).await?;
+            Some(ot)
+        } else {
+            None
+        };
+
+        // Phase 6b: Pause broadcasters if configured (must happen before Phase 7 node provisioning)
+        if config.paused || cli_paused {
+            if let Some(ref rpc) = anvil_rpc_url {
+                crate::contracts::set_broadcasters_paused(
+                    rpc.as_str(),
+                    crate::constants::Anvil::ADMIN_KEY,
+                    true,
+                )
+                .await?;
+                info!("broadcaster contracts paused");
+            }
+        }
 
         let mut this = Self {
             node_go,
@@ -111,70 +176,50 @@ impl ServiceManager {
             traefik_config,
             proxy,
             gateway,
-            services,
+            v3_services,
+            d14n_services,
+            shared_services,
+            anvil_rpc_url,
             otterscan,
             prometheus,
             grafana,
             pgadmin,
             nodes: Vec::new(),
-            anvil_rpc_url: anvil_external_rpc,
         };
 
-        let gateway_host = this.gateway.external_url().expect("just created gateway");
-        let mut id = 0;
-        // start any xmtpd nodes described in toml
-        let config = Config::load()?;
-        let cli = XmtpdCli::builder().toxiproxy(this.proxy.clone());
-        let existing_proxies = this.proxy.list_proxies().await?;
-        let mut output = stdout();
-        for NodeToml {
-            port,
-            migrator,
-            name,
-            enable,
-            use_standard_port,
-        } in config.xmtpd_nodes
-        {
-            id += XmtpdConst::NODE_ID_INCREMENT;
-            let node_name = name.as_ref().unwrap_or(&format!("xnet-{}", id)).to_string();
-            if existing_proxies.contains_key(&node_name) {
-                info!("node {} already has proxy registered, skipping", node_name);
-                continue;
-            }
-            if !enable {
-                continue;
-            }
-            let node = XmtpdNode::builder();
-            let node = node.port(resolve_port(use_standard_port, port)?);
-            let node = if let Some(n) = name {
-                node.name(n)
-            } else {
-                node.name(format!("xnet-{}", id))
-            };
-            let node = node.node_id(id);
-            let num_ids = id / XmtpdConst::NODE_ID_INCREMENT;
-            let base_idx = num_ids as usize * 3 + 1;
-            let mut node = node
-                .signer(config.signers[base_idx].clone())
-                .payer(config.signers[base_idx + 1].clone())
-                .migration_payer(config.signers[base_idx + 2].clone())
-                .build();
-            cli.clone()
-                .build()
-                .register(&this, &mut output, &node)
-                .await?;
-            cli.clone().build().enable(&mut node, &mut output).await?;
-            if migrator {
-                this.add_xmtpd_with_migrator(node).await?;
-            } else {
-                this.add_xmtpd(node).await?;
+        // Phase 7: XMTPD nodes from config (requires D14n)
+        if config.enable_d14n {
+            let existing_proxies = this.proxy.list_proxies().await?;
+            for node_toml in &config.xmtpd_nodes {
+                if !node_toml.enable {
+                    continue;
+                }
+                // Skip nodes whose proxy already exists (already provisioned in a previous run).
+                // Only applies to named nodes — unnamed nodes get their name from the gateway ID.
+                if let Some(ref name) = node_toml.name
+                    && existing_proxies.contains_key(name)
+                {
+                    info!("node {} already has proxy registered, skipping", name);
+                    continue;
+                }
+
+                NodeProvisioner::builder()
+                    .migrator(node_toml.migrator)
+                    .use_standard_port(node_toml.use_standard_port)
+                    .maybe_name(node_toml.name.clone())
+                    .maybe_port(node_toml.port)
+                    .build()
+                    .provision(&mut this)
+                    .await?;
             }
         }
 
         // Start PgAdmin AFTER xmtpd nodes so it can discover their
         // ReplicationDb containers via Docker labels (xnet.pgadmin=true).
         // Dependency chain: ReplicationDb (labels) → PgAdmin (scans labels)
-        this.pgadmin.start(&this.proxy).await?;
+        if let Some(ref mut pa) = this.pgadmin {
+            pa.start(&this.proxy).await?;
+        }
 
         Ok(this)
     }
@@ -184,15 +229,48 @@ impl ServiceManager {
     }
 
     pub async fn stop(&mut self) -> Result<()> {
-        for service in &mut self.services {
+        // Stop node-go before its database dependencies
+        if let Some(ref mut ng) = self.node_go {
+            ng.stop().await?;
+        }
+        // Stop V3 services (databases)
+        for service in &mut self.v3_services {
             service.stop().await?;
         }
-        self.gateway.stop().await?;
-        self.node_go.stop().await?;
-        self.otterscan.stop().await?;
-        self.pgadmin.stop().await?;
-        self.grafana.stop().await?;
-        self.prometheus.stop().await?;
+
+        // Stop XMTPD nodes (before their dependencies)
+        for node in &mut self.nodes {
+            node.stop().await?;
+        }
+
+        // Stop D14n services
+        for service in &mut self.d14n_services {
+            service.stop().await?;
+        }
+        if let Some(ref mut gw) = self.gateway {
+            gw.stop().await?;
+        }
+
+        // Stop shared services (Anvil, Validation, History)
+        for service in &mut self.shared_services {
+            service.stop().await?;
+        }
+
+        // Stop monitoring
+        if let Some(ref mut ot) = self.otterscan {
+            ot.stop().await?;
+        }
+        if let Some(ref mut pa) = self.pgadmin {
+            pa.stop().await?;
+        }
+        if let Some(ref mut g) = self.grafana {
+            g.stop().await?;
+        }
+        if let Some(ref mut p) = self.prometheus {
+            p.stop().await?;
+        }
+
+        // Infrastructure (always)
         self.coredns.stop().await?;
         self.traefik.stop().await?;
         self.proxy.stop().await?;
@@ -206,35 +284,47 @@ impl ServiceManager {
     }
 
     pub async fn add_xmtpd_with_migrator(&mut self, node: XmtpdNode) -> Result<()> {
+        let node_go = self.node_go.as_ref().ok_or_else(|| {
+            color_eyre::eyre::eyre!(
+                "Cannot add migrator node: V3 stack is disabled (enable_v3 required)"
+            )
+        })?;
         let dns_ip = self.coredns.container_ip().await?;
         let xmtpd = Xmtpd::builder()
             .node(node)
             .migrator(true)
-            .node_go(self.node_go.clone())
+            .node_go(node_go.clone())
             .dns_server(dns_ip)
             .build()?;
         self.internal_add_xmtpd(xmtpd).await
     }
 
     pub async fn reload_node_go(&mut self, d14n_cutover_ns: i64) -> Result<()> {
-        self.node_go.reload(d14n_cutover_ns, &self.proxy).await
+        let node_go = self.node_go.as_mut().ok_or_else(|| {
+            color_eyre::eyre::eyre!(
+                "Cannot reload node-go: V3 stack is disabled (enable_v3 required)"
+            )
+        })?;
+        node_go.reload(d14n_cutover_ns, &self.proxy).await
     }
 
     async fn internal_add_xmtpd(&mut self, mut xmtpd: Xmtpd) -> Result<()> {
-        // Fund all node wallets (signer, payer, migration payer) with testnet ETH
-        let rpc = self.anvil_rpc_url.as_str();
+        let rpc = self.anvil_rpc_url.as_ref().ok_or_else(|| {
+            color_eyre::eyre::eyre!(
+                "Cannot add xmtpd node: Anvil is not running (enable_v3 or enable_d14n required)"
+            )
+        })?;
         let node = xmtpd.node();
         for address in [
             node.address(),
             node.payer_address(),
             node.migration_payer_address(),
         ] {
-            crate::wallet_funding::fund_wallet(rpc, address, None).await?;
+            crate::wallet_funding::fund_wallet(rpc.as_str(), address, None).await?;
         }
 
         xmtpd.start(&self.proxy).await?;
 
-        // Register with Traefik for unified addressing
         if let Some(hostname) = <Xmtpd as Service>::hostname(&xmtpd)
             && let Some(toxi_port) = xmtpd.proxy_port()
         {
@@ -243,13 +333,16 @@ impl ServiceManager {
 
         self.nodes.push(xmtpd);
 
-        // Update Prometheus scrape targets with the new node
-        self.prometheus.update_targets(&self.nodes)?;
+        if let Some(ref mut prometheus) = self.prometheus {
+            prometheus.update_targets(&self.nodes)?;
+        }
 
         // Rescan Docker labels to pick up the new node's ReplicationDb.
         // PgAdmin discovers databases via xnet.pgadmin=true container labels,
         // so it doesn't need to know about Xmtpd directly.
-        self.pgadmin.discover_databases().await?;
+        if let Some(ref mut pgadmin) = self.pgadmin {
+            pgadmin.discover_databases().await?;
+        }
 
         Ok(())
     }
@@ -343,73 +436,75 @@ impl ServiceManager {
     }
 }
 
+struct SharedServices {
+    services: Vec<Box<dyn Service>>,
+    anvil_rpc_url: url::Url,
+    anvil_proxy_host: String,
+}
+
+/// Start shared services needed by both V3 and D14n: Anvil, Validation, History
+async fn start_shared_services(proxy: &ToxiProxy) -> Result<SharedServices> {
+    let mut anvil = services::Anvil::builder().build()?;
+    anvil.start(proxy).await?;
+    let rpc = anvil.external_rpc_url().unwrap_or_else(|| anvil.rpc_url());
+    let anvil_proxy_host = anvil.internal_proxy_host()?;
+
+    let mut validation = services::Validation::builder().build()?;
+    let mut history = services::HistoryServer::builder().build()?;
+    let launch = vec![
+        validation.start(proxy).boxed(),
+        history.start(proxy).boxed(),
+    ];
+    futures::future::try_join_all(launch).await?;
+
+    Ok(SharedServices {
+        services: vec![
+            Box::new(anvil) as _,
+            Box::new(validation) as _,
+            Box::new(history) as _,
+        ],
+        anvil_rpc_url: rpc,
+        anvil_proxy_host,
+    })
+}
+
 async fn start_d14n(
     proxy: &ToxiProxy,
     dns_ip: String,
-) -> Result<(Gateway, url::Url, Vec<Box<dyn Service>>)> {
+    anvil_proxy_host: String,
+    anvil_rpc: &url::Url,
+) -> Result<(Gateway, Vec<Box<dyn Service>>)> {
     use crate::constants::Gateway as GatewayConst;
     use alloy::signers::local::PrivateKeySigner;
 
-    let mut anvil = services::Anvil::builder().build()?;
     let mut redis = services::Redis::builder().build();
-
-    let launch = vec![anvil.start(proxy).boxed(), redis.start(proxy).boxed()];
-    futures::future::try_join_all(launch).await?;
+    redis.start(proxy).await?;
 
     // Fund the gateway wallet before starting it
-    let anvil_rpc = anvil.external_rpc_url().unwrap_or_else(|| anvil.rpc_url());
     let gateway_key: PrivateKeySigner = GatewayConst::PRIVATE_KEY.parse()?;
     let gateway_address = gateway_key.address();
-    crate::wallet_funding::fund_wallet(
-        anvil_rpc.as_str(),
-        gateway_address,
-        None, // Use default funding amount (1000 ETH)
-    )
-    .await?;
+    crate::wallet_funding::fund_wallet(anvil_rpc.as_str(), gateway_address, None).await?;
 
     let mut gateway = services::Gateway::builder()
         .redis_host(redis.internal_proxy_host()?)
-        .anvil_host(anvil.internal_proxy_host()?)
+        .anvil_host(anvil_proxy_host)
         .dns_server(dns_ip)
         .build()?;
     gateway.start(proxy).await?;
 
-    let anvil_external_rpc = anvil.external_rpc_url().unwrap_or_else(|| anvil.rpc_url());
-    Ok((
-        gateway,
-        anvil_external_rpc,
-        vec![Box::new(anvil) as _, Box::new(redis) as _],
-    ))
+    Ok((gateway, vec![Box::new(redis) as _]))
 }
 
 async fn start_v3(proxy: &ToxiProxy) -> Result<(NodeGo, Vec<Box<dyn Service>>)> {
-    let mut validation = services::Validation::builder().build()?;
     let mut mls_db = services::MlsDb::builder().build();
     let mut v3_db = services::V3Db::builder().build();
-    // history is both but OK to start with v3 stuff to follow docker-compose
-    let mut history = services::HistoryServer::builder().build()?;
-    // dependencies
-    let launch = vec![
-        validation.start(proxy).boxed(),
-        mls_db.start(proxy).boxed(),
-        v3_db.start(proxy).boxed(),
-        history.start(proxy).boxed(),
-    ];
+    let launch = vec![mls_db.start(proxy).boxed(), v3_db.start(proxy).boxed()];
     futures::future::try_join_all(launch).await?;
     let mut node_go = services::NodeGo::builder()
         .store_db_host(v3_db.internal_proxy_host()?)
         .mls_store_db_host(mls_db.internal_proxy_host()?)
-        .mls_validation_address(validation.internal_proxy_host()?)
         .build()?;
     node_go.start(proxy).await?;
 
-    Ok((
-        node_go,
-        vec![
-            Box::new(validation) as _,
-            Box::new(mls_db) as _,
-            Box::new(v3_db) as _,
-            Box::new(history) as _,
-        ],
-    ))
+    Ok((node_go, vec![Box::new(mls_db) as _, Box::new(v3_db) as _]))
 }

--- a/apps/xnet/lib/src/app/service_manager.rs
+++ b/apps/xnet/lib/src/app/service_manager.rs
@@ -178,11 +178,11 @@ impl ServiceManager {
                 }
                 // Skip nodes whose proxy already exists (already provisioned in a previous run).
                 // Only applies to named nodes — unnamed nodes get their name from the gateway ID.
-                if let Some(ref name) = node_toml.name {
-                    if existing_proxies.contains_key(name) {
-                        info!("node {} already has proxy registered, skipping", name);
-                        continue;
-                    }
+                if let Some(ref name) = node_toml.name
+                    && existing_proxies.contains_key(name)
+                {
+                    info!("node {} already has proxy registered, skipping", name);
+                    continue;
                 }
 
                 NodeProvisioner::builder()

--- a/apps/xnet/lib/src/app/service_manager.rs
+++ b/apps/xnet/lib/src/app/service_manager.rs
@@ -29,80 +29,127 @@ use futures::FutureExt;
 /// Starts services in the right order
 /// and keeps a list of running services
 pub struct ServiceManager {
+    // Always required (infrastructure)
     pub coredns: CoreDns,
     pub traefik: Traefik,
     pub traefik_config: TraefikConfig,
     pub proxy: ToxiProxy,
-    pub gateway: Gateway,
-    pub node_go: NodeGo,
-    services: Vec<Box<dyn Service>>,
-    otterscan: Otterscan,
-    prometheus: Prometheus,
-    grafana: Grafana,
-    pgadmin: PgAdmin,
+
+    // V3 stack (None when enable_v3 = false)
+    pub node_go: Option<NodeGo>,
+    v3_services: Vec<Box<dyn Service>>,
+
+    // D14n stack (None when enable_d14n = false)
+    pub gateway: Option<Gateway>,
+    d14n_services: Vec<Box<dyn Service>>,
+
+    // Shared — starts when either V3 or D14n is enabled
+    anvil_rpc_url: Option<url::Url>,
+    shared_services: Vec<Box<dyn Service>>,
+
+    // Monitoring (None when enable_monitoring = false)
+    prometheus: Option<Prometheus>,
+    grafana: Option<Grafana>,
+    pgadmin: Option<PgAdmin>,
+    otterscan: Option<Otterscan>,
+
     nodes: Vec<Xmtpd>,
-    /// Anvil RPC URL for funding node wallets and contract calls
-    anvil_rpc_url: url::Url,
 }
 
 impl ServiceManager {
-    pub fn anvil_rpc_url(&self) -> &url::Url {
-        &self.anvil_rpc_url
+    pub fn anvil_rpc_url(&self) -> Option<&url::Url> {
+        self.anvil_rpc_url.as_ref()
     }
 
     /// starts services if not already started
     /// if running connects to them.
     pub async fn start() -> Result<Self> {
-        // Start ToxiProxy first (other services may register with it)
+        let config = Config::load()?;
+
+        // Phase 1: Infrastructure (always)
         let mut proxy = ToxiProxy::builder().build()?;
         proxy.start().await?;
 
-        // Start Traefik first so we can get its IP for CoreDNS
-        let config = Config::load()?;
         let mut traefik = Traefik::builder()
             .maybe_http_port(config.traefik_port)
+            .maybe_https_port(config.traefik_https_port)
             .build();
         traefik.start(&proxy).await?;
 
-        // Get Traefik's IP address for CoreDNS container-facing DNS
         let traefik_ip = traefik.container_ip().await?;
 
-        // Start CoreDNS with Traefik's IP
         let mut coredns = CoreDns::builder().traefik_ip(traefik_ip).build();
         coredns.start(&proxy).await?;
 
-        // Create Traefik config manager (loads existing routes from file)
         let traefik_config = TraefikConfig::new(traefik.dynamic_config_path())?;
 
-        // Start monitoring services (Prometheus + Grafana) in parallel.
-        // PgAdmin is started AFTER xmtpd nodes — see below.
-        let mut prometheus = Prometheus::builder().build();
-        let mut grafana = Grafana::builder().build();
-        let pgadmin = PgAdmin::builder().build();
-        let launch = vec![
-            prometheus.start(&proxy).boxed(),
-            grafana.start(&proxy).boxed(),
-        ];
-        futures::future::try_join_all(launch).await?;
-
-        let mut services = Vec::new();
-        info!("starting v3");
-        let (node_go, svcs) = start_v3(&proxy).await?;
-        services.extend(svcs);
-        let dns_ip = coredns.container_ip().await?;
-        let (gateway, anvil_external_rpc, svcs) = start_d14n(&proxy, dns_ip).await?;
-        services.extend(svcs);
-
-        let anvil_host_for_browser = match &config.address_mode {
-            crate::config::AddressMode::Remote(ip) => anvil_external_rpc
-                .to_string()
-                .replace("localhost", &ip.to_string()),
-            _ => anvil_external_rpc.to_string(),
+        // Phase 2: Monitoring — Prometheus + Grafana (conditional)
+        // PgAdmin is started AFTER xmtpd nodes so it can discover their
+        // ReplicationDb containers via Docker labels (xnet.pgadmin=true).
+        let (prometheus, grafana, pgadmin) = if config.enable_monitoring {
+            let mut p = Prometheus::builder().build();
+            let mut g = Grafana::builder().build();
+            let pa = PgAdmin::builder().build();
+            let launch = vec![p.start(&proxy).boxed(), g.start(&proxy).boxed()];
+            futures::future::try_join_all(launch).await?;
+            (Some(p), Some(g), Some(pa))
+        } else {
+            (None, None, None)
         };
-        let mut otterscan = Otterscan::builder()
-            .anvil_host(anvil_host_for_browser)
-            .build();
-        otterscan.start(&proxy).await?;
+
+        // Phase 3: Shared services — Anvil, Validation, History
+        // These are needed by both V3 and D14n stacks
+        let need_shared = config.enable_v3 || config.enable_d14n;
+        let (anvil_rpc_url, anvil_proxy_host, shared_services) = if need_shared {
+            let shared = start_shared_services(&proxy).await?;
+            (
+                Some(shared.anvil_rpc_url),
+                Some(shared.anvil_proxy_host),
+                shared.services,
+            )
+        } else {
+            (None, None, vec![])
+        };
+
+        // Phase 4: V3 (conditional)
+        let (node_go, v3_services) = if config.enable_v3 {
+            info!("starting v3");
+            let (ng, svcs) = start_v3(&proxy).await?;
+            (Some(ng), svcs)
+        } else {
+            (None, vec![])
+        };
+
+        // Phase 5: D14n — Redis + Gateway (conditional)
+        let dns_ip = coredns.container_ip().await?;
+        let (gateway, d14n_services) = if config.enable_d14n {
+            let host = anvil_proxy_host
+                .as_ref()
+                .expect("anvil must be running when d14n is enabled");
+            let anvil_rpc = anvil_rpc_url.as_ref().unwrap();
+            let (gw, svcs) = start_d14n(&proxy, dns_ip.clone(), host.clone(), anvil_rpc).await?;
+            (Some(gw), svcs)
+        } else {
+            (None, vec![])
+        };
+
+        // Phase 6: Otterscan (needs monitoring AND shared services)
+        let otterscan = if config.enable_monitoring && need_shared {
+            let anvil_rpc = anvil_rpc_url.as_ref().unwrap();
+            let anvil_host_for_browser = match &config.address_mode {
+                crate::config::AddressMode::Remote(ip) => {
+                    anvil_rpc.to_string().replace("localhost", &ip.to_string())
+                }
+                _ => anvil_rpc.to_string(),
+            };
+            let mut ot = Otterscan::builder()
+                .anvil_host(anvil_host_for_browser)
+                .build();
+            ot.start(&proxy).await?;
+            Some(ot)
+        } else {
+            None
+        };
 
         let mut this = Self {
             node_go,
@@ -111,70 +158,74 @@ impl ServiceManager {
             traefik_config,
             proxy,
             gateway,
-            services,
+            v3_services,
+            d14n_services,
+            shared_services,
+            anvil_rpc_url,
             otterscan,
             prometheus,
             grafana,
             pgadmin,
             nodes: Vec::new(),
-            anvil_rpc_url: anvil_external_rpc,
         };
 
-        let gateway_host = this.gateway.external_url().expect("just created gateway");
-        let mut id = 0;
-        // start any xmtpd nodes described in toml
-        let config = Config::load()?;
-        let cli = XmtpdCli::builder().toxiproxy(this.proxy.clone());
-        let existing_proxies = this.proxy.list_proxies().await?;
-        let mut output = stdout();
-        for NodeToml {
-            port,
-            migrator,
-            name,
-            enable,
-            use_standard_port,
-        } in config.xmtpd_nodes
-        {
-            id += XmtpdConst::NODE_ID_INCREMENT;
-            let node_name = name.as_ref().unwrap_or(&format!("xnet-{}", id)).to_string();
-            if existing_proxies.contains_key(&node_name) {
-                info!("node {} already has proxy registered, skipping", node_name);
-                continue;
-            }
-            if !enable {
-                continue;
-            }
-            let node = XmtpdNode::builder();
-            let node = node.port(resolve_port(use_standard_port, port)?);
-            let node = if let Some(n) = name {
-                node.name(n)
-            } else {
-                node.name(format!("xnet-{}", id))
-            };
-            let node = node.node_id(id);
-            let num_ids = id / XmtpdConst::NODE_ID_INCREMENT;
-            let base_idx = num_ids as usize * 3 + 1;
-            let mut node = node
-                .signer(config.signers[base_idx].clone())
-                .payer(config.signers[base_idx + 1].clone())
-                .migration_payer(config.signers[base_idx + 2].clone())
-                .build();
-            cli.clone()
-                .build()
-                .register(&this, &mut output, &node)
-                .await?;
-            cli.clone().build().enable(&mut node, &mut output).await?;
-            if migrator {
-                this.add_xmtpd_with_migrator(node).await?;
-            } else {
-                this.add_xmtpd(node).await?;
+        // Phase 7: XMTPD nodes from config (requires D14n)
+        if config.enable_d14n {
+            let existing_proxies = this.proxy.list_proxies().await?;
+            let cli = XmtpdCli::builder().toxiproxy(this.proxy.clone());
+            let mut output = stdout();
+            let mut id = 0;
+            for NodeToml {
+                port,
+                migrator,
+                name,
+                enable,
+                use_standard_port,
+            } in config.xmtpd_nodes
+            {
+                id += XmtpdConst::NODE_ID_INCREMENT;
+                let node_name = name.as_ref().unwrap_or(&format!("xnet-{}", id)).to_string();
+                if existing_proxies.contains_key(&node_name) {
+                    info!("node {} already has proxy registered, skipping", node_name);
+                    continue;
+                }
+                if !enable {
+                    continue;
+                }
+                let node = XmtpdNode::builder();
+                let node = node.port(resolve_port(use_standard_port, port)?);
+                let node = if let Some(n) = name {
+                    node.name(n)
+                } else {
+                    node.name(format!("xnet-{}", id))
+                };
+                let node = node.node_id(id);
+                let num_ids = id / XmtpdConst::NODE_ID_INCREMENT;
+                let base_idx = num_ids as usize * 3 + 1;
+                let mut node = node
+                    .signer(config.signers[base_idx].clone())
+                    .payer(config.signers[base_idx + 1].clone())
+                    .migration_payer(config.signers[base_idx + 2].clone())
+                    .build();
+                cli.clone()
+                    .build()
+                    .register(&this, &mut output, &node)
+                    .await?;
+                cli.clone().build().enable(&mut node, &mut output).await?;
+                if migrator {
+                    this.add_xmtpd_with_migrator(node).await?;
+                } else {
+                    this.add_xmtpd(node).await?;
+                }
             }
         }
 
         // Start PgAdmin AFTER xmtpd nodes so it can discover their
         // ReplicationDb containers via Docker labels (xnet.pgadmin=true).
         // Dependency chain: ReplicationDb (labels) → PgAdmin (scans labels)
-        this.pgadmin.start(&this.proxy).await?;
+        if let Some(ref mut pa) = this.pgadmin {
+            pa.start(&this.proxy).await?;
+        }
 
         Ok(this)
     }
@@ -184,15 +235,47 @@ impl ServiceManager {
     }
 
     pub async fn stop(&mut self) -> Result<()> {
-        for service in &mut self.services {
+        // Stop V3 services
+        for service in &mut self.v3_services {
             service.stop().await?;
         }
-        self.gateway.stop().await?;
-        self.node_go.stop().await?;
-        self.otterscan.stop().await?;
-        self.pgadmin.stop().await?;
-        self.grafana.stop().await?;
-        self.prometheus.stop().await?;
+        if let Some(ref mut ng) = self.node_go {
+            ng.stop().await?;
+        }
+
+        // Stop XMTPD nodes (before their dependencies)
+        for node in &mut self.nodes {
+            node.stop().await?;
+        }
+
+        // Stop D14n services
+        for service in &mut self.d14n_services {
+            service.stop().await?;
+        }
+        if let Some(ref mut gw) = self.gateway {
+            gw.stop().await?;
+        }
+
+        // Stop shared services (Anvil, Validation, History)
+        for service in &mut self.shared_services {
+            service.stop().await?;
+        }
+
+        // Stop monitoring
+        if let Some(ref mut ot) = self.otterscan {
+            ot.stop().await?;
+        }
+        if let Some(ref mut pa) = self.pgadmin {
+            pa.stop().await?;
+        }
+        if let Some(ref mut g) = self.grafana {
+            g.stop().await?;
+        }
+        if let Some(ref mut p) = self.prometheus {
+            p.stop().await?;
+        }
+
+        // Infrastructure (always)
         self.coredns.stop().await?;
         self.traefik.stop().await?;
         self.proxy.stop().await?;
@@ -206,35 +289,47 @@ impl ServiceManager {
     }
 
     pub async fn add_xmtpd_with_migrator(&mut self, node: XmtpdNode) -> Result<()> {
+        let node_go = self.node_go.as_ref().ok_or_else(|| {
+            color_eyre::eyre::eyre!(
+                "Cannot add migrator node: V3 stack is disabled (enable_v3 required)"
+            )
+        })?;
         let dns_ip = self.coredns.container_ip().await?;
         let xmtpd = Xmtpd::builder()
             .node(node)
             .migrator(true)
-            .node_go(self.node_go.clone())
+            .node_go(node_go.clone())
             .dns_server(dns_ip)
             .build()?;
         self.internal_add_xmtpd(xmtpd).await
     }
 
     pub async fn reload_node_go(&mut self, d14n_cutover_ns: i64) -> Result<()> {
-        self.node_go.reload(d14n_cutover_ns, &self.proxy).await
+        let node_go = self.node_go.as_mut().ok_or_else(|| {
+            color_eyre::eyre::eyre!(
+                "Cannot reload node-go: V3 stack is disabled (enable_v3 required)"
+            )
+        })?;
+        node_go.reload(d14n_cutover_ns, &self.proxy).await
     }
 
     async fn internal_add_xmtpd(&mut self, mut xmtpd: Xmtpd) -> Result<()> {
-        // Fund all node wallets (signer, payer, migration payer) with testnet ETH
-        let rpc = self.anvil_rpc_url.as_str();
+        let rpc = self.anvil_rpc_url.as_ref().ok_or_else(|| {
+            color_eyre::eyre::eyre!(
+                "Cannot add xmtpd node: Anvil is not running (enable_v3 or enable_d14n required)"
+            )
+        })?;
         let node = xmtpd.node();
         for address in [
             node.address(),
             node.payer_address(),
             node.migration_payer_address(),
         ] {
-            crate::wallet_funding::fund_wallet(rpc, address, None).await?;
+            crate::wallet_funding::fund_wallet(rpc.as_str(), address, None).await?;
         }
 
         xmtpd.start(&self.proxy).await?;
 
-        // Register with Traefik for unified addressing
         if let Some(hostname) = <Xmtpd as Service>::hostname(&xmtpd)
             && let Some(toxi_port) = xmtpd.proxy_port()
         {
@@ -243,13 +338,16 @@ impl ServiceManager {
 
         self.nodes.push(xmtpd);
 
-        // Update Prometheus scrape targets with the new node
-        self.prometheus.update_targets(&self.nodes)?;
+        if let Some(ref mut prometheus) = self.prometheus {
+            prometheus.update_targets(&self.nodes)?;
+        }
 
         // Rescan Docker labels to pick up the new node's ReplicationDb.
         // PgAdmin discovers databases via xnet.pgadmin=true container labels,
         // so it doesn't need to know about Xmtpd directly.
-        self.pgadmin.discover_databases().await?;
+        if let Some(ref mut pgadmin) = self.pgadmin {
+            pgadmin.discover_databases().await?;
+        }
 
         Ok(())
     }
@@ -343,73 +441,75 @@ impl ServiceManager {
     }
 }
 
+struct SharedServices {
+    services: Vec<Box<dyn Service>>,
+    anvil_rpc_url: url::Url,
+    anvil_proxy_host: String,
+}
+
+/// Start shared services needed by both V3 and D14n: Anvil, Validation, History
+async fn start_shared_services(proxy: &ToxiProxy) -> Result<SharedServices> {
+    let mut anvil = services::Anvil::builder().build()?;
+    anvil.start(proxy).await?;
+    let rpc = anvil.external_rpc_url().unwrap_or_else(|| anvil.rpc_url());
+    let anvil_proxy_host = anvil.internal_proxy_host()?;
+
+    let mut validation = services::Validation::builder().build()?;
+    let mut history = services::HistoryServer::builder().build()?;
+    let launch = vec![
+        validation.start(proxy).boxed(),
+        history.start(proxy).boxed(),
+    ];
+    futures::future::try_join_all(launch).await?;
+
+    Ok(SharedServices {
+        services: vec![
+            Box::new(anvil) as _,
+            Box::new(validation) as _,
+            Box::new(history) as _,
+        ],
+        anvil_rpc_url: rpc,
+        anvil_proxy_host,
+    })
+}
+
 async fn start_d14n(
     proxy: &ToxiProxy,
     dns_ip: String,
-) -> Result<(Gateway, url::Url, Vec<Box<dyn Service>>)> {
+    anvil_proxy_host: String,
+    anvil_rpc: &url::Url,
+) -> Result<(Gateway, Vec<Box<dyn Service>>)> {
     use crate::constants::Gateway as GatewayConst;
     use alloy::signers::local::PrivateKeySigner;
 
-    let mut anvil = services::Anvil::builder().build()?;
     let mut redis = services::Redis::builder().build();
-
-    let launch = vec![anvil.start(proxy).boxed(), redis.start(proxy).boxed()];
-    futures::future::try_join_all(launch).await?;
+    redis.start(proxy).await?;
 
     // Fund the gateway wallet before starting it
-    let anvil_rpc = anvil.external_rpc_url().unwrap_or_else(|| anvil.rpc_url());
     let gateway_key: PrivateKeySigner = GatewayConst::PRIVATE_KEY.parse()?;
     let gateway_address = gateway_key.address();
-    crate::wallet_funding::fund_wallet(
-        anvil_rpc.as_str(),
-        gateway_address,
-        None, // Use default funding amount (1000 ETH)
-    )
-    .await?;
+    crate::wallet_funding::fund_wallet(anvil_rpc.as_str(), gateway_address, None).await?;
 
     let mut gateway = services::Gateway::builder()
         .redis_host(redis.internal_proxy_host()?)
-        .anvil_host(anvil.internal_proxy_host()?)
+        .anvil_host(anvil_proxy_host)
         .dns_server(dns_ip)
         .build()?;
     gateway.start(proxy).await?;
 
-    let anvil_external_rpc = anvil.external_rpc_url().unwrap_or_else(|| anvil.rpc_url());
-    Ok((
-        gateway,
-        anvil_external_rpc,
-        vec![Box::new(anvil) as _, Box::new(redis) as _],
-    ))
+    Ok((gateway, vec![Box::new(redis) as _]))
 }
 
 async fn start_v3(proxy: &ToxiProxy) -> Result<(NodeGo, Vec<Box<dyn Service>>)> {
-    let mut validation = services::Validation::builder().build()?;
     let mut mls_db = services::MlsDb::builder().build();
     let mut v3_db = services::V3Db::builder().build();
-    // history is both but OK to start with v3 stuff to follow docker-compose
-    let mut history = services::HistoryServer::builder().build()?;
-    // dependencies
-    let launch = vec![
-        validation.start(proxy).boxed(),
-        mls_db.start(proxy).boxed(),
-        v3_db.start(proxy).boxed(),
-        history.start(proxy).boxed(),
-    ];
+    let launch = vec![mls_db.start(proxy).boxed(), v3_db.start(proxy).boxed()];
     futures::future::try_join_all(launch).await?;
     let mut node_go = services::NodeGo::builder()
         .store_db_host(v3_db.internal_proxy_host()?)
         .mls_store_db_host(mls_db.internal_proxy_host()?)
-        .mls_validation_address(validation.internal_proxy_host()?)
         .build()?;
     node_go.start(proxy).await?;
 
-    Ok((
-        node_go,
-        vec![
-            Box::new(validation) as _,
-            Box::new(mls_db) as _,
-            Box::new(v3_db) as _,
-            Box::new(history) as _,
-        ],
-    ))
+    Ok((node_go, vec![Box::new(mls_db) as _, Box::new(v3_db) as _]))
 }

--- a/apps/xnet/lib/src/app/service_manager.rs
+++ b/apps/xnet/lib/src/app/service_manager.rs
@@ -82,6 +82,9 @@ impl ServiceManager {
         coredns.start(&proxy).await?;
 
         let traefik_config = TraefikConfig::new(traefik.dynamic_config_path())?;
+        if !config.extra_traefik_routes.is_empty() {
+            traefik_config.set_extra_routes(config.extra_traefik_routes.clone())?;
+        }
 
         // Phase 2: Monitoring — Prometheus + Grafana (conditional)
         // PgAdmin is started AFTER xmtpd nodes so it can discover their

--- a/apps/xnet/lib/src/app/service_manager.rs
+++ b/apps/xnet/lib/src/app/service_manager.rs
@@ -140,7 +140,7 @@ impl ServiceManager {
         let otterscan = if config.enable_monitoring && need_shared {
             let anvil_rpc = anvil_rpc_url.as_ref().unwrap();
             let anvil_host_for_browser = match &config.address_mode {
-                crate::config::AddressMode::Remote(ip) => {
+                crate::config::AddressMode::RemoteIp(ip) => {
                     anvil_rpc.to_string().replace("localhost", &ip.to_string())
                 }
                 _ => anvil_rpc.to_string(),

--- a/apps/xnet/lib/src/app/service_manager.rs
+++ b/apps/xnet/lib/src/app/service_manager.rs
@@ -1,19 +1,16 @@
 //! Stateful service manager
 //! network is hardcoded to XNET_NETWORK_NAME
 use std::collections::HashMap;
-use std::io::stdout;
 
 use crate::{
     Config,
-    config::NodeToml,
-    constants::Xmtpd as XmtpdConst,
     network::{Network, XNET_NETWORK_NAME},
+    node_provisioner::NodeProvisioner,
     services::{
         self, CoreDns, Gateway, Grafana, NodeGo, Otterscan, PgAdmin, Prometheus, ReplicationDb,
         Service, ToxiProxy, Traefik, TraefikConfig, Xmtpd, create_and_start_container,
     },
-    types::{XmtpdNode, resolve_port},
-    xmtpd_cli::XmtpdCli,
+    types::XmtpdNode,
 };
 use bollard::{
     Docker,
@@ -175,51 +172,27 @@ impl ServiceManager {
         // Phase 7: XMTPD nodes from config (requires D14n)
         if config.enable_d14n {
             let existing_proxies = this.proxy.list_proxies().await?;
-            let cli = XmtpdCli::builder().toxiproxy(this.proxy.clone());
-            let mut output = stdout();
-            let mut id = 0;
-            for NodeToml {
-                port,
-                migrator,
-                name,
-                enable,
-                use_standard_port,
-            } in config.xmtpd_nodes
-            {
-                id += XmtpdConst::NODE_ID_INCREMENT;
-                let node_name = name.as_ref().unwrap_or(&format!("xnet-{}", id)).to_string();
-                if existing_proxies.contains_key(&node_name) {
-                    info!("node {} already has proxy registered, skipping", node_name);
+            for node_toml in &config.xmtpd_nodes {
+                if !node_toml.enable {
                     continue;
                 }
-                if !enable {
-                    continue;
+                // Skip nodes whose proxy already exists (already provisioned in a previous run).
+                // Only applies to named nodes — unnamed nodes get their name from the gateway ID.
+                if let Some(ref name) = node_toml.name {
+                    if existing_proxies.contains_key(name) {
+                        info!("node {} already has proxy registered, skipping", name);
+                        continue;
+                    }
                 }
-                let node = XmtpdNode::builder();
-                let node = node.port(resolve_port(use_standard_port, port)?);
-                let node = if let Some(n) = name {
-                    node.name(n)
-                } else {
-                    node.name(format!("xnet-{}", id))
-                };
-                let node = node.node_id(id);
-                let num_ids = id / XmtpdConst::NODE_ID_INCREMENT;
-                let base_idx = num_ids as usize * 3 + 1;
-                let mut node = node
-                    .signer(config.signers[base_idx].clone())
-                    .payer(config.signers[base_idx + 1].clone())
-                    .migration_payer(config.signers[base_idx + 2].clone())
-                    .build();
-                cli.clone()
+
+                NodeProvisioner::builder()
+                    .migrator(node_toml.migrator)
+                    .use_standard_port(node_toml.use_standard_port)
+                    .maybe_name(node_toml.name.clone())
+                    .maybe_port(node_toml.port)
                     .build()
-                    .register(&this, &mut output, &node)
+                    .provision(&mut this)
                     .await?;
-                cli.clone().build().enable(&mut node, &mut output).await?;
-                if migrator {
-                    this.add_xmtpd_with_migrator(node).await?;
-                } else {
-                    this.add_xmtpd(node).await?;
-                }
             }
         }
 

--- a/apps/xnet/lib/src/app/service_manager.rs
+++ b/apps/xnet/lib/src/app/service_manager.rs
@@ -140,7 +140,10 @@ impl ServiceManager {
                 crate::config::AddressMode::RemoteIp(ip) => {
                     anvil_rpc.to_string().replace("localhost", &ip.to_string())
                 }
-                _ => anvil_rpc.to_string(),
+                crate::config::AddressMode::RemoteDomain(domain) => {
+                    anvil_rpc.to_string().replace("localhost", domain)
+                }
+                crate::config::AddressMode::Local => anvil_rpc.to_string(),
             };
             let mut ot = Otterscan::builder()
                 .anvil_host(anvil_host_for_browser)

--- a/apps/xnet/lib/src/app/service_manager.rs
+++ b/apps/xnet/lib/src/app/service_manager.rs
@@ -151,6 +151,19 @@ impl ServiceManager {
             None
         };
 
+        // Phase 6b: Pause broadcasters if configured (must happen before Phase 7 node provisioning)
+        if config.paused {
+            if let Some(ref rpc) = anvil_rpc_url {
+                crate::contracts::set_broadcasters_paused(
+                    rpc.as_str(),
+                    crate::constants::Anvil::ADMIN_KEY,
+                    true,
+                )
+                .await?;
+                info!("broadcaster contracts paused");
+            }
+        }
+
         let mut this = Self {
             node_go,
             coredns,

--- a/apps/xnet/lib/src/app/service_manager.rs
+++ b/apps/xnet/lib/src/app/service_manager.rs
@@ -86,7 +86,7 @@ impl ServiceManager {
         let mut coredns = CoreDns::builder().traefik_ip(traefik_ip).build();
         coredns.start(&proxy).await?;
 
-        let traefik_config = TraefikConfig::new(traefik.dynamic_config_path())?;
+        let traefik_config = TraefikConfig::new(traefik.dynamic_config_path(), config.use_tls)?;
         if !config.extra_traefik_routes.is_empty() {
             traefik_config.set_extra_routes(config.extra_traefik_routes.clone())?;
         }

--- a/apps/xnet/lib/src/app/service_manager.rs
+++ b/apps/xnet/lib/src/app/service_manager.rs
@@ -77,6 +77,7 @@ impl ServiceManager {
             .maybe_http_port(config.traefik_port)
             .maybe_https_port(config.traefik_https_port)
             .maybe_acme(config.traefik_acme.clone())
+            .use_tls(config.use_tls)
             .build();
         traefik.start(&proxy).await?;
 

--- a/apps/xnet/lib/src/app/service_manager.rs
+++ b/apps/xnet/lib/src/app/service_manager.rs
@@ -70,6 +70,7 @@ impl ServiceManager {
         let mut traefik = Traefik::builder()
             .maybe_http_port(config.traefik_port)
             .maybe_https_port(config.traefik_https_port)
+            .maybe_acme(config.traefik_acme.clone())
             .build();
         traefik.start(&proxy).await?;
 

--- a/apps/xnet/lib/src/app/service_manager.rs
+++ b/apps/xnet/lib/src/app/service_manager.rs
@@ -61,6 +61,12 @@ impl ServiceManager {
     /// starts services if not already started
     /// if running connects to them.
     pub async fn start() -> Result<Self> {
+        Self::start_paused(false).await
+    }
+
+    /// Like [`start`](Self::start) but also pauses broadcaster contracts when
+    /// `cli_paused` is true (before node provisioning).
+    pub async fn start_paused(cli_paused: bool) -> Result<Self> {
         let config = Config::load()?;
 
         // Phase 1: Infrastructure (always)
@@ -156,7 +162,7 @@ impl ServiceManager {
         };
 
         // Phase 6b: Pause broadcasters if configured (must happen before Phase 7 node provisioning)
-        if config.paused {
+        if config.paused || cli_paused {
             if let Some(ref rpc) = anvil_rpc_url {
                 crate::contracts::set_broadcasters_paused(
                     rpc.as_str(),

--- a/apps/xnet/lib/src/config/address_mode.rs
+++ b/apps/xnet/lib/src/config/address_mode.rs
@@ -1,29 +1,23 @@
-use std::net::IpAddr;
-
 const LOCAL_DOMAIN: &str = "xmtpd.local";
-const REMOTE_DOMAIN: &str = "sslip.io";
 
 /// Determines how xnet constructs service hostnames.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AddressMode {
     /// Local mode: hostnames like `{name}.xmtpd.local`
     Local,
-    /// Remote mode: hostnames like `{name}.{ip-dashed}.sslip.io`
-    Remote(IpAddr),
+    /// Remote domain mode: hostnames like `{name}.{domain}`
+    RemoteDomain(String),
 }
 
 impl AddressMode {
     /// Build a hostname for the given service name.
     ///
-    /// - Local:  `{name}.xmtpd.local`
-    /// - Remote: `{name}.{ip}.sslip.io` (dots and colons replaced by dashes)
+    /// - Local:        `{name}.xmtpd.local`
+    /// - RemoteDomain: `{name}.{domain}`
     pub fn hostname(&self, name: &str) -> String {
         match self {
             Self::Local => format!("{name}.{LOCAL_DOMAIN}"),
-            Self::Remote(ip) => {
-                let ip_dashed = ip.to_string().replace(['.', ':'], "-");
-                format!("{name}.{ip_dashed}.{REMOTE_DOMAIN}")
-            }
+            Self::RemoteDomain(domain) => format!("{name}.{domain}"),
         }
     }
 
@@ -31,12 +25,12 @@ impl AddressMode {
     pub fn dns_domain(&self) -> &str {
         match self {
             Self::Local => LOCAL_DOMAIN,
-            Self::Remote(_) => REMOTE_DOMAIN,
+            Self::RemoteDomain(domain) => domain,
         }
     }
 
     pub fn is_remote(&self) -> bool {
-        matches!(self, Self::Remote(_))
+        matches!(self, Self::RemoteDomain(_))
     }
 }
 
@@ -58,37 +52,24 @@ mod tests {
     }
 
     #[test]
-    fn remote_hostname_ipv4() {
-        let ip: IpAddr = "203.0.113.42".parse().unwrap();
-        let mode = AddressMode::Remote(ip);
-        assert_eq!(mode.hostname("node100"), "node100.203-0-113-42.sslip.io");
-        assert_eq!(mode.hostname("xnet-200"), "xnet-200.203-0-113-42.sslip.io");
-    }
-
-    #[test]
-    fn remote_hostname_ipv6() {
-        let ip: IpAddr = "2001:db8::1".parse().unwrap();
-        let mode = AddressMode::Remote(ip);
-        // IpAddr displays 2001:db8::1, colons become dashes
-        assert_eq!(mode.hostname("node100"), "node100.2001-db8--1.sslip.io");
-    }
-
-    #[test]
     fn dns_domain() {
         assert_eq!(AddressMode::Local.dns_domain(), "xmtpd.local");
-        let ip: IpAddr = "10.0.0.1".parse().unwrap();
-        assert_eq!(AddressMode::Remote(ip).dns_domain(), "sslip.io");
+        assert_eq!(
+            AddressMode::RemoteDomain("xmtp.run".to_string()).dns_domain(),
+            "xmtp.run"
+        );
     }
 
     #[test]
     fn is_remote() {
         assert!(!AddressMode::Local.is_remote());
-        let ip: IpAddr = "10.0.0.1".parse().unwrap();
-        assert!(AddressMode::Remote(ip).is_remote());
+        assert!(AddressMode::RemoteDomain("xmtp.run".to_string()).is_remote());
     }
 
     #[test]
-    fn default_is_local() {
-        assert_eq!(AddressMode::default(), AddressMode::Local);
+    fn remote_domain_hostname() {
+        let mode = AddressMode::RemoteDomain("xmtp.run".to_string());
+        assert_eq!(mode.hostname("node100"), "node100.xmtp.run");
+        assert_eq!(mode.hostname("xnet-200"), "xnet-200.xmtp.run");
     }
 }

--- a/apps/xnet/lib/src/config/address_mode.rs
+++ b/apps/xnet/lib/src/config/address_mode.rs
@@ -8,22 +8,26 @@ const REMOTE_DOMAIN: &str = "sslip.io";
 pub enum AddressMode {
     /// Local mode: hostnames like `{name}.xmtpd.local`
     Local,
-    /// Remote mode: hostnames like `{name}.{ip-dashed}.sslip.io`
-    Remote(IpAddr),
+    /// Remote IP mode: hostnames like `{name}.{ip-dashed}.sslip.io`
+    RemoteIp(IpAddr),
+    /// Remote domain mode: hostnames like `{name}.{domain}`
+    RemoteDomain(String),
 }
 
 impl AddressMode {
     /// Build a hostname for the given service name.
     ///
-    /// - Local:  `{name}.xmtpd.local`
-    /// - Remote: `{name}.{ip}.sslip.io` (dots and colons replaced by dashes)
+    /// - Local:        `{name}.xmtpd.local`
+    /// - RemoteIp:     `{name}.{ip}.sslip.io` (dots and colons replaced by dashes)
+    /// - RemoteDomain: `{name}.{domain}`
     pub fn hostname(&self, name: &str) -> String {
         match self {
             Self::Local => format!("{name}.{LOCAL_DOMAIN}"),
-            Self::Remote(ip) => {
+            Self::RemoteIp(ip) => {
                 let ip_dashed = ip.to_string().replace(['.', ':'], "-");
                 format!("{name}.{ip_dashed}.{REMOTE_DOMAIN}")
             }
+            Self::RemoteDomain(domain) => format!("{name}.{domain}"),
         }
     }
 
@@ -31,12 +35,13 @@ impl AddressMode {
     pub fn dns_domain(&self) -> &str {
         match self {
             Self::Local => LOCAL_DOMAIN,
-            Self::Remote(_) => REMOTE_DOMAIN,
+            Self::RemoteIp(_) => REMOTE_DOMAIN,
+            Self::RemoteDomain(domain) => domain,
         }
     }
 
     pub fn is_remote(&self) -> bool {
-        matches!(self, Self::Remote(_))
+        matches!(self, Self::RemoteIp(_) | Self::RemoteDomain(_))
     }
 }
 
@@ -60,7 +65,7 @@ mod tests {
     #[test]
     fn remote_hostname_ipv4() {
         let ip: IpAddr = "203.0.113.42".parse().unwrap();
-        let mode = AddressMode::Remote(ip);
+        let mode = AddressMode::RemoteIp(ip);
         assert_eq!(mode.hostname("node100"), "node100.203-0-113-42.sslip.io");
         assert_eq!(mode.hostname("xnet-200"), "xnet-200.203-0-113-42.sslip.io");
     }
@@ -68,7 +73,7 @@ mod tests {
     #[test]
     fn remote_hostname_ipv6() {
         let ip: IpAddr = "2001:db8::1".parse().unwrap();
-        let mode = AddressMode::Remote(ip);
+        let mode = AddressMode::RemoteIp(ip);
         // IpAddr displays 2001:db8::1, colons become dashes
         assert_eq!(mode.hostname("node100"), "node100.2001-db8--1.sslip.io");
     }
@@ -77,18 +82,37 @@ mod tests {
     fn dns_domain() {
         assert_eq!(AddressMode::Local.dns_domain(), "xmtpd.local");
         let ip: IpAddr = "10.0.0.1".parse().unwrap();
-        assert_eq!(AddressMode::Remote(ip).dns_domain(), "sslip.io");
+        assert_eq!(AddressMode::RemoteIp(ip).dns_domain(), "sslip.io");
     }
 
     #[test]
     fn is_remote() {
         assert!(!AddressMode::Local.is_remote());
         let ip: IpAddr = "10.0.0.1".parse().unwrap();
-        assert!(AddressMode::Remote(ip).is_remote());
+        assert!(AddressMode::RemoteIp(ip).is_remote());
     }
 
     #[test]
     fn default_is_local() {
         assert_eq!(AddressMode::default(), AddressMode::Local);
+    }
+
+    #[test]
+    fn remote_domain_hostname() {
+        let mode = AddressMode::RemoteDomain("xmtp.run".to_string());
+        assert_eq!(mode.hostname("node100"), "node100.xmtp.run");
+        assert_eq!(mode.hostname("xnet-200"), "xnet-200.xmtp.run");
+    }
+
+    #[test]
+    fn remote_domain_dns_domain() {
+        let mode = AddressMode::RemoteDomain("xmtp.run".to_string());
+        assert_eq!(mode.dns_domain(), "xmtp.run");
+    }
+
+    #[test]
+    fn remote_domain_is_remote() {
+        let mode = AddressMode::RemoteDomain("xmtp.run".to_string());
+        assert!(mode.is_remote());
     }
 }

--- a/apps/xnet/lib/src/config/address_mode.rs
+++ b/apps/xnet/lib/src/config/address_mode.rs
@@ -93,26 +93,9 @@ mod tests {
     }
 
     #[test]
-    fn default_is_local() {
-        assert_eq!(AddressMode::default(), AddressMode::Local);
-    }
-
-    #[test]
     fn remote_domain_hostname() {
         let mode = AddressMode::RemoteDomain("xmtp.run".to_string());
         assert_eq!(mode.hostname("node100"), "node100.xmtp.run");
         assert_eq!(mode.hostname("xnet-200"), "xnet-200.xmtp.run");
-    }
-
-    #[test]
-    fn remote_domain_dns_domain() {
-        let mode = AddressMode::RemoteDomain("xmtp.run".to_string());
-        assert_eq!(mode.dns_domain(), "xmtp.run");
-    }
-
-    #[test]
-    fn remote_domain_is_remote() {
-        let mode = AddressMode::RemoteDomain("xmtp.run".to_string());
-        assert!(mode.is_remote());
     }
 }

--- a/apps/xnet/lib/src/config/args.rs
+++ b/apps/xnet/lib/src/config/args.rs
@@ -1,4 +1,3 @@
-use std::net::IpAddr;
 use std::path::PathBuf;
 
 use clap::{Args, Parser, Subcommand};
@@ -16,10 +15,10 @@ pub struct AppArgs {
     /// Path to a TOML configuration to use for xnet
     #[arg(long, short)]
     pub config: Option<PathBuf>,
-    /// Enable remote addressing mode with sslip.io.
-    /// Hostnames become {name}.{ip-dashed}.sslip.io instead of {name}.xmtpd.local.
+    /// Enable remote addressing mode with a custom domain.
+    /// Hostnames become {name}.{domain} instead of {name}.xmtpd.local.
     #[arg(long)]
-    pub remote: Option<IpAddr>,
+    pub remote_domain: Option<String>,
 }
 
 #[derive(Subcommand, Clone, Debug)]

--- a/apps/xnet/lib/src/config/args.rs
+++ b/apps/xnet/lib/src/config/args.rs
@@ -20,6 +20,11 @@ pub struct AppArgs {
     /// Hostnames become {name}.{ip-dashed}.sslip.io instead of {name}.xmtpd.local.
     #[arg(long)]
     pub remote: Option<IpAddr>,
+    /// Enable remote addressing mode with a custom domain.
+    /// Hostnames become {name}.{domain} instead of {name}.xmtpd.local.
+    /// Mutually exclusive with --remote.
+    #[arg(long)]
+    pub remote_domain: Option<String>,
 }
 
 #[derive(Subcommand, Clone, Debug)]

--- a/apps/xnet/lib/src/config/loadable.rs
+++ b/apps/xnet/lib/src/config/loadable.rs
@@ -13,7 +13,7 @@ use crate::config::AppArgs;
 use crate::constants::{ToxiProxy as ToxiProxyConst, Xmtpd as XmtpdConst};
 
 use super::AddressMode;
-use super::toml_config::{ImageConfig, MigrationConfig, NodeToml, TomlConfig};
+use super::toml_config::{ExtraTraefikRoute, ImageConfig, MigrationConfig, NodeToml, TomlConfig};
 
 static CONF: OnceLock<Config> = OnceLock::new();
 
@@ -69,13 +69,29 @@ pub struct Config {
     pub v3: ImageConfig,
     /// V3 node-go port override
     pub v3_port: Option<u16>,
+    /// Enable the V3 stack
+    #[builder(default = true)]
+    pub enable_v3: bool,
+    /// Enable the D14n stack
+    #[builder(default = true)]
+    pub enable_d14n: bool,
+    /// Enable monitoring services
+    #[builder(default = true)]
+    pub enable_monitoring: bool,
     /// Toxiproxy image overrides
     #[builder(default)]
     pub toxiproxy: ImageConfig,
     /// ToxiProxy port override
     pub toxiproxy_port: Option<u16>,
+    /// Traefik image overrides
+    #[builder(default)]
+    pub traefik: ImageConfig,
     /// Traefik HTTP host port override
     pub traefik_port: Option<u16>,
+    /// URL scheme for public references ("http" or "https").
+    /// Set to "https" when TLS is terminated at CDN/proxy (e.g. Cloudflare).
+    #[builder(default = "http".to_string())]
+    pub public_scheme: String,
     /// Gateway image overrides
     #[builder(default)]
     pub gateway: ImageConfig,
@@ -94,9 +110,25 @@ pub struct Config {
     /// Grafana image overrides
     #[builder(default)]
     pub grafana: ImageConfig,
-    /// Addressing mode (local or remote/sslip.io)
+    /// Addressing mode (local or remote domain)
     #[builder(default)]
     pub address_mode: AddressMode,
+    /// Extra Traefik routes from TOML config
+    #[builder(default)]
+    pub extra_traefik_routes: Vec<ExtraTraefikRoute>,
+}
+
+/// Validate that `remote_domain` is well-formed if provided.
+pub fn validate_remote_domain(remote_domain: &Option<String>) -> Result<()> {
+    if let Some(domain) = remote_domain {
+        if domain.is_empty() {
+            color_eyre::eyre::bail!("`remote_domain` must not be empty");
+        }
+        if domain.starts_with('.') || domain.ends_with('.') {
+            color_eyre::eyre::bail!("`remote_domain` must not start or end with '.'");
+        }
+    }
+    Ok(())
 }
 
 impl Config {
@@ -112,34 +144,34 @@ impl Config {
             let app = App::parse()?;
             let toml = Self::load_toml(&app.args)?;
             let signers = Self::load_signers();
-            // Resolve address mode: XNET_REMOTE_IP env > --remote CLI flag > TOML remote_ip > Local
-            let address_mode = if let Ok(env_ip) = std::env::var("XNET_REMOTE_IP") {
-                match env_ip.parse::<std::net::IpAddr>() {
-                    Ok(ip) => {
-                        tracing::info!("Remote mode from env XNET_REMOTE_IP: {}", ip);
-                        AddressMode::Remote(ip)
-                    }
-                    Err(_) => {
-                        tracing::error!(
-                            "XNET_REMOTE_IP is not a valid IP: '{}', falling back to local mode",
-                            env_ip
-                        );
-                        AddressMode::Local
-                    }
-                }
-            } else if let Some(ip) = app.args.remote {
-                tracing::info!("Remote mode from --remote flag: {}", ip);
-                AddressMode::Remote(ip)
-            } else if let Some(ip) = toml.xnet.remote_ip {
-                tracing::info!("Remote mode from TOML remote_ip: {}", ip);
-                AddressMode::Remote(ip)
+            // Resolve address mode: env > CLI > TOML
+            let effective_remote_domain = std::env::var("XNET_REMOTE_DOMAIN")
+                .ok()
+                .filter(|s| !s.is_empty())
+                .or(app.args.remote_domain.clone())
+                .or(toml.xnet.remote_domain.clone());
+
+            validate_remote_domain(&effective_remote_domain)?;
+
+            let address_mode = if let Some(domain) = effective_remote_domain {
+                tracing::info!("Remote domain mode: {}", domain);
+                AddressMode::RemoteDomain(domain)
             } else {
                 AddressMode::Local
             };
 
+            // Merge CLI --paused flag with TOML paused setting
+            let cli_paused = matches!(
+                app.args.cmd,
+                Some(crate::config::Commands::Up(crate::config::Up {
+                    paused: true
+                }))
+            );
+            let paused = cli_paused || toml.xnet.paused;
+
             let mut c = Config::builder()
                 .use_standard_ports(toml.xnet.use_standard_ports)
-                .paused(toml.xnet.paused)
+                .paused(paused)
                 .signers(signers)
                 .migration(toml.migration)
                 .xmtpd(toml.xmtpd.image)
@@ -151,12 +183,24 @@ impl Config {
                 .validation(toml.validation)
                 .contracts(toml.contracts)
                 .history(toml.history)
-                .toxiproxy(toml.toxiproxy)
-                .maybe_toxiproxy_port(toml.xnet.toxiproxy_port)
-                .maybe_traefik_port(toml.xnet.traefik_port)
+                .toxiproxy(toml.toxiproxy.image)
+                .maybe_toxiproxy_port(toml.toxiproxy.port)
+                .traefik(toml.traefik.image)
+                .maybe_traefik_port(toml.traefik.port)
+                .public_scheme(
+                    toml.xnet
+                        .public_scheme
+                        .clone()
+                        .filter(|s| !s.is_empty())
+                        .unwrap_or_else(|| "http".to_string()),
+                )
+                .enable_v3(toml.xnet.enable_v3)
+                .enable_d14n(toml.xnet.enable_d14n)
+                .enable_monitoring(toml.xnet.enable_monitoring)
                 .prometheus(toml.prometheus)
                 .grafana(toml.grafana)
                 .address_mode(address_mode)
+                .extra_traefik_routes(toml.extra_traefik_routes)
                 .build();
 
             // Allow XNET_CUTOVER_TIMESTAMP env var to override the TOML migration_timestamp

--- a/apps/xnet/lib/src/config/loadable.rs
+++ b/apps/xnet/lib/src/config/loadable.rs
@@ -69,13 +69,27 @@ pub struct Config {
     pub v3: ImageConfig,
     /// V3 node-go port override
     pub v3_port: Option<u16>,
+    /// Enable the V3 stack
+    #[builder(default = true)]
+    pub enable_v3: bool,
+    /// Enable the D14n stack
+    #[builder(default = true)]
+    pub enable_d14n: bool,
+    /// Enable monitoring services
+    #[builder(default = true)]
+    pub enable_monitoring: bool,
     /// Toxiproxy image overrides
     #[builder(default)]
     pub toxiproxy: ImageConfig,
     /// ToxiProxy port override
     pub toxiproxy_port: Option<u16>,
+    /// Traefik image overrides
+    #[builder(default)]
+    pub traefik: ImageConfig,
     /// Traefik HTTP host port override
     pub traefik_port: Option<u16>,
+    /// Traefik HTTPS host port override
+    pub traefik_https_port: Option<u16>,
     /// Gateway image overrides
     #[builder(default)]
     pub gateway: ImageConfig,
@@ -151,9 +165,14 @@ impl Config {
                 .validation(toml.validation)
                 .contracts(toml.contracts)
                 .history(toml.history)
-                .toxiproxy(toml.toxiproxy)
-                .maybe_toxiproxy_port(toml.xnet.toxiproxy_port)
-                .maybe_traefik_port(toml.xnet.traefik_port)
+                .toxiproxy(toml.toxiproxy.image)
+                .maybe_toxiproxy_port(toml.toxiproxy.port)
+                .traefik(toml.traefik.image)
+                .maybe_traefik_port(toml.traefik.port)
+                .maybe_traefik_https_port(toml.traefik.https_port)
+                .enable_v3(toml.xnet.enable_v3)
+                .enable_d14n(toml.xnet.enable_d14n)
+                .enable_monitoring(toml.xnet.enable_monitoring)
                 .prometheus(toml.prometheus)
                 .grafana(toml.grafana)
                 .address_mode(address_mode)

--- a/apps/xnet/lib/src/config/loadable.rs
+++ b/apps/xnet/lib/src/config/loadable.rs
@@ -134,7 +134,7 @@ impl Config {
                 match env_ip.parse::<std::net::IpAddr>() {
                     Ok(ip) => {
                         tracing::info!("Remote mode from env XNET_REMOTE_IP: {}", ip);
-                        AddressMode::Remote(ip)
+                        AddressMode::RemoteIp(ip)
                     }
                     Err(_) => {
                         tracing::error!(
@@ -146,10 +146,10 @@ impl Config {
                 }
             } else if let Some(ip) = app.args.remote {
                 tracing::info!("Remote mode from --remote flag: {}", ip);
-                AddressMode::Remote(ip)
+                AddressMode::RemoteIp(ip)
             } else if let Some(ip) = toml.xnet.remote_ip {
                 tracing::info!("Remote mode from TOML remote_ip: {}", ip);
-                AddressMode::Remote(ip)
+                AddressMode::RemoteIp(ip)
             } else {
                 AddressMode::Local
             };

--- a/apps/xnet/lib/src/config/loadable.rs
+++ b/apps/xnet/lib/src/config/loadable.rs
@@ -13,7 +13,7 @@ use crate::config::AppArgs;
 use crate::constants::{ToxiProxy as ToxiProxyConst, Xmtpd as XmtpdConst};
 
 use super::AddressMode;
-use super::toml_config::{ImageConfig, MigrationConfig, NodeToml, TomlConfig};
+use super::toml_config::{ExtraTraefikRoute, ImageConfig, MigrationConfig, NodeToml, TomlConfig};
 
 static CONF: OnceLock<Config> = OnceLock::new();
 
@@ -111,6 +111,9 @@ pub struct Config {
     /// Addressing mode (local or remote/sslip.io)
     #[builder(default)]
     pub address_mode: AddressMode,
+    /// Extra Traefik routes from TOML config
+    #[builder(default)]
+    pub extra_traefik_routes: Vec<ExtraTraefikRoute>,
 }
 
 impl Config {
@@ -176,6 +179,7 @@ impl Config {
                 .prometheus(toml.prometheus)
                 .grafana(toml.grafana)
                 .address_mode(address_mode)
+                .extra_traefik_routes(toml.extra_traefik_routes)
                 .build();
 
             // Allow XNET_CUTOVER_TIMESTAMP env var to override the TOML migration_timestamp

--- a/apps/xnet/lib/src/config/loadable.rs
+++ b/apps/xnet/lib/src/config/loadable.rs
@@ -116,6 +116,28 @@ pub struct Config {
     pub extra_traefik_routes: Vec<ExtraTraefikRoute>,
 }
 
+/// Validate that `remote_ip` and `remote_domain` are not both set,
+/// and that `remote_domain` is well-formed if provided.
+pub fn validate_remote_config(
+    remote_ip: Option<std::net::IpAddr>,
+    remote_domain: Option<String>,
+) -> Result<()> {
+    if remote_ip.is_some() && remote_domain.is_some() {
+        color_eyre::eyre::bail!(
+            "`remote_ip` and `remote_domain` are mutually exclusive — set one or neither"
+        );
+    }
+    if let Some(ref domain) = remote_domain {
+        if domain.is_empty() {
+            color_eyre::eyre::bail!("`remote_domain` must not be empty");
+        }
+        if domain.starts_with('.') || domain.ends_with('.') {
+            color_eyre::eyre::bail!("`remote_domain` must not start or end with '.'");
+        }
+    }
+    Ok(())
+}
+
 impl Config {
     /// Load config from TOML file (if found) merged with defaults.
     ///
@@ -129,27 +151,27 @@ impl Config {
             let app = App::parse()?;
             let toml = Self::load_toml(&app.args)?;
             let signers = Self::load_signers();
-            // Resolve address mode: XNET_REMOTE_IP env > --remote CLI flag > TOML remote_ip > Local
-            let address_mode = if let Ok(env_ip) = std::env::var("XNET_REMOTE_IP") {
-                match env_ip.parse::<std::net::IpAddr>() {
-                    Ok(ip) => {
-                        tracing::info!("Remote mode from env XNET_REMOTE_IP: {}", ip);
-                        AddressMode::RemoteIp(ip)
-                    }
-                    Err(_) => {
-                        tracing::error!(
-                            "XNET_REMOTE_IP is not a valid IP: '{}', falling back to local mode",
-                            env_ip
-                        );
-                        AddressMode::Local
-                    }
-                }
-            } else if let Some(ip) = app.args.remote {
-                tracing::info!("Remote mode from --remote flag: {}", ip);
+            // Resolve address mode: env > CLI > TOML, with mutual exclusion validation
+            let effective_remote_ip = std::env::var("XNET_REMOTE_IP")
+                .ok()
+                .and_then(|s| s.parse::<std::net::IpAddr>().ok())
+                .or(app.args.remote)
+                .or(toml.xnet.remote_ip);
+
+            let effective_remote_domain = std::env::var("XNET_REMOTE_DOMAIN")
+                .ok()
+                .filter(|s| !s.is_empty())
+                .or(app.args.remote_domain.clone())
+                .or(toml.xnet.remote_domain.clone());
+
+            validate_remote_config(effective_remote_ip, effective_remote_domain.clone())?;
+
+            let address_mode = if let Some(ip) = effective_remote_ip {
+                tracing::info!("Remote IP mode: {}", ip);
                 AddressMode::RemoteIp(ip)
-            } else if let Some(ip) = toml.xnet.remote_ip {
-                tracing::info!("Remote mode from TOML remote_ip: {}", ip);
-                AddressMode::RemoteIp(ip)
+            } else if let Some(domain) = effective_remote_domain {
+                tracing::info!("Remote domain mode: {}", domain);
+                AddressMode::RemoteDomain(domain)
             } else {
                 AddressMode::Local
             };

--- a/apps/xnet/lib/src/config/loadable.rs
+++ b/apps/xnet/lib/src/config/loadable.rs
@@ -239,6 +239,17 @@ impl Config {
             // Validate node configuration
             validate_node_toml(&c.xmtpd_nodes)?;
 
+            // Validate ACME config values don't contain YAML-breaking characters
+            if let Some(ref acme) = c.traefik_acme {
+                for (field, value) in [("email", &acme.email), ("storage", &acme.storage)] {
+                    if value.contains('"') || value.contains('\n') || value.contains('\r') {
+                        color_eyre::eyre::bail!(
+                            "[traefik.acme] {field} contains invalid characters (quotes or newlines)"
+                        );
+                    }
+                }
+            }
+
             // Warn and strip tls flags if ACME is not configured
             if c.traefik_acme.is_none() {
                 for route in &mut c.extra_traefik_routes {

--- a/apps/xnet/lib/src/config/loadable.rs
+++ b/apps/xnet/lib/src/config/loadable.rs
@@ -179,7 +179,9 @@ impl Config {
             // Merge CLI --paused flag with TOML paused setting
             let cli_paused = matches!(
                 app.args.cmd,
-                Some(crate::config::Commands::Up(crate::config::Up { paused: true }))
+                Some(crate::config::Commands::Up(crate::config::Up {
+                    paused: true
+                }))
             );
             let paused = cli_paused || toml.xnet.paused;
 

--- a/apps/xnet/lib/src/config/loadable.rs
+++ b/apps/xnet/lib/src/config/loadable.rs
@@ -94,6 +94,9 @@ pub struct Config {
     pub traefik_https_port: Option<u16>,
     /// Traefik ACME/TLS configuration (None = disabled)
     pub traefik_acme: Option<AcmeConfig>,
+    /// File-based TLS mode (wildcard cert, no ACME)
+    #[builder(default)]
+    pub use_tls: bool,
     /// Gateway image overrides
     #[builder(default)]
     pub gateway: ImageConfig,
@@ -215,6 +218,7 @@ impl Config {
                 .maybe_traefik_port(toml.traefik.port)
                 .maybe_traefik_https_port(toml.traefik.https_port)
                 .maybe_traefik_acme(toml.traefik.acme.clone())
+                .use_tls(toml.xnet.use_tls)
                 .enable_v3(toml.xnet.enable_v3)
                 .enable_d14n(toml.xnet.enable_d14n)
                 .enable_monitoring(toml.xnet.enable_monitoring)
@@ -258,12 +262,20 @@ impl Config {
                 }
             }
 
-            // Warn and strip tls flags if ACME is not configured
-            if c.traefik_acme.is_none() {
+            if c.use_tls && c.traefik_acme.is_some() {
+                color_eyre::eyre::bail!(
+                    "use_tls and [traefik.acme] are mutually exclusive — \
+                     use_tls uses file-based certs, acme uses Let's Encrypt"
+                );
+            }
+
+            // Warn and strip tls flags if neither TLS mode is configured
+            let has_tls = c.use_tls || c.traefik_acme.is_some();
+            if !has_tls {
                 for route in &mut c.extra_traefik_routes {
                     if route.tls {
                         tracing::warn!(
-                            "Route '{}' has tls=true but [traefik.acme] is not configured — ignoring TLS",
+                            "Route '{}' has tls=true but neither use_tls nor [traefik.acme] is configured — ignoring TLS",
                             route.name
                         );
                         route.tls = false;

--- a/apps/xnet/lib/src/config/loadable.rs
+++ b/apps/xnet/lib/src/config/loadable.rs
@@ -161,10 +161,7 @@ impl Config {
                 .and_then(|s| match s.parse::<std::net::IpAddr>() {
                     Ok(ip) => Some(ip),
                     Err(_) => {
-                        tracing::warn!(
-                            "XNET_REMOTE_IP is not a valid IP: '{}', ignoring",
-                            s
-                        );
+                        tracing::warn!("XNET_REMOTE_IP is not a valid IP: '{}', ignoring", s);
                         None
                     }
                 })

--- a/apps/xnet/lib/src/config/loadable.rs
+++ b/apps/xnet/lib/src/config/loadable.rs
@@ -176,9 +176,16 @@ impl Config {
                 AddressMode::Local
             };
 
+            // Merge CLI --paused flag with TOML paused setting
+            let cli_paused = matches!(
+                app.args.cmd,
+                Some(crate::config::Commands::Up(crate::config::Up { paused: true }))
+            );
+            let paused = cli_paused || toml.xnet.paused;
+
             let mut c = Config::builder()
                 .use_standard_ports(toml.xnet.use_standard_ports)
-                .paused(toml.xnet.paused)
+                .paused(paused)
                 .signers(signers)
                 .migration(toml.migration)
                 .xmtpd(toml.xmtpd.image)

--- a/apps/xnet/lib/src/config/loadable.rs
+++ b/apps/xnet/lib/src/config/loadable.rs
@@ -13,7 +13,9 @@ use crate::config::AppArgs;
 use crate::constants::{ToxiProxy as ToxiProxyConst, Xmtpd as XmtpdConst};
 
 use super::AddressMode;
-use super::toml_config::{AcmeConfig, ExtraTraefikRoute, ImageConfig, MigrationConfig, NodeToml, TomlConfig};
+use super::toml_config::{
+    AcmeConfig, ExtraTraefikRoute, ImageConfig, MigrationConfig, NodeToml, TomlConfig,
+};
 
 static CONF: OnceLock<Config> = OnceLock::new();
 
@@ -156,7 +158,16 @@ impl Config {
             // Resolve address mode: env > CLI > TOML, with mutual exclusion validation
             let effective_remote_ip = std::env::var("XNET_REMOTE_IP")
                 .ok()
-                .and_then(|s| s.parse::<std::net::IpAddr>().ok())
+                .and_then(|s| match s.parse::<std::net::IpAddr>() {
+                    Ok(ip) => Some(ip),
+                    Err(_) => {
+                        tracing::warn!(
+                            "XNET_REMOTE_IP is not a valid IP: '{}', ignoring",
+                            s
+                        );
+                        None
+                    }
+                })
                 .or(app.args.remote)
                 .or(toml.xnet.remote_ip);
 

--- a/apps/xnet/lib/src/config/loadable.rs
+++ b/apps/xnet/lib/src/config/loadable.rs
@@ -13,7 +13,7 @@ use crate::config::AppArgs;
 use crate::constants::{ToxiProxy as ToxiProxyConst, Xmtpd as XmtpdConst};
 
 use super::AddressMode;
-use super::toml_config::{ExtraTraefikRoute, ImageConfig, MigrationConfig, NodeToml, TomlConfig};
+use super::toml_config::{AcmeConfig, ExtraTraefikRoute, ImageConfig, MigrationConfig, NodeToml, TomlConfig};
 
 static CONF: OnceLock<Config> = OnceLock::new();
 
@@ -90,6 +90,8 @@ pub struct Config {
     pub traefik_port: Option<u16>,
     /// Traefik HTTPS host port override
     pub traefik_https_port: Option<u16>,
+    /// Traefik ACME/TLS configuration (None = disabled)
+    pub traefik_acme: Option<AcmeConfig>,
     /// Gateway image overrides
     #[builder(default)]
     pub gateway: ImageConfig,
@@ -204,6 +206,7 @@ impl Config {
                 .traefik(toml.traefik.image)
                 .maybe_traefik_port(toml.traefik.port)
                 .maybe_traefik_https_port(toml.traefik.https_port)
+                .maybe_traefik_acme(toml.traefik.acme.clone())
                 .enable_v3(toml.xnet.enable_v3)
                 .enable_d14n(toml.xnet.enable_d14n)
                 .enable_monitoring(toml.xnet.enable_monitoring)
@@ -235,6 +238,19 @@ impl Config {
 
             // Validate node configuration
             validate_node_toml(&c.xmtpd_nodes)?;
+
+            // Warn and strip tls flags if ACME is not configured
+            if c.traefik_acme.is_none() {
+                for route in &mut c.extra_traefik_routes {
+                    if route.tls {
+                        tracing::warn!(
+                            "Route '{}' has tls=true but [traefik.acme] is not configured — ignoring TLS",
+                            route.name
+                        );
+                        route.tls = false;
+                    }
+                }
+            }
 
             CONF.set(c)
                 .map_err(|_| eyre!("Config already initialized"))?;

--- a/apps/xnet/lib/src/config/toml_config.rs
+++ b/apps/xnet/lib/src/config/toml_config.rs
@@ -13,9 +13,12 @@ pub(crate) struct TomlConfig {
     pub validation: ImageConfig,
     pub contracts: ImageConfig,
     pub history: ImageConfig,
-    pub toxiproxy: ImageConfig,
+    pub toxiproxy: ToxiProxyToml,
     pub prometheus: ImageConfig,
     pub grafana: ImageConfig,
+    pub traefik: TraefikToml,
+    #[serde(default)]
+    pub extra_traefik_routes: Vec<ExtraTraefikRoute>,
 }
 
 /// Reusable image+version pair for any Docker service
@@ -30,26 +33,51 @@ pub struct ImageConfig {
 #[serde(default)]
 pub struct XnetToml {
     pub use_standard_ports: bool,
-    pub toxiproxy_port: Option<u16>,
-    /// Override the Traefik HTTP host port (default: 80)
-    pub traefik_port: Option<u16>,
     /// Pause broadcaster contracts on startup (same as `--paused` CLI flag)
     pub paused: bool,
-    /// Public IP for remote addressing mode (sslip.io).
-    /// Equivalent to the --remote CLI flag.
-    pub remote_ip: Option<std::net::IpAddr>,
+    /// Custom domain for remote addressing mode.
+    /// Hostnames become {name}.{domain} instead of {name}.xmtpd.local.
+    pub remote_domain: Option<String>,
+    /// Enable the V3 stack (Validation, V3Db, MlsDb, History, NodeGo)
+    pub enable_v3: bool,
+    /// Enable the D14n stack (Redis, Gateway, XMTPD nodes)
+    pub enable_d14n: bool,
+    /// Enable monitoring services (Prometheus, Grafana, PgAdmin, Otterscan)
+    pub enable_monitoring: bool,
+    /// URL scheme for external references (gateway responses, node URLs).
+    /// "http" or "https". Default: "http".
+    /// Set to "https" when TLS is terminated at a CDN/proxy (e.g. Cloudflare).
+    pub public_scheme: Option<String>,
 }
 
 impl Default for XnetToml {
     fn default() -> Self {
         Self {
             use_standard_ports: true,
-            toxiproxy_port: Default::default(),
-            traefik_port: None,
             paused: false,
-            remote_ip: None,
+            remote_domain: None,
+            enable_v3: true,
+            enable_d14n: true,
+            enable_monitoring: true,
+            public_scheme: None,
         }
     }
+}
+
+#[derive(Deserialize, Default, Debug, Clone)]
+#[serde(default)]
+pub struct TraefikToml {
+    #[serde(flatten)]
+    pub image: ImageConfig,
+    pub port: Option<u16>,
+}
+
+#[derive(Deserialize, Default, Debug, Clone)]
+#[serde(default)]
+pub struct ToxiProxyToml {
+    #[serde(flatten)]
+    pub image: ImageConfig,
+    pub port: Option<u16>,
 }
 
 #[derive(Deserialize, Default, Debug, Clone)]
@@ -84,4 +112,12 @@ pub struct V3Toml {
     #[serde(flatten)]
     pub image: ImageConfig,
     pub port: Option<u16>,
+}
+
+#[derive(Deserialize, Default, Debug, Clone)]
+pub struct ExtraTraefikRoute {
+    pub name: String,
+    pub rule: String,
+    pub url: String,
+    pub priority: Option<i32>,
 }

--- a/apps/xnet/lib/src/config/toml_config.rs
+++ b/apps/xnet/lib/src/config/toml_config.rs
@@ -38,6 +38,8 @@ pub struct XnetToml {
     /// Public IP for remote addressing mode (sslip.io).
     /// Equivalent to the --remote CLI flag.
     pub remote_ip: Option<std::net::IpAddr>,
+    /// Custom domain for remote addressing mode. Mutually exclusive with remote_ip.
+    pub remote_domain: Option<String>,
     /// Enable the V3 stack (Validation, V3Db, MlsDb, History, NodeGo)
     pub enable_v3: bool,
     /// Enable the D14n stack (Redis, Gateway, XMTPD nodes)
@@ -52,6 +54,7 @@ impl Default for XnetToml {
             use_standard_ports: true,
             paused: false,
             remote_ip: None,
+            remote_domain: None,
             enable_v3: true,
             enable_d14n: true,
             enable_monitoring: true,

--- a/apps/xnet/lib/src/config/toml_config.rs
+++ b/apps/xnet/lib/src/config/toml_config.rs
@@ -17,6 +17,8 @@ pub(crate) struct TomlConfig {
     pub prometheus: ImageConfig,
     pub grafana: ImageConfig,
     pub traefik: TraefikToml,
+    #[serde(default)]
+    pub extra_traefik_routes: Vec<ExtraTraefikRoute>,
 }
 
 /// Reusable image+version pair for any Docker service
@@ -106,4 +108,12 @@ pub struct V3Toml {
     #[serde(flatten)]
     pub image: ImageConfig,
     pub port: Option<u16>,
+}
+
+#[derive(Deserialize, Default, Debug, Clone)]
+pub struct ExtraTraefikRoute {
+    pub name: String,
+    pub rule: String,
+    pub url: String,
+    pub priority: Option<i32>,
 }

--- a/apps/xnet/lib/src/config/toml_config.rs
+++ b/apps/xnet/lib/src/config/toml_config.rs
@@ -13,9 +13,10 @@ pub(crate) struct TomlConfig {
     pub validation: ImageConfig,
     pub contracts: ImageConfig,
     pub history: ImageConfig,
-    pub toxiproxy: ImageConfig,
+    pub toxiproxy: ToxiProxyToml,
     pub prometheus: ImageConfig,
     pub grafana: ImageConfig,
+    pub traefik: TraefikToml,
 }
 
 /// Reusable image+version pair for any Docker service
@@ -30,26 +31,47 @@ pub struct ImageConfig {
 #[serde(default)]
 pub struct XnetToml {
     pub use_standard_ports: bool,
-    pub toxiproxy_port: Option<u16>,
-    /// Override the Traefik HTTP host port (default: 80)
-    pub traefik_port: Option<u16>,
     /// Pause broadcaster contracts on startup (same as `--paused` CLI flag)
     pub paused: bool,
     /// Public IP for remote addressing mode (sslip.io).
     /// Equivalent to the --remote CLI flag.
     pub remote_ip: Option<std::net::IpAddr>,
+    /// Enable the V3 stack (Validation, V3Db, MlsDb, History, NodeGo)
+    pub enable_v3: bool,
+    /// Enable the D14n stack (Redis, Gateway, XMTPD nodes)
+    pub enable_d14n: bool,
+    /// Enable monitoring services (Prometheus, Grafana, PgAdmin, Otterscan)
+    pub enable_monitoring: bool,
 }
 
 impl Default for XnetToml {
     fn default() -> Self {
         Self {
             use_standard_ports: true,
-            toxiproxy_port: Default::default(),
-            traefik_port: None,
             paused: false,
             remote_ip: None,
+            enable_v3: true,
+            enable_d14n: true,
+            enable_monitoring: true,
         }
     }
+}
+
+#[derive(Deserialize, Default, Debug, Clone)]
+#[serde(default)]
+pub struct TraefikToml {
+    #[serde(flatten)]
+    pub image: ImageConfig,
+    pub port: Option<u16>,
+    pub https_port: Option<u16>,
+}
+
+#[derive(Deserialize, Default, Debug, Clone)]
+#[serde(default)]
+pub struct ToxiProxyToml {
+    #[serde(flatten)]
+    pub image: ImageConfig,
+    pub port: Option<u16>,
 }
 
 #[derive(Deserialize, Default, Debug, Clone)]

--- a/apps/xnet/lib/src/config/toml_config.rs
+++ b/apps/xnet/lib/src/config/toml_config.rs
@@ -46,6 +46,9 @@ pub struct XnetToml {
     pub enable_d14n: bool,
     /// Enable monitoring services (Prometheus, Grafana, PgAdmin, Otterscan)
     pub enable_monitoring: bool,
+    /// Enable TLS mode. Gateway returns https:// URLs and Traefik routes
+    /// use the HTTPS entrypoint. Requires TLS cert files to be present.
+    pub use_tls: bool,
 }
 
 impl Default for XnetToml {
@@ -58,6 +61,7 @@ impl Default for XnetToml {
             enable_v3: true,
             enable_d14n: true,
             enable_monitoring: true,
+            use_tls: false,
         }
     }
 }

--- a/apps/xnet/lib/src/config/toml_config.rs
+++ b/apps/xnet/lib/src/config/toml_config.rs
@@ -69,6 +69,18 @@ pub struct TraefikToml {
     pub image: ImageConfig,
     pub port: Option<u16>,
     pub https_port: Option<u16>,
+    pub acme: Option<AcmeConfig>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct AcmeConfig {
+    pub email: String,
+    #[serde(default = "default_acme_storage")]
+    pub storage: String,
+}
+
+fn default_acme_storage() -> String {
+    "/tmp/xnet/traefik/acme.json".to_string()
 }
 
 #[derive(Deserialize, Default, Debug, Clone)]
@@ -119,4 +131,6 @@ pub struct ExtraTraefikRoute {
     pub rule: String,
     pub url: String,
     pub priority: Option<i32>,
+    #[serde(default)]
+    pub tls: bool,
 }

--- a/apps/xnet/lib/src/config/toml_config.rs
+++ b/apps/xnet/lib/src/config/toml_config.rs
@@ -75,6 +75,8 @@ pub struct TraefikToml {
 #[derive(Deserialize, Debug, Clone)]
 pub struct AcmeConfig {
     pub email: String,
+    /// Path used as both the host-side bind mount source and the container-internal
+    /// Traefik ACME storage target. Must be a valid path on both systems.
     #[serde(default = "default_acme_storage")]
     pub storage: String,
 }

--- a/apps/xnet/lib/src/config/toml_config_test.rs
+++ b/apps/xnet/lib/src/config/toml_config_test.rs
@@ -109,3 +109,91 @@ fn validation_allows_zero_standard_port_nodes() {
     ];
     assert!(validate_node_toml(&nodes).is_ok());
 }
+
+#[test]
+fn extra_traefik_routes_defaults_to_empty() {
+    let toml_str = "[xnet]\n";
+    let config: TomlConfig = toml::from_str(toml_str).unwrap();
+    assert!(config.extra_traefik_routes.is_empty());
+}
+
+#[test]
+fn extra_traefik_routes_parses_single_route() {
+    let toml_str = r#"
+[[extra_traefik_routes]]
+name = "status-page"
+rule = "Host(`migrate.xmtp.run`)"
+url = "http://127.0.0.1:8899"
+priority = 100
+"#;
+    let config: TomlConfig = toml::from_str(toml_str).unwrap();
+    assert_eq!(config.extra_traefik_routes.len(), 1);
+    let route = &config.extra_traefik_routes[0];
+    assert_eq!(route.name, "status-page");
+    assert_eq!(route.rule, "Host(`migrate.xmtp.run`)");
+    assert_eq!(route.url, "http://127.0.0.1:8899");
+    assert_eq!(route.priority, Some(100));
+}
+
+#[test]
+fn remote_domain_is_valid() {
+    crate::config::loadable::validate_remote_domain(&Some("xmtp.run".to_string())).unwrap();
+}
+
+#[test]
+fn no_remote_domain_is_valid() {
+    crate::config::loadable::validate_remote_domain(&None).unwrap();
+}
+
+#[test]
+fn remote_domain_rejects_empty() {
+    let err = crate::config::loadable::validate_remote_domain(&Some("".to_string())).unwrap_err();
+    assert!(
+        err.to_string().contains("empty"),
+        "expected empty domain error, got: {}",
+        err
+    );
+}
+
+#[test]
+fn remote_domain_rejects_leading_dot() {
+    let err = crate::config::loadable::validate_remote_domain(&Some(".xmtp.run".to_string()))
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("must not start or end with '.'"),
+        "expected leading dot error, got: {}",
+        err
+    );
+}
+
+#[test]
+fn remote_domain_rejects_trailing_dot() {
+    let err = crate::config::loadable::validate_remote_domain(&Some("xmtp.run.".to_string()))
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("must not start or end with '.'"),
+        "expected trailing dot error, got: {}",
+        err
+    );
+}
+
+#[test]
+fn extra_traefik_routes_parses_multiple_routes() {
+    let toml_str = r#"
+[[extra_traefik_routes]]
+name = "status-page"
+rule = "Host(`migrate.xmtp.run`)"
+url = "http://127.0.0.1:8899"
+priority = 100
+
+[[extra_traefik_routes]]
+name = "another-service"
+rule = "Host(`other.example.com`)"
+url = "http://127.0.0.1:9999"
+"#;
+    let config: TomlConfig = toml::from_str(toml_str).unwrap();
+    assert_eq!(config.extra_traefik_routes.len(), 2);
+    assert_eq!(config.extra_traefik_routes[0].name, "status-page");
+    assert_eq!(config.extra_traefik_routes[1].name, "another-service");
+    assert_eq!(config.extra_traefik_routes[1].priority, None);
+}

--- a/apps/xnet/lib/src/config/toml_config_test.rs
+++ b/apps/xnet/lib/src/config/toml_config_test.rs
@@ -186,6 +186,18 @@ fn remote_domain_rejects_leading_dot() {
 }
 
 #[test]
+fn remote_domain_rejects_trailing_dot() {
+    let err =
+        crate::config::loadable::validate_remote_config(None, Some("xmtp.run.".to_string()))
+            .unwrap_err();
+    assert!(
+        err.to_string().contains("must not start or end with '.'"),
+        "expected trailing dot error, got: {}",
+        err
+    );
+}
+
+#[test]
 fn extra_traefik_routes_parses_multiple_routes() {
     let toml_str = r#"
 [[extra_traefik_routes]]

--- a/apps/xnet/lib/src/config/toml_config_test.rs
+++ b/apps/xnet/lib/src/config/toml_config_test.rs
@@ -138,8 +138,9 @@ priority = 100
 #[test]
 fn remote_ip_and_domain_mutually_exclusive() {
     let ip: std::net::IpAddr = "10.0.0.1".parse().unwrap();
-    let err = crate::config::loadable::validate_remote_config(Some(ip), Some("xmtp.run".to_string()))
-        .unwrap_err();
+    let err =
+        crate::config::loadable::validate_remote_config(Some(ip), Some("xmtp.run".to_string()))
+            .unwrap_err();
     assert!(
         err.to_string().contains("mutually exclusive"),
         "expected mutual exclusion error, got: {}",
@@ -165,8 +166,8 @@ fn neither_remote_is_valid() {
 
 #[test]
 fn remote_domain_rejects_empty() {
-    let err = crate::config::loadable::validate_remote_config(None, Some("".to_string()))
-        .unwrap_err();
+    let err =
+        crate::config::loadable::validate_remote_config(None, Some("".to_string())).unwrap_err();
     assert!(
         err.to_string().contains("empty"),
         "expected empty domain error, got: {}",
@@ -187,9 +188,8 @@ fn remote_domain_rejects_leading_dot() {
 
 #[test]
 fn remote_domain_rejects_trailing_dot() {
-    let err =
-        crate::config::loadable::validate_remote_config(None, Some("xmtp.run.".to_string()))
-            .unwrap_err();
+    let err = crate::config::loadable::validate_remote_config(None, Some("xmtp.run.".to_string()))
+        .unwrap_err();
     assert!(
         err.to_string().contains("must not start or end with '.'"),
         "expected trailing dot error, got: {}",

--- a/apps/xnet/lib/src/config/toml_config_test.rs
+++ b/apps/xnet/lib/src/config/toml_config_test.rs
@@ -109,3 +109,49 @@ fn validation_allows_zero_standard_port_nodes() {
     ];
     assert!(validate_node_toml(&nodes).is_ok());
 }
+
+#[test]
+fn extra_traefik_routes_defaults_to_empty() {
+    let toml_str = "[xnet]\n";
+    let config: TomlConfig = toml::from_str(toml_str).unwrap();
+    assert!(config.extra_traefik_routes.is_empty());
+}
+
+#[test]
+fn extra_traefik_routes_parses_single_route() {
+    let toml_str = r#"
+[[extra_traefik_routes]]
+name = "status-page"
+rule = "Host(`migrate.xmtp.run`)"
+url = "http://127.0.0.1:8899"
+priority = 100
+"#;
+    let config: TomlConfig = toml::from_str(toml_str).unwrap();
+    assert_eq!(config.extra_traefik_routes.len(), 1);
+    let route = &config.extra_traefik_routes[0];
+    assert_eq!(route.name, "status-page");
+    assert_eq!(route.rule, "Host(`migrate.xmtp.run`)");
+    assert_eq!(route.url, "http://127.0.0.1:8899");
+    assert_eq!(route.priority, Some(100));
+}
+
+#[test]
+fn extra_traefik_routes_parses_multiple_routes() {
+    let toml_str = r#"
+[[extra_traefik_routes]]
+name = "status-page"
+rule = "Host(`migrate.xmtp.run`)"
+url = "http://127.0.0.1:8899"
+priority = 100
+
+[[extra_traefik_routes]]
+name = "another-service"
+rule = "Host(`other.example.com`)"
+url = "http://127.0.0.1:9999"
+"#;
+    let config: TomlConfig = toml::from_str(toml_str).unwrap();
+    assert_eq!(config.extra_traefik_routes.len(), 2);
+    assert_eq!(config.extra_traefik_routes[0].name, "status-page");
+    assert_eq!(config.extra_traefik_routes[1].name, "another-service");
+    assert_eq!(config.extra_traefik_routes[1].priority, None);
+}

--- a/apps/xnet/lib/src/config/toml_config_test.rs
+++ b/apps/xnet/lib/src/config/toml_config_test.rs
@@ -136,6 +136,56 @@ priority = 100
 }
 
 #[test]
+fn remote_ip_and_domain_mutually_exclusive() {
+    let ip: std::net::IpAddr = "10.0.0.1".parse().unwrap();
+    let err = crate::config::loadable::validate_remote_config(Some(ip), Some("xmtp.run".to_string()))
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("mutually exclusive"),
+        "expected mutual exclusion error, got: {}",
+        err
+    );
+}
+
+#[test]
+fn remote_ip_only_is_valid() {
+    let ip: std::net::IpAddr = "10.0.0.1".parse().unwrap();
+    crate::config::loadable::validate_remote_config(Some(ip), None).unwrap();
+}
+
+#[test]
+fn remote_domain_only_is_valid() {
+    crate::config::loadable::validate_remote_config(None, Some("xmtp.run".to_string())).unwrap();
+}
+
+#[test]
+fn neither_remote_is_valid() {
+    crate::config::loadable::validate_remote_config(None, None).unwrap();
+}
+
+#[test]
+fn remote_domain_rejects_empty() {
+    let err = crate::config::loadable::validate_remote_config(None, Some("".to_string()))
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("empty"),
+        "expected empty domain error, got: {}",
+        err
+    );
+}
+
+#[test]
+fn remote_domain_rejects_leading_dot() {
+    let err = crate::config::loadable::validate_remote_config(None, Some(".xmtp.run".to_string()))
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("must not start or end with '.'"),
+        "expected leading dot error, got: {}",
+        err
+    );
+}
+
+#[test]
 fn extra_traefik_routes_parses_multiple_routes() {
     let toml_str = r#"
 [[extra_traefik_routes]]

--- a/apps/xnet/lib/src/config/toml_config_test.rs
+++ b/apps/xnet/lib/src/config/toml_config_test.rs
@@ -217,3 +217,60 @@ url = "http://127.0.0.1:9999"
     assert_eq!(config.extra_traefik_routes[1].name, "another-service");
     assert_eq!(config.extra_traefik_routes[1].priority, None);
 }
+
+#[test]
+fn acme_config_defaults_to_none() {
+    let toml_str = "[xnet]\n";
+    let config: TomlConfig = toml::from_str(toml_str).unwrap();
+    assert!(config.traefik.acme.is_none());
+}
+
+#[test]
+fn acme_config_parses_email() {
+    let toml_str = r#"
+[traefik.acme]
+email = "ops@xmtp.com"
+"#;
+    let config: TomlConfig = toml::from_str(toml_str).unwrap();
+    let acme = config.traefik.acme.unwrap();
+    assert_eq!(acme.email, "ops@xmtp.com");
+    assert_eq!(acme.storage, "/tmp/xnet/traefik/acme.json");
+}
+
+#[test]
+fn acme_config_parses_custom_storage() {
+    let toml_str = r#"
+[traefik.acme]
+email = "ops@xmtp.com"
+storage = "/data/acme.json"
+"#;
+    let config: TomlConfig = toml::from_str(toml_str).unwrap();
+    let acme = config.traefik.acme.unwrap();
+    assert_eq!(acme.storage, "/data/acme.json");
+}
+
+#[test]
+fn extra_route_tls_defaults_to_false() {
+    let toml_str = r#"
+[[extra_traefik_routes]]
+name = "grafana"
+rule = "Host(`grafana.xmtp.run`)"
+url = "http://xnet-grafana:3000"
+"#;
+    let config: TomlConfig = toml::from_str(toml_str).unwrap();
+    assert!(!config.extra_traefik_routes[0].tls);
+}
+
+#[test]
+fn extra_route_tls_parses_true() {
+    let toml_str = r#"
+[[extra_traefik_routes]]
+name = "status-page"
+rule = "Host(`migrate.xmtp.run`)"
+url = "http://xnet-status:8899"
+priority = 100
+tls = true
+"#;
+    let config: TomlConfig = toml::from_str(toml_str).unwrap();
+    assert!(config.extra_traefik_routes[0].tls);
+}

--- a/apps/xnet/lib/src/constants.rs
+++ b/apps/xnet/lib/src/constants.rs
@@ -195,6 +195,7 @@ impl Traefik {
     pub const IMAGE: &str = "traefik";
     pub const VERSION: &str = "v3.2";
     pub const HTTP_PORT: u16 = 80;
+    pub const HTTPS_PORT: u16 = 443;
     pub const DASHBOARD_PORT: u16 = 8080;
     pub const CONTAINER_NAME: &str = "xnet-traefik";
 }

--- a/apps/xnet/lib/src/dns_setup.rs
+++ b/apps/xnet/lib/src/dns_setup.rs
@@ -7,16 +7,16 @@
 ///
 /// Attempts to resolve a test hostname and returns `Ok(())` if it resolves
 /// to 127.0.0.1, or an error describing the failure.
-/// In remote mode, this check is skipped (sslip.io handles DNS resolution).
+/// In remote domain mode, this check is skipped (external DNS handles resolution).
 pub async fn check_dns_configured() -> color_eyre::eyre::Result<()> {
     use color_eyre::eyre::eyre;
 
-    // In remote mode, skip DNS check — sslip.io handles resolution externally
+    // In remote domain mode, skip DNS check — external DNS handles resolution
     if crate::Config::load()
         .map(|c| c.address_mode.is_remote())
         .unwrap_or(false)
     {
-        tracing::info!("Remote mode: skipping local DNS check (sslip.io handles resolution)");
+        tracing::info!("Remote domain mode: skipping local DNS check");
         return Ok(());
     }
 

--- a/apps/xnet/lib/src/lib.rs
+++ b/apps/xnet/lib/src/lib.rs
@@ -11,6 +11,7 @@ pub mod constants;
 pub mod contracts;
 pub mod dns_setup;
 pub mod network;
+pub mod node_provisioner;
 pub mod services;
 pub mod types;
 pub mod wallet_funding;

--- a/apps/xnet/lib/src/lib.rs
+++ b/apps/xnet/lib/src/lib.rs
@@ -11,9 +11,9 @@ pub mod constants;
 pub mod contracts;
 pub mod dns_setup;
 pub mod network;
+pub mod node_provisioner;
 pub mod services;
 pub mod types;
-pub mod node_provisioner;
 pub mod wallet_funding;
 pub mod xmtpd_cli;
 

--- a/apps/xnet/lib/src/lib.rs
+++ b/apps/xnet/lib/src/lib.rs
@@ -13,6 +13,7 @@ pub mod dns_setup;
 pub mod network;
 pub mod services;
 pub mod types;
+pub mod node_provisioner;
 pub mod wallet_funding;
 pub mod xmtpd_cli;
 

--- a/apps/xnet/lib/src/node_provisioner.rs
+++ b/apps/xnet/lib/src/node_provisioner.rs
@@ -1,0 +1,239 @@
+//! Node provisioning: derive signers and orchestrate the full lifecycle of an XMTPD node.
+
+use alloy::signers::local::PrivateKeySigner;
+use bon::Builder;
+use color_eyre::eyre::{Result, eyre};
+
+use crate::{
+    Config,
+    app::ServiceManager,
+    constants::{Anvil as AnvilConst, Xmtpd as XmtpdConst},
+    contracts::{get_broadcaster_pause_status, set_payload_bootstrapper},
+    types::{XmtpdNode, resolve_port},
+    xmtpd_cli::XmtpdCli,
+};
+
+/// The three signers associated with a single XMTPD node.
+pub struct NodeSigners {
+    pub signer: PrivateKeySigner,
+    pub payer: PrivateKeySigner,
+    pub migration_payer: PrivateKeySigner,
+}
+
+/// Derive the three signers for a node from its assigned ID.
+///
+/// Node IDs are assigned in increments of [`XmtpdConst::NODE_ID_INCREMENT`] (100).
+/// Each node uses 3 consecutive signers starting at index `(node_id / 100) * 3 + 1`.
+pub fn derive_signers(node_id: u32) -> Result<NodeSigners> {
+    let config = Config::load()?;
+    let num_ids = node_id / XmtpdConst::NODE_ID_INCREMENT;
+    let base_idx = num_ids as usize * 3 + 1;
+
+    if base_idx + 2 >= config.signers.len() {
+        return Err(eyre!(
+            "node_id {} requires signer index {} which exceeds available signers ({})",
+            node_id,
+            base_idx + 2,
+            config.signers.len()
+        ));
+    }
+
+    Ok(NodeSigners {
+        signer: config.signers[base_idx].clone(),
+        payer: config.signers[base_idx + 1].clone(),
+        migration_payer: config.signers[base_idx + 2].clone(),
+    })
+}
+
+/// Builder-based provisioner that encapsulates the full node lifecycle:
+/// allocate ID, derive signers, register on-chain, and start the container.
+#[derive(Builder)]
+#[builder(on(String, into))]
+pub struct NodeProvisioner {
+    /// Whether this node should run as a migrator (V2->V3 migration mode).
+    #[builder(default)]
+    migrator: bool,
+    /// Use the standard gRPC port (5050) instead of allocating from the dynamic range.
+    #[builder(default)]
+    use_standard_port: bool,
+    /// Optional human-readable name for the node (defaults to `xnet-{node_id}`).
+    name: Option<String>,
+    /// Optional explicit port override.
+    port: Option<u16>,
+}
+
+impl NodeProvisioner {
+    /// Provision a new XMTPD node end-to-end.
+    ///
+    /// Steps:
+    /// 1. If `migrator`, validate that all broadcasters are paused.
+    /// 2. Resolve the gRPC port.
+    /// 3. Allocate a node ID from the gateway via gRPC.
+    /// 4. Derive signers for the allocated ID.
+    /// 5. If `migrator`, set the payload bootstrapper on-chain.
+    /// 6. Build the [`XmtpdNode`].
+    /// 7. Register and enable the node on-chain via [`XmtpdCli`].
+    /// 8. Start the container via [`ServiceManager`].
+    pub async fn provision(&self, mgr: &mut ServiceManager) -> Result<XmtpdNode> {
+        // 1. If migrator, validate preconditions before any state changes
+        if self.migrator {
+            // V3 stack must be running — migrator nodes need node-go
+            if mgr.node_go.is_none() {
+                return Err(eyre!(
+                    "cannot provision migrator node: V3 stack is disabled (enable_v3 required)"
+                ));
+            }
+
+            let rpc_url = mgr
+                .anvil_rpc_url()
+                .ok_or_else(|| eyre!("anvil RPC URL not available"))?
+                .to_string();
+            let statuses = get_broadcaster_pause_status(&rpc_url).await?;
+            for (name, paused) in &statuses {
+                if !paused {
+                    return Err(eyre!(
+                        "cannot provision migrator node: {} broadcaster is not paused",
+                        name
+                    ));
+                }
+            }
+            info!("all broadcasters confirmed paused for migrator node");
+        }
+
+        // 2. Resolve port
+        let port = resolve_port(self.use_standard_port, self.port)?;
+
+        // 3. Allocate node ID from gateway
+        let gateway = mgr
+            .gateway
+            .as_ref()
+            .ok_or_else(|| eyre!("gateway not available — is the D14n stack enabled?"))?;
+        let gateway_url = gateway
+            .external_url()
+            .ok_or_else(|| eyre!("gateway has no external URL"))?;
+        let node_id = XmtpdNode::get_next_id(gateway_url.as_str()).await?;
+        info!(node_id, port, "allocated node ID");
+
+        // 4. Derive signers
+        let signers = derive_signers(node_id)?;
+
+        // 5. If migrator, set the payload bootstrapper
+        if self.migrator {
+            let rpc_url = mgr
+                .anvil_rpc_url()
+                .ok_or_else(|| eyre!("anvil RPC URL not available"))?
+                .to_string();
+            set_payload_bootstrapper(
+                &rpc_url,
+                AnvilConst::ADMIN_KEY,
+                signers.migration_payer.address(),
+            )
+            .await?;
+            info!(
+                bootstrapper = %signers.migration_payer.address(),
+                "set payload bootstrapper for migrator node"
+            );
+        }
+
+        // 6. Build the XmtpdNode
+        let name = self
+            .name
+            .clone()
+            .unwrap_or_else(|| format!("xnet-{}", node_id));
+
+        let mut node = XmtpdNode::builder()
+            .port(port)
+            .signer(signers.signer)
+            .payer(signers.payer)
+            .migration_payer(signers.migration_payer)
+            .node_id(node_id)
+            .name(name)
+            .build();
+
+        // 7. Register and enable on-chain
+        let cli = XmtpdCli::builder().toxiproxy(mgr.proxy.clone()).build();
+        cli.register(mgr, std::io::stdout(), &node).await?;
+        cli.enable(&mut node, std::io::stdout()).await?;
+        info!(node_id, "node registered and enabled on-chain");
+
+        // 8. Start container
+        if self.migrator {
+            mgr.add_xmtpd_with_migrator(node.clone()).await?;
+        } else {
+            mgr.add_xmtpd(node.clone()).await?;
+        }
+        info!(node_id, "node container started");
+
+        Ok(node)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verify signer derivation formula: base_idx = (node_id / NODE_ID_INCREMENT) * 3 + 1
+    #[test]
+    fn derive_signers_index_formula() {
+        // We can't call derive_signers directly because Config::load() requires
+        // the full application context. Instead, verify the formula in isolation.
+        let node_id: u32 = 100;
+        let num_ids = node_id / XmtpdConst::NODE_ID_INCREMENT;
+        let base_idx = num_ids as usize * 3 + 1;
+        assert_eq!(base_idx, 4, "node_id 100 should map to base_idx 4");
+
+        let node_id: u32 = 200;
+        let num_ids = node_id / XmtpdConst::NODE_ID_INCREMENT;
+        let base_idx = num_ids as usize * 3 + 1;
+        assert_eq!(base_idx, 7, "node_id 200 should map to base_idx 7");
+
+        let node_id: u32 = 300;
+        let num_ids = node_id / XmtpdConst::NODE_ID_INCREMENT;
+        let base_idx = num_ids as usize * 3 + 1;
+        assert_eq!(base_idx, 10, "node_id 300 should map to base_idx 10");
+    }
+
+    /// Verify the first node (id=100) uses indices 4, 5, 6
+    /// (indices 0 is admin, 1-3 are reserved for id=0 which is unused).
+    #[test]
+    fn derive_signers_first_node_indices() {
+        let node_id: u32 = 100;
+        let num_ids = node_id / XmtpdConst::NODE_ID_INCREMENT;
+        let base_idx = num_ids as usize * 3 + 1;
+        assert_eq!(base_idx, 4);
+        assert_eq!(base_idx + 1, 5);
+        assert_eq!(base_idx + 2, 6);
+    }
+
+    /// Verify that a node_id of 0 maps to base_idx 1 (the first usable signer slot).
+    #[test]
+    fn derive_signers_zero_id() {
+        let node_id: u32 = 0;
+        let num_ids = node_id / XmtpdConst::NODE_ID_INCREMENT;
+        let base_idx = num_ids as usize * 3 + 1;
+        assert_eq!(base_idx, 1, "node_id 0 should map to base_idx 1");
+    }
+
+    /// Verify the maximum supported node (32 nodes * 3 signers + 1 = index 97,
+    /// so node_id 3200 would need index 97 which is the last valid triple).
+    #[test]
+    fn derive_signers_max_node_within_bounds() {
+        let node_id: u32 = 3200;
+        let num_ids = node_id / XmtpdConst::NODE_ID_INCREMENT;
+        let base_idx = num_ids as usize * 3 + 1;
+        assert_eq!(base_idx, 97);
+        // base_idx + 2 = 99, which is valid for a 100-element array (indices 0..99)
+        assert!(base_idx + 2 < 100);
+    }
+
+    /// Verify that a node_id beyond the signer array would overflow.
+    #[test]
+    fn derive_signers_overflow_detection() {
+        let node_id: u32 = 3300;
+        let num_ids = node_id / XmtpdConst::NODE_ID_INCREMENT;
+        let base_idx = num_ids as usize * 3 + 1;
+        assert_eq!(base_idx, 100);
+        // base_idx + 2 = 102, which exceeds the 100-element array
+        assert!(base_idx + 2 >= 100);
+    }
+}

--- a/apps/xnet/lib/src/node_provisioner.rs
+++ b/apps/xnet/lib/src/node_provisioner.rs
@@ -144,9 +144,7 @@ impl NodeProvisioner {
             .build();
 
         // 7. Register and enable on-chain
-        let cli = XmtpdCli::builder()
-            .toxiproxy(mgr.proxy.clone())
-            .build();
+        let cli = XmtpdCli::builder().toxiproxy(mgr.proxy.clone()).build();
         cli.register(mgr, std::io::stdout(), &node).await?;
         cli.enable(&mut node, std::io::stdout()).await?;
         info!(node_id, "node registered and enabled on-chain");

--- a/apps/xnet/lib/src/node_provisioner.rs
+++ b/apps/xnet/lib/src/node_provisioner.rs
@@ -1,0 +1,234 @@
+//! Node provisioning: derive signers and orchestrate the full lifecycle of an XMTPD node.
+
+use alloy::signers::local::PrivateKeySigner;
+use bon::Builder;
+use color_eyre::eyre::{Result, eyre};
+
+use crate::{
+    Config,
+    app::ServiceManager,
+    constants::{Anvil as AnvilConst, Xmtpd as XmtpdConst},
+    contracts::{get_broadcaster_pause_status, set_payload_bootstrapper},
+    types::{XmtpdNode, resolve_port},
+    xmtpd_cli::XmtpdCli,
+};
+
+/// The three signers associated with a single XMTPD node.
+pub struct NodeSigners {
+    pub signer: PrivateKeySigner,
+    pub payer: PrivateKeySigner,
+    pub migration_payer: PrivateKeySigner,
+}
+
+/// Derive the three signers for a node from its assigned ID.
+///
+/// Node IDs are assigned in increments of [`XmtpdConst::NODE_ID_INCREMENT`] (100).
+/// Each node uses 3 consecutive signers starting at index `(node_id / 100) * 3 + 1`.
+pub fn derive_signers(node_id: u32) -> Result<NodeSigners> {
+    let config = Config::load()?;
+    let num_ids = node_id / XmtpdConst::NODE_ID_INCREMENT;
+    let base_idx = num_ids as usize * 3 + 1;
+
+    if base_idx + 2 >= config.signers.len() {
+        return Err(eyre!(
+            "node_id {} requires signer index {} which exceeds available signers ({})",
+            node_id,
+            base_idx + 2,
+            config.signers.len()
+        ));
+    }
+
+    Ok(NodeSigners {
+        signer: config.signers[base_idx].clone(),
+        payer: config.signers[base_idx + 1].clone(),
+        migration_payer: config.signers[base_idx + 2].clone(),
+    })
+}
+
+/// Builder-based provisioner that encapsulates the full node lifecycle:
+/// allocate ID, derive signers, register on-chain, and start the container.
+#[derive(Builder)]
+#[builder(on(String, into))]
+pub struct NodeProvisioner {
+    /// Whether this node should run as a migrator (V2->V3 migration mode).
+    #[builder(default)]
+    migrator: bool,
+    /// Use the standard gRPC port (5050) instead of allocating from the dynamic range.
+    #[builder(default)]
+    use_standard_port: bool,
+    /// Optional human-readable name for the node (defaults to `xnet-{node_id}`).
+    name: Option<String>,
+    /// Optional explicit port override.
+    port: Option<u16>,
+}
+
+impl NodeProvisioner {
+    /// Provision a new XMTPD node end-to-end.
+    ///
+    /// Steps:
+    /// 1. If `migrator`, validate that all broadcasters are paused.
+    /// 2. Resolve the gRPC port.
+    /// 3. Allocate a node ID from the gateway via gRPC.
+    /// 4. Derive signers for the allocated ID.
+    /// 5. If `migrator`, set the payload bootstrapper on-chain.
+    /// 6. Build the [`XmtpdNode`].
+    /// 7. Register and enable the node on-chain via [`XmtpdCli`].
+    /// 8. Start the container via [`ServiceManager`].
+    pub async fn provision(&self, mgr: &mut ServiceManager) -> Result<XmtpdNode> {
+        // 1. If migrator, ensure broadcasters are paused
+        if self.migrator {
+            let rpc_url = mgr
+                .anvil_rpc_url()
+                .ok_or_else(|| eyre!("anvil RPC URL not available"))?
+                .to_string();
+            let statuses = get_broadcaster_pause_status(&rpc_url).await?;
+            for (name, paused) in &statuses {
+                if !paused {
+                    return Err(eyre!(
+                        "cannot provision migrator node: {} broadcaster is not paused",
+                        name
+                    ));
+                }
+            }
+            info!("all broadcasters confirmed paused for migrator node");
+        }
+
+        // 2. Resolve port
+        let port = resolve_port(self.use_standard_port, self.port)?;
+
+        // 3. Allocate node ID from gateway
+        let gateway = mgr
+            .gateway
+            .as_ref()
+            .ok_or_else(|| eyre!("gateway not available — is the D14n stack enabled?"))?;
+        let gateway_url = gateway
+            .external_url()
+            .ok_or_else(|| eyre!("gateway has no external URL"))?;
+        let node_id = XmtpdNode::get_next_id(gateway_url.as_str()).await?;
+        info!(node_id, port, "allocated node ID");
+
+        // 4. Derive signers
+        let signers = derive_signers(node_id)?;
+
+        // 5. If migrator, set the payload bootstrapper
+        if self.migrator {
+            let rpc_url = mgr
+                .anvil_rpc_url()
+                .ok_or_else(|| eyre!("anvil RPC URL not available"))?
+                .to_string();
+            set_payload_bootstrapper(
+                &rpc_url,
+                AnvilConst::ADMIN_KEY,
+                signers.migration_payer.address(),
+            )
+            .await?;
+            info!(
+                bootstrapper = %signers.migration_payer.address(),
+                "set payload bootstrapper for migrator node"
+            );
+        }
+
+        // 6. Build the XmtpdNode
+        let name = self
+            .name
+            .clone()
+            .unwrap_or_else(|| format!("xnet-{}", node_id));
+
+        let mut node = XmtpdNode::builder()
+            .port(port)
+            .signer(signers.signer)
+            .payer(signers.payer)
+            .migration_payer(signers.migration_payer)
+            .node_id(node_id)
+            .name(name)
+            .build();
+
+        // 7. Register and enable on-chain
+        let cli = XmtpdCli::builder()
+            .toxiproxy(mgr.proxy.clone())
+            .build();
+        cli.register(mgr, std::io::stdout(), &node).await?;
+        cli.enable(&mut node, std::io::stdout()).await?;
+        info!(node_id, "node registered and enabled on-chain");
+
+        // 8. Start container
+        if self.migrator {
+            mgr.add_xmtpd_with_migrator(node.clone()).await?;
+        } else {
+            mgr.add_xmtpd(node.clone()).await?;
+        }
+        info!(node_id, "node container started");
+
+        Ok(node)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verify signer derivation formula: base_idx = (node_id / NODE_ID_INCREMENT) * 3 + 1
+    #[test]
+    fn derive_signers_index_formula() {
+        // We can't call derive_signers directly because Config::load() requires
+        // the full application context. Instead, verify the formula in isolation.
+        let node_id: u32 = 100;
+        let num_ids = node_id / XmtpdConst::NODE_ID_INCREMENT;
+        let base_idx = num_ids as usize * 3 + 1;
+        assert_eq!(base_idx, 4, "node_id 100 should map to base_idx 4");
+
+        let node_id: u32 = 200;
+        let num_ids = node_id / XmtpdConst::NODE_ID_INCREMENT;
+        let base_idx = num_ids as usize * 3 + 1;
+        assert_eq!(base_idx, 7, "node_id 200 should map to base_idx 7");
+
+        let node_id: u32 = 300;
+        let num_ids = node_id / XmtpdConst::NODE_ID_INCREMENT;
+        let base_idx = num_ids as usize * 3 + 1;
+        assert_eq!(base_idx, 10, "node_id 300 should map to base_idx 10");
+    }
+
+    /// Verify the first node (id=100) uses indices 4, 5, 6
+    /// (indices 0 is admin, 1-3 are reserved for id=0 which is unused).
+    #[test]
+    fn derive_signers_first_node_indices() {
+        let node_id: u32 = 100;
+        let num_ids = node_id / XmtpdConst::NODE_ID_INCREMENT;
+        let base_idx = num_ids as usize * 3 + 1;
+        assert_eq!(base_idx, 4);
+        assert_eq!(base_idx + 1, 5);
+        assert_eq!(base_idx + 2, 6);
+    }
+
+    /// Verify that a node_id of 0 maps to base_idx 1 (the first usable signer slot).
+    #[test]
+    fn derive_signers_zero_id() {
+        let node_id: u32 = 0;
+        let num_ids = node_id / XmtpdConst::NODE_ID_INCREMENT;
+        let base_idx = num_ids as usize * 3 + 1;
+        assert_eq!(base_idx, 1, "node_id 0 should map to base_idx 1");
+    }
+
+    /// Verify the maximum supported node (32 nodes * 3 signers + 1 = index 97,
+    /// so node_id 3200 would need index 97 which is the last valid triple).
+    #[test]
+    fn derive_signers_max_node_within_bounds() {
+        let node_id: u32 = 3200;
+        let num_ids = node_id / XmtpdConst::NODE_ID_INCREMENT;
+        let base_idx = num_ids as usize * 3 + 1;
+        assert_eq!(base_idx, 97);
+        // base_idx + 2 = 99, which is valid for a 100-element array (indices 0..99)
+        assert!(base_idx + 2 < 100);
+    }
+
+    /// Verify that a node_id beyond the signer array would overflow.
+    #[test]
+    fn derive_signers_overflow_detection() {
+        let node_id: u32 = 3300;
+        let num_ids = node_id / XmtpdConst::NODE_ID_INCREMENT;
+        let base_idx = num_ids as usize * 3 + 1;
+        assert_eq!(base_idx, 100);
+        // base_idx + 2 = 102, which exceeds the 100-element array
+        assert!(base_idx + 2 >= 100);
+    }
+}

--- a/apps/xnet/lib/src/node_provisioner.rs
+++ b/apps/xnet/lib/src/node_provisioner.rs
@@ -75,8 +75,15 @@ impl NodeProvisioner {
     /// 7. Register and enable the node on-chain via [`XmtpdCli`].
     /// 8. Start the container via [`ServiceManager`].
     pub async fn provision(&self, mgr: &mut ServiceManager) -> Result<XmtpdNode> {
-        // 1. If migrator, ensure broadcasters are paused
+        // 1. If migrator, validate preconditions before any state changes
         if self.migrator {
+            // V3 stack must be running — migrator nodes need node-go
+            if mgr.node_go.is_none() {
+                return Err(eyre!(
+                    "cannot provision migrator node: V3 stack is disabled (enable_v3 required)"
+                ));
+            }
+
             let rpc_url = mgr
                 .anvil_rpc_url()
                 .ok_or_else(|| eyre!("anvil RPC URL not available"))?

--- a/apps/xnet/lib/src/services/coredns.rs
+++ b/apps/xnet/lib/src/services/coredns.rs
@@ -30,9 +30,10 @@ use crate::{
 /// - Port 5354: Resolves *.xmtpd.local → 127.0.0.1 for host machine access
 /// - Port 53: Resolves *.xmtpd.local → Traefik IP for container-to-container access
 ///
-/// In remote mode, sslip.io handles external DNS, so:
+///
+/// In remote domain mode, external DNS is handled by the domain provider, so:
 /// - Port 5354: Just forwards (no template needed)
-/// - Port 53: Resolves *.{ip-dashed}.sslip.io → Traefik IP for container-to-container access
+/// - Port 53: Resolves *.{domain} → Traefik IP for container-to-container access
 fn generate_corefile(traefik_ip: &str, address_mode: &AddressMode) -> String {
     match address_mode {
         AddressMode::Local => {
@@ -61,6 +62,10 @@ fn generate_corefile(traefik_ip: &str, address_mode: &AddressMode) -> String {
         answer "{{{{ .Name }}}} 60 IN A {traefik_ip}"
     }}
 
+    template IN AAAA xmtpd.local {{
+        rcode NOERROR
+    }}
+
     # Forward everything else to Docker's internal DNS
     forward . 127.0.0.11
 
@@ -69,10 +74,9 @@ fn generate_corefile(traefik_ip: &str, address_mode: &AddressMode) -> String {
 "#
             )
         }
-        AddressMode::Remote(ip) => {
-            let ip_dashed = ip.to_string().replace(['.', ':'], "-");
+        AddressMode::RemoteDomain(domain) => {
             format!(
-                r#"# Host-facing DNS (port 5354) - remote mode, just forward
+                r#"# Host-facing DNS (port 5354) - remote domain mode, just forward
 .:5354 {{
     log
     errors
@@ -82,13 +86,20 @@ fn generate_corefile(traefik_ip: &str, address_mode: &AddressMode) -> String {
 }}
 
 # Container-facing DNS (port 53)
-# Resolves *.{ip_dashed}.sslip.io to Traefik for container-to-container routing
+# Resolves *.{domain} to Traefik for container-to-container routing
 .:53 {{
     log
     errors
 
-    template IN A {ip_dashed}.sslip.io {{
+    template IN A {domain} {{
         answer "{{{{ .Name }}}} 60 IN A {traefik_ip}"
+    }}
+
+    # Block AAAA (IPv6) lookups for the domain so clients fall back to A records.
+    # Without this, Go's DNS resolver prefers IPv6 and connects to external IPs
+    # (e.g. Cloudflare) instead of the internal Traefik container.
+    template IN AAAA {domain} {{
+        rcode NOERROR
     }}
 
     # Forward everything else to Docker's internal DNS

--- a/apps/xnet/lib/src/services/coredns.rs
+++ b/apps/xnet/lib/src/services/coredns.rs
@@ -99,6 +99,35 @@ fn generate_corefile(traefik_ip: &str, address_mode: &AddressMode) -> String {
 "#
             )
         }
+        AddressMode::RemoteDomain(domain) => {
+            format!(
+                r#"# Host-facing DNS (port 5354) - remote domain mode, just forward
+.:5354 {{
+    log
+    errors
+
+    forward . /etc/resolv.conf
+    cache 30
+}}
+
+# Container-facing DNS (port 53)
+# Resolves *.{domain} to Traefik for container-to-container routing
+.:53 {{
+    log
+    errors
+
+    template IN A {domain} {{
+        answer "{{{{ .Name }}}} 60 IN A {traefik_ip}"
+    }}
+
+    # Forward everything else to Docker's internal DNS
+    forward . 127.0.0.11
+
+    cache 30
+}}
+"#
+            )
+        }
     }
 }
 

--- a/apps/xnet/lib/src/services/coredns.rs
+++ b/apps/xnet/lib/src/services/coredns.rs
@@ -69,7 +69,7 @@ fn generate_corefile(traefik_ip: &str, address_mode: &AddressMode) -> String {
 "#
             )
         }
-        AddressMode::Remote(ip) => {
+        AddressMode::RemoteIp(ip) => {
             let ip_dashed = ip.to_string().replace(['.', ':'], "-");
             format!(
                 r#"# Host-facing DNS (port 5354) - remote mode, just forward

--- a/apps/xnet/lib/src/services/otterscan.rs
+++ b/apps/xnet/lib/src/services/otterscan.rs
@@ -16,8 +16,6 @@ use color_eyre::eyre::Result;
 use url::Url;
 
 use crate::{
-    Config,
-    config::AddressMode,
     constants::{Anvil as AnvilConst, Otterscan as OtterscanConst},
     network::XNET_NETWORK_NAME,
     services::{ManagedContainer, Service, ToxiProxy},
@@ -105,12 +103,8 @@ impl Otterscan {
     }
 
     /// URL for external access (direct port binding).
-    /// Uses the remote IP when address_mode is Remote, otherwise localhost.
     pub fn external_url(&self) -> Url {
-        let host = match Config::load_unchecked().address_mode {
-            AddressMode::Remote(ip) => ip.to_string(),
-            _ => "localhost".to_string(),
-        };
+        let host = "localhost";
         Url::parse(&format!(
             "http://{}:{}",
             host,

--- a/apps/xnet/lib/src/services/otterscan.rs
+++ b/apps/xnet/lib/src/services/otterscan.rs
@@ -108,7 +108,7 @@ impl Otterscan {
     /// Uses the remote IP when address_mode is Remote, otherwise localhost.
     pub fn external_url(&self) -> Url {
         let host = match Config::load_unchecked().address_mode {
-            AddressMode::Remote(ip) => ip.to_string(),
+            AddressMode::RemoteIp(ip) => ip.to_string(),
             _ => "localhost".to_string(),
         };
         Url::parse(&format!(

--- a/apps/xnet/lib/src/services/pgadmin.rs
+++ b/apps/xnet/lib/src/services/pgadmin.rs
@@ -171,6 +171,7 @@ impl PgAdmin {
 
     /// Write the servers.json file with static databases and discovered databases.
     fn write_servers(&self, discovered: &[DiscoveredDb]) -> Result<()> {
+        fs::create_dir_all(PGADMIN_DIR)?;
         let servers_path = Path::new(PGADMIN_DIR).join("servers.json");
 
         let mut server_id = 0u32;

--- a/apps/xnet/lib/src/services/traefik.rs
+++ b/apps/xnet/lib/src/services/traefik.rs
@@ -7,10 +7,7 @@ use async_trait::async_trait;
 use bollard::{
     Docker,
     container::NetworkingConfig,
-    models::{
-        ContainerCreateBody, EndpointSettings, HostConfig, Mount, MountTypeEnum,
-        NetworkConnectRequest,
-    },
+    models::{ContainerCreateBody, EndpointSettings, HostConfig, Mount, MountTypeEnum},
     query_parameters::CreateContainerOptionsBuilder,
 };
 use bon::Builder;
@@ -24,12 +21,17 @@ use crate::{
     config::NodeToml,
     constants::{MAX_XMTPD_NODES, Traefik as TraefikConst, Xmtpd as XmtpdConst},
     network::XNET_NETWORK_NAME,
-    services::{ManagedContainer, Service, ToxiProxy, TraefikConfig, expose, expose_127},
+    services::{ManagedContainer, Service, ToxiProxy, expose, expose_127},
 };
 
-/// Traefik static configuration (traefik.yml)
-/// Listens on both port 80 and 443 since gRPC clients may default to 443
-const TRAEFIK_STATIC_CONFIG: &str = r#"# Traefik static configuration
+/// Generate Traefik static configuration (traefik.yml).
+///
+/// Traefik listens on:
+/// - Port 80 (HTTP) for external traffic (CDN terminates TLS upstream)
+/// - Port 443 (HTTPS) for internal gRPC traffic between xmtpd nodes
+///   Uses Traefik's default self-signed cert for internal TLS termination.
+fn traefik_static_config() -> String {
+    r#"# Traefik static configuration
 entryPoints:
   http:
     address: ":80"
@@ -61,7 +63,9 @@ log:
   level: INFO
 
 accessLog: {}
-"#;
+"#
+    .to_string()
+}
 
 /// Manages a Traefik Docker container for reverse proxy routing.
 #[derive(Builder)]
@@ -108,7 +112,7 @@ impl Traefik {
         fs::create_dir_all(config_dir)?;
 
         // Write static config
-        fs::write(&self.static_config_path, TRAEFIK_STATIC_CONFIG)?;
+        fs::write(&self.static_config_path, traefik_static_config())?;
         info!(
             "Created Traefik static config at {}",
             self.static_config_path
@@ -121,7 +125,7 @@ impl Traefik {
 
         let options = CreateContainerOptionsBuilder::default().name(TraefikConst::CONTAINER_NAME);
 
-        // Map host ports - expose 80 and 443 for HTTP/gRPC traffic
+        // Map host ports - expose 80 (HTTP) and 443 (HTTPS, self-signed cert for Cloudflare "Full" mode)
         let port_bindings = hash_map! {
             "80/tcp".to_string() => expose(self.http_port),
             "443/tcp".to_string() => expose(443),
@@ -161,22 +165,26 @@ impl Traefik {
             host_config: Some(HostConfig {
                 network_mode: Some(XNET_NETWORK_NAME.to_string()),
                 port_bindings: Some(port_bindings),
-                mounts: Some(vec![
-                    Mount {
-                        target: Some("/etc/traefik/traefik.yml".to_string()),
-                        source: Some(self.static_config_path.clone()),
-                        typ: Some(MountTypeEnum::BIND),
-                        read_only: Some(true),
-                        ..Default::default()
-                    },
-                    Mount {
-                        target: Some("/etc/traefik/dynamic.yml".to_string()),
-                        source: Some(self.dynamic_config_path.clone()),
-                        typ: Some(MountTypeEnum::BIND),
-                        read_only: Some(false),
-                        ..Default::default()
-                    },
-                ]),
+                extra_hosts: Some(vec!["host.docker.internal:host-gateway".to_string()]),
+                mounts: Some({
+                    let mounts = vec![
+                        Mount {
+                            target: Some("/etc/traefik/traefik.yml".to_string()),
+                            source: Some(self.static_config_path.clone()),
+                            typ: Some(MountTypeEnum::BIND),
+                            read_only: Some(true),
+                            ..Default::default()
+                        },
+                        Mount {
+                            target: Some("/etc/traefik/dynamic.yml".to_string()),
+                            source: Some(self.dynamic_config_path.clone()),
+                            typ: Some(MountTypeEnum::BIND),
+                            read_only: Some(false),
+                            ..Default::default()
+                        },
+                    ];
+                    mounts
+                }),
                 ..Default::default()
             }),
             networking_config: Some(NetworkingConfig { endpoints_config }.into()),

--- a/apps/xnet/lib/src/services/traefik.rs
+++ b/apps/xnet/lib/src/services/traefik.rs
@@ -87,6 +87,10 @@ pub struct Traefik {
     #[builder(default = TraefikConst::HTTP_PORT)]
     http_port: u16,
 
+    /// The host port for HTTPS/gRPC traffic (default: 443)
+    #[builder(default = TraefikConst::HTTPS_PORT)]
+    https_port: u16,
+
     /// Managed container state
     #[builder(default = ManagedContainer::new())]
     container: ManagedContainer,
@@ -124,7 +128,7 @@ impl Traefik {
         // Map host ports - expose 80 and 443 for HTTP/gRPC traffic
         let port_bindings = hash_map! {
             "80/tcp".to_string() => expose(self.http_port),
-            "443/tcp".to_string() => expose(443),
+            "443/tcp".to_string() => expose(self.https_port),
             "8080/tcp".to_string() => expose_127(TraefikConst::DASHBOARD_PORT),
         };
 

--- a/apps/xnet/lib/src/services/traefik.rs
+++ b/apps/xnet/lib/src/services/traefik.rs
@@ -165,6 +165,7 @@ impl Traefik {
             host_config: Some(HostConfig {
                 network_mode: Some(XNET_NETWORK_NAME.to_string()),
                 port_bindings: Some(port_bindings),
+                extra_hosts: Some(vec!["host.docker.internal:host-gateway".to_string()]),
                 mounts: Some(vec![
                     Mount {
                         target: Some("/etc/traefik/traefik.yml".to_string()),

--- a/apps/xnet/lib/src/services/traefik.rs
+++ b/apps/xnet/lib/src/services/traefik.rs
@@ -22,14 +22,18 @@ use url::Url;
 use crate::{
     Config,
     config::NodeToml,
+    config::toml_config::AcmeConfig,
     constants::{MAX_XMTPD_NODES, Traefik as TraefikConst, Xmtpd as XmtpdConst},
     network::XNET_NETWORK_NAME,
     services::{ManagedContainer, Service, ToxiProxy, TraefikConfig, expose, expose_127},
 };
 
-/// Traefik static configuration (traefik.yml)
-/// Listens on both port 80 and 443 since gRPC clients may default to 443
-const TRAEFIK_STATIC_CONFIG: &str = r#"# Traefik static configuration
+/// Generate Traefik static configuration (traefik.yml).
+///
+/// When `acme` is provided, appends a `certificatesResolvers` block
+/// for Let's Encrypt using the HTTP challenge on the `http` entrypoint.
+fn traefik_static_config(acme: Option<&AcmeConfig>) -> String {
+    let mut yaml = r#"# Traefik static configuration
 entryPoints:
   http:
     address: ":80"
@@ -61,7 +65,26 @@ log:
   level: INFO
 
 accessLog: {}
-"#;
+"#
+    .to_string();
+
+    if let Some(acme) = acme {
+        yaml.push_str(&format!(
+            r#"
+certificatesResolvers:
+  letsencrypt:
+    acme:
+      email: "{}"
+      storage: "{}"
+      httpChallenge:
+        entryPoint: http
+"#,
+            acme.email, acme.storage
+        ));
+    }
+
+    yaml
+}
 
 /// Manages a Traefik Docker container for reverse proxy routing.
 #[derive(Builder)]
@@ -82,6 +105,10 @@ pub struct Traefik {
     /// Path to dynamic config file (managed by TraefikConfig)
     #[builder(default = "/tmp/xnet/traefik/dynamic.yml".to_string())]
     dynamic_config_path: String,
+
+    /// ACME/TLS configuration (None = no cert management)
+    #[builder(default)]
+    acme: Option<AcmeConfig>,
 
     /// The host port for HTTP traffic (default: 80)
     #[builder(default = TraefikConst::HTTP_PORT)]
@@ -112,7 +139,7 @@ impl Traefik {
         fs::create_dir_all(config_dir)?;
 
         // Write static config
-        fs::write(&self.static_config_path, TRAEFIK_STATIC_CONFIG)?;
+        fs::write(&self.static_config_path, traefik_static_config(self.acme.as_ref()))?;
         info!(
             "Created Traefik static config at {}",
             self.static_config_path
@@ -166,22 +193,51 @@ impl Traefik {
                 network_mode: Some(XNET_NETWORK_NAME.to_string()),
                 port_bindings: Some(port_bindings),
                 extra_hosts: Some(vec!["host.docker.internal:host-gateway".to_string()]),
-                mounts: Some(vec![
-                    Mount {
-                        target: Some("/etc/traefik/traefik.yml".to_string()),
-                        source: Some(self.static_config_path.clone()),
-                        typ: Some(MountTypeEnum::BIND),
-                        read_only: Some(true),
-                        ..Default::default()
-                    },
-                    Mount {
-                        target: Some("/etc/traefik/dynamic.yml".to_string()),
-                        source: Some(self.dynamic_config_path.clone()),
-                        typ: Some(MountTypeEnum::BIND),
-                        read_only: Some(false),
-                        ..Default::default()
-                    },
-                ]),
+                mounts: Some({
+                    let mut mounts = vec![
+                        Mount {
+                            target: Some("/etc/traefik/traefik.yml".to_string()),
+                            source: Some(self.static_config_path.clone()),
+                            typ: Some(MountTypeEnum::BIND),
+                            read_only: Some(true),
+                            ..Default::default()
+                        },
+                        Mount {
+                            target: Some("/etc/traefik/dynamic.yml".to_string()),
+                            source: Some(self.dynamic_config_path.clone()),
+                            typ: Some(MountTypeEnum::BIND),
+                            read_only: Some(false),
+                            ..Default::default()
+                        },
+                    ];
+                    if let Some(acme) = &self.acme {
+                        // Ensure the ACME storage file exists with restricted permissions.
+                        // Traefik requires 600 on acme.json or it refuses to start.
+                        let acme_path = std::path::Path::new(&acme.storage);
+                        if let Some(parent) = acme_path.parent() {
+                            fs::create_dir_all(parent)?;
+                        }
+                        if !acme_path.exists() {
+                            fs::write(&acme.storage, "{}")?;
+                        }
+                        #[cfg(unix)]
+                        {
+                            use std::os::unix::fs::PermissionsExt;
+                            fs::set_permissions(
+                                &acme.storage,
+                                fs::Permissions::from_mode(0o600),
+                            )?;
+                        }
+                        mounts.push(Mount {
+                            target: Some(acme.storage.clone()),
+                            source: Some(acme.storage.clone()),
+                            typ: Some(MountTypeEnum::BIND),
+                            read_only: Some(false),
+                            ..Default::default()
+                        });
+                    }
+                    mounts
+                }),
                 ..Default::default()
             }),
             networking_config: Some(NetworkingConfig { endpoints_config }.into()),

--- a/apps/xnet/lib/src/services/traefik.rs
+++ b/apps/xnet/lib/src/services/traefik.rs
@@ -21,8 +21,8 @@ use url::Url;
 
 use crate::{
     Config,
-    config::NodeToml,
     config::AcmeConfig,
+    config::NodeToml,
     constants::{MAX_XMTPD_NODES, Traefik as TraefikConst, Xmtpd as XmtpdConst},
     network::XNET_NETWORK_NAME,
     services::{ManagedContainer, Service, ToxiProxy, TraefikConfig, expose, expose_127},

--- a/apps/xnet/lib/src/services/traefik.rs
+++ b/apps/xnet/lib/src/services/traefik.rs
@@ -22,7 +22,7 @@ use url::Url;
 use crate::{
     Config,
     config::NodeToml,
-    config::toml_config::AcmeConfig,
+    config::AcmeConfig,
     constants::{MAX_XMTPD_NODES, Traefik as TraefikConst, Xmtpd as XmtpdConst},
     network::XNET_NETWORK_NAME,
     services::{ManagedContainer, Service, ToxiProxy, TraefikConfig, expose, expose_127},
@@ -107,7 +107,6 @@ pub struct Traefik {
     dynamic_config_path: String,
 
     /// ACME/TLS configuration (None = no cert management)
-    #[builder(default)]
     acme: Option<AcmeConfig>,
 
     /// The host port for HTTP traffic (default: 80)
@@ -139,7 +138,10 @@ impl Traefik {
         fs::create_dir_all(config_dir)?;
 
         // Write static config
-        fs::write(&self.static_config_path, traefik_static_config(self.acme.as_ref()))?;
+        fs::write(
+            &self.static_config_path,
+            traefik_static_config(self.acme.as_ref()),
+        )?;
         info!(
             "Created Traefik static config at {}",
             self.static_config_path
@@ -223,10 +225,7 @@ impl Traefik {
                         #[cfg(unix)]
                         {
                             use std::os::unix::fs::PermissionsExt;
-                            fs::set_permissions(
-                                &acme.storage,
-                                fs::Permissions::from_mode(0o600),
-                            )?;
+                            fs::set_permissions(&acme.storage, fs::Permissions::from_mode(0o600))?;
                         }
                         mounts.push(Mount {
                             target: Some(acme.storage.clone()),

--- a/apps/xnet/lib/src/services/traefik.rs
+++ b/apps/xnet/lib/src/services/traefik.rs
@@ -253,25 +253,27 @@ impl Traefik {
                         });
                     }
                     if self.use_tls {
-                        for path in ["/tmp/xnet/traefik/cert.pem", "/tmp/xnet/traefik/key.pem"] {
-                            if !std::path::Path::new(path).exists() {
+                        let cert_path = config_dir.join("cert.pem");
+                        let key_path = config_dir.join("key.pem");
+                        for path in [&cert_path, &key_path] {
+                            if !path.exists() {
                                 return Err(color_eyre::eyre::eyre!(
                                     "use_tls is enabled but {} does not exist — \
                                      deploy cert files before starting Traefik",
-                                    path
+                                    path.display()
                                 ));
                             }
                         }
                         mounts.push(Mount {
                             target: Some("/etc/traefik/cert.pem".to_string()),
-                            source: Some("/tmp/xnet/traefik/cert.pem".to_string()),
+                            source: Some(cert_path.to_string_lossy().into_owned()),
                             typ: Some(MountTypeEnum::BIND),
                             read_only: Some(true),
                             ..Default::default()
                         });
                         mounts.push(Mount {
                             target: Some("/etc/traefik/key.pem".to_string()),
-                            source: Some("/tmp/xnet/traefik/key.pem".to_string()),
+                            source: Some(key_path.to_string_lossy().into_owned()),
                             typ: Some(MountTypeEnum::BIND),
                             read_only: Some(true),
                             ..Default::default()

--- a/apps/xnet/lib/src/services/traefik.rs
+++ b/apps/xnet/lib/src/services/traefik.rs
@@ -32,7 +32,7 @@ use crate::{
 ///
 /// When `acme` is provided, appends a `certificatesResolvers` block
 /// for Let's Encrypt using the HTTP challenge on the `http` entrypoint.
-fn traefik_static_config(acme: Option<&AcmeConfig>) -> String {
+fn traefik_static_config(acme: Option<&AcmeConfig>, use_tls: bool) -> String {
     let mut yaml = r#"# Traefik static configuration
 entryPoints:
   http:
@@ -83,6 +83,19 @@ certificatesResolvers:
         ));
     }
 
+    if use_tls {
+        yaml.push_str(
+            r#"
+tls:
+  stores:
+    default:
+      defaultCertificate:
+        certFile: /etc/traefik/cert.pem
+        keyFile: /etc/traefik/key.pem
+"#,
+        );
+    }
+
     yaml
 }
 
@@ -108,6 +121,10 @@ pub struct Traefik {
 
     /// ACME/TLS configuration (None = no cert management)
     acme: Option<AcmeConfig>,
+
+    /// File-based TLS mode (wildcard cert)
+    #[builder(default)]
+    use_tls: bool,
 
     /// The host port for HTTP traffic (default: 80)
     #[builder(default = TraefikConst::HTTP_PORT)]
@@ -140,7 +157,7 @@ impl Traefik {
         // Write static config
         fs::write(
             &self.static_config_path,
-            traefik_static_config(self.acme.as_ref()),
+            traefik_static_config(self.acme.as_ref(), self.use_tls),
         )?;
         info!(
             "Created Traefik static config at {}",

--- a/apps/xnet/lib/src/services/traefik.rs
+++ b/apps/xnet/lib/src/services/traefik.rs
@@ -252,6 +252,31 @@ impl Traefik {
                             ..Default::default()
                         });
                     }
+                    if self.use_tls {
+                        for path in ["/tmp/xnet/traefik/cert.pem", "/tmp/xnet/traefik/key.pem"] {
+                            if !std::path::Path::new(path).exists() {
+                                return Err(color_eyre::eyre::eyre!(
+                                    "use_tls is enabled but {} does not exist — \
+                                     deploy cert files before starting Traefik",
+                                    path
+                                ));
+                            }
+                        }
+                        mounts.push(Mount {
+                            target: Some("/etc/traefik/cert.pem".to_string()),
+                            source: Some("/tmp/xnet/traefik/cert.pem".to_string()),
+                            typ: Some(MountTypeEnum::BIND),
+                            read_only: Some(true),
+                            ..Default::default()
+                        });
+                        mounts.push(Mount {
+                            target: Some("/etc/traefik/key.pem".to_string()),
+                            source: Some("/tmp/xnet/traefik/key.pem".to_string()),
+                            typ: Some(MountTypeEnum::BIND),
+                            read_only: Some(true),
+                            ..Default::default()
+                        });
+                    }
                     mounts
                 }),
                 ..Default::default()

--- a/apps/xnet/lib/src/services/traefik_config.rs
+++ b/apps/xnet/lib/src/services/traefik_config.rs
@@ -10,8 +10,10 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use color_eyre::eyre::{Result, eyre};
+use color_eyre::eyre::Result;
 use serde::{Deserialize, Serialize};
+
+use crate::config::ExtraTraefikRoute;
 
 /// Traefik dynamic configuration manager.
 ///
@@ -23,6 +25,8 @@ pub struct TraefikConfig {
     config_path: PathBuf,
     /// Hostname -> ToxiProxy port mapping (thread-safe)
     routes: Arc<Mutex<HashMap<String, u16>>>,
+    /// User-defined extra routes (from TOML config, stored in memory only)
+    extra_routes: Arc<Mutex<Vec<ExtraTraefikRoute>>>,
 }
 
 /// Traefik dynamic configuration structure (for YAML serialization)
@@ -51,6 +55,11 @@ struct Router {
     service: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     priority: Option<i32>,
+    #[serde(rename = "entryPoints", skip_serializing_if = "Option::is_none")]
+    entry_points: Option<Vec<String>>,
+    /// When present (even empty), enables TLS on this router (Traefik uses default self-signed cert).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tls: Option<HashMap<String, String>>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -105,16 +114,14 @@ impl TraefikConfig {
                 .strip_prefix("Host(`")
                 .and_then(|s| s.strip_suffix("`)"))
             {
-                // Get port from corresponding service
+                // Get port from corresponding service (only auto-generated routes
+                // use the h2c://xnet-toxiproxy:{port} URL pattern)
                 if let Some(service) = config.http.services.get(&router.service)
                     && let Some(server) = service.load_balancer.servers.first()
+                    && let Some(port_str) = server.url.strip_prefix("h2c://xnet-toxiproxy:")
+                    && let Ok(port) = port_str.parse()
                 {
-                    // Parse "http://toxiproxy:8150" -> 8150
-                    if let Some((_, port_str)) = server.url.rsplit_once(':')
-                        && let Ok(port) = port_str.parse()
-                    {
-                        routes.insert(hostname.to_string(), port);
-                    }
+                    routes.insert(hostname.to_string(), port);
                 }
             }
         }
@@ -146,6 +153,7 @@ impl TraefikConfig {
         Ok(Self {
             config_path,
             routes: Arc::new(Mutex::new(routes)),
+            extra_routes: Arc::new(Mutex::new(Vec::new())),
         })
     }
 
@@ -187,25 +195,58 @@ impl TraefikConfig {
         self.routes.lock().unwrap().clone()
     }
 
+    /// Set user-defined extra routes from TOML config.
+    ///
+    /// Extra routes are stored in memory only (not round-tripped through YAML)
+    /// and merged into dynamic.yml on every write() call.
+    pub fn set_extra_routes(&self, routes: Vec<ExtraTraefikRoute>) -> Result<()> {
+        {
+            let mut extra = self.extra_routes.lock().unwrap();
+            *extra = routes;
+        }
+        self.write()?;
+        info!(
+            "Set {} extra Traefik route(s)",
+            self.extra_routes.lock().unwrap().len()
+        );
+        Ok(())
+    }
+
     /// Write the current configuration to the dynamic.yml file.
     ///
     /// Traefik will automatically detect and reload the changes.
+    /// Routes listen on the HTTP entrypoint. TLS is terminated at the CDN.
     fn write(&self) -> Result<()> {
         let routes = self.routes.lock().unwrap();
+        let extra = self.extra_routes.lock().unwrap();
 
         let mut routers = HashMap::new();
         let mut services = HashMap::new();
 
         for (hostname, toxi_port) in routes.iter() {
-            // Generate a safe router/service name from hostname
             let name = hostname.replace(['.', '-'], "_");
 
+            // HTTP router (for CDN-terminated traffic on port 80)
             routers.insert(
                 name.clone(),
                 Router {
                     rule: format!("Host(`{}`)", hostname),
                     service: name.clone(),
                     priority: None,
+                    entry_points: Some(vec!["http".to_string()]),
+                    tls: None,
+                },
+            );
+
+            // HTTPS router (for internal node-to-node gRPC over TLS)
+            routers.insert(
+                format!("{}_tls", name),
+                Router {
+                    rule: format!("Host(`{}`)", hostname),
+                    service: name.clone(),
+                    priority: None,
+                    entry_points: Some(vec!["https".to_string()]),
+                    tls: Some(HashMap::new()),
                 },
             );
 
@@ -215,6 +256,44 @@ impl TraefikConfig {
                     load_balancer: LoadBalancer {
                         servers: vec![Server {
                             url: format!("h2c://xnet-toxiproxy:{}", toxi_port),
+                        }],
+                        servers_transport: None,
+                        pass_host_header: Some(true),
+                    },
+                },
+            );
+        }
+
+        // Extra routes (user-defined, may use any URL/rule)
+        for route in extra.iter() {
+            routers.insert(
+                route.name.clone(),
+                Router {
+                    rule: route.rule.clone(),
+                    service: route.name.clone(),
+                    priority: route.priority,
+                    entry_points: Some(vec!["http".to_string()]),
+                    tls: None,
+                },
+            );
+
+            routers.insert(
+                format!("{}_tls", route.name),
+                Router {
+                    rule: route.rule.clone(),
+                    service: route.name.clone(),
+                    priority: route.priority,
+                    entry_points: Some(vec!["https".to_string()]),
+                    tls: Some(HashMap::new()),
+                },
+            );
+
+            services.insert(
+                route.name.clone(),
+                TraefikService {
+                    load_balancer: LoadBalancer {
+                        servers: vec![Server {
+                            url: route.url.clone(),
                         }],
                         servers_transport: None,
                         pass_host_header: Some(true),
@@ -235,8 +314,10 @@ impl TraefikConfig {
         fs::write(&self.config_path, yaml)?;
 
         debug!(
-            "Wrote Traefik config with {} routes to {}",
+            "Wrote Traefik config with {} routes ({} auto + {} extra) to {}",
+            routes.len() + extra.len(),
             routes.len(),
+            extra.len(),
             self.config_path.display()
         );
 
@@ -252,7 +333,7 @@ impl TraefikConfig {
     ///
     /// Returns a formatted string that can be appended to /etc/hosts.
     /// All hostnames resolve to 127.0.0.1 for local access through Traefik.
-    /// In remote mode, returns empty (sslip.io handles DNS resolution).
+    /// In remote domain mode, returns empty (external DNS handles resolution).
     pub fn hosts_entries(&self) -> String {
         // In remote mode, no /etc/hosts entries needed
         if crate::Config::load()
@@ -275,5 +356,203 @@ impl TraefikConfig {
         }
 
         entries.join("\n")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ExtraTraefikRoute;
+    use tempfile::NamedTempFile;
+
+    fn temp_config() -> (TraefikConfig, NamedTempFile) {
+        let file = NamedTempFile::new().unwrap();
+        let config = TraefikConfig::new(file.path()).unwrap();
+        (config, file)
+    }
+
+    #[test]
+    fn write_with_no_routes_produces_empty_config() {
+        let (config, file) = temp_config();
+        config.write().unwrap();
+        let contents = fs::read_to_string(file.path()).unwrap();
+        let parsed: TraefikDynamicConfig = serde_yaml::from_str(&contents).unwrap();
+        assert!(parsed.http.routers.is_empty());
+        assert!(parsed.http.services.is_empty());
+    }
+
+    #[test]
+    fn extra_routes_appear_in_dynamic_yaml() {
+        let (config, file) = temp_config();
+        config
+            .set_extra_routes(vec![ExtraTraefikRoute {
+                name: "status-page".to_string(),
+                rule: "Host(`migrate.xmtp.run`)".to_string(),
+                url: "http://127.0.0.1:8899".to_string(),
+                priority: Some(100),
+                ..Default::default()
+            }])
+            .unwrap();
+
+        let contents = fs::read_to_string(file.path()).unwrap();
+        let parsed: TraefikDynamicConfig = serde_yaml::from_str(&contents).unwrap();
+
+        let router = parsed
+            .http
+            .routers
+            .get("status-page")
+            .expect("router missing");
+        assert_eq!(router.rule, "Host(`migrate.xmtp.run`)");
+        assert_eq!(router.service, "status-page");
+        assert_eq!(router.priority, Some(100));
+
+        let service = parsed
+            .http
+            .services
+            .get("status-page")
+            .expect("service missing");
+        assert_eq!(
+            service.load_balancer.servers[0].url,
+            "http://127.0.0.1:8899"
+        );
+        assert_eq!(service.load_balancer.pass_host_header, Some(true));
+    }
+
+    #[test]
+    fn extra_routes_without_priority_omit_priority_field() {
+        let (config, file) = temp_config();
+        config
+            .set_extra_routes(vec![ExtraTraefikRoute {
+                name: "no-priority".to_string(),
+                rule: "Host(`example.com`)".to_string(),
+                url: "http://127.0.0.1:9999".to_string(),
+                priority: None,
+                ..Default::default()
+            }])
+            .unwrap();
+
+        let contents = fs::read_to_string(file.path()).unwrap();
+        let parsed: TraefikDynamicConfig = serde_yaml::from_str(&contents).unwrap();
+        let router = parsed.http.routers.get("no-priority").unwrap();
+        assert_eq!(router.priority, None);
+    }
+
+    #[test]
+    fn extra_routes_merge_with_auto_routes() {
+        let (config, file) = temp_config();
+        config.add_route("node100.xmtpd.local", 8150).unwrap();
+        config
+            .set_extra_routes(vec![ExtraTraefikRoute {
+                name: "status-page".to_string(),
+                rule: "Host(`migrate.xmtp.run`)".to_string(),
+                url: "http://127.0.0.1:8899".to_string(),
+                priority: Some(100),
+                ..Default::default()
+            }])
+            .unwrap();
+
+        let contents = fs::read_to_string(file.path()).unwrap();
+        let parsed: TraefikDynamicConfig = serde_yaml::from_str(&contents).unwrap();
+
+        // Auto-generated route present
+        assert!(parsed.http.routers.contains_key("node100_xmtpd_local"));
+        assert!(parsed.http.services.contains_key("node100_xmtpd_local"));
+
+        // Extra route present
+        assert!(parsed.http.routers.contains_key("status-page"));
+        assert!(parsed.http.services.contains_key("status-page"));
+
+        // TLS routers also present
+        assert!(parsed.http.routers.contains_key("node100_xmtpd_local_tls"));
+        assert!(parsed.http.routers.contains_key("status-page_tls"));
+
+        // Total: 4 routers (HTTP + HTTPS each), 2 services
+        assert_eq!(parsed.http.routers.len(), 4);
+        assert_eq!(parsed.http.services.len(), 2);
+    }
+
+    #[test]
+    fn extra_routes_not_lost_after_add_route() {
+        let (config, file) = temp_config();
+        config
+            .set_extra_routes(vec![ExtraTraefikRoute {
+                name: "status-page".to_string(),
+                rule: "Host(`migrate.xmtp.run`)".to_string(),
+                url: "http://127.0.0.1:8899".to_string(),
+                priority: None,
+                ..Default::default()
+            }])
+            .unwrap();
+
+        // Adding a regular route should not lose extra routes
+        config.add_route("node200.xmtpd.local", 8151).unwrap();
+
+        let contents = fs::read_to_string(file.path()).unwrap();
+        let parsed: TraefikDynamicConfig = serde_yaml::from_str(&contents).unwrap();
+        assert!(parsed.http.routers.contains_key("status-page"));
+        assert!(parsed.http.routers.contains_key("node200_xmtpd_local"));
+    }
+
+    #[test]
+    fn load_from_file_ignores_extra_routes_in_yaml() {
+        let (config, file) = temp_config();
+        // Write an extra route
+        config
+            .set_extra_routes(vec![ExtraTraefikRoute {
+                name: "status-page".to_string(),
+                rule: "Host(`migrate.xmtp.run`)".to_string(),
+                url: "http://127.0.0.1:8899".to_string(),
+                priority: Some(100),
+                ..Default::default()
+            }])
+            .unwrap();
+
+        // Re-load from file — extra routes should NOT be recovered
+        // (they are memory-only, sourced from TOML config)
+        let config2 = TraefikConfig::new(file.path()).unwrap();
+        assert!(config2.routes().is_empty());
+
+        // Extra routes Vec should be empty on fresh load
+        let extra = config2.extra_routes.lock().unwrap();
+        assert!(extra.is_empty());
+    }
+
+    #[test]
+    fn routes_listen_on_http_entrypoint() {
+        let (config, file) = temp_config();
+        config.add_route("node100.xmtp.run", 8150).unwrap();
+
+        let contents = fs::read_to_string(file.path()).unwrap();
+        let parsed: TraefikDynamicConfig = serde_yaml::from_str(&contents).unwrap();
+
+        let router = parsed
+            .http
+            .routers
+            .get("node100_xmtp_run")
+            .expect("router missing");
+        assert_eq!(router.entry_points, Some(vec!["http".to_string()]));
+    }
+
+    #[test]
+    fn extra_routes_listen_on_http_entrypoint() {
+        let (config, file) = temp_config();
+        config
+            .set_extra_routes(vec![ExtraTraefikRoute {
+                name: "status-page".to_string(),
+                rule: "Host(`migrate.xmtp.run`)".to_string(),
+                url: "http://xnet-status:8899".to_string(),
+                priority: Some(100),
+            }])
+            .unwrap();
+
+        let contents = fs::read_to_string(file.path()).unwrap();
+        let parsed: TraefikDynamicConfig = serde_yaml::from_str(&contents).unwrap();
+
+        let router = parsed
+            .http
+            .routers
+            .get("status-page")
+            .expect("router missing");
+        assert_eq!(router.entry_points, Some(vec!["http".to_string()]));
     }
 }

--- a/apps/xnet/lib/src/services/traefik_config.rs
+++ b/apps/xnet/lib/src/services/traefik_config.rs
@@ -109,16 +109,14 @@ impl TraefikConfig {
                 .strip_prefix("Host(`")
                 .and_then(|s| s.strip_suffix("`)"))
             {
-                // Get port from corresponding service
+                // Get port from corresponding service (only auto-generated routes
+                // use the h2c://xnet-toxiproxy:{port} URL pattern)
                 if let Some(service) = config.http.services.get(&router.service)
                     && let Some(server) = service.load_balancer.servers.first()
+                    && let Some(port_str) = server.url.strip_prefix("h2c://xnet-toxiproxy:")
+                    && let Ok(port) = port_str.parse()
                 {
-                    // Parse "http://toxiproxy:8150" -> 8150
-                    if let Some((_, port_str)) = server.url.rsplit_once(':')
-                        && let Ok(port) = port_str.parse()
-                    {
-                        routes.insert(hostname.to_string(), port);
-                    }
+                    routes.insert(hostname.to_string(), port);
                 }
             }
         }
@@ -331,7 +329,7 @@ impl TraefikConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::toml_config::ExtraTraefikRoute;
+    use crate::config::ExtraTraefikRoute;
     use tempfile::NamedTempFile;
 
     fn temp_config() -> (TraefikConfig, NamedTempFile) {

--- a/apps/xnet/lib/src/services/traefik_config.rs
+++ b/apps/xnet/lib/src/services/traefik_config.rs
@@ -13,7 +13,7 @@ use std::{
 use color_eyre::eyre::{Result, eyre};
 use serde::{Deserialize, Serialize};
 
-use crate::config::toml_config::ExtraTraefikRoute;
+use crate::config::ExtraTraefikRoute;
 
 /// Traefik dynamic configuration manager.
 ///

--- a/apps/xnet/lib/src/services/traefik_config.rs
+++ b/apps/xnet/lib/src/services/traefik_config.rs
@@ -202,7 +202,10 @@ impl TraefikConfig {
             *extra = routes;
         }
         self.write()?;
-        info!("Set {} extra Traefik route(s)", self.extra_routes.lock().unwrap().len());
+        info!(
+            "Set {} extra Traefik route(s)",
+            self.extra_routes.lock().unwrap().len()
+        );
         Ok(())
     }
 
@@ -362,13 +365,24 @@ mod tests {
         let contents = fs::read_to_string(file.path()).unwrap();
         let parsed: TraefikDynamicConfig = serde_yaml::from_str(&contents).unwrap();
 
-        let router = parsed.http.routers.get("status-page").expect("router missing");
+        let router = parsed
+            .http
+            .routers
+            .get("status-page")
+            .expect("router missing");
         assert_eq!(router.rule, "Host(`migrate.xmtp.run`)");
         assert_eq!(router.service, "status-page");
         assert_eq!(router.priority, Some(100));
 
-        let service = parsed.http.services.get("status-page").expect("service missing");
-        assert_eq!(service.load_balancer.servers[0].url, "http://127.0.0.1:8899");
+        let service = parsed
+            .http
+            .services
+            .get("status-page")
+            .expect("service missing");
+        assert_eq!(
+            service.load_balancer.servers[0].url,
+            "http://127.0.0.1:8899"
+        );
         assert_eq!(service.load_balancer.pass_host_header, Some(true));
     }
 

--- a/apps/xnet/lib/src/services/traefik_config.rs
+++ b/apps/xnet/lib/src/services/traefik_config.rs
@@ -13,6 +13,8 @@ use std::{
 use color_eyre::eyre::{Result, eyre};
 use serde::{Deserialize, Serialize};
 
+use crate::config::toml_config::ExtraTraefikRoute;
+
 /// Traefik dynamic configuration manager.
 ///
 /// This struct manages the dynamic.yml file that Traefik watches.
@@ -23,6 +25,8 @@ pub struct TraefikConfig {
     config_path: PathBuf,
     /// Hostname -> ToxiProxy port mapping (thread-safe)
     routes: Arc<Mutex<HashMap<String, u16>>>,
+    /// User-defined extra routes (from TOML config, stored in memory only)
+    extra_routes: Arc<Mutex<Vec<ExtraTraefikRoute>>>,
 }
 
 /// Traefik dynamic configuration structure (for YAML serialization)
@@ -146,6 +150,7 @@ impl TraefikConfig {
         Ok(Self {
             config_path,
             routes: Arc::new(Mutex::new(routes)),
+            extra_routes: Arc::new(Mutex::new(Vec::new())),
         })
     }
 
@@ -187,11 +192,26 @@ impl TraefikConfig {
         self.routes.lock().unwrap().clone()
     }
 
+    /// Set user-defined extra routes from TOML config.
+    ///
+    /// Extra routes are stored in memory only (not round-tripped through YAML)
+    /// and merged into dynamic.yml on every write() call.
+    pub fn set_extra_routes(&self, routes: Vec<ExtraTraefikRoute>) -> Result<()> {
+        {
+            let mut extra = self.extra_routes.lock().unwrap();
+            *extra = routes;
+        }
+        self.write()?;
+        info!("Set {} extra Traefik route(s)", self.extra_routes.lock().unwrap().len());
+        Ok(())
+    }
+
     /// Write the current configuration to the dynamic.yml file.
     ///
     /// Traefik will automatically detect and reload the changes.
     fn write(&self) -> Result<()> {
         let routes = self.routes.lock().unwrap();
+        let extra = self.extra_routes.lock().unwrap();
 
         let mut routers = HashMap::new();
         let mut services = HashMap::new();
@@ -223,6 +243,31 @@ impl TraefikConfig {
             );
         }
 
+        // Extra routes (user-defined, may use any URL/rule)
+        for route in extra.iter() {
+            routers.insert(
+                route.name.clone(),
+                Router {
+                    rule: route.rule.clone(),
+                    service: route.name.clone(),
+                    priority: route.priority,
+                },
+            );
+
+            services.insert(
+                route.name.clone(),
+                TraefikService {
+                    load_balancer: LoadBalancer {
+                        servers: vec![Server {
+                            url: route.url.clone(),
+                        }],
+                        servers_transport: None,
+                        pass_host_header: Some(true),
+                    },
+                },
+            );
+        }
+
         let config = TraefikDynamicConfig {
             http: HttpConfig {
                 routers,
@@ -235,8 +280,10 @@ impl TraefikConfig {
         fs::write(&self.config_path, yaml)?;
 
         debug!(
-            "Wrote Traefik config with {} routes to {}",
+            "Wrote Traefik config with {} routes ({} auto + {} extra) to {}",
+            routes.len() + extra.len(),
             routes.len(),
+            extra.len(),
             self.config_path.display()
         );
 
@@ -275,5 +322,144 @@ impl TraefikConfig {
         }
 
         entries.join("\n")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::toml_config::ExtraTraefikRoute;
+    use tempfile::NamedTempFile;
+
+    fn temp_config() -> (TraefikConfig, NamedTempFile) {
+        let file = NamedTempFile::new().unwrap();
+        let config = TraefikConfig::new(file.path()).unwrap();
+        (config, file)
+    }
+
+    #[test]
+    fn write_with_no_routes_produces_empty_config() {
+        let (config, file) = temp_config();
+        config.write().unwrap();
+        let contents = fs::read_to_string(file.path()).unwrap();
+        let parsed: TraefikDynamicConfig = serde_yaml::from_str(&contents).unwrap();
+        assert!(parsed.http.routers.is_empty());
+        assert!(parsed.http.services.is_empty());
+    }
+
+    #[test]
+    fn extra_routes_appear_in_dynamic_yaml() {
+        let (config, file) = temp_config();
+        config
+            .set_extra_routes(vec![ExtraTraefikRoute {
+                name: "status-page".to_string(),
+                rule: "Host(`migrate.xmtp.run`)".to_string(),
+                url: "http://127.0.0.1:8899".to_string(),
+                priority: Some(100),
+            }])
+            .unwrap();
+
+        let contents = fs::read_to_string(file.path()).unwrap();
+        let parsed: TraefikDynamicConfig = serde_yaml::from_str(&contents).unwrap();
+
+        let router = parsed.http.routers.get("status-page").expect("router missing");
+        assert_eq!(router.rule, "Host(`migrate.xmtp.run`)");
+        assert_eq!(router.service, "status-page");
+        assert_eq!(router.priority, Some(100));
+
+        let service = parsed.http.services.get("status-page").expect("service missing");
+        assert_eq!(service.load_balancer.servers[0].url, "http://127.0.0.1:8899");
+        assert_eq!(service.load_balancer.pass_host_header, Some(true));
+    }
+
+    #[test]
+    fn extra_routes_without_priority_omit_priority_field() {
+        let (config, file) = temp_config();
+        config
+            .set_extra_routes(vec![ExtraTraefikRoute {
+                name: "no-priority".to_string(),
+                rule: "Host(`example.com`)".to_string(),
+                url: "http://127.0.0.1:9999".to_string(),
+                priority: None,
+            }])
+            .unwrap();
+
+        let contents = fs::read_to_string(file.path()).unwrap();
+        let parsed: TraefikDynamicConfig = serde_yaml::from_str(&contents).unwrap();
+        let router = parsed.http.routers.get("no-priority").unwrap();
+        assert_eq!(router.priority, None);
+    }
+
+    #[test]
+    fn extra_routes_merge_with_auto_routes() {
+        let (config, file) = temp_config();
+        config.add_route("node100.xmtpd.local", 8150).unwrap();
+        config
+            .set_extra_routes(vec![ExtraTraefikRoute {
+                name: "status-page".to_string(),
+                rule: "Host(`migrate.xmtp.run`)".to_string(),
+                url: "http://127.0.0.1:8899".to_string(),
+                priority: Some(100),
+            }])
+            .unwrap();
+
+        let contents = fs::read_to_string(file.path()).unwrap();
+        let parsed: TraefikDynamicConfig = serde_yaml::from_str(&contents).unwrap();
+
+        // Auto-generated route present
+        assert!(parsed.http.routers.contains_key("node100_xmtpd_local"));
+        assert!(parsed.http.services.contains_key("node100_xmtpd_local"));
+
+        // Extra route present
+        assert!(parsed.http.routers.contains_key("status-page"));
+        assert!(parsed.http.services.contains_key("status-page"));
+
+        // Total: 2 routes
+        assert_eq!(parsed.http.routers.len(), 2);
+        assert_eq!(parsed.http.services.len(), 2);
+    }
+
+    #[test]
+    fn extra_routes_not_lost_after_add_route() {
+        let (config, file) = temp_config();
+        config
+            .set_extra_routes(vec![ExtraTraefikRoute {
+                name: "status-page".to_string(),
+                rule: "Host(`migrate.xmtp.run`)".to_string(),
+                url: "http://127.0.0.1:8899".to_string(),
+                priority: None,
+            }])
+            .unwrap();
+
+        // Adding a regular route should not lose extra routes
+        config.add_route("node200.xmtpd.local", 8151).unwrap();
+
+        let contents = fs::read_to_string(file.path()).unwrap();
+        let parsed: TraefikDynamicConfig = serde_yaml::from_str(&contents).unwrap();
+        assert!(parsed.http.routers.contains_key("status-page"));
+        assert!(parsed.http.routers.contains_key("node200_xmtpd_local"));
+    }
+
+    #[test]
+    fn load_from_file_ignores_extra_routes_in_yaml() {
+        let (config, file) = temp_config();
+        // Write an extra route
+        config
+            .set_extra_routes(vec![ExtraTraefikRoute {
+                name: "status-page".to_string(),
+                rule: "Host(`migrate.xmtp.run`)".to_string(),
+                url: "http://127.0.0.1:8899".to_string(),
+                priority: Some(100),
+            }])
+            .unwrap();
+
+        // Re-load from file — extra routes should NOT be recovered
+        // (they are memory-only, sourced from TOML config)
+        let config2 = TraefikConfig::new(file.path()).unwrap();
+        assert!(config2.routes().is_empty());
+
+        // Extra routes Vec should be empty on fresh load
+        let extra = config2.extra_routes.lock().unwrap();
+        assert!(extra.is_empty());
     }
 }

--- a/apps/xnet/lib/src/services/traefik_config.rs
+++ b/apps/xnet/lib/src/services/traefik_config.rs
@@ -357,6 +357,7 @@ mod tests {
                 rule: "Host(`migrate.xmtp.run`)".to_string(),
                 url: "http://127.0.0.1:8899".to_string(),
                 priority: Some(100),
+                ..Default::default()
             }])
             .unwrap();
 
@@ -393,6 +394,7 @@ mod tests {
                 rule: "Host(`example.com`)".to_string(),
                 url: "http://127.0.0.1:9999".to_string(),
                 priority: None,
+                ..Default::default()
             }])
             .unwrap();
 
@@ -412,6 +414,7 @@ mod tests {
                 rule: "Host(`migrate.xmtp.run`)".to_string(),
                 url: "http://127.0.0.1:8899".to_string(),
                 priority: Some(100),
+                ..Default::default()
             }])
             .unwrap();
 
@@ -440,6 +443,7 @@ mod tests {
                 rule: "Host(`migrate.xmtp.run`)".to_string(),
                 url: "http://127.0.0.1:8899".to_string(),
                 priority: None,
+                ..Default::default()
             }])
             .unwrap();
 
@@ -462,6 +466,7 @@ mod tests {
                 rule: "Host(`migrate.xmtp.run`)".to_string(),
                 url: "http://127.0.0.1:8899".to_string(),
                 priority: Some(100),
+                ..Default::default()
             }])
             .unwrap();
 

--- a/apps/xnet/lib/src/services/traefik_config.rs
+++ b/apps/xnet/lib/src/services/traefik_config.rs
@@ -727,4 +727,90 @@ mod tests {
         // Only 2 services (redirect router shares the service)
         assert_eq!(parsed.http.services.len(), 2);
     }
+
+    #[test]
+    fn auto_routes_get_tls_when_use_tls_enabled() {
+        let (config, file) = temp_config_tls();
+        config.add_route("node100.xmtp.run", 8150).unwrap();
+
+        let contents = fs::read_to_string(file.path()).unwrap();
+        let parsed: TraefikDynamicConfig = serde_yaml::from_str(&contents).unwrap();
+
+        let name = "node100_xmtp_run";
+        let router = parsed.http.routers.get(name).expect("HTTPS router missing");
+        assert_eq!(router.entry_points, Some(vec!["https".to_string()]));
+        let tls = router.tls.as_ref().expect("tls config missing");
+        assert!(
+            tls.cert_resolver.is_none(),
+            "file-based TLS should have no certResolver"
+        );
+
+        let redirect_name = format!("{}_redirect", name);
+        let redirect = parsed
+            .http
+            .routers
+            .get(&redirect_name)
+            .expect("redirect router missing");
+        assert_eq!(redirect.entry_points, Some(vec!["http".to_string()]));
+        assert_eq!(
+            redirect.middlewares,
+            Some(vec!["redirect-https".to_string()])
+        );
+        assert!(redirect.tls.is_none());
+
+        let mw = parsed
+            .http
+            .middlewares
+            .as_ref()
+            .expect("middlewares missing");
+        assert!(mw.contains_key("redirect-https"));
+    }
+
+    #[test]
+    fn auto_routes_no_tls_when_use_tls_disabled() {
+        let (config, file) = temp_config();
+        config.add_route("node100.xmtpd.local", 8150).unwrap();
+
+        let contents = fs::read_to_string(file.path()).unwrap();
+        let parsed: TraefikDynamicConfig = serde_yaml::from_str(&contents).unwrap();
+
+        let router = parsed
+            .http
+            .routers
+            .get("node100_xmtpd_local")
+            .expect("router missing");
+        assert!(router.tls.is_none());
+        assert!(router.entry_points.is_none());
+        assert!(router.middlewares.is_none());
+        assert!(!parsed
+            .http
+            .routers
+            .contains_key("node100_xmtpd_local_redirect"));
+    }
+
+    #[test]
+    fn extra_route_tls_uses_file_cert_when_use_tls_enabled() {
+        let (config, file) = temp_config_tls();
+        config
+            .set_extra_routes(vec![ExtraTraefikRoute {
+                name: "status-page".to_string(),
+                rule: "Host(`migrate.xmtp.run`)".to_string(),
+                url: "http://xnet-status:8899".to_string(),
+                priority: Some(100),
+                tls: true,
+            }])
+            .unwrap();
+
+        let contents = fs::read_to_string(file.path()).unwrap();
+        let parsed: TraefikDynamicConfig = serde_yaml::from_str(&contents).unwrap();
+
+        let router = parsed
+            .http
+            .routers
+            .get("status-page")
+            .expect("HTTPS router missing");
+        let tls = router.tls.as_ref().expect("tls config missing");
+        assert!(tls.cert_resolver.is_none());
+        assert_eq!(router.entry_points, Some(vec!["https".to_string()]));
+    }
 }

--- a/apps/xnet/lib/src/services/traefik_config.rs
+++ b/apps/xnet/lib/src/services/traefik_config.rs
@@ -259,7 +259,9 @@ impl TraefikConfig {
                         rule: format!("Host(`{}`)", hostname),
                         service: name.clone(),
                         priority: None,
-                        tls: Some(TlsConfig { cert_resolver: None }),
+                        tls: Some(TlsConfig {
+                            cert_resolver: None,
+                        }),
                         entry_points: Some(vec!["https".to_string()]),
                         middlewares: None,
                     },
@@ -312,7 +314,9 @@ impl TraefikConfig {
                 any_tls = true;
 
                 let tls_config = if self.use_tls {
-                    TlsConfig { cert_resolver: None }
+                    TlsConfig {
+                        cert_resolver: None,
+                    }
                 } else {
                     TlsConfig {
                         cert_resolver: Some("letsencrypt".to_string()),
@@ -782,10 +786,12 @@ mod tests {
         assert!(router.tls.is_none());
         assert!(router.entry_points.is_none());
         assert!(router.middlewares.is_none());
-        assert!(!parsed
-            .http
-            .routers
-            .contains_key("node100_xmtpd_local_redirect"));
+        assert!(
+            !parsed
+                .http
+                .routers
+                .contains_key("node100_xmtpd_local_redirect")
+        );
     }
 
     #[test]

--- a/apps/xnet/lib/src/services/traefik_config.rs
+++ b/apps/xnet/lib/src/services/traefik_config.rs
@@ -582,26 +582,47 @@ mod tests {
         let parsed: TraefikDynamicConfig = serde_yaml::from_str(&contents).unwrap();
 
         // HTTPS router with certResolver
-        let router = parsed.http.routers.get("status-page").expect("HTTPS router missing");
+        let router = parsed
+            .http
+            .routers
+            .get("status-page")
+            .expect("HTTPS router missing");
         assert_eq!(router.entry_points, Some(vec!["https".to_string()]));
         let tls = router.tls.as_ref().expect("tls config missing");
         assert_eq!(tls.cert_resolver, Some("letsencrypt".to_string()));
 
         // HTTP→HTTPS redirect router
-        let redirect = parsed.http.routers.get("status-page-redirect").expect("redirect router missing");
+        let redirect = parsed
+            .http
+            .routers
+            .get("status-page-redirect")
+            .expect("redirect router missing");
         assert_eq!(redirect.entry_points, Some(vec!["http".to_string()]));
-        assert_eq!(redirect.middlewares, Some(vec!["redirect-https".to_string()]));
+        assert_eq!(
+            redirect.middlewares,
+            Some(vec!["redirect-https".to_string()])
+        );
         assert!(redirect.tls.is_none());
 
         // Redirect middleware
-        let mw = parsed.http.middlewares.as_ref().expect("middlewares missing");
-        let rs = mw.get("redirect-https").expect("redirect-https middleware missing");
+        let mw = parsed
+            .http
+            .middlewares
+            .as_ref()
+            .expect("middlewares missing");
+        let rs = mw
+            .get("redirect-https")
+            .expect("redirect-https middleware missing");
         let scheme = rs.redirect_scheme.as_ref().expect("redirectScheme missing");
         assert_eq!(scheme.scheme, "https");
         assert!(scheme.permanent);
 
         // Service exists
-        let svc = parsed.http.services.get("status-page").expect("service missing");
+        let svc = parsed
+            .http
+            .services
+            .get("status-page")
+            .expect("service missing");
         assert_eq!(svc.load_balancer.servers[0].url, "http://xnet-status:8899");
     }
 

--- a/apps/xnet/lib/src/services/traefik_config.rs
+++ b/apps/xnet/lib/src/services/traefik_config.rs
@@ -455,7 +455,13 @@ mod tests {
 
     fn temp_config() -> (TraefikConfig, NamedTempFile) {
         let file = NamedTempFile::new().unwrap();
-        let config = TraefikConfig::new(file.path()).unwrap();
+        let config = TraefikConfig::new(file.path(), false).unwrap();
+        (config, file)
+    }
+
+    fn temp_config_tls() -> (TraefikConfig, NamedTempFile) {
+        let file = NamedTempFile::new().unwrap();
+        let config = TraefikConfig::new(file.path(), true).unwrap();
         (config, file)
     }
 
@@ -593,7 +599,7 @@ mod tests {
 
         // Re-load from file — extra routes should NOT be recovered
         // (they are memory-only, sourced from TOML config)
-        let config2 = TraefikConfig::new(file.path()).unwrap();
+        let config2 = TraefikConfig::new(file.path(), false).unwrap();
         assert!(config2.routes().is_empty());
 
         // Extra routes Vec should be empty on fresh load

--- a/apps/xnet/lib/src/services/traefik_config.rs
+++ b/apps/xnet/lib/src/services/traefik_config.rs
@@ -47,6 +47,8 @@ struct HttpConfig {
     services: HashMap<String, TraefikService>,
     #[serde(rename = "serversTransports", skip_serializing_if = "Option::is_none")]
     servers_transports: Option<HashMap<String, ServersTransport>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    middlewares: Option<HashMap<String, Middleware>>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -55,6 +57,12 @@ struct Router {
     service: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     priority: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tls: Option<TlsConfig>,
+    #[serde(rename = "entryPoints", skip_serializing_if = "Option::is_none")]
+    entry_points: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    middlewares: Option<Vec<String>>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -75,6 +83,24 @@ struct LoadBalancer {
 #[derive(Debug, Serialize, Deserialize)]
 struct Server {
     url: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct TlsConfig {
+    #[serde(rename = "certResolver", skip_serializing_if = "Option::is_none")]
+    cert_resolver: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Middleware {
+    #[serde(rename = "redirectScheme", skip_serializing_if = "Option::is_none")]
+    redirect_scheme: Option<RedirectScheme>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct RedirectScheme {
+    scheme: String,
+    permanent: bool,
 }
 
 impl TraefikConfig {
@@ -227,6 +253,9 @@ impl TraefikConfig {
                     rule: format!("Host(`{}`)", hostname),
                     service: name.clone(),
                     priority: None,
+                    tls: None,
+                    entry_points: None,
+                    middlewares: None,
                 },
             );
 
@@ -245,15 +274,53 @@ impl TraefikConfig {
         }
 
         // Extra routes (user-defined, may use any URL/rule)
+        let mut middlewares = HashMap::new();
+        let mut any_tls = false;
+
         for route in extra.iter() {
-            routers.insert(
-                route.name.clone(),
-                Router {
-                    rule: route.rule.clone(),
-                    service: route.name.clone(),
-                    priority: route.priority,
-                },
-            );
+            if route.tls {
+                any_tls = true;
+
+                // HTTPS router with cert resolver
+                routers.insert(
+                    route.name.clone(),
+                    Router {
+                        rule: route.rule.clone(),
+                        service: route.name.clone(),
+                        priority: route.priority,
+                        tls: Some(TlsConfig {
+                            cert_resolver: Some("letsencrypt".to_string()),
+                        }),
+                        entry_points: Some(vec!["https".to_string()]),
+                        middlewares: None,
+                    },
+                );
+
+                // HTTP → HTTPS redirect router
+                routers.insert(
+                    format!("{}-redirect", route.name),
+                    Router {
+                        rule: route.rule.clone(),
+                        service: route.name.clone(),
+                        priority: route.priority,
+                        entry_points: Some(vec!["http".to_string()]),
+                        middlewares: Some(vec!["redirect-https".to_string()]),
+                        tls: None,
+                    },
+                );
+            } else {
+                routers.insert(
+                    route.name.clone(),
+                    Router {
+                        rule: route.rule.clone(),
+                        service: route.name.clone(),
+                        priority: route.priority,
+                        tls: None,
+                        entry_points: None,
+                        middlewares: None,
+                    },
+                );
+            }
 
             services.insert(
                 route.name.clone(),
@@ -269,11 +336,29 @@ impl TraefikConfig {
             );
         }
 
+        // Insert redirect middleware once if any route uses TLS
+        if any_tls {
+            middlewares.insert(
+                "redirect-https".to_string(),
+                Middleware {
+                    redirect_scheme: Some(RedirectScheme {
+                        scheme: "https".to_string(),
+                        permanent: true,
+                    }),
+                },
+            );
+        }
+
         let config = TraefikDynamicConfig {
             http: HttpConfig {
                 routers,
                 services,
                 servers_transports: None,
+                middlewares: if middlewares.is_empty() {
+                    None
+                } else {
+                    Some(middlewares)
+                },
             },
         };
 
@@ -478,5 +563,105 @@ mod tests {
         // Extra routes Vec should be empty on fresh load
         let extra = config2.extra_routes.lock().unwrap();
         assert!(extra.is_empty());
+    }
+
+    #[test]
+    fn tls_route_generates_router_with_cert_resolver_and_redirect() {
+        let (config, file) = temp_config();
+        config
+            .set_extra_routes(vec![ExtraTraefikRoute {
+                name: "status-page".to_string(),
+                rule: "Host(`migrate.xmtp.run`)".to_string(),
+                url: "http://xnet-status:8899".to_string(),
+                priority: Some(100),
+                tls: true,
+            }])
+            .unwrap();
+
+        let contents = fs::read_to_string(file.path()).unwrap();
+        let parsed: TraefikDynamicConfig = serde_yaml::from_str(&contents).unwrap();
+
+        // HTTPS router with certResolver
+        let router = parsed.http.routers.get("status-page").expect("HTTPS router missing");
+        assert_eq!(router.entry_points, Some(vec!["https".to_string()]));
+        let tls = router.tls.as_ref().expect("tls config missing");
+        assert_eq!(tls.cert_resolver, Some("letsencrypt".to_string()));
+
+        // HTTP→HTTPS redirect router
+        let redirect = parsed.http.routers.get("status-page-redirect").expect("redirect router missing");
+        assert_eq!(redirect.entry_points, Some(vec!["http".to_string()]));
+        assert_eq!(redirect.middlewares, Some(vec!["redirect-https".to_string()]));
+        assert!(redirect.tls.is_none());
+
+        // Redirect middleware
+        let mw = parsed.http.middlewares.as_ref().expect("middlewares missing");
+        let rs = mw.get("redirect-https").expect("redirect-https middleware missing");
+        let scheme = rs.redirect_scheme.as_ref().expect("redirectScheme missing");
+        assert_eq!(scheme.scheme, "https");
+        assert!(scheme.permanent);
+
+        // Service exists
+        let svc = parsed.http.services.get("status-page").expect("service missing");
+        assert_eq!(svc.load_balancer.servers[0].url, "http://xnet-status:8899");
+    }
+
+    #[test]
+    fn non_tls_route_has_no_tls_fields() {
+        let (config, file) = temp_config();
+        config
+            .set_extra_routes(vec![ExtraTraefikRoute {
+                name: "grafana".to_string(),
+                rule: "Host(`grafana.xmtp.run`)".to_string(),
+                url: "http://xnet-grafana:3000".to_string(),
+                priority: None,
+                tls: false,
+            }])
+            .unwrap();
+
+        let contents = fs::read_to_string(file.path()).unwrap();
+        let parsed: TraefikDynamicConfig = serde_yaml::from_str(&contents).unwrap();
+
+        let router = parsed.http.routers.get("grafana").expect("router missing");
+        assert!(router.tls.is_none());
+        assert!(router.entry_points.is_none());
+        assert!(router.middlewares.is_none());
+
+        // No redirect router
+        assert!(parsed.http.routers.get("grafana-redirect").is_none());
+    }
+
+    #[test]
+    fn mixed_tls_and_non_tls_routes() {
+        let (config, file) = temp_config();
+        config
+            .set_extra_routes(vec![
+                ExtraTraefikRoute {
+                    name: "status-page".to_string(),
+                    rule: "Host(`migrate.xmtp.run`)".to_string(),
+                    url: "http://xnet-status:8899".to_string(),
+                    priority: Some(100),
+                    tls: true,
+                },
+                ExtraTraefikRoute {
+                    name: "grafana".to_string(),
+                    rule: "Host(`grafana.xmtp.run`)".to_string(),
+                    url: "http://xnet-grafana:3000".to_string(),
+                    priority: None,
+                    tls: false,
+                },
+            ])
+            .unwrap();
+
+        let contents = fs::read_to_string(file.path()).unwrap();
+        let parsed: TraefikDynamicConfig = serde_yaml::from_str(&contents).unwrap();
+
+        // TLS route: main + redirect = 2 routers, non-TLS: 1 router => total 3
+        assert_eq!(parsed.http.routers.len(), 3);
+        assert!(parsed.http.routers.contains_key("status-page"));
+        assert!(parsed.http.routers.contains_key("status-page-redirect"));
+        assert!(parsed.http.routers.contains_key("grafana"));
+
+        // Only 2 services (redirect router shares the service)
+        assert_eq!(parsed.http.services.len(), 2);
     }
 }

--- a/apps/xnet/lib/src/services/traefik_config.rs
+++ b/apps/xnet/lib/src/services/traefik_config.rs
@@ -23,6 +23,8 @@ use crate::config::ExtraTraefikRoute;
 pub struct TraefikConfig {
     /// Path to the dynamic configuration file
     config_path: PathBuf,
+    /// File-based TLS mode — all routes get HTTPS entrypoint
+    use_tls: bool,
     /// Hostname -> ToxiProxy port mapping (thread-safe)
     routes: Arc<Mutex<HashMap<String, u16>>>,
     /// User-defined extra routes (from TOML config, stored in memory only)
@@ -155,7 +157,7 @@ impl TraefikConfig {
     /// The config file will be written to the specified path.
     /// Creates parent directories if they don't exist.
     /// Loads existing routes from the file if it exists.
-    pub fn new(config_path: impl Into<PathBuf>) -> Result<Self> {
+    pub fn new(config_path: impl Into<PathBuf>, use_tls: bool) -> Result<Self> {
         let config_path = config_path.into();
 
         // Create parent directory if it doesn't exist
@@ -173,6 +175,7 @@ impl TraefikConfig {
 
         Ok(Self {
             config_path,
+            use_tls,
             routes: Arc::new(Mutex::new(routes)),
             extra_routes: Arc::new(Mutex::new(Vec::new())),
         })
@@ -242,22 +245,51 @@ impl TraefikConfig {
 
         let mut routers = HashMap::new();
         let mut services = HashMap::new();
+        let mut middlewares = HashMap::new();
+        let mut any_tls = false;
 
         for (hostname, toxi_port) in routes.iter() {
-            // Generate a safe router/service name from hostname
             let name = hostname.replace(['.', '-'], "_");
 
-            routers.insert(
-                name.clone(),
-                Router {
-                    rule: format!("Host(`{}`)", hostname),
-                    service: name.clone(),
-                    priority: None,
-                    tls: None,
-                    entry_points: None,
-                    middlewares: None,
-                },
-            );
+            if self.use_tls {
+                // HTTPS router (primary)
+                routers.insert(
+                    name.clone(),
+                    Router {
+                        rule: format!("Host(`{}`)", hostname),
+                        service: name.clone(),
+                        priority: None,
+                        tls: Some(TlsConfig { cert_resolver: None }),
+                        entry_points: Some(vec!["https".to_string()]),
+                        middlewares: None,
+                    },
+                );
+                // HTTP → HTTPS redirect router
+                routers.insert(
+                    format!("{}_redirect", name),
+                    Router {
+                        rule: format!("Host(`{}`)", hostname),
+                        service: name.clone(),
+                        priority: None,
+                        tls: None,
+                        entry_points: Some(vec!["http".to_string()]),
+                        middlewares: Some(vec!["redirect-https".to_string()]),
+                    },
+                );
+                any_tls = true;
+            } else {
+                routers.insert(
+                    name.clone(),
+                    Router {
+                        rule: format!("Host(`{}`)", hostname),
+                        service: name.clone(),
+                        priority: None,
+                        tls: None,
+                        entry_points: None,
+                        middlewares: None,
+                    },
+                );
+            }
 
             services.insert(
                 name,
@@ -274,12 +306,18 @@ impl TraefikConfig {
         }
 
         // Extra routes (user-defined, may use any URL/rule)
-        let mut middlewares = HashMap::new();
-        let mut any_tls = false;
 
         for route in extra.iter() {
             if route.tls {
                 any_tls = true;
+
+                let tls_config = if self.use_tls {
+                    TlsConfig { cert_resolver: None }
+                } else {
+                    TlsConfig {
+                        cert_resolver: Some("letsencrypt".to_string()),
+                    }
+                };
 
                 // HTTPS router with cert resolver
                 routers.insert(
@@ -288,9 +326,7 @@ impl TraefikConfig {
                         rule: route.rule.clone(),
                         service: route.name.clone(),
                         priority: route.priority,
-                        tls: Some(TlsConfig {
-                            cert_resolver: Some("letsencrypt".to_string()),
-                        }),
+                        tls: Some(tls_config),
                         entry_points: Some(vec!["https".to_string()]),
                         middlewares: None,
                     },

--- a/apps/xnet/lib/src/services/xmtpd.rs
+++ b/apps/xnet/lib/src/services/xmtpd.rs
@@ -267,8 +267,10 @@ impl Xmtpd {
 
     /// External URL for access through ToxiProxy.
     /// Returns hostname for unified addressing.
+    /// Uses the configured `public_scheme` ("http" or "https").
     pub fn external_url(&self) -> Url {
-        Url::parse(&format!("http://{}", self.hostname())).expect("valid URL")
+        let config = Config::load_unchecked();
+        Url::parse(&format!("{}://{}", config.public_scheme, self.hostname())).expect("valid URL")
     }
 
     /// Container name derived from the node ID.

--- a/apps/xnet/lib/src/services/xmtpd.rs
+++ b/apps/xnet/lib/src/services/xmtpd.rs
@@ -267,8 +267,11 @@ impl Xmtpd {
 
     /// External URL for access through ToxiProxy.
     /// Returns hostname for unified addressing.
+    /// Uses `https://` when `use_tls` is enabled.
     pub fn external_url(&self) -> Url {
-        Url::parse(&format!("http://{}", self.hostname())).expect("valid URL")
+        let config = Config::load_unchecked();
+        let scheme = if config.use_tls { "https" } else { "http" };
+        Url::parse(&format!("{}://{}", scheme, self.hostname())).expect("valid URL")
     }
 
     /// Container name derived from the node ID.

--- a/apps/xnet/lib/src/types.rs
+++ b/apps/xnet/lib/src/types.rs
@@ -9,7 +9,7 @@ use xmtp_proto::{
     prelude::{ApiBuilder, NetConnectConfig},
 };
 
-use crate::{Config, constants::Xmtpd as XmtpdConst, services::allocate_xmtpd_port};
+use crate::{constants::Xmtpd as XmtpdConst, services::allocate_xmtpd_port};
 
 /// An XMTPD node that must run at `port`
 /// and is owned by `signer`.
@@ -42,23 +42,6 @@ pub fn resolve_port(use_standard_port: bool, port: Option<u16>) -> Result<u16> {
 }
 
 impl XmtpdNode {
-    pub async fn new(gateway_host: &str, use_standard_port: bool) -> Result<Self> {
-        let config = Config::load()?;
-        let next_id = Self::get_next_id(gateway_host).await?;
-        let port = resolve_port(use_standard_port, None)?;
-
-        let num_ids = next_id / XmtpdConst::NODE_ID_INCREMENT;
-        let base_idx = num_ids as usize * 3 + 1;
-        Ok(Self {
-            port,
-            node_id: next_id,
-            signer: config.signers[base_idx].clone(),
-            payer: config.signers[base_idx + 1].clone(),
-            migration_payer: config.signers[base_idx + 2].clone(),
-            name: format!("xnet-{}", next_id),
-        })
-    }
-
     pub fn name(&self) -> &String {
         &self.name
     }

--- a/apps/xnet/lib/src/xmtpd_cli.rs
+++ b/apps/xnet/lib/src/xmtpd_cli.rs
@@ -81,10 +81,14 @@ impl XmtpdCli {
             "register".to_string(),
             format!("--owner-address={addr}"),
             format!("--signing-key-pub=0x{pubkey}"),
-            format!(
-                "--http-address=http://{}",
-                Config::load_unchecked().address_mode.hostname(&node.name())
-            ),
+            {
+                let cfg = Config::load_unchecked();
+                format!(
+                    "--http-address={}://{}",
+                    cfg.public_scheme,
+                    cfg.address_mode.hostname(&node.name())
+                )
+            },
         ];
         self.run(cmd, None, w).await?;
         Ok(())

--- a/crates/xmtp_api_d14n/src/queries/builder.rs
+++ b/crates/xmtp_api_d14n/src/queries/builder.rs
@@ -27,6 +27,11 @@ pub struct MessageBackendBuilder {
 
 #[derive(Error, Debug, ErrorCode)]
 pub enum MessageBackendBuilderError {
+    /// Missing XMTPD host.
+    ///
+    /// XMTPD host was not set on the builder. Not retryable.
+    #[error("Xmtpd Host is Required")]
+    MissingXmtpdHost,
     /// Missing V3 host.
     ///
     /// V3 host was not set on the builder. Not retryable.
@@ -84,7 +89,7 @@ pub enum MessageBackendBuilderError {
 }
 
 impl MessageBackendBuilderError {
-    pub fn invalid_url(e: url::ParseError, url: String) -> Self {
+    pub fn bad_url(e: url::ParseError, url: String) -> Self {
         MessageBackendBuilderError::InvalidUrl { url, source: e }
     }
 }
@@ -115,12 +120,19 @@ impl MessageBackendBuilder {
     }
 
     /// Specify the node host as an Option<T>
-    /// for d14n this is the replication node
     /// for v3 this is xmtp-node-go
     ///
     /// Required for V3 mode; optional when gateway_host is provided (D14n mode).
     pub fn maybe_v3_host<S: Into<String>>(&mut self, host: Option<S>) -> &mut Self {
         self.client_bundle.maybe_v3_host(host);
+        self
+    }
+
+    /// Specify the node host as an Option<T>
+    ///
+    /// Required for xmtpd single-node mode
+    pub fn maybe_xmtpd_host<S: Into<String>>(&mut self, host: Option<S>) -> &mut Self {
+        self.client_bundle.maybe_xmtpd_host(host);
         self
     }
 

--- a/crates/xmtp_api_d14n/src/queries/builder.rs
+++ b/crates/xmtp_api_d14n/src/queries/builder.rs
@@ -216,6 +216,15 @@ impl MessageBackendBuilder {
         self.from_bundle(bundle)
     }
 
+    /// Builds a d14n client that reads from a single node directly (no MultiNodeClient).
+    /// Writes still route to the gateway.
+    /// Errors if V3 Host or Gateway Host is missing.
+    pub fn build_d14n_single(&mut self) -> Result<XmtpApiClient, MessageBackendBuilderError> {
+        let Self { client_bundle, .. } = self;
+        let bundle = client_bundle.build_d14n_single()?;
+        self.from_bundle(bundle)
+    }
+
     /// If a gateway host is present, builds d14n-only
     /// otherwise builds a v3 client
     /// Errors if V3 Host is missing

--- a/crates/xmtp_api_d14n/src/queries/client_bundle.rs
+++ b/crates/xmtp_api_d14n/src/queries/client_bundle.rs
@@ -94,6 +94,8 @@ struct __ClientBundleBuilder {
     #[builder(setter(into))]
     v3_host: String,
     #[builder(setter(into))]
+    xmtpd_host: String,
+    #[builder(setter(into))]
     gateway_host: String,
     #[builder(setter(into))]
     auth_callback: Arc<dyn AuthCallback>,
@@ -102,7 +104,6 @@ struct __ClientBundleBuilder {
     readonly: bool,
 }
 
-// getters
 impl ClientBundleBuilder {
     pub fn get_v3_host(&self) -> Option<&String> {
         self.v3_host.as_ref()
@@ -117,7 +118,6 @@ impl ClientBundleBuilder {
     }
 }
 
-// setters
 impl ClientBundleBuilder {
     /// Set the v3 host if `host` is `Some`
     /// Overwrites any value that may already be set
@@ -151,6 +151,12 @@ impl ClientBundleBuilder {
         self.app_version = version.map(Into::into).or_else(|| self.app_version.take());
         self
     }
+
+    pub fn maybe_xmtpd_host<U: Into<String>>(&mut self, host: Option<U>) -> &mut Self {
+        self.xmtpd_host = host.map(Into::into).or_else(|| self.xmtpd_host.take());
+        self
+    }
+
     /// Specify a fallback value for the V3 Host. Only used as a fallback.
     /// `v3_host()` always takes precedence. Never overwrites `v3_host` if already set.
     pub fn env(&mut self, env: XmtpEnv) -> &mut Self {
@@ -166,53 +172,69 @@ impl ClientBundleBuilder {
         &mut self,
     ) -> Result<(ArcClient, Option<xmtp_proto::types::AppVersion>), MessageBackendBuilderError>
     {
-        let Self {
-            app_version,
-            auth_callback,
-            auth_handle,
-            ..
-        } = self.clone();
+        use MessageBackendBuilderError::*;
+        let app_version = self.app_version.clone();
         let gw_host = self
             .gateway_host
             .as_ref()
-            .ok_or(MessageBackendBuilderError::MissingGatewayHost)?;
+            .ok_or(MissingGatewayHost)?
+            .clone();
         let readonly = self.readonly.unwrap_or_default();
 
-        let mut gateway_client_builder = GrpcClient::builder();
-        gateway_client_builder.set_host(
+        let mut gw_builder = GrpcClient::builder();
+        gw_builder.set_host(
             gw_host
                 .parse()
-                .map_err(|e| MessageBackendBuilderError::invalid_url(e, gw_host.clone()))?,
+                .map_err(|e| MessageBackendBuilderError::bad_url(e, gw_host.to_string()))?,
         );
-
-        if let Some(ref version) = app_version {
-            gateway_client_builder.set_app_version(version.clone())?;
+        if let Some(ref version) = self.app_version {
+            gw_builder.set_app_version(version.clone())?;
         }
 
-        let gateway_client = gateway_client_builder.build()?;
-        let gateway_client = if auth_callback.is_some() || auth_handle.is_some() {
-            crate::AuthMiddleware::new(gateway_client, auth_callback, auth_handle).arced()
+        let gateway_client = gw_builder.build()?;
+        let gateway_client = if self.auth_callback.is_some() || self.auth_handle.is_some() {
+            crate::AuthMiddleware::new(
+                gateway_client,
+                self.auth_callback.clone(),
+                self.auth_handle.clone(),
+            )
+            .arced()
         } else {
             gateway_client.arced()
         };
 
-        let mut multi_node = crate::middleware::MultiNodeClient::builder();
-        let multi_node = multi_node.gateway_client(gateway_client.clone());
-        let mut template = GrpcClient::builder();
-        if let Some(ref version) = app_version {
-            template.set_app_version(version.clone())?;
-        }
-        let multi_node = multi_node.node_client_template(template).build()?;
+        // if the xmtpd host is explicitly specified, build a client
+        // that will use only that host.
+        let xmtpd: ArcClient = if let Some(xmtpd_host) = &self.xmtpd_host {
+            let mut xmtpd = GrpcClient::builder();
+            xmtpd.set_host(
+                xmtpd_host
+                    .parse()
+                    .map_err(|e| MessageBackendBuilderError::bad_url(e, xmtpd_host.to_string()))?,
+            );
+            if let Some(ref version) = self.app_version {
+                xmtpd.set_app_version(version.clone())?;
+            }
+            Ok::<_, MessageBackendBuilderError>(xmtpd.build()?.arced())
+        } else {
+            let mut multi_node = crate::middleware::MultiNodeClient::builder();
+            let multi_node = multi_node.gateway_client(gateway_client.clone());
+            let mut template = GrpcClient::builder();
+            if let Some(ref version) = app_version {
+                template.set_app_version(version.clone())?;
+            }
+            Ok(multi_node.node_client_template(template).build()?.arced())
+        }?;
 
         if readonly {
             return Ok((
-                ReadonlyClient::builder().inner(multi_node).build()?.arced(),
+                ReadonlyClient::builder().inner(xmtpd).build()?.arced(),
                 app_version,
             ));
         }
 
         let client = ReadWriteClient::builder()
-            .read(multi_node)
+            .read(xmtpd)
             .write(gateway_client)
             .filter(PAYER_WRITE_FILTER)
             .build()?;
@@ -229,16 +251,14 @@ impl ClientBundleBuilder {
     }
 
     fn inner_build_v3(&mut self) -> Result<ArcClient, MessageBackendBuilderError> {
-        let v3_host = self
-            .v3_host
-            .as_ref()
-            .ok_or(MessageBackendBuilderError::MissingV3Host)?;
+        use MessageBackendBuilderError::*;
+        let v3_host = self.v3_host.as_ref().ok_or(MissingV3Host)?;
         let readonly = self.readonly.unwrap_or_default();
         let mut v3_client = GrpcClient::builder();
         v3_client.set_host(
             v3_host
                 .parse()
-                .map_err(|e| MessageBackendBuilderError::invalid_url(e, v3_host.clone()))?,
+                .map_err(|e| MessageBackendBuilderError::bad_url(e, v3_host.clone()))?,
         );
         if let Some(ref version) = self.app_version {
             v3_client.set_app_version(version.clone())?;

--- a/crates/xmtp_api_d14n/src/queries/client_bundle.rs
+++ b/crates/xmtp_api_d14n/src/queries/client_bundle.rs
@@ -228,6 +228,91 @@ impl ClientBundleBuilder {
         Ok(ClientBundle::d14n(client, app_version))
     }
 
+    /// Build a D14n client that reads from a single node directly and writes to the gateway.
+    /// Requires both `v3_host` (the direct node URL) and `gateway_host` (for writes).
+    /// Skips `MultiNodeClient` — no gateway-based node discovery for reads.
+    fn inner_build_d14n_single(
+        &mut self,
+    ) -> Result<(ArcClient, Option<xmtp_proto::types::AppVersion>), MessageBackendBuilderError>
+    {
+        let Self {
+            app_version,
+            auth_callback,
+            auth_handle,
+            ..
+        } = self.clone();
+        let v3_host = self
+            .v3_host
+            .as_ref()
+            .ok_or(MessageBackendBuilderError::MissingV3Host)?;
+        let gw_host = self
+            .gateway_host
+            .as_ref()
+            .ok_or(MessageBackendBuilderError::MissingGatewayHost)?;
+        let readonly = self.readonly.unwrap_or_default();
+
+        // Build the direct node client (for reads)
+        let mut read_builder = GrpcClient::builder();
+        read_builder.set_host(
+            v3_host
+                .parse()
+                .map_err(|e| MessageBackendBuilderError::invalid_url(e, v3_host.clone()))?,
+        );
+        if let Some(ref version) = app_version {
+            read_builder.set_app_version(version.clone())?;
+        }
+        let read_client = read_builder.build()?;
+        let read_client = if auth_callback.is_some() || auth_handle.is_some() {
+            crate::AuthMiddleware::new(read_client, auth_callback.clone(), auth_handle.clone())
+                .arced()
+        } else {
+            read_client.arced()
+        };
+
+        if readonly {
+            return Ok((
+                ReadonlyClient::builder()
+                    .inner(read_client)
+                    .build()?
+                    .arced(),
+                app_version,
+            ));
+        }
+
+        // Build the gateway client (for writes)
+        let mut write_builder = GrpcClient::builder();
+        write_builder.set_host(
+            gw_host
+                .parse()
+                .map_err(|e| MessageBackendBuilderError::invalid_url(e, gw_host.clone()))?,
+        );
+        if let Some(ref version) = app_version {
+            write_builder.set_app_version(version.clone())?;
+        }
+        let write_client = write_builder.build()?;
+        let write_client = if auth_callback.is_some() || auth_handle.is_some() {
+            crate::AuthMiddleware::new(write_client, auth_callback, auth_handle).arced()
+        } else {
+            write_client.arced()
+        };
+
+        let client = ReadWriteClient::builder()
+            .read(read_client)
+            .write(write_client)
+            .filter(PAYER_WRITE_FILTER)
+            .build()?;
+
+        Ok((client.arced(), app_version))
+    }
+
+    /// Build a D14n client using a single node for reads (no MultiNodeClient).
+    /// Writes still route to the gateway.
+    /// Requires both `v3_host` and `gateway_host`.
+    pub fn build_d14n_single(&mut self) -> Result<ClientBundle, MessageBackendBuilderError> {
+        let (client, app_version) = self.inner_build_d14n_single()?;
+        Ok(ClientBundle::d14n(client, app_version))
+    }
+
     fn inner_build_v3(&mut self) -> Result<ArcClient, MessageBackendBuilderError> {
         let v3_host = self
             .v3_host

--- a/docs/superpowers/specs/2026-04-13-extra-traefik-routes.md
+++ b/docs/superpowers/specs/2026-04-13-extra-traefik-routes.md
@@ -1,0 +1,231 @@
+# Extra Traefik Routes — Design Spec
+
+## Overview
+
+Add support for user-defined Traefik routes in xnet's TOML configuration. This allows the NixOS deployment to inject additional routes (e.g., a status page) into Traefik's dynamic config alongside the auto-generated service routes.
+
+## Motivation
+
+The xnet Hetzner deployment runs a status page via Caddy on an internal port (8899). Traefik owns port 80 and handles all incoming HTTP/gRPC traffic. We need Traefik to route `Host(`migrate.xmtp.run`)` to the status page without putting another proxy (like Caddy or nginx) in front of Traefik, which breaks gRPC.
+
+## TOML Configuration
+
+New top-level array of tables in `xnet.toml`:
+
+```toml
+[[extra_traefik_routes]]
+name = "status-page"
+rule = "Host(`migrate.xmtp.run`)"
+url = "http://host.docker.internal:8899"
+priority = 100
+
+[[extra_traefik_routes]]
+name = "another-service"
+rule = "Host(`other.example.com`)"
+url = "http://host.docker.internal:9999"
+```
+
+### Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | yes | Unique identifier for the router and service in Traefik's dynamic config. Must be a valid Traefik service name (alphanumeric, hyphens, underscores). |
+| `rule` | string | yes | Traefik matcher rule. Passed through verbatim. Any valid [Traefik router rule](https://doc.traefik.io/traefik/routing/routers/#rule) works: `Host(...)`, `PathPrefix(...)`, `Headers(...)`, combinations with `&&`/`||`. |
+| `url` | string | yes | Backend URL. Where Traefik forwards matching requests. Supports `http://`, `https://`, and `h2c://` schemes. **Important:** This URL must be reachable from inside the Traefik Docker container (see URL Addressing below). |
+| `priority` | integer | no | Traefik router priority. Higher values match first. If omitted, Traefik uses its default priority (based on rule length). Useful to ensure extra routes take precedence over wildcard service routes. |
+
+### URL Addressing
+
+The `url` field is used by Traefik inside its Docker container. This means:
+
+- **`127.0.0.1` / `localhost`** refers to the Traefik container itself, NOT the host machine. Do not use these for host services.
+- **`host.docker.internal`** resolves to the host machine (Docker Engine 20.10+, Linux and macOS). The Traefik container is configured with `extra_hosts: ["host.docker.internal:host-gateway"]` to enable this.
+- **Docker container names** (e.g., `xnet-toxiproxy`) are reachable directly by name on the `xnet` network.
+
+For services running on the host (like a Caddy status page on port 8899), use:
+```toml
+url = "http://host.docker.internal:8899"
+```
+
+For services running in Docker on the xnet network, use the container name:
+```toml
+url = "http://my-container:8080"
+```
+
+### Defaults
+
+If `[[extra_traefik_routes]]` is omitted entirely, no extra routes are added. The existing auto-generated service routes are unaffected.
+
+## Implementation
+
+### Rust changes (xnet-cli)
+
+**File: `apps/xnet/lib/src/config/toml_config.rs`**
+
+Add a new struct and field to `TomlConfig`:
+
+```rust
+#[derive(Deserialize, Default, Debug, Clone)]
+pub struct ExtraTraefikRoute {
+    pub name: String,
+    pub rule: String,
+    pub url: String,
+    pub priority: Option<i32>,
+}
+```
+
+Add to `TomlConfig`:
+
+```rust
+#[serde(default)]
+pub extra_traefik_routes: Vec<ExtraTraefikRoute>,
+```
+
+**File: `apps/xnet/lib/src/config/loadable.rs`**
+
+Propagate extra routes from `TomlConfig` to `Config`. Add a new field to the `Config` struct:
+
+```rust
+/// Extra Traefik routes from TOML config
+#[builder(default)]
+pub extra_traefik_routes: Vec<ExtraTraefikRoute>,
+```
+
+And in `Config::load()`, wire it through the builder (around line 178):
+
+```rust
+.extra_traefik_routes(toml.extra_traefik_routes)
+```
+
+**File: `apps/xnet/lib/src/services/traefik.rs`**
+
+Add `host.docker.internal` to the Traefik container's `HostConfig` so it can reach host services:
+
+```rust
+extra_hosts: Some(vec!["host.docker.internal:host-gateway".to_string()]),
+```
+
+**File: `apps/xnet/lib/src/services/traefik_config.rs`**
+
+The current `TraefikConfig` stores routes as `HashMap<String, u16>` (hostname -> ToxiProxy port), which cannot represent extra routes with arbitrary URLs and matcher rules. Add a separate `Vec` for extra routes:
+
+```rust
+pub struct TraefikConfig {
+    config_path: PathBuf,
+    /// Hostname -> ToxiProxy port mapping (auto-generated service routes)
+    routes: Arc<Mutex<HashMap<String, u16>>>,
+    /// User-defined extra routes (from TOML config, stored in memory only)
+    extra_routes: Arc<Mutex<Vec<ExtraTraefikRoute>>>,
+}
+```
+
+Extra routes are **not** round-tripped through the YAML file. The current `load_from_file()` parses routes by extracting hostnames from `Host(...)` rules and ports from URLs — extra routes with arbitrary rules/URLs would be silently discarded on reload. Instead, extra routes are stored only in memory from the TOML config and re-merged into `dynamic.yml` on every `write()` call.
+
+Update `write()` to merge both route types into the YAML output. Add `set_extra_routes()`:
+
+```rust
+pub fn set_extra_routes(&self, routes: Vec<ExtraTraefikRoute>) -> Result<()> {
+    {
+        let mut extra = self.extra_routes.lock().unwrap();
+        *extra = routes;
+    }
+    self.write()?;
+    Ok(())
+}
+```
+
+**File: `apps/xnet/lib/src/app/service_manager.rs`**
+
+After creating `traefik_config` (line 84), use the existing `config` variable (already loaded at line 67):
+
+```rust
+let traefik_config = TraefikConfig::new(traefik.dynamic_config_path())?;
+if !config.extra_traefik_routes.is_empty() {
+    traefik_config.set_extra_routes(config.extra_traefik_routes.clone())?;
+}
+```
+
+### Dynamic config output
+
+For a route like:
+
+```toml
+[[extra_traefik_routes]]
+name = "status-page"
+rule = "Host(`migrate.xmtp.run`)"
+url = "http://host.docker.internal:8899"
+priority = 100
+```
+
+The generated `dynamic.yml` should include:
+
+```yaml
+http:
+  routers:
+    status-page:
+      rule: "Host(`migrate.xmtp.run`)"
+      service: status-page
+      priority: 100
+  services:
+    status-page:
+      loadBalancer:
+        servers:
+          - url: "http://host.docker.internal:8899"
+        passHostHeader: true
+```
+
+Extra routes are merged with auto-generated service routes in the same `dynamic.yml`. Name collisions between extra routes and auto-generated routes are unlikely in practice: auto-generated routes use sanitized hostnames as keys (e.g. `node100_xmtpd_local`), while extra routes use user-chosen names (e.g. `status-page`). If a collision does occur, extra routes are inserted after auto-generated routes in `write()`, so they overwrite the auto-generated entry in the `HashMap` — but this is coincidental, not a guaranteed ordering. To avoid surprises, choose extra route names that don't resemble sanitized hostnames.
+
+### NixOS changes (xnet-public)
+
+**File: `modules/xnet.nix`**
+
+Add a new option:
+
+```nix
+extraTraefikRoutes = lib.mkOption {
+  type = lib.types.listOf (lib.types.submodule {
+    options = {
+      name = lib.mkOption { type = lib.types.str; };
+      rule = lib.mkOption { type = lib.types.str; };
+      url = lib.mkOption { type = lib.types.str; };
+      priority = lib.mkOption {
+        type = lib.types.nullOr lib.types.int;
+        default = null;
+      };
+    };
+  });
+  default = [];
+  description = "Additional Traefik routes to inject into the dynamic config";
+};
+```
+
+Add to TOML generation:
+
+```nix
+extra_traefik_routes = map (r:
+  { inherit (r) name rule url; }
+  // lib.optionalAttrs (r.priority != null) { inherit (r) priority; }
+) cfg.settings.extraTraefikRoutes;
+```
+
+**File: `modules/xnet-status/default.nix`**
+
+Remove the `xnet-status-route` systemd service. Instead, configure the route declaratively:
+
+```nix
+services.xnet.settings.extraTraefikRoutes = [{
+  name = "status-page";
+  rule = "Host(`${cfg.domain}`)";
+  url = "http://host.docker.internal:8899";
+  priority = 100;
+}];
+```
+
+## Testing
+
+1. **Local (no extra routes)**: Run xnet-cli with a config that has no `[[extra_traefik_routes]]`. Verify `dynamic.yml` contains only auto-generated service routes.
+2. **Local (with extra routes)**: Add a route to the TOML config. Verify it appears in `dynamic.yml` alongside service routes.
+3. **Hetzner deploy**: Provision with the status page route configured. Verify `http://migrate.xmtp.run` serves the status page and `http://xnet-100.5-161-27-26.sslip.io` routes to xmtpd.
+4. **Priority**: Verify that the extra route with `priority = 100` takes precedence over any auto-generated wildcard routes that might also match.
+5. **host.docker.internal**: Verify that `host.docker.internal` resolves correctly from inside the Traefik container on Linux (`docker exec xnet-traefik ping -c1 host.docker.internal`).


### PR DESCRIPTION
  Summary

  - Add enable_v3, enable_d14n, enable_monitoring boolean flags to [xnet] TOML config (all default true) to allow disabling unnecessary service groups in CI
  - Restructure [traefik] and [toxiproxy] into standalone config sections with image/version/port fields
  - Extract Anvil, Validation, and History as shared services that start when either V3 or D14n is enabled, matching the docker-compose split
  - enable_v3 = false skips: V3Db, MlsDb, NodeGo
  - enable_d14n = false skips: Redis, Gateway, XMTPD nodes
  - enable_monitoring = false skips: Prometheus, Grafana, PgAdmin, Otterscan
  - Conditional service fields (gateway, node_go, anvil_rpc_url, monitoring) are now Option<T> with descriptive error messages when accessed while disabled

  Test plan

  - just check crate xnet-lib compiles
  - just check crate xnet-cli compiles
  - just check crate xnet-gui compiles
  - Start with defaults (all enabled) — behavior unchanged
  - Start with enable_monitoring = false — no Prometheus/Grafana/PgAdmin/Otterscan
  - Start with enable_v3 = false — no V3Db/MlsDb/NodeGo, but Anvil/Validation/History still up for D14n
  - Start with enable_d14n = false — no Redis/Gateway/XMTPD nodes, but shared services still up for V3
  - Start with both enable_v3 = false and enable_d14n = false — no Anvil/Validation/History either

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add TOML flags to disable V3, d14n, and monitoring services in xnet
> - Adds `enable_v3`, `enable_d14n`, and `enable_monitoring` boolean flags to the TOML/config schema, making those service groups optional at startup in [`service_manager.rs`](https://github.com/xmtp/libxmtp/pull/3458/files#diff-94cdc0e922a829f2b19f5d8f94aee1b22e2fd693ba226810ed0be1b6fdeba45c).
> - Replaces `--remote <ip>` / `AddressMode::Remote(IpAddr)` with `--remote-domain <domain>` / `AddressMode::RemoteDomain(String)`, dropping sslip.io-based hostname derivation throughout.
> - Extracts node provisioning logic into a new [`node_provisioner.rs`](https://github.com/xmtp/libxmtp/pull/3458/files#diff-46170e82758c142e21f730aa8df40c7ede105a4b1d5aa3e9f604880b89a3c272) module with a `NodeProvisioner` builder that handles preflight checks, signer derivation, on-chain registration, and container startup.
> - Extends Traefik config to emit both HTTP and HTTPS routers per route and supports user-defined `[[extra_traefik_routes]]` in TOML, merged into `dynamic.yml` at write time.
> - Adds `xmtpd_host` support to `ClientBundleBuilder` so the D14n client can target a single xmtpd node for reads instead of using gateway-based discovery.
> - Risk: `--remote` CLI flag and `xnet.remote_ip` / `toxiproxy_port` / `traefik_port` TOML fields are no longer recognized; existing configs must be updated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6e33e52.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->