### PR TITLE
refactor(bindings): adopt GroupId for DecodedMessageMetadata (Task 9)

### DIFF
--- a/bindings/mobile/src/message.rs
+++ b/bindings/mobile/src/message.rs
@@ -1021,7 +1021,7 @@ impl From<DecodedMessageMetadata> for FfiDecodedMessageMetadata {
                 GroupMessageKind::MembershipChange => FfiGroupMessageKind::MembershipChange,
             },
             sender_installation_id: metadata.sender_installation_id,
-            conversation_id: metadata.group_id,
+            conversation_id: metadata.group_id.to_vec(),
             sender_inbox_id: metadata.sender_inbox_id,
             content_type: metadata.content_type.into(),
             inserted_at_ns: metadata.inserted_at_ns,

--- a/crates/xmtp_mls/src/messages/decoded_message.rs
+++ b/crates/xmtp_mls/src/messages/decoded_message.rs
@@ -23,6 +23,7 @@ use xmtp_content_types::{
 };
 use xmtp_db::group_message::StoredGroupMessage;
 use xmtp_db::group_message::{DeliveryStatus, GroupMessageKind};
+use xmtp_proto::types::GroupId;
 use xmtp_proto::xmtp::mls::message_contents::{
     ContentTypeId, EncodedContent, GroupUpdated,
     content_types::{LeaveRequest, MultiRemoteAttachment, ReactionV2},
@@ -85,7 +86,7 @@ pub struct DecodedMessageMetadata {
     // The message ID
     pub id: Vec<u8>,
     // The group ID
-    pub group_id: Vec<u8>,
+    pub group_id: GroupId,
     // The timestamp of the message in nanoseconds
     pub sent_at_ns: i64,
     // The kind of message
@@ -229,7 +230,7 @@ impl TryFrom<StoredGroupMessage> for DecodedMessage {
         // Create the metadata
         let metadata = DecodedMessageMetadata {
             id: value.id,
-            group_id: value.group_id.to_vec(),
+            group_id: value.group_id,
             sent_at_ns: value.sent_at_ns,
             kind: value.kind,
             sender_installation_id: value.sender_installation_id,


### PR DESCRIPTION
## Summary

Final task from [#3550](https://github.com/xmtp/libxmtp/issues/3550) — bindings audit and FFI boundary cleanup.

The bindings (`bindings/mobile`, `bindings/node`, `bindings/wasm`) already keep their public `group_id` surfaces as `Vec<u8>` and convert to `GroupId` internally — that pattern landed alongside the cascade work in PRs #3555, #3571, and #3577.

The one remaining internal type in `xmtp_mls` still holding `Vec<u8>` for a group identifier was `DecodedMessageMetadata` — flipped here. The mobile FFI binding's `FfiDecodedMessageMetadata.conversation_id` keeps `Vec<u8>` at its surface and converts via `.to_vec()` at the boundary, per the spec's "FFI surface stays Vec<u8>" rule.

This closes out the GroupId migration tracked in #3550.

## Test plan

- [ ] `just check` — workspace compiles green
- [ ] `just lint-rust` — clippy + fmt + hakari clean
- [ ] `just wasm check` — wasm build green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Change `DecodedMessageMetadata.group_id` field type from `Vec<u8>` to `GroupId`
> Updates [`DecodedMessageMetadata`](https://github.com/xmtp/libxmtp/pull/3579/files#diff-83d799c351a96dac6563d0d38276d0ebed07989e83b2bbad93633fcc2037ed52) to use the `GroupId` type from `xmtp_proto` instead of a raw `Vec<u8>`. The `TryFrom<StoredGroupMessage>` conversion assigns `group_id` directly, and the FFI binding calls `.to_vec()` when mapping to `FfiDecodedMessageMetadata`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7ab0922.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->