### PR TITLE
test(ios): stabilize testCountMessages against client/server clock skew

### DIFF
--- a/sdks/ios/Tests/XMTPTests/ConversationTests.swift
+++ b/sdks/ios/Tests/XMTPTests/ConversationTests.swift
@@ -679,9 +679,8 @@ class ConversationTests: XCTestCase {
 		// otherwise flake this assertion. See issue #3502.
 		let groupMessages = try await group.messages()
 		let dmMessages = try await dm.messages()
-		let maxObservedSentAtNs =
-			(groupMessages.map(\.sentAtNs) + dmMessages.map(\.sentAtNs))
-			.max() ?? 0
+		let allSentAtNs = groupMessages.map(\.sentAtNs) + dmMessages.map(\.sentAtNs)
+		let maxObservedSentAtNs = allSentAtNs.max() ?? 0
 		let futureCutoffNs = maxObservedSentAtNs + 1_000_000_000 // +1s buffer
 		let futureGroupCount = try group.countMessages(afterNs: futureCutoffNs)
 		let futureDmCount = try dm.countMessages(afterNs: futureCutoffNs)

--- a/sdks/ios/Tests/XMTPTests/ConversationTests.swift
+++ b/sdks/ios/Tests/XMTPTests/ConversationTests.swift
@@ -671,12 +671,22 @@ class ConversationTests: XCTestCase {
 		XCTAssertTrue(publishedGroupCount == 3 || publishedGroupCount == 4)
 		XCTAssertEqual(publishedDmCount, 2)
 
-		// Test counting with time-based filters
-		let now = Int64(Date().millisecondsSinceEpoch + 2000) // Allow for 2s of clock skew between client and server
-		let futureGroupCount = try group.countMessages(afterNs: now * 1_000_000)
-		let futureDmCount = try dm.countMessages(afterNs: now * 1_000_000)
+		// Test counting with time-based filters.
+		//
+		// Anchor the cutoff to the latest server-stamped `sentAtNs` we've
+		// actually observed (rather than the client's local wall clock),
+		// because any skew between the CI runner and the XMTP node would
+		// otherwise flake this assertion. See issue #3502.
+		let groupMessages = try await group.messages()
+		let dmMessages = try await dm.messages()
+		let maxObservedSentAtNs =
+			(groupMessages.map(\.sentAtNs) + dmMessages.map(\.sentAtNs))
+			.max() ?? 0
+		let futureCutoffNs = maxObservedSentAtNs + 1_000_000_000 // +1s buffer
+		let futureGroupCount = try group.countMessages(afterNs: futureCutoffNs)
+		let futureDmCount = try dm.countMessages(afterNs: futureCutoffNs)
 
-		// No messages should be after current time
+		// No messages should exist strictly after the latest observed send.
 		XCTAssertEqual(futureGroupCount, 0)
 		XCTAssertEqual(futureDmCount, 0)
 


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3502

## Summary

`ConversationTests.testCountMessages` flaked on CI run 24459579283 at the assertion `XCTAssertEqual(futureDmCount, 0)` (got 1). The test computed the `afterNs` cutoff from the iOS runner's local wall clock plus a hardcoded 2 s buffer, but `sent_at_ns` is set by the server — any skew between the GHA macOS runner and the XMTP node exceeding 2 s pushes a freshly-sent message's server timestamp past the cutoff and flakes the assertion.

This PR anchors the cutoff to the **latest server-stamped `sentAtNs` observed** across the DM and group messages we just sent, plus a 1 s defensive buffer. Because the cutoff is computed from data the server itself authored, it no longer depends on the two machines' clocks agreeing within any tolerance.

Only the test is changed; no production code is touched. The unrelated `Platform(PoolNeedsConnection)` log noise in the same CI run leaks from a different test context and is out of scope.

## Test plan

- [ ] CI `test-ios` job passes on this PR
- [ ] Locally: `just ios test` passes the `testCountMessages` case (requires a running backend via `just backend up`)

## Design

Design notes and EARS requirements are posted as a comment on issue #3502.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stabilize `testCountMessages` against client/server clock skew in iOS tests
> The test previously computed a message cutoff using the local wall clock plus a skew allowance, which was fragile when client and server clocks diverged. It now fetches all messages from the group and DM first, derives the cutoff from the maximum observed `sentAtNs` value plus a 1-second buffer, and then asserts zero messages exist after that cutoff.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b4c337d. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->