### PR TITLE
xmtp_mls: relax unknown-component handling at the three receive-side sites

### DIFF
--- a/crates/xmtp_mls/src/groups/app_data/component_source.rs
+++ b/crates/xmtp_mls/src/groups/app_data/component_source.rs
@@ -39,7 +39,11 @@ use openmls::{
 use tls_codec::{Deserialize, Serialize};
 use xmtp_mls_common::{
     app_data::{
-        component_id::ComponentId, registry_table::lookup_component, typed::ComponentTypedError,
+        component_id::ComponentId,
+        component_registry::ComponentRegistry,
+        components::type_dispatch::{apply_update_payload_for_type, expand_to_changes_for_type},
+        registry_table::lookup_component,
+        typed::ComponentTypedError,
     },
     group_mutable_metadata::{
         GroupMutableMetadata, GroupMutableMetadataError, MetadataField,
@@ -167,6 +171,10 @@ impl From<ComponentTypedError> for ComponentSourceError {
             ComponentTypedError::TlsCodec(e) => Self::TlsCodec(e),
             ComponentTypedError::TlsSetApply(e) => Self::TlsSetApply(e),
             ComponentTypedError::TlsMapApply(e) => Self::TlsMapApply(e),
+            ComponentTypedError::UnspecifiedType(id) => Self::MalformedComponentValue {
+                component_id: id,
+                reason: "registered ComponentType is Unspecified".to_string(),
+            },
         }
     }
 }
@@ -446,9 +454,9 @@ pub(crate) fn encode_app_data_update_payload(
 }
 
 // `ExpandedComponentChange` lives in `xmtp_mls_common::app_data::typed`
-// so the `Component` trait there can return it. Re-exported here for
-// backward compatibility while the dispatch refactor (subsequent jj
-// changes) shifts call sites onto the trait directly.
+// so the `Component` trait there can return it. Re-exported here so
+// in-crate callers can construct the change list without pulling the
+// xmtp_mls_common path in directly.
 pub(crate) use xmtp_mls_common::app_data::typed::ExpandedComponentChange;
 
 /// Expand an `AppDataUpdate` proposal payload into the per-element changes
@@ -483,12 +491,33 @@ pub(crate) fn expand_app_data_update_to_changes(
     component_id: ComponentId,
     operation: &AppDataUpdateOperation,
     old_value: Option<&[u8]>,
+    registry: &ComponentRegistry,
 ) -> Result<Vec<ExpandedComponentChange>, ComponentSourceError> {
-    let component = lookup_component(component_id)
-        .ok_or(ComponentSourceError::UnknownComponent(component_id))?;
-    component
-        .expand_to_changes(operation, old_value)
-        .map_err(Into::into)
+    if let Some(component) = lookup_component(component_id) {
+        return component
+            .expand_to_changes(operation, old_value)
+            .map_err(Into::into);
+    }
+
+    // No per-id [`Component`] impl on this client. Two type-resolution
+    // sources, tried in order:
+    //
+    // 1. In-code [`component_type`] mapping — covers well-known XMTP
+    //    ids whose type is known to this release but which have no
+    //    typed decoder (e.g. the immutable seeds CREATOR_INBOX_ID,
+    //    ONESHOT_MESSAGE — handled by bootstrap byte-compare, not by a
+    //    `Component` impl).
+    // 2. On-dict [`ComponentRegistry`] entry — covers components a
+    //    *newer* release ships that this client has never heard of;
+    //    the registry's `component_type` tag is the type oracle.
+    //
+    // Either way, the closed type universe (6 variants) means every
+    // shape — including `TlsSet` / `TlsMap` deltas — surfaces a proper
+    // per-element change list to the validator. Old and new clients
+    // converge on the same dict state for the same wire bytes.
+    let ty = component_type(component_id)
+        .map_or_else(|| registered_component_type(component_id, registry), Ok)?;
+    expand_to_changes_for_type(component_id, ty, operation, old_value).map_err(Into::into)
 }
 
 /// Decode an incoming `AppDataUpdateOperation::Update(bytes)` payload
@@ -506,6 +535,7 @@ pub(crate) fn apply_app_data_update_payload(
     id: ComponentId,
     payload: &[u8],
     old_value: Option<&[u8]>,
+    registry: &ComponentRegistry,
 ) -> Result<Vec<u8>, ComponentSourceError> {
     // Immutability gate. Reject only on overwrite — a fresh insert
     // (no prior value) is the bootstrap commit's first write of an
@@ -517,19 +547,53 @@ pub(crate) fn apply_app_data_update_payload(
         return Err(ComponentSourceError::ImmutableUpdate(id));
     }
 
-    // Immutable seeds without a Component impl (CONVERSATION_TYPE,
-    // CREATOR_INBOX_ID, ONESHOT_MESSAGE) — store the payload bytes
-    // verbatim. They have no decode/encode step because steady-state
-    // never updates them; the wire bytes ARE the value.
-    let Some(component) = lookup_component(id) else {
-        if id.is_immutable() {
-            return Ok(payload.to_vec());
+    // Per-id `Component` impl on this client — handles all 13 well-
+    // known mutable components with a typed decoder.
+    if let Some(component) = lookup_component(id) {
+        return component
+            .apply_update_payload(payload, old_value)
+            .map_err(Into::into);
+    }
+
+    // Two type-resolution sources for components without a per-id
+    // impl, tried in order:
+    //
+    // 1. In-code [`component_type`] mapping — covers well-known XMTP
+    //    ids whose type is known but which have no typed decoder
+    //    (immutable seeds like CREATOR_INBOX_ID — bootstrap-only
+    //    first-write path).
+    // 2. On-dict [`ComponentRegistry`] entry — covers components a
+    //    *newer* release ships that this client has never heard of;
+    //    the registry's `component_type` tag is the type oracle.
+    let ty = component_type(id).map_or_else(|| registered_component_type(id, registry), Ok)?;
+    apply_update_payload_for_type(id, ty, payload, old_value).map_err(Into::into)
+}
+
+/// Look up the [`ComponentType`] registered for a component id in the
+/// on-dict [`ComponentRegistry`]. Returns
+/// [`ComponentSourceError::UnknownComponent`] when no registry entry
+/// exists — the deny-by-default rule that keeps unrecognized payloads
+/// from being applied opaquely.
+fn registered_component_type(
+    id: ComponentId,
+    registry: &ComponentRegistry,
+) -> Result<ComponentType, ComponentSourceError> {
+    let meta = registry
+        .get(&id)
+        .map_err(|e| ComponentSourceError::MalformedComponentValue {
+            component_id: id,
+            reason: format!("registry lookup: {e}"),
+        })?
+        .ok_or(ComponentSourceError::UnknownComponent(id))?;
+    ComponentType::try_from(meta.component_type).map_err(|_| {
+        ComponentSourceError::MalformedComponentValue {
+            component_id: id,
+            reason: format!(
+                "registry entry has unknown component_type tag {}",
+                meta.component_type
+            ),
         }
-        return Err(ComponentSourceError::UnknownComponent(id));
-    };
-    component
-        .apply_update_payload(payload, old_value)
-        .map_err(Into::into)
+    })
 }
 
 /// Overlay AppData-dict component values onto a base [`GroupMutableMetadata`]
@@ -962,10 +1026,17 @@ mod tests {
     use super::*;
     use tls_codec::VLBytes;
     use xmtp_mls_common::{
-        app_data::component_registry::ComponentOp,
+        app_data::{
+            component_permissions::component_permissions,
+            component_registry::{ComponentOp, new_component_metadata},
+        },
         inbox_id::INBOX_ID_BYTE_LEN,
         tls_map::{TlsMap, TlsMapDelta},
         tls_set::TlsKeyHash,
+    };
+    use xmtp_proto::xmtp::mls::message_contents::{
+        MetadataPolicy as MetadataPolicyProto,
+        metadata_policy::{Kind as MetadataPolicyKind, MetadataBasePolicy},
     };
 
     /// Build a deterministic 64-character hex inbox id from a tag byte. The
@@ -978,6 +1049,34 @@ mod tests {
     /// Build the [`InboxId`] form of [`fake_inbox_id`] directly.
     fn fake_inbox(tag: u8) -> InboxId {
         InboxId::from_bytes([tag; INBOX_ID_BYTE_LEN])
+    }
+
+    /// Empty registry constant for tests that exercise known-id paths —
+    /// `lookup_component` resolves first, so the registry is never
+    /// consulted and an empty one is sufficient.
+    fn empty_registry() -> ComponentRegistry {
+        ComponentRegistry::new()
+    }
+
+    /// Build a single-entry registry for tests that exercise the
+    /// type-aware fallback on unknown ids. Permissions are `Allow` for
+    /// every op so the policy layer does not interfere with the
+    /// dispatch test under question.
+    fn registry_with(id: ComponentId, ty: ComponentType) -> ComponentRegistry {
+        fn allow() -> MetadataPolicyProto {
+            MetadataPolicyProto {
+                kind: Some(MetadataPolicyKind::Base(MetadataBasePolicy::Allow as i32)),
+            }
+        }
+        let perms = component_permissions()
+            .insert(allow())
+            .update(allow())
+            .delete(allow())
+            .call();
+        let meta = new_component_metadata(perms, ty);
+        let mut reg = ComponentRegistry::new();
+        reg.set(id, meta).unwrap();
+        reg
     }
 
     // --- inbox-id helpers --------------------------------------------------
@@ -1204,8 +1303,13 @@ mod tests {
     #[xmtp_common::test]
     fn test_apply_bytes_payload_returns_payload_verbatim() {
         let payload = b"new_name";
-        let new_value =
-            apply_app_data_update_payload(ComponentId::GROUP_NAME, payload, None).unwrap();
+        let new_value = apply_app_data_update_payload(
+            ComponentId::GROUP_NAME,
+            payload,
+            None,
+            &empty_registry(),
+        )
+        .unwrap();
         assert_eq!(new_value, payload);
     }
 
@@ -1216,6 +1320,7 @@ mod tests {
             ComponentId::GROUP_DESCRIPTION,
             b"replacement",
             Some(b"old_description"),
+            &empty_registry(),
         )
         .unwrap();
         assert_eq!(new_value, b"replacement");
@@ -1230,8 +1335,13 @@ mod tests {
             encode_app_data_update_payload(&ComponentMutation::AdminListAdd { inbox_id: &inbox })
                 .unwrap();
 
-        let new_bytes =
-            apply_app_data_update_payload(ComponentId::ADMIN_LIST, &insert_payload, None).unwrap();
+        let new_bytes = apply_app_data_update_payload(
+            ComponentId::ADMIN_LIST,
+            &insert_payload,
+            None,
+            &empty_registry(),
+        )
+        .unwrap();
 
         let set = TlsSet::<InboxId>::tls_deserialize_exact(&new_bytes).unwrap();
         assert_eq!(set.len(), 1);
@@ -1250,9 +1360,13 @@ mod tests {
             encode_app_data_update_payload(&ComponentMutation::AdminListAdd { inbox_id: &bob })
                 .unwrap();
 
-        let new_bytes =
-            apply_app_data_update_payload(ComponentId::ADMIN_LIST, &insert_payload, Some(&prior))
-                .unwrap();
+        let new_bytes = apply_app_data_update_payload(
+            ComponentId::ADMIN_LIST,
+            &insert_payload,
+            Some(&prior),
+            &empty_registry(),
+        )
+        .unwrap();
 
         let set = TlsSet::<InboxId>::tls_deserialize_exact(&new_bytes).unwrap();
         assert_eq!(set.len(), 2);
@@ -1271,9 +1385,13 @@ mod tests {
         })
         .unwrap();
 
-        let new_bytes =
-            apply_app_data_update_payload(ComponentId::ADMIN_LIST, &remove_payload, Some(&prior))
-                .unwrap();
+        let new_bytes = apply_app_data_update_payload(
+            ComponentId::ADMIN_LIST,
+            &remove_payload,
+            Some(&prior),
+            &empty_registry(),
+        )
+        .unwrap();
 
         let set = TlsSet::<InboxId>::tls_deserialize_exact(&new_bytes).unwrap();
         assert_eq!(set.len(), 1);
@@ -1296,6 +1414,7 @@ mod tests {
             ComponentId::SUPER_ADMIN_LIST,
             &add_payload,
             Some(&prior),
+            &empty_registry(),
         )
         .unwrap();
 
@@ -1313,9 +1432,13 @@ mod tests {
         // `process_message_with_app_data` propagates this through the new
         // GroupMessageProcessingError::OpenMlsProcessMessageWithAppData
         // variant rather than masking it as `FoundAppDataUpdateProposal`.
-        let err =
-            apply_app_data_update_payload(ComponentId::ADMIN_LIST, &[0xff, 0xff, 0xff, 0xff], None)
-                .unwrap_err();
+        let err = apply_app_data_update_payload(
+            ComponentId::ADMIN_LIST,
+            &[0xff, 0xff, 0xff, 0xff],
+            None,
+            &empty_registry(),
+        )
+        .unwrap_err();
         assert!(
             matches!(err, ComponentSourceError::TlsCodec(_)),
             "got {err:?}"
@@ -1334,6 +1457,7 @@ mod tests {
             ComponentId::ADMIN_LIST,
             &payload,
             Some(&[0xde, 0xad, 0xbe, 0xef]),
+            &empty_registry(),
         )
         .unwrap_err();
         assert!(
@@ -1350,8 +1474,13 @@ mod tests {
         // verbatim — the bootstrap validator's byte-compare catches a
         // peer that crafts a malicious initial value, so the apply
         // layer doesn't need its own decode/check step.
-        let bytes =
-            apply_app_data_update_payload(ComponentId::CONVERSATION_TYPE, b"seed", None).unwrap();
+        let bytes = apply_app_data_update_payload(
+            ComponentId::CONVERSATION_TYPE,
+            b"seed",
+            None,
+            &empty_registry(),
+        )
+        .unwrap();
         assert_eq!(bytes, b"seed");
     }
 
@@ -1361,9 +1490,13 @@ mod tests {
         // component that already has a prior value must fail. This is
         // the only path Byzantine peers have to mutate immutables
         // post-bootstrap, and the apply layer is the gatekeeper.
-        let err =
-            apply_app_data_update_payload(ComponentId::CONVERSATION_TYPE, b"junk", Some(b"prior"))
-                .unwrap_err();
+        let err = apply_app_data_update_payload(
+            ComponentId::CONVERSATION_TYPE,
+            b"junk",
+            Some(b"prior"),
+            &empty_registry(),
+        )
+        .unwrap_err();
         assert!(matches!(err, ComponentSourceError::ImmutableUpdate(_)));
     }
 
@@ -1379,8 +1512,13 @@ mod tests {
             .insert(id_b, VLBytes::new(vec![0x22; 4]));
         let payload = delta.tls_serialize_detached().unwrap();
 
-        let new_bytes =
-            apply_app_data_update_payload(ComponentId::COMPONENT_REGISTRY, &payload, None).unwrap();
+        let new_bytes = apply_app_data_update_payload(
+            ComponentId::COMPONENT_REGISTRY,
+            &payload,
+            None,
+            &empty_registry(),
+        )
+        .unwrap();
         let map = TlsMap::<ComponentId, VLBytes>::tls_deserialize_exact(&new_bytes).unwrap();
         assert_eq!(map.len(), 2);
         assert_eq!(
@@ -1414,6 +1552,7 @@ mod tests {
             ComponentId::GROUP_MEMBERSHIP,
             &payload,
             Some(&prior_bytes),
+            &empty_registry(),
         )
         .unwrap();
         let map = TlsMap::<InboxId, VLBytes>::tls_deserialize_exact(&new_bytes).unwrap();
@@ -1433,6 +1572,7 @@ mod tests {
             ComponentId::COMPONENT_REGISTRY,
             &[0xff, 0xff, 0xff, 0xff],
             None,
+            &empty_registry(),
         )
         .unwrap_err();
         assert!(
@@ -1448,8 +1588,13 @@ mod tests {
         let alice = fake_inbox(0x01);
         let delta = TlsMapDelta::<InboxId, VLBytes>::new().update(alice, VLBytes::new(vec![0x42]));
         let payload = delta.tls_serialize_detached().unwrap();
-        let err = apply_app_data_update_payload(ComponentId::GROUP_MEMBERSHIP, &payload, None)
-            .unwrap_err();
+        let err = apply_app_data_update_payload(
+            ComponentId::GROUP_MEMBERSHIP,
+            &payload,
+            None,
+            &empty_registry(),
+        )
+        .unwrap_err();
         assert!(
             matches!(
                 err,
@@ -1459,10 +1604,145 @@ mod tests {
         );
     }
 
+    // --- Unknown-component tolerance via type-aware dispatch ---------------
+    //
+    // No per-id `Component` impl exists for these ids on this client; the
+    // sender shipped a newer release. Old clients look up the
+    // `ComponentType` registered for the id in the on-dict
+    // [`ComponentRegistry`] and route the payload through the
+    // type-level decoder. The six `ComponentType` variants cover the
+    // wire-format universe, so any future well-known or
+    // application-range component lands convergently — including
+    // `TlsSet` / `TlsMap` deltas, which previously needed a per-id
+    // impl to apply correctly.
+
     #[xmtp_common::test]
-    fn test_apply_app_range_component_unknown() {
-        let err = apply_app_data_update_payload(ComponentId::new(0xC123), b"x", None).unwrap_err();
+    fn test_apply_unknown_id_with_bytes_registry_entry_stores_payload() {
+        // Bytes shape: opaque passthrough, registry entry supplies the
+        // type tag so the dispatch knows *not* to try a TLS-delta
+        // decode (which would corrupt the bytes).
+        let id = ComponentId::new(0xC123);
+        let registry = registry_with(id, ComponentType::Bytes);
+        let new_value = apply_app_data_update_payload(id, b"opaque", None, &registry).unwrap();
+        assert_eq!(new_value, b"opaque");
+    }
+
+    #[xmtp_common::test]
+    fn test_apply_unknown_id_with_string_registry_entry_validates_utf8() {
+        // String shape: payload must be valid UTF-8. Bad bytes surface
+        // as `MalformedComponentValue` rather than silently corrupting
+        // the dict.
+        let id = ComponentId::new(0xC222);
+        let registry = registry_with(id, ComponentType::String);
+        let ok = apply_app_data_update_payload(id, b"hello", None, &registry).unwrap();
+        assert_eq!(ok, b"hello");
+        let err = apply_app_data_update_payload(id, &[0xC3, 0x28], None, &registry).unwrap_err();
+        assert!(matches!(
+            err,
+            ComponentSourceError::MalformedComponentValue { .. }
+        ));
+    }
+
+    #[xmtp_common::test]
+    fn test_apply_unknown_id_with_tls_set_inbox_id_applies_delta() {
+        // The whole point of registry-typed dispatch: a new
+        // `TlsSet<InboxId>` component lands as a typed delta apply, not
+        // as an opaque blob replacement — old and new clients converge
+        // on the same `TlsSet` snapshot byte-for-byte.
+        let id = ComponentId::new(0xC333);
+        let registry = registry_with(id, ComponentType::TlsSetInboxId);
+        let bob = fake_inbox(0x02);
+        let delta = TlsSetDelta::<InboxId>::new().insert(bob);
+        let payload = delta.tls_serialize_detached().unwrap();
+        let new_bytes = apply_app_data_update_payload(id, &payload, None, &registry).unwrap();
+        let set = TlsSet::<InboxId>::tls_deserialize_exact(&new_bytes).unwrap();
+        assert_eq!(set.len(), 1);
+        assert!(set.contains(&bob));
+    }
+
+    #[xmtp_common::test]
+    fn test_apply_unknown_id_with_no_registry_entry_rejected() {
+        // Deny-by-default: no per-id impl AND no registry entry means
+        // we have no type to decode against. Reject rather than store
+        // bytes whose shape we can't reason about — the alternative
+        // would fork the dict the moment a typed client did know the
+        // shape.
+        let err =
+            apply_app_data_update_payload(ComponentId::new(0xC456), b"x", None, &empty_registry())
+                .unwrap_err();
         assert!(matches!(err, ComponentSourceError::UnknownComponent(_)));
+    }
+
+    /// Immutability is enforced range-by-id, not per-`Component`-impl,
+    /// so an unknown id sitting in the XMTP immutable range
+    /// (`0xBE00-0xBFFF`) still gets the bootstrap-style "first insert
+    /// allowed, subsequent overwrite rejected" contract — even when
+    /// the type-aware dispatcher (not a per-id `Component` impl) is
+    /// the path being exercised. Pins the reviewer's concern that the
+    /// tolerance branch might bypass immutability for newly-defined
+    /// immutable components that a NEWER release ships.
+    #[xmtp_common::test]
+    fn test_apply_unknown_id_in_xmtp_immutable_range_first_write_allowed() {
+        let id = ComponentId::new(0xBE05); // XMTP immutable range
+        assert!(id.is_immutable());
+        let registry = registry_with(id, ComponentType::Bytes);
+        let new_value = apply_app_data_update_payload(id, b"seed", None, &registry).unwrap();
+        assert_eq!(new_value, b"seed");
+    }
+
+    #[xmtp_common::test]
+    fn test_apply_unknown_id_in_xmtp_immutable_range_overwrite_rejected() {
+        let id = ComponentId::new(0xBE05);
+        assert!(id.is_immutable());
+        let registry = registry_with(id, ComponentType::Bytes);
+        let err = apply_app_data_update_payload(id, b"new", Some(b"old"), &registry).unwrap_err();
+        assert!(matches!(err, ComponentSourceError::ImmutableUpdate(_)));
+    }
+
+    /// Same contract for the application immutable range
+    /// (`0xFD00-0xFEFF`) — overwrites of an unknown immutable
+    /// application component are rejected even though no per-id impl
+    /// exists on this client.
+    #[xmtp_common::test]
+    fn test_apply_unknown_id_in_app_immutable_range_overwrite_rejected() {
+        let id = ComponentId::new(0xFD42); // app immutable range
+        assert!(id.is_immutable());
+        let registry = registry_with(id, ComponentType::Bytes);
+        let err = apply_app_data_update_payload(id, b"new", Some(b"old"), &registry).unwrap_err();
+        assert!(matches!(err, ComponentSourceError::ImmutableUpdate(_)));
+    }
+
+    #[xmtp_common::test]
+    fn test_apply_reserved_range_component_rejected_with_or_without_registry() {
+        // 0xFF00+ is the reserved range. `ComponentRegistry::set`
+        // refuses to insert reserved ids, so a registry entry can't
+        // even be constructed — the apply path falls through to
+        // `UnknownComponent`.
+        let err =
+            apply_app_data_update_payload(ComponentId::new(0xFF01), b"x", None, &empty_registry())
+                .unwrap_err();
+        assert!(matches!(err, ComponentSourceError::UnknownComponent(_)));
+    }
+
+    #[xmtp_common::test]
+    fn test_apply_out_of_range_component_rejected() {
+        // Ids below 0x8000 are outside the AppData address space.
+        let err =
+            apply_app_data_update_payload(ComponentId::new(0x0042), b"x", None, &empty_registry())
+                .unwrap_err();
+        assert!(matches!(err, ComponentSourceError::UnknownComponent(_)));
+    }
+
+    #[xmtp_common::test]
+    fn test_apply_unknown_xmtp_range_id_with_registry_dispatches() {
+        // Same path applies to the XMTP-defined range, not just the
+        // app range: any 0x8000-0xBFFF id that lacks a per-id impl
+        // routes through the registry.
+        let id = ComponentId::new(0x8FFF);
+        assert!(id.is_xmtp_range());
+        let registry = registry_with(id, ComponentType::Bytes);
+        let new_value = apply_app_data_update_payload(id, b"opaque", None, &registry).unwrap();
+        assert_eq!(new_value, b"opaque");
     }
 
     // --- expand_app_data_update_to_changes ---------------------------------
@@ -1479,9 +1759,13 @@ mod tests {
         let delta: TlsSetDelta<InboxId> = TlsSetDelta {
             mutations: vec![TlsSetMutation::Insert(alice)],
         };
-        let changes =
-            expand_app_data_update_to_changes(ComponentId::ADMIN_LIST, &update_op(delta), None)
-                .unwrap();
+        let changes = expand_app_data_update_to_changes(
+            ComponentId::ADMIN_LIST,
+            &update_op(delta),
+            None,
+            &empty_registry(),
+        )
+        .unwrap();
         assert_eq!(changes.len(), 1);
         assert_eq!(changes[0].op, ComponentOp::Insert);
         assert_eq!(
@@ -1496,9 +1780,13 @@ mod tests {
         let delta: TlsSetDelta<InboxId> = TlsSetDelta {
             mutations: vec![TlsSetMutation::Remove(alice)],
         };
-        let changes =
-            expand_app_data_update_to_changes(ComponentId::ADMIN_LIST, &update_op(delta), None)
-                .unwrap();
+        let changes = expand_app_data_update_to_changes(
+            ComponentId::ADMIN_LIST,
+            &update_op(delta),
+            None,
+            &empty_registry(),
+        )
+        .unwrap();
         assert_eq!(changes.len(), 1);
         assert_eq!(changes[0].op, ComponentOp::Delete);
         assert_eq!(
@@ -1525,6 +1813,7 @@ mod tests {
             ComponentId::ADMIN_LIST,
             &update_op(delta),
             Some(&old_bytes),
+            &empty_registry(),
         )
         .unwrap();
         assert_eq!(changes.len(), 1);
@@ -1553,6 +1842,7 @@ mod tests {
             ComponentId::ADMIN_LIST,
             &update_op(delta),
             Some(&old_bytes),
+            &empty_registry(),
         )
         .unwrap();
         assert_eq!(changes.len(), 1);
@@ -1571,6 +1861,7 @@ mod tests {
             ComponentId::SUPER_ADMIN_LIST,
             &update_op(delta),
             None,
+            &empty_registry(),
         )
         .unwrap();
         assert_eq!(changes.len(), 1);
@@ -1591,12 +1882,103 @@ mod tests {
             ComponentId::ADMIN_LIST,
             &update_op(delta),
             Some(&[0xde, 0xad, 0xbe, 0xef]),
+            &empty_registry(),
         )
         .unwrap_err();
         assert!(
             matches!(err, ComponentSourceError::TlsCodec(_)),
             "got {err:?}"
         );
+    }
+
+    /// XIP §2.2: an unknown component id with `Update(payload)` and a
+    /// registered [`ComponentType::Bytes`] expands to a single Update
+    /// change carrying the payload, so registry-policy validation runs
+    /// against bytes a typed client would also accept opaquely.
+    #[xmtp_common::test]
+    fn test_expand_unknown_component_bytes_typed_emits_single_update() {
+        let id = ComponentId::new(0x80FF);
+        let registry = registry_with(id, ComponentType::Bytes);
+        let changes = expand_app_data_update_to_changes(
+            id,
+            &AppDataUpdateOperation::Update(b"opaque".to_vec().into()),
+            None,
+            &registry,
+        )
+        .unwrap();
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].op, ComponentOp::Update);
+        assert_eq!(changes[0].value.as_deref(), Some(b"opaque".as_slice()));
+    }
+
+    /// Unknown id with `Remove` and any registered type expands to a
+    /// single Delete change — the wipe semantics are type-agnostic.
+    #[xmtp_common::test]
+    fn test_expand_unknown_component_remove_emits_single_delete() {
+        let id = ComponentId::new(0x80FF);
+        let registry = registry_with(id, ComponentType::Bytes);
+        let changes =
+            expand_app_data_update_to_changes(id, &AppDataUpdateOperation::Remove, None, &registry)
+                .unwrap();
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].op, ComponentOp::Delete);
+        assert!(changes[0].value.is_none());
+    }
+
+    /// Type-aware dispatch is the whole point: an unknown
+    /// `TlsSet<InboxId>` component expands to a per-element change
+    /// list, not a single opaque blob — so the validator policy loop
+    /// inspects each `Insert` individually, the same as it would for a
+    /// known set-shaped component.
+    #[xmtp_common::test]
+    fn test_expand_unknown_component_tls_set_inbox_id_emits_per_element_changes() {
+        let id = ComponentId::new(0x80FE);
+        let registry = registry_with(id, ComponentType::TlsSetInboxId);
+        let alice = fake_inbox(0x11);
+        let bob = fake_inbox(0x22);
+        let delta = TlsSetDelta::<InboxId>::new().insert(alice).insert(bob);
+        let payload = delta.tls_serialize_detached().unwrap();
+        let changes = expand_app_data_update_to_changes(
+            id,
+            &AppDataUpdateOperation::Update(payload.into()),
+            None,
+            &registry,
+        )
+        .unwrap();
+        assert_eq!(changes.len(), 2);
+        assert!(changes.iter().all(|c| c.op == ComponentOp::Insert));
+    }
+
+    /// Reserved-range ids are not tolerated. `ComponentRegistry::set`
+    /// rejects reserved ids at construction time, so a registry entry
+    /// can't even be built — the dispatcher falls through to the
+    /// `UnknownComponent` rejection.
+    #[xmtp_common::test]
+    fn test_expand_reserved_range_id_still_rejected() {
+        let err = expand_app_data_update_to_changes(
+            ComponentId::new(0xFF02),
+            &AppDataUpdateOperation::Update(b"x".to_vec().into()),
+            None,
+            &empty_registry(),
+        )
+        .unwrap_err();
+        assert!(matches!(err, ComponentSourceError::UnknownComponent(_)));
+    }
+
+    /// Deny-by-default: an unknown id with no registry entry is
+    /// rejected. Without a type tag we have no idea how to decode the
+    /// payload, and storing it opaquely would diverge from any future
+    /// typed client that DID know the shape.
+    #[xmtp_common::test]
+    fn test_expand_unknown_component_no_registry_entry_rejected() {
+        let err = expand_app_data_update_to_changes(
+            ComponentId::new(0x80FF),
+            &AppDataUpdateOperation::Update(b"opaque".to_vec().into()),
+            None,
+            &empty_registry(),
+        )
+        .unwrap_err();
+        assert!(matches!(err, ComponentSourceError::UnknownComponent(_)));
     }
 
     #[xmtp_common::test]
@@ -1611,6 +1993,7 @@ mod tests {
             ComponentId::ADMIN_LIST,
             &update_op(delta),
             Some(&[0xff, 0xff, 0xff]), // intentionally malformed
+            &empty_registry(),
         )
         .unwrap();
         assert_eq!(changes.len(), 1);

--- a/crates/xmtp_mls/src/groups/app_data/migration.rs
+++ b/crates/xmtp_mls/src/groups/app_data/migration.rs
@@ -417,15 +417,25 @@ pub fn stage_bootstrap_commit<Provider: OpenMlsProvider>(
     // `UnableToDecrypt` and the bootstrap commit is rejected.
     //
     // Single source of truth: route each component's wire bytes
-    // through `apply_app_data_update_payload(id, wire, None)` to
+    // through `apply_app_data_update_payload(id, wire, None, &reg)` to
     // derive the dict bytes. The receiver runs the same function over
     // the same wire bytes (with prior=None at bootstrap) and gets the
     // same output, so dict byte-equality is guaranteed by construction.
+    //
+    // The empty `ComponentRegistry` here is intentional: bootstrap
+    // only writes well-known components, each of which has a per-id
+    // `Component` impl, so the type-aware fallback branch in
+    // `apply_app_data_update_payload` is never consulted.
+    let empty_registry = xmtp_mls_common::app_data::component_registry::ComponentRegistry::new();
     let mut updater = stage.app_data_dictionary_updater();
     for (component_id, wire_bytes) in component_values.iter() {
-        let dict_bytes =
-            super::component_source::apply_app_data_update_payload(*component_id, wire_bytes, None)
-                .map_err(BootstrapCommitError::DictApply)?;
+        let dict_bytes = super::component_source::apply_app_data_update_payload(
+            *component_id,
+            wire_bytes,
+            None,
+            &empty_registry,
+        )
+        .map_err(BootstrapCommitError::DictApply)?;
         updater.set(ComponentData::from_parts(
             component_id.as_u16(),
             dict_bytes.into(),

--- a/crates/xmtp_mls/src/groups/app_data/mod.rs
+++ b/crates/xmtp_mls/src/groups/app_data/mod.rs
@@ -101,6 +101,16 @@ where
 {
     let mut in_batch: BTreeMap<openmls::component::ComponentId, Option<Vec<u8>>> = BTreeMap::new();
 
+    // Load the pre-commit registry once. It supplies the
+    // `ComponentType` tag the type-aware dispatcher in
+    // `apply_app_data_update_payload` uses when an unknown component id
+    // arrives. Registry updates that land in the same commit don't
+    // retroactively change this snapshot — the typed path would need
+    // an in-batch registry overlay to handle the corner case where the
+    // very same commit both registers a new component and writes to
+    // it.
+    let registry = load_component_registry(mls_group)?;
+
     for (openmls_id, operation) in proposals {
         let xmtp_id = ComponentId::from(openmls_id);
         match operation {
@@ -117,14 +127,18 @@ where
                         xmtp_id,
                         payload.as_slice(),
                         Some(bytes.as_slice()),
+                        &registry,
                     ),
-                    Some(None) => apply_app_data_update_payload(xmtp_id, payload.as_slice(), None),
+                    Some(None) => {
+                        apply_app_data_update_payload(xmtp_id, payload.as_slice(), None, &registry)
+                    }
                     None => {
                         let from_dict = read_from_app_data_dict(xmtp_id, mls_group);
                         apply_app_data_update_payload(
                             xmtp_id,
                             payload.as_slice(),
                             from_dict.as_deref(),
+                            &registry,
                         )
                     }
                 }

--- a/crates/xmtp_mls/src/groups/tests/test_validate_app_data_update.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_validate_app_data_update.rs
@@ -418,3 +418,205 @@ fn proposer_leaf_new_member_proposal_rejected() {
         "expected ActorNotMember, got {err:?}"
     );
 }
+
+// ------------------------------------------------------------------------
+// validate_one_app_data_update_with_old_value — unknown-component
+// tolerance (XIP §2.2)
+//
+// These pin the relaxed-rejection branch added in jj `lmtv`. The
+// receive-side accepts unknown ids inside the XMTP/application range
+// opaquely (registry-policy still gates writes; per-component invariants
+// are skipped because the receiver has no `Component` impl to consult).
+// Reserved range `0xFF00+` still rejects.
+// ------------------------------------------------------------------------
+
+/// Unknown id with no registry entry: registry-policy validation runs
+/// (deny-by-default) and rejects. The relaxation does NOT bypass
+/// permissions — it only allows the validator to skip the per-component
+/// invariant hook when no `Component` impl exists.
+#[test]
+fn unknown_component_in_xmtp_range_rejected_without_registry_entry() {
+    let reg = ComponentRegistry::new();
+    let op = AppDataUpdateOperation::Update(b"opaque".to_vec().into());
+    let err = validate_one_app_data_update_with_old_value(
+        ComponentId::new(0x8FFF),
+        &op,
+        super_admin(),
+        "inbox_alice",
+        &reg,
+        None,
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, CommitValidationError::InsufficientPermissions),
+        "deny-by-default must fire for unknown ids without a registry entry, got {err:?}"
+    );
+}
+
+/// Unknown id with a permissive registry entry: validation passes.
+/// This is the "graceful unknown" path — old clients learn the new
+/// component exists via the registry write that newer clients ship
+/// alongside the component, and policy gates the write the same way it
+/// would for a known component.
+#[test]
+fn unknown_component_in_xmtp_range_allowed_when_registry_permits() {
+    let reg = registry_with(
+        ComponentId::new(0x8FFF),
+        allow(),
+        allow(),
+        allow(),
+        ComponentType::Bytes,
+    );
+    let op = AppDataUpdateOperation::Update(b"opaque".to_vec().into());
+    let result = validate_one_app_data_update_with_old_value(
+        ComponentId::new(0x8FFF),
+        &op,
+        member(),
+        "inbox_alice",
+        &reg,
+        None,
+    );
+    assert!(
+        result.is_ok(),
+        "unknown id with permissive registry must pass, got {result:?}"
+    );
+}
+
+/// Same as the prior case but in the app range (`0xC000-0xFCFF`).
+/// Confirms the type-aware dispatch is range-agnostic across the
+/// XMTP / application id space.
+#[test]
+fn unknown_component_in_app_range_allowed_when_registry_permits() {
+    let reg = registry_with(
+        ComponentId::new(0xC123),
+        allow(),
+        allow(),
+        allow(),
+        ComponentType::Bytes,
+    );
+    let op = AppDataUpdateOperation::Update(b"opaque".to_vec().into());
+    let result = validate_one_app_data_update_with_old_value(
+        ComponentId::new(0xC123),
+        &op,
+        member(),
+        "inbox_alice",
+        &reg,
+        None,
+    );
+    assert!(
+        result.is_ok(),
+        "unknown app-range id with permissive registry must pass, got {result:?}"
+    );
+}
+
+/// Reserved range `0xFF00+` is NOT in the tolerance predicate. The
+/// validator falls through to the catch-all rejection path — these
+/// slots are protocol-level and have no graceful-degrade story. We
+/// can't construct a registry entry for a reserved-range id
+/// (`ComponentRegistry::set` rejects them at construction), so this
+/// only exercises the "no registry + reserved id" path. That's the
+/// only production path anyway: a malicious sender can put a reserved
+/// id on the wire, but they can't get a registry entry to back it.
+#[test]
+fn unknown_component_in_reserved_range_rejected_with_empty_registry() {
+    let reg = ComponentRegistry::new();
+    let op = AppDataUpdateOperation::Update(b"x".to_vec().into());
+    let err = validate_one_app_data_update_with_old_value(
+        ComponentId::new(0xFF00),
+        &op,
+        super_admin(),
+        "inbox_alice",
+        &reg,
+        None,
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, CommitValidationError::InsufficientPermissions),
+        "reserved-range ids must be rejected, got {err:?}"
+    );
+}
+
+/// Unknown id Remove with no prior value: registry-delete policy
+/// gates this the same way as for known components.
+#[test]
+fn unknown_component_remove_with_no_prior_rejected_without_registry_entry() {
+    let reg = ComponentRegistry::new();
+    let op = AppDataUpdateOperation::Remove;
+    let err = validate_one_app_data_update_with_old_value(
+        ComponentId::new(0x8FFF),
+        &op,
+        super_admin(),
+        "inbox_alice",
+        &reg,
+        None,
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, CommitValidationError::InsufficientPermissions),
+        "deny-by-default applies to Remove on unknown ids, got {err:?}"
+    );
+}
+
+/// Unknown id Remove with permissive delete policy passes — same
+/// contract as known components. Pins that the validator doesn't
+/// require `old_value` to be present for the unknown-Remove path.
+#[test]
+fn unknown_component_remove_allowed_when_registry_permits_delete() {
+    let reg = registry_with(
+        ComponentId::new(0x8FFF),
+        allow(),
+        allow(),
+        allow(),
+        ComponentType::Bytes,
+    );
+    let op = AppDataUpdateOperation::Remove;
+    let result = validate_one_app_data_update_with_old_value(
+        ComponentId::new(0x8FFF),
+        &op,
+        member(),
+        "inbox_alice",
+        &reg,
+        None,
+    );
+    assert!(
+        result.is_ok(),
+        "Remove on unknown id with permissive delete-policy must pass, got {result:?}"
+    );
+}
+
+/// Unknown `TlsSet`-typed component with a well-formed delta payload
+/// but a malformed prior snapshot in the dict: the type-aware expander
+/// fails when it tries to decode `old_value` as a `TlsSet`. Surfaces
+/// as `InsufficientPermissions` (the validator's catch-all rejection
+/// for any expand-time failure) and produces a log line tagged with
+/// the component id so triage can distinguish "bad payload" from
+/// "bad prior."
+#[test]
+fn unknown_component_update_with_malformed_prior_rejected() {
+    use tls_codec::VLBytes;
+    let id = ComponentId::new(0x8FFF);
+    let reg = registry_with(id, allow(), allow(), allow(), ComponentType::TlsSetBytes);
+    let delta = TlsSetDelta::<VLBytes>::new()
+        .remove_by_hash(TlsKeyHash::of(&VLBytes::new(b"x".to_vec())).unwrap());
+    let payload = delta.tls_serialize_detached().unwrap();
+    let op = AppDataUpdateOperation::Update(payload.into());
+
+    // Prior bytes don't decode as a `TlsSet<VLBytes>` — the
+    // RemoveByHash arm builds the prior hash index, which tls-codec
+    // rejects.
+    let corrupt_prior = b"\xDE\xAD\xBE\xEF";
+
+    let err = validate_one_app_data_update_with_old_value(
+        id,
+        &op,
+        super_admin(),
+        "inbox_alice",
+        &reg,
+        Some(corrupt_prior),
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, CommitValidationError::InsufficientPermissions),
+        "malformed prior on unknown id must reject, got {err:?}"
+    );
+}

--- a/crates/xmtp_mls/src/groups/validated_commit.rs
+++ b/crates/xmtp_mls/src/groups/validated_commit.rs
@@ -1260,29 +1260,53 @@ pub(super) fn validate_one_app_data_update_with_old_value(
         validation::{ComponentChange, validate_component_write},
     };
 
-    // Single dispatch lookup serves both expansion and the per-element
-    // invariant hook below.
-    let Some(component) = lookup_component(component_id) else {
-        tracing::warn!(
-            proposer_inbox_id,
-            component_id = %component_id,
-            "AppDataUpdate proposal rejected: no Component impl for component id"
-        );
-        return Err(CommitValidationError::InsufficientPermissions);
+    // Two dispatch shapes:
+    //
+    // - **Known component**: expand via the per-id `Component` impl
+    //   (decodes Set/Map deltas into per-element changes) and run both
+    //   layers — registry policy AND per-component invariant.
+    //
+    // - **Unknown component** (no per-id impl on this client; the
+    //   sender shipped a newer release): look the component's
+    //   registered [`ComponentType`] up in the registry and run the
+    //   type-aware expansion. Same per-element change list a typed
+    //   client would produce, fed through the same policy loop. The
+    //   per-component invariant hook is skipped — there's no per-id
+    //   trait method to call — but registry-policy enforcement still
+    //   gates the write, so deny-by-default applies.
+    let component = lookup_component(component_id);
+    let changes = if let Some(component) = component {
+        component
+            .expand_to_changes(operation, old_value)
+            .map_err(|e| {
+                let wrapped = super::app_data::component_source::ComponentSourceError::from(e);
+                tracing::warn!(
+                    proposer_inbox_id,
+                    component_id = %component_id,
+                    error = %wrapped,
+                    "AppDataUpdate proposal rejected: failed to expand payload"
+                );
+                CommitValidationError::InsufficientPermissions
+            })?
+    } else {
+        match super::app_data::component_source::expand_app_data_update_to_changes(
+            component_id,
+            operation,
+            old_value,
+            registry,
+        ) {
+            Ok(changes) => changes,
+            Err(err) => {
+                tracing::warn!(
+                    proposer_inbox_id,
+                    component_id = %component_id,
+                    error = %err,
+                    "AppDataUpdate proposal rejected"
+                );
+                return Err(CommitValidationError::InsufficientPermissions);
+            }
+        }
     };
-
-    let changes = component
-        .expand_to_changes(operation, old_value)
-        .map_err(|e| {
-            let wrapped = super::app_data::component_source::ComponentSourceError::from(e);
-            tracing::warn!(
-                proposer_inbox_id,
-                component_id = %component_id,
-                error = %wrapped,
-                "AppDataUpdate proposal rejected: failed to expand payload"
-            );
-            CommitValidationError::InsufficientPermissions
-        })?;
 
     for change in &changes {
         let cc = ComponentChange::builder()
@@ -1292,7 +1316,9 @@ pub(super) fn validate_one_app_data_update_with_old_value(
             .maybe_new_value(change.value.as_deref())
             .build();
 
-        // Layer 1: registry-based policy.
+        // Layer 1: registry-based policy. Applies to both known and
+        // unknown components — every component requires a registry
+        // entry (deny by default).
         if let Err(e) = validate_component_write(&cc, registry) {
             tracing::warn!(
                 proposer_inbox_id,
@@ -1304,9 +1330,13 @@ pub(super) fn validate_one_app_data_update_with_old_value(
             return Err(CommitValidationError::InsufficientPermissions);
         }
 
-        // Layer 2: per-component invariants. Runs after the policy
-        // check so a denied actor can't trigger expensive invariants.
-        if let Err(e) = component.validate_invariant(&cc, registry) {
+        // Layer 2: per-component invariants. Only available for known
+        // components — unknown ids have nothing to invoke. Skipping
+        // the invariant is the cost of forward compatibility (see
+        // module-level docstring).
+        if let Some(component) = component
+            && let Err(e) = component.validate_invariant(&cc, registry)
+        {
             tracing::warn!(
                 proposer_inbox_id,
                 component_id = %component_id,

--- a/crates/xmtp_mls_common/src/app_data/components/inbox_id_set.rs
+++ b/crates/xmtp_mls_common/src/app_data/components/inbox_id_set.rs
@@ -33,8 +33,12 @@ use crate::{
 /// always carries a delta describing the change. This function is
 /// the one boundary that translates between them.
 ///
-/// Shared between the three inbox-id-set impls.
-fn apply_inbox_id_set_delta(
+/// Shared between the three inbox-id-set impls, and reachable from the
+/// type-aware fallback in
+/// [`super::type_dispatch::apply_update_payload_for_type`] for any
+/// future `TlsSetInboxId` component an old client does not yet have a
+/// per-id `Component` impl for.
+pub(crate) fn apply_inbox_id_set_delta(
     payload: &[u8],
     prior: Option<&[u8]>,
 ) -> Result<Vec<u8>, ComponentTypedError> {
@@ -55,7 +59,7 @@ fn apply_inbox_id_set_delta(
 /// implementation in `xmtp_mls::groups::app_data::component_source`
 /// (which #7 will retire). `RemoveByHash` mutations resolve back to
 /// the underlying `InboxId` via a hash index built from the prior set.
-fn expand_inbox_id_set_changes(
+pub(crate) fn expand_inbox_id_set_changes(
     op: &AppDataUpdateOperation,
     prior: Option<&[u8]>,
 ) -> Result<Vec<ExpandedComponentChange>, ComponentTypedError> {

--- a/crates/xmtp_mls_common/src/app_data/components/metadata_attributes.rs
+++ b/crates/xmtp_mls_common/src/app_data/components/metadata_attributes.rs
@@ -35,14 +35,14 @@ use crate::app_data::{
 
 /// Apply a passthrough Update payload — no delta math, the payload is
 /// the new full value bytes.
-fn apply_passthrough(payload: &[u8]) -> Result<Vec<u8>, ComponentTypedError> {
+pub(crate) fn apply_passthrough(payload: &[u8]) -> Result<Vec<u8>, ComponentTypedError> {
     Ok(payload.to_vec())
 }
 
 /// Expand an `AppDataUpdate` proposal for a passthrough component:
 /// `Update` produces one `Update` change carrying the payload bytes;
 /// `Remove` produces one `Delete` change with no value.
-fn expand_passthrough(
+pub(crate) fn expand_passthrough(
     op: &AppDataUpdateOperation,
 ) -> Result<Vec<ExpandedComponentChange>, ComponentTypedError> {
     match op {
@@ -60,7 +60,10 @@ fn expand_passthrough(
 /// Decode UTF-8 bytes into a `String`, surfacing a structured
 /// [`ComponentTypedError::MalformedValue`] on invalid input rather than
 /// the bare `Utf8Error`.
-fn decode_utf8(component_id: ComponentId, bytes: &[u8]) -> Result<String, ComponentTypedError> {
+pub(crate) fn decode_utf8(
+    component_id: ComponentId,
+    bytes: &[u8],
+) -> Result<String, ComponentTypedError> {
     std::str::from_utf8(bytes)
         .map(str::to_owned)
         .map_err(|err| ComponentTypedError::MalformedValue {

--- a/crates/xmtp_mls_common/src/app_data/components/mod.rs
+++ b/crates/xmtp_mls_common/src/app_data/components/mod.rs
@@ -11,3 +11,4 @@
 pub mod inbox_id_set;
 pub mod metadata_attributes;
 pub mod tls_map_components;
+pub mod type_dispatch;

--- a/crates/xmtp_mls_common/src/app_data/components/tls_map_components.rs
+++ b/crates/xmtp_mls_common/src/app_data/components/tls_map_components.rs
@@ -43,8 +43,11 @@ use crate::{
 /// the one boundary that translates between them.
 ///
 /// Generic over the key type so both `InboxId`-keyed and
-/// `ComponentId`-keyed maps share the same body.
-fn apply_tls_map_delta<K>(
+/// `ComponentId`-keyed maps share the same body. Also reachable from the
+/// type-aware fallback in
+/// [`super::type_dispatch::apply_update_payload_for_type`] (with
+/// `K = VLBytes` for the `TlsMapBytesBytes` shape).
+pub(crate) fn apply_tls_map_delta<K>(
     payload: &[u8],
     prior: Option<&[u8]>,
 ) -> Result<Vec<u8>, ComponentTypedError>
@@ -93,7 +96,7 @@ where
 /// sync with the apply-time rules and reject things the apply step
 /// would happily accept. Keep it single-source: codec here, semantics
 /// at apply.
-fn expand_tls_map_changes<K>(
+pub(crate) fn expand_tls_map_changes<K>(
     op: &AppDataUpdateOperation,
     _prior: Option<&[u8]>,
 ) -> Result<Vec<ExpandedComponentChange>, ComponentTypedError>

--- a/crates/xmtp_mls_common/src/app_data/components/type_dispatch.rs
+++ b/crates/xmtp_mls_common/src/app_data/components/type_dispatch.rs
@@ -1,0 +1,398 @@
+//! Type-aware dispatch for `AppDataUpdate` proposals against a
+//! component whose `Component` impl this client does not have.
+//!
+//! The receive-side relaxation path in
+//! `xmtp_mls::groups::app_data::component_source` calls
+//! [`lookup_component`](super::super::registry_table::lookup_component)
+//! first; on a hit the per-id `Component` impl handles everything. On a
+//! miss the caller looks the component up in the on-dict
+//! [`ComponentRegistry`](crate::app_data::component_registry::ComponentRegistry),
+//! pulls the registered [`ComponentType`], and dispatches through this
+//! module.
+//!
+//! The dispatch is by-type because every `Component` impl in
+//! [`super::metadata_attributes`], [`super::inbox_id_set`], and
+//! [`super::tls_map_components`] is a thin per-id wrapper over the
+//! type-level encoding semantics. Decoding bytes for an unknown
+//! `TlsSet<InboxId>` component is identical to decoding bytes for
+//! `AdminListComponent` — only the policy applied at validation time
+//! differs, and that's keyed off the registry entry. So the closed
+//! universe of six [`ComponentType`] variants is the same as the closed
+//! universe of dispatch arms here.
+
+use openmls::messages::proposals::AppDataUpdateOperation;
+use std::collections::HashMap;
+use tls_codec::{Deserialize, Serialize, VLBytes};
+use xmtp_proto::xmtp::mls::message_contents::ComponentType;
+
+use crate::{
+    app_data::{
+        component_id::ComponentId,
+        component_registry::ComponentOp,
+        components::{
+            inbox_id_set::{apply_inbox_id_set_delta, expand_inbox_id_set_changes},
+            metadata_attributes::{apply_passthrough, decode_utf8, expand_passthrough},
+            tls_map_components::{apply_tls_map_delta, expand_tls_map_changes},
+        },
+        typed::{ComponentTypedError, ExpandedComponentChange},
+    },
+    inbox_id::InboxId,
+    tls_set::{TlsKeyHash, TlsSet, TlsSetDelta, TlsSetError, TlsSetMutation},
+};
+
+/// Apply an `AppDataUpdateOperation::Update` payload for a component
+/// whose `Component` impl is not available on this client, using only
+/// its registered [`ComponentType`].
+///
+/// `component_id` is carried through to error context — it does not
+/// influence the dispatch, which is purely a function of `ty`. Bare
+/// `tls_codec::Error`s leaking out of the per-type helpers get wrapped
+/// with the id so log triage can pinpoint *which* unknown component
+/// failed to decode, instead of just seeing a context-free codec
+/// error.
+pub fn apply_update_payload_for_type(
+    component_id: ComponentId,
+    ty: ComponentType,
+    payload: &[u8],
+    prior: Option<&[u8]>,
+) -> Result<Vec<u8>, ComponentTypedError> {
+    let result = match ty {
+        ComponentType::Bytes => apply_passthrough(payload),
+        ComponentType::String => {
+            let _ = decode_utf8(component_id, payload)?;
+            apply_passthrough(payload)
+        }
+        ComponentType::TlsSetInboxId => apply_inbox_id_set_delta(payload, prior),
+        ComponentType::TlsSetBytes => apply_bytes_set_delta(payload, prior),
+        ComponentType::TlsMapInboxIdBytes => apply_tls_map_delta::<InboxId>(payload, prior),
+        ComponentType::TlsMapBytesBytes => apply_tls_map_delta::<VLBytes>(payload, prior),
+        ComponentType::Unspecified => Err(ComponentTypedError::UnspecifiedType(component_id)),
+    };
+    result.map_err(|e| attach_component_id(component_id, ty, e, ApplyOrExpand::Apply))
+}
+
+/// Expand an `AppDataUpdateOperation` for a component whose `Component`
+/// impl is not available on this client, using only its registered
+/// [`ComponentType`].
+pub fn expand_to_changes_for_type(
+    component_id: ComponentId,
+    ty: ComponentType,
+    op: &AppDataUpdateOperation,
+    prior: Option<&[u8]>,
+) -> Result<Vec<ExpandedComponentChange>, ComponentTypedError> {
+    let result = match ty {
+        ComponentType::Bytes => expand_passthrough(op),
+        ComponentType::String => {
+            if let AppDataUpdateOperation::Update(payload) = op {
+                let _ = decode_utf8(component_id, payload.as_slice())?;
+            }
+            expand_passthrough(op)
+        }
+        ComponentType::TlsSetInboxId => expand_inbox_id_set_changes(op, prior),
+        ComponentType::TlsSetBytes => expand_bytes_set_changes(op, prior),
+        ComponentType::TlsMapInboxIdBytes => expand_tls_map_changes::<InboxId>(op, prior),
+        ComponentType::TlsMapBytesBytes => expand_tls_map_changes::<VLBytes>(op, prior),
+        ComponentType::Unspecified => Err(ComponentTypedError::UnspecifiedType(component_id)),
+    };
+    result.map_err(|e| attach_component_id(component_id, ty, e, ApplyOrExpand::Expand))
+}
+
+#[derive(Clone, Copy)]
+enum ApplyOrExpand {
+    Apply,
+    Expand,
+}
+
+impl std::fmt::Display for ApplyOrExpand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Apply => f.write_str("apply"),
+            Self::Expand => f.write_str("expand"),
+        }
+    }
+}
+
+/// Re-wrap bare `tls_codec::Error`s — which lack component context —
+/// into a [`ComponentTypedError::MalformedValue`] that carries the id
+/// and a short description of where the failure happened. Other
+/// variants (already-structured `MalformedValue`, set/map apply
+/// errors, etc.) pass through unchanged.
+fn attach_component_id(
+    component_id: ComponentId,
+    ty: ComponentType,
+    err: ComponentTypedError,
+    site: ApplyOrExpand,
+) -> ComponentTypedError {
+    match err {
+        ComponentTypedError::TlsCodec(inner) => ComponentTypedError::MalformedValue {
+            component_id,
+            reason: format!("type-aware {site} ({ty:?}) tls codec error: {inner}"),
+        },
+        other => other,
+    }
+}
+
+// =============================================================================
+// TlsSet<VLBytes> apply/expand
+// =============================================================================
+//
+// Mirrors `apply_inbox_id_set_delta` / `expand_inbox_id_set_changes` but
+// keyed on `VLBytes`. No well-known `TlsSetBytes` component ships today;
+// this exists so a future XMTP-defined or runtime-registered bytes-set
+// component lands on old clients via the same delta-aware path the
+// inbox-id-set components use.
+
+fn apply_bytes_set_delta(
+    payload: &[u8],
+    prior: Option<&[u8]>,
+) -> Result<Vec<u8>, ComponentTypedError> {
+    let delta = TlsSetDelta::<VLBytes>::tls_deserialize_exact(payload)?;
+    let mut set: TlsSet<VLBytes> = match prior {
+        Some(bytes) => TlsSet::<VLBytes>::tls_deserialize_exact(bytes)?,
+        None => TlsSet::new(),
+    };
+    set.apply_delta(delta)?;
+    Ok(set.tls_serialize_detached()?)
+}
+
+fn expand_bytes_set_changes(
+    op: &AppDataUpdateOperation,
+    prior: Option<&[u8]>,
+) -> Result<Vec<ExpandedComponentChange>, ComponentTypedError> {
+    match op {
+        AppDataUpdateOperation::Remove => Ok(vec![ExpandedComponentChange {
+            op: ComponentOp::Delete,
+            value: None,
+        }]),
+        AppDataUpdateOperation::Update(payload) => {
+            let delta = TlsSetDelta::<VLBytes>::tls_deserialize_exact(payload.as_slice())?;
+
+            // Same RemoveByHash resolution discipline as
+            // `expand_inbox_id_set_changes`: build the hash index once,
+            // only when the delta carries at least one `RemoveByHash`,
+            // and only when prior bytes exist.
+            let needs_index = delta
+                .mutations
+                .iter()
+                .any(|m| matches!(m, TlsSetMutation::RemoveByHash(_)));
+            let hash_index: Option<HashMap<TlsKeyHash, VLBytes>> = if needs_index {
+                match prior {
+                    Some(bytes) => {
+                        let prior_set = TlsSet::<VLBytes>::tls_deserialize_exact(bytes)?;
+                        let mut idx = HashMap::with_capacity(prior_set.len());
+                        for key in prior_set.iter() {
+                            if idx.insert(TlsKeyHash::of(key)?, key.clone()).is_some() {
+                                return Err(ComponentTypedError::TlsSetApply(
+                                    TlsSetError::DuplicateHash,
+                                ));
+                            }
+                        }
+                        Some(idx)
+                    }
+                    None => None,
+                }
+            } else {
+                None
+            };
+
+            let mut out = Vec::with_capacity(delta.mutations.len());
+            for mutation in delta.mutations {
+                match mutation {
+                    TlsSetMutation::Insert(key) => out.push(ExpandedComponentChange {
+                        op: ComponentOp::Insert,
+                        value: Some(key.as_slice().to_vec()),
+                    }),
+                    TlsSetMutation::Remove(key) => out.push(ExpandedComponentChange {
+                        op: ComponentOp::Delete,
+                        value: Some(key.as_slice().to_vec()),
+                    }),
+                    TlsSetMutation::RemoveByHash(target) => {
+                        let resolved = hash_index
+                            .as_ref()
+                            .and_then(|idx| idx.get(&target))
+                            .map(|key| key.as_slice().to_vec());
+                        out.push(ExpandedComponentChange {
+                            op: ComponentOp::Delete,
+                            value: resolved,
+                        });
+                    }
+                }
+            }
+            Ok(out)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app_data::component_registry::ComponentOp;
+    use crate::tls_map::{TlsMap, TlsMapDelta, TlsMapMutation};
+
+    const UNKNOWN_ID: ComponentId = ComponentId::new(0x80FF);
+
+    fn vl(bytes: &[u8]) -> VLBytes {
+        VLBytes::new(bytes.to_vec())
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn apply_bytes_passthrough() {
+        let new_bytes = apply_update_payload_for_type(
+            UNKNOWN_ID,
+            ComponentType::Bytes,
+            b"opaque-bytes",
+            Some(b"prior-bytes"),
+        )
+        .unwrap();
+        assert_eq!(new_bytes, b"opaque-bytes");
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn apply_string_validates_utf8() {
+        let ok = apply_update_payload_for_type(UNKNOWN_ID, ComponentType::String, b"hello", None)
+            .unwrap();
+        assert_eq!(ok, b"hello");
+
+        // Invalid UTF-8 (lone continuation byte) is rejected. Keeps
+        // old-client behavior consistent with what a typed
+        // `String`-shaped `Component` impl would do.
+        let invalid =
+            apply_update_payload_for_type(UNKNOWN_ID, ComponentType::String, &[0xC3, 0x28], None);
+        assert!(matches!(
+            invalid,
+            Err(ComponentTypedError::MalformedValue { .. })
+        ));
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn apply_tls_set_inbox_id_delta() {
+        let id1 = InboxId::from_bytes([1u8; 32]);
+        let delta = TlsSetDelta::<InboxId>::new().insert(id1);
+        let payload = delta.tls_serialize_detached().unwrap();
+        let new_bytes =
+            apply_update_payload_for_type(UNKNOWN_ID, ComponentType::TlsSetInboxId, &payload, None)
+                .unwrap();
+        let set = TlsSet::<InboxId>::tls_deserialize_exact(&new_bytes).unwrap();
+        assert_eq!(set.len(), 1);
+        assert!(set.contains(&id1));
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn apply_tls_set_bytes_delta() {
+        let delta = TlsSetDelta::<VLBytes>::new().insert(vl(b"alpha"));
+        let payload = delta.tls_serialize_detached().unwrap();
+        let new_bytes =
+            apply_update_payload_for_type(UNKNOWN_ID, ComponentType::TlsSetBytes, &payload, None)
+                .unwrap();
+        let set = TlsSet::<VLBytes>::tls_deserialize_exact(&new_bytes).unwrap();
+        assert_eq!(set.len(), 1);
+        assert!(set.contains(&vl(b"alpha")));
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn apply_tls_map_inbox_id_bytes_delta() {
+        let id1 = InboxId::from_bytes([2u8; 32]);
+        let mut delta = TlsMapDelta::<InboxId, VLBytes>::new();
+        delta.mutations.push(TlsMapMutation::Insert {
+            key: id1,
+            value: vl(b"v1"),
+        });
+        let payload = delta.tls_serialize_detached().unwrap();
+        let new_bytes = apply_update_payload_for_type(
+            UNKNOWN_ID,
+            ComponentType::TlsMapInboxIdBytes,
+            &payload,
+            None,
+        )
+        .unwrap();
+        let map = TlsMap::<InboxId, VLBytes>::tls_deserialize_exact(&new_bytes).unwrap();
+        assert_eq!(map.len(), 1);
+        assert_eq!(map.get(&id1).map(|v| v.as_slice()), Some(&b"v1"[..]));
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn apply_tls_map_bytes_bytes_delta() {
+        let mut delta = TlsMapDelta::<VLBytes, VLBytes>::new();
+        delta.mutations.push(TlsMapMutation::Insert {
+            key: vl(b"k"),
+            value: vl(b"v"),
+        });
+        let payload = delta.tls_serialize_detached().unwrap();
+        let new_bytes = apply_update_payload_for_type(
+            UNKNOWN_ID,
+            ComponentType::TlsMapBytesBytes,
+            &payload,
+            None,
+        )
+        .unwrap();
+        let map = TlsMap::<VLBytes, VLBytes>::tls_deserialize_exact(&new_bytes).unwrap();
+        assert_eq!(map.len(), 1);
+        assert_eq!(map.get(&vl(b"k")).map(|v| v.as_slice()), Some(&b"v"[..]));
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn unspecified_type_is_rejected() {
+        let err = apply_update_payload_for_type(
+            UNKNOWN_ID,
+            ComponentType::Unspecified,
+            b"whatever",
+            None,
+        )
+        .unwrap_err();
+        assert!(matches!(err, ComponentTypedError::UnspecifiedType(_)));
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn expand_bytes_remove_yields_delete_no_value() {
+        let changes = expand_to_changes_for_type(
+            UNKNOWN_ID,
+            ComponentType::Bytes,
+            &AppDataUpdateOperation::Remove,
+            None,
+        )
+        .unwrap();
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].op, ComponentOp::Delete);
+        assert!(changes[0].value.is_none());
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn expand_tls_set_bytes_insert_yields_per_element() {
+        let delta = TlsSetDelta::<VLBytes>::new()
+            .insert(vl(b"alpha"))
+            .insert(vl(b"beta"));
+        let payload = delta.tls_serialize_detached().unwrap();
+        let op = AppDataUpdateOperation::Update(payload.into());
+        let changes =
+            expand_to_changes_for_type(UNKNOWN_ID, ComponentType::TlsSetBytes, &op, None).unwrap();
+        assert_eq!(changes.len(), 2);
+        assert_eq!(changes[0].op, ComponentOp::Insert);
+        assert_eq!(changes[0].value.as_deref(), Some(&b"alpha"[..]));
+        assert_eq!(changes[1].op, ComponentOp::Insert);
+        assert_eq!(changes[1].value.as_deref(), Some(&b"beta"[..]));
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn expand_tls_set_bytes_remove_by_hash_resolves_against_prior() {
+        let key = vl(b"target");
+        let mut prior_set = TlsSet::<VLBytes>::new();
+        prior_set.insert(key.clone()).unwrap();
+        let prior_bytes = prior_set.tls_serialize_detached().unwrap();
+
+        let target_hash = TlsKeyHash::of(&key).unwrap();
+        let delta = TlsSetDelta::<VLBytes>::new().remove_by_hash(target_hash);
+        let payload = delta.tls_serialize_detached().unwrap();
+        let op = AppDataUpdateOperation::Update(payload.into());
+
+        let changes = expand_to_changes_for_type(
+            UNKNOWN_ID,
+            ComponentType::TlsSetBytes,
+            &op,
+            Some(&prior_bytes),
+        )
+        .unwrap();
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].op, ComponentOp::Delete);
+        assert_eq!(changes[0].value.as_deref(), Some(&b"target"[..]));
+    }
+}

--- a/crates/xmtp_mls_common/src/app_data/typed.rs
+++ b/crates/xmtp_mls_common/src/app_data/typed.rs
@@ -270,6 +270,17 @@ pub enum ComponentTypedError {
     /// full value of a Map component from an incoming delta.
     #[error("tls map apply error: {0}")]
     TlsMapApply(#[from] TlsMapError),
+
+    /// The component's registered [`ComponentType`] is
+    /// [`ComponentType::Unspecified`] (a proto-default sentinel). The
+    /// type-aware fallback in
+    /// [`super::components::type_dispatch::apply_update_payload_for_type`]
+    /// has no decoder for this — the registry entry is malformed or
+    /// was written by a peer that does not know the type yet.
+    ///
+    /// [`ComponentType`]: xmtp_proto::xmtp::mls::message_contents::ComponentType
+    #[error("component {0} has no registered ComponentType (unspecified)")]
+    UnspecifiedType(ComponentId),
 }
 
 /// Errors surfaced by [`Component::validate_invariant`].


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Relax unknown-component rejection at receive-side validation, accumulation, and apply sites
- Unknown MLS app data components are no longer categorically rejected; if the on-dict `ComponentRegistry` provides a `ComponentType`, the update is applied and validated using type-aware dispatch instead of being immediately rejected.
- Adds a new `type_dispatch` module in `xmtp_mls_common` with `apply_update_payload_for_type` and `expand_to_changes_for_type`, covering `Bytes`, `String` (UTF-8 validated), `TlsSetInboxId`, TLS maps, and byte-sets.
- `validate_one_app_data_update_with_old_value`, `accumulate_app_data_updates`, and `apply_app_data_update_payload` all gain a `&ComponentRegistry` parameter; the registry is snapshotted at pre-commit and passed through the call chain.
- Per-component invariant checks still only run when a known per-id `Component` impl exists; unknown components pass with policy enforcement only.
- Risk: callers that previously received an `UnknownComponent` error for unregistered components will now succeed if the registry entry is present and policy allows it, changing runtime behavior for forward-compatible components.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized c6f6e02.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->