### PR TITLE
allow setting native log level for platform specific tracing

### DIFF
--- a/bindings/mobile/Cargo.toml
+++ b/bindings/mobile/Cargo.toml
@@ -23,7 +23,7 @@ prost.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
-tracing = { workspace = true, features = ["release_max_level_debug"] }
+tracing = { workspace = true }
 tracing-appender = "0.2"
 tracing-subscriber = { workspace = true, features = [
   "registry",

--- a/bindings/mobile/src/logger.rs
+++ b/bindings/mobile/src/logger.rs
@@ -18,23 +18,49 @@ use tracing_subscriber::{
     registry::LookupSpan, registry::Registry, reload, util::SubscriberInitExt,
 };
 
+// Default native log level used until `set_native_log_level` is called.
+#[cfg(any(target_os = "android", target_os = "ios"))]
+const DEFAULT_NATIVE_LOG_LEVEL: FfiLogLevel = FfiLogLevel::Debug;
+
+// Native layers install on the global `Registry` (see `LOGGER`), so S is pinned
+// to `Registry` to give the reload handle a concrete, storable type.
+#[cfg(any(target_os = "android", target_os = "ios"))]
+static LIBXMTP_FILTER_HANDLE: std::sync::OnceLock<
+    parking_lot::Mutex<reload::Handle<tracing_subscriber::EnvFilter, Registry>>,
+> = std::sync::OnceLock::new();
+
+#[cfg(any(target_os = "android", target_os = "ios"))]
+fn set_native_filter(level: &str) -> Result<(), FfiError> {
+    let handle = LIBXMTP_FILTER_HANDLE
+        .get()
+        .ok_or_else(|| crate::GenericError::Generic {
+            err: "native logger not initialized".to_string(),
+        })?;
+    let new_filter = xmtp_common::filter_directive(level);
+    handle.lock().reload(new_filter)?;
+    Ok(())
+}
+
 #[cfg(target_os = "android")]
 pub use android::*;
 #[cfg(target_os = "android")]
 mod android {
     use super::*;
-    pub fn native_layer<S>() -> impl Layer<S>
-    where
-        S: Subscriber + for<'a> LookupSpan<'a>,
-    {
-        use tracing_subscriber::EnvFilter;
+    use tracing_subscriber::EnvFilter;
+
+    pub fn native_layer() -> impl Layer<Registry> {
         let api_calls_filter = EnvFilter::builder().parse_lossy("xmtp_api=debug");
-        let libxmtp_filter = xmtp_common::filter_directive("debug");
+        let libxmtp_filter = xmtp_common::filter_directive(DEFAULT_NATIVE_LOG_LEVEL.to_str());
+        let (reloadable_filter, handle) = reload::Layer::new(libxmtp_filter);
+        // `native_layer` is invoked exactly once via the `LOGGER` LazyLock; if
+        // somehow called again (e.g. a stray test re-init), keep the original
+        // handle so `set_native_log_level` still drives the live filter.
+        let _ = LIBXMTP_FILTER_HANDLE.set(parking_lot::Mutex::new(handle));
 
         vec![
             paranoid_android::layer(env!("CARGO_PKG_NAME"))
                 .with_thread_names(true)
-                .with_filter(libxmtp_filter)
+                .with_filter(reloadable_filter)
                 .boxed(),
             tracing_android_trace::AndroidTraceAsyncLayer::new()
                 .with_filter(api_calls_filter)
@@ -49,15 +75,14 @@ pub use ios::*;
 mod ios {
     use super::*;
     use tracing_oslog::OsLogger;
-    use tracing_subscriber::EnvFilter;
 
-    pub fn native_layer<S>() -> impl Layer<S>
-    where
-        S: Subscriber + for<'a> LookupSpan<'a>,
-    {
-        let libxmtp_filter = xmtp_common::filter_directive("debug");
+    pub fn native_layer() -> impl Layer<Registry> {
+        let libxmtp_filter = xmtp_common::filter_directive(DEFAULT_NATIVE_LOG_LEVEL.to_str());
+        let (reloadable_filter, handle) = reload::Layer::new(libxmtp_filter);
+        // See android::native_layer for the rationale on ignoring the set result.
+        let _ = LIBXMTP_FILTER_HANDLE.set(parking_lot::Mutex::new(handle));
         let subsystem = format!("org.xmtp.{}", env!("CARGO_PKG_NAME"));
-        OsLogger::new(subsystem, "default").with_filter(libxmtp_filter)
+        OsLogger::new(subsystem, "default").with_filter(reloadable_filter)
     }
 }
 
@@ -90,6 +115,11 @@ mod other {
                 })
             })
             .with_filter(filter)
+    }
+
+    // Non-mobile builds have no reloadable native filter; the FFI call is a no-op.
+    pub(super) fn set_native_filter(_level: &str) -> Result<(), FfiError> {
+        Ok(())
     }
 }
 
@@ -348,6 +378,14 @@ pub fn init_logger() {
     let _ = *LOGGER;
 }
 
+/// Updates the log level of the native log layer (oslog on iOS, logcat on Android).
+/// Activity spans are emitted as os_signpost on iOS — set to `Trace` to see span
+/// activity in Console.app / Instruments. No-op on non-mobile builds.
+#[uniffi::export]
+pub fn set_native_log_level(log_level: FfiLogLevel) -> Result<(), FfiError> {
+    set_native_filter(log_level.to_str())
+}
+
 #[cfg(test)]
 pub use test_logger::*;
 
@@ -361,6 +399,11 @@ mod test_logger {
         S: Subscriber + for<'a> LookupSpan<'a>,
     {
         xmtp_common::logger_layer()
+    }
+
+    // Test builds don't install a reloadable native filter; the FFI call is a no-op.
+    pub(super) fn set_native_filter(_level: &str) -> Result<(), FfiError> {
+        Ok(())
     }
 
     // _NOTE:_ this test **fails** if there are rogue loggers

--- a/crates/xmtp_common/src/event_logging.rs
+++ b/crates/xmtp_common/src/event_logging.rs
@@ -78,7 +78,7 @@ pub enum Event {
     /// Attempted to sync on an inactive group.
     #[context(group_id, icon = "⏸️")]
     GroupSyncGroupInactive,
-    /// Intent failed to sync but did not error. This can happen for a variety of reasons.
+    /// Intent failed to sync and will be retried.
     #[context(group_id, intent_id, intent_kind, state, icon = "🔁")]
     GroupSyncIntentRetry,
     /// Intent was found to be in error after attempting to sync.

--- a/crates/xmtp_common/src/logging.rs
+++ b/crates/xmtp_common/src/logging.rs
@@ -2,7 +2,7 @@ use tracing_subscriber::EnvFilter;
 
 pub fn filter_directive(level: &str) -> EnvFilter {
     let filter = format!(
-        "xmtp_mls={level},xmtp_id={level},\
+        "xmtp_mls={level},xmtp_mls_common={level},xmtp_id={level},\
         xmtp_api={level},xmtp_api_grpc={level},xmtp_proto={level},\
         xmtp_common={level},xmtp_api_d14n={level},\
         xmtp_content_types={level},xmtp_cryptography={level},\

--- a/crates/xmtp_db/src/errors.rs
+++ b/crates/xmtp_db/src/errors.rs
@@ -200,8 +200,8 @@ pub enum NotFound {
     /// MLS group not found.
     ///
     /// OpenMLS group not in local state. Retryable.
-    #[error("MLS Group Not Found")]
-    MlsGroup,
+    #[error("MLS Group {0} Not Found")]
+    MlsGroup(GroupId),
     /// Post-quantum private key not found.
     ///
     /// PQ key pair not in store. Retryable.

--- a/crates/xmtp_db/src/test_utils/impls.rs
+++ b/crates/xmtp_db/src/test_utils/impls.rs
@@ -75,7 +75,7 @@ impl Distribution<NotFound> for StandardUniform {
             ),
             11 => NotFound::CipherSalt("random salt for testing".into()),
             12 => NotFound::SyncGroup(xmtp_common::rand_array::<32>().into()),
-            13 => NotFound::MlsGroup,
+            13 => NotFound::MlsGroup(GroupId::from(xmtp_common::rand_array::<16>().to_vec())),
             _ => unreachable!(),
         }
     }

--- a/crates/xmtp_mls/src/groups/mls_ext/reload.rs
+++ b/crates/xmtp_mls/src/groups/mls_ext/reload.rs
@@ -1,5 +1,6 @@
 use openmls::group::MlsGroup as OpenMlsGroup;
 use xmtp_db::{NotFound, StorageError, XmtpMlsStorageProvider};
+use xmtp_proto::types::GroupId;
 
 use crate::groups::mls_sync::GroupMessageProcessingError;
 
@@ -15,8 +16,9 @@ impl MlsGroupReload for OpenMlsGroup {
         &mut self,
         provider: &S,
     ) -> Result<(), GroupMessageProcessingError> {
-        *self = OpenMlsGroup::load(provider, self.group_id())?
-            .ok_or(StorageError::NotFound(NotFound::MlsGroup))?;
+        *self = OpenMlsGroup::load(provider, self.group_id())?.ok_or(StorageError::NotFound(
+            NotFound::MlsGroup(GroupId::from(self.group_id())),
+        ))?;
         Ok(())
     }
 }

--- a/crates/xmtp_mls/src/groups/mod.rs
+++ b/crates/xmtp_mls/src/groups/mod.rs
@@ -370,9 +370,10 @@ where
         // Acquire the lock synchronously using blocking_lock
         let _lock = self.mls_commit_lock.get_lock_sync(group_id.clone());
         // Load the MLS group
-        let mls_group = OpenMlsGroup::load(storage, &OpenMlsGroupId::from_slice(&self.group_id))
-            .map_err(|_| NotFound::MlsGroup)?
-            .ok_or(NotFound::MlsGroup)?;
+        let mls_group = OpenMlsGroup::load(storage, &self.group_id.to_openmls())
+            .inspect_err(|e| tracing::error!("openmls error while loading group {e}"))
+            .map_err(|_| NotFound::MlsGroup(self.group_id.clone()))?
+            .ok_or(NotFound::MlsGroup(self.group_id.clone()))?;
 
         // Perform the operation with the MLS group
         operation(mls_group)
@@ -767,7 +768,7 @@ where
     }
 
     /// Send a message on this users XMTP [`Client`](crate::client::Client).
-    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", skip_all, fields(who = self.context.inbox_id(), message = %String::from_utf8_lossy(&message[..message.len().min(100)]))))]
+    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", skip_all, fields(who = self.context.inbox_id())))]
     #[cfg_attr(
         not(any(test, feature = "test-utils")),
         tracing::instrument(level = "trace", skip_all)

--- a/crates/xmtp_mls/src/worker.rs
+++ b/crates/xmtp_mls/src/worker.rs
@@ -170,7 +170,7 @@ pub trait Worker: MaybeSend + MaybeSync + 'static {
                         tracing::debug!("pool disconnected. task will restart on reconnect");
                         break;
                     } else {
-                        tracing::error!("{:?} worker error: {:?}", self.kind(), err);
+                        tracing::error!("{:?} worker error: {}", self.kind(), err);
                         xmtp_common::time::sleep(WORKER_RESTART_DELAY).await;
                         tracing::info!("Restarting {:?} worker...", self.kind());
                     }

--- a/sdks/android/library/src/main/java/org/xmtp/android/library/Client.kt
+++ b/sdks/android/library/src/main/java/org/xmtp/android/library/Client.kt
@@ -43,6 +43,7 @@ import uniffi.xmtpv3.inboxStateFromInboxIds
 import uniffi.xmtpv3.isConnected
 import uniffi.xmtpv3.revokeInstallations
 import java.io.File
+import uniffi.xmtpv3.setNativeLogLevel as ffiSetNativeLogLevel
 
 typealias PreEventCallback = suspend () -> Unit
 typealias ProcessType = FfiProcessType
@@ -194,6 +195,15 @@ class Client(
 
         fun deactivatePersistentLibXMTPLogWriter() {
             exitDebugWriter()
+        }
+
+        /**
+         * Sets the log level for the native log layer (logcat on Android). Use
+         * `FfiLogLevel.TRACE` to capture span/activity events. Independent of the
+         * persistent file log writer.
+         */
+        fun setLibXMTPNativeLogLevel(logLevel: FfiLogLevel) {
+            ffiSetNativeLogLevel(logLevel)
         }
 
         fun getXMTPLogFilePaths(appContext: Context): List<String> {

--- a/sdks/ios/Sources/XMTPiOS/Client.swift
+++ b/sdks/ios/Sources/XMTPiOS/Client.swift
@@ -1233,6 +1233,9 @@ public extension Client {
 		case info
 		/// Debug level and above
 		case debug
+		/// Trace level — includes span/activity events (visible as
+		/// signposts in Console.app and Instruments).
+		case trace
 
 		fileprivate var ffiLogLevel: FfiLogLevel {
 			switch self {
@@ -1240,6 +1243,7 @@ public extension Client {
 			case .warn: .warn
 			case .info: .info
 			case .debug: .debug
+			case .trace: .trace
 			}
 		}
 	}
@@ -1344,6 +1348,20 @@ public extension Client {
 		} catch {
 			os_log(
 				"Failed to deactivate persistent log writer: %{public}@",
+				log: OSLog.default, type: .error, error.localizedDescription
+			)
+		}
+	}
+
+	/// Sets the log level for the native log layer (oslog on iOS).
+	/// Use `.trace` to surface tracing spans as os_signpost activities visible
+	/// in Console.app and Instruments. Independent of the persistent file log writer.
+	static func setLibXMTPNativeLogLevel(_ logLevel: LogLevel) {
+		do {
+			try setNativeLogLevel(logLevel: logLevel.ffiLogLevel)
+		} catch {
+			os_log(
+				"Failed to set native log level: %{public}@",
 				log: OSLog.default, type: .error, error.localizedDescription
 			)
 		}


### PR DESCRIPTION
the native log level differs from the level of the file export. OsLog exports to OsLog and the file exporter is internal to libxmtp. OsLog supports `activity` traces as well, so setting the level to `trace` will integrate into OsLog activities

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `setNativeLogLevel` FFI function to allow runtime log level changes on mobile
> - Adds a new `set_native_log_level` FFI function in [logger.rs](https://github.com/xmtp/libxmtp/pull/3599/files#diff-9d8abec9a152321af4b2de4c3e41865e58cdcc8b6ac56aa49c772ba6321aad33) that lets Android and iOS callers dynamically adjust the native log layer (logcat/oslog) level at runtime without restarting.
> - Uses `tracing_subscriber`'s `reload::Layer` to store a handle in a `OnceLock`-wrapped static, allowing filter updates via `set_native_filter`; defaults to `Debug` level until explicitly changed.
> - Exposes `Client.setLibXMTPNativeLogLevel` on both Android and iOS SDKs, mapping SDK-level log level enums to `FfiLogLevel`.
> - Also adds `xmtp_mls_common` to the composed `EnvFilter` string in [logging.rs](https://github.com/xmtp/libxmtp/pull/3599/files#diff-ef1e0613df1012fa7ec8b7fc09d95d1932d4f0948fec3c33c96ee515b458c6ab) so logs from that target are governed by the configured level.
> - `NotFound::MlsGroup` now carries a `GroupId` in its payload and display message for better error diagnostics.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 621bee7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->