### PR TITLE
Allow RUSTSEC-2026-0124 until openmls has a fix

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,6 @@
 [advisories]
 ignore = [
-  { id = "RUSTSEC-2024-0384", reason = "need to upgrade openmls" },
+  { id = "RUSTSEC-2026-0124", reason = "need to upgrade openmls" },
   { id = "RUSTSEC-2024-0436", reason = "required by uniffi" },
   { id = "RUSTSEC-2021-0139", reason = "ansi_term is only used in tests" },
   { id = "RUSTSEC-2025-0141", reason = "migrate from bincode" },


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Allow RUSTSEC-2026-0124 in cargo-deny until openmls provides a fix
Updates [deny.toml](https://github.com/xmtp/libxmtp/pull/3638/files#diff-1040309c64844eb1b6b63d8fd67938adbf9461f1b3c61f12cf738f064a02d3de) to ignore advisory RUSTSEC-2026-0124 instead of the previously ignored RUSTSEC-2024-0384, unblocking builds while the upstream openmls crate is patched.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f20150.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->