### PR TITLE
fix(xdbg): pass &group.id directly to client.group()

### DIFF
--- a/apps/xmtp_debug/src/app/generate/messages.rs
+++ b/apps/xmtp_debug/src/app/generate/messages.rs
@@ -211,7 +211,7 @@ impl GenerateMessages {
                 .ok_or(eyre!("client does not exist"))?;
             let client = client.lock().await;
             client.sync_welcomes().await?;
-            let mls_group = client.group(&group.id.into())?;
+            let mls_group = client.group(&group.id)?;
             mls_group.sync_with_conn().await?;
             mls_group.maybe_update_installations(None).await?;
             let words = rng.random_range(0..10);
@@ -300,7 +300,7 @@ impl GenerateMessages {
                 .ok_or(eyre!("client does not exist"))?;
             let client = client.lock().await;
             client.sync_welcomes().await?;
-            let group = client.group(&group.id.into())?;
+            let group = client.group(&group.id)?;
             group.sync_with_conn().await?;
             group.maybe_update_installations(None).await?;
             let words = rng.random_range(0..*max_message_size);


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3570

## Summary

The xdbg Docker build (and Nix cache aggregation workflow) has been broken since PR #3555 reshaped the OpenMLS `GroupId` boundary types. `apps/xmtp_debug/src/app/generate/messages.rs` calls `client.group(&group.id.into())` on lines 214 and 303. `Group.id` is `[u8; 16]`, so `.into()` here resolves to `Into<[u8]>`, which has no impl:

```
error[E0277]: the trait bound `[u8]: From<[u8; 16]>` is not satisfied
```

`Client::group` (in `crates/xmtp_mls/src/client.rs:758`) takes `&[u8]`. `&[u8; 16]` auto-coerces to `&[u8]`, so the fix is just to drop the `.into()`.

## Changes

- `apps/xmtp_debug/src/app/generate/messages.rs:214` — `&group.id.into()` → `&group.id`
- `apps/xmtp_debug/src/app/generate/messages.rs:303` — same

## Test plan

- [x] `just check crate xdbg` succeeds locally (was failing on `main` with the E0277 errors)
- [ ] Verify `Push XDBG Image` workflow completes on this branch
- [ ] Verify `Cache all Nix Outputs` workflow completes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove redundant `.into()` calls when passing group IDs to `client.group()` in xdbg
> In [messages.rs](https://github.com/xmtp/libxmtp/pull/3574/files#diff-d5e22c19c0b27072221b181e135255d8128ad8549e99b914051ef1f323d445f2), `&group.id` is passed directly to `client.group()` instead of `&group.id.into()`, removing an unnecessary type conversion in both the `description-update` and `send-message` methods.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 56fa6bd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->