### PR TITLE
ci: cap test workflow jobs at 30 min (60 min for WASM)

### DIFF
--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -7,6 +7,7 @@ jobs:
   unit-tests:
     name: Unit Tests (Android)
     runs-on: warp-ubuntu-latest-x64-16x
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix

--- a/.github/workflows/test-bindings-check.yml
+++ b/.github/workflows/test-bindings-check.yml
@@ -4,6 +4,7 @@ on:
 jobs:
   check-swift:
     runs-on: warp-macos-15-arm64-6x
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -26,6 +27,7 @@ jobs:
 
   check-android:
     runs-on: warp-ubuntu-latest-x64-16x
+    timeout-minutes: 30
     env:
       NIX_DEVSHELL: android
     steps:

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -44,6 +44,7 @@ jobs:
     runs-on: warp-macos-15-arm64-6x
     needs: deploy-backend
     name: Tests (iOS)
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix

--- a/.github/workflows/test-node.yml
+++ b/.github/workflows/test-node.yml
@@ -7,6 +7,7 @@ jobs:
   test:
     name: Test (Node)
     runs-on: warp-ubuntu-latest-x64-16x
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/test-wasm.yml
+++ b/.github/workflows/test-wasm.yml
@@ -7,6 +7,7 @@ jobs:
   wasm-ci:
     name: Test (WASM)
     runs-on: warp-ubuntu-latest-x64-16x
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/test-workspace.yml
+++ b/.github/workflows/test-workspace.yml
@@ -8,6 +8,7 @@ jobs:
   test:
     name: Test (Rust Workspace)
     runs-on: warp-ubuntu-latest-x64-16x
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/test-xdbg.yml
+++ b/.github/workflows/test-xdbg.yml
@@ -5,6 +5,7 @@ jobs:
   check:
     name: Check (xdbg)
     runs-on: warp-ubuntu-latest-x64-16x
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3607

## Summary

Adds `timeout-minutes` to every test workflow job that previously relied on GitHub Actions' 6-hour default cap. This prevents stuck jobs from hanging for hours, as in [run 25479221258](https://github.com/xmtp/libxmtp/actions/runs/25479221258/job/74759451178?pr=3597).

| Workflow | Job(s) | `timeout-minutes` |
|---|---|---|
| `test-workspace.yml` | `test` | 30 |
| `test-node.yml` | `test` | 30 |
| `test-wasm.yml` | `wasm-ci` | **60** (WASM is slower) |
| `test-ios.yml` | `tests` | 30 (`deploy-backend` keeps existing 10; `cleanup` left alone) |
| `test-android.yml` | `unit-tests` | 30 (`integration-tests` already has 30) |
| `test-bindings-check.yml` | `check-swift`, `check-android` | 30 |
| `test-xdbg.yml` | `check` | 30 |

## Assumptions

- **`test-devcontainer.yml`** is left at its existing **45 min** cap. The cap has a documented reason (cold Nix flake evaluation pulls the full Rust toolchain + every devShell dep over the network on every run, since the in-container Nix store is ephemeral) and already prevents multi-hour hangs. Happy to lower to 30 if preferred.
- The `test-ios.yml` `cleanup` job (`flyctl apps destroy` under `if: always()`) is short and runs unconditionally for cleanup — left at the default.
- Lint workflows (`lint-*.yml`) are out of scope; the issue specifies "test workflows".

## Test plan

- [x] `git diff` confirms exactly the expected jobs got the new `timeout-minutes`
- [x] `just lint-config` passes (treefmt + taplo + nixfmt clean)
- [ ] CI run on this PR exercises the workflows so GitHub validates syntax
- [ ] No timeout regression: caps are at or above expected job durations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cap CI test workflow jobs at 30 minutes (60 minutes for WASM)
> Adds `timeout-minutes` to all test workflow jobs across Android, iOS, Node, Rust workspace, WASM, bindings check, and xdbg workflows. Most jobs are capped at 30 minutes; the WASM job gets a 60-minute limit due to its longer build time. This prevents hung jobs from consuming CI runners indefinitely.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3dca390.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->