### PR TITLE
use same verbosity filter in xdbg file logs as stdout logs. remove noisy trace logline.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14008,6 +14008,7 @@ dependencies = [
  "vergen-gix",
  "xmtp_api_d14n",
  "xmtp_api_grpc",
+ "xmtp_common",
  "xmtp_configuration",
  "xmtp_cryptography",
  "xmtp_db",

--- a/apps/xmtp_debug/Cargo.toml
+++ b/apps/xmtp_debug/Cargo.toml
@@ -63,6 +63,7 @@ url.workspace = true
 valuable = { version = "0.1", features = ["derive"] }
 xmtp_api_d14n.workspace = true
 xmtp_api_grpc.workspace = true
+xmtp_common = { workspace = true, features = ["logging"] }
 xmtp_configuration.workspace = true
 xmtp_cryptography = { workspace = true, features = ["exposed-keys"] }
 xmtp_db.workspace = true

--- a/apps/xmtp_debug/src/logger.rs
+++ b/apps/xmtp_debug/src/logger.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use clap_verbosity_flag::{InfoLevel, Verbosity};
 use color_eyre::eyre;
 use owo_colors::OwoColorize;
-use tracing::{Dispatch, Level};
+use tracing::Dispatch;
 use tracing::{Event, Subscriber};
 use tracing_subscriber::fmt::MakeWriter;
 use tracing_subscriber::{EnvFilter, prelude::*};
@@ -14,6 +14,7 @@ use tracing_subscriber::{
     fmt::{FmtContext, FormatEvent, FormatFields, format, format::Writer},
     registry::LookupSpan,
 };
+use xmtp_mls::common::filter_directive;
 
 use crate::args::{LogFormat, LogOptions};
 
@@ -54,7 +55,7 @@ impl Logger {
             ref mut guards,
         } = *self;
 
-        let verbosity = verbosity.tracing_level().unwrap_or(Level::INFO);
+        let verbosity = verbosity.tracing_level_filter();
 
         // prefer `RUST_LOG` variable if set
         // otherwise passed-in level filter
@@ -65,11 +66,7 @@ impl Logger {
                     .expect("filter is static")
             })
         };
-        let file_filter = || {
-            EnvFilter::builder().parse(
-                "xmtp_api_d14n=DEBUG,xmtp_api=DEBUG,xmtp_mls=DEBUG,xmtp_id=DEBUG,xmtp_cryptography=DEBUG,xmtp_api_grpc=DEBUG,xdbg=ERROR",
-            ).expect("filter is static")
-        };
+        let file_filter = || filter_directive(&verbosity.to_string());
         let subscriber = tracing_subscriber::registry();
         let now = chrono::Local::now();
         let log_file_name = PathBuf::from(format!("./{}-xdbg", now));

--- a/crates/xmtp_common/src/logging.rs
+++ b/crates/xmtp_common/src/logging.rs
@@ -7,7 +7,7 @@ pub fn filter_directive(level: &str) -> EnvFilter {
         xmtp_common={level},xmtp_api_d14n={level},\
         xmtp_content_types={level},xmtp_cryptography={level},\
         xmtp_user_preferences={level},xmtpv3={level},xmtp_db={level},\
-        bindings_wasm={level},bindings_node={level}"
+        bindings_wasm={level},bindings_node={level},xdbg=error"
     );
     EnvFilter::builder().parse_lossy(filter)
 }

--- a/crates/xmtp_db/src/encrypted_store/database/native.rs
+++ b/crates/xmtp_db/src/encrypted_store/database/native.rs
@@ -494,11 +494,6 @@ impl ConnectionExt for NativeDbConnection {
         Self: Sized,
     {
         if let Some(pool) = &*self.pool.load() {
-            tracing::trace!(
-                "pulling connection from pool, idle={}, total={}",
-                pool.state().idle_connections,
-                pool.state().connections
-            );
             let mut conn = pool.get()?;
             fun(&mut conn).map_err(ConnectionError::from)
         } else {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Apply verbosity filter to xdbg file logs and remove noisy trace log in `ConnectionExt.raw_query`
- The `xdbg` file log layer now uses `filter_directive` from `xmtp_common` instead of a hardcoded per-crate `EnvFilter`, so file logs respect the same verbosity level as stdout logs.
- `filter_directive` is extended to always set `xdbg=error` regardless of the verbosity passed, preventing debug noise from the `xdbg` binary itself.
- Removes a `trace`-level log in [`native.rs`](https://github.com/xmtp/libxmtp/pull/3615/files#diff-bc7a9f6a2afbeb2139c48ac8059045ef48990cdd08d2e61cf64b946c3100fb54) that reported pool idle/total connection counts on every `raw_query` call.
- Behavioral Change: file log output from `xdbg` will now filter differently — previously hardcoded crate-level rules are replaced by the centralized directive, and `xdbg`-target logs are capped at `error`.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 31814ba.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->