### PR TITLE
fix(nix): guard Android NDK cross-compilation outputs on macOS ARM

### DIFF
--- a/nix/android-packages.nix
+++ b/nix/android-packages.nix
@@ -7,86 +7,77 @@
       lib,
       ...
     }:
-    let
-      platforms = import "${inputs.nixpkgs}/lib/systems/platforms.nix" { inherit lib; };
+    # The Android NDK cross-compilation toolchain in nixpkgs (androidndk-pkgs.nix)
+    # does not support arm64-apple-darwin as a build host and hard-throws during
+    # evaluation. Guard all Android cross-compilation outputs so they are only
+    # exposed on Linux, where the NDK is supported.
+    # Note: use `system` (a plain string) instead of `pkgs.stdenv.isLinux` to
+    # avoid infinite recursion in the flake-parts module system.
+    # See https://github.com/xmtp/libxmtp/issues/3481
+    lib.optionalAttrs (lib.hasSuffix "-linux" system) (
+      let
+        platforms = import "${inputs.nixpkgs}/lib/systems/platforms.nix" { inherit lib; };
 
-      sdkConfig = {
-        androidSdkVersion = "23";
-        androidNdkVersion = "27";
-        useAndroidPrebuilt = true;
-      };
-
-      # Single source of truth: ABI name → target config
-      androidTargets = {
-        "arm64-v8a" = {
-          config = "aarch64-unknown-linux-android";
-          rust.rustcTarget = "aarch64-linux-android";
+        sdkConfig = {
+          androidSdkVersion = "23";
+          androidNdkVersion = "27";
+          useAndroidPrebuilt = true;
         };
-        "armeabi-v7a" = {
-          config = "armv7a-unknown-linux-androideabi";
-          rust.rustcTarget = "armv7-linux-androideabi";
-        }
-        // platforms.armv7a-android;
-        "x86_64" = {
-          config = "x86_64-unknown-linux-android";
-          rust.rustcTarget = "x86_64-linux-android";
+
+        # Single source of truth: ABI name → target config
+        androidTargets = {
+          "arm64-v8a" = {
+            config = "aarch64-unknown-linux-android";
+            rust.rustcTarget = "aarch64-linux-android";
+          };
+          "armeabi-v7a" = {
+            config = "armv7a-unknown-linux-androideabi";
+            rust.rustcTarget = "armv7-linux-androideabi";
+          }
+          // platforms.armv7a-android;
+          "x86_64" = {
+            config = "x86_64-unknown-linux-android";
+            rust.rustcTarget = "x86_64-linux-android";
+          };
+          "x86" = {
+            config = "i686-unknown-linux-android";
+            rust.rustcTarget = "i686-linux-android";
+          };
         };
-        "x86" = {
-          config = "i686-unknown-linux-android";
-          rust.rustcTarget = "i686-linux-android";
-        };
-      };
 
-      # config name → ABI name
-      configToAbi = lib.listToAttrs (
-        lib.mapAttrsToList (abi: t: {
-          name = t.config;
-          value = abi;
-        }) androidTargets
-      );
+        # config name → ABI name
+        configToAbi = lib.listToAttrs (
+          lib.mapAttrsToList (abi: t: {
+            name = t.config;
+            value = abi;
+          }) androidTargets
+        );
 
-      crossPkgs = self.lib.mkCrossPkgs system (lib.mapAttrsToList (_: t: t // sdkConfig) androidTargets);
-      mkAndroidBindings = p: p.callPackage ./package/android.nix;
+        crossPkgs = self.lib.mkCrossPkgs system (lib.mapAttrsToList (_: t: t // sdkConfig) androidTargets);
+        mkAndroidBindings = p: p.callPackage ./package/android.nix;
 
-      # Per-target dylibs keyed by config name
-      androidDylibs = lib.mapAttrs (_: p: (mkAndroidBindings p { }).dylib) crossPkgs;
+        # Per-target dylibs keyed by config name
+        androidDylibs = lib.mapAttrs (_: p: (mkAndroidBindings p { }).dylib) crossPkgs;
 
-      # Kotlin bindings from host build
-      inherit (mkAndroidBindings pkgs { }) kotlin-bindings;
+        # Kotlin bindings from host build
+        inherit (mkAndroidBindings pkgs { }) kotlin-bindings;
 
-      fastAbi =
-        if pkgs.stdenv.hostPlatform.isx86_64 then
-          "x86_64"
-        else if pkgs.stdenv.hostPlatform.isAarch64 then
-          "arm64-v8a"
-        else
-          throw "Unsupported host architecture for android-libs-fast";
+        fastAbi =
+          if pkgs.stdenv.hostPlatform.isx86_64 then
+            "x86_64"
+          else if pkgs.stdenv.hostPlatform.isAarch64 then
+            "arm64-v8a"
+          else
+            throw "Unsupported host architecture for android-libs-fast";
 
-      fastTarget = androidTargets.${fastAbi};
-      fastDylib = androidDylibs.${fastTarget.config};
+        fastTarget = androidTargets.${fastAbi};
+        fastDylib = androidDylibs.${fastTarget.config};
 
-      android-libs-fast = pkgs.linkFarm "xmtpv3-android-fast" [
-        {
-          name = "jniLibs/${fastAbi}/libuniffi_xmtpv3.so";
-          path = "${fastDylib}/libuniffi_xmtpv3.so";
-        }
-        {
-          name = "java/uniffi/xmtpv3/xmtpv3.kt";
-          path = "${kotlin-bindings}/kotlin/uniffi/xmtpv3/xmtpv3.kt";
-        }
-        {
-          name = "libxmtp-version.txt";
-          path = "${kotlin-bindings}/libxmtp-version.txt";
-        }
-      ];
-
-      # Aggregate all targets + Kotlin bindings into a Gradle-ready layout
-      android-libs = pkgs.linkFarm "xmtpv3-android" (
-        lib.mapAttrsToList (config: dylib: {
-          name = "jniLibs/${configToAbi.${config}}/libuniffi_xmtpv3.so";
-          path = "${dylib}/libuniffi_xmtpv3.so";
-        }) androidDylibs
-        ++ [
+        android-libs-fast = pkgs.linkFarm "xmtpv3-android-fast" [
+          {
+            name = "jniLibs/${fastAbi}/libuniffi_xmtpv3.so";
+            path = "${fastDylib}/libuniffi_xmtpv3.so";
+          }
           {
             name = "java/uniffi/xmtpv3/xmtpv3.kt";
             path = "${kotlin-bindings}/kotlin/uniffi/xmtpv3/xmtpv3.kt";
@@ -95,16 +86,34 @@
             name = "libxmtp-version.txt";
             path = "${kotlin-bindings}/libxmtp-version.txt";
           }
-        ]
-      );
-    in
-    {
-      packages = {
-        inherit android-libs android-libs-fast kotlin-bindings;
+        ];
+
+        # Aggregate all targets + Kotlin bindings into a Gradle-ready layout
+        android-libs = pkgs.linkFarm "xmtpv3-android" (
+          lib.mapAttrsToList (config: dylib: {
+            name = "jniLibs/${configToAbi.${config}}/libuniffi_xmtpv3.so";
+            path = "${dylib}/libuniffi_xmtpv3.so";
+          }) androidDylibs
+          ++ [
+            {
+              name = "java/uniffi/xmtpv3/xmtpv3.kt";
+              path = "${kotlin-bindings}/kotlin/uniffi/xmtpv3/xmtpv3.kt";
+            }
+            {
+              name = "libxmtp-version.txt";
+              path = "${kotlin-bindings}/libxmtp-version.txt";
+            }
+          ]
+        );
+      in
+      {
+        packages = {
+          inherit android-libs android-libs-fast kotlin-bindings;
+        }
+        // lib.mapAttrs' (config: dylib: {
+          name = "android-bindings-${configToAbi.${config}}";
+          value = dylib;
+        }) androidDylibs;
       }
-      // lib.mapAttrs' (config: dylib: {
-        name = "android-bindings-${configToAbi.${config}}";
-        value = dylib;
-      }) androidDylibs;
-    };
+    );
 }


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3481

## Summary

- Wrap the `perSystem` output in `nix/android-packages.nix` with `lib.optionalAttrs (lib.hasSuffix "-linux" system)` so Android NDK cross-compilation packages are only exposed on Linux systems
- Prevents nixpkgs' `androidndk-pkgs.nix` from being evaluated on `arm64-apple-darwin`, which hard-throws because the NDK doesn't support that build host
- The Android devShell remains available on all platforms (uses pre-built SDK/NDK downloads, not cross-compilation)
- Uses the `system` string instead of `pkgs.stdenv.isLinux` to avoid infinite recursion in flake-parts module evaluation

## Test plan

- [x] `nix flake show` succeeds — Android packages appear on Linux systems, not on aarch64-darwin
- [x] `nix fmt -- --ci` passes (formatting clean)
- [ ] CI: "Cache all Nix Outputs" workflow passes on macOS ARM runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Guard Android NDK cross-compilation outputs on Linux in `android-packages.nix`
> Wraps all Android package attributes (`android-libs`, `android-libs-fast`, `kotlin-bindings`, and per-ABI `android-bindings-*`) in `lib.optionalAttrs (lib.hasSuffix "-linux" system)` in [android-packages.nix](https://github.com/xmtp/libxmtp/pull/3488/files#diff-8b047e47ceb6f5603985efee1af17c324796e643cb15c21de53b90e3b35fc9fc), so they are only exposed when building on a Linux host. The inner logic (link farms, ABI mappings, cross-compilation targets) is unchanged.
>
> Behavioral Change: On macOS ARM (and any non-Linux system), all Android NDK cross-compilation outputs are now absent from the package set rather than present but broken.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7ca9ade.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->