### PR TITLE
xmtp_mls: split stage_inline_app_data_commit into standalone propose + commit

### DIFF
--- a/crates/xmtp_mls/src/groups/app_data/component_source.rs
+++ b/crates/xmtp_mls/src/groups/app_data/component_source.rs
@@ -361,7 +361,7 @@ pub(crate) fn read_component_bytes(
 /// into [`expand_app_data_update_to_changes`] as `old_value` — the
 /// validator uses that to resolve `RemoveByHash` mutations back to
 /// their underlying inbox id. The parent `app_data` module also uses
-/// it from `process_message_with_app_data`, `stage_inline_app_data_commit`,
+/// it from `process_message_with_app_data`, `stage_app_data_propose_and_commit`,
 /// and `pending_app_data_updates`.
 pub(crate) fn read_from_app_data_dict(
     id: ComponentId,

--- a/crates/xmtp_mls/src/groups/app_data/mod.rs
+++ b/crates/xmtp_mls/src/groups/app_data/mod.rs
@@ -25,8 +25,8 @@ use std::collections::BTreeMap;
 
 use openmls::{
     component::ComponentData,
-    framing::{ProcessedMessage, ProtocolMessage},
-    group::{AppDataUpdates, MlsGroup as OpenMlsGroup, ProcessMessageError},
+    framing::{MlsMessageOut, ProcessedMessage, ProtocolMessage},
+    group::{AppDataUpdates, MlsGroup as OpenMlsGroup, ProcessMessageError, ProposalError},
     messages::proposals::{AppDataUpdateOperation, Proposal},
     messages::proposals_in::{ProposalIn, ProposalOrRefIn},
     // `CommitMessageBundle` lives in `prelude` because the natural path
@@ -243,63 +243,78 @@ pub(crate) fn process_message_with_app_data<Provider: OpenMlsProvider>(
     )?)
 }
 
-/// Stage a commit that bundles a single inline `AppDataUpdate(Update)`
-/// proposal AND the resulting AppDataDictionary update.
+/// Stage a standalone `AppDataUpdate(Update)` proposal AND a follow-up
+/// commit that references it from the OpenMLS proposal store.
 ///
-/// This is the shape used by the per-field intent handlers
-/// (`MetadataUpdate`, `UpdateAdminList`, …) when `proposals_enabled` is
-/// on. Unlike `propose_app_data_update` (which produces a
-/// proposal-by-reference that has to be committed in a follow-up sync),
-/// this builds a self-contained commit so the propose-and-apply happens in
-/// a single network round trip — preserving the "metadata update completes
-/// in one sync" semantics that the legacy GCE path provides.
+/// This is the shape XIP §1.5.2 / §3.4 prescribes for post-migration
+/// metadata updates: separate proposal and commit MLS messages, so the
+/// commit message carries only a `ProposalRef` (hash) rather than the
+/// AppDataUpdate payload bytes. Smaller commits, smaller proposal-
+/// processing hot paths, identical end state.
+///
+/// Returns `(proposal_msg, commit_bundle)`. The caller MUST publish
+/// `proposal_msg` and `commit_bundle.commit()` together in one
+/// `payloads_to_publish` batch (proposal first) so receivers see the
+/// proposal in the same network round trip before processing the
+/// commit that references it.
 ///
 /// The caller is expected to wrap this inside `generate_commit_with_rollback`
 /// so the staged commit can be extracted and persisted alongside the
 /// intent.
-pub(crate) fn stage_inline_app_data_commit<Provider: OpenMlsProvider>(
+pub(crate) fn stage_app_data_propose_and_commit<Provider: OpenMlsProvider>(
     mls_group: &mut OpenMlsGroup,
     provider: &Provider,
     signer: &impl openmls_traits::signatures::Signer,
     component_id: ComponentId,
     payload: Vec<u8>,
-) -> Result<CommitMessageBundle, GroupAppDataError<Provider::StorageError>> {
-    use openmls::messages::proposals::AppDataUpdateProposal;
-
+) -> Result<(MlsMessageOut, CommitMessageBundle), GroupAppDataError<Provider::StorageError>> {
+    // Lazy-batching: we deliberately do NOT block on pre-existing
+    // pending proposals. This helper queues a new `AppDataUpdate` then
+    // commits via `consume_proposal_store(true)`, sweeping whatever
+    // else is in the store — concurrent `AppDataUpdate`s (accumulated
+    // into the dict by step 2), leaf-node `Update`s, membership
+    // `Add` / `Remove` / `SelfRemove`, PSK, etc. — all into one
+    // commit. That's the design: minimize commit count, let the
+    // producers of those proposals decide if they need to force their
+    // own commit (because they want to send a message right now or
+    // grant access immediately). MLS guarantees consistent state
+    // convergence on the wire regardless of which commit body carries
+    // which proposal; the sender's intent ledger may carry less
+    // information than the on-wire commit, but the producer of each
+    // folded-in proposal already accepted that outcome by leaving it
+    // pending instead of issuing its own commit.
     let openmls_id = component_id.as_u16();
+    let operation = AppDataUpdateOperation::Update(payload.into());
 
-    // The commit builder defaults to `consume_proposal_store(true)` (see
-    // openmls's `Initial::default()`), matching the legacy GCE metadata-
-    // update path's behavior. So any pending `AppDataUpdate` proposals
-    // sitting in the store at the moment this runs will ALSO be swept
-    // into the commit — we account for their effects by chaining them
-    // with our own inline proposal through `accumulate_app_data_updates`
-    // below. Otherwise OpenMLS's `apply_app_data_update_proposals` would
-    // silently drop the pending proposals' dict writes.
+    // Step 1: publish a standalone proposal. This adds the proposal to
+    // the local pending-proposal store AND returns the wire-form
+    // MlsMessageOut for the proposal so the caller can broadcast it.
+    let (proposal_msg, _proposal_ref) = mls_group
+        .propose_app_data_update(provider, signer, openmls_id, operation)
+        .map_err(GroupAppDataError::Propose)?;
+
+    // Step 2: compute the per-component dict updates by sweeping every
+    // `AppDataUpdate` proposal currently in the store. The store may
+    // contain pre-existing `AppDataUpdate` proposals queued by earlier
+    // intents (e.g. two members each issuing a `GROUP_MEMBERSHIP`
+    // update, or a queued `update_group_name` that hasn't been
+    // committed yet); the accumulator chains them via the in-batch
+    // map so the final dict bytes match what
+    // `process_message_with_app_data` produces on the receive side.
     //
-    // Compute `AppDataUpdates` BEFORE we hand the proposal off to the
-    // commit builder. The receiver does the same dance via
-    // `process_message_with_app_data`, so both sides must end up with
-    // identical dict bytes — otherwise the commit's confirmation tag
-    // won't match across peers.
+    // Non-`AppDataUpdate` proposals (Add/Remove/Update/PSK/etc.) also
+    // get swept by `consume_proposal_store(true)` at step 3 — they
+    // ride into the commit natively via OpenMLS and don't contribute
+    // to AppData dict updates, so we don't include them in this
+    // iteration.
     //
-    // The ordering (pending first, inline last) mirrors OpenMLS's commit
-    // builder (`group_proposal_store_queue.chain(own_proposals)`) so
-    // that if a pending proposal and the inline proposal both target
-    // the same component, the inline one wins the final value.
-    //
-    // Failure mode if OpenMLS ever changes that chain order: the sender
-    // and receiver will each compute a different final dict value for the
-    // same component, so the commit's confirmation tag won't match across
-    // peers. That is an *observable* failure (receivers reject the commit
-    // with `WrongConfirmationTag`) — not a silent one — and the E2E tests
-    // in `groups/tests/test_proposals.rs` under the AppDataUpdate section
-    // would fail loudly on any openmls bump that reordered the chain. A
-    // dedicated "pending-vs-inline ordering" test belongs in the migration
-    // PR that wires a public standalone-proposal path — without that path
-    // there's no public API today to pre-populate the pending store with
-    // an AppDataUpdate proposal to test against.
-    let inline_operation = AppDataUpdateOperation::Update(payload.clone().into());
+    // Failure mode if OpenMLS ever changes `consume_proposal_store(true)`'s
+    // sweep behavior or `pending_proposals()` ordering: sender and
+    // receiver compute different final dict bytes for the same
+    // component, the commit's confirmation tag mismatches, and
+    // receivers reject the commit with `WrongConfirmationTag`. The E2E
+    // tests in `groups/tests/test_proposals.rs` under the AppDataUpdate
+    // section will fail loudly on any OpenMLS bump that breaks this.
     let pending_tuples: Vec<(openmls::component::ComponentId, AppDataUpdateOperation)> = mls_group
         .pending_proposals()
         .filter_map(|q| match q.proposal() {
@@ -307,23 +322,23 @@ pub(crate) fn stage_inline_app_data_commit<Provider: OpenMlsProvider>(
             _ => None,
         })
         .collect();
-    let chained = pending_tuples
-        .iter()
-        .map(|(id, op)| (*id, op))
-        .chain(std::iter::once((openmls_id, &inline_operation)));
-    let app_data_updates = accumulate_app_data_updates(mls_group, chained).inspect_err(|e| {
-        tracing::error!(
-            component_id = %component_id,
-            error = %e,
-            "Failed to compute AppDataUpdates for inline commit"
-        );
-    })?;
+    let pending_iter = pending_tuples.iter().map(|(id, op)| (*id, op));
+    let app_data_updates =
+        accumulate_app_data_updates(mls_group, pending_iter).inspect_err(|e| {
+            tracing::error!(
+                component_id = %component_id,
+                error = %e,
+                "Failed to compute AppDataUpdates for standalone propose+commit"
+            );
+        })?;
 
+    // Step 3: build a commit that consumes the proposal store (picks up
+    // the just-queued proposal). No `add_proposal` call — the proposal
+    // is encoded as a `ProposalRef` because it comes from the store, not
+    // from inline staging.
     let mut stage = mls_group
         .commit_builder()
-        .add_proposal(Proposal::AppDataUpdate(Box::new(
-            AppDataUpdateProposal::update(openmls_id, payload),
-        )))
+        .consume_proposal_store(true)
         .load_psks(provider.storage())?;
     stage.with_app_data_dictionary_updates(app_data_updates);
 
@@ -331,10 +346,10 @@ pub(crate) fn stage_inline_app_data_commit<Provider: OpenMlsProvider>(
         .build(provider.rand(), provider.crypto(), signer, |_| true)?
         .stage_commit(provider)?;
 
-    Ok(bundle)
+    Ok((proposal_msg, bundle))
 }
 
-/// Errors surfaced by [`stage_inline_app_data_commit`].
+/// Errors surfaced by [`stage_app_data_propose_and_commit`].
 ///
 /// Wrapped into `GroupError` via the `#[from]` impl on
 /// `GroupError::AppDataCommit` so the structured source is preserved at
@@ -343,6 +358,10 @@ pub(crate) fn stage_inline_app_data_commit<Provider: OpenMlsProvider>(
 /// the public `GroupError` enum.
 #[derive(Debug, thiserror::Error)]
 pub enum GroupAppDataError<StorageError: std::error::Error> {
+    /// `propose_app_data_update(…)` failed when staging the standalone
+    /// proposal that precedes the commit.
+    #[error("propose error: {0}")]
+    Propose(#[from] ProposalError<StorageError>),
     /// `commit_builder().load_psks(…).build(…)` failed.
     #[error("commit create error: {0}")]
     CreateCommit(#[from] openmls::group::CreateCommitError),
@@ -356,6 +375,33 @@ pub enum GroupAppDataError<StorageError: std::error::Error> {
     /// tag mismatch on the wire if it ever escaped.
     #[error("apply payload error: {0}")]
     ApplyPayload(#[from] self::component_source::ComponentSourceError),
+}
+
+// Specialize to the concrete SqlKeyStoreError because that's the only
+// storage instantiation used (see `GroupError::AppDataCommit` at
+// error.rs). It also lets us delegate to `RetryableError<Mls>` impls
+// already defined in `xmtp_db::errors` for the inner OpenMLS error
+// types — sibling pattern to `GroupError::Proposal(e) => e.is_retryable()`
+// — so SQLite-busy storage faults retry instead of permanently failing
+// the intent.
+impl xmtp_common::RetryableError for GroupAppDataError<xmtp_db::sql_key_store::SqlKeyStoreError> {
+    fn is_retryable(&self) -> bool {
+        match self {
+            // Delegate to the inner OpenMLS error's retryability so
+            // SQLite-busy storage faults during propose / stage retry
+            // rather than permanently fail the intent. The matching
+            // upstream impls live in `xmtp_db::errors`
+            // (`RetryableError<Mls>` for `ProposalError` /
+            // `CommitBuilderStageError`).
+            Self::Propose(e) => xmtp_common::retryable!(e),
+            Self::StageCommit(e) => xmtp_common::retryable!(e),
+            // Deterministic shape / staging-precondition failures —
+            // CreateCommit is upstream-`false`, and ApplyPayload is a
+            // sender-side encode failure that won't get better on
+            // retry.
+            Self::CreateCommit(_) | Self::ApplyPayload(_) => false,
+        }
+    }
 }
 
 /// Compute the [`AppDataUpdates`] required to commit any pending

--- a/crates/xmtp_mls/src/groups/app_data/sender_intents.rs
+++ b/crates/xmtp_mls/src/groups/app_data/sender_intents.rs
@@ -31,7 +31,7 @@ use xmtp_proto::xmtp::mls::message_contents::{
 };
 
 use super::component_source::{ComponentSourceError, metadata_field_to_component_id};
-use super::{load_component_registry, stage_inline_app_data_commit};
+use super::{load_component_registry, stage_app_data_propose_and_commit};
 use crate::{
     context::XmtpSharedContext,
     groups::{
@@ -86,11 +86,11 @@ pub(crate) fn apply_update_admin_list_app_data_intent(
     }
     .map_err(|e| GroupError::ComponentSource(ComponentSourceError::from(e)))?;
 
-    let (bundle, staged_commit, group_epoch) = generate_commit_with_rollback(
+    let ((proposal_msg, bundle), staged_commit, group_epoch) = generate_commit_with_rollback(
         storage,
         openmls_group,
         move |group, provider| -> Result<_, GroupError> {
-            Ok(stage_inline_app_data_commit(
+            Ok(stage_app_data_propose_and_commit(
                 group,
                 provider,
                 &signer,
@@ -106,7 +106,10 @@ pub(crate) fn apply_update_admin_list_app_data_intent(
         "UpdateAdminList via AppDataUpdate must not produce a welcome"
     );
     Ok(PublishIntentData {
-        payloads_to_publish: vec![commit.tls_serialize_detached()?],
+        payloads_to_publish: vec![
+            proposal_msg.tls_serialize_detached()?,
+            commit.tls_serialize_detached()?,
+        ],
         staged_commit,
         post_commit_action: None,
         should_send_push_notification,
@@ -196,11 +199,11 @@ pub(crate) fn apply_update_permission_app_data_intent(
     let payload = <ComponentRegistryComponent as Component>::encode_mutation(&delta)
         .map_err(|e| GroupError::ComponentSource(ComponentSourceError::from(e)))?;
 
-    let (bundle, staged_commit, group_epoch) = generate_commit_with_rollback(
+    let ((proposal_msg, bundle), staged_commit, group_epoch) = generate_commit_with_rollback(
         storage,
         openmls_group,
         move |group, provider| -> Result<_, GroupError> {
-            Ok(stage_inline_app_data_commit(
+            Ok(stage_app_data_propose_and_commit(
                 group,
                 provider,
                 &signer,
@@ -216,7 +219,10 @@ pub(crate) fn apply_update_permission_app_data_intent(
         "UpdatePermission via AppDataUpdate must not produce a welcome"
     );
     Ok(PublishIntentData {
-        payloads_to_publish: vec![commit.tls_serialize_detached()?],
+        payloads_to_publish: vec![
+            proposal_msg.tls_serialize_detached()?,
+            commit.tls_serialize_detached()?,
+        ],
         staged_commit,
         post_commit_action: None,
         should_send_push_notification,

--- a/crates/xmtp_mls/src/groups/app_data/typed_facade.rs
+++ b/crates/xmtp_mls/src/groups/app_data/typed_facade.rs
@@ -3,7 +3,7 @@
 //! [`MlsGroupAppData`] borrows an `&OpenMlsGroup` and exposes typed,
 //! per-component reads via [`MlsGroupAppData::get`]. Write paths
 //! continue to use the existing intent infrastructure (`mls_sync.rs`)
-//! plus `stage_inline_app_data_commit`; this facade is for callers
+//! plus `stage_app_data_propose_and_commit`; this facade is for callers
 //! that need a single typed value (e.g. permissions checks, registry
 //! lookups, custom-component reads).
 //!

--- a/crates/xmtp_mls/src/groups/error.rs
+++ b/crates/xmtp_mls/src/groups/error.rs
@@ -266,7 +266,7 @@ pub enum GroupError {
     ///
     /// Failed to build or stage a commit that bundles an inline AppDataUpdate
     /// proposal. Wraps the structured `GroupAppDataError` from
-    /// [`stage_inline_app_data_commit`] so the underlying OpenMLS create/stage
+    /// [`stage_app_data_propose_and_commit`] so the underlying OpenMLS create/stage
     /// failure is preserved instead of being string-flattened.
     #[error("app data commit error: {0}")]
     AppDataCommit(#[from] super::app_data::GroupAppDataError<sql_key_store::SqlKeyStoreError>),
@@ -565,7 +565,7 @@ impl RetryableError for GroupError {
             Self::CommitToPendingProposals(e) => e.is_retryable(),
             Self::ProposalsNotSupported(_) => false,
             Self::ComponentSource(_) => false,
-            Self::AppDataCommit(_) => false,
+            Self::AppDataCommit(e) => e.is_retryable(),
             // Bootstrap synthesis can fail on a transient identity-update
             // API blip — delegate to the inner error so we retry on
             // network errors and stay non-retryable on deterministic

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -2789,16 +2789,17 @@ where
                     "MetadataUpdate intent routing"
                 );
                 if proposals_on && registry_populated {
-                    // Bundle the AppDataUpdate proposal and its resulting
-                    // dict update into a single commit so propose-and-apply
-                    // stays atomic — matching the legacy GCE path's
-                    // "metadata update completes in one sync" semantics.
+                    // Publish a STANDALONE AppDataUpdate proposal followed
+                    // by a commit that references it (XIP §1.5.2 / §3.4).
+                    // Both wire messages go in one publish batch — the
+                    // proposal comes first so the receiver has it in its
+                    // pending store before processing the commit.
                     use super::app_data::{
                         component_source::{
                             ComponentMutation, ComponentSourceError,
                             encode_app_data_update_payload, metadata_field_to_component_id,
                         },
-                        stage_inline_app_data_commit,
+                        stage_app_data_propose_and_commit,
                     };
 
                     let component_id = metadata_field_to_component_id(&metadata_intent.field_name)
@@ -2814,19 +2815,20 @@ where
                     })?;
 
                     let signer = self.context.identity().installation_keys.clone();
-                    let (bundle, staged_commit, group_epoch) = generate_commit_with_rollback(
-                        storage,
-                        openmls_group,
-                        move |group, provider| -> Result<_, GroupError> {
-                            Ok(stage_inline_app_data_commit(
-                                group,
-                                provider,
-                                &signer,
-                                component_id,
-                                payload,
-                            )?)
-                        },
-                    )?;
+                    let ((proposal_msg, bundle), staged_commit, group_epoch) =
+                        generate_commit_with_rollback(
+                            storage,
+                            openmls_group,
+                            move |group, provider| -> Result<_, GroupError> {
+                                Ok(stage_app_data_propose_and_commit(
+                                    group,
+                                    provider,
+                                    &signer,
+                                    component_id,
+                                    payload,
+                                )?)
+                            },
+                        )?;
 
                     let (commit, welcome, _group_info) = bundle.into_messages();
                     // A metadata-only AppDataUpdate commit has no add/remove
@@ -2838,7 +2840,10 @@ where
                         "MetadataUpdate via AppDataUpdate must not produce a welcome"
                     );
                     return Ok(Some(PublishIntentData {
-                        payloads_to_publish: vec![commit.tls_serialize_detached()?],
+                        payloads_to_publish: vec![
+                            proposal_msg.tls_serialize_detached()?,
+                            commit.tls_serialize_detached()?,
+                        ],
                         staged_commit,
                         post_commit_action: None,
                         should_send_push_notification: intent.should_push,


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Split `stage_inline_app_data_commit` into separate propose and commit steps in MLS group sync
- Replaces `stage_inline_app_data_commit` with `stage_app_data_propose_and_commit`, which first enqueues a standalone `AppDataUpdate` proposal via `propose_app_data_update`, then builds a commit that references it by `ProposalRef` using `consume_proposal_store(true)`.
- Callers in [sender_intents.rs](https://github.com/xmtp/libxmtp/pull/3629/files#diff-09753ccd507e9327f4b4e1df1c02244081bdeeecb5088bb6d21ddb89a349513a) and [mls_sync.rs](https://github.com/xmtp/libxmtp/pull/3629/files#diff-160aadcd7de477c1116260a79601a0548842f3bd91bf16bd8443debb66ce6684) now publish two payloads per intent: the proposal message first, followed by the commit.
- Adds a `Propose(ProposalError)` variant to `GroupAppDataError` and implements `RetryableError`, making propose/stage failures retryable while create-commit and payload-apply failures remain non-retryable.
- `GroupError::AppDataCommit` now delegates retryability to the inner error instead of always returning false.
- Behavioral Change: receivers must now handle a separate proposal message before the commit for `AppDataUpdate`, `UpdateAdminList`, and `UpdatePermission` intents.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1a1c164.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->