### PR TITLE
bindings: expose enable_proposals() in mobile/wasm/node bindings (Task 7+ production wiring)

### DIFF
--- a/bindings/mobile/src/mls.rs
+++ b/bindings/mobile/src/mls.rs
@@ -2576,6 +2576,29 @@ impl FfiConversation {
         Ok(())
     }
 
+    /// Enable AppData-proposal-based metadata updates on this group.
+    ///
+    /// Builds and stages the bootstrap commit that migrates this
+    /// group's per-field metadata, admin lists, permissions, and
+    /// membership from the legacy `GroupContextExtensions` shape into
+    /// the unified OpenMLS `AppDataDictionary`. After it returns
+    /// successfully, all subsequent metadata updates flow as
+    /// `AppDataUpdate` proposals rather than GCE proposals.
+    ///
+    /// **Requires**: every existing member's latest key package must
+    /// advertise `ProposalType::AppDataUpdate`. Hosts should ramp
+    /// adoption with the migration code shipped before flipping any
+    /// group; the call hard-fails with `ProposalsNotSupported` if
+    /// any member lags. (The error currently surfaces a static
+    /// message; structured per-inbox lag info is a future
+    /// enhancement.)
+    ///
+    /// **One-way**: a migrated group cannot return to the legacy
+    /// path. Operationally treated as a flag day per group.
+    pub async fn enable_proposals(&self) -> Result<(), FfiError> {
+        self.inner.enable_proposals().await.map_err(Into::into)
+    }
+
     pub fn group_name(&self) -> Result<String, FfiError> {
         let group_name = self.inner.group_name()?;
         Ok(group_name)

--- a/bindings/node/src/conversation/metadata.rs
+++ b/bindings/node/src/conversation/metadata.rs
@@ -55,6 +55,22 @@ impl Conversation {
     Ok(())
   }
 
+  /// Enable AppData-proposal-based metadata updates on this group.
+  ///
+  /// Stages the bootstrap commit that migrates the group's metadata
+  /// from the legacy GroupContextExtensions shape into the OpenMLS
+  /// AppData dictionary. Hard-fails if any member's latest key
+  /// package doesn't advertise `ProposalType::AppDataUpdate`. One-
+  /// way: migrated groups cannot return to the legacy path.
+  #[napi]
+  pub async fn enable_proposals(&self) -> Result<()> {
+    let group = self.create_mls_group();
+    group
+      .enable_proposals()
+      .await
+      .map_err(|e| ErrorWrapper::from(e).into())
+  }
+
   #[napi]
   pub fn group_description(&self) -> Result<String> {
     let group = self.create_mls_group();

--- a/bindings/wasm/src/conversation.rs
+++ b/bindings/wasm/src/conversation.rs
@@ -645,6 +645,19 @@ impl Conversation {
     Ok(())
   }
 
+  /// Enable AppData-proposal-based metadata updates on this group.
+  ///
+  /// Stages the bootstrap commit that migrates the group's metadata
+  /// from the legacy GroupContextExtensions shape into the OpenMLS
+  /// AppData dictionary. Hard-fails if any member's latest key
+  /// package doesn't advertise `ProposalType::AppDataUpdate`. One-
+  /// way: migrated groups cannot return to the legacy path.
+  #[wasm_bindgen(js_name = enableProposals)]
+  pub async fn enable_proposals(&self) -> Result<(), JsError> {
+    let group = self.to_mls_group();
+    group.enable_proposals().await.map_err(ErrorWrapper::js)
+  }
+
   #[wasm_bindgen(js_name = groupName)]
   pub fn group_name(&self) -> Result<String, JsError> {
     let group = self.to_mls_group();


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Expose `enable_proposals()` in mobile, WASM, and Node.js bindings
Adds `enable_proposals` as a public async method on `Conversation` in all three binding targets: [mls.rs](https://github.com/xmtp/libxmtp/pull/3595/files#diff-ce381c5891b3b5967aca582076bc5241ba04fc310d39949fed1859da13d876ec) (FFI/mobile), [metadata.rs](https://github.com/xmtp/libxmtp/pull/3595/files#diff-3ada3b6dfc7c6089e2528c0823a058c967f88435da5f8c6a9ad79aae96d006c7) (N-API/Node), and [conversation.rs](https://github.com/xmtp/libxmtp/pull/3595/files#diff-35aeb79801a6cf0400cf956eb71fc0cbad1420701406c6992d70ddf543739e6e) (WASM). Each binding delegates to the underlying MLS group's `enable_proposals()` and maps errors to the appropriate wrapper type for its platform.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 74514ae.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->