### PR TITLE
ci(fh-cache): keep-going and fail-fast=false for full cache coverage

### DIFF
--- a/.github/workflows/fh-cache.yml
+++ b/.github/workflows/fh-cache.yml
@@ -12,6 +12,7 @@ concurrency:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [warp-ubuntu-latest-x64-16x, warp-macos-26-arm64-12x]
     runs-on: ${{ matrix.os }}
@@ -27,7 +28,7 @@ jobs:
       - name: Install omnix
         run: nix profile install nixpkgs#omnix
       - name: Build all flake outputs
-        run: om ci run --include-all-dependencies --results=om.json
+        run: om ci run --include-all-dependencies --results=om.json -- --keep-going
       - name: Pin outputs to cachix
         # if: github.ref_name == 'main'
         run: |


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3525

## Summary

Harden the `Cache all Nix Outputs` workflow (`.github/workflows/fh-cache.yml`) so that a
single failing flake output or a single failing OS no longer prevents the cache from
being refreshed for the rest.

- **`-- --keep-going`** is forwarded from `om ci run` to the underlying `nix build`
  (supported via `om ci run`'s `--` passthrough — see
  [omnix docs](https://omnix.page/om/ci.html)). Remaining outputs continue building after
  a single-package failure, and the existing cachix-pin step then uploads every output
  that *did* build (it reads `om.json → .result.omnix.build.byName`, which lists only
  successful results).
- **`strategy.fail-fast: false`** on the `build` matrix prevents a failure on one OS from
  cancelling the still-running sibling OS, so both `warp-ubuntu-latest-x64-16x` and
  `warp-macos-26-arm64-12x` always run to completion independently.

If any output fails, the step still exits non-zero and the job is still marked failed, so
regressions remain visible.

## Test plan

- [ ] Next push to `main` (or manual `workflow_dispatch`) shows both matrix legs running
      to completion and each leg attempts every flake output even on failure.
- [ ] `actionlint` (local + the repo's `lint-config` job) reports no new warnings for the
      edited file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep CI cache builds running on failure with `--keep-going` and `fail-fast: false`
> Updates [fh-cache.yml](https://github.com/xmtp/libxmtp/pull/3526/files#diff-ce3dd25bde306abc234d96f51a92cb524edcabd8e9e5eeed5eb121f73b32b9e2) so all matrix jobs and build targets are attempted even when some fail. Sets `strategy.fail-fast: false` on the build matrix and appends `-- --keep-going` to the `om ci run` command, ensuring full cache coverage across all flake outputs regardless of individual failures.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0500f46.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->