### PR TITLE
introduce cross-version CI

### DIFF
--- a/.github/workflows/cross-version-test.yml
+++ b/.github/workflows/cross-version-test.yml
@@ -66,7 +66,7 @@ concurrency:
 jobs:
   compat:
     name: ${{ matrix.profile }}
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-16x
     strategy:
       # Both profiles always run; one is independently meaningful even if
       # the other fails (e.g. nightly breakage doesn't mask stable signal).
@@ -81,13 +81,46 @@ jobs:
             sample-size: ""
             lenient: "--lenient-nightlies"
     steps:
+      # Shallow clone of just the PR ref, with NO tags. The repo carries
+      # ~1500 tags (per-commit cli/binding tags) that otherwise dominate
+      # checkout time (~75s). We only need:
+      #   - release/* branches (fetched in the next step)
+      #   - *-nightly.* tags (fetched in the step after that)
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
+          fetch-tags: false
 
-      - name: Fetch release branches explicitly
+      - name: Fetch release branches + nightly tags
         run: |
-          git fetch origin '+refs/heads/release/*:refs/remotes/origin/release/*' --no-tags
+          set -euo pipefail
+          # Stable branches for last_two_stable_branches() resolution.
+          git fetch origin \
+            '+refs/heads/release/*:refs/remotes/origin/release/*' \
+            --no-tags --depth=1
+
+          # Nightly tags only (skip ~1500 cli/kotlin/swift/ios per-commit
+          # tags that dominate fetch time). `git fetch` refspecs reject
+          # mid-pattern globs, so list remote tags first, filter to the
+          # nightly-binding patterns the script's regex actually matches,
+          # then fetch by exact name.
+          mapfile -t nightly_tags < <(
+            git ls-remote --tags --refs origin \
+              | awk '{print $2}' \
+              | sed 's|^refs/tags/||' \
+              | grep -E '^(node-bindings|wasm-bindings|android|ios)-.*-nightly\.[0-9]{8}\.[0-9a-f]{7}$'
+          )
+          if [ "${#nightly_tags[@]}" -eq 0 ]; then
+            echo "::warning::no nightly tags matched; nightly sampling will be empty"
+          else
+            echo "Fetching ${#nightly_tags[@]} nightly tags"
+            # Build refspec list: refs/tags/<name>:refs/tags/<name>
+            refspecs=()
+            for t in "${nightly_tags[@]}"; do
+              refspecs+=("refs/tags/${t}:refs/tags/${t}")
+            done
+            git fetch origin --no-tags --depth=1 "${refspecs[@]}"
+          fi
 
       - uses: ./.github/actions/setup-nix
         with:
@@ -142,13 +175,37 @@ jobs:
           # shellcheck disable=SC2086  # LENIENT is either empty or a single flag
           nix run .#cross-version-test -- run-sequence $LENIENT plan.json
 
+      # xdbg's NDJSON log files are named "YYYY-MM-DD HH:MM:SS.json".
+      # actions/upload-artifact rejects filenames with `:`, `<`, `>`, etc.
+      # Rename to ISO-safe form before upload so the archive succeeds.
+      - name: Sanitize log filenames
+        # Belt-and-suspenders: require out_dir to be set AND look like one
+        # of our temp dirs so a bug elsewhere can't expand the glob into
+        # an absolute root path (`/**/*.json`).
+        if: always() && steps.run.outputs.out_dir != '' && contains(steps.run.outputs.out_dir, 'xvt-out')
+        env:
+          OUT_DIR: ${{ steps.run.outputs.out_dir }}
+        run: |
+          set -euo pipefail
+          find "$OUT_DIR" -type f -name '*.json' | while IFS= read -r f; do
+            base=$(basename "$f")
+            sanitized=${base//:/-}
+            sanitized=${sanitized// /T}
+            if [ "$base" != "$sanitized" ]; then
+              mv -- "$f" "$(dirname "$f")/$sanitized"
+            fi
+          done
+
       # Only upload if `Run sequence` actually executed and produced an
       # out_dir. Without this guard, a cancelled or skipped run leaves
       # steps.run.outputs.out_dir empty and the glob expands to absolute
       # `/**/*.json` — which then tries to scan the entire filesystem and
       # fails with permission errors on /boot/efi etc.
       - name: Upload plan + summary
-        if: always() && steps.run.outputs.out_dir != ''
+        # Belt-and-suspenders: require out_dir to be set AND look like one
+        # of our temp dirs so a bug elsewhere can't expand the glob into
+        # an absolute root path (`/**/*.json`).
+        if: always() && steps.run.outputs.out_dir != '' && contains(steps.run.outputs.out_dir, 'xvt-out')
         uses: actions/upload-artifact@v7
         with:
           name: cross-version-test-${{ matrix.profile }}-summary-${{ github.run_id }}
@@ -159,7 +216,10 @@ jobs:
           retention-days: 30
 
       - name: Upload libxmtp NDJSON logs
-        if: always() && steps.run.outputs.out_dir != ''
+        # Belt-and-suspenders: require out_dir to be set AND look like one
+        # of our temp dirs so a bug elsewhere can't expand the glob into
+        # an absolute root path (`/**/*.json`).
+        if: always() && steps.run.outputs.out_dir != '' && contains(steps.run.outputs.out_dir, 'xvt-out')
         uses: actions/upload-artifact@v7
         with:
           name: cross-version-test-${{ matrix.profile }}-libxmtp-logs-${{ github.run_id }}

--- a/.github/workflows/cross-version-test.yml
+++ b/.github/workflows/cross-version-test.yml
@@ -1,0 +1,170 @@
+name: cross-version-test
+
+# Sanity-check that xdbg builds across recent versions remain compatible
+# when sharing one xdbg data dir. Two jobs run in parallel for every
+# PR / cron / dispatch:
+#
+#   stable-only — last two stable release branches + HEAD. Strict.
+#                 Catches regressions that affect what we'd ship in a
+#                 release; unaffected by broken nightlies.
+#
+#   with-nightlies — same + N most-recent nightlies. Lenient (a nightly
+#                    runtime failure warns + continues, doesn't fail the
+#                    job). Covers main-branch drift between releases.
+#
+# Two jobs because a single broken nightly otherwise blocks the whole
+# run, including the stable-only signal we actually need for releases.
+#
+# All logic lives in the packaged driver; this workflow only wires
+# triggers + nix invocations. See:
+#   docs/superpowers/specs/2026-05-08-xdbg-cross-version-compat-design.md
+
+on:
+  pull_request:
+    paths:
+      - "apps/xmtp_debug/**"
+      - "crates/xmtp_mls/**"
+      - "crates/xmtp_mls_common/**"
+      - "crates/xmtp_api/**"
+      - "crates/xmtp_db/**"
+      - "crates/xmtp_id/**"
+      - "crates/xmtp_cryptography/**"
+      - "crates/xmtp_proto/**"
+      - "crates/xmtp_api_grpc/**"
+      - "crates/xmtp_api_d14n/**"
+      - "crates/xmtp_configuration/**"
+      - "crates/xmtp_common/**"
+      - "crates/xmtp_content_types/**"
+      - "crates/xmtp_archive/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "flake.nix"
+      - "nix/**"
+      - ".github/workflows/cross-version-test.yml"
+  workflow_dispatch:
+    inputs:
+      nightly-sample-size:
+        description: "Most-recent N nightlies in the with-nightlies job (stable-only ignores this)"
+        required: false
+        default: "3"
+        type: string
+      backend:
+        description: "xdbg backend (-b flag)"
+        required: false
+        default: "dev"
+        type: string
+  schedule:
+    - cron: "0 7 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compat:
+    name: ${{ matrix.profile }}
+    runs-on: ubuntu-latest
+    strategy:
+      # Both profiles always run; one is independently meaningful even if
+      # the other fails (e.g. nightly breakage doesn't mask stable signal).
+      fail-fast: false
+      matrix:
+        include:
+          - profile: stable
+            sample-size: "0"
+            lenient: ""
+          - profile: nightly
+            # sample-size resolved at runtime from inputs.nightly-sample-size
+            sample-size: ""
+            lenient: "--lenient-nightlies"
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Fetch release branches explicitly
+        run: |
+          git fetch origin '+refs/heads/release/*:refs/remotes/origin/release/*' --no-tags
+
+      - uses: ./.github/actions/setup-nix
+        with:
+          github-token: ${{ github.token }}
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          sccache: "false"
+          with-warpbuild-cache: "false"
+
+      - name: Resolve sample size
+        id: sample
+        env:
+          MATRIX_SAMPLE_SIZE: ${{ matrix.sample-size }}
+          INPUT_NIGHTLY_SAMPLE_SIZE: ${{ inputs.nightly-sample-size }}
+        run: |
+          # stable-only profile pins sample-size to 0 via the matrix.
+          # with-nightlies takes the dispatch input, falling back to 3.
+          if [ -n "$MATRIX_SAMPLE_SIZE" ]; then
+            size="$MATRIX_SAMPLE_SIZE"
+          elif [ -n "$INPUT_NIGHTLY_SAMPLE_SIZE" ]; then
+            size="$INPUT_NIGHTLY_SAMPLE_SIZE"
+          else
+            size=3
+          fi
+          echo "size=$size" >> "$GITHUB_OUTPUT"
+
+      - name: Pick versions
+        id: pick
+        env:
+          SAMPLE_SIZE: ${{ steps.sample.outputs.size }}
+          PROFILE: ${{ matrix.profile }}
+        run: |
+          set -euo pipefail
+          nix run .#cross-version-test -- pick-versions \
+            --sample-size "$SAMPLE_SIZE" \
+            > plan.json
+          jq . plan.json
+          {
+            echo "## xdbg cross-version plan ($PROFILE, sample-size: $SAMPLE_SIZE)"
+            echo
+            echo '```json'
+            jq . plan.json
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Run sequence
+        id: run
+        env:
+          BACKEND: ${{ inputs.backend || 'dev' }}
+          LENIENT: ${{ matrix.lenient }}
+        run: |
+          set -euo pipefail
+          # shellcheck disable=SC2086  # LENIENT is either empty or a single flag
+          nix run .#cross-version-test -- run-sequence $LENIENT plan.json
+
+      # Only upload if `Run sequence` actually executed and produced an
+      # out_dir. Without this guard, a cancelled or skipped run leaves
+      # steps.run.outputs.out_dir empty and the glob expands to absolute
+      # `/**/*.json` — which then tries to scan the entire filesystem and
+      # fails with permission errors on /boot/efi etc.
+      - name: Upload plan + summary
+        if: always() && steps.run.outputs.out_dir != ''
+        uses: actions/upload-artifact@v7
+        with:
+          name: cross-version-test-${{ matrix.profile }}-summary-${{ github.run_id }}
+          path: |
+            plan.json
+            ${{ steps.run.outputs.out_dir }}/summary.json
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Upload libxmtp NDJSON logs
+        if: always() && steps.run.outputs.out_dir != ''
+        uses: actions/upload-artifact@v7
+        with:
+          name: cross-version-test-${{ matrix.profile }}-libxmtp-logs-${{ github.run_id }}
+          path: |
+            ${{ steps.run.outputs.out_dir }}/**/*.json
+            !${{ steps.run.outputs.out_dir }}/summary.json
+          if-no-files-found: ignore
+          retention-days: 14

--- a/flake.nix
+++ b/flake.nix
@@ -79,6 +79,7 @@
             inherit (pkgs) napi-rs-cli wasm-bindgen-cli;
             wasm-bindings = (pkgs.callPackage ./nix/package/wasm.nix { }).bin;
             wasm-bindings-test = (pkgs.callPackage ./nix/package/wasm.nix { test = true; }).bin;
+            cross-version-test = pkgs.callPackage ./nix/package/cross-version-test { };
           }
           // lib.optionalAttrs pkgs.stdenv.isDarwin {
             # stdenvNoCC is passed to callPackage (for the aggregate derivation).

--- a/justfile
+++ b/justfile
@@ -99,6 +99,34 @@ _test-crate +crates:
   args=""; for c in {{crates}}; do args="$args -p $c"; done; \
   {{cargo_test}} $args
 
+# `just cross-test`, `just cross-test stable`, `just cross-test nightly`, `just cross-test nightly 5`
+[script("bash")]
+cross-test profile="stable" *args="":
+  just _cross-test-{{profile}} {{args}}
+
+# `just cross-test stable` → stable HEADs + repo HEAD only (sample-size 0).
+# Same shape the workflow's stable-only job runs. Strict failure mode.
+[private]
+[script("bash")]
+_cross-test-stable *args="":
+  set -euo pipefail
+  plan=$(mktemp -t xvt-plan-XXXXXX.json)
+  nix run .#cross-version-test -- pick-versions --sample-size 0 {{args}} > "$plan"
+  jq . "$plan"
+  nix run .#cross-version-test -- run-sequence "$plan"
+
+# `just cross-test nightly` (default 3) or `just cross-test nightly 5`.
+# Includes the N most-recent nightlies. Lenient — nightly runtime failures
+# warn + continue instead of failing the run.
+[private]
+[script("bash")]
+_cross-test-nightly n="3" *args="":
+  set -euo pipefail
+  plan=$(mktemp -t xvt-plan-XXXXXX.json)
+  nix run .#cross-version-test -- pick-versions --sample-size {{n}} {{args}} > "$plan"
+  jq . "$plan"
+  nix run .#cross-version-test -- run-sequence --lenient-nightlies "$plan"
+
 # --- BACKEND ---
 
 # `just backend up`, `just backend down`

--- a/justfile
+++ b/justfile
@@ -99,33 +99,60 @@ _test-crate +crates:
   args=""; for c in {{crates}}; do args="$args -p $c"; done; \
   {{cargo_test}} $args
 
-# `just cross-test`, `just cross-test stable`, `just cross-test nightly`, `just cross-test nightly 5`
+# Args forwarded to xdbg (verbosity etc.) via XVT_XDBG_FLAGS:
+#   just cross-test -vvvv                  # stable, -vvvv to xdbg
+#   just cross-test stable -vvvv           # explicit profile
+#   just cross-test nightly 5 -vvvv        # nightly profile, sample 5, -vvvv
+#
+# Run xdbg cross-version compat harness with stable HEADs (default) or nightlies
 [script("bash")]
-cross-test profile="stable" *args="":
-  just _cross-test-{{profile}} {{args}}
+cross-test *args="":
+  set -euo pipefail
+  # First positional arg controls profile selection only when it does NOT
+  # start with `-`. Everything else passes through to xdbg as global flags.
+  args=({{args}})
+  profile="stable"
+  if [ "${#args[@]}" -gt 0 ] && [[ "${args[0]}" != -* ]]; then
+      profile="${args[0]}"
+      args=("${args[@]:1}")
+  fi
+  case "$profile" in
+      stable|nightly) ;;
+      *) echo "cross-test: unknown profile '$profile' (want stable|nightly)" >&2; exit 2 ;;
+  esac
+  just "_cross-test-${profile}" "${args[@]}"
 
 # `just cross-test stable` → stable HEADs + repo HEAD only (sample-size 0).
 # Same shape the workflow's stable-only job runs. Strict failure mode.
+# Any leading non-numeric args pass through to xdbg as global flags via
+# XVT_XDBG_FLAGS (e.g. -vvvv for trace logging).
 [private]
 [script("bash")]
 _cross-test-stable *args="":
   set -euo pipefail
   plan=$(mktemp -t xvt-plan-XXXXXX.json)
-  nix run .#cross-version-test -- pick-versions --sample-size 0 {{args}} > "$plan"
+  nix run .#cross-version-test -- pick-versions --sample-size 0 > "$plan"
   jq . "$plan"
-  nix run .#cross-version-test -- run-sequence "$plan"
+  XVT_XDBG_FLAGS="{{args}}" nix run .#cross-version-test -- run-sequence "$plan"
 
 # `just cross-test nightly` (default 3) or `just cross-test nightly 5`.
 # Includes the N most-recent nightlies. Lenient — nightly runtime failures
-# warn + continue instead of failing the run.
+# warn + continue instead of failing the run. Trailing args (after the
+# optional numeric sample size) pass through to xdbg via XVT_XDBG_FLAGS.
 [private]
 [script("bash")]
-_cross-test-nightly n="3" *args="":
+_cross-test-nightly *args="":
   set -euo pipefail
+  args=({{args}})
+  n=3
+  if [ "${#args[@]}" -gt 0 ] && [[ "${args[0]}" =~ ^[0-9]+$ ]]; then
+      n="${args[0]}"
+      args=("${args[@]:1}")
+  fi
   plan=$(mktemp -t xvt-plan-XXXXXX.json)
-  nix run .#cross-version-test -- pick-versions --sample-size {{n}} {{args}} > "$plan"
+  nix run .#cross-version-test -- pick-versions --sample-size "$n" > "$plan"
   jq . "$plan"
-  nix run .#cross-version-test -- run-sequence --lenient-nightlies "$plan"
+  XVT_XDBG_FLAGS="${args[*]}" nix run .#cross-version-test -- run-sequence --lenient-nightlies "$plan"
 
 # --- BACKEND ---
 

--- a/nix/lib/default.nix
+++ b/nix/lib/default.nix
@@ -166,6 +166,7 @@
           toNapiTarget = import ./napiTarget.nix;
           gitSha = self.shortRev or self.dirtyShortRev or "unknown";
           gitCommitDate = self.lastModifiedDate or "";
+          cross-version-test = pkgs.callPackage ./../package/cross-version-test { };
         };
         wasm-bindgen-cli = pkgs.callPackage ./packages/wasm-bindgen-cli.nix { };
         napi-rs-cli = pkgs.callPackage ./packages/napi-rs-cli { };

--- a/nix/package/cross-version-test/cross-version-test.sh
+++ b/nix/package/cross-version-test/cross-version-test.sh
@@ -1,0 +1,796 @@
+#!/usr/bin/env bash
+# cross-version-test — drive multiple xdbg builds against a shared
+# XVT_DB_ROOT to detect cross-version MLS regressions.
+#
+# Subcommands:
+#   pick-versions [--sample-size N]
+#       Emit plan JSON to stdout.
+#   run-sequence [--lenient-nightlies] <plan.json>
+#       Execute the plan; exits non-zero on first failure. Stable
+#       branches + HEAD are always strict. With --lenient-nightlies a
+#       nightly runtime failure emits ::warning:: and the sequence
+#       continues instead of failing.
+#
+# See docs/superpowers/specs/2026-05-08-xdbg-cross-version-compat-design.md
+# (filename retained for history; spec describes this same tool).
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage:
+  cross-version-test pick-versions [--sample-size N]
+  cross-version-test run-sequence [--lenient-nightlies] <plan.json>
+  cross-version-test --help
+EOF
+}
+
+main() {
+    if [ $# -eq 0 ]; then
+        usage >&2
+        exit 2
+    fi
+
+    case "$1" in
+        --help|-h)
+            usage
+            ;;
+        pick-versions)
+            shift
+            cmd_pick_versions "$@"
+            ;;
+        run-sequence)
+            shift
+            cmd_run_sequence "$@"
+            ;;
+        *)
+            echo "unknown subcommand: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+}
+
+# Print the names of the last two stable release branches (newest first),
+# one per line. Names are emitted as the suffix after 'release/' — e.g.
+# '1.10.0', 'v1.9'.
+#
+# Resolution rules (per spec):
+#   - source: refs/remotes/origin/release/*
+#   - keep names matching ^v?[0-9]+\.[0-9]+(\.[0-9]+)?$
+#   - sort by semver after stripping leading 'v'
+#   - dedup by major.minor (newest in each minor wins)
+last_two_stable_branches() {
+    git for-each-ref --format='%(refname:short)' \
+        'refs/remotes/origin/release/*' \
+        | sed -n 's|^origin/release/||p' \
+        | awk '
+            {
+                name = $0
+                ver = name
+                sub(/^v/, "", ver)
+                if (ver !~ /^[0-9]+\.[0-9]+(\.[0-9]+)?$/) next
+                n = split(ver, parts, ".")
+                major = parts[1]; minor = parts[2]
+                patch = (n >= 3) ? parts[3] : 0
+                printf "%010d.%010d.%010d\t%s\t%s\n", major, minor, patch, major"."minor, name
+            }' \
+        | sort -k1,1 \
+        | awk -F'\t' '
+            # Dedup by major.minor; last-write-wins because input is sorted
+            # ascending — the highest patch per minor overwrites earlier ones.
+            { rows[$2] = $0 }
+            END {
+                for (k in rows) print rows[k]
+            }' \
+        | sort -k1,1 \
+        | tail -n 2 \
+        | awk -F'\t' '{ print $3 }' \
+        | tac
+}
+
+# Print unique nightly-tag (date, sha7) pairs, newest first, in the format
+# "YYYYMMDD<TAB>sha7". Tag scheme:
+#   <binding>-X.Y.Z-nightly.YYYYMMDD.<sha7>
+# Each nightly date produces multiple tags (one per binding family); we
+# dedupe on the (date, sha7) suffix so each calendar day contributes at
+# most one candidate sha.
+nightly_tag_candidates() {
+    git tag --sort=-creatordate \
+        | grep -E -- '-nightly\.[0-9]{8}\.[0-9a-f]{7}$' \
+        | sed -E 's/.*-nightly\.([0-9]{8})\.([0-9a-f]{7})$/\1\t\2/' \
+        | awk -F'\t' '!seen[$1"\t"$2]++'
+}
+
+cmd_pick_versions() {
+    local sample_size=3
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --sample-size)
+                sample_size="${2:?--sample-size requires an argument}"
+                shift 2
+                ;;
+            *)
+                echo "pick-versions: unknown arg: $1" >&2
+                exit 2
+                ;;
+        esac
+    done
+
+    if ! [[ "$sample_size" =~ ^[0-9]+$ ]]; then
+        echo "pick-versions: --sample-size must be a non-negative integer, got '$sample_size'" >&2
+        exit 2
+    fi
+
+    local -a BRANCHES
+    mapfile -t BRANCHES < <(last_two_stable_branches)
+    if [ "${#BRANCHES[@]}" -lt 2 ]; then
+        echo "pick-versions: need at least 2 stable release branches; found ${#BRANCHES[@]}" >&2
+        exit 1
+    fi
+
+    # BRANCHES[0] is newest (e.g. 1.10.0), BRANCHES[1] next (e.g. v1.9).
+    local newest_branch="${BRANCHES[0]}"
+    local next_branch="${BRANCHES[1]}"
+
+    local newest_sha next_sha head_sha
+    {
+        read -r newest_sha
+        read -r next_sha
+        read -r head_sha
+    } < <(git rev-parse \
+              "origin/release/${newest_branch}" \
+              "origin/release/${next_branch}" \
+              HEAD)
+
+    # Always include the two stable branch heads + HEAD; add $sample_size
+    # random nightly tags. Nightlies are tagged daily off main, so each
+    # picked sha7 resolves to a real commit reachable from main without
+    # walking git log. sample_size=0 reduces to the 3-version base set.
+    local -a shas=("$newest_sha" "$next_sha" "$head_sha")
+    local -a branches_for_sha=("release/${newest_branch}" "release/${next_branch}" "")
+    local -a labels_for_sha=("" "" "")
+
+    if [ "$sample_size" -gt 0 ]; then
+        # nightly_tag_candidates emits newest-first; `head -n` takes the
+        # most recent N. Deterministic = easier triage than `shuf -n`.
+        local picked
+        picked=$(nightly_tag_candidates | head -n "$sample_size") || true
+        if [ -n "$picked" ]; then
+            local date sha7 full
+            while IFS=$'\t' read -r date sha7; do
+                # Resolve sha7 to a full sha; rev-parse fails loudly if the
+                # short sha is ambiguous or missing (e.g. pruned branch).
+                full=$(git rev-parse "$sha7^{commit}")
+                shas+=("$full")
+                branches_for_sha+=("")
+                labels_for_sha+=("nightly.${date}")
+            done <<< "$picked"
+        fi
+    fi
+
+    # Dedup on sha (a sampled nightly could collide with a stable branch
+    # HEAD or with HEAD itself). Then sort oldest -> newest by commit time.
+    declare -A seen=()
+    local -a uniq_shas=()
+    local -a uniq_branches=()
+    local -a uniq_labels=()
+    local i
+    for i in "${!shas[@]}"; do
+        local s="${shas[$i]}"
+        if [ -z "${seen[$s]+x}" ]; then
+            seen[$s]=1
+            uniq_shas+=("$s")
+            uniq_branches+=("${branches_for_sha[$i]}")
+            uniq_labels+=("${labels_for_sha[$i]}")
+        fi
+    done
+
+    # Order by semver, grouped: stable branches first (asc), then nightlies
+    # (asc by YYYYMMDD), then HEAD last. Deterministic across clones and
+    # ensures the creator always runs before any sender. HEAD runs last so
+    # every older version has already exercised the shared state by the
+    # time HEAD reads it — that's the highest-signal regression check.
+    #
+    # Sort key (tab-separated, lexical sort with zero-padded components):
+    #   kind_key (0=stable, 1=nightly, 2=head)
+    #   semver_key (10-digit zero-padded major.minor.patch, or YYYYMMDD)
+    # The kind_key dominates so groups stay contiguous regardless of the
+    # nightly's nominal X.Y.Z prefix (today's nightlies advertise 1.10.0
+    # but their build sha is well past release/1.10.0).
+    local sorted_payload
+    sorted_payload=$(
+        for i in "${!uniq_shas[@]}"; do
+            local _kind_key=2 _semver_key="0000000000.0000000000.0000000000"
+            local _label="${uniq_labels[$i]}"
+            local _branch="${uniq_branches[$i]}"
+            if [ -n "$_label" ]; then
+                # nightly.YYYYMMDD → key = YYYYMMDD (already zero-padded)
+                _kind_key=1
+                _semver_key="${_label#nightly.}"
+            elif [ -n "$_branch" ]; then
+                # release/v?X.Y(.Z)? → key = padded major.minor.patch
+                _kind_key=0
+                local _ver="${_branch#release/}"
+                _ver="${_ver#v}"
+                local _maj _min _pat
+                local -a _parts
+                IFS='.' read -ra _parts <<< "$_ver"
+                _maj="${_parts[0]:-0}"
+                _min="${_parts[1]:-0}"
+                _pat="${_parts[2]:-0}"
+                _semver_key=$(printf '%010d.%010d.%010d' "$_maj" "$_min" "$_pat")
+            fi
+            printf '%s\t%s\t%s\t%s\t%s\n' \
+                "$_kind_key" \
+                "$_semver_key" \
+                "${uniq_shas[$i]}" \
+                "$_branch" \
+                "$_label"
+        done | sort -k1,1n -k2,2 | cut -f2-
+    )
+
+    # Emit JSON. Role = creator for the first REQUIRED row (stable branch
+    # HEAD or repo HEAD, i.e. label empty), sender for the rest. Nightlies
+    # can never be the planned creator: a failing nightly must not take
+    # down the sequence; the creator is load-bearing.
+    # Fields: sha, short (7-char prefix), role, branch (release/X if a
+    # stable branch HEAD, empty otherwise), label (nightly.YYYYMMDD if
+    # the row came from a nightly tag, empty otherwise).
+    echo "$sorted_payload" \
+        | awk -F'\t' '
+            BEGIN { print "["; creator_seen = 0 }
+            {
+                if (NR > 1) printf ",\n"
+                is_required = ($4 == "")
+                if (!creator_seen && is_required) {
+                    role = "creator"
+                    creator_seen = 1
+                } else {
+                    role = "sender"
+                }
+                short = substr($2, 1, 7)
+                printf "  {\"sha\":\"%s\",\"short\":\"%s\",\"role\":\"%s\",\"branch\":\"%s\",\"label\":\"%s\"}",
+                       $2, short, role, $3, $4
+            }
+            END { print "\n]" }'
+}
+
+# Build the flake reference for a sha. Centralizes the github:xmtp/libxmtp
+# path so probe + info + real invocations can't silently diverge.
+xdbg_flake_ref() {
+    printf 'github:xmtp/libxmtp/%s#xdbg' "$1"
+}
+
+# Resolve the path to the built xdbg binary for a sha.
+#
+# Uses `nix build --no-link --print-out-paths` so we get the store path
+# without leaving a `result` symlink in CWD. Caller is expected to have
+# already invoked xdbg_probe_available "full" (or accept the build cost
+# here). Echoes the absolute path of `xdbg` binary on stdout, returns
+# non-zero on any failure.
+xdbg_binary_path() {
+    local sha="$1"
+    local out_path
+    out_path=$(nix build --no-link --print-out-paths "$(xdbg_flake_ref "$sha")" 2>&1) || {
+        printf '%s\n' "$out_path" >&2
+        return 1
+    }
+    # nix may print multiple lines; binary is at $out_path/bin/xdbg.
+    out_path=$(printf '%s\n' "$out_path" | tail -n1)
+    if [ ! -x "$out_path/bin/xdbg" ]; then
+        echo "xdbg_binary_path: no xdbg binary at $out_path/bin/xdbg" >&2
+        return 1
+    fi
+    printf '%s\n' "$out_path/bin/xdbg"
+}
+
+# Compose the env-prefix args that point xdbg at the shared XDBG_DB_ROOT
+# for an invocation. Echoes the args one per line for use with bash arrays.
+# Globals read: XVT_DB_ROOT.
+xdbg_sandbox_env_args() {
+    printf 'XDBG_DB_ROOT=%s\n' "$XVT_DB_ROOT"
+}
+
+# Probe whether xdbg is exposed and (optionally) builds for this sha.
+#
+# Args: mode sha
+#   mode=dry  → `nix build --dry-run` (evaluates, doesn't build).
+#   mode=full → `nix build` (compiles xdbg). Used for entries that the
+#               caller wants to verify CAN build, so a downstream
+#               failure can be classified as compile-error.
+#
+# Returns:
+#   0 — attribute present (and built, if mode=full).
+#   2 — flake evaluation failure (network / eval regression / broken pin /
+#       attribute missing). Caller treats as fatal: silently skipping
+#       would let a real flake regression sneak past CI.
+#   3 — flake evaluates fine, but the xdbg derivation fails to build
+#       (compile error, broken interface vs current deps). Caller decides
+#       whether to skip (nightly) or fail (required entry).
+xdbg_probe_available() {
+    local mode="$1" sha="$2"
+    local short="${sha:0:7}"
+    local probe_out probe_rc=0
+    local nix_args=("$(xdbg_flake_ref "$sha")")
+    if [ "$mode" = "dry" ]; then
+        nix_args=(--dry-run "${nix_args[@]}")
+    elif [ "$mode" != "full" ]; then
+        echo "xdbg_probe_available: bad mode '$mode' (want dry|full)" >&2
+        return 2
+    fi
+
+    probe_out=$(nix build "${nix_args[@]}" 2>&1) || probe_rc=$?
+    if [ $probe_rc -eq 0 ]; then
+        return 0
+    fi
+    # Distinguish eval failure (no derivation produced, or attribute
+    # missing) from build failure (derivation built but compile/check
+    # failed). nix emits "builder failed with exit code" or
+    # "error: build of '...' failed" for build failures.
+    if printf '%s\n' "$probe_out" \
+            | grep -qE "builder( for '.*')? failed|build of '.*' failed|builder failed with exit code"; then
+        printf '%s\n' "$probe_out" >&2
+        echo "::warning::xdbg@${short} build failed (compile error or similar)" >&2
+        return 3
+    fi
+    echo "::error::xdbg@${short} probe failed (rc=$probe_rc); flake evaluation broken" >&2
+    printf '%s\n' "$probe_out" >&2
+    return 2
+}
+
+# Run a non-informative xdbg command. Always tries --json --fail-fast first;
+# on clap "unexpected argument" (old sha without --fail-fast), retries
+# without it and scans the per-call JSON log file(s) for level == ERROR.
+#
+# Args: base_dir sha cmd_args...
+# base_dir is the parent under which per-call subdirs are minted so xdbg's
+# second-precision log filenames can't collide between rapid invocations.
+#
+# The built xdbg binary is exec'd via `env XDBG_DB_ROOT=$XVT_DB_ROOT` so
+# every tested version shares one redb/sqlite. Pre-XDBG_DB_ROOT xdbg
+# versions are skipped via the probe step.
+#
+# Globals read: BACKEND, XVT_DB_ROOT.
+# Echoes combined stdout+stderr; returns 0 on success, non-zero on failure.
+run_xdbg_real() {
+    local base_dir="$1" sha="$2"; shift 2
+    local short="${sha:0:7}"
+    local bin out rc
+    bin=$(xdbg_binary_path "$sha") || {
+        echo "::error::xdbg@${short} could not resolve binary path" >&2
+        return 1
+    }
+
+    local -a env_args
+    mapfile -t env_args < <(xdbg_sandbox_env_args)
+
+    local call_dir
+    call_dir=$(mktemp -d "${base_dir}/xvt-call-XXXXXX")
+
+    # `|| rc=$?` keeps `set -e` from firing on the xdbg failure (we need
+    # to inspect rc + output). `set +e`/`set -e` inside a function leaks
+    # the option change to the caller and breaks loops.
+    rc=0
+    out=$(cd "$call_dir" && env "${env_args[@]}" "$bin" \
+            -b "$BACKEND" --json --fail-fast "$@" 2>&1) || rc=$?
+
+    if [ $rc -eq 0 ]; then
+        printf '%s\n' "$out"
+        return 0
+    fi
+
+    # clap v4 emits "unexpected argument '<flag>' found" on unknown flags;
+    # if the message format ever changes, fall through to genuine-failure.
+    if grep -qE "unexpected argument" <<< "$out"; then
+        echo "::notice::xdbg@${short} lacks --fail-fast; retrying without flag and scanning JSON logs for ERROR" >&2
+        local retry_dir
+        retry_dir=$(mktemp -d "${base_dir}/xvt-call-XXXXXX")
+        rc=0
+        out=$(cd "$retry_dir" && env "${env_args[@]}" "$bin" \
+                -b "$BACKEND" --json "$@" 2>&1) || rc=$?
+
+        if [ $rc -ne 0 ]; then
+            printf '%s\n' "$out"
+            echo "::error::xdbg@${short} failed even without --fail-fast: rc=$rc" >&2
+            return 1
+        fi
+
+        # xdbg's --json writes ndJSON to a file in CWD
+        # (apps/xmtp_debug/src/logger.rs: File::create_new("{now}-xdbg.json")),
+        # NOT to stdout. Scan every .json file in retry_dir for level==ERROR.
+        # `try fromjson` per line tolerates non-JSON lines without aborting jq.
+        local json_files
+        json_files=$(find "$retry_dir" -maxdepth 1 -name '*.json' -type f 2>/dev/null)
+        if [ -z "$json_files" ]; then
+            printf '%s\n' "$out"
+            echo "::warning::xdbg@${short} produced no JSON log file in $retry_dir; legacy fallback cannot scan for ERROR" >&2
+            if printf '%s\n' "$out" \
+                    | jq -Rr 'try fromjson | select(.level == "ERROR") | true' \
+                      2>/dev/null \
+                    | grep -q .; then
+                echo "::error::xdbg@${short} produced ERROR log lines (legacy --fail-fast fallback, stdout scan)" >&2
+                return 1
+            fi
+            return 0
+        fi
+
+        local f
+        while IFS= read -r f; do
+            if jq -Rr 'try fromjson | select(.level == "ERROR") | true' \
+                    < "$f" 2>/dev/null \
+                    | grep -q .; then
+                printf '%s\n' "$out"
+                echo "::error::xdbg@${short} produced ERROR log lines in $f (legacy --fail-fast fallback)" >&2
+                jq -c 'select(.level == "ERROR")' < "$f" 2>/dev/null | head -20 >&2 || true
+                return 1
+            fi
+        done <<< "$json_files"
+
+        printf '%s\n' "$out"
+        return 0
+    fi
+
+    printf '%s\n' "$out"
+    echo "::error::xdbg@${short} failed: rc=$rc" >&2
+    return 1
+}
+
+# Run an informative xdbg command (e.g. --version) without --fail-fast/--json.
+# Same sandboxed-env mechanism as run_xdbg_real.
+run_xdbg_info() {
+    local sha="$1"; shift
+    local short="${sha:0:7}"
+    echo "::group::xdbg@${short} (info) $*" >&2
+    local rc=0
+    local bin
+    bin=$(xdbg_binary_path "$sha") || {
+        echo "::endgroup::" >&2
+        echo "::error::xdbg@${short} could not resolve binary path" >&2
+        return 1
+    }
+    local -a env_args
+    mapfile -t env_args < <(xdbg_sandbox_env_args)
+    env "${env_args[@]}" "$bin" "$@" || rc=$?
+    echo "::endgroup::" >&2
+    return "$rc"
+}
+
+cmd_run_sequence() {
+    local lenient_nightlies=0
+    while [ $# -gt 0 ] && [[ "$1" == --* ]]; do
+        case "$1" in
+            --lenient-nightlies)
+                lenient_nightlies=1
+                shift
+                ;;
+            --)
+                shift
+                break
+                ;;
+            *)
+                echo "run-sequence: unknown flag: $1" >&2
+                exit 2
+                ;;
+        esac
+    done
+    local plan="${1:?run-sequence requires a plan.json path}"
+
+    # Export out_dir to GITHUB_OUTPUT BEFORE any validation so the workflow's
+    # artifact-upload glob always has a valid prefix even on early exit.
+    # Otherwise it expands to /**/*.json and sweeps unrelated checkout files.
+    local out_dir="${XVT_OUT_DIR:-${TMPDIR:-/tmp}/xvt-out-$$}"
+    mkdir -p "$out_dir"
+    if [ -n "${GITHUB_OUTPUT:-}" ]; then
+        echo "out_dir=$out_dir" >> "$GITHUB_OUTPUT"
+    fi
+
+    if [ ! -r "$plan" ]; then
+        echo "run-sequence: cannot read plan: $plan" >&2
+        exit 2
+    fi
+
+    : "${BACKEND:=dev}"
+    export BACKEND
+
+    # Shared xdbg data dir across all tested versions. release/v1.9 +
+    # release/1.10.0 both carry the XDBG_DB_ROOT backport, and HEAD has
+    # it natively, so a single env var unifies state.
+    XVT_DB_ROOT="${TMPDIR:-/tmp}/xvt-db-$$"
+    mkdir -p "$XVT_DB_ROOT"
+    export XVT_DB_ROOT
+    echo "::notice::xvt XDBG_DB_ROOT=$XVT_DB_ROOT" >&2
+    echo "::notice::xvt output dir: $out_dir" >&2
+
+    # One jq pass: first line is length, then (role|short|sha|branch|label)
+    # per plan entry. Uses `|` instead of tab because bash's `read` with
+    # IFS=$'\t' treats tabs as whitespace and collapses consecutive ones,
+    # losing empty-branch entries (nightlies have empty branch + non-empty
+    # label). `|` is non-whitespace so consecutive separators preserve
+    # empty fields. Aborts under set -e if jq can't parse the plan.
+    local -a plan_lines
+    if ! mapfile -t plan_lines < <(
+        jq -r 'length, (.[] | [.role, .short, .sha, (.branch // ""), (.label // "")] | join("|"))' "$plan"
+    ); then
+        echo "run-sequence: failed to parse plan: $plan" >&2
+        exit 2
+    fi
+    local n="${plan_lines[0]}"
+    if [ "$n" -lt 2 ]; then
+        echo "run-sequence: plan must have at least 2 entries; got $n" >&2
+        exit 2
+    fi
+    echo "::notice::Running ${n} versions" >&2
+
+    {
+        printf 'ROLE|SHORT|SHA|BRANCH|LABEL\n'
+        printf '%s\n' "${plan_lines[@]:1}"
+    } | column -t -s '|' >&2
+
+    # Per-version status accumulation. Each entry: "STATUS|short|sha|kind|label"
+    # STATUS values:
+    #   PASS         — ran successfully
+    #   FAIL         — runtime failure (or build failure on required entry)
+    #   SKIP-BUILD   — nightly failed to compile; skipped
+    #   SKIP-NOT-RUN — planned but the loop bailed early on an earlier
+    #                  required-version failure
+    #   SKIP         — generic skip (reserved)
+    # kind: stable | nightly | head
+    local -a results=()
+    local creator_done=0
+    local sender_done=0
+    local nightly_failure=0
+    local required_failure=0
+    local _record_not_run_remaining=0
+    local sha role rand probe_rc probe_mode kind
+    local entry _short branch label
+    local plan_idx=0
+    for entry in "${plan_lines[@]:1}"; do
+        plan_idx=$((plan_idx + 1))
+        IFS='|' read -r role _short sha branch label <<< "$entry"
+        if [ -z "$sha" ] || [ -z "$role" ] || [ "$sha" = "null" ] || [ "$role" = "null" ]; then
+            echo "run-sequence: plan entry missing sha or role" >&2
+            exit 2
+        fi
+
+        # Classify entry. label non-empty → nightly. branch non-empty → stable.
+        # Both empty → HEAD (also required).
+        if [ -n "$label" ]; then
+            kind="nightly"
+        elif [ -n "$branch" ]; then
+            kind="stable"
+        else
+            kind="head"
+        fi
+        local is_required=1
+        if [ "$kind" = "nightly" ]; then
+            is_required=0
+        fi
+
+        # Required entries: probe dry (fast). Nightlies: probe full so a
+        # compile failure surfaces here and can be skipped without polluting
+        # the sequence; required entries that fail to build are fatal.
+        if [ "$is_required" -eq 1 ]; then
+            probe_mode=dry
+        else
+            probe_mode=full
+        fi
+
+        probe_rc=0
+        xdbg_probe_available "$probe_mode" "$sha" || probe_rc=$?
+        case "$probe_rc" in
+            0) ;;                                        # present (built if full)
+            3)
+                if [ "$is_required" -eq 0 ]; then
+                    echo "::warning::xdbg@${sha:0:7} nightly $label fails to build; skipping" >&2
+                    results+=("SKIP-BUILD|${sha:0:7}|$sha|$kind|$label")
+                    nightly_failure=1
+                    continue
+                fi
+                echo "::error::run-sequence: required version ${sha:0:7} ($branch) fails to build" >&2
+                results+=("FAIL|${sha:0:7}|$sha|$kind|$label")
+                required_failure=1
+                # Required build failure is fatal; record remaining entries
+                # as NOT-RUN so the summary still lists every planned version.
+                _record_not_run_remaining=1
+                break
+                ;;
+            *)
+                echo "::error::run-sequence: aborting on probe failure for ${sha:0:7} (rc=$probe_rc)" >&2
+                results+=("FAIL|${sha:0:7}|$sha|$kind|$label")
+                required_failure=1
+                _record_not_run_remaining=1
+                break
+                ;;
+        esac
+
+        run_xdbg_info "$sha" --version || true
+
+        # If the planned creator slot is still empty (e.g. earlier entries
+        # were all skipped), promote this entry to creator. Only required
+        # entries (stable / HEAD) get promoted — a nightly is allowed to
+        # fail and we don't want a single failing nightly to take down the
+        # whole sequence by being the creator.
+        local effective_role="$role"
+        if [ "$creator_done" -eq 0 ] && [ "$is_required" -eq 1 ]; then
+            effective_role="creator"
+        fi
+
+        local entry_rc=0
+        if [ "$effective_role" = "creator" ]; then
+            echo "::group::creator@${sha:0:7} setup" >&2
+            run_xdbg_real "$out_dir" "$sha" generate --entity identity -a "$n" \
+                || entry_rc=$?
+            if [ "$entry_rc" -eq 0 ]; then
+                run_xdbg_real "$out_dir" "$sha" generate --entity group -a 1 --invite "$n" \
+                    || entry_rc=$?
+            fi
+            if [ "$entry_rc" -eq 0 ]; then
+                run_xdbg_real "$out_dir" "$sha" generate --entity message -a 1 \
+                    || entry_rc=$?
+            fi
+            echo "::endgroup::" >&2
+            if [ "$entry_rc" -eq 0 ]; then
+                creator_done=1
+                results+=("PASS|${sha:0:7}|$sha|$kind|$label")
+            else
+                # Creator is load-bearing: senders have nothing to read.
+                # Always fatal regardless of leniency.
+                echo "::error::xdbg@${sha:0:7} creator failed (rc=$entry_rc); cannot continue" >&2
+                results+=("FAIL|${sha:0:7}|$sha|$kind|$label")
+                required_failure=1
+                _record_not_run_remaining=1
+                break
+            fi
+        else
+            rand=$(( (RANDOM % 6) + 5 ))   # 5..10 inclusive
+            echo "::group::sender@${sha:0:7} (${rand} msgs + change-description)" >&2
+            run_xdbg_real "$out_dir" "$sha" generate --entity group -a 1 --invite "$n" \
+                || entry_rc=$?
+            if [ "$entry_rc" -eq 0 ]; then
+                run_xdbg_real "$out_dir" "$sha" generate --entity message -a "$rand" --change-description \
+                    || entry_rc=$?
+            fi
+            echo "::endgroup::" >&2
+
+            if [ "$entry_rc" -eq 0 ]; then
+                sender_done=1
+                results+=("PASS|${sha:0:7}|$sha|$kind|$label")
+            else
+                results+=("FAIL|${sha:0:7}|$sha|$kind|$label")
+                if [ "$is_required" -eq 0 ]; then
+                    echo "::warning::xdbg@${sha:0:7} nightly $label runtime failure (rc=$entry_rc); continuing so later versions (incl. HEAD) still run" >&2
+                    nightly_failure=1
+                    continue
+                fi
+                # Required sender failure — record but keep running so
+                # remaining entries (including HEAD) still get a chance.
+                # The required_failure flag will cause non-zero exit at end.
+                echo "::error::xdbg@${sha:0:7} required sender ($kind) runtime failure (rc=$entry_rc); continuing to remaining entries" >&2
+                required_failure=1
+            fi
+        fi
+    done
+
+    # If we broke out of the loop early (required-version fatal), record
+    # the remaining planned entries as NOT-RUN so the summary still shows
+    # every version that was in the plan.
+    if [ "$_record_not_run_remaining" -eq 1 ]; then
+        local remaining_idx
+        for ((remaining_idx = plan_idx + 1; remaining_idx <= n; remaining_idx++)); do
+            local _r_entry="${plan_lines[$remaining_idx]}"
+            local _r_role _r_short _r_sha _r_branch _r_label _r_kind
+            IFS='|' read -r _r_role _r_short _r_sha _r_branch _r_label <<< "$_r_entry"
+            if [ -n "$_r_label" ]; then
+                _r_kind="nightly"
+            elif [ -n "$_r_branch" ]; then
+                _r_kind="stable"
+            else
+                _r_kind="head"
+            fi
+            results+=("SKIP-NOT-RUN|${_r_sha:0:7}|$_r_sha|$_r_kind|$_r_label")
+        done
+    fi
+
+    # Build summary in three forms:
+    #   - plain text table to stderr (always)
+    #   - markdown table appended to $GITHUB_STEP_SUMMARY if set
+    #   - JSON file at $out_dir/summary.json for tool/artifact consumption
+    local summary_json="$out_dir/summary.json"
+    local r status short_sha full_sha r_kind r_label glyph md_glyph
+
+    # Stderr plain table.
+    {
+        echo ""
+        echo "=== cross-version-test summary ==="
+        printf 'STATUS|KIND|SHORT|SHA|LABEL\n'
+        for r in "${results[@]}"; do
+            IFS='|' read -r status short_sha full_sha r_kind r_label <<< "$r"
+            case "$status" in
+                PASS)          glyph="✓ PASS" ;;
+                FAIL)          glyph="✗ FAIL" ;;
+                SKIP-BUILD)    glyph="⊘ SKIP (build failed)" ;;
+                SKIP-NOT-RUN)  glyph="⊘ SKIP (not run — earlier required failure)" ;;
+                *)             glyph="? $status" ;;
+            esac
+            printf '%s|%s|%s|%s|%s\n' "$glyph" "$r_kind" "$short_sha" "$full_sha" "$r_label"
+        done
+    } | column -t -s '|' >&2
+
+    # JSON summary.
+    {
+        printf '{\n  "creator_done": %s,\n' "$creator_done"
+        printf '  "sender_done": %s,\n' "$sender_done"
+        printf '  "nightly_failure": %s,\n' "$nightly_failure"
+        printf '  "required_failure": %s,\n' "$required_failure"
+        printf '  "lenient_nightlies": %s,\n' "$lenient_nightlies"
+        printf '  "results": [\n'
+        local first=1
+        for r in "${results[@]}"; do
+            IFS='|' read -r status short_sha full_sha r_kind r_label <<< "$r"
+            if [ "$first" -eq 0 ]; then printf ',\n'; fi
+            first=0
+            printf '    {"status":"%s","short":"%s","sha":"%s","kind":"%s","label":"%s"}' \
+                "$status" "$short_sha" "$full_sha" "$r_kind" "$r_label"
+        done
+        printf '\n  ]\n}\n'
+    } > "$summary_json"
+    echo "::notice::summary JSON: $summary_json" >&2
+
+    # Count libxmtp NDJSON log files produced this run for the summary.
+    local log_count=0
+    log_count=$(find "$out_dir" -maxdepth 2 -name '*.json' -type f \
+                ! -name 'summary.json' 2>/dev/null | wc -l)
+
+    # GitHub Actions step summary (markdown, renders in the Actions UI).
+    if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+        {
+            echo "## cross-version-test results"
+            echo ""
+            echo "| Status | Kind | Short | Label | SHA |"
+            echo "|---|---|---|---|---|"
+            for r in "${results[@]}"; do
+                IFS='|' read -r status short_sha full_sha r_kind r_label <<< "$r"
+                case "$status" in
+                    PASS)          md_glyph="✅ PASS" ;;
+                    FAIL)          md_glyph="❌ FAIL" ;;
+                    SKIP-BUILD)    md_glyph="⊘ SKIP (build failed)" ;;
+                    SKIP-NOT-RUN)  md_glyph="⊘ SKIP (not run — earlier required failure)" ;;
+                    *)             md_glyph="❓ $status" ;;
+                esac
+                # shellcheck disable=SC2016  # backticks in template are markdown, not subshells
+                printf '| %s | %s | `%s` | %s | `%s` |\n' \
+                    "$md_glyph" "$r_kind" "$short_sha" "${r_label:--}" "$full_sha"
+            done
+            echo ""
+            echo "**creator_done=$creator_done sender_done=$sender_done required_failure=$required_failure nightly_failure=$nightly_failure lenient=$lenient_nightlies**"
+            echo ""
+            echo "**libxmtp NDJSON log files captured: ${log_count}** (download the run artifact to inspect)"
+        } >> "$GITHUB_STEP_SUMMARY"
+    fi
+
+    # Cross-version compat requires at least one creator AND one sender.
+    if [ "$creator_done" -eq 0 ] || [ "$sender_done" -eq 0 ]; then
+        echo "::error::run-sequence: insufficient cross-version coverage (creator=$creator_done, sender=$sender_done); need at least one creator + one sender" >&2
+        exit 1
+    fi
+
+    # Exit-code policy:
+    #   required failure → always non-zero (catches stable/HEAD regressions)
+    #   nightly failure + lenient → exit 0 (warning already emitted)
+    #   nightly failure + strict  → exit 1
+    if [ "$required_failure" -eq 1 ]; then
+        echo "::error::run-sequence: one or more required versions failed" >&2
+        exit 1
+    fi
+    if [ "$nightly_failure" -eq 1 ] && [ "$lenient_nightlies" -eq 0 ]; then
+        echo "::error::run-sequence: one or more nightlies failed (strict mode)" >&2
+        exit 1
+    fi
+    if [ "$nightly_failure" -eq 1 ]; then
+        echo "::notice::run-sequence completed with nightly failures (lenient mode; HEAD + required versions OK)" >&2
+    else
+        echo "::notice::run-sequence completed without failures" >&2
+    fi
+}
+
+main "$@"

--- a/nix/package/cross-version-test/cross-version-test.sh
+++ b/nix/package/cross-version-test/cross-version-test.sh
@@ -158,9 +158,13 @@ cmd_pick_versions() {
         if [ -n "$picked" ]; then
             local date sha7 full
             while IFS=$'\t' read -r date sha7; do
-                # Resolve sha7 to a full sha; rev-parse fails loudly if the
-                # short sha is ambiguous or missing (e.g. pruned branch).
-                full=$(git rev-parse "$sha7^{commit}")
+                # Resolve sha7 to a full sha. Fails loudly with a labelled
+                # message if the short sha is ambiguous (multiple matches)
+                # or missing (e.g. tag points at a pruned/gc'd commit).
+                if ! full=$(git rev-parse --verify "$sha7^{commit}" 2>/dev/null); then
+                    echo "pick-versions: failed to resolve nightly sha7 '$sha7' (ambiguous or missing); skipping nightly.${date}" >&2
+                    continue
+                fi
                 shas+=("$full")
                 branches_for_sha+=("")
                 labels_for_sha+=("nightly.${date}")
@@ -338,17 +342,16 @@ xdbg_probe_available() {
     return 2
 }
 
-# Run a non-informative xdbg command. Always tries --json --fail-fast first;
-# on clap "unexpected argument" (old sha without --fail-fast), retries
-# without it and scans the per-call JSON log file(s) for level == ERROR.
+# Run a non-informative xdbg command with `--json --fail-fast`. Every
+# tested sha now carries the --fail-fast flag, so non-zero rc IS the
+# failure signal — no log-file scanning needed.
 #
 # Args: base_dir sha cmd_args...
 # base_dir is the parent under which per-call subdirs are minted so xdbg's
 # second-precision log filenames can't collide between rapid invocations.
 #
 # The built xdbg binary is exec'd via `env XDBG_DB_ROOT=$XVT_DB_ROOT` so
-# every tested version shares one redb/sqlite. Pre-XDBG_DB_ROOT xdbg
-# versions are skipped via the probe step.
+# every tested version shares one redb/sqlite.
 #
 # Globals read: BACKEND, XVT_DB_ROOT.
 # Echoes combined stdout+stderr; returns 0 on success, non-zero on failure.
@@ -374,65 +377,12 @@ run_xdbg_real() {
     out=$(cd "$call_dir" && env "${env_args[@]}" "$bin" \
             -b "$BACKEND" --json --fail-fast "$@" 2>&1) || rc=$?
 
-    if [ $rc -eq 0 ]; then
-        printf '%s\n' "$out"
-        return 0
-    fi
-
-    # clap v4 emits "unexpected argument '<flag>' found" on unknown flags;
-    # if the message format ever changes, fall through to genuine-failure.
-    if grep -qE "unexpected argument" <<< "$out"; then
-        echo "::notice::xdbg@${short} lacks --fail-fast; retrying without flag and scanning JSON logs for ERROR" >&2
-        local retry_dir
-        retry_dir=$(mktemp -d "${base_dir}/xvt-call-XXXXXX")
-        rc=0
-        out=$(cd "$retry_dir" && env "${env_args[@]}" "$bin" \
-                -b "$BACKEND" --json "$@" 2>&1) || rc=$?
-
-        if [ $rc -ne 0 ]; then
-            printf '%s\n' "$out"
-            echo "::error::xdbg@${short} failed even without --fail-fast: rc=$rc" >&2
-            return 1
-        fi
-
-        # xdbg's --json writes ndJSON to a file in CWD
-        # (apps/xmtp_debug/src/logger.rs: File::create_new("{now}-xdbg.json")),
-        # NOT to stdout. Scan every .json file in retry_dir for level==ERROR.
-        # `try fromjson` per line tolerates non-JSON lines without aborting jq.
-        local json_files
-        json_files=$(find "$retry_dir" -maxdepth 1 -name '*.json' -type f 2>/dev/null)
-        if [ -z "$json_files" ]; then
-            printf '%s\n' "$out"
-            echo "::warning::xdbg@${short} produced no JSON log file in $retry_dir; legacy fallback cannot scan for ERROR" >&2
-            if printf '%s\n' "$out" \
-                    | jq -Rr 'try fromjson | select(.level == "ERROR") | true' \
-                      2>/dev/null \
-                    | grep -q .; then
-                echo "::error::xdbg@${short} produced ERROR log lines (legacy --fail-fast fallback, stdout scan)" >&2
-                return 1
-            fi
-            return 0
-        fi
-
-        local f
-        while IFS= read -r f; do
-            if jq -Rr 'try fromjson | select(.level == "ERROR") | true' \
-                    < "$f" 2>/dev/null \
-                    | grep -q .; then
-                printf '%s\n' "$out"
-                echo "::error::xdbg@${short} produced ERROR log lines in $f (legacy --fail-fast fallback)" >&2
-                jq -c 'select(.level == "ERROR")' < "$f" 2>/dev/null | head -20 >&2 || true
-                return 1
-            fi
-        done <<< "$json_files"
-
-        printf '%s\n' "$out"
-        return 0
-    fi
-
     printf '%s\n' "$out"
-    echo "::error::xdbg@${short} failed: rc=$rc" >&2
-    return 1
+    if [ $rc -ne 0 ]; then
+        echo "::error::xdbg@${short} failed: rc=$rc" >&2
+        return 1
+    fi
+    return 0
 }
 
 # Run an informative xdbg command (e.g. --version) without --fail-fast/--json.
@@ -506,14 +456,17 @@ cmd_run_sequence() {
     # IFS=$'\t' treats tabs as whitespace and collapses consecutive ones,
     # losing empty-branch entries (nightlies have empty branch + non-empty
     # label). `|` is non-whitespace so consecutive separators preserve
-    # empty fields. Aborts under set -e if jq can't parse the plan.
-    local -a plan_lines
-    if ! mapfile -t plan_lines < <(
-        jq -r 'length, (.[] | [.role, .short, .sha, (.branch // ""), (.label // "")] | join("|"))' "$plan"
-    ); then
+    # empty fields. Capture jq output into a variable first so jq failures
+    # propagate — `mapfile < <(jq …)` swallows jq's exit status via the
+    # process substitution and leaves plan_lines empty without erroring.
+    local jq_out jq_rc=0
+    jq_out=$(jq -r 'length, (.[] | [.role, .short, .sha, (.branch // ""), (.label // "")] | join("|"))' "$plan") || jq_rc=$?
+    if [ "$jq_rc" -ne 0 ]; then
         echo "run-sequence: failed to parse plan: $plan" >&2
         exit 2
     fi
+    local -a plan_lines
+    mapfile -t plan_lines <<< "$jq_out"
     local n="${plan_lines[0]}"
     if [ "$n" -lt 2 ]; then
         echo "run-sequence: plan must have at least 2 entries; got $n" >&2

--- a/nix/package/cross-version-test/cross-version-test.sh
+++ b/nix/package/cross-version-test/cross-version-test.sh
@@ -479,7 +479,8 @@ cmd_run_sequence() {
         printf '%s\n' "${plan_lines[@]:1}"
     } | column -t -s '|' >&2
 
-    # Per-version status accumulation. Each entry: "STATUS|short|sha|kind|label"
+    # Per-version status accumulation. Each entry:
+    #   "STATUS|short|sha|kind|branch|label"
     # STATUS values:
     #   PASS         — ran successfully
     #   FAIL         — runtime failure (or build failure on required entry)
@@ -535,12 +536,12 @@ cmd_run_sequence() {
             3)
                 if [ "$is_required" -eq 0 ]; then
                     echo "::warning::xdbg@${sha:0:7} nightly $label fails to build; skipping" >&2
-                    results+=("SKIP-BUILD|${sha:0:7}|$sha|$kind|$label")
+                    results+=("SKIP-BUILD|${sha:0:7}|$sha|$kind|$branch|$label")
                     nightly_failure=1
                     continue
                 fi
                 echo "::error::run-sequence: required version ${sha:0:7} ($branch) fails to build" >&2
-                results+=("FAIL|${sha:0:7}|$sha|$kind|$label")
+                results+=("FAIL|${sha:0:7}|$sha|$kind|$branch|$label")
                 required_failure=1
                 # Required build failure is fatal; record remaining entries
                 # as NOT-RUN so the summary still lists every planned version.
@@ -549,7 +550,7 @@ cmd_run_sequence() {
                 ;;
             *)
                 echo "::error::run-sequence: aborting on probe failure for ${sha:0:7} (rc=$probe_rc)" >&2
-                results+=("FAIL|${sha:0:7}|$sha|$kind|$label")
+                results+=("FAIL|${sha:0:7}|$sha|$kind|$branch|$label")
                 required_failure=1
                 _record_not_run_remaining=1
                 break
@@ -584,12 +585,12 @@ cmd_run_sequence() {
             echo "::endgroup::" >&2
             if [ "$entry_rc" -eq 0 ]; then
                 creator_done=1
-                results+=("PASS|${sha:0:7}|$sha|$kind|$label")
+                results+=("PASS|${sha:0:7}|$sha|$kind|$branch|$label")
             else
                 # Creator is load-bearing: senders have nothing to read.
                 # Always fatal regardless of leniency.
                 echo "::error::xdbg@${sha:0:7} creator failed (rc=$entry_rc); cannot continue" >&2
-                results+=("FAIL|${sha:0:7}|$sha|$kind|$label")
+                results+=("FAIL|${sha:0:7}|$sha|$kind|$branch|$label")
                 required_failure=1
                 _record_not_run_remaining=1
                 break
@@ -607,9 +608,9 @@ cmd_run_sequence() {
 
             if [ "$entry_rc" -eq 0 ]; then
                 sender_done=1
-                results+=("PASS|${sha:0:7}|$sha|$kind|$label")
+                results+=("PASS|${sha:0:7}|$sha|$kind|$branch|$label")
             else
-                results+=("FAIL|${sha:0:7}|$sha|$kind|$label")
+                results+=("FAIL|${sha:0:7}|$sha|$kind|$branch|$label")
                 if [ "$is_required" -eq 0 ]; then
                     echo "::warning::xdbg@${sha:0:7} nightly $label runtime failure (rc=$entry_rc); continuing so later versions (incl. HEAD) still run" >&2
                     nightly_failure=1
@@ -640,7 +641,7 @@ cmd_run_sequence() {
             else
                 _r_kind="head"
             fi
-            results+=("SKIP-NOT-RUN|${_r_sha:0:7}|$_r_sha|$_r_kind|$_r_label")
+            results+=("SKIP-NOT-RUN|${_r_sha:0:7}|$_r_sha|$_r_kind|$_r_branch|$_r_label")
         done
     fi
 
@@ -649,7 +650,7 @@ cmd_run_sequence() {
     #   - markdown table appended to $GITHUB_STEP_SUMMARY if set
     #   - JSON file at $out_dir/summary.json for tool/artifact consumption
     local summary_json="$out_dir/summary.json"
-    local r status short_sha full_sha r_kind r_label glyph md_glyph
+    local r status short_sha full_sha r_kind r_branch r_label glyph md_glyph display
 
     # Stderr plain table.
     {
@@ -657,7 +658,7 @@ cmd_run_sequence() {
         echo "=== cross-version-test summary ==="
         printf 'STATUS|KIND|SHORT|SHA|LABEL\n'
         for r in "${results[@]}"; do
-            IFS='|' read -r status short_sha full_sha r_kind r_label <<< "$r"
+            IFS='|' read -r status short_sha full_sha r_kind r_branch r_label <<< "$r"
             case "$status" in
                 PASS)          glyph="✓ PASS" ;;
                 FAIL)          glyph="✗ FAIL" ;;
@@ -665,7 +666,10 @@ cmd_run_sequence() {
                 SKIP-NOT-RUN)  glyph="⊘ SKIP (not run — earlier required failure)" ;;
                 *)             glyph="? $status" ;;
             esac
-            printf '%s|%s|%s|%s|%s\n' "$glyph" "$r_kind" "$short_sha" "$full_sha" "$r_label"
+            # Display: nightly tag label if present, else release branch
+            # (stable rows), else empty (HEAD).
+            display="${r_label:-$r_branch}"
+            printf '%s|%s|%s|%s|%s\n' "$glyph" "$r_kind" "$short_sha" "$full_sha" "$display"
         done
     } | column -t -s '|' >&2
 
@@ -679,11 +683,11 @@ cmd_run_sequence() {
         printf '  "results": [\n'
         local first=1
         for r in "${results[@]}"; do
-            IFS='|' read -r status short_sha full_sha r_kind r_label <<< "$r"
+            IFS='|' read -r status short_sha full_sha r_kind r_branch r_label <<< "$r"
             if [ "$first" -eq 0 ]; then printf ',\n'; fi
             first=0
-            printf '    {"status":"%s","short":"%s","sha":"%s","kind":"%s","label":"%s"}' \
-                "$status" "$short_sha" "$full_sha" "$r_kind" "$r_label"
+            printf '    {"status":"%s","short":"%s","sha":"%s","kind":"%s","branch":"%s","label":"%s"}' \
+                "$status" "$short_sha" "$full_sha" "$r_kind" "$r_branch" "$r_label"
         done
         printf '\n  ]\n}\n'
     } > "$summary_json"
@@ -699,10 +703,10 @@ cmd_run_sequence() {
         {
             echo "## cross-version-test results"
             echo ""
-            echo "| Status | Kind | Short | Label | SHA |"
+            echo "| Status | Kind | Short | Label / Branch | SHA |"
             echo "|---|---|---|---|---|"
             for r in "${results[@]}"; do
-                IFS='|' read -r status short_sha full_sha r_kind r_label <<< "$r"
+                IFS='|' read -r status short_sha full_sha r_kind r_branch r_label <<< "$r"
                 case "$status" in
                     PASS)          md_glyph="✅ PASS" ;;
                     FAIL)          md_glyph="❌ FAIL" ;;
@@ -710,9 +714,12 @@ cmd_run_sequence() {
                     SKIP-NOT-RUN)  md_glyph="⊘ SKIP (not run — earlier required failure)" ;;
                     *)             md_glyph="❓ $status" ;;
                 esac
+                # Nightly rows carry a label (nightly.YYYYMMDD); stable rows
+                # carry a branch (release/X); HEAD has neither.
+                display="${r_label:-${r_branch:--}}"
                 # shellcheck disable=SC2016  # backticks in template are markdown, not subshells
                 printf '| %s | %s | `%s` | %s | `%s` |\n' \
-                    "$md_glyph" "$r_kind" "$short_sha" "${r_label:--}" "$full_sha"
+                    "$md_glyph" "$r_kind" "$short_sha" "$display" "$full_sha"
             done
             echo ""
             echo "**creator_done=$creator_done sender_done=$sender_done required_failure=$required_failure nightly_failure=$nightly_failure lenient=$lenient_nightlies**"

--- a/nix/package/cross-version-test/cross-version-test.sh
+++ b/nix/package/cross-version-test/cross-version-test.sh
@@ -146,9 +146,20 @@ cmd_pick_versions() {
     # random nightly tags. Nightlies are tagged daily off main, so each
     # picked sha7 resolves to a real commit reachable from main without
     # walking git log. sample_size=0 reduces to the 3-version base set.
+    #
+    # HEAD's label embeds the current ref name so locally-run plans show
+    # something more useful than empty (e.g. `HEAD@feature-branch`). In CI
+    # the checkout is detached so `--abbrev-ref` returns `HEAD`; we elide
+    # the redundant suffix in that case.
+    local head_ref head_label="HEAD"
+    head_ref=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "HEAD")
+    if [ -n "$head_ref" ] && [ "$head_ref" != "HEAD" ]; then
+        head_label="HEAD@${head_ref}"
+    fi
+
     local -a shas=("$newest_sha" "$next_sha" "$head_sha")
     local -a branches_for_sha=("release/${newest_branch}" "release/${next_branch}" "")
-    local -a labels_for_sha=("" "" "")
+    local -a labels_for_sha=("" "" "$head_label")
 
     if [ "$sample_size" -gt 0 ]; then
         # nightly_tag_candidates emits newest-first; `head -n` takes the
@@ -259,13 +270,23 @@ cmd_pick_versions() {
             END { print "\n]" }'
 }
 
-# Build the flake reference for a sha. Centralizes the github:xmtp/libxmtp
-# path so probe + info + real invocations can't silently diverge.
+# Build the flake reference for a (kind, sha) pair.
+#
+# For kind=head the local working-tree flake (`.#xdbg`) is used, so:
+#   - CI doesn't need HEAD pushed to github before run-sequence executes
+#     (it always is in practice, but this avoids a 404 race),
+#   - local `just cross-test` works against unpushed working-copy commits.
+# All other kinds (stable, nightly) resolve via github:xmtp/libxmtp/<sha>.
 xdbg_flake_ref() {
-    printf 'github:xmtp/libxmtp/%s#xdbg' "$1"
+    local kind="$1" sha="$2"
+    if [ "$kind" = "head" ]; then
+        printf '.#xdbg'
+    else
+        printf 'github:xmtp/libxmtp/%s#xdbg' "$sha"
+    fi
 }
 
-# Resolve the path to the built xdbg binary for a sha.
+# Resolve the path to the built xdbg binary for a (kind, sha) pair.
 #
 # Uses `nix build --no-link --print-out-paths` so we get the store path
 # without leaving a `result` symlink in CWD. Caller is expected to have
@@ -273,9 +294,9 @@ xdbg_flake_ref() {
 # here). Echoes the absolute path of `xdbg` binary on stdout, returns
 # non-zero on any failure.
 xdbg_binary_path() {
-    local sha="$1"
+    local kind="$1" sha="$2"
     local out_path
-    out_path=$(nix build --no-link --print-out-paths "$(xdbg_flake_ref "$sha")" 2>&1) || {
+    out_path=$(nix build --no-link --print-out-paths "$(xdbg_flake_ref "$kind" "$sha")" 2>&1) || {
         printf '%s\n' "$out_path" >&2
         return 1
     }
@@ -295,13 +316,14 @@ xdbg_sandbox_env_args() {
     printf 'XDBG_DB_ROOT=%s\n' "$XVT_DB_ROOT"
 }
 
-# Probe whether xdbg is exposed and (optionally) builds for this sha.
+# Probe whether xdbg is exposed and (optionally) builds for this entry.
 #
-# Args: mode sha
+# Args: mode kind sha
 #   mode=dry  → `nix build --dry-run` (evaluates, doesn't build).
 #   mode=full → `nix build` (compiles xdbg). Used for entries that the
 #               caller wants to verify CAN build, so a downstream
 #               failure can be classified as compile-error.
+#   kind      → "head" uses local .#xdbg, else uses github:xmtp/libxmtp/<sha>.
 #
 # Returns:
 #   0 — attribute present (and built, if mode=full).
@@ -312,10 +334,10 @@ xdbg_sandbox_env_args() {
 #       (compile error, broken interface vs current deps). Caller decides
 #       whether to skip (nightly) or fail (required entry).
 xdbg_probe_available() {
-    local mode="$1" sha="$2"
+    local mode="$1" kind="$2" sha="$3"
     local short="${sha:0:7}"
     local probe_out probe_rc=0
-    local nix_args=("$(xdbg_flake_ref "$sha")")
+    local nix_args=("$(xdbg_flake_ref "$kind" "$sha")")
     if [ "$mode" = "dry" ]; then
         nix_args=(--dry-run "${nix_args[@]}")
     elif [ "$mode" != "full" ]; then
@@ -346,9 +368,10 @@ xdbg_probe_available() {
 # tested sha now carries the --fail-fast flag, so non-zero rc IS the
 # failure signal — no log-file scanning needed.
 #
-# Args: base_dir sha cmd_args...
+# Args: base_dir kind sha cmd_args...
 # base_dir is the parent under which per-call subdirs are minted so xdbg's
 # second-precision log filenames can't collide between rapid invocations.
+# kind selects local-flake vs github-flake via xdbg_flake_ref.
 #
 # The built xdbg binary is exec'd via `env XDBG_DB_ROOT=$XVT_DB_ROOT` so
 # every tested version shares one redb/sqlite.
@@ -356,16 +379,25 @@ xdbg_probe_available() {
 # Globals read: BACKEND, XVT_DB_ROOT.
 # Echoes combined stdout+stderr; returns 0 on success, non-zero on failure.
 run_xdbg_real() {
-    local base_dir="$1" sha="$2"; shift 2
+    local base_dir="$1" kind="$2" sha="$3"; shift 3
     local short="${sha:0:7}"
     local bin out rc
-    bin=$(xdbg_binary_path "$sha") || {
+    bin=$(xdbg_binary_path "$kind" "$sha") || {
         echo "::error::xdbg@${short} could not resolve binary path" >&2
         return 1
     }
 
     local -a env_args
     mapfile -t env_args < <(xdbg_sandbox_env_args)
+
+    # Caller-supplied global flags (verbosity etc.) splice in BEFORE the
+    # harness's own `-b ... --json --fail-fast`. Space-separated; empty by
+    # default. Useful for `just cross-test -vvvv` style debugging.
+    local -a xtra_flags=()
+    if [ -n "${XVT_XDBG_FLAGS:-}" ]; then
+        # shellcheck disable=SC2206  # word-split is the intent
+        xtra_flags=(${XVT_XDBG_FLAGS})
+    fi
 
     local call_dir
     call_dir=$(mktemp -d "${base_dir}/xvt-call-XXXXXX")
@@ -375,7 +407,7 @@ run_xdbg_real() {
     # the option change to the caller and breaks loops.
     rc=0
     out=$(cd "$call_dir" && env "${env_args[@]}" "$bin" \
-            -b "$BACKEND" --json --fail-fast "$@" 2>&1) || rc=$?
+            "${xtra_flags[@]}" -b "$BACKEND" --json --fail-fast "$@" 2>&1) || rc=$?
 
     printf '%s\n' "$out"
     if [ $rc -ne 0 ]; then
@@ -387,13 +419,14 @@ run_xdbg_real() {
 
 # Run an informative xdbg command (e.g. --version) without --fail-fast/--json.
 # Same sandboxed-env mechanism as run_xdbg_real.
+# Args: kind sha cmd_args...
 run_xdbg_info() {
-    local sha="$1"; shift
+    local kind="$1" sha="$2"; shift 2
     local short="${sha:0:7}"
     echo "::group::xdbg@${short} (info) $*" >&2
     local rc=0
     local bin
-    bin=$(xdbg_binary_path "$sha") || {
+    bin=$(xdbg_binary_path "$kind" "$sha") || {
         echo "::endgroup::" >&2
         echo "::error::xdbg@${short} could not resolve binary path" >&2
         return 1
@@ -506,15 +539,26 @@ cmd_run_sequence() {
             exit 2
         fi
 
-        # Classify entry. label non-empty → nightly. branch non-empty → stable.
-        # Both empty → HEAD (also required).
-        if [ -n "$label" ]; then
-            kind="nightly"
-        elif [ -n "$branch" ]; then
-            kind="stable"
-        else
-            kind="head"
-        fi
+        # Classify entry by label/branch:
+        #   label starts with "nightly." → nightly
+        #   label starts with "HEAD"     → head (carries ref name like HEAD@<branch>)
+        #   branch non-empty              → stable release branch
+        #   neither                       → head (legacy: empty-label HEAD)
+        case "$label" in
+            nightly.*) kind="nightly" ;;
+            HEAD*)     kind="head" ;;
+            "")
+                if [ -n "$branch" ]; then
+                    kind="stable"
+                else
+                    kind="head"
+                fi
+                ;;
+            *)
+                echo "::warning::unrecognized plan label '$label'; treating as nightly" >&2
+                kind="nightly"
+                ;;
+        esac
         local is_required=1
         if [ "$kind" = "nightly" ]; then
             is_required=0
@@ -530,7 +574,7 @@ cmd_run_sequence() {
         fi
 
         probe_rc=0
-        xdbg_probe_available "$probe_mode" "$sha" || probe_rc=$?
+        xdbg_probe_available "$probe_mode" "$kind" "$sha" || probe_rc=$?
         case "$probe_rc" in
             0) ;;                                        # present (built if full)
             3)
@@ -557,7 +601,7 @@ cmd_run_sequence() {
                 ;;
         esac
 
-        run_xdbg_info "$sha" --version || true
+        run_xdbg_info "$kind" "$sha" --version || true
 
         # If the planned creator slot is still empty (e.g. earlier entries
         # were all skipped), promote this entry to creator. Only required
@@ -572,14 +616,14 @@ cmd_run_sequence() {
         local entry_rc=0
         if [ "$effective_role" = "creator" ]; then
             echo "::group::creator@${sha:0:7} setup" >&2
-            run_xdbg_real "$out_dir" "$sha" generate --entity identity -a "$n" \
+            run_xdbg_real "$out_dir" "$kind" "$sha" generate --entity identity -a "$n" \
                 || entry_rc=$?
             if [ "$entry_rc" -eq 0 ]; then
-                run_xdbg_real "$out_dir" "$sha" generate --entity group -a 1 --invite "$n" \
+                run_xdbg_real "$out_dir" "$kind" "$sha" generate --entity group -a 1 --invite "$n" \
                     || entry_rc=$?
             fi
             if [ "$entry_rc" -eq 0 ]; then
-                run_xdbg_real "$out_dir" "$sha" generate --entity message -a 1 \
+                run_xdbg_real "$out_dir" "$kind" "$sha" generate --entity message -a 1 \
                     || entry_rc=$?
             fi
             echo "::endgroup::" >&2
@@ -598,10 +642,10 @@ cmd_run_sequence() {
         else
             rand=$(( (RANDOM % 6) + 5 ))   # 5..10 inclusive
             echo "::group::sender@${sha:0:7} (${rand} msgs + change-description)" >&2
-            run_xdbg_real "$out_dir" "$sha" generate --entity group -a 1 --invite "$n" \
+            run_xdbg_real "$out_dir" "$kind" "$sha" generate --entity group -a 1 --invite "$n" \
                 || entry_rc=$?
             if [ "$entry_rc" -eq 0 ]; then
-                run_xdbg_real "$out_dir" "$sha" generate --entity message -a "$rand" --change-description \
+                run_xdbg_real "$out_dir" "$kind" "$sha" generate --entity message -a "$rand" --change-description \
                     || entry_rc=$?
             fi
             echo "::endgroup::" >&2

--- a/nix/package/cross-version-test/default.nix
+++ b/nix/package/cross-version-test/default.nix
@@ -1,0 +1,38 @@
+# Derivation that packages the cross-version-test driver as a
+# self-contained shell application with declared runtime deps. The
+# script lives alongside this file (cross-version-test.sh); this is
+# just the Nix wrapper so callers don't need to know it's bash.
+#
+# writeShellApplication runs shellcheck at build time, so a build
+# failure here means the script needs fixing before merge.
+{
+  writeShellApplication,
+  git,
+  jq,
+  coreutils,
+  gnugrep,
+  gnused,
+  gawk,
+  util-linux,
+  nix,
+}:
+writeShellApplication {
+  name = "cross-version-test";
+  runtimeInputs = [
+    git
+    jq
+    coreutils
+    gnugrep
+    gnused
+    gawk
+    util-linux # provides column(1), used in the run-sequence plan-table.
+    # `nix` itself is needed because the script invokes
+    # `nix run github:xmtp/libxmtp/<sha>#xdbg` for each version.
+    # writeShellApplication prepends runtimeInputs to PATH, so this pins a
+    # specific Nix binary; that's fine for CI and Nix-shell users (the only
+    # contexts this tool runs in), and ensures the script doesn't break if
+    # the ambient PATH lacks nix.
+    nix
+  ];
+  text = builtins.readFile ./cross-version-test.sh;
+}

--- a/nix/shells/local.nix
+++ b/nix/shells/local.nix
@@ -106,6 +106,7 @@ mkShell (
         # Misc dev
         mktemp
         diesel-cli
+        xmtp.cross-version-test
       ]
       # Wasm, cargo, CI, proto, lint tools
       ++ shellCommon.wasmTools


### PR DESCRIPTION
CI  that runs on all prs with two workflows, one testing only stable and one testing stable + nightlies. introdces `just cross-test` runner

`just cross-test` - cross test with just stable + head
`just cross test nightly` - cross test with stable + latest 3 nightlies + head
`just cross test nightly 5` - cross test with stable + latest 5 nightlies + head

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Introduce cross-version CI workflow for xdbg compatibility testing
> - Adds a new GitHub Actions workflow ([cross-version-test.yml](.github/workflows/cross-version-test.yml)) that runs on PRs, manual dispatch, and a weekly cron, testing multiple `xdbg` versions against a shared database directory
> - Adds a Nix shell script ([cross-version-test.sh](nix/package/cross-version-test/cross-version-test.sh)) with two subcommands: `pick-versions` generates a JSON plan selecting the last two stable release branches, HEAD, and optional nightly samples; `run-sequence` executes each version as creator or sender against a shared DB and produces a structured summary
> - Exposes the tool via `nix run .#cross-version-test` and includes it in the local dev shell; adds a `just cross-test` target for local use
> - Nightly failures are treated as warnings in lenient mode and hard failures in strict mode; required stable/HEAD failures always fail the run
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 512c3d1.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->