### PR TITLE
migration part 3: receiver-side bootstrap validator (Task 5)

### DIFF
--- a/crates/xmtp_mls/src/groups/app_data/bootstrap_validator.rs
+++ b/crates/xmtp_mls/src/groups/app_data/bootstrap_validator.rs
@@ -1,0 +1,1194 @@
+//! Receiver-side bootstrap-commit validator.
+//!
+//! The one-time AppData-migration bootstrap carries a deterministic,
+//! sender-authoritative payload: every honest receiver synthesizes the
+//! same canonical subset from the pre-flip group state and byte-
+//! compares it against the commit's `AppDataUpdate` proposals.
+//! Divergence is rejected.
+//!
+//! Entry points:
+//! - [`is_bootstrap_commit`] — shape-check a staged commit (GCE flips
+//!   `PROPOSAL_SUPPORT` on, drops the four legacy extensions, plus a
+//!   `COMPONENT_REGISTRY` write). Routes commits into this validator.
+//! - [`validate_bootstrap_commit`] — full validation against pre-flip
+//!   state. Pure-logic core lives in [`validate_against_canonical_subset`]
+//!   so it's unit-testable without a real `StagedCommit`.
+
+use std::collections::BTreeMap;
+
+use openmls::{
+    extensions::{Extension, ExtensionType, Extensions},
+    framing::Sender,
+    group::{GroupContext, MlsGroup as OpenMlsGroup, StagedCommit},
+    messages::proposals::{AppDataUpdateOperationType, Proposal},
+};
+use prost::Message as _;
+use tls_codec::{Deserialize, VLBytes};
+use xmtp_configuration::{
+    GROUP_MEMBERSHIP_EXTENSION_ID, GROUP_PERMISSIONS_EXTENSION_ID, MUTABLE_METADATA_EXTENSION_ID,
+    PROPOSAL_SUPPORT_EXTENSION_ID,
+};
+use xmtp_mls_common::{
+    app_data::{
+        component_id::ComponentId,
+        component_registry::ComponentRegistry,
+        migration::{CanonicalBootstrapExpectation, synthesize_canonical_subset_for_validation},
+    },
+    group_metadata::GroupMetadata,
+    group_mutable_metadata::GroupMutableMetadata,
+    inbox_id::InboxId,
+    tls_map::{TlsMapDelta, TlsMapMutation},
+};
+use xmtp_proto::xmtp::mls::message_contents::{
+    GroupMembershipEntry, group_membership_entry::Version as GroupMembershipEntryVersion,
+};
+
+use crate::groups::validated_commit::{
+    CommitParticipant, CommitValidationError, extract_commit_participant,
+};
+
+/// Bootstrap-commit-specific validation failures.
+///
+/// Wrapped behind [`CommitValidationError::Bootstrap`] in the steady-state
+/// validator surface so the AppData-migration variants don't drown the
+/// rest of the enum. Construct these locally; callers higher up convert
+/// via the `#[from]` on `CommitValidationError::Bootstrap`.
+#[derive(Debug, thiserror::Error)]
+pub enum BootstrapValidationError {
+    /// The canonical subset says this `ComponentId` should be present
+    /// among the bootstrap commit's `AppDataUpdate` proposals, but the
+    /// commit didn't include one for it.
+    #[error("bootstrap commit is missing seed for component {0}")]
+    MissingSeed(ComponentId),
+    /// The commit carries an `AppDataUpdate` proposal for this
+    /// component but its bytes (or operation type) don't match what
+    /// the pre-flip state produces. Signals a malicious or buggy
+    /// sender.
+    #[error("bootstrap commit payload mismatch for component {0}")]
+    Mismatch(ComponentId),
+    /// The commit carries an `AppDataUpdate` proposal for a component
+    /// outside the canonical subset (and not `GROUP_MEMBERSHIP`).
+    /// Bootstrap is not a sender-discretion op — there are no extras.
+    #[error("bootstrap commit carries unexpected proposal for component {0}")]
+    UnexpectedProposal(ComponentId),
+    /// The commit carries two or more `AppDataUpdate` proposals for the
+    /// same component. Bootstrap is sender-authoritative byte-compare —
+    /// duplicates would let the sender's queue order diverge from
+    /// OpenMLS' apply order (proposals are sorted by `(component_id,
+    /// op_type)` at apply time but iterated in queue order during
+    /// validation), so the validator could green-light bytes that
+    /// aren't what gets merged into the dictionary.
+    #[error("bootstrap commit carries duplicate proposal for component {0}")]
+    DuplicateProposal(ComponentId),
+    /// The commit's `GROUP_MEMBERSHIP` payload carries an inbox id
+    /// that isn't in the pre-flip membership map.
+    #[error("bootstrap commit introduces unknown member inbox {}", hex::encode(.0))]
+    ExtraMember(Vec<u8>),
+    /// The commit's `GROUP_MEMBERSHIP` payload is missing an inbox
+    /// that IS in the pre-flip membership map.
+    #[error("bootstrap commit is missing member inbox {}", hex::encode(.0))]
+    MissingMember(Vec<u8>),
+    /// A per-inbox `sequence_id` in the commit's `GROUP_MEMBERSHIP`
+    /// payload doesn't match the pre-flip state. Security-sensitive
+    /// (a smuggled-in higher sequence_id would cause honest receivers
+    /// to skip legitimate identity updates).
+    #[error(
+        "bootstrap commit sequence-id mismatch for inbox {}: expected {expected}, got {actual}",
+        hex::encode(inbox_id)
+    )]
+    SequenceIdMismatch {
+        inbox_id: Vec<u8>,
+        expected: u64,
+        actual: u64,
+    },
+    /// The commit's GCE proposal doesn't have the shape bootstrap
+    /// requires: add exactly `PROPOSAL_SUPPORT`, remove exactly the
+    /// four legacy XMTP extensions, and matching `RequiredCapabilities`
+    /// adjustment.
+    #[error("bootstrap GCE-proposal shape mismatch: {0}")]
+    GceMismatch(String),
+    /// Failed to decode the on-wire bytes of a bootstrap `AppDataUpdate`
+    /// payload under the expected encoding (e.g. a `GROUP_MEMBERSHIP`
+    /// payload that isn't a valid `TlsMap<[u8;32], VLBytes>`).
+    #[error("bootstrap commit payload decode failure for component {component_id}: {reason}")]
+    PayloadDecode {
+        component_id: ComponentId,
+        reason: String,
+    },
+    /// The bootstrap commit's proposer is not a super-admin of the
+    /// pre-flip group.
+    #[error("bootstrap commit proposer is not a super-admin")]
+    ProposerNotSuperAdmin,
+    /// A `COMPONENT_REGISTRY` entry in the bootstrap commit decoded
+    /// to a `ComponentMetadata` that doesn't match the receiver's
+    /// expected metadata (different permissions, type, or default
+    /// value) for that component id.
+    #[error("bootstrap commit registry entry for component {0} doesn't match expected metadata")]
+    RegistryEntryMismatch(ComponentId),
+    /// A per-inbox `failed_installations` entry references an
+    /// installation id that wasn't in the pre-flip legacy
+    /// `failed_installations` list. The legacy state bounds the universe
+    /// of installations the migrator may legally mark failed.
+    #[error(
+        "bootstrap commit references unauthorized failed installation: {}",
+        hex::encode(.0)
+    )]
+    UnauthorizedFailedInstallation(Vec<u8>),
+    /// The canonical-subset synthesis failed. Almost always means the
+    /// pre-flip group state is corrupted (missing a legacy extension
+    /// this module's synthesis depends on).
+    #[error("bootstrap canonical-subset synthesis failed: {0}")]
+    Synthesis(#[from] xmtp_mls_common::app_data::migration::MigrationError),
+    /// The bootstrap commit carries a proposal whose type isn't
+    /// `GroupContextExtensions` or `AppDataUpdate`. Defense-in-depth:
+    /// `is_bootstrap_commit` only checks for the GCE shape plus a
+    /// `COMPONENT_REGISTRY` write, so a malicious sender could in
+    /// principle bundle in an `Add` / `Remove` / `Update` / `SelfRemove`
+    /// / `ReInit` / `ExternalInit` / `AppEphemeral` / `Custom` proposal
+    /// and still satisfy the routing predicate. Bootstrap is
+    /// membership-neutral and AppData-only — anything outside that pair
+    /// is rejected here so OpenMLS never gets a chance to apply the
+    /// smuggled proposal at merge time.
+    #[error("bootstrap commit carries disallowed proposal type {0}")]
+    DisallowedProposalType(&'static str),
+}
+
+/// Shape-check a staged commit against the bootstrap signature.
+///
+/// A bootstrap commit has, in a single MLS commit:
+/// 1. A `GroupContextExtensions` proposal that adds
+///    `PROPOSAL_SUPPORT_EXTENSION_ID` (the capability flip).
+/// 2. The same GCE proposal drops `MUTABLE_METADATA_EXTENSION_ID`,
+///    `GROUP_PERMISSIONS_EXTENSION_ID`, `GROUP_MEMBERSHIP_EXTENSION_ID`,
+///    and the OpenMLS-built-in `ImmutableMetadata` extension.
+/// 3. At least one `AppDataUpdate` proposal writing
+///    `COMPONENT_REGISTRY` (the migration marker).
+///
+/// The three conditions together are what differentiate a bootstrap
+/// from a plain `enable_proposals()` commit (which only satisfies #1),
+/// from a metadata-attribute update via `AppDataUpdate` (which never
+/// satisfies #1 or #2), and from any other combinatorial GCE flow.
+pub(crate) fn is_bootstrap_commit(
+    staged_commit: &StagedCommit,
+    existing_extensions: &Extensions<GroupContext>,
+) -> bool {
+    // Only fire on the pre-flip side — a group that already has
+    // PROPOSAL_SUPPORT can't "bootstrap" again.
+    if crate::groups::check_proposals_enabled(existing_extensions) {
+        return false;
+    }
+
+    let mut writes_component_registry = false;
+    let mut gce_matches = false;
+    for queued in staged_commit.queued_proposals() {
+        match queued.proposal() {
+            Proposal::GroupContextExtensions(gce) => {
+                gce_matches = gce_matches_bootstrap_shape(gce.extensions());
+            }
+            Proposal::AppDataUpdate(app_data)
+                if ComponentId::from(app_data.component_id())
+                    == ComponentId::COMPONENT_REGISTRY =>
+            {
+                writes_component_registry = true;
+            }
+            _ => {}
+        }
+    }
+    gce_matches && writes_component_registry
+}
+
+/// Does `new_extensions` look like the bootstrap GCE output?
+/// Adds `PROPOSAL_SUPPORT` and drops the four legacy XMTP extensions.
+fn gce_matches_bootstrap_shape(new_extensions: &Extensions<GroupContext>) -> bool {
+    let has_proposal_support = new_extensions.iter().any(|ext| {
+        matches!(
+            ext,
+            Extension::Unknown(id, _) if *id == PROPOSAL_SUPPORT_EXTENSION_ID
+        )
+    });
+    let drops_legacy = |id: u16| {
+        !new_extensions
+            .iter()
+            .any(|ext| matches!(ext, Extension::Unknown(candidate, _) if *candidate == id))
+    };
+    let drops_immutable = !new_extensions
+        .iter()
+        .any(|ext| matches!(ext, Extension::ImmutableMetadata(_)));
+
+    has_proposal_support
+        && drops_legacy(MUTABLE_METADATA_EXTENSION_ID)
+        && drops_legacy(GROUP_PERMISSIONS_EXTENSION_ID)
+        && drops_legacy(GROUP_MEMBERSHIP_EXTENSION_ID)
+        && drops_immutable
+}
+
+/// Extract the bootstrap commit's single GCE-proposal proposer.
+/// Returns `None` if the commit has no GCE proposal (not bootstrap-
+/// shaped). Any `Sender` other than `Member` (external, new-member)
+/// is rejected as non-member per the existing commit validator's
+/// shape.
+pub(crate) fn extract_gce_proposer(
+    staged_commit: &StagedCommit,
+    openmls_group: &OpenMlsGroup,
+    immutable_metadata: &GroupMetadata,
+    mutable_metadata: &GroupMutableMetadata,
+) -> Result<Option<CommitParticipant>, CommitValidationError> {
+    for queued in staged_commit.queued_proposals() {
+        if matches!(queued.proposal(), Proposal::GroupContextExtensions(_)) {
+            let leaf_index = match queued.sender() {
+                Sender::Member(idx) => idx,
+                _ => return Err(CommitValidationError::ActorNotMember),
+            };
+            let participant = extract_commit_participant(
+                leaf_index,
+                openmls_group,
+                immutable_metadata,
+                mutable_metadata,
+            )?;
+            return Ok(Some(participant));
+        }
+    }
+    Ok(None)
+}
+
+/// Full receiver-side validation of a bootstrap commit.
+///
+/// Called from `ValidatedCommit::from_staged_commit` **before**
+/// `validate_app_data_update_proposals_in_commit` so the bootstrap
+/// path bypasses the deny-by-default registry check (the dict doesn't
+/// have a `COMPONENT_REGISTRY` entry until this very commit merges).
+///
+/// The `proposer` argument is the GCE-proposal proposer extracted by
+/// `get_proposal_changes` — bootstrap requires that actor to be a
+/// super-admin per the pre-flip GMM. The legacy permission check is
+/// still valid at this moment because the legacy extensions are still
+/// present on the receiver side (the GCE strip only takes effect
+/// after the commit merges).
+pub(crate) fn validate_bootstrap_commit(
+    staged_commit: &StagedCommit,
+    openmls_group: &OpenMlsGroup,
+    proposer: &CommitParticipant,
+) -> Result<(), BootstrapValidationError> {
+    if !proposer.is_super_admin {
+        return Err(BootstrapValidationError::ProposerNotSuperAdmin);
+    }
+
+    // Defense-in-depth: bootstrap is membership-neutral and AppData-
+    // only. Reject any proposal type other than `GroupContextExtensions`
+    // and `AppDataUpdate` BEFORE the canonical-subset compare, so a
+    // smuggled `Add`/`Remove`/`Update`/`SelfRemove`/`ReInit`/
+    // `ExternalInit`/`AppEphemeral`/`Custom` proposal that satisfied
+    // `is_bootstrap_commit` (which only checks the GCE shape + a
+    // COMPONENT_REGISTRY write) cannot reach OpenMLS' merge step.
+    validate_only_allowed_proposal_types(staged_commit)?;
+
+    // Expected bytes: sync synthesis over the pre-flip extensions.
+    // No identity-update API lookups; the receiver does NOT call the
+    // sender-side async synthesizer.
+    let expected = synthesize_canonical_subset_for_validation(openmls_group)?;
+
+    // Actual: the `AppDataUpdate` proposal bag from the staged commit.
+    let actual = collect_app_data_updates(staged_commit)?;
+
+    validate_against_canonical_subset(&expected, &actual)?;
+    validate_gce_shape(staged_commit)?;
+
+    Ok(())
+}
+
+/// True iff `proposal` is a proposal type the bootstrap commit is
+/// allowed to carry. Bootstrap is membership-neutral (no `Add`,
+/// `Remove`, `Update`, `SelfRemove`) and identity-key-neutral (no
+/// `ReInit`, `ExternalInit`, `PreSharedKey`); the canonical-subset
+/// compare also presumes there are no `AppEphemeral` or `Custom`
+/// payloads. The only legal types are the single GCE that flips
+/// `PROPOSAL_SUPPORT` and the `AppDataUpdate` proposals that seed the
+/// post-flip dictionary.
+fn is_allowed_bootstrap_proposal(proposal: &Proposal) -> bool {
+    matches!(
+        proposal,
+        Proposal::GroupContextExtensions(_) | Proposal::AppDataUpdate(_)
+    )
+}
+
+/// Static debug name for a `Proposal` variant. Used solely to make the
+/// `DisallowedProposalType` error self-describing in logs.
+fn proposal_type_name(proposal: &Proposal) -> &'static str {
+    match proposal {
+        Proposal::Add(_) => "Add",
+        Proposal::Update(_) => "Update",
+        Proposal::Remove(_) => "Remove",
+        Proposal::PreSharedKey(_) => "PreSharedKey",
+        Proposal::ReInit(_) => "ReInit",
+        Proposal::ExternalInit(_) => "ExternalInit",
+        Proposal::GroupContextExtensions(_) => "GroupContextExtensions",
+        Proposal::AppDataUpdate(_) => "AppDataUpdate",
+        Proposal::SelfRemove => "SelfRemove",
+        Proposal::AppEphemeral(_) => "AppEphemeral",
+        Proposal::Custom(_) => "Custom",
+    }
+}
+
+/// Reject any queued proposal whose type isn't on the bootstrap
+/// allowlist. See [`is_allowed_bootstrap_proposal`] for the allowed set
+/// and the security rationale.
+fn validate_only_allowed_proposal_types(
+    staged_commit: &StagedCommit,
+) -> Result<(), BootstrapValidationError> {
+    for queued in staged_commit.queued_proposals() {
+        let proposal = queued.proposal();
+        if !is_allowed_bootstrap_proposal(proposal) {
+            return Err(BootstrapValidationError::DisallowedProposalType(
+                proposal_type_name(proposal),
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Collect every `AppDataUpdate` proposal in a staged commit into a
+/// `BTreeMap` keyed by `ComponentId`. Reject duplicate component ids:
+/// OpenMLS sorts AppData proposals by `(component_id, op_type)` at
+/// apply time but the validator iterates in queue order — a duplicate
+/// where one entry happens to byte-equal the canonical subset could
+/// green-light a different payload than what gets merged. Fail closed
+/// with [`BootstrapValidationError::DuplicateProposal`].
+fn collect_app_data_updates(
+    staged_commit: &StagedCommit,
+) -> Result<BTreeMap<ComponentId, (AppDataUpdateOperationType, Vec<u8>)>, BootstrapValidationError>
+{
+    use openmls::messages::proposals::AppDataUpdateOperation;
+    let mut out = BTreeMap::new();
+    for queued in staged_commit.queued_proposals() {
+        if let Proposal::AppDataUpdate(p) = queued.proposal() {
+            let id = ComponentId::from(p.component_id());
+            let (op_type, bytes) = match p.operation() {
+                AppDataUpdateOperation::Update(bytes) => (
+                    AppDataUpdateOperationType::Update,
+                    bytes.as_slice().to_vec(),
+                ),
+                AppDataUpdateOperation::Remove => (AppDataUpdateOperationType::Remove, Vec::new()),
+            };
+            if out.insert(id, (op_type, bytes)).is_some() {
+                return Err(BootstrapValidationError::DuplicateProposal(id));
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Pure-logic byte-compare between the canonical subset and the
+/// actual `AppDataUpdate` proposal bag. Separated from the
+/// `StagedCommit`-reading layer so it can be unit-tested directly.
+///
+/// All four `CanonicalBootstrapExpectation` fields are validated here,
+/// in two layers:
+/// 1. **Strict byte-compare** — `expected.strict` (sender-authoritative
+///    components like `GROUP_NAME`, `ADMIN_LIST`, etc.) is compared
+///    op-type and bytes-for-bytes against `actual` (loops 1 + 2 below).
+/// 2. **Decoded compares** — `COMPONENT_REGISTRY` and `GROUP_MEMBERSHIP`
+///    can't be byte-compared safely (encoder-version drift on the proto
+///    payload, sender-discretionary `failed_installations` bounded by
+///    the pre-flip set), so they're delegated to
+///    [`validate_component_registry_payload`] (consumes
+///    `expected.expected_registry`) and
+///    [`validate_group_membership_payload`] (consumes both
+///    `expected.membership_sequence_ids` and
+///    `expected.allowed_failed_installations`). The strict-loop's
+///    "unexpected proposal" check explicitly allowlists those two
+///    component ids so the byte-compare layer doesn't reject them
+///    before the decoded layer gets to validate them.
+///
+/// Together these cover every field on
+/// [`CanonicalBootstrapExpectation`]; if you add a new field there,
+/// add a corresponding compare here (or to one of the two delegates).
+pub(crate) fn validate_against_canonical_subset(
+    expected: &CanonicalBootstrapExpectation,
+    actual: &BTreeMap<ComponentId, (AppDataUpdateOperationType, Vec<u8>)>,
+) -> Result<(), BootstrapValidationError> {
+    // 1. Every strict component must appear with matching op_type +
+    //    payload bytes.
+    for (id, (expected_op, expected_bytes)) in expected.strict.iter() {
+        let Some((actual_op, actual_bytes)) = actual.get(id) else {
+            return Err(BootstrapValidationError::MissingSeed(*id));
+        };
+        if actual_op != expected_op || actual_bytes != expected_bytes {
+            return Err(BootstrapValidationError::Mismatch(*id));
+        }
+    }
+
+    // 2. Nothing outside `expected.strict`, `COMPONENT_REGISTRY`, or
+    //    `GROUP_MEMBERSHIP` (the latter two are validated separately
+    //    via decoded compare and hybrid-bounds compare respectively).
+    for id in actual.keys() {
+        if id != &ComponentId::GROUP_MEMBERSHIP
+            && id != &ComponentId::COMPONENT_REGISTRY
+            && !expected.strict.contains_key(id)
+        {
+            return Err(BootstrapValidationError::UnexpectedProposal(*id));
+        }
+    }
+
+    // 3. COMPONENT_REGISTRY: decoded per-entry compare against
+    //    `expected.expected_registry`. Byte-compare is brittle to
+    //    proto evolution / encoder differences (see
+    //    `CanonicalBootstrapExpectation` docs); decode actual and
+    //    compare typed `ComponentMetadata`s.
+    validate_component_registry_payload(
+        actual.get(&ComponentId::COMPONENT_REGISTRY),
+        &expected.expected_registry,
+    )?;
+
+    // 4. GROUP_MEMBERSHIP hybrid validation: sequence_id must match
+    //    the pre-flip state exactly (byte-compare); per-inbox
+    //    `failed_installations` is bounded by the pre-flip legacy
+    //    list (`allowed_failed_installations`).
+    validate_group_membership_payload(
+        actual.get(&ComponentId::GROUP_MEMBERSHIP),
+        &expected.membership_sequence_ids,
+        &expected.allowed_failed_installations,
+    )?;
+
+    Ok(())
+}
+
+/// Decoded compare of the bootstrap commit's `COMPONENT_REGISTRY`
+/// payload against the receiver-derived `expected_registry`.
+///
+/// Per-entry equality on `ComponentMetadata` (a prost message with
+/// `PartialEq`) tolerates encoder-version drift on the inner bytes that
+/// a raw byte-compare would not. Missing, extra, or differently-shaped
+/// entries surface as [`BootstrapValidationError::RegistryEntryMismatch`]
+/// — same variant for all three so the operator-side log says which
+/// component is wrong without juggling three error types.
+fn validate_component_registry_payload(
+    actual: Option<&(AppDataUpdateOperationType, Vec<u8>)>,
+    expected_registry: &BTreeMap<
+        ComponentId,
+        xmtp_proto::xmtp::mls::message_contents::ComponentMetadata,
+    >,
+) -> Result<(), BootstrapValidationError> {
+    let Some((op, bytes)) = actual else {
+        // No COMPONENT_REGISTRY payload at all.
+        return if expected_registry.is_empty() {
+            Ok(())
+        } else {
+            Err(BootstrapValidationError::MissingSeed(
+                ComponentId::COMPONENT_REGISTRY,
+            ))
+        };
+    };
+    if *op != AppDataUpdateOperationType::Update {
+        return Err(BootstrapValidationError::Mismatch(
+            ComponentId::COMPONENT_REGISTRY,
+        ));
+    }
+    let actual_registry = ComponentRegistry::from_bytes(bytes).map_err(|e| {
+        BootstrapValidationError::PayloadDecode {
+            component_id: ComponentId::COMPONENT_REGISTRY,
+            reason: format!("ComponentRegistry decode: {e}"),
+        }
+    })?;
+
+    let mut actual_entries: BTreeMap<ComponentId, _> = BTreeMap::new();
+    for entry in actual_registry.iter() {
+        let (id, meta) = entry.map_err(|e| BootstrapValidationError::PayloadDecode {
+            component_id: ComponentId::COMPONENT_REGISTRY,
+            reason: format!("ComponentRegistry entry decode: {e}"),
+        })?;
+        actual_entries.insert(id, meta);
+    }
+
+    for (id, expected_meta) in expected_registry.iter() {
+        let Some(actual_meta) = actual_entries.get(id) else {
+            return Err(BootstrapValidationError::RegistryEntryMismatch(*id));
+        };
+        if actual_meta != expected_meta {
+            return Err(BootstrapValidationError::RegistryEntryMismatch(*id));
+        }
+    }
+    for id in actual_entries.keys() {
+        if !expected_registry.contains_key(id) {
+            return Err(BootstrapValidationError::RegistryEntryMismatch(*id));
+        }
+    }
+    // Cardinality belt: the two existence loops above imply set
+    // equality, but only because `actual_entries` is a `BTreeMap` (so
+    // duplicate keys collapsed silently during decode). If a future
+    // ComponentRegistry encoder changes that, the entry-mismatch loops
+    // wouldn't notice — fail closed on count divergence.
+    if actual_entries.len() != expected_registry.len() {
+        return Err(BootstrapValidationError::PayloadDecode {
+            component_id: ComponentId::COMPONENT_REGISTRY,
+            reason: format!(
+                "COMPONENT_REGISTRY entry cardinality mismatch: payload has {} entries, \
+                 expected {}",
+                actual_entries.len(),
+                expected_registry.len()
+            ),
+        });
+    }
+    Ok(())
+}
+
+/// Hybrid validation for `GROUP_MEMBERSHIP`:
+/// - Payload must be present with op_type `Update`.
+/// - Deserialize as `TlsMapDelta<InboxId, VLBytes>` (bootstrap is
+///   delta-from-empty, so every mutation must be `Insert`); each value
+///   prost-decodes as a `GroupMembershipEntry` envelope and we read
+///   its `V1` variant.
+/// - Inbox-id set must equal the pre-flip membership (no extras,
+///   nothing missing); duplicate inserts surface as decode errors.
+/// - Each entry's `sequence_id` must equal the pre-flip value.
+/// - `failed_installations` is sender-authoritative on which subset to
+///   carry per inbox, but the *universe* of legal install ids is
+///   bounded by `allowed_failed_installations` (drawn from the pre-flip
+///   legacy `GroupMembership.failed_installations` list). Each entry
+///   must be 32 bytes (Ed25519 install key) AND present in that set.
+fn validate_group_membership_payload(
+    actual: Option<&(AppDataUpdateOperationType, Vec<u8>)>,
+    expected_sequence_ids: &BTreeMap<InboxId, u64>,
+    allowed_failed_installations: &std::collections::BTreeSet<[u8; 32]>,
+) -> Result<(), BootstrapValidationError> {
+    let Some((op, bytes)) = actual else {
+        // No GROUP_MEMBERSHIP entry at all. If expected_sequence_ids
+        // is empty this is fine (an empty membership doesn't need a
+        // payload); otherwise every expected inbox is "missing."
+        return match expected_sequence_ids.keys().next() {
+            Some(missing) => Err(BootstrapValidationError::MissingMember(
+                missing.as_bytes().to_vec(),
+            )),
+            None => Ok(()),
+        };
+    };
+    if *op != AppDataUpdateOperationType::Update {
+        return Err(BootstrapValidationError::Mismatch(
+            ComponentId::GROUP_MEMBERSHIP,
+        ));
+    }
+
+    let delta = TlsMapDelta::<InboxId, VLBytes>::tls_deserialize_exact(bytes).map_err(|e| {
+        BootstrapValidationError::PayloadDecode {
+            component_id: ComponentId::GROUP_MEMBERSHIP,
+            reason: format!("TlsMapDelta decode: {e}"),
+        }
+    })?;
+
+    let mut seen: std::collections::BTreeSet<InboxId> = std::collections::BTreeSet::new();
+    for mutation in delta.mutations {
+        let (inbox_id, raw_entry) = match mutation {
+            TlsMapMutation::Insert { key, value } => (key, value),
+            TlsMapMutation::Update { .. } | TlsMapMutation::Delete { .. } => {
+                return Err(BootstrapValidationError::PayloadDecode {
+                    component_id: ComponentId::GROUP_MEMBERSHIP,
+                    reason: "GROUP_MEMBERSHIP bootstrap delta carried a non-Insert mutation"
+                        .to_string(),
+                });
+            }
+        };
+        if !seen.insert(inbox_id) {
+            return Err(BootstrapValidationError::PayloadDecode {
+                component_id: ComponentId::GROUP_MEMBERSHIP,
+                reason: format!(
+                    "GROUP_MEMBERSHIP bootstrap delta has duplicate Insert for inbox {}",
+                    inbox_id.to_hex()
+                ),
+            });
+        }
+        let Some(expected_seq) = expected_sequence_ids.get(&inbox_id) else {
+            return Err(BootstrapValidationError::ExtraMember(
+                inbox_id.as_bytes().to_vec(),
+            ));
+        };
+        let envelope = GroupMembershipEntry::decode(raw_entry.as_slice()).map_err(|e| {
+            BootstrapValidationError::PayloadDecode {
+                component_id: ComponentId::GROUP_MEMBERSHIP,
+                reason: format!(
+                    "GroupMembershipEntry decode for inbox {}: {e}",
+                    inbox_id.to_hex()
+                ),
+            }
+        })?;
+        let entry = match envelope.version {
+            Some(GroupMembershipEntryVersion::V1(v1)) => v1,
+            None => {
+                return Err(BootstrapValidationError::PayloadDecode {
+                    component_id: ComponentId::GROUP_MEMBERSHIP,
+                    reason: format!(
+                        "GroupMembershipEntry envelope for inbox {} has unknown version",
+                        inbox_id.to_hex()
+                    ),
+                });
+            }
+        };
+        if entry.sequence_id != *expected_seq {
+            return Err(BootstrapValidationError::SequenceIdMismatch {
+                inbox_id: inbox_id.as_bytes().to_vec(),
+                expected: *expected_seq,
+                actual: entry.sequence_id,
+            });
+        }
+        for fi in &entry.failed_installations {
+            // 32-byte length is the Ed25519 install-key contract. A
+            // wrong length implies a malformed payload, not a
+            // sender-vs-receiver disagreement.
+            let key: [u8; 32] =
+                fi.as_slice()
+                    .try_into()
+                    .map_err(|_| BootstrapValidationError::PayloadDecode {
+                        component_id: ComponentId::GROUP_MEMBERSHIP,
+                        reason: format!(
+                            "failed_installation for inbox {} is {} bytes, expected 32",
+                            inbox_id.to_hex(),
+                            fi.len()
+                        ),
+                    })?;
+            if !allowed_failed_installations.contains(&key) {
+                return Err(BootstrapValidationError::UnauthorizedFailedInstallation(
+                    fi.clone(),
+                ));
+            }
+        }
+    }
+
+    // Every expected inbox must be in the actual payload.
+    for inbox_id in expected_sequence_ids.keys() {
+        if !seen.contains(inbox_id) {
+            return Err(BootstrapValidationError::MissingMember(
+                inbox_id.as_bytes().to_vec(),
+            ));
+        }
+    }
+
+    // Belt-and-suspenders: existence in both directions implies set
+    // equality only if the sets have equal size. The duplicate-Insert
+    // guard above keeps `seen` deduplicated, but a future change there
+    // could regress silently — assert the cardinality so any divergence
+    // surfaces as a decode failure rather than a missed inbox.
+    if seen.len() != expected_sequence_ids.len() {
+        return Err(BootstrapValidationError::PayloadDecode {
+            component_id: ComponentId::GROUP_MEMBERSHIP,
+            reason: format!(
+                "GROUP_MEMBERSHIP delta cardinality mismatch: payload carries {} inboxes, \
+                 pre-flip state has {}",
+                seen.len(),
+                expected_sequence_ids.len()
+            ),
+        });
+    }
+
+    Ok(())
+}
+
+/// Verify the commit's single GCE proposal has the bootstrap shape:
+/// adds exactly `PROPOSAL_SUPPORT`, drops exactly the four legacy
+/// extension types (and mirrors that in `RequiredCapabilities`). Any
+/// extra add/drop beyond the bootstrap contract → reject.
+fn validate_gce_shape(staged_commit: &StagedCommit) -> Result<(), BootstrapValidationError> {
+    let mut found_gce = None;
+    for queued in staged_commit.queued_proposals() {
+        if let Proposal::GroupContextExtensions(gce) = queued.proposal() {
+            if found_gce.is_some() {
+                return Err(BootstrapValidationError::GceMismatch(
+                    "multiple GCE proposals in bootstrap commit".into(),
+                ));
+            }
+            found_gce = Some(gce);
+        }
+    }
+    let Some(gce) = found_gce else {
+        return Err(BootstrapValidationError::GceMismatch(
+            "no GCE proposal in bootstrap commit".into(),
+        ));
+    };
+    validate_gce_extension_set(gce.extensions())
+}
+
+/// Pure-extension-bag validation. Split out of [`validate_gce_shape`]
+/// so the `RequiredCapabilities`-presence check (security-critical,
+/// see in-body comment) can be unit-tested directly without standing
+/// up a real `StagedCommit`.
+fn validate_gce_extension_set(
+    new_extensions: &Extensions<GroupContext>,
+) -> Result<(), BootstrapValidationError> {
+    if !gce_matches_bootstrap_shape(new_extensions) {
+        return Err(BootstrapValidationError::GceMismatch(
+            "GCE extension set does not match bootstrap shape (needs +PROPOSAL_SUPPORT, \
+             -MUTABLE_METADATA, -GROUP_PERMISSIONS, -GROUP_MEMBERSHIP, -ImmutableMetadata)"
+                .into(),
+        ));
+    }
+
+    // RequiredCapabilities MUST be present and MUST drop the four
+    // legacy extension types while adding PROPOSAL_SUPPORT. A bootstrap
+    // commit with no RequiredCapabilities at all would let post-flip
+    // adds skip the PROPOSAL_SUPPORT check and rejoin a broken group
+    // shape — reject hard.
+    let required = new_extensions.required_capabilities().ok_or_else(|| {
+        BootstrapValidationError::GceMismatch(
+            "RequiredCapabilities extension is missing — bootstrap requires it to enforce \
+             PROPOSAL_SUPPORT and ban the four legacy extension types"
+                .into(),
+        )
+    })?;
+    let ext_types: Vec<ExtensionType> = required.extension_types().to_vec();
+    let has_proposal_support =
+        ext_types.contains(&ExtensionType::Unknown(PROPOSAL_SUPPORT_EXTENSION_ID));
+    let bans_legacy = ![
+        ExtensionType::Unknown(MUTABLE_METADATA_EXTENSION_ID),
+        ExtensionType::Unknown(GROUP_PERMISSIONS_EXTENSION_ID),
+        ExtensionType::Unknown(GROUP_MEMBERSHIP_EXTENSION_ID),
+        ExtensionType::ImmutableMetadata,
+    ]
+    .iter()
+    .any(|banned| ext_types.contains(banned));
+    if !has_proposal_support || !bans_legacy {
+        return Err(BootstrapValidationError::GceMismatch(
+            "RequiredCapabilities doesn't match bootstrap shape".into(),
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    //! Pure-logic coverage for [`validate_against_canonical_subset`]
+    //! and [`validate_group_membership_payload`]. The `StagedCommit`-
+    //! reading helpers need a real MLS group; covered in integration tests.
+    use super::*;
+    use std::collections::{BTreeMap, BTreeSet};
+    use xmtp_mls_common::app_data::migration::{
+        CanonicalBootstrapExpectation, encode_group_membership_delta,
+    };
+    use xmtp_proto::xmtp::mls::message_contents::group_membership_entry::V1 as GroupMembershipEntryV1;
+
+    /// Build an `InboxId` from a single fill byte. Tests use these as
+    /// throwaway distinct identifiers — no semantics, just "give me a
+    /// new one." Keeps call sites readable (`inbox(0xAA)`) instead of
+    /// `InboxId::from_bytes([0xAA; 32])`.
+    fn inbox(b: u8) -> InboxId {
+        InboxId::from_bytes([b; 32])
+    }
+
+    fn expected(
+        strict: Vec<(ComponentId, AppDataUpdateOperationType, Vec<u8>)>,
+        membership: Vec<(InboxId, u64)>,
+    ) -> CanonicalBootstrapExpectation {
+        // Empty `expected_registry` + empty `allowed_failed_installations`
+        // is the correct baseline for tests focused on `strict` and
+        // membership-sequence-id behavior: a commit with no
+        // COMPONENT_REGISTRY proposal and no failed_installations is
+        // valid against an empty expectation. Tests targeting registry
+        // or failed-installation bounds construct the expectation
+        // directly with non-empty fields.
+        CanonicalBootstrapExpectation {
+            strict: strict
+                .into_iter()
+                .map(|(id, op, b)| (id, (op, b)))
+                .collect(),
+            expected_registry: BTreeMap::new(),
+            membership_sequence_ids: membership.into_iter().collect(),
+            allowed_failed_installations: BTreeSet::new(),
+        }
+    }
+
+    fn seed(op: AppDataUpdateOperationType, bytes: &[u8]) -> (AppDataUpdateOperationType, Vec<u8>) {
+        (op, bytes.to_vec())
+    }
+
+    fn membership_entry(seq: u64, failed: Vec<Vec<u8>>) -> GroupMembershipEntry {
+        GroupMembershipEntry {
+            version: Some(GroupMembershipEntryVersion::V1(GroupMembershipEntryV1 {
+                sequence_id: seq,
+                failed_installations: failed,
+            })),
+        }
+    }
+
+    /// `(inbox_id, sequence_id, failed_installations)` triple used by
+    /// [`encoded_membership`] to stamp out test payloads.
+    type MembershipInputRow = (InboxId, u64, Vec<Vec<u8>>);
+
+    fn encoded_membership(entries: &[MembershipInputRow]) -> Vec<u8> {
+        let mut map: BTreeMap<InboxId, GroupMembershipEntry> = BTreeMap::new();
+        for (inbox, seq, failed) in entries {
+            map.insert(*inbox, membership_entry(*seq, failed.clone()));
+        }
+        encode_group_membership_delta(&map).unwrap()
+    }
+
+    #[test]
+    fn happy_path_accepts_matching_bag() {
+        let exp = expected(
+            vec![(
+                ComponentId::GROUP_NAME,
+                AppDataUpdateOperationType::Update,
+                b"test".to_vec(),
+            )],
+            vec![(inbox(0x11), 1_u64)],
+        );
+        let mut actual = BTreeMap::new();
+        actual.insert(
+            ComponentId::GROUP_NAME,
+            seed(AppDataUpdateOperationType::Update, b"test"),
+        );
+        actual.insert(
+            ComponentId::GROUP_MEMBERSHIP,
+            (
+                AppDataUpdateOperationType::Update,
+                encoded_membership(&[(inbox(0x11), 1_u64, vec![])]),
+            ),
+        );
+        validate_against_canonical_subset(&exp, &actual).unwrap();
+    }
+
+    #[test]
+    fn missing_strict_component_surfaces_missing_seed() {
+        let exp = expected(
+            vec![(
+                ComponentId::GROUP_NAME,
+                AppDataUpdateOperationType::Update,
+                b"expected".to_vec(),
+            )],
+            vec![],
+        );
+        let actual = BTreeMap::new();
+        let err = validate_against_canonical_subset(&exp, &actual).unwrap_err();
+        assert!(matches!(
+            err,
+            BootstrapValidationError::MissingSeed(ComponentId::GROUP_NAME)
+        ));
+    }
+
+    #[test]
+    fn byte_mismatch_surfaces_mismatch() {
+        let exp = expected(
+            vec![(
+                ComponentId::GROUP_NAME,
+                AppDataUpdateOperationType::Update,
+                b"expected".to_vec(),
+            )],
+            vec![],
+        );
+        let mut actual = BTreeMap::new();
+        actual.insert(
+            ComponentId::GROUP_NAME,
+            seed(AppDataUpdateOperationType::Update, b"DIFFERENT"),
+        );
+        let err = validate_against_canonical_subset(&exp, &actual).unwrap_err();
+        assert!(matches!(
+            err,
+            BootstrapValidationError::Mismatch(ComponentId::GROUP_NAME)
+        ));
+    }
+
+    #[test]
+    fn op_type_mismatch_surfaces_mismatch() {
+        let exp = expected(
+            vec![(
+                ComponentId::GROUP_NAME,
+                AppDataUpdateOperationType::Update,
+                b"v".to_vec(),
+            )],
+            vec![],
+        );
+        let mut actual = BTreeMap::new();
+        actual.insert(
+            ComponentId::GROUP_NAME,
+            seed(AppDataUpdateOperationType::Remove, b"v"),
+        );
+        let err = validate_against_canonical_subset(&exp, &actual).unwrap_err();
+        assert!(matches!(
+            err,
+            BootstrapValidationError::Mismatch(ComponentId::GROUP_NAME)
+        ));
+    }
+
+    #[test]
+    fn unexpected_component_surfaces_unexpected_proposal() {
+        // Sender tried to smuggle in an `APP_DATA` seed outside the
+        // canonical subset.
+        let exp = expected(vec![], vec![]);
+        let mut actual = BTreeMap::new();
+        actual.insert(
+            ComponentId::APP_DATA,
+            seed(AppDataUpdateOperationType::Update, b"malicious"),
+        );
+        let err = validate_against_canonical_subset(&exp, &actual).unwrap_err();
+        assert!(matches!(
+            err,
+            BootstrapValidationError::UnexpectedProposal(ComponentId::APP_DATA)
+        ));
+    }
+
+    #[test]
+    fn group_membership_sequence_id_mismatch_rejected() {
+        // Security-critical: a forged higher sequence_id would
+        // silently skip legitimate identity updates on receivers.
+        let exp = expected(vec![], vec![(inbox(0xAA), 7_u64)]);
+        let mut actual = BTreeMap::new();
+        actual.insert(
+            ComponentId::GROUP_MEMBERSHIP,
+            (
+                AppDataUpdateOperationType::Update,
+                encoded_membership(&[(inbox(0xAA), 9999_u64, vec![])]),
+            ),
+        );
+        let err = validate_against_canonical_subset(&exp, &actual).unwrap_err();
+        assert!(matches!(
+            err,
+            BootstrapValidationError::SequenceIdMismatch {
+                expected: 7,
+                actual: 9999,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn group_membership_extra_member_rejected() {
+        let exp = expected(vec![], vec![(inbox(0xAA), 1_u64)]);
+        let mut actual = BTreeMap::new();
+        actual.insert(
+            ComponentId::GROUP_MEMBERSHIP,
+            (
+                AppDataUpdateOperationType::Update,
+                encoded_membership(&[
+                    (inbox(0xAA), 1_u64, vec![]),
+                    (inbox(0xBB), 2_u64, vec![]), // extra
+                ]),
+            ),
+        );
+        let err = validate_against_canonical_subset(&exp, &actual).unwrap_err();
+        assert!(matches!(
+            err,
+            BootstrapValidationError::ExtraMember(ref id) if id == &vec![0xBB; 32]
+        ));
+    }
+
+    #[test]
+    fn group_membership_missing_member_rejected() {
+        let exp = expected(vec![], vec![(inbox(0xAA), 1_u64), (inbox(0xBB), 2_u64)]);
+        let mut actual = BTreeMap::new();
+        actual.insert(
+            ComponentId::GROUP_MEMBERSHIP,
+            (
+                AppDataUpdateOperationType::Update,
+                encoded_membership(&[(inbox(0xAA), 1_u64, vec![])]), // BB missing
+            ),
+        );
+        let err = validate_against_canonical_subset(&exp, &actual).unwrap_err();
+        assert!(matches!(
+            err,
+            BootstrapValidationError::MissingMember(ref id) if id == &vec![0xBB; 32]
+        ));
+    }
+
+    #[test]
+    fn group_membership_failed_installations_accepted_within_allowed_set() {
+        // `failed_installations` is sender-authoritative on which subset
+        // to carry per inbox, but each entry must be 32 bytes AND in
+        // `allowed_failed_installations` (the pre-flip universe).
+        let install_a = [0xDE_u8; 32];
+        let install_b = [0xAD_u8; 32];
+        let mut exp = expected(vec![], vec![(inbox(0xAA), 1_u64)]);
+        exp.allowed_failed_installations.insert(install_a);
+        exp.allowed_failed_installations.insert(install_b);
+        let mut actual = BTreeMap::new();
+        actual.insert(
+            ComponentId::GROUP_MEMBERSHIP,
+            (
+                AppDataUpdateOperationType::Update,
+                encoded_membership(&[(
+                    inbox(0xAA),
+                    1_u64,
+                    vec![install_a.to_vec(), install_b.to_vec()],
+                )]),
+            ),
+        );
+        validate_against_canonical_subset(&exp, &actual).unwrap();
+    }
+
+    #[test]
+    fn group_membership_unauthorized_failed_installation_rejected() {
+        // A `failed_installation` not in `allowed_failed_installations`
+        // is rejected: the legacy pre-flip list is the only authoritative
+        // source for which install ids may appear.
+        let install_legit = [0xDE_u8; 32];
+        let install_smuggled = [0xBE_u8; 32];
+        let mut exp = expected(vec![], vec![(inbox(0xAA), 1_u64)]);
+        exp.allowed_failed_installations.insert(install_legit);
+        let mut actual = BTreeMap::new();
+        actual.insert(
+            ComponentId::GROUP_MEMBERSHIP,
+            (
+                AppDataUpdateOperationType::Update,
+                encoded_membership(&[(inbox(0xAA), 1_u64, vec![install_smuggled.to_vec()])]),
+            ),
+        );
+        let err = validate_against_canonical_subset(&exp, &actual).unwrap_err();
+        assert!(matches!(
+            err,
+            BootstrapValidationError::UnauthorizedFailedInstallation(ref id) if id == &install_smuggled.to_vec()
+        ));
+    }
+
+    #[test]
+    fn component_registry_empty_round_trips() {
+        // Empty `expected_registry` + empty COMPONENT_REGISTRY proposal
+        // round-trips through TlsMapDelta decode and passes. Exercises
+        // the registry decode path without needing the full
+        // ComponentMetadata-construction infrastructure (covered in
+        // integration tests where a real ComponentRegistry is built).
+        use xmtp_mls_common::app_data::component_registry::ComponentRegistry;
+        let empty_registry_bytes = ComponentRegistry::new().to_bytes().unwrap();
+        let exp = expected(vec![], vec![]);
+        let mut actual = BTreeMap::new();
+        actual.insert(
+            ComponentId::COMPONENT_REGISTRY,
+            (AppDataUpdateOperationType::Update, empty_registry_bytes),
+        );
+        validate_against_canonical_subset(&exp, &actual).unwrap();
+    }
+
+    #[test]
+    fn component_registry_malformed_bytes_surface_decode() {
+        let exp = expected(vec![], vec![]);
+        let mut actual = BTreeMap::new();
+        actual.insert(
+            ComponentId::COMPONENT_REGISTRY,
+            (AppDataUpdateOperationType::Update, vec![0xFF, 0xFE, 0xFD]),
+        );
+        let err = validate_against_canonical_subset(&exp, &actual).unwrap_err();
+        assert!(matches!(
+            err,
+            BootstrapValidationError::PayloadDecode {
+                component_id: ComponentId::COMPONENT_REGISTRY,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn group_membership_wrong_length_failed_installation_surfaces_decode() {
+        // Wrong-length entries (not 32 bytes) imply a malformed payload,
+        // surfaced as `PayloadDecode` rather than the
+        // unauthorized-install variant.
+        let mut exp = expected(vec![], vec![(inbox(0xAA), 1_u64)]);
+        exp.allowed_failed_installations.insert([0xDE_u8; 32]);
+        let mut actual = BTreeMap::new();
+        actual.insert(
+            ComponentId::GROUP_MEMBERSHIP,
+            (
+                AppDataUpdateOperationType::Update,
+                encoded_membership(&[(inbox(0xAA), 1_u64, vec![vec![0xDE; 16]])]),
+            ),
+        );
+        let err = validate_against_canonical_subset(&exp, &actual).unwrap_err();
+        assert!(matches!(
+            err,
+            BootstrapValidationError::PayloadDecode {
+                component_id: ComponentId::GROUP_MEMBERSHIP,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn group_membership_empty_both_sides_accepted() {
+        // Expected empty membership + no GROUP_MEMBERSHIP proposal →
+        // trivially valid. Matches the "empty group" edge case.
+        let exp = expected(vec![], vec![]);
+        let actual = BTreeMap::new();
+        validate_against_canonical_subset(&exp, &actual).unwrap();
+    }
+
+    #[test]
+    fn group_membership_malformed_tlsmap_bytes_surfaces_decode() {
+        let exp = expected(vec![], vec![(inbox(0xAA), 1_u64)]);
+        let mut actual = BTreeMap::new();
+        actual.insert(
+            ComponentId::GROUP_MEMBERSHIP,
+            (
+                AppDataUpdateOperationType::Update,
+                vec![0xDE, 0xAD, 0xBE, 0xEF],
+            ),
+        );
+        let err = validate_against_canonical_subset(&exp, &actual).unwrap_err();
+        assert!(matches!(
+            err,
+            BootstrapValidationError::PayloadDecode {
+                component_id: ComponentId::GROUP_MEMBERSHIP,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn allowed_bootstrap_proposal_predicate_rejects_membership_and_smuggled_types() {
+        // SelfRemove and Custom are the trivially-constructible
+        // disallowed variants; the rest (Add/Update/Remove/PreSharedKey/
+        // ReInit/ExternalInit/AppEphemeral) need full openmls plumbing
+        // to construct and are covered indirectly by the same `match`
+        // arm in `is_allowed_bootstrap_proposal`. Coverage here proves
+        // the predicate fails closed for at least one membership-
+        // changing variant and one opaque-payload variant.
+        use openmls::messages::proposals::CustomProposal;
+
+        assert!(!is_allowed_bootstrap_proposal(&Proposal::SelfRemove));
+        assert_eq!(proposal_type_name(&Proposal::SelfRemove), "SelfRemove");
+
+        let custom = Proposal::Custom(Box::new(CustomProposal::new(0xCAFE, vec![0xBE, 0xEF])));
+        assert!(!is_allowed_bootstrap_proposal(&custom));
+        assert_eq!(proposal_type_name(&custom), "Custom");
+    }
+
+    /// Build a bootstrap-shaped GCE extension set (adds `PROPOSAL_SUPPORT`,
+    /// drops the four legacy extensions). `with_required_capabilities`
+    /// controls whether the synthesized `RequiredCapabilities` extension
+    /// is included — that's the security-critical bit under test.
+    fn bootstrap_gce_extensions(with_required_capabilities: bool) -> Extensions<GroupContext> {
+        use openmls::extensions::{Extension, RequiredCapabilitiesExtension, UnknownExtension};
+        use openmls::prelude::ProposalType;
+        let mut exts = Extensions::empty();
+        exts.add(Extension::Unknown(
+            PROPOSAL_SUPPORT_EXTENSION_ID,
+            UnknownExtension(vec![]),
+        ))
+        .unwrap();
+        if with_required_capabilities {
+            let ext_types = [ExtensionType::Unknown(PROPOSAL_SUPPORT_EXTENSION_ID)];
+            let proposal_types = [ProposalType::AppDataUpdate];
+            let required = RequiredCapabilitiesExtension::new(&ext_types, &proposal_types, &[]);
+            exts.add(Extension::RequiredCapabilities(required)).unwrap();
+        }
+        exts
+    }
+
+    #[test]
+    fn gce_extension_set_missing_required_capabilities_rejected() {
+        // Security-critical: a bootstrap commit that strips
+        // `RequiredCapabilities` lets post-flip adds skip the
+        // `PROPOSAL_SUPPORT` check and rejoin a broken group shape.
+        // Pure-extension-bag check covers the path that
+        // `validate_gce_shape` delegates to.
+        let exts = bootstrap_gce_extensions(false);
+        let err = validate_gce_extension_set(&exts).unwrap_err();
+        match err {
+            BootstrapValidationError::GceMismatch(msg) => {
+                assert!(
+                    msg.contains("RequiredCapabilities extension is missing"),
+                    "expected RequiredCapabilities-missing message, got: {msg}"
+                );
+            }
+            other => panic!("expected GceMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn gce_extension_set_with_required_capabilities_accepted() {
+        let exts = bootstrap_gce_extensions(true);
+        validate_gce_extension_set(&exts).unwrap();
+    }
+}

--- a/crates/xmtp_mls/src/groups/app_data/migration.rs
+++ b/crates/xmtp_mls/src/groups/app_data/migration.rs
@@ -69,6 +69,19 @@ pub enum BootstrapSynthesisError {
     /// crates rather than user-visible state.
     #[error("registry re-encode: {0}")]
     RegistryReEncode(#[from] ComponentRegistryError),
+
+    /// A `GROUP_MEMBERSHIP` `sequence_id` exceeded `i64::MAX` and so
+    /// can't be passed through to the identity-update API (whose query
+    /// surface is signed). Practically unreachable today (sequence ids
+    /// don't get within thirteen orders of magnitude of `i64::MAX`),
+    /// but a `as i64` cast would silently wrap to a negative value and
+    /// quietly query the wrong association state — surface it as a
+    /// terminal error rather than risk a deceptive partition of
+    /// `failed_installations`.
+    #[error(
+        "sequence_id {sequence_id} for inbox {inbox_id} exceeds i64::MAX; cannot query identity-update history"
+    )]
+    SequenceIdOverflow { inbox_id: String, sequence_id: u64 },
 }
 
 impl xmtp_common::retry::RetryableError for BootstrapSynthesisError {
@@ -82,7 +95,10 @@ impl xmtp_common::retry::RetryableError for BootstrapSynthesisError {
     fn is_retryable(&self) -> bool {
         match self {
             Self::IdentityUpdateLookup { source, .. } => source.is_retryable(),
-            Self::Common(_) | Self::LegacyMembershipDecode(_) | Self::RegistryReEncode(_) => false,
+            Self::Common(_)
+            | Self::LegacyMembershipDecode(_)
+            | Self::RegistryReEncode(_)
+            | Self::SequenceIdOverflow { .. } => false,
         }
     }
 }
@@ -177,10 +193,15 @@ async fn build_partitioned_group_membership<C: XmtpSharedContext>(
     // into the serialized output.
     let mut install_owner: std::collections::HashMap<Vec<u8>, InboxId> =
         std::collections::HashMap::new();
-    for (inbox_id, _seq) in sequence_ids.iter() {
+    for (inbox_id, seq) in sequence_ids.iter() {
         let inbox_id_hex = inbox_id.to_hex();
+        let signed_seq =
+            i64::try_from(*seq).map_err(|_| BootstrapSynthesisError::SequenceIdOverflow {
+                inbox_id: inbox_id_hex.clone(),
+                sequence_id: *seq,
+            })?;
         let state = identity_updates
-            .get_association_state(&db, &inbox_id_hex, None)
+            .get_association_state(&db, &inbox_id_hex, Some(signed_seq))
             .await
             .map_err(|source| BootstrapSynthesisError::IdentityUpdateLookup {
                 inbox_id: inbox_id_hex.clone(),
@@ -400,6 +421,8 @@ mod tests {
         permissions_update_policy::{Kind as PermissionsKind, PermissionsBasePolicy},
     };
 
+    use xmtp_db::identity_update::QueryIdentityUpdates;
+
     use crate::{identity_updates::load_identity_updates, tester};
 
     /// Unwrap a `GroupMembershipEntry` envelope to its inner `V1`
@@ -490,10 +513,22 @@ mod tests {
             &[alix.inbox_id(), bo.inbox_id()],
         )
         .await?;
+        // GROUP_MEMBERSHIP sequence_ids are no longer synthetic: the
+        // synthesizer pins the per-inbox association-state lookup to
+        // the GMM's sequence_id, so the value must match an existing
+        // identity-update record.
+        let alix_seq = alix
+            .context
+            .db()
+            .get_latest_sequence_id_for_inbox(alix.inbox_id())? as u64;
+        let bo_seq = alix
+            .context
+            .db()
+            .get_latest_sequence_id_for_inbox(bo.inbox_id())? as u64;
 
         let mut members = HashMap::new();
-        members.insert(alix.inbox_id().to_string(), 7_u64);
-        members.insert(bo.inbox_id().to_string(), 42_u64);
+        members.insert(alix.inbox_id().to_string(), alix_seq);
+        members.insert(bo.inbox_id().to_string(), bo_seq);
         let exts = build_test_extensions(
             default_gmm(),
             GroupMembershipProto {
@@ -526,10 +561,18 @@ mod tests {
         let bo_install = bo.installation_id.to_vec();
         let alix_inbox = InboxId::from_hex(alix.inbox_id())?;
         let bo_inbox = InboxId::from_hex(bo.inbox_id())?;
+        let alix_seq = alix
+            .context
+            .db()
+            .get_latest_sequence_id_for_inbox(alix.inbox_id())? as u64;
+        let bo_seq = alix
+            .context
+            .db()
+            .get_latest_sequence_id_for_inbox(bo.inbox_id())? as u64;
 
         let mut members = HashMap::new();
-        members.insert(alix.inbox_id().to_string(), 7_u64);
-        members.insert(bo.inbox_id().to_string(), 42_u64);
+        members.insert(alix.inbox_id().to_string(), alix_seq);
+        members.insert(bo.inbox_id().to_string(), bo_seq);
         let exts = build_test_extensions(
             default_gmm(),
             GroupMembershipProto {
@@ -547,9 +590,9 @@ mod tests {
         assert_eq!(decoded.len(), 2);
         let v1_a = unwrap_v1(decoded.get(&alix_inbox).unwrap());
         let v1_b = unwrap_v1(decoded.get(&bo_inbox).unwrap());
-        assert_eq!(v1_a.sequence_id, 7);
+        assert_eq!(v1_a.sequence_id, alix_seq);
         assert_eq!(v1_a.failed_installations, vec![alix_install]);
-        assert_eq!(v1_b.sequence_id, 42);
+        assert_eq!(v1_b.sequence_id, bo_seq);
         assert_eq!(v1_b.failed_installations, vec![bo_install]);
     }
 
@@ -561,10 +604,14 @@ mod tests {
         load_identity_updates(alix.context.api(), &alix.context.db(), &[alix.inbox_id()]).await?;
 
         let alix_inbox = InboxId::from_hex(alix.inbox_id())?;
+        let alix_seq = alix
+            .context
+            .db()
+            .get_latest_sequence_id_for_inbox(alix.inbox_id())? as u64;
         let orphan_install = vec![0xDE; 32]; // not owned by any inbox
 
         let mut members = HashMap::new();
-        members.insert(alix.inbox_id().to_string(), 1_u64);
+        members.insert(alix.inbox_id().to_string(), alix_seq);
         let exts = build_test_extensions(
             default_gmm(),
             GroupMembershipProto {
@@ -606,5 +653,149 @@ mod tests {
         assert!(out.contains_key(&ComponentId::CONVERSATION_TYPE));
         assert!(!out.contains_key(&ComponentId::DM_MEMBERS));
         assert!(!out.contains_key(&ComponentId::ONESHOT_MESSAGE));
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn synthesize_partitions_against_snapshotted_view_not_latest() {
+        // Two members, each with multiple installations; the group's
+        // recorded sequence_id captures a snapshot of identity history.
+        // After the snapshot, new installations are added to each
+        // member's chain WITHOUT a group-side resync. The bootstrap
+        // synthesizer pins per-inbox association-state lookups to the
+        // group's snapshotted sequence_id, so:
+        //  - installations live at the snapshot are partitioned to their
+        //    owning inbox
+        //  - installations added AFTER the snapshot have no owner at the
+        //    snapshotted state and are dropped from `failed_installations`
+        //  - bogus install ids that never belonged to anyone are dropped
+        //  - cross-inbox leakage doesn't happen
+        //  - re-running synthesis with the same input is byte-stable
+        //
+        // This is the exact "group has not refreshed yet, identity moved
+        // on" scenario every honest receiver will hit during a real
+        // bootstrap rollout.
+        use std::collections::BTreeSet;
+
+        tester!(alix);
+        let alix2 = alix.new_installation().await;
+        tester!(bo);
+        let bo2 = bo.new_installation().await;
+
+        // Refresh once so the synthesizer's local-DB read sees both
+        // inboxes' chains up through the second installation.
+        load_identity_updates(
+            alix.context.api(),
+            &alix.context.db(),
+            &[alix.inbox_id(), bo.inbox_id()],
+        )
+        .await?;
+
+        // Snapshot the group's view of each inbox here. The synthetic
+        // pre-flip GMM below uses these as its sequence_ids, so the
+        // synthesizer will pin its per-inbox lookups to this point in
+        // each chain.
+        let alix_snapshot_seq =
+            alix.context
+                .db()
+                .get_latest_sequence_id_for_inbox(alix.inbox_id())? as u64;
+        let bo_snapshot_seq = alix
+            .context
+            .db()
+            .get_latest_sequence_id_for_inbox(bo.inbox_id())? as u64;
+
+        let alix1_install = alix.installation_id.to_vec();
+        let alix2_install = alix2.installation_id.to_vec();
+        let bo1_install = bo.installation_id.to_vec();
+        let bo2_install = bo2.installation_id.to_vec();
+
+        // After the snapshot: each chain extends. The group has NOT
+        // resynced, so its recorded sequence_id stays put.
+        let alix3 = alix.new_installation().await;
+        let bo3 = bo.new_installation().await;
+        let alix3_install = alix3.installation_id.to_vec();
+        let bo3_install = bo3.installation_id.to_vec();
+
+        // Refresh local DB so post-snapshot updates are visible — the
+        // point of this test is that the synthesizer DOESN'T use them
+        // because it queries at the snapshotted seq_id, not latest.
+        load_identity_updates(
+            alix.context.api(),
+            &alix.context.db(),
+            &[alix.inbox_id(), bo.inbox_id()],
+        )
+        .await?;
+
+        let alix_inbox = InboxId::from_hex(alix.inbox_id())?;
+        let bo_inbox = InboxId::from_hex(bo.inbox_id())?;
+
+        // Bogus install id that has never belonged to any inbox — the
+        // legacy `failed_installations` proto is permissive enough that
+        // a malicious or buggy prior commit could have stuffed garbage
+        // in here.
+        let bogus_install = vec![0xCA; 32];
+
+        let mut members = HashMap::new();
+        members.insert(alix.inbox_id().to_string(), alix_snapshot_seq);
+        members.insert(bo.inbox_id().to_string(), bo_snapshot_seq);
+        let exts = build_test_extensions(
+            default_gmm(),
+            GroupMembershipProto {
+                members,
+                failed_installations: vec![
+                    alix1_install.clone(),
+                    alix2_install.clone(),
+                    alix3_install.clone(),
+                    bo1_install.clone(),
+                    bo2_install.clone(),
+                    bo3_install.clone(),
+                    bogus_install.clone(),
+                ],
+            },
+            default_metadata(alix.inbox_id().to_string()),
+        );
+
+        let out = synthesize_initial_component_values_from_extensions(&alix.context, &exts).await?;
+        let bytes = out.get(&ComponentId::GROUP_MEMBERSHIP).unwrap();
+        let decoded =
+            xmtp_mls_common::app_data::migration::decode_group_membership_delta(bytes).unwrap();
+
+        let alix_v1 = unwrap_v1(decoded.get(&alix_inbox).unwrap());
+        let bo_v1 = unwrap_v1(decoded.get(&bo_inbox).unwrap());
+
+        assert_eq!(alix_v1.sequence_id, alix_snapshot_seq);
+        assert_eq!(bo_v1.sequence_id, bo_snapshot_seq);
+
+        let alix_failed: BTreeSet<Vec<u8>> = alix_v1.failed_installations.iter().cloned().collect();
+        let bo_failed: BTreeSet<Vec<u8>> = bo_v1.failed_installations.iter().cloned().collect();
+
+        // Snapshot-visible installations partition to their owner.
+        assert!(alix_failed.contains(&alix1_install));
+        assert!(alix_failed.contains(&alix2_install));
+        assert!(bo_failed.contains(&bo1_install));
+        assert!(bo_failed.contains(&bo2_install));
+
+        // Post-snapshot installations have no owner at the snapshotted
+        // sequence_id and are dropped.
+        assert!(!alix_failed.contains(&alix3_install));
+        assert!(!bo_failed.contains(&alix3_install));
+        assert!(!alix_failed.contains(&bo3_install));
+        assert!(!bo_failed.contains(&bo3_install));
+
+        // Bogus install id is dropped — never belonged to any inbox.
+        assert!(!alix_failed.contains(&bogus_install));
+        assert!(!bo_failed.contains(&bogus_install));
+
+        // No cross-inbox leakage.
+        assert!(!alix_failed.contains(&bo1_install));
+        assert!(!alix_failed.contains(&bo2_install));
+        assert!(!bo_failed.contains(&alix1_install));
+        assert!(!bo_failed.contains(&alix2_install));
+
+        // Determinism: byte-identical output across calls. Validation
+        // peers byte-compare against this, so any non-determinism here
+        // would make every honest receiver reject the bootstrap commit.
+        let again =
+            synthesize_initial_component_values_from_extensions(&alix.context, &exts).await?;
+        assert_eq!(out, again, "bootstrap synthesis must be byte-stable");
     }
 }

--- a/crates/xmtp_mls/src/groups/app_data/mod.rs
+++ b/crates/xmtp_mls/src/groups/app_data/mod.rs
@@ -14,6 +14,7 @@
 // lint. The functions inside the module remain `pub(crate)`, so the wider
 // crate ecosystem still can't read or write arbitrary components — only
 // `GroupError` consumers see the error type.
+pub(crate) mod bootstrap_validator;
 pub mod component_source;
 pub mod migration;
 

--- a/crates/xmtp_mls/src/groups/validated_commit.rs
+++ b/crates/xmtp_mls/src/groups/validated_commit.rs
@@ -112,6 +112,13 @@ pub enum CommitValidationError {
     /// (which would let a permissive validator state slip in).
     #[error(transparent)]
     ComponentSource(#[from] super::app_data::component_source::ComponentSourceError),
+
+    /// All bootstrap-commit-validator failures. The bootstrap path runs
+    /// only during the one-time AppData migration; isolating its many
+    /// failure modes in a sub-enum keeps the steady-state validator's
+    /// surface from being dominated by migration-specific noise.
+    #[error(transparent)]
+    Bootstrap(#[from] super::app_data::bootstrap_validator::BootstrapValidationError),
 }
 
 impl RetryableError for CommitValidationError {
@@ -338,17 +345,48 @@ pub struct ValidatedCommit {
     pub dm_members: Option<DmMembers<String>>,
 }
 
+/// Reject any commit that carries a `PreSharedKey` proposal.
+///
+/// Called from both the steady-state and bootstrap commit-validation
+/// paths so the rejection rule lives in one place — drift between the
+/// two paths is a security risk (a steady-state tightening that misses
+/// the bootstrap path would let a sender smuggle a PSK proposal through
+/// a bootstrap-shaped commit).
+fn reject_psk_proposals(staged_commit: &StagedCommit) -> Result<(), CommitValidationError> {
+    if staged_commit.psk_proposals().any(|_| true) {
+        return Err(CommitValidationError::NoPSKSupport);
+    }
+    Ok(())
+}
+
 impl ValidatedCommit {
     pub async fn from_staged_commit(
         context: &impl XmtpSharedContext,
         staged_commit: &StagedCommit,
         openmls_group: &OpenMlsGroup,
     ) -> Result<Self, CommitValidationError> {
-        let conn = context.db();
-        // Get the immutable and mutable metadata
         let extensions = openmls_group.extensions();
         let immutable_metadata: GroupMetadata = extensions.try_into()?;
         let mutable_metadata: GroupMutableMetadata = extensions.try_into()?;
+
+        // Bootstrap detection MUST run before the steady-state
+        // extractors below — bootstrap commits strip MUTABLE_METADATA,
+        // GROUP_PERMISSIONS, and GROUP_MEMBERSHIP from
+        // `new_group_extensions`, so `extract_metadata_changes` /
+        // `extract_permissions_changed` / membership-diff would all
+        // surface MissingExtension errors before bootstrap-specific
+        // validation could ever run. The pre-flip extensions still
+        // carry the legacy set, so the metadata reads above are safe.
+        if super::app_data::bootstrap_validator::is_bootstrap_commit(staged_commit, extensions) {
+            return Self::validate_bootstrap_and_build(
+                staged_commit,
+                openmls_group,
+                immutable_metadata,
+                mutable_metadata,
+            );
+        }
+
+        let conn = context.db();
         let group_permissions: GroupMutablePermissions = extensions.try_into()?;
         let current_group_members = get_current_group_members(openmls_group);
 
@@ -412,16 +450,16 @@ impl ValidatedCommit {
             &mutable_metadata,
         )?;
 
-        // Block any psk proposals
-        if staged_commit.psk_proposals().any(|_| true) {
-            return Err(CommitValidationError::NoPSKSupport);
-        }
+        reject_psk_proposals(staged_commit)?;
 
         // AppDataUpdate proposals carried by a commit (inline OR by
         // reference, since `staged_commit.app_data_update_proposals()`
-        // iterates both) never flow through `validate_proposal()` — that
-        // path only handles standalone proposal-by-reference messages —
-        // so this is where their permission check lives.
+        // iterates both) never flow through `validate_proposal()` —
+        // that path only handles standalone proposal-by-reference
+        // messages — so this is where their permission check lives.
+        // Bootstrap commits are routed earlier in this function and
+        // never reach this path; their dispatch is via
+        // `validate_bootstrap_and_build`.
         validate_app_data_update_proposals_in_commit(
             staged_commit,
             openmls_group,
@@ -589,6 +627,59 @@ impl ValidatedCommit {
     pub fn actor_installation_id(&self) -> Vec<u8> {
         self.actor.installation_id.clone()
     }
+
+    /// Build a `ValidatedCommit` for the one-time AppData-migration
+    /// bootstrap commit.
+    ///
+    /// Bootstrap commits don't add or remove members, don't change the
+    /// per-inbox sequence ids, and don't change the legacy permissions
+    /// (their state is migrated to the AppData dictionary, not
+    /// modified). They're validated against the receiver-derived
+    /// canonical subset and a super-admin proposer requirement; the
+    /// resulting `ValidatedCommit` reports "no diff" on every
+    /// steady-state field so downstream policy evaluation and
+    /// installation-diff checks see a no-op.
+    fn validate_bootstrap_and_build(
+        staged_commit: &StagedCommit,
+        openmls_group: &OpenMlsGroup,
+        immutable_metadata: GroupMetadata,
+        mutable_metadata: GroupMutableMetadata,
+    ) -> Result<Self, CommitValidationError> {
+        reject_psk_proposals(staged_commit)?;
+
+        let (actor, proposers) = extract_committer_and_proposers(
+            staged_commit,
+            openmls_group,
+            &immutable_metadata,
+            &mutable_metadata,
+        )?;
+
+        let gce_proposer = super::app_data::bootstrap_validator::extract_gce_proposer(
+            staged_commit,
+            openmls_group,
+            &immutable_metadata,
+            &mutable_metadata,
+        )?
+        .ok_or(CommitValidationError::ProposerNotFound)?;
+
+        super::app_data::bootstrap_validator::validate_bootstrap_commit(
+            staged_commit,
+            openmls_group,
+            &gce_proposer,
+        )?;
+
+        Ok(Self {
+            actor,
+            proposers,
+            added_inboxes: Vec::new(),
+            removed_inboxes: Vec::new(),
+            readded_installations: HashSet::new(),
+            metadata_validation_info: MutableMetadataValidationInfo::default(),
+            installations_changed: false,
+            permissions_changed: false,
+            dm_members: immutable_metadata.dm_members,
+        })
+    }
 }
 
 impl From<ValidatedCommit> for GroupMembershipChanges {
@@ -745,10 +836,7 @@ impl ExpectedDiff {
         let immutable_metadata: GroupMetadata = extensions.try_into()?;
         let mutable_metadata: GroupMutableMetadata = extensions.try_into()?;
 
-        // Block any psk proposals
-        if staged_commit.psk_proposals().any(|_| true) {
-            return Err(CommitValidationError::NoPSKSupport);
-        }
+        reject_psk_proposals(staged_commit)?;
 
         let expected_diff = Self::extract_expected_diff_with_proposers(
             context,
@@ -1183,7 +1271,7 @@ fn validate_app_data_update_proposals_in_commit(
 }
 
 /// Extracts the [`CommitParticipant`] from the [`LeafNodeIndex`]
-fn extract_commit_participant(
+pub(super) fn extract_commit_participant(
     leaf_index: &LeafNodeIndex,
     group: &OpenMlsGroup,
     immutable_metadata: &GroupMetadata,


### PR DESCRIPTION
Adds the receiver-side counterpart to the sender's bootstrap
synthesis (Task 3a/3b). The bootstrap commit carries a
deterministic, sender-authoritative payload; every honest receiver
synthesizes the same canonical subset from the pre-flip group
state and byte-compares it against the commit's AppDataUpdate
proposals. Any divergence is rejected with a structured error.

- New module crates/xmtp_mls/src/groups/bootstrap_validator.rs
  with three layered entry points:
  - is_bootstrap_commit: shape-check a staged commit for the
    bootstrap signature (GCE flips PROPOSAL_SUPPORT, strips the
    four legacy extensions, AND at least one AppDataUpdate writes
    COMPONENT_REGISTRY)
  - extract_gce_proposer: pull the GCE-proposal proposer as a
    CommitParticipant for the super-admin check
  - validate_bootstrap_commit: full pipeline — super-admin check,
    canonical-subset synthesis, byte-compare, GCE shape check
- Pure-logic helper validate_against_canonical_subset takes the
  canonical subset + actual proposal bag, so the byte-compare
  contract is testable without a real StagedCommit
- GROUP_MEMBERSHIP hybrid validation: sequence_id byte-match
  (security-critical — forged higher seq_id would silently skip
  legitimate identity updates), failed_installations accepted
  sender-authoritative per the proto contract
- Wired into ValidatedCommit::from_staged_commit before the
  steady-state validate_app_data_update_proposals_in_commit so
  the bootstrap path bypasses the deny-by-default registry check
  (the dict has no COMPONENT_REGISTRY entry until this very
  commit merges)
- 8 new CommitValidationError variants (BootstrapMissingSeed,
  BootstrapMismatch, BootstrapUnexpectedProposal,
  BootstrapExtraMember, BootstrapMissingMember,
  BootstrapSequenceIdMismatch, BootstrapGceMismatch,
  BootstrapPayloadDecode, BootstrapProposerNotSuperAdmin,
  BootstrapSynthesis)
- 11 unit tests covering happy path, missing seed, byte
  mismatch, op-type mismatch, unexpected component,
  GROUP_MEMBERSHIP seq_id mismatch / extra member / missing
  member / accepted failed_installations / empty-both-sides /
  malformed TlsMap bytes

Pairs with IntentKind::BootstrapMigration dispatch (part 2b).
Bootstrap commits now land end-to-end on honest receivers.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add receiver-side bootstrap commit validator for AppData migration
> - Adds [`bootstrap_validator`](https://github.com/xmtp/libxmtp/pull/3566/files#diff-2161f31035c57ef1c233bc2a4ec6ca81a22d2b47eb407d5f89b0757bdedd802c) module that detects and validates the one-time AppData migration commit, which flips `PROPOSAL_SUPPORT` and seeds `COMPONENT_REGISTRY` and `GROUP_MEMBERSHIP` AppData components.
> - Detection checks for a `GroupContextExtensions` proposal adding `PROPOSAL_SUPPORT` while removing four legacy extensions, plus at least one `AppDataUpdate` for `COMPONENT_REGISTRY`.
> - Validation enforces: proposer is super-admin; only `GroupContextExtensions` and `AppDataUpdate` proposals are present; AppData updates exactly match a canonical subset synthesized from pre-flip state; GCE shape and `RequiredCapabilities` are correct.
> - Pins `build_partitioned_group_membership` association-state lookups to each member's snapshotted `sequence_id` rather than latest, ensuring byte-stable canonical subsets; adds `SequenceIdOverflow` error for IDs exceeding `i64::MAX`.
> - Integrates into [`ValidatedCommit::from_staged_commit`](https://github.com/xmtp/libxmtp/pull/3566/files#diff-233994c0ec18d23d0636e849849a3500e44611a4f64c6fffb1d0931aa1461ed6): bootstrap-shaped commits route to a dedicated validation path and produce a no-op diff on success.
> - Behavioral Change: bootstrap commits that pass detection but fail structural validation now return `CommitValidationError::Bootstrap` instead of proceeding through steady-state checks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5d61dcd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->