### PR TITLE
simplify disappearing messages worker + streams

### DIFF
--- a/crates/xmtp_mls/src/client.rs
+++ b/crates/xmtp_mls/src/client.rs
@@ -863,16 +863,19 @@ where
         let conn = self.context.db();
 
         // Fetch the message before deleting so we can emit the decoded message in the event
-        let decoded_message = self.message_v2(message_id.clone()).ok();
+        let msg = conn.get_group_message(&message_id)?;
 
         let num_deleted = conn.delete_message_by_id(&message_id)?;
         // Fire a local event if the message was successfully deleted
         if num_deleted > 0
-            && let Some(message) = decoded_message
+            && let Some(message) = msg
         {
-            let _ = self.context.local_events().send(
-                crate::subscriptions::LocalEvents::MessageDeleted(Box::new(message)),
-            );
+            let _ =
+                self.context
+                    .local_events()
+                    .send(crate::subscriptions::LocalEvents::MsgsDeleted(vec![
+                        message,
+                    ]));
         }
 
         Ok(num_deleted)

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -1444,20 +1444,12 @@ where
             return;
         };
 
-        match crate::messages::decoded_message::DecodedMessage::try_from(original_msg) {
-            Ok(decoded_message) => {
-                let _ = self.context.local_events().send(
-                    crate::subscriptions::LocalEvents::MessageDeleted(Box::new(decoded_message)),
-                );
-            }
-            Err(e) => {
-                tracing::warn!(
-                    message_id = hex::encode(&deletion.deleted_message_id),
-                    error = ?e,
-                    "Failed to decode deleted message for deletion event"
-                );
-            }
-        }
+        let _ = self
+            .context
+            .local_events()
+            .send(crate::subscriptions::LocalEvents::MsgsDeleted(vec![
+                original_msg,
+            ]));
     }
 
     fn process_leave_request_message(
@@ -1590,22 +1582,12 @@ where
 
         let out_of_order = original_msg_opt.is_none();
         if let Some(original_msg) = original_msg_opt {
-            match crate::messages::decoded_message::DecodedMessage::try_from(original_msg) {
-                Ok(decoded_message) => {
-                    let _ = self.context.local_events().send(
-                        crate::subscriptions::LocalEvents::MessageDeleted(Box::new(
-                            decoded_message,
-                        )),
-                    );
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        message_id = hex::encode(&target_message_id),
-                        error = ?e,
-                        "Failed to decode deleted message for deletion event"
-                    );
-                }
-            }
+            let _ =
+                self.context
+                    .local_events()
+                    .send(crate::subscriptions::LocalEvents::MsgsDeleted(vec![
+                        original_msg,
+                    ]));
         }
 
         tracing::info!(

--- a/crates/xmtp_mls/src/groups/tests/test_welcome_pointers.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_welcome_pointers.rs
@@ -649,7 +649,7 @@ async fn test_welcome_pointer_task_retry_resolution() {
         crate::subscriptions::LocalEvents::NewGroup(id) => {
             assert_eq!(id, group.group_id.clone());
         }
-        _ => panic!("Expected NewGroup event"),
+        e => panic!("Expected NewGroup event, got {:?}", e),
     }
 
     tracing::info!("Finding group for bo");

--- a/crates/xmtp_mls/src/subscriptions/mod.rs
+++ b/crates/xmtp_mls/src/subscriptions/mod.rs
@@ -22,6 +22,7 @@ mod stream_all;
 mod stream_conversations;
 pub mod stream_messages;
 
+use crate::messages::enrichment::EnrichMessageError;
 #[cfg(any(test, feature = "test-utils"))]
 use crate::subscriptions::stream_messages::stream_stats::{StreamStatsWrapper, StreamWithStats};
 
@@ -64,7 +65,7 @@ pub enum LocalEvents {
     NewGroup(Vec<u8>),
     PreferencesChanged(Vec<PreferenceUpdate>),
     // a message was deleted (contains the decoded message that was deleted)
-    MessageDeleted(Box<DecodedMessage>),
+    MsgsDeleted(Vec<StoredGroupMessage>),
 }
 
 #[derive(Clone)]
@@ -126,9 +127,9 @@ impl LocalEvents {
         }
     }
 
-    fn message_deletion_filter(self) -> Option<Box<DecodedMessage>> {
+    fn message_deletion_filter(self) -> Option<Vec<StoredGroupMessage>> {
         match self {
-            Self::MessageDeleted(message) => Some(message),
+            Self::MsgsDeleted(msgs) => Some(msgs),
             _ => None,
         }
     }
@@ -137,7 +138,7 @@ impl LocalEvents {
 pub(crate) trait StreamMessages {
     fn stream_consent_updates(self) -> impl Stream<Item = Result<Vec<StoredConsentRecord>>>;
     fn stream_preference_updates(self) -> impl Stream<Item = Result<Vec<PreferenceUpdate>>>;
-    fn stream_message_deletions(self) -> impl Stream<Item = Result<Box<DecodedMessage>>>;
+    fn stream_message_deletions(self) -> impl Stream<Item = Result<DecodedMessage>>;
 }
 
 impl StreamMessages for broadcast::Receiver<LocalEvents> {
@@ -160,12 +161,17 @@ impl StreamMessages for broadcast::Receiver<LocalEvents> {
     }
 
     #[instrument(level = "trace", skip_all)]
-    fn stream_message_deletions(self) -> impl Stream<Item = Result<Box<DecodedMessage>>> {
-        BroadcastStream::new(self).filter_map(|event| async {
-            xmtp_common::optify!(event, "Missed message due to event queue lag")
-                .and_then(LocalEvents::message_deletion_filter)
-                .map(Result::Ok)
-        })
+    fn stream_message_deletions(self) -> impl Stream<Item = Result<DecodedMessage>> {
+        BroadcastStream::new(self)
+            .filter_map(|event| async {
+                xmtp_common::optify!(event, "Missed message due to event queue lag")
+                    .and_then(LocalEvents::message_deletion_filter)
+                    .map(futures::stream::iter)
+            })
+            .flatten()
+            // let caller handle any potential decode failures
+            // this should be rare since the message already in db
+            .map(|m| DecodedMessage::try_from(m).map_err(Into::into))
     }
 }
 
@@ -237,6 +243,9 @@ pub enum SubscribeError {
     /// Decentralized API envelope error. May be retryable.
     #[error(transparent)]
     Envelope(#[from] xmtp_api_d14n::protocol::EnvelopeError),
+    /// Enriched Message Error.
+    #[error("error occured during subscription {0}")]
+    Enriched(#[from] EnrichMessageError),
 }
 
 impl SubscribeError {
@@ -274,6 +283,7 @@ impl RetryableError for SubscribeError {
             Db(c) => retryable!(c),
             Conversion(c) => retryable!(c),
             Envelope(c) => retryable!(c),
+            Enriched(c) => retryable!(c),
         }
     }
 }
@@ -546,7 +556,7 @@ where
             futures::pin_mut!(stream);
             let _ = tx.send(());
             while let Some(message) = stream.next().await {
-                callback(message.map(|boxed| *boxed))
+                callback(message)
             }
             tracing::debug!("`stream_message_deletions` stream ended, dropping stream");
             Ok::<_, SubscribeError>(())

--- a/crates/xmtp_mls/src/worker/disappearing_messages.rs
+++ b/crates/xmtp_mls/src/worker/disappearing_messages.rs
@@ -1,5 +1,4 @@
 use crate::context::XmtpSharedContext;
-use crate::messages::decoded_message::DecodedMessage;
 use crate::worker::{BoxedWorker, NeedsDbReconnect, Worker, WorkerFactory};
 use crate::worker::{WorkerKind, WorkerResult};
 use futures::{StreamExt, TryFutureExt};
@@ -101,41 +100,31 @@ where
     /// Iterate on the list of groups and delete expired messages
     async fn delete_expired_messages(&mut self) -> Result<(), DisappearingMessagesCleanerError> {
         let db = self.context.db();
-        match db.delete_expired_messages() {
-            Ok(deleted_messages) if !deleted_messages.is_empty() => {
-                tracing::info!(
-                    "Successfully deleted {} expired messages",
-                    deleted_messages.len()
-                );
-
-                // Emit an event for each deleted message
-                for message in deleted_messages {
-                    let message_id = message.id.clone();
-                    // Try to convert to DecodedMessage, log warning if conversion fails
-                    match DecodedMessage::try_from(message) {
-                        Ok(decoded_message) => {
-                            let _ = self.context.local_events().send(
-                                crate::subscriptions::LocalEvents::MessageDeleted(Box::new(
-                                    decoded_message,
-                                )),
-                            );
-                        }
-                        Err(e) => {
-                            tracing::warn!(
-                                message_id = hex::encode(&message_id),
-                                error = ?e,
-                                "Failed to decode expired message for deletion event"
-                            );
-                        }
-                    }
-                    tokio::task::yield_now().await;
-                }
-            }
-            Ok(_) => {}
-            Err(e) => {
+        // ensure we propagate the error so that the worker harness can properly handle
+        // `PoolDisconnected`
+        let deleted_messages = db
+            .delete_expired_messages()
+            .inspect_err(|e| {
                 tracing::error!("Failed to delete expired messages, error: {:?}", e);
-            }
+            })
+            .map_err(StorageError::from)?;
+
+        if !deleted_messages.is_empty() {
+            tracing::info!(
+                "Successfully deleted {} expired messages",
+                deleted_messages.len()
+            );
+
+            // Emit a single event for all deleted messages
+            // this avoids a hot loop that may starve async tasks.
+            let _ =
+                self.context
+                    .local_events()
+                    .send(crate::subscriptions::LocalEvents::MsgsDeleted(
+                        deleted_messages,
+                    ));
         }
+
         Ok(())
     }
 }


### PR DESCRIPTION
this fixes the error messages in #3558 . the disappearing messages worker was not properly propagating messages up the stack, so the worker harness never received the `PoolDisconnection` error, and the worker never stopped/restarted. further, the worker sent individual events for each deleted message rather than batch them, which increased the probability of starving async tasks when a pool disconnect happens (worker may loop forever on error, halting other worker operations and possibly causing intermittent failed message sends). 

This PR batches all deleted message into one local event send. further, it decodes the message on the receiving side, simplifying logic elsewhere and propagating a failed decode to the SDK caller allowing caller to handle gracefully

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Simplify disappearing messages worker to emit batched deletion events without decoding
> - Replaces per-message `MessageDeleted(Box<DecodedMessage>)` local events with a single batched `MsgsDeleted(Vec<StoredGroupMessage>)` event across the disappearing messages worker, group sync, and `delete_message` in the client.
> - Removes in-place `DecodedMessage::try_from` calls and associated decode-failure warnings from deletion paths; decoding is now deferred to subscription time in `stream_message_deletions`.
> - Adds an `Enriched(EnrichMessageError)` variant to `SubscribeError` so decode failures during streaming are surfaced as per-message errors rather than silently dropped.
> - Behavioral Change: deletion streams now yield `Result<DecodedMessage>` and may return errors per message; callers previously receiving a guaranteed decoded message must now handle errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d4547de.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->