### PR TITLE
xmtp_mls: pin permission-on-receive parity for AppDataUpdate proposals

### DIFF
--- a/crates/xmtp_mls/src/groups/validated_commit.rs
+++ b/crates/xmtp_mls/src/groups/validated_commit.rs
@@ -2186,3 +2186,95 @@ impl FromWith<ValidatedCommit> for GroupUpdatedProto {
         }
     }
 }
+
+#[cfg(test)]
+mod permission_on_receive_tests {
+    //! Pins the receive-side permission check on `AppDataUpdate`
+    //! proposals. Every proposal that reaches
+    //! [`validate_one_app_data_update_with_old_value`] runs through
+    //! `validate_component_write` (registry policy + hardcoded
+    //! super-admin gating). Without this guarantee an attacker who
+    //! patched out the send-side permission check could still poison
+    //! the dictionary as long as their proposal landed in a commit.
+    use super::*;
+    use openmls::messages::proposals::AppDataUpdateOperation;
+    use xmtp_mls_common::app_data::{
+        component_id::ComponentId, component_registry::ComponentRegistry,
+        validation::ActorAuthority,
+    };
+
+    fn non_admin_actor() -> ActorAuthority {
+        ActorAuthority {
+            is_admin: false,
+            is_super_admin: false,
+        }
+    }
+
+    fn admin_actor() -> ActorAuthority {
+        ActorAuthority {
+            is_admin: true,
+            is_super_admin: false,
+        }
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn non_admin_writing_super_admin_only_component_is_rejected() {
+        let operation = AppDataUpdateOperation::Update(vec![0u8; 16].into());
+        let registry = ComponentRegistry::new();
+        let err = validate_one_app_data_update_with_old_value(
+            ComponentId::COMPONENT_REGISTRY,
+            &operation,
+            non_admin_actor(),
+            "test-inbox",
+            &registry,
+            None,
+        )
+        .expect_err("non-admin write to super-admin-only component must be rejected");
+        assert!(
+            matches!(err, CommitValidationError::InsufficientPermissions),
+            "expected InsufficientPermissions, got {err:?}"
+        );
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn plain_admin_writing_super_admin_only_component_is_rejected() {
+        let operation = AppDataUpdateOperation::Update(vec![0u8; 16].into());
+        let registry = ComponentRegistry::new();
+        let err = validate_one_app_data_update_with_old_value(
+            ComponentId::COMPONENT_REGISTRY,
+            &operation,
+            admin_actor(),
+            "test-inbox",
+            &registry,
+            None,
+        )
+        .expect_err("plain-admin write to super-admin-only component must be rejected");
+        assert!(
+            matches!(err, CommitValidationError::InsufficientPermissions),
+            "expected InsufficientPermissions, got {err:?}"
+        );
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    fn non_admin_writing_component_with_no_registry_entry_is_rejected() {
+        // Unknown component in well-known range with no registry
+        // entry → deny by default at the registry-policy layer
+        // (validate_component_write Layer 3), regardless of actor role.
+        let unknown_id = ComponentId::new(0x80FF);
+        let operation = AppDataUpdateOperation::Update(vec![0u8; 16].into());
+        let registry = ComponentRegistry::new();
+        let err = validate_one_app_data_update_with_old_value(
+            unknown_id,
+            &operation,
+            non_admin_actor(),
+            "test-inbox",
+            &registry,
+            None,
+        )
+        .expect_err("write to unregistered component must be rejected");
+        assert!(
+            matches!(err, CommitValidationError::InsufficientPermissions),
+            "expected InsufficientPermissions, got {err:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
Pins the receive-side permission check on \`AppDataUpdate\` proposals. Every proposal that reaches \`validate_one_app_data_update_with_old_value\` runs through \`validate_component_write\` (registry policy + hardcoded super-admin gating). Without this guarantee, an attacker who patched out the send-side permission check could still poison the dictionary as long as their proposal landed in a commit.

## Test plan
- [x] \`non_admin_writing_super_admin_only_component_is_rejected\` — non-admin → \`InsufficientPermissions\`.
- [x] \`plain_admin_writing_super_admin_only_component_is_rejected\` — plain admin (not super-admin) → \`InsufficientPermissions\`.
- [x] \`non_admin_writing_component_with_no_registry_entry_is_rejected\` — registry deny-by-default fires regardless of actor role.
- [x] cargo clippy -D warnings clean.
- [x] cargo fmt --check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add receive-side permission tests for `AppDataUpdate` proposals in `validated_commit`
> Adds a `permission_on_receive_tests` module to [validated_commit.rs](https://github.com/xmtp/libxmtp/pull/3654/files#diff-233994c0ec18d23d0636e849849a3500e44611a4f64c6fffb1d0931aa1461ed6) with three tests covering `validate_one_app_data_update_with_old_value` rejection cases:
> - Verifies non-admin actors cannot write to super-admin-only components (e.g. `ComponentId::COMPONENT_REGISTRY`)
> - Verifies plain admins (not super-admin) are also rejected for the same component
> - Verifies non-admin actors are rejected when targeting a well-known component ID with no registry entry
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5ddd70e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->