### PR TITLE
feat(xdbg): make migration tests optional via XDBG_SKIP_MIGRATION_TESTS

### DIFF
--- a/apps/xmtp_debug/docker/entrypoint.sh
+++ b/apps/xmtp_debug/docker/entrypoint.sh
@@ -8,6 +8,7 @@ set -uo pipefail
 : "${XDBG_V4_NODE_URL:=}"      # V4/D14N node URL for migration latency test
 : "${XDBG_MIGRATION_TIMEOUT:=120}" # timeout for migration latency polling
 : "${XDBG_CONTINUITY_MESSAGES:=5}" # messages per wallet continuity iteration
+: "${XDBG_SKIP_MIGRATION_TESTS:=false}" # set "true" to skip migration tests
 
 function log {
     echo "[$(date '+%F %T')] $*"
@@ -22,6 +23,7 @@ case "${WORKSPACE}" in
     ""|*) BACKEND="local" ;;
 esac
 log "WORKSPACE='${WORKSPACE:-<unset>}' -> backend='${BACKEND}'"
+log "XDBG_SKIP_MIGRATION_TESTS='${XDBG_SKIP_MIGRATION_TESTS}'"
 
 # Migration test: always writes to V3 production and reads from V4 testnet,
 # because the only migrator path is V3 production → V4 testnet.
@@ -57,33 +59,40 @@ while true; do
     log "Running health checks..."
     bash "$(dirname "$0")/web-healthcheck.sh" || log "WARNING: health check failed"
 
-    # Migration latency test: always V3 production → V4 testnet (the only migration path).
-    # Omits -d and --perf (D14N mode) since this writes to V3.
-    # Uses -b production regardless of WORKSPACE.
-    log "Migration latency test..."
-    XDBG_LOOP_PAUSE=0 xdbg -b production test migration-latency \
-      --v4-node-url "${XDBG_V4_NODE_URL}" \
-      --migration-timeout "${XDBG_MIGRATION_TIMEOUT}" \
-      --iterations 1 \
-      || log "WARNING: migration latency test $x failed"
+    # Migration tests: V3 production → V4 testnet (the only migration path).
+    # Skipped when XDBG_SKIP_MIGRATION_TESTS=true (e.g. testnet where
+    # the migrator is not running).
+    if [ "${XDBG_SKIP_MIGRATION_TESTS}" = "true" ]; then
+      log "Skipping migration tests (XDBG_SKIP_MIGRATION_TESTS=true)"
+    else
+      # Migration latency test: always V3 production → V4 testnet.
+      # Omits -d and --perf (D14N mode) since this writes to V3.
+      # Uses -b production regardless of WORKSPACE.
+      log "Migration latency test..."
+      XDBG_LOOP_PAUSE=0 xdbg -b production test migration-latency \
+        --v4-node-url "${XDBG_V4_NODE_URL}" \
+        --migration-timeout "${XDBG_MIGRATION_TIMEOUT}" \
+        --iterations 1 \
+        || log "WARNING: migration latency test $x failed"
 
-    # Content parity test: write structured payloads to V3, diff on V4.
-    log "Content parity test..."
-    XDBG_LOOP_PAUSE=0 xdbg -b production test content-parity \
-      --v4-node-url "${XDBG_V4_NODE_URL}" \
-      --migration-timeout "${XDBG_MIGRATION_TIMEOUT}" \
-      --parity-messages "${XDBG_PARITY_MESSAGES:-5}" \
-      --iterations 1 \
-      || log "WARNING: content parity test $x failed"
+      # Content parity test: write structured payloads to V3, diff on V4.
+      log "Content parity test..."
+      XDBG_LOOP_PAUSE=0 xdbg -b production test content-parity \
+        --v4-node-url "${XDBG_V4_NODE_URL}" \
+        --migration-timeout "${XDBG_MIGRATION_TIMEOUT}" \
+        --parity-messages "${XDBG_PARITY_MESSAGES:-5}" \
+        --iterations 1 \
+        || log "WARNING: content parity test $x failed"
 
-    # Wallet continuity test: verify same wallet → same inbox_id on V4.
-    log "Wallet continuity test..."
-    XDBG_LOOP_PAUSE=0 xdbg -b production test wallet-continuity \
-      --v4-node-url "${XDBG_V4_NODE_URL}" \
-      --migration-timeout "${XDBG_MIGRATION_TIMEOUT}" \
-      --continuity-messages "${XDBG_CONTINUITY_MESSAGES}" \
-      --iterations 1 \
-      || log "WARNING: wallet continuity test $x failed"
+      # Wallet continuity test: verify same wallet → same inbox_id on V4.
+      log "Wallet continuity test..."
+      XDBG_LOOP_PAUSE=0 xdbg -b production test wallet-continuity \
+        --v4-node-url "${XDBG_V4_NODE_URL}" \
+        --migration-timeout "${XDBG_MIGRATION_TIMEOUT}" \
+        --continuity-messages "${XDBG_CONTINUITY_MESSAGES}" \
+        --iterations 1 \
+        || log "WARNING: wallet continuity test $x failed"
+    fi
 
     log "Sleeping ${XDBG_LOOP_PAUSE} seconds..."
     sleep "${XDBG_LOOP_PAUSE}"


### PR DESCRIPTION
## Summary
- Adds `XDBG_SKIP_MIGRATION_TESTS` environment variable (default `false`) to `entrypoint.sh`
- When set to `true`, all three migration tests (migration-latency, content-parity, wallet-continuity) are skipped with a clear log message
- D14N health probing (identity/group/message generation) always runs regardless of this flag
- Allows infra to disable migration tests per environment (testnet: skip, mainnet: run)

## Changes
- `apps/xmtp_debug/docker/entrypoint.sh`: Added `XDBG_SKIP_MIGRATION_TESTS` env var with `false` default; wrapped the three migration test blocks in a conditional; added startup log line showing the configured value

## Usage
```bash
# Testnet (migrator not running) — skip migration tests
XDBG_SKIP_MIGRATION_TESTS=true

# Mainnet (migrator active) — run all tests (default behavior, no change needed)
# XDBG_SKIP_MIGRATION_TESTS=false (or unset)
```

In `xmtpd_monitoring/ecs.tf`, add to the testnet container environment:
```hcl
{ name = "XDBG_SKIP_MIGRATION_TESTS", value = "true" }
```

## Test plan
- [x] Built Docker image locally (`docker build -t xdbg:test`)
- [x] Verified `XDBG_SKIP_MIGRATION_TESTS=true` skips all migration tests and logs skip message
- [x] Verified default (`false`) runs all migration tests as before

Closes #3486

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `XDBG_SKIP_MIGRATION_TESTS` flag to make migration tests optional in xdbg entrypoint
> Wraps the `migration-latency`, `content-parity`, and `wallet-continuity` tests in a conditional block in [entrypoint.sh](https://github.com/xmtp/libxmtp/pull/3495/files#diff-d52d6f3d3a240eff514aa3f59dcfa9b2be580b2e48a1c199f53c8c631a448e7e). When `XDBG_SKIP_MIGRATION_TESTS=true`, the script logs that migration tests are skipped and omits them from each loop iteration. The flag defaults to `false`, preserving existing behavior. Its value is logged at startup for observability.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 30b83a3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->