### PR TITLE
xmtp_mls: bootstrap retry safety — idempotent on already-migrated groups

### DIFF
--- a/crates/xmtp_mls/src/groups/tests/test_proposals.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_proposals.rs
@@ -3653,3 +3653,53 @@ async fn test_steady_state_pause_on_min_version_bump_via_app_data_update() {
          only floor signal the validator can read"
     );
 }
+
+/// Bootstrap retry safety: a successful migration is a hard idempotent
+/// fixed-point. A second `enable_proposals` call on an already-migrated
+/// group MUST NOT emit a new commit (advance the epoch). The existing
+/// idempotency check at the `proposals_enabled` early-return is the
+/// protection; this test pins the wire-level behavior so a refactor
+/// that removes the check would surface in CI.
+///
+/// Backstops the "user retries enable_proposals after a flaky network"
+/// scenario where the first call succeeded but the user believes it
+/// didn't.
+#[xmtp_common::test(unwrap_try = true)]
+async fn test_enable_proposals_no_wire_commit_on_already_migrated() {
+    tester!(alix);
+    tester!(bo);
+
+    let alix_group = alix.create_group(None, None)?;
+    alix_group
+        .add_members(&[bo.context.identity.inbox_id()])
+        .await?;
+
+    // First call — migrates the group, advances the epoch.
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
+    let epoch_after_migration = alix_group.epoch().await?;
+
+    // Second call — must early-return (no commit, no epoch advance).
+    alix_group
+        .enable_proposals(EnableProposalsOptions::test_default())
+        .await?;
+    assert_eq!(
+        alix_group.epoch().await?,
+        epoch_after_migration,
+        "second enable_proposals must NOT advance the epoch (no commit emitted)"
+    );
+
+    // Third call with a different `force` value — same fixed-point.
+    alix_group
+        .enable_proposals(EnableProposalsOptions {
+            force: true,
+            min_version: None,
+        })
+        .await?;
+    assert_eq!(
+        alix_group.epoch().await?,
+        epoch_after_migration,
+        "third enable_proposals with different options must STILL NOT advance the epoch"
+    );
+}


### PR DESCRIPTION
## Summary
Pins the wire-level idempotency invariant of \`enable_proposals\`. A successful migration is a hard fixed-point: a second (or third) call MUST NOT emit a new commit or advance the group epoch, regardless of what \`EnableProposalsOptions\` are passed. The existing \`proposals_enabled\` early-return inside the lock is the protection — this test makes a refactor that removes it visible in CI.

Backstops the "user retries \`enable_proposals\` after a flaky network" scenario where the first call succeeded but the user believes it didn't.

## Test plan
- [x] New test \`test_enable_proposals_no_wire_commit_on_already_migrated\` covers: first call advances epoch; second call same options → epoch unchanged; third call with different \`force\` → epoch still unchanged.
- [x] cargo clippy -D warnings clean.
- [x] cargo fmt --check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add idempotency test for `enable_proposals` on already-migrated groups
> Adds a test in [test_proposals.rs](https://github.com/xmtp/libxmtp/pull/3650/files#diff-fb8ffb096fea904de9f05e2ad66734c897c3a9ceb42099e25f894c256f1f5f8e) that verifies calling `enable_proposals` multiple times on an already-migrated group does not emit a new commit (no epoch advance). The test covers both normal and `force: true` invocations to guard against bootstrap retry regressions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0e42584.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->