### PR TITLE
update rust to 1.95, update crane, run tests if flake.lock changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,7 @@ jobs:
               - 'rust-toolchain.toml'
               - 'dev/docker/**'
               - 'dev/up'
+              - 'flake.lock'
               - '.github/workflows/test.yml'
               - '.github/workflows/test-workspace*'
             node:
@@ -47,6 +48,7 @@ jobs:
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'nix/**'
+              - 'flake.lock'
               - 'dev/docker/**'
               - 'dev/up'
               - '.github/workflows/test-node*'
@@ -56,6 +58,7 @@ jobs:
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'nix/**'
+              - 'flake.lock'
               - 'dev/docker/**'
               - '.github/workflows/test-wasm*'
             ios:
@@ -63,6 +66,7 @@ jobs:
               - 'bindings/mobile/**'
               - 'crates/**'
               - 'nix/**'
+              - 'flake.lock'
               - 'Package.swift'
               - 'Cargo.toml'
               - 'Cargo.lock'
@@ -72,6 +76,7 @@ jobs:
               - 'bindings/mobile/**'
               - 'crates/**'
               - 'nix/**'
+              - 'flake.lock'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - '.github/workflows/test-android*'
@@ -83,6 +88,7 @@ jobs:
               - 'dev/up'
               - 'rust-toolchain.toml'
               - '.cargo/**'
+              - 'flake.lock'
               - '.github/workflows/test-bindings*'
             devcontainer:
               - '.devcontainer/**'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12455,9 +12455,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/crates/xmtp_api_d14n/src/protocol/sort/causal.rs
+++ b/crates/xmtp_api_d14n/src/protocol/sort/causal.rs
@@ -59,7 +59,7 @@ impl<'b, 'a: 'b, E: Envelope<'a>> Sort<Vec<E>> for CausalSort<'b, E> {
                 self.topic_cursor.apply(env)?;
                 let newly_valid = self.recover_newly_valid(&mut missed);
                 i += 1;
-                self.envelopes.splice(i..i, newly_valid.into_iter());
+                self.envelopes.splice(i..i, newly_valid);
             } else {
                 let missed_envelope = self.envelopes.remove(i);
                 missed.push(Missed::new(missed_envelope, last_seen, topic));

--- a/crates/xmtp_mls/src/client.rs
+++ b/crates/xmtp_mls/src/client.rs
@@ -1168,8 +1168,8 @@ where
             .api()
             .get_inbox_ids(requests)
             .await?
-            .into_iter()
-            .filter_map(|(ident, _)| Some((ident.try_into().ok()?, true)))
+            .into_keys()
+            .filter_map(|ident| Some((ident.try_into().ok()?, true)))
             .collect();
 
         // Fill in the rest with false

--- a/crates/xmtp_mls/src/groups/group_membership.rs
+++ b/crates/xmtp_mls/src/groups/group_membership.rs
@@ -64,14 +64,8 @@ impl GroupMembership {
 
         let added_inboxes = new_group_membership
             .members
-            .iter()
-            .filter_map(|(inbox_id, _)| {
-                if self.members.contains_key(inbox_id) {
-                    None
-                } else {
-                    Some(inbox_id)
-                }
-            })
+            .keys()
+            .filter(|&inbox_id| !self.members.contains_key(inbox_id))
             .collect::<Vec<&String>>();
 
         MembershipDiff {

--- a/crates/xmtp_mls/src/groups/subscriptions.rs
+++ b/crates/xmtp_mls/src/groups/subscriptions.rs
@@ -85,7 +85,7 @@ where
             }
         }?;
 
-        future_stream::iter(messages.into_iter())
+        future_stream::iter(messages)
             .then(|msg| async move {
                 ProcessMessageFuture::new(self.context.clone())
                     .create(msg)

--- a/crates/xmtp_mls/src/groups/tests/test_welcome_pointers.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_welcome_pointers.rs
@@ -229,27 +229,24 @@ async fn test_welcome_pointer_round_trip(
     .unwrap();
 
     // Verify testers can see the group
-    let welcomes = futures::future::join_all(
-        testers
-            .into_iter()
-            .chain(extra_installations.into_iter())
-            .map(|tester| async {
-                tester.sync_welcomes().await.unwrap();
-                let tester_groups = tester
-                    .find_groups(xmtp_db::group::GroupQueryArgs::default())
-                    .unwrap();
-                assert_eq!(tester_groups.len(), 1);
-                let installation_id = tester.identity().installation_id();
-                drop(tester);
-                // use alix's context here to avoid caching issues for welcome topics
-                alix_group
-                    .context
-                    .api()
-                    .query_welcome_messages(&installation_id)
-                    .await
-                    .unwrap()
-            }),
-    )
+    let welcomes = futures::future::join_all(testers.into_iter().chain(extra_installations).map(
+        |tester| async {
+            tester.sync_welcomes().await.unwrap();
+            let tester_groups = tester
+                .find_groups(xmtp_db::group::GroupQueryArgs::default())
+                .unwrap();
+            assert_eq!(tester_groups.len(), 1);
+            let installation_id = tester.identity().installation_id();
+            drop(tester);
+            // use alix's context here to avoid caching issues for welcome topics
+            alix_group
+                .context
+                .api()
+                .query_welcome_messages(&installation_id)
+                .await
+                .unwrap()
+        },
+    ))
     .await;
 
     for welcome in welcomes {

--- a/crates/xmtp_mls/src/subscriptions/mod.rs
+++ b/crates/xmtp_mls/src/subscriptions/mod.rs
@@ -290,7 +290,7 @@ where
         envelope_bytes: Vec<u8>,
     ) -> Result<Vec<MlsGroup<Context>>> {
         let conn = self.context.db();
-        let mut known_welcomes = HashSet::from_iter(conn.group_cursors()?.into_iter());
+        let mut known_welcomes = HashSet::from_iter(conn.group_cursors()?);
         let welcome = decode_welcome_message(envelope_bytes.as_slice())?;
         let welcomes: Vec<_> = match welcome {
             V3OrD14n::D14n(envelope) => {

--- a/crates/xmtp_mls/src/subscriptions/stream_conversations.rs
+++ b/crates/xmtp_mls/src/subscriptions/stream_conversations.rs
@@ -284,7 +284,7 @@ where
             .subscribe_welcome_messages(&installation_key)
             .await?;
         let subscription = SubscriptionStream::new(subscription);
-        let known_welcome_ids = HashSet::from_iter(conn.group_cursors()?.into_iter());
+        let known_welcome_ids = HashSet::from_iter(conn.group_cursors()?);
 
         let stream = multiplexed(subscription, events);
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1775839657,
-        "narHash": "sha256-SPm9ck7jh3Un9nwPuMGbRU04UroFmOHjLP56T10MOeM=",
+        "lastModified": 1776635034,
+        "narHash": "sha256-OEOJrT3ZfwbChzODfIH4GzlNTtOFuZFWPtW7jIeR8xU=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "7cf72d978629469c4bd4206b95c402514c1f6000",
+        "rev": "dc7496d8ea6e526b1254b55d09b966e94673750f",
         "type": "github"
       },
       "original": {
@@ -233,13 +233,13 @@
     "rust-manifest": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-LYmBXXb1ks+HgyKwlqL0uICiwcRzWXRn4lHe6eLqJ8s=",
+        "narHash": "sha256-gOowX/J8r9U9Y3H0PNdAUI0W/e6BGX3tsWh/bA+SnpQ=",
         "type": "file",
-        "url": "https://static.rust-lang.org/dist/channel-rust-1.94.1.toml"
+        "url": "https://static.rust-lang.org/dist/channel-rust-1.95.0.toml"
       },
       "original": {
         "type": "file",
-        "url": "https://static.rust-lang.org/dist/channel-rust-1.94.1.toml"
+        "url": "https://static.rust-lang.org/dist/channel-rust-1.95.0.toml"
       }
     },
     "rust-overlay": {

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
     };
     rust-flake.url = "github:juspay/rust-flake";
     rust-manifest = {
-      url = "https://static.rust-lang.org/dist/channel-rust-1.94.1.toml";
+      url = "https://static.rust-lang.org/dist/channel-rust-1.95.0.toml";
       flake = false;
     };
     treefmt-nix.url = "github:numtide/treefmt-nix";


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update the dev toolchain to use the current stable version of the toolchain
> - Updates the [flake.nix](https://github.com/xmtp/libxmtp/pull/3536/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0) rust manifest from 1.94.1 to 1.95.0, updating the toolchain used in dev shells and CI builds.
> - Updates [flake.lock](https://github.com/xmtp/libxmtp/pull/3536/files#diff-216b2b7bfde9416c79d133bacb031e95702a20bdedb548c0b055c837aa4f6a9c) and [cargo.lock](https://github.com/xmtp/libxmtp/pull/3536/files#diff-b489ef1b0e20526d79e21bda8fca1f10779bd07cd2f26015dc497eb4e62fab62) to reflect updated dependency versions.
> - Updates the [test.yml](https://github.com/xmtp/libxmtp/pull/3536/files#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88) CI workflow to also run tests when `flake.lock` changes.
> - Makes several minor code simplifications (removing redundant `.into_iter()` calls) required by updated lint rules in 1.95.0.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 61c72a7. 6 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->


running workspace tests on flake.lock change should reduce breakage seen previously when updating nixpkgs/rust version. this also makes me more confident in the new dependabot auto updates for nix flake.