### PR TITLE
xdbg(healthcheck): rewrite NoMissingMessages to use redb as source of truth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14152,7 +14152,7 @@ dependencies = [
  "hyper-util",
  "idna",
  "indexmap 2.14.0",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "k256",
  "libc",
  "libcrux-ed25519",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,7 +707,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -863,7 +863,7 @@ checksum = "eed3ed3300a998f88639ed619fdbbd88bd82865e00c6a8ecb796c99eb12358f6"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "reqwest 0.13.3",
  "serde_json",
  "tower",
@@ -1004,7 +1004,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1015,7 +1015,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2638,7 +2638,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3482,7 +3482,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3805,7 +3805,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6625,7 +6625,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7813,7 +7813,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8524,7 +8524,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9294,8 +9294,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.10.5",
+ "heck 0.5.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -9316,7 +9316,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -9669,9 +9669,9 @@ dependencies = [
 
 [[package]]
 name = "redb"
-version = "3.1.3"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba239c1c1693315d3cc0e601db3b3965543afbf48c41730fdca2f069f510f4a"
+checksum = "8e925444704b5f17d32bf42f5b6e2df050bceebc3dcd6e71cc73dafe8092e839"
 dependencies = [
  "libc",
  "log",
@@ -10133,7 +10133,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10190,7 +10190,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11018,7 +11018,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11041,7 +11041,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11399,7 +11399,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12314,7 +12314,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13252,7 +13252,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/apps/xmtp_debug/Cargo.toml
+++ b/apps/xmtp_debug/Cargo.toml
@@ -41,7 +41,7 @@ owo-colors.workspace = true
 prometheus = "0.14"
 prost.workspace = true
 rand.workspace = true
-redb = { version = "3.1", features = ["logging"] }
+redb = { version = "4.1", features = ["logging"] }
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/apps/xmtp_debug/src/app/generate/messages.rs
+++ b/apps/xmtp_debug/src/app/generate/messages.rs
@@ -1,13 +1,13 @@
 use crate::DbgClient;
 use crate::app::store::Database;
-use crate::app::types::InboxId;
+use crate::app::types::{InboxId, Message};
 use crate::app::{App, load_all_identities};
 use crate::args::BackendOpts;
 use crate::metrics::record_phase_metric;
 use crate::{
     app::{
         self,
-        store::{GroupStore, IdentityStore, RandomDatabase},
+        store::{GroupStore, IdentityStore, MessageStore, RandomDatabase},
     },
     args,
 };
@@ -18,11 +18,65 @@ use indicatif::{ProgressBar, ProgressStyle};
 use rand::{RngExt, SeedableRng, prelude::IteratorRandom, rngs::SmallRng, seq::IndexedRandom};
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::sync::OnceLock;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use xmtp_mls::groups::send_message_opts::SendMessageOptsBuilder;
 use xmtp_mls::groups::summary::SyncSummary;
+
+/// Per-process `op_run_id` for generate runs. Stamped on every recorded
+/// `Message` so cross-tool inspection can attribute rows to specific
+/// generator invocations.
+fn generate_op_run_id() -> [u8; 16] {
+    static ID: OnceLock<[u8; 16]> = OnceLock::new();
+    *ID.get_or_init(rand::random)
+}
+
+/// Mirror a successfully-sent message to redb's `MessageStore`. Soft
+/// errors only — generate is best-effort, so logged-and-skipped rather
+/// than aborted. Non-16-byte group_id or non-32-byte message_id would
+/// indicate a libxmtp invariant break the validator path already
+/// surfaces; we just don't record those rows.
+fn record_generated_message(
+    store: &MessageStore<'static>,
+    network: &args::BackendOpts,
+    group_id: &[u8],
+    message_id: &[u8],
+    sender_inbox_id: InboxId,
+) {
+    let Ok(group_id_bytes) = <[u8; 16]>::try_from(group_id) else {
+        tracing::warn!(
+            target: "generate",
+            len = group_id.len(),
+            "expected 16-byte group_id; skipping redb message record",
+        );
+        return;
+    };
+    let Ok(message_id_bytes) = <[u8; 32]>::try_from(message_id) else {
+        tracing::warn!(
+            target: "generate",
+            len = message_id.len(),
+            "expected 32-byte message_id; skipping redb message record",
+        );
+        return;
+    };
+    let sent_at_ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos() as i64)
+        .unwrap_or(0);
+    let msg = Message {
+        id: message_id_bytes,
+        group_id: group_id_bytes,
+        sender_inbox_id,
+        sent_at_ns,
+        op_run_id: generate_op_run_id(),
+        xdbg_version: crate::get_version(),
+    };
+    if let Err(e) = store.set(msg, u64::from(network)) {
+        tracing::warn!(target: "generate", error = %e, "redb set failed; skipping message record");
+    }
+}
 
 mod content_type;
 
@@ -52,6 +106,7 @@ pub struct GenerateMessages {
     opts: args::MessageGenerateOpts,
     identity_store: IdentityStore<'static>,
     group_store: GroupStore<'static>,
+    message_store: MessageStore<'static>,
     identities: IdentityMap,
     semaphore: ConcSemaphore,
 }
@@ -62,17 +117,15 @@ impl GenerateMessages {
         opts: args::MessageGenerateOpts,
         concurrency: usize,
     ) -> Result<Self> {
-        let (identity_store, group_store) = {
-            if opts.add_and_change_description || opts.change_description {
-                let db = App::db().wrap_err(
-                    "must have exclusive write access for adding members or changing description",
-                )?;
-                (db.clone().into(), db.into())
-            } else {
-                let db = App::readonly_db()?;
-                (db.clone().into(), db.into())
-            }
-        };
+        // Always open write-capable redb so we can mirror sent messages
+        // into `MessageStore`. add_member/change_description already
+        // required write; default path now does too because we record
+        // every successful send.
+        let db = App::db()
+            .wrap_err("must have exclusive write access to record sent messages in redb")?;
+        let identity_store: IdentityStore<'static> = db.clone().into();
+        let group_store: GroupStore<'static> = db.clone().into();
+        let message_store: MessageStore<'static> = db.into();
         let identities = load_all_identities(&identity_store, &network)?;
         let semaphore = Arc::new(tokio::sync::Semaphore::new(concurrency));
 
@@ -81,6 +134,7 @@ impl GenerateMessages {
             opts,
             identity_store,
             group_store,
+            message_store,
             identities,
             semaphore,
         })
@@ -240,17 +294,21 @@ impl GenerateMessages {
         let clients = self.identities.clone();
         let mut set: tokio::task::JoinSet<Result<Duration, eyre::Error>> =
             tokio::task::JoinSet::new();
-        let stores = (self.identity_store.clone(), self.group_store.clone());
+        let stores = (
+            self.identity_store.clone(),
+            self.group_store.clone(),
+            self.message_store.clone(),
+        );
         for _ in 0..n {
             let bar_pointer = bar.clone();
             let n = network.clone();
             let opts = opts.clone();
-            let (_, group) = stores.clone();
+            let (_, group, messages) = stores.clone();
             let semaphore = semaphore.clone();
             let cs = clients.clone();
             set.spawn(async move {
                 let _permit = semaphore.acquire().await?;
-                let latency = Self::send_message(&group, cs, n, opts)
+                let latency = Self::send_message(&group, &messages, cs, n, opts)
                     .await
                     .inspect_err(|e| error!("{}", e))?;
                 bar_pointer.inc(1);
@@ -289,6 +347,7 @@ impl GenerateMessages {
     /// Returns the duration of just the send_message() call (excluding sync overhead)
     async fn send_message(
         group_store: &GroupStore<'static>,
+        message_store: &MessageStore<'static>,
         clients: Arc<HashMap<InboxId, Mutex<DbgClient>>>,
         network: args::BackendOpts,
         opts: args::MessageGenerateOpts,
@@ -299,43 +358,52 @@ impl GenerateMessages {
         } = opts;
 
         let rng = &mut SmallRng::from_rng(&mut rand::rng());
-        let group = group_store
+        let stored_group = group_store
             .random(&network, rng)?
             .ok_or(eyre!("no group in local store"))?;
-        info!(time = ?Instant::now(), group = hex::encode(group.id), "sending message");
-        if let Some(inbox_id) = group.members.choose(rng) {
-            let client = clients
-                .get(inbox_id.as_slice())
-                .ok_or(eyre!("client does not exist"))?;
-            let client = client.lock().await;
-            client.sync_welcomes().await?;
-            let group = client.group(&group.id)?;
-            group.sync_with_conn().await?;
-            group.maybe_update_installations(None).await?;
-            let words = rng.random_range(0..*max_message_size);
-            let words = lipsum::lipsum_words(words as usize);
-            let message = content_type::new_message(words);
+        info!(time = ?Instant::now(), group = hex::encode(stored_group.id), "sending message");
+        let Some(sender_inbox_id) = stored_group.members.choose(rng).copied() else {
+            return Err(MessageSendError::NoGroup);
+        };
+        let client = clients
+            .get(sender_inbox_id.as_slice())
+            .ok_or(eyre!("client does not exist"))?;
+        let client = client.lock().await;
+        client.sync_welcomes().await?;
+        let mls_group = client.group(&stored_group.id)?;
+        mls_group.sync_with_conn().await?;
+        mls_group.maybe_update_installations(None).await?;
+        let words = rng.random_range(0..*max_message_size);
+        let words = lipsum::lipsum_words(words as usize);
+        let message = content_type::new_message(words);
 
-            // Time ONLY the send_message() call
-            let start = Instant::now();
-            group
-                .send_message(
-                    &message,
-                    SendMessageOptsBuilder::default()
-                        .should_push(true)
-                        .build()
-                        .unwrap(),
-                )
-                .await?;
-            let send_latency = start.elapsed();
-            let send_secs = send_latency.as_secs_f64();
+        // Time ONLY the send_message() call
+        let start = Instant::now();
+        let message_id = mls_group
+            .send_message(
+                &message,
+                SendMessageOptsBuilder::default()
+                    .should_push(true)
+                    .build()
+                    .unwrap(),
+            )
+            .await?;
+        let send_latency = start.elapsed();
+        let send_secs = send_latency.as_secs_f64();
 
-            record_phase_metric("send_message", send_secs, "send_message", "xdbg_debug").await;
+        record_phase_metric("send_message", send_secs, "send_message", "xdbg_debug").await;
 
-            Ok(send_latency)
-        } else {
-            Err(MessageSendError::NoGroup)
-        }
+        // Mirror to redb so healthcheck's `NoMissingMessages` validator
+        // and any cross-tool inspection can find this message later.
+        record_generated_message(
+            message_store,
+            &network,
+            &stored_group.id,
+            &message_id,
+            sender_inbox_id,
+        );
+
+        Ok(send_latency)
     }
 }
 

--- a/apps/xmtp_debug/src/app/health/context.rs
+++ b/apps/xmtp_debug/src/app/health/context.rs
@@ -25,11 +25,6 @@ pub struct HealthContext {
     /// redb identity store so future runs see it as an existing identity.
     pub primary: Arc<DbgClient>,
 
-    /// Single-run identity used by destructive ops (e.g. `LeaveGroup`).
-    /// Not persisted to redb — exists only to be removed from groups
-    /// without losing the run-stable `primary`.
-    pub transient_identity: Arc<DbgClient>,
-
     /// Identities loaded from the redb `IdentityStore` for this network.
     /// On a fresh run, contains the freshly-bootstrapped identities.
     pub existing_clients: HashMap<InboxId, Arc<DbgClient>>,
@@ -118,14 +113,7 @@ impl HealthContext {
         id_store.set(primary_identity, net_key)?;
         let primary = Arc::new(primary_client);
 
-        // 3. Transient identity for destructive ops. Not persisted.
-        let transient_wallet = app::generate_wallet();
-        let transient_client =
-            app::new_unregistered_client(&network, Some(&transient_wallet)).await?;
-        app::register_client(&transient_client, transient_wallet.into_alloy()).await?;
-        let transient_identity = Arc::new(transient_client);
-
-        // 4. Existing groups from redb.
+        // 3. Existing groups from redb.
         let existing_groups = group_store
             .load(net_key)?
             .map(|iter| {
@@ -147,7 +135,6 @@ impl HealthContext {
         Ok(Self {
             network,
             primary,
-            transient_identity,
             existing_clients,
             existing_groups,
             new_groups: Vec::new(),
@@ -155,6 +142,18 @@ impl HealthContext {
             xdbg_version,
             network_key: net_key,
         })
+    }
+
+    /// Register a fresh single-use identity. Not persisted to redb. Used
+    /// by ops that need a victim/leaver they own end-to-end — e.g.
+    /// `LeaveGroup` adds + leaves; `RemoveMember` adds + admin-removes.
+    /// The returned `Arc<DbgClient>` is owned by the caller; once dropped,
+    /// nothing in the run references it.
+    pub async fn create_transient(&self) -> Result<Arc<DbgClient>> {
+        let wallet = app::generate_wallet();
+        let client = app::new_unregistered_client(&self.network, Some(&wallet)).await?;
+        app::register_client(&client, wallet.into_alloy()).await?;
+        Ok(Arc::new(client))
     }
 
     /// Persist a newly-created group to redb's `GroupStore` so subsequent
@@ -245,13 +244,12 @@ impl HealthContext {
             .filter(|c| c != &[0u8; 32])
     }
 
-    /// Every client involved in this run: primary + transient + every
-    /// entry in `existing_clients`. The two run-scoped clients are
-    /// returned first so consumers can match on inbox_id if needed.
+    /// Every persisted client involved in this run: primary + every
+    /// entry in `existing_clients`. Run-scoped throwaway transients
+    /// created by ops are NOT included — they're op-local.
     pub fn all_clients(&self) -> Vec<Arc<DbgClient>> {
-        let mut out = Vec::with_capacity(self.existing_clients.len() + 2);
+        let mut out = Vec::with_capacity(self.existing_clients.len() + 1);
         out.push(self.primary.clone());
-        out.push(self.transient_identity.clone());
         out.extend(self.existing_clients.values().cloned());
         out
     }
@@ -262,16 +260,11 @@ impl HealthContext {
         self.existing_groups.iter().chain(self.new_groups.iter())
     }
 
-    pub fn is_transient(&self, client: &DbgClient) -> bool {
-        client.inbox_id() == self.transient_identity.inbox_id()
-    }
-
     /// Concurrently sync welcomes on every client involved in the run.
     /// Failures are logged but never propagated — `sync_welcomes` is
     /// best-effort plumbing, not a validation step.
     pub async fn sync_welcomes_fanout(&self, label: &'static str) {
-        let syncs = std::iter::once(self.transient_identity.as_ref())
-            .chain(std::iter::once(self.primary.as_ref()))
+        let syncs = std::iter::once(self.primary.as_ref())
             .chain(self.existing_clients.values().map(|c| c.as_ref()))
             .map(|c| async move {
                 if let Err(e) = c.sync_welcomes().await {

--- a/apps/xmtp_debug/src/app/health/context.rs
+++ b/apps/xmtp_debug/src/app/health/context.rs
@@ -1,13 +1,14 @@
 //! Shared state for the health-check run.
 
 use crate::DbgClient;
-use crate::app::store::{Database, GroupStore, IdentityStore};
-use crate::app::types::{Group, Identity, InboxId};
+use crate::app::store::{Database, GroupStore, IdentityStore, MessageStore};
+use crate::app::types::{Group, Identity, InboxId, Message};
 use crate::app::{self, App};
 use crate::args;
 use color_eyre::eyre::{Result, eyre};
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 use xmtp_proto::types::GroupId;
 
 /// Number of identities to create when the redb identity store is empty.
@@ -41,6 +42,21 @@ pub struct HealthContext {
     /// HealthContext` and mutate this directly — execution is sequential
     /// so no synchronization is needed.
     pub new_groups: Vec<GroupId>,
+
+    /// Random 16-byte id generated at bootstrap. Stamped on every
+    /// recorded `Message` so cross-version tooling can attribute messages
+    /// to specific runs without scanning logs.
+    pub op_run_id: [u8; 16],
+
+    /// `crate::get_version()` output of the running xdbg binary. Stamped
+    /// alongside `op_run_id` so a recovered redb row carries enough
+    /// origin info for debugging.
+    pub xdbg_version: String,
+
+    /// The active network. Held so helpers (`record_message`,
+    /// `recorded_messages`) can re-open `MessageStore` without threading
+    /// network through every call site.
+    pub network_key: u64,
 }
 
 impl HealthContext {
@@ -125,6 +141,9 @@ impl HealthContext {
             "health context bootstrapped"
         );
 
+        let op_run_id: [u8; 16] = rand::random();
+        let xdbg_version = crate::get_version();
+
         Ok(Self {
             network,
             primary,
@@ -132,6 +151,9 @@ impl HealthContext {
             existing_clients,
             existing_groups,
             new_groups: Vec::new(),
+            op_run_id,
+            xdbg_version,
+            network_key: net_key,
         })
     }
 
@@ -140,10 +162,16 @@ impl HealthContext {
     /// it as an existing group. Called by `CreateGroup` after the MLS
     /// group is created on the network.
     ///
-    /// Panics if redb can't be opened — that indicates an xdbg state
-    /// directory problem, not a healthcheck assertion, and the run can't
-    /// continue meaningfully.
-    pub fn persist_new_group(&self, id: [u8; 16], created_by: InboxId, members: Vec<InboxId>) {
+    /// Panics if redb can't be opened or if `group_id` isn't 16 bytes —
+    /// both indicate state-dir / invariant problems, not op-level
+    /// failures, and the run can't continue meaningfully.
+    pub fn persist_new_group(
+        &self,
+        group_id: &GroupId,
+        created_by: InboxId,
+        members: Vec<InboxId>,
+    ) {
+        let id = group_id_bytes(group_id).expect("libxmtp group_id is 16 bytes");
         let group_store: GroupStore<'static> = redb_or_panic("persist_new_group").into();
         let group = Group {
             id,
@@ -161,8 +189,9 @@ impl HealthContext {
     /// `RemoveMember`, `LeaveGroup`) so redb's view stays consistent with
     /// the MLS-level state across runs.
     ///
-    /// Panics on redb failure — same rationale as `persist_new_group`.
-    pub fn update_group_members(&self, id: [u8; 16], members: Vec<InboxId>) {
+    /// Panics on redb failure or non-16-byte `group_id`.
+    pub fn update_group_members(&self, group_id: &GroupId, members: Vec<InboxId>) {
+        let id = group_id_bytes(group_id).expect("libxmtp group_id is 16 bytes");
         let group_store: GroupStore<'static> = redb_or_panic("update_group_members").into();
         let net_key = u64::from(&self.network);
         let key = crate::app::store::NetworkKey::new(net_key, id);
@@ -186,7 +215,10 @@ impl HealthContext {
 
     /// Look up a persisted group's current members, if it's recorded.
     /// Returns an empty vec if the group is not in redb.
-    pub fn persisted_members(&self, id: [u8; 16]) -> Vec<InboxId> {
+    pub fn persisted_members(&self, group_id: &GroupId) -> Vec<InboxId> {
+        let Ok(id) = group_id_bytes(group_id) else {
+            return Vec::new();
+        };
         let group_store: GroupStore<'static> = redb_or_panic("persisted_members").into();
         let net_key = u64::from(&self.network);
         let key = crate::app::store::NetworkKey::new(net_key, id);
@@ -197,11 +229,12 @@ impl HealthContext {
             .unwrap_or_default()
     }
 
-    /// Read the persisted `created_by` for a group. Returns `None` when no
-    /// row exists or `created_by` is the all-zero placeholder written by
-    /// `update_group_members` for groups created before persistence was
-    /// added.
-    pub fn persisted_creator(&self, id: [u8; 16]) -> Option<InboxId> {
+    /// Read the persisted `created_by` for a group. Returns `None` when
+    /// no row exists, `group_id` isn't 16 bytes, or `created_by` is the
+    /// all-zero placeholder written by `update_group_members` for groups
+    /// created before persistence was added.
+    pub fn persisted_creator(&self, group_id: &GroupId) -> Option<InboxId> {
+        let id = group_id_bytes(group_id).ok()?;
         let group_store: GroupStore<'static> = redb_or_panic("persisted_creator").into();
         let net_key = u64::from(&self.network);
         let key = crate::app::store::NetworkKey::new(net_key, id);
@@ -252,6 +285,51 @@ impl HealthContext {
                 }
             });
         futures::future::join_all(syncs).await;
+    }
+
+    /// Record a successfully-sent message to redb's `MessageStore`. The
+    /// `op_run_id` and `xdbg_version` fields are sourced from `self` so
+    /// every row carries this run's identity. Panics on redb failure or
+    /// on a non-16-byte `group_id` (libxmtp invariant).
+    pub fn record_message(&self, group_id: &GroupId, message_id: [u8; 32], sender: &DbgClient) {
+        let id_bytes = group_id_bytes(group_id).expect("libxmtp group_id is 16 bytes");
+        let sent_at_ns = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos() as i64)
+            .unwrap_or(0);
+        let store: MessageStore<'static> = redb_or_panic("record_message").into();
+        let msg = Message {
+            id: message_id,
+            group_id: id_bytes,
+            sender_inbox_id: inbox_id_to_bytes(sender.inbox_id()),
+            sent_at_ns,
+            op_run_id: self.op_run_id,
+            xdbg_version: self.xdbg_version.clone(),
+        };
+        store
+            .set(msg, self.network_key)
+            .expect("redb MessageStore::set failed");
+    }
+
+    /// Load every recorded message for this network and bucket by
+    /// `group_id`. Single scan; the validator calls this once and reads
+    /// per-group sub-vecs out of the map.
+    pub fn recorded_messages_by_group(&self) -> HashMap<GroupId, Vec<Message>> {
+        let store: MessageStore<'static> = redb_or_panic("recorded_messages_by_group").into();
+        let Some(iter) = store
+            .load(self.network_key)
+            .expect("redb MessageStore::load failed")
+        else {
+            return HashMap::new();
+        };
+        let mut out: HashMap<GroupId, Vec<Message>> = HashMap::new();
+        for guard in iter {
+            let msg = guard.value();
+            out.entry(GroupId::from(msg.group_id.as_slice()))
+                .or_default()
+                .push(msg);
+        }
+        out
     }
 }
 

--- a/apps/xmtp_debug/src/app/health/ops/add_members.rs
+++ b/apps/xmtp_debug/src/app/health/ops/add_members.rs
@@ -5,7 +5,7 @@
 //! - `AddPrimaryToExistingGroups`: for every group in `ctx.existing_groups`,
 //!   primary is added by an active member of that group.
 
-use crate::app::health::context::{HealthContext, group_id_bytes, inbox_id_to_bytes};
+use crate::app::health::context::{HealthContext, inbox_id_to_bytes};
 use crate::app::health::ops::HealthOp;
 use crate::app::health::result::{OpResult, Status};
 use async_trait::async_trait;
@@ -67,10 +67,9 @@ impl HealthOp for AddMembersToNewGroup {
                 .map_err(color_eyre::eyre::Report::from)?;
             // Mirror the new membership to redb so subsequent runs see
             // the full member list, not just the creator.
-            let id_bytes = group_id_bytes(&new_group_id)?;
             let mut members = vec![inbox_id_to_bytes(ctx.primary.inbox_id())];
             members.extend(inbox_ids.iter().map(|s| inbox_id_to_bytes(s)));
-            ctx.update_group_members(id_bytes, members);
+            ctx.update_group_members(&new_group_id, members);
             Ok(())
         }
         .await;
@@ -113,12 +112,11 @@ impl HealthOp for AddPrimaryToExistingGroups {
         for gid in &ctx.existing_groups {
             let start = Instant::now();
             let outcome: color_eyre::eyre::Result<()> = async {
-                let id_bytes = group_id_bytes(gid)?;
                 // Prefer the persisted creator (super-admin) so we can also
                 // promote primary below. Fall back to any active member if
                 // the creator isn't available locally — the add will still
                 // succeed but the promote will be skipped.
-                let creator = ctx.persisted_creator(id_bytes);
+                let creator = ctx.persisted_creator(gid);
                 let adder = creator
                     .and_then(|c| ctx.existing_clients.get(&c))
                     .and_then(|c| c.group(gid.as_slice()).ok())
@@ -152,12 +150,12 @@ impl HealthOp for AddPrimaryToExistingGroups {
                          metadata ops requiring admin will fail on this group",
                     );
                 }
-                let mut members = ctx.persisted_members(id_bytes);
+                let mut members = ctx.persisted_members(gid);
                 let primary_bytes = inbox_id_to_bytes(&primary_inbox);
                 if !members.contains(&primary_bytes) {
                     members.push(primary_bytes);
                 }
-                ctx.update_group_members(id_bytes, members);
+                ctx.update_group_members(gid, members);
                 Ok(())
             }
             .await;

--- a/apps/xmtp_debug/src/app/health/ops/add_members.rs
+++ b/apps/xmtp_debug/src/app/health/ops/add_members.rs
@@ -50,14 +50,11 @@ impl HealthOp for AddMembersToNewGroup {
             }
         };
 
-        let mut inbox_ids: Vec<String> = ctx
+        let inbox_ids: Vec<String> = ctx
             .existing_clients
             .values()
             .map(|c| c.inbox_id().to_string())
             .collect();
-        // Include transient so `LeaveGroup` has a member to remove without
-        // disturbing the run-stable primary.
-        inbox_ids.push(ctx.transient_identity.inbox_id().to_string());
 
         let start = Instant::now();
         let outcome: color_eyre::eyre::Result<()> = async {

--- a/apps/xmtp_debug/src/app/health/ops/create_group.rs
+++ b/apps/xmtp_debug/src/app/health/ops/create_group.rs
@@ -2,7 +2,7 @@
 //! The new group's id is appended to `ctx.new_groups` so downstream ops
 //! and validators see it.
 
-use crate::app::health::context::{HealthContext, group_id_bytes, inbox_id_to_bytes};
+use crate::app::health::context::{HealthContext, inbox_id_to_bytes};
 use crate::app::health::ops::HealthOp;
 use crate::app::health::result::{OpResult, Status};
 use async_trait::async_trait;
@@ -26,15 +26,10 @@ impl HealthOp for CreateGroup {
             Ok(group) => {
                 let new_group_id = GroupId::from(group.group_id.as_slice());
                 let hex_id = format!("{new_group_id}");
-                match group_id_bytes(&new_group_id) {
-                    Ok(id_bytes) => {
-                        let creator = inbox_id_to_bytes(ctx.primary.inbox_id());
-                        ctx.persist_new_group(id_bytes, creator, vec![creator]);
-                        ctx.new_groups.push(new_group_id);
-                        (Status::Pass, Some(hex_id), None)
-                    }
-                    Err(e) => (Status::Fail, Some(hex_id), Some(e)),
-                }
+                let creator = inbox_id_to_bytes(ctx.primary.inbox_id());
+                ctx.persist_new_group(&new_group_id, creator, vec![creator]);
+                ctx.new_groups.push(new_group_id);
+                (Status::Pass, Some(hex_id), None)
             }
             Err(e) => (Status::Fail, None, Some(eyre!("{e}"))),
         };

--- a/apps/xmtp_debug/src/app/health/ops/leave_group.rs
+++ b/apps/xmtp_debug/src/app/health/ops/leave_group.rs
@@ -1,12 +1,12 @@
-//! Op: transient identity self-removes from the newly-created group via
-//! MLS `leave_group`. Uses the transient instead of the primary so the
-//! persisted primary stays in every group across runs.
-//! Must run last so prior ops are not invalidated by the membership change.
+//! Op: a freshly-created throwaway identity self-removes from the
+//! newly-created group via MLS `leave_group`. The transient is created
+//! by this op so nothing else in the run is disturbed by the membership
+//! change.
 //!
 //! Distinct from `RemoveMember` which exercises the admin-remove path
 //! (one identity removes another via `remove_members`).
 
-use crate::app::health::context::{HealthContext, inbox_id_to_bytes};
+use crate::app::health::context::HealthContext;
 use crate::app::health::ops::HealthOp;
 use crate::app::health::result::{OpResult, Status};
 use async_trait::async_trait;
@@ -35,28 +35,32 @@ impl HealthOp for LeaveGroup {
 
         let start = Instant::now();
         let outcome: color_eyre::eyre::Result<()> = async {
-            // Transient must see the welcome for this group before it can
-            // load + leave it. The add happened earlier in the run but is
-            // only visible after a sync.
-            ctx.transient_identity
+            // Fresh single-use identity. Created locally so it doesn't
+            // appear in `ctx.all_clients()` and isn't held to validator
+            // convergence checks after the leave.
+            let transient = ctx.create_transient().await?;
+
+            // Primary adds the transient to the group, then transient
+            // syncs the welcome and leaves.
+            let primary_group = ctx
+                .primary
+                .group(gid.as_slice())
+                .map_err(color_eyre::eyre::Report::from)?;
+            primary_group
+                .add_members(&[transient.inbox_id().to_string()])
+                .await
+                .map_err(color_eyre::eyre::Report::from)?;
+            transient
                 .sync_welcomes()
                 .await
                 .map_err(color_eyre::eyre::Report::from)?;
-            let group = ctx
-                .transient_identity
+            let transient_group = transient
                 .group(gid.as_slice())
                 .map_err(color_eyre::eyre::Report::from)?;
-            group
+            transient_group
                 .leave_group()
                 .await
                 .map_err(color_eyre::eyre::Report::from)?;
-            let transient_bytes = inbox_id_to_bytes(ctx.transient_identity.inbox_id());
-            let members: Vec<_> = ctx
-                .persisted_members(&gid)
-                .into_iter()
-                .filter(|m| m != &transient_bytes)
-                .collect();
-            ctx.update_group_members(&gid, members);
             Ok(())
         }
         .await;

--- a/apps/xmtp_debug/src/app/health/ops/leave_group.rs
+++ b/apps/xmtp_debug/src/app/health/ops/leave_group.rs
@@ -6,7 +6,7 @@
 //! Distinct from `RemoveMember` which exercises the admin-remove path
 //! (one identity removes another via `remove_members`).
 
-use crate::app::health::context::{HealthContext, group_id_bytes, inbox_id_to_bytes};
+use crate::app::health::context::{HealthContext, inbox_id_to_bytes};
 use crate::app::health::ops::HealthOp;
 use crate::app::health::result::{OpResult, Status};
 use async_trait::async_trait;
@@ -50,14 +50,13 @@ impl HealthOp for LeaveGroup {
                 .leave_group()
                 .await
                 .map_err(color_eyre::eyre::Report::from)?;
-            let id_bytes = group_id_bytes(&gid)?;
             let transient_bytes = inbox_id_to_bytes(ctx.transient_identity.inbox_id());
             let members: Vec<_> = ctx
-                .persisted_members(id_bytes)
+                .persisted_members(&gid)
                 .into_iter()
                 .filter(|m| m != &transient_bytes)
                 .collect();
-            ctx.update_group_members(id_bytes, members);
+            ctx.update_group_members(&gid, members);
             Ok(())
         }
         .await;

--- a/apps/xmtp_debug/src/app/health/ops/remove_member.rs
+++ b/apps/xmtp_debug/src/app/health/ops/remove_member.rs
@@ -1,19 +1,18 @@
-//! Op: primary admin-removes a peer from the newly-created group via
-//! `MlsGroup::remove_members`. Distinct from `LeaveGroup` which exercises
-//! the MLS self-remove path. Both code paths produce a remove commit but
-//! follow different intent + validation flows in libxmtp.
+//! Op: primary admin-removes a freshly-created throwaway identity from
+//! the newly-created group via `MlsGroup::remove_members`. The transient
+//! victim is created inside this op so nothing persisted gets disturbed
+//! (avoids the cross-run "removed-and-stays-around" fork-noise pattern).
 //!
-//! Victim is the first existing identity (i.e. one of the bootstrap or
-//! pre-existing clients). If none is available, the op fails with a
-//! reason.
+//! Distinct from `LeaveGroup` which exercises the MLS self-remove path.
+//! Both produce a remove commit but follow different intent + validation
+//! flows in libxmtp.
 
-use crate::app::health::context::{HealthContext, inbox_id_to_bytes};
+use crate::app::health::context::HealthContext;
 use crate::app::health::ops::HealthOp;
 use crate::app::health::result::{OpResult, Status};
 use async_trait::async_trait;
 use color_eyre::eyre::eyre;
 use std::time::{Duration, Instant};
-use xmtp_proto::types::GroupId;
 
 pub struct RemoveMember;
 
@@ -35,34 +34,27 @@ impl HealthOp for RemoveMember {
             }];
         };
 
-        let primary_inbox = ctx.primary.inbox_id().to_string();
-        let transient_inbox = ctx.transient_identity.inbox_id().to_string();
-        let Some(victim_inbox) = ctx
-            .existing_clients
-            .values()
-            .map(|c| c.inbox_id().to_string())
-            .find(|id| id != &primary_inbox && id != &transient_inbox)
-        else {
-            return vec![OpResult {
-                op_name: self.name(),
-                target: Some(format!("{gid}")),
-                status: Status::Fail,
-                duration: Duration::ZERO,
-                error: Some(eyre!("no existing identity available as remove target")),
-            }];
-        };
-
         let start = Instant::now();
+        let mut victim_label = String::from("(uncreated)");
         let outcome: color_eyre::eyre::Result<()> = async {
-            let group = ctx
+            let victim = ctx.create_transient().await?;
+            let victim_inbox = victim.inbox_id().to_string();
+            victim_label = victim_inbox.clone();
+
+            // Primary adds the victim, then admin-removes them via
+            // `remove_members`. Both commits go through primary.
+            let primary_group = ctx
                 .primary
                 .group(gid.as_slice())
                 .map_err(color_eyre::eyre::Report::from)?;
-            group
+            primary_group
+                .add_members(std::slice::from_ref(&victim_inbox))
+                .await
+                .map_err(color_eyre::eyre::Report::from)?;
+            primary_group
                 .remove_members(&[victim_inbox.as_str()])
                 .await
                 .map_err(color_eyre::eyre::Report::from)?;
-            drop_member_from_persisted_group(ctx, &gid, &victim_inbox);
             Ok(())
         }
         .await;
@@ -72,25 +64,12 @@ impl HealthOp for RemoveMember {
         };
         vec![OpResult {
             op_name: self.name(),
-            target: Some(format!("group={gid} victim={victim_inbox}")),
+            target: Some(format!("group={gid} victim={victim_label}")),
             status,
             duration: start.elapsed(),
             error,
         }]
     }
-}
-
-/// Read the persisted group's members from redb, drop `victim_inbox`,
-/// and write back. Panics if redb is unreachable — a redb failure
-/// indicates an xdbg state-directory issue, not an op-level failure.
-fn drop_member_from_persisted_group(ctx: &HealthContext, group_id: &GroupId, victim_inbox: &str) {
-    let victim_bytes = inbox_id_to_bytes(victim_inbox);
-    let members: Vec<_> = ctx
-        .persisted_members(group_id)
-        .into_iter()
-        .filter(|m| m != &victim_bytes)
-        .collect();
-    ctx.update_group_members(group_id, members);
 }
 
 #[cfg(test)]

--- a/apps/xmtp_debug/src/app/health/ops/remove_member.rs
+++ b/apps/xmtp_debug/src/app/health/ops/remove_member.rs
@@ -7,12 +7,13 @@
 //! pre-existing clients). If none is available, the op fails with a
 //! reason.
 
-use crate::app::health::context::{HealthContext, group_id_bytes, inbox_id_to_bytes};
+use crate::app::health::context::{HealthContext, inbox_id_to_bytes};
 use crate::app::health::ops::HealthOp;
 use crate::app::health::result::{OpResult, Status};
 use async_trait::async_trait;
 use color_eyre::eyre::eyre;
 use std::time::{Duration, Instant};
+use xmtp_proto::types::GroupId;
 
 pub struct RemoveMember;
 
@@ -61,8 +62,7 @@ impl HealthOp for RemoveMember {
                 .remove_members(&[victim_inbox.as_str()])
                 .await
                 .map_err(color_eyre::eyre::Report::from)?;
-            let id_bytes = group_id_bytes(&gid)?;
-            drop_member_from_persisted_group(ctx, id_bytes, &victim_inbox);
+            drop_member_from_persisted_group(ctx, &gid, &victim_inbox);
             Ok(())
         }
         .await;
@@ -83,18 +83,14 @@ impl HealthOp for RemoveMember {
 /// Read the persisted group's members from redb, drop `victim_inbox`,
 /// and write back. Panics if redb is unreachable — a redb failure
 /// indicates an xdbg state-directory issue, not an op-level failure.
-fn drop_member_from_persisted_group(
-    ctx: &HealthContext,
-    group_id_bytes: [u8; 16],
-    victim_inbox: &str,
-) {
+fn drop_member_from_persisted_group(ctx: &HealthContext, group_id: &GroupId, victim_inbox: &str) {
     let victim_bytes = inbox_id_to_bytes(victim_inbox);
     let members: Vec<_> = ctx
-        .persisted_members(group_id_bytes)
+        .persisted_members(group_id)
         .into_iter()
         .filter(|m| m != &victim_bytes)
         .collect();
-    ctx.update_group_members(group_id_bytes, members);
+    ctx.update_group_members(group_id, members);
 }
 
 #[cfg(test)]

--- a/apps/xmtp_debug/src/app/health/ops/send_message.rs
+++ b/apps/xmtp_debug/src/app/health/ops/send_message.rs
@@ -70,14 +70,7 @@ impl HealthOp for SendMessage {
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
         let mut out = Vec::new();
         for client in ctx.all_clients() {
-            // Transient is only added to new_groups, so existing_groups skip
-            // is by design — see AddMembersToNewGroup.
-            if !ctx.is_transient(&client) {
-                for gid in &ctx.existing_groups {
-                    out.push(send_one(self.name(), ctx, &client, gid).await);
-                }
-            }
-            for gid in &ctx.new_groups {
+            for gid in ctx.all_groups() {
                 out.push(send_one(self.name(), ctx, &client, gid).await);
             }
         }

--- a/apps/xmtp_debug/src/app/health/ops/send_message.rs
+++ b/apps/xmtp_debug/src/app/health/ops/send_message.rs
@@ -1,11 +1,15 @@
 //! Op: every client sends one message into every group it belongs to.
 //! Feeds the missing-messages validator.
+//!
+//! On success the message id is written to redb's `MessageStore` so the
+//! `NoMissingMessages` validator has an authoritative cross-version set.
 
 use crate::DbgClient;
 use crate::app::health::context::HealthContext;
 use crate::app::health::ops::HealthOp;
 use crate::app::health::result::{OpResult, Status};
 use async_trait::async_trait;
+use color_eyre::eyre::eyre;
 use std::sync::Arc;
 use std::time::Instant;
 use xmtp_mls::groups::send_message_opts::SendMessageOpts;
@@ -13,25 +17,38 @@ use xmtp_proto::types::GroupId;
 
 pub struct SendMessage;
 
-async fn send_one(op_name: &'static str, client: &Arc<DbgClient>, gid: &GroupId) -> OpResult {
+async fn send_one(
+    op_name: &'static str,
+    ctx: &HealthContext,
+    client: &Arc<DbgClient>,
+    gid: &GroupId,
+) -> OpResult {
     let start = Instant::now();
-    let outcome: color_eyre::eyre::Result<()> = async {
+    let outcome: color_eyre::eyre::Result<Option<[u8; 32]>> = async {
         let group = client
             .group(gid.as_slice())
             .map_err(color_eyre::eyre::Report::from)?;
         if !group.is_active().map_err(color_eyre::eyre::Report::from)? {
-            return Ok(());
+            return Ok(None);
         }
         let body = format!("healthcheck from {}", client.inbox_id());
-        group
+        let message_id = group
             .send_message(body.as_bytes(), SendMessageOpts::default())
             .await
             .map_err(color_eyre::eyre::Report::from)?;
-        Ok(())
+        let id: [u8; 32] = message_id
+            .as_slice()
+            .try_into()
+            .map_err(|_| eyre!("libxmtp returned non-32-byte message_id"))?;
+        Ok(Some(id))
     }
     .await;
     let (status, error) = match outcome {
-        Ok(_) => (Status::Pass, None),
+        Ok(Some(id)) => {
+            ctx.record_message(gid, id, client);
+            (Status::Pass, None)
+        }
+        Ok(None) => (Status::Pass, None),
         Err(e) => (Status::Fail, Some(e)),
     };
     OpResult {
@@ -57,11 +74,11 @@ impl HealthOp for SendMessage {
             // is by design — see AddMembersToNewGroup.
             if !ctx.is_transient(&client) {
                 for gid in &ctx.existing_groups {
-                    out.push(send_one(self.name(), &client, gid).await);
+                    out.push(send_one(self.name(), ctx, &client, gid).await);
                 }
             }
             for gid in &ctx.new_groups {
-                out.push(send_one(self.name(), &client, gid).await);
+                out.push(send_one(self.name(), ctx, &client, gid).await);
             }
         }
         out

--- a/apps/xmtp_debug/src/app/health/validators/no_forks.rs
+++ b/apps/xmtp_debug/src/app/health/validators/no_forks.rs
@@ -12,7 +12,6 @@ use async_trait::async_trait;
 use color_eyre::eyre::eyre;
 use std::time::Instant;
 use xmtp_db::prelude::QueryGroup;
-use xmtp_proto::types::GroupId;
 
 pub struct NoForkedGroups;
 
@@ -30,25 +29,20 @@ impl Validator for NoForkedGroups {
     async fn validate(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
         let mut out = Vec::new();
         for client in ctx.all_clients() {
-            let is_transient = ctx.is_transient(&client);
             let db = client.db();
-            // Transient is only added to new_groups (see AddMembersToNewGroup);
-            // skip existing_groups for transient.
-            let check = |gid: &GroupId, out: &mut Vec<OpResult>| {
-                let start = Instant::now();
-                // Transient may have its group row purged on LeaveGroup
-                // depending on libxmtp version — skip with a debug log so
-                // unexpected non-leave errors don't slip past silently.
-                if is_transient && let Err(e) = client.group(gid.as_slice()) {
-                    tracing::debug!(
-                        target: "healthcheck",
-                        inbox = client.inbox_id(),
-                        group = %gid,
-                        error = %e,
-                        "skip fork check: transient missing group locally",
-                    );
-                    return;
+            for gid in ctx.all_groups() {
+                // Skip clients that aren't active members. A removed
+                // client's frozen local commit-log diverges from the
+                // live one by design; that's not a fork worth flagging.
+                let is_active = client
+                    .group(gid.as_slice())
+                    .ok()
+                    .and_then(|g| g.is_active().ok())
+                    .unwrap_or(false);
+                if !is_active {
+                    continue;
                 }
+                let start = Instant::now();
                 let (status, error) = match db.get_group_commit_log_forked_status(gid) {
                     Ok(Some(true)) => (Status::Fail, Some(eyre!("group forked"))),
                     Ok(_) => (Status::Pass, None),
@@ -61,14 +55,6 @@ impl Validator for NoForkedGroups {
                     duration: start.elapsed(),
                     error,
                 });
-            };
-            if !is_transient {
-                for gid in &ctx.existing_groups {
-                    check(gid, &mut out);
-                }
-            }
-            for gid in &ctx.new_groups {
-                check(gid, &mut out);
             }
         }
         out

--- a/apps/xmtp_debug/src/app/health/validators/no_missing_messages.rs
+++ b/apps/xmtp_debug/src/app/health/validators/no_missing_messages.rs
@@ -1,27 +1,15 @@
-//! Validator: every client must have every message every other client has,
-//! filtered by the join-time floor (messages sent before a client joined a
-//! group are not expected to be present on that client).
+//! Validator: every active member of a group must have every message that
+//! redb's `MessageStore` recorded for that group. Cross-version,
+//! authoritative — independent of any single client's local libxmtp DB.
 
 use crate::app::health::context::HealthContext;
 use crate::app::health::result::{OpResult, Status};
 use crate::app::health::validators::Validator;
 use async_trait::async_trait;
 use color_eyre::eyre::eyre;
-use std::collections::{HashMap, HashSet};
 use std::time::Instant;
 use xmtp_db::group::QueryGroup;
-use xmtp_db::group_message::MsgQueryArgs;
 use xmtp_db::prelude::QueryGroupMessage;
-
-/// Per-(client, group) state cached while inspecting a single group.
-struct ClientGroupState {
-    inbox: String,
-    /// Sequence_ids this client has stored locally for this group.
-    seqs: HashSet<i64>,
-    /// Authoritative join time: `StoredGroup::created_at_ns` (the welcome
-    /// timestamp for invited members, group creation for the creator).
-    join_at_ns: i64,
-}
 
 pub struct NoMissingMessages;
 
@@ -39,107 +27,131 @@ impl Validator for NoMissingMessages {
     async fn validate(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
         let mut out = Vec::new();
         let clients = ctx.all_clients();
+        // Load everything once — `recorded_messages` per-group would
+        // rescan the whole network per iteration.
+        let by_group = ctx.recorded_messages_by_group();
 
+        // Collect every (client, group, active_mls_group) we'll inspect.
+        // Inactive clients (left/removed) aren't held to convergence.
+        let mut pairs = Vec::new();
         for group_id in ctx.all_groups() {
-            // Members of this group only — skip clients that aren't part of it.
-            let mut per_client: Vec<ClientGroupState> = Vec::new();
-            // Authoritative seq → sent_at_ns map across every member's
-            // local store. Built once, consulted by every per-client diff.
-            let mut sent_at: HashMap<i64, i64> = HashMap::new();
-
+            let Some(expected) = by_group.get(group_id) else {
+                continue;
+            };
+            if expected.is_empty() {
+                continue;
+            }
             for client in &clients {
-                let db = client.db();
-                let stored = match db.find_group(group_id) {
-                    Ok(Some(g)) => g,
-                    Ok(None) => continue,
-                    Err(e) => {
-                        tracing::warn!(
-                            target: "healthcheck",
-                            inbox = client.inbox_id(),
-                            group = %group_id,
-                            error = %e,
-                            "skipping client/group: find_group failed",
-                        );
-                        continue;
-                    }
+                let Ok(mls_group) = client.group(group_id.as_slice()) else {
+                    continue;
                 };
-                // Skip clients that left or were removed: their local view
-                // is intentionally frozen at the moment of removal and will
-                // not see post-removal commits. The MLS group's
-                // `is_active()` returns false for those clients.
-                let active = client
-                    .group(group_id.as_slice())
-                    .ok()
-                    .and_then(|g| g.is_active().ok())
-                    .unwrap_or(false);
-                if !active {
+                if !mls_group.is_active().unwrap_or(false) {
+                    continue;
+                }
+                pairs.push((client.clone(), group_id, mls_group, expected));
+            }
+        }
+
+        // Pre-sync every pair in parallel so we don't false-positive on
+        // commits that haven't reached the local DB yet (own sends and
+        // concurrent peer sends both qualify).
+        futures::future::join_all(pairs.iter().map(
+            |(client, group_id, mls_group, _)| async move {
+                if let Err(e) = mls_group.sync_with_conn().await {
                     tracing::debug!(
                         target: "healthcheck",
                         inbox = client.inbox_id(),
                         group = %group_id,
-                        "skipping inactive client (left or removed)",
+                        error = %e,
+                        "sync_with_conn before NoMissingMessages check failed",
+                    );
+                }
+            },
+        ))
+        .await;
+
+        for (client, group_id, _mls_group, expected) in &pairs {
+            let start = Instant::now();
+            let db = client.db();
+            // Authoritative join floor: messages older than the group's
+            // local `created_at_ns` were sent before this client joined
+            // and aren't expected to appear in their store.
+            let join_at_ns = match db.find_group(group_id) {
+                Ok(Some(g)) => g.created_at_ns,
+                Ok(None) => {
+                    tracing::debug!(
+                        target: "healthcheck",
+                        inbox = client.inbox_id(),
+                        group = %group_id,
+                        "skipping NoMissingMessages: client has no local group row",
                     );
                     continue;
                 }
-                let msgs = match db.get_group_messages(group_id, &MsgQueryArgs::default()) {
-                    Ok(m) => m,
+                Err(e) => {
+                    tracing::warn!(
+                        target: "healthcheck",
+                        inbox = client.inbox_id(),
+                        group = %group_id,
+                        error = %e,
+                        "find_group failed; skipping client/group",
+                    );
+                    continue;
+                }
+            };
+
+            let mut expected_after_join = 0usize;
+            let mut missing = 0usize;
+            for msg in *expected {
+                if msg.sent_at_ns < join_at_ns {
+                    continue;
+                }
+                expected_after_join += 1;
+                match db.get_group_message(msg.id) {
+                    Ok(Some(_)) => {}
+                    Ok(None) => {
+                        missing += 1;
+                        tracing::warn!(
+                            target: "healthcheck",
+                            inbox = client.inbox_id(),
+                            group = %group_id,
+                            message_id = %hex::encode(msg.id),
+                            sender = %hex::encode(msg.sender_inbox_id),
+                            sent_at_ns = msg.sent_at_ns,
+                            recorded_by_version = %msg.xdbg_version,
+                            "missing recorded message in local DB",
+                        );
+                    }
                     Err(e) => {
                         tracing::warn!(
                             target: "healthcheck",
                             inbox = client.inbox_id(),
                             group = %group_id,
                             error = %e,
-                            "skipping client/group: get_group_messages failed",
+                            message_id = %hex::encode(msg.id),
+                            "get_group_message error; counting as missing",
                         );
-                        continue;
+                        missing += 1;
                     }
-                };
-                let mut seqs = HashSet::new();
-                for m in msgs {
-                    seqs.insert(m.sequence_id);
-                    // First writer wins — sent_at_ns is invariant per seq.
-                    sent_at.entry(m.sequence_id).or_insert(m.sent_at_ns);
                 }
-                per_client.push(ClientGroupState {
-                    inbox: client.inbox_id().to_string(),
-                    seqs,
-                    join_at_ns: stored.created_at_ns,
-                });
             }
 
-            // Union of every member's seqs. A client is missing seq `s` iff
-            // `s ∈ global_union \ client.seqs` AND `sent_at[s] >= client.join_at_ns`.
-            let global_union: HashSet<i64> = per_client
-                .iter()
-                .flat_map(|s| s.seqs.iter().copied())
-                .collect();
-
-            for state in &per_client {
-                let start = Instant::now();
-                let missing_count = global_union
-                    .difference(&state.seqs)
-                    .filter(|seq| match sent_at.get(seq) {
-                        Some(&ts) => ts >= state.join_at_ns,
-                        None => false,
-                    })
-                    .count();
-
-                let (status, error) = if missing_count == 0 {
-                    (Status::Pass, None)
-                } else {
-                    (
-                        Status::Fail,
-                        Some(eyre!("{missing_count} missing messages")),
-                    )
-                };
-                out.push(OpResult {
-                    op_name: self.name(),
-                    target: Some(format!("inbox={} group={group_id}", state.inbox)),
-                    status,
-                    duration: start.elapsed(),
-                    error,
-                });
-            }
+            let (status, error) = if missing == 0 {
+                (Status::Pass, None)
+            } else {
+                (
+                    Status::Fail,
+                    Some(eyre!(
+                        "{missing}/{expected_after_join} expected messages missing"
+                    )),
+                )
+            };
+            out.push(OpResult {
+                op_name: self.name(),
+                target: Some(format!("inbox={} group={group_id}", client.inbox_id())),
+                status,
+                duration: start.elapsed(),
+                error,
+            });
         }
         out
     }

--- a/apps/xmtp_debug/src/app/info.rs
+++ b/apps/xmtp_debug/src/app/info.rs
@@ -51,7 +51,7 @@ impl Info {
         info!(
             metadata.identities,
             metadata.groups,
-            // metadata.messages,
+            metadata.messages,
             project = crate::app::App::data_directory()?.as_value(),
             sqlite = sqlite_stores.as_value(),
             sqlite_size = %format!("{db_dir_size}MB"),

--- a/apps/xmtp_debug/src/app/store.rs
+++ b/apps/xmtp_debug/src/app/store.rs
@@ -1,5 +1,6 @@
 mod groups;
 mod identity;
+mod messages;
 mod metadata;
 
 use std::{borrow::Borrow, sync::Arc};
@@ -11,6 +12,7 @@ use speedy::{Readable, Writable};
 
 pub use groups::*;
 pub use identity::*;
+pub use messages::*;
 pub use metadata::*;
 
 #[derive(Debug, Copy, Clone)]
@@ -505,6 +507,15 @@ impl<'a: 'b, 'b> From<IdentityStore<'a>> for MetadataStore<'b> {
 
 impl<'a: 'b, 'b> From<GroupStore<'a>> for MetadataStore<'b> {
     fn from(store: GroupStore<'a>) -> MetadataStore<'b> {
+        MetadataStore {
+            db: store.db,
+            store: MetadataStorage,
+        }
+    }
+}
+
+impl<'a: 'b, 'b> From<MessageStore<'a>> for MetadataStore<'b> {
+    fn from(store: MessageStore<'a>) -> MetadataStore<'b> {
         MetadataStore {
             db: store.db,
             store: MetadataStorage,

--- a/apps/xmtp_debug/src/app/store/messages.rs
+++ b/apps/xmtp_debug/src/app/store/messages.rs
@@ -1,0 +1,170 @@
+//! Messages storage table
+use color_eyre::eyre::Result;
+use redb::TableDefinition;
+use std::sync::Arc;
+
+use crate::{app::types::*, constants::STORAGE_PREFIX};
+
+use super::{Database, MetadataStore};
+
+pub const MODULE: &str = "messages";
+pub const VERSION: u16 = 1;
+pub const NAMESPACE: &str = const_format::concatcp!(STORAGE_PREFIX, ":", VERSION, "//", MODULE);
+
+/// Mapping of [`MessageKey`] to a serialized [`Message`].
+const TABLE: TableDefinition<MessageKey, Message> = TableDefinition::new(NAMESPACE);
+
+/// Composite key: `(network, group_id ++ message_id)`. The 48-byte payload
+/// places `group_id` first so a range scan over `(network, group || 0x00…)
+/// ..= (network, group || 0xFF…)` returns exactly that group's messages.
+pub type MessageKey = super::NetworkKey<48>;
+
+impl super::DeriveKey<MessageKey> for Message {
+    fn key(&self, network: u64) -> MessageKey {
+        let mut combined = [0u8; 48];
+        combined[..16].copy_from_slice(&self.group_id);
+        combined[16..].copy_from_slice(&self.id);
+        MessageKey::new(network, combined)
+    }
+}
+
+impl super::DeriveKey<MessageKey> for &Message {
+    fn key(&self, network: u64) -> MessageKey {
+        let mut combined = [0u8; 48];
+        combined[..16].copy_from_slice(&self.group_id);
+        combined[16..].copy_from_slice(&self.id);
+        MessageKey::new(network, combined)
+    }
+}
+
+pub type MessageStore<'a> = super::KeyValueStore<'a, MessageStorage>;
+
+impl From<Arc<redb::Database>> for MessageStore<'_> {
+    fn from(value: Arc<redb::Database>) -> Self {
+        MessageStore {
+            db: super::DatabaseOrTransaction::Db(value),
+            store: MessageStorage,
+        }
+    }
+}
+
+impl From<Arc<redb::ReadOnlyDatabase>> for MessageStore<'_> {
+    fn from(value: Arc<redb::ReadOnlyDatabase>) -> Self {
+        MessageStore {
+            db: super::DatabaseOrTransaction::ReadOnly(value),
+            store: MessageStorage,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MessageStorage;
+
+impl<'a> super::TableProvider<'a, MessageKey, Message> for MessageStorage {
+    fn table() -> TableDefinition<'a, MessageKey, Message> {
+        TABLE
+    }
+}
+
+impl super::TrackMetadata for MessageStorage {
+    fn increment<'a>(
+        &self,
+        store: impl Into<MetadataStore<'a>>,
+        network: u64,
+        n: u32,
+    ) -> Result<()> {
+        let store = store.into();
+        store.modify(crate::meta_key!(network), |meta| meta.messages += n)?;
+        Ok(())
+    }
+
+    fn decrement<'a>(
+        &self,
+        store: impl Into<MetadataStore<'a>>,
+        network: u64,
+        n: u32,
+    ) -> Result<()> {
+        let store = store.into();
+        store.modify(crate::meta_key!(network), |meta| meta.messages -= n)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::store::Database;
+    use std::sync::Arc;
+    use tempfile::NamedTempFile;
+
+    fn open_temp_db() -> (Arc<redb::Database>, NamedTempFile) {
+        let tmp = NamedTempFile::new().expect("tempfile");
+        let db = redb::Database::create(tmp.path()).expect("open redb");
+        (Arc::new(db), tmp)
+    }
+
+    fn sample_message(group: [u8; 16], msg_id: [u8; 32]) -> Message {
+        Message {
+            id: msg_id,
+            group_id: group,
+            sender_inbox_id: [1u8; 32],
+            sent_at_ns: 42,
+            op_run_id: [2u8; 16],
+            xdbg_version: "test".to_string(),
+        }
+    }
+
+    #[test]
+    fn message_store_set_then_get_roundtrips() {
+        let (db, _tmp) = open_temp_db();
+        let store: MessageStore<'static> = db.into();
+        let msg = sample_message([0xAAu8; 16], [0xBBu8; 32]);
+
+        store.set(msg.clone(), 1u64).expect("set");
+
+        let key = <Message as super::super::DeriveKey<MessageKey>>::key(&msg, 1);
+        let got = store.get(key).expect("get");
+        assert_eq!(got, Some(msg));
+    }
+
+    #[test]
+    fn message_store_load_returns_all_messages_for_network() {
+        let (db, _tmp) = open_temp_db();
+        let store: MessageStore<'static> = db.into();
+        let m1 = sample_message([0x10u8; 16], [0x01u8; 32]);
+        let m2 = sample_message([0x20u8; 16], [0x02u8; 32]);
+        let m3 = sample_message([0x20u8; 16], [0x03u8; 32]);
+
+        store
+            .set_all(&[m1.clone(), m2.clone(), m3.clone()], 7u64)
+            .expect("set_all");
+
+        let iter = store.load(7u64).expect("load").expect("non-empty");
+        let collected: Vec<Message> = iter.map(|g| g.value()).collect();
+        assert_eq!(collected.len(), 3);
+    }
+
+    #[test]
+    fn message_store_load_then_filter_by_group_id() {
+        let (db, _tmp) = open_temp_db();
+        let store: MessageStore<'static> = db.into();
+        let group_a = [0x10u8; 16];
+        let group_b = [0x20u8; 16];
+        let a1 = sample_message(group_a, [0x01u8; 32]);
+        let a2 = sample_message(group_a, [0x02u8; 32]);
+        let b1 = sample_message(group_b, [0x03u8; 32]);
+        store
+            .set_all(&[a1.clone(), a2.clone(), b1.clone()], 7u64)
+            .expect("set_all");
+
+        let iter = store.load(7u64).expect("load").expect("non-empty");
+        let only_a: Vec<Message> = iter
+            .map(|g| g.value())
+            .filter(|m| m.group_id == group_a)
+            .collect();
+        assert_eq!(only_a.len(), 2);
+        assert!(only_a.contains(&a1));
+        assert!(only_a.contains(&a2));
+        assert!(!only_a.contains(&b1));
+    }
+}

--- a/apps/xmtp_debug/src/app/types.rs
+++ b/apps/xmtp_debug/src/app/types.rs
@@ -5,7 +5,7 @@ use alloy::signers::local::PrivateKeySigner;
 use color_eyre::eyre::{self, Result};
 use ecdsa::SigningKey;
 use openmls::{credentials::BasicCredential, prelude::Credential};
-use prost::Message;
+use prost::Message as _;
 use speedy::{Readable, Writable};
 
 use xmtp_cryptography::XmtpInstallationCredential;
@@ -227,5 +227,111 @@ impl redb::Value for Group {
 
     fn type_name() -> redb::TypeName {
         redb::TypeName::new("group")
+    }
+}
+
+/// Message recorded for a single healthcheck `SendMessage` op.
+/// Persisted to redb so the `NoMissingMessages` validator has an
+/// authoritative source of truth across runs and versions.
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Readable, Writable)]
+pub struct Message {
+    /// MLS message id (sha-256-derived hash from libxmtp's
+    /// `calculate_message_id`). Always 32 bytes — runtime-asserted at
+    /// the call site of `record_message`.
+    pub id: [u8; 32],
+    /// Group this message belongs to.
+    pub group_id: [u8; 16],
+    /// Sender's inbox_id (32-byte form, same convention as `Identity`).
+    pub sender_inbox_id: InboxId,
+    /// Wall-clock at the sending op's call site. libxmtp doesn't surface
+    /// its internal envelope timestamp at `send_message` return, so this
+    /// is best-effort for diagnostics. Not used by the validator.
+    pub sent_at_ns: i64,
+    /// UUID of the healthcheck run that sent this message.
+    pub op_run_id: [u8; 16],
+    /// `crate::get_version()` output of the sending xdbg binary.
+    pub xdbg_version: String,
+}
+
+impl std::fmt::Display for Message {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", hex::encode(self.id))
+    }
+}
+
+impl redb::Value for Message {
+    type SelfType<'a>
+        = Message
+    where
+        Self: 'a;
+
+    type AsBytes<'a>
+        = Vec<u8>
+    where
+        Self: 'a;
+
+    fn fixed_width() -> Option<usize> {
+        None
+    }
+
+    fn from_bytes<'a>(data: &'a [u8]) -> Self::SelfType<'a>
+    where
+        Self: 'a,
+    {
+        Message::read_from_buffer(data).unwrap()
+    }
+
+    fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> Self::AsBytes<'a>
+    where
+        Self: 'a,
+        Self: 'b,
+    {
+        value.write_to_vec().unwrap()
+    }
+
+    fn type_name() -> redb::TypeName {
+        redb::TypeName::new("message")
+    }
+}
+
+#[cfg(test)]
+mod message_tests {
+    use super::*;
+
+    #[test]
+    fn message_speedy_roundtrip() {
+        let msg = Message {
+            id: [7u8; 32],
+            group_id: [3u8; 16],
+            sender_inbox_id: [9u8; 32],
+            sent_at_ns: 1_700_000_000_000_000_000,
+            op_run_id: [42u8; 16],
+            xdbg_version: "1.10.0-abcdefg".to_string(),
+        };
+        let bytes = msg.write_to_vec().unwrap();
+        let decoded = Message::read_from_buffer(&bytes).unwrap();
+        assert_eq!(msg, decoded);
+    }
+
+    use crate::app::store::DeriveKey;
+    use crate::app::store::MessageKey;
+
+    #[test]
+    fn message_derive_key_composes_group_and_message_id() {
+        let msg = Message {
+            id: [0xAAu8; 32],
+            group_id: [0xBBu8; 16],
+            sender_inbox_id: [0u8; 32],
+            sent_at_ns: 0,
+            op_run_id: [0u8; 16],
+            xdbg_version: String::new(),
+        };
+        let key: MessageKey = msg.key(7);
+        // u64 network (8 bytes, LE) + 48-byte combined key.
+        let bytes = speedy::Writable::write_to_vec(&key).unwrap();
+        assert_eq!(bytes.len(), 8 + 48);
+        assert_eq!(&bytes[0..8], &7u64.to_le_bytes());
+        assert_eq!(&bytes[8..24], &[0xBBu8; 16]);
+        assert_eq!(&bytes[24..56], &[0xAAu8; 32]);
     }
 }

--- a/crates/xmtp-workspace-hack/Cargo.toml
+++ b/crates/xmtp-workspace-hack/Cargo.toml
@@ -55,7 +55,7 @@ hpke-rs = { version = "0.6", features = ["hazmat", "libcrux", "serialization"] }
 hyper = { version = "1", features = ["http1", "http2", "server"] }
 idna = { version = "1" }
 indexmap = { version = "2", features = ["serde"] }
-itertools = { version = "0.13" }
+itertools = { version = "0.14" }
 k256 = { version = "0.13", default-features = false, features = ["ecdh", "ecdsa", "std"] }
 libcrux-ed25519 = { version = "0.0.7", default-features = false, features = ["rand"] }
 log = { version = "0.4", default-features = false, features = ["std"] }
@@ -147,7 +147,7 @@ hpke-rs = { version = "0.6", features = ["hazmat", "libcrux", "serialization"] }
 hyper = { version = "1", features = ["http1", "http2", "server"] }
 idna = { version = "1" }
 indexmap = { version = "2", features = ["serde"] }
-itertools = { version = "0.13" }
+itertools = { version = "0.14" }
 k256 = { version = "0.13", default-features = false, features = ["ecdh", "ecdsa", "std"] }
 libcrux-ed25519 = { version = "0.0.7", default-features = false, features = ["rand"] }
 log = { version = "0.4", default-features = false, features = ["std"] }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Rewrite `NoMissingMessages` validator to use redb as source of truth
- Introduces a `MessageStore` backed by redb in [messages.rs](https://github.com/xmtp/libxmtp/pull/3640/files#diff-e33ce6de4314a233f1d058d7e89a96f9bfdc73c76ed780f35fd8e4e7300f98fa) with a composite key of `(network, group_id || message_id)`, plus a `Message` type with serialization support.
- `SendMessage` and `GenerateMessages` now record each successfully sent message to `MessageStore` with run ID, sender, timestamp, and binary version.
- `NoMissingMessages` validator replaces local sequence union comparison with a lookup against redb-recorded message IDs per group, filtered by each client's join time.
- `HealthContext` drops its shared transient identity; `LeaveGroup` and `RemoveMember` now create fresh transient clients within their own ops instead.
- Bumps the `redb` dependency from 3.1 to 4.1.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 96da6b6.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->