### PR TITLE
unpin nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,17 +135,17 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1774078191,
-        "narHash": "sha256-nyxxxW1/2ouu9dU0I02ul5pHrmUrE1JVFhfFlmYe3Lw=",
+        "lastModified": 1775710090,
+        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "09061f748ee21f68a089cd5d91ec1859cd93d0be",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
-        "rev": "09061f748ee21f68a089cd5d91ec1859cd93d0be",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,11 +7,7 @@
   };
 
   inputs = {
-    # pinned to last succeeding ref for harfbuzz,
-    # required by google-chrome on darwin
-    # https://hydra.nixos.org/build/324477496
-    # hydra-check --arch aarch64-darwin harfbuzz --channel unstable --eval
-    nixpkgs.url = "github:NixOS/nixpkgs/09061f748ee21f68a089cd5d91ec1859cd93d0be";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     fenix = {
       url = "github:nix-community/fenix";
       inputs = {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Unpin nixpkgs to track the nixos-unstable channel
Updates [flake.nix](https://github.com/xmtp/libxmtp/pull/3482/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0) to point `inputs.nixpkgs` at `github:NixOS/nixpkgs/nixos-unstable` instead of a specific pinned commit. Risk: builds will now resolve against the latest nixos-unstable state, which may introduce breaking changes on future `nix flake update` runs.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5bcc6ce.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->