### PR TITLE
ci(nix): wait for daemon readiness after cache restore

### DIFF
--- a/.github/actions/setup-nix-cache/action.yml
+++ b/.github/actions/setup-nix-cache/action.yml
@@ -89,10 +89,37 @@ runs:
           sudo chown -R root:wheel /nix/var/nix/db
           sudo launchctl bootstrap system /Library/LaunchDaemons/org.nixos.nix-daemon.plist 2>/dev/null || true
           sudo launchctl kickstart -k system/org.nixos.nix-daemon || true
+          DAEMON_WAIT_MAX=60
         else
           sudo chown -R root:root /nix/var/nix/db
           sudo systemctl start nix-daemon.socket nix-daemon.service
+          DAEMON_WAIT_MAX=30
         fi
+        # Wait for the daemon to accept client connections before returning.
+        # launchctl kickstart / systemctl start return before the daemon is
+        # listening, so a subsequent step (e.g. cachix-action running
+        # `nix-env`) can race the daemon, fall back to single-user mode, and
+        # fail on `/nix/var/nix/db/big-lock: Permission denied` (the DB is
+        # now root-owned again). Probe as the runner user via the real
+        # daemon protocol — that matches the permission context the next
+        # step will use.
+        echo "Waiting up to ${DAEMON_WAIT_MAX}s for Nix daemon to become ready..."
+        for i in $(seq 1 "$DAEMON_WAIT_MAX"); do
+          if nix store ping --store daemon >/dev/null 2>&1; then
+            echo "Nix daemon ready after ${i}s"
+            break
+          fi
+          if [ "$i" -eq "$DAEMON_WAIT_MAX" ]; then
+            echo "::error::Nix daemon failed to become ready within ${DAEMON_WAIT_MAX}s after restart"
+            if [ "$(uname)" = "Darwin" ]; then
+              sudo launchctl print system/org.nixos.nix-daemon 2>&1 || true
+            else
+              sudo systemctl status --no-pager nix-daemon.service 2>&1 || true
+            fi
+            exit 1
+          fi
+          sleep 1
+        done
       shell: bash
 
     - name: Fix Nix directory ownership for cache save

--- a/.github/actions/setup-nix-cache/action.yml
+++ b/.github/actions/setup-nix-cache/action.yml
@@ -95,14 +95,9 @@ runs:
           sudo systemctl start nix-daemon.socket nix-daemon.service
           DAEMON_WAIT_MAX=30
         fi
-        # Wait for the daemon to accept client connections before returning.
-        # launchctl kickstart / systemctl start return before the daemon is
-        # listening, so a subsequent step (e.g. cachix-action running
-        # `nix-env`) can race the daemon, fall back to single-user mode, and
-        # fail on `/nix/var/nix/db/big-lock: Permission denied` (the DB is
-        # now root-owned again). Probe as the runner user via the real
-        # daemon protocol — that matches the permission context the next
-        # step will use.
+        # Wait for the daemon to accept connections before returning; otherwise
+        # the next step can race it, fall back to single-user mode, and fail on
+        # `/nix/var/nix/db/big-lock: Permission denied`.
         echo "Waiting up to ${DAEMON_WAIT_MAX}s for Nix daemon to become ready..."
         for i in $(seq 1 "$DAEMON_WAIT_MAX"); do
           if nix store ping --store daemon >/dev/null 2>&1; then


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3504

## Summary

The `Cache all Nix Outputs` workflow flakes on `warp-macos-26-arm64-12x` with:

```
error: opening lock file "/nix/var/nix/db/big-lock": Permission denied
```

…inside `cachix/cachix-action@v17`, which runs `nix-env -iA cachix` immediately after `setup-nix-cache` restores ~23.5 GB of `/nix/store` from the WarpBuild cache.

**Root cause:** On macOS, the cache-restore step ends with `sudo launchctl kickstart -k system/org.nixos.nix-daemon`, which returns before the daemon is accepting client connections. The step has also just chowned `/nix/var/nix/db` back to `root:wheel`, so any client that falls back to single-user mode (because it can't reach the daemon yet) can no longer open `/nix/var/nix/db/big-lock` — hence `Permission denied`.

**Fix:** At the end of the `Merge Nix databases and restart daemon` step, poll `nix store ping --store daemon` once a second (up to 60 s on macOS, 30 s on Linux) before returning. Probing via the real daemon protocol **as the runner user** matches the exact permission context the next step will use. On timeout, emit a `::error::` annotation, dump `launchctl print` / `systemctl status`, and `exit 1` so the workflow fails loudly rather than producing a cryptic `big-lock` error in a later step.

The Linux branch (`systemctl start`) hasn't been observed to fail, but the same race is structurally possible — the guard is cheap and uniform.

## Changes

- `.github/actions/setup-nix-cache/action.yml` — after the existing daemon-restart commands (both Darwin and Linux branches), wait for `nix store ping --store daemon` to succeed.

## Test plan

- [ ] Trigger `Cache all Nix Outputs` via workflow-dispatch on this PR branch.
- [ ] Confirm the new log line `Nix daemon ready after Ns` appears between the `Merge Nix databases and restart daemon` step and the cachix-action step.
- [ ] Confirm `cachix/cachix-action@v17` completes `nix-env --quiet -j8 -iA cachix` without the `big-lock: Permission denied` error.
- [ ] Confirm the Linux matrix leg (`warp-ubuntu-latest-x64-16x`) continues to pass.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wait for Nix daemon readiness after cache restore in CI setup action
> After restarting the Nix daemon in the cache restore step, the action now polls `nix store ping --store daemon` until the daemon is ready before proceeding. The timeout is 60s on macOS and 30s on Linux; if the daemon is not ready in time, the step logs the daemon status via `launchctl` or `systemctl` and exits with a non-zero status. Behavioral Change: the setup action now fails explicitly instead of silently continuing if the daemon is not ready after a restart.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 79130e7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->