### PR TITLE
test(ios,android): relax concurrency in testStreamsAndMessages

### DIFF
--- a/sdks/android/library/src/androidTest/java/org/xmtp/android/library/ConversationsTest.kt
+++ b/sdks/android/library/src/androidTest/java/org/xmtp/android/library/ConversationsTest.kt
@@ -512,6 +512,10 @@ class ConversationsTest : BaseInstrumentedTest() {
                         alixGroup.send(message)
                         alixGroup2.send(message)
                         println("Alix sent: $message")
+                        // 50ms yield between sends so a single sender's MLS
+                        // ratchet doesn't outrun OpenMLS's 5-generation
+                        // out-of-order tolerance under concurrent load (#3512).
+                        delay(50)
                     }
                 }
 
@@ -523,6 +527,7 @@ class ConversationsTest : BaseInstrumentedTest() {
                         boGroup.send(message)
                         boGroup2.send(message)
                         println("Bo sent: $message")
+                        delay(50) // #3512
                     }
                 }
 
@@ -534,6 +539,7 @@ class ConversationsTest : BaseInstrumentedTest() {
                         val group = davonClient.conversations.newGroup(listOf(caroClient.inboxId))
                         group.send(spamMessage)
                         println("Davon spam: $spamMessage")
+                        delay(50) // #3512
                     }
                 }
 
@@ -545,6 +551,7 @@ class ConversationsTest : BaseInstrumentedTest() {
                         caroGroup.send(message)
                         caroGroup2.send(message)
                         println("Caro sent: $message")
+                        delay(50) // #3512
                     }
                 }
 

--- a/sdks/ios/Tests/XMTPTests/ConversationTests.swift
+++ b/sdks/ios/Tests/XMTPTests/ConversationTests.swift
@@ -346,6 +346,10 @@ class ConversationTests: XCTestCase {
 					_ = try await alixGroup.send(content: message)
 					_ = try await alixGroup2.send(content: message)
 					print("Alix sent: \(message)")
+					// 50ms yield between sends so a single sender's MLS
+					// ratchet doesn't outrun OpenMLS's 5-generation
+					// out-of-order tolerance under concurrent load (#3512).
+					try await Task.sleep(nanoseconds: 50_000_000)
 				}
 			}
 
@@ -356,6 +360,7 @@ class ConversationTests: XCTestCase {
 					_ = try await boGroup.send(content: message)
 					_ = try await boGroup2.send(content: message)
 					print("Bo sent: \(message)")
+					try await Task.sleep(nanoseconds: 50_000_000) // #3512
 				}
 			}
 
@@ -369,6 +374,7 @@ class ConversationTests: XCTestCase {
 						)
 					_ = try await group.send(content: spamMessage)
 					print("Davon spam: \(spamMessage)")
+					try await Task.sleep(nanoseconds: 50_000_000) // #3512
 				}
 			}
 
@@ -379,6 +385,7 @@ class ConversationTests: XCTestCase {
 					_ = try await caroGroup.send(content: message)
 					_ = try await caroGroup2.send(content: message)
 					print("Caro sent: \(message)")
+					try await Task.sleep(nanoseconds: 50_000_000) // #3512
 				}
 			}
 		}


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3512

## Summary

`ConversationTests.testStreamsAndMessages` (iOS) and the Kotlin twin have
been flaking in CI with OpenMLS-level decryption errors:

- `SecretReuseError` — forward-secrecy deletion
- `TooDistantInThePast` — out-of-order tolerance exceeded (observed gap
  of 10–18 generations vs. the 5-generation window)

### Root cause

Each of the four concurrent sender tasks (Alix/Bo/Caro/Davon) looped
back-to-back with **no yield** between sends. A single sender's MLS
sender-ratchet could advance 10+ generations in the time a peer
processed one envelope, and OpenMLS only retains 5 generations of
out-of-order tolerance. Hence the decryption failures.

Per the maintainer's comment on the issue
(https://github.com/xmtp/libxmtp/issues/3512#issuecomment-4255559320),
*"the concurrency in this test is pretty unrealistic for normal
workloads and we might want to relax it a bit."* Real clients do not
fire 20 back-to-back sends with zero yield; the test was artificially
stressing the ratchet window in a way the protocol is not expected to
survive.

### Fix

Insert a 50 ms yield at the end of each sender loop iteration in both
test files:

- iOS (`ConversationTests.swift`): `try await Task.sleep(nanoseconds: 50_000_000)`
- Android (`ConversationsTest.kt`): `delay(50)` (already imported)

Counts, asserted totals (`90` streamed messages, `41` messages per
shared group), stream timeouts, and overall structure are unchanged —
the test still exercises four concurrent senders with overlapping
groups and a streaming listener.

### Why 50 ms

- Observed ratchet gap in failure logs: 10–18; tolerance window: 5.
- 50 ms × 20 iterations adds ~1 s to the slowest task, well inside the
  existing 30 s (iOS) / 60 s (Android) stream-wait budgets.
- Test-only knob; easy to raise if CI hardware still flakes.

No production code is touched. Diff is 14 additive lines across two
test files.

## Test plan

- [ ] CI runs `testStreamsAndMessages` on iOS and Android lanes cleanly
- [ ] No new lint/format violations (SwiftFormat lint passes locally;
      Android Spotless/ktlint relies on CI here since this is a Linux
      container without xcodebuild/gradle)
- [ ] Re-run the iOS lane a few times to confirm the flake is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 50ms delay between sends in `testStreamsAndMessages` to reduce OpenMLS out-of-order failures
> Inserts a 50ms sleep between successive message sends in four concurrent sender loops (Alix, Bo, Davon, Caro) in the iOS and Android versions of the streams-and-messages test. This prevents any single sender's MLS ratchet from advancing faster than OpenMLS's out-of-order tolerance under concurrent load. Behavioral Change: test runtime increases slightly due to the added delays.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7322772.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->