### PR TITLE
fix(xnet): add missing use_standard_port field to GUI AddNode calls

### DIFF
--- a/apps/xnet/gui/src/actions.rs
+++ b/apps/xnet/gui/src/actions.rs
@@ -126,7 +126,12 @@ pub async fn execute_delete() -> Result<()> {
 }
 
 pub async fn execute_add_node() -> Result<NodeInfo> {
-    let node = App::parse()?.add_node(&AddNode { migrator: false }).await?;
+    let node = App::parse()?
+        .add_node(&AddNode {
+            migrator: false,
+            use_standard_port: false,
+        })
+        .await?;
     let config = xnet::Config::load()?;
     Ok(NodeInfo {
         id: *node.id(),
@@ -140,7 +145,12 @@ pub async fn execute_add_node() -> Result<NodeInfo> {
 }
 
 pub async fn execute_add_migrator() -> Result<NodeInfo> {
-    let node = App::parse()?.add_node(&AddNode { migrator: true }).await?;
+    let node = App::parse()?
+        .add_node(&AddNode {
+            migrator: true,
+            use_standard_port: false,
+        })
+        .await?;
     let config = xnet::Config::load()?;
     Ok(NodeInfo {
         id: *node.id(),


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3459

## Summary

Fix the Release XNet GUI build break introduced by #3454. Commit `a4085dd` added a required `use_standard_port: bool` field to the `AddNode` struct but did not update `apps/xnet/gui/src/actions.rs`, which supplies `AddNode { ... }` literals to `execute_add_node` and `execute_add_migrator`. Those two call sites failed to compile with `E0063: missing field use_standard_port`, breaking the "Release XNet GUI" workflow (macOS DMG build via `nix build .#xnet-gui`).

## Change

- `apps/xnet/gui/src/actions.rs`: add `use_standard_port: false` to both `AddNode` struct literals (lines 129 and 143).

## Why `false`?

- Matches the CLI default when `--use-standard-port` is not passed.
- The GUI typically runs `execute_add_node` / `execute_add_migrator` *after* `up` has already started the network, so port 5050 is likely held by an existing node. `resolve_port(false, None)` will allocate from the `8150..8200` range.
- `apps/xnet/lib/src/app/run.rs` already rejects requests for the standard port when it is already in use, so `false` avoids surfacing that error in the GUI flow.

## Why CI lint missed this

`just lint-rust` runs `cargo clippy ... -Dwarnings` over workspace default-members only. `Cargo.toml`'s `default-members` includes `apps/mls_validation_service`, `bindings/*`, and `crates/*` — not `apps/xnet/*`. The break only surfaces in the `release-xnet-gui.yml` workflow, which explicitly builds `.#xnet-gui`.

## Test plan

- [x] `cargo check -p xnet-gui` — clean compile
- [x] `cargo clippy -p xnet-gui --no-deps --all-targets -- -D warnings` — no warnings
- [x] `cargo fmt -p xnet-gui -- --check` — clean
- [x] `just lint-rust` — clean (workspace default-members)
- [ ] Release XNet GUI workflow re-runs green on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix missing `use_standard_port` field in xnet GUI `add_node` calls
> Sets `use_standard_port: false` explicitly in the `AddNode` arguments passed by `execute_add_node` and `execute_add_migrator` in [actions.rs](https://github.com/xmtp/libxmtp/pull/3462/files#diff-05f1d404d25561fe4e13d28ef53673c38debcd11264fbf3ae23a3e3dbcd20fe7). Previously, the field was absent, which likely caused a compile error or unintended default behavior after `AddNode` gained the `use_standard_port` field.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2e6ff00.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->