### PR TITLE
gitignore: ignore .claude/scheduled_tasks.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,3 +200,6 @@ docs/plans
 
 # Firecrawl
 .firecrawl
+
+# Claude Code
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
## Summary

Stops the per-session Claude Code scheduled-tasks lock file from being snapshotted into commits.

The file is a runtime artifact (PID + acquired-at timestamp) created by Claude Code when scheduling self-paced wakeups in a session. It briefly slipped into a previous push of #3613 (since cleaned up); this gitignore entry prevents recurrence across all future sessions in this repo.

## Test plan
- [x] no-op for tracked files; only affects future snapshots

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ignore `.claude/scheduled_tasks.lock` in git
> Adds `.claude/scheduled_tasks.lock` to [.gitignore](https://github.com/xmtp/libxmtp/pull/3614/files#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947) to prevent Claude Code's lock file from being tracked.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2fec582.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->