### PR TITLE
test(ios): deflake testStreamsAndMessages with event-driven wait

### DIFF
--- a/sdks/ios/Tests/XMTPTests/ConversationTests.swift
+++ b/sdks/ios/Tests/XMTPTests/ConversationTests.swift
@@ -272,7 +272,13 @@ class ConversationTests: XCTestCase {
 	}
 
 	func testStreamsAndMessages() async throws {
-		var messages: [String] = []
+		let transcript = TestTranscript()
+		let expectation = XCTestExpectation(
+			description: "caro received 90 streamed messages"
+		)
+		expectation.expectedFulfillmentCount = 90
+		expectation.assertForOverFulfill = false
+
 		let fixtures = try await fixtures()
 
 		let alixGroup = try await fixtures.alixClient.conversations.newGroup(
@@ -311,14 +317,18 @@ class ConversationTests: XCTestCase {
 		// Start listening for messages
 		let caroTask = Task {
 			print("Caro is listening...")
+			var received = 0
 			do {
 				for try await message in await fixtures.caroClient.conversations
 					.streamAllMessages()
 				{
-					try messages.append(message.body)
-					try print("Caro received: \(message.body)")
+					let body = try message.body
+					await transcript.add(body)
+					print("Caro received: \(body)")
+					received += 1
+					expectation.fulfill()
 
-					if messages.count >= 90 { break }
+					if received >= 90 { break }
 				}
 			} catch {
 				print("Error while streaming messages: \(error)")
@@ -373,13 +383,15 @@ class ConversationTests: XCTestCase {
 			}
 		}
 
-		// Wait a bit to ensure all messages are processed
-		try await Task.sleep(nanoseconds: 5_000_000_000) // 2 seconds delay
+		// Wait for all 90 messages to arrive (event-driven, with a generous
+		// ceiling so a real streaming regression fails fast instead of
+		// masquerading as a flake).
+		await fulfillment(of: [expectation], timeout: 30)
 
 		caroTask.cancel()
 
-		// This test seems to fail with some random number between 87, 88, or 89, even with increased delay
-		XCTAssertEqual(messages.count, 90)
+		let finalCount = await transcript.messages.count
+		XCTAssertEqual(finalCount, 90)
 		let caroMessagesCount = try await caroGroup.messages().count
 		XCTAssertEqual(caroMessagesCount, 41)
 


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3491

## Summary

`testStreamsAndMessages` in `sdks/ios/Tests/XMTPTests/ConversationTests.swift` intermittently failed with 87/88/89 messages instead of the expected 90. The flake was structural: after all senders finished, the test did a blind `Task.sleep(nanoseconds: 5_000_000_000)` and then asserted `messages.count == 90`. If the last message landed more than 5 s after the senders completed, the assertion lost the race. The flaky-failure watcher (#3491) flagged this on commit `40d0b01`, and an in-test comment already acknowledged it:

> "This test seems to fail with some random number between 87, 88, or 89, even with increased delay"

## Fix

- Swap the `var messages: [String]` local for a `TestTranscript` actor (already provided in `XMTPTestHelpers`), eliminating the data race between the stream task's `append` and the main test's count read.
- Add an `XCTestExpectation` with `expectedFulfillmentCount = 90` and `assertForOverFulfill = false`. Each received message fires `expectation.fulfill()` in addition to being stored.
- Replace `Task.sleep(5s) + caroTask.cancel() + XCTAssertEqual(messages.count, 90)` with `await fulfillment(of: [expectation], timeout: 30) + caroTask.cancel() + XCTAssertEqual(finalCount, 90)`.
- Remove the obsolete "fails with some random number" comment.

### Why this isn't just "raise the sleep"

`fulfillment(of:timeout:)` returns *as soon as* the 90th message fulfills — so the happy path is **faster** than the old unconditional 5 s sleep. Only a genuine streaming regression would hit the 30 s ceiling, and it would surface with the same clear `expected 90, got N` assertion rather than an opaque flake. This pattern is already used by neighbouring tests in the same file (`testCanStreamAllMessagesFilterConsent`, `testOnlyStreamsAllowedConversations`).

## Test plan

- [ ] CI: `test-ios` workflow passes (the only way to exercise Swift tests on macOS — the repo's Linux dev shell has no Swift toolchain).
- [ ] CI: `lint-ios` workflow passes (SwiftFormat + SwiftLint).
- [ ] No non-test files modified; no SDK API changes.
- [ ] Spot-check `testStreamsAndMessages` locally (if you have a macOS + local XMTP node): confirm it passes and is faster than the old version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deflake `testStreamsAndMessages` with event-driven wait instead of fixed sleep
> Replaces a fixed 5-second sleep with an `XCTestExpectation` that waits up to 30 seconds for exactly 90 streamed messages in [ConversationTests.swift](https://github.com/xmtp/libxmtp/pull/3493/files#diff-ca4555e7974998a39352e81e2d37a02b8a23f08ca36ce660f53fe013d4496483). Message counting is moved from a plain array to a `TestTranscript` instance accessed asynchronously. The break condition in the streaming task now checks a local counter rather than array length.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ea8922a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->