### PR TITLE
fix(devcontainer): sync devcontainer.json to latest built image digest

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json.
 {
     "name": "libxmtp (Nix)",
-    "image": "ghcr.io/xmtp/libxmtp-devcontainer@sha256:3cd92ccc9a182a542056d99c5f02892ab8b01be0257cf64f03e5eb2d475291a2",
+    "image": "ghcr.io/xmtp/libxmtp-devcontainer@sha256:148e01e999f996b4400847bd260af3563fda366d45c82c2299e941d5bf71c9e3",
     "runArgs": ["--ulimit", "stack=-1:-1"],
     "mounts": [
         "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3537

## Summary

The `test-devcontainer` workflow rebuilt the devcontainer image and produced digest `sha256:148e01e999f996b4400847bd260af3563fda366d45c82c2299e941d5bf71c9e3`, but `.devcontainer/devcontainer.json` still pinned the previous digest (`sha256:3cd92ccc…`). The post-build sync check in `.github/workflows/test-devcontainer.yml` failed as a result.

## Change

Bump the `image` digest in `.devcontainer/devcontainer.json` to the one produced by the latest build so the sync check passes.

## Test plan

- [ ] `test-devcontainer` workflow runs and the "Check if committed devcontainer.json is in sync with the built image" step reports `in sync ✓`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update devcontainer base image digest in `devcontainer.json`
> Updates the pinned image digest in [devcontainer.json](.devcontainer/devcontainer.json) from `sha256:3cd92ccc...` to `sha256:148e01e9...` to sync with the latest built `ghcr.io/xmtp/libxmtp-devcontainer` image.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a058ec6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->