### PR TITLE
Use semver crate to parse min version instead of bespoke impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14629,6 +14629,7 @@ dependencies = [
  "reqwest 0.13.3",
  "rstest",
  "rstest_reuse",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,7 @@ reqwest = { version = "0.13.2", default-features = false, features = [
 rstest = "0.26"
 rstest_reuse = "0.7.0"
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
+semver = "1.0"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-wasm-bindgen = "0.6.5"
 serde_bytes = "0.11"

--- a/crates/xmtp_mls/Cargo.toml
+++ b/crates/xmtp_mls/Cargo.toml
@@ -78,6 +78,7 @@ pin-project.workspace = true
 prost = { workspace = true, features = ["derive"] }
 rand.workspace = true
 reqwest.workspace = true
+semver.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/xmtp_mls/src/groups/mod.rs
+++ b/crates/xmtp_mls/src/groups/mod.rs
@@ -1799,10 +1799,12 @@ where
     /// * `version` - The libxmtp version to update the group min version to.
     ///   This is a semver-formatted string matching the Cargo.toml in the
     ///   libxmtp dependency, and does not match mobile or web release versions.
-    ///   Do NOT include pre-release metadata like "1.0.0-alpha",
-    ///   "1.0.0-beta", etc, as the version comparison may not match what
-    ///   is expected. For historical reasons, "1.0.0-alpha" is considered to be
-    ///   > "1.0.0", so it is better to just specify "1.0.0".
+    ///   Comparison is done via the [`semver`] crate's `Ord` impl, so
+    ///   pre-release identifiers (e.g. `"1.0.0-rc.1"`) sort BEFORE the
+    ///   corresponding release (`"1.0.0"`) per semver 2.0 §11. Build
+    ///   metadata (`+...`) parses but is included in ordering by the
+    ///   semver crate — avoid passing it unless you understand the
+    ///   total-ordering implication.
     ///
     /// # Returns
     /// A `Result` indicating success or failure of the operation.

--- a/crates/xmtp_mls/src/groups/tests/test_libxmtp_version.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_libxmtp_version.rs
@@ -7,19 +7,15 @@ fn test_parse_and_compare_basic_versions() {
     let v1_1_0 = LibXMTPVersion::parse("1.1.0").unwrap();
     let v2_0_0 = LibXMTPVersion::parse("2.0.0").unwrap();
 
-    // Test patch version comparison
     assert!(v1_0_0 < v1_0_1);
     assert!(v1_0_1 > v1_0_0);
 
-    // Test minor version comparison
     assert!(v1_0_1 < v1_1_0);
     assert!(v1_1_0 > v1_0_1);
 
-    // Test major version comparison
     assert!(v1_1_0 < v2_0_0);
     assert!(v2_0_0 > v1_1_0);
 
-    // Test equality
     let v1_0_0_dup = LibXMTPVersion::parse("1.0.0").unwrap();
     assert_eq!(v1_0_0, v1_0_0_dup);
 }
@@ -32,17 +28,18 @@ fn test_parse_and_compare_with_suffixes() {
     let v1_0_0_rc1 = LibXMTPVersion::parse("1.0.0-rc1").unwrap();
     let v1_0_1_alpha = LibXMTPVersion::parse("1.0.1-alpha").unwrap();
 
-    // Versions with suffixes compare lexicographically by suffix after version parts
+    // Pre-release identifiers compare alphabetically when non-numeric.
     assert!(v1_0_0_alpha < v1_0_0_beta);
     assert!(v1_0_0_beta < v1_0_0_rc1);
 
-    // Version without suffix (None) is less than version with suffix (Some)
-    // because None < Some in Rust's default Ord implementation
-    // NOTE: this does not match semver comparison
-    assert!(v1_0_0 < v1_0_0_alpha);
-    assert!(v1_0_0 < v1_0_0_beta);
+    // Per semver 2.0 §11: a pre-release version sorts BEFORE the
+    // corresponding release. This is the correctness fix the
+    // semver-crate swap delivers — the old hand-rolled comparison had
+    // the relationship inverted.
+    assert!(v1_0_0_alpha < v1_0_0);
+    assert!(v1_0_0_beta < v1_0_0);
 
-    // Numeric parts take precedence over suffix
+    // Numeric parts take precedence over the pre-release tag.
     assert!(v1_0_0 < v1_0_1_alpha);
     assert!(v1_0_0_rc1 < v1_0_1_alpha);
 }
@@ -60,57 +57,55 @@ fn test_parse_and_compare_zero_versions() {
 }
 
 #[test]
-fn test_parse_and_compare_complex_suffixes() {
-    let v1_2_3_alpha1 = LibXMTPVersion::parse("1.2.3-alpha1").unwrap();
-    let v1_2_3_alpha2 = LibXMTPVersion::parse("1.2.3-alpha2").unwrap();
-    let v1_2_3_beta = LibXMTPVersion::parse("1.2.3-beta").unwrap();
-    let v1_2_3_dev = LibXMTPVersion::parse("1.2.3-dev").unwrap();
-    let v1_2_3_snapshot = LibXMTPVersion::parse("1.2.3-snapshot").unwrap();
+fn test_numeric_pre_release_identifiers_compare_numerically() {
+    // Per semver 2.0 §11.4.1: identifiers consisting only of digits
+    // are compared numerically. The hand-rolled implementation
+    // compared lexicographically, which got `rc10 < rc2` because of
+    // ASCII ordering; this test pins the fix.
+    let v1_0_0_rc_2 = LibXMTPVersion::parse("1.0.0-rc.2").unwrap();
+    let v1_0_0_rc_10 = LibXMTPVersion::parse("1.0.0-rc.10").unwrap();
+    assert!(v1_0_0_rc_2 < v1_0_0_rc_10);
 
-    // Lexicographic ordering of suffixes
-    assert!(v1_2_3_alpha1 < v1_2_3_alpha2);
-    assert!(v1_2_3_alpha2 < v1_2_3_beta);
-    assert!(v1_2_3_beta < v1_2_3_dev);
-    assert!(v1_2_3_dev < v1_2_3_snapshot);
+    let v1_0_0_alpha_2 = LibXMTPVersion::parse("1.0.0-alpha.2").unwrap();
+    let v1_0_0_alpha_11 = LibXMTPVersion::parse("1.0.0-alpha.11").unwrap();
+    assert!(v1_0_0_alpha_2 < v1_0_0_alpha_11);
+}
+
+#[test]
+fn test_multi_segment_pre_release_parses() {
+    // Multi-segment pre-release identifiers like `1.0.0-alpha.1` are
+    // valid semver 2.0; the hand-rolled parser rejected them because
+    // it split on `.` first and required exactly three parts.
+    assert!(LibXMTPVersion::parse("1.0.0-alpha.1").is_ok());
+    assert!(LibXMTPVersion::parse("1.0.0-rc.1.build.42").is_ok());
+}
+
+#[test]
+fn test_build_metadata_parses() {
+    // Build metadata strings (`+...`) are accepted by the parser. Note
+    // that the [`semver`] crate's `Ord` impl deliberately includes
+    // build metadata for total-ordering / `Hash` consistency, which
+    // deviates from semver 2.0 §10 ("build metadata MUST be ignored
+    // when determining version precedence"). This is irrelevant for
+    // libxmtp's floor comparison because no caller passes a `+`-
+    // suffixed string today — `CARGO_PKG_VERSION` is a plain
+    // `X.Y.Z`, and the application-facing `update_group_min_version`
+    // host API never injects build metadata. Pinning parse-success
+    // here so a future caller that *does* pass `+`-suffixed input
+    // gets predictable behavior instead of `InvalidVersionFormat`.
+    assert!(LibXMTPVersion::parse("1.0.0+build.5").is_ok());
+    assert!(LibXMTPVersion::parse("1.0.0-rc.1+build.5").is_ok());
 }
 
 #[test]
 fn test_parse_invalid_format() {
-    let result = LibXMTPVersion::parse("1.0");
-    assert!(matches!(
-        result,
-        Err(CommitValidationError::InvalidVersionFormat(_))
-    ));
-    let result = LibXMTPVersion::parse("1.0.0.0");
-    assert!(matches!(
-        result,
-        Err(CommitValidationError::InvalidVersionFormat(_))
-    ));
-    let result = LibXMTPVersion::parse("1.x.0");
-    assert!(matches!(
-        result,
-        Err(CommitValidationError::InvalidVersionFormat(_))
-    ));
-
-    let result = LibXMTPVersion::parse("a.b.c");
-    assert!(matches!(
-        result,
-        Err(CommitValidationError::InvalidVersionFormat(_))
-    ));
-    let result = LibXMTPVersion::parse("1..0");
-    assert!(matches!(
-        result,
-        Err(CommitValidationError::InvalidVersionFormat(_))
-    ));
-    let result = LibXMTPVersion::parse("");
-    assert!(matches!(
-        result,
-        Err(CommitValidationError::InvalidVersionFormat(_))
-    ));
-}
-
-#[test]
-fn test_parse_suffix_only() {
-    let result = LibXMTPVersion::parse("1.0.0-");
-    assert!(result.is_ok());
+    for bad in ["1.0", "1.0.0.0", "1.x.0", "a.b.c", "1..0", ""] {
+        assert!(
+            matches!(
+                LibXMTPVersion::parse(bad),
+                Err(CommitValidationError::InvalidVersionFormat(_)),
+            ),
+            "expected {bad:?} to fail parsing"
+        );
+    }
 }

--- a/crates/xmtp_mls/src/groups/validated_commit.rs
+++ b/crates/xmtp_mls/src/groups/validated_commit.rs
@@ -98,8 +98,6 @@ pub enum CommitValidationError {
     StorageError(#[from] StorageError),
     #[error("Exceeded max characters for this field. Must be under: {length}")]
     TooManyCharacters { length: usize },
-    #[error("Version part missing")]
-    VersionMissing,
     #[error("Proposer could not be determined for inbox change in proposal-enabled group")]
     ProposerNotFound,
     #[error("Proposals are not enabled on this group")]
@@ -265,52 +263,36 @@ impl MetadataFieldChange {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub struct LibXMTPVersion {
-    major: u32,
-    minor: u32,
-    patch: u32,
-    suffix: Option<String>,
-}
+/// Wrapper around [`semver::Version`] used for the
+/// `MIN_SUPPORTED_PROTOCOL_VERSION` floor and related min-version checks.
+///
+/// Delegates parsing and ordering to the [`semver`] crate so behavior
+/// matches the semver 2.0 spec — most importantly:
+///
+/// * Pre-release versions sort *before* the release: `1.0.0-alpha <
+///   1.0.0-beta < 1.0.0`. The previous hand-rolled implementation got
+///   this backwards (`1.0.0 < 1.0.0-alpha`), which would silently
+///   pause clients running release builds against any group floor set
+///   by a caller passing a pre-release string.
+/// * Pre-release identifiers compare numerically when all-digits, so
+///   `rc2 < rc10` instead of lexicographic `rc10 < rc2`.
+/// * Multi-segment pre-release tags like `1.0.0-alpha.1` parse cleanly
+///   instead of failing with `InvalidVersionFormat`.
+/// * Build metadata (after `+`) parses cleanly. Note: the [`semver`]
+///   crate's `Ord` impl deliberately *includes* build metadata for
+///   total-ordering / `Hash` consistency, deviating from semver 2.0
+///   §10 ("build metadata MUST be ignored when determining version
+///   precedence"). Irrelevant in practice — `CARGO_PKG_VERSION` and
+///   the application-facing `update_group_min_version` callers never
+///   pass `+`-suffixed input.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct LibXMTPVersion(semver::Version);
 
 impl LibXMTPVersion {
     pub fn parse(version_str: &str) -> Result<Self, CommitValidationError> {
-        let parts: Vec<&str> = version_str.split('.').collect();
-        if parts.len() != 3 {
-            return Err(CommitValidationError::InvalidVersionFormat(
-                version_str.to_string(),
-            ));
-        }
-
-        let major = parts
-            .first()
-            .ok_or(CommitValidationError::VersionMissing)?
-            .parse()
-            .map_err(|_| CommitValidationError::InvalidVersionFormat(version_str.to_string()))?;
-        let minor = parts
-            .get(1)
-            .ok_or(CommitValidationError::VersionMissing)?
-            .parse()
-            .map_err(|_| CommitValidationError::InvalidVersionFormat(version_str.to_string()))?;
-
-        let patch_and_suffix = parts
-            .get(2)
-            .ok_or(CommitValidationError::VersionMissing)?
-            .split('-')
-            .collect::<Vec<_>>();
-
-        let patch = patch_and_suffix
-            .first()
-            .ok_or(CommitValidationError::VersionMissing)?
-            .parse()
-            .map_err(|_| CommitValidationError::InvalidVersionFormat(version_str.to_string()))?;
-
-        Ok(LibXMTPVersion {
-            major,
-            minor,
-            patch,
-            suffix: patch_and_suffix.get(1).map(ToString::to_string),
-        })
+        semver::Version::parse(version_str)
+            .map(Self)
+            .map_err(|_| CommitValidationError::InvalidVersionFormat(version_str.to_string()))
     }
 }
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Replace bespoke `LibXMTPVersion` parsing with the `semver` crate
- Replaces the hand-rolled major/minor/patch/suffix struct in [`validated_commit.rs`](https://github.com/xmtp/libxmtp/pull/3644/files#diff-233994c0ec18d23d0636e849849a3500e44611a4f64c6fffb1d0931aa1461ed6) with a tuple wrapper around `semver::Version`, delegating all parsing and comparison to the `semver` crate.
- Removes the `VersionMissing` error variant; all parse failures now map to `InvalidVersionFormat`.
- Behavioral Change: pre-release versions (e.g. `1.0.0-rc.1`) now sort *before* their release counterpart, and numeric pre-release identifiers compare numerically — both per semver spec, differing from the previous bespoke logic.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized b005647.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->