### PR TITLE
chore(hakari): exclude libsqlite3-sys to keep openssl out of workspace-hack

### DIFF
--- a/.config/hakari.toml
+++ b/.config/hakari.toml
@@ -43,6 +43,11 @@ third-party = [
   { name = "tokio" },
   { name = "uniffi" },
   { name = "wasm-bindgen" },
+  # Excluded so workspace-hack does not unify libsqlite3-sys's
+  # `bundled-sqlcipher-vendored-openssl` feature into every workspace member,
+  # which would drag openssl-sys/openssl into builds (e.g. mls-validation-service)
+  # that have no need for SQLite.
+  { name = "libsqlite3-sys" },
 ]
 
 [final-excludes]
@@ -60,4 +65,5 @@ third-party = [
   { name = "tokio" },
   { name = "uniffi" },
   { name = "wasm-bindgen" },
+  { name = "libsqlite3-sys" },
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14131,7 +14131,6 @@ dependencies = [
  "k256",
  "libc",
  "libcrux-ed25519",
- "libsqlite3-sys",
  "log",
  "memchr",
  "nu-ansi-term",

--- a/crates/xmtp-workspace-hack/Cargo.toml
+++ b/crates/xmtp-workspace-hack/Cargo.toml
@@ -205,7 +205,6 @@ diesel = { git = "https://github.com/ephemerahq/diesel", branch = "coda/copy-to-
 getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 hyper = { version = "1", default-features = false, features = ["client"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "server-graceful", "service"] }
-libsqlite3-sys = { version = "0.35", features = ["bundled-sqlcipher-vendored-openssl"] }
 proptest = { version = "1", default-features = false, features = ["bit-set", "timeout"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 rustls-pki-types = { version = "1", features = ["std"] }
@@ -220,7 +219,6 @@ diesel_derives = { git = "https://github.com/ephemerahq/diesel", branch = "coda/
 getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 hyper = { version = "1", default-features = false, features = ["client"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "server-graceful", "service"] }
-libsqlite3-sys = { version = "0.35", features = ["bundled-sqlcipher-vendored-openssl"] }
 proptest = { version = "1", default-features = false, features = ["bit-set", "timeout"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 rustls-pki-types = { version = "1", features = ["std"] }
@@ -235,7 +233,6 @@ getrandom = { version = "0.4", default-features = false, features = ["std", "sys
 hyper = { version = "1", default-features = false, features = ["client"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "server-graceful", "service"] }
 libc = { version = "0.2" }
-libsqlite3-sys = { version = "0.35", features = ["bundled-sqlcipher-vendored-openssl"] }
 proptest = { version = "1", default-features = false, features = ["bit-set", "timeout"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 rustls-pki-types = { version = "1", features = ["std"] }
@@ -252,7 +249,6 @@ getrandom = { version = "0.4", default-features = false, features = ["std", "sys
 hyper = { version = "1", default-features = false, features = ["client"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "server-graceful", "service"] }
 libc = { version = "0.2" }
-libsqlite3-sys = { version = "0.35", features = ["bundled-sqlcipher-vendored-openssl"] }
 proptest = { version = "1", default-features = false, features = ["bit-set", "timeout"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 rustls-pki-types = { version = "1", features = ["std"] }
@@ -267,7 +263,6 @@ getrandom = { version = "0.4", default-features = false, features = ["std", "sys
 hyper = { version = "1", default-features = false, features = ["client"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "server-graceful", "service"] }
 libc = { version = "0.2" }
-libsqlite3-sys = { version = "0.35", features = ["bundled-sqlcipher-vendored-openssl"] }
 proptest = { version = "1", default-features = false, features = ["bit-set", "timeout"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 rustls-pki-types = { version = "1", features = ["std"] }
@@ -284,7 +279,6 @@ getrandom = { version = "0.4", default-features = false, features = ["std", "sys
 hyper = { version = "1", default-features = false, features = ["client"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "server-graceful", "service"] }
 libc = { version = "0.2" }
-libsqlite3-sys = { version = "0.35", features = ["bundled-sqlcipher-vendored-openssl"] }
 proptest = { version = "1", default-features = false, features = ["bit-set", "timeout"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 rustls-pki-types = { version = "1", features = ["std"] }
@@ -298,7 +292,6 @@ errno = { version = "0.3" }
 getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 hyper = { version = "1", default-features = false, features = ["client"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "server-graceful", "service"] }
-libsqlite3-sys = { version = "0.35", features = ["bundled-sqlcipher-vendored-openssl"] }
 proptest = { version = "1", default-features = false, features = ["bit-set", "timeout"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 rustls-pki-types = { version = "1", features = ["std"] }
@@ -314,7 +307,6 @@ errno = { version = "0.3" }
 getrandom = { version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 hyper = { version = "1", default-features = false, features = ["client"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "server-graceful", "service"] }
-libsqlite3-sys = { version = "0.35", features = ["bundled-sqlcipher-vendored-openssl"] }
 proptest = { version = "1", default-features = false, features = ["bit-set", "timeout"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 rustls-pki-types = { version = "1", features = ["std"] }


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3586

## Summary

`xmtp_proto`'s optional `diesel` feature caused `cargo hakari` to unify `libsqlite3-sys` (with the `bundled-sqlcipher-vendored-openssl` feature) into `xmtp-workspace-hack`. Because every workspace member depends on `xmtp-workspace-hack`, this dragged `openssl-sys`/`openssl` into builds that have no business linking OpenSSL — most notably `mls_validation_service`, the underlying cause of the macOS-26 build failures patched around in #3584.

This change adds `libsqlite3-sys` to both `traversal-excludes` and `final-excludes` in `.config/hakari.toml` and regenerates `xmtp-workspace-hack`. Per the issue, the goal was to add the minimum subset of `{openssl, diesel, libsqlite3-sys, openssl-sys}` needed to keep openssl out of workspace-hack — excluding only `libsqlite3-sys` is sufficient, because libsqlite3-sys (with the vendored-openssl feature) was the only path to openssl in the unified graph.

## Verification

- `cargo hakari generate --diff` — no diff after the change
- `cargo hakari manage-deps --dry-run` — no operations to perform
- `grep -niE 'openssl|libsqlite3-sys' crates/xmtp-workspace-hack/Cargo.toml` — empty
- `cargo tree -p mls_validation_service` — no `openssl`, `openssl-sys`, `libsqlite3-sys`, or `diesel` in the tree
- `cargo check -p mls_validation_service` — passes
- `cargo check -p xmtp_db` (a real diesel/sqlite consumer) — passes
- `cargo fmt --check` — passes
- `taplo format --check` on `.config/hakari.toml` — passes

## Test plan

- [ ] CI build passes on macOS-26 without the OpenSSL workaround needing to fire for crates that don't actually use SQLite
- [ ] CI build still works for crates that do use SQLite (xmtp_db, xmtp_mls, mobile/wasm/node bindings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Exclude `libsqlite3-sys` from workspace-hack to remove OpenSSL from unified dependencies
> Adds `libsqlite3-sys` to the `final-excludes` list in [hakari.toml](https://github.com/xmtp/libxmtp/pull/3587/files#diff-6ca1bb1e13a357482741fd29eafc6b6306971ba70f5bba83f721c01322849165), preventing cargo-hakari from unifying the `bundled-sqlcipher-vendored-openssl` feature into `xmtp-workspace-hack`. This removes the transitive OpenSSL dependency that was being pulled into the workspace-hack crate unnecessarily.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized edc0093.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->