### PR TITLE
fix(nix): use system openssl for non-android builds to avoid macOS-26…

### DIFF
--- a/nix/lib/base.nix
+++ b/nix/lib/base.nix
@@ -35,6 +35,25 @@ let
     builtins.replaceStrings [ "-" ] [ "_" ]
       pkgsBuildHost.stdenv.hostPlatform.rust.rustcTarget;
 
+  # macOS 26 vendored openssl-src build aborts in util/mkinstallvars.pl
+  # (empty LIBDIR) when cross-compiling to *-unknown-linux-musl. Point
+  # openssl-sys at nixpkgs openssl to skip vendored build.
+  # See https://github.com/xmtp/libxmtp/issues/3575.
+  #
+  # Skip on android: cross openssl fails on internal/ktls.h (NDK sysroot
+  # missing msghdr/cmsghdr fields). android.nix clears buildInputs;
+  # OPENSSL_DIR here would re-pull cross-android openssl or link
+  # android-arm64 against native x86_64 openssl libs.
+  # ios.nix strips these keys itself since it runs through native pkgs
+  # (CARGO_BUILD_TARGET=*-apple-ios) and the inherited macOS libssl.dylib
+  # would fail to link against an ios-simulator slice.
+  opensslEnv = lib.optionalAttrs (!stdenv.hostPlatform.isAndroid) {
+    OPENSSL_NO_VENDOR = "1";
+    OPENSSL_DIR = "${openssl.dev}";
+    OPENSSL_LIB_DIR = "${openssl.out}/lib";
+    OPENSSL_INCLUDE_DIR = "${openssl.dev}/include";
+  };
+
   # Common build arguments shared between iOS and Android derivations.
   # Platform-specific args (like ANDROID_HOME or __noChroot) are added by each derivation.
   commonArgs = {
@@ -70,7 +89,8 @@ let
     "AWS_LC_SYS_TARGET_CC_${buildPlatformSuffix}" = "cc";
     "AWS_LC_SYS_TARGET_CXX_${buildPlatformSuffix}" = "c++";
 
-  };
+  }
+  // opensslEnv;
 
   # Make cargo artifacts for a derivation building rust code
   # "rust" is the rust toolchain to use (native or host)

--- a/nix/lib/default.nix
+++ b/nix/lib/default.nix
@@ -4,167 +4,180 @@
   lib,
   ...
 }:
+let
+  mkToolchain = import ./mkToolchain.nix { inherit inputs lib; };
+  craneConfig = final: prev: {
+    # add napi builder to crane scope
+    napiBuild = final.callPackage ./napiBuild.nix { };
+    uniffiGenerate = final.callPackage ./uniffiGenerate.nix { };
+  };
+
+  # `xmtp` namespace via `lib.makeScope` — same pattern as
+  # python311Packages, darwin.apple_sdk, haskell.packages. `p.newScope`
+  # (splice.nix) makes `xself.callPackage` auto-resolve cross-spliced inputs.
+  mkXmtpLib =
+    p:
+    p.lib.makeScope p.newScope (xself: {
+      inherit mkToolchain;
+      mkNativeToolchain = mkToolchain p;
+      filesets = xself.callPackage ./filesets.nix { };
+      craneLib = (inputs.crane.mkLib p).overrideScope craneConfig;
+      androidEnv = xself.callPackage ./android-env.nix { };
+      iosEnv = xself.callPackage ./ios-env.nix { };
+      ffi-uniffi-bindgen = xself.callPackage ./packages/uniffi-bindgen.nix { };
+      shellCommon = xself.callPackage ./shell-common.nix { };
+      mkVersion = import ./mkVersion.nix;
+      toNapiTarget = import ./napiTarget.nix;
+    });
+
+  normalize =
+    x:
+    if builtins.isString x then
+      { config = x; }
+    else if builtins.isAttrs x then
+      x
+    else
+      throw "expected a string or attribute set";
+
+  mkCrossPkgs =
+    system: targets:
+    lib.listToAttrs (
+      map (
+        target:
+        let
+          t = normalize target;
+          pkgs = import inputs.nixpkgs (
+            self.lib.pkgConfig
+            // {
+              localSystem = system;
+              crossSystem = t;
+              overlays = self.lib.pkgConfig.overlays ++ [
+                (final: _: { xmtp = mkXmtpLib final; })
+              ];
+            }
+          );
+          # Resolve base.nix against pkg with a cross target so hostPlatform
+          # is correctly resolved.
+          # `extend` injects `xmtp-base` into splice graph.
+          # Plain `pkgs // { xmtp-base = ... }` only handles direct field
+          # access. auto-arg lookup falls through to native-stdenv version.
+          pkgs' = pkgs.extend (_: _: { xmtp-base = pkgs.callPackage ./base.nix { }; });
+        in
+        {
+          name = t.config;
+          value = pkgs';
+        }
+      ) targets
+    );
+in
 {
-  flake.lib =
-    let
-      normalize =
-        x:
-        if builtins.isString x then
-          { config = x; }
-        else if builtins.isAttrs x then
-          x
-        else
-          throw "expected a string or attribute set";
-    in
-    {
-      pkgConfig = {
-        # Rust Overlay
-        overlays = [
-          inputs.fenix.overlays.default
-          inputs.foundry.overlay
-          self.overlays.default
-          # mold is significantly faster on linux for local dev
-          (
-            final: prev:
-            prev.lib.optionalAttrs prev.stdenv.isLinux {
-              mkShell = prev.mkShell.override {
-                stdenv = prev.stdenvAdapters.useMoldLinker prev.clangStdenv;
-              };
-            }
-          )
-          # atf 0.23's configure.ac uses AC_RUN_IFELSE for three probes that
-          # cannot execute a compiled test binary during cross-compilation,
-          # aborting with:
-          #   "configure: error: cannot run test program while cross compiling"
-          #
-          # This breaks the aarch64-apple-darwin cross-build chain:
-          #   atf → libiconv → apple-sdk-14.4 → bindings-node-js-napi-*
-          # See https://github.com/xmtp/libxmtp/issues/3470
-          # and https://github.com/xmtp/libxmtp/issues/3476.
-          #
-          # The three AC_RUN_IFELSE cache variables and their justifications:
-          #
-          #   kyua_cv_getopt_plus (m4/module-application.m4)
-          #     Tests whether getopt(3) accepts a leading '+' for POSIX
-          #     behavior. All target platforms (Darwin, glibc, musl) honour '+'.
-          #
-          #   kyua_cv_attribute_noreturn (m4/module-defs.m4)
-          #     Tests whether __attribute__((__noreturn__)) is supported by
-          #     checking GCC version >= 2.5. All modern GCC/Clang satisfy this.
-          #
-          #   kyua_cv_getcwd_works (m4/module-fs.m4)
-          #     Tests whether getcwd(NULL, 0) dynamically allocates. Both
-          #     Darwin and Linux (glibc and musl) support this.
-          #
-          # Pre-seeding all three is safe for every target in this flake.
-          # Gated on cross-compilation so native builds keep pulling from
-          # cache.nixos.org unchanged.
-          (
-            final: prev:
-            prev.lib.optionalAttrs (prev.stdenv.buildPlatform != prev.stdenv.hostPlatform) {
-              atf = prev.atf.overrideAttrs (old: {
-                configureFlags = (old.configureFlags or [ ]) ++ [
-                  "kyua_cv_getopt_plus=yes"
-                  "kyua_cv_attribute_noreturn=yes"
-                  "kyua_cv_getcwd_works=yes"
-                ];
-              });
-            }
-          )
-          # tcl 8.6.16 (pinned via nixpkgs 09061f74...) has multiple
-          # cross-compile bugs when targeting *-unknown-linux-musl, and the
-          # Hydra build farm only caches the x86_64-linux build host (not
-          # aarch64-darwin), so builds from a darwin host hit the bugs cold.
-          # See https://github.com/xmtp/libxmtp/issues/3444.
-          #
-          # Symptoms seen in CI on warp-macos-26-arm64-12x:
-          #   * compat/mkstemp.c: strlen() called without <string.h>; gcc 15
-          #     promotes -Wimplicit-function-declaration to an error.
-          #   * unix/configure's `uname -s` = "Darwin" on the build host
-          #     defines TCL_WIDE_CLICKS + MAC_OSX_TCL even when cross-compiling
-          #     to linux-musl, so tclUnixTime.c tries to include
-          #     <mach/mach_time.h> against a linux sysroot.
-          #
-          # Rather than patching tcl itself — which requires fixing both the
-          # generated configure script and the MAC_OSX_SRCS makefile variable,
-          # and is fragile across nixpkgs revisions — we sidestep the build
-          # entirely. sqlite only depends on tcl for its tclsqlite3 extension
-          # and its test harness; libxmtp consumes libsqlite3 directly, so
-          # --disable-tcl is safe. sqlite's autosetup uses the bundled jimsh0.c
-          # for its own code generation when tcl is disabled.
-          #
-          # Override is gated on `hostPlatform.isMusl` so native sqlite on
-          # linux/darwin keeps substituting from cache.nixos.org unchanged.
-          (
-            final: prev:
-            prev.lib.optionalAttrs prev.stdenv.hostPlatform.isMusl {
-              sqlite = prev.sqlite.overrideAttrs (old: {
-                configureFlags =
-                  (prev.lib.filter (f: !(prev.lib.hasPrefix "--with-tcl=" f)) old.configureFlags)
-                  ++ [ "--disable-tcl" ];
-                nativeBuildInputs = prev.lib.filter (p: !(prev.lib.hasPrefix "tcl" (p.pname or ""))) (
-                  old.nativeBuildInputs or [ ]
-                );
-                doCheck = false;
-              });
-            }
-          )
-        ];
-        config = {
-          android_sdk.accept_license = true;
-          allowUnfree = true;
-        };
-      };
-      mkCrossPkgs =
-        system: targets:
-        lib.listToAttrs (
-          map (
-            target:
-            let
-              t = normalize target;
-            in
-            {
-              name = t.config;
-              value = import inputs.nixpkgs (
-                self.lib.pkgConfig
-                // {
-                  localSystem = system;
-                  crossSystem = t;
-                }
+  flake.lib = {
+    inherit mkCrossPkgs;
+    pkgConfig = {
+      # Rust Overlay
+      overlays = [
+        inputs.fenix.overlays.default
+        inputs.foundry.overlay
+        self.overlays.default
+        # mold is significantly faster on linux for local dev
+        (
+          final: prev:
+          prev.lib.optionalAttrs prev.stdenv.isLinux {
+            mkShell = prev.mkShell.override {
+              stdenv = prev.stdenvAdapters.useMoldLinker prev.clangStdenv;
+            };
+          }
+        )
+        # atf 0.23's configure.ac uses AC_RUN_IFELSE for three probes that
+        # cannot execute a compiled test binary during cross-compilation,
+        # aborting with:
+        #   "configure: error: cannot run test program while cross compiling"
+        #
+        # This breaks the aarch64-apple-darwin cross-build chain:
+        #   atf → libiconv → apple-sdk-14.4 → bindings-node-js-napi-*
+        # See https://github.com/xmtp/libxmtp/issues/3470
+        # and https://github.com/xmtp/libxmtp/issues/3476.
+        #
+        # The three AC_RUN_IFELSE cache variables and their justifications:
+        #
+        #   kyua_cv_getopt_plus (m4/module-application.m4)
+        #     Tests whether getopt(3) accepts a leading '+' for POSIX
+        #     behavior. All target platforms (Darwin, glibc, musl) honour '+'.
+        #
+        #   kyua_cv_attribute_noreturn (m4/module-defs.m4)
+        #     Tests whether __attribute__((__noreturn__)) is supported by
+        #     checking GCC version >= 2.5. All modern GCC/Clang satisfy this.
+        #
+        #   kyua_cv_getcwd_works (m4/module-fs.m4)
+        #     Tests whether getcwd(NULL, 0) dynamically allocates. Both
+        #     Darwin and Linux (glibc and musl) support this.
+        #
+        # Pre-seeding all three is safe for every target in this flake.
+        # Gated on cross-compilation so native builds keep pulling from
+        # cache.nixos.org unchanged.
+        (
+          final: prev:
+          prev.lib.optionalAttrs (prev.stdenv.buildPlatform != prev.stdenv.hostPlatform) {
+            atf = prev.atf.overrideAttrs (old: {
+              configureFlags = (old.configureFlags or [ ]) ++ [
+                "kyua_cv_getopt_plus=yes"
+                "kyua_cv_attribute_noreturn=yes"
+                "kyua_cv_getcwd_works=yes"
+              ];
+            });
+          }
+        )
+        # tcl 8.6.16 (pinned via nixpkgs 09061f74...) has multiple
+        # cross-compile bugs when targeting *-unknown-linux-musl, and the
+        # Hydra build farm only caches the x86_64-linux build host (not
+        # aarch64-darwin), so builds from a darwin host hit the bugs cold.
+        # See https://github.com/xmtp/libxmtp/issues/3444.
+        #
+        # Symptoms seen in CI on warp-macos-26-arm64-12x:
+        #   * compat/mkstemp.c: strlen() called without <string.h>; gcc 15
+        #     promotes -Wimplicit-function-declaration to an error.
+        #   * unix/configure's `uname -s` = "Darwin" on the build host
+        #     defines TCL_WIDE_CLICKS + MAC_OSX_TCL even when cross-compiling
+        #     to linux-musl, so tclUnixTime.c tries to include
+        #     <mach/mach_time.h> against a linux sysroot.
+        #
+        # Rather than patching tcl itself — which requires fixing both the
+        # generated configure script and the MAC_OSX_SRCS makefile variable,
+        # and is fragile across nixpkgs revisions — we sidestep the build
+        # entirely. sqlite only depends on tcl for its tclsqlite3 extension
+        # and its test harness; libxmtp consumes libsqlite3 directly, so
+        # --disable-tcl is safe. sqlite's autosetup uses the bundled jimsh0.c
+        # for its own code generation when tcl is disabled.
+        #
+        # Override is gated on `hostPlatform.isMusl` so native sqlite on
+        # linux/darwin keeps substituting from cache.nixos.org unchanged.
+        (
+          final: prev:
+          prev.lib.optionalAttrs prev.stdenv.hostPlatform.isMusl {
+            sqlite = prev.sqlite.overrideAttrs (old: {
+              configureFlags =
+                (prev.lib.filter (f: !(prev.lib.hasPrefix "--with-tcl=" f)) old.configureFlags)
+                ++ [ "--disable-tcl" ];
+              nativeBuildInputs = prev.lib.filter (p: !(prev.lib.hasPrefix "tcl" (p.pname or ""))) (
+                old.nativeBuildInputs or [ ]
               );
-            }
-          ) targets
-        );
-    };
-  perSystem =
-    {
-      pkgs,
-      ...
-    }:
-    let
-      craneConfig = final: prev: {
-        # add napi builder to crane scope
-        napiBuild = final.callPackage ./napiBuild.nix { };
-        uniffiGenerate = final.callPackage ./uniffiGenerate.nix { };
+              doCheck = false;
+            });
+          }
+        )
+      ];
+      config = {
+        android_sdk.accept_license = true;
+        allowUnfree = true;
       };
-      mkToolchain = pkgs.callPackage ./mkToolchain.nix { inherit inputs; };
-    in
+    };
+  };
+  perSystem =
+    { pkgs, ... }:
     {
       overlayAttrs = {
-        xmtp = {
-          inherit mkToolchain;
-          # toolchain with native pkgs
-          mkNativeToolchain = mkToolchain pkgs;
-          filesets = pkgs.callPackage ./filesets.nix { };
-          craneLib = (inputs.crane.mkLib pkgs).overrideScope craneConfig;
-          base = pkgs.callPackage ./base.nix { };
-          androidEnv = pkgs.callPackage ./android-env.nix { };
-          iosEnv = pkgs.callPackage ./ios-env.nix { };
-          ffi-uniffi-bindgen = pkgs.callPackage ./packages/uniffi-bindgen.nix { };
-          shellCommon = pkgs.callPackage ./shell-common.nix { };
-          mkVersion = import ./mkVersion.nix;
-          toNapiTarget = import ./napiTarget.nix;
-        };
+        xmtp = mkXmtpLib pkgs;
+        xmtp-base = pkgs.callPackage ./base.nix { };
         wasm-bindgen-cli = pkgs.callPackage ./packages/wasm-bindgen-cli.nix { };
         napi-rs-cli = pkgs.callPackage ./packages/napi-rs-cli { };
         ffi-uniffi-bindgen = pkgs.callPackage ./packages/uniffi-bindgen.nix { };

--- a/nix/lib/packages/uniffi-bindgen.nix
+++ b/nix/lib/packages/uniffi-bindgen.nix
@@ -1,16 +1,16 @@
 {
   xmtp,
+  xmtp-base,
   lib,
 }:
 let
-  inherit (xmtp) base;
   rust-toolchain = p: xmtp.mkToolchain p [ ] [ ];
   rust = xmtp.craneLib.overrideToolchain rust-toolchain;
-  cargoArtifacts = xmtp.base.mkCargoArtifacts rust false null;
+  cargoArtifacts = xmtp-base.mkCargoArtifacts rust false null;
   src = ./../../..;
 in
 rust.buildPackage (
-  base.commonArgs
+  xmtp-base.commonArgs
   // {
     inherit cargoArtifacts;
     pname = "ffi-uniffi-bindgen";

--- a/nix/lib/shell-common.nix
+++ b/nix/lib/shell-common.nix
@@ -40,6 +40,7 @@
   chromium,
   writeText,
   xmtp,
+  xmtp-base,
 }:
 let
   inherit (stdenv) isLinux;
@@ -67,7 +68,7 @@ let
 in
 {
   # Core Rust build environment: env vars, hardening, native deps, LD_LIBRARY_PATH
-  rustBase = xmtp.base.commonArgs // {
+  rustBase = xmtp-base.commonArgs // {
     env = {
       OPENSSL_DIR = "${openssl.dev}";
       OPENSSL_LIB_DIR = "${lib.getLib openssl}/lib";

--- a/nix/package/android.nix
+++ b/nix/package/android.nix
@@ -1,15 +1,16 @@
 {
   gnused,
   xmtp,
+  xmtp-base,
   stdenv,
   ...
 }:
 let
-  inherit (xmtp) craneLib base;
+  inherit (xmtp) craneLib;
   rust-toolchain = p: xmtp.mkToolchain p [ stdenv.hostPlatform.rust.rustcTarget ] [ ];
   rust = craneLib.overrideToolchain rust-toolchain;
   version = xmtp.mkVersion rust;
-  inherit (base) bindingsFileset commonArgs;
+  inherit (xmtp-base) bindingsFileset commonArgs;
 
   specialArgs = {
     # set buildInputs to empty to force the android build to link against libraries in the NDK sysroot instead
@@ -17,7 +18,7 @@ let
     buildInputs = [ ];
   };
 
-  cargoArtifacts = xmtp.base.mkCargoArtifacts rust false specialArgs;
+  cargoArtifacts = xmtp-base.mkCargoArtifacts rust false specialArgs;
 
   ext = if stdenv.isDarwin then "dylib" else "so";
   dylib = rust.buildPackage (

--- a/nix/package/ios.nix
+++ b/nix/package/ios.nix
@@ -15,11 +15,12 @@
 {
   lib,
   xmtp,
+  xmtp-base,
   stdenv,
   ...
 }:
 let
-  inherit (xmtp) iosEnv base;
+  inherit (xmtp) iosEnv;
   # override craneLib rust toolchain with given stdenv
   # https://crane.dev/API.html#mklib
   craneLib = xmtp.craneLib.overrideScope (
@@ -38,8 +39,19 @@ let
   # Extract version once for use throughout the file
   version = xmtp.mkVersion rust;
 
-  # Inherit shared config
-  inherit (base) commonArgs bindingsFileset;
+  # Inherit shared config. Strip OPENSSL_* vars: ios.nix runs as native
+  # `pkgs.callPackage` (target stdenv = ios via CARGO_BUILD_TARGET), but
+  # `xmtp-base` here is the native-macOS-spliced one whose OPENSSL_DIR
+  # points at native libssl.dylib. Linking ios-sim against macOS libssl
+  # fails with "building for iOS-simulator, but linking in dylib built
+  # for macOS". xcode SDK supplies its own crypto so dropping is safe.
+  inherit (xmtp-base) bindingsFileset;
+  commonArgs = removeAttrs xmtp-base.commonArgs [
+    "OPENSSL_NO_VENDOR"
+    "OPENSSL_DIR"
+    "OPENSSL_LIB_DIR"
+    "OPENSSL_INCLUDE_DIR"
+  ];
 
   # Build static (.a) and dynamic (.dylib) libraries for a single cross-compilation target.
   #
@@ -61,7 +73,7 @@ let
     let
       envSetup = iosEnv.envSetup target;
     in
-    xmtp.base.mkCargoArtifacts rust false {
+    xmtp-base.mkCargoArtifacts rust false {
       pname = "xmtpv3-deps-${target}";
       CARGO_BUILD_TARGET = target;
       __noChroot = true;

--- a/nix/package/mls_validation_service.nix
+++ b/nix/package/mls_validation_service.nix
@@ -1,11 +1,12 @@
 {
   xmtp,
+  xmtp-base,
   lib,
   stdenv,
 }:
 let
   inherit (lib.fileset) unions;
-  inherit (xmtp) craneLib mkToolchain base;
+  inherit (xmtp) craneLib mkToolchain;
   inherit (craneLib.fileset) commonCargoSources;
 
   rust-toolchain = p: mkToolchain p [ stdenv.hostPlatform.rust.rustcTarget ] [ ];
@@ -16,7 +17,7 @@ let
     RUSTFLAGS = "-C target-feature=+crt-static";
   };
 
-  commonArgs = base.commonArgs // specialArgs;
+  commonArgs = xmtp-base.commonArgs // specialArgs;
 
   src = lib.fileset.toSource {
     inherit root;
@@ -47,7 +48,7 @@ let
     ];
   };
 
-  cargoArtifacts = xmtp.base.mkCargoArtifacts rust false specialArgs;
+  cargoArtifacts = xmtp-base.mkCargoArtifacts rust false specialArgs;
 in
 rust.buildPackage (
   commonArgs

--- a/nix/package/nextest.nix
+++ b/nix/package/nextest.nix
@@ -1,6 +1,7 @@
 # Derivation that runs cargo nextest with llvm-cov on the workspace
 {
   xmtp,
+  xmtp-base,
   lib,
   cargo-llvm-cov,
   d14n ? false,
@@ -27,13 +28,13 @@ let
     ];
   };
 
-  commonArgs = xmtp.base.commonArgs // {
-    nativeBuildInputs = xmtp.base.commonArgs.nativeBuildInputs ++ [
+  commonArgs = xmtp-base.commonArgs // {
+    nativeBuildInputs = xmtp-base.commonArgs.nativeBuildInputs ++ [
       cargo-llvm-cov
     ];
   };
 
-  cargoArtifacts = xmtp.base.mkCargoArtifacts rust false (
+  cargoArtifacts = xmtp-base.mkCargoArtifacts rust false (
     (removeAttrs commonArgs [ "src" ])
     // {
       buildPhaseCargoCommand = "cargo llvm-cov --locked --profile $CARGO_PROFILE --no-report";

--- a/nix/package/node.nix
+++ b/nix/package/node.nix
@@ -1,5 +1,6 @@
 {
   xmtp,
+  xmtp-base,
   cacert,
   lib,
   stdenv,
@@ -44,18 +45,18 @@ let
     };
 
   commonArgs =
-    xmtp.base.commonArgs
+    xmtp-base.commonArgs
     // {
       inherit version;
     }
     // specialArgs;
 
-  cargoArtifacts = xmtp.base.mkCargoArtifacts rust test (
+  cargoArtifacts = xmtp-base.mkCargoArtifacts rust test (
     specialArgs
     // lib.optionalAttrs isGnu {
       # override everything for glibc compatibility
       preBuild = "export HOME=$TMPDIR";
-      nativeBuildInputs = xmtp.base.commonArgs.nativeBuildInputs ++ [ cargo-zigbuild ];
+      nativeBuildInputs = xmtp-base.commonArgs.nativeBuildInputs ++ [ cargo-zigbuild ];
       buildPhaseCargoCommand = "cargo zigbuild ${maybeTestFeature} --profile $CARGO_PROFILE --locked";
     }
   );

--- a/nix/package/wasm-nextest.nix
+++ b/nix/package/wasm-nextest.nix
@@ -1,6 +1,7 @@
 # Derivation that runs cargo nextest with llvm-cov on the workspace
 {
   xmtp,
+  xmtp-base,
   lib,
   chromedriver,
   google-chrome,
@@ -14,7 +15,7 @@
 }:
 let
   inherit (lib.fileset) unions fileFilter;
-  inherit (xmtp) craneLib base;
+  inherit (xmtp) craneLib;
   inherit (craneLib.fileset) commonCargoSources;
   root = ./../..;
   rust-toolchain = p: xmtp.mkToolchain p [ "wasm32-unknown-unknown" ] [ "llvm-tools-preview" ];
@@ -33,8 +34,8 @@ let
     ];
   };
 
-  commonArgs = base.commonArgs // {
-    nativeBuildInputs = base.commonArgs.nativeBuildInputs ++ [
+  commonArgs = xmtp-base.commonArgs // {
+    nativeBuildInputs = xmtp-base.commonArgs.nativeBuildInputs ++ [
       cargo-nextest
       wasm-bindgen-cli
       nodejs_24
@@ -54,7 +55,7 @@ let
   d14nTestArgs = if d14n then "--features d14n" else "";
   wasmPackages = "-p xmtp_mls -p xmtp_cryptography -p xmtp_common -p xmtp_api -p xmtp_id -p xmtp_db -p xmtp_api_d14n -p xmtp_content_types";
 
-  cargoArtifacts = xmtp.base.mkCargoArtifacts rust false (
+  cargoArtifacts = xmtp-base.mkCargoArtifacts rust false (
     (removeAttrs commonArgs [ "src" ])
     // {
       buildPhaseCargoCommand = "cargo nextest run --locked --cargo-profile $CARGO_PROFILE --no-run ${wasmPackages}";
@@ -76,7 +77,7 @@ rust.cargoNextest (
     # chromedriver requires home to be editable/set, otherwise it SIGKILLS and fails tests.
     preBuild = "export HOME=$TMPDIR";
     buildInputs =
-      base.commonArgs.buildInputs
+      xmtp-base.commonArgs.buildInputs
       ++ [
         chromedriver
       ]

--- a/nix/package/wasm.nix
+++ b/nix/package/wasm.nix
@@ -8,6 +8,7 @@
   llvmPackages,
   wasm-bindgen-cli,
   xmtp,
+  xmtp-base,
   chromedriver,
   google-chrome,
   chromium,
@@ -17,7 +18,7 @@
   test ? false,
 }:
 let
-  inherit (xmtp) craneLib base;
+  inherit (xmtp) craneLib;
   # Pinned Rust Version (must use mkToolchain to match the rest of the project)
   rust-toolchain =
     xmtp.mkNativeToolchain
@@ -31,7 +32,7 @@ let
     fileset = xmtp.filesets.forCrate ./../../bindings/wasm;
   };
 
-  commonArgs = base.commonArgs // {
+  commonArgs = xmtp-base.commonArgs // {
     meta.description = "WebAssembly Bindings";
     # EM_CACHE = "$TMPDIR/.emscripten_cache";
     # we need to set tmpdir for emscripten cache
@@ -43,7 +44,7 @@ let
       # export EM_CACHE=$TMPDIR
       # export EMCC_DEBUG=2
     '';
-    nativeBuildInputs = base.commonArgs.nativeBuildInputs ++ [
+    nativeBuildInputs = xmtp-base.commonArgs.nativeBuildInputs ++ [
       wasm-pack
       emscripten
       llvmPackages.lld
@@ -68,7 +69,7 @@ let
   };
 
   # enables caching all build time crates
-  cargoArtifacts = xmtp.base.mkCargoArtifacts rust test (
+  cargoArtifacts = xmtp-base.mkCargoArtifacts rust test (
     commonEnv
     // {
       buildPhaseCargoCommand = "cargo build --package bindings_wasm ${features} --profile $CARGO_PROFILE --locked";

--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -40,25 +40,17 @@ _: {
           fileset = pkgs.xmtp.filesets.workspace;
         };
         defaults = {
-          perCrate.crane.args = pkgs.xmtp.base.commonArgs;
+          perCrate.crane.args = pkgs.xmtp-base.commonArgs;
         };
         crates = {
           "xmtp_debug" = {
             autoWire = [ "crate" ];
             path = src + /apps/xmtp_debug;
-            # cacert is needed so xdbg can negotiate TLS to remote XMTP
-            # gateways at runtime (e.g. grpc.testnet.xmtp.network) without
-            # an externally-provided CA bundle.  Concatenate onto the
-            # shared commonArgs.nativeBuildInputs rather than replace it.
-            crane.args.nativeBuildInputs = pkgs.xmtp.base.commonArgs.nativeBuildInputs ++ [ pkgs.cacert ];
+            crane.args.nativeBuildInputs = pkgs.xmtp-base.commonArgs.nativeBuildInputs ++ [ pkgs.cacert ];
           };
           "xmtp_cli" = {
             path = src + /apps/cli;
             autoWire = [ "crate" ];
-          };
-          "bindings_wasm" = {
-            # wasm bindings have custom build in wasm.nix
-            autoWire = [ ];
           };
           "xnet" = {
             path = src + /apps/xnet/lib;

--- a/nix/shells/android.nix
+++ b/nix/shells/android.nix
@@ -9,10 +9,11 @@
   lib,
   gnused,
   xmtp,
+  xmtp-base,
   zlib,
 }:
 let
-  inherit (xmtp) androidEnv base shellCommon;
+  inherit (xmtp) androidEnv shellCommon;
 
   # Rust toolchain with Android cross-compilation targets
   rust-android-toolchain = xmtp.mkNativeToolchain androidEnv.androidTargets [
@@ -36,10 +37,10 @@ mkShell (
       zlib
     ];
 
-    inherit (base.commonArgs) nativeBuildInputs;
+    inherit (xmtp-base.commonArgs) nativeBuildInputs;
 
     buildInputs =
-      base.commonArgs.buildInputs
+      xmtp-base.commonArgs.buildInputs
       ++ [
         rust-android-toolchain
         kotlin


### PR DESCRIPTION
fixes #3575 

this began happening b/c one of my prs pulled libsqlite into workspace hack so it is used for builds which previously did not require it (mls-validation-service).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix macOS-26 OpenSSL build failures by using system OpenSSL for non-Android builds
> - Sets `OPENSSL_NO_VENDOR`, `OPENSSL_DIR`, `OPENSSL_LIB_DIR`, and `OPENSSL_INCLUDE_DIR` in [nix/lib/base.nix](https://github.com/xmtp/libxmtp/pull/3584/files#diff-78e27920e7e7f148052510551d065fae07e34ca9a88df0abd2450dedb25668bc) for non-Android platforms, directing `openssl-sys` to link against nixpkgs' OpenSSL instead of building a vendored copy.
> - iOS builds strip the `OPENSSL_*` vars from `commonArgs` to avoid accidentally linking against macOS libssl when targeting iOS/iOS-simulator.
> - Refactors the Nix library structure in [nix/lib/default.nix](https://github.com/xmtp/libxmtp/pull/3584/files#diff-6fd175d36064b2e9b9371596932bf201514494fc02c317f3f4526243d72991f1) to expose base utilities as a top-level `xmtp-base` attribute instead of `xmtp.base`, and updates all package derivations and shells accordingly.
> - Behavioral Change: consumers referencing `xmtp.base` in Nix expressions must switch to `xmtp-base`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ea5f03a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->