### PR TITLE
fix(nix): pre-seed atf getopt cache var to unblock cross-compilation

### DIFF
--- a/nix/lib/default.nix
+++ b/nix/lib/default.nix
@@ -32,19 +32,30 @@
               };
             }
           )
-          (final: prev: {
-            #atf = prev.atf.overrideAttrs (old: {
-            #  configureFlags = (old.configureFlags or [ ]) ++ [
-            #    "kyua_cv_getopt_plus=yes"
-            #  ];
-            #});
-            # # Override harfbuzz to disable tests - test-coretext fails with SIGABRT
-            # # This fixes iOS/Android builds that transitively depend on harfbuzz
-            # harfbuzz = prev.harfbuzz.overrideAttrs (old: {
-            #   doCheck = false;
-            #   mesonFlags = (old.mesonFlags or [ ]) ++ [ "-Dtests=disabled" ];
-            # });
-          })
+          # atf 0.23's configure.ac (m4/module-application.m4) uses AC_RUN_IFELSE
+          # to check whether getopt(3) accepts a leading '+' for POSIX behavior
+          # (cache var kyua_cv_getopt_plus). AC_RUN_IFELSE cannot execute the
+          # compiled test binary during cross-compilation, aborting with:
+          #   "configure: error: cannot run test program while cross compiling"
+          #
+          # This breaks the aarch64-apple-darwin cross-build chain:
+          #   atf → libiconv → apple-sdk-14.4 → bindings-node-js-napi-*
+          # See https://github.com/xmtp/libxmtp/issues/3470.
+          #
+          # All target platforms in this flake (Darwin, glibc Linux, musl Linux)
+          # have a getopt that honours '+', so pre-seeding yes is safe.
+          # Gated on cross-compilation so native builds keep pulling from
+          # cache.nixos.org unchanged.
+          (
+            final: prev:
+            prev.lib.optionalAttrs (prev.stdenv.buildPlatform != prev.stdenv.hostPlatform) {
+              atf = prev.atf.overrideAttrs (old: {
+                configureFlags = (old.configureFlags or [ ]) ++ [
+                  "kyua_cv_getopt_plus=yes"
+                ];
+              });
+            }
+          )
           # tcl 8.6.16 (pinned via nixpkgs 09061f74...) has multiple
           # cross-compile bugs when targeting *-unknown-linux-musl, and the
           # Hydra build farm only caches the x86_64-linux build host (not


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3470

## Summary

- Pre-seeds `kyua_cv_getopt_plus=yes` in the atf package override when cross-compiling (`buildPlatform != hostPlatform`), fixing the `AC_RUN_IFELSE` failure that aborts `atf` configure with "cannot run test program while cross compiling"
- Unblocks the `aarch64-apple-darwin` build chain: `atf -> libiconv -> apple-sdk-14.4 -> bindings-node-js-napi-*`
- Gated on cross-compilation only, so native builds continue pulling from `cache.nixos.org` unchanged

## Context

The `atf-0.23` configure script (`m4/module-application.m4`) uses `AC_RUN_IFELSE` to check whether `getopt(3)` accepts a leading `+` for POSIX behavior. During cross-compilation the compiled test binary cannot execute on the build host, causing configure to abort. All target platforms in this flake (Darwin, glibc Linux, musl Linux) support `+` in getopt, so pre-seeding `yes` is correct.

This follows the same pattern as the sqlite/tcl cross-compilation fix from #3450.

## Test plan

- [ ] CI "Cache all Nix Outputs" workflow passes on `warp-macos-26-arm64-12x` runner
- [ ] Native Darwin builds still substitute from cache (no derivation hash change for native atf)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pre-seed `kyua_cv_getopt_plus` configure flag in `atf` to fix cross-compilation
> During cross-compilation, autoconf cache variables are not automatically populated, causing the `atf` build to fail. The overlay in [default.nix](https://github.com/xmtp/libxmtp/pull/3472/files#diff-6fd175d36064b2e9b9371596932bf201514494fc02c317f3f4526243d72991f1) now appends `kyua_cv_getopt_plus=yes` to `atf`'s `configureFlags` when `buildPlatform != hostPlatform`. Native builds are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4127f19.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->