### PR TITLE
test(ios): stabilize Phase 4 of disappearing-messages tests

### DIFF
--- a/sdks/ios/Tests/XMTPTests/DmTests.swift
+++ b/sdks/ios/Tests/XMTPTests/DmTests.swift
@@ -422,12 +422,16 @@ class DmTests: XCTestCase {
 		XCTAssertEqual(boGroupMessagesPersist, 5) // memberAdd settings 1, settings 2, boMessage, alixMessage
 		XCTAssertEqual(alixGroupMessagesPersist, 5) // memberAdd settings 1, settings 2, boMessage, alixMessage
 
-		// Re-enable disappearing messages
+		// Re-enable disappearing messages.
+		// Retention is 5s (long enough that the count==9 assertion below
+		// wins the race with the 1s-interval disappearing_messages worker
+		// even on slow CI runners — see issue #3505, same root cause as
+		// the Phase 1 fix in #3448/#3451).
 		let boDmMessages = try await boDm.messages()
 		let updatedSettings = try DisappearingMessageSettings(
 			disappearStartingAtNs: XCTUnwrap(boDmMessages.first?.sentAtNs)
-				+ 1_000_000_000, // 1s from now
-			retentionDurationInNs: 1_000_000_000 // 2s duration
+				+ 1_000_000_000, // disappearStartingAtNs offset; does not gate deletion
+			retentionDurationInNs: 5_000_000_000 // 5s duration
 		)
 		try await boDm.updateDisappearingMessageSettings(updatedSettings)
 		try await boDm.sync()
@@ -458,7 +462,8 @@ class DmTests: XCTestCase {
 		XCTAssertEqual(boGroupMessagesAfterNewSend, 9)
 		XCTAssertEqual(alixGroupMessagesAfterNewSend, 9)
 
-		try await Task.sleep(nanoseconds: 6_000_000_000) // Sleep for 6 seconds to let messages disappear
+		// Sleep longer than retention (5s) + worker interval (1s) + buffer — see issue #3505.
+		try await Task.sleep(nanoseconds: 8_000_000_000) // Sleep for 8 seconds to let messages disappear
 
 		let boGroupMessagesFinal = try await boDm.messages().count
 		let alixGroupMessagesFinal = try await alixDm?.messages().count

--- a/sdks/ios/Tests/XMTPTests/GroupTests.swift
+++ b/sdks/ios/Tests/XMTPTests/GroupTests.swift
@@ -1346,12 +1346,16 @@ class GroupTests: XCTestCase {
 		XCTAssertEqual(boGroupMessagesPersist, 5) // memberAdd, settings 1, settings 2, boMessage, alixMessage
 		XCTAssertEqual(alixGroupMessagesPersist, 5) // memberAdd, settings 1, settings 2, boMessage, alixMessage
 
-		// Re-enable disappearing messages
+		// Re-enable disappearing messages.
+		// Retention is 5s (long enough that the count==9 assertion below
+		// wins the race with the 1s-interval disappearing_messages worker
+		// even on slow CI runners — see issue #3505, same root cause as
+		// the Phase 1 fix in #3448/#3451).
 		let boGroupMessages = try await boGroup.messages()
 		let updatedSettings = try DisappearingMessageSettings(
 			disappearStartingAtNs: XCTUnwrap(boGroupMessages.first?.sentAtNs)
-				+ 1_000_000_000, // 1s from now
-			retentionDurationInNs: 1_000_000_000 // 2s duration
+				+ 1_000_000_000, // disappearStartingAtNs offset; does not gate deletion
+			retentionDurationInNs: 5_000_000_000 // 5s duration
 		)
 		try await boGroup.updateDisappearingMessageSettings(updatedSettings)
 		try await boGroup.sync()
@@ -1382,7 +1386,8 @@ class GroupTests: XCTestCase {
 		XCTAssertEqual(boGroupMessagesAfterNewSend, 9)
 		XCTAssertEqual(alixGroupMessagesAfterNewSend, 9)
 
-		try await Task.sleep(nanoseconds: 6_000_000_000) // Sleep for 6 seconds to let messages disappear
+		// Sleep longer than retention (5s) + worker interval (1s) + buffer — see issue #3505.
+		try await Task.sleep(nanoseconds: 8_000_000_000) // Sleep for 8 seconds to let messages disappear
 
 		let boGroupMessagesFinal = try await boGroup.messages().count
 		let alixGroupMessagesFinal = try await alixGroup?.messages().count


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3505

## Summary

- Fixes the `testGroupDisappearingMessages` flake (`8 != 9` at `GroupTests.swift:1382`) by widening the Phase 4 retention window from 1 s to 5 s and the post-assertion sleep from 6 s to 8 s, so the count assertion reliably wins the race with the 1 s-interval `disappearing_messages` worker on loaded CI runners.
- Applies the symmetric change to `testDmDisappearingMessages` (DmTests.swift) — identical Phase 4 shape, identical latent race; preempts the inevitable matching flake report.
- No production code changes. The worker, `expire_at_ns` assignment (`crates/xmtp_mls/src/groups/mls_sync.rs:1812`), and deletion query (`crates/xmtp_db/src/encrypted_store/group_message.rs:1256`) are all behaving correctly — only the test-side timing budget was wrong.

## Why this race exists

`get_message_expire_at_ns` sets each Application message's `expire_at_ns = now_ns() + retention`. The worker (`crates/xmtp_mls/src/worker/disappearing_messages.rs:12`, interval 1 s) deletes any Application message whose `expire_at_ns ≤ now_ns()`. With `retention = 1 s`, the freshly-sent `"this will disappear soon"` and `"so will this"` could expire mid-pipeline (between `send` and `messages().count`) on a slow runner, dropping the count to 8.

Same root cause and same fix shape as #3448 / #3451, which addressed the Phase 1 race in both tests but explicitly left Phase 4 untouched. This PR completes that pattern for Phase 4.

All correctness assertions are preserved: counts of 9 (before deletion) and 7 (after the lengthened sleep), settings retention values, and `isDisappearingMessagesEnabled` checks.

Design notes and EARS requirements were posted as an [issue comment](https://github.com/xmtp/libxmtp/issues/3505#issuecomment-4255087807) for traceability.

## Test plan

- [ ] `test-ios` CI job passes (authoritative — iOS Swift tests cannot be exercised from the Linux dev environment in this repo)
- [ ] `lint-ios` CI job passes (SwiftLint + SwiftFormat)
- [ ] Re-run `test-ios` multiple times to confirm the `8 != 9` failure mode no longer reproduces

## Notes for reviewers

- Test runtime grows by ~6 s per affected test (4 s longer Phase 4 retention + 2 s longer post-sleep). Both tests are already multi-tens-of-seconds; negligible.
- Android equivalents (`sdks/android/.../{DmTest,GroupTest}.kt`) are not currently flaking and are intentionally left alone, mirroring the precedent set by #3451. Apply the same fix there as a follow-up if they begin flaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stabilize disappearing messages Phase 4 tests in iOS by increasing retention and sleep durations
> Increases `retentionDurationInNs` from 1s to 5s and the post-send sleep from 6s to 8s in both [DmTests.swift](https://github.com/xmtp/libxmtp/pull/3510/files#diff-ec070a63f7290c8eb0a69af972b344ad6ca193d35adbe1a56f119ef3a5d4c63e) and [GroupTests.swift](https://github.com/xmtp/libxmtp/pull/3510/files#diff-4ac29f8309a18599a70579204927c4763092bfe27b407f036bf4af1f33279c5b). The longer retention window and sleep buffer account for the disappearing messages worker interval, reducing flakiness in post-deletion count assertions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c8051f2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->