### PR TITLE
xmtp_mls: enforce registry membership policy on migrated commits

### DIFF
--- a/crates/xmtp_mls/src/groups/app_data/mod.rs
+++ b/crates/xmtp_mls/src/groups/app_data/mod.rs
@@ -17,6 +17,7 @@
 pub(crate) mod bootstrap_validator;
 pub mod component_source;
 pub mod migration;
+pub(crate) mod policy;
 pub(crate) mod sender_intents;
 pub(crate) mod typed_facade;
 

--- a/crates/xmtp_mls/src/groups/app_data/policy.rs
+++ b/crates/xmtp_mls/src/groups/app_data/policy.rs
@@ -1,0 +1,136 @@
+//! Translate the AppData `COMPONENT_REGISTRY`'s membership policies into
+//! the legacy [`GroupMutablePermissions`] shape so the receive-side
+//! validator and standalone-proposal validator can evaluate Add /
+//! Remove proposals on migrated groups against the same policy that
+//! `validate_app_data_update_proposals_in_commit` enforces for the
+//! companion `AppDataUpdate(GROUP_MEMBERSHIP)` proposal.
+//!
+//! The mapping is:
+//! - `GROUP_MEMBERSHIP.insert_policy` → `add_member_policy`
+//! - `GROUP_MEMBERSHIP.delete_policy` → `remove_member_policy`
+//!
+//! Other slots on the synthesized `PolicySet` (metadata field updates,
+//! admin add/remove, permissions update) keep the conservative
+//! "super admin only" stub — the AppDataUpdate path enforces those
+//! per-component when a real change comes through, and the legacy
+//! callers only consult them as part of structural sanity checks.
+
+use openmls::group::MlsGroup as OpenMlsGroup;
+use xmtp_mls_common::app_data::component_id::ComponentId;
+use xmtp_proto::xmtp::mls::message_contents::{
+    MetadataPolicy as MetadataPolicyProto, metadata_policy::Kind as MetadataPolicyKindProto,
+    metadata_policy::MetadataBasePolicy as MetadataBasePolicyProto,
+};
+
+use super::component_source::ComponentSourceError;
+use crate::groups::group_permissions::{
+    GroupMutablePermissions, MembershipPolicies, PermissionsPolicies, PolicySet,
+};
+
+/// Translate a wire-form `MetadataPolicy` into a `MembershipPolicies`.
+///
+/// Unknown / non-base variants conservatively map to `Deny` — Add /
+/// Remove proposals from peers using a policy shape we don't recognize
+/// must not slip through silently.
+fn metadata_policy_to_membership(p: &MetadataPolicyProto) -> MembershipPolicies {
+    match p.kind.as_ref() {
+        Some(MetadataPolicyKindProto::Base(base)) => {
+            match MetadataBasePolicyProto::try_from(*base) {
+                Ok(MetadataBasePolicyProto::Allow) => MembershipPolicies::allow(),
+                Ok(MetadataBasePolicyProto::Deny) => MembershipPolicies::deny(),
+                Ok(MetadataBasePolicyProto::AllowIfAdmin) => {
+                    MembershipPolicies::allow_if_actor_admin()
+                }
+                Ok(MetadataBasePolicyProto::AllowIfSuperAdmin) => {
+                    MembershipPolicies::allow_if_actor_super_admin()
+                }
+                Ok(MetadataBasePolicyProto::Unspecified) | Err(_) => MembershipPolicies::deny(),
+            }
+        }
+        // AndCondition / AnyCondition variants don't have a clean
+        // `MembershipPolicies` analogue today — every well-known
+        // component the bootstrap synthesizer emits uses `Base`.
+        // Conservative deny here keeps the door closed if we ever hit
+        // a richer policy shape we haven't translated.
+        _ => MembershipPolicies::deny(),
+    }
+}
+
+/// Build a `GroupMutablePermissions` whose `add_member_policy` /
+/// `remove_member_policy` reflect the registry's `GROUP_MEMBERSHIP`
+/// policies. Everything else is a stub — the AppDataUpdate validation
+/// path is the authoritative gate for non-membership components.
+pub(crate) fn membership_policy_set_from_registry(
+    mls_group: &OpenMlsGroup,
+) -> Result<GroupMutablePermissions, ComponentSourceError> {
+    let registry = super::load_component_registry(mls_group)?;
+
+    let (add_policy, remove_policy) = match registry.get(&ComponentId::GROUP_MEMBERSHIP) {
+        Ok(Some(meta)) => match meta.permissions {
+            Some(perms) => {
+                let add = match perms.insert_policy.as_ref() {
+                    Some(p) => metadata_policy_to_membership(p),
+                    None => {
+                        tracing::warn!(
+                            "GROUP_MEMBERSHIP registry entry missing insert_policy; \
+                             falling back to deny-add membership policy"
+                        );
+                        MembershipPolicies::deny()
+                    }
+                };
+                let remove = match perms.delete_policy.as_ref() {
+                    Some(p) => metadata_policy_to_membership(p),
+                    None => {
+                        tracing::warn!(
+                            "GROUP_MEMBERSHIP registry entry missing delete_policy; \
+                             falling back to deny-remove membership policy"
+                        );
+                        MembershipPolicies::deny()
+                    }
+                };
+                (add, remove)
+            }
+            None => {
+                tracing::warn!(
+                    "GROUP_MEMBERSHIP registry entry has no permissions block; \
+                     falling back to deny-all membership policy"
+                );
+                (MembershipPolicies::deny(), MembershipPolicies::deny())
+            }
+        },
+        // Missing GROUP_MEMBERSHIP entry — the dict is partially
+        // populated or we're racing the bootstrap. Production groups
+        // always carry this entry post-bootstrap, so a miss here is
+        // worth a breadcrumb rather than surfacing only as a
+        // downstream `InsufficientPermissions`.
+        Ok(None) => {
+            tracing::warn!(
+                "no GROUP_MEMBERSHIP entry in component registry; \
+                 falling back to deny-all membership policy"
+            );
+            (MembershipPolicies::deny(), MembershipPolicies::deny())
+        }
+        Err(e) => {
+            tracing::warn!(
+                error = ?e,
+                "GROUP_MEMBERSHIP registry decode failed; falling back to deny-all membership policy"
+            );
+            (MembershipPolicies::deny(), MembershipPolicies::deny())
+        }
+    };
+
+    // Non-membership slots stay on the conservative super-admin stub:
+    // metadata field updates, admin add/remove, and permissions update
+    // are all enforced per-component by
+    // `validate_app_data_update_proposals_in_commit` when a real change
+    // comes through. Legacy callers only consult these slots as part
+    // of structural sanity checks, so super-admin-only is safe.
+    Ok(GroupMutablePermissions::new(PolicySet::new(
+        add_policy,
+        remove_policy,
+        std::collections::HashMap::new(),
+        PermissionsPolicies::allow_if_actor_super_admin(),
+        PermissionsPolicies::allow_if_actor_super_admin(),
+        PermissionsPolicies::allow_if_actor_super_admin(),
+    )))
+}

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -786,9 +786,13 @@ where
                         envelope.created_ns
                     );
 
+                    // We just published this commit ourselves, so the committer
+                    // is our own leaf — no need to consult the staged commit's
+                    // path update field.
                     let maybe_validated_commit = ValidatedCommit::from_staged_commit(
                         &self.context,
                         &staged_commit,
+                        mls_group.own_leaf_index(),
                         mls_group,
                     )
                     .await;
@@ -1085,9 +1089,25 @@ where
 
         let validated_commit = match &processed_message.content() {
             ProcessedMessageContent::StagedCommitMessage(staged_commit) => {
-                let result =
-                    ValidatedCommit::from_staged_commit(&self.context, staged_commit, mls_group)
-                        .await;
+                // OpenMLS already verified the framing signature against the
+                // sender's leaf during `process_message`, and `extract_message_sender`
+                // above asserted `Sender::Member` — so this match is exhaustive
+                // for the cases that reach here.
+                let committer_leaf_index = match processed_message.sender() {
+                    openmls::prelude::Sender::Member(idx) => *idx,
+                    _ => {
+                        return Err(GroupMessageProcessingError::CommitValidation(
+                            CommitValidationError::ActorNotMember,
+                        ));
+                    }
+                };
+                let result = ValidatedCommit::from_staged_commit(
+                    &self.context,
+                    staged_commit,
+                    committer_leaf_index,
+                    mls_group,
+                )
+                .await;
 
                 let validated_commit = match result {
                     Err(e) if !e.is_retryable() => {
@@ -1136,17 +1156,17 @@ where
                 // for AppDataUpdate proposals.
                 let is_migrated = super::app_data::is_migrated_group(mls_group);
                 let policy_set = if is_migrated {
-                    use crate::groups::group_permissions::{
-                        GroupMutablePermissions, MembershipPolicies, PermissionsPolicies, PolicySet,
-                    };
-                    GroupMutablePermissions::new(PolicySet::new(
-                        MembershipPolicies::allow_if_actor_super_admin(),
-                        MembershipPolicies::allow_if_actor_super_admin(),
-                        std::collections::HashMap::new(),
-                        PermissionsPolicies::allow_if_actor_super_admin(),
-                        PermissionsPolicies::allow_if_actor_super_admin(),
-                        PermissionsPolicies::allow_if_actor_super_admin(),
-                    ))
+                    // Derive add/remove member policies from the
+                    // COMPONENT_REGISTRY's GROUP_MEMBERSHIP entry.
+                    // Insert/Delete in the dict map onto Add/Remove on
+                    // the MLS tree.
+                    match super::app_data::policy::membership_policy_set_from_registry(mls_group) {
+                        Ok(ps) => ps,
+                        Err(e) => {
+                            self.maybe_update_cursor(&self.context.db(), envelope)?;
+                            return Err(CommitValidationError::from(e).into());
+                        }
+                    }
                 } else {
                     match extract_group_permissions(mls_group) {
                         Ok(p) => p,

--- a/crates/xmtp_mls/src/groups/tests/test_proposals.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_proposals.rs
@@ -927,7 +927,6 @@ async fn test_proposer_can_commit_own_proposal() {
 /// Pattern: Alix proposes, Bo proposes, Caro (non-proposer) commits both.
 /// NOTE: Now proposers CAN commit their own proposals too - permissions are checked against proposer.
 #[xmtp_common::test(unwrap_try = true)]
-#[ignore = "post-bootstrap commit validation: extract_committer_and_proposers in validated_commit.rs returns ActorCouldNotBeFound on commits with no path update + multiple proposers, AND the migrated-group policy stub rejects non-super-admin proposers. Both addressed in a follow-on change."]
 async fn test_concurrent_proposals_from_different_members() {
     tester!(alix);
     tester!(bo);
@@ -1525,7 +1524,6 @@ async fn test_non_admin_commits_admin_proposals_in_admin_group() {
 /// 2. Each add is validated against its proposer, not the committer
 /// 3. The admin can then perform admin-only operations (group name update)
 #[xmtp_common::test(unwrap_try = true)]
-#[ignore = "post-bootstrap commit validation: see test_concurrent_proposals_from_different_members for the same root cause."]
 async fn test_multiple_non_admin_proposers_with_admin_committer() {
     tester!(alix);
     tester!(bo);
@@ -2307,7 +2305,6 @@ async fn test_add_members_direct_commit_when_proposals_disabled() {
 /// Test that commit_pending_proposals batches GCE and commit when proposals come from
 /// a different member (Bob proposes, Alice commits).
 #[xmtp_common::test(unwrap_try = true)]
-#[ignore = "post-bootstrap commit validation: see test_concurrent_proposals_from_different_members for the same root cause."]
 async fn test_commit_pending_proposals_batches_gce_and_commit() {
     tester!(alix);
     tester!(bo);

--- a/crates/xmtp_mls/src/groups/validated_commit.rs
+++ b/crates/xmtp_mls/src/groups/validated_commit.rs
@@ -3,9 +3,8 @@ use super::{
     MAX_GROUP_NAME_LENGTH,
     group_membership::{GroupMembership, MembershipDiff},
     group_permissions::{
-        GroupMutablePermissions, GroupMutablePermissionsError, MembershipPolicies,
-        MembershipPolicy, MetadataPolicy, PermissionsPolicies, PermissionsPolicy, PolicySet,
-        extract_group_permissions,
+        GroupMutablePermissions, GroupMutablePermissionsError, MembershipPolicy, MetadataPolicy,
+        PermissionsPolicy, PolicySet, extract_group_permissions,
     },
 };
 use crate::{
@@ -364,6 +363,7 @@ impl ValidatedCommit {
     pub async fn from_staged_commit(
         context: &impl XmtpSharedContext,
         staged_commit: &StagedCommit,
+        committer_leaf_index: LeafNodeIndex,
         openmls_group: &OpenMlsGroup,
     ) -> Result<Self, CommitValidationError> {
         let extensions = openmls_group.extensions();
@@ -426,6 +426,7 @@ impl ValidatedCommit {
         if super::app_data::bootstrap_validator::is_bootstrap_commit(staged_commit, extensions) {
             return Self::validate_bootstrap_and_build(
                 staged_commit,
+                committer_leaf_index,
                 openmls_group,
                 immutable_metadata,
                 mutable_metadata,
@@ -434,22 +435,19 @@ impl ValidatedCommit {
 
         let conn = context.db();
         // On migrated groups the legacy `GROUP_PERMISSIONS_EXTENSION_ID`
-        // is gone — permissions live in the AppData dictionary's
-        // COMPONENT_REGISTRY entry. Synthesize a stub here so the
-        // legacy code paths below (extract_permissions_changed,
-        // committer/proposer extraction) don't crash. The actual
-        // policy enforcement runs through
-        // `validate_app_data_update_proposals_in_commit` below, which
-        // is capability-aware and uses the registry directly.
+        // is gone — membership policy lives in the AppData
+        // dictionary's COMPONENT_REGISTRY entry under
+        // `GROUP_MEMBERSHIP`. Per-component AppDataUpdate enforcement
+        // runs separately in
+        // `validate_app_data_update_proposals_in_commit`, but the
+        // legacy code paths here (extract_permissions_changed +
+        // standalone Add/Remove proposer permission checks) still
+        // need a `GroupMutablePermissions` instance to evaluate
+        // against. We derive the membership-affecting bits from the
+        // registry so post-bootstrap commits enforce the same policy
+        // a pre-bootstrap GCE-extension lookup would.
         let group_permissions: GroupMutablePermissions = if is_migrated {
-            GroupMutablePermissions::new(PolicySet::new(
-                MembershipPolicies::allow_if_actor_super_admin(),
-                MembershipPolicies::allow_if_actor_super_admin(),
-                std::collections::HashMap::new(),
-                PermissionsPolicies::allow_if_actor_super_admin(),
-                PermissionsPolicies::allow_if_actor_super_admin(),
-                PermissionsPolicies::allow_if_actor_super_admin(),
-            ))
+            super::app_data::policy::membership_policy_set_from_registry(openmls_group)?
         } else {
             extensions.try_into()?
         };
@@ -531,6 +529,7 @@ impl ValidatedCommit {
         // proposals created by other members).
         let (actor, proposers) = extract_committer_and_proposers(
             staged_commit,
+            committer_leaf_index,
             openmls_group,
             &immutable_metadata,
             &mutable_metadata,
@@ -738,6 +737,7 @@ impl ValidatedCommit {
     /// installation-diff checks see a no-op.
     fn validate_bootstrap_and_build(
         staged_commit: &StagedCommit,
+        committer_leaf_index: LeafNodeIndex,
         openmls_group: &OpenMlsGroup,
         immutable_metadata: GroupMetadata,
         mutable_metadata: GroupMutableMetadata,
@@ -746,6 +746,7 @@ impl ValidatedCommit {
 
         let (actor, proposers) = extract_committer_and_proposers(
             staged_commit,
+            committer_leaf_index,
             openmls_group,
             &immutable_metadata,
             &mutable_metadata,
@@ -1674,25 +1675,28 @@ fn inbox_id_from_credential(
     Ok(decoded.inbox_id)
 }
 
-/// Takes a [`StagedCommit`] and extracts the committer (from path update) and all unique proposers.
-/// In the case of a self-update, which does not contain any proposals, this will come from the update_path.
-/// In the case of a commit with proposals, it collects all unique proposers from the proposals.
+/// Takes a [`StagedCommit`] and extracts the committer and all unique proposers.
+///
+/// `committer_leaf_index` is the verified sender of the commit message — for
+/// received commits, that's `ProcessedMessage::sender()` after OpenMLS has
+/// validated the framing signature against the leaf at that index; for our
+/// own commits being applied from an intent, that's `mls_group.own_leaf_index()`.
+/// Either way the cryptographic signature is the source of truth, so we
+/// don't need a path update to identify the committer.
 ///
 /// Returns (committer, proposers) where:
-/// - `committer` is the actor who created the commit (from path update or single proposer)
+/// - `committer` is the actor who created the commit
 /// - `proposers` is a list of all unique members who created proposals
 ///
-/// Note: The committer may differ from the proposers - this is valid when one member commits
-/// proposals created by other members.
+/// Note: The committer may differ from the proposers — this is valid when one
+/// member commits proposals created by other members.
 fn extract_committer_and_proposers(
     staged_commit: &StagedCommit,
+    committer_leaf_index: LeafNodeIndex,
     openmls_group: &OpenMlsGroup,
     immutable_metadata: &GroupMetadata,
     mutable_metadata: &GroupMutableMetadata,
 ) -> Result<(CommitParticipant, Vec<CommitParticipant>), CommitValidationError> {
-    // If there was a path update, get the leaf node that was updated (this is the committer)
-    let path_update_leaf_node: Option<&LeafNode> = staged_commit.update_path_leaf_node();
-
     // Collect all unique proposers from the proposals
     let mut proposer_leaf_indices: Vec<&LeafNodeIndex> = Vec::new();
     for proposal in staged_commit.queued_proposals() {
@@ -1719,26 +1723,12 @@ fn extract_committer_and_proposers(
         proposers.push(participant);
     }
 
-    // Determine the committer:
-    // 1. If there's a path update, the committer is from the path update
-    // 2. Otherwise, if there are proposers, the committer is the single proposer (for backwards compat)
-    let committer = if let Some(path_update_leaf_node) = path_update_leaf_node {
-        CommitParticipant::from_leaf_node(
-            path_update_leaf_node,
-            immutable_metadata,
-            mutable_metadata,
-        )?
-    } else if proposer_leaf_indices.len() == 1 {
-        // Single proposer case - for backwards compatibility, use them as the committer
-        proposers[0].clone()
-    } else if proposer_leaf_indices.is_empty() {
-        // No path update and no proposals - this should be impossible
-        return Err(CommitValidationError::ActorCouldNotBeFound);
-    } else {
-        // Multiple proposers but no path update - this shouldn't happen in practice
-        // because commits with proposals should have a path update from the committer
-        return Err(CommitValidationError::ActorCouldNotBeFound);
-    };
+    let committer = extract_commit_participant(
+        &committer_leaf_index,
+        openmls_group,
+        immutable_metadata,
+        mutable_metadata,
+    )?;
 
     Ok((committer, proposers))
 }


### PR DESCRIPTION
## Summary

Two coupled fixes that together unblock the last 3 of 8 previously-ignored bootstrap-flow proposal tests in `test_proposals.rs`. Stacks on #3612.

**1. Use the verified message sender as the committer.** Previously `extract_committer_and_proposers` derived the committer from `StagedCommit::update_path_leaf_node()`, with a "single proposer becomes the committer" fallback. Both branches were workarounds for not having the actual sender — but OpenMLS already verifies the framing signature against the leaf at `ProcessedMessage::sender()` during `process_message`, so that's the authoritative committer (same way `proposal.sender()` is used for proposals). `extract_committer_and_proposers` now takes an explicit `committer_leaf_index: LeafNodeIndex`. Receive path passes the index from `processed_message.sender()`; own-intent path passes `mls_group.own_leaf_index()`. The path-update + single-proposer fallbacks are gone.

This fixes `ActorCouldNotBeFound` on migrated commits without a path. Migrated `CommitPendingProposals` commits with only `{Add, AppDataUpdate}` proposals don't require a path under RFC 9420 §17.4 (unlike the unmigrated path where the always-emitted GCE proposal forced one), so they were hitting that error.

**2. Replace the `allow_if_super_admin` migrated-policy stub with a real registry-derived `PolicySet`.** Two stub sites had `MembershipPolicies::allow_if_actor_super_admin()` hardcoded for both add and remove member policies. New helper `app_data::policy::membership_policy_set_from_registry` (new file `crates/xmtp_mls/src/groups/app_data/policy.rs`) translates the registry's `GROUP_MEMBERSHIP` insert/delete `MetadataBasePolicy` (Allow / Deny / AllowIfAdmin / AllowIfSuperAdmin) into `MembershipPolicies` for the add/remove slots, with `tracing::warn!` breadcrumbs on every deny-all fallback path. Other slots stay on the conservative super-admin stub because `validate_app_data_update_proposals_in_commit` is the authoritative gate for non-membership components.

The two fixes are interlocked: relaxing the policy stub alone makes admin-only group tests fall over (peer proposals accepted on receive); fixing committer identification alone leaves the migrated path rejecting non-super-admin proposers in default-permission groups.

## Test plan
- [x] `just test crate xmtp_mls` — 539/539 pass (1 flaky, 5 platform-skipped)
- [x] `cargo clippy -p xmtp_mls --all-targets --no-deps -- -Dwarnings` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
