### PR TITLE
nix ios fixes for catching missing cache or common xcode build errors

### DIFF
--- a/sdks/ios/Sources/XMTPiOS/Client.swift
+++ b/sdks/ios/Sources/XMTPiOS/Client.swift
@@ -8,7 +8,6 @@ public enum ClientError: Error, CustomStringConvertible, LocalizedError {
 	case creationError(String)
 	case missingInboxId
 	case invalidInboxId(String)
-	case clientDeallocated
 
 	public var description: String {
 		switch self {
@@ -18,8 +17,6 @@ public enum ClientError: Error, CustomStringConvertible, LocalizedError {
 			"ClientError.missingInboxId"
 		case let .invalidInboxId(inboxId):
 			"Invalid inboxId: \(inboxId). Inbox IDs cannot start with '0x'."
-		case .clientDeallocated:
-			"ClientError.clientDeallocated: The Client has been deallocated."
 		}
 	}
 
@@ -204,7 +201,8 @@ public final class Client {
 	private static let apiCache = ApiClientCache()
 
 	public lazy var conversations: Conversations = .init(
-		client: self, ffiConversations: ffiClient.conversations(),
+		clientInboxId: inboxID,
+		ffiConversations: ffiClient.conversations(),
 		ffiClient: ffiClient
 	)
 

--- a/sdks/ios/Sources/XMTPiOS/Conversation.swift
+++ b/sdks/ios/Sources/XMTPiOS/Conversation.swift
@@ -345,12 +345,12 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 		}
 	}
 
-	public var client: Client {
+	public var clientInboxId: InboxId {
 		switch self {
 		case let .group(group):
-			group.client
+			group.clientInboxId
 		case let .dm(dm):
-			dm.client
+			dm.clientInboxId
 		}
 	}
 

--- a/sdks/ios/Sources/XMTPiOS/Conversations.swift
+++ b/sdks/ios/Sources/XMTPiOS/Conversations.swift
@@ -119,24 +119,22 @@ actor FfiStreamActor {
 
 /// Handles listing and creating Conversations.
 public class Conversations {
-	private weak var client: Client?
+	/// The inboxId of the Client that owns this Conversations instance.
+	/// Captured at construction time so Conversations does not need a
+	/// back-reference to Client (which would create a retain cycle with
+	/// Client's `lazy var conversations`).
+	let clientInboxId: InboxId
 	var ffiConversations: FfiConversations
 	var ffiClient: FfiXmtpClient
 
 	init(
-		client: Client, ffiConversations: FfiConversations,
+		clientInboxId: InboxId,
+		ffiConversations: FfiConversations,
 		ffiClient: FfiXmtpClient
 	) {
-		self.client = client
+		self.clientInboxId = clientInboxId
 		self.ffiConversations = ffiConversations
 		self.ffiClient = ffiClient
-	}
-
-	private func requireClient() throws -> Client {
-		guard let client else {
-			throw ClientError.clientDeallocated
-		}
-		return client
 	}
 
 	/// Helper function to convert DisappearingMessageSettings to FfiMessageDisappearingSettings
@@ -152,13 +150,12 @@ public class Conversations {
 	}
 
 	public func findGroup(groupId: String) throws -> Group? {
-		let client = try requireClient()
 		do {
 			return try Group(
 				ffiGroup: ffiClient.conversation(
 					conversationId: groupId.hexToData
 				),
-				client: client
+				clientInboxId: clientInboxId
 			)
 		} catch {
 			return nil
@@ -168,12 +165,13 @@ public class Conversations {
 	public func findConversation(conversationId: String) async throws
 		-> Conversation?
 	{
-		let client = try requireClient()
 		do {
 			let conversation = try ffiClient.conversation(
 				conversationId: conversationId.hexToData
 			)
-			return try await conversation.toConversation(client: client)
+			return try await conversation.toConversation(
+				clientInboxId: clientInboxId
+			)
 		} catch {
 			return nil
 		}
@@ -182,7 +180,6 @@ public class Conversations {
 	public func findConversationByTopic(topic: String) async throws
 		-> Conversation?
 	{
-		let client = try requireClient()
 		do {
 			let regexPattern = #"/xmtp/mls/1/g-(.*?)/proto"#
 			if let regex = try? NSRegularExpression(pattern: regexPattern) {
@@ -196,7 +193,9 @@ public class Conversations {
 					let conversation = try ffiClient.conversation(
 						conversationId: conversationId.hexToData
 					)
-					return try await conversation.toConversation(client: client)
+					return try await conversation.toConversation(
+						clientInboxId: clientInboxId
+					)
 				}
 			}
 		} catch {
@@ -206,13 +205,13 @@ public class Conversations {
 	}
 
 	public func findDmByInboxId(inboxId: InboxId) throws -> Dm? {
-		let client = try requireClient()
 		do {
 			let conversation = try ffiClient.dmConversation(
 				targetInboxId: inboxId
 			)
 			return Dm(
-				ffiConversation: conversation, client: client
+				ffiConversation: conversation,
+				clientInboxId: clientInboxId
 			)
 		} catch {
 			return nil
@@ -222,10 +221,9 @@ public class Conversations {
 	public func findDmByIdentity(publicIdentity: PublicIdentity) async throws
 		-> Dm?
 	{
-		let client = try requireClient()
 		guard
-			let inboxId = try await client.inboxIdFromIdentity(
-				identity: publicIdentity
+			let inboxId = try await ffiClient.findInboxId(
+				identifier: publicIdentity.ffiPrivate
 			)
 		else {
 			throw ClientError.creationError("No inboxId present")
@@ -282,7 +280,6 @@ public class Conversations {
 		consentStates: [ConsentState]? = nil,
 		orderBy: ConversationsOrderBy = ConversationsOrderBy.lastActivity
 	) throws -> [Group] {
-		let client = try requireClient()
 		var options = FfiListConversationsOptions(
 			createdAfterNs: createdAfterNs,
 			createdBeforeNs: createdBeforeNs,
@@ -302,7 +299,7 @@ public class Conversations {
 		)
 
 		return conversations.map {
-			$0.groupFromFFI(client: client)
+			$0.groupFromFFI(clientInboxId: clientInboxId)
 		}
 	}
 
@@ -315,7 +312,6 @@ public class Conversations {
 		consentStates: [ConsentState]? = nil,
 		orderBy: ConversationsOrderBy = ConversationsOrderBy.lastActivity
 	) throws -> [Dm] {
-		let client = try requireClient()
 		var options = FfiListConversationsOptions(
 			createdAfterNs: createdAfterNs,
 			createdBeforeNs: createdBeforeNs,
@@ -336,7 +332,7 @@ public class Conversations {
 		)
 
 		return conversations.map {
-			$0.dmFromFFI(client: client)
+			$0.dmFromFFI(clientInboxId: clientInboxId)
 		}
 	}
 
@@ -349,7 +345,6 @@ public class Conversations {
 		consentStates: [ConsentState]? = nil,
 		orderBy: ConversationsOrderBy = ConversationsOrderBy.lastActivity
 	) async throws -> [Conversation] {
-		let client = try requireClient()
 		var options = FfiListConversationsOptions(
 			createdAfterNs: createdAfterNs,
 			createdBeforeNs: createdBeforeNs,
@@ -371,7 +366,7 @@ public class Conversations {
 		var conversations: [Conversation] = []
 		for conversation in ffiConversations {
 			let conversation = try await conversation.toConversation(
-				client: client
+				clientInboxId: clientInboxId
 			)
 			conversations.append(conversation)
 		}
@@ -383,11 +378,8 @@ public class Conversations {
 	) -> AsyncThrowingStream<
 		Conversation, Error
 	> {
-		AsyncThrowingStream { continuation in
-			guard let client = self.client else {
-				continuation.finish(throwing: ClientError.clientDeallocated)
-				return
-			}
+		let clientInboxId = clientInboxId
+		return AsyncThrowingStream { continuation in
 			let ffiStreamActor = FfiStreamActor()
 			let conversationCallback = ConversationStreamCallback {
 				conversation in
@@ -402,14 +394,16 @@ public class Conversations {
 						if conversationType == .dm {
 							continuation.yield(
 								Conversation.dm(
-									conversation.dmFromFFI(client: client)
+									conversation.dmFromFFI(
+										clientInboxId: clientInboxId
+									)
 								)
 							)
 						} else if conversationType == .group {
 							continuation.yield(
 								Conversation.group(
 									conversation.groupFromFFI(
-										client: client
+										clientInboxId: clientInboxId
 									)
 								)
 							)
@@ -470,9 +464,12 @@ public class Conversations {
 		with peerIdentity: PublicIdentity,
 		disappearingMessageSettings: DisappearingMessageSettings? = nil
 	) async throws -> Dm {
-		let client = try requireClient()
-		if try await client.inboxState(refreshFromNetwork: false).identities
-			.map(\.identifier).contains(peerIdentity.identifier)
+		let ffiInboxState = try await ffiClient.inboxState(
+			refreshFromNetwork: false
+		)
+		let inboxState = InboxState(ffiInboxState: ffiInboxState)
+		if inboxState.identities.map(\.identifier)
+			.contains(peerIdentity.identifier)
 		{
 			throw ConversationError.memberCannotBeSelf
 		}
@@ -488,7 +485,7 @@ public class Conversations {
 					)
 				)
 
-		return dm.dmFromFFI(client: client)
+		return dm.dmFromFFI(clientInboxId: clientInboxId)
 	}
 
 	public func newConversation(
@@ -508,8 +505,7 @@ public class Conversations {
 	)
 		async throws -> Dm
 	{
-		let client = try requireClient()
-		if peerInboxId == client.inboxID {
+		if peerInboxId == clientInboxId {
 			throw ConversationError.memberCannotBeSelf
 		}
 		try validateInboxId(peerInboxId)
@@ -523,7 +519,7 @@ public class Conversations {
 						)
 					)
 				)
-		return dm.dmFromFFI(client: client)
+		return dm.dmFromFFI(clientInboxId: clientInboxId)
 	}
 
 	public func newGroupWithIdentities(
@@ -583,8 +579,7 @@ public class Conversations {
 		disappearingMessageSettings: DisappearingMessageSettings? = nil,
 		appData: String?
 	) async throws -> Group {
-		let client = try requireClient()
-		return try await ffiConversations.createGroupByIdentity(
+		try await ffiConversations.createGroupByIdentity(
 			accountIdentities: identities.map(\.ffiPrivate),
 			opts: FfiCreateGroupOptions(
 				permissions: permissions,
@@ -597,7 +592,7 @@ public class Conversations {
 				),
 				appData: appData
 			)
-		).groupFromFFI(client: client)
+		).groupFromFFI(clientInboxId: clientInboxId)
 	}
 
 	public func newGroup(
@@ -657,7 +652,6 @@ public class Conversations {
 		disappearingMessageSettings: DisappearingMessageSettings? = nil,
 		appData: String?
 	) async throws -> Group {
-		let client = try requireClient()
 		try validateInboxIds(inboxIds)
 		return try await ffiConversations.createGroup(
 			inboxIds: inboxIds,
@@ -672,7 +666,7 @@ public class Conversations {
 				),
 				appData: appData
 			)
-		).groupFromFFI(client: client)
+		).groupFromFFI(clientInboxId: clientInboxId)
 	}
 
 	public func newGroupOptimistic(
@@ -683,7 +677,6 @@ public class Conversations {
 		disappearingMessageSettings: DisappearingMessageSettings? = nil,
 		appData: String? = nil
 	) throws -> Group {
-		let client = try requireClient()
 		let ffiOpts = FfiCreateGroupOptions(
 			permissions:
 			GroupPermissionPreconfiguration.toFfiGroupPermissionOptions(
@@ -700,7 +693,7 @@ public class Conversations {
 		)
 
 		let ffiGroup = try ffiConversations.createGroupOptimistic(opts: ffiOpts)
-		return Group(ffiGroup: ffiGroup, client: client)
+		return Group(ffiGroup: ffiGroup, clientInboxId: clientInboxId)
 	}
 
 	public func streamAllMessages(
@@ -804,14 +797,15 @@ public class Conversations {
 	public func fromWelcome(envelopeBytes: Data) async throws
 		-> Conversation?
 	{
-		let client = try requireClient()
 		let conversations =
 			try await ffiConversations
 				.processStreamedWelcomeMessage(envelopeBytes: envelopeBytes)
 		guard let firstConversation = conversations.first else {
 			return nil
 		}
-		return try await firstConversation.toConversation(client: client)
+		return try await firstConversation.toConversation(
+			clientInboxId: clientInboxId
+		)
 	}
 
 	public func getHmacKeys() throws

--- a/sdks/ios/Sources/XMTPiOS/Dm.swift
+++ b/sdks/ios/Sources/XMTPiOS/Dm.swift
@@ -4,7 +4,9 @@ public struct Dm: Identifiable, Equatable, Hashable {
 	var ffiConversation: FfiConversation
 	var ffiLastMessage: FfiMessage?
 	var ffiCommitLogForkStatus: Bool?
-	var client: Client
+	/// InboxId of the owning Client. Captured at construction time so Dm
+	/// does not need to hold a reference to Client itself.
+	public var clientInboxId: InboxId
 	let streamHolder = StreamHolder()
 
 	public enum ConversationError: Error, CustomStringConvertible, LocalizedError {
@@ -59,7 +61,7 @@ public struct Dm: Identifiable, Equatable, Hashable {
 	}
 
 	public func isCreator() async throws -> Bool {
-		try await metadata().creatorInboxId() == client.inboxID
+		try await metadata().creatorInboxId() == clientInboxId
 	}
 
 	public func isActive() throws -> Bool {

--- a/sdks/ios/Sources/XMTPiOS/Extensions/Ffi.swift
+++ b/sdks/ios/Sources/XMTPiOS/Extensions/Ffi.swift
@@ -1,43 +1,45 @@
 import Foundation
 
 extension FfiConversation {
-	func groupFromFFI(client: Client) -> Group {
-		Group(ffiGroup: self, client: client)
+	func groupFromFFI(clientInboxId: InboxId) -> Group {
+		Group(ffiGroup: self, clientInboxId: clientInboxId)
 	}
 
-	func dmFromFFI(client: Client) -> Dm {
-		Dm(ffiConversation: self, client: client)
+	func dmFromFFI(clientInboxId: InboxId) -> Dm {
+		Dm(ffiConversation: self, clientInboxId: clientInboxId)
 	}
 
-	func toConversation(client: Client) async throws -> Conversation {
+	func toConversation(clientInboxId: InboxId) async throws -> Conversation {
 		if conversationType() == .dm {
-			Conversation.dm(dmFromFFI(client: client))
+			Conversation.dm(dmFromFFI(clientInboxId: clientInboxId))
 		} else {
-			Conversation.group(groupFromFFI(client: client))
+			Conversation.group(groupFromFFI(clientInboxId: clientInboxId))
 		}
 	}
 }
 
 extension FfiConversationListItem {
-	func groupFromFFI(client: Client) -> Group {
+	func groupFromFFI(clientInboxId: InboxId) -> Group {
 		Group(
 			ffiGroup: conversation(), ffiLastMessage: lastMessage(),
-			ffiCommitLogForkStatus: isCommitLogForked(), client: client
+			ffiCommitLogForkStatus: isCommitLogForked(),
+			clientInboxId: clientInboxId
 		)
 	}
 
-	func dmFromFFI(client: Client) -> Dm {
+	func dmFromFFI(clientInboxId: InboxId) -> Dm {
 		Dm(
 			ffiConversation: conversation(), ffiLastMessage: lastMessage(),
-			ffiCommitLogForkStatus: isCommitLogForked(), client: client
+			ffiCommitLogForkStatus: isCommitLogForked(),
+			clientInboxId: clientInboxId
 		)
 	}
 
-	func toConversation(client: Client) async throws -> Conversation {
+	func toConversation(clientInboxId: InboxId) async throws -> Conversation {
 		if conversation().conversationType() == .dm {
-			Conversation.dm(dmFromFFI(client: client))
+			Conversation.dm(dmFromFFI(clientInboxId: clientInboxId))
 		} else {
-			Conversation.group(groupFromFFI(client: client))
+			Conversation.group(groupFromFFI(clientInboxId: clientInboxId))
 		}
 	}
 }

--- a/sdks/ios/Sources/XMTPiOS/Group.swift
+++ b/sdks/ios/Sources/XMTPiOS/Group.swift
@@ -37,7 +37,9 @@ public struct Group: Identifiable, Equatable, Hashable {
 	var ffiGroup: FfiConversation
 	var ffiLastMessage: FfiMessage?
 	var ffiCommitLogForkStatus: Bool?
-	var client: Client
+	/// InboxId of the owning Client. Captured at construction time so Group
+	/// does not need to hold a reference to Client itself.
+	public var clientInboxId: InboxId
 	let streamHolder = StreamHolder()
 
 	public var id: String {
@@ -85,7 +87,7 @@ public struct Group: Identifiable, Equatable, Hashable {
 	}
 
 	public func isCreator() async throws -> Bool {
-		try await metadata().creatorInboxId() == client.inboxID
+		try await metadata().creatorInboxId() == clientInboxId
 	}
 
 	public func isAdmin(inboxId: InboxId) throws -> Bool {
@@ -151,7 +153,7 @@ public struct Group: Identifiable, Equatable, Hashable {
 	public var peerInboxIds: [InboxId] {
 		get async throws {
 			var ids = try await members.map(\.inboxId)
-			if let index = ids.firstIndex(of: client.inboxID) {
+			if let index = ids.firstIndex(of: clientInboxId) {
 				ids.remove(at: index)
 			}
 			return ids

--- a/sdks/ios/Sources/XMTPiOS/Libxmtp/xmtpv3.swift
+++ b/sdks/ios/Sources/XMTPiOS/Libxmtp/xmtpv3.swift
@@ -707,9 +707,8 @@ fileprivate struct UniffiCallbackInterfaceFfiAuthCallback {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
     //
-    // This creates 1-element array, since this seems to be the only way to construct a const
-    // pointer that we can pass to the Rust code.
-    static let vtable: [UniffiVTableCallbackInterfaceFfiAuthCallback] = [UniffiVTableCallbackInterfaceFfiAuthCallback(
+    // Store the vtable directly.
+    static let vtable: UniffiVTableCallbackInterfaceFfiAuthCallback = UniffiVTableCallbackInterfaceFfiAuthCallback(
         uniffiFree: { (uniffiHandle: UInt64) -> () in
             do {
                 try FfiConverterTypeFfiAuthCallback.handleMap.remove(handle: uniffiHandle)
@@ -765,11 +764,19 @@ fileprivate struct UniffiCallbackInterfaceFfiAuthCallback {
                 droppedCallback: uniffiOutDroppedCallback
             )
         }
-    )]
+    )
+
+    // Rust stores this pointer for future callback invocations, so it must live
+    // for the process lifetime (not just for the init function call).
+    static let vtablePtr: UnsafePointer<UniffiVTableCallbackInterfaceFfiAuthCallback> = {
+        let ptr = UnsafeMutablePointer<UniffiVTableCallbackInterfaceFfiAuthCallback>.allocate(capacity: 1)
+        ptr.initialize(to: vtable)
+        return UnsafePointer(ptr)
+    }()
 }
 
 private func uniffiCallbackInitFfiAuthCallback() {
-    uniffi_xmtpv3_fn_init_callback_vtable_ffiauthcallback(UniffiCallbackInterfaceFfiAuthCallback.vtable)
+    uniffi_xmtpv3_fn_init_callback_vtable_ffiauthcallback(UniffiCallbackInterfaceFfiAuthCallback.vtablePtr)
 }
 
 #if swift(>=5.8)
@@ -1071,9 +1078,8 @@ fileprivate struct UniffiCallbackInterfaceFfiConsentCallback {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
     //
-    // This creates 1-element array, since this seems to be the only way to construct a const
-    // pointer that we can pass to the Rust code.
-    static let vtable: [UniffiVTableCallbackInterfaceFfiConsentCallback] = [UniffiVTableCallbackInterfaceFfiConsentCallback(
+    // Store the vtable directly.
+    static let vtable: UniffiVTableCallbackInterfaceFfiConsentCallback = UniffiVTableCallbackInterfaceFfiConsentCallback(
         uniffiFree: { (uniffiHandle: UInt64) -> () in
             do {
                 try FfiConverterTypeFfiConsentCallback.handleMap.remove(handle: uniffiHandle)
@@ -1158,11 +1164,19 @@ fileprivate struct UniffiCallbackInterfaceFfiConsentCallback {
                 writeReturn: writeReturn
             )
         }
-    )]
+    )
+
+    // Rust stores this pointer for future callback invocations, so it must live
+    // for the process lifetime (not just for the init function call).
+    static let vtablePtr: UnsafePointer<UniffiVTableCallbackInterfaceFfiConsentCallback> = {
+        let ptr = UnsafeMutablePointer<UniffiVTableCallbackInterfaceFfiConsentCallback>.allocate(capacity: 1)
+        ptr.initialize(to: vtable)
+        return UnsafePointer(ptr)
+    }()
 }
 
 private func uniffiCallbackInitFfiConsentCallback() {
-    uniffi_xmtpv3_fn_init_callback_vtable_fficonsentcallback(UniffiCallbackInterfaceFfiConsentCallback.vtable)
+    uniffi_xmtpv3_fn_init_callback_vtable_fficonsentcallback(UniffiCallbackInterfaceFfiConsentCallback.vtablePtr)
 }
 
 #if swift(>=5.8)
@@ -2293,9 +2307,8 @@ fileprivate struct UniffiCallbackInterfaceFfiConversationCallback {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
     //
-    // This creates 1-element array, since this seems to be the only way to construct a const
-    // pointer that we can pass to the Rust code.
-    static let vtable: [UniffiVTableCallbackInterfaceFfiConversationCallback] = [UniffiVTableCallbackInterfaceFfiConversationCallback(
+    // Store the vtable directly.
+    static let vtable: UniffiVTableCallbackInterfaceFfiConversationCallback = UniffiVTableCallbackInterfaceFfiConversationCallback(
         uniffiFree: { (uniffiHandle: UInt64) -> () in
             do {
                 try FfiConverterTypeFfiConversationCallback.handleMap.remove(handle: uniffiHandle)
@@ -2380,11 +2393,19 @@ fileprivate struct UniffiCallbackInterfaceFfiConversationCallback {
                 writeReturn: writeReturn
             )
         }
-    )]
+    )
+
+    // Rust stores this pointer for future callback invocations, so it must live
+    // for the process lifetime (not just for the init function call).
+    static let vtablePtr: UnsafePointer<UniffiVTableCallbackInterfaceFfiConversationCallback> = {
+        let ptr = UnsafeMutablePointer<UniffiVTableCallbackInterfaceFfiConversationCallback>.allocate(capacity: 1)
+        ptr.initialize(to: vtable)
+        return UnsafePointer(ptr)
+    }()
 }
 
 private func uniffiCallbackInitFfiConversationCallback() {
-    uniffi_xmtpv3_fn_init_callback_vtable_fficonversationcallback(UniffiCallbackInterfaceFfiConversationCallback.vtable)
+    uniffi_xmtpv3_fn_init_callback_vtable_fficonversationcallback(UniffiCallbackInterfaceFfiConversationCallback.vtablePtr)
 }
 
 #if swift(>=5.8)
@@ -3707,9 +3728,8 @@ fileprivate struct UniffiCallbackInterfaceFfiInboxOwner {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
     //
-    // This creates 1-element array, since this seems to be the only way to construct a const
-    // pointer that we can pass to the Rust code.
-    static let vtable: [UniffiVTableCallbackInterfaceFfiInboxOwner] = [UniffiVTableCallbackInterfaceFfiInboxOwner(
+    // Store the vtable directly.
+    static let vtable: UniffiVTableCallbackInterfaceFfiInboxOwner = UniffiVTableCallbackInterfaceFfiInboxOwner(
         uniffiFree: { (uniffiHandle: UInt64) -> () in
             do {
                 try FfiConverterTypeFfiInboxOwner.handleMap.remove(handle: uniffiHandle)
@@ -3772,11 +3792,19 @@ fileprivate struct UniffiCallbackInterfaceFfiInboxOwner {
                 lowerError: FfiConverterTypeSigningError_lower
             )
         }
-    )]
+    )
+
+    // Rust stores this pointer for future callback invocations, so it must live
+    // for the process lifetime (not just for the init function call).
+    static let vtablePtr: UnsafePointer<UniffiVTableCallbackInterfaceFfiInboxOwner> = {
+        let ptr = UnsafeMutablePointer<UniffiVTableCallbackInterfaceFfiInboxOwner>.allocate(capacity: 1)
+        ptr.initialize(to: vtable)
+        return UnsafePointer(ptr)
+    }()
 }
 
 private func uniffiCallbackInitFfiInboxOwner() {
-    uniffi_xmtpv3_fn_init_callback_vtable_ffiinboxowner(UniffiCallbackInterfaceFfiInboxOwner.vtable)
+    uniffi_xmtpv3_fn_init_callback_vtable_ffiinboxowner(UniffiCallbackInterfaceFfiInboxOwner.vtablePtr)
 }
 
 #if swift(>=5.8)
@@ -3936,9 +3964,8 @@ fileprivate struct UniffiCallbackInterfaceFfiMessageCallback {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
     //
-    // This creates 1-element array, since this seems to be the only way to construct a const
-    // pointer that we can pass to the Rust code.
-    static let vtable: [UniffiVTableCallbackInterfaceFfiMessageCallback] = [UniffiVTableCallbackInterfaceFfiMessageCallback(
+    // Store the vtable directly.
+    static let vtable: UniffiVTableCallbackInterfaceFfiMessageCallback = UniffiVTableCallbackInterfaceFfiMessageCallback(
         uniffiFree: { (uniffiHandle: UInt64) -> () in
             do {
                 try FfiConverterTypeFfiMessageCallback.handleMap.remove(handle: uniffiHandle)
@@ -4023,11 +4050,19 @@ fileprivate struct UniffiCallbackInterfaceFfiMessageCallback {
                 writeReturn: writeReturn
             )
         }
-    )]
+    )
+
+    // Rust stores this pointer for future callback invocations, so it must live
+    // for the process lifetime (not just for the init function call).
+    static let vtablePtr: UnsafePointer<UniffiVTableCallbackInterfaceFfiMessageCallback> = {
+        let ptr = UnsafeMutablePointer<UniffiVTableCallbackInterfaceFfiMessageCallback>.allocate(capacity: 1)
+        ptr.initialize(to: vtable)
+        return UnsafePointer(ptr)
+    }()
 }
 
 private func uniffiCallbackInitFfiMessageCallback() {
-    uniffi_xmtpv3_fn_init_callback_vtable_ffimessagecallback(UniffiCallbackInterfaceFfiMessageCallback.vtable)
+    uniffi_xmtpv3_fn_init_callback_vtable_ffimessagecallback(UniffiCallbackInterfaceFfiMessageCallback.vtablePtr)
 }
 
 #if swift(>=5.8)
@@ -4168,9 +4203,8 @@ fileprivate struct UniffiCallbackInterfaceFfiMessageDeletionCallback {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
     //
-    // This creates 1-element array, since this seems to be the only way to construct a const
-    // pointer that we can pass to the Rust code.
-    static let vtable: [UniffiVTableCallbackInterfaceFfiMessageDeletionCallback] = [UniffiVTableCallbackInterfaceFfiMessageDeletionCallback(
+    // Store the vtable directly.
+    static let vtable: UniffiVTableCallbackInterfaceFfiMessageDeletionCallback = UniffiVTableCallbackInterfaceFfiMessageDeletionCallback(
         uniffiFree: { (uniffiHandle: UInt64) -> () in
             do {
                 try FfiConverterTypeFfiMessageDeletionCallback.handleMap.remove(handle: uniffiHandle)
@@ -4209,11 +4243,19 @@ fileprivate struct UniffiCallbackInterfaceFfiMessageDeletionCallback {
                 writeReturn: writeReturn
             )
         }
-    )]
+    )
+
+    // Rust stores this pointer for future callback invocations, so it must live
+    // for the process lifetime (not just for the init function call).
+    static let vtablePtr: UnsafePointer<UniffiVTableCallbackInterfaceFfiMessageDeletionCallback> = {
+        let ptr = UnsafeMutablePointer<UniffiVTableCallbackInterfaceFfiMessageDeletionCallback>.allocate(capacity: 1)
+        ptr.initialize(to: vtable)
+        return UnsafePointer(ptr)
+    }()
 }
 
 private func uniffiCallbackInitFfiMessageDeletionCallback() {
-    uniffi_xmtpv3_fn_init_callback_vtable_ffimessagedeletioncallback(UniffiCallbackInterfaceFfiMessageDeletionCallback.vtable)
+    uniffi_xmtpv3_fn_init_callback_vtable_ffimessagedeletioncallback(UniffiCallbackInterfaceFfiMessageDeletionCallback.vtablePtr)
 }
 
 #if swift(>=5.8)
@@ -4373,9 +4415,8 @@ fileprivate struct UniffiCallbackInterfaceFfiPreferenceCallback {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
     //
-    // This creates 1-element array, since this seems to be the only way to construct a const
-    // pointer that we can pass to the Rust code.
-    static let vtable: [UniffiVTableCallbackInterfaceFfiPreferenceCallback] = [UniffiVTableCallbackInterfaceFfiPreferenceCallback(
+    // Store the vtable directly.
+    static let vtable: UniffiVTableCallbackInterfaceFfiPreferenceCallback = UniffiVTableCallbackInterfaceFfiPreferenceCallback(
         uniffiFree: { (uniffiHandle: UInt64) -> () in
             do {
                 try FfiConverterTypeFfiPreferenceCallback.handleMap.remove(handle: uniffiHandle)
@@ -4460,11 +4501,19 @@ fileprivate struct UniffiCallbackInterfaceFfiPreferenceCallback {
                 writeReturn: writeReturn
             )
         }
-    )]
+    )
+
+    // Rust stores this pointer for future callback invocations, so it must live
+    // for the process lifetime (not just for the init function call).
+    static let vtablePtr: UnsafePointer<UniffiVTableCallbackInterfaceFfiPreferenceCallback> = {
+        let ptr = UnsafeMutablePointer<UniffiVTableCallbackInterfaceFfiPreferenceCallback>.allocate(capacity: 1)
+        ptr.initialize(to: vtable)
+        return UnsafePointer(ptr)
+    }()
 }
 
 private func uniffiCallbackInitFfiPreferenceCallback() {
-    uniffi_xmtpv3_fn_init_callback_vtable_ffipreferencecallback(UniffiCallbackInterfaceFfiPreferenceCallback.vtable)
+    uniffi_xmtpv3_fn_init_callback_vtable_ffipreferencecallback(UniffiCallbackInterfaceFfiPreferenceCallback.vtablePtr)
 }
 
 #if swift(>=5.8)

--- a/sdks/ios/dev/bindings
+++ b/sdks/ios/dev/bindings
@@ -3,13 +3,7 @@ source "$(dirname "$0")/.setup"
 
 SWIFT_OUT="${ROOT}/bindings/mobile/build/swift"
 
-# --- Fix 3: preflight sanity check on the nix binary cache ---
-# If xmtp.cachix.org is not configured as a substituter, nix will rebuild
-# every Rust dependency from source, which on macOS reliably trips over
-# the aws-lc-sys / cc-wrapper triple-mismatch bug ("--target
-# arm64-apple-macosx != arm64-apple-darwin"). Bail early with an
-# actionable message instead of letting people stare at a cryptic
-# linker error for an hour.
+# --- Preflight sanity check on the nix binary cache ---
 if ! nix config show substituters 2>/dev/null | grep -q "xmtp.cachix.org"; then
     echo "⚠️  xmtp.cachix.org is not in your nix substituters."
     echo "    Without it, nix will rebuild every dependency from source,"
@@ -32,15 +26,7 @@ if [[ "${1:-}" == "--release" ]]; then
         "${ROOT}/sdks/ios/Sources/XMTPiOS/Libxmtp/xmtpv3.swift"
 else
     echo "Building iOS xcframeworks (simulator + macOS only)..."
-    # --- Fix 1: materialize the xcframework instead of symlinking ---
-    # Previously this script did `nix build --out-link $SWIFT_OUT`, which
-    # made build/swift a symlink directly into /nix/store. That works for
-    # `swift test` but causes Xcode to cache a stale xcframework in its
-    # DerivedData SPM artifact store — after a uniffi regen, you end up
-    # with "Cannot convert UInt64 to UnsafeMutableRawPointer" errors at
-    # every FFI call site. Copying the xcframework into build/swift as
-    # a real directory (like the --release branch already does) gives
-    # Xcode a stable path to stat and keeps it in sync with nix rebuilds.
+    # Materialize the xcframework instead of symlinking ---
     rm -rf "$SWIFT_OUT"
     nix build "${ROOT}#ios-xcframeworks-fast" \
         --out-link "${ROOT}/bindings/mobile/build/nix-fast"
@@ -52,14 +38,7 @@ else
     cp -f "$SWIFT_OUT/xmtpv3.swift" "${ROOT}/sdks/ios/Sources/XMTPiOS/Libxmtp/xmtpv3.swift"
 fi
 
-# --- Fix 2: invalidate Xcode's staged binary-target cache ---
-# Xcode stages .binaryTarget artifacts into DerivedData at package
-# resolve time and does NOT re-stage when the source file underneath
-# changes. After we've rebuilt the xcframework, walk every DerivedData
-# workspace and delete only the libxmtp-specific staged artifacts so
-# Xcode re-stages against the fresh xcframework on its next resolve.
-# Everything else in DerivedData (compiled modules, indexes, other
-# packages' artifacts) is left untouched.
+# Invalidate Xcode's staged binary-target cache ---
 DERIVED_DATA="$HOME/Library/Developer/Xcode/DerivedData"
 if [[ -d "$DERIVED_DATA" ]]; then
     shopt -s nullglob

--- a/sdks/ios/dev/bindings
+++ b/sdks/ios/dev/bindings
@@ -3,6 +3,23 @@ source "$(dirname "$0")/.setup"
 
 SWIFT_OUT="${ROOT}/bindings/mobile/build/swift"
 
+# --- Fix 3: preflight sanity check on the nix binary cache ---
+# If xmtp.cachix.org is not configured as a substituter, nix will rebuild
+# every Rust dependency from source, which on macOS reliably trips over
+# the aws-lc-sys / cc-wrapper triple-mismatch bug ("--target
+# arm64-apple-macosx != arm64-apple-darwin"). Bail early with an
+# actionable message instead of letting people stare at a cryptic
+# linker error for an hour.
+if ! nix config show substituters 2>/dev/null | grep -q "xmtp.cachix.org"; then
+    echo "⚠️  xmtp.cachix.org is not in your nix substituters."
+    echo "    Without it, nix will rebuild every dependency from source,"
+    echo "    which on macOS typically fails inside aws-lc-sys."
+    echo "    Run ./dev/nix-cache-up to configure the cache, then retry."
+    echo ""
+    read -p "Continue anyway? (y/N) " -n 1 -r; echo
+    [[ $REPLY =~ ^[Yy]$ ]] || exit 1
+fi
+
 if [[ "${1:-}" == "--release" ]]; then
     echo "Building iOS xcframeworks (all targets)..."
     nix build "${ROOT}#ios-xcframeworks" --out-link "${ROOT}/bindings/mobile/build/release"
@@ -15,8 +32,40 @@ if [[ "${1:-}" == "--release" ]]; then
         "${ROOT}/sdks/ios/Sources/XMTPiOS/Libxmtp/xmtpv3.swift"
 else
     echo "Building iOS xcframeworks (simulator + macOS only)..."
+    # --- Fix 1: materialize the xcframework instead of symlinking ---
+    # Previously this script did `nix build --out-link $SWIFT_OUT`, which
+    # made build/swift a symlink directly into /nix/store. That works for
+    # `swift test` but causes Xcode to cache a stale xcframework in its
+    # DerivedData SPM artifact store — after a uniffi regen, you end up
+    # with "Cannot convert UInt64 to UnsafeMutableRawPointer" errors at
+    # every FFI call site. Copying the xcframework into build/swift as
+    # a real directory (like the --release branch already does) gives
+    # Xcode a stable path to stat and keeps it in sync with nix rebuilds.
     rm -rf "$SWIFT_OUT"
-    nix build "${ROOT}#ios-xcframeworks-fast" --out-link "$SWIFT_OUT"
+    nix build "${ROOT}#ios-xcframeworks-fast" \
+        --out-link "${ROOT}/bindings/mobile/build/nix-fast"
+    mkdir -p "$SWIFT_OUT"
+    cp -rL "${ROOT}/bindings/mobile/build/nix-fast/LibXMTPSwiftFFI.xcframework" "$SWIFT_OUT/"
+    cp -f  "${ROOT}/bindings/mobile/build/nix-fast/xmtpv3.swift" "$SWIFT_OUT/xmtpv3.swift"
+    chmod -R u+w "$SWIFT_OUT"
     # Update SDK source tree with freshly generated Swift bindings
     cp -f "$SWIFT_OUT/xmtpv3.swift" "${ROOT}/sdks/ios/Sources/XMTPiOS/Libxmtp/xmtpv3.swift"
+fi
+
+# --- Fix 2: invalidate Xcode's staged binary-target cache ---
+# Xcode stages .binaryTarget artifacts into DerivedData at package
+# resolve time and does NOT re-stage when the source file underneath
+# changes. After we've rebuilt the xcframework, walk every DerivedData
+# workspace and delete only the libxmtp-specific staged artifacts so
+# Xcode re-stages against the fresh xcframework on its next resolve.
+# Everything else in DerivedData (compiled modules, indexes, other
+# packages' artifacts) is left untouched.
+DERIVED_DATA="$HOME/Library/Developer/Xcode/DerivedData"
+if [[ -d "$DERIVED_DATA" ]]; then
+    shopt -s nullglob
+    for staged in "$DERIVED_DATA"/*/SourcePackages/artifacts/libxmtp; do
+        echo "Invalidating stale Xcode SPM artifact cache: $staged"
+        rm -rf "$staged"
+    done
+    shopt -u nullglob
 fi


### PR DESCRIPTION
nix ios fixes for catching missing cache or common xcode build errors

make comments more succinct

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix iOS Nix build script and vtable stability in UniFFI callback interfaces
> - Replaces single-element Swift array vtables with heap-allocated `vtablePtr` values in all `UniffiCallbackInterface*` structs in [xmtpv3.swift](https://github.com/xmtp/libxmtp/pull/3498/files#diff-a700aa043faadbfda772fbdb5bb89d90475d4da4e02fe6a77691d111cd6d85bb), ensuring the vtable pointer remains stable for the process lifetime instead of pointing into a potentially relocated Swift array.
> - Updates the [bindings build script](https://github.com/xmtp/libxmtp/pull/3498/files#diff-56a9dc2d9952fcaf7cc99e40616cc8299e11605a510b9265136116eda725497c) to warn and prompt when `xmtp.cachix.org` is not configured as a Nix substituter.
> - Changes the fast (non-release) build path from symlinking the Nix output to copying the xcframework and Swift file into `SWIFT_OUT`, with writable permissions set after copy.
> - Adds post-build invalidation of Xcode's staged SPM artifact cache by removing stale `libxmtp` entries from `DerivedData`.
> - Risk: copying artifacts instead of symlinking means artifact changes require re-running the script to propagate; stale symlinks from previous runs may need manual cleanup.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #3498 opened
>
> - Replaced `Client` references with `InboxId` throughout the conversation model [177c88f]
> - Removed client deallocation error handling and weak reference checks [177c88f]
> - Updated FFI conversion utilities to accept `clientInboxId` instead of `Client` [177c88f]
> - Changed `Conversations.findDmByIdentity` to call FFI client directly for inbox ID resolution [177c88f]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0516651.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->