### PR TITLE
xmtp_mls: advertise AppDataUpdate proposal capability

### DIFF
--- a/crates/xmtp_mls/src/groups/mod.rs
+++ b/crates/xmtp_mls/src/groups/mod.rs
@@ -2715,11 +2715,25 @@ pub(crate) fn build_group_config(
 
     let required_proposal_types = &[ProposalType::GroupContextExtensions];
 
+    // Leaf-node-advertised proposal types: a superset of `required_proposal_types`.
+    // We advertise `AppDataUpdate` here so that the new path (commit-with-inline-
+    // AppDataUpdate-proposal) is supported, but we DO NOT add it to
+    // `required_proposal_types` because that would break backwards compatibility
+    // with members whose leaf nodes don't yet advertise it. The capability check
+    // OpenMLS performs at commit-build time inspects every member leaf node's
+    // proposal capabilities — adding it here ensures the creator advertises
+    // support; joining clients pick it up via their own key package (see
+    // `identity.rs`).
+    let creator_capability_proposals = &[
+        ProposalType::GroupContextExtensions,
+        ProposalType::AppDataUpdate,
+    ];
+
     let capabilities = Capabilities::new(
         None,
         None,
         Some(&creator_capability_extensions),
-        Some(required_proposal_types),
+        Some(creator_capability_proposals),
         None,
     );
     let credentials = &[CredentialType::Basic];

--- a/crates/xmtp_mls/src/groups/tests/test_proposals.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_proposals.rs
@@ -2544,3 +2544,56 @@ async fn test_add_member_after_sequence_id_bump_with_proposals_enabled() {
     assert_eq!(bo_members.len(), 3, "Bo should see 3 members");
     assert_eq!(caro_members.len(), 3, "Caro should see 3 members");
 }
+
+// =============================================================================
+// Capability Advertisement Backwards Compatibility
+// =============================================================================
+
+/// Backwards-compat invariant for the `AppDataUpdate` proposal capability flip.
+///
+/// The creator advertises `AppDataUpdate` on its own leaf node (so the new
+/// commit-with-inline-AppDataUpdate-proposal path works), but the group's
+/// `RequiredCapabilities` must NOT require it. Required-but-not-universally-
+/// advertised would break OpenMLS's RequiredCapabilities check for any
+/// installation whose leaf node only advertises the legacy proposal set,
+/// stranding every unmigrated client at join time.
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_app_data_update_advertised_but_not_required() {
+    use openmls::messages::proposals::ProposalType;
+
+    tester!(alix);
+    let alix_group = alix.create_group(None, None)?;
+
+    alix_group
+        .load_mls_group_with_lock_async(async |mls_group| {
+            let own_proposals = mls_group
+                .own_leaf_node()
+                .expect("group creator must have own leaf")
+                .capabilities()
+                .proposals()
+                .to_vec();
+            assert!(
+                own_proposals.contains(&ProposalType::AppDataUpdate),
+                "creator leaf must advertise AppDataUpdate, got: {own_proposals:?}",
+            );
+
+            let required = mls_group
+                .extensions()
+                .required_capabilities()
+                .expect("required_capabilities must be set")
+                .proposal_types()
+                .to_vec();
+            assert!(
+                required.contains(&ProposalType::GroupContextExtensions),
+                "GroupContextExtensions must be required, got: {required:?}",
+            );
+            assert!(
+                !required.contains(&ProposalType::AppDataUpdate),
+                "AppDataUpdate must NOT be required — would break backwards compat \
+                 with legacy leaf nodes. got: {required:?}",
+            );
+
+            Ok::<(), crate::groups::GroupError>(())
+        })
+        .await?;
+}

--- a/crates/xmtp_mls/src/identity.rs
+++ b/crates/xmtp_mls/src/identity.rs
@@ -856,11 +856,19 @@ impl XmtpKeyPackageBuilder {
                     .retain(|e| *e != ExtensionType::Unknown(PROPOSAL_SUPPORT_EXTENSION_ID));
             }
         }
+        // Advertise both `GroupContextExtensions` (required by all groups)
+        // and `AppDataUpdate` (used by the new app-data path) so this client
+        // can join groups that commit AppDataUpdate proposals. Required-vs-
+        // supported is enforced by the group's RequiredCapabilities, not by
+        // this leaf-node list, so advertising more is always safe.
         let capabilities = Capabilities::new(
             None,
             Some(&[CIPHERSUITE]),
             Some(&capability_extensions),
-            Some(&[ProposalType::GroupContextExtensions]),
+            Some(&[
+                ProposalType::GroupContextExtensions,
+                ProposalType::AppDataUpdate,
+            ]),
             None,
         );
 
@@ -1175,6 +1183,39 @@ mod tests {
         let key_package_from_db: Option<KeyPackageBundle> =
             provider.storage().key_package(&pq_hash_ref_inner).unwrap();
         assert!(key_package_from_db.is_none());
+    }
+
+    /// Companion to `test_app_data_update_advertised_but_not_required` in
+    /// `groups/tests/test_proposals.rs`, which covers the group-creator side.
+    ///
+    /// The joiner side: a key package built by `XmtpKeyPackageBuilder` must
+    /// advertise `AppDataUpdate` on its leaf node so this installation can be
+    /// added to groups whose commits inline AppDataUpdate proposals. If this
+    /// regresses, new clients would fail RequiredCapabilities on join into any
+    /// group created by a peer that later requires the capability.
+    #[xmtp_common::test]
+    async fn test_app_data_update_capability_advertised_on_key_package() {
+        use openmls::messages::proposals::ProposalType;
+
+        let client = ClientBuilder::new_test_client(&generate_local_wallet()).await;
+        let storage = client.context.mls_storage();
+        let provider = XmtpOpenMlsProviderRef::new(storage);
+
+        let kp = client
+            .identity()
+            .new_key_package(&provider, false)
+            .unwrap()
+            .key_package;
+        let proposals = kp.leaf_node().capabilities().proposals();
+
+        assert!(
+            proposals.contains(&ProposalType::AppDataUpdate),
+            "key package must advertise AppDataUpdate, got: {proposals:?}",
+        );
+        assert!(
+            proposals.contains(&ProposalType::GroupContextExtensions),
+            "key package must still advertise GroupContextExtensions, got: {proposals:?}",
+        );
     }
 
     #[test]


### PR DESCRIPTION
Add ProposalType::AppDataUpdate to the leaf-node capabilities
advertised by:

- `XmtpKeyPackageBuilder` (identity.rs) — so joining clients advertise
  support and can be added to groups that commit AppDataUpdate proposals.
- `build_group_config` (groups/mod.rs) — so group creators advertise it
  on their own leaf node.

Critically, neither site adds `AppDataUpdate` to `required_proposal_types`:
OpenMLS's RequiredCapabilities check must keep admitting members whose
leaf nodes only advertise the legacy set, so migration can roll forward
without stranding unmigrated installations. This commit is a standalone
capability-flip: no producer or receiver code consumes the advertisement
yet.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Advertise `AppDataUpdate` proposal capability in MLS key packages and group leaf nodes
> - Key packages built by `XmtpKeyPackageBuilder.build` now include `AppDataUpdate` alongside `GroupContextExtensions` in their leaf node proposal capabilities ([identity.rs](https://github.com/xmtp/libxmtp/pull/3547/files#diff-7a53ab1775c572e550b2b08934d90d3f8433e012043b1ee641110036902663ed)).
> - Groups created via `build_group_config` advertise `AppDataUpdate` in the creator's leaf node capabilities, but `RequiredCapabilities` still only requires `GroupContextExtensions` ([groups/mod.rs](https://github.com/xmtp/libxmtp/pull/3547/files#diff-c27dd00cf700fd888b75fdbd19738462c2549fdc881dad70f8e61c979d440966)).
> - Tests added to verify both invariants: capability advertisement and non-requirement of `AppDataUpdate`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4504305.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->