### PR TITLE
ci(cross-version): replace generate ops with xdbg healthcheck

### DIFF
--- a/apps/xmtp_debug/src/app/health/context.rs
+++ b/apps/xmtp_debug/src/app/health/context.rs
@@ -2,7 +2,7 @@
 
 use crate::DbgClient;
 use crate::app::store::{Database, GroupStore, IdentityStore};
-use crate::app::types::{Identity, InboxId};
+use crate::app::types::{Group, Identity, InboxId};
 use crate::app::{self, App};
 use crate::args;
 use color_eyre::eyre::Result;
@@ -16,6 +16,10 @@ use xmtp_proto::types::GroupId;
 const BOOTSTRAP_IDENTITY_COUNT: usize = 3;
 
 pub struct HealthContext {
+    /// Network selection. Held so ops can re-open `GroupStore` to persist
+    /// newly-created groups for future runs.
+    pub network: args::BackendOpts,
+
     /// The single new identity created for this run. Persisted to the
     /// redb identity store so future runs see it as an existing identity.
     pub primary: Arc<DbgClient>,
@@ -122,12 +126,75 @@ impl HealthContext {
         );
 
         Ok(Self {
+            network,
             primary,
             transient_identity,
             existing_clients,
             existing_groups,
             new_groups: Vec::new(),
         })
+    }
+
+    /// Persist a newly-created group to redb's `GroupStore` so subsequent
+    /// healthcheck runs (potentially on a different libxmtp version) see
+    /// it as an existing group. Called by `CreateGroup` after the MLS
+    /// group is created on the network.
+    ///
+    /// Panics if redb can't be opened — that indicates an xdbg state
+    /// directory problem, not a healthcheck assertion, and the run can't
+    /// continue meaningfully.
+    pub fn persist_new_group(&self, id: [u8; 16], created_by: InboxId, members: Vec<InboxId>) {
+        let group_store: GroupStore<'static> = redb_or_panic("persist_new_group").into();
+        let group = Group {
+            id,
+            created_by,
+            member_size: members.len() as u32,
+            members,
+        };
+        group_store
+            .set(group, u64::from(&self.network))
+            .expect("redb GroupStore::set failed");
+    }
+
+    /// Replace a persisted group's member list. Used by membership ops
+    /// (`AddMembersToNewGroup`, `AddPrimaryToExistingGroups`,
+    /// `RemoveMember`, `LeaveGroup`) so redb's view stays consistent with
+    /// the MLS-level state across runs.
+    ///
+    /// Panics on redb failure — same rationale as `persist_new_group`.
+    pub fn update_group_members(&self, id: [u8; 16], members: Vec<InboxId>) {
+        let group_store: GroupStore<'static> = redb_or_panic("update_group_members").into();
+        let net_key = u64::from(&self.network);
+        let key = crate::app::store::NetworkKey::new(net_key, id);
+        // Preserve `created_by` if a row already exists; otherwise default
+        // to zero — the field is informational, not load-bearing.
+        let created_by = group_store
+            .get(key)
+            .expect("redb GroupStore::get failed")
+            .map(|g| g.created_by)
+            .unwrap_or([0u8; 32]);
+        let group = Group {
+            id,
+            created_by,
+            member_size: members.len() as u32,
+            members,
+        };
+        group_store
+            .set(group, net_key)
+            .expect("redb GroupStore::set failed");
+    }
+
+    /// Look up a persisted group's current members, if it's recorded.
+    /// Returns an empty vec if the group is not in redb.
+    pub fn persisted_members(&self, id: [u8; 16]) -> Vec<InboxId> {
+        let group_store: GroupStore<'static> = redb_or_panic("persisted_members").into();
+        let net_key = u64::from(&self.network);
+        let key = crate::app::store::NetworkKey::new(net_key, id);
+        group_store
+            .get(key)
+            .expect("redb GroupStore::get failed")
+            .map(|g| g.members)
+            .unwrap_or_default()
     }
 
     /// Every client involved in this run: primary + transient + every
@@ -146,4 +213,22 @@ impl HealthContext {
     pub fn all_groups(&self) -> impl Iterator<Item = &GroupId> {
         self.existing_groups.iter().chain(self.new_groups.iter())
     }
+}
+
+/// Decode the libxmtp hex inbox_id into the 32-byte form xdbg's redb uses
+/// as a `HashMap` / `IdentityStore` key. The hex form is guaranteed valid
+/// by libxmtp, so we panic on malformed input.
+pub fn inbox_id_to_bytes(hex_inbox: &str) -> InboxId {
+    let mut out = [0u8; 32];
+    hex::decode_to_slice(hex_inbox, &mut out).expect("inbox_id is 32-byte hex");
+    out
+}
+
+/// Open the xdbg redb database or abort the process. Failure here means
+/// xdbg's state directory is broken — not an op-level failure — so
+/// trying to keep going would produce misleading healthcheck results.
+fn redb_or_panic(caller: &str) -> Arc<redb::Database> {
+    App::db().unwrap_or_else(|e| {
+        panic!("healthcheck::{caller}: failed to open redb database: {e:#}")
+    })
 }

--- a/apps/xmtp_debug/src/app/health/context.rs
+++ b/apps/xmtp_debug/src/app/health/context.rs
@@ -5,7 +5,7 @@ use crate::app::store::{Database, GroupStore, IdentityStore};
 use crate::app::types::{Group, Identity, InboxId};
 use crate::app::{self, App};
 use crate::args;
-use color_eyre::eyre::Result;
+use color_eyre::eyre::{Result, eyre};
 use std::collections::HashMap;
 use std::sync::Arc;
 use xmtp_proto::types::GroupId;
@@ -197,6 +197,21 @@ impl HealthContext {
             .unwrap_or_default()
     }
 
+    /// Read the persisted `created_by` for a group. Returns `None` when no
+    /// row exists or `created_by` is the all-zero placeholder written by
+    /// `update_group_members` for groups created before persistence was
+    /// added.
+    pub fn persisted_creator(&self, id: [u8; 16]) -> Option<InboxId> {
+        let group_store: GroupStore<'static> = redb_or_panic("persisted_creator").into();
+        let net_key = u64::from(&self.network);
+        let key = crate::app::store::NetworkKey::new(net_key, id);
+        group_store
+            .get(key)
+            .expect("redb GroupStore::get failed")
+            .map(|g| g.created_by)
+            .filter(|c| c != &[0u8; 32])
+    }
+
     /// Every client involved in this run: primary + transient + every
     /// entry in `existing_clients`. The two run-scoped clients are
     /// returned first so consumers can match on inbox_id if needed.
@@ -213,6 +228,31 @@ impl HealthContext {
     pub fn all_groups(&self) -> impl Iterator<Item = &GroupId> {
         self.existing_groups.iter().chain(self.new_groups.iter())
     }
+
+    pub fn is_transient(&self, client: &DbgClient) -> bool {
+        client.inbox_id() == self.transient_identity.inbox_id()
+    }
+
+    /// Concurrently sync welcomes on every client involved in the run.
+    /// Failures are logged but never propagated — `sync_welcomes` is
+    /// best-effort plumbing, not a validation step.
+    pub async fn sync_welcomes_fanout(&self, label: &'static str) {
+        let syncs = std::iter::once(self.transient_identity.as_ref())
+            .chain(std::iter::once(self.primary.as_ref()))
+            .chain(self.existing_clients.values().map(|c| c.as_ref()))
+            .map(|c| async move {
+                if let Err(e) = c.sync_welcomes().await {
+                    tracing::warn!(
+                        target: "healthcheck",
+                        inbox = c.inbox_id(),
+                        error = %e,
+                        label,
+                        "sync_welcomes fanout failed",
+                    );
+                }
+            });
+        futures::future::join_all(syncs).await;
+    }
 }
 
 /// Decode the libxmtp hex inbox_id into the 32-byte form xdbg's redb uses
@@ -224,11 +264,23 @@ pub fn inbox_id_to_bytes(hex_inbox: &str) -> InboxId {
     out
 }
 
+/// Convert a libxmtp `GroupId` to the 16-byte form xdbg's redb uses as a
+/// key. libxmtp's MLS group ids are always 16 bytes; an unexpected length
+/// is an invariant violation, surfaced as an op-level error so the run
+/// reports the divergence instead of silently skipping the redb write.
+pub fn group_id_bytes(gid: &GroupId) -> color_eyre::eyre::Result<[u8; 16]> {
+    <[u8; 16]>::try_from(gid.as_slice()).map_err(|_| {
+        eyre!(
+            "expected 16-byte group_id, got {} bytes",
+            gid.as_slice().len()
+        )
+    })
+}
+
 /// Open the xdbg redb database or abort the process. Failure here means
 /// xdbg's state directory is broken — not an op-level failure — so
 /// trying to keep going would produce misleading healthcheck results.
 fn redb_or_panic(caller: &str) -> Arc<redb::Database> {
-    App::db().unwrap_or_else(|e| {
-        panic!("healthcheck::{caller}: failed to open redb database: {e:#}")
-    })
+    App::db()
+        .unwrap_or_else(|e| panic!("healthcheck::{caller}: failed to open redb database: {e:#}"))
 }

--- a/apps/xmtp_debug/src/app/health/ops/add_members.rs
+++ b/apps/xmtp_debug/src/app/health/ops/add_members.rs
@@ -5,7 +5,7 @@
 //! - `AddPrimaryToExistingGroups`: for every group in `ctx.existing_groups`,
 //!   primary is added by an active member of that group.
 
-use crate::app::health::context::HealthContext;
+use crate::app::health::context::{HealthContext, inbox_id_to_bytes};
 use crate::app::health::ops::HealthOp;
 use crate::app::health::result::{OpResult, Status};
 use async_trait::async_trait;
@@ -61,7 +61,16 @@ impl HealthOp for AddMembersToNewGroup {
         let start = Instant::now();
         let outcome = group.add_members(&inbox_ids).await;
         let (status, error) = match outcome {
-            Ok(_) => (Status::Pass, None),
+            Ok(_) => {
+                // Mirror the new membership to redb so subsequent runs
+                // see the full member list, not just the creator.
+                if let Ok(id_bytes) = <[u8; 16]>::try_from(new_group_id.as_slice()) {
+                    let mut members = vec![inbox_id_to_bytes(ctx.primary.inbox_id())];
+                    members.extend(inbox_ids.iter().map(|s| inbox_id_to_bytes(s)));
+                    ctx.update_group_members(id_bytes, members);
+                }
+                (Status::Pass, None)
+            }
             Err(e) => (Status::Fail, Some(eyre!("{e}"))),
         };
         vec![OpResult {
@@ -109,7 +118,17 @@ impl HealthOp for AddPrimaryToExistingGroups {
             .await;
 
             let (status, error) = match outcome {
-                Ok(_) => (Status::Pass, None),
+                Ok(_) => {
+                    if let Ok(id_bytes) = <[u8; 16]>::try_from(gid.as_slice()) {
+                        let mut members = ctx.persisted_members(id_bytes);
+                        let primary_bytes = inbox_id_to_bytes(&primary_inbox);
+                        if !members.contains(&primary_bytes) {
+                            members.push(primary_bytes);
+                        }
+                        ctx.update_group_members(id_bytes, members);
+                    }
+                    (Status::Pass, None)
+                }
                 Err(e) => (Status::Fail, Some(e)),
             };
             out.push(OpResult {
@@ -141,16 +160,14 @@ mod tests {
 
 inventory::submit! {
     crate::app::health::ops::OpEntry {
-        op_name: "AddMembersToNewGroup",
         depends_on: &["CreateGroup"],
-        make: || Box::new(AddMembersToNewGroup),
+        op: &AddMembersToNewGroup,
     }
 }
 
 inventory::submit! {
     crate::app::health::ops::OpEntry {
-        op_name: "AddPrimaryToExistingGroups",
         depends_on: &["CreateIdentity"],
-        make: || Box::new(AddPrimaryToExistingGroups),
+        op: &AddPrimaryToExistingGroups,
     }
 }

--- a/apps/xmtp_debug/src/app/health/ops/add_members.rs
+++ b/apps/xmtp_debug/src/app/health/ops/add_members.rs
@@ -5,12 +5,13 @@
 //! - `AddPrimaryToExistingGroups`: for every group in `ctx.existing_groups`,
 //!   primary is added by an active member of that group.
 
-use crate::app::health::context::{HealthContext, inbox_id_to_bytes};
+use crate::app::health::context::{HealthContext, group_id_bytes, inbox_id_to_bytes};
 use crate::app::health::ops::HealthOp;
 use crate::app::health::result::{OpResult, Status};
 use async_trait::async_trait;
 use color_eyre::eyre::eyre;
 use std::time::{Duration, Instant};
+use xmtp_mls::groups::UpdateAdminListType;
 
 pub struct AddMembersToNewGroup;
 
@@ -59,20 +60,29 @@ impl HealthOp for AddMembersToNewGroup {
         inbox_ids.push(ctx.transient_identity.inbox_id().to_string());
 
         let start = Instant::now();
-        let outcome = group.add_members(&inbox_ids).await;
+        let outcome: color_eyre::eyre::Result<()> = async {
+            group
+                .add_members(&inbox_ids)
+                .await
+                .map_err(color_eyre::eyre::Report::from)?;
+            // Mirror the new membership to redb so subsequent runs see
+            // the full member list, not just the creator.
+            let id_bytes = group_id_bytes(&new_group_id)?;
+            let mut members = vec![inbox_id_to_bytes(ctx.primary.inbox_id())];
+            members.extend(inbox_ids.iter().map(|s| inbox_id_to_bytes(s)));
+            ctx.update_group_members(id_bytes, members);
+            Ok(())
+        }
+        .await;
         let (status, error) = match outcome {
-            Ok(_) => {
-                // Mirror the new membership to redb so subsequent runs
-                // see the full member list, not just the creator.
-                if let Ok(id_bytes) = <[u8; 16]>::try_from(new_group_id.as_slice()) {
-                    let mut members = vec![inbox_id_to_bytes(ctx.primary.inbox_id())];
-                    members.extend(inbox_ids.iter().map(|s| inbox_id_to_bytes(s)));
-                    ctx.update_group_members(id_bytes, members);
-                }
-                (Status::Pass, None)
-            }
-            Err(e) => (Status::Fail, Some(eyre!("{e}"))),
+            Ok(_) => (Status::Pass, None),
+            Err(e) => (Status::Fail, Some(e)),
         };
+        // Welcomes aren't auto-pulled mid-run — sync so newly-added clients
+        // can `client.group(...)` immediately in downstream ops.
+        if status == Status::Pass {
+            ctx.sync_welcomes_fanout("AddMembersToNewGroup").await;
+        }
         vec![OpResult {
             op_name: self.name(),
             target: Some(format!("{new_group_id}")),
@@ -103,32 +113,57 @@ impl HealthOp for AddPrimaryToExistingGroups {
         for gid in &ctx.existing_groups {
             let start = Instant::now();
             let outcome: color_eyre::eyre::Result<()> = async {
-                let group = ctx
-                    .existing_clients
-                    .values()
-                    .filter_map(|c| c.group(gid.as_slice()).ok())
-                    .find(|g| g.is_active().unwrap_or(false))
+                let id_bytes = group_id_bytes(gid)?;
+                // Prefer the persisted creator (super-admin) so we can also
+                // promote primary below. Fall back to any active member if
+                // the creator isn't available locally — the add will still
+                // succeed but the promote will be skipped.
+                let creator = ctx.persisted_creator(id_bytes);
+                let adder = creator
+                    .and_then(|c| ctx.existing_clients.get(&c))
+                    .and_then(|c| c.group(gid.as_slice()).ok())
+                    .filter(|g| g.is_active().unwrap_or(false));
+                let group = adder
+                    .or_else(|| {
+                        ctx.existing_clients
+                            .values()
+                            .filter_map(|c| c.group(gid.as_slice()).ok())
+                            .find(|g| g.is_active().unwrap_or(false))
+                    })
                     .ok_or_else(|| eyre!("no active member found for group"))?;
                 group
                     .add_members(std::slice::from_ref(&primary_inbox))
                     .await
                     .map_err(color_eyre::eyre::Report::from)?;
+                // Promote primary to super-admin so downstream metadata ops
+                // (UpdateAdminList, UpdateMessageDisappearing,
+                // UpdatePermissionPolicy) can run on this prior-version
+                // group. Best-effort: if the adder isn't super-admin, this
+                // fails and we log but don't abort the run.
+                if let Err(e) = group
+                    .update_admin_list(UpdateAdminListType::AddSuper, primary_inbox.clone())
+                    .await
+                {
+                    tracing::warn!(
+                        target: "healthcheck",
+                        group = %gid,
+                        error = %e,
+                        "failed to promote primary to super-admin on existing group; \
+                         metadata ops requiring admin will fail on this group",
+                    );
+                }
+                let mut members = ctx.persisted_members(id_bytes);
+                let primary_bytes = inbox_id_to_bytes(&primary_inbox);
+                if !members.contains(&primary_bytes) {
+                    members.push(primary_bytes);
+                }
+                ctx.update_group_members(id_bytes, members);
                 Ok(())
             }
             .await;
 
             let (status, error) = match outcome {
-                Ok(_) => {
-                    if let Ok(id_bytes) = <[u8; 16]>::try_from(gid.as_slice()) {
-                        let mut members = ctx.persisted_members(id_bytes);
-                        let primary_bytes = inbox_id_to_bytes(&primary_inbox);
-                        if !members.contains(&primary_bytes) {
-                            members.push(primary_bytes);
-                        }
-                        ctx.update_group_members(id_bytes, members);
-                    }
-                    (Status::Pass, None)
-                }
+                Ok(_) => (Status::Pass, None),
                 Err(e) => (Status::Fail, Some(e)),
             };
             out.push(OpResult {
@@ -138,6 +173,12 @@ impl HealthOp for AddPrimaryToExistingGroups {
                 duration: start.elapsed(),
                 error,
             });
+        }
+
+        // Welcomes aren't auto-pulled mid-run — sync primary + observers so
+        // downstream metadata reads on these groups succeed.
+        if out.iter().any(|r| r.status == Status::Pass) {
+            ctx.sync_welcomes_fanout("AddPrimaryToExistingGroups").await;
         }
 
         out

--- a/apps/xmtp_debug/src/app/health/ops/create_dm.rs
+++ b/apps/xmtp_debug/src/app/health/ops/create_dm.rs
@@ -97,8 +97,7 @@ mod tests {
 
 inventory::submit! {
     crate::app::health::ops::OpEntry {
-        op_name: "CreateDm",
         depends_on: &["CreateIdentity"],
-        make: || Box::new(CreateDm),
+        op: &CreateDm,
     }
 }

--- a/apps/xmtp_debug/src/app/health/ops/create_group.rs
+++ b/apps/xmtp_debug/src/app/health/ops/create_group.rs
@@ -2,7 +2,7 @@
 //! The new group's id is appended to `ctx.new_groups` so downstream ops
 //! and validators see it.
 
-use crate::app::health::context::{HealthContext, inbox_id_to_bytes};
+use crate::app::health::context::{HealthContext, group_id_bytes, inbox_id_to_bytes};
 use crate::app::health::ops::HealthOp;
 use crate::app::health::result::{OpResult, Status};
 use async_trait::async_trait;
@@ -26,25 +26,15 @@ impl HealthOp for CreateGroup {
             Ok(group) => {
                 let new_group_id = GroupId::from(group.group_id.as_slice());
                 let hex_id = format!("{new_group_id}");
-                let id_bytes: [u8; 16] = match group.group_id.as_slice().try_into() {
-                    Ok(b) => b,
-                    Err(_) => {
-                        return vec![OpResult {
-                            op_name: self.name(),
-                            target: Some(hex_id),
-                            status: Status::Fail,
-                            duration: start.elapsed(),
-                            error: Some(eyre!(
-                                "expected 16-byte group_id, got {} bytes",
-                                group.group_id.len()
-                            )),
-                        }];
+                match group_id_bytes(&new_group_id) {
+                    Ok(id_bytes) => {
+                        let creator = inbox_id_to_bytes(ctx.primary.inbox_id());
+                        ctx.persist_new_group(id_bytes, creator, vec![creator]);
+                        ctx.new_groups.push(new_group_id);
+                        (Status::Pass, Some(hex_id), None)
                     }
-                };
-                let creator = inbox_id_to_bytes(ctx.primary.inbox_id());
-                ctx.persist_new_group(id_bytes, creator, vec![creator]);
-                ctx.new_groups.push(new_group_id);
-                (Status::Pass, Some(hex_id), None)
+                    Err(e) => (Status::Fail, Some(hex_id), Some(e)),
+                }
             }
             Err(e) => (Status::Fail, None, Some(eyre!("{e}"))),
         };

--- a/apps/xmtp_debug/src/app/health/ops/create_group.rs
+++ b/apps/xmtp_debug/src/app/health/ops/create_group.rs
@@ -2,7 +2,7 @@
 //! The new group's id is appended to `ctx.new_groups` so downstream ops
 //! and validators see it.
 
-use crate::app::health::context::HealthContext;
+use crate::app::health::context::{HealthContext, inbox_id_to_bytes};
 use crate::app::health::ops::HealthOp;
 use crate::app::health::result::{OpResult, Status};
 use async_trait::async_trait;
@@ -26,6 +26,23 @@ impl HealthOp for CreateGroup {
             Ok(group) => {
                 let new_group_id = GroupId::from(group.group_id.as_slice());
                 let hex_id = format!("{new_group_id}");
+                let id_bytes: [u8; 16] = match group.group_id.as_slice().try_into() {
+                    Ok(b) => b,
+                    Err(_) => {
+                        return vec![OpResult {
+                            op_name: self.name(),
+                            target: Some(hex_id),
+                            status: Status::Fail,
+                            duration: start.elapsed(),
+                            error: Some(eyre!(
+                                "expected 16-byte group_id, got {} bytes",
+                                group.group_id.len()
+                            )),
+                        }];
+                    }
+                };
+                let creator = inbox_id_to_bytes(ctx.primary.inbox_id());
+                ctx.persist_new_group(id_bytes, creator, vec![creator]);
                 ctx.new_groups.push(new_group_id);
                 (Status::Pass, Some(hex_id), None)
             }
@@ -53,8 +70,7 @@ mod tests {
 
 inventory::submit! {
     crate::app::health::ops::OpEntry {
-        op_name: "CreateGroup",
         depends_on: &["CreateIdentity"],
-        make: || Box::new(CreateGroup),
+        op: &CreateGroup,
     }
 }

--- a/apps/xmtp_debug/src/app/health/ops/create_identity.rs
+++ b/apps/xmtp_debug/src/app/health/ops/create_identity.rs
@@ -47,8 +47,7 @@ mod tests {
 
 inventory::submit! {
     crate::app::health::ops::OpEntry {
-        op_name: "CreateIdentity",
         depends_on: &[],
-        make: || Box::new(CreateIdentity),
+        op: &CreateIdentity,
     }
 }

--- a/apps/xmtp_debug/src/app/health/ops/get_mutable_metadata.rs
+++ b/apps/xmtp_debug/src/app/health/ops/get_mutable_metadata.rs
@@ -58,8 +58,7 @@ mod tests {
 
 inventory::submit! {
     crate::app::health::ops::OpEntry {
-        op_name: "GetMutableMetadata",
         depends_on: &["AddMembersToNewGroup", "AddPrimaryToExistingGroups"],
-        make: || Box::new(GetMutableMetadata),
+        op: &GetMutableMetadata,
     }
 }

--- a/apps/xmtp_debug/src/app/health/ops/leave_group.rs
+++ b/apps/xmtp_debug/src/app/health/ops/leave_group.rs
@@ -6,7 +6,7 @@
 //! Distinct from `RemoveMember` which exercises the admin-remove path
 //! (one identity removes another via `remove_members`).
 
-use crate::app::health::context::HealthContext;
+use crate::app::health::context::{HealthContext, inbox_id_to_bytes};
 use crate::app::health::ops::HealthOp;
 use crate::app::health::result::{OpResult, Status};
 use async_trait::async_trait;
@@ -54,7 +54,18 @@ impl HealthOp for LeaveGroup {
         }
         .await;
         let (status, error) = match outcome {
-            Ok(_) => (Status::Pass, None),
+            Ok(_) => {
+                if let Ok(id_bytes) = <[u8; 16]>::try_from(gid.as_slice()) {
+                    let transient_bytes = inbox_id_to_bytes(ctx.transient_identity.inbox_id());
+                    let members: Vec<_> = ctx
+                        .persisted_members(id_bytes)
+                        .into_iter()
+                        .filter(|m| m != &transient_bytes)
+                        .collect();
+                    ctx.update_group_members(id_bytes, members);
+                }
+                (Status::Pass, None)
+            }
             Err(e) => (Status::Fail, Some(e)),
         };
         vec![OpResult {
@@ -79,7 +90,6 @@ mod tests {
 
 inventory::submit! {
     crate::app::health::ops::OpEntry {
-        op_name: "LeaveGroup",
         depends_on: &[
             "SendMessage",
             "UpdateGroupName",
@@ -93,6 +103,6 @@ inventory::submit! {
             "UpdateConsentStateQuiet",
             "GetMutableMetadata",
         ],
-        make: || Box::new(LeaveGroup),
+        op: &LeaveGroup,
     }
 }

--- a/apps/xmtp_debug/src/app/health/ops/leave_group.rs
+++ b/apps/xmtp_debug/src/app/health/ops/leave_group.rs
@@ -6,7 +6,7 @@
 //! Distinct from `RemoveMember` which exercises the admin-remove path
 //! (one identity removes another via `remove_members`).
 
-use crate::app::health::context::{HealthContext, inbox_id_to_bytes};
+use crate::app::health::context::{HealthContext, group_id_bytes, inbox_id_to_bytes};
 use crate::app::health::ops::HealthOp;
 use crate::app::health::result::{OpResult, Status};
 use async_trait::async_trait;
@@ -50,22 +50,19 @@ impl HealthOp for LeaveGroup {
                 .leave_group()
                 .await
                 .map_err(color_eyre::eyre::Report::from)?;
+            let id_bytes = group_id_bytes(&gid)?;
+            let transient_bytes = inbox_id_to_bytes(ctx.transient_identity.inbox_id());
+            let members: Vec<_> = ctx
+                .persisted_members(id_bytes)
+                .into_iter()
+                .filter(|m| m != &transient_bytes)
+                .collect();
+            ctx.update_group_members(id_bytes, members);
             Ok(())
         }
         .await;
         let (status, error) = match outcome {
-            Ok(_) => {
-                if let Ok(id_bytes) = <[u8; 16]>::try_from(gid.as_slice()) {
-                    let transient_bytes = inbox_id_to_bytes(ctx.transient_identity.inbox_id());
-                    let members: Vec<_> = ctx
-                        .persisted_members(id_bytes)
-                        .into_iter()
-                        .filter(|m| m != &transient_bytes)
-                        .collect();
-                    ctx.update_group_members(id_bytes, members);
-                }
-                (Status::Pass, None)
-            }
+            Ok(_) => (Status::Pass, None),
             Err(e) => (Status::Fail, Some(e)),
         };
         vec![OpResult {

--- a/apps/xmtp_debug/src/app/health/ops/mod.rs
+++ b/apps/xmtp_debug/src/app/health/ops/mod.rs
@@ -1,12 +1,13 @@
 //! Health-check ops registry.
 //!
 //! Every op exercises one user-visible libxmtp operation. Each op lives in
-//! its own submodule and self-registers via `inventory::submit!`. The
-//! `registry()` function returns ops topologically sorted by their
-//! declared `depends_on` relationships.
+//! its own submodule and self-registers via `inventory::submit!` with a
+//! `&'static` reference to its (zero-sized) impl. The `registry()` function
+//! returns ops topologically sorted by their declared `depends_on`
+//! relationships.
 
 use crate::app::health::context::HealthContext;
-use crate::app::health::registry::{self, RegistryEntry};
+use crate::app::health::registry::{self, Named, RegistryEntry};
 use crate::app::health::result::OpResult;
 use async_trait::async_trait;
 
@@ -37,13 +38,21 @@ pub trait HealthOp: Send + Sync {
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult>;
 }
 
+impl Named for dyn HealthOp {
+    fn name(&self) -> &'static str {
+        HealthOp::name(self)
+    }
+}
+
 /// Self-registration entry for an op. Each op submits one of these from
-/// its own module via `inventory::submit!`.
+/// its own module via `inventory::submit!`. The name lives on the op's own
+/// `HealthOp::name()` impl — no duplication on the entry.
 pub struct OpEntry {
-    pub op_name: &'static str,
     /// Names of ops that must complete before this one runs.
     pub depends_on: &'static [&'static str],
-    pub make: fn() -> Box<dyn HealthOp>,
+    /// `&'static` reference to the op's impl. Ops are zero-sized unit
+    /// structs, so `&MyOp` is `'static`-promotable in a `static` context.
+    pub op: &'static (dyn HealthOp + Sync),
 }
 
 inventory::collect!(OpEntry);
@@ -52,40 +61,15 @@ impl RegistryEntry for OpEntry {
     type Item = dyn HealthOp;
     const KIND: &'static str = "op";
 
-    fn name(&self) -> &'static str {
-        self.op_name
-    }
     fn depends_on(&self) -> &'static [&'static str] {
         self.depends_on
     }
-    fn make(&self) -> Box<dyn HealthOp> {
-        (self.make)()
+    fn value(&self) -> &'static dyn HealthOp {
+        self.op
     }
 }
 
 /// Topologically-sorted list of every registered op.
-pub fn registry() -> Vec<Box<dyn HealthOp>> {
+pub fn registry() -> Vec<&'static dyn HealthOp> {
     registry::topo_sort::<OpEntry>(inventory::iter::<OpEntry>)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// Every `inventory::submit!` block carries a string `op_name`; the
-    /// implementing struct carries its own `HealthOp::name()`. Assert
-    /// they agree so the two can't drift silently. Doesn't cover the
-    /// third copy (the `fields(op = "...")` on `#[tracing::instrument]`),
-    /// which the proc-macro requires as a string literal.
-    #[test]
-    fn entry_name_matches_op_name() {
-        for entry in inventory::iter::<OpEntry> {
-            let op = (entry.make)();
-            assert_eq!(
-                entry.op_name,
-                op.name(),
-                "OpEntry::op_name disagrees with HealthOp::name() for one op",
-            );
-        }
-    }
 }

--- a/apps/xmtp_debug/src/app/health/ops/remove_member.rs
+++ b/apps/xmtp_debug/src/app/health/ops/remove_member.rs
@@ -7,7 +7,7 @@
 //! pre-existing clients). If none is available, the op fails with a
 //! reason.
 
-use crate::app::health::context::HealthContext;
+use crate::app::health::context::{HealthContext, inbox_id_to_bytes};
 use crate::app::health::ops::HealthOp;
 use crate::app::health::result::{OpResult, Status};
 use async_trait::async_trait;
@@ -65,7 +65,12 @@ impl HealthOp for RemoveMember {
         }
         .await;
         let (status, error) = match outcome {
-            Ok(_) => (Status::Pass, None),
+            Ok(_) => {
+                if let Ok(id_bytes) = <[u8; 16]>::try_from(gid.as_slice()) {
+                    drop_member_from_persisted_group(ctx, id_bytes, &victim_inbox);
+                }
+                (Status::Pass, None)
+            }
             Err(e) => (Status::Fail, Some(e)),
         };
         vec![OpResult {
@@ -76,6 +81,23 @@ impl HealthOp for RemoveMember {
             error,
         }]
     }
+}
+
+/// Read the persisted group's members from redb, drop `victim_inbox`,
+/// and write back. Panics if redb is unreachable — a redb failure
+/// indicates an xdbg state-directory issue, not an op-level failure.
+fn drop_member_from_persisted_group(
+    ctx: &HealthContext,
+    group_id_bytes: [u8; 16],
+    victim_inbox: &str,
+) {
+    let victim_bytes = inbox_id_to_bytes(victim_inbox);
+    let members: Vec<_> = ctx
+        .persisted_members(group_id_bytes)
+        .into_iter()
+        .filter(|m| m != &victim_bytes)
+        .collect();
+    ctx.update_group_members(group_id_bytes, members);
 }
 
 #[cfg(test)]
@@ -90,7 +112,6 @@ mod tests {
 
 inventory::submit! {
     crate::app::health::ops::OpEntry {
-        op_name: "RemoveMember",
         depends_on: &[
             "SendMessage",
             "UpdateGroupName",
@@ -104,6 +125,6 @@ inventory::submit! {
             "UpdateConsentStateQuiet",
             "GetMutableMetadata",
         ],
-        make: || Box::new(RemoveMember),
+        op: &RemoveMember,
     }
 }

--- a/apps/xmtp_debug/src/app/health/ops/remove_member.rs
+++ b/apps/xmtp_debug/src/app/health/ops/remove_member.rs
@@ -7,7 +7,7 @@
 //! pre-existing clients). If none is available, the op fails with a
 //! reason.
 
-use crate::app::health::context::{HealthContext, inbox_id_to_bytes};
+use crate::app::health::context::{HealthContext, group_id_bytes, inbox_id_to_bytes};
 use crate::app::health::ops::HealthOp;
 use crate::app::health::result::{OpResult, Status};
 use async_trait::async_trait;
@@ -61,16 +61,13 @@ impl HealthOp for RemoveMember {
                 .remove_members(&[victim_inbox.as_str()])
                 .await
                 .map_err(color_eyre::eyre::Report::from)?;
+            let id_bytes = group_id_bytes(&gid)?;
+            drop_member_from_persisted_group(ctx, id_bytes, &victim_inbox);
             Ok(())
         }
         .await;
         let (status, error) = match outcome {
-            Ok(_) => {
-                if let Ok(id_bytes) = <[u8; 16]>::try_from(gid.as_slice()) {
-                    drop_member_from_persisted_group(ctx, id_bytes, &victim_inbox);
-                }
-                (Status::Pass, None)
-            }
+            Ok(_) => (Status::Pass, None),
             Err(e) => (Status::Fail, Some(e)),
         };
         vec![OpResult {

--- a/apps/xmtp_debug/src/app/health/ops/send_message.rs
+++ b/apps/xmtp_debug/src/app/health/ops/send_message.rs
@@ -68,8 +68,7 @@ mod tests {
 
 inventory::submit! {
     crate::app::health::ops::OpEntry {
-        op_name: "SendMessage",
         depends_on: &["AddMembersToNewGroup", "AddPrimaryToExistingGroups"],
-        make: || Box::new(SendMessage),
+        op: &SendMessage,
     }
 }

--- a/apps/xmtp_debug/src/app/health/ops/send_message.rs
+++ b/apps/xmtp_debug/src/app/health/ops/send_message.rs
@@ -1,14 +1,47 @@
 //! Op: every client sends one message into every group it belongs to.
 //! Feeds the missing-messages validator.
 
+use crate::DbgClient;
 use crate::app::health::context::HealthContext;
 use crate::app::health::ops::HealthOp;
 use crate::app::health::result::{OpResult, Status};
 use async_trait::async_trait;
+use std::sync::Arc;
 use std::time::Instant;
 use xmtp_mls::groups::send_message_opts::SendMessageOpts;
+use xmtp_proto::types::GroupId;
 
 pub struct SendMessage;
+
+async fn send_one(op_name: &'static str, client: &Arc<DbgClient>, gid: &GroupId) -> OpResult {
+    let start = Instant::now();
+    let outcome: color_eyre::eyre::Result<()> = async {
+        let group = client
+            .group(gid.as_slice())
+            .map_err(color_eyre::eyre::Report::from)?;
+        if !group.is_active().map_err(color_eyre::eyre::Report::from)? {
+            return Ok(());
+        }
+        let body = format!("healthcheck from {}", client.inbox_id());
+        group
+            .send_message(body.as_bytes(), SendMessageOpts::default())
+            .await
+            .map_err(color_eyre::eyre::Report::from)?;
+        Ok(())
+    }
+    .await;
+    let (status, error) = match outcome {
+        Ok(_) => (Status::Pass, None),
+        Err(e) => (Status::Fail, Some(e)),
+    };
+    OpResult {
+        op_name,
+        target: Some(format!("inbox={} group={gid}", client.inbox_id())),
+        status,
+        duration: start.elapsed(),
+        error,
+    }
+}
 
 #[async_trait]
 impl HealthOp for SendMessage {
@@ -20,38 +53,17 @@ impl HealthOp for SendMessage {
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
         let mut out = Vec::new();
         for client in ctx.all_clients() {
-            for gid in ctx.all_groups() {
-                let start = Instant::now();
-                let outcome: color_eyre::eyre::Result<()> = async {
-                    let Ok(group) = client.group(gid.as_slice()) else {
-                        return Ok(());
-                    };
-                    if !group.is_active().map_err(color_eyre::eyre::Report::from)? {
-                        return Ok(());
-                    }
-                    let body = format!("healthcheck from {}", client.inbox_id());
-                    group
-                        .send_message(body.as_bytes(), SendMessageOpts::default())
-                        .await
-                        .map_err(color_eyre::eyre::Report::from)?;
-                    Ok(())
+            // Transient is only added to new_groups, so existing_groups skip
+            // is by design — see AddMembersToNewGroup.
+            if !ctx.is_transient(&client) {
+                for gid in &ctx.existing_groups {
+                    out.push(send_one(self.name(), &client, gid).await);
                 }
-                .await;
-
-                let (status, error) = match outcome {
-                    Ok(_) => (Status::Pass, None),
-                    Err(e) => (Status::Fail, Some(e)),
-                };
-                out.push(OpResult {
-                    op_name: self.name(),
-                    target: Some(format!("inbox={} group={gid}", client.inbox_id())),
-                    status,
-                    duration: start.elapsed(),
-                    error,
-                });
+            }
+            for gid in &ctx.new_groups {
+                out.push(send_one(self.name(), &client, gid).await);
             }
         }
-
         out
     }
 }

--- a/apps/xmtp_debug/src/app/health/ops/tree.rs
+++ b/apps/xmtp_debug/src/app/health/ops/tree.rs
@@ -5,14 +5,14 @@
 //! has length N. Ops in the same stage can run in any order (they have no
 //! mutual dependencies). Stages run sequentially.
 
-use super::OpEntry;
+use super::{HealthOp, OpEntry};
 use std::collections::BTreeMap;
 use std::fmt::Write;
 
 pub fn render_order_tree() -> String {
     let entries: BTreeMap<&'static str, &'static OpEntry> = inventory::iter::<OpEntry>
         .into_iter()
-        .map(|e| (e.op_name, e))
+        .map(|e| (HealthOp::name(e.op), e))
         .collect();
 
     // stage[name] = longest dep-chain length from any root, computed via

--- a/apps/xmtp_debug/src/app/health/ops/update_admin_list.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_admin_list.rs
@@ -62,8 +62,7 @@ mod tests {
 
 inventory::submit! {
     crate::app::health::ops::OpEntry {
-        op_name: "UpdateAdminList",
         depends_on: &["AddMembersToNewGroup", "AddPrimaryToExistingGroups"],
-        make: || Box::new(UpdateAdminList),
+        op: &UpdateAdminList,
     }
 }

--- a/apps/xmtp_debug/src/app/health/ops/update_app_data.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_app_data.rs
@@ -58,8 +58,7 @@ mod tests {
 
 inventory::submit! {
     crate::app::health::ops::OpEntry {
-        op_name: "UpdateAppData",
         depends_on: &["AddMembersToNewGroup", "AddPrimaryToExistingGroups"],
-        make: || Box::new(UpdateAppData),
+        op: &UpdateAppData,
     }
 }

--- a/apps/xmtp_debug/src/app/health/ops/update_commit_log_signer.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_commit_log_signer.rs
@@ -65,8 +65,7 @@ mod tests {
 
 inventory::submit! {
     crate::app::health::ops::OpEntry {
-        op_name: "UpdateCommitLogSigner",
         depends_on: &["AddMembersToNewGroup", "AddPrimaryToExistingGroups"],
-        make: || Box::new(UpdateCommitLogSigner),
+        op: &UpdateCommitLogSigner,
     }
 }

--- a/apps/xmtp_debug/src/app/health/ops/update_consent_state.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_consent_state.rs
@@ -106,16 +106,14 @@ mod tests {
 
 inventory::submit! {
     crate::app::health::ops::OpEntry {
-        op_name: "UpdateConsentState",
         depends_on: &["AddMembersToNewGroup", "AddPrimaryToExistingGroups"],
-        make: || Box::new(UpdateConsentState),
+        op: &UpdateConsentState,
     }
 }
 
 inventory::submit! {
     crate::app::health::ops::OpEntry {
-        op_name: "UpdateConsentStateQuiet",
         depends_on: &["UpdateConsentState"],
-        make: || Box::new(UpdateConsentStateQuiet),
+        op: &UpdateConsentStateQuiet,
     }
 }

--- a/apps/xmtp_debug/src/app/health/ops/update_group_description.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_group_description.rs
@@ -62,8 +62,7 @@ mod tests {
 
 inventory::submit! {
     crate::app::health::ops::OpEntry {
-        op_name: "UpdateGroupDescription",
         depends_on: &["AddMembersToNewGroup", "AddPrimaryToExistingGroups"],
-        make: || Box::new(UpdateGroupDescription),
+        op: &UpdateGroupDescription,
     }
 }

--- a/apps/xmtp_debug/src/app/health/ops/update_group_image_url.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_group_image_url.rs
@@ -65,8 +65,7 @@ mod tests {
 
 inventory::submit! {
     crate::app::health::ops::OpEntry {
-        op_name: "UpdateGroupImageUrlSquare",
         depends_on: &["AddMembersToNewGroup", "AddPrimaryToExistingGroups"],
-        make: || Box::new(UpdateGroupImageUrlSquare),
+        op: &UpdateGroupImageUrlSquare,
     }
 }

--- a/apps/xmtp_debug/src/app/health/ops/update_group_name.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_group_name.rs
@@ -58,8 +58,7 @@ mod tests {
 
 inventory::submit! {
     crate::app::health::ops::OpEntry {
-        op_name: "UpdateGroupName",
         depends_on: &["AddMembersToNewGroup", "AddPrimaryToExistingGroups"],
-        make: || Box::new(UpdateGroupName),
+        op: &UpdateGroupName,
     }
 }

--- a/apps/xmtp_debug/src/app/health/ops/update_message_disappearing.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_message_disappearing.rs
@@ -117,16 +117,14 @@ mod tests {
 
 inventory::submit! {
     crate::app::health::ops::OpEntry {
-        op_name: "UpdateMessageDisappearing",
         depends_on: &["AddMembersToNewGroup", "AddPrimaryToExistingGroups"],
-        make: || Box::new(UpdateMessageDisappearing),
+        op: &UpdateMessageDisappearing,
     }
 }
 
 inventory::submit! {
     crate::app::health::ops::OpEntry {
-        op_name: "RemoveMessageDisappearing",
         depends_on: &["UpdateMessageDisappearing"],
-        make: || Box::new(RemoveMessageDisappearing),
+        op: &RemoveMessageDisappearing,
     }
 }

--- a/apps/xmtp_debug/src/app/health/ops/update_permission_policy.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_permission_policy.rs
@@ -67,8 +67,7 @@ mod tests {
 
 inventory::submit! {
     crate::app::health::ops::OpEntry {
-        op_name: "UpdatePermissionPolicy",
         depends_on: &["AddMembersToNewGroup", "AddPrimaryToExistingGroups"],
-        make: || Box::new(UpdatePermissionPolicy),
+        op: &UpdatePermissionPolicy,
     }
 }

--- a/apps/xmtp_debug/src/app/health/ops/upload_key_package.rs
+++ b/apps/xmtp_debug/src/app/health/ops/upload_key_package.rs
@@ -55,8 +55,7 @@ mod tests {
 
 inventory::submit! {
     crate::app::health::ops::OpEntry {
-        op_name: "UploadKeyPackage",
         depends_on: &[],
-        make: || Box::new(UploadKeyPackage),
+        op: &UploadKeyPackage,
     }
 }

--- a/apps/xmtp_debug/src/app/health/registry.rs
+++ b/apps/xmtp_debug/src/app/health/registry.rs
@@ -1,41 +1,46 @@
 //! Generic topo-sort over self-registered entries.
 //!
 //! Both ops and validators share the same shape: a `*Entry` struct with a
-//! name, a list of dependency names, and a `make` function pointer that
-//! materializes a `Box<dyn Trait>`. This module factors out the sort so
-//! each registry consumer just provides the entry → name/deps/make
-//! projections via the `RegistryEntry` trait.
+//! dependency list and a `&'static` reference to the trait object that
+//! implements the work. Ops and validators are unit structs, so a single
+//! `static` per impl lets us cheaply name and use them without boxing.
 
 use std::collections::{BTreeMap, BTreeSet};
 
-/// Projection trait. The `Kind` associated type lets the trait describe
+/// Projection trait. The `KIND` associated constant lets the trait describe
 /// itself in panic messages ("op", "validator").
+///
+/// `Item` is the trait the ops/validators implement (e.g. `dyn HealthOp`).
+/// `value()` returns a `'static` reference so callers can use the resulting
+/// trait object without allocating.
 pub trait RegistryEntry: 'static {
-    /// Trait object materialized by `make`.
-    type Item: ?Sized;
+    type Item: ?Sized + 'static;
 
     /// Human label for panic messages, e.g. `"op"` or `"validator"`.
     const KIND: &'static str;
 
-    fn name(&self) -> &'static str;
     fn depends_on(&self) -> &'static [&'static str];
-    fn make(&self) -> Box<Self::Item>;
+    fn value(&self) -> &'static Self::Item;
 }
 
 /// Topologically sort a stream of entries by their `depends_on` edges.
 ///
-/// Ties (entries with the same satisfied-dep set) are broken alphabetically
-/// by `name()` for deterministic output across runs.
+/// Each entry must implement `Named` (via `value()`) so the sort can read
+/// names through the trait object. Ties (entries with the same satisfied-
+/// dep set) are broken alphabetically by name.
 ///
-/// Panics on dependency cycles or unknown `depends_on` references.
-pub fn topo_sort<E>(stream: impl IntoIterator<Item = &'static E>) -> Vec<Box<E::Item>>
+/// Panics on dependency cycles, unknown `depends_on` references, or
+/// duplicate names.
+pub fn topo_sort<E>(stream: impl IntoIterator<Item = &'static E>) -> Vec<&'static E::Item>
 where
     E: RegistryEntry,
+    E::Item: Named,
 {
     let mut entries: BTreeMap<&'static str, &'static E> = BTreeMap::new();
     for e in stream {
-        if entries.insert(e.name(), e).is_some() {
-            panic!("duplicate {} name '{}'", E::KIND, e.name());
+        let n = e.value().name();
+        if entries.insert(n, e).is_some() {
+            panic!("duplicate {} name '{}'", E::KIND, n);
         }
     }
 
@@ -46,7 +51,7 @@ where
                 panic!(
                     "{} '{}' depends on unknown {} '{}'",
                     E::KIND,
-                    e.name(),
+                    e.value().name(),
                     E::KIND,
                     dep
                 );
@@ -56,7 +61,7 @@ where
 
     let mut in_degree: BTreeMap<&'static str, usize> = entries.keys().map(|n| (*n, 0)).collect();
     for e in entries.values() {
-        *in_degree.get_mut(e.name()).unwrap() = e.depends_on().len();
+        *in_degree.get_mut(e.value().name()).unwrap() = e.depends_on().len();
     }
 
     // BTreeSet keeps the ready set sorted for stable output.
@@ -72,10 +77,10 @@ where
         order.push(name);
         for e in entries.values() {
             if e.depends_on().contains(&name) {
-                let d = in_degree.get_mut(e.name()).unwrap();
+                let d = in_degree.get_mut(e.value().name()).unwrap();
                 *d -= 1;
                 if *d == 0 {
-                    ready.insert(e.name());
+                    ready.insert(e.value().name());
                 }
             }
         }
@@ -90,18 +95,20 @@ where
         panic!("{} dependency cycle among: {remaining:?}", E::KIND);
     }
 
-    order.into_iter().map(|n| entries[n].make()).collect()
+    order.into_iter().map(|n| entries[n].value()).collect()
+}
+
+/// Items materialized through a `RegistryEntry` must expose a static name.
+/// Both `HealthOp` and `Validator` already declare a `fn name()` method;
+/// declaring the requirement here lets `topo_sort` read names from the
+/// trait object without the entry struct duplicating the string.
+pub trait Named {
+    fn name(&self) -> &'static str;
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// Stand-in trait object so we can name the topo-sort output without
-    /// dragging in `HealthOp`/`Validator`.
-    trait Named {
-        fn name(&self) -> &'static str;
-    }
 
     struct TestItem(&'static str);
 
@@ -112,28 +119,31 @@ mod tests {
     }
 
     struct TestEntry {
-        name: &'static str,
+        item: &'static TestItem,
         deps: &'static [&'static str],
     }
 
     impl RegistryEntry for TestEntry {
-        type Item = dyn Named;
+        type Item = TestItem;
         const KIND: &'static str = "test";
 
-        fn name(&self) -> &'static str {
-            self.name
-        }
         fn depends_on(&self) -> &'static [&'static str] {
             self.deps
         }
-        fn make(&self) -> Box<dyn Named> {
-            Box::new(TestItem(self.name))
+        fn value(&self) -> &'static TestItem {
+            self.item
         }
     }
 
-    fn names(out: Vec<Box<dyn Named>>) -> Vec<&'static str> {
-        out.iter().map(|b| b.name()).collect()
+    fn names(out: Vec<&'static TestItem>) -> Vec<&'static str> {
+        out.iter().map(|i| i.name()).collect()
     }
+
+    static A_ITEM: TestItem = TestItem("A");
+    static B_ITEM: TestItem = TestItem("B");
+    static C_ITEM: TestItem = TestItem("C");
+    static D_ITEM: TestItem = TestItem("D");
+    static Z_ITEM: TestItem = TestItem("Z");
 
     #[test]
     fn empty_input_returns_empty() {
@@ -144,7 +154,7 @@ mod tests {
     #[test]
     fn single_root_no_deps() {
         static A: TestEntry = TestEntry {
-            name: "A",
+            item: &A_ITEM,
             deps: &[],
         };
         let out = topo_sort::<TestEntry>(vec![&A]);
@@ -154,18 +164,17 @@ mod tests {
     #[test]
     fn linear_chain_orders_by_dependency() {
         static A: TestEntry = TestEntry {
-            name: "A",
+            item: &A_ITEM,
             deps: &[],
         };
         static B: TestEntry = TestEntry {
-            name: "B",
+            item: &B_ITEM,
             deps: &["A"],
         };
         static C: TestEntry = TestEntry {
-            name: "C",
+            item: &C_ITEM,
             deps: &["B"],
         };
-        // Out-of-order input — sort must respect deps regardless.
         let out = topo_sort::<TestEntry>(vec![&C, &A, &B]);
         assert_eq!(names(out), vec!["A", "B", "C"]);
     }
@@ -173,34 +182,33 @@ mod tests {
     #[test]
     fn diamond_dag_orders_correctly() {
         static A: TestEntry = TestEntry {
-            name: "A",
+            item: &A_ITEM,
             deps: &[],
         };
         static B: TestEntry = TestEntry {
-            name: "B",
+            item: &B_ITEM,
             deps: &["A"],
         };
         static C: TestEntry = TestEntry {
-            name: "C",
+            item: &C_ITEM,
             deps: &["A"],
         };
         static D: TestEntry = TestEntry {
-            name: "D",
+            item: &D_ITEM,
             deps: &["B", "C"],
         };
         let out = names(topo_sort::<TestEntry>(vec![&A, &B, &C, &D]));
-        // A first, D last, B and C in between in alphabetical tie order.
         assert_eq!(out, vec!["A", "B", "C", "D"]);
     }
 
     #[test]
     fn ties_break_alphabetically() {
         static A: TestEntry = TestEntry {
-            name: "A",
+            item: &A_ITEM,
             deps: &[],
         };
         static Z: TestEntry = TestEntry {
-            name: "Z",
+            item: &Z_ITEM,
             deps: &[],
         };
         let out = names(topo_sort::<TestEntry>(vec![&Z, &A]));
@@ -211,11 +219,11 @@ mod tests {
     #[should_panic(expected = "duplicate test name 'A'")]
     fn duplicate_name_panics() {
         static A1: TestEntry = TestEntry {
-            name: "A",
+            item: &A_ITEM,
             deps: &[],
         };
         static A2: TestEntry = TestEntry {
-            name: "A",
+            item: &A_ITEM,
             deps: &[],
         };
         let _ = topo_sort::<TestEntry>(vec![&A1, &A2]);
@@ -225,7 +233,7 @@ mod tests {
     #[should_panic(expected = "depends on unknown test 'X'")]
     fn unknown_dep_panics() {
         static A: TestEntry = TestEntry {
-            name: "A",
+            item: &A_ITEM,
             deps: &["X"],
         };
         let _ = topo_sort::<TestEntry>(vec![&A]);
@@ -235,11 +243,11 @@ mod tests {
     #[should_panic(expected = "test dependency cycle")]
     fn cycle_panics() {
         static A: TestEntry = TestEntry {
-            name: "A",
+            item: &A_ITEM,
             deps: &["B"],
         };
         static B: TestEntry = TestEntry {
-            name: "B",
+            item: &B_ITEM,
             deps: &["A"],
         };
         let _ = topo_sort::<TestEntry>(vec![&A, &B]);

--- a/apps/xmtp_debug/src/app/health/result.rs
+++ b/apps/xmtp_debug/src/app/health/result.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use owo_colors::OwoColorize;
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Status {
     Pass,
     Fail,

--- a/apps/xmtp_debug/src/app/health/validators/mod.rs
+++ b/apps/xmtp_debug/src/app/health/validators/mod.rs
@@ -1,11 +1,11 @@
 //! Validators run after ops + the final sync. They check that all clients
 //! converged (no forks, no missing messages).
 //!
-//! Each validator self-registers via `inventory::submit!` and is sorted by
-//! declared `depends_on` relationships, same shape as `ops::OpEntry`.
+//! Each validator self-registers via `inventory::submit!` with a `&'static`
+//! reference to its impl, same shape as `ops::OpEntry`.
 
 use crate::app::health::context::HealthContext;
-use crate::app::health::registry::{self, RegistryEntry};
+use crate::app::health::registry::{self, Named, RegistryEntry};
 use crate::app::health::result::OpResult;
 use async_trait::async_trait;
 
@@ -18,10 +18,15 @@ pub trait Validator: Send + Sync {
     async fn validate(&self, ctx: &mut HealthContext) -> Vec<OpResult>;
 }
 
+impl Named for dyn Validator {
+    fn name(&self) -> &'static str {
+        Validator::name(self)
+    }
+}
+
 pub struct ValidatorEntry {
-    pub name: &'static str,
     pub depends_on: &'static [&'static str],
-    pub make: fn() -> Box<dyn Validator>,
+    pub validator: &'static (dyn Validator + Sync),
 }
 
 inventory::collect!(ValidatorEntry);
@@ -30,34 +35,14 @@ impl RegistryEntry for ValidatorEntry {
     type Item = dyn Validator;
     const KIND: &'static str = "validator";
 
-    fn name(&self) -> &'static str {
-        self.name
-    }
     fn depends_on(&self) -> &'static [&'static str] {
         self.depends_on
     }
-    fn make(&self) -> Box<dyn Validator> {
-        (self.make)()
+    fn value(&self) -> &'static dyn Validator {
+        self.validator
     }
 }
 
-pub fn registry() -> Vec<Box<dyn Validator>> {
+pub fn registry() -> Vec<&'static dyn Validator> {
     registry::topo_sort::<ValidatorEntry>(inventory::iter::<ValidatorEntry>)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn entry_name_matches_validator_name() {
-        for entry in inventory::iter::<ValidatorEntry> {
-            let v = (entry.make)();
-            assert_eq!(
-                entry.name,
-                v.name(),
-                "ValidatorEntry::name disagrees with Validator::name() for one validator",
-            );
-        }
-    }
 }

--- a/apps/xmtp_debug/src/app/health/validators/no_forks.rs
+++ b/apps/xmtp_debug/src/app/health/validators/no_forks.rs
@@ -12,6 +12,7 @@ use async_trait::async_trait;
 use color_eyre::eyre::eyre;
 use std::time::Instant;
 use xmtp_db::prelude::QueryGroup;
+use xmtp_proto::types::GroupId;
 
 pub struct NoForkedGroups;
 
@@ -29,28 +30,26 @@ impl Validator for NoForkedGroups {
     async fn validate(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
         let mut out = Vec::new();
         for client in ctx.all_clients() {
+            let is_transient = ctx.is_transient(&client);
             let db = client.db();
-            for gid in ctx.all_groups() {
-                // Skip clients that don't have a local record of this
-                // group: they were never members, or they left and the
-                // group row was purged. Either way, fork status is N/A.
-                match db.find_group(gid) {
-                    Ok(Some(_)) => {}
-                    Ok(None) => continue,
-                    Err(e) => {
-                        tracing::debug!(
-                            target: "healthcheck",
-                            inbox = client.inbox_id(),
-                            group = %gid,
-                            error = %e,
-                            "skipping fork check: find_group returned error (group likely purged after leave/remove)",
-                        );
-                        continue;
-                    }
-                }
+            // Transient is only added to new_groups (see AddMembersToNewGroup);
+            // skip existing_groups for transient.
+            let check = |gid: &GroupId, out: &mut Vec<OpResult>| {
                 let start = Instant::now();
-                let outcome = db.get_group_commit_log_forked_status(gid);
-                let (status, error) = match outcome {
+                // Transient may have its group row purged on LeaveGroup
+                // depending on libxmtp version — skip with a debug log so
+                // unexpected non-leave errors don't slip past silently.
+                if is_transient && let Err(e) = client.group(gid.as_slice()) {
+                    tracing::debug!(
+                        target: "healthcheck",
+                        inbox = client.inbox_id(),
+                        group = %gid,
+                        error = %e,
+                        "skip fork check: transient missing group locally",
+                    );
+                    return;
+                }
+                let (status, error) = match db.get_group_commit_log_forked_status(gid) {
                     Ok(Some(true)) => (Status::Fail, Some(eyre!("group forked"))),
                     Ok(_) => (Status::Pass, None),
                     Err(e) => (Status::Fail, Some(eyre!("{e}"))),
@@ -62,6 +61,14 @@ impl Validator for NoForkedGroups {
                     duration: start.elapsed(),
                     error,
                 });
+            };
+            if !is_transient {
+                for gid in &ctx.existing_groups {
+                    check(gid, &mut out);
+                }
+            }
+            for gid in &ctx.new_groups {
+                check(gid, &mut out);
             }
         }
         out

--- a/apps/xmtp_debug/src/app/health/validators/no_forks.rs
+++ b/apps/xmtp_debug/src/app/health/validators/no_forks.rs
@@ -31,6 +31,23 @@ impl Validator for NoForkedGroups {
         for client in ctx.all_clients() {
             let db = client.db();
             for gid in ctx.all_groups() {
+                // Skip clients that don't have a local record of this
+                // group: they were never members, or they left and the
+                // group row was purged. Either way, fork status is N/A.
+                match db.find_group(gid) {
+                    Ok(Some(_)) => {}
+                    Ok(None) => continue,
+                    Err(e) => {
+                        tracing::debug!(
+                            target: "healthcheck",
+                            inbox = client.inbox_id(),
+                            group = %gid,
+                            error = %e,
+                            "skipping fork check: find_group returned error (group likely purged after leave/remove)",
+                        );
+                        continue;
+                    }
+                }
                 let start = Instant::now();
                 let outcome = db.get_group_commit_log_forked_status(gid);
                 let (status, error) = match outcome {
@@ -63,8 +80,7 @@ mod tests {
 
 inventory::submit! {
     crate::app::health::validators::ValidatorEntry {
-        name: "NoForkedGroups",
         depends_on: &[],
-        make: || Box::new(NoForkedGroups),
+        validator: &NoForkedGroups,
     }
 }

--- a/apps/xmtp_debug/src/app/health/validators/no_missing_messages.rs
+++ b/apps/xmtp_debug/src/app/health/validators/no_missing_messages.rs
@@ -63,6 +63,24 @@ impl Validator for NoMissingMessages {
                         continue;
                     }
                 };
+                // Skip clients that left or were removed: their local view
+                // is intentionally frozen at the moment of removal and will
+                // not see post-removal commits. The MLS group's
+                // `is_active()` returns false for those clients.
+                let active = client
+                    .group(group_id.as_slice())
+                    .ok()
+                    .and_then(|g| g.is_active().ok())
+                    .unwrap_or(false);
+                if !active {
+                    tracing::debug!(
+                        target: "healthcheck",
+                        inbox = client.inbox_id(),
+                        group = %group_id,
+                        "skipping inactive client (left or removed)",
+                    );
+                    continue;
+                }
                 let msgs = match db.get_group_messages(group_id, &MsgQueryArgs::default()) {
                     Ok(m) => m,
                     Err(e) => {
@@ -139,8 +157,7 @@ mod tests {
 
 inventory::submit! {
     crate::app::health::validators::ValidatorEntry {
-        name: "NoMissingMessages",
         depends_on: &[],
-        make: || Box::new(NoMissingMessages),
+        validator: &NoMissingMessages,
     }
 }

--- a/nix/package/cross-version-test/cross-version-test.sh
+++ b/nix/package/cross-version-test/cross-version-test.sh
@@ -395,6 +395,32 @@ xdbg_supports_flag() {
     return 1
 }
 
+# Probe whether `xdbg <subcommand> --help` succeeds at this kind/sha.
+# Used to require `healthcheck` on every tested version. Cached.
+# Args: kind sha subcommand
+# Returns 0 if supported, 1 otherwise.
+xdbg_supports_subcommand() {
+    local kind="$1" sha="$2" sub="$3"
+    local key="${kind}:${sha}:sub:${sub}"
+    if [ -n "${XDBG_FLAG_CACHE[$key]:-}" ]; then
+        return "${XDBG_FLAG_CACHE[$key]}"
+    fi
+    local bin rc=0
+    bin=$(xdbg_binary_path "$kind" "$sha") || {
+        XDBG_FLAG_CACHE[$key]=1
+        return 1
+    }
+    local -a env_args
+    mapfile -t env_args < <(xdbg_sandbox_env_args)
+    env "${env_args[@]}" "$bin" "$sub" --help >/dev/null 2>&1 || rc=$?
+    if [ "$rc" -eq 0 ]; then
+        XDBG_FLAG_CACHE[$key]=0
+        return 0
+    fi
+    XDBG_FLAG_CACHE[$key]=1
+    return 1
+}
+
 # Run a non-informative xdbg command with `--json --fail-fast`. Every
 # tested sha now carries the --fail-fast flag, so non-zero rc IS the
 # failure signal — no log-file scanning needed.
@@ -560,12 +586,11 @@ cmd_run_sequence() {
     #   SKIP         — generic skip (reserved)
     # kind: stable | nightly | head
     local -a results=()
-    local creator_done=0
-    local sender_done=0
+    local completed_count=0
     local nightly_failure=0
     local required_failure=0
     local _record_not_run_remaining=0
-    local sha role rand probe_rc probe_mode kind
+    local sha role probe_rc probe_mode kind
     local entry _short branch label
     local plan_idx=0
     for entry in "${plan_lines[@]:1}"; do
@@ -640,69 +665,40 @@ cmd_run_sequence() {
 
         run_xdbg_info "$kind" "$sha" --version || true
 
-        # If the planned creator slot is still empty (e.g. earlier entries
-        # were all skipped), promote this entry to creator. Only required
-        # entries (stable / HEAD) get promoted — a nightly is allowed to
-        # fail and we don't want a single failing nightly to take down the
-        # whole sequence by being the creator.
-        local effective_role="$role"
-        if [ "$creator_done" -eq 0 ] && [ "$is_required" -eq 1 ]; then
-            effective_role="creator"
+        # Require the `healthcheck` subcommand on every tested version.
+        # Versions without it cannot drive the cross-version sequence —
+        # the old `generate identity/group/message` path is gone.
+        if ! xdbg_supports_subcommand "$kind" "$sha" healthcheck; then
+            if [ "$is_required" -eq 0 ]; then
+                echo "::warning::xdbg@${sha:0:7} nightly $label lacks 'healthcheck' subcommand; skipping" >&2
+                results+=("SKIP-NO-HEALTHCHECK|${sha:0:7}|$sha|$kind|$branch|$label")
+                nightly_failure=1
+                continue
+            fi
+            echo "::error::xdbg@${sha:0:7} required version ($branch) lacks 'healthcheck' subcommand; cannot continue" >&2
+            results+=("FAIL|${sha:0:7}|$sha|$kind|$branch|$label")
+            required_failure=1
+            _record_not_run_remaining=1
+            break
         fi
 
         local entry_rc=0
-        if [ "$effective_role" = "creator" ]; then
-            echo "::group::creator@${sha:0:7} setup" >&2
-            run_xdbg_real "$out_dir" "$kind" "$sha" generate --entity identity -a "$n" \
-                || entry_rc=$?
-            if [ "$entry_rc" -eq 0 ]; then
-                run_xdbg_real "$out_dir" "$kind" "$sha" generate --entity group -a 1 --invite "$n" \
-                    || entry_rc=$?
-            fi
-            if [ "$entry_rc" -eq 0 ]; then
-                run_xdbg_real "$out_dir" "$kind" "$sha" generate --entity message -a 1 \
-                    || entry_rc=$?
-            fi
-            echo "::endgroup::" >&2
-            if [ "$entry_rc" -eq 0 ]; then
-                creator_done=1
-                results+=("PASS|${sha:0:7}|$sha|$kind|$branch|$label")
-            else
-                # Creator is load-bearing: senders have nothing to read.
-                # Always fatal regardless of leniency.
-                echo "::error::xdbg@${sha:0:7} creator failed (rc=$entry_rc); cannot continue" >&2
-                results+=("FAIL|${sha:0:7}|$sha|$kind|$branch|$label")
-                required_failure=1
-                _record_not_run_remaining=1
-                break
-            fi
-        else
-            rand=$(( (RANDOM % 6) + 5 ))   # 5..10 inclusive
-            echo "::group::sender@${sha:0:7} (${rand} msgs + change-description)" >&2
-            run_xdbg_real "$out_dir" "$kind" "$sha" generate --entity group -a 1 --invite "$n" \
-                || entry_rc=$?
-            if [ "$entry_rc" -eq 0 ]; then
-                run_xdbg_real "$out_dir" "$kind" "$sha" generate --entity message -a "$rand" --change-description \
-                    || entry_rc=$?
-            fi
-            echo "::endgroup::" >&2
+        echo "::group::healthcheck@${sha:0:7} ($kind $label)" >&2
+        run_xdbg_real "$out_dir" "$kind" "$sha" healthcheck || entry_rc=$?
+        echo "::endgroup::" >&2
 
-            if [ "$entry_rc" -eq 0 ]; then
-                sender_done=1
-                results+=("PASS|${sha:0:7}|$sha|$kind|$branch|$label")
-            else
-                results+=("FAIL|${sha:0:7}|$sha|$kind|$branch|$label")
-                if [ "$is_required" -eq 0 ]; then
-                    echo "::warning::xdbg@${sha:0:7} nightly $label runtime failure (rc=$entry_rc); continuing so later versions (incl. HEAD) still run" >&2
-                    nightly_failure=1
-                    continue
-                fi
-                # Required sender failure — record but keep running so
-                # remaining entries (including HEAD) still get a chance.
-                # The required_failure flag will cause non-zero exit at end.
-                echo "::error::xdbg@${sha:0:7} required sender ($kind) runtime failure (rc=$entry_rc); continuing to remaining entries" >&2
-                required_failure=1
+        if [ "$entry_rc" -eq 0 ]; then
+            completed_count=$((completed_count + 1))
+            results+=("PASS|${sha:0:7}|$sha|$kind|$branch|$label")
+        else
+            results+=("FAIL|${sha:0:7}|$sha|$kind|$branch|$label")
+            if [ "$is_required" -eq 0 ]; then
+                echo "::warning::xdbg@${sha:0:7} nightly $label healthcheck failure (rc=$entry_rc); continuing so later versions (incl. HEAD) still run" >&2
+                nightly_failure=1
+                continue
             fi
+            echo "::error::xdbg@${sha:0:7} required version ($kind) healthcheck failure (rc=$entry_rc); continuing to remaining entries" >&2
+            required_failure=1
         fi
     done
 
@@ -741,11 +737,12 @@ cmd_run_sequence() {
         for r in "${results[@]}"; do
             IFS='|' read -r status short_sha full_sha r_kind r_branch r_label <<< "$r"
             case "$status" in
-                PASS)          glyph="✓ PASS" ;;
-                FAIL)          glyph="✗ FAIL" ;;
-                SKIP-BUILD)    glyph="⊘ SKIP (build failed)" ;;
-                SKIP-NOT-RUN)  glyph="⊘ SKIP (not run — earlier required failure)" ;;
-                *)             glyph="? $status" ;;
+                PASS)               glyph="✓ PASS" ;;
+                FAIL)               glyph="✗ FAIL" ;;
+                SKIP-BUILD)         glyph="⊘ SKIP (build failed)" ;;
+                SKIP-NOT-RUN)       glyph="⊘ SKIP (not run — earlier required failure)" ;;
+                SKIP-NO-HEALTHCHECK) glyph="⊘ SKIP (no healthcheck subcommand)" ;;
+                *)                  glyph="? $status" ;;
             esac
             # Display: nightly tag label if present, else release branch
             # (stable rows), else empty (HEAD).
@@ -756,8 +753,7 @@ cmd_run_sequence() {
 
     # JSON summary.
     {
-        printf '{\n  "creator_done": %s,\n' "$creator_done"
-        printf '  "sender_done": %s,\n' "$sender_done"
+        printf '{\n  "completed_count": %s,\n' "$completed_count"
         printf '  "nightly_failure": %s,\n' "$nightly_failure"
         printf '  "required_failure": %s,\n' "$required_failure"
         printf '  "lenient_nightlies": %s,\n' "$lenient_nightlies"
@@ -789,11 +785,12 @@ cmd_run_sequence() {
             for r in "${results[@]}"; do
                 IFS='|' read -r status short_sha full_sha r_kind r_branch r_label <<< "$r"
                 case "$status" in
-                    PASS)          md_glyph="✅ PASS" ;;
-                    FAIL)          md_glyph="❌ FAIL" ;;
-                    SKIP-BUILD)    md_glyph="⊘ SKIP (build failed)" ;;
-                    SKIP-NOT-RUN)  md_glyph="⊘ SKIP (not run — earlier required failure)" ;;
-                    *)             md_glyph="❓ $status" ;;
+                    PASS)               md_glyph="✅ PASS" ;;
+                    FAIL)               md_glyph="❌ FAIL" ;;
+                    SKIP-BUILD)         md_glyph="⊘ SKIP (build failed)" ;;
+                    SKIP-NOT-RUN)       md_glyph="⊘ SKIP (not run — earlier required failure)" ;;
+                    SKIP-NO-HEALTHCHECK) md_glyph="⊘ SKIP (no healthcheck subcommand)" ;;
+                    *)                  md_glyph="❓ $status" ;;
                 esac
                 # Nightly rows carry a label (nightly.YYYYMMDD); stable rows
                 # carry a branch (release/X); HEAD has neither.
@@ -803,15 +800,17 @@ cmd_run_sequence() {
                     "$md_glyph" "$r_kind" "$short_sha" "$display" "$full_sha"
             done
             echo ""
-            echo "**creator_done=$creator_done sender_done=$sender_done required_failure=$required_failure nightly_failure=$nightly_failure lenient=$lenient_nightlies**"
+            echo "**completed_count=$completed_count required_failure=$required_failure nightly_failure=$nightly_failure lenient=$lenient_nightlies**"
             echo ""
             echo "**libxmtp NDJSON log files captured: ${log_count}** (download the run artifact to inspect)"
         } >> "$GITHUB_STEP_SUMMARY"
     fi
 
-    # Cross-version compat requires at least one creator AND one sender.
-    if [ "$creator_done" -eq 0 ] || [ "$sender_done" -eq 0 ]; then
-        echo "::error::run-sequence: insufficient cross-version coverage (creator=$creator_done, sender=$sender_done); need at least one creator + one sender" >&2
+    # Cross-version compat requires at least two versions to successfully
+    # complete `xdbg healthcheck` against the shared state, otherwise the
+    # run did not actually exercise inter-version compatibility.
+    if [ "$completed_count" -lt 2 ]; then
+        echo "::error::run-sequence: insufficient cross-version coverage (completed=$completed_count); need at least 2 successful healthcheck runs" >&2
         exit 1
     fi
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Replace generate ops with `xdbg healthcheck` in cross-version CI tests
- Replaces the previous `generate identity/group/message` step sequence in [cross-version-test.sh](https://github.com/xmtp/libxmtp/pull/3637/files#diff-712ae198e9da13375e53de2f93117a81e188aaba91515716e8fac87bbcef4c24) with `xdbg healthcheck` runs per tested version; requires at least two successful healthchecks for coverage.
- Adds `xdbg_supports_subcommand` to probe subcommand availability before running; versions missing `healthcheck` are skipped (nightly) or cause failure (required), emitting a `SKIP-NO-HEALTHCHECK` status.
- Extends `HealthContext` with persistence helpers (`persist_new_group`, `update_group_members`, `persisted_members`, `persisted_creator`) that keep redb in sync with runtime group membership across ops.
- Updates `AddPrimaryToExistingGroups` to prefer the persisted super-admin as the caller and attempts to promote primary to super-admin after adding; all membership-mutating ops now trigger a best-effort `sync_welcomes` fanout.
- Refactors `OpEntry` and `ValidatorEntry` registry structs to hold `&'static` references to op/validator instances instead of factory functions, removing duplicated `op_name` and `make` fields across all op registrations.
- Behavioral Change: `SendMessage` no longer attempts to send into existing groups for the transient identity; failed group lookups now produce `Fail` results instead of silent no-ops.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized c680870.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->