### PR TITLE
xmtp_mls: replace custom PROPOSAL_SUPPORT extension

### DIFF
--- a/crates/xmtp_configuration/src/common/metadata.rs
+++ b/crates/xmtp_configuration/src/common/metadata.rs
@@ -20,7 +20,9 @@ pub const GROUP_MEMBERSHIP_EXTENSION_ID: u16 = 0xff01;
 pub const GROUP_PERMISSIONS_EXTENSION_ID: u16 = 0xff02;
 pub const WELCOME_WRAPPER_ENCRYPTION_EXTENSION_ID: u16 = 0xff03;
 pub const WELCOME_POINTEE_ENCRYPTION_AEAD_TYPES_EXTENSION_ID: u16 = 0xff04;
-/// Extension ID for proposal support.
-/// - On leaf nodes: indicates the installation supports proposal-by-reference flow
-/// - On group context: indicates the group uses proposal-by-reference flow exclusively
-pub const PROPOSAL_SUPPORT_EXTENSION_ID: u16 = 0xff05;
+// 0xff05 was the custom XMTP `PROPOSAL_SUPPORT` extension id, removed
+// in favor of the standard MLS `ExtensionType::AppDataDictionary`
+// advertisement + `RequiredCapabilities` mechanism. Do not reuse this
+// id — any historical artifact carrying it on the wire should be
+// treated as a no-op opaque extension by the unknown-component
+// tolerance machinery.

--- a/crates/xmtp_configuration/src/prod/mls.rs
+++ b/crates/xmtp_configuration/src/prod/mls.rs
@@ -3,5 +3,3 @@ use xmtp_common::{NS_IN_DAY, NS_IN_HOUR};
 pub const SYNC_UPDATE_INSTALLATIONS_INTERVAL_NS: i64 = NS_IN_HOUR / 2; // 30 min
 
 pub const KEYS_EXPIRATION_INTERVAL_NS: i64 = NS_IN_DAY; // 1 day
-
-pub const BROADCAST_PROPOSAL_SUPPORT: bool = false;

--- a/crates/xmtp_configuration/src/test/mls.rs
+++ b/crates/xmtp_configuration/src/test/mls.rs
@@ -5,5 +5,3 @@ use xmtp_common::NS_IN_SEC;
 pub const SYNC_UPDATE_INSTALLATIONS_INTERVAL_NS: i64 = NS_IN_SEC; // 1 Second
 
 pub const KEYS_EXPIRATION_INTERVAL_NS: i64 = 3 * NS_IN_SEC; //3 seconds
-
-pub const BROADCAST_PROPOSAL_SUPPORT: bool = true;

--- a/crates/xmtp_mls/src/groups/app_data/bootstrap_validator.rs
+++ b/crates/xmtp_mls/src/groups/app_data/bootstrap_validator.rs
@@ -7,9 +7,10 @@
 //! Divergence is rejected.
 //!
 //! Entry points:
-//! - [`is_bootstrap_commit`] — shape-check a staged commit (GCE flips
-//!   `PROPOSAL_SUPPORT` on, drops the four legacy extensions, plus a
-//!   `COMPONENT_REGISTRY` write). Routes commits into this validator.
+//! - [`is_bootstrap_commit`] — shape-check a staged commit (GCE drops
+//!   the four legacy extensions and requires `AppDataDictionary` in
+//!   `RequiredCapabilities`, plus a `COMPONENT_REGISTRY` write).
+//!   Routes commits into this validator.
 //! - [`validate_bootstrap_commit`] — full validation against pre-flip
 //!   state. Pure-logic core lives in [`validate_against_canonical_subset`]
 //!   so it's unit-testable without a real `StagedCommit`.
@@ -26,7 +27,6 @@ use prost::Message as _;
 use tls_codec::Deserialize;
 use xmtp_configuration::{
     GROUP_MEMBERSHIP_EXTENSION_ID, GROUP_PERMISSIONS_EXTENSION_ID, MUTABLE_METADATA_EXTENSION_ID,
-    PROPOSAL_SUPPORT_EXTENSION_ID,
 };
 use xmtp_mls_common::{
     app_data::{
@@ -103,9 +103,8 @@ pub enum BootstrapValidationError {
         actual: u64,
     },
     /// The commit's GCE proposal doesn't have the shape bootstrap
-    /// requires: add exactly `PROPOSAL_SUPPORT`, remove exactly the
-    /// four legacy XMTP extensions, and matching `RequiredCapabilities`
-    /// adjustment.
+    /// requires: remove exactly the four legacy XMTP extensions and
+    /// list `AppDataDictionary` in `RequiredCapabilities`.
     #[error("bootstrap GCE-proposal shape mismatch: {0}")]
     GceMismatch(String),
     /// Failed to decode the on-wire bytes of a bootstrap `AppDataUpdate`
@@ -157,24 +156,27 @@ pub enum BootstrapValidationError {
 /// Shape-check a staged commit against the bootstrap signature.
 ///
 /// A bootstrap commit has, in a single MLS commit:
-/// 1. A `GroupContextExtensions` proposal that adds
-///    `PROPOSAL_SUPPORT_EXTENSION_ID` (the capability flip).
-/// 2. The same GCE proposal drops `MUTABLE_METADATA_EXTENSION_ID`,
-///    `GROUP_PERMISSIONS_EXTENSION_ID`, `GROUP_MEMBERSHIP_EXTENSION_ID`,
-///    and the OpenMLS-built-in `ImmutableMetadata` extension.
+/// 1. A `GroupContextExtensions` proposal that drops
+///    `MUTABLE_METADATA_EXTENSION_ID`, `GROUP_PERMISSIONS_EXTENSION_ID`,
+///    `GROUP_MEMBERSHIP_EXTENSION_ID`, and the OpenMLS-built-in
+///    `ImmutableMetadata` extension.
+/// 2. The same GCE proposal's `RequiredCapabilities` lists
+///    `ExtensionType::AppDataDictionary` (the standard MLS extension
+///    that carries the dict). After commit application this is the
+///    invariant pinning the group into migrated state.
 /// 3. At least one `AppDataUpdate` proposal writing
-///    `COMPONENT_REGISTRY` (the migration marker).
+///    `COMPONENT_REGISTRY`. Its application populates the
+///    `AppDataDictionary` GCE that `RequiredCapabilities` now
+///    requires.
 ///
-/// The three conditions together are what differentiate a bootstrap
-/// from a plain `enable_proposals()` commit (which only satisfies #1),
-/// from a metadata-attribute update via `AppDataUpdate` (which never
-/// satisfies #1 or #2), and from any other combinatorial GCE flow.
+/// The three conditions together differentiate a bootstrap from any
+/// other combinatorial GCE flow.
 pub(crate) fn is_bootstrap_commit(
     staged_commit: &StagedCommit,
     existing_extensions: &Extensions<GroupContext>,
 ) -> bool {
-    // Only fire on the pre-flip side — a group that already has
-    // PROPOSAL_SUPPORT can't "bootstrap" again.
+    // Only fire on the pre-flip side — a group that already has the
+    // AppDataDictionary GCE can't "bootstrap" again.
     if crate::groups::check_proposals_enabled(existing_extensions) {
         return false;
     }
@@ -184,7 +186,16 @@ pub(crate) fn is_bootstrap_commit(
     for queued in staged_commit.queued_proposals() {
         match queued.proposal() {
             Proposal::GroupContextExtensions(gce) => {
-                gce_matches = gce_matches_bootstrap_shape(gce.extensions());
+                let exts = gce.extensions();
+                // Symmetric routing: a GCE that strips the legacy
+                // extensions without flipping RequiredCapabilities is
+                // NOT a bootstrap commit. Routing it to the bootstrap
+                // validator would surface a misleading
+                // "RequiredCapabilities is missing" error when the
+                // real problem is "you can't strip legacy extensions
+                // unless you're migrating".
+                gce_matches = gce_matches_bootstrap_shape(exts)
+                    && gce_required_capabilities_match_bootstrap_shape(exts);
             }
             Proposal::AppDataUpdate(app_data)
                 if ComponentId::from(app_data.component_id())
@@ -199,14 +210,12 @@ pub(crate) fn is_bootstrap_commit(
 }
 
 /// Does `new_extensions` look like the bootstrap GCE output?
-/// Adds `PROPOSAL_SUPPORT` and drops the four legacy XMTP extensions.
+/// Drops the four legacy XMTP extensions. The `RequiredCapabilities`
+/// shape check is enforced separately by
+/// `gce_required_capabilities_match_bootstrap_shape` so the validator
+/// can distinguish "no RC at all" from "RC has wrong shape" — pinned
+/// by `gce_extension_set_missing_required_capabilities_rejected`.
 fn gce_matches_bootstrap_shape(new_extensions: &Extensions<GroupContext>) -> bool {
-    let has_proposal_support = new_extensions.iter().any(|ext| {
-        matches!(
-            ext,
-            Extension::Unknown(id, _) if *id == PROPOSAL_SUPPORT_EXTENSION_ID
-        )
-    });
     let drops_legacy = |id: u16| {
         !new_extensions
             .iter()
@@ -216,11 +225,29 @@ fn gce_matches_bootstrap_shape(new_extensions: &Extensions<GroupContext>) -> boo
         .iter()
         .any(|ext| matches!(ext, Extension::ImmutableMetadata(_)));
 
-    has_proposal_support
-        && drops_legacy(MUTABLE_METADATA_EXTENSION_ID)
+    drops_legacy(MUTABLE_METADATA_EXTENSION_ID)
         && drops_legacy(GROUP_PERMISSIONS_EXTENSION_ID)
         && drops_legacy(GROUP_MEMBERSHIP_EXTENSION_ID)
         && drops_immutable
+}
+
+/// Does `new_extensions.required_capabilities()` carry the
+/// `AppDataDictionary` flip the bootstrap requires? Used by the router
+/// (`is_bootstrap_commit`) so a GCE that drops the legacy extensions
+/// but doesn't flip RequiredCapabilities is NOT routed into the
+/// bootstrap validator at all — the steady-state validator will
+/// reject it for losing the legacy extensions on a non-migrated
+/// group, which is the more accurate error mode.
+fn gce_required_capabilities_match_bootstrap_shape(
+    new_extensions: &Extensions<GroupContext>,
+) -> bool {
+    new_extensions
+        .required_capabilities()
+        .map(|rc| {
+            rc.extension_types()
+                .contains(&ExtensionType::AppDataDictionary)
+        })
+        .unwrap_or(false)
 }
 
 /// Extract the bootstrap commit's single GCE-proposal proposer.
@@ -302,9 +329,9 @@ pub(crate) fn validate_bootstrap_commit(
 /// `Remove`, `Update`, `SelfRemove`) and identity-key-neutral (no
 /// `ReInit`, `ExternalInit`, `PreSharedKey`); the canonical-subset
 /// compare also presumes there are no `AppEphemeral` or `Custom`
-/// payloads. The only legal types are the single GCE that flips
-/// `PROPOSAL_SUPPORT` and the `AppDataUpdate` proposals that seed the
-/// post-flip dictionary.
+/// payloads. The only legal types are the single GCE that drops the
+/// legacy extensions plus requires `AppDataDictionary`, and the
+/// `AppDataUpdate` proposals that seed the post-flip dictionary.
 fn is_allowed_bootstrap_proposal(proposal: &Proposal) -> bool {
     matches!(
         proposal,
@@ -693,9 +720,9 @@ fn validate_group_membership_payload(
 }
 
 /// Verify the commit's single GCE proposal has the bootstrap shape:
-/// adds exactly `PROPOSAL_SUPPORT`, drops exactly the four legacy
-/// extension types (and mirrors that in `RequiredCapabilities`). Any
-/// extra add/drop beyond the bootstrap contract → reject.
+/// drops exactly the four legacy extension types and lists
+/// `AppDataDictionary` in `RequiredCapabilities`. Any extra add/drop
+/// beyond the bootstrap contract → reject.
 fn validate_gce_shape(staged_commit: &StagedCommit) -> Result<(), BootstrapValidationError> {
     let mut found_gce = None;
     for queued in staged_commit.queued_proposals() {
@@ -725,27 +752,26 @@ fn validate_gce_extension_set(
 ) -> Result<(), BootstrapValidationError> {
     if !gce_matches_bootstrap_shape(new_extensions) {
         return Err(BootstrapValidationError::GceMismatch(
-            "GCE extension set does not match bootstrap shape (needs +PROPOSAL_SUPPORT, \
+            "GCE extension set does not match bootstrap shape (needs \
              -MUTABLE_METADATA, -GROUP_PERMISSIONS, -GROUP_MEMBERSHIP, -ImmutableMetadata)"
                 .into(),
         ));
     }
 
     // RequiredCapabilities MUST be present and MUST drop the four
-    // legacy extension types while adding PROPOSAL_SUPPORT. A bootstrap
-    // commit with no RequiredCapabilities at all would let post-flip
-    // adds skip the PROPOSAL_SUPPORT check and rejoin a broken group
-    // shape — reject hard.
+    // legacy extension types while adding `AppDataDictionary`. A
+    // bootstrap commit with no RequiredCapabilities at all would let
+    // post-flip adds skip the AppData support check and rejoin a
+    // broken group shape — reject hard.
     let required = new_extensions.required_capabilities().ok_or_else(|| {
         BootstrapValidationError::GceMismatch(
             "RequiredCapabilities extension is missing — bootstrap requires it to enforce \
-             PROPOSAL_SUPPORT and ban the four legacy extension types"
+             AppDataDictionary support and ban the four legacy extension types"
                 .into(),
         )
     })?;
     let ext_types: Vec<ExtensionType> = required.extension_types().to_vec();
-    let has_proposal_support =
-        ext_types.contains(&ExtensionType::Unknown(PROPOSAL_SUPPORT_EXTENSION_ID));
+    let requires_app_data_dictionary = ext_types.contains(&ExtensionType::AppDataDictionary);
     let bans_legacy = ![
         ExtensionType::Unknown(MUTABLE_METADATA_EXTENSION_ID),
         ExtensionType::Unknown(GROUP_PERMISSIONS_EXTENSION_ID),
@@ -754,7 +780,7 @@ fn validate_gce_extension_set(
     ]
     .iter()
     .any(|banned| ext_types.contains(banned));
-    if !has_proposal_support || !bans_legacy {
+    if !requires_app_data_dictionary || !bans_legacy {
         return Err(BootstrapValidationError::GceMismatch(
             "RequiredCapabilities doesn't match bootstrap shape".into(),
         ));
@@ -1156,21 +1182,17 @@ mod tests {
         assert_eq!(proposal_type_name(&custom), "Custom");
     }
 
-    /// Build a bootstrap-shaped GCE extension set (adds `PROPOSAL_SUPPORT`,
-    /// drops the four legacy extensions). `with_required_capabilities`
-    /// controls whether the synthesized `RequiredCapabilities` extension
-    /// is included — that's the security-critical bit under test.
+    /// Build a bootstrap-shaped GCE extension set (drops the four
+    /// legacy extensions). `with_required_capabilities` controls
+    /// whether the synthesized `RequiredCapabilities` extension is
+    /// included with `AppDataDictionary` listed — that's the
+    /// security-critical bit under test.
     fn bootstrap_gce_extensions(with_required_capabilities: bool) -> Extensions<GroupContext> {
-        use openmls::extensions::{Extension, RequiredCapabilitiesExtension, UnknownExtension};
+        use openmls::extensions::{Extension, RequiredCapabilitiesExtension};
         use openmls::prelude::ProposalType;
         let mut exts = Extensions::empty();
-        exts.add(Extension::Unknown(
-            PROPOSAL_SUPPORT_EXTENSION_ID,
-            UnknownExtension(vec![]),
-        ))
-        .unwrap();
         if with_required_capabilities {
-            let ext_types = [ExtensionType::Unknown(PROPOSAL_SUPPORT_EXTENSION_ID)];
+            let ext_types = [ExtensionType::AppDataDictionary];
             let proposal_types = [ProposalType::AppDataUpdate];
             let required = RequiredCapabilitiesExtension::new(&ext_types, &proposal_types, &[]);
             exts.add(Extension::RequiredCapabilities(required)).unwrap();
@@ -1182,8 +1204,8 @@ mod tests {
     fn gce_extension_set_missing_required_capabilities_rejected() {
         // Security-critical: a bootstrap commit that strips
         // `RequiredCapabilities` lets post-flip adds skip the
-        // `PROPOSAL_SUPPORT` check and rejoin a broken group shape.
-        // Pure-extension-bag check covers the path that
+        // `AppDataDictionary` requirement and rejoin a broken group
+        // shape. Pure-extension-bag check covers the path that
         // `validate_gce_shape` delegates to.
         let exts = bootstrap_gce_extensions(false);
         let err = validate_gce_extension_set(&exts).unwrap_err();

--- a/crates/xmtp_mls/src/groups/app_data/migration.rs
+++ b/crates/xmtp_mls/src/groups/app_data/migration.rs
@@ -308,10 +308,13 @@ pub enum BootstrapCommitError<StorageError: std::error::Error> {
     /// a commit that every honest receiver rejects.
     #[error("bootstrap precondition: new_extensions still carries legacy XMTP extension {0:#06x}")]
     LegacyExtensionPresent(u16),
-    /// Caller invariant violated: `new_extensions` is missing the
-    /// PROPOSAL_SUPPORT extension that bootstrap groups MUST carry.
-    #[error("bootstrap precondition: new_extensions is missing PROPOSAL_SUPPORT")]
-    MissingProposalSupport,
+    /// Caller invariant violated: `new_extensions`'s
+    /// `RequiredCapabilities` doesn't list
+    /// `ExtensionType::AppDataDictionary`. Every bootstrap commit
+    /// MUST require AppDataDictionary so post-flip members can't skip
+    /// the support check.
+    #[error("bootstrap precondition: RequiredCapabilities doesn't list AppDataDictionary")]
+    MissingAppDataDictionaryRequirement,
     /// Sender-side `apply_app_data_update_payload` rejected one of
     /// the synthesized component values when deriving dict bytes from
     /// wire bytes. Indicates a bug in synthesis (the wire bytes don't
@@ -333,11 +336,15 @@ pub enum BootstrapCommitError<StorageError: std::error::Error> {
 /// The caller is responsible for computing `component_values` via the
 /// async [`synthesize_initial_component_values`] and for building
 /// `new_extensions` with:
-/// - `PROPOSAL_SUPPORT_EXTENSION_ID` added
 /// - `MUTABLE_METADATA_EXTENSION_ID`, `GROUP_PERMISSIONS_EXTENSION_ID`,
 ///   `GROUP_MEMBERSHIP_EXTENSION_ID`, and the immutable metadata
 ///   extension (`ExtensionType::ImmutableMetadata`) removed from the
 ///   group context extensions AND from `RequiredCapabilities`.
+/// - `ExtensionType::AppDataDictionary` added to `RequiredCapabilities`
+///   so receivers must advertise support for the dict-carrying
+///   standard MLS extension. The `AppDataDictionary` GCE itself is
+///   populated by OpenMLS when the bundled `AppDataUpdate` proposals
+///   apply during commit processing.
 pub fn stage_bootstrap_commit<Provider: OpenMlsProvider>(
     mls_group: &mut OpenMlsGroup,
     provider: &Provider,
@@ -380,8 +387,21 @@ pub fn stage_bootstrap_commit<Provider: OpenMlsProvider>(
             _ => {}
         }
     }
-    if !crate::groups::check_proposals_enabled(&new_extensions) {
-        return Err(BootstrapCommitError::MissingProposalSupport);
+    // RequiredCapabilities MUST list AppDataDictionary so post-flip
+    // members can't add themselves without supporting the dict. Using
+    // `check_proposals_enabled` (which detects the AppDataDictionary
+    // GCE itself) wouldn't work here — openmls only adds the dict GCE
+    // when the AppDataUpdate proposals apply during commit processing.
+    use openmls::extensions::ExtensionType;
+    let requires_app_data_dictionary = new_extensions
+        .required_capabilities()
+        .map(|rc| {
+            rc.extension_types()
+                .contains(&ExtensionType::AppDataDictionary)
+        })
+        .unwrap_or(false);
+    if !requires_app_data_dictionary {
+        return Err(BootstrapCommitError::MissingAppDataDictionaryRequirement);
     }
 
     // OpenMLS commit-ordering rule (draft-ietf-mls-extensions §4.7-7):

--- a/crates/xmtp_mls/src/groups/intents/queue.rs
+++ b/crates/xmtp_mls/src/groups/intents/queue.rs
@@ -171,10 +171,11 @@ impl QueueIntent {
     /// Create an intent to fire the one-shot AppData-migration
     /// bootstrap commit. The intent payload is a
     /// [`ProposeGroupContextExtensionsIntentData`] carrying the
-    /// target extensions blob (proposal-support added, four legacy
-    /// XMTP extensions removed, RequiredCapabilities updated). The
-    /// handler synthesizes the per-component dict seeds and bundles
-    /// everything into a single commit.
+    /// target extensions blob (four legacy XMTP extensions removed,
+    /// `RequiredCapabilities` updated to require
+    /// `ExtensionType::AppDataDictionary` and drop the legacy
+    /// extension types). The handler synthesizes the per-component
+    /// dict seeds and bundles everything into a single commit.
     pub fn bootstrap_migration() -> QueueIntentBuilder {
         let mut this = QueueIntent::builder();
         this.kind = Some(IntentKind::BootstrapMigration);

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -81,9 +81,8 @@ use xmtp_common::{
 };
 use xmtp_configuration::{
     GRPC_PAYLOAD_LIMIT, HMAC_SALT, MAX_GROUP_SIZE, MAX_GROUP_SYNC_RETRIES,
-    MAX_INTENT_PUBLISH_ATTEMPTS, MAX_PAST_EPOCHS, PROPOSAL_SUPPORT_EXTENSION_ID,
-    SYNC_BACKOFF_TOTAL_WAIT_MAX_SECS, SYNC_BACKOFF_WAIT_MS, SYNC_JITTER_MS,
-    SYNC_UPDATE_INSTALLATIONS_INTERVAL_NS,
+    MAX_INTENT_PUBLISH_ATTEMPTS, MAX_PAST_EPOCHS, SYNC_BACKOFF_TOTAL_WAIT_MAX_SECS,
+    SYNC_BACKOFF_WAIT_MS, SYNC_JITTER_MS, SYNC_UPDATE_INSTALLATIONS_INTERVAL_NS,
 };
 use xmtp_content_types::{CodecError, ContentCodec, group_updated::GroupUpdatedCodec};
 use xmtp_db::message_deletion::{QueryMessageDeletion, StoredMessageDeletion};
@@ -3267,8 +3266,9 @@ where
             IntentKind::BootstrapMigration => {
                 // One-time AppData-migration bootstrap: bundles one
                 // GCE proposal (that strips the four legacy XMTP
-                // extensions and adds PROPOSAL_SUPPORT) with an
-                // `AppDataUpdate` proposal per well-known component.
+                // extensions and adds AppDataDictionary to
+                // RequiredCapabilities) with an `AppDataUpdate`
+                // proposal per well-known component.
                 // Routed on an explicit [`IntentKind::BootstrapMigration`]
                 // rather than shape-sniffing `ProposeGroupContextExtensions`
                 // payloads so a future non-bootstrap GCE intent with
@@ -3509,10 +3509,9 @@ where
 
                         if !new_members_support_proposals {
                             tracing::info!(
-                                "Disabling proposals: new members don't support proposal extension"
+                                "Disabling proposals: new members don't support the AppData dictionary extension"
                             );
-                            new_extensions
-                                .remove(ExtensionType::Unknown(PROPOSAL_SUPPORT_EXTENSION_ID));
+                            new_extensions.remove(ExtensionType::AppDataDictionary);
                             update_required_capabilities_for_proposals(&mut new_extensions, false)?;
                         }
                     }

--- a/crates/xmtp_mls/src/groups/mls_sync/update_group_membership.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync/update_group_membership.rs
@@ -162,24 +162,25 @@ pub(crate) async fn apply_update_group_membership_intent(
     }
 
     // Check if proposals need to be disabled due to new members not supporting them
-    let proposal_ext_type =
-        openmls::prelude::ExtensionType::Unknown(xmtp_configuration::PROPOSAL_SUPPORT_EXTENSION_ID);
+    let app_data_ext_type = openmls::prelude::ExtensionType::AppDataDictionary;
     let mut proposals_currently_enabled = openmls_group
         .extensions()
         .iter()
-        .any(|ext| ext.extension_type() == proposal_ext_type);
+        .any(|ext| ext.extension_type() == app_data_ext_type);
     let mut downgrade_to_legacy = false;
     if proposals_currently_enabled && !changes_with_kps.new_key_packages.is_empty() {
         let new_members_support_proposals = changes_with_kps.new_key_packages.iter().all(|kp| {
             kp.leaf_node()
                 .capabilities()
                 .extensions()
-                .contains(&proposal_ext_type)
+                .contains(&app_data_ext_type)
         });
         // TODO: D14N Hammer
         if !new_members_support_proposals {
-            tracing::info!("Disabling proposals: new members don't support proposal extension");
-            new_extensions.remove(proposal_ext_type);
+            tracing::info!(
+                "Disabling proposals: new members don't support the AppData dictionary extension"
+            );
+            new_extensions.remove(app_data_ext_type);
             update_required_capabilities_for_proposals(&mut new_extensions, false)?;
             proposals_currently_enabled = false;
             // If this group was migrated, downgrading to legacy

--- a/crates/xmtp_mls/src/groups/mod.rs
+++ b/crates/xmtp_mls/src/groups/mod.rs
@@ -62,9 +62,9 @@ use std::{collections::HashSet, sync::Arc};
 use tokio::sync::Mutex;
 use xmtp_common::{Event, log_event, time::now_ns};
 use xmtp_configuration::{
-    BROADCAST_PROPOSAL_SUPPORT, CIPHERSUITE, GROUP_MEMBERSHIP_EXTENSION_ID,
-    GROUP_PERMISSIONS_EXTENSION_ID, MAX_GROUP_SIZE, MAX_PAST_EPOCHS, MUTABLE_METADATA_EXTENSION_ID,
-    Originators, PROPOSAL_SUPPORT_EXTENSION_ID, SEND_MESSAGE_UPDATE_INSTALLATIONS_INTERVAL_NS,
+    CIPHERSUITE, GROUP_MEMBERSHIP_EXTENSION_ID, GROUP_PERMISSIONS_EXTENSION_ID, MAX_GROUP_SIZE,
+    MAX_PAST_EPOCHS, MUTABLE_METADATA_EXTENSION_ID, Originators,
+    SEND_MESSAGE_UPDATE_INSTALLATIONS_INTERVAL_NS,
     WELCOME_POINTEE_ENCRYPTION_AEAD_TYPES_EXTENSION_ID, WELCOME_WRAPPER_ENCRYPTION_EXTENSION_ID,
 };
 use xmtp_content_types::delete_message::DeleteMessageCodec;
@@ -478,7 +478,12 @@ where
         &self,
         mls_group: &OpenMlsGroup,
     ) -> Result<bool, GroupError> {
-        let extension_type = ExtensionType::Unknown(PROPOSAL_SUPPORT_EXTENSION_ID);
+        // The standard MLS Capabilities extension advertises support
+        // for the `AppDataDictionary` extension type. A leaf that lists
+        // it can participate in a migrated group; a leaf that doesn't
+        // can't. This replaces the XMTP-specific PROPOSAL_SUPPORT
+        // extension we used to advertise in parallel.
+        let extension_type = ExtensionType::AppDataDictionary;
 
         // Check leaf nodes in the group first (fast path).
         // If all leaf nodes advertise support, we're done — no network call needed.
@@ -522,12 +527,16 @@ where
 
     /// Check if the group has proposals enabled (proposal-by-reference flow).
     ///
-    /// This checks if the group context contains the `PROPOSAL_SUPPORT_EXTENSION_ID`
-    /// extension with a `ProposalSupport` proto.
+    /// Delegates to `check_proposals_enabled` which detects the
+    /// standard MLS `ExtensionType::AppDataDictionary` group-context
+    /// extension. A migrated group carries the dict via that extension
+    /// type, making it both the wire-format carrier AND the signal
+    /// that the proposal flow is in effect.
     ///
     /// When proposals are enabled on a group:
     /// - Add/remove member operations MUST use proposals
-    /// - All members being added MUST support the proposal extension
+    /// - All members being added MUST advertise `AppDataDictionary`
+    ///   support in their key-package capabilities
     /// - Direct commits for membership changes are not allowed
     pub fn proposals_enabled(&self, mls_group: &OpenMlsGroup) -> bool {
         check_proposals_enabled(mls_group.extensions())
@@ -535,10 +544,15 @@ where
 
     /// Enable proposals on this group (proposal-by-reference flow).
     ///
-    /// This sets the `PROPOSAL_SUPPORT_EXTENSION_ID` extension on the group context.
+    /// Runs the bootstrap commit that migrates the group's state out
+    /// of legacy GMM-style extensions and into the standard MLS
+    /// `AppDataDictionary` extension. After bootstrap completes the
+    /// dictionary is the sole source of truth for the metadata
+    /// attributes that previously lived in the legacy extensions.
     /// Once enabled:
     /// - All add/remove member operations will use proposals
-    /// - All members being added must support proposals
+    /// - All members being added must advertise `AppDataDictionary`
+    ///   support in their key-package capabilities
     /// - This cannot be disabled once set
     ///
     /// # Options
@@ -585,7 +599,7 @@ where
         // never observes step B.
         //
         // Step B: bootstrap commit. Strips legacy extensions, seeds
-        // the dict, adds `PROPOSAL_SUPPORT` to RequiredCapabilities.
+        // the dict, adds `AppDataDictionary` to RequiredCapabilities.
         // Fires only for the still-active (above-floor) members.
         //
         // The safety primitive here is **server-side commit ordering**:
@@ -705,13 +719,15 @@ where
         // Build the bootstrap-target extensions in a single lock
         // acquisition to avoid races. The bootstrap commit produced by
         // `IntentKind::BootstrapMigration` will:
-        // - add `PROPOSAL_SUPPORT` to GCE
         // - REMOVE the four legacy XMTP extensions (mutable metadata,
         //   group permissions, group membership, ImmutableMetadata)
-        // - update RequiredCapabilities to add `PROPOSAL_SUPPORT` and
+        // - update RequiredCapabilities to add `AppDataDictionary` and
         //   drop the four legacy extension types
         // - emit one `AppDataUpdate(component_id, Update(bytes))`
-        //   proposal per well-known component, seeding the dict
+        //   proposal per well-known component, seeding the dict — the
+        //   AppDataDictionary GCE itself is populated by openmls when
+        //   the bundled AppDataUpdate proposals apply during commit
+        //   processing
         // All in a single commit, so the migration is atomic on-the-
         // wire: receivers either see the migrated state (bootstrap
         // commit accepted) or the legacy state (commit rejected).
@@ -735,21 +751,25 @@ where
                 }
                 let mut extensions: Extensions<GroupContext> = mls_group.extensions().clone();
 
-                // 1. Add proposal-support extension.
-                extensions.add_or_replace(build_proposals_enabled_extension())?;
-
-                // 2. Remove the four legacy XMTP extensions. The
+                // 1. Remove the four legacy XMTP extensions. The
                 //    bootstrap commit's job is to eliminate them so
                 //    the dict becomes the sole source of truth.
+                //    The bundled `AppDataUpdate(COMPONENT_REGISTRY)`
+                //    proposal triggers openmls to add the standard
+                //    `AppDataDictionary` group-context extension when
+                //    the commit applies — that extension's presence
+                //    (plus the registry entry) IS the migrated marker.
+                //    No separate XMTP-flavored marker is needed.
                 extensions.remove(ExtensionType::Unknown(MUTABLE_METADATA_EXTENSION_ID));
                 extensions.remove(ExtensionType::Unknown(GROUP_PERMISSIONS_EXTENSION_ID));
                 extensions.remove(ExtensionType::Unknown(GROUP_MEMBERSHIP_EXTENSION_ID));
                 extensions.remove(ExtensionType::ImmutableMetadata);
 
-                // 3. Update RequiredCapabilities: add PROPOSAL_SUPPORT
-                //    and drop the four legacy extension types so
-                //    receivers don't reject the commit for missing
-                //    required extensions.
+                // 2. Update RequiredCapabilities: require
+                //    `AppDataDictionary` (the standard extension that
+                //    carries the dict) and drop the four legacy
+                //    extension types so receivers don't reject the
+                //    commit for missing required extensions.
                 update_required_capabilities_for_bootstrap(&mut extensions)?;
 
                 Ok(extensions)
@@ -792,15 +812,16 @@ where
         Ok(())
     }
 
-    /// Validate that key packages support the proposal extension.
-    ///
-    /// This checks if all provided key packages have the `PROPOSAL_SUPPORT_EXTENSION_ID`
-    /// in their capabilities, meaning the installations can receive standalone proposals.
+    /// Validate that key packages support the AppData dictionary
+    /// group-context extension. A leaf that advertises
+    /// `ExtensionType::AppDataDictionary` in its standard MLS
+    /// `Capabilities` can join a migrated group and receive standalone
+    /// `AppDataUpdate` proposals.
     pub fn validate_key_packages_support_proposals(
         &self,
         key_packages: &[openmls::key_packages::KeyPackage],
     ) -> Result<(), GroupError> {
-        let extension_type = ExtensionType::Unknown(PROPOSAL_SUPPORT_EXTENSION_ID);
+        let extension_type = ExtensionType::AppDataDictionary;
 
         for kp in key_packages {
             let leaf_node = kp.leaf_node();
@@ -808,7 +829,7 @@ where
 
             if !capabilities.extensions().contains(&extension_type) {
                 return Err(GroupError::ProposalsNotSupported(
-                    "Member does not support proposals: installation cannot receive standalone proposal messages".to_string(),
+                    "Member does not support AppData dictionary: installation cannot receive standalone proposal messages".to_string(),
                 ));
             }
         }
@@ -3013,55 +3034,39 @@ pub fn build_group_membership_extension(group_membership: &GroupMembership) -> E
     Extension::Unknown(GROUP_MEMBERSHIP_EXTENSION_ID, unknown_gc_extension)
 }
 
-/// Check if the given extensions contain a valid proposal support extension.
+/// Check if the given extensions belong to a migrated group.
 ///
-/// Returns `true` if the extensions contain a `PROPOSAL_SUPPORT_EXTENSION_ID` extension
-/// with a `ProposalSupport` proto where `version > 0`.
+/// "Migrated" means the bootstrap commit completed: the
+/// [`ExtensionType::AppDataDictionary`] group-context extension is
+/// present and its dict contains a `COMPONENT_REGISTRY` entry. This is
+/// also the canonical predicate used by
+/// [`crate::groups::app_data::is_migrated_extensions`]; the two
+/// converge so the rest of the codebase can use one name where the
+/// proposal-by-reference flow is the question and another where the
+/// dict-source-of-truth migration is the question.
 pub fn check_proposals_enabled(extensions: &Extensions<GroupContext>) -> bool {
-    use prost::Message;
-    use xmtp_proto::xmtp::mls::message_contents::ProposalSupport;
-    for extension in extensions.iter() {
-        if let Extension::Unknown(PROPOSAL_SUPPORT_EXTENSION_ID, UnknownExtension(data)) = extension
-        {
-            if let Ok(ps) = ProposalSupport::decode(data.as_slice()) {
-                return ps.version > 0;
-            } else {
-                return false;
-            }
-        }
-    }
-    false
+    crate::groups::app_data::is_migrated_extensions(extensions)
 }
 
-/// Build an extension that enables proposals on the group context.
-///
-/// This extension uses `PROPOSAL_SUPPORT_EXTENSION_ID` with a `ProposalSupport` proto
-/// to indicate that the group uses proposal-by-reference flow exclusively.
-pub fn build_proposals_enabled_extension() -> Extension {
-    use prost::Message;
-    use xmtp_proto::xmtp::mls::message_contents::ProposalSupport;
-    let data = ProposalSupport { version: 1 }.encode_to_vec();
-    Extension::Unknown(PROPOSAL_SUPPORT_EXTENSION_ID, UnknownExtension(data))
-}
-
-/// Update the `RequiredCapabilities` extension to add or remove the `PROPOSAL_SUPPORT_EXTENSION_ID`.
-/// Per MLS RFC 9420 Section 7.2, unknown extensions in the group context MUST be listed
-/// in the required capabilities, so this must be called whenever the proposal support
-/// extension is added to or removed from the group context.
+/// Update the `RequiredCapabilities` extension to add or remove
+/// `ExtensionType::AppDataDictionary`. Per MLS RFC 9420 §7.2, unknown
+/// extensions in the group context MUST be listed in the required
+/// capabilities, so this must be called whenever the AppData
+/// dictionary extension is added to or removed from the group context.
 pub fn update_required_capabilities_for_proposals(
     extensions: &mut Extensions<GroupContext>,
     add: bool,
 ) -> Result<(), GroupError> {
-    let proposal_ext_type = ExtensionType::Unknown(PROPOSAL_SUPPORT_EXTENSION_ID);
+    let app_data_ext_type = ExtensionType::AppDataDictionary;
 
     if let Some(required_caps) = extensions.required_capabilities() {
         let mut ext_types: Vec<ExtensionType> = required_caps.extension_types().to_vec();
-        let has_it = ext_types.contains(&proposal_ext_type);
+        let has_it = ext_types.contains(&app_data_ext_type);
 
         if add && !has_it {
-            ext_types.push(proposal_ext_type);
+            ext_types.push(app_data_ext_type);
         } else if !add && has_it {
-            ext_types.retain(|t| *t != proposal_ext_type);
+            ext_types.retain(|t| *t != app_data_ext_type);
         } else {
             return Ok(()); // already in desired state
         }
@@ -3078,7 +3083,9 @@ pub fn update_required_capabilities_for_proposals(
 }
 
 /// Update RequiredCapabilities for the bootstrap commit:
-///   - Add `PROPOSAL_SUPPORT` to the required extension types.
+///   - Add `ExtensionType::AppDataDictionary` to the required
+///     extension types so receivers MUST advertise support for the
+///     standard AppData dictionary group-context extension.
 ///   - Remove the four legacy XMTP extension types
 ///     (`MUTABLE_METADATA`, `GROUP_PERMISSIONS`, `GROUP_MEMBERSHIP`,
 ///     `ImmutableMetadata`) since the bootstrap commit also removes
@@ -3090,7 +3097,7 @@ pub fn update_required_capabilities_for_proposals(
 pub fn update_required_capabilities_for_bootstrap(
     extensions: &mut Extensions<GroupContext>,
 ) -> Result<(), GroupError> {
-    let proposal_ext_type = ExtensionType::Unknown(PROPOSAL_SUPPORT_EXTENSION_ID);
+    let app_data_ext_type = ExtensionType::AppDataDictionary;
     let to_remove: &[ExtensionType] = &[
         ExtensionType::Unknown(MUTABLE_METADATA_EXTENSION_ID),
         ExtensionType::Unknown(GROUP_PERMISSIONS_EXTENSION_ID),
@@ -3105,8 +3112,8 @@ pub fn update_required_capabilities_for_bootstrap(
             .copied()
             .filter(|t| !to_remove.contains(t))
             .collect();
-        if !ext_types.contains(&proposal_ext_type) {
-            ext_types.push(proposal_ext_type);
+        if !ext_types.contains(&app_data_ext_type) {
+            ext_types.push(app_data_ext_type);
         }
         let new_required = Extension::RequiredCapabilities(RequiredCapabilitiesExtension::new(
             &ext_types,
@@ -3148,9 +3155,9 @@ pub(crate) fn build_group_config(
     ];
 
     // Extensions the creator's leaf node advertises support for (superset of required).
-    // Optional extensions like PROPOSAL_SUPPORT and AppDataDictionary are listed here so
-    // the group can use them, but are NOT in required_extension_types so members without
-    // support can join.
+    // `AppDataDictionary` is listed here so the group can be migrated
+    // later, but is NOT in required_extension_types so members without
+    // support can join the pre-migration legacy group.
     let mut creator_capability_extensions = required_extension_types.to_vec();
     creator_capability_extensions.push(ExtensionType::Unknown(
         WELCOME_WRAPPER_ENCRYPTION_EXTENSION_ID,
@@ -3164,9 +3171,6 @@ pub(crate) fn build_group_config(
     // bootstrap), so advertising here unconditionally is safe and lets
     // a fresh group's creator be the migration trigger.
     creator_capability_extensions.push(ExtensionType::AppDataDictionary);
-    if BROADCAST_PROPOSAL_SUPPORT {
-        creator_capability_extensions.push(ExtensionType::Unknown(PROPOSAL_SUPPORT_EXTENSION_ID));
-    }
 
     let required_proposal_types = &[ProposalType::GroupContextExtensions];
 

--- a/crates/xmtp_mls/src/groups/tests/test_proposals.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_proposals.rs
@@ -7,15 +7,13 @@
 
 use crate::{
     groups::{
-        EnableProposalsOptions, build_proposals_enabled_extension,
+        EnableProposalsOptions,
         intents::{CommitPendingProposalsIntentData, ProposeMemberUpdateIntentData},
         send_message_opts::SendMessageOpts,
     },
     tester,
 };
-use openmls::extensions::{Extension, UnknownExtension};
 use rstest::rstest;
-use xmtp_configuration::PROPOSAL_SUPPORT_EXTENSION_ID;
 use xmtp_db::{group_intent::IntentKind, prelude::*};
 
 // =============================================================================
@@ -147,26 +145,6 @@ async fn test_proposals_enabled_default_false() {
         !proposals_enabled,
         "Proposals should not be enabled by default"
     );
-}
-
-/// Test that the build_proposals_enabled_extension creates the correct extension.
-#[xmtp_common::test(unwrap_try = true)]
-async fn test_proposals_enabled_extension_builder() {
-    use prost::Message;
-    use xmtp_proto::xmtp::mls::message_contents::ProposalSupport;
-
-    let extension = build_proposals_enabled_extension();
-
-    if let Extension::Unknown(id, UnknownExtension(data)) = extension {
-        assert_eq!(
-            id, PROPOSAL_SUPPORT_EXTENSION_ID,
-            "Extension ID should be PROPOSAL_SUPPORT_EXTENSION_ID"
-        );
-        let ps = ProposalSupport::decode(data.as_slice()).expect("should decode ProposalSupport");
-        assert_eq!(ps.version, 1, "ProposalSupport version should be 1");
-    } else {
-        panic!("Expected Unknown extension type");
-    }
 }
 
 // =============================================================================
@@ -1225,12 +1203,12 @@ async fn test_enable_proposals_and_proposals_enabled() {
 /// Test that enable_proposals() fails when a member doesn't support proposals.
 #[xmtp_common::test(unwrap_try = true)]
 async fn test_enable_proposals_fails_without_support() {
-    use crate::identity::ENABLE_PROPOSAL_SUPPORT;
+    use crate::identity::ENABLE_APP_DATA_DICTIONARY_BROADCAST;
 
     tester!(alix);
 
     // Create bo without proposal support by scoping the task local
-    ENABLE_PROPOSAL_SUPPORT
+    ENABLE_APP_DATA_DICTIONARY_BROADCAST
         .scope(false, async {
             tester!(bo);
 
@@ -1262,9 +1240,11 @@ async fn test_enable_proposals_fails_without_support() {
         .await;
 }
 
-/// Test that adding a member without proposal support to a proposal-enabled group
-/// is rejected by OpenMLS. The PROPOSAL_SUPPORT extension in the group context means
-/// all new members must have that capability in their key packages.
+/// Test that adding a member without AppDataDictionary support to a
+/// migrated group is rejected by OpenMLS. Post-bootstrap the group
+/// context contains the `AppDataDictionary` extension and `RequiredCapabilities`
+/// lists it, so every new leaf MUST advertise it in its key-package
+/// capabilities.
 ///
 /// Note: OpenMLS validates Add proposals against the CURRENT group context extensions
 /// (validation.rs:395-404), so you cannot simultaneously remove an extension and add
@@ -1272,7 +1252,7 @@ async fn test_enable_proposals_fails_without_support() {
 /// must be disabled first via a separate GCE commit.
 #[xmtp_common::test(unwrap_try = true)]
 async fn test_adding_unsupported_member_rejected_when_proposals_enabled() {
-    use crate::identity::ENABLE_PROPOSAL_SUPPORT;
+    use crate::identity::ENABLE_APP_DATA_DICTIONARY_BROADCAST;
 
     tester!(alix);
     tester!(bo);
@@ -1295,10 +1275,11 @@ async fn test_adding_unsupported_member_rejected_when_proposals_enabled() {
         .await?;
     assert!(enabled, "Proposals should be enabled");
 
-    // Adding a member without proposal support should fail because the group
-    // context contains PROPOSAL_SUPPORT and OpenMLS requires new members to
-    // support all group context extensions
-    ENABLE_PROPOSAL_SUPPORT
+    // Adding a member without AppDataDictionary support should fail
+    // because the migrated group context contains the AppDataDictionary
+    // extension and OpenMLS requires new members to support all group
+    // context extensions.
+    ENABLE_APP_DATA_DICTIONARY_BROADCAST
         .scope(false, async {
             tester!(caro);
 
@@ -2591,6 +2572,75 @@ async fn test_add_member_after_sequence_id_bump_with_proposals_enabled() {
 // =============================================================================
 // Capability Advertisement Backwards Compatibility
 // =============================================================================
+
+/// Migration gate: AppDataDictionary capability is advertised on the
+/// creator's KP unconditionally (so `all_members_support_proposals`
+/// can pass), and after the bootstrap commit it's in
+/// `RequiredCapabilities`. Replaces the older custom-extension
+/// (`PROPOSAL_SUPPORT_EXTENSION_ID`) signal with the standard MLS
+/// mechanism.
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_app_data_dictionary_capability_and_required() {
+    use openmls::extensions::ExtensionType;
+
+    tester!(alix);
+    tester!(bo);
+    let alix_group = alix.create_group(None, None)?;
+    alix_group
+        .add_members(&[bo.context.identity.inbox_id()])
+        .await?;
+
+    // Pre-bootstrap: KP advertises AppDataDictionary, but it's NOT in
+    // RequiredCapabilities — unmigrated groups don't carry the dict.
+    alix_group
+        .load_mls_group_with_lock_async(async |mls_group| {
+            let own_caps_exts = mls_group
+                .own_leaf_node()
+                .expect("group creator must have own leaf")
+                .capabilities()
+                .extensions()
+                .to_vec();
+            assert!(
+                own_caps_exts.contains(&ExtensionType::AppDataDictionary),
+                "creator KP capabilities must advertise AppDataDictionary, got: {own_caps_exts:?}",
+            );
+
+            let required = mls_group
+                .extensions()
+                .required_capabilities()
+                .expect("required_capabilities must be set")
+                .extension_types()
+                .to_vec();
+            assert!(
+                !required.contains(&ExtensionType::AppDataDictionary),
+                "Pre-bootstrap RequiredCapabilities must NOT require AppDataDictionary, got: {required:?}",
+            );
+            Ok::<(), crate::groups::GroupError>(())
+        })
+        .await?;
+
+    // Run the bootstrap commit.
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
+
+    // Post-bootstrap: AppDataDictionary IS in RequiredCapabilities.
+    alix_group
+        .load_mls_group_with_lock_async(async |mls_group| {
+            let required = mls_group
+                .extensions()
+                .required_capabilities()
+                .expect("required_capabilities must be set after bootstrap")
+                .extension_types()
+                .to_vec();
+            assert!(
+                required.contains(&ExtensionType::AppDataDictionary),
+                "Post-bootstrap RequiredCapabilities MUST require AppDataDictionary, got: {required:?}",
+            );
+            Ok::<(), crate::groups::GroupError>(())
+        })
+        .await?;
+}
 
 /// Backwards-compat invariant for the `AppDataUpdate` proposal capability flip.
 ///

--- a/crates/xmtp_mls/src/identity.rs
+++ b/crates/xmtp_mls/src/identity.rs
@@ -32,10 +32,9 @@ use xmtp_common::ErrorCode;
 use xmtp_common::time::now_ns;
 use xmtp_common::{RetryableError, retryable};
 use xmtp_configuration::{
-    BROADCAST_PROPOSAL_SUPPORT, CIPHERSUITE, CREATE_PQ_KEY_PACKAGE_EXTENSION,
-    GROUP_MEMBERSHIP_EXTENSION_ID, GROUP_PERMISSIONS_EXTENSION_ID,
-    KEY_PACKAGE_ROTATION_INTERVAL_NS, MAX_INSTALLATIONS_PER_INBOX, MUTABLE_METADATA_EXTENSION_ID,
-    PROPOSAL_SUPPORT_EXTENSION_ID, WELCOME_POINTEE_ENCRYPTION_AEAD_TYPES_EXTENSION_ID,
+    CIPHERSUITE, CREATE_PQ_KEY_PACKAGE_EXTENSION, GROUP_MEMBERSHIP_EXTENSION_ID,
+    GROUP_PERMISSIONS_EXTENSION_ID, KEY_PACKAGE_ROTATION_INTERVAL_NS, MAX_INSTALLATIONS_PER_INBOX,
+    MUTABLE_METADATA_EXTENSION_ID, WELCOME_POINTEE_ENCRYPTION_AEAD_TYPES_EXTENSION_ID,
     WELCOME_WRAPPER_ENCRYPTION_EXTENSION_ID,
 };
 use xmtp_cryptography::configuration::POST_QUANTUM_CIPHERSUITE;
@@ -778,7 +777,14 @@ impl Identity {
 #[cfg(any(test, feature = "test-utils"))]
 tokio::task_local! {
     pub static ENABLE_WELCOME_POINTERS: bool;
-    pub static ENABLE_PROPOSAL_SUPPORT: bool;
+    /// Test-only opt-out from advertising `AppDataDictionary` in the
+    /// key package's leaf-node capabilities. Tests that simulate an
+    /// "old client without AppData support" set this to `false` for
+    /// the scope of one client build, and the resulting KP omits the
+    /// extension type from its `Capabilities`. Production has no
+    /// equivalent gate — `AppDataDictionary` is broadcast
+    /// unconditionally.
+    pub static ENABLE_APP_DATA_DICTIONARY_BROADCAST: bool;
 }
 
 #[derive(Builder, Debug)]
@@ -840,12 +846,12 @@ impl XmtpKeyPackageBuilder {
             // Advertise AppDataDictionary so the bootstrap commit
             // (and later AppDataUpdate proposals) are accepted —
             // OpenMLS rejects commits whose new extension set isn't
-            // covered by every leaf's capabilities. The extension is
-            // optional pre-bootstrap (groups that never call
-            // `enable_proposals` won't carry the dict) but advertising
+            // covered by every leaf's capabilities. Advertising
             // unconditionally is the simplest path: required-vs-
             // supported is enforced by RequiredCapabilities, not by
-            // this leaf-node list.
+            // this leaf-node list. This advertisement also doubles
+            // as the migration-eligibility signal that
+            // `all_members_support_proposals` reads.
             ExtensionType::AppDataDictionary,
             ExtensionType::Unknown(GROUP_PERMISSIONS_EXTENSION_ID),
             ExtensionType::Unknown(MUTABLE_METADATA_EXTENSION_ID),
@@ -853,17 +859,16 @@ impl XmtpKeyPackageBuilder {
             ExtensionType::Unknown(WELCOME_WRAPPER_ENCRYPTION_EXTENSION_ID),
             ExtensionType::Unknown(WELCOME_POINTEE_ENCRYPTION_AEAD_TYPES_EXTENSION_ID),
         ];
-        if BROADCAST_PROPOSAL_SUPPORT {
-            capability_extensions.push(ExtensionType::Unknown(PROPOSAL_SUPPORT_EXTENSION_ID));
-        }
+        // Test-only opt-out: tests that simulate an "old client
+        // without AppData support" drop the advertisement so the
+        // member-support check fails for that installation.
         #[cfg(any(test, feature = "test-utils"))]
         {
-            const {
-                assert!(BROADCAST_PROPOSAL_SUPPORT);
-            }
-            if !ENABLE_PROPOSAL_SUPPORT.try_with(|v| *v).unwrap_or(true) {
-                capability_extensions
-                    .retain(|e| *e != ExtensionType::Unknown(PROPOSAL_SUPPORT_EXTENSION_ID));
+            if !ENABLE_APP_DATA_DICTIONARY_BROADCAST
+                .try_with(|v| *v)
+                .unwrap_or(true)
+            {
+                capability_extensions.retain(|e| *e != ExtensionType::AppDataDictionary);
             }
         }
         // Advertise both `GroupContextExtensions` (required by all groups)


### PR DESCRIPTION
with standard MLS Capabilities/RequiredCapabilities + AppDataDictionary marker

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace custom `PROPOSAL_SUPPORT` extension with `AppDataDictionary` in MLS group management
> - Removes the custom `PROPOSAL_SUPPORT_EXTENSION_ID` (0xff05) extension and replaces all usages with the standard `ExtensionType::AppDataDictionary` across group creation, bootstrap, and membership update flows.
> - Bootstrap commit validation now requires `RequiredCapabilities` to list `AppDataDictionary` instead of checking for the custom unknown extension; commits missing this are rejected.
> - Production key packages and new group creator leaf nodes unconditionally advertise `AppDataDictionary` capability; tests can opt out via `ENABLE_APP_DATA_DICTIONARY_BROADCAST` to simulate older clients.
> - Disabling proposals (when new members lack support) now removes the `AppDataDictionary` GCE instead of the custom extension.
> - Behavioral Change: any in-flight or historical bootstrap commits shaped around the old custom extension will no longer be recognized as bootstrap commits.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f966636.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->