### PR TITLE
fix(nix): robustly rewrite Darwin node libiconv refs via otool -L

### DIFF
--- a/nix/package/node.nix
+++ b/nix/package/node.nix
@@ -89,10 +89,23 @@ rust.napiBuild (
     postFixup = ''
       NODE_LIB=$(echo $out/dist/bindings_node.*.node)
 
-      # Replace /nix/store paths (the dylib's own id and its libiconv dep)
-      # with macOS system paths so the .node loads on hosts without Nix.
+      # Rewrite the dylib's own install name (LC_ID_DYLIB) so consumers
+      # resolve it relative to the .node file, not the Nix build path.
       install_name_tool -id "@loader_path/$(basename $NODE_LIB)" "$NODE_LIB"
-      install_name_tool -change "${darwin.libiconv}/lib/libiconv.2.dylib" "/usr/lib/libiconv.2.dylib" "$NODE_LIB"
+
+      # Rewrite every /nix/store/.../libiconv.<ver>.dylib load reference
+      # to the macOS system copy. Using otool -L output as the source of
+      # truth is drift-proof — we rewrite whatever the linker actually
+      # recorded, not whatever Nix evaluation resolves darwin.libiconv to.
+      # Cross-compile splicing in mkCrossPkgs was causing the two to
+      # diverge, silently defeating a hardcoded `install_name_tool -change`.
+      # See https://github.com/xmtp/libxmtp/issues/3516.
+      # NR > 1 skips otool -L's header line (the file's own id).
+      otool -L "$NODE_LIB" \
+        | awk 'NR > 1 && $1 ~ /^\/nix\/store\/.*\/libiconv(\.[0-9]+)*\.dylib$/ { print $1 }' \
+        | while read -r old; do
+          install_name_tool -change "$old" "/usr/lib/$(basename "$old")" "$NODE_LIB"
+        done
 
       # install_name_tool invalidates the ad-hoc signature applied by
       # darwin.autoSignDarwinBinariesHook; re-sign so the .node loads under


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3516

## Summary

`bindings-node-js-napi-aarch64-apple-darwin-1.10.0` was failing the
Nix build in `postFixup` because the produced `.node` binary still
recorded `/nix/store/.../libiconv.2.dylib` as a load dependency after
the `install_name_tool` rewrite step. The build-time `/nix/store`
assertion shipped in #3500/#3511 correctly refused to ship the binary.

## Root cause

`nix/package/node.nix` used a hardcoded
`install_name_tool -change "${darwin.libiconv}/lib/libiconv.2.dylib" …`
which silently no-ops when the Nix evaluation-time value of
`darwin.libiconv` does not byte-for-byte equal the libiconv path the
linker actually embedded in the binary. Cross-compile splicing in
`mkCrossPkgs` makes those two diverge on the cross-compiled
`node-bindings-darwin-{arm64,x64}` targets — exactly the failure
mode PR #3500's root-cause analysis described.

## Fix

Replace the hardcoded `-change` with a loop over `otool -L` output
that rewrites every `/nix/store/.../libiconv(.N)*.dylib` reference to
`/usr/lib/<basename>`. The linker-recorded path is the source of
truth, so Nix-eval drift and cross-compile splicing can no longer
silently defeat the rewrite. The downstream `codesign --force --sign -`
re-sign and the `/nix/store` leak assertion are unchanged.

The `awk` selector was validated locally against six simulated
`otool -L` fixtures (single match, header-skip requires `NR > 1`,
negative control without `NR > 1`, `/usr/lib` / `@rpath` /
non-libiconv store paths ignored, multi-digit version, basename
transform) before landing.

## Test plan

- [x] Inline awk-pipeline validation against `otool -L` fixtures — passes.
- [x] `nix fmt -- --fail-on-change` — clean.
- [x] `just lint-config` (taplo, nixfmt, treefmt) — clean.
- [x] `nix eval .#packages.aarch64-darwin.node-bindings-darwin-arm64.drvPath` — resolves.
- [x] `nix eval .#packages.aarch64-darwin.node-bindings-darwin-x64.drvPath` — resolves.
- [x] `nix eval .#node-bindings-linux-arm64-musl.drvPath` — resolves (non-regression).
- [x] `nix flake check --no-build` — exit 0.
- [ ] **CI authoritative:** `build (warp-macos-26-arm64-12x)` on `Cache all Nix Outputs` goes green for both `bindings-node-js-napi-aarch64-apple-darwin` and `bindings-node-js-napi-x86_64-apple-darwin`.

## Out of scope

- `darwin.sigtool` / `autoSignDarwinBinariesHook` (kept as-is from #3514).
- Linux / musl / Windows branches.
- Pinning nixpkgs or freezing libiconv — the whole point of the fix
  is to be drift-proof.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Darwin `.node` libiconv rewrite to handle all Nix store versions via `otool -L`
> Previously, [node.nix](https://github.com/xmtp/libxmtp/pull/3518/files#diff-fa9b6ba547ea5ae35048580f634e5edb6375afb0138fd6fb6e77fef6ee8c357b) hardcoded a single `install_name_tool -change` targeting `${darwin.libiconv}/lib/libiconv.2.dylib`, which broke when a different libiconv version was present. The fix parses `otool -L` output at build time to find all `/nix/store/.../libiconv*.dylib` references and rewrites each to the matching `/usr/lib/<basename>` path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized edf7824.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->