### PR TITLE
refactor(xmtp_db): consolidate raw_query_read/raw_query_write into raw_query

### DIFF
--- a/apps/db_tools/src/tasks/db_bench.rs
+++ b/apps/db_tools/src/tasks/db_bench.rs
@@ -108,7 +108,7 @@ where
 
     pub fn bench(&mut self) -> Result<Vec<Result<()>>> {
         let mut results = vec![];
-        let result = self.store.conn().raw_query_write(|conn| {
+        let result = self.store.conn().raw_query(|conn| {
             conn.transaction(|_txn| {
                 results.push(self.bench_group_queries());
                 results.push(self.bench_group_intent_queries());

--- a/apps/db_tools/src/tasks/migrations.rs
+++ b/apps/db_tools/src/tasks/migrations.rs
@@ -142,7 +142,7 @@ mod tests {
 
         // Helper to check if column exists using raw SQL
         fn check_column_exists(conn: &impl xmtp_db::ConnectionExt) -> anyhow::Result<bool> {
-            Ok(conn.raw_query_read(|c| {
+            Ok(conn.raw_query(|c| {
                 use xmtp_db::diesel::connection::SimpleConnection;
                 // Try to select the column - if it fails, the column doesn't exist
                 let result = c.batch_execute("SELECT inserted_at_ns FROM group_messages LIMIT 0");

--- a/apps/db_tools/src/tasks/snapshot_to_persistent.rs
+++ b/apps/db_tools/src/tasks/snapshot_to_persistent.rs
@@ -1,9 +1,9 @@
 use anyhow::Result;
 use std::path::Path;
-use xmtp_db::{EncryptedMessageStore, NativeDb};
+use xmtp_db::{ConnectionExt, EncryptedMessageStore, NativeDb};
 
 pub fn db_vacuum(store: &EncryptedMessageStore<NativeDb>, dest: impl AsRef<Path>) -> Result<()> {
-    let buff = store.db().raw_query_write(|conn| {
+    let buff = store.db().raw_query(|conn| {
         let buff = conn.serialize_database_to_buffer();
         Ok(buff)
     })?;

--- a/crates/xmtp_db/src/encrypted_store/association_state.rs
+++ b/crates/xmtp_db/src/encrypted_store/association_state.rs
@@ -135,7 +135,7 @@ impl<C: ConnectionExt> QueryAssociationStateCache for DbConnection<C> {
             );
 
         let association_states =
-            self.raw_query_read(|query_conn| query.load::<StoredAssociationState>(query_conn))?;
+            self.raw_query(|query_conn| query.load::<StoredAssociationState>(query_conn))?;
 
         association_states
             .into_iter()

--- a/crates/xmtp_db/src/encrypted_store/consent_record.rs
+++ b/crates/xmtp_db/src/encrypted_store/consent_record.rs
@@ -126,7 +126,7 @@ impl<C: ConnectionExt> QueryConsentRecord for DbConnection<C> {
         entity: String,
         entity_type: ConsentType,
     ) -> Result<Option<StoredConsentRecord>, crate::ConnectionError> {
-        self.raw_query_read(|conn| {
+        self.raw_query(|conn| {
             dsl::consent_records
                 .filter(dsl::entity.eq(entity))
                 .filter(dsl::entity_type.eq(entity_type))
@@ -136,7 +136,7 @@ impl<C: ConnectionExt> QueryConsentRecord for DbConnection<C> {
     }
 
     fn consent_records(&self) -> Result<Vec<StoredConsentRecord>, crate::ConnectionError> {
-        self.raw_query_read(|conn| super::schema::consent_records::table.load(conn))
+        self.raw_query(|conn| super::schema::consent_records::table.load(conn))
     }
 
     fn consent_records_paged(
@@ -149,7 +149,7 @@ impl<C: ConnectionExt> QueryConsentRecord for DbConnection<C> {
             .limit(limit)
             .offset(offset);
 
-        self.raw_query_read(|conn| query.load::<StoredConsentRecord>(conn))
+        self.raw_query(|conn| query.load::<StoredConsentRecord>(conn))
     }
 
     // returns true if newer
@@ -157,7 +157,7 @@ impl<C: ConnectionExt> QueryConsentRecord for DbConnection<C> {
         &self,
         record: StoredConsentRecord,
     ) -> Result<bool, crate::ConnectionError> {
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             let maybe_inserted_consent_record: Option<StoredConsentRecord> =
                 diesel::insert_into(dsl::consent_records)
                     .values(&record)
@@ -211,7 +211,7 @@ impl<C: ConnectionExt> QueryConsentRecord for DbConnection<C> {
             );
         }
 
-        let changed = self.raw_query_write(|conn| {
+        let changed = self.raw_query(|conn| {
             let existing: Vec<StoredConsentRecord> = query.load(conn)?;
             let changed: Vec<_> = records
                 .iter()
@@ -241,7 +241,7 @@ impl<C: ConnectionExt> QueryConsentRecord for DbConnection<C> {
         &self,
         record: &StoredConsentRecord,
     ) -> Result<Option<StoredConsentRecord>, crate::ConnectionError> {
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             let maybe_inserted_consent_record: Option<StoredConsentRecord> =
                 diesel::insert_into(dsl::consent_records)
                     .values(record)
@@ -265,7 +265,7 @@ impl<C: ConnectionExt> QueryConsentRecord for DbConnection<C> {
         &self,
         dm_id: &str,
     ) -> Result<Vec<StoredConsentRecord>, crate::ConnectionError> {
-        self.raw_query_read(|conn| {
+        self.raw_query(|conn| {
             // First, get all group IDs for this dm_id
             let group_ids: Vec<Vec<u8>> = groups_dsl::groups
                 .filter(groups_dsl::dm_id.eq(dm_id))

--- a/crates/xmtp_db/src/encrypted_store/conversation_list.rs
+++ b/crates/xmtp_db/src/encrypted_store/conversation_list.rs
@@ -198,7 +198,7 @@ impl<C: ConnectionExt> QueryConversationList for DbConnection<C> {
 
         let mut conversations = if includes_all {
             // No filtering at all
-            self.raw_query_read(|conn| query.load::<ConversationListItem>(conn))?
+            self.raw_query(|conn| query.load::<ConversationListItem>(conn))?
         } else if includes_unknown {
             // LEFT JOIN: include Unknown + NULL + filtered states
             let left_joined_query = query
@@ -216,7 +216,7 @@ impl<C: ConnectionExt> QueryConversationList for DbConnection<C> {
                 )
                 .select(conversation_list::all_columns());
 
-            self.raw_query_read(|conn| left_joined_query.load::<ConversationListItem>(conn))?
+            self.raw_query(|conn| left_joined_query.load::<ConversationListItem>(conn))?
         } else {
             // INNER JOIN: strict match only to specific states (no Unknown or NULL)
             let inner_joined_query = query
@@ -229,7 +229,7 @@ impl<C: ConnectionExt> QueryConversationList for DbConnection<C> {
                 .filter(consent_dsl::state.eq_any(filtered_states.clone()))
                 .select(conversation_list::all_columns());
 
-            self.raw_query_read(|conn| inner_joined_query.load::<ConversationListItem>(conn))?
+            self.raw_query(|conn| inner_joined_query.load::<ConversationListItem>(conn))?
         };
 
         // Were sync groups explicitly asked for? Was the include_sync_groups flag set to true?
@@ -237,7 +237,7 @@ impl<C: ConnectionExt> QueryConversationList for DbConnection<C> {
         if matches!(conversation_type, Some(ConversationType::Sync)) || *include_sync_groups {
             let query = conversation_list_dsl::conversation_list
                 .filter(conversation_list_dsl::conversation_type.eq(ConversationType::Sync));
-            let mut sync_groups = self.raw_query_read(|conn| query.load(conn))?;
+            let mut sync_groups = self.raw_query(|conn| query.load(conn))?;
             conversations.append(&mut sync_groups);
         }
 

--- a/crates/xmtp_db/src/encrypted_store/d14n_migration_cutover.rs
+++ b/crates/xmtp_db/src/encrypted_store/d14n_migration_cutover.rs
@@ -63,13 +63,12 @@ impl<T: QueryMigrationCutover> QueryMigrationCutover for &T {
 
 impl<C: ConnectionExt> QueryMigrationCutover for DbConnection<C> {
     fn get_migration_cutover(&self) -> Result<StoredMigrationCutover, StorageError> {
-        let result =
-            self.raw_query_read(|conn| dsl::d14n_migration_cutover.first(conn).optional())?;
+        let result = self.raw_query(|conn| dsl::d14n_migration_cutover.first(conn).optional())?;
         Ok(result.unwrap_or_default())
     }
 
     fn set_cutover_ns(&self, cutover_ns: i64) -> Result<(), StorageError> {
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             diesel::update(dsl::d14n_migration_cutover.find(1))
                 .set(d14n_migration_cutover::cutover_ns.eq(cutover_ns))
                 .execute(conn)
@@ -83,7 +82,7 @@ impl<C: ConnectionExt> QueryMigrationCutover for DbConnection<C> {
     }
 
     fn set_last_checked_ns(&self, last_checked_ns: i64) -> Result<(), StorageError> {
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             diesel::update(dsl::d14n_migration_cutover.find(1))
                 .set(d14n_migration_cutover::last_checked_ns.eq(last_checked_ns))
                 .execute(conn)
@@ -92,7 +91,7 @@ impl<C: ConnectionExt> QueryMigrationCutover for DbConnection<C> {
     }
 
     fn set_has_migrated(&self, has_migrated: bool) -> Result<(), StorageError> {
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             diesel::update(dsl::d14n_migration_cutover.find(1))
                 .set(d14n_migration_cutover::has_migrated.eq(has_migrated))
                 .execute(conn)

--- a/crates/xmtp_db/src/encrypted_store/database.rs
+++ b/crates/xmtp_db/src/encrypted_store/database.rs
@@ -44,25 +44,14 @@ where
     P: ConnectionExt,
     M: ConnectionExt,
 {
-    fn raw_query_read<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
+    fn raw_query<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
     where
         F: FnOnce(&mut SqliteConnection) -> Result<T, diesel::result::Error>,
         Self: Sized,
     {
         match self {
-            Self::Persistent(p) => p.raw_query_read(fun),
-            Self::Mem(m) => m.raw_query_read(fun),
-        }
-    }
-
-    fn raw_query_write<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
-    where
-        F: FnOnce(&mut SqliteConnection) -> Result<T, diesel::result::Error>,
-        Self: Sized,
-    {
-        match self {
-            Self::Persistent(p) => p.raw_query_write(fun),
-            Self::Mem(m) => m.raw_query_write(fun),
+            Self::Persistent(p) => p.raw_query(fun),
+            Self::Mem(m) => m.raw_query(fun),
         }
     }
 

--- a/crates/xmtp_db/src/encrypted_store/database/native.rs
+++ b/crates/xmtp_db/src/encrypted_store/database/native.rs
@@ -412,16 +412,7 @@ impl EphemeralDbConnection {
 }
 
 impl ConnectionExt for EphemeralDbConnection {
-    fn raw_query_read<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
-    where
-        F: FnOnce(&mut SqliteConnection) -> Result<T, diesel::result::Error>,
-        Self: Sized,
-    {
-        let mut conn = self.conn.lock();
-        fun(&mut conn).map_err(ConnectionError::from)
-    }
-
-    fn raw_query_write<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
+    fn raw_query<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
     where
         F: FnOnce(&mut SqliteConnection) -> Result<T, diesel::result::Error>,
         Self: Sized,
@@ -497,7 +488,7 @@ impl NativeDbConnection {
 
 impl ConnectionExt for NativeDbConnection {
     #[tracing::instrument(level = "trace", skip_all)]
-    fn raw_query_read<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
+    fn raw_query<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
     where
         F: FnOnce(&mut SqliteConnection) -> Result<T, diesel::result::Error>,
         Self: Sized,
@@ -505,27 +496,6 @@ impl ConnectionExt for NativeDbConnection {
         if let Some(pool) = &*self.pool.load() {
             tracing::trace!(
                 "pulling connection from pool, idle={}, total={}",
-                pool.state().idle_connections,
-                pool.state().connections
-            );
-            let mut conn = pool.get()?;
-            fun(&mut conn).map_err(ConnectionError::from)
-        } else {
-            Err(ConnectionError::from(
-                PlatformStorageError::PoolNeedsConnection,
-            ))
-        }
-    }
-
-    #[tracing::instrument(level = "trace", skip_all)]
-    fn raw_query_write<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
-    where
-        F: FnOnce(&mut SqliteConnection) -> Result<T, diesel::result::Error>,
-        Self: Sized,
-    {
-        if let Some(pool) = &*self.pool.load() {
-            tracing::trace!(
-                "pulling connection from pool for write, idle={}, total={}",
                 pool.state().idle_connections,
                 pool.state().connections
             );

--- a/crates/xmtp_db/src/encrypted_store/database/native/pool.rs
+++ b/crates/xmtp_db/src/encrypted_store/database/native/pool.rs
@@ -60,16 +60,7 @@ mod tests {
     use rstest::*;
 
     impl ConnectionExt for DbPool {
-        fn raw_query_read<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
-        where
-            F: FnOnce(&mut SqliteConnection) -> Result<T, diesel::result::Error>,
-            Self: Sized,
-        {
-            let mut c = self.get().unwrap();
-            Ok(fun(&mut c)?)
-        }
-
-        fn raw_query_write<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
+        fn raw_query<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
         where
             F: FnOnce(&mut SqliteConnection) -> Result<T, diesel::result::Error>,
             Self: Sized,

--- a/crates/xmtp_db/src/encrypted_store/database/wasm.rs
+++ b/crates/xmtp_db/src/encrypted_store/database/wasm.rs
@@ -198,16 +198,7 @@ impl WasmDbConnection {
 }
 
 impl ConnectionExt for WasmDbConnection {
-    fn raw_query_read<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
-    where
-        F: FnOnce(&mut SqliteConnection) -> Result<T, diesel::result::Error>,
-        Self: Sized,
-    {
-        let mut conn = self.conn.borrow_mut();
-        Ok(fun(&mut conn)?)
-    }
-
-    fn raw_query_write<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
+    fn raw_query<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
     where
         F: FnOnce(&mut SqliteConnection) -> Result<T, diesel::result::Error>,
         Self: Sized,

--- a/crates/xmtp_db/src/encrypted_store/db_connection.rs
+++ b/crates/xmtp_db/src/encrypted_store/db_connection.rs
@@ -25,43 +25,16 @@ impl<C: ConnectionExt> crate::IntoConnection for DbConnection<C> {
     }
 }
 
-impl<C> DbConnection<C>
-where
-    C: ConnectionExt,
-{
-    pub fn raw_query_read<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
-    where
-        F: FnOnce(&mut SqliteConnection) -> Result<T, diesel::result::Error>,
-    {
-        <Self as ConnectionExt>::raw_query_read::<_, _>(self, fun)
-    }
-
-    pub fn raw_query_write<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
-    where
-        F: FnOnce(&mut SqliteConnection) -> Result<T, diesel::result::Error>,
-    {
-        <Self as ConnectionExt>::raw_query_write::<_, _>(self, fun)
-    }
-}
-
 impl<C> ConnectionExt for DbConnection<C>
 where
     C: ConnectionExt,
 {
-    fn raw_query_read<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
+    fn raw_query<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
     where
         F: FnOnce(&mut SqliteConnection) -> Result<T, diesel::result::Error>,
         Self: Sized,
     {
-        self.conn.raw_query_read(fun)
-    }
-
-    fn raw_query_write<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
-    where
-        F: FnOnce(&mut SqliteConnection) -> Result<T, diesel::result::Error>,
-        Self: Sized,
-    {
-        self.conn.raw_query_write(fun)
+        self.conn.raw_query(fun)
     }
 
     fn disconnect(&self) -> Result<(), crate::ConnectionError> {

--- a/crates/xmtp_db/src/encrypted_store/group.rs
+++ b/crates/xmtp_db/src/encrypted_store/group.rs
@@ -672,7 +672,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
 
         let mut groups = if includes_all {
             // No filtering at all
-            self.raw_query_read(|conn| query.load::<StoredGroup>(conn))?
+            self.raw_query(|conn| query.load::<StoredGroup>(conn))?
         } else if includes_unknown {
             // LEFT JOIN: include Unknown + NULL + filtered states
             let left_joined_query = query
@@ -687,7 +687,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
                 )
                 .select(dsl::groups::all_columns());
 
-            self.raw_query_read(|conn| left_joined_query.load::<StoredGroup>(conn))?
+            self.raw_query(|conn| left_joined_query.load::<StoredGroup>(conn))?
         } else {
             // INNER JOIN: strict match only to specific states (no Unknown or NULL)
             let inner_joined_query = query
@@ -697,14 +697,14 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
                 .filter(consent_dsl::state.eq_any(filtered_states.clone()))
                 .select(dsl::groups::all_columns());
 
-            self.raw_query_read(|conn| inner_joined_query.load::<StoredGroup>(conn))?
+            self.raw_query(|conn| inner_joined_query.load::<StoredGroup>(conn))?
         };
 
         // Were sync groups explicitly asked for? Was the include_sync_groups flag set to true?
         // Then query for those separately
         if matches!(conversation_type, Some(ConversationType::Sync)) || *include_sync_groups {
             let query = dsl::groups.filter(dsl::conversation_type.eq(ConversationType::Sync));
-            let mut sync_groups = self.raw_query_read(|conn| query.load(conn))?;
+            let mut sync_groups = self.raw_query(|conn| query.load(conn))?;
             groups.append(&mut sync_groups);
         }
 
@@ -737,7 +737,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
 
         query = query.limit(limit.unwrap_or(100)).offset(offset);
 
-        self.raw_query_read(|conn| query.load::<StoredGroup>(conn))
+        self.raw_query(|conn| query.load::<StoredGroup>(conn))
     }
 
     /// Updates group membership state
@@ -746,7 +746,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
         group_id: GroupId,
         state: GroupMembershipState,
     ) -> Result<(), crate::ConnectionError> {
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             diesel::update(dsl::groups.find(group_id.as_ref()))
                 .set(dsl::membership_state.eq(state))
                 .execute(conn)
@@ -760,7 +760,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
             .order(dsl::created_at_ns.desc())
             .filter(dsl::conversation_type.eq(ConversationType::Sync));
 
-        self.raw_query_read(|conn| query.load(conn))
+        self.raw_query(|conn| query.load(conn))
     }
 
     fn find_sync_group(&self, id: &[u8]) -> Result<Option<StoredGroup>, crate::ConnectionError> {
@@ -768,7 +768,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
             .filter(dsl::conversation_type.eq(ConversationType::Sync))
             .filter(dsl::id.eq(id));
 
-        self.raw_query_read(|conn| query.first(conn).optional())
+        self.raw_query(|conn| query.first(conn).optional())
     }
 
     fn primary_sync_group(&self) -> Result<Option<StoredGroup>, crate::ConnectionError> {
@@ -776,7 +776,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
             .order(dsl::created_at_ns.desc())
             .filter(dsl::conversation_type.eq(ConversationType::Sync));
 
-        self.raw_query_read(|conn| query.first(conn).optional())
+        self.raw_query(|conn| query.first(conn).optional())
     }
 
     /// Return a single group that matches the given ID
@@ -785,7 +785,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
             .order(dsl::created_at_ns.asc())
             .limit(1)
             .filter(dsl::id.eq(id));
-        let groups = self.raw_query_read(|conn| query.load(conn))?;
+        let groups = self.raw_query(|conn| query.load(conn))?;
 
         Ok(groups.into_iter().next())
     }
@@ -800,7 +800,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
             .filter(dsl::sequence_id.eq(cursor.sequence_id as i64))
             .filter(dsl::originator_id.eq(cursor.originator_id as i64));
 
-        let groups = self.raw_query_read(|conn| query.load(conn))?;
+        let groups = self.raw_query(|conn| query.load(conn))?;
 
         if groups.len() > 1 {
             tracing::warn!(
@@ -813,7 +813,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
     }
 
     fn get_rotated_at_ns(&self, group_id: Vec<u8>) -> Result<i64, StorageError> {
-        let last_ts: Option<i64> = self.raw_query_read(|conn| {
+        let last_ts: Option<i64> = self.raw_query(|conn| {
             dsl::groups
                 .find(&group_id)
                 .select(dsl::rotated_at_ns)
@@ -828,7 +828,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
 
     /// Updates the 'last time checked' we checked for new installations.
     fn update_rotated_at_ns(&self, group_id: Vec<u8>) -> Result<(), StorageError> {
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             let now = xmtp_common::time::now_ns();
             diesel::update(dsl::groups.find(&group_id))
                 .set(dsl::rotated_at_ns.eq(now))
@@ -839,7 +839,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
     }
 
     fn get_installations_time_checked(&self, group_id: Vec<u8>) -> Result<i64, StorageError> {
-        let last_ts = self.raw_query_read(|conn| {
+        let last_ts = self.raw_query(|conn| {
             dsl::groups
                 .find(&group_id)
                 .select(dsl::installations_last_checked)
@@ -852,7 +852,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
 
     /// Updates the 'last time checked' we checked for new installations.
     fn update_installations_time_checked(&self, group_id: Vec<u8>) -> Result<(), StorageError> {
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             let now = xmtp_common::time::now_ns();
             diesel::update(dsl::groups.find(&group_id))
                 .set(dsl::installations_last_checked.eq(now))
@@ -867,7 +867,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
         group_id: Vec<u8>,
         from_ns: Option<i64>,
     ) -> Result<(), StorageError> {
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             diesel::update(dsl::groups.find(&group_id))
                 .set(dsl::message_disappear_from_ns.eq(from_ns))
                 .execute(conn)
@@ -881,7 +881,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
         group_id: Vec<u8>,
         in_ns: Option<i64>,
     ) -> Result<(), StorageError> {
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             diesel::update(dsl::groups.find(&group_id))
                 .set(dsl::message_disappear_in_ns.eq(in_ns))
                 .execute(conn)
@@ -891,7 +891,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
     }
 
     fn insert_or_replace_group(&self, group: StoredGroup) -> Result<StoredGroup, StorageError> {
-        let maybe_inserted_group: Option<StoredGroup> = self.raw_query_write(|conn| {
+        let maybe_inserted_group: Option<StoredGroup> = self.raw_query(|conn| {
             diesel::insert_into(dsl::groups)
                 .values(&group)
                 .on_conflict_do_nothing()
@@ -901,13 +901,13 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
 
         if maybe_inserted_group.is_none() {
             let mut existing_group: StoredGroup =
-                self.raw_query_read(|conn| dsl::groups.find(&group.id).first(conn))?;
+                self.raw_query(|conn| dsl::groups.find(&group.id).first(conn))?;
             // A restored group should be overwritten
             if matches!(
                 existing_group.membership_state,
                 GroupMembershipState::Restored
             ) {
-                self.raw_query_write(|c| {
+                self.raw_query(|c| {
                     diesel::update(dsl::groups.find(&group.id))
                         .set(&group)
                         .execute(c)
@@ -928,7 +928,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
                     && (existing_group.sequence_id.is_none()
                         || group.sequence_id > existing_group.sequence_id)
                 {
-                    self.raw_query_write(|c| {
+                    self.raw_query(|c| {
                         diesel::update(dsl::groups.find(&group.id))
                             .set(dsl::sequence_id.eq(group.sequence_id))
                             .execute(c)
@@ -938,13 +938,13 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
                 Ok(existing_group)
             }
         } else {
-            Ok(self.raw_query_read(|c| dsl::groups.find(group.id).first(c))?)
+            Ok(self.raw_query(|c| dsl::groups.find(group.id).first(c))?)
         }
     }
 
     /// Get all the welcome ids turned into groups
     fn group_cursors(&self) -> Result<Vec<Cursor>, crate::ConnectionError> {
-        self.raw_query_read(|conn| {
+        self.raw_query(|conn| {
             Ok(dsl::groups
                 .filter(dsl::sequence_id.is_not_null())
                 .select((dsl::sequence_id, dsl::originator_id))
@@ -965,7 +965,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
         group_id: &[u8],
         fork_details: String,
     ) -> Result<(), StorageError> {
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             diesel::update(dsl::groups.find(&group_id))
                 .set((
                     dsl::maybe_forked.eq(true),
@@ -978,7 +978,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
     }
 
     fn clear_fork_flag_for_group(&self, group_id: &[u8]) -> Result<(), crate::ConnectionError> {
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             diesel::update(dsl::groups.find(&group_id))
                 .set((dsl::maybe_forked.eq(false), dsl::fork_details.eq("")))
                 .execute(conn)
@@ -987,7 +987,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
     }
 
     fn has_duplicate_dm(&self, group_id: &[u8]) -> Result<bool, crate::ConnectionError> {
-        self.raw_query_read(|conn| {
+        self.raw_query(|conn| {
             let dm_id: Option<String> = dsl::groups
                 .filter(dsl::id.eq(group_id))
                 .select(dsl::dm_id)
@@ -1031,7 +1031,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
             .select((dsl::id, dsl::commit_log_public_key))
             .order(dsl::created_at_ns.asc());
 
-        self.raw_query_read(|conn| query.load::<StoredGroupCommitLogPublicKey>(conn))
+        self.raw_query(|conn| query.load::<StoredGroupCommitLogPublicKey>(conn))
     }
 
     // All dms and groups that are not sync groups and have consent state Allowed
@@ -1048,7 +1048,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
             .filter(consent_dsl::state.eq(ConsentState::Allowed))
             .select((dsl::id, dsl::commit_log_public_key));
 
-        self.raw_query_read(|conn| query.load::<StoredGroupCommitLogPublicKey>(conn))
+        self.raw_query(|conn| query.load::<StoredGroupCommitLogPublicKey>(conn))
     }
 
     // Get conversation IDs for fork checking (excludes already forked conversations and sync groups)
@@ -1065,7 +1065,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
             )
             .select(dsl::id);
 
-        self.raw_query_read(|conn| query.load::<Vec<u8>>(conn))
+        self.raw_query(|conn| query.load::<Vec<u8>>(conn))
     }
 
     fn get_conversation_ids_for_requesting_readds(
@@ -1074,7 +1074,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
         use super::schema::{groups::dsl as groups_dsl, remote_commit_log::dsl as rcl_dsl};
         use diesel::dsl::max;
 
-        self.raw_query_read(|conn| {
+        self.raw_query(|conn| {
             groups_dsl::groups
                 .left_join(rcl_dsl::remote_commit_log.on(groups_dsl::id.eq(rcl_dsl::group_id)))
                 .filter(
@@ -1094,7 +1094,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
         use super::schema::{groups::dsl as groups_dsl, readd_status::dsl as readd_dsl};
         use diesel::{ExpressionMethods, JoinOnDsl, QueryDsl};
 
-        self.raw_query_read(|conn| {
+        self.raw_query(|conn| {
             readd_dsl::readd_status
                 .inner_join(groups_dsl::groups.on(readd_dsl::group_id.eq(groups_dsl::id)))
                 .filter(readd_dsl::requested_at_sequence_id.is_not_null())
@@ -1121,7 +1121,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
         let query = dsl::groups
             .filter(dsl::id.eq(group_id))
             .select(dsl::conversation_type);
-        let conversation_type = self.raw_query_read(|conn| query.first(conn))?;
+        let conversation_type = self.raw_query(|conn| query.first(conn))?;
         Ok(conversation_type)
     }
 
@@ -1131,7 +1131,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
         public_key: &[u8],
     ) -> Result<(), StorageError> {
         use crate::schema::groups::dsl;
-        let num_updated = self.raw_query_write(|conn| {
+        let num_updated = self.raw_query(|conn| {
             diesel::update(dsl::groups)
                 .filter(
                     dsl::id
@@ -1155,7 +1155,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
         is_forked: Option<bool>,
     ) -> Result<(), StorageError> {
         use crate::schema::groups::dsl;
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             diesel::update(dsl::groups.find(group_id))
                 .set(dsl::is_commit_log_forked.eq(is_forked))
                 .execute(conn)
@@ -1168,7 +1168,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
         group_id: &[u8],
     ) -> Result<Option<bool>, StorageError> {
         use crate::schema::groups::dsl;
-        self.raw_query_read(|conn| {
+        self.raw_query(|conn| {
             dsl::groups
                 .find(group_id)
                 .select(dsl::is_commit_log_forked)
@@ -1183,7 +1183,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
         has_pending_leave_request: Option<bool>,
     ) -> Result<(), StorageError> {
         use crate::schema::groups::dsl;
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             diesel::update(dsl::groups.find(group_id))
                 .set(dsl::has_pending_leave_request.eq(has_pending_leave_request))
                 .execute(conn)
@@ -1202,7 +1202,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
             )
             .select(dsl::id);
 
-        self.raw_query_read(|conn| query.load::<Vec<u8>>(conn))
+        self.raw_query(|conn| query.load::<Vec<u8>>(conn))
     }
 }
 
@@ -1410,7 +1410,7 @@ pub(crate) mod tests {
 
             test_group.store(conn).unwrap();
             assert_eq!(
-                conn.raw_query_read(|raw_conn| groups.first::<StoredGroup>(raw_conn))
+                conn.raw_query(|raw_conn| groups.first::<StoredGroup>(raw_conn))
                     .unwrap(),
                 test_group
             );
@@ -1422,7 +1422,7 @@ pub(crate) mod tests {
         with_connection(|conn| {
             let test_group = generate_group(None);
 
-            conn.raw_query_write(|raw_conn| {
+            conn.raw_query(|raw_conn| {
                 diesel::insert_into(groups)
                     .values(test_group.clone())
                     .execute(raw_conn)
@@ -1580,7 +1580,7 @@ pub(crate) mod tests {
         with_connection(|conn| {
             let test_group = generate_group(None);
 
-            conn.raw_query_write(|raw_conn| {
+            conn.raw_query(|raw_conn| {
                 diesel::insert_into(groups)
                     .values(test_group.clone())
                     .execute(raw_conn)

--- a/crates/xmtp_db/src/encrypted_store/group/dms.rs
+++ b/crates/xmtp_db/src/encrypted_store/group/dms.rs
@@ -38,7 +38,7 @@ where
 impl<C: ConnectionExt> QueryDms for DbConnection<C> {
     /// Same behavior as fetched, but will stitch DM groups
     fn fetch_stitched(&self, key: &[u8]) -> Result<Option<StoredGroup>, ConnectionError> {
-        let group = self.raw_query_read(|conn| {
+        let group = self.raw_query(|conn| {
             groups::table
                 .filter(groups::id.eq(key))
                 .first::<StoredGroup>(conn)
@@ -55,7 +55,7 @@ impl<C: ConnectionExt> QueryDms for DbConnection<C> {
         };
 
         // Otherwise, return the stitched DM
-        self.raw_query_read(|conn| {
+        self.raw_query(|conn| {
             groups::table
                 .filter(groups::dm_id.eq(dm_id))
                 .order_by(groups::last_message_ns.desc())
@@ -73,14 +73,14 @@ impl<C: ConnectionExt> QueryDms for DbConnection<C> {
             .filter(dsl::membership_state.ne(GroupMembershipState::Restored))
             .order_by(dsl::last_message_ns.desc());
 
-        self.raw_query_read(|conn| query.first(conn).optional())
+        self.raw_query(|conn| query.first(conn).optional())
     }
 
     /// Load the other DMs that are stitched into this group
     fn other_dms(&self, group_id: &[u8]) -> Result<Vec<StoredGroup>, ConnectionError> {
         let query = dsl::groups.filter(dsl::id.eq(group_id));
 
-        let groups: Vec<StoredGroup> = self.raw_query_read(|conn| query.load(conn))?;
+        let groups: Vec<StoredGroup> = self.raw_query(|conn| query.load(conn))?;
 
         // Grab the dm_id of the group
         let Some(StoredGroup {
@@ -96,7 +96,7 @@ impl<C: ConnectionExt> QueryDms for DbConnection<C> {
             .filter(dsl::dm_id.eq(dm_id))
             .filter(dsl::id.ne(id));
 
-        let other_dms: Vec<StoredGroup> = self.raw_query_read(|conn| query.load(conn))?;
+        let other_dms: Vec<StoredGroup> = self.raw_query(|conn| query.load(conn))?;
         Ok(other_dms)
     }
 }

--- a/crates/xmtp_db/src/encrypted_store/group/version.rs
+++ b/crates/xmtp_db/src/encrypted_store/group/version.rs
@@ -31,7 +31,7 @@ impl<C: ConnectionExt> QueryGroupVersion for DbConnection<C> {
     fn set_group_paused(&self, group_id: &[u8], min_version: &str) -> Result<(), StorageError> {
         use crate::schema::groups::dsl;
 
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             diesel::update(dsl::groups.filter(dsl::id.eq(group_id)))
                 .set(dsl::paused_for_version.eq(Some(min_version.to_string())))
                 .execute(conn)
@@ -43,7 +43,7 @@ impl<C: ConnectionExt> QueryGroupVersion for DbConnection<C> {
     fn unpause_group(&self, group_id: &[u8]) -> Result<(), StorageError> {
         use crate::schema::groups::dsl;
 
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             diesel::update(dsl::groups.filter(dsl::id.eq(group_id)))
                 .set(dsl::paused_for_version.eq::<Option<String>>(None))
                 .execute(conn)
@@ -55,7 +55,7 @@ impl<C: ConnectionExt> QueryGroupVersion for DbConnection<C> {
     fn get_group_paused_version(&self, group_id: &[u8]) -> Result<Option<String>, StorageError> {
         use crate::schema::groups::dsl;
 
-        let paused_version = self.raw_query_read(|conn| {
+        let paused_version = self.raw_query(|conn| {
             dsl::groups
                 .select(dsl::paused_for_version)
                 .filter(dsl::id.eq(group_id))

--- a/crates/xmtp_db/src/encrypted_store/group_intent.rs
+++ b/crates/xmtp_db/src/encrypted_store/group_intent.rs
@@ -141,9 +141,8 @@ impl_fetch!(StoredGroupIntent, group_intents, ID);
 impl<C: ConnectionExt> Delete<StoredGroupIntent> for DbConnection<C> {
     type Key = ID;
     fn delete(&self, key: ID) -> Result<usize, StorageError> {
-        Ok(self.raw_query_write(|raw_conn| {
-            diesel::delete(dsl::group_intents.find(key)).execute(raw_conn)
-        })?)
+        Ok(self
+            .raw_query(|raw_conn| diesel::delete(dsl::group_intents.find(key)).execute(raw_conn))?)
     }
 }
 
@@ -331,7 +330,7 @@ impl<C: ConnectionExt> QueryGroupIntent for DbConnection<C> {
         &self,
         to_save: NewGroupIntent,
     ) -> Result<StoredGroupIntent, crate::ConnectionError> {
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             diesel::insert_into(dsl::group_intents)
                 .values(to_save)
                 .get_result(conn)
@@ -361,7 +360,7 @@ impl<C: ConnectionExt> QueryGroupIntent for DbConnection<C> {
 
         query = query.order(dsl::id.asc());
 
-        self.raw_query_read(|conn| query.load::<StoredGroupIntent>(conn))
+        self.raw_query(|conn| query.load::<StoredGroupIntent>(conn))
     }
 
     // Set the intent with the given ID to `Published` and set the payload hash. Optionally add
@@ -374,7 +373,7 @@ impl<C: ConnectionExt> QueryGroupIntent for DbConnection<C> {
         staged_commit: Option<Vec<u8>>,
         published_in_epoch: i64,
     ) -> Result<(), StorageError> {
-        let rows_changed = self.raw_query_write(|conn| {
+        let rows_changed = self.raw_query(|conn| {
             diesel::update(dsl::group_intents)
                 .filter(dsl::id.eq(intent_id))
                 // State machine requires that the only valid state transition to Published is from
@@ -391,7 +390,7 @@ impl<C: ConnectionExt> QueryGroupIntent for DbConnection<C> {
         })?;
 
         if rows_changed == 0 {
-            let already_published = self.raw_query_read(|conn| {
+            let already_published = self.raw_query(|conn| {
                 dsl::group_intents
                     .filter(dsl::id.eq(intent_id))
                     .first::<StoredGroupIntent>(conn)
@@ -412,7 +411,7 @@ impl<C: ConnectionExt> QueryGroupIntent for DbConnection<C> {
         intent_id: ID,
         cursor: Cursor,
     ) -> Result<(), StorageError> {
-        let rows_changed: usize = self.raw_query_write(|conn| {
+        let rows_changed: usize = self.raw_query(|conn| {
             diesel::update(dsl::group_intents)
                 .filter(dsl::id.eq(intent_id))
                 // State machine requires that the only valid state transition to Committed is from
@@ -436,7 +435,7 @@ impl<C: ConnectionExt> QueryGroupIntent for DbConnection<C> {
 
     // Set the intent with the given ID to `Committed`
     fn set_group_intent_processed(&self, intent_id: ID) -> Result<(), StorageError> {
-        let rows_changed = self.raw_query_write(|conn| {
+        let rows_changed = self.raw_query(|conn| {
             diesel::update(dsl::group_intents)
                 .filter(dsl::id.eq(intent_id))
                 .set(dsl::state.eq(IntentState::Processed))
@@ -454,7 +453,7 @@ impl<C: ConnectionExt> QueryGroupIntent for DbConnection<C> {
     // Set the intent with the given ID to `ToPublish`. Wipe any values for `payload_hash` and
     // `post_commit_data`
     fn set_group_intent_to_publish(&self, intent_id: ID) -> Result<(), StorageError> {
-        let rows_changed = self.raw_query_write(|conn| {
+        let rows_changed = self.raw_query(|conn| {
             diesel::update(dsl::group_intents)
                 .filter(dsl::id.eq(intent_id))
                 // State machine requires that the only valid state transition to ToPublish is from
@@ -480,7 +479,7 @@ impl<C: ConnectionExt> QueryGroupIntent for DbConnection<C> {
     /// Set the intent with the given ID to `Error`
     #[tracing::instrument(level = "trace", skip(self))]
     fn set_group_intent_error(&self, intent_id: ID) -> Result<(), StorageError> {
-        let rows_changed = self.raw_query_write(|conn| {
+        let rows_changed = self.raw_query(|conn| {
             diesel::update(dsl::group_intents)
                 .filter(dsl::id.eq(intent_id))
                 .set(dsl::state.eq(IntentState::Error))
@@ -505,7 +504,7 @@ impl<C: ConnectionExt> QueryGroupIntent for DbConnection<C> {
         &self,
         payload_hash: &[u8],
     ) -> Result<Option<StoredGroupIntent>, StorageError> {
-        let result = self.raw_query_read(|conn| {
+        let result = self.raw_query(|conn| {
             dsl::group_intents
                 .filter(dsl::payload_hash.eq(payload_hash))
                 .first::<StoredGroupIntent>(conn)
@@ -529,7 +528,7 @@ impl<C: ConnectionExt> QueryGroupIntent for DbConnection<C> {
             .map(|h| PayloadHashRef::from(h.as_ref()));
 
         // Query all dependencies in a single database call
-        let map: HashMap<PayloadHash, Vec<IntentDependency>> = self.raw_query_read(|conn| {
+        let map: HashMap<PayloadHash, Vec<IntentDependency>> = self.raw_query(|conn| {
             dsl::group_intents
                 .filter(dsl::payload_hash.eq_any(hashes))
                 .inner_join(
@@ -582,7 +581,7 @@ impl<C: ConnectionExt> QueryGroupIntent for DbConnection<C> {
     }
 
     fn increment_intent_publish_attempt_count(&self, intent_id: ID) -> Result<(), StorageError> {
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             diesel::update(dsl::group_intents)
                 .filter(dsl::id.eq(intent_id))
                 .set(dsl::publish_attempts.eq(dsl::publish_attempts + 1))
@@ -707,7 +706,7 @@ pub(crate) mod tests {
         conn: &DbConnection<C>,
         group_id: group::ID,
     ) -> StoredGroupIntent {
-        conn.raw_query_read(|raw_conn| {
+        conn.raw_query(|raw_conn| {
             dsl::group_intents
                 .filter(dsl::group_id.eq(group_id))
                 .first(raw_conn)

--- a/crates/xmtp_db/src/encrypted_store/group_message.rs
+++ b/crates/xmtp_db/src/encrypted_store/group_message.rs
@@ -414,7 +414,7 @@ where
     type Output = ();
     fn store(&self, into: &C) -> Result<(), crate::StorageError> {
         let new_msg = NewStoredGroupMessage::from(self);
-        into.raw_query_write::<_, _>(|conn| {
+        into.raw_query::<_, _>(|conn| {
             diesel::insert_into(group_messages::table)
                 .values(&new_msg)
                 .execute(conn)
@@ -433,7 +433,7 @@ where
 
     fn store_or_ignore(&self, into: &C) -> Result<(), crate::StorageError> {
         let new_msg = NewStoredGroupMessage::from(self);
-        into.raw_query_write(|conn| {
+        into.raw_query(|conn| {
             diesel::insert_or_ignore_into(group_messages::table)
                 .values(&new_msg)
                 .execute(conn)
@@ -873,7 +873,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
             query = query.limit(limit);
         }
 
-        self.raw_query_read(|conn| query.load::<StoredGroupMessage>(conn))
+        self.raw_query(|conn| query.load::<StoredGroupMessage>(conn))
     }
 
     /// Count group messages matching the given criteria
@@ -885,7 +885,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
         use crate::schema::{group_messages::dsl, groups::dsl as groups_dsl};
 
         // Check if this is a DM group
-        let is_dm = self.raw_query_read(|conn| {
+        let is_dm = self.raw_query(|conn| {
             groups_dsl::groups
                 .filter(groups_dsl::id.eq(group_id))
                 .select(groups_dsl::conversation_type)
@@ -917,7 +917,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
         query = apply_message_filters!(query, args);
 
         let count =
-            self.raw_query_read(|conn| query.select(diesel::dsl::count_star()).first::<i64>(conn))?;
+            self.raw_query(|conn| query.select(diesel::dsl::count_star()).first::<i64>(conn))?;
 
         Ok(count)
     }
@@ -962,7 +962,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
 
         query = query.limit(limit.unwrap_or(100)).offset(offset);
 
-        self.raw_query_read(|conn| {
+        self.raw_query(|conn| {
             query
                 .select(group_messages::all_columns)
                 .load::<StoredGroupMessage>(conn)
@@ -1016,7 +1016,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
         };
 
         let reactions: Vec<StoredGroupMessage> =
-            self.raw_query_read(|conn| reactions_query.load::<StoredGroupMessage>(conn))?;
+            self.raw_query(|conn| reactions_query.load::<StoredGroupMessage>(conn))?;
 
         // Group reactions by parent message id
         let mut reactions_by_reference: HashMap<Vec<u8>, Vec<StoredGroupMessage>> = HashMap::new();
@@ -1077,7 +1077,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
         }
 
         let raw_inbound_relations: Vec<StoredGroupMessage> =
-            self.raw_query_read(|conn| inbound_relations_query.load::<StoredGroupMessage>(conn))?;
+            self.raw_query(|conn| inbound_relations_query.load::<StoredGroupMessage>(conn))?;
 
         for inbound_reference in raw_inbound_relations {
             if let Some(reference_id) = &inbound_reference.reference_id {
@@ -1102,7 +1102,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
             .into_boxed();
 
         let raw_outbound_references: Vec<StoredGroupMessage> =
-            self.raw_query_read(|conn| outbound_references_query.load::<StoredGroupMessage>(conn))?;
+            self.raw_query(|conn| outbound_references_query.load::<StoredGroupMessage>(conn))?;
 
         Ok(raw_outbound_references
             .into_iter()
@@ -1129,7 +1129,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
         }
 
         let raw_counts: Vec<(Option<Vec<u8>>, i64)> =
-            self.raw_query_read(|conn| count_query.load(conn))?;
+            self.raw_query(|conn| count_query.load(conn))?;
 
         Ok(raw_counts
             .into_iter()
@@ -1149,8 +1149,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
             .select((dsl::sender_inbox_id, diesel::dsl::max(dsl::sent_at_ns)))
             .into_boxed();
 
-        let raw_results: Vec<(String, Option<i64>)> =
-            self.raw_query_read(|conn| query.load(conn))?;
+        let raw_results: Vec<(String, Option<i64>)> = self.raw_query(|conn| query.load(conn))?;
 
         Ok(raw_results
             .into_iter()
@@ -1165,7 +1164,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
         &self,
         id: MessageId,
     ) -> Result<Option<StoredGroupMessage>, crate::ConnectionError> {
-        self.raw_query_read(|conn| {
+        self.raw_query(|conn| {
             dsl::group_messages
                 .filter(dsl::id.eq(id.as_ref()))
                 .first::<StoredGroupMessage>(conn)
@@ -1178,7 +1177,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
         &self,
         id: MessageId,
     ) -> Result<Option<StoredGroupMessage>, crate::ConnectionError> {
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             dsl::group_messages
                 .filter(dsl::id.eq(id.as_ref()))
                 .first::<StoredGroupMessage>(conn)
@@ -1191,7 +1190,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
         group_id: GroupId,
         timestamp: i64,
     ) -> Result<Option<StoredGroupMessage>, crate::ConnectionError> {
-        self.raw_query_read(|conn| {
+        self.raw_query(|conn| {
             dsl::group_messages
                 .filter(dsl::group_id.eq(group_id.as_ref()))
                 .filter(dsl::sent_at_ns.eq(&timestamp))
@@ -1205,7 +1204,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
         group_id: GroupId,
         cursor: Cursor,
     ) -> Result<Option<StoredGroupMessage>, crate::ConnectionError> {
-        self.raw_query_read(|conn| {
+        self.raw_query(|conn| {
             dsl::group_messages
                 .filter(dsl::group_id.eq(group_id.as_ref()))
                 .filter(dsl::sequence_id.eq(cursor.sequence_id as i64))
@@ -1227,7 +1226,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
             hex::encode(msg_id),
             cursor
         );
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             diesel::update(dsl::group_messages)
                 .filter(dsl::id.eq(msg_id.as_ref()))
                 .set((
@@ -1245,7 +1244,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
         &self,
         msg_id: &MessageId,
     ) -> Result<usize, crate::ConnectionError> {
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             diesel::update(dsl::group_messages)
                 .filter(dsl::id.eq(msg_id.as_ref()))
                 .set((dsl::delivery_status.eq(DeliveryStatus::Failed),))
@@ -1254,7 +1253,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
     }
 
     fn delete_expired_messages(&self) -> Result<Vec<StoredGroupMessage>, crate::ConnectionError> {
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             use diesel::prelude::*;
             let now = now_ns();
 
@@ -1274,7 +1273,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
         &self,
         message_id: MessageId,
     ) -> Result<usize, crate::ConnectionError> {
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             use diesel::prelude::*;
             diesel::delete(dsl::group_messages.filter(dsl::id.eq(message_id.as_ref())))
                 .execute(conn)
@@ -1349,7 +1348,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
             }
 
             // Execute the query
-            let messages: Vec<(i64, i64)> = self.raw_query_read(|conn| {
+            let messages: Vec<(i64, i64)> = self.raw_query(|conn| {
                 dsl::group_messages
                     .select((dsl::originator_id, dsl::sequence_id))
                     .filter(batch_filter)
@@ -1380,7 +1379,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
             query = query.filter(dsl::sent_at_ns.lt(limit));
         }
 
-        self.raw_query_write(|conn| query.execute(conn))
+        self.raw_query(|conn| query.execute(conn))
     }
 }
 

--- a/crates/xmtp_db/src/encrypted_store/group_message/tests.rs
+++ b/crates/xmtp_db/src/encrypted_store/group_message/tests.rs
@@ -158,7 +158,7 @@ fn it_gets_many_messages() {
         }
 
         let count: i64 = conn
-            .raw_query_read(|raw_conn| {
+            .raw_query(|raw_conn| {
                 dsl::group_messages
                     .select(diesel::dsl::count_star())
                     .first(raw_conn)

--- a/crates/xmtp_db/src/encrypted_store/icebox.rs
+++ b/crates/xmtp_db/src/encrypted_store/icebox.rs
@@ -125,7 +125,7 @@ impl<C: ConnectionExt> DbConnection<C> {
         &self,
         query_str: String,
     ) -> Result<Vec<OrphanedEnvelope>, crate::ConnectionError> {
-        self.raw_query_read(|conn| {
+        self.raw_query(|conn| {
             diesel::sql_query(query_str)
                 .load_iter::<IceboxWithDep, _>(conn)?
                 .process_results(|iter| {
@@ -133,7 +133,7 @@ impl<C: ConnectionExt> DbConnection<C> {
                     // to optimize, we load a *const [u8] into `IceboxWithDep` for group_id and
                     // envelope_payload, cloning it only once in `fold_with`.
                     // as long as we are in the scope of `load_iter` (attached to the lifetime of
-                    // `conn` or `&mut SqliteConnection` within `raw_query_read`) the lifetime of group_id and
+                    // `conn` or `&mut SqliteConnection` within `raw_query`) the lifetime of group_id and
                     // envelope_payload is safe.
                     // the other raw pointers are safe as long as they aren't accessed once
                     // iteration ends, which is guaranteed by the end of grouping operation and
@@ -302,7 +302,7 @@ impl<C: ConnectionExt> QueryIcebox for DbConnection<C> {
         if orphans.is_empty() {
             return Ok(0);
         }
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             conn.transaction::<_, diesel::result::Error, _>(|conn| {
                 let mut total = 0;
 
@@ -332,7 +332,7 @@ impl<C: ConnectionExt> QueryIcebox for DbConnection<C> {
         use super::refresh_state::EntityKind;
         use super::schema::{icebox, refresh_state};
 
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             diesel::delete(
                 icebox::table.filter(diesel::dsl::exists(
                     refresh_state::table
@@ -720,9 +720,8 @@ mod tests {
             );
 
             // Verify entry 30 remains
-            let mut remaining: Vec<Icebox> = conn.raw_query_read(|conn| {
-                dsl::icebox.filter(dsl::group_id.eq(&group_id)).load(conn)
-            })?;
+            let mut remaining: Vec<Icebox> =
+                conn.raw_query(|conn| dsl::icebox.filter(dsl::group_id.eq(&group_id)).load(conn))?;
             remaining.sort_by_key(|e| e.originator_id);
 
             assert_eq!(remaining.len(), 2, "Should have 2 entries remaining");
@@ -770,9 +769,8 @@ mod tests {
             let deleted = conn.prune_icebox()?;
             assert_eq!(deleted, 0, "Should not delete any entries");
 
-            let remaining: Vec<Icebox> = conn.raw_query_read(|conn| {
-                dsl::icebox.filter(dsl::group_id.eq(&group_id)).load(conn)
-            })?;
+            let remaining: Vec<Icebox> =
+                conn.raw_query(|conn| dsl::icebox.filter(dsl::group_id.eq(&group_id)).load(conn))?;
             assert_eq!(remaining.len(), 2);
         })
     }
@@ -807,9 +805,8 @@ mod tests {
             let deleted = conn.prune_icebox()?;
             assert_eq!(deleted, 0, "Should not delete due to wrong entity_kind");
 
-            let remaining: Vec<Icebox> = conn.raw_query_read(|conn| {
-                dsl::icebox.filter(dsl::group_id.eq(&group_id)).load(conn)
-            })?;
+            let remaining: Vec<Icebox> =
+                conn.raw_query(|conn| dsl::icebox.filter(dsl::group_id.eq(&group_id)).load(conn))?;
             assert_eq!(remaining.len(), 1);
         })
     }
@@ -834,7 +831,7 @@ mod tests {
             conn.ice(orphans)?;
 
             use crate::schema::icebox_dependencies::dsl as dep_dsl;
-            let deps: Vec<IceboxDependency> = conn.raw_query_read(|conn| {
+            let deps: Vec<IceboxDependency> = conn.raw_query(|conn| {
                 icebox_dependencies::table
                     .filter(dep_dsl::envelope_originator_id.eq(1))
                     .filter(dep_dsl::envelope_sequence_id.eq(10))
@@ -853,12 +850,11 @@ mod tests {
             let deleted = conn.prune_icebox()?;
             assert_eq!(deleted, 1, "Should delete the icebox entry");
 
-            let remaining: Vec<Icebox> = conn.raw_query_read(|conn| {
-                dsl::icebox.filter(dsl::group_id.eq(&group_id)).load(conn)
-            })?;
+            let remaining: Vec<Icebox> =
+                conn.raw_query(|conn| dsl::icebox.filter(dsl::group_id.eq(&group_id)).load(conn))?;
             assert_eq!(remaining.len(), 0);
 
-            let deps: Vec<IceboxDependency> = conn.raw_query_read(|conn| {
+            let deps: Vec<IceboxDependency> = conn.raw_query(|conn| {
                 icebox_dependencies::table
                     .filter(dep_dsl::envelope_originator_id.eq(1))
                     .filter(dep_dsl::envelope_sequence_id.eq(10))

--- a/crates/xmtp_db/src/encrypted_store/identity.rs
+++ b/crates/xmtp_db/src/encrypted_store/identity.rs
@@ -76,7 +76,7 @@ where
 
 impl<C: ConnectionExt> QueryIdentity for DbConnection<C> {
     fn queue_key_package_rotation(&self) -> Result<(), StorageError> {
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             let rotate_at_ns = now_ns() + KEY_PACKAGE_QUEUE_INTERVAL_NS;
             diesel::update(dsl::identity)
                 .filter(dsl::next_key_package_rotation_ns.gt(rotate_at_ns))
@@ -95,7 +95,7 @@ impl<C: ConnectionExt> QueryIdentity for DbConnection<C> {
     ) -> Result<(), StorageError> {
         use crate::schema::identity::dsl;
 
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             diesel::update(dsl::identity)
                 .filter(
                     dsl::next_key_package_rotation_ns
@@ -113,7 +113,7 @@ impl<C: ConnectionExt> QueryIdentity for DbConnection<C> {
     fn is_identity_needs_rotation(&self) -> Result<bool, StorageError> {
         use crate::schema::identity::dsl;
 
-        let next_rotation_opt: Option<i64> = self.raw_query_read(|conn| {
+        let next_rotation_opt: Option<i64> = self.raw_query(|conn| {
             dsl::identity
                 .select(dsl::next_key_package_rotation_ns)
                 .first::<Option<i64>>(conn)

--- a/crates/xmtp_db/src/encrypted_store/identity_cache.rs
+++ b/crates/xmtp_db/src/encrypted_store/identity_cache.rs
@@ -140,7 +140,7 @@ impl<C: ConnectionExt> QueryIdentityCache for DbConnection<C> {
         }
 
         let result = self
-            .raw_query_read(|conn| conditions.load::<IdentityCache>(conn))?
+            .raw_query(|conn| conditions.load::<IdentityCache>(conn))?
             .into_iter()
             .map(|entry| (entry.identity, entry.inbox_id))
             .collect();

--- a/crates/xmtp_db/src/encrypted_store/identity_update.rs
+++ b/crates/xmtp_db/src/encrypted_store/identity_update.rs
@@ -146,7 +146,7 @@ impl<C: ConnectionExt> QueryIdentityUpdates for DbConnection<C> {
             query = query.filter(dsl::sequence_id.le(sequence_id));
         }
 
-        self.raw_query_read(|conn| query.load::<StoredIdentityUpdate>(conn))
+        self.raw_query(|conn| query.load::<StoredIdentityUpdate>(conn))
     }
 
     /// Batch insert identity updates, ignoring duplicates.
@@ -155,7 +155,7 @@ impl<C: ConnectionExt> QueryIdentityUpdates for DbConnection<C> {
         &self,
         updates: &[StoredIdentityUpdate],
     ) -> Result<(), crate::ConnectionError> {
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             diesel::insert_or_ignore_into(dsl::identity_updates)
                 .values(updates)
                 .execute(conn)
@@ -174,7 +174,7 @@ impl<C: ConnectionExt> QueryIdentityUpdates for DbConnection<C> {
             .filter(dsl::inbox_id.eq(inbox_id))
             .into_boxed();
 
-        self.raw_query_read(|conn| query.first::<i64>(conn))
+        self.raw_query(|conn| query.first::<i64>(conn))
     }
 
     /// Given a list of inbox_ids return a HashMap of each inbox ID -> highest known sequence ID
@@ -191,7 +191,7 @@ impl<C: ConnectionExt> QueryIdentityUpdates for DbConnection<C> {
 
         // Get the results as a Vec of (inbox_id, sequence_id) tuples
         let result_tuples: Vec<(String, i64)> = self
-            .raw_query_read(|conn| query.load::<(String, Option<i64>)>(conn))?
+            .raw_query(|conn| query.load::<(String, Option<i64>)>(conn))?
             .into_iter()
             // Diesel needs an Option type for aggregations like max(sequence_id), so we
             // unwrap the option here
@@ -213,7 +213,7 @@ impl<C: ConnectionExt> QueryIdentityUpdates for DbConnection<C> {
             .group_by(dsl::inbox_id)
             .select((dsl::inbox_id, count_star()))
             .filter(dsl::inbox_id.eq_any(inbox_ids));
-        self.raw_query_read(|conn| {
+        self.raw_query(|conn| {
             query
                 .load_iter::<(String, i64), _>(conn)?
                 .collect::<Result<HashMap<_, _>, _>>()

--- a/crates/xmtp_db/src/encrypted_store/key_package_history.rs
+++ b/crates/xmtp_db/src/encrypted_store/key_package_history.rs
@@ -115,7 +115,7 @@ impl<C: ConnectionExt> QueryKeyPackageHistory for DbConnection<C> {
         &self,
         hash_ref: Vec<u8>,
     ) -> Result<StoredKeyPackageHistoryEntry, StorageError> {
-        let result = self.raw_query_read(|conn| {
+        let result = self.raw_query(|conn| {
             key_package_history::dsl::key_package_history
                 .filter(key_package_history::dsl::key_package_hash_ref.eq(hash_ref))
                 .first::<StoredKeyPackageHistoryEntry>(conn)
@@ -128,7 +128,7 @@ impl<C: ConnectionExt> QueryKeyPackageHistory for DbConnection<C> {
         &self,
         id: i32,
     ) -> Result<Vec<StoredKeyPackageHistoryEntry>, StorageError> {
-        let result = self.raw_query_read(|conn| {
+        let result = self.raw_query(|conn| {
             key_package_history::dsl::key_package_history
                 .filter(key_package_history::dsl::id.lt(id))
                 .load::<StoredKeyPackageHistoryEntry>(conn)
@@ -140,7 +140,7 @@ impl<C: ConnectionExt> QueryKeyPackageHistory for DbConnection<C> {
     fn mark_key_package_before_id_to_be_deleted(&self, id: i32) -> Result<(), StorageError> {
         use crate::schema::key_package_history::dsl;
         let delete_at_24_hrs_ns = now_ns() + KEYS_EXPIRATION_INTERVAL_NS;
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             diesel::update(
                 dsl::key_package_history
                     .filter(dsl::id.lt(id))
@@ -155,7 +155,7 @@ impl<C: ConnectionExt> QueryKeyPackageHistory for DbConnection<C> {
 
     fn get_expired_key_packages(&self) -> Result<Vec<StoredKeyPackageHistoryEntry>, StorageError> {
         use crate::schema::key_package_history::dsl;
-        self.raw_query_read(|conn| {
+        self.raw_query(|conn| {
             dsl::key_package_history
                 .filter(dsl::delete_at_ns.le(now_ns()))
                 .load::<StoredKeyPackageHistoryEntry>(conn)
@@ -164,7 +164,7 @@ impl<C: ConnectionExt> QueryKeyPackageHistory for DbConnection<C> {
     }
 
     fn delete_key_package_history_up_to_id(&self, id: i32) -> Result<(), StorageError> {
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             diesel::delete(
                 key_package_history::dsl::key_package_history
                     .filter(key_package_history::dsl::id.le(id)),
@@ -176,7 +176,7 @@ impl<C: ConnectionExt> QueryKeyPackageHistory for DbConnection<C> {
     }
 
     fn delete_key_package_entry_with_id(&self, id: i32) -> Result<(), StorageError> {
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             diesel::delete(
                 key_package_history::dsl::key_package_history
                     .filter(key_package_history::dsl::id.eq(id)),

--- a/crates/xmtp_db/src/encrypted_store/key_store_entry.rs
+++ b/crates/xmtp_db/src/encrypted_store/key_store_entry.rs
@@ -18,7 +18,7 @@ impl<C: ConnectionExt> Delete<StoredKeyStoreEntry> for DbConnection<C> {
     type Key = Vec<u8>;
     fn delete(&self, key: Vec<u8>) -> Result<usize, StorageError> where {
         use super::schema::openmls_key_store::dsl::*;
-        Ok(self.raw_query_write(|conn| {
+        Ok(self.raw_query(|conn| {
             diesel::delete(openmls_key_store.filter(key_bytes.eq(key))).execute(conn)
         })?)
     }
@@ -57,7 +57,7 @@ impl<C: ConnectionExt> QueryKeyStoreEntry for DbConnection<C> {
             value_bytes: value,
         };
 
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             diesel::replace_into(openmls_key_store)
                 .values(entry)
                 .execute(conn)

--- a/crates/xmtp_db/src/encrypted_store/local_commit_log.rs
+++ b/crates/xmtp_db/src/encrypted_store/local_commit_log.rs
@@ -191,7 +191,7 @@ impl<C: ConnectionExt> QueryLocalCommitLog for DbConnection<C> {
         &self,
         group_id: &[u8],
     ) -> Result<Vec<LocalCommitLog>, crate::ConnectionError> {
-        self.raw_query_read(|db| {
+        self.raw_query(|db| {
             dsl::local_commit_log
                 .filter(dsl::group_id.eq(group_id))
                 .order_by(dsl::rowid.asc())
@@ -220,7 +220,7 @@ impl<C: ConnectionExt> QueryLocalCommitLog for DbConnection<C> {
             .filter(dsl::rowid.gt(after_cursor))
             .filter(dsl::commit_sequence_id.ne(0));
 
-        self.raw_query_read(|db| match order {
+        self.raw_query(|db| match order {
             LocalCommitLogOrder::AscendingByRowid => query.order_by(dsl::rowid.asc()).load(db),
             LocalCommitLogOrder::DescendingByRowid => query.order_by(dsl::rowid.desc()).load(db),
         })
@@ -230,7 +230,7 @@ impl<C: ConnectionExt> QueryLocalCommitLog for DbConnection<C> {
         &self,
         group_id: &[u8],
     ) -> Result<Option<LocalCommitLog>, crate::ConnectionError> {
-        self.raw_query_read(|db| {
+        self.raw_query(|db| {
             dsl::local_commit_log
                 .filter(dsl::group_id.eq(group_id))
                 .order_by(dsl::rowid.desc())
@@ -250,6 +250,6 @@ impl<C: ConnectionExt> QueryLocalCommitLog for DbConnection<C> {
             .order(dsl::rowid.desc())
             .limit(1);
 
-        self.raw_query_read(|conn| query.first::<i32>(conn).optional())
+        self.raw_query(|conn| query.first::<i32>(conn).optional())
     }
 }

--- a/crates/xmtp_db/src/encrypted_store/message_deletion.rs
+++ b/crates/xmtp_db/src/encrypted_store/message_deletion.rs
@@ -109,7 +109,7 @@ impl<C: ConnectionExt> QueryMessageDeletion for DbConnection<C> {
         &self,
         id: &[u8],
     ) -> Result<Option<StoredMessageDeletion>, crate::ConnectionError> {
-        self.raw_query_read(|conn| {
+        self.raw_query(|conn| {
             dsl::message_deletions
                 .filter(dsl::id.eq(id))
                 .first(conn)
@@ -121,7 +121,7 @@ impl<C: ConnectionExt> QueryMessageDeletion for DbConnection<C> {
         &self,
         deleted_message_id: &[u8],
     ) -> Result<Option<StoredMessageDeletion>, crate::ConnectionError> {
-        self.raw_query_read(|conn| {
+        self.raw_query(|conn| {
             dsl::message_deletions
                 .filter(dsl::deleted_message_id.eq(deleted_message_id))
                 .first(conn)
@@ -137,7 +137,7 @@ impl<C: ConnectionExt> QueryMessageDeletion for DbConnection<C> {
             return Ok(vec![]);
         }
 
-        self.raw_query_read(|conn| {
+        self.raw_query(|conn| {
             dsl::message_deletions
                 .filter(dsl::deleted_message_id.eq_any(message_ids))
                 .load(conn)
@@ -148,7 +148,7 @@ impl<C: ConnectionExt> QueryMessageDeletion for DbConnection<C> {
         &self,
         group_id: &[u8],
     ) -> Result<Vec<StoredMessageDeletion>, crate::ConnectionError> {
-        self.raw_query_read(|conn| {
+        self.raw_query(|conn| {
             dsl::message_deletions
                 .filter(dsl::group_id.eq(group_id))
                 .load(conn)
@@ -156,7 +156,7 @@ impl<C: ConnectionExt> QueryMessageDeletion for DbConnection<C> {
     }
 
     fn is_message_deleted(&self, message_id: &[u8]) -> Result<bool, crate::ConnectionError> {
-        self.raw_query_read(|conn| {
+        self.raw_query(|conn| {
             diesel::dsl::select(diesel::dsl::exists(
                 dsl::message_deletions.filter(dsl::deleted_message_id.eq(message_id)),
             ))

--- a/crates/xmtp_db/src/encrypted_store/migration_test/add_inserted_at_ns.rs
+++ b/crates/xmtp_db/src/encrypted_store/migration_test/add_inserted_at_ns.rs
@@ -7,7 +7,7 @@ use super::*;
 /// Helper function to insert a group message before the migration
 /// (without the inserted_at_ns field)
 fn insert_message_before_migration(db: impl ConnectionExt, group_id: &[u8], payload: Vec<u8>) {
-    db.raw_query_write(|conn| {
+    db.raw_query(|conn| {
         sql_query(
             r#"
             INSERT INTO group_messages (
@@ -42,7 +42,7 @@ fn insert_message_before_migration(db: impl ConnectionExt, group_id: &[u8], payl
 
 /// Helper function to create a group before the migration
 fn insert_group_before_migration(db: impl ConnectionExt, group_id: &[u8]) {
-    db.raw_query_write(|conn| {
+    db.raw_query(|conn| {
         sql_query(
             r#"
             INSERT INTO groups (
@@ -96,7 +96,7 @@ async fn migration_performance_10k_messages() {
 
     // Run just the add_inserted_at_ns migration
     db.conn()
-        .raw_query_write(|conn| {
+        .raw_query(|conn| {
             conn.run_next_migration(MIGRATIONS).unwrap();
             Ok(())
         })
@@ -121,7 +121,7 @@ async fn migration_performance_10k_messages() {
 
     let result: CountResult = db
         .conn()
-        .raw_query_read(|conn| {
+        .raw_query(|conn| {
             sql_query(
                 "SELECT COUNT(*) as count FROM group_messages WHERE inserted_at_ns IS NOT NULL",
             )

--- a/crates/xmtp_db/src/encrypted_store/migration_test/mod.rs
+++ b/crates/xmtp_db/src/encrypted_store/migration_test/mod.rs
@@ -28,7 +28,7 @@ fn migrate(db: impl ConnectionExt, name: &str, index_change: i32) {
     // index is 0-based position, so we need index+1 migrations to include the named one
     // with index_change: -1 = before, 0 = to (including), 1 = after
     let target_index = ((index + 1) as i32 + index_change) as usize;
-    db.raw_query_write(|conn| {
+    db.raw_query(|conn| {
         for _ in 0..target_index {
             conn.run_next_migration(MIGRATIONS).unwrap();
         }
@@ -38,7 +38,7 @@ fn migrate(db: impl ConnectionExt, name: &str, index_change: i32) {
 }
 
 fn finish_migrations(db: impl ConnectionExt) {
-    db.raw_query_write(|conn| {
+    db.raw_query(|conn| {
         conn.run_pending_migrations(MIGRATIONS).unwrap();
         Ok(())
     })

--- a/crates/xmtp_db/src/encrypted_store/migration_test/originator_id_refresh_state.rs
+++ b/crates/xmtp_db/src/encrypted_store/migration_test/originator_id_refresh_state.rs
@@ -11,7 +11,7 @@ use xmtp_proto::types::{Cursor, OriginatorId, SequenceId};
 use super::*;
 
 fn update_cursor(db: impl ConnectionExt, id: &[u8], kind: i32, cursor: i64) {
-    db.raw_query_write(|conn| {
+    db.raw_query(|conn| {
         sql_query(
             r#"
                 INSERT INTO refresh_state (entity_id, entity_kind, cursor)
@@ -34,7 +34,7 @@ fn update_cursor_new(
     sequence_id: i64,
     originator_id: i32,
 ) {
-    db.raw_query_write(|conn| {
+    db.raw_query(|conn| {
         sql_query(
             r#"
                 INSERT INTO refresh_state (entity_id, entity_kind, sequence_id, originator_id)
@@ -52,7 +52,7 @@ fn update_cursor_new(
 }
 
 fn message(db: impl ConnectionExt, group_id: &[u8], kind: i32, sequence_id: i64) {
-    db.raw_query_write(|conn| {
+    db.raw_query(|conn| {
         sql_query(r#"
             INSERT INTO group_messages (id, group_id, decrypted_message_bytes, sent_at_ns, kind, sender_installation_id, sender_inbox_id, delivery_status, content_type, version_major, version_minor, authority_id, sequence_id)
             VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
@@ -77,7 +77,7 @@ fn message(db: impl ConnectionExt, group_id: &[u8], kind: i32, sequence_id: i64)
 }
 
 fn identity_update(db: impl ConnectionExt, inbox_id: &str, sequence_id: i64) {
-    db.raw_query_write(|conn| {
+    db.raw_query(|conn| {
         sql_query(
             r#"
             INSERT INTO identity_updates (inbox_id, sequence_id, server_timestamp_ns, payload)
@@ -96,7 +96,7 @@ fn identity_update(db: impl ConnectionExt, inbox_id: &str, sequence_id: i64) {
 
 fn group(db: impl ConnectionExt, group_id: &[u8], welcome_id: Option<i64>) {
     if let Some(w_id) = welcome_id {
-        db.raw_query_write(|conn| {
+        db.raw_query(|conn| {
             sql_query(r#"
                 INSERT INTO groups (id, created_at_ns, membership_state, installations_last_checked, added_by_inbox_id, rotated_at_ns, conversation_type, maybe_forked, fork_details, should_publish_commit_log, welcome_id)
                 VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
@@ -116,7 +116,7 @@ fn group(db: impl ConnectionExt, group_id: &[u8], welcome_id: Option<i64>) {
                 Ok(())
         }).unwrap();
     } else {
-        db.raw_query_write(|conn| {
+        db.raw_query(|conn| {
             sql_query(r#"
                 INSERT INTO groups (id, created_at_ns, membership_state, installations_last_checked, added_by_inbox_id, rotated_at_ns, conversation_type, maybe_forked, fork_details, should_publish_commit_log)
                 VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
@@ -205,7 +205,7 @@ async fn down_identity_updates() {
     .unwrap();
 
     db.conn()
-        .raw_query_write(|conn| {
+        .raw_query(|conn| {
             conn.revert_last_migration(MIGRATIONS).unwrap();
             Ok(())
         })
@@ -223,7 +223,7 @@ async fn down_identity_updates() {
         #[diesel(sql_type = Blob)]
         payload: Vec<u8>,
     }
-    let results: Vec<OldIdentityUpdate> = db.conn().raw_query_read(|conn| {
+    let results: Vec<OldIdentityUpdate> = db.conn().raw_query(|conn| {
         sql_query("SELECT inbox_id, sequence_id, server_timestamp_ns, payload FROM identity_updates ORDER BY sequence_id")
             .load(conn)
     }).unwrap();
@@ -310,7 +310,7 @@ async fn down() {
     update_cursor_new(db.conn(), &[0, 0, 0], 1, 75, 11); // Welcome, seq_id=75, originator=11
 
     db.conn()
-        .raw_query_write(|conn| {
+        .raw_query(|conn| {
             conn.revert_last_migration(MIGRATIONS).unwrap();
             Ok(())
         })
@@ -332,7 +332,7 @@ async fn down() {
         cursor: i64,
     }
 
-    let results: Vec<OldRefreshState> = db.conn().raw_query_read(|conn| {
+    let results: Vec<OldRefreshState> = db.conn().raw_query(|conn| {
         sql_query("SELECT entity_id, entity_kind, cursor FROM refresh_state ORDER BY entity_id, entity_kind")
             .load(conn)
     }).unwrap();

--- a/crates/xmtp_db/src/encrypted_store/migration_test/update_dm_trigger.rs
+++ b/crates/xmtp_db/src/encrypted_store/migration_test/update_dm_trigger.rs
@@ -4,14 +4,14 @@ use super::*;
 async fn update_dm_trigger() {
     let db = crate::TestDb::create_database(None).await;
     db.conn()
-        .raw_query_read(|c| {
+        .raw_query(|c| {
             db.validate(c).unwrap();
             Ok(())
         })
         .unwrap();
 
     db.conn()
-        .raw_query_write(|conn| {
+        .raw_query(|conn| {
             for _ in 0..25 {
                 conn.run_next_migration(MIGRATIONS).unwrap();
             }
@@ -30,7 +30,7 @@ async fn update_dm_trigger() {
         .unwrap();
 
     db.conn()
-        .raw_query_write(|conn| {
+        .raw_query(|conn| {
             conn.run_pending_migrations(MIGRATIONS).unwrap();
             Ok(())
         })

--- a/crates/xmtp_db/src/encrypted_store/migrations.rs
+++ b/crates/xmtp_db/src/encrypted_store/migrations.rs
@@ -43,7 +43,7 @@ fn get_migrations() -> Result<Vec<Box<dyn Migration<Sqlite>>>, ConnectionError> 
 
 impl<C: ConnectionExt> QueryMigrations for DbConnection<C> {
     fn applied_migrations(&self) -> Result<Vec<String>, ConnectionError> {
-        let applied: Vec<MigrationVersion<'static>> = self.raw_query_read(|conn| {
+        let applied: Vec<MigrationVersion<'static>> = self.raw_query(|conn| {
             conn.applied_migrations()
                 .map_err(diesel::result::Error::QueryBuilderError)
         })?;
@@ -80,7 +80,7 @@ impl<C: ConnectionExt> QueryMigrations for DbConnection<C> {
                 break;
             }
 
-            let result = self.raw_query_write(|conn| {
+            let result = self.raw_query(|conn| {
                 conn.revert_last_migration(MIGRATIONS)
                     .map(|v| v.to_string())
                     .map_err(diesel::result::Error::QueryBuilderError)
@@ -105,7 +105,7 @@ impl<C: ConnectionExt> QueryMigrations for DbConnection<C> {
 
         for migration in &migrations {
             if migration.name().to_string() == name {
-                self.raw_query_write(|c| {
+                self.raw_query(|c| {
                     migration
                         .run(c)
                         .map_err(diesel::result::Error::QueryBuilderError)
@@ -124,7 +124,7 @@ impl<C: ConnectionExt> QueryMigrations for DbConnection<C> {
 
         for migration in &migrations {
             if migration.name().to_string() == name {
-                self.raw_query_write(|c| {
+                self.raw_query(|c| {
                     migration
                         .revert(c)
                         .map_err(diesel::result::Error::QueryBuilderError)
@@ -139,7 +139,7 @@ impl<C: ConnectionExt> QueryMigrations for DbConnection<C> {
     }
 
     fn run_pending_migrations(&self) -> Result<Vec<String>, ConnectionError> {
-        let ran: Vec<String> = self.raw_query_write(|conn| {
+        let ran: Vec<String> = self.raw_query(|conn| {
             conn.run_pending_migrations(MIGRATIONS)
                 .map(|versions| versions.into_iter().map(|v| v.to_string()).collect())
                 .map_err(diesel::result::Error::QueryBuilderError)

--- a/crates/xmtp_db/src/encrypted_store/mod.rs
+++ b/crates/xmtp_db/src/encrypted_store/mod.rs
@@ -192,15 +192,8 @@ impl RetryableError for ConnectionError {
 }
 
 pub trait ConnectionExt: MaybeSend + MaybeSync {
-    /// in order to track transaction context
-    fn raw_query_read<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
-    where
-        F: FnOnce(&mut SqliteConnection) -> Result<T, diesel::result::Error>,
-        Self: Sized;
-
-    /// Run a scoped write-only query
-    /// in order to track transaction context
-    fn raw_query_write<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
+    /// Run a scoped query against the underlying SQLite connection.
+    fn raw_query<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
     where
         F: FnOnce(&mut SqliteConnection) -> Result<T, diesel::result::Error>,
         Self: Sized;
@@ -213,20 +206,12 @@ impl<C> ConnectionExt for &C
 where
     C: ConnectionExt,
 {
-    fn raw_query_read<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
+    fn raw_query<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
     where
         F: FnOnce(&mut SqliteConnection) -> Result<T, diesel::result::Error>,
         Self: Sized,
     {
-        <C as ConnectionExt>::raw_query_read(self, fun)
-    }
-
-    fn raw_query_write<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
-    where
-        F: FnOnce(&mut SqliteConnection) -> Result<T, diesel::result::Error>,
-        Self: Sized,
-    {
-        <C as ConnectionExt>::raw_query_write(self, fun)
+        <C as ConnectionExt>::raw_query(self, fun)
     }
 
     fn disconnect(&self) -> Result<(), ConnectionError> {
@@ -242,20 +227,12 @@ impl<C> ConnectionExt for &mut C
 where
     C: ConnectionExt,
 {
-    fn raw_query_read<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
+    fn raw_query<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
     where
         F: FnOnce(&mut SqliteConnection) -> Result<T, diesel::result::Error>,
         Self: Sized,
     {
-        <C as ConnectionExt>::raw_query_read(self, fun)
-    }
-
-    fn raw_query_write<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
-    where
-        F: FnOnce(&mut SqliteConnection) -> Result<T, diesel::result::Error>,
-        Self: Sized,
-    {
-        <C as ConnectionExt>::raw_query_write(self, fun)
+        <C as ConnectionExt>::raw_query(self, fun)
     }
 
     fn disconnect(&self) -> Result<(), ConnectionError> {
@@ -271,20 +248,12 @@ impl<C> ConnectionExt for Arc<C>
 where
     C: ConnectionExt,
 {
-    fn raw_query_read<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
+    fn raw_query<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
     where
         F: FnOnce(&mut SqliteConnection) -> Result<T, diesel::result::Error>,
         Self: Sized,
     {
-        <C as ConnectionExt>::raw_query_read(self, fun)
-    }
-
-    fn raw_query_write<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
-    where
-        F: FnOnce(&mut SqliteConnection) -> Result<T, diesel::result::Error>,
-        Self: Sized,
-    {
-        <C as ConnectionExt>::raw_query_write(self, fun)
+        <C as ConnectionExt>::raw_query(self, fun)
     }
 
     fn disconnect(&self) -> Result<(), ConnectionError> {
@@ -311,7 +280,7 @@ pub trait XmtpDb: MaybeSend + MaybeSync {
     type DbQuery: crate::DbQuery + MaybeSend + MaybeSync;
 
     fn init(&self) -> Result<(), ConnectionError> {
-        self.conn().raw_query_write(|conn| {
+        self.conn().raw_query(|conn| {
             self.validate(conn).map_err(|e| {
                 diesel::result::Error::DatabaseError(
                     DatabaseErrorKind::Unknown,
@@ -374,7 +343,7 @@ macro_rules! impl_fetch {
             type Key = ();
             fn fetch(&self, _key: &Self::Key) -> Result<Option<$model>, $crate::StorageError> {
                 use $crate::encrypted_store::schema::$table::dsl::*;
-                self.raw_query_read(|conn| $table.first(conn).optional())
+                self.raw_query(|conn| $table.first(conn).optional())
                     .map_err(Into::into)
             }
         }
@@ -388,7 +357,7 @@ macro_rules! impl_fetch {
             type Key = $key;
             fn fetch(&self, key: &Self::Key) -> Result<Option<$model>, $crate::StorageError> {
                 use $crate::encrypted_store::schema::$table::dsl::*;
-                self.raw_query_read::<_, _>(|conn| $table.find(key.clone()).first(conn).optional())
+                self.raw_query::<_, _>(|conn| $table.find(key.clone()).first(conn).optional())
                     .map_err(Into::into)
             }
         }
@@ -404,7 +373,7 @@ macro_rules! impl_fetch_list {
         {
             fn fetch_list(&self) -> Result<Vec<$model>, $crate::StorageError> {
                 use $crate::encrypted_store::schema::$table::dsl::*;
-                self.raw_query_read(|conn| $table.load::<$model>(conn))
+                self.raw_query(|conn| $table.load::<$model>(conn))
                     .map_err(Into::into)
             }
         }
@@ -421,7 +390,7 @@ macro_rules! impl_store {
         {
             type Output = ();
             fn store(&self, into: &C) -> Result<(), $crate::StorageError> {
-                into.raw_query_write::<_, _>(|conn| {
+                into.raw_query::<_, _>(|conn| {
                     diesel::insert_into($table::table)
                         .values(self)
                         .execute(conn)
@@ -445,7 +414,7 @@ macro_rules! impl_store_or_ignore {
             type Output = ();
 
             fn store_or_ignore(&self, into: &C) -> Result<(), $crate::StorageError> {
-                into.raw_query_write(|conn| {
+                into.raw_query(|conn| {
                     diesel::insert_or_ignore_into($table::table)
                         .values(self)
                         .execute(conn)

--- a/crates/xmtp_db/src/encrypted_store/pending_remove.rs
+++ b/crates/xmtp_db/src/encrypted_store/pending_remove.rs
@@ -77,7 +77,7 @@ impl<C: ConnectionExt> QueryPendingRemove for DbConnection<C> {
         &self,
         group_id: &[u8],
     ) -> Result<Vec<String>, crate::ConnectionError> {
-        let result = self.raw_query_read(|conn| {
+        let result = self.raw_query(|conn| {
             dsl::pending_remove
                 .filter(dsl::group_id.eq(group_id))
                 .select(dsl::inbox_id)
@@ -92,7 +92,7 @@ impl<C: ConnectionExt> QueryPendingRemove for DbConnection<C> {
         group_id: &[u8],
         inbox_id: &str,
     ) -> Result<bool, crate::ConnectionError> {
-        let result: bool = self.raw_query_read(|conn| {
+        let result: bool = self.raw_query(|conn| {
             select(exists(dsl::pending_remove.filter(
                 dsl::group_id.eq(group_id).and(dsl::inbox_id.eq(inbox_id)),
             )))
@@ -106,7 +106,7 @@ impl<C: ConnectionExt> QueryPendingRemove for DbConnection<C> {
         group_id: &[u8],
         inbox_ids: Vec<String>,
     ) -> Result<usize, crate::ConnectionError> {
-        let result = self.raw_query_write(|conn| {
+        let result = self.raw_query(|conn| {
             diesel::delete(
                 dsl::pending_remove.filter(
                     dsl::inbox_id

--- a/crates/xmtp_db/src/encrypted_store/pragmas.rs
+++ b/crates/xmtp_db/src/encrypted_store/pragmas.rs
@@ -31,7 +31,7 @@ where
 
 impl<C: ConnectionExt> Pragmas for DbConnection<C> {
     fn busy_timeout(&self) -> Result<i32, crate::ConnectionError> {
-        self.raw_query_read(|conn| {
+        self.raw_query(|conn| {
             let BusyTimeout { timeout } =
                 diesel::sql_query("PRAGMA busy_timeout").get_result::<BusyTimeout>(conn)?;
             Ok(timeout)
@@ -40,7 +40,7 @@ impl<C: ConnectionExt> Pragmas for DbConnection<C> {
 
     fn set_sqlcipher_log<S: AsRef<str>>(&self, level: S) -> Result<(), crate::ConnectionError> {
         let level = level.as_ref();
-        self.raw_query_read(|conn| {
+        self.raw_query(|conn| {
             diesel::sql_query(format!("PRAGMA cipher_log_level = {level}")).execute(conn)?;
             Ok(())
         })

--- a/crates/xmtp_db/src/encrypted_store/processed_device_sync_messages.rs
+++ b/crates/xmtp_db/src/encrypted_store/processed_device_sync_messages.rs
@@ -141,7 +141,7 @@ where
 
 impl<C: ConnectionExt> QueryDeviceSyncMessages for DbConnection<C> {
     fn unprocessed_sync_group_messages(&self) -> Result<Vec<StoredGroupMessage>, StorageError> {
-        let result = self.raw_query_read(|conn| {
+        let result = self.raw_query(|conn| {
             group_messages_dsl::group_messages
                 .inner_join(groups_dsl::groups.on(group_messages_dsl::group_id.eq(groups_dsl::id)))
                 .filter(groups_dsl::conversation_type.eq(ConversationType::Sync))
@@ -170,7 +170,7 @@ impl<C: ConnectionExt> QueryDeviceSyncMessages for DbConnection<C> {
         offset: i64,
         limit: i64,
     ) -> Result<Vec<StoredGroupMessage>, StorageError> {
-        let result = self.raw_query_read(|conn| {
+        let result = self.raw_query(|conn| {
             group_messages_dsl::group_messages
                 .inner_join(groups_dsl::groups.on(group_messages_dsl::group_id.eq(groups_dsl::id)))
                 .filter(groups_dsl::conversation_type.eq(ConversationType::Sync))
@@ -184,7 +184,7 @@ impl<C: ConnectionExt> QueryDeviceSyncMessages for DbConnection<C> {
     }
 
     fn mark_device_sync_msg_as_processed(&self, message_id: &[u8]) -> Result<(), StorageError> {
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             diesel::insert_into(dsl::processed_device_sync_messages)
                 .values(StoredProcessedDeviceSyncMessages {
                     message_id: message_id.to_vec(),
@@ -204,7 +204,7 @@ impl<C: ConnectionExt> QueryDeviceSyncMessages for DbConnection<C> {
         message_id: &[u8],
         max_attempts: i32,
     ) -> Result<i32, StorageError> {
-        let attempts = self.raw_query_write(|conn| {
+        let attempts = self.raw_query(|conn| {
             // Upsert: insert with attempts=1 if no record exists, or increment attempts if it does
             diesel::insert_into(dsl::processed_device_sync_messages)
                 .values(StoredProcessedDeviceSyncMessages {
@@ -327,7 +327,7 @@ mod tests {
             conn.mark_device_sync_msg_as_processed(&message.id)?;
 
             // Verify attempts are preserved (should be 2)
-            let record: StoredProcessedDeviceSyncMessages = conn.raw_query_read(|c| {
+            let record: StoredProcessedDeviceSyncMessages = conn.raw_query(|c| {
                 dsl::processed_device_sync_messages
                     .find(&message.id)
                     .first(c)

--- a/crates/xmtp_db/src/encrypted_store/readd_status.rs
+++ b/crates/xmtp_db/src/encrypted_store/readd_status.rs
@@ -81,7 +81,7 @@ impl<C: ConnectionExt> QueryReaddStatus for DbConnection<C> {
         use super::schema::readd_status::dsl as readd_dsl;
         use diesel::QueryDsl;
 
-        self.raw_query_read(|conn| {
+        self.raw_query(|conn| {
             readd_dsl::readd_status
                 .filter(readd_dsl::group_id.eq(group_id))
                 .filter(readd_dsl::installation_id.eq(installation_id))
@@ -121,7 +121,7 @@ impl<C: ConnectionExt> QueryReaddStatus for DbConnection<C> {
             responded_at_sequence_id: None,
         };
 
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             diesel::insert_into(readd_dsl::readd_status)
                 .values(&new_status)
                 .on_conflict((readd_dsl::group_id, readd_dsl::installation_id))
@@ -154,7 +154,7 @@ impl<C: ConnectionExt> QueryReaddStatus for DbConnection<C> {
             responded_at_sequence_id: Some(sequence_id),
         };
 
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             diesel::insert_into(readd_dsl::readd_status)
                 .values(&new_status)
                 .on_conflict((readd_dsl::group_id, readd_dsl::installation_id))
@@ -179,7 +179,7 @@ impl<C: ConnectionExt> QueryReaddStatus for DbConnection<C> {
         use super::schema::readd_status::dsl as readd_dsl;
         use diesel::{ExpressionMethods, QueryDsl};
 
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             diesel::delete(
                 readd_dsl::readd_status
                     .filter(readd_dsl::group_id.eq(group_id))
@@ -198,7 +198,7 @@ impl<C: ConnectionExt> QueryReaddStatus for DbConnection<C> {
         use super::schema::readd_status::dsl as readd_dsl;
         use diesel::{ExpressionMethods, QueryDsl};
 
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             diesel::delete(
                 readd_dsl::readd_status
                     .filter(readd_dsl::group_id.eq(group_id))
@@ -217,7 +217,7 @@ impl<C: ConnectionExt> QueryReaddStatus for DbConnection<C> {
         use super::schema::readd_status::dsl as readd_dsl;
         use diesel::{ExpressionMethods, QueryDsl};
 
-        self.raw_query_read(|conn| {
+        self.raw_query(|conn| {
             readd_dsl::readd_status
                 .filter(readd_dsl::group_id.eq(group_id))
                 .filter(readd_dsl::installation_id.ne(self_installation_id))

--- a/crates/xmtp_db/src/encrypted_store/refresh_state.rs
+++ b/crates/xmtp_db/src/encrypted_store/refresh_state.rs
@@ -242,7 +242,7 @@ impl<C: ConnectionExt> QueryRefreshState for DbConnection<C> {
     ) -> Result<Option<RefreshState>, StorageError> {
         use super::schema::refresh_state::dsl;
 
-        let res = self.raw_query_read(|conn| {
+        let res = self.raw_query(|conn| {
             dsl::refresh_state
                 .find((entity_id.as_ref(), entity_kind, originator_id as i32))
                 .first(conn)
@@ -262,7 +262,7 @@ impl<C: ConnectionExt> QueryRefreshState for DbConnection<C> {
         let id_ref = id.as_ref();
 
         let originator_ids_i32: Vec<i32> = originator_ids.iter().map(|o| *o as i32).collect();
-        let found_states: Vec<RefreshState> = self.raw_query_read(|conn| {
+        let found_states: Vec<RefreshState> = self.raw_query(|conn| {
             dsl::refresh_state
                 .filter(dsl::entity_id.eq(id_ref))
                 .filter(dsl::entity_kind.eq(entity_kind))
@@ -319,7 +319,7 @@ impl<C: ConnectionExt> QueryRefreshState for DbConnection<C> {
         // Keep chunks comfortably under SQLite's default 999-bind limit.
         const CHUNK: usize = 900;
 
-        let map = self.raw_query_read(|conn| {
+        let map = self.raw_query(|conn| {
             ids.chunks(CHUNK)
                 .map(|chunk| {
                     let id_refs: Vec<&[u8]> = chunk.iter().map(|id| id.as_ref()).collect();
@@ -368,7 +368,7 @@ impl<C: ConnectionExt> QueryRefreshState for DbConnection<C> {
             sequence_id: cursor.sequence_id as i64,
             originator_id: cursor.originator_id as i32,
         };
-        let num_updated = self.raw_query_write(|conn| {
+        let num_updated = self.raw_query(|conn| {
             diesel::insert_into(dsl::refresh_state)
                 .values(&state)
                 .on_conflict((dsl::entity_id, dsl::entity_kind, dsl::originator_id))
@@ -409,7 +409,7 @@ impl<C: ConnectionExt> QueryRefreshState for DbConnection<C> {
 
         let entity_ref = entity_id.as_ref();
 
-        let cursor_map = self.raw_query_read(|conn| {
+        let cursor_map = self.raw_query(|conn| {
             let base_query = dsl::refresh_state
                 .filter(dsl::entity_id.eq(entity_ref))
                 .filter(dsl::entity_kind.eq_any(entities));

--- a/crates/xmtp_db/src/encrypted_store/remote_commit_log.rs
+++ b/crates/xmtp_db/src/encrypted_store/remote_commit_log.rs
@@ -177,7 +177,7 @@ impl<C: ConnectionExt> QueryRemoteCommitLog for DbConnection<C> {
         &self,
         group_id: &[u8],
     ) -> Result<Option<RemoteCommitLog>, crate::ConnectionError> {
-        self.raw_query_read(|db| {
+        self.raw_query(|db| {
             dsl::remote_commit_log
                 .filter(remote_commit_log::group_id.eq(group_id))
                 .order(remote_commit_log::log_sequence_id.desc())
@@ -207,7 +207,7 @@ impl<C: ConnectionExt> QueryRemoteCommitLog for DbConnection<C> {
             .filter(dsl::rowid.gt(after_cursor))
             .filter(dsl::commit_sequence_id.ne(0));
 
-        self.raw_query_read(|db| match order {
+        self.raw_query(|db| match order {
             RemoteCommitLogOrder::AscendingByRowid => query.order_by(dsl::rowid.asc()).load(db),
             RemoteCommitLogOrder::DescendingByRowid => query.order_by(dsl::rowid.desc()).load(db),
         })

--- a/crates/xmtp_db/src/encrypted_store/tasks.rs
+++ b/crates/xmtp_db/src/encrypted_store/tasks.rs
@@ -134,7 +134,7 @@ impl<T: QueryTasks> QueryTasks for &'_ T {
 
 impl<C: ConnectionExt> QueryTasks for DbConnection<C> {
     fn create_task(&self, task: NewTask) -> Result<Task, StorageError> {
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             diesel::insert_into(tasks::table)
                 .values(task)
                 .get_result::<Task>(conn)
@@ -143,12 +143,12 @@ impl<C: ConnectionExt> QueryTasks for DbConnection<C> {
     }
 
     fn get_tasks(&self) -> Result<Vec<Task>, StorageError> {
-        self.raw_query_read(|conn| tasks::table.load::<Task>(conn))
+        self.raw_query(|conn| tasks::table.load::<Task>(conn))
             .map_err(Into::into)
     }
 
     fn get_next_task(&self) -> Result<Option<Task>, StorageError> {
-        self.raw_query_read(|conn| {
+        self.raw_query(|conn| {
             tasks::table
                 .order(tasks::next_attempt_at_ns)
                 .first::<Task>(conn)
@@ -164,7 +164,7 @@ impl<C: ConnectionExt> QueryTasks for DbConnection<C> {
         last_attempted_at_ns: i64,
         next_attempt_at_ns: i64,
     ) -> Result<Task, StorageError> {
-        self.raw_query_write(|conn| {
+        self.raw_query(|conn| {
             diesel::update(tasks::table.filter(tasks::id.eq(id)))
                 .set((
                     tasks::attempts.eq(attempts),
@@ -177,7 +177,7 @@ impl<C: ConnectionExt> QueryTasks for DbConnection<C> {
     }
 
     fn delete_task(&self, id: i32) -> Result<bool, StorageError> {
-        let num_deleted = self.raw_query_write(|conn| {
+        let num_deleted = self.raw_query(|conn| {
             diesel::delete(tasks::table.filter(tasks::id.eq(id))).execute(conn)
         })?;
         Ok(num_deleted == 1)

--- a/crates/xmtp_db/src/encrypted_store/user_preferences.rs
+++ b/crates/xmtp_db/src/encrypted_store/user_preferences.rs
@@ -26,7 +26,7 @@ where
 {
     type Output = ();
     fn store(&self, conn: &C) -> Result<Self::Output, StorageError> {
-        conn.raw_query_write(|conn| {
+        conn.raw_query(|conn| {
             diesel::update(dsl::user_preferences)
                 .set(self)
                 .execute(conn)
@@ -52,12 +52,12 @@ impl HmacKey {
 
 impl StoredUserPreferences {
     pub fn load(conn: impl ConnectionExt) -> Result<Self, StorageError> {
-        let pref = conn.raw_query_read(|conn| dsl::user_preferences.first(conn).optional())?;
+        let pref = conn.raw_query(|conn| dsl::user_preferences.first(conn).optional())?;
         Ok(pref.unwrap_or_default())
     }
 
     fn store(&self, conn: &impl crate::DbQuery) -> Result<(), StorageError> {
-        conn.raw_query_write(|conn| {
+        conn.raw_query(|conn| {
             insert_into(dsl::user_preferences)
                 .values(self)
                 .on_conflict(user_preferences::id)
@@ -120,7 +120,7 @@ mod tests {
             // check that there is only one preference stored
             let query = dsl::user_preferences.order(dsl::id.desc());
             let result = conn
-                .raw_query_read(|conn| query.load::<StoredUserPreferences>(conn))
+                .raw_query(|conn| query.load::<StoredUserPreferences>(conn))
                 .unwrap();
             assert_eq!(result.len(), 1);
         })

--- a/crates/xmtp_db/src/lib.rs
+++ b/crates/xmtp_db/src/lib.rs
@@ -70,13 +70,13 @@ pub trait ReadOnly {
 impl<C: ConnectionExt> ReadOnly for DbConnection<C> {
     #[allow(unused)]
     fn enable_readonly(&self) -> Result<(), StorageError> {
-        self.raw_query_write(|conn| conn.batch_execute("PRAGMA query_only = ON;"))?;
+        self.raw_query(|conn| conn.batch_execute("PRAGMA query_only = ON;"))?;
         Ok(())
     }
 
     #[allow(unused)]
     fn disable_readonly(&self) -> Result<(), StorageError> {
-        self.raw_query_write(|conn| conn.batch_execute("PRAGMA query_only = OFF;"))?;
+        self.raw_query(|conn| conn.batch_execute("PRAGMA query_only = OFF;"))?;
         Ok(())
     }
 }
@@ -199,7 +199,7 @@ pub mod test_util {
             ];
             for query in queries {
                 let query = diesel::sql_query(query);
-                let _ = self.raw_query_write(|conn| query.execute(conn)).unwrap();
+                let _ = self.raw_query(|conn| query.execute(conn)).unwrap();
             }
         }
 
@@ -207,12 +207,12 @@ pub mod test_util {
         pub fn disable_memory_security(&self) {
             let query = r#"PRAGMA cipher_memory_security = OFF"#;
             let query = diesel::sql_query(query);
-            let _ = self.raw_query_read(|c| query.clone().execute(c)).unwrap();
-            let _ = self.raw_query_write(|c| query.execute(c)).unwrap();
+            let _ = self.raw_query(|c| query.clone().execute(c)).unwrap();
+            let _ = self.raw_query(|c| query.execute(c)).unwrap();
         }
 
         pub fn intents_published(&self) -> i32 {
-            self.raw_query_read(|conn| {
+            self.raw_query(|conn| {
                 let mut row = conn
                     .load(sql_query(
                         "SELECT intents_published FROM test_metadata WHERE rowid = 1",
@@ -228,7 +228,7 @@ pub mod test_util {
         }
 
         pub fn intents_processed(&self) -> i32 {
-            self.raw_query_read(|conn| {
+            self.raw_query(|conn| {
                 let mut row = conn
                     .load(sql_query(
                         "SELECT intents_processed FROM test_metadata WHERE rowid = 1",
@@ -244,7 +244,7 @@ pub mod test_util {
         }
 
         pub fn intents_deleted(&self) -> i32 {
-            self.raw_query_read(|conn| {
+            self.raw_query(|conn| {
                 let mut row = conn
                     .load(sql_query("SELECT intents_deleted FROM test_metadata"))
                     .unwrap();
@@ -259,7 +259,7 @@ pub mod test_util {
 
         pub fn intent_payloads_deleted(&self) -> Vec<Vec<u8>> {
             let mut hashes = vec![];
-            self.raw_query_read(|conn| {
+            self.raw_query(|conn| {
                 let row = conn
                     .load(sql_query(
                         "SELECT payload_hash FROM deleted_intents_history",
@@ -280,7 +280,7 @@ pub mod test_util {
         }
 
         pub fn intents_created(&self) -> i32 {
-            self.raw_query_read(|conn| {
+            self.raw_query(|conn| {
                 let mut row = conn
                     .load(sql_query("SELECT intents_created FROM test_metadata"))
                     .unwrap();
@@ -303,12 +303,12 @@ pub mod test_util {
                 .filter(group_messages::kind.eq(GroupMessageKind::Application))
                 .order(group_messages::sequence_id.asc());
 
-            self.raw_query_read(|conn| query.load(conn)).unwrap()
+            self.raw_query(|conn| query.load(conn)).unwrap()
         }
 
         pub fn key_package_rotation_history(&self) -> Vec<(i64, i64)> {
             let mut history = vec![];
-            self.raw_query_read(|conn| {
+            self.raw_query(|conn| {
                  let rows = conn
                      .load(sql_query(
                          "SELECT next_key_package_rotation_ns, updated_at FROM key_package_rotation_history ORDER BY id ASC",
@@ -362,7 +362,7 @@ pub mod test_util {
 
             println!("\n=== group_messages ===");
             let msgs: Vec<crate::group_message::StoredGroupMessage> = self
-                .raw_query_read(|c| crate::schema::group_messages::table.load(c))
+                .raw_query(|c| crate::schema::group_messages::table.load(c))
                 .unwrap_or_default();
             t.column(0).set_header("id");
             t.column(1).set_header("group_id");
@@ -400,7 +400,7 @@ pub mod test_util {
             let mut t = AsciiTable::default();
             println!("\n=== refresh_state ===");
             let states: Vec<crate::refresh_state::RefreshState> = self
-                .raw_query_read(|c| crate::schema::refresh_state::table.load(c))
+                .raw_query(|c| crate::schema::refresh_state::table.load(c))
                 .unwrap_or_default();
             t.column(0).set_header("entity_id");
             t.column(1).set_header("entity_kind");
@@ -430,7 +430,7 @@ pub mod test_util {
             t.column(3).set_header("envelope_payload");
             println!("\n=== icebox ===");
             let ice: Vec<crate::icebox::Icebox> = self
-                .raw_query_read(|c| crate::schema::icebox::table.load(c))
+                .raw_query(|c| crate::schema::icebox::table.load(c))
                 .unwrap_or_default();
             let rows: Vec<Vec<String>> = ice
                 .iter()

--- a/crates/xmtp_db/src/mock.rs
+++ b/crates/xmtp_db/src/mock.rs
@@ -39,16 +39,7 @@ impl AsRef<MockConnection> for MockConnection {
 
 // TODO: We should use diesels test transaction
 impl ConnectionExt for MockConnection {
-    fn raw_query_read<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
-    where
-        F: FnOnce(&mut SqliteConnection) -> Result<T, diesel::result::Error>,
-        Self: Sized,
-    {
-        let mut conn = self.inner.lock();
-        fun(&mut conn).map_err(ConnectionError::from)
-    }
-
-    fn raw_query_write<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
+    fn raw_query<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
     where
         F: FnOnce(&mut SqliteConnection) -> Result<T, diesel::result::Error>,
         Self: Sized,
@@ -847,21 +838,13 @@ mock! {
 }
 
 impl ConnectionExt for MockDbQuery {
-    fn raw_query_read<T, F>(&self, _fun: F) -> Result<T, crate::ConnectionError>
+    fn raw_query<T, F>(&self, _fun: F) -> Result<T, crate::ConnectionError>
     where
         F: FnOnce(&mut SqliteConnection) -> Result<T, diesel::result::Error>,
         Self: Sized,
     {
-        todo!()
-    }
-
-    fn raw_query_write<T, F>(&self, _fun: F) -> Result<T, crate::ConnectionError>
-    where
-        F: FnOnce(&mut SqliteConnection) -> Result<T, diesel::result::Error>,
-        Self: Sized,
-    {
-        // usually OK because we seldom use the result of a write
-        tracing::warn!("unhandled mock raw_query_write");
+        // usually OK because we seldom use the result
+        tracing::warn!("unhandled mock raw_query");
         unsafe {
             let uninit = std::mem::MaybeUninit::<T>::uninit();
             Ok(uninit.assume_init())

--- a/crates/xmtp_db/src/sql_key_store.rs
+++ b/crates/xmtp_db/src/sql_key_store.rs
@@ -111,7 +111,7 @@ where
         &self,
         storage_key: &Vec<u8>,
     ) -> Result<Vec<StorageData>, crate::ConnectionError> {
-        self.conn.raw_query_read(|conn| {
+        self.conn.raw_query(|conn| {
             sql_query(SELECT_QUERY)
                 .bind::<diesel::sql_types::Binary, _>(&storage_key)
                 .bind::<diesel::sql_types::Integer, _>(VERSION as i32)
@@ -124,7 +124,7 @@ where
         storage_key: &Vec<u8>,
         value: &[u8],
     ) -> Result<usize, crate::ConnectionError> {
-        self.conn.raw_query_write(|conn| {
+        self.conn.raw_query(|conn| {
             sql_query(REPLACE_QUERY)
                 .bind::<diesel::sql_types::Binary, _>(&storage_key)
                 .bind::<diesel::sql_types::Integer, _>(VERSION as i32)
@@ -138,7 +138,7 @@ where
         storage_key: &Vec<u8>,
         modified_data: &Vec<u8>,
     ) -> Result<usize, crate::ConnectionError> {
-        self.conn.raw_query_write(|conn| {
+        self.conn.raw_query(|conn| {
             sql_query(UPDATE_QUERY)
                 .bind::<diesel::sql_types::Binary, _>(&modified_data)
                 .bind::<diesel::sql_types::Binary, _>(&storage_key)
@@ -277,7 +277,7 @@ where
         key: &[u8],
     ) -> Result<(), <Self as StorageProvider<CURRENT_VERSION>>::Error> {
         let storage_key = build_key_from_vec::<VERSION>(label, key.to_vec());
-        self.conn.raw_query_write(|conn| {
+        self.conn.raw_query(|conn| {
             sql_query(DELETE_QUERY)
                 .bind::<diesel::sql_types::Binary, _>(&storage_key)
                 .bind::<diesel::sql_types::Integer, _>(VERSION as i32)
@@ -890,7 +890,7 @@ where
 
         let query = "SELECT value_bytes FROM openmls_key_value WHERE key_bytes = ? AND version = ?";
 
-        let data: Vec<StorageData> = self.conn.raw_query_read(|conn| {
+        let data: Vec<StorageData> = self.conn.raw_query(|conn| {
             sql_query(query)
                 .bind::<diesel::sql_types::Binary, _>(&storage_key)
                 .bind::<diesel::sql_types::Integer, _>(CURRENT_VERSION as i32)

--- a/crates/xmtp_db/src/sql_key_store/transactions.rs
+++ b/crates/xmtp_db/src/sql_key_store/transactions.rs
@@ -21,16 +21,7 @@ impl<'a> MutableTransactionConnection<'a> {
 }
 
 impl<'a> ConnectionExt for MutableTransactionConnection<'a> {
-    fn raw_query_read<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
-    where
-        F: FnOnce(&mut SqliteConnection) -> Result<T, diesel::result::Error>,
-        Self: Sized,
-    {
-        let mut conn = self.conn.try_lock().expect("Lock is held somewhere else");
-        fun(&mut conn).map_err(crate::ConnectionError::from)
-    }
-
-    fn raw_query_write<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
+    fn raw_query<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
     where
         F: FnOnce(&mut SqliteConnection) -> Result<T, diesel::result::Error>,
         Self: Sized,
@@ -85,7 +76,7 @@ impl<C: ConnectionExt> XmtpMlsStorageProvider for SqlKeyStore<C> {
         //      transaction starts. Otherwise, we still run into problem #2, even if BUSY_TIMEOUT is
         //      set.
 
-        conn.raw_query_write(|c| Ok(c.immediate_transaction(|sqlite_c| f(sqlite_c))))?
+        conn.raw_query(|c| Ok(c.immediate_transaction(|sqlite_c| f(sqlite_c))))?
     }
 
     fn savepoint<T, E, F>(&self, f: F) -> Result<T, E>
@@ -94,7 +85,7 @@ impl<C: ConnectionExt> XmtpMlsStorageProvider for SqlKeyStore<C> {
         E: From<diesel::result::Error> + From<crate::ConnectionError> + std::error::Error,
     {
         self.conn
-            .raw_query_write(|c| Ok(c.transaction(|sqlite_c| f(sqlite_c))))?
+            .raw_query(|c| Ok(c.transaction(|sqlite_c| f(sqlite_c))))?
     }
 
     fn read<V: Entity<CURRENT_VERSION>>(
@@ -133,7 +124,7 @@ impl<C: ConnectionExt> XmtpMlsStorageProvider for SqlKeyStore<C> {
     #[cfg(feature = "test-utils")]
     fn hash_all(&self) -> Result<Vec<u8>, SqlKeyStoreError> {
         self.conn
-            .raw_query_read(OpenMlsKeyValue::hash_all)
+            .raw_query(OpenMlsKeyValue::hash_all)
             .map_err(Into::into)
     }
 }

--- a/crates/xmtp_db/src/test_utils.rs
+++ b/crates/xmtp_db/src/test_utils.rs
@@ -83,7 +83,7 @@ mod wasm {
             let store = EncryptedMessageStore::new_uninit(db).unwrap();
             store
                 .db()
-                .raw_query_write(|conn| conn.deserialize_database_from_buffer(snapshot))
+                .raw_query(|conn| conn.deserialize_database_from_buffer(snapshot))
                 .unwrap();
 
             store
@@ -192,7 +192,7 @@ mod native {
                     .build_unencrypted()
                     .unwrap();
                 let store = EncryptedMessageStore::new_uninit(db).unwrap();
-                let result = store.db().raw_query_write(|conn| {
+                let result = store.db().raw_query(|conn| {
                     conn.deserialize_database_from_buffer(snapshot)?;
                     conn.batch_execute("PRAGMA journal_mode = DELETE")?;
                     Ok(())
@@ -223,7 +223,7 @@ mod native {
 
             store
                 .conn()
-                .raw_query_write(|c| {
+                .raw_query(|c| {
                     c.run_pending_migrations(MIGRATIONS).unwrap();
                     Ok(())
                 })

--- a/crates/xmtp_db/src/test_utils.rs
+++ b/crates/xmtp_db/src/test_utils.rs
@@ -61,7 +61,7 @@ pub use wasm::*;
 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
 mod wasm {
     use super::*;
-    use crate::{PersistentOrMem, StorageOption, WasmDbConnection};
+    use crate::{ConnectionExt, PersistentOrMem, StorageOption, WasmDbConnection};
     use futures::FutureExt;
     use std::sync::Arc;
 

--- a/crates/xmtp_db/src/test_utils/mls_memory_storage.rs
+++ b/crates/xmtp_db/src/test_utils/mls_memory_storage.rs
@@ -70,16 +70,7 @@ impl MemoryStorage {
 }
 
 impl ConnectionExt for MemoryStorage {
-    fn raw_query_read<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
-    where
-        F: FnOnce(&mut SqliteConnection) -> Result<T, diesel::result::Error>,
-        Self: Sized,
-    {
-        let mut c = self.inner.lock();
-        Ok(fun(&mut c)?)
-    }
-
-    fn raw_query_write<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
+    fn raw_query<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
     where
         F: FnOnce(&mut SqliteConnection) -> Result<T, diesel::result::Error>,
         Self: Sized,

--- a/crates/xmtp_db_test/src/chaos.rs
+++ b/crates/xmtp_db_test/src/chaos.rs
@@ -252,33 +252,26 @@ impl<C> ConnectionExt for ChaosConnection<C>
 where
     C: ConnectionExt,
 {
-    fn raw_query_read<T, F>(&self, fun: F) -> Result<T, xmtp_db::ConnectionError>
+    fn raw_query<T, F>(&self, fun: F) -> Result<T, xmtp_db::ConnectionError>
     where
         F: FnOnce(&mut SqliteConnection) -> Result<T, diesel::result::Error>,
         Self: Sized,
     {
+        // Hook registration APIs (pre_read_hook / pre_write_hook / etc.) are kept
+        // for backward compatibility, but after the raw_query consolidation all
+        // registered hooks fire on every query.
         self.run_static_hooks(STATIC_PRE_READ_HOOK)?;
+        self.run_static_hooks(STATIC_PRE_WRITE_HOOK)?;
         self.run_hook(PRE_READ_HOOK)?;
+        self.run_hook(PRE_WRITE_HOOK)?;
         self.maybe_random_error::<xmtp_db::ConnectionError>()?;
-        let result = self.db.raw_query_read(fun)?;
+        let result = self.db.raw_query(fun)?;
         // TODO: we could potentially pass T into the POST hook,
         // and then the test could do some (probably unsafe) casting to
         // get a specific type out. Unsure if useful?
         self.run_hook(POST_READ_HOOK)?;
-        self.run_static_hooks(STATIC_POST_READ_HOOK)?;
-        Ok(result)
-    }
-
-    fn raw_query_write<T, F>(&self, fun: F) -> Result<T, xmtp_db::ConnectionError>
-    where
-        F: FnOnce(&mut SqliteConnection) -> Result<T, diesel::result::Error>,
-        Self: Sized,
-    {
-        self.run_static_hooks(STATIC_PRE_WRITE_HOOK)?;
-        self.run_hook(PRE_WRITE_HOOK)?;
-        self.maybe_random_error::<xmtp_db::ConnectionError>()?;
-        let result = self.db.raw_query_write(fun)?;
         self.run_hook(POST_WRITE_HOOK)?;
+        self.run_static_hooks(STATIC_POST_READ_HOOK)?;
         self.run_static_hooks(STATIC_POST_WRITE_HOOK)?;
         Ok(result)
     }

--- a/crates/xmtp_mls/src/client.rs
+++ b/crates/xmtp_mls/src/client.rs
@@ -1227,7 +1227,7 @@ pub(crate) mod tests {
             .unwrap();
 
         let conn = amal.context.store().conn();
-        conn.raw_query_write(|conn| diesel::delete(identity_updates::table).execute(conn))
+        conn.raw_query(|conn| diesel::delete(identity_updates::table).execute(conn))
             .unwrap();
 
         let members = group.members().await.unwrap();

--- a/crates/xmtp_mls/src/groups/tests/mod.rs
+++ b/crates/xmtp_mls/src/groups/tests/mod.rs
@@ -30,6 +30,7 @@ use prost::Message;
 use tls_codec::Deserialize;
 use xmtp_api_d14n::protocol::XmtpQuery;
 use xmtp_configuration::Originators;
+use xmtp_db::ConnectionExt;
 use xmtp_db::XmtpOpenMlsProviderRef;
 use xmtp_db::refresh_state::EntityKind;
 use xmtp_id::InboxOwner;
@@ -437,7 +438,7 @@ async fn test_dm_stitching() {
     let alix_groups = alix
         .context
         .db()
-        .raw_query_read(|conn| {
+        .raw_query(|conn| {
             groups::table
                 .order(groups::created_at_ns.desc())
                 .load::<StoredGroup>(conn)
@@ -3436,7 +3437,7 @@ async fn process_messages_abort_on_retryable_error() {
         .unwrap();
 
     let db = bo.context.store().db();
-    db.raw_query_write(|c| {
+    db.raw_query(|c| {
         c.batch_execute("BEGIN EXCLUSIVE").unwrap();
         Ok::<_, diesel::result::Error>(())
     })

--- a/crates/xmtp_mls/src/utils/cleanup_duplicate_updates.rs
+++ b/crates/xmtp_mls/src/utils/cleanup_duplicate_updates.rs
@@ -88,7 +88,7 @@ where
                         continue;
                     }
 
-                    db.raw_query_write(|conn| {
+                    db.raw_query(|conn| {
                         xmtp_db::diesel::delete(xmtp_db::schema::group_messages::table)
                             .filter(xmtp_db::schema::group_messages::id.eq(&msg.metadata.id))
                             .execute(conn)
@@ -104,7 +104,7 @@ where
         group_offset += BATCH_SIZE;
     }
 
-    db.raw_query_write(|conn| {
+    db.raw_query(|conn| {
         xmtp_db::diesel::update(xmtp_db::schema::user_preferences::table)
             .set(xmtp_db::schema::user_preferences::dm_group_updates_migrated.eq(true))
             .execute(conn)

--- a/crates/xmtp_mls/src/utils/test/tester_utils.rs
+++ b/crates/xmtp_mls/src/utils/test/tester_utils.rs
@@ -125,7 +125,7 @@ where
         }
 
         self.db()
-            .raw_query_write(|conn| {
+            .raw_query(|conn| {
                 let buff = conn.serialize_database_to_buffer();
                 Ok(buff.to_vec())
             })
@@ -344,7 +344,7 @@ where
     fn reset_identity_and_refresh_state(&self) {
         self.context
             .db()
-            .raw_query_write(|c| {
+            .raw_query(|c| {
                 xmtp_db::diesel::delete(xmtp_db::schema::association_state::table)
                     .execute(c)
                     .unwrap();

--- a/crates/xmtp_mls/src/worker/device_sync/archive.rs
+++ b/crates/xmtp_mls/src/worker/device_sync/archive.rs
@@ -32,7 +32,7 @@ impl ImportContext {
         // We want to update the group timestamps to either be what they were before the import,
         // or what they are in the archive group field.
         for (group_id, timestamp) in &self.group_timestamps {
-            if let Err(err) = context.db().raw_query_write(|conn| {
+            if let Err(err) = context.db().raw_query(|conn| {
                 xmtp_db::diesel::update(dsl::groups.find(group_id))
                     .set(dsl::last_message_ns.eq(*timestamp))
                     .execute(conn)
@@ -365,7 +365,7 @@ mod tests {
         let messages: Vec<StoredGroupMessage> = alix2
             .context
             .db()
-            .raw_query_read(|conn| group_messages::table.load(conn))
+            .raw_query(|conn| group_messages::table.load(conn))
             .unwrap();
         assert_eq!(messages.len(), 0);
 
@@ -380,7 +380,7 @@ mod tests {
         let messages: Vec<StoredGroupMessage> = alix2
             .context
             .db()
-            .raw_query_read(|conn| group_messages::table.load(conn))
+            .raw_query(|conn| group_messages::table.load(conn))
             .unwrap();
         assert_eq!(messages.len(), 1);
     }
@@ -420,21 +420,21 @@ mod tests {
         let mut consent_records: Vec<StoredConsentRecord> = alix
             .context
             .db()
-            .raw_query_read(|conn| consent_records::table.load(conn))?;
+            .raw_query(|conn| consent_records::table.load(conn))?;
         assert_eq!(consent_records.len(), 1);
         let old_consent_record = consent_records.pop()?;
 
         let mut groups: Vec<StoredGroup> = alix
             .context
             .db()
-            .raw_query_read(|conn| groups::table.load(conn))?;
+            .raw_query(|conn| groups::table.load(conn))?;
         assert_eq!(groups.len(), 2);
         let old_group = groups.pop()?;
 
         let old_messages: Vec<StoredGroupMessage> = alix
             .context
             .db()
-            .raw_query_read(|conn| group_messages::table.load(conn))?;
+            .raw_query(|conn| group_messages::table.load(conn))?;
         assert_eq!(old_messages.len(), 4);
 
         let opts = ArchiveOptions {
@@ -460,7 +460,7 @@ mod tests {
         let consent_records: Vec<StoredConsentRecord> = alix2
             .context
             .db()
-            .raw_query_read(|conn| consent_records::table.load(conn))?;
+            .raw_query(|conn| consent_records::table.load(conn))?;
         assert_eq!(consent_records.len(), 0);
 
         let mut importer = ArchiveImporter::from_file(path, &key).await?;
@@ -472,12 +472,12 @@ mod tests {
         let consent_records: Vec<StoredConsentRecord> = alix2
             .context
             .db()
-            .raw_query_read(|conn| consent_records::table.load(conn))?;
+            .raw_query(|conn| consent_records::table.load(conn))?;
         assert_eq!(consent_records.len(), 1);
         // It's the same consent record.
         assert_eq!(consent_records[0], old_consent_record);
 
-        let groups: Vec<StoredGroup> = alix2.context.db().raw_query_read(|conn| {
+        let groups: Vec<StoredGroup> = alix2.context.db().raw_query(|conn| {
             groups::table
                 .filter(groups::conversation_type.ne_all(ConversationType::virtual_types()))
                 .load(conn)
@@ -486,7 +486,7 @@ mod tests {
         // It's the same group
         assert_eq!(groups[0].id, old_group.id);
 
-        let messages: Vec<StoredGroupMessage> = alix2.context.db().raw_query_read(|conn| {
+        let messages: Vec<StoredGroupMessage> = alix2.context.db().raw_query(|conn| {
             group_messages::table
                 .filter(group_messages::group_id.eq(&groups[0].id))
                 .load(conn)

--- a/crates/xmtp_mls/src/worker/device_sync/tests.rs
+++ b/crates/xmtp_mls/src/worker/device_sync/tests.rs
@@ -4,6 +4,7 @@ use crate::groups::send_message_opts::SendMessageOpts;
 use crate::tester;
 use xmtp_configuration::DeviceSyncUrls;
 use xmtp_db::{
+    ConnectionExt,
     consent_record::ConsentState,
     group::{ConversationType, StoredGroup},
     group_message::MsgQueryArgs,
@@ -315,7 +316,7 @@ async fn test_only_added_to_correct_groups() {
     old_group
         .send_message(b"hi there", SendMessageOpts::default())
         .await?;
-    alix1.context.db().raw_query_write(|conn| {
+    alix1.context.db().raw_query(|conn| {
         diesel::update(dsl::groups.find(&old_group.group_id))
             .set((dsl::last_message_ns.eq(0), dsl::created_at_ns.eq(0)))
             .execute(conn)
@@ -395,7 +396,7 @@ async fn test_new_devices_not_added_to_old_sync_groups() {
     }
 
     // alix1 should have it's own created sync group and alix2's sync group
-    let alix1_sync_groups: Vec<StoredGroup> = alix1.context.db().raw_query_read(|conn| {
+    let alix1_sync_groups: Vec<StoredGroup> = alix1.context.db().raw_query(|conn| {
         dsl::groups
             .filter(dsl::conversation_type.eq(ConversationType::Sync))
             .load(conn)
@@ -405,7 +406,7 @@ async fn test_new_devices_not_added_to_old_sync_groups() {
     // alix2 should not be added to alix1's old sync group
 
     alix2.sync_welcomes().await?;
-    let alix2_sync_groups: Vec<StoredGroup> = alix2.context.db().raw_query_read(|conn| {
+    let alix2_sync_groups: Vec<StoredGroup> = alix2.context.db().raw_query(|conn| {
         dsl::groups
             .filter(dsl::conversation_type.eq(ConversationType::Sync))
             .load(conn)


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/2400

## Summary

`ConnectionExt` had two methods, `raw_query_read` and `raw_query_write`, with identical signatures and identical bodies across every backing implementation in the workspace. There was no read replica, RWLock split, read-only transaction semantics, or distinct connection-acquisition path between them — the split was tech debt from an earlier iteration of the storage layer.

This PR collapses them into a single `ConnectionExt::raw_query`, drops the redundant inherent forwarding wrappers on `DbConnection<C>`, and mechanically renames all ~295 callsites. `ConnectionExt` is internal to `xmtp_db`; the bindings surface is unchanged.

## Changes

- **Trait definition** — one `raw_query` method on `ConnectionExt` (`crates/xmtp_db/src/encrypted_store/mod.rs`).
- **Blanket impls** — `&C`, `&mut C`, `Arc<C>` collapsed.
- **Backing impls** collapsed: `NativeDbConnection`, `EphemeralDbConnection`, `DbPool` (test-only), `WasmDbConnection`, `PersistentOrMem<P, M>`, `SqlKeyStore`'s `MutableTransactionConnection`, `MockConnection`, `MockDbQuery`, `MemoryStorage`, `ChaosConnection`.
- **`DbConnection<C>`** — removed the inherent `impl<C: ConnectionExt> DbConnection<C>` block whose only purpose was to re-expose the split; callers now resolve through the `ConnectionExt` trait impl on the same type.
- **`ChaosConnection`** — with the read/write distinction gone at the trait level, the combined `raw_query` now fires both the PRE_READ/POST_READ and PRE_WRITE/POST_WRITE hook lists on every query (superset behavior). The public `*_hook` registration APIs are unchanged for backward compatibility with existing chaos tests.
- **Callsites** — mechanical rename across 53 files (~295 occurrences) in `crates/xmtp_db`, `crates/xmtp_mls`, `crates/xmtp_db_test`, and `apps/db_tools`.
- **Imports** — a handful of callsites needed `use xmtp_db::ConnectionExt` after the inherent wrappers were dropped (the trait was already available but unreferenced in those files).

## Verification

- `cargo check` clean across `xmtp_db`, `xmtp_mls`, `xmtp_db_test`, `xmtp-db-tools` (tests + bins, v3 and d14n feature sets).
- `cargo check --target wasm32-unknown-unknown` clean on `xmtp_db` and `xmtp_mls`.
- `cargo clippy -- -D warnings` clean on all touched crates.
- `cargo fmt --check` clean.
- `rg 'raw_query_(read|write)'` — zero matches.

## Test plan

- [ ] CI — `just lint`, `just test v3`, `just test d14n`.
- [ ] CI — `just wasm check`, `just android check`, `just ios check`.
- [ ] Spot-check one chaos test that registers a `post_read_hook` to confirm the superset hook behavior is acceptable in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `raw_query_read` and `raw_query_write` with a single `raw_query` in `xmtp_db`
> - The `ConnectionExt` trait previously exposed separate `raw_query_read` and `raw_query_write` methods; these are collapsed into a single `raw_query` that handles both read and write closures across all connection types (native, wasm, mock, ephemeral, transaction).
> - All call sites across `xmtp_db`, `xmtp_mls`, `xmtp_db_test`, and `apps/db_tools` are updated to use the unified method.
> - Risk: In `xmtp_db_test`'s chaos connection, all pre/post read and write hooks now fire on every `raw_query` call regardless of whether the operation is logically a read or write, which may affect chaos test behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3abe4d6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->