### PR TITLE
xmtp_debug: add --fail-on-error flag for fail-fast bisect sessions

### DIFF
--- a/apps/xmtp_debug/src/app/generate/groups.rs
+++ b/apps/xmtp_debug/src/app/generate/groups.rs
@@ -90,7 +90,7 @@ impl GenerateGroups {
                         .await;
 
                         if let Some(ref invitee) = first_invitee {
-                            check_member_visibility(&group_id, invitee, &network_clone).await;
+                            check_member_visibility(&group_id, invitee, &network_clone).await?;
                         }
 
                         // -- total group create + add latency --
@@ -218,10 +218,19 @@ async fn create_group_on_network(
 }
 
 /// Check whether an invitee can see the group via sync_welcomes (read-your-own-writes).
-async fn check_member_visibility(group_id: &[u8], invitee: &Identity, network: &args::BackendOpts) {
+async fn check_member_visibility(
+    group_id: &[u8],
+    invitee: &Identity,
+    network: &args::BackendOpts,
+) -> Result<()> {
     let reader_client = match app::client_from_identity(invitee, network) {
         Ok(c) => c,
-        Err(_) => return,
+        Err(e) => {
+            if crate::fail_on_error() {
+                return Err(e);
+            }
+            return Ok(());
+        }
     };
 
     let t_visibility = Instant::now();
@@ -231,6 +240,9 @@ async fn check_member_visibility(group_id: &[u8], invitee: &Identity, network: &
 
     loop {
         if let Err(e) = reader_client.sync_welcomes().await {
+            if crate::fail_on_error() {
+                return Err(eyre!("sync_welcomes failed during visibility poll: {e}"));
+            }
             tracing::warn!(error = %e, "sync_welcomes failed during visibility poll");
         }
         if reader_client.group(group_id).is_ok() {
@@ -260,4 +272,5 @@ async fn check_member_visibility(group_id: &[u8], invitee: &Identity, network: &
         &[("phase", "member_visibility"), ("success", vis_ok)],
     );
     push_metrics("xdbg_debug").await;
+    Ok(())
 }

--- a/apps/xmtp_debug/src/app/generate/groups.rs
+++ b/apps/xmtp_debug/src/app/generate/groups.rs
@@ -89,8 +89,14 @@ impl GenerateGroups {
                         )
                         .await;
 
-                        if let Some(ref invitee) = first_invitee {
-                            check_member_visibility(&group_id, invitee, &network_clone).await?;
+                        if let Some(ref invitee) = first_invitee
+                            && let Err(e) =
+                                check_member_visibility(&group_id, invitee, &network_clone).await
+                        {
+                            if crate::fail_on_error() {
+                                return Err(e);
+                            }
+                            tracing::warn!(error = %e, "member visibility check failed");
                         }
 
                         // -- total group create + add latency --
@@ -231,12 +237,7 @@ async fn check_member_visibility(
     let mut visible = false;
 
     loop {
-        if let Err(e) = reader_client.sync_welcomes().await {
-            if crate::fail_on_error() {
-                return Err(eyre!("sync_welcomes failed during visibility poll: {e}"));
-            }
-            tracing::warn!(error = %e, "sync_welcomes failed during visibility poll");
-        }
+        reader_client.sync_welcomes().await?;
         if reader_client.group(group_id).is_ok() {
             visible = true;
             break;

--- a/apps/xmtp_debug/src/app/generate/groups.rs
+++ b/apps/xmtp_debug/src/app/generate/groups.rs
@@ -223,15 +223,7 @@ async fn check_member_visibility(
     invitee: &Identity,
     network: &args::BackendOpts,
 ) -> Result<()> {
-    let reader_client = match app::client_from_identity(invitee, network) {
-        Ok(c) => c,
-        Err(e) => {
-            if crate::fail_on_error() {
-                return Err(e);
-            }
-            return Ok(());
-        }
-    };
+    let reader_client = app::client_from_identity(invitee, network)?;
 
     let t_visibility = Instant::now();
     let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(30);

--- a/apps/xmtp_debug/src/app/generate/groups.rs
+++ b/apps/xmtp_debug/src/app/generate/groups.rs
@@ -93,7 +93,7 @@ impl GenerateGroups {
                             && let Err(e) =
                                 check_member_visibility(&group_id, invitee, &network_clone).await
                         {
-                            if crate::fail_on_error() {
+                            if crate::fail_fast() {
                                 return Err(e);
                             }
                             tracing::warn!(error = %e, "member visibility check failed");

--- a/apps/xmtp_debug/src/app/generate/messages.rs
+++ b/apps/xmtp_debug/src/app/generate/messages.rs
@@ -271,6 +271,15 @@ impl GenerateMessages {
 
         if !errors.is_empty() {
             info!(errors = ?errors, "errors");
+            if crate::fail_on_error() {
+                let first = errors[0].to_string();
+                return Err(eyre!(
+                    "{} of {} send_message tasks failed (--fail-on-error): {}",
+                    errors.len(),
+                    res.len(),
+                    first
+                ));
+            }
         }
 
         let latencies: Vec<Duration> = res.into_iter().filter_map(|r| r.ok()).collect();

--- a/apps/xmtp_debug/src/app/generate/messages.rs
+++ b/apps/xmtp_debug/src/app/generate/messages.rs
@@ -271,10 +271,10 @@ impl GenerateMessages {
 
         if !errors.is_empty() {
             info!(errors = ?errors, "errors");
-            if crate::fail_on_error() {
+            if crate::fail_fast() {
                 let first = errors[0].to_string();
                 return Err(eyre!(
-                    "{} of {} send_message tasks failed (--fail-on-error): {}",
+                    "{} of {} send_message tasks failed (--fail-fast): {}",
                     errors.len(),
                     res.len(),
                     first

--- a/apps/xmtp_debug/src/app/stream.rs
+++ b/apps/xmtp_debug/src/app/stream.rs
@@ -62,7 +62,7 @@ impl Stream {
             Box::new(BufWriter::new(std::io::stdout()))
         };
 
-        let fail_on_error = crate::fail_on_error();
+        let fail_fast = crate::fail_fast();
         match kind {
             args::StreamKind::Conversations => {
                 let s = client.stream_conversations(None, false).await?;
@@ -70,7 +70,7 @@ impl Stream {
                 while let Some(item) = s.as_mut().next().await {
                     let group = match item {
                         Ok(g) => g,
-                        Err(e) if fail_on_error => return Err(e.into()),
+                        Err(e) if fail_fast => return Err(e.into()),
                         Err(e) => {
                             tracing::warn!(error = %e, "stream_conversations item error");
                             continue;
@@ -100,7 +100,7 @@ impl Stream {
                 while let Some(next) = s.as_mut().next().await {
                     let message = match next {
                         Ok(m) => m,
-                        Err(e) if fail_on_error => return Err(e.into()),
+                        Err(e) if fail_fast => return Err(e.into()),
                         Err(e) => {
                             tracing::warn!(error = %e, "stream_all_messages item error");
                             continue;

--- a/apps/xmtp_debug/src/app/stream.rs
+++ b/apps/xmtp_debug/src/app/stream.rs
@@ -62,11 +62,20 @@ impl Stream {
             Box::new(BufWriter::new(std::io::stdout()))
         };
 
+        let fail_on_error = crate::fail_on_error();
         match kind {
             args::StreamKind::Conversations => {
                 let s = client.stream_conversations(None, false).await?;
                 tokio::pin!(s);
-                while let Some(Ok(group)) = s.as_mut().next().await {
+                while let Some(item) = s.as_mut().next().await {
+                    let group = match item {
+                        Ok(g) => g,
+                        Err(e) if fail_on_error => return Err(e.into()),
+                        Err(e) => {
+                            tracing::warn!(error = %e, "stream_conversations item error");
+                            continue;
+                        }
+                    };
                     let stored: StoredGroup = group.load()?;
                     let item = Conversation {
                         group_id: hex::encode(&stored.id),
@@ -88,7 +97,15 @@ impl Stream {
             args::StreamKind::Messages => {
                 let s = client.stream_all_messages(None, None).await?;
                 tokio::pin!(s);
-                while let Some(Ok(message)) = s.as_mut().next().await {
+                while let Some(next) = s.as_mut().next().await {
+                    let message = match next {
+                        Ok(m) => m,
+                        Err(e) if fail_on_error => return Err(e.into()),
+                        Err(e) => {
+                            tracing::warn!(error = %e, "stream_all_messages item error");
+                            continue;
+                        }
+                    };
                     let item = Message {
                         contents: String::from_utf8_lossy(&message.decrypted_message_bytes)
                             .to_string(),

--- a/apps/xmtp_debug/src/app/test.rs
+++ b/apps/xmtp_debug/src/app/test.rs
@@ -195,6 +195,9 @@ impl Test {
                         }
                     }
                     Err(e) => {
+                        if crate::fail_on_error() {
+                            return Err(eyre!("Error receiving message: {:?}", e));
+                        }
                         warn!("Error receiving message: {:?}", e);
                     }
                 }

--- a/apps/xmtp_debug/src/app/test.rs
+++ b/apps/xmtp_debug/src/app/test.rs
@@ -195,7 +195,7 @@ impl Test {
                         }
                     }
                     Err(e) => {
-                        if crate::fail_on_error() {
+                        if crate::fail_fast() {
                             return Err(eyre!("Error receiving message: {:?}", e));
                         }
                         warn!("Error receiving message: {:?}", e);

--- a/apps/xmtp_debug/src/args.rs
+++ b/apps/xmtp_debug/src/args.rs
@@ -34,6 +34,11 @@ pub struct AppOpts {
     /// to stdout. Off by default for clean CLI output.
     #[arg(long)]
     pub metrics: bool,
+    /// Fail-fast on the first per-operation error instead of logging and
+    /// continuing. Useful in `git bisect run` sessions where a single
+    /// failed send/sync should mark the commit bad.
+    #[arg(long)]
+    pub fail_on_error: bool,
 }
 
 #[derive(Subcommand, Debug)]
@@ -688,5 +693,33 @@ mod tests {
             .expect("--metrics and -m should coexist");
         assert!(opts.metrics);
         assert!(opts.backend.enable_migration);
+    }
+
+    #[test]
+    fn fail_on_error_defaults_false() {
+        let opts = AppOpts::try_parse_from(["xdbg"]).expect("parses with no args");
+        assert!(
+            !opts.fail_on_error,
+            "--fail-on-error should default to false"
+        );
+    }
+
+    #[test]
+    fn fail_on_error_parses_when_present() {
+        let opts = AppOpts::try_parse_from(["xdbg", "--fail-on-error"])
+            .expect("parses with --fail-on-error");
+        assert!(opts.fail_on_error);
+    }
+
+    #[test]
+    fn fail_on_error_has_no_short_alias() {
+        // Asserts that we don't allocate `-f` (or any short) for this flag,
+        // so future subcommands remain free to use short flags. `xdbg -f`
+        // should fail to parse.
+        let opts = AppOpts::try_parse_from(["xdbg", "-f"]);
+        assert!(
+            opts.is_err(),
+            "--fail-on-error should not have a short alias"
+        );
     }
 }

--- a/apps/xmtp_debug/src/args.rs
+++ b/apps/xmtp_debug/src/args.rs
@@ -34,11 +34,11 @@ pub struct AppOpts {
     /// to stdout. Off by default for clean CLI output.
     #[arg(long)]
     pub metrics: bool,
-    /// Fail-fast on the first per-operation error instead of logging and
-    /// continuing. Useful in `git bisect run` sessions where a single
+    /// Exit non-zero on the first per-operation error instead of logging
+    /// and continuing. Useful in `git bisect run` sessions where a single
     /// failed send/sync should mark the commit bad.
     #[arg(long)]
-    pub fail_on_error: bool,
+    pub fail_fast: bool,
 }
 
 #[derive(Subcommand, Debug)]
@@ -696,30 +696,24 @@ mod tests {
     }
 
     #[test]
-    fn fail_on_error_defaults_false() {
+    fn fail_fast_defaults_false() {
         let opts = AppOpts::try_parse_from(["xdbg"]).expect("parses with no args");
-        assert!(
-            !opts.fail_on_error,
-            "--fail-on-error should default to false"
-        );
+        assert!(!opts.fail_fast, "--fail-fast should default to false");
     }
 
     #[test]
-    fn fail_on_error_parses_when_present() {
-        let opts = AppOpts::try_parse_from(["xdbg", "--fail-on-error"])
-            .expect("parses with --fail-on-error");
-        assert!(opts.fail_on_error);
+    fn fail_fast_parses_when_present() {
+        let opts =
+            AppOpts::try_parse_from(["xdbg", "--fail-fast"]).expect("parses with --fail-fast");
+        assert!(opts.fail_fast);
     }
 
     #[test]
-    fn fail_on_error_has_no_short_alias() {
+    fn fail_fast_has_no_short_alias() {
         // Asserts that we don't allocate `-f` (or any short) for this flag,
         // so future subcommands remain free to use short flags. `xdbg -f`
         // should fail to parse.
         let opts = AppOpts::try_parse_from(["xdbg", "-f"]);
-        assert!(
-            opts.is_err(),
-            "--fail-on-error should not have a short alias"
-        );
+        assert!(opts.is_err(), "--fail-fast should not have a short alias");
     }
 }

--- a/apps/xmtp_debug/src/main.rs
+++ b/apps/xmtp_debug/src/main.rs
@@ -9,8 +9,16 @@ mod metrics;
 use clap::Parser;
 use color_eyre::eyre::Result;
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use xmtp_mls::context::XmtpMlsLocalContext;
+
+static FAIL_ON_ERROR: OnceLock<bool> = OnceLock::new();
+
+/// Whether `--fail-on-error` was passed at the CLI. Returns `false` when
+/// uninitialized (unit tests, early init paths).
+pub fn fail_on_error() -> bool {
+    FAIL_ON_ERROR.get().copied().unwrap_or(false)
+}
 
 pub type MlsContext =
     Arc<XmtpMlsLocalContext<DbgClientApi, xmtp_db::DefaultStore, xmtp_db::DefaultMlsStore>>;
@@ -30,6 +38,7 @@ async fn main() -> Result<()> {
     let mut logger = logger::Logger::from(&opts.log);
     logger.init()?;
     metrics::init_metrics(opts.metrics);
+    let _ = FAIL_ON_ERROR.set(opts.fail_on_error);
 
     if opts.version {
         info!("Version: {0}", get_version());

--- a/apps/xmtp_debug/src/main.rs
+++ b/apps/xmtp_debug/src/main.rs
@@ -12,12 +12,12 @@ use color_eyre::eyre::Result;
 use std::sync::{Arc, OnceLock};
 use xmtp_mls::context::XmtpMlsLocalContext;
 
-static FAIL_ON_ERROR: OnceLock<bool> = OnceLock::new();
+static FAIL_FAST: OnceLock<bool> = OnceLock::new();
 
-/// Whether `--fail-on-error` was passed at the CLI. Returns `false` when
+/// Whether `--fail-fast` was passed at the CLI. Returns `false` when
 /// uninitialized (unit tests, early init paths).
-pub fn fail_on_error() -> bool {
-    FAIL_ON_ERROR.get().copied().unwrap_or(false)
+pub fn fail_fast() -> bool {
+    FAIL_FAST.get().copied().unwrap_or(false)
 }
 
 pub type MlsContext =
@@ -38,7 +38,7 @@ async fn main() -> Result<()> {
     let mut logger = logger::Logger::from(&opts.log);
     logger.init()?;
     metrics::init_metrics(opts.metrics);
-    let _ = FAIL_ON_ERROR.set(opts.fail_on_error);
+    let _ = FAIL_FAST.set(opts.fail_fast);
 
     if opts.version {
         info!("Version: {0}", get_version());


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3610

## Summary

Adds a top-level `--fail-on-error` flag to xdbg that turns the existing log-and-continue error sites into fail-fast errors. Intended for `git bisect run` sessions, where a single failed send/sync should mark the commit bad rather than be lost in logs. Default behavior is unchanged.

The plan was [posted to the issue](https://github.com/xmtp/libxmtp/issues/3610#issuecomment-4399751878) per the request to brainstorm first.

## Sites updated

| File | Behavior change when `--fail-on-error` is set |
| --- | --- |
| `generate/messages.rs` | `send_many_messages` returns `Err` on the first per-task failure (was: log + return successes only). |
| `stream.rs` | Conversation/Message stream loops propagate the first `Err` item (was: skip with `while let Some(Ok(...))`). |
| `generate/groups.rs` | `check_member_visibility` now returns `Result<()>`; visibility-poll `sync_welcomes` failures surface (was: warn-and-continue forever). |
| `test.rs` | `MessageVisibility` scenario propagates stream errors (was: warn-and-continue). |

## Plumbing

A process-global `OnceLock<bool>` is initialized in `main.rs` immediately after `AppOpts::parse()`, read via a `crate::fail_on_error()` accessor at each call site. This mirrors the existing `static FDLIMIT: OnceLock<usize>` pattern in `app.rs` and avoids threading a bool through ~10 subcommand constructors.

## Out of scope

- `metrics.rs` push warnings (observability, not client operations).
- Library-side changes — libxmtp already returns `Result`; the policy decision (log vs. fail) lives in the CLI.

## Test plan

- [x] `cargo check -p xdbg` clean
- [x] `cargo test -p xdbg --bin xdbg args::` — 17/17 passing, including 3 new tests:
  - `fail_on_error_defaults_false`
  - `fail_on_error_parses_when_present`
  - `fail_on_error_has_no_short_alias` (asserts `xdbg -f` does not parse, leaving `-f` free for future subcommand options)
- [x] `just lint-rust` — clippy + fmt + hakari all clean
- [ ] Manual smoke against a backend (not gated; requires running `dev/up`): `xdbg generate -e message -a 1 --backend nonexistent` with and without `--fail-on-error` to confirm exit-code difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--fail-fast` flag to `xmtp_debug` for terminating on first error
> - Adds a `--fail-fast` CLI flag to [`args.rs`](https://github.com/xmtp/libxmtp/pull/3611/files#diff-625330612e40d918eef6d9785cc1b9adbc3c444cc2666c0d632bb216d3b2b4f5) and stores it in a global `OnceLock<bool>` in [`main.rs`](https://github.com/xmtp/libxmtp/pull/3611/files#diff-1402fc2e065b4dfc49f0c88fdd0afcbab0b1ea61526ee56858b46f0f95be79e1) accessible via `fail_fast()`.
> - When `--fail-fast` is set, errors in group creation, message generation, stream processing, and message visibility tests now return immediately instead of logging a warning and continuing.
> - `check_member_visibility` in [`groups.rs`](https://github.com/xmtp/libxmtp/pull/3611/files#diff-2a926685e9318ce1dc82bb85f365db546e52a68aca168cf9ac4fe69aa9b702d1) is updated to propagate errors via `?` rather than silently swallowing them.
> - Behavioral Change: without `--fail-fast`, behavior is unchanged; with the flag, the first per-operation error terminates the process with a non-zero exit code.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d709e9d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->