### PR TITLE
xmtp_mls: pause recovery — unstick groups when client upgrades past required floor

### DIFF
--- a/crates/xmtp_db/src/encrypted_store/group/version.rs
+++ b/crates/xmtp_db/src/encrypted_store/group/version.rs
@@ -9,6 +9,13 @@ pub trait QueryGroupVersion {
     fn unpause_group(&self, group_id: &GroupId) -> Result<(), StorageError>;
 
     fn get_group_paused_version(&self, group_id: &GroupId) -> Result<Option<String>, StorageError>;
+
+    /// Return every group currently flagged as paused, with the
+    /// `paused_for_version` floor it's pinned to. Used by the
+    /// startup/sweep recovery path to re-evaluate paused groups
+    /// against the now-current `pkg_version` without having to sync
+    /// each group individually.
+    fn get_paused_groups_with_versions(&self) -> Result<Vec<(GroupId, String)>, StorageError>;
 }
 
 impl<T> QueryGroupVersion for &T
@@ -25,6 +32,10 @@ where
 
     fn get_group_paused_version(&self, group_id: &GroupId) -> Result<Option<String>, StorageError> {
         (**self).get_group_paused_version(group_id)
+    }
+
+    fn get_paused_groups_with_versions(&self) -> Result<Vec<(GroupId, String)>, StorageError> {
+        (**self).get_paused_groups_with_versions()
     }
 }
 
@@ -64,5 +75,36 @@ impl<C: ConnectionExt> QueryGroupVersion for DbConnection<C> {
         })?;
 
         Ok(paused_version)
+    }
+
+    fn get_paused_groups_with_versions(&self) -> Result<Vec<(GroupId, String)>, StorageError> {
+        use crate::schema::groups::dsl;
+
+        let rows: Vec<(Vec<u8>, Option<String>)> = self.raw_query(|conn| {
+            dsl::groups
+                .select((dsl::id, dsl::paused_for_version))
+                .filter(dsl::paused_for_version.is_not_null())
+                .load::<(Vec<u8>, Option<String>)>(conn)
+        })?;
+
+        Ok(rows
+            .into_iter()
+            .filter_map(|(id, version)| {
+                let v = version?;
+                match GroupId::try_from(id.as_slice()) {
+                    Ok(group_id) => Some((group_id, v)),
+                    Err(err) => {
+                        tracing::warn!(
+                            error = %err,
+                            id_hex = %hex::encode(&id),
+                            id_len = id.len(),
+                            "get_paused_groups_with_versions: skipping row with \
+                             unparseable group id (not 16 bytes)"
+                        );
+                        None
+                    }
+                }
+            })
+            .collect())
     }
 }

--- a/crates/xmtp_db/src/mock.rs
+++ b/crates/xmtp_db/src/mock.rs
@@ -261,6 +261,8 @@ mock! {
         fn unpause_group(&self, group_id: &GroupId) -> Result<(), StorageError>;
 
         fn get_group_paused_version(&self, group_id: &GroupId) -> Result<Option<String>, StorageError>;
+
+        fn get_paused_groups_with_versions(&self) -> Result<Vec<(GroupId, String)>, StorageError>;
     }
 
     impl QueryGroupIntent for DbQuery {

--- a/crates/xmtp_mls/src/client.rs
+++ b/crates/xmtp_mls/src/client.rs
@@ -1104,6 +1104,22 @@ where
             .await
     }
 
+    /// Sweep every group flagged `paused_for_version` and clear the
+    /// pause flag for any whose floor is now satisfied by this
+    /// client's `pkg_version`. Pure local-state operation — no
+    /// network calls. Returns the count of groups unstuck.
+    ///
+    /// `sync_all_welcomes_and_groups` already runs this sweep as a
+    /// preamble; the standalone entry point is for SDKs that want a
+    /// cheap "post-upgrade recovery" hook independent of the normal
+    /// sync flow.
+    pub async fn unstick_paused_groups(&self) -> Result<usize, GroupError> {
+        self.ensure_identity_ready()?;
+        WelcomeService::new(self.context.clone())
+            .unstick_paused_groups()
+            .await
+    }
+
     pub async fn sync_all_welcomes_and_device_sync_groups(
         &self,
     ) -> Result<GroupSyncSummary, ClientError> {

--- a/crates/xmtp_mls/src/groups/tests/test_proposals.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_proposals.rs
@@ -3654,6 +3654,94 @@ async fn test_steady_state_pause_on_min_version_bump_via_app_data_update() {
     );
 }
 
+/// Pause recovery: a client that's been pinned to `paused_for_version`
+/// gets the flag cleared once their `pkg_version` catches up. Without
+/// this sweep a paused group could stay paused indefinitely on quiet
+/// installations (the per-group `handle_group_paused` re-evaluator only
+/// fires when the group is actively synced, and the sync sweep filters
+/// out groups with no new server messages).
+///
+/// Uses direct `set_group_paused` to install the pause flag rather
+/// than driving a real cross-version migration: the pause-side flows
+/// are pinned by `test_steady_state_pause_on_min_version_bump_via_app_data_update`
+/// and friends, so this test focuses on the sweep logic.
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_unstick_paused_groups_recovers_after_upgrade() {
+    use xmtp_db::prelude::*;
+
+    tester!(alix);
+    let alix_pkg = alix.version_info().pkg_version().to_string();
+    let alix_group = alix.create_group(None, None)?;
+    let group_id_typed = &alix_group.group_id;
+
+    // No paused groups initially → sweep is a no-op.
+    assert_eq!(
+        alix.unstick_paused_groups().await?,
+        0,
+        "no paused groups → sweep must return 0"
+    );
+
+    // Pin the floor above the client's own version → sweep stays
+    // hands-off (an installation can't unstick itself by reading a
+    // floor it can't yet satisfy).
+    alix.context
+        .db()
+        .set_group_paused(group_id_typed, "999.0.0")?;
+    assert_eq!(
+        alix.unstick_paused_groups().await?,
+        0,
+        "current pkg_version below floor → sweep must NOT unstick"
+    );
+    assert_eq!(
+        alix_group.paused_for_version()?.as_deref(),
+        Some("999.0.0"),
+        "pause flag must still be set"
+    );
+
+    // Pin the floor at or below the client's own version → sweep
+    // clears the flag.
+    alix.context
+        .db()
+        .set_group_paused(group_id_typed, &alix_pkg)?;
+    assert_eq!(
+        alix.unstick_paused_groups().await?,
+        1,
+        "current pkg_version == floor → sweep must unstick exactly one group"
+    );
+    assert!(
+        alix_group.paused_for_version()?.is_none(),
+        "pause flag must be cleared after the sweep"
+    );
+
+    // Idempotent: a second sweep on a clean state is a no-op.
+    assert_eq!(
+        alix.unstick_paused_groups().await?,
+        0,
+        "second sweep on clean state must be a no-op"
+    );
+
+    // Lenient on malformed stored bytes — skip that row, don't
+    // poison the sweep for everything else.
+    alix.context
+        .db()
+        .set_group_paused(group_id_typed, "not-a-version")?;
+    let result = alix.unstick_paused_groups().await;
+    assert!(
+        result.is_ok(),
+        "sweep must succeed even when a row carries unparseable bytes, got {result:?}",
+    );
+    assert_eq!(
+        result.unwrap(),
+        0,
+        "unparseable rows are skipped, not unstuck"
+    );
+    assert_eq!(
+        alix_group.paused_for_version()?.as_deref(),
+        Some("not-a-version"),
+        "unparseable pause row must be preserved verbatim"
+    );
+}
+
 /// Bootstrap retry safety: a successful migration is a hard idempotent
 /// fixed-point. A second `enable_proposals` call on an already-migrated
 /// group MUST NOT emit a new commit (advance the epoch). The existing

--- a/crates/xmtp_mls/src/groups/welcome_sync.rs
+++ b/crates/xmtp_mls/src/groups/welcome_sync.rs
@@ -246,6 +246,71 @@ where
         Ok(self.sync_all_groups(groups).await?)
     }
 
+    /// Sweep every paused group and clear the pause flag for any
+    /// whose `paused_for_version` is now satisfied by the client's
+    /// `pkg_version`. Pure local-state operation — no network calls.
+    ///
+    /// Returns the count of groups unstuck. Safe to call on any
+    /// installation regardless of whether any groups are paused
+    /// (a no-op on installations with none).
+    ///
+    /// This is the recovery path for the "user upgrades but didn't
+    /// touch a paused group" scenario: without this sweep a paused
+    /// group could stay paused indefinitely after the upgrade, since
+    /// `handle_group_paused` (which is the per-group re-evaluator)
+    /// only fires when the group is actively synced — and
+    /// `sync_all_welcomes_and_groups` filters out groups with no
+    /// new messages on the server.
+    pub async fn unstick_paused_groups(&self) -> Result<usize, GroupError> {
+        use crate::groups::validated_commit::LibXMTPVersion;
+
+        let paused = self.context.db().get_paused_groups_with_versions()?;
+        if paused.is_empty() {
+            return Ok(0);
+        }
+        // Parse current version once; reuse across every paused group.
+        let own_version_str = self.context.version_info().pkg_version().to_string();
+        let own_v = LibXMTPVersion::parse(&own_version_str)?;
+
+        let mut unstuck = 0usize;
+        for (group_id, required_str) in paused {
+            // Lenient on malformed stored bytes — log and skip rather
+            // than fail the whole sweep (one corrupted row shouldn't
+            // brick recovery for all the others).
+            let Ok(required_v) = LibXMTPVersion::parse(&required_str) else {
+                tracing::warn!(
+                    group_id = hex::encode(group_id.as_ref()),
+                    required = %required_str,
+                    "skipping unparseable paused_for_version while sweeping"
+                );
+                continue;
+            };
+            if required_v <= own_v {
+                // Same leniency as the parse-error branch above: a
+                // transient DB failure on one row shouldn't abort the
+                // sweep for the others. The next sync sweep will pick
+                // this row up again.
+                if let Err(err) = self.context.db().unpause_group(&group_id) {
+                    tracing::warn!(
+                        group_id = hex::encode(group_id.as_ref()),
+                        required = %required_str,
+                        error = %err,
+                        "failed to unpause group during sweep; will retry on next sync"
+                    );
+                    continue;
+                }
+                tracing::info!(
+                    group_id = hex::encode(group_id.as_ref()),
+                    required = %required_str,
+                    own = %own_version_str,
+                    "unstuck previously paused group: client version now satisfies floor"
+                );
+                unstuck += 1;
+            }
+        }
+        Ok(unstuck)
+    }
+
     /// Sync all unread welcome messages and then sync groups in descending order of recent activity.
     /// Returns number of active groups successfully synced.
     pub async fn sync_all_welcomes_and_groups(
@@ -253,6 +318,15 @@ where
         consent_states: Option<Vec<ConsentState>>,
     ) -> Result<GroupSyncSummary, GroupError> {
         let db = self.context.db();
+
+        // Recover any paused groups whose floor the current pkg_version
+        // now satisfies. Runs ahead of the activity filter (groups with
+        // no new server messages get filtered out below, so the per-
+        // group re-evaluation in `handle_group_paused` wouldn't fire
+        // for a quiet paused group).
+        if let Err(err) = self.unstick_paused_groups().await {
+            tracing::warn!(?err, "unstick_paused_groups failed, continuing with sync");
+        }
 
         if let Err(err) = self.sync_welcomes().await {
             tracing::warn!(?err, "sync_welcomes failed, continuing with group sync");


### PR DESCRIPTION
## Summary
- Add `Client::unstick_paused_groups` (and `WelcomeService::unstick_paused_groups`) — pure local-state sweep that clears `paused_for_version` on groups whose floor the current `pkg_version` now satisfies.
- Wire the sweep into `sync_all_welcomes_and_groups` so the common SDK entrypoint recovers paused groups even when the activity filter (`filter_groups_needing_sync`) would otherwise skip them.
- Add `QueryGroupVersion::get_paused_groups_with_versions` — one read for the whole paused set, no per-group enumeration.

The pre-existing `handle_group_paused` re-evaluator only fires when a group is actively synced, and `sync_all_welcomes_and_groups` filters out groups with no new server messages — so a quiet paused group could stay paused indefinitely after the client upgraded. This change closes that gap.

## Test plan
- [x] New integration test `test_unstick_paused_groups_recovers_after_upgrade` covers: no-paused-groups → 0; pinned-above-own-version → 0 (no unstick); pinned-at-own-version → 1 (unstick); idempotent second sweep → 0; unparseable stored bytes → 0 (skip, don't poison the sweep).
- [x] Full xmtp_mls test sweep (755 tests) passes.
- [x] cargo clippy -D warnings clean.
- [x] cargo fmt --check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Unstick paused MLS groups when client version meets the required floor on sync
> - Adds `WelcomeService::unstick_paused_groups` in [welcome_sync.rs](https://github.com/xmtp/libxmtp/pull/3649/files#diff-5ad5d6ca4506c4960727c32b22b9168a128f14af4d61497cd168ba5c80fb43f5), which queries all groups with a non-null `paused_for_version`, compares each against the client's current `pkg_version`, and clears the pause flag when the floor is satisfied.
> - Wires this sweep into `sync_all_welcomes_and_groups` as a pre-sync step; failures are logged but non-fatal.
> - Exposes `Client::unstick_paused_groups` as a public method for callers that need to trigger the sweep explicitly.
> - Adds `get_paused_groups_with_versions` to the `QueryGroupVersion` trait and its `DbConnection` implementation in [version.rs](https://github.com/xmtp/libxmtp/pull/3649/files#diff-51608aa0f8e43578ff517c45542de0b1ad62a672cb8734a2a2d6ba6eb084bb00).
> - Behavioral Change: every call to `sync_all_welcomes_and_groups` now runs a DB sweep over paused groups before syncing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 64e7b85.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->