### PR TITLE
chore(deny): ignore RUSTSEC-2026-0105 (core2 unmaintained)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -11,6 +11,7 @@ ignore = [
   { id = "RUSTSEC-2026-0073", reason = "libcrux-poly1305 0.0.4 pinned by xmtp/openmls fork; upstream fix in openmls/openmls@68bd8b28" },
   { id = "RUSTSEC-2025-0134", reason = "used in temporary xnet-gui" },
   { id = "RUSTSEC-2025-0052", reason = "used in temporary xnet-gui" },
+  { id = "RUSTSEC-2026-0105", reason = "core2 reached only via image/rav1e pulled in by log_parser and xnet-gui tooling" },
 ]
 
 # This rustsec can be added to ignore list if using mls `test_utils` for tests


### PR DESCRIPTION
core2 is reached only transitively via image/rav1e, pulled in by the
log_parser and xnet-gui tooling crates. Neither is shipped by the
published bindings, and the advisory notes there's no safe upgrade.
Matches the existing pattern for RUSTSEC-2025-0134 / RUSTSEC-2025-0052.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ignore RUSTSEC-2026-0105 (`core2` unmaintained) in cargo-deny config
> Adds RUSTSEC-2026-0105 to the ignore list in [deny.toml](https://github.com/xmtp/libxmtp/pull/3543/files#diff-1040309c64844eb1b6b63d8fd67938adbf9461f1b3c61f12cf738f064a02d3de). The advisory is only reachable via `image`/`rav1e`, pulled in by `log_parser` and `xnet-gui` tooling, so suppressing it avoids blocking CI without exposing production code to risk.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0f9bd72.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->