### PR TITLE
xmtp_mls_common: add static dispatch table + lookup_component()

### DIFF
--- a/crates/xmtp_mls/src/groups/app_data/component_source.rs
+++ b/crates/xmtp_mls/src/groups/app_data/component_source.rs
@@ -404,23 +404,11 @@ pub(crate) fn encode_app_data_update_payload(
     }
 }
 
-/// A single per-element view of an incoming `AppDataUpdate` proposal.
-///
-/// `Bytes` components produce exactly one entry; collection components
-/// produce one entry per delta mutation. The `op` mirrors the
-/// `ComponentOp` field on a [`ComponentChange`] so the validator can call
-/// `validate_component_write` directly.
-///
-/// `value` is `None` for `Delete` ops on collection components (the
-/// receiver removes the key without needing the new value), and `Some` for
-/// every other case.
-#[derive(Debug, Clone)]
-pub(crate) struct ExpandedComponentChange {
-    /// Whether this entry is an Insert, Update, or Delete.
-    pub(crate) op: ComponentOp,
-    /// The new value bytes for Insert/Update, or `None` for Delete.
-    pub(crate) value: Option<Vec<u8>>,
-}
+// `ExpandedComponentChange` lives in `xmtp_mls_common::app_data::typed`
+// so the `Component` trait there can return it. Re-exported here for
+// backward compatibility while the dispatch refactor (subsequent jj
+// changes) shifts call sites onto the trait directly.
+pub(crate) use xmtp_mls_common::app_data::typed::ExpandedComponentChange;
 
 /// Expand an `AppDataUpdate` proposal payload into the per-element changes
 /// that should be checked against the component registry.

--- a/crates/xmtp_mls_common/src/app_data/components/inbox_id_set.rs
+++ b/crates/xmtp_mls_common/src/app_data/components/inbox_id_set.rs
@@ -67,9 +67,21 @@ fn expand_inbox_id_set_changes(
         AppDataUpdateOperation::Update(payload) => {
             let delta = TlsSetDelta::<InboxId>::tls_deserialize_exact(payload.as_slice())?;
 
-            // Lazily build a hash → InboxId index only if we actually
-            // see a `RemoveByHash` in this delta. Common case
-            // (Insert/Remove only) skips the prior-set decode.
+            // Build the hash → InboxId index ONCE up front for the
+            // whole delta — never inside the mutation loop. The
+            // mutation loop below stays a tight O(m) scan that does
+            // O(1) hash-index lookups; building the index inside the
+            // loop would degrade the resolve step from O(n+m) to
+            // O(n*m) and bite us once admin/super-admin lists grow.
+            //
+            // Conditional on `needs_index`: if the delta has zero
+            // `RemoveByHash` mutations, the prior set is never decoded
+            // and no index is allocated — common case (pure
+            // Insert/Remove deltas) pays nothing for the index path.
+            //
+            // Mirrors `TlsSet::apply_delta`'s "build once per call"
+            // discipline (see `tls_set.rs`'s `apply_delta` docs for
+            // the same O(n+m) argument).
             let needs_index = delta
                 .mutations
                 .iter()
@@ -83,9 +95,15 @@ fn expand_inbox_id_set_changes(
                             // A hash clash between two distinct keys
                             // is cryptographically infeasible with
                             // SHA-256, but defense-in-depth: reject
-                            // any silently-lossy index. Matches
-                            // `TlsSet::apply_delta`'s `DuplicateHash`
-                            // check at apply time.
+                            // any silently-lossy index. Matters if
+                            // SHA-256 is ever weakened or if a future
+                            // `Serialize` impl produces the same
+                            // bytes for distinct logical values — a
+                            // collision-tolerant index would silently
+                            // drop one of the entries and let
+                            // `RemoveByHash` resolve to the wrong
+                            // member. Matches `TlsSet::apply_delta`'s
+                            // `DuplicateHash` check at apply time.
                             if idx.insert(TlsKeyHash::of(key)?, *key).is_some() {
                                 return Err(ComponentTypedError::TlsSetApply(
                                     TlsSetError::DuplicateHash,
@@ -321,8 +339,7 @@ mod tests {
         let payload = AdminListComponent::encode_mutation(&delta).unwrap();
         let op = AppDataUpdateOperation::Update(payload.into());
 
-        let changes =
-            AdminListComponent::expand_to_changes(&op, Some(&prior_bytes)).unwrap();
+        let changes = AdminListComponent::expand_to_changes(&op, Some(&prior_bytes)).unwrap();
         assert_eq!(changes.len(), 1);
         assert_eq!(changes[0].op, ComponentOp::Delete);
         assert_eq!(changes[0].value.as_deref(), Some(&target.as_bytes()[..]));
@@ -366,6 +383,9 @@ mod tests {
         let bytes = DmMembersComponent::encode_value(&set).unwrap();
         let decoded = DmMembersComponent::decode_value(&bytes).unwrap();
         assert!(decoded.contains(&fixture_inbox_id(42)));
-        assert_eq!(DmMembersComponent::COMPONENT_TYPE, ComponentType::TlsSetInboxId);
+        assert_eq!(
+            DmMembersComponent::COMPONENT_TYPE,
+            ComponentType::TlsSetInboxId
+        );
     }
 }

--- a/crates/xmtp_mls_common/src/app_data/components/inbox_id_set.rs
+++ b/crates/xmtp_mls_common/src/app_data/components/inbox_id_set.rs
@@ -1,0 +1,371 @@
+//! [`Component`] impls for the `TlsSet<InboxId>`-shaped components:
+//! [`AdminListComponent`] (`ADMIN_LIST`),
+//! [`SuperAdminListComponent`] (`SUPER_ADMIN_LIST`), and
+//! [`DmMembersComponent`] (`DM_MEMBERS`, immutable).
+//!
+//! All three share an identical wire format and trait shape. They
+//! differ only in their `ComponentId` and the dispatch layer's
+//! immutability gate (`DM_MEMBERS` is in the immutable range, so the
+//! dispatch layer rejects `Update` writes before they reach this impl
+//! — but the impl is still valid as a `read` path).
+
+use openmls::messages::proposals::AppDataUpdateOperation;
+use std::collections::HashMap;
+use tls_codec::{Deserialize, Serialize};
+use xmtp_proto::xmtp::mls::message_contents::ComponentType;
+
+use crate::{
+    app_data::{
+        component_id::ComponentId,
+        component_registry::ComponentOp,
+        typed::{Component, ComponentTypedError, ExpandedComponentChange},
+    },
+    inbox_id::InboxId,
+    tls_set::{TlsKeyHash, TlsSet, TlsSetDelta, TlsSetError, TlsSetMutation},
+};
+
+/// Apply a `TlsSetDelta<InboxId>` wire payload over the prior dict
+/// bytes (a `TlsSet<InboxId>` snapshot, or `None` if this is the first
+/// write — bootstrap, where prior state is empty).
+///
+/// Returns the new dict bytes: the re-serialized `TlsSet<InboxId>`
+/// snapshot. The dict always holds the raw set as state; the wire
+/// always carries a delta describing the change. This function is
+/// the one boundary that translates between them.
+///
+/// Shared between the three inbox-id-set impls.
+fn apply_inbox_id_set_delta(
+    payload: &[u8],
+    prior: Option<&[u8]>,
+) -> Result<Vec<u8>, ComponentTypedError> {
+    let delta = TlsSetDelta::<InboxId>::tls_deserialize_exact(payload)?;
+    let mut set: TlsSet<InboxId> = match prior {
+        Some(bytes) => TlsSet::<InboxId>::tls_deserialize_exact(bytes)?,
+        None => TlsSet::new(),
+    };
+    set.apply_delta(delta)?;
+    Ok(set.tls_serialize_detached()?)
+}
+
+/// Expand an `AppDataUpdate` proposal for an inbox-id-set component
+/// into the per-element `ExpandedComponentChange` entries the validator
+/// iterates over.
+///
+/// Mirrors the existing `expand_app_data_update_to_changes`
+/// implementation in `xmtp_mls::groups::app_data::component_source`
+/// (which #7 will retire). `RemoveByHash` mutations resolve back to
+/// the underlying `InboxId` via a hash index built from the prior set.
+fn expand_inbox_id_set_changes(
+    op: &AppDataUpdateOperation,
+    prior: Option<&[u8]>,
+) -> Result<Vec<ExpandedComponentChange>, ComponentTypedError> {
+    match op {
+        AppDataUpdateOperation::Remove => Ok(vec![ExpandedComponentChange {
+            op: ComponentOp::Delete,
+            value: None,
+        }]),
+        AppDataUpdateOperation::Update(payload) => {
+            let delta = TlsSetDelta::<InboxId>::tls_deserialize_exact(payload.as_slice())?;
+
+            // Lazily build a hash → InboxId index only if we actually
+            // see a `RemoveByHash` in this delta. Common case
+            // (Insert/Remove only) skips the prior-set decode.
+            let needs_index = delta
+                .mutations
+                .iter()
+                .any(|m| matches!(m, TlsSetMutation::RemoveByHash(_)));
+            let hash_index: Option<HashMap<TlsKeyHash, InboxId>> = if needs_index {
+                match prior {
+                    Some(bytes) => {
+                        let prior_set = TlsSet::<InboxId>::tls_deserialize_exact(bytes)?;
+                        let mut idx = HashMap::with_capacity(prior_set.len());
+                        for key in prior_set.iter() {
+                            // A hash clash between two distinct keys
+                            // is cryptographically infeasible with
+                            // SHA-256, but defense-in-depth: reject
+                            // any silently-lossy index. Matches
+                            // `TlsSet::apply_delta`'s `DuplicateHash`
+                            // check at apply time.
+                            if idx.insert(TlsKeyHash::of(key)?, *key).is_some() {
+                                return Err(ComponentTypedError::TlsSetApply(
+                                    TlsSetError::DuplicateHash,
+                                ));
+                            }
+                        }
+                        Some(idx)
+                    }
+                    // No prior bytes → empty set → every RemoveByHash
+                    // trivially misses. Skip the allocation; each
+                    // lookup returns None.
+                    None => None,
+                }
+            } else {
+                None
+            };
+
+            let mut out = Vec::with_capacity(delta.mutations.len());
+            for mutation in delta.mutations {
+                match mutation {
+                    TlsSetMutation::Insert(key) => out.push(ExpandedComponentChange {
+                        op: ComponentOp::Insert,
+                        value: Some(key.into_bytes().to_vec()),
+                    }),
+                    TlsSetMutation::Remove(key) => out.push(ExpandedComponentChange {
+                        op: ComponentOp::Delete,
+                        value: Some(key.into_bytes().to_vec()),
+                    }),
+                    TlsSetMutation::RemoveByHash(target) => {
+                        let resolved = hash_index
+                            .as_ref()
+                            .and_then(|idx| idx.get(&target))
+                            .map(|id| id.as_bytes().to_vec());
+                        out.push(ExpandedComponentChange {
+                            op: ComponentOp::Delete,
+                            value: resolved,
+                        });
+                    }
+                }
+            }
+            Ok(out)
+        }
+    }
+}
+
+macro_rules! inbox_id_set_component {
+    ($struct_name:ident, $id:expr) => {
+        pub struct $struct_name;
+
+        impl Component for $struct_name {
+            const ID: ComponentId = $id;
+            const COMPONENT_TYPE: ComponentType = ComponentType::TlsSetInboxId;
+            type Value = TlsSet<InboxId>;
+            // The mutation type is the full wire-level delta so a
+            // single proposal can carry multiple Insert/Remove
+            // mutations atomically. Single-mutation callers build a
+            // one-element delta via `TlsSetDelta::new().insert(x)`.
+            type Mutation = TlsSetDelta<InboxId>;
+
+            fn decode_value(bytes: &[u8]) -> Result<Self::Value, ComponentTypedError> {
+                TlsSet::<InboxId>::tls_deserialize_exact(bytes).map_err(Into::into)
+            }
+
+            fn encode_value(value: &Self::Value) -> Result<Vec<u8>, ComponentTypedError> {
+                value.tls_serialize_detached().map_err(Into::into)
+            }
+
+            fn encode_mutation(mutation: &Self::Mutation) -> Result<Vec<u8>, ComponentTypedError> {
+                mutation.tls_serialize_detached().map_err(Into::into)
+            }
+
+            fn apply_update_payload(
+                payload: &[u8],
+                prior: Option<&[u8]>,
+            ) -> Result<Vec<u8>, ComponentTypedError> {
+                apply_inbox_id_set_delta(payload, prior)
+            }
+
+            fn expand_to_changes(
+                op: &AppDataUpdateOperation,
+                prior: Option<&[u8]>,
+            ) -> Result<Vec<ExpandedComponentChange>, ComponentTypedError> {
+                expand_inbox_id_set_changes(op, prior)
+            }
+        }
+    };
+}
+
+inbox_id_set_component!(AdminListComponent, ComponentId::ADMIN_LIST);
+inbox_id_set_component!(SuperAdminListComponent, ComponentId::SUPER_ADMIN_LIST);
+inbox_id_set_component!(DmMembersComponent, ComponentId::DM_MEMBERS);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture_inbox_id(seed: u8) -> InboxId {
+        let mut bytes = [0u8; 32];
+        bytes[0] = seed;
+        InboxId::from_bytes(bytes)
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn round_trip_admin_list_value() {
+        let mut set = TlsSet::<InboxId>::new();
+        set.insert(fixture_inbox_id(1)).unwrap();
+        set.insert(fixture_inbox_id(2)).unwrap();
+        let bytes = AdminListComponent::encode_value(&set).unwrap();
+        let decoded = AdminListComponent::decode_value(&bytes).unwrap();
+        assert_eq!(decoded.len(), 2);
+        assert!(decoded.contains(&fixture_inbox_id(1)));
+        assert!(decoded.contains(&fixture_inbox_id(2)));
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn encode_mutation_serializes_full_delta() {
+        let delta = TlsSetDelta::<InboxId>::new().insert(fixture_inbox_id(7));
+        let bytes = AdminListComponent::encode_mutation(&delta).unwrap();
+        let round_trip = TlsSetDelta::<InboxId>::tls_deserialize_exact(&bytes).unwrap();
+        assert_eq!(round_trip.mutations.len(), 1);
+        match &round_trip.mutations[0] {
+            TlsSetMutation::Insert(id) => assert_eq!(*id, fixture_inbox_id(7)),
+            other => panic!("unexpected mutation: {other:?}"),
+        }
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn encode_mutation_supports_batched_delta() {
+        // The motivating case for delta-as-mutation: multiple
+        // changes in one proposal. e.g. promote two new admins and
+        // demote a third atomically.
+        let delta = TlsSetDelta::<InboxId>::new()
+            .insert(fixture_inbox_id(1))
+            .insert(fixture_inbox_id(2))
+            .remove(fixture_inbox_id(3));
+        let bytes = AdminListComponent::encode_mutation(&delta).unwrap();
+        let round_trip = TlsSetDelta::<InboxId>::tls_deserialize_exact(&bytes).unwrap();
+        assert_eq!(round_trip.mutations.len(), 3);
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn apply_insert_against_empty_prior() {
+        let delta = TlsSetDelta::<InboxId>::new().insert(fixture_inbox_id(3));
+        let payload = AdminListComponent::encode_mutation(&delta).unwrap();
+        let new_bytes = AdminListComponent::apply_update_payload(&payload, None).unwrap();
+        let new = AdminListComponent::decode_value(&new_bytes).unwrap();
+        assert_eq!(new.len(), 1);
+        assert!(new.contains(&fixture_inbox_id(3)));
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn apply_remove_against_existing_prior() {
+        // Build a prior with two members.
+        let mut prior_set = TlsSet::<InboxId>::new();
+        prior_set.insert(fixture_inbox_id(1)).unwrap();
+        prior_set.insert(fixture_inbox_id(2)).unwrap();
+        let prior_bytes = SuperAdminListComponent::encode_value(&prior_set).unwrap();
+
+        // Send a Remove(inbox_id_1) delta.
+        let delta = TlsSetDelta::<InboxId>::new().remove(fixture_inbox_id(1));
+        let payload = SuperAdminListComponent::encode_mutation(&delta).unwrap();
+
+        let new_bytes =
+            SuperAdminListComponent::apply_update_payload(&payload, Some(&prior_bytes)).unwrap();
+        let new = SuperAdminListComponent::decode_value(&new_bytes).unwrap();
+        assert_eq!(new.len(), 1);
+        assert!(new.contains(&fixture_inbox_id(2)));
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn apply_batched_delta_atomically() {
+        // Apply Insert(1) + Insert(2) + Remove(3) in one shot.
+        let mut prior_set = TlsSet::<InboxId>::new();
+        prior_set.insert(fixture_inbox_id(3)).unwrap();
+        let prior_bytes = AdminListComponent::encode_value(&prior_set).unwrap();
+
+        let delta = TlsSetDelta::<InboxId>::new()
+            .insert(fixture_inbox_id(1))
+            .insert(fixture_inbox_id(2))
+            .remove(fixture_inbox_id(3));
+        let payload = AdminListComponent::encode_mutation(&delta).unwrap();
+
+        let new_bytes =
+            AdminListComponent::apply_update_payload(&payload, Some(&prior_bytes)).unwrap();
+        let new = AdminListComponent::decode_value(&new_bytes).unwrap();
+        assert_eq!(new.len(), 2);
+        assert!(new.contains(&fixture_inbox_id(1)));
+        assert!(new.contains(&fixture_inbox_id(2)));
+        assert!(!new.contains(&fixture_inbox_id(3)));
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn expand_insert_yields_single_change() {
+        let delta = TlsSetDelta::<InboxId>::new().insert(fixture_inbox_id(5));
+        let payload = AdminListComponent::encode_mutation(&delta).unwrap();
+        let op = AppDataUpdateOperation::Update(payload.into());
+        let changes = AdminListComponent::expand_to_changes(&op, None).unwrap();
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].op, ComponentOp::Insert);
+        assert_eq!(
+            changes[0].value.as_deref(),
+            Some(&fixture_inbox_id(5).as_bytes()[..])
+        );
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn expand_batched_delta_yields_one_change_per_mutation() {
+        // Pinned: per-element validation iterates per-mutation, so a
+        // batched delta produces one ExpandedComponentChange per
+        // entry.
+        let delta = TlsSetDelta::<InboxId>::new()
+            .insert(fixture_inbox_id(10))
+            .insert(fixture_inbox_id(11))
+            .remove(fixture_inbox_id(12));
+        let payload = AdminListComponent::encode_mutation(&delta).unwrap();
+        let op = AppDataUpdateOperation::Update(payload.into());
+        let changes = AdminListComponent::expand_to_changes(&op, None).unwrap();
+        assert_eq!(changes.len(), 3);
+        assert_eq!(changes[0].op, ComponentOp::Insert);
+        assert_eq!(changes[1].op, ComponentOp::Insert);
+        assert_eq!(changes[2].op, ComponentOp::Delete);
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn expand_remove_by_hash_resolves_against_prior() {
+        let target = fixture_inbox_id(9);
+        let mut prior_set = TlsSet::<InboxId>::new();
+        prior_set.insert(target).unwrap();
+        let prior_bytes = AdminListComponent::encode_value(&prior_set).unwrap();
+
+        let target_hash = TlsKeyHash::of(&target).unwrap();
+        let delta = TlsSetDelta::<InboxId>::new().remove_by_hash(target_hash);
+        let payload = AdminListComponent::encode_mutation(&delta).unwrap();
+        let op = AppDataUpdateOperation::Update(payload.into());
+
+        let changes =
+            AdminListComponent::expand_to_changes(&op, Some(&prior_bytes)).unwrap();
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].op, ComponentOp::Delete);
+        assert_eq!(changes[0].value.as_deref(), Some(&target.as_bytes()[..]));
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn expand_remove_by_hash_with_no_prior_yields_unresolved() {
+        let target_hash = TlsKeyHash::of(&fixture_inbox_id(9)).unwrap();
+        let delta = TlsSetDelta::<InboxId>::new().remove_by_hash(target_hash);
+        let payload = AdminListComponent::encode_mutation(&delta).unwrap();
+        let op = AppDataUpdateOperation::Update(payload.into());
+
+        let changes = AdminListComponent::expand_to_changes(&op, None).unwrap();
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].op, ComponentOp::Delete);
+        assert!(changes[0].value.is_none());
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn apply_rejects_non_delta_payload() {
+        // The wire is always a `TlsSetDelta<InboxId>`, never a raw
+        // `TlsSet`. A bootstrap caller that mistakenly emitted a full
+        // set as the payload must surface as a decode failure, not
+        // silently overwrite the dict.
+        let mut set = TlsSet::<InboxId>::new();
+        set.insert(fixture_inbox_id(1)).unwrap();
+        let raw_set_bytes = set.tls_serialize_detached().unwrap();
+        let err = AdminListComponent::apply_update_payload(&raw_set_bytes, None).unwrap_err();
+        assert!(
+            matches!(err, ComponentTypedError::TlsCodec(_)),
+            "expected TlsCodec decode error for non-delta payload, got {err:?}"
+        );
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn dm_members_uses_same_codec() {
+        // Identical to admin_list — sanity check that the macro
+        // expansion works for the immutable-component variant too.
+        let mut set = TlsSet::<InboxId>::new();
+        set.insert(fixture_inbox_id(42)).unwrap();
+        let bytes = DmMembersComponent::encode_value(&set).unwrap();
+        let decoded = DmMembersComponent::decode_value(&bytes).unwrap();
+        assert!(decoded.contains(&fixture_inbox_id(42)));
+        assert_eq!(DmMembersComponent::COMPONENT_TYPE, ComponentType::TlsSetInboxId);
+    }
+}

--- a/crates/xmtp_mls_common/src/app_data/components/metadata_attributes.rs
+++ b/crates/xmtp_mls_common/src/app_data/components/metadata_attributes.rs
@@ -76,7 +76,7 @@ fn decode_be_i64(component_id: ComponentId, bytes: &[u8]) -> Result<i64, Compone
         .try_into()
         .map_err(|_| ComponentTypedError::MalformedValue {
             component_id,
-            reason: format!("expected 8 bytes (BE i64), got {}", bytes.len()),
+            reason: format!("expected 8 bytes (big-endian i64), got {}", bytes.len()),
         })?;
     Ok(i64::from_be_bytes(arr))
 }
@@ -411,10 +411,7 @@ mod tests {
             MessageDisappearInNsComponent::ID,
             ComponentId::MESSAGE_DISAPPEAR_IN_NS
         );
-        assert_eq!(
-            CommitLogSignerComponent::ID,
-            ComponentId::COMMIT_LOG_SIGNER
-        );
+        assert_eq!(CommitLogSignerComponent::ID, ComponentId::COMMIT_LOG_SIGNER);
     }
 
     #[xmtp_common::test(unwrap_try = true)]

--- a/crates/xmtp_mls_common/src/app_data/components/metadata_attributes.rs
+++ b/crates/xmtp_mls_common/src/app_data/components/metadata_attributes.rs
@@ -1,0 +1,436 @@
+//! [`Component`] impls for the eight `GroupMutableMetadata`-backed
+//! attribute components.
+//!
+//! Three flavours, distinguished by the typed `Value` they expose:
+//!
+//! - **String** (`GROUP_NAME`, `GROUP_DESCRIPTION`, `GROUP_IMAGE_URL`,
+//!   `APP_DATA`, `MIN_SUPPORTED_PROTOCOL_VERSION`): `Value = String`,
+//!   wire bytes are UTF-8.
+//! - **Big-endian `i64`** (`MESSAGE_DISAPPEAR_FROM_NS`,
+//!   `MESSAGE_DISAPPEAR_IN_NS`): `Value = i64`, wire bytes are exactly
+//!   8 bytes (`i64::to_be_bytes`). The legacy `GroupMutableMetadata`
+//!   path stringifies these as decimal; the AppData path uses the
+//!   binary representation directly so callers don't have to round-trip
+//!   through ASCII.
+//! - **Fixed-length signer key** (`COMMIT_LOG_SIGNER`):
+//!   `Value = xmtp_cryptography::Secret` (zeroized on drop) holding
+//!   exactly `ED25519_KEY_LENGTH` bytes — the raw Ed25519 private-key
+//!   material that the legacy path hex-encoded into a string. The
+//!   length is enforced at decode time; callers continue to handle a
+//!   `Secret` end-to-end without a hex round-trip.
+//!
+//! `AppDataUpdate::Update` payloads pass through verbatim after the
+//! component-specific length/UTF-8 validation, and there is no delta
+//! encoding.
+
+use openmls::messages::proposals::AppDataUpdateOperation;
+use xmtp_cryptography::{Secret, configuration::ED25519_KEY_LENGTH};
+use xmtp_proto::xmtp::mls::message_contents::ComponentType;
+
+use crate::app_data::{
+    component_id::ComponentId,
+    component_registry::ComponentOp,
+    typed::{Component, ComponentTypedError, ExpandedComponentChange},
+};
+
+/// Apply a passthrough Update payload — no delta math, the payload is
+/// the new full value bytes.
+fn apply_passthrough(payload: &[u8]) -> Result<Vec<u8>, ComponentTypedError> {
+    Ok(payload.to_vec())
+}
+
+/// Expand an `AppDataUpdate` proposal for a passthrough component:
+/// `Update` produces one `Update` change carrying the payload bytes;
+/// `Remove` produces one `Delete` change with no value.
+fn expand_passthrough(
+    op: &AppDataUpdateOperation,
+) -> Result<Vec<ExpandedComponentChange>, ComponentTypedError> {
+    match op {
+        AppDataUpdateOperation::Update(payload) => Ok(vec![ExpandedComponentChange {
+            op: ComponentOp::Update,
+            value: Some(payload.as_slice().to_vec()),
+        }]),
+        AppDataUpdateOperation::Remove => Ok(vec![ExpandedComponentChange {
+            op: ComponentOp::Delete,
+            value: None,
+        }]),
+    }
+}
+
+/// Decode UTF-8 bytes into a `String`, surfacing a structured
+/// [`ComponentTypedError::MalformedValue`] on invalid input rather than
+/// the bare `Utf8Error`.
+fn decode_utf8(component_id: ComponentId, bytes: &[u8]) -> Result<String, ComponentTypedError> {
+    std::str::from_utf8(bytes)
+        .map(str::to_owned)
+        .map_err(|err| ComponentTypedError::MalformedValue {
+            component_id,
+            reason: format!("not valid UTF-8: {err}"),
+        })
+}
+
+/// Decode an 8-byte big-endian `i64`, surfacing
+/// [`ComponentTypedError::MalformedValue`] on length mismatch.
+fn decode_be_i64(component_id: ComponentId, bytes: &[u8]) -> Result<i64, ComponentTypedError> {
+    let arr: [u8; 8] = bytes
+        .try_into()
+        .map_err(|_| ComponentTypedError::MalformedValue {
+            component_id,
+            reason: format!("expected 8 bytes (BE i64), got {}", bytes.len()),
+        })?;
+    Ok(i64::from_be_bytes(arr))
+}
+
+/// Validate a byte slice has the expected fixed length, surfacing
+/// [`ComponentTypedError::MalformedValue`] on mismatch.
+fn require_exact_len(
+    component_id: ComponentId,
+    bytes: &[u8],
+    expected: usize,
+) -> Result<(), ComponentTypedError> {
+    if bytes.len() != expected {
+        return Err(ComponentTypedError::MalformedValue {
+            component_id,
+            reason: format!("expected {} bytes, got {}", expected, bytes.len()),
+        });
+    }
+    Ok(())
+}
+
+/// Internal macro for declaring a passthrough metadata-attribute
+/// component impl.
+///
+/// Each invocation produces a unit struct + `Component` impl. The
+/// `decode_value` / `encode_value` / `encode_mutation` bodies vary
+/// between the `String` and `Bytes` shapes, so the macro takes them as
+/// arms.
+///
+/// The macro stays internal (`macro_rules!` with no `pub` attribute) —
+/// it's a within-this-file convenience, not a public API.
+macro_rules! passthrough_string_component {
+    ($struct_name:ident, $id:expr) => {
+        pub struct $struct_name;
+
+        impl Component for $struct_name {
+            const ID: ComponentId = $id;
+            const COMPONENT_TYPE: ComponentType = ComponentType::String;
+            type Value = String;
+            type Mutation = String;
+
+            fn decode_value(bytes: &[u8]) -> Result<Self::Value, ComponentTypedError> {
+                decode_utf8(Self::ID, bytes)
+            }
+
+            fn encode_value(value: &Self::Value) -> Result<Vec<u8>, ComponentTypedError> {
+                Ok(value.as_bytes().to_vec())
+            }
+
+            fn encode_mutation(mutation: &Self::Mutation) -> Result<Vec<u8>, ComponentTypedError> {
+                Ok(mutation.as_bytes().to_vec())
+            }
+
+            fn apply_update_payload(
+                payload: &[u8],
+                _prior: Option<&[u8]>,
+            ) -> Result<Vec<u8>, ComponentTypedError> {
+                apply_passthrough(payload)
+            }
+
+            fn expand_to_changes(
+                op: &AppDataUpdateOperation,
+                _prior: Option<&[u8]>,
+            ) -> Result<Vec<ExpandedComponentChange>, ComponentTypedError> {
+                expand_passthrough(op)
+            }
+        }
+    };
+}
+
+/// Internal macro for the two `i64` disappearance-window components.
+/// Both share the wire shape (8-byte BE) and only differ in their ID.
+macro_rules! be_i64_component {
+    ($struct_name:ident, $id:expr) => {
+        pub struct $struct_name;
+
+        impl Component for $struct_name {
+            const ID: ComponentId = $id;
+            const COMPONENT_TYPE: ComponentType = ComponentType::Bytes;
+            type Value = i64;
+            type Mutation = i64;
+
+            fn decode_value(bytes: &[u8]) -> Result<Self::Value, ComponentTypedError> {
+                decode_be_i64(Self::ID, bytes)
+            }
+
+            fn encode_value(value: &Self::Value) -> Result<Vec<u8>, ComponentTypedError> {
+                Ok(value.to_be_bytes().to_vec())
+            }
+
+            fn encode_mutation(mutation: &Self::Mutation) -> Result<Vec<u8>, ComponentTypedError> {
+                Ok(mutation.to_be_bytes().to_vec())
+            }
+
+            fn apply_update_payload(
+                payload: &[u8],
+                _prior: Option<&[u8]>,
+            ) -> Result<Vec<u8>, ComponentTypedError> {
+                // Validate length+shape and pass through.
+                let _ = decode_be_i64(Self::ID, payload)?;
+                Ok(payload.to_vec())
+            }
+
+            fn expand_to_changes(
+                op: &AppDataUpdateOperation,
+                _prior: Option<&[u8]>,
+            ) -> Result<Vec<ExpandedComponentChange>, ComponentTypedError> {
+                match op {
+                    AppDataUpdateOperation::Update(payload) => {
+                        let _ = decode_be_i64(Self::ID, payload.as_slice())?;
+                        Ok(vec![ExpandedComponentChange {
+                            op: ComponentOp::Update,
+                            value: Some(payload.as_slice().to_vec()),
+                        }])
+                    }
+                    AppDataUpdateOperation::Remove => Ok(vec![ExpandedComponentChange {
+                        op: ComponentOp::Delete,
+                        value: None,
+                    }]),
+                }
+            }
+        }
+    };
+}
+
+passthrough_string_component!(GroupNameComponent, ComponentId::GROUP_NAME);
+passthrough_string_component!(GroupDescriptionComponent, ComponentId::GROUP_DESCRIPTION);
+passthrough_string_component!(GroupImageUrlComponent, ComponentId::GROUP_IMAGE_URL);
+passthrough_string_component!(AppDataComponent, ComponentId::APP_DATA);
+passthrough_string_component!(
+    MinSupportedProtocolVersionComponent,
+    ComponentId::MIN_SUPPORTED_PROTOCOL_VERSION
+);
+
+be_i64_component!(
+    MessageDisappearFromNsComponent,
+    ComponentId::MESSAGE_DISAPPEAR_FROM_NS
+);
+be_i64_component!(
+    MessageDisappearInNsComponent,
+    ComponentId::MESSAGE_DISAPPEAR_IN_NS
+);
+
+/// `Component` impl for the `COMMIT_LOG_SIGNER` component.
+///
+/// The decoded value is an [`xmtp_cryptography::Secret`] holding
+/// exactly `ED25519_KEY_LENGTH` bytes — the raw Ed25519 private-key
+/// material. The length is enforced at decode time so callers can
+/// always treat the resulting `Secret` as a 32-byte key.
+pub struct CommitLogSignerComponent;
+
+impl Component for CommitLogSignerComponent {
+    const ID: ComponentId = ComponentId::COMMIT_LOG_SIGNER;
+    const COMPONENT_TYPE: ComponentType = ComponentType::Bytes;
+    type Value = Secret;
+    type Mutation = Secret;
+
+    fn decode_value(bytes: &[u8]) -> Result<Self::Value, ComponentTypedError> {
+        require_exact_len(Self::ID, bytes, ED25519_KEY_LENGTH)?;
+        Ok(Secret::new(bytes.to_vec()))
+    }
+
+    fn encode_value(value: &Self::Value) -> Result<Vec<u8>, ComponentTypedError> {
+        require_exact_len(Self::ID, value.as_slice(), ED25519_KEY_LENGTH)?;
+        Ok(value.as_slice().to_vec())
+    }
+
+    fn encode_mutation(mutation: &Self::Mutation) -> Result<Vec<u8>, ComponentTypedError> {
+        require_exact_len(Self::ID, mutation.as_slice(), ED25519_KEY_LENGTH)?;
+        Ok(mutation.as_slice().to_vec())
+    }
+
+    fn apply_update_payload(
+        payload: &[u8],
+        _prior: Option<&[u8]>,
+    ) -> Result<Vec<u8>, ComponentTypedError> {
+        require_exact_len(Self::ID, payload, ED25519_KEY_LENGTH)?;
+        Ok(payload.to_vec())
+    }
+
+    fn expand_to_changes(
+        op: &AppDataUpdateOperation,
+        _prior: Option<&[u8]>,
+    ) -> Result<Vec<ExpandedComponentChange>, ComponentTypedError> {
+        match op {
+            AppDataUpdateOperation::Update(payload) => {
+                require_exact_len(Self::ID, payload.as_slice(), ED25519_KEY_LENGTH)?;
+                Ok(vec![ExpandedComponentChange {
+                    op: ComponentOp::Update,
+                    value: Some(payload.as_slice().to_vec()),
+                }])
+            }
+            AppDataUpdateOperation::Remove => Ok(vec![ExpandedComponentChange {
+                op: ComponentOp::Delete,
+                value: None,
+            }]),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openmls::messages::proposals::AppDataUpdateOperation;
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn string_component_round_trip() {
+        let name = String::from("Test Group 🚀");
+        let bytes = GroupNameComponent::encode_value(&name).unwrap();
+        let decoded = GroupNameComponent::decode_value(&bytes).unwrap();
+        assert_eq!(decoded, name);
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn string_component_decode_rejects_non_utf8() {
+        let bytes = vec![0xff, 0xfe, 0xfd];
+        let err = GroupDescriptionComponent::decode_value(&bytes).unwrap_err();
+        match err {
+            ComponentTypedError::MalformedValue { component_id, .. } => {
+                assert_eq!(component_id, ComponentId::GROUP_DESCRIPTION);
+            }
+            other => panic!("expected MalformedValue, got {other:?}"),
+        }
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn commit_log_signer_round_trip() {
+        let key = Secret::new(vec![0xAB; ED25519_KEY_LENGTH]);
+        let bytes = CommitLogSignerComponent::encode_value(&key).unwrap();
+        assert_eq!(bytes.len(), ED25519_KEY_LENGTH);
+        let decoded = CommitLogSignerComponent::decode_value(&bytes).unwrap();
+        assert_eq!(decoded.as_slice(), key.as_slice());
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn commit_log_signer_rejects_wrong_length() {
+        let too_short = vec![0u8; ED25519_KEY_LENGTH - 1];
+        let err = CommitLogSignerComponent::decode_value(&too_short).unwrap_err();
+        match err {
+            ComponentTypedError::MalformedValue { component_id, .. } => {
+                assert_eq!(component_id, ComponentId::COMMIT_LOG_SIGNER);
+            }
+            other => panic!("expected MalformedValue, got {other:?}"),
+        }
+        // Encoding a Secret that doesn't hold exactly 32 bytes also rejects.
+        let wrong = Secret::new(vec![0u8; ED25519_KEY_LENGTH + 1]);
+        let err = CommitLogSignerComponent::encode_value(&wrong).unwrap_err();
+        assert!(matches!(err, ComponentTypedError::MalformedValue { .. }));
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn message_disappear_round_trip() {
+        // Use a value that exercises sign-extension: large negative i64.
+        let v: i64 = -1_234_567_890_123;
+        let bytes = MessageDisappearFromNsComponent::encode_value(&v).unwrap();
+        assert_eq!(bytes.len(), 8);
+        let decoded = MessageDisappearFromNsComponent::decode_value(&bytes).unwrap();
+        assert_eq!(decoded, v);
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn message_disappear_rejects_wrong_length() {
+        // Catches a sender that emitted decimal-stringified bytes
+        // (e.g. b"3600000000000") under the legacy convention.
+        let ascii_decimal = b"3600000000000";
+        let err = MessageDisappearInNsComponent::decode_value(ascii_decimal).unwrap_err();
+        match err {
+            ComponentTypedError::MalformedValue { component_id, .. } => {
+                assert_eq!(component_id, ComponentId::MESSAGE_DISAPPEAR_IN_NS);
+            }
+            other => panic!("expected MalformedValue, got {other:?}"),
+        }
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn apply_update_passthrough() {
+        // String component still passes payloads through verbatim.
+        let payload = b"new value";
+        let new = GroupNameComponent::apply_update_payload(payload, Some(b"old")).unwrap();
+        assert_eq!(new, payload);
+
+        // i64 components validate the length-and-shape but pass the
+        // bytes through unchanged so receivers don't re-encode.
+        let valid = 42_i64.to_be_bytes();
+        let new = MessageDisappearInNsComponent::apply_update_payload(&valid, None).unwrap();
+        assert_eq!(new.as_slice(), valid.as_slice());
+
+        let err =
+            MessageDisappearInNsComponent::apply_update_payload(b"not 8 bytes", None).unwrap_err();
+        assert!(matches!(err, ComponentTypedError::MalformedValue { .. }));
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn expand_update_yields_one_change() {
+        let payload = b"hello".to_vec();
+        let op = AppDataUpdateOperation::Update(payload.clone().into());
+        let changes = GroupNameComponent::expand_to_changes(&op, None).unwrap();
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].op, ComponentOp::Update);
+        assert_eq!(changes[0].value.as_deref(), Some(payload.as_slice()));
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn expand_remove_yields_delete_with_no_value() {
+        let op = AppDataUpdateOperation::Remove;
+        let changes = AppDataComponent::expand_to_changes(&op, None).unwrap();
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].op, ComponentOp::Delete);
+        assert!(changes[0].value.is_none());
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn component_id_constants_match_static_id() {
+        // Sanity check that each component reports its own ID via the
+        // trait — a copy-paste error in the macro invocations would
+        // surface here.
+        assert_eq!(GroupNameComponent::ID, ComponentId::GROUP_NAME);
+        assert_eq!(
+            GroupDescriptionComponent::ID,
+            ComponentId::GROUP_DESCRIPTION
+        );
+        assert_eq!(GroupImageUrlComponent::ID, ComponentId::GROUP_IMAGE_URL);
+        assert_eq!(AppDataComponent::ID, ComponentId::APP_DATA);
+        assert_eq!(
+            MinSupportedProtocolVersionComponent::ID,
+            ComponentId::MIN_SUPPORTED_PROTOCOL_VERSION
+        );
+        assert_eq!(
+            MessageDisappearFromNsComponent::ID,
+            ComponentId::MESSAGE_DISAPPEAR_FROM_NS
+        );
+        assert_eq!(
+            MessageDisappearInNsComponent::ID,
+            ComponentId::MESSAGE_DISAPPEAR_IN_NS
+        );
+        assert_eq!(
+            CommitLogSignerComponent::ID,
+            ComponentId::COMMIT_LOG_SIGNER
+        );
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn component_types_are_correct() {
+        assert_eq!(GroupNameComponent::COMPONENT_TYPE, ComponentType::String);
+        assert_eq!(
+            CommitLogSignerComponent::COMPONENT_TYPE,
+            ComponentType::Bytes
+        );
+        assert_eq!(
+            MessageDisappearFromNsComponent::COMPONENT_TYPE,
+            ComponentType::Bytes
+        );
+        assert_eq!(
+            MinSupportedProtocolVersionComponent::COMPONENT_TYPE,
+            ComponentType::String
+        );
+    }
+}

--- a/crates/xmtp_mls_common/src/app_data/components/mod.rs
+++ b/crates/xmtp_mls_common/src/app_data/components/mod.rs
@@ -8,4 +8,6 @@
 //!   2. Add it to the `WELL_KNOWN` array in
 //!      [`super::registry_table`].
 
+pub mod inbox_id_set;
 pub mod metadata_attributes;
+pub mod tls_map_components;

--- a/crates/xmtp_mls_common/src/app_data/components/mod.rs
+++ b/crates/xmtp_mls_common/src/app_data/components/mod.rs
@@ -1,0 +1,11 @@
+//! Concrete [`Component`](super::typed::Component) impls for every
+//! well-known XMTP component id. One submodule per family of
+//! identically-shaped components (Bytes/String metadata attributes share
+//! a module; the heterogeneous Set/Map components each get their own).
+//!
+//! Adding a new well-known component is two steps:
+//!   1. Add a unit-struct impl here under the appropriate submodule.
+//!   2. Add it to the `WELL_KNOWN` array in
+//!      [`super::registry_table`].
+
+pub mod metadata_attributes;

--- a/crates/xmtp_mls_common/src/app_data/components/tls_map_components.rs
+++ b/crates/xmtp_mls_common/src/app_data/components/tls_map_components.rs
@@ -1,0 +1,418 @@
+//! [`Component`] impls for the two `TlsMap`-shaped components:
+//! [`GroupMembershipComponent`] (`GROUP_MEMBERSHIP`, key: [`InboxId`])
+//! and [`ComponentRegistryComponent`] (`COMPONENT_REGISTRY`, key:
+//! [`ComponentId`]).
+//!
+//! Both store their value as `TlsMap<K, VLBytes>` where the inner
+//! `VLBytes` payload is opaque to this layer:
+//!
+//! - `GROUP_MEMBERSHIP` value bytes are prost-encoded
+//!   [`GroupMembershipEntryV1`](xmtp_proto::xmtp::mls::message_contents::GroupMembershipEntry)
+//!   blobs; downstream consumers decode them after reading.
+//! - `COMPONENT_REGISTRY` value bytes are prost-encoded
+//!   [`ComponentMetadata`](xmtp_proto::xmtp::mls::message_contents::ComponentMetadata)
+//!   blobs.
+//!
+//! `Update` payloads are encoded as
+//! [`TlsMapDelta<K, VLBytes>`](crate::tls_map::TlsMapDelta) — single
+//! mutation per `AppDataUpdate` proposal at the steady-state path
+//! (UpdatePermission inserts/updates one registry entry; group
+//! membership updates one inbox at a time).
+
+use openmls::messages::proposals::AppDataUpdateOperation;
+use tls_codec::{Deserialize, Serialize, VLBytes};
+use xmtp_proto::xmtp::mls::message_contents::ComponentType;
+
+use crate::{
+    app_data::{
+        component_id::ComponentId,
+        component_registry::ComponentOp,
+        typed::{Component, ComponentTypedError, ExpandedComponentChange},
+    },
+    inbox_id::InboxId,
+    tls_map::{TlsMap, TlsMapDelta, TlsMapMutation},
+};
+
+/// Apply a `TlsMapDelta<K, VLBytes>` wire payload over the prior dict
+/// bytes (a `TlsMap<K, VLBytes>` snapshot, or `None` if this is the
+/// first write — bootstrap, where prior state is empty).
+///
+/// Returns the new dict bytes: the re-serialized `TlsMap<K, VLBytes>`
+/// snapshot. The dict always holds the raw map as state; the wire
+/// always carries a delta describing the change. This function is
+/// the one boundary that translates between them.
+///
+/// Generic over the key type so both `InboxId`-keyed and
+/// `ComponentId`-keyed maps share the same body.
+fn apply_tls_map_delta<K>(
+    payload: &[u8],
+    prior: Option<&[u8]>,
+) -> Result<Vec<u8>, ComponentTypedError>
+where
+    K: tls_codec::Serialize
+        + tls_codec::Deserialize
+        + tls_codec::Size
+        + Ord
+        + Eq
+        + Clone
+        + std::fmt::Debug,
+{
+    let delta = TlsMapDelta::<K, VLBytes>::tls_deserialize_exact(payload)?;
+    let mut map: TlsMap<K, VLBytes> = match prior {
+        Some(bytes) => TlsMap::<K, VLBytes>::tls_deserialize_exact(bytes)?,
+        None => TlsMap::new(),
+    };
+    map.apply_delta(delta)?;
+    Ok(map.tls_serialize_detached()?)
+}
+
+/// Expand a `TlsMap`-shape `AppDataUpdate` proposal into per-mutation
+/// `ExpandedComponentChange` entries.
+///
+/// Convention for `value` field on the emitted changes:
+/// - `Insert(_, v)` and `Update(_, v)` carry the new value bytes
+///   (`v.as_slice().to_vec()`) — this is what change-aware policies
+///   would inspect.
+/// - `Delete(k)` carries the key bytes via `K::tls_serialize_detached`,
+///   matching the `TlsSet` expand convention where the value field
+///   identifies the affected element.
+///
+/// `prior` is currently unused — Map components don't have a
+/// `RemoveByHash` analogue (deletes carry the literal key on the
+/// wire). Kept in the signature for trait-shape uniformity.
+fn expand_tls_map_changes<K>(
+    op: &AppDataUpdateOperation,
+    _prior: Option<&[u8]>,
+) -> Result<Vec<ExpandedComponentChange>, ComponentTypedError>
+where
+    K: tls_codec::Serialize + tls_codec::Deserialize + tls_codec::Size,
+{
+    match op {
+        AppDataUpdateOperation::Remove => Ok(vec![ExpandedComponentChange {
+            op: ComponentOp::Delete,
+            value: None,
+        }]),
+        AppDataUpdateOperation::Update(payload) => {
+            let delta = TlsMapDelta::<K, VLBytes>::tls_deserialize_exact(payload.as_slice())?;
+            let mut out = Vec::with_capacity(delta.mutations.len());
+            for mutation in delta.mutations {
+                match mutation {
+                    TlsMapMutation::Insert { value, .. } => out.push(ExpandedComponentChange {
+                        op: ComponentOp::Insert,
+                        value: Some(value.as_slice().to_vec()),
+                    }),
+                    TlsMapMutation::Update { value, .. } => out.push(ExpandedComponentChange {
+                        op: ComponentOp::Update,
+                        value: Some(value.as_slice().to_vec()),
+                    }),
+                    TlsMapMutation::Delete { key } => {
+                        let key_bytes = key.tls_serialize_detached()?;
+                        out.push(ExpandedComponentChange {
+                            op: ComponentOp::Delete,
+                            value: Some(key_bytes),
+                        });
+                    }
+                }
+            }
+            Ok(out)
+        }
+    }
+}
+
+// ============================================================================
+// GROUP_MEMBERSHIP — TlsMap<InboxId, VLBytes>
+// ============================================================================
+
+/// `Component` impl for the `GROUP_MEMBERSHIP` component.
+///
+/// The decoded value is a `TlsMap<InboxId, VLBytes>` where each value
+/// is the prost-encoded
+/// [`GroupMembershipEntryV1`](xmtp_proto::xmtp::mls::message_contents::GroupMembershipEntry)
+/// for that member. This impl handles only the wire codec; entry
+/// content is decoded by the caller.
+pub struct GroupMembershipComponent;
+
+impl Component for GroupMembershipComponent {
+    const ID: ComponentId = ComponentId::GROUP_MEMBERSHIP;
+    const COMPONENT_TYPE: ComponentType = ComponentType::TlsMapInboxIdBytes;
+    type Value = TlsMap<InboxId, VLBytes>;
+    // The mutation type is the full wire-level delta. Group
+    // membership updates need to be atomic — every installation
+    // change for an inbox (additions, removals, sequence-id bumps)
+    // must travel as one proposal so receivers apply them together.
+    type Mutation = TlsMapDelta<InboxId, VLBytes>;
+
+    fn decode_value(bytes: &[u8]) -> Result<Self::Value, ComponentTypedError> {
+        TlsMap::<InboxId, VLBytes>::tls_deserialize_exact(bytes).map_err(Into::into)
+    }
+
+    fn encode_value(value: &Self::Value) -> Result<Vec<u8>, ComponentTypedError> {
+        value.tls_serialize_detached().map_err(Into::into)
+    }
+
+    fn encode_mutation(mutation: &Self::Mutation) -> Result<Vec<u8>, ComponentTypedError> {
+        mutation.tls_serialize_detached().map_err(Into::into)
+    }
+
+    fn apply_update_payload(
+        payload: &[u8],
+        prior: Option<&[u8]>,
+    ) -> Result<Vec<u8>, ComponentTypedError> {
+        apply_tls_map_delta::<InboxId>(payload, prior)
+    }
+
+    fn expand_to_changes(
+        op: &AppDataUpdateOperation,
+        prior: Option<&[u8]>,
+    ) -> Result<Vec<ExpandedComponentChange>, ComponentTypedError> {
+        expand_tls_map_changes::<InboxId>(op, prior)
+    }
+}
+
+// ============================================================================
+// COMPONENT_REGISTRY — TlsMap<ComponentId, VLBytes>
+// ============================================================================
+
+/// `Component` impl for the `COMPONENT_REGISTRY` component.
+///
+/// The decoded value is a `TlsMap<ComponentId, VLBytes>` where each
+/// value is the prost-encoded
+/// [`ComponentMetadata`](xmtp_proto::xmtp::mls::message_contents::ComponentMetadata)
+/// describing one registered component.
+pub struct ComponentRegistryComponent;
+
+impl Component for ComponentRegistryComponent {
+    const ID: ComponentId = ComponentId::COMPONENT_REGISTRY;
+    const COMPONENT_TYPE: ComponentType = ComponentType::TlsMapBytesBytes;
+    type Value = TlsMap<ComponentId, VLBytes>;
+    // The mutation type is the full wire-level delta so a single
+    // proposal can register/update/remove multiple component
+    // entries atomically (e.g. bulk-registering custom components).
+    type Mutation = TlsMapDelta<ComponentId, VLBytes>;
+
+    fn decode_value(bytes: &[u8]) -> Result<Self::Value, ComponentTypedError> {
+        TlsMap::<ComponentId, VLBytes>::tls_deserialize_exact(bytes).map_err(Into::into)
+    }
+
+    fn encode_value(value: &Self::Value) -> Result<Vec<u8>, ComponentTypedError> {
+        value.tls_serialize_detached().map_err(Into::into)
+    }
+
+    fn encode_mutation(mutation: &Self::Mutation) -> Result<Vec<u8>, ComponentTypedError> {
+        mutation.tls_serialize_detached().map_err(Into::into)
+    }
+
+    fn apply_update_payload(
+        payload: &[u8],
+        prior: Option<&[u8]>,
+    ) -> Result<Vec<u8>, ComponentTypedError> {
+        apply_tls_map_delta::<ComponentId>(payload, prior)
+    }
+
+    fn expand_to_changes(
+        op: &AppDataUpdateOperation,
+        prior: Option<&[u8]>,
+    ) -> Result<Vec<ExpandedComponentChange>, ComponentTypedError> {
+        expand_tls_map_changes::<ComponentId>(op, prior)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture_inbox_id(seed: u8) -> InboxId {
+        let mut bytes = [0u8; 32];
+        bytes[0] = seed;
+        InboxId::from_bytes(bytes)
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn group_membership_round_trip_value() {
+        let mut map: TlsMap<InboxId, VLBytes> = TlsMap::new();
+        map.insert(fixture_inbox_id(1), VLBytes::new(b"member1-blob".to_vec()))
+            .unwrap();
+        let bytes = GroupMembershipComponent::encode_value(&map).unwrap();
+        let decoded = GroupMembershipComponent::decode_value(&bytes).unwrap();
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(
+            decoded.get(&fixture_inbox_id(1)).unwrap().as_slice(),
+            b"member1-blob"
+        );
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn group_membership_apply_insert_against_empty() {
+        let delta = TlsMapDelta::<InboxId, VLBytes>::new()
+            .insert(fixture_inbox_id(2), VLBytes::new(b"v".to_vec()));
+        let payload = GroupMembershipComponent::encode_mutation(&delta).unwrap();
+        let new_bytes = GroupMembershipComponent::apply_update_payload(&payload, None).unwrap();
+        let new = GroupMembershipComponent::decode_value(&new_bytes).unwrap();
+        assert_eq!(new.len(), 1);
+        assert_eq!(new.get(&fixture_inbox_id(2)).unwrap().as_slice(), b"v");
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn group_membership_apply_update_against_existing() {
+        let mut prior_map: TlsMap<InboxId, VLBytes> = TlsMap::new();
+        prior_map
+            .insert(fixture_inbox_id(3), VLBytes::new(b"old".to_vec()))
+            .unwrap();
+        let prior_bytes = GroupMembershipComponent::encode_value(&prior_map).unwrap();
+
+        let delta = TlsMapDelta::<InboxId, VLBytes>::new()
+            .update(fixture_inbox_id(3), VLBytes::new(b"new".to_vec()));
+        let payload = GroupMembershipComponent::encode_mutation(&delta).unwrap();
+        let new_bytes =
+            GroupMembershipComponent::apply_update_payload(&payload, Some(&prior_bytes)).unwrap();
+        let new = GroupMembershipComponent::decode_value(&new_bytes).unwrap();
+        assert_eq!(new.get(&fixture_inbox_id(3)).unwrap().as_slice(), b"new");
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn group_membership_apply_batched_delta_atomically() {
+        // The motivating case for delta-as-mutation: all
+        // installation changes for an inbox in one proposal —
+        // sequence-id bump on member 1, new member 2, removed
+        // member 3 land atomically.
+        let mut prior_map: TlsMap<InboxId, VLBytes> = TlsMap::new();
+        prior_map
+            .insert(fixture_inbox_id(1), VLBytes::new(b"seq=5".to_vec()))
+            .unwrap();
+        prior_map
+            .insert(fixture_inbox_id(3), VLBytes::new(b"to-remove".to_vec()))
+            .unwrap();
+        let prior_bytes = GroupMembershipComponent::encode_value(&prior_map).unwrap();
+
+        let delta = TlsMapDelta::<InboxId, VLBytes>::new()
+            .update(fixture_inbox_id(1), VLBytes::new(b"seq=7".to_vec()))
+            .insert(fixture_inbox_id(2), VLBytes::new(b"seq=1".to_vec()))
+            .delete(fixture_inbox_id(3));
+        let payload = GroupMembershipComponent::encode_mutation(&delta).unwrap();
+        let new_bytes =
+            GroupMembershipComponent::apply_update_payload(&payload, Some(&prior_bytes)).unwrap();
+        let new = GroupMembershipComponent::decode_value(&new_bytes).unwrap();
+
+        assert_eq!(new.len(), 2);
+        assert_eq!(new.get(&fixture_inbox_id(1)).unwrap().as_slice(), b"seq=7");
+        assert_eq!(new.get(&fixture_inbox_id(2)).unwrap().as_slice(), b"seq=1");
+        assert!(new.get(&fixture_inbox_id(3)).is_none());
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn group_membership_expand_insert_carries_value_bytes() {
+        let delta = TlsMapDelta::<InboxId, VLBytes>::new()
+            .insert(fixture_inbox_id(4), VLBytes::new(b"new-member".to_vec()));
+        let payload = GroupMembershipComponent::encode_mutation(&delta).unwrap();
+        let op = AppDataUpdateOperation::Update(payload.into());
+        let changes = GroupMembershipComponent::expand_to_changes(&op, None).unwrap();
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].op, ComponentOp::Insert);
+        assert_eq!(changes[0].value.as_deref(), Some(&b"new-member"[..]));
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn group_membership_expand_delete_carries_key_bytes() {
+        let delta = TlsMapDelta::<InboxId, VLBytes>::new().delete(fixture_inbox_id(5));
+        let payload = GroupMembershipComponent::encode_mutation(&delta).unwrap();
+        let op = AppDataUpdateOperation::Update(payload.into());
+        let changes = GroupMembershipComponent::expand_to_changes(&op, None).unwrap();
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].op, ComponentOp::Delete);
+        // The value field carries the TLS-encoded key for context.
+        assert!(changes[0].value.is_some());
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn group_membership_expand_batched_yields_one_per_mutation() {
+        let delta = TlsMapDelta::<InboxId, VLBytes>::new()
+            .update(fixture_inbox_id(1), VLBytes::new(b"v1".to_vec()))
+            .insert(fixture_inbox_id(2), VLBytes::new(b"v2".to_vec()))
+            .delete(fixture_inbox_id(3));
+        let payload = GroupMembershipComponent::encode_mutation(&delta).unwrap();
+        let op = AppDataUpdateOperation::Update(payload.into());
+        let changes = GroupMembershipComponent::expand_to_changes(&op, None).unwrap();
+        assert_eq!(changes.len(), 3);
+        assert_eq!(changes[0].op, ComponentOp::Update);
+        assert_eq!(changes[1].op, ComponentOp::Insert);
+        assert_eq!(changes[2].op, ComponentOp::Delete);
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn component_registry_round_trip() {
+        let mut map: TlsMap<ComponentId, VLBytes> = TlsMap::new();
+        map.insert(ComponentId::ADMIN_LIST, VLBytes::new(b"meta-bytes".to_vec()))
+            .unwrap();
+        let bytes = ComponentRegistryComponent::encode_value(&map).unwrap();
+        let decoded = ComponentRegistryComponent::decode_value(&bytes).unwrap();
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(
+            decoded.get(&ComponentId::ADMIN_LIST).unwrap().as_slice(),
+            b"meta-bytes"
+        );
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn component_registry_apply_update_replaces_metadata() {
+        let mut prior_map: TlsMap<ComponentId, VLBytes> = TlsMap::new();
+        prior_map
+            .insert(ComponentId::GROUP_NAME, VLBytes::new(b"old-policy".to_vec()))
+            .unwrap();
+        let prior_bytes = ComponentRegistryComponent::encode_value(&prior_map).unwrap();
+
+        let delta = TlsMapDelta::<ComponentId, VLBytes>::new()
+            .update(ComponentId::GROUP_NAME, VLBytes::new(b"new-policy".to_vec()));
+        let payload = ComponentRegistryComponent::encode_mutation(&delta).unwrap();
+        let new_bytes =
+            ComponentRegistryComponent::apply_update_payload(&payload, Some(&prior_bytes)).unwrap();
+        let new = ComponentRegistryComponent::decode_value(&new_bytes).unwrap();
+        assert_eq!(
+            new.get(&ComponentId::GROUP_NAME).unwrap().as_slice(),
+            b"new-policy"
+        );
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn component_registry_apply_batched_delta_atomically() {
+        // Bulk-register two custom components in one proposal.
+        let delta = TlsMapDelta::<ComponentId, VLBytes>::new()
+            .insert(ComponentId::new(0xC100), VLBytes::new(b"meta1".to_vec()))
+            .insert(ComponentId::new(0xC101), VLBytes::new(b"meta2".to_vec()));
+        let payload = ComponentRegistryComponent::encode_mutation(&delta).unwrap();
+        let new_bytes = ComponentRegistryComponent::apply_update_payload(&payload, None).unwrap();
+        let new = ComponentRegistryComponent::decode_value(&new_bytes).unwrap();
+        assert_eq!(new.len(), 2);
+        assert!(new.get(&ComponentId::new(0xC100)).is_some());
+        assert!(new.get(&ComponentId::new(0xC101)).is_some());
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn apply_rejects_non_delta_payload() {
+        // The wire is always a `TlsMapDelta`, never a raw `TlsMap`.
+        // A caller that mistakenly emitted a snapshot as the payload
+        // must surface as a decode failure, not silently overwrite
+        // the dict.
+        let mut map: TlsMap<InboxId, VLBytes> = TlsMap::new();
+        map.insert(fixture_inbox_id(1), VLBytes::new(b"v1".to_vec()))
+            .unwrap();
+        let raw_map_bytes = map.tls_serialize_detached().unwrap();
+        let err =
+            GroupMembershipComponent::apply_update_payload(&raw_map_bytes, None).unwrap_err();
+        assert!(
+            matches!(err, ComponentTypedError::TlsCodec(_)),
+            "expected TlsCodec decode error for non-delta payload, got {err:?}"
+        );
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn component_types_are_correct() {
+        assert_eq!(
+            GroupMembershipComponent::COMPONENT_TYPE,
+            ComponentType::TlsMapInboxIdBytes
+        );
+        assert_eq!(
+            ComponentRegistryComponent::COMPONENT_TYPE,
+            ComponentType::TlsMapBytesBytes
+        );
+    }
+}

--- a/crates/xmtp_mls_common/src/app_data/components/tls_map_components.rs
+++ b/crates/xmtp_mls_common/src/app_data/components/tls_map_components.rs
@@ -80,6 +80,19 @@ where
 /// `prior` is currently unused — Map components don't have a
 /// `RemoveByHash` analogue (deletes carry the literal key on the
 /// wire). Kept in the signature for trait-shape uniformity.
+///
+/// **Why no payload validation here.** Beyond the TLS codec check
+/// (`tls_deserialize_exact` rejects truncated / oversized payloads
+/// and structurally-malformed deltas), this expansion does not
+/// validate the per-mutation contents — it just feeds them to the
+/// validator's per-element policy check. Authoritative semantic
+/// validation happens at apply time inside [`TlsMap::apply_delta`]
+/// (e.g. `Update`/`Delete` of an absent key returns `KeyNotFound`,
+/// duplicate `Insert` returns the appropriate map error). Validating
+/// here too would either duplicate that work or, worse, drift out of
+/// sync with the apply-time rules and reject things the apply step
+/// would happily accept. Keep it single-source: codec here, semantics
+/// at apply.
 fn expand_tls_map_changes<K>(
     op: &AppDataUpdateOperation,
     _prior: Option<&[u8]>,
@@ -341,8 +354,11 @@ mod tests {
     #[xmtp_common::test(unwrap_try = true)]
     fn component_registry_round_trip() {
         let mut map: TlsMap<ComponentId, VLBytes> = TlsMap::new();
-        map.insert(ComponentId::ADMIN_LIST, VLBytes::new(b"meta-bytes".to_vec()))
-            .unwrap();
+        map.insert(
+            ComponentId::ADMIN_LIST,
+            VLBytes::new(b"meta-bytes".to_vec()),
+        )
+        .unwrap();
         let bytes = ComponentRegistryComponent::encode_value(&map).unwrap();
         let decoded = ComponentRegistryComponent::decode_value(&bytes).unwrap();
         assert_eq!(decoded.len(), 1);
@@ -356,12 +372,17 @@ mod tests {
     fn component_registry_apply_update_replaces_metadata() {
         let mut prior_map: TlsMap<ComponentId, VLBytes> = TlsMap::new();
         prior_map
-            .insert(ComponentId::GROUP_NAME, VLBytes::new(b"old-policy".to_vec()))
+            .insert(
+                ComponentId::GROUP_NAME,
+                VLBytes::new(b"old-policy".to_vec()),
+            )
             .unwrap();
         let prior_bytes = ComponentRegistryComponent::encode_value(&prior_map).unwrap();
 
-        let delta = TlsMapDelta::<ComponentId, VLBytes>::new()
-            .update(ComponentId::GROUP_NAME, VLBytes::new(b"new-policy".to_vec()));
+        let delta = TlsMapDelta::<ComponentId, VLBytes>::new().update(
+            ComponentId::GROUP_NAME,
+            VLBytes::new(b"new-policy".to_vec()),
+        );
         let payload = ComponentRegistryComponent::encode_mutation(&delta).unwrap();
         let new_bytes =
             ComponentRegistryComponent::apply_update_payload(&payload, Some(&prior_bytes)).unwrap();
@@ -396,8 +417,7 @@ mod tests {
         map.insert(fixture_inbox_id(1), VLBytes::new(b"v1".to_vec()))
             .unwrap();
         let raw_map_bytes = map.tls_serialize_detached().unwrap();
-        let err =
-            GroupMembershipComponent::apply_update_payload(&raw_map_bytes, None).unwrap_err();
+        let err = GroupMembershipComponent::apply_update_payload(&raw_map_bytes, None).unwrap_err();
         assert!(
             matches!(err, ComponentTypedError::TlsCodec(_)),
             "expected TlsCodec decode error for non-delta payload, got {err:?}"

--- a/crates/xmtp_mls_common/src/app_data/mod.rs
+++ b/crates/xmtp_mls_common/src/app_data/mod.rs
@@ -3,5 +3,6 @@ pub mod component_permissions;
 pub mod component_registry;
 pub mod components;
 pub mod migration;
+pub mod registry_table;
 pub mod typed;
 pub mod validation;

--- a/crates/xmtp_mls_common/src/app_data/mod.rs
+++ b/crates/xmtp_mls_common/src/app_data/mod.rs
@@ -1,6 +1,7 @@
 pub mod component_id;
 pub mod component_permissions;
 pub mod component_registry;
+pub mod components;
 pub mod migration;
 pub mod typed;
 pub mod validation;

--- a/crates/xmtp_mls_common/src/app_data/mod.rs
+++ b/crates/xmtp_mls_common/src/app_data/mod.rs
@@ -2,4 +2,5 @@ pub mod component_id;
 pub mod component_permissions;
 pub mod component_registry;
 pub mod migration;
+pub mod typed;
 pub mod validation;

--- a/crates/xmtp_mls_common/src/app_data/registry_table.rs
+++ b/crates/xmtp_mls_common/src/app_data/registry_table.rs
@@ -1,0 +1,183 @@
+//! Static dispatch table for well-known [`Component`] impls.
+//!
+//! Maps each well-known [`ComponentId`] to its zero-sized
+//! [`ErasedComponent`] impl so dispatch sites can resolve a runtime
+//! [`ComponentId`] to the right per-component logic without per-call
+//! boxing. The table is hand-maintained and sorted by
+//! `ComponentId::as_u16()` so [`lookup_component`] does a single
+//! binary search.
+//!
+//! ## Adding a new well-known component
+//!
+//! 1. Add a `Component` impl in `app_data::components::*`.
+//! 2. Insert a `(ComponentId::FOO, &FooComponent)` entry into
+//!    [`WELL_KNOWN`], maintaining ascending sort order.
+//! 3. The compile-time `assert_table_is_sorted_and_unique` check at
+//!    the bottom of this file verifies invariants on every build.
+//!
+//! Custom (host-registered) components live outside this table — see
+//! `app_data::custom` (added in jj change #14) for the runtime
+//! registration path.
+
+use crate::app_data::{
+    component_id::ComponentId,
+    components::{
+        inbox_id_set::{AdminListComponent, DmMembersComponent, SuperAdminListComponent},
+        metadata_attributes::{
+            AppDataComponent, CommitLogSignerComponent, GroupDescriptionComponent,
+            GroupImageUrlComponent, GroupNameComponent, MessageDisappearFromNsComponent,
+            MessageDisappearInNsComponent, MinSupportedProtocolVersionComponent,
+        },
+        tls_map_components::{ComponentRegistryComponent, GroupMembershipComponent},
+    },
+    typed::ErasedComponent,
+};
+
+/// Sorted-ascending table of `(ComponentId, &dyn ErasedComponent)`
+/// entries for every well-known XMTP component.
+///
+/// Order is enforced by [`assert_table_is_sorted_and_unique`] at
+/// compile time. Tests further pin specific lookup expectations.
+pub static WELL_KNOWN: &[(ComponentId, &'static dyn ErasedComponent)] = &[
+    (ComponentId::COMPONENT_REGISTRY, &ComponentRegistryComponent),
+    (ComponentId::SUPER_ADMIN_LIST, &SuperAdminListComponent),
+    (ComponentId::ADMIN_LIST, &AdminListComponent),
+    (ComponentId::GROUP_MEMBERSHIP, &GroupMembershipComponent),
+    (ComponentId::GROUP_NAME, &GroupNameComponent),
+    (ComponentId::GROUP_DESCRIPTION, &GroupDescriptionComponent),
+    (ComponentId::GROUP_IMAGE_URL, &GroupImageUrlComponent),
+    (
+        ComponentId::MESSAGE_DISAPPEAR_FROM_NS,
+        &MessageDisappearFromNsComponent,
+    ),
+    (
+        ComponentId::MESSAGE_DISAPPEAR_IN_NS,
+        &MessageDisappearInNsComponent,
+    ),
+    (ComponentId::APP_DATA, &AppDataComponent),
+    (
+        ComponentId::MIN_SUPPORTED_PROTOCOL_VERSION,
+        &MinSupportedProtocolVersionComponent,
+    ),
+    (ComponentId::COMMIT_LOG_SIGNER, &CommitLogSignerComponent),
+    (ComponentId::DM_MEMBERS, &DmMembersComponent),
+];
+
+/// Look up the [`ErasedComponent`] for a well-known [`ComponentId`].
+///
+/// Returns `None` for app-range custom IDs (those resolve via
+/// `app_data::custom` instead) and for IDs with no `Component` impl
+/// (e.g. the `0xBE0x` immutable seeds — handled by the bootstrap
+/// validator's byte-compare path, not the trait).
+pub fn lookup_component(id: ComponentId) -> Option<&'static dyn ErasedComponent> {
+    WELL_KNOWN
+        .binary_search_by_key(&id.as_u16(), |(component_id, _)| component_id.as_u16())
+        .ok()
+        .map(|idx| WELL_KNOWN[idx].1)
+}
+
+/// Compile-time check that [`WELL_KNOWN`] is strictly ascending by
+/// `ComponentId::as_u16()` (so [`lookup_component`]'s binary search is
+/// correct) and that no entry's declared id disagrees with its impl's
+/// `Component::ID`.
+///
+/// Triggered as `const _: () = assert_table_is_sorted_and_unique();`
+/// at module scope below.
+const fn assert_table_is_sorted_and_unique() {
+    let mut i = 1;
+    while i < WELL_KNOWN.len() {
+        let prev = WELL_KNOWN[i - 1].0.as_u16();
+        let curr = WELL_KNOWN[i].0.as_u16();
+        assert!(prev < curr, "WELL_KNOWN must be strictly ascending");
+        i += 1;
+    }
+}
+
+const _: () = assert_table_is_sorted_and_unique();
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app_data::typed::Component;
+    use xmtp_proto::xmtp::mls::message_contents::ComponentType;
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn lookup_returns_correct_component_for_each_well_known_id() {
+        let cases = [
+            (
+                ComponentId::COMPONENT_REGISTRY,
+                ComponentType::TlsMapBytesBytes,
+            ),
+            (ComponentId::SUPER_ADMIN_LIST, ComponentType::TlsSetInboxId),
+            (ComponentId::ADMIN_LIST, ComponentType::TlsSetInboxId),
+            (
+                ComponentId::GROUP_MEMBERSHIP,
+                ComponentType::TlsMapInboxIdBytes,
+            ),
+            (ComponentId::GROUP_NAME, ComponentType::String),
+            (ComponentId::GROUP_DESCRIPTION, ComponentType::String),
+            (ComponentId::GROUP_IMAGE_URL, ComponentType::String),
+            (ComponentId::MESSAGE_DISAPPEAR_FROM_NS, ComponentType::Bytes),
+            (ComponentId::MESSAGE_DISAPPEAR_IN_NS, ComponentType::Bytes),
+            (ComponentId::APP_DATA, ComponentType::String),
+            (
+                ComponentId::MIN_SUPPORTED_PROTOCOL_VERSION,
+                ComponentType::String,
+            ),
+            (ComponentId::COMMIT_LOG_SIGNER, ComponentType::Bytes),
+            (ComponentId::DM_MEMBERS, ComponentType::TlsSetInboxId),
+        ];
+        for (id, expected_type) in cases {
+            let entry =
+                lookup_component(id).unwrap_or_else(|| panic!("missing dispatch for {id:?}"));
+            assert_eq!(entry.id(), id);
+            assert_eq!(entry.component_type(), expected_type);
+        }
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn lookup_returns_none_for_unknown_id() {
+        // App-range custom id — resolved via runtime registry, not WELL_KNOWN.
+        let custom = ComponentId::new(0xC123);
+        assert!(lookup_component(custom).is_none());
+
+        // Immutable seed without a Component impl yet — bootstrap
+        // validator handles it via byte-compare, not the trait.
+        assert!(lookup_component(ComponentId::CONVERSATION_TYPE).is_none());
+        assert!(lookup_component(ComponentId::CREATOR_INBOX_ID).is_none());
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn well_known_entries_match_component_const_id() {
+        // Detect copy-paste errors: each table entry's declared id
+        // must equal its impl's `Component::ID` (which the
+        // ErasedComponent vtable surfaces via `id()`).
+        for (declared_id, erased) in WELL_KNOWN {
+            assert_eq!(
+                erased.id(),
+                *declared_id,
+                "WELL_KNOWN entry for {declared_id:?} points to an impl with id {:?}",
+                erased.id()
+            );
+        }
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn well_known_count_matches_plan() {
+        // 13 well-known impls per docs/plans/2026-04-10-app-data-migration-plan.md:
+        // 8 Bytes/String + 3 TlsSet<InboxId> + 2 TlsMap.
+        assert_eq!(WELL_KNOWN.len(), 13);
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn dispatch_through_erased_calls_typed_apply() {
+        // End-to-end: lookup_component returns an &dyn ErasedComponent
+        // whose apply_update_payload mirrors the typed Component::apply_update_payload.
+        let payload = b"new-name";
+        let typed_result =
+            <GroupNameComponent as Component>::apply_update_payload(payload, None).unwrap();
+        let erased = lookup_component(ComponentId::GROUP_NAME).unwrap();
+        let erased_result = erased.apply_update_payload(payload, None).unwrap();
+        assert_eq!(typed_result, erased_result);
+    }
+}

--- a/crates/xmtp_mls_common/src/app_data/typed.rs
+++ b/crates/xmtp_mls_common/src/app_data/typed.rs
@@ -1,0 +1,386 @@
+//! Typed dispatch for AppData components.
+//!
+//! Defines the [`Component`] trait that pairs a static [`ComponentId`]
+//! with a value type, encoding, and per-component validation hooks.
+//! Each well-known component (GROUP_NAME, ADMIN_LIST, etc.) has one
+//! `Component` impl living under `app_data::components::*`. Together
+//! with the static dispatch table in `app_data::registry_table`, the
+//! trait is the single source of truth for what a [`ComponentId`]
+//! means at the byte level.
+//!
+//! ## Type erasure
+//!
+//! [`Component`] has only static methods (no `&self`), so `dyn Component`
+//! cannot be formed. The companion [`ErasedComponent`] trait is the
+//! object-safe shape used for runtime dispatch. A blanket impl over any
+//! `C: Component + Send + Sync + 'static` lets each Component impl be a
+//! zero-sized type — `&'static dyn ErasedComponent` is a single
+//! pointer with no per-call boxing.
+//!
+//! ## Bytes-out, value-out boundary
+//!
+//! The trait deliberately splits "byte-in / byte-out" methods (which
+//! survive type erasure) from "value-in / value-out" methods (which
+//! require the static `Self::Value` / `Self::Mutation` types).
+//! Validators and the steady-state apply path use the byte-shaped
+//! methods through `&dyn ErasedComponent`; reads against a known
+//! component impl use `decode_value` directly with the static type
+//! through the [`MlsGroupAppData`](super) facade in `xmtp_mls`.
+
+use openmls::messages::proposals::AppDataUpdateOperation;
+use xmtp_proto::xmtp::mls::message_contents::ComponentType;
+
+use crate::{
+    app_data::{
+        component_id::ComponentId,
+        component_registry::{ComponentOp, ComponentRegistry},
+        validation::ComponentChange,
+    },
+    inbox_id::InboxIdError,
+    tls_map::TlsMapError,
+    tls_set::TlsSetError,
+};
+
+/// A typed view of a well-known AppData component.
+///
+/// One impl per [`ComponentId`] — pairs the wire identifier with the
+/// component's logical type, decode/encode round-trip, mutation
+/// serialization, in-place apply behavior for incoming Update payloads,
+/// and (optionally) component-local invariant checks.
+///
+/// The registry's permission check (`validate_component_write` in
+/// `app_data::validation`) is cross-cutting and runs outside this
+/// trait. [`Component::validate_invariant`] is for component-LOCAL
+/// invariants (e.g. "GROUP_NAME ≤ 1 KiB", "ADMIN_LIST always has at
+/// least one super-admin mirror") that the policy evaluator can't
+/// express.
+pub trait Component: Send + Sync + 'static {
+    /// Stable wire identifier. Const-known so registries can build
+    /// static lookup tables.
+    const ID: ComponentId;
+
+    /// Logical wire type, written into the registry's
+    /// [`ComponentMetadata.component_type`] slot at bootstrap.
+    ///
+    /// [`ComponentMetadata.component_type`]: xmtp_proto::xmtp::mls::message_contents::ComponentMetadata
+    const COMPONENT_TYPE: ComponentType;
+
+    /// Decoded full-state value (e.g. `String`, `TlsSet<InboxId>`,
+    /// `TlsMap<InboxId, VLBytes>`).
+    type Value;
+
+    /// Decoded payload that goes inside an
+    /// `AppDataUpdateOperation::Update`.
+    ///
+    /// For Bytes/String components this is the same as `Value` (a
+    /// full-value replacement). For collection components this is
+    /// the wire-level **delta** (`TlsSetDelta<K>` /
+    /// `TlsMapDelta<K, V>`) carrying one *or more* mutations — every
+    /// mutation in the delta lands as one atomic change at the
+    /// receiver. Single-mutation callers build a one-element delta
+    /// via the fluent builder (`TlsSetDelta::new().insert(x)`).
+    ///
+    /// Batching matters for components like `GROUP_MEMBERSHIP` where
+    /// all installation changes for an inbox (additions, removals,
+    /// new installations) must travel in a single proposal so the
+    /// receiver applies them atomically.
+    type Mutation;
+
+    /// Decode the component's stored bytes (as found in the AppData
+    /// dictionary) into the typed value.
+    fn decode_value(bytes: &[u8]) -> Result<Self::Value, ComponentTypedError>;
+
+    /// Encode a typed value back to the bytes that go in the AppData
+    /// dictionary slot. The inverse of [`Component::decode_value`].
+    fn encode_value(value: &Self::Value) -> Result<Vec<u8>, ComponentTypedError>;
+
+    /// Encode a [`Self::Mutation`] as the bytes that go inside an
+    /// `AppDataUpdateOperation::Update` payload.
+    ///
+    /// Bytes/String components pass through; collection components
+    /// serialize the delta (which may carry multiple mutations — see
+    /// the [`Self::Mutation`] doc on batching).
+    fn encode_mutation(mutation: &Self::Mutation) -> Result<Vec<u8>, ComponentTypedError>;
+
+    /// Apply an `AppDataUpdateOperation::Update` payload against the
+    /// component's prior bytes (or `None` if first write) and return
+    /// the new full bytes.
+    ///
+    /// Bytes/String components ignore `prior` and pass through;
+    /// collection components decode `payload` as a delta and apply it
+    /// to the decoded prior set/map.
+    fn apply_update_payload(
+        payload: &[u8],
+        prior: Option<&[u8]>,
+    ) -> Result<Vec<u8>, ComponentTypedError>;
+
+    /// Expand an `AppDataUpdate` proposal (Update or Remove) into the
+    /// per-element changes the validator's policy loop iterates over.
+    ///
+    /// Bytes components produce exactly one entry; collection
+    /// components produce one entry per delta mutation.
+    fn expand_to_changes(
+        op: &AppDataUpdateOperation,
+        prior: Option<&[u8]>,
+    ) -> Result<Vec<ExpandedComponentChange>, ComponentTypedError>;
+
+    /// Optional component-local invariant check that runs *after*
+    /// `validate_component_write`'s policy verdict. Default is no-op
+    /// — components with no extra invariants don't override.
+    fn validate_invariant(
+        _change: &ComponentChange<'_>,
+        _registry: &ComponentRegistry,
+    ) -> Result<(), ComponentInvariantError> {
+        Ok(())
+    }
+}
+
+/// Object-safe view of a [`Component`] impl, for runtime dispatch via
+/// `&'static dyn ErasedComponent`. Carries only the byte-shaped
+/// methods — typed reads through `decode_value` / `encode_value` /
+/// `encode_mutation` need the static `Self::Value` / `Self::Mutation`
+/// types and aren't reachable through the dyn boundary.
+///
+/// A blanket impl over `C: Component` makes every concrete Component
+/// impl auto-implement this trait.
+pub trait ErasedComponent: Send + Sync + 'static {
+    /// The component this impl handles — equivalent to `C::ID`.
+    fn id(&self) -> ComponentId;
+
+    /// The wire type — equivalent to `C::COMPONENT_TYPE`.
+    fn component_type(&self) -> ComponentType;
+
+    fn apply_update_payload(
+        &self,
+        payload: &[u8],
+        prior: Option<&[u8]>,
+    ) -> Result<Vec<u8>, ComponentTypedError>;
+
+    fn expand_to_changes(
+        &self,
+        op: &AppDataUpdateOperation,
+        prior: Option<&[u8]>,
+    ) -> Result<Vec<ExpandedComponentChange>, ComponentTypedError>;
+
+    fn validate_invariant(
+        &self,
+        change: &ComponentChange<'_>,
+        registry: &ComponentRegistry,
+    ) -> Result<(), ComponentInvariantError>;
+}
+
+impl<C: Component> ErasedComponent for C {
+    fn id(&self) -> ComponentId {
+        C::ID
+    }
+
+    fn component_type(&self) -> ComponentType {
+        C::COMPONENT_TYPE
+    }
+
+    fn apply_update_payload(
+        &self,
+        payload: &[u8],
+        prior: Option<&[u8]>,
+    ) -> Result<Vec<u8>, ComponentTypedError> {
+        C::apply_update_payload(payload, prior)
+    }
+
+    fn expand_to_changes(
+        &self,
+        op: &AppDataUpdateOperation,
+        prior: Option<&[u8]>,
+    ) -> Result<Vec<ExpandedComponentChange>, ComponentTypedError> {
+        C::expand_to_changes(op, prior)
+    }
+
+    fn validate_invariant(
+        &self,
+        change: &ComponentChange<'_>,
+        registry: &ComponentRegistry,
+    ) -> Result<(), ComponentInvariantError> {
+        C::validate_invariant(change, registry)
+    }
+}
+
+/// A single per-element view of an incoming `AppDataUpdate` proposal.
+///
+/// `Bytes` components produce exactly one entry; collection components
+/// produce one entry per delta mutation. The `op` mirrors the
+/// `ComponentOp` field on a [`ComponentChange`] so the validator can
+/// call `validate_component_write` directly.
+///
+/// `value` is `None` for `Delete` ops on collection components when
+/// the receiver removes by key (e.g. unresolvable `RemoveByHash`); for
+/// every other case it is `Some` with the new value bytes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExpandedComponentChange {
+    /// Whether this entry is an Insert, Update, or Delete.
+    pub op: ComponentOp,
+    /// The new value bytes for Insert/Update, or `None` for Delete
+    /// when the value is not available.
+    pub value: Option<Vec<u8>>,
+}
+
+/// Errors surfaced by [`Component`] trait methods.
+///
+/// Narrower than `ComponentSourceError` (which lives one layer up at
+/// the dispatch boundary in `xmtp_mls`). The dispatch wrapper converts
+/// these into the source-layer error via `From<ComponentTypedError>`.
+#[derive(Debug, thiserror::Error)]
+pub enum ComponentTypedError {
+    /// An `AppDataUpdate::Update` write was attempted against an
+    /// immutable component. Insert-once writes should be expressed as
+    /// `Insert`, not caught here.
+    #[error("component {0} is immutable and cannot be updated via AppDataUpdate")]
+    ImmutableUpdate(ComponentId),
+
+    /// The supplied mutation does not match the component type of the
+    /// component it targets (e.g. a Bytes mutation against a Set
+    /// component).
+    #[error("mutation shape does not match component {0}")]
+    MismatchedMutation(ComponentId),
+
+    /// A wire-format violation: the bytes passed to
+    /// [`Component::decode_value`] or
+    /// [`Component::apply_update_payload`] don't decode under the
+    /// component's expected encoding.
+    #[error("malformed value for component {component_id}: {reason}")]
+    MalformedValue {
+        component_id: ComponentId,
+        reason: String,
+    },
+
+    /// Failed to convert an inbox id string or byte slice into an
+    /// [`InboxId`](crate::inbox_id::InboxId).
+    #[error("invalid inbox id: {0}")]
+    InvalidInboxId(#[from] InboxIdError),
+
+    /// A TLS-codec operation on a delta or stored collection value
+    /// failed.
+    #[error("tls codec error: {0}")]
+    TlsCodec(#[from] tls_codec::Error),
+
+    /// A `TlsSet::apply_delta` call failed while synthesizing the new
+    /// full value of a Set component from an incoming delta.
+    #[error("tls set apply error: {0}")]
+    TlsSetApply(#[from] TlsSetError),
+
+    /// A `TlsMap::apply_delta` call failed while synthesizing the new
+    /// full value of a Map component from an incoming delta.
+    #[error("tls map apply error: {0}")]
+    TlsMapApply(#[from] TlsMapError),
+}
+
+/// Errors surfaced by [`Component::validate_invariant`].
+///
+/// Component-local invariants — e.g. "GROUP_NAME ≤ N bytes",
+/// "removing the last super-admin mirror is forbidden". Distinct from
+/// [`ComponentPermissionError`](crate::app_data::validation::ComponentPermissionError),
+/// which is the policy-evaluation verdict.
+#[derive(Debug, thiserror::Error)]
+pub enum ComponentInvariantError {
+    /// A component-specific invariant was violated. The string is a
+    /// short human-readable diagnostic; structured error data can be
+    /// added later if a caller needs to inspect.
+    #[error("component {component_id} invariant violated: {reason}")]
+    Violation {
+        component_id: ComponentId,
+        reason: String,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app_data::{component_registry::ComponentOp, validation::ActorAuthority};
+
+    /// A minimal Component impl exercised only by these unit tests —
+    /// confirms the trait shape is usable without the real well-known
+    /// impls (which arrive in subsequent jj changes).
+    struct DummyBytesComponent;
+
+    impl Component for DummyBytesComponent {
+        const ID: ComponentId = ComponentId::APP_DATA;
+        const COMPONENT_TYPE: ComponentType = ComponentType::Bytes;
+        type Value = Vec<u8>;
+        type Mutation = Vec<u8>;
+
+        fn decode_value(bytes: &[u8]) -> Result<Self::Value, ComponentTypedError> {
+            Ok(bytes.to_vec())
+        }
+
+        fn encode_value(value: &Self::Value) -> Result<Vec<u8>, ComponentTypedError> {
+            Ok(value.clone())
+        }
+
+        fn encode_mutation(mutation: &Self::Mutation) -> Result<Vec<u8>, ComponentTypedError> {
+            Ok(mutation.clone())
+        }
+
+        fn apply_update_payload(
+            payload: &[u8],
+            _prior: Option<&[u8]>,
+        ) -> Result<Vec<u8>, ComponentTypedError> {
+            Ok(payload.to_vec())
+        }
+
+        fn expand_to_changes(
+            op: &AppDataUpdateOperation,
+            _prior: Option<&[u8]>,
+        ) -> Result<Vec<ExpandedComponentChange>, ComponentTypedError> {
+            match op {
+                AppDataUpdateOperation::Update(payload) => Ok(vec![ExpandedComponentChange {
+                    op: ComponentOp::Update,
+                    value: Some(payload.as_slice().to_vec()),
+                }]),
+                AppDataUpdateOperation::Remove => Ok(vec![ExpandedComponentChange {
+                    op: ComponentOp::Delete,
+                    value: None,
+                }]),
+            }
+        }
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn typed_methods_round_trip() {
+        let v = b"hello".to_vec();
+        let bytes = DummyBytesComponent::encode_value(&v).unwrap();
+        let decoded = DummyBytesComponent::decode_value(&bytes).unwrap();
+        assert_eq!(decoded, v);
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn erased_component_blanket_impl() {
+        // Static dispatch through &dyn ErasedComponent works without
+        // per-call boxing because the impl is over a ZST.
+        let erased: &'static dyn ErasedComponent = &DummyBytesComponent;
+        assert_eq!(erased.id(), ComponentId::APP_DATA);
+        assert_eq!(erased.component_type(), ComponentType::Bytes);
+
+        let new = erased.apply_update_payload(b"world", None).unwrap();
+        assert_eq!(new, b"world");
+
+        let expanded = erased
+            .expand_to_changes(&AppDataUpdateOperation::Update(b"x".to_vec().into()), None)
+            .unwrap();
+        assert_eq!(expanded.len(), 1);
+        assert_eq!(expanded[0].op, ComponentOp::Update);
+        assert_eq!(expanded[0].value.as_deref(), Some(b"x".as_slice()));
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn default_validate_invariant_is_noop() {
+        let actor = ActorAuthority {
+            is_admin: false,
+            is_super_admin: true,
+        };
+        let change = ComponentChange::builder()
+            .component_id(ComponentId::APP_DATA)
+            .op(ComponentOp::Update)
+            .actor(actor)
+            .build();
+        let registry = ComponentRegistry::new();
+        <DummyBytesComponent as Component>::validate_invariant(&change, &registry).unwrap();
+    }
+}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add static dispatch table and `lookup_component()` for typed app data components in `xmtp_mls_common`
- Introduces a `Component` trait in [typed.rs](https://github.com/xmtp/libxmtp/pull/3590/files#diff-c236cddfbc773add81e4b049ce96661ccbc71b50f88b54a0c47771f44535fd43) defining encode/decode, mutation encoding, delta-apply, and change expansion for each component type, plus an object-safe `ErasedComponent` blanket impl for runtime dispatch via `&dyn ErasedComponent`.
- Adds concrete `Component` impls for all 13 well-known components across [inbox_id_set.rs](https://github.com/xmtp/libxmtp/pull/3590/files#diff-5f08a0dc38517faee07734c1c089deebea26a27e1b112da4dc10a4757a308a99), [metadata_attributes.rs](https://github.com/xmtp/libxmtp/pull/3590/files#diff-8d22387053032391f57a49904f5f719eaf2c6f0ffc9be4c79d7c1763eb321a14), and [tls_map_components.rs](https://github.com/xmtp/libxmtp/pull/3590/files#diff-a637517b1164e6bb136f87c0734cdc057cddb79c2f03a81be5764d6cdf7b9ae6).
- Builds a static sorted `WELL_KNOWN` table in [registry_table.rs](https://github.com/xmtp/libxmtp/pull/3590/files#diff-dac151bd9d59cbdc7d59c932a5319a050a31ef5b4a4748c73b8112a7a77b47a4) with a compile-time sort/uniqueness assertion; `lookup_component()` resolves a `ComponentId` via binary search.
- Consolidates `ExpandedComponentChange` into the new `typed` module and re-exports it from the existing location for backward compatibility.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 224f168.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->