### PR TITLE
chore: drop release_max_level_debug + simplify tracing dep entries

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -37,16 +37,12 @@ rustflags = ["-Clink-arg=-Wl,-z,max-page-size=16384"]
 build-override = { opt-level = 3, debug = false, debug-assertions = false, overflow-checks = false, incremental = false }
 # Build all non-local dependencies in release mode
 package."*" = { opt-level = 3, debug = false, debug-assertions = false, overflow-checks = false, incremental = false }
-# It uses debug_assertions internally to decide whether to choose where to use `max_level_*` or `release_max_level_*`
-package.tracing = { opt-level = 3, debug = false, debug-assertions = true, overflow-checks = false, incremental = false }
 
 [profile.test]
 # build scripts don't need extra assertions
 build-override = { opt-level = 3, debug = false, debug-assertions = false, overflow-checks = false, incremental = false }
 # Build all non-local dependencies in release mode
 package."*" = { opt-level = 3, debug = false, debug-assertions = false, overflow-checks = false, incremental = false }
-# It uses debug_assertions internally to decide whether to choose where to use `max_level_*` or `release_max_level_*`
-package.tracing = { opt-level = 3, debug = false, debug-assertions = true, overflow-checks = false, incremental = false }
 
 # Optimized test profile for WASM — debug builds produce huge binaries that are expensive to parse in Chrome
 [profile.wasm-test]

--- a/bindings/mobile/Cargo.toml
+++ b/bindings/mobile/Cargo.toml
@@ -23,7 +23,7 @@ prost.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
-tracing = { workspace = true }
+tracing.workspace = true
 tracing-appender = "0.2"
 tracing-subscriber = { workspace = true, features = [
   "registry",

--- a/bindings/node/Cargo.toml
+++ b/bindings/node/Cargo.toml
@@ -30,7 +30,7 @@ napi-derive = "3.3.0"
 prost.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
-tracing = { workspace = true, features = ["release_max_level_debug"] }
+tracing.workspace = true
 tracing-subscriber = { workspace = true, features = [
   "env-filter",
   "fmt",

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -35,7 +35,7 @@ serde-wasm-bindgen.workspace = true
 serde_bytes.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-tracing = { workspace = true, features = ["release_max_level_debug"] }
+tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 tracing-web.workspace = true
 tsify.workspace = true

--- a/crates/xmtp-workspace-hack/Cargo.toml
+++ b/crates/xmtp-workspace-hack/Cargo.toml
@@ -96,7 +96,7 @@ time = { version = "0.3", features = ["formatting", "local-offset", "parsing"] }
 tokio-util = { version = "0.7", features = ["codec", "compat", "io"] }
 toml_datetime = { version = "1", features = ["serde"] }
 toml_parser = { version = "1" }
-tracing = { version = "0.1", features = ["log", "release_max_level_debug"] }
+tracing = { version = "0.1", features = ["log"] }
 tracing-core = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["chrono", "env-filter", "json"] }
 typenum = { version = "1", default-features = false, features = ["const-generics"] }
@@ -190,7 +190,7 @@ time = { version = "0.3", features = ["formatting", "local-offset", "parsing"] }
 tokio-util = { version = "0.7", features = ["codec", "compat", "io"] }
 toml_datetime = { version = "1", features = ["serde"] }
 toml_parser = { version = "1" }
-tracing = { version = "0.1", features = ["log", "release_max_level_debug"] }
+tracing = { version = "0.1", features = ["log"] }
 tracing-core = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["chrono", "env-filter", "json"] }
 typenum = { version = "1", default-features = false, features = ["const-generics"] }


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3600

## Summary

- `bindings/{mobile,node,wasm}/Cargo.toml`: switched to `tracing.workspace = true` and dropped the `release_max_level_debug` feature override so all bindings pick up the workspace-default tracing config (per @insipx feedback on the issue: "drop release max level debug from everywhere").
- `.cargo/config.toml`: removed the `package.tracing = { ... debug-assertions = true ... }` overrides under `[profile.dev]` and `[profile.test]`, plus the explanatory comment lines. The override was only load-bearing while `release_max_level_debug` was set on a binding; with the feature gone everywhere, `tracing` builds with the same `debug_assertions` setting as every other dep and the special-case is dead weight.
- `crates/xmtp-workspace-hack/Cargo.toml`: regenerated via `cargo hakari generate` — the `tracing` entries in both platform sections now read `features = ["log"]` instead of `["log", "release_max_level_debug"]`.

## Test plan

- [x] `cargo check -p xmtpv3` (mobile binding compiles)
- [x] `just lint-rust` — clippy `--all-features --all-targets`, `cargo fmt --check`, `cargo hakari generate --diff`, `cargo hakari manage-deps --dry-run`, all green
- [ ] CI full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `release_max_level_debug` from tracing dependencies in node, wasm, and workspace-hack
> - Removes the `release_max_level_debug` feature from `tracing` in [bindings/node/Cargo.toml](https://github.com/xmtp/libxmtp/pull/3602/files#diff-98ff543d5073f14c4dfb7b62ef82cdb26bcac28480e95767c54d4176807a6464), [bindings/wasm/Cargo.toml](https://github.com/xmtp/libxmtp/pull/3602/files#diff-25e6aeed7f39d4f8e6e927434f7a8bef7b77471c2fb32e9d78f83eaa4f60ebeb), and [crates/xmtp-workspace-hack/Cargo.toml](https://github.com/xmtp/libxmtp/pull/3602/files#diff-d376defcdc6ba9d6bc902fe0f3e91f5d4b09191e5bcc2776cf4fdf65e467df65).
> - Removes per-package `debug-assertions = true` overrides for `tracing` in [.cargo/config.toml](https://github.com/xmtp/libxmtp/pull/3602/files#diff-9a4f3e4537ebb7474452d131b0d969d89a51286f4269aac5ef268e712be17268).
> - Simplifies remaining `tracing` dependency entries to use the `tracing.workspace = true` shorthand.
> - Behavioral Change: debug-level tracing events are no longer compiled into release builds for node and wasm bindings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b6eb0e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->