### PR TITLE
fix(xdbg): convert GroupId to Vec<u8> in create_group_on_network

### DIFF
--- a/apps/xmtp_debug/src/app/generate/groups.rs
+++ b/apps/xmtp_debug/src/app/generate/groups.rs
@@ -211,7 +211,7 @@ async fn create_group_on_network(
     );
     push_metrics("xdbg_debug").await;
 
-    let group_id = group.group_id.clone();
+    let group_id = group.group_id.clone().to_vec();
     drop(client_guard);
 
     Ok((group_id, create_secs))


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3578

## Summary
The `GroupId` refactor in #3577 changed `MlsGroup.group_id` from `Vec<u8>` to `xmtp_proto::types::GroupId`, but the `xdbg` debug app at `apps/xmtp_debug/src/app/generate/groups.rs:214` was not updated. The function `create_group_on_network` returns `Result<(Vec<u8>, f64)>`, so assigning a `GroupId` directly produces:

```
error[E0308]: mismatched types
   --> apps/xmtp_debug/src/app/generate/groups.rs:217:9
    |
217 |     Ok((group_id, create_secs))
    |         ^^^^^^^^ expected `Vec<u8>`, found `GroupId`
```

This has broken the **Push XDBG Image** workflow and the **Cache all Nix Outputs** workflow on every push to `main` since commit `e87c081` (six consecutive commits as of issue report).

## Fix
Convert at the call site by appending `.to_vec()`:

```rust
let group_id = group.group_id.clone().to_vec();
```

This is the minimal change — the surrounding code (`check_member_visibility(&group_id, …)` taking `&Vec<u8>`, and `group_id.try_into()` for `[u8; 32]`) continues to work unchanged.

## Test plan
- [x] `nix develop --command cargo build --package xdbg` — builds cleanly (`Finished dev profile in 3m 47s`)
- [ ] CI: `Push XDBG Image` workflow passes on this branch
- [ ] CI: `Cache all Nix Outputs` workflow passes on this branch

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Convert `group_id` to `Vec<u8>` in `create_group_on_network`
> Adds `.to_vec()` to the cloned `group_id` before returning in [groups.rs](https://github.com/xmtp/libxmtp/pull/3581/files#diff-2a926685e9318ce1dc82bb85f365db546e52a68aca168cf9ac4fe69aa9b702d1), ensuring the return type is an explicit `Vec<u8>` rather than whatever type `.clone()` previously produced.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c238aef.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->