### PR TITLE
xmtp_mls: defensive stub for IntentKind::ProposeMemberUpdate on migrated groups (Task 7d)

### DIFF
--- a/crates/xmtp_mls/src/groups/app_data/mod.rs
+++ b/crates/xmtp_mls/src/groups/app_data/mod.rs
@@ -17,6 +17,7 @@
 pub(crate) mod bootstrap_validator;
 pub mod component_source;
 pub mod migration;
+pub(crate) mod sender_intents;
 pub(crate) mod typed_facade;
 
 use std::collections::BTreeMap;

--- a/crates/xmtp_mls/src/groups/app_data/sender_intents.rs
+++ b/crates/xmtp_mls/src/groups/app_data/sender_intents.rs
@@ -1,0 +1,100 @@
+//! AppDataUpdate-path helpers for the migrated-group sender intents.
+//!
+//! Each helper here corresponds to one `IntentKind` branch in
+//! `mls_sync.rs::get_publish_intent_data`. The caller has already
+//! confirmed `is_migrated_group(openmls_group)` is true; these
+//! functions stage the inline `AppDataUpdate` commit and return the
+//! resulting `PublishIntentData`.
+
+use openmls::{group::MlsGroup as OpenMlsGroup, prelude::tls_codec::Serialize};
+use openmls_traits::signatures::Signer;
+use xmtp_mls_common::{
+    app_data::{
+        component_id::ComponentId,
+        components::inbox_id_set::{AdminListComponent, SuperAdminListComponent},
+        typed::Component,
+    },
+    inbox_id::InboxId,
+    tls_set::{TlsSetDelta, TlsSetMutation},
+};
+
+use super::component_source::ComponentSourceError;
+use super::stage_inline_app_data_commit;
+use crate::{
+    context::XmtpSharedContext,
+    groups::{
+        AdminListActionType, GroupError,
+        intents::UpdateAdminListIntentData,
+        mls_sync::{PublishIntentData, generate_commit_with_rollback},
+    },
+};
+
+/// Stage the `AppDataUpdate` commit for an `UpdateAdminList` intent on
+/// a migrated group. Maps the intent action onto a one-element
+/// `TlsSetDelta` over `ADMIN_LIST` (Add/Remove) or `SUPER_ADMIN_LIST`
+/// (AddSuper/RemoveSuper) and returns the staged commit's
+/// `PublishIntentData`. The wire format always carries a delta, even
+/// for single mutations.
+pub(crate) fn apply_update_admin_list_app_data_intent(
+    context: &impl XmtpSharedContext,
+    openmls_group: &mut OpenMlsGroup,
+    intent_data: UpdateAdminListIntentData,
+    signer: impl Signer,
+    should_send_push_notification: bool,
+) -> Result<PublishIntentData, GroupError> {
+    let storage = context.mls_storage();
+
+    let inbox_id = InboxId::from_hex(&intent_data.inbox_id)
+        .map_err(|e| GroupError::ComponentSource(e.into()))?;
+    let (component_id, mutation) = match intent_data.action_type {
+        AdminListActionType::Add => (ComponentId::ADMIN_LIST, TlsSetMutation::Insert(inbox_id)),
+        AdminListActionType::Remove => (ComponentId::ADMIN_LIST, TlsSetMutation::Remove(inbox_id)),
+        AdminListActionType::AddSuper => (
+            ComponentId::SUPER_ADMIN_LIST,
+            TlsSetMutation::Insert(inbox_id),
+        ),
+        AdminListActionType::RemoveSuper => (
+            ComponentId::SUPER_ADMIN_LIST,
+            TlsSetMutation::Remove(inbox_id),
+        ),
+    };
+
+    let delta = TlsSetDelta::<InboxId> {
+        mutations: vec![mutation],
+    };
+    let payload = match component_id {
+        ComponentId::ADMIN_LIST => <AdminListComponent as Component>::encode_mutation(&delta),
+        ComponentId::SUPER_ADMIN_LIST => {
+            <SuperAdminListComponent as Component>::encode_mutation(&delta)
+        }
+        _ => unreachable!("admin-list intent maps to ADMIN_LIST or SUPER_ADMIN_LIST only"),
+    }
+    .map_err(|e| GroupError::ComponentSource(ComponentSourceError::from(e)))?;
+
+    let (bundle, staged_commit, group_epoch) = generate_commit_with_rollback(
+        storage,
+        openmls_group,
+        move |group, provider| -> Result<_, GroupError> {
+            Ok(stage_inline_app_data_commit(
+                group,
+                provider,
+                &signer,
+                component_id,
+                payload,
+            )?)
+        },
+    )?;
+
+    let (commit, welcome, _group_info) = bundle.into_messages();
+    debug_assert!(
+        welcome.is_none(),
+        "UpdateAdminList via AppDataUpdate must not produce a welcome"
+    );
+    Ok(PublishIntentData {
+        payloads_to_publish: vec![commit.tls_serialize_detached()?],
+        staged_commit,
+        post_commit_action: None,
+        should_send_push_notification,
+        group_epoch,
+    })
+}

--- a/crates/xmtp_mls/src/groups/app_data/sender_intents.rs
+++ b/crates/xmtp_mls/src/groups/app_data/sender_intents.rs
@@ -8,23 +8,38 @@
 
 use openmls::{group::MlsGroup as OpenMlsGroup, prelude::tls_codec::Serialize};
 use openmls_traits::signatures::Signer;
+use prost::Message;
+use tls_codec::VLBytes;
 use xmtp_mls_common::{
     app_data::{
         component_id::ComponentId,
-        components::inbox_id_set::{AdminListComponent, SuperAdminListComponent},
+        component_registry::ComponentOp,
+        components::{
+            inbox_id_set::{AdminListComponent, SuperAdminListComponent},
+            tls_map_components::ComponentRegistryComponent,
+        },
         typed::Component,
     },
+    group_mutable_metadata::GroupMutableMetadataError,
     inbox_id::InboxId,
+    tls_map::TlsMapDelta,
     tls_set::{TlsSetDelta, TlsSetMutation},
 };
+use xmtp_proto::xmtp::mls::message_contents::{
+    MetadataPolicy as MetadataPolicyProto,
+    metadata_policy::{Kind as MetadataPolicyKind, MetadataBasePolicy},
+};
 
-use super::component_source::ComponentSourceError;
-use super::stage_inline_app_data_commit;
+use super::component_source::{ComponentSourceError, metadata_field_to_component_id};
+use super::{load_component_registry, stage_inline_app_data_commit};
 use crate::{
     context::XmtpSharedContext,
     groups::{
         AdminListActionType, GroupError,
-        intents::UpdateAdminListIntentData,
+        intents::{
+            PermissionPolicyOption, PermissionUpdateType, UpdateAdminListIntentData,
+            UpdatePermissionIntentData,
+        },
         mls_sync::{PublishIntentData, generate_commit_with_rollback},
     },
 };
@@ -89,6 +104,116 @@ pub(crate) fn apply_update_admin_list_app_data_intent(
     debug_assert!(
         welcome.is_none(),
         "UpdateAdminList via AppDataUpdate must not produce a welcome"
+    );
+    Ok(PublishIntentData {
+        payloads_to_publish: vec![commit.tls_serialize_detached()?],
+        staged_commit,
+        post_commit_action: None,
+        should_send_push_notification,
+        group_epoch,
+    })
+}
+
+/// Stage the `AppDataUpdate` commit for an `UpdatePermission` intent on
+/// a migrated group. The commit only mutates the affected
+/// `COMPONENT_REGISTRY` entry's policy field — custom-component
+/// entries survive untouched. `PolicyOption::Allow` is permitted
+/// here because the underlying `COMPONENT_REGISTRY` mutation is
+/// hardcoded super-admin-only by the dispatch layer's permission
+/// check.
+pub(crate) fn apply_update_permission_app_data_intent(
+    context: &impl XmtpSharedContext,
+    openmls_group: &mut OpenMlsGroup,
+    intent_data: UpdatePermissionIntentData,
+    signer: impl Signer,
+    should_send_push_notification: bool,
+) -> Result<PublishIntentData, GroupError> {
+    let storage = context.mls_storage();
+
+    let base = match intent_data.policy_option {
+        PermissionPolicyOption::Allow => MetadataBasePolicy::Allow,
+        PermissionPolicyOption::Deny => MetadataBasePolicy::Deny,
+        PermissionPolicyOption::AdminOnly => MetadataBasePolicy::AllowIfAdmin,
+        PermissionPolicyOption::SuperAdminOnly => MetadataBasePolicy::AllowIfSuperAdmin,
+    };
+    let new_policy = MetadataPolicyProto {
+        kind: Some(MetadataPolicyKind::Base(base as i32)),
+    };
+
+    // Map (update_type, metadata_field_name) onto (target_component,
+    // which policy field to mutate).
+    let (target, op) = match intent_data.update_type {
+        PermissionUpdateType::AddMember => (ComponentId::GROUP_MEMBERSHIP, ComponentOp::Insert),
+        PermissionUpdateType::RemoveMember => (ComponentId::GROUP_MEMBERSHIP, ComponentOp::Delete),
+        PermissionUpdateType::AddAdmin => (ComponentId::ADMIN_LIST, ComponentOp::Insert),
+        PermissionUpdateType::RemoveAdmin => (ComponentId::ADMIN_LIST, ComponentOp::Delete),
+        PermissionUpdateType::UpdateMetadata => {
+            let field_name = intent_data.metadata_field_name.as_deref().ok_or_else(|| {
+                GroupError::MetadataPermissionsError(
+                    GroupMutableMetadataError::MissingMetadataField.into(),
+                )
+            })?;
+            let component_id = metadata_field_to_component_id(field_name).ok_or_else(|| {
+                GroupError::ComponentSource(ComponentSourceError::UnknownMetadataField(
+                    field_name.to_owned(),
+                ))
+            })?;
+            (component_id, ComponentOp::Update)
+        }
+    };
+
+    let registry = load_component_registry(openmls_group)?;
+    let mut metadata = registry
+        .get(&target)
+        .map_err(|e| {
+            GroupError::ComponentSource(ComponentSourceError::MalformedComponentValue {
+                component_id: target,
+                reason: format!("registry get failed: {e}"),
+            })
+        })?
+        .ok_or_else(|| {
+            GroupError::ComponentSource(ComponentSourceError::MalformedComponentValue {
+                component_id: target,
+                reason: "registry has no entry for target component".into(),
+            })
+        })?;
+    let mut perms = metadata.permissions.clone().ok_or_else(|| {
+        GroupError::ComponentSource(ComponentSourceError::MalformedComponentValue {
+            component_id: target,
+            reason: "registry entry missing permissions".into(),
+        })
+    })?;
+    match op {
+        ComponentOp::Insert => perms.insert_policy = Some(new_policy),
+        ComponentOp::Update => perms.update_policy = Some(new_policy),
+        ComponentOp::Delete => perms.delete_policy = Some(new_policy),
+    }
+    metadata.permissions = Some(perms);
+
+    let new_metadata_bytes = metadata.encode_to_vec();
+    let delta =
+        TlsMapDelta::<ComponentId, VLBytes>::new().update(target, VLBytes::new(new_metadata_bytes));
+    let payload = <ComponentRegistryComponent as Component>::encode_mutation(&delta)
+        .map_err(|e| GroupError::ComponentSource(ComponentSourceError::from(e)))?;
+
+    let (bundle, staged_commit, group_epoch) = generate_commit_with_rollback(
+        storage,
+        openmls_group,
+        move |group, provider| -> Result<_, GroupError> {
+            Ok(stage_inline_app_data_commit(
+                group,
+                provider,
+                &signer,
+                ComponentId::COMPONENT_REGISTRY,
+                payload,
+            )?)
+        },
+    )?;
+
+    let (commit, welcome, _group_info) = bundle.into_messages();
+    debug_assert!(
+        welcome.is_none(),
+        "UpdatePermission via AppDataUpdate must not produce a welcome"
     );
     Ok(PublishIntentData {
         payloads_to_publish: vec![commit.tls_serialize_detached()?],

--- a/crates/xmtp_mls/src/groups/error.rs
+++ b/crates/xmtp_mls/src/groups/error.rs
@@ -108,6 +108,19 @@ pub enum GroupError {
     /// Group membership state is invalid. Not retryable.
     #[error("invalid group membership")]
     InvalidGroupMembership,
+    /// `IntentKind::UpdateGroupMembership` and
+    /// `IntentKind::ProposeMemberUpdate` aren't yet wired through the
+    /// AppDataUpdate path on migrated groups. Hosts that call
+    /// `enable_proposals()` and then try to update group membership
+    /// see this error rather than a commit that would re-add the
+    /// legacy `GROUP_MEMBERSHIP_EXTENSION_ID` extension that
+    /// bootstrap just removed.
+    // TODO(7c, 7d): wire GROUP_MEMBERSHIP through the AppDataUpdate
+    // path; the integration tests for membership-on-migrated-groups
+    // will drive the precise per-inbox `GroupMembershipEntryV1`
+    // partitioning and `failed_installations` propagation.
+    #[error("UpdateGroupMembership via AppDataUpdate is not yet implemented for migrated groups")]
+    UpdateGroupMembershipMigratedNotImplemented,
     /// Leave cannot be processed.
     ///
     /// Group leave validation failed. Not retryable.
@@ -615,7 +628,8 @@ impl RetryableError for GroupError {
             | Self::NoWelcomesToSend
             | Self::WelcomeDataNotFound(_)
             | Self::UninitializedField(_)
-            | Self::UninitializedResult => false,
+            | Self::UninitializedResult
+            | Self::UpdateGroupMembershipMigratedNotImplemented => false,
         }
     }
 }

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -2862,6 +2862,35 @@ where
             IntentKind::UpdatePermission => {
                 let update_permissions_intent =
                     UpdatePermissionIntentData::try_from(intent.data.clone())?;
+
+                // Mirror the MetadataUpdate / UpdateAdminList dual-
+                // routing gate via the shared `is_migrated_group`
+                // predicate.
+                let is_migrated = super::app_data::is_migrated_group(openmls_group);
+                tracing::debug!(
+                    group_id = hex::encode(self.group_id.as_slice()),
+                    is_migrated,
+                    path = if is_migrated {
+                        "app_data_update"
+                    } else {
+                        "legacy_gce"
+                    },
+                    "UpdatePermission intent routing"
+                );
+                if is_migrated {
+                    let signer = self.context.identity().installation_keys.clone();
+                    let publish =
+                        super::app_data::sender_intents::apply_update_permission_app_data_intent(
+                            &self.context,
+                            openmls_group,
+                            update_permissions_intent,
+                            signer,
+                            intent.should_push,
+                        )?;
+                    return Ok(Some(publish));
+                }
+
+                // Legacy GCE path on unmigrated groups.
                 let group_permissions_extensions = build_extensions_for_permissions_update(
                     openmls_group,
                     update_permissions_intent,

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -320,13 +320,13 @@ impl RetryableError for IntentResolutionError {
 
 #[derive(Debug)]
 pub(crate) struct PublishIntentData {
-    staged_commit: Option<Vec<u8>>,
-    post_commit_action: Option<Vec<u8>>,
+    pub(crate) staged_commit: Option<Vec<u8>>,
+    pub(crate) post_commit_action: Option<Vec<u8>>,
     /// One or more payloads to publish. Most intents have a single payload (commit or message),
     /// but proposal intents may have multiple payloads (one per proposal).
-    payloads_to_publish: Vec<Vec<u8>>,
-    should_send_push_notification: bool,
-    group_epoch: u64,
+    pub(crate) payloads_to_publish: Vec<Vec<u8>>,
+    pub(crate) should_send_push_notification: bool,
+    pub(crate) group_epoch: u64,
 }
 
 #[cfg(any(test, feature = "test-utils"))]
@@ -2797,12 +2797,43 @@ where
                 }))
             }
             IntentKind::UpdateAdminList => {
-                // ADMIN_LIST stays on the legacy GCE path: routing it
-                // through AppDataUpdate would let the GMM-backed validators
-                // in `validated_commit.rs` diverge from the dict until the
-                // migration is dual-write or complete.
                 let admin_list_update_intent =
                     UpdateAdminListIntentData::try_from(intent.data.clone())?;
+
+                // Mirror the MetadataUpdate dual-routing gate: only
+                // route through AppDataUpdate on groups whose AppData
+                // dict has the `COMPONENT_REGISTRY` entry (the
+                // bootstrap-commit marker). Otherwise stay on the
+                // legacy GCE path so unmigrated peers continue to
+                // validate via the legacy `GroupMutableMetadata`
+                // extension. Single shared predicate via
+                // `is_migrated_group` keeps every send/receive/validate
+                // path honest about what "migrated" means.
+                let is_migrated = super::app_data::is_migrated_group(openmls_group);
+                tracing::debug!(
+                    group_id = hex::encode(self.group_id.as_slice()),
+                    is_migrated,
+                    path = if is_migrated {
+                        "app_data_update"
+                    } else {
+                        "legacy_gce"
+                    },
+                    "UpdateAdminList intent routing"
+                );
+                if is_migrated {
+                    let signer = self.context.identity().installation_keys.clone();
+                    let publish =
+                        super::app_data::sender_intents::apply_update_admin_list_app_data_intent(
+                            &self.context,
+                            openmls_group,
+                            admin_list_update_intent,
+                            signer,
+                            intent.should_push,
+                        )?;
+                    return Ok(Some(publish));
+                }
+
+                // Legacy GCE path on unmigrated groups.
                 let mutable_metadata_extensions = build_extensions_for_admin_lists_update(
                     openmls_group,
                     admin_list_update_intent,

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -2926,6 +2926,19 @@ where
                     return Err(GroupError::from(CommitValidationError::ProposalsNotEnabled));
                 }
 
+                // Defensive gate. The proposal-by-reference flow
+                // emits Add/Remove + GCE proposals updating the
+                // legacy GROUP_MEMBERSHIP_EXTENSION_ID extension. On
+                // migrated groups that extension is gone, so the
+                // GCE would re-add it and break the dict-as-source-
+                // of-truth invariant. Bail out the same way Task 7c
+                // (`apply_update_group_membership_intent`) does, via
+                // the same canonical `is_migrated_extensions`
+                // predicate.
+                if super::app_data::is_migrated_extensions(openmls_group.extensions()) {
+                    return Err(GroupError::UpdateGroupMembershipMigratedNotImplemented);
+                }
+
                 let intent_data = ProposeMemberUpdateIntentData::try_from(intent.data.as_slice())?;
                 let group_epoch = openmls_group.epoch().as_u64();
                 let signer = &self.context.identity().installation_keys;

--- a/crates/xmtp_mls/src/groups/mls_sync/update_group_membership.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync/update_group_membership.rs
@@ -22,6 +22,24 @@ pub(crate) async fn apply_update_group_membership_intent(
     intent_data: UpdateGroupMembershipIntentData,
     signer: impl Signer,
 ) -> Result<Option<PublishIntentData>, GroupError> {
+    // Defensive gate. The full AppDataUpdate wiring for
+    // GROUP_MEMBERSHIP needs end-to-end integration coverage to pin
+    // the wire-shape decisions (per-inbox `GroupMembershipEntryV1`
+    // partitioning, `failed_installations` propagation across
+    // steady-state). Until that lands, fail fast on migrated groups
+    // so a host that prematurely calls `enable_proposals()` doesn't
+    // emit a GCE proposal that re-adds the legacy
+    // `GROUP_MEMBERSHIP_EXTENSION_ID` extension bootstrap just
+    // removed.
+    //
+    // Uses the canonical `is_migrated_extensions` predicate (presence
+    // of the `COMPONENT_REGISTRY` entry written by the bootstrap
+    // commit) so this gate agrees with every other send/receive/
+    // validate path in the migration.
+    if super::super::app_data::is_migrated_extensions(openmls_group.extensions()) {
+        return Err(GroupError::UpdateGroupMembershipMigratedNotImplemented);
+    }
+
     let extensions = openmls_group.extensions().clone();
     let old_group_membership = extract_group_membership(&extensions)?;
     let new_group_membership = intent_data.apply_to_group_membership(&old_group_membership);


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add defensive stubs for migrated group intents in `xmtp_mls` sync
- Routes `UpdateAdminList` and `UpdatePermission` intents through new AppDataUpdate commit helpers ([sender_intents.rs](https://github.com/xmtp/libxmtp/pull/3593/files#diff-09753ccd507e9327f4b4e1df1c02244081bdeeecb5088bb6d21ddb89a349513a)) on migrated groups, while unmigrated groups retain the legacy Group Context Extensions path.
- Adds an early guard in `apply_update_group_membership_intent` and the `ProposeMemberUpdate` sync path that returns a non-retryable `UpdateGroupMembershipMigratedNotImplemented` error on migrated groups, preventing legacy membership extension writes.
- Behavioral Change: `UpdateGroupMembership` and `ProposeMemberUpdate` now fail immediately on migrated groups instead of proceeding with legacy extension updates.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized a1d59dc.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->