### PR TITLE
ci(fh-cache): push to cachix before pinning aarch64 validation image

### DIFF
--- a/.github/workflows/fh-cache.yml
+++ b/.github/workflows/fh-cache.yml
@@ -57,6 +57,13 @@ jobs:
         run: nix build .#validation-service-image-aarch64-unknown-linux-musl
       - name: Pin to cachix
         if: github.ref_name == 'main'
-        run: cachix pin xmtp validation-service-image-aarch64 ./result
+        # Push synchronously before pinning. The cachix-action watch-store
+        # daemon uploads paths in the background, so a bare `cachix pin`
+        # races against it and fails with HTTP 400 when the path has not
+        # yet been pushed. `cachix push` is idempotent — a no-op if the
+        # path is already in the cache — so it is safe to always run.
+        run: |
+          cachix push xmtp ./result
+          cachix pin xmtp validation-service-image-aarch64 ./result
         env:
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3601

## Problem

The `validation-image-aarch64` job in `.github/workflows/fh-cache.yml` builds the validation service image and then immediately calls `cachix pin xmtp validation-service-image-aarch64 ./result`. Uploads to the `xmtp` cachix cache are handled asynchronously by the `cachix watch-store` daemon that `cachix/cachix-action@v17` starts in the background, so `cachix pin` can race the daemon and fail with HTTP 400 when the freshly-built store path has not yet been pushed:

```
cachix: FailureResponse
  Request POST https://cachix.org/api/v1/cache/xmtp/pin
  Response: Status 400 Bad Request
  Body: {"error": "/nix/store/.../mls-validation-service.tar.gz not in binary cache xmtp.
                  Run `cachix push xmtp /nix/store/.../mls-validation-service.tar.gz`"}
```

## Fix

Run an explicit `cachix push xmtp ./result` immediately before the pin command. `cachix push` is idempotent — a no-op when the path is already in the cache — so it is safe regardless of whether the watch-store daemon got there first.

The `if: github.ref_name == 'main'` gate is preserved; only the `run:` block is modified.

## Scope

- Touches only the `validation-image-aarch64` job. The sibling `build` job (x64 + macOS arm64) uses an omnix-driven pin loop and was reported successful in the failing run; left unchanged.
- The non-fatal KVM warning from the failing run is out of scope.

## Test Plan

- [ ] Re-run `Cache all Nix Outputs` workflow on `main` and confirm the `validation-image-aarch64` job's `Pin to cachix` step succeeds.
- [ ] Confirm `cachix push xmtp ./result` is a no-op (or near no-op) when watch-store has already uploaded the path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Push aarch64 validation image to cachix before pinning
> In [fh-cache.yml](https://github.com/xmtp/libxmtp/pull/3616/files#diff-ce3dd25bde306abc234d96f51a92cb524edcabd8e9e5eeed5eb121f73b32b9e2), the "Pin to cachix" step now runs `cachix push xmtp ./result` before `cachix pin xmtp validation-service-image-aarch64 ./result`. This ensures the artifact is present in the cache before the pin is created.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1118bf9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->