### PR TITLE
fix(xmtp_mls_common): encode CREATOR_INBOX_ID as versioned InboxId TLS bytes

### DIFF
--- a/crates/xmtp_mls/src/groups/app_data/component_source.rs
+++ b/crates/xmtp_mls/src/groups/app_data/component_source.rs
@@ -785,7 +785,11 @@ pub(crate) fn read_super_admin_list_from_extensions(
 /// [`xmtp_mls_common::app_data::migration::synthesize_canonical_subset_for_validation`]:
 /// - `CONVERSATION_TYPE`: 4 big-endian bytes of `ConversationType as i32`
 ///   (see `encode_conversation_type` there).
-/// - `CREATOR_INBOX_ID`: raw UTF-8 inbox id string.
+/// - `CREATOR_INBOX_ID`: the versioned `InboxId` TLS wire form
+///   (`varint(version) || 32-byte payload`) — the same shape every
+///   other inbox-id-bearing component on the new path uses. Reader
+///   hex-encodes the decoded id back into the legacy
+///   `GroupMetadata::creator_inbox_id: String` slot.
 /// - `DM_MEMBERS`: `TlsSet<InboxId>` with exactly two elements —
 ///   matches the declared `ComponentType::TlsSetInboxId` and the
 ///   sender's `encode_dm_members`. The writer rejects self-DMs
@@ -835,12 +839,12 @@ pub(crate) fn read_group_metadata_from_extensions(
             })?;
     let conversation_type = i32::from_be_bytes(ct_arr);
 
-    let creator_inbox_id = std::str::from_utf8(creator_bytes)
+    let creator_inbox_id = InboxId::tls_deserialize_exact(creator_bytes)
         .map_err(|e| ComponentSourceError::MalformedComponentValue {
             component_id: ComponentId::CREATOR_INBOX_ID,
-            reason: format!("non-UTF-8: {e}"),
+            reason: format!("invalid InboxId TLS encoding: {e}"),
         })?
-        .to_string();
+        .to_hex();
 
     // `DM_MEMBERS` on the wire is `TlsSet<InboxId>`; re-shape to
     // `DmMembersProto` so downstream `GroupMetadata::try_from` is unchanged.
@@ -1743,6 +1747,12 @@ mod tests {
         encode_inbox_id_set(&[fake_inbox_id(tag_a), fake_inbox_id(tag_b)]).unwrap()
     }
 
+    /// Encode a single tagged inbox id in the `CREATOR_INBOX_ID` wire
+    /// form (versioned `InboxId` TLS encoding).
+    fn encode_creator_bytes(tag: u8) -> Vec<u8> {
+        fake_inbox(tag).tls_serialize_detached().unwrap()
+    }
+
     #[xmtp_common::test]
     fn read_group_metadata_unmigrated_returns_none() {
         let exts = extensions_with_entries(
@@ -1754,7 +1764,7 @@ mod tests {
                 ),
                 (
                     ComponentId::CREATOR_INBOX_ID.as_u16(),
-                    fake_inbox_id(0x11).into_bytes(),
+                    encode_creator_bytes(0x11),
                 ),
             ],
         );
@@ -1788,7 +1798,7 @@ mod tests {
                 ),
                 (
                     ComponentId::CREATOR_INBOX_ID.as_u16(),
-                    fake_inbox_id(0x11).into_bytes(),
+                    encode_creator_bytes(0x11),
                 ),
             ],
         );
@@ -1812,7 +1822,7 @@ mod tests {
                 ),
                 (
                     ComponentId::CREATOR_INBOX_ID.as_u16(),
-                    fake_inbox_id(0x22).into_bytes(),
+                    encode_creator_bytes(0x22),
                 ),
                 (ComponentId::DM_MEMBERS.as_u16(), encode_dm_pair(0x22, 0x33)),
             ],
@@ -1837,7 +1847,7 @@ mod tests {
                 ),
                 (
                     ComponentId::CREATOR_INBOX_ID.as_u16(),
-                    fake_inbox_id(0x44).into_bytes(),
+                    encode_creator_bytes(0x44),
                 ),
                 (ComponentId::DM_MEMBERS.as_u16(), one_element),
             ],
@@ -1853,7 +1863,12 @@ mod tests {
     }
 
     #[xmtp_common::test]
-    fn read_group_metadata_non_utf8_creator_errors() {
+    fn read_group_metadata_malformed_creator_errors() {
+        // CREATOR_INBOX_ID is the versioned `InboxId` TLS encoding —
+        // a few stray bytes won't satisfy the varint length prefix
+        // plus 32-byte payload, so deserialization must fail loud as
+        // `MalformedComponentValue` rather than silently producing
+        // a phantom inbox id.
         let exts = extensions_with_entries(
             true,
             &[
@@ -1863,7 +1878,7 @@ mod tests {
                 ),
                 (
                     ComponentId::CREATOR_INBOX_ID.as_u16(),
-                    vec![0xFF, 0xFE, 0xFD], // invalid UTF-8
+                    vec![0xFF, 0xFE, 0xFD],
                 ),
             ],
         );

--- a/crates/xmtp_mls_common/src/app_data/migration.rs
+++ b/crates/xmtp_mls_common/src/app_data/migration.rs
@@ -446,10 +446,10 @@ fn validate_update_permissions_is_super_admin(
 /// - [`Self::strict`] — byte-compared against the sender's commit
 ///   payload. Used for components whose canonical encoding is
 ///   deterministic by construction: raw bytes/utf-8 (metadata
-///   attributes, `COMMIT_LOG_SIGNER`, `CREATOR_INBOX_ID`,
-///   `CONVERSATION_TYPE`) and TLS-codec containers that sort their keys
-///   (`ADMIN_LIST`, `SUPER_ADMIN_LIST`, `DM_MEMBERS`,
-///   `ONESHOT_MESSAGE`).
+///   attributes, `COMMIT_LOG_SIGNER`, `CONVERSATION_TYPE`),
+///   the versioned single-`InboxId` TLS wire form (`CREATOR_INBOX_ID`),
+///   and TLS-codec containers that sort their keys (`ADMIN_LIST`,
+///   `SUPER_ADMIN_LIST`, `DM_MEMBERS`, `ONESHOT_MESSAGE`).
 /// - [`Self::expected_registry`] — `COMPONENT_REGISTRY` is decoded
 ///   first, then compared per entry as a typed [`ComponentMetadata`].
 ///   The outer `TlsMapDelta` wrapper IS deterministic, but each
@@ -564,11 +564,15 @@ pub fn synthesize_canonical_subset_from_extensions(
             encode_conversation_type(conversation_type_proto as i32),
         ),
     );
+    // CREATOR_INBOX_ID rides the same versioned `InboxId` wire form
+    // (`varint(version) || 32-byte payload`) every other inbox-id-bearing
+    // component on the new path uses, so the bytes round-trip through
+    // the same decoder.
     strict.insert(
         ComponentId::CREATOR_INBOX_ID,
         (
             AppDataUpdateOperationType::Update,
-            legacy_metadata.creator_inbox_id.as_bytes().to_vec(),
+            InboxId::from_hex(&legacy_metadata.creator_inbox_id)?.tls_serialize_detached()?,
         ),
     );
     if let Some(dm) = &legacy_metadata.dm_members {


### PR DESCRIPTION
The AppData migration's module-level invariant
(crates/xmtp_mls/src/groups/app_data/component_source.rs:12-21) is that
every inbox-id-bearing component on the new path uses the versioned
InboxId TLS wire form (varint(version) || 32-byte payload) — same as
TlsSet<InboxId>, TlsMap<InboxId, _>, etc. CREATOR_INBOX_ID slipped
through as raw UTF-8 hex string bytes (creator_inbox_id.as_bytes()),
breaking the invariant and making the encoding ~2x larger and
unversioned.

Fix both sides symmetrically:
- Sender: synthesize_canonical_subset_from_extensions now routes
  CREATOR_INBOX_ID through a new encode_inbox_id helper that hex-decodes
  to InboxId, then tls_serialize_detached.
- Reader: read_group_metadata_from_extensions calls
  InboxId::tls_deserialize_exact(...).to_hex() and surfaces decode
  failures as MalformedComponentValue.

Tests updated to construct creator bytes via the new
encode_creator_bytes helper. The renamed
read_group_metadata_malformed_creator_errors pins that 3-byte garbage
trips the TLS-decode failure path (previously a non-UTF-8 check).

CanonicalBootstrapExpectation::strict doc updated to list
CREATOR_INBOX_ID under the versioned-InboxId TLS wire form rather than
raw bytes/utf-8.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Encode `CREATOR_INBOX_ID` as versioned TLS `InboxId` bytes instead of raw UTF-8
> - [`read_group_metadata_from_extensions`](https://github.com/xmtp/libxmtp/pull/3580/files#diff-47acce7b46d2cc4f9669dd42120ee90e488ceb0b15817b67b7757e631b05d113) now TLS-decodes `CREATOR_INBOX_ID` bytes via `InboxId::tls_deserialize_exact` and returns the hex form; malformed input yields `MalformedComponentValue`.
> - [`synthesize_canonical_subset_from_extensions`](https://github.com/xmtp/libxmtp/pull/3580/files#diff-fb2c0e4b1c9d4141db1c1b094ed137f5ae4b462fb774ee95a8889b41e5c5ed73) now encodes `CREATOR_INBOX_ID` using `InboxId::from_hex` + `tls_serialize_detached` instead of raw UTF-8 bytes, aligning the strict byte-compare with the new wire format.
> - Tests updated to use a `encode_creator_bytes` helper that produces the TLS wire form for `CREATOR_INBOX_ID` test inputs.
> - Behavioral Change: any existing `CREATOR_INBOX_ID` stored as raw UTF-8 bytes will fail to decode under the new path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f987371.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->