### PR TITLE
fix(nix): skip otool -L header line in darwin node binary /nix/store check

### DIFF
--- a/nix/package/node.nix
+++ b/nix/package/node.nix
@@ -89,17 +89,7 @@ rust.napiBuild (
       # Replace /nix/store paths (the dylib's own id and its libiconv dep)
       # with macOS system paths so the .node loads on hosts without Nix.
       install_name_tool -id "@loader_path/$(basename $NODE_LIB)" "$NODE_LIB"
-
-      # Discover the actually-embedded libiconv store path from otool -L
-      # rather than trusting ${darwin.libiconv} to match the store hash the
-      # linker recorded — nixpkgs drift / cross-compile splicing can make the
-      # two diverge, at which point a hardcoded -change is a silent no-op.
-      # NR > 1 skips otool -L's header line (which is the file's own path).
-      otool -L "$NODE_LIB" \
-        | awk 'NR > 1 && $1 ~ /^\/nix\/store\/.*\/libiconv\.[0-9]+\.dylib$/ { print $1 }' \
-        | while read -r old; do
-            install_name_tool -change "$old" "/usr/lib/$(basename "$old")" "$NODE_LIB"
-          done
+      install_name_tool -change "${darwin.libiconv}/lib/libiconv.2.dylib" "/usr/lib/libiconv.2.dylib" "$NODE_LIB"
 
       # install_name_tool invalidates the ad-hoc signature applied by
       # darwin.autoSignDarwinBinariesHook; re-sign so the .node loads under

--- a/nix/package/node.nix
+++ b/nix/package/node.nix
@@ -89,12 +89,28 @@ rust.napiBuild (
       # Replace /nix/store paths (the dylib's own id and its libiconv dep)
       # with macOS system paths so the .node loads on hosts without Nix.
       install_name_tool -id "@loader_path/$(basename $NODE_LIB)" "$NODE_LIB"
-      install_name_tool -change "${darwin.libiconv}/lib/libiconv.2.dylib" "/usr/lib/libiconv.2.dylib" "$NODE_LIB"
+
+      # Discover the actually-embedded libiconv store path from otool -L
+      # rather than trusting ${darwin.libiconv} to match the store hash the
+      # linker recorded — nixpkgs drift / cross-compile splicing can make the
+      # two diverge, at which point a hardcoded -change is a silent no-op.
+      # NR > 1 skips otool -L's header line (which is the file's own path).
+      otool -L "$NODE_LIB" \
+        | awk 'NR > 1 && $1 ~ /^\/nix\/store\/.*\/libiconv\.[0-9]+\.dylib$/ { print $1 }' \
+        | while read -r old; do
+            install_name_tool -change "$old" "/usr/lib/$(basename "$old")" "$NODE_LIB"
+          done
+
+      # install_name_tool invalidates the ad-hoc signature applied by
+      # darwin.autoSignDarwinBinariesHook; re-sign so the .node loads under
+      # Gatekeeper on end-user macOS hosts.
+      codesign --force --sign - "$NODE_LIB"
 
       # Assert no /nix/store references remain — guards against silent
       # no-ops in the rewrites above and catches the 1.10.0 regression.
       # See https://github.com/xmtp/libxmtp/issues/3479.
-      remaining=$(otool -L "$NODE_LIB" | awk '$1 ~ /^\/nix\/store\// { print $1 }')
+      # NR > 1 skips otool -L's header line (the file's own /nix/store path).
+      remaining=$(otool -L "$NODE_LIB" | awk 'NR > 1 && $1 ~ /^\/nix\/store\// { print $1 }')
       if [ -n "$remaining" ]; then
         echo "error: $NODE_LIB still references /nix/store after postFixup:" >&2
         echo "$remaining" >&2


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3503

## Summary

The `postFixup` assertion in `nix/package/node.nix` introduced by #3500 fails deterministically on every macOS arm64 run. Root cause: the awk filter `$1 ~ /^\/nix\/store\//` matches the **first line of `otool -L`'s output**, which is the file's own path (with trailing colon) — and `$NODE_LIB` itself lives under `/nix/store`. CI was reporting `$NODE_LIB:` as the "leaked" reference, not a library.

The `install_name_tool -change ... libiconv.2.dylib` rewrite on the preceding line is actually working. Only the assertion is broken.

## Fix

Two small changes in `nix/package/node.nix` Darwin `postFixup`:

1. **Fix the false positive** — add `NR > 1` to the assertion awk filter so it skips `otool -L`'s header line (the file's own path).
2. **Re-sign after modification** — `install_name_tool` invalidates the ad-hoc signature applied by `darwin.autoSignDarwinBinariesHook`; add `codesign --force --sign -` so the `.node` loads under Gatekeeper on end-user macOS hosts. (The #3500 commit message promised this but did not ship it.)

## Why the original PR missed this

#3500's test plan listed "awk/bash pipeline validated against simulated `otool -L` output" — but the simulation almost certainly omitted the header line. There was no macOS CI gate on that PR, and the failure only shows up on the actual Darwin build.

## Test plan

- [x] `nix fmt` — formatting clean
- [x] `just lint-nix` passes
- [x] `just lint-config` (treefmt + nixfmt + taplo) passes
- [x] `nix eval .#packages.aarch64-linux.node-bindings-linux-arm64-musl.drvPath` — flake evaluates on Linux
- [x] `nix eval` for the `aarch64-darwin.node-bindings-darwin-arm64` derivation — flake evaluates for Darwin
- [x] Offline awk validation against three simulated `otool -L` shapes:
  - Post-rewrite (libiconv rewritten to `/usr/lib`): assertion emits nothing ✓
  - Real leak (synthetic `/nix/store/.../libfoo.dylib`): assertion flags it ✓
  - Old buggy awk on clean post-rewrite output: confirms header line was the false positive ✓
- [ ] **Pending macOS CI:** the `build (warp-macos-26-arm64-12x)` job in "Cache all Nix Outputs" is the end-to-end signal — the build-time assertion runs against real `otool -L` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix false-positive /nix/store check by skipping `otool -L` header line in Darwin node binary
> - Fixes the awk filter in the `postFixup` script in [node.nix](https://github.com/xmtp/libxmtp/pull/3511/files#diff-fa9b6ba547ea5ae35048580f634e5edb6375afb0138fd6fb6e77fef6ee8c357b) to skip the first line of `otool -L` output (`NR > 1 &&`), preventing false positives when the binary's own path contains `/nix/store`.
> - Adds an ad-hoc `codesign --force --sign -` step after `install_name_tool` adjustments so the `.node` binary remains loadable on macOS after its library paths are rewritten.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6db38a8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->