### PR TITLE
tracing to k/v store, logging for serialization failures, `--trace-openmls-kv` flag in xdbg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14001,6 +14001,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "tracing-appender",
+ "tracing-log",
  "tracing-logfmt",
  "tracing-subscriber",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10526,6 +10526,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14477,6 +14488,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "sqlite-wasm-rs",
  "sqlite-wasm-vfs",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,7 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-wasm-bindgen = "0.6.5"
 serde_bytes = "0.11"
 serde_json = { version = "1.0", default-features = false }
+serde_path_to_error = "0.1"
 # must stay on this version for compatibility with ed25519_dalek
 sha2 = "0.10.9"
 syn = { version = "2.0", features = [

--- a/apps/xmtp_debug/Cargo.toml
+++ b/apps/xmtp_debug/Cargo.toml
@@ -50,6 +50,7 @@ tokio = { workspace = true, features = ["rt-multi-thread"] }
 tokio-stream.workspace = true
 tracing = { workspace = true, features = ["valuable"] }
 tracing-appender = "0.2"
+tracing-log = "0.2"
 tracing-logfmt.workspace = true
 tracing-subscriber = { workspace = true, features = [
   "time",

--- a/apps/xmtp_debug/Cargo.toml
+++ b/apps/xmtp_debug/Cargo.toml
@@ -59,6 +59,7 @@ tracing-subscriber = { workspace = true, features = [
   "env-filter",
   "valuable",
   "ansi",
+  "tracing-log",
 ] }
 url.workspace = true
 valuable = { version = "0.1", features = ["derive"] }

--- a/apps/xmtp_debug/Cargo.toml
+++ b/apps/xmtp_debug/Cargo.toml
@@ -73,3 +73,8 @@ xmtp_id.workspace = true
 xmtp_mls.workspace = true
 xmtp_proto.workspace = true
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
+
+[features]
+default = ["deserialize-paths"]
+# Forward bincode field-path debug to xmtp_db. Runtime-gated on `openmls_kv` target enabled.
+deserialize-paths = ["xmtp_db/deserialize-paths"]

--- a/apps/xmtp_debug/src/args.rs
+++ b/apps/xmtp_debug/src/args.rs
@@ -308,6 +308,9 @@ pub struct LogOptions {
     /// Specify verbosity of logs, default ERROR
     #[command(flatten)]
     pub verbose: Verbosity<InfoLevel>,
+    /// Append `openmls_kv=trace` to file-log filter to capture SqlKeyStore K/V spans.
+    #[arg(long)]
+    pub trace_openmls_kv: bool,
 }
 
 /// Specify which backend to use

--- a/apps/xmtp_debug/src/logger.rs
+++ b/apps/xmtp_debug/src/logger.rs
@@ -19,9 +19,7 @@ use xmtp_mls::common::filter_directive;
 
 use crate::args::{LogFormat, LogOptions};
 
-/// Env var whose value is appended (comma-separated) to the file-log
-/// EnvFilter directives. Lets callers add targets like `openmls=trace`
-/// without having to override the whole filter via `RUST_LOG`.
+/// Comma-separated EnvFilter directives appended to file-log filter. Bypasses RUST_LOG override.
 const FILE_LOG_EXTRA_ENV: &str = "XDBG_FILE_LOG_EXTRA";
 
 #[derive(Default)]
@@ -32,6 +30,7 @@ pub struct Logger {
     human: bool,
     logfmt: bool,
     verbosity: Verbosity<InfoLevel>,
+    trace_openmls_kv: bool,
     guards: Vec<tracing_appender::non_blocking::WorkerGuard>,
 }
 
@@ -44,6 +43,7 @@ impl<'a> From<&'a LogOptions> for Logger {
             show_fields: options.show_fields,
             verbosity: options.verbose,
             human: options.human,
+            trace_openmls_kv: options.trace_openmls_kv,
             guards: Vec::new(),
         }
     }
@@ -58,6 +58,7 @@ impl Logger {
             human,
             logfmt,
             ref verbosity,
+            trace_openmls_kv,
             ref mut guards,
         } = *self;
 
@@ -79,8 +80,14 @@ impl Logger {
                     .parse()
                     .expect("static directive must be correct"),
             );
+            if trace_openmls_kv {
+                filter = filter.add_directive(
+                    format!("{}=trace", xmtp_configuration::OPENMLS_KV_TARGET)
+                        .parse()
+                        .expect("static directive must be correct"),
+                );
+            }
             if let Ok(extra) = std::env::var(FILE_LOG_EXTRA_ENV) {
-                println!("adding {}", extra);
                 for piece in extra.split(',').map(str::trim).filter(|s| !s.is_empty()) {
                     match piece.parse() {
                         Ok(directive) => filter = filter.add_directive(directive),
@@ -90,7 +97,6 @@ impl Logger {
                     }
                 }
             }
-            println!("full filter = {}", filter);
             filter
         };
         // capture logs as tracing events from crates which use `log` (openmls)

--- a/apps/xmtp_debug/src/logger.rs
+++ b/apps/xmtp_debug/src/logger.rs
@@ -18,6 +18,11 @@ use xmtp_mls::common::filter_directive;
 
 use crate::args::{LogFormat, LogOptions};
 
+/// Env var whose value is appended (comma-separated) to the file-log
+/// EnvFilter directives. Lets callers add targets like `openmls=trace`
+/// without having to override the whole filter via `RUST_LOG`.
+const FILE_LOG_EXTRA_ENV: &str = "XDBG_FILE_LOG_EXTRA";
+
 #[derive(Default)]
 pub struct Logger {
     log_format: LogFormat,
@@ -66,7 +71,20 @@ impl Logger {
                     .expect("filter is static")
             })
         };
-        let file_filter = || filter_directive(&verbosity.to_string());
+        let file_filter = || {
+            let mut filter = filter_directive(&verbosity.to_string());
+            if let Ok(extra) = std::env::var(FILE_LOG_EXTRA_ENV) {
+                for piece in extra.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+                    match piece.parse() {
+                        Ok(directive) => filter = filter.add_directive(directive),
+                        Err(e) => eprintln!(
+                            "warning: ignoring invalid {FILE_LOG_EXTRA_ENV} directive {piece:?}: {e}"
+                        ),
+                    }
+                }
+            }
+            filter
+        };
         let subscriber = tracing_subscriber::registry();
         let now = chrono::Local::now();
         let log_file_name = PathBuf::from(format!("./{}-xdbg", now));

--- a/apps/xmtp_debug/src/logger.rs
+++ b/apps/xmtp_debug/src/logger.rs
@@ -59,6 +59,8 @@ impl Logger {
             ref verbosity,
             ref mut guards,
         } = *self;
+        // capture logs as tracing events from crates which use `log` (openmls)
+        LogTracer::init()?;
 
         let verbosity = verbosity.tracing_level_filter();
 
@@ -74,6 +76,7 @@ impl Logger {
         let file_filter = || {
             let mut filter = filter_directive(&verbosity.to_string());
             if let Ok(extra) = std::env::var(FILE_LOG_EXTRA_ENV) {
+                println!("adding {}", extra);
                 for piece in extra.split(',').map(str::trim).filter(|s| !s.is_empty()) {
                     match piece.parse() {
                         Ok(directive) => filter = filter.add_directive(directive),
@@ -83,6 +86,7 @@ impl Logger {
                     }
                 }
             }
+            println!("full filter = {}", filter);
             filter
         };
         let subscriber = tracing_subscriber::registry();

--- a/apps/xmtp_debug/src/logger.rs
+++ b/apps/xmtp_debug/src/logger.rs
@@ -7,6 +7,7 @@ use color_eyre::eyre;
 use owo_colors::OwoColorize;
 use tracing::Dispatch;
 use tracing::{Event, Subscriber};
+use tracing_log::LogTracer;
 use tracing_subscriber::fmt::MakeWriter;
 use tracing_subscriber::{EnvFilter, prelude::*};
 use tracing_subscriber::{
@@ -59,8 +60,6 @@ impl Logger {
             ref verbosity,
             ref mut guards,
         } = *self;
-        // capture logs as tracing events from crates which use `log` (openmls)
-        LogTracer::init()?;
 
         let verbosity = verbosity.tracing_level_filter();
 
@@ -75,6 +74,11 @@ impl Logger {
         };
         let file_filter = || {
             let mut filter = filter_directive(&verbosity.to_string());
+            filter = filter.add_directive(
+                format!("openmls={verbosity}")
+                    .parse()
+                    .expect("static directive must be correct"),
+            );
             if let Ok(extra) = std::env::var(FILE_LOG_EXTRA_ENV) {
                 println!("adding {}", extra);
                 for piece in extra.split(',').map(str::trim).filter(|s| !s.is_empty()) {
@@ -89,6 +93,9 @@ impl Logger {
             println!("full filter = {}", filter);
             filter
         };
+        // capture logs as tracing events from crates which use `log` (openmls)
+        LogTracer::init()?;
+
         let subscriber = tracing_subscriber::registry();
         let now = chrono::Local::now();
         let log_file_name = PathBuf::from(format!("./{}-xdbg", now));

--- a/crates/xmtp_configuration/src/common.rs
+++ b/crates/xmtp_configuration/src/common.rs
@@ -4,6 +4,7 @@ mod db;
 mod env;
 mod metadata;
 mod mls;
+mod tracing;
 
 pub use api::*;
 pub use d14n::*;
@@ -11,3 +12,4 @@ pub use db::*;
 pub use env::*;
 pub use metadata::*;
 pub use mls::*;
+pub use tracing::*;

--- a/crates/xmtp_configuration/src/common/tracing.rs
+++ b/crates/xmtp_configuration/src/common/tracing.rs
@@ -1,0 +1,2 @@
+/// Target for `xmtp_db::sql_key_store` instrumentation. Enable via `openmls_kv=trace`.
+pub const OPENMLS_KV_TARGET: &str = "openmls_kv";

--- a/crates/xmtp_db/Cargo.toml
+++ b/crates/xmtp_db/Cargo.toml
@@ -46,6 +46,7 @@ prost.workspace = true
 rand.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+serde_path_to_error = { workspace = true, optional = true }
 thiserror.workspace = true
 toml = { workspace = true, optional = true }
 tracing.workspace = true
@@ -86,6 +87,8 @@ wasm-bindgen-test.workspace = true
 
 [features]
 update-schema = ["dep:toml"]
+# Re-decode bincode failures via serde_path_to_error to log failing field path on `openmls_kv` target.
+deserialize-paths = ["dep:serde_path_to_error"]
 test-utils = [
   "dep:futures",
   "xmtp_common/test-utils",

--- a/crates/xmtp_db/src/sql_key_store.rs
+++ b/crates/xmtp_db/src/sql_key_store.rs
@@ -373,6 +373,7 @@ where
 {
     type Error = SqlKeyStoreError;
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id), proposal_ref = %hex_kv(proposal_ref)))]
     fn queue_proposal<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ProposalRef: traits::ProposalRef<CURRENT_VERSION>,
@@ -396,6 +397,7 @@ where
         Ok(())
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
     fn write_tree<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         TreeSync: traits::TreeSync<CURRENT_VERSION>,
@@ -409,6 +411,7 @@ where
         self.write::<CURRENT_VERSION>(TREE_LABEL, &key, &value)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
     fn write_interim_transcript_hash<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         InterimTranscriptHash: traits::InterimTranscriptHash<CURRENT_VERSION>,
@@ -424,6 +427,7 @@ where
         Ok(())
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id), group_context = %hex_kv(group_context)))]
     fn write_context<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         GroupContext: traits::GroupContext<CURRENT_VERSION>,
@@ -438,6 +442,7 @@ where
         self.write::<CURRENT_VERSION>(GROUP_CONTEXT_LABEL, &key, &value)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
     fn write_confirmation_tag<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ConfirmationTag: traits::ConfirmationTag<CURRENT_VERSION>,
@@ -452,6 +457,7 @@ where
         self.write::<CURRENT_VERSION>(CONFIRMATION_TAG_LABEL, &key, &value)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(public_key = %hex_kv(public_key)))]
     fn write_signature_key_pair<
         SignaturePublicKey: traits::SignaturePublicKey<CURRENT_VERSION>,
         SignatureKeyPair: traits::SignatureKeyPair<CURRENT_VERSION>,
@@ -469,6 +475,7 @@ where
         self.write::<CURRENT_VERSION>(SIGNATURE_KEY_PAIR_LABEL, &key, &value)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
     fn queued_proposal_refs<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ProposalRef: traits::ProposalRef<CURRENT_VERSION>,
@@ -480,6 +487,7 @@ where
         self.read_list(PROPOSAL_QUEUE_REFS_LABEL, &key)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
     fn queued_proposals<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ProposalRef: traits::ProposalRef<CURRENT_VERSION>,
@@ -502,6 +510,7 @@ where
             .collect::<Result<Vec<_>, _>>()
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
     fn tree<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         TreeSync: traits::TreeSync<CURRENT_VERSION>,
@@ -514,6 +523,7 @@ where
         self.read(TREE_LABEL, &key)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
     fn group_context<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         GroupContext: traits::GroupContext<CURRENT_VERSION>,
@@ -526,6 +536,7 @@ where
         self.read(GROUP_CONTEXT_LABEL, &key)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
     fn interim_transcript_hash<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         InterimTranscriptHash: traits::InterimTranscriptHash<CURRENT_VERSION>,
@@ -538,6 +549,7 @@ where
         self.read(INTERIM_TRANSCRIPT_HASH_LABEL, &key)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
     fn confirmation_tag<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ConfirmationTag: traits::ConfirmationTag<CURRENT_VERSION>,
@@ -550,6 +562,7 @@ where
         self.read(CONFIRMATION_TAG_LABEL, &key)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(public_key = %hex_kv(public_key)))]
     fn signature_key_pair<
         SignaturePublicKey: traits::SignaturePublicKey<CURRENT_VERSION>,
         SignatureKeyPair: traits::SignatureKeyPair<CURRENT_VERSION>,
@@ -565,6 +578,7 @@ where
         self.read(SIGNATURE_KEY_PAIR_LABEL, &key)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(hash_ref = %hex_kv(hash_ref), key_package = %hex_kv(key_package)))]
     fn write_key_package<
         HashReference: traits::HashReference<CURRENT_VERSION>,
         KeyPackage: traits::KeyPackage<CURRENT_VERSION>,
@@ -580,6 +594,7 @@ where
         self.write::<CURRENT_VERSION>(KEY_PACKAGE_LABEL, &key, &value)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(_psk_id = %hex_kv(_psk_id)))]
     fn write_psk<
         PskId: traits::PskId<CURRENT_VERSION>,
         PskBundle: traits::PskBundle<CURRENT_VERSION>,
@@ -591,6 +606,7 @@ where
         Ok(())
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(public_key = %hex_kv(public_key)))]
     fn write_encryption_key_pair<
         EncryptionKey: traits::EncryptionKey<CURRENT_VERSION>,
         HpkeKeyPair: traits::HpkeKeyPair<CURRENT_VERSION>,
@@ -609,6 +625,7 @@ where
         )
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(hash_ref = %hex_kv(hash_ref)))]
     fn key_package<
         HashReference: traits::HashReference<CURRENT_VERSION>,
         KeyPackage: traits::KeyPackage<CURRENT_VERSION>,
@@ -621,6 +638,7 @@ where
         self.read(KEY_PACKAGE_LABEL, &key)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(_psk_id = %hex_kv(_psk_id)))]
     fn psk<PskBundle: traits::PskBundle<CURRENT_VERSION>, PskId: traits::PskId<CURRENT_VERSION>>(
         &self,
         _psk_id: &PskId,
@@ -628,6 +646,7 @@ where
         Ok(None)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(public_key = %hex_kv(public_key)))]
     fn encryption_key_pair<
         HpkeKeyPair: traits::HpkeKeyPair<CURRENT_VERSION>,
         EncryptionKey: traits::EncryptionKey<CURRENT_VERSION>,
@@ -641,6 +660,7 @@ where
         self.read(ENCRYPTION_KEY_PAIR_LABEL, &key)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(public_key = %hex_kv(public_key)))]
     fn delete_signature_key_pair<
         SignaturePublicKey: traits::SignaturePublicKey<CURRENT_VERSION>,
     >(
@@ -655,6 +675,7 @@ where
         self.delete::<CURRENT_VERSION>(SIGNATURE_KEY_PAIR_LABEL, &key)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(public_key = %hex_kv(public_key)))]
     fn delete_encryption_key_pair<EncryptionKey: traits::EncryptionKey<CURRENT_VERSION>>(
         &self,
         public_key: &EncryptionKey,
@@ -665,6 +686,7 @@ where
         self.delete::<CURRENT_VERSION>(ENCRYPTION_KEY_PAIR_LABEL, &key)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(hash_ref = %hex_kv(hash_ref)))]
     fn delete_key_package<HashReference: traits::HashReference<CURRENT_VERSION>>(
         &self,
         hash_ref: &HashReference,
@@ -673,6 +695,7 @@ where
         self.delete::<CURRENT_VERSION>(KEY_PACKAGE_LABEL, &key)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(_psk_id = %hex_kv(_psk_id)))]
     fn delete_psk<PskKey: traits::PskId<CURRENT_VERSION>>(
         &self,
         _psk_id: &PskKey,
@@ -680,6 +703,7 @@ where
         Err(SqlKeyStoreError::UnsupportedMethod)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
     fn group_state<
         GroupState: traits::GroupState<CURRENT_VERSION>,
         GroupId: traits::GroupId<CURRENT_VERSION>,
@@ -692,6 +716,7 @@ where
         self.read(GROUP_STATE_LABEL, &key)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
     fn write_group_state<
         GroupState: traits::GroupState<CURRENT_VERSION>,
         GroupId: traits::GroupId<CURRENT_VERSION>,
@@ -705,6 +730,7 @@ where
         self.write::<CURRENT_VERSION>(GROUP_STATE_LABEL, &key, &bincode::serialize(group_state)?)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
     fn delete_group_state<GroupId: traits::GroupId<CURRENT_VERSION>>(
         &self,
         group_id: &GroupId,
@@ -714,6 +740,7 @@ where
         self.delete::<CURRENT_VERSION>(GROUP_STATE_LABEL, &key)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
     fn message_secrets<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         MessageSecrets: traits::MessageSecrets<CURRENT_VERSION>,
@@ -726,6 +753,7 @@ where
         self.read(MESSAGE_SECRETS_LABEL, &key)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
     fn write_message_secrets<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         MessageSecrets: traits::MessageSecrets<CURRENT_VERSION>,
@@ -743,6 +771,7 @@ where
         )
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
     fn delete_message_secrets<GroupId: traits::GroupId<CURRENT_VERSION>>(
         &self,
         group_id: &GroupId,
@@ -752,6 +781,7 @@ where
         self.delete::<CURRENT_VERSION>(MESSAGE_SECRETS_LABEL, &key)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
     fn resumption_psk_store<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ResumptionPskStore: traits::ResumptionPskStore<CURRENT_VERSION>,
@@ -762,6 +792,7 @@ where
         self.read(RESUMPTION_PSK_STORE_LABEL, &bincode::serialize(group_id)?)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
     fn write_resumption_psk_store<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ResumptionPskStore: traits::ResumptionPskStore<CURRENT_VERSION>,
@@ -777,6 +808,7 @@ where
         )
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
     fn delete_all_resumption_psk_secrets<GroupId: traits::GroupId<CURRENT_VERSION>>(
         &self,
         group_id: &GroupId,
@@ -784,6 +816,7 @@ where
         self.delete::<CURRENT_VERSION>(RESUMPTION_PSK_STORE_LABEL, &bincode::serialize(group_id)?)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
     fn own_leaf_index<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         LeafNodeIndex: traits::LeafNodeIndex<CURRENT_VERSION>,
@@ -795,6 +828,7 @@ where
         self.read(OWN_LEAF_NODE_INDEX_LABEL, &key)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id), own_leaf_index = %hex_kv(own_leaf_index)))]
     fn write_own_leaf_index<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         LeafNodeIndex: traits::LeafNodeIndex<CURRENT_VERSION>,
@@ -811,6 +845,7 @@ where
         )
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
     fn delete_own_leaf_index<GroupId: traits::GroupId<CURRENT_VERSION>>(
         &self,
         group_id: &GroupId,
@@ -819,6 +854,7 @@ where
         self.delete::<CURRENT_VERSION>(OWN_LEAF_NODE_INDEX_LABEL, &key)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
     fn group_epoch_secrets<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         GroupEpochSecrets: traits::GroupEpochSecrets<CURRENT_VERSION>,
@@ -830,6 +866,7 @@ where
         self.read(EPOCH_SECRETS_LABEL, &key)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
     fn write_group_epoch_secrets<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         GroupEpochSecrets: traits::GroupEpochSecrets<CURRENT_VERSION>,
@@ -846,6 +883,7 @@ where
         )
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
     fn delete_group_epoch_secrets<GroupId: traits::GroupId<CURRENT_VERSION>>(
         &self,
         group_id: &GroupId,
@@ -854,6 +892,7 @@ where
         self.delete::<CURRENT_VERSION>(EPOCH_SECRETS_LABEL, &key)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id), epoch = %hex_kv(epoch), leaf_index = %leaf_index))]
     fn write_encryption_epoch_key_pairs<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         EpochKey: traits::EpochKey<CURRENT_VERSION>,
@@ -872,6 +911,7 @@ where
         self.write::<CURRENT_VERSION>(EPOCH_KEY_PAIRS_LABEL, &key, &value)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id), epoch = %hex_kv(epoch), leaf_index = %leaf_index))]
     fn encryption_epoch_key_pairs<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         EpochKey: traits::EpochKey<CURRENT_VERSION>,
@@ -910,6 +950,7 @@ where
         }
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id), epoch = %hex_kv(epoch), leaf_index = %leaf_index))]
     fn delete_encryption_epoch_key_pairs<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         EpochKey: traits::EpochKey<CURRENT_VERSION>,
@@ -924,6 +965,7 @@ where
         self.delete::<CURRENT_VERSION>(EPOCH_KEY_PAIRS_LABEL, &key)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
     fn clear_proposal_queue<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ProposalRef: traits::ProposalRef<CURRENT_VERSION>,
@@ -944,6 +986,7 @@ where
         self.delete::<CURRENT_VERSION>(PROPOSAL_QUEUE_REFS_LABEL, &key)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
     fn mls_group_join_config<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         MlsGroupJoinConfig: traits::MlsGroupJoinConfig<CURRENT_VERSION>,
@@ -956,6 +999,7 @@ where
         self.read(JOIN_CONFIG_LABEL, &key)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id), config = %hex_kv(config)))]
     fn write_mls_join_config<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         MlsGroupJoinConfig: traits::MlsGroupJoinConfig<CURRENT_VERSION>,
@@ -970,6 +1014,7 @@ where
         self.write::<CURRENT_VERSION>(JOIN_CONFIG_LABEL, &key, &value)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
     fn own_leaf_nodes<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         LeafNode: traits::LeafNode<CURRENT_VERSION>,
@@ -983,6 +1028,7 @@ where
         self.read_list(OWN_LEAF_NODES_LABEL, &key)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id), leaf_node = %hex_kv(leaf_node)))]
     fn append_own_leaf_node<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         LeafNode: traits::LeafNode<CURRENT_VERSION>,
@@ -997,6 +1043,7 @@ where
         self.append::<CURRENT_VERSION>(OWN_LEAF_NODES_LABEL, &key, &value)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
     fn delete_own_leaf_nodes<GroupId: traits::GroupId<CURRENT_VERSION>>(
         &self,
         group_id: &GroupId,
@@ -1005,6 +1052,7 @@ where
         self.delete::<CURRENT_VERSION>(OWN_LEAF_NODES_LABEL, &key)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
     fn delete_group_config<GroupId: traits::GroupId<CURRENT_VERSION>>(
         &self,
         group_id: &GroupId,
@@ -1013,6 +1061,7 @@ where
         self.delete::<CURRENT_VERSION>(JOIN_CONFIG_LABEL, &key)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
     fn delete_tree<GroupId: traits::GroupId<CURRENT_VERSION>>(
         &self,
         group_id: &GroupId,
@@ -1022,6 +1071,7 @@ where
         self.delete::<CURRENT_VERSION>(TREE_LABEL, &key)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
     fn delete_confirmation_tag<GroupId: traits::GroupId<CURRENT_VERSION>>(
         &self,
         group_id: &GroupId,
@@ -1031,6 +1081,7 @@ where
         self.delete::<CURRENT_VERSION>(CONFIRMATION_TAG_LABEL, &key)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
     fn delete_context<GroupId: traits::GroupId<CURRENT_VERSION>>(
         &self,
         group_id: &GroupId,
@@ -1040,6 +1091,7 @@ where
         self.delete::<CURRENT_VERSION>(GROUP_CONTEXT_LABEL, &key)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
     fn delete_interim_transcript_hash<GroupId: traits::GroupId<CURRENT_VERSION>>(
         &self,
         group_id: &GroupId,
@@ -1049,6 +1101,7 @@ where
         self.delete::<CURRENT_VERSION>(INTERIM_TRANSCRIPT_HASH_LABEL, &key)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id), proposal_ref = %hex_kv(proposal_ref)))]
     fn remove_proposal<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ProposalRef: traits::ProposalRef<CURRENT_VERSION>,
@@ -1067,6 +1120,7 @@ where
         self.delete::<CURRENT_VERSION>(QUEUED_PROPOSAL_LABEL, &key)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
     fn write_application_export_tree<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ApplicationExportTree: traits::ApplicationExportTree<CURRENT_VERSION>,
@@ -1083,6 +1137,7 @@ where
         )
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
     fn application_export_tree<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ApplicationExportTree: traits::ApplicationExportTree<CURRENT_VERSION>,
@@ -1094,6 +1149,7 @@ where
         self.read(APPLICATION_EXPORT_TREE_LABEL, &key)
     }
 
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
     fn delete_application_export_tree<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ApplicationExportTree: traits::ApplicationExportTree<CURRENT_VERSION>,
@@ -1104,6 +1160,13 @@ where
         let key = build_key::<CURRENT_VERSION, &GroupId>(APPLICATION_EXPORT_TREE_LABEL, group_id)?;
         self.delete::<CURRENT_VERSION>(APPLICATION_EXPORT_TREE_LABEL, &key)
     }
+}
+
+/// Hex-encode a Serialize-able value for use as a `tracing` field. Returns
+/// an empty string on serialization failure rather than propagating an
+/// error, since tracing field expressions can't fail.
+fn hex_kv<T: Serialize + ?Sized>(v: &T) -> String {
+    bincode::serialize(v).map(hex::encode).unwrap_or_default()
 }
 
 /// Build a key with version and label.

--- a/crates/xmtp_db/src/sql_key_store.rs
+++ b/crates/xmtp_db/src/sql_key_store.rs
@@ -11,6 +11,7 @@ use diesel::{
 };
 use openmls_traits::storage::*;
 use serde::Serialize;
+use xmtp_configuration::OPENMLS_KV_TARGET;
 
 #[cfg(any(feature = "test-utils", test))]
 pub mod mock;
@@ -171,16 +172,11 @@ where
 
         if let Some(entry) = data.into_iter().next() {
             // The value in the storage is an array of array of bytes
-            match bincode::deserialize::<Vec<Vec<u8>>>(&entry.value_bytes) {
-                Ok(mut deserialized) => {
-                    deserialized.push(value.to_vec());
-                    let modified_data = bincode::serialize(&deserialized)?;
-
-                    let _ = self.update_query::<VERSION>(&storage_key, &modified_data)?;
-                    Ok(())
-                }
-                Err(_e) => Err(SqlKeyStoreError::SerializationError),
-            }
+            let mut deserialized = deserialize_bincode::<Vec<Vec<u8>>>(label, &entry.value_bytes)?;
+            deserialized.push(value.to_vec());
+            let modified_data = bincode::serialize(&deserialized)?;
+            let _ = self.update_query::<VERSION>(&storage_key, &modified_data)?;
+            Ok(())
         } else {
             // Add a first entry
             let value_bytes = &bincode::serialize(&vec![value])?;
@@ -203,8 +199,7 @@ where
 
         if let Some(entry) = data.into_iter().next() {
             // The value in the storage is an array of array of bytes.
-            let mut deserialized = bincode::deserialize::<Vec<Vec<u8>>>(&entry.value_bytes)
-                .map_err(|_| SqlKeyStoreError::SerializationError)?;
+            let mut deserialized = deserialize_bincode::<Vec<Vec<u8>>>(label, &entry.value_bytes)?;
             let vpos = deserialized.iter().position(|v| v == value);
 
             if let Some(pos) = vpos {
@@ -234,8 +229,7 @@ where
         let data = self.select_query::<VERSION>(&storage_key)?;
 
         if let Some(entry) = data.into_iter().next() {
-            let deserialized = bincode::deserialize::<V>(&entry.value_bytes)
-                .map_err(|_| SqlKeyStoreError::SerializationError)?;
+            let deserialized = deserialize_bincode::<V>(label, &entry.value_bytes)?;
 
             Ok(Some(deserialized))
         } else {
@@ -252,18 +246,12 @@ where
         let results = self.select_query::<VERSION>(&storage_key)?;
 
         if let Some(entry) = results.into_iter().next() {
-            let list = bincode::deserialize::<Vec<Vec<u8>>>(&entry.value_bytes)?;
+            let list = deserialize_bincode::<Vec<Vec<u8>>>(label, &entry.value_bytes)?;
 
             // Read the values from the bytes in the list
-            let mut deserialized_list = Vec::new();
+            let mut deserialized_list = Vec::with_capacity(list.len());
             for v in list {
-                match bincode::deserialize::<V>(&v) {
-                    Ok(deserialized_value) => deserialized_list.push(deserialized_value),
-                    Err(e) => {
-                        tracing::error!("Error occurred: {}", e);
-                        return Err(SqlKeyStoreError::SerializationError);
-                    }
-                }
+                deserialized_list.push(deserialize_bincode::<V>(label, &v)?);
             }
             Ok(deserialized_list)
         } else {
@@ -373,7 +361,7 @@ where
 {
     type Error = SqlKeyStoreError;
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id), proposal_ref = %hex_kv(proposal_ref)), ret, err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id), proposal_ref = %hex_kv(proposal_ref)), err)]
     fn queue_proposal<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ProposalRef: traits::ProposalRef<CURRENT_VERSION>,
@@ -397,7 +385,7 @@ where
         Ok(())
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id)), err)]
     fn write_tree<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         TreeSync: traits::TreeSync<CURRENT_VERSION>,
@@ -411,7 +399,7 @@ where
         self.write::<CURRENT_VERSION>(TREE_LABEL, &key, &value)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id)), err)]
     fn write_interim_transcript_hash<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         InterimTranscriptHash: traits::InterimTranscriptHash<CURRENT_VERSION>,
@@ -427,7 +415,7 @@ where
         Ok(())
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id), group_context = %hex_kv(group_context)), ret, err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id), group_context = %hex_kv(group_context)), err)]
     fn write_context<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         GroupContext: traits::GroupContext<CURRENT_VERSION>,
@@ -442,7 +430,7 @@ where
         self.write::<CURRENT_VERSION>(GROUP_CONTEXT_LABEL, &key, &value)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id)), err)]
     fn write_confirmation_tag<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ConfirmationTag: traits::ConfirmationTag<CURRENT_VERSION>,
@@ -457,7 +445,7 @@ where
         self.write::<CURRENT_VERSION>(CONFIRMATION_TAG_LABEL, &key, &value)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(public_key = %hex_kv(public_key)), ret, err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(public_key = %hex_kv(public_key)), err)]
     fn write_signature_key_pair<
         SignaturePublicKey: traits::SignaturePublicKey<CURRENT_VERSION>,
         SignatureKeyPair: traits::SignatureKeyPair<CURRENT_VERSION>,
@@ -475,7 +463,7 @@ where
         self.write::<CURRENT_VERSION>(SIGNATURE_KEY_PAIR_LABEL, &key, &value)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id)), err)]
     fn queued_proposal_refs<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ProposalRef: traits::ProposalRef<CURRENT_VERSION>,
@@ -487,7 +475,7 @@ where
         self.read_list(PROPOSAL_QUEUE_REFS_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id)), err)]
     fn queued_proposals<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ProposalRef: traits::ProposalRef<CURRENT_VERSION>,
@@ -510,7 +498,7 @@ where
             .collect::<Result<Vec<_>, _>>()
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id)), err)]
     fn tree<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         TreeSync: traits::TreeSync<CURRENT_VERSION>,
@@ -523,7 +511,7 @@ where
         self.read(TREE_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id)), err)]
     fn group_context<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         GroupContext: traits::GroupContext<CURRENT_VERSION>,
@@ -536,7 +524,7 @@ where
         self.read(GROUP_CONTEXT_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id)), err)]
     fn interim_transcript_hash<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         InterimTranscriptHash: traits::InterimTranscriptHash<CURRENT_VERSION>,
@@ -549,7 +537,7 @@ where
         self.read(INTERIM_TRANSCRIPT_HASH_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id)), err)]
     fn confirmation_tag<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ConfirmationTag: traits::ConfirmationTag<CURRENT_VERSION>,
@@ -562,7 +550,7 @@ where
         self.read(CONFIRMATION_TAG_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(public_key = %hex_kv(public_key)), err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(public_key = %hex_kv(public_key)), err)]
     fn signature_key_pair<
         SignaturePublicKey: traits::SignaturePublicKey<CURRENT_VERSION>,
         SignatureKeyPair: traits::SignatureKeyPair<CURRENT_VERSION>,
@@ -578,7 +566,7 @@ where
         self.read(SIGNATURE_KEY_PAIR_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(hash_ref = %hex_kv(hash_ref), key_package = %hex_kv(key_package)), ret, err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(hash_ref = %hex_kv(hash_ref), key_package = %hex_kv(key_package)), err)]
     fn write_key_package<
         HashReference: traits::HashReference<CURRENT_VERSION>,
         KeyPackage: traits::KeyPackage<CURRENT_VERSION>,
@@ -594,7 +582,7 @@ where
         self.write::<CURRENT_VERSION>(KEY_PACKAGE_LABEL, &key, &value)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(_psk_id = %hex_kv(_psk_id)), ret, err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(_psk_id = %hex_kv(_psk_id)), err)]
     fn write_psk<
         PskId: traits::PskId<CURRENT_VERSION>,
         PskBundle: traits::PskBundle<CURRENT_VERSION>,
@@ -606,7 +594,7 @@ where
         Ok(())
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(public_key = %hex_kv(public_key)), ret, err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(public_key = %hex_kv(public_key)), err)]
     fn write_encryption_key_pair<
         EncryptionKey: traits::EncryptionKey<CURRENT_VERSION>,
         HpkeKeyPair: traits::HpkeKeyPair<CURRENT_VERSION>,
@@ -625,7 +613,7 @@ where
         )
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(hash_ref = %hex_kv(hash_ref)), err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(hash_ref = %hex_kv(hash_ref)), err)]
     fn key_package<
         HashReference: traits::HashReference<CURRENT_VERSION>,
         KeyPackage: traits::KeyPackage<CURRENT_VERSION>,
@@ -638,7 +626,7 @@ where
         self.read(KEY_PACKAGE_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(_psk_id = %hex_kv(_psk_id)), err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(_psk_id = %hex_kv(_psk_id)), err)]
     fn psk<PskBundle: traits::PskBundle<CURRENT_VERSION>, PskId: traits::PskId<CURRENT_VERSION>>(
         &self,
         _psk_id: &PskId,
@@ -646,7 +634,7 @@ where
         Ok(None)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(public_key = %hex_kv(public_key)), err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(public_key = %hex_kv(public_key)), err)]
     fn encryption_key_pair<
         HpkeKeyPair: traits::HpkeKeyPair<CURRENT_VERSION>,
         EncryptionKey: traits::EncryptionKey<CURRENT_VERSION>,
@@ -660,7 +648,7 @@ where
         self.read(ENCRYPTION_KEY_PAIR_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(public_key = %hex_kv(public_key)), ret, err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(public_key = %hex_kv(public_key)), err)]
     fn delete_signature_key_pair<
         SignaturePublicKey: traits::SignaturePublicKey<CURRENT_VERSION>,
     >(
@@ -675,7 +663,7 @@ where
         self.delete::<CURRENT_VERSION>(SIGNATURE_KEY_PAIR_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(public_key = %hex_kv(public_key)), ret, err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(public_key = %hex_kv(public_key)), err)]
     fn delete_encryption_key_pair<EncryptionKey: traits::EncryptionKey<CURRENT_VERSION>>(
         &self,
         public_key: &EncryptionKey,
@@ -686,7 +674,7 @@ where
         self.delete::<CURRENT_VERSION>(ENCRYPTION_KEY_PAIR_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(hash_ref = %hex_kv(hash_ref)), ret, err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(hash_ref = %hex_kv(hash_ref)), err)]
     fn delete_key_package<HashReference: traits::HashReference<CURRENT_VERSION>>(
         &self,
         hash_ref: &HashReference,
@@ -695,7 +683,7 @@ where
         self.delete::<CURRENT_VERSION>(KEY_PACKAGE_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(_psk_id = %hex_kv(_psk_id)), ret, err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(_psk_id = %hex_kv(_psk_id)), err)]
     fn delete_psk<PskKey: traits::PskId<CURRENT_VERSION>>(
         &self,
         _psk_id: &PskKey,
@@ -703,7 +691,7 @@ where
         Err(SqlKeyStoreError::UnsupportedMethod)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id)), err)]
     fn group_state<
         GroupState: traits::GroupState<CURRENT_VERSION>,
         GroupId: traits::GroupId<CURRENT_VERSION>,
@@ -716,7 +704,7 @@ where
         self.read(GROUP_STATE_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id)), err)]
     fn write_group_state<
         GroupState: traits::GroupState<CURRENT_VERSION>,
         GroupId: traits::GroupId<CURRENT_VERSION>,
@@ -730,7 +718,7 @@ where
         self.write::<CURRENT_VERSION>(GROUP_STATE_LABEL, &key, &bincode::serialize(group_state)?)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id)), err)]
     fn delete_group_state<GroupId: traits::GroupId<CURRENT_VERSION>>(
         &self,
         group_id: &GroupId,
@@ -740,7 +728,7 @@ where
         self.delete::<CURRENT_VERSION>(GROUP_STATE_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id)), err)]
     fn message_secrets<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         MessageSecrets: traits::MessageSecrets<CURRENT_VERSION>,
@@ -753,7 +741,7 @@ where
         self.read(MESSAGE_SECRETS_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id)), err)]
     fn write_message_secrets<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         MessageSecrets: traits::MessageSecrets<CURRENT_VERSION>,
@@ -771,7 +759,7 @@ where
         )
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id)), err)]
     fn delete_message_secrets<GroupId: traits::GroupId<CURRENT_VERSION>>(
         &self,
         group_id: &GroupId,
@@ -781,7 +769,7 @@ where
         self.delete::<CURRENT_VERSION>(MESSAGE_SECRETS_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id)), err)]
     fn resumption_psk_store<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ResumptionPskStore: traits::ResumptionPskStore<CURRENT_VERSION>,
@@ -792,7 +780,7 @@ where
         self.read(RESUMPTION_PSK_STORE_LABEL, &bincode::serialize(group_id)?)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id)), err)]
     fn write_resumption_psk_store<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ResumptionPskStore: traits::ResumptionPskStore<CURRENT_VERSION>,
@@ -808,7 +796,7 @@ where
         )
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id)), err)]
     fn delete_all_resumption_psk_secrets<GroupId: traits::GroupId<CURRENT_VERSION>>(
         &self,
         group_id: &GroupId,
@@ -816,7 +804,7 @@ where
         self.delete::<CURRENT_VERSION>(RESUMPTION_PSK_STORE_LABEL, &bincode::serialize(group_id)?)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id)), err)]
     fn own_leaf_index<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         LeafNodeIndex: traits::LeafNodeIndex<CURRENT_VERSION>,
@@ -828,7 +816,7 @@ where
         self.read(OWN_LEAF_NODE_INDEX_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id), own_leaf_index = %hex_kv(own_leaf_index)), ret, err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id), own_leaf_index = %hex_kv(own_leaf_index)), err)]
     fn write_own_leaf_index<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         LeafNodeIndex: traits::LeafNodeIndex<CURRENT_VERSION>,
@@ -845,7 +833,7 @@ where
         )
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id)), err)]
     fn delete_own_leaf_index<GroupId: traits::GroupId<CURRENT_VERSION>>(
         &self,
         group_id: &GroupId,
@@ -854,7 +842,7 @@ where
         self.delete::<CURRENT_VERSION>(OWN_LEAF_NODE_INDEX_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id)), err)]
     fn group_epoch_secrets<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         GroupEpochSecrets: traits::GroupEpochSecrets<CURRENT_VERSION>,
@@ -866,7 +854,7 @@ where
         self.read(EPOCH_SECRETS_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id)), err)]
     fn write_group_epoch_secrets<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         GroupEpochSecrets: traits::GroupEpochSecrets<CURRENT_VERSION>,
@@ -883,7 +871,7 @@ where
         )
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id)), err)]
     fn delete_group_epoch_secrets<GroupId: traits::GroupId<CURRENT_VERSION>>(
         &self,
         group_id: &GroupId,
@@ -892,7 +880,7 @@ where
         self.delete::<CURRENT_VERSION>(EPOCH_SECRETS_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id), epoch = %hex_kv(epoch), leaf_index = %leaf_index), ret, err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id), epoch = %hex_kv(epoch), leaf_index = %leaf_index), err)]
     fn write_encryption_epoch_key_pairs<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         EpochKey: traits::EpochKey<CURRENT_VERSION>,
@@ -911,7 +899,7 @@ where
         self.write::<CURRENT_VERSION>(EPOCH_KEY_PAIRS_LABEL, &key, &value)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id), epoch = %hex_kv(epoch), leaf_index = %leaf_index), err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id), epoch = %hex_kv(epoch), leaf_index = %leaf_index), err)]
     fn encryption_epoch_key_pairs<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         EpochKey: traits::EpochKey<CURRENT_VERSION>,
@@ -938,19 +926,13 @@ where
         })?;
 
         if let Some(entry) = data.into_iter().next() {
-            match bincode::deserialize::<Vec<HpkeKeyPair>>(&entry.value_bytes) {
-                Ok(deserialized) => Ok(deserialized),
-                Err(e) => {
-                    eprintln!("Error occurred: {}", e);
-                    Err(SqlKeyStoreError::SerializationError)
-                }
-            }
+            deserialize_bincode::<Vec<HpkeKeyPair>>(EPOCH_KEY_PAIRS_LABEL, &entry.value_bytes)
         } else {
             Ok(vec![])
         }
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id), epoch = %hex_kv(epoch), leaf_index = %leaf_index), ret, err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id), epoch = %hex_kv(epoch), leaf_index = %leaf_index), err)]
     fn delete_encryption_epoch_key_pairs<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         EpochKey: traits::EpochKey<CURRENT_VERSION>,
@@ -965,7 +947,7 @@ where
         self.delete::<CURRENT_VERSION>(EPOCH_KEY_PAIRS_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id)), err)]
     fn clear_proposal_queue<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ProposalRef: traits::ProposalRef<CURRENT_VERSION>,
@@ -986,7 +968,7 @@ where
         self.delete::<CURRENT_VERSION>(PROPOSAL_QUEUE_REFS_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id)), err)]
     fn mls_group_join_config<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         MlsGroupJoinConfig: traits::MlsGroupJoinConfig<CURRENT_VERSION>,
@@ -999,7 +981,7 @@ where
         self.read(JOIN_CONFIG_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id), config = %hex_kv(config)), ret, err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id), config = %hex_kv(config)), err)]
     fn write_mls_join_config<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         MlsGroupJoinConfig: traits::MlsGroupJoinConfig<CURRENT_VERSION>,
@@ -1014,7 +996,7 @@ where
         self.write::<CURRENT_VERSION>(JOIN_CONFIG_LABEL, &key, &value)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id)), err)]
     fn own_leaf_nodes<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         LeafNode: traits::LeafNode<CURRENT_VERSION>,
@@ -1028,7 +1010,7 @@ where
         self.read_list(OWN_LEAF_NODES_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id), leaf_node = %hex_kv(leaf_node)), ret, err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id), leaf_node = %hex_kv(leaf_node)), err)]
     fn append_own_leaf_node<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         LeafNode: traits::LeafNode<CURRENT_VERSION>,
@@ -1043,7 +1025,7 @@ where
         self.append::<CURRENT_VERSION>(OWN_LEAF_NODES_LABEL, &key, &value)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id)), err)]
     fn delete_own_leaf_nodes<GroupId: traits::GroupId<CURRENT_VERSION>>(
         &self,
         group_id: &GroupId,
@@ -1052,7 +1034,7 @@ where
         self.delete::<CURRENT_VERSION>(OWN_LEAF_NODES_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id)), err)]
     fn delete_group_config<GroupId: traits::GroupId<CURRENT_VERSION>>(
         &self,
         group_id: &GroupId,
@@ -1061,7 +1043,7 @@ where
         self.delete::<CURRENT_VERSION>(JOIN_CONFIG_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id)), err)]
     fn delete_tree<GroupId: traits::GroupId<CURRENT_VERSION>>(
         &self,
         group_id: &GroupId,
@@ -1071,7 +1053,7 @@ where
         self.delete::<CURRENT_VERSION>(TREE_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id)), err)]
     fn delete_confirmation_tag<GroupId: traits::GroupId<CURRENT_VERSION>>(
         &self,
         group_id: &GroupId,
@@ -1081,7 +1063,7 @@ where
         self.delete::<CURRENT_VERSION>(CONFIRMATION_TAG_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id)), err)]
     fn delete_context<GroupId: traits::GroupId<CURRENT_VERSION>>(
         &self,
         group_id: &GroupId,
@@ -1091,7 +1073,7 @@ where
         self.delete::<CURRENT_VERSION>(GROUP_CONTEXT_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id)), err)]
     fn delete_interim_transcript_hash<GroupId: traits::GroupId<CURRENT_VERSION>>(
         &self,
         group_id: &GroupId,
@@ -1101,7 +1083,7 @@ where
         self.delete::<CURRENT_VERSION>(INTERIM_TRANSCRIPT_HASH_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id), proposal_ref = %hex_kv(proposal_ref)), ret, err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id), proposal_ref = %hex_kv(proposal_ref)), err)]
     fn remove_proposal<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ProposalRef: traits::ProposalRef<CURRENT_VERSION>,
@@ -1120,7 +1102,7 @@ where
         self.delete::<CURRENT_VERSION>(QUEUED_PROPOSAL_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id)), err)]
     fn write_application_export_tree<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ApplicationExportTree: traits::ApplicationExportTree<CURRENT_VERSION>,
@@ -1137,7 +1119,7 @@ where
         )
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id)), err)]
     fn application_export_tree<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ApplicationExportTree: traits::ApplicationExportTree<CURRENT_VERSION>,
@@ -1149,7 +1131,7 @@ where
         self.read(APPLICATION_EXPORT_TREE_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
+    #[tracing::instrument(skip_all, target = OPENMLS_KV_TARGET, fields(group_id = %hex_kv(group_id)), err)]
     fn delete_application_export_tree<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ApplicationExportTree: traits::ApplicationExportTree<CURRENT_VERSION>,
@@ -1162,9 +1144,7 @@ where
     }
 }
 
-/// Hex-encode a Serialize-able value for use as a `tracing` field. Returns
-/// an empty string on serialization failure rather than propagating an
-/// error, since tracing field expressions can't fail.
+/// Hex bincode of `v` for tracing fields. Empty string on serialize fail (field exprs can't propagate).
 fn hex_kv<T: Serialize + ?Sized>(v: &T) -> String {
     bincode::serialize(v).map(hex::encode).unwrap_or_default()
 }
@@ -1184,6 +1164,57 @@ fn build_key<const V: u16, K: Serialize>(
 ) -> Result<Vec<u8>, SqlKeyStoreError> {
     let key_vec = bincode::serialize(&key)?;
     Ok(build_key_from_vec::<V>(label, key_vec))
+}
+
+/// Bincode decode → `SerializationError`. With `deserialize-paths` feature + `openmls_kv` target
+/// enabled, error path re-decodes via `serde_path_to_error` to log failing field path.
+fn deserialize_bincode<'de, T>(
+    #[cfg_attr(not(feature = "deserialize-paths"), allow(unused_variables))] label: &[u8],
+    bytes: &'de [u8],
+) -> Result<T, SqlKeyStoreError>
+where
+    T: serde::Deserialize<'de>,
+{
+    match bincode::deserialize::<T>(bytes) {
+        Ok(val) => Ok(val),
+        Err(_orig_err) => {
+            #[cfg(feature = "deserialize-paths")]
+            if tracing::event_enabled!(target: OPENMLS_KV_TARGET, tracing::Level::ERROR) {
+                use bincode::Options;
+                let opts = bincode::DefaultOptions::new()
+                    .with_fixint_encoding()
+                    .allow_trailing_bytes();
+                let mut de = bincode::de::Deserializer::from_slice(bytes, opts);
+                match serde_path_to_error::deserialize::<_, T>(&mut de) {
+                    Ok(_) => {
+                        // Second pass succeeded — bincode option mismatch; log err without path.
+                        tracing::error!(
+                            target: OPENMLS_KV_TARGET,
+                            label = %String::from_utf8_lossy(label),
+                            type_name = std::any::type_name::<T>(),
+                            bytes_len = bytes.len(),
+                            err = %_orig_err,
+                            "bincode deserialize failed (no path captured)",
+                        );
+                    }
+                    Err(e) => {
+                        let path = e.path().to_string();
+                        let inner = e.into_inner();
+                        tracing::error!(
+                            target: OPENMLS_KV_TARGET,
+                            label = %String::from_utf8_lossy(label),
+                            path = %path,
+                            type_name = std::any::type_name::<T>(),
+                            bytes_len = bytes.len(),
+                            err = %inner,
+                            "bincode deserialize failed",
+                        );
+                    }
+                }
+            }
+            Err(SqlKeyStoreError::SerializationError)
+        }
+    }
 }
 
 fn epoch_key_pairs_id(

--- a/crates/xmtp_db/src/sql_key_store.rs
+++ b/crates/xmtp_db/src/sql_key_store.rs
@@ -373,7 +373,7 @@ where
 {
     type Error = SqlKeyStoreError;
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id), proposal_ref = %hex_kv(proposal_ref)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id), proposal_ref = %hex_kv(proposal_ref)), ret, err)]
     fn queue_proposal<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ProposalRef: traits::ProposalRef<CURRENT_VERSION>,
@@ -397,7 +397,7 @@ where
         Ok(())
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
     fn write_tree<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         TreeSync: traits::TreeSync<CURRENT_VERSION>,
@@ -411,7 +411,7 @@ where
         self.write::<CURRENT_VERSION>(TREE_LABEL, &key, &value)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
     fn write_interim_transcript_hash<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         InterimTranscriptHash: traits::InterimTranscriptHash<CURRENT_VERSION>,
@@ -427,7 +427,7 @@ where
         Ok(())
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id), group_context = %hex_kv(group_context)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id), group_context = %hex_kv(group_context)), ret, err)]
     fn write_context<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         GroupContext: traits::GroupContext<CURRENT_VERSION>,
@@ -442,7 +442,7 @@ where
         self.write::<CURRENT_VERSION>(GROUP_CONTEXT_LABEL, &key, &value)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
     fn write_confirmation_tag<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ConfirmationTag: traits::ConfirmationTag<CURRENT_VERSION>,
@@ -457,7 +457,7 @@ where
         self.write::<CURRENT_VERSION>(CONFIRMATION_TAG_LABEL, &key, &value)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(public_key = %hex_kv(public_key)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(public_key = %hex_kv(public_key)), ret, err)]
     fn write_signature_key_pair<
         SignaturePublicKey: traits::SignaturePublicKey<CURRENT_VERSION>,
         SignatureKeyPair: traits::SignatureKeyPair<CURRENT_VERSION>,
@@ -475,7 +475,7 @@ where
         self.write::<CURRENT_VERSION>(SIGNATURE_KEY_PAIR_LABEL, &key, &value)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), err)]
     fn queued_proposal_refs<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ProposalRef: traits::ProposalRef<CURRENT_VERSION>,
@@ -487,7 +487,7 @@ where
         self.read_list(PROPOSAL_QUEUE_REFS_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), err)]
     fn queued_proposals<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ProposalRef: traits::ProposalRef<CURRENT_VERSION>,
@@ -510,7 +510,7 @@ where
             .collect::<Result<Vec<_>, _>>()
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), err)]
     fn tree<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         TreeSync: traits::TreeSync<CURRENT_VERSION>,
@@ -523,7 +523,7 @@ where
         self.read(TREE_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), err)]
     fn group_context<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         GroupContext: traits::GroupContext<CURRENT_VERSION>,
@@ -536,7 +536,7 @@ where
         self.read(GROUP_CONTEXT_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), err)]
     fn interim_transcript_hash<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         InterimTranscriptHash: traits::InterimTranscriptHash<CURRENT_VERSION>,
@@ -549,7 +549,7 @@ where
         self.read(INTERIM_TRANSCRIPT_HASH_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), err)]
     fn confirmation_tag<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ConfirmationTag: traits::ConfirmationTag<CURRENT_VERSION>,
@@ -562,7 +562,7 @@ where
         self.read(CONFIRMATION_TAG_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(public_key = %hex_kv(public_key)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(public_key = %hex_kv(public_key)), err)]
     fn signature_key_pair<
         SignaturePublicKey: traits::SignaturePublicKey<CURRENT_VERSION>,
         SignatureKeyPair: traits::SignatureKeyPair<CURRENT_VERSION>,
@@ -578,7 +578,7 @@ where
         self.read(SIGNATURE_KEY_PAIR_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(hash_ref = %hex_kv(hash_ref), key_package = %hex_kv(key_package)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(hash_ref = %hex_kv(hash_ref), key_package = %hex_kv(key_package)), ret, err)]
     fn write_key_package<
         HashReference: traits::HashReference<CURRENT_VERSION>,
         KeyPackage: traits::KeyPackage<CURRENT_VERSION>,
@@ -594,7 +594,7 @@ where
         self.write::<CURRENT_VERSION>(KEY_PACKAGE_LABEL, &key, &value)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(_psk_id = %hex_kv(_psk_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(_psk_id = %hex_kv(_psk_id)), ret, err)]
     fn write_psk<
         PskId: traits::PskId<CURRENT_VERSION>,
         PskBundle: traits::PskBundle<CURRENT_VERSION>,
@@ -606,7 +606,7 @@ where
         Ok(())
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(public_key = %hex_kv(public_key)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(public_key = %hex_kv(public_key)), ret, err)]
     fn write_encryption_key_pair<
         EncryptionKey: traits::EncryptionKey<CURRENT_VERSION>,
         HpkeKeyPair: traits::HpkeKeyPair<CURRENT_VERSION>,
@@ -625,7 +625,7 @@ where
         )
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(hash_ref = %hex_kv(hash_ref)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(hash_ref = %hex_kv(hash_ref)), err)]
     fn key_package<
         HashReference: traits::HashReference<CURRENT_VERSION>,
         KeyPackage: traits::KeyPackage<CURRENT_VERSION>,
@@ -638,7 +638,7 @@ where
         self.read(KEY_PACKAGE_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(_psk_id = %hex_kv(_psk_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(_psk_id = %hex_kv(_psk_id)), err)]
     fn psk<PskBundle: traits::PskBundle<CURRENT_VERSION>, PskId: traits::PskId<CURRENT_VERSION>>(
         &self,
         _psk_id: &PskId,
@@ -646,7 +646,7 @@ where
         Ok(None)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(public_key = %hex_kv(public_key)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(public_key = %hex_kv(public_key)), err)]
     fn encryption_key_pair<
         HpkeKeyPair: traits::HpkeKeyPair<CURRENT_VERSION>,
         EncryptionKey: traits::EncryptionKey<CURRENT_VERSION>,
@@ -660,7 +660,7 @@ where
         self.read(ENCRYPTION_KEY_PAIR_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(public_key = %hex_kv(public_key)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(public_key = %hex_kv(public_key)), ret, err)]
     fn delete_signature_key_pair<
         SignaturePublicKey: traits::SignaturePublicKey<CURRENT_VERSION>,
     >(
@@ -675,7 +675,7 @@ where
         self.delete::<CURRENT_VERSION>(SIGNATURE_KEY_PAIR_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(public_key = %hex_kv(public_key)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(public_key = %hex_kv(public_key)), ret, err)]
     fn delete_encryption_key_pair<EncryptionKey: traits::EncryptionKey<CURRENT_VERSION>>(
         &self,
         public_key: &EncryptionKey,
@@ -686,7 +686,7 @@ where
         self.delete::<CURRENT_VERSION>(ENCRYPTION_KEY_PAIR_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(hash_ref = %hex_kv(hash_ref)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(hash_ref = %hex_kv(hash_ref)), ret, err)]
     fn delete_key_package<HashReference: traits::HashReference<CURRENT_VERSION>>(
         &self,
         hash_ref: &HashReference,
@@ -695,7 +695,7 @@ where
         self.delete::<CURRENT_VERSION>(KEY_PACKAGE_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(_psk_id = %hex_kv(_psk_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(_psk_id = %hex_kv(_psk_id)), ret, err)]
     fn delete_psk<PskKey: traits::PskId<CURRENT_VERSION>>(
         &self,
         _psk_id: &PskKey,
@@ -703,7 +703,7 @@ where
         Err(SqlKeyStoreError::UnsupportedMethod)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), err)]
     fn group_state<
         GroupState: traits::GroupState<CURRENT_VERSION>,
         GroupId: traits::GroupId<CURRENT_VERSION>,
@@ -716,7 +716,7 @@ where
         self.read(GROUP_STATE_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
     fn write_group_state<
         GroupState: traits::GroupState<CURRENT_VERSION>,
         GroupId: traits::GroupId<CURRENT_VERSION>,
@@ -730,7 +730,7 @@ where
         self.write::<CURRENT_VERSION>(GROUP_STATE_LABEL, &key, &bincode::serialize(group_state)?)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
     fn delete_group_state<GroupId: traits::GroupId<CURRENT_VERSION>>(
         &self,
         group_id: &GroupId,
@@ -740,7 +740,7 @@ where
         self.delete::<CURRENT_VERSION>(GROUP_STATE_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), err)]
     fn message_secrets<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         MessageSecrets: traits::MessageSecrets<CURRENT_VERSION>,
@@ -753,7 +753,7 @@ where
         self.read(MESSAGE_SECRETS_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
     fn write_message_secrets<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         MessageSecrets: traits::MessageSecrets<CURRENT_VERSION>,
@@ -771,7 +771,7 @@ where
         )
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
     fn delete_message_secrets<GroupId: traits::GroupId<CURRENT_VERSION>>(
         &self,
         group_id: &GroupId,
@@ -781,7 +781,7 @@ where
         self.delete::<CURRENT_VERSION>(MESSAGE_SECRETS_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), err)]
     fn resumption_psk_store<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ResumptionPskStore: traits::ResumptionPskStore<CURRENT_VERSION>,
@@ -792,7 +792,7 @@ where
         self.read(RESUMPTION_PSK_STORE_LABEL, &bincode::serialize(group_id)?)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
     fn write_resumption_psk_store<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ResumptionPskStore: traits::ResumptionPskStore<CURRENT_VERSION>,
@@ -808,7 +808,7 @@ where
         )
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
     fn delete_all_resumption_psk_secrets<GroupId: traits::GroupId<CURRENT_VERSION>>(
         &self,
         group_id: &GroupId,
@@ -816,7 +816,7 @@ where
         self.delete::<CURRENT_VERSION>(RESUMPTION_PSK_STORE_LABEL, &bincode::serialize(group_id)?)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), err)]
     fn own_leaf_index<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         LeafNodeIndex: traits::LeafNodeIndex<CURRENT_VERSION>,
@@ -828,7 +828,7 @@ where
         self.read(OWN_LEAF_NODE_INDEX_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id), own_leaf_index = %hex_kv(own_leaf_index)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id), own_leaf_index = %hex_kv(own_leaf_index)), ret, err)]
     fn write_own_leaf_index<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         LeafNodeIndex: traits::LeafNodeIndex<CURRENT_VERSION>,
@@ -845,7 +845,7 @@ where
         )
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
     fn delete_own_leaf_index<GroupId: traits::GroupId<CURRENT_VERSION>>(
         &self,
         group_id: &GroupId,
@@ -854,7 +854,7 @@ where
         self.delete::<CURRENT_VERSION>(OWN_LEAF_NODE_INDEX_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), err)]
     fn group_epoch_secrets<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         GroupEpochSecrets: traits::GroupEpochSecrets<CURRENT_VERSION>,
@@ -866,7 +866,7 @@ where
         self.read(EPOCH_SECRETS_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
     fn write_group_epoch_secrets<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         GroupEpochSecrets: traits::GroupEpochSecrets<CURRENT_VERSION>,
@@ -883,7 +883,7 @@ where
         )
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
     fn delete_group_epoch_secrets<GroupId: traits::GroupId<CURRENT_VERSION>>(
         &self,
         group_id: &GroupId,
@@ -892,7 +892,7 @@ where
         self.delete::<CURRENT_VERSION>(EPOCH_SECRETS_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id), epoch = %hex_kv(epoch), leaf_index = %leaf_index))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id), epoch = %hex_kv(epoch), leaf_index = %leaf_index), ret, err)]
     fn write_encryption_epoch_key_pairs<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         EpochKey: traits::EpochKey<CURRENT_VERSION>,
@@ -911,7 +911,7 @@ where
         self.write::<CURRENT_VERSION>(EPOCH_KEY_PAIRS_LABEL, &key, &value)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id), epoch = %hex_kv(epoch), leaf_index = %leaf_index))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id), epoch = %hex_kv(epoch), leaf_index = %leaf_index), err)]
     fn encryption_epoch_key_pairs<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         EpochKey: traits::EpochKey<CURRENT_VERSION>,
@@ -950,7 +950,7 @@ where
         }
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id), epoch = %hex_kv(epoch), leaf_index = %leaf_index))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id), epoch = %hex_kv(epoch), leaf_index = %leaf_index), ret, err)]
     fn delete_encryption_epoch_key_pairs<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         EpochKey: traits::EpochKey<CURRENT_VERSION>,
@@ -965,7 +965,7 @@ where
         self.delete::<CURRENT_VERSION>(EPOCH_KEY_PAIRS_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
     fn clear_proposal_queue<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ProposalRef: traits::ProposalRef<CURRENT_VERSION>,
@@ -986,7 +986,7 @@ where
         self.delete::<CURRENT_VERSION>(PROPOSAL_QUEUE_REFS_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), err)]
     fn mls_group_join_config<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         MlsGroupJoinConfig: traits::MlsGroupJoinConfig<CURRENT_VERSION>,
@@ -999,7 +999,7 @@ where
         self.read(JOIN_CONFIG_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id), config = %hex_kv(config)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id), config = %hex_kv(config)), ret, err)]
     fn write_mls_join_config<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         MlsGroupJoinConfig: traits::MlsGroupJoinConfig<CURRENT_VERSION>,
@@ -1014,7 +1014,7 @@ where
         self.write::<CURRENT_VERSION>(JOIN_CONFIG_LABEL, &key, &value)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), err)]
     fn own_leaf_nodes<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         LeafNode: traits::LeafNode<CURRENT_VERSION>,
@@ -1028,7 +1028,7 @@ where
         self.read_list(OWN_LEAF_NODES_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id), leaf_node = %hex_kv(leaf_node)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id), leaf_node = %hex_kv(leaf_node)), ret, err)]
     fn append_own_leaf_node<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         LeafNode: traits::LeafNode<CURRENT_VERSION>,
@@ -1043,7 +1043,7 @@ where
         self.append::<CURRENT_VERSION>(OWN_LEAF_NODES_LABEL, &key, &value)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
     fn delete_own_leaf_nodes<GroupId: traits::GroupId<CURRENT_VERSION>>(
         &self,
         group_id: &GroupId,
@@ -1052,7 +1052,7 @@ where
         self.delete::<CURRENT_VERSION>(OWN_LEAF_NODES_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
     fn delete_group_config<GroupId: traits::GroupId<CURRENT_VERSION>>(
         &self,
         group_id: &GroupId,
@@ -1061,7 +1061,7 @@ where
         self.delete::<CURRENT_VERSION>(JOIN_CONFIG_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
     fn delete_tree<GroupId: traits::GroupId<CURRENT_VERSION>>(
         &self,
         group_id: &GroupId,
@@ -1071,7 +1071,7 @@ where
         self.delete::<CURRENT_VERSION>(TREE_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
     fn delete_confirmation_tag<GroupId: traits::GroupId<CURRENT_VERSION>>(
         &self,
         group_id: &GroupId,
@@ -1081,7 +1081,7 @@ where
         self.delete::<CURRENT_VERSION>(CONFIRMATION_TAG_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
     fn delete_context<GroupId: traits::GroupId<CURRENT_VERSION>>(
         &self,
         group_id: &GroupId,
@@ -1091,7 +1091,7 @@ where
         self.delete::<CURRENT_VERSION>(GROUP_CONTEXT_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
     fn delete_interim_transcript_hash<GroupId: traits::GroupId<CURRENT_VERSION>>(
         &self,
         group_id: &GroupId,
@@ -1101,7 +1101,7 @@ where
         self.delete::<CURRENT_VERSION>(INTERIM_TRANSCRIPT_HASH_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id), proposal_ref = %hex_kv(proposal_ref)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id), proposal_ref = %hex_kv(proposal_ref)), ret, err)]
     fn remove_proposal<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ProposalRef: traits::ProposalRef<CURRENT_VERSION>,
@@ -1120,7 +1120,7 @@ where
         self.delete::<CURRENT_VERSION>(QUEUED_PROPOSAL_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
     fn write_application_export_tree<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ApplicationExportTree: traits::ApplicationExportTree<CURRENT_VERSION>,
@@ -1137,7 +1137,7 @@ where
         )
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), err)]
     fn application_export_tree<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ApplicationExportTree: traits::ApplicationExportTree<CURRENT_VERSION>,
@@ -1149,7 +1149,7 @@ where
         self.read(APPLICATION_EXPORT_TREE_LABEL, &key)
     }
 
-    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)))]
+    #[tracing::instrument(skip_all, target = "openmls_kv", fields(group_id = %hex_kv(group_id)), ret, err)]
     fn delete_application_export_tree<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ApplicationExportTree: traits::ApplicationExportTree<CURRENT_VERSION>,

--- a/nix/package/cross-version-test/cross-version-test.sh
+++ b/nix/package/cross-version-test/cross-version-test.sh
@@ -364,6 +364,37 @@ xdbg_probe_available() {
     return 2
 }
 
+# Per-binary cache of which optional flags an xdbg build supports.
+# Key: "$kind:$sha:$flag". Value: 0 (supported), 1 (absent). Populated
+# lazily by xdbg_supports_flag via a single `--help` probe per binary.
+declare -A XDBG_FLAG_CACHE=()
+
+# Check whether the xdbg binary for ($kind, $sha) advertises $flag in its
+# top-level --help output. Returns 0 if present, 1 otherwise.
+# Cached so repeated calls (one per xdbg invocation in run-sequence) don't
+# re-exec the binary.
+xdbg_supports_flag() {
+    local kind="$1" sha="$2" flag="$3"
+    local key="${kind}:${sha}:${flag}"
+    if [ -n "${XDBG_FLAG_CACHE[$key]:-}" ]; then
+        return "${XDBG_FLAG_CACHE[$key]}"
+    fi
+    local bin help_out rc=0
+    bin=$(xdbg_binary_path "$kind" "$sha") || {
+        XDBG_FLAG_CACHE[$key]=1
+        return 1
+    }
+    local -a env_args
+    mapfile -t env_args < <(xdbg_sandbox_env_args)
+    help_out=$(env "${env_args[@]}" "$bin" --help 2>&1) || rc=$?
+    if [ "$rc" -eq 0 ] && grep -qF -- "$flag" <<<"$help_out"; then
+        XDBG_FLAG_CACHE[$key]=0
+        return 0
+    fi
+    XDBG_FLAG_CACHE[$key]=1
+    return 1
+}
+
 # Run a non-informative xdbg command with `--json --fail-fast`. Every
 # tested sha now carries the --fail-fast flag, so non-zero rc IS the
 # failure signal — no log-file scanning needed.
@@ -397,6 +428,12 @@ run_xdbg_real() {
     if [ -n "${XVT_XDBG_FLAGS:-}" ]; then
         # shellcheck disable=SC2206  # word-split is the intent
         xtra_flags=(${XVT_XDBG_FLAGS})
+    fi
+    # `--trace-openmls-kv` lands on xdbg after the openmls_kv instrumentation
+    # PR. Probe --help once per binary so newer stables/nightlies pick it up
+    # without code changes here, but older builds don't get rejected.
+    if xdbg_supports_flag "$kind" "$sha" "--trace-openmls-kv"; then
+        xtra_flags+=(--trace-openmls-kv)
     fi
 
     local call_dir


### PR DESCRIPTION
for debugging purposes, this puts all openmls KV operations under a tracing instrumentation at trace level under `openmls_kv` target. the separate target is to prevent polluting consumers with xmtp_db target enabled since K/V traces will be noisy.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tracing instrumentation to `SqlKeyStore` and `--trace-openmls-kv` flag in xdbg
> - Adds `#[tracing::instrument]` attributes to all `StorageProvider` methods in [`sql_key_store.rs`](https://github.com/xmtp/libxmtp/pull/3621/files#diff-8634bcb374db4ae6216e2c4af6aa38e77aaffe5e5249bb0ac7f0d2bfd4975d35), emitting spans on the `openmls_kv` target with hex-encoded identifiers and error annotations.
> - Introduces a `deserialize_bincode` helper that logs structured errors (including field paths via `serde_path_to_error`) on deserialization failures, replacing scattered `eprintln` and `bincode::deserialize` calls.
> - Adds `--trace-openmls-kv` CLI flag to xdbg that appends `openmls_kv=trace` to file-log filters, and supports `XDBG_FILE_LOG_EXTRA` for arbitrary extra directives.
> - Updates the cross-version test script to detect and pass `--trace-openmls-kv` automatically for binaries that support it, leaving older binaries unaffected.
> - Adds `OPENMLS_KV_TARGET` constant to `xmtp_configuration` and the `deserialize-paths` feature flag to `xmtp_db` for opt-in path-aware deserialization error reporting.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8c568ae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->