### PR TITLE
fix(ci): ignore transient infra failures in flaky-failure-watcher

### DIFF
--- a/.github/workflows/flaky-failure-watcher.yml
+++ b/.github/workflows/flaky-failure-watcher.yml
@@ -157,6 +157,7 @@ jobs:
 
             ## Important
 
+            - **Ignore transient infrastructure failures.** If the failure appears to be caused by external infrastructure being down or degraded (e.g., GitHub outages, Docker registry timeouts, runner provisioning failures, network connectivity issues, rate limiting from external services, package registry unavailability), do NOT create an issue. These are transient and resolve on their own. Only create an issue for an infrastructure problem if existing open issues or comments show that the same infrastructure failure has been recurring for more than 24 hours.
             - Do NOT create duplicate issues. If in doubt, err on the side of commenting on an existing issue.
             - Keep error excerpts concise — include the most relevant 20-50 lines, not entire logs.
             - Always use code blocks for error output and stack traces.


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3480

## Summary

- Adds a prompt instruction to the flaky-failure-watcher GitHub Action telling Claude to **skip issue creation for transient infrastructure failures** (GitHub outages, Docker registry timeouts, runner provisioning failures, network connectivity issues, rate limiting from external services, package registry unavailability)
- Only creates an issue for infrastructure problems if existing open issues/comments show the same failure has been **recurring for more than 24 hours**

## Test plan

- [ ] Verify the workflow YAML is valid by inspecting the Actions tab after merge
- [ ] Monitor the next infrastructure-related CI failure to confirm the watcher skips it appropriately

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ignore transient infrastructure failures in flaky-failure-watcher CI prompt
> Updates the AI prompt in the [flaky-failure-watcher.yml](https://github.com/xmtp/libxmtp/pull/3485/files#diff-ba7f390dd6c7e0b63abfd6b267167da364c24343b7edd0d162b1a8b25fdde5d6) 'Investigate failure' step to skip issue creation for transient infra failures (e.g. GitHub outages, registry timeouts, runner provisioning issues, network errors, rate limiting) unless the failure has recurred for more than 24 hours.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7ba53e2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->