### PR TITLE
Remove testnet-dev and testnet-staging environments

### DIFF
--- a/apps/cli/cli-client.rs
+++ b/apps/cli/cli-client.rs
@@ -33,7 +33,7 @@ use valuable::Valuable;
 use xmtp_api_d14n::MessageBackendBuilder;
 use xmtp_api_d14n::protocol::XmtpQuery;
 use xmtp_common::time::now_ns;
-use xmtp_configuration::{GrpcUrlsDev, GrpcUrlsLocal, GrpcUrlsProduction, GrpcUrlsStaging};
+use xmtp_configuration::{GrpcUrlsDev, GrpcUrlsLocal, GrpcUrlsProduction};
 use xmtp_content_types::{ContentCodec, text::TextCodec};
 use xmtp_cryptography::signature::IdentifierValidationError;
 use xmtp_cryptography::signature::SignatureError;
@@ -69,7 +69,6 @@ enum Env {
     #[default]
     Local,
     Dev,
-    Staging,
     Production,
 }
 
@@ -240,18 +239,15 @@ async fn main() -> color_eyre::eyre::Result<()> {
             .v3_host(GrpcUrlsProduction::NODE)
             .gateway_host(GrpcUrlsProduction::GATEWAY)
             .build()?,
-        (true, Env::Staging) => MessageBackendBuilder::default()
-            .v3_host(GrpcUrlsStaging::NODE)
-            .gateway_host(GrpcUrlsStaging::GATEWAY)
-            .build()?,
-        (true, Env::Dev) => MessageBackendBuilder::default()
-            .v3_host(GrpcUrlsDev::NODE)
-            .gateway_host(GrpcUrlsDev::GATEWAY)
-            .build()?,
+        (true, Env::Dev) => {
+            return Err(color_eyre::eyre::eyre!(
+                "No testnet gateway for --env dev; use --testnet --env production (testnet) or --testnet --env local"
+            ));
+        }
         (false, Env::Local) => MessageBackendBuilder::default()
             .v3_host(GrpcUrlsLocal::NODE)
             .build()?,
-        (false, Env::Dev) | (false, Env::Staging) => MessageBackendBuilder::default()
+        (false, Env::Dev) => MessageBackendBuilder::default()
             .v3_host(GrpcUrlsDev::NODE)
             .build()?,
         (false, Env::Production) => MessageBackendBuilder::default()

--- a/apps/xmtp_debug/README.md
+++ b/apps/xmtp_debug/README.md
@@ -152,7 +152,7 @@ is designed for ECS/Fargate deployment as a continuous health probe.
 
 ```bash
 docker run -d \
-  -e WORKSPACE=testnet-dev \
+  -e WORKSPACE=testnet \
   -e XDBG_LOOP_PAUSE=300 \
   -e PUSHGATEWAY_URL=http://pushgateway:9091 \
   ghcr.io/xmtp/xdbg
@@ -160,7 +160,7 @@ docker run -d \
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `WORKSPACE` | _(empty → local)_ | Target environment: `testnet`, `testnet-dev`, `testnet-staging` |
+| `WORKSPACE` | _(empty → local)_ | Target environment: `testnet` |
 | `XDBG_LOOP_PAUSE` | `300` | Seconds to sleep between monitoring loop iterations |
 | `PUSHGATEWAY_URL` | _(unset)_ | Prometheus PushGateway URL. If unset, metrics are silently disabled |
 | `XDBG_DB_ROOT` | _(unset)_ | Override the default data directory for xdbg state |

--- a/apps/xmtp_debug/docker/entrypoint.sh
+++ b/apps/xmtp_debug/docker/entrypoint.sh
@@ -17,8 +17,6 @@ function log {
 WORKSPACE="${WORKSPACE:-}"
 case "${WORKSPACE}" in
     testnet) BACKEND="production" ;;
-    testnet-dev) BACKEND="dev" ;;
-    testnet-staging) BACKEND="staging" ;;
     ""|*) BACKEND="local" ;;
 esac
 log "WORKSPACE='${WORKSPACE:-<unset>}' -> backend='${BACKEND}'"

--- a/apps/xmtp_debug/src/args.rs
+++ b/apps/xmtp_debug/src/args.rs
@@ -351,25 +351,22 @@ impl BackendOpts {
         if self.perf {
             debug_assert!(self.d14n, "--perf requires --d14n");
             return match self.backend {
-                Dev => Ok((*crate::constants::XMTP_DEV_PERF_GATEWAY).clone()),
-                Staging => Ok((*crate::constants::XMTP_STAGING_PERF_GATEWAY).clone()),
+                Dev => eyre::bail!(
+                    "No D14n gateway for --backend dev; use --backend production (testnet) or --backend local"
+                ),
                 Production => Ok((*crate::constants::XMTP_PRODUCTION_PERF_GATEWAY).clone()),
                 Local => Ok((*crate::constants::XMTP_LOCAL_PERF_GATEWAY).clone()),
             };
         }
 
         match (self.backend, self.d14n, self.enable_migration) {
-            (Dev, false, false) => eyre::bail!("No gateway for V3"),
-            (Staging, false, false) => eyre::bail!("No gateway for V3"),
-            (Production, false, false) => eyre::bail!("No gateway for V3"),
-            (Local, false, false) => eyre::bail!("No gateway for V3"),
-            (Dev, true, false) => Ok((*crate::constants::XMTP_DEV_GATEWAY).clone()),
-            (Staging, true, false) => Ok((*crate::constants::XMTP_STAGING_GATEWAY).clone()),
+            (_, false, false) => eyre::bail!("No gateway for V3"),
+            (Dev, true, _) | (Dev, _, true) => eyre::bail!(
+                "No D14n gateway for --backend dev; use --backend production (testnet) or --backend local"
+            ),
             (Production, true, false) => Ok((*crate::constants::XMTP_PRODUCTION_GATEWAY).clone()),
             (Local, true, false) => Ok((*crate::constants::XMTP_LOCAL_GATEWAY).clone()),
             (Local, _, true) => Ok((*crate::constants::XMTP_LOCAL_GATEWAY).clone()),
-            (Dev, _, true) => Ok((*crate::constants::XMTP_DEV_GATEWAY).clone()),
-            (Staging, _, true) => Ok((*crate::constants::XMTP_STAGING_GATEWAY).clone()),
             (Production, _, true) => Ok((*crate::constants::XMTP_PRODUCTION_GATEWAY).clone()),
         }
     }
@@ -454,17 +451,22 @@ impl<'a> From<&'a BackendOpts> for u64 {
         } else {
             match (value.backend, value.d14n, value.enable_migration) {
                 (Production, false, false) => 2,
-                (Staging, false, false) => 1,
                 (Dev, false, false) => 1,
                 (Local, false, false) => 0,
                 (Production, true, false) => 5,
-                (Staging, true, false) => 6,
-                (Dev, true, false) => 4,
+                (Dev, true, false) => {
+                    panic!(
+                        "No D14n isolation id for --backend dev; use --backend production (testnet) or --backend local"
+                    )
+                }
                 (Local, true, false) => 3,
                 // Migration cases, where the client is both d14n and v3
                 (Local, _, true) => 7,
-                (Dev, _, true) => 8,
-                (Staging, _, true) => 9,
+                (Dev, _, true) => {
+                    panic!(
+                        "No D14n isolation id for --backend dev; use --backend production (testnet) or --backend local"
+                    )
+                }
                 (Production, _, true) => 10,
             }
         }
@@ -489,7 +491,6 @@ impl From<BackendOpts> for url::Url {
 #[derive(ValueEnum, Debug, Copy, Clone, Default)]
 pub enum BackendKind {
     Dev,
-    Staging,
     Production,
     #[default]
     Local,
@@ -500,11 +501,11 @@ impl BackendKind {
         use BackendKind::*;
         match (self, d14n) {
             (Dev, false) => (*crate::constants::XMTP_DEV).clone(),
-            (Staging, false) => (*crate::constants::XMTP_STAGING).clone(),
             (Production, false) => (*crate::constants::XMTP_PRODUCTION).clone(),
             (Local, false) => (*crate::constants::XMTP_LOCAL).clone(),
-            (Dev, true) => (*crate::constants::XMTP_DEV_D14N).clone(),
-            (Staging, true) => (*crate::constants::XMTP_STAGING_D14N).clone(),
+            (Dev, true) => panic!(
+                "No D14n network URL for --backend dev; use --backend production (testnet) or --backend local"
+            ),
             (Production, true) => (*crate::constants::XMTP_PRODUCTION_D14N).clone(),
             (Local, true) => (*crate::constants::XMTP_LOCAL_D14N).clone(),
         }

--- a/apps/xmtp_debug/src/constants.rs
+++ b/apps/xmtp_debug/src/constants.rs
@@ -2,38 +2,25 @@
 use std::sync::LazyLock;
 use tempfile::TempDir;
 use url::Url;
-use xmtp_configuration::{GrpcUrlsDev, GrpcUrlsLocal, GrpcUrlsProduction, GrpcUrlsStaging};
+use xmtp_configuration::{GrpcUrlsDev, GrpcUrlsLocal, GrpcUrlsProduction};
 
 pub static XMTP_PRODUCTION: LazyLock<Url> =
     LazyLock::new(|| Url::parse(GrpcUrlsProduction::NODE).unwrap());
 pub static XMTP_DEV: LazyLock<Url> = LazyLock::new(|| Url::parse(GrpcUrlsDev::NODE).unwrap());
-pub static XMTP_STAGING: LazyLock<Url> =
-    LazyLock::new(|| Url::parse(GrpcUrlsStaging::NODE).unwrap());
 pub static XMTP_LOCAL: LazyLock<Url> = LazyLock::new(|| Url::parse(GrpcUrlsLocal::NODE).unwrap());
 
 pub static XMTP_PRODUCTION_D14N: LazyLock<Url> =
     LazyLock::new(|| Url::parse(GrpcUrlsProduction::XMTPD).unwrap());
-pub static XMTP_STAGING_D14N: LazyLock<Url> =
-    LazyLock::new(|| Url::parse(GrpcUrlsStaging::XMTPD).unwrap());
-pub static XMTP_DEV_D14N: LazyLock<Url> = LazyLock::new(|| Url::parse(GrpcUrlsDev::XMTPD).unwrap());
 pub static XMTP_LOCAL_D14N: LazyLock<Url> =
     LazyLock::new(|| Url::parse(GrpcUrlsLocal::XMTPD).unwrap());
 
 pub static XMTP_PRODUCTION_GATEWAY: LazyLock<Url> =
     LazyLock::new(|| Url::parse(GrpcUrlsProduction::GATEWAY).unwrap());
-pub static XMTP_STAGING_GATEWAY: LazyLock<Url> =
-    LazyLock::new(|| Url::parse(GrpcUrlsStaging::GATEWAY).unwrap());
-pub static XMTP_DEV_GATEWAY: LazyLock<Url> =
-    LazyLock::new(|| Url::parse(GrpcUrlsDev::GATEWAY).unwrap());
 pub static XMTP_LOCAL_GATEWAY: LazyLock<Url> =
     LazyLock::new(|| Url::parse(GrpcUrlsLocal::GATEWAY).unwrap());
 
 pub static XMTP_PRODUCTION_PERF_GATEWAY: LazyLock<Url> =
     LazyLock::new(|| Url::parse(GrpcUrlsProduction::PERF_GATEWAY).unwrap());
-pub static XMTP_STAGING_PERF_GATEWAY: LazyLock<Url> =
-    LazyLock::new(|| Url::parse(GrpcUrlsStaging::PERF_GATEWAY).unwrap());
-pub static XMTP_DEV_PERF_GATEWAY: LazyLock<Url> =
-    LazyLock::new(|| Url::parse(GrpcUrlsDev::PERF_GATEWAY).unwrap());
 pub static XMTP_LOCAL_PERF_GATEWAY: LazyLock<Url> =
     LazyLock::new(|| Url::parse(GrpcUrlsLocal::PERF_GATEWAY).unwrap());
 

--- a/bindings/node/src/client/options.rs
+++ b/bindings/node/src/client/options.rs
@@ -58,8 +58,6 @@ pub enum XmtpEnv {
   Local,
   Dev,
   Production,
-  TestnetStaging,
-  TestnetDev,
   Testnet,
   Mainnet,
 }
@@ -70,8 +68,6 @@ impl From<XmtpEnv> for CoreXmtpEnv {
       XmtpEnv::Local => Self::Local,
       XmtpEnv::Dev => Self::Dev,
       XmtpEnv::Production => Self::Production,
-      XmtpEnv::TestnetStaging => Self::TestnetStaging,
-      XmtpEnv::TestnetDev => Self::TestnetDev,
       XmtpEnv::Testnet => Self::Testnet,
       XmtpEnv::Mainnet => Self::Mainnet,
     }

--- a/bindings/wasm/src/client.rs
+++ b/bindings/wasm/src/client.rs
@@ -98,8 +98,6 @@ pub enum XmtpEnv {
   Local = 0,
   Dev = 1,
   Production = 2,
-  TestnetStaging = 3,
-  TestnetDev = 4,
   Testnet = 5,
   Mainnet = 6,
 }
@@ -110,8 +108,6 @@ impl From<XmtpEnv> for xmtp_configuration::XmtpEnv {
       XmtpEnv::Local => Self::Local,
       XmtpEnv::Dev => Self::Dev,
       XmtpEnv::Production => Self::Production,
-      XmtpEnv::TestnetStaging => Self::TestnetStaging,
-      XmtpEnv::TestnetDev => Self::TestnetDev,
       XmtpEnv::Testnet => Self::Testnet,
       XmtpEnv::Mainnet => Self::Mainnet,
     }

--- a/crates/xmtp_api_grpc/src/grpc_client/test/clients.rs
+++ b/crates/xmtp_api_grpc/src/grpc_client/test/clients.rs
@@ -1,5 +1,5 @@
 use toxiproxy_rust::TOXIPROXY;
-use xmtp_configuration::{GrpcUrls, GrpcUrlsDev, GrpcUrlsLocal, GrpcUrlsToxic};
+use xmtp_configuration::{GrpcUrls, GrpcUrlsDev, GrpcUrlsLocal, GrpcUrlsProduction, GrpcUrlsToxic};
 use xmtp_proto::{
     api_client::{ToxicProxies, ToxicTestClient, XmtpTestClient},
     prelude::NetConnectConfig,
@@ -52,23 +52,23 @@ impl XmtpTestClient for DevNodeGoClient {
     }
 }
 
-/// Client connected to xmtp-node-go on the dev network
+/// Client connected to the public testnet payer gateway.
 pub struct DevGatewayClient;
 impl XmtpTestClient for DevGatewayClient {
     type Builder = ClientBuilder;
 
     fn create() -> Self::Builder {
-        build_client(GrpcUrlsDev::GATEWAY)
+        build_client(GrpcUrlsProduction::GATEWAY)
     }
 }
 
-/// Client connected to xmtp-node-go on the dev network
+/// Client connected to the public testnet xmtpd node.
 pub struct DevXmtpdClient;
 impl XmtpTestClient for DevXmtpdClient {
     type Builder = ClientBuilder;
 
     fn create() -> Self::Builder {
-        build_client(GrpcUrlsDev::XMTPD)
+        build_client(GrpcUrlsProduction::XMTPD)
     }
 }
 

--- a/crates/xmtp_configuration/src/common/api.rs
+++ b/crates/xmtp_configuration/src/common/api.rs
@@ -42,8 +42,8 @@ pub struct GrpcUrls;
 if_dev! {
     impl GrpcUrls {
         pub const NODE: &'static str = GrpcUrlsDev::NODE;
-        pub const XMTPD: &'static str = GrpcUrlsStaging::XMTPD;
-        pub const GATEWAY: &'static str = GrpcUrlsStaging::GATEWAY;
+        pub const XMTPD: &'static str = GrpcUrlsProduction::XMTPD;
+        pub const GATEWAY: &'static str = GrpcUrlsProduction::GATEWAY;
     }
 }
 
@@ -75,13 +75,8 @@ if_native! {
     }
 }
 
-/// GRPC URLS corresponding to dev environments
+/// GRPC URLS corresponding to the V3 dev node-go environment.
 pub struct GrpcUrlsDev;
-impl GrpcUrlsDev {
-    pub const XMTPD: &'static str = "https://grpc.testnet-dev.xmtp.network:443";
-    pub const GATEWAY: &'static str = "https://payer.testnet-dev.xmtp.network:443";
-    pub const PERF_GATEWAY: &'static str = "https://payer-perf.testnet-dev.xmtp.network:443";
-}
 
 if_wasm! {
     impl GrpcUrlsDev {
@@ -91,26 +86,6 @@ if_wasm! {
 
 if_native! {
      impl GrpcUrlsDev {
-        pub const NODE: &'static str = "https://grpc.dev.xmtp.network:443";
-    }
-}
-
-/// GRPC URLS corresponding to staging environments
-pub struct GrpcUrlsStaging;
-impl GrpcUrlsStaging {
-    pub const XMTPD: &'static str = "https://grpc.testnet-staging.xmtp.network:443";
-    pub const GATEWAY: &'static str = "https://payer.testnet-staging.xmtp.network:443";
-    pub const PERF_GATEWAY: &'static str = "https://payer-perf.testnet-staging.xmtp.network:443";
-}
-
-if_wasm! {
-    impl GrpcUrlsStaging {
-        pub const NODE: &'static str = "https://api.dev.xmtp.network:5558";
-    }
-}
-
-if_native! {
-    impl GrpcUrlsStaging {
         pub const NODE: &'static str = "https://grpc.dev.xmtp.network:443";
     }
 }

--- a/crates/xmtp_configuration/src/common/env.rs
+++ b/crates/xmtp_configuration/src/common/env.rs
@@ -6,8 +6,8 @@ use super::{GrpcUrlsDev, GrpcUrlsLocal, GrpcUrlsProduction};
 ///
 /// There are two categories of environments:
 /// - **Centralized (V3):** `Local`, `Dev`, `Production` -- backed by node-go with gRPC.
-/// - **Decentralized (D14n):** `TestnetStaging`, `TestnetDev`, `Testnet`, `Mainnet` -- backed by
-///   the decentralized XMTP network (xmtpd).
+/// - **Decentralized (D14n):** `Testnet`, `Mainnet` -- backed by the decentralized XMTP network
+///   (xmtpd).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum XmtpEnv {
     // Centralized (V3) environments
@@ -19,10 +19,6 @@ pub enum XmtpEnv {
     Production,
 
     // Decentralized (D14n) environments
-    /// Testnet staging (internal pre-release).
-    TestnetStaging,
-    /// Testnet dev (development iteration).
-    TestnetDev,
     /// Public testnet.
     Testnet,
     /// Mainnet (production decentralized network).
@@ -39,16 +35,13 @@ impl XmtpEnv {
             Self::Local => Some(GrpcUrlsLocal::NODE),
             Self::Dev => Some(GrpcUrlsDev::NODE),
             Self::Production => Some(GrpcUrlsProduction::NODE),
-            Self::TestnetStaging | Self::TestnetDev | Self::Testnet | Self::Mainnet => None,
+            Self::Testnet | Self::Mainnet => None,
         }
     }
 
     /// Returns `true` if this is a decentralized (D14n) environment.
     pub fn is_d14n(&self) -> bool {
-        matches!(
-            self,
-            Self::TestnetStaging | Self::TestnetDev | Self::Testnet | Self::Mainnet
-        )
+        matches!(self, Self::Testnet | Self::Mainnet)
     }
 }
 
@@ -65,8 +58,6 @@ mod tests {
 
     #[test]
     fn d14n_envs_have_no_api_url() {
-        assert!(XmtpEnv::TestnetStaging.default_api_url().is_none());
-        assert!(XmtpEnv::TestnetDev.default_api_url().is_none());
         assert!(XmtpEnv::Testnet.default_api_url().is_none());
         assert!(XmtpEnv::Mainnet.default_api_url().is_none());
     }
@@ -79,8 +70,6 @@ mod tests {
         assert!(!XmtpEnv::Production.is_d14n());
 
         // D14n envs ARE d14n
-        assert!(XmtpEnv::TestnetStaging.is_d14n());
-        assert!(XmtpEnv::TestnetDev.is_d14n());
         assert!(XmtpEnv::Testnet.is_d14n());
         assert!(XmtpEnv::Mainnet.is_d14n());
     }


### PR DESCRIPTION
## Summary
- Drops `XmtpEnv::TestnetDev` / `XmtpEnv::TestnetStaging` from the core enum and both Node + WASM bindings (Mainnet was already present; `Testnet = 5` / `Mainnet = 6` numeric values preserved in the WASM enum for JS compatibility).
- Deletes `GrpcUrlsStaging` and the testnet-dev URL constants on `GrpcUrlsDev` (kept `GrpcUrlsDev::NODE`, which is the V3 dev node-go URL used by `XmtpEnv::Dev`). `if_dev!` override now routes XMTPD/GATEWAY to `GrpcUrlsProduction` (testnet).
- Cleans up `xdbg` (removes `BackendKind::Staging`, bails on `--backend dev --d14n`) and `xmtp_cli` (removes `Env::Staging`, errors on `--testnet --env dev`).
- Updates `xdbg`'s Docker entrypoint and README so `WORKSPACE` only understands `testnet`.
- Repoints `DevXmtpdClient` / `DevGatewayClient` test helpers (used by benchmarks and tester framework) to `GrpcUrlsProduction` instead of the removed testnet-dev URLs so downstream test infra keeps compiling.

## Test plan
- [ ] `cargo check --workspace` still passes in CI (verified locally for the touched crates: `xmtp_configuration`, `bindings_node`, `xmtp_api_grpc`, `xmtp_api_d14n`, `xmtp_mls`, `xmtp_cli`, `xdbg`).
- [ ] `cargo test -p xmtp_configuration` passes (ran locally — 3/3 env tests green).
- [ ] `just lint` clean.
- [ ] `just node check` / `just wasm check` confirm bindings still build.
- [ ] Manual smoke: `xdbg --backend dev --d14n` now errors cleanly; `xmtp_cli --testnet --env dev` now errors cleanly; `WORKSPACE=testnet` entrypoint still resolves to `BACKEND=production`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove testnet-dev and testnet-staging environments from all bindings and configuration
> - `TestnetDev` and `TestnetStaging` variants are removed from `XmtpEnv` in the core configuration, Node bindings, and wasm bindings; `BackendKind::Dev` and the CLI `--env staging` option are similarly removed.
> - Test clients (`DevGatewayClient`, `DevXmtpdClient`) now point to production testnet endpoints instead of dev endpoints.
> - `GrpcUrlsStaging` struct and all dev D14n/gateway constants are deleted from [api.rs](https://github.com/xmtp/libxmtp/pull/3533/files#diff-eea8d664cbd080a2a3d9fb19d6bbda2808dad91b3277c1a5fbe64c03d0d247b4); remaining dev gateway references resolve to production testnet equivalents.
> - The `xmtp_debug` Docker entrypoint and README are updated to reflect only `testnet` as a valid `--workspace` value.
> - Risk: any caller passing `TestnetDev`, `TestnetStaging`, or `--env staging` will now receive an error or panic at runtime instead of connecting to those endpoints.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e3bc982.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->