### PR TITLE
draft: xmtp_mls: per-AppDataUpdate payload size cap

### DIFF
--- a/crates/xmtp_configuration/src/common/mls.rs
+++ b/crates/xmtp_configuration/src/common/mls.rs
@@ -28,6 +28,25 @@ pub const SEND_MESSAGE_UPDATE_INSTALLATIONS_INTERVAL_NS: i64 = 5 * NS_IN_SEC;
 
 pub const MAX_GROUP_SIZE: usize = 250;
 
+/// Per-component cap on the bytes payload of an `AppDataUpdate(Update(...))`
+/// proposal. The dictionary lives in the `AppDataDictionary`
+/// group-context extension and is replicated to every member; a single
+/// runaway component value would balloon every group context until
+/// welcomes become slow and forks become likely. The cap is enforced
+/// on both the send side (refuse to queue an oversized intent) and
+/// the receive side (reject an oversized proposal in the validator)
+/// so a misbehaving SDK consumer can't poison a group by writing
+/// directly to the dictionary via the typed-component path.
+///
+/// Chosen for headroom over typical use:
+/// - Display strings (`GROUP_NAME`, `GROUP_DESCRIPTION`): single-digit
+///   KB ceilings in practice.
+/// - Identity/key-material components: <1 KB.
+/// - KeyValue-component shaped use: each Insert/Update payload is one
+///   entry, so 32 KB lets a single entry hold a reasonably large
+///   structured value without dominating the dict.
+pub const MAX_APP_DATA_COMPONENT_PAYLOAD_BYTES: usize = 32 * 1024;
+
 pub const MAX_INSTALLATIONS_PER_INBOX: usize = 10;
 
 pub const MAX_PAST_EPOCHS: usize = 3;

--- a/crates/xmtp_mls/src/groups/app_data/mod.rs
+++ b/crates/xmtp_mls/src/groups/app_data/mod.rs
@@ -283,6 +283,20 @@ pub(crate) fn stage_app_data_propose_and_commit<Provider: OpenMlsProvider>(
     // information than the on-wire commit, but the producer of each
     // folded-in proposal already accepted that outcome by leaving it
     // pending instead of issuing its own commit.
+    // Send-side mirror of the receive-side payload cap enforced by
+    // `validate_one_app_data_update_with_old_value`. Honest callers
+    // discover oversize payloads here, before a proposal is published —
+    // saves a network round trip and surfaces a structured error to the
+    // SDK consumer instead of a `Sync`-error rejection later.
+    let payload_size = payload.len();
+    if payload_size > xmtp_configuration::MAX_APP_DATA_COMPONENT_PAYLOAD_BYTES {
+        return Err(GroupAppDataError::PayloadTooLarge {
+            component_id,
+            size: payload_size,
+            limit: xmtp_configuration::MAX_APP_DATA_COMPONENT_PAYLOAD_BYTES,
+        });
+    }
+
     let openmls_id = component_id.as_u16();
     let operation = AppDataUpdateOperation::Update(payload.into());
 
@@ -358,6 +372,19 @@ pub(crate) fn stage_app_data_propose_and_commit<Provider: OpenMlsProvider>(
 /// the public `GroupError` enum.
 #[derive(Debug, thiserror::Error)]
 pub enum GroupAppDataError<StorageError: std::error::Error> {
+    /// Payload size exceeded the per-component cap before the proposal
+    /// was published. Mirror of receive-side `AppDataPayloadTooLarge`;
+    /// surfaces the same structured fields so SDK consumers fail fast
+    /// instead of waiting for commit-validation rejection.
+    #[error(
+        "AppDataUpdate payload too large: component {component_id} \
+         size {size} bytes exceeds limit {limit}"
+    )]
+    PayloadTooLarge {
+        component_id: ComponentId,
+        size: usize,
+        limit: usize,
+    },
     /// `propose_app_data_update(…)` failed when staging the standalone
     /// proposal that precedes the commit.
     #[error("propose error: {0}")]
@@ -396,10 +423,10 @@ impl xmtp_common::RetryableError for GroupAppDataError<xmtp_db::sql_key_store::S
             Self::Propose(e) => xmtp_common::retryable!(e),
             Self::StageCommit(e) => xmtp_common::retryable!(e),
             // Deterministic shape / staging-precondition failures —
-            // CreateCommit is upstream-`false`, and ApplyPayload is a
-            // sender-side encode failure that won't get better on
-            // retry.
-            Self::CreateCommit(_) | Self::ApplyPayload(_) => false,
+            // CreateCommit is upstream-`false`, ApplyPayload is a
+            // sender-side encode failure, and PayloadTooLarge is a hard
+            // size-limit violation. None of these recover on retry.
+            Self::CreateCommit(_) | Self::ApplyPayload(_) | Self::PayloadTooLarge { .. } => false,
         }
     }
 }

--- a/crates/xmtp_mls/src/groups/validated_commit.rs
+++ b/crates/xmtp_mls/src/groups/validated_commit.rs
@@ -103,6 +103,19 @@ pub enum CommitValidationError {
     ProposerNotFound,
     #[error("Proposals are not enabled on this group")]
     ProposalsNotEnabled,
+    /// Sender published an `AppDataUpdate(Update)` whose payload
+    /// exceeds [`xmtp_configuration::MAX_APP_DATA_COMPONENT_PAYLOAD_BYTES`].
+    /// Caps how much a single proposal can bloat the
+    /// `AppDataDictionary` group-context extension that every member
+    /// carries.
+    #[error(
+        "AppDataUpdate payload for component {component_id} is {size} bytes, exceeds the {limit}-byte cap"
+    )]
+    AppDataPayloadTooLarge {
+        component_id: xmtp_mls_common::app_data::component_id::ComponentId,
+        size: usize,
+        limit: usize,
+    },
     /// A well-known component value in the AppData dictionary failed
     /// to decode while validating an AppDataUpdate proposal — most
     /// commonly a malformed `COMPONENT_REGISTRY`. Treated as a
@@ -1295,10 +1308,35 @@ pub(super) fn validate_one_app_data_update_with_old_value(
     registry: &xmtp_mls_common::app_data::component_registry::ComponentRegistry,
     old_value: Option<&[u8]>,
 ) -> Result<(), CommitValidationError> {
+    use openmls::messages::proposals::AppDataUpdateOperation;
     use xmtp_mls_common::app_data::{
         registry_table::lookup_component,
         validation::{ComponentChange, validate_component_write},
     };
+
+    // Receive-side cap on the proposal's payload size. Caps how much a
+    // single proposal can bloat the `AppDataDictionary` group-context
+    // extension every member carries. The mirror send-side check in
+    // `stage_app_data_propose_and_commit` (see `app_data/mod.rs`)
+    // fails honest clients fast — this receive-side check is the
+    // source of truth for dishonest clients.
+    if let AppDataUpdateOperation::Update(payload) = operation {
+        let size = payload.as_slice().len();
+        if size > xmtp_configuration::MAX_APP_DATA_COMPONENT_PAYLOAD_BYTES {
+            tracing::warn!(
+                proposer_inbox_id,
+                component_id = %component_id,
+                size,
+                limit = xmtp_configuration::MAX_APP_DATA_COMPONENT_PAYLOAD_BYTES,
+                "AppDataUpdate proposal rejected: payload exceeds per-component size cap"
+            );
+            return Err(CommitValidationError::AppDataPayloadTooLarge {
+                component_id,
+                size,
+                limit: xmtp_configuration::MAX_APP_DATA_COMPONENT_PAYLOAD_BYTES,
+            });
+        }
+    }
 
     // Two dispatch shapes:
     //
@@ -2280,5 +2318,98 @@ mod permission_on_receive_tests {
             matches!(err, CommitValidationError::InsufficientPermissions),
             "expected InsufficientPermissions, got {err:?}"
         );
+    }
+}
+
+#[cfg(test)]
+mod app_data_payload_cap_tests {
+    use super::*;
+    use openmls::messages::proposals::AppDataUpdateOperation;
+    use xmtp_mls_common::app_data::{
+        component_id::ComponentId, component_registry::ComponentRegistry,
+        validation::ActorAuthority,
+    };
+
+    fn super_admin_actor() -> ActorAuthority {
+        ActorAuthority {
+            is_admin: true,
+            is_super_admin: true,
+        }
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn payload_at_or_below_cap_is_accepted_by_size_check() {
+        // Exactly at the cap is allowed. The component-id used here is
+        // a hardcoded one with super-admin policy so the rest of the
+        // validator (post the size check) accepts it.
+        let payload = vec![0u8; xmtp_configuration::MAX_APP_DATA_COMPONENT_PAYLOAD_BYTES];
+        let operation = AppDataUpdateOperation::Update(payload.into());
+        let registry = ComponentRegistry::new();
+        let result = validate_one_app_data_update_with_old_value(
+            ComponentId::COMPONENT_REGISTRY,
+            &operation,
+            super_admin_actor(),
+            "test-inbox",
+            &registry,
+            None,
+        );
+        // The size check passes; subsequent layers may reject for
+        // other reasons (e.g. the bytes don't decode as a valid
+        // ComponentRegistry). What matters here is that we do NOT
+        // see `AppDataPayloadTooLarge`.
+        if let Err(err) = result {
+            assert!(
+                !matches!(err, CommitValidationError::AppDataPayloadTooLarge { .. }),
+                "expected size check to PASS at the cap, got {err:?}"
+            );
+        }
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn payload_above_cap_is_rejected() {
+        let oversize = xmtp_configuration::MAX_APP_DATA_COMPONENT_PAYLOAD_BYTES + 1;
+        let payload = vec![0u8; oversize];
+        let operation = AppDataUpdateOperation::Update(payload.into());
+        let registry = ComponentRegistry::new();
+        let err = validate_one_app_data_update_with_old_value(
+            ComponentId::GROUP_NAME,
+            &operation,
+            super_admin_actor(),
+            "test-inbox",
+            &registry,
+            None,
+        )
+        .expect_err("oversize payload must be rejected");
+        assert!(
+            matches!(
+                err,
+                CommitValidationError::AppDataPayloadTooLarge { component_id, size, limit }
+                    if component_id == ComponentId::GROUP_NAME
+                        && size == oversize
+                        && limit == xmtp_configuration::MAX_APP_DATA_COMPONENT_PAYLOAD_BYTES
+            ),
+            "expected AppDataPayloadTooLarge with matching fields, got {err:?}",
+        );
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn remove_operation_is_not_subject_to_cap() {
+        // Remove has no payload — the size check should not fire.
+        let operation = AppDataUpdateOperation::Remove;
+        let registry = ComponentRegistry::new();
+        let result = validate_one_app_data_update_with_old_value(
+            ComponentId::COMPONENT_REGISTRY,
+            &operation,
+            super_admin_actor(),
+            "test-inbox",
+            &registry,
+            None,
+        );
+        if let Err(err) = result {
+            assert!(
+                !matches!(err, CommitValidationError::AppDataPayloadTooLarge { .. }),
+                "Remove must NOT trip the payload-size cap, got {err:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
Adds a 32 KB per-payload size cap (\`MAX_APP_DATA_COMPONENT_PAYLOAD_BYTES\`) on \`AppDataUpdate(Update(...))\` proposals. The dictionary lives in the \`AppDataDictionary\` group-context extension and is replicated to every member; a single runaway component value would balloon every group context until welcomes become slow and forks become likely. Defense-in-depth on top of the existing per-field caps (\`MAX_GROUP_NAME_LENGTH\`, \`MAX_APP_DATA_LENGTH\`, etc.):

- The existing per-field caps cover the known well-known components. The new global cap covers any future component without an explicit per-field check (KeyValue, custom, etc.).
- The new cap is enforced **receive-side** (\`validate_one_app_data_update_with_old_value\`) so a misbehaving sender that bypasses send-side checks still gets rejected by every honest receiver. New structured error \`CommitValidationError::AppDataPayloadTooLarge { component_id, size, limit }\` carries the component id, observed size, and the cap.

## Test plan
- [x] Unit test \`payload_above_cap_is_rejected\` — confirms structured error fields.
- [x] Unit test \`payload_at_or_below_cap_is_accepted_by_size_check\` — exactly-at-cap allowed.
- [x] Unit test \`remove_operation_is_not_subject_to_cap\` — \`Remove\` ops have no payload, must not trip.
- [x] cargo clippy -D warnings clean.
- [x] cargo fmt --check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-component payload size cap for `AppDataUpdate` proposals
> - Adds a `MAX_APP_DATA_COMPONENT_PAYLOAD_BYTES` constant (32 KB) in [mls.rs](https://github.com/xmtp/libxmtp/pull/3651/files#diff-d0b0dc608b199f942bd88e256e6a5ee61aa72e1ae1f7bff11656540aea89aabb) as the enforced limit.
> - In `stage_app_data_propose_and_commit`, rejects payloads exceeding the cap before proposing, returning a non-retryable `GroupAppDataError::PayloadTooLarge` with structured fields.
> - In `validate_one_app_data_update_with_old_value`, rejects oversized `Update` proposals during commit validation with `CommitValidationError::AppDataPayloadTooLarge` and logs a warning with proposer details. `Remove` operations are unaffected.
> - Adds unit tests covering acceptance at the cap, rejection above the cap, and that `Remove` operations bypass the cap check.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b384b2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->