### PR TITLE
fix: move Tick event log to debug level

### DIFF
--- a/crates/xmtp_mls/src/worker/device_sync/worker.rs
+++ b/crates/xmtp_mls/src/worker/device_sync/worker.rs
@@ -134,10 +134,17 @@ where
 
     async fn run_internal(&mut self) -> Result<(), DeviceSyncError> {
         while let Ok(event) = self.receiver.recv().await {
-            tracing::info!(
-                "[{}] New event: {event:?}",
-                self.client.context.installation_id()
-            );
+            if matches!(event, SyncWorkerEvent::Tick) {
+                tracing::debug!(
+                    "[{}] New event: {event:?}",
+                    self.client.context.installation_id()
+                );
+            } else {
+                tracing::info!(
+                    "[{}] New event: {event:?}",
+                    self.client.context.installation_id()
+                );
+            }
 
             match event {
                 SyncWorkerEvent::NewSyncGroupFromWelcome(_group_id) => {


### PR DESCRIPTION
## Summary

- Moves the "New event: Tick" log line from `info` to `debug` level in the device sync worker
- Keeps all other sync worker event logs at `info` level
- The Tick event fires frequently and produces noisy logs that clutter output

Resolves https://github.com/xmtp/libxmtp/issues/3467

## Test plan

- [x] `cargo check -p xmtp_mls` passes
- [x] `cargo clippy -p xmtp_mls` passes with no warnings
- [x] `cargo fmt -p xmtp_mls -- --check` passes
- [ ] Verify Tick events appear only at debug level in logs
- [ ] Verify other sync worker events still appear at info level

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move `Tick` event logging to debug level in `device_sync` worker
> In `worker.run_internal`, `Tick` events are now logged at debug level instead of info. All other `SyncWorkerEvent` variants continue to log at info level. This reduces log noise since `Tick` events are emitted frequently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9d7b8f9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->