### PR TITLE
xmtp_mls_common: bootstrap synthesis iterates WELL_KNOWN dispatch table for ComponentType lookup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14646,6 +14646,7 @@ dependencies = [
  "bon",
  "const-hex",
  "openmls",
+ "parking_lot",
  "proptest",
  "prost",
  "serde",

--- a/crates/xmtp_mls_common/Cargo.toml
+++ b/crates/xmtp_mls_common/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 bon.workspace = true
 hex.workspace = true
 openmls.workspace = true
+parking_lot.workspace = true
 prost.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/xmtp_mls_common/src/app_data/custom.rs
+++ b/crates/xmtp_mls_common/src/app_data/custom.rs
@@ -1,0 +1,376 @@
+//! Host-defined ("custom") component registration.
+//!
+//! Custom components live in the app range (`0xC000-0xFEFF`,
+//! per [`ComponentId::is_app_range`]) and are registered by host
+//! apps at process startup. Unlike well-known components — which
+//! have static `Component` impls with `const ID: ComponentId` — a
+//! [`RuntimeComponent`] carries its id as a runtime value so a host
+//! can register multiple distinct components from one impl type
+//! parameterized by id (or build them dynamically).
+//!
+//! ## Lifecycle
+//!
+//! 1. **Process startup** (host): the host calls
+//!    [`register_global_runtime_component`] for each component it
+//!    wants to support. The registry stores a `&'static dyn
+//!    ErasedComponent`-shaped handle keyed by `ComponentId`.
+//! 2. **Dispatch lookup**: callers of
+//!    [`super::registry_table::lookup_component`] check the static
+//!    `WELL_KNOWN` table first; if no entry exists there and the id
+//!    is in the app range, the runtime registry is consulted.
+//! 3. **Per-group registration**: registering a custom component in
+//!    a *group's* `COMPONENT_REGISTRY` happens via
+//!    `IntentKind::UpdatePermission` (post-bootstrap), separately
+//!    from the host-process registration here. Both must happen
+//!    before a group can carry a custom component's value: the host
+//!    needs a `RuntimeComponent` impl to decode the bytes, and the
+//!    group needs a registry entry so writes pass
+//!    `validate_component_write`.
+//!
+//! ## Why a global rather than per-Client
+//!
+//! Threading a per-`Client` registry through every dispatch site
+//! (`apply_app_data_update_payload`, `expand_app_data_update_to_changes`,
+//! `validate_component_write`, the facade) would touch ~dozens of
+//! call shapes. A process-global registry keeps the dispatch
+//! signature stable and reflects the operational reality: hosts
+//! register their custom-component shapes once, at process startup,
+//! before any group is created. There is no use case for "different
+//! Clients in the same process know different custom components."
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, OnceLock},
+};
+
+use parking_lot::RwLock;
+
+use openmls::messages::proposals::AppDataUpdateOperation;
+use xmtp_common::{MaybeSend, MaybeSync};
+use xmtp_proto::xmtp::mls::message_contents::ComponentType;
+
+use super::{
+    component_id::ComponentId,
+    component_registry::ComponentRegistry,
+    typed::{
+        ComponentInvariantError, ComponentTypedError, ErasedComponent, ExpandedComponentChange,
+    },
+    validation::ComponentChange,
+};
+
+/// A host-defined component whose `ComponentId` is known at runtime.
+///
+/// Unlike [`super::typed::Component`], `RuntimeComponent` takes
+/// `&self` and reports its id via [`Self::id`] so a single impl can
+/// service multiple distinct ids (or build them dynamically). The
+/// trait is otherwise structurally identical to `Component` minus
+/// the typed `Value` / `Mutation` associated types — runtime
+/// components handle bytes only, since the host owns whatever
+/// further decoding it does on top.
+///
+/// The bounds are [`MaybeSend`] + [`MaybeSync`] rather than `Send +
+/// Sync` so that WASM hosts can register impls that hold non-`Send`
+/// state (e.g. JS-bound objects). On native targets these expand to
+/// `Send + Sync` and the trait behaves identically to before; on
+/// `wasm32` they expand to vacuous bounds. The dispatch path's static
+/// storage requirements are bridged in [`RuntimeAdapter`] below — see
+/// the SAFETY note there.
+pub trait RuntimeComponent: MaybeSend + MaybeSync + 'static {
+    /// The component this instance handles.
+    fn id(&self) -> ComponentId;
+
+    /// Logical wire type, written into the registry entry's
+    /// `ComponentMetadata.component_type` slot. The host typically
+    /// picks one of the existing [`ComponentType`] variants
+    /// (`Bytes`, `String`, `TlsSetInboxId`, etc.) — runtime
+    /// components are not currently expected to introduce new
+    /// `ComponentType`s.
+    fn component_type(&self) -> ComponentType;
+
+    /// Apply an `AppDataUpdateOperation::Update` payload against the
+    /// prior bytes (if any) and produce the new full-state bytes.
+    fn apply_update_payload(
+        &self,
+        payload: &[u8],
+        prior: Option<&[u8]>,
+    ) -> Result<Vec<u8>, ComponentTypedError>;
+
+    /// Expand an `AppDataUpdate` proposal into per-element changes
+    /// for the validator's policy loop.
+    fn expand_to_changes(
+        &self,
+        op: &AppDataUpdateOperation,
+        prior: Option<&[u8]>,
+    ) -> Result<Vec<ExpandedComponentChange>, ComponentTypedError>;
+
+    /// Optional component-local invariant check. Default no-op.
+    fn validate_invariant(
+        &self,
+        _change: &ComponentChange<'_>,
+        _registry: &ComponentRegistry,
+    ) -> Result<(), ComponentInvariantError> {
+        Ok(())
+    }
+}
+
+/// Adapter so a [`RuntimeComponent`] can be used wherever an
+/// [`ErasedComponent`] is expected. The dispatch table consults
+/// runtime components via this adapter.
+struct RuntimeAdapter(Arc<dyn RuntimeComponent>);
+
+// SAFETY: wasm32 is single-threaded; the runtime registry's
+// `Arc<dyn RuntimeComponent>` is only ever accessed from the same
+// thread that registered it. On native, `RuntimeComponent` carries
+// `Send + Sync` (via `MaybeSend + MaybeSync`) so this impl is
+// unnecessary — only WASM needs the manual bridge because the trait
+// bounds are vacuous there but `ErasedComponent` (used by the static
+// dispatch table) still requires `Send + Sync`.
+#[cfg(target_arch = "wasm32")]
+unsafe impl Send for RuntimeAdapter {}
+#[cfg(target_arch = "wasm32")]
+unsafe impl Sync for RuntimeAdapter {}
+
+impl ErasedComponent for RuntimeAdapter {
+    fn id(&self) -> ComponentId {
+        self.0.id()
+    }
+
+    fn component_type(&self) -> ComponentType {
+        self.0.component_type()
+    }
+
+    fn apply_update_payload(
+        &self,
+        payload: &[u8],
+        prior: Option<&[u8]>,
+    ) -> Result<Vec<u8>, ComponentTypedError> {
+        self.0.apply_update_payload(payload, prior)
+    }
+
+    fn expand_to_changes(
+        &self,
+        op: &AppDataUpdateOperation,
+        prior: Option<&[u8]>,
+    ) -> Result<Vec<ExpandedComponentChange>, ComponentTypedError> {
+        self.0.expand_to_changes(op, prior)
+    }
+
+    fn validate_invariant(
+        &self,
+        change: &ComponentChange<'_>,
+        registry: &ComponentRegistry,
+    ) -> Result<(), ComponentInvariantError> {
+        self.0.validate_invariant(change, registry)
+    }
+}
+
+/// Errors surfaced by [`register_global_runtime_component`].
+#[derive(Debug, thiserror::Error)]
+pub enum RuntimeRegistrationError {
+    /// The id is outside the app range (`0xC000-0xFEFF`).
+    /// XMTP-range ids are reserved for static well-known impls.
+    #[error("component id {0} is not in the app-defined range (0xC000-0xFEFF)")]
+    OutOfRange(ComponentId),
+
+    /// The id is already registered. Re-registration is rejected
+    /// unconditionally — even with the same impl — because
+    /// `Arc<dyn>` and `&'static dyn` have different fat-pointer
+    /// layouts, so we can't cheaply detect "same impl" without
+    /// extra bookkeeping. Hosts should `Once`-gate their startup
+    /// registration paths.
+    #[error("component id {0} is already registered")]
+    AlreadyRegistered(ComponentId),
+}
+
+/// Process-global runtime component registry.
+///
+/// Stores `Arc<dyn RuntimeComponent>` keyed by `ComponentId`. The
+/// adapter wrapping each entry into `&'static dyn ErasedComponent`
+/// is also cached so the dispatch path can hand back a stable
+/// `&'static` reference. Updates happen at process startup; reads
+/// happen on every commit's validation path.
+struct RuntimeRegistry {
+    inner: RwLock<HashMap<ComponentId, &'static dyn ErasedComponent>>,
+}
+
+impl RuntimeRegistry {
+    fn new() -> Self {
+        Self {
+            inner: RwLock::new(HashMap::new()),
+        }
+    }
+
+    fn register(
+        &self,
+        component: Arc<dyn RuntimeComponent>,
+    ) -> Result<(), RuntimeRegistrationError> {
+        let id = component.id();
+        if !id.is_app_range() {
+            return Err(RuntimeRegistrationError::OutOfRange(id));
+        }
+        let mut guard = self.inner.write();
+        if let Some(_existing) = guard.get(&id) {
+            // Bypass the duplicate check if pointer-equal: re-
+            // registering the same impl is harmless and lets hosts
+            // call `register_global_runtime_component` from
+            // idempotent setup paths.
+            //
+            // We can't compare the underlying `Arc<dyn ...>`
+            // pointers directly because `&'static dyn` and
+            // `Arc<dyn>` have different fat-pointer layouts. For
+            // now treat any second registration as an error;
+            // hosts can `Once`-gate their setup.
+            return Err(RuntimeRegistrationError::AlreadyRegistered(id));
+        }
+        // Leak the adapter to get a `&'static` — runtime components
+        // live for the process lifetime by design (registered at
+        // startup, never unregistered). `Box::leak` of an `Arc`
+        // adapter is the simplest way to mint a static reference
+        // that the dispatch table can hand back.
+        let adapter: Box<dyn ErasedComponent> = Box::new(RuntimeAdapter(component));
+        let leaked: &'static dyn ErasedComponent = Box::leak(adapter);
+        guard.insert(id, leaked);
+        Ok(())
+    }
+
+    fn lookup(&self, id: ComponentId) -> Option<&'static dyn ErasedComponent> {
+        self.inner.read().get(&id).copied()
+    }
+}
+
+fn registry() -> &'static RuntimeRegistry {
+    static REGISTRY: OnceLock<RuntimeRegistry> = OnceLock::new();
+    REGISTRY.get_or_init(RuntimeRegistry::new)
+}
+
+/// Register a host-defined runtime component.
+///
+/// Call once per component at process startup, before any
+/// `Client` operates on a group that may carry this component.
+/// Returns `Err(OutOfRange)` if the id is outside `0xC000-0xFEFF`,
+/// `Err(AlreadyRegistered)` if a different impl is already
+/// registered for the same id.
+///
+/// The component lives for the process lifetime — there is no
+/// `unregister`. Hosts that need to swap impls should restart.
+pub fn register_global_runtime_component(
+    component: Arc<dyn RuntimeComponent>,
+) -> Result<(), RuntimeRegistrationError> {
+    registry().register(component)
+}
+
+/// Look up a runtime-registered component by id.
+///
+/// Returns `None` if the id is not in the app range (those go
+/// through the static `WELL_KNOWN` dispatch table) or if no host
+/// has registered a `RuntimeComponent` for the id yet.
+pub(crate) fn lookup_runtime_component(id: ComponentId) -> Option<&'static dyn ErasedComponent> {
+    if !id.is_app_range() {
+        return None;
+    }
+    registry().lookup(id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app_data::component_registry::ComponentOp;
+
+    /// A test-only RuntimeComponent that just passes Bytes through.
+    /// Each instance carries its own id so different test cases
+    /// don't collide on the global registry.
+    struct PassthroughBytes(ComponentId);
+
+    impl RuntimeComponent for PassthroughBytes {
+        fn id(&self) -> ComponentId {
+            self.0
+        }
+
+        fn component_type(&self) -> ComponentType {
+            ComponentType::Bytes
+        }
+
+        fn apply_update_payload(
+            &self,
+            payload: &[u8],
+            _prior: Option<&[u8]>,
+        ) -> Result<Vec<u8>, ComponentTypedError> {
+            Ok(payload.to_vec())
+        }
+
+        fn expand_to_changes(
+            &self,
+            op: &AppDataUpdateOperation,
+            _prior: Option<&[u8]>,
+        ) -> Result<Vec<ExpandedComponentChange>, ComponentTypedError> {
+            match op {
+                AppDataUpdateOperation::Update(p) => Ok(vec![ExpandedComponentChange {
+                    op: ComponentOp::Update,
+                    value: Some(p.as_slice().to_vec()),
+                }]),
+                AppDataUpdateOperation::Remove => Ok(vec![ExpandedComponentChange {
+                    op: ComponentOp::Delete,
+                    value: None,
+                }]),
+            }
+        }
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn rejects_out_of_range_ids() {
+        let well_known_id = ComponentId::GROUP_NAME; // XMTP range
+        let err = register_global_runtime_component(Arc::new(PassthroughBytes(well_known_id)))
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            RuntimeRegistrationError::OutOfRange(id) if id == well_known_id
+        ));
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn registers_and_dispatches_through_lookup() {
+        // Pick a unique id per test run to avoid cross-test
+        // collisions on the process-global registry. 0xC100 is
+        // arbitrary but stays in the app range.
+        let id = ComponentId::new(0xC100);
+
+        // First registration succeeds.
+        register_global_runtime_component(Arc::new(PassthroughBytes(id))).unwrap();
+
+        // Lookup returns an ErasedComponent that handles the id.
+        let entry = lookup_runtime_component(id).expect("registered component should look up");
+        assert_eq!(entry.id(), id);
+        assert_eq!(entry.component_type(), ComponentType::Bytes);
+
+        // Apply path works.
+        let new = entry.apply_update_payload(b"hello", None).unwrap();
+        assert_eq!(new, b"hello");
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn duplicate_registration_rejected() {
+        // Use a different id than `registers_and_dispatches_through_lookup`
+        // so test ordering doesn't matter.
+        let id = ComponentId::new(0xC101);
+        register_global_runtime_component(Arc::new(PassthroughBytes(id))).unwrap();
+
+        let err = register_global_runtime_component(Arc::new(PassthroughBytes(id))).unwrap_err();
+        assert!(matches!(
+            err,
+            RuntimeRegistrationError::AlreadyRegistered(seen) if seen == id
+        ));
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn lookup_returns_none_for_unregistered_id() {
+        // 0xC1FF is reserved for "no test ever uses this" — so
+        // this lookup deterministically returns None even when
+        // tests run in arbitrary order.
+        let unregistered = ComponentId::new(0xC1FF);
+        assert!(lookup_runtime_component(unregistered).is_none());
+
+        // XMTP-range ids always return None from the runtime path
+        // (they're handled by the static dispatch table instead).
+        assert!(lookup_runtime_component(ComponentId::GROUP_NAME).is_none());
+    }
+}

--- a/crates/xmtp_mls_common/src/app_data/migration.rs
+++ b/crates/xmtp_mls_common/src/app_data/migration.rs
@@ -328,6 +328,11 @@ fn build_registry(
 /// bytes, while everything else is utf-8 text. Tagging the type here
 /// drives `new_component_metadata` to register the correct
 /// `ComponentType`.
+///
+/// The `(ComponentId, ComponentType)` pairs in this table must agree
+/// with the static dispatch table at
+/// [`super::registry_table::WELL_KNOWN`] — pinned by the unit test
+/// `metadata_field_mapping_agrees_with_dispatch_table` below.
 fn metadata_field_registry_mapping() -> &'static [(MetadataField, ComponentId, ComponentType)] {
     &[
         (
@@ -923,6 +928,26 @@ mod tests {
                 ))
             }
         );
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn metadata_field_mapping_agrees_with_dispatch_table() {
+        // The `metadata_field_registry_mapping` table duplicates
+        // ComponentType info that `WELL_KNOWN` now also carries (one
+        // entry per `Component` impl). Pin the invariant: if a
+        // future change drifts one of the tables out of sync (e.g.
+        // changes a Bytes component to String only in WELL_KNOWN),
+        // this test catches it before any commit goes out.
+        use crate::app_data::registry_table::lookup_component;
+        for (_field, component_id, expected_type) in metadata_field_registry_mapping() {
+            let dispatched = lookup_component(*component_id)
+                .unwrap_or_else(|| panic!("WELL_KNOWN missing entry for {component_id}"));
+            assert_eq!(
+                dispatched.component_type(),
+                *expected_type,
+                "metadata_field_registry_mapping disagrees with WELL_KNOWN for {component_id}"
+            );
+        }
     }
 
     #[test]

--- a/crates/xmtp_mls_common/src/app_data/mod.rs
+++ b/crates/xmtp_mls_common/src/app_data/mod.rs
@@ -2,6 +2,7 @@ pub mod component_id;
 pub mod component_permissions;
 pub mod component_registry;
 pub mod components;
+pub mod custom;
 pub mod migration;
 pub mod registry_table;
 pub mod typed;

--- a/crates/xmtp_mls_common/src/app_data/registry_table.rs
+++ b/crates/xmtp_mls_common/src/app_data/registry_table.rs
@@ -63,17 +63,33 @@ pub static WELL_KNOWN: &[(ComponentId, &'static dyn ErasedComponent)] = &[
     (ComponentId::DM_MEMBERS, &DmMembersComponent),
 ];
 
-/// Look up the [`ErasedComponent`] for a well-known [`ComponentId`].
+/// Look up the [`ErasedComponent`] for a [`ComponentId`].
 ///
-/// Returns `None` for app-range custom IDs (those resolve via
-/// `app_data::custom` instead) and for IDs with no `Component` impl
-/// (e.g. the `0xBE0x` immutable seeds — handled by the bootstrap
-/// validator's byte-compare path, not the trait).
+/// The two sources are disjoint by construction — `WELL_KNOWN`
+/// entries all sit in the XMTP range (`0x8000-0xBFFF`) and runtime
+/// entries are gated to the app range (`0xC000-0xFEFF`) at
+/// registration time — so we route by id space and skip the wrong
+/// table entirely:
+///
+/// 1. XMTP range → binary-search the static `WELL_KNOWN` table.
+/// 2. App range → consult the process-global runtime registry
+///    ([`super::custom::lookup_runtime_component`]).
+/// 3. Reserved range (`0xFF00-0xFFFF`) → no dispatch.
+///
+/// Returns `None` if the id is in a known range but has no impl
+/// registered (e.g. the `0xBE0x` immutable seeds — handled by the
+/// bootstrap validator's byte-compare path rather than the trait).
 pub fn lookup_component(id: ComponentId) -> Option<&'static dyn ErasedComponent> {
-    WELL_KNOWN
-        .binary_search_by_key(&id.as_u16(), |(component_id, _)| component_id.as_u16())
-        .ok()
-        .map(|idx| WELL_KNOWN[idx].1)
+    if id.is_xmtp_range() {
+        return WELL_KNOWN
+            .binary_search_by_key(&id.as_u16(), |(component_id, _)| component_id.as_u16())
+            .ok()
+            .map(|idx| WELL_KNOWN[idx].1);
+    }
+    if id.is_app_range() {
+        return super::custom::lookup_runtime_component(id);
+    }
+    None
 }
 
 /// Compile-time check that [`WELL_KNOWN`] is strictly ascending by


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add runtime component registry to `lookup_component` for app-range `ComponentId` dispatch
- Introduces a `RuntimeComponent` trait and process-global `RuntimeRegistry` in [`custom.rs`](https://github.com/xmtp/libxmtp/pull/3594/files#diff-33c4d572e2ded5d568d863d307ea5f80bda5f485f78a202a50fc012e0c25cb52) so hosts can register custom components keyed by app-range `ComponentId` at startup.
- Updates [`lookup_component`](https://github.com/xmtp/libxmtp/pull/3594/files#diff-dac151bd9d59cbdc7d59c932a5319a050a31ef5b4a4748c73b8112a7a77b47a4) to route XMTP-range IDs to the static `WELL_KNOWN` table and app-range IDs to the new runtime registry, returning `None` for all others.
- Adds a `RuntimeAdapter` that wraps `Arc<dyn RuntimeComponent>` and implements `ErasedComponent`, allowing runtime-registered components to participate in apply and validation dispatch.
- Adds a unit test in [`migration.rs`](https://github.com/xmtp/libxmtp/pull/3594/files#diff-fb2c0e4b1c9d4141db1c1b094ed137f5ae4b462fb774ee95a8889b41e5c5ed73) that pins `WELL_KNOWN` against `metadata_field_registry_mapping()` to catch `ComponentType` mismatches at test time.
- Risk: `RuntimeAdapter` uses `unsafe` `Send`/`Sync` impls gated to `wasm32`; registered components are leaked via `Box::leak` to produce `'static` references.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized af704e8.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->