### PR TITLE
xmtp_mls: telemetry events for AppData migration lifecycle

### DIFF
--- a/crates/xmtp_common/src/event_logging.rs
+++ b/crates/xmtp_common/src/event_logging.rs
@@ -165,4 +165,15 @@ pub enum Event {
     /// Cannot send sync archive. No server_url present.
     #[context(pin)]
     DeviceSyncNoServerUrl,
+
+    // ===================== AppData Migration =====================
+    /// `enable_proposals` started — pre-flight passed, about to publish
+    /// the legacy-GMM bump (step A) and/or bootstrap commit (step B).
+    #[context(group_id, min_version, force, icon = "🌱")]
+    EnableProposalsStart,
+    /// `enable_proposals` completed. `already_migrated = true` means
+    /// the call was a no-op fast-path; `false` means a bootstrap
+    /// commit was actually published.
+    #[context(group_id, already_migrated, min_version, icon = "🌳")]
+    EnableProposalsCompleted,
 }

--- a/crates/xmtp_mls/src/groups/mod.rs
+++ b/crates/xmtp_mls/src/groups/mod.rs
@@ -642,6 +642,14 @@ where
             GroupError::ProposalsNotSupported(format!("parsing min_version '{min_version}': {e}"))
         })?;
         let force = options.force;
+
+        log_event!(
+            Event::EnableProposalsStart,
+            self.context.installation_id(),
+            group_id = self.group_id,
+            min_version = min_version.as_str(),
+            force
+        );
         let (already_migrated, needs_min_version_bump) = self
             .load_mls_group_with_lock_async(async |mls_group| {
                 if !force && !self.all_members_support_proposals(&mls_group).await? {
@@ -675,6 +683,13 @@ where
             .await?;
 
         if already_migrated {
+            log_event!(
+                Event::EnableProposalsCompleted,
+                self.context.installation_id(),
+                group_id = self.group_id,
+                already_migrated = true,
+                min_version = min_version.as_str()
+            );
             return Ok(());
         }
 
@@ -771,6 +786,13 @@ where
             ));
         }
 
+        log_event!(
+            Event::EnableProposalsCompleted,
+            self.context.installation_id(),
+            group_id = self.group_id,
+            already_migrated = false,
+            min_version = min_version.as_str()
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
Adds two log events to the \`Event\` enum so a fleet dashboard can observe AppData migration rollout health without scraping ad-hoc tracing strings:

- \`Event::EnableProposalsStart\` — fires once at the top of \`enable_proposals\` after pre-flight parsing. Carries \`group_id\`, \`min_version\`, \`force\`.
- \`Event::EnableProposalsCompleted\` — fires on every success path with \`already_migrated\` distinguishing the no-op fast-path from a real bootstrap commit.

Without these events, "flying blind during rollout" — no way to know what fraction of groups are migrated, which floors were chosen, or whether a regression silently breaks the migration path.

## Test plan
- [x] Existing enable_proposals tests pass (events are no-op observers; their absence in the test fixture doesn't affect assertions).
- [x] cargo clippy -D warnings clean.
- [x] cargo fmt --check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add telemetry events for the `enable_proposals` AppData migration lifecycle
> Adds two new event variants, `EnableProposalsStart` and `EnableProposalsCompleted`, to the [`Event` enum](https://github.com/xmtp/libxmtp/pull/3655/files#diff-b892bd1dce497466fd9fa05752e7d5858b05185df4cfbc2acd1e03982cfcca14). Emits these events in [`Group::enable_proposals`](https://github.com/xmtp/libxmtp/pull/3655/files#diff-c27dd00cf700fd888b75fdbd19738462c2549fdc881dad70f8e61c979d440966) at the start of the call and at each exit path, including an `already_migrated` flag to distinguish no-op calls from those that publish a bootstrap commit.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9d5a864.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->