### PR TITLE
xmtp_mls: dispatch steady-state validator through Component trait + invariant hooks

### DIFF
--- a/crates/xmtp_mls/src/groups/app_data/component_source.rs
+++ b/crates/xmtp_mls/src/groups/app_data/component_source.rs
@@ -460,6 +460,11 @@ pub(crate) use xmtp_mls_common::app_data::typed::ExpandedComponentChange;
 ///
 /// Used on the receiver side to feed `validate_component_write` for each
 /// distinct change inside a single `AppDataUpdate` proposal.
+///
+/// The steady-state validator dispatches through `lookup_component`
+/// directly so it can also call `Component::validate_invariant`
+/// without a second binary search. This wrapper is retained for
+/// callers that don't need the invariant hook.
 pub(crate) fn expand_app_data_update_to_changes(
     component_id: ComponentId,
     operation: &AppDataUpdateOperation,

--- a/crates/xmtp_mls/src/groups/app_data/mod.rs
+++ b/crates/xmtp_mls/src/groups/app_data/mod.rs
@@ -17,6 +17,7 @@
 pub(crate) mod bootstrap_validator;
 pub mod component_source;
 pub mod migration;
+pub(crate) mod typed_facade;
 
 use std::collections::BTreeMap;
 

--- a/crates/xmtp_mls/src/groups/app_data/typed_facade.rs
+++ b/crates/xmtp_mls/src/groups/app_data/typed_facade.rs
@@ -1,0 +1,81 @@
+// `expect` (not `allow`) so the compiler reminds us to drop this
+// attribute when the first production caller wires in.
+#![expect(dead_code)]
+
+//! Typed read facade over an OpenMLS group's AppData dictionary.
+//!
+//! [`MlsGroupAppData`] borrows an `&OpenMlsGroup` and exposes typed,
+//! per-component reads via [`MlsGroupAppData::get`]. Write paths
+//! continue to use the existing intent infrastructure (`mls_sync.rs`)
+//! plus `stage_inline_app_data_commit`; this facade is for callers
+//! that need a single typed value (e.g. permissions checks, registry
+//! lookups, custom-component reads).
+//!
+//! ## Capability awareness
+//!
+//! On unmigrated groups the dict is empty, so [`MlsGroupAppData::get`]
+//! falls back to the legacy group-context-extension translation via
+//! [`super::component_source::read_component_bytes`]. On migrated
+//! groups (post-bootstrap) the dict is authoritative. Either way the
+//! caller gets `C::Value` decoded — no manual capability switching.
+
+use openmls::group::MlsGroup as OpenMlsGroup;
+use xmtp_mls_common::app_data::typed::Component;
+
+use super::component_source::{ComponentSourceError, read_component_bytes};
+use super::is_migrated_group;
+
+/// A typed view over a group's AppData state.
+///
+/// Holds nothing but the borrow + the migration flag. Cheap to
+/// construct; intended to be created locally inside a
+/// `load_mls_group_with_lock` closure and discarded.
+pub(crate) struct MlsGroupAppData<'g> {
+    group: &'g OpenMlsGroup,
+    proposals_enabled: bool,
+}
+
+impl<'g> MlsGroupAppData<'g> {
+    /// Wrap an `&OpenMlsGroup` for typed AppData reads.
+    ///
+    /// **Construct under the same `load_mls_group_with_lock` closure
+    /// that consumes the facade.** The cached `proposals_enabled`
+    /// flag is read once at construction, so a facade that outlives
+    /// the lock could observe a stale migration state on a subsequent
+    /// `get` call. In practice every call site lives inside one
+    /// closure and discards the facade at the end.
+    pub(crate) fn new(group: &'g OpenMlsGroup) -> Self {
+        let proposals_enabled = is_migrated_group(group);
+        Self {
+            group,
+            proposals_enabled,
+        }
+    }
+
+    /// `true` if this group has completed its bootstrap commit and the
+    /// AppData dictionary is the authoritative source for components.
+    pub(crate) fn is_migrated(&self) -> bool {
+        self.proposals_enabled
+    }
+
+    /// Read the typed value of a [`Component`] from this group.
+    ///
+    /// Returns `Ok(None)` if the component has no current bytes (slot
+    /// missing in the dict, or the legacy extension wasn't populated).
+    /// Returns `Ok(Some(value))` on a successful decode of bytes.
+    /// Returns `Err` for transport-level (read) or codec-level
+    /// (decode) failures.
+    pub(crate) fn get<C: Component>(&self) -> Result<Option<C::Value>, ComponentSourceError> {
+        let bytes = read_component_bytes(C::ID, self.group, self.proposals_enabled)?;
+        match bytes {
+            Some(b) => Ok(Some(C::decode_value(&b)?)),
+            None => Ok(None),
+        }
+    }
+}
+
+// End-to-end coverage lives in the bootstrap-flow integration tests
+// in `tests/test_proposals.rs`; constructing an `OpenMlsGroup`
+// outside the full keystore setup is expensive and adds little
+// signal beyond what `read_component_bytes` and
+// `Component::decode_value` already pin in their own modules.

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -2690,20 +2690,17 @@ where
             IntentKind::MetadataUpdate => {
                 let metadata_intent = UpdateMetadataIntentData::try_from(intent.data.clone())?;
 
-                // Gate the AppDataUpdate path on both the capability flag
-                // AND a non-empty component registry. The registry check
-                // keeps unmigrated groups on the legacy path so a sender
-                // doesn't publish commits that the receiver would deny
-                // (`NoRegistryEntry`) against an empty registry.
+                // Gate the AppDataUpdate path on the capability flag
+                // AND a non-empty component registry. The registry
+                // check keeps unmigrated groups on the legacy path so
+                // a sender doesn't publish commits the receiver would
+                // deny against an empty registry. `load_component_registry`
+                // also consults `TEST_REGISTRY_OVERRIDE`, so tests that
+                // install a fake registry exercise this branch even
+                // before a real bootstrap commit lands.
                 let proposals_on = self.proposals_enabled(openmls_group);
                 let registry_populated =
                     !super::app_data::load_component_registry(openmls_group)?.is_empty();
-                // DEBUG-level routing trace so operators can see which
-                // groups are on which path during the rollout — especially
-                // useful if the migration ships only partially and we need
-                // to know how many groups are still on the legacy path.
-                // INFO would spam every metadata update; DEBUG keeps it
-                // opt-in for on-demand investigation.
                 tracing::debug!(
                     group_id = hex::encode(self.group_id.as_slice()),
                     proposals_enabled = proposals_on,

--- a/crates/xmtp_mls/src/groups/validated_commit.rs
+++ b/crates/xmtp_mls/src/groups/validated_commit.rs
@@ -1132,15 +1132,30 @@ pub(super) fn validate_one_app_data_update_with_old_value(
     registry: &xmtp_mls_common::app_data::component_registry::ComponentRegistry,
     old_value: Option<&[u8]>,
 ) -> Result<(), CommitValidationError> {
-    use super::app_data::component_source::expand_app_data_update_to_changes;
-    use xmtp_mls_common::app_data::validation::{ComponentChange, validate_component_write};
+    use xmtp_mls_common::app_data::{
+        registry_table::lookup_component,
+        validation::{ComponentChange, validate_component_write},
+    };
 
-    let changes =
-        expand_app_data_update_to_changes(component_id, operation, old_value).map_err(|e| {
+    // Single dispatch lookup serves both expansion and the per-element
+    // invariant hook below.
+    let Some(component) = lookup_component(component_id) else {
+        tracing::warn!(
+            proposer_inbox_id,
+            component_id = %component_id,
+            "AppDataUpdate proposal rejected: no Component impl for component id"
+        );
+        return Err(CommitValidationError::InsufficientPermissions);
+    };
+
+    let changes = component
+        .expand_to_changes(operation, old_value)
+        .map_err(|e| {
+            let wrapped = super::app_data::component_source::ComponentSourceError::from(e);
             tracing::warn!(
                 proposer_inbox_id,
                 component_id = %component_id,
-                error = %e,
+                error = %wrapped,
                 "AppDataUpdate proposal rejected: failed to expand payload"
             );
             CommitValidationError::InsufficientPermissions
@@ -1158,6 +1173,7 @@ pub(super) fn validate_one_app_data_update_with_old_value(
             .maybe_new_value(change.value.as_deref())
             .build();
 
+        // Layer 1: registry-based policy.
         if let Err(e) = validate_component_write(&cc, registry) {
             tracing::warn!(
                 proposer_inbox_id,
@@ -1165,6 +1181,19 @@ pub(super) fn validate_one_app_data_update_with_old_value(
                 op = %change.op,
                 error = %e,
                 "AppDataUpdate proposal rejected"
+            );
+            return Err(CommitValidationError::InsufficientPermissions);
+        }
+
+        // Layer 2: per-component invariants. Runs after the policy
+        // check so a denied actor can't trigger expensive invariants.
+        if let Err(e) = component.validate_invariant(&cc, registry) {
+            tracing::warn!(
+                proposer_inbox_id,
+                component_id = %component_id,
+                op = %change.op,
+                error = %e,
+                "AppDataUpdate proposal rejected: component invariant violated"
             );
             return Err(CommitValidationError::InsufficientPermissions);
         }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Dispatch steady-state AppData validation through `Component` trait with invariant hooks
- Reworks `validate_one_app_data_update_with_old_value` in [validated_commit.rs](https://github.com/xmtp/libxmtp/pull/3592/files#diff-233994c0ec18d23d0636e849849a3500e44611a4f64c6fffb1d0931aa1461ed6) to dispatch through `registry_table::lookup_component` instead of `expand_app_data_update_to_changes`, rejecting proposals that lack a registered `Component` implementation.
- Adds a second validation pass calling `component.validate_invariant()` after policy checks; violations are logged and cause proposal rejection.
- Introduces `MlsGroupAppData<'g>` in [typed_facade.rs](https://github.com/xmtp/libxmtp/pull/3592/files#diff-6724ebfc492120116b727168c18fbeb66dd72399ea64f6ff0b624d43ec1d0183), a typed read facade over an OpenMLS group's AppData dictionary with transparent fallback to legacy group-context extension for unmigrated groups.
- Risk: AppData update proposals that previously passed policy checks may now be rejected if no `Component` is registered for the `component_id` or if `validate_invariant` fails.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0459084.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->