### PR TITLE
fix(nix): guard Android packages from evaluation on Darwin

### DIFF
--- a/nix/android-packages.nix
+++ b/nix/android-packages.nix
@@ -7,86 +7,78 @@
       lib,
       ...
     }:
-    let
-      platforms = import "${inputs.nixpkgs}/lib/systems/platforms.nix" { inherit lib; };
+    # Android NDK does not support macOS ARM as a build host.
+    # Evaluating Android cross-compilation packages on aarch64-darwin can cause
+    # failures that cascade and block other package outputs (e.g. ios-xcframeworks).
+    # See https://github.com/xmtp/libxmtp/issues/3481
+    # and https://github.com/xmtp/libxmtp/issues/3484
+    #
+    # Use `system` (a string) rather than `pkgs.stdenv.isLinux` to avoid
+    # infinite recursion in the flake-parts module system.
+    lib.optionalAttrs (lib.hasSuffix "-linux" system) (
+      let
+        platforms = import "${inputs.nixpkgs}/lib/systems/platforms.nix" { inherit lib; };
 
-      sdkConfig = {
-        androidSdkVersion = "23";
-        androidNdkVersion = "27";
-        useAndroidPrebuilt = true;
-      };
-
-      # Single source of truth: ABI name → target config
-      androidTargets = {
-        "arm64-v8a" = {
-          config = "aarch64-unknown-linux-android";
-          rust.rustcTarget = "aarch64-linux-android";
+        sdkConfig = {
+          androidSdkVersion = "23";
+          androidNdkVersion = "27";
+          useAndroidPrebuilt = true;
         };
-        "armeabi-v7a" = {
-          config = "armv7a-unknown-linux-androideabi";
-          rust.rustcTarget = "armv7-linux-androideabi";
-        }
-        // platforms.armv7a-android;
-        "x86_64" = {
-          config = "x86_64-unknown-linux-android";
-          rust.rustcTarget = "x86_64-linux-android";
+
+        # Single source of truth: ABI name → target config
+        androidTargets = {
+          "arm64-v8a" = {
+            config = "aarch64-unknown-linux-android";
+            rust.rustcTarget = "aarch64-linux-android";
+          };
+          "armeabi-v7a" = {
+            config = "armv7a-unknown-linux-androideabi";
+            rust.rustcTarget = "armv7-linux-androideabi";
+          }
+          // platforms.armv7a-android;
+          "x86_64" = {
+            config = "x86_64-unknown-linux-android";
+            rust.rustcTarget = "x86_64-linux-android";
+          };
+          "x86" = {
+            config = "i686-unknown-linux-android";
+            rust.rustcTarget = "i686-linux-android";
+          };
         };
-        "x86" = {
-          config = "i686-unknown-linux-android";
-          rust.rustcTarget = "i686-linux-android";
-        };
-      };
 
-      # config name → ABI name
-      configToAbi = lib.listToAttrs (
-        lib.mapAttrsToList (abi: t: {
-          name = t.config;
-          value = abi;
-        }) androidTargets
-      );
+        # config name → ABI name
+        configToAbi = lib.listToAttrs (
+          lib.mapAttrsToList (abi: t: {
+            name = t.config;
+            value = abi;
+          }) androidTargets
+        );
 
-      crossPkgs = self.lib.mkCrossPkgs system (lib.mapAttrsToList (_: t: t // sdkConfig) androidTargets);
-      mkAndroidBindings = p: p.callPackage ./package/android.nix;
+        crossPkgs = self.lib.mkCrossPkgs system (lib.mapAttrsToList (_: t: t // sdkConfig) androidTargets);
+        mkAndroidBindings = p: p.callPackage ./package/android.nix;
 
-      # Per-target dylibs keyed by config name
-      androidDylibs = lib.mapAttrs (_: p: (mkAndroidBindings p { }).dylib) crossPkgs;
+        # Per-target dylibs keyed by config name
+        androidDylibs = lib.mapAttrs (_: p: (mkAndroidBindings p { }).dylib) crossPkgs;
 
-      # Kotlin bindings from host build
-      inherit (mkAndroidBindings pkgs { }) kotlin-bindings;
+        # Kotlin bindings from host build
+        inherit (mkAndroidBindings pkgs { }) kotlin-bindings;
 
-      fastAbi =
-        if pkgs.stdenv.hostPlatform.isx86_64 then
-          "x86_64"
-        else if pkgs.stdenv.hostPlatform.isAarch64 then
-          "arm64-v8a"
-        else
-          throw "Unsupported host architecture for android-libs-fast";
+        fastAbi =
+          if pkgs.stdenv.hostPlatform.isx86_64 then
+            "x86_64"
+          else if pkgs.stdenv.hostPlatform.isAarch64 then
+            "arm64-v8a"
+          else
+            throw "Unsupported host architecture for android-libs-fast";
 
-      fastTarget = androidTargets.${fastAbi};
-      fastDylib = androidDylibs.${fastTarget.config};
+        fastTarget = androidTargets.${fastAbi};
+        fastDylib = androidDylibs.${fastTarget.config};
 
-      android-libs-fast = pkgs.linkFarm "xmtpv3-android-fast" [
-        {
-          name = "jniLibs/${fastAbi}/libuniffi_xmtpv3.so";
-          path = "${fastDylib}/libuniffi_xmtpv3.so";
-        }
-        {
-          name = "java/uniffi/xmtpv3/xmtpv3.kt";
-          path = "${kotlin-bindings}/kotlin/uniffi/xmtpv3/xmtpv3.kt";
-        }
-        {
-          name = "libxmtp-version.txt";
-          path = "${kotlin-bindings}/libxmtp-version.txt";
-        }
-      ];
-
-      # Aggregate all targets + Kotlin bindings into a Gradle-ready layout
-      android-libs = pkgs.linkFarm "xmtpv3-android" (
-        lib.mapAttrsToList (config: dylib: {
-          name = "jniLibs/${configToAbi.${config}}/libuniffi_xmtpv3.so";
-          path = "${dylib}/libuniffi_xmtpv3.so";
-        }) androidDylibs
-        ++ [
+        android-libs-fast = pkgs.linkFarm "xmtpv3-android-fast" [
+          {
+            name = "jniLibs/${fastAbi}/libuniffi_xmtpv3.so";
+            path = "${fastDylib}/libuniffi_xmtpv3.so";
+          }
           {
             name = "java/uniffi/xmtpv3/xmtpv3.kt";
             path = "${kotlin-bindings}/kotlin/uniffi/xmtpv3/xmtpv3.kt";
@@ -95,16 +87,34 @@
             name = "libxmtp-version.txt";
             path = "${kotlin-bindings}/libxmtp-version.txt";
           }
-        ]
-      );
-    in
-    {
-      packages = {
-        inherit android-libs android-libs-fast kotlin-bindings;
+        ];
+
+        # Aggregate all targets + Kotlin bindings into a Gradle-ready layout
+        android-libs = pkgs.linkFarm "xmtpv3-android" (
+          lib.mapAttrsToList (config: dylib: {
+            name = "jniLibs/${configToAbi.${config}}/libuniffi_xmtpv3.so";
+            path = "${dylib}/libuniffi_xmtpv3.so";
+          }) androidDylibs
+          ++ [
+            {
+              name = "java/uniffi/xmtpv3/xmtpv3.kt";
+              path = "${kotlin-bindings}/kotlin/uniffi/xmtpv3/xmtpv3.kt";
+            }
+            {
+              name = "libxmtp-version.txt";
+              path = "${kotlin-bindings}/libxmtp-version.txt";
+            }
+          ]
+        );
+      in
+      {
+        packages = {
+          inherit android-libs android-libs-fast kotlin-bindings;
+        }
+        // lib.mapAttrs' (config: dylib: {
+          name = "android-bindings-${configToAbi.${config}}";
+          value = dylib;
+        }) androidDylibs;
       }
-      // lib.mapAttrs' (config: dylib: {
-        name = "android-bindings-${configToAbi.${config}}";
-        value = dylib;
-      }) androidDylibs;
-    };
+    );
 }


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3484
Related https://github.com/xmtp/libxmtp/issues/3481

## Summary

- Guard `android-packages.nix` module output with `lib.optionalAttrs (lib.hasSuffix "-linux" system)` so Android cross-compilation packages are only emitted on Linux systems
- Prevents Android NDK evaluation on `aarch64-darwin` from cascading and blocking other package outputs like `ios-xcframeworks`
- Uses the `system` string (not `pkgs.stdenv.isLinux`) to avoid infinite recursion in the flake-parts module system

## Root Cause

The `release-ios` job fails because `nix/android-packages.nix` evaluates Android cross-compilation packages for all systems. The Android NDK does not support macOS ARM as a build host (#3481), and after the nixpkgs unpin (#3482), the NDK evaluation behavior changed. On the macOS ARM CI runner (Nix 2.31.2), this causes cascade failures in the flake-parts module system that prevent `packages.aarch64-darwin.ios-xcframeworks` from being accessible.

## Verification

- `nix eval .#packages.aarch64-darwin` — Android packages excluded, `ios-xcframeworks` present
- `nix eval .#packages.x86_64-linux` — Android packages present
- `nix eval .#packages.aarch64-linux` — Android packages present
- `nix fmt` passes
- Android release workflows already run on Linux (`warp-ubuntu-latest-x64-16x`), unaffected
- Android devShell unaffected (uses host SDK/emulator, not cross-compilation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Guard Android packages from evaluation on Darwin in `android-packages.nix`
> Wraps the entire Android packaging logic in `lib.optionalAttrs (lib.hasSuffix "-linux" system)` so that none of the Android package attributes (`android-libs`, `android-libs-fast`, `kotlin-bindings`, `android-bindings-*`) are defined on non-Linux systems. Uses `system` directly rather than `pkgs.stdenv.isLinux` to avoid evaluation of platform-specific expressions on Darwin.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1146f34.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->