### PR TITLE
Enable proposal parameters

### DIFF
--- a/bindings/mobile/src/mls.rs
+++ b/bindings/mobile/src/mls.rs
@@ -1144,6 +1144,28 @@ impl From<FfiVisibilityConfirmationOptions>
     }
 }
 
+/// Options for [`FfiConversation::enable_proposals`]. Mirrors
+/// [`xmtp_mls::groups::EnableProposalsOptions`].
+#[derive(uniffi::Record, Default, Clone, Debug)]
+pub struct FfiEnableProposalsOptions {
+    /// Skip the pre-flight key-package capability check. Post-d14n
+    /// every client supports proposals by version floor alone; set
+    /// `true` to bypass the per-member scan in that environment.
+    pub force: Option<bool>,
+    /// Override the `MIN_SUPPORTED_PROTOCOL_VERSION` floor. `None`
+    /// defaults to `xmtp_configuration::PROPOSALS_MIN_PROTOCOL_VERSION`.
+    pub min_version: Option<String>,
+}
+
+impl From<FfiEnableProposalsOptions> for xmtp_mls::groups::EnableProposalsOptions {
+    fn from(opts: FfiEnableProposalsOptions) -> Self {
+        xmtp_mls::groups::EnableProposalsOptions {
+            force: opts.force.unwrap_or(false),
+            min_version: opts.min_version,
+        }
+    }
+}
+
 /// Signature kind used in identity operations
 #[derive(uniffi::Enum, Clone, Debug, PartialEq)]
 pub enum FfiSignatureKind {
@@ -2674,8 +2696,14 @@ impl FfiConversation {
     /// **One-way**: a migrated group cannot return to the legacy
     /// path. Operationally treated as a flag day per group.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub async fn enable_proposals(&self) -> Result<(), FfiError> {
-        self.inner.enable_proposals().await.map_err(Into::into)
+    pub async fn enable_proposals(
+        &self,
+        options: FfiEnableProposalsOptions,
+    ) -> Result<(), FfiError> {
+        self.inner
+            .enable_proposals(options.into())
+            .await
+            .map_err(Into::into)
     }
 
     #[tracing::instrument(level = "debug", skip_all)]

--- a/bindings/node/src/conversation/metadata.rs
+++ b/bindings/node/src/conversation/metadata.rs
@@ -3,6 +3,28 @@ use napi::bindgen_prelude::Result;
 use napi_derive::napi;
 use xmtp_mls::mls_common::group_metadata::GroupMetadata as XmtpGroupMetadata;
 
+/// Options for [`Conversation::enableProposals`]. Mirrors
+/// [`xmtp_mls::groups::EnableProposalsOptions`].
+#[napi(object)]
+pub struct EnableProposalsOptions {
+  /// Skip the pre-flight key-package capability check. Post-d14n
+  /// every client supports proposals by version floor alone; set
+  /// `true` to bypass the per-member scan in that environment.
+  pub force: Option<bool>,
+  /// Override the `MIN_SUPPORTED_PROTOCOL_VERSION` floor. `None`
+  /// defaults to `xmtp_configuration::PROPOSALS_MIN_PROTOCOL_VERSION`.
+  pub min_version: Option<String>,
+}
+
+impl From<EnableProposalsOptions> for xmtp_mls::groups::EnableProposalsOptions {
+  fn from(opts: EnableProposalsOptions) -> Self {
+    xmtp_mls::groups::EnableProposalsOptions {
+      force: opts.force.unwrap_or(false),
+      min_version: opts.min_version,
+    }
+  }
+}
+
 #[napi]
 pub struct GroupMetadata {
   metadata: XmtpGroupMetadata,
@@ -63,10 +85,10 @@ impl Conversation {
   /// package doesn't advertise `ProposalType::AppDataUpdate`. One-
   /// way: migrated groups cannot return to the legacy path.
   #[napi]
-  pub async fn enable_proposals(&self) -> Result<()> {
+  pub async fn enable_proposals(&self, options: EnableProposalsOptions) -> Result<()> {
     let group = self.create_mls_group();
     group
-      .enable_proposals()
+      .enable_proposals(options.into())
       .await
       .map_err(|e| ErrorWrapper::from(e).into())
   }

--- a/bindings/wasm/src/conversation.rs
+++ b/bindings/wasm/src/conversation.rs
@@ -73,6 +73,34 @@ impl From<SendMessageOpts> for xmtp_mls::groups::send_message_opts::SendMessageO
   }
 }
 
+/// Options for [`Conversation::enableProposals`]. Mirrors
+/// [`xmtp_mls::groups::EnableProposalsOptions`].
+#[derive(Clone, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(rename_all = "camelCase")]
+pub struct EnableProposalsOptions {
+  /// Skip the pre-flight key-package capability check. Post-d14n
+  /// every client supports proposals by version floor alone; set
+  /// `true` to bypass the per-member scan in that environment.
+  #[tsify(optional)]
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub force: Option<bool>,
+  /// Override the `MIN_SUPPORTED_PROTOCOL_VERSION` floor. `None`
+  /// defaults to `xmtp_configuration::PROPOSALS_MIN_PROTOCOL_VERSION`.
+  #[tsify(optional)]
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub min_version: Option<String>,
+}
+
+impl From<EnableProposalsOptions> for xmtp_mls::groups::EnableProposalsOptions {
+  fn from(opts: EnableProposalsOptions) -> Self {
+    xmtp_mls::groups::EnableProposalsOptions {
+      force: opts.force.unwrap_or(false),
+      min_version: opts.min_version,
+    }
+  }
+}
+
 #[derive(Clone, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
@@ -653,9 +681,12 @@ impl Conversation {
   /// package doesn't advertise `ProposalType::AppDataUpdate`. One-
   /// way: migrated groups cannot return to the legacy path.
   #[wasm_bindgen(js_name = enableProposals)]
-  pub async fn enable_proposals(&self) -> Result<(), JsError> {
+  pub async fn enable_proposals(&self, options: EnableProposalsOptions) -> Result<(), JsError> {
     let group = self.to_mls_group();
-    group.enable_proposals().await.map_err(ErrorWrapper::js)
+    group
+      .enable_proposals(options.into())
+      .await
+      .map_err(ErrorWrapper::js)
   }
 
   #[wasm_bindgen(js_name = groupName)]

--- a/crates/xmtp_configuration/src/common/mls.rs
+++ b/crates/xmtp_configuration/src/common/mls.rs
@@ -42,6 +42,20 @@ pub const HMAC_SALT: &[u8] = b"libXMTP HKDF salt!";
 pub const ENABLE_COMMIT_LOG: bool = true;
 pub const MIN_RECOVERY_REQUEST_VERSION: &str = "1.6.0";
 
+/// Default floor written into `MIN_SUPPORTED_PROTOCOL_VERSION` when a
+/// group is migrated via `enable_proposals` without an explicit override.
+///
+/// Set to the release where the AppData-migration / proposals feature
+/// first ships. Clients older than this version cannot read the
+/// AppData dictionary, so the welcome-time / commit-time pause path
+/// uses this value to gate them out of migrated groups before they
+/// fork.
+///
+/// Callers that need a different floor (testing, dev nightlies,
+/// staged rollouts) pass `EnableProposalsOptions::min_version` instead
+/// of relying on this default.
+pub const PROPOSALS_MIN_PROTOCOL_VERSION: &str = "1.11.0";
+
 // Welcome pointers are mostly the hpke public key and less than 100 bytes for the welcome pointer
 // so as long as we have 2 installations that need a single welcome it will result in less data being
 // ingested by the nodes and stored. There is a slight penalty for egress data, but the amount needed

--- a/crates/xmtp_mls/src/groups/mod.rs
+++ b/crates/xmtp_mls/src/groups/mod.rs
@@ -216,6 +216,58 @@ pub enum UpdateAdminListType {
     RemoveSuper,
 }
 
+/// Options for [`MlsGroup::enable_proposals`].
+///
+/// Default (`EnableProposalsOptions::default()` or
+/// `EnableProposalsOptions { force: false, min_version: None }`) is
+/// the safe production setting: enforce the pre-flight capability
+/// check and write the standard
+/// [`xmtp_configuration::PROPOSALS_MIN_PROTOCOL_VERSION`] floor.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct EnableProposalsOptions {
+    /// Skip the pre-flight `all_members_support_proposals` check. The
+    /// key-package capability advertisement is the pre-d14n
+    /// negotiation mechanism; post-d14n every client is guaranteed to
+    /// support proposals by version floor alone, so the per-member
+    /// scan stops adding signal. Setting `force = true` bypasses it on
+    /// both the pre-flight pass and the bootstrap-time re-check.
+    ///
+    /// Callers using this MUST be confident every member is at >=
+    /// `min_version` — there is no second gate.
+    pub force: bool,
+
+    /// Override the floor written into
+    /// `MIN_SUPPORTED_PROTOCOL_VERSION`. When `None`, defaults to
+    /// [`xmtp_configuration::PROPOSALS_MIN_PROTOCOL_VERSION`] — the
+    /// release where proposals support first ships.
+    ///
+    /// Use cases:
+    /// - Tests that want a synthetic floor (e.g. `"99.0.0"` to force
+    ///   the pause path) or no floor (e.g. `"0.0.0"`).
+    /// - Dev / nightly builds that need to migrate groups without
+    ///   pausing peers running older `pkg_version`s.
+    /// - Staged production rollouts that need a non-default floor.
+    pub min_version: Option<String>,
+}
+
+impl EnableProposalsOptions {
+    /// Test/dev-only constructor that sets the floor to `"0.0.0"` so
+    /// the migration never pauses any peer. Use in tests that aren't
+    /// specifically exercising the pause path — passing
+    /// [`EnableProposalsOptions::default()`] in a test environment
+    /// would write the production
+    /// [`xmtp_configuration::PROPOSALS_MIN_PROTOCOL_VERSION`] floor,
+    /// which a test client running at the workspace `CARGO_PKG_VERSION`
+    /// (below that floor) would self-pause against.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn test_default() -> Self {
+        Self {
+            force: false,
+            min_version: Some("0.0.0".to_string()),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 enum AdminListKind {
     Admin,
@@ -493,17 +545,33 @@ where
     /// - All members being added must support proposals
     /// - This cannot be disabled once set
     ///
+    /// # Options
+    ///
+    /// See [`EnableProposalsOptions`] for the two knobs:
+    /// - `force`: skip the pre-flight key-package capability check. Use
+    ///   after d14n cuts over, when capability advertisement is
+    ///   redundant with the version floor.
+    /// - `min_version`: override the `MIN_SUPPORTED_PROTOCOL_VERSION`
+    ///   floor written into the migrated group. Defaults to
+    ///   [`xmtp_configuration::PROPOSALS_MIN_PROTOCOL_VERSION`] — the
+    ///   release where proposals support first ships.
+    ///
     /// # Prerequisites
     ///
-    /// Before calling this method, ensure all existing members support proposals
-    /// by calling `all_members_support_proposals()`.
+    /// Before calling this method with `force = false`, ensure all
+    /// existing members support proposals by calling
+    /// `all_members_support_proposals()`.
     ///
     /// # Errors
     ///
     /// Returns an error if:
-    /// - Not all existing members support proposals
+    /// - `force = false` and not all existing members support proposals
+    /// - `min_version` is set to an invalid semver string
     /// - The group context extension update fails
-    pub async fn enable_proposals(&self) -> Result<(), GroupError> {
+    pub async fn enable_proposals(
+        &self,
+        options: EnableProposalsOptions,
+    ) -> Result<(), GroupError> {
         // Two-step migration so old clients (any peer running a
         // libxmtp release predating this code's `pkg_version`) get a
         // pause hint they can read BEFORE the legacy
@@ -548,7 +616,10 @@ where
         // (1) `all_members_support_proposals` ensures every peer can
         // process the bootstrap commit so we don't ship step A — the
         // legacy GMM bump — for a migration that's about to fail at
-        // step B and leave below-floor peers permanently paused.
+        // step B and leave below-floor peers permanently paused. Gated
+        // by `options.force`: post-d14n the capability advertisement
+        // becomes redundant with the version floor and callers can
+        // explicitly opt out of the per-member scan.
         // (2) `proposals_enabled` early-exits if the group is already
         // migrated; calling `enable_proposals()` twice is a user error
         // and we don't want to publish a redundant legacy GMM bump on
@@ -560,11 +631,20 @@ where
         // that case re-bumping with a lower string value would
         // downgrade the floor and silently unpause peers between the
         // lower and the higher version. Skip step A when the current
-        // floor already covers our pkg_version.
-        let pkg_version = self.context.version_info().pkg_version().to_string();
+        // floor already covers the target.
+        let min_version = options
+            .min_version
+            .unwrap_or_else(|| xmtp_configuration::PROPOSALS_MIN_PROTOCOL_VERSION.to_string());
+        // Validate the floor string up-front so we fail with a clear
+        // error before publishing the legacy GMM bump rather than
+        // discovering it mid-flight when the validator parses it.
+        let target_v = LibXMTPVersion::parse(&min_version).map_err(|e| {
+            GroupError::ProposalsNotSupported(format!("parsing min_version '{min_version}': {e}"))
+        })?;
+        let force = options.force;
         let (already_migrated, needs_min_version_bump) = self
             .load_mls_group_with_lock_async(async |mls_group| {
-                if !self.all_members_support_proposals(&mls_group).await? {
+                if !force && !self.all_members_support_proposals(&mls_group).await? {
                     return Err(GroupError::ProposalsNotSupported(
                         "Cannot enable proposals: not all members support the proposal extension"
                             .to_string(),
@@ -587,11 +667,6 @@ where
                                 "parsing legacy GMM MinimumSupportedProtocolVersion '{current_str}': {e}"
                             ))
                         })?;
-                        let target_v = LibXMTPVersion::parse(&pkg_version).map_err(|e| {
-                            GroupError::ProposalsNotSupported(format!(
-                                "parsing this binary's pkg_version '{pkg_version}': {e}"
-                            ))
-                        })?;
                         current_v < target_v
                     }
                 };
@@ -606,7 +681,7 @@ where
         if needs_min_version_bump {
             let min_version_intent_data: Vec<u8> =
                 intents::UpdateMetadataIntentData::new_update_group_min_version_to_match_self(
-                    pkg_version,
+                    min_version.clone(),
                 )
                 .into();
             let min_version_intent = intents::QueueIntent::metadata_update()
@@ -634,10 +709,14 @@ where
         // pass is a defense-in-depth: pre-flight ran above before step
         // A, but a peer could join between then and now. The intent
         // dispatch reads live group state at publish time, so step B
-        // must observe the same predicate it gated step A with.
+        // must observe the same predicate it gated step A with. Same
+        // `force` gate as the pre-flight — if the caller explicitly
+        // disabled the capability check there, honor that here too so
+        // a freshly-joined member can't re-block the migration mid-
+        // flight.
         let new_extensions = self
             .load_mls_group_with_lock_async(async |mls_group| {
-                if !self.all_members_support_proposals(&mls_group).await? {
+                if !force && !self.all_members_support_proposals(&mls_group).await? {
                     return Err(GroupError::ProposalsNotSupported(
                         "Cannot enable proposals: not all members support the proposal extension"
                             .to_string(),

--- a/crates/xmtp_mls/src/groups/tests/test_proposals.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_proposals.rs
@@ -7,7 +7,7 @@
 
 use crate::{
     groups::{
-        build_proposals_enabled_extension,
+        EnableProposalsOptions, build_proposals_enabled_extension,
         intents::{CommitPendingProposalsIntentData, ProposeMemberUpdateIntentData},
         send_message_opts::SendMessageOpts,
     },
@@ -200,7 +200,9 @@ async fn test_e2e_propose_add_member_flow() {
     assert_eq!(initial_members.len(), 2);
 
     // Enable proposals so members can send/receive them
-    alix_group.enable_proposals().await?;
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
     bo_group.sync().await?;
 
     // 2. Alix proposes to add caro
@@ -301,7 +303,9 @@ async fn test_e2e_propose_remove_member_flow() {
     assert_eq!(initial_members.len(), 3);
 
     // Enable proposals
-    alix_group.enable_proposals().await?;
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
     bo_group.sync().await?;
     caro_group.sync().await?;
 
@@ -422,7 +426,10 @@ async fn test_propose_invalid_member_operations(#[case] is_add: bool) {
     assert_eq!(members.len(), 2);
 
     // Enable proposals
-    alix_group.enable_proposals().await.unwrap();
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await
+        .unwrap();
     bo_group.sync().await.unwrap();
 
     let db = alix_group.context.db();
@@ -500,7 +507,9 @@ async fn test_message_auto_commits_pending_proposals() {
     assert!(has_message);
 
     // Enable proposals
-    alix_group.enable_proposals().await?;
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
     bo_group.sync().await?;
 
     // Alix proposes to add caro
@@ -595,7 +604,9 @@ async fn test_multiple_add_proposals_before_commit() {
     bo_group.sync().await?;
 
     // Enable proposals
-    alix_group.enable_proposals().await?;
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
     bo_group.sync().await?;
 
     // Alix proposes to add caro
@@ -697,7 +708,9 @@ async fn test_mixed_add_remove_proposals_before_commit() {
     assert_eq!(initial_members.len(), 3, "Should start with 3 members");
 
     // Enable proposals
-    alix_group.enable_proposals().await?;
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
     bo_group.sync().await?;
     caro_group.sync().await?;
 
@@ -827,7 +840,9 @@ async fn test_proposer_can_commit_own_proposal() {
     assert_eq!(initial_members.len(), 2);
 
     // Enable proposals
-    alix_group.enable_proposals().await?;
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
     bo_group.sync().await?;
 
     let initial_epoch = alix_group.epoch().await?;
@@ -939,7 +954,9 @@ async fn test_concurrent_proposals_from_different_members() {
     caro_group.sync().await?;
 
     // Enable proposals
-    alix_group.enable_proposals().await?;
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
     bo_group.sync().await?;
     caro_group.sync().await?;
 
@@ -1050,7 +1067,9 @@ async fn test_non_admin_proposal_rejected_in_admin_only_group() {
     );
 
     // Enable proposals
-    alix_group.enable_proposals().await?;
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
     bo_group.sync().await?;
 
     // Bo (non-admin) attempts to propose adding Caro
@@ -1120,7 +1139,9 @@ async fn test_admin_proposal_accepted_in_admin_only_group() {
     bo_group.sync().await?;
 
     // Enable proposals
-    alix_group.enable_proposals().await?;
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
     bo_group.sync().await?;
 
     // Alix (admin) proposes to add Caro
@@ -1176,7 +1197,9 @@ async fn test_enable_proposals_and_proposals_enabled() {
     assert!(!enabled_before, "Proposals should not be enabled initially");
 
     // Enable proposals
-    alix_group.enable_proposals().await?;
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
 
     // Verify proposals_enabled returns true (tests proto decode + version > 0 path)
     let enabled_after = alix_group
@@ -1228,7 +1251,9 @@ async fn test_enable_proposals_fails_without_support() {
             assert!(!all_support, "Not all members should support proposals");
 
             // enable_proposals should fail
-            let result = alix_group.enable_proposals().await;
+            let result = alix_group
+                .enable_proposals(EnableProposalsOptions::test_default())
+                .await;
             assert!(
                 result.is_err(),
                 "enable_proposals should fail when not all members support it"
@@ -1259,7 +1284,9 @@ async fn test_adding_unsupported_member_rejected_when_proposals_enabled() {
     bo.sync_welcomes().await?;
 
     // Enable proposals (alix + bo both support it)
-    alix_group.enable_proposals().await?;
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
 
     let enabled = alix_group
         .load_mls_group_with_lock_async(async |mls_group| {
@@ -1411,7 +1438,9 @@ async fn test_non_admin_commits_admin_proposals_in_admin_group() {
     );
 
     // Enable proposals
-    alix_group.enable_proposals().await?;
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
     bo_group.sync().await?;
     caro_group.sync().await?;
 
@@ -1539,7 +1568,9 @@ async fn test_multiple_non_admin_proposers_with_admin_committer() {
     assert_eq!(initial_members.len(), 3);
 
     // Enable proposals
-    alix_group.enable_proposals().await?;
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
     bo_group.sync().await?;
     caro_group.sync().await?;
 
@@ -1668,7 +1699,9 @@ async fn test_remove_proposal_validation_in_admin_group() {
     caro_group.sync().await?;
 
     // Enable proposals
-    alix_group.enable_proposals().await?;
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
     bo_group.sync().await?;
 
     // Scenario A: Bo (non-admin) proposes removing Caro → should be rejected by Alix
@@ -1757,7 +1790,9 @@ async fn test_admin_proposes_remove_committed_by_non_admin() {
     caro_group.sync().await?;
 
     // Enable proposals
-    alix_group.enable_proposals().await?;
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
     bo_group.sync().await?;
     caro_group.sync().await?;
 
@@ -2195,7 +2230,9 @@ async fn test_add_members_batched_when_proposals_enabled() {
     bo_group.sync().await?;
 
     // Enable proposals on the group
-    alix_group.enable_proposals().await?;
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
     bo_group.sync().await?;
 
     // Verify proposals are enabled
@@ -2311,7 +2348,9 @@ async fn test_commit_pending_proposals_batches_gce_and_commit() {
     bo_group.sync().await?;
 
     // Enable proposals
-    alix_group.enable_proposals().await?;
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
     bo_group.sync().await?;
 
     // Bo proposes to add Caro
@@ -2409,7 +2448,9 @@ async fn test_sequence_id_bump_triggers_gce_with_proposals_enabled() {
     bo_group.sync().await?;
 
     // Enable proposals
-    alix_group.enable_proposals().await?;
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
     bo_group.sync().await?;
 
     // Capture bo's sequence ID before the bump
@@ -2476,7 +2517,9 @@ async fn test_add_member_after_sequence_id_bump_with_proposals_enabled() {
     bo_group.sync().await?;
 
     // Enable proposals
-    alix_group.enable_proposals().await?;
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
     bo_group.sync().await?;
 
     // Bo creates a second installation, bumping his sequence ID
@@ -2632,7 +2675,9 @@ async fn test_update_group_name_via_app_data_update() {
 
     // Run the real bootstrap commit so the dict carries the
     // registry, immutable seeds, and admin lists.
-    alix_group.enable_proposals().await?;
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
     bo_group.sync().await?;
 
     // Sanity check the flag actually flipped from both sides.
@@ -2693,7 +2738,9 @@ async fn test_update_group_description_via_app_data_update() {
     let bo_group = bo_groups.first()?;
     bo_group.sync().await?;
 
-    alix_group.enable_proposals().await?;
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
     bo_group.sync().await?;
 
     alix_group
@@ -2771,7 +2818,9 @@ async fn test_disappearing_settings_survive_bootstrap() {
     );
 
     // Run the real bootstrap commit — strips the legacy GMM extension.
-    alix_group.enable_proposals().await?;
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
     bo_group.sync().await?;
 
     // Send a post-bootstrap message. Before the capability-aware fix,
@@ -2865,7 +2914,15 @@ async fn test_enable_proposals_pauses_old_client_via_legacy_gmm_bump() {
     //   1. A legacy GCE commit bumping MIN_SUPPORTED_PROTOCOL_VERSION
     //      in the still-present legacy GMM extension.
     //   2. The bootstrap commit (strips legacy extensions, seeds dict).
-    alix_group.enable_proposals().await?;
+    // Pass alix's pkg_version as the floor explicitly: the test
+    // default's "0.0.0" floor would skip the step-A pause hint that's
+    // the whole subject of this test.
+    alix_group
+        .enable_proposals(EnableProposalsOptions {
+            force: false,
+            min_version: Some(alix_pkg_version.clone()),
+        })
+        .await?;
 
     // Bo syncs. He processes commit (1), sees min_version > his own,
     // lands in `paused_for_version`, and stops processing — commit (2)
@@ -3020,7 +3077,9 @@ async fn test_inline_app_data_update_denied_by_registry_policy() {
 
     // Bootstrap and tighten GROUP_NAME's update policy to Deny so
     // any subsequent update_group_name is rejected by the validator.
-    alix_group.enable_proposals().await?;
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
     bo_group.sync().await?;
     alix_group
         .update_permission_policy(
@@ -3170,7 +3229,9 @@ async fn test_admin_list_add_via_app_data_path_after_migration() {
     // Run the real bootstrap commit. After this the dict carries
     // the registry, the immutable seeds, and the admin lists, and
     // the legacy XMTP extensions are gone.
-    alix_group.enable_proposals().await?;
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
     bo_group.sync().await?;
 
     // Promote bo to admin via the host-facing API. Internally queues
@@ -3221,7 +3282,9 @@ async fn test_admin_list_remove_via_app_data_path_after_migration() {
     let bo_group = bo_groups.first()?;
     bo_group.sync().await?;
 
-    alix_group.enable_proposals().await?;
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
     bo_group.sync().await?;
 
     alix_group
@@ -3261,7 +3324,9 @@ async fn test_super_admin_list_add_via_app_data_path_after_migration() {
     let bo_group = bo_groups.first()?;
     bo_group.sync().await?;
 
-    alix_group.enable_proposals().await?;
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
     bo_group.sync().await?;
 
     // AddSuper targets SUPER_ADMIN_LIST per the sender's mapping.
@@ -3317,7 +3382,9 @@ async fn test_permission_update_via_app_data_path_after_migration() {
     let bo_group = bo_groups.first()?;
     bo_group.sync().await?;
 
-    alix_group.enable_proposals().await?;
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
     bo_group.sync().await?;
 
     // Tighten GROUP_NAME's update_policy from `Allow` (the default
@@ -3458,7 +3525,9 @@ async fn test_welcome_on_migrated_group_pauses_below_min_version() {
 
     // Alix migrates. Post-migration the legacy GMM is stripped and the
     // floor lives in the AppData dict only.
-    alix_group.enable_proposals().await?;
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
     let alix_migrated = alix_group
         .load_mls_group_with_lock_async(async |g| {
             Ok::<bool, crate::groups::GroupError>(alix_group.proposals_enabled(&g))

--- a/sdks/android/library/src/main/java/org/xmtp/android/library/Group.kt
+++ b/sdks/android/library/src/main/java/org/xmtp/android/library/Group.kt
@@ -30,6 +30,7 @@ import uniffi.xmtpv3.FfiConversation
 import uniffi.xmtpv3.FfiConversationMetadata
 import uniffi.xmtpv3.FfiDeliveryStatus
 import uniffi.xmtpv3.FfiDirection
+import uniffi.xmtpv3.FfiEnableProposalsOptions
 import uniffi.xmtpv3.FfiException
 import uniffi.xmtpv3.FfiGroupMembershipState
 import uniffi.xmtpv3.FfiGroupPermissions
@@ -599,18 +600,33 @@ class Group(
      * image URL, admin list, permissions) flow through the proposal-based
      * path instead of GCE commits.
      *
-     * Hard-fails if any member's latest key package doesn't advertise
-     * `ProposalType.AppDataUpdate`. The migration is one-way — a migrated
-     * group cannot return to the legacy path.
+     * @param force Skip the pre-flight key-package capability check.
+     *   Post-d14n every client supports proposals by version floor
+     *   alone, so the per-member scan stops adding signal. Set `true`
+     *   to bypass it. Callers using this MUST be confident every
+     *   member is at `>= minVersion`. Defaults to `false`.
+     * @param minVersion Override the `MIN_SUPPORTED_PROTOCOL_VERSION`
+     *   floor. `null` defaults to libxmtp's
+     *   `PROPOSALS_MIN_PROTOCOL_VERSION` — the release where proposals
+     *   support first ships.
+     *
+     * Hard-fails if `force == false` and any member's latest key
+     * package doesn't advertise `ProposalType.AppDataUpdate`. The
+     * migration is one-way — a migrated group cannot return to the
+     * legacy path.
      */
-    suspend fun enableProposals() =
-        withContext(Dispatchers.IO) {
-            try {
-                libXMTPGroup.enableProposals()
-            } catch (e: Exception) {
-                throw XMTPException("Unable to enable proposals on group", e)
-            }
+    suspend fun enableProposals(
+        force: Boolean = false,
+        minVersion: String? = null,
+    ) = withContext(Dispatchers.IO) {
+        try {
+            libXMTPGroup.enableProposals(
+                FfiEnableProposalsOptions(force = force, minVersion = minVersion),
+            )
+        } catch (e: Exception) {
+            throw XMTPException("Unable to enable proposals on group", e)
         }
+    }
 
     suspend fun clearDisappearingMessageSettings() =
         withContext(Dispatchers.IO) {

--- a/sdks/ios/Sources/XMTPiOS/Group.swift
+++ b/sdks/ios/Sources/XMTPiOS/Group.swift
@@ -244,12 +244,25 @@ public struct Group: Identifiable, Equatable, Hashable {
 	/// image URL, admin list, permissions) flow through the proposal-based
 	/// path instead of GCE commits.
 	///
-	/// Hard-fails with `ProposalsNotSupported` if any member's latest key
-	/// package doesn't advertise `ProposalType::AppDataUpdate`. The
-	/// migration is one-way — a migrated group cannot return to the
-	/// legacy path.
-	public func enableProposals() async throws {
-		try await ffiGroup.enableProposals()
+	/// - Parameters:
+	///   - force: Skip the pre-flight key-package capability check.
+	///     Post-d14n every client supports proposals by version floor
+	///     alone, so the per-member scan stops adding signal. Set
+	///     `true` to bypass it. Callers using this MUST be confident
+	///     every member is at `>= minVersion`. Defaults to `false`.
+	///   - minVersion: Override the `MIN_SUPPORTED_PROTOCOL_VERSION`
+	///     floor. `nil` defaults to libxmtp's
+	///     `PROPOSALS_MIN_PROTOCOL_VERSION` — the release where
+	///     proposals support first ships.
+	///
+	/// Hard-fails with `ProposalsNotSupported` if `force == false` and
+	/// any member's latest key package doesn't advertise
+	/// `ProposalType::AppDataUpdate`. The migration is one-way — a
+	/// migrated group cannot return to the legacy path.
+	public func enableProposals(force: Bool = false, minVersion: String? = nil) async throws {
+		try await ffiGroup.enableProposals(
+			options: FfiEnableProposalsOptions(force: force, minVersion: minVersion)
+		)
 	}
 
 	public func updateAddMemberPermission(newPermissionOption: PermissionOption)

--- a/sdks/ios/Sources/XMTPiOS/Libxmtp/xmtpv3.swift
+++ b/sdks/ios/Sources/XMTPiOS/Libxmtp/xmtpv3.swift
@@ -1295,7 +1295,7 @@ public protocol FfiConversationProtocol: AnyObject, Sendable {
      * **One-way**: a migrated group cannot return to the legacy
      * path. Operationally treated as a flag day per group.
      */
-    func enableProposals() async throws 
+    func enableProposals(options: FfiEnableProposalsOptions) async throws 
     
     func findDuplicateDms() async throws  -> [FfiConversation]
     
@@ -1639,13 +1639,13 @@ open func dmPeerInboxId() -> String?  {
      * **One-way**: a migrated group cannot return to the legacy
      * path. Operationally treated as a flag day per group.
      */
-open func enableProposals()async throws   {
+open func enableProposals(options: FfiEnableProposalsOptions)async throws   {
     return
         try  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_xmtpv3_fn_method_fficonversation_enable_proposals(
-                    self.uniffiCloneHandle()
-                    
+                    self.uniffiCloneHandle(),
+                    FfiConverterTypeFfiEnableProposalsOptions_lower(options)
                 )
             },
             pollFunc: ffi_xmtpv3_rust_future_poll_void,
@@ -7428,6 +7428,82 @@ public func FfiConverterTypeFfiDeletedMessage_lift(_ buf: RustBuffer) throws -> 
 #endif
 public func FfiConverterTypeFfiDeletedMessage_lower(_ value: FfiDeletedMessage) -> RustBuffer {
     return FfiConverterTypeFfiDeletedMessage.lower(value)
+}
+
+
+/**
+ * Options for [`FfiConversation::enable_proposals`]. Mirrors
+ * [`xmtp_mls::groups::EnableProposalsOptions`].
+ */
+public struct FfiEnableProposalsOptions: Equatable, Hashable {
+    /**
+     * Skip the pre-flight key-package capability check. Post-d14n
+     * every client supports proposals by version floor alone; set
+     * `true` to bypass the per-member scan in that environment.
+     */
+    public var force: Bool?
+    /**
+     * Override the `MIN_SUPPORTED_PROTOCOL_VERSION` floor. `None`
+     * defaults to `xmtp_configuration::PROPOSALS_MIN_PROTOCOL_VERSION`.
+     */
+    public var minVersion: String?
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(
+        /**
+         * Skip the pre-flight key-package capability check. Post-d14n
+         * every client supports proposals by version floor alone; set
+         * `true` to bypass the per-member scan in that environment.
+         */force: Bool?, 
+        /**
+         * Override the `MIN_SUPPORTED_PROTOCOL_VERSION` floor. `None`
+         * defaults to `xmtp_configuration::PROPOSALS_MIN_PROTOCOL_VERSION`.
+         */minVersion: String?) {
+        self.force = force
+        self.minVersion = minVersion
+    }
+
+    
+
+    
+}
+
+#if compiler(>=6)
+extension FfiEnableProposalsOptions: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeFfiEnableProposalsOptions: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> FfiEnableProposalsOptions {
+        return
+            try FfiEnableProposalsOptions(
+                force: FfiConverterOptionBool.read(from: &buf), 
+                minVersion: FfiConverterOptionString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: FfiEnableProposalsOptions, into buf: inout [UInt8]) {
+        FfiConverterOptionBool.write(value.force, into: &buf)
+        FfiConverterOptionString.write(value.minVersion, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeFfiEnableProposalsOptions_lift(_ buf: RustBuffer) throws -> FfiEnableProposalsOptions {
+    return try FfiConverterTypeFfiEnableProposalsOptions.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeFfiEnableProposalsOptions_lower(_ value: FfiEnableProposalsOptions) -> RustBuffer {
+    return FfiConverterTypeFfiEnableProposalsOptions.lower(value)
 }
 
 
@@ -15702,7 +15778,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_xmtpv3_checksum_method_fficonversation_dm_peer_inbox_id() != 2891) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_xmtpv3_checksum_method_fficonversation_enable_proposals() != 57516) {
+    if (uniffi_xmtpv3_checksum_method_fficonversation_enable_proposals() != 40008) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_xmtpv3_checksum_method_fficonversation_find_duplicate_dms() != 57431) {


### PR DESCRIPTION
Allow forcing upgrades and overriding min group version when enabling proposals

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `EnableProposalsOptions` parameters to `enable_proposals` across all bindings
> - Introduces `EnableProposalsOptions` (with `force: bool` and `min_version: Option<String>`) in the core crate and exposes equivalent structs in the Node, WASM, mobile FFI, Android, and iOS bindings.
> - `force=true` skips the capability advertisement checks for all group members, allowing migration even when not all members advertise support.
> - `min_version` overrides the default protocol version floor (`1.11.0` from `PROPOSALS_MIN_PROTOCOL_VERSION`) used when deciding whether to bump the legacy minimum version during migration.
> - Invalid `min_version` strings now cause a `ProposalsNotSupported` error before any changes are published.
> - Risk: `enable_proposals` now requires an options argument in all bindings; callers that previously called it with no arguments must be updated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 91d4d5f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->