### PR TITLE
xdbg: backport --fail-fast flag from main (#3611)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -4,9 +4,13 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
     fenix = {
       url = "github:nix-community/fenix";
-      inputs = { nixpkgs.follows = "nixpkgs"; };
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+      };
     };
-    flake-parts = { url = "github:hercules-ci/flake-parts"; };
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+    };
     foundry.url = "github:shazow/foundry.nix/stable";
     crane = {
       url = "github:ipetkov/crane";
@@ -23,12 +27,13 @@
   };
 
   outputs =
-    inputs @ { self
-    , flake-parts
-    , fenix
-    , crane
-    , foundry
-    , ...
+    inputs@{
+      self,
+      flake-parts,
+      fenix,
+      crane,
+      foundry,
+      ...
     }:
     flake-parts.lib.mkFlake { inherit inputs; } {
       systems = [
@@ -40,15 +45,20 @@
         flake-parts.flakeModules.easyOverlay
       ];
       perSystem =
-        { pkgs
-        , system
-        , ...
+        {
+          pkgs,
+          system,
+          ...
         }:
         let
           pkgConfig = {
             inherit system;
             # Rust Overlay
-            overlays = [ fenix.overlays.default foundry.overlay self.overlays.default ];
+            overlays = [
+              fenix.overlays.default
+              foundry.overlay
+              self.overlays.default
+            ];
             config = {
               android_sdk.accept_license = true;
               allowUnfree = true;
@@ -68,8 +78,10 @@
             # the environment bindings_wasm is built in
             wasm = (pkgs.callPackage ./nix/package/wasm.nix { craneLib = crane.mkLib pkgs; }).devShell;
           };
-          packages.wasm-bindings = (pkgs.callPackage ./nix/package/wasm.nix { craneLib = crane.mkLib pkgs; }).bin;
+          packages.wasm-bindings =
+            (pkgs.callPackage ./nix/package/wasm.nix { craneLib = crane.mkLib pkgs; }).bin;
           packages.wasm-bindgen-cli = pkgs.callPackage ./nix/lib/packages/wasm-bindgen-cli.nix { };
+          packages.xdbg = pkgs.callPackage ./nix/package/xdbg.nix { craneLib = crane.mkLib pkgs; };
         };
     };
 }

--- a/nix/lib/filesets.nix
+++ b/nix/lib/filesets.nix
@@ -1,5 +1,6 @@
-{ lib
-, craneLib
+{
+  lib,
+  craneLib,
 }:
 let
   inherit (craneLib.fileset) commonCargoSources;
@@ -29,6 +30,7 @@ let
     ./../../xmtp_proto/src/gen/proto_descriptor.bin
     ./../../bindings_ffi/Makefile
     ./../../webdriver.json
+    ../../.cargo/config.toml
   ];
   binaries = lib.fileset.unions [
     (commonCargoSources ./../../examples/cli)
@@ -39,15 +41,22 @@ let
     (commonCargoSources ./../../bindings_ffi)
     (commonCargoSources ./../../xmtp_debug)
   ];
-  forCrate = crate: lib.fileset.unions [
-    workspace
-    crate
-  ];
+  forCrate =
+    crate:
+    lib.fileset.unions [
+      workspace
+      crate
+    ];
   workspace = lib.fileset.unions [
     binaries
     libraries
   ];
 in
 {
-  inherit libraries binaries forCrate workspace;
+  inherit
+    libraries
+    binaries
+    forCrate
+    workspace
+    ;
 }

--- a/nix/package/wasm.nix
+++ b/nix/package/wasm.nix
@@ -1,19 +1,20 @@
-{ emscripten
-, stdenv
-, lib
-, fenix
-, wasm-pack
-, binaryen
-, zstd
-, craneLib
-, mkShell
-, sqlite
-, llvmPackages
-, wasm-bindgen-cli
-, xmtp
-, geckodriver
-, firefox
-, corepack
+{
+  emscripten,
+  stdenv,
+  lib,
+  fenix,
+  wasm-pack,
+  binaryen,
+  zstd,
+  craneLib,
+  mkShell,
+  sqlite,
+  llvmPackages,
+  wasm-bindgen-cli,
+  xmtp,
+  geckodriver,
+  firefox,
+  corepack,
 }:
 let
   # Pinned Rust Version
@@ -43,45 +44,74 @@ let
       # export EMCC_DEBUG=2
     '';
 
-    nativeBuildInputs = [ wasm-pack emscripten llvmPackages.lld binaryen wasm-bindgen-cli ];
-    buildInputs = [ zstd sqlite ];
+    nativeBuildInputs = [
+      wasm-pack
+      emscripten
+      llvmPackages.lld
+      binaryen
+      wasm-bindgen-cli
+    ];
+    buildInputs = [
+      zstd
+      sqlite
+    ];
     doCheck = false;
     cargoExtraArgs = "--workspace --exclude xmtpv3 --exclude bindings_node --exclude xmtp_cli --exclude xdbg --exclude mls_validation_service --exclude xmtp_api_grpc --exclude benches";
     CARGO_BUILD_TARGET = "wasm32-unknown-unknown";
-    hardeningDisable = [ "zerocallusedregs" "stackprotector" ];
+    hardeningDisable = [
+      "zerocallusedregs"
+      "stackprotector"
+    ];
     NIX_DEBUG = 1;
     # SQLITE_WASM_RS_UPDATE_PREBUILD = 1;
-  } // lib.optionalAttrs stdenv.isDarwin {
+  }
+  // lib.optionalAttrs stdenv.isDarwin {
     CC_wasm32_unknown_unknown = "${llvmPackages.libcxxClang}/bin/clang";
     AR_wasm32_unknown_unknown = "${llvmPackages.bintools-unwrapped}/bin/llvm-ar";
   };
 
   # enables caching all build time crates
-  cargoArtifacts = rust.buildDepsOnly (commonArgs // {
-    doCheck = false;
-  });
+  cargoArtifacts = rust.buildDepsOnly (
+    commonArgs
+    // {
+      doCheck = false;
+    }
+  );
 
-  bin = rust.buildPackage
-    (commonArgs // {
+  bin = rust.buildPackage (
+    commonArgs
+    // {
       inherit cargoArtifacts;
       src = workspaceFileset;
-      inherit (rust.crateNameFromCargoToml {
-        cargoToml = ./../../bindings_wasm/Cargo.toml;
-      }) pname;
-      inherit (rust.crateNameFromCargoToml {
-        cargoToml = ./../../Cargo.toml;
-      }) version;
+      inherit
+        (rust.crateNameFromCargoToml {
+          cargoToml = ./../../bindings_wasm/Cargo.toml;
+        })
+        pname
+        ;
+      inherit
+        (rust.crateNameFromCargoToml {
+          cargoToml = ./../../Cargo.toml;
+        })
+        version
+        ;
       buildPhaseCargoCommand = ''
         mkdir -p $out/dist
         cargoBuildLog=$(mktemp cargoBuildLogXXXX.json)
 
         HOME=$(mktemp -d fake-homeXXXX) wasm-pack --verbose build --target web --out-dir $out/dist --no-pack --release ./bindings_wasm -- --message-format json-render-diagnostics > "$cargoBuildLog"
       '';
-    });
-  devShell = mkShell
-    {
+    }
+  );
+  devShell =
+    mkShell {
       inherit (commonArgs) nativeBuildInputs;
-      buildInputs = commonArgs.buildInputs ++ [ rust-toolchain firefox geckodriver corepack ];
+      buildInputs = commonArgs.buildInputs ++ [
+        rust-toolchain
+        firefox
+        geckodriver
+        corepack
+      ];
       CC_wasm32_unknown_unknown = "${llvmPackages.clang-unwrapped}/bin/clang";
       AR_wasm32_unknown_unknown = "${llvmPackages.bintools-unwrapped}/bin/llvm-ar";
       SQLITE = "${sqlite.dev}";
@@ -94,12 +124,9 @@ let
       RSTEST_TIMEOUT = 90;
       CARGO_PROFILE_TEST_DEBUG = 0;
       WASM_BINDGEN_TEST_WEBDRIVER_JSON = ./../../webdriver.json;
-    } // commonArgs;
+    }
+    // commonArgs;
 in
 {
   inherit bin devShell;
 }
-
-
-
-

--- a/nix/package/xdbg.nix
+++ b/nix/package/xdbg.nix
@@ -1,0 +1,53 @@
+{
+  fenix,
+  lib,
+  zstd,
+  sqlite,
+  perl,
+  craneLib,
+  xmtp,
+  openssl,
+  pkg-config,
+}:
+let
+
+  # Pinned Rust Version
+  rust-toolchain = fenix.combine [
+    fenix.stable.cargo
+    fenix.stable.rustc
+  ];
+  rust = craneLib.overrideToolchain (p: rust-toolchain);
+
+  workspaceFileset = lib.fileset.toSource {
+    root = ./../..;
+    fileset = (xmtp.filesets { inherit lib craneLib; }).workspace;
+  };
+  commonArgs = {
+    src = rust.cleanCargoSource ./../..;
+    strictDeps = true;
+    nativeBuildInputs = [
+      pkg-config
+      perl
+    ];
+
+    buildInputs = [
+      zstd
+      sqlite
+      openssl
+    ];
+    doCheck = false;
+  };
+
+  cargoArtifacts = rust.buildDepsOnly commonArgs;
+
+in
+rust.buildPackage (
+  commonArgs
+  // {
+    inherit cargoArtifacts;
+    src = workspaceFileset;
+    pname = "xmtp-debug";
+    version = "1.9.2";
+    cargoExtraArgs = "-p xdbg";
+  }
+)

--- a/xmtp_debug/src/app.rs
+++ b/xmtp_debug/src/app.rs
@@ -87,8 +87,12 @@ impl App {
         Ok(Arc::new(redb::Database::create(Self::redb()?)?))
     }
 
-    /// All data stored here
+    /// All data stored here.
+    /// Respects `XDBG_DB_ROOT` env var for overriding the default data directory.
     fn data_directory() -> Result<PathBuf> {
+        if let Ok(root) = std::env::var("XDBG_DB_ROOT") {
+            return Ok(PathBuf::from(root));
+        }
         let data = if let Some(dir) = ProjectDirs::from("org", "xmtp", "xdbg") {
             Ok::<_, eyre::Report>(dir.data_dir().to_path_buf())
         } else {

--- a/xmtp_debug/src/app/generate/messages.rs
+++ b/xmtp_debug/src/app/generate/messages.rs
@@ -251,6 +251,15 @@ impl GenerateMessages {
 
         if !errors.is_empty() {
             info!(errors = ?errors, "errors");
+            if crate::fail_fast() {
+                let first = errors[0].to_string();
+                return Err(eyre!(
+                    "{} of {} send_message tasks failed (--fail-fast): {}",
+                    errors.len(),
+                    res.len(),
+                    first
+                ));
+            }
         }
 
         let msgs_sent = res

--- a/xmtp_debug/src/app/stream.rs
+++ b/xmtp_debug/src/app/stream.rs
@@ -62,11 +62,20 @@ impl Stream {
             Box::new(BufWriter::new(std::io::stdout()))
         };
 
+        let fail_fast = crate::fail_fast();
         match kind {
             args::StreamKind::Conversations => {
                 let s = client.stream_conversations(None, false).await?;
                 tokio::pin!(s);
-                while let Some(Ok(group)) = s.as_mut().next().await {
+                while let Some(item) = s.as_mut().next().await {
+                    let group = match item {
+                        Ok(g) => g,
+                        Err(e) if fail_fast => return Err(e.into()),
+                        Err(e) => {
+                            tracing::warn!(error = %e, "stream_conversations item error");
+                            continue;
+                        }
+                    };
                     let stored: StoredGroup = group.load()?;
                     let item = Conversation {
                         group_id: hex::encode(&stored.id),
@@ -88,7 +97,15 @@ impl Stream {
             args::StreamKind::Messages => {
                 let s = client.stream_all_messages(None, None).await?;
                 tokio::pin!(s);
-                while let Some(Ok(message)) = s.as_mut().next().await {
+                while let Some(next) = s.as_mut().next().await {
+                    let message = match next {
+                        Ok(m) => m,
+                        Err(e) if fail_fast => return Err(e.into()),
+                        Err(e) => {
+                            tracing::warn!(error = %e, "stream_all_messages item error");
+                            continue;
+                        }
+                    };
                     let item = Message {
                         contents: String::from_utf8_lossy(&message.decrypted_message_bytes)
                             .to_string(),

--- a/xmtp_debug/src/args.rs
+++ b/xmtp_debug/src/args.rs
@@ -31,6 +31,11 @@ pub struct AppOpts {
     /// Runs at the end of execution, so operations will still be carried out
     #[arg(long)]
     pub clear: bool,
+    /// Exit non-zero on the first per-operation error instead of logging
+    /// and continuing. Useful in `git bisect run` sessions where a single
+    /// failed send/sync should mark the commit bad.
+    #[arg(long)]
+    pub fail_fast: bool,
 }
 
 #[derive(Subcommand, Debug)]
@@ -542,5 +547,27 @@ mod tests {
             "http://localhost:5052",
         ]);
         assert!(opts.is_err());
+    }
+
+    #[test]
+    fn fail_fast_defaults_false() {
+        let opts = AppOpts::try_parse_from(["xdbg"]).expect("parses with no args");
+        assert!(!opts.fail_fast, "--fail-fast should default to false");
+    }
+
+    #[test]
+    fn fail_fast_parses_when_present() {
+        let opts =
+            AppOpts::try_parse_from(["xdbg", "--fail-fast"]).expect("parses with --fail-fast");
+        assert!(opts.fail_fast);
+    }
+
+    #[test]
+    fn fail_fast_has_no_short_alias() {
+        // Asserts that we don't allocate `-f` (or any short) for this flag,
+        // so future subcommands remain free to use short flags. `xdbg -f`
+        // should fail to parse.
+        let opts = AppOpts::try_parse_from(["xdbg", "-f"]);
+        assert!(opts.is_err(), "--fail-fast should not have a short alias");
     }
 }

--- a/xmtp_debug/src/main.rs
+++ b/xmtp_debug/src/main.rs
@@ -6,8 +6,16 @@ mod logger;
 use clap::Parser;
 use color_eyre::eyre::Result;
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use xmtp_mls::context::XmtpMlsLocalContext;
+
+static FAIL_FAST: OnceLock<bool> = OnceLock::new();
+
+/// Whether `--fail-fast` was passed at the CLI. Returns `false` when
+/// uninitialized (unit tests, early init paths).
+pub fn fail_fast() -> bool {
+    FAIL_FAST.get().copied().unwrap_or(false)
+}
 
 pub type MlsContext =
     Arc<XmtpMlsLocalContext<DbgClientApi, xmtp_db::DefaultStore, xmtp_db::DefaultMlsStore>>;
@@ -26,6 +34,7 @@ async fn main() -> Result<()> {
     let opts = args::AppOpts::parse();
     let mut logger = logger::Logger::from(&opts.log);
     logger.init()?;
+    let _ = FAIL_FAST.set(opts.fail_fast);
 
     if opts.version {
         info!("Version: {0}", get_version());


### PR DESCRIPTION
add xdbg nix package

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--fail-fast` flag to `xdbg` CLI to abort on errors during message generation and streaming
> - Adds a `--fail-fast` boolean CLI flag to [`xmtp_debug/src/args.rs`](https://github.com/xmtp/libxmtp/pull/3617/files#diff-f5a20f8b0880b662184dc94120d482df9acbc8ceffc02f7e81c0d6a491d69ec3), stored in a process-wide `OnceLock<bool>` in [`main.rs`](https://github.com/xmtp/libxmtp/pull/3617/files#diff-4b025fbb788c796477fdf2a6499714f48a7fec90342d8181535fc64247da6044) and accessible via `crate::fail_fast()`.
> - When set, message generation in [`generate/messages.rs`](https://github.com/xmtp/libxmtp/pull/3617/files#diff-eeaf742c78c261e05257950d12daa2ec07c1dfe459a732f2ee1484f184da9371) returns an error summarizing failure count if any send task fails, instead of logging and continuing.
> - When set, streaming loops in [`stream.rs`](https://github.com/xmtp/libxmtp/pull/3617/files#diff-4364d4356d16445e66708480d14d208a8e2a87c401f4faa2080fc85b8620ce9f) return early on per-item errors instead of logging a warning and continuing.
> - Also adds a `packages.xdbg` Nix derivation in [`nix/package/xdbg.nix`](https://github.com/xmtp/libxmtp/pull/3617/files#diff-62794fac2b8f9cba45a5e9f4d1e3576fc350097165b26f2e8dfc06b59e053481) and exposes it via [`flake.nix`](https://github.com/xmtp/libxmtp/pull/3617/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0).
> - Adds `XDBG_DB_ROOT` environment variable support in [`app.rs`](https://github.com/xmtp/libxmtp/pull/3617/files#diff-5271efe9f61f1d96b0145caa92d489e6553e2a26818be003b9d68cd745aa5914) to override the default data directory.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 55d71bd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->