### PR TITLE
refactor(xmtp_api): adopt GroupId in GroupFilter and query endpoints (Task 5)

### DIFF
--- a/bindings/mobile/src/mls.rs
+++ b/bindings/mobile/src/mls.rs
@@ -245,12 +245,10 @@ pub async fn get_newest_message_metadata(
     api: Arc<XmtpApiClient>,
     group_ids: Vec<Vec<u8>>,
 ) -> Result<HashMap<Vec<u8>, FfiMessageMetadata>, FfiError> {
-    let group_id_refs: Vec<&[u8]> = group_ids.iter().map(|id| id.as_slice()).collect();
+    let group_ids: Vec<xmtp_proto::types::GroupId> =
+        group_ids.into_iter().map(Into::into).collect();
 
-    let metadata = api
-        .wrapper
-        .get_newest_message_metadata(group_id_refs)
-        .await?;
+    let metadata = api.wrapper.get_newest_message_metadata(&group_ids).await?;
 
     metadata
         .into_iter()

--- a/crates/xmtp_api/src/mls.rs
+++ b/crates/xmtp_api/src/mls.rs
@@ -36,7 +36,7 @@ impl GroupFilter {
 impl From<GroupFilter> for GroupFilterProto {
     fn from(filter: GroupFilter) -> Self {
         Self {
-            group_id: filter.group_id.to_vec(),
+            group_id: filter.group_id.into(),
             id_cursor: filter.id_cursor.unwrap_or(0),
         }
     }

--- a/crates/xmtp_api/src/mls.rs
+++ b/crates/xmtp_api/src/mls.rs
@@ -18,23 +18,14 @@ use xmtp_proto::xmtp::mls::api::v1::{
 };
 
 /// A filter for querying group messages
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct GroupFilter {
-    pub group_id: Vec<u8>,
+    pub group_id: GroupId,
     pub id_cursor: Option<u64>,
 }
 
-impl std::fmt::Debug for GroupFilter {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("GroupFilter")
-            .field("group_id", &xmtp_common::fmt::debug_hex(&self.group_id))
-            .field("id_cursor", &self.id_cursor)
-            .finish()
-    }
-}
-
 impl GroupFilter {
-    pub fn new(group_id: Vec<u8>, id_cursor: Option<u64>) -> Self {
+    pub fn new(group_id: GroupId, id_cursor: Option<u64>) -> Self {
         Self {
             group_id,
             id_cursor,
@@ -45,7 +36,7 @@ impl GroupFilter {
 impl From<GroupFilter> for GroupFilterProto {
     fn from(filter: GroupFilter) -> Self {
         Self {
-            group_id: filter.group_id,
+            group_id: filter.group_id.to_vec(),
             id_cursor: filter.id_cursor.unwrap_or(0),
         }
     }
@@ -330,7 +321,7 @@ where
 
     pub async fn get_newest_message_metadata(
         &self,
-        group_ids: Vec<&[u8]>,
+        group_ids: &[GroupId],
     ) -> Result<MessageMetadataMap> {
         const BATCH_SIZE: usize = 1000;
 
@@ -338,7 +329,7 @@ where
             futures::future::try_join_all(group_ids.chunks(BATCH_SIZE).map(|chunk| async move {
                 self.api_client
                     .get_newest_group_message(GetNewestGroupMessageRequest {
-                        group_ids: chunk.to_vec().iter().map(|id| id.to_vec()).collect(),
+                        group_ids: chunk.iter().map(|id| id.to_vec()).collect(),
                         include_content: false,
                     })
                     .await

--- a/crates/xmtp_api_d14n/src/endpoints/v3/mls/query_group_messages.rs
+++ b/crates/xmtp_api_d14n/src/endpoints/v3/mls/query_group_messages.rs
@@ -4,13 +4,14 @@ use prost::bytes::Bytes;
 use std::borrow::Cow;
 use xmtp_proto::api::{BodyError, Endpoint, Pageable};
 use xmtp_proto::mls_v1::QueryGroupMessagesResponse;
+use xmtp_proto::types::GroupId;
 use xmtp_proto::xmtp::mls::api::v1::{PagingInfo, QueryGroupMessagesRequest};
 
 #[derive(Debug, Builder, Default)]
 #[builder(setter(strip_option), build_fn(error = "BodyError"))]
 pub struct QueryGroupMessages {
     #[builder(setter(into))]
-    group_id: Vec<u8>,
+    group_id: GroupId,
     paging_info: Option<PagingInfo>,
 }
 
@@ -28,7 +29,7 @@ impl Endpoint for QueryGroupMessages {
 
     fn body(&self) -> Result<Bytes, BodyError> {
         Ok(QueryGroupMessagesRequest {
-            group_id: self.group_id.clone(),
+            group_id: self.group_id.to_vec(),
             paging_info: self.paging_info,
         }
         .encode_to_vec()
@@ -49,6 +50,7 @@ mod test {
     use crate::v3::QueryGroupMessages;
     use xmtp_api_grpc::test::NodeGoClient;
     use xmtp_proto::prelude::*;
+    use xmtp_proto::types::GroupId;
     use xmtp_proto::xmtp::mls::api::v1::*;
 
     #[xmtp_common::test]
@@ -65,7 +67,7 @@ mod test {
         let client = NodeGoClient::create();
         let client = client.build().unwrap();
         let mut endpoint = QueryGroupMessages::builder()
-            .group_id(vec![1, 2, 3])
+            .group_id(GroupId::from(vec![1, 2, 3]))
             .paging_info(PagingInfo::default())
             .build()
             .unwrap();

--- a/crates/xmtp_mls/src/groups/welcome_sync.rs
+++ b/crates/xmtp_mls/src/groups/welcome_sync.rs
@@ -207,12 +207,16 @@ where
         let db = self.context.db();
         let api = self.context.api();
 
-        let group_ids: Vec<&[u8]> = groups.iter().map(|group| group.group_id.as_ref()).collect();
+        let group_ids: Vec<GroupId> = groups
+            .iter()
+            .map(|group| GroupId::from(group.group_id.as_slice()))
+            .collect();
+        let id_slices: Vec<&[u8]> = group_ids.iter().map(|id| id.as_ref()).collect();
         let last_synced_cursors = db.get_last_cursor_for_ids(
-            &group_ids,
+            &id_slices,
             &[EntityKind::ApplicationMessage, EntityKind::CommitMessage],
         )?;
-        let latest_message_metadata = api.get_newest_message_metadata(group_ids).await?;
+        let latest_message_metadata = api.get_newest_message_metadata(&group_ids).await?;
 
         let group_ids_needing_sync =
             filter_groups_with_new_messages(last_synced_cursors, latest_message_metadata);

--- a/crates/xmtp_proto/src/types/ids/group_id.rs
+++ b/crates/xmtp_proto/src/types/ids/group_id.rs
@@ -101,6 +101,12 @@ impl From<&[u8]> for GroupId {
     }
 }
 
+impl From<GroupId> for Vec<u8> {
+    fn from(id: GroupId) -> Vec<u8> {
+        id.0.into()
+    }
+}
+
 #[cfg(feature = "diesel")]
 impl ToSql<Binary, Sqlite> for GroupId
 where


### PR DESCRIPTION
## Summary

Task 5 of [#3550](https://github.com/xmtp/libxmtp/issues/3550) — flips the remaining `Vec<u8>`/`&[u8]` group-id surfaces in `xmtp_api` and `xmtp_api_d14n` to `GroupId`. The trait surface in `XmtpMlsClient` already takes `GroupId` from prior PRs; this picks up the leftovers.

- `GroupFilter.group_id`: `Vec<u8>` → `GroupId`. `GroupFilter → GroupFilterProto` calls `.to_vec()` at the prost boundary.
- `ApiClientWrapper::get_newest_message_metadata` accepts `&[GroupId]` instead of `Vec<&[u8]>`.
- `xmtp_api_d14n::v3::QueryGroupMessages.group_id`: `Vec<u8>` → `GroupId`.
- Mobile FFI binding `get_newest_message_metadata` ingests `Vec<Vec<u8>>` at the FFI surface and converts to `Vec<GroupId>` internally — FFI signature unchanged.

## Test plan

- [ ] `just check` — workspace compiles green
- [ ] `just lint-rust` — clippy + fmt + hakari clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Adopt `GroupId` type in `GroupFilter` and query endpoints across MLS API
> - Replaces raw `Vec<u8>` group ID fields with the `GroupId` newtype in [`GroupFilter`](https://github.com/xmtp/libxmtp/pull/3571/files#diff-85c63ca17c26ee353960247a8a31b08598056b1f5f229c35cbaf0de0e0f800f8), [`QueryGroupMessages`](https://github.com/xmtp/libxmtp/pull/3571/files#diff-80d1710838d2e6de964b736766dda1341bc44fcc833410782e861f7115815eb2), and related API call sites.
> - Updates `get_newest_message_metadata` to accept `&[GroupId]` instead of `Vec<&[u8]>`, converting to `Vec<u8>` only at the proto serialization boundary.
> - Adds `From<GroupId> for Vec<u8>` in [`group_id.rs`](https://github.com/xmtp/libxmtp/pull/3571/files#diff-104b61fe50ada45ed3044f22b9d7583a8f9da70d9adab879ebd1b26b1ce8c310) to support the new conversions.
> - Removes the manual `Debug` impl from `GroupFilter` in favor of a derived one now that the field type supports it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c8512e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->