### PR TITLE
xmtp_mls: capability-aware GroupMutableMetadata reads + single-field getter refactor

### DIFF
--- a/crates/xmtp_mls/src/groups/app_data/component_source.rs
+++ b/crates/xmtp_mls/src/groups/app_data/component_source.rs
@@ -169,11 +169,22 @@ impl From<ComponentTypedError> for ComponentSourceError {
 }
 
 impl From<ComponentSourceError> for GroupMutableMetadataError {
-    /// Preserve the offending `component_id` when it's available so
-    /// downstream consumers (bindings, error-mapping) can match on it
-    /// structurally. Variants without one surface as `component_id:
-    /// None`; the display string stays the authoritative diagnostic.
+    /// Preserve structure where possible. If the source already wraps a
+    /// `GroupMutableMetadataError` (e.g. `MissingExtension` raised by the
+    /// legacy `TryFrom<&OpenMlsGroup>` path on an unmigrated group),
+    /// unwrap and return that inner variant verbatim so callers can
+    /// match on `MissingExtension` / `MissingMetadataField` / etc.
+    ///
+    /// For every other variant, surface as `MalformedComponent` and
+    /// preserve the offending `component_id` when it's available so
+    /// downstream consumers (bindings, error-mapping) can match
+    /// structurally on it. Variants without one surface as
+    /// `component_id: None`; the display string stays the
+    /// authoritative diagnostic.
     fn from(err: ComponentSourceError) -> Self {
+        if let ComponentSourceError::GroupMutableMetadata(inner) = err {
+            return inner;
+        }
         let component_id = err.component_id();
         GroupMutableMetadataError::MalformedComponent {
             component_id,
@@ -553,6 +564,41 @@ pub(crate) fn merge_app_data_into_mutable_metadata(
     mls_group: &OpenMlsGroup,
 ) -> Result<(), ComponentSourceError> {
     merge_app_data_into_mutable_metadata_from_extensions(base, mls_group.extensions())
+}
+
+/// Capability-aware [`GroupMutableMetadata`] extractor.
+///
+/// On migrated groups the legacy `GroupMutableMetadata` group context
+/// extension is stripped by the bootstrap commit, so the static
+/// [`xmtp_mls_common::group_mutable_metadata::extract_group_mutable_metadata`]
+/// returns `MissingExtension` and any caller that swallows the error
+/// with `.ok()` silently defaults every metadata field (notably:
+/// disappearing-message settings and `MinimumSupportedProtocolVersion`
+/// — the latter is what gates the XIP §3 pause-on-version-bump flow).
+///
+/// This helper returns the same `GroupMutableMetadata` shape but reads
+/// from the right source per migration state:
+///
+/// - **Migrated** ([`super::is_migrated_group`] returns `true`): starts
+///   from an empty composite and overlays every field from the AppData
+///   dictionary via [`merge_app_data_into_mutable_metadata`].
+/// - **Unmigrated**: parses the legacy GMM extension via
+///   `GroupMutableMetadata::try_from(&OpenMlsGroup)`, matching the
+///   legacy static helper byte-for-byte.
+pub(crate) fn extract_group_mutable_metadata_capability_aware(
+    mls_group: &OpenMlsGroup,
+) -> Result<GroupMutableMetadata, ComponentSourceError> {
+    if super::is_migrated_group(mls_group) {
+        let mut base = GroupMutableMetadata::new(
+            std::collections::HashMap::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+        merge_app_data_into_mutable_metadata(&mut base, mls_group)?;
+        Ok(base)
+    } else {
+        Ok(GroupMutableMetadata::try_from(mls_group)?)
+    }
 }
 
 /// Extensions-only variant of [`merge_app_data_into_mutable_metadata`].

--- a/crates/xmtp_mls/src/groups/app_data/component_source.rs
+++ b/crates/xmtp_mls/src/groups/app_data/component_source.rs
@@ -573,7 +573,7 @@ pub(crate) fn merge_app_data_into_mutable_metadata(
 ///
 /// On migrated groups the legacy `GroupMutableMetadata` group context
 /// extension is stripped by the bootstrap commit, so the static
-/// [`xmtp_mls_common::group_mutable_metadata::extract_group_mutable_metadata`]
+/// [`xmtp_mls_common::group_mutable_metadata::extract_legacy_group_mutable_metadata`]
 /// returns `MissingExtension` and any caller that swallows the error
 /// with `.ok()` silently defaults every metadata field (notably:
 /// disappearing-message settings and `MinimumSupportedProtocolVersion`
@@ -592,11 +592,8 @@ pub(crate) fn extract_group_mutable_metadata_capability_aware(
     mls_group: &OpenMlsGroup,
 ) -> Result<GroupMutableMetadata, ComponentSourceError> {
     if super::is_migrated_group(mls_group) {
-        let mut base = GroupMutableMetadata::new(
-            std::collections::HashMap::new(),
-            Vec::new(),
-            Vec::new(),
-        );
+        let mut base =
+            GroupMutableMetadata::new(std::collections::HashMap::new(), Vec::new(), Vec::new());
         merge_app_data_into_mutable_metadata(&mut base, mls_group)?;
         Ok(base)
     } else {

--- a/crates/xmtp_mls/src/groups/app_data/component_source.rs
+++ b/crates/xmtp_mls/src/groups/app_data/component_source.rs
@@ -20,12 +20,15 @@
 //! the short version is `varint(version) || 32-byte payload`, with
 //! version 0 producing a 33-byte encoding.
 
-// Several helpers here are scaffolding for the migration PR that follows
-// this one (see `docs/plans/2026-04-10-app-data-migration-plan.md`). They
-// have no production callers yet but are referenced by tests and by the
-// follow-up PR's intent handlers. `expect` (not `allow`) so when the
-// migration lands and these go live, the compiler flags this attribute as
-// unfulfilled and we remember to drop it.
+// `ComponentMutation`, `component_type`, and the standalone
+// `expand_app_data_update_to_changes` entry point are scaffolding for
+// the standalone proposal-by-reference flow (`IntentKind::ProposeAppDataUpdate`)
+// described in XIP §1.5.2 / §3.4. They have unit-test coverage but no
+// production caller yet — the inline path goes through
+// `apply_app_data_update_payload` instead. `expect` (not `allow`) so the
+// compiler trips this when standalone-propose wiring lands, and we
+// either drop the attribute or trim whichever scaffolding the new path
+// supersedes.
 #![expect(dead_code)]
 
 use openmls::{

--- a/crates/xmtp_mls/src/groups/app_data/typed_facade.rs
+++ b/crates/xmtp_mls/src/groups/app_data/typed_facade.rs
@@ -1,7 +1,3 @@
-// `expect` (not `allow`) so the compiler reminds us to drop this
-// attribute when the first production caller wires in.
-#![expect(dead_code)]
-
 //! Typed read facade over an OpenMLS group's AppData dictionary.
 //!
 //! [`MlsGroupAppData`] borrows an `&OpenMlsGroup` and exposes typed,
@@ -50,12 +46,6 @@ impl<'g> MlsGroupAppData<'g> {
             group,
             proposals_enabled,
         }
-    }
-
-    /// `true` if this group has completed its bootstrap commit and the
-    /// AppData dictionary is the authoritative source for components.
-    pub(crate) fn is_migrated(&self) -> bool {
-        self.proposals_enabled
     }
 
     /// Read the typed value of a [`Component`] from this group.

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -106,7 +106,7 @@ use xmtp_db::{
 };
 use xmtp_id::{InboxId, InboxIdRef};
 use xmtp_mls_common::group_metadata::extract_group_metadata;
-use xmtp_mls_common::group_mutable_metadata::{MetadataField, extract_group_mutable_metadata};
+use xmtp_mls_common::group_mutable_metadata::MetadataField;
 use xmtp_proto::types::GroupId;
 use xmtp_proto::xmtp::mls::message_contents::content_types::DeleteMessage;
 use xmtp_proto::xmtp::mls::{
@@ -1214,38 +1214,19 @@ where
                         }
                     }
                 };
-                let mutable_metadata = if is_migrated {
-                    // On migrated groups, build a GMM-shaped view by
-                    // overlaying dict entries on an empty base — same
-                    // shape as `MlsGroup::mutable_metadata()`.
-                    let mut metadata =
-                        xmtp_mls_common::group_mutable_metadata::GroupMutableMetadata::new(
-                            std::collections::HashMap::new(),
-                            Vec::new(),
-                            Vec::new(),
-                        );
-                    if let Err(e) =
-                        super::app_data::component_source::merge_app_data_into_mutable_metadata(
-                            &mut metadata,
-                            mls_group,
-                        )
-                    {
-                        self.maybe_update_cursor(&self.context.db(), envelope)?;
-                        return Err(CommitValidationError::from(
-                            xmtp_mls_common::group_mutable_metadata::GroupMutableMetadataError::from(e),
-                        )
-                        .into());
-                    }
-                    metadata
-                } else {
-                    match extract_group_mutable_metadata(mls_group) {
+                let mutable_metadata =
+                    match super::app_data::component_source::extract_group_mutable_metadata_capability_aware(
+                        mls_group,
+                    ) {
                         Ok(m) => m,
                         Err(e) => {
                             self.maybe_update_cursor(&self.context.db(), envelope)?;
-                            return Err(CommitValidationError::from(e).into());
+                            return Err(CommitValidationError::from(
+                                xmtp_mls_common::group_mutable_metadata::GroupMutableMetadataError::from(e),
+                            )
+                            .into());
                         }
-                    }
-                };
+                    };
 
                 let validation_result = validate_proposal(
                     queued_proposal,
@@ -1938,10 +1919,11 @@ where
     }
 
     fn get_message_expire_at_ns(mls_group: &OpenMlsGroup) -> Option<i64> {
-        // TODO(app-data-migration): on post-bootstrap groups the legacy
-        // GMM extension is gone; `.ok()?` will silently disable
-        // message-disappear settings.
-        let mutable_metadata = extract_group_mutable_metadata(mls_group).ok()?;
+        let mutable_metadata =
+            super::app_data::component_source::extract_group_mutable_metadata_capability_aware(
+                mls_group,
+            )
+            .ok()?;
         let group_disappearing_settings =
             Self::conversation_message_disappearing_settings_from_extensions(&mutable_metadata)
                 .ok()?;

--- a/crates/xmtp_mls/src/groups/mod.rs
+++ b/crates/xmtp_mls/src/groups/mod.rs
@@ -102,6 +102,12 @@ use xmtp_db::{group_message::LatestMessageTimeBySender, local_commit_log::LocalC
 use xmtp_id::associations::Identifier;
 use xmtp_id::{AsIdRef, InboxId, InboxIdRef};
 use xmtp_mls_common::{
+    app_data::components::{
+        inbox_id_set::{AdminListComponent, SuperAdminListComponent},
+        metadata_attributes::{
+            AppDataComponent, GroupDescriptionComponent, GroupImageUrlComponent, GroupNameComponent,
+        },
+    },
     group::{DMMetadataOptions, GroupMetadataOptions},
     group_metadata::{DmMembers, GroupMetadata, GroupMetadataError, extract_group_metadata},
     group_mutable_metadata::{
@@ -208,6 +214,12 @@ pub enum UpdateAdminListType {
     Remove,
     AddSuper,
     RemoveSuper,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum AdminListKind {
+    Admin,
+    SuperAdmin,
 }
 
 /// Fields extracted from content of a message that should be stored in the DB
@@ -1762,32 +1774,18 @@ where
 
     /// Retrieves the group name from the group's mutable metadata extension.
     pub fn group_name(&self) -> Result<String, GroupError> {
-        let mutable_metadata = self.mutable_metadata()?;
-        match mutable_metadata
-            .attributes
-            .get(&MetadataField::GroupName.to_string())
-        {
-            Some(group_name) => Ok(group_name.clone()),
-            None => Err(MetadataPermissionsError::from(
-                GroupMutableMetadataError::MissingExtension,
-            )
-            .into()),
-        }
+        self.read_single_component::<GroupNameComponent>()?
+            .ok_or_else(|| {
+                MetadataPermissionsError::from(GroupMutableMetadataError::MissingExtension).into()
+            })
     }
 
     /// Retrieves the app_data field from the group's mutable metadata extension
     pub fn app_data(&self) -> Result<String, GroupError> {
-        let mutable_metadata = self.mutable_metadata()?;
-        match mutable_metadata
-            .attributes
-            .get(&MetadataField::AppData.to_string())
-        {
-            Some(app_data) => Ok(app_data.clone()),
-            None => Err(MetadataPermissionsError::from(
-                GroupMutableMetadataError::MissingExtension,
-            )
-            .into()),
-        }
+        self.read_single_component::<AppDataComponent>()?
+            .ok_or_else(|| {
+                MetadataPermissionsError::from(GroupMutableMetadataError::MissingExtension).into()
+            })
     }
 
     /// Updates the description of the group.
@@ -1822,16 +1820,12 @@ where
     }
 
     pub fn group_description(&self) -> Result<String, GroupError> {
-        let mutable_metadata = self.mutable_metadata()?;
-        match mutable_metadata
-            .attributes
-            .get(&MetadataField::Description.to_string())
-        {
-            Some(group_description) => Ok(group_description.clone()),
-            None => Err(GroupError::MetadataPermissionsError(
-                GroupMutableMetadataError::MissingExtension.into(),
-            )),
-        }
+        self.read_single_component::<GroupDescriptionComponent>()?
+            .ok_or_else(|| {
+                GroupError::MetadataPermissionsError(
+                    GroupMutableMetadataError::MissingExtension.into(),
+                )
+            })
     }
 
     /// Updates the image URL (square) of the group.
@@ -1868,17 +1862,11 @@ where
 
     /// Retrieves the image URL (square) of the group from the group's mutable metadata extension.
     pub fn group_image_url_square(&self) -> Result<String, GroupError> {
-        let mutable_metadata = self.mutable_metadata()?;
-        match mutable_metadata
-            .attributes
-            .get(&MetadataField::GroupImageUrlSquare.to_string())
-        {
-            Some(group_image_url_square) => Ok(group_image_url_square.clone()),
-            None => Err(MetadataPermissionsError::Mutable(
-                GroupMutableMetadataError::MissingExtension,
-            )
-            .into()),
-        }
+        self.read_single_component::<GroupImageUrlComponent>()?
+            .ok_or_else(|| {
+                MetadataPermissionsError::Mutable(GroupMutableMetadataError::MissingExtension)
+                    .into()
+            })
     }
 
     pub async fn update_conversation_message_disappearing_settings(
@@ -2018,15 +2006,77 @@ where
     }
 
     /// Retrieves the admin list of the group from the group's mutable metadata extension.
+    ///
+    /// Element order: on migrated groups the dict-backed `TlsSet<InboxId>`
+    /// is iterated in sorted-by-raw-bytes order. On unmigrated groups
+    /// the legacy `GroupMutableMetadata.admin_list` is returned in its
+    /// stored (insertion) order. Both contracts pre-date this refactor;
+    /// preserving each side avoids surprising binding consumers that
+    /// rely on the pre-migration order.
     pub fn admin_list(&self) -> Result<Vec<String>, GroupError> {
-        let mutable_metadata = self.mutable_metadata()?;
-        Ok(mutable_metadata.admin_list)
+        self.read_admin_set_preserving_legacy_order(AdminListKind::Admin)
     }
 
     /// Retrieves the super admin list of the group from the group's mutable metadata extension.
+    ///
+    /// Same ordering contract as [`Self::admin_list`].
     pub fn super_admin_list(&self) -> Result<Vec<String>, GroupError> {
-        let mutable_metadata = self.mutable_metadata()?;
-        Ok(mutable_metadata.super_admin_list)
+        self.read_admin_set_preserving_legacy_order(AdminListKind::SuperAdmin)
+    }
+
+    fn read_admin_set_preserving_legacy_order(
+        &self,
+        kind: AdminListKind,
+    ) -> Result<Vec<String>, GroupError> {
+        self.load_mls_group_with_lock(self.context.mls_storage(), |mls_group| {
+            if self::app_data::is_migrated_group(&mls_group) {
+                let facade = self::app_data::typed_facade::MlsGroupAppData::new(&mls_group);
+                let set = match kind {
+                    AdminListKind::Admin => facade.get::<AdminListComponent>(),
+                    AdminListKind::SuperAdmin => facade.get::<SuperAdminListComponent>(),
+                }
+                .map_err(|e| {
+                    GroupError::MetadataPermissionsError(
+                        MetadataPermissionsError::ComponentSource(e),
+                    )
+                })?;
+                Ok(set
+                    .map(|s| s.iter().map(|id| id.to_hex()).collect())
+                    .unwrap_or_default())
+            } else {
+                // Unmigrated: return the Vec<String> straight from the
+                // legacy GMM extension so callers keep their pre-
+                // migration insertion order. Propagate decode errors
+                // (e.g. a corrupted legacy GMM extension) via the same
+                // `MetadataPermissionsError::Mutable(...)` shape that
+                // pre-refactor `mutable_metadata()?.admin_list`
+                // produced — a soft `.ok()` here would convert a loud
+                // failure into silent "no admins" data corruption.
+                // `MissingExtension` is the legacy "no extension on
+                // the group" case and remains the soft-skip → empty
+                // Vec contract.
+                let metadata =
+                    match xmtp_mls_common::group_mutable_metadata::extract_group_mutable_metadata(
+                        &mls_group,
+                    ) {
+                        Ok(m) => Some(m),
+                        Err(
+                            xmtp_mls_common::group_mutable_metadata::GroupMutableMetadataError::MissingExtension,
+                        ) => None,
+                        Err(e) => {
+                            return Err(GroupError::MetadataPermissionsError(
+                                MetadataPermissionsError::Mutable(e),
+                            ));
+                        }
+                    };
+                Ok(metadata
+                    .map(|m| match kind {
+                        AdminListKind::Admin => m.admin_list,
+                        AdminListKind::SuperAdmin => m.super_admin_list,
+                    })
+                    .unwrap_or_default())
+            }
+        })
     }
 
     /// Checks if the given inbox ID is an admin of the group at the most recently synced epoch.
@@ -2359,31 +2409,69 @@ where
     /// its bootstrap commit (the foundation-PR window). During that
     /// window the legacy GMM is still authoritative.
     pub fn mutable_metadata(&self) -> Result<GroupMutableMetadata, GroupError> {
+        use self::app_data::component_source::ComponentSourceError;
         self.load_mls_group_with_lock(self.context.mls_storage(), |mls_group| {
-            let mut metadata = if self::app_data::is_migrated_group(&mls_group) {
-                // Post-migration: legacy GMM extension is gone. Start
-                // with an empty base; `merge_app_data_into_mutable_metadata`
-                // populates every field from the dict.
-                GroupMutableMetadata::new(std::collections::HashMap::new(), Vec::new(), Vec::new())
-            } else {
-                GroupMutableMetadata::try_from(&mls_group)
-                    .map_err(MetadataPermissionsError::from)
-                    .map_err(GroupError::from)?
-            };
-            // The merge helper is also gated on the migration marker,
-            // so on unmigrated groups this is a no-op regardless of
-            // what the dict happens to contain.
-            self::app_data::component_source::merge_app_data_into_mutable_metadata(
-                &mut metadata,
+            self::app_data::component_source::extract_group_mutable_metadata_capability_aware(
                 &mls_group,
-            )?;
-            Ok(metadata)
+            )
+            .map_err(|e| match e {
+                // Inner `GroupMutableMetadataError` originates from the
+                // legacy `TryFrom<&OpenMlsGroup>` path on unmigrated
+                // groups; the `From<ComponentSourceError>` impl
+                // preserves it verbatim so binding consumers that
+                // pattern-match on `MetadataPermissionsError::Mutable`
+                // keep lighting up on `MissingExtension`.
+                ComponentSourceError::GroupMutableMetadata(inner) => {
+                    GroupError::MetadataPermissionsError(MetadataPermissionsError::Mutable(inner))
+                }
+                other => GroupError::MetadataPermissionsError(
+                    MetadataPermissionsError::ComponentSource(other),
+                ),
+            })
         })
     }
 
     pub fn permissions(&self) -> Result<GroupMutablePermissions, GroupError> {
         self.load_mls_group_with_lock(self.context.mls_storage(), |mls_group| {
             Ok(extract_group_permissions(&mls_group).map_err(MetadataPermissionsError::from)?)
+        })
+    }
+
+    /// Capability-aware single-component read.
+    ///
+    /// Acquires the group lock, then uses the
+    /// [`self::app_data::typed_facade::MlsGroupAppData`] facade to read
+    /// exactly one [`Component`](xmtp_mls_common::app_data::typed::Component)
+    /// — avoiding the full `GroupMutableMetadata` composite parse that
+    /// [`Self::mutable_metadata`] runs on every call.
+    ///
+    /// Returns `Ok(None)` when the component has no stored value
+    /// (legacy GMM attribute missing on unmigrated groups, or dict slot
+    /// absent on migrated groups).
+    ///
+    /// Preserves the pre-refactor `GroupError::MetadataPermissionsError(...)`
+    /// shape that `self.mutable_metadata()` produced. For the corrupted-
+    /// legacy-GMM case the inner `GroupMutableMetadataError` is peeled
+    /// out of `ComponentSourceError::GroupMutableMetadata(...)` and
+    /// surfaced as `MetadataPermissionsError::Mutable(inner)`, matching
+    /// what binding consumers used to see. Other `ComponentSourceError`
+    /// variants (TLS codec, set/map apply failures) surface as
+    /// `MetadataPermissionsError::ComponentSource(other)`.
+    fn read_single_component<C>(&self) -> Result<Option<C::Value>, GroupError>
+    where
+        C: xmtp_mls_common::app_data::typed::Component,
+    {
+        use self::app_data::component_source::ComponentSourceError;
+        self.load_mls_group_with_lock(self.context.mls_storage(), |mls_group| {
+            let facade = self::app_data::typed_facade::MlsGroupAppData::new(&mls_group);
+            facade.get::<C>().map_err(|e| match e {
+                ComponentSourceError::GroupMutableMetadata(inner) => {
+                    GroupError::MetadataPermissionsError(MetadataPermissionsError::Mutable(inner))
+                }
+                other => GroupError::MetadataPermissionsError(
+                    MetadataPermissionsError::ComponentSource(other),
+                ),
+            })
         })
     }
 

--- a/crates/xmtp_mls/src/groups/mod.rs
+++ b/crates/xmtp_mls/src/groups/mod.rs
@@ -2056,13 +2056,27 @@ where
                 // the group" case and remains the soft-skip → empty
                 // Vec contract.
                 let metadata =
-                    match xmtp_mls_common::group_mutable_metadata::extract_group_mutable_metadata(
+                    match xmtp_mls_common::group_mutable_metadata::extract_legacy_group_mutable_metadata(
                         &mls_group,
                     ) {
                         Ok(m) => Some(m),
                         Err(
                             xmtp_mls_common::group_mutable_metadata::GroupMutableMetadataError::MissingExtension,
-                        ) => None,
+                        ) => {
+                            // Expected on very old groups created before
+                            // the legacy GMM extension existed; logged at
+                            // debug to give operators visibility without
+                            // spamming warn on a legitimate state. An
+                            // empty list is the contract callers expect
+                            // (admin_list / super_admin_list return
+                            // `Ok(vec![])` here, not `Err`).
+                            tracing::debug!(
+                                group_id = hex::encode(self.group_id.as_slice()),
+                                kind = ?kind,
+                                "unmigrated group has no legacy GroupMutableMetadata extension; returning empty admin set"
+                            );
+                            None
+                        }
                         Err(e) => {
                             return Err(GroupError::MetadataPermissionsError(
                                 MetadataPermissionsError::Mutable(e),

--- a/crates/xmtp_mls/src/groups/tests/test_proposals.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_proposals.rs
@@ -3230,3 +3230,90 @@ async fn test_admin_list_add_unchanged_on_unmigrated_group() {
         bo_meta.admin_list,
     );
 }
+
+/// XIP §3 welcome-time pause path: when a new member is welcomed into a
+/// fully-migrated group whose AppData dict carries a
+/// `MIN_SUPPORTED_PROTOCOL_VERSION` higher than the joiner's pkg_version,
+/// the joiner MUST land in `paused_for_version` directly from
+/// `sync_welcomes`.
+///
+/// Sibling of `test_enable_proposals_pauses_old_client_via_legacy_gmm_bump`
+/// (sync-time pause via the legacy GMM bump, the pre-bootstrap
+/// rollout-safety step). This one pins the WELCOME-time pause via the
+/// AppData dict on a fully-migrated group — the post-bootstrap
+/// steady-state path. Without `oruw`'s capability-aware welcome read,
+/// the legacy GMM extension is gone on migrated groups so
+/// `extract_group_mutable_metadata` returned `MissingExtension`,
+/// `.ok()` swallowed it, and the welcomed group admitted the member
+/// unpaused — fork hazard for clients below the dict's floor version.
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_welcome_on_migrated_group_pauses_below_min_version() {
+    use crate::builder::ClientBuilder;
+    use crate::groups::tests::increment_patch_version;
+    use crate::utils::VersionInfo;
+    use xmtp_cryptography::utils::generate_local_wallet;
+
+    // Alix runs at a newer version. Before migrating, she bumps the
+    // legacy GMM's `MinimumSupportedProtocolVersion` to her pkg_version
+    // so the bootstrap synthesis carries that floor into the AppData
+    // dict (synthesis reads `gmm.attributes` to seed dict entries).
+    let mut alix_version = VersionInfo::default();
+    alix_version.test_update_version(
+        increment_patch_version(alix_version.pkg_version())
+            .unwrap()
+            .as_str(),
+    );
+    let alix_pkg_version = alix_version.pkg_version().to_string();
+    let alix =
+        ClientBuilder::new_test_client_with_version(&generate_local_wallet(), alix_version.clone())
+            .await;
+
+    // Bo joins PRE-migration so alix's bootstrap synthesis has resolved
+    // member identities to work with. He's at the floor version so the
+    // pre-migration min-version bump pauses him via legacy GMM — not
+    // the subject of this test.
+    tester!(bo);
+    let alix_group = alix.create_group(None, None)?;
+    alix_group.add_members(&[bo.context.identity.inbox_id()]).await?;
+
+    // Bump min-version in legacy GMM (the only place to write it
+    // before migration). Bootstrap synthesis will pull this value
+    // forward into the AppData dict.
+    alix_group.update_group_min_version_to_match_self().await?;
+    alix_group.sync().await?;
+
+    // Alix migrates. Post-migration the legacy GMM is stripped and the
+    // floor lives in the AppData dict only.
+    alix_group.enable_proposals().await?;
+    let alix_migrated = alix_group
+        .load_mls_group_with_lock_async(async |g| {
+            Ok::<bool, crate::groups::GroupError>(alix_group.proposals_enabled(&g))
+        })
+        .await?;
+    assert!(
+        alix_migrated,
+        "alix must be migrated post-enable_proposals (precondition for this test)"
+    );
+
+    // Carol joins POST-migration at the default (older) pkg_version.
+    // Her welcome carries the migrated GroupContext — no legacy GMM,
+    // floor only in the AppData dict. This is the path `oruw` fixes:
+    // the welcome-time read MUST find the floor in the dict and pause
+    // the welcomed group at welcome-application time.
+    tester!(carol);
+    alix_group.add_members(&[carol.context.identity.inbox_id()]).await?;
+
+    let carol_groups = carol.sync_welcomes().await?;
+    let carol_group = carol_groups
+        .iter()
+        .find(|g| g.group_id == alix_group.group_id)
+        .expect("carol should receive a welcome for alix_group");
+
+    let paused = carol_group.paused_for_version()?;
+    assert_eq!(
+        paused.as_deref(),
+        Some(alix_pkg_version.as_str()),
+        "carol must be paused at alix's pkg_version directly from sync_welcomes; \
+         the floor lives only in the AppData dict at this point"
+    );
+}

--- a/crates/xmtp_mls/src/groups/tests/test_proposals.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_proposals.rs
@@ -2732,10 +2732,10 @@ async fn test_update_group_description_via_app_data_update() {
 /// Pins the bug fixed by routing `get_message_expire_at_ns` through
 /// the capability-aware `extract_group_mutable_metadata_capability_aware`
 /// helper: before the fix, the static
-/// `extract_group_mutable_metadata` swallowed `MissingExtension` on
-/// migrated groups, so `get_message_expire_at_ns` returned `None` and
-/// every message stored post-bootstrap had `expire_at_ns = None` — no
-/// expiry, silently disabling disappearing messages.
+/// `extract_legacy_group_mutable_metadata` swallowed `MissingExtension`
+/// on migrated groups, so `get_message_expire_at_ns` returned `None`
+/// and every message stored post-bootstrap had `expire_at_ns = None` —
+/// no expiry, silently disabling disappearing messages.
 #[xmtp_common::test(unwrap_try = true)]
 async fn test_disappearing_settings_survive_bootstrap() {
     use xmtp_db::group_message::MsgQueryArgs;
@@ -3338,7 +3338,7 @@ async fn test_admin_list_add_unchanged_on_unmigrated_group() {
 /// AppData dict on a fully-migrated group — the post-bootstrap
 /// steady-state path. Without `oruw`'s capability-aware welcome read,
 /// the legacy GMM extension is gone on migrated groups so
-/// `extract_group_mutable_metadata` returned `MissingExtension`,
+/// `extract_legacy_group_mutable_metadata` returned `MissingExtension`,
 /// `.ok()` swallowed it, and the welcomed group admitted the member
 /// unpaused — fork hazard for clients below the dict's floor version.
 #[xmtp_common::test(unwrap_try = true)]
@@ -3369,7 +3369,9 @@ async fn test_welcome_on_migrated_group_pauses_below_min_version() {
     // the subject of this test.
     tester!(bo);
     let alix_group = alix.create_group(None, None)?;
-    alix_group.add_members(&[bo.context.identity.inbox_id()]).await?;
+    alix_group
+        .add_members(&[bo.context.identity.inbox_id()])
+        .await?;
 
     // Bump min-version in legacy GMM (the only place to write it
     // before migration). Bootstrap synthesis will pull this value
@@ -3396,7 +3398,9 @@ async fn test_welcome_on_migrated_group_pauses_below_min_version() {
     // the welcome-time read MUST find the floor in the dict and pause
     // the welcomed group at welcome-application time.
     tester!(carol);
-    alix_group.add_members(&[carol.context.identity.inbox_id()]).await?;
+    alix_group
+        .add_members(&[carol.context.identity.inbox_id()])
+        .await?;
 
     let carol_groups = carol.sync_welcomes().await?;
     let carol_group = carol_groups

--- a/crates/xmtp_mls/src/groups/tests/test_proposals.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_proposals.rs
@@ -2727,6 +2727,101 @@ async fn test_update_group_description_via_app_data_update() {
     );
 }
 
+/// Disappearing-message settings MUST survive the bootstrap commit.
+///
+/// Pins the bug fixed by routing `get_message_expire_at_ns` through
+/// the capability-aware `extract_group_mutable_metadata_capability_aware`
+/// helper: before the fix, the static
+/// `extract_group_mutable_metadata` swallowed `MissingExtension` on
+/// migrated groups, so `get_message_expire_at_ns` returned `None` and
+/// every message stored post-bootstrap had `expire_at_ns = None` — no
+/// expiry, silently disabling disappearing messages.
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_disappearing_settings_survive_bootstrap() {
+    use xmtp_db::group_message::MsgQueryArgs;
+    use xmtp_mls_common::group_mutable_metadata::MessageDisappearingSettings;
+
+    tester!(alix);
+    tester!(bo);
+
+    let alix_group = alix
+        .create_group_with_members(&[bo.inbox_id()], None, None)
+        .await?;
+    let bo_groups = bo.sync_welcomes().await?;
+    let bo_group = bo_groups.first()?;
+    bo_group.sync().await?;
+
+    // Configure disappearing messages on the unmigrated group. Both
+    // `from_ns` and `in_ns` must be > 0 —
+    // `MessageDisappearingSettings::is_enabled` is the gate that flips
+    // on the expire_at_ns plumbing. `from_ns = 1` is a sentinel-low
+    // value (not a real "from" timestamp); the test only needs `> 0`
+    // to satisfy `is_enabled`.
+    const DISAPPEAR_IN_NS: i64 = 3_600_000_000_000; // 1 hour
+    let settings = MessageDisappearingSettings::new(1, DISAPPEAR_IN_NS);
+    alix_group
+        .update_conversation_message_disappearing_settings(settings)
+        .await?;
+    bo_group.sync().await?;
+
+    // Send a pre-bootstrap message. Stored expire_at_ns should be set
+    // to roughly `now_ns + DISAPPEAR_IN_NS`.
+    let pre_send_ns = xmtp_common::time::now_ns();
+    alix_group
+        .send_message(b"before-bootstrap", SendMessageOpts::default())
+        .await?;
+    bo_group.sync().await?;
+    let bo_pre_msgs = bo_group.find_messages(&MsgQueryArgs::default())?;
+    let pre_msg = bo_pre_msgs
+        .iter()
+        .find(|m| m.decrypted_message_bytes == b"before-bootstrap")
+        .expect("bo should have decrypted the pre-bootstrap message");
+    let pre_expire = pre_msg.expire_at_ns.expect(
+        "pre-bootstrap message should carry an expire_at_ns derived from disappearing settings",
+    );
+    assert!(
+        pre_expire > pre_send_ns,
+        "pre-bootstrap expire_at_ns ({pre_expire}) must be in the future of send ts ({pre_send_ns})"
+    );
+    assert!(
+        pre_expire < pre_send_ns + 2 * DISAPPEAR_IN_NS,
+        "pre-bootstrap expire_at_ns ({pre_expire}) must be within 2x the disappear window of send ts ({pre_send_ns}); \
+         catches a regression that stores `Some(now_ns())` (zero-duration) or `Some(garbage)`"
+    );
+
+    // Run the real bootstrap commit — strips the legacy GMM extension.
+    alix_group.enable_proposals().await?;
+    bo_group.sync().await?;
+
+    // Send a post-bootstrap message. Before the capability-aware fix,
+    // `get_message_expire_at_ns` returned None here because it read
+    // the (now-absent) legacy GMM extension. After the fix, the dict
+    // overlay supplies the disappearing settings and expire_at_ns is
+    // populated.
+    let post_send_ns = xmtp_common::time::now_ns();
+    alix_group
+        .send_message(b"after-bootstrap", SendMessageOpts::default())
+        .await?;
+    bo_group.sync().await?;
+    let bo_post_msgs = bo_group.find_messages(&MsgQueryArgs::default())?;
+    let post_msg = bo_post_msgs
+        .iter()
+        .find(|m| m.decrypted_message_bytes == b"after-bootstrap")
+        .expect("bo should have decrypted the post-bootstrap message");
+    let post_expire = post_msg.expire_at_ns.expect(
+        "post-bootstrap message MUST carry an expire_at_ns — disappearing settings must survive the legacy GMM strip",
+    );
+    assert!(
+        post_expire > post_send_ns,
+        "post-bootstrap expire_at_ns ({post_expire}) must be in the future of send ts ({post_send_ns})"
+    );
+    assert!(
+        post_expire < post_send_ns + 2 * DISAPPEAR_IN_NS,
+        "post-bootstrap expire_at_ns ({post_expire}) must be within 2x the disappear window of send ts ({post_send_ns}); \
+         catches a regression that stores `Some(now_ns())` or `Some(garbage)`"
+    );
+}
+
 // NOTE: Three E2E tests are deliberately missing from phase 1. Each is
 // tracked here so a future PR can tick them off once the underlying
 // callpath exists.

--- a/crates/xmtp_mls/src/groups/welcomes/xmtp_welcome.rs
+++ b/crates/xmtp_mls/src/groups/welcomes/xmtp_welcome.rs
@@ -32,9 +32,9 @@ use xmtp_db::{
     prelude::*,
     refresh_state::EntityKind,
 };
-use xmtp_mls_common::{
-    group_metadata::extract_group_metadata, group_mutable_metadata::extract_group_mutable_metadata,
-};
+use xmtp_mls_common::group_metadata::extract_group_metadata;
+
+use crate::groups::app_data::component_source::extract_group_mutable_metadata_capability_aware;
 use xmtp_proto::types::Cursor;
 use xmtp_proto::xmtp::mls::message_contents::{ContentTypeId, GroupUpdated, group_updated::Inbox};
 
@@ -362,11 +362,32 @@ where
         )?;
         let dm_members = metadata.dm_members;
         let conversation_type = metadata.conversation_type;
-        // TODO(app-data-migration): same caveat as the `metadata`
-        // extraction above — `.ok()` swallows the missing-GMM error
-        // on post-bootstrap groups, silently defaulting downstream
-        // disappearing / min-protocol reads.
-        let mutable_metadata = extract_group_mutable_metadata(&mls_group).ok();
+        // Capability-aware: on migrated groups the legacy GMM
+        // extension is gone, so read from the AppData dictionary
+        // overlay. Otherwise this read silently defaults
+        // disappearing-message settings AND paused_for_version,
+        // breaking the XIP §3 pause-on-min-version-bump rollout path.
+        //
+        // `MissingExtension` on an unmigrated group is the soft-skip
+        // path the legacy code relied on (welcomes from very old
+        // clients can lack a GMM extension); anything else indicates
+        // wire corruption from the welcomer and is worth surfacing in
+        // logs so it can be triaged without breaking the welcome.
+        let mutable_metadata = match extract_group_mutable_metadata_capability_aware(&mls_group) {
+            Ok(metadata) => Some(metadata),
+            Err(crate::groups::app_data::component_source::ComponentSourceError::GroupMutableMetadata(
+                xmtp_mls_common::group_mutable_metadata::GroupMutableMetadataError::MissingExtension,
+            )) => None,
+            Err(e) => {
+                tracing::warn!(
+                    group_id = hex::encode(&group_id),
+                    error = ?e,
+                    "welcome-time GroupMutableMetadata read failed; \
+                     disappearing-settings and paused_for_version will fall back to defaults"
+                );
+                None
+            }
+        };
         let disappearing_settings = mutable_metadata.as_ref().and_then(|metadata| {
             MlsGroup::<C>::conversation_message_disappearing_settings_from_extensions(metadata).ok()
         });

--- a/crates/xmtp_mls/src/groups/welcomes/xmtp_welcome.rs
+++ b/crates/xmtp_mls/src/groups/welcomes/xmtp_welcome.rs
@@ -377,8 +377,25 @@ where
             Ok(metadata) => Some(metadata),
             Err(crate::groups::app_data::component_source::ComponentSourceError::GroupMutableMetadata(
                 xmtp_mls_common::group_mutable_metadata::GroupMutableMetadataError::MissingExtension,
-            )) => None,
+            )) => {
+                // Expected on welcomes from very old clients (no GMM
+                // extension on the group context). Logged at debug
+                // rather than dropped silently so an operator can
+                // distinguish "legitimately old group" from "fresh
+                // welcome that should have had GMM" when triaging.
+                tracing::debug!(
+                    group_id = hex::encode(&group_id),
+                    "welcome carries no legacy GroupMutableMetadata extension; \
+                     disappearing-settings and paused_for_version fall back to defaults"
+                );
+                None
+            }
             Err(e) => {
+                // Wire corruption from the welcomer (malformed legacy
+                // GMM bytes, dict decode failure on a migrated group).
+                // Warn-level so operators see this in production logs
+                // — the welcome still completes with default settings
+                // rather than failing the join.
                 tracing::warn!(
                     group_id = hex::encode(&group_id),
                     error = ?e,

--- a/crates/xmtp_mls_common/src/group_mutable_metadata.rs
+++ b/crates/xmtp_mls_common/src/group_mutable_metadata.rs
@@ -375,7 +375,20 @@ pub fn find_mutable_metadata_extension(extensions: &Extensions<GroupContext>) ->
     })
 }
 
-pub fn extract_group_mutable_metadata(
+/// Read `GroupMutableMetadata` from the **legacy** group-context
+/// extension only.
+///
+/// Use only when the caller is certain the group is unmigrated — on
+/// post-bootstrap groups the legacy extension is gone and this returns
+/// [`GroupMutableMetadataError::MissingExtension`].
+///
+/// For capability-aware reads that handle both legacy and migrated
+/// groups, use `extract_group_mutable_metadata_capability_aware` in
+/// the `xmtp_mls` crate at
+/// `xmtp_mls::groups::app_data::component_source`.
+/// (`xmtp_mls_common` cannot rustdoc-link to it because the dependency
+/// direction is one-way — this comment is the pointer.)
+pub fn extract_legacy_group_mutable_metadata(
     group: &OpenMlsGroup,
 ) -> Result<GroupMutableMetadata, GroupMutableMetadataError> {
     find_mutable_metadata_extension(group.extensions())


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add capability-aware `GroupMutableMetadata` reads for migrated MLS groups
- Introduces `extract_group_mutable_metadata_capability_aware` in [component_source.rs](https://github.com/xmtp/libxmtp/pull/3627/files#diff-47acce7b46d2cc4f9669dd42120ee90e488ceb0b15817b67b7757e631b05d113) to read `GroupMutableMetadata` from the AppData dictionary on migrated groups and from the legacy MLS extension on unmigrated groups.
- Refactors single-field getters (`group_name`, `group_description`, `group_image_url_square`, `app_data`, `admin_list`, `super_admin_list`) in [mod.rs](https://github.com/xmtp/libxmtp/pull/3627/files#diff-c27dd00cf700fd888b75fdbd19738462c2549fdc881dad70f8e61c979d440966) to use `read_single_component` or `read_admin_set_preserving_legacy_order`, routing reads through the AppData dict on migrated groups.
- Fixes `get_message_expire_at_ns` and welcome processing in [mls_sync.rs](https://github.com/xmtp/libxmtp/pull/3627/files#diff-160aadcd7de477c1116260a79601a0548842f3bd91bf16bd8443debb66ce6684) and [xmtp_welcome.rs](https://github.com/xmtp/libxmtp/pull/3627/files#diff-7ad79af03cc69f17888ed323b42554f52c5c706674e76a981c4fd4663464bb4e) so disappearing-message settings and `paused_for_version` are correctly sourced post-migration.
- Renames `extract_group_mutable_metadata` to `extract_legacy_group_mutable_metadata` in [group_mutable_metadata.rs](https://github.com/xmtp/libxmtp/pull/3627/files#diff-ed696106212fb67c35890c8338ccfd437eff9d62595cc6d1b73139430893a8ed) to make its unmigrated-only contract explicit.
- Behavioral Change: on migrated groups, all metadata reads now source from the AppData dictionary; legacy MLS extension reads will return `MissingExtension` and are no longer used post-bootstrap.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 30c20db.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->