### PR TITLE
fix: propagate PendingRemove state to late-joining installations

### DIFF
--- a/crates/xmtp_mls/src/groups/group_permissions.rs
+++ b/crates/xmtp_mls/src/groups/group_permissions.rs
@@ -1480,6 +1480,7 @@ pub(crate) mod tests {
                 .map(build_membership_change)
                 .unwrap_or_default(),
             readded_installations: HashSet::new(),
+            added_installation_inbox_ids: HashSet::new(),
             metadata_validation_info: MutableMetadataValidationInfo {
                 metadata_field_changes: field_changes,
                 ..Default::default()

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -2313,6 +2313,11 @@ where
     ///
     /// Runs within the same transaction as commit processing, so the queued intent is
     /// rolled back if the commit fails to apply.
+    ///
+    /// Only queues the SendMessage intent — no optimistic StoredGroupMessage is created
+    /// because this is an internal re-send (not user-initiated) and the sender already
+    /// has the original LeaveRequest in their local history. Newly-added installations
+    /// will store the re-sent message when they receive it via the external-message path.
     fn maybe_resend_leave_request_for_new_installations(
         &self,
         added_installation_inbox_ids: &HashSet<String>,
@@ -2339,32 +2344,7 @@ where
         })?;
         let message_bytes = encoded_content_to_bytes(encoded_content);
 
-        let now = now_ns();
-        let queryable_content_fields = Self::extract_queryable_content_fields(&message_bytes);
-        let message_id = calculate_message_id(&self.group_id, &message_bytes, &now.to_string());
-        let stored_message = StoredGroupMessage {
-            id: message_id,
-            group_id: self.group_id.clone(),
-            decrypted_message_bytes: message_bytes.clone(),
-            sent_at_ns: now,
-            kind: GroupMessageKind::Application,
-            sender_installation_id: self.context.installation_id().into(),
-            sender_inbox_id: own_inbox_id.to_string(),
-            delivery_status: DeliveryStatus::Unpublished,
-            content_type: queryable_content_fields.content_type,
-            version_major: queryable_content_fields.version_major,
-            version_minor: queryable_content_fields.version_minor,
-            authority_id: queryable_content_fields.authority_id,
-            reference_id: queryable_content_fields.reference_id,
-            sequence_id: 0,
-            originator_id: 0,
-            expire_at_ns: None,
-            inserted_at_ns: 0,
-            should_push: false,
-        };
-        stored_message.store(&db)?;
-
-        let plain_envelope = Self::into_envelope(&message_bytes, now);
+        let plain_envelope = Self::into_envelope(&message_bytes, now_ns());
         let mut encoded_envelope = vec![];
         plain_envelope.encode(&mut encoded_envelope)?;
 

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -85,7 +85,10 @@ use xmtp_configuration::{
     SYNC_BACKOFF_TOTAL_WAIT_MAX_SECS, SYNC_BACKOFF_WAIT_MS, SYNC_JITTER_MS,
     SYNC_UPDATE_INSTALLATIONS_INTERVAL_NS,
 };
-use xmtp_content_types::{CodecError, ContentCodec, group_updated::GroupUpdatedCodec};
+use xmtp_content_types::{
+    CodecError, ContentCodec, encoded_content_to_bytes, group_updated::GroupUpdatedCodec,
+    leave_request::LeaveRequestCodec,
+};
 use xmtp_db::message_deletion::{QueryMessageDeletion, StoredMessageDeletion};
 use xmtp_db::{
     Fetch, MlsProviderExt, StorageError, StoreOrIgnore,
@@ -107,7 +110,7 @@ use xmtp_db::{
 use xmtp_id::{InboxId, InboxIdRef};
 use xmtp_mls_common::group_metadata::extract_group_metadata;
 use xmtp_mls_common::group_mutable_metadata::{MetadataField, extract_group_mutable_metadata};
-use xmtp_proto::xmtp::mls::message_contents::content_types::DeleteMessage;
+use xmtp_proto::xmtp::mls::message_contents::content_types::{DeleteMessage, LeaveRequest};
 use xmtp_proto::xmtp::mls::{
     api::v1::{
         GroupMessageInput, WelcomeMessageInput, WelcomeMetadata,
@@ -3298,6 +3301,27 @@ where
             .queue(self)?;
 
         let _ = self.sync_until_intent_resolved(intent.id).await?;
+
+        // After adding new installations (which creates a new epoch), if this inbox
+        // has a pending self-removal, re-send the LeaveRequest. Newly-added
+        // installations joined in a later epoch and cannot decrypt the original
+        // LeaveRequest, so this ensures they can process it and set PendingRemove.
+        if self.is_in_pending_remove(self.context.inbox_id())? {
+            debug!(
+                inbox_id = self.context.inbox_id(),
+                group_id = hex::encode(&self.group_id),
+                "Re-sending LeaveRequest after adding installations for pending self-removal"
+            );
+            let content = LeaveRequestCodec::encode(LeaveRequest {
+                authenticated_note: None,
+            })?;
+            let message_bytes = encoded_content_to_bytes(content);
+            self.prepare_message(&message_bytes, Default::default(), |now| {
+                Self::into_envelope(&message_bytes, now)
+            })?;
+            self.sync_until_last_intent_resolved().await?;
+        }
+
         Ok(())
     }
 

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -2291,6 +2291,80 @@ where
         Ok(updated)
     }
 
+    /// When a commit adds new installations of the current inbox while this inbox is
+    /// in a pending self-removal state, re-send the LeaveRequest so the newly-added
+    /// installations (which joined in a later MLS epoch) can decrypt it and mirror the
+    /// PendingRemove state. Without this, the original LeaveRequest is encrypted for an
+    /// earlier epoch and is invisible to the new installations.
+    ///
+    /// Runs within the same transaction as commit processing, so the queued intent is
+    /// rolled back if the commit fails to apply.
+    fn maybe_resend_leave_request_for_new_installations(
+        &self,
+        added_installation_inbox_ids: &HashSet<String>,
+        storage: &impl XmtpMlsStorageProvider,
+    ) -> Result<(), GroupMessageProcessingError> {
+        let own_inbox_id = self.context.inbox_id();
+        if !added_installation_inbox_ids.contains(own_inbox_id) {
+            return Ok(());
+        }
+
+        let db = storage.db();
+        if !db.get_user_pending_remove_status(self.group_id.as_slice(), own_inbox_id)? {
+            return Ok(());
+        }
+
+        debug!(
+            inbox_id = own_inbox_id,
+            group_id = hex::encode(&self.group_id),
+            "Re-sending LeaveRequest after new installations for this inbox were added while in pending self-removal"
+        );
+
+        let encoded_content = LeaveRequestCodec::encode(LeaveRequest {
+            authenticated_note: None,
+        })?;
+        let message_bytes = encoded_content_to_bytes(encoded_content);
+
+        let now = now_ns();
+        let queryable_content_fields = Self::extract_queryable_content_fields(&message_bytes);
+        let message_id = calculate_message_id(&self.group_id, &message_bytes, &now.to_string());
+        let stored_message = StoredGroupMessage {
+            id: message_id,
+            group_id: self.group_id.clone(),
+            decrypted_message_bytes: message_bytes.clone(),
+            sent_at_ns: now,
+            kind: GroupMessageKind::Application,
+            sender_installation_id: self.context.installation_id().into(),
+            sender_inbox_id: own_inbox_id.to_string(),
+            delivery_status: DeliveryStatus::Unpublished,
+            content_type: queryable_content_fields.content_type,
+            version_major: queryable_content_fields.version_major,
+            version_minor: queryable_content_fields.version_minor,
+            authority_id: queryable_content_fields.authority_id,
+            reference_id: queryable_content_fields.reference_id,
+            sequence_id: 0,
+            originator_id: 0,
+            expire_at_ns: None,
+            inserted_at_ns: 0,
+            should_push: false,
+        };
+        stored_message.store(&db)?;
+
+        let plain_envelope = Self::into_envelope(&message_bytes, now);
+        let mut encoded_envelope = vec![];
+        plain_envelope.encode(&mut encoded_envelope)?;
+
+        let intent_data: Vec<u8> = SendMessageIntentData::new(encoded_envelope).into();
+        db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
+            IntentKind::SendMessage,
+            self.group_id.clone(),
+            intent_data,
+            false,
+        ))?;
+
+        Ok(())
+    }
+
     fn save_transcript_message(
         &self,
         validated_commit: ValidatedCommit,
@@ -2298,6 +2372,16 @@ where
         cursor: Cursor,
         storage: &impl XmtpMlsStorageProvider,
     ) -> Result<Option<(StoredGroupMessage, GroupUpdated)>, GroupMessageProcessingError> {
+        // Run this check before the `is_empty()` early-return: an installation-only
+        // commit (e.g. `add_missing_installations` for a same-inbox device) has no
+        // added/removed inboxes or metadata changes, so it would be treated as empty
+        // here — but we still need to re-send the LeaveRequest for new installations
+        // of the current inbox.
+        self.maybe_resend_leave_request_for_new_installations(
+            &validated_commit.added_installation_inbox_ids,
+            storage,
+        )?;
+
         if validated_commit.is_empty() {
             return Ok(None);
         }
@@ -3301,27 +3385,6 @@ where
             .queue(self)?;
 
         let _ = self.sync_until_intent_resolved(intent.id).await?;
-
-        // After adding new installations (which creates a new epoch), if this inbox
-        // has a pending self-removal, re-send the LeaveRequest. Newly-added
-        // installations joined in a later epoch and cannot decrypt the original
-        // LeaveRequest, so this ensures they can process it and set PendingRemove.
-        if self.is_in_pending_remove(self.context.inbox_id())? {
-            debug!(
-                inbox_id = self.context.inbox_id(),
-                group_id = hex::encode(&self.group_id),
-                "Re-sending LeaveRequest after adding installations for pending self-removal"
-            );
-            let content = LeaveRequestCodec::encode(LeaveRequest {
-                authenticated_note: None,
-            })?;
-            let message_bytes = encoded_content_to_bytes(content);
-            self.prepare_message(&message_bytes, Default::default(), |now| {
-                Self::into_envelope(&message_bytes, now)
-            })?;
-            self.sync_until_last_intent_resolved().await?;
-        }
-
         Ok(())
     }
 

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -912,6 +912,15 @@ where
                     next_intent_state: IntentState::Error,
                 })?;
 
+            self.maybe_resend_leave_request_for_new_installations(
+                &validated_commit.added_installation_inbox_ids,
+                storage,
+            )
+            .map_err(|err| IntentResolutionError {
+                processing_error: err,
+                next_intent_state: IntentState::Error,
+            })?;
+
             // Clean up pending_remove list for removed members
             self.clean_pending_remove_list(storage, &validated_commit.removed_inboxes);
 
@@ -1360,6 +1369,11 @@ where
                     validated_commit.clone(),
                     envelope_timestamp_ns as u64,
                     *cursor,
+                    storage,
+                )?;
+
+                self.maybe_resend_leave_request_for_new_installations(
+                    &validated_commit.added_installation_inbox_ids,
                     storage,
                 )?;
 
@@ -2372,16 +2386,6 @@ where
         cursor: Cursor,
         storage: &impl XmtpMlsStorageProvider,
     ) -> Result<Option<(StoredGroupMessage, GroupUpdated)>, GroupMessageProcessingError> {
-        // Run this check before the `is_empty()` early-return: an installation-only
-        // commit (e.g. `add_missing_installations` for a same-inbox device) has no
-        // added/removed inboxes or metadata changes, so it would be treated as empty
-        // here — but we still need to re-send the LeaveRequest for new installations
-        // of the current inbox.
-        self.maybe_resend_leave_request_for_new_installations(
-            &validated_commit.added_installation_inbox_ids,
-            storage,
-        )?;
-
         if validated_commit.is_empty() {
             return Ok(None);
         }

--- a/crates/xmtp_mls/src/groups/tests/mod.rs
+++ b/crates/xmtp_mls/src/groups/tests/mod.rs
@@ -1655,7 +1655,6 @@ async fn test_self_removal_with_multiple_initial_installations() {
 }
 
 #[xmtp_common::test(flavor = "current_thread")]
-#[ignore] // fix after consent sync
 async fn test_self_removal_with_late_installation() {
     tester!(amal);
     tester!(bola_i1);

--- a/crates/xmtp_mls/src/groups/validated_commit.rs
+++ b/crates/xmtp_mls/src/groups/validated_commit.rs
@@ -309,6 +309,10 @@ pub struct ValidatedCommit {
     pub added_inboxes: Vec<Inbox>,
     pub removed_inboxes: Vec<Inbox>,
     pub readded_installations: HashSet<Vec<u8>>,
+    /// Inbox ids that had at least one installation added in this commit.
+    /// Unlike `added_inboxes`, this also includes inboxes that were already
+    /// members of the group — so new installations of an existing inbox show up here.
+    pub added_installation_inbox_ids: HashSet<String>,
     pub metadata_validation_info: MutableMetadataValidationInfo,
     pub installations_changed: bool,
     pub permissions_changed: bool,
@@ -480,12 +484,16 @@ impl ValidatedCommit {
             }
         }
 
+        let added_installation_inbox_ids: HashSet<String> =
+            added_inbox_proposers.keys().cloned().collect();
+
         let verified_commit = Self {
             actor,
             proposers,
             added_inboxes,
             removed_inboxes,
             readded_installations,
+            added_installation_inbox_ids,
             metadata_validation_info,
             installations_changed,
             permissions_changed,


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3475

## Summary

- Re-sends LeaveRequest in the new MLS epoch after adding missing installations, so late-joining same-inbox installations can decrypt and process the self-removal
- Unignores `test_self_removal_with_late_installation` which now passes

## Problem

When an inbox has multiple installations and one leaves a group (PendingRemove), a new installation created later cannot decrypt the original LeaveRequest because it was encrypted for an earlier MLS epoch. This caused the new installation to miss the pending self-removal state, leading to inconsistent group state across installations.

## Solution

In `add_missing_installations()`, after the commit that adds new installations to the group resolves, check if the current inbox has a pending self-removal. If so, re-send the LeaveRequest message in the current epoch. This allows newly-added installations (which now have the epoch keys) to decrypt and process it, correctly setting `PendingRemove` state and populating the pending-remove list.

The re-send is safe because:
- `PendingRemove::store_or_ignore` handles duplicate records idempotently
- `update_group_membership` to PendingRemove is idempotent when already in that state
- The re-send only triggers when installations were actually added (not on every sync)

## Test plan

- [x] `test_self_removal_with_late_installation` — unignored and passing
- [x] `test_self_removal_with_multiple_initial_installations` — still passing (no regression)
- [x] `test_clean_pending_remove_list_on_member_removal` — still passing
- [x] All 6 `test_self_removal*` tests pass
- [x] `cargo clippy` clean, `cargo fmt` clean, `hakari` clean

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Propagate `PendingRemove` state to late-joining installations via re-sent LeaveRequest
> - Adds `added_installation_inbox_ids` to `ValidatedCommit` to track which inboxes gained new installations in a commit.
> - Adds `maybe_resend_leave_request_for_new_installations` in [`mls_sync.rs`](https://github.com/xmtp/libxmtp/pull/3490/files#diff-160aadcd7de477c1116260a79601a0548842f3bd91bf16bd8443debb66ce6684): if the current inbox is in `PendingRemove` state and a commit adds one of its installations, a `SendMessage` intent carrying a `LeaveRequest` is queued in the same transaction.
> - This runs for both locally originated commits and externally received commits during sync.
> - Enables the previously ignored test `test_self_removal_with_late_installation`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0360080.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->