### PR TITLE
xdbg: backport --fail-fast flag from main (#3611)

### DIFF
--- a/apps/xmtp_debug/src/app.rs
+++ b/apps/xmtp_debug/src/app.rs
@@ -87,8 +87,12 @@ impl App {
         Ok(Arc::new(redb::Database::create(Self::redb()?)?))
     }
 
-    /// All data stored here
+    /// All data stored here.
+    /// Respects `XDBG_DB_ROOT` env var for overriding the default data directory.
     fn data_directory() -> Result<PathBuf> {
+        if let Ok(root) = std::env::var("XDBG_DB_ROOT") {
+            return Ok(PathBuf::from(root));
+        }
         let data = if let Some(dir) = ProjectDirs::from("org", "xmtp", "xdbg") {
             Ok::<_, eyre::Report>(dir.data_dir().to_path_buf())
         } else {

--- a/apps/xmtp_debug/src/app/generate/messages.rs
+++ b/apps/xmtp_debug/src/app/generate/messages.rs
@@ -264,6 +264,15 @@ impl GenerateMessages {
 
         if !errors.is_empty() {
             info!(errors = ?errors, "errors");
+            if crate::fail_fast() {
+                let first = errors[0].to_string();
+                return Err(eyre!(
+                    "{} of {} send_message tasks failed (--fail-fast): {}",
+                    errors.len(),
+                    res.len(),
+                    first
+                ));
+            }
         }
 
         let msgs_sent = res

--- a/apps/xmtp_debug/src/app/stream.rs
+++ b/apps/xmtp_debug/src/app/stream.rs
@@ -62,11 +62,20 @@ impl Stream {
             Box::new(BufWriter::new(std::io::stdout()))
         };
 
+        let fail_fast = crate::fail_fast();
         match kind {
             args::StreamKind::Conversations => {
                 let s = client.stream_conversations(None, false).await?;
                 tokio::pin!(s);
-                while let Some(Ok(group)) = s.as_mut().next().await {
+                while let Some(item) = s.as_mut().next().await {
+                    let group = match item {
+                        Ok(g) => g,
+                        Err(e) if fail_fast => return Err(e.into()),
+                        Err(e) => {
+                            tracing::warn!(error = %e, "stream_conversations item error");
+                            continue;
+                        }
+                    };
                     let stored: StoredGroup = group.load()?;
                     let item = Conversation {
                         group_id: hex::encode(&stored.id),
@@ -88,7 +97,15 @@ impl Stream {
             args::StreamKind::Messages => {
                 let s = client.stream_all_messages(None, None).await?;
                 tokio::pin!(s);
-                while let Some(Ok(message)) = s.as_mut().next().await {
+                while let Some(next) = s.as_mut().next().await {
+                    let message = match next {
+                        Ok(m) => m,
+                        Err(e) if fail_fast => return Err(e.into()),
+                        Err(e) => {
+                            tracing::warn!(error = %e, "stream_all_messages item error");
+                            continue;
+                        }
+                    };
                     let item = Message {
                         contents: String::from_utf8_lossy(&message.decrypted_message_bytes)
                             .to_string(),

--- a/apps/xmtp_debug/src/args.rs
+++ b/apps/xmtp_debug/src/args.rs
@@ -31,6 +31,11 @@ pub struct AppOpts {
     /// Runs at the end of execution, so operations will still be carried out
     #[arg(long)]
     pub clear: bool,
+    /// Exit non-zero on the first per-operation error instead of logging
+    /// and continuing. Useful in `git bisect run` sessions where a single
+    /// failed send/sync should mark the commit bad.
+    #[arg(long)]
+    pub fail_fast: bool,
 }
 
 #[derive(Subcommand, Debug)]
@@ -542,5 +547,27 @@ mod tests {
             "http://localhost:5052",
         ]);
         assert!(opts.is_err());
+    }
+
+    #[test]
+    fn fail_fast_defaults_false() {
+        let opts = AppOpts::try_parse_from(["xdbg"]).expect("parses with no args");
+        assert!(!opts.fail_fast, "--fail-fast should default to false");
+    }
+
+    #[test]
+    fn fail_fast_parses_when_present() {
+        let opts =
+            AppOpts::try_parse_from(["xdbg", "--fail-fast"]).expect("parses with --fail-fast");
+        assert!(opts.fail_fast);
+    }
+
+    #[test]
+    fn fail_fast_has_no_short_alias() {
+        // Asserts that we don't allocate `-f` (or any short) for this flag,
+        // so future subcommands remain free to use short flags. `xdbg -f`
+        // should fail to parse.
+        let opts = AppOpts::try_parse_from(["xdbg", "-f"]);
+        assert!(opts.is_err(), "--fail-fast should not have a short alias");
     }
 }

--- a/apps/xmtp_debug/src/main.rs
+++ b/apps/xmtp_debug/src/main.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 mod app;
 mod args;
 mod constants;
@@ -6,8 +8,16 @@ mod logger;
 use clap::Parser;
 use color_eyre::eyre::Result;
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use xmtp_mls::context::XmtpMlsLocalContext;
+
+static FAIL_FAST: OnceLock<bool> = OnceLock::new();
+
+/// Whether `--fail-fast` was passed at the CLI. Returns `false` when
+/// uninitialized (unit tests, early init paths).
+pub fn fail_fast() -> bool {
+    FAIL_FAST.get().copied().unwrap_or(false)
+}
 
 pub type MlsContext =
     Arc<XmtpMlsLocalContext<DbgClientApi, xmtp_db::DefaultStore, xmtp_db::DefaultMlsStore>>;
@@ -26,6 +36,7 @@ async fn main() -> Result<()> {
     let opts = args::AppOpts::parse();
     let mut logger = logger::Logger::from(&opts.log);
     logger.init()?;
+    let _ = FAIL_FAST.set(opts.fail_fast);
 
     if opts.version {
         info!("Version: {0}", get_version());


### PR DESCRIPTION
backport XDBG_DB_ROOT
backport `--fail-fast` flag

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--fail-fast` flag to `xdbg` CLI
> - Adds a `--fail-fast` boolean CLI flag to [args.rs](https://github.com/xmtp/libxmtp/pull/3618/files#diff-625330612e40d918eef6d9785cc1b9adbc3c444cc2666c0d632bb216d3b2b4f5), defaulting to false, with three new tests covering default, parse, and no-short-alias behavior.
> - Stores the flag in a process-global `FAIL_FAST` `OnceLock<bool>` in [main.rs](https://github.com/xmtp/libxmtp/pull/3618/files#diff-1402fc2e065b4dfc49f0c88fdd0afcbab0b1ea61526ee56858b46f0f95be79e1), accessible via a public `fail_fast()` helper.
> - In [generate/messages.rs](https://github.com/xmtp/libxmtp/pull/3618/files#diff-d5e22c19c0b27072221b181e135255d8128ad8549e99b914051ef1f323d445f2), returns an error after send_message task failures when `fail_fast()` is true, instead of only logging.
> - In [stream.rs](https://github.com/xmtp/libxmtp/pull/3618/files#diff-39788c1509dea6be3b4a43787cfbcfdbc173dd058ff1da76c0661fca15788518), terminates the stream loop on the first item-level error when `fail_fast()` is true, instead of logging and continuing.
> - Also adds `XDBG_DB_ROOT` env var support to override the data directory in [app.rs](https://github.com/xmtp/libxmtp/pull/3618/files#diff-8ed842a5afecb3f8ea515786fdf84084c33c130af7bc5cef780c6d1b08e42800).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4b67d14.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->