### PR TITLE
migration part 2a: capability-aware read paths (Task 6)

### DIFF
--- a/crates/xmtp_mls/src/groups/app_data/component_source.rs
+++ b/crates/xmtp_mls/src/groups/app_data/component_source.rs
@@ -121,6 +121,40 @@ pub enum ComponentSourceError {
     TlsMapApply(#[from] TlsMapError),
 }
 
+impl ComponentSourceError {
+    /// Best-effort `ComponentId` extraction for the variants that carry
+    /// one — so error-mapping shims can preserve structured context
+    /// across the crate boundary into
+    /// [`GroupMutableMetadataError::MalformedComponent`] without
+    /// stringifying.
+    pub(crate) fn component_id(&self) -> Option<ComponentId> {
+        match self {
+            Self::UnknownComponent(id)
+            | Self::NotImplemented(id)
+            | Self::ImmutableUpdate(id)
+            | Self::MismatchedMutation(id)
+            | Self::MalformedComponentValue {
+                component_id: id, ..
+            } => Some(*id),
+            _ => None,
+        }
+    }
+}
+
+impl From<ComponentSourceError> for GroupMutableMetadataError {
+    /// Preserve the offending `component_id` when it's available so
+    /// downstream consumers (bindings, error-mapping) can match on it
+    /// structurally. Variants without one surface as `component_id:
+    /// None`; the display string stays the authoritative diagnostic.
+    fn from(err: ComponentSourceError) -> Self {
+        let component_id = err.component_id();
+        GroupMutableMetadataError::MalformedComponent {
+            component_id,
+            reason: err.to_string(),
+        }
+    }
+}
+
 /// Describes a single, atomic mutation that a per-field intent handler wants
 /// to apply to a component. The encoder picks the wire shape (single-element
 /// [`TlsSetDelta`] for collections, passthrough for bytes components).
@@ -589,34 +623,57 @@ pub(crate) fn apply_app_data_update_payload(
     }
 }
 
-/// Merge any well-known component values stored in the OpenMLS AppData
-/// dictionary into a base [`GroupMutableMetadata`] read from the legacy
-/// extension.
+/// Overlay AppData-dict component values onto a base [`GroupMutableMetadata`]
+/// read from the legacy extension. On migrated groups the dict is
+/// authoritative; for unmigrated components the legacy GMM stays as the
+/// fallback, so callers always get a complete view.
 ///
-/// Used by the per-field read accessors (`group_name()`, `admin_list()`,
-/// etc.) so that a group with `proposals_enabled` sees AppData-dict writes
-/// take precedence over whatever the legacy GMM extension still says. The
-/// legacy extension stays as the fallback for components that have not
-/// been migrated yet, so callers always get a complete view.
+/// Gated on [`super::is_migrated_group`] (defense-in-depth) so a stray
+/// dict entry on a pre-bootstrap group can't shadow legacy GMM.
 ///
-/// This is a no-op when the AppData dictionary extension is absent or
-/// empty — the common case for unmigrated groups, where it preserves the
-/// exact bytes returned by [`GroupMutableMetadata::try_from`].
-///
-/// Wire format expectations (must match what the sender path emits via
+/// Wire formats (must match what the sender emits via
 /// [`encode_app_data_update_payload`] / [`apply_app_data_update_payload`]):
+/// - Bytes components: raw UTF-8 string bytes.
+/// - `ADMIN_LIST` / `SUPER_ADMIN_LIST`: TLS-serialized `TlsSet<InboxId>`,
+///   each id hex-encoded back to string form.
 ///
-/// - Bytes components: raw UTF-8 string bytes, written verbatim into the
-///   `attributes` map under the corresponding [`MetadataField`].
-/// - `ADMIN_LIST` / `SUPER_ADMIN_LIST`: a TLS-serialized `TlsSet<InboxId>`
-///   (each entry is `varint(version) || 32-byte payload`); each entry is
-///   hex-encoded back to its string form before being stored in
-///   `admin_list` / `super_admin_list`.
+/// ## Independence from `COMPONENT_REGISTRY` parseability
+///
+/// This function reads metadata field entries directly from the dict and
+/// **never** loads or validates the `COMPONENT_REGISTRY` payload — it
+/// only uses [`super::is_migrated_extensions`] (key-existence check) as
+/// the gate. So a malformed `COMPONENT_REGISTRY` blob does NOT cause
+/// metadata reads to drop authoritative data: as long as the individual
+/// metadata field bytes (`GROUP_NAME`, `ADMIN_LIST`, …) decode
+/// correctly, they round-trip into the returned GMM. Registry corruption
+/// is surfaced loudly on the *write* paths instead — the sender gate in
+/// `mls_sync.rs` and the commit validator in `validated_commit.rs` both
+/// call [`super::load_component_registry`] and propagate decode errors
+/// — so a corrupt registry blocks state changes without making readable
+/// data unreachable. See
+/// `merge_with_malformed_registry_returns_valid_field` for the test
+/// that pins this invariant.
 pub(crate) fn merge_app_data_into_mutable_metadata(
     base: &mut GroupMutableMetadata,
     mls_group: &OpenMlsGroup,
 ) -> Result<(), ComponentSourceError> {
-    let Some(ext) = mls_group.extensions().app_data_dictionary() else {
+    merge_app_data_into_mutable_metadata_from_extensions(base, mls_group.extensions())
+}
+
+/// Extensions-only variant of [`merge_app_data_into_mutable_metadata`].
+/// Mirrors the [`super::is_migrated_group`] / [`super::is_migrated_extensions`]
+/// and [`super::load_component_registry`] /
+/// [`super::load_component_registry_from_extensions`] splits so unit
+/// tests can pin the merge contract without materializing an
+/// `OpenMlsGroup`.
+pub(crate) fn merge_app_data_into_mutable_metadata_from_extensions(
+    base: &mut GroupMutableMetadata,
+    extensions: &openmls::extensions::Extensions<openmls::group::GroupContext>,
+) -> Result<(), ComponentSourceError> {
+    if !super::is_migrated_extensions(extensions) {
+        return Ok(());
+    }
+    let Some(ext) = extensions.app_data_dictionary() else {
         return Ok(());
     };
     let dict = ext.dictionary();
@@ -638,23 +695,23 @@ pub(crate) fn merge_app_data_into_mutable_metadata(
         }
     }
 
-    // ADMIN_LIST / SUPER_ADMIN_LIST are intentionally NOT merged in
-    // this PR. `IntentKind::UpdateAdminList` in `mls_sync.rs` stays
-    // unconditionally on the legacy GCE path — nothing in the
-    // production sender pipeline emits an `AppDataUpdate(ADMIN_LIST,…)`
-    // proposal, so the ADMIN_LIST dict entry is empty by construction.
-    //
-    // Merging a hypothetical dict entry here without also re-routing
-    // the sender path AND updating the `validated_commit.rs` admin-list
-    // validators (which currently treat the legacy GMM extension as
-    // source of truth) would put writers and readers out of sync, and
-    // would let a Byzantine peer shadow the validated GMM state via
-    // the un-validated dict.
-    //
-    // The overlay is re-enabled as Task 6 of the migration PR — see
-    // `docs/plans/2026-04-10-app-data-migration-plan.md`. That PR
-    // flips the sender path, the validator, and this merge in lockstep
-    // so all three layers agree.
+    // ADMIN_LIST / SUPER_ADMIN_LIST overlay: on migrated groups the
+    // dict is authoritative; decode the `TlsSet<InboxId>` and
+    // hex-encode each id back to string form for the base GMM.
+    for (component_id, list) in [
+        (ComponentId::ADMIN_LIST, &mut base.admin_list),
+        (ComponentId::SUPER_ADMIN_LIST, &mut base.super_admin_list),
+    ] {
+        if let Some(bytes) = dict.get(&component_id.as_u16()) {
+            let set = TlsSet::<InboxId>::tls_deserialize_exact(bytes).map_err(|e| {
+                ComponentSourceError::MalformedComponentValue {
+                    component_id,
+                    reason: format!("invalid TlsSet<InboxId>: {e}"),
+                }
+            })?;
+            *list = set.iter().map(|id| id.to_hex()).collect();
+        }
+    }
     Ok(())
 }
 
@@ -677,6 +734,245 @@ pub(crate) fn merge_app_data_into_mutable_metadata(
 /// inner variant.
 pub(crate) fn inbox_id_str_to_bytes(inbox_id: &str) -> Result<InboxId, ComponentSourceError> {
     InboxId::from_hex(inbox_id).map_err(Into::into)
+}
+
+/// Read the super-admin list from the AppData dictionary on a migrated
+/// group. Returns `Ok(None)` on unmigrated groups (or migrated groups
+/// that happen not to have written `SUPER_ADMIN_LIST` yet).
+///
+/// Gated on [`super::is_migrated_group`] for the same reason as
+/// [`merge_app_data_into_mutable_metadata`] — keep stray dict entries
+/// from shadowing the authoritative legacy path pre-bootstrap.
+pub(crate) fn read_super_admin_list_from_dict(
+    mls_group: &OpenMlsGroup,
+) -> Result<Option<Vec<String>>, ComponentSourceError> {
+    read_super_admin_list_from_extensions(mls_group.extensions())
+}
+
+/// Extensions-only variant of [`read_super_admin_list_from_dict`]. Use
+/// the shim above when an `OpenMlsGroup` is at hand; this form is
+/// available primarily for unit testing and for commit-validation
+/// paths that only carry an `Extensions` reference.
+pub(crate) fn read_super_admin_list_from_extensions(
+    extensions: &Extensions<GroupContext>,
+) -> Result<Option<Vec<String>>, ComponentSourceError> {
+    if !super::is_migrated_extensions(extensions) {
+        return Ok(None);
+    }
+    let Some(ext) = extensions.app_data_dictionary() else {
+        return Ok(None);
+    };
+    let Some(bytes) = ext
+        .dictionary()
+        .get(&ComponentId::SUPER_ADMIN_LIST.as_u16())
+    else {
+        return Ok(None);
+    };
+    let set = TlsSet::<InboxId>::tls_deserialize_exact(bytes).map_err(|e| {
+        ComponentSourceError::MalformedComponentValue {
+            component_id: ComponentId::SUPER_ADMIN_LIST,
+            reason: format!("invalid TlsSet<InboxId>: {e}"),
+        }
+    })?;
+    Ok(Some(set.iter().map(|id| id.to_hex()).collect()))
+}
+
+/// Synthesize a [`GroupMetadata`] from the AppData dictionary on a
+/// migrated group. Returns `Ok(None)` if the critical immutable seeds
+/// aren't present (unmigrated group).
+///
+/// Encoding mirrors the sender-side synthesis in
+/// [`xmtp_mls_common::app_data::migration::synthesize_canonical_subset_for_validation`]:
+/// - `CONVERSATION_TYPE`: 4 big-endian bytes of `ConversationType as i32`
+///   (see `encode_conversation_type` there).
+/// - `CREATOR_INBOX_ID`: raw UTF-8 inbox id string.
+/// - `DM_MEMBERS`: `TlsSet<InboxId>` with exactly two elements —
+///   matches the declared `ComponentType::TlsSetInboxId` and the
+///   sender's `encode_dm_members`. The writer rejects self-DMs
+///   (identical slots) up front; readers that see a 1-element set
+///   surface `MalformedComponentValue`.
+/// - `ONESHOT_MESSAGE`: prost-encoded `OneshotMessage`.
+pub(crate) fn read_group_metadata_from_dict(
+    mls_group: &OpenMlsGroup,
+) -> Result<Option<GroupMetadataReturn>, ComponentSourceError> {
+    read_group_metadata_from_extensions(mls_group.extensions())
+}
+
+/// Extensions-only variant of [`read_group_metadata_from_dict`]. Same
+/// rationale for the split as [`read_super_admin_list_from_extensions`].
+pub(crate) fn read_group_metadata_from_extensions(
+    extensions: &Extensions<GroupContext>,
+) -> Result<Option<GroupMetadataReturn>, ComponentSourceError> {
+    use prost::Message;
+    use xmtp_proto::xmtp::mls::message_contents::{
+        DmMembers as DmMembersProto, Inbox as InboxProto, OneshotMessage,
+    };
+
+    // Gated on the unified migration predicate — see
+    // `merge_app_data_into_mutable_metadata` for the rationale.
+    if !super::is_migrated_extensions(extensions) {
+        return Ok(None);
+    }
+
+    let Some(ext) = extensions.app_data_dictionary() else {
+        return Ok(None);
+    };
+    let dict = ext.dictionary();
+
+    let Some(ct_bytes) = dict.get(&ComponentId::CONVERSATION_TYPE.as_u16()) else {
+        return Ok(None);
+    };
+    let Some(creator_bytes) = dict.get(&ComponentId::CREATOR_INBOX_ID.as_u16()) else {
+        return Ok(None);
+    };
+
+    let ct_arr: [u8; 4] =
+        ct_bytes
+            .try_into()
+            .map_err(|_| ComponentSourceError::MalformedComponentValue {
+                component_id: ComponentId::CONVERSATION_TYPE,
+                reason: format!("expected 4 bytes, got {}", ct_bytes.len()),
+            })?;
+    let conversation_type = i32::from_be_bytes(ct_arr);
+
+    let creator_inbox_id = std::str::from_utf8(creator_bytes)
+        .map_err(|e| ComponentSourceError::MalformedComponentValue {
+            component_id: ComponentId::CREATOR_INBOX_ID,
+            reason: format!("non-UTF-8: {e}"),
+        })?
+        .to_string();
+
+    // `DM_MEMBERS` on the wire is `TlsSet<InboxId>`; re-shape to
+    // `DmMembersProto` so downstream `GroupMetadata::try_from` is unchanged.
+    let dm_members = match dict.get(&ComponentId::DM_MEMBERS.as_u16()) {
+        Some(b) => {
+            let set = TlsSet::<InboxId>::tls_deserialize_exact(b).map_err(|e| {
+                ComponentSourceError::MalformedComponentValue {
+                    component_id: ComponentId::DM_MEMBERS,
+                    reason: format!("invalid TlsSet<InboxId>: {e}"),
+                }
+            })?;
+            let ids: Vec<InboxId> = set.iter().copied().collect();
+            if ids.len() != 2 {
+                return Err(ComponentSourceError::MalformedComponentValue {
+                    component_id: ComponentId::DM_MEMBERS,
+                    reason: format!("expected 2 inbox ids, got {}", ids.len()),
+                });
+            }
+            Some(DmMembersProto {
+                dm_member_one: Some(InboxProto {
+                    inbox_id: ids[0].to_hex(),
+                }),
+                dm_member_two: Some(InboxProto {
+                    inbox_id: ids[1].to_hex(),
+                }),
+            })
+        }
+        None => None,
+    };
+
+    let oneshot = match dict.get(&ComponentId::ONESHOT_MESSAGE.as_u16()) {
+        Some(b) => Some(OneshotMessage::decode(b).map_err(|e| {
+            ComponentSourceError::MalformedComponentValue {
+                component_id: ComponentId::ONESHOT_MESSAGE,
+                reason: format!("OneshotMessage prost decode: {e}"),
+            }
+        })?),
+        None => None,
+    };
+
+    Ok(Some(GroupMetadataReturn {
+        conversation_type,
+        creator_inbox_id,
+        dm_members,
+        oneshot,
+    }))
+}
+
+/// Intermediate proto-shaped result of [`read_group_metadata_from_extensions`].
+/// Caller converts to the final [`xmtp_mls_common::group_metadata::GroupMetadata`].
+#[derive(Debug)]
+pub(crate) struct GroupMetadataReturn {
+    pub conversation_type: i32,
+    pub creator_inbox_id: String,
+    pub dm_members: Option<xmtp_proto::xmtp::mls::message_contents::DmMembers>,
+    pub oneshot: Option<xmtp_proto::xmtp::mls::message_contents::OneshotMessage>,
+}
+
+/// Read the `GROUP_MEMBERSHIP` dict entry and decode it into the
+/// legacy `GroupMembership` proto shape. Returns `Ok(None)` for
+/// unmigrated groups. Used by `extract_group_membership` on the
+/// receive-side validator to bridge the dict-stored membership back
+/// into the existing `GroupMembership` Rust type without rewriting
+/// every caller.
+pub(crate) fn read_group_membership_from_dict(
+    extensions: &Extensions<GroupContext>,
+) -> Result<Option<xmtp_proto::xmtp::mls::message_contents::GroupMembership>, ComponentSourceError>
+{
+    use xmtp_mls_common::app_data::migration::decode_group_membership_delta;
+    use xmtp_proto::xmtp::mls::message_contents::GroupMembership as GroupMembershipProto;
+
+    // Gate on the unified migration predicate so a stray
+    // `GROUP_MEMBERSHIP` dict entry on a pre-bootstrap group can't
+    // shadow the authoritative legacy extension. Matches the gating
+    // used by [`merge_app_data_into_mutable_metadata`] and the
+    // `mutable_metadata()` / `is_super_admin_without_lock` callers.
+    if !super::is_migrated_extensions(extensions) {
+        return Ok(None);
+    }
+
+    let Some(ext) = extensions.app_data_dictionary() else {
+        return Ok(None);
+    };
+    let Some(bytes) = ext
+        .dictionary()
+        .get(&ComponentId::GROUP_MEMBERSHIP.as_u16())
+    else {
+        return Ok(None);
+    };
+
+    let entries = decode_group_membership_delta(bytes).map_err(|e| {
+        ComponentSourceError::MalformedComponentValue {
+            component_id: ComponentId::GROUP_MEMBERSHIP,
+            reason: format!("TlsMap decode: {e}"),
+        }
+    })?;
+
+    // Flatten per-inbox GroupMembershipEntryV1 back into the legacy
+    // proto shape: members (inbox_id → sequence_id), failed_installations
+    // (flat Vec). The proto still has a flat failed_installations field
+    // for backward compat — we concatenate per-inbox failed lists for
+    // callers that still read the flat list.
+    //
+    // `decode_group_membership_delta` already rejects entries with
+    // `version: None` (`MigrationError::GroupMembershipEntryUnknownVersion`),
+    // so the only legal post-decode shape today is `Some(Version::V1(_))`.
+    // Anything else (a future Version variant we can't interpret) is a
+    // forward-compat hazard and surfaces as `MalformedComponentValue`.
+    use xmtp_proto::xmtp::mls::message_contents::group_membership_entry::Version as GroupMembershipEntryVersion;
+    let mut members: std::collections::HashMap<String, u64> = std::collections::HashMap::new();
+    let mut failed: Vec<Vec<u8>> = Vec::new();
+    for (inbox_id, entry) in entries {
+        let v1 = match entry.version {
+            Some(GroupMembershipEntryVersion::V1(v1)) => v1,
+            None => {
+                return Err(ComponentSourceError::MalformedComponentValue {
+                    component_id: ComponentId::GROUP_MEMBERSHIP,
+                    reason: format!(
+                        "GroupMembershipEntry for {} has no version",
+                        inbox_id.to_hex()
+                    ),
+                });
+            }
+        };
+        members.insert(inbox_id.to_hex(), v1.sequence_id);
+        failed.extend(v1.failed_installations);
+    }
+
+    Ok(Some(GroupMembershipProto {
+        members,
+        failed_installations: failed,
+    }))
 }
 
 /// Encode a list of hex inbox ids as a TLS-serialized `TlsSet<InboxId>`.
@@ -1335,5 +1631,427 @@ mod tests {
         .unwrap();
         assert_eq!(changes.len(), 1);
         assert_eq!(changes[0].op, ComponentOp::Insert);
+    }
+
+    // ========================================================================
+    // Dict-reader helpers — happy path / unmigrated / malformed coverage
+    // ========================================================================
+    //
+    // The three `read_*_from_dict` helpers execute before bootstrap is
+    // wired end-to-end; the unit tests below pin the wire-format
+    // contract so a decoder drift can't silently ship a broken read path.
+
+    use openmls::extensions::{
+        AppDataDictionary, AppDataDictionaryExtension, Extension as OpenMlsExtension, Extensions,
+    };
+
+    /// Build a synthetic `Extensions<GroupContext>` that carries only
+    /// an `AppDataDictionary`. `migrated=true` seeds
+    /// `COMPONENT_REGISTRY` with placeholder bytes so
+    /// `is_migrated_extensions` returns true; `migrated=false` leaves
+    /// the marker absent.
+    fn extensions_with_entries(
+        migrated: bool,
+        entries: &[(u16, Vec<u8>)],
+    ) -> Extensions<openmls::group::GroupContext> {
+        let mut dict = AppDataDictionary::new();
+        if migrated {
+            let _ = dict.insert(ComponentId::COMPONENT_REGISTRY.as_u16(), vec![0xCA; 4]);
+        }
+        for (id, bytes) in entries {
+            let _ = dict.insert(*id, bytes.clone());
+        }
+        Extensions::from_vec(vec![OpenMlsExtension::AppDataDictionary(
+            AppDataDictionaryExtension::new(dict),
+        )])
+        .expect("valid group-context extension set")
+    }
+
+    // --- read_super_admin_list_from_extensions ------------------------------
+
+    #[xmtp_common::test]
+    fn read_super_admin_list_unmigrated_returns_none() {
+        // No COMPONENT_REGISTRY marker => unmigrated, overlay stays off
+        // even if SUPER_ADMIN_LIST bytes happen to exist.
+        let exts = extensions_with_entries(
+            false,
+            &[(
+                ComponentId::SUPER_ADMIN_LIST.as_u16(),
+                encode_inbox_id_set(&[fake_inbox_id(0x11)]).unwrap(),
+            )],
+        );
+        assert!(
+            read_super_admin_list_from_extensions(&exts)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[xmtp_common::test]
+    fn read_super_admin_list_migrated_absent_returns_none() {
+        // Migrated group but the dict has no SUPER_ADMIN_LIST entry —
+        // `Ok(None)` rather than surfacing a malformed-value error.
+        let exts = extensions_with_entries(true, &[]);
+        assert!(
+            read_super_admin_list_from_extensions(&exts)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[xmtp_common::test]
+    fn read_super_admin_list_migrated_happy_path() {
+        let ids = vec![fake_inbox_id(0xAA), fake_inbox_id(0xBB)];
+        let bytes = encode_inbox_id_set(&ids).unwrap();
+        let exts =
+            extensions_with_entries(true, &[(ComponentId::SUPER_ADMIN_LIST.as_u16(), bytes)]);
+        let got = read_super_admin_list_from_extensions(&exts)
+            .unwrap()
+            .unwrap();
+        assert_eq!(got.len(), 2);
+        // TlsSet sorts by value so 0xAA sorts before 0xBB.
+        assert_eq!(got[0], fake_inbox_id(0xAA));
+        assert_eq!(got[1], fake_inbox_id(0xBB));
+    }
+
+    #[xmtp_common::test]
+    fn read_super_admin_list_malformed_bytes_surface_error() {
+        let exts = extensions_with_entries(
+            true,
+            &[(
+                ComponentId::SUPER_ADMIN_LIST.as_u16(),
+                vec![0x00, 0xDE, 0xAD],
+            )],
+        );
+        let err = read_super_admin_list_from_extensions(&exts).unwrap_err();
+        assert!(matches!(
+            err,
+            ComponentSourceError::MalformedComponentValue {
+                component_id,
+                ..
+            } if component_id == ComponentId::SUPER_ADMIN_LIST
+        ));
+    }
+
+    // --- read_group_metadata_from_extensions --------------------------------
+
+    fn encode_conv_type_bytes(value: i32) -> Vec<u8> {
+        value.to_be_bytes().to_vec()
+    }
+
+    fn encode_dm_pair(tag_a: u8, tag_b: u8) -> Vec<u8> {
+        encode_inbox_id_set(&[fake_inbox_id(tag_a), fake_inbox_id(tag_b)]).unwrap()
+    }
+
+    #[xmtp_common::test]
+    fn read_group_metadata_unmigrated_returns_none() {
+        let exts = extensions_with_entries(
+            false,
+            &[
+                (
+                    ComponentId::CONVERSATION_TYPE.as_u16(),
+                    encode_conv_type_bytes(1),
+                ),
+                (
+                    ComponentId::CREATOR_INBOX_ID.as_u16(),
+                    fake_inbox_id(0x11).into_bytes(),
+                ),
+            ],
+        );
+        assert!(
+            read_group_metadata_from_extensions(&exts)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[xmtp_common::test]
+    fn read_group_metadata_missing_required_seeds_returns_none() {
+        // Migrated group but CONVERSATION_TYPE is absent — treat as
+        // "seeds not ready yet" (Ok(None)) rather than malformed.
+        let exts = extensions_with_entries(true, &[]);
+        assert!(
+            read_group_metadata_from_extensions(&exts)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[xmtp_common::test]
+    fn read_group_metadata_happy_path_non_dm() {
+        let exts = extensions_with_entries(
+            true,
+            &[
+                (
+                    ComponentId::CONVERSATION_TYPE.as_u16(),
+                    encode_conv_type_bytes(1),
+                ),
+                (
+                    ComponentId::CREATOR_INBOX_ID.as_u16(),
+                    fake_inbox_id(0x11).into_bytes(),
+                ),
+            ],
+        );
+        let got = read_group_metadata_from_extensions(&exts).unwrap().unwrap();
+        assert_eq!(got.conversation_type, 1);
+        assert_eq!(got.creator_inbox_id, fake_inbox_id(0x11));
+        assert!(got.dm_members.is_none());
+        assert!(got.oneshot.is_none());
+    }
+
+    #[xmtp_common::test]
+    fn read_group_metadata_dm_happy_path() {
+        // DM group — DM_MEMBERS decodes as TlsSet<InboxId>, re-shaped
+        // to the proto's two-slot form.
+        let exts = extensions_with_entries(
+            true,
+            &[
+                (
+                    ComponentId::CONVERSATION_TYPE.as_u16(),
+                    encode_conv_type_bytes(2),
+                ),
+                (
+                    ComponentId::CREATOR_INBOX_ID.as_u16(),
+                    fake_inbox_id(0x22).into_bytes(),
+                ),
+                (ComponentId::DM_MEMBERS.as_u16(), encode_dm_pair(0x22, 0x33)),
+            ],
+        );
+        let got = read_group_metadata_from_extensions(&exts).unwrap().unwrap();
+        let dm = got.dm_members.unwrap();
+        assert_eq!(dm.dm_member_one.unwrap().inbox_id, fake_inbox_id(0x22));
+        assert_eq!(dm.dm_member_two.unwrap().inbox_id, fake_inbox_id(0x33));
+    }
+
+    #[xmtp_common::test]
+    fn read_group_metadata_dm_wrong_cardinality_errors() {
+        // A 1-element TlsSet<InboxId> is invalid for DM_MEMBERS —
+        // surfaces `MalformedComponentValue`.
+        let one_element = encode_inbox_id_set(&[fake_inbox_id(0x44)]).unwrap();
+        let exts = extensions_with_entries(
+            true,
+            &[
+                (
+                    ComponentId::CONVERSATION_TYPE.as_u16(),
+                    encode_conv_type_bytes(2),
+                ),
+                (
+                    ComponentId::CREATOR_INBOX_ID.as_u16(),
+                    fake_inbox_id(0x44).into_bytes(),
+                ),
+                (ComponentId::DM_MEMBERS.as_u16(), one_element),
+            ],
+        );
+        let err = read_group_metadata_from_extensions(&exts).unwrap_err();
+        assert!(matches!(
+            err,
+            ComponentSourceError::MalformedComponentValue {
+                component_id,
+                ..
+            } if component_id == ComponentId::DM_MEMBERS
+        ));
+    }
+
+    #[xmtp_common::test]
+    fn read_group_metadata_non_utf8_creator_errors() {
+        let exts = extensions_with_entries(
+            true,
+            &[
+                (
+                    ComponentId::CONVERSATION_TYPE.as_u16(),
+                    encode_conv_type_bytes(1),
+                ),
+                (
+                    ComponentId::CREATOR_INBOX_ID.as_u16(),
+                    vec![0xFF, 0xFE, 0xFD], // invalid UTF-8
+                ),
+            ],
+        );
+        let err = read_group_metadata_from_extensions(&exts).unwrap_err();
+        assert!(matches!(
+            err,
+            ComponentSourceError::MalformedComponentValue {
+                component_id,
+                ..
+            } if component_id == ComponentId::CREATOR_INBOX_ID
+        ));
+    }
+
+    // --- read_group_membership_from_dict ------------------------------------
+
+    #[xmtp_common::test]
+    fn read_group_membership_unmigrated_returns_none() {
+        use std::collections::BTreeMap;
+        use xmtp_mls_common::app_data::migration::encode_group_membership_delta;
+        use xmtp_proto::xmtp::mls::message_contents::{
+            GroupMembershipEntry,
+            group_membership_entry::{V1 as GroupMembershipEntryV1, Version},
+        };
+        let mut entries: BTreeMap<InboxId, GroupMembershipEntry> = BTreeMap::new();
+        entries.insert(
+            InboxId::from_bytes([0x11; INBOX_ID_BYTE_LEN]),
+            GroupMembershipEntry {
+                version: Some(Version::V1(GroupMembershipEntryV1 {
+                    sequence_id: 1,
+                    failed_installations: vec![],
+                })),
+            },
+        );
+        let bytes = encode_group_membership_delta(&entries).unwrap();
+        let exts =
+            extensions_with_entries(false, &[(ComponentId::GROUP_MEMBERSHIP.as_u16(), bytes)]);
+        assert!(read_group_membership_from_dict(&exts).unwrap().is_none());
+    }
+
+    #[xmtp_common::test]
+    fn read_group_membership_happy_path_flattens_per_inbox() {
+        use std::collections::BTreeMap;
+        use xmtp_mls_common::app_data::migration::encode_group_membership_delta;
+        use xmtp_proto::xmtp::mls::message_contents::{
+            GroupMembershipEntry,
+            group_membership_entry::{V1 as GroupMembershipEntryV1, Version},
+        };
+        let mut entries: BTreeMap<InboxId, GroupMembershipEntry> = BTreeMap::new();
+        entries.insert(
+            InboxId::from_bytes([0x11; INBOX_ID_BYTE_LEN]),
+            GroupMembershipEntry {
+                version: Some(Version::V1(GroupMembershipEntryV1 {
+                    sequence_id: 7,
+                    failed_installations: vec![vec![0xA1; 16]],
+                })),
+            },
+        );
+        entries.insert(
+            InboxId::from_bytes([0x22; INBOX_ID_BYTE_LEN]),
+            GroupMembershipEntry {
+                version: Some(Version::V1(GroupMembershipEntryV1 {
+                    sequence_id: 42,
+                    failed_installations: vec![vec![0xB1; 16]],
+                })),
+            },
+        );
+        let bytes = encode_group_membership_delta(&entries).unwrap();
+        let exts =
+            extensions_with_entries(true, &[(ComponentId::GROUP_MEMBERSHIP.as_u16(), bytes)]);
+
+        let proto = read_group_membership_from_dict(&exts).unwrap().unwrap();
+        // `members` is flat <hex_inbox_id, seq>
+        assert_eq!(proto.members.len(), 2);
+        assert_eq!(proto.members.get(&fake_inbox_id(0x11)), Some(&7));
+        assert_eq!(proto.members.get(&fake_inbox_id(0x22)), Some(&42));
+        // `failed_installations` concatenates the per-inbox lists.
+        assert_eq!(proto.failed_installations.len(), 2);
+    }
+
+    #[xmtp_common::test]
+    fn read_group_membership_malformed_bytes_surface_error() {
+        let exts = extensions_with_entries(
+            true,
+            &[(
+                ComponentId::GROUP_MEMBERSHIP.as_u16(),
+                vec![0xDE, 0xAD, 0xBE, 0xEF],
+            )],
+        );
+        let err = read_group_membership_from_dict(&exts).unwrap_err();
+        assert!(matches!(
+            err,
+            ComponentSourceError::MalformedComponentValue {
+                component_id,
+                ..
+            } if component_id == ComponentId::GROUP_MEMBERSHIP
+        ));
+    }
+
+    // ========================================================================
+    // merge_app_data_into_mutable_metadata_from_extensions —
+    //   independence from COMPONENT_REGISTRY parseability
+    // ========================================================================
+    //
+    // These pin the call-graph invariant that a malformed
+    // `COMPONENT_REGISTRY` does **not** cause `mutable_metadata()` to
+    // drop authoritative dict-backed fields. The migration-marker check
+    // (`is_migrated_extensions`) uses key existence; the merge function
+    // reads each metadata field directly from the dict; nothing on this
+    // read path calls `load_component_registry`. Registry corruption is
+    // surfaced loudly on the *write* paths (sender gate in `mls_sync.rs`
+    // and the commit validator in `validated_commit.rs`), where it
+    // belongs.
+    //
+    // Note: the existing `extensions_with_entries(migrated=true, …)`
+    // helper already seeds `COMPONENT_REGISTRY` with placeholder bytes
+    // (`vec![0xCA; 4]`) that don't decode as a valid registry, so every
+    // migrated-test in this file already exercises the malformed-
+    // registry branch implicitly. The tests below pin it explicitly so
+    // a reviewer doesn't have to chase the helper to verify.
+
+    use xmtp_mls_common::group_mutable_metadata::{GroupMutableMetadata, MetadataField};
+
+    fn empty_base_gmm() -> GroupMutableMetadata {
+        GroupMutableMetadata::new(std::collections::HashMap::new(), Vec::new(), Vec::new())
+    }
+
+    #[xmtp_common::test]
+    fn merge_with_malformed_registry_returns_valid_field() {
+        // Reviewer's alleged "data loss" scenario: COMPONENT_REGISTRY
+        // contains malformed bytes, but a metadata field (GROUP_NAME)
+        // is present and valid. The merge function does NOT validate
+        // the registry — it reads GROUP_NAME directly — so the result
+        // must contain "My Group" with no error.
+        let exts = extensions_with_entries(
+            true, // seeds COMPONENT_REGISTRY with non-decodable 0xCA bytes
+            &[(ComponentId::GROUP_NAME.as_u16(), b"My Group".to_vec())],
+        );
+        let mut base = empty_base_gmm();
+        merge_app_data_into_mutable_metadata_from_extensions(&mut base, &exts)
+            .expect("merge ignores registry parseability and reads field directly");
+        assert_eq!(
+            base.attributes
+                .get(MetadataField::GroupName.as_str())
+                .map(String::as_str),
+            Some("My Group"),
+        );
+    }
+
+    #[xmtp_common::test]
+    fn merge_unmigrated_is_noop() {
+        // Sanity: pre-migration, the merge gate stays closed — even
+        // if a stray dict entry exists, the base GMM is left untouched
+        // so legacy GMM remains authoritative.
+        let exts = extensions_with_entries(
+            false,
+            &[(ComponentId::GROUP_NAME.as_u16(), b"Stray".to_vec())],
+        );
+        let mut base = empty_base_gmm();
+        merge_app_data_into_mutable_metadata_from_extensions(&mut base, &exts).unwrap();
+        assert!(
+            !base
+                .attributes
+                .contains_key(MetadataField::GroupName.as_str()),
+            "merge must be a no-op on unmigrated extensions"
+        );
+    }
+
+    #[xmtp_common::test]
+    fn merge_with_malformed_field_surfaces_error_not_silent_loss() {
+        // The other half of the invariant: when a metadata field's bytes
+        // ARE malformed, the merge fails loudly with
+        // `MalformedComponentValue` carrying the offending component id —
+        // it never silently swallows the value. Pairs with the test
+        // above to disprove "all metadata may be lost" framings.
+        let exts = extensions_with_entries(
+            true,
+            &[(ComponentId::ADMIN_LIST.as_u16(), vec![0xff, 0xff, 0xff])],
+        );
+        let mut base = empty_base_gmm();
+        let err =
+            merge_app_data_into_mutable_metadata_from_extensions(&mut base, &exts).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                ComponentSourceError::MalformedComponentValue { component_id, .. }
+                    if component_id == ComponentId::ADMIN_LIST
+            ),
+            "expected MalformedComponentValue for ADMIN_LIST, got: {err:?}"
+        );
     }
 }

--- a/crates/xmtp_mls/src/groups/app_data/mod.rs
+++ b/crates/xmtp_mls/src/groups/app_data/mod.rs
@@ -364,46 +364,309 @@ pub(crate) fn pending_app_data_updates(
     accumulate_app_data_updates(mls_group, iter)
 }
 
+/// True when the group has completed the bootstrap migration from
+/// legacy GCE extensions to the AppData dictionary.
+///
+/// The discriminator is "does the dict have a `COMPONENT_REGISTRY`
+/// entry?" — bootstrap writes that entry as its first proposal, so
+/// its presence is the ground-truth marker that the group has been
+/// migrated.
+///
+/// This is intentionally distinct from [`MlsGroup::proposals_enabled`]:
+/// a group can have `proposals_enabled == true` without having
+/// completed a bootstrap commit yet (the foundation-PR window).
+/// Read accessors key off this helper instead so they correctly fall
+/// back to the legacy GMM extension on proposals-enabled-but-
+/// unbootstrapped groups.
+pub(crate) fn is_migrated_group(mls_group: &OpenMlsGroup) -> bool {
+    is_migrated_extensions(mls_group.extensions())
+}
+
+/// Extensions-only variant of [`is_migrated_group`]. Kept in sync so
+/// every read-path gate lands on the same predicate (COMPONENT_REGISTRY
+/// present in the AppData dict) — consumers that only have an
+/// `Extensions` reference (e.g. commit-validation paths walking
+/// staged-commit extensions) can call this directly without
+/// materializing an `OpenMlsGroup`.
+///
+/// Test-only override: when a test harness has installed a
+/// [`TEST_REGISTRY_OVERRIDE`] scope the group is treated as migrated
+/// regardless of what the dict contains. This bridges the gap for
+/// tests that exercise post-bootstrap reader semantics without
+/// actually running the bootstrap commit (which writes the real
+/// `COMPONENT_REGISTRY` entry — that work lives in a follow-up
+/// branch). Production paths never hit this branch because the
+/// task-local is only initialized inside test scopes.
+pub(crate) fn is_migrated_extensions(
+    extensions: &openmls::extensions::Extensions<openmls::group::GroupContext>,
+) -> bool {
+    // Test-only override: treat the group as migrated when a
+    // [`TEST_REGISTRY_OVERRIDE`] scope is active *and* the dict has
+    // any entry — i.e. at least one post-capability AppDataUpdate has
+    // written something. The dict-has-any-entry clause matters so that
+    // pre-`enable_proposals()` test steps (which write via the legacy
+    // path and leave the dict empty) still see legacy-authoritative
+    // semantics.
+    #[cfg(any(test, feature = "test-utils"))]
+    if TEST_REGISTRY_OVERRIDE.try_with(|_| ()).is_ok() {
+        let has_any_entry = extensions
+            .app_data_dictionary()
+            .map(|ext| !ext.dictionary().is_empty())
+            .unwrap_or(false);
+        if has_any_entry {
+            return true;
+        }
+    }
+    extensions
+        .app_data_dictionary()
+        .map(|ext| {
+            ext.dictionary()
+                .contains(&ComponentId::COMPONENT_REGISTRY.as_u16())
+        })
+        .unwrap_or(false)
+}
+
 /// Load the [`ComponentRegistry`] for a group.
 ///
-/// Returns an empty registry in production until the migration PR lands
-/// — see `docs/plans/2026-04-10-app-data-migration-plan.md` for the
-/// bootstrap-commit design that will synthesize and persist the
-/// registry inside the AppData dict under
-/// [`ComponentId::COMPONENT_REGISTRY`].
+/// On a migrated group the registry lives in the AppData dict under
+/// [`ComponentId::COMPONENT_REGISTRY`]; on unmigrated groups it
+/// returns an empty registry (or the test override, when present —
+/// see [`TEST_REGISTRY_OVERRIDE`]).
 ///
-/// ## Security model while the registry is empty
+/// Returns an error when a `COMPONENT_REGISTRY` entry is present in
+/// the dict but its bytes don't decode — silently swallowing that into
+/// an empty registry would let [`is_migrated_extensions`] (which only
+/// checks key existence) and this loader disagree about whether the
+/// group is migrated, and downstream readers built on an empty
+/// registry would silently lose every dict-backed component on the
+/// migrated path. Surfacing as
+/// [`ComponentSourceError::MalformedComponentValue`] keeps the
+/// wire-format-violation signal loud and reuses the same variant the
+/// rest of the dict-decode helpers already reach for.
+///
+/// ## Security model while the registry is empty (pre-bootstrap)
 ///
 /// Empty registry is the **strictest** validator state, not the most
 /// permissive. Two layers make this safe:
 ///
 /// 1. **Sender gate** (`mls_sync.rs`): the `AppDataUpdate` sender path
 ///    is guarded by `proposals_enabled(group) && !registry.is_empty()`.
-///    In production the second clause is false, so the legacy GCE path
-///    runs and no `AppDataUpdate` proposals get emitted.
+///    In production the second clause is false on unmigrated groups,
+///    so the legacy GCE path runs and no `AppDataUpdate` proposals get
+///    emitted.
 ///    (`test_update_group_name_uses_legacy_path_when_registry_is_empty`
 ///    pins this.)
-/// 2. **Receiver deny-by-default** (`xmtp_mls_common::app_data::
-///    validation::validate_component_write`): any `AppDataUpdate` whose
-///    component has no registry entry is rejected with
-///    `ComponentPermissionError::NoRegistryEntry`, surfacing as
-///    `CommitValidationError::InsufficientPermissions` in
+/// 2. **Receiver deny-by-default**
+///    (`xmtp_mls_common::app_data::validation::validate_component_write`):
+///    any `AppDataUpdate` whose component has no registry entry is
+///    rejected with `ComponentPermissionError::NoRegistryEntry`,
+///    surfacing as `CommitValidationError::InsufficientPermissions` in
 ///    [`validate_app_data_update_proposals_in_commit`]. So even if a
 ///    Byzantine peer crafts a commit carrying `AppDataUpdate`
 ///    proposals, honest receivers reject it.
 ///
 /// Hardcoded components (`COMPONENT_REGISTRY`, `SUPER_ADMIN_LIST`)
 /// bypass the registry lookup by design — they're super-admin-only in
-/// code — so the migration PR's bootstrap commit (which writes
-/// `COMPONENT_REGISTRY` as its first proposal) can land even against
-/// an empty registry.
+/// code — so the bootstrap commit (which writes `COMPONENT_REGISTRY`
+/// as its first proposal) can land even against an empty registry.
 ///
 /// Test code can inject a populated registry by wrapping its body in
 /// `TEST_REGISTRY_OVERRIDE.scope(registry, async { … }).await`.
-pub(crate) fn load_component_registry(_mls_group: &OpenMlsGroup) -> ComponentRegistry {
+pub(crate) fn load_component_registry(
+    mls_group: &OpenMlsGroup,
+) -> Result<ComponentRegistry, ComponentSourceError> {
+    load_component_registry_from_extensions(mls_group.extensions())
+}
+
+/// Extensions-only variant of [`load_component_registry`]. Mirrors the
+/// [`is_migrated_group`] / [`is_migrated_extensions`] split so unit
+/// tests can exercise the registry-decode path without materializing
+/// an `OpenMlsGroup`.
+pub(crate) fn load_component_registry_from_extensions(
+    extensions: &openmls::extensions::Extensions<openmls::group::GroupContext>,
+) -> Result<ComponentRegistry, ComponentSourceError> {
+    // Post-migration: the registry lives in the AppData dict under
+    // `COMPONENT_REGISTRY`. A migrated group's dict always has this
+    // entry (the bootstrap commit seeds it before flipping
+    // proposals_enabled), so if we find it, it's authoritative.
+    if let Some(ext) = extensions.app_data_dictionary()
+        && let Some(bytes) = ext
+            .dictionary()
+            .get(&ComponentId::COMPONENT_REGISTRY.as_u16())
+    {
+        return ComponentRegistry::from_bytes(bytes).map_err(|e| {
+            ComponentSourceError::MalformedComponentValue {
+                component_id: ComponentId::COMPONENT_REGISTRY,
+                reason: format!("registry decode: {e}"),
+            }
+        });
+    }
+
+    // Pre-migration or test override.
     #[cfg(any(test, feature = "test-utils"))]
     if let Ok(reg) = TEST_REGISTRY_OVERRIDE.try_with(|r| r.clone()) {
-        return reg;
+        return Ok(reg);
     }
-    ComponentRegistry::new()
+    Ok(ComponentRegistry::new())
+}
+
+#[cfg(test)]
+mod tests {
+    //! Unit coverage for the migration-marker predicate —
+    //! [`is_migrated_extensions`]. These pin the three read-side
+    //! invariants from the PR review:
+    //!   (a) registry empty / dict missing => legacy-authoritative,
+    //!   (b) overlay no-op on unmigrated groups (even if `TEST_REGISTRY_OVERRIDE`
+    //!       is set but the dict is empty),
+    //!   (c) `COMPONENT_REGISTRY` in dict => migrated
+    //!       (production signal, independent of any test override).
+    //!
+    //! Post-bootstrap reader-see-dict-values coverage lives as an
+    //! integration test in `groups/tests/test_proposals.rs` — see
+    //! `test_app_data_update_overlays_legacy_gmm_on_conflict` — because
+    //! it needs the full MLS commit pipeline.
+    use super::*;
+    use openmls::extensions::{
+        AppDataDictionary, AppDataDictionaryExtension, Extension, Extensions,
+    };
+
+    fn extensions_with_dict(
+        entries: &[(u16, Vec<u8>)],
+    ) -> Extensions<openmls::group::GroupContext> {
+        let mut dict = AppDataDictionary::new();
+        for (id, bytes) in entries {
+            let _ = dict.insert(*id, bytes.clone());
+        }
+        Extensions::from_vec(vec![Extension::AppDataDictionary(
+            AppDataDictionaryExtension::new(dict),
+        )])
+        .expect("AppDataDictionary is a valid GroupContext extension")
+    }
+
+    fn empty_extensions() -> Extensions<openmls::group::GroupContext> {
+        Extensions::from_vec(vec![]).expect("empty extensions are always valid")
+    }
+
+    #[test]
+    fn unmigrated_without_override_is_not_migrated() {
+        // Invariant (a): no dict, no override → legacy authoritative.
+        assert!(!is_migrated_extensions(&empty_extensions()));
+        // Dict present but empty → still not migrated.
+        assert!(!is_migrated_extensions(&extensions_with_dict(&[])));
+    }
+
+    #[test]
+    fn dict_without_registry_entry_is_not_migrated() {
+        // Invariant (a) corollary: a dict entry for some *other*
+        // component isn't enough to flip the gate in production —
+        // only `COMPONENT_REGISTRY` counts.
+        let exts =
+            extensions_with_dict(&[(ComponentId::GROUP_NAME.as_u16(), b"Group Name".to_vec())]);
+        assert!(!is_migrated_extensions(&exts));
+    }
+
+    #[test]
+    fn dict_with_registry_entry_is_migrated() {
+        // Invariant (c): production signal. `COMPONENT_REGISTRY` in the
+        // dict => migrated, regardless of any test override.
+        let exts =
+            extensions_with_dict(&[(ComponentId::COMPONENT_REGISTRY.as_u16(), vec![0x01, 0x02])]);
+        assert!(is_migrated_extensions(&exts));
+    }
+
+    #[tokio::test]
+    async fn override_without_dict_entries_is_not_migrated() {
+        // Invariant (b): with `TEST_REGISTRY_OVERRIDE` set but the dict
+        // empty (i.e. the pre-`enable_proposals()` window of an
+        // integration test), the gate stays closed. This is what lets
+        // step-1 assertions in `test_app_data_update_overlays_legacy_gmm_on_conflict`
+        // still read the legacy GMM value instead of being shadowed by
+        // an empty-dict overlay.
+        let reg = ComponentRegistry::new();
+        TEST_REGISTRY_OVERRIDE
+            .scope(reg, async {
+                assert!(!is_migrated_extensions(&empty_extensions()));
+                assert!(!is_migrated_extensions(&extensions_with_dict(&[])));
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn override_with_dict_entry_flips_migrated_in_tests() {
+        // Complement to the above: once a test has written at least
+        // one component to the dict, the test-override branch flips
+        // the gate so subsequent reads route through the overlay.
+        let reg = ComponentRegistry::new();
+        TEST_REGISTRY_OVERRIDE
+            .scope(reg, async {
+                let exts = extensions_with_dict(&[(
+                    ComponentId::GROUP_NAME.as_u16(),
+                    b"Dict Name".to_vec(),
+                )]);
+                assert!(is_migrated_extensions(&exts));
+            })
+            .await;
+    }
+
+    // ========================================================================
+    // load_component_registry_from_extensions
+    // ========================================================================
+    //
+    // These pin the contract that the migration-marker
+    // (`is_migrated_extensions`, key-existence) and the registry loader
+    // (`load_component_registry_from_extensions`, parseability) agree on
+    // exactly one shape of disagreement: malformed bytes surface as a
+    // hard `MalformedComponentValue` error rather than silently
+    // collapsing to an empty registry. An empty registry on a "migrated"
+    // group would cause downstream readers (mutable_metadata, validators)
+    // to silently lose every dict-backed component, so this invariant is
+    // load-bearing.
+
+    #[test]
+    fn load_registry_no_dict_returns_empty() {
+        let reg = load_component_registry_from_extensions(&empty_extensions()).unwrap();
+        assert!(reg.is_empty());
+    }
+
+    #[test]
+    fn load_registry_dict_without_entry_returns_empty() {
+        // Dict present but no COMPONENT_REGISTRY entry => pre-bootstrap.
+        // An entry under some *other* component id must not be confused
+        // for the registry payload.
+        let exts =
+            extensions_with_dict(&[(ComponentId::GROUP_NAME.as_u16(), b"Group Name".to_vec())]);
+        let reg = load_component_registry_from_extensions(&exts).unwrap();
+        assert!(reg.is_empty());
+    }
+
+    #[test]
+    fn load_registry_with_valid_bytes_round_trips() {
+        let original = ComponentRegistry::new();
+        let bytes = original.to_bytes().expect("empty registry serializes");
+        let exts = extensions_with_dict(&[(ComponentId::COMPONENT_REGISTRY.as_u16(), bytes)]);
+        let loaded = load_component_registry_from_extensions(&exts).unwrap();
+        assert_eq!(loaded, original);
+    }
+
+    #[test]
+    fn load_registry_with_malformed_bytes_surfaces_error() {
+        // Pin the "fail loud, never return empty" invariant: a
+        // malformed `COMPONENT_REGISTRY` value must surface as
+        // `MalformedComponentValue` so downstream readers don't carry
+        // on with a phantom empty registry against an
+        // `is_migrated_extensions == true` dict.
+        let exts = extensions_with_dict(&[(
+            ComponentId::COMPONENT_REGISTRY.as_u16(),
+            vec![0xff, 0xff, 0xff],
+        )]);
+        let err = load_component_registry_from_extensions(&exts).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                ComponentSourceError::MalformedComponentValue { component_id, .. }
+                    if component_id == ComponentId::COMPONENT_REGISTRY
+            ),
+            "expected MalformedComponentValue for COMPONENT_REGISTRY, got: {err:?}"
+        );
+    }
 }

--- a/crates/xmtp_mls/src/groups/error.rs
+++ b/crates/xmtp_mls/src/groups/error.rs
@@ -459,6 +459,13 @@ pub enum MetadataPermissionsError {
     DmValidation(#[from] DmValidationError),
     #[error("Invalid extension: {0}")]
     InvalidExtension(#[from] openmls::prelude::InvalidExtensionError),
+    /// Failed to decode a well-known component value from the
+    /// AppData dictionary on a migrated group. Surfaces
+    /// [`ComponentSourceError`] via `#[from]` so callers (e.g.
+    /// `mutable_metadata()`, `metadata()`) preserve the structured
+    /// source.
+    #[error(transparent)]
+    ComponentSource(#[from] crate::groups::app_data::component_source::ComponentSourceError),
 }
 
 impl RetryableError for MetadataPermissionsError {

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -1133,6 +1133,10 @@ where
                         return Err(CommitValidationError::from(e).into());
                     }
                 };
+                // TODO(app-data-migration): these legacy extractors
+                // fail on post-bootstrap groups (GMM / GroupMetadata
+                // extensions are stripped). Unmigrated groups — the
+                // only ones in production today — are unaffected.
                 let immutable_metadata = match extract_group_metadata(extensions) {
                     Ok(m) => m,
                     Err(e) => {
@@ -1842,6 +1846,9 @@ where
     }
 
     fn get_message_expire_at_ns(mls_group: &OpenMlsGroup) -> Option<i64> {
+        // TODO(app-data-migration): on post-bootstrap groups the legacy
+        // GMM extension is gone; `.ok()?` will silently disable
+        // message-disappear settings.
         let mutable_metadata = extract_group_mutable_metadata(mls_group).ok()?;
         let group_disappearing_settings =
             Self::conversation_message_disappearing_settings_from_extensions(&mutable_metadata)
@@ -2696,7 +2703,7 @@ where
                 // (`NoRegistryEntry`) against an empty registry.
                 let proposals_on = self.proposals_enabled(openmls_group);
                 let registry_populated =
-                    !super::app_data::load_component_registry(openmls_group).is_empty();
+                    !super::app_data::load_component_registry(openmls_group)?.is_empty();
                 // DEBUG-level routing trace so operators can see which
                 // groups are on which path during the rollout — especially
                 // useful if the migration ships only partially and we need

--- a/crates/xmtp_mls/src/groups/mod.rs
+++ b/crates/xmtp_mls/src/groups/mod.rs
@@ -2043,6 +2043,25 @@ where
         mls_group: &OpenMlsGroup,
         inbox_id: String,
     ) -> Result<bool, GroupMutableMetadataError> {
+        // On migrated groups, the legacy GMM extension is gone — read
+        // SUPER_ADMIN_LIST from the AppData dict. A missing dict
+        // entry on a migrated group is treated as "no super-admins":
+        // falling through to `GroupMutableMetadata::try_from(mls_group)`
+        // would hit `MissingExtension` because bootstrap has already
+        // stripped the legacy GMM. Today bootstrap always seeds an
+        // (empty or populated) `SUPER_ADMIN_LIST` entry so the `None`
+        // branch is defensive, but the explicit handling keeps the
+        // read-side safe against any future weakening of that
+        // invariant.
+        //
+        // On unmigrated groups we fall back to the legacy GMM
+        // extension — that path is unchanged.
+        if self::app_data::is_migrated_group(mls_group) {
+            let list = self::app_data::component_source::read_super_admin_list_from_dict(mls_group)
+                .map_err(GroupMutableMetadataError::from)?
+                .unwrap_or_default();
+            return Ok(list.contains(&inbox_id));
+        }
         let mutable_metadata = GroupMutableMetadata::try_from(mls_group)?;
         Ok(mutable_metadata.super_admin_list.contains(&inbox_id))
     }
@@ -2272,8 +2291,46 @@ where
     }
 
     /// Get the `GroupMetadata` of the group.
+    ///
+    /// On migrated groups the legacy immutable-metadata extension has
+    /// been removed; synthesize from dict (CONVERSATION_TYPE,
+    /// CREATOR_INBOX_ID, DM_MEMBERS, ONESHOT_MESSAGE). On unmigrated
+    /// groups, the legacy extension is authoritative.
+    ///
+    /// Migrated-but-no-seeds is treated as a hard error rather than
+    /// falling through to the legacy extension — the bootstrap commit
+    /// strips the legacy `GroupContextExtension`, so falling through
+    /// would surface an unrelated `MissingExtension` from the legacy
+    /// path. Returning `MissingExtension` directly here keeps the
+    /// failure shape callers already handle while making the
+    /// "incomplete migration" condition explicit at the originating
+    /// site.
     pub async fn metadata(&self) -> Result<GroupMetadata, GroupError> {
         self.load_mls_group_with_lock_async(async |mls_group| {
+            if self::app_data::is_migrated_group(&mls_group) {
+                let seed =
+                    self::app_data::component_source::read_group_metadata_from_dict(&mls_group)
+                        .map_err(MetadataPermissionsError::from)?
+                        .ok_or_else(|| {
+                            MetadataPermissionsError::from(GroupMetadataError::MissingExtension)
+                        })?;
+                use xmtp_proto::xmtp::mls::message_contents::GroupMetadataV1 as GroupMetadataProto;
+                // `creator_account_address` has been `""` on the
+                // legacy write path since long before this migration
+                // (see the `TODO: remove from proto` note in
+                // `xmtp_mls_common::group_metadata`). The field is
+                // effectively dead — no consumer reads it — so the
+                // migrated synthesis keeps it empty to match legacy
+                // bytes exactly.
+                let proto = GroupMetadataProto {
+                    conversation_type: seed.conversation_type,
+                    creator_inbox_id: seed.creator_inbox_id,
+                    creator_account_address: String::new(),
+                    dm_members: seed.dm_members,
+                    oneshot_message: seed.oneshot,
+                };
+                return Ok(GroupMetadata::try_from(proto).map_err(MetadataPermissionsError::from)?);
+            }
             extract_group_metadata(mls_group.extensions())
                 .map_err(MetadataPermissionsError::from)
                 .map_err(Into::into)
@@ -2281,28 +2338,41 @@ where
         .await
     }
 
-    /// Get the `GroupMutableMetadata` of the group. Reads the legacy
-    /// mutable metadata extension as the base, then — on groups that
-    /// have flipped `proposals_enabled` — overlays any well-known
-    /// component values stored in the OpenMLS AppData dictionary on top.
+    /// Get the `GroupMutableMetadata` of the group.
     ///
-    /// The dict-overlay is gated on `proposals_enabled` so that an
-    /// unmigrated group never accidentally reads from the dict: on those
-    /// groups the legacy GCE path is still authoritative, the dict
-    /// should be empty, and a stray entry (e.g. a misbehaving peer's
-    /// commit that somehow slipped through) would otherwise silently
-    /// shadow legacy metadata values.
+    /// Post-migration (dict contains `COMPONENT_REGISTRY` — see
+    /// [`self::app_data::is_migrated_group`]) the legacy GMM extension
+    /// is gone; we start with an empty base and
+    /// `merge_app_data_into_mutable_metadata` populates every field
+    /// from the AppData dict. Pre-migration we read the legacy GMM
+    /// extension authoritatively. The overlay helper itself also
+    /// checks the migration marker (defense in depth), so a stray
+    /// dict entry on a pre-bootstrap group can't silently shadow
+    /// legacy values.
+    ///
+    /// Intentionally distinct from `proposals_enabled`: a group can
+    /// have `proposals_enabled == true` but not yet have completed
+    /// its bootstrap commit (the foundation-PR window). During that
+    /// window the legacy GMM is still authoritative.
     pub fn mutable_metadata(&self) -> Result<GroupMutableMetadata, GroupError> {
         self.load_mls_group_with_lock(self.context.mls_storage(), |mls_group| {
-            let mut metadata = GroupMutableMetadata::try_from(&mls_group)
-                .map_err(MetadataPermissionsError::from)
-                .map_err(GroupError::from)?;
-            if self.proposals_enabled(&mls_group) {
-                self::app_data::component_source::merge_app_data_into_mutable_metadata(
-                    &mut metadata,
-                    &mls_group,
-                )?;
-            }
+            let mut metadata = if self::app_data::is_migrated_group(&mls_group) {
+                // Post-migration: legacy GMM extension is gone. Start
+                // with an empty base; `merge_app_data_into_mutable_metadata`
+                // populates every field from the dict.
+                GroupMutableMetadata::new(std::collections::HashMap::new(), Vec::new(), Vec::new())
+            } else {
+                GroupMutableMetadata::try_from(&mls_group)
+                    .map_err(MetadataPermissionsError::from)
+                    .map_err(GroupError::from)?
+            };
+            // The merge helper is also gated on the migration marker,
+            // so on unmigrated groups this is a no-op regardless of
+            // what the dict happens to contain.
+            self::app_data::component_source::merge_app_data_into_mutable_metadata(
+                &mut metadata,
+                &mls_group,
+            )?;
             Ok(metadata)
         })
     }

--- a/crates/xmtp_mls/src/groups/tests/test_proposals.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_proposals.rs
@@ -2906,7 +2906,9 @@ async fn test_update_group_name_uses_legacy_path_when_registry_is_empty() {
     // ever changes.
     let registry = alix_group
         .load_mls_group_with_lock_async(async |g| {
-            Ok::<_, crate::groups::GroupError>(crate::groups::app_data::load_component_registry(&g))
+            Ok::<_, crate::groups::GroupError>(crate::groups::app_data::load_component_registry(
+                &g,
+            )?)
         })
         .await?;
     assert!(

--- a/crates/xmtp_mls/src/groups/validated_commit.rs
+++ b/crates/xmtp_mls/src/groups/validated_commit.rs
@@ -104,6 +104,14 @@ pub enum CommitValidationError {
     ProposerNotFound,
     #[error("Proposals are not enabled on this group")]
     ProposalsNotEnabled,
+    /// A well-known component value in the AppData dictionary failed
+    /// to decode while validating an AppDataUpdate proposal — most
+    /// commonly a malformed `COMPONENT_REGISTRY`. Treated as a
+    /// terminal wire-format violation so the offending commit is
+    /// rejected rather than silently downgraded to "empty registry"
+    /// (which would let a permissive validator state slip in).
+    #[error(transparent)]
+    ComponentSource(#[from] super::app_data::component_source::ComponentSourceError),
 }
 
 impl RetryableError for CommitValidationError {
@@ -1139,7 +1147,7 @@ fn validate_app_data_update_proposals_in_commit(
         return Ok(());
     }
 
-    let registry = load_component_registry(openmls_group);
+    let registry = load_component_registry(openmls_group)?;
     // A single commit's bootstrap can carry multiple AppDataUpdate proposals
     // from the same leaf; cache extracted `CommitParticipant`s so we don't
     // re-walk the admin lists and re-parse the credential for every one.
@@ -1196,12 +1204,32 @@ fn extract_commit_participant(
     }
 }
 
-/// Get the [`GroupMembership`] from a `GroupContext` struct by iterating through all extensions
-/// until a match is found
+/// Get the [`GroupMembership`] from a `GroupContext` struct.
+///
+/// Post-migration the legacy `GROUP_MEMBERSHIP_EXTENSION_ID` is gone —
+/// we reconstruct from the AppData dictionary's `GROUP_MEMBERSHIP`
+/// component. Pre-migration the legacy extension is authoritative.
 #[tracing::instrument(level = "trace", skip_all)]
 pub fn extract_group_membership(
     extensions: &Extensions<GroupContext>,
 ) -> Result<GroupMembership, CommitValidationError> {
+    if let Some(proto) = super::app_data::component_source::read_group_membership_from_dict(
+        extensions,
+    )
+    .map_err(|e| {
+        CommitValidationError::GroupMutableMetadata(
+            xmtp_mls_common::group_mutable_metadata::GroupMutableMetadataError::from(e),
+        )
+    })? {
+        // Proto and `GroupMembership` carry the same two fields; build
+        // directly to skip a wasteful `encode → decode` round-trip
+        // through `try_from(bytes)`.
+        return Ok(GroupMembership {
+            members: proto.members,
+            failed_installations: proto.failed_installations,
+        });
+    }
+
     for extension in extensions.iter() {
         if let Extension::Unknown(
             xmtp_configuration::GROUP_MEMBERSHIP_EXTENSION_ID,
@@ -1678,7 +1706,7 @@ pub fn validate_proposal(
                 component_id::ComponentId, validation::ActorAuthority,
             };
 
-            let registry = load_component_registry(openmls_group);
+            let registry = load_component_registry(openmls_group)?;
 
             // Delegate to the shared helper so the commit-time path
             // (`validate_app_data_update_proposals_in_commit`) and this

--- a/crates/xmtp_mls/src/groups/welcomes/xmtp_welcome.rs
+++ b/crates/xmtp_mls/src/groups/welcomes/xmtp_welcome.rs
@@ -323,6 +323,9 @@ where
                 welcome.cursor,
             )?;
         }
+        // TODO(app-data-migration): post-bootstrap groups have no legacy
+        // GroupMetadata extension; route through a capability-aware
+        // helper before the bootstrap commit lands.
         let metadata =
             extract_group_metadata(staged_welcome.public_group().group_context().extensions())
                 .map_err(MetadataPermissionsError::from)?;
@@ -362,6 +365,10 @@ where
         )?;
         let dm_members = metadata.dm_members;
         let conversation_type = metadata.conversation_type;
+        // TODO(app-data-migration): same caveat as the `metadata`
+        // extraction above — `.ok()` swallows the missing-GMM error
+        // on post-bootstrap groups, silently defaulting downstream
+        // disappearing / min-protocol reads.
         let mutable_metadata = extract_group_mutable_metadata(&mls_group).ok();
         let disappearing_settings = mutable_metadata.as_ref().and_then(|metadata| {
             MlsGroup::<C>::conversation_message_disappearing_settings_from_extensions(metadata).ok()

--- a/crates/xmtp_mls_common/src/group_mutable_metadata.rs
+++ b/crates/xmtp_mls_common/src/group_mutable_metadata.rs
@@ -33,6 +33,26 @@ pub enum GroupMutableMetadataError {
     NoUpdates,
     #[error("missing metadata field")]
     MissingMetadataField,
+    /// A well-known component in the AppData dictionary failed to
+    /// decode — surfaced by the migrated-group read paths when a
+    /// component's wire bytes can't be parsed.
+    ///
+    /// Structured rather than a flat `String` so downstream consumers
+    /// (bindings, error mapping) can match on the offending
+    /// `component_id` to discriminate failure modes without parsing a
+    /// display string. `component_id` is `Option` because the upstream
+    /// `ComponentSourceError` has a few variants that don't carry one
+    /// (e.g. wrapped legacy-metadata errors); those map to `None`. The
+    /// inner `reason` is diagnostic-only — typically a formatted
+    /// `ComponentSourceError` — and should not be matched against.
+    #[error("malformed app-data component {component_id:?}: {reason}")]
+    MalformedComponent {
+        /// Component whose wire bytes failed to decode. `None` for
+        /// errors that don't originate at a specific component.
+        component_id: Option<super::app_data::component_id::ComponentId>,
+        /// Diagnostic string (display-only; not a stable API).
+        reason: String,
+    },
 }
 
 /// Represents the "updateable" metadata fields for a group.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add capability-aware read paths for migrated MLS groups using AppData dictionary
- Introduces migration-gated read functions in [component_source.rs](https://github.com/xmtp/libxmtp/pull/3564/files#diff-47acce7b46d2cc4f9669dd42120ee90e488ceb0b15817b67b7757e631b05d113) to extract group metadata, mutable metadata, super-admin list, and group membership from the AppData dictionary instead of legacy MLS extensions on migrated groups.
- Updates `Group::metadata`, `Group::mutable_metadata`, and `Group::is_super_admin_without_lock` in [mod.rs](https://github.com/xmtp/libxmtp/pull/3564/files#diff-c27dd00cf700fd888b75fdbd19738462c2549fdc881dad70f8e61c979d440966) to branch on `is_migrated_group` and use the new dict-backed readers.
- Updates `extract_group_membership` and commit validation in [validated_commit.rs](https://github.com/xmtp/libxmtp/pull/3564/files#diff-233994c0ec18d23d0636e849849a3500e44611a4f64c6fffb1d0931aa1461ed6) to prefer the AppData dictionary on migrated groups, falling back to the legacy extension scan.
- Adds `MalformedComponent` to `GroupMutableMetadataError` and `ComponentSource` variants to `CommitValidationError` and `MetadataPermissionsError` to surface structured decode failures.
- Risk: malformed `COMPONENT_REGISTRY` or component dict bytes now propagate as errors rather than silently defaulting to empty, affecting sync, proposal validation, and metadata reads.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 959da2e.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->