### PR TITLE
ci: add per-PR cargo check for xdbg

### DIFF
--- a/.github/workflows/test-xdbg.yml
+++ b/.github/workflows/test-xdbg.yml
@@ -15,4 +15,4 @@ jobs:
           sccache: "false"
           with-warpbuild-cache: "false"
       - name: Check xdbg compiles
-        run: nix-fast-build --no-nom --flake .#xdbg-check.x86_64-linux
+        run: nix-fast-build --no-nom --flake .#cargo-clippy.x86_64-linux.xdbg

--- a/.github/workflows/test-xdbg.yml
+++ b/.github/workflows/test-xdbg.yml
@@ -15,4 +15,4 @@ jobs:
           sccache: "false"
           with-warpbuild-cache: "false"
       - name: Check xdbg compiles
-        run: nix-fast-build --no-nom --flake .#packages.x86_64-linux.xdbg-check --option sandbox relaxed
+        run: nix-fast-build --no-nom --flake .#packages.x86_64-linux.xdbg-check

--- a/.github/workflows/test-xdbg.yml
+++ b/.github/workflows/test-xdbg.yml
@@ -1,8 +1,6 @@
 name: Test XDBG
 on:
   workflow_call:
-env:
-  NIX_DEVSHELL: rust
 jobs:
   check:
     name: Check (xdbg)
@@ -14,7 +12,7 @@ jobs:
         with:
           github-token: ${{ github.token }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          sccache: "true"
+          sccache: "false"
           with-warpbuild-cache: "false"
       - name: Check xdbg compiles
-        run: nix develop .#rust --command cargo check --locked -p xdbg
+        run: nix build .#xdbg-check --print-build-logs

--- a/.github/workflows/test-xdbg.yml
+++ b/.github/workflows/test-xdbg.yml
@@ -15,4 +15,4 @@ jobs:
           sccache: "false"
           with-warpbuild-cache: "false"
       - name: Check xdbg compiles
-        run: nix-fast-build --no-nom --flake .#packages.x86_64-linux.xdbg-check
+        run: nix-fast-build --no-nom --flake .#xdbg-check.x86_64-linux

--- a/.github/workflows/test-xdbg.yml
+++ b/.github/workflows/test-xdbg.yml
@@ -1,0 +1,20 @@
+name: Test XDBG
+on:
+  workflow_call:
+env:
+  NIX_DEVSHELL: rust
+jobs:
+  check:
+    name: Check (xdbg)
+    runs-on: warp-ubuntu-latest-x64-16x
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-nix
+        with:
+          github-token: ${{ github.token }}
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          sccache: "true"
+          with-warpbuild-cache: "false"
+      - name: Check xdbg compiles
+        run: nix develop .#rust --command cargo check --locked -p xdbg

--- a/.github/workflows/test-xdbg.yml
+++ b/.github/workflows/test-xdbg.yml
@@ -15,4 +15,4 @@ jobs:
           sccache: "false"
           with-warpbuild-cache: "false"
       - name: Check xdbg compiles
-        run: nix build .#xdbg-check --print-build-logs
+        run: nix-fast-build --no-nom --flake .#packages.x86_64-linux.xdbg-check --option sandbox relaxed

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
       android: ${{ steps.filter.outputs.android }}
       bindings-check: ${{ steps.filter.outputs.bindings-check }}
       devcontainer: ${{ steps.filter.outputs.devcontainer }}
+      xdbg: ${{ steps.filter.outputs.xdbg }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4
@@ -93,11 +94,28 @@ jobs:
             devcontainer:
               - '.devcontainer/**'
               - '.github/workflows/test-devcontainer*'
+            xdbg:
+              - 'apps/xmtp_debug/**'
+              - 'crates/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - '.cargo/**'
+              - 'rust-toolchain.toml'
+              - 'nix/**'
+              - 'flake.lock'
+              - '.github/workflows/test.yml'
+              - '.github/workflows/test-xdbg.yml'
 
   test-workspace:
     needs: detect-changes
     if: needs.detect-changes.outputs.workspace == 'true'
     uses: ./.github/workflows/test-workspace.yml
+    secrets: inherit
+
+  test-xdbg:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.xdbg == 'true'
+    uses: ./.github/workflows/test-xdbg.yml
     secrets: inherit
 
   test-node:
@@ -156,6 +174,7 @@ jobs:
     if: always()
     needs:
       - test-workspace
+      - test-xdbg
       - test-node
       - test-wasm
       # - test-ios TODO:(nm) Temporarily making optional until we are confident the new workflows are fast/reliable enough to block CI

--- a/apps/xmtp_debug/src/app/generate/groups.rs
+++ b/apps/xmtp_debug/src/app/generate/groups.rs
@@ -218,11 +218,7 @@ async fn create_group_on_network(
 }
 
 /// Check whether an invitee can see the group via sync_welcomes (read-your-own-writes).
-async fn check_member_visibility(
-    group_id: &[u8],
-    invitee: &Identity,
-    network: &args::BackendOpts,
-) {
+async fn check_member_visibility(group_id: &[u8], invitee: &Identity, network: &args::BackendOpts) {
     let reader_client = match app::client_from_identity(invitee, network) {
         Ok(c) => c,
         Err(_) => return,

--- a/apps/xmtp_debug/src/app/generate/groups.rs
+++ b/apps/xmtp_debug/src/app/generate/groups.rs
@@ -219,7 +219,7 @@ async fn create_group_on_network(
 
 /// Check whether an invitee can see the group via sync_welcomes (read-your-own-writes).
 async fn check_member_visibility(
-    group_id: &Vec<u8>,
+    group_id: &[u8],
     invitee: &Identity,
     network: &args::BackendOpts,
 ) {

--- a/apps/xmtp_debug/src/app/generate/messages.rs
+++ b/apps/xmtp_debug/src/app/generate/messages.rs
@@ -170,7 +170,7 @@ impl GenerateMessages {
             .get(&group.created_by)
             .ok_or(eyre!("group has no owner"))?;
         let owner = owner.lock().await;
-        let owner_group = owner.group(&group.id.to_vec()).wrap_err(format!(
+        let owner_group = owner.group(group.id.as_ref()).wrap_err(format!(
             "owner {} of group {} failed to look up in sqlite db",
             hex::encode(group.created_by),
             hex::encode(group.id)

--- a/apps/xmtp_debug/src/app/modify.rs
+++ b/apps/xmtp_debug/src/app/modify.rs
@@ -45,7 +45,7 @@ impl Modify {
             hex::encode(local_group.created_by)
         ))?;
         let admin = app::client_from_identity(&identity, &network)?;
-        let group = admin.group(&local_group.id.to_vec())?;
+        let group = admin.group(local_group.id.as_ref())?;
         match action {
             Remove => {
                 if inbox_id.is_none() {

--- a/apps/xmtp_debug/src/app/send.rs
+++ b/apps/xmtp_debug/src/app/send.rs
@@ -49,7 +49,7 @@ impl Send {
 
         let client = crate::app::client_from_identity(&identity, network)?;
         client.sync_welcomes().await?;
-        let xmtp_group = client.group(&group.id.to_vec())?;
+        let xmtp_group = client.group(group.id.as_ref())?;
         xmtp_group
             .send_message(
                 data.as_bytes(),

--- a/flake.nix
+++ b/flake.nix
@@ -79,7 +79,6 @@
             inherit (pkgs) napi-rs-cli wasm-bindgen-cli;
             wasm-bindings = (pkgs.callPackage ./nix/package/wasm.nix { }).bin;
             wasm-bindings-test = (pkgs.callPackage ./nix/package/wasm.nix { test = true; }).bin;
-            xdbg-check = pkgs.callPackage ./nix/package/xdbg-check.nix { };
           }
           // lib.optionalAttrs pkgs.stdenv.isDarwin {
             # stdenvNoCC is passed to callPackage (for the aggregate derivation).

--- a/flake.nix
+++ b/flake.nix
@@ -79,6 +79,7 @@
             inherit (pkgs) napi-rs-cli wasm-bindgen-cli;
             wasm-bindings = (pkgs.callPackage ./nix/package/wasm.nix { }).bin;
             wasm-bindings-test = (pkgs.callPackage ./nix/package/wasm.nix { test = true; }).bin;
+            xdbg-check = pkgs.callPackage ./nix/package/xdbg-check.nix { };
           }
           // lib.optionalAttrs pkgs.stdenv.isDarwin {
             # stdenvNoCC is passed to callPackage (for the aggregate derivation).

--- a/nix/ci-checks.nix
+++ b/nix/ci-checks.nix
@@ -1,28 +1,35 @@
-# Nextest derivations for CI test runs.
-# Exposed under a custom `nextest` top-level output so that `om ci run`
-# (via devour-flake) won't try to build them — nextest requires Docker
-# services which aren't available in sandboxed builds.
-# The test-workspace.yml workflow starts Docker first, then builds these
-# directly via `nix build .#nextest.<system>.v3`.
+# CI-only derivations for things `om ci run` (via devour-flake) should
+# not pick up automatically:
+#
+#   - nextest: requires Docker services that aren't available in sandboxed builds.
+#     test-workspace.yml starts Docker first, then builds them directly via
+#     `nix build .#nextest.<system>.v3`.
+#   - xdbg-check: a clippy gate for the apps/xmtp_debug crate. It builds fine
+#     in the standard sandbox; it lives here so the per-PR test-xdbg.yml
+#     workflow can target it explicitly without enrolling it in `om ci run`.
 { lib, withSystem, ... }:
+let
+  systems = [
+    "aarch64-darwin"
+    "x86_64-linux"
+    "aarch64-linux"
+  ];
+in
 {
-  flake.nextest =
-    lib.genAttrs
-      [
-        "aarch64-darwin"
-        "x86_64-linux"
-        "aarch64-linux"
-      ]
-      (
-        system:
-        withSystem system (
-          { pkgs, ... }:
-          {
-            v3 = pkgs.callPackage ./package/nextest.nix { };
-            d14n = pkgs.callPackage ./package/nextest.nix { d14n = true; };
-            wasm-v3 = pkgs.callPackage ./package/wasm-nextest.nix { };
-            wasm-d14n = pkgs.callPackage ./package/wasm-nextest.nix { d14n = true; };
-          }
-        )
-      );
+  flake.nextest = lib.genAttrs systems (
+    system:
+    withSystem system (
+      { pkgs, ... }:
+      {
+        v3 = pkgs.callPackage ./package/nextest.nix { };
+        d14n = pkgs.callPackage ./package/nextest.nix { d14n = true; };
+        wasm-v3 = pkgs.callPackage ./package/wasm-nextest.nix { };
+        wasm-d14n = pkgs.callPackage ./package/wasm-nextest.nix { d14n = true; };
+      }
+    )
+  );
+
+  flake.xdbg-check = lib.genAttrs systems (
+    system: withSystem system ({ pkgs, ... }: pkgs.callPackage ./package/xdbg-check.nix { })
+  );
 }

--- a/nix/ci-checks.nix
+++ b/nix/ci-checks.nix
@@ -4,9 +4,11 @@
 #   - nextest: requires Docker services that aren't available in sandboxed builds.
 #     test-workspace.yml starts Docker first, then builds them directly via
 #     `nix build .#nextest.<system>.v3`.
-#   - xdbg-check: a clippy gate for the apps/xmtp_debug crate. It builds fine
-#     in the standard sandbox; it lives here so the per-PR test-xdbg.yml
-#     workflow can target it explicitly without enrolling it in `om ci run`.
+#   - cargo-clippy: per-crate clippy gates (currently just `xdbg`) that the
+#     existing workspace-wide lint job skips because their crates aren't in
+#     `default-members`. They build fine in the standard sandbox; they live
+#     here so the per-PR workflows (e.g. test-xdbg.yml) can target them
+#     explicitly without enrolling them in `om ci run`.
 { lib, withSystem, ... }:
 let
   systems = [
@@ -29,7 +31,13 @@ in
     )
   );
 
-  flake.xdbg-check = lib.genAttrs systems (
-    system: withSystem system ({ pkgs, ... }: pkgs.callPackage ./package/xdbg-check.nix { })
+  flake.cargo-clippy = lib.genAttrs systems (
+    system:
+    withSystem system (
+      { pkgs, ... }:
+      {
+        xdbg = pkgs.callPackage ./package/xdbg-check.nix { };
+      }
+    )
   );
 }

--- a/nix/package/xdbg-check.nix
+++ b/nix/package/xdbg-check.nix
@@ -10,29 +10,20 @@
   stdenv,
 }:
 let
-  inherit (lib.fileset) unions fileFilter;
   inherit (xmtp) craneLib base;
-  inherit (craneLib.fileset) commonCargoSources;
   root = ./../..;
 
   rust-toolchain = p: xmtp.mkToolchain p [ stdenv.hostPlatform.rust.rustcTarget ] [ ];
   rust = craneLib.overrideToolchain rust-toolchain;
 
-  # All workspace members' Cargo.toml/build.rs need to be present so
-  # `cargo check --locked` evaluates the workspace without trying to
-  # rewrite Cargo.lock to drop missing members.
-  workspaceManifests = unions [
-    (fileFilter (file: file.name == "Cargo.toml" || file.name == "build.rs") (root + /apps))
-    (fileFilter (file: file.name == "Cargo.toml" || file.name == "build.rs") (root + /bindings))
-  ];
-
+  # `workspace` is `libraries + binaries`, which covers every workspace
+  # member declared in the root Cargo.toml. cargo --locked needs every
+  # workspace member's manifest *and* enough source for cargo to
+  # resolve auto-discovered targets, otherwise it errors with either
+  # "cannot update lock file" or "no targets specified in the manifest".
   src = lib.fileset.toSource {
     inherit root;
-    fileset = unions [
-      xmtp.filesets.libraries
-      workspaceManifests
-      (commonCargoSources (root + /apps/xmtp_debug))
-    ];
+    fileset = xmtp.filesets.workspace;
   };
 
   cargoArtifacts = base.mkCargoArtifacts rust false null;

--- a/nix/package/xdbg-check.nix
+++ b/nix/package/xdbg-check.nix
@@ -16,11 +16,7 @@ let
   rust-toolchain = p: xmtp.mkToolchain p [ stdenv.hostPlatform.rust.rustcTarget ] [ ];
   rust = craneLib.overrideToolchain rust-toolchain;
 
-  # `workspace` is `libraries + binaries`, which covers every workspace
-  # member declared in the root Cargo.toml. cargo --locked needs every
-  # workspace member's manifest *and* enough source for cargo to
-  # resolve auto-discovered targets, otherwise it errors with either
-  # "cannot update lock file" or "no targets specified in the manifest".
+  # `workspace` covers every member so cargo --locked can resolve all manifests and targets.
   src = lib.fileset.toSource {
     inherit root;
     fileset = xmtp.filesets.workspace;

--- a/nix/package/xdbg-check.nix
+++ b/nix/package/xdbg-check.nix
@@ -10,7 +10,7 @@
   stdenv,
 }:
 let
-  inherit (lib.fileset) unions;
+  inherit (lib.fileset) unions fileFilter;
   inherit (xmtp) craneLib base;
   inherit (craneLib.fileset) commonCargoSources;
   root = ./../..;
@@ -18,10 +18,19 @@ let
   rust-toolchain = p: xmtp.mkToolchain p [ stdenv.hostPlatform.rust.rustcTarget ] [ ];
   rust = craneLib.overrideToolchain rust-toolchain;
 
+  # All workspace members' Cargo.toml/build.rs need to be present so
+  # `cargo check --locked` evaluates the workspace without trying to
+  # rewrite Cargo.lock to drop missing members.
+  workspaceManifests = unions [
+    (fileFilter (file: file.name == "Cargo.toml" || file.name == "build.rs") (root + /apps))
+    (fileFilter (file: file.name == "Cargo.toml" || file.name == "build.rs") (root + /bindings))
+  ];
+
   src = lib.fileset.toSource {
     inherit root;
     fileset = unions [
       xmtp.filesets.libraries
+      workspaceManifests
       (commonCargoSources (root + /apps/xmtp_debug))
     ];
   };

--- a/nix/package/xdbg-check.nix
+++ b/nix/package/xdbg-check.nix
@@ -13,7 +13,8 @@ let
   inherit (xmtp) craneLib base;
   root = ./../..;
 
-  rust-toolchain = p: xmtp.mkToolchain p [ stdenv.hostPlatform.rust.rustcTarget ] [ "clippy-preview" ];
+  rust-toolchain =
+    p: xmtp.mkToolchain p [ stdenv.hostPlatform.rust.rustcTarget ] [ "clippy-preview" ];
   rust = craneLib.overrideToolchain rust-toolchain;
 
   # `workspace` covers every member so cargo --locked can resolve all manifests and targets.

--- a/nix/package/xdbg-check.nix
+++ b/nix/package/xdbg-check.nix
@@ -1,0 +1,41 @@
+# Derivation that runs `cargo check -p xdbg`.
+#
+# xdbg is excluded from default-members in the root Cargo.toml, so the
+# default per-PR Rust CI (clippy, nextest) skips it. This derivation is
+# the per-PR gate that catches workspace changes which break xdbg's
+# build before they land on main.
+{
+  xmtp,
+  lib,
+  stdenv,
+}:
+let
+  inherit (lib.fileset) unions;
+  inherit (xmtp) craneLib base;
+  inherit (craneLib.fileset) commonCargoSources;
+  root = ./../..;
+
+  rust-toolchain = p: xmtp.mkToolchain p [ stdenv.hostPlatform.rust.rustcTarget ] [ ];
+  rust = craneLib.overrideToolchain rust-toolchain;
+
+  src = lib.fileset.toSource {
+    inherit root;
+    fileset = unions [
+      xmtp.filesets.libraries
+      (commonCargoSources (root + /apps/xmtp_debug))
+    ];
+  };
+
+  cargoArtifacts = base.mkCargoArtifacts rust false null;
+in
+rust.mkCargoDerivation (
+  base.commonArgs
+  // {
+    inherit src cargoArtifacts;
+    pname = "xdbg-check";
+    version = xmtp.mkVersion rust;
+    buildPhaseCargoCommand = "cargo check --locked --profile $CARGO_PROFILE -p xdbg";
+    doCheck = false;
+    doInstallCargoArtifacts = false;
+  }
+)

--- a/nix/package/xdbg-check.nix
+++ b/nix/package/xdbg-check.nix
@@ -1,4 +1,4 @@
-# Derivation that runs `cargo check -p xdbg`.
+# Derivation that runs `cargo clippy -p xdbg`.
 #
 # xdbg is excluded from default-members in the root Cargo.toml, so the
 # default per-PR Rust CI (clippy, nextest) skips it. This derivation is
@@ -13,7 +13,7 @@ let
   inherit (xmtp) craneLib base;
   root = ./../..;
 
-  rust-toolchain = p: xmtp.mkToolchain p [ stdenv.hostPlatform.rust.rustcTarget ] [ ];
+  rust-toolchain = p: xmtp.mkToolchain p [ stdenv.hostPlatform.rust.rustcTarget ] [ "clippy-preview" ];
   rust = craneLib.overrideToolchain rust-toolchain;
 
   # `workspace` covers every member so cargo --locked can resolve all manifests and targets.
@@ -24,13 +24,14 @@ let
 
   cargoArtifacts = base.mkCargoArtifacts rust false null;
 in
-rust.mkCargoDerivation (
+rust.cargoClippy (
   base.commonArgs
   // {
     inherit src cargoArtifacts;
-    pname = "xdbg-check";
+    pname = "xdbg";
     version = xmtp.mkVersion rust;
-    buildPhaseCargoCommand = "cargo check --locked --profile $CARGO_PROFILE -p xdbg";
+    cargoExtraArgs = "--locked --all-targets -p xdbg";
+    cargoClippyExtraArgs = "--no-deps -- -Dwarnings";
     doCheck = false;
     doInstallCargoArtifacts = false;
   }


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3582

## Summary

- Adds `.github/workflows/test-xdbg.yml`, a reusable workflow that runs `cargo check --locked -p xdbg` in the `rust` nix devshell.
- Wires it into `.github/workflows/test.yml` with a paths-filter (`apps/xmtp_debug/**`, `crates/**`, `Cargo.toml`/`Cargo.lock`, `.cargo/**`, `rust-toolchain.toml`, `nix/**`, `flake.lock`, the workflow files), and adds it to the final `test` aggregator's `needs:` so the existing aggregate `Test` required check fails when `xdbg` doesn't compile.

## Why

`xdbg` (`apps/xmtp_debug`) is excluded from `default-members` in the root `Cargo.toml` (per the comment, "Default members must be part of workspace hack to maximize cache hits in CI/nix/crane"). Existing per-PR Rust CI operates on default-members, so:

- `lint-workspace.yml` (`cargo clippy`) skips `xdbg`.
- `test-workspace.yml` (nextest derivations) skips `xdbg`.
- The only workflow that builds `xdbg` is `push-xdbg.yml`, which runs **only on push to `main`** — so breakage lands on `main` and fails the Docker image build post-merge.

This PR adds a cheap `cargo check` gate on PRs to catch the breakage before merge.

## Design choices (matching existing patterns)

- Reusable `workflow_call` workflow following `lint-workspace.yml` / `test-bindings-check.yml` shape.
- `warp-ubuntu-latest-x64-16x` runner with `setup-nix` (`sccache: true`, `with-warpbuild-cache: false`) — same as `lint-workspace.yml`.
- `nix develop .#rust --command cargo check --locked -p xdbg` — same invocation pattern as `test-bindings-check.yml`.
- Path filter follows the broad pattern used by the existing `workspace`/`node` filters; false positives (running when nothing in `xdbg`'s tree changed) are acceptable since a single-crate `cargo check` is cheap.
- Wires into the existing `Test` aggregator instead of introducing a new required check name.

## Test plan

- [ ] CI on this PR runs `Test / detect-changes` and produces `xdbg=true` (the PR touches `.github/workflows/test.yml`).
- [ ] CI runs `Test / test-xdbg / Check (xdbg)` and either passes or surfaces a real `xdbg` compile failure.
- [ ] If `cargo check -p xdbg` fails, the failure is a *true positive* — the gate is doing its job. The underlying compile fix is **not in scope for this issue** and should be tracked separately.
- [ ] Verify on a future unrelated PR (e.g. iOS-only) that `test-xdbg` is skipped.

## Out of scope

- Running `xdbg` tests on PRs (issue asks for `cargo check`).
- Running `clippy` on `xdbg`.
- Re-adding `xdbg` to `default-members` (excluded for nix-cache reasons).
- Building the Docker image on PRs (intentionally `main`-only).
- Fixing any pre-existing `xdbg` compile errors that this gate may surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-PR cargo clippy CI check for the xdbg crate
> - Adds a new reusable workflow [test-xdbg.yml](.github/workflows/test-xdbg.yml) that runs `nix-fast-build` targeting `cargo-clippy.x86_64-linux.xdbg`, invoked when relevant files change.
> - Wires the new job into [test.yml](.github/workflows/test.yml) via a paths filter on `apps/xmtp_debug/**`, Cargo manifests, and Nix files, and includes it in the aggregate `test` job.
> - Adds [nix/package/xdbg-check.nix](https://github.com/xmtp/libxmtp/pull/3583/files#diff-911cfef1605431c15805084015f63f19e36a9c2604057a48b39f5ffea8ad0456) defining a Nix derivation that runs `cargo clippy --locked --all-targets -p xdbg -- -Dwarnings`.
> - Exposes the new derivation as `flake.cargo-clippy.<system>.xdbg` in [nix/ci-checks.nix](https://github.com/xmtp/libxmtp/pull/3583/files#diff-9012eb276afdf1bd8abc7f1b4caa410e84dd90d7eb70c5ebdefe5300aa0d7df5).
> - Cleans up xdbg source to pass `&[u8]` slices instead of `&Vec<u8>` / `.to_vec()` calls, fixing clippy warnings that would fail the new check.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c49838.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->