### PR TITLE
fix(mls): don't burn publish-attempt budget on retriable send failures

### DIFF
--- a/crates/xmtp_configuration/src/common/mls.rs
+++ b/crates/xmtp_configuration/src/common/mls.rs
@@ -15,6 +15,18 @@ pub const MAX_GROUP_SYNC_RETRIES: usize = 3;
 
 pub const MAX_INTENT_PUBLISH_ATTEMPTS: usize = 3;
 
+/// Fail-safe cap on publish attempts for *retriable* errors.
+///
+/// Retriable publish failures (e.g. a client that is temporarily offline)
+/// use a separate budget from content-level failures so that a normal
+/// outage cannot poison a perfectly good intent. The generous cap here
+/// exists as defense-in-depth against errors that the API layer marks
+/// retriable but which would never actually recover — for example, a
+/// malformed payload that the server persistently rejects with a
+/// retriable gRPC status. In that case the intent will still eventually
+/// be poisoned rather than retried forever.
+pub const MAX_INTENT_RETRIABLE_PUBLISH_ATTEMPTS: usize = 30;
+
 pub const GROUP_KEY_ROTATION_INTERVAL_NS: i64 = NS_IN_30_DAYS;
 
 pub const KEY_PACKAGE_QUEUE_INTERVAL_NS: i64 = 5 * NS_IN_SEC; // 5 secs

--- a/crates/xmtp_configuration/src/common/mls.rs
+++ b/crates/xmtp_configuration/src/common/mls.rs
@@ -19,13 +19,14 @@ pub const MAX_INTENT_PUBLISH_ATTEMPTS: usize = 3;
 ///
 /// Retriable publish failures (e.g. a client that is temporarily offline)
 /// use a separate budget from content-level failures so that a normal
-/// outage cannot poison a perfectly good intent. The generous cap here
-/// exists as defense-in-depth against errors that the API layer marks
-/// retriable but which would never actually recover — for example, a
-/// malformed payload that the server persistently rejects with a
-/// retriable gRPC status. In that case the intent will still eventually
-/// be poisoned rather than retried forever.
-pub const MAX_INTENT_RETRIABLE_PUBLISH_ATTEMPTS: usize = 30;
+/// outage cannot poison a perfectly good intent. The cap here exists as
+/// defense-in-depth against errors that the API layer marks retriable but
+/// which would never actually recover — for example, a malformed payload
+/// that the server persistently rejects with a retriable gRPC status. In
+/// that case the intent will eventually be poisoned rather than retried
+/// forever, but the larger budget tolerates a real offline window before
+/// the app surfaces a hard failure to the user.
+pub const MAX_INTENT_RETRIABLE_PUBLISH_ATTEMPTS: usize = 12;
 
 pub const GROUP_KEY_ROTATION_INTERVAL_NS: i64 = NS_IN_30_DAYS;
 

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -81,9 +81,9 @@ use xmtp_common::{
 };
 use xmtp_configuration::{
     GRPC_PAYLOAD_LIMIT, HMAC_SALT, MAX_GROUP_SIZE, MAX_GROUP_SYNC_RETRIES,
-    MAX_INTENT_PUBLISH_ATTEMPTS, MAX_PAST_EPOCHS, PROPOSAL_SUPPORT_EXTENSION_ID,
-    SYNC_BACKOFF_TOTAL_WAIT_MAX_SECS, SYNC_BACKOFF_WAIT_MS, SYNC_JITTER_MS,
-    SYNC_UPDATE_INSTALLATIONS_INTERVAL_NS,
+    MAX_INTENT_PUBLISH_ATTEMPTS, MAX_INTENT_RETRIABLE_PUBLISH_ATTEMPTS, MAX_PAST_EPOCHS,
+    PROPOSAL_SUPPORT_EXTENSION_ID, SYNC_BACKOFF_TOTAL_WAIT_MAX_SECS, SYNC_BACKOFF_WAIT_MS,
+    SYNC_JITTER_MS, SYNC_UPDATE_INSTALLATIONS_INTERVAL_NS,
 };
 use xmtp_content_types::{CodecError, ContentCodec, group_updated::GroupUpdatedCodec};
 use xmtp_db::message_deletion::{QueryMessageDeletion, StoredMessageDeletion};
@@ -3902,35 +3902,47 @@ fn handle_published_intent_send_failure<Db: QueryGroupIntent>(
     intent: &StoredGroupIntent,
     is_retryable: bool,
 ) -> Result<(), GroupError> {
-    if is_retryable {
-        // Retriable failures (e.g. transient transport errors while the client
-        // is offline) must not consume the MAX_INTENT_PUBLISH_ATTEMPTS budget
-        // that exists to guard against content-level failures. Reset the
-        // intent back to ToPublish without bumping publish_attempts so the
-        // next sync — after connectivity returns — can re-encrypt and
-        // retry at the current epoch.
-        tracing::warn!(
-            intent.id,
-            intent.kind = %intent.kind,
-            "retriable publish failure for intent {}, resetting to ToPublish without incrementing publish_attempts",
-            intent.id
-        );
-        db.set_group_intent_to_publish(intent.id)?;
-        return Ok(());
-    }
+    // Always bump publish_attempts so a truly permanent failure — even one
+    // the API layer currently classifies as retriable — cannot loop forever.
+    db.increment_intent_publish_attempt_count(intent.id)?;
+    let next_attempts = (intent.publish_attempts + 1) as usize;
 
-    if (intent.publish_attempts + 1) as usize >= MAX_INTENT_PUBLISH_ATTEMPTS {
+    // Non-retriable failures keep the tight MAX_INTENT_PUBLISH_ATTEMPTS cap
+    // (guards against content-level failures). Retriable failures get a much
+    // higher cap so a normal offline window can recover; the cap exists as
+    // defense-in-depth against errors that the API layer marks retriable
+    // but which would never actually succeed (e.g. a malformed payload the
+    // server persistently rejects with a retriable gRPC status).
+    let cap = if is_retryable {
+        MAX_INTENT_RETRIABLE_PUBLISH_ATTEMPTS
+    } else {
+        MAX_INTENT_PUBLISH_ATTEMPTS
+    };
+
+    if next_attempts >= cap {
         tracing::error!(
             intent.id,
             intent.kind = %intent.kind,
+            is_retryable,
+            attempts = next_attempts,
+            cap,
             "intent {} has reached max publish attempts",
             intent.id
         );
         let id = utils::id::calculate_message_id_for_intent(intent)?;
         db.set_group_intent_error_and_fail_msg(intent, id)?;
     } else {
+        if is_retryable {
+            tracing::warn!(
+                intent.id,
+                intent.kind = %intent.kind,
+                attempts = next_attempts,
+                cap,
+                "retriable publish failure for intent {}, resetting to ToPublish",
+                intent.id
+            );
+        }
         // Reset so the next retry re-encrypts at the current epoch.
-        db.increment_intent_publish_attempt_count(intent.id)?;
         db.set_group_intent_to_publish(intent.id)?;
     }
 
@@ -4054,7 +4066,9 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn retriable_send_failures_revert_to_to_publish_without_incrementing_attempts() {
+    fn retriable_send_failures_revert_to_to_publish_under_the_retriable_cap() {
+        // Well below MAX_INTENT_RETRIABLE_PUBLISH_ATTEMPTS: resets to
+        // ToPublish and does not mark the intent as errored.
         let intent = StoredGroupIntent {
             id: 99,
             kind: IntentKind::SendMessage,
@@ -4072,15 +4086,72 @@ pub(crate) mod tests {
         };
 
         let mut db = MockDbQuery::new();
-        // Retriable failures must not bump the publish-attempt counter or
-        // mark the intent as errored — they only reset state to ToPublish.
-        db.expect_increment_intent_publish_attempt_count().times(0);
+        db.expect_increment_intent_publish_attempt_count()
+            .with(eq(intent.id))
+            .times(1)
+            .returning(|_| Ok(()));
         db.expect_set_group_intent_error_and_fail_msg().times(0);
         db.expect_set_group_intent_to_publish()
             .with(eq(intent.id))
             .times(1)
             .returning(|_| Ok(()));
 
+        let result = handle_published_intent_send_failure(&db, &intent, true);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn retriable_send_failures_over_their_cap_still_poison_the_intent() {
+        // Above MAX_INTENT_PUBLISH_ATTEMPTS (non-retriable cap) but just
+        // below MAX_INTENT_RETRIABLE_PUBLISH_ATTEMPTS: should NOT error yet
+        // when the failure is retriable — defense-in-depth is scoped to the
+        // retriable cap, not the tight non-retriable one.
+        let mut intent = StoredGroupIntent {
+            id: 101,
+            kind: IntentKind::SendMessage,
+            group_id: xmtp_common::rand_vec::<16>(),
+            data: Vec::new(),
+            state: IntentState::Published,
+            payload_hash: Some(xmtp_common::rand_vec::<32>()),
+            post_commit_data: None,
+            publish_attempts: (MAX_INTENT_PUBLISH_ATTEMPTS as i32) + 2,
+            staged_commit: None,
+            published_in_epoch: Some(7),
+            should_push: false,
+            sequence_id: None,
+            originator_id: None,
+        };
+        {
+            let mut db = MockDbQuery::new();
+            db.expect_increment_intent_publish_attempt_count()
+                .with(eq(intent.id))
+                .times(1)
+                .returning(|_| Ok(()));
+            db.expect_set_group_intent_error_and_fail_msg().times(0);
+            db.expect_set_group_intent_to_publish()
+                .with(eq(intent.id))
+                .times(1)
+                .returning(|_| Ok(()));
+            let result = handle_published_intent_send_failure(&db, &intent, true);
+            assert!(result.is_ok());
+        }
+
+        // At the retriable cap — 1: should poison the intent on this next
+        // increment (which lands it at the cap), protecting against a
+        // retriable-classified permanent rejection looping forever.
+        // Use IntentKind::KeyUpdate so `calculate_message_id_for_intent`
+        // short-circuits to Ok(None) instead of parsing intent.data.
+        intent.kind = IntentKind::KeyUpdate;
+        intent.publish_attempts = (MAX_INTENT_RETRIABLE_PUBLISH_ATTEMPTS as i32) - 1;
+        let mut db = MockDbQuery::new();
+        db.expect_increment_intent_publish_attempt_count()
+            .with(eq(intent.id))
+            .times(1)
+            .returning(|_| Ok(()));
+        db.expect_set_group_intent_to_publish().times(0);
+        db.expect_set_group_intent_error_and_fail_msg()
+            .times(1)
+            .returning(|_, _| Ok(()));
         let result = handle_published_intent_send_failure(&db, &intent, true);
         assert!(result.is_ok());
     }

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -2470,11 +2470,22 @@ where
 
                 match result {
                     Err(err) => {
-                        tracing::error!(error = %err, "error getting publish intent data {:?}", err);
-                        if (intent.publish_attempts + 1) as usize >= MAX_INTENT_PUBLISH_ATTEMPTS {
+                        // `get_publish_intent_data` performs MLS encryption *and*
+                        // (for `UpdateGroupMembership`) network calls to fetch
+                        // identity updates and key packages — so its errors can
+                        // legitimately be retriable. Mirror the send-failure
+                        // path's two-cap policy here so a transient network
+                        // outage during data preparation can't poison an intent
+                        // in just three retries.
+                        let is_retryable = err.is_retryable();
+                        tracing::error!(error = %err, is_retryable, "error getting publish intent data {:?}", err);
+                        let cap = cap_for_publish_attempts(is_retryable);
+                        if (intent.publish_attempts + 1) as usize >= cap {
                             tracing::error!(
                                 intent.id,
                                 intent.kind = %intent.kind,
+                                is_retryable,
+                                cap,
                                 inbox_id = self.context.inbox_id(),
                                 installation_id = %self.context.installation_id(),group_id = hex::encode(&self.group_id),
                                 "intent {} has reached max publish attempts", intent.id);
@@ -3897,6 +3908,21 @@ pub(crate) fn decode_staged_commit(
     Ok(xmtp_db::db_deserialize(data)?)
 }
 
+/// Returns the maximum number of publish attempts allowed before an intent is
+/// poisoned. Non-retriable failures keep the tight `MAX_INTENT_PUBLISH_ATTEMPTS`
+/// cap (guards against content-level failures). Retriable failures get a much
+/// higher cap so a normal offline window can recover; the cap exists as
+/// defense-in-depth against errors that the API layer marks retriable but
+/// which would never actually succeed (e.g. a malformed payload the server
+/// persistently rejects with a retriable gRPC status).
+fn cap_for_publish_attempts(is_retryable: bool) -> usize {
+    if is_retryable {
+        MAX_INTENT_RETRIABLE_PUBLISH_ATTEMPTS
+    } else {
+        MAX_INTENT_PUBLISH_ATTEMPTS
+    }
+}
+
 fn handle_published_intent_send_failure<Db: QueryGroupIntent>(
     db: &Db,
     intent: &StoredGroupIntent,
@@ -3906,18 +3932,7 @@ fn handle_published_intent_send_failure<Db: QueryGroupIntent>(
     // the API layer currently classifies as retriable — cannot loop forever.
     db.increment_intent_publish_attempt_count(intent.id)?;
     let next_attempts = (intent.publish_attempts + 1) as usize;
-
-    // Non-retriable failures keep the tight MAX_INTENT_PUBLISH_ATTEMPTS cap
-    // (guards against content-level failures). Retriable failures get a much
-    // higher cap so a normal offline window can recover; the cap exists as
-    // defense-in-depth against errors that the API layer marks retriable
-    // but which would never actually succeed (e.g. a malformed payload the
-    // server persistently rejects with a retriable gRPC status).
-    let cap = if is_retryable {
-        MAX_INTENT_RETRIABLE_PUBLISH_ATTEMPTS
-    } else {
-        MAX_INTENT_PUBLISH_ATTEMPTS
-    };
+    let cap = cap_for_publish_attempts(is_retryable);
 
     if next_attempts >= cap {
         tracing::error!(

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -2546,16 +2546,18 @@ where
                                 );
                             }
                             (kind, Err(err)) => {
+                                let is_retryable = err.is_retryable();
                                 log_event!(
                                     Event::GroupSyncPublishFailed,
                                     self.context.installation_id(),
                                     group_id = intent.group_id,
                                     intent_id = intent.id,
                                     intent_kind = ?kind,
+                                    is_retryable,
                                     err = ?err
                                 );
 
-                                handle_published_intent_send_failure(&db, &intent)?;
+                                handle_published_intent_send_failure(&db, &intent, is_retryable)?;
                                 return Err(err)?;
                             }
                             (kind, Ok(_)) => {
@@ -3898,7 +3900,25 @@ pub(crate) fn decode_staged_commit(
 fn handle_published_intent_send_failure<Db: QueryGroupIntent>(
     db: &Db,
     intent: &StoredGroupIntent,
+    is_retryable: bool,
 ) -> Result<(), GroupError> {
+    if is_retryable {
+        // Retriable failures (e.g. transient transport errors while the client
+        // is offline) must not consume the MAX_INTENT_PUBLISH_ATTEMPTS budget
+        // that exists to guard against content-level failures. Reset the
+        // intent back to ToPublish without bumping publish_attempts so the
+        // next sync — after connectivity returns — can re-encrypt and
+        // retry at the current epoch.
+        tracing::warn!(
+            intent.id,
+            intent.kind = %intent.kind,
+            "retriable publish failure for intent {}, resetting to ToPublish without incrementing publish_attempts",
+            intent.id
+        );
+        db.set_group_intent_to_publish(intent.id)?;
+        return Ok(());
+    }
+
     if (intent.publish_attempts + 1) as usize >= MAX_INTENT_PUBLISH_ATTEMPTS {
         tracing::error!(
             intent.id,
@@ -4029,7 +4049,39 @@ pub(crate) mod tests {
             .times(1)
             .returning(|_| Ok(()));
 
-        let result = handle_published_intent_send_failure(&db, &intent);
+        let result = handle_published_intent_send_failure(&db, &intent, false);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn retriable_send_failures_revert_to_to_publish_without_incrementing_attempts() {
+        let intent = StoredGroupIntent {
+            id: 99,
+            kind: IntentKind::SendMessage,
+            group_id: xmtp_common::rand_vec::<16>(),
+            data: Vec::new(),
+            state: IntentState::Published,
+            payload_hash: Some(xmtp_common::rand_vec::<32>()),
+            post_commit_data: None,
+            publish_attempts: 0,
+            staged_commit: None,
+            published_in_epoch: Some(7),
+            should_push: false,
+            sequence_id: None,
+            originator_id: None,
+        };
+
+        let mut db = MockDbQuery::new();
+        // Retriable failures must not bump the publish-attempt counter or
+        // mark the intent as errored — they only reset state to ToPublish.
+        db.expect_increment_intent_publish_attempt_count().times(0);
+        db.expect_set_group_intent_error_and_fail_msg().times(0);
+        db.expect_set_group_intent_to_publish()
+            .with(eq(intent.id))
+            .times(1)
+            .returning(|_| Ok(()));
+
+        let result = handle_published_intent_send_failure(&db, &intent, true);
         assert!(result.is_ok());
     }
 

--- a/crates/xmtp_mls/src/groups/tests/test_commit_log_local.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_commit_log_local.rs
@@ -193,8 +193,6 @@ async fn test_welcome_commit_log() {
     );
 }
 
-// TODO(rich): Fix intent publishing on bad network conditions
-#[ignore]
 #[xmtp_common::test(unwrap_try = true)]
 async fn test_commit_log_retriable_error() {
     toxiproxy_test(async || {
@@ -225,8 +223,8 @@ async fn test_commit_log_retriable_error() {
         assert_eq!(b.local_commit_log().await?.len(), 1);
 
         bo.for_each_proxy(async |p| p.enable().await.unwrap()).await;
-        // This currently fails with error SyncFailedToWait, because the intent has been marked as 'published'
-        // despite not being published. We need to fix the intent publishing flow for this test to work.
+        // Now that the network is back, the pending intents should be
+        // publishable again — retriable failures must not have poisoned them.
         b.sync_until_last_intent_resolved().await?;
         a.sync().await?;
         // KeyUpdate should have been added to the commit log (SendMessage is not logged because it is not a commit)

--- a/crates/xmtp_mls/src/groups/tests/test_commit_log_local.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_commit_log_local.rs
@@ -193,6 +193,11 @@ async fn test_welcome_commit_log() {
     );
 }
 
+// Toxiproxy's `node-go` proxy speaks raw gRPC (localhost:6010 → node:5556).
+// WASM tests use the browser's `fetch`, which can only talk gRPC-Web — the
+// other toxiproxy test (`test_network`) sidesteps this by gating its entire
+// module on `cfg(not(target_arch = "wasm32"))`. We do the same per-test.
+#[cfg(not(target_arch = "wasm32"))]
 #[xmtp_common::test(unwrap_try = true)]
 async fn test_commit_log_retriable_error() {
     toxiproxy_test(async || {


### PR DESCRIPTION
Resolves #3474

## Summary

When `publish_intents` saw a transport-level error from `send_group_messages` (e.g. while the client was offline), the bookkeeping treated it the same as a content-level failure: it bumped `publish_attempts` and, after `MAX_INTENT_PUBLISH_ATTEMPTS` (3), transitioned the intent to `Error`. A sustained outage spanning a few sync cycles would shoot every queued intent dead even though nothing about the intents themselves was wrong — the network was just down.

This change threads `err.is_retryable()` into `handle_published_intent_send_failure`. On a retriable failure the intent is reset to `ToPublish` **without** incrementing `publish_attempts`, so the next sync — after connectivity returns — can re-encrypt and republish at the current epoch. Non-retriable failures keep today's bounded-retry behavior unchanged.

## Why this design

- **Minimal blast radius.** No new enum variants, no new DB migrations, no change to `set_group_intent_to_publish`. We just stop counting retriable errors against a budget that was meant for content-level failures.
- **Correct retry semantics.** Retriable errors are, by definition, ones the caller can safely retry; burning a 3-attempt budget on them effectively turned a recoverable outage into a permanent intent failure, contradicting the existing `RetryableError` trait contract.
- **Loop bounds still hold.** `publish_intents` still returns `Err(err)` after handling a retriable failure, so `sync_with_conn` still records the publish error in its `SyncSummary` and `sync_until_intent_resolved_inner` still gives up after `MAX_GROUP_SYNC_RETRIES`. The difference is that the *intent* is now left in a publishable state, so a later sync (or `sync_until_last_intent_resolved` once the network returns) picks it up and pushes it through.

## Changes

- `crates/xmtp_mls/src/groups/mls_sync.rs`
  - `handle_published_intent_send_failure` now takes a `bool is_retryable`. The retriable branch only calls `set_group_intent_to_publish` and emits a `tracing::warn!`.
  - Call site in `publish_intents` computes `let is_retryable = err.is_retryable();` once and threads it through (also surfaces `is_retryable` in the existing `GroupSyncPublishFailed` log event).
  - Updates the existing `send_failures_for_published_intents_revert_to_to_publish` unit test to the new signature, and adds `retriable_send_failures_revert_to_to_publish_without_incrementing_attempts` covering the new branch.
- `crates/xmtp_mls/src/groups/tests/test_commit_log_local.rs`
  - Removes `#[ignore]` and the `TODO(rich)` comment on `test_commit_log_retriable_error`.

## Test plan

- [x] `just test v3 test_commit_log_retriable_error` — passes (was previously `#[ignore]`)
- [x] `just test v3 test_commit_log_non_retriable_error` — passes (no regression on the bounded-retry path)
- [x] All 30 `test_commit_log_*` and `send_failures_*` / `retriable_send_failures_*` tests in `xmtp_mls` pass via `cargo nextest`
- [x] `just lint-rust` clean (clippy `--all-features --all-targets -Dwarnings`, fmt, hakari)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix MLS intent publish to use a higher attempt budget for retriable send failures
> - Adds `MAX_INTENT_RETRIABLE_PUBLISH_ATTEMPTS` (12) alongside the existing lower cap, and a `cap_for_publish_attempts(is_retryable: bool)` helper in [`mls_sync.rs`](https://github.com/xmtp/libxmtp/pull/3515/files#diff-160aadcd7de477c1116260a79601a0548842f3bd91bf16bd8443debb66ce6684) to select between them.
> - Retriable failures during intent data preparation and send now reset the intent to `ToPublish` and consume the larger cap before poisoning; non-retriable failures keep the original smaller cap.
> - Behavioral Change: previously, all publish failures counted against the same budget and could poison an intent after just a few transient network errors; now transient failures get up to 12 attempts before the intent is marked as errored.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 08274f0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->