### PR TITLE
feat(ios): add DbPoolOptions wrapper to ClientOptions

### DIFF
--- a/sdks/android/library/src/main/java/org/xmtp/android/library/Client.kt
+++ b/sdks/android/library/src/main/java/org/xmtp/android/library/Client.kt
@@ -56,8 +56,7 @@ data class ClientOptions(
     val dbDirectory: String? = null,
     val deviceSyncEnabled: Boolean = true,
     val forkRecoveryOptions: ForkRecoveryOptions? = null,
-    val maxDbPoolSize: UInt? = null,
-    val minDbPoolSize: UInt? = null,
+    val dbPoolOptions: DbPoolOptions? = null,
     val waitForRegistrationVisible: VisibilityConfirmationOptions? = null,
 ) {
     data class Api(
@@ -110,6 +109,11 @@ data class VisibilityConfirmationOptions(
             timeoutMs = this.timeoutMs,
         )
 }
+
+data class DbPoolOptions(
+    val maxPoolSize: UInt? = null,
+    val minPoolSize: UInt? = null,
+)
 
 typealias InboxId = String
 
@@ -533,8 +537,8 @@ class Client(
                             DbOptions(
                                 db = dbPath,
                                 encryptionKey = options.dbEncryptionKey,
-                                maxDbPoolSize = options.maxDbPoolSize,
-                                minDbPoolSize = options.minDbPoolSize,
+                                maxDbPoolSize = options.dbPoolOptions?.maxPoolSize,
+                                minDbPoolSize = options.dbPoolOptions?.minPoolSize,
                             ),
                         accountIdentifier = publicIdentity.ffiPrivate,
                         inboxId = inboxId,

--- a/sdks/android/library/src/test/java/org/xmtp/android/library/DbPoolOptionsTest.kt
+++ b/sdks/android/library/src/test/java/org/xmtp/android/library/DbPoolOptionsTest.kt
@@ -1,0 +1,28 @@
+package org.xmtp.android.library
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class DbPoolOptionsTest {
+    @Test
+    fun defaultsToAllNull() {
+        val options = DbPoolOptions()
+        assertNull(options.maxPoolSize)
+        assertNull(options.minPoolSize)
+    }
+
+    @Test
+    fun carriesValuesThrough() {
+        val options = DbPoolOptions(maxPoolSize = 10u, minPoolSize = 2u)
+        assertEquals(10u, options.maxPoolSize)
+        assertEquals(2u, options.minPoolSize)
+    }
+
+    @Test
+    fun acceptsPartialFields() {
+        val options = DbPoolOptions(maxPoolSize = 7u)
+        assertEquals(7u, options.maxPoolSize)
+        assertNull(options.minPoolSize)
+    }
+}

--- a/sdks/ios/Sources/XMTPiOS/Client.swift
+++ b/sdks/ios/Sources/XMTPiOS/Client.swift
@@ -94,6 +94,16 @@ public struct VisibilityConfirmationOptions {
 	}
 }
 
+public struct DbPoolOptions {
+	public var maxPoolSize: UInt32?
+	public var minPoolSize: UInt32?
+
+	public init(maxPoolSize: UInt32? = nil, minPoolSize: UInt32? = nil) {
+		self.maxPoolSize = maxPoolSize
+		self.minPoolSize = minPoolSize
+	}
+}
+
 /// Specify configuration options for creating a ``Client``.
 public struct ClientOptions {
 	/// Specify network options
@@ -134,6 +144,7 @@ public struct ClientOptions {
 	public var debugEventsEnabled: Bool
 	public var forkRecoveryOptions: ForkRecoveryOptions?
 	public var waitForRegistrationVisible: VisibilityConfirmationOptions?
+	public var dbPoolOptions: DbPoolOptions?
 
 	public init(
 		api: Api = Api(),
@@ -144,7 +155,8 @@ public struct ClientOptions {
 		deviceSyncEnabled: Bool = true,
 		debugEventsEnabled: Bool = false,
 		forkRecoveryOptions: ForkRecoveryOptions? = nil,
-		waitForRegistrationVisible: VisibilityConfirmationOptions? = nil
+		waitForRegistrationVisible: VisibilityConfirmationOptions? = nil,
+		dbPoolOptions: DbPoolOptions? = nil
 	) {
 		self.api = api
 		self.codecs = codecs
@@ -155,6 +167,7 @@ public struct ClientOptions {
 		self.debugEventsEnabled = debugEventsEnabled
 		self.forkRecoveryOptions = forkRecoveryOptions
 		self.waitForRegistrationVisible = waitForRegistrationVisible
+		self.dbPoolOptions = dbPoolOptions
 	}
 }
 
@@ -415,7 +428,12 @@ public final class Client {
 		let ffiClient = try await createClient(
 			api: connectToApiBackend(api: options.api),
 			syncApi: connectToSyncApiBackend(api: options.api),
-			db: DbOptions(db: dbURL, encryptionKey: options.dbEncryptionKey, maxDbPoolSize: nil, minDbPoolSize: nil),
+			db: DbOptions(
+				db: dbURL,
+				encryptionKey: options.dbEncryptionKey,
+				maxDbPoolSize: options.dbPoolOptions?.maxPoolSize,
+				minDbPoolSize: options.dbPoolOptions?.minPoolSize
+			),
 			inboxId: inboxId,
 			accountIdentifier: accountIdentifier.ffiPrivate,
 			nonce: 0,

--- a/sdks/ios/Tests/XMTPTests/ClientTests.swift
+++ b/sdks/ios/Tests/XMTPTests/ClientTests.swift
@@ -1427,4 +1427,32 @@ class ClientTests: XCTestCase {
 		))
 		XCTAssertNotEqual(key22.stringValue, key23.stringValue, "Cache keys should differ when only gatewayHost differs")
 	}
+
+	func testClientOptionsDefaultsDbPoolOptionsToNil() {
+		let key = Data(repeating: 0, count: 32)
+		let options = ClientOptions(dbEncryptionKey: key)
+		XCTAssertNil(options.dbPoolOptions)
+	}
+
+	func testClientOptionsCarriesDbPoolOptions() {
+		let key = Data(repeating: 0, count: 32)
+		let pool = DbPoolOptions(maxPoolSize: 10, minPoolSize: 2)
+		let options = ClientOptions(
+			dbEncryptionKey: key,
+			dbPoolOptions: pool
+		)
+		XCTAssertEqual(options.dbPoolOptions?.maxPoolSize, 10)
+		XCTAssertEqual(options.dbPoolOptions?.minPoolSize, 2)
+	}
+
+	func testClientOptionsDbPoolOptionsPartialFields() {
+		let key = Data(repeating: 0, count: 32)
+		let pool = DbPoolOptions(maxPoolSize: 7)
+		let options = ClientOptions(
+			dbEncryptionKey: key,
+			dbPoolOptions: pool
+		)
+		XCTAssertEqual(options.dbPoolOptions?.maxPoolSize, 7)
+		XCTAssertNil(options.dbPoolOptions?.minPoolSize)
+	}
 }


### PR DESCRIPTION
feat(ios): add DbPoolOptions wrapper to ClientOptions

feat(android)!: replace top-level pool fields with DbPoolOptions

BREAKING CHANGE: ClientOptions.maxDbPoolSize and minDbPoolSize are removed.
Use ClientOptions(dbPoolOptions = DbPoolOptions(maxPoolSize = ..., minPoolSize = ...)) instead.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `DbPoolOptions` wrapper to `ClientOptions` in iOS and Android SDKs
> - Introduces a new `DbPoolOptions` type (struct in Swift, data class in Kotlin) with optional `maxPoolSize` and `minPoolSize` fields.
> - Replaces the flat `maxDbPoolSize`/`minDbPoolSize` fields on `ClientOptions` with a single optional `dbPoolOptions` property in both SDKs.
> - During client initialization, pool sizes are forwarded to the underlying `DbOptions` when `dbPoolOptions` is set.
> - Risk: Breaking API change for Android callers — `maxDbPoolSize` and `minDbPoolSize` are removed from `ClientOptions` and must now be set via `dbPoolOptions`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 08454bb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->