### PR TITLE
ci(release-wasm): install wasm-pack before yarn build

### DIFF
--- a/.github/workflows/release-wasm.yml
+++ b/.github/workflows/release-wasm.yml
@@ -76,6 +76,11 @@ jobs:
         with:
           tool: wasm-bindgen@0.2.108
 
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack
+
       - name: Setup node
         uses: ./.github/actions/setup-node
         with:


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3622

## Summary

The `build` job in `.github/workflows/release-wasm.yml` runs `yarn build` in `bindings/wasm`, which invokes `wasm-pack build` via the `build:web` / `build:test` scripts in `bindings/wasm/package.json`. The workflow installed `wasm-bindgen@0.2.108` via `taiki-e/install-action@v2` but never installed `wasm-pack`, so every WASM release run exited with `command not found: wasm-pack` (exit 127) at the build step.

This PR adds the missing install step using the same `taiki-e/install-action@v2` pattern already used for `wasm-bindgen`, keeping the workflow consistent and avoiding any new action dependency.

```yaml
- name: Install wasm-pack
  uses: taiki-e/install-action@v2
  with:
    tool: wasm-pack
```

The `test-wasm.yml` / `lint-wasm.yml` workflows are unaffected because they get `wasm-pack` from the Nix devShell — only the non-Nix `release-wasm.yml` was missing the tool.

## Test plan

- [x] Workflow YAML parses cleanly (validated with `js-yaml`).
- [x] New step matches the existing `wasm-bindgen` install pattern.
- [ ] Next dispatch of `release-wasm.yml` reaches and completes the `Build` step. End-to-end verification happens when `release.yml` invokes this workflow for the next WASM release.

Failed run that motivated this fix: https://github.com/xmtp/libxmtp/actions/runs/25718514073

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Install `wasm-pack` before yarn build in the release-wasm CI workflow
> Adds an 'Install wasm-pack' step using `taiki-e/install-action@v2` in [release-wasm.yml](.github/workflows/release-wasm.yml) before the build runs, ensuring `wasm-pack` is available during the build job.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0ae881b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->