### PR TITLE
xmtp_mls: add Client::close for coordinated shutdown (PR1/3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11731,6 +11731,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/bindings/mobile/src/mls.rs
+++ b/bindings/mobile/src/mls.rs
@@ -1963,6 +1963,7 @@ impl FfiConversations {
                     callback.on_message_deleted(Arc::new(ffi_message))
                 }
             },
+            || {},
         );
 
         FfiStreamCloser::new(handle)

--- a/bindings/node/src/conversations/streams.rs
+++ b/bindings/node/src/conversations/streams.rs
@@ -232,6 +232,7 @@ impl Conversations {
           );
         }
       },
+      || {},
     );
 
     Ok(StreamCloser::new(stream_closer))

--- a/bindings/wasm/src/conversations.rs
+++ b/bindings/wasm/src/conversations.rs
@@ -698,6 +698,7 @@ impl Conversations {
         },
         Err(e) => callback.on_error(JsError::from(e)),
       },
+      || {},
     );
     Ok(StreamCloser::new(stream_closer))
   }

--- a/bindings/wasm/src/conversations.rs
+++ b/bindings/wasm/src/conversations.rs
@@ -689,6 +689,7 @@ impl Conversations {
     &self,
     callback: StreamCallback,
   ) -> Result<StreamCloser, JsError> {
+    let on_close_cb = callback.clone();
     let stream_closer = RustXmtpClient::stream_message_deletions_with_callback(
       self.inner_client.clone(),
       move |message| match message {
@@ -698,7 +699,7 @@ impl Conversations {
         },
         Err(e) => callback.on_error(JsError::from(e)),
       },
-      || {},
+      move || on_close_cb.on_close(),
     );
     Ok(StreamCloser::new(stream_closer))
   }

--- a/crates/xmtp-workspace-hack/Cargo.toml
+++ b/crates/xmtp-workspace-hack/Cargo.toml
@@ -93,7 +93,7 @@ slab = { version = "0.4" }
 smallvec = { version = "1", default-features = false, features = ["const_new", "serde", "union", "write"] }
 sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
 time = { version = "0.3", features = ["formatting", "local-offset", "parsing"] }
-tokio-util = { version = "0.7", features = ["codec", "compat", "io"] }
+tokio-util = { version = "0.7", features = ["codec", "compat", "io", "rt"] }
 toml_datetime = { version = "1", features = ["serde"] }
 toml_parser = { version = "1" }
 tracing = { version = "0.1", features = ["log"] }
@@ -187,7 +187,7 @@ smallvec = { version = "1", default-features = false, features = ["const_new", "
 syn = { version = "2", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
 sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
 time = { version = "0.3", features = ["formatting", "local-offset", "parsing"] }
-tokio-util = { version = "0.7", features = ["codec", "compat", "io"] }
+tokio-util = { version = "0.7", features = ["codec", "compat", "io", "rt"] }
 toml_datetime = { version = "1", features = ["serde"] }
 toml_parser = { version = "1" }
 tracing = { version = "0.1", features = ["log"] }

--- a/crates/xmtp_common/src/event_logging.rs
+++ b/crates/xmtp_common/src/event_logging.rs
@@ -16,6 +16,9 @@ pub enum Event {
     /// Client dropped.
     #[context(icon = "⬇️")]
     ClientDropped,
+    /// Client cleanly closed via `Client::close`.
+    #[context(icon = "🔒")]
+    ClientClosed,
     /// Associating name with installation.
     #[context(name)]
     AssociateName,

--- a/crates/xmtp_mls/Cargo.toml
+++ b/crates/xmtp_mls/Cargo.toml
@@ -89,7 +89,7 @@ tokio.workspace = true
 tokio-stream = { workspace = true, default-features = false, features = [
   "sync",
 ] }
-tokio-util.workspace = true
+tokio-util = { workspace = true, features = ["rt"] }
 tracing.workspace = true
 trait-variant.workspace = true
 zeroize.workspace = true

--- a/crates/xmtp_mls/src/builder.rs
+++ b/crates/xmtp_mls/src/builder.rs
@@ -15,8 +15,10 @@ use crate::{
 };
 use futures::FutureExt;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use thiserror::Error;
 use tokio::sync::broadcast;
+use tokio_util::sync::CancellationToken;
 use tracing::debug;
 use xmtp_api::{ApiClientWrapper, ApiDebugWrapper};
 use xmtp_api_d14n::{
@@ -319,6 +321,8 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             sync_api_client,
             worker_metrics: workers.metrics().clone(),
             task_channels: workers.task_channels().clone(),
+            cancellation_token: CancellationToken::new(),
+            closed: Arc::new(AtomicBool::new(false)),
         });
 
         // register workers
@@ -377,7 +381,13 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
 
         // Cleanup old unstitched group updated messages.
         let conn = DbConnection::new(client.db());
-        xmtp_common::spawn(None, cleanup_duplicate_updates::perform(conn));
+        let cancel = client.context.cancellation_token().clone();
+        xmtp_common::spawn(None, async move {
+            tokio::select! {
+                _ = cancel.cancelled() => {}
+                _ = cleanup_duplicate_updates::perform(conn) => {}
+            }
+        });
 
         Ok(client)
     }

--- a/crates/xmtp_mls/src/builder.rs
+++ b/crates/xmtp_mls/src/builder.rs
@@ -15,7 +15,6 @@ use crate::{
 };
 use futures::FutureExt;
 use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
 use thiserror::Error;
 use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
@@ -322,7 +321,6 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             worker_metrics: workers.metrics().clone(),
             task_channels: workers.task_channels().clone(),
             cancellation_token: CancellationToken::new(),
-            closed: Arc::new(AtomicBool::new(false)),
         });
 
         // register workers

--- a/crates/xmtp_mls/src/builder.rs
+++ b/crates/xmtp_mls/src/builder.rs
@@ -15,9 +15,9 @@ use crate::{
 };
 use futures::FutureExt;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use thiserror::Error;
 use tokio::sync::broadcast;
-use std::sync::atomic::AtomicBool;
 use tokio_util::sync::CancellationToken;
 use tracing::debug;
 use xmtp_api::{ApiClientWrapper, ApiDebugWrapper};

--- a/crates/xmtp_mls/src/builder.rs
+++ b/crates/xmtp_mls/src/builder.rs
@@ -17,6 +17,7 @@ use futures::FutureExt;
 use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::broadcast;
+use std::sync::atomic::AtomicBool;
 use tokio_util::sync::CancellationToken;
 use tracing::debug;
 use xmtp_api::{ApiClientWrapper, ApiDebugWrapper};
@@ -321,6 +322,7 @@ impl<ApiClient, S, Db> ClientBuilder<ApiClient, S, Db> {
             worker_metrics: workers.metrics().clone(),
             task_channels: workers.task_channels().clone(),
             cancellation_token: CancellationToken::new(),
+            shutdown_complete: Arc::new(AtomicBool::new(false)),
         });
 
         // register workers

--- a/crates/xmtp_mls/src/client.rs
+++ b/crates/xmtp_mls/src/client.rs
@@ -181,6 +181,12 @@ pub enum ClientError {
     /// Registration envelopes haven't propagated to the node yet. Retryable.
     #[error("Envelopes not yet visible on node {node_id}")]
     EnvelopesNotYetVisible { node_id: u32 },
+    /// Client is closed.
+    ///
+    /// Operation was attempted on a client that has been shut down via
+    /// `Client::close`. Not retryable — build a new client instead.
+    #[error("client is closed")]
+    AlreadyClosed,
 }
 
 impl ClientError {
@@ -328,8 +334,31 @@ where
 {
     /// Reconnect to the client's database if it has previously been released
     pub fn reconnect_db(&self) -> Result<(), ClientError> {
+        if self.context.is_closed() {
+            return Err(ClientError::AlreadyClosed);
+        }
         self.context.db().reconnect().map_err(StorageError::from)?;
         self.workers.spawn(self.context.clone());
+        Ok(())
+    }
+
+    /// Cleanly shut down this client: cancel in-flight workers and streams,
+    /// then release the DB connection. Idempotent — a second call is `Ok(())`.
+    ///
+    /// Callers (notably the Node binding consumers) should `await` this before
+    /// deleting the SQLite file or dropping the client wrapper, to avoid late
+    /// log spew from detached workers/streams firing against a dead DB.
+    pub async fn close(&self) -> Result<(), ClientError> {
+        if self.context.mark_closed() {
+            return Ok(());
+        }
+        self.context.cancellation_token().cancel();
+        self.workers.shutdown().await;
+        self.context
+            .db()
+            .disconnect()
+            .map_err(xmtp_db::StorageError::from)?;
+        log_event!(Event::ClientClosed, self.installation_id);
         Ok(())
     }
 

--- a/crates/xmtp_mls/src/client.rs
+++ b/crates/xmtp_mls/src/client.rs
@@ -2218,4 +2218,106 @@ pub(crate) mod tests {
             "Deleting non-existent message should return 0"
         );
     }
+
+    // ============================================================
+    // Client::close coordinated-shutdown tests
+    // ============================================================
+
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn close_stops_workers() {
+        tester!(client);
+        assert!(
+            client.workers.is_running(),
+            "worker supervisor must be running before close"
+        );
+
+        client.close().await?;
+
+        assert!(
+            !client.workers.is_running(),
+            "supervisor handle should be taken after close"
+        );
+        assert!(
+            client.context.is_closed(),
+            "context closed flag must be set after close"
+        );
+        assert!(
+            client.context.cancellation_token().is_cancelled(),
+            "cancellation token must be cancelled after close"
+        );
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn close_is_idempotent() {
+        tester!(client);
+        client.close().await?;
+        // second call must return Ok(()) without panic
+        client.close().await?;
+    }
+
+    // persistent_db: ephemeral in-memory stores no-op on disconnect, so the
+    // pool-released assertion only meaningfully tests against a real SQLite
+    // file. Skipped on WASM where file-backed test stores aren't wired in.
+    #[xmtp_common::test(unwrap_try = true)]
+    #[cfg_attr(target_arch = "wasm32", ignore)]
+    async fn close_disconnects_db() {
+        use diesel::RunQueryDsl;
+        use diesel::sql_query;
+
+        tester!(client, persistent_db);
+        client.close().await?;
+
+        let conn = client.context.store().conn();
+        let result = conn.raw_query(|c| sql_query("SELECT 1").execute(c));
+        assert!(
+            result.is_err(),
+            "raw_query after close should surface a ConnectionError; got Ok"
+        );
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    #[cfg_attr(target_arch = "wasm32", ignore)]
+    async fn close_cancels_callback_stream() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        tester!(client);
+
+        let closed_flag = Arc::new(AtomicBool::new(false));
+        let flag_for_cb = closed_flag.clone();
+
+        let _handle = super::Client::stream_conversations_with_callback(
+            Arc::new((*client).clone()),
+            None,
+            move |_| {},
+            move || {
+                flag_for_cb.store(true, Ordering::SeqCst);
+            },
+            false,
+        );
+
+        client.close().await?;
+
+        xmtp_common::time::timeout(std::time::Duration::from_secs(1), async {
+            while !closed_flag.load(Ordering::SeqCst) {
+                xmtp_common::time::sleep(std::time::Duration::from_millis(25)).await;
+            }
+        })
+        .await
+        .expect("on_close must fire within 1s of Client::close");
+    }
+
+    #[xmtp_common::test(unwrap_try = true)]
+    async fn reconnect_after_close_errors() {
+        tester!(client);
+        client.close().await?;
+
+        let err = client
+            .reconnect_db()
+            .expect_err("reconnect_db after close must fail");
+        assert!(
+            matches!(err, super::ClientError::AlreadyClosed),
+            "expected ClientError::AlreadyClosed, got {err:?}"
+        );
+    }
 }

--- a/crates/xmtp_mls/src/client.rs
+++ b/crates/xmtp_mls/src/client.rs
@@ -349,10 +349,11 @@ where
     /// deleting the SQLite file or dropping the client wrapper, to avoid late
     /// log spew from detached workers/streams firing against a dead DB.
     pub async fn close(&self) -> Result<(), ClientError> {
-        if self.context.mark_closed() {
+        let token = self.context.cancellation_token();
+        if token.is_cancelled() {
             return Ok(());
         }
-        self.context.cancellation_token().cancel();
+        token.cancel();
         self.workers.shutdown().await;
         self.context
             .db()

--- a/crates/xmtp_mls/src/client.rs
+++ b/crates/xmtp_mls/src/client.rs
@@ -349,16 +349,20 @@ where
     /// deleting the SQLite file or dropping the client wrapper, to avoid late
     /// log spew from detached workers/streams firing against a dead DB.
     pub async fn close(&self) -> Result<(), ClientError> {
-        let token = self.context.cancellation_token();
-        if token.is_cancelled() {
+        // `shutdown_complete` is distinct from `is_closed()` (which reflects
+        // cancellation): only set after the DB actually disconnects. If
+        // `disconnect()` errors below, callers can retry `close()` and we'll
+        // attempt disconnect again rather than silently short-circuiting.
+        if self.context.shutdown_complete() {
             return Ok(());
         }
-        token.cancel();
+        self.context.cancellation_token().cancel();
         self.workers.shutdown().await;
         self.context
             .db()
             .disconnect()
             .map_err(xmtp_db::StorageError::from)?;
+        self.context.mark_shutdown_complete();
         log_event!(Event::ClientClosed, self.installation_id);
         Ok(())
     }

--- a/crates/xmtp_mls/src/context.rs
+++ b/crates/xmtp_mls/src/context.rs
@@ -14,7 +14,9 @@ use crate::{
 use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::sync::broadcast;
+use tokio_util::sync::CancellationToken;
 use xmtp_api::{ApiClientWrapper, XmtpApi};
 use xmtp_api_d14n::protocol::XmtpQuery;
 use xmtp_common::{MaybeSend, MaybeSync};
@@ -51,6 +53,8 @@ pub struct XmtpMlsLocalContext<ApiClient, Db, S> {
     // pub(crate) workers: Arc<WorkerRunner>,
     pub(crate) worker_metrics: Arc<Mutex<HashMap<WorkerKind, DynMetrics>>>,
     pub(crate) task_channels: TaskWorkerChannels,
+    pub(crate) cancellation_token: CancellationToken,
+    pub(crate) closed: Arc<AtomicBool>,
 }
 
 impl<ApiClient, Db, S> XmtpMlsLocalContext<ApiClient, Db, S>
@@ -117,6 +121,8 @@ impl<ApiClient, Db, S> XmtpMlsLocalContext<ApiClient, Db, S> {
             fork_recovery_opts: self.fork_recovery_opts,
             worker_metrics: self.worker_metrics,
             task_channels: self.task_channels,
+            cancellation_token: self.cancellation_token,
+            closed: self.closed,
         }
     }
 }
@@ -159,6 +165,20 @@ impl<ApiClient, Db, S> XmtpMlsLocalContext<ApiClient, Db, S> {
             .lock()
             .get(&WorkerKind::DeviceSync)?
             .as_sync_metrics()
+    }
+
+    pub fn cancellation_token(&self) -> &CancellationToken {
+        &self.cancellation_token
+    }
+
+    pub fn is_closed(&self) -> bool {
+        self.closed.load(Ordering::Acquire)
+    }
+
+    /// Atomically marks the context as closed. Returns `true` if it was
+    /// already closed (caller should treat the operation as a no-op).
+    pub fn mark_closed(&self) -> bool {
+        self.closed.swap(true, Ordering::AcqRel)
     }
 }
 
@@ -212,6 +232,11 @@ where
     fn sync_metrics(&self) -> Option<Arc<WorkerMetrics<SyncMetric>>>;
     fn mls_commit_lock(&self) -> &Arc<GroupCommitLock>;
     fn mutexes(&self) -> &MutexRegistry;
+    fn cancellation_token(&self) -> &CancellationToken;
+    fn is_closed(&self) -> bool;
+    /// Atomically marks this context closed. Returns `true` if it was
+    /// already closed; callers should short-circuit in that case.
+    fn mark_closed(&self) -> bool;
 }
 
 impl<XApiClient, XDb, XMls> XmtpSharedContext for Arc<XmtpMlsLocalContext<XApiClient, XDb, XMls>>
@@ -293,6 +318,18 @@ where
     fn mutexes(&self) -> &MutexRegistry {
         &self.mutexes
     }
+
+    fn cancellation_token(&self) -> &CancellationToken {
+        &self.cancellation_token
+    }
+
+    fn is_closed(&self) -> bool {
+        self.closed.load(Ordering::Acquire)
+    }
+
+    fn mark_closed(&self) -> bool {
+        self.closed.swap(true, Ordering::AcqRel)
+    }
 }
 
 impl<T> XmtpSharedContext for &T
@@ -370,5 +407,17 @@ where
 
     fn mutexes(&self) -> &MutexRegistry {
         <T as XmtpSharedContext>::mutexes(self)
+    }
+
+    fn cancellation_token(&self) -> &CancellationToken {
+        <T as XmtpSharedContext>::cancellation_token(self)
+    }
+
+    fn is_closed(&self) -> bool {
+        <T as XmtpSharedContext>::is_closed(self)
+    }
+
+    fn mark_closed(&self) -> bool {
+        <T as XmtpSharedContext>::mark_closed(self)
     }
 }

--- a/crates/xmtp_mls/src/context.rs
+++ b/crates/xmtp_mls/src/context.rs
@@ -14,6 +14,7 @@ use crate::{
 use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
 use xmtp_api::{ApiClientWrapper, XmtpApi};
@@ -53,6 +54,12 @@ pub struct XmtpMlsLocalContext<ApiClient, Db, S> {
     pub(crate) worker_metrics: Arc<Mutex<HashMap<WorkerKind, DynMetrics>>>,
     pub(crate) task_channels: TaskWorkerChannels,
     pub(crate) cancellation_token: CancellationToken,
+    // Set only after a successful `Client::close` (workers stopped + DB
+    // disconnected). The cancellation token tracks "shutdown initiated";
+    // this tracks "shutdown completed cleanly" — distinct semantics so
+    // a `disconnect()` failure mid-`close` doesn't silently short-circuit
+    // future retries.
+    pub(crate) shutdown_complete: Arc<AtomicBool>,
 }
 
 impl<ApiClient, Db, S> XmtpMlsLocalContext<ApiClient, Db, S>
@@ -120,6 +127,7 @@ impl<ApiClient, Db, S> XmtpMlsLocalContext<ApiClient, Db, S> {
             worker_metrics: self.worker_metrics,
             task_channels: self.task_channels,
             cancellation_token: self.cancellation_token,
+            shutdown_complete: self.shutdown_complete,
         }
     }
 }
@@ -166,6 +174,14 @@ impl<ApiClient, Db, S> XmtpMlsLocalContext<ApiClient, Db, S> {
 
     pub fn cancellation_token(&self) -> &CancellationToken {
         &self.cancellation_token
+    }
+
+    pub fn shutdown_complete(&self) -> bool {
+        self.shutdown_complete.load(Ordering::Acquire)
+    }
+
+    pub fn mark_shutdown_complete(&self) {
+        self.shutdown_complete.store(true, Ordering::Release);
     }
 }
 
@@ -225,6 +241,14 @@ where
     fn is_closed(&self) -> bool {
         self.cancellation_token().is_cancelled()
     }
+
+    /// Returns `true` only after `Client::close` has fully torn the client
+    /// down (workers drained + DB disconnected). Distinct from [`is_closed`]
+    /// which fires the moment shutdown begins — this guards `close`'s
+    /// idempotency check so a mid-shutdown failure stays retryable.
+    fn shutdown_complete(&self) -> bool;
+
+    fn mark_shutdown_complete(&self);
 }
 
 impl<XApiClient, XDb, XMls> XmtpSharedContext for Arc<XmtpMlsLocalContext<XApiClient, XDb, XMls>>
@@ -310,6 +334,14 @@ where
     fn cancellation_token(&self) -> &CancellationToken {
         &self.cancellation_token
     }
+
+    fn shutdown_complete(&self) -> bool {
+        self.shutdown_complete.load(Ordering::Acquire)
+    }
+
+    fn mark_shutdown_complete(&self) {
+        self.shutdown_complete.store(true, Ordering::Release);
+    }
 }
 
 impl<T> XmtpSharedContext for &T
@@ -391,5 +423,13 @@ where
 
     fn cancellation_token(&self) -> &CancellationToken {
         <T as XmtpSharedContext>::cancellation_token(self)
+    }
+
+    fn shutdown_complete(&self) -> bool {
+        <T as XmtpSharedContext>::shutdown_complete(self)
+    }
+
+    fn mark_shutdown_complete(&self) {
+        <T as XmtpSharedContext>::mark_shutdown_complete(self)
     }
 }

--- a/crates/xmtp_mls/src/context.rs
+++ b/crates/xmtp_mls/src/context.rs
@@ -14,7 +14,6 @@ use crate::{
 use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
 use xmtp_api::{ApiClientWrapper, XmtpApi};
@@ -54,7 +53,6 @@ pub struct XmtpMlsLocalContext<ApiClient, Db, S> {
     pub(crate) worker_metrics: Arc<Mutex<HashMap<WorkerKind, DynMetrics>>>,
     pub(crate) task_channels: TaskWorkerChannels,
     pub(crate) cancellation_token: CancellationToken,
-    pub(crate) closed: Arc<AtomicBool>,
 }
 
 impl<ApiClient, Db, S> XmtpMlsLocalContext<ApiClient, Db, S>
@@ -122,7 +120,6 @@ impl<ApiClient, Db, S> XmtpMlsLocalContext<ApiClient, Db, S> {
             worker_metrics: self.worker_metrics,
             task_channels: self.task_channels,
             cancellation_token: self.cancellation_token,
-            closed: self.closed,
         }
     }
 }
@@ -169,16 +166,6 @@ impl<ApiClient, Db, S> XmtpMlsLocalContext<ApiClient, Db, S> {
 
     pub fn cancellation_token(&self) -> &CancellationToken {
         &self.cancellation_token
-    }
-
-    pub fn is_closed(&self) -> bool {
-        self.closed.load(Ordering::Acquire)
-    }
-
-    /// Atomically marks the context as closed. Returns `true` if it was
-    /// already closed (caller should treat the operation as a no-op).
-    pub fn mark_closed(&self) -> bool {
-        self.closed.swap(true, Ordering::AcqRel)
     }
 }
 
@@ -233,10 +220,11 @@ where
     fn mls_commit_lock(&self) -> &Arc<GroupCommitLock>;
     fn mutexes(&self) -> &MutexRegistry;
     fn cancellation_token(&self) -> &CancellationToken;
-    fn is_closed(&self) -> bool;
-    /// Atomically marks this context closed. Returns `true` if it was
-    /// already closed; callers should short-circuit in that case.
-    fn mark_closed(&self) -> bool;
+
+    /// Returns `true` once `Client::close` has been called on this context.
+    fn is_closed(&self) -> bool {
+        self.cancellation_token().is_cancelled()
+    }
 }
 
 impl<XApiClient, XDb, XMls> XmtpSharedContext for Arc<XmtpMlsLocalContext<XApiClient, XDb, XMls>>
@@ -322,14 +310,6 @@ where
     fn cancellation_token(&self) -> &CancellationToken {
         &self.cancellation_token
     }
-
-    fn is_closed(&self) -> bool {
-        self.closed.load(Ordering::Acquire)
-    }
-
-    fn mark_closed(&self) -> bool {
-        self.closed.swap(true, Ordering::AcqRel)
-    }
 }
 
 impl<T> XmtpSharedContext for &T
@@ -411,13 +391,5 @@ where
 
     fn cancellation_token(&self) -> &CancellationToken {
         <T as XmtpSharedContext>::cancellation_token(self)
-    }
-
-    fn is_closed(&self) -> bool {
-        <T as XmtpSharedContext>::is_closed(self)
-    }
-
-    fn mark_closed(&self) -> bool {
-        <T as XmtpSharedContext>::mark_closed(self)
     }
 }

--- a/crates/xmtp_mls/src/groups/tests/test_delete_message.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_delete_message.rs
@@ -1109,6 +1109,7 @@ async fn test_stream_message_deletions_from_other_client() {
                 notify_clone.notify_one();
             }
         },
+        || {},
     );
 
     // Wait for stream to be ready
@@ -1176,6 +1177,7 @@ async fn test_stream_message_deletions_fires_for_self_after_publish() {
                 notify_clone.notify_one();
             }
         },
+        || {},
     );
 
     // Wait for stream to be ready

--- a/crates/xmtp_mls/src/groups/tests/test_welcomes.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_welcomes.rs
@@ -163,6 +163,8 @@ async fn test_spoofed_inbox_id() {
         fork_recovery_opts: alix.context.fork_recovery_opts.clone(),
         task_channels: alix.context.task_channels.clone(),
         worker_metrics: alix.context.worker_metrics.clone(),
+        cancellation_token: alix.context.cancellation_token.clone(),
+        closed: alix.context.closed.clone(),
     });
     let group = MlsGroup::create_and_insert(
         malicious_context,

--- a/crates/xmtp_mls/src/groups/tests/test_welcomes.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_welcomes.rs
@@ -164,7 +164,6 @@ async fn test_spoofed_inbox_id() {
         task_channels: alix.context.task_channels.clone(),
         worker_metrics: alix.context.worker_metrics.clone(),
         cancellation_token: alix.context.cancellation_token.clone(),
-        closed: alix.context.closed.clone(),
     });
     let group = MlsGroup::create_and_insert(
         malicious_context,

--- a/crates/xmtp_mls/src/groups/tests/test_welcomes.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_welcomes.rs
@@ -164,6 +164,7 @@ async fn test_spoofed_inbox_id() {
         task_channels: alix.context.task_channels.clone(),
         worker_metrics: alix.context.worker_metrics.clone(),
         cancellation_token: alix.context.cancellation_token.clone(),
+        shutdown_complete: alix.context.shutdown_complete.clone(),
     });
     let group = MlsGroup::create_and_insert(
         malicious_context,

--- a/crates/xmtp_mls/src/subscriptions/mod.rs
+++ b/crates/xmtp_mls/src/subscriptions/mod.rs
@@ -574,6 +574,7 @@ where
     pub fn stream_message_deletions_with_callback(
         client: Arc<Client<Context>>,
         mut callback: impl FnMut(Result<DecodedMessage>) + MaybeSend + 'static,
+        on_close: impl FnOnce() + MaybeSend + 'static,
     ) -> impl StreamHandle<StreamOutput = Result<()>> {
         let (tx, rx) = oneshot::channel();
 
@@ -594,6 +595,7 @@ where
                 }
             }
             tracing::debug!("`stream_message_deletions` stream ended, dropping stream");
+            on_close();
             Ok::<_, SubscribeError>(())
         })
     }

--- a/crates/xmtp_mls/src/subscriptions/mod.rs
+++ b/crates/xmtp_mls/src/subscriptions/mod.rs
@@ -412,6 +412,7 @@ where
         let (tx, rx) = oneshot::channel();
 
         xmtp_common::spawn(Some(rx), async move {
+            let cancel = client.context.cancellation_token().clone();
             let stream = match client
                 .stream_conversations(conversation_type, include_duplicate_dms)
                 .await
@@ -425,8 +426,14 @@ where
             };
             futures::pin_mut!(stream);
             let _ = tx.send(());
-            while let Some(convo) = stream.next().await {
-                convo_callback(convo)
+            loop {
+                tokio::select! {
+                    _ = cancel.cancelled() => break,
+                    next = stream.next() => match next {
+                        Some(convo) => convo_callback(convo),
+                        None => break,
+                    }
+                }
             }
             tracing::debug!("`stream_conversations` stream ended, dropping stream");
             on_close();
@@ -477,6 +484,7 @@ where
 
         xmtp_common::spawn(Some(rx), async move {
             tracing::debug!("stream all messages with callback");
+            let cancel = context.cancellation_token().clone();
             let stream =
                 match StreamAllMessages::new(&context, conversation_type, consent_state).await {
                     Ok(stream) => stream,
@@ -490,8 +498,14 @@ where
             futures::pin_mut!(stream);
             let _ = tx.send(());
 
-            while let Some(message) = stream.next().await {
-                callback(message)
+            loop {
+                tokio::select! {
+                    _ = cancel.cancelled() => break,
+                    next = stream.next() => match next {
+                        Some(message) => callback(message),
+                        None => break,
+                    }
+                }
             }
             tracing::debug!("`stream_all_messages` stream ended, dropping stream");
             on_close();
@@ -507,13 +521,20 @@ where
         let (tx, rx) = oneshot::channel();
 
         xmtp_common::spawn(Some(rx), async move {
+            let cancel = client.context.cancellation_token().clone();
             let receiver = client.local_events.subscribe();
             let stream = receiver.stream_consent_updates();
 
             futures::pin_mut!(stream);
             let _ = tx.send(());
-            while let Some(message) = stream.next().await {
-                callback(message)
+            loop {
+                tokio::select! {
+                    _ = cancel.cancelled() => break,
+                    next = stream.next() => match next {
+                        Some(message) => callback(message),
+                        None => break,
+                    }
+                }
             }
             tracing::debug!("`stream_consent` stream ended, dropping stream");
             on_close();
@@ -529,13 +550,20 @@ where
         let (tx, rx) = oneshot::channel();
 
         xmtp_common::spawn(Some(rx), async move {
+            let cancel = client.context.cancellation_token().clone();
             let receiver = client.local_events.subscribe();
             let stream = receiver.stream_preference_updates();
 
             futures::pin_mut!(stream);
             let _ = tx.send(());
-            while let Some(message) = stream.next().await {
-                callback(message)
+            loop {
+                tokio::select! {
+                    _ = cancel.cancelled() => break,
+                    next = stream.next() => match next {
+                        Some(message) => callback(message),
+                        None => break,
+                    }
+                }
             }
             tracing::debug!("`stream_preferences` stream ended, dropping stream");
             on_close();
@@ -550,13 +578,20 @@ where
         let (tx, rx) = oneshot::channel();
 
         xmtp_common::spawn(Some(rx), async move {
+            let cancel = client.context.cancellation_token().clone();
             let receiver = client.local_events.subscribe();
             let stream = receiver.stream_message_deletions();
 
             futures::pin_mut!(stream);
             let _ = tx.send(());
-            while let Some(message) = stream.next().await {
-                callback(message)
+            loop {
+                tokio::select! {
+                    _ = cancel.cancelled() => break,
+                    next = stream.next() => match next {
+                        Some(message) => callback(message),
+                        None => break,
+                    }
+                }
             }
             tracing::debug!("`stream_message_deletions` stream ended, dropping stream");
             Ok::<_, SubscribeError>(())

--- a/crates/xmtp_mls/src/test/mock.rs
+++ b/crates/xmtp_mls/src/test/mock.rs
@@ -93,6 +93,7 @@ impl Clone for NewMockContext {
             task_channels: self.task_channels.clone(),
             worker_metrics: self.worker_metrics.clone(),
             cancellation_token: self.cancellation_token.clone(),
+            shutdown_complete: self.shutdown_complete.clone(),
         }
     }
 }
@@ -174,5 +175,15 @@ impl XmtpSharedContext for NewMockContext {
 
     fn cancellation_token(&self) -> &CancellationToken {
         &self.cancellation_token
+    }
+
+    fn shutdown_complete(&self) -> bool {
+        self.shutdown_complete
+            .load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    fn mark_shutdown_complete(&self) {
+        self.shutdown_complete
+            .store(true, std::sync::atomic::Ordering::Release);
     }
 }

--- a/crates/xmtp_mls/src/test/mock.rs
+++ b/crates/xmtp_mls/src/test/mock.rs
@@ -178,12 +178,10 @@ impl XmtpSharedContext for NewMockContext {
     }
 
     fn is_closed(&self) -> bool {
-        self.closed
-            .load(std::sync::atomic::Ordering::Acquire)
+        self.closed.load(std::sync::atomic::Ordering::Acquire)
     }
 
     fn mark_closed(&self) -> bool {
-        self.closed
-            .swap(true, std::sync::atomic::Ordering::AcqRel)
+        self.closed.swap(true, std::sync::atomic::Ordering::AcqRel)
     }
 }

--- a/crates/xmtp_mls/src/test/mock.rs
+++ b/crates/xmtp_mls/src/test/mock.rs
@@ -21,6 +21,7 @@ use crate::{
 use alloy::signers::local::PrivateKeySigner;
 use mockall::mock;
 use tokio::sync::broadcast;
+use tokio_util::sync::CancellationToken;
 use xmtp_api::ApiClientWrapper;
 use xmtp_api_d14n::MockApiClient;
 use xmtp_cryptography::XmtpInstallationCredential;
@@ -91,6 +92,8 @@ impl Clone for NewMockContext {
             fork_recovery_opts: self.fork_recovery_opts.clone(),
             task_channels: self.task_channels.clone(),
             worker_metrics: self.worker_metrics.clone(),
+            cancellation_token: self.cancellation_token.clone(),
+            closed: self.closed.clone(),
         }
     }
 }
@@ -168,5 +171,19 @@ impl XmtpSharedContext for NewMockContext {
 
     fn sync_api(&self) -> &ApiClientWrapper<Self::ApiClient> {
         &self.sync_api_client
+    }
+
+    fn cancellation_token(&self) -> &CancellationToken {
+        &self.cancellation_token
+    }
+
+    fn is_closed(&self) -> bool {
+        self.closed
+            .load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    fn mark_closed(&self) -> bool {
+        self.closed
+            .swap(true, std::sync::atomic::Ordering::AcqRel)
     }
 }

--- a/crates/xmtp_mls/src/test/mock.rs
+++ b/crates/xmtp_mls/src/test/mock.rs
@@ -93,7 +93,6 @@ impl Clone for NewMockContext {
             task_channels: self.task_channels.clone(),
             worker_metrics: self.worker_metrics.clone(),
             cancellation_token: self.cancellation_token.clone(),
-            closed: self.closed.clone(),
         }
     }
 }
@@ -175,13 +174,5 @@ impl XmtpSharedContext for NewMockContext {
 
     fn cancellation_token(&self) -> &CancellationToken {
         &self.cancellation_token
-    }
-
-    fn is_closed(&self) -> bool {
-        self.closed.load(std::sync::atomic::Ordering::Acquire)
-    }
-
-    fn mark_closed(&self) -> bool {
-        self.closed.swap(true, std::sync::atomic::Ordering::AcqRel)
     }
 }

--- a/crates/xmtp_mls/src/test/mock/generate.rs
+++ b/crates/xmtp_mls/src/test/mock/generate.rs
@@ -40,7 +40,6 @@ pub fn context() -> NewMockContext {
         task_channels: TaskWorkerChannels::default(),
         worker_metrics: Arc::default(),
         cancellation_token: tokio_util::sync::CancellationToken::new(),
-        closed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     }
 }
 

--- a/crates/xmtp_mls/src/test/mock/generate.rs
+++ b/crates/xmtp_mls/src/test/mock/generate.rs
@@ -40,6 +40,7 @@ pub fn context() -> NewMockContext {
         task_channels: TaskWorkerChannels::default(),
         worker_metrics: Arc::default(),
         cancellation_token: tokio_util::sync::CancellationToken::new(),
+        shutdown_complete: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     }
 }
 

--- a/crates/xmtp_mls/src/test/mock/generate.rs
+++ b/crates/xmtp_mls/src/test/mock/generate.rs
@@ -39,6 +39,8 @@ pub fn context() -> NewMockContext {
         sync_api_client: ApiClientWrapper::new(MockApiClient::new(), Default::default()),
         task_channels: TaskWorkerChannels::default(),
         worker_metrics: Arc::default(),
+        cancellation_token: tokio_util::sync::CancellationToken::new(),
+        closed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     }
 }
 

--- a/crates/xmtp_mls/src/worker.rs
+++ b/crates/xmtp_mls/src/worker.rs
@@ -14,10 +14,16 @@ use std::fmt::Debug;
 use std::pin::Pin;
 use std::{any::Any, collections::HashMap, hash::Hash, sync::Arc};
 use tasks::TaskWorkerChannels;
+use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
 use tracing::instrument::Instrumented;
 use xmtp_common::{MaybeSend, MaybeSync, StreamHandle, if_native, if_wasm, time::Duration};
 use xmtp_configuration::WORKER_RESTART_DELAY;
+
+/// Hard cap on how long `WorkerRunner::shutdown` waits for the supervisor
+/// task to drain after cancellation. Anything beyond this gets logged and
+/// the task is allowed to detach — keeps `Client::close` bounded.
+const WORKER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
 
 #[derive(PartialEq, Eq, Copy, Clone, Hash, Debug)]
 pub enum WorkerKind {
@@ -89,6 +95,7 @@ impl WorkerRunner {
         }
 
         let this = self.clone();
+        let cancel = ctx.cancellation_token().clone();
         let handle = xmtp_common::spawn(
             None,
             async move {
@@ -110,7 +117,7 @@ impl WorkerRunner {
                         let mut m = this.metrics.lock();
                         m.insert(worker.kind(), metrics);
                     }
-                    futs.push(worker.spawn());
+                    futs.push(worker.spawn(cancel.clone()));
                 }
 
                 while let Some(kind) = futs.next().await {
@@ -121,6 +128,24 @@ impl WorkerRunner {
         );
 
         *handle_lock = Some(Box::new(handle));
+    }
+
+    /// Drain the running worker supervisor. Bounded by [`WORKER_SHUTDOWN_TIMEOUT`].
+    /// Cancellation must be signalled separately (via the shared
+    /// `CancellationToken` on the context) — this only joins the supervisor.
+    pub async fn shutdown(&self) {
+        let mut handle = self.handle.lock().take();
+        let Some(handle) = handle.as_mut() else {
+            return;
+        };
+        match xmtp_common::time::timeout(WORKER_SHUTDOWN_TIMEOUT, handle.end_and_wait()).await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => tracing::debug!("worker supervisor ended with: {e:?}"),
+            Err(_) => tracing::warn!(
+                "worker supervisor did not drain within {:?}; abandoning",
+                WORKER_SHUTDOWN_TIMEOUT
+            ),
+        }
     }
 
     pub async fn wait_for_sync_worker_init(&self) {
@@ -167,24 +192,40 @@ pub trait Worker: MaybeSend + MaybeSync + 'static {
         Box::new(self) as Box<_>
     }
 
-    fn spawn(mut self: Box<Self>) -> Instrumented<Pin<Box<SpawnWorkerFut>>> {
+    // Wrap the outer loop (not each `run_tasks` impl) so individual workers
+    // observe cancellation by having their in-flight future dropped at the
+    // next await point — no per-impl plumbing required.
+    fn spawn(
+        mut self: Box<Self>,
+        cancel: CancellationToken,
+    ) -> Instrumented<Pin<Box<SpawnWorkerFut>>> {
         let kind_str = format!("{:?}", self.kind());
         let fut = Box::pin(async move {
-            loop {
-                if let Err(err) = self.run_tasks().await {
-                    if err.needs_db_reconnect() {
-                        // drop the worker
-                        tracing::debug!("pool disconnected. task will restart on reconnect");
-                        break;
-                    } else {
-                        tracing::error!("{:?} worker error: {}", self.kind(), err);
-                        xmtp_common::time::sleep(WORKER_RESTART_DELAY).await;
-                        tracing::info!("Restarting {:?} worker...", self.kind());
+            let kind = self.kind();
+            let run = async move {
+                loop {
+                    if let Err(err) = self.run_tasks().await {
+                        if err.needs_db_reconnect() {
+                            // drop the worker
+                            tracing::debug!("pool disconnected. task will restart on reconnect");
+                            break;
+                        } else {
+                            tracing::error!("{:?} worker error: {}", self.kind(), err);
+                            xmtp_common::time::sleep(WORKER_RESTART_DELAY).await;
+                            tracing::info!("Restarting {:?} worker...", self.kind());
+                        }
                     }
                 }
-            }
+                self.kind()
+            };
 
-            self.kind()
+            tokio::select! {
+                k = run => k,
+                _ = cancel.cancelled() => {
+                    tracing::debug!("{:?} worker cancelled", kind);
+                    kind
+                }
+            }
         }) as Pin<Box<SpawnWorkerFut>>;
         fut.instrument(tracing::debug_span!("libxmtp_worker", kind = kind_str))
     }

--- a/crates/xmtp_mls/src/worker.rs
+++ b/crates/xmtp_mls/src/worker.rs
@@ -7,6 +7,7 @@ pub mod tasks;
 
 use crate::context::XmtpSharedContext;
 use device_sync::worker::SyncMetric;
+use futures::future::{AbortHandle, Abortable};
 use futures::{StreamExt, stream::FuturesUnordered};
 use metrics::WorkerMetrics;
 use parking_lot::Mutex;
@@ -42,6 +43,11 @@ pub struct WorkerRunner {
     metrics: Arc<Mutex<HashMap<WorkerKind, DynMetrics>>>,
     task_channels: TaskWorkerChannels,
     handle: Mutex<Option<Box<dyn StreamHandle<StreamOutput = ()>>>>,
+    // Per-worker abort handles. `shutdown` calls `abort()` on each so the
+    // worker future is dropped at its next poll regardless of whether the
+    // outer loop observed the cancellation token. Belt to the token's
+    // suspenders for workers that don't yield to cancellation promptly.
+    abort_handles: Mutex<Vec<AbortHandle>>,
 }
 
 impl Default for WorkerRunner {
@@ -57,6 +63,7 @@ impl WorkerRunner {
             metrics: Arc::default(),
             task_channels: TaskWorkerChannels::default(),
             handle: Mutex::default(),
+            abort_handles: Mutex::default(),
         }
     }
 
@@ -100,6 +107,10 @@ impl WorkerRunner {
         if let Some(handle) = handle_lock.take() {
             handle.abort_handle().end();
         }
+        // Force-abort any prior worker futures still alive from a previous spawn.
+        for h in self.abort_handles.lock().drain(..) {
+            h.abort();
+        }
 
         let this = self.clone();
         let cancel = ctx.cancellation_token().clone();
@@ -111,6 +122,7 @@ impl WorkerRunner {
                 }
 
                 let mut futs = FuturesUnordered::new();
+                let mut new_handles = Vec::with_capacity(this.factories.len());
 
                 for factory in &this.factories {
                     let metric = this.metrics.lock().get(&factory.kind()).cloned();
@@ -124,11 +136,17 @@ impl WorkerRunner {
                         let mut m = this.metrics.lock();
                         m.insert(worker.kind(), metrics);
                     }
-                    futs.push(worker.spawn(cancel.clone()));
+                    let (abort_handle, reg) = AbortHandle::new_pair();
+                    new_handles.push(abort_handle);
+                    futs.push(Abortable::new(worker.spawn(cancel.clone()), reg));
                 }
+                *this.abort_handles.lock() = new_handles;
 
-                while let Some(kind) = futs.next().await {
-                    tracing::warn!("Worker {kind:?} completed unexpectedly")
+                while let Some(outcome) = futs.next().await {
+                    match outcome {
+                        Ok(kind) => tracing::warn!("Worker {kind:?} completed unexpectedly"),
+                        Err(_aborted) => tracing::debug!("worker aborted during shutdown"),
+                    }
                 }
             }
             .instrument(tracing::debug_span!("xmtp_worker_supervisor")),
@@ -139,8 +157,15 @@ impl WorkerRunner {
 
     /// Drain the running worker supervisor. Bounded by [`WORKER_SHUTDOWN_TIMEOUT`].
     /// Cancellation must be signalled separately (via the shared
-    /// `CancellationToken` on the context) — this only joins the supervisor.
+    /// `CancellationToken` on the context); this method additionally aborts
+    /// each worker's future to guarantee no further DB writes happen,
+    /// independent of whether the worker's loop respects the token.
     pub async fn shutdown(&self) {
+        // Hard-kill each worker future at its next poll. Critical for workers
+        // that sit on long sleeps and only check the token between intervals.
+        for h in self.abort_handles.lock().drain(..) {
+            h.abort();
+        }
         let mut handle = self.handle.lock().take();
         let Some(handle) = handle.as_mut() else {
             return;

--- a/crates/xmtp_mls/src/worker.rs
+++ b/crates/xmtp_mls/src/worker.rs
@@ -74,6 +74,13 @@ impl WorkerRunner {
     pub fn task_channels(&self) -> &TaskWorkerChannels {
         &self.task_channels
     }
+
+    /// True while the supervisor handle is held; false after a successful
+    /// `shutdown` or before the first `spawn`. Used in tests and as a
+    /// cheap liveness check.
+    pub fn is_running(&self) -> bool {
+        self.handle.lock().is_some()
+    }
 }
 
 impl WorkerRunner {


### PR DESCRIPTION
Part of #3659 (PR1 of 3).

## Review feedback addressed (most recent push)

- **@insipx — workers should be force-killable, not cooperative**: each worker future now wrapped in \`futures::future::Abortable\`; \`WorkerRunner::shutdown\` aborts each handle before draining the supervisor. Cancellation token stays as the cooperative-shutdown signal; Abortable is the hard kill for workers whose loops don't yield promptly (e.g. ones sitting on long interval sleeps).
- **Macroscope idempotency bug**: \`Client::close\` now gates its early-return on a new \`shutdown_complete\` flag set only after \`disconnect()\` succeeds, not on \`is_cancelled()\`. A mid-close disconnect failure leaves \`shutdown_complete\` false so a retry actually re-attempts the disconnect. Distinct semantic from Tyler's removed-atomic case (cancellation tracking) — this atomic tracks fully-landed teardown.
- **Claude bot — missing on_close in \`stream_message_deletions_with_callback\`**: the one variant of five that wasn't firing \`on_close\` after its loop. Now parameterized like the others; binding sites pass \`|| {}\` for now (real handlers wire through in PR2/PR3).

## Summary

First of three PRs adding \`Client::close()\` to libxmtp. This PR lands the core plumbing in \`xmtp_mls\`; no public binding surface change.

- \`CancellationToken\` on \`XmtpMlsLocalContext\`, exposed via \`XmtpSharedContext\`. \`is_closed()\` delegates to \`cancellation_token().is_cancelled()\`.
- \`shutdown_complete\` \`AtomicBool\` on the context — distinct semantic from cancellation; set only after \`disconnect()\` succeeds, used as \`close()\`'s idempotency check.
- Each worker future wrapped in \`Abortable\`. \`WorkerRunner::shutdown\` aborts every worker and drains the supervisor under a 2s timeout.
- Cancellation token also races each \`stream_*_with_callback\` inner loop, the \`cleanup_duplicate_updates\` spawn, and each worker's outer loop (cooperative path).
- Idempotent \`Client::close(&self) -> Result<(), ClientError>\` and \`ClientError::AlreadyClosed\`. \`reconnect_db\` refuses after close; \`release_db_connection\` is unchanged for callers that want release-then-reconnect cycles.
- New lifecycle \`Event::ClientClosed\` mirroring \`ClientDropped\`.

## Why

Full consumer ask is in #3659. Short version: the Convos / Herald team needs **an awaitable shutdown handshake** for their Node SDK client. They need to:

1. Stop accepting new work.
2. Wait until in-flight workers and streams have actually stopped.
3. Release the DB pool.
4. Get a single \`Ok(())\` back so they can confidently delete the SQLite file and drop their JS references.

\`Drop\` cannot deliver that contract. \`Drop::drop\` is sync, so it can signal workers to stop but cannot \`.await\` their completion. JS finalizers (napi) are also non-deterministic — the JS host decides when to run them. Even a perfect Drop story leaves Herald guessing about *when* teardown is complete, which is the exact thing they're trying to stop guessing about.

\`await client.close()\` provides that signal. Drop-based cleanup remains the fallback for callers that forget; \`close()\` is the contract for callers that care.

(The log spam Herald sees today is one downstream symptom of not having this handshake — workers and streams fire against the disconnected DB before they notice. Fixing log noise alone via per-worker Drop hygiene or finer-grained log levels would help, but neither gives Herald the awaitable signal they actually need.)

PR2 will expose \`close()\` on \`bindings/node\`; PR3 on \`bindings/mobile\` (uniffi).

## Notable change for reviewers

\`Worker::spawn\` (trait method in \`crates/xmtp_mls/src/worker.rs\`) takes a \`CancellationToken\` parameter. Internal trait, no external surface change. The new Abortable wrapping is purely on the supervisor side and doesn't change the trait signature again.

## Test plan

- [x] \`cargo nextest run -p xmtp_mls\` — 574 tests pass (2 flakes pre-existing on main). Five new tests: \`close_stops_workers\`, \`close_is_idempotent\`, \`close_disconnects_db\`, \`close_cancels_callback_stream\`, \`reconnect_after_close_errors\`.
- [x] \`cargo fmt --check\`, \`cargo clippy -Dwarnings\`, \`cargo hakari generate --diff\` — all clean.
- [x] \`test-wasm\` CI — passed, confirming \`tokio_util::sync::CancellationToken\` works on \`wasm32-unknown-unknown\`.
- [ ] \`just lint\` in nix shell (needs reviewer verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> Part of #3659 (PR1 of 3).
>
> ## Review feedback addressed (most recent push)
>
> - **@insipx — workers should be force-killable, not cooperative**: each worker future now wrapped in \`futures::future::Abortable\`; \`WorkerRunner::shutdown\` aborts each handle before draining the supervisor. Cancellation token stays as the cooperative-shutdown signal; Abortable is the hard kill for workers whose loops don't yield promptly (e.g. ones sitting on long interval sleeps).
> - **Macroscope idempotency bug**: \`Client::close\` now gates its early-return on a new \`shutdown_complete\` flag set only after \`disconnect()\` succeeds, not on \`is_cancelled()\`. A mid-close disconnect failure leaves \`shutdown_complete\` false so a retry actually re-attempts the disconnect. Distinct semantic from Tyler's removed-atomic case (cancellation tracking) — this atomic tracks fully-landed teardown.
> - **Claude bot — missing on_close in \`stream_message_deletions_with_callback\`**: the one variant of five that wasn't firing \`on_close\` after its loop. Now parameterized like the others; binding sites pass \`|| {}\` for now (real handlers wire through in PR2/PR3).
>
> ## Summary
>
> First of three PRs adding \`Client::close()\` to libxmtp. This PR lands the core plumbing in \`xmtp_mls\`; no public binding surface change.
>
> - \`CancellationToken\` on \`XmtpMlsLocalContext\`, exposed via \`XmtpSharedContext\`. \`is_closed()\` delegates to \`cancellation_token().is_cancelled()\`.
> - \`shutdown_complete\` \`AtomicBool\` on the context — distinct semantic from cancellation; set only after \`disconnect()\` succeeds, used as \`close()\`'s idempotency check.
> - Each worker future wrapped in \`Abortable\`. \`WorkerRunner::shutdown\` aborts every worker and drains the supervisor under a 2s timeout.
> - Cancellation token also races each \`stream_*_with_callback\` inner loop, the \`cleanup_duplicate_updates\` spawn, and each worker's outer loop (cooperative path).
> - Idempotent \`Client::close(&self) -> Result<(), ClientError>\` and \`ClientError::AlreadyClosed\`. \`reconnect_db\` refuses after close; \`release_db_connection\` is unchanged for callers that want release-then-reconnect cycles.
> - New lifecycle \`Event::ClientClosed\` mirroring \`ClientDropped\`.
>
> ## Why
>
> Full consumer ask is in #3659. Short version: the Convos / Herald team needs **an awaitable shutdown handshake** for their Node SDK client. They need to:
>
> 1. Stop accepting new work.
> 2. Wait until in-flight workers and streams have actually stopped.
> 3. Release the DB pool.
> 4. Get a single \`Ok(())\` back so they can confidently delete the SQLite file and drop their JS references.
>
> \`Drop\` cannot deliver that contract. \`Drop::drop\` is sync, so it can signal workers to stop but cannot \`.await\` their completion. JS finalizers (napi) are also non-deterministic — the JS host decides when to run them. Even a perfect Drop story leaves Herald guessing about *when* teardown is complete, which is the exact thing they're trying to stop guessing about.
>
> \`await client.close()\` provides that signal. Drop-based cleanup remains the fallback for callers that forget; \`close()\` is the contract for callers that care.
>
> (The log spam Herald sees today is one downstream symptom of not having this handshake — workers and streams fire against the disconnected DB before they notice. Fixing log noise alone via per-worker Drop hygiene or finer-grained log levels would help, but neither gives Herald the awaitable signal they actually need.)
>
> PR2 will expose \`close()\` on \`bindings/node\`; PR3 on \`bindings/mobile\` (uniffi).
>
> ## Notable change for reviewers
>
> \`Worker::spawn\` (trait method in \`crates/xmtp_mls/src/worker.rs\`) takes a \`CancellationToken\` parameter. Internal trait, no external surface change. The new Abortable wrapping is purely on the supervisor side and doesn't change the trait signature again.
>
> ## Test plan
>
> - [x] \`cargo nextest run -p xmtp_mls\` — 574 tests pass (2 flakes pre-existing on main). Five new tests: \`close_stops_workers\`, \`close_is_idempotent\`, \`close_disconnects_db\`, \`close_cancels_callback_stream\`, \`reconnect_after_close_errors\`.
> - [x] \`cargo fmt --check\`, \`cargo clippy -Dwarnings\`, \`cargo hakari generate --diff\` — all clean.
> - [x] \`test-wasm\` CI — passed, confirming \`tokio_util::sync::CancellationToken\` works on \`wasm32-unknown-unknown\`.
> - [ ] \`just lint\` in nix shell (needs reviewer verification).
>
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)<!-- Macroscope's changelog starts here -->
> #### Changes since #3658 opened
>
> - Added force-abort capability to `WorkerRunner` using `AbortHandle` and `Abortable` futures [639c009]
> - Modified `Client::close` idempotency logic to use `shutdown_complete` flag instead of cancellation token [639c009]
> - Added `shutdown_complete` tracking infrastructure to `XmtpMlsLocalContext` and `XmtpSharedContext` trait [639c009]
> - Added `on_close` callback parameter to `stream_message_deletions_with_callback` methods across all bindings and core subscription system [639c009]
> - Implemented on-close callback invocation for `Conversations::stream_message_deletions` method in the `xmtp_mls` wasm bindings [b1dc195]
> - Reordered `AtomicBool` import statement [3f4728f]
> <!-- Macroscope's changelog ends here -->
>
<!-- Macroscope's pull request summary ends here -->