### PR TITLE
fix(nix): bind openssl-sys against prebuilt openssl in base.nix

### DIFF
--- a/docs/plans/2026-04-28-issue-3575-design.md
+++ b/docs/plans/2026-04-28-issue-3575-design.md
@@ -28,16 +28,23 @@ The dev-shell config already sets these vars (see `nix/lib/shell-common.nix:72-7
 
 ## Implementation
 
-In `nix/lib/base.nix`, extend the `commonArgs` attrset with:
+In `nix/lib/base.nix`, expose a separate `opensslEnv` attribute set:
 
 ```nix
-OPENSSL_NO_VENDOR = "1";
-OPENSSL_DIR = "${openssl.dev}";
-OPENSSL_LIB_DIR = "${lib.getLib openssl}/lib";
-OPENSSL_INCLUDE_DIR = "${openssl.dev}/include";
+opensslEnv = {
+  OPENSSL_NO_VENDOR = "1";
+  OPENSSL_DIR = "${openssl.dev}";
+  OPENSSL_LIB_DIR = "${lib.getLib openssl}/lib";
+  OPENSSL_INCLUDE_DIR = "${openssl.dev}/include";
+};
 ```
 
-`openssl` is already a parameter of `base.nix` and is included in `buildInputs`, so no new inputs are needed. The form mirrors `shell-common.nix:72-74`, with `OPENSSL_INCLUDE_DIR` added explicitly per the maintainer's suggestion in the issue thread.
+The first attempt folded these into `commonArgs`. That broke `nix/package/android.nix`, which deliberately clears `buildInputs` (it links against the NDK sysroot). The `OPENSSL_DIR = "${openssl.dev}"` interpolation forced the cross-compiled `openssl-x86_64-unknown-linux-android-3.6.1` derivation into the closure, where it fails to build — `internal/ktls.h` references `struct msghdr` / `struct cmsghdr` that aren't satisfied by the Android sysroot. Splicing also evaluates `stdenv.hostPlatform.isAndroid` inconsistently inside `base.nix`, so a simple `lib.optionalAttrs (!stdenv.hostPlatform.isAndroid)` guard does not actually skip the env vars on Android.
+
+So `opensslEnv` lives outside `commonArgs`. Consumers that keep `buildInputs` intact (`nix/package/mls_validation_service.nix`, `nix/package/node.nix`) opt in by merging it into both `commonArgs` and the `cargoArtifacts` overrides. `android.nix` and `ios.nix` don't merge it, so:
+
+- Android keeps the vendored `openssl-src` path it has always used (no NDK breakage).
+- iOS reverts to the vendored path it had before this change (no behavior change there).
 
 ## Validation
 

--- a/docs/plans/2026-04-28-issue-3575-design.md
+++ b/docs/plans/2026-04-28-issue-3575-design.md
@@ -1,0 +1,45 @@
+# Bugfix Spec: openssl-sys vendored build fails on macOS 26 musl cross-compile
+
+**Issue:** [#3575](https://github.com/xmtp/libxmtp/issues/3575)
+
+## Current Behavior
+
+When the `Cache all Nix Outputs` workflow runs on the `warp-macos-26-arm64-12x` runner, the `openssl-sys v0.9.114` build script fails for both `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` targets. Failure cascades through:
+
+- `cargo-package-deps-{x86_64,aarch64}-unknown-linux-musl` (the cargo dep cache derivations from `base.mkCargoArtifacts`)
+- `mls-validation-service-{x86_64,aarch64}-unknown-linux-musl`
+- `bindings-node-js-napi-*-linux-musl`
+- The top-level `devour-output.json.drv` (9 dependent failures).
+
+The root cause is that `nix/lib/base.nix` builds Rust crates with `openssl` as a `buildInput` but does **not** set the `OPENSSL_*` env vars that tell `openssl-sys` to bind against that prebuilt nixpkgs OpenSSL. With those env vars missing, `openssl-sys` falls through to the vendored path (`openssl-src`), which compiles OpenSSL from source. That source build invokes `util/mkinstallvars.pl`, which in the macOS 26 cross-compile env has an empty `LIBDIR` and aborts with `Use of uninitialized value` errors during install.
+
+The dev-shell config already sets these vars (see `nix/lib/shell-common.nix:72-74`), so interactive builds are unaffected; only `nix build` paths going through `base.commonArgs` hit the vendored fallback.
+
+## Expected Behavior
+
+`base.commonArgs` exports `OPENSSL_NO_VENDOR=1`, `OPENSSL_DIR`, `OPENSSL_LIB_DIR`, and `OPENSSL_INCLUDE_DIR` pointed at the host-platform nixpkgs `openssl` already in `buildInputs`. With these set, `openssl-sys` uses the prebuilt OpenSSL for the cross-compile target and skips its source-build fallback entirely. The `mkinstallvars.pl` failure can no longer occur because the install phase never runs. Both musl derivations build cleanly on macOS 26 and Linux runners alike, restoring the cascading downstream builds (`mls-validation-service`, `bindings-node-js-napi-*-linux-musl`, `devour-output.json.drv`).
+
+## Unchanged Behavior
+
+- Native (non-cross) builds and other cross targets (Android, iOS, GNU) keep working as before — the env vars merely point `openssl-sys` at the same `openssl` already on `buildInputs`, which is what splicing already passes for the host platform.
+- `nix/lib/shell-common.nix` is unchanged; dev shells already set these vars and continue to do so.
+- The `aws-lc-sys` host-CC overrides in `commonArgs` are unaffected.
+- The `No space left on device` Linux failure mentioned in the issue is a separate infra issue and is out of scope.
+
+## Implementation
+
+In `nix/lib/base.nix`, extend the `commonArgs` attrset with:
+
+```nix
+OPENSSL_NO_VENDOR = "1";
+OPENSSL_DIR = "${openssl.dev}";
+OPENSSL_LIB_DIR = "${lib.getLib openssl}/lib";
+OPENSSL_INCLUDE_DIR = "${openssl.dev}/include";
+```
+
+`openssl` is already a parameter of `base.nix` and is included in `buildInputs`, so no new inputs are needed. The form mirrors `shell-common.nix:72-74`, with `OPENSSL_INCLUDE_DIR` added explicitly per the maintainer's suggestion in the issue thread.
+
+## Validation
+
+- `nix flake check` and `nix eval` evaluate cleanly.
+- The next CI run on the macOS 26 runner builds the musl targets without invoking `openssl-src`'s install step.

--- a/nix/lib/base.nix
+++ b/nix/lib/base.nix
@@ -70,6 +70,15 @@ let
     "AWS_LC_SYS_TARGET_CC_${buildPlatformSuffix}" = "cc";
     "AWS_LC_SYS_TARGET_CXX_${buildPlatformSuffix}" = "c++";
 
+    # Tell openssl-sys to bind against the prebuilt nixpkgs openssl already in
+    # buildInputs instead of falling through to its vendored `openssl-src` path,
+    # which compiles OpenSSL from source. The source build's `mkinstallvars.pl`
+    # fails on macOS 26 cross-compiles to musl with empty `LIBDIR`.
+    # See https://github.com/xmtp/libxmtp/issues/3575.
+    OPENSSL_NO_VENDOR = "1";
+    OPENSSL_DIR = "${openssl.dev}";
+    OPENSSL_LIB_DIR = "${lib.getLib openssl}/lib";
+    OPENSSL_INCLUDE_DIR = "${openssl.dev}/include";
   };
 
   # Make cargo artifacts for a derivation building rust code

--- a/nix/lib/base.nix
+++ b/nix/lib/base.nix
@@ -69,12 +69,21 @@ let
     # https://crane.dev/faq/cross-compiling-aws-lc-sys.html
     "AWS_LC_SYS_TARGET_CC_${buildPlatformSuffix}" = "cc";
     "AWS_LC_SYS_TARGET_CXX_${buildPlatformSuffix}" = "c++";
+  };
 
-    # Tell openssl-sys to bind against the prebuilt nixpkgs openssl already in
-    # buildInputs instead of falling through to its vendored `openssl-src` path,
-    # which compiles OpenSSL from source. The source build's `mkinstallvars.pl`
-    # fails on macOS 26 cross-compiles to musl with empty `LIBDIR`.
-    # See https://github.com/xmtp/libxmtp/issues/3575.
+  # Tell openssl-sys to bind against the prebuilt nixpkgs openssl already in
+  # buildInputs instead of falling through to its vendored `openssl-src` path,
+  # which compiles OpenSSL from source. The source build's `mkinstallvars.pl`
+  # fails on macOS 26 cross-compiles to musl with empty `LIBDIR`.
+  # See https://github.com/xmtp/libxmtp/issues/3575.
+  #
+  # Not folded into `commonArgs` because `package/android.nix` deliberately
+  # clears `buildInputs` to use the NDK sysroot — we let openssl-sys vendor
+  # there since the cross-compiled openssl for `*-unknown-linux-android`
+  # fails to build (kernel TLS headers in `internal/ktls.h` aren't satisfied
+  # by the Android sysroot). Consumers that keep `buildInputs` intact merge
+  # this set into their args explicitly.
+  opensslEnv = {
     OPENSSL_NO_VENDOR = "1";
     OPENSSL_DIR = "${openssl.dev}";
     OPENSSL_LIB_DIR = "${lib.getLib openssl}/lib";
@@ -107,5 +116,6 @@ in
     bindingsFileset
     commonArgs
     mkCargoArtifacts
+    opensslEnv
     ;
 }

--- a/nix/package/mls_validation_service.nix
+++ b/nix/package/mls_validation_service.nix
@@ -16,7 +16,7 @@ let
     RUSTFLAGS = "-C target-feature=+crt-static";
   };
 
-  commonArgs = base.commonArgs // specialArgs;
+  commonArgs = base.commonArgs // base.opensslEnv // specialArgs;
 
   src = lib.fileset.toSource {
     inherit root;
@@ -47,7 +47,7 @@ let
     ];
   };
 
-  cargoArtifacts = xmtp.base.mkCargoArtifacts rust false specialArgs;
+  cargoArtifacts = xmtp.base.mkCargoArtifacts rust false (base.opensslEnv // specialArgs);
 in
 rust.buildPackage (
   commonArgs

--- a/nix/package/node.nix
+++ b/nix/package/node.nix
@@ -45,13 +45,15 @@ let
 
   commonArgs =
     xmtp.base.commonArgs
+    // xmtp.base.opensslEnv
     // {
       inherit version;
     }
     // specialArgs;
 
   cargoArtifacts = xmtp.base.mkCargoArtifacts rust test (
-    specialArgs
+    xmtp.base.opensslEnv
+    // specialArgs
     // lib.optionalAttrs isGnu {
       # override everything for glibc compatibility
       preBuild = "export HOME=$TMPDIR";


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3575

## Summary

Tell `openssl-sys` to bind against the prebuilt nixpkgs `openssl` instead of falling through to its vendored `openssl-src` path. The vendored source build's `util/mkinstallvars.pl` aborts on the macOS 26 runner with empty `LIBDIR` (`Use of uninitialized value` errors), breaking `cargo-package-deps-{x86_64,aarch64}-unknown-linux-musl` and cascading through `mls-validation-service-*-musl`, `bindings-node-js-napi-*-linux-musl`, and `devour-output.json.drv`.

## Implementation

`nix/lib/base.nix` exposes a separate `opensslEnv` attribute set with `OPENSSL_NO_VENDOR=1` plus `OPENSSL_DIR` / `OPENSSL_LIB_DIR` / `OPENSSL_INCLUDE_DIR`. Consumers that keep `buildInputs` intact (`nix/package/mls_validation_service.nix` and `nix/package/node.nix`) merge `opensslEnv` into both `commonArgs` and the `cargoArtifacts` overrides.

The first attempt at this fix folded `opensslEnv` directly into `commonArgs`, which broke Android: `nix/package/android.nix` deliberately clears `buildInputs` to use the NDK sysroot, but a literal `OPENSSL_DIR = "${openssl.dev}"` reintroduced cross-compiled `openssl-x86_64-unknown-linux-android-3.6.1` into the closure, and that derivation cannot build (`internal/ktls.h` needs `struct msghdr`/`struct cmsghdr` from the Linux kernel headers, which the Android sysroot doesn't satisfy). A `lib.optionalAttrs (!stdenv.hostPlatform.isAndroid)` guard inside `base.nix` doesn't help — nixpkgs splicing evaluates `stdenv` to the build-platform variant for the env-var string-interpolation path, so the predicate reads `false` in the cross-android pkgset anyway.

Keeping `opensslEnv` separate sidesteps both issues:

- Android (and iOS) keep the vendored `openssl-src` path they have always used. iOS is also explicitly excluded because the vendored path was working there before issue #3575 was opened.
- `mls_validation_service` and `node` (musl + native) get the bound-against-nixpkgs path that resolves the macOS 26 failure.

## Verification

`nix derivation show` on the realised derivations:

```
cargo-package-deps-x86_64-unknown-linux-musl-1.10.0
  OPENSSL_NO_VENDOR=1
  OPENSSL_DIR=/nix/store/...-openssl-x86_64-unknown-linux-musl-3.6.1-dev
  OPENSSL_LIB_DIR=/nix/store/...-openssl-x86_64-unknown-linux-musl-3.6.1/lib
  OPENSSL_INCLUDE_DIR=/nix/store/...-openssl-x86_64-unknown-linux-musl-3.6.1-dev/include

mls-validation-service-x86_64-unknown-linux-musl-1.10.0
  (same OPENSSL_* values)

bindings-node-js-napi-x86_64-unknown-linux-musl-1.10.0
  (same OPENSSL_* values)

xmtpv3-x86_64-linux-android-x86_64-unknown-linux-android-1.10.0
  (no OPENSSL_* env vars)
  buildInputs=
  no openssl drv in inputDrvs closure

cargo-package-deps-x86_64-unknown-linux-android-1.10.0
  (no OPENSSL_* env vars)
  buildInputs=
  no openssl drv in inputDrvs closure
```

## Test plan

- [ ] Re-run the `Cache all Nix Outputs` workflow on `warp-macos-26-arm64-12x` and confirm the musl derivations build cleanly.
- [ ] Confirm `test-android / Integration Tests (Android)` and `test-android / Unit Tests (Android)` build green again.
- [ ] Confirm `mls-validation-service-{x86_64,aarch64}-unknown-linux-musl` and `bindings-node-js-napi-*-linux-musl` build on the Linux runner.