### PR TITLE
xmtp_mls_common: document WELL_KNOWN change-control rule + drop stale migration-plan refs

### DIFF
--- a/crates/xmtp_mls/src/groups/app_data/component_source.rs
+++ b/crates/xmtp_mls/src/groups/app_data/component_source.rs
@@ -381,8 +381,15 @@ pub(crate) fn read_from_app_data_dict(
 /// For `GroupMutableMetadata`-backed bytes components this returns the
 /// attribute's UTF-8 bytes. For `ADMIN_LIST` / `SUPER_ADMIN_LIST` it
 /// re-encodes the legacy `Vec<String>` of hex inbox ids as a
-/// `TlsSet<InboxId>`. For `GROUP_MEMBERSHIP` this is currently a stub
-/// returning [`ComponentSourceError::NotImplemented`] — see §3 of the plan.
+/// `TlsSet<InboxId>`.
+///
+/// `GROUP_MEMBERSHIP` is intentionally unsupported here and returns
+/// [`ComponentSourceError::NotImplemented`]: unmigrated groups read
+/// membership via the dedicated `GROUP_MEMBERSHIP_EXTENSION_ID`
+/// GroupContext extension (see [`extract_group_membership`]), not as
+/// an AppData component. Migrated groups use the dict directly.
+///
+/// [`extract_group_membership`]: crate::groups::group_membership::extract_group_membership
 fn read_from_legacy(
     id: ComponentId,
     extensions: &Extensions<GroupContext>,

--- a/crates/xmtp_mls/src/groups/app_data/policy.rs
+++ b/crates/xmtp_mls/src/groups/app_data/policy.rs
@@ -10,10 +10,12 @@
 //! - `GROUP_MEMBERSHIP.delete_policy` → `remove_member_policy`
 //!
 //! Other slots on the synthesized `PolicySet` (metadata field updates,
-//! admin add/remove, permissions update) keep the conservative
-//! "super admin only" stub — the AppDataUpdate path enforces those
-//! per-component when a real change comes through, and the legacy
-//! callers only consult them as part of structural sanity checks.
+//! admin add/remove, permissions update) are structural placeholders
+//! filled with the conservative "super admin only" policy. The
+//! AppDataUpdate proposal validator is the authoritative gate for
+//! those component writes; the slots here only exist because the
+//! legacy GCE-shaped callers expect a populated `PolicySet` for
+//! sanity checks unrelated to the per-component policy lookup.
 
 use openmls::group::MlsGroup as OpenMlsGroup;
 use xmtp_mls_common::app_data::component_id::ComponentId;
@@ -58,8 +60,9 @@ fn metadata_policy_to_membership(p: &MetadataPolicyProto) -> MembershipPolicies 
 
 /// Build a `GroupMutablePermissions` whose `add_member_policy` /
 /// `remove_member_policy` reflect the registry's `GROUP_MEMBERSHIP`
-/// policies. Everything else is a stub — the AppDataUpdate validation
-/// path is the authoritative gate for non-membership components.
+/// policies. Other slots are structural placeholders — the
+/// AppDataUpdate validation path is the authoritative gate for
+/// non-membership components.
 pub(crate) fn membership_policy_set_from_registry(
     mls_group: &OpenMlsGroup,
 ) -> Result<GroupMutablePermissions, ComponentSourceError> {
@@ -119,12 +122,13 @@ pub(crate) fn membership_policy_set_from_registry(
         }
     };
 
-    // Non-membership slots stay on the conservative super-admin stub:
-    // metadata field updates, admin add/remove, and permissions update
-    // are all enforced per-component by
-    // `validate_app_data_update_proposals_in_commit` when a real change
-    // comes through. Legacy callers only consult these slots as part
-    // of structural sanity checks, so super-admin-only is safe.
+    // Non-membership slots are structural placeholders, filled with
+    // super-admin-only. Metadata field updates, admin add/remove, and
+    // permissions update are all gated per-component by
+    // `validate_app_data_update_proposals_in_commit` when a real
+    // change comes through; legacy callers only consult these slots
+    // for sanity checks unrelated to the per-component permission
+    // policy.
     Ok(GroupMutablePermissions::new(PolicySet::new(
         add_policy,
         remove_policy,

--- a/crates/xmtp_mls/src/groups/tests/test_proposals.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_proposals.rs
@@ -574,15 +574,6 @@ async fn test_message_auto_commits_pending_proposals() {
 }
 
 // =============================================================================
-// Enable Proposals Flow Tests
-// =============================================================================
-
-// NOTE: The GCE (Group Context Extensions) proposal flow tests are currently
-// failing because CommitPendingProposals doesn't properly apply GCE proposals.
-// This needs investigation in mls_sync.rs CommitPendingProposals handling.
-// The tests below verify intent creation works; full E2E flow is TODO.
-
-// =============================================================================
 // Multiple Proposals Tests
 // =============================================================================
 
@@ -2611,11 +2602,15 @@ async fn test_app_data_update_advertised_but_not_required() {
 // AppDataUpdate Path Tests
 // =============================================================================
 //
-// These tests exercise the app-data-update flow that activates when a
-// group has flipped `proposals_enabled`. They confirm that:
+// These tests exercise the AppDataUpdate flow that activates after
+// `enable_proposals()` fires the bootstrap commit. They confirm that:
 // 1. `update_group_name` and friends still work end-to-end (sender → receiver)
 // 2. The capability-gated read accessors return the new value
-// 3. The legacy path is unchanged for groups without `proposals_enabled`
+// 3. The legacy path is unchanged for unmigrated groups
+//
+// `TEST_REGISTRY_OVERRIDE` stays in `app_data/mod.rs` for synthetic-
+// registry unit tests but no integration test in this file needs it —
+// bootstrap writes a real `COMPONENT_REGISTRY` entry.
 
 /// `update_group_name` on a group with `proposals_enabled` should:
 /// - publish a commit containing an `AppDataUpdate(GROUP_NAME)` proposal,
@@ -2910,6 +2905,27 @@ async fn test_enable_proposals_pauses_old_client_via_legacy_gmm_bump() {
     );
 }
 
+// Two areas still rely on indirect coverage:
+//
+// 1. **Standalone-proposal `validate_proposal` arm.** PR-C (standalone
+//    proposal-by-reference flow) now publishes `AppDataUpdate` proposals
+//    as separate MLS messages preceding the commit, so the
+//    `Proposal::AppDataUpdate` arm of `validate_proposal` (the path
+//    that handles a proposal received *outside* a commit) is reachable
+//    by any update via `update_group_name` / `update_admin_list` /
+//    `update_permissions`. The end-to-end tests above exercise it via
+//    the receiver's normal commit-processing pipeline, which routes
+//    standalone proposals into the same `validate_one_app_data_update`
+//    helper as the inline-bundled path; a regression that broke
+//    permission enforcement would trip either entry point.
+//
+// 2. **`RemoveByHash` resolution through the validator.** No production
+//    code path currently emits `RemoveByHash` (admin-list paths use
+//    explicit `Remove(inbox_id)` mutations). Unit coverage for the
+//    resolver lives in
+//    `crates/xmtp_mls/src/groups/app_data/component_source.rs` under
+//    `test_expand_remove_by_hash_*`; revisit if a future caller starts
+//    emitting hash-based deletes.
 /// Sanity check the legacy path: a group with `proposals_enabled = false`
 /// (the default for fresh groups) should still produce a normal GCE commit
 /// for `update_group_name`, with no AppDataUpdate involvement. Confirms

--- a/crates/xmtp_mls_common/src/app_data/registry_table.rs
+++ b/crates/xmtp_mls_common/src/app_data/registry_table.rs
@@ -38,6 +38,72 @@ use crate::app_data::{
 ///
 /// Order is enforced by [`assert_table_is_sorted_and_unique`] at
 /// compile time. Tests further pin specific lookup expectations.
+///
+/// # Change control
+///
+/// Component-id ranges in play (mirror of [`lookup_component`] below):
+///
+/// | Range            | Purpose                                       |
+/// |------------------|-----------------------------------------------|
+/// | `0x8000-0xBFFF`  | XMTP-allocated well-known ids (this table)    |
+/// | `0xC000-0xFEFF`  | Application-range `RuntimeComponent` ids      |
+/// | `0xFF00-0xFFFF`  | Reserved (hard-rejected, no graceful-degrade) |
+///
+/// Adding a new well-known entry here changes the protocol's
+/// receiver-side acceptance set. Old clients (released before the new
+/// entry) handle the new id via the **type-aware unknown-component
+/// tolerance** path in:
+///   - `apply_app_data_update_payload`
+///   - `expand_app_data_update_to_changes`
+///   - `validate_one_app_data_update_with_old_value`
+///
+/// That path looks the unknown id up in the on-dict
+/// [`ComponentRegistry`](crate::app_data::component_registry::ComponentRegistry),
+/// pulls its registered [`ComponentType`], and dispatches through the
+/// type-level decoder. The closed type universe covers every shape:
+/// Bytes / String pass-through, `TlsSet<InboxId>` / `TlsSet<bytes>` /
+/// `TlsMap<InboxId, bytes>` / `TlsMap<bytes, bytes>` apply their deltas
+/// element-wise — old and new clients converge on the same dict bytes.
+/// The tolerance path covers the XMTP range (`0x8000-0xBFFF`) and the
+/// application range (`0xC000-0xFEFF`); the reserved range
+/// (`0xFF00-0xFFFF`) is **still hard-rejected** — those slots are
+/// protocol-level and have no graceful-degrade story. Do not allocate
+/// new ids there.
+///
+/// **Requirements when adding a new well-known component:**
+/// - The component MUST be reachable through one of the six
+///   [`ComponentType`] variants. The wire codec for each is fixed; an
+///   old client decodes it the same way a typed client would.
+/// - The component MUST NOT carry receive-side invariants beyond
+///   registry policy. Old (type-dispatched) clients lack the per-id
+///   `Component::validate_invariant` hook — diverging invariant
+///   behavior would fork the dict.
+/// - Read-side accessors surface **the default value for the
+///   component's type** on old clients (empty `Bytes` / `String` /
+///   `TlsSet` / `TlsMap`). The "absent" state is indistinguishable
+///   from "explicitly cleared" on old clients — design semantics
+///   accordingly and document that degradation at the accessor
+///   boundary.
+/// - The component MUST land in the registry **before or with** the
+///   first commit that writes to it. Old clients consult the
+///   pre-commit registry snapshot, so a same-commit registration
+///   followed by a same-commit write fails to dispatch.
+///
+/// Two ergonomic patterns for shipping a new component without
+/// editing `WELL_KNOWN`:
+///
+/// 1. **Application-range `RuntimeComponent`.** Components in
+///    `0xC000-0xFCFF` registered at runtime via the
+///    `RuntimeComponent` facility (see `app_data::custom`) ship
+///    without touching `WELL_KNOWN` — only the host that registered
+///    the component decodes its payload, while old clients
+///    type-dispatch via the registry the same way.
+/// 2. **Coordinated protocol-version bump.** Required only when the
+///    new component must reject specific bytes that the type-level
+///    codec would otherwise accept (e.g. a per-id invariant beyond
+///    type shape).
+///
+/// [`ComponentType`]: xmtp_proto::xmtp::mls::message_contents::ComponentType
 pub static WELL_KNOWN: &[(ComponentId, &'static dyn ErasedComponent)] = &[
     (ComponentId::COMPONENT_REGISTRY, &ComponentRegistryComponent),
     (ComponentId::SUPER_ADMIN_LIST, &SuperAdminListComponent),


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Document WELL_KNOWN change-control rules and remove stale migration-plan references
- Adds extensive documentation to [`registry_table.rs`](https://github.com/xmtp/libxmtp/pull/3630/files#diff-dac151bd9d59cbdc7d59c932a5319a050a31ef5b4a4748c73b8112a7a77b47a4) covering component-id ranges, receiver-side tolerance behavior, and requirements for adding new components to the WELL_KNOWN registry.
- Clarifies module and inline comments in [`policy.rs`](https://github.com/xmtp/libxmtp/pull/3630/files#diff-e77c387fd3922591e80936163b4fd57b0ca8f190aeafe5a62162278b5ba22207) around non-membership slot behavior and AppDataUpdate as the authoritative gate for component writes.
- Updates [`component_source.rs`](https://github.com/xmtp/libxmtp/pull/3630/files#diff-47acce7b46d2cc4f9669dd42120ee90e488ceb0b15817b67b7757e631b05d113) docs to explicitly note that GROUP_MEMBERSHIP is unsupported in `read_from_legacy` and directs consumers to the dedicated extension.
- Removes obsolete comments in [`test_proposals.rs`](https://github.com/xmtp/libxmtp/pull/3630/files#diff-fb8ffb096fea904de9f05e2ad66734c897c3a9ceb42099e25f894c256f1f5f8e) about stale migration plans and failed GCE proposal flow tests. No code or logic was changed in any file.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized c511936.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->