### PR TITLE
remove circular reference of client in conversations

### DIFF
--- a/sdks/ios/Sources/XMTPiOS/Client.swift
+++ b/sdks/ios/Sources/XMTPiOS/Client.swift
@@ -8,7 +8,6 @@ public enum ClientError: Error, CustomStringConvertible, LocalizedError {
 	case creationError(String)
 	case missingInboxId
 	case invalidInboxId(String)
-	case clientDeallocated
 
 	public var description: String {
 		switch self {
@@ -18,8 +17,6 @@ public enum ClientError: Error, CustomStringConvertible, LocalizedError {
 			"ClientError.missingInboxId"
 		case let .invalidInboxId(inboxId):
 			"Invalid inboxId: \(inboxId). Inbox IDs cannot start with '0x'."
-		case .clientDeallocated:
-			"ClientError.clientDeallocated: The Client has been deallocated."
 		}
 	}
 
@@ -204,7 +201,8 @@ public final class Client {
 	private static let apiCache = ApiClientCache()
 
 	public lazy var conversations: Conversations = .init(
-		client: self, ffiConversations: ffiClient.conversations(),
+		clientInboxId: inboxID,
+		ffiConversations: ffiClient.conversations(),
 		ffiClient: ffiClient
 	)
 

--- a/sdks/ios/Sources/XMTPiOS/Conversation.swift
+++ b/sdks/ios/Sources/XMTPiOS/Conversation.swift
@@ -345,12 +345,12 @@ public enum Conversation: Identifiable, Equatable, Hashable {
 		}
 	}
 
-	public var client: Client {
+	public var clientInboxId: InboxId {
 		switch self {
 		case let .group(group):
-			group.client
+			group.clientInboxId
 		case let .dm(dm):
-			dm.client
+			dm.clientInboxId
 		}
 	}
 

--- a/sdks/ios/Sources/XMTPiOS/Conversations.swift
+++ b/sdks/ios/Sources/XMTPiOS/Conversations.swift
@@ -119,24 +119,22 @@ actor FfiStreamActor {
 
 /// Handles listing and creating Conversations.
 public class Conversations {
-	private weak var client: Client?
+	/// The inboxId of the Client that owns this Conversations instance.
+	/// Captured at construction time so Conversations does not need a
+	/// back-reference to Client (which would create a retain cycle with
+	/// Client's `lazy var conversations`).
+	let clientInboxId: InboxId
 	var ffiConversations: FfiConversations
 	var ffiClient: FfiXmtpClient
 
 	init(
-		client: Client, ffiConversations: FfiConversations,
+		clientInboxId: InboxId,
+		ffiConversations: FfiConversations,
 		ffiClient: FfiXmtpClient
 	) {
-		self.client = client
+		self.clientInboxId = clientInboxId
 		self.ffiConversations = ffiConversations
 		self.ffiClient = ffiClient
-	}
-
-	private func requireClient() throws -> Client {
-		guard let client else {
-			throw ClientError.clientDeallocated
-		}
-		return client
 	}
 
 	/// Helper function to convert DisappearingMessageSettings to FfiMessageDisappearingSettings
@@ -152,13 +150,12 @@ public class Conversations {
 	}
 
 	public func findGroup(groupId: String) throws -> Group? {
-		let client = try requireClient()
 		do {
 			return try Group(
 				ffiGroup: ffiClient.conversation(
 					conversationId: groupId.hexToData
 				),
-				client: client
+				clientInboxId: clientInboxId
 			)
 		} catch {
 			return nil
@@ -168,12 +165,13 @@ public class Conversations {
 	public func findConversation(conversationId: String) async throws
 		-> Conversation?
 	{
-		let client = try requireClient()
 		do {
 			let conversation = try ffiClient.conversation(
 				conversationId: conversationId.hexToData
 			)
-			return try await conversation.toConversation(client: client)
+			return try await conversation.toConversation(
+				clientInboxId: clientInboxId
+			)
 		} catch {
 			return nil
 		}
@@ -182,7 +180,6 @@ public class Conversations {
 	public func findConversationByTopic(topic: String) async throws
 		-> Conversation?
 	{
-		let client = try requireClient()
 		do {
 			let regexPattern = #"/xmtp/mls/1/g-(.*?)/proto"#
 			if let regex = try? NSRegularExpression(pattern: regexPattern) {
@@ -196,7 +193,9 @@ public class Conversations {
 					let conversation = try ffiClient.conversation(
 						conversationId: conversationId.hexToData
 					)
-					return try await conversation.toConversation(client: client)
+					return try await conversation.toConversation(
+						clientInboxId: clientInboxId
+					)
 				}
 			}
 		} catch {
@@ -206,13 +205,13 @@ public class Conversations {
 	}
 
 	public func findDmByInboxId(inboxId: InboxId) throws -> Dm? {
-		let client = try requireClient()
 		do {
 			let conversation = try ffiClient.dmConversation(
 				targetInboxId: inboxId
 			)
 			return Dm(
-				ffiConversation: conversation, client: client
+				ffiConversation: conversation,
+				clientInboxId: clientInboxId
 			)
 		} catch {
 			return nil
@@ -222,10 +221,9 @@ public class Conversations {
 	public func findDmByIdentity(publicIdentity: PublicIdentity) async throws
 		-> Dm?
 	{
-		let client = try requireClient()
 		guard
-			let inboxId = try await client.inboxIdFromIdentity(
-				identity: publicIdentity
+			let inboxId = try await ffiClient.findInboxId(
+				identifier: publicIdentity.ffiPrivate
 			)
 		else {
 			throw ClientError.creationError("No inboxId present")
@@ -282,7 +280,6 @@ public class Conversations {
 		consentStates: [ConsentState]? = nil,
 		orderBy: ConversationsOrderBy = ConversationsOrderBy.lastActivity
 	) throws -> [Group] {
-		let client = try requireClient()
 		var options = FfiListConversationsOptions(
 			createdAfterNs: createdAfterNs,
 			createdBeforeNs: createdBeforeNs,
@@ -302,7 +299,7 @@ public class Conversations {
 		)
 
 		return conversations.map {
-			$0.groupFromFFI(client: client)
+			$0.groupFromFFI(clientInboxId: clientInboxId)
 		}
 	}
 
@@ -315,7 +312,6 @@ public class Conversations {
 		consentStates: [ConsentState]? = nil,
 		orderBy: ConversationsOrderBy = ConversationsOrderBy.lastActivity
 	) throws -> [Dm] {
-		let client = try requireClient()
 		var options = FfiListConversationsOptions(
 			createdAfterNs: createdAfterNs,
 			createdBeforeNs: createdBeforeNs,
@@ -336,7 +332,7 @@ public class Conversations {
 		)
 
 		return conversations.map {
-			$0.dmFromFFI(client: client)
+			$0.dmFromFFI(clientInboxId: clientInboxId)
 		}
 	}
 
@@ -349,7 +345,6 @@ public class Conversations {
 		consentStates: [ConsentState]? = nil,
 		orderBy: ConversationsOrderBy = ConversationsOrderBy.lastActivity
 	) async throws -> [Conversation] {
-		let client = try requireClient()
 		var options = FfiListConversationsOptions(
 			createdAfterNs: createdAfterNs,
 			createdBeforeNs: createdBeforeNs,
@@ -371,7 +366,7 @@ public class Conversations {
 		var conversations: [Conversation] = []
 		for conversation in ffiConversations {
 			let conversation = try await conversation.toConversation(
-				client: client
+				clientInboxId: clientInboxId
 			)
 			conversations.append(conversation)
 		}
@@ -383,11 +378,8 @@ public class Conversations {
 	) -> AsyncThrowingStream<
 		Conversation, Error
 	> {
-		AsyncThrowingStream { continuation in
-			guard let client = self.client else {
-				continuation.finish(throwing: ClientError.clientDeallocated)
-				return
-			}
+		let clientInboxId = clientInboxId
+		return AsyncThrowingStream { continuation in
 			let ffiStreamActor = FfiStreamActor()
 			let conversationCallback = ConversationStreamCallback {
 				conversation in
@@ -402,14 +394,16 @@ public class Conversations {
 						if conversationType == .dm {
 							continuation.yield(
 								Conversation.dm(
-									conversation.dmFromFFI(client: client)
+									conversation.dmFromFFI(
+										clientInboxId: clientInboxId
+									)
 								)
 							)
 						} else if conversationType == .group {
 							continuation.yield(
 								Conversation.group(
 									conversation.groupFromFFI(
-										client: client
+										clientInboxId: clientInboxId
 									)
 								)
 							)
@@ -470,9 +464,12 @@ public class Conversations {
 		with peerIdentity: PublicIdentity,
 		disappearingMessageSettings: DisappearingMessageSettings? = nil
 	) async throws -> Dm {
-		let client = try requireClient()
-		if try await client.inboxState(refreshFromNetwork: false).identities
-			.map(\.identifier).contains(peerIdentity.identifier)
+		let ffiInboxState = try await ffiClient.inboxState(
+			refreshFromNetwork: false
+		)
+		let inboxState = InboxState(ffiInboxState: ffiInboxState)
+		if inboxState.identities.map(\.identifier)
+			.contains(peerIdentity.identifier)
 		{
 			throw ConversationError.memberCannotBeSelf
 		}
@@ -488,7 +485,7 @@ public class Conversations {
 					)
 				)
 
-		return dm.dmFromFFI(client: client)
+		return dm.dmFromFFI(clientInboxId: clientInboxId)
 	}
 
 	public func newConversation(
@@ -508,8 +505,7 @@ public class Conversations {
 	)
 		async throws -> Dm
 	{
-		let client = try requireClient()
-		if peerInboxId == client.inboxID {
+		if peerInboxId == clientInboxId {
 			throw ConversationError.memberCannotBeSelf
 		}
 		try validateInboxId(peerInboxId)
@@ -523,7 +519,7 @@ public class Conversations {
 						)
 					)
 				)
-		return dm.dmFromFFI(client: client)
+		return dm.dmFromFFI(clientInboxId: clientInboxId)
 	}
 
 	public func newGroupWithIdentities(
@@ -583,8 +579,7 @@ public class Conversations {
 		disappearingMessageSettings: DisappearingMessageSettings? = nil,
 		appData: String?
 	) async throws -> Group {
-		let client = try requireClient()
-		return try await ffiConversations.createGroupByIdentity(
+		try await ffiConversations.createGroupByIdentity(
 			accountIdentities: identities.map(\.ffiPrivate),
 			opts: FfiCreateGroupOptions(
 				permissions: permissions,
@@ -597,7 +592,7 @@ public class Conversations {
 				),
 				appData: appData
 			)
-		).groupFromFFI(client: client)
+		).groupFromFFI(clientInboxId: clientInboxId)
 	}
 
 	public func newGroup(
@@ -657,7 +652,6 @@ public class Conversations {
 		disappearingMessageSettings: DisappearingMessageSettings? = nil,
 		appData: String?
 	) async throws -> Group {
-		let client = try requireClient()
 		try validateInboxIds(inboxIds)
 		return try await ffiConversations.createGroup(
 			inboxIds: inboxIds,
@@ -672,7 +666,7 @@ public class Conversations {
 				),
 				appData: appData
 			)
-		).groupFromFFI(client: client)
+		).groupFromFFI(clientInboxId: clientInboxId)
 	}
 
 	public func newGroupOptimistic(
@@ -683,7 +677,6 @@ public class Conversations {
 		disappearingMessageSettings: DisappearingMessageSettings? = nil,
 		appData: String? = nil
 	) throws -> Group {
-		let client = try requireClient()
 		let ffiOpts = FfiCreateGroupOptions(
 			permissions:
 			GroupPermissionPreconfiguration.toFfiGroupPermissionOptions(
@@ -700,7 +693,7 @@ public class Conversations {
 		)
 
 		let ffiGroup = try ffiConversations.createGroupOptimistic(opts: ffiOpts)
-		return Group(ffiGroup: ffiGroup, client: client)
+		return Group(ffiGroup: ffiGroup, clientInboxId: clientInboxId)
 	}
 
 	public func streamAllMessages(
@@ -804,14 +797,15 @@ public class Conversations {
 	public func fromWelcome(envelopeBytes: Data) async throws
 		-> Conversation?
 	{
-		let client = try requireClient()
 		let conversations =
 			try await ffiConversations
 				.processStreamedWelcomeMessage(envelopeBytes: envelopeBytes)
 		guard let firstConversation = conversations.first else {
 			return nil
 		}
-		return try await firstConversation.toConversation(client: client)
+		return try await firstConversation.toConversation(
+			clientInboxId: clientInboxId
+		)
 	}
 
 	public func getHmacKeys() throws

--- a/sdks/ios/Sources/XMTPiOS/Dm.swift
+++ b/sdks/ios/Sources/XMTPiOS/Dm.swift
@@ -4,7 +4,9 @@ public struct Dm: Identifiable, Equatable, Hashable {
 	var ffiConversation: FfiConversation
 	var ffiLastMessage: FfiMessage?
 	var ffiCommitLogForkStatus: Bool?
-	var client: Client
+	/// InboxId of the owning Client. Captured at construction time so Dm
+	/// does not need to hold a reference to Client itself.
+	public var clientInboxId: InboxId
 	let streamHolder = StreamHolder()
 
 	public enum ConversationError: Error, CustomStringConvertible, LocalizedError {
@@ -59,7 +61,7 @@ public struct Dm: Identifiable, Equatable, Hashable {
 	}
 
 	public func isCreator() async throws -> Bool {
-		try await metadata().creatorInboxId() == client.inboxID
+		try await metadata().creatorInboxId() == clientInboxId
 	}
 
 	public func isActive() throws -> Bool {

--- a/sdks/ios/Sources/XMTPiOS/Extensions/Ffi.swift
+++ b/sdks/ios/Sources/XMTPiOS/Extensions/Ffi.swift
@@ -1,43 +1,45 @@
 import Foundation
 
 extension FfiConversation {
-	func groupFromFFI(client: Client) -> Group {
-		Group(ffiGroup: self, client: client)
+	func groupFromFFI(clientInboxId: InboxId) -> Group {
+		Group(ffiGroup: self, clientInboxId: clientInboxId)
 	}
 
-	func dmFromFFI(client: Client) -> Dm {
-		Dm(ffiConversation: self, client: client)
+	func dmFromFFI(clientInboxId: InboxId) -> Dm {
+		Dm(ffiConversation: self, clientInboxId: clientInboxId)
 	}
 
-	func toConversation(client: Client) async throws -> Conversation {
+	func toConversation(clientInboxId: InboxId) async throws -> Conversation {
 		if conversationType() == .dm {
-			Conversation.dm(dmFromFFI(client: client))
+			Conversation.dm(dmFromFFI(clientInboxId: clientInboxId))
 		} else {
-			Conversation.group(groupFromFFI(client: client))
+			Conversation.group(groupFromFFI(clientInboxId: clientInboxId))
 		}
 	}
 }
 
 extension FfiConversationListItem {
-	func groupFromFFI(client: Client) -> Group {
+	func groupFromFFI(clientInboxId: InboxId) -> Group {
 		Group(
 			ffiGroup: conversation(), ffiLastMessage: lastMessage(),
-			ffiCommitLogForkStatus: isCommitLogForked(), client: client
+			ffiCommitLogForkStatus: isCommitLogForked(),
+			clientInboxId: clientInboxId
 		)
 	}
 
-	func dmFromFFI(client: Client) -> Dm {
+	func dmFromFFI(clientInboxId: InboxId) -> Dm {
 		Dm(
 			ffiConversation: conversation(), ffiLastMessage: lastMessage(),
-			ffiCommitLogForkStatus: isCommitLogForked(), client: client
+			ffiCommitLogForkStatus: isCommitLogForked(),
+			clientInboxId: clientInboxId
 		)
 	}
 
-	func toConversation(client: Client) async throws -> Conversation {
+	func toConversation(clientInboxId: InboxId) async throws -> Conversation {
 		if conversation().conversationType() == .dm {
-			Conversation.dm(dmFromFFI(client: client))
+			Conversation.dm(dmFromFFI(clientInboxId: clientInboxId))
 		} else {
-			Conversation.group(groupFromFFI(client: client))
+			Conversation.group(groupFromFFI(clientInboxId: clientInboxId))
 		}
 	}
 }

--- a/sdks/ios/Sources/XMTPiOS/Group.swift
+++ b/sdks/ios/Sources/XMTPiOS/Group.swift
@@ -37,7 +37,9 @@ public struct Group: Identifiable, Equatable, Hashable {
 	var ffiGroup: FfiConversation
 	var ffiLastMessage: FfiMessage?
 	var ffiCommitLogForkStatus: Bool?
-	var client: Client
+	/// InboxId of the owning Client. Captured at construction time so Group
+	/// does not need to hold a reference to Client itself.
+	public var clientInboxId: InboxId
 	let streamHolder = StreamHolder()
 
 	public var id: String {
@@ -85,7 +87,7 @@ public struct Group: Identifiable, Equatable, Hashable {
 	}
 
 	public func isCreator() async throws -> Bool {
-		try await metadata().creatorInboxId() == client.inboxID
+		try await metadata().creatorInboxId() == clientInboxId
 	}
 
 	public func isAdmin(inboxId: InboxId) throws -> Bool {
@@ -151,7 +153,7 @@ public struct Group: Identifiable, Equatable, Hashable {
 	public var peerInboxIds: [InboxId] {
 		get async throws {
 			var ids = try await members.map(\.inboxId)
-			if let index = ids.firstIndex(of: client.inboxID) {
+			if let index = ids.firstIndex(of: clientInboxId) {
 				ids.remove(at: index)
 			}
 			return ids


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Remove circular client reference from iOS conversation types
- Replaces the `Client` reference held by `Group`, `Dm`, and `Conversations` with a plain `InboxId` string, breaking a circular retain cycle.
- Updates all FFI conversion helpers in [Ffi.swift](https://github.com/xmtp/libxmtp/pull/3499/files#diff-abe893e86cf5b92ecef4b962e75e9f81e265cbbe24c3685baeadbd87a78a9f6e) to accept `clientInboxId: InboxId` instead of a `Client` instance.
- Removes `ClientError.clientDeallocated` and the `requireClient()` helper; streams no longer check for client liveness before yielding conversations.
- `findDmByIdentity` now resolves the target inbox ID via `ffiClient.findInboxId` rather than `client.inboxIdFromIdentity`.
- Behavioral Change: deallocated-client guard paths are gone, so code that previously threw or caught `ClientError.clientDeallocated` will no longer compile.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 177c88f.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->