### PR TITLE
fix(nix): add darwin.sigtool so codesign is on PATH during node fixupPhase

### DIFF
--- a/nix/package/node.nix
+++ b/nix/package/node.nix
@@ -80,8 +80,16 @@ rust.napiBuild (
     '';
   }
   // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    # stdenv-darwin's fixupPhase invokes `codesign` *before* postFixup runs.
+    # darwin.autoSignDarwinBinariesHook's transitive sigtool propagation is
+    # unreliable on native aarch64-darwin, causing `codesign: command not
+    # found` (exit 127) at setup.sh line 277. Adding darwin.sigtool directly
+    # to nativeBuildInputs puts the sigtool-provided `codesign` symlink on
+    # PATH for both stdenv's fixup hooks and the postFixup re-sign below.
+    # See https://github.com/xmtp/libxmtp/issues/3513.
     nativeBuildInputs = commonArgs.nativeBuildInputs ++ [
       darwin.autoSignDarwinBinariesHook
+      darwin.sigtool
     ];
     postFixup = ''
       NODE_LIB=$(echo $out/dist/bindings_node.*.node)

--- a/nix/package/node.nix
+++ b/nix/package/node.nix
@@ -80,12 +80,7 @@ rust.napiBuild (
     '';
   }
   // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
-    # stdenv-darwin's fixupPhase invokes `codesign` *before* postFixup runs.
-    # darwin.autoSignDarwinBinariesHook's transitive sigtool propagation is
-    # unreliable on native aarch64-darwin, causing `codesign: command not
-    # found` (exit 127) at setup.sh line 277. Adding darwin.sigtool directly
-    # to nativeBuildInputs puts the sigtool-provided `codesign` symlink on
-    # PATH for both stdenv's fixup hooks and the postFixup re-sign below.
+    # sigtool provides `codesign` on PATH for the postFixup re-sign.
     # See https://github.com/xmtp/libxmtp/issues/3513.
     nativeBuildInputs = commonArgs.nativeBuildInputs ++ [
       darwin.autoSignDarwinBinariesHook


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3513

## Summary

Every `warp-macos-26-arm64-12x` run of `Cache all Nix Outputs` since #3500 has failed during `fixupPhase` for `bindings-node-js-napi-1.10.0` with:

```
/nix/store/…-stdenv-darwin/setup: line 277: codesign: command not found
error: builder failed with exit code 127.
```

The failure comes from **stdenv-darwin's own fixup**, which runs *before* the package's `postFixup`. `darwin.autoSignDarwinBinariesHook` (line 84 of `nix/package/node.nix`) is supposed to put `codesign` on `PATH` via its propagation chain (hook → `signingUtils` → `sigtool`), but that propagation is not reliable on native aarch64-darwin.

## Fix

Add `darwin.sigtool` directly to `nativeBuildInputs` in the Darwin branch of `nix/package/node.nix`. `sigtool`'s `$out/bin` contains a `codesign` symlink, so the stdenv's fixup hooks and the `codesign --force --sign -` re-sign added in #3511 both resolve it unambiguously.

Verified `derivation show` of `packages.aarch64-darwin.node-bindings-darwin-arm64`:

```
nativeBuildInputs: … auto-sign-darwin-binaries-hook  sigtool-0.1.3 …
```

## Why sigtool is the right choice

- It's already transitively present in the closure (via the auto-sign hook's `signingUtils`), so this adds no new nixpkgs dependency — it just pins what was supposed to propagate.
- `sigtool` is nixpkgs' sandbox-compatible drop-in for `codesign --force --sign -` (ad-hoc signing), which is exactly what the `postFixup` does.
- It avoids the alternative of `__noChroot = true` + `/usr/bin` on `PATH` (ios.nix does this, but it gives up reproducibility; overkill for a package that ships to npm).

## Test plan

- [x] `nix fmt --check` — clean
- [x] `just lint-config` — passes (treefmt + taplo + nixfmt)
- [x] `nix flake check` — evaluates, all checks pass
- [x] `nix derivation show` for `packages.aarch64-darwin.node-bindings-darwin-arm64` — confirms `sigtool-0.1.3` is in `nativeBuildInputs`
- [ ] **Pending macOS CI:** `build (warp-macos-26-arm64-12x)` in `Cache all Nix Outputs` is the end-to-end signal — no more `codesign: command not found`, and the produced `.node` still has a valid ad-hoc signature and no `/nix/store` references (the postFixup assertion shipped in #3511 still holds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `darwin.sigtool` to nativeBuildInputs so `codesign` is on PATH during node fixupPhase
> On Darwin builds, `codesign` was missing from PATH during the fixup phase. Adding `darwin.sigtool` to `nativeBuildInputs` in [node.nix](https://github.com/xmtp/libxmtp/pull/3514/files#diff-fa9b6ba547ea5ae35048580f634e5edb6375afb0138fd6fb6e77fef6ee8c357b) alongside the existing `darwin.autoSignDarwinBinariesHook` makes `codesign` available.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 993185b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->