### PR TITLE
fix(ci): enable grpc_server_impls feature in proto generation script

### DIFF
--- a/dev/gen_protos.sh
+++ b/dev/gen_protos.sh
@@ -13,4 +13,4 @@ WORKSPACE_PATH="$(dirname "$WORKSPACE_MANIFEST")"
 
 export GEN_PROTOS=1
 echo "$REV" > "$WORKSPACE_PATH"/crates/xmtp_proto/proto_version
-cargo build -p xmtp_proto
+cargo build -p xmtp_proto --features grpc_server_impls


### PR DESCRIPTION
## Summary

Resolves https://github.com/xmtp/libxmtp/issues/3466

- Add `--features grpc_server_impls` to `cargo build` in `dev/gen_protos.sh`

**Root cause:** The nightly-protos CI job runs `dev/gen_protos.sh`, which executes `cargo build -p xmtp_proto` without enabling the `grpc_server_impls` feature. On non-wasm targets (Linux CI), the generated server code modules are compiled unconditionally (gated by `#[cfg(any(not(target_arch = "wasm32"), feature = "grpc_server_impls"))]`) and import `tonic::codegen::*`, which requires the `tonic/codegen` feature — only available through `grpc_server_impls`. This causes 36 compile errors.

## Test plan

- [x] `cargo check -p xmtp_proto --features grpc_server_impls` succeeds
- [x] `cargo check -p xmtp_proto` (without the feature) still produces the expected errors, confirming the feature is necessary
- [x] `shellcheck dev/gen_protos.sh` passes
- [ ] Nightly-protos CI job should pass on next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable `grpc_server_impls` feature in proto generation script
> Adds `--features grpc_server_impls` to the `cargo build -p xmtp_proto` command in [gen_protos.sh](https://github.com/xmtp/libxmtp/pull/3469/files#diff-c8b24636b765c6331ef56744aa8d6becce5dccb46d9e12062e5a73ac6992f4ec) so the feature is active during proto generation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 26d1c4a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->