### PR TITLE
force logger init when setting level

### DIFF
--- a/apps/mls_validation_service/build.rs
+++ b/apps/mls_validation_service/build.rs
@@ -2,11 +2,18 @@ use std::error::Error;
 use vergen_gix::{BuildBuilder, Emitter, GixBuilder};
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let build = BuildBuilder::all_build()?;
-    let git = GixBuilder::default().branch(true).sha(true).build()?;
-    Emitter::default()
-        .add_instructions(&build)?
-        .add_instructions(&git)?
-        .emit()?;
+    println!("cargo:rerun-if-env-changed=NIX_GIT_SHA");
+
+    if let Ok(sha) = std::env::var("NIX_GIT_SHA") {
+        // Nix-driven build: short-circuit vergen and emit the SHA ourselves.
+        println!("cargo:rustc-env=VERGEN_GIT_SHA={sha}");
+    } else {
+        let build = BuildBuilder::all_build()?;
+        let gix = GixBuilder::default().branch(true).sha(true).build()?;
+        Emitter::default()
+            .add_instructions(&build)?
+            .add_instructions(&gix)?
+            .emit()?;
+    }
     Ok(())
 }

--- a/apps/xmtp_debug/build.rs
+++ b/apps/xmtp_debug/build.rs
@@ -2,11 +2,18 @@ use std::error::Error;
 use vergen_gix::{BuildBuilder, Emitter, GixBuilder};
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let build = BuildBuilder::all_build()?;
-    let git = GixBuilder::default().branch(true).sha(true).build()?;
-    Emitter::default()
-        .add_instructions(&build)?
-        .add_instructions(&git)?
-        .emit()?;
+    println!("cargo:rerun-if-env-changed=NIX_GIT_SHA");
+
+    if let Ok(sha) = std::env::var("NIX_GIT_SHA") {
+        // Nix-driven build: short-circuit vergen and emit the SHA ourselves.
+        println!("cargo:rustc-env=VERGEN_GIT_SHA={sha}");
+    } else {
+        let build = BuildBuilder::all_build()?;
+        let gix = GixBuilder::default().branch(true).sha(true).build()?;
+        Emitter::default()
+            .add_instructions(&build)?
+            .add_instructions(&gix)?
+            .emit()?;
+    }
     Ok(())
 }

--- a/apps/xnet/lib/build.rs
+++ b/apps/xnet/lib/build.rs
@@ -2,11 +2,18 @@ use std::error::Error;
 use vergen_gix::{BuildBuilder, Emitter, GixBuilder};
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let build = BuildBuilder::all_build()?;
-    let git = GixBuilder::default().branch(true).sha(true).build()?;
-    Emitter::default()
-        .add_instructions(&build)?
-        .add_instructions(&git)?
-        .emit()?;
+    println!("cargo:rerun-if-env-changed=NIX_GIT_SHA");
+
+    if let Ok(sha) = std::env::var("NIX_GIT_SHA") {
+        // Nix-driven build: short-circuit vergen and emit the SHA ourselves.
+        println!("cargo:rustc-env=VERGEN_GIT_SHA={sha}");
+    } else {
+        let build = BuildBuilder::all_build()?;
+        let gix = GixBuilder::default().branch(true).sha(true).build()?;
+        Emitter::default()
+            .add_instructions(&build)?
+            .add_instructions(&gix)?
+            .emit()?;
+    }
     Ok(())
 }

--- a/bindings/mobile/build.rs
+++ b/bindings/mobile/build.rs
@@ -1,18 +1,25 @@
 use std::error::Error;
-use std::process::Command;
 use vergen_gix::{BuildBuilder, Emitter, GixBuilder};
 
 fn main() -> Result<(), Box<dyn Error>> {
-    Command::new("make")
-        .args(["libxmtp-version"])
-        .status()
-        .expect("failed to make libxmtp-version");
+    println!("cargo:rerun-if-env-changed=NIX_GIT_SHA");
+    println!("cargo:rerun-if-env-changed=NIX_GIT_COMMIT_DATE");
+
+    let nix_sha = std::env::var("NIX_GIT_SHA").ok();
+    let nix_date = std::env::var("NIX_GIT_COMMIT_DATE").ok();
+
+    if let Some(sha) = &nix_sha {
+        println!("cargo:rustc-env=VERGEN_GIT_SHA={sha}");
+    }
+    if let Some(date) = &nix_date {
+        println!("cargo:rustc-env=VERGEN_GIT_COMMIT_DATE={date}");
+    }
 
     let build = BuildBuilder::all_build()?;
     let git = GixBuilder::default()
-        .sha(true)
+        .sha(nix_sha.is_none())
         .branch(true)
-        .commit_date(true)
+        .commit_date(nix_date.is_none())
         .commit_timestamp(true)
         .build()?;
 
@@ -20,6 +27,5 @@ fn main() -> Result<(), Box<dyn Error>> {
         .add_instructions(&build)?
         .add_instructions(&git)?
         .emit()?;
-
     Ok(())
 }

--- a/bindings/mobile/src/lib.rs
+++ b/bindings/mobile/src/lib.rs
@@ -13,6 +13,7 @@ pub mod worker;
 mod builder_test;
 
 pub use crate::inbox_owner::SigningError;
+use log::level_filters::ParseLevelFilterError;
 pub use logger::{enter_debug_writer, exit_debug_writer};
 pub use message::*;
 pub use mls::*;
@@ -132,6 +133,9 @@ pub enum GenericError {
     #[error(transparent)]
     #[error_code(inherit)]
     Enrich(#[from] EnrichMessageError),
+    /// Log Level failed to parse because it was invalid
+    #[error(transparent)]
+    Level(#[from] ParseLevelFilterError),
 }
 
 // this impl allows us to gracefully handle unexpected errors from foreign code without panicking

--- a/bindings/mobile/src/logger.rs
+++ b/bindings/mobile/src/logger.rs
@@ -375,7 +375,7 @@ pub fn exit_debug_writer() -> Result<(), FfiError> {
 }
 
 pub fn init_logger() {
-    let _ = *LOGGER;
+    let _ = LazyLock::force(&LOGGER);
 }
 
 /// Updates the log level of the native log layer (oslog on iOS, logcat on Android).
@@ -383,6 +383,7 @@ pub fn init_logger() {
 /// activity in Console.app / Instruments. No-op on non-mobile builds.
 #[uniffi::export]
 pub fn set_native_log_level(log_level: FfiLogLevel) -> Result<(), FfiError> {
+    init_logger();
     set_native_filter(log_level.to_str())
 }
 

--- a/bindings/mobile/src/logger.rs
+++ b/bindings/mobile/src/logger.rs
@@ -1,5 +1,4 @@
 use crate::FfiError;
-use log::Subscriber;
 use log::level_filters::LevelFilter;
 use parking_lot::Mutex;
 use std::io::Write;
@@ -20,7 +19,7 @@ use tracing_subscriber::{
 
 // Default native log level used until `set_native_log_level` is called.
 #[cfg(any(target_os = "android", target_os = "ios"))]
-const DEFAULT_NATIVE_LOG_LEVEL: FfiLogLevel = FfiLogLevel::Trace;
+const DEFAULT_NATIVE_LOG_LEVEL: FfiLogLevel = FfiLogLevel::Info;
 
 // Native layers install on the global `Registry` (see `LOGGER`), so S is pinned
 // to `Registry` to give the reload handle a concrete, storable type.
@@ -31,13 +30,15 @@ static LIBXMTP_FILTER_HANDLE: std::sync::OnceLock<
 
 #[cfg(any(target_os = "android", target_os = "ios"))]
 fn set_native_filter(level: &str) -> Result<(), FfiError> {
+    use crate::GenericError;
+
     let handle = LIBXMTP_FILTER_HANDLE
         .get()
         .ok_or_else(|| crate::GenericError::Generic {
             err: "native logger not initialized".to_string(),
         })?;
-    let new_filter = xmtp_common::filter_directive(level);
-    handle.lock().reload(new_filter)?;
+    let filter = xmtp_common::filter_directive(level);
+    handle.lock().reload(filter)?;
     Ok(())
 }
 
@@ -92,6 +93,7 @@ pub use other::*;
 #[cfg(not(any(target_os = "ios", target_os = "android", test)))]
 mod other {
     use super::*;
+    use log::Subscriber;
 
     pub fn native_layer<S>() -> impl Layer<S>
     where
@@ -394,6 +396,7 @@ pub use test_logger::*;
 #[cfg(test)]
 mod test_logger {
     use super::*;
+    use log::Subscriber;
     use std::io::Read;
 
     pub fn native_layer<S>() -> impl Layer<S>

--- a/bindings/mobile/src/logger.rs
+++ b/bindings/mobile/src/logger.rs
@@ -11,8 +11,8 @@ use tracing_appender::non_blocking::NonBlockingBuilder;
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_appender::rolling::RollingFileAppender;
 use tracing_subscriber::fmt::MakeWriter;
-use tracing_subscriber::fmt::format::DefaultFields;
-use tracing_subscriber::fmt::format::Format;
+use tracing_subscriber::fmt::format::JsonFields;
+use tracing_subscriber::fmt::format::{Format, Json};
 use tracing_subscriber::{
     EnvFilter, Layer, filter::Filtered, fmt, layer::Layered, layer::SubscriberExt,
     registry::LookupSpan, registry::Registry, reload, util::SubscriberInitExt,
@@ -20,7 +20,7 @@ use tracing_subscriber::{
 
 // Default native log level used until `set_native_log_level` is called.
 #[cfg(any(target_os = "android", target_os = "ios"))]
-const DEFAULT_NATIVE_LOG_LEVEL: FfiLogLevel = FfiLogLevel::Debug;
+const DEFAULT_NATIVE_LOG_LEVEL: FfiLogLevel = FfiLogLevel::Trace;
 
 // Native layers install on the global `Registry` (see `LOGGER`), so S is pinned
 // to `Registry` to give the reload handle a concrete, storable type.
@@ -168,8 +168,8 @@ static LOGGER: LazyLock<
                 Filtered<
                     fmt::Layer<
                         Layered<Box<dyn Layer<Registry> + Send + Sync>, Registry>,
-                        DefaultFields,
-                        Format,
+                        JsonFields,
+                        Format<Json>,
                         EmptyOrFileWriter,
                     >,
                     EnvFilter,
@@ -184,6 +184,7 @@ static LOGGER: LazyLock<
     // just turn the layer off for now
     let fmt = fmt::Layer::default()
         .with_writer(EmptyOrFileWriter::default())
+        .json()
         .with_filter(
             EnvFilter::builder()
                 .with_default_directive(LevelFilter::OFF.into())

--- a/bindings/mobile/src/mls.rs
+++ b/bindings/mobile/src/mls.rs
@@ -134,6 +134,7 @@ impl XmtpApiClient {
 /// and assumes `host` is set to the correct
 /// d14n backend url.
 #[uniffi::export(async_runtime = "tokio")]
+#[tracing::instrument(level = "debug", skip_all, fields(v3_host, ?gateway_host, app_version))]
 pub async fn connect_to_backend(
     v3_host: String,
     gateway_host: Option<String>,
@@ -185,6 +186,7 @@ pub async fn is_connected(api: Arc<XmtpApiClient>) -> bool {
  * Static Get the inbox state for each `inbox_id`.
  */
 #[uniffi::export(async_runtime = "tokio")]
+#[tracing::instrument(level = "debug", skip_all)]
 pub async fn inbox_state_from_inbox_ids(
     api: Arc<XmtpApiClient>,
     inbox_ids: Vec<String>,
@@ -241,6 +243,7 @@ impl TryFrom<GroupMessageMetadata> for FfiMessageMetadata {
 }
 
 #[uniffi::export(async_runtime = "tokio")]
+#[tracing::instrument(level = "debug", skip_all)]
 pub async fn get_newest_message_metadata(
     api: Arc<XmtpApiClient>,
     group_ids: Vec<Vec<u8>>,
@@ -260,6 +263,7 @@ pub async fn get_newest_message_metadata(
  * Static revoke a list of installations
  */
 #[uniffi::export]
+#[tracing::instrument(level = "debug", skip_all)]
 pub fn revoke_installations(
     api: Arc<XmtpApiClient>,
     recovery_identifier: FfiIdentifier,
@@ -281,6 +285,7 @@ pub fn revoke_installations(
  * Static apply a signature request
  */
 #[uniffi::export(async_runtime = "tokio")]
+#[tracing::instrument(level = "debug", skip_all)]
 pub async fn apply_signature_request(
     api: Arc<XmtpApiClient>,
     signature_request: Arc<FfiSignatureRequest>,
@@ -339,6 +344,7 @@ impl DbOptions {
 /// ```
 #[allow(clippy::too_many_arguments)]
 #[uniffi::export(async_runtime = "tokio")]
+#[tracing::instrument(level = "debug", skip_all)]
 pub async fn create_client(
     api: Arc<XmtpApiClient>,
     sync_api: Arc<XmtpApiClient>,
@@ -446,6 +452,7 @@ pub async fn create_client(
 
 #[allow(unused)]
 #[uniffi::export(async_runtime = "tokio")]
+#[tracing::instrument(level = "debug", skip_all)]
 pub async fn get_inbox_id_for_identifier(
     api: Arc<XmtpApiClient>,
     account_identifier: FfiIdentifier,
@@ -480,6 +487,7 @@ pub struct FfiPasskeySignature {
 #[uniffi::export(async_runtime = "tokio")]
 impl FfiSignatureRequest {
     // Signature that's signed by EOA wallet
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn add_ecdsa_signature(&self, signature_bytes: Vec<u8>) -> Result<(), FfiError> {
         let mut inner = self.inner.lock().await;
         inner
@@ -492,6 +500,7 @@ impl FfiSignatureRequest {
         Ok(())
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn add_passkey_signature(
         &self,
         signature: FfiPasskeySignature,
@@ -513,6 +522,7 @@ impl FfiSignatureRequest {
     }
 
     // Signature that's signed by smart contract wallet
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn add_scw_signature(
         &self,
         signature_bytes: Vec<u8>,
@@ -540,11 +550,13 @@ impl FfiSignatureRequest {
         self.inner.lock().await.is_ready()
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn signature_text(&self) -> Result<String, FfiError> {
         Ok(self.inner.lock().await.signature_text())
     }
 
     /// missing signatures that are from `MemberKind::Address`
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn missing_address_signatures(&self) -> Result<Vec<String>, FfiError> {
         let inner = self.inner.lock().await;
         Ok(inner
@@ -592,16 +604,19 @@ impl FfiXmtpClient {
         self.inner_client.clear_stats()
     }
 
+    #[tracing::instrument(skip_all)]
     pub fn inbox_id(&self) -> InboxId {
         self.inner_client.inbox_id().to_string()
     }
 
+    #[tracing::instrument(skip_all)]
     pub fn conversations(&self) -> Arc<FfiConversations> {
         Arc::new(FfiConversations {
             inner_client: self.inner_client.clone(),
         })
     }
 
+    #[tracing::instrument(skip_all)]
     pub fn conversation(&self, conversation_id: Vec<u8>) -> Result<FfiConversation, FfiError> {
         self.inner_client
             .stitched_group(&conversation_id)
@@ -609,6 +624,7 @@ impl FfiXmtpClient {
             .map_err(Into::into)
     }
 
+    #[tracing::instrument(skip_all)]
     pub fn dm_conversation(&self, target_inbox_id: String) -> Result<FfiConversation, FfiError> {
         let convo = self
             .inner_client
@@ -616,21 +632,25 @@ impl FfiXmtpClient {
         Ok(convo.into())
     }
 
+    #[tracing::instrument(skip_all)]
     pub fn message(&self, message_id: Vec<u8>) -> Result<FfiMessage, FfiError> {
         let message = self.inner_client.message(message_id)?;
         Ok(message.into())
     }
 
+    #[tracing::instrument(skip_all)]
     pub fn enriched_message(&self, message_id: Vec<u8>) -> Result<FfiDecodedMessage, FfiError> {
         let message = self.inner_client.message_v2(message_id)?;
         Ok(message.into())
     }
 
+    #[tracing::instrument(skip_all)]
     pub fn delete_message(&self, message_id: Vec<u8>) -> Result<u32, FfiError> {
         let deleted_count = self.inner_client.delete_message(message_id)?;
         Ok(deleted_count as u32)
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn can_message(
         &self,
         account_identifiers: Vec<FfiIdentifier>,
@@ -653,18 +673,22 @@ impl FfiXmtpClient {
         Ok(results)
     }
 
+    #[tracing::instrument(skip_all)]
     pub fn installation_id(&self) -> Vec<u8> {
         self.inner_client.installation_public_key().to_vec()
     }
 
+    #[tracing::instrument(skip_all)]
     pub fn release_db_connection(&self) -> Result<(), FfiError> {
         Ok(self.inner_client.release_db_connection()?)
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn db_reconnect(&self) -> Result<(), FfiError> {
         Ok(self.inner_client.reconnect_db()?)
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn find_inbox_id(
         &self,
         identifier: FfiIdentifier,
@@ -683,6 +707,7 @@ impl FfiXmtpClient {
      * If `refresh_from_network` is true, the client will go to the network first to refresh the state.
      * Otherwise, the state will be read from the local database.
      */
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn inbox_state(&self, refresh_from_network: bool) -> Result<FfiInboxState, FfiError> {
         let state = self.inner_client.inbox_state(refresh_from_network).await?;
         let inbox_id = state.inbox_id();
@@ -700,6 +725,7 @@ impl FfiXmtpClient {
     }
 
     // Returns a HashMap of installation_id to FfiKeyPackageStatus
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn get_key_package_statuses_for_installation_ids(
         &self,
         installation_ids: Vec<Vec<u8>>,
@@ -734,6 +760,7 @@ impl FfiXmtpClient {
      * If `refresh_from_network` is true, the client will go to the network first to refresh the state.
      * Otherwise, the state will be read from the local database.
      */
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn addresses_from_inbox_id(
         &self,
         refresh_from_network: bool,
@@ -749,6 +776,7 @@ impl FfiXmtpClient {
         Ok(state.into_iter().map(Into::into).collect())
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn get_latest_inbox_state(
         &self,
         inbox_id: String,
@@ -771,6 +799,7 @@ impl FfiXmtpClient {
         Ok(ffi_state)
     }
 
+    #[tracing::instrument(level = "debug", skip_all, fields(refresh_from_network))]
     pub async fn fetch_inbox_updates_count(
         &self,
         refresh_from_network: bool,
@@ -783,6 +812,7 @@ impl FfiXmtpClient {
             .map_err(Into::into)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn fetch_own_inbox_updates_count(
         &self,
         refresh_from_network: bool,
@@ -793,6 +823,7 @@ impl FfiXmtpClient {
             .map_err(Into::into)
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn set_consent_states(&self, records: Vec<FfiConsent>) -> Result<(), FfiError> {
         let inner = self.inner_client.as_ref();
         let stored_records: Vec<StoredConsentRecord> =
@@ -802,6 +833,7 @@ impl FfiXmtpClient {
         Ok(())
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn get_consent_state(
         &self,
         entity_type: FfiConsentEntityType,
@@ -814,12 +846,14 @@ impl FfiXmtpClient {
     }
 
     /// A utility function to sign a piece of text with this installation's private key.
+    #[tracing::instrument(skip_all)]
     pub fn sign_with_installation_key(&self, text: &str) -> Result<Vec<u8>, FfiError> {
         let inner = self.inner_client.as_ref();
         Ok(inner.context.sign_with_public_context(text)?)
     }
 
     /// A utility function to easily verify that a piece of text was signed by this installation.
+    #[tracing::instrument(skip_all)]
     pub fn verify_signed_with_installation_key(
         &self,
         signature_text: &str,
@@ -833,6 +867,7 @@ impl FfiXmtpClient {
 
     /// A utility function to easily verify that a string has been signed by another libXmtp installation.
     /// Only works for verifying libXmtp public context signatures.
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn verify_signed_with_public_key(
         &self,
         signature_text: &str,
@@ -866,10 +901,12 @@ impl FfiXmtpClient {
         )?)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn sync_preferences(&self) -> Result<FfiGroupSyncSummary, FfiError> {
         self.sync_all_device_sync_groups().await
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn signature_request(&self) -> Option<Arc<FfiSignatureRequest>> {
         let scw_verifier = self.inner_client.scw_verifier().clone();
         self.inner_client
@@ -883,6 +920,7 @@ impl FfiXmtpClient {
             })
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn register_identity(
         &self,
         signature_request: Arc<FfiSignatureRequest>,
@@ -905,6 +943,7 @@ impl FfiXmtpClient {
     }
 
     /// Adds a wallet address to the existing client
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn add_identity(
         &self,
         new_identity: FfiIdentifier,
@@ -923,6 +962,7 @@ impl FfiXmtpClient {
         Ok(request)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn apply_signature_request(
         &self,
         signature_request: Arc<FfiSignatureRequest>,
@@ -937,6 +977,7 @@ impl FfiXmtpClient {
     }
 
     /// Revokes or removes an identity from the existing client
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn revoke_identity(
         &self,
         identifier: FfiIdentifier,
@@ -961,6 +1002,7 @@ impl FfiXmtpClient {
      * Returns Some FfiSignatureRequest if we have installations to revoke.
      * If we have no other installations to revoke, returns None.
      */
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn revoke_all_other_installations_signature_request(
         &self,
     ) -> Result<Option<Arc<FfiSignatureRequest>>, FfiError> {
@@ -991,6 +1033,7 @@ impl FfiXmtpClient {
     /**
      * Revoke a list of installations
      */
+    #[tracing::instrument(skip_all)]
     pub async fn revoke_installations(
         &self,
         installation_ids: Vec<Vec<u8>>,
@@ -1010,6 +1053,7 @@ impl FfiXmtpClient {
     /**
      * Change the recovery identifier for your inboxId
      */
+    #[tracing::instrument(skip_all)]
     pub async fn change_recovery_identifier(
         &self,
         new_recovery_identifier: FfiIdentifier,
@@ -1500,6 +1544,7 @@ impl From<&FfiMetadataField> for MetadataField {
 
 #[uniffi::export(async_runtime = "tokio")]
 impl FfiConversations {
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn create_group_optimistic(
         &self,
         opts: FfiCreateGroupOptions,
@@ -1542,6 +1587,7 @@ impl FfiConversations {
         Ok(Arc::new(convo.into()))
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn create_group_by_identity(
         &self,
         account_identities: Vec<FfiIdentifier>,
@@ -1567,6 +1613,7 @@ impl FfiConversations {
         Ok(convo)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn create_group(
         &self,
         inbox_ids: Vec<String>,
@@ -1588,6 +1635,7 @@ impl FfiConversations {
         Ok(convo)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn find_or_create_dm_by_identity(
         &self,
         target_identity: FfiIdentifier,
@@ -1602,6 +1650,7 @@ impl FfiConversations {
             .map_err(Into::into)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn find_or_create_dm(
         &self,
         inbox_id: String,
@@ -1615,6 +1664,7 @@ impl FfiConversations {
             .map_err(Into::into)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn process_streamed_welcome_message(
         &self,
         envelope_bytes: Vec<u8>,
@@ -1626,13 +1676,14 @@ impl FfiConversations {
             .map_err(Into::into)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn sync(&self) -> Result<(), FfiError> {
         let inner = self.inner_client.as_ref();
         inner.sync_welcomes().await?;
         Ok(())
     }
 
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn sync_all_conversations(
         &self,
         consent_states: Option<Vec<FfiConsentState>>,
@@ -1645,6 +1696,7 @@ impl FfiConversations {
         Ok(summary.into())
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn list(
         &self,
         opts: FfiListConversationsOptions,
@@ -1667,6 +1719,7 @@ impl FfiConversations {
         Ok(convo_list)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn list_groups(
         &self,
         opts: FfiListConversationsOptions,
@@ -1692,6 +1745,7 @@ impl FfiConversations {
         Ok(convo_list)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn list_dms(
         &self,
         opts: FfiListConversationsOptions,
@@ -1717,6 +1771,7 @@ impl FfiConversations {
         Ok(convo_list)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn stream_groups(
         &self,
         callback: Arc<dyn FfiConversationCallback>,
@@ -1737,6 +1792,7 @@ impl FfiConversations {
         FfiStreamCloser::new(handle)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn stream_dms(&self, callback: Arc<dyn FfiConversationCallback>) -> FfiStreamCloser {
         let client = self.inner_client.clone();
         let close_cb = callback.clone();
@@ -1885,6 +1941,7 @@ impl FfiConversations {
         FfiStreamCloser::new(handle)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn get_hmac_keys(&self) -> Result<HashMap<Vec<u8>, Vec<FfiHmacKey>>, FfiError> {
         let inner = self.inner_client.as_ref();
         let conversations = inner.find_groups(GroupQueryArgs {
@@ -2360,6 +2417,7 @@ impl FfiCreateDMOptions {
 
 #[uniffi::export(async_runtime = "tokio")]
 impl FfiConversation {
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn send(
         &self,
         content_bytes: Vec<u8>,
@@ -2372,6 +2430,7 @@ impl FfiConversation {
         Ok(message_id)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) async fn send_text(&self, text: &str) -> Result<Vec<u8>, FfiError> {
         let content =
             TextCodec::encode(text.to_string()).map_err(|e| FfiError::generic(e.to_string()))?;
@@ -2383,6 +2442,7 @@ impl FfiConversation {
     }
 
     /// send a message without immediately publishing to the delivery service.
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn send_optimistic(
         &self,
         content_bytes: Vec<u8>,
@@ -2396,12 +2456,14 @@ impl FfiConversation {
     }
 
     /// Delete a message by its ID. Returns the ID of the deletion message.
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn delete_message(&self, message_id: Vec<u8>) -> Result<Vec<u8>, FfiError> {
         let deletion_id = self.inner.delete_message(message_id)?;
         Ok(deletion_id)
     }
 
     /// Publish all unpublished messages
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn publish_messages(&self) -> Result<(), FfiError> {
         self.inner.publish_messages().await?;
         Ok(())
@@ -2409,6 +2471,7 @@ impl FfiConversation {
 
     /// Prepare a message for later publishing.
     /// Stores the message locally without publishing. Returns the message ID.
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn prepare_message(
         &self,
         content_bytes: Vec<u8>,
@@ -2421,17 +2484,20 @@ impl FfiConversation {
     }
 
     /// Publish a previously prepared message by ID.
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn publish_stored_message(&self, message_id: Vec<u8>) -> Result<(), FfiError> {
         self.inner.publish_stored_message(&message_id).await?;
         Ok(())
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn sync(&self) -> Result<(), FfiError> {
         self.inner.sync().await?;
 
         Ok(())
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn find_messages(
         &self,
         opts: FfiListMessagesOptions,
@@ -2446,12 +2512,14 @@ impl FfiConversation {
         Ok(messages)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn count_messages(&self, opts: FfiListMessagesOptions) -> Result<i64, FfiError> {
         let count = self.inner.count_messages(&opts.into())?;
 
         Ok(count)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn find_messages_with_reactions(
         &self,
         opts: FfiListMessagesOptions,
@@ -2465,6 +2533,7 @@ impl FfiConversation {
         Ok(messages)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn find_enriched_messages(
         &self,
         opts: FfiListMessagesOptions,
@@ -2478,6 +2547,7 @@ impl FfiConversation {
         Ok(messages)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn process_streamed_conversation_message(
         &self,
         envelope_bytes: Vec<u8>,
@@ -2489,6 +2559,7 @@ impl FfiConversation {
         Ok(message.into_iter().map(Into::into).collect())
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn list_members(&self) -> Result<Vec<FfiConversationMember>, FfiError> {
         let members: Vec<FfiConversationMember> = self
             .inner
@@ -2511,11 +2582,13 @@ impl FfiConversation {
         Ok(members)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn membership_state(&self) -> Result<FfiGroupMembershipState, FfiError> {
         let state = self.inner.membership_state()?;
         Ok(state.into())
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn add_members_by_identity(
         &self,
         account_identifiers: Vec<FfiIdentifier>,
@@ -2537,6 +2610,7 @@ impl FfiConversation {
             .map_err(Into::into)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn add_members(
         &self,
         inbox_ids: Vec<String>,
@@ -2550,6 +2624,7 @@ impl FfiConversation {
             .map_err(Into::into)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn remove_members_by_identity(
         &self,
         account_identifiers: Vec<FfiIdentifier>,
@@ -2560,17 +2635,20 @@ impl FfiConversation {
             .map_err(Into::into)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn remove_members(&self, inbox_ids: Vec<String>) -> Result<(), FfiError> {
         let ids = inbox_ids.iter().map(AsRef::as_ref).collect::<Vec<&str>>();
         self.inner.remove_members(ids.as_slice()).await?;
         Ok(())
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn leave_group(&self) -> Result<(), FfiError> {
         self.inner.leave_group().await?;
         Ok(())
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn update_group_name(&self, group_name: String) -> Result<(), FfiError> {
         self.inner.update_group_name(group_name).await?;
         Ok(())
@@ -2595,25 +2673,30 @@ impl FfiConversation {
     ///
     /// **One-way**: a migrated group cannot return to the legacy
     /// path. Operationally treated as a flag day per group.
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn enable_proposals(&self) -> Result<(), FfiError> {
         self.inner.enable_proposals().await.map_err(Into::into)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn group_name(&self) -> Result<String, FfiError> {
         let group_name = self.inner.group_name()?;
         Ok(group_name)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn update_app_data(&self, app_data: String) -> Result<(), FfiError> {
         self.inner.update_app_data(app_data).await?;
         Ok(())
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn app_data(&self) -> Result<String, FfiError> {
         let app_data = self.inner.app_data()?;
         Ok(app_data)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn update_group_image_url_square(
         &self,
         group_image_url_square: String,
@@ -2625,10 +2708,12 @@ impl FfiConversation {
         Ok(())
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn group_image_url_square(&self) -> Result<String, FfiError> {
         Ok(self.inner.group_image_url_square()?)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn update_group_description(
         &self,
         group_description: String,
@@ -2640,10 +2725,12 @@ impl FfiConversation {
         Ok(())
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn group_description(&self) -> Result<String, FfiError> {
         Ok(self.inner.group_description()?)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn update_conversation_message_disappearing_settings(
         &self,
         settings: FfiMessageDisappearingSettings,
@@ -2657,6 +2744,7 @@ impl FfiConversation {
         Ok(())
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn remove_conversation_message_disappearing_settings(&self) -> Result<(), FfiError> {
         self.inner
             .remove_conversation_message_disappearing_settings()
@@ -2665,6 +2753,7 @@ impl FfiConversation {
         Ok(())
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn conversation_message_disappearing_settings(
         &self,
     ) -> Result<Option<FfiMessageDisappearingSettings>, FfiError> {
@@ -2676,6 +2765,7 @@ impl FfiConversation {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn is_conversation_message_disappearing_enabled(&self) -> Result<bool, FfiError> {
         self.conversation_message_disappearing_settings()
             .map(|settings| {
@@ -2685,24 +2775,29 @@ impl FfiConversation {
             })
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn admin_list(&self) -> Result<Vec<String>, FfiError> {
         self.inner.admin_list().map_err(Into::into)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn super_admin_list(&self) -> Result<Vec<String>, FfiError> {
         self.inner.super_admin_list().map_err(Into::into)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn is_admin(&self, inbox_id: &String) -> Result<bool, FfiError> {
         let admin_list = self.admin_list()?;
         Ok(admin_list.contains(inbox_id))
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn is_super_admin(&self, inbox_id: &String) -> Result<bool, FfiError> {
         let super_admin_list = self.super_admin_list()?;
         Ok(super_admin_list.contains(inbox_id))
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn add_admin(&self, inbox_id: String) -> Result<(), FfiError> {
         self.inner
             .update_admin_list(UpdateAdminListType::Add, inbox_id)
@@ -2710,6 +2805,7 @@ impl FfiConversation {
             .map_err(Into::into)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn remove_admin(&self, inbox_id: String) -> Result<(), FfiError> {
         self.inner
             .update_admin_list(UpdateAdminListType::Remove, inbox_id)
@@ -2717,6 +2813,7 @@ impl FfiConversation {
             .map_err(Into::into)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn add_super_admin(&self, inbox_id: String) -> Result<(), FfiError> {
         self.inner
             .update_admin_list(UpdateAdminListType::AddSuper, inbox_id)
@@ -2724,6 +2821,7 @@ impl FfiConversation {
             .map_err(Into::into)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn remove_super_admin(&self, inbox_id: String) -> Result<(), FfiError> {
         self.inner
             .update_admin_list(UpdateAdminListType::RemoveSuper, inbox_id)
@@ -2731,6 +2829,7 @@ impl FfiConversation {
             .map_err(Into::into)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn group_permissions(&self) -> Result<Arc<FfiGroupPermissions>, FfiError> {
         let permissions = self.inner.permissions()?;
         Ok(Arc::new(FfiGroupPermissions {
@@ -2738,6 +2837,7 @@ impl FfiConversation {
         }))
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn update_permission_policy(
         &self,
         permission_update_type: FfiPermissionUpdateType,
@@ -2754,6 +2854,7 @@ impl FfiConversation {
             .map_err(Into::into)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn stream(&self, message_callback: Arc<dyn FfiMessageCallback>) -> FfiStreamCloser {
         let close_cb = message_callback.clone();
         let handle = MlsGroup::stream_with_callback(
@@ -2781,6 +2882,7 @@ impl FfiConversation {
         self.inner.paused_for_version().map_err(Into::into)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn consent_state(&self) -> Result<FfiConsentState, FfiError> {
         self.inner
             .consent_state()
@@ -2788,6 +2890,7 @@ impl FfiConversation {
             .map_err(Into::into)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn update_consent_state(&self, state: FfiConsentState) -> Result<(), FfiError> {
         self.inner
             .update_consent_state(state.into())
@@ -2798,6 +2901,7 @@ impl FfiConversation {
         self.inner.added_by_inbox_id().map_err(Into::into)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn group_metadata(&self) -> Result<Arc<FfiConversationMetadata>, FfiError> {
         let metadata = self.inner.metadata().await?;
         Ok(Arc::new(FfiConversationMetadata {
@@ -2805,6 +2909,7 @@ impl FfiConversation {
         }))
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn dm_peer_inbox_id(&self) -> Option<String> {
         self.inner
             .dm_id
@@ -2812,6 +2917,7 @@ impl FfiConversation {
             .map(|dm_id| dm_id.other_inbox_id(self.inner.context.inbox_id()))
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn get_hmac_keys(&self) -> Result<HashMap<Vec<u8>, Vec<FfiHmacKey>>, FfiError> {
         let duplicate_dms = self.inner.find_duplicate_dms()?;
 
@@ -2844,6 +2950,7 @@ impl FfiConversation {
         Ok(debug_info.into())
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn find_duplicate_dms(&self) -> Result<Vec<Arc<FfiConversation>>, FfiError> {
         let dms = self.inner.find_duplicate_dms()?;
 
@@ -2853,6 +2960,7 @@ impl FfiConversation {
         Ok(ffi_conversations)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn get_last_read_times(&self) -> Result<HashMap<String, i64>, FfiError> {
         let latest_read_times = self.inner.get_last_read_times()?;
         Ok(latest_read_times)
@@ -2924,6 +3032,7 @@ impl From<StoredGroupMessageWithReactions> for FfiMessageWithReactions {
 }
 
 #[uniffi::export]
+#[tracing::instrument(skip_all)]
 pub fn encode_reaction(reaction: FfiReactionPayload) -> Result<Vec<u8>, FfiError> {
     // Convert FfiReaction to Reaction
     let reaction: ReactionV2 = reaction.into();
@@ -2941,6 +3050,7 @@ pub fn encode_reaction(reaction: FfiReactionPayload) -> Result<Vec<u8>, FfiError
 }
 
 #[uniffi::export]
+#[tracing::instrument(skip_all)]
 pub fn decode_reaction(bytes: Vec<u8>) -> Result<FfiReactionPayload, FfiError> {
     // Decode bytes into EncodedContent
     let encoded_content =
@@ -2955,6 +3065,7 @@ pub fn decode_reaction(bytes: Vec<u8>) -> Result<FfiReactionPayload, FfiError> {
 // RemoteAttachmentInfo and MultiRemoteAttachment FFI structures - using types from message module
 
 #[uniffi::export]
+#[tracing::instrument(skip_all)]
 pub fn encode_multi_remote_attachment(
     ffi_multi_remote_attachment: FfiMultiRemoteAttachment,
 ) -> Result<Vec<u8>, FfiError> {
@@ -2975,6 +3086,7 @@ pub fn encode_multi_remote_attachment(
 }
 
 #[uniffi::export]
+#[tracing::instrument(skip_all)]
 pub fn decode_multi_remote_attachment(
     bytes: Vec<u8>,
 ) -> Result<FfiMultiRemoteAttachment, FfiError> {
@@ -2991,6 +3103,7 @@ pub fn decode_multi_remote_attachment(
 // TransactionReference FFI structures - using types from message module
 
 #[uniffi::export]
+#[tracing::instrument(skip_all)]
 pub fn encode_transaction_reference(
     reference: FfiTransactionReference,
 ) -> Result<Vec<u8>, FfiError> {
@@ -3008,6 +3121,7 @@ pub fn encode_transaction_reference(
 }
 
 #[uniffi::export]
+#[tracing::instrument(skip_all)]
 pub fn decode_transaction_reference(bytes: Vec<u8>) -> Result<FfiTransactionReference, FfiError> {
     let encoded_content =
         EncodedContent::decode(bytes.as_slice()).map_err(|e| FfiError::generic(e.to_string()))?;
@@ -3020,6 +3134,7 @@ pub fn decode_transaction_reference(bytes: Vec<u8>) -> Result<FfiTransactionRefe
 // Attachment FFI structures - using FfiAttachment from message module
 
 #[uniffi::export]
+#[tracing::instrument(skip_all)]
 pub fn encode_attachment(attachment: FfiAttachment) -> Result<Vec<u8>, FfiError> {
     let attachment: Attachment = attachment.into();
 
@@ -3035,6 +3150,7 @@ pub fn encode_attachment(attachment: FfiAttachment) -> Result<Vec<u8>, FfiError>
 }
 
 #[uniffi::export]
+#[tracing::instrument(skip_all)]
 pub fn decode_attachment(bytes: Vec<u8>) -> Result<FfiAttachment, FfiError> {
     let encoded_content =
         EncodedContent::decode(bytes.as_slice()).map_err(|e| FfiError::generic(e.to_string()))?;
@@ -3045,6 +3161,7 @@ pub fn decode_attachment(bytes: Vec<u8>) -> Result<FfiAttachment, FfiError> {
 }
 
 #[uniffi::export]
+#[tracing::instrument(skip_all)]
 pub fn encode_reply(reply: FfiReply) -> Result<Vec<u8>, FfiError> {
     let reply: Reply = reply.into();
 
@@ -3059,6 +3176,7 @@ pub fn encode_reply(reply: FfiReply) -> Result<Vec<u8>, FfiError> {
 }
 
 #[uniffi::export]
+#[tracing::instrument(skip_all)]
 pub fn decode_reply(bytes: Vec<u8>) -> Result<FfiReply, FfiError> {
     let encoded_content =
         EncodedContent::decode(bytes.as_slice()).map_err(|e| FfiError::generic(e.to_string()))?;
@@ -3071,6 +3189,7 @@ pub fn decode_reply(bytes: Vec<u8>) -> Result<FfiReply, FfiError> {
 // ReadReceipt FFI structures - using FfiReadReceipt from message module
 
 #[uniffi::export]
+#[tracing::instrument(skip_all)]
 pub fn encode_read_receipt(read_receipt: FfiReadReceipt) -> Result<Vec<u8>, FfiError> {
     let read_receipt: ReadReceipt = read_receipt.into();
 
@@ -3086,6 +3205,7 @@ pub fn encode_read_receipt(read_receipt: FfiReadReceipt) -> Result<Vec<u8>, FfiE
 }
 
 #[uniffi::export]
+#[tracing::instrument(skip_all)]
 pub fn decode_read_receipt(bytes: Vec<u8>) -> Result<FfiReadReceipt, FfiError> {
     let encoded_content =
         EncodedContent::decode(bytes.as_slice()).map_err(|e| FfiError::generic(e.to_string()))?;
@@ -3098,6 +3218,7 @@ pub fn decode_read_receipt(bytes: Vec<u8>) -> Result<FfiReadReceipt, FfiError> {
 // RemoteAttachment FFI structures - using FfiRemoteAttachment from message module
 
 #[uniffi::export]
+#[tracing::instrument(skip_all)]
 pub fn encode_remote_attachment(
     remote_attachment: FfiRemoteAttachment,
 ) -> Result<Vec<u8>, FfiError> {
@@ -3115,6 +3236,7 @@ pub fn encode_remote_attachment(
 }
 
 #[uniffi::export]
+#[tracing::instrument(skip_all)]
 pub fn decode_remote_attachment(bytes: Vec<u8>) -> Result<FfiRemoteAttachment, FfiError> {
     let encoded_content =
         EncodedContent::decode(bytes.as_slice()).map_err(|e| FfiError::generic(e.to_string()))?;
@@ -3127,6 +3249,7 @@ pub fn decode_remote_attachment(bytes: Vec<u8>) -> Result<FfiRemoteAttachment, F
 // Intent FFI encode/decode functions
 
 #[uniffi::export]
+#[tracing::instrument(skip_all)]
 pub fn encode_intent(intent: FfiIntent) -> Result<Vec<u8>, FfiError> {
     let intent: Intent = intent.try_into()?;
 
@@ -3141,6 +3264,7 @@ pub fn encode_intent(intent: FfiIntent) -> Result<Vec<u8>, FfiError> {
 }
 
 #[uniffi::export]
+#[tracing::instrument(skip_all)]
 pub fn decode_intent(bytes: Vec<u8>) -> Result<FfiIntent, FfiError> {
     let encoded_content =
         EncodedContent::decode(bytes.as_slice()).map_err(|e| FfiError::generic(e.to_string()))?;
@@ -3154,6 +3278,7 @@ pub fn decode_intent(bytes: Vec<u8>) -> Result<FfiIntent, FfiError> {
 // Actions FFI encode/decode functions
 
 #[uniffi::export]
+#[tracing::instrument(skip_all)]
 pub fn encode_actions(actions: FfiActions) -> Result<Vec<u8>, FfiError> {
     let actions: Actions = actions.into();
 
@@ -3168,6 +3293,7 @@ pub fn encode_actions(actions: FfiActions) -> Result<Vec<u8>, FfiError> {
 }
 
 #[uniffi::export]
+#[tracing::instrument(skip_all)]
 pub fn decode_actions(bytes: Vec<u8>) -> Result<FfiActions, FfiError> {
     let encoded_content =
         EncodedContent::decode(bytes.as_slice()).map_err(|e| FfiError::generic(e.to_string()))?;
@@ -3180,6 +3306,7 @@ pub fn decode_actions(bytes: Vec<u8>) -> Result<FfiActions, FfiError> {
 
 // LeaveRequest FFI encode function
 #[uniffi::export]
+#[tracing::instrument(skip_all)]
 pub fn encode_leave_request(request: FfiLeaveRequest) -> Result<Vec<u8>, FfiError> {
     let leave_request: LeaveRequest = request.into();
 
@@ -3196,6 +3323,7 @@ pub fn encode_leave_request(request: FfiLeaveRequest) -> Result<Vec<u8>, FfiErro
 
 // LeaveRequest FFI decode function
 #[uniffi::export]
+#[tracing::instrument(skip_all)]
 pub fn decode_leave_request(bytes: Vec<u8>) -> Result<FfiLeaveRequest, FfiError> {
     let encoded_content =
         EncodedContent::decode(bytes.as_slice()).map_err(|e| FfiError::generic(e.to_string()))?;
@@ -3207,6 +3335,7 @@ pub fn decode_leave_request(bytes: Vec<u8>) -> Result<FfiLeaveRequest, FfiError>
 
 // DeleteMessage FFI encode function
 #[uniffi::export]
+#[tracing::instrument(skip_all)]
 pub fn encode_delete_message(request: FfiDeleteMessage) -> Result<Vec<u8>, FfiError> {
     let delete_message: DeleteMessage = request.into();
 
@@ -3223,6 +3352,7 @@ pub fn encode_delete_message(request: FfiDeleteMessage) -> Result<Vec<u8>, FfiEr
 
 // DeleteMessage FFI decode function
 #[uniffi::export]
+#[tracing::instrument(skip_all)]
 pub fn decode_delete_message(bytes: Vec<u8>) -> Result<FfiDeleteMessage, FfiError> {
     let encoded_content =
         EncodedContent::decode(bytes.as_slice()).map_err(|e| FfiError::generic(e.to_string()))?;
@@ -3233,6 +3363,7 @@ pub fn decode_delete_message(bytes: Vec<u8>) -> Result<FfiDeleteMessage, FfiErro
 }
 
 #[uniffi::export]
+#[tracing::instrument(skip_all)]
 pub fn decode_group_updated(bytes: Vec<u8>) -> Result<FfiGroupUpdated, FfiError> {
     let encoded_content =
         EncodedContent::decode(bytes.as_slice()).map_err(|e| FfiError::generic(e.to_string()))?;
@@ -3243,6 +3374,7 @@ pub fn decode_group_updated(bytes: Vec<u8>) -> Result<FfiGroupUpdated, FfiError>
 }
 
 #[uniffi::export]
+#[tracing::instrument(skip_all)]
 pub fn encode_text(text: String) -> Result<Vec<u8>, FfiError> {
     let encoded = TextCodec::encode(text).map_err(|e| FfiError::generic(e.to_string()))?;
 
@@ -3255,6 +3387,7 @@ pub fn encode_text(text: String) -> Result<Vec<u8>, FfiError> {
 }
 
 #[uniffi::export]
+#[tracing::instrument(skip_all)]
 pub fn decode_text(bytes: Vec<u8>) -> Result<String, FfiError> {
     let encoded_content =
         EncodedContent::decode(bytes.as_slice()).map_err(|e| FfiError::generic(e.to_string()))?;
@@ -3263,6 +3396,7 @@ pub fn decode_text(bytes: Vec<u8>) -> Result<String, FfiError> {
 }
 
 #[uniffi::export]
+#[tracing::instrument(skip_all)]
 pub fn encode_markdown(text: String) -> Result<Vec<u8>, FfiError> {
     let encoded = MarkdownCodec::encode(text).map_err(|e| FfiError::generic(e.to_string()))?;
 
@@ -3275,6 +3409,7 @@ pub fn encode_markdown(text: String) -> Result<Vec<u8>, FfiError> {
 }
 
 #[uniffi::export]
+#[tracing::instrument(skip_all)]
 pub fn decode_markdown(bytes: Vec<u8>) -> Result<String, FfiError> {
     let encoded_content =
         EncodedContent::decode(bytes.as_slice()).map_err(|e| FfiError::generic(e.to_string()))?;
@@ -3283,6 +3418,7 @@ pub fn decode_markdown(bytes: Vec<u8>) -> Result<String, FfiError> {
 }
 
 #[uniffi::export]
+#[tracing::instrument(skip_all)]
 pub fn encode_wallet_send_calls(
     wallet_send_calls: FfiWalletSendCalls,
 ) -> Result<Vec<u8>, FfiError> {
@@ -3298,6 +3434,7 @@ pub fn encode_wallet_send_calls(
 }
 
 #[uniffi::export]
+#[tracing::instrument(skip_all)]
 pub fn decode_wallet_send_calls(bytes: Vec<u8>) -> Result<FfiWalletSendCalls, FfiError> {
     let encoded_content =
         EncodedContent::decode(bytes.as_slice()).map_err(|e| FfiError::generic(e.to_string()))?;
@@ -3433,11 +3570,13 @@ impl FfiStreamCloser {
 impl FfiStreamCloser {
     /// Signal the stream to end
     /// Does not wait for the stream to end.
+    #[tracing::instrument(level = "debug", name = "end_stream", skip_all)]
     pub fn end(&self) {
         self.abort_handle.end();
     }
 
     /// End the stream and asynchronously wait for it to shutdown
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn end_and_wait(&self) -> Result<(), FfiError> {
         use xmtp_common::StreamHandleError::*;
 
@@ -3460,10 +3599,12 @@ impl FfiStreamCloser {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn is_closed(&self) -> bool {
         self.abort_handle.is_finished()
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn wait_for_ready(&self) {
         let mut stream_handle = self.stream_handle.lock().await;
         if let Some(ref mut h) = *stream_handle {

--- a/crates/xmtp_common/src/logging.rs
+++ b/crates/xmtp_common/src/logging.rs
@@ -1,6 +1,12 @@
+use tracing::level_filters::LevelFilter;
 use tracing_subscriber::EnvFilter;
 
 pub fn filter_directive(level: &str) -> EnvFilter {
+    let level: LevelFilter = level
+        .parse()
+        .inspect_err(|_| tracing::error!("invalid level `{}`, defaulting to `INFO`", level))
+        .unwrap_or(LevelFilter::INFO);
+
     let filter = format!(
         "xmtp_mls={level},xmtp_mls_common={level},xmtp_id={level},\
         xmtp_api={level},xmtp_api_grpc={level},xmtp_proto={level},\
@@ -25,5 +31,6 @@ mod tests {
         filter_directive("INFO");
         filter_directive("DEBUG");
         filter_directive("TRACE");
+        filter_directive("INCORRECT_DOES_NOT_PANIC");
     }
 }

--- a/crates/xmtp_common/src/logging.rs
+++ b/crates/xmtp_common/src/logging.rs
@@ -9,5 +9,21 @@ pub fn filter_directive(level: &str) -> EnvFilter {
         xmtp_user_preferences={level},xmtpv3={level},xmtp_db={level},\
         bindings_wasm={level},bindings_node={level},xdbg=error"
     );
-    EnvFilter::builder().parse_lossy(filter)
+    EnvFilter::builder()
+        .parse(filter)
+        .expect("Static filter must be correct")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[xmtp_common::test]
+    fn test_filter_correct() {
+        filter_directive("OFF");
+        filter_directive("ERROR");
+        filter_directive("WARN");
+        filter_directive("INFO");
+        filter_directive("DEBUG");
+        filter_directive("TRACE");
+    }
 }

--- a/crates/xmtp_db/src/encrypted_store/database/native.rs
+++ b/crates/xmtp_db/src/encrypted_store/database/native.rs
@@ -487,7 +487,6 @@ impl NativeDbConnection {
 }
 
 impl ConnectionExt for NativeDbConnection {
-    #[tracing::instrument(level = "trace", skip_all)]
     fn raw_query<T, F>(&self, fun: F) -> Result<T, crate::ConnectionError>
     where
         F: FnOnce(&mut SqliteConnection) -> Result<T, diesel::result::Error>,

--- a/crates/xmtp_db/src/encrypted_store/group.rs
+++ b/crates/xmtp_db/src/encrypted_store/group.rs
@@ -560,6 +560,7 @@ where
 
 impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
     /// Return regular `Purpose::Conversation` groups with additional optional filters
+    #[tracing::instrument(level = "debug", skip_all)]
     fn find_groups<A: AsRef<GroupQueryArgs>>(
         &self,
         args: A,

--- a/crates/xmtp_db/src/encrypted_store/group_intent.rs
+++ b/crates/xmtp_db/src/encrypted_store/group_intent.rs
@@ -339,7 +339,7 @@ where
 }
 
 impl<C: ConnectionExt> QueryGroupIntent for DbConnection<C> {
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[tracing::instrument(level = "debug", skip(self))]
     fn insert_group_intent(
         &self,
         to_save: NewGroupIntent,
@@ -352,7 +352,7 @@ impl<C: ConnectionExt> QueryGroupIntent for DbConnection<C> {
     }
 
     // Query for group_intents by group_id, optionally filtering by state and kind
-    #[tracing::instrument(level = "trace", skip(self), fields(group_id = hex::encode(group_id.as_ref())))]
+    #[tracing::instrument(level = "debug", skip(self), fields(group_id = hex::encode(group_id.as_ref())))]
     fn find_group_intents<Id: AsRef<[u8]>>(
         &self,
         group_id: Id,
@@ -379,6 +379,7 @@ impl<C: ConnectionExt> QueryGroupIntent for DbConnection<C> {
 
     // Set the intent with the given ID to `Published` and set the payload hash. Optionally add
     // `post_commit_data`
+    #[tracing::instrument(level = "debug", skip(self, payload_hash), fields(id = intent_id, payload_hash = hex::encode(payload_hash)))]
     fn set_group_intent_published(
         &self,
         intent_id: ID,
@@ -420,6 +421,7 @@ impl<C: ConnectionExt> QueryGroupIntent for DbConnection<C> {
     }
 
     // Set the intent with the given ID to `Committed`
+    #[tracing::instrument(level = "debug", skip(self))]
     fn set_group_intent_committed(
         &self,
         intent_id: ID,
@@ -448,6 +450,7 @@ impl<C: ConnectionExt> QueryGroupIntent for DbConnection<C> {
     }
 
     // Set the intent with the given ID to `Committed`
+    #[tracing::instrument(level = "debug", skip(self))]
     fn set_group_intent_processed(&self, intent_id: ID) -> Result<(), StorageError> {
         let rows_changed = self.raw_query(|conn| {
             diesel::update(dsl::group_intents)
@@ -466,6 +469,7 @@ impl<C: ConnectionExt> QueryGroupIntent for DbConnection<C> {
 
     // Set the intent with the given ID to `ToPublish`. Wipe any values for `payload_hash` and
     // `post_commit_data`
+    #[tracing::instrument(level = "debug", skip(self))]
     fn set_group_intent_to_publish(&self, intent_id: ID) -> Result<(), StorageError> {
         let rows_changed = self.raw_query(|conn| {
             diesel::update(dsl::group_intents)
@@ -491,7 +495,7 @@ impl<C: ConnectionExt> QueryGroupIntent for DbConnection<C> {
     }
 
     /// Set the intent with the given ID to `Error`
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[tracing::instrument(level = "debug", skip(self))]
     fn set_group_intent_error(&self, intent_id: ID) -> Result<(), StorageError> {
         let rows_changed = self.raw_query(|conn| {
             diesel::update(dsl::group_intents)
@@ -510,8 +514,8 @@ impl<C: ConnectionExt> QueryGroupIntent for DbConnection<C> {
     // Simple lookup of intents by payload hash, meant to be used when processing messages off the
     // network
     #[tracing::instrument(
-        level = "trace",
-        skip_all,
+        level = "debug",
+        skip(self),
         fields(payload_hash = hex::encode(payload_hash))
     )]
     fn find_group_intent_by_payload_hash(
@@ -530,6 +534,7 @@ impl<C: ConnectionExt> QueryGroupIntent for DbConnection<C> {
 
     /// Find the commit message refresh state for each intent by payload hash.
     /// Returns a map from payload hash to a vector of dependencies (one per originator).
+    #[tracing::instrument(level = "debug", skip_all)]
     fn find_dependant_commits<P: AsRef<[u8]>>(
         &self,
         payload_hashes: &[P],
@@ -594,6 +599,7 @@ impl<C: ConnectionExt> QueryGroupIntent for DbConnection<C> {
         Ok(map)
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     fn increment_intent_publish_attempt_count(&self, intent_id: ID) -> Result<(), StorageError> {
         self.raw_query(|conn| {
             diesel::update(dsl::group_intents)
@@ -605,6 +611,7 @@ impl<C: ConnectionExt> QueryGroupIntent for DbConnection<C> {
         Ok(())
     }
 
+    #[tracing::instrument(level = "debug", skip_all, fields(id = %intent.id, kind = %intent.kind, group_id = %intent.group_id))]
     fn set_group_intent_error_and_fail_msg(
         &self,
         intent: &StoredGroupIntent,

--- a/crates/xmtp_db/src/encrypted_store/refresh_state.rs
+++ b/crates/xmtp_db/src/encrypted_store/refresh_state.rs
@@ -234,6 +234,7 @@ impl<T: QueryRefreshState> QueryRefreshState for &'_ T {
 }
 
 impl<C: ConnectionExt> QueryRefreshState for DbConnection<C> {
+    #[tracing::instrument(level = "debug", skip_all)]
     fn get_refresh_state<EntityId: AsRef<[u8]>>(
         &self,
         entity_id: EntityId,
@@ -251,6 +252,7 @@ impl<C: ConnectionExt> QueryRefreshState for DbConnection<C> {
         Ok(res)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     fn get_last_cursor_for_originators<Id: AsRef<[u8]>>(
         &self,
         id: Id,
@@ -303,6 +305,7 @@ impl<C: ConnectionExt> QueryRefreshState for DbConnection<C> {
         Ok(result)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     fn get_last_cursor_for_ids<Id: AsRef<[u8]>>(
         &self,
         ids: &[Id],
@@ -380,6 +383,7 @@ impl<C: ConnectionExt> QueryRefreshState for DbConnection<C> {
         Ok(num_updated >= 1)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     fn get_remote_log_cursors(
         &self,
         conversation_ids: &[&Vec<u8>],
@@ -398,6 +402,7 @@ impl<C: ConnectionExt> QueryRefreshState for DbConnection<C> {
         Ok(cursor_map)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     fn latest_cursor_for_id<Id: AsRef<[u8]>>(
         &self,
         entity_id: Id,

--- a/crates/xmtp_mls/src/client.rs
+++ b/crates/xmtp_mls/src/client.rs
@@ -659,6 +659,7 @@ where
         Ok(group)
     }
 
+    #[tracing::instrument(level = "debug", skip_all, fields(who = self.context.inbox_id(), size = inbox_ids.len()))]
     pub async fn create_group_with_members(
         &self,
         inbox_ids: &[impl AsIdRef],
@@ -674,6 +675,7 @@ where
     }
 
     /// Create a new Direct Message with the default settings
+    #[tracing::instrument(level = "debug", skip_all, fields(who = self.context.inbox_id(), with = target_inbox_id))]
     async fn create_dm_by_inbox_id(
         &self,
         target_inbox_id: InboxId,
@@ -1054,7 +1056,7 @@ where
     }
 
     /// Fetches the current key package from the network for each of the `installation_id`s specified
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[tracing::instrument(skip_all)]
     pub async fn get_key_packages_for_installation_ids(
         &self,
         installation_ids: Vec<Vec<u8>>,
@@ -1070,7 +1072,7 @@ where
 
     /// Download all unread welcome messages and converts to a group struct, ignoring malformed messages.
     /// Returns any new groups created in the operation
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[tracing::instrument(skip_all)]
     pub async fn sync_welcomes(&self) -> Result<Vec<MlsGroup<Context>>, GroupError> {
         self.ensure_identity_ready()?;
         WelcomeService::new(self.context.clone())

--- a/crates/xmtp_mls/src/groups/mod.rs
+++ b/crates/xmtp_mls/src/groups/mod.rs
@@ -775,11 +775,7 @@ where
     }
 
     /// Send a message on this users XMTP [`Client`](crate::client::Client).
-    #[cfg_attr(any(test, feature = "test-utils"), tracing::instrument(level = "info", skip_all, fields(who = self.context.inbox_id())))]
-    #[cfg_attr(
-        not(any(test, feature = "test-utils")),
-        tracing::instrument(level = "trace", skip_all)
-    )]
+    #[tracing::instrument(level = "debug", skip_all, fields(who = self.context.inbox_id()))]
     pub async fn send_message(
         &self,
         message: &[u8],

--- a/crates/xmtp_mls/src/subscriptions/mod.rs
+++ b/crates/xmtp_mls/src/subscriptions/mod.rs
@@ -358,7 +358,7 @@ where
         Ok(out)
     }
 
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn stream_conversations(
         &self,
         conversation_type: Option<ConversationType>,
@@ -377,7 +377,7 @@ where
     }
 
     /// Stream conversations but decouple the lifetime of 'self' from the stream.
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn stream_conversations_owned(
         &self,
         conversation_type: Option<ConversationType>,
@@ -434,7 +434,7 @@ where
         })
     }
 
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn stream_all_messages(
         &self,
         conversation_type: Option<ConversationType>,
@@ -450,7 +450,7 @@ where
         StreamAllMessages::new(&self.context, conversation_type, consent_state).await
     }
 
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn stream_all_messages_owned(
         &self,
         conversation_type: Option<ConversationType>,

--- a/crates/xmtp_mls/src/subscriptions/stream_all.rs
+++ b/crates/xmtp_mls/src/subscriptions/stream_all.rs
@@ -171,7 +171,7 @@ where
 {
     type Item = Result<StoredGroupMessage>;
 
-    #[tracing::instrument(skip_all, level = "trace", name = "poll_next_stream_all")]
+    #[tracing::instrument(skip_all, level = "debug", name = "poll_next_stream_all")]
     fn poll_next(
         mut self: Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,

--- a/crates/xmtp_mls/src/subscriptions/stream_conversations.rs
+++ b/crates/xmtp_mls/src/subscriptions/stream_conversations.rs
@@ -331,7 +331,7 @@ where
 {
     type Item = Result<MlsGroup<C>>;
 
-    #[tracing::instrument(skip_all, name = "poll_next_stream_conversations" level = "trace")]
+    #[tracing::instrument(skip_all, name = "poll_next_stream_conversations" level = "debug")]
     fn poll_next(
         mut self: Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,

--- a/crates/xmtp_mls/src/worker.rs
+++ b/crates/xmtp_mls/src/worker.rs
@@ -14,6 +14,8 @@ use std::fmt::Debug;
 use std::pin::Pin;
 use std::{any::Any, collections::HashMap, hash::Hash, sync::Arc};
 use tasks::TaskWorkerChannels;
+use tracing::Instrument;
+use tracing::instrument::Instrumented;
 use xmtp_common::{MaybeSend, MaybeSync, StreamHandle, if_native, if_wasm, time::Duration};
 use xmtp_configuration::WORKER_RESTART_DELAY;
 
@@ -87,32 +89,36 @@ impl WorkerRunner {
         }
 
         let this = self.clone();
-        let handle = xmtp_common::spawn(None, async move {
-            while !ctx.identity().is_ready() {
-                xmtp_common::time::sleep(Duration::from_millis(50)).await;
-            }
-
-            let mut futs = FuturesUnordered::new();
-
-            for factory in &this.factories {
-                let metric = this.metrics.lock().get(&factory.kind()).cloned();
-                let (worker, metrics) = factory.create(metric);
-
-                if let Some(metrics) = metrics {
-                    this.metrics.lock().insert(factory.kind(), metrics);
+        let handle = xmtp_common::spawn(
+            None,
+            async move {
+                while !ctx.identity().is_ready() {
+                    xmtp_common::time::sleep(Duration::from_millis(50)).await;
                 }
 
-                if let Some(metrics) = worker.metrics() {
-                    let mut m = this.metrics.lock();
-                    m.insert(worker.kind(), metrics);
-                }
-                futs.push(worker.spawn());
-            }
+                let mut futs = FuturesUnordered::new();
 
-            while let Some(kind) = futs.next().await {
-                tracing::warn!("Worker {kind:?} completed unexpectedly")
+                for factory in &this.factories {
+                    let metric = this.metrics.lock().get(&factory.kind()).cloned();
+                    let (worker, metrics) = factory.create(metric);
+
+                    if let Some(metrics) = metrics {
+                        this.metrics.lock().insert(factory.kind(), metrics);
+                    }
+
+                    if let Some(metrics) = worker.metrics() {
+                        let mut m = this.metrics.lock();
+                        m.insert(worker.kind(), metrics);
+                    }
+                    futs.push(worker.spawn());
+                }
+
+                while let Some(kind) = futs.next().await {
+                    tracing::warn!("Worker {kind:?} completed unexpectedly")
+                }
             }
-        });
+            .instrument(tracing::debug_span!("xmtp_worker_supervisor")),
+        );
 
         *handle_lock = Some(Box::new(handle));
     }
@@ -161,8 +167,9 @@ pub trait Worker: MaybeSend + MaybeSync + 'static {
         Box::new(self) as Box<_>
     }
 
-    fn spawn(mut self: Box<Self>) -> Pin<Box<SpawnWorkerFut>> {
-        let fut = async move {
+    fn spawn(mut self: Box<Self>) -> Instrumented<Pin<Box<SpawnWorkerFut>>> {
+        let kind_str = format!("{:?}", self.kind());
+        let fut = Box::pin(async move {
             loop {
                 if let Err(err) = self.run_tasks().await {
                     if err.needs_db_reconnect() {
@@ -178,9 +185,8 @@ pub trait Worker: MaybeSend + MaybeSync + 'static {
             }
 
             self.kind()
-        };
-
-        Box::pin(fut)
+        }) as Pin<Box<SpawnWorkerFut>>;
+        fut.instrument(tracing::debug_span!("libxmtp_worker", kind = kind_str))
     }
 }
 

--- a/crates/xmtp_mls/src/worker/device_sync/worker.rs
+++ b/crates/xmtp_mls/src/worker/device_sync/worker.rs
@@ -136,7 +136,7 @@ where
     async fn run_internal(&mut self) -> Result<(), DeviceSyncError> {
         while let Ok(event) = self.receiver.recv().await {
             if matches!(event, SyncWorkerEvent::Tick) {
-                tracing::debug!(
+                tracing::trace!(
                     "[{}] New event: {event:?}",
                     self.client.context.installation_id()
                 );

--- a/nix/lib/base.nix
+++ b/nix/lib/base.nix
@@ -61,6 +61,9 @@ let
     hardeningDisable = [ "zerocallusedregs" ];
     CARGO_BUILD_TARGET = stdenv.hostPlatform.rust.rustcTarget;
     CARGO_PROFILE = "release";
+    # passes through to all build.rs scripts
+    NIX_GIT_SHA = xmtp.gitSha;
+    NIX_GIT_COMMIT_DATE = xmtp.gitCommitDate;
 
     # aws-lc-sys is tricky to x-compile, since it needs host CC to compile libraries to do host-side checks.
     # aws-lc-sys's build script resolves CC via TARGET_CC (set by Nix to the cross-compiler) and

--- a/nix/lib/default.nix
+++ b/nix/lib/default.nix
@@ -164,6 +164,8 @@
           shellCommon = pkgs.callPackage ./shell-common.nix { };
           mkVersion = import ./mkVersion.nix;
           toNapiTarget = import ./napiTarget.nix;
+          gitSha = self.shortRev or self.dirtyShortRev or "unknown";
+          gitCommitDate = self.lastModifiedDate or "";
         };
         wasm-bindgen-cli = pkgs.callPackage ./packages/wasm-bindgen-cli.nix { };
         napi-rs-cli = pkgs.callPackage ./packages/napi-rs-cli { };

--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -1,5 +1,6 @@
 # Rust Binaries to expose in nix flake
-_: {
+{ self, ... }:
+{
   perSystem =
     {
       self',


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Force logger initialization in `set_native_log_level` to prevent no-op on mobile
- `set_native_log_level` now calls `init_logger()` before reloading the native filter, ensuring the logger is initialized even if it hasn't been explicitly set up yet.
- Default native log level on mobile (iOS/Android) changed from `Debug` to `Info`.
- File/debug logger output in [logger.rs](https://github.com/xmtp/libxmtp/pull/3603/files#diff-9d8abec9a152321af4b2de4c3e41865e58cdcc8b6ac56aa49c772ba6321aad33) is now JSON-formatted instead of plain/compact.
- Broadly upgrades tracing span levels from `trace` to `debug` across mobile FFI bindings, MLS client, subscription streams, and DB query methods, and adds new `debug`-level spans to many previously uninstrumented FFI methods.
- Build scripts for mobile and other apps now source `VERGEN_GIT_SHA`/`VERGEN_GIT_COMMIT_DATE` from `NIX_GIT_SHA`/`NIX_GIT_COMMIT_DATE` environment variables when present, skipping `vergen_gix` git probing.
- Behavioral Change: mobile logger output format changes to JSON; default log level changes from Debug to Info.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 21ab084.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->