### PR TITLE
xmtp_mls: validate AppDataUpdate proposals in ValidatedCommit

### DIFF
--- a/crates/xmtp_mls/src/groups/tests/mod.rs
+++ b/crates/xmtp_mls/src/groups/tests/mod.rs
@@ -14,6 +14,7 @@ mod test_network;
 mod test_prepare_message_for_later_publish;
 mod test_proposals;
 mod test_send_message_opts;
+mod test_validate_app_data_update;
 mod test_welcome_pointers;
 mod test_welcomes;
 

--- a/crates/xmtp_mls/src/groups/tests/test_validate_app_data_update.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_validate_app_data_update.rs
@@ -1,0 +1,420 @@
+//! Unit tests for the `AppDataUpdate` validator helpers.
+//!
+//! These cover the pure-logic seams of
+//! `validated_commit::validate_one_app_data_update_with_old_value` and
+//! `validated_commit::app_data_update_proposer_leaf`. The commit-time
+//! wrapper `validate_one_app_data_update` adds only a dictionary read
+//! on top of the pure core, so exercising the pure core plus the
+//! sender dispatch gives us the full decision-tree without requiring a
+//! real `OpenMlsGroup` / `StagedCommit`.
+
+use openmls::messages::proposals::AppDataUpdateOperation;
+use openmls::prelude::{LeafNodeIndex, Sender, SenderExtensionIndex};
+use tls_codec::Serialize as _;
+
+use xmtp_mls_common::app_data::component_id::ComponentId;
+use xmtp_mls_common::app_data::component_permissions::component_permissions;
+use xmtp_mls_common::app_data::component_registry::{ComponentRegistry, new_component_metadata};
+use xmtp_mls_common::app_data::validation::ActorAuthority;
+use xmtp_mls_common::inbox_id::InboxId;
+use xmtp_mls_common::tls_set::{TlsKeyHash, TlsSetDelta};
+use xmtp_proto::xmtp::mls::message_contents::{
+    ComponentType, MetadataPolicy as MetadataPolicyProto,
+    metadata_policy::{Kind as MetadataPolicyKind, MetadataBasePolicy},
+};
+
+use crate::groups::validated_commit::{
+    CommitValidationError, app_data_update_proposer_leaf,
+    validate_one_app_data_update_with_old_value,
+};
+
+// --- actor / policy / registry helpers -----------------------------------
+
+fn member() -> ActorAuthority {
+    ActorAuthority {
+        is_admin: false,
+        is_super_admin: false,
+    }
+}
+
+fn admin() -> ActorAuthority {
+    ActorAuthority {
+        is_admin: true,
+        is_super_admin: false,
+    }
+}
+
+fn super_admin() -> ActorAuthority {
+    ActorAuthority {
+        is_admin: true,
+        is_super_admin: true,
+    }
+}
+
+fn base_policy(base: MetadataBasePolicy) -> MetadataPolicyProto {
+    MetadataPolicyProto {
+        kind: Some(MetadataPolicyKind::Base(base as i32)),
+    }
+}
+
+fn allow() -> MetadataPolicyProto {
+    base_policy(MetadataBasePolicy::Allow)
+}
+
+fn deny() -> MetadataPolicyProto {
+    base_policy(MetadataBasePolicy::Deny)
+}
+
+fn admin_only() -> MetadataPolicyProto {
+    base_policy(MetadataBasePolicy::AllowIfAdmin)
+}
+
+/// Build a `ComponentRegistry` with a single entry permitting exactly
+/// the insert/update/delete policies given.
+fn registry_with(
+    id: ComponentId,
+    insert: MetadataPolicyProto,
+    update: MetadataPolicyProto,
+    delete: MetadataPolicyProto,
+    component_type: ComponentType,
+) -> ComponentRegistry {
+    let mut reg = ComponentRegistry::new();
+    reg.set(
+        id,
+        new_component_metadata(
+            component_permissions()
+                .insert(insert)
+                .update(update)
+                .delete(delete)
+                .call(),
+            component_type,
+        ),
+    )
+    .unwrap();
+    reg
+}
+
+fn fake_inbox(byte: u8) -> InboxId {
+    InboxId::from_bytes([byte; 32])
+}
+
+// ------------------------------------------------------------------------
+// validate_one_app_data_update_with_old_value — Bytes component happy paths
+// ------------------------------------------------------------------------
+
+#[test]
+fn bytes_update_allowed_when_registry_allows() {
+    let reg = registry_with(
+        ComponentId::GROUP_NAME,
+        allow(),
+        allow(),
+        allow(),
+        ComponentType::Bytes,
+    );
+    let op = AppDataUpdateOperation::Update(b"new-name".to_vec().into());
+    let result = validate_one_app_data_update_with_old_value(
+        ComponentId::GROUP_NAME,
+        &op,
+        member(),
+        "inbox_alice",
+        &reg,
+        Some(b"old-name"),
+    );
+    assert!(result.is_ok(), "expected Ok, got {result:?}");
+}
+
+#[test]
+fn bytes_update_accepts_none_old_value_for_first_write() {
+    // First-write case: AppData dict has no prior bytes. Bytes-component
+    // expansion ignores `old_value`, so this must succeed when the
+    // policy allows.
+    let reg = registry_with(
+        ComponentId::GROUP_NAME,
+        allow(),
+        allow(),
+        allow(),
+        ComponentType::Bytes,
+    );
+    let op = AppDataUpdateOperation::Update(b"first-name".to_vec().into());
+    let result = validate_one_app_data_update_with_old_value(
+        ComponentId::GROUP_NAME,
+        &op,
+        super_admin(),
+        "inbox_alice",
+        &reg,
+        None,
+    );
+    assert!(result.is_ok(), "expected Ok, got {result:?}");
+}
+
+#[test]
+fn bytes_remove_allowed_when_registry_allows_delete() {
+    let reg = registry_with(
+        ComponentId::GROUP_NAME,
+        allow(),
+        allow(),
+        allow(),
+        ComponentType::Bytes,
+    );
+    let op = AppDataUpdateOperation::Remove;
+    let result = validate_one_app_data_update_with_old_value(
+        ComponentId::GROUP_NAME,
+        &op,
+        admin(),
+        "inbox_alice",
+        &reg,
+        Some(b"y"),
+    );
+    assert!(result.is_ok(), "expected Ok, got {result:?}");
+}
+
+// ------------------------------------------------------------------------
+// validate_one_app_data_update_with_old_value — permission rejections
+// ------------------------------------------------------------------------
+
+#[test]
+fn bytes_update_rejected_when_registry_empty() {
+    // Deny-by-default: component has no registry entry.
+    let reg = ComponentRegistry::new();
+    let op = AppDataUpdateOperation::Update(b"x".to_vec().into());
+    let err = validate_one_app_data_update_with_old_value(
+        ComponentId::GROUP_NAME,
+        &op,
+        member(),
+        "inbox_alice",
+        &reg,
+        Some(b"y"),
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, CommitValidationError::InsufficientPermissions),
+        "expected InsufficientPermissions, got {err:?}"
+    );
+}
+
+#[test]
+fn bytes_update_rejected_when_policy_denies() {
+    // Update policy is explicitly Deny — even super_admin is rejected.
+    let reg = registry_with(
+        ComponentId::GROUP_NAME,
+        allow(),
+        deny(),
+        allow(),
+        ComponentType::Bytes,
+    );
+    let op = AppDataUpdateOperation::Update(b"x".to_vec().into());
+    let err = validate_one_app_data_update_with_old_value(
+        ComponentId::GROUP_NAME,
+        &op,
+        super_admin(),
+        "inbox_alice",
+        &reg,
+        Some(b"y"),
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, CommitValidationError::InsufficientPermissions),
+        "expected InsufficientPermissions, got {err:?}"
+    );
+}
+
+#[test]
+fn admin_list_insert_rejected_for_member() {
+    // ADMIN_LIST is constrained to AllowIfAdmin / AllowIfSuperAdmin.
+    // A plain member proposing an Insert is rejected.
+    let reg = registry_with(
+        ComponentId::ADMIN_LIST,
+        admin_only(),
+        admin_only(),
+        admin_only(),
+        ComponentType::TlsSetInboxId,
+    );
+    let alice = fake_inbox(0x11);
+    let delta: TlsSetDelta<InboxId> = TlsSetDelta::new().insert(alice);
+    let op = AppDataUpdateOperation::Update(delta.tls_serialize_detached().unwrap().into());
+
+    let err = validate_one_app_data_update_with_old_value(
+        ComponentId::ADMIN_LIST,
+        &op,
+        member(),
+        "inbox_member",
+        &reg,
+        None,
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, CommitValidationError::InsufficientPermissions),
+        "expected InsufficientPermissions, got {err:?}"
+    );
+}
+
+#[test]
+fn super_admin_list_insert_rejected_for_admin() {
+    // SUPER_ADMIN_LIST is hardcoded super-admin-only, enforced in code
+    // and not through the registry. An admin (but not super admin) is
+    // rejected.
+    let reg = ComponentRegistry::new();
+    let alice = fake_inbox(0x11);
+    let delta: TlsSetDelta<InboxId> = TlsSetDelta::new().insert(alice);
+    let op = AppDataUpdateOperation::Update(delta.tls_serialize_detached().unwrap().into());
+
+    let err = validate_one_app_data_update_with_old_value(
+        ComponentId::SUPER_ADMIN_LIST,
+        &op,
+        admin(),
+        "inbox_admin",
+        &reg,
+        None,
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, CommitValidationError::InsufficientPermissions),
+        "expected InsufficientPermissions, got {err:?}"
+    );
+}
+
+// ------------------------------------------------------------------------
+// validate_one_app_data_update_with_old_value — expansion-failure mapping
+// ------------------------------------------------------------------------
+
+#[test]
+fn malformed_delta_maps_to_insufficient_permissions() {
+    // Corrupt TlsSetDelta payload on ADMIN_LIST — the expansion step
+    // surfaces a TlsCodec error. The validator intentionally collapses
+    // that into InsufficientPermissions so an ill-formed proposal is
+    // rejected wholesale; the underlying parse error is still logged
+    // via `tracing::warn!` for debuggability.
+    let reg = registry_with(
+        ComponentId::ADMIN_LIST,
+        admin_only(),
+        admin_only(),
+        admin_only(),
+        ComponentType::TlsSetInboxId,
+    );
+    let op = AppDataUpdateOperation::Update(vec![0xde, 0xad, 0xbe, 0xef].into());
+
+    let err = validate_one_app_data_update_with_old_value(
+        ComponentId::ADMIN_LIST,
+        &op,
+        super_admin(),
+        "inbox_super",
+        &reg,
+        None,
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, CommitValidationError::InsufficientPermissions),
+        "expected InsufficientPermissions, got {err:?}"
+    );
+}
+
+#[test]
+fn unknown_collection_component_maps_to_insufficient_permissions() {
+    // A component in the XMTP range that has no expansion handler
+    // (neither metadata-field-mapped nor ADMIN/SUPER_ADMIN_LIST) fails
+    // expansion with UnknownComponent — which the validator flattens
+    // to InsufficientPermissions.
+    let reg = ComponentRegistry::new();
+    // 0xBE00 is an XMTP-immutable id with no expansion handler.
+    let op = AppDataUpdateOperation::Update(vec![0x00, 0x01].into());
+    let err = validate_one_app_data_update_with_old_value(
+        ComponentId::new(0xBE00),
+        &op,
+        super_admin(),
+        "inbox_super",
+        &reg,
+        None,
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, CommitValidationError::InsufficientPermissions),
+        "expected InsufficientPermissions, got {err:?}"
+    );
+}
+
+#[test]
+fn remove_by_hash_miss_does_not_short_circuit_policy() {
+    // RemoveByHash against an empty prior set surfaces `value: None`
+    // from the expansion. Per-change policy still runs — super_admin
+    // on SUPER_ADMIN_LIST passes regardless of value, so the
+    // validator must return Ok.
+    let delta: TlsSetDelta<InboxId> =
+        TlsSetDelta::new().remove_by_hash(TlsKeyHash::of(&fake_inbox(0x55)).unwrap());
+    let op = AppDataUpdateOperation::Update(delta.tls_serialize_detached().unwrap().into());
+    let reg = ComponentRegistry::new();
+
+    let result = validate_one_app_data_update_with_old_value(
+        ComponentId::SUPER_ADMIN_LIST,
+        &op,
+        super_admin(),
+        "inbox_super",
+        &reg,
+        None,
+    );
+    assert!(result.is_ok(), "expected Ok, got {result:?}");
+}
+
+#[test]
+fn multi_mutation_delta_all_allowed_returns_ok() {
+    // Super admin inserting two new inboxes and removing one — all
+    // three expanded per-element writes must pass. Cheap happy-path
+    // check that the per-change loop doesn't spuriously reject.
+    let delta: TlsSetDelta<InboxId> = TlsSetDelta::new()
+        .insert(fake_inbox(0x01))
+        .insert(fake_inbox(0x02))
+        .remove(fake_inbox(0x03));
+    let op = AppDataUpdateOperation::Update(delta.tls_serialize_detached().unwrap().into());
+    let reg = ComponentRegistry::new();
+
+    let result = validate_one_app_data_update_with_old_value(
+        ComponentId::SUPER_ADMIN_LIST,
+        &op,
+        super_admin(),
+        "inbox_super",
+        &reg,
+        None,
+    );
+    assert!(result.is_ok(), "expected Ok, got {result:?}");
+}
+
+// ------------------------------------------------------------------------
+// app_data_update_proposer_leaf — sender dispatch
+// ------------------------------------------------------------------------
+
+#[test]
+fn proposer_leaf_member_returns_leaf_index() {
+    let leaf = LeafNodeIndex::new(7);
+    let sender = Sender::Member(leaf);
+    let result = app_data_update_proposer_leaf(&sender).unwrap();
+    assert_eq!(*result, leaf);
+}
+
+#[test]
+fn proposer_leaf_external_rejected_as_actor_not_member() {
+    let sender = Sender::External(SenderExtensionIndex::new(0));
+    let err = app_data_update_proposer_leaf(&sender).unwrap_err();
+    assert!(
+        matches!(err, CommitValidationError::ActorNotMember),
+        "expected ActorNotMember, got {err:?}"
+    );
+}
+
+#[test]
+fn proposer_leaf_new_member_commit_rejected() {
+    let sender = Sender::NewMemberCommit;
+    let err = app_data_update_proposer_leaf(&sender).unwrap_err();
+    assert!(
+        matches!(err, CommitValidationError::ActorNotMember),
+        "expected ActorNotMember, got {err:?}"
+    );
+}
+
+#[test]
+fn proposer_leaf_new_member_proposal_rejected() {
+    let sender = Sender::NewMemberProposal;
+    let err = app_data_update_proposer_leaf(&sender).unwrap_err();
+    assert!(
+        matches!(err, CommitValidationError::ActorNotMember),
+        "expected ActorNotMember, got {err:?}"
+    );
+}

--- a/crates/xmtp_mls/src/groups/validated_commit.rs
+++ b/crates/xmtp_mls/src/groups/validated_commit.rs
@@ -180,6 +180,21 @@ impl CommitParticipant {
             mutable_metadata,
         ))
     }
+
+    /// Project this participant into the admin/super-admin view that the
+    /// component-permission validator consumes.
+    fn actor_authority(&self) -> xmtp_mls_common::app_data::validation::ActorAuthority {
+        xmtp_mls_common::app_data::validation::ActorAuthority {
+            is_admin: self.is_admin,
+            is_super_admin: self.is_super_admin,
+        }
+    }
+}
+
+impl From<&CommitParticipant> for xmtp_mls_common::app_data::validation::ActorAuthority {
+    fn from(participant: &CommitParticipant) -> Self {
+        participant.actor_authority()
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize)]
@@ -393,6 +408,18 @@ impl ValidatedCommit {
         if staged_commit.psk_proposals().any(|_| true) {
             return Err(CommitValidationError::NoPSKSupport);
         }
+
+        // AppDataUpdate proposals carried by a commit (inline OR by
+        // reference, since `staged_commit.app_data_update_proposals()`
+        // iterates both) never flow through `validate_proposal()` — that
+        // path only handles standalone proposal-by-reference messages —
+        // so this is where their permission check lives.
+        validate_app_data_update_proposals_in_commit(
+            staged_commit,
+            openmls_group,
+            &immutable_metadata,
+            &mutable_metadata,
+        )?;
 
         // Get the installations actually added and removed in the commit
         let ProposalChanges {
@@ -943,6 +970,210 @@ fn validate_membership_diff(
     Ok(())
 }
 
+/// Validate a single `AppDataUpdate` (component_id + operation) against
+/// `registry` on behalf of `actor`.
+///
+/// Shared core for both validator entry points:
+/// [`validate_proposal`] (standalone proposal-by-reference messages) and
+/// [`validate_app_data_update_proposals_in_commit`] (proposals inside
+/// commits, inline or referenced). Both paths must enforce identical
+/// permission checks; lifting the loop here keeps them in lockstep so a
+/// future change can't drift the two implementations apart.
+///
+/// Reads the pre-commit stored bytes for `component_id` from the
+/// group's AppData dictionary and threads them into the expansion step
+/// so `RemoveByHash` mutations can be resolved back to the concrete
+/// inbox id being removed. If the component has no prior entry (first
+/// write), `read_from_app_data_dict` returns `None`, which
+/// [`expand_app_data_update_to_changes`] treats as an empty prior set
+/// — `Insert` / `Remove` deltas expand normally, and any `RemoveByHash`
+/// surfaces `value: None` (the CRDT apply step later rejects with
+/// `KeyNotFound`). This matches the `Bytes` component case where a
+/// first-time `Update` has no prior value to diff against.
+///
+/// Returns `Err(InsufficientPermissions)` on the first failure (expand or
+/// per-element check) so the caller can reject the wider message wholesale.
+fn validate_one_app_data_update(
+    component_id: xmtp_mls_common::app_data::component_id::ComponentId,
+    operation: &openmls::messages::proposals::AppDataUpdateOperation,
+    actor: xmtp_mls_common::app_data::validation::ActorAuthority,
+    proposer_inbox_id: &str,
+    registry: &xmtp_mls_common::app_data::component_registry::ComponentRegistry,
+    openmls_group: &OpenMlsGroup,
+) -> Result<(), CommitValidationError> {
+    use super::app_data::component_source::read_from_app_data_dict;
+
+    // Pull the pre-commit stored bytes for this component so the expansion
+    // step can resolve `RemoveByHash` mutations back to the concrete
+    // inbox id being removed. `None` is a legal first-write state — see
+    // the fn docstring above for how the expansion handles it.
+    let old_value = read_from_app_data_dict(component_id, openmls_group);
+
+    validate_one_app_data_update_with_old_value(
+        component_id,
+        operation,
+        actor,
+        proposer_inbox_id,
+        registry,
+        old_value.as_deref(),
+    )
+}
+
+/// Pure core of [`validate_one_app_data_update`] with the
+/// `&OpenMlsGroup` dependency lifted into an explicit `old_value`
+/// argument.
+///
+/// Split out so unit tests can exercise the expand → per-change policy
+/// loop without building a real MLS group. The wrapper just reads
+/// `old_value` from the group's AppData dictionary and forwards the
+/// rest unchanged; both paths must produce identical results, so if
+/// you're tempted to change one, change the other.
+pub(super) fn validate_one_app_data_update_with_old_value(
+    component_id: xmtp_mls_common::app_data::component_id::ComponentId,
+    operation: &openmls::messages::proposals::AppDataUpdateOperation,
+    actor: xmtp_mls_common::app_data::validation::ActorAuthority,
+    proposer_inbox_id: &str,
+    registry: &xmtp_mls_common::app_data::component_registry::ComponentRegistry,
+    old_value: Option<&[u8]>,
+) -> Result<(), CommitValidationError> {
+    use super::app_data::component_source::expand_app_data_update_to_changes;
+    use xmtp_mls_common::app_data::validation::{ComponentChange, validate_component_write};
+
+    let changes =
+        expand_app_data_update_to_changes(component_id, operation, old_value).map_err(|e| {
+            tracing::warn!(
+                proposer_inbox_id,
+                component_id = %component_id,
+                error = %e,
+                "AppDataUpdate proposal rejected: failed to expand payload"
+            );
+            CommitValidationError::InsufficientPermissions
+        })?;
+
+    for change in &changes {
+        // bon::Builder uses type-state encoding for set fields, so each
+        // `.field(_)` call returns a different builder type. We can't
+        // reassign back to the same binding, so the conditional `new_value`
+        // goes through `maybe_new_value` (which accepts `Option<&[u8]>`).
+        let cc = ComponentChange::builder()
+            .component_id(component_id)
+            .op(change.op)
+            .actor(actor)
+            .maybe_new_value(change.value.as_deref())
+            .build();
+
+        if let Err(e) = validate_component_write(&cc, registry) {
+            tracing::warn!(
+                proposer_inbox_id,
+                component_id = %component_id,
+                op = %change.op,
+                error = %e,
+                "AppDataUpdate proposal rejected"
+            );
+            return Err(CommitValidationError::InsufficientPermissions);
+        }
+    }
+
+    Ok(())
+}
+
+/// Resolve the proposer leaf index for a proposal sender, rejecting
+/// senders that can't legally propose `AppDataUpdate`.
+///
+/// External senders and new-member proposals can't carry
+/// `AppDataUpdate` by design — only an existing leaf can propose one.
+/// Pulled out so the rejection reason is a single code path that can
+/// be unit-tested without constructing a `StagedCommit`.
+pub(super) fn app_data_update_proposer_leaf(
+    sender: &Sender,
+) -> Result<&LeafNodeIndex, CommitValidationError> {
+    match sender {
+        Sender::Member(leaf_index) => Ok(leaf_index),
+        Sender::External(_) | Sender::NewMemberCommit | Sender::NewMemberProposal => {
+            Err(CommitValidationError::ActorNotMember)
+        }
+    }
+}
+
+/// Validate every `AppDataUpdate` proposal carried by `staged_commit`
+/// against the group's component registry.
+///
+/// `staged_commit.app_data_update_proposals()` iterates both inline
+/// proposals and references that resolve into the group's proposal
+/// store, so this covers both shapes. `validate_proposal()` covers the
+/// standalone-proposal-by-reference path (proposals that arrive as
+/// their own message), but commits never flow through
+/// `validate_proposal` — they go through `from_staged_commit`. Without
+/// this helper, `AppDataUpdate` proposals committed alongside a commit
+/// would bypass `validate_component_write` entirely, since
+/// `extract_metadata_changes` only inspects the legacy mutable-metadata
+/// extension.
+///
+/// Delegates the per-proposal permission check to
+/// [`validate_one_app_data_update`] so the core logic stays shared with
+/// the standalone-proposal path in [`validate_proposal`].
+fn validate_app_data_update_proposals_in_commit(
+    staged_commit: &StagedCommit,
+    openmls_group: &OpenMlsGroup,
+    immutable_metadata: &GroupMetadata,
+    mutable_metadata: &GroupMutableMetadata,
+) -> Result<(), CommitValidationError> {
+    use super::app_data::load_component_registry;
+    use std::collections::HashMap;
+    use xmtp_mls_common::app_data::{component_id::ComponentId, validation::ActorAuthority};
+
+    // Peek first: the common case is zero AppDataUpdate proposals, in
+    // which case we skip the registry load and the per-proposer work
+    // entirely. This runs on every commit's validation path.
+    //
+    // Safety of the early-exit against unresolvable references: OpenMLS
+    // rejects commits that reference proposals it can't resolve against
+    // the group's proposal store *before* `from_staged_commit` is called
+    // (see `process_message`'s reference-resolution pass). So
+    // `staged_commit.app_data_update_proposals()` iterates only
+    // inline-or-successfully-resolved proposals — an attacker can't
+    // smuggle in a dangling reference that would `peek()` as `None` and
+    // bypass the loop.
+    let mut proposals = staged_commit.app_data_update_proposals().peekable();
+    if proposals.peek().is_none() {
+        return Ok(());
+    }
+
+    let registry = load_component_registry(openmls_group);
+    // A single commit's bootstrap can carry multiple AppDataUpdate proposals
+    // from the same leaf; cache extracted `CommitParticipant`s so we don't
+    // re-walk the admin lists and re-parse the credential for every one.
+    let mut participants: HashMap<LeafNodeIndex, CommitParticipant> = HashMap::new();
+
+    for queued in proposals {
+        let app_data = queued.app_data_update_proposal();
+        let proposer_leaf = app_data_update_proposer_leaf(queued.sender())?;
+        let proposer = match participants.get(proposer_leaf) {
+            Some(cached) => cached,
+            None => {
+                let fresh = extract_commit_participant(
+                    proposer_leaf,
+                    openmls_group,
+                    immutable_metadata,
+                    mutable_metadata,
+                )?;
+                participants.entry(*proposer_leaf).or_insert(fresh)
+            }
+        };
+
+        validate_one_app_data_update(
+            ComponentId::from(app_data.component_id()),
+            app_data.operation(),
+            ActorAuthority::from(proposer),
+            &proposer.inbox_id,
+            &registry,
+            openmls_group,
+        )?;
+    }
+
+    Ok(())
+}
+
 /// Extracts the [`CommitParticipant`] from the [`LeafNodeIndex`]
 fn extract_commit_participant(
     leaf_index: &LeafNodeIndex,
@@ -1441,8 +1672,25 @@ pub fn validate_proposal(
         Proposal::Custom(_) => {
             return Err(unsupported_error());
         }
-        Proposal::AppDataUpdate(_) => {
-            return Err(unsupported_error());
+        Proposal::AppDataUpdate(app_data) => {
+            use super::app_data::load_component_registry;
+            use xmtp_mls_common::app_data::{
+                component_id::ComponentId, validation::ActorAuthority,
+            };
+
+            let registry = load_component_registry(openmls_group);
+
+            // Delegate to the shared helper so the commit-time path
+            // (`validate_app_data_update_proposals_in_commit`) and this
+            // standalone-proposal-by-reference path can't drift apart.
+            validate_one_app_data_update(
+                ComponentId::from(app_data.component_id()),
+                app_data.operation(),
+                ActorAuthority::from(&proposer),
+                &proposer.inbox_id,
+                &registry,
+                openmls_group,
+            )?;
         }
         Proposal::AppEphemeral(_) => {
             return Err(unsupported_error());


### PR DESCRIPTION
Wires the component-permission check into the commit-validation path.
Previously `validate_proposal`'s AppDataUpdate arm returned
`unsupported_error()` and commits that carried AppDataUpdate proposals
(inline or by reference) bypassed permission checks entirely, because
`extract_metadata_changes` only inspects the legacy GMM extension.

- `validate_one_app_data_update` — shared per-proposal check. Expands
  the proposal into `ComponentChange`s (resolving pre-commit values for
  RemoveByHash), then runs `validate_component_write` against the
  registry. Returns `InsufficientPermissions` on the first failure.
- `validate_app_data_update_proposals_in_commit` — iterates every
  AppDataUpdate proposal on a `StagedCommit` (both inline and resolved
  references), caches per-leaf `CommitParticipant` lookups to avoid
  re-walking admin lists, and rejects external/new-member senders
  outright.
- `ValidatedCommit::from_staged_commit` now calls the per-commit check
  after the PSK guard.
- `validate_proposal`'s AppDataUpdate arm delegates to
  `validate_one_app_data_update` so the proposal-by-reference path and
  the in-commit path can't drift.
- `ActorAuthority: From<&CommitParticipant>` maps the admin/super-admin
  flags into the form the registry validator consumes.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Validate AppDataUpdate proposals in `ValidatedCommit` against component permissions
> - `ValidatedCommit::from_staged_commit` now calls `validate_app_data_update_proposals_in_commit` before processing proposal changes, rejecting commits with invalid `AppDataUpdate` proposals.
> - `validate_proposal` no longer returns `UnsupportedProposalType` for `AppDataUpdate`; it now checks the proposal against the component registry and returns `InsufficientPermissions` on failure.
> - Non-member senders (external, new-member commit/proposal) are rejected via `app_data_update_proposer_leaf`, which returns `ActorNotMember` for those sender types.
> - New tests in [test_validate_app_data_update.rs](https://github.com/xmtp/libxmtp/pull/3549/files#diff-f75f6659cdfe281245031edcc9eb481153d705f3b9ce59d110a321f0e6d728ff) cover allowed paths, permission rejections, expansion failures, and sender dispatch cases.
> - Risk: commits containing `AppDataUpdate` proposals that were previously accepted (or returned a different error) will now be rejected if the proposer lacks component write permission.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 603c6aa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->