### PR TITLE
build(xmtp_proto): add tonic codegen feature for native builds

### DIFF
--- a/crates/xmtp_proto/Cargo.toml
+++ b/crates/xmtp_proto/Cargo.toml
@@ -41,7 +41,10 @@ toxiproxy_rust = { workspace = true, optional = true }
 xmtp-workspace-hack.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tonic = { workspace = true, features = ["channel"] }
+# `codegen` is required because `build.rs` gates server-side generated
+# modules on `cfg(any(not(target_arch = "wasm32"), feature = "grpc_server_impls"))`,
+# so native builds always compile server stubs that `use tonic::codegen::*`.
+tonic = { workspace = true, features = ["channel", "codegen"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen-test.workspace = true

--- a/deny.toml
+++ b/deny.toml
@@ -11,6 +11,7 @@ ignore = [
   { id = "RUSTSEC-2026-0073", reason = "libcrux-poly1305 0.0.4 pinned by xmtp/openmls fork; upstream fix in openmls/openmls@68bd8b28" },
   { id = "RUSTSEC-2025-0134", reason = "used in temporary xnet-gui" },
   { id = "RUSTSEC-2025-0052", reason = "used in temporary xnet-gui" },
+  { id = "RUSTSEC-2026-0105", reason = "core2 reached only via image/rav1e pulled in by log_parser and xnet-gui tooling" },
 ]
 
 # This rustsec can be added to ignore list if using mls `test_utils` for tests


### PR DESCRIPTION
`build.rs` configures server-side module generation to use
`#[cfg(any(not(target_arch = "wasm32"), feature = "grpc_server_impls"))]`,
meaning every native (non-wasm) build compiles the server stubs —
which `use tonic::codegen::*`. Previously `codegen` was only pulled in
via the `grpc_server_impls` feature, which was only activated by the
`mls_validation_service` app. As a result, narrow builds like
`cargo check -p xmtp_proto` or `cargo check -p xmtp_mls_common` failed
with 36 errors (unresolved `tonic::codegen`, cascading `Self::Future`
ambiguities) on native targets, while full-workspace builds silently
worked thanks to feature unification.

Adding `codegen` unconditionally for non-wasm targets aligns the
dependency features with what the generated code actually requires.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `tonic` codegen feature flag for native builds in `xmtp_proto`
> Expands the `tonic` dependency features for non-wasm32 targets in [Cargo.toml](https://github.com/xmtp/libxmtp/pull/3544/files#diff-40539541a78043690cf70b1db9cb099e00efeb63f185cb423d32e8ac91baf2b1) from `["channel"]` to `["channel", "codegen"]`, enabling server stub compilation that depends on `tonic::codegen`. Also adds an ignore entry for RUSTSEC-2026-0105 in [deny.toml](https://github.com/xmtp/libxmtp/pull/3544/files#diff-1040309c64844eb1b6b63d8fd67938adbf9461f1b3c61f12cf738f064a02d3de).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0637b4c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->