### PR TITLE
xmtp_mls: drop stale implementation-history references in docblocks

### DIFF
--- a/crates/xmtp_mls/src/groups/app_data/component_source.rs
+++ b/crates/xmtp_mls/src/groups/app_data/component_source.rs
@@ -64,7 +64,7 @@ use xmtp_proto::xmtp::mls::message_contents::ComponentType;
 /// [`GroupError`]: super::super::error::GroupError
 #[derive(Debug, thiserror::Error)]
 pub enum ComponentSourceError {
-    /// The component is not in the well-known XMTP range that phase 1 handles.
+    /// The component id is outside the well-known XMTP range.
     #[error("unknown component {0}")]
     UnknownComponent(ComponentId),
 
@@ -249,7 +249,7 @@ impl ComponentMutation<'_> {
 
 /// Hardcoded logical type of a well-known component. Returns `None` for
 /// app-range components (`0xC000-0xFEFF`) and for any well-known id that
-/// phase 1 has not yet mapped.
+/// is not yet wired into this match.
 pub(crate) fn component_type(id: ComponentId) -> Option<ComponentType> {
     match id {
         // Hardcoded registry / list components. ComponentRegistry itself is a
@@ -274,8 +274,8 @@ pub(crate) fn component_type(id: ComponentId) -> Option<ComponentType> {
         | ComponentId::MESSAGE_DISAPPEAR_IN_NS
         | ComponentId::COMMIT_LOG_SIGNER => Some(ComponentType::Bytes),
 
-        // Immutable metadata (not flowable through AppDataUpdate writes in
-        // phase 1, but we still advertise the type for completeness).
+        // Immutable metadata (not flowable through AppDataUpdate writes,
+        // but we still advertise the type for completeness).
         ComponentId::CONVERSATION_TYPE
         | ComponentId::CREATOR_INBOX_ID
         | ComponentId::ONESHOT_MESSAGE => Some(ComponentType::Bytes),

--- a/crates/xmtp_mls/src/groups/app_data/mod.rs
+++ b/crates/xmtp_mls/src/groups/app_data/mod.rs
@@ -438,11 +438,10 @@ pub(crate) fn pending_app_data_updates(
 /// migrated.
 ///
 /// This is intentionally distinct from [`MlsGroup::proposals_enabled`]:
-/// a group can have `proposals_enabled == true` without having
-/// completed a bootstrap commit yet (the foundation-PR window).
-/// Read accessors key off this helper instead so they correctly fall
-/// back to the legacy GMM extension on proposals-enabled-but-
-/// unbootstrapped groups.
+/// a group can have `proposals_enabled == true` without having yet
+/// completed its bootstrap commit. Read accessors key off this helper
+/// instead so they correctly fall back to the legacy GMM extension on
+/// proposals-enabled-but-unbootstrapped groups.
 pub(crate) fn is_migrated_group(mls_group: &OpenMlsGroup) -> bool {
     is_migrated_extensions(mls_group.extensions())
 }
@@ -579,7 +578,7 @@ pub(crate) fn load_component_registry_from_extensions(
 mod tests {
     //! Unit coverage for the migration-marker predicate —
     //! [`is_migrated_extensions`]. These pin the three read-side
-    //! invariants from the PR review:
+    //! invariants:
     //!   (a) registry empty / dict missing => legacy-authoritative,
     //!   (b) overlay no-op on unmigrated groups (even if `TEST_REGISTRY_OVERRIDE`
     //!       is set but the dict is empty),

--- a/crates/xmtp_mls/src/groups/mod.rs
+++ b/crates/xmtp_mls/src/groups/mod.rs
@@ -2420,8 +2420,8 @@ where
     ///
     /// Intentionally distinct from `proposals_enabled`: a group can
     /// have `proposals_enabled == true` but not yet have completed
-    /// its bootstrap commit (the foundation-PR window). During that
-    /// window the legacy GMM is still authoritative.
+    /// its bootstrap commit, during which window the legacy GMM is
+    /// still authoritative.
     pub fn mutable_metadata(&self) -> Result<GroupMutableMetadata, GroupError> {
         use self::app_data::component_source::ComponentSourceError;
         self.load_mls_group_with_lock(self.context.mls_storage(), |mls_group| {

--- a/crates/xmtp_mls/src/groups/tests/test_proposals.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_proposals.rs
@@ -2611,25 +2611,11 @@ async fn test_app_data_update_advertised_but_not_required() {
 // AppDataUpdate Path Tests
 // =============================================================================
 //
-// These tests exercise the new app-data-update flow that activates when a
+// These tests exercise the app-data-update flow that activates when a
 // group has flipped `proposals_enabled`. They confirm that:
 // 1. `update_group_name` and friends still work end-to-end (sender → receiver)
 // 2. The capability-gated read accessors return the new value
 // 3. The legacy path is unchanged for groups without `proposals_enabled`
-//
-// The component registry is empty in phase 1, so the receiver-side validator
-// denies-by-default for non-hardcoded components. These tests inject a
-// permissive registry for the duration of the test by scoping
-// `TEST_REGISTRY_OVERRIDE` (a tokio task-local) around the test body,
-// mirroring how production code will eventually load a populated registry
-// from the AppData dictionary.
-
-// `TEST_REGISTRY_OVERRIDE` is no longer wrapped from these tests.
-// `enable_proposals()` now fires the real `IntentKind::BootstrapMigration`
-// commit, which writes a proper `COMPONENT_REGISTRY` entry and the
-// immutable seeds to the AppData dictionary. The override mechanism
-// itself stays in `app_data/mod.rs` for any future synthetic-registry
-// unit tests, but no integration test needs it now.
 
 /// `update_group_name` on a group with `proposals_enabled` should:
 /// - publish a commit containing an `AppDataUpdate(GROUP_NAME)` proposal,
@@ -2821,33 +2807,6 @@ async fn test_disappearing_settings_survive_bootstrap() {
          catches a regression that stores `Some(now_ns())` or `Some(garbage)`"
     );
 }
-
-// NOTE: Three E2E tests are deliberately missing from phase 1. Each is
-// tracked here so a future PR can tick them off once the underlying
-// callpath exists.
-//
-// 1. **ADMIN_LIST via AppDataUpdate.** The new collection-component path
-//    for ADMIN_LIST is disabled (see the TODO in
-//    `IntentKind::UpdateAdminList`) until either dual-write or full
-//    migration ships, because the legacy validator and the new dict path
-//    otherwise diverge. Once that's in place, mirror
-//    `test_update_group_name_via_app_data_update` against
-//    `update_admin_list(UpdateAdminListType::Add, …)`.
-//
-// 2. **Standalone `validate_proposal` arm for `AppDataUpdate`.** Today
-//    libxmtp always bundles an `AppDataUpdate` inline with a commit via
-//    `stage_inline_app_data_commit`; there is no public API producing a
-//    standalone proposal-by-reference `AppDataUpdate` message. Structural
-//    coverage comes from the inline-path tests below — both the commit-
-//    time path and the standalone path delegate to the shared
-//    `validate_one_app_data_update` helper, so a regression that broke
-//    permission enforcement would trip either entry point.
-//
-// 3. **`RemoveByHash` resolution through the validator.** No production
-//    code path emits `RemoveByHash` in this PR (the admin-list path that
-//    would is disabled per note 1). Unit coverage for resolution lives in
-//    `crates/xmtp_mls/src/groups/app_data/component_source.rs` under
-//    `test_expand_remove_by_hash_*`.
 
 /// Sanity check the legacy path: a group with `proposals_enabled = false`
 /// (the default for fresh groups) should still produce a normal GCE commit

--- a/crates/xmtp_mls_common/src/app_data/migration.rs
+++ b/crates/xmtp_mls_common/src/app_data/migration.rs
@@ -157,7 +157,7 @@ pub enum MigrationError {
 /// [`PolicySetProto`]. Deterministic: every honest peer synthesizes
 /// bit-identical output from the same input.
 ///
-/// Mapping summary (see the migration plan for the full table):
+/// Mapping summary:
 ///
 /// - Mutable scalar components pull insert/update from
 ///   `update_metadata_policy[field_name]` (default Allow); delete is


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Remove stale implementation-history references from docblocks in `xmtp_mls`
Updates documentation comments across several files in `xmtp_mls` and `xmtp_mls_common` to remove outdated phase-specific language and references to external plans. No code, logic, or assertions are changed.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized a046938.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->