### PR TITLE
xmtp_proto: represent GroupId as fixed-size [u8; 16] Copy newtype

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14693,6 +14693,7 @@ name = "xmtp_proto"
 version = "1.10.0"
 dependencies = [
  "async-trait",
+ "bincode 1.3.3",
  "bytes",
  "chrono",
  "color-eyre",

--- a/apps/cli/cli-client.rs
+++ b/apps/cli/cli-client.rs
@@ -420,9 +420,10 @@ async fn main() -> color_eyre::eyre::Result<()> {
             );
         }
         Commands::GroupInfo { group_id } => {
-            let group = &client
-                .group(&hex::decode(group_id).expect("bad group id"))
-                .expect("group not found");
+            let gid_bytes = hex::decode(group_id).expect("bad group id");
+            let gid: xmtp_proto::types::GroupId =
+                gid_bytes.try_into().expect("group id must be 16 bytes");
+            let group = &client.group(&gid).expect("group not found");
             group.sync().await.unwrap();
             let serializable = SerializableGroup::from(group).await;
             info!(
@@ -530,6 +531,9 @@ where
 
 async fn get_group(client: &Client, group_id: Vec<u8>) -> Result<RustMlsGroup, CliError> {
     client.sync_welcomes().await?;
+    let group_id: xmtp_proto::types::GroupId = group_id
+        .try_into()
+        .map_err(|e: xmtp_proto::ConversionError| CliError::Generic(e.to_string()))?;
     let group = client.group(&group_id)?;
     group
         .sync()

--- a/apps/cli/debug.rs
+++ b/apps/cli/debug.rs
@@ -36,10 +36,10 @@ fn format_timestamp(timestamp_ns: u64) -> String {
 
 pub async fn debug_group_messages(client: &crate::Client, group_id: Vec<u8>) -> Result<(), String> {
     let api_client = client.context.api();
-    let envelopes = api_client
-        .query_group_messages(group_id.into())
-        .await
-        .unwrap();
+    let group_id: xmtp_proto::types::GroupId = group_id
+        .try_into()
+        .map_err(|e: xmtp_proto::ConversionError| e.to_string())?;
+    let envelopes = api_client.query_group_messages(group_id).await.unwrap();
     for envelope in envelopes {
         let body = match envelope.message {
             ProtocolMessage::PrivateMessage(message) => message,

--- a/apps/cli/serializable.rs
+++ b/apps/cli/serializable.rs
@@ -21,7 +21,7 @@ pub struct SerializableGroup {
 
 impl SerializableGroup {
     pub async fn from<Context: XmtpSharedContext>(group: &MlsGroup<Context>) -> Self {
-        let group_id = hex::encode(group.group_id.clone());
+        let group_id = hex::encode(group.group_id);
         let members = group
             .members()
             .await

--- a/apps/db_tools/src/main.rs
+++ b/apps/db_tools/src/main.rs
@@ -5,6 +5,7 @@ use clap::{Parser, ValueEnum};
 use dotenvy::{dotenv, var};
 use std::io::{self, Write};
 use tracing::info;
+use xmtp_db::proto::types::GroupId;
 use xmtp_db::{
     ConnectionExt, DbConnection, EncryptedMessageStore, EncryptionKey, NativeDb, XmtpDb,
     migrations::QueryMigrations,
@@ -104,12 +105,12 @@ fn main() -> Result<()> {
         }
         Task::EnableGroup => {
             let arg_group_ids = args.group_ids()?;
-            let group_ids: Vec<_> = arg_group_ids.iter().map(Vec::as_slice).collect();
+            let group_ids: Vec<_> = arg_group_ids.iter().map(GroupId::as_slice).collect();
             tasks::enable_groups(&manager.store.db(), &group_ids)?;
         }
         Task::DisableGroup => {
             let arg_group_ids = args.group_ids()?;
-            let group_ids: Vec<_> = arg_group_ids.iter().map(Vec::as_slice).collect();
+            let group_ids: Vec<_> = arg_group_ids.iter().map(GroupId::as_slice).collect();
             tasks::disable_groups(&manager.store.db(), &group_ids)?;
         }
         Task::DbListMigrations => {
@@ -196,14 +197,14 @@ impl Args {
         })
     }
 
-    fn group_ids(&self) -> Result<Vec<Vec<u8>>> {
+    fn group_ids(&self) -> Result<Vec<GroupId>> {
         let Some(group_id) = &self.target else {
             bail!("A hex-encoded group_id must be provided as the --target param for this task.");
         };
-        let group_ids: Vec<Vec<u8>> = group_id
+        let group_ids: Vec<GroupId> = group_id
             .split(',')
             .filter(|id| !id.trim().is_empty())
-            .map(hex::decode)
+            .map(|s| s.parse::<GroupId>())
             .collect::<Result<Vec<_>, _>>()?;
 
         if group_ids.is_empty() {

--- a/apps/db_tools/src/tasks/clear_messages.rs
+++ b/apps/db_tools/src/tasks/clear_messages.rs
@@ -53,10 +53,11 @@ mod tests {
         // Commit and application msg
         assert_eq!(alix_msgs.len(), 2);
 
+        let dm_group_id_vec = alix_bo_dm.group_id.to_vec();
         clear_all_messages_confirmed(
             &alix.db(),
             None,
-            Some(std::slice::from_ref(&alix_bo_dm.group_id)),
+            Some(std::slice::from_ref(&dm_group_id_vec)),
         )?;
         let alix_msgs = alix_bo_dm.find_messages(&MsgQueryArgs::default())?;
         // Commit and application msg

--- a/apps/db_tools/src/tasks/clear_messages.rs
+++ b/apps/db_tools/src/tasks/clear_messages.rs
@@ -1,12 +1,14 @@
 use anyhow::Result;
-use xmtp_db::{ConnectionExt, DbConnection, group_message::QueryGroupMessage};
+use xmtp_db::{
+    ConnectionExt, DbConnection, group_message::QueryGroupMessage, proto::types::GroupId,
+};
 
 use crate::confirm_destructive;
 
 pub fn clear_all_messages<C: ConnectionExt>(
     conn: &C,
     limit_days: Option<u32>,
-    group_ids: Option<&[Vec<u8>]>,
+    group_ids: Option<&[GroupId]>,
 ) -> Result<()> {
     confirm_destructive()?;
     clear_all_messages_confirmed(conn, limit_days, group_ids)
@@ -15,7 +17,7 @@ pub fn clear_all_messages<C: ConnectionExt>(
 pub fn clear_all_messages_confirmed<C: ConnectionExt>(
     conn: &C,
     limit_days: Option<u32>,
-    group_ids: Option<&[Vec<u8>]>,
+    group_ids: Option<&[GroupId]>,
 ) -> Result<()> {
     let db = DbConnection::new(conn);
     db.clear_messages(group_ids, limit_days)?;
@@ -53,11 +55,10 @@ mod tests {
         // Commit and application msg
         assert_eq!(alix_msgs.len(), 2);
 
-        let dm_group_id_vec = alix_bo_dm.group_id.to_vec();
         clear_all_messages_confirmed(
             &alix.db(),
             None,
-            Some(std::slice::from_ref(&dm_group_id_vec)),
+            Some(std::slice::from_ref(&alix_bo_dm.group_id)),
         )?;
         let alix_msgs = alix_bo_dm.find_messages(&MsgQueryArgs::default())?;
         // Commit and application msg

--- a/apps/db_tools/src/tasks/db_bench.rs
+++ b/apps/db_tools/src/tasks/db_bench.rs
@@ -316,17 +316,17 @@ where
         bench!(self, primary_sync_group())?;
         bench!(self, find_group(&group.id))?;
         bench!(self, find_sync_group(&group.id))?;
-        bench!(self, get_rotated_at_ns(group.id.clone()))?;
-        bench!(self, update_rotated_at_ns(group.id.clone()))?;
-        bench!(self, get_installations_time_checked(group.id.clone()))?;
-        bench!(self, update_installations_time_checked(group.id.clone()))?;
+        bench!(self, get_rotated_at_ns(&group.id))?;
+        bench!(self, update_rotated_at_ns(&group.id))?;
+        bench!(self, get_installations_time_checked(&group.id))?;
+        bench!(self, update_installations_time_checked(&group.id))?;
         bench!(
             self,
-            update_message_disappearing_from_ns(group.id.clone(), Some(1000))
+            update_message_disappearing_from_ns(&group.id, Some(1000))
         )?;
         bench!(
             self,
-            update_message_disappearing_in_ns(group.id.clone(), Some(1000))
+            update_message_disappearing_in_ns(&group.id, Some(1000))
         )?;
 
         // Fork status queries
@@ -347,7 +347,7 @@ where
         let Some(group) = self.group_or_dm() else {
             bail!("No group to lookup DMs on");
         };
-        let group_id = hex::encode(&group.id);
+        let group_id = hex::encode(group.id);
 
         let new_consent = StoredConsentRecord {
             consented_at_ns: 0,
@@ -471,7 +471,7 @@ where
         )?;
 
         // Get last cursor for IDs
-        let ids = vec![group.id.clone()];
+        let ids = vec![group.id];
         let entities = vec![EntityKind::ApplicationMessage, EntityKind::CommitMessage];
         bench!(self, get_last_cursor_for_ids(&ids, &entities))?;
 
@@ -479,7 +479,7 @@ where
         bench!(
             self,
             update_cursor(
-                group.id.clone(),
+                group.id,
                 EntityKind::ApplicationMessage,
                 Cursor::new(0, 0u32)
             )
@@ -489,7 +489,8 @@ where
         bench!(self, latest_cursor_for_id(&group.id, &entities, None))?;
 
         // Get remote log cursors
-        let conv_ids = vec![&group.id];
+        let conv_id_vec = group.id.to_vec();
+        let conv_ids = vec![&conv_id_vec];
         bench!(self, get_remote_log_cursors(&conv_ids))?;
 
         Ok(())

--- a/apps/db_tools/src/tasks/db_bench.rs
+++ b/apps/db_tools/src/tasks/db_bench.rs
@@ -489,9 +489,7 @@ where
         bench!(self, latest_cursor_for_id(&group.id, &entities, None))?;
 
         // Get remote log cursors
-        let conv_id_vec = group.id.to_vec();
-        let conv_ids = vec![&conv_id_vec];
-        bench!(self, get_remote_log_cursors(&conv_ids))?;
+        bench!(self, get_remote_log_cursors(&[group.id.as_slice()]))?;
 
         Ok(())
     }

--- a/apps/db_tools/src/tasks/group_management.rs
+++ b/apps/db_tools/src/tasks/group_management.rs
@@ -49,12 +49,12 @@ mod tests {
         tester!(alix);
 
         let g = alix.create_group(None, None)?;
-        disable_groups(&alix.db(), &[&g.group_id])?;
+        disable_groups(&alix.db(), &[g.group_id.as_slice()])?;
 
         let g = alix.group(&g.group_id)?;
         assert_eq!(g.consent_state()?, ConsentState::Denied);
 
-        enable_groups(&alix.db(), &[&g.group_id])?;
+        enable_groups(&alix.db(), &[g.group_id.as_slice()])?;
 
         let g = alix.group(&g.group_id)?;
         assert_eq!(g.consent_state()?, ConsentState::Allowed);

--- a/apps/log_parser/src/state/assertions/build_group_order.rs
+++ b/apps/log_parser/src/state/assertions/build_group_order.rs
@@ -15,7 +15,7 @@ impl LogAssertion for BuildGroupOrder {
                 continue;
             };
 
-            order.insert(event.time(), group_id.clone());
+            order.insert(event.time(), *group_id);
         }
 
         *state.group_order.lock() = order;

--- a/apps/log_parser/src/state/assertions/epoch_continuity.rs
+++ b/apps/log_parser/src/state/assertions/epoch_continuity.rs
@@ -13,7 +13,7 @@ impl LogAssertion for EpochContinuityAssertion {
         for (group_id, group) in &*groups {
             // Group the events into epochs
             let mut all_group_epochs = state.grouped_epochs.lock();
-            let group_epochs = all_group_epochs.entry(group_id.clone()).or_default();
+            let group_epochs = all_group_epochs.entry(*group_id).or_default();
 
             // Massage the epoch # and auth forward through group states.
 

--- a/apps/xmtp_debug/src/app/generate/groups.rs
+++ b/apps/xmtp_debug/src/app/generate/groups.rs
@@ -217,7 +217,7 @@ async fn create_group_on_network(
     );
     push_metrics("xdbg_debug").await;
 
-    let group_id = group.group_id.clone().to_vec();
+    let group_id = group.group_id.to_vec();
     drop(client_guard);
 
     Ok((group_id, create_secs))
@@ -230,6 +230,7 @@ async fn check_member_visibility(
     network: &args::BackendOpts,
 ) -> Result<()> {
     let reader_client = app::client_from_identity(invitee, network)?;
+    let group_id_typed = xmtp_proto::types::GroupId::try_from(group_id)?;
 
     let t_visibility = Instant::now();
     let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(30);
@@ -238,7 +239,7 @@ async fn check_member_visibility(
 
     loop {
         reader_client.sync_welcomes().await?;
-        if reader_client.group(group_id).is_ok() {
+        if reader_client.group(&group_id_typed).is_ok() {
             visible = true;
             break;
         }

--- a/apps/xmtp_debug/src/app/generate/messages.rs
+++ b/apps/xmtp_debug/src/app/generate/messages.rs
@@ -170,13 +170,11 @@ impl GenerateMessages {
             .get(&group.created_by)
             .ok_or(eyre!("group has no owner"))?;
         let owner = owner.lock().await;
-        let owner_group = owner
-            .group(&xmtp_proto::types::GroupId::from(group.id))
-            .wrap_err(format!(
-                "owner {} of group {} failed to look up in sqlite db",
-                hex::encode(group.created_by),
-                hex::encode(group.id)
-            ))?;
+        let owner_group = owner.group(&group.group_id()).wrap_err(format!(
+            "owner {} of group {} failed to look up in sqlite db",
+            hex::encode(group.created_by),
+            group.group_id()
+        ))?;
         owner_group
             .add_members(&[hex::encode(not_in_group)])
             .await
@@ -213,7 +211,7 @@ impl GenerateMessages {
                 .ok_or(eyre!("client does not exist"))?;
             let client = client.lock().await;
             client.sync_welcomes().await?;
-            let mls_group = client.group(&xmtp_proto::types::GroupId::from(group.id))?;
+            let mls_group = client.group(&group.group_id())?;
             mls_group.sync_with_conn().await?;
             mls_group.maybe_update_installations(None).await?;
             let words = rng.random_range(0..10);
@@ -304,14 +302,14 @@ impl GenerateMessages {
         let group = group_store
             .random(&network, rng)?
             .ok_or(eyre!("no group in local store"))?;
-        info!(time = ?Instant::now(), group = hex::encode(group.id), "sending message");
+        info!(time = ?Instant::now(), group = %group.group_id(), "sending message");
         if let Some(inbox_id) = group.members.choose(rng) {
             let client = clients
                 .get(inbox_id.as_slice())
                 .ok_or(eyre!("client does not exist"))?;
             let client = client.lock().await;
             client.sync_welcomes().await?;
-            let group = client.group(&xmtp_proto::types::GroupId::from(group.id))?;
+            let group = client.group(&group.group_id())?;
             group.sync_with_conn().await?;
             group.maybe_update_installations(None).await?;
             let words = rng.random_range(0..*max_message_size);

--- a/apps/xmtp_debug/src/app/generate/messages.rs
+++ b/apps/xmtp_debug/src/app/generate/messages.rs
@@ -170,11 +170,13 @@ impl GenerateMessages {
             .get(&group.created_by)
             .ok_or(eyre!("group has no owner"))?;
         let owner = owner.lock().await;
-        let owner_group = owner.group(group.id.as_ref()).wrap_err(format!(
-            "owner {} of group {} failed to look up in sqlite db",
-            hex::encode(group.created_by),
-            hex::encode(group.id)
-        ))?;
+        let owner_group = owner
+            .group(&xmtp_proto::types::GroupId::from(group.id))
+            .wrap_err(format!(
+                "owner {} of group {} failed to look up in sqlite db",
+                hex::encode(group.created_by),
+                hex::encode(group.id)
+            ))?;
         owner_group
             .add_members(&[hex::encode(not_in_group)])
             .await
@@ -211,7 +213,7 @@ impl GenerateMessages {
                 .ok_or(eyre!("client does not exist"))?;
             let client = client.lock().await;
             client.sync_welcomes().await?;
-            let mls_group = client.group(&group.id)?;
+            let mls_group = client.group(&xmtp_proto::types::GroupId::from(group.id))?;
             mls_group.sync_with_conn().await?;
             mls_group.maybe_update_installations(None).await?;
             let words = rng.random_range(0..10);
@@ -309,7 +311,7 @@ impl GenerateMessages {
                 .ok_or(eyre!("client does not exist"))?;
             let client = client.lock().await;
             client.sync_welcomes().await?;
-            let group = client.group(&group.id)?;
+            let group = client.group(&xmtp_proto::types::GroupId::from(group.id))?;
             group.sync_with_conn().await?;
             group.maybe_update_installations(None).await?;
             let words = rng.random_range(0..*max_message_size);

--- a/apps/xmtp_debug/src/app/health/context.rs
+++ b/apps/xmtp_debug/src/app/health/context.rs
@@ -113,7 +113,7 @@ impl HealthContext {
         let existing_groups = group_store
             .load(net_key)?
             .map(|iter| {
-                iter.map(|g| GroupId::from(g.value().id.as_slice()))
+                iter.map(|g| GroupId::from(g.value().id))
                     .collect::<Vec<_>>()
             })
             .unwrap_or_default();

--- a/apps/xmtp_debug/src/app/health/ops/add_members.rs
+++ b/apps/xmtp_debug/src/app/health/ops/add_members.rs
@@ -37,7 +37,7 @@ impl HealthOp for AddMembersToNewGroup {
             }];
         };
 
-        let group = match ctx.primary.group(new_group_id.as_slice()) {
+        let group = match ctx.primary.group(&new_group_id) {
             Ok(g) => g,
             Err(e) => {
                 return vec![OpResult {
@@ -121,13 +121,13 @@ impl HealthOp for AddPrimaryToExistingGroups {
                 let creator = ctx.persisted_creator(id_bytes);
                 let adder = creator
                     .and_then(|c| ctx.existing_clients.get(&c))
-                    .and_then(|c| c.group(gid.as_slice()).ok())
+                    .and_then(|c| c.group(gid).ok())
                     .filter(|g| g.is_active().unwrap_or(false));
                 let group = adder
                     .or_else(|| {
                         ctx.existing_clients
                             .values()
-                            .filter_map(|c| c.group(gid.as_slice()).ok())
+                            .filter_map(|c| c.group(gid).ok())
                             .find(|g| g.is_active().unwrap_or(false))
                     })
                     .ok_or_else(|| eyre!("no active member found for group"))?;

--- a/apps/xmtp_debug/src/app/health/ops/create_group.rs
+++ b/apps/xmtp_debug/src/app/health/ops/create_group.rs
@@ -8,7 +8,6 @@ use crate::app::health::result::{OpResult, Status};
 use async_trait::async_trait;
 use color_eyre::eyre::eyre;
 use std::time::Instant;
-use xmtp_proto::types::GroupId;
 
 pub struct CreateGroup;
 
@@ -24,7 +23,7 @@ impl HealthOp for CreateGroup {
         let outcome = ctx.primary.create_group(None, None);
         let (status, target, error) = match outcome {
             Ok(group) => {
-                let new_group_id = GroupId::from(group.group_id.as_slice());
+                let new_group_id = group.group_id;
                 let hex_id = format!("{new_group_id}");
                 match group_id_bytes(&new_group_id) {
                     Ok(id_bytes) => {

--- a/apps/xmtp_debug/src/app/health/ops/get_mutable_metadata.rs
+++ b/apps/xmtp_debug/src/app/health/ops/get_mutable_metadata.rs
@@ -23,7 +23,7 @@ impl HealthOp for GetMutableMetadata {
             let outcome: color_eyre::eyre::Result<()> = (|| {
                 let group = ctx
                     .primary
-                    .group(gid.as_slice())
+                    .group(gid)
                     .map_err(color_eyre::eyre::Report::from)?;
                 let _ = group
                     .mutable_metadata()

--- a/apps/xmtp_debug/src/app/health/ops/leave_group.rs
+++ b/apps/xmtp_debug/src/app/health/ops/leave_group.rs
@@ -44,7 +44,7 @@ impl HealthOp for LeaveGroup {
                 .map_err(color_eyre::eyre::Report::from)?;
             let group = ctx
                 .transient_identity
-                .group(gid.as_slice())
+                .group(&gid)
                 .map_err(color_eyre::eyre::Report::from)?;
             group
                 .leave_group()

--- a/apps/xmtp_debug/src/app/health/ops/remove_member.rs
+++ b/apps/xmtp_debug/src/app/health/ops/remove_member.rs
@@ -55,7 +55,7 @@ impl HealthOp for RemoveMember {
         let outcome: color_eyre::eyre::Result<()> = async {
             let group = ctx
                 .primary
-                .group(gid.as_slice())
+                .group(&gid)
                 .map_err(color_eyre::eyre::Report::from)?;
             group
                 .remove_members(&[victim_inbox.as_str()])

--- a/apps/xmtp_debug/src/app/health/ops/send_message.rs
+++ b/apps/xmtp_debug/src/app/health/ops/send_message.rs
@@ -16,9 +16,7 @@ pub struct SendMessage;
 async fn send_one(op_name: &'static str, client: &Arc<DbgClient>, gid: &GroupId) -> OpResult {
     let start = Instant::now();
     let outcome: color_eyre::eyre::Result<()> = async {
-        let group = client
-            .group(gid.as_slice())
-            .map_err(color_eyre::eyre::Report::from)?;
+        let group = client.group(gid).map_err(color_eyre::eyre::Report::from)?;
         if !group.is_active().map_err(color_eyre::eyre::Report::from)? {
             return Ok(());
         }

--- a/apps/xmtp_debug/src/app/health/ops/update_admin_list.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_admin_list.rs
@@ -23,7 +23,7 @@ impl HealthOp for UpdateAdminList {
             let outcome: color_eyre::eyre::Result<()> = async {
                 let group = ctx
                     .primary
-                    .group(gid.as_slice())
+                    .group(gid)
                     .map_err(color_eyre::eyre::Report::from)?;
                 group
                     .update_admin_list(

--- a/apps/xmtp_debug/src/app/health/ops/update_app_data.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_app_data.rs
@@ -22,7 +22,7 @@ impl HealthOp for UpdateAppData {
             let outcome: color_eyre::eyre::Result<()> = async {
                 let group = ctx
                     .primary
-                    .group(gid.as_slice())
+                    .group(gid)
                     .map_err(color_eyre::eyre::Report::from)?;
                 group
                     .update_app_data("healthcheck-app-data".into())

--- a/apps/xmtp_debug/src/app/health/ops/update_commit_log_signer.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_commit_log_signer.rs
@@ -27,7 +27,7 @@ impl HealthOp for UpdateCommitLogSigner {
             let outcome: color_eyre::eyre::Result<()> = async {
                 let group = ctx
                     .primary
-                    .group(gid.as_slice())
+                    .group(gid)
                     .map_err(color_eyre::eyre::Report::from)?;
                 let signer: Secret = vec![0u8; 32].into();
                 group

--- a/apps/xmtp_debug/src/app/health/ops/update_consent_state.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_consent_state.rs
@@ -26,7 +26,7 @@ impl HealthOp for UpdateConsentState {
             let outcome: color_eyre::eyre::Result<()> = (|| {
                 let group = ctx
                     .primary
-                    .group(gid.as_slice())
+                    .group(gid)
                     .map_err(color_eyre::eyre::Report::from)?;
                 group
                     .update_consent_state(ConsentState::Allowed)
@@ -70,7 +70,7 @@ impl HealthOp for UpdateConsentStateQuiet {
             let outcome: color_eyre::eyre::Result<()> = (|| {
                 let group = ctx
                     .primary
-                    .group(gid.as_slice())
+                    .group(gid)
                     .map_err(color_eyre::eyre::Report::from)?;
                 group
                     .quietly_update_consent_state(ConsentState::Allowed, &db)

--- a/apps/xmtp_debug/src/app/health/ops/update_group_description.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_group_description.rs
@@ -26,7 +26,7 @@ impl HealthOp for UpdateGroupDescription {
             let outcome: color_eyre::eyre::Result<()> = async {
                 let group = ctx
                     .primary
-                    .group(gid.as_slice())
+                    .group(gid)
                     .map_err(color_eyre::eyre::Report::from)?;
                 group
                     .update_group_description("healthcheck-desc".into())

--- a/apps/xmtp_debug/src/app/health/ops/update_group_image_url.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_group_image_url.rs
@@ -26,7 +26,7 @@ impl HealthOp for UpdateGroupImageUrlSquare {
             let outcome: color_eyre::eyre::Result<()> = async {
                 let group = ctx
                     .primary
-                    .group(gid.as_slice())
+                    .group(gid)
                     .map_err(color_eyre::eyre::Report::from)?;
                 group
                     .update_group_image_url_square("https://example.invalid/img.png".into())

--- a/apps/xmtp_debug/src/app/health/ops/update_group_name.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_group_name.rs
@@ -22,7 +22,7 @@ impl HealthOp for UpdateGroupName {
             let outcome: color_eyre::eyre::Result<()> = async {
                 let group = ctx
                     .primary
-                    .group(gid.as_slice())
+                    .group(gid)
                     .map_err(color_eyre::eyre::Report::from)?;
                 group
                     .update_group_name("healthcheck-name".into())

--- a/apps/xmtp_debug/src/app/health/ops/update_message_disappearing.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_message_disappearing.rs
@@ -27,7 +27,7 @@ impl HealthOp for UpdateMessageDisappearing {
             let outcome: color_eyre::eyre::Result<()> = async {
                 let group = ctx
                     .primary
-                    .group(gid.as_slice())
+                    .group(gid)
                     .map_err(color_eyre::eyre::Report::from)?;
                 group
                     .update_conversation_message_disappearing_settings(
@@ -74,7 +74,7 @@ impl HealthOp for RemoveMessageDisappearing {
             let outcome: color_eyre::eyre::Result<()> = async {
                 let group = ctx
                     .primary
-                    .group(gid.as_slice())
+                    .group(gid)
                     .map_err(color_eyre::eyre::Report::from)?;
                 group
                     .remove_conversation_message_disappearing_settings()

--- a/apps/xmtp_debug/src/app/health/ops/update_permission_policy.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_permission_policy.rs
@@ -27,7 +27,7 @@ impl HealthOp for UpdatePermissionPolicy {
             let outcome: color_eyre::eyre::Result<()> = async {
                 let group = ctx
                     .primary
-                    .group(gid.as_slice())
+                    .group(gid)
                     .map_err(color_eyre::eyre::Report::from)?;
                 group
                     .update_permission_policy(

--- a/apps/xmtp_debug/src/app/health/validators/no_forks.rs
+++ b/apps/xmtp_debug/src/app/health/validators/no_forks.rs
@@ -39,7 +39,7 @@ impl Validator for NoForkedGroups {
                 // Transient may have its group row purged on LeaveGroup
                 // depending on libxmtp version — skip with a debug log so
                 // unexpected non-leave errors don't slip past silently.
-                if is_transient && let Err(e) = client.group(gid.as_slice()) {
+                if is_transient && let Err(e) = client.group(gid) {
                     tracing::debug!(
                         target: "healthcheck",
                         inbox = client.inbox_id(),

--- a/apps/xmtp_debug/src/app/health/validators/no_missing_messages.rs
+++ b/apps/xmtp_debug/src/app/health/validators/no_missing_messages.rs
@@ -68,7 +68,7 @@ impl Validator for NoMissingMessages {
                 // not see post-removal commits. The MLS group's
                 // `is_active()` returns false for those clients.
                 let active = client
-                    .group(group_id.as_slice())
+                    .group(group_id)
                     .ok()
                     .and_then(|g| g.is_active().ok())
                     .unwrap_or(false);

--- a/apps/xmtp_debug/src/app/modify.rs
+++ b/apps/xmtp_debug/src/app/modify.rs
@@ -45,7 +45,7 @@ impl Modify {
             hex::encode(local_group.created_by)
         ))?;
         let admin = app::client_from_identity(&identity, &network)?;
-        let group = admin.group(local_group.id.as_ref())?;
+        let group = admin.group(&xmtp_proto::types::GroupId::from(local_group.id))?;
         match action {
             Remove => {
                 if inbox_id.is_none() {

--- a/apps/xmtp_debug/src/app/modify.rs
+++ b/apps/xmtp_debug/src/app/modify.rs
@@ -45,7 +45,7 @@ impl Modify {
             hex::encode(local_group.created_by)
         ))?;
         let admin = app::client_from_identity(&identity, &network)?;
-        let group = admin.group(&xmtp_proto::types::GroupId::from(local_group.id))?;
+        let group = admin.group(&local_group.group_id())?;
         match action {
             Remove => {
                 if inbox_id.is_none() {
@@ -78,7 +78,7 @@ impl Modify {
                 group.add_members(&[hex::encode(identity.inbox_id)]).await?;
                 info!(
                     inbox_id = hex::encode(identity.inbox_id),
-                    group_id = hex::encode(local_group.id),
+                    group_id = %local_group.group_id(),
                     "Member added"
                 );
                 group_store.set(local_group, &network)?;
@@ -95,7 +95,7 @@ impl Modify {
                     .await?;
                 info!(
                     inbox_id = hex::encode(*inbox_id),
-                    group_id = hex::encode(local_group.id),
+                    group_id = %local_group.group_id(),
                     added_by = hex::encode(identity.inbox_id),
                     "Member added as Super Admin"
                 );

--- a/apps/xmtp_debug/src/app/send.rs
+++ b/apps/xmtp_debug/src/app/send.rs
@@ -49,7 +49,7 @@ impl Send {
 
         let client = crate::app::client_from_identity(&identity, network)?;
         client.sync_welcomes().await?;
-        let xmtp_group = client.group(group.id.as_ref())?;
+        let xmtp_group = client.group(&xmtp_proto::types::GroupId::from(group.id))?;
         xmtp_group
             .send_message(
                 data.as_bytes(),

--- a/apps/xmtp_debug/src/app/send.rs
+++ b/apps/xmtp_debug/src/app/send.rs
@@ -49,7 +49,7 @@ impl Send {
 
         let client = crate::app::client_from_identity(&identity, network)?;
         client.sync_welcomes().await?;
-        let xmtp_group = client.group(&xmtp_proto::types::GroupId::from(group.id))?;
+        let xmtp_group = client.group(&group.group_id())?;
         xmtp_group
             .send_message(
                 data.as_bytes(),

--- a/apps/xmtp_debug/src/app/stream.rs
+++ b/apps/xmtp_debug/src/app/stream.rs
@@ -78,7 +78,7 @@ impl Stream {
                     };
                     let stored: StoredGroup = group.load()?;
                     let item = Conversation {
-                        group_id: hex::encode(&stored.id),
+                        group_id: hex::encode(stored.id),
                         dm_id: stored.dm_id.unwrap_or("".to_string()),
                         conversation_type: stored.conversation_type as i32,
                         created_at: stored.created_at_ns,
@@ -114,7 +114,7 @@ impl Stream {
                         timestamp: message.sent_at_ns,
                         sequence_id: message.sequence_id,
                         originator_id: message.originator_id,
-                        group_id: hex::encode(&message.group_id),
+                        group_id: hex::encode(message.group_id),
                         expire_at: message.expire_at_ns.unwrap_or(0),
                         content_type: message.content_type as i32,
                         version_major: message.version_major,

--- a/apps/xmtp_debug/src/app/test.rs
+++ b/apps/xmtp_debug/src/app/test.rs
@@ -151,7 +151,7 @@ impl Test {
         info!("creating group and adding receiver");
         let group = client1.create_group(Default::default(), Default::default())?;
         group.add_members(std::slice::from_ref(&inbox_id2)).await?;
-        let group_id = hex::encode(&group.group_id);
+        let group_id = hex::encode(group.group_id);
         info!(group_id, "group created");
 
         // Sync user2 to receive the group welcome
@@ -302,7 +302,7 @@ impl Test {
         info!("creating group and adding receiver");
         let group = client1.create_group(Default::default(), Default::default())?;
         group.add_members(std::slice::from_ref(&inbox_id2)).await?;
-        let group_id = hex::encode(&group.group_id);
+        let group_id = hex::encode(group.group_id);
         info!(group_id, "group created");
 
         // Step 3: Sync user2 to receive the group welcome (but don't sync messages yet)
@@ -570,11 +570,11 @@ impl Test {
         info!("creating group and adding receiver");
         let group = client1.create_group(Default::default(), Default::default())?;
         group.add_members(std::slice::from_ref(&inbox_id2)).await?;
-        let group_id = group.group_id.clone();
-        let group_id_hex = hex::encode(&group_id);
+        let group_id = group.group_id;
+        let group_id_hex = hex::encode(group_id);
         info!(group_id = group_id_hex, "group created, receiver added");
 
-        let group_topic = Topic::new_group_message(&group_id);
+        let group_topic = Topic::new_group_message(group_id);
         let group_baseline = query_v4_envelopes(v4_client, &group_topic).await.len();
         info!(group_baseline, "group topic baseline");
 
@@ -886,12 +886,12 @@ impl Test {
 
         // Step 2: Create a group (just ourselves — sufficient for migration)
         let group = client.create_group(Default::default(), Default::default())?;
-        let group_id = group.group_id.clone();
-        let group_id_hex = hex::encode(&group_id);
+        let group_id = group.group_id;
+        let group_id_hex = hex::encode(group_id);
         info!(group_id = group_id_hex, "group created on V3");
 
         // Step 3: Snapshot V4 baseline for this topic
-        let topic = Topic::new_group_message(&group_id);
+        let topic = Topic::new_group_message(group_id);
         let baseline_count = {
             let mut endpoint = QueryEnvelopes::builder()
                 .envelopes(EnvelopesQuery {
@@ -1098,12 +1098,12 @@ impl Test {
         info!("creating group and adding receiver");
         let group = client1.create_group(Default::default(), Default::default())?;
         group.add_members(std::slice::from_ref(&inbox_id2)).await?;
-        let group_id = group.group_id.clone();
-        let group_id_hex = hex::encode(&group_id);
+        let group_id = group.group_id;
+        let group_id_hex = hex::encode(group_id);
         info!(group_id = group_id_hex, "group created, receiver added");
 
         // Capture group topic baseline BEFORE sending messages
-        let group_topic = Topic::new_group_message(&group_id);
+        let group_topic = Topic::new_group_message(group_id);
         let group_baseline = query_v4_envelopes(v4_client, &group_topic).await.len();
         info!(group_baseline, "group topic baseline captured");
 

--- a/apps/xmtp_debug/src/app/types.rs
+++ b/apps/xmtp_debug/src/app/types.rs
@@ -181,7 +181,9 @@ impl redb::Value for Identity {
 pub struct Group {
     /// user that created group
     pub created_by: InboxId,
-    /// Id of the group
+    /// Id of the group. Stored as `[u8; 16]` so it can be serialized via
+    /// `speedy`; use [`Group::group_id`] when interacting with xmtp_mls
+    /// APIs that expect a `GroupId`.
     pub id: [u8; 16],
     /// Size of the groups
     pub member_size: u32,
@@ -189,9 +191,16 @@ pub struct Group {
     pub members: Vec<InboxId>,
 }
 
+impl Group {
+    /// View `self.id` as the canonical [`xmtp_proto::types::GroupId`].
+    pub fn group_id(&self) -> xmtp_proto::types::GroupId {
+        xmtp_proto::types::GroupId::from(self.id)
+    }
+}
+
 impl std::fmt::Display for Group {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", hex::encode(self.id))
+        write!(f, "{}", self.group_id())
     }
 }
 

--- a/apps/xnet/lib/src/app/service_manager.rs
+++ b/apps/xnet/lib/src/app/service_manager.rs
@@ -157,16 +157,16 @@ impl ServiceManager {
         };
 
         // Phase 6b: Pause broadcasters if configured (must happen before Phase 7 node provisioning)
-        if config.paused || cli_paused {
-            if let Some(ref rpc) = anvil_rpc_url {
-                crate::contracts::set_broadcasters_paused(
-                    rpc.as_str(),
-                    crate::constants::Anvil::ADMIN_KEY,
-                    true,
-                )
-                .await?;
-                info!("broadcaster contracts paused");
-            }
+        if (config.paused || cli_paused)
+            && let Some(ref rpc) = anvil_rpc_url
+        {
+            crate::contracts::set_broadcasters_paused(
+                rpc.as_str(),
+                crate::constants::Anvil::ADMIN_KEY,
+                true,
+            )
+            .await?;
+            info!("broadcaster contracts paused");
         }
 
         let mut this = Self {

--- a/apps/xnet/lib/src/config/address_mode.rs
+++ b/apps/xnet/lib/src/config/address_mode.rs
@@ -1,9 +1,10 @@
 const LOCAL_DOMAIN: &str = "xmtpd.local";
 
 /// Determines how xnet constructs service hostnames.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum AddressMode {
     /// Local mode: hostnames like `{name}.xmtpd.local`
+    #[default]
     Local,
     /// Remote domain mode: hostnames like `{name}.{domain}`
     RemoteDomain(String),
@@ -31,12 +32,6 @@ impl AddressMode {
 
     pub fn is_remote(&self) -> bool {
         matches!(self, Self::RemoteDomain(_))
-    }
-}
-
-impl Default for AddressMode {
-    fn default() -> Self {
-        Self::Local
     }
 }
 

--- a/apps/xnet/lib/src/xmtpd_cli.rs
+++ b/apps/xnet/lib/src/xmtpd_cli.rs
@@ -86,7 +86,7 @@ impl XmtpdCli {
                 format!(
                     "--http-address={}://{}",
                     cfg.public_scheme,
-                    cfg.address_mode.hostname(&node.name())
+                    cfg.address_mode.hostname(node.name())
                 )
             },
         ];

--- a/bindings/mobile/src/mls.rs
+++ b/bindings/mobile/src/mls.rs
@@ -248,8 +248,11 @@ pub async fn get_newest_message_metadata(
     api: Arc<XmtpApiClient>,
     group_ids: Vec<Vec<u8>>,
 ) -> Result<HashMap<Vec<u8>, FfiMessageMetadata>, FfiError> {
-    let group_ids: Vec<xmtp_proto::types::GroupId> =
-        group_ids.into_iter().map(Into::into).collect();
+    let group_ids: Vec<xmtp_proto::types::GroupId> = group_ids
+        .into_iter()
+        .map(xmtp_proto::types::GroupId::try_from)
+        .collect::<Result<_, _>>()
+        .map_err(|e| FfiError::generic(e.to_string()))?;
 
     let metadata = api.wrapper.get_newest_message_metadata(&group_ids).await?;
 
@@ -618,6 +621,8 @@ impl FfiXmtpClient {
 
     #[tracing::instrument(skip_all)]
     pub fn conversation(&self, conversation_id: Vec<u8>) -> Result<FfiConversation, FfiError> {
+        let conversation_id = xmtp_proto::types::GroupId::try_from(conversation_id)
+            .map_err(|e| FfiError::generic(e.to_string()))?;
         self.inner_client
             .stitched_group(&conversation_id)
             .map(Into::into)
@@ -2859,7 +2864,7 @@ impl FfiConversation {
         let close_cb = message_callback.clone();
         let handle = MlsGroup::stream_with_callback(
             self.inner.context.clone(),
-            self.inner.group_id.clone(),
+            self.inner.group_id,
             move |message| match message {
                 Ok(m) => message_callback.on_message(m.into()),
                 Err(e) => message_callback.on_error(e.into()),

--- a/bindings/mobile/src/mls/tests/dms.rs
+++ b/bindings/mobile/src/mls/tests/dms.rs
@@ -574,7 +574,7 @@ async fn test_set_disappearing_messages_when_creating_dm() {
     let group_from_db = alix_provider
         .key_store()
         .db()
-        .find_group(&GroupId::from(alix_group.id()))
+        .find_group(&GroupId::try_from(alix_group.id()).unwrap())
         .unwrap();
     assert_eq!(
         group_from_db
@@ -628,15 +628,15 @@ async fn test_can_successfully_thread_dms() {
     convo_alix.send_text("Alix hey").await.unwrap();
 
     let group_bo = bo_conn
-        .find_group(&GroupId::from(convo_bo.id()))
+        .find_group(&GroupId::try_from(convo_bo.id()).unwrap())
         .unwrap()
         .unwrap();
     let group_alix = alix_conn
-        .find_group(&GroupId::from(convo_alix.id()))
+        .find_group(&GroupId::try_from(convo_alix.id()).unwrap())
         .unwrap()
         .unwrap();
     assert!(group_bo.last_message_ns.unwrap() < group_alix.last_message_ns.unwrap());
-    assert_eq!(group_bo.id, convo_bo.id().into());
+    assert_eq!(group_bo.id, convo_bo.id());
 
     // Check messages
     let bo_messages = convo_bo

--- a/bindings/mobile/src/mls/tests/group_management.rs
+++ b/bindings/mobile/src/mls/tests/group_management.rs
@@ -793,7 +793,7 @@ async fn test_disappearing_messages_deletion() {
         .inner_client
         .context
         .db()
-        .find_group(&GroupId::from(alix_group.id()))
+        .find_group(&GroupId::try_from(alix_group.id()).unwrap())
         .unwrap();
     assert_eq!(
         group_from_db
@@ -821,7 +821,7 @@ async fn test_disappearing_messages_deletion() {
     let bola_group_from_db = bola_provider
         .key_store()
         .db()
-        .find_group(&GroupId::from(alix_group.id()))
+        .find_group(&GroupId::try_from(alix_group.id()).unwrap())
         .unwrap();
     assert_eq!(
         bola_group_from_db
@@ -888,7 +888,7 @@ async fn test_disappearing_messages_deletion() {
     let group_from_db = alix_provider
         .key_store()
         .db()
-        .find_group(&GroupId::from(alix_group.id()))
+        .find_group(&GroupId::try_from(alix_group.id()).unwrap())
         .unwrap();
     assert_eq!(
         group_from_db
@@ -981,7 +981,7 @@ async fn test_disappearing_messages_with_0_from_ns_settings() {
         .inner_client
         .context
         .db()
-        .find_group(&GroupId::from(alix_group.id()))
+        .find_group(&GroupId::try_from(alix_group.id()).unwrap())
         .unwrap();
     assert_eq!(
         group_from_db
@@ -1009,7 +1009,7 @@ async fn test_disappearing_messages_with_0_from_ns_settings() {
     let bola_group_from_db = bola_provider
         .key_store()
         .db()
-        .find_group(&GroupId::from(alix_group.id()))
+        .find_group(&GroupId::try_from(alix_group.id()).unwrap())
         .unwrap();
     assert_eq!(
         bola_group_from_db
@@ -1059,7 +1059,7 @@ async fn test_disappearing_messages_with_0_from_ns_settings() {
     let group_from_db = alix_provider
         .key_store()
         .db()
-        .find_group(&GroupId::from(alix_group.id()))
+        .find_group(&GroupId::try_from(alix_group.id()).unwrap())
         .unwrap();
     assert_eq!(
         group_from_db
@@ -1139,7 +1139,7 @@ async fn test_set_disappearing_messages_when_creating_group() {
     let group_from_db = alix_provider
         .key_store()
         .db()
-        .find_group(&GroupId::from(alix_group.id()))
+        .find_group(&GroupId::try_from(alix_group.id()).unwrap())
         .unwrap();
     assert_eq!(
         group_from_db

--- a/bindings/mobile/src/mls/tests/networking.rs
+++ b/bindings/mobile/src/mls/tests/networking.rs
@@ -224,7 +224,7 @@ async fn test_is_connected_after_connect() {
     .unwrap();
     let result = api
         .wrapper
-        .query_group_messages(xmtp_common::rand_vec::<16>().into())
+        .query_group_messages(xmtp_common::rand_array::<16>().into())
         .await;
     assert!(result.is_err(), "Expected connection to fail");
 }

--- a/bindings/node/src/conversation/hmac_key.rs
+++ b/bindings/node/src/conversation/hmac_key.rs
@@ -13,7 +13,7 @@ impl Conversation {
 
     let mut hmac_map = HashMap::new();
     for conversation in dms {
-      let id = hex::encode(&conversation.group_id);
+      let id = hex::encode(conversation.group_id);
       let keys = conversation
         .hmac_keys(-1..=1)
         .map_err(ErrorWrapper::from)?

--- a/bindings/node/src/conversation/mod.rs
+++ b/bindings/node/src/conversation/mod.rs
@@ -2,6 +2,7 @@ use crate::{ErrorWrapper, client::RustMlsGroup};
 use napi::bindgen_prelude::{BigInt, Result};
 use napi_derive::napi;
 use xmtp_mls::groups::MlsGroup;
+use xmtp_proto::types::GroupId;
 
 pub mod consent_state;
 pub mod content_types;
@@ -19,7 +20,7 @@ pub mod streams;
 #[derive(Clone)]
 pub struct Conversation {
   inner_group: RustMlsGroup,
-  group_id: Vec<u8>,
+  group_id: GroupId,
   dm_id: Option<String>,
   created_at_ns: BigInt,
 }
@@ -27,7 +28,7 @@ pub struct Conversation {
 impl From<RustMlsGroup> for Conversation {
   fn from(mls_group: RustMlsGroup) -> Self {
     Conversation {
-      group_id: mls_group.group_id.to_vec(),
+      group_id: mls_group.group_id,
       dm_id: mls_group.dm_id.clone(),
       created_at_ns: BigInt::from(mls_group.created_at_ns),
       inner_group: mls_group,
@@ -39,7 +40,7 @@ impl From<RustMlsGroup> for Conversation {
 impl Conversation {
   pub fn new(
     inner_group: RustMlsGroup,
-    group_id: Vec<u8>,
+    group_id: GroupId,
     dm_id: Option<String>,
     created_at_ns: BigInt,
   ) -> Self {
@@ -55,7 +56,7 @@ impl Conversation {
   pub fn create_mls_group(&self) -> RustMlsGroup {
     MlsGroup::new(
       self.inner_group.context.clone(),
-      self.group_id.clone().into(),
+      self.group_id,
       self.dm_id.clone(),
       self.inner_group.conversation_type,
       self.created_at_ns.get_i64().0,
@@ -64,7 +65,7 @@ impl Conversation {
 
   #[napi]
   pub fn id(&self) -> String {
-    hex::encode(self.group_id.clone())
+    hex::encode(self.group_id)
   }
 
   #[napi]

--- a/bindings/node/src/conversation/streams.rs
+++ b/bindings/node/src/conversation/streams.rs
@@ -17,7 +17,7 @@ impl Conversation {
     let group = self.create_mls_group();
     let stream_closer = MlsGroup::stream_with_callback(
       group.context.clone(),
-      group.group_id.clone(),
+      group.group_id,
       move |message| {
         let status = callback.call(
           message

--- a/bindings/node/src/conversations/hmac_key.rs
+++ b/bindings/node/src/conversations/hmac_key.rs
@@ -20,7 +20,7 @@ impl Conversations {
 
     let mut hmac_map = HashMap::new();
     for conversation in conversations {
-      let id = hex::encode(&conversation.group_id);
+      let id = hex::encode(conversation.group_id);
       let keys = conversation
         .hmac_keys(-1..=1)
         .map_err(ErrorWrapper::from)?

--- a/bindings/node/src/conversations/mod.rs
+++ b/bindings/node/src/conversations/mod.rs
@@ -150,6 +150,7 @@ impl Conversations {
   #[napi]
   pub fn get_conversation_by_id(&self, group_id: String) -> Result<Conversation> {
     let group_id = hex::decode(group_id).map_err(ErrorWrapper::from)?;
+    let group_id = xmtp_proto::types::GroupId::try_from(group_id).map_err(ErrorWrapper::from)?;
 
     let group = self
       .inner_client

--- a/bindings/node/src/messages/decoded_message.rs
+++ b/bindings/node/src/messages/decoded_message.rs
@@ -67,7 +67,7 @@ impl TryFrom<XmtpDecodedMessage> for DecodedMessage {
       sender_installation_id: hex::encode(&msg.metadata.sender_installation_id),
       sender_inbox_id: msg.metadata.sender_inbox_id.clone(),
       content_type: msg.metadata.content_type.clone().into(),
-      conversation_id: hex::encode(&msg.metadata.group_id),
+      conversation_id: hex::encode(msg.metadata.group_id),
       fallback: msg.fallback_text.clone(),
       delivery_status: msg.metadata.delivery_status.into(),
       num_replies: msg.num_replies as i64,

--- a/bindings/node/src/messages/mod.rs
+++ b/bindings/node/src/messages/mod.rs
@@ -156,7 +156,7 @@ pub struct Message {
 impl From<StoredGroupMessage> for Message {
   fn from(msg: StoredGroupMessage) -> Self {
     let id = hex::encode(msg.id.clone());
-    let convo_id = hex::encode(msg.group_id.clone());
+    let convo_id = hex::encode(msg.group_id);
     let contents = msg.decrypted_message_bytes.clone();
     let content: EncodedContent = match XmtpEncodedContent::decode(contents.as_slice()) {
       Ok(value) => value.into(),

--- a/bindings/wasm/src/conversation.rs
+++ b/bindings/wasm/src/conversation.rs
@@ -926,7 +926,7 @@ impl Conversation {
 
     let mut hmac_map: HashMap<String, Vec<HmacKey>> = HashMap::new();
     for conversation in dms {
-      let id = hex::encode(&conversation.group_id);
+      let id = hex::encode(conversation.group_id);
       let keys = conversation
         .hmac_keys(-1..=1)
         .map_err(ErrorWrapper::js)?

--- a/bindings/wasm/src/conversation.rs
+++ b/bindings/wasm/src/conversation.rs
@@ -53,6 +53,7 @@ use xmtp_mls::{
     group_mutable_metadata::MetadataField as XmtpMetadataField,
   },
 };
+use xmtp_proto::types::GroupId;
 use xmtp_proto::xmtp::mls::message_contents::EncodedContent as XmtpEncodedContent;
 
 #[derive(Clone, Serialize, Deserialize, Tsify)]
@@ -112,7 +113,7 @@ pub struct GroupMember {
 #[derive(Clone)]
 pub struct Conversation {
   inner_group: RustMlsGroup,
-  group_id: Vec<u8>,
+  group_id: GroupId,
   dm_id: Option<String>,
   created_at_ns: i64,
 }
@@ -120,7 +121,7 @@ pub struct Conversation {
 impl Conversation {
   pub fn new(
     inner_group: RustMlsGroup,
-    group_id: Vec<u8>,
+    group_id: GroupId,
     dm_id: Option<String>,
     created_at_ns: i64,
   ) -> Self {
@@ -135,7 +136,7 @@ impl Conversation {
   pub fn to_mls_group(&self) -> RustMlsGroup {
     MlsGroup::new(
       self.inner_group.context.clone(),
-      self.group_id.clone().into(),
+      self.group_id,
       self.dm_id.clone(),
       self.inner_group.conversation_type,
       self.created_at_ns,
@@ -146,7 +147,7 @@ impl Conversation {
 impl From<RustMlsGroup> for Conversation {
   fn from(mls_group: RustMlsGroup) -> Self {
     Conversation {
-      group_id: mls_group.group_id.to_vec(),
+      group_id: mls_group.group_id,
       dm_id: mls_group.dm_id.clone(),
       created_at_ns: mls_group.created_at_ns,
       inner_group: mls_group,
@@ -158,7 +159,7 @@ impl From<RustMlsGroup> for Conversation {
 impl Conversation {
   #[wasm_bindgen]
   pub fn id(&self) -> String {
-    hex::encode(self.group_id.clone())
+    hex::encode(self.group_id)
   }
 
   #[wasm_bindgen]
@@ -744,7 +745,7 @@ impl Conversation {
     let on_close_cb = callback.clone();
     let stream_closer = MlsGroup::stream_with_callback(
       self.inner_group.context.clone(),
-      self.group_id.clone().into(),
+      self.group_id,
       move |message| match message {
         Ok(item) => callback.on_message(item.into()),
         Err(e) => callback.on_error(JsError::from(e)),
@@ -988,7 +989,7 @@ mod tests {
   fn test_group_message_to_object() {
     let stored_message = StoredGroupMessage {
       id: xmtp_common::rand_vec::<32>(),
-      group_id: xmtp_common::rand_vec::<32>().into(),
+      group_id: xmtp_common::rand_array::<16>().into(),
       decrypted_message_bytes: xmtp_common::rand_vec::<32>(),
       sent_at_ns: 1738354508964432000,
       inserted_at_ns: 1738354508964432000,

--- a/bindings/wasm/src/conversations.rs
+++ b/bindings/wasm/src/conversations.rs
@@ -579,7 +579,7 @@ impl Conversations {
 
     let mut hmac_map: HashMap<String, Vec<HmacKey>> = HashMap::new();
     for conversation in conversations {
-      let id = hex::encode(&conversation.group_id);
+      let id = hex::encode(conversation.group_id);
       let keys = conversation
         .hmac_keys(-1..=1)
         .map_err(ErrorWrapper::js)?

--- a/bindings/wasm/src/conversations.rs
+++ b/bindings/wasm/src/conversations.rs
@@ -452,6 +452,7 @@ impl Conversations {
     #[wasm_bindgen(js_name = groupId)] group_id: String,
   ) -> Result<Conversation, JsError> {
     let group_id = hex::decode(group_id).map_err(ErrorWrapper::js)?;
+    let group_id = xmtp_proto::types::GroupId::try_from(group_id).map_err(ErrorWrapper::js)?;
 
     let group = self
       .inner_client

--- a/bindings/wasm/src/messages.rs
+++ b/bindings/wasm/src/messages.rs
@@ -174,7 +174,7 @@ pub struct Message {
 impl From<StoredGroupMessage> for Message {
   fn from(msg: StoredGroupMessage) -> Self {
     let id = hex::encode(msg.id.clone());
-    let convo_id = hex::encode(msg.group_id.clone());
+    let convo_id = hex::encode(msg.group_id);
     let contents = msg.decrypted_message_bytes.clone();
     let content: EncodedContent = match XmtpEncodedContent::decode(contents.as_slice()) {
       Ok(value) => value.into(),

--- a/crates/xmtp_api/src/mls.rs
+++ b/crates/xmtp_api/src/mls.rs
@@ -69,7 +69,7 @@ impl<ApiClient> ApiClientWrapper<ApiClient>
 where
     ApiClient: XmtpApi,
 {
-    #[tracing::instrument(level = "trace", skip_all, fields(group_id = hex::encode(group_id)))]
+    #[tracing::instrument(level = "trace", skip_all, fields(group_id = %group_id))]
     pub async fn query_group_messages(&self, group_id: GroupId) -> Result<Vec<GroupMessage>> {
         self.api_client
             .query_group_messages(group_id)
@@ -78,13 +78,13 @@ where
     }
 
     /// Query for the latest message on a group
-    #[tracing::instrument(level = "trace", skip_all, fields(group_id = hex::encode(group_id)))]
+    #[tracing::instrument(level = "trace", skip_all, fields(group_id = %group_id))]
     pub async fn query_latest_group_message(
         &self,
         group_id: GroupId,
     ) -> Result<Option<GroupMessage>> {
         tracing::debug!(
-            group_id = hex::encode(group_id),
+            group_id = %group_id,
             inbox_id = self.inbox_id,
             "query latest group message"
         );

--- a/crates/xmtp_api/src/mls.rs
+++ b/crates/xmtp_api/src/mls.rs
@@ -389,7 +389,7 @@ pub mod tests {
 
     pub fn build_group_messages(
         num_messages: usize,
-        group_id: Vec<u8>,
+        group_id: GroupId,
     ) -> Vec<mls_v1::GroupMessage> {
         let mut out: Vec<mls_v1::GroupMessage> = vec![];
         for i in 0..num_messages {
@@ -397,7 +397,7 @@ pub mod tests {
                 version: Some(GroupMessageVersion::V1(GroupMessageV1 {
                     id: i as u64,
                     created_ns: i as u64,
-                    group_id: group_id.clone(),
+                    group_id: group_id.to_vec(),
                     data: MlsMessageOut::from(FakeMlsApplicationMessage::generate())
                         .to_bytes()
                         .unwrap(),
@@ -472,17 +472,16 @@ pub mod tests {
     async fn test_read_group_messages_single_page() {
         let mock_api = MockNetworkClient::default();
         let mut v3_client = V3Client::new(mock_api, NoCursorStore);
-        let group_id = rand_vec::<16>();
-        let group_id_clone = group_id.clone();
+        let group_id = GroupId::generate();
         // Set expectation for first request with no cursor
         v3_client
             .client_mut()
             .expect_request()
             .returning(move |_, _, mut body| {
                 let req = QueryGroupMessagesRequest::decode(&mut body).unwrap();
-                assert_eq!(req.group_id, group_id.clone());
+                assert_eq!(req.group_id, group_id);
 
-                let msgs = build_group_messages(10, group_id.clone());
+                let msgs = build_group_messages(10, group_id);
                 let mut bytes = prost::bytes::BytesMut::new();
                 let res = QueryGroupMessagesResponse {
                     messages: msgs,
@@ -498,10 +497,7 @@ pub mod tests {
 
         let wrapper = ApiClientWrapper::new(v3_client, exponential().build());
 
-        let result = wrapper
-            .query_group_messages(group_id_clone.try_into().unwrap())
-            .await
-            .unwrap();
+        let result = wrapper.query_group_messages(group_id).await.unwrap();
         assert_eq!(result.len(), 10);
     }
 
@@ -509,17 +505,16 @@ pub mod tests {
     async fn test_read_group_messages_single_page_xactly_100_results() {
         let mock_api = MockNetworkClient::default();
         let mut v3_client = V3Client::new(mock_api, NoCursorStore);
-        let group_id = rand_vec::<16>();
-        let group_id_clone = group_id.clone();
+        let group_id = GroupId::generate();
         // Set expectation for first request with no cursor
         v3_client
             .client_mut()
             .expect_request()
             .returning(move |_, _, mut body| {
                 let req = QueryGroupMessagesRequest::decode(&mut body).unwrap();
-                assert_eq!(req.group_id, group_id.clone());
+                assert_eq!(req.group_id, group_id);
 
-                let msgs = build_group_messages(100, group_id.clone());
+                let msgs = build_group_messages(100, group_id);
                 let mut bytes = prost::bytes::BytesMut::new();
                 let res = QueryGroupMessagesResponse {
                     messages: msgs,
@@ -535,10 +530,7 @@ pub mod tests {
 
         let wrapper = ApiClientWrapper::new(v3_client, exponential().build());
 
-        let result = wrapper
-            .query_group_messages(group_id_clone.try_into().unwrap())
-            .await
-            .unwrap();
+        let result = wrapper.query_group_messages(group_id).await.unwrap();
         assert_eq!(result.len(), 100);
     }
 
@@ -546,9 +538,7 @@ pub mod tests {
     async fn test_read_topic_multi_page() {
         let mock_api = MockNetworkClient::new();
         let mut v3_client = V3Client::new(mock_api, NoCursorStore);
-        let group_id = vec![1u8; 16];
-        let group_id_clone = group_id.clone();
-        let group_id_clone2 = group_id.clone();
+        let group_id = GroupId::ONE;
         // Set expectation for first request with no cursor
         v3_client
             .client_mut()
@@ -562,7 +552,7 @@ pub mod tests {
             })
             .returning(move |_, _, mut body| {
                 let req = QueryGroupMessagesRequest::decode(&mut body).unwrap();
-                assert_eq!(req.group_id, group_id.clone());
+                assert_eq!(req.group_id, group_id);
 
                 Ok(http::Response::new(
                     QueryGroupMessagesResponse {
@@ -571,7 +561,7 @@ pub mod tests {
                             limit: 100,
                             direction: 0,
                         }),
-                        messages: build_group_messages(100, group_id.clone()),
+                        messages: build_group_messages(100, group_id),
                     }
                     .encode_to_vec()
                     .into(),
@@ -590,12 +580,12 @@ pub mod tests {
             })
             .returning(move |_, _, mut body| {
                 let req = QueryGroupMessagesRequest::decode(&mut body).unwrap();
-                assert_eq!(req.group_id, group_id_clone.clone());
+                assert_eq!(req.group_id, group_id);
 
                 Ok(http::Response::new(
                     QueryGroupMessagesResponse {
                         paging_info: None,
-                        messages: build_group_messages(100, group_id_clone.clone()),
+                        messages: build_group_messages(100, group_id),
                     }
                     .encode_to_vec()
                     .into(),
@@ -604,10 +594,7 @@ pub mod tests {
         tracing::info!("wrapper");
         let wrapper = ApiClientWrapper::new(v3_client, exponential().build());
 
-        let result = wrapper
-            .query_group_messages(group_id_clone2.try_into().unwrap())
-            .await
-            .unwrap();
+        let result = wrapper.query_group_messages(group_id).await.unwrap();
         assert_eq!(result.len(), 200);
     }
 

--- a/crates/xmtp_api/src/mls.rs
+++ b/crates/xmtp_api/src/mls.rs
@@ -649,9 +649,9 @@ pub mod tests {
             .unwrap();
         let d14n = D14nClient::new(rw, NoCursorStore).unwrap();
         let wrapper = ApiClientWrapper::new(d14n, Retry::default());
-        let _first = wrapper.query_group_messages(GroupId::from([0u8; 16])).await;
+        let _first = wrapper.query_group_messages(GroupId::ZERO).await;
         let now = std::time::Instant::now();
-        let _second = wrapper.query_group_messages(GroupId::from([0u8; 16])).await;
+        let _second = wrapper.query_group_messages(GroupId::ZERO).await;
         assert!(now.elapsed() > std::time::Duration::from_secs(60));
     }
 

--- a/crates/xmtp_api/src/mls.rs
+++ b/crates/xmtp_api/src/mls.rs
@@ -69,7 +69,7 @@ impl<ApiClient> ApiClientWrapper<ApiClient>
 where
     ApiClient: XmtpApi,
 {
-    #[tracing::instrument(level = "trace", skip_all, fields(group_id = hex::encode(&group_id)))]
+    #[tracing::instrument(level = "trace", skip_all, fields(group_id = hex::encode(group_id)))]
     pub async fn query_group_messages(&self, group_id: GroupId) -> Result<Vec<GroupMessage>> {
         self.api_client
             .query_group_messages(group_id)
@@ -79,9 +79,9 @@ where
 
     /// Query for the latest message on a group
     #[tracing::instrument(level = "trace", skip_all, fields(group_id = hex::encode(group_id)))]
-    pub async fn query_latest_group_message<Id: AsRef<[u8]> + Copy>(
+    pub async fn query_latest_group_message(
         &self,
-        group_id: Id,
+        group_id: GroupId,
     ) -> Result<Option<GroupMessage>> {
         tracing::debug!(
             group_id = hex::encode(group_id),
@@ -89,7 +89,7 @@ where
             "query latest group message"
         );
         self.api_client
-            .query_latest_group_message(group_id.as_ref().into())
+            .query_latest_group_message(group_id)
             .await
             .map_err(crate::dyn_err)
     }
@@ -341,7 +341,7 @@ where
         let metadata_map = res
             .into_iter()
             .flatten()
-            .filter_map(|response| response.map(|msg| (msg.group_id.clone(), msg)))
+            .filter_map(|response| response.map(|msg| (msg.group_id, msg)))
             .collect();
 
         Ok(metadata_map)
@@ -379,6 +379,7 @@ pub mod tests {
         welcome_message_input::{V1 as WelcomeV1, Version as WelcomeVersion},
     };
     use xmtp_proto::mls_v1::{PublishCommitLogRequest, QueryCommitLogRequest};
+    use xmtp_proto::types::GroupId;
     use xmtp_proto::xmtp::mls::api::v1::group_message::{
         V1 as GroupMessageV1, Version as GroupMessageVersion,
     };
@@ -498,7 +499,7 @@ pub mod tests {
         let wrapper = ApiClientWrapper::new(v3_client, exponential().build());
 
         let result = wrapper
-            .query_group_messages(group_id_clone.into())
+            .query_group_messages(group_id_clone.try_into().unwrap())
             .await
             .unwrap();
         assert_eq!(result.len(), 10);
@@ -535,7 +536,7 @@ pub mod tests {
         let wrapper = ApiClientWrapper::new(v3_client, exponential().build());
 
         let result = wrapper
-            .query_group_messages(group_id_clone.into())
+            .query_group_messages(group_id_clone.try_into().unwrap())
             .await
             .unwrap();
         assert_eq!(result.len(), 100);
@@ -545,7 +546,7 @@ pub mod tests {
     async fn test_read_topic_multi_page() {
         let mock_api = MockNetworkClient::new();
         let mut v3_client = V3Client::new(mock_api, NoCursorStore);
-        let group_id = vec![1, 2, 3, 4];
+        let group_id = vec![1u8; 16];
         let group_id_clone = group_id.clone();
         let group_id_clone2 = group_id.clone();
         // Set expectation for first request with no cursor
@@ -604,7 +605,7 @@ pub mod tests {
         let wrapper = ApiClientWrapper::new(v3_client, exponential().build());
 
         let result = wrapper
-            .query_group_messages(group_id_clone2.into())
+            .query_group_messages(group_id_clone2.try_into().unwrap())
             .await
             .unwrap();
         assert_eq!(result.len(), 200);
@@ -661,9 +662,9 @@ pub mod tests {
             .unwrap();
         let d14n = D14nClient::new(rw, NoCursorStore).unwrap();
         let wrapper = ApiClientWrapper::new(d14n, Retry::default());
-        let _first = wrapper.query_group_messages(vec![0, 0].into()).await;
+        let _first = wrapper.query_group_messages(GroupId::from([0u8; 16])).await;
         let now = std::time::Instant::now();
-        let _second = wrapper.query_group_messages(vec![0, 0].into()).await;
+        let _second = wrapper.query_group_messages(GroupId::from([0u8; 16])).await;
         assert!(now.elapsed() > std::time::Duration::from_secs(60));
     }
 

--- a/crates/xmtp_api_d14n/src/endpoints/v3/mls/query_group_messages.rs
+++ b/crates/xmtp_api_d14n/src/endpoints/v3/mls/query_group_messages.rs
@@ -67,7 +67,7 @@ mod test {
         let client = NodeGoClient::create();
         let client = client.build().unwrap();
         let mut endpoint = QueryGroupMessages::builder()
-            .group_id(GroupId::from([1u8; 16]))
+            .group_id(GroupId::ONE)
             .paging_info(PagingInfo::default())
             .build()
             .unwrap();

--- a/crates/xmtp_api_d14n/src/endpoints/v3/mls/query_group_messages.rs
+++ b/crates/xmtp_api_d14n/src/endpoints/v3/mls/query_group_messages.rs
@@ -67,7 +67,7 @@ mod test {
         let client = NodeGoClient::create();
         let client = client.build().unwrap();
         let mut endpoint = QueryGroupMessages::builder()
-            .group_id(GroupId::from(vec![1, 2, 3]))
+            .group_id(GroupId::from([1u8; 16]))
             .paging_info(PagingInfo::default())
             .build()
             .unwrap();

--- a/crates/xmtp_api_d14n/src/middleware/multi_node_client/client.rs
+++ b/crates/xmtp_api_d14n/src/middleware/multi_node_client/client.rs
@@ -204,7 +204,7 @@ mod tests {
     #[xmtp_common::test]
     async fn d14n_request_latest_group_message() {
         let client = create_d14n_client();
-        let id: GroupId = GroupId::from(vec![]);
+        let id: GroupId = GroupId::from([0u8; 16]);
         let response = client.query_latest_group_message(id).await;
         match response {
             Err(e) => {

--- a/crates/xmtp_api_d14n/src/middleware/multi_node_client/client.rs
+++ b/crates/xmtp_api_d14n/src/middleware/multi_node_client/client.rs
@@ -90,6 +90,7 @@ impl<T: IsConnectedCheck> IsConnectedCheck for MultiNodeClient<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use xmtp_common::Generate;
     use xmtp_proto::types::GroupId;
 
     use crate::middleware::multi_node_client::client::MultiNodeClientBuilder;
@@ -204,7 +205,7 @@ mod tests {
     #[xmtp_common::test]
     async fn d14n_request_latest_group_message() {
         let client = create_d14n_client();
-        let id: GroupId = GroupId::from([0u8; 16]);
+        let id = GroupId::generate();
         let response = client.query_latest_group_message(id).await;
         match response {
             Err(e) => {

--- a/crates/xmtp_api_d14n/src/protocol/extractors/group_message_metadata.rs
+++ b/crates/xmtp_api_d14n/src/protocol/extractors/group_message_metadata.rs
@@ -65,7 +65,7 @@ impl EnvelopeVisitor<'_> for MessageMetadataExtractor {
             Cursor::v3_messages(v1_message.id)
         };
 
-        let group_id: GroupId = v1_message.group_id.clone().into();
+        let group_id: GroupId = v1_message.group_id.as_slice().try_into()?;
 
         let metadata = GroupMessageMetadata::builder()
             .created_ns(DateTime::from_timestamp_nanos(v1_message.created_ns as i64))

--- a/crates/xmtp_api_d14n/src/protocol/extractors/group_messages.rs
+++ b/crates/xmtp_api_d14n/src/protocol/extractors/group_messages.rs
@@ -2,7 +2,7 @@ use xmtp_cryptography::hash::sha256_bytes;
 use xmtp_proto::{
     ConversionError,
     mls_v1::group_message,
-    types::{Cursor, GlobalCursor, GroupMessage, GroupMessageBuilder},
+    types::{Cursor, GlobalCursor, GroupId, GroupMessage, GroupMessageBuilder},
 };
 
 use crate::protocol::traits::EnvelopeVisitor;
@@ -139,7 +139,7 @@ fn extract_common_mls(
     let is_commit = protocol_message.content_type() == ContentType::Commit;
 
     builder
-        .group_id(protocol_message.group_id().to_vec())
+        .group_id(GroupId::try_from(protocol_message.group_id().as_slice())?)
         .message(protocol_message);
     Ok(is_commit)
 }
@@ -156,11 +156,11 @@ mod tests {
             .with_originator_node_id(123)
             .with_originator_sequence_id(456)
             .with_originator_ns(789)
-            .with_application_message(vec![1, 2, 3])
+            .with_application_message(vec![0x01; 16])
             .build();
         let mut extractor = GroupMessageExtractor::default();
         envelope.accept(&mut extractor).unwrap();
         let msg = extractor.get().unwrap();
-        assert_eq!(vec![1, 2, 3], *msg.group_id);
+        assert_eq!(msg.group_id, [0x01u8; 16]);
     }
 }

--- a/crates/xmtp_api_d14n/src/protocol/utils/test/test_envelope.rs
+++ b/crates/xmtp_api_d14n/src/protocol/utils/test/test_envelope.rs
@@ -150,7 +150,7 @@ impl Envelope<'_> for TestEnvelope {
             .cursor(self.cursor())
             .depends_on(self.depends_on())
             .payload(buf)
-            .group_id(vec![0, 1, 2])
+            .group_id([0u8; 16])
             .build()?)
     }
 }

--- a/crates/xmtp_api_d14n/src/protocol/utils/test/test_envelope.rs
+++ b/crates/xmtp_api_d14n/src/protocol/utils/test/test_envelope.rs
@@ -2,7 +2,7 @@ use crate::protocol::{Envelope, EnvelopeError};
 use chrono::Utc;
 use std::collections::HashSet;
 use std::sync::LazyLock;
-use xmtp_proto::types::{Cursor, GlobalCursor, OrphanedEnvelope, Topic, TopicKind};
+use xmtp_proto::types::{Cursor, GlobalCursor, GroupId, OrphanedEnvelope, Topic, TopicKind};
 use xmtp_proto::xmtp::xmtpv4;
 use xmtp_proto::xmtp::xmtpv4::envelopes::ClientEnvelope;
 use xmtp_proto::xmtp::xmtpv4::envelopes::client_envelope::Payload;
@@ -150,7 +150,7 @@ impl Envelope<'_> for TestEnvelope {
             .cursor(self.cursor())
             .depends_on(self.depends_on())
             .payload(buf)
-            .group_id([0u8; 16])
+            .group_id(GroupId::ZERO)
             .build()?)
     }
 }

--- a/crates/xmtp_api_d14n/src/queries/d14n/mls.rs
+++ b/crates/xmtp_api_d14n/src/queries/d14n/mls.rs
@@ -137,7 +137,7 @@ where
         &self,
         group_id: GroupId,
     ) -> Result<Vec<xmtp_proto::types::GroupMessage>, Self::Error> {
-        let topic = TopicKind::GroupMessagesV1.create(&group_id);
+        let topic = TopicKind::GroupMessagesV1.create(group_id);
         let cursor = self.cursor_store.latest(&topic, None)?;
         tracing::debug!(%topic, %cursor, "querying messages");
         let mut topic_cursor = TopicCursor::default();

--- a/crates/xmtp_api_d14n/src/queries/v3/mls.rs
+++ b/crates/xmtp_api_d14n/src/queries/v3/mls.rs
@@ -63,7 +63,7 @@ where
         &self,
         group_id: GroupId,
     ) -> Result<Vec<xmtp_proto::types::GroupMessage>, Self::Error> {
-        let topic = &TopicKind::GroupMessagesV1.create(&group_id);
+        let topic = &TopicKind::GroupMessagesV1.create(group_id);
         let cursor = self
             .cursor_store
             .latest(
@@ -75,7 +75,7 @@ where
             )?
             .max();
         let endpoint = QueryGroupMessages::builder()
-            .group_id(group_id.to_vec())
+            .group_id(group_id)
             .paging_info(PagingInfo {
                 limit: MAX_PAGE_SIZE,
                 direction: SortDirection::Ascending as i32,
@@ -102,7 +102,7 @@ where
         group_id: GroupId,
     ) -> Result<Option<xmtp_proto::types::GroupMessage>, Self::Error> {
         let endpoint = QueryGroupMessages::builder()
-            .group_id(group_id.to_vec())
+            .group_id(group_id)
             .paging_info(PagingInfo {
                 limit: 1,
                 direction: SortDirection::Descending as i32,

--- a/crates/xmtp_api_d14n/src/queries/v3/xmtp_query.rs
+++ b/crates/xmtp_api_d14n/src/queries/v3/xmtp_query.rs
@@ -10,7 +10,7 @@ use xmtp_proto::identity_v1::{
 use xmtp_proto::{
     api::{ApiClientError, Client, EndpointExt, Query},
     mls_v1::{PagingInfo, SortDirection},
-    types::{GlobalCursor, Topic, TopicKind},
+    types::{GlobalCursor, GroupId, Topic, TopicKind},
 };
 
 #[xmtp_common::async_trait]
@@ -30,7 +30,7 @@ where
             GroupMessagesV1 => {
                 let id_cursor = at.map(|c| c.v3_message()).unwrap_or(0);
                 let result = QueryGroupMessages::builder()
-                    .group_id(topic.identifier())
+                    .group_id(GroupId::try_from(topic.identifier())?)
                     .paging_info(PagingInfo {
                         direction: SortDirection::Ascending as i32,
                         limit: MAX_PAGE_SIZE,

--- a/crates/xmtp_archive/src/export_stream/group_save.rs
+++ b/crates/xmtp_archive/src/export_stream/group_save.rs
@@ -12,7 +12,6 @@ use xmtp_proto::xmtp::device_sync::{
     },
 };
 
-use xmtp_proto::types::GroupId;
 #[xmtp_common::async_trait]
 impl BackupRecordProvider for GroupSave {
     const BATCH_SIZE: i64 = 100;
@@ -43,7 +42,7 @@ impl BackupRecordProvider for GroupSave {
                 if record.conversation_type.is_virtual() {
                     return None;
                 }
-                let group_id = GroupId::from(record.id.as_slice());
+                let group_id = record.id;
                 let mls_group = MlsGroup::load(&storage, &group_id.to_openmls()).ok()??;
                 let immutable = mls_group.extensions().immutable_metadata()?;
 

--- a/crates/xmtp_db/src/encrypted_store/consent_record.rs
+++ b/crates/xmtp_db/src/encrypted_store/consent_record.rs
@@ -69,7 +69,7 @@ impl StoredConsentRecord {
             let cr = Self::new(
                 ConsentType::ConversationId,
                 last_consent.state,
-                hex::encode(&group.id),
+                hex::encode(group.id),
             );
             conn.insert_newer_consent_record(cr)?;
         }

--- a/crates/xmtp_db/src/encrypted_store/conversation_list.rs
+++ b/crates/xmtp_db/src/encrypted_store/conversation_list.rs
@@ -406,19 +406,19 @@ pub(crate) mod tests {
             let test_group_1_consent = generate_consent_record(
                 ConsentType::ConversationId,
                 ConsentState::Allowed,
-                hex::encode(test_group_1.id.clone()),
+                hex::encode(test_group_1.id),
             );
             test_group_1_consent.store(conn).unwrap();
             let test_group_2_consent = generate_consent_record(
                 ConsentType::ConversationId,
                 ConsentState::Denied,
-                hex::encode(test_group_2.id.clone()),
+                hex::encode(test_group_2.id),
             );
             test_group_2_consent.store(conn).unwrap();
             let test_group_3_consent = generate_consent_record(
                 ConsentType::ConversationId,
                 ConsentState::Allowed,
-                hex::encode(test_group_3.id.clone()),
+                hex::encode(test_group_3.id),
             );
             test_group_3_consent.store(conn).unwrap();
 
@@ -500,14 +500,14 @@ pub(crate) mod tests {
             let allowed_consent = generate_consent_record(
                 ConsentType::ConversationId,
                 ConsentState::Allowed,
-                hex::encode(allowed_group.id.clone()),
+                hex::encode(allowed_group.id),
             );
             allowed_consent.store(conn).unwrap();
 
             let denied_consent = generate_consent_record(
                 ConsentType::ConversationId,
                 ConsentState::Denied,
-                hex::encode(denied_group.id.clone()),
+                hex::encode(denied_group.id),
             );
             denied_consent.store(conn).unwrap();
 

--- a/crates/xmtp_db/src/encrypted_store/group.rs
+++ b/crates/xmtp_db/src/encrypted_store/group.rs
@@ -821,7 +821,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
         })?;
 
         last_ts.ok_or(StorageError::NotFound(NotFound::InstallationTimeForGroup(
-            group_id.clone(),
+            *group_id,
         )))
     }
 
@@ -846,7 +846,7 @@ impl<C: ConnectionExt> QueryGroup for DbConnection<C> {
                 .optional()
         })?;
 
-        last_ts.ok_or(NotFound::InstallationTimeForGroup(group_id.clone()).into())
+        last_ts.ok_or(NotFound::InstallationTimeForGroup(*group_id).into())
     }
 
     /// Updates the 'last time checked' we checked for new installations.
@@ -1357,7 +1357,7 @@ pub(crate) mod tests {
         state: Option<GroupMembershipState>,
         created_at_ns: i64,
     ) -> StoredGroup {
-        let id = rand_vec::<24>();
+        let id = GroupId::from(xmtp_common::rand_array::<16>());
         let membership_state = state.unwrap_or(GroupMembershipState::Allowed);
         StoredGroup::builder()
             .id(id)
@@ -1373,7 +1373,7 @@ pub(crate) mod tests {
         state: Option<GroupMembershipState>,
         welcome_id: Option<i64>,
     ) -> StoredGroup {
-        let id = rand_vec::<24>();
+        let id = GroupId::from(xmtp_common::rand_array::<16>());
         let created_at_ns = now_ns();
         let membership_state = state.unwrap_or(GroupMembershipState::Allowed);
         StoredGroup::builder()
@@ -1439,7 +1439,7 @@ pub(crate) mod tests {
             let test_group = generate_group(Some(GroupMembershipState::Pending));
 
             test_group.store(conn).unwrap();
-            conn.update_group_membership(&test_group.id, GroupMembershipState::Rejected)
+            conn.update_group_membership(test_group.id, GroupMembershipState::Rejected)
                 .unwrap();
 
             let updated_group: StoredGroup = conn.fetch(&test_group.id).ok().flatten().unwrap();
@@ -1608,19 +1608,19 @@ pub(crate) mod tests {
             let test_group_1_consent = generate_consent_record(
                 ConsentType::ConversationId,
                 ConsentState::Allowed,
-                hex::encode(test_group_1.id.clone()),
+                hex::encode(test_group_1.id),
             );
             test_group_1_consent.store(conn).unwrap();
             let test_group_2_consent = generate_consent_record(
                 ConsentType::ConversationId,
                 ConsentState::Denied,
-                hex::encode(test_group_2.id.clone()),
+                hex::encode(test_group_2.id),
             );
             test_group_2_consent.store(conn).unwrap();
             let test_group_3_consent = generate_consent_record(
                 ConsentType::ConversationId,
                 ConsentState::Allowed,
-                hex::encode(test_group_3.id.clone()),
+                hex::encode(test_group_3.id),
             );
             test_group_3_consent.store(conn).unwrap();
 
@@ -1723,14 +1723,14 @@ pub(crate) mod tests {
             let allowed_consent = generate_consent_record(
                 ConsentType::ConversationId,
                 ConsentState::Allowed,
-                hex::encode(allowed_group.id.clone()),
+                hex::encode(allowed_group.id),
             );
             allowed_consent.store(conn).unwrap();
 
             let denied_consent = generate_consent_record(
                 ConsentType::ConversationId,
                 ConsentState::Denied,
-                hex::encode(denied_group.id.clone()),
+                hex::encode(denied_group.id),
             );
             denied_consent.store(conn).unwrap();
 
@@ -1758,7 +1758,7 @@ pub(crate) mod tests {
             generate_consent_record(
                 ConsentType::ConversationId,
                 ConsentState::Allowed,
-                hex::encode(group1.id.clone()),
+                hex::encode(group1.id),
             )
             .store(conn)?;
             group2.should_publish_commit_log = true;
@@ -1769,7 +1769,7 @@ pub(crate) mod tests {
             generate_consent_record(
                 ConsentType::ConversationId,
                 ConsentState::Allowed,
-                hex::encode(group3.id.clone()),
+                hex::encode(group3.id),
             )
             .store(conn)?;
             group4.should_publish_commit_log = false;
@@ -1810,14 +1810,14 @@ pub(crate) mod tests {
             let allowed_consent = generate_consent_record(
                 ConsentType::ConversationId,
                 ConsentState::Allowed,
-                hex::encode(allowed_group.id.clone()),
+                hex::encode(allowed_group.id),
             );
             allowed_consent.store(conn).unwrap();
 
             let denied_consent = generate_consent_record(
                 ConsentType::ConversationId,
                 ConsentState::Denied,
-                hex::encode(denied_group.id.clone()),
+                hex::encode(denied_group.id),
             );
             denied_consent.store(conn).unwrap();
 
@@ -1848,7 +1848,7 @@ pub(crate) mod tests {
             let sync_consent = generate_consent_record(
                 ConsentType::ConversationId,
                 ConsentState::Allowed,
-                hex::encode(sync_group.id.clone()),
+                hex::encode(sync_group.id),
             );
             sync_consent.store(conn).unwrap();
 
@@ -1856,14 +1856,14 @@ pub(crate) mod tests {
             let allowed_consent = generate_consent_record(
                 ConsentType::ConversationId,
                 ConsentState::Allowed,
-                hex::encode(allowed_group.id.clone()),
+                hex::encode(allowed_group.id),
             );
             allowed_consent.store(conn).unwrap();
 
             let denied_consent = generate_consent_record(
                 ConsentType::ConversationId,
                 ConsentState::Denied,
-                hex::encode(denied_group.id.clone()),
+                hex::encode(denied_group.id),
             );
             denied_consent.store(conn).unwrap();
 
@@ -1878,12 +1878,12 @@ pub(crate) mod tests {
     fn test_get_conversation_ids_for_responding_readds() {
         with_connection(|conn| {
             // Create test groups
-            let group_id_1: GroupId = vec![1, 2, 3].into();
-            let group_id_2: GroupId = vec![4, 5, 6].into();
-            let group_id_3: GroupId = vec![7, 8, 9].into();
+            let group_id_1: GroupId = [1u8; 16].into();
+            let group_id_2: GroupId = [2u8; 16].into();
+            let group_id_3: GroupId = [3u8; 16].into();
 
             let group1 = StoredGroup::builder()
-                .id(group_id_1.clone())
+                .id(group_id_1)
                 .created_at_ns(1000)
                 .membership_state(GroupMembershipState::Allowed)
                 .added_by_inbox_id("placeholder_address")
@@ -1892,7 +1892,7 @@ pub(crate) mod tests {
             group1.store(conn).unwrap();
 
             let group2 = StoredGroup::builder()
-                .id(group_id_2.clone())
+                .id(group_id_2)
                 .created_at_ns(2000)
                 .membership_state(GroupMembershipState::Allowed)
                 .added_by_inbox_id("placeholder_address")
@@ -1901,7 +1901,7 @@ pub(crate) mod tests {
             group2.store(conn).unwrap();
 
             let group3 = StoredGroup::builder()
-                .id(group_id_3.clone())
+                .id(group_id_3)
                 .created_at_ns(3000)
                 .membership_state(GroupMembershipState::Allowed)
                 .added_by_inbox_id("placeholder_address")
@@ -1913,35 +1913,35 @@ pub(crate) mod tests {
             let test_cases = vec![
                 // Case 1: Pending readd (requested_at > responded_at)
                 ReaddStatus {
-                    group_id: group_id_1.clone(),
+                    group_id: group_id_1,
                     installation_id: vec![1],
                     requested_at_sequence_id: Some(10),
                     responded_at_sequence_id: Some(5),
                 },
                 // Case 2: Pending readd (responded_at is None)
                 ReaddStatus {
-                    group_id: group_id_1.clone(),
+                    group_id: group_id_1,
                     installation_id: vec![2],
                     requested_at_sequence_id: Some(8),
                     responded_at_sequence_id: None,
                 },
                 // Case 4: Not pending (requested_at < responded_at)
                 ReaddStatus {
-                    group_id: group_id_2.clone(),
+                    group_id: group_id_2,
                     installation_id: vec![4],
                     requested_at_sequence_id: Some(12),
                     responded_at_sequence_id: Some(15),
                 },
                 // Case 5: Not pending (requested_at is None)
                 ReaddStatus {
-                    group_id: group_id_2.clone(),
+                    group_id: group_id_2,
                     installation_id: vec![5],
                     requested_at_sequence_id: None,
                     responded_at_sequence_id: Some(20),
                 },
                 // Case 6: Pending readd (requested_at == responded_at, should be pending)
                 ReaddStatus {
-                    group_id: group_id_3.clone(),
+                    group_id: group_id_3,
                     installation_id: vec![6],
                     requested_at_sequence_id: Some(25),
                     responded_at_sequence_id: Some(25),
@@ -1961,8 +1961,7 @@ pub(crate) mod tests {
             assert_eq!(result.len(), 2);
 
             // Results should be sorted by group_id (since we used distinct())
-            let mut result_group_ids: Vec<GroupId> =
-                result.iter().map(|r| r.group_id.clone()).collect();
+            let mut result_group_ids: Vec<GroupId> = result.iter().map(|r| r.group_id).collect();
             result_group_ids.sort();
 
             assert_eq!(result_group_ids[0], group_id_1);

--- a/crates/xmtp_db/src/encrypted_store/group.rs
+++ b/crates/xmtp_db/src/encrypted_store/group.rs
@@ -1878,9 +1878,9 @@ pub(crate) mod tests {
     fn test_get_conversation_ids_for_responding_readds() {
         with_connection(|conn| {
             // Create test groups
-            let group_id_1: GroupId = [1u8; 16].into();
-            let group_id_2: GroupId = [2u8; 16].into();
-            let group_id_3: GroupId = [3u8; 16].into();
+            let group_id_1 = GroupId::ONE;
+            let group_id_2 = GroupId::TWO;
+            let group_id_3 = GroupId::THREE;
 
             let group1 = StoredGroup::builder()
                 .id(group_id_1)

--- a/crates/xmtp_db/src/encrypted_store/group.rs
+++ b/crates/xmtp_db/src/encrypted_store/group.rs
@@ -1344,7 +1344,7 @@ pub(crate) mod tests {
         schema::groups::dsl::groups,
         test_utils::{with_connection, with_connection_async},
     };
-    use xmtp_common::{assert_ok, rand_vec, time::now_ns};
+    use xmtp_common::{Generate, assert_ok, rand_vec, time::now_ns};
     use xmtp_configuration::Originators;
 
     /// Generate a test group
@@ -1357,7 +1357,7 @@ pub(crate) mod tests {
         state: Option<GroupMembershipState>,
         created_at_ns: i64,
     ) -> StoredGroup {
-        let id = GroupId::from(xmtp_common::rand_array::<16>());
+        let id = GroupId::generate();
         let membership_state = state.unwrap_or(GroupMembershipState::Allowed);
         StoredGroup::builder()
             .id(id)
@@ -1373,7 +1373,7 @@ pub(crate) mod tests {
         state: Option<GroupMembershipState>,
         welcome_id: Option<i64>,
     ) -> StoredGroup {
-        let id = GroupId::from(xmtp_common::rand_array::<16>());
+        let id = GroupId::generate();
         let created_at_ns = now_ns();
         let membership_state = state.unwrap_or(GroupMembershipState::Allowed);
         StoredGroup::builder()

--- a/crates/xmtp_db/src/encrypted_store/group/dms.rs
+++ b/crates/xmtp_db/src/encrypted_store/group/dms.rs
@@ -107,7 +107,7 @@ pub(super) mod tests {
     use super::*;
     use crate::{Store, test_utils::with_connection};
     use std::sync::atomic::{AtomicU16, Ordering};
-    use xmtp_common::time::now_ns;
+    use xmtp_common::{Generate, time::now_ns};
 
     static TARGET_INBOX_ID: AtomicU16 = AtomicU16::new(2);
 
@@ -115,7 +115,7 @@ pub(super) mod tests {
     pub fn generate_dm(state: Option<GroupMembershipState>) -> StoredGroup {
         let target = TARGET_INBOX_ID.fetch_add(1, Ordering::SeqCst).to_string();
         StoredGroup::builder()
-            .id(GroupId::from(xmtp_common::rand_array::<16>()))
+            .id(GroupId::generate())
             .created_at_ns(now_ns())
             .membership_state(state.unwrap_or(GroupMembershipState::Allowed))
             .added_by_inbox_id("placeholder_address")
@@ -130,7 +130,7 @@ pub(super) mod tests {
     fn test_dm_stitching() {
         with_connection(|conn| {
             StoredGroup::builder()
-                .id(GroupId::from(xmtp_common::rand_array::<16>()))
+                .id(GroupId::generate())
                 .created_at_ns(now_ns())
                 .membership_state(GroupMembershipState::Allowed)
                 .added_by_inbox_id("placeholder_address")
@@ -141,7 +141,7 @@ pub(super) mod tests {
                 .unwrap();
 
             StoredGroup::builder()
-                .id(GroupId::from(xmtp_common::rand_array::<16>()))
+                .id(GroupId::generate())
                 .created_at_ns(now_ns())
                 .membership_state(GroupMembershipState::Allowed)
                 .added_by_inbox_id("placeholder_address")
@@ -167,7 +167,7 @@ pub(super) mod tests {
 
             // Oldest DM (should be filtered out)
             let oldest_dm = StoredGroup::builder()
-                .id(GroupId::from(xmtp_common::rand_array::<16>()))
+                .id(GroupId::generate())
                 .created_at_ns(base_time)
                 .last_message_ns(base_time)
                 .membership_state(GroupMembershipState::Allowed)
@@ -179,7 +179,7 @@ pub(super) mod tests {
 
             // Middle DM (should be filtered out)
             let middle_dm = StoredGroup::builder()
-                .id(GroupId::from(xmtp_common::rand_array::<16>()))
+                .id(GroupId::generate())
                 .created_at_ns(base_time + 1_000_000)
                 .last_message_ns(base_time + 1_000_000)
                 .membership_state(GroupMembershipState::Allowed)
@@ -191,7 +191,7 @@ pub(super) mod tests {
 
             // Latest DM (should be kept)
             let latest_dm = StoredGroup::builder()
-                .id(GroupId::from(xmtp_common::rand_array::<16>()))
+                .id(GroupId::generate())
                 .created_at_ns(base_time + 2_000_000)
                 .last_message_ns(base_time + 2_000_000)
                 .membership_state(GroupMembershipState::Allowed)
@@ -203,7 +203,7 @@ pub(super) mod tests {
 
             // Create another DM with different dm_id (should always be kept)
             let different_dm = StoredGroup::builder()
-                .id(GroupId::from(xmtp_common::rand_array::<16>()))
+                .id(GroupId::generate())
                 .created_at_ns(base_time + 500_000)
                 .last_message_ns(base_time + 500_000)
                 .membership_state(GroupMembershipState::Allowed)
@@ -215,7 +215,7 @@ pub(super) mod tests {
 
             // Create a regular group (non-DM, should always be kept)
             let regular_group = StoredGroup::builder()
-                .id(GroupId::from(xmtp_common::rand_array::<16>()))
+                .id(GroupId::generate())
                 .created_at_ns(base_time + 1_500_000)
                 .last_message_ns(base_time + 1_500_000)
                 .membership_state(GroupMembershipState::Allowed)

--- a/crates/xmtp_db/src/encrypted_store/group/dms.rs
+++ b/crates/xmtp_db/src/encrypted_store/group/dms.rs
@@ -107,7 +107,7 @@ pub(super) mod tests {
     use super::*;
     use crate::{Store, test_utils::with_connection};
     use std::sync::atomic::{AtomicU16, Ordering};
-    use xmtp_common::{rand_vec, time::now_ns};
+    use xmtp_common::time::now_ns;
 
     static TARGET_INBOX_ID: AtomicU16 = AtomicU16::new(2);
 
@@ -115,7 +115,7 @@ pub(super) mod tests {
     pub fn generate_dm(state: Option<GroupMembershipState>) -> StoredGroup {
         let target = TARGET_INBOX_ID.fetch_add(1, Ordering::SeqCst).to_string();
         StoredGroup::builder()
-            .id(rand_vec::<24>())
+            .id(GroupId::from(xmtp_common::rand_array::<16>()))
             .created_at_ns(now_ns())
             .membership_state(state.unwrap_or(GroupMembershipState::Allowed))
             .added_by_inbox_id("placeholder_address")
@@ -130,7 +130,7 @@ pub(super) mod tests {
     fn test_dm_stitching() {
         with_connection(|conn| {
             StoredGroup::builder()
-                .id(rand_vec::<24>())
+                .id(GroupId::from(xmtp_common::rand_array::<16>()))
                 .created_at_ns(now_ns())
                 .membership_state(GroupMembershipState::Allowed)
                 .added_by_inbox_id("placeholder_address")
@@ -141,7 +141,7 @@ pub(super) mod tests {
                 .unwrap();
 
             StoredGroup::builder()
-                .id(rand_vec::<24>())
+                .id(GroupId::from(xmtp_common::rand_array::<16>()))
                 .created_at_ns(now_ns())
                 .membership_state(GroupMembershipState::Allowed)
                 .added_by_inbox_id("placeholder_address")
@@ -167,7 +167,7 @@ pub(super) mod tests {
 
             // Oldest DM (should be filtered out)
             let oldest_dm = StoredGroup::builder()
-                .id(rand_vec::<24>())
+                .id(GroupId::from(xmtp_common::rand_array::<16>()))
                 .created_at_ns(base_time)
                 .last_message_ns(base_time)
                 .membership_state(GroupMembershipState::Allowed)
@@ -179,7 +179,7 @@ pub(super) mod tests {
 
             // Middle DM (should be filtered out)
             let middle_dm = StoredGroup::builder()
-                .id(rand_vec::<24>())
+                .id(GroupId::from(xmtp_common::rand_array::<16>()))
                 .created_at_ns(base_time + 1_000_000)
                 .last_message_ns(base_time + 1_000_000)
                 .membership_state(GroupMembershipState::Allowed)
@@ -191,7 +191,7 @@ pub(super) mod tests {
 
             // Latest DM (should be kept)
             let latest_dm = StoredGroup::builder()
-                .id(rand_vec::<24>())
+                .id(GroupId::from(xmtp_common::rand_array::<16>()))
                 .created_at_ns(base_time + 2_000_000)
                 .last_message_ns(base_time + 2_000_000)
                 .membership_state(GroupMembershipState::Allowed)
@@ -203,7 +203,7 @@ pub(super) mod tests {
 
             // Create another DM with different dm_id (should always be kept)
             let different_dm = StoredGroup::builder()
-                .id(rand_vec::<24>())
+                .id(GroupId::from(xmtp_common::rand_array::<16>()))
                 .created_at_ns(base_time + 500_000)
                 .last_message_ns(base_time + 500_000)
                 .membership_state(GroupMembershipState::Allowed)
@@ -215,7 +215,7 @@ pub(super) mod tests {
 
             // Create a regular group (non-DM, should always be kept)
             let regular_group = StoredGroup::builder()
-                .id(rand_vec::<24>())
+                .id(GroupId::from(xmtp_common::rand_array::<16>()))
                 .created_at_ns(base_time + 1_500_000)
                 .last_message_ns(base_time + 1_500_000)
                 .membership_state(GroupMembershipState::Allowed)

--- a/crates/xmtp_db/src/encrypted_store/group_intent.rs
+++ b/crates/xmtp_db/src/encrypted_store/group_intent.rs
@@ -691,7 +691,7 @@ pub(crate) mod tests {
         group::{GroupMembershipState, StoredGroup},
         test_utils::with_connection,
     };
-    use xmtp_common::rand_vec;
+    use xmtp_common::{Generate, rand_vec};
 
     fn insert_group<C: ConnectionExt>(conn: &DbConnection<C>, group_id: GroupId) {
         StoredGroup::builder()
@@ -738,7 +738,7 @@ pub(crate) mod tests {
 
     #[xmtp_common::test]
     fn test_store_and_fetch() {
-        let group_id = GroupId::from(xmtp_common::rand_array::<16>());
+        let group_id = GroupId::generate();
         let data = rand_vec::<24>();
         let kind = IntentKind::UpdateGroupMembership;
         let state = IntentState::ToPublish;
@@ -770,7 +770,7 @@ pub(crate) mod tests {
 
     #[xmtp_common::test]
     fn test_query() {
-        let group_id = GroupId::from(xmtp_common::rand_array::<16>());
+        let group_id = GroupId::generate();
 
         let test_intents: Vec<NewGroupIntent> = vec![
             NewGroupIntent::new_test(
@@ -848,7 +848,7 @@ pub(crate) mod tests {
 
     #[xmtp_common::test]
     fn find_by_payload_hash() {
-        let group_id = GroupId::from(xmtp_common::rand_array::<16>());
+        let group_id = GroupId::generate();
 
         with_connection(|conn| {
             insert_group(conn, group_id);
@@ -890,7 +890,7 @@ pub(crate) mod tests {
 
     #[xmtp_common::test]
     fn test_happy_path_state_transitions() {
-        let group_id = GroupId::from(xmtp_common::rand_array::<16>());
+        let group_id = GroupId::generate();
 
         with_connection(|conn| {
             insert_group(conn, group_id);
@@ -936,7 +936,7 @@ pub(crate) mod tests {
 
     #[xmtp_common::test]
     fn test_republish_state_transition() {
-        let group_id = GroupId::from(xmtp_common::rand_array::<16>());
+        let group_id = GroupId::generate();
 
         with_connection(|conn| {
             insert_group(conn, group_id);
@@ -980,7 +980,7 @@ pub(crate) mod tests {
 
     #[xmtp_common::test]
     fn test_invalid_state_transition() {
-        let group_id = GroupId::from(xmtp_common::rand_array::<16>());
+        let group_id = GroupId::generate();
 
         with_connection(|conn| {
             insert_group(conn, group_id);
@@ -1015,7 +1015,7 @@ pub(crate) mod tests {
 
     #[xmtp_common::test]
     fn test_increment_publish_attempts() {
-        let group_id = GroupId::from(xmtp_common::rand_array::<16>());
+        let group_id = GroupId::generate();
         with_connection(|conn| {
             insert_group(conn, group_id);
             NewGroupIntent::new(
@@ -1043,7 +1043,7 @@ pub(crate) mod tests {
     fn test_find_dependant_commits() {
         use crate::encrypted_store::refresh_state::{EntityKind, QueryRefreshState};
 
-        let group_id = GroupId::from(xmtp_common::rand_array::<16>());
+        let group_id = GroupId::generate();
         let payload_hash1 = rand_vec::<24>();
         let payload_hash2 = rand_vec::<24>();
 
@@ -1094,7 +1094,7 @@ pub(crate) mod tests {
         // Exercises both the i32 → IntentKind::BootstrapMigration arm
         // and the Display impl. Cheap coverage for the new variant
         // that would otherwise sit dead until end-to-end migration tests.
-        let group_id = GroupId::from(xmtp_common::rand_array::<16>());
+        let group_id = GroupId::generate();
         let data = rand_vec::<24>();
         let kind = IntentKind::BootstrapMigration;
         let to_insert =

--- a/crates/xmtp_db/src/encrypted_store/group_intent.rs
+++ b/crates/xmtp_db/src/encrypted_store/group_intent.rs
@@ -113,7 +113,7 @@ impl std::fmt::Debug for StoredGroupIntent {
         write!(
             f,
             "group_id: {}, ",
-            fmt::truncate_hex(hex::encode(&self.group_id))
+            fmt::truncate_hex(hex::encode(self.group_id))
         )?;
         write!(f, "data: {}, ", fmt::truncate_hex(hex::encode(&self.data)))?;
         write!(f, "state: {:?}, ", self.state)?;
@@ -561,13 +561,13 @@ impl<C: ConnectionExt> QueryGroupIntent for DbConnection<C> {
                     refresh_state::originator_id,
                     dsl::group_id,
                 ))
-                .load_iter::<(Vec<u8>, i64, i32, Vec<u8>), DefaultLoadingMode>(conn)?
+                .load_iter::<(Vec<u8>, i64, i32, GroupId), DefaultLoadingMode>(conn)?
                 .map_ok(|(hash, sequence_id, originator_id, group_id)| {
                     (
                         PayloadHash::from(hash),
                         IntentDependency {
                             cursor: Cursor::new(sequence_id as u64, originator_id as u32),
-                            group_id: group_id.into(),
+                            group_id,
                         },
                     )
                 })
@@ -581,7 +581,7 @@ impl<C: ConnectionExt> QueryGroupIntent for DbConnection<C> {
                     return Err(GroupIntentError::MoreThanOneDependency {
                         payload_hash: hash.clone(),
                         cursors: d.iter().map(|d| d.cursor).collect(),
-                        group_id: d[0].group_id.clone(),
+                        group_id: d[0].group_id,
                     }
                     .into());
                 }
@@ -693,7 +693,7 @@ pub(crate) mod tests {
     };
     use xmtp_common::rand_vec;
 
-    fn insert_group<C: ConnectionExt>(conn: &DbConnection<C>, group_id: Vec<u8>) {
+    fn insert_group<C: ConnectionExt>(conn: &DbConnection<C>, group_id: GroupId) {
         StoredGroup::builder()
             .id(group_id)
             .created_at_ns(100)
@@ -710,13 +710,13 @@ pub(crate) mod tests {
         // state
         pub fn new_test(
             kind: IntentKind,
-            group_id: Vec<u8>,
+            group_id: GroupId,
             data: Vec<u8>,
             state: IntentState,
         ) -> Self {
             Self {
                 kind,
-                group_id: group_id.into(),
+                group_id,
                 data,
                 state,
                 should_push: false,
@@ -726,7 +726,7 @@ pub(crate) mod tests {
 
     fn find_first_intent<C: ConnectionExt>(
         conn: &DbConnection<C>,
-        group_id: Vec<u8>,
+        group_id: GroupId,
     ) -> StoredGroupIntent {
         conn.raw_query(|raw_conn| {
             dsl::group_intents
@@ -738,21 +738,21 @@ pub(crate) mod tests {
 
     #[xmtp_common::test]
     fn test_store_and_fetch() {
-        let group_id = rand_vec::<24>();
+        let group_id = GroupId::from(xmtp_common::rand_array::<16>());
         let data = rand_vec::<24>();
         let kind = IntentKind::UpdateGroupMembership;
         let state = IntentState::ToPublish;
 
-        let to_insert = NewGroupIntent::new_test(kind, group_id.clone(), data.clone(), state);
+        let to_insert = NewGroupIntent::new_test(kind, group_id, data.clone(), state);
 
         with_connection(|conn| {
             // Group needs to exist or FK constraint will fail
-            insert_group(conn, group_id.clone());
+            insert_group(conn, group_id);
 
             to_insert.store(conn).unwrap();
 
             let results = conn
-                .find_group_intents(group_id.clone(), Some(vec![IntentState::ToPublish]), None)
+                .find_group_intents(group_id, Some(vec![IntentState::ToPublish]), None)
                 .unwrap();
 
             assert_eq!(results.len(), 1);
@@ -770,24 +770,24 @@ pub(crate) mod tests {
 
     #[xmtp_common::test]
     fn test_query() {
-        let group_id = rand_vec::<24>();
+        let group_id = GroupId::from(xmtp_common::rand_array::<16>());
 
         let test_intents: Vec<NewGroupIntent> = vec![
             NewGroupIntent::new_test(
                 IntentKind::UpdateGroupMembership,
-                group_id.clone(),
+                group_id,
                 rand_vec::<24>(),
                 IntentState::ToPublish,
             ),
             NewGroupIntent::new_test(
                 IntentKind::KeyUpdate,
-                group_id.clone(),
+                group_id,
                 rand_vec::<24>(),
                 IntentState::Published,
             ),
             NewGroupIntent::new_test(
                 IntentKind::KeyUpdate,
-                group_id.clone(),
+                group_id,
                 rand_vec::<24>(),
                 IntentState::Committed,
             ),
@@ -795,7 +795,7 @@ pub(crate) mod tests {
 
         with_connection(|conn| {
             // Group needs to exist or FK constraint will fail
-            insert_group(conn, group_id.clone());
+            insert_group(conn, group_id);
 
             for case in test_intents {
                 case.store(conn).unwrap();
@@ -804,7 +804,7 @@ pub(crate) mod tests {
             // Can query for multiple states
             let mut results = conn
                 .find_group_intents(
-                    group_id.clone(),
+                    group_id,
                     Some(vec![IntentState::ToPublish, IntentState::Published]),
                     None,
                 )
@@ -814,14 +814,14 @@ pub(crate) mod tests {
 
             // Can query by kind
             results = conn
-                .find_group_intents(group_id.clone(), None, Some(vec![IntentKind::KeyUpdate]))
+                .find_group_intents(group_id, None, Some(vec![IntentKind::KeyUpdate]))
                 .unwrap();
             assert_eq!(results.len(), 2);
 
             // Can query by kind and state
             results = conn
                 .find_group_intents(
-                    group_id.clone(),
+                    group_id,
                     Some(vec![IntentState::Committed]),
                     Some(vec![IntentKind::KeyUpdate]),
                 )
@@ -832,7 +832,7 @@ pub(crate) mod tests {
             // Can get no results
             results = conn
                 .find_group_intents(
-                    group_id.clone(),
+                    group_id,
                     Some(vec![IntentState::Committed]),
                     Some(vec![IntentKind::SendMessage]),
                 )
@@ -848,15 +848,15 @@ pub(crate) mod tests {
 
     #[xmtp_common::test]
     fn find_by_payload_hash() {
-        let group_id = rand_vec::<24>();
+        let group_id = GroupId::from(xmtp_common::rand_array::<16>());
 
         with_connection(|conn| {
-            insert_group(conn, group_id.clone());
+            insert_group(conn, group_id);
 
             // Store the intent
             NewGroupIntent::new(
                 IntentKind::UpdateGroupMembership,
-                group_id.clone(),
+                group_id,
                 rand_vec::<24>(),
                 false,
             )
@@ -864,7 +864,7 @@ pub(crate) mod tests {
             .unwrap();
 
             // Find the intent with the ID populated
-            let intent = find_first_intent(conn, group_id.clone());
+            let intent = find_first_intent(conn, group_id);
 
             // Set the payload hash
             let payload_hash = rand_vec::<24>();
@@ -890,22 +890,22 @@ pub(crate) mod tests {
 
     #[xmtp_common::test]
     fn test_happy_path_state_transitions() {
-        let group_id = rand_vec::<24>();
+        let group_id = GroupId::from(xmtp_common::rand_array::<16>());
 
         with_connection(|conn| {
-            insert_group(conn, group_id.clone());
+            insert_group(conn, group_id);
 
             // Store the intent
             NewGroupIntent::new(
                 IntentKind::UpdateGroupMembership,
-                group_id.clone(),
+                group_id,
                 rand_vec::<24>(),
                 false,
             )
             .store(conn)
             .unwrap();
 
-            let mut intent = find_first_intent(conn, group_id.clone());
+            let mut intent = find_first_intent(conn, group_id);
 
             // Set to published
             let payload_hash = rand_vec::<24>();
@@ -936,22 +936,22 @@ pub(crate) mod tests {
 
     #[xmtp_common::test]
     fn test_republish_state_transition() {
-        let group_id = rand_vec::<24>();
+        let group_id = GroupId::from(xmtp_common::rand_array::<16>());
 
         with_connection(|conn| {
-            insert_group(conn, group_id.clone());
+            insert_group(conn, group_id);
 
             // Store the intent
             NewGroupIntent::new(
                 IntentKind::UpdateGroupMembership,
-                group_id.clone(),
+                group_id,
                 rand_vec::<24>(),
                 false,
             )
             .store(conn)
             .unwrap();
 
-            let mut intent = find_first_intent(conn, group_id.clone());
+            let mut intent = find_first_intent(conn, group_id);
 
             // Set to published
             let payload_hash = rand_vec::<24>();
@@ -980,22 +980,22 @@ pub(crate) mod tests {
 
     #[xmtp_common::test]
     fn test_invalid_state_transition() {
-        let group_id = rand_vec::<24>();
+        let group_id = GroupId::from(xmtp_common::rand_array::<16>());
 
         with_connection(|conn| {
-            insert_group(conn, group_id.clone());
+            insert_group(conn, group_id);
 
             // Store the intent
             NewGroupIntent::new(
                 IntentKind::UpdateGroupMembership,
-                group_id.clone(),
+                group_id,
                 rand_vec::<24>(),
                 false,
             )
             .store(conn)
             .unwrap();
 
-            let intent = find_first_intent(conn, group_id.clone());
+            let intent = find_first_intent(conn, group_id);
 
             let commit_result = conn.set_group_intent_committed(intent.id, Cursor::default());
             assert!(commit_result.is_err());
@@ -1015,27 +1015,27 @@ pub(crate) mod tests {
 
     #[xmtp_common::test]
     fn test_increment_publish_attempts() {
-        let group_id = rand_vec::<24>();
+        let group_id = GroupId::from(xmtp_common::rand_array::<16>());
         with_connection(|conn| {
-            insert_group(conn, group_id.clone());
+            insert_group(conn, group_id);
             NewGroupIntent::new(
                 IntentKind::UpdateGroupMembership,
-                group_id.clone(),
+                group_id,
                 rand_vec::<24>(),
                 false,
             )
             .store(conn)
             .unwrap();
 
-            let mut intent = find_first_intent(conn, group_id.clone());
+            let mut intent = find_first_intent(conn, group_id);
             assert_eq!(intent.publish_attempts, 0);
             conn.increment_intent_publish_attempt_count(intent.id)
                 .unwrap();
-            intent = find_first_intent(conn, group_id.clone());
+            intent = find_first_intent(conn, group_id);
             assert_eq!(intent.publish_attempts, 1);
             conn.increment_intent_publish_attempt_count(intent.id)
                 .unwrap();
-            intent = find_first_intent(conn, group_id.clone());
+            intent = find_first_intent(conn, group_id);
             assert_eq!(intent.publish_attempts, 2);
         })
     }
@@ -1043,46 +1043,30 @@ pub(crate) mod tests {
     fn test_find_dependant_commits() {
         use crate::encrypted_store::refresh_state::{EntityKind, QueryRefreshState};
 
-        let group_id = rand_vec::<24>();
+        let group_id = GroupId::from(xmtp_common::rand_array::<16>());
         let payload_hash1 = rand_vec::<24>();
         let payload_hash2 = rand_vec::<24>();
 
         with_connection(|conn| {
-            insert_group(conn, group_id.clone());
-            NewGroupIntent::new(
-                IntentKind::SendMessage,
-                group_id.clone(),
-                rand_vec::<24>(),
-                false,
-            )
-            .store(conn)
-            .unwrap();
+            insert_group(conn, group_id);
+            NewGroupIntent::new(IntentKind::SendMessage, group_id, rand_vec::<24>(), false)
+                .store(conn)
+                .unwrap();
 
-            let intent1 = find_first_intent(conn, group_id.clone());
+            let intent1 = find_first_intent(conn, group_id);
             conn.set_group_intent_published(intent1.id, &payload_hash1, None, None, 1)
                 .unwrap();
 
-            NewGroupIntent::new(
-                IntentKind::KeyUpdate,
-                group_id.clone(),
-                rand_vec::<24>(),
-                false,
-            )
-            .store(conn)
-            .unwrap();
-            let intents = conn
-                .find_group_intents(group_id.clone(), None, None)
+            NewGroupIntent::new(IntentKind::KeyUpdate, group_id, rand_vec::<24>(), false)
+                .store(conn)
                 .unwrap();
+            let intents = conn.find_group_intents(group_id, None, None).unwrap();
             let intent2 = intents.iter().find(|i| i.id != intent1.id).unwrap();
             conn.set_group_intent_published(intent2.id, &payload_hash2, None, None, 1)
                 .unwrap();
 
-            conn.update_cursor(
-                group_id.clone(),
-                EntityKind::CommitMessage,
-                Cursor::new(100, 42u32),
-            )
-            .unwrap();
+            conn.update_cursor(group_id, EntityKind::CommitMessage, Cursor::new(100, 42u32))
+                .unwrap();
 
             let result = conn
                 .find_dependant_commits(&[&payload_hash1, &payload_hash2])
@@ -1110,18 +1094,18 @@ pub(crate) mod tests {
         // Exercises both the i32 → IntentKind::BootstrapMigration arm
         // and the Display impl. Cheap coverage for the new variant
         // that would otherwise sit dead until end-to-end migration tests.
-        let group_id = rand_vec::<24>();
+        let group_id = GroupId::from(xmtp_common::rand_array::<16>());
         let data = rand_vec::<24>();
         let kind = IntentKind::BootstrapMigration;
         let to_insert =
-            NewGroupIntent::new_test(kind, group_id.clone(), data.clone(), IntentState::ToPublish);
+            NewGroupIntent::new_test(kind, group_id, data.clone(), IntentState::ToPublish);
 
         with_connection(|conn| {
-            insert_group(conn, group_id.clone());
+            insert_group(conn, group_id);
             to_insert.store(conn).unwrap();
 
             let results = conn
-                .find_group_intents(group_id.clone(), Some(vec![IntentState::ToPublish]), None)
+                .find_group_intents(group_id, Some(vec![IntentState::ToPublish]), None)
                 .unwrap();
 
             assert_eq!(results.len(), 1);

--- a/crates/xmtp_db/src/encrypted_store/group_message.rs
+++ b/crates/xmtp_db/src/encrypted_store/group_message.rs
@@ -117,7 +117,7 @@ impl From<&StoredGroupMessage> for NewStoredGroupMessage {
     fn from(msg: &StoredGroupMessage) -> Self {
         Self {
             id: msg.id.clone(),
-            group_id: msg.group_id.clone(),
+            group_id: msg.group_id,
             decrypted_message_bytes: msg.decrypted_message_bytes.clone(),
             sent_at_ns: msg.sent_at_ns,
             kind: msg.kind,

--- a/crates/xmtp_db/src/encrypted_store/group_message.rs
+++ b/crates/xmtp_db/src/encrypted_store/group_message.rs
@@ -633,7 +633,7 @@ pub trait QueryGroupMessage {
     /// The number of messages deleted.
     fn clear_messages(
         &self,
-        group_ids: Option<&[Vec<u8>]>,
+        group_ids: Option<&[GroupId]>,
         retention_days: Option<u32>,
     ) -> Result<usize, crate::ConnectionError>;
 }
@@ -788,7 +788,7 @@ where
 
     fn clear_messages(
         &self,
-        group_ids: Option<&[Vec<u8>]>,
+        group_ids: Option<&[GroupId]>,
         retention_days: Option<u32>,
     ) -> Result<usize, crate::ConnectionError> {
         (**self).clear_messages(group_ids, retention_days)
@@ -1401,7 +1401,7 @@ impl<C: ConnectionExt> QueryGroupMessage for DbConnection<C> {
 
     fn clear_messages(
         &self,
-        group_ids: Option<&[Vec<u8>]>,
+        group_ids: Option<&[GroupId]>,
         retention_days: Option<u32>,
     ) -> Result<usize, crate::ConnectionError> {
         let mut query = diesel::delete(dsl::group_messages).into_boxed();

--- a/crates/xmtp_db/src/encrypted_store/group_message/convert.rs
+++ b/crates/xmtp_db/src/encrypted_store/group_message/convert.rs
@@ -18,7 +18,7 @@ impl TryFrom<GroupMessageSave> for StoredGroupMessage {
 
         Ok(Self {
             id: value.id,
-            group_id: value.group_id.into(),
+            group_id: value.group_id.try_into()?,
             decrypted_message_bytes: value.decrypted_message_bytes,
             sent_at_ns: value.sent_at_ns,
             kind,

--- a/crates/xmtp_db/src/encrypted_store/group_message/messages_newer_than_tests.rs
+++ b/crates/xmtp_db/src/encrypted_store/group_message/messages_newer_than_tests.rs
@@ -12,7 +12,7 @@ fn generate_message_with_cursor(
 ) -> StoredGroupMessage {
     StoredGroupMessage {
         id: rand_vec::<24>(),
-        group_id: group_id.clone(),
+        group_id: *group_id,
         decrypted_message_bytes: rand_vec::<24>(),
         sent_at_ns,
         sender_installation_id: rand_vec::<24>(),

--- a/crates/xmtp_db/src/encrypted_store/group_message/tests.rs
+++ b/crates/xmtp_db/src/encrypted_store/group_message/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{Store, group::tests::generate_group, prelude::*, test_utils::with_connection};
-use xmtp_common::{assert_err, assert_ok, rand_time, rand_vec};
+use xmtp_common::{Generate, assert_err, assert_ok, rand_time, rand_vec};
 
 pub(crate) fn generate_message(
     kind: Option<GroupMessageKind>,
@@ -12,9 +12,7 @@ pub(crate) fn generate_message(
 ) -> StoredGroupMessage {
     StoredGroupMessage {
         id: rand_vec::<24>(),
-        group_id: group_id
-            .copied()
-            .unwrap_or_else(|| GroupId::from(xmtp_common::rand_array::<16>())),
+        group_id: group_id.copied().unwrap_or_else(GroupId::generate),
         decrypted_message_bytes: rand_vec::<24>(),
         sent_at_ns: sent_at_ns.unwrap_or(rand_time()),
         sender_installation_id: rand_vec::<24>(),

--- a/crates/xmtp_db/src/encrypted_store/group_message/tests.rs
+++ b/crates/xmtp_db/src/encrypted_store/group_message/tests.rs
@@ -4,7 +4,7 @@ use xmtp_common::{assert_err, assert_ok, rand_time, rand_vec};
 
 pub(crate) fn generate_message(
     kind: Option<GroupMessageKind>,
-    group_id: Option<&[u8]>,
+    group_id: Option<&GroupId>,
     sent_at_ns: Option<i64>,
     content_type: Option<ContentType>,
     expire_at_ns: Option<i64>,
@@ -13,9 +13,8 @@ pub(crate) fn generate_message(
     StoredGroupMessage {
         id: rand_vec::<24>(),
         group_id: group_id
-            .map(<[u8]>::to_vec)
-            .unwrap_or(rand_vec::<24>())
-            .into(),
+            .copied()
+            .unwrap_or_else(|| GroupId::from(xmtp_common::rand_array::<16>())),
         decrypted_message_bytes: rand_vec::<24>(),
         sent_at_ns: sent_at_ns.unwrap_or(rand_time()),
         sender_installation_id: rand_vec::<24>(),
@@ -576,14 +575,14 @@ fn it_dedupes_group_updated_messages_from_dm_by_default() {
 
 pub(crate) fn generate_message_with_reference<C: ConnectionExt>(
     conn: &DbConnection<C>,
-    group_id: &[u8],
+    group_id: &GroupId,
     sent_at_ns: i64,
     content_type: ContentType,
     reference_id: Option<Vec<u8>>,
 ) -> StoredGroupMessage {
     let message = StoredGroupMessage {
         id: rand_vec::<24>(),
-        group_id: group_id.into(),
+        group_id: *group_id,
         decrypted_message_bytes: rand_vec::<24>(),
         sent_at_ns,
         sender_installation_id: rand_vec::<24>(),
@@ -1462,7 +1461,7 @@ fn test_get_latest_message_times_by_sender_single_sender() {
 
         // Test getting latest message times
         let latest_times = conn
-            .get_latest_message_times_by_sender(&group.id, &[ContentType::Text])
+            .get_latest_message_times_by_sender(group.id, &[ContentType::Text])
             .unwrap();
 
         assert_eq!(latest_times.len(), 1);
@@ -1531,7 +1530,7 @@ fn test_get_latest_message_times_by_sender_multiple_senders() {
 
         // Test getting latest message times
         let latest_times = conn
-            .get_latest_message_times_by_sender(&group.id, &[ContentType::Text])
+            .get_latest_message_times_by_sender(group.id, &[ContentType::Text])
             .unwrap();
 
         assert_eq!(latest_times.len(), 3);
@@ -1549,7 +1548,7 @@ fn test_get_latest_message_times_by_sender_empty_results() {
 
         // Test with no messages
         let latest_times = conn
-            .get_latest_message_times_by_sender(&group.id, &[ContentType::Text])
+            .get_latest_message_times_by_sender(group.id, &[ContentType::Text])
             .unwrap();
 
         assert_eq!(latest_times.len(), 0);
@@ -1569,7 +1568,7 @@ fn test_get_latest_message_times_by_sender_empty_results() {
 
         // Filter by content type that doesn't match
         let latest_times = conn
-            .get_latest_message_times_by_sender(&group.id, &[ContentType::Attachment])
+            .get_latest_message_times_by_sender(group.id, &[ContentType::Attachment])
             .unwrap();
 
         assert_eq!(latest_times.len(), 0);
@@ -1659,7 +1658,7 @@ fn test_get_latest_message_times_by_sender_dm_group() {
         // Test getting latest message times for any of the groups with the shared dm_id
         // The query should find messages from all groups that share the same dm_id
         let latest_times = conn
-            .get_latest_message_times_by_sender(&group1.id, &[ContentType::Text])
+            .get_latest_message_times_by_sender(group1.id, &[ContentType::Text])
             .unwrap();
 
         assert_eq!(latest_times.len(), 1);
@@ -1670,14 +1669,14 @@ fn test_get_latest_message_times_by_sender_dm_group() {
 
         // Test that querying any of the groups returns the same result
         let latest_times_group2 = conn
-            .get_latest_message_times_by_sender(&group2.id, &[ContentType::Text])
+            .get_latest_message_times_by_sender(group2.id, &[ContentType::Text])
             .unwrap();
 
         assert_eq!(latest_times_group2.len(), 1);
         assert_eq!(latest_times_group2.get(&sender_id).unwrap(), &6000);
 
         let latest_times_group3 = conn
-            .get_latest_message_times_by_sender(&group3.id, &[ContentType::Text])
+            .get_latest_message_times_by_sender(group3.id, &[ContentType::Text])
             .unwrap();
 
         assert_eq!(latest_times_group3.len(), 1);
@@ -1930,7 +1929,7 @@ fn test_count_group_messages_dm_vs_regular_groups() {
         regular_group.store(conn).unwrap();
 
         // Create identical message sets for both groups
-        let create_messages = |group_id: &[u8]| {
+        let create_messages = |group_id: &GroupId| {
             vec![
                 generate_message(
                     Some(GroupMessageKind::Application),
@@ -2136,7 +2135,7 @@ fn test_get_latest_message_times_by_sender_mixed_content_types() {
 
         // Test filtering by text only - should get both senders
         let latest_times_text = conn
-            .get_latest_message_times_by_sender(&group.id, &[ContentType::Text])
+            .get_latest_message_times_by_sender(group.id, &[ContentType::Text])
             .unwrap();
 
         assert_eq!(latest_times_text.len(), 2);
@@ -2145,7 +2144,7 @@ fn test_get_latest_message_times_by_sender_mixed_content_types() {
 
         // Test filtering by attachment only - should get only sender1
         let latest_times_attachment = conn
-            .get_latest_message_times_by_sender(&group.id, &[ContentType::Attachment])
+            .get_latest_message_times_by_sender(group.id, &[ContentType::Attachment])
             .unwrap();
 
         assert_eq!(latest_times_attachment.len(), 1);
@@ -2154,7 +2153,7 @@ fn test_get_latest_message_times_by_sender_mixed_content_types() {
         // Test filtering by both - should get both senders with their latest overall times
         let latest_times_both = conn
             .get_latest_message_times_by_sender(
-                &group.id,
+                group.id,
                 &[ContentType::Text, ContentType::Attachment],
             )
             .unwrap();
@@ -2609,7 +2608,7 @@ fn test_inserted_at_populated_in_all_queries() {
 
         // Test get_group_message_by_timestamp
         let by_timestamp = conn
-            .get_group_message_by_timestamp(&group.id, 1000)
+            .get_group_message_by_timestamp(group.id, 1000)
             .unwrap()
             .unwrap();
         assert!(by_timestamp.inserted_at_ns > 0);

--- a/crates/xmtp_db/src/encrypted_store/icebox.rs
+++ b/crates/xmtp_db/src/encrypted_store/icebox.rs
@@ -154,8 +154,10 @@ impl<C: ConnectionExt> DbConnection<C> {
                                         row.sequence_id as SequenceId,
                                         row.originator_id as OriginatorId,
                                     ))
-                                    .payload(payload)
-                                    .group_id(group_id);
+                                    .payload(payload);
+                                if let Ok(gid) = GroupId::try_from(group_id) {
+                                    builder.group_id(gid);
+                                }
                                 builder
                             },
                             |mut acc, _key, row| {
@@ -366,10 +368,10 @@ mod tests {
 
     use super::*;
 
-    fn create_test_group(conn: &impl crate::DbQuery) -> Vec<u8> {
-        let group_id = xmtp_common::rand_vec::<24>();
+    fn create_test_group(conn: &impl crate::DbQuery) -> GroupId {
+        let group_id = GroupId::from(xmtp_common::rand_array::<16>());
         let group = StoredGroup {
-            id: group_id.clone().into(),
+            id: group_id,
             created_at_ns: 0,
             membership_state: GroupMembershipState::Allowed,
             installations_last_checked: 0,
@@ -394,20 +396,20 @@ mod tests {
         group_id
     }
 
-    fn iced(group_id: Vec<u8>) -> Vec<OrphanedEnvelope> {
+    fn iced(group_id: GroupId) -> Vec<OrphanedEnvelope> {
         vec![
             OrphanedEnvelope::builder()
                 .cursor(Cursor::new(41, 1u32))
                 .depending_on(Cursor::new(40, 1u32))
                 .payload(vec![1, 2, 3])
-                .group_id(group_id.clone())
+                .group_id(group_id)
                 .build()
                 .unwrap(),
             OrphanedEnvelope::builder()
                 .cursor(Cursor::new(40, 1u32))
                 .depending_on(Cursor::new(39, 2u32))
                 .payload(vec![1, 2, 3])
-                .group_id(group_id.clone())
+                .group_id(group_id)
                 .build()
                 .unwrap(),
             OrphanedEnvelope::builder()
@@ -454,7 +456,7 @@ mod tests {
         with_connection(|conn| {
             let group_id = create_test_group(conn);
             // Break the chain by changing the originator
-            let mut orphans = iced(group_id.clone());
+            let mut orphans = iced(group_id);
             // Change envelope (39, 2) to (39, 1), breaking the chain
             orphans[2] = OrphanedEnvelope::builder()
                 .cursor(Cursor::new(39, 1u32))
@@ -487,7 +489,7 @@ mod tests {
         with_connection(|conn| {
             let group_id = create_test_group(conn);
             // Break the chain by changing the sequence_id to a non-conflicting value
-            let mut orphans = iced(group_id.clone());
+            let mut orphans = iced(group_id);
             // Change envelope (39, 2) to (100, 2), breaking the chain
             orphans[2] = OrphanedEnvelope::builder()
                 .cursor(Cursor::new(100, 2u32))
@@ -526,7 +528,7 @@ mod tests {
                     .cursor(Cursor::new(1, 100u32))
                     .depending_on(Cursor::new(10, 0u32))
                     .payload(vec![1; 5])
-                    .group_id(group_id.clone())
+                    .group_id(group_id)
                     .build()
                     .unwrap(),
                 OrphanedEnvelope::builder()
@@ -567,14 +569,14 @@ mod tests {
                     .cursor(Cursor::new(1, 100u32))
                     .depending_on(Cursor::new(3, 0u32))
                     .payload(vec![1])
-                    .group_id(group_id.clone())
+                    .group_id(group_id)
                     .build()
                     .unwrap(),
                 OrphanedEnvelope::builder()
                     .cursor(Cursor::new(2, 100u32))
                     .depending_on(Cursor::new(3, 0u32))
                     .payload(vec![1])
-                    .group_id(group_id.clone())
+                    .group_id(group_id)
                     .build()
                     .unwrap(),
                 OrphanedEnvelope::builder()
@@ -678,35 +680,35 @@ mod tests {
                     .cursor(Cursor::new(10, 1u32))
                     .depending_on(Cursor::new(9, 1u32))
                     .payload(vec![1, 2, 3])
-                    .group_id(group_id.clone())
+                    .group_id(group_id)
                     .build()
                     .unwrap(),
                 OrphanedEnvelope::builder()
                     .cursor(Cursor::new(20, 1u32))
                     .depending_on(Cursor::new(19, 1u32))
                     .payload(vec![4, 5, 6])
-                    .group_id(group_id.clone())
+                    .group_id(group_id)
                     .build()
                     .unwrap(),
                 OrphanedEnvelope::builder()
                     .cursor(Cursor::new(30, 1u32))
                     .depending_on(Cursor::new(29, 1u32))
                     .payload(vec![7, 8, 9])
-                    .group_id(group_id.clone())
+                    .group_id(group_id)
                     .build()
                     .unwrap(),
                 OrphanedEnvelope::builder()
                     .cursor(Cursor::new(10, 10u32))
                     .depending_on(Cursor::new(1, 1u32))
                     .payload(vec![1, 2, 3])
-                    .group_id(group_id.clone())
+                    .group_id(group_id)
                     .build()
                     .unwrap(),
             ];
             conn.ice(orphans)?;
 
             RefreshState {
-                entity_id: group_id.clone(),
+                entity_id: group_id.to_vec(),
                 entity_kind: EntityKind::ApplicationMessage,
                 sequence_id: 20,
                 originator_id: 1,
@@ -745,21 +747,21 @@ mod tests {
                     .cursor(Cursor::new(50, 1u32))
                     .depending_on(Cursor::new(49, 1u32))
                     .payload(vec![1, 2, 3])
-                    .group_id(group_id.clone())
+                    .group_id(group_id)
                     .build()
                     .unwrap(),
                 OrphanedEnvelope::builder()
                     .cursor(Cursor::new(60, 1u32))
                     .depending_on(Cursor::new(59, 1u32))
                     .payload(vec![4, 5, 6])
-                    .group_id(group_id.clone())
+                    .group_id(group_id)
                     .build()
                     .unwrap(),
             ];
             conn.ice(orphans)?;
 
             RefreshState {
-                entity_id: group_id.clone(),
+                entity_id: group_id.to_vec(),
                 entity_kind: EntityKind::ApplicationMessage,
                 sequence_id: 40,
                 originator_id: 1,
@@ -788,14 +790,14 @@ mod tests {
                     .cursor(Cursor::new(10, 1u32))
                     .depending_on(Cursor::new(9, 1u32))
                     .payload(vec![1, 2, 3])
-                    .group_id(group_id.clone())
+                    .group_id(group_id)
                     .build()
                     .unwrap(),
             ];
             conn.ice(orphans)?;
 
             RefreshState {
-                entity_id: group_id.clone(),
+                entity_id: group_id.to_vec(),
                 entity_kind: EntityKind::Welcome,
                 sequence_id: 100,
                 originator_id: 1,
@@ -824,7 +826,7 @@ mod tests {
                     .cursor(Cursor::new(10, 1u32))
                     .depending_on(Cursor::new(9, 1u32))
                     .payload(vec![1, 2, 3])
-                    .group_id(group_id.clone())
+                    .group_id(group_id)
                     .build()
                     .unwrap(),
             ];
@@ -840,7 +842,7 @@ mod tests {
             assert_eq!(deps.len(), 1);
 
             RefreshState {
-                entity_id: group_id.clone(),
+                entity_id: group_id.to_vec(),
                 entity_kind: EntityKind::ApplicationMessage,
                 sequence_id: 10,
                 originator_id: 1,

--- a/crates/xmtp_db/src/encrypted_store/icebox.rs
+++ b/crates/xmtp_db/src/encrypted_store/icebox.rs
@@ -360,6 +360,7 @@ impl<C: ConnectionExt> QueryIcebox for DbConnection<C> {
 
 #[cfg(test)]
 mod tests {
+    use xmtp_common::Generate;
     use xmtp_proto::types::Cursor;
 
     use crate::Store;
@@ -369,7 +370,7 @@ mod tests {
     use super::*;
 
     fn create_test_group(conn: &impl crate::DbQuery) -> GroupId {
-        let group_id = GroupId::from(xmtp_common::rand_array::<16>());
+        let group_id = GroupId::generate();
         let group = StoredGroup {
             id: group_id,
             created_at_ns: 0,

--- a/crates/xmtp_db/src/encrypted_store/icebox/types.rs
+++ b/crates/xmtp_db/src/encrypted_store/icebox/types.rs
@@ -53,7 +53,7 @@ impl IceboxOrphans for OrphanedEnvelope {
 
 impl From<OrphanedEnvelope> for Icebox {
     fn from(value: OrphanedEnvelope) -> Self {
-        let group_id = value.group_id.clone();
+        let group_id = value.group_id;
         Icebox {
             sequence_id: value.cursor.sequence_id as i64,
             originator_id: value.cursor.originator_id as i64,

--- a/crates/xmtp_db/src/encrypted_store/local_commit_log.rs
+++ b/crates/xmtp_db/src/encrypted_store/local_commit_log.rs
@@ -107,7 +107,7 @@ impl std::fmt::Debug for LocalCommitLog {
             f,
             "LocalCommitLog {{ rowid: {:?}, group_id {:?}, commit_sequence_id: {:?}, last_epoch_authenticator: {:?}, commit_result: {:?}, error_message: {:?}, applied_epoch_number: {:?}, applied_epoch_authenticator: {:?}, sender_inbox_id: {:?}, sender_installation_id: {:?}, commit_type: {:?} }}",
             self.rowid,
-            &self.group_id.snippet(),
+            &self.group_id.as_slice().snippet(),
             self.commit_sequence_id,
             &self.last_epoch_authenticator.snippet(),
             self.commit_result,

--- a/crates/xmtp_db/src/encrypted_store/message_deletion.rs
+++ b/crates/xmtp_db/src/encrypted_store/message_deletion.rs
@@ -175,9 +175,9 @@ mod tests {
     };
     use crate::{Store, with_connection};
 
-    fn create_test_group(conn: &DbConnection<impl ConnectionExt>, group_id: Vec<u8>) {
+    fn create_test_group(conn: &DbConnection<impl ConnectionExt>, group_id: GroupId) {
         StoredGroup {
-            id: group_id.into(),
+            id: group_id,
             created_at_ns: 0,
             membership_state: GroupMembershipState::Allowed,
             installations_last_checked: 0,
@@ -205,11 +205,11 @@ mod tests {
     fn create_test_message(
         conn: &DbConnection<impl ConnectionExt>,
         id: Vec<u8>,
-        group_id: Vec<u8>,
+        group_id: GroupId,
     ) {
         StoredGroupMessage {
             id,
-            group_id: group_id.into(),
+            group_id,
             decrypted_message_bytes: vec![],
             sent_at_ns: 1000,
             kind: GroupMessageKind::Application,
@@ -234,17 +234,17 @@ mod tests {
     #[xmtp_common::test(unwrap_try = true)]
     fn test_store_and_get_deletion() {
         with_connection(|conn| {
-            let group_id = vec![1, 2, 3];
+            let group_id = GroupId::from([1u8; 16]);
             let message_id = vec![4, 5, 6];
             let delete_message_id = vec![7, 8, 9];
 
-            create_test_group(conn, group_id.clone());
-            create_test_message(conn, message_id.clone(), group_id.clone());
-            create_test_message(conn, delete_message_id.clone(), group_id.clone());
+            create_test_group(conn, group_id);
+            create_test_message(conn, message_id.clone(), group_id);
+            create_test_message(conn, delete_message_id.clone(), group_id);
 
             let deletion = StoredMessageDeletion {
                 id: delete_message_id.clone(),
-                group_id: group_id.clone().into(),
+                group_id,
                 deleted_message_id: message_id.clone(),
                 deleted_by_inbox_id: "sender".to_string(),
                 is_super_admin_deletion: false,
@@ -268,13 +268,13 @@ mod tests {
     #[xmtp_common::test(unwrap_try = true)]
     fn test_is_message_deleted() {
         with_connection(|conn| {
-            let group_id = vec![1, 2, 3];
+            let group_id = GroupId::from([1u8; 16]);
             let message_id = vec![4, 5, 6];
             let delete_message_id = vec![7, 8, 9];
 
-            create_test_group(conn, group_id.clone());
-            create_test_message(conn, message_id.clone(), group_id.clone());
-            create_test_message(conn, delete_message_id.clone(), group_id.clone());
+            create_test_group(conn, group_id);
+            create_test_message(conn, message_id.clone(), group_id);
+            create_test_message(conn, delete_message_id.clone(), group_id);
 
             // Initially not deleted
             assert!(!conn.is_message_deleted(&message_id)?);
@@ -282,7 +282,7 @@ mod tests {
             // Store deletion
             StoredMessageDeletion {
                 id: delete_message_id.clone(),
-                group_id: group_id.clone().into(),
+                group_id,
                 deleted_message_id: message_id.clone(),
                 deleted_by_inbox_id: "sender".to_string(),
                 is_super_admin_deletion: false,
@@ -298,24 +298,24 @@ mod tests {
     #[xmtp_common::test(unwrap_try = true)]
     fn test_get_deletions_for_messages() {
         with_connection(|conn| {
-            let group_id = vec![1, 2, 3];
+            let group_id = GroupId::from([1u8; 16]);
             let msg1 = vec![4, 5, 6];
             let msg2 = vec![7, 8, 9];
             let msg3 = vec![10, 11, 12];
             let del1 = vec![13, 14, 15];
             let del2 = vec![16, 17, 18];
 
-            create_test_group(conn, group_id.clone());
-            create_test_message(conn, msg1.clone(), group_id.clone());
-            create_test_message(conn, msg2.clone(), group_id.clone());
-            create_test_message(conn, msg3.clone(), group_id.clone());
-            create_test_message(conn, del1.clone(), group_id.clone());
-            create_test_message(conn, del2.clone(), group_id.clone());
+            create_test_group(conn, group_id);
+            create_test_message(conn, msg1.clone(), group_id);
+            create_test_message(conn, msg2.clone(), group_id);
+            create_test_message(conn, msg3.clone(), group_id);
+            create_test_message(conn, del1.clone(), group_id);
+            create_test_message(conn, del2.clone(), group_id);
 
             // Delete msg1 and msg2
             StoredMessageDeletion {
                 id: del1.clone(),
-                group_id: group_id.clone().into(),
+                group_id,
                 deleted_message_id: msg1.clone(),
                 deleted_by_inbox_id: "sender".to_string(),
                 is_super_admin_deletion: false,
@@ -325,7 +325,7 @@ mod tests {
 
             StoredMessageDeletion {
                 id: del2.clone(),
-                group_id: group_id.clone().into(),
+                group_id,
                 deleted_message_id: msg2.clone(),
                 deleted_by_inbox_id: "admin".to_string(),
                 is_super_admin_deletion: true,
@@ -346,23 +346,23 @@ mod tests {
     #[xmtp_common::test(unwrap_try = true)]
     fn test_get_group_deletions() {
         with_connection(|conn| {
-            let group1 = vec![1, 2, 3];
-            let group2 = vec![4, 5, 6];
+            let group1 = GroupId::from([1u8; 16]);
+            let group2 = GroupId::from([2u8; 16]);
             let msg1 = vec![7, 8, 9];
             let msg2 = vec![10, 11, 12];
             let del1 = vec![13, 14, 15];
             let del2 = vec![16, 17, 18];
 
-            create_test_group(conn, group1.clone());
-            create_test_group(conn, group2.clone());
-            create_test_message(conn, msg1.clone(), group1.clone());
-            create_test_message(conn, msg2.clone(), group2.clone());
-            create_test_message(conn, del1.clone(), group1.clone());
-            create_test_message(conn, del2.clone(), group2.clone());
+            create_test_group(conn, group1);
+            create_test_group(conn, group2);
+            create_test_message(conn, msg1.clone(), group1);
+            create_test_message(conn, msg2.clone(), group2);
+            create_test_message(conn, del1.clone(), group1);
+            create_test_message(conn, del2.clone(), group2);
 
             StoredMessageDeletion {
                 id: del1.clone(),
-                group_id: group1.clone().into(),
+                group_id: group1,
                 deleted_message_id: msg1.clone(),
                 deleted_by_inbox_id: "sender".to_string(),
                 is_super_admin_deletion: false,
@@ -372,7 +372,7 @@ mod tests {
 
             StoredMessageDeletion {
                 id: del2.clone(),
-                group_id: group2.clone().into(),
+                group_id: group2,
                 deleted_message_id: msg2.clone(),
                 deleted_by_inbox_id: "sender".to_string(),
                 is_super_admin_deletion: false,
@@ -381,12 +381,12 @@ mod tests {
             .store(conn)?;
 
             // Get deletions for group1
-            let group1_deletions = conn.get_group_deletions(&GroupId::from(group1.clone()))?;
+            let group1_deletions = conn.get_group_deletions(&group1)?;
             assert_eq!(group1_deletions.len(), 1);
             assert_eq!(group1_deletions[0].deleted_message_id, msg1);
 
             // Get deletions for group2
-            let group2_deletions = conn.get_group_deletions(&GroupId::from(group2.clone()))?;
+            let group2_deletions = conn.get_group_deletions(&group2)?;
             assert_eq!(group2_deletions.len(), 1);
             assert_eq!(group2_deletions[0].deleted_message_id, msg2);
         })

--- a/crates/xmtp_db/src/encrypted_store/message_deletion.rs
+++ b/crates/xmtp_db/src/encrypted_store/message_deletion.rs
@@ -234,7 +234,7 @@ mod tests {
     #[xmtp_common::test(unwrap_try = true)]
     fn test_store_and_get_deletion() {
         with_connection(|conn| {
-            let group_id = GroupId::from([1u8; 16]);
+            let group_id = GroupId::ONE;
             let message_id = vec![4, 5, 6];
             let delete_message_id = vec![7, 8, 9];
 
@@ -268,7 +268,7 @@ mod tests {
     #[xmtp_common::test(unwrap_try = true)]
     fn test_is_message_deleted() {
         with_connection(|conn| {
-            let group_id = GroupId::from([1u8; 16]);
+            let group_id = GroupId::ONE;
             let message_id = vec![4, 5, 6];
             let delete_message_id = vec![7, 8, 9];
 
@@ -298,7 +298,7 @@ mod tests {
     #[xmtp_common::test(unwrap_try = true)]
     fn test_get_deletions_for_messages() {
         with_connection(|conn| {
-            let group_id = GroupId::from([1u8; 16]);
+            let group_id = GroupId::ONE;
             let msg1 = vec![4, 5, 6];
             let msg2 = vec![7, 8, 9];
             let msg3 = vec![10, 11, 12];
@@ -346,8 +346,8 @@ mod tests {
     #[xmtp_common::test(unwrap_try = true)]
     fn test_get_group_deletions() {
         with_connection(|conn| {
-            let group1 = GroupId::from([1u8; 16]);
-            let group2 = GroupId::from([2u8; 16]);
+            let group1 = GroupId::ONE;
+            let group2 = GroupId::TWO;
             let msg1 = vec![7, 8, 9];
             let msg2 = vec![10, 11, 12];
             let del1 = vec![13, 14, 15];

--- a/crates/xmtp_db/src/encrypted_store/migration_test/originator_id_refresh_state.rs
+++ b/crates/xmtp_db/src/encrypted_store/migration_test/originator_id_refresh_state.rs
@@ -142,14 +142,14 @@ async fn up_groups() {
     let db = crate::TestDb::create_database(None).await;
     migrate_before(db.conn(), "2025-08-19-141841_originator_id_groups");
 
-    group(db.conn(), &[1, 2, 3], Some(100));
-    group(db.conn(), &[3, 4, 5], Some(150));
+    group(db.conn(), &[1u8; 16], Some(100));
+    group(db.conn(), &[3u8; 16], Some(150));
 
     finish_migrations(db.conn());
 
     let group = db
         .db()
-        .find_group(&GroupId::from(&[1u8, 2, 3][..]))
+        .find_group(&GroupId::from([1u8; 16]))
         .unwrap()
         .unwrap();
     assert_eq!(group.sequence_id, Some(100));

--- a/crates/xmtp_db/src/encrypted_store/migration_test/originator_id_refresh_state.rs
+++ b/crates/xmtp_db/src/encrypted_store/migration_test/originator_id_refresh_state.rs
@@ -142,8 +142,8 @@ async fn up_groups() {
     let db = crate::TestDb::create_database(None).await;
     migrate_before(db.conn(), "2025-08-19-141841_originator_id_groups");
 
-    group(db.conn(), &[1u8; 16], Some(100));
-    group(db.conn(), &[3u8; 16], Some(150));
+    group(db.conn(), GroupId::ONE.as_slice(), Some(100));
+    group(db.conn(), GroupId::THREE.as_slice(), Some(150));
 
     finish_migrations(db.conn());
 

--- a/crates/xmtp_db/src/encrypted_store/migration_test/originator_id_refresh_state.rs
+++ b/crates/xmtp_db/src/encrypted_store/migration_test/originator_id_refresh_state.rs
@@ -147,11 +147,7 @@ async fn up_groups() {
 
     finish_migrations(db.conn());
 
-    let group = db
-        .db()
-        .find_group(&GroupId::from([1u8; 16]))
-        .unwrap()
-        .unwrap();
+    let group = db.db().find_group(&GroupId::ONE).unwrap().unwrap();
     assert_eq!(group.sequence_id, Some(100));
     assert_eq!(
         group.originator_id,

--- a/crates/xmtp_db/src/encrypted_store/pending_remove.rs
+++ b/crates/xmtp_db/src/encrypted_store/pending_remove.rs
@@ -132,17 +132,13 @@ mod tests {
             // Break the chain by unsetting the originator.
             PendingRemove {
                 inbox_id: "123".to_string(),
-                group_id: GroupId::from([1u8; 16]),
+                group_id: GroupId::ONE,
                 message_id: vec![1, 2, 3],
             }
             .store_or_ignore(conn)?;
-            let users = conn
-                .get_pending_remove_users(&GroupId::from([1u8; 16]))
-                .unwrap();
+            let users = conn.get_pending_remove_users(&GroupId::ONE).unwrap();
             assert_eq!(users.len(), 1);
-            let users = conn
-                .get_pending_remove_users(&GroupId::from([2u8; 16]))
-                .unwrap();
+            let users = conn.get_pending_remove_users(&GroupId::TWO).unwrap();
             assert_eq!(users.len(), 0);
         })
     }
@@ -153,19 +149,19 @@ mod tests {
             // Break the chain by unsetting the originator.
             PendingRemove {
                 inbox_id: "1".to_string(),
-                group_id: GroupId::from([1u8; 16]),
+                group_id: GroupId::ONE,
                 message_id: vec![1, 2, 3],
             }
             .store_or_ignore(conn)?;
             PendingRemove {
                 inbox_id: "2".to_string(),
-                group_id: GroupId::from([1u8; 16]),
+                group_id: GroupId::ONE,
                 message_id: vec![1, 2, 3],
             }
             .store_or_ignore(conn)?;
             PendingRemove {
                 inbox_id: "3".to_string(),
-                group_id: GroupId::from([1u8; 16]),
+                group_id: GroupId::ONE,
                 message_id: vec![1, 2, 3],
             }
             .store_or_ignore(conn)?;
@@ -179,7 +175,7 @@ mod tests {
             let users = conn.get_pending_remove_users(&group_id).unwrap();
             assert_eq!(users.len(), 1);
             let deleted_users = conn
-                .delete_pending_remove_users(&GroupId::from([2u8; 16]), vec!["3".to_string()])
+                .delete_pending_remove_users(&GroupId::TWO, vec!["3".to_string()])
                 .unwrap();
             assert_eq!(deleted_users, 0usize);
         })

--- a/crates/xmtp_db/src/encrypted_store/pending_remove.rs
+++ b/crates/xmtp_db/src/encrypted_store/pending_remove.rs
@@ -165,7 +165,7 @@ mod tests {
                 message_id: vec![1, 2, 3],
             }
             .store_or_ignore(conn)?;
-            let group_id: GroupId = [1u8; 16].into();
+            let group_id = GroupId::ONE;
             let users = conn.get_pending_remove_users(&group_id).unwrap();
             assert_eq!(users.len(), 3);
             let deleted_users = conn

--- a/crates/xmtp_db/src/encrypted_store/pending_remove.rs
+++ b/crates/xmtp_db/src/encrypted_store/pending_remove.rs
@@ -132,16 +132,16 @@ mod tests {
             // Break the chain by unsetting the originator.
             PendingRemove {
                 inbox_id: "123".to_string(),
-                group_id: GroupId::from(vec![1, 2, 3]),
+                group_id: GroupId::from([1u8; 16]),
                 message_id: vec![1, 2, 3],
             }
             .store_or_ignore(conn)?;
             let users = conn
-                .get_pending_remove_users(&GroupId::from(&[1u8, 2, 3][..]))
+                .get_pending_remove_users(&GroupId::from([1u8; 16]))
                 .unwrap();
             assert_eq!(users.len(), 1);
             let users = conn
-                .get_pending_remove_users(&GroupId::from(&[1u8][..]))
+                .get_pending_remove_users(&GroupId::from([2u8; 16]))
                 .unwrap();
             assert_eq!(users.len(), 0);
         })
@@ -153,23 +153,23 @@ mod tests {
             // Break the chain by unsetting the originator.
             PendingRemove {
                 inbox_id: "1".to_string(),
-                group_id: GroupId::from(vec![1, 2, 3]),
+                group_id: GroupId::from([1u8; 16]),
                 message_id: vec![1, 2, 3],
             }
             .store_or_ignore(conn)?;
             PendingRemove {
                 inbox_id: "2".to_string(),
-                group_id: GroupId::from(vec![1, 2, 3]),
+                group_id: GroupId::from([1u8; 16]),
                 message_id: vec![1, 2, 3],
             }
             .store_or_ignore(conn)?;
             PendingRemove {
                 inbox_id: "3".to_string(),
-                group_id: GroupId::from(vec![1, 2, 3]),
+                group_id: GroupId::from([1u8; 16]),
                 message_id: vec![1, 2, 3],
             }
             .store_or_ignore(conn)?;
-            let group_id: GroupId = vec![1u8, 2, 3].into();
+            let group_id: GroupId = [1u8; 16].into();
             let users = conn.get_pending_remove_users(&group_id).unwrap();
             assert_eq!(users.len(), 3);
             let deleted_users = conn
@@ -179,7 +179,7 @@ mod tests {
             let users = conn.get_pending_remove_users(&group_id).unwrap();
             assert_eq!(users.len(), 1);
             let deleted_users = conn
-                .delete_pending_remove_users(&GroupId::from(&[1u8][..]), vec!["3".to_string()])
+                .delete_pending_remove_users(&GroupId::from([2u8; 16]), vec!["3".to_string()])
                 .unwrap();
             assert_eq!(deleted_users, 0usize);
         })

--- a/crates/xmtp_db/src/encrypted_store/readd_status.rs
+++ b/crates/xmtp_db/src/encrypted_store/readd_status.rs
@@ -304,7 +304,7 @@ mod tests {
     #[xmtp_common::test]
     fn test_get_readd_status_not_found() {
         with_connection(|conn| {
-            let group_id: GroupId = [1u8; 16].into();
+            let group_id = GroupId::ONE;
             let installation_id = vec![4, 5, 6];
 
             let result = conn.get_readd_status(&group_id, &installation_id).unwrap();
@@ -315,7 +315,7 @@ mod tests {
     #[xmtp_common::test]
     fn test_store_and_get_readd_status() {
         with_connection(|conn| {
-            let group_id: GroupId = [1u8; 16].into();
+            let group_id = GroupId::ONE;
             let installation_id = vec![4, 5, 6];
 
             let status = ReaddStatus {
@@ -340,7 +340,7 @@ mod tests {
     #[xmtp_common::test]
     fn test_update_requested_at_sequence_id_creates_new() {
         with_connection(|conn| {
-            let group_id: GroupId = [1u8; 16].into();
+            let group_id = GroupId::ONE;
             let installation_id = vec![4, 5, 6];
             let sequence_id = 100;
 
@@ -360,7 +360,7 @@ mod tests {
     #[xmtp_common::test]
     fn test_update_requested_at_sequence_id_updates_existing() {
         with_connection(|conn| {
-            let group_id: GroupId = [1u8; 16].into();
+            let group_id = GroupId::ONE;
             let installation_id = vec![4, 5, 6];
 
             // Create initial status
@@ -388,7 +388,7 @@ mod tests {
     #[xmtp_common::test]
     fn test_update_requested_at_sequence_id_only_updates_if_higher() {
         with_connection(|conn| {
-            let group_id: GroupId = [1u8; 16].into();
+            let group_id = GroupId::ONE;
             let installation_id = vec![4, 5, 6];
 
             // Create initial status with high sequence_id
@@ -416,7 +416,7 @@ mod tests {
     #[xmtp_common::test]
     fn test_update_requested_at_sequence_id_updates_from_null() {
         with_connection(|conn| {
-            let group_id: GroupId = [1u8; 16].into();
+            let group_id = GroupId::ONE;
             let installation_id = vec![4, 5, 6];
 
             // Create initial status with null requested_at_sequence_id
@@ -444,7 +444,7 @@ mod tests {
     #[xmtp_common::test]
     async fn test_update_responded_at_sequence_id_creates_new() {
         with_connection(|conn| {
-            let group_id: GroupId = [1u8; 16].into();
+            let group_id = GroupId::ONE;
             let installation_id = vec![4, 5, 6];
             let sequence_id = 100;
 
@@ -464,7 +464,7 @@ mod tests {
     #[xmtp_common::test]
     fn test_update_responded_at_sequence_id_only_updates_if_higher() {
         with_connection(|conn| {
-            let group_id: GroupId = [1u8; 16].into();
+            let group_id = GroupId::ONE;
             let installation_id = vec![4, 5, 6];
 
             // Create initial status with high responded_at_sequence_id
@@ -503,7 +503,7 @@ mod tests {
     #[xmtp_common::test]
     fn test_is_awaiting_readd_no_status() {
         with_connection(|conn| {
-            let group_id: GroupId = [1u8; 16].into();
+            let group_id = GroupId::ONE;
             let installation_id = vec![4, 5, 6];
 
             // Should return false when no readd status exists
@@ -515,7 +515,7 @@ mod tests {
     #[xmtp_common::test]
     fn test_is_awaiting_readd_no_request() {
         with_connection(|conn| {
-            let group_id: GroupId = [1u8; 16].into();
+            let group_id = GroupId::ONE;
             let installation_id = vec![4, 5, 6];
 
             // Create a readd status without a requested_at_sequence_id
@@ -537,7 +537,7 @@ mod tests {
     #[xmtp_common::test]
     fn test_is_awaiting_readd_request_pending() {
         with_connection(|conn| {
-            let group_id: GroupId = [1u8; 16].into();
+            let group_id = GroupId::ONE;
             let installation_id = vec![4, 5, 6];
 
             // Create a readd status with requested_at > responded_at
@@ -559,7 +559,7 @@ mod tests {
     #[xmtp_common::test]
     fn test_is_awaiting_readd_request_fulfilled() {
         with_connection(|conn| {
-            let group_id: GroupId = [1u8; 16].into();
+            let group_id = GroupId::ONE;
             let installation_id = vec![4, 5, 6];
 
             // Create a readd status with requested_at <= responded_at
@@ -581,7 +581,7 @@ mod tests {
     #[xmtp_common::test]
     fn test_is_awaiting_readd_equal_sequence_ids() {
         with_connection(|conn| {
-            let group_id: GroupId = [1u8; 16].into();
+            let group_id = GroupId::ONE;
             let installation_id = vec![4, 5, 6];
 
             // Create a readd status with requested_at == responded_at
@@ -605,7 +605,7 @@ mod tests {
     #[xmtp_common::test]
     fn test_is_awaiting_readd_no_responded_at() {
         with_connection(|conn| {
-            let group_id: GroupId = [1u8; 16].into();
+            let group_id = GroupId::ONE;
             let installation_id = vec![4, 5, 6];
 
             // Create a readd status with requested_at but no responded_at (defaults to 0)
@@ -627,7 +627,7 @@ mod tests {
     #[xmtp_common::test]
     fn test_delete_other_readd_statuses() {
         with_connection(|conn| {
-            let group_id: GroupId = [1u8; 16].into();
+            let group_id = GroupId::ONE;
             let keep_installation_id = vec![10, 11, 12];
             let delete_installation_id_1 = vec![20, 21, 22];
             let delete_installation_id_2 = vec![30, 31, 32];
@@ -698,7 +698,7 @@ mod tests {
     #[xmtp_common::test]
     fn test_get_readds_awaiting_response() {
         with_connection(|conn| {
-            let group_id: GroupId = [1u8; 16].into();
+            let group_id = GroupId::ONE;
             let self_installation_id = vec![10, 11, 12];
             let other_installation_id_1 = vec![20, 21, 22];
             let other_installation_id_2 = vec![30, 31, 32];

--- a/crates/xmtp_db/src/encrypted_store/readd_status.rs
+++ b/crates/xmtp_db/src/encrypted_store/readd_status.rs
@@ -116,7 +116,7 @@ impl<C: ConnectionExt> QueryReaddStatus for DbConnection<C> {
         use diesel::query_dsl::methods::FilterDsl;
 
         let new_status = super::readd_status::ReaddStatus {
-            group_id: group_id.clone(),
+            group_id: *group_id,
             installation_id: installation_id.to_vec(),
             requested_at_sequence_id: Some(sequence_id),
             responded_at_sequence_id: None,
@@ -149,7 +149,7 @@ impl<C: ConnectionExt> QueryReaddStatus for DbConnection<C> {
         use diesel::query_dsl::methods::FilterDsl;
 
         let new_status = super::readd_status::ReaddStatus {
-            group_id: group_id.clone(),
+            group_id: *group_id,
             installation_id: installation_id.to_vec(),
             requested_at_sequence_id: None,
             responded_at_sequence_id: Some(sequence_id),
@@ -304,7 +304,7 @@ mod tests {
     #[xmtp_common::test]
     fn test_get_readd_status_not_found() {
         with_connection(|conn| {
-            let group_id: GroupId = vec![1, 2, 3].into();
+            let group_id: GroupId = [1u8; 16].into();
             let installation_id = vec![4, 5, 6];
 
             let result = conn.get_readd_status(&group_id, &installation_id).unwrap();
@@ -315,11 +315,11 @@ mod tests {
     #[xmtp_common::test]
     fn test_store_and_get_readd_status() {
         with_connection(|conn| {
-            let group_id: GroupId = vec![1, 2, 3].into();
+            let group_id: GroupId = [1u8; 16].into();
             let installation_id = vec![4, 5, 6];
 
             let status = ReaddStatus {
-                group_id: group_id.clone(),
+                group_id,
                 installation_id: installation_id.clone(),
                 requested_at_sequence_id: Some(100),
                 responded_at_sequence_id: Some(50),
@@ -340,7 +340,7 @@ mod tests {
     #[xmtp_common::test]
     fn test_update_requested_at_sequence_id_creates_new() {
         with_connection(|conn| {
-            let group_id: GroupId = vec![1, 2, 3].into();
+            let group_id: GroupId = [1u8; 16].into();
             let installation_id = vec![4, 5, 6];
             let sequence_id = 100;
 
@@ -360,12 +360,12 @@ mod tests {
     #[xmtp_common::test]
     fn test_update_requested_at_sequence_id_updates_existing() {
         with_connection(|conn| {
-            let group_id: GroupId = vec![1, 2, 3].into();
+            let group_id: GroupId = [1u8; 16].into();
             let installation_id = vec![4, 5, 6];
 
             // Create initial status
             let initial_status = ReaddStatus {
-                group_id: group_id.clone(),
+                group_id,
                 installation_id: installation_id.clone(),
                 requested_at_sequence_id: Some(50),
                 responded_at_sequence_id: Some(25),
@@ -388,12 +388,12 @@ mod tests {
     #[xmtp_common::test]
     fn test_update_requested_at_sequence_id_only_updates_if_higher() {
         with_connection(|conn| {
-            let group_id: GroupId = vec![1, 2, 3].into();
+            let group_id: GroupId = [1u8; 16].into();
             let installation_id = vec![4, 5, 6];
 
             // Create initial status with high sequence_id
             let initial_status = ReaddStatus {
-                group_id: group_id.clone(),
+                group_id,
                 installation_id: installation_id.clone(),
                 requested_at_sequence_id: Some(100),
                 responded_at_sequence_id: Some(50),
@@ -416,12 +416,12 @@ mod tests {
     #[xmtp_common::test]
     fn test_update_requested_at_sequence_id_updates_from_null() {
         with_connection(|conn| {
-            let group_id: GroupId = vec![1, 2, 3].into();
+            let group_id: GroupId = [1u8; 16].into();
             let installation_id = vec![4, 5, 6];
 
             // Create initial status with null requested_at_sequence_id
             let initial_status = ReaddStatus {
-                group_id: group_id.clone(),
+                group_id,
                 installation_id: installation_id.clone(),
                 requested_at_sequence_id: None,
                 responded_at_sequence_id: Some(25),
@@ -444,7 +444,7 @@ mod tests {
     #[xmtp_common::test]
     async fn test_update_responded_at_sequence_id_creates_new() {
         with_connection(|conn| {
-            let group_id: GroupId = vec![1, 2, 3].into();
+            let group_id: GroupId = [1u8; 16].into();
             let installation_id = vec![4, 5, 6];
             let sequence_id = 100;
 
@@ -464,12 +464,12 @@ mod tests {
     #[xmtp_common::test]
     fn test_update_responded_at_sequence_id_only_updates_if_higher() {
         with_connection(|conn| {
-            let group_id: GroupId = vec![1, 2, 3].into();
+            let group_id: GroupId = [1u8; 16].into();
             let installation_id = vec![4, 5, 6];
 
             // Create initial status with high responded_at_sequence_id
             let initial_status = ReaddStatus {
-                group_id: group_id.clone(),
+                group_id,
                 installation_id: installation_id.clone(),
                 requested_at_sequence_id: Some(50),
                 responded_at_sequence_id: Some(100),
@@ -503,7 +503,7 @@ mod tests {
     #[xmtp_common::test]
     fn test_is_awaiting_readd_no_status() {
         with_connection(|conn| {
-            let group_id: GroupId = vec![1, 2, 3].into();
+            let group_id: GroupId = [1u8; 16].into();
             let installation_id = vec![4, 5, 6];
 
             // Should return false when no readd status exists
@@ -515,12 +515,12 @@ mod tests {
     #[xmtp_common::test]
     fn test_is_awaiting_readd_no_request() {
         with_connection(|conn| {
-            let group_id: GroupId = vec![1, 2, 3].into();
+            let group_id: GroupId = [1u8; 16].into();
             let installation_id = vec![4, 5, 6];
 
             // Create a readd status without a requested_at_sequence_id
             ReaddStatus {
-                group_id: group_id.clone(),
+                group_id,
                 installation_id: installation_id.clone(),
                 requested_at_sequence_id: None,
                 responded_at_sequence_id: Some(5),
@@ -537,12 +537,12 @@ mod tests {
     #[xmtp_common::test]
     fn test_is_awaiting_readd_request_pending() {
         with_connection(|conn| {
-            let group_id: GroupId = vec![1, 2, 3].into();
+            let group_id: GroupId = [1u8; 16].into();
             let installation_id = vec![4, 5, 6];
 
             // Create a readd status with requested_at > responded_at
             ReaddStatus {
-                group_id: group_id.clone(),
+                group_id,
                 installation_id: installation_id.clone(),
                 requested_at_sequence_id: Some(10),
                 responded_at_sequence_id: Some(5),
@@ -559,12 +559,12 @@ mod tests {
     #[xmtp_common::test]
     fn test_is_awaiting_readd_request_fulfilled() {
         with_connection(|conn| {
-            let group_id: GroupId = vec![1, 2, 3].into();
+            let group_id: GroupId = [1u8; 16].into();
             let installation_id = vec![4, 5, 6];
 
             // Create a readd status with requested_at <= responded_at
             ReaddStatus {
-                group_id: group_id.clone(),
+                group_id,
                 installation_id: installation_id.clone(),
                 requested_at_sequence_id: Some(5),
                 responded_at_sequence_id: Some(10),
@@ -581,12 +581,12 @@ mod tests {
     #[xmtp_common::test]
     fn test_is_awaiting_readd_equal_sequence_ids() {
         with_connection(|conn| {
-            let group_id: GroupId = vec![1, 2, 3].into();
+            let group_id: GroupId = [1u8; 16].into();
             let installation_id = vec![4, 5, 6];
 
             // Create a readd status with requested_at == responded_at
             ReaddStatus {
-                group_id: group_id.clone(),
+                group_id,
                 installation_id: installation_id.clone(),
                 requested_at_sequence_id: Some(10),
                 responded_at_sequence_id: Some(10),
@@ -605,12 +605,12 @@ mod tests {
     #[xmtp_common::test]
     fn test_is_awaiting_readd_no_responded_at() {
         with_connection(|conn| {
-            let group_id: GroupId = vec![1, 2, 3].into();
+            let group_id: GroupId = [1u8; 16].into();
             let installation_id = vec![4, 5, 6];
 
             // Create a readd status with requested_at but no responded_at (defaults to 0)
             ReaddStatus {
-                group_id: group_id.clone(),
+                group_id,
                 installation_id: installation_id.clone(),
                 requested_at_sequence_id: Some(5),
                 responded_at_sequence_id: None,
@@ -627,14 +627,14 @@ mod tests {
     #[xmtp_common::test]
     fn test_delete_other_readd_statuses() {
         with_connection(|conn| {
-            let group_id: GroupId = vec![1, 2, 3].into();
+            let group_id: GroupId = [1u8; 16].into();
             let keep_installation_id = vec![10, 11, 12];
             let delete_installation_id_1 = vec![20, 21, 22];
             let delete_installation_id_2 = vec![30, 31, 32];
 
             // Create readd statuses for the same group with different installation IDs
             let status_to_keep = ReaddStatus {
-                group_id: group_id.clone(),
+                group_id,
                 installation_id: keep_installation_id.clone(),
                 requested_at_sequence_id: Some(10),
                 responded_at_sequence_id: Some(5),
@@ -642,7 +642,7 @@ mod tests {
             status_to_keep.store(conn).unwrap();
 
             let status_to_delete_1 = ReaddStatus {
-                group_id: group_id.clone(),
+                group_id,
                 installation_id: delete_installation_id_1.clone(),
                 requested_at_sequence_id: Some(15),
                 responded_at_sequence_id: Some(8),
@@ -650,7 +650,7 @@ mod tests {
             status_to_delete_1.store(conn).unwrap();
 
             let status_to_delete_2 = ReaddStatus {
-                group_id: group_id.clone(),
+                group_id,
                 installation_id: delete_installation_id_2.clone(),
                 requested_at_sequence_id: Some(20),
                 responded_at_sequence_id: None,
@@ -659,7 +659,7 @@ mod tests {
 
             // Create a status for a different group (should not be affected)
             let different_group_status = ReaddStatus {
-                group_id: GroupId::from(vec![4, 5, 6]),
+                group_id: GroupId::from([4u8; 16]),
                 installation_id: vec![40, 41, 42],
                 requested_at_sequence_id: Some(25),
                 responded_at_sequence_id: Some(12),
@@ -689,7 +689,7 @@ mod tests {
 
             // Verify the status in the different group was not affected
             let different_group_check = conn
-                .get_readd_status(&GroupId::from(&[4u8, 5, 6][..]), &[40, 41, 42])
+                .get_readd_status(&GroupId::from([4u8; 16]), &[40, 41, 42])
                 .unwrap();
             assert!(different_group_check.is_some());
         })
@@ -698,7 +698,7 @@ mod tests {
     #[xmtp_common::test]
     fn test_get_readds_awaiting_response() {
         with_connection(|conn| {
-            let group_id: GroupId = vec![1, 2, 3].into();
+            let group_id: GroupId = [1u8; 16].into();
             let self_installation_id = vec![10, 11, 12];
             let other_installation_id_1 = vec![20, 21, 22];
             let other_installation_id_2 = vec![30, 31, 32];
@@ -707,7 +707,7 @@ mod tests {
 
             // Case 1: Pending readd from other installation (should be included)
             let pending_status_1 = ReaddStatus {
-                group_id: group_id.clone(),
+                group_id,
                 installation_id: other_installation_id_1.clone(),
                 requested_at_sequence_id: Some(10),
                 responded_at_sequence_id: Some(5),
@@ -716,7 +716,7 @@ mod tests {
 
             // Case 2: Pending readd from other installation with null responded_at (should be included)
             let pending_status_2 = ReaddStatus {
-                group_id: group_id.clone(),
+                group_id,
                 installation_id: other_installation_id_2.clone(),
                 requested_at_sequence_id: Some(15),
                 responded_at_sequence_id: None,
@@ -725,7 +725,7 @@ mod tests {
 
             // Case 3: Not pending readd from other installation (should be excluded)
             let fulfilled_status = ReaddStatus {
-                group_id: group_id.clone(),
+                group_id,
                 installation_id: vec![40, 41, 42],
                 requested_at_sequence_id: Some(8),
                 responded_at_sequence_id: Some(12),
@@ -734,7 +734,7 @@ mod tests {
 
             // Case 4: Pending readd from self installation (should be excluded)
             let self_status = ReaddStatus {
-                group_id: group_id.clone(),
+                group_id,
                 installation_id: self_installation_id.clone(),
                 requested_at_sequence_id: Some(20),
                 responded_at_sequence_id: Some(10),
@@ -743,7 +743,7 @@ mod tests {
 
             // Case 5: No requested_at_sequence_id (should be excluded)
             let no_request_status = ReaddStatus {
-                group_id: group_id.clone(),
+                group_id,
                 installation_id: vec![50, 51, 52],
                 requested_at_sequence_id: None,
                 responded_at_sequence_id: Some(5),
@@ -752,7 +752,7 @@ mod tests {
 
             // Case 6: Different group (should be excluded)
             let different_group_status = ReaddStatus {
-                group_id: GroupId::from(vec![4, 5, 6]),
+                group_id: GroupId::from([4u8; 16]),
                 installation_id: vec![60, 61, 62],
                 requested_at_sequence_id: Some(25),
                 responded_at_sequence_id: Some(15),

--- a/crates/xmtp_db/src/encrypted_store/readd_status.rs
+++ b/crates/xmtp_db/src/encrypted_store/readd_status.rs
@@ -659,7 +659,7 @@ mod tests {
 
             // Create a status for a different group (should not be affected)
             let different_group_status = ReaddStatus {
-                group_id: GroupId::from([4u8; 16]),
+                group_id: GroupId::FOUR,
                 installation_id: vec![40, 41, 42],
                 requested_at_sequence_id: Some(25),
                 responded_at_sequence_id: Some(12),
@@ -689,7 +689,7 @@ mod tests {
 
             // Verify the status in the different group was not affected
             let different_group_check = conn
-                .get_readd_status(&GroupId::from([4u8; 16]), &[40, 41, 42])
+                .get_readd_status(&GroupId::FOUR, &[40, 41, 42])
                 .unwrap();
             assert!(different_group_check.is_some());
         })
@@ -752,7 +752,7 @@ mod tests {
 
             // Case 6: Different group (should be excluded)
             let different_group_status = ReaddStatus {
-                group_id: GroupId::from([4u8; 16]),
+                group_id: GroupId::FOUR,
                 installation_id: vec![60, 61, 62],
                 requested_at_sequence_id: Some(25),
                 responded_at_sequence_id: Some(15),

--- a/crates/xmtp_db/src/encrypted_store/refresh_state.rs
+++ b/crates/xmtp_db/src/encrypted_store/refresh_state.rs
@@ -176,7 +176,7 @@ pub trait QueryRefreshState {
 
     fn get_remote_log_cursors(
         &self,
-        conversation_ids: &[&Vec<u8>],
+        conversation_ids: &[&[u8]],
     ) -> Result<HashMap<Vec<u8>, Cursor>, crate::ConnectionError>;
 }
 
@@ -209,7 +209,7 @@ impl<T: QueryRefreshState> QueryRefreshState for &'_ T {
 
     fn get_remote_log_cursors(
         &self,
-        conversation_ids: &[&Vec<u8>],
+        conversation_ids: &[&[u8]],
     ) -> Result<HashMap<Vec<u8>, Cursor>, crate::ConnectionError> {
         (**self).get_remote_log_cursors(conversation_ids)
     }
@@ -386,7 +386,7 @@ impl<C: ConnectionExt> QueryRefreshState for DbConnection<C> {
     #[tracing::instrument(level = "debug", skip_all)]
     fn get_remote_log_cursors(
         &self,
-        conversation_ids: &[&Vec<u8>],
+        conversation_ids: &[&[u8]],
     ) -> Result<HashMap<Vec<u8>, Cursor>, crate::ConnectionError> {
         let mut cursor_map: HashMap<Vec<u8>, Cursor> = HashMap::new();
         for conversation_id in conversation_ids {

--- a/crates/xmtp_db/src/encrypted_store/remote_commit_log.rs
+++ b/crates/xmtp_db/src/encrypted_store/remote_commit_log.rs
@@ -86,7 +86,7 @@ impl std::fmt::Debug for RemoteCommitLog {
             "RemoteCommitLog {{ rowid: {:?}, log_sequence_id: {:?}, group_id {:?}, commit_sequence_id: {:?}, commit_result: {:?}, applied_epoch_number: {:?}, applied_epoch_authenticator: {:?} }}",
             self.rowid,
             self.log_sequence_id,
-            &self.group_id.snippet(),
+            &self.group_id.as_slice().snippet(),
             self.commit_sequence_id,
             self.commit_result,
             self.applied_epoch_number,

--- a/crates/xmtp_db/src/lib.rs
+++ b/crates/xmtp_db/src/lib.rs
@@ -379,7 +379,7 @@ pub mod test_util {
                 .map(|m| {
                     vec![
                         hex::encode(&m.id)[..16].to_string(),
-                        hex::encode(&m.group_id)[..16].to_string(),
+                        hex::encode(m.group_id)[..16].to_string(),
                         m.sent_at_ns.to_string(),
                         format!("{:?}", m.kind),
                         m.sender_inbox_id.clone(),
@@ -438,7 +438,7 @@ pub mod test_util {
                     vec![
                         i.originator_id.to_string(),
                         i.sequence_id.to_string(),
-                        hex::encode(&i.group_id)[..16].to_string(),
+                        hex::encode(i.group_id)[..16].to_string(),
                         hex::encode(&i.envelope_payload)[..20.min(i.envelope_payload.len() * 2)]
                             .to_string(),
                     ]

--- a/crates/xmtp_db/src/mock.rs
+++ b/crates/xmtp_db/src/mock.rs
@@ -612,7 +612,7 @@ mock! {
         #[mockall::concretize]
         fn get_remote_log_cursors(
             &self,
-            conversation_ids: &[&Vec<u8>],
+            conversation_ids: &[&[u8]],
         ) -> Result<HashMap<Vec<u8>, Cursor>, crate::ConnectionError>;
 
         #[mockall::concretize]

--- a/crates/xmtp_db/src/mock.rs
+++ b/crates/xmtp_db/src/mock.rs
@@ -490,7 +490,7 @@ mock! {
 
         fn clear_messages<'a>(
             &self,
-            group_ids: Option<&'a [Vec<u8>]>,
+            group_ids: Option<&'a [GroupId]>,
             retention_days: Option<u32>,
         ) -> Result<usize, crate::ConnectionError>;
     }

--- a/crates/xmtp_db/src/test_utils/impls.rs
+++ b/crates/xmtp_db/src/test_utils/impls.rs
@@ -5,6 +5,7 @@ use rand::{
     distr::{Distribution, StandardUniform},
     prelude::IteratorRandom,
 };
+use xmtp_common::Generate;
 use xmtp_proto::types::{Cursor, GroupId};
 
 use crate::{
@@ -75,7 +76,7 @@ impl Distribution<NotFound> for StandardUniform {
             ),
             11 => NotFound::CipherSalt("random salt for testing".into()),
             12 => NotFound::SyncGroup(xmtp_common::rand_array::<32>().into()),
-            13 => NotFound::MlsGroup(GroupId::from(xmtp_common::rand_array::<16>())),
+            13 => NotFound::MlsGroup(GroupId::generate()),
             _ => unreachable!(),
         }
     }

--- a/crates/xmtp_db/src/test_utils/impls.rs
+++ b/crates/xmtp_db/src/test_utils/impls.rs
@@ -75,7 +75,7 @@ impl Distribution<NotFound> for StandardUniform {
             ),
             11 => NotFound::CipherSalt("random salt for testing".into()),
             12 => NotFound::SyncGroup(xmtp_common::rand_array::<32>().into()),
-            13 => NotFound::MlsGroup(GroupId::from(xmtp_common::rand_array::<16>().to_vec())),
+            13 => NotFound::MlsGroup(GroupId::from(xmtp_common::rand_array::<16>())),
             _ => unreachable!(),
         }
     }

--- a/crates/xmtp_db/src/test_utils/impls.rs
+++ b/crates/xmtp_db/src/test_utils/impls.rs
@@ -5,7 +5,6 @@ use rand::{
     distr::{Distribution, StandardUniform},
     prelude::IteratorRandom,
 };
-use xmtp_common::Generate;
 use xmtp_proto::types::{Cursor, GroupId};
 
 use crate::{
@@ -76,7 +75,7 @@ impl Distribution<NotFound> for StandardUniform {
             ),
             11 => NotFound::CipherSalt("random salt for testing".into()),
             12 => NotFound::SyncGroup(xmtp_common::rand_array::<32>().into()),
-            13 => NotFound::MlsGroup(GroupId::generate()),
+            13 => NotFound::MlsGroup(GroupId::from(xmtp_common::rand_array::<16>())),
             _ => unreachable!(),
         }
     }

--- a/crates/xmtp_mls/benches/sync_conversations.rs
+++ b/crates/xmtp_mls/benches/sync_conversations.rs
@@ -84,7 +84,7 @@ async fn setup_sync_conversations_bench(
         group.add_members(&[other_client.inbox_id()]).await.unwrap();
 
         all_groups.push(group.clone());
-        other_client_groups.push(group.group_id.clone());
+        other_client_groups.push(group.group_id);
 
         // Mark the first `groups_with_messages` groups as having new messages
         if i < groups_with_messages {

--- a/crates/xmtp_mls/src/client.rs
+++ b/crates/xmtp_mls/src/client.rs
@@ -640,7 +640,7 @@ where
         // notify streams of our new group
         let _ = self
             .local_events
-            .send(LocalEvents::NewGroup(group.group_id.clone()));
+            .send(LocalEvents::NewGroup(group.group_id));
 
         Ok(group)
     }
@@ -700,7 +700,7 @@ where
         // notify any streams of the new group
         let _ = self
             .local_events
-            .send(LocalEvents::NewGroup(group.group_id.clone()));
+            .send(LocalEvents::NewGroup(group.group_id));
 
         Ok(group)
     }
@@ -757,7 +757,7 @@ where
     ///
     /// Returns a [`MlsGroup`] if the group exists, or an error if it does not
     ///
-    pub fn group(&self, group_id: &[u8]) -> Result<MlsGroup<Context>, ClientError> {
+    pub fn group(&self, group_id: &GroupId) -> Result<MlsGroup<Context>, ClientError> {
         MlsStore::new(self.context.clone())
             .group(group_id)
             .map_err(Into::into)
@@ -767,9 +767,9 @@ where
     ///
     /// Returns a [`MlsGroup`] if the group exists, or an error if it does not
     ///
-    pub fn stitched_group(&self, group_id: &[u8]) -> Result<MlsGroup<Context>, ClientError> {
+    pub fn stitched_group(&self, group_id: &GroupId) -> Result<MlsGroup<Context>, ClientError> {
         let conn = self.context.db();
-        let stored_group = conn.fetch_stitched(&GroupId::from(group_id))?;
+        let stored_group = conn.fetch_stitched(group_id)?;
         stored_group
             .map(|g| {
                 MlsGroup::new(
@@ -780,14 +780,14 @@ where
                     g.created_at_ns,
                 )
             })
-            .ok_or(NotFound::GroupById(GroupId::from(group_id)))
+            .ok_or(NotFound::GroupById(*group_id))
             .map_err(Into::into)
     }
 
     /// Find all the duplicate dms for this group
     pub fn find_duplicate_dms_for_group(
         &self,
-        group_id: &[u8],
+        group_id: &GroupId,
     ) -> Result<Vec<MlsGroup<Context>>, ClientError> {
         let (group, _) = MlsGroup::new_cached(self.context.clone(), group_id)?;
         group.find_duplicate_dms()
@@ -799,7 +799,7 @@ where
     /// `None` if the group or settings are missing, or `Err(ClientError)` on a database error.
     pub fn group_disappearing_settings(
         &self,
-        group_id: &[u8],
+        group_id: &GroupId,
     ) -> Result<Option<MessageDisappearingSettings>, ClientError> {
         let (group, _) = MlsGroup::new_cached(self.context.clone(), group_id)?;
         Ok(group.disappearing_settings()?)
@@ -847,7 +847,7 @@ where
             .get_group_message(&message_id)?
             .ok_or_else(|| NotFound::MessageById(message_id.clone()))?;
 
-        let group_id = message.group_id.clone();
+        let group_id = message.group_id;
 
         let enriched = enrich_messages(conn, &group_id, vec![message])?;
 
@@ -916,7 +916,7 @@ where
                     // Only construct StoredGroupMessage if all fields are Some
                     let msg: Option<StoredGroupMessage> = Some(StoredGroupMessage {
                         id: message_id,
-                        group_id: conversation_item.id.clone(),
+                        group_id: conversation_item.id,
                         decrypted_message_bytes: conversation_item.decrypted_message_bytes?,
                         sent_at_ns: conversation_item.sent_at_ns?,
                         sender_installation_id: conversation_item.sender_installation_id?,
@@ -1525,10 +1525,10 @@ pub(crate) mod tests {
         assert_eq!(bob_received_groups.len(), 2);
 
         let bo_groups = bo.find_groups(GroupQueryArgs::default()).unwrap();
-        let bo_group1 = bo.group(&alix_bo_group1.clone().group_id).unwrap();
+        let bo_group1 = bo.group(&alix_bo_group1.group_id).unwrap();
         let bo_messages1 = bo_group1.find_messages(&MsgQueryArgs::default()).unwrap();
         assert_eq!(bo_messages1.len(), 1);
-        let bo_group2 = bo.group(&alix_bo_group2.clone().group_id).unwrap();
+        let bo_group2 = bo.group(&alix_bo_group2.group_id).unwrap();
         let bo_messages2 = bo_group2.find_messages(&MsgQueryArgs::default()).unwrap();
         assert_eq!(bo_messages2.len(), 1);
         alix_bo_group1
@@ -1545,7 +1545,7 @@ pub(crate) mod tests {
 
         let bo_messages1 = bo_group1.find_messages(&MsgQueryArgs::default()).unwrap();
         assert_eq!(bo_messages1.len(), 2);
-        let bo_group2 = bo.group(&alix_bo_group2.clone().group_id).unwrap();
+        let bo_group2 = bo.group(&alix_bo_group2.group_id).unwrap();
         let bo_messages2 = bo_group2.find_messages(&MsgQueryArgs::default()).unwrap();
         assert_eq!(bo_messages2.len(), 2);
     }
@@ -1569,7 +1569,7 @@ pub(crate) mod tests {
         xmtp_common::time::sleep(Duration::from_millis(100)).await;
 
         // Verify Bo initially has no messages
-        let bo_group1 = bo.group(&alix_bo_group1.group_id.clone()).unwrap();
+        let bo_group1 = bo.group(&alix_bo_group1.group_id).unwrap();
         assert_eq!(
             bo_group1
                 .find_messages(&MsgQueryArgs::default())
@@ -1577,7 +1577,7 @@ pub(crate) mod tests {
                 .len(),
             1
         );
-        let bo_group2 = bo.group(&alix_bo_group2.group_id.clone()).unwrap();
+        let bo_group2 = bo.group(&alix_bo_group2.group_id).unwrap();
         assert_eq!(
             bo_group2
                 .find_messages(&MsgQueryArgs::default())
@@ -1949,7 +1949,7 @@ pub(crate) mod tests {
 
         // second is allowing consent for the group
         alix.set_consent_states(&[StoredConsentRecord {
-            entity: hex::encode(&group.group_id),
+            entity: hex::encode(group.group_id),
             state: ConsentState::Allowed,
             entity_type: ConsentType::ConversationId,
             consented_at_ns: now_ns(),
@@ -1973,13 +1973,13 @@ pub(crate) mod tests {
         let item = stream.next().await??;
         assert_eq!(item.len(), 1);
         assert_eq!(item[0].entity_type, ConsentType::ConversationId);
-        assert_eq!(item[0].entity, hex::encode(&group.group_id));
+        assert_eq!(item[0].entity, hex::encode(group.group_id));
         assert_eq!(item[0].state, ConsentState::Allowed);
 
         let item = stream.next().await??;
         assert_eq!(item.len(), 1);
         assert_eq!(item[0].entity_type, ConsentType::ConversationId);
-        assert_eq!(item[0].entity, hex::encode(&group.group_id));
+        assert_eq!(item[0].entity, hex::encode(group.group_id));
         assert_eq!(item[0].state, ConsentState::Denied);
 
         let item = stream.next().await??;
@@ -2072,7 +2072,7 @@ pub(crate) mod tests {
                 )
                 .await
                 .unwrap();
-            all_group_ids.push(group.group_id.clone());
+            all_group_ids.push(group.group_id);
             group
                 .send_message(
                     TextCodec::encode("hello".to_string())
@@ -2103,7 +2103,7 @@ pub(crate) mod tests {
             }
             assert_eq!(results.len(), 5);
 
-            all_conversation_ids.extend(results.iter().map(|item| item.group.group_id.clone()));
+            all_conversation_ids.extend(results.iter().map(|item| item.group.group_id));
 
             before_ns = Some(
                 results

--- a/crates/xmtp_mls/src/groups/commit_log.rs
+++ b/crates/xmtp_mls/src/groups/commit_log.rs
@@ -639,13 +639,13 @@ where
         // Check if a readd request has already been sent for this group
         if conn.is_awaiting_readd(&group_id, self.context.installation_id().as_slice())? {
             tracing::debug!(
-                group_id = hex::encode(group_id),
+                group_id = %group_id,
                 "Skipping readd request for group because it has already been requested"
             );
             return Ok(());
         }
 
-        tracing::info!(group_id = hex::encode(group_id), "Sending readd request");
+        tracing::info!(group_id = %group_id, "Sending readd request");
 
         // Send oneshot message with readd request to super admins
         let latest_commit_sequence_id =
@@ -663,13 +663,13 @@ where
         };
         let readders = self.permitted_readders(&group_id).await?;
         tracing::info!(
-            group_id = hex::encode(group_id),
+            group_id = %group_id,
             "Sending readd request to {:?}",
             readders
         );
         Oneshot::send_message(self.context.clone(), readders, oneshot_message).await?;
 
-        tracing::info!(group_id = hex::encode(group_id), "Sent readd request",);
+        tracing::info!(group_id = %group_id, "Sent readd request",);
 
         // Mark readd as requested
         conn.update_requested_at_sequence_id(
@@ -679,7 +679,7 @@ where
         )?;
 
         tracing::info!(
-            group_id = hex::encode(group_id),
+            group_id = %group_id,
             sequence_id = latest_commit_sequence_id,
             "Updated requested readd sequence id",
         );
@@ -726,7 +726,7 @@ where
             // Process the readd request and log any errors
             if let Err(e) = self.request_readd(group_info).await {
                 tracing::error!(
-                    group_id = hex::encode(group_id),
+                    group_id = %group_id,
                     error = ?e,
                     "Failed to send readd request for group"
                 );
@@ -771,13 +771,13 @@ where
                 }
                 Err(e) => {
                     tracing::warn!(
-                        group_id = hex::encode(group.group_id),
+                        group_id = %group.group_id,
                         "Failed to validate readd requests for group: {}",
                         e
                     );
                     if !e.is_retryable() {
                         tracing::warn!(
-                            group_id = hex::encode(group.group_id),
+                            group_id = %group.group_id,
                             "Deleting readd statuses for group because it failed validation: {}",
                             e
                         );
@@ -801,7 +801,7 @@ where
     ) -> Result<HashSet<Vec<u8>>, CommitLogError> {
         let (mls_group, _) = MlsGroup::new_cached(self.context.clone(), &group.group_id)?;
         tracing::debug!(
-            group_id = hex::encode(mls_group.group_id),
+            group_id = %mls_group.group_id,
             "Processing readd requests for group"
         );
 
@@ -831,7 +831,7 @@ where
             ));
         } else if fork_state.is_none() {
             tracing::info!(
-                group_id = hex::encode(mls_group.group_id),
+                group_id = %mls_group.group_id,
                 "Local commit log ahead of remote, skipping group"
             );
             return Ok(HashSet::new());
@@ -859,7 +859,7 @@ where
             })
             .await?;
         tracing::debug!(
-            group_id = hex::encode(mls_group.group_id),
+            group_id = %mls_group.group_id,
             "{} readd requests were for non-members, while {} were for members",
             unverified.len(),
             verified.len()

--- a/crates/xmtp_mls/src/groups/commit_log.rs
+++ b/crates/xmtp_mls/src/groups/commit_log.rs
@@ -97,6 +97,8 @@ pub enum CommitLogError {
     CryptoError(#[from] openmls_traits::types::CryptoError),
     #[error("try from slice error: {0}")]
     TryFromSliceError(#[from] std::array::TryFromSliceError),
+    #[error("conversion error: {0}")]
+    Conversion(#[from] xmtp_proto::ConversionError),
     #[error("Group did not pass readd validation: {0}")]
     GroupReaddValidationError(String),
     #[error("sync error: {0}")]
@@ -117,6 +119,7 @@ impl RetryableError for CommitLogError {
             Self::GroupError(group_error) => group_error.is_retryable(),
             Self::CryptoError(_crypto_error) => false,
             Self::TryFromSliceError(_try_from_slice_error) => false,
+            Self::Conversion(_) => false,
             Self::GroupReaddValidationError(_group_readd_validation_error) => false,
             Self::SyncError(sync_error) => sync_error.is_retryable(),
             Self::GenericError(_generic_error) => false,
@@ -136,6 +139,7 @@ impl NeedsDbReconnect for CommitLogError {
             Self::GroupError(_group_error) => false,       // TODO(rich): What does this method do?
             Self::CryptoError(_crypto_error) => false,
             Self::TryFromSliceError(_try_from_slice_error) => false,
+            Self::Conversion(_) => false,
             Self::GroupReaddValidationError(_group_readd_validation_error) => false,
             Self::SyncError(_sync_error) => false,
             Self::GenericError(_generic_error) => false,
@@ -304,7 +308,7 @@ where
                 .unwrap_or(0);
             let published_commit_log_cursor = conn
                 .get_last_cursor_for_originator(
-                    &conversation.id,
+                    conversation.id,
                     xmtp_db::refresh_state::EntityKind::CommitLogUpload,
                     Originators::REMOTE_COMMIT_LOG,
                 )
@@ -356,7 +360,7 @@ where
         let Some(private_key) = get_or_create_signing_key(&self.context, conversation)? else {
             tracing::warn!(
                 "No signing key available for group {:?}",
-                hex::encode(&conversation.id)
+                hex::encode(conversation.id)
             );
             return Ok(vec![]);
         };
@@ -460,15 +464,14 @@ where
         commit_log_response: QueryCommitLogResponse,
         consensus_public_key: Option<Vec<u8>>,
     ) -> Result<usize, CommitLogError> {
-        let group_id = commit_log_response.group_id;
+        let group_id = GroupId::try_from(commit_log_response.group_id)?;
         let mut num_entries_saved = 0;
         // From the stored remote commit log, fetch the following info:
         // 1. The latest applied epoch authenticator
         // 2. The latest applied epoch number
         // 3. The latest stored sequence id
         if let Some(consensus_public_key) = consensus_public_key {
-            let mut latest_saved_remote_log =
-                conn.get_latest_remote_log_for_group(&GroupId::from(group_id.as_slice()))?;
+            let mut latest_saved_remote_log = conn.get_latest_remote_log_for_group(&group_id)?;
             for commit_log_entry in &commit_log_response.commit_log_entries {
                 let log_entry = match PlaintextCommitLogEntry::decode(
                     commit_log_entry.serialized_commit_log_entry.as_slice(),
@@ -484,7 +487,7 @@ where
                     }
                 };
                 if self.should_skip_remote_commit_log_entry(
-                    &group_id,
+                    group_id.as_slice(),
                     latest_saved_remote_log.clone(),
                     commit_log_entry,
                     &log_entry,
@@ -493,10 +496,11 @@ where
                     continue;
                 }
 
+                let log_entry_group_id = GroupId::try_from(log_entry.group_id.as_slice())?;
                 num_entries_saved += 1;
                 NewRemoteCommitLog {
                     log_sequence_id: commit_log_entry.sequence_id as i64,
-                    group_id: GroupId::from(log_entry.group_id.as_slice()),
+                    group_id: log_entry_group_id,
                     commit_sequence_id: log_entry.commit_sequence_id as i64,
                     commit_result: CommitResult::from(
                         ProtoCommitResult::try_from(log_entry.commit_result)
@@ -510,7 +514,7 @@ where
                 latest_saved_remote_log = Some(RemoteCommitLog {
                     rowid: 0,
                     log_sequence_id: commit_log_entry.sequence_id as i64,
-                    group_id: GroupId::from(log_entry.group_id),
+                    group_id: log_entry_group_id,
                     commit_sequence_id: log_entry.commit_sequence_id as i64,
                     commit_result: CommitResult::from(
                         ProtoCommitResult::try_from(log_entry.commit_result)
@@ -523,7 +527,7 @@ where
         }
         if let Some(last_entry) = commit_log_response.commit_log_entries.last() {
             conn.update_cursor(
-                &group_id,
+                group_id,
                 xmtp_db::refresh_state::EntityKind::CommitLogDownload,
                 Cursor::commit_log(last_entry.sequence_id),
             )?;
@@ -594,15 +598,13 @@ where
             self.context.db().get_conversation_ids_for_fork_check()?;
 
         for conversation_id in conversation_ids_for_forked_state_check {
+            let conversation_id = GroupId::try_from(conversation_id)?;
             self.context.mls_provider().storage().transaction(|conn| {
                 let key_store = conn.key_store();
                 let db = key_store.db();
                 let is_forked = self.check_conversation_fork_state(&db, &conversation_id)?;
                 // Persist the fork status to the database
-                db.set_group_commit_log_forked_status(
-                    &GroupId::from(conversation_id.as_slice()),
-                    is_forked,
-                )?;
+                db.set_group_commit_log_forked_status(&conversation_id, is_forked)?;
                 Ok::<(), CommitLogError>(())
             })?;
             tokio::task::yield_now().await;
@@ -613,7 +615,7 @@ where
 
     /// Returns the list of permitted readders for a group
     /// Note: Does not return self - self is always a permitted readder
-    async fn permitted_readders(&self, group_id: &[u8]) -> Result<Vec<String>, CommitLogError> {
+    async fn permitted_readders(&self, group_id: &GroupId) -> Result<Vec<String>, CommitLogError> {
         let (group, stored_group) = MlsGroup::new_cached(self.context.clone(), group_id)?;
         if stored_group.conversation_type == ConversationType::Dm {
             let Some(dm_id) = stored_group.dm_id.clone() else {
@@ -633,18 +635,17 @@ where
     ) -> Result<(), CommitLogError> {
         let conn = self.context.db();
         let group_id = group_info.group_id;
-        let group_id_typed = GroupId::from(group_id.as_slice());
 
         // Check if a readd request has already been sent for this group
-        if conn.is_awaiting_readd(&group_id_typed, self.context.installation_id().as_slice())? {
+        if conn.is_awaiting_readd(&group_id, self.context.installation_id().as_slice())? {
             tracing::debug!(
-                group_id = hex::encode(&group_id),
+                group_id = hex::encode(group_id),
                 "Skipping readd request for group because it has already been requested"
             );
             return Ok(());
         }
 
-        tracing::info!(group_id = hex::encode(&group_id), "Sending readd request");
+        tracing::info!(group_id = hex::encode(group_id), "Sending readd request");
 
         // Send oneshot message with readd request to super admins
         let latest_commit_sequence_id =
@@ -652,7 +653,7 @@ where
                 .latest_commit_sequence_id
                 .ok_or(CommitLogError::GenericError(format!(
                     "No latest commit sequence id found for forked group {}",
-                    hex::encode(&group_id)
+                    hex::encode(group_id)
                 )))?;
         let oneshot_message = OneshotMessage {
             message_type: Some(MessageType::ReaddRequest(ReaddRequest {
@@ -660,25 +661,25 @@ where
                 latest_commit_sequence_id: latest_commit_sequence_id as u64,
             })),
         };
-        let readders = self.permitted_readders(group_id.as_ref()).await?;
+        let readders = self.permitted_readders(&group_id).await?;
         tracing::info!(
-            group_id = hex::encode(&group_id),
+            group_id = hex::encode(group_id),
             "Sending readd request to {:?}",
             readders
         );
         Oneshot::send_message(self.context.clone(), readders, oneshot_message).await?;
 
-        tracing::info!(group_id = hex::encode(&group_id), "Sent readd request",);
+        tracing::info!(group_id = hex::encode(group_id), "Sent readd request",);
 
         // Mark readd as requested
         conn.update_requested_at_sequence_id(
-            &group_id_typed,
+            &group_id,
             self.context.installation_id().as_slice(),
             latest_commit_sequence_id as i64,
         )?;
 
         tracing::info!(
-            group_id = hex::encode(&group_id),
+            group_id = hex::encode(group_id),
             sequence_id = latest_commit_sequence_id,
             "Updated requested readd sequence id",
         );
@@ -709,23 +710,23 @@ where
                 "Forked groups: {:?}, allowlisted groups for sending recovery requests: {:?}",
                 forked_groups
                     .iter()
-                    .map(|group_info| hex::encode(&group_info.group_id))
+                    .map(|group_info| hex::encode(group_info.group_id))
                     .collect::<Vec<String>>(),
                 groups_to_request_recovery
             );
             forked_groups.retain(|group_info| {
                 groups_to_request_recovery
-                    .contains(&hex::encode(&group_info.group_id).normalize_hex())
+                    .contains(&hex::encode(group_info.group_id).normalize_hex())
             });
         }
 
         for group_info in forked_groups {
-            let group_id = group_info.group_id.clone();
+            let group_id = group_info.group_id;
 
             // Process the readd request and log any errors
             if let Err(e) = self.request_readd(group_info).await {
                 tracing::error!(
-                    group_id = hex::encode(&group_id),
+                    group_id = hex::encode(group_id),
                     error = ?e,
                     "Failed to send readd request for group"
                 );
@@ -757,7 +758,7 @@ where
                     }
                     let mls_group = MlsGroup::new(
                         self.context.clone(),
-                        GroupId::from(group.group_id.as_slice()),
+                        group.group_id,
                         group.dm_id.clone(),
                         group.conversation_type,
                         group.created_at_ns,
@@ -770,18 +771,18 @@ where
                 }
                 Err(e) => {
                     tracing::warn!(
-                        group_id = hex::encode(&group.group_id),
+                        group_id = hex::encode(group.group_id),
                         "Failed to validate readd requests for group: {}",
                         e
                     );
                     if !e.is_retryable() {
                         tracing::warn!(
-                            group_id = hex::encode(&group.group_id),
+                            group_id = hex::encode(group.group_id),
                             "Deleting readd statuses for group because it failed validation: {}",
                             e
                         );
                         conn.delete_other_readd_statuses(
-                            &GroupId::from(group.group_id.as_slice()),
+                            &group.group_id,
                             self.context.installation_id().as_slice(),
                         )?;
                     }
@@ -800,7 +801,7 @@ where
     ) -> Result<HashSet<Vec<u8>>, CommitLogError> {
         let (mls_group, _) = MlsGroup::new_cached(self.context.clone(), &group.group_id)?;
         tracing::debug!(
-            group_id = hex::encode(&mls_group.group_id),
+            group_id = hex::encode(mls_group.group_id),
             "Processing readd requests for group"
         );
 
@@ -830,14 +831,14 @@ where
             ));
         } else if fork_state.is_none() {
             tracing::info!(
-                group_id = hex::encode(&mls_group.group_id),
+                group_id = hex::encode(mls_group.group_id),
                 "Local commit log ahead of remote, skipping group"
             );
             return Ok(HashSet::new());
         }
 
         let readd_statuses = conn.get_readds_awaiting_response(
-            &GroupId::from(mls_group.group_id.as_slice()),
+            &mls_group.group_id,
             self.context.installation_id().as_slice(),
         )?;
         let mut unverified = readd_statuses
@@ -858,12 +859,12 @@ where
             })
             .await?;
         tracing::debug!(
-            group_id = hex::encode(&mls_group.group_id),
+            group_id = hex::encode(mls_group.group_id),
             "{} readd requests were for non-members, while {} were for members",
             unverified.len(),
             verified.len()
         );
-        conn.delete_readd_statuses(&GroupId::from(mls_group.group_id.as_slice()), unverified)?;
+        conn.delete_readd_statuses(&mls_group.group_id, unverified)?;
 
         Ok(verified)
     }
@@ -871,7 +872,7 @@ where
     fn check_conversation_fork_state(
         &self,
         conn: &impl DbQuery,
-        conversation_id: &[u8],
+        conversation_id: &GroupId,
     ) -> Result<Option<bool>, CommitLogError> {
         // Get cursors for this conversation
         let fork_check_local_cursor = conn.get_last_cursor_for_originator(
@@ -886,21 +887,20 @@ where
         )?;
 
         // Get local and remote commit logs
-        let conversation_id_typed = GroupId::from(conversation_id);
         let local_logs = conn.get_local_commit_log_after_cursor(
-            &conversation_id_typed,
+            conversation_id,
             fork_check_local_cursor.sequence_id as i64,
             LocalCommitLogOrder::DescendingByRowid,
         )?;
         let remote_logs = conn.get_remote_commit_log_after_cursor(
-            &conversation_id_typed,
+            conversation_id,
             fork_check_remote_cursor.sequence_id as i64,
             RemoteCommitLogOrder::DescendingByRowid,
         )?;
 
         // If there are no new commits to check, preserve the existing fork status
         if local_logs.is_empty() {
-            return Ok(conn.get_group_commit_log_forked_status(&conversation_id_typed)?);
+            return Ok(conn.get_group_commit_log_forked_status(conversation_id)?);
         }
 
         let mut is_remote_log_up_to_date = true;

--- a/crates/xmtp_mls/src/groups/commit_log.rs
+++ b/crates/xmtp_mls/src/groups/commit_log.rs
@@ -402,6 +402,7 @@ where
         let remote_log_cursors = conn.get_remote_log_cursors(
             conversation_id_to_public_key
                 .keys()
+                .map(Vec::as_slice)
                 .collect::<Vec<_>>()
                 .as_slice(),
         )?;

--- a/crates/xmtp_mls/src/groups/commit_log_key.rs
+++ b/crates/xmtp_mls/src/groups/commit_log_key.rs
@@ -66,23 +66,37 @@ impl CommitLogKeyCrypto for RustCrypto {
 
 pub(crate) trait CommitLogKeyStore {
     type Error: std::error::Error;
-    fn read_commit_log_key(&self, group_id: &[u8]) -> Result<Option<Secret>, Self::Error>;
-    fn write_commit_log_key(&self, group_id: &[u8], value: &Secret) -> Result<(), Self::Error>;
+    fn read_commit_log_key(
+        &self,
+        group_id: impl AsRef<[u8]>,
+    ) -> Result<Option<Secret>, Self::Error>;
+    fn write_commit_log_key(
+        &self,
+        group_id: impl AsRef<[u8]>,
+        value: &Secret,
+    ) -> Result<(), Self::Error>;
 }
 
 impl<KeyStore: XmtpMlsStorageProvider> CommitLogKeyStore for KeyStore {
     type Error = SqlKeyStoreError;
 
-    fn read_commit_log_key(&self, group_id: &[u8]) -> Result<Option<Secret>, Self::Error> {
-        let key = bincode::serialize(group_id)?;
+    fn read_commit_log_key(
+        &self,
+        group_id: impl AsRef<[u8]>,
+    ) -> Result<Option<Secret>, Self::Error> {
+        let key = bincode::serialize(group_id.as_ref())?;
         let value = self
             .read::<Vec<u8>>(COMMIT_LOG_SIGNER_PRIVATE_KEY, &key)?
             .map(Secret::new);
         Ok(value)
     }
 
-    fn write_commit_log_key(&self, group_id: &[u8], value: &Secret) -> Result<(), Self::Error> {
-        let key = bincode::serialize(group_id)?;
+    fn write_commit_log_key(
+        &self,
+        group_id: impl AsRef<[u8]>,
+        value: &Secret,
+    ) -> Result<(), Self::Error> {
+        let key = bincode::serialize(group_id.as_ref())?;
         let value = Secret::new(bincode::serialize(value.as_slice())?);
         self.write(COMMIT_LOG_SIGNER_PRIVATE_KEY, &key, value.as_slice())
     }
@@ -90,7 +104,7 @@ impl<KeyStore: XmtpMlsStorageProvider> CommitLogKeyStore for KeyStore {
 
 pub(crate) async fn maybe_share_private_key(
     context: &impl XmtpSharedContext,
-    group_id: &[u8],
+    group_id: &GroupId,
     consensus_public_key: &[u8],
 ) -> Result<(), CommitLogError> {
     let provider = context.mls_provider();
@@ -117,6 +131,7 @@ pub(crate) async fn derive_consensus_public_key(
     commit_log_response: &QueryCommitLogResponse,
 ) -> Result<Option<Vec<u8>>, CommitLogError> {
     let provider = context.mls_provider();
+    let group_id = GroupId::try_from(commit_log_response.group_id.as_slice())?;
     // Find the first entry with a valid signature and extract its public key
     for entry in &commit_log_response.commit_log_entries {
         if let Some(signature) = &entry.signature
@@ -125,16 +140,10 @@ pub(crate) async fn derive_consensus_public_key(
                 .verify_commit_log_signature(entry, &signature.public_key)
                 .is_ok()
         {
-            maybe_share_private_key(
-                context,
-                &commit_log_response.group_id,
-                &signature.public_key,
-            )
-            .await?;
-            context.db().set_group_commit_log_public_key(
-                &GroupId::from(commit_log_response.group_id.as_slice()),
-                &signature.public_key,
-            )?;
+            maybe_share_private_key(context, &group_id, &signature.public_key).await?;
+            context
+                .db()
+                .set_group_commit_log_public_key(&group_id, &signature.public_key)?;
             return Ok(Some(signature.public_key.clone()));
         }
     }
@@ -157,7 +166,7 @@ pub(crate) fn get_or_create_signing_key(
     // If there is none, we use any existing private key from the same locations, creating a new key if not found.
     let consensus_public_key = conversation.commit_log_public_key.as_ref();
 
-    if let Some(private_key) = key_store.read_commit_log_key(&conversation.id)?
+    if let Some(private_key) = key_store.read_commit_log_key(conversation.id)?
         && consensus_public_key.is_none_or(|consensus_public_key| {
             RustCrypto::public_key_matches_private_key(consensus_public_key, &private_key)
         })
@@ -171,7 +180,7 @@ pub(crate) fn get_or_create_signing_key(
             RustCrypto::public_key_matches_private_key(consensus_public_key, &private_key)
         })
     {
-        key_store.write_commit_log_key(&conversation.id, &private_key)?;
+        key_store.write_commit_log_key(conversation.id, &private_key)?;
         return Ok(Some(private_key));
     }
 
@@ -180,14 +189,14 @@ pub(crate) fn get_or_create_signing_key(
         // We store the key locally, but do not share it via mutable metadata until we verify that we
         // published it as the first commit log entry.
         let private_key = provider.crypto().generate_commit_log_key()?;
-        key_store.write_commit_log_key(&conversation.id, &private_key)?;
+        key_store.write_commit_log_key(conversation.id, &private_key)?;
         return Ok(Some(private_key));
     }
 
     tracing::warn!(
         "Commit log consensus key {:?} is not available yet for conversation {:?}",
         consensus_public_key.map(hex::encode),
-        hex::encode(&conversation.id)
+        hex::encode(conversation.id)
     );
     Ok(None)
 }
@@ -206,14 +215,14 @@ mod tests {
         let provider = alix.context.mls_provider();
         let key_store = provider.key_store();
 
-        key_store.write_commit_log_key(&[1u8; 32], &Secret::new(vec![10u8; 32]))?;
+        key_store.write_commit_log_key([1u8; 32], &Secret::new(vec![10u8; 32]))?;
 
         // Query on a value that hasn't been written
-        let result = key_store.read_commit_log_key(&[2u8; 32]);
+        let result = key_store.read_commit_log_key([2u8; 32]);
         assert!(result.is_ok(), "{}", result.err().unwrap());
         assert!(result.unwrap().is_none());
 
-        let result = key_store.read_commit_log_key(&[1u8; 32]);
+        let result = key_store.read_commit_log_key([1u8; 32]);
         assert!(result.is_ok(), "{}", result.err().unwrap());
         assert_eq!(result.unwrap().unwrap().as_slice(), &[10u8; 32]);
     }
@@ -491,7 +500,7 @@ mod tests {
         let mutable_metadata_key = metadata.commit_log_signer().unwrap();
 
         let conversation = StoredGroupCommitLogPublicKey {
-            id: group.group_id.clone(),
+            id: group.group_id,
             commit_log_public_key: None, // No consensus key
         };
 
@@ -513,7 +522,7 @@ mod tests {
         // Store a key that doesn't match the consensus
         let stored_key = crypto.generate_commit_log_key().unwrap();
         key_store
-            .write_commit_log_key(&group.group_id, &stored_key)
+            .write_commit_log_key(group.group_id, &stored_key)
             .unwrap();
 
         // Set a different consensus key
@@ -523,7 +532,7 @@ mod tests {
             .to_vec();
 
         let conversation = StoredGroupCommitLogPublicKey {
-            id: group.group_id.clone(),
+            id: group.group_id,
             commit_log_public_key: Some(consensus_public_key),
         };
 
@@ -547,12 +556,12 @@ mod tests {
             .unwrap()
             .to_vec();
         key_store
-            .write_commit_log_key(&group.group_id, &stored_key)
+            .write_commit_log_key(group.group_id, &stored_key)
             .unwrap();
 
         // Set consensus key that matches the stored key
         let conversation = StoredGroupCommitLogPublicKey {
-            id: group.group_id.clone(),
+            id: group.group_id,
             commit_log_public_key: Some(stored_public_key),
         };
 
@@ -575,7 +584,7 @@ mod tests {
 
         // Set consensus key that matches the mutable metadata key
         let conversation = StoredGroupCommitLogPublicKey {
-            id: group.group_id.clone(),
+            id: group.group_id,
             commit_log_public_key: Some(metadata_public_key),
         };
 
@@ -593,7 +602,7 @@ mod tests {
         let key_store = provider.key_store();
 
         let group = alix.create_group(None, None).unwrap();
-        let group_id = group.group_id.clone();
+        let group_id = group.group_id;
 
         // Clear the key store to ensure no stored key exists
         key_store

--- a/crates/xmtp_mls/src/groups/intents.rs
+++ b/crates/xmtp_mls/src/groups/intents.rs
@@ -1143,7 +1143,7 @@ pub(crate) mod tests {
         let messages = group
             .context
             .api()
-            .query_at(TopicKind::GroupMessagesV1.create(&group.group_id), None)
+            .query_at(TopicKind::GroupMessagesV1.create(group.group_id), None)
             .await
             .unwrap();
         assert_eq!(messages.len(), num_messages);

--- a/crates/xmtp_mls/src/groups/intents/queue.rs
+++ b/crates/xmtp_mls/src/groups/intents/queue.rs
@@ -243,6 +243,7 @@ impl QueueIntent {
 mod tests {
     use std::{iter, sync::Arc};
     use tokio::sync::Mutex;
+    use xmtp_common::Generate;
     use xmtp_db::group::{GroupMembershipState, StoredGroup};
     use xmtp_proto::types::GroupId;
 
@@ -252,7 +253,7 @@ mod tests {
     use rstest::*;
 
     fn group<C: XmtpSharedContext>(context: &C, id: Option<GroupId>) -> MlsGroup<&C> {
-        let id = id.unwrap_or_else(|| GroupId::from(xmtp_common::rand_array::<16>()));
+        let id = id.unwrap_or_else(GroupId::generate);
         StoredGroup::builder()
             .id(id)
             .created_at_ns(1)

--- a/crates/xmtp_mls/src/groups/intents/queue.rs
+++ b/crates/xmtp_mls/src/groups/intents/queue.rs
@@ -291,7 +291,7 @@ mod tests {
     #[rstest]
     #[xmtp_common::test]
     async fn only_queues_for_unique(context: NewMockContext) {
-        let groups = iter::repeat_n(group(&context, Some(GroupId::from([0u8; 16]))), 10);
+        let groups = iter::repeat_n(group(&context, Some(GroupId::ZERO)), 10);
 
         let stored = QueueIntent::update_group_membership()
             .data(vec![0, 1, 2])

--- a/crates/xmtp_mls/src/groups/intents/queue.rs
+++ b/crates/xmtp_mls/src/groups/intents/queue.rs
@@ -205,7 +205,7 @@ impl QueueIntent {
 
         let intent = conn.insert_group_intent(NewGroupIntent::new(
             intent_kind,
-            group.group_id.clone(),
+            group.group_id,
             intent_data,
             should_push,
         ))?;
@@ -244,16 +244,17 @@ mod tests {
     use std::{iter, sync::Arc};
     use tokio::sync::Mutex;
     use xmtp_db::group::{GroupMembershipState, StoredGroup};
+    use xmtp_proto::types::GroupId;
 
     use crate::test::mock::{NewMockContext, context};
 
     use super::*;
     use rstest::*;
 
-    fn group<C: XmtpSharedContext>(context: &C, id: Option<Vec<u8>>) -> MlsGroup<&C> {
-        let id = id.unwrap_or(xmtp_common::rand_vec::<2>());
+    fn group<C: XmtpSharedContext>(context: &C, id: Option<GroupId>) -> MlsGroup<&C> {
+        let id = id.unwrap_or_else(|| GroupId::from(xmtp_common::rand_array::<16>()));
         StoredGroup::builder()
-            .id(id.clone())
+            .id(id)
             .created_at_ns(1)
             .membership_state(GroupMembershipState::Allowed)
             .added_by_inbox_id("bob")
@@ -264,7 +265,7 @@ mod tests {
             .unwrap();
 
         MlsGroup {
-            group_id: id.into(),
+            group_id: id,
             dm_id: None,
             created_at_ns: 1,
             context,
@@ -289,7 +290,7 @@ mod tests {
     #[rstest]
     #[xmtp_common::test]
     async fn only_queues_for_unique(context: NewMockContext) {
-        let groups = iter::repeat_n(group(&context, Some(vec![0])), 10);
+        let groups = iter::repeat_n(group(&context, Some(GroupId::from([0u8; 16]))), 10);
 
         let stored = QueueIntent::update_group_membership()
             .data(vec![0, 1, 2])

--- a/crates/xmtp_mls/src/groups/message_list.rs
+++ b/crates/xmtp_mls/src/groups/message_list.rs
@@ -6,7 +6,6 @@ use xmtp_db::DbQuery;
 use xmtp_db::group_message::{ContentType as DbContentType, MsgQueryArgs};
 use xmtp_db::prelude::QueryGroupMessage;
 
-use xmtp_proto::types::GroupId;
 impl<Context> MlsGroup<Context>
 where
     Context: XmtpSharedContext,
@@ -27,9 +26,8 @@ where
     where
         C: QueryGroupMessage + DbQuery,
     {
-        let group_id_typed = GroupId::from(self.group_id.as_slice());
         let initial_messages = conn.get_group_messages(
-            &group_id_typed,
+            &self.group_id,
             &filter_out_hidden_message_types_from_query(query),
         )?;
 
@@ -78,6 +76,7 @@ mod tests {
     use xmtp_db::group_message::{
         ContentType as DbContentType, DeliveryStatus, GroupMessageKind, StoredGroupMessage,
     };
+    use xmtp_proto::types::GroupId;
     use xmtp_proto::xmtp::mls::message_contents::content_types::ReactionAction;
     use xmtp_proto::xmtp::mls::message_contents::{ContentTypeId, EncodedContent};
 
@@ -89,7 +88,7 @@ mod tests {
     }
 
     fn create_test_message(
-        group_id: &[u8],
+        group_id: &GroupId,
         message_id: Vec<u8>,
         encoded_content: EncodedContent,
         sent_at_ns: i64,
@@ -101,7 +100,7 @@ mod tests {
 
         StoredGroupMessage {
             id: message_id,
-            group_id: group_id.into(),
+            group_id: *group_id,
             decrypted_message_bytes: content_bytes,
             sent_at_ns,
             kind: GroupMessageKind::Application,
@@ -123,7 +122,7 @@ mod tests {
 
     // For tests that need malformed content
     fn create_test_message_raw(
-        group_id: &[u8],
+        group_id: &GroupId,
         message_id: Vec<u8>,
         content: Vec<u8>,
         sent_at_ns: i64,
@@ -145,7 +144,7 @@ mod tests {
 
         StoredGroupMessage {
             id: message_id,
-            group_id: group_id.into(),
+            group_id: *group_id,
             decrypted_message_bytes: content,
             sent_at_ns,
             kind: GroupMessageKind::Application,
@@ -243,7 +242,7 @@ mod tests {
 
     fn create_and_store_message<S>(
         conn: &S,
-        group_id: &[u8],
+        group_id: &GroupId,
         message_id: Vec<u8>,
         content: EncodedContent,
         timestamp_offset: i64,

--- a/crates/xmtp_mls/src/groups/mls_ext/commit_log_storer.rs
+++ b/crates/xmtp_mls/src/groups/mls_ext/commit_log_storer.rs
@@ -77,7 +77,7 @@ impl CommitLogStorer for MlsGroup {
 
         if xmtp_configuration::ENABLE_COMMIT_LOG {
             NewLocalCommitLog {
-                group_id: mls_group.group_id().into(),
+                group_id: mls_group.group_id().try_into()?,
                 commit_sequence_id: 0,
                 last_epoch_authenticator: vec![],
                 commit_result: CommitResult::Success,
@@ -115,7 +115,7 @@ impl CommitLogStorer for MlsGroup {
             // It is safe to log this stubbed encryption state, because we will not upload anything
             // to the remote commit log with a sequence ID of 0.
             NewLocalCommitLog {
-                group_id: mls_group.group_id().into(),
+                group_id: mls_group.group_id().try_into()?,
                 commit_sequence_id: 0,
                 last_epoch_authenticator: vec![],
                 commit_result: CommitResult::Success,
@@ -143,7 +143,7 @@ impl CommitLogStorer for MlsGroup {
 
         if xmtp_configuration::ENABLE_COMMIT_LOG {
             NewLocalCommitLog {
-                group_id: mls_group.group_id().into(),
+                group_id: mls_group.group_id().try_into()?,
                 // TODO(rich): Replace with the cursor sequence ID of the welcome once implemented
                 commit_sequence_id: 0,
                 last_epoch_authenticator: vec![],
@@ -173,7 +173,7 @@ impl CommitLogStorer for MlsGroup {
 
         if xmtp_configuration::ENABLE_COMMIT_LOG {
             NewLocalCommitLog {
-                group_id: self.group_id().into(),
+                group_id: self.group_id().try_into()?,
                 commit_sequence_id: sequence_id,
                 last_epoch_authenticator,
                 commit_result: CommitResult::Success,
@@ -200,7 +200,7 @@ impl CommitLogStorer for MlsGroup {
         if !xmtp_configuration::ENABLE_COMMIT_LOG {
             return Ok(());
         }
-        let group_id: GroupId = self.group_id().into();
+        let group_id: GroupId = self.group_id().try_into()?;
         let last_epoch_number = self.epoch();
         let last_epoch_authenticator = self.epoch_authenticator();
         let conn = provider.key_store().db();

--- a/crates/xmtp_mls/src/groups/mls_ext/reload.rs
+++ b/crates/xmtp_mls/src/groups/mls_ext/reload.rs
@@ -17,7 +17,7 @@ impl MlsGroupReload for OpenMlsGroup {
         provider: &S,
     ) -> Result<(), GroupMessageProcessingError> {
         *self = OpenMlsGroup::load(provider, self.group_id())?.ok_or(StorageError::NotFound(
-            NotFound::MlsGroup(GroupId::from(self.group_id())),
+            NotFound::MlsGroup(GroupId::try_from(self.group_id())?),
         ))?;
         Ok(())
     }

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -136,7 +136,7 @@ pub mod update_group_membership;
 pub enum GroupMessageProcessingError {
     #[error("intent already processed")]
     IntentAlreadyProcessed,
-    #[error("message with cursor [{}] for group [{}] already processed", _0.cursor, xmtp_common::fmt::debug_hex(&_0.group_id)
+    #[error("message with cursor [{}] for group [{}] already processed", _0.cursor, xmtp_common::fmt::debug_hex(_0.group_id)
     )]
     MessageAlreadyProcessed(MessageIdentifier),
     #[error("message identifier not found")]
@@ -217,6 +217,8 @@ pub enum GroupMessageProcessingError {
     EnrichMessage(#[from] EnrichMessageError),
     #[error("pre-commit proposal phase complete, re-queuing intent")]
     PreCommitProposalPhaseComplete,
+    #[error(transparent)]
+    Conversion(#[from] xmtp_proto::ConversionError),
 }
 
 impl RetryableError for GroupMessageProcessingError {
@@ -261,6 +263,7 @@ impl RetryableError for GroupMessageProcessingError {
             | Self::OldEpoch(_, _)
             | Self::PreCommitProposalPhaseComplete => false,
             Self::Builder(_) => false,
+            Self::Conversion(_) => false,
         }
     }
 }
@@ -380,7 +383,7 @@ where
 
     fn handle_group_paused(&self) -> Result<(), GroupError> {
         // Check if group is paused and try to unpause if version requirements are met
-        let group_id_typed = self.group_id.clone();
+        let group_id_typed = self.group_id;
         if let Some(required_min_version_str) = self
             .context
             .db()
@@ -398,7 +401,7 @@ where
                 tracing::info!(
                     "Unpausing group since version requirements are met. \
                      Group ID: {}",
-                    hex::encode(&self.group_id),
+                    hex::encode(self.group_id),
                 );
                 self.context.db().unpause_group(&group_id_typed)?;
             } else {
@@ -407,7 +410,7 @@ where
                     Group ID: {}, \
                     Required version: {}, \
                     Current version: {}",
-                    hex::encode(&self.group_id),
+                    hex::encode(self.group_id),
                     required_min_version_str,
                     current_version_str
                 );
@@ -485,7 +488,7 @@ where
     )]
     pub(crate) async fn sync_until_last_intent_resolved(&self) -> Result<SyncSummary, GroupError> {
         let intents = self.context.db().find_group_intents(
-            self.group_id.clone(),
+            self.group_id,
             Some(vec![IntentState::ToPublish, IntentState::Published]),
             None,
         )?;
@@ -725,7 +728,7 @@ where
                         tracing::warn!(
                             inbox_id = self.context.inbox_id(),
                             installation_id = %self.context.installation_id(),
-                            group_id = hex::encode(&self.group_id),
+                            group_id = hex::encode(self.group_id),
                             cursor = %cursor,
                             intent.id,
                             intent.kind = %intent.kind,
@@ -766,7 +769,7 @@ where
                             tracing::error!(
                                 inbox_id = self.context.inbox_id(),
                                 installation_id = %self.context.installation_id(),
-                                group_id = hex::encode(&self.group_id),
+                                group_id = hex::encode(self.group_id),
                                 cursor = %cursor,
                                 intent_id = intent.id,
                                 intent.kind = %intent.kind,
@@ -802,7 +805,7 @@ where
                             tracing::error!(
                                 inbox_id = self.context.inbox_id(),
                                 installation_id = %self.context.installation_id(),
-                                group_id = hex::encode(&self.group_id),
+                                group_id = hex::encode(self.group_id),
                                 cursor = %cursor,
                                 intent.id,
                                 intent.kind = %intent.kind,
@@ -893,13 +896,13 @@ where
         tracing::debug!(
             inbox_id = self.context.inbox_id(),
             installation_id = %self.context.installation_id(),
-            group_id = hex::encode(&self.group_id),
+            group_id = hex::encode(self.group_id),
             cursor = %cursor,
             intent.id,
             intent.kind = %intent.kind,
             "[{}]-[{}] processing own message for intent {} / {}, message_epoch: {}",
             self.context.inbox_id(),
-            hex::encode(self.group_id.clone()),
+            hex::encode(self.group_id),
             intent.id,
             intent.kind,
             message_epoch.clone()
@@ -1077,7 +1080,7 @@ where
             inbox_id = self.context.inbox_id(),
             installation_id = %self.context.installation_id(),sender_inbox_id = sender_inbox_id,
             sender_installation_id = hex::encode(&sender_installation_id),
-            group_id = hex::encode(&self.group_id),
+            group_id = hex::encode(self.group_id),
             current_epoch = mls_group.epoch().as_u64(),
             msg_epoch = processed_message.epoch().as_u64(),
             msg_group_id = hex::encode(processed_message.group_id().as_slice()),
@@ -1136,7 +1139,7 @@ where
                 {
                     tracing::warn!(
                         inbox_id = self.context.inbox_id(),
-                        group_id = hex::encode(&self.group_id),
+                        group_id = hex::encode(self.group_id),
                         ?proposal_type,
                         "Received proposal but proposals are not enabled on this group"
                     );
@@ -1240,7 +1243,7 @@ where
                     tracing::warn!(
                         inbox_id = self.context.inbox_id(),
                         installation_id = %self.context.installation_id(),
-                        group_id = hex::encode(&self.group_id),
+                        group_id = hex::encode(self.group_id),
                         proposal_type = ?queued_proposal.proposal().proposal_type(),
                         error = %e,
                         "Received invalid proposal, rejecting"
@@ -1263,7 +1266,7 @@ where
             tracing::debug!(
                 inbox_id = self.context.inbox_id(),
                 installation_id = %self.context.installation_id(),
-                group_id = hex::encode(&self.group_id),
+                group_id = hex::encode(self.group_id),
                 current_epoch = mls_group.epoch().as_u64(),
                 msg_epoch = processed_message.epoch().as_u64(),
                 cursor = ?cursor,
@@ -1281,7 +1284,7 @@ where
                     *cursor
                 );
                 let current_cursor = db
-                    .get_last_cursor_for_originator(&envelope.group_id, envelope.entity_kind(), envelope.originator_id())?;
+                    .get_last_cursor_for_originator(envelope.group_id, envelope.entity_kind(), envelope.originator_id())?;
                 current_cursor.sequence_id < envelope.cursor.sequence_id
             };
             if !requires_processing {
@@ -1290,7 +1293,7 @@ where
                 // has already been processed, has the potential to result in forks.
                 tracing::debug!("message @cursor=[{}] for group=[{}] created_at=[{}] no longer require processing, should be available in database",
                     envelope.cursor,
-                    xmtp_common::fmt::debug_hex(&envelope.group_id),
+                    xmtp_common::fmt::debug_hex(envelope.group_id),
                     envelope.created_ns
                  );
                 identifier.previously_processed(true);
@@ -1364,13 +1367,13 @@ where
                         content,
                     })) => {
                         let message_id =
-                            calculate_message_id(&self.group_id, &content, &idempotency_key);
+                            calculate_message_id(self.group_id, &content, &idempotency_key);
                         let queryable_content_fields =
                             Self::extract_queryable_content_fields(&content);
 
                         let message = StoredGroupMessage {
                             id: message_id.clone(),
-                            group_id: self.group_id.clone(),
+                            group_id: self.group_id,
                             decrypted_message_bytes: content,
                             sent_at_ns: envelope_timestamp_ns,
                             kind: GroupMessageKind::Application,
@@ -1431,7 +1434,7 @@ where
                 tracing::debug!(
                     inbox_id = self.context.inbox_id(),
                     installation_id = %self.context.installation_id(),
-                    group_id = hex::encode(&self.group_id),
+                    group_id = hex::encode(self.group_id),
                     proposal_type = ?proposal_ptr.proposal().proposal_type(),
                     "Received and storing proposal in proposal store"
                 );
@@ -1592,12 +1595,12 @@ where
         if message.sender_inbox_id == current_inbox_id {
             storage
                 .db()
-                .update_group_membership(&self.group_id, GroupMembershipState::PendingRemove)?;
+                .update_group_membership(self.group_id, GroupMembershipState::PendingRemove)?;
         }
 
         // put the user in the pending-remove list
         PendingRemove {
-            group_id: message.group_id.clone(),
+            group_id: message.group_id,
             inbox_id: message.sender_inbox_id.clone(),
             message_id: message.id.clone(),
         }
@@ -1655,7 +1658,7 @@ where
                 tracing::warn!(
                     "Cross-group deletion attempt: message {} from group {}",
                     delete_msg.message_id,
-                    hex::encode(&original_msg.group_id)
+                    hex::encode(original_msg.group_id)
                 );
                 return Ok(());
             }
@@ -1698,7 +1701,7 @@ where
 
         let deletion = StoredMessageDeletion {
             id: message.id.clone(),
-            group_id: self.group_id.clone(),
+            group_id: self.group_id,
             deleted_message_id: target_message_id.clone(),
             deleted_by_inbox_id: message.sender_inbox_id.clone(),
             is_super_admin_deletion,
@@ -1755,7 +1758,7 @@ where
         }
         let pending_remove_users = storage
             .db()
-            .get_pending_remove_users(&GroupId::from(mls_group.group_id().as_slice()))?;
+            .get_pending_remove_users(&GroupId::try_from(mls_group.group_id())?)?;
         if pending_remove_users.is_empty() {
             return Ok(());
         }
@@ -1788,14 +1791,14 @@ where
         {
             Ok(_) => {
                 tracing::info!(
-                    group_id = hex::encode(&self.group_id),
+                    group_id = hex::encode(self.group_id),
                     removed_inboxes = ?removed_inbox_ids,
                     "Successfully removed left/removed members from pending_remove list"
                 );
             }
             Err(e) => {
                 tracing::info!(
-                    group_id = hex::encode(&self.group_id),
+                    group_id = hex::encode(self.group_id),
                     removed_inboxes = ?removed_inbox_ids,
                     error = %e,
                     "Failed to clean pending_remove list for removed members"
@@ -1831,10 +1834,11 @@ where
 
         if was_promoted {
             // Promoted to super_admin: check if there are pending remove users
-            match storage
-                .db()
-                .get_pending_remove_users(&GroupId::from(mls_group.group_id().as_slice()))
-            {
+            let Ok(group_id) = GroupId::try_from(mls_group.group_id()) else {
+                tracing::warn!("Invalid group_id length while handling super-admin promotion");
+                return;
+            };
+            match storage.db().get_pending_remove_users(&group_id) {
                 Ok(pending_remove_users) => {
                     if !pending_remove_users.is_empty()
                         && !pending_remove_users.contains(&current_inbox_id)
@@ -1844,7 +1848,7 @@ where
                 }
                 Err(e) => {
                     tracing::info!(
-                        group_id = hex::encode(&self.group_id),
+                        group_id = hex::encode(self.group_id),
                         inbox_id = %current_inbox_id,
                         error = %e,
                         "Failed to get pending remove users after promotion"
@@ -1865,7 +1869,7 @@ where
         // This is where we would mark the group as having/not having pending remove requests
         if has_pending_removes {
             tracing::info!(
-                group_id = hex::encode(&self.group_id),
+                group_id = hex::encode(self.group_id),
                 inbox_id = %self.context.inbox_id(),
                 "Group has pending remove requests requiring admin action"
             );
@@ -1877,13 +1881,13 @@ where
                 tracing::error!(
                     error = %e,
                     operation = "set_group_pending_status",
-                    group_id = hex::encode(&self.group_id),
+                    group_id = hex::encode(self.group_id),
                     "Failed to mark group as having pending leave requests"
                 );
             }
         } else {
             tracing::debug!(
-                group_id = hex::encode(&self.group_id),
+                group_id = hex::encode(self.group_id),
                 inbox_id = %self.context.inbox_id(),
                 "Group has no pending remove requests"
             );
@@ -1894,7 +1898,7 @@ where
             {
                 tracing::error!(
                     operation = "set_group_pending_status",
-                    group_id = hex::encode(&self.group_id),
+                    group_id = hex::encode(self.group_id),
                     "Failed to mark group as not having pending leave requests {}",
                     e,
                 );
@@ -1957,7 +1961,7 @@ where
     ) -> Result<MessageIdentifier, GroupMessageProcessingError> {
         if trust_message_order {
             let last_cursor = self.context.db().get_last_cursor_for_originator(
-                &envelope.group_id,
+                envelope.group_id,
                 envelope.entity_kind(),
                 envelope.originator_id(),
             )?;
@@ -1966,7 +1970,7 @@ where
                 tracing::info!(
                     inbox_id = self.context.inbox_id(),
                     installation_id = %self.context.installation_id(),
-                    group_id = hex::encode(&envelope.group_id),
+                    group_id = hex::encode(envelope.group_id),
                     "Message already processed: skipped cursor:[{}] last cursor in db: [{}]",
                     envelope.cursor,
                     last_cursor
@@ -2021,7 +2025,7 @@ where
             .map_err(GroupMessageProcessingError::Storage)?;
 
         let group_cursor = db.get_last_cursor_for_originator(
-            &self.group_id,
+            self.group_id,
             envelope.entity_kind(),
             envelope.originator_id(),
         )?;
@@ -2037,7 +2041,7 @@ where
         tracing::info!(
             inbox_id = self.context.inbox_id(),
             installation_id = %self.context.installation_id(),
-            group_id = hex::encode(&self.group_id),
+            group_id = hex::encode(self.group_id),
             cursor = %envelope.cursor,
             "Processing envelope with hash {}, cursor = {}, is_own_intent={}",
             hex::encode(&envelope.payload_hash),
@@ -2053,7 +2057,7 @@ where
                 tracing::info!(
                     inbox_id = self.context.inbox_id(),
                     installation_id = %self.context.installation_id(),
-                    group_id = hex::encode(&self.group_id),
+                    group_id = hex::encode(self.group_id),
                     cursor = %envelope.cursor,
                     intent_id,
                     intent.kind = %intent.kind,
@@ -2081,13 +2085,13 @@ where
                             cursor
                         );
                         let current_cursor = db
-                            .get_last_cursor_for_originator(&envelope.group_id, envelope.entity_kind(), envelope.originator_id())?;
+                            .get_last_cursor_for_originator(envelope.group_id, envelope.entity_kind(), envelope.originator_id())?;
                         current_cursor.sequence_id < envelope.sequence_id()
                     };
                     if !requires_processing {
                         tracing::debug!("message @cursor=[{}] for group=[{}] created_at=[{}] no longer require processing, should be available in database",
                             envelope.cursor,
-                            xmtp_common::fmt::debug_hex(&envelope.group_id),
+                            xmtp_common::fmt::debug_hex(envelope.group_id),
                             envelope.created_ns
                         );
 
@@ -2153,7 +2157,7 @@ where
                 tracing::info!(
                     inbox_id = self.context.inbox_id(),
                     installation_id = %self.context.installation_id(),
-                    group_id = hex::encode(&self.group_id),
+                    group_id = hex::encode(self.group_id),
                     cursor = %envelope.cursor,
                     "client [{}] is about to process external envelope [{}]",
                     self.context.inbox_id(),
@@ -2257,7 +2261,7 @@ where
                     .set_group_paused(&self.group_id, &min_version)?;
                 tracing::warn!(
                     "Group [{}] paused due to minimum protocol version requirement",
-                    hex::encode(&self.group_id)
+                    hex::encode(self.group_id)
                 );
                 Err(GroupMessageProcessingError::GroupPaused)
             }
@@ -2342,7 +2346,7 @@ where
                 Err(GroupMessageProcessingError::GroupPaused) => {
                     tracing::info!(
                         "Group [{}] is paused, skip syncing remaining messages",
-                        hex::encode(&self.group_id),
+                        hex::encode(self.group_id),
                     );
                     return summary;
                 }
@@ -2373,7 +2377,7 @@ where
     #[tracing::instrument(skip_all, level = "trace")]
     pub async fn receive(&self) -> Result<ProcessSummary, GroupError> {
         let messages = MlsStore::new(self.context.clone())
-            .query_group_messages(&self.group_id)
+            .query_group_messages(self.group_id)
             .await?;
 
         let summary = self.process_messages(messages).await;
@@ -2386,7 +2390,7 @@ where
         db: &impl DbQuery,
         message: &xmtp_proto::types::GroupMessage,
     ) -> Result<bool, StorageError> {
-        let updated = db.update_cursor(&message.group_id, message.entity_kind(), message.cursor)?;
+        let updated = db.update_cursor(message.group_id, message.entity_kind(), message.cursor)?;
         if updated {
             log_event!(
                 Event::GroupCursorUpdate,
@@ -2422,7 +2426,7 @@ where
         encoded_payload.encode(&mut encoded_payload_bytes)?;
 
         let message_id = calculate_message_id(
-            &self.group_id,
+            self.group_id,
             encoded_payload_bytes.as_slice(),
             &timestamp_ns.to_string(),
         );
@@ -2446,7 +2450,7 @@ where
 
         let msg = StoredGroupMessage {
             id: message_id,
-            group_id: self.group_id.clone(),
+            group_id: self.group_id,
             decrypted_message_bytes: encoded_payload_bytes,
             sent_at_ns: timestamp_ns as i64,
             kind: GroupMessageKind::MembershipChange,
@@ -2546,7 +2550,7 @@ where
             tracing::error!(
                 inbox_id = self.context.inbox_id(),
                 installation_id = %self.context.installation_id(),
-                group_id = hex::encode(&self.group_id),
+                group_id = hex::encode(self.group_id),
                 original_error = error.to_string(),
                 fork_details
             );
@@ -2565,7 +2569,7 @@ where
         let db = self.context.db();
         self.load_mls_group_with_lock_async(async |mut mls_group| {
             let intents = db.find_group_intents(
-                self.group_id.clone(),
+                self.group_id,
                 Some(vec![IntentState::ToPublish]),
                 None,
             )?;
@@ -2587,7 +2591,7 @@ where
                                 intent.id,
                                 intent.kind = %intent.kind,
                                 inbox_id = self.context.inbox_id(),
-                                installation_id = %self.context.installation_id(),group_id = hex::encode(&self.group_id),
+                                installation_id = %self.context.installation_id(),group_id = hex::encode(self.group_id),
                                 "intent {} has reached max publish attempts", intent.id);
                             // TODO: Eventually clean up errored attempts
                             let id = utils::id::calculate_message_id_for_intent(&intent)?;
@@ -2629,7 +2633,7 @@ where
                             installation_id = %self.context.installation_id(),
                             intent.id,
                             intent.kind = %intent.kind,
-                            group_id = hex::encode(&self.group_id),
+                            group_id = hex::encode(self.group_id),
                             "[{}] set stored intent [{}] with hash [{}] to state `published`",
                             self.context.inbox_id(),
                             intent.id,
@@ -3174,7 +3178,7 @@ where
                 if proposal_payloads.is_empty() {
                     tracing::debug!(
                         inbox_id = self.context.inbox_id(),
-                        group_id = hex::encode(&self.group_id),
+                        group_id = hex::encode(self.group_id),
                         add_inbox_ids = ?intent_data.add_inbox_ids,
                         remove_inbox_ids = ?intent_data.remove_inbox_ids,
                         "ProposeMemberUpdate produced no proposals (members may already be in desired state)"
@@ -3659,11 +3663,8 @@ where
     #[tracing::instrument(skip_all)]
     pub(crate) async fn post_commit(&self) -> Result<(), GroupError> {
         let db = self.context.db();
-        let intents = db.find_group_intents(
-            self.group_id.clone(),
-            Some(vec![IntentState::Committed]),
-            None,
-        )?;
+        let intents =
+            db.find_group_intents(self.group_id, Some(vec![IntentState::Committed]), None)?;
 
         for intent in intents {
             if let Some(post_commit_data) = intent.post_commit_data {
@@ -3693,9 +3694,7 @@ where
     ) -> Result<(), GroupError> {
         let db = self.context.db();
         let Some(stored_group) = db.find_group(&self.group_id)? else {
-            return Err(GroupError::NotFound(NotFound::GroupById(
-                self.group_id.clone(),
-            )));
+            return Err(GroupError::NotFound(NotFound::GroupById(self.group_id)));
         };
         if stored_group.conversation_type.is_virtual() {
             return Ok(());
@@ -4128,7 +4127,7 @@ fn extract_message_sender(
 
 async fn calculate_membership_changes_with_keypackages<'a>(
     context: &impl XmtpSharedContext,
-    group_id: &[u8],
+    group_id: &GroupId,
     new_group_membership: &'a GroupMembership,
     old_group_membership: &'a GroupMembership,
 ) -> Result<MembershipDiffWithKeyPackages, GroupError> {
@@ -4497,7 +4496,7 @@ pub(crate) mod tests {
         let intent = StoredGroupIntent {
             id: 42,
             kind: IntentKind::SendMessage,
-            group_id: GroupId::from(xmtp_common::rand_vec::<16>()),
+            group_id: GroupId::from(xmtp_common::rand_array::<16>()),
             data: Vec::new(),
             state: IntentState::Published,
             payload_hash: Some(xmtp_common::rand_vec::<32>()),
@@ -4538,7 +4537,7 @@ pub(crate) mod tests {
         // Create a message with completely invalid EncodedContent proto
         let malformed_message = xmtp_db::group_message::StoredGroupMessage {
             id: vec![1, 2, 3],
-            group_id: alix_group.group_id.clone(),
+            group_id: alix_group.group_id,
             decrypted_message_bytes: vec![0xFF, 0xFE, 0xFD], // Invalid protobuf
             sent_at_ns: xmtp_common::time::now_ns(),
             kind: GroupMessageKind::Application,
@@ -4605,7 +4604,7 @@ pub(crate) mod tests {
 
         let malformed_message = xmtp_db::group_message::StoredGroupMessage {
             id: vec![4, 5, 6],
-            group_id: alix_group.group_id.clone(),
+            group_id: alix_group.group_id,
             decrypted_message_bytes: encoded_bytes,
             sent_at_ns: xmtp_common::time::now_ns(),
             kind: GroupMessageKind::Application,
@@ -4679,7 +4678,7 @@ pub(crate) mod tests {
 
         let message_with_bad_hex = xmtp_db::group_message::StoredGroupMessage {
             id: vec![7, 8, 9],
-            group_id: alix_group.group_id.clone(),
+            group_id: alix_group.group_id,
             decrypted_message_bytes: encoded_bytes,
             sent_at_ns: xmtp_common::time::now_ns(),
             kind: GroupMessageKind::Application,

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -728,7 +728,7 @@ where
                         tracing::warn!(
                             inbox_id = self.context.inbox_id(),
                             installation_id = %self.context.installation_id(),
-                            group_id = hex::encode(self.group_id),
+                            group_id = %self.group_id,
                             cursor = %cursor,
                             intent.id,
                             intent.kind = %intent.kind,
@@ -769,7 +769,7 @@ where
                             tracing::error!(
                                 inbox_id = self.context.inbox_id(),
                                 installation_id = %self.context.installation_id(),
-                                group_id = hex::encode(self.group_id),
+                                group_id = %self.group_id,
                                 cursor = %cursor,
                                 intent_id = intent.id,
                                 intent.kind = %intent.kind,
@@ -805,7 +805,7 @@ where
                             tracing::error!(
                                 inbox_id = self.context.inbox_id(),
                                 installation_id = %self.context.installation_id(),
-                                group_id = hex::encode(self.group_id),
+                                group_id = %self.group_id,
                                 cursor = %cursor,
                                 intent.id,
                                 intent.kind = %intent.kind,
@@ -896,7 +896,7 @@ where
         tracing::debug!(
             inbox_id = self.context.inbox_id(),
             installation_id = %self.context.installation_id(),
-            group_id = hex::encode(self.group_id),
+            group_id = %self.group_id,
             cursor = %cursor,
             intent.id,
             intent.kind = %intent.kind,
@@ -1080,7 +1080,7 @@ where
             inbox_id = self.context.inbox_id(),
             installation_id = %self.context.installation_id(),sender_inbox_id = sender_inbox_id,
             sender_installation_id = hex::encode(&sender_installation_id),
-            group_id = hex::encode(self.group_id),
+            group_id = %self.group_id,
             current_epoch = mls_group.epoch().as_u64(),
             msg_epoch = processed_message.epoch().as_u64(),
             msg_group_id = hex::encode(processed_message.group_id().as_slice()),
@@ -1139,7 +1139,7 @@ where
                 {
                     tracing::warn!(
                         inbox_id = self.context.inbox_id(),
-                        group_id = hex::encode(self.group_id),
+                        group_id = %self.group_id,
                         ?proposal_type,
                         "Received proposal but proposals are not enabled on this group"
                     );
@@ -1243,7 +1243,7 @@ where
                     tracing::warn!(
                         inbox_id = self.context.inbox_id(),
                         installation_id = %self.context.installation_id(),
-                        group_id = hex::encode(self.group_id),
+                        group_id = %self.group_id,
                         proposal_type = ?queued_proposal.proposal().proposal_type(),
                         error = %e,
                         "Received invalid proposal, rejecting"
@@ -1266,7 +1266,7 @@ where
             tracing::debug!(
                 inbox_id = self.context.inbox_id(),
                 installation_id = %self.context.installation_id(),
-                group_id = hex::encode(self.group_id),
+                group_id = %self.group_id,
                 current_epoch = mls_group.epoch().as_u64(),
                 msg_epoch = processed_message.epoch().as_u64(),
                 cursor = ?cursor,
@@ -1434,7 +1434,7 @@ where
                 tracing::debug!(
                     inbox_id = self.context.inbox_id(),
                     installation_id = %self.context.installation_id(),
-                    group_id = hex::encode(self.group_id),
+                    group_id = %self.group_id,
                     proposal_type = ?proposal_ptr.proposal().proposal_type(),
                     "Received and storing proposal in proposal store"
                 );
@@ -1791,14 +1791,14 @@ where
         {
             Ok(_) => {
                 tracing::info!(
-                    group_id = hex::encode(self.group_id),
+                    group_id = %self.group_id,
                     removed_inboxes = ?removed_inbox_ids,
                     "Successfully removed left/removed members from pending_remove list"
                 );
             }
             Err(e) => {
                 tracing::info!(
-                    group_id = hex::encode(self.group_id),
+                    group_id = %self.group_id,
                     removed_inboxes = ?removed_inbox_ids,
                     error = %e,
                     "Failed to clean pending_remove list for removed members"
@@ -1848,7 +1848,7 @@ where
                 }
                 Err(e) => {
                     tracing::info!(
-                        group_id = hex::encode(self.group_id),
+                        group_id = %self.group_id,
                         inbox_id = %current_inbox_id,
                         error = %e,
                         "Failed to get pending remove users after promotion"
@@ -1869,7 +1869,7 @@ where
         // This is where we would mark the group as having/not having pending remove requests
         if has_pending_removes {
             tracing::info!(
-                group_id = hex::encode(self.group_id),
+                group_id = %self.group_id,
                 inbox_id = %self.context.inbox_id(),
                 "Group has pending remove requests requiring admin action"
             );
@@ -1881,13 +1881,13 @@ where
                 tracing::error!(
                     error = %e,
                     operation = "set_group_pending_status",
-                    group_id = hex::encode(self.group_id),
+                    group_id = %self.group_id,
                     "Failed to mark group as having pending leave requests"
                 );
             }
         } else {
             tracing::debug!(
-                group_id = hex::encode(self.group_id),
+                group_id = %self.group_id,
                 inbox_id = %self.context.inbox_id(),
                 "Group has no pending remove requests"
             );
@@ -1898,7 +1898,7 @@ where
             {
                 tracing::error!(
                     operation = "set_group_pending_status",
-                    group_id = hex::encode(self.group_id),
+                    group_id = %self.group_id,
                     "Failed to mark group as not having pending leave requests {}",
                     e,
                 );
@@ -1970,7 +1970,7 @@ where
                 tracing::info!(
                     inbox_id = self.context.inbox_id(),
                     installation_id = %self.context.installation_id(),
-                    group_id = hex::encode(envelope.group_id),
+                    group_id = %envelope.group_id,
                     "Message already processed: skipped cursor:[{}] last cursor in db: [{}]",
                     envelope.cursor,
                     last_cursor
@@ -2041,7 +2041,7 @@ where
         tracing::info!(
             inbox_id = self.context.inbox_id(),
             installation_id = %self.context.installation_id(),
-            group_id = hex::encode(self.group_id),
+            group_id = %self.group_id,
             cursor = %envelope.cursor,
             "Processing envelope with hash {}, cursor = {}, is_own_intent={}",
             hex::encode(&envelope.payload_hash),
@@ -2057,7 +2057,7 @@ where
                 tracing::info!(
                     inbox_id = self.context.inbox_id(),
                     installation_id = %self.context.installation_id(),
-                    group_id = hex::encode(self.group_id),
+                    group_id = %self.group_id,
                     cursor = %envelope.cursor,
                     intent_id,
                     intent.kind = %intent.kind,
@@ -2157,7 +2157,7 @@ where
                 tracing::info!(
                     inbox_id = self.context.inbox_id(),
                     installation_id = %self.context.installation_id(),
-                    group_id = hex::encode(self.group_id),
+                    group_id = %self.group_id,
                     cursor = %envelope.cursor,
                     "client [{}] is about to process external envelope [{}]",
                     self.context.inbox_id(),
@@ -2550,7 +2550,7 @@ where
             tracing::error!(
                 inbox_id = self.context.inbox_id(),
                 installation_id = %self.context.installation_id(),
-                group_id = hex::encode(self.group_id),
+                group_id = %self.group_id,
                 original_error = error.to_string(),
                 fork_details
             );
@@ -2591,7 +2591,7 @@ where
                                 intent.id,
                                 intent.kind = %intent.kind,
                                 inbox_id = self.context.inbox_id(),
-                                installation_id = %self.context.installation_id(),group_id = hex::encode(self.group_id),
+                                installation_id = %self.context.installation_id(),group_id = %self.group_id,
                                 "intent {} has reached max publish attempts", intent.id);
                             // TODO: Eventually clean up errored attempts
                             let id = utils::id::calculate_message_id_for_intent(&intent)?;
@@ -2633,7 +2633,7 @@ where
                             installation_id = %self.context.installation_id(),
                             intent.id,
                             intent.kind = %intent.kind,
-                            group_id = hex::encode(self.group_id),
+                            group_id = %self.group_id,
                             "[{}] set stored intent [{}] with hash [{}] to state `published`",
                             self.context.inbox_id(),
                             intent.id,
@@ -2782,7 +2782,7 @@ where
                 let registry_populated =
                     !super::app_data::load_component_registry(openmls_group)?.is_empty();
                 tracing::debug!(
-                    group_id = hex::encode(self.group_id.as_slice()),
+                    group_id = %self.group_id,
                     proposals_enabled = proposals_on,
                     registry_populated,
                     path = if proposals_on && registry_populated {
@@ -2896,7 +2896,7 @@ where
                 // path honest about what "migrated" means.
                 let is_migrated = super::app_data::is_migrated_group(openmls_group);
                 tracing::debug!(
-                    group_id = hex::encode(self.group_id.as_slice()),
+                    group_id = %self.group_id,
                     is_migrated,
                     path = if is_migrated {
                         "app_data_update"
@@ -2953,7 +2953,7 @@ where
                 // predicate.
                 let is_migrated = super::app_data::is_migrated_group(openmls_group);
                 tracing::debug!(
-                    group_id = hex::encode(self.group_id.as_slice()),
+                    group_id = %self.group_id,
                     is_migrated,
                     path = if is_migrated {
                         "app_data_update"
@@ -3178,7 +3178,7 @@ where
                 if proposal_payloads.is_empty() {
                     tracing::debug!(
                         inbox_id = self.context.inbox_id(),
-                        group_id = hex::encode(self.group_id),
+                        group_id = %self.group_id,
                         add_inbox_ids = ?intent_data.add_inbox_ids,
                         remove_inbox_ids = ?intent_data.remove_inbox_ids,
                         "ProposeMemberUpdate produced no proposals (members may already be in desired state)"

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -4414,6 +4414,7 @@ pub(crate) mod tests {
     use crate::{builder::ClientBuilder, utils::TestMlsGroup};
     use mockall::predicate::eq;
     use std::sync::Arc;
+    use xmtp_common::Generate;
     use xmtp_cryptography::utils::generate_local_wallet;
     use xmtp_db::mock::MockDbQuery;
 
@@ -4496,7 +4497,7 @@ pub(crate) mod tests {
         let intent = StoredGroupIntent {
             id: 42,
             kind: IntentKind::SendMessage,
-            group_id: GroupId::from(xmtp_common::rand_array::<16>()),
+            group_id: GroupId::generate(),
             data: Vec::new(),
             state: IntentState::Published,
             payload_hash: Some(xmtp_common::rand_vec::<32>()),

--- a/crates/xmtp_mls/src/groups/mls_sync/update_group_membership.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync/update_group_membership.rs
@@ -117,9 +117,10 @@ pub(crate) async fn apply_update_group_membership_intent(
     let new_group_membership = intent_data.apply_to_group_membership(&old_group_membership);
     let membership_diff = old_group_membership.diff(&new_group_membership);
 
+    let group_id = GroupId::try_from(openmls_group.group_id())?;
     let changes_with_kps = calculate_membership_changes_with_keypackages(
         context,
-        openmls_group.group_id().as_slice(),
+        &group_id,
         &new_group_membership,
         &old_group_membership,
     )

--- a/crates/xmtp_mls/src/groups/mod.rs
+++ b/crates/xmtp_mls/src/groups/mod.rs
@@ -54,9 +54,7 @@ use openmls::{
     },
     group::{GroupContext, MlsGroupCreateConfig},
     messages::proposals::ProposalType,
-    prelude::{
-        Capabilities, GroupId as OpenMlsGroupId, MlsGroup as OpenMlsGroup, WireFormatPolicy,
-    },
+    prelude::{Capabilities, MlsGroup as OpenMlsGroup, WireFormatPolicy},
 };
 use prost::Message;
 use std::collections::HashMap;
@@ -162,7 +160,7 @@ where
     Context: XmtpSharedContext,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-        let id = xmtp_common::fmt::truncate_hex(hex::encode(&self.group_id));
+        let id = xmtp_common::fmt::truncate_hex(hex::encode(self.group_id));
         let inbox_id = self.context.inbox_id();
         let installation = self.context.installation_id().to_string();
         let time = chrono::DateTime::from_timestamp_nanos(self.created_at_ns);
@@ -186,7 +184,7 @@ pub struct ConversationListItem<Context> {
 impl<Context: XmtpSharedContext> Clone for MlsGroup<Context> {
     fn clone(&self) -> Self {
         Self {
-            group_id: self.group_id.clone(),
+            group_id: self.group_id,
             dm_id: self.dm_id.clone(),
             conversation_type: self.conversation_type,
             created_at_ns: self.created_at_ns,
@@ -327,14 +325,14 @@ where
     /// Returns the Group and the stored group information as a tuple.
     pub fn new_cached(
         context: Context,
-        group_id: &[u8],
+        group_id: &GroupId,
     ) -> Result<(Self, StoredGroup), StorageError> {
         let conn = context.db();
-        if let Some(group) = conn.find_group(&GroupId::from(group_id))? {
+        if let Some(group) = conn.find_group(group_id)? {
             Ok((
                 Self::new_from_arc(
                     context,
-                    GroupId::from(group_id),
+                    *group_id,
                     group.dm_id.clone(),
                     group.conversation_type,
                     group.created_at_ns,
@@ -343,7 +341,7 @@ where
             ))
         } else {
             tracing::error!("group {} does not exist", hex::encode(group_id));
-            Err(NotFound::GroupById(GroupId::from(group_id)).into())
+            Err(NotFound::GroupById(*group_id).into())
         }
     }
 
@@ -356,7 +354,7 @@ where
     ) -> Self {
         let mut mutexes = context.mutexes().clone();
         Self {
-            group_id: group_id.clone(),
+            group_id,
             dm_id,
             conversation_type,
             created_at_ns,
@@ -377,15 +375,15 @@ where
         F: Fn(OpenMlsGroup) -> Result<R, GroupError>,
     {
         // Get the group ID for locking
-        let group_id = self.group_id.clone();
+        let group_id = self.group_id;
 
         // Acquire the lock synchronously using blocking_lock
-        let _lock = self.mls_commit_lock.get_lock_sync(group_id.clone());
+        let _lock = self.mls_commit_lock.get_lock_sync(group_id);
         // Load the MLS group
         let mls_group = OpenMlsGroup::load(storage, &self.group_id.to_openmls())
             .inspect_err(|e| tracing::error!("openmls error while loading group {e}"))
-            .map_err(|_| NotFound::MlsGroup(self.group_id.clone()))?
-            .ok_or(NotFound::MlsGroup(self.group_id.clone()))?;
+            .map_err(|_| NotFound::MlsGroup(self.group_id))?
+            .ok_or(NotFound::MlsGroup(self.group_id))?;
 
         // Perform the operation with the MLS group
         operation(mls_group)
@@ -402,16 +400,14 @@ where
     {
         let mls_storage = self.context.mls_storage();
         // Get the group ID for locking
-        let group_id = self.group_id.clone();
+        let group_id = self.group_id;
 
         // Acquire the lock asynchronously
-        let _lock = self.mls_commit_lock.get_lock_async(group_id.clone()).await;
+        let _lock = self.mls_commit_lock.get_lock_async(group_id).await;
 
         // Load the MLS group
-        let mls_group =
-            OpenMlsGroup::load(mls_storage, &OpenMlsGroupId::from_slice(&self.group_id))?.ok_or(
-                StorageError::from(NotFound::GroupById(self.group_id.clone())),
-            )?;
+        let mls_group = OpenMlsGroup::load(mls_storage, &self.group_id.to_openmls())?
+            .ok_or(StorageError::from(NotFound::GroupById(self.group_id)))?;
 
         // Perform the operation with the MLS group
         operation(mls_group).await
@@ -790,19 +786,19 @@ where
                 &provider,
                 context.identity(),
                 &group_config,
-                GroupId::from(existing_group_id),
+                GroupId::try_from(existing_group_id)?,
             )?
         } else {
             OpenMlsGroup::from_creation_logged(&provider, context.identity(), &group_config)?
         };
 
-        let group_id = mls_group.group_id().to_vec();
+        let group_id: GroupId = mls_group.group_id().try_into()?;
         // If not an existing group, the creator is a super admin and should publish the commit log
         // Otherwise, for existing groups, we'll never publish the commit log until we receive a welcome message
         let should_publish_commit_log = existing_group_id.is_none();
 
         let stored_group = StoredGroup::builder()
-            .id(group_id.clone())
+            .id(group_id)
             .created_at_ns(now_ns())
             .membership_state(membership_state)
             .conversation_type(conversation_type)
@@ -853,15 +849,15 @@ where
                 &provider,
                 context.identity(),
                 &group_config,
-                GroupId::from(group_id),
+                GroupId::try_from(group_id)?,
             )?
         } else {
             OpenMlsGroup::from_creation_logged(&provider, context.identity(), &group_config)?
         };
 
-        let group_id: GroupId = mls_group.group_id().into();
+        let group_id: GroupId = mls_group.group_id().try_into()?;
         let stored_group = StoredGroup::builder()
-            .id(group_id.clone())
+            .id(group_id)
             .created_at_ns(now_ns())
             .membership_state(membership_state)
             .added_by_inbox_id(context.inbox_id().to_string())
@@ -948,7 +944,7 @@ where
         if has_pending {
             tracing::debug!(
                 inbox_id = self.context.inbox_id(),
-                group_id = hex::encode(&self.group_id),
+                group_id = hex::encode(self.group_id),
                 "Found pending proposals, committing before sending message"
             );
 
@@ -1018,10 +1014,10 @@ where
         let now = now_ns();
         let queryable_content_fields = Self::extract_queryable_content_fields(message);
 
-        let message_id = calculate_message_id(&self.group_id, message, &now.to_string());
+        let message_id = calculate_message_id(self.group_id, message, &now.to_string());
         let group_message = StoredGroupMessage {
             id: message_id.clone(),
-            group_id: self.group_id.clone(),
+            group_id: self.group_id,
             decrypted_message_bytes: message.to_vec(),
             sent_at_ns: now,
             kind: GroupMessageKind::Application,
@@ -1159,7 +1155,7 @@ where
 
         let deletion = StoredMessageDeletion {
             id: deletion_message_id.clone(),
-            group_id: self.group_id.clone(),
+            group_id: self.group_id,
             deleted_message_id: message_id,
             deleted_by_inbox_id: sender_inbox_id.to_string(),
             is_super_admin_deletion,
@@ -1247,14 +1243,14 @@ where
         args: &MsgQueryArgs,
     ) -> Result<Vec<StoredGroupMessage>, GroupError> {
         let conn = self.context.db();
-        let messages = conn.get_group_messages(&GroupId::from(self.group_id.as_slice()), args)?;
+        let messages = conn.get_group_messages(&self.group_id, args)?;
         Ok(messages)
     }
 
     /// Count the number of stored messages matching the given criteria
     pub fn count_messages(&self, args: &MsgQueryArgs) -> Result<i64, GroupError> {
         let conn = self.context.db();
-        let count = conn.count_group_messages(&GroupId::from(self.group_id.as_slice()), args)?;
+        let count = conn.count_group_messages(&self.group_id, args)?;
         Ok(count)
     }
 
@@ -1265,8 +1261,7 @@ where
         args: &MsgQueryArgs,
     ) -> Result<Vec<StoredGroupMessageWithReactions>, GroupError> {
         let conn = self.context.db();
-        let messages =
-            conn.get_group_messages_with_reactions(&GroupId::from(self.group_id.as_slice()), args)?;
+        let messages = conn.get_group_messages_with_reactions(&self.group_id, args)?;
         Ok(messages)
     }
 
@@ -1276,7 +1271,7 @@ where
         args: &MsgQueryArgs,
     ) -> Result<Vec<crate::messages::decoded_message::DecodedMessage>, EnrichMessageError> {
         let conn = self.context.db();
-        let messages = conn.get_group_messages(&GroupId::from(self.group_id.as_slice()), args)?;
+        let messages = conn.get_group_messages(&self.group_id, args)?;
         let enriched =
             crate::messages::enrichment::enrich_messages(conn, &self.group_id, messages)?;
         Ok(enriched)
@@ -1285,18 +1280,18 @@ where
     pub fn get_last_read_times(&self) -> Result<LatestMessageTimeBySender, GroupError> {
         let conn = self.context.db();
         let latest_read_receipt =
-            conn.get_latest_message_times_by_sender(&self.group_id, &[ContentType::ReadReceipt])?;
+            conn.get_latest_message_times_by_sender(self.group_id, &[ContentType::ReadReceipt])?;
         Ok(latest_read_receipt)
     }
 
     /// Load the group reference stored in the local database
     pub fn load(&self) -> Result<StoredGroup, StorageError> {
         let conn = self.context.db();
-        if let Some(group) = conn.find_group(&GroupId::from(self.group_id.as_slice()))? {
+        if let Some(group) = conn.find_group(&self.group_id)? {
             Ok(group)
         } else {
-            tracing::error!("group {} does not exist", hex::encode(&self.group_id));
-            Err(NotFound::GroupById(self.group_id.clone()).into())
+            tracing::error!("group {} does not exist", hex::encode(self.group_id));
+            Err(NotFound::GroupById(self.group_id).into())
         }
     }
 
@@ -1505,7 +1500,7 @@ where
 
         if pending_removal_list.is_empty() {
             tracing::debug!(
-                group_id = hex::encode(&self.group_id),
+                group_id = hex::encode(self.group_id),
                 inbox_id = %self.context.inbox_id(),
                 "Group has no pending removal members"
             );
@@ -1515,7 +1510,7 @@ where
         let is_super_admin = self.is_super_admin(self.context.inbox_id().to_string())?;
         if !is_super_admin {
             tracing::debug!(
-                group_id = hex::encode(&self.group_id),
+                group_id = hex::encode(self.group_id),
                 inbox_id = %self.context.inbox_id(),
                 "Current inbox ID is not in admin or super admin list, skipping pending removal processing"
             );
@@ -1536,7 +1531,7 @@ where
 
         if valid_removals.is_empty() {
             tracing::warn!(
-                group_id = hex::encode(&self.group_id),
+                group_id = hex::encode(self.group_id),
                 pending_count = pending_removal_list.len(),
                 "No valid members found in pending removal list"
             );
@@ -1550,7 +1545,7 @@ where
 
         if !invalid_removals.is_empty() {
             tracing::warn!(
-                group_id = hex::encode(&self.group_id),
+                group_id = hex::encode(self.group_id),
                 invalid_members = ?invalid_removals,
                 "Some members in pending removal list are not in the group"
             );
@@ -1558,7 +1553,7 @@ where
 
         // Remove all valid members at once
         tracing::info!(
-            group_id = hex::encode(&self.group_id),
+            group_id = hex::encode(self.group_id),
             removing_count = valid_removals.len(),
             members_to_remove = ?valid_removals,
             "Removing pending members from group"
@@ -1567,7 +1562,7 @@ where
         match self.remove_members(&valid_removals).await {
             Ok(_) => {
                 tracing::info!(
-                    group_id = hex::encode(&self.group_id),
+                    group_id = hex::encode(self.group_id),
                     removed_count = valid_removals.len(),
                     removed_members = ?valid_removals,
                     "Successfully removed all pending members from group"
@@ -1575,7 +1570,7 @@ where
             }
             Err(e) => {
                 tracing::error!(
-                    group_id = hex::encode(&self.group_id),
+                    group_id = hex::encode(self.group_id),
                     members = ?valid_removals,
                     error = %e,
                     "Failed to remove pending members from group"
@@ -1599,7 +1594,7 @@ where
     /// * `Err(GroupError)` - Failed to retrieve data or update the pending list
     pub async fn cleanup_pending_removal_list(&self) -> Result<(), GroupError> {
         tracing::debug!(
-            group_id = hex::encode(&self.group_id),
+            group_id = hex::encode(self.group_id),
             "Starting pending removal list cleanup"
         );
 
@@ -1608,16 +1603,13 @@ where
 
         if pending_removal_list.is_empty() {
             tracing::debug!(
-                group_id = hex::encode(&self.group_id),
+                group_id = hex::encode(self.group_id),
                 "No pending removals to clean up"
             );
             // Clear the pending leave request status
             self.context
                 .db()
-                .set_group_has_pending_leave_request_status(
-                    &GroupId::from(self.group_id.as_slice()),
-                    Some(false),
-                )?;
+                .set_group_has_pending_leave_request_status(&self.group_id, Some(false))?;
             return Ok(());
         }
 
@@ -1637,17 +1629,16 @@ where
 
         if !removed_members.is_empty() {
             tracing::info!(
-                group_id = hex::encode(&self.group_id),
+                group_id = hex::encode(self.group_id),
                 removed_count = removed_members.len(),
                 removed_members = ?removed_members,
                 "Removing members from pending removal list - they are no longer in the group"
             );
 
             // Remove all users who are no longer in the group from pending list
-            self.context.db().delete_pending_remove_users(
-                &GroupId::from(self.group_id.as_slice()),
-                removed_members,
-            )?;
+            self.context
+                .db()
+                .delete_pending_remove_users(&self.group_id, removed_members)?;
         }
 
         // After cleanup, check if there are any pending removals left
@@ -1656,14 +1647,11 @@ where
             // Clear the pending leave request status if no pending removals remain
             self.context
                 .db()
-                .set_group_has_pending_leave_request_status(
-                    &GroupId::from(self.group_id.as_slice()),
-                    Some(false),
-                )?;
+                .set_group_has_pending_leave_request_status(&self.group_id, Some(false))?;
         }
 
         tracing::info!(
-            group_id = hex::encode(&self.group_id),
+            group_id = hex::encode(self.group_id),
             remaining_pending = remaining_pending_list.len(),
             "Finished cleaning up pending removal list"
         );
@@ -2056,20 +2044,13 @@ where
 
     /// If group is not paused, will return None, otherwise will return the version that the group is paused for
     pub fn paused_for_version(&self) -> Result<Option<String>, GroupError> {
-        let paused_for_version = self
-            .context
-            .db()
-            .get_group_paused_version(&GroupId::from(self.group_id.as_slice()))?;
+        let paused_for_version = self.context.db().get_group_paused_version(&self.group_id)?;
         Ok(paused_for_version)
     }
 
     #[tracing::instrument(skip_all, level = "trace")]
     async fn ensure_not_paused(&self) -> Result<(), GroupError> {
-        if let Some(min_version) = self
-            .context
-            .db()
-            .get_group_paused_version(&GroupId::from(self.group_id.as_slice()))?
-        {
+        if let Some(min_version) = self.context.db().get_group_paused_version(&self.group_id)? {
             Err(GroupError::GroupPausedUntilUpdate(min_version))
         } else {
             Ok(())
@@ -2111,7 +2092,7 @@ where
     pub fn pending_remove_list(&self) -> Result<Vec<String>, GroupError> {
         self.context
             .db()
-            .get_pending_remove_users(&GroupId::from(self.group_id.as_slice()))
+            .get_pending_remove_users(&self.group_id)
             .map_err(Into::into)
     }
 
@@ -2119,7 +2100,7 @@ where
     pub fn is_in_pending_remove(&self, inbox_id: &str) -> Result<bool, GroupError> {
         self.context
             .db()
-            .get_user_pending_remove_status(&GroupId::from(self.group_id.as_slice()), inbox_id)
+            .get_user_pending_remove_status(&self.group_id, inbox_id)
             .map_err(Into::into)
     }
 
@@ -2254,10 +2235,7 @@ where
 
     /// Retrieves the conversation type of the group from the group's metadata extension.
     pub async fn conversation_type(&self) -> Result<ConversationType, GroupError> {
-        let conversation_type = self
-            .context
-            .db()
-            .get_conversation_type(&GroupId::from(self.group_id.as_slice()))?;
+        let conversation_type = self.context.db().get_conversation_type(&self.group_id)?;
         Ok(conversation_type)
     }
 
@@ -2295,18 +2273,16 @@ where
     pub fn added_by_inbox_id(&self) -> Result<String, GroupError> {
         let conn = self.context.db();
         let group = conn
-            .find_group(&GroupId::from(self.group_id.as_slice()))?
-            .ok_or_else(|| NotFound::GroupById(self.group_id.clone()))?;
+            .find_group(&self.group_id)?
+            .ok_or(NotFound::GroupById(self.group_id))?;
         Ok(group.added_by_inbox_id)
     }
 
     /// Find the `consent_state` of the group
     pub fn consent_state(&self) -> Result<ConsentState, GroupError> {
         let conn = self.context.db();
-        let record = conn.get_consent_record(
-            hex::encode(self.group_id.clone()),
-            ConsentType::ConversationId,
-        )?;
+        let record =
+            conn.get_consent_record(hex::encode(self.group_id), ConsentType::ConversationId)?;
 
         match record {
             Some(rec) => Ok(rec.state),
@@ -2323,7 +2299,7 @@ where
         let consent_record = StoredConsentRecord::new(
             ConsentType::ConversationId,
             state,
-            hex::encode(self.group_id.clone()),
+            hex::encode(self.group_id),
         );
 
         Ok(db.insert_or_replace_consent_records(std::slice::from_ref(&consent_record))?)
@@ -2372,12 +2348,12 @@ where
     pub async fn cursor(&self) -> Result<[Cursor; 2], GroupError> {
         let db = self.context.db();
         let msgs = db.get_last_cursor_for_originator(
-            &self.group_id,
+            self.group_id,
             EntityKind::ApplicationMessage,
             Originators::APPLICATION_MESSAGES,
         )?;
         let commits = db.get_last_cursor_for_originator(
-            &self.group_id,
+            self.group_id,
             EntityKind::CommitMessage,
             Originators::MLS_COMMITS,
         )?;
@@ -2385,15 +2361,12 @@ where
     }
 
     pub async fn local_commit_log(&self) -> Result<Vec<LocalCommitLog>, GroupError> {
-        Ok(self
-            .context
-            .db()
-            .get_group_logs(&GroupId::from(self.group_id.as_slice()))?)
+        Ok(self.context.db().get_group_logs(&self.group_id)?)
     }
 
     pub async fn remote_commit_log(&self) -> Result<Vec<RemoteCommitLog>, GroupError> {
         Ok(self.context.db().get_remote_commit_log_after_cursor(
-            &GroupId::from(self.group_id.as_slice()),
+            &self.group_id,
             0,
             RemoteCommitLogOrder::AscendingByRowid,
         )?)
@@ -2406,12 +2379,10 @@ where
         let remote_commit_log = self.remote_commit_log().await?;
         let db = self.context.db();
 
-        let stored_group = match db.find_group(&GroupId::from(self.group_id.as_slice()))? {
+        let stored_group = match db.find_group(&self.group_id)? {
             Some(group) => group,
             None => {
-                return Err(GroupError::NotFound(NotFound::GroupById(
-                    self.group_id.clone(),
-                )));
+                return Err(GroupError::NotFound(NotFound::GroupById(self.group_id)));
             }
         };
 
@@ -2444,14 +2415,8 @@ where
     #[tracing::instrument(skip_all, level = "trace")]
     pub fn is_active(&self) -> Result<bool, GroupError> {
         // Restored groups that are not yet added are inactive
-        let Some(stored_group) = self
-            .context
-            .db()
-            .find_group(&GroupId::from(self.group_id.as_slice()))?
-        else {
-            return Err(GroupError::NotFound(NotFound::GroupById(
-                self.group_id.clone(),
-            )));
+        let Some(stored_group) = self.context.db().find_group(&self.group_id)? else {
+            return Err(GroupError::NotFound(NotFound::GroupById(self.group_id)));
         };
         if matches!(
             stored_group.membership_state,
@@ -2471,8 +2436,8 @@ where
         let stored_group = self
             .context
             .db()
-            .find_group(&GroupId::from(self.group_id.as_slice()))?
-            .ok_or_else(|| GroupError::NotFound(NotFound::GroupById(self.group_id.clone())))?;
+            .find_group(&self.group_id)?
+            .ok_or_else(|| GroupError::NotFound(NotFound::GroupById(self.group_id)))?;
         Ok(stored_group.membership_state)
     }
 
@@ -2613,8 +2578,7 @@ where
     /// `None` if the group or settings are missing, or `Err(ClientError)` on a database error.
     pub fn disappearing_settings(&self) -> Result<Option<MessageDisappearingSettings>, GroupError> {
         let conn = self.context.db();
-        let stored_group: Option<StoredGroup> =
-            conn.fetch(&GroupId::from(self.group_id.as_slice()))?;
+        let stored_group: Option<StoredGroup> = conn.fetch(&self.group_id)?;
 
         let settings = stored_group.and_then(|group| {
             let from_ns = group.message_disappear_from_ns?;
@@ -2628,10 +2592,7 @@ where
 
     /// Find all the duplicate dms for this group
     pub fn find_duplicate_dms(&self) -> Result<Vec<MlsGroup<Context>>, ClientError> {
-        let duplicates = self
-            .context
-            .db()
-            .other_dms(&GroupId::from(self.group_id.as_slice()))?;
+        let duplicates = self.context.db().other_dms(&self.group_id)?;
 
         let mls_groups = duplicates
             .into_iter()
@@ -2691,9 +2652,9 @@ where
 
         let mls_group =
             OpenMlsGroup::from_creation_logged(&provider, context.identity(), &group_config)?;
-        let group_id: GroupId = mls_group.group_id().into();
+        let group_id: GroupId = mls_group.group_id().try_into()?;
         let stored_group = StoredGroup::builder()
-            .id(group_id.clone())
+            .id(group_id)
             .created_at_ns(now_ns())
             .membership_state(GroupMembershipState::Allowed)
             .added_by_inbox_id(context.inbox_id().to_string())

--- a/crates/xmtp_mls/src/groups/mod.rs
+++ b/crates/xmtp_mls/src/groups/mod.rs
@@ -944,7 +944,7 @@ where
         if has_pending {
             tracing::debug!(
                 inbox_id = self.context.inbox_id(),
-                group_id = hex::encode(self.group_id),
+                group_id = %self.group_id,
                 "Found pending proposals, committing before sending message"
             );
 
@@ -1500,7 +1500,7 @@ where
 
         if pending_removal_list.is_empty() {
             tracing::debug!(
-                group_id = hex::encode(self.group_id),
+                group_id = %self.group_id,
                 inbox_id = %self.context.inbox_id(),
                 "Group has no pending removal members"
             );
@@ -1510,7 +1510,7 @@ where
         let is_super_admin = self.is_super_admin(self.context.inbox_id().to_string())?;
         if !is_super_admin {
             tracing::debug!(
-                group_id = hex::encode(self.group_id),
+                group_id = %self.group_id,
                 inbox_id = %self.context.inbox_id(),
                 "Current inbox ID is not in admin or super admin list, skipping pending removal processing"
             );
@@ -1531,7 +1531,7 @@ where
 
         if valid_removals.is_empty() {
             tracing::warn!(
-                group_id = hex::encode(self.group_id),
+                group_id = %self.group_id,
                 pending_count = pending_removal_list.len(),
                 "No valid members found in pending removal list"
             );
@@ -1545,7 +1545,7 @@ where
 
         if !invalid_removals.is_empty() {
             tracing::warn!(
-                group_id = hex::encode(self.group_id),
+                group_id = %self.group_id,
                 invalid_members = ?invalid_removals,
                 "Some members in pending removal list are not in the group"
             );
@@ -1553,7 +1553,7 @@ where
 
         // Remove all valid members at once
         tracing::info!(
-            group_id = hex::encode(self.group_id),
+            group_id = %self.group_id,
             removing_count = valid_removals.len(),
             members_to_remove = ?valid_removals,
             "Removing pending members from group"
@@ -1562,7 +1562,7 @@ where
         match self.remove_members(&valid_removals).await {
             Ok(_) => {
                 tracing::info!(
-                    group_id = hex::encode(self.group_id),
+                    group_id = %self.group_id,
                     removed_count = valid_removals.len(),
                     removed_members = ?valid_removals,
                     "Successfully removed all pending members from group"
@@ -1570,7 +1570,7 @@ where
             }
             Err(e) => {
                 tracing::error!(
-                    group_id = hex::encode(self.group_id),
+                    group_id = %self.group_id,
                     members = ?valid_removals,
                     error = %e,
                     "Failed to remove pending members from group"
@@ -1594,7 +1594,7 @@ where
     /// * `Err(GroupError)` - Failed to retrieve data or update the pending list
     pub async fn cleanup_pending_removal_list(&self) -> Result<(), GroupError> {
         tracing::debug!(
-            group_id = hex::encode(self.group_id),
+            group_id = %self.group_id,
             "Starting pending removal list cleanup"
         );
 
@@ -1603,7 +1603,7 @@ where
 
         if pending_removal_list.is_empty() {
             tracing::debug!(
-                group_id = hex::encode(self.group_id),
+                group_id = %self.group_id,
                 "No pending removals to clean up"
             );
             // Clear the pending leave request status
@@ -1629,7 +1629,7 @@ where
 
         if !removed_members.is_empty() {
             tracing::info!(
-                group_id = hex::encode(self.group_id),
+                group_id = %self.group_id,
                 removed_count = removed_members.len(),
                 removed_members = ?removed_members,
                 "Removing members from pending removal list - they are no longer in the group"
@@ -1651,7 +1651,7 @@ where
         }
 
         tracing::info!(
-            group_id = hex::encode(self.group_id),
+            group_id = %self.group_id,
             remaining_pending = remaining_pending_list.len(),
             "Finished cleaning up pending removal list"
         );
@@ -2170,7 +2170,7 @@ where
                             // (admin_list / super_admin_list return
                             // `Ok(vec![])` here, not `Err`).
                             tracing::debug!(
-                                group_id = hex::encode(self.group_id.as_slice()),
+                                group_id = %self.group_id,
                                 kind = ?kind,
                                 "unmigrated group has no legacy GroupMutableMetadata extension; returning empty admin set"
                             );

--- a/crates/xmtp_mls/src/groups/oneshot.rs
+++ b/crates/xmtp_mls/src/groups/oneshot.rs
@@ -68,7 +68,7 @@ impl Oneshot {
                     &readd_request.group_id,
                     &sender_installation_id,
                 )? {
-                    let group_id = GroupId::from(readd_request.group_id.as_slice());
+                    let group_id = GroupId::try_from(readd_request.group_id.as_slice())?;
                     provider.key_store().db().update_requested_at_sequence_id(
                         &group_id,
                         &sender_installation_id,
@@ -136,7 +136,7 @@ impl Oneshot {
         // Fetch the OpenMLS group without locking; consistency is not important here, and we are not writing to it
         let Ok(Some(openmls_group)) = openmls::group::MlsGroup::load(
             storage,
-            &GroupId::from(group_id.as_slice()).to_openmls(),
+            &openmls::group::GroupId::from_slice(group_id.as_slice()),
         ) else {
             tracing::warn!(
                 group_id = group_id.snippet(),
@@ -178,8 +178,8 @@ mod tests {
             .create_group_with_members(&[bo.inbox_id(), caro.inbox_id()], None, None)
             .await
             .unwrap();
-        let group_id = a_group.group_id.to_vec();
-        let group_id_typed: GroupId = group_id.clone().into();
+        let group_id = a_group.group_id;
+        let group_id_typed: GroupId = group_id;
         bo.sync_all_welcomes_and_groups(None).await.unwrap();
         caro.sync_all_welcomes_and_groups(None).await.unwrap();
         let b_group = bo.group(&group_id).unwrap();
@@ -211,7 +211,7 @@ mod tests {
 
         // Create a test oneshot message (using ReaddRequest as example)
         let readd_request = ReaddRequest {
-            group_id: group_id.clone(),
+            group_id: group_id.to_vec(),
             latest_commit_sequence_id,
         };
         let oneshot_message = OneshotMessage {

--- a/crates/xmtp_mls/src/groups/subscriptions.rs
+++ b/crates/xmtp_mls/src/groups/subscriptions.rs
@@ -103,7 +103,7 @@ where
     where
         Context::ApiClient: XmtpMlsStreams + 'a,
     {
-        StreamGroupMessages::new(&self.context, vec![self.group_id.clone()]).await
+        StreamGroupMessages::new(&self.context, vec![self.group_id]).await
     }
 
     /// create a stream that is not attached to any lifetime
@@ -115,7 +115,7 @@ where
         Context::ApiClient: XmtpMlsStreams + 'static,
         Context::Db: 'static,
     {
-        StreamGroupMessages::new_owned(self.context.clone(), vec![self.group_id.clone()]).await
+        StreamGroupMessages::new_owned(self.context.clone(), vec![self.group_id]).await
     }
 
     pub fn stream_with_callback(
@@ -315,7 +315,8 @@ pub(crate) mod tests {
                     use xmtp_proto::types::GroupId;
                     Ok(Some(StoredGroupMessage {
                         id: xmtp_common::rand_vec::<32>(),
-                        group_id: GroupId::from(group_id.as_ref()),
+                        group_id: GroupId::try_from(group_id.as_ref())
+                            .expect("group_id must be 16 bytes"),
                         decrypted_message_bytes: b"test message".to_vec(),
                         sent_at_ns: timestamp,
                         kind: GroupMessageKind::Application,
@@ -402,7 +403,8 @@ pub(crate) mod tests {
                     use xmtp_proto::types::GroupId;
                     Ok(Some(StoredGroupMessage {
                         id: xmtp_common::rand_vec::<32>(),
-                        group_id: GroupId::from(group_id.as_ref()),
+                        group_id: GroupId::try_from(group_id.as_ref())
+                            .expect("group_id must be 16 bytes"),
                         decrypted_message_bytes: b"test message".to_vec(),
                         sent_at_ns: timestamp,
                         kind: GroupMessageKind::Application,

--- a/crates/xmtp_mls/src/groups/summary.rs
+++ b/crates/xmtp_mls/src/groups/summary.rs
@@ -178,7 +178,7 @@ impl std::fmt::Debug for MessageIdentifier {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MessageIdentifier")
             .field("cursor", &self.cursor)
-            .field("group_id", &xmtp_common::fmt::debug_hex(&self.group_id))
+            .field("group_id", &xmtp_common::fmt::debug_hex(self.group_id))
             .field("created_ns", &self.created_ns)
             .field("internal_id", &self.internal_id)
             .field("context", &self.group_context.as_ref().map(|g| g.epoch()))
@@ -191,7 +191,7 @@ impl From<&xmtp_proto::types::GroupMessage> for MessageIdentifierBuilder {
     fn from(value: &xmtp_proto::types::GroupMessage) -> Self {
         MessageIdentifierBuilder {
             cursor: Some(value.cursor),
-            group_id: Some(value.group_id.clone()),
+            group_id: Some(value.group_id),
             created_ns: Some(value.created_ns),
             internal_id: None,
             group_context: None,
@@ -205,7 +205,7 @@ impl From<&xmtp_proto::types::GroupMessage> for MessageIdentifier {
     fn from(value: &xmtp_proto::types::GroupMessage) -> Self {
         MessageIdentifier {
             cursor: value.cursor,
-            group_id: value.group_id.clone(),
+            group_id: value.group_id,
             created_ns: value.created_ns,
             internal_id: None,
             group_context: None,

--- a/crates/xmtp_mls/src/groups/tests/mod.rs
+++ b/crates/xmtp_mls/src/groups/tests/mod.rs
@@ -35,7 +35,7 @@ use xmtp_db::ConnectionExt;
 use xmtp_db::XmtpOpenMlsProviderRef;
 use xmtp_db::refresh_state::EntityKind;
 use xmtp_id::InboxOwner;
-use xmtp_proto::types::{Cursor, GroupId, TopicKind};
+use xmtp_proto::types::{Cursor, TopicKind};
 
 use super::group_permissions::PolicySet;
 use crate::context::XmtpSharedContext;
@@ -170,7 +170,7 @@ async fn test_send_message() {
     let messages = alix
         .context
         .api()
-        .query_at(TopicKind::GroupMessagesV1.create(&group.group_id), None)
+        .query_at(TopicKind::GroupMessagesV1.create(group.group_id), None)
         .await?;
 
     group.sync().await?;
@@ -325,7 +325,7 @@ async fn test_add_member_conflict() {
 
     let amal_uncommitted_intents = amal_db
         .find_group_intents(
-            amal_group.group_id.clone(),
+            amal_group.group_id,
             Some(vec![
                 IntentState::ToPublish,
                 IntentState::Published,
@@ -337,11 +337,7 @@ async fn test_add_member_conflict() {
     assert_eq!(amal_uncommitted_intents.len(), 0);
 
     let bola_failed_intents = bola_db
-        .find_group_intents(
-            bola_group.group_id.clone(),
-            Some(vec![IntentState::Error]),
-            None,
-        )
+        .find_group_intents(bola_group.group_id, Some(vec![IntentState::Error]), None)
         .unwrap();
     // Bola's attempted add should be deleted, since it will have been a no-op on the second try
     assert_eq!(bola_failed_intents.len(), 0);
@@ -468,7 +464,7 @@ async fn test_dm_stitching() {
         now
     );
 
-    let dm_group = alix.group(dm_group.id.as_ref()).unwrap();
+    let dm_group = alix.group(&dm_group.id).unwrap();
     let alix_msgs = dm_group
         .find_messages(&MsgQueryArgs {
             kind: Some(GroupMessageKind::Application),
@@ -498,7 +494,7 @@ async fn test_add_inbox() {
     let messages = client
         .context
         .api()
-        .query_at(TopicKind::GroupMessagesV1.create(&group_id), None)
+        .query_at(TopicKind::GroupMessagesV1.create(group_id), None)
         .await
         .unwrap();
     assert_eq!(messages.len(), 1);
@@ -577,7 +573,7 @@ async fn test_create_group_with_member_two_installations_one_malformed_keypackag
     let messages_bola_1 = bola_1
         .context
         .api()
-        .query_at(TopicKind::GroupMessagesV1.create(&group.group_id), None)
+        .query_at(TopicKind::GroupMessagesV1.create(group.group_id), None)
         .await
         .unwrap();
 
@@ -588,7 +584,7 @@ async fn test_create_group_with_member_two_installations_one_malformed_keypackag
     let messages_alix = alix
         .context
         .api()
-        .query_at(TopicKind::GroupMessagesV1.create(&group.group_id), None)
+        .query_at(TopicKind::GroupMessagesV1.create(group.group_id), None)
         .await
         .unwrap();
 
@@ -1066,7 +1062,7 @@ async fn test_remove_inbox() {
     let messages = client_1
         .context
         .api()
-        .query_at(TopicKind::GroupMessagesV1.create(&group_id), None)
+        .query_at(TopicKind::GroupMessagesV1.create(group_id), None)
         .await
         .expect("read topic");
 
@@ -1155,7 +1151,7 @@ async fn test_self_remove_group_fail_with_one_member() {
 
     let amal_group_pending_leave_users = amal
         .db()
-        .get_pending_remove_users(&GroupId::from(amal_group.group_id.as_slice()))
+        .get_pending_remove_users(&amal_group.group_id)
         .unwrap();
     assert!(amal_group_pending_leave_users.is_empty());
 
@@ -1195,7 +1191,7 @@ async fn test_non_member_cannot_leave_group() {
     // Verify the pending-remove list is empty on Amal's group
     let amal_group_pending_leave_users = amal
         .db()
-        .get_pending_remove_users(&GroupId::from(amal_group.group_id.as_slice()))
+        .get_pending_remove_users(&amal_group.group_id)
         .unwrap();
     assert!(amal_group_pending_leave_users.is_empty());
     let bola_groups = bola.find_groups(GroupQueryArgs::default()).unwrap();
@@ -1208,7 +1204,7 @@ async fn test_non_member_cannot_leave_group() {
     // Verify the pending-remove list is empty on Bola_i1's group
     let bola_group_pending_leave_users = bola
         .db()
-        .get_pending_remove_users(&GroupId::from(bola_group.group_id.as_slice()))
+        .get_pending_remove_users(&bola_group.group_id)
         .unwrap();
     assert!(bola_group_pending_leave_users.is_empty());
 
@@ -1237,7 +1233,7 @@ async fn test_self_removal() {
     // Verify the pending-remove list is empty on Amal's group
     let amal_group_pending_leave_users = amal
         .db()
-        .get_pending_remove_users(&GroupId::from(amal_group.group_id.as_slice()))
+        .get_pending_remove_users(&amal_group.group_id)
         .unwrap();
     assert!(amal_group_pending_leave_users.is_empty());
 
@@ -1251,7 +1247,7 @@ async fn test_self_removal() {
     // Verify the pending-remove list is empty on Bola_i1's group
     let bola_i1_group_pending_leave_users = bola_i1
         .db()
-        .get_pending_remove_users(&GroupId::from(bola_i1_group.group_id.as_slice()))
+        .get_pending_remove_users(&bola_i1_group.group_id)
         .unwrap();
     assert!(bola_i1_group_pending_leave_users.is_empty());
 
@@ -1262,7 +1258,7 @@ async fn test_self_removal() {
         .expect_err("Amal should not be able to leave the group");
     let amal_group_pending_leave_users = amal
         .db()
-        .get_pending_remove_users(&GroupId::from(amal_group.group_id.as_slice()))
+        .get_pending_remove_users(&amal_group.group_id)
         .unwrap();
     assert!(amal_group_pending_leave_users.is_empty());
 
@@ -1274,7 +1270,7 @@ async fn test_self_removal() {
     bola_i1_group.leave_group().await.unwrap();
     let bola_i1_group_pending_leave_users = bola_i1
         .db()
-        .get_pending_remove_users(&GroupId::from(bola_i1_group.group_id.as_slice()))
+        .get_pending_remove_users(&bola_i1_group.group_id)
         .unwrap();
     tracing::info!(
         "Bola_i1_group_pending_leave_users: {:?}",
@@ -1285,10 +1281,7 @@ async fn test_self_removal() {
     assert_eq!(bola_i1_group_pending_leave_users.len(), 1);
 
     // Bola's state for the group should be set to PendingRemove
-    let bola_i1_group_from_db = bola_i1
-        .db()
-        .find_group(&GroupId::from(bola_i1_group.group_id.as_slice()))
-        .unwrap();
+    let bola_i1_group_from_db = bola_i1.db().find_group(&bola_i1_group.group_id).unwrap();
     assert_eq!(
         bola_i1_group_from_db.unwrap().membership_state,
         GroupMembershipState::PendingRemove
@@ -1298,7 +1291,7 @@ async fn test_self_removal() {
     amal_group.sync().await.unwrap();
     let amal_group_member_state = amal
         .db()
-        .find_group(&GroupId::from(amal_group.group_id.as_slice()))
+        .find_group(&amal_group.group_id)
         .unwrap()
         .unwrap()
         .membership_state;
@@ -1314,16 +1307,13 @@ async fn test_self_removal() {
 
     let bola_i2_group_pending_leave_users = bola_i2
         .db()
-        .get_pending_remove_users(&GroupId::from(bola_i2_group.group_id.as_slice()))
+        .get_pending_remove_users(&bola_i2_group.group_id)
         .unwrap();
     // Bola's inboxId should be in the pending-remove list
     assert!(bola_i2_group_pending_leave_users.contains(&bola_i1.inbox_id().to_string()));
     // The pending-remove list should only contain one item
     assert_eq!(bola_i2_group_pending_leave_users.len(), 1);
-    let bola_i2_group_state_in_db = bola_i2
-        .db()
-        .find_group(&GroupId::from(bola_i2_group.group_id.as_slice()))
-        .unwrap();
+    let bola_i2_group_state_in_db = bola_i2.db().find_group(&bola_i2_group.group_id).unwrap();
 
     // group's state should be set to PendingRemove on Bola's other installation
     assert_eq!(
@@ -1523,7 +1513,7 @@ async fn test_self_removal_single_installations() {
     // Verify the pending-remove list is empty on Amal's group
     let amal_group_pending_leave_users = amal
         .db()
-        .get_pending_remove_users(&GroupId::from(amal_group.group_id.as_slice()))
+        .get_pending_remove_users(&amal_group.group_id)
         .unwrap();
     assert!(amal_group_pending_leave_users.is_empty());
 
@@ -1537,7 +1527,7 @@ async fn test_self_removal_single_installations() {
     // Verify the pending-remove list is empty on Bola's group
     let bola_group_pending_leave_users = bola
         .db()
-        .get_pending_remove_users(&GroupId::from(bola_group.group_id.as_slice()))
+        .get_pending_remove_users(&bola_group.group_id)
         .unwrap();
     assert!(bola_group_pending_leave_users.is_empty());
 
@@ -1548,7 +1538,7 @@ async fn test_self_removal_single_installations() {
         .expect_err("Amal should not be able to leave the group");
     let amal_group_pending_leave_users = amal
         .db()
-        .get_pending_remove_users(&GroupId::from(amal_group.group_id.as_slice()))
+        .get_pending_remove_users(&amal_group.group_id)
         .unwrap();
     // Amal's inboxId shouldn't be in the pending-remove list
     assert!(!amal_group_pending_leave_users.contains(&amal.inbox_id().to_string()));
@@ -1574,17 +1564,14 @@ async fn test_self_removal_single_installations() {
 
     let bola_group_pending_leave_users = bola
         .db()
-        .get_pending_remove_users(&GroupId::from(bola_group.group_id.as_slice()))
+        .get_pending_remove_users(&bola_group.group_id)
         .unwrap();
 
     // Bola's inboxId should be in the pending-remove list on Bola's group
     assert!(bola_group_pending_leave_users.contains(&bola.inbox_id().to_string()));
 
     // Bola's state for the group should be set to PendingRemove
-    let bola_group_from_db = bola
-        .db()
-        .find_group(&GroupId::from(bola_group.group_id.as_slice()))
-        .unwrap();
+    let bola_group_from_db = bola.db().find_group(&bola_group.group_id).unwrap();
     assert_eq!(
         bola_group_from_db.unwrap().membership_state,
         GroupMembershipState::PendingRemove
@@ -1594,7 +1581,7 @@ async fn test_self_removal_single_installations() {
     amal_group.sync().await.unwrap();
     let amal_group_member_state = amal
         .db()
-        .find_group(&GroupId::from(amal_group.group_id.as_slice()))
+        .find_group(&amal_group.group_id)
         .unwrap()
         .unwrap()
         .membership_state;
@@ -1632,17 +1619,14 @@ async fn test_self_removal_with_multiple_initial_installations() {
     bola_i1_group.leave_group().await.unwrap();
     let bola_i1_group_pending_leave_users = bola_i1
         .db()
-        .get_pending_remove_users(&GroupId::from(bola_i1_group.group_id.as_slice()))
+        .get_pending_remove_users(&bola_i1_group.group_id)
         .unwrap();
 
     // Bola's inboxId should be in the pending-remove list on Bola_i1's group
     assert!(bola_i1_group_pending_leave_users.contains(&bola_i1.inbox_id().to_string()));
 
     // Bola_i1's state for the group should be set to PendingRemove
-    let bola_i1_group_from_db = bola_i1
-        .db()
-        .find_group(&GroupId::from(bola_i1_group.group_id.as_slice()))
-        .unwrap();
+    let bola_i1_group_from_db = bola_i1.db().find_group(&bola_i1_group.group_id).unwrap();
     assert_eq!(
         bola_i1_group_from_db.unwrap().membership_state,
         GroupMembershipState::PendingRemove
@@ -1652,7 +1636,7 @@ async fn test_self_removal_with_multiple_initial_installations() {
     bola_i2_group.sync().await.unwrap();
     let bola_i2_group_pending_leave_users = bola_i2
         .db()
-        .get_pending_remove_users(&GroupId::from(bola_i2_group.group_id.as_slice()))
+        .get_pending_remove_users(&bola_i2_group.group_id)
         .unwrap();
 
     // Bola's inboxId should be in the pending-remove list on i2 as well
@@ -1660,10 +1644,7 @@ async fn test_self_removal_with_multiple_initial_installations() {
     // The pending-remove list should only contain one item
     assert_eq!(bola_i2_group_pending_leave_users.len(), 1);
 
-    let bola_i2_group_state_in_db = bola_i2
-        .db()
-        .find_group(&GroupId::from(bola_i2_group.group_id.as_slice()))
-        .unwrap();
+    let bola_i2_group_state_in_db = bola_i2.db().find_group(&bola_i2_group.group_id).unwrap();
     // Group's state should be set to PendingRemove on Bola's other installation
     assert_eq!(
         bola_i2_group_state_in_db.unwrap().membership_state,
@@ -1693,17 +1674,14 @@ async fn test_self_removal_with_late_installation() {
     bola_i1_group.leave_group().await.unwrap();
     let bola_i1_group_pending_leave_users = bola_i1
         .db()
-        .get_pending_remove_users(&GroupId::from(bola_i1_group.group_id.as_slice()))
+        .get_pending_remove_users(&bola_i1_group.group_id)
         .unwrap();
 
     // Bola's inboxId should be in the pending-remove list on Bola_i1's group
     assert!(bola_i1_group_pending_leave_users.contains(&bola_i1.inbox_id().to_string()));
 
     // Bola_i1's state for the group should be set to PendingRemove
-    let bola_i1_group_from_db = bola_i1
-        .db()
-        .find_group(&GroupId::from(bola_i1_group.group_id.as_slice()))
-        .unwrap();
+    let bola_i1_group_from_db = bola_i1.db().find_group(&bola_i1_group.group_id).unwrap();
     assert_eq!(
         bola_i1_group_from_db.unwrap().membership_state,
         GroupMembershipState::PendingRemove
@@ -1729,7 +1707,7 @@ async fn test_self_removal_with_late_installation() {
 
     let bola_i3_group_pending_leave_users = bola_i3
         .db()
-        .get_pending_remove_users(&GroupId::from(bola_i3_group.group_id.as_slice()))
+        .get_pending_remove_users(&bola_i3_group.group_id)
         .unwrap();
 
     // Bola's inboxId should be in the pending-remove list on the new installation
@@ -1737,10 +1715,7 @@ async fn test_self_removal_with_late_installation() {
     // The pending-remove list should only contain one item
     assert_eq!(bola_i3_group_pending_leave_users.len(), 1);
 
-    let bola_i3_group_state_in_db = bola_i3
-        .db()
-        .find_group(&GroupId::from(bola_i1_group.group_id.as_slice()))
-        .unwrap();
+    let bola_i3_group_state_in_db = bola_i3.db().find_group(&bola_i1_group.group_id).unwrap();
     // Group's state should be set to PendingRemove on the new installation
     assert_eq!(
         bola_i3_group_state_in_db.unwrap().membership_state,
@@ -1779,7 +1754,7 @@ async fn test_clean_pending_remove_list_on_member_removal() {
     // Verify Bola is in the pending_remove list
     let pending_users = bola
         .db()
-        .get_pending_remove_users(&GroupId::from(bola_group.group_id.as_slice()))
+        .get_pending_remove_users(&bola_group.group_id)
         .unwrap();
     assert_eq!(pending_users.len(), 1);
     assert!(pending_users.contains(&bola.inbox_id().to_string()));
@@ -1799,13 +1774,13 @@ async fn test_clean_pending_remove_list_on_member_removal() {
     // Verify Bola is removed from the pending_remove list on all clients
     let amal_pending = amal
         .db()
-        .get_pending_remove_users(&GroupId::from(amal_group.group_id.as_slice()))
+        .get_pending_remove_users(&amal_group.group_id)
         .unwrap();
     assert!(amal_pending.is_empty());
 
     let caro_pending = caro
         .db()
-        .get_pending_remove_users(&GroupId::from(caro_group.group_id.as_slice()))
+        .get_pending_remove_users(&caro_group.group_id)
         .unwrap();
     assert!(caro_pending.is_empty());
 
@@ -1881,17 +1856,13 @@ async fn test_super_admin_promotion_marks_pending_leave_requests() {
     // Verify Caro is in the pending_remove list
     let pending_users = caro
         .db()
-        .get_pending_remove_users(&GroupId::from(caro_group.group_id.as_slice()))
+        .get_pending_remove_users(&caro_group.group_id)
         .unwrap();
     assert_eq!(pending_users.len(), 1);
     assert!(pending_users.contains(&caro.inbox_id().to_string()));
 
     // Initially, the group should not have pending leave requests on Bola's side (not super admin)
-    let bola_group_status = bola
-        .db()
-        .find_group(&GroupId::from(bola_group.group_id.as_slice()))
-        .unwrap()
-        .unwrap();
+    let bola_group_status = bola.db().find_group(&bola_group.group_id).unwrap().unwrap();
     assert_eq!(bola_group_status.has_pending_leave_request, None);
 
     // Amal promotes Bola to super_admin
@@ -1913,11 +1884,7 @@ async fn test_super_admin_promotion_marks_pending_leave_requests() {
     );
 
     // Verify the group is marked as having pending leave requests
-    let bola_group_status = bola
-        .db()
-        .find_group(&GroupId::from(bola_group.group_id.as_slice()))
-        .unwrap()
-        .unwrap();
+    let bola_group_status = bola.db().find_group(&bola_group.group_id).unwrap().unwrap();
     assert_eq!(bola_group_status.has_pending_leave_request, Some(true));
 }
 
@@ -1968,11 +1935,7 @@ async fn test_super_admin_demotion_clears_pending_leave_requests() {
     bola_group.sync().await.unwrap();
 
     // Verify the group is marked as having pending leave requests on Bola's side
-    let bola_group_status = bola
-        .db()
-        .find_group(&GroupId::from(bola_group.group_id.as_slice()))
-        .unwrap()
-        .unwrap();
+    let bola_group_status = bola.db().find_group(&bola_group.group_id).unwrap().unwrap();
     assert_eq!(bola_group_status.has_pending_leave_request, Some(true));
 
     // Bola demotes themselves from super_admin
@@ -1994,11 +1957,7 @@ async fn test_super_admin_demotion_clears_pending_leave_requests() {
     );
 
     // Verify the pending leave request flag is cleared
-    let bola_group_status = bola
-        .db()
-        .find_group(&GroupId::from(bola_group.group_id.as_slice()))
-        .unwrap()
-        .unwrap();
+    let bola_group_status = bola.db().find_group(&bola_group.group_id).unwrap().unwrap();
     assert_eq!(bola_group_status.has_pending_leave_request, Some(false));
 }
 
@@ -2021,7 +1980,7 @@ async fn test_no_status_change_when_not_in_pending_remove_list() {
     // Verify no pending remove users
     let pending_users = bola
         .db()
-        .get_pending_remove_users(&GroupId::from(bola_group.group_id.as_slice()))
+        .get_pending_remove_users(&bola_group.group_id)
         .unwrap();
     assert!(pending_users.is_empty());
 
@@ -2042,11 +2001,7 @@ async fn test_no_status_change_when_not_in_pending_remove_list() {
     );
 
     // Verify the group is NOT marked as having pending leave requests (no pending users)
-    let bola_group_status = bola
-        .db()
-        .find_group(&GroupId::from(bola_group.group_id.as_slice()))
-        .unwrap()
-        .unwrap();
+    let bola_group_status = bola.db().find_group(&bola_group.group_id).unwrap().unwrap();
     // The status should be false or None since there are no pending remove users
     assert!(
         bola_group_status.has_pending_leave_request == Some(false)
@@ -2077,7 +2032,7 @@ async fn test_promotion_excludes_self_from_pending_check() {
     // Verify Bola is in the pending_remove list
     let pending_users = bola
         .db()
-        .get_pending_remove_users(&GroupId::from(bola_group.group_id.as_slice()))
+        .get_pending_remove_users(&bola_group.group_id)
         .unwrap();
     assert!(pending_users.contains(&bola.inbox_id().to_string()));
 
@@ -2099,11 +2054,7 @@ async fn test_promotion_excludes_self_from_pending_check() {
 
     // Verify the group is NOT marked as having pending leave requests
     // (because the only pending user is Bola themselves)
-    let bola_group_status = bola
-        .db()
-        .find_group(&GroupId::from(bola_group.group_id.as_slice()))
-        .unwrap()
-        .unwrap();
+    let bola_group_status = bola.db().find_group(&bola_group.group_id).unwrap().unwrap();
     assert!(
         bola_group_status.has_pending_leave_request == Some(false)
             || bola_group_status.has_pending_leave_request.is_none()
@@ -2139,7 +2090,7 @@ async fn test_admin_removal_without_pending_shows_as_removed() {
     // Verify Bola is NOT in the pending_remove list
     let pending_users = amal
         .db()
-        .get_pending_remove_users(&GroupId::from(amal_group.group_id.as_slice()))
+        .get_pending_remove_users(&amal_group.group_id)
         .unwrap();
     assert!(pending_users.is_empty());
 
@@ -2204,7 +2155,7 @@ async fn test_key_update() {
     let messages = client
         .context
         .api()
-        .query_at(TopicKind::GroupMessagesV1.create(&group.group_id), None)
+        .query_at(TopicKind::GroupMessagesV1.create(group.group_id), None)
         .await
         .unwrap();
     assert_eq!(messages.len(), 2);
@@ -2337,7 +2288,7 @@ async fn test_removed_members_cannot_send_message_to_others() {
 
     let bola_group = TestMlsGroup::new(
         bola.context.clone(),
-        amal_group.group_id.clone(),
+        amal_group.group_id,
         amal_group.dm_id.clone(),
         amal_group.conversation_type,
         amal_group.created_at_ns,
@@ -3149,7 +3100,7 @@ async fn test_staged_welcome() {
     // Bola gets the group id. This will be needed to fetch the group from
     // the database.
     let bola_group = bola_groups.first().unwrap();
-    let bola_group_id = bola_group.group_id.clone();
+    let bola_group_id = bola_group.group_id;
 
     // Bola fetches group from the database
     let bola_fetched_group = bola.group(&bola_group_id).unwrap();
@@ -3476,7 +3427,7 @@ async fn process_messages_abort_on_retryable_error() {
     let bo_messages = bo
         .context
         .api()
-        .query_at(TopicKind::GroupMessagesV1.create(&bo_group.group_id), None)
+        .query_at(TopicKind::GroupMessagesV1.create(bo_group.group_id), None)
         .await
         .unwrap()
         .group_messages()
@@ -3519,7 +3470,7 @@ async fn skip_already_processed_messages() {
     let mut bo_messages_from_api = bo
         .context
         .api()
-        .query_at(TopicKind::GroupMessagesV1.create(&bo_group.group_id), None)
+        .query_at(TopicKind::GroupMessagesV1.create(bo_group.group_id), None)
         .await
         .unwrap()
         .group_messages()
@@ -3539,7 +3490,7 @@ async fn skip_already_processed_messages() {
     // get new, unprocessed messages
     let new_message = bo
         .mls_store()
-        .query_group_messages(&bo_group.group_id)
+        .query_group_messages(bo_group.group_id)
         .await
         .unwrap();
     bo_messages_from_api.extend(new_message);
@@ -3573,11 +3524,7 @@ async fn skip_already_processed_intents() {
     let intent = bo_client
         .context
         .db()
-        .find_group_intents(
-            bo_group.clone().group_id,
-            Some(vec![IntentState::Processed]),
-            None,
-        )
+        .find_group_intents(bo_group.group_id, Some(vec![IntentState::Processed]), None)
         .unwrap();
     assert_eq!(intent.len(), 2); //key_update and send_message
 
@@ -3628,7 +3575,7 @@ async fn test_parallel_syncs() {
         .context
         .api()
         .query_at(
-            TopicKind::GroupMessagesV1.create(&alix1_group.group_id),
+            TopicKind::GroupMessagesV1.create(alix1_group.group_id),
             None,
         )
         .await
@@ -3738,7 +3685,7 @@ async fn add_missing_installs_reentrancy() {
         .context
         .api()
         .query_at(
-            TopicKind::GroupMessagesV1.create(&alix1_group.group_id),
+            TopicKind::GroupMessagesV1.create(alix1_group.group_id),
             None,
         )
         .await
@@ -3793,7 +3740,7 @@ async fn respect_allow_epoch_increment() {
     let messages = client
         .context
         .api()
-        .query_at(TopicKind::GroupMessagesV1.create(&group.group_id), None)
+        .query_at(TopicKind::GroupMessagesV1.create(group.group_id), None)
         .await
         .unwrap()
         .group_messages()
@@ -4840,7 +4787,7 @@ async fn test_when_processing_message_return_future_wrong_epoch_group_marked_pro
     client_b
         .context
         .db()
-        .clear_fork_flag_for_group(&GroupId::from(group_b.group_id.as_slice()))
+        .clear_fork_flag_for_group(&group_b.group_id)
         .unwrap();
     let group_debug_info = group_b.debug_info().await.unwrap();
     assert!(!group_debug_info.maybe_forked);
@@ -4923,7 +4870,7 @@ async fn can_stream_out_of_order_without_forking() {
     let messages = client_b
         .context
         .api()
-        .query_at(TopicKind::GroupMessagesV1.create(&group_b.group_id), None)
+        .query_at(TopicKind::GroupMessagesV1.create(group_b.group_id), None)
         .await
         .unwrap()
         .group_messages()
@@ -4990,7 +4937,7 @@ async fn non_retryable_error_increments_cursor() {
     let message = xmtp_proto::types::GroupMessage {
         cursor: new_cursor,
         created_ns: DateTime::from_timestamp_nanos(xmtp_common::time::now_ns()),
-        group_id: group.group_id.clone(),
+        group_id: group.group_id,
         message: MlsMessageIn::tls_deserialize(&mut message.to_bytes().unwrap().as_slice())
             .unwrap()
             .try_into_protocol_message()
@@ -5008,7 +4955,7 @@ async fn non_retryable_error_increments_cursor() {
         .context
         .db()
         .get_last_cursor_for_originator(
-            &group.group_id,
+            group.group_id,
             EntityKind::ApplicationMessage,
             Originators::MLS_COMMITS,
         )

--- a/crates/xmtp_mls/src/groups/tests/test_commit_log_fork_detection.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_commit_log_fork_detection.rs
@@ -13,11 +13,11 @@ use xmtp_proto::types::Cursor;
 async fn test_commit_log_fork_detection_no_fork() -> Result<(), Box<dyn std::error::Error>> {
     tester!(alix);
     let group = alix.create_group(None, None).unwrap();
-    let group_id = group.group_id.clone();
+    let group_id = group.group_id;
 
     // Insert local commit log entries
     let local_entry_1 = NewLocalCommitLog {
-        group_id: group_id.clone(),
+        group_id,
         commit_sequence_id: 1,
         last_epoch_authenticator: vec![0x11, 0x22, 0x33],
         commit_result: CommitResult::Success,
@@ -30,7 +30,7 @@ async fn test_commit_log_fork_detection_no_fork() -> Result<(), Box<dyn std::err
     };
 
     let local_entry_2 = NewLocalCommitLog {
-        group_id: group_id.clone(),
+        group_id,
         commit_sequence_id: 2,
         last_epoch_authenticator: vec![0xAA, 0xBB, 0xCC],
         commit_result: CommitResult::Success,
@@ -48,7 +48,7 @@ async fn test_commit_log_fork_detection_no_fork() -> Result<(), Box<dyn std::err
     // Insert matching remote commit log entries (no fork)
     let remote_entry_1 = NewRemoteCommitLog {
         log_sequence_id: 100,
-        group_id: group_id.clone(),
+        group_id,
         commit_sequence_id: 1,
         commit_result: CommitResult::Success,
         applied_epoch_number: 1,
@@ -57,7 +57,7 @@ async fn test_commit_log_fork_detection_no_fork() -> Result<(), Box<dyn std::err
 
     let remote_entry_2 = NewRemoteCommitLog {
         log_sequence_id: 101,
-        group_id: group_id.clone(),
+        group_id,
         commit_sequence_id: 2,
         commit_result: CommitResult::Success,
         applied_epoch_number: 2,
@@ -93,11 +93,11 @@ async fn test_commit_log_fork_detection_no_fork() -> Result<(), Box<dyn std::err
 async fn test_commit_log_fork_detection_forked() -> Result<(), Box<dyn std::error::Error>> {
     tester!(alix);
     let group = alix.create_group(None, None).unwrap();
-    let group_id = group.group_id.clone();
+    let group_id = group.group_id;
 
     // Insert local commit log entries
     let local_entry_1 = NewLocalCommitLog {
-        group_id: group_id.clone(),
+        group_id,
         commit_sequence_id: 200,
         last_epoch_authenticator: vec![0x11, 0x22, 0x33],
         commit_result: CommitResult::Success,
@@ -110,7 +110,7 @@ async fn test_commit_log_fork_detection_forked() -> Result<(), Box<dyn std::erro
     };
 
     let local_entry_2 = NewLocalCommitLog {
-        group_id: group_id.clone(),
+        group_id,
         commit_sequence_id: 201,
         last_epoch_authenticator: vec![0xAA, 0xBB, 0xCC],
         commit_result: CommitResult::Success,
@@ -128,7 +128,7 @@ async fn test_commit_log_fork_detection_forked() -> Result<(), Box<dyn std::erro
     // Insert matching remote commit log entries (no fork)
     let remote_entry_1 = NewRemoteCommitLog {
         log_sequence_id: 100,
-        group_id: group_id.clone(),
+        group_id,
         commit_sequence_id: 200,
         commit_result: CommitResult::Invalid, // For some reason remote marked this commit invalid
         applied_epoch_number: 1,
@@ -137,7 +137,7 @@ async fn test_commit_log_fork_detection_forked() -> Result<(), Box<dyn std::erro
 
     let remote_entry_2 = NewRemoteCommitLog {
         log_sequence_id: 101,
-        group_id: group_id.clone(),
+        group_id,
         commit_sequence_id: 200,
         commit_result: CommitResult::Success,
         applied_epoch_number: 1,
@@ -173,11 +173,11 @@ async fn test_commit_log_fork_detection_forked() -> Result<(), Box<dyn std::erro
 async fn test_commit_log_fork_detection_cursor_updates() -> Result<(), Box<dyn std::error::Error>> {
     tester!(alix);
     let group = alix.create_group(None, None).unwrap();
-    let group_id = group.group_id.clone();
+    let group_id = group.group_id;
 
     // Insert local commit log entry
     let local_entry = NewLocalCommitLog {
-        group_id: group_id.clone(),
+        group_id,
         commit_sequence_id: 1,
         last_epoch_authenticator: vec![0x11, 0x22, 0x33],
         commit_result: CommitResult::Success,
@@ -194,7 +194,7 @@ async fn test_commit_log_fork_detection_cursor_updates() -> Result<(), Box<dyn s
     // Insert matching remote commit log entry with same authenticator (should update cursors)
     let remote_entry = NewRemoteCommitLog {
         log_sequence_id: 100,
-        group_id: group_id.clone(),
+        group_id,
         commit_sequence_id: 1, // Same commit_sequence_id
         commit_result: CommitResult::Success,
         applied_epoch_number: 1,
@@ -205,12 +205,12 @@ async fn test_commit_log_fork_detection_cursor_updates() -> Result<(), Box<dyn s
 
     // Get initial cursor values (should be 0)
     let initial_local_cursor = alix.context.db().get_last_cursor_for_originator(
-        &group_id,
+        group_id,
         xmtp_db::refresh_state::EntityKind::CommitLogForkCheckLocal,
         Originators::REMOTE_COMMIT_LOG,
     )?;
     let initial_remote_cursor = alix.context.db().get_last_cursor_for_originator(
-        &group_id,
+        group_id,
         xmtp_db::refresh_state::EntityKind::CommitLogForkCheckRemote,
         Originators::REMOTE_COMMIT_LOG,
     )?;
@@ -243,12 +243,12 @@ async fn test_commit_log_fork_detection_cursor_updates() -> Result<(), Box<dyn s
 
     // Verify cursors were updated
     let updated_local_cursor = alix.context.db().get_last_cursor_for_originator(
-        &group_id,
+        group_id,
         xmtp_db::refresh_state::EntityKind::CommitLogForkCheckLocal,
         Originators::REMOTE_COMMIT_LOG,
     )?;
     let updated_remote_cursor = alix.context.db().get_last_cursor_for_originator(
-        &group_id,
+        group_id,
         xmtp_db::refresh_state::EntityKind::CommitLogForkCheckRemote,
         Originators::REMOTE_COMMIT_LOG,
     )?;
@@ -265,7 +265,7 @@ async fn test_commit_log_fork_detection_cursor_updates() -> Result<(), Box<dyn s
 
     // Insert local commit log entry
     let local_entry = NewLocalCommitLog {
-        group_id: group_id.clone(),
+        group_id,
         commit_sequence_id: 2,
         last_epoch_authenticator: vec![0x11, 0x22, 0x33],
         commit_result: CommitResult::Success,
@@ -282,7 +282,7 @@ async fn test_commit_log_fork_detection_cursor_updates() -> Result<(), Box<dyn s
     // Insert matching remote commit log entry with same authenticator (should update cursors)
     let remote_entry = NewRemoteCommitLog {
         log_sequence_id: 101,
-        group_id: group_id.clone(),
+        group_id,
         commit_sequence_id: 2, // Same commit_sequence_id
         commit_result: CommitResult::Success,
         applied_epoch_number: 2,
@@ -316,12 +316,12 @@ async fn test_commit_log_fork_detection_cursor_updates() -> Result<(), Box<dyn s
 
     // Verify cursors were updated
     let updated_two_local_cursor = alix.context.db().get_last_cursor_for_originator(
-        &group_id,
+        group_id,
         xmtp_db::refresh_state::EntityKind::CommitLogForkCheckLocal,
         Originators::REMOTE_COMMIT_LOG,
     )?;
     let updated_two_remote_cursor = alix.context.db().get_last_cursor_for_originator(
-        &group_id,
+        group_id,
         xmtp_db::refresh_state::EntityKind::CommitLogForkCheckRemote,
         Originators::REMOTE_COMMIT_LOG,
     )?;
@@ -353,11 +353,11 @@ async fn test_commit_log_fork_detection_returns_none_when_no_matching_remote()
 -> Result<(), Box<dyn std::error::Error>> {
     tester!(alix);
     let group = alix.create_group(None, None).unwrap();
-    let group_id = group.group_id.clone();
+    let group_id = group.group_id;
 
     // Insert local commit log entries
     let local_entry_1 = NewLocalCommitLog {
-        group_id: group_id.clone(),
+        group_id,
         commit_sequence_id: 1,
         last_epoch_authenticator: vec![0x11, 0x22, 0x33],
         commit_result: CommitResult::Success,
@@ -370,7 +370,7 @@ async fn test_commit_log_fork_detection_returns_none_when_no_matching_remote()
     };
 
     let local_entry_2 = NewLocalCommitLog {
-        group_id: group_id.clone(),
+        group_id,
         commit_sequence_id: 2,
         last_epoch_authenticator: vec![0xAA, 0xBB, 0xCC],
         commit_result: CommitResult::Success,
@@ -388,7 +388,7 @@ async fn test_commit_log_fork_detection_returns_none_when_no_matching_remote()
     // Insert remote commit log entries with different commit_sequence_ids (no match for latest local)
     let remote_entry = NewRemoteCommitLog {
         log_sequence_id: 100,
-        group_id: group_id.clone(),
+        group_id,
         commit_sequence_id: 1, // Only matches first local entry
         commit_result: CommitResult::Success,
         applied_epoch_number: 1,
@@ -429,11 +429,11 @@ async fn test_commit_log_fork_status_persistence_no_new_commits()
 -> Result<(), Box<dyn std::error::Error>> {
     tester!(alix);
     let group = alix.create_group(None, None).unwrap();
-    let group_id = group.group_id.clone();
+    let group_id = group.group_id;
 
     // Insert local commit log entries
     let local_entry_1 = NewLocalCommitLog {
-        group_id: group_id.clone(),
+        group_id,
         commit_sequence_id: 1,
         last_epoch_authenticator: vec![0x11, 0x22, 0x33],
         commit_result: CommitResult::Success,
@@ -446,7 +446,7 @@ async fn test_commit_log_fork_status_persistence_no_new_commits()
     };
 
     let local_entry_2 = NewLocalCommitLog {
-        group_id: group_id.clone(),
+        group_id,
         commit_sequence_id: 2,
         last_epoch_authenticator: vec![0xAA, 0xBB, 0xCC],
         commit_result: CommitResult::Success,
@@ -464,7 +464,7 @@ async fn test_commit_log_fork_status_persistence_no_new_commits()
     // Insert matching remote commit log entries (no fork)
     let remote_entry_1 = NewRemoteCommitLog {
         log_sequence_id: 100,
-        group_id: group_id.clone(),
+        group_id,
         commit_sequence_id: 1,
         commit_result: CommitResult::Success,
         applied_epoch_number: 1,
@@ -473,7 +473,7 @@ async fn test_commit_log_fork_status_persistence_no_new_commits()
 
     let remote_entry_2 = NewRemoteCommitLog {
         log_sequence_id: 101,
-        group_id: group_id.clone(),
+        group_id,
         commit_sequence_id: 2,
         commit_result: CommitResult::Success,
         applied_epoch_number: 2,

--- a/crates/xmtp_mls/src/groups/tests/test_commit_log_readd_requests.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_commit_log_readd_requests.rs
@@ -39,32 +39,23 @@ async fn test_request_readd() {
     let c_conn = caro.context.db();
     // Simulate a fork
     a_conn
-        .set_group_commit_log_forked_status(&GroupId::from(group.group_id.as_slice()), Some(true))
+        .set_group_commit_log_forked_status(&group.group_id, Some(true))
         .unwrap();
 
     // No readd requests yet
     assert!(
         !a_conn
-            .is_awaiting_readd(
-                &GroupId::from(group.group_id.as_slice()),
-                alix.context.installation_id().as_slice(),
-            )
+            .is_awaiting_readd(&group.group_id, alix.context.installation_id().as_slice(),)
             .unwrap()
     );
     assert!(
         !b_conn
-            .is_awaiting_readd(
-                &GroupId::from(group.group_id.as_slice()),
-                alix.context.installation_id().as_slice(),
-            )
+            .is_awaiting_readd(&group.group_id, alix.context.installation_id().as_slice(),)
             .unwrap()
     );
     assert!(
         !c_conn
-            .is_awaiting_readd(
-                &GroupId::from(group.group_id.as_slice()),
-                alix.context.installation_id().as_slice(),
-            )
+            .is_awaiting_readd(&group.group_id, alix.context.installation_id().as_slice(),)
             .unwrap()
     );
 
@@ -80,50 +71,32 @@ async fn test_request_readd() {
     // Only Alix and Bo are superadmins, so only they should have recorded a readd request
     assert!(
         a_conn
-            .is_awaiting_readd(
-                &GroupId::from(group.group_id.as_slice()),
-                alix.context.installation_id().as_slice(),
-            )
+            .is_awaiting_readd(&group.group_id, alix.context.installation_id().as_slice(),)
             .unwrap()
     );
     assert!(
         b_conn
-            .is_awaiting_readd(
-                &GroupId::from(group.group_id.as_slice()),
-                alix.context.installation_id().as_slice(),
-            )
+            .is_awaiting_readd(&group.group_id, alix.context.installation_id().as_slice(),)
             .unwrap()
     );
     assert!(
         !c_conn
-            .is_awaiting_readd(
-                &GroupId::from(group.group_id.as_slice()),
-                alix.context.installation_id().as_slice(),
-            )
+            .is_awaiting_readd(&group.group_id, alix.context.installation_id().as_slice(),)
             .unwrap()
     );
     assert!(
         !a_conn
-            .is_awaiting_readd(
-                &GroupId::from(group.group_id.as_slice()),
-                bo.context.installation_id().as_slice(),
-            )
+            .is_awaiting_readd(&group.group_id, bo.context.installation_id().as_slice(),)
             .unwrap()
     );
     assert!(
         !b_conn
-            .is_awaiting_readd(
-                &GroupId::from(group.group_id.as_slice()),
-                bo.context.installation_id().as_slice(),
-            )
+            .is_awaiting_readd(&group.group_id, bo.context.installation_id().as_slice(),)
             .unwrap()
     );
     assert!(
         !c_conn
-            .is_awaiting_readd(
-                &GroupId::from(group.group_id.as_slice()),
-                bo.context.installation_id().as_slice(),
-            )
+            .is_awaiting_readd(&group.group_id, bo.context.installation_id().as_slice(),)
             .unwrap()
     );
 }
@@ -148,24 +121,18 @@ async fn test_request_readd_dm() {
     let b_conn = bo.context.db();
     // Simulate a fork
     a_conn
-        .set_group_commit_log_forked_status(&GroupId::from(dm.group_id.as_slice()), Some(true))
+        .set_group_commit_log_forked_status(&dm.group_id, Some(true))
         .unwrap();
 
     // No readd requests yet
     assert!(
         !a_conn
-            .is_awaiting_readd(
-                &GroupId::from(dm.group_id.as_slice()),
-                alix.context.installation_id().as_slice(),
-            )
+            .is_awaiting_readd(&dm.group_id, alix.context.installation_id().as_slice(),)
             .unwrap()
     );
     assert!(
         !b_conn
-            .is_awaiting_readd(
-                &GroupId::from(dm.group_id.as_slice()),
-                alix.context.installation_id().as_slice(),
-            )
+            .is_awaiting_readd(&dm.group_id, alix.context.installation_id().as_slice(),)
             .unwrap()
     );
 
@@ -179,34 +146,22 @@ async fn test_request_readd_dm() {
 
     assert!(
         a_conn
-            .is_awaiting_readd(
-                &GroupId::from(dm.group_id.as_slice()),
-                alix.context.installation_id().as_slice(),
-            )
+            .is_awaiting_readd(&dm.group_id, alix.context.installation_id().as_slice(),)
             .unwrap()
     );
     assert!(
         b_conn
-            .is_awaiting_readd(
-                &GroupId::from(dm.group_id.as_slice()),
-                alix.context.installation_id().as_slice(),
-            )
+            .is_awaiting_readd(&dm.group_id, alix.context.installation_id().as_slice(),)
             .unwrap()
     );
     assert!(
         !a_conn
-            .is_awaiting_readd(
-                &GroupId::from(dm.group_id.as_slice()),
-                bo.context.installation_id().as_slice(),
-            )
+            .is_awaiting_readd(&dm.group_id, bo.context.installation_id().as_slice(),)
             .unwrap()
     );
     assert!(
         !b_conn
-            .is_awaiting_readd(
-                &GroupId::from(dm.group_id.as_slice()),
-                bo.context.installation_id().as_slice(),
-            )
+            .is_awaiting_readd(&dm.group_id, bo.context.installation_id().as_slice(),)
             .unwrap()
     );
 }
@@ -297,32 +252,23 @@ async fn test_readd_bookkeeping() {
     let d_conn = devon.context.db();
     // Simulate a fork
     a_conn
-        .set_group_commit_log_forked_status(&GroupId::from(group.group_id.as_slice()), Some(true))
+        .set_group_commit_log_forked_status(&group.group_id, Some(true))
         .unwrap();
 
     // No readd requests yet
     assert!(
         !a_conn
-            .is_awaiting_readd(
-                &GroupId::from(group.group_id.as_slice()),
-                alix.context.installation_id().as_slice(),
-            )
+            .is_awaiting_readd(&group.group_id, alix.context.installation_id().as_slice(),)
             .unwrap()
     );
     assert!(
         !b_conn
-            .is_awaiting_readd(
-                &GroupId::from(group.group_id.as_slice()),
-                alix.context.installation_id().as_slice(),
-            )
+            .is_awaiting_readd(&group.group_id, alix.context.installation_id().as_slice(),)
             .unwrap()
     );
     assert!(
         !c_conn
-            .is_awaiting_readd(
-                &GroupId::from(group.group_id.as_slice()),
-                alix.context.installation_id().as_slice(),
-            )
+            .is_awaiting_readd(&group.group_id, alix.context.installation_id().as_slice(),)
             .unwrap()
     );
 
@@ -337,34 +283,22 @@ async fn test_readd_bookkeeping() {
     // Everyone except Devon (non-superadmin) sees Alix as awaiting readd
     assert!(
         a_conn
-            .is_awaiting_readd(
-                &GroupId::from(group.group_id.as_slice()),
-                alix.context.installation_id().as_slice(),
-            )
+            .is_awaiting_readd(&group.group_id, alix.context.installation_id().as_slice(),)
             .unwrap()
     );
     assert!(
         b_conn
-            .is_awaiting_readd(
-                &GroupId::from(group.group_id.as_slice()),
-                alix.context.installation_id().as_slice(),
-            )
+            .is_awaiting_readd(&group.group_id, alix.context.installation_id().as_slice(),)
             .unwrap()
     );
     assert!(
         c_conn
-            .is_awaiting_readd(
-                &GroupId::from(group.group_id.as_slice()),
-                alix.context.installation_id().as_slice(),
-            )
+            .is_awaiting_readd(&group.group_id, alix.context.installation_id().as_slice(),)
             .unwrap()
     );
     assert!(
         !d_conn
-            .is_awaiting_readd(
-                &GroupId::from(group.group_id.as_slice()),
-                alix.context.installation_id().as_slice(),
-            )
+            .is_awaiting_readd(&group.group_id, alix.context.installation_id().as_slice(),)
             .unwrap()
     );
 
@@ -378,36 +312,24 @@ async fn test_readd_bookkeeping() {
     // Everyone should see that Alix is no longer awaiting readd
     assert!(
         !b_conn
-            .is_awaiting_readd(
-                &GroupId::from(group.group_id.as_slice()),
-                alix.context.installation_id().as_slice(),
-            )
+            .is_awaiting_readd(&group.group_id, alix.context.installation_id().as_slice(),)
             .unwrap()
     );
     assert!(
         !c_conn
-            .is_awaiting_readd(
-                &GroupId::from(group.group_id.as_slice()),
-                alix.context.installation_id().as_slice(),
-            )
+            .is_awaiting_readd(&group.group_id, alix.context.installation_id().as_slice(),)
             .unwrap()
     );
     assert!(
         !d_conn
-            .is_awaiting_readd(
-                &GroupId::from(group.group_id.as_slice()),
-                alix.context.installation_id().as_slice(),
-            )
+            .is_awaiting_readd(&group.group_id, alix.context.installation_id().as_slice(),)
             .unwrap()
     );
 
     alix.sync_welcomes().await.unwrap();
     assert!(
         !a_conn
-            .is_awaiting_readd(
-                &GroupId::from(group.group_id.as_slice()),
-                alix.context.installation_id().as_slice(),
-            )
+            .is_awaiting_readd(&group.group_id, alix.context.installation_id().as_slice(),)
             .unwrap()
     );
 }
@@ -424,9 +346,9 @@ async fn test_request_readd_with_allowlisted_groups() {
         .await
         .unwrap();
 
-    let group_id = group.group_id.to_vec();
-    let group_id_typed: GroupId = group_id.clone().into();
-    let group_id_hex = hex::encode(&group_id);
+    let group_id = group.group_id;
+    let group_id_typed: GroupId = group_id;
+    let group_id_hex = hex::encode(group_id);
     let unnormalized_group_id = "0x".to_owned() + &group_id_hex.to_uppercase();
 
     // Step 2: Create Alix with that group ID in the allowlist
@@ -460,7 +382,7 @@ async fn test_request_readd_with_allowlisted_groups() {
 
     // Simulate a fork
     a_conn
-        .set_group_commit_log_forked_status(&GroupId::from(group_id.as_slice()), Some(true))
+        .set_group_commit_log_forked_status(&group_id, Some(true))
         .unwrap();
 
     // No readd requests yet

--- a/crates/xmtp_mls/src/groups/tests/test_commit_log_remote.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_commit_log_remote.rs
@@ -39,7 +39,7 @@ async fn print_commit_log_with_types(group: &MlsGroup<impl XmtpSharedContext>) {
     let logs = group.local_commit_log().await.unwrap();
     println!(
         "Commit log for group {}: {:?}",
-        hex::encode(&group.group_id[0..4]),
+        hex::encode(&group.group_id.as_slice()[0..4]),
         get_commit_types_as_strings(&logs)
     );
 }
@@ -113,7 +113,7 @@ async fn test_device_sync_mutable_metadata_is_overwritten() {
     // Currently, device sync creates a placeholder OpenMLS group with its own commit log secret
     MlsGroup::insert(
         &bo.context,
-        Some(&a.group_id),
+        Some(a.group_id.as_slice()),
         GroupMembershipState::Restored,
         ConversationType::Group,
         PolicySet::default(),
@@ -295,7 +295,7 @@ async fn test_publish_commit_log_to_remote() {
     let commit_log_entries = alix
         .context
         .db()
-        .get_group_logs(&GroupId::from(alix_group.group_id.as_slice()))
+        .get_group_logs(&alix_group.group_id)
         .unwrap();
     assert_eq!(commit_log_entries.len(), 2);
 
@@ -304,7 +304,7 @@ async fn test_publish_commit_log_to_remote() {
         .context
         .db()
         .get_last_cursor_for_originator(
-            &alix_group.group_id,
+            alix_group.group_id,
             xmtp_db::refresh_state::EntityKind::CommitLogUpload,
             Originators::REMOTE_COMMIT_LOG,
         )
@@ -322,7 +322,7 @@ async fn test_publish_commit_log_to_remote() {
         .context
         .db()
         .get_last_cursor_for_originator(
-            &alix_group.group_id,
+            alix_group.group_id,
             xmtp_db::refresh_state::EntityKind::CommitLogUpload,
             Originators::REMOTE_COMMIT_LOG,
         )
@@ -406,7 +406,7 @@ async fn test_download_commit_log_from_remote() {
         .context
         .db()
         .get_last_cursor_for_originator(
-            &alix_group.group_id,
+            alix_group.group_id,
             xmtp_db::refresh_state::EntityKind::CommitLogUpload,
             Originators::REMOTE_COMMIT_LOG,
         )
@@ -466,7 +466,7 @@ async fn test_download_commit_log_from_remote() {
         .context
         .db()
         .get_last_cursor_for_originator(
-            &alix_group.group_id,
+            alix_group.group_id,
             xmtp_db::refresh_state::EntityKind::CommitLogUpload,
             Originators::REMOTE_COMMIT_LOG,
         )
@@ -705,7 +705,7 @@ async fn test_should_skip_remote_log_entry() {
     let latest_saved_remote_log = RemoteCommitLog {
         rowid: 0,
         log_sequence_id: 0,
-        group_id: GroupId::from(vec![0x11, 0x22, 0x33]),
+        group_id: GroupId::from([0x11u8; 16]),
         commit_sequence_id: 100,
         commit_result: CommitResult::Success,
         applied_epoch_number: 3,
@@ -733,7 +733,7 @@ async fn test_should_skip_remote_log_entry() {
     let latest_saved_remote_log = RemoteCommitLog {
         rowid: 0,
         log_sequence_id: 0,
-        group_id: GroupId::from(vec![0x11, 0x22, 0x33]),
+        group_id: GroupId::from([0x11u8; 16]),
         commit_sequence_id: 100,
         commit_result: CommitResult::Success,
         applied_epoch_number: 3,
@@ -760,7 +760,7 @@ async fn test_should_skip_remote_log_entry() {
     let latest_saved_remote_log = RemoteCommitLog {
         rowid: 0,
         log_sequence_id: 0,
-        group_id: GroupId::from(vec![0x11, 0x22, 0x33]),
+        group_id: GroupId::from([0x11u8; 16]),
         commit_sequence_id: 100,
         commit_result: CommitResult::Success,
         applied_epoch_number: 3,
@@ -788,7 +788,7 @@ async fn test_should_skip_remote_log_entry() {
     let latest_saved_remote_log = RemoteCommitLog {
         rowid: 0,
         log_sequence_id: 0,
-        group_id: GroupId::from(vec![0x11, 0x22, 0x33]),
+        group_id: GroupId::from([0x11u8; 16]),
         commit_sequence_id: 100,
         commit_result: CommitResult::Success,
         applied_epoch_number: 3,
@@ -816,7 +816,7 @@ async fn test_should_skip_remote_log_entry() {
     let latest_saved_remote_log = RemoteCommitLog {
         rowid: 0,
         log_sequence_id: 0,
-        group_id: GroupId::from(vec![0x11, 0x22, 0x33]),
+        group_id: GroupId::from([0x11u8; 16]),
         commit_sequence_id: 100,
         commit_result: CommitResult::Success,
         applied_epoch_number: 3,
@@ -844,7 +844,7 @@ async fn test_should_skip_remote_log_entry() {
     let latest_saved_remote_log = RemoteCommitLog {
         rowid: 0,
         log_sequence_id: 0,
-        group_id: GroupId::from(vec![0x11, 0x22, 0x33]),
+        group_id: GroupId::from([0x11u8; 16]),
         commit_sequence_id: 100,
         commit_result: CommitResult::Success,
         applied_epoch_number: 3,
@@ -872,7 +872,7 @@ async fn test_should_skip_remote_log_entry() {
     let latest_saved_remote_log = RemoteCommitLog {
         rowid: 0,
         log_sequence_id: 0,
-        group_id: GroupId::from(vec![0x11, 0x22, 0x33]),
+        group_id: GroupId::from([0x11u8; 16]),
         commit_sequence_id: 100,
         commit_result: CommitResult::Success,
         applied_epoch_number: 3,
@@ -899,7 +899,7 @@ async fn test_should_skip_remote_log_entry() {
     let latest_saved_remote_log = RemoteCommitLog {
         rowid: 0,
         log_sequence_id: 0,
-        group_id: GroupId::from(vec![0x11, 0x22, 0x33]),
+        group_id: GroupId::from([0x11u8; 16]),
         commit_sequence_id: 100,
         commit_result: CommitResult::Success,
         applied_epoch_number: 3,
@@ -1521,7 +1521,7 @@ async fn test_legacy_group_signing_key_discovery_via_remote_commit_log() {
 
     // Store this key in alix's key store (overwriting any existing key)
     key_store
-        .write_commit_log_key(&group.group_id, &new_signing_key)
+        .write_commit_log_key(group.group_id, &new_signing_key)
         .unwrap();
 
     println!("✓ Generated and stored new signing key for alix in key store");
@@ -1593,11 +1593,7 @@ async fn test_legacy_group_signing_key_discovery_via_remote_commit_log() {
     println!("✓ All participants now have the new signing key in mutable metadata");
 
     // Additional verification: the consensus key should be set in the database
-    let stored_group = alix
-        .context
-        .db()
-        .find_group(&GroupId::from(group.group_id.as_slice()))?
-        .unwrap();
+    let stored_group = alix.context.db().find_group(&group.group_id)?.unwrap();
     assert_eq!(
         stored_group.commit_log_public_key,
         Some(new_public_key.clone())

--- a/crates/xmtp_mls/src/groups/tests/test_delete_message.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_delete_message.rs
@@ -7,7 +7,6 @@ use xmtp_content_types::{ContentCodec, text::TextCodec};
 use xmtp_db::group_message::{ContentType, GroupMessageKind, MsgQueryArgs, QueryGroupMessage};
 use xmtp_db::message_deletion::QueryMessageDeletion;
 
-use xmtp_proto::types::GroupId;
 /// Test basic message deletion by the original sender
 #[xmtp_common::test(unwrap_try = true)]
 async fn test_delete_message_by_sender() {
@@ -264,7 +263,7 @@ async fn test_true_out_of_order_deletion_by_sender() {
 
     let delete_message = StoredGroupMessage {
         id: delete_message_id.clone(),
-        group_id: alix_group.group_id.clone(),
+        group_id: alix_group.group_id,
         decrypted_message_bytes: delete_msg_bytes,
         sent_at_ns: xmtp_common::time::now_ns(),
         kind: GroupMessageKind::Application,
@@ -288,7 +287,7 @@ async fn test_true_out_of_order_deletion_by_sender() {
     // This simulates the deletion arriving before the original message
     let deletion = StoredMessageDeletion {
         id: delete_message_id.clone(),
-        group_id: alix_group.group_id.clone(),
+        group_id: alix_group.group_id,
         deleted_message_id: future_message_id.clone(),
         deleted_by_inbox_id: alix_inbox_id.clone(), // Sender deleting their own message
         is_super_admin_deletion: false,             // Regular user deletion
@@ -310,7 +309,7 @@ async fn test_true_out_of_order_deletion_by_sender() {
 
     let message = StoredGroupMessage {
         id: future_message_id.clone(),
-        group_id: alix_group.group_id.clone(),
+        group_id: alix_group.group_id,
         decrypted_message_bytes: text_bytes,
         sent_at_ns: xmtp_common::time::now_ns() - 1000, // Sent before deletion
         kind: GroupMessageKind::Application,
@@ -384,7 +383,7 @@ async fn test_out_of_order_unauthorized_deletion_rejected() {
 
     let malicious_delete_message = StoredGroupMessage {
         id: malicious_delete_msg_id.clone(),
-        group_id: bo_group.group_id.clone(),
+        group_id: bo_group.group_id,
         decrypted_message_bytes: delete_msg_bytes,
         sent_at_ns: xmtp_common::time::now_ns(),
         kind: GroupMessageKind::Application,
@@ -408,7 +407,7 @@ async fn test_out_of_order_unauthorized_deletion_rejected() {
     // This simulates a malicious deletion arriving before the message
     let malicious_deletion = StoredMessageDeletion {
         id: malicious_delete_msg_id.clone(),
-        group_id: bo_group.group_id.clone(),
+        group_id: bo_group.group_id,
         deleted_message_id: future_message_id.clone(),
         deleted_by_inbox_id: bo_inbox_id.clone(), // Bo trying to delete
         is_super_admin_deletion: false,           // Bo is not super admin
@@ -422,7 +421,7 @@ async fn test_out_of_order_unauthorized_deletion_rejected() {
 
     let message = StoredGroupMessage {
         id: future_message_id.clone(),
-        group_id: bo_group.group_id.clone(),
+        group_id: bo_group.group_id,
         decrypted_message_bytes: text_bytes,
         sent_at_ns: xmtp_common::time::now_ns() - 1000,
         kind: GroupMessageKind::Application,
@@ -584,8 +583,7 @@ async fn test_deletion_database_queries() {
     assert!(conn.is_message_deleted(&message_ids[2])?);
 
     // Test get_group_deletions
-    let group_deletions =
-        conn.get_group_deletions(&GroupId::from(alix_group.group_id.as_slice()))?;
+    let group_deletions = conn.get_group_deletions(&alix_group.group_id)?;
     assert_eq!(group_deletions.len(), 2);
 }
 
@@ -991,7 +989,7 @@ async fn test_out_of_order_sender_deletion_shows_correct_deleted_by() {
 
     let delete_message = StoredGroupMessage {
         id: delete_message_id.clone(),
-        group_id: alix_group.group_id.clone(),
+        group_id: alix_group.group_id,
         decrypted_message_bytes: delete_msg_bytes,
         sent_at_ns: xmtp_common::time::now_ns(),
         kind: GroupMessageKind::Application,
@@ -1014,7 +1012,7 @@ async fn test_out_of_order_sender_deletion_shows_correct_deleted_by() {
     // Store deletion with is_super_admin_deletion=true (out-of-order scenario)
     let deletion = StoredMessageDeletion {
         id: delete_message_id.clone(),
-        group_id: alix_group.group_id.clone(),
+        group_id: alix_group.group_id,
         deleted_message_id: future_message_id.clone(),
         deleted_by_inbox_id: alix_inbox_id.clone(),
         is_super_admin_deletion: true,
@@ -1028,7 +1026,7 @@ async fn test_out_of_order_sender_deletion_shows_correct_deleted_by() {
 
     let original_message = StoredGroupMessage {
         id: future_message_id.clone(),
-        group_id: alix_group.group_id.clone(),
+        group_id: alix_group.group_id,
         decrypted_message_bytes: text_bytes,
         sent_at_ns: xmtp_common::time::now_ns() - 1000,
         kind: GroupMessageKind::Application,

--- a/crates/xmtp_mls/src/groups/tests/test_dm.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_dm.rs
@@ -48,7 +48,7 @@ async fn test_dm_welcome_with_preexisting_consent() {
     let cr = StoredConsentRecord::new(
         ConsentType::ConversationId,
         ConsentState::Allowed,
-        hex::encode(&a_group.group_id),
+        hex::encode(a_group.group_id),
     );
     bo2.context.db().insert_newer_consent_record(cr)?;
     // Now bo2 processes the welcome

--- a/crates/xmtp_mls/src/groups/tests/test_message_dependencies.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_message_dependencies.rs
@@ -7,7 +7,7 @@ use crate::utils::test::MlsGroupExt;
 use crate::{context::XmtpSharedContext, tester};
 
 // gets all messages on a group topic
-async fn get_messages(context: &impl XmtpSharedContext, group_id: &[u8]) -> XmtpEnvelope {
+async fn get_messages(context: &impl XmtpSharedContext, group_id: &GroupId) -> XmtpEnvelope {
     context
         .api()
         .query_at(TopicKind::GroupMessagesV1.create(group_id), None)
@@ -28,8 +28,8 @@ fn message_debug(env: &XmtpEnvelope) -> String {
     )
 }
 
-fn db_message_debug(db: impl QueryGroupMessage, id: &[u8]) -> String {
-    db.get_group_messages(&GroupId::from(id), &Default::default())
+fn db_message_debug(db: impl QueryGroupMessage, id: &GroupId) -> String {
+    db.get_group_messages(id, &Default::default())
         .unwrap()
         .into_iter()
         .enumerate()
@@ -87,7 +87,7 @@ async fn messages_have_dependencies() {
     tester!(bo);
 
     let alix_group = alix.create_group(None, None)?;
-    let group_id = alix_group.group_id.clone();
+    let group_id = alix_group.group_id;
     alix_group.invite(&bo).await?;
     let messages = get_messages(&alix.context, &group_id).await;
     // no messages have been sent in group yet. alix about to process first commit alix
@@ -112,7 +112,7 @@ async fn messages_dependencies_out_of_order_invites() {
     let alix_group = alix
         .create_group_with_members(&[bo.inbox_id()], None, None) // message 0
         .await?;
-    let group_id = alix_group.group_id.clone();
+    let group_id = alix_group.group_id;
     let messages = get_messages(&alix.context, &group_id).await;
     assert_no_dependant(&messages, 0);
     let bo_group = bo.sync_welcomes().await?.pop()?;

--- a/crates/xmtp_mls/src/groups/tests/test_proposals.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_proposals.rs
@@ -108,7 +108,7 @@ async fn test_proposal_intent_serialization(
     let intent = db
         .insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
             IntentKind::ProposeMemberUpdate,
-            alix_group.group_id.clone(),
+            alix_group.group_id,
             intent_bytes,
             false,
         ))
@@ -210,7 +210,7 @@ async fn test_e2e_propose_add_member_flow() {
     let propose_intent =
         alix_db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
             IntentKind::ProposeMemberUpdate,
-            alix_group.group_id.clone(),
+            alix_group.group_id,
             intent_data,
             false,
         ))?;
@@ -237,7 +237,7 @@ async fn test_e2e_propose_add_member_flow() {
     let bo_db = bo_group.context.db();
     let commit_intent = bo_db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
         IntentKind::CommitPendingProposals,
-        bo_group.group_id.clone(),
+        bo_group.group_id,
         CommitPendingProposalsIntentData::default().into(),
         false,
     ))?;
@@ -312,7 +312,7 @@ async fn test_e2e_propose_remove_member_flow() {
     let propose_intent =
         alix_db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
             IntentKind::ProposeMemberUpdate,
-            alix_group.group_id.clone(),
+            alix_group.group_id,
             intent_data,
             false,
         ))?;
@@ -328,7 +328,7 @@ async fn test_e2e_propose_remove_member_flow() {
     let bo_db = bo_group.context.db();
     let commit_intent = bo_db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
         IntentKind::CommitPendingProposals,
-        bo_group.group_id.clone(),
+        bo_group.group_id,
         CommitPendingProposalsIntentData::default().into(),
         false,
     ))?;
@@ -382,7 +382,7 @@ async fn test_commit_with_no_pending_proposals() {
     let db = alix_group.context.db();
     let commit_intent = db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
         IntentKind::CommitPendingProposals,
-        alix_group.group_id.clone(),
+        alix_group.group_id,
         CommitPendingProposalsIntentData::default().into(),
         false,
     ))?;
@@ -448,7 +448,7 @@ async fn test_propose_invalid_member_operations(#[case] is_add: bool) {
     let propose_intent = db
         .insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
             kind,
-            alix_group.group_id.clone(),
+            alix_group.group_id,
             intent_bytes,
             false,
         ))
@@ -507,7 +507,7 @@ async fn test_message_auto_commits_pending_proposals() {
     let db = alix_group.context.db();
     let propose_intent = db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
         IntentKind::ProposeMemberUpdate,
-        alix_group.group_id.clone(),
+        alix_group.group_id,
         ProposeMemberUpdateIntentData::new(vec![caro.inbox_id().to_string()], vec![]).try_into()?,
         false,
     ))?;
@@ -611,7 +611,7 @@ async fn test_multiple_add_proposals_before_commit() {
     let alix_db = alix_group.context.db();
     let propose_caro = alix_db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
         IntentKind::ProposeMemberUpdate,
-        alix_group.group_id.clone(),
+        alix_group.group_id,
         ProposeMemberUpdateIntentData::new(vec![caro.inbox_id().to_string()], vec![]).try_into()?,
         false,
     ))?;
@@ -622,7 +622,7 @@ async fn test_multiple_add_proposals_before_commit() {
     // Alix proposes to add dave
     let propose_dave = alix_db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
         IntentKind::ProposeMemberUpdate,
-        alix_group.group_id.clone(),
+        alix_group.group_id,
         ProposeMemberUpdateIntentData::new(vec![dave.inbox_id().to_string()], vec![]).try_into()?,
         false,
     ))?;
@@ -646,7 +646,7 @@ async fn test_multiple_add_proposals_before_commit() {
     let bo_db = bo_group.context.db();
     let commit_intent = bo_db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
         IntentKind::CommitPendingProposals,
-        bo_group.group_id.clone(),
+        bo_group.group_id,
         CommitPendingProposalsIntentData::default().into(),
         false,
     ))?;
@@ -714,7 +714,7 @@ async fn test_mixed_add_remove_proposals_before_commit() {
     let alix_db = alix_group.context.db();
     let propose_add = alix_db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
         IntentKind::ProposeMemberUpdate,
-        alix_group.group_id.clone(),
+        alix_group.group_id,
         ProposeMemberUpdateIntentData::new(vec![dave.inbox_id().to_string()], vec![]).try_into()?,
         false,
     ))?;
@@ -726,7 +726,7 @@ async fn test_mixed_add_remove_proposals_before_commit() {
     let propose_remove =
         alix_db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
             IntentKind::ProposeMemberUpdate,
-            alix_group.group_id.clone(),
+            alix_group.group_id,
             ProposeMemberUpdateIntentData::new(vec![], vec![caro.inbox_id().to_string()])
                 .try_into()?,
             false,
@@ -750,7 +750,7 @@ async fn test_mixed_add_remove_proposals_before_commit() {
     let bo_db = bo_group.context.db();
     let commit_intent = bo_db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
         IntentKind::CommitPendingProposals,
-        bo_group.group_id.clone(),
+        bo_group.group_id,
         CommitPendingProposalsIntentData::default().into(),
         false,
     ))?;
@@ -798,7 +798,7 @@ async fn test_propose_group_context_extensions_intent() {
     let db = alix_group.context.db();
     let intent = db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
         IntentKind::ProposeGroupContextExtensions,
-        alix_group.group_id.clone(),
+        alix_group.group_id,
         intent_bytes,
         false,
     ))?;
@@ -846,7 +846,7 @@ async fn test_proposer_can_commit_own_proposal() {
     let propose_intent =
         alix_db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
             IntentKind::ProposeMemberUpdate,
-            alix_group.group_id.clone(),
+            alix_group.group_id,
             ProposeMemberUpdateIntentData::new(vec![caro.inbox_id().to_string()], vec![])
                 .try_into()?,
             false,
@@ -881,7 +881,7 @@ async fn test_proposer_can_commit_own_proposal() {
     // Alix commits their own proposal (this should now work!)
     let commit_intent = alix_db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
         IntentKind::CommitPendingProposals,
-        alix_group.group_id.clone(),
+        alix_group.group_id,
         CommitPendingProposalsIntentData::default().into(),
         false,
     ))?;
@@ -956,7 +956,7 @@ async fn test_concurrent_proposals_from_different_members() {
     let alix_db = alix_group.context.db();
     let alix_propose = alix_db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
         IntentKind::ProposeMemberUpdate,
-        alix_group.group_id.clone(),
+        alix_group.group_id,
         ProposeMemberUpdateIntentData::new(vec![dave.inbox_id().to_string()], vec![]).try_into()?,
         false,
     ))?;
@@ -971,7 +971,7 @@ async fn test_concurrent_proposals_from_different_members() {
     let bo_db = bo_group.context.db();
     let bo_propose = bo_db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
         IntentKind::ProposeMemberUpdate,
-        bo_group.group_id.clone(),
+        bo_group.group_id,
         ProposeMemberUpdateIntentData::new(vec![eve.inbox_id().to_string()], vec![]).try_into()?,
         false,
     ))?;
@@ -993,7 +993,7 @@ async fn test_concurrent_proposals_from_different_members() {
     let caro_db = caro_group.context.db();
     let commit_intent = caro_db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
         IntentKind::CommitPendingProposals,
-        caro_group.group_id.clone(),
+        caro_group.group_id,
         CommitPendingProposalsIntentData::default().into(),
         false,
     ))?;
@@ -1067,7 +1067,7 @@ async fn test_non_admin_proposal_rejected_in_admin_only_group() {
     let bo_db = bo_group.context.db();
     let propose_intent = bo_db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
         IntentKind::ProposeMemberUpdate,
-        bo_group.group_id.clone(),
+        bo_group.group_id,
         ProposeMemberUpdateIntentData::new(vec![caro.inbox_id().to_string()], vec![]).try_into()?,
         false,
     ))?;
@@ -1137,7 +1137,7 @@ async fn test_admin_proposal_accepted_in_admin_only_group() {
     let propose_intent =
         alix_db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
             IntentKind::ProposeMemberUpdate,
-            alix_group.group_id.clone(),
+            alix_group.group_id,
             ProposeMemberUpdateIntentData::new(vec![caro.inbox_id().to_string()], vec![])
                 .try_into()?,
             false,
@@ -1428,7 +1428,7 @@ async fn test_non_admin_commits_admin_proposals_in_admin_group() {
     let alix_db = alix_group.context.db();
     let propose_dave = alix_db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
         IntentKind::ProposeMemberUpdate,
-        alix_group.group_id.clone(),
+        alix_group.group_id,
         ProposeMemberUpdateIntentData::new(vec![dave.inbox_id().to_string()], vec![]).try_into()?,
         false,
     ))?;
@@ -1439,7 +1439,7 @@ async fn test_non_admin_commits_admin_proposals_in_admin_group() {
     // Alix (admin) proposes adding Eve
     let propose_eve = alix_db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
         IntentKind::ProposeMemberUpdate,
-        alix_group.group_id.clone(),
+        alix_group.group_id,
         ProposeMemberUpdateIntentData::new(vec![eve.inbox_id().to_string()], vec![]).try_into()?,
         false,
     ))?;
@@ -1467,7 +1467,7 @@ async fn test_non_admin_commits_admin_proposals_in_admin_group() {
     let bo_db = bo_group.context.db();
     let commit_intent = bo_db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
         IntentKind::CommitPendingProposals,
-        bo_group.group_id.clone(),
+        bo_group.group_id,
         CommitPendingProposalsIntentData::default().into(),
         false,
     ))?;
@@ -1556,7 +1556,7 @@ async fn test_multiple_non_admin_proposers_with_admin_committer() {
     let bo_db = bo_group.context.db();
     let bo_propose = bo_db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
         IntentKind::ProposeMemberUpdate,
-        bo_group.group_id.clone(),
+        bo_group.group_id,
         ProposeMemberUpdateIntentData::new(vec![dave.inbox_id().to_string()], vec![]).try_into()?,
         false,
     ))?;
@@ -1566,7 +1566,7 @@ async fn test_multiple_non_admin_proposers_with_admin_committer() {
     let caro_db = caro_group.context.db();
     let caro_propose = caro_db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
         IntentKind::ProposeMemberUpdate,
-        caro_group.group_id.clone(),
+        caro_group.group_id,
         ProposeMemberUpdateIntentData::new(vec![eve.inbox_id().to_string()], vec![]).try_into()?,
         false,
     ))?;
@@ -1595,7 +1595,7 @@ async fn test_multiple_non_admin_proposers_with_admin_committer() {
     let alix_db = alix_group.context.db();
     let commit_intent = alix_db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
         IntentKind::CommitPendingProposals,
-        alix_group.group_id.clone(),
+        alix_group.group_id,
         CommitPendingProposalsIntentData::default().into(),
         false,
     ))?;
@@ -1685,7 +1685,7 @@ async fn test_remove_proposal_validation_in_admin_group() {
     let remove_caro_intent =
         bo_db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
             IntentKind::ProposeMemberUpdate,
-            bo_group.group_id.clone(),
+            bo_group.group_id,
             ProposeMemberUpdateIntentData::new(vec![], vec![caro.inbox_id().to_string()])
                 .try_into()?,
             false,
@@ -1711,7 +1711,7 @@ async fn test_remove_proposal_validation_in_admin_group() {
     let remove_alix_intent =
         bo_db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
             IntentKind::ProposeMemberUpdate,
-            bo_group.group_id.clone(),
+            bo_group.group_id,
             ProposeMemberUpdateIntentData::new(vec![], vec![alix.inbox_id().to_string()])
                 .try_into()?,
             false,
@@ -1774,7 +1774,7 @@ async fn test_admin_proposes_remove_committed_by_non_admin() {
     let alix_db = alix_group.context.db();
     let remove_intent = alix_db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
         IntentKind::ProposeMemberUpdate,
-        alix_group.group_id.clone(),
+        alix_group.group_id,
         ProposeMemberUpdateIntentData::new(vec![], vec![caro.inbox_id().to_string()]).try_into()?,
         false,
     ))?;
@@ -1799,7 +1799,7 @@ async fn test_admin_proposes_remove_committed_by_non_admin() {
     let bo_db = bo_group.context.db();
     let commit_intent = bo_db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
         IntentKind::CommitPendingProposals,
-        bo_group.group_id.clone(),
+        bo_group.group_id,
         CommitPendingProposalsIntentData::new().into(),
         false,
     ))?;
@@ -1881,7 +1881,7 @@ async fn test_non_admin_gce_metadata_proposal_rejected() {
     let bo_db = bo_group.context.db();
     let propose_intent = bo_db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
         IntentKind::ProposeGroupContextExtensions,
-        bo_group.group_id.clone(),
+        bo_group.group_id,
         intent_bytes,
         false,
     ))?;
@@ -1917,7 +1917,7 @@ async fn test_non_admin_gce_metadata_proposal_rejected() {
     let intent_bytes: Vec<u8> = intent_data.into();
     let propose_intent = bo_db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
         IntentKind::ProposeGroupContextExtensions,
-        bo_group.group_id.clone(),
+        bo_group.group_id,
         intent_bytes,
         false,
     ))?;
@@ -1998,7 +1998,7 @@ async fn test_non_admin_gce_admin_list_proposal_rejected() {
     let bo_db = bo_group.context.db();
     let propose_intent = bo_db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
         IntentKind::ProposeGroupContextExtensions,
-        bo_group.group_id.clone(),
+        bo_group.group_id,
         intent_bytes,
         false,
     ))?;
@@ -2037,7 +2037,7 @@ async fn test_non_admin_gce_admin_list_proposal_rejected() {
     let intent_bytes: Vec<u8> = intent_data.into();
     let propose_intent = bo_db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
         IntentKind::ProposeGroupContextExtensions,
-        bo_group.group_id.clone(),
+        bo_group.group_id,
         intent_bytes,
         false,
     ))?;
@@ -2085,7 +2085,7 @@ async fn test_non_admin_gce_admin_list_proposal_rejected() {
     let intent_bytes: Vec<u8> = intent_data.into();
     let propose_intent = bo_db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
         IntentKind::ProposeGroupContextExtensions,
-        bo_group.group_id.clone(),
+        bo_group.group_id,
         intent_bytes,
         false,
     ))?;
@@ -2159,7 +2159,7 @@ async fn test_non_super_admin_gce_permission_change_rejected() {
     let bo_db = bo_group.context.db();
     let propose_intent = bo_db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
         IntentKind::ProposeGroupContextExtensions,
-        bo_group.group_id.clone(),
+        bo_group.group_id,
         intent_bytes,
         false,
     ))?;
@@ -2327,7 +2327,7 @@ async fn test_commit_pending_proposals_batches_gce_and_commit() {
     let bo_db = bo_group.context.db();
     let propose_intent = bo_db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
         IntentKind::ProposeMemberUpdate,
-        bo_group.group_id.clone(),
+        bo_group.group_id,
         ProposeMemberUpdateIntentData::new(vec![caro.inbox_id().to_string()], vec![]).try_into()?,
         false,
     ))?;
@@ -2350,7 +2350,7 @@ async fn test_commit_pending_proposals_batches_gce_and_commit() {
     let alix_db = alix_group.context.db();
     let commit_intent = alix_db.insert_group_intent(xmtp_db::group_intent::NewGroupIntent::new(
         IntentKind::CommitPendingProposals,
-        alix_group.group_id.clone(),
+        alix_group.group_id,
         CommitPendingProposalsIntentData::default().into(),
         false,
     ))?;

--- a/crates/xmtp_mls/src/groups/tests/test_welcome_pointers.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_welcome_pointers.rs
@@ -138,7 +138,7 @@ async fn test_welcome_pointer_round_trip(
 
     // Create a group with alix as the creator
     let alix_group = alix.create_group(None, None).unwrap();
-    tracing::info!("Alix group id: {}", hex::encode(&alix_group.group_id));
+    tracing::info!("Alix group id: {}", hex::encode(alix_group.group_id));
     alix_group.sync().await.unwrap();
 
     // Add bola to the group - this should trigger welcome message creation
@@ -647,7 +647,7 @@ async fn test_welcome_pointer_task_retry_resolution() {
         .unwrap();
     match event {
         crate::subscriptions::LocalEvents::NewGroup(id) => {
-            assert_eq!(id, group.group_id.clone());
+            assert_eq!(id, group.group_id);
         }
         e => panic!("Expected NewGroup event, got {:?}", e),
     }

--- a/crates/xmtp_mls/src/groups/tests/test_welcomes.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_welcomes.rs
@@ -36,7 +36,7 @@ async fn test_welcome_cursor() {
 
     alix2.sync_welcomes().await?;
     let alix2_refresh_state = alix2.context.db().latest_cursor_for_id(
-        &group.group_id,
+        group.group_id,
         &[EntityKind::CommitMessage],
         None,
     )?;
@@ -46,14 +46,13 @@ async fn test_welcome_cursor() {
 }
 
 #[track_caller]
-fn assert_cursors(db: &impl DbQuery, db2: &impl DbQuery, group_id: &[u8]) {
-    let group_id_typed = GroupId::from(group_id);
+fn assert_cursors(db: &impl DbQuery, db2: &impl DbQuery, group_id: &GroupId) {
     let msg = db
-        .get_group_messages(&group_id_typed, &Default::default())
+        .get_group_messages(group_id, &Default::default())
         .unwrap();
     let msg = msg.last().unwrap();
     let cursor = db
-        .get_last_cursor_for_ids(&[&group_id], &[EntityKind::CommitMessage])
+        .get_last_cursor_for_ids(&[group_id.as_slice()], &[EntityKind::CommitMessage])
         .unwrap()
         .values()
         .next()
@@ -67,7 +66,7 @@ fn assert_cursors(db: &impl DbQuery, db2: &impl DbQuery, group_id: &[u8]) {
     );
 
     let other_msg = db2
-        .get_group_messages(&group_id_typed, &Default::default())
+        .get_group_messages(group_id, &Default::default())
         .unwrap();
     let other_msg = other_msg.last().unwrap();
     assert_eq!(
@@ -76,7 +75,7 @@ fn assert_cursors(db: &impl DbQuery, db2: &impl DbQuery, group_id: &[u8]) {
         "GroupMessage must equal group message of db2"
     );
     let other_cursor = db2
-        .get_last_cursor_for_ids(&[&group_id], &[EntityKind::CommitMessage])
+        .get_last_cursor_for_ids(&[group_id.as_slice()], &[EntityKind::CommitMessage])
         .unwrap()
         .values()
         .next()

--- a/crates/xmtp_mls/src/groups/validated_commit.rs
+++ b/crates/xmtp_mls/src/groups/validated_commit.rs
@@ -38,6 +38,7 @@ use xmtp_mls_common::{
         find_mutable_metadata_extension,
     },
 };
+use xmtp_proto::types::GroupId;
 use xmtp_proto::xmtp::{
     identity::MlsCredential,
     mls::message_contents::{
@@ -119,6 +120,8 @@ pub enum CommitValidationError {
     /// surface from being dominated by migration-specific noise.
     #[error(transparent)]
     Bootstrap(#[from] super::app_data::bootstrap_validator::BootstrapValidationError),
+    #[error(transparent)]
+    Conversion(#[from] xmtp_proto::ConversionError),
 }
 
 impl RetryableError for CommitValidationError {
@@ -967,9 +970,10 @@ impl ExpectedDiff {
 
         reject_psk_proposals(staged_commit)?;
 
+        let group_id = GroupId::try_from(openmls_group.group_id())?;
         let expected_diff = Self::extract_expected_diff_with_proposers(
             context,
-            openmls_group.group_id().as_slice(),
+            &group_id,
             staged_commit,
             extensions,
             &immutable_metadata,
@@ -989,7 +993,7 @@ impl ExpectedDiff {
     #[allow(clippy::too_many_arguments)]
     async fn extract_expected_diff_with_proposers(
         context: &impl XmtpSharedContext,
-        group_id: &[u8], // used for logging
+        group_id: &GroupId, // used for logging
         staged_commit: &StagedCommit,
         existing_group_extensions: &Extensions<GroupContext>,
         immutable_metadata: &GroupMetadata,

--- a/crates/xmtp_mls/src/groups/welcome_sync.rs
+++ b/crates/xmtp_mls/src/groups/welcome_sync.rs
@@ -207,10 +207,7 @@ where
         let db = self.context.db();
         let api = self.context.api();
 
-        let group_ids: Vec<GroupId> = groups
-            .iter()
-            .map(|group| GroupId::from(group.group_id.as_slice()))
-            .collect();
+        let group_ids: Vec<GroupId> = groups.iter().map(|group| group.group_id).collect();
         let id_slices: Vec<&[u8]> = group_ids.iter().map(|id| id.as_ref()).collect();
         let last_synced_cursors = db.get_last_cursor_for_ids(
             &id_slices,
@@ -763,7 +760,7 @@ mod tests {
     }
 
     fn make_message_metadata(
-        group_id: Vec<u8>,
+        group_id: GroupId,
         originator_id: u32,
         sequence_id: u64,
     ) -> GroupMessageMetadata {
@@ -778,59 +775,59 @@ mod tests {
 
     #[xmtp_common::test]
     fn filter_groups_with_new_messages_basic_behavior() {
-        let group_id_1 = vec![1, 2, 3];
-        let group_id_2 = vec![4, 5, 6];
+        let group_id_1 = GroupId::from([0x01u8; 16]);
+        let group_id_2 = GroupId::from([0x02u8; 16]);
         let originator = 100;
 
         let mut last_synced = HashMap::new();
-        last_synced.insert(group_id_1.clone(), make_cursor(originator, 5));
-        last_synced.insert(group_id_2.clone(), make_cursor(originator, 10));
+        last_synced.insert(group_id_1.to_vec(), make_cursor(originator, 5));
+        last_synced.insert(group_id_2.to_vec(), make_cursor(originator, 10));
 
         let mut latest = HashMap::new();
         latest.insert(
-            group_id_1.clone().into(),
-            make_message_metadata(group_id_1.clone(), originator, 10), // New: 10 > 5
+            group_id_1,
+            make_message_metadata(group_id_1, originator, 10), // New: 10 > 5
         );
         latest.insert(
-            group_id_2.clone().into(),
-            make_message_metadata(group_id_2.clone(), originator, 8), // No new: 8 < 10
+            group_id_2,
+            make_message_metadata(group_id_2, originator, 8), // No new: 8 < 10
         );
 
         let result = filter_groups_with_new_messages(last_synced, latest);
 
         assert_eq!(result.len(), 1);
-        assert!(result.contains(&GroupId::from(group_id_1.as_slice())));
+        assert!(result.contains(&group_id_1));
     }
 
     #[xmtp_common::test]
     fn filter_groups_includes_never_synced_and_excludes_up_to_date() {
-        let group_synced = vec![1, 2, 3];
-        let group_never_synced = vec![4, 5, 6];
+        let group_synced = GroupId::from([0x01u8; 16]);
+        let group_never_synced = GroupId::from([0x02u8; 16]);
         let originator = 100;
 
         let mut last_synced = HashMap::new();
-        last_synced.insert(group_synced.clone(), make_cursor(originator, 5));
+        last_synced.insert(group_synced.to_vec(), make_cursor(originator, 5));
         // group_never_synced has no entry
 
         let mut latest = HashMap::new();
         latest.insert(
-            group_synced.clone().into(),
-            make_message_metadata(group_synced.clone(), originator, 3), // Already synced
+            group_synced,
+            make_message_metadata(group_synced, originator, 3), // Already synced
         );
         latest.insert(
-            group_never_synced.clone().into(),
-            make_message_metadata(group_never_synced.clone(), originator, 1),
+            group_never_synced,
+            make_message_metadata(group_never_synced, originator, 1),
         );
 
         let result = filter_groups_with_new_messages(last_synced, latest);
 
         assert_eq!(result.len(), 1);
-        assert!(result.contains(&GroupId::from(group_never_synced.as_slice())));
+        assert!(result.contains(&group_never_synced));
     }
 
     #[xmtp_common::test]
     fn filter_groups_handles_multiple_originators() {
-        let group_id = vec![1, 2, 3];
+        let group_id = GroupId::from([0x01u8; 16]);
         let orig_1 = 100;
         let orig_2 = 200;
 
@@ -838,37 +835,37 @@ mod tests {
         let mut cursor_map = GlobalCursor::default();
         cursor_map.insert(orig_1, 10);
         cursor_map.insert(orig_2, 20);
-        last_synced.insert(group_id.clone(), cursor_map);
+        last_synced.insert(group_id.to_vec(), cursor_map);
 
         let mut latest = HashMap::new();
         latest.insert(
-            group_id.clone().into(),
-            make_message_metadata(group_id.clone(), orig_2, 25), // New from orig_2
+            group_id,
+            make_message_metadata(group_id, orig_2, 25), // New from orig_2
         );
 
         let result = filter_groups_with_new_messages(last_synced, latest);
 
         assert_eq!(result.len(), 1);
-        assert!(result.contains(&GroupId::from(group_id.as_slice())));
+        assert!(result.contains(&group_id));
     }
 
     #[xmtp_common::test]
     fn filter_groups_treats_unknown_originator_as_new() {
-        let group_id = vec![1, 2, 3];
+        let group_id = GroupId::from([0x01u8; 16]);
 
         let mut last_synced = HashMap::new();
-        last_synced.insert(group_id.clone(), make_cursor(100, 10));
+        last_synced.insert(group_id.to_vec(), make_cursor(100, 10));
 
         let mut latest = HashMap::new();
         latest.insert(
-            group_id.clone().into(),
-            make_message_metadata(group_id.clone(), 200, 5), // Unknown originator defaults to 0
+            group_id,
+            make_message_metadata(group_id, 200, 5), // Unknown originator defaults to 0
         );
 
         let result = filter_groups_with_new_messages(last_synced, latest);
 
         assert_eq!(result.len(), 1);
-        assert!(result.contains(&GroupId::from(group_id.as_slice())));
+        assert!(result.contains(&group_id));
     }
 
     // I have no idea why this test is specifically failing on WASM
@@ -877,11 +874,12 @@ mod tests {
     #[case(HashMap::new(), HashMap::new())] // Empty inputs
     #[case({
         let mut m = HashMap::new();
-        m.insert(vec![1], make_cursor(100, 10));
+        m.insert(GroupId::from([0x01u8; 16]).to_vec(), make_cursor(100, 10));
         m
     }, {
         let mut m = HashMap::new();
-        m.insert(vec![1].into(), make_message_metadata(vec![1], 100, 10));
+        let gid = GroupId::from([0x01u8; 16]);
+        m.insert(gid, make_message_metadata(gid, 100, 10));
         m
     })] // Equal cursors
     #[xmtp_common::test]
@@ -895,40 +893,28 @@ mod tests {
 
     #[xmtp_common::test]
     fn filter_groups_comprehensive_mixed_states() {
-        let g1 = vec![1];
-        let g2 = vec![2];
-        let g3 = vec![3];
-        let g4 = vec![4];
+        let g1 = GroupId::from([0x01u8; 16]);
+        let g2 = GroupId::from([0x02u8; 16]);
+        let g3 = GroupId::from([0x03u8; 16]);
+        let g4 = GroupId::from([0x04u8; 16]);
         let orig = 100;
 
         let mut last_synced = HashMap::new();
-        last_synced.insert(g1.clone(), make_cursor(orig, 5)); // Will have new
-        last_synced.insert(g2.clone(), make_cursor(orig, 15)); // Already synced
-        last_synced.insert(g3.clone(), make_cursor(orig, 10)); // Equal
+        last_synced.insert(g1.to_vec(), make_cursor(orig, 5)); // Will have new
+        last_synced.insert(g2.to_vec(), make_cursor(orig, 15)); // Already synced
+        last_synced.insert(g3.to_vec(), make_cursor(orig, 10)); // Equal
         // g4 never synced
 
         let mut latest = HashMap::new();
-        latest.insert(
-            g1.clone().into(),
-            make_message_metadata(g1.clone(), orig, 10),
-        );
-        latest.insert(
-            g2.clone().into(),
-            make_message_metadata(g2.clone(), orig, 12),
-        );
-        latest.insert(
-            g3.clone().into(),
-            make_message_metadata(g3.clone(), orig, 10),
-        );
-        latest.insert(
-            g4.clone().into(),
-            make_message_metadata(g4.clone(), orig, 1),
-        );
+        latest.insert(g1, make_message_metadata(g1, orig, 10));
+        latest.insert(g2, make_message_metadata(g2, orig, 12));
+        latest.insert(g3, make_message_metadata(g3, orig, 10));
+        latest.insert(g4, make_message_metadata(g4, orig, 1));
 
         let result = filter_groups_with_new_messages(last_synced, latest);
 
         assert_eq!(result.len(), 2);
-        assert!(result.contains(&GroupId::from(g1.as_slice())));
-        assert!(result.contains(&GroupId::from(g4.as_slice())));
+        assert!(result.contains(&g1));
+        assert!(result.contains(&g4));
     }
 }

--- a/crates/xmtp_mls/src/groups/welcomes/xmtp_welcome.rs
+++ b/crates/xmtp_mls/src/groups/welcomes/xmtp_welcome.rs
@@ -206,15 +206,12 @@ where
         self.validator
             .check_initial_membership(staged_welcome)
             .await?;
-        let group_id = staged_welcome.public_group().group_id();
+        let group_id = GroupId::try_from(staged_welcome.public_group().group_id())?;
         // try to load the group this welcome represents
         // defensive to avoid race conditions & duplicates
-        if db
-            .find_group(&GroupId::from(group_id.as_slice()))?
-            .is_some()
-        {
+        if db.find_group(&group_id)?.is_some() {
             // Fetch the original MLS group, rather than the one from the welcome
-            let result = MlsGroup::new_cached(self.context.clone(), group_id.as_slice());
+            let result = MlsGroup::new_cached(self.context.clone(), &group_id);
             if let Ok((group, _)) = result {
                 // Check the group epoch as well, because we may not have synced the latest is_active state
                 // TODO(rich): Design a better way to detect if incoming welcomes are valid
@@ -338,8 +335,8 @@ where
         }
 
         // Extract group_id before consuming staged_welcome
-        let group_id = staged_welcome.public_group().group_id().to_vec();
-        let existing_group = db.find_group(&GroupId::from(group_id.as_slice()))?;
+        let group_id = GroupId::try_from(staged_welcome.public_group().group_id())?;
+        let existing_group = db.find_group(&group_id)?;
 
         // Check if this is a re-add scenario:
         // - Self-removal (PendingRemove): user left voluntarily, then gets re-added
@@ -384,7 +381,7 @@ where
                 // distinguish "legitimately old group" from "fresh
                 // welcome that should have had GMM" when triaging.
                 tracing::debug!(
-                    group_id = hex::encode(&group_id),
+                    group_id = hex::encode(group_id),
                     "welcome carries no legacy GroupMutableMetadata extension; \
                      disappearing-settings and paused_for_version fall back to defaults"
                 );
@@ -397,7 +394,7 @@ where
                 // — the welcome still completes with default settings
                 // rather than failing the join.
                 tracing::warn!(
-                    group_id = hex::encode(&group_id),
+                    group_id = hex::encode(group_id),
                     error = ?e,
                     "welcome-time GroupMutableMetadata read failed; \
                      disappearing-settings and paused_for_version will fall back to defaults"
@@ -422,7 +419,7 @@ where
                         Group ID: {}, \
                         Required version: {}, \
                         Current version: {}",
-                        hex::encode(group_id.clone()),
+                        hex::encode(group_id),
                         min_version,
                         current_version_str
                     );
@@ -440,13 +437,13 @@ where
         // Otherwise, new members start in PENDING state
         let membership_state = if is_readd_after_leaving {
             tracing::info!(
-                group_id = hex::encode(&group_id),
+                group_id = hex::encode(group_id),
                 "User is being re-added after leaving/removal, setting membership state to ALLOWED"
             );
             GroupMembershipState::Allowed
         } else {
             tracing::debug!(
-                group_id = hex::encode(&group_id),
+                group_id = hex::encode(group_id),
                 "User is being added to new group, setting membership state to PENDING"
             );
             GroupMembershipState::Pending
@@ -501,10 +498,10 @@ where
         // before calling insert_or_replace_group
         if is_readd_after_leaving && let Some(ref existing) = existing_group {
             tracing::info!(
-                group_id = hex::encode(&existing.id),
+                group_id = hex::encode(existing.id),
                 "Updating existing group membership state from PENDING_REMOVE to ALLOWED"
             );
-            db.update_group_membership(&existing.id, GroupMembershipState::Allowed)?;
+            db.update_group_membership(existing.id, GroupMembershipState::Allowed)?;
         }
 
         // Insert or replace the group in the database.
@@ -534,7 +531,7 @@ where
         encoded_added_payload.encode(&mut encoded_added_payload_bytes)?;
 
         let added_message_id = crate::utils::id::calculate_message_id(
-            &stored_group.id,
+            stored_group.id,
             encoded_added_payload_bytes.as_slice(),
             &format!("{}_welcome_added", welcome.created_ns),
         );
@@ -556,7 +553,7 @@ where
         // this is the commit that brought us into the group
         let added_msg = StoredGroupMessage {
             id: added_message_id,
-            group_id: stored_group.id.clone(),
+            group_id: stored_group.id,
             decrypted_message_bytes: encoded_added_payload_bytes,
             sent_at_ns: welcome.timestamp(),
             kind: GroupMessageKind::MembershipChange,
@@ -597,14 +594,14 @@ where
             // If user is being re-added after leaving, reset consent to Unknown
             // This requires the user to explicitly accept being added back
             tracing::info!(
-                group_id = hex::encode(&group.group_id),
+                group_id = hex::encode(group.group_id),
                 "Resetting consent state to Unknown for re-added user"
             );
             group.quietly_update_consent_state(ConsentState::Unknown, &db)?;
         }
 
         db.update_cursor(
-            &group.group_id,
+            group.group_id,
             EntityKind::CommitMessage,
             //TODO:d14n this must change before D14n-only
             //Originator must be included in welcome
@@ -620,7 +617,7 @@ where
         tracing::info!(
             inbox_id = %current_inbox_id,
             installation_id = %self.context.installation_id(),
-            group_id = %hex::encode(&group.group_id),
+            group_id = %hex::encode(group.group_id),
             welcome_id = welcome.cursor.sequence_id,
             originator_id = welcome.cursor.originator_id,
             cursor = cursor,

--- a/crates/xmtp_mls/src/groups/welcomes/xmtp_welcome.rs
+++ b/crates/xmtp_mls/src/groups/welcomes/xmtp_welcome.rs
@@ -381,7 +381,7 @@ where
                 // distinguish "legitimately old group" from "fresh
                 // welcome that should have had GMM" when triaging.
                 tracing::debug!(
-                    group_id = hex::encode(group_id),
+                    group_id = %group_id,
                     "welcome carries no legacy GroupMutableMetadata extension; \
                      disappearing-settings and paused_for_version fall back to defaults"
                 );
@@ -394,7 +394,7 @@ where
                 // — the welcome still completes with default settings
                 // rather than failing the join.
                 tracing::warn!(
-                    group_id = hex::encode(group_id),
+                    group_id = %group_id,
                     error = ?e,
                     "welcome-time GroupMutableMetadata read failed; \
                      disappearing-settings and paused_for_version will fall back to defaults"
@@ -437,13 +437,13 @@ where
         // Otherwise, new members start in PENDING state
         let membership_state = if is_readd_after_leaving {
             tracing::info!(
-                group_id = hex::encode(group_id),
+                group_id = %group_id,
                 "User is being re-added after leaving/removal, setting membership state to ALLOWED"
             );
             GroupMembershipState::Allowed
         } else {
             tracing::debug!(
-                group_id = hex::encode(group_id),
+                group_id = %group_id,
                 "User is being added to new group, setting membership state to PENDING"
             );
             GroupMembershipState::Pending
@@ -498,7 +498,7 @@ where
         // before calling insert_or_replace_group
         if is_readd_after_leaving && let Some(ref existing) = existing_group {
             tracing::info!(
-                group_id = hex::encode(existing.id),
+                group_id = %existing.id,
                 "Updating existing group membership state from PENDING_REMOVE to ALLOWED"
             );
             db.update_group_membership(existing.id, GroupMembershipState::Allowed)?;
@@ -594,7 +594,7 @@ where
             // If user is being re-added after leaving, reset consent to Unknown
             // This requires the user to explicitly accept being added back
             tracing::info!(
-                group_id = hex::encode(group.group_id),
+                group_id = %group.group_id,
                 "Resetting consent state to Unknown for re-added user"
             );
             group.quietly_update_consent_state(ConsentState::Unknown, &db)?;
@@ -617,7 +617,7 @@ where
         tracing::info!(
             inbox_id = %current_inbox_id,
             installation_id = %self.context.installation_id(),
-            group_id = %hex::encode(group.group_id),
+            group_id = %group.group_id,
             welcome_id = welcome.cursor.sequence_id,
             originator_id = welcome.cursor.originator_id,
             cursor = cursor,

--- a/crates/xmtp_mls/src/identity_updates.rs
+++ b/crates/xmtp_mls/src/identity_updates.rs
@@ -33,6 +33,7 @@ use xmtp_macro::log_event;
 use xmtp_proto::{
     ShortHex,
     api_client::{XmtpIdentityClient, XmtpMlsClient},
+    types::GroupId,
 };
 
 use xmtp_api::{ApiClientWrapper, GetIdentityUpdatesV2Filter};
@@ -488,7 +489,7 @@ where
     pub async fn get_installation_diff(
         &self,
         conn: &impl DbQuery,
-        group_id: &[u8], // used for logging
+        group_id: &GroupId, // used for logging
         old_group_membership: &GroupMembership,
         new_group_membership: &GroupMembership,
         membership_diff: &MembershipDiff<'_>,
@@ -736,6 +737,7 @@ pub(crate) mod tests {
         ConnectionExt, db_connection::DbConnection, identity_update::StoredIdentityUpdate,
         prelude::*,
     };
+    use xmtp_proto::types::GroupId;
 
     use xmtp_common::rand_vec;
 
@@ -1088,7 +1090,7 @@ pub(crate) mod tests {
             .identity_updates()
             .get_installation_diff(
                 &other_conn,
-                &[],
+                &GroupId::default(),
                 &original_group_membership,
                 &new_group_membership,
                 &membership_diff,

--- a/crates/xmtp_mls/src/intents.rs
+++ b/crates/xmtp_mls/src/intents.rs
@@ -16,7 +16,7 @@ use crate::groups::summary::MessageIdentifier;
 
 #[derive(Debug, Error)]
 pub enum ProcessIntentError {
-    #[error("message with cursor [{}] for group [{}] already processed", _0.cursor, xmtp_common::fmt::debug_hex(&_0.group_id))]
+    #[error("message with cursor [{}] for group [{}] already processed", _0.cursor, xmtp_common::fmt::debug_hex(_0.group_id))]
     MessageAlreadyProcessed(MessageIdentifier),
     #[error("welcome with cursor [{0}] already processed")]
     WelcomeAlreadyProcessed(Cursor),

--- a/crates/xmtp_mls/src/messages/enrichment.rs
+++ b/crates/xmtp_mls/src/messages/enrichment.rs
@@ -59,13 +59,13 @@ type DeletionMap = HashMap<Vec<u8>, StoredMessageDeletion>;
 pub(crate) fn is_deletion_valid(
     deletion: &StoredMessageDeletion,
     message: &StoredGroupMessage,
-    group_id: &[u8],
+    group_id: &GroupId,
 ) -> bool {
     if deletion.deleted_message_id != message.id {
         return false;
     }
 
-    if deletion.group_id.as_slice() != group_id || message.group_id.as_slice() != group_id {
+    if deletion.group_id != *group_id || message.group_id != *group_id {
         return false;
     }
 
@@ -79,7 +79,7 @@ pub(crate) fn is_deletion_valid(
 
 pub fn enrich_messages(
     conn: impl DbQuery,
-    group_id: &[u8],
+    group_id: &GroupId,
     messages: Vec<StoredGroupMessage>,
 ) -> Result<Vec<DecodedMessage>, EnrichMessageError> {
     let initial_message_ids: Vec<&[u8]> = messages.iter().map(|m| m.id.as_ref()).collect();
@@ -171,7 +171,7 @@ pub fn enrich_messages(
 
 fn get_relations(
     conn: impl DbQuery,
-    group_id: &[u8],
+    group_id: &GroupId,
     message_ids: &[&[u8]],
     reference_ids: &[&[u8]],
 ) -> Result<GetRelationsResults, EnrichMessageError> {
@@ -194,12 +194,10 @@ fn get_relations(
         .build()
         .unwrap_or_default();
 
-    let group_id_typed = GroupId::from(group_id);
-    let reactions =
-        conn.get_inbound_relations(&group_id_typed, message_ids, reactions_relations_query)?;
-    let referenced_messages = conn.get_outbound_relations(&group_id_typed, reference_ids)?;
+    let reactions = conn.get_inbound_relations(group_id, message_ids, reactions_relations_query)?;
+    let referenced_messages = conn.get_outbound_relations(group_id, reference_ids)?;
     let reply_counts =
-        conn.get_inbound_relation_counts(&group_id_typed, message_ids, replies_count_query)?;
+        conn.get_inbound_relation_counts(group_id, message_ids, replies_count_query)?;
 
     // Get deletions for all messages AND referenced messages in a single batch query.
     // This ensures that if a reply references a deleted message, we can properly show

--- a/crates/xmtp_mls/src/messages/tests/test_deletion_validation.rs
+++ b/crates/xmtp_mls/src/messages/tests/test_deletion_validation.rs
@@ -3,18 +3,19 @@
 use crate::messages::enrichment::is_deletion_valid;
 use xmtp_db::group_message::{ContentType, DeliveryStatus, GroupMessageKind, StoredGroupMessage};
 use xmtp_db::message_deletion::StoredMessageDeletion;
+use xmtp_proto::types::GroupId;
 
 /// Create a test message with the given parameters
 fn create_test_message(
     id: Vec<u8>,
-    group_id: Vec<u8>,
+    group_id: GroupId,
     sender_inbox_id: &str,
     content_type: ContentType,
     kind: GroupMessageKind,
 ) -> StoredGroupMessage {
     StoredGroupMessage {
         id,
-        group_id: group_id.into(),
+        group_id,
         decrypted_message_bytes: vec![],
         sent_at_ns: 1000,
         kind,
@@ -37,14 +38,14 @@ fn create_test_message(
 /// Create a test deletion record
 fn create_test_deletion(
     id: Vec<u8>,
-    group_id: Vec<u8>,
+    group_id: GroupId,
     deleted_message_id: Vec<u8>,
     deleted_by_inbox_id: &str,
     is_super_admin: bool,
 ) -> StoredMessageDeletion {
     StoredMessageDeletion {
         id,
-        group_id: group_id.into(),
+        group_id,
         deleted_message_id,
         deleted_by_inbox_id: deleted_by_inbox_id.to_string(),
         is_super_admin_deletion: is_super_admin,
@@ -54,13 +55,13 @@ fn create_test_deletion(
 
 #[test]
 fn test_valid_deletion_by_sender() {
-    let group_id = vec![1, 2, 3];
+    let group_id = GroupId::from([0x01u8; 16]);
     let message_id = vec![4, 5, 6];
     let sender = "sender_inbox";
 
     let message = create_test_message(
         message_id.clone(),
-        group_id.clone(),
+        group_id,
         sender,
         ContentType::Text,
         GroupMessageKind::Application,
@@ -68,7 +69,7 @@ fn test_valid_deletion_by_sender() {
 
     let deletion = create_test_deletion(
         vec![7, 8, 9],
-        group_id.clone(),
+        group_id,
         message_id.clone(),
         sender, // Same sender deleting their own message
         false,
@@ -79,12 +80,12 @@ fn test_valid_deletion_by_sender() {
 
 #[test]
 fn test_valid_deletion_by_super_admin() {
-    let group_id = vec![1, 2, 3];
+    let group_id = GroupId::from([0x01u8; 16]);
     let message_id = vec![4, 5, 6];
 
     let message = create_test_message(
         message_id.clone(),
-        group_id.clone(),
+        group_id,
         "original_sender",
         ContentType::Text,
         GroupMessageKind::Application,
@@ -92,7 +93,7 @@ fn test_valid_deletion_by_super_admin() {
 
     let deletion = create_test_deletion(
         vec![7, 8, 9],
-        group_id.clone(),
+        group_id,
         message_id.clone(),
         "admin_inbox", // Different person, but is super admin
         true,
@@ -103,12 +104,12 @@ fn test_valid_deletion_by_super_admin() {
 
 #[test]
 fn test_invalid_deletion_unauthorized() {
-    let group_id = vec![1, 2, 3];
+    let group_id = GroupId::from([0x01u8; 16]);
     let message_id = vec![4, 5, 6];
 
     let message = create_test_message(
         message_id.clone(),
-        group_id.clone(),
+        group_id,
         "original_sender",
         ContentType::Text,
         GroupMessageKind::Application,
@@ -116,7 +117,7 @@ fn test_invalid_deletion_unauthorized() {
 
     let deletion = create_test_deletion(
         vec![7, 8, 9],
-        group_id.clone(),
+        group_id,
         message_id.clone(),
         "random_user", // Not the sender
         false,         // Not a super admin
@@ -127,14 +128,14 @@ fn test_invalid_deletion_unauthorized() {
 
 #[test]
 fn test_invalid_deletion_message_id_mismatch() {
-    let group_id = vec![1, 2, 3];
+    let group_id = GroupId::from([0x01u8; 16]);
     let message_id = vec![4, 5, 6];
     let wrong_message_id = vec![10, 11, 12];
     let sender = "sender_inbox";
 
     let message = create_test_message(
         message_id.clone(),
-        group_id.clone(),
+        group_id,
         sender,
         ContentType::Text,
         GroupMessageKind::Application,
@@ -143,7 +144,7 @@ fn test_invalid_deletion_message_id_mismatch() {
     // Deletion targets a different message than the one we're checking
     let deletion = create_test_deletion(
         vec![7, 8, 9],
-        group_id.clone(),
+        group_id,
         wrong_message_id, // Wrong message ID
         sender,
         false,
@@ -154,14 +155,14 @@ fn test_invalid_deletion_message_id_mismatch() {
 
 #[test]
 fn test_invalid_deletion_cross_group_deletion_group_mismatch() {
-    let group_id = vec![1, 2, 3];
-    let other_group_id = vec![10, 11, 12];
+    let group_id = GroupId::from([0x01u8; 16]);
+    let other_group_id = GroupId::from([0x0au8; 16]);
     let message_id = vec![4, 5, 6];
     let sender = "sender_inbox";
 
     let message = create_test_message(
         message_id.clone(),
-        group_id.clone(),
+        group_id,
         sender,
         ContentType::Text,
         GroupMessageKind::Application,
@@ -181,8 +182,8 @@ fn test_invalid_deletion_cross_group_deletion_group_mismatch() {
 
 #[test]
 fn test_invalid_deletion_message_group_mismatch() {
-    let expected_group_id = vec![1, 2, 3];
-    let message_group_id = vec![10, 11, 12];
+    let expected_group_id = GroupId::from([0x01u8; 16]);
+    let message_group_id = GroupId::from([0x0au8; 16]);
     let message_id = vec![4, 5, 6];
     let sender = "sender_inbox";
 
@@ -197,7 +198,7 @@ fn test_invalid_deletion_message_group_mismatch() {
 
     let deletion = create_test_deletion(
         vec![7, 8, 9],
-        expected_group_id.clone(),
+        expected_group_id,
         message_id.clone(),
         sender,
         false,
@@ -208,234 +209,180 @@ fn test_invalid_deletion_message_group_mismatch() {
 
 #[test]
 fn test_invalid_deletion_non_deletable_content_type() {
-    let group_id = vec![1, 2, 3];
+    let group_id = GroupId::from([0x01u8; 16]);
     let message_id = vec![4, 5, 6];
     let sender = "sender_inbox";
 
     // GroupUpdated is not deletable
     let message = create_test_message(
         message_id.clone(),
-        group_id.clone(),
+        group_id,
         sender,
         ContentType::GroupUpdated,
         GroupMessageKind::Application,
     );
 
-    let deletion = create_test_deletion(
-        vec![7, 8, 9],
-        group_id.clone(),
-        message_id.clone(),
-        sender,
-        false,
-    );
+    let deletion = create_test_deletion(vec![7, 8, 9], group_id, message_id.clone(), sender, false);
 
     assert!(!is_deletion_valid(&deletion, &message, &group_id));
 }
 
 #[test]
 fn test_invalid_deletion_non_deletable_message_kind() {
-    let group_id = vec![1, 2, 3];
+    let group_id = GroupId::from([0x01u8; 16]);
     let message_id = vec![4, 5, 6];
     let sender = "sender_inbox";
 
     // MembershipChange kind is not deletable
     let message = create_test_message(
         message_id.clone(),
-        group_id.clone(),
+        group_id,
         sender,
         ContentType::Text,
         GroupMessageKind::MembershipChange,
     );
 
-    let deletion = create_test_deletion(
-        vec![7, 8, 9],
-        group_id.clone(),
-        message_id.clone(),
-        sender,
-        false,
-    );
+    let deletion = create_test_deletion(vec![7, 8, 9], group_id, message_id.clone(), sender, false);
 
     assert!(!is_deletion_valid(&deletion, &message, &group_id));
 }
 
 #[test]
 fn test_invalid_deletion_delete_message_content_type() {
-    let group_id = vec![1, 2, 3];
+    let group_id = GroupId::from([0x01u8; 16]);
     let message_id = vec![4, 5, 6];
     let sender = "sender_inbox";
 
     // DeleteMessage content type should not be deletable
     let message = create_test_message(
         message_id.clone(),
-        group_id.clone(),
+        group_id,
         sender,
         ContentType::DeleteMessage,
         GroupMessageKind::Application,
     );
 
-    let deletion = create_test_deletion(
-        vec![7, 8, 9],
-        group_id.clone(),
-        message_id.clone(),
-        sender,
-        false,
-    );
+    let deletion = create_test_deletion(vec![7, 8, 9], group_id, message_id.clone(), sender, false);
 
     assert!(!is_deletion_valid(&deletion, &message, &group_id));
 }
 
 #[test]
 fn test_invalid_deletion_read_receipt_not_deletable() {
-    let group_id = vec![1, 2, 3];
+    let group_id = GroupId::from([0x01u8; 16]);
     let message_id = vec![4, 5, 6];
     let sender = "sender_inbox";
 
     // ReadReceipt is not deletable
     let message = create_test_message(
         message_id.clone(),
-        group_id.clone(),
+        group_id,
         sender,
         ContentType::ReadReceipt,
         GroupMessageKind::Application,
     );
 
-    let deletion = create_test_deletion(
-        vec![7, 8, 9],
-        group_id.clone(),
-        message_id.clone(),
-        sender,
-        false,
-    );
+    let deletion = create_test_deletion(vec![7, 8, 9], group_id, message_id.clone(), sender, false);
 
     assert!(!is_deletion_valid(&deletion, &message, &group_id));
 }
 
 #[test]
 fn test_invalid_deletion_reaction_not_deletable() {
-    let group_id = vec![1, 2, 3];
+    let group_id = GroupId::from([0x01u8; 16]);
     let message_id = vec![4, 5, 6];
     let sender = "sender_inbox";
 
     // Reaction is not deletable
     let message = create_test_message(
         message_id.clone(),
-        group_id.clone(),
+        group_id,
         sender,
         ContentType::Reaction,
         GroupMessageKind::Application,
     );
 
-    let deletion = create_test_deletion(
-        vec![7, 8, 9],
-        group_id.clone(),
-        message_id.clone(),
-        sender,
-        false,
-    );
+    let deletion = create_test_deletion(vec![7, 8, 9], group_id, message_id.clone(), sender, false);
 
     assert!(!is_deletion_valid(&deletion, &message, &group_id));
 }
 
 #[test]
 fn test_valid_deletion_markdown_content() {
-    let group_id = vec![1, 2, 3];
+    let group_id = GroupId::from([0x01u8; 16]);
     let message_id = vec![4, 5, 6];
     let sender = "sender_inbox";
 
     // Markdown is deletable
     let message = create_test_message(
         message_id.clone(),
-        group_id.clone(),
+        group_id,
         sender,
         ContentType::Markdown,
         GroupMessageKind::Application,
     );
 
-    let deletion = create_test_deletion(
-        vec![7, 8, 9],
-        group_id.clone(),
-        message_id.clone(),
-        sender,
-        false,
-    );
+    let deletion = create_test_deletion(vec![7, 8, 9], group_id, message_id.clone(), sender, false);
 
     assert!(is_deletion_valid(&deletion, &message, &group_id));
 }
 
 #[test]
 fn test_valid_deletion_reply_content() {
-    let group_id = vec![1, 2, 3];
+    let group_id = GroupId::from([0x01u8; 16]);
     let message_id = vec![4, 5, 6];
     let sender = "sender_inbox";
 
     // Reply is deletable
     let message = create_test_message(
         message_id.clone(),
-        group_id.clone(),
+        group_id,
         sender,
         ContentType::Reply,
         GroupMessageKind::Application,
     );
 
-    let deletion = create_test_deletion(
-        vec![7, 8, 9],
-        group_id.clone(),
-        message_id.clone(),
-        sender,
-        false,
-    );
+    let deletion = create_test_deletion(vec![7, 8, 9], group_id, message_id.clone(), sender, false);
 
     assert!(is_deletion_valid(&deletion, &message, &group_id));
 }
 
 #[test]
 fn test_valid_deletion_attachment_content() {
-    let group_id = vec![1, 2, 3];
+    let group_id = GroupId::from([0x01u8; 16]);
     let message_id = vec![4, 5, 6];
     let sender = "sender_inbox";
 
     // Attachment is deletable
     let message = create_test_message(
         message_id.clone(),
-        group_id.clone(),
+        group_id,
         sender,
         ContentType::Attachment,
         GroupMessageKind::Application,
     );
 
-    let deletion = create_test_deletion(
-        vec![7, 8, 9],
-        group_id.clone(),
-        message_id.clone(),
-        sender,
-        false,
-    );
+    let deletion = create_test_deletion(vec![7, 8, 9], group_id, message_id.clone(), sender, false);
 
     assert!(is_deletion_valid(&deletion, &message, &group_id));
 }
 
 #[test]
 fn test_valid_deletion_remote_attachment_content() {
-    let group_id = vec![1, 2, 3];
+    let group_id = GroupId::from([0x01u8; 16]);
     let message_id = vec![4, 5, 6];
     let sender = "sender_inbox";
 
     // RemoteAttachment is deletable
     let message = create_test_message(
         message_id.clone(),
-        group_id.clone(),
+        group_id,
         sender,
         ContentType::RemoteAttachment,
         GroupMessageKind::Application,
     );
 
-    let deletion = create_test_deletion(
-        vec![7, 8, 9],
-        group_id.clone(),
-        message_id.clone(),
-        sender,
-        false,
-    );
+    let deletion = create_test_deletion(vec![7, 8, 9], group_id, message_id.clone(), sender, false);
 
     assert!(is_deletion_valid(&deletion, &message, &group_id));
 }

--- a/crates/xmtp_mls/src/mls_store.rs
+++ b/crates/xmtp_mls/src/mls_store.rs
@@ -75,12 +75,12 @@ where
     /// found in the local database
     pub(crate) async fn query_group_messages(
         &self,
-        group_id: &[u8],
+        group_id: GroupId,
     ) -> Result<Vec<GroupMessage>, MlsStoreError> {
         let messages = self
             .context
             .sync_api()
-            .query_group_messages(group_id.into())
+            .query_group_messages(group_id)
             .await?;
 
         Ok(messages)
@@ -149,9 +149,9 @@ where
     ///
     /// Returns a [`MlsGroup`] if the group exists, or an error if it does not
     ///
-    pub fn group(&self, group_id: &[u8]) -> Result<MlsGroup<Context>, MlsStoreError> {
+    pub fn group(&self, group_id: &GroupId) -> Result<MlsGroup<Context>, MlsStoreError> {
         let conn = self.context.db();
-        let stored_group: Option<StoredGroup> = conn.fetch(&GroupId::from(group_id))?;
+        let stored_group: Option<StoredGroup> = conn.fetch(group_id)?;
         stored_group
             .map(|g| {
                 MlsGroup::new(
@@ -162,7 +162,7 @@ where
                     g.created_at_ns,
                 )
             })
-            .ok_or(NotFound::GroupById(GroupId::from(group_id)))
+            .ok_or(NotFound::GroupById(*group_id))
             .map_err(Into::into)
     }
 }

--- a/crates/xmtp_mls/src/subscriptions/process_message.rs
+++ b/crates/xmtp_mls/src/subscriptions/process_message.rs
@@ -267,10 +267,10 @@ mod tests {
 
     #[rstest]
     #[case(None)]
-    #[case(Some(generate_stored_msg(Cursor::new(55, 0u32), xmtp_proto::types::GroupId::from([0u8; 16]))))]
+    #[case(Some(generate_stored_msg(Cursor::new(55, 0u32), xmtp_proto::types::GroupId::ZERO)))]
     #[xmtp_common::test]
     pub async fn test_cursor_no_sync(#[case] message: Option<StoredGroupMessage>) {
-        let current_message = generate_message(55, &xmtp_proto::types::GroupId::from([0u8; 16]));
+        let current_message = generate_message(55, &xmtp_proto::types::GroupId::ZERO);
         let mock_syncer = MockSync::new();
         let mut mock_db = MockGroupDatabase::new();
         let oid = current_message.originator_id();

--- a/crates/xmtp_mls/src/subscriptions/process_message.rs
+++ b/crates/xmtp_mls/src/subscriptions/process_message.rs
@@ -126,9 +126,9 @@ mod tests {
     pub async fn test_process_returns_correct_cursor(
         #[values(5, 8, 10, 11, 13, 18)] current_message: u64,
     ) {
-        use xmtp_common::rand_vec;
+        use xmtp_common::Generate as _;
 
-        let current_message = generate_message(current_message, &rand_vec::<16>());
+        let current_message = generate_message(current_message, &GroupId::generate());
         let mut mock_syncer = MockSync::new();
         let mut mock_db = MockGroupDatabase::new();
         let oid = current_message.originator_id();
@@ -220,9 +220,9 @@ mod tests {
         use crate::test::mock::{generate_errored_summary_with_group, generate_stored_msg};
 
         let gid = GroupId::generate();
-        let stream_msg = generate_message(10, gid.as_ref());
+        let stream_msg = generate_message(10, &gid);
         let oid = stream_msg.originator_id();
-        let stored_11 = generate_stored_msg(Cursor::new(11, oid), gid.to_vec());
+        let stored_11 = generate_stored_msg(Cursor::new(11, oid), gid);
 
         let mut mock_syncer = MockSync::new();
         let mut mock_db = MockGroupDatabase::new();
@@ -249,10 +249,10 @@ mod tests {
                 GroupMessageProcessingError::InvalidPayload,
             )))
         });
-        let group_bytes = gid.to_vec();
-        mock_syncer.expect_recover().times(1).returning(move |_| {
-            generate_errored_summary_with_group(&group_bytes, &[10, 12], &[11])
-        });
+        mock_syncer
+            .expect_recover()
+            .times(1)
+            .returning(move |_| generate_errored_summary_with_group(&gid, &[10, 12], &[11]));
 
         let processed = MessageProcessor::new(mock_syncer, mock_db)
             .process(stream_msg.clone())
@@ -267,10 +267,10 @@ mod tests {
 
     #[rstest]
     #[case(None)]
-    #[case(Some(generate_stored_msg(Cursor::new(55, 0u32), xmtp_common::rand_vec::<32>())))]
+    #[case(Some(generate_stored_msg(Cursor::new(55, 0u32), xmtp_proto::types::GroupId::from([0u8; 16]))))]
     #[xmtp_common::test]
     pub async fn test_cursor_no_sync(#[case] message: Option<StoredGroupMessage>) {
-        let current_message = generate_message(55, &[0]);
+        let current_message = generate_message(55, &xmtp_proto::types::GroupId::from([0u8; 16]));
         let mock_syncer = MockSync::new();
         let mut mock_db = MockGroupDatabase::new();
         let oid = current_message.originator_id();

--- a/crates/xmtp_mls/src/subscriptions/process_message/factory.rs
+++ b/crates/xmtp_mls/src/subscriptions/process_message/factory.rs
@@ -142,7 +142,7 @@ where
             Err(summary) => {
                 tracing::warn!(
                     inbox_id = self.0.inbox_id(),
-                    group_id = hex::encode(msg.group_id),
+                    group_id = %msg.group_id,
                     cursor_id = %msg.cursor,
                     "recovery sync triggered by streamed message failed",
                 );
@@ -289,7 +289,7 @@ where
                 // This should never occur because we map the error to `ReceiveGroup`
                 // But still exists defensively
                 tracing::error!(
-                    group_id = hex::encode(msg.group_id),
+                    group_id = %msg.group_id,
                     cursor_id = %msg.cursor,
                     err = e.to_string(),
                     "process stream entry {:?}",
@@ -300,7 +300,7 @@ where
             Ok(processed_msg) => {
                 tracing::trace!(
                     cursor_id = %msg.cursor,
-                    group_id = hex::encode(msg.group_id),
+                    group_id = %msg.group_id,
                     "message process in stream success, synced single msg @cursor={},group_id={}",
                     processed_msg.cursor,
                     xmtp_common::fmt::truncate_hex(hex::encode(processed_msg.group_id))

--- a/crates/xmtp_mls/src/subscriptions/process_message/factory.rs
+++ b/crates/xmtp_mls/src/subscriptions/process_message/factory.rs
@@ -14,12 +14,12 @@ use xmtp_common::{Retry, retry_async};
 use xmtp_db::group::ConversationType;
 use xmtp_db::prelude::*;
 use xmtp_db::{StorageError, group_message::StoredGroupMessage, refresh_state::EntityKind};
-use xmtp_proto::types::{Cursor, GlobalCursor};
+use xmtp_proto::types::{Cursor, GlobalCursor, GroupId};
 
 #[cfg_attr(test, mockall::automock)]
 pub trait GroupDatabase {
     /// Get the last cursor for a message
-    fn last_cursor(&self, group_id: &[u8]) -> Result<GlobalCursor, StorageError>;
+    fn last_cursor(&self, group_id: &GroupId) -> Result<GlobalCursor, StorageError>;
     /// get a message from the database
     // not needless, required by mockall
     #[allow(clippy::needless_lifetimes)]
@@ -47,12 +47,12 @@ impl<Context> GroupDatabase for GroupDb<Context>
 where
     Context: XmtpSharedContext,
 {
-    fn last_cursor(&self, group_id: &[u8]) -> Result<GlobalCursor, StorageError> {
+    fn last_cursor(&self, group_id: &GroupId) -> Result<GlobalCursor, StorageError> {
         let mut maps = self
             .0
             .db()
-            .get_last_cursor_for_ids(&[group_id], &MESSAGE_ENTITIES)?;
-        Ok(maps.remove(group_id).unwrap_or_default())
+            .get_last_cursor_for_ids(&[group_id.as_slice()], &MESSAGE_ENTITIES)?;
+        Ok(maps.remove(group_id.as_slice()).unwrap_or_default())
     }
 
     fn msg(
@@ -68,7 +68,7 @@ where
             m.internal_id.clone()
         })
         .map(|id| conn.get_group_message(id))
-        .unwrap_or_else(|| conn.get_group_message_by_timestamp(&msg.group_id, msg.timestamp()))
+        .unwrap_or_else(|| conn.get_group_message_by_timestamp(msg.group_id, msg.timestamp()))
         .map_err(StorageError::from)
     }
 }
@@ -121,7 +121,7 @@ where
     async fn recover(&self, msg: &xmtp_proto::types::GroupMessage) -> SyncSummary {
         let group = MlsGroup::new(
             self.0.clone(),
-            msg.group_id.clone(),
+            msg.group_id,
             None,
             ConversationType::Group,
             msg.timestamp(),
@@ -132,7 +132,7 @@ where
                 tracing::debug!(
                     "recovery sync processed=[{}] messages, group@[{}] now in epoch=[{}] with the first decryptable message @cursor=[{:?}]",
                     summary.process.total(),
-                    xmtp_common::fmt::truncate_hex(hex::encode(&msg.group_id)),
+                    xmtp_common::fmt::truncate_hex(hex::encode(msg.group_id)),
                     epoch,
                     summary.process.first_new()
                 );
@@ -142,7 +142,7 @@ where
             Err(summary) => {
                 tracing::warn!(
                     inbox_id = self.0.inbox_id(),
-                    group_id = hex::encode(&msg.group_id),
+                    group_id = hex::encode(msg.group_id),
                     cursor_id = %msg.cursor,
                     "recovery sync triggered by streamed message failed",
                 );
@@ -289,7 +289,7 @@ where
                 // This should never occur because we map the error to `ReceiveGroup`
                 // But still exists defensively
                 tracing::error!(
-                    group_id = hex::encode(&msg.group_id),
+                    group_id = hex::encode(msg.group_id),
                     cursor_id = %msg.cursor,
                     err = e.to_string(),
                     "process stream entry {:?}",
@@ -300,10 +300,10 @@ where
             Ok(processed_msg) => {
                 tracing::trace!(
                     cursor_id = %msg.cursor,
-                    group_id = hex::encode(&msg.group_id),
+                    group_id = hex::encode(msg.group_id),
                     "message process in stream success, synced single msg @cursor={},group_id={}",
                     processed_msg.cursor,
-                    xmtp_common::fmt::truncate_hex(hex::encode(&processed_msg.group_id))
+                    xmtp_common::fmt::truncate_hex(hex::encode(processed_msg.group_id))
                 );
                 SyncSummary::single(processed_msg)
             }

--- a/crates/xmtp_mls/src/subscriptions/process_welcome.rs
+++ b/crates/xmtp_mls/src/subscriptions/process_welcome.rs
@@ -10,7 +10,7 @@ use xmtp_common::{Retry, retry_async};
 use xmtp_db::{consent_record::ConsentState, group::ConversationType, prelude::*};
 use xmtp_proto::types::OriginatorId;
 use xmtp_proto::types::SequenceId;
-use xmtp_proto::types::{Cursor, GroupId, WelcomeMessage};
+use xmtp_proto::types::{Cursor, WelcomeMessage};
 
 /// Future for processing `WelcomeorGroup`
 pub struct ProcessWelcomeFuture<Context> {
@@ -206,10 +206,7 @@ where
         // Filter out duplicate DMs if not included
         if !self.include_duplicate_dms
             && metadata.conversation_type == ConversationType::Dm
-            && self
-                .context
-                .db()
-                .has_duplicate_dm(&GroupId::from(group.group_id.as_slice()))?
+            && self.context.db().has_duplicate_dm(&group.group_id)?
         {
             tracing::debug!("Duplicate DM group detected. Skipping stream.");
             return Ok(false);
@@ -355,7 +352,7 @@ where
         };
         tracing::info!(
             inbox_id = self.context.inbox_id(),
-            group_id = hex::encode(&group.id),
+            group_id = hex::encode(group.id),
             dm_id = group.dm_id,
             welcome_id = ?group.sequence_id,
             "loading existing group for welcome_id: {:?}",

--- a/crates/xmtp_mls/src/subscriptions/process_welcome.rs
+++ b/crates/xmtp_mls/src/subscriptions/process_welcome.rs
@@ -352,7 +352,7 @@ where
         };
         tracing::info!(
             inbox_id = self.context.inbox_id(),
-            group_id = hex::encode(group.id),
+            group_id = %group.id,
             dm_id = group.dm_id,
             welcome_id = ?group.sequence_id,
             "loading existing group for welcome_id: {:?}",

--- a/crates/xmtp_mls/src/subscriptions/stream_all/tests.rs
+++ b/crates/xmtp_mls/src/subscriptions/stream_all/tests.rs
@@ -318,7 +318,7 @@ async fn test_stream_all_messages_detached_group_changes() {
                         message_id = hex::encode(&msg.id),
                         sender_inbox_id = msg.sender_inbox_id,
                         sender_installation_id = hex::encode(&msg.sender_installation_id),
-                        group_id = hex::encode(msg.group_id),
+                        group_id = %msg.group_id,
                         "GOT MESSAGE {}, text={}",
                         messages.len(),
                         String::from_utf8_lossy(msg.decrypted_message_bytes.as_slice())

--- a/crates/xmtp_mls/src/subscriptions/stream_all/tests.rs
+++ b/crates/xmtp_mls/src/subscriptions/stream_all/tests.rs
@@ -24,7 +24,7 @@ async fn test_stream_all_messages_changing_group_list() {
     let caro = ClientBuilder::new_test_client_vanilla(&caro_wallet).await;
 
     let alix_group = alix.create_group(None, None).unwrap();
-    tracing::info!("Created alix group {}", hex::encode(&alix_group.group_id));
+    tracing::info!("Created alix group {}", hex::encode(alix_group.group_id));
     alix_group.add_members(&[caro.inbox_id()]).await.unwrap();
 
     let stream = caro.stream_all_messages(None, None).await.unwrap();
@@ -299,7 +299,7 @@ async fn test_stream_all_messages_detached_group_changes() {
             new_group.add_members(&[caro]).await.unwrap();
             tracing::info!(
                 "\n\n HALE SENDING {i} to group {}\n\n",
-                hex::encode(&new_group.group_id)
+                hex::encode(new_group.group_id)
             );
             new_group
                 .send_message(b"spam from new group", SendMessageOpts::default())
@@ -318,7 +318,7 @@ async fn test_stream_all_messages_detached_group_changes() {
                         message_id = hex::encode(&msg.id),
                         sender_inbox_id = msg.sender_inbox_id,
                         sender_installation_id = hex::encode(&msg.sender_installation_id),
-                        group_id = hex::encode(&msg.group_id),
+                        group_id = hex::encode(msg.group_id),
                         "GOT MESSAGE {}, text={}",
                         messages.len(),
                         String::from_utf8_lossy(msg.decrypted_message_bytes.as_slice())

--- a/crates/xmtp_mls/src/subscriptions/stream_conversations.rs
+++ b/crates/xmtp_mls/src/subscriptions/stream_conversations.rs
@@ -391,9 +391,9 @@ where
                 id: welcome_id,
             }) => {
                 tracing::debug!(
-                    group_id = hex::encode(&group.group_id),
+                    group_id = hex::encode(group.group_id),
                     "finished processing with group {}",
-                    hex::encode(&group.group_id)
+                    hex::encode(group.group_id)
                 );
                 this.known_welcome_ids.insert(welcome_id);
                 Some(Ok(group))
@@ -414,9 +414,9 @@ where
                 maybe_originator,
             }) => {
                 tracing::debug!(
-                    group_id = hex::encode(&group.group_id),
+                    group_id = hex::encode(group.group_id),
                     "finished processing with group {}",
-                    hex::encode(&group.group_id)
+                    hex::encode(group.group_id)
                 );
                 if let Some(id) = maybe_sequence_id
                     && let Some(originator) = maybe_originator
@@ -463,7 +463,7 @@ mod test {
             .unwrap();
         for _ in 0..group_size {
             let alix_bo_group = alix.create_group(None, None).unwrap();
-            groups.push(alix_bo_group.group_id.clone());
+            groups.push(alix_bo_group.group_id);
             alix_bo_group.add_members(&[bo.inbox_id()]).await.unwrap();
         }
         while !groups.is_empty() {

--- a/crates/xmtp_mls/src/subscriptions/stream_conversations.rs
+++ b/crates/xmtp_mls/src/subscriptions/stream_conversations.rs
@@ -391,7 +391,7 @@ where
                 id: welcome_id,
             }) => {
                 tracing::debug!(
-                    group_id = hex::encode(group.group_id),
+                    group_id = %group.group_id,
                     "finished processing with group {}",
                     hex::encode(group.group_id)
                 );
@@ -414,7 +414,7 @@ where
                 maybe_originator,
             }) => {
                 tracing::debug!(
-                    group_id = hex::encode(group.group_id),
+                    group_id = %group.group_id,
                     "finished processing with group {}",
                     hex::encode(group.group_id)
                 );

--- a/crates/xmtp_mls/src/subscriptions/stream_messages.rs
+++ b/crates/xmtp_mls/src/subscriptions/stream_messages.rs
@@ -196,7 +196,7 @@ where
                 .get(group_id.as_slice())
                 .cloned()
                 .unwrap_or_default();
-            topic_cursor.add(Topic::new_group_message(group_id.clone()), cursor);
+            topic_cursor.add(Topic::new_group_message(*group_id), cursor);
         }
 
         let groups_list = GroupList::new(topic_cursor, seen_cursors.clone());
@@ -235,13 +235,13 @@ where
     /// The actual subscription update happens when the stream is polled.
     pub(super) fn add(mut self: Pin<&mut Self>, group: MlsGroup<C>) {
         if self.add_queue.iter().any(|g| g.group_id == group.group_id) {
-            tracing::debug!("group {} already queued", hex::encode(&group.group_id));
+            tracing::debug!("group {} already queued", hex::encode(group.group_id));
             return;
         }
         tracing::debug!(
             "queuing group {} for {}",
-            hex::encode(&group.group_id),
-            if self.groups.contains(&group.group_id) {
+            hex::encode(group.group_id),
+            if self.groups.contains(group.group_id) {
                 "re-subscription"
             } else {
                 "add"
@@ -461,11 +461,11 @@ where
     fn resolve_group_additions(mut self: Pin<&mut Self>, group: MlsGroup<C>) {
         tracing::debug!(
             "begin establishing new message stream to include group_id={}",
-            hex::encode(&group.group_id)
+            hex::encode(group.group_id)
         );
         let this = self.as_mut().project();
-        if !this.groups.contains(&group.group_id) {
-            this.groups.add(&group.group_id, GlobalCursor::default());
+        if !this.groups.contains(group.group_id) {
+            this.groups.add(group.group_id, GlobalCursor::default());
         }
         let groups_with_positions = self.groups.groups_with_positions().clone();
         let future = Self::subscribe(self.context.clone(), groups_with_positions, group.group_id);
@@ -505,7 +505,7 @@ where
             this.got.push(envelope.cursor);
             tracing::trace!(
                 "got new message for group=[{}] @cursor=[{}] from network, total messages=[{}]",
-                xmtp_common::fmt::debug_hex(&envelope.group_id),
+                xmtp_common::fmt::debug_hex(envelope.group_id),
                 envelope.cursor,
                 this.got.len()
             );
@@ -606,7 +606,7 @@ pub mod tests {
         tester!(bob, with_name: "bob");
 
         let alice_group = alice.create_group(None, None).unwrap();
-        tracing::info!("Group Id = [{}]", hex::encode(&alice_group.group_id));
+        tracing::info!("Group Id = [{}]", hex::encode(alice_group.group_id));
 
         alice_group.add_members(&[bob.inbox_id()]).await.unwrap();
         let bob_groups = bob.sync_welcomes().await.unwrap();

--- a/crates/xmtp_mls/src/subscriptions/stream_messages/test_utils.rs
+++ b/crates/xmtp_mls/src/subscriptions/stream_messages/test_utils.rs
@@ -8,12 +8,9 @@ pub mod cases {
     // creates groups 1, 2, 3, 4
     #[fixture]
     pub fn group_list() -> Vec<GroupId> {
-        vec![vec![1], vec![2], vec![3], vec![4]]
-            .into_iter()
-            .map(|mut i| {
-                i.resize(31, 0);
-                GroupId::from(i)
-            })
+        [0x01u8, 0x02, 0x03, 0x04]
+            .iter()
+            .map(|i| GroupId::from([*i; 16]))
             .collect::<Vec<GroupId>>()
     }
 }

--- a/crates/xmtp_mls/src/test/builder_native_only.rs
+++ b/crates/xmtp_mls/src/test/builder_native_only.rs
@@ -256,7 +256,7 @@ async fn test_two_smart_contract_wallets_group_messaging(
 
     // Create a group with client1
     let group1 = client1.create_group(None, None).unwrap();
-    println!("Created group with ID: {:?}", hex::encode(&group1.group_id));
+    println!("Created group with ID: {:?}", hex::encode(group1.group_id));
 
     group1.sync().await.unwrap();
 

--- a/crates/xmtp_mls/src/test/group_test_utils.rs
+++ b/crates/xmtp_mls/src/test/group_test_utils.rs
@@ -63,7 +63,7 @@ where
         let mut messages = self
             .context
             .api()
-            .query_at(TopicKind::GroupMessagesV1.create(&self.group_id), None)
+            .query_at(TopicKind::GroupMessagesV1.create(self.group_id), None)
             .await
             .map_err(xmtp_api::dyn_err)?
             .group_messages()?;

--- a/crates/xmtp_mls/src/test/mock/generate.rs
+++ b/crates/xmtp_mls/src/test/mock/generate.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use xmtp_common::{Generate, rand_vec};
+use xmtp_common::Generate;
 use xmtp_db::{MemoryStorage, group_message::StoredGroupMessage, sql_key_store::SqlKeyStore};
 use xmtp_proto::types::Cursor;
 
@@ -53,15 +53,18 @@ pub fn generate_inbox_id_credential() -> (String, XmtpInstallationCredential) {
 
 pub fn generate_messages_with_ids(ids: &[u64]) -> Vec<xmtp_proto::types::GroupMessage> {
     ids.iter()
-        .map(|id| generate_message(*id, &rand_vec::<16>()))
+        .map(|id| generate_message(*id, &xmtp_proto::types::GroupId::generate()))
         .collect()
 }
 
-pub fn generate_message(cursor: u64, group_id: &[u8]) -> xmtp_proto::types::GroupMessage {
+pub fn generate_message(
+    cursor: u64,
+    group_id: &xmtp_proto::types::GroupId,
+) -> xmtp_proto::types::GroupMessage {
     let mut msg = xmtp_proto::types::GroupMessage::generate();
     msg.cursor.sequence_id = cursor;
     msg.cursor.originator_id = xmtp_configuration::Originators::APPLICATION_MESSAGES;
-    msg.group_id = group_id.into();
+    msg.group_id = *group_id;
     msg
 }
 
@@ -111,7 +114,7 @@ pub fn generate_errored_summary(error_cursors: &[u64], successful_cursors: &[u64
 /// Like `generate_errored_summary`, but every success `MessageIdentifier` shares `group_id`
 /// (matches production sync summaries). Random per-message group ids break stream recovery tests.
 pub fn generate_errored_summary_with_group(
-    group_id: &[u8],
+    group_id: &xmtp_proto::types::GroupId,
     error_cursors: &[u64],
     successful_cursors: &[u64],
 ) -> SyncSummary {
@@ -147,10 +150,13 @@ pub fn generate_errored_summary_with_group(
     }
 }
 
-pub fn generate_stored_msg(cursor: Cursor, group_id: Vec<u8>) -> StoredGroupMessage {
+pub fn generate_stored_msg(
+    cursor: Cursor,
+    group_id: xmtp_proto::types::GroupId,
+) -> StoredGroupMessage {
     StoredGroupMessage {
         id: xmtp_common::rand_vec::<32>(),
-        group_id: group_id.into(),
+        group_id,
         decrypted_message_bytes: b"test message".to_vec(),
         sent_at_ns: 100,
         kind: xmtp_db::group_message::GroupMessageKind::Application,

--- a/crates/xmtp_mls/src/utils/bench/groups.rs
+++ b/crates/xmtp_mls/src/utils/bench/groups.rs
@@ -13,6 +13,7 @@ use xmtp_db::encrypted_store::group_message::{MsgQueryArgs, SortDirection};
 use xmtp_db::group::{ConversationType, GroupMembershipState, StoredGroup};
 use xmtp_id::associations::Identifier;
 use xmtp_mls_common::group_metadata::DmMembers;
+use xmtp_proto::types::GroupId;
 
 use super::{BenchClient, Identity};
 
@@ -109,10 +110,10 @@ pub async fn create_dm_with_consent(
         }
         .to_string();
 
-        let group_id = xmtp_common::rand_vec::<20>();
-        let consent_entity = hex::encode(&group_id);
+        let group_id = xmtp_common::rand_array::<16>();
+        let consent_entity = hex::encode(group_id);
         let group = StoredGroup {
-            id: group_id.into(),
+            id: GroupId::from(group_id),
             dm_id: Some(dm_id.clone()),
             added_by_inbox_id: client.inbox_id().to_string(),
             created_at_ns: now_ns(),

--- a/crates/xmtp_mls/src/utils/cleanup_duplicate_updates.rs
+++ b/crates/xmtp_mls/src/utils/cleanup_duplicate_updates.rs
@@ -190,9 +190,9 @@ mod tests {
         let mut duplicates = vec![];
 
         for i in 0..3 {
-            let msg1 = gen_update_msg(dm.group_id.clone(), payload1.clone());
+            let msg1 = gen_update_msg(dm.group_id, payload1.clone());
             msg1.store(&alix.db())?;
-            let msg2 = gen_update_msg(dm.group_id.clone(), payload2.clone());
+            let msg2 = gen_update_msg(dm.group_id, payload2.clone());
             msg2.store(&alix.db())?;
 
             if i > 0 {
@@ -220,7 +220,7 @@ mod tests {
 
         // Let's insert another duplicate and make sure it stays this time.
         // We don't want the perform to run more than once.
-        let msg = gen_update_msg(dm.group_id.clone(), payload1.clone());
+        let msg = gen_update_msg(dm.group_id, payload1.clone());
         msg.store(&alix.db())?;
         perform(alix.db()).await;
 

--- a/crates/xmtp_mls/src/utils/mod.rs
+++ b/crates/xmtp_mls/src/utils/mod.rs
@@ -32,13 +32,13 @@ pub mod id {
 
     /// Relies on a client-created idempotency_key (which could be a timestamp)
     pub fn calculate_message_id(
-        group_id: &[u8],
+        group_id: impl AsRef<[u8]>,
         decrypted_message_bytes: &[u8],
         idempotency_key: &str,
     ) -> Vec<u8> {
         let separator = b"\t";
         let mut id_vec = Vec::new();
-        id_vec.extend_from_slice(group_id);
+        id_vec.extend_from_slice(group_id.as_ref());
         id_vec.extend_from_slice(separator);
         id_vec.extend_from_slice(idempotency_key.as_bytes());
         id_vec.extend_from_slice(separator);
@@ -78,7 +78,7 @@ pub mod id {
             return Ok(None);
         };
 
-        Ok(Some(calculate_message_id(&intent.group_id, &message, &key)))
+        Ok(Some(calculate_message_id(intent.group_id, &message, &key)))
     }
 }
 

--- a/crates/xmtp_mls/src/worker/device_sync/archive.rs
+++ b/crates/xmtp_mls/src/worker/device_sync/archive.rs
@@ -79,8 +79,9 @@ fn insert(
             context.db().insert_newer_consent_record(consent)?;
         }
         Element::Group(save) => {
-            if let Ok(Some(existing_group)) =
-                context.db().find_group(&GroupId::from(save.id.as_slice()))
+            if let Ok(Some(existing_group)) = context
+                .db()
+                .find_group(&GroupId::try_from(save.id.as_slice())?)
             {
                 let timestamp = match (existing_group.last_message_ns, save.last_message_ns) {
                     (Some(e), Some(s)) => Some(e.max(s)),
@@ -245,15 +246,15 @@ mod tests {
 
         let alix_timestamp = alix
             .db()
-            .find_group(&GroupId::from(alix_group.group_id.as_slice()))??
+            .find_group(&alix_group.group_id)??
             .last_message_ns?;
         let alix2_timestamp = alix2
             .db()
-            .find_group(&GroupId::from(alix_group.group_id.as_slice()))??
+            .find_group(&alix_group.group_id)??
             .last_message_ns?;
         let alix3_timestamp = alix3
             .db()
-            .find_group(&GroupId::from(alix_group.group_id.as_slice()))??
+            .find_group(&alix_group.group_id)??
             .last_message_ns?;
 
         // Alix2's older timestamp on the existing group should be updated.
@@ -274,7 +275,7 @@ mod tests {
 
         let timestamp = alix
             .db()
-            .find_group(&GroupId::from(alix_bo_dm.group_id.as_slice()))??
+            .find_group(&alix_bo_dm.group_id)??
             .last_message_ns?;
 
         let key = vec![7; 32];
@@ -313,7 +314,7 @@ mod tests {
 
         let timestamp2 = alix2
             .db()
-            .find_group(&GroupId::from(alix_bo_dm.group_id.as_slice()))??
+            .find_group(&alix_bo_dm.group_id)??
             .last_message_ns?;
         assert_eq!(timestamp, timestamp2);
 
@@ -506,7 +507,7 @@ mod tests {
             assert_eq!(old_msg.group_id, msg.group_id);
         }
 
-        let alix2_group = alix2.group(old_group.id.as_ref())?;
+        let alix2_group = alix2.group(&old_group.id)?;
         // Loading all the groups works fine
         let _groups = alix2.find_groups(GroupQueryArgs::default())?;
         // Can fetch the group name no problem
@@ -514,13 +515,13 @@ mod tests {
         assert!(!alix2_group.is_active()?);
 
         // Add the new inbox to the groups
-        alix.group(old_group.id.as_ref())?
+        alix.group(&old_group.id)?
             .add_members(&[alix2.inbox_id()])
             .await?;
         alix2.sync_welcomes().await?;
 
         // The group restores to being fully functional
-        let alix2_group = alix2.group(old_group.id.as_ref())?;
+        let alix2_group = alix2.group(&old_group.id)?;
         assert!(alix2_group.is_active()?);
 
         // The old messages should be stitched in

--- a/crates/xmtp_mls/src/worker/device_sync/message_sync.rs
+++ b/crates/xmtp_mls/src/worker/device_sync/message_sync.rs
@@ -236,8 +236,7 @@ pub(crate) mod tests {
         let sync_group_id = amal_sync_group.id;
         let created_at_ns = amal_sync_group.created_at_ns;
 
-        let external_client_group =
-            MlsGroup::new(bo_client.clone(), sync_group_id, created_at_ns);
+        let external_client_group = MlsGroup::new(bo_client.clone(), sync_group_id, created_at_ns);
         let result = external_client_group
             .add_members(&[bo_wallet.identifier()])
             .await;

--- a/crates/xmtp_mls/src/worker/device_sync/message_sync.rs
+++ b/crates/xmtp_mls/src/worker/device_sync/message_sync.rs
@@ -233,11 +233,11 @@ pub(crate) mod tests {
         let amal_sync_group = amal_sync_group.unwrap();
 
         // try to join amal's sync group
-        let sync_group_id = amal_sync_group.id.clone();
+        let sync_group_id = amal_sync_group.id;
         let created_at_ns = amal_sync_group.created_at_ns;
 
         let external_client_group =
-            MlsGroup::new(bo_client.clone(), sync_group_id.clone(), created_at_ns);
+            MlsGroup::new(bo_client.clone(), sync_group_id, created_at_ns);
         let result = external_client_group
             .add_members(&[bo_wallet.identifier()])
             .await;

--- a/crates/xmtp_mls/src/worker/device_sync/mod.rs
+++ b/crates/xmtp_mls/src/worker/device_sync/mod.rs
@@ -289,7 +289,7 @@ where
         let msg = format!(
             "[{}] Sending sync message to group {:?}",
             self.context.installation_id(),
-            xmtp_common::fmt::debug_hex(&sync_group.group_id)
+            xmtp_common::fmt::debug_hex(sync_group.group_id)
         );
         tracing::info!("{}", msg.yellow());
 
@@ -350,7 +350,7 @@ where
                 tracing::info!(
                     "[{}] Creating sync group: {}",
                     hex::encode(self.context.installation_id()),
-                    hex::encode(&sync_group.group_id)
+                    hex::encode(sync_group.group_id)
                 );
                 sync_group.add_missing_installations().await?;
                 sync_group.sync_with_conn().await?;

--- a/crates/xmtp_mls/src/worker/pending_self_remove.rs
+++ b/crates/xmtp_mls/src/worker/pending_self_remove.rs
@@ -7,6 +7,7 @@ use futures::{StreamExt, TryFutureExt};
 use std::time::Duration;
 use thiserror::Error;
 use xmtp_db::{StorageError, prelude::*};
+use xmtp_proto::types::GroupId;
 
 /// Interval at which the PendingSelfRemoveWorker runs to remove the members want requested SelfRemove.
 pub const INTERVAL_DURATION: Duration = Duration::from_secs(2);
@@ -108,7 +109,7 @@ where
         mls_group: &MlsGroup<Context>,
     ) -> Result<(), PendingSelfRemoveWorkerError> {
         tracing::info!(
-            group_id = hex::encode(&mls_group.group_id),
+            group_id = hex::encode(mls_group.group_id),
             "Processing pending leave requests for group"
         );
         mls_group.remove_members_pending_removal().await?;
@@ -123,6 +124,10 @@ where
         match db.get_groups_have_pending_leave_request() {
             Ok(groups) => {
                 for group_id in groups {
+                    let Ok(group_id) = GroupId::try_from(group_id) else {
+                        tracing::warn!("skipping malformed group_id in pending leave request list");
+                        continue;
+                    };
                     match self.mls_store.group(&group_id) {
                         Ok(mls_group) => {
                             if let Err(e) = self
@@ -130,7 +135,7 @@ where
                                 .await
                             {
                                 tracing::error!(
-                                    group_id = hex::encode(&group_id),
+                                    group_id = hex::encode(group_id),
                                     error = %e,
                                     "Failed to process pending leave request for group"
                                 );
@@ -138,7 +143,7 @@ where
                         }
                         Err(e) => {
                             tracing::error!(
-                                group_id = hex::encode(&group_id),
+                                group_id = hex::encode(group_id),
                                 error = %e,
                                 "Failed to load MLS group from store"
                             );

--- a/crates/xmtp_mls/src/worker/pending_self_remove.rs
+++ b/crates/xmtp_mls/src/worker/pending_self_remove.rs
@@ -109,7 +109,7 @@ where
         mls_group: &MlsGroup<Context>,
     ) -> Result<(), PendingSelfRemoveWorkerError> {
         tracing::info!(
-            group_id = hex::encode(mls_group.group_id),
+            group_id = %mls_group.group_id,
             "Processing pending leave requests for group"
         );
         mls_group.remove_members_pending_removal().await?;
@@ -135,7 +135,7 @@ where
                                 .await
                             {
                                 tracing::error!(
-                                    group_id = hex::encode(group_id),
+                                    group_id = %group_id,
                                     error = %e,
                                     "Failed to process pending leave request for group"
                                 );
@@ -143,7 +143,7 @@ where
                         }
                         Err(e) => {
                             tracing::error!(
-                                group_id = hex::encode(group_id),
+                                group_id = %group_id,
                                 error = %e,
                                 "Failed to load MLS group from store"
                             );

--- a/crates/xmtp_mls/src/worker/tasks.rs
+++ b/crates/xmtp_mls/src/worker/tasks.rs
@@ -35,6 +35,8 @@ pub enum TaskWorkerError {
     ReceiverLocked,
     #[error("Cannot send sync archives without metrics handle")]
     MissingMetrics,
+    #[error(transparent)]
+    Conversion(#[from] xmtp_proto::ConversionError),
 }
 
 impl NeedsDbReconnect for TaskWorkerError {
@@ -49,6 +51,7 @@ impl NeedsDbReconnect for TaskWorkerError {
             TaskWorkerError::InvalidHash { .. } => false,
             TaskWorkerError::ReceiverLocked => false,
             TaskWorkerError::MissingMetrics => false,
+            TaskWorkerError::Conversion(_) => false,
         }
     }
 }
@@ -249,9 +252,9 @@ where
                 client
                     .send_archive(
                         &options,
-                        &xmtp_proto::types::GroupId::from(
+                        &xmtp_proto::types::GroupId::try_from(
                             send_sync_archive.sync_group_id.as_slice(),
-                        ),
+                        )?,
                         &pin,
                         &send_sync_archive.server_url,
                     )

--- a/crates/xmtp_proto/Cargo.toml
+++ b/crates/xmtp_proto/Cargo.toml
@@ -52,6 +52,7 @@ tonic = { workspace = true, features = ["channel", "codegen"] }
 wasm-bindgen-test.workspace = true
 
 [dev-dependencies]
+bincode.workspace = true
 mockall.workspace = true
 rstest.workspace = true
 tokio = { workspace = true }

--- a/crates/xmtp_proto/src/traits/short_hex.rs
+++ b/crates/xmtp_proto/src/traits/short_hex.rs
@@ -50,7 +50,7 @@ mod tests {
     fn test_short_hex_group_id() {
         let hex = "5bf078bd83995fe83092d93c5655f059";
         let bytes = hex::decode(hex).unwrap();
-        let group_id = GroupId::from(bytes);
+        let group_id = GroupId::try_from(bytes).unwrap();
         assert_eq!(group_id.short_hex(), &hex[..SHORT_LEN * 2]);
     }
 }

--- a/crates/xmtp_proto/src/types/ids.rs
+++ b/crates/xmtp_proto/src/types/ids.rs
@@ -1,4 +1,4 @@
 mod group_id;
 mod installation_id;
-pub use group_id::*;
+pub use group_id::{GroupId, GroupIdParseError};
 pub use installation_id::*;

--- a/crates/xmtp_proto/src/types/ids/group_id.rs
+++ b/crates/xmtp_proto/src/types/ids/group_id.rs
@@ -1,6 +1,5 @@
-use std::{fmt, ops::Deref, str::FromStr};
+use std::{borrow::Borrow, fmt, str::FromStr};
 
-use bytes::Bytes;
 #[cfg(feature = "diesel")]
 use diesel::{
     backend::Backend,
@@ -10,57 +9,103 @@ use diesel::{
     sql_types::Binary,
     sqlite::Sqlite,
 };
-use hex::FromHexError;
 use serde::{Deserialize, Serialize};
 
-/// The canonical group identifier.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+use crate::ConversionError;
+
+/// The canonical group identifier. Exactly 16 bytes, by protocol invariant.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[cfg_attr(feature = "diesel", derive(AsExpression, FromSqlRow))]
 #[cfg_attr(feature = "diesel", diesel(sql_type = Binary))]
-pub struct GroupId(bytes::Bytes);
-
-impl Serialize for GroupId {
-    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
-        self.0.as_ref().serialize(s)
-    }
-}
-
-impl<'de> Deserialize<'de> for GroupId {
-    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
-        Vec::<u8>::deserialize(d).map(GroupId::from)
-    }
-}
+pub struct GroupId([u8; 16]);
 
 impl GroupId {
+    /// Borrowed byte slice view over the underlying 16 bytes.
     pub fn as_slice(&self) -> &[u8] {
-        self.0.as_ref()
+        &self.0
     }
 
-    pub fn to_openmls(&self) -> openmls::group::GroupId {
-        openmls::group::GroupId::from_slice(self.as_ref())
+    /// Borrowed reference to the underlying 16-byte array.
+    pub fn as_bytes(&self) -> &[u8; 16] {
+        &self.0
     }
 
+    /// Consume the `GroupId` and return its raw bytes.
+    pub fn into_bytes(self) -> [u8; 16] {
+        self.0
+    }
+
+    /// Convert to an owned `Vec<u8>` of the 16 bytes.
+    pub fn to_vec(self) -> Vec<u8> {
+        self.0.to_vec()
+    }
+
+    /// Convert to an `openmls::group::GroupId`.
+    pub fn to_openmls(self) -> openmls::group::GroupId {
+        openmls::group::GroupId::from_slice(&self.0)
+    }
+
+    /// Construct a `GroupId` containing 16 random bytes drawn from `rand`.
     pub fn random<R: openmls_traits::random::OpenMlsRand>(rand: &R) -> Self {
-        let bytes = rand
+        let mut bytes = [0u8; 16];
+        let v = rand
             .random_vec(16)
             .expect("OpenMlsRand failed to produce randomness for GroupId");
-        GroupId::from(bytes)
+        bytes.copy_from_slice(&v);
+        GroupId(bytes)
     }
 }
 
-impl fmt::Debug for GroupId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("GroupId")
-            .field(&xmtp_common::fmt::debug_hex(&self.0))
-            .finish()
+// --- Infallible constructors -------------------------------------------------
+
+impl From<[u8; 16]> for GroupId {
+    fn from(v: [u8; 16]) -> Self {
+        GroupId(v)
     }
 }
 
-impl FromStr for GroupId {
-    type Err = FromHexError;
+impl From<&[u8; 16]> for GroupId {
+    fn from(v: &[u8; 16]) -> Self {
+        GroupId(*v)
+    }
+}
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(GroupId(Bytes::from(hex::decode(s)?)))
+// --- Fallible constructors ---------------------------------------------------
+
+impl TryFrom<Vec<u8>> for GroupId {
+    type Error = ConversionError;
+    fn try_from(v: Vec<u8>) -> Result<Self, Self::Error> {
+        Ok(GroupId(v.as_slice().try_into()?))
+    }
+}
+
+impl TryFrom<&[u8]> for GroupId {
+    type Error = ConversionError;
+    fn try_from(v: &[u8]) -> Result<Self, Self::Error> {
+        let bytes: [u8; 16] = v.try_into()?;
+        Ok(GroupId(bytes))
+    }
+}
+
+impl TryFrom<&openmls::group::GroupId> for GroupId {
+    type Error = ConversionError;
+    fn try_from(id: &openmls::group::GroupId) -> Result<Self, Self::Error> {
+        GroupId::try_from(id.as_slice())
+    }
+}
+
+impl TryFrom<openmls::group::GroupId> for GroupId {
+    type Error = ConversionError;
+    fn try_from(id: openmls::group::GroupId) -> Result<Self, Self::Error> {
+        GroupId::try_from(id.as_slice())
+    }
+}
+
+// --- Outward conversions -----------------------------------------------------
+
+impl From<GroupId> for Vec<u8> {
+    fn from(id: GroupId) -> Vec<u8> {
+        id.0.to_vec()
     }
 }
 
@@ -70,42 +115,115 @@ impl AsRef<[u8]> for GroupId {
     }
 }
 
-impl fmt::Display for GroupId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:x}", self.0)
-    }
-}
-
-impl Deref for GroupId {
-    type Target = bytes::Bytes;
-    fn deref(&self) -> &Self::Target {
+impl Borrow<[u8]> for GroupId {
+    fn borrow(&self) -> &[u8] {
         &self.0
     }
 }
 
-impl std::borrow::Borrow<[u8]> for GroupId {
-    fn borrow(&self) -> &[u8] {
-        self.0.as_ref()
+// --- Display / Debug ---------------------------------------------------------
+
+impl fmt::Display for GroupId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", hex::encode(self.0))
     }
 }
 
-impl From<Vec<u8>> for GroupId {
-    fn from(v: Vec<u8>) -> GroupId {
-        GroupId(v.into())
+impl fmt::Debug for GroupId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("GroupId")
+            .field(&xmtp_common::fmt::debug_hex(self.0))
+            .finish()
     }
 }
 
-impl From<&[u8]> for GroupId {
-    fn from(v: &[u8]) -> GroupId {
-        GroupId(v.to_vec().into())
+// --- FromStr / parse error ---------------------------------------------------
+
+/// Error returned by `<GroupId as FromStr>::from_str`.
+#[derive(Debug, thiserror::Error)]
+pub enum GroupIdParseError {
+    /// Input string was not valid hexadecimal.
+    #[error(transparent)]
+    Hex(#[from] hex::FromHexError),
+    /// Decoded byte length was not 16.
+    #[error(transparent)]
+    Length(#[from] ConversionError),
+}
+
+impl FromStr for GroupId {
+    type Err = GroupIdParseError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let bytes = hex::decode(s)?;
+        Ok(GroupId::try_from(bytes)?)
     }
 }
 
-impl From<GroupId> for Vec<u8> {
-    fn from(id: GroupId) -> Vec<u8> {
-        id.0.into()
+// --- PartialEq family --------------------------------------------------------
+
+impl PartialEq<Vec<u8>> for GroupId {
+    fn eq(&self, other: &Vec<u8>) -> bool {
+        self.0.eq(&other[..])
     }
 }
+
+impl PartialEq<GroupId> for Vec<u8> {
+    fn eq(&self, other: &GroupId) -> bool {
+        other.0.eq(&self[..])
+    }
+}
+
+impl PartialEq<&Vec<u8>> for GroupId {
+    fn eq(&self, other: &&Vec<u8>) -> bool {
+        self.0.eq(&other[..])
+    }
+}
+
+impl PartialEq<GroupId> for &Vec<u8> {
+    fn eq(&self, other: &GroupId) -> bool {
+        other.0.eq(&self[..])
+    }
+}
+
+impl PartialEq<[u8]> for GroupId {
+    fn eq(&self, other: &[u8]) -> bool {
+        self.0.eq(other)
+    }
+}
+
+impl PartialEq<GroupId> for [u8] {
+    fn eq(&self, other: &GroupId) -> bool {
+        other.0.eq(self)
+    }
+}
+
+impl PartialEq<[u8; 16]> for GroupId {
+    fn eq(&self, other: &[u8; 16]) -> bool {
+        self.0.eq(other)
+    }
+}
+
+impl PartialEq<GroupId> for [u8; 16] {
+    fn eq(&self, other: &GroupId) -> bool {
+        other.0.eq(&self[..])
+    }
+}
+
+// --- Serde -------------------------------------------------------------------
+
+impl Serialize for GroupId {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        self.0.as_ref().serialize(s)
+    }
+}
+
+impl<'de> Deserialize<'de> for GroupId {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let v = Vec::<u8>::deserialize(d)?;
+        GroupId::try_from(v).map_err(serde::de::Error::custom)
+    }
+}
+
+// --- Diesel ------------------------------------------------------------------
 
 #[cfg(feature = "diesel")]
 impl ToSql<Binary, Sqlite> for GroupId
@@ -113,7 +231,7 @@ where
     [u8]: ToSql<Binary, Sqlite>,
 {
     fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Sqlite>) -> serialize::Result {
-        out.set_value(self.as_slice().to_vec());
+        out.set_value(self.0.to_vec());
         Ok(IsNull::No)
     }
 }
@@ -124,29 +242,22 @@ where
     Vec<u8>: FromSql<Binary, Sqlite>,
 {
     fn from_sql(bytes: <Sqlite as Backend>::RawValue<'_>) -> deserialize::Result<Self> {
-        Vec::<u8>::from_sql(bytes).map(GroupId::from)
+        let v = Vec::<u8>::from_sql(bytes)?;
+        GroupId::try_from(v).map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)
     }
 }
 
-impl From<&openmls::group::GroupId> for GroupId {
-    fn from(id: &openmls::group::GroupId) -> Self {
-        GroupId::from(id.as_slice())
-    }
-}
-
-impl From<openmls::group::GroupId> for GroupId {
-    fn from(id: openmls::group::GroupId) -> Self {
-        GroupId::from(id.as_slice())
-    }
-}
+// --- Generate (test-only) ----------------------------------------------------
 
 xmtp_common::if_test! {
     impl xmtp_common::Generate for GroupId {
         fn generate() -> Self {
-            GroupId(xmtp_common::rand_vec::<16>().into())
+            GroupId(xmtp_common::rand_array::<16>())
         }
     }
 }
+
+// --- Tests -------------------------------------------------------------------
 
 #[cfg(test)]
 mod test {
@@ -154,44 +265,211 @@ mod test {
 
     use super::*;
 
-    #[xmtp_common::test]
-    fn test_fromstr() {
-        let hex = hex::encode(xmtp_common::rand_vec::<16>());
-        let id: GroupId = hex.parse().unwrap();
-        assert_eq!(hex::encode(&id.0), hex);
+    #[rstest]
+    #[case([0u8; 16])]
+    #[case([0xffu8; 16])]
+    #[case([1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])]
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn test_group_id_from_array(#[case] input: [u8; 16]) {
+        let id = GroupId::from(input);
+        assert_eq!(id.as_slice(), &input);
+        assert_eq!(id.as_bytes(), &input);
+        assert_eq!(id.into_bytes(), input);
+        assert_eq!(GroupId::from(&input).as_slice(), &input);
+        assert_eq!(GroupId::from(input).to_vec(), input.to_vec());
     }
 
     #[rstest]
-    #[case(b"test_group".to_vec())]
-    #[case(vec![1, 2, 3, 4, 5])]
-    #[case(Vec::new())]
-    #[xmtp_common::test]
-    async fn test_group_id_from_vec(#[case] input: Vec<u8>) {
-        assert_eq!(GroupId::from(input.clone()).as_slice(), input.as_slice());
-        assert_eq!(GroupId::from(input.clone()).as_ref(), input.as_slice());
+    #[case(vec![1u8; 16], true)]
+    #[case(vec![1u8; 15], false)]
+    #[case(vec![1u8; 17], false)]
+    #[case(Vec::new(), false)]
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn test_group_id_try_from_vec(#[case] input: Vec<u8>, #[case] ok: bool) {
+        assert_eq!(GroupId::try_from(input).is_ok(), ok);
     }
 
     #[rstest]
-    #[case(b"test")]
-    #[case(b"")]
-    #[case(b"longer_test_data")]
-    #[xmtp_common::test]
-    async fn test_group_id_from_slice(#[case] input: &[u8]) {
-        assert_eq!(GroupId::from(input).as_slice(), input);
+    #[case(&[1u8; 16][..], true)]
+    #[case(&[1u8; 15][..], false)]
+    #[case(&[1u8; 17][..], false)]
+    #[case(&[][..], false)]
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn test_group_id_try_from_slice(#[case] input: &[u8], #[case] ok: bool) {
+        assert_eq!(GroupId::try_from(input).is_ok(), ok);
     }
 
-    #[xmtp_common::test]
-    fn test_group_id_display_debug() {
-        let data = vec![0x12, 0x34, 0xab, 0xcd];
-        assert!(format!("{}", GroupId::from(data.clone())).contains("1234abcd"));
-        assert!(format!("{:?}", GroupId::from(data)).contains("GroupId"));
+    #[xmtp_common::test(unwrap_try = true)]
+    fn test_openmls_try_from_valid() {
+        let bytes: [u8; 16] = xmtp_common::rand_array::<16>();
+        let ommls = openmls::group::GroupId::from_slice(&bytes);
+        let xmtp_id = GroupId::try_from(&ommls).unwrap();
+        assert_eq!(xmtp_id.as_slice(), &bytes);
+
+        let ommls_owned = openmls::group::GroupId::from_slice(&bytes);
+        let xmtp_id_owned = GroupId::try_from(ommls_owned).unwrap();
+        assert_eq!(xmtp_id_owned.as_slice(), &bytes);
     }
 
-    #[xmtp_common::test]
+    #[xmtp_common::test(unwrap_try = true)]
+    fn test_openmls_try_from_wrong_length() {
+        let short = openmls::group::GroupId::from_slice(&[1u8; 8]);
+        assert!(GroupId::try_from(&short).is_err());
+
+        let long = openmls::group::GroupId::from_slice(&[1u8; 32]);
+        assert!(GroupId::try_from(long).is_err());
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
     fn test_to_openmls_roundtrip() {
-        let bytes: [u8; 16] = xmtp_common::rand_vec::<16>().try_into().unwrap();
-        let xmtp_id = GroupId::from(bytes.as_slice());
+        let bytes: [u8; 16] = xmtp_common::rand_array::<16>();
+        let xmtp_id = GroupId::from(bytes);
         let ommls_id = xmtp_id.to_openmls();
         assert_eq!(ommls_id.as_slice(), xmtp_id.as_slice());
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn test_fromstr_success() {
+        let bytes: [u8; 16] = xmtp_common::rand_array::<16>();
+        let hex = hex::encode(bytes);
+        let id: GroupId = hex.parse().unwrap();
+        assert_eq!(id.as_slice(), &bytes);
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn test_fromstr_bad_hex() {
+        let err = "zz".parse::<GroupId>().unwrap_err();
+        assert!(matches!(err, GroupIdParseError::Hex(_)));
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn test_fromstr_wrong_length() {
+        // 6 hex chars = 3 bytes (not 16).
+        let err = "abcdef".parse::<GroupId>().unwrap_err();
+        assert!(matches!(err, GroupIdParseError::Length(_)));
+    }
+
+    #[rstest]
+    #[case(GroupId::from([1u8; 16]), vec![1u8; 16], true)]
+    #[case(GroupId::from([1u8; 16]), vec![2u8; 16], false)]
+    #[case(GroupId::from([1u8; 16]), vec![1u8; 15], false)] // length mismatch
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn test_group_id_eq_vec(#[case] id: GroupId, #[case] v: Vec<u8>, #[case] equal: bool) {
+        // Each direction exercises a different PartialEq impl: by-value, by-reference,
+        // and the reverse pair. The op_ref allow keeps the &v cases intentional.
+        #[allow(clippy::op_ref)]
+        {
+            assert_eq!(id == v, equal);
+            assert_eq!(v == id, equal);
+            assert_eq!(id == &v, equal);
+            assert_eq!(&v == id, equal);
+        }
+    }
+
+    #[rstest]
+    #[case(GroupId::from([1u8; 16]), [1u8; 16], true)]
+    #[case(GroupId::from([1u8; 16]), [2u8; 16], false)]
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn test_group_id_eq_array(#[case] id: GroupId, #[case] a: [u8; 16], #[case] equal: bool) {
+        assert_eq!(id == a, equal);
+        assert_eq!(a == id, equal);
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn test_group_id_eq_slice() {
+        let id = GroupId::from([1u8; 16]);
+        let s: &[u8] = &[1u8; 16];
+        assert_eq!(id, *s);
+        assert_eq!(*s, id);
+
+        let wrong_len: &[u8] = &[1u8; 8];
+        assert_ne!(id, *wrong_len);
+        assert_ne!(*wrong_len, id);
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn test_serde_roundtrip() {
+        let id = GroupId::from([7u8; 16]);
+        let bytes = bincode::serialize(&id).unwrap();
+        let decoded: GroupId = bincode::deserialize(&bytes).unwrap();
+        assert_eq!(decoded, id);
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn test_serde_wrong_length_fails() {
+        // Manually craft a bincode-encoded Vec<u8> of length 8.
+        let bad: Vec<u8> = vec![1, 2, 3, 4, 5, 6, 7, 8];
+        let bytes = bincode::serialize(&bad).unwrap();
+        assert!(bincode::deserialize::<GroupId>(&bytes).is_err());
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn test_generate_produces_16_bytes() {
+        use xmtp_common::Generate;
+        let id: GroupId = GroupId::generate();
+        assert_eq!(id.as_slice().len(), 16);
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn test_default_is_zero() {
+        let id = GroupId::default();
+        assert_eq!(id.as_slice(), &[0u8; 16][..]);
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn test_display_debug() {
+        let id = GroupId::from([0x12, 0x34, 0xab, 0xcd, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+        let displayed = format!("{}", id);
+        assert!(displayed.starts_with("1234abcd"));
+        assert_eq!(displayed.len(), 32);
+        let debugged = format!("{:?}", id);
+        assert!(debugged.starts_with("GroupId("));
+    }
+
+    #[cfg(feature = "diesel")]
+    mod diesel_test {
+        use super::*;
+        use diesel::prelude::*;
+
+        diesel::table! {
+            test_group_ids (id) {
+                id -> Binary,
+            }
+        }
+
+        #[derive(Insertable, Queryable)]
+        #[diesel(table_name = test_group_ids)]
+        struct Row {
+            id: GroupId,
+        }
+
+        #[xmtp_common::test(unwrap_try = true)]
+        fn test_diesel_roundtrip() {
+            let mut conn = SqliteConnection::establish(":memory:").unwrap();
+            diesel::sql_query("CREATE TABLE test_group_ids (id BLOB NOT NULL PRIMARY KEY)")
+                .execute(&mut conn)
+                .unwrap();
+            let id = GroupId::from([0xabu8; 16]);
+            diesel::insert_into(test_group_ids::table)
+                .values(&Row { id })
+                .execute(&mut conn)
+                .unwrap();
+            let got: Row = test_group_ids::table.first(&mut conn).unwrap();
+            assert_eq!(got.id, id);
+        }
+
+        #[xmtp_common::test(unwrap_try = true)]
+        fn test_diesel_wrong_length_errors() {
+            let mut conn = SqliteConnection::establish(":memory:").unwrap();
+            diesel::sql_query("CREATE TABLE test_group_ids (id BLOB NOT NULL PRIMARY KEY)")
+                .execute(&mut conn)
+                .unwrap();
+            // Insert raw 8-byte blob bypassing the type.
+            diesel::sql_query("INSERT INTO test_group_ids (id) VALUES (X'0102030405060708')")
+                .execute(&mut conn)
+                .unwrap();
+            let result: Result<Row, _> = test_group_ids::table.first(&mut conn);
+            assert!(result.is_err());
+        }
     }
 }

--- a/crates/xmtp_proto/src/types/ids/group_id.rs
+++ b/crates/xmtp_proto/src/types/ids/group_id.rs
@@ -20,6 +20,17 @@ use crate::ConversionError;
 pub struct GroupId([u8; 16]);
 
 impl GroupId {
+    /// `GroupId([0u8; 16])` — sentinel / placeholder. Same as `GroupId::default()`.
+    pub const ZERO: GroupId = GroupId([0u8; 16]);
+    /// `GroupId([1u8; 16])` — convenience constant for tests.
+    pub const ONE: GroupId = GroupId([1u8; 16]);
+    /// `GroupId([2u8; 16])` — convenience constant for tests.
+    pub const TWO: GroupId = GroupId([2u8; 16]);
+    /// `GroupId([3u8; 16])` — convenience constant for tests.
+    pub const THREE: GroupId = GroupId([3u8; 16]);
+    /// `GroupId([4u8; 16])` — convenience constant for tests.
+    pub const FOUR: GroupId = GroupId([4u8; 16]);
+
     /// Borrowed byte slice view over the underlying 16 bytes.
     pub fn as_slice(&self) -> &[u8] {
         &self.0
@@ -414,6 +425,16 @@ mod test {
     fn test_default_is_zero() {
         let id = GroupId::default();
         assert_eq!(id.as_slice(), &[0u8; 16][..]);
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn test_const_helpers() {
+        assert_eq!(GroupId::ZERO, GroupId::default());
+        assert_eq!(GroupId::ZERO.as_bytes(), &[0u8; 16]);
+        assert_eq!(GroupId::ONE.as_bytes(), &[1u8; 16]);
+        assert_eq!(GroupId::TWO.as_bytes(), &[2u8; 16]);
+        assert_eq!(GroupId::THREE.as_bytes(), &[3u8; 16]);
+        assert_eq!(GroupId::FOUR.as_bytes(), &[4u8; 16]);
     }
 
     #[xmtp_common::test(unwrap_try = true)]


### PR DESCRIPTION
Resolves https://github.com/xmtp/libxmtp/issues/3639

## Summary

- Replace `GroupId`'s `bytes::Bytes` backing with a `Copy` newtype over `[u8; 16]`, encoding the protocol's 16-byte invariant in the type system.
- Migrate all callsites: `TryFrom` at decode boundaries (propagating `ConversionError`), 16-byte literals or `Generate::generate()` for test fixtures.
- Mechanical cleanup: drop redundant `.clone()` and reference patterns now that `GroupId: Copy`. Mirror the existing `InstallationId` pattern.

## API surface changes

**New:**
- `From<[u8; 16]>`, `From<&[u8; 16]>` (infallible)
- `TryFrom<&[u8]>`, `TryFrom<Vec<u8>>`, `TryFrom<&openmls::group::GroupId>`, `TryFrom<openmls::group::GroupId>` returning `ConversionError`
- `as_bytes() -> &[u8; 16]`, `into_bytes() -> [u8; 16]` accessors
- `GroupIdParseError` (`FromStr` distinguishes hex vs length errors)

**Removed:**
- Infallible `From<Vec<u8>>`, `From<&[u8]>`, `From<openmls::group::GroupId>` (replaced by `TryFrom`)
- `Deref<Target = bytes::Bytes>` impl

**Behavior change (intentional, per spec):**
- `Default` now produces `[0u8; 16]` instead of empty bytes.
- Serde and Diesel `FromSql` now reject wrong-length data (was silently truncated/padded).

## Wire compatibility

- Serde format is unchanged (16 raw bytes).
- Diesel `ToSql`/`FromSql` still read/write a 16-byte `Binary` blob; rows with wrong-length data now surface as load errors (per spec § \"Invariants 2\": such data is corruption and should not be silently accepted).

## Ripple

| Crate | Type of change |
|-------|---------------|
| `xmtp_proto` | Type rewrite + 18 new in-file tests |
| `xmtp_db` | Diesel boundary `try_from`; test fixtures to 16-byte literals; helper signatures tightened |
| `xmtp_api`, `xmtp_api_d14n` | Proto decode boundary `try_from`; test fixtures |
| `xmtp_mls` | Boundary `try_from` (welcomes, sync, commit log, validated commit, oneshot, worker); new `Conversion` error variants where they didn't exist |
| `xmtp_archive` | One redundant projection dropped |
| `bindings/{mobile,node,wasm}` | FFI entry-point `try_from`, mapping `ConversionError` to host error type. Public FFI signatures unchanged. |
| `apps/*` | Same pattern at CLI/debug-tool entry points |
| Workspace-wide | ~160 `hex::encode(&group_id)` → `hex::encode(group_id)` and similar `.clone()` removals now that `GroupId: Copy` |

## Verification

- ✅ `just lint-rust` clean (clippy `-D warnings`, fmt, hakari).
- ✅ `cargo nextest` hermetic suites pass:
  - `xmtp_proto`: 30 new tests for the new type (round-trip, length error paths, serde, Diesel, hex parse).
  - `xmtp_db`: 188 tests pass.
  - `xmtp_archive`: 5 tests pass.
  - `xmtp_proto + xmtp_db + xmtp_archive`: 300 total tests pass.
- ✅ Workspace `cargo check --workspace --all-features --all-targets --exclude log_parser` clean (including `xmtpv3`, `bindings_node`, `bindings_wasm`).
- ✅ Spec invariant audit: zero remaining `GroupId::from(vec![...])` / `GroupId::from(&[...])` / `impl Deref for GroupId` / infallible `From<Vec<u8>>` for GroupId callsites or impls.
- ⏸️ `just test v3` / `just test d14n` / `just wasm test` / `just node test` not run locally (require Docker XMTP node / browser env not available in build sandbox); leaving to CI.
- ⏸️ `just android check` / `just ios check` not run locally; leaving to CI.

## Plan & design

The spec, multi-phase plan, and per-phase task files are checked in under `docs/plans/2026-05-14-issue-3639*`.

## Test plan

- [ ] CI green on `just test v3` and `just test d14n`
- [ ] CI green on `just wasm test`, `just node test`
- [ ] CI green on `just android check`, `just ios check`
- [ ] Reviewer confirms FFI error mapping is the right variant in each binding crate (mobile/wasm/node)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Represent `GroupId` as a fixed-size `[u8; 16]` Copy newtype with fallible constructors
> - Changes `GroupId` internal representation from `bytes::Bytes` to `[u8; 16]`, making it `Copy` and enforcing a 16-byte invariant at construction time.
> - Removes infallible `From<Vec<u8>>` and `From<&[u8]>` conversions; all paths that previously accepted arbitrary-length byte buffers now use `TryFrom` and return `ConversionError` on invalid length.
> - Adds convenience constants (`ZERO`, `ONE`, `TWO`, etc.), `as_slice`, `to_vec`, `into_bytes`, and a `Generate` impl; `to_openmls` now takes ownership.
> - Propagates `ConversionError` through all layers that accept group IDs: MLS sync, commit log, welcome processing, subscriptions, FFI bindings (Node/WASM/mobile), CLI, and DB queries.
> - Risk: Any stored or network-supplied group ID that is not exactly 16 bytes will now produce a hard error instead of being silently accepted; deserialization via serde/Diesel will also fail on wrong-length blobs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e61fed3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->