### PR TITLE
xmtp_mls: bump legacy MIN_SUPPORTED_PROTOCOL_VERSION before bootstrap commit

### DIFF
--- a/crates/xmtp_mls/src/groups/mod.rs
+++ b/crates/xmtp_mls/src/groups/mod.rs
@@ -504,6 +504,118 @@ where
     /// - Not all existing members support proposals
     /// - The group context extension update fails
     pub async fn enable_proposals(&self) -> Result<(), GroupError> {
+        // Two-step migration so old clients (any peer running a
+        // libxmtp release predating this code's `pkg_version`) get a
+        // pause hint they can read BEFORE the legacy
+        // GroupMutableMetadata extension that carries it is stripped
+        // by the bootstrap commit. XIP §3.2.
+        //
+        // Step A: bump MIN_SUPPORTED_PROTOCOL_VERSION in legacy GMM to
+        // `pkg_version()`. Pre-bootstrap groups have no AppData
+        // dictionary registry, so the `MetadataUpdate` handler's
+        // migrated branch is false and the write goes through the
+        // legacy GCE path — exactly the extension old clients know how
+        // to read for `paused_for_version`. Any peer below the version
+        // floor processes this commit, sees the version mismatch in
+        // `validate_one_commit`, and lands in `paused_for_version`. It
+        // never observes step B.
+        //
+        // Step B: bootstrap commit. Strips legacy extensions, seeds
+        // the dict, adds `PROPOSAL_SUPPORT` to RequiredCapabilities.
+        // Fires only for the still-active (above-floor) members.
+        //
+        // The safety primitive here is **server-side commit ordering**:
+        // peers see step A's commit before step B's because the server
+        // linearizes them. `sync_until_intent_resolved` confirms only
+        // the migrator's local Processed state — it does NOT wait for
+        // peer pickup. Server linearization is what guarantees
+        // below-floor peers pause before they could ever see the
+        // bootstrap commit.
+        //
+        // Pre-flight: read all three gating signals under one lock so
+        // a concurrent migrator's bootstrap commit can't land between
+        // our reads. Without the single-lock pass:
+        //   * member-support check passes, then a concurrent migrator's
+        //     bootstrap commit lands locally, then the legacy-GMM read
+        //     returns `None` (extension stripped), then `needs_bump`
+        //     becomes `true`, then step A publishes a legacy GCE bump
+        //     against a group whose legacy extensions are gone — fails
+        //     mid-flight with a confusing error.
+        // Reading all three together collapses that race window: if
+        // `proposals_enabled` flipped to true under us, we early-return
+        // and never publish step A.
+        //
+        // (1) `all_members_support_proposals` ensures every peer can
+        // process the bootstrap commit so we don't ship step A — the
+        // legacy GMM bump — for a migration that's about to fail at
+        // step B and leave below-floor peers permanently paused.
+        // (2) `proposals_enabled` early-exits if the group is already
+        // migrated; calling `enable_proposals()` twice is a user error
+        // and we don't want to publish a redundant legacy GMM bump on
+        // a group that no longer has a legacy GMM.
+        // (3) `needs_min_version_bump` decides whether step A is
+        // necessary. Semver comparison, NOT string equality. A
+        // concurrent migrator at a higher version (or this very
+        // migrator on retry) may have already set a floor >= ours; in
+        // that case re-bumping with a lower string value would
+        // downgrade the floor and silently unpause peers between the
+        // lower and the higher version. Skip step A when the current
+        // floor already covers our pkg_version.
+        let pkg_version = self.context.version_info().pkg_version().to_string();
+        let (already_migrated, needs_min_version_bump) = self
+            .load_mls_group_with_lock_async(async |mls_group| {
+                if !self.all_members_support_proposals(&mls_group).await? {
+                    return Err(GroupError::ProposalsNotSupported(
+                        "Cannot enable proposals: not all members support the proposal extension"
+                            .to_string(),
+                    ));
+                }
+                if self.proposals_enabled(&mls_group) {
+                    return Ok::<(bool, bool), GroupError>((true, false));
+                }
+                let metadata =
+                    xmtp_mls_common::group_mutable_metadata::extract_legacy_group_mutable_metadata(
+                        &mls_group,
+                    )
+                    .ok();
+                let current = metadata.and_then(|m| Self::min_protocol_version_from_extensions(&m));
+                let needs_bump = match current.as_deref() {
+                    None => true,
+                    Some(current_str) => {
+                        let current_v = LibXMTPVersion::parse(current_str).map_err(|e| {
+                            GroupError::ProposalsNotSupported(format!(
+                                "parsing legacy GMM MinimumSupportedProtocolVersion '{current_str}': {e}"
+                            ))
+                        })?;
+                        let target_v = LibXMTPVersion::parse(&pkg_version).map_err(|e| {
+                            GroupError::ProposalsNotSupported(format!(
+                                "parsing this binary's pkg_version '{pkg_version}': {e}"
+                            ))
+                        })?;
+                        current_v < target_v
+                    }
+                };
+                Ok::<(bool, bool), GroupError>((false, needs_bump))
+            })
+            .await?;
+
+        if already_migrated {
+            return Ok(());
+        }
+
+        if needs_min_version_bump {
+            let min_version_intent_data: Vec<u8> =
+                intents::UpdateMetadataIntentData::new_update_group_min_version_to_match_self(
+                    pkg_version,
+                )
+                .into();
+            let min_version_intent = intents::QueueIntent::metadata_update()
+                .data(min_version_intent_data)
+                .queue(self)?;
+            self.sync_until_intent_resolved(min_version_intent.id)
+                .await?;
+        }
+
         // Build the bootstrap-target extensions in a single lock
         // acquisition to avoid races. The bootstrap commit produced by
         // `IntentKind::BootstrapMigration` will:
@@ -517,6 +629,12 @@ where
         // All in a single commit, so the migration is atomic on-the-
         // wire: receivers either see the migrated state (bootstrap
         // commit accepted) or the legacy state (commit rejected).
+        //
+        // The `all_members_support_proposals` re-check on this read
+        // pass is a defense-in-depth: pre-flight ran above before step
+        // A, but a peer could join between then and now. The intent
+        // dispatch reads live group state at publish time, so step B
+        // must observe the same predicate it gated step A with.
         let new_extensions = self
             .load_mls_group_with_lock_async(async |mls_group| {
                 if !self.all_members_support_proposals(&mls_group).await? {

--- a/crates/xmtp_mls/src/groups/tests/test_proposals.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_proposals.rs
@@ -2808,6 +2808,108 @@ async fn test_disappearing_settings_survive_bootstrap() {
     );
 }
 
+/// XIP §3.2: a libxmtp client running below the migrator's pkg_version
+/// MUST land in `paused_for_version` rather than fork or fail when the
+/// migrator calls `enable_proposals()`. The two-step bootstrap in
+/// `enable_proposals()` makes this work by writing
+/// MIN_SUPPORTED_PROTOCOL_VERSION to legacy GMM **before** the
+/// bootstrap commit strips that extension — old clients can still read
+/// the version-bump from the legacy GCE path, pause on it, and never
+/// process the (legacy-extension-stripping) bootstrap commit they
+/// wouldn't understand.
+///
+/// ## What this test covers and doesn't cover
+///
+/// Covered: Bo (running the SAME binary as Alix but at the older
+/// pkg_version) processes step A's legacy GCE bump, hits the
+/// version-mismatch arm of `validate_one_commit`, and lands in
+/// `paused_for_version`. He never applies step B.
+///
+/// NOT covered: a TRULY pre-AppData binary processing step B and
+/// failing because the bootstrap commit strips extensions it requires.
+/// That code path is impossible to exercise in-tree (the only client
+/// is the current binary), so the test confirms the pause hint is
+/// reachable via the legacy reader — that's the contract that lets
+/// a pre-AppData binary pause without ever opening step B.
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_enable_proposals_pauses_old_client_via_legacy_gmm_bump() {
+    use crate::builder::ClientBuilder;
+    use crate::groups::tests::increment_patch_version;
+    use crate::utils::VersionInfo;
+    use xmtp_cryptography::utils::generate_local_wallet;
+
+    let mut alix_version = VersionInfo::default();
+    alix_version.test_update_version(
+        increment_patch_version(alix_version.pkg_version())
+            .unwrap()
+            .as_str(),
+    );
+    let alix_pkg_version = alix_version.pkg_version().to_string();
+    // Alix is on the newer version; bo is on the default (older).
+    let alix =
+        ClientBuilder::new_test_client_with_version(&generate_local_wallet(), alix_version).await;
+
+    tester!(bo);
+
+    let alix_group = alix.create_group(None, None)?;
+    alix_group
+        .add_members(&[bo.context.identity.inbox_id()])
+        .await?;
+
+    // Bo joins the group at his current (older) version. No min-version
+    // requirement yet, so the welcome itself doesn't pause him.
+    let bo_groups = bo.sync_welcomes().await?;
+    let bo_group = bo_groups.first()?;
+    bo_group.sync().await?;
+    assert!(
+        bo_group.paused_for_version()?.is_none(),
+        "Bo should not be paused before alix calls enable_proposals"
+    );
+
+    // Alix migrates. The two-step bootstrap publishes:
+    //   1. A legacy GCE commit bumping MIN_SUPPORTED_PROTOCOL_VERSION
+    //      in the still-present legacy GMM extension.
+    //   2. The bootstrap commit (strips legacy extensions, seeds dict).
+    alix_group.enable_proposals().await?;
+
+    // Bo syncs. He processes commit (1), sees min_version > his own,
+    // lands in `paused_for_version`, and stops processing — commit (2)
+    // is never applied locally.
+    bo_group.sync().await?;
+
+    let paused = bo_group.paused_for_version()?;
+    assert_eq!(
+        paused.as_deref(),
+        Some(alix_pkg_version.as_str()),
+        "Bo must be paused at alix's pkg_version — the legacy GMM bump is the pause hint old clients can read"
+    );
+
+    // Bo's group must NOT show as migrated. The bootstrap commit
+    // strips legacy GMM and seeds the AppData dict; if Bo applied it
+    // he'd be migrated but unable to ever read the pause hint.
+    let bo_migrated = bo_group
+        .load_mls_group_with_lock_async(async |g| {
+            Ok::<bool, crate::groups::GroupError>(bo_group.proposals_enabled(&g))
+        })
+        .await?;
+    assert!(
+        !bo_migrated,
+        "Bo must not have processed the bootstrap commit — it ships after the pause-triggering legacy bump"
+    );
+
+    // Alix is at the floor version, so she runs both commits and ends
+    // up migrated as normal.
+    let alix_migrated = alix_group
+        .load_mls_group_with_lock_async(async |g| {
+            Ok::<bool, crate::groups::GroupError>(alix_group.proposals_enabled(&g))
+        })
+        .await?;
+    assert!(
+        alix_migrated,
+        "Alix should be migrated post-enable_proposals"
+    );
+}
+
 /// Sanity check the legacy path: a group with `proposals_enabled = false`
 /// (the default for fresh groups) should still produce a normal GCE commit
 /// for `update_group_name`, with no AppDataUpdate involvement. Confirms


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Bump legacy MIN_SUPPORTED_PROTOCOL_VERSION before bootstrap commit in `Group.enable_proposals`
- Before issuing the bootstrap commit, `enable_proposals` now checks the group's existing `MinimumSupportedProtocolVersion` via legacy `GroupMutableMetadata` and, if it is below the caller's binary version, publishes a metadata update intent to raise the floor and waits for it to resolve via `sync_until_intent_resolved`.
- The method skips the bump if the group is already migrated or if the current floor is already >= the caller's version, and early-returns if proposals are already enabled.
- Member support for proposals is verified twice: once before the optional bump and once before the bootstrap commit.
- A new test in [test_proposals.rs](https://github.com/xmtp/libxmtp/pull/3631/files#diff-fb8ffb096fea904de9f05e2ad66734c897c3a9ceb42099e25f894c256f1f5f8e) validates that after the bump, older clients enter `paused_for_version` and do not apply the bootstrap commit, while the newer client completes migration.
- Behavioral Change: callers on groups needing a version bump now experience an additional commit and blocking sync wait before the bootstrap commit.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized c150483.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->