### PR TITLE
add in-memory options for iOS and android SDKs

### DIFF
--- a/sdks/android/library/src/main/java/org/xmtp/android/library/Client.kt
+++ b/sdks/android/library/src/main/java/org/xmtp/android/library/Client.kt
@@ -419,6 +419,7 @@ class Client(
             signingKey: SigningKey? = null,
             inboxId: InboxId? = null,
             buildOffline: Boolean = false,
+            inMemory: Boolean = false,
         ): Client =
             withContext(Dispatchers.IO) {
                 val recoveredInboxId =
@@ -431,6 +432,7 @@ class Client(
                         clientOptions,
                         clientOptions.appContext,
                         buildOffline,
+                        inMemory,
                     )
                 clientOptions.preAuthenticateToInboxCallback?.let {
                     runBlocking {
@@ -484,6 +486,35 @@ class Client(
                 }
             }
 
+        /**
+         * Creates a Client backed by an in-memory SQLCipher database.
+         *
+         * Bypasses all on-disk database management — no `.db3` file is created,
+         * no directory is touched, and `dropLocalDatabaseConnection` /
+         * `reconnectLocalDatabase` are no-ops against the in-memory pool. Intended
+         * for tests and other ephemeral flows where a real client is needed but
+         * persistence is not. State is lost when the client is garbage collected.
+         *
+         * `options.dbDirectory` and `options.dbEncryptionKey` are ignored — libxmtp
+         * manages the in-memory store itself.
+         */
+        suspend fun createInMemory(
+            account: SigningKey,
+            options: ClientOptions,
+        ): Client =
+            withContext(Dispatchers.IO) {
+                try {
+                    initializeV3Client(
+                        account.publicIdentity,
+                        options,
+                        account,
+                        inMemory = true,
+                    )
+                } catch (e: Exception) {
+                    throw XMTPException("Error creating in-memory V3 client: ${e.message}", e)
+                }
+            }
+
         // Function to build a client from a address
         suspend fun build(
             publicIdentity: PublicIdentity,
@@ -509,8 +540,37 @@ class Client(
             options: ClientOptions,
             appContext: Context,
             buildOffline: Boolean = false,
+            inMemory: Boolean = false,
         ): Pair<FfiXmtpClient, String> =
             withContext(Dispatchers.IO) {
+                if (inMemory) {
+                    val ffiClient =
+                        createClient(
+                            api = connectToApiBackend(options.api),
+                            syncApi = connectToSyncApiBackend(options.api),
+                            db =
+                                DbOptions(
+                                    db = null,
+                                    encryptionKey = null,
+                                    maxDbPoolSize = options.dbPoolOptions?.maxPoolSize,
+                                    minDbPoolSize = options.dbPoolOptions?.minPoolSize,
+                                ),
+                            accountIdentifier = publicIdentity.ffiPrivate,
+                            inboxId = inboxId,
+                            nonce = 0.toULong(),
+                            legacySignedPrivateKeyProto = null,
+                            deviceSyncMode =
+                                if (!options.deviceSyncEnabled) {
+                                    FfiDeviceSyncMode.DISABLED
+                                } else {
+                                    FfiDeviceSyncMode.ENABLED
+                                },
+                            allowOffline = buildOffline,
+                            forkRecoveryOpts = options.forkRecoveryOptions?.toFfi(),
+                        )
+                    return@withContext Pair(ffiClient, ":memory:")
+                }
+
                 val alias = "xmtp-${options.api.env}-$inboxId"
 
                 val mlsDbDirectory = options.dbDirectory

--- a/sdks/android/library/src/main/java/org/xmtp/android/library/Client.kt
+++ b/sdks/android/library/src/main/java/org/xmtp/android/library/Client.kt
@@ -138,8 +138,23 @@ class Client(
     val libXMTPVersion: String = getVersionInfo()
     private val ffiClient: FfiXmtpClient = libXMTPClient
 
+    /**
+     * `true` when this client is backed by an in-memory database. In that case
+     * [deleteLocalDatabase], [dropLocalDatabaseConnection] and
+     * [reconnectLocalDatabase] are no-ops and the underlying state is
+     * discarded when the client is garbage collected.
+     */
+    val isInMemory: Boolean
+        get() = dbPath == IN_MEMORY_DB_PATH
+
     companion object {
         private const val TAG = "Client"
+
+        /**
+         * Sentinel value assigned to [Client.dbPath] when the client was created
+         * via [createInMemory]. No file exists at this path.
+         */
+        const val IN_MEMORY_DB_PATH: String = ":memory:"
 
         var codecRegistry =
             run {
@@ -489,14 +504,20 @@ class Client(
         /**
          * Creates a Client backed by an in-memory SQLCipher database.
          *
-         * Bypasses all on-disk database management — no `.db3` file is created,
-         * no directory is touched, and `dropLocalDatabaseConnection` /
-         * `reconnectLocalDatabase` are no-ops against the in-memory pool. Intended
-         * for tests and other ephemeral flows where a real client is needed but
-         * persistence is not. State is lost when the client is garbage collected.
+         * Bypasses all on-disk database management — no `.db3` file is created
+         * and no directory is touched. The returned client has [Client.dbPath]
+         * equal to [IN_MEMORY_DB_PATH] (`":memory:"`) and [Client.isInMemory]
+         * returns `true`.
          *
-         * `options.dbDirectory` and `options.dbEncryptionKey` are ignored — libxmtp
-         * manages the in-memory store itself.
+         * On in-memory clients, [Client.deleteLocalDatabase],
+         * [Client.dropLocalDatabaseConnection] and
+         * [Client.reconnectLocalDatabase] are no-ops — state lives only in the
+         * FFI pool and is discarded when the client is garbage collected.
+         *
+         * Intended for tests and other ephemeral flows where a real client is
+         * needed but persistence is not. [ClientOptions.dbDirectory] and
+         * [ClientOptions.dbEncryptionKey] are ignored — libxmtp manages the
+         * in-memory store itself.
          */
         suspend fun createInMemory(
             account: SigningKey,
@@ -568,7 +589,7 @@ class Client(
                             allowOffline = buildOffline,
                             forkRecoveryOpts = options.forkRecoveryOptions?.toFfi(),
                         )
-                    return@withContext Pair(ffiClient, ":memory:")
+                    return@withContext Pair(ffiClient, IN_MEMORY_DB_PATH)
                 }
 
                 val alias = "xmtp-${options.api.env}-$inboxId"
@@ -749,6 +770,8 @@ class Client(
 
     suspend fun deleteLocalDatabase() =
         withContext(Dispatchers.IO) {
+            // In-memory clients have no on-disk file; nothing to drop or remove.
+            if (isInMemory) return@withContext
             dropLocalDatabaseConnection()
             File(dbPath).delete()
         }
@@ -758,11 +781,15 @@ class Client(
     )
     suspend fun dropLocalDatabaseConnection() =
         withContext(Dispatchers.IO) {
+            // In-memory clients hold their state in the FFI pool; releasing the
+            // connection would discard data that cannot be restored on reconnect.
+            if (isInMemory) return@withContext
             ffiClient.releaseDbConnection()
         }
 
     suspend fun reconnectLocalDatabase() =
         withContext(Dispatchers.IO) {
+            if (isInMemory) return@withContext
             ffiClient.dbReconnect()
         }
 

--- a/sdks/ios/Sources/XMTPiOS/Client.swift
+++ b/sdks/ios/Sources/XMTPiOS/Client.swift
@@ -204,6 +204,10 @@ actor ApiClientCache {
 public typealias InboxId = String
 
 public final class Client {
+	/// Sentinel value assigned to ``dbPath`` when the client was created via
+	/// ``createInMemory(account:options:)``. No file exists at this path.
+	public static let inMemoryDbPath = ":memory:"
+
 	public let inboxID: InboxId
 	public let libXMTPVersion: String = getVersionInfo()
 	public let dbPath: String
@@ -212,6 +216,14 @@ public final class Client {
 	public let environment: XMTPEnvironment
 	private let ffiClient: FfiXmtpClient
 	private static let apiCache = ApiClientCache()
+
+	/// `true` when this client is backed by an in-memory database. In that case
+	/// ``deleteLocalDatabase()``, ``dropLocalDatabaseConnection()`` and
+	/// ``reconnectLocalDatabase()`` are no-ops and the underlying state is
+	/// discarded when the client is deallocated.
+	public var isInMemory: Bool {
+		dbPath == Client.inMemoryDbPath
+	}
 
 	public lazy var conversations: Conversations = .init(
 		clientInboxId: inboxID,
@@ -324,14 +336,19 @@ public final class Client {
 
 	/// Creates a Client backed by an in-memory SQLCipher database.
 	///
-	/// This bypasses all on-disk database management — no `.db3` file is created,
-	/// no directory is touched, and `dropLocalDatabaseConnection` / `reconnectLocalDatabase`
-	/// are no-ops against the in-memory pool. Intended for tests and other ephemeral
-	/// flows where a real client is needed but persistence is not. State is lost when
-	/// the client is deallocated.
+	/// This bypasses all on-disk database management — no `.db3` file is created
+	/// and no directory is touched. The returned client has ``dbPath`` equal to
+	/// ``Client/inMemoryDbPath`` (`":memory:"`) and ``isInMemory`` returns `true`.
 	///
-	/// `options.dbDirectory` and `options.dbEncryptionKey` are ignored — libxmtp manages
-	/// the in-memory store itself.
+	/// On in-memory clients, ``deleteLocalDatabase()``,
+	/// ``dropLocalDatabaseConnection()`` and ``reconnectLocalDatabase()`` are
+	/// no-ops — state lives only in the FFI pool and is discarded when the
+	/// client is deallocated.
+	///
+	/// Intended for tests and other ephemeral flows where a real client is
+	/// needed but persistence is not. `options.dbDirectory` and
+	/// `options.dbEncryptionKey` are ignored — libxmtp manages the in-memory
+	/// store itself.
 	public static func createInMemory(
 		account: SigningKey, options: ClientOptions
 	)
@@ -435,7 +452,7 @@ public final class Client {
 				forkRecoveryOpts: options.forkRecoveryOptions?.toFfi()
 			)
 
-			return (ffiClient, ":memory:")
+			return (ffiClient, Client.inMemoryDbPath)
 		}
 
 		let mlsDbDirectory = options.dbDirectory
@@ -924,6 +941,8 @@ public final class Client {
 	}
 
 	public func deleteLocalDatabase() throws {
+		// In-memory clients have no on-disk file; nothing to drop or remove.
+		guard !isInMemory else { return }
 		try dropLocalDatabaseConnection()
 		let fm = FileManager.default
 		try fm.removeItem(atPath: dbPath)
@@ -935,10 +954,14 @@ public final class Client {
 		"This function is delicate and should be used with caution. App will error if database not properly reconnected. See: reconnectLocalDatabase()"
 	)
 	public func dropLocalDatabaseConnection() throws {
+		// In-memory clients hold their state in the FFI pool; releasing the
+		// connection would discard data that cannot be restored on reconnect.
+		guard !isInMemory else { return }
 		try ffiClient.releaseDbConnection()
 	}
 
 	public func reconnectLocalDatabase() async throws {
+		guard !isInMemory else { return }
 		try await ffiClient.dbReconnect()
 	}
 

--- a/sdks/ios/Sources/XMTPiOS/Client.swift
+++ b/sdks/ios/Sources/XMTPiOS/Client.swift
@@ -239,13 +239,15 @@ public final class Client {
 		signingKey: SigningKey?,
 		inboxId: InboxId,
 		apiClient _: XmtpApiClient? = nil,
-		buildOffline: Bool = false
+		buildOffline: Bool = false,
+		inMemory: Bool = false
 	) async throws -> Client {
 		let (libxmtpClient, dbPath) = try await initFFiClient(
 			accountIdentifier: publicIdentity,
 			options: options,
 			inboxId: inboxId,
-			buildOffline: buildOffline
+			buildOffline: buildOffline,
+			inMemory: inMemory
 		)
 
 		let client = try Client(
@@ -320,6 +322,35 @@ public final class Client {
 		)
 	}
 
+	/// Creates a Client backed by an in-memory SQLCipher database.
+	///
+	/// This bypasses all on-disk database management — no `.db3` file is created,
+	/// no directory is touched, and `dropLocalDatabaseConnection` / `reconnectLocalDatabase`
+	/// are no-ops against the in-memory pool. Intended for tests and other ephemeral
+	/// flows where a real client is needed but persistence is not. State is lost when
+	/// the client is deallocated.
+	///
+	/// `options.dbDirectory` and `options.dbEncryptionKey` are ignored — libxmtp manages
+	/// the in-memory store itself.
+	public static func createInMemory(
+		account: SigningKey, options: ClientOptions
+	)
+		async throws -> Client
+	{
+		let identity = account.identity
+		let inboxId = try await getOrCreateInboxId(
+			api: options.api, publicIdentity: identity
+		)
+
+		return try await initializeClient(
+			publicIdentity: identity,
+			options: options,
+			signingKey: account,
+			inboxId: inboxId,
+			inMemory: true
+		)
+	}
+
 	public static func build(
 		publicIdentity: PublicIdentity, options: ClientOptions,
 		inboxId: InboxId? = nil
@@ -379,8 +410,34 @@ public final class Client {
 		accountIdentifier: PublicIdentity,
 		options: ClientOptions,
 		inboxId: InboxId,
-		buildOffline: Bool = false
+		buildOffline: Bool = false,
+		inMemory: Bool = false
 	) async throws -> (FfiXmtpClient, String) {
+		if inMemory {
+			let deviceSyncMode: FfiDeviceSyncMode =
+				!options.deviceSyncEnabled ? .disabled : .enabled
+
+			let ffiClient = try await createClient(
+				api: connectToApiBackend(api: options.api),
+				syncApi: connectToSyncApiBackend(api: options.api),
+				db: DbOptions(
+					db: nil,
+					encryptionKey: nil,
+					maxDbPoolSize: options.dbPoolOptions?.maxPoolSize,
+					minDbPoolSize: options.dbPoolOptions?.minPoolSize
+				),
+				inboxId: inboxId,
+				accountIdentifier: accountIdentifier.ffiPrivate,
+				nonce: 0,
+				legacySignedPrivateKeyProto: nil,
+				deviceSyncMode: deviceSyncMode,
+				allowOffline: buildOffline,
+				forkRecoveryOpts: options.forkRecoveryOptions?.toFfi()
+			)
+
+			return (ffiClient, ":memory:")
+		}
+
 		let mlsDbDirectory = options.dbDirectory
 		var directoryURL: URL
 		if let mlsDbDirectory {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add in-memory database support to iOS and Android SDK clients
- Adds `createInMemory` factory methods to `Client` in both the [iOS](https://github.com/xmtp/libxmtp/pull/3569/files#diff-fda53e366d262601ad6a3c0d242a4e628b446a19baec1687abfd484b6cb1efc4) and [Android](https://github.com/xmtp/libxmtp/pull/3569/files#diff-6a1a4efe485f82ebc6bac85479e71e7de7a9756b0e39be79db3cdf1d6723d937) SDKs, creating FFI clients with `DbOptions` having null db and encryption key.
- Adds an `isInMemory` computed property that checks if `dbPath` equals the sentinel value `":memory:"`.
- `deleteLocalDatabase`, `dropLocalDatabaseConnection`, and `reconnectLocalDatabase` are no-ops when `isInMemory` is true.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 66aa6ec.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->