### PR TITLE
ci: move remaining paid macOS runners to WarpBuild

### DIFF
--- a/.github/workflows/lint-ios.yml
+++ b/.github/workflows/lint-ios.yml
@@ -6,7 +6,7 @@ env:
 jobs:
   lint:
     name: Lint (iOS)
-    runs-on: macos-15
+    runs-on: warp-macos-15-arm64-6x
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -210,7 +210,7 @@ jobs:
 
   build-macos-universal:
     needs: [setup, build-macos]
-    runs-on: macos-latest
+    runs-on: warp-macos-latest-arm64-6x
     steps:
       - uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/release-xnet-gui.yml
+++ b/.github/workflows/release-xnet-gui.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   build-dmg:
     name: Build macOS DMG
-    runs-on: macos-latest
+    runs-on: warp-macos-latest-arm64-6x
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3519

## Summary

Three jobs still targeted paid GitHub-hosted macOS runners and accounted for the remaining GitHub Actions spend. Each is migrated to a WarpBuild label that is already in production use elsewhere in this repo for an analogous workload, so we inherit validated configuration.

| File | Line | Before | After |
|---|---|---|---|
| `.github/workflows/lint-ios.yml` | 9 | `macos-15` | `warp-macos-15-arm64-6x` |
| `.github/workflows/release-xnet-gui.yml` | 22 | `macos-latest` | `warp-macos-latest-arm64-6x` |
| `.github/workflows/release-node.yml` | 213 | `macos-latest` | `warp-macos-latest-arm64-6x` |

No job steps, secrets, permissions, or triggers change — only the three `runs-on:` labels.

## Validation

- Re-grepped `.github/workflows/` for `macos-*` / larger Ubuntu / larger Windows GitHub-hosted labels — zero matches remain.
- YAML-parsed each modified workflow.
- `ubuntu-latest` jobs (free on public repos) were intentionally left unchanged.

## Test plan

- [ ] CI on this PR runs `lint-ios` against the Warp runner and passes.
- [ ] The two release workflows (`release-xnet-gui`, `release-node`) are release-triggered; their new labels match labels already proven by neighboring jobs in the same file, minimizing risk at release time.

## Rollback

Single 3-line commit — revert is trivial.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move remaining CI macOS jobs to WarpBuild runners
> Migrates three GitHub Actions jobs from GitHub-hosted macOS runners to WarpBuild runners (`warp-macos-15-arm64-6x`, `warp-macos-latest-arm64-6x`). Affected workflows are [lint-ios.yml](https://github.com/xmtp/libxmtp/pull/3520/files#diff-6e482a08dbc369461508f07b640b7b6b91a4e867d05b3bdd0f2cab4088eefd2a), [release-node.yml](https://github.com/xmtp/libxmtp/pull/3520/files#diff-369d0df8e29bc0db28d8bec1f9ec550c1b868da3efeaabdfe1fcf4afe5962768), and [release-xnet-gui.yml](https://github.com/xmtp/libxmtp/pull/3520/files#diff-524ec8e1ada505186ffeffc6bc355260aa6873543fb7b579294e5684ee0aa505).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2ac6997.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->