### PR TITLE
clamp min_version <= own version when enabling/bumping proposals

### DIFF
--- a/crates/xmtp_configuration/src/common/mls.rs
+++ b/crates/xmtp_configuration/src/common/mls.rs
@@ -51,10 +51,17 @@ pub const MIN_RECOVERY_REQUEST_VERSION: &str = "1.6.0";
 /// uses this value to gate them out of migrated groups before they
 /// fork.
 ///
+/// **Invariant**: must be `<= CARGO_PKG_VERSION`. The send-side clamp
+/// in `enable_proposals` refuses any `min_version > own pkg_version`
+/// (you can't legally write a floor you yourself don't satisfy), so
+/// a constant ahead of the workspace version would brick every
+/// production call to `enable_proposals` that takes the default. Bump
+/// this in lockstep with the workspace version, never independently.
+///
 /// Callers that need a different floor (testing, dev nightlies,
 /// staged rollouts) pass `EnableProposalsOptions::min_version` instead
 /// of relying on this default.
-pub const PROPOSALS_MIN_PROTOCOL_VERSION: &str = "1.11.0";
+pub const PROPOSALS_MIN_PROTOCOL_VERSION: &str = "1.11.0-dev";
 
 // Welcome pointers are mostly the hpke public key and less than 100 bytes for the welcome pointer
 // so as long as we have 2 installations that need a single welcome it will result in less data being

--- a/crates/xmtp_mls/src/groups/error.rs
+++ b/crates/xmtp_mls/src/groups/error.rs
@@ -256,6 +256,25 @@ pub enum GroupError {
     /// Encountered a proposal when our client does not support proposals. Not retryable.
     #[error("Proposals not supported: {0}")]
     ProposalsNotSupported(String),
+    /// Caller asked to set `MIN_SUPPORTED_PROTOCOL_VERSION` to a value
+    /// the caller's own client does not satisfy. Refusing prevents the
+    /// caller from immediately pausing themselves (and every peer at or
+    /// below their version) the moment the bump lands. Not retryable.
+    #[error("min_version {requested} exceeds own pkg_version {own}")]
+    MinVersionExceedsOwnVersion { requested: String, own: String },
+    /// Caller asked to lower `MIN_SUPPORTED_PROTOCOL_VERSION` below the
+    /// floor already on the group. Monotonic-only: a downgrade would
+    /// silently unpause peers between the old and new floors, defeating
+    /// the gate. Not retryable.
+    #[error("min_version {requested} would downgrade existing floor {current}")]
+    MinVersionDowngrade { requested: String, current: String },
+    /// Caller passed a `min_version` string that doesn't parse as
+    /// semver. Surfaces from the send-side paths
+    /// (`enable_proposals`, `update_group_min_version`) so SDK
+    /// consumers can `match`-handle malformed input without parsing
+    /// string-flattened wrappers. Not retryable.
+    #[error("invalid min_version {value:?}: {reason}")]
+    InvalidMinVersion { value: String, reason: String },
     /// Component source error.
     ///
     /// Failed to encode, decode, or look up a well-known component during the
@@ -564,6 +583,9 @@ impl RetryableError for GroupError {
             Self::Proposal(e) => e.is_retryable(),
             Self::CommitToPendingProposals(e) => e.is_retryable(),
             Self::ProposalsNotSupported(_) => false,
+            Self::MinVersionExceedsOwnVersion { .. } => false,
+            Self::MinVersionDowngrade { .. } => false,
+            Self::InvalidMinVersion { .. } => false,
             Self::ComponentSource(_) => false,
             Self::AppDataCommit(e) => e.is_retryable(),
             // Bootstrap synthesis can fail on a transient identity-update

--- a/crates/xmtp_mls/src/groups/mod.rs
+++ b/crates/xmtp_mls/src/groups/mod.rs
@@ -695,9 +695,17 @@ where
         // Validate the floor string up-front so we fail with a clear
         // error before publishing the legacy GMM bump rather than
         // discovering it mid-flight when the validator parses it.
-        let target_v = LibXMTPVersion::parse(&min_version).map_err(|e| {
-            GroupError::ProposalsNotSupported(format!("parsing min_version '{min_version}': {e}"))
-        })?;
+        let target_v =
+            LibXMTPVersion::parse(&min_version).map_err(|e| GroupError::InvalidMinVersion {
+                value: min_version.clone(),
+                reason: e.to_string(),
+            })?;
+        let own_version_str = self.context.version_info().pkg_version().to_string();
+        let own_v =
+            LibXMTPVersion::parse(&own_version_str).map_err(|e| GroupError::InvalidMinVersion {
+                value: own_version_str.clone(),
+                reason: format!("own pkg_version: {e}"),
+            })?;
         let force = options.force;
 
         log_event!(
@@ -715,8 +723,28 @@ where
                             .to_string(),
                     ));
                 }
+                // Idempotency: re-calling enable_proposals on an
+                // already-migrated group is a no-op success.
+                // The footgun clamp below MUST run after this
+                // early-return — otherwise a caller pinning a
+                // forward-looking constant in idempotent retry code
+                // would error post-migration even when the floor was
+                // already set by the original call.
                 if self.proposals_enabled(&mls_group) {
                     return Ok::<(bool, bool), GroupError>((true, false));
+                }
+                // Footgun guard: a caller setting min_version above
+                // their own pkg_version would pause themselves (and
+                // every peer at or below their version) the moment the
+                // bump landed — bricking the group from the inside.
+                // Refuse. Honest mistakes only; a malicious client can
+                // patch this out, but honest mistakes are what we're
+                // protecting against.
+                if target_v > own_v {
+                    return Err(GroupError::MinVersionExceedsOwnVersion {
+                        requested: min_version.clone(),
+                        own: own_version_str.clone(),
+                    });
                 }
                 let metadata =
                     xmtp_mls_common::group_mutable_metadata::extract_legacy_group_mutable_metadata(
@@ -726,14 +754,25 @@ where
                 let current = metadata.and_then(|m| Self::min_protocol_version_from_extensions(&m));
                 let needs_bump = match current.as_deref() {
                     None => true,
-                    Some(current_str) => {
-                        let current_v = LibXMTPVersion::parse(current_str).map_err(|e| {
-                            GroupError::ProposalsNotSupported(format!(
-                                "parsing legacy GMM MinimumSupportedProtocolVersion '{current_str}': {e}"
-                            ))
-                        })?;
-                        current_v < target_v
-                    }
+                    Some(current_str) => match LibXMTPVersion::parse(current_str) {
+                        Ok(current_v) => current_v < target_v,
+                        Err(e) => {
+                            // Lenient on a malformed legacy GMM floor (mirrors the
+                            // receive-side leniency in
+                            // [`enforce_min_version_monotonicity`]). Step A
+                            // overwrites the value entirely with a known-good
+                            // semver string, so a malformed prior can't poison the
+                            // bump. Log a warning so operators can detect
+                            // corrupted state.
+                            tracing::warn!(
+                                current = %current_str,
+                                error = %e,
+                                "enable_proposals: legacy GMM MinimumSupportedProtocolVersion is unparseable; \
+                                 proceeding with step-A bump to overwrite"
+                            );
+                            true
+                        }
+                    },
                 };
                 Ok::<(bool, bool), GroupError>((false, needs_bump))
             })
@@ -796,6 +835,16 @@ where
                             .to_string(),
                     ));
                 }
+                // Re-check `proposals_enabled` inside the lock: a
+                // concurrent migrator may have completed the migration
+                // between the first idempotency check and this second
+                // lock acquisition. Returning `None` here lets the
+                // outer code skip queuing a redundant bootstrap intent
+                // — preserves the idempotency contract documented at
+                // the top of `enable_proposals_inner`.
+                if self.proposals_enabled(&mls_group) {
+                    return Ok::<Option<Extensions<GroupContext>>, GroupError>(None);
+                }
                 let mut extensions: Extensions<GroupContext> = mls_group.extensions().clone();
 
                 // 1. Remove the four legacy XMTP extensions. The
@@ -819,9 +868,16 @@ where
                 //    commit for missing required extensions.
                 update_required_capabilities_for_bootstrap(&mut extensions)?;
 
-                Ok(extensions)
+                Ok(Some(extensions))
             })
             .await?;
+
+        // Concurrent migrator won the race between the two lock
+        // acquisitions — group is already migrated, no bootstrap
+        // intent to queue.
+        let Some(new_extensions) = new_extensions else {
+            return Ok(());
+        };
 
         use openmls::prelude::tls_codec::Serialize;
         let extensions_bytes = new_extensions.tls_serialize_detached()?;
@@ -1967,7 +2023,70 @@ where
     /// A `Result` indicating success or failure of the operation.
     pub async fn update_group_min_version(&self, version: &str) -> Result<(), GroupError> {
         self.ensure_not_paused().await?;
-        tracing::info!("updating group min version to match self: {}", version);
+
+        // Footgun guards (apply on send side; receive side enforces
+        // the same monotonicity invariant as the source of truth):
+        //
+        // 1. `version > own pkg_version` would pause this client (and
+        //    every peer at or below this version) the moment the bump
+        //    lands. Refuse.
+        // 2. `version < current floor` would silently unpause peers
+        //    between the new and old floors, defeating the gate. Refuse.
+        //    Lenient on an unparseable current floor — mirror the
+        //    receive-side behavior in `enforce_min_version_monotonicity`
+        //    rather than have the send-side refuse where the receive-
+        //    side accepts. (Brick recovery: a group with malformed
+        //    legacy GMM bytes shouldn't be permanently un-bumpable.)
+        let target_v =
+            LibXMTPVersion::parse(version).map_err(|e| GroupError::InvalidMinVersion {
+                value: version.to_string(),
+                reason: e.to_string(),
+            })?;
+        let own_version_str = self.context.version_info().pkg_version().to_string();
+        let own_v =
+            LibXMTPVersion::parse(&own_version_str).map_err(|e| GroupError::InvalidMinVersion {
+                value: own_version_str.clone(),
+                reason: format!("own pkg_version: {e}"),
+            })?;
+        if target_v > own_v {
+            return Err(GroupError::MinVersionExceedsOwnVersion {
+                requested: version.to_string(),
+                own: own_version_str,
+            });
+        }
+        let current_str = self
+            .mutable_metadata()?
+            .attributes
+            .get(MetadataField::MinimumSupportedProtocolVersion.as_str())
+            .cloned();
+        if let Some(current_str) = current_str.as_deref()
+            && !current_str.is_empty()
+        {
+            match LibXMTPVersion::parse(current_str) {
+                Ok(current_v) => {
+                    if target_v < current_v {
+                        return Err(GroupError::MinVersionDowngrade {
+                            requested: version.to_string(),
+                            current: current_str.to_string(),
+                        });
+                    }
+                }
+                Err(e) => {
+                    // Observability: malformed prior floor is an operator-
+                    // visible signal that the legacy GMM bytes are corrupt.
+                    // Leniency below preserves brick-recovery; the warning
+                    // surfaces the corruption.
+                    tracing::warn!(
+                        current = %current_str,
+                        error = %e,
+                        "update_group_min_version: existing min_version is unparseable; \
+                         proceeding without downgrade check"
+                    );
+                }
+            }
+        }
+
+        tracing::info!("update_group_min_version: queuing bump to {}", version);
         let intent_data: Vec<u8> =
             UpdateMetadataIntentData::new_update_group_min_version_to_match_self(
                 version.to_string(),

--- a/crates/xmtp_mls/src/groups/tests/test_libxmtp_version.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_libxmtp_version.rs
@@ -109,3 +109,25 @@ fn test_parse_invalid_format() {
         );
     }
 }
+
+/// `PROPOSALS_MIN_PROTOCOL_VERSION` is the default floor written by
+/// `enable_proposals` when the caller doesn't override `min_version`.
+/// The send-side clamp in `enable_proposals` refuses any
+/// `min_version > own pkg_version`, so this constant being ahead of
+/// the workspace version would brick every production call to
+/// `enable_proposals` that takes the default. Pin the invariant here
+/// so CI fails on a one-sided bump.
+#[test]
+fn proposals_min_protocol_version_does_not_exceed_workspace_version() {
+    let default_floor = LibXMTPVersion::parse(xmtp_configuration::PROPOSALS_MIN_PROTOCOL_VERSION)
+        .expect("PROPOSALS_MIN_PROTOCOL_VERSION must be valid semver");
+    let workspace = LibXMTPVersion::parse(env!("CARGO_PKG_VERSION"))
+        .expect("CARGO_PKG_VERSION must be valid semver");
+    assert!(
+        default_floor <= workspace,
+        "PROPOSALS_MIN_PROTOCOL_VERSION ({}) must be <= CARGO_PKG_VERSION ({}); \
+         a higher default would trip the enable_proposals clamp",
+        xmtp_configuration::PROPOSALS_MIN_PROTOCOL_VERSION,
+        env!("CARGO_PKG_VERSION"),
+    );
+}

--- a/crates/xmtp_mls/src/groups/tests/test_proposals.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_proposals.rs
@@ -1373,6 +1373,167 @@ async fn test_adding_unsupported_member_rejected_when_proposals_enabled() {
     );
 }
 
+/// Footgun guard: `enable_proposals` refuses to write a floor above the
+/// caller's own pkg_version. Without this guard a developer who picked
+/// the wrong constant could brick the group from the inside on the
+/// very next sync.
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_enable_proposals_rejects_min_version_above_own() {
+    use crate::groups::GroupError;
+
+    tester!(alix);
+
+    let alix_group = alix.create_group(None, None)?;
+    let result = alix_group
+        .enable_proposals(EnableProposalsOptions {
+            force: true,
+            min_version: Some("99.0.0".to_string()),
+        })
+        .await;
+    let err = result.expect_err("min_version above own pkg_version must be rejected");
+    assert!(
+        matches!(
+            err,
+            GroupError::MinVersionExceedsOwnVersion { ref requested, .. }
+            if requested == "99.0.0"
+        ),
+        "expected MinVersionExceedsOwnVersion, got {err:?}",
+    );
+}
+
+/// Send-side mirror of the receive-side downgrade check. Calling
+/// `update_group_min_version` with a value below the existing floor
+/// fails fast with a structured error rather than queueing a doomed
+/// AppDataUpdate that every receiver would reject anyway.
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_update_group_min_version_rejects_downgrade() {
+    use crate::groups::GroupError;
+
+    tester!(alix);
+    tester!(bo);
+
+    let alix_group = alix.create_group(None, None)?;
+    alix_group
+        .add_members(&[bo.context.identity.inbox_id()])
+        .await?;
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
+
+    // Raise the floor to alix's own pkg_version (legal — equal to own,
+    // above the test_default 0.0.0 prior).
+    let pkg = alix.version_info().pkg_version().to_string();
+    alix_group.update_group_min_version(&pkg).await?;
+
+    // Attempt to lower the floor to 0.0.0. Rejected before any intent
+    // is queued.
+    let err = alix_group
+        .update_group_min_version("0.0.0")
+        .await
+        .expect_err("downgrade must be rejected by the send-side guard");
+    assert!(
+        matches!(
+            err,
+            GroupError::MinVersionDowngrade { ref requested, ref current }
+            if requested == "0.0.0" && current == &pkg
+        ),
+        "expected MinVersionDowngrade, got {err:?}",
+    );
+}
+
+/// `enable_proposals` is idempotent on an already-migrated group even
+/// when the second call passes a forward-looking `min_version` that
+/// would normally trip the above-own clamp. The clamp runs inside the
+/// lock AFTER the `proposals_enabled` early-return so retry-on-failure
+/// patterns can pin a constant without bricking idempotent callers.
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_enable_proposals_idempotent_with_forward_min_version() {
+    tester!(alix);
+    tester!(bo);
+
+    let alix_group = alix.create_group(None, None)?;
+    alix_group
+        .add_members(&[bo.context.identity.inbox_id()])
+        .await?;
+    // First call succeeds — group migrates with the test floor.
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
+    // Second call with a min_version far above own pkg_version must
+    // be a no-op (idempotent), NOT a MinVersionExceedsOwnVersion error.
+    alix_group
+        .enable_proposals(EnableProposalsOptions {
+            force: true,
+            min_version: Some("99.0.0".to_string()),
+        })
+        .await?;
+}
+
+/// `update_group_min_version` surfaces an unparseable input as a clean
+/// `ProposalsNotSupported` error rather than leaking the internal
+/// `CommitValidationError::InvalidVersionFormat` through the send-side
+/// API. Pinned so a future refactor that drops the `map_err` wrapper
+/// surfaces in CI.
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_update_group_min_version_rejects_malformed_input() {
+    use crate::groups::GroupError;
+
+    tester!(alix);
+    tester!(bo);
+
+    let alix_group = alix.create_group(None, None)?;
+    alix_group
+        .add_members(&[bo.context.identity.inbox_id()])
+        .await?;
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
+
+    let err = alix_group
+        .update_group_min_version("not-a-version")
+        .await
+        .expect_err("malformed semver must be rejected");
+    assert!(
+        matches!(
+            err,
+            GroupError::InvalidMinVersion { ref value, .. } if value == "not-a-version"
+        ),
+        "expected InvalidMinVersion, got {err:?}",
+    );
+}
+
+/// Send-side mirror of the `enable_proposals` clamp on the steady-state
+/// bump path: `update_group_min_version` also refuses values above own
+/// pkg_version. Same footgun, same guard.
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_update_group_min_version_rejects_above_own() {
+    use crate::groups::GroupError;
+
+    tester!(alix);
+    tester!(bo);
+
+    let alix_group = alix.create_group(None, None)?;
+    alix_group
+        .add_members(&[bo.context.identity.inbox_id()])
+        .await?;
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
+
+    let err = alix_group
+        .update_group_min_version("99.0.0")
+        .await
+        .expect_err("min_version above own pkg_version must be rejected");
+    assert!(
+        matches!(
+            err,
+            GroupError::MinVersionExceedsOwnVersion { ref requested, .. }
+            if requested == "99.0.0"
+        ),
+        "expected MinVersionExceedsOwnVersion, got {err:?}",
+    );
+}
+
 // =============================================================================
 // Build Extensions Tests
 // =============================================================================
@@ -3765,13 +3926,23 @@ async fn test_welcome_on_migrated_group_pauses_below_min_version() {
 /// below-floor receiver silently kept processing commits.
 #[xmtp_common::test(unwrap_try = true)]
 async fn test_steady_state_pause_on_min_version_bump_via_app_data_update() {
+    use crate::builder::ClientBuilder;
     use crate::groups::tests::increment_patch_version;
+    use crate::utils::VersionInfo;
+    use xmtp_cryptography::utils::generate_local_wallet;
 
-    // Both alix and bo at the default pkg_version so both can apply the
-    // bootstrap commit cleanly. `enable_proposals`' step-A legacy GMM
-    // bump sets the floor to alix's pkg_version (== bo's pkg_version),
-    // so neither is paused by the legacy path, and both migrate.
-    tester!(alix);
+    // Alix runs one patch ahead of the default pkg_version so she can
+    // legitimately bump the floor to her own version — the send-side
+    // clamp added in this change rejects `min_version > own_pkg_version`
+    // (footgun guard). Bo stays at the default version so he ends up
+    // below the new floor.
+    let mut alix_version = VersionInfo::default();
+    let bumped = increment_patch_version(alix_version.pkg_version()).expect("patch bump");
+    alix_version.test_update_version(&bumped);
+    let alix_pkg_version = alix_version.pkg_version().to_string();
+    let alix =
+        ClientBuilder::new_test_client_with_version(&generate_local_wallet(), alix_version).await;
+
     tester!(bo);
 
     let alix_group = alix.create_group(None, None)?;
@@ -3786,6 +3957,9 @@ async fn test_steady_state_pause_on_min_version_bump_via_app_data_update() {
         .expect("bo should receive a welcome for alix_group");
     bo_group.sync().await?;
 
+    // Migrate with the test floor (`0.0.0`) so bo isn't paused by the
+    // step-A legacy GMM bump — this test specifically exercises the
+    // POST-migration steady-state pause path, not the pre-bootstrap one.
     alix_group
         .enable_proposals(EnableProposalsOptions::test_default())
         .await?;
@@ -3804,32 +3978,21 @@ async fn test_steady_state_pause_on_min_version_bump_via_app_data_update() {
         );
     }
 
-    // Alix raises the floor above both members' pkg_version. On the
-    // migrated group this flows as an
-    // `AppDataUpdate(MIN_SUPPORTED_PROTOCOL_VERSION)` proposal inside a
-    // commit — the legacy GMM extension is gone, so the dict is the
-    // only path the floor can ride on. Alix's call may return Ok (her
-    // local sync resolves the intent before her validator re-applies
-    // the commit against the new floor) or Err (her local replay hits
-    // `ProtocolVersionTooLow` since her pkg_version is also below the
-    // new floor). Either way, the commit reaches the server. Log the
-    // error instead of swallowing it silently so a non-version-pause
-    // failure mode (network, intent rejection) would surface in test
-    // output if this assumption stopped holding.
-    let pkg = alix.version_info().pkg_version().to_string();
-    let bumped = increment_patch_version(&pkg).expect("patch bump");
-    if let Err(e) = alix_group.update_group_min_version(&bumped).await {
-        tracing::debug!(
-            "expected: alix's update_group_min_version surfaced an error \
-             (her pkg_version is below the new floor): {e}"
-        );
-    }
+    // Alix raises the floor to her own version, which is above bo's.
+    // Send-side clamp is satisfied (alix's pkg_version == requested
+    // floor). The bump flows as an
+    // `AppDataUpdate(MIN_SUPPORTED_PROTOCOL_VERSION)` inside a commit —
+    // post-bootstrap the legacy GMM extension is gone so the dict is
+    // the only path the floor can ride on.
+    alix_group
+        .update_group_min_version(&alix_pkg_version)
+        .await?;
 
     bo_group.sync().await?;
     let paused = bo_group.paused_for_version()?;
     assert_eq!(
         paused.as_deref(),
-        Some(bumped.as_str()),
+        Some(alix_pkg_version.as_str()),
         "bo must be paused at the new floor via the AppDataUpdate-driven path; \
          post-bootstrap the legacy GMM extension is gone so the dict overlay is the \
          only floor signal the validator can read"

--- a/crates/xmtp_mls/src/groups/validated_commit.rs
+++ b/crates/xmtp_mls/src/groups/validated_commit.rs
@@ -103,6 +103,18 @@ pub enum CommitValidationError {
     ProposerNotFound,
     #[error("Proposals are not enabled on this group")]
     ProposalsNotEnabled,
+    /// Sender published an `AppDataUpdate(Update)` against
+    /// `MIN_SUPPORTED_PROTOCOL_VERSION` whose new value is below the
+    /// existing floor. Monotonic-only: a downgrade silently unpauses
+    /// peers between the new and old floors, defeating XIP §3's gate.
+    #[error("min_version {requested} would downgrade existing floor {current}")]
+    MinVersionDowngrade { requested: String, current: String },
+    /// Sender published an `AppDataUpdate(Remove)` against
+    /// `MIN_SUPPORTED_PROTOCOL_VERSION` on a group that already has a
+    /// floor set. Explicit unsetting is just a downgrade in disguise,
+    /// rejected for the same XIP §3 reason.
+    #[error("min_version remove is rejected; existing floor is {current}")]
+    MinVersionRemoveOnExistingFloor { current: String },
     /// A well-known component value in the AppData dictionary failed
     /// to decode while validating an AppDataUpdate proposal — most
     /// commonly a malformed `COMPONENT_REGISTRY`. Treated as a
@@ -1284,6 +1296,59 @@ fn validate_one_app_data_update(
     )
 }
 
+/// Receive-side enforcement of `MIN_SUPPORTED_PROTOCOL_VERSION`
+/// monotonicity. A proposal that lowers the floor (or removes it
+/// while one was set) is rejected before it can reach the dict.
+/// `Update(new)` with `new >= old` (or `old` absent / unparseable)
+/// passes. `Remove` with an existing floor fails — explicit unsetting
+/// of the floor is just a downgrade in disguise.
+///
+/// This is the source-of-truth check; the send-side guard in
+/// `update_group_min_version` is a friendlier UX layer over the same
+/// invariant. An attacker patching out the send-side gate still hits
+/// this one on every receiver.
+fn enforce_min_version_monotonicity(
+    operation: &openmls::messages::proposals::AppDataUpdateOperation,
+    old_value: Option<&[u8]>,
+) -> Result<(), CommitValidationError> {
+    use openmls::messages::proposals::AppDataUpdateOperation;
+    // First-set on a group with no prior floor is always allowed —
+    // there's nothing to downgrade against.
+    let Some(old_bytes) = old_value else {
+        return Ok(());
+    };
+    // If the prior bytes don't parse as semver, we can't compare.
+    // Treat as "no prior floor" and accept — refusing every future
+    // update on a malformed prior would brick the group.
+    let Ok(old_str) = std::str::from_utf8(old_bytes) else {
+        return Ok(());
+    };
+    let Ok(old_v) = LibXMTPVersion::parse(old_str) else {
+        return Ok(());
+    };
+    match operation {
+        AppDataUpdateOperation::Update(payload) => {
+            let new_bytes = payload.as_slice();
+            let new_str = std::str::from_utf8(new_bytes).map_err(|_| {
+                CommitValidationError::InvalidVersionFormat(format!("{:?}", new_bytes))
+            })?;
+            let new_v = LibXMTPVersion::parse(new_str)?;
+            if new_v < old_v {
+                return Err(CommitValidationError::MinVersionDowngrade {
+                    requested: new_str.to_string(),
+                    current: old_str.to_string(),
+                });
+            }
+            Ok(())
+        }
+        AppDataUpdateOperation::Remove => {
+            Err(CommitValidationError::MinVersionRemoveOnExistingFloor {
+                current: old_str.to_string(),
+            })
+        }
+    }
+}
+
 /// Pure core of [`validate_one_app_data_update`] with `old_value`
 /// passed explicitly so unit tests can exercise the
 /// expand → per-change policy loop without a real MLS group.
@@ -1299,6 +1364,24 @@ pub(super) fn validate_one_app_data_update_with_old_value(
         registry_table::lookup_component,
         validation::{ComponentChange, validate_component_write},
     };
+
+    // Source-of-truth monotonicity for `MIN_SUPPORTED_PROTOCOL_VERSION`.
+    // Runs ahead of the per-element policy loop so a downgrade fails
+    // fast with a structured error rather than passing the policy
+    // check and silently relaxing the pause gate. See
+    // `enforce_min_version_monotonicity` for the rule shape.
+    if component_id
+        == xmtp_mls_common::app_data::component_id::ComponentId::MIN_SUPPORTED_PROTOCOL_VERSION
+    {
+        enforce_min_version_monotonicity(operation, old_value).inspect_err(|err| {
+            tracing::warn!(
+                proposer_inbox_id,
+                component_id = %component_id,
+                error = %err,
+                "AppDataUpdate proposal rejected: min_version monotonicity"
+            );
+        })?;
+    }
 
     // Two dispatch shapes:
     //
@@ -2279,6 +2362,131 @@ mod permission_on_receive_tests {
         assert!(
             matches!(err, CommitValidationError::InsufficientPermissions),
             "expected InsufficientPermissions, got {err:?}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod min_version_monotonicity_tests {
+    use super::*;
+    use openmls::messages::proposals::AppDataUpdateOperation;
+
+    fn update_op(s: &str) -> AppDataUpdateOperation {
+        AppDataUpdateOperation::Update(s.as_bytes().to_vec().into())
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn first_set_with_no_prior_floor_is_allowed() {
+        enforce_min_version_monotonicity(&update_op("1.11.0-dev"), None)?;
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn equal_version_is_allowed() {
+        enforce_min_version_monotonicity(&update_op("1.11.0-dev"), Some(b"1.11.0-dev"))?;
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn higher_version_is_allowed() {
+        enforce_min_version_monotonicity(&update_op("1.11.0"), Some(b"1.11.0-dev"))?;
+        enforce_min_version_monotonicity(&update_op("1.12.0"), Some(b"1.11.0-dev"))?;
+        enforce_min_version_monotonicity(&update_op("2.0.0"), Some(b"1.11.0-dev"))?;
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn lower_version_is_rejected() {
+        let err = enforce_min_version_monotonicity(&update_op("1.10.0"), Some(b"1.11.0-dev"))
+            .expect_err("downgrade must be rejected");
+        assert!(
+            matches!(
+                err,
+                CommitValidationError::MinVersionDowngrade { ref requested, ref current }
+                if requested == "1.10.0" && current == "1.11.0-dev"
+            ),
+            "expected MinVersionDowngrade, got {err:?}",
+        );
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn remove_with_prior_floor_is_rejected() {
+        let err =
+            enforce_min_version_monotonicity(&AppDataUpdateOperation::Remove, Some(b"1.11.0-dev"))
+                .expect_err("remove on a set floor must be rejected");
+        assert!(
+            matches!(
+                err,
+                CommitValidationError::MinVersionRemoveOnExistingFloor { ref current }
+                if current == "1.11.0-dev"
+            ),
+            "expected MinVersionRemoveOnExistingFloor, got {err:?}",
+        );
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn remove_with_no_prior_floor_is_allowed() {
+        enforce_min_version_monotonicity(&AppDataUpdateOperation::Remove, None)?;
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn malformed_prior_skips_check() {
+        // Lenient on unparseable prior bytes — refusing every future
+        // update on a malformed floor would brick the group.
+        enforce_min_version_monotonicity(&update_op("1.11.0-dev"), Some(b"not-a-version"))?;
+        enforce_min_version_monotonicity(&update_op("1.11.0-dev"), Some(&[0xff, 0xfe, 0xfd]))?;
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn malformed_new_value_surfaces_parse_error() {
+        let err =
+            enforce_min_version_monotonicity(&update_op("not-a-version"), Some(b"1.11.0-dev"))
+                .expect_err("malformed new value must error");
+        assert!(
+            matches!(err, CommitValidationError::InvalidVersionFormat(_)),
+            "expected InvalidVersionFormat, got {err:?}",
+        );
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn prerelease_ordering_matches_semver() {
+        // semver §11: pre-release sorts BEFORE the release. Bumping
+        // from a pre-release to the corresponding release is allowed;
+        // going the other way is a downgrade.
+        enforce_min_version_monotonicity(&update_op("1.10.0"), Some(b"1.10.0-rc.1"))?;
+        let err = enforce_min_version_monotonicity(&update_op("1.10.0-rc.1"), Some(b"1.10.0"))
+            .expect_err("rc → release reverse must be rejected");
+        assert!(
+            matches!(err, CommitValidationError::MinVersionDowngrade { .. }),
+            "expected MinVersionDowngrade, got {err:?}",
+        );
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn dev_prerelease_is_lower_than_release() {
+        // The default `PROPOSALS_MIN_PROTOCOL_VERSION` is the
+        // `-dev` pre-release of the workspace version, so by
+        // semver §11 the release of the same x.y.z must sort
+        // above it. Lock both directions:
+        //   - LibXMTPVersion comparator agrees,
+        //   - bumping the floor from `-dev` to the release is allowed,
+        //   - the reverse is a downgrade.
+        let dev = LibXMTPVersion::parse("1.11.0-dev")?;
+        let release = LibXMTPVersion::parse("1.11.0")?;
+        assert!(
+            release > dev,
+            "expected 1.11.0 > 1.11.0-dev per semver §11, got release={release:?} dev={dev:?}",
+        );
+        assert!(dev < release, "expected 1.11.0-dev < 1.11.0 per semver §11");
+
+        enforce_min_version_monotonicity(&update_op("1.11.0"), Some(b"1.11.0-dev"))?;
+
+        let err = enforce_min_version_monotonicity(&update_op("1.11.0-dev"), Some(b"1.11.0"))
+            .expect_err("release → -dev reverse must be rejected");
+        assert!(
+            matches!(
+                err,
+                CommitValidationError::MinVersionDowngrade { ref requested, ref current }
+                if requested == "1.11.0-dev" && current == "1.11.0"
+            ),
+            "expected MinVersionDowngrade, got {err:?}",
         );
     }
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Clamp min_version to own package version when enabling or bumping proposals
- `enable_proposals` and `update_group_min_version` now reject any `min_version` value greater than the caller's own `CARGO_PKG_VERSION`, returning `GroupError::MinVersionExceedsOwnVersion`.
- `update_group_min_version` also rejects downgrades below the current floor (`MinVersionDowngrade`) and malformed inputs (`InvalidMinVersion`); receive-side commit validation enforces the same monotonicity rules via a new `enforce_min_version_monotonicity` helper in [`validated_commit.rs`](https://github.com/xmtp/libxmtp/pull/3647/files#diff-233994c0ec18d23d0636e849849a3500e44611a4f64c6fffb1d0931aa1461ed6).
- `PROPOSALS_MIN_PROTOCOL_VERSION` is changed from `"1.11.0"` to `"1.11.0-dev"` so the default floor stays within the workspace's own pre-release version.
- `enable_proposals` is now idempotent even when a forward-looking `min_version` is supplied on an already-migrated group, and skips queuing a redundant bootstrap intent if a concurrent migration completed between lock acquisitions.
- Risk: callers that previously passed `min_version` values above the current package version will now receive a non-retryable error instead of succeeding.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3e85f6a.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->