### PR TITLE
feat(xdbg): add structured JSON logging for Docker/Datadog

### DIFF
--- a/apps/xmtp_debug/src/args.rs
+++ b/apps/xmtp_debug/src/args.rs
@@ -281,8 +281,8 @@ pub enum LogFormat {
 #[derive(Args, Debug)]
 pub struct LogOptions {
     /// Stdout log format: "text" (default, colored in terminals) or "json" (for Docker/Datadog).
-    /// Can also be set via LOG_FORMAT env var.
-    #[arg(long, env = "LOG_FORMAT", default_value = "text")]
+    /// Can also be set via XDBG_LOG_FORMAT env var.
+    #[arg(long, env = "XDBG_LOG_FORMAT", default_value = "text")]
     pub log_format: LogFormat,
     /// Output libxmtp logs into file with a structured, ndJSON format
     #[arg(long)]

--- a/apps/xmtp_debug/src/args.rs
+++ b/apps/xmtp_debug/src/args.rs
@@ -267,9 +267,23 @@ impl std::fmt::Display for EntityKind {
     }
 }
 
+/// Log format for stdout output
+#[derive(ValueEnum, Debug, Clone, Default)]
+pub enum LogFormat {
+    /// Human-readable, colored in terminals
+    #[default]
+    Text,
+    /// Structured JSON (for Docker/Datadog)
+    Json,
+}
+
 /// specify the log output
 #[derive(Args, Debug)]
 pub struct LogOptions {
+    /// Stdout log format: "text" (default, colored in terminals) or "json" (for Docker/Datadog).
+    /// Can also be set via LOG_FORMAT env var.
+    #[arg(long, env = "LOG_FORMAT", default_value = "text")]
+    pub log_format: LogFormat,
     /// Output libxmtp logs into file with a structured, ndJSON format
     #[arg(long)]
     pub json: bool,

--- a/apps/xmtp_debug/src/logger.rs
+++ b/apps/xmtp_debug/src/logger.rs
@@ -78,25 +78,19 @@ impl Logger {
         let use_json_stdout = matches!(log_format, LogFormat::Json);
 
         let subscriber = subscriber
-            .with(if use_json_stdout {
-                Some(
-                    tracing_subscriber::fmt::layer()
-                        .json()
-                        .with_filter(app_filter()),
-                )
-            } else {
-                None
-            })
-            .with(if !use_json_stdout {
-                Some(human_layer(
+            .with(use_json_stdout.then(|| {
+                tracing_subscriber::fmt::layer()
+                    .json()
+                    .with_filter(app_filter())
+            }))
+            .with((!use_json_stdout).then(|| {
+                human_layer(
                     app_filter(),
                     true,
                     std::io::stdout,
                     std::io::stdout().is_terminal(),
-                ))
-            } else {
-                None
-            })
+                )
+            }))
             .with(json.then(|| {
                 let mut json = log_file_name.clone();
                 json.set_extension("json");

--- a/apps/xmtp_debug/src/logger.rs
+++ b/apps/xmtp_debug/src/logger.rs
@@ -1,4 +1,5 @@
 //! Logger for the CLI
+use std::io::IsTerminal;
 use std::path::PathBuf;
 
 use clap_verbosity_flag::{InfoLevel, Verbosity};
@@ -14,10 +15,11 @@ use tracing_subscriber::{
     registry::LookupSpan,
 };
 
-use crate::args::LogOptions;
+use crate::args::{LogFormat, LogOptions};
 
 #[derive(Default)]
 pub struct Logger {
+    log_format: LogFormat,
     json: bool,
     show_fields: bool,
     human: bool,
@@ -28,8 +30,8 @@ pub struct Logger {
 
 impl<'a> From<&'a LogOptions> for Logger {
     fn from(options: &'a LogOptions) -> Self {
-        // let pretty = !(options.json || options.logfmt);
         Self {
+            log_format: options.log_format.clone(),
             json: options.json,
             logfmt: options.logfmt,
             show_fields: options.show_fields,
@@ -43,6 +45,7 @@ impl<'a> From<&'a LogOptions> for Logger {
 impl Logger {
     pub fn init(&mut self) -> eyre::Result<()> {
         let Logger {
+            ref log_format,
             show_fields,
             json,
             human,
@@ -55,11 +58,13 @@ impl Logger {
 
         // prefer `RUST_LOG` variable if set
         // otherwise passed-in level filter
-        let app_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-            EnvFilter::builder()
-                .parse(format!("xdbg={verbosity}"))
-                .expect("filter is static")
-        });
+        let app_filter = || {
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                EnvFilter::builder()
+                    .parse(format!("xdbg={verbosity}"))
+                    .expect("filter is static")
+            })
+        };
         let file_filter = || {
             EnvFilter::builder().parse(
                 "xmtp_api_d14n=DEBUG,xmtp_api=DEBUG,xmtp_mls=DEBUG,xmtp_id=DEBUG,xmtp_cryptography=DEBUG,xmtp_api_grpc=DEBUG,xdbg=ERROR",
@@ -69,9 +74,29 @@ impl Logger {
         let now = chrono::Local::now();
         let log_file_name = PathBuf::from(format!("./{}-xdbg", now));
 
+        // Stdout layer: JSON for containers, human-readable with TTY-gated ANSI for terminals
+        let use_json_stdout = matches!(log_format, LogFormat::Json);
+
         let subscriber = subscriber
-            // default, always-on layer
-            .with(human_layer(app_filter, true, std::io::stdout))
+            .with(if use_json_stdout {
+                Some(
+                    tracing_subscriber::fmt::layer()
+                        .json()
+                        .with_filter(app_filter()),
+                )
+            } else {
+                None
+            })
+            .with(if !use_json_stdout {
+                Some(human_layer(
+                    app_filter(),
+                    true,
+                    std::io::stdout,
+                    std::io::stdout().is_terminal(),
+                ))
+            } else {
+                None
+            })
             .with(json.then(|| {
                 let mut json = log_file_name.clone();
                 json.set_extension("json");
@@ -90,7 +115,7 @@ impl Logger {
                 let file = std::fs::File::create_new(human).unwrap();
                 let (appender, guard) = tracing_appender::non_blocking(file);
                 guards.push(guard);
-                human_layer(file_filter(), show_fields, appender)
+                human_layer(file_filter(), show_fields, appender, false)
             }))
             .with(logfmt.then(|| {
                 let mut logfmt = log_file_name.clone();
@@ -109,13 +134,14 @@ impl Logger {
     }
 }
 
-fn human_layer<S, W>(filter: EnvFilter, show_fields: bool, writer: W) -> impl Layer<S>
+fn human_layer<S, W>(filter: EnvFilter, show_fields: bool, writer: W, ansi: bool) -> impl Layer<S>
 where
     S: Subscriber + for<'a> LookupSpan<'a>,
     W: for<'writer> MakeWriter<'writer> + Send + Sync + 'static,
 {
     let layer = tracing_subscriber::fmt::layer()
         .without_time()
+        .with_ansi(ansi)
         .map_event_format(|_| PrettyTarget)
         .fmt_fields({
             let fun = format::debug_fn(move |writer, field, value| {


### PR DESCRIPTION
## Summary
- Adds `--log-format` CLI flag (also configurable via `LOG_FORMAT` env var) to xdbg with `text` (default) and `json` variants
- In `text` mode, ANSI colors are enabled only when stdout is a terminal (fixes `[91m`, `[1m`, `[32m` escape codes in container logs)
- In `json` mode, logs are emitted as structured JSON via tracing-subscriber's JSON formatter, suitable for Datadog ingestion

Mirrors the same pattern from #3333 (mls-validation-service structured logging).

## Infra follow-up
Set `LOG_FORMAT=json` in the xdbg ECS container environment and switch log driver to `awsfirelens` for Datadog forwarding.

## Test plan
- [ ] `cargo check -p xdbg` passes
- [ ] Run `xdbg --log-format json --version` locally, verify JSON output on stdout
- [ ] Run `xdbg --log-format text --version` locally, verify colored output in terminal, plain in pipe
- [ ] Deploy to testnet, verify logs appear in Datadog as structured JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add structured JSON logging for stdout in `xmtp_debug` via `--log-format`
> - Adds a `--log-format` CLI flag (and `LOG_FORMAT` env var) to `xdbg` with `text` (default) and `json` options, defined in [args.rs](https://github.com/xmtp/libxmtp/pull/3483/files#diff-625330612e40d918eef6d9785cc1b9adbc3c444cc2666c0d632bb216d3b2b4f5).
> - When `json` is selected, the stdout tracing layer emits structured JSON; otherwise it emits human-readable output.
> - ANSI color codes on stdout are now gated on TTY detection (`std::io::stdout().is_terminal()`).
> - Behavioral Change: human-formatted file logs no longer include ANSI escape codes.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #3483 opened
>
> - Changed environment variable for log format configuration [e6f469d]
> - Refactored conditional layer addition in logger initialization [e6f469d]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7c8cc96.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->