### PR TITLE
fix(nix): pre-seed all atf AC_RUN_IFELSE cache vars for cross-compilation

### DIFF
--- a/nix/lib/default.nix
+++ b/nix/lib/default.nix
@@ -32,18 +32,31 @@
               };
             }
           )
-          # atf 0.23's configure.ac (m4/module-application.m4) uses AC_RUN_IFELSE
-          # to check whether getopt(3) accepts a leading '+' for POSIX behavior
-          # (cache var kyua_cv_getopt_plus). AC_RUN_IFELSE cannot execute the
-          # compiled test binary during cross-compilation, aborting with:
+          # atf 0.23's configure.ac uses AC_RUN_IFELSE for three probes that
+          # cannot execute a compiled test binary during cross-compilation,
+          # aborting with:
           #   "configure: error: cannot run test program while cross compiling"
           #
           # This breaks the aarch64-apple-darwin cross-build chain:
           #   atf → libiconv → apple-sdk-14.4 → bindings-node-js-napi-*
-          # See https://github.com/xmtp/libxmtp/issues/3470.
+          # See https://github.com/xmtp/libxmtp/issues/3470
+          # and https://github.com/xmtp/libxmtp/issues/3476.
           #
-          # All target platforms in this flake (Darwin, glibc Linux, musl Linux)
-          # have a getopt that honours '+', so pre-seeding yes is safe.
+          # The three AC_RUN_IFELSE cache variables and their justifications:
+          #
+          #   kyua_cv_getopt_plus (m4/module-application.m4)
+          #     Tests whether getopt(3) accepts a leading '+' for POSIX
+          #     behavior. All target platforms (Darwin, glibc, musl) honour '+'.
+          #
+          #   kyua_cv_attribute_noreturn (m4/module-defs.m4)
+          #     Tests whether __attribute__((__noreturn__)) is supported by
+          #     checking GCC version >= 2.5. All modern GCC/Clang satisfy this.
+          #
+          #   kyua_cv_getcwd_works (m4/module-fs.m4)
+          #     Tests whether getcwd(NULL, 0) dynamically allocates. Both
+          #     Darwin and Linux (glibc and musl) support this.
+          #
+          # Pre-seeding all three is safe for every target in this flake.
           # Gated on cross-compilation so native builds keep pulling from
           # cache.nixos.org unchanged.
           (
@@ -52,6 +65,8 @@
               atf = prev.atf.overrideAttrs (old: {
                 configureFlags = (old.configureFlags or [ ]) ++ [
                   "kyua_cv_getopt_plus=yes"
+                  "kyua_cv_attribute_noreturn=yes"
+                  "kyua_cv_getcwd_works=yes"
                 ];
               });
             }


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3476

## Summary

- Pre-seeds the two remaining `AC_RUN_IFELSE` cache variables in the atf
  cross-compilation overlay (`kyua_cv_attribute_noreturn` and
  `kyua_cv_getcwd_works`), completing the set started by #3472
  (`kyua_cv_getopt_plus`)
- Eliminates the non-deterministic CI failures on `warp-macos-26-arm64-12x`
  where the blocking probe varied between `__noreturn__` and other checks
  across runs

## Context

`atf-0.23`'s `configure.ac` has exactly three `AC_RUN_IFELSE` probes that
cannot execute during cross-compilation:

| Cache variable | Source | What it tests |
|---|---|---|
| `kyua_cv_getopt_plus` | `m4/module-application.m4` | getopt `+` (already pre-seeded by #3472) |
| `kyua_cv_attribute_noreturn` | `m4/module-defs.m4` | `__attribute__((__noreturn__))` (GCC ≥ 2.5) |
| `kyua_cv_getcwd_works` | `m4/module-fs.m4` | `getcwd(NULL, 0)` dynamic allocation |

Pre-seeding `yes` is safe for all targets in this flake (Darwin, glibc Linux,
musl Linux). The override remains gated on cross-compilation so native builds
continue substituting from `cache.nixos.org` unchanged.

The `-Wsynth` compiler flag check referenced in the issue comments uses
`AC_LINK_IFELSE` (not `AC_RUN_IFELSE`) and is not a blocker — it was the
last configure output line before the runtime probe aborted.

## Test plan

- [ ] CI "Cache all Nix Outputs" workflow passes on `warp-macos-26-arm64-12x`
- [ ] Native builds still substitute from cache (no derivation hash change for
  native atf)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix atf cross-compilation by pre-seeding missing `AC_RUN_IFELSE` cache variables
> During cross-compilation, `AC_RUN_IFELSE` macros cannot execute test binaries, causing configure to fail. The atf derivation in [default.nix](https://github.com/xmtp/libxmtp/pull/3487/files#diff-6fd175d36064b2e9b9371596932bf201514494fc02c317f3f4526243d72991f1) now pre-seeds three cache variables (`kyua_cv_getopt_plus`, `kyua_cv_attribute_noreturn`, `kyua_cv_getcwd_works`) instead of just one.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b8a11bd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->