### PR TITLE
fix hpke-rs codepoint for welcomes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1004,7 +1004,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1015,7 +1015,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2638,7 +2638,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3482,7 +3482,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3805,7 +3805,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5585,8 +5585,7 @@ dependencies = [
 [[package]]
 name = "hpke-rs"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6ad6a58eb3e0ee30be8bfc7a9770ae98adcfa1d9bc820a5847732ce84f70837"
+source = "git+https://github.com/xmtp/hpke-rs?rev=3425025bb43b68bdef28ce47da8013ae13b69cbc#3425025bb43b68bdef28ce47da8013ae13b69cbc"
 dependencies = [
  "hpke-rs-crypto",
  "hpke-rs-libcrux",
@@ -5603,8 +5602,7 @@ dependencies = [
 [[package]]
 name = "hpke-rs-crypto"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a73a99d9008010d73289f41335a3f6e14fb8c04eaf60e9111b450463b1bbc7f"
+source = "git+https://github.com/xmtp/hpke-rs?rev=3425025bb43b68bdef28ce47da8013ae13b69cbc#3425025bb43b68bdef28ce47da8013ae13b69cbc"
 dependencies = [
  "rand_core 0.9.5",
  "zeroize",
@@ -5613,8 +5611,7 @@ dependencies = [
 [[package]]
 name = "hpke-rs-libcrux"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ce6b7e54aebe540faee869c67ee253bede44ea6cb67c6e72c7847d6c59f1df"
+source = "git+https://github.com/xmtp/hpke-rs?rev=3425025bb43b68bdef28ce47da8013ae13b69cbc#3425025bb43b68bdef28ce47da8013ae13b69cbc"
 dependencies = [
  "hpke-rs-crypto",
  "libcrux-aead",
@@ -5631,8 +5628,7 @@ dependencies = [
 [[package]]
 name = "hpke-rs-rust-crypto"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b28be6cba9081c7feda2651d51c2a900029798e78b4c1e093e792f4571a870"
+source = "git+https://github.com/xmtp/hpke-rs?rev=3425025bb43b68bdef28ce47da8013ae13b69cbc#3425025bb43b68bdef28ce47da8013ae13b69cbc"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -6625,7 +6621,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7813,7 +7809,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8524,7 +8520,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9294,7 +9290,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -10133,7 +10129,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10190,7 +10186,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11018,7 +11014,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11041,7 +11037,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11399,7 +11395,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12314,7 +12310,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13252,7 +13248,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -236,6 +236,18 @@ lto = true
 [patch.crates-io]
 diesel = { git = "https://github.com/ephemerahq/diesel", branch = "coda/copy-to-sqlite" }
 diesel_migrations = { git = "https://github.com/ephemerahq/diesel", branch = "coda/copy-to-sqlite" }
+# xmtp/hpke-rs fork of v0.6.1 with one extra commit adding
+# XWingDraft06Obsolete dispatch in the libcrux backend. Lets the
+# welcome wrapper pin to the obsolete 0x004D codepoint for wire compat
+# with v1.9 / v1.10 clients (hpke-rs 0.4). All four sister crates patch
+# together: they're one workspace with internal path deps, so patching
+# only the backend produces two HpkeCrypto trait versions in the graph
+# and breaks openmls_libcrux_crypto. Remove when the d14n cutover
+# migrates everyone to 0x647a (#3661).
+hpke-rs = { git = "https://github.com/xmtp/hpke-rs", rev = "3425025bb43b68bdef28ce47da8013ae13b69cbc" }
+hpke-rs-crypto = { git = "https://github.com/xmtp/hpke-rs", rev = "3425025bb43b68bdef28ce47da8013ae13b69cbc" }
+hpke-rs-libcrux = { git = "https://github.com/xmtp/hpke-rs", rev = "3425025bb43b68bdef28ce47da8013ae13b69cbc" }
+hpke-rs-rust-crypto = { git = "https://github.com/xmtp/hpke-rs", rev = "3425025bb43b68bdef28ce47da8013ae13b69cbc" }
 
 [patch.crates-io.xmtp-workspace-hack]
 path = "crates/xmtp-workspace-hack"

--- a/apps/xmtp_debug/src/app/sync.rs
+++ b/apps/xmtp_debug/src/app/sync.rs
@@ -14,6 +14,7 @@ use color_eyre::eyre::{self, Report, Result};
 use itertools::Itertools;
 use std::time::Instant;
 use tracing::warn;
+use xmtp_db::group_message::{GroupMessageKind, MsgQueryArgs};
 use xmtp_db::prelude::QueryGroupMessage;
 
 pub struct Sync {
@@ -135,7 +136,16 @@ impl Sync {
             }
 
             let db = client.db();
-            let msgs = db.get_group_messages(&gid, &Default::default())?;
+            // Application only — MembershipChange commits fan out
+            // per-member at backend-dependent times. Recording them
+            // makes NoMissingMessages racy across peers.
+            let msgs = db.get_group_messages(
+                &gid,
+                &MsgQueryArgs::builder()
+                    .kind(GroupMessageKind::Application)
+                    .build()
+                    .expect("MsgQueryArgs builder"),
+            )?;
 
             for m in msgs {
                 let message_id: [u8; 32] =

--- a/crates/xmtp-workspace-hack/Cargo.toml
+++ b/crates/xmtp-workspace-hack/Cargo.toml
@@ -51,7 +51,7 @@ futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
 generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "zeroize"] }
 hashbrown-9067fe90e8c1f593 = { package = "hashbrown", version = "0.17" }
 hashbrown-986da7b5efc2b80e = { package = "hashbrown", version = "0.16", features = ["serde"] }
-hpke-rs = { version = "0.6", features = ["hazmat", "libcrux", "serialization"] }
+hpke-rs = { git = "https://github.com/xmtp/hpke-rs", rev = "3425025bb43b68bdef28ce47da8013ae13b69cbc", features = ["hazmat", "libcrux", "serialization"] }
 hyper = { version = "1", features = ["http1", "http2", "server"] }
 idna = { version = "1" }
 indexmap = { version = "2", features = ["serde"] }
@@ -143,7 +143,7 @@ futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
 generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "zeroize"] }
 hashbrown-9067fe90e8c1f593 = { package = "hashbrown", version = "0.17" }
 hashbrown-986da7b5efc2b80e = { package = "hashbrown", version = "0.16", features = ["serde"] }
-hpke-rs = { version = "0.6", features = ["hazmat", "libcrux", "serialization"] }
+hpke-rs = { git = "https://github.com/xmtp/hpke-rs", rev = "3425025bb43b68bdef28ce47da8013ae13b69cbc", features = ["hazmat", "libcrux", "serialization"] }
 hyper = { version = "1", features = ["http1", "http2", "server"] }
 idna = { version = "1" }
 indexmap = { version = "2", features = ["serde"] }

--- a/crates/xmtp_id/src/key_package/mls_ext_wrapper_encryption.rs
+++ b/crates/xmtp_id/src/key_package/mls_ext_wrapper_encryption.rs
@@ -26,9 +26,17 @@ impl WrapperAlgorithm {
     // hardcoded because the functions to do the translations are private
     // and placed here so that any changes to the this algorithm will have to be handled
     pub fn to_hpke_config(self) -> hpke_rs::Hpke<hpke_rs::libcrux::HpkeLibcrux> {
+        // Pin XWING to the obsolete 0x004D codepoint so the HPKE
+        // suite_id labels (and thus AEAD keys) match v1.9 / v1.10
+        // clients which shipped on hpke-rs 0.4 where 0x004D was the
+        // only XWING variant. Upstream hpke-rs-libcrux 0.6.1 lacks
+        // dispatch for the Obsolete variant; we use a fork via
+        // [patch.crates-io] in this Cargo.toml. See #3661 for the
+        // d14n cutover plan to the canonical 0x647a codepoint.
+        #[allow(deprecated)]
         let kem = match self {
             Self::Curve25519 => hpke_rs::hpke_types::KemAlgorithm::DhKem25519,
-            Self::XWingMLKEM768Draft6 => hpke_rs::hpke_types::KemAlgorithm::XWingDraft06,
+            Self::XWingMLKEM768Draft6 => hpke_rs::hpke_types::KemAlgorithm::XWingDraft06Obsolete,
         };
         hpke_rs::Hpke::<hpke_rs::libcrux::HpkeLibcrux>::new(
             hpke_rs::Mode::Base,

--- a/crates/xmtp_mls/src/groups/mls_ext/welcome_wrapper.rs
+++ b/crates/xmtp_mls/src/groups/mls_ext/welcome_wrapper.rs
@@ -325,6 +325,15 @@ mod tests {
             crypto_provider,
         )?)
     }
+    // Verifies wrap_welcome / unwrap_welcome is byte-compatible with
+    // openmls's canonical hpke::encrypt_with_label /
+    // decrypt_with_label path. Currently ignored: we pin XWING to the
+    // obsolete 0x004D codepoint for wire compat with v1.9 / v1.10
+    // (hpke-rs 0.4 only knew 0x004D — see to_hpke_config). The two
+    // paths thus produce different HPKE suite_id labels and can't
+    // round-trip against each other. Un-ignore + verify once the d14n
+    // cutover migrates everyone back to the canonical 0x647a (#3661).
+    #[ignore = "pinned to obsolete XWING codepoint for v1.9 / v1.10 wire compat (#3661)"]
     #[xmtp_common::test]
     async fn round_trip_xwing_mlkem512_current_to_previous_and_back() {
         let client = ClientBuilder::new_test_client(&generate_local_wallet()).await;

--- a/dev/drivers/cross_talk_test/cross_talk_test/__main__.py
+++ b/dev/drivers/cross_talk_test/cross_talk_test/__main__.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import sys
+from pathlib import Path
 
 import xdbg_driver_lib_py as d
 
@@ -127,6 +128,10 @@ def run_sequence(
             "--amount",
             "1",
         )
+        # Use --out so xdbg writes the export JSON to a file rather than
+        # stdout — `-vvvvv` floods stdout with JSON log lines that would
+        # otherwise mix with the payload and break parsing.
+        export_path = Path(out_dir) / "groups-export.json"
         r = run_strict(
             env_extras,
             out_dir,
@@ -135,12 +140,14 @@ def run_sequence(
             "export",
             "-e",
             "group",
+            "--out",
+            str(export_path),
             tee=False,
         )
         gid = None
-        if r.returncode == 0 and r.stdout:
+        if r.returncode == 0 and export_path.exists():
             try:
-                groups = json.loads(r.stdout)
+                groups = json.loads(export_path.read_text())
                 if groups:
                     gid = groups[0].get("id")
             except json.JSONDecodeError:

--- a/nix/lib/packages/wasm-bindgen-cli.nix
+++ b/nix/lib/packages/wasm-bindgen-cli.nix
@@ -42,5 +42,6 @@ rustPlatform.buildRustPackage {
   doCheck = false;
   meta = {
     description = "Custom maintained wasm-bindgen-cli package to match Cargo.toml";
+    mainProgram = "wasm-bindgen";
   };
 }


### PR DESCRIPTION
fixes codepoint to make HEAD compatible with `1.9`. w/o this change, users on 1.9 cannot invite users on latest to a group, the welcome decryption fails

this is something we should change on cutover

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix HPKE codepoint for XWing welcomes by switching to obsolete KEM variant
> - Changes `WrapperAlgorithm::to_hpke_config` in [mls_ext_wrapper_encryption.rs](https://github.com/xmtp/libxmtp/pull/3662/files#diff-953b8e1e1fda90d73df4c1df6a1d9899a2625466e2079ef9f4792facfdb0086b) to use `XWingDraft06Obsolete` instead of `XWingDraft06` for `XWingMLKEM768Draft6`, correcting the HPKE suite ID used in welcome message encryption.
> - Pins `hpke-rs` workspace dependencies to a specific git revision in [Cargo.toml](https://github.com/xmtp/libxmtp/pull/3662/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542) to get the `XWingDraft06Obsolete` variant.
> - Disables the `round_trip_xwing_mlkem512_current_to_previous_and_back` test in [welcome_wrapper.rs](https://github.com/xmtp/libxmtp/pull/3662/files#diff-92f909b12614602dac5436a54a2c75812d1a1911473e78137b1c57860bec36cb) while the obsolete codepoint is in use.
> - Risk: Changes derived HPKE keys and suite IDs for XWing-based welcome messages, breaking compatibility with clients using the previous codepoint.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eefdfd2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->