### PR TITLE
xdbg: healthcheck command backport 1.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4600,6 +4600,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9674,6 +9683,7 @@ name = "xdbg"
 version = "0.1.0"
 dependencies = [
  "alloy",
+ "async-trait",
  "chrono",
  "clap",
  "clap-verbosity-flag",
@@ -9688,6 +9698,7 @@ dependencies = [
  "futures",
  "humantime",
  "indicatif",
+ "inventory",
  "itertools 0.14.0",
  "k256",
  "lipsum",
@@ -9720,6 +9731,7 @@ dependencies = [
  "xmtp_db",
  "xmtp_id",
  "xmtp_mls",
+ "xmtp_mls_common",
  "xmtp_proto",
  "xxhash-rust",
 ]

--- a/apps/xmtp_debug/Cargo.toml
+++ b/apps/xmtp_debug/Cargo.toml
@@ -13,6 +13,7 @@ vergen-gix = { workspace = true, features = ["build"] }
 
 [dependencies]
 alloy = { workspace = true, features = ["reqwest-rustls-tls"] }
+async-trait.workspace = true
 chrono.workspace = true
 clap.workspace = true
 clap-verbosity-flag = { version = "3.0", features = ["tracing"] }
@@ -27,6 +28,7 @@ futures.workspace = true
 hex.workspace = true
 humantime = "2.3"
 indicatif.workspace = true
+inventory = "0.3"
 itertools.workspace = true
 k256 = "0.13"
 lipsum = "0.9"
@@ -65,5 +67,6 @@ xmtp_cryptography = { workspace = true, features = ["exposed-keys"] }
 xmtp_db.workspace = true
 xmtp_id.workspace = true
 xmtp_mls.workspace = true
+xmtp_mls_common.workspace = true
 xmtp_proto.workspace = true
 xxhash-rust = { version = "0.8", features = ["xxh3"] }

--- a/apps/xmtp_debug/src/app.rs
+++ b/apps/xmtp_debug/src/app.rs
@@ -6,6 +6,8 @@ mod clients;
 mod export;
 /// Generate functionality
 mod generate;
+/// E2E health check across all protocol ops
+mod health;
 /// Information about this app
 mod info;
 /// Inspect data on the XMTP Network
@@ -142,6 +144,7 @@ impl App {
                 Export(e) => export::Export::new(e, backend)?.run(),
                 Modify(m) => modify::Modify::new(m, backend)?.run().await,
                 Stream(s) => stream::Stream::new(s, backend)?.run().await,
+                Healthcheck(h) => health::Health::new(h, backend).run().await,
             }?;
         }
 

--- a/apps/xmtp_debug/src/app/health/context.rs
+++ b/apps/xmtp_debug/src/app/health/context.rs
@@ -1,0 +1,159 @@
+//! Shared state for the health-check run.
+
+use crate::DbgClient;
+use crate::app::store::{Database, GroupStore, IdentityStore};
+use crate::app::types::{Identity, InboxId};
+use crate::app::{self, App};
+use crate::args;
+use color_eyre::eyre::Result;
+use std::collections::HashMap;
+use std::sync::Arc;
+use xmtp_proto::types::GroupId;
+
+pub struct HealthContext {
+    /// The single new identity created for this run. Persisted to the
+    /// redb identity store so future runs see it as an existing identity.
+    pub primary: Arc<DbgClient>,
+
+    /// Single-run identity used by destructive ops (e.g. `LeaveGroup`).
+    /// Not persisted to redb — exists only to be removed from groups
+    /// without losing the run-stable `primary`.
+    pub transient_identity: Arc<DbgClient>,
+
+    /// Extra new identities created only when the redb identity store
+    /// was empty at startup. Empty on a non-fresh run.
+    pub bootstrap_clients: Vec<Arc<DbgClient>>,
+
+    /// Identities loaded from the redb `IdentityStore` for this network.
+    /// On a fresh run, contains the registered `bootstrap_clients`.
+    pub existing_clients: HashMap<InboxId, Arc<DbgClient>>,
+
+    /// Group IDs loaded from the redb `GroupStore` for this network.
+    /// Stored as the raw 16-byte ids as produced by libxmtp.
+    pub existing_groups: Vec<GroupId>,
+
+    /// Groups created by ops during this run. Ops receive `&mut
+    /// HealthContext` and mutate this directly — execution is sequential
+    /// so no synchronization is needed.
+    pub new_groups: Vec<GroupId>,
+}
+
+impl HealthContext {
+    /// Build the full context: load existing state, bootstrap on fresh DB,
+    /// create the primary identity. Hard-fails on infrastructure errors.
+    pub async fn bootstrap(network: args::BackendOpts) -> Result<Self> {
+        let redb = App::db()?;
+        let id_store: IdentityStore<'static> = redb.clone().into();
+        let group_store: GroupStore<'static> = redb.into();
+        let net_key = u64::from(&network);
+
+        // 1. Existing identities.
+        let identity_count = id_store
+            .load(net_key)?
+            .map(|iter| iter.count())
+            .unwrap_or(0);
+
+        let mut bootstrap_clients: Vec<Arc<DbgClient>> = Vec::new();
+        let mut existing_clients: HashMap<InboxId, Arc<DbgClient>> = HashMap::new();
+
+        if identity_count == 0 {
+            tracing::info!(target: "healthcheck", "redb identity store empty; creating 3 bootstrap identities");
+            let mut fresh_identities: Vec<Identity> = Vec::new();
+            for _ in 0..3 {
+                let wallet = app::generate_wallet();
+                let client = app::new_unregistered_client(&network, Some(&wallet)).await?;
+                let identity = Identity::from_libxmtp(client.identity(), wallet.clone())?;
+                app::register_client(&client, wallet.into_alloy()).await?;
+                let inbox_id = identity.inbox_id;
+                let arc = Arc::new(client);
+                fresh_identities.push(identity);
+                bootstrap_clients.push(arc.clone());
+                existing_clients.insert(inbox_id, arc);
+            }
+            id_store.set_all(fresh_identities.as_slice(), net_key)?;
+        } else {
+            let loaded = app::load_all_identities(&id_store, &network)?;
+            let map = Arc::try_unwrap(loaded).map_err(|arc| {
+                color_eyre::eyre::eyre!(
+                    "load_all_identities returned multiply-owned Arc (strong={}, weak={}). \
+                     HealthContext::bootstrap must be its sole caller — something is holding a clone.",
+                    Arc::strong_count(&arc),
+                    Arc::weak_count(&arc),
+                )
+            })?;
+            for (inbox_id, mutex) in map.into_iter() {
+                existing_clients.insert(inbox_id, Arc::new(mutex.into_inner()));
+            }
+        }
+
+        // 2. Primary new identity. Also persisted to redb so subsequent
+        //    healthcheck runs see it as an existing identity.
+        let primary_wallet = app::generate_wallet();
+        let primary_client = app::new_unregistered_client(&network, Some(&primary_wallet)).await?;
+        let primary_identity =
+            Identity::from_libxmtp(primary_client.identity(), primary_wallet.clone())?;
+        app::register_client(&primary_client, primary_wallet.into_alloy()).await?;
+        id_store.set(primary_identity, net_key)?;
+        let primary = Arc::new(primary_client);
+
+        // 3. Transient identity for destructive ops. Not persisted.
+        let transient_wallet = app::generate_wallet();
+        let transient_client =
+            app::new_unregistered_client(&network, Some(&transient_wallet)).await?;
+        app::register_client(&transient_client, transient_wallet.into_alloy()).await?;
+        let transient_identity = Arc::new(transient_client);
+
+        // 4. Existing groups from redb.
+        let existing_groups = group_store
+            .load(net_key)?
+            .map(|iter| {
+                iter.map(|g| GroupId::from(g.value().id.as_slice()))
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+
+        tracing::info!(
+            target: "healthcheck",
+            existing_identities = existing_clients.len(),
+            existing_groups = existing_groups.len(),
+            bootstrap = bootstrap_clients.len(),
+            "health context bootstrapped"
+        );
+
+        Ok(Self {
+            primary,
+            transient_identity,
+            bootstrap_clients,
+            existing_clients,
+            existing_groups,
+            new_groups: Vec::new(),
+        })
+    }
+
+    /// Iterate every client involved in this run: primary + transient +
+    /// bootstrap + existing. Bootstrap clients are also in
+    /// `existing_clients` (same `Arc`); de-duplicate by inbox_id.
+    pub fn all_clients(&self) -> Vec<Arc<DbgClient>> {
+        let mut seen: HashMap<InboxId, Arc<DbgClient>> = HashMap::new();
+        seen.insert(inbox_id_bytes(&self.primary), self.primary.clone());
+        seen.insert(
+            inbox_id_bytes(&self.transient_identity),
+            self.transient_identity.clone(),
+        );
+        for c in &self.bootstrap_clients {
+            seen.insert(inbox_id_bytes(c), c.clone());
+        }
+        for (id, c) in &self.existing_clients {
+            seen.insert(*id, c.clone());
+        }
+        seen.into_values().collect()
+    }
+}
+
+/// Decode the client's hex `inbox_id` into the 32-byte form used as the
+/// `HashMap` key. The hex form is guaranteed valid by libxmtp.
+fn inbox_id_bytes(client: &DbgClient) -> InboxId {
+    let mut out = [0u8; 32];
+    hex::decode_to_slice(client.inbox_id(), &mut out).expect("inbox_id is 32-byte hex");
+    out
+}

--- a/apps/xmtp_debug/src/app/health/mod.rs
+++ b/apps/xmtp_debug/src/app/health/mod.rs
@@ -1,0 +1,89 @@
+//! `xdbg healthcheck` — cross-version libxmtp protocol exerciser.
+//!
+//! Runs every user-visible op against existing xdbg state, validates
+//! convergence, exits non-zero on any failure. See
+//! `docs/superpowers/specs/2026-05-13-xdbg-healthcheck-design.md`.
+
+mod context;
+mod ops;
+mod registry;
+mod result;
+mod validators;
+
+pub use context::HealthContext;
+
+use crate::args;
+use color_eyre::eyre::{Result, eyre};
+use std::time::Instant;
+
+pub struct Health {
+    #[allow(dead_code)]
+    opts: args::HealthcheckOpts,
+    network: args::BackendOpts,
+}
+
+impl Health {
+    pub fn new(opts: args::HealthcheckOpts, network: args::BackendOpts) -> Self {
+        Self { opts, network }
+    }
+
+    pub async fn run(self) -> Result<()> {
+        // Print the resolved op execution order before bootstrap so it's
+        // visible even if bootstrap fails.
+        print!("{}", ops::tree::render_order_tree());
+
+        let mut ctx = HealthContext::bootstrap(self.network).await?;
+        let mut report = result::Report::new();
+
+        // Ops phase. Each op's `execute` is annotated with
+        // `#[tracing::instrument]` carrying the op name as a span field, so
+        // structured log consumers (--json / --logfmt) can correlate events
+        // to ops.
+        for op in ops::registry() {
+            let results = op.execute(&mut ctx).await;
+            for r in results {
+                r.print();
+                report.push(r);
+            }
+        }
+
+        // Final sync between ops and validators.
+        sync_all(&ctx, &mut report).await;
+
+        // Validation phase.
+        for v in validators::registry() {
+            let results = v.validate(&mut ctx).await;
+            for r in results {
+                r.print();
+                report.push(r);
+            }
+        }
+
+        report.print_summary();
+
+        if report.has_failures() {
+            std::process::exit(1);
+        }
+        Ok(())
+    }
+}
+
+async fn sync_all(ctx: &HealthContext, report: &mut result::Report) {
+    for client in ctx.all_clients() {
+        let start = Instant::now();
+        let outcome = client.sync_all_welcomes_and_groups(None).await;
+        let (status, error) = match outcome {
+            Ok(_) => (result::Status::Pass, None),
+            Err(e) => (result::Status::Fail, Some(eyre!("{e}"))),
+        };
+        let r = result::OpResult {
+            op_name: "Sync",
+            target: Some(client.inbox_id().to_string()),
+            status,
+            duration: start.elapsed(),
+            error,
+        };
+        r.print();
+        report.push(r);
+    }
+}

--- a/apps/xmtp_debug/src/app/health/ops/add_members.rs
+++ b/apps/xmtp_debug/src/app/health/ops/add_members.rs
@@ -1,0 +1,154 @@
+//! Ops that exercise membership changes against groups.
+//!
+//! - `AddMembersToNewGroup`: primary adds every existing identity to the
+//!   newly-created group.
+//! - `AddPrimaryToExistingGroups`: for every group in `ctx.existing_groups`,
+//!   primary is added by an active member of that group.
+
+use crate::app::health::context::HealthContext;
+use crate::app::health::ops::HealthOp;
+use crate::app::health::result::{OpResult, Status};
+use async_trait::async_trait;
+use color_eyre::eyre::eyre;
+use std::time::{Duration, Instant};
+
+pub struct AddMembersToNewGroup;
+
+#[async_trait]
+impl HealthOp for AddMembersToNewGroup {
+    fn name(&self) -> &'static str {
+        "AddMembersToNewGroup"
+    }
+
+    #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "AddMembersToNewGroup"))]
+    async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
+        let Some(new_group_id) = ctx.new_groups.first().cloned() else {
+            return vec![OpResult {
+                op_name: self.name(),
+                target: None,
+                status: Status::Fail,
+                duration: Duration::ZERO,
+                error: Some(eyre!("no new group; CreateGroup must run first")),
+            }];
+        };
+
+        let group = match ctx.primary.group(&new_group_id.to_vec()) {
+            Ok(g) => g,
+            Err(e) => {
+                return vec![OpResult {
+                    op_name: self.name(),
+                    target: Some(format!("{new_group_id}")),
+                    status: Status::Fail,
+                    duration: Duration::ZERO,
+                    error: Some(eyre!("{e}")),
+                }];
+            }
+        };
+
+        let mut inbox_ids: Vec<String> = ctx
+            .existing_clients
+            .values()
+            .map(|c| c.inbox_id().to_string())
+            .collect();
+        // Include transient so `LeaveGroup` has a member to remove without
+        // disturbing the run-stable primary.
+        inbox_ids.push(ctx.transient_identity.inbox_id().to_string());
+
+        let start = Instant::now();
+        let outcome = group.add_members(&inbox_ids).await;
+        let (status, error) = match outcome {
+            Ok(_) => (Status::Pass, None),
+            Err(e) => (Status::Fail, Some(eyre!("{e}"))),
+        };
+        vec![OpResult {
+            op_name: self.name(),
+            target: Some(format!("{new_group_id}")),
+            status,
+            duration: start.elapsed(),
+            error,
+        }]
+    }
+}
+
+pub struct AddPrimaryToExistingGroups;
+
+#[async_trait]
+impl HealthOp for AddPrimaryToExistingGroups {
+    fn name(&self) -> &'static str {
+        "AddPrimaryToExistingGroups"
+    }
+
+    #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "AddPrimaryToExistingGroups"))]
+    async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
+        let mut out = Vec::new();
+        let primary_inbox = ctx.primary.inbox_id().to_string();
+
+        for gid in &ctx.existing_groups {
+            let start = Instant::now();
+            let outcome: color_eyre::eyre::Result<()> = async {
+                // Find a client that is an active member of this group.
+                let mut adder = None;
+                for client in ctx.existing_clients.values() {
+                    let Ok(g) = client.group(&gid.to_vec()) else {
+                        continue;
+                    };
+                    if g.is_active().map_err(|e| eyre!("{e}"))? {
+                        adder = Some(g);
+                        break;
+                    }
+                }
+                let group = adder.ok_or_else(|| eyre!("no active member found for group"))?;
+                group
+                    .add_members(&[primary_inbox.clone()])
+                    .await
+                    .map_err(|e| eyre!("{e}"))?;
+                Ok(())
+            }
+            .await;
+
+            let (status, error) = match outcome {
+                Ok(_) => (Status::Pass, None),
+                Err(e) => (Status::Fail, Some(e)),
+            };
+            out.push(OpResult {
+                op_name: self.name(),
+                target: Some(format!("{gid}")),
+                status,
+                duration: start.elapsed(),
+                error,
+            });
+        }
+
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn names_are_stable() {
+        assert_eq!(AddMembersToNewGroup.name(), "AddMembersToNewGroup");
+        assert_eq!(
+            AddPrimaryToExistingGroups.name(),
+            "AddPrimaryToExistingGroups"
+        );
+    }
+}
+
+inventory::submit! {
+    crate::app::health::ops::OpEntry {
+        op_name: "AddMembersToNewGroup",
+        depends_on: &["CreateGroup"],
+        make: || Box::new(AddMembersToNewGroup),
+    }
+}
+
+inventory::submit! {
+    crate::app::health::ops::OpEntry {
+        op_name: "AddPrimaryToExistingGroups",
+        depends_on: &["CreateIdentity"],
+        make: || Box::new(AddPrimaryToExistingGroups),
+    }
+}

--- a/apps/xmtp_debug/src/app/health/ops/create_dm.rs
+++ b/apps/xmtp_debug/src/app/health/ops/create_dm.rs
@@ -1,0 +1,105 @@
+//! Op: primary creates a DM with every existing peer and round-trips one
+//! message in each direction.
+
+use crate::app::health::context::HealthContext;
+use crate::app::health::ops::HealthOp;
+use crate::app::health::result::{OpResult, Status};
+use async_trait::async_trait;
+use color_eyre::eyre::eyre;
+use std::time::Instant;
+use xmtp_mls::groups::send_message_opts::SendMessageOpts;
+
+pub struct CreateDm;
+
+#[async_trait]
+impl HealthOp for CreateDm {
+    fn name(&self) -> &'static str {
+        "CreateDm"
+    }
+
+    #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "CreateDm"))]
+    async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
+        let mut out = Vec::new();
+        let primary_inbox = ctx.primary.inbox_id().to_string();
+
+        for (peer_inbox_bytes, peer) in &ctx.existing_clients {
+            let peer_inbox = peer.inbox_id().to_string();
+            if peer_inbox == primary_inbox {
+                continue;
+            }
+
+            // Direction A: primary → peer.
+            let start = Instant::now();
+            let dir_a: color_eyre::eyre::Result<()> = async {
+                let dm = ctx
+                    .primary
+                    .find_or_create_dm(peer_inbox.as_str(), None)
+                    .await
+                    .map_err(|e| eyre!("{e}"))?;
+                dm.send_message(b"hi from primary", SendMessageOpts::default())
+                    .await
+                    .map_err(|e| eyre!("{e}"))?;
+                Ok(())
+            }
+            .await;
+            let (status, error) = match dir_a {
+                Ok(_) => (Status::Pass, None),
+                Err(e) => (Status::Fail, Some(e)),
+            };
+            out.push(OpResult {
+                op_name: "CreateDm",
+                target: Some(format!("primary->{}", hex::encode(peer_inbox_bytes))),
+                status,
+                duration: start.elapsed(),
+                error,
+            });
+
+            // Direction B: peer → primary.
+            let start = Instant::now();
+            let dir_b: color_eyre::eyre::Result<()> = async {
+                peer.sync_all_welcomes_and_groups(None)
+                    .await
+                    .map_err(|e| eyre!("{e}"))?;
+                let dm = peer
+                    .find_or_create_dm(primary_inbox.as_str(), None)
+                    .await
+                    .map_err(|e| eyre!("{e}"))?;
+                dm.send_message(b"hi from peer", SendMessageOpts::default())
+                    .await
+                    .map_err(|e| eyre!("{e}"))?;
+                Ok(())
+            }
+            .await;
+            let (status, error) = match dir_b {
+                Ok(_) => (Status::Pass, None),
+                Err(e) => (Status::Fail, Some(e)),
+            };
+            out.push(OpResult {
+                op_name: "SendDmRoundTrip",
+                target: Some(format!("{}->primary", hex::encode(peer_inbox_bytes))),
+                status,
+                duration: start.elapsed(),
+                error,
+            });
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn name_is_stable() {
+        assert_eq!(CreateDm.name(), "CreateDm");
+    }
+}
+
+inventory::submit! {
+    crate::app::health::ops::OpEntry {
+        op_name: "CreateDm",
+        depends_on: &["CreateIdentity"],
+        make: || Box::new(CreateDm),
+    }
+}

--- a/apps/xmtp_debug/src/app/health/ops/create_group.rs
+++ b/apps/xmtp_debug/src/app/health/ops/create_group.rs
@@ -1,0 +1,60 @@
+//! Op: primary creates one new group with default policy and metadata.
+//! The new group's id is appended to `ctx.new_groups` so downstream ops
+//! and validators see it.
+
+use crate::app::health::context::HealthContext;
+use crate::app::health::ops::HealthOp;
+use crate::app::health::result::{OpResult, Status};
+use async_trait::async_trait;
+use color_eyre::eyre::eyre;
+use std::time::Instant;
+use xmtp_proto::types::GroupId;
+
+pub struct CreateGroup;
+
+#[async_trait]
+impl HealthOp for CreateGroup {
+    fn name(&self) -> &'static str {
+        "CreateGroup"
+    }
+
+    #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "CreateGroup"))]
+    async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
+        let start = Instant::now();
+        let outcome = ctx.primary.create_group(None, None);
+        let (status, target, error) = match outcome {
+            Ok(group) => {
+                let new_group_id = GroupId::from(group.group_id.as_slice());
+                let hex_id = format!("{new_group_id}");
+                ctx.new_groups.push(new_group_id);
+                (Status::Pass, Some(hex_id), None)
+            }
+            Err(e) => (Status::Fail, None, Some(eyre!("{e}"))),
+        };
+        vec![OpResult {
+            op_name: self.name(),
+            target,
+            status,
+            duration: start.elapsed(),
+            error,
+        }]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn name_is_stable() {
+        assert_eq!(CreateGroup.name(), "CreateGroup");
+    }
+}
+
+inventory::submit! {
+    crate::app::health::ops::OpEntry {
+        op_name: "CreateGroup",
+        depends_on: &["CreateIdentity"],
+        make: || Box::new(CreateGroup),
+    }
+}

--- a/apps/xmtp_debug/src/app/health/ops/create_identity.rs
+++ b/apps/xmtp_debug/src/app/health/ops/create_identity.rs
@@ -1,0 +1,54 @@
+//! Op: record that the run's primary identity was successfully created.
+//! The actual creation happens during `HealthContext::bootstrap`; this op
+//! exposes that success as a discrete check in the run's result table.
+
+use crate::app::health::context::HealthContext;
+use crate::app::health::ops::HealthOp;
+use crate::app::health::result::{OpResult, Status};
+use async_trait::async_trait;
+use std::time::Instant;
+
+pub struct CreateIdentity;
+
+#[async_trait]
+impl HealthOp for CreateIdentity {
+    fn name(&self) -> &'static str {
+        "CreateIdentity"
+    }
+
+    #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "CreateIdentity"))]
+    async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
+        let start = Instant::now();
+        let inbox_id = ctx.primary.inbox_id().to_string();
+        let status = if inbox_id.is_empty() {
+            Status::Fail
+        } else {
+            Status::Pass
+        };
+        vec![OpResult {
+            op_name: self.name(),
+            target: Some(inbox_id),
+            status,
+            duration: start.elapsed(),
+            error: None,
+        }]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn name_is_stable() {
+        assert_eq!(CreateIdentity.name(), "CreateIdentity");
+    }
+}
+
+inventory::submit! {
+    crate::app::health::ops::OpEntry {
+        op_name: "CreateIdentity",
+        depends_on: &[],
+        make: || Box::new(CreateIdentity),
+    }
+}

--- a/apps/xmtp_debug/src/app/health/ops/get_mutable_metadata.rs
+++ b/apps/xmtp_debug/src/app/health/ops/get_mutable_metadata.rs
@@ -1,0 +1,68 @@
+//! Op: read mutable_metadata from every group primary is in.
+//! Read-only — verifies the metadata extension is reachable.
+
+use crate::app::health::context::HealthContext;
+use crate::app::health::ops::HealthOp;
+use crate::app::health::result::{OpResult, Status};
+use async_trait::async_trait;
+use color_eyre::eyre::eyre;
+use std::time::Instant;
+use xmtp_proto::types::GroupId;
+
+pub struct GetMutableMetadata;
+
+#[async_trait]
+impl HealthOp for GetMutableMetadata {
+    fn name(&self) -> &'static str {
+        "GetMutableMetadata"
+    }
+
+    #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "GetMutableMetadata"))]
+    async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
+        let mut out = Vec::new();
+        let mut all_groups: Vec<GroupId> = ctx.existing_groups.clone();
+        all_groups.extend(ctx.new_groups.iter().cloned());
+
+        for gid in &all_groups {
+            let start = Instant::now();
+            let outcome: color_eyre::eyre::Result<()> = (|| {
+                let group = ctx
+                    .primary
+                    .group(&gid.to_vec())
+                    .map_err(|e| eyre!("{e}"))?;
+                let _ = group.mutable_metadata().map_err(|e| eyre!("{e}"))?;
+                Ok(())
+            })();
+            let (status, error) = match outcome {
+                Ok(_) => (Status::Pass, None),
+                Err(e) => (Status::Fail, Some(e)),
+            };
+            out.push(OpResult {
+                op_name: self.name(),
+                target: Some(format!("{gid}")),
+                status,
+                duration: start.elapsed(),
+                error,
+            });
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn name_is_stable() {
+        assert_eq!(GetMutableMetadata.name(), "GetMutableMetadata");
+    }
+}
+
+inventory::submit! {
+    crate::app::health::ops::OpEntry {
+        op_name: "GetMutableMetadata",
+        depends_on: &["AddMembersToNewGroup", "AddPrimaryToExistingGroups"],
+        make: || Box::new(GetMutableMetadata),
+    }
+}

--- a/apps/xmtp_debug/src/app/health/ops/leave_group.rs
+++ b/apps/xmtp_debug/src/app/health/ops/leave_group.rs
@@ -1,0 +1,95 @@
+//! Op: transient identity self-removes from the newly-created group via
+//! MLS `leave_group`. Uses the transient instead of the primary so the
+//! persisted primary stays in every group across runs.
+//! Must run last so prior ops are not invalidated by the membership change.
+//!
+//! Distinct from `RemoveMember` which exercises the admin-remove path
+//! (one identity removes another via `remove_members`).
+
+use crate::app::health::context::HealthContext;
+use crate::app::health::ops::HealthOp;
+use crate::app::health::result::{OpResult, Status};
+use async_trait::async_trait;
+use color_eyre::eyre::eyre;
+use std::time::{Duration, Instant};
+
+pub struct LeaveGroup;
+
+#[async_trait]
+impl HealthOp for LeaveGroup {
+    fn name(&self) -> &'static str {
+        "LeaveGroup"
+    }
+
+    #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "LeaveGroup"))]
+    async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
+        let Some(gid) = ctx.new_groups.first().cloned() else {
+            return vec![OpResult {
+                op_name: self.name(),
+                target: None,
+                status: Status::Fail,
+                duration: Duration::ZERO,
+                error: Some(eyre!("no new group to leave")),
+            }];
+        };
+
+        let start = Instant::now();
+        let outcome: color_eyre::eyre::Result<()> = async {
+            // Transient must see the welcome for this group before it can
+            // load + leave it. The add happened earlier in the run but is
+            // only visible after a sync.
+            ctx.transient_identity
+                .sync_welcomes()
+                .await
+                .map_err(|e| eyre!("{e}"))?;
+            let group = ctx
+                .transient_identity
+                .group(&gid.to_vec())
+                .map_err(|e| eyre!("{e}"))?;
+            group.leave_group().await.map_err(|e| eyre!("{e}"))?;
+            Ok(())
+        }
+        .await;
+        let (status, error) = match outcome {
+            Ok(_) => (Status::Pass, None),
+            Err(e) => (Status::Fail, Some(e)),
+        };
+        vec![OpResult {
+            op_name: self.name(),
+            target: Some(format!("{gid}")),
+            status,
+            duration: start.elapsed(),
+            error,
+        }]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn name_is_stable() {
+        assert_eq!(LeaveGroup.name(), "LeaveGroup");
+    }
+}
+
+inventory::submit! {
+    crate::app::health::ops::OpEntry {
+        op_name: "LeaveGroup",
+        depends_on: &[
+            "SendMessage",
+            "UpdateGroupName",
+            "UpdateGroupDescription",
+            "UpdateGroupImageUrlSquare",
+            "RemoveMessageDisappearing",
+            "UpdateAdminList",
+            "UpdatePermissionPolicy",
+            "UpdateAppData",
+            "UpdateCommitLogSigner",
+            "UpdateConsentStateQuiet",
+            "GetMutableMetadata",
+        ],
+        make: || Box::new(LeaveGroup),
+    }
+}

--- a/apps/xmtp_debug/src/app/health/ops/mod.rs
+++ b/apps/xmtp_debug/src/app/health/ops/mod.rs
@@ -1,0 +1,69 @@
+//! Health-check ops registry.
+//!
+//! Every op exercises one user-visible libxmtp operation. Each op lives in
+//! its own submodule and self-registers via `inventory::submit!`. The
+//! `registry()` function returns ops topologically sorted by their
+//! declared `depends_on` relationships.
+
+use crate::app::health::context::HealthContext;
+use crate::app::health::registry::{self, RegistryEntry};
+use crate::app::health::result::OpResult;
+use async_trait::async_trait;
+
+mod add_members;
+mod create_dm;
+mod create_group;
+mod create_identity;
+mod get_mutable_metadata;
+mod leave_group;
+mod remove_member;
+mod send_message;
+mod update_admin_list;
+mod update_app_data;
+mod update_commit_log_signer;
+mod update_consent_state;
+mod update_group_description;
+mod update_group_image_url;
+mod update_group_name;
+mod update_message_disappearing;
+mod update_permission_policy;
+mod upload_key_package;
+
+pub mod tree;
+
+#[async_trait]
+pub trait HealthOp: Send + Sync {
+    fn name(&self) -> &'static str;
+    async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult>;
+}
+
+/// Self-registration entry for an op. Each op submits one of these from
+/// its own module via `inventory::submit!`.
+pub struct OpEntry {
+    pub op_name: &'static str,
+    /// Names of ops that must complete before this one runs.
+    pub depends_on: &'static [&'static str],
+    pub make: fn() -> Box<dyn HealthOp>,
+}
+
+inventory::collect!(OpEntry);
+
+impl RegistryEntry for OpEntry {
+    type Item = dyn HealthOp;
+    const KIND: &'static str = "op";
+
+    fn name(&self) -> &'static str {
+        self.op_name
+    }
+    fn depends_on(&self) -> &'static [&'static str] {
+        self.depends_on
+    }
+    fn make(&self) -> Box<dyn HealthOp> {
+        (self.make)()
+    }
+}
+
+/// Topologically-sorted list of every registered op.
+pub fn registry() -> Vec<Box<dyn HealthOp>> {
+    registry::topo_sort::<OpEntry>(inventory::iter::<OpEntry>)
+}

--- a/apps/xmtp_debug/src/app/health/ops/remove_member.rs
+++ b/apps/xmtp_debug/src/app/health/ops/remove_member.rs
@@ -1,0 +1,109 @@
+//! Op: primary admin-removes a peer from the newly-created group via
+//! `MlsGroup::remove_members`. Distinct from `LeaveGroup` which exercises
+//! the MLS self-remove path. Both code paths produce a remove commit but
+//! follow different intent + validation flows in libxmtp.
+//!
+//! Victim is the first existing identity (i.e. one of the bootstrap or
+//! pre-existing clients). If none is available, the op fails with a
+//! reason.
+
+use crate::app::health::context::HealthContext;
+use crate::app::health::ops::HealthOp;
+use crate::app::health::result::{OpResult, Status};
+use async_trait::async_trait;
+use color_eyre::eyre::eyre;
+use std::time::{Duration, Instant};
+
+pub struct RemoveMember;
+
+#[async_trait]
+impl HealthOp for RemoveMember {
+    fn name(&self) -> &'static str {
+        "RemoveMember"
+    }
+
+    #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "RemoveMember"))]
+    async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
+        let Some(gid) = ctx.new_groups.first().cloned() else {
+            return vec![OpResult {
+                op_name: self.name(),
+                target: None,
+                status: Status::Fail,
+                duration: Duration::ZERO,
+                error: Some(eyre!("no new group to remove from")),
+            }];
+        };
+
+        let primary_inbox = ctx.primary.inbox_id().to_string();
+        let transient_inbox = ctx.transient_identity.inbox_id().to_string();
+        let Some(victim_inbox) = ctx
+            .existing_clients
+            .values()
+            .map(|c| c.inbox_id().to_string())
+            .find(|id| id != &primary_inbox && id != &transient_inbox)
+        else {
+            return vec![OpResult {
+                op_name: self.name(),
+                target: Some(format!("{gid}")),
+                status: Status::Fail,
+                duration: Duration::ZERO,
+                error: Some(eyre!("no existing identity available as remove target")),
+            }];
+        };
+
+        let start = Instant::now();
+        let outcome: color_eyre::eyre::Result<()> = async {
+            let group = ctx
+                .primary
+                .group(&gid.to_vec())
+                .map_err(|e| eyre!("{e}"))?;
+            group
+                .remove_members(&[victim_inbox.as_str()])
+                .await
+                .map_err(|e| eyre!("{e}"))?;
+            Ok(())
+        }
+        .await;
+        let (status, error) = match outcome {
+            Ok(_) => (Status::Pass, None),
+            Err(e) => (Status::Fail, Some(e)),
+        };
+        vec![OpResult {
+            op_name: self.name(),
+            target: Some(format!("group={gid} victim={victim_inbox}")),
+            status,
+            duration: start.elapsed(),
+            error,
+        }]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn name_is_stable() {
+        assert_eq!(RemoveMember.name(), "RemoveMember");
+    }
+}
+
+inventory::submit! {
+    crate::app::health::ops::OpEntry {
+        op_name: "RemoveMember",
+        depends_on: &[
+            "SendMessage",
+            "UpdateGroupName",
+            "UpdateGroupDescription",
+            "UpdateGroupImageUrlSquare",
+            "RemoveMessageDisappearing",
+            "UpdateAdminList",
+            "UpdatePermissionPolicy",
+            "UpdateAppData",
+            "UpdateCommitLogSigner",
+            "UpdateConsentStateQuiet",
+            "GetMutableMetadata",
+        ],
+        make: || Box::new(RemoveMember),
+    }
+}

--- a/apps/xmtp_debug/src/app/health/ops/send_message.rs
+++ b/apps/xmtp_debug/src/app/health/ops/send_message.rs
@@ -1,0 +1,81 @@
+//! Op: every client sends one message into every group it belongs to.
+//! Feeds the missing-messages validator.
+
+use crate::app::health::context::HealthContext;
+use crate::app::health::ops::HealthOp;
+use crate::app::health::result::{OpResult, Status};
+use async_trait::async_trait;
+use color_eyre::eyre::eyre;
+use std::time::Instant;
+use xmtp_mls::groups::send_message_opts::SendMessageOpts;
+use xmtp_proto::types::GroupId;
+
+pub struct SendMessage;
+
+#[async_trait]
+impl HealthOp for SendMessage {
+    fn name(&self) -> &'static str {
+        "SendMessage"
+    }
+
+    #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "SendMessage"))]
+    async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
+        let mut out = Vec::new();
+
+        let mut all_groups: Vec<GroupId> = ctx.existing_groups.clone();
+        all_groups.extend(ctx.new_groups.iter().cloned());
+
+        for client in ctx.all_clients() {
+            for gid in &all_groups {
+                let start = Instant::now();
+                let outcome: color_eyre::eyre::Result<()> = async {
+                    let Ok(group) = client.group(&gid.to_vec()) else {
+                        return Ok(());
+                    };
+                    if !group.is_active().map_err(|e| eyre!("{e}"))? {
+                        return Ok(());
+                    }
+                    let body = format!("healthcheck from {}", client.inbox_id());
+                    group
+                        .send_message(body.as_bytes(), SendMessageOpts::default())
+                        .await
+                        .map_err(|e| eyre!("{e}"))?;
+                    Ok(())
+                }
+                .await;
+
+                let (status, error) = match outcome {
+                    Ok(_) => (Status::Pass, None),
+                    Err(e) => (Status::Fail, Some(e)),
+                };
+                out.push(OpResult {
+                    op_name: self.name(),
+                    target: Some(format!("inbox={} group={gid}", client.inbox_id())),
+                    status,
+                    duration: start.elapsed(),
+                    error,
+                });
+            }
+        }
+
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn name_is_stable() {
+        assert_eq!(SendMessage.name(), "SendMessage");
+    }
+}
+
+inventory::submit! {
+    crate::app::health::ops::OpEntry {
+        op_name: "SendMessage",
+        depends_on: &["AddMembersToNewGroup", "AddPrimaryToExistingGroups"],
+        make: || Box::new(SendMessage),
+    }
+}

--- a/apps/xmtp_debug/src/app/health/ops/tree.rs
+++ b/apps/xmtp_debug/src/app/health/ops/tree.rs
@@ -1,0 +1,73 @@
+//! Cosmetic: render the resolved op execution order as staged layers. Not
+//! load-bearing — purely human-readable preflight output before a run.
+//!
+//! Stage N contains every op whose longest dependency chain from a root
+//! has length N. Ops in the same stage can run in any order (they have no
+//! mutual dependencies). Stages run sequentially.
+
+use super::OpEntry;
+use std::collections::BTreeMap;
+use std::fmt::Write;
+
+pub fn render_order_tree() -> String {
+    let entries: BTreeMap<&'static str, &'static OpEntry> = inventory::iter::<OpEntry>
+        .into_iter()
+        .map(|e| (e.op_name, e))
+        .collect();
+
+    // stage[name] = longest dep-chain length from any root, computed via
+    // memoized DFS. A node with no deps is stage 0. Otherwise it is
+    // 1 + max(stage of each dep).
+    let mut stage: BTreeMap<&'static str, usize> = BTreeMap::new();
+    for name in entries.keys() {
+        compute_stage(name, &entries, &mut stage);
+    }
+
+    // Group by stage. BTreeMap keys sort numerically; BTreeSet groups
+    // alphabetically within each stage.
+    let mut by_stage: BTreeMap<usize, Vec<&'static str>> = BTreeMap::new();
+    for (name, s) in &stage {
+        by_stage.entry(*s).or_default().push(*name);
+    }
+    for ops in by_stage.values_mut() {
+        ops.sort();
+    }
+
+    let mut out = String::new();
+    out.push_str(
+        "healthcheck op stages (stages run sequentially; within a stage, \
+         ops are independent and shown alphabetically):\n",
+    );
+    for (s, ops) in &by_stage {
+        let _ = writeln!(out, "  stage {s}:");
+        for op in ops {
+            let _ = writeln!(out, "    - {op}");
+        }
+    }
+    out
+}
+
+fn compute_stage(
+    name: &'static str,
+    entries: &BTreeMap<&'static str, &'static OpEntry>,
+    stage: &mut BTreeMap<&'static str, usize>,
+) -> usize {
+    if let Some(&s) = stage.get(name) {
+        return s;
+    }
+    let Some(entry) = entries.get(name) else {
+        return 0;
+    };
+    let s = if entry.depends_on.is_empty() {
+        0
+    } else {
+        entry
+            .depends_on
+            .iter()
+            .map(|dep| compute_stage(dep, entries, stage) + 1)
+            .max()
+            .unwrap_or(0)
+    };
+    stage.insert(name, s);
+    s
+}

--- a/apps/xmtp_debug/src/app/health/ops/update_admin_list.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_admin_list.rs
@@ -1,0 +1,74 @@
+//! Op: add the primary client as a super-admin on every reachable group.
+
+use crate::app::health::context::HealthContext;
+use crate::app::health::ops::HealthOp;
+use crate::app::health::result::{OpResult, Status};
+use async_trait::async_trait;
+use color_eyre::eyre::eyre;
+use std::time::Instant;
+use xmtp_mls::groups::UpdateAdminListType;
+use xmtp_proto::types::GroupId;
+
+pub struct UpdateAdminList;
+
+#[async_trait]
+impl HealthOp for UpdateAdminList {
+    fn name(&self) -> &'static str {
+        "UpdateAdminList"
+    }
+
+    #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "UpdateAdminList"))]
+    async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
+        let mut out = Vec::new();
+        let mut all_groups: Vec<GroupId> = ctx.existing_groups.clone();
+        all_groups.extend(ctx.new_groups.iter().cloned());
+
+        for gid in &all_groups {
+            let start = Instant::now();
+            let outcome: color_eyre::eyre::Result<()> = async {
+                let group = ctx
+                    .primary
+                    .group(&gid.to_vec())
+                    .map_err(|e| eyre!("{e}"))?;
+                group
+                    .update_admin_list(
+                        UpdateAdminListType::AddSuper,
+                        ctx.primary.inbox_id().to_string(),
+                    )
+                    .await
+                    .map_err(|e| eyre!("{e}"))?;
+                Ok(())
+            }
+            .await;
+            let (status, error) = match outcome {
+                Ok(_) => (Status::Pass, None),
+                Err(e) => (Status::Fail, Some(e)),
+            };
+            out.push(OpResult {
+                op_name: self.name(),
+                target: Some(format!("{gid}")),
+                status,
+                duration: start.elapsed(),
+                error,
+            });
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn name_is_stable() {
+        assert_eq!(UpdateAdminList.name(), "UpdateAdminList");
+    }
+}
+
+inventory::submit! {
+    crate::app::health::ops::OpEntry {
+        op_name: "UpdateAdminList",
+        depends_on: &["AddMembersToNewGroup", "AddPrimaryToExistingGroups"],
+        make: || Box::new(UpdateAdminList),
+    }
+}

--- a/apps/xmtp_debug/src/app/health/ops/update_app_data.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_app_data.rs
@@ -1,0 +1,70 @@
+//! Op: update the app-data metadata field on every reachable group.
+
+use crate::app::health::context::HealthContext;
+use crate::app::health::ops::HealthOp;
+use crate::app::health::result::{OpResult, Status};
+use async_trait::async_trait;
+use color_eyre::eyre::eyre;
+use std::time::Instant;
+use xmtp_proto::types::GroupId;
+
+pub struct UpdateAppData;
+
+#[async_trait]
+impl HealthOp for UpdateAppData {
+    fn name(&self) -> &'static str {
+        "UpdateAppData"
+    }
+
+    #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "UpdateAppData"))]
+    async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
+        let mut out = Vec::new();
+        let mut all_groups: Vec<GroupId> = ctx.existing_groups.clone();
+        all_groups.extend(ctx.new_groups.iter().cloned());
+
+        for gid in &all_groups {
+            let start = Instant::now();
+            let outcome: color_eyre::eyre::Result<()> = async {
+                let group = ctx
+                    .primary
+                    .group(&gid.to_vec())
+                    .map_err(|e| eyre!("{e}"))?;
+                group
+                    .update_app_data("healthcheck-app-data".into())
+                    .await
+                    .map_err(|e| eyre!("{e}"))?;
+                Ok(())
+            }
+            .await;
+            let (status, error) = match outcome {
+                Ok(_) => (Status::Pass, None),
+                Err(e) => (Status::Fail, Some(e)),
+            };
+            out.push(OpResult {
+                op_name: self.name(),
+                target: Some(format!("{gid}")),
+                status,
+                duration: start.elapsed(),
+                error,
+            });
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn name_is_stable() {
+        assert_eq!(UpdateAppData.name(), "UpdateAppData");
+    }
+}
+
+inventory::submit! {
+    crate::app::health::ops::OpEntry {
+        op_name: "UpdateAppData",
+        depends_on: &["AddMembersToNewGroup", "AddPrimaryToExistingGroups"],
+        make: || Box::new(UpdateAppData),
+    }
+}

--- a/apps/xmtp_debug/src/app/health/ops/update_commit_log_signer.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_commit_log_signer.rs
@@ -1,0 +1,73 @@
+//! Op: rotate the commit-log signer on every group primary is in.
+
+use crate::app::health::context::HealthContext;
+use crate::app::health::ops::HealthOp;
+use crate::app::health::result::{OpResult, Status};
+use async_trait::async_trait;
+use color_eyre::eyre::eyre;
+use std::time::Instant;
+use xmtp_cryptography::Secret;
+use xmtp_proto::types::GroupId;
+
+pub struct UpdateCommitLogSigner;
+
+#[async_trait]
+impl HealthOp for UpdateCommitLogSigner {
+    fn name(&self) -> &'static str {
+        "UpdateCommitLogSigner"
+    }
+
+    #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "UpdateCommitLogSigner"))]
+    async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
+        let mut out = Vec::new();
+        let mut all_groups: Vec<GroupId> = ctx.existing_groups.clone();
+        all_groups.extend(ctx.new_groups.iter().cloned());
+
+        for gid in &all_groups {
+            let start = Instant::now();
+            let outcome: color_eyre::eyre::Result<()> = async {
+                let group = ctx
+                    .primary
+                    .group(&gid.to_vec())
+                    .map_err(|e| eyre!("{e}"))?;
+                let signer: Secret = vec![0u8; 32].into();
+                group
+                    .update_commit_log_signer(signer)
+                    .await
+                    .map_err(|e| eyre!("{e}"))?;
+                Ok(())
+            }
+            .await;
+            let (status, error) = match outcome {
+                Ok(_) => (Status::Pass, None),
+                Err(e) => (Status::Fail, Some(e)),
+            };
+            out.push(OpResult {
+                op_name: self.name(),
+                target: Some(format!("{gid}")),
+                status,
+                duration: start.elapsed(),
+                error,
+            });
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn name_is_stable() {
+        assert_eq!(UpdateCommitLogSigner.name(), "UpdateCommitLogSigner");
+    }
+}
+
+inventory::submit! {
+    crate::app::health::ops::OpEntry {
+        op_name: "UpdateCommitLogSigner",
+        depends_on: &["AddMembersToNewGroup", "AddPrimaryToExistingGroups"],
+        make: || Box::new(UpdateCommitLogSigner),
+    }
+}

--- a/apps/xmtp_debug/src/app/health/ops/update_consent_state.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_consent_state.rs
@@ -1,0 +1,125 @@
+//! Ops: set consent state on every group primary is in.
+//!
+//! - `UpdateConsentState`: emits an MLS commit recording the new consent.
+//! - `UpdateConsentStateQuiet`: updates only local consent state, no commit.
+
+use crate::app::health::context::HealthContext;
+use crate::app::health::ops::HealthOp;
+use crate::app::health::result::{OpResult, Status};
+use async_trait::async_trait;
+use color_eyre::eyre::eyre;
+use std::time::Instant;
+use xmtp_db::consent_record::ConsentState;
+use xmtp_proto::types::GroupId;
+
+pub struct UpdateConsentState;
+
+#[async_trait]
+impl HealthOp for UpdateConsentState {
+    fn name(&self) -> &'static str {
+        "UpdateConsentState"
+    }
+
+    #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "UpdateConsentState"))]
+    async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
+        let mut out = Vec::new();
+        let mut all_groups: Vec<GroupId> = ctx.existing_groups.clone();
+        all_groups.extend(ctx.new_groups.iter().cloned());
+
+        for gid in &all_groups {
+            let start = Instant::now();
+            let outcome: color_eyre::eyre::Result<()> = (|| {
+                let group = ctx
+                    .primary
+                    .group(&gid.to_vec())
+                    .map_err(|e| eyre!("{e}"))?;
+                group
+                    .update_consent_state(ConsentState::Allowed)
+                    .map_err(|e| eyre!("{e}"))?;
+                Ok(())
+            })();
+            let (status, error) = match outcome {
+                Ok(_) => (Status::Pass, None),
+                Err(e) => (Status::Fail, Some(e)),
+            };
+            out.push(OpResult {
+                op_name: self.name(),
+                target: Some(format!("{gid}")),
+                status,
+                duration: start.elapsed(),
+                error,
+            });
+        }
+        out
+    }
+}
+
+pub struct UpdateConsentStateQuiet;
+
+#[async_trait]
+impl HealthOp for UpdateConsentStateQuiet {
+    fn name(&self) -> &'static str {
+        "UpdateConsentStateQuiet"
+    }
+
+    #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "UpdateConsentStateQuiet"))]
+    async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
+        let mut out = Vec::new();
+        let mut all_groups: Vec<GroupId> = ctx.existing_groups.clone();
+        all_groups.extend(ctx.new_groups.iter().cloned());
+
+        let db = ctx.primary.db();
+        for gid in &all_groups {
+            let start = Instant::now();
+            let outcome: color_eyre::eyre::Result<()> = (|| {
+                let group = ctx
+                    .primary
+                    .group(&gid.to_vec())
+                    .map_err(|e| eyre!("{e}"))?;
+                group
+                    .quietly_update_consent_state(ConsentState::Allowed, &db)
+                    .map_err(|e| eyre!("{e}"))?;
+                Ok(())
+            })();
+            let (status, error) = match outcome {
+                Ok(_) => (Status::Pass, None),
+                Err(e) => (Status::Fail, Some(e)),
+            };
+            out.push(OpResult {
+                op_name: self.name(),
+                target: Some(format!("{gid}")),
+                status,
+                duration: start.elapsed(),
+                error,
+            });
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn names_are_stable() {
+        assert_eq!(UpdateConsentState.name(), "UpdateConsentState");
+        assert_eq!(UpdateConsentStateQuiet.name(), "UpdateConsentStateQuiet");
+    }
+}
+
+inventory::submit! {
+    crate::app::health::ops::OpEntry {
+        op_name: "UpdateConsentState",
+        depends_on: &["AddMembersToNewGroup", "AddPrimaryToExistingGroups"],
+        make: || Box::new(UpdateConsentState),
+    }
+}
+
+inventory::submit! {
+    crate::app::health::ops::OpEntry {
+        op_name: "UpdateConsentStateQuiet",
+        depends_on: &["UpdateConsentState"],
+        make: || Box::new(UpdateConsentStateQuiet),
+    }
+}

--- a/apps/xmtp_debug/src/app/health/ops/update_group_description.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_group_description.rs
@@ -1,0 +1,70 @@
+//! Op: update the group description on every reachable group.
+
+use crate::app::health::context::HealthContext;
+use crate::app::health::ops::HealthOp;
+use crate::app::health::result::{OpResult, Status};
+use async_trait::async_trait;
+use color_eyre::eyre::eyre;
+use std::time::Instant;
+use xmtp_proto::types::GroupId;
+
+pub struct UpdateGroupDescription;
+
+#[async_trait]
+impl HealthOp for UpdateGroupDescription {
+    fn name(&self) -> &'static str {
+        "UpdateGroupDescription"
+    }
+
+    #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "UpdateGroupDescription"))]
+    async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
+        let mut out = Vec::new();
+        let mut all_groups: Vec<GroupId> = ctx.existing_groups.clone();
+        all_groups.extend(ctx.new_groups.iter().cloned());
+
+        for gid in &all_groups {
+            let start = Instant::now();
+            let outcome: color_eyre::eyre::Result<()> = async {
+                let group = ctx
+                    .primary
+                    .group(&gid.to_vec())
+                    .map_err(|e| eyre!("{e}"))?;
+                group
+                    .update_group_description("healthcheck-desc".into())
+                    .await
+                    .map_err(|e| eyre!("{e}"))?;
+                Ok(())
+            }
+            .await;
+            let (status, error) = match outcome {
+                Ok(_) => (Status::Pass, None),
+                Err(e) => (Status::Fail, Some(e)),
+            };
+            out.push(OpResult {
+                op_name: self.name(),
+                target: Some(format!("{gid}")),
+                status,
+                duration: start.elapsed(),
+                error,
+            });
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn name_is_stable() {
+        assert_eq!(UpdateGroupDescription.name(), "UpdateGroupDescription");
+    }
+}
+
+inventory::submit! {
+    crate::app::health::ops::OpEntry {
+        op_name: "UpdateGroupDescription",
+        depends_on: &["AddMembersToNewGroup", "AddPrimaryToExistingGroups"],
+        make: || Box::new(UpdateGroupDescription),
+    }
+}

--- a/apps/xmtp_debug/src/app/health/ops/update_group_image_url.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_group_image_url.rs
@@ -1,0 +1,73 @@
+//! Op: update the group image URL (square) on every reachable group.
+
+use crate::app::health::context::HealthContext;
+use crate::app::health::ops::HealthOp;
+use crate::app::health::result::{OpResult, Status};
+use async_trait::async_trait;
+use color_eyre::eyre::eyre;
+use std::time::Instant;
+use xmtp_proto::types::GroupId;
+
+pub struct UpdateGroupImageUrlSquare;
+
+#[async_trait]
+impl HealthOp for UpdateGroupImageUrlSquare {
+    fn name(&self) -> &'static str {
+        "UpdateGroupImageUrlSquare"
+    }
+
+    #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "UpdateGroupImageUrlSquare"))]
+    async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
+        let mut out = Vec::new();
+        let mut all_groups: Vec<GroupId> = ctx.existing_groups.clone();
+        all_groups.extend(ctx.new_groups.iter().cloned());
+
+        for gid in &all_groups {
+            let start = Instant::now();
+            let outcome: color_eyre::eyre::Result<()> = async {
+                let group = ctx
+                    .primary
+                    .group(&gid.to_vec())
+                    .map_err(|e| eyre!("{e}"))?;
+                group
+                    .update_group_image_url_square("https://example.invalid/img.png".into())
+                    .await
+                    .map_err(|e| eyre!("{e}"))?;
+                Ok(())
+            }
+            .await;
+            let (status, error) = match outcome {
+                Ok(_) => (Status::Pass, None),
+                Err(e) => (Status::Fail, Some(e)),
+            };
+            out.push(OpResult {
+                op_name: self.name(),
+                target: Some(format!("{gid}")),
+                status,
+                duration: start.elapsed(),
+                error,
+            });
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn name_is_stable() {
+        assert_eq!(
+            UpdateGroupImageUrlSquare.name(),
+            "UpdateGroupImageUrlSquare"
+        );
+    }
+}
+
+inventory::submit! {
+    crate::app::health::ops::OpEntry {
+        op_name: "UpdateGroupImageUrlSquare",
+        depends_on: &["AddMembersToNewGroup", "AddPrimaryToExistingGroups"],
+        make: || Box::new(UpdateGroupImageUrlSquare),
+    }
+}

--- a/apps/xmtp_debug/src/app/health/ops/update_group_name.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_group_name.rs
@@ -1,0 +1,70 @@
+//! Op: update the group name on every reachable group.
+
+use crate::app::health::context::HealthContext;
+use crate::app::health::ops::HealthOp;
+use crate::app::health::result::{OpResult, Status};
+use async_trait::async_trait;
+use color_eyre::eyre::eyre;
+use std::time::Instant;
+use xmtp_proto::types::GroupId;
+
+pub struct UpdateGroupName;
+
+#[async_trait]
+impl HealthOp for UpdateGroupName {
+    fn name(&self) -> &'static str {
+        "UpdateGroupName"
+    }
+
+    #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "UpdateGroupName"))]
+    async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
+        let mut out = Vec::new();
+        let mut all_groups: Vec<GroupId> = ctx.existing_groups.clone();
+        all_groups.extend(ctx.new_groups.iter().cloned());
+
+        for gid in &all_groups {
+            let start = Instant::now();
+            let outcome: color_eyre::eyre::Result<()> = async {
+                let group = ctx
+                    .primary
+                    .group(&gid.to_vec())
+                    .map_err(|e| eyre!("{e}"))?;
+                group
+                    .update_group_name("healthcheck-name".into())
+                    .await
+                    .map_err(|e| eyre!("{e}"))?;
+                Ok(())
+            }
+            .await;
+            let (status, error) = match outcome {
+                Ok(_) => (Status::Pass, None),
+                Err(e) => (Status::Fail, Some(e)),
+            };
+            out.push(OpResult {
+                op_name: self.name(),
+                target: Some(format!("{gid}")),
+                status,
+                duration: start.elapsed(),
+                error,
+            });
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn name_is_stable() {
+        assert_eq!(UpdateGroupName.name(), "UpdateGroupName");
+    }
+}
+
+inventory::submit! {
+    crate::app::health::ops::OpEntry {
+        op_name: "UpdateGroupName",
+        depends_on: &["AddMembersToNewGroup", "AddPrimaryToExistingGroups"],
+        make: || Box::new(UpdateGroupName),
+    }
+}

--- a/apps/xmtp_debug/src/app/health/ops/update_message_disappearing.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_message_disappearing.rs
@@ -1,0 +1,132 @@
+//! Op: set and remove conversation message-disappearing settings on every reachable group.
+
+use crate::app::health::context::HealthContext;
+use crate::app::health::ops::HealthOp;
+use crate::app::health::result::{OpResult, Status};
+use async_trait::async_trait;
+use color_eyre::eyre::eyre;
+use std::time::Instant;
+use xmtp_mls_common::group_mutable_metadata::MessageDisappearingSettings;
+use xmtp_proto::types::GroupId;
+
+pub struct UpdateMessageDisappearing;
+
+#[async_trait]
+impl HealthOp for UpdateMessageDisappearing {
+    fn name(&self) -> &'static str {
+        "UpdateMessageDisappearing"
+    }
+
+    #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "UpdateMessageDisappearing"))]
+    async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
+        let mut out = Vec::new();
+        let mut all_groups: Vec<GroupId> = ctx.existing_groups.clone();
+        all_groups.extend(ctx.new_groups.iter().cloned());
+
+        for gid in &all_groups {
+            let start = Instant::now();
+            let outcome: color_eyre::eyre::Result<()> = async {
+                let group = ctx
+                    .primary
+                    .group(&gid.to_vec())
+                    .map_err(|e| eyre!("{e}"))?;
+                group
+                    .update_conversation_message_disappearing_settings(
+                        MessageDisappearingSettings::new(1, 86_400_000_000_000),
+                    )
+                    .await
+                    .map_err(|e| eyre!("{e}"))?;
+                Ok(())
+            }
+            .await;
+            let (status, error) = match outcome {
+                Ok(_) => (Status::Pass, None),
+                Err(e) => (Status::Fail, Some(e)),
+            };
+            out.push(OpResult {
+                op_name: self.name(),
+                target: Some(format!("{gid}")),
+                status,
+                duration: start.elapsed(),
+                error,
+            });
+        }
+        out
+    }
+}
+
+pub struct RemoveMessageDisappearing;
+
+#[async_trait]
+impl HealthOp for RemoveMessageDisappearing {
+    fn name(&self) -> &'static str {
+        "RemoveMessageDisappearing"
+    }
+
+    #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "RemoveMessageDisappearing"))]
+    async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
+        let mut out = Vec::new();
+        let mut all_groups: Vec<GroupId> = ctx.existing_groups.clone();
+        all_groups.extend(ctx.new_groups.iter().cloned());
+
+        for gid in &all_groups {
+            let start = Instant::now();
+            let outcome: color_eyre::eyre::Result<()> = async {
+                let group = ctx
+                    .primary
+                    .group(&gid.to_vec())
+                    .map_err(|e| eyre!("{e}"))?;
+                group
+                    .remove_conversation_message_disappearing_settings()
+                    .await
+                    .map_err(|e| eyre!("{e}"))?;
+                Ok(())
+            }
+            .await;
+            let (status, error) = match outcome {
+                Ok(_) => (Status::Pass, None),
+                Err(e) => (Status::Fail, Some(e)),
+            };
+            out.push(OpResult {
+                op_name: self.name(),
+                target: Some(format!("{gid}")),
+                status,
+                duration: start.elapsed(),
+                error,
+            });
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn names_are_stable() {
+        assert_eq!(
+            UpdateMessageDisappearing.name(),
+            "UpdateMessageDisappearing"
+        );
+        assert_eq!(
+            RemoveMessageDisappearing.name(),
+            "RemoveMessageDisappearing"
+        );
+    }
+}
+
+inventory::submit! {
+    crate::app::health::ops::OpEntry {
+        op_name: "UpdateMessageDisappearing",
+        depends_on: &["AddMembersToNewGroup", "AddPrimaryToExistingGroups"],
+        make: || Box::new(UpdateMessageDisappearing),
+    }
+}
+
+inventory::submit! {
+    crate::app::health::ops::OpEntry {
+        op_name: "RemoveMessageDisappearing",
+        depends_on: &["UpdateMessageDisappearing"],
+        make: || Box::new(RemoveMessageDisappearing),
+    }
+}

--- a/apps/xmtp_debug/src/app/health/ops/update_permission_policy.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_permission_policy.rs
@@ -1,0 +1,75 @@
+//! Op: update the add-member permission policy on every reachable group.
+
+use crate::app::health::context::HealthContext;
+use crate::app::health::ops::HealthOp;
+use crate::app::health::result::{OpResult, Status};
+use async_trait::async_trait;
+use color_eyre::eyre::eyre;
+use std::time::Instant;
+use xmtp_mls::groups::intents::{PermissionPolicyOption, PermissionUpdateType};
+use xmtp_proto::types::GroupId;
+
+pub struct UpdatePermissionPolicy;
+
+#[async_trait]
+impl HealthOp for UpdatePermissionPolicy {
+    fn name(&self) -> &'static str {
+        "UpdatePermissionPolicy"
+    }
+
+    #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "UpdatePermissionPolicy"))]
+    async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
+        let mut out = Vec::new();
+        let mut all_groups: Vec<GroupId> = ctx.existing_groups.clone();
+        all_groups.extend(ctx.new_groups.iter().cloned());
+
+        for gid in &all_groups {
+            let start = Instant::now();
+            let outcome: color_eyre::eyre::Result<()> = async {
+                let group = ctx
+                    .primary
+                    .group(&gid.to_vec())
+                    .map_err(|e| eyre!("{e}"))?;
+                group
+                    .update_permission_policy(
+                        PermissionUpdateType::AddMember,
+                        PermissionPolicyOption::Allow,
+                        None,
+                    )
+                    .await
+                    .map_err(|e| eyre!("{e}"))?;
+                Ok(())
+            }
+            .await;
+            let (status, error) = match outcome {
+                Ok(_) => (Status::Pass, None),
+                Err(e) => (Status::Fail, Some(e)),
+            };
+            out.push(OpResult {
+                op_name: self.name(),
+                target: Some(format!("{gid}")),
+                status,
+                duration: start.elapsed(),
+                error,
+            });
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn name_is_stable() {
+        assert_eq!(UpdatePermissionPolicy.name(), "UpdatePermissionPolicy");
+    }
+}
+
+inventory::submit! {
+    crate::app::health::ops::OpEntry {
+        op_name: "UpdatePermissionPolicy",
+        depends_on: &["AddMembersToNewGroup", "AddPrimaryToExistingGroups"],
+        make: || Box::new(UpdatePermissionPolicy),
+    }
+}

--- a/apps/xmtp_debug/src/app/health/ops/upload_key_package.rs
+++ b/apps/xmtp_debug/src/app/health/ops/upload_key_package.rs
@@ -1,0 +1,56 @@
+//! Op: rotate + upload a fresh key package for every existing client.
+
+use crate::app::health::context::HealthContext;
+use crate::app::health::ops::HealthOp;
+use crate::app::health::result::{OpResult, Status};
+use async_trait::async_trait;
+use color_eyre::eyre::eyre;
+use std::time::Instant;
+
+pub struct UploadKeyPackage;
+
+#[async_trait]
+impl HealthOp for UploadKeyPackage {
+    fn name(&self) -> &'static str {
+        "UploadKeyPackage"
+    }
+
+    #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "UploadKeyPackage"))]
+    async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
+        let mut out = Vec::new();
+        for (inbox_id, client) in &ctx.existing_clients {
+            let start = Instant::now();
+            let outcome = client.rotate_and_upload_key_package().await;
+            let (status, error) = match outcome {
+                Ok(_) => (Status::Pass, None),
+                Err(e) => (Status::Fail, Some(eyre!("{e}"))),
+            };
+            out.push(OpResult {
+                op_name: self.name(),
+                target: Some(hex::encode(inbox_id)),
+                status,
+                duration: start.elapsed(),
+                error,
+            });
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn name_is_stable() {
+        assert_eq!(UploadKeyPackage.name(), "UploadKeyPackage");
+    }
+}
+
+inventory::submit! {
+    crate::app::health::ops::OpEntry {
+        op_name: "UploadKeyPackage",
+        depends_on: &[],
+        make: || Box::new(UploadKeyPackage),
+    }
+}

--- a/apps/xmtp_debug/src/app/health/registry.rs
+++ b/apps/xmtp_debug/src/app/health/registry.rs
@@ -1,0 +1,91 @@
+//! Generic topo-sort over self-registered entries.
+//!
+//! Both ops and validators share the same shape: a `*Entry` struct with a
+//! name, a list of dependency names, and a `make` function pointer that
+//! materializes a `Box<dyn Trait>`. This module factors out the sort so
+//! each registry consumer just provides the entry → name/deps/make
+//! projections via the `RegistryEntry` trait.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+/// Projection trait. The `Kind` associated type lets the trait describe
+/// itself in panic messages ("op", "validator").
+pub trait RegistryEntry: 'static {
+    /// Trait object materialized by `make`.
+    type Item: ?Sized;
+
+    /// Human label for panic messages, e.g. `"op"` or `"validator"`.
+    const KIND: &'static str;
+
+    fn name(&self) -> &'static str;
+    fn depends_on(&self) -> &'static [&'static str];
+    fn make(&self) -> Box<Self::Item>;
+}
+
+/// Topologically sort a stream of entries by their `depends_on` edges.
+///
+/// Ties (entries with the same satisfied-dep set) are broken alphabetically
+/// by `name()` for deterministic output across runs.
+///
+/// Panics on dependency cycles or unknown `depends_on` references.
+pub fn topo_sort<E>(stream: impl IntoIterator<Item = &'static E>) -> Vec<Box<E::Item>>
+where
+    E: RegistryEntry,
+{
+    let entries: BTreeMap<&'static str, &'static E> =
+        stream.into_iter().map(|e| (e.name(), e)).collect();
+
+    // Validate dependency references.
+    for e in entries.values() {
+        for dep in e.depends_on() {
+            if !entries.contains_key(dep) {
+                panic!(
+                    "{} '{}' depends on unknown {} '{}'",
+                    E::KIND,
+                    e.name(),
+                    E::KIND,
+                    dep
+                );
+            }
+        }
+    }
+
+    let mut in_degree: BTreeMap<&'static str, usize> =
+        entries.keys().map(|n| (*n, 0)).collect();
+    for e in entries.values() {
+        *in_degree.get_mut(e.name()).unwrap() = e.depends_on().len();
+    }
+
+    // BTreeSet keeps the ready set sorted for stable output.
+    let mut ready: BTreeSet<&'static str> = in_degree
+        .iter()
+        .filter(|&(_, &d)| d == 0)
+        .map(|(n, _)| *n)
+        .collect();
+
+    let mut order: Vec<&'static str> = Vec::with_capacity(entries.len());
+    while let Some(&name) = ready.iter().next() {
+        ready.remove(name);
+        order.push(name);
+        for e in entries.values() {
+            if e.depends_on().contains(&name) {
+                let d = in_degree.get_mut(e.name()).unwrap();
+                *d -= 1;
+                if *d == 0 {
+                    ready.insert(e.name());
+                }
+            }
+        }
+    }
+
+    if order.len() != entries.len() {
+        let remaining: Vec<&str> = in_degree
+            .iter()
+            .filter(|&(_, &d)| d > 0)
+            .map(|(n, _)| *n)
+            .collect();
+        panic!("{} dependency cycle among: {remaining:?}", E::KIND);
+    }
+
+    order.into_iter().map(|n| entries[n].make()).collect()
+}

--- a/apps/xmtp_debug/src/app/health/result.rs
+++ b/apps/xmtp_debug/src/app/health/result.rs
@@ -1,0 +1,144 @@
+//! Op and validator result types.
+
+use std::time::Duration;
+
+use owo_colors::OwoColorize;
+
+pub enum Status {
+    Pass,
+    Fail,
+}
+
+pub struct OpResult {
+    pub op_name: &'static str,
+    pub target: Option<String>,
+    pub status: Status,
+    pub duration: Duration,
+    pub error: Option<color_eyre::eyre::Report>,
+}
+
+pub struct Report {
+    pub results: Vec<OpResult>,
+}
+
+impl Report {
+    pub fn new() -> Self {
+        Self {
+            results: Vec::new(),
+        }
+    }
+
+    pub fn push(&mut self, r: OpResult) {
+        self.results.push(r);
+    }
+
+    pub fn has_failures(&self) -> bool {
+        self.results
+            .iter()
+            .any(|r| matches!(r.status, Status::Fail))
+    }
+
+    pub fn counts(&self) -> (usize, usize) {
+        let failed = self
+            .results
+            .iter()
+            .filter(|r| matches!(r.status, Status::Fail))
+            .count();
+        let passed = self.results.len() - failed;
+        (passed, failed)
+    }
+
+    pub fn print_summary(&self) {
+        let (passed, failed) = self.counts();
+        println!();
+        println!("== Summary ==");
+        println!(
+            "Total: {passed} passed, {failed} failed ({} total)",
+            self.results.len()
+        );
+        if self.has_failures() {
+            println!("Result: {}", "FAIL".red().bold());
+        } else {
+            println!("Result: {}", "PASS".green().bold());
+        }
+    }
+}
+
+impl Default for Report {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl OpResult {
+    /// Print a one-line `[✓]`/`[✗]` summary to stdout and emit a structured
+    /// tracing event on the `healthcheck.op` target.
+    pub fn print(&self) {
+        let mark = match self.status {
+            Status::Pass => "[✓]".green().to_string(),
+            Status::Fail => "[✗]".red().to_string(),
+        };
+        let duration_ms = self.duration.as_millis();
+        let target = self.target.as_deref().unwrap_or("");
+        let err = match &self.error {
+            Some(e) => format!(" — error: {e:#}"),
+            None => String::new(),
+        };
+        println!(
+            "{mark} {name:<32} ({duration_ms:>5}ms) {target}{err}",
+            name = self.op_name
+        );
+
+        match self.status {
+            Status::Pass => tracing::info!(
+                target: "healthcheck",
+                op = self.op_name,
+                status = "pass",
+                target = %self.target.as_deref().unwrap_or(""),
+                duration_ms = duration_ms as u64,
+                "op passed"
+            ),
+            Status::Fail => tracing::error!(
+                target: "healthcheck",
+                op = self.op_name,
+                status = "fail",
+                target = %self.target.as_deref().unwrap_or(""),
+                duration_ms = duration_ms as u64,
+                error = ?self.error,
+                "op failed"
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mk(name: &'static str, status: Status) -> OpResult {
+        OpResult {
+            op_name: name,
+            target: None,
+            status,
+            duration: Duration::from_millis(10),
+            error: None,
+        }
+    }
+
+    #[test]
+    fn report_counts_and_failures() {
+        let mut r = Report::new();
+        r.push(mk("A", Status::Pass));
+        r.push(mk("B", Status::Fail));
+        r.push(mk("C", Status::Pass));
+        assert_eq!(r.counts(), (2, 1));
+        assert!(r.has_failures());
+    }
+
+    #[test]
+    fn empty_report_has_no_failures() {
+        let r = Report::new();
+        assert!(!r.has_failures());
+        assert_eq!(r.counts(), (0, 0));
+    }
+}

--- a/apps/xmtp_debug/src/app/health/validators/mod.rs
+++ b/apps/xmtp_debug/src/app/health/validators/mod.rs
@@ -1,0 +1,46 @@
+//! Validators run after ops + the final sync. They check that all clients
+//! converged (no forks, no missing messages).
+//!
+//! Each validator self-registers via `inventory::submit!` and is sorted by
+//! declared `depends_on` relationships, same shape as `ops::OpEntry`.
+
+use crate::app::health::context::HealthContext;
+use crate::app::health::registry::{self, RegistryEntry};
+use crate::app::health::result::OpResult;
+use async_trait::async_trait;
+
+mod no_forks;
+mod no_missing_messages;
+
+#[async_trait]
+pub trait Validator: Send + Sync {
+    fn name(&self) -> &'static str;
+    async fn validate(&self, ctx: &mut HealthContext) -> Vec<OpResult>;
+}
+
+pub struct ValidatorEntry {
+    pub name: &'static str,
+    pub depends_on: &'static [&'static str],
+    pub make: fn() -> Box<dyn Validator>,
+}
+
+inventory::collect!(ValidatorEntry);
+
+impl RegistryEntry for ValidatorEntry {
+    type Item = dyn Validator;
+    const KIND: &'static str = "validator";
+
+    fn name(&self) -> &'static str {
+        self.name
+    }
+    fn depends_on(&self) -> &'static [&'static str] {
+        self.depends_on
+    }
+    fn make(&self) -> Box<dyn Validator> {
+        (self.make)()
+    }
+}
+
+pub fn registry() -> Vec<Box<dyn Validator>> {
+    registry::topo_sort::<ValidatorEntry>(inventory::iter::<ValidatorEntry>)
+}

--- a/apps/xmtp_debug/src/app/health/validators/no_forks.rs
+++ b/apps/xmtp_debug/src/app/health/validators/no_forks.rs
@@ -1,0 +1,71 @@
+//! Validator: every (client, group) pair must not be in a forked state.
+//!
+//! For each client, queries the local DB for every group's fork status via
+//! `QueryGroup::get_group_commit_log_forked_status`. A `Some(true)` is a
+//! fail. `Some(false)` and `None` are passes (the latter means commit-log
+//! verification isn't enabled for that group).
+
+use crate::app::health::context::HealthContext;
+use crate::app::health::result::{OpResult, Status};
+use crate::app::health::validators::Validator;
+use async_trait::async_trait;
+use color_eyre::eyre::eyre;
+use std::time::Instant;
+use xmtp_db::prelude::QueryGroup;
+use xmtp_proto::types::GroupId;
+
+pub struct NoForkedGroups;
+
+#[async_trait]
+impl Validator for NoForkedGroups {
+    fn name(&self) -> &'static str {
+        "NoForkedGroups"
+    }
+
+    #[tracing::instrument(target = "healthcheck.validator", skip_all, fields(op = "NoForkedGroups"))]
+    async fn validate(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
+        let mut out = Vec::new();
+
+        let mut all_groups: Vec<GroupId> = ctx.existing_groups.clone();
+        all_groups.extend(ctx.new_groups.iter().cloned());
+
+        for client in ctx.all_clients() {
+            let db = client.db();
+            for gid in &all_groups {
+                let start = Instant::now();
+                let outcome = db.get_group_commit_log_forked_status(gid);
+                let (status, error) = match outcome {
+                    Ok(Some(true)) => (Status::Fail, Some(eyre!("group forked"))),
+                    Ok(_) => (Status::Pass, None),
+                    Err(e) => (Status::Fail, Some(eyre!("{e}"))),
+                };
+                out.push(OpResult {
+                    op_name: self.name(),
+                    target: Some(format!("inbox={} group={gid}", client.inbox_id())),
+                    status,
+                    duration: start.elapsed(),
+                    error,
+                });
+            }
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn name_is_stable() {
+        assert_eq!(NoForkedGroups.name(), "NoForkedGroups");
+    }
+}
+
+inventory::submit! {
+    crate::app::health::validators::ValidatorEntry {
+        name: "NoForkedGroups",
+        depends_on: &[],
+        make: || Box::new(NoForkedGroups),
+    }
+}

--- a/apps/xmtp_debug/src/app/health/validators/no_missing_messages.rs
+++ b/apps/xmtp_debug/src/app/health/validators/no_missing_messages.rs
@@ -1,0 +1,141 @@
+//! Validator: every client must have every message every other client has,
+//! filtered by the join-time floor (messages sent before a client joined a
+//! group are not expected to be present on that client).
+
+use crate::app::health::context::HealthContext;
+use crate::app::health::result::{OpResult, Status};
+use crate::app::health::validators::Validator;
+use async_trait::async_trait;
+use color_eyre::eyre::eyre;
+use std::collections::HashSet;
+use std::time::Instant;
+use xmtp_db::group_message::MsgQueryArgs;
+use xmtp_db::prelude::QueryGroupMessage;
+use xmtp_proto::types::GroupId;
+
+/// Cached per-(client, group) state: sequence_ids the client has + the
+/// earliest application-message timestamp it observed in this group.
+struct ClientGroupState {
+    inbox: String,
+    seqs: HashSet<i64>,
+    earliest: Option<i64>,
+}
+
+pub struct NoMissingMessages;
+
+#[async_trait]
+impl Validator for NoMissingMessages {
+    fn name(&self) -> &'static str {
+        "NoMissingMessages"
+    }
+
+    #[tracing::instrument(target = "healthcheck.validator", skip_all, fields(op = "NoMissingMessages"))]
+    async fn validate(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
+        let mut out = Vec::new();
+
+        let mut all_groups: Vec<GroupId> = ctx.existing_groups.clone();
+        all_groups.extend(ctx.new_groups.iter().cloned());
+
+        let clients = ctx.all_clients();
+
+        for group_id in &all_groups {
+            // Gather each client's local view of this group's messages.
+            // We compare in-memory rather than via a SQL "not in (...)"
+            // query, since the union of sequence_ids is already in scope.
+            let mut per_client: Vec<ClientGroupState> = Vec::new();
+            for client in &clients {
+                let db = client.db();
+                let msgs = match db.get_group_messages(group_id, &MsgQueryArgs::default()) {
+                    Ok(m) => m,
+                    Err(_) => continue,
+                };
+                let mut seqs = HashSet::new();
+                let mut earliest: Option<i64> = None;
+                for m in msgs {
+                    seqs.insert(m.sequence_id);
+                    earliest = Some(match earliest {
+                        None => m.sent_at_ns,
+                        Some(e) => e.min(m.sent_at_ns),
+                    });
+                }
+                per_client.push(ClientGroupState {
+                    inbox: client.inbox_id().to_string(),
+                    seqs,
+                    earliest,
+                });
+            }
+
+            // For each client C, compute union of every other client's
+            // sequence_ids. Anything in that union but not in C's own set
+            // is a missing message — but only if it was sent *after* C's
+            // earliest observed message (proxy for "C had joined by then").
+            //
+            // We re-query the per-other-client message rows for the missing
+            // seq ids so we can recover their `sent_at_ns` for the join-time
+            // filter. The query is cheap because the message list is local.
+            for (i, state) in per_client.iter().enumerate() {
+                let join_floor = state.earliest.unwrap_or(i64::MIN);
+
+                let mut missing_count = 0usize;
+                for (j, other) in per_client.iter().enumerate() {
+                    if i == j {
+                        continue;
+                    }
+                    let Some(other_client) =
+                        clients.iter().find(|c| c.inbox_id() == other.inbox.as_str())
+                    else {
+                        continue;
+                    };
+                    let other_msgs = match other_client
+                        .db()
+                        .get_group_messages(group_id, &MsgQueryArgs::default())
+                    {
+                        Ok(m) => m,
+                        Err(_) => continue,
+                    };
+                    for m in other_msgs {
+                        if !state.seqs.contains(&m.sequence_id) && m.sent_at_ns >= join_floor {
+                            missing_count += 1;
+                        }
+                    }
+                }
+
+                let start = Instant::now();
+                let (status, error) = if missing_count == 0 {
+                    (Status::Pass, None)
+                } else {
+                    (
+                        Status::Fail,
+                        Some(eyre!("{missing_count} missing messages")),
+                    )
+                };
+                out.push(OpResult {
+                    op_name: self.name(),
+                    target: Some(format!("inbox={} group={group_id}", state.inbox)),
+                    status,
+                    duration: start.elapsed(),
+                    error,
+                });
+            }
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn name_is_stable() {
+        assert_eq!(NoMissingMessages.name(), "NoMissingMessages");
+    }
+}
+
+inventory::submit! {
+    crate::app::health::validators::ValidatorEntry {
+        name: "NoMissingMessages",
+        depends_on: &[],
+        make: || Box::new(NoMissingMessages),
+    }
+}

--- a/apps/xmtp_debug/src/args.rs
+++ b/apps/xmtp_debug/src/args.rs
@@ -49,7 +49,14 @@ pub enum Commands {
     Info(InfoOpts),
     Export(ExportOpts),
     Stream(StreamOpts),
+    Healthcheck(HealthcheckOpts),
 }
+
+/// Cross-version libxmtp health check.
+/// Runs every user-visible protocol op against the local xdbg state,
+/// validates that all clients converge, and exits non-zero on any failure.
+#[derive(Args, Debug)]
+pub struct HealthcheckOpts {}
 
 /// Send Data on the network
 #[derive(Args, Debug)]


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add `healthcheck` CLI command to `xmtp_debug` for end-to-end protocol validation
- Adds a `healthcheck` subcommand to the `xdbg` CLI that runs a full sequence of protocol operations (identity creation, group/DM creation, member add/remove, message send, metadata updates) against a target network.
- Operations are registered via an `inventory`-based plugin system and executed in topologically sorted dependency order, with results aggregated into a pass/fail summary.
- Two validators run after ops complete: `NoForkedGroups` checks for forked commit logs, and `NoMissingMessages` detects per-client message gaps accounting for join time.
- The process exits with status 1 if any op or validator fails, making it suitable for automated health monitoring.
- A transient (non-persisted) identity is used for leave-group and other destructive ops to avoid polluting the persistent identity store.

<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e7417a4. 30 files reviewed, 4 issues evaluated, 0 issues filtered, 4 comments posted</summary>

### 🗂️ Filtered Issues

</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->