### PR TITLE
ci(dependabot): add Nix ecosystem with single grouped PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,3 +56,15 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
+  # Maintain dependencies for the Nix flake (flake.lock inputs)
+  - package-ecosystem: "nix"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      nix-deps:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3527

## Summary

GitHub [added Dependabot version-update support for the Nix ecosystem](https://github.blog/changelog/2026-04-07-dependabot-version-updates-now-support-the-nix-ecosystem/) on 2026-04-07. This PR wires `flake.lock` inputs into Dependabot with the same conventions already used for the other ecosystems in this repo.

- New `package-ecosystem: "nix"` entry in `.github/dependabot.yml`, targeting `/` (root, next to `flake.nix` / `flake.lock`).
- Single group `nix-deps` with pattern `*` — every flake-input update batches into one weekly PR, per the "minimize noise" requirement in the issue.
- Weekly schedule + `version-update:semver-patch` ignore list, mirroring the existing cargo / github-actions / npm entries for consistency.

## Test plan

This is a GitHub-side config file; there is no local test harness for it. Verification:

- [x] `nix fmt -- --fail-on-change` passes (no formatting drift).
- [x] YAML parses cleanly (file read-back + indentation check).
- [ ] After merge: confirm Dependabot picks up the new entry (check the repo's Dependabot insights tab on the next weekly run) and that updates land as a single grouped PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Nix ecosystem to Dependabot with weekly grouped updates
> Adds a Nix ecosystem entry to [dependabot.yml](https://github.com/xmtp/libxmtp/pull/3528/files#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28) that runs weekly checks against the repository root. All Nix dependencies are grouped into a single `nix-deps` PR, and semver patch updates are ignored.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c5c72b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->