### PR TITLE
xmtp_mls_common: make extract_group_metadata capability-aware

### DIFF
--- a/crates/xmtp_mls/src/groups/tests/test_proposals.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_proposals.rs
@@ -474,7 +474,6 @@ async fn test_propose_invalid_member_operations(#[case] is_add: bool) {
 /// This verifies that the SendMessage handler automatically queues a CommitPendingProposals
 /// intent and retries, ensuring seamless messaging even with pending proposals.
 #[xmtp_common::test(unwrap_try = true)]
-#[ignore = "post-bootstrap welcome receive: welcomes for migrated groups fail because the welcome receiver path (groups/welcomes/xmtp_welcome.rs) calls extract_group_metadata / extract_group_mutable_metadata which read the legacy ImmutableMetadata + MUTABLE_METADATA extensions that bootstrap strips. extract_group_membership is already capability-aware (reads dict first); these are not. Follow-on PR: make these two extractors capability-aware (add dict-reader fallback), then drop these ignores. See TODO(app-data-migration) markers in xmtp_welcome.rs:326,368 and mls_sync.rs:1921."]
 async fn test_message_auto_commits_pending_proposals() {
     tester!(alix);
     tester!(bo);
@@ -683,7 +682,6 @@ async fn test_multiple_add_proposals_before_commit() {
 /// Test creating both add and remove proposals before committing.
 /// Pattern: Alix proposes add+remove, Bo commits both.
 #[xmtp_common::test(unwrap_try = true)]
-#[ignore = "post-bootstrap welcome receive: welcomes for migrated groups fail because the welcome receiver path (groups/welcomes/xmtp_welcome.rs) calls extract_group_metadata / extract_group_mutable_metadata which read the legacy ImmutableMetadata + MUTABLE_METADATA extensions that bootstrap strips. extract_group_membership is already capability-aware (reads dict first); these are not. Follow-on PR: make these two extractors capability-aware (add dict-reader fallback), then drop these ignores. See TODO(app-data-migration) markers in xmtp_welcome.rs:326,368 and mls_sync.rs:1921."]
 async fn test_mixed_add_remove_proposals_before_commit() {
     tester!(alix);
     tester!(bo);
@@ -929,7 +927,7 @@ async fn test_proposer_can_commit_own_proposal() {
 /// Pattern: Alix proposes, Bo proposes, Caro (non-proposer) commits both.
 /// NOTE: Now proposers CAN commit their own proposals too - permissions are checked against proposer.
 #[xmtp_common::test(unwrap_try = true)]
-#[ignore = "post-bootstrap welcome receive: welcomes for migrated groups fail because the welcome receiver path (groups/welcomes/xmtp_welcome.rs) calls extract_group_metadata / extract_group_mutable_metadata which read the legacy ImmutableMetadata + MUTABLE_METADATA extensions that bootstrap strips. extract_group_membership is already capability-aware (reads dict first); these are not. Follow-on PR: make these two extractors capability-aware (add dict-reader fallback), then drop these ignores. See TODO(app-data-migration) markers in xmtp_welcome.rs:326,368 and mls_sync.rs:1921."]
+#[ignore = "post-bootstrap commit validation: extract_committer_and_proposers in validated_commit.rs returns ActorCouldNotBeFound on commits with no path update + multiple proposers, AND the migrated-group policy stub rejects non-super-admin proposers. Both addressed in a follow-on change."]
 async fn test_concurrent_proposals_from_different_members() {
     tester!(alix);
     tester!(bo);
@@ -1381,7 +1379,6 @@ async fn test_build_extensions_for_membership_update() {
 /// It also verifies that `extract_committer_and_proposers` correctly identifies the committer
 /// from the path update leaf node when multiple proposals are pending.
 #[xmtp_common::test(unwrap_try = true)]
-#[ignore = "post-bootstrap welcome receive: welcomes for migrated groups fail because the welcome receiver path (groups/welcomes/xmtp_welcome.rs) calls extract_group_metadata / extract_group_mutable_metadata which read the legacy ImmutableMetadata + MUTABLE_METADATA extensions that bootstrap strips. extract_group_membership is already capability-aware (reads dict first); these are not. Follow-on PR: make these two extractors capability-aware (add dict-reader fallback), then drop these ignores. See TODO(app-data-migration) markers in xmtp_welcome.rs:326,368 and mls_sync.rs:1921."]
 async fn test_non_admin_commits_admin_proposals_in_admin_group() {
     use crate::groups::group_permissions::PreconfiguredPolicies;
 
@@ -1528,7 +1525,7 @@ async fn test_non_admin_commits_admin_proposals_in_admin_group() {
 /// 2. Each add is validated against its proposer, not the committer
 /// 3. The admin can then perform admin-only operations (group name update)
 #[xmtp_common::test(unwrap_try = true)]
-#[ignore = "post-bootstrap welcome receive: welcomes for migrated groups fail because the welcome receiver path (groups/welcomes/xmtp_welcome.rs) calls extract_group_metadata / extract_group_mutable_metadata which read the legacy ImmutableMetadata + MUTABLE_METADATA extensions that bootstrap strips. extract_group_membership is already capability-aware (reads dict first); these are not. Follow-on PR: make these two extractors capability-aware (add dict-reader fallback), then drop these ignores. See TODO(app-data-migration) markers in xmtp_welcome.rs:326,368 and mls_sync.rs:1921."]
+#[ignore = "post-bootstrap commit validation: see test_concurrent_proposals_from_different_members for the same root cause."]
 async fn test_multiple_non_admin_proposers_with_admin_committer() {
     tester!(alix);
     tester!(bo);
@@ -2194,7 +2191,6 @@ async fn test_non_super_admin_gce_permission_change_rejected() {
 /// When proposals_enabled is true, UpdateGroupMembership should create Add proposals + GCE + commit
 /// in a single publish, rather than a direct commit.
 #[xmtp_common::test(unwrap_try = true)]
-#[ignore = "post-bootstrap welcome receive: welcomes for migrated groups fail because the welcome receiver path (groups/welcomes/xmtp_welcome.rs) calls extract_group_metadata / extract_group_mutable_metadata which read the legacy ImmutableMetadata + MUTABLE_METADATA extensions that bootstrap strips. extract_group_membership is already capability-aware (reads dict first); these are not. Follow-on PR: make these two extractors capability-aware (add dict-reader fallback), then drop these ignores. See TODO(app-data-migration) markers in xmtp_welcome.rs:326,368 and mls_sync.rs:1921."]
 async fn test_add_members_batched_when_proposals_enabled() {
     tester!(alix);
     tester!(bo);
@@ -2311,7 +2307,7 @@ async fn test_add_members_direct_commit_when_proposals_disabled() {
 /// Test that commit_pending_proposals batches GCE and commit when proposals come from
 /// a different member (Bob proposes, Alice commits).
 #[xmtp_common::test(unwrap_try = true)]
-#[ignore = "post-bootstrap welcome receive: welcomes for migrated groups fail because the welcome receiver path (groups/welcomes/xmtp_welcome.rs) calls extract_group_metadata / extract_group_mutable_metadata which read the legacy ImmutableMetadata + MUTABLE_METADATA extensions that bootstrap strips. extract_group_membership is already capability-aware (reads dict first); these are not. Follow-on PR: make these two extractors capability-aware (add dict-reader fallback), then drop these ignores. See TODO(app-data-migration) markers in xmtp_welcome.rs:326,368 and mls_sync.rs:1921."]
+#[ignore = "post-bootstrap commit validation: see test_concurrent_proposals_from_different_members for the same root cause."]
 async fn test_commit_pending_proposals_batches_gce_and_commit() {
     tester!(alix);
     tester!(bo);
@@ -2475,7 +2471,6 @@ async fn test_sequence_id_bump_triggers_gce_with_proposals_enabled() {
 /// This verifies that compute_publish_data_for_proposal_based_update correctly compares
 /// the full GroupMembership (including sequence IDs) when deciding whether a GCE is needed.
 #[xmtp_common::test(unwrap_try = true)]
-#[ignore = "post-bootstrap welcome receive: welcomes for migrated groups fail because the welcome receiver path (groups/welcomes/xmtp_welcome.rs) calls extract_group_metadata / extract_group_mutable_metadata which read the legacy ImmutableMetadata + MUTABLE_METADATA extensions that bootstrap strips. extract_group_membership is already capability-aware (reads dict first); these are not. Follow-on PR: make these two extractors capability-aware (add dict-reader fallback), then drop these ignores. See TODO(app-data-migration) markers in xmtp_welcome.rs:326,368 and mls_sync.rs:1921."]
 async fn test_add_member_after_sequence_id_bump_with_proposals_enabled() {
     use crate::groups::validated_commit::extract_group_membership;
 

--- a/crates/xmtp_mls/src/groups/welcomes/xmtp_welcome.rs
+++ b/crates/xmtp_mls/src/groups/welcomes/xmtp_welcome.rs
@@ -323,9 +323,6 @@ where
                 welcome.cursor,
             )?;
         }
-        // TODO(app-data-migration): post-bootstrap groups have no legacy
-        // GroupMetadata extension; route through a capability-aware
-        // helper before the bootstrap commit lands.
         let metadata =
             extract_group_metadata(staged_welcome.public_group().group_context().extensions())
                 .map_err(MetadataPermissionsError::from)?;

--- a/crates/xmtp_mls_common/src/group_metadata.rs
+++ b/crates/xmtp_mls_common/src/group_metadata.rs
@@ -214,14 +214,122 @@ impl TryFrom<DmMembersProto> for DmMembers<InboxId> {
     }
 }
 
+/// Extract `GroupMetadata` from a group context.
+///
+/// **Capability-aware.** On migrated groups (post-bootstrap, where the
+/// AppData dictionary contains the canonical `COMPONENT_REGISTRY` entry)
+/// the metadata is reconstructed from the dict's `CONVERSATION_TYPE`,
+/// `CREATOR_INBOX_ID`, `DM_MEMBERS`, and `ONESHOT_MESSAGE` components.
+/// On unmigrated groups it is read from the legacy `ImmutableMetadata`
+/// MLS extension. Callers don't need to know which path applies.
 pub fn extract_group_metadata(
     extensions: &Extensions<GroupContext>,
 ) -> Result<GroupMetadata, GroupMetadataError> {
+    if let Some(metadata) = read_group_metadata_from_dict(extensions)? {
+        return Ok(metadata);
+    }
+
     let extension = extensions
         .immutable_metadata()
         .ok_or(GroupMetadataError::MissingExtension)?;
 
     extension.metadata().try_into()
+}
+
+/// Read `GroupMetadata` from the AppData dictionary on a migrated group.
+///
+/// Returns `Ok(None)` for unmigrated groups (no `COMPONENT_REGISTRY`
+/// entry in the dict, or no AppData dictionary at all) so the caller
+/// can fall back to the legacy `ImmutableMetadata` extension. Returns
+/// `Err` only on a malformed dict entry on a group that *is* migrated.
+fn read_group_metadata_from_dict(
+    extensions: &Extensions<GroupContext>,
+) -> Result<Option<GroupMetadata>, GroupMetadataError> {
+    use crate::app_data::component_id::ComponentId;
+    use crate::inbox_id::InboxId as DictInboxId;
+    use crate::tls_set::TlsSet;
+    use tls_codec::Deserialize;
+
+    let Some(ext) = extensions.app_data_dictionary() else {
+        return Ok(None);
+    };
+    let dict = ext.dictionary();
+
+    // Use COMPONENT_REGISTRY presence as the post-bootstrap marker. A
+    // pre-bootstrap group should never carry a stray dict entry that
+    // shadows the legacy extension.
+    if !dict.contains(&ComponentId::COMPONENT_REGISTRY.as_u16()) {
+        return Ok(None);
+    }
+
+    // On a migrated group these two are required. Falling back to the
+    // legacy `ImmutableMetadata` extension would mean trusting a stale
+    // (or absent) value, so surface the malformed dict instead.
+    let Some(ct_bytes) = dict.get(&ComponentId::CONVERSATION_TYPE.as_u16()) else {
+        return Err(GroupMetadataError::Conversion(
+            xmtp_proto::ConversionError::Missing {
+                item: "CONVERSATION_TYPE",
+                r#type: "AppData dictionary entry",
+            },
+        ));
+    };
+    let Some(creator_bytes) = dict.get(&ComponentId::CREATOR_INBOX_ID.as_u16()) else {
+        return Err(GroupMetadataError::Conversion(
+            xmtp_proto::ConversionError::Missing {
+                item: "CREATOR_INBOX_ID",
+                r#type: "AppData dictionary entry",
+            },
+        ));
+    };
+
+    // CONVERSATION_TYPE: 4-byte big-endian i32 matching `ConversationTypeProto`.
+    let ct_arr: [u8; 4] = ct_bytes
+        .try_into()
+        .map_err(|_| GroupMetadataError::InvalidConversationType)?;
+    let conversation_type_i32 = i32::from_be_bytes(ct_arr);
+    let conversation_type: ConversationType = conversation_type_i32.try_into()?;
+
+    // CREATOR_INBOX_ID: versioned `InboxId` TLS form. Hex-encode for the
+    // legacy `String` slot the rest of the codebase consumes.
+    let creator_inbox_id = DictInboxId::tls_deserialize_exact(creator_bytes)
+        .map_err(|e| {
+            GroupMetadataError::Conversion(xmtp_proto::ConversionError::InvalidValue {
+                item: "CREATOR_INBOX_ID",
+                expected: "versioned InboxId TLS encoding",
+                got: format!("{e}"),
+            })
+        })?
+        .to_hex();
+
+    // DM_MEMBERS: `TlsSet<InboxId>` with exactly two elements, or absent.
+    let dm_members = match dict.get(&ComponentId::DM_MEMBERS.as_u16()) {
+        Some(b) => {
+            let set = TlsSet::<DictInboxId>::tls_deserialize_exact(b)
+                .map_err(|_| GroupMetadataError::InvalidDmMembers)?;
+            let ids: Vec<DictInboxId> = set.iter().copied().collect();
+            if ids.len() != 2 {
+                return Err(GroupMetadataError::InvalidDmMembers);
+            }
+            Some(DmMembers {
+                member_one_inbox_id: ids[0].to_hex(),
+                member_two_inbox_id: ids[1].to_hex(),
+            })
+        }
+        None => None,
+    };
+
+    // ONESHOT_MESSAGE: prost-encoded `OneshotMessage`.
+    let oneshot_message = match dict.get(&ComponentId::ONESHOT_MESSAGE.as_u16()) {
+        Some(b) => Some(OneshotMessage::decode(b)?),
+        None => None,
+    };
+
+    Ok(Some(GroupMetadata {
+        conversation_type,
+        creator_inbox_id,
+        dm_members,
+        oneshot_message,
+    }))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Makes `extract_group_metadata` (in `xmtp_mls_common::group_metadata`) capability-aware so the welcome receiver path works on migrated groups. Reads from the AppData dictionary's `CONVERSATION_TYPE` + `CREATOR_INBOX_ID` + `DM_MEMBERS` + `ONESHOT_MESSAGE` components when the dict has `COMPONENT_REGISTRY`; falls back to the legacy `ImmutableMetadata` MLS extension on unmigrated groups.

The bootstrap commit (#3598) strips `ImmutableMetadata` alongside the other three legacy extensions. Without this fix, every post-bootstrap welcome fails the receiver path with `MetadataPermissionsError(Mutable(MissingExtension))` — visible to test_proposals.rs as "Caro should have received a welcome".

Mirrors the dict-then-legacy pattern `extract_group_membership` already follows (see `validated_commit.rs:1448`).

Unblocks 5 of the 8 previously-ignored bootstrap-flow proposal tests in `test_proposals.rs`. Three remain ignored with a precise reason pointing at a separate validator bug; that bug is fixed in the follow-on PR (`tyler/app-data-11-validator-policy-and-path`).

## Test plan
- [x] \`just test crate xmtp_mls\` — 536/536 pass (3 still-ignored bug-blocked tests + 5 platform-skipped)
- [x] \`cargo clippy -p xmtp_mls --all-features --all-targets --no-deps -- -Dwarnings\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `extract_group_metadata` capability-aware by reading from AppData dictionary on migrated groups
> - `extract_group_metadata` in [`group_metadata.rs`](https://github.com/xmtp/libxmtp/pull/3612/files#diff-1d8002fd96da6307acba18b08d8f199f03f7de228bd552ff4172a982bfcfbf48) now first attempts to read `GroupMetadata` from the MLS AppData dictionary via a new `read_group_metadata_from_dict` helper, falling back to the legacy `ImmutableMetadata` extension for unmigrated groups.
> - `read_group_metadata_from_dict` checks for `COMPONENT_REGISTRY` presence to detect migration, then parses required fields (`CONVERSATION_TYPE`, `CREATOR_INBOX_ID`) and optional fields (`DM_MEMBERS`, `ONESHOT_MESSAGE`).
> - Several previously ignored proposal-related tests in [`test_proposals.rs`](https://github.com/xmtp/libxmtp/pull/3612/files#diff-fb8ffb096fea904de9f05e2ad66734c897c3a9ceb42099e25f894c256f1f5f8e) are re-enabled as part of this change.
> - Risk: migrated groups with malformed or missing required dict entries now return an error instead of silently falling back to the legacy path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9a2d749.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->