### PR TITLE
Read min group version from incoming app data proposal post migration

### DIFF
--- a/crates/xmtp_mls/src/groups/app_data/component_source.rs
+++ b/crates/xmtp_mls/src/groups/app_data/component_source.rs
@@ -33,7 +33,7 @@
 
 use openmls::{
     extensions::Extensions,
-    group::{GroupContext, MlsGroup as OpenMlsGroup},
+    group::{GroupContext, MlsGroup as OpenMlsGroup, StagedCommit},
     messages::proposals::AppDataUpdateOperation,
 };
 use tls_codec::{Deserialize, Serialize};
@@ -352,6 +352,102 @@ pub(crate) fn read_component_bytes(
     } else {
         read_from_legacy(id, mls_group.extensions())
     }
+}
+
+/// Compute the post-commit value of a single component on a migrated group
+/// by overlaying the staged commit's `AppDataUpdate` proposals on top of
+/// the pre-commit dict. Last-write-wins matches the lazy-batching apply
+/// order in [`super::accumulate_app_data_updates`]: every `Update(payload)`
+/// is decoded against the running value (so collection deltas compose),
+/// and `Remove` collapses to `None`.
+///
+/// Returns `Ok(None)` when the component is absent both before and after
+/// the commit, or when it was explicitly removed. Returns `Err` only when
+/// an `Update` payload fails to decode against the running value — the
+/// same condition `validate_app_data_update_proposals_in_commit` would
+/// also reject upstream, so callers can treat decode failure here as
+/// "validator will surface the real error" and short-circuit.
+///
+/// Used by the commit validator to evaluate per-component invariants
+/// (notably `MIN_SUPPORTED_PROTOCOL_VERSION`) that need the post-commit
+/// view on migrated groups, where the legacy `GroupMutableMetadata`
+/// extension diff that drives the same check on unmigrated groups is
+/// unavailable.
+///
+/// # Registry semantics
+///
+/// `registry` is the **pre-commit** `COMPONENT_REGISTRY` (i.e. the state
+/// of the dictionary entry before the staged commit applies). Callers
+/// should load it once via [`super::load_component_registry`] on the
+/// live `mls_group` and reuse it across all validator helpers — same
+/// registry feeds [`super::validate_app_data_update_proposals_in_commit`]
+/// and any other per-component checks.
+///
+/// **Implication for commits that modify `COMPONENT_REGISTRY` in the
+/// same commit as a write to a newly-registered component**: such a
+/// write fails with `UnknownComponent` here because the new entry is
+/// not yet visible in the pre-commit registry. This matches what the
+/// receiver-side validator
+/// ([`super::validate_app_data_update_proposals_in_commit`]) enforces
+/// today and is the documented convention across the migrated commit
+/// path: registry mutations and writes that depend on those mutations
+/// MUST land in separate commits.
+///
+/// The bootstrap commit is the only legitimate "register + write in
+/// the same commit" pattern and is routed through a dedicated
+/// validator ([`super::bootstrap_validator::validate_bootstrap_commit`])
+/// that does not flow through this function.
+pub(crate) fn read_post_commit_component_bytes(
+    id: ComponentId,
+    mls_group: &OpenMlsGroup,
+    staged_commit: &StagedCommit,
+    registry: &ComponentRegistry,
+) -> Result<Option<Vec<u8>>, ComponentSourceError> {
+    let openmls_id: openmls::component::ComponentId = id.as_u16();
+
+    // Owned snapshot of operations targeting this specific component.
+    // Iterating `app_data_update_proposals()` yields short-lived
+    // `QueuedAppDataUpdateProposal` views that borrow into the staged
+    // commit — we can't hold their byte slices across iterations, so
+    // we materialize an owned form up front. `Update` payloads are
+    // typically tiny (version strings, single-key deltas), so the
+    // clone cost is negligible.
+    enum Op {
+        Update(Vec<u8>),
+        Remove,
+    }
+    let ops: Vec<Op> = staged_commit
+        .app_data_update_proposals()
+        .filter_map(|queued| {
+            let proposal = queued.app_data_update_proposal();
+            if proposal.component_id() != openmls_id {
+                return None;
+            }
+            Some(match proposal.operation() {
+                AppDataUpdateOperation::Update(payload) => Op::Update(payload.as_slice().to_vec()),
+                AppDataUpdateOperation::Remove => Op::Remove,
+            })
+        })
+        .collect();
+    if ops.is_empty() {
+        return Ok(read_from_app_data_dict(id, mls_group));
+    }
+
+    let mut current = read_from_app_data_dict(id, mls_group);
+    for op in &ops {
+        match op {
+            Op::Update(payload) => {
+                current = Some(apply_app_data_update_payload(
+                    id,
+                    payload,
+                    current.as_deref(),
+                    registry,
+                )?);
+            }
+            Op::Remove => current = None,
+        }
+    }
+    Ok(current)
 }
 
 /// Look up the component's bytes in the OpenMLS AppData dictionary.

--- a/crates/xmtp_mls/src/groups/tests/test_proposals.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_proposals.rs
@@ -3562,3 +3562,94 @@ async fn test_welcome_on_migrated_group_pauses_below_min_version() {
          the floor lives only in the AppData dict at this point"
     );
 }
+
+/// XIP §3 steady-state pause path: when an already-migrated client bumps
+/// `MIN_SUPPORTED_PROTOCOL_VERSION` on an already-migrated group, the
+/// floor flows as an `AppDataUpdate(MIN_SUPPORTED_PROTOCOL_VERSION)`
+/// proposal carried inside a regular commit. The legacy GMM extension
+/// is gone post-bootstrap so the validator can't diff it — instead it
+/// must read the post-commit floor from the dict overlay (current dict
+/// + any staged AppDataUpdate proposals targeting the component) and
+/// raise `ProtocolVersionTooLow` against the receiver's pkg_version.
+/// `mls_sync` then writes `paused_for_version`.
+///
+/// Sibling of `test_welcome_on_migrated_group_pauses_below_min_version`
+/// (welcome-time pause) and `test_enable_proposals_pauses_old_client_via_legacy_gmm_bump`
+/// (pre-bootstrap legacy GMM bump). Pre-fix, the migrated branch of
+/// `ValidatedCommit::from_staged_commit` set
+/// `MutableMetadataValidationInfo::default()` unconditionally — so
+/// `minimum_supported_protocol_version` was always `None`, the
+/// validator's version arm never fired on migrated groups, and a
+/// below-floor receiver silently kept processing commits.
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_steady_state_pause_on_min_version_bump_via_app_data_update() {
+    use crate::groups::tests::increment_patch_version;
+
+    // Both alix and bo at the default pkg_version so both can apply the
+    // bootstrap commit cleanly. `enable_proposals`' step-A legacy GMM
+    // bump sets the floor to alix's pkg_version (== bo's pkg_version),
+    // so neither is paused by the legacy path, and both migrate.
+    tester!(alix);
+    tester!(bo);
+
+    let alix_group = alix.create_group(None, None)?;
+    alix_group
+        .add_members(&[bo.context.identity.inbox_id()])
+        .await?;
+
+    let bo_groups = bo.sync_welcomes().await?;
+    let bo_group = bo_groups
+        .iter()
+        .find(|g| g.group_id == alix_group.group_id)
+        .expect("bo should receive a welcome for alix_group");
+    bo_group.sync().await?;
+
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
+    bo_group.sync().await?;
+
+    for (label, group) in [("alix", &alix_group), ("bo", bo_group)] {
+        let migrated = group
+            .load_mls_group_with_lock_async(async |g| {
+                Ok::<bool, crate::groups::GroupError>(group.proposals_enabled(&g))
+            })
+            .await?;
+        assert!(migrated, "{label} must be migrated post-enable_proposals");
+        assert!(
+            group.paused_for_version()?.is_none(),
+            "{label} must not be paused after migration (test_default floor is 0.0.0)"
+        );
+    }
+
+    // Alix raises the floor above both members' pkg_version. On the
+    // migrated group this flows as an
+    // `AppDataUpdate(MIN_SUPPORTED_PROTOCOL_VERSION)` proposal inside a
+    // commit — the legacy GMM extension is gone, so the dict is the
+    // only path the floor can ride on. Alix's call may return Ok (her
+    // local sync resolves the intent before her validator re-applies
+    // the commit against the new floor) or Err (her local replay hits
+    // `ProtocolVersionTooLow` since her pkg_version is also below the
+    // new floor). Either way, the commit reaches the server. Log the
+    // error instead of swallowing it silently so a non-version-pause
+    // failure mode (network, intent rejection) would surface in test
+    // output if this assumption stopped holding.
+    let pkg = alix.version_info().pkg_version().to_string();
+    let bumped = increment_patch_version(&pkg).expect("patch bump");
+    if let Err(e) = alix_group.update_group_min_version(&bumped).await {
+        tracing::debug!(
+            "expected: alix's update_group_min_version surfaced an error \
+             (her pkg_version is below the new floor): {e}"
+        );
+    }
+
+    bo_group.sync().await?;
+    let paused = bo_group.paused_for_version()?;
+    assert_eq!(
+        paused.as_deref(),
+        Some(bumped.as_str()),
+        "bo must be paused at the new floor via the AppDataUpdate-driven path; \
+         post-bootstrap the legacy GMM extension is gone so the dict overlay is the \
+         only floor signal the validator can read"
+    );
+}

--- a/crates/xmtp_mls/src/groups/validated_commit.rs
+++ b/crates/xmtp_mls/src/groups/validated_commit.rs
@@ -439,24 +439,77 @@ impl ValidatedCommit {
         let proposals_enabled = super::check_proposals_enabled(existing_group_extensions);
         let new_group_extensions = staged_commit.group_context().extensions();
 
-        let metadata_validation_info = if is_migrated {
-            // On migrated groups, metadata changes flow as
-            // AppDataUpdate proposals — there is no legacy
-            // GroupMutableMetadata extension on either side to diff.
-            // Per-component policy enforcement happens through
-            // `validate_app_data_update_proposals_in_commit` below;
-            // character limits are enforced at the sender (host APIs
-            // like `update_group_name`) and via Component-level
-            // `validate_invariant` hooks. An empty struct is the
-            // correct "no legacy metadata changes" view.
-            MutableMetadataValidationInfo::default()
+        // On migrated groups, load the pre-commit COMPONENT_REGISTRY
+        // exactly once and thread it through both
+        // `read_post_commit_component_bytes` (here) and
+        // `validate_app_data_update_proposals_in_commit` (further
+        // down). This collapses two independent dict reads on every
+        // migrated-commit validation into one.
+        //
+        // Pre-commit semantics are the documented convention across
+        // the migrated commit path — see the doc on
+        // `read_post_commit_component_bytes` for the full statement
+        // and the bootstrap-commit carve-out.
+        //
+        // On migrated groups, metadata changes flow as AppDataUpdate
+        // proposals — there is no legacy GroupMutableMetadata
+        // extension on either side to diff. Per-component policy
+        // enforcement happens through
+        // `validate_app_data_update_proposals_in_commit` below;
+        // character limits are enforced at the sender (host APIs like
+        // `update_group_name`) and via Component-level
+        // `validate_invariant` hooks. An empty struct is the correct
+        // "no legacy metadata changes" view — *except* for
+        // `MIN_SUPPORTED_PROTOCOL_VERSION`, where the validator below
+        // relies on the post-commit floor being surfaced so old
+        // clients reject commits raising the floor above their
+        // pkg_version. Compute it capability-aware: pre-commit dict
+        // overlaid with any `AppDataUpdate(MIN_SUPPORTED_PROTOCOL_VERSION)`
+        // proposals carried by the staged commit, last-write-wins.
+        // Mirrors the unmigrated branch's reliance on
+        // `extract_metadata_changes` returning the new GMM attribute
+        // even when nothing else changed.
+        let (metadata_validation_info, migrated_registry) = if is_migrated {
+            let registry = super::app_data::load_component_registry(openmls_group)
+                .map_err(GroupMutableMetadataError::from)?;
+            let min_version_bytes =
+                super::app_data::component_source::read_post_commit_component_bytes(
+                    xmtp_mls_common::app_data::component_id::ComponentId::MIN_SUPPORTED_PROTOCOL_VERSION,
+                    openmls_group,
+                    staged_commit,
+                    &registry,
+                )
+                .map_err(xmtp_mls_common::group_mutable_metadata::GroupMutableMetadataError::from)?;
+            let minimum_supported_protocol_version = match min_version_bytes {
+                Some(bytes) => Some(String::from_utf8(bytes).map_err(|e| {
+                    CommitValidationError::GroupMutableMetadata(
+                        GroupMutableMetadataError::MalformedComponent {
+                            component_id: Some(
+                                xmtp_mls_common::app_data::component_id::ComponentId::MIN_SUPPORTED_PROTOCOL_VERSION,
+                            ),
+                            reason: format!("invalid utf-8: {e}"),
+                        },
+                    )
+                })?),
+                None => None,
+            };
+            (
+                MutableMetadataValidationInfo {
+                    minimum_supported_protocol_version,
+                    ..Default::default()
+                },
+                Some(registry),
+            )
         } else {
-            extract_metadata_changes(
-                &immutable_metadata,
-                &mutable_metadata,
-                existing_group_extensions,
-                new_group_extensions,
-            )?
+            (
+                extract_metadata_changes(
+                    &immutable_metadata,
+                    &mutable_metadata,
+                    existing_group_extensions,
+                    new_group_extensions,
+                )?,
+                None,
+            )
         };
 
         // Enforce character limits for specific metadata fields
@@ -532,6 +585,7 @@ impl ValidatedCommit {
             openmls_group,
             &immutable_metadata,
             &mutable_metadata,
+            migrated_registry.as_ref(),
         )?;
 
         // Get the installations actually added and removed in the commit
@@ -1368,11 +1422,32 @@ pub(super) fn app_data_update_proposer_leaf(
 /// Delegates the per-proposal permission check to
 /// [`validate_one_app_data_update`] so the core logic stays shared with
 /// the standalone-proposal path in [`validate_proposal`].
+///
+/// # Registry semantics
+///
+/// `preloaded_registry`, when `Some`, is the **pre-commit**
+/// `COMPONENT_REGISTRY` — the same view used by
+/// [`super::app_data::component_source::read_post_commit_component_bytes`]
+/// and any other per-component check on this commit. Pre-commit (not
+/// post-commit) is the documented convention across the migrated commit
+/// path: registry mutations and writes that depend on those mutations
+/// MUST land in separate commits. Bootstrap commits are the only
+/// "register + write in the same commit" legitimate pattern and route
+/// through a dedicated validator instead.
+///
+/// `None` defers the registry load to this function, which only
+/// materializes it lazily after a peek confirms at least one
+/// `AppDataUpdate` proposal exists. The split lets the caller share a
+/// single registry across this helper and
+/// `read_post_commit_component_bytes` on the migrated branch, while
+/// unmigrated callers (or commits with zero `AppDataUpdate` proposals)
+/// pay zero load cost.
 fn validate_app_data_update_proposals_in_commit(
     staged_commit: &StagedCommit,
     openmls_group: &OpenMlsGroup,
     immutable_metadata: &GroupMetadata,
     mutable_metadata: &GroupMutableMetadata,
+    preloaded_registry: Option<&xmtp_mls_common::app_data::component_registry::ComponentRegistry>,
 ) -> Result<(), CommitValidationError> {
     use super::app_data::load_component_registry;
     use std::collections::HashMap;
@@ -1395,7 +1470,18 @@ fn validate_app_data_update_proposals_in_commit(
         return Ok(());
     }
 
-    let registry = load_component_registry(openmls_group)?;
+    // Use the caller's pre-loaded registry when available; otherwise
+    // load lazily. `owned_registry` keeps the loaded value alive for
+    // the `registry` borrow.
+    let owned_registry;
+    let registry = match preloaded_registry {
+        Some(r) => r,
+        None => {
+            owned_registry = load_component_registry(openmls_group)?;
+            &owned_registry
+        }
+    };
+
     // A single commit's bootstrap can carry multiple AppDataUpdate proposals
     // from the same leaf; cache extracted `CommitParticipant`s so we don't
     // re-walk the admin lists and re-parse the credential for every one.
@@ -1422,7 +1508,7 @@ fn validate_app_data_update_proposals_in_commit(
             app_data.operation(),
             ActorAuthority::from(proposer),
             &proposer.inbox_id,
-            &registry,
+            registry,
             openmls_group,
         )?;
     }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Read min group version from AppData proposals post migration in commit validation
- On migrated groups, `ValidatedCommit::from_staged_commit` now computes `minimum_supported_protocol_version` by applying staged `AppDataUpdate` proposals over the pre-commit AppData dict using the new `read_post_commit_component_bytes` helper in [component_source.rs](https://github.com/xmtp/libxmtp/pull/3643/files#diff-47acce7b46d2cc4f9669dd42120ee90e488ceb0b15817b67b7757e631b05d113).
- The pre-commit `ComponentRegistry` is loaded once and reused across both post-commit component reads and `validate_app_data_update_proposals_in_commit`, avoiding duplicate loads.
- Risk: Invalid UTF-8 in the `MIN_SUPPORTED_PROTOCOL_VERSION` component now causes commit validation to fail with a `MalformedComponent` error rather than being silently ignored.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 84c4817.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->