### PR TITLE
xmtp_mls: real impl for ProposeMemberUpdate via AppDataUpdate(GROUP_MEMBERSHIP) on migrated groups

### DIFF
--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -2926,30 +2926,40 @@ where
                     return Err(GroupError::from(CommitValidationError::ProposalsNotEnabled));
                 }
 
-                // Defensive gate. The proposal-by-reference flow
-                // emits Add/Remove + GCE proposals updating the
-                // legacy GROUP_MEMBERSHIP_EXTENSION_ID extension. On
-                // migrated groups that extension is gone, so the
-                // GCE would re-add it and break the dict-as-source-
-                // of-truth invariant. Bail out the same way Task 7c
-                // (`apply_update_group_membership_intent`) does, via
-                // the same canonical `is_migrated_extensions`
-                // predicate.
-                if super::app_data::is_migrated_extensions(openmls_group.extensions()) {
-                    return Err(GroupError::UpdateGroupMembershipMigratedNotImplemented);
-                }
+                // Detect whether this is a migrated group. On
+                // migrated groups, in addition to the Add/Remove
+                // proposals below, we also emit an
+                // `AppDataUpdate(GROUP_MEMBERSHIP)` proposal carrying
+                // the membership delta. The subsequent
+                // `CommitPendingProposals` intent sweeps everything
+                // into a single commit. Bootstrap removed the legacy
+                // `GROUP_MEMBERSHIP_EXTENSION_ID` extension, so the
+                // legacy GCE proposal that `CommitPendingProposals`
+                // would otherwise emit is no-op on migrated groups —
+                // the AppData path carries the source of truth.
+                //
+                // Uses the canonical `is_migrated_group` predicate
+                // (presence of the `COMPONENT_REGISTRY` entry) to
+                // match every other send/receive/validate gate.
+                let is_migrated = super::app_data::is_migrated_group(openmls_group);
 
                 let intent_data = ProposeMemberUpdateIntentData::try_from(intent.data.as_slice())?;
                 let group_epoch = openmls_group.epoch().as_u64();
                 let signer = &self.context.identity().installation_keys;
                 let mut proposal_payloads = Vec::new();
 
+                // The membership the AppDataUpdate proposal will encode on
+                // migrated groups. We mutate this as we process adds/removes
+                // so it ends up reflecting only the inbox_ids that actually
+                // got Add proposals (i.e. had at least one key package that
+                // fetched successfully) plus any explicit removes — not the
+                // raw intent.
+                let extensions: Extensions<GroupContext> = openmls_group.extensions().clone();
+                let old_group_membership = extract_group_membership(&extensions)?;
+                let mut new_membership = old_group_membership.clone();
+
                 // Handle adds
                 if !intent_data.add_inbox_ids.is_empty() {
-                    // Get current group membership
-                    let extensions: Extensions<GroupContext> = openmls_group.extensions().clone();
-                    let old_group_membership = extract_group_membership(&extensions)?;
-
                     // Get latest sequence IDs for the inbox_ids to add
                     let inbox_ids_to_add: Vec<&str> = intent_data
                         .add_inbox_ids
@@ -2969,21 +2979,21 @@ where
                         .db()
                         .get_latest_sequence_id(&inbox_ids_to_add)?;
 
-                    // Build the new membership with the added inbox_ids
-                    let mut new_membership = old_group_membership.clone();
+                    // Build the projected membership for kp lookup.
+                    let mut projected = old_group_membership.clone();
                     for inbox_id in &intent_data.add_inbox_ids {
                         let sequence_id = latest_sequence_ids
                             .get(inbox_id.as_str())
                             .copied()
                             .ok_or(GroupError::MissingSequenceId)?;
-                        new_membership.add(inbox_id.clone(), sequence_id as u64);
+                        projected.add(inbox_id.clone(), sequence_id as u64);
                     }
 
                     // Get key packages for the installations to add
                     let changes_with_kps = calculate_membership_changes_with_keypackages(
                         &self.context,
                         &self.group_id,
-                        &new_membership,
+                        &projected,
                         &old_group_membership,
                     )
                     .await?;
@@ -2994,6 +3004,52 @@ where
                     {
                         return Err(GroupError::FailedToVerifyInstallations);
                     }
+
+                    // Compute the inbox_ids that actually got at least one
+                    // key package — those are the only ones that should
+                    // appear in the AppDataUpdate payload below. An
+                    // inbox_id whose installations all failed kp fetch has
+                    // no MLS leaf in the commit, so claiming membership
+                    // for it would diverge dict and tree state.
+                    let added_inbox_ids: HashSet<String> = changes_with_kps
+                        .new_key_packages
+                        .iter()
+                        .filter_map(|kp| {
+                            let credential =
+                                BasicCredential::try_from(kp.leaf_node().credential().clone())
+                                    .ok()?;
+                            parse_credential(credential.identity()).ok()
+                        })
+                        .collect();
+                    for inbox_id in &intent_data.add_inbox_ids {
+                        if !added_inbox_ids.contains(inbox_id) {
+                            continue;
+                        }
+                        let sequence_id = latest_sequence_ids
+                            .get(inbox_id.as_str())
+                            .copied()
+                            .ok_or(GroupError::MissingSequenceId)?;
+                        new_membership.add(inbox_id.clone(), sequence_id as u64);
+                    }
+
+                    // Carry forward the failed-installations set on
+                    // the local `new_membership`. On the legacy path
+                    // this drives the GCE proposal that
+                    // `CommitPendingProposals` emits against
+                    // GROUP_MEMBERSHIP_EXTENSION_ID, where
+                    // failed_installations is part of the wire form.
+                    // On the migrated path the AppDataUpdate payload
+                    // built by `build_group_membership_app_data_payload`
+                    // intentionally does NOT propagate
+                    // failed_installations (see that function's doc);
+                    // we still set it here so the equality check at
+                    // the AppDataUpdate emit site below
+                    // (`old_group_membership != new_membership`)
+                    // detects kp-failure-only deltas, and so the
+                    // unmigrated and migrated branches share one
+                    // `new_membership` value.
+                    new_membership.failed_installations =
+                        changes_with_kps.failed_installations.clone();
 
                     // Generate add proposals for each key package
                     for key_package in &changes_with_kps.new_key_packages {
@@ -3028,6 +3084,10 @@ where
                             .map_err(GroupError::ProposeRemoveMember)?;
                         proposal_payloads.push(proposal_msg.tls_serialize_detached()?);
                     }
+
+                    for inbox_id in &intent_data.remove_inbox_ids {
+                        new_membership.remove(inbox_id);
+                    }
                 }
 
                 if proposal_payloads.is_empty() {
@@ -3041,9 +3101,39 @@ where
                     return Ok(None);
                 }
 
+                // On migrated groups, emit a parallel
+                // `AppDataUpdate(GROUP_MEMBERSHIP)` proposal carrying
+                // the membership delta we computed above (filtered to
+                // kp-successful adds + explicit removes + carried-
+                // forward failed_installations). The subsequent
+                // `CommitPendingProposals` intent sweeps Add/Remove
+                // and AppDataUpdate proposals into one commit and
+                // skips the legacy GCE proposal (since the legacy
+                // GROUP_MEMBERSHIP_EXTENSION_ID is gone post-bootstrap).
+                if is_migrated && old_group_membership != new_membership {
+                    use crate::groups::mls_sync::update_group_membership::build_group_membership_app_data_payload;
+
+                    let payload = build_group_membership_app_data_payload(
+                        &old_group_membership,
+                        &new_membership,
+                    )?;
+                    let (proposal_msg, _) = openmls_group
+                        .propose_app_data_update(
+                            &self.context.mls_provider(),
+                            signer,
+                            xmtp_mls_common::app_data::component_id::ComponentId::GROUP_MEMBERSHIP
+                                .as_u16(),
+                            openmls::messages::proposals::AppDataUpdateOperation::Update(
+                                payload.into(),
+                            ),
+                        )
+                        .map_err(GroupError::Proposal)?;
+                    proposal_payloads.push(proposal_msg.tls_serialize_detached()?);
+                }
+
                 // Note: The GroupContextExtensions proposal to update membership is created
-                // by CommitPendingProposals, not here. This avoids issues with tracking
-                // multiple message hashes per intent.
+                // by CommitPendingProposals, not here (and is no-op on migrated groups since
+                // the legacy GROUP_MEMBERSHIP_EXTENSION_ID is gone).
 
                 Ok(Some(PublishIntentData {
                     payloads_to_publish: proposal_payloads,
@@ -3290,7 +3380,19 @@ where
                         }
                     });
 
-                if membership_changed && !has_pending_gce_with_membership {
+                // Detect migrated state. On migrated groups the legacy
+                // `GROUP_MEMBERSHIP_EXTENSION_ID` is gone; membership
+                // updates flow as AppDataUpdate proposals (already
+                // emitted by `ProposeMemberUpdate` and sitting in the
+                // pending queue). The GCE proposal that this branch
+                // would otherwise build to update the legacy extension
+                // is skipped — the commit just sweeps the pending
+                // AppDataUpdate alongside the Add/Remove proposals.
+                let is_migrated_for_commit =
+                    super::app_data::is_migrated_extensions(openmls_group.extensions());
+
+                if membership_changed && !has_pending_gce_with_membership && !is_migrated_for_commit
+                {
                     // === GCE needed: batch GCE proposal + commit in one publish ===
                     // Create GCE proposal and commit locally inside one
                     // generate_commit_with_rollback call, returning both payloads.

--- a/crates/xmtp_mls/src/groups/mls_sync/update_group_membership.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync/update_group_membership.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::groups::group_membership::GroupMembership;
 use crate::groups::{
     GroupError, build_group_membership_extension,
     intents::{PostCommitAction, UpdateGroupMembershipIntentData},
@@ -8,10 +9,99 @@ use crate::groups::{
 use openmls::{
     extensions::Extensions,
     group::GroupContext,
-    messages::proposals::Proposal,
+    messages::proposals::{AppDataUpdateOperation, Proposal},
     prelude::{LeafNodeIndex, MlsGroup as OpenMlsGroup, tls_codec::Serialize},
 };
 use openmls_traits::signatures::Signer;
+use prost::Message;
+use tls_codec::VLBytes;
+use xmtp_mls_common::{
+    app_data::{
+        component_id::ComponentId, components::tls_map_components::GroupMembershipComponent,
+        typed::Component,
+    },
+    inbox_id::InboxId,
+    tls_map::TlsMapDelta,
+};
+use xmtp_proto::xmtp::mls::message_contents::{GroupMembershipEntry, group_membership_entry};
+
+/// Build the wire-level `TlsMapDelta<InboxId, VLBytes>` payload for an
+/// `AppDataUpdate(GROUP_MEMBERSHIP)` proposal from the diff between
+/// the old and new `GroupMembership` view. Shared between the commit-
+/// bundling `apply_update_group_membership_intent` flow and the
+/// propose-by-reference `IntentKind::ProposeMemberUpdate` flow so
+/// both emit byte-identical payloads for the same diff.
+///
+/// One mutation per affected inbox:
+/// - `Insert(inbox_id, encode(V1 { sequence_id, failed_installations: [] }))`
+///   for inboxes added.
+/// - `Update(inbox_id, encode(V1 { ... }))` for inboxes whose
+///   `sequence_id` changed.
+/// - `Delete(inbox_id)` for inboxes removed.
+///
+/// `failed_installations` is left empty here — per the proto comment
+/// it's a sender-authoritative retry-suppression hint and the
+/// per-inbox partitioning happens at bootstrap. Steady-state membership
+/// updates intentionally don't propagate failed_installations changes
+/// over the AppData path; the worst case is a slightly noisier retry
+/// loop. Future enhancement once a clearer attribution path exists.
+pub(crate) fn build_group_membership_app_data_payload(
+    old: &GroupMembership,
+    new: &GroupMembership,
+) -> Result<Vec<u8>, GroupError> {
+    let mut delta = TlsMapDelta::<InboxId, VLBytes>::new();
+
+    // Inserts and updates: walk new.members, classify against old.
+    for (inbox_id_str, &sequence_id) in new.members.iter() {
+        let entry = encode_membership_entry(sequence_id)?;
+        match old.members.get(inbox_id_str) {
+            None => {
+                // New inbox: Insert.
+                let inbox_id = InboxId::from_hex(inbox_id_str)
+                    .map_err(|e| GroupError::ComponentSource(e.into()))?;
+                delta = delta.insert(inbox_id, VLBytes::new(entry));
+            }
+            Some(&old_seq) if old_seq != sequence_id => {
+                // Existing inbox with bumped sequence_id: Update.
+                let inbox_id = InboxId::from_hex(inbox_id_str)
+                    .map_err(|e| GroupError::ComponentSource(e.into()))?;
+                delta = delta.update(inbox_id, VLBytes::new(entry));
+            }
+            _ => {
+                // Same sequence_id, no change for this inbox.
+            }
+        }
+    }
+
+    // Deletes: in old but not new.
+    for inbox_id_str in old.members.keys() {
+        if !new.members.contains_key(inbox_id_str) {
+            let inbox_id = InboxId::from_hex(inbox_id_str)
+                .map_err(|e| GroupError::ComponentSource(e.into()))?;
+            delta = delta.delete(inbox_id);
+        }
+    }
+
+    <GroupMembershipComponent as Component>::encode_mutation(&delta).map_err(|e| {
+        GroupError::ComponentSource(
+            crate::groups::app_data::component_source::ComponentSourceError::from(e),
+        )
+    })
+}
+
+/// Encode a per-inbox `GroupMembershipEntry::V1` value with the given
+/// `sequence_id` and an empty `failed_installations` list.
+fn encode_membership_entry(sequence_id: u64) -> Result<Vec<u8>, GroupError> {
+    let entry = GroupMembershipEntry {
+        version: Some(group_membership_entry::Version::V1(
+            group_membership_entry::V1 {
+                sequence_id,
+                failed_installations: vec![],
+            },
+        )),
+    };
+    Ok(entry.encode_to_vec())
+}
 
 // Takes UpdateGroupMembershipIntentData and applies it to the openmls group
 // returning the commit and post_commit_action
@@ -22,24 +112,6 @@ pub(crate) async fn apply_update_group_membership_intent(
     intent_data: UpdateGroupMembershipIntentData,
     signer: impl Signer,
 ) -> Result<Option<PublishIntentData>, GroupError> {
-    // Defensive gate. The full AppDataUpdate wiring for
-    // GROUP_MEMBERSHIP needs end-to-end integration coverage to pin
-    // the wire-shape decisions (per-inbox `GroupMembershipEntryV1`
-    // partitioning, `failed_installations` propagation across
-    // steady-state). Until that lands, fail fast on migrated groups
-    // so a host that prematurely calls `enable_proposals()` doesn't
-    // emit a GCE proposal that re-adds the legacy
-    // `GROUP_MEMBERSHIP_EXTENSION_ID` extension bootstrap just
-    // removed.
-    //
-    // Uses the canonical `is_migrated_extensions` predicate (presence
-    // of the `COMPONENT_REGISTRY` entry written by the bootstrap
-    // commit) so this gate agrees with every other send/receive/
-    // validate path in the migration.
-    if super::super::app_data::is_migrated_extensions(openmls_group.extensions()) {
-        return Err(GroupError::UpdateGroupMembershipMigratedNotImplemented);
-    }
-
     let extensions = openmls_group.extensions().clone();
     let old_group_membership = extract_group_membership(&extensions)?;
     let new_group_membership = intent_data.apply_to_group_membership(&old_group_membership);
@@ -67,10 +139,26 @@ pub(crate) async fn apply_update_group_membership_intent(
         return Ok(None);
     }
 
-    // Update the extensions to have the new GroupMembership
-    let mut new_extensions = extensions.clone();
+    // Detect whether this is a migrated group. On migrated groups the
+    // legacy `GROUP_MEMBERSHIP_EXTENSION_ID` is gone and the
+    // membership lives in the AppData dictionary; the membership
+    // delta travels as an `AppDataUpdate(GROUP_MEMBERSHIP)` proposal
+    // rather than a GCE proposal updating the legacy extension.
+    //
+    // Uses the canonical `is_migrated_extensions` predicate (presence
+    // of the `COMPONENT_REGISTRY` entry written by the bootstrap
+    // commit) so we agree with every other send/receive/validate gate
+    // in the migration.
+    let is_migrated = super::super::app_data::is_migrated_extensions(openmls_group.extensions());
 
-    new_extensions.add_or_replace(build_group_membership_extension(&new_group_membership))?;
+    // Update the extensions to have the new GroupMembership.
+    // On migrated groups we deliberately skip writing the legacy
+    // `GROUP_MEMBERSHIP_EXTENSION_ID` — bootstrap removed it and the
+    // AppDataUpdate proposal carries the delta instead.
+    let mut new_extensions = extensions.clone();
+    if !is_migrated {
+        new_extensions.add_or_replace(build_group_membership_extension(&new_group_membership))?;
+    }
 
     // Check if proposals need to be disabled due to new members not supporting them
     let proposal_ext_type =
@@ -79,6 +167,7 @@ pub(crate) async fn apply_update_group_membership_intent(
         .extensions()
         .iter()
         .any(|ext| ext.extension_type() == proposal_ext_type);
+    let mut downgrade_to_legacy = false;
     if proposals_currently_enabled && !changes_with_kps.new_key_packages.is_empty() {
         let new_members_support_proposals = changes_with_kps.new_key_packages.iter().all(|kp| {
             kp.leaf_node()
@@ -92,11 +181,30 @@ pub(crate) async fn apply_update_group_membership_intent(
             new_extensions.remove(proposal_ext_type);
             update_required_capabilities_for_proposals(&mut new_extensions, false)?;
             proposals_currently_enabled = false;
+            // If this group was migrated, downgrading to legacy
+            // means we need to re-add the legacy GROUP_MEMBERSHIP
+            // extension since the AppDataUpdate path is no longer
+            // available. (This is a rare rollback scenario; covered
+            // here defensively so the subsequent direct-commit path
+            // doesn't lose membership state.)
+            if is_migrated {
+                new_extensions
+                    .add_or_replace(build_group_membership_extension(&new_group_membership))?;
+                downgrade_to_legacy = true;
+            }
         }
     }
 
     if proposals_currently_enabled {
-        // Batched proposal path: proposals + GCE + commit in one publish
+        // Batched proposal path: proposals + (AppDataUpdate or GCE) + commit in one publish
+        let app_data_payload = if is_migrated {
+            Some(build_group_membership_app_data_payload(
+                &old_group_membership,
+                &new_group_membership,
+            )?)
+        } else {
+            None
+        };
         let publish_intent_data = compute_publish_data_for_proposal_based_update(
             context,
             openmls_group,
@@ -104,9 +212,11 @@ pub(crate) async fn apply_update_group_membership_intent(
             changes_with_kps.new_key_packages,
             leaf_nodes_to_remove,
             new_extensions,
+            app_data_payload,
             signer,
         )
         .await?;
+        let _ = downgrade_to_legacy; // marker so future logic can branch on it; currently unused
         Ok(Some(publish_intent_data))
     } else {
         // Direct commit path (no proposals)
@@ -166,9 +276,18 @@ async fn compute_publish_data_for_group_membership_update(
 }
 
 /// Like `compute_publish_data_for_group_membership_update`, but instead of creating a direct
-/// commit via `update_group_membership`, creates MLS proposals (Add/Remove + GCE) and a commit
-/// that references them. All payloads are returned together so they can be published in a single
-/// `send_group_messages` call, eliminating multiple network roundtrips.
+/// commit via `update_group_membership`, creates MLS proposals (Add/Remove + GCE *or*
+/// AppDataUpdate) and a commit that references them. All payloads are returned together so
+/// they can be published in a single `send_group_messages` call, eliminating multiple network
+/// roundtrips.
+///
+/// `app_data_membership_payload`:
+/// - `Some(bytes)` on migrated groups — emit an
+///   `AppDataUpdate(GROUP_MEMBERSHIP, Update(bytes))` proposal-by-reference.
+///   `bytes` is the wire-encoded `TlsMapDelta<InboxId, VLBytes>` from
+///   `build_group_membership_app_data_payload`.
+/// - `None` on unmigrated groups — fall back to a GCE proposal that
+///   updates the legacy `GROUP_MEMBERSHIP_EXTENSION_ID` extension.
 #[tracing::instrument(level = "trace", skip_all)]
 async fn compute_publish_data_for_proposal_based_update(
     context: &impl XmtpSharedContext,
@@ -177,14 +296,20 @@ async fn compute_publish_data_for_proposal_based_update(
     key_packages_to_add: Vec<KeyPackage>,
     leaf_nodes_to_remove: Vec<LeafNodeIndex>,
     new_extensions: Extensions<GroupContext>,
+    app_data_membership_payload: Option<Vec<u8>>,
     signer: impl Signer,
 ) -> Result<PublishIntentData, GroupError> {
-    // Compare current extensions to new_extensions to determine if a GCE is needed.
-    // This catches adds/removes, updated_inboxes (sequence ID bumps), and
-    // failed_installations changes.
-    let current_membership = extract_group_membership(openmls_group.extensions())?;
-    let new_membership_check = extract_group_membership(&new_extensions)?;
-    let extensions_changed = current_membership != new_membership_check;
+    let is_migrated_path = app_data_membership_payload.is_some();
+    // Only used on the legacy path. On the migrated path the
+    // membership delta travels via the AppDataUpdate proposal so the
+    // GCE-changed check is irrelevant.
+    let extensions_changed = if is_migrated_path {
+        false
+    } else {
+        let current_membership = extract_group_membership(openmls_group.extensions())?;
+        let new_membership_check = extract_group_membership(&new_extensions)?;
+        current_membership != new_membership_check
+    };
     let new_extensions_for_filter = new_extensions.clone();
 
     let ((proposal_payloads, bundle), staged_commit, group_epoch) =
@@ -207,32 +332,62 @@ async fn compute_publish_data_for_proposal_based_update(
                 proposal_payloads.push(msg.tls_serialize_detached()?);
             }
 
-            // 3. Create GCE proposal when the membership extension has changed
-            if extensions_changed {
+            // 3a. Migrated: emit AppDataUpdate(GROUP_MEMBERSHIP) proposal carrying the delta.
+            //     Receivers walk the proposal alongside the Add/Remove proposals
+            //     and apply the dict update via `accumulate_app_data_updates`.
+            if let Some(payload) = &app_data_membership_payload {
+                let (msg, _) = group
+                    .propose_app_data_update(
+                        provider,
+                        &signer,
+                        ComponentId::GROUP_MEMBERSHIP.as_u16(),
+                        AppDataUpdateOperation::Update(payload.clone().into()),
+                    )
+                    .map_err(GroupError::Proposal)?;
+                proposal_payloads.push(msg.tls_serialize_detached()?);
+            // 3b. Legacy: GCE proposal updating GROUP_MEMBERSHIP_EXTENSION_ID
+            //     (only when the membership actually changed).
+            } else if extensions_changed {
                 let (msg, _) = group
                     .propose_group_context_extensions(provider, new_extensions.clone(), &signer)
                     .map_err(GroupError::Proposal)?;
                 proposal_payloads.push(msg.tls_serialize_detached()?);
             }
 
-            // 4. Create commit consuming all proposals (including the ones just created)
-            let new_membership =
-                extract_group_membership(&new_extensions_for_filter).map_err(GroupError::from)?;
-            let bundle = group
+            // 4. Create commit consuming all proposals (including the ones just created).
+            //    On migrated groups, also pre-compute the dict updates
+            //    so the commit's confirmation tag agrees with what the
+            //    receiver will compute via its own AppDataUpdate apply path.
+            let new_membership = extract_group_membership(&new_extensions_for_filter).ok();
+            let app_data_updates = if is_migrated_path {
+                Some(crate::groups::app_data::pending_app_data_updates(group)?)
+            } else {
+                None
+            };
+            let mut stage = group
                 .commit_builder()
                 .consume_proposal_store(true)
                 .load_psks(provider.storage())
-                .map_err(CommitToPendingProposalsError::from)?
+                .map_err(CommitToPendingProposalsError::from)?;
+            if let Some(Some(updates)) = app_data_updates {
+                stage.with_app_data_dictionary_updates(Some(updates));
+            }
+            let bundle = stage
                 .build(provider.rand(), provider.crypto(), &signer, |qp| {
                     match qp.proposal() {
                         // Always filter GCEs against expected membership.
                         // Accept only if it matches our new_membership; reject stale ones.
                         // Compare the full GroupMembership (members + failed_installations).
-                        Proposal::GroupContextExtensions(gce) => {
-                            extract_group_membership(gce.extensions())
-                                .map(|m| m == new_membership)
-                                .unwrap_or(false)
-                        }
+                        // On migrated groups `extract_group_membership(new_extensions)`
+                        // can't extract (no legacy ext present); we conservatively
+                        // accept all GCEs in that case since the membership is
+                        // delivered via the AppDataUpdate proposal instead.
+                        Proposal::GroupContextExtensions(gce) => match &new_membership {
+                            Some(expected) => extract_group_membership(gce.extensions())
+                                .map(|m| &m == expected)
+                                .unwrap_or(false),
+                            None => true,
+                        },
                         _ => true,
                     }
                 })

--- a/crates/xmtp_mls/src/groups/mls_sync/update_group_membership.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync/update_group_membership.rs
@@ -288,6 +288,7 @@ async fn compute_publish_data_for_group_membership_update(
 ///   `build_group_membership_app_data_payload`.
 /// - `None` on unmigrated groups — fall back to a GCE proposal that
 ///   updates the legacy `GROUP_MEMBERSHIP_EXTENSION_ID` extension.
+#[allow(clippy::too_many_arguments)]
 #[tracing::instrument(level = "trace", skip_all)]
 async fn compute_publish_data_for_proposal_based_update(
     context: &impl XmtpSharedContext,


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Implement `ProposeMemberUpdate` via `AppDataUpdate(GROUP_MEMBERSHIP)` on migrated groups
- On migrated groups, `ProposeMemberUpdate` now emits an `AppDataUpdate(GROUP_MEMBERSHIP)` proposal alongside Add/Remove proposals instead of returning an error.
- Adds `build_group_membership_app_data_payload` in [update_group_membership.rs](https://github.com/xmtp/libxmtp/pull/3597/files#diff-56361bf0fcb1e9400991ea5996f3629427f28874ca78d913d3fd695be7c736f4) to compute TLS-encoded membership deltas (inserts, updates, deletes) from the diff between old and new `GroupMembership`.
- `compute_publish_data_for_proposal_based_update` now accepts an optional `AppDataUpdate` payload; on the migrated path it stages app data dictionary updates in the commit and skips emitting a legacy `GroupContextExtensions` proposal.
- When proposals must be disabled (new members lack support) on a migrated group, the legacy membership extension is restored to allow the direct-commit path to carry membership state.
- Behavioral Change: `ProposeGroupContextExtensions` skips creating a legacy GCE on migrated groups; `CommitPendingProposals` sweeps pending `AppDataUpdate` proposals instead.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 190b218.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->