### PR TITLE
deps: bump openmls fork to feature/external-commit-by-value @ 9cdd5e7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,7 +707,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -863,7 +863,7 @@ checksum = "eed3ed3300a998f88639ed619fdbbd88bd82865e00c6a8ecb796c99eb12358f6"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "reqwest 0.13.3",
  "serde_json",
  "tower",
@@ -1004,7 +1004,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1015,7 +1015,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2639,7 +2639,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3483,7 +3483,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3806,7 +3806,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6622,7 +6622,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7834,7 +7834,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8364,7 +8364,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 [[package]]
 name = "openmls"
 version = "0.8.1"
-source = "git+https://github.com/xmtp/openmls?rev=e125674303a715b00bf133ceba903862304eac83#e125674303a715b00bf133ceba903862304eac83"
+source = "git+https://github.com/xmtp/openmls?rev=9cdd5e798cb9217ef246964885e87d371ea553b3#9cdd5e798cb9217ef246964885e87d371ea553b3"
 dependencies = [
  "backtrace",
  "getrandom 0.3.4",
@@ -8391,7 +8391,7 @@ dependencies = [
 [[package]]
 name = "openmls_basic_credential"
 version = "0.5.0"
-source = "git+https://github.com/xmtp/openmls?rev=e125674303a715b00bf133ceba903862304eac83#e125674303a715b00bf133ceba903862304eac83"
+source = "git+https://github.com/xmtp/openmls?rev=9cdd5e798cb9217ef246964885e87d371ea553b3#9cdd5e798cb9217ef246964885e87d371ea553b3"
 dependencies = [
  "ed25519-dalek",
  "openmls_traits",
@@ -8405,7 +8405,7 @@ dependencies = [
 [[package]]
 name = "openmls_libcrux_crypto"
 version = "0.3.1"
-source = "git+https://github.com/xmtp/openmls?rev=e125674303a715b00bf133ceba903862304eac83#e125674303a715b00bf133ceba903862304eac83"
+source = "git+https://github.com/xmtp/openmls?rev=9cdd5e798cb9217ef246964885e87d371ea553b3#9cdd5e798cb9217ef246964885e87d371ea553b3"
 dependencies = [
  "hpke-rs",
  "hpke-rs-crypto",
@@ -8426,7 +8426,7 @@ dependencies = [
 [[package]]
 name = "openmls_memory_storage"
 version = "0.5.0"
-source = "git+https://github.com/xmtp/openmls?rev=e125674303a715b00bf133ceba903862304eac83#e125674303a715b00bf133ceba903862304eac83"
+source = "git+https://github.com/xmtp/openmls?rev=9cdd5e798cb9217ef246964885e87d371ea553b3#9cdd5e798cb9217ef246964885e87d371ea553b3"
 dependencies = [
  "hex",
  "log",
@@ -8439,7 +8439,7 @@ dependencies = [
 [[package]]
 name = "openmls_rust_crypto"
 version = "0.5.1"
-source = "git+https://github.com/xmtp/openmls?rev=e125674303a715b00bf133ceba903862304eac83#e125674303a715b00bf133ceba903862304eac83"
+source = "git+https://github.com/xmtp/openmls?rev=9cdd5e798cb9217ef246964885e87d371ea553b3#9cdd5e798cb9217ef246964885e87d371ea553b3"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -8463,7 +8463,7 @@ dependencies = [
 [[package]]
 name = "openmls_test"
 version = "0.2.1"
-source = "git+https://github.com/xmtp/openmls?rev=e125674303a715b00bf133ceba903862304eac83#e125674303a715b00bf133ceba903862304eac83"
+source = "git+https://github.com/xmtp/openmls?rev=9cdd5e798cb9217ef246964885e87d371ea553b3#9cdd5e798cb9217ef246964885e87d371ea553b3"
 dependencies = [
  "ansi_term",
  "openmls_rust_crypto",
@@ -8478,7 +8478,7 @@ dependencies = [
 [[package]]
 name = "openmls_traits"
 version = "0.5.0"
-source = "git+https://github.com/xmtp/openmls?rev=e125674303a715b00bf133ceba903862304eac83#e125674303a715b00bf133ceba903862304eac83"
+source = "git+https://github.com/xmtp/openmls?rev=9cdd5e798cb9217ef246964885e87d371ea553b3#9cdd5e798cb9217ef246964885e87d371ea553b3"
 dependencies = [
  "serde",
  "tls_codec",
@@ -8634,7 +8634,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -9404,8 +9404,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -9426,7 +9426,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10244,7 +10244,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10301,7 +10301,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11129,7 +11129,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11152,7 +11152,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11510,7 +11510,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12428,7 +12428,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -13375,7 +13375,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -14280,7 +14280,7 @@ dependencies = [
  "hyper-util",
  "idna",
  "indexmap 2.14.0",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "k256",
  "libc",
  "libcrux-ed25519",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,15 +85,15 @@ lru = "0.18"
 mockall = { version = "0.14" }
 mockall_double = "0.3.1"
 once_cell = "1.21.4"
-openmls = { git = "https://github.com/xmtp/openmls", rev = "e125674303a715b00bf133ceba903862304eac83", default-features = false, features = [
+openmls = { git = "https://github.com/xmtp/openmls", rev = "9cdd5e798cb9217ef246964885e87d371ea553b3", default-features = false, features = [
   "extensions-draft-08",
 ] }
-openmls_basic_credential = { git = "https://github.com/xmtp/openmls", rev = "e125674303a715b00bf133ceba903862304eac83" }
-openmls_libcrux_crypto = { git = "https://github.com/xmtp/openmls", rev = "e125674303a715b00bf133ceba903862304eac83", features = [
+openmls_basic_credential = { git = "https://github.com/xmtp/openmls", rev = "9cdd5e798cb9217ef246964885e87d371ea553b3" }
+openmls_libcrux_crypto = { git = "https://github.com/xmtp/openmls", rev = "9cdd5e798cb9217ef246964885e87d371ea553b3", features = [
   "extensions-draft-08",
 ] }
-openmls_rust_crypto = { git = "https://github.com/xmtp/openmls", rev = "e125674303a715b00bf133ceba903862304eac83" }
-openmls_traits = { git = "https://github.com/xmtp/openmls", rev = "e125674303a715b00bf133ceba903862304eac83", features = [
+openmls_rust_crypto = { git = "https://github.com/xmtp/openmls", rev = "9cdd5e798cb9217ef246964885e87d371ea553b3" }
+openmls_traits = { git = "https://github.com/xmtp/openmls", rev = "9cdd5e798cb9217ef246964885e87d371ea553b3", features = [
   "extensions-draft-08",
 ] }
 owo-colors = { version = "4.1" }

--- a/crates/xmtp-workspace-hack/Cargo.toml
+++ b/crates/xmtp-workspace-hack/Cargo.toml
@@ -55,18 +55,18 @@ hpke-rs = { git = "https://github.com/xmtp/hpke-rs", rev = "3425025bb43b68bdef28
 hyper = { version = "1", features = ["http1", "http2", "server"] }
 idna = { version = "1" }
 indexmap = { version = "2", features = ["serde"] }
-itertools = { version = "0.14" }
+itertools = { version = "0.13" }
 k256 = { version = "0.13", default-features = false, features = ["ecdh", "ecdsa", "std"] }
 libcrux-ed25519 = { version = "0.0.7", default-features = false, features = ["rand"] }
 log = { version = "0.4", default-features = false, features = ["std"] }
 memchr = { version = "2" }
 nu-ansi-term = { version = "0.50" }
 num-traits = { version = "0.2", features = ["libm"] }
-openmls = { git = "https://github.com/xmtp/openmls", rev = "e125674303a715b00bf133ceba903862304eac83", default-features = false, features = ["extensions-draft-08", "test-utils"] }
-openmls_basic_credential = { git = "https://github.com/xmtp/openmls", rev = "e125674303a715b00bf133ceba903862304eac83", default-features = false, features = ["clonable", "test-utils"] }
-openmls_memory_storage = { git = "https://github.com/xmtp/openmls", rev = "e125674303a715b00bf133ceba903862304eac83", default-features = false, features = ["extensions-draft-08", "test-utils"] }
-openmls_rust_crypto = { git = "https://github.com/xmtp/openmls", rev = "e125674303a715b00bf133ceba903862304eac83", default-features = false, features = ["test-utils"] }
-openmls_traits = { git = "https://github.com/xmtp/openmls", rev = "e125674303a715b00bf133ceba903862304eac83", features = ["extensions-draft-08", "test-utils"] }
+openmls = { git = "https://github.com/xmtp/openmls", rev = "9cdd5e798cb9217ef246964885e87d371ea553b3", default-features = false, features = ["extensions-draft-08", "test-utils"] }
+openmls_basic_credential = { git = "https://github.com/xmtp/openmls", rev = "9cdd5e798cb9217ef246964885e87d371ea553b3", default-features = false, features = ["clonable", "test-utils"] }
+openmls_memory_storage = { git = "https://github.com/xmtp/openmls", rev = "9cdd5e798cb9217ef246964885e87d371ea553b3", default-features = false, features = ["extensions-draft-08", "test-utils"] }
+openmls_rust_crypto = { git = "https://github.com/xmtp/openmls", rev = "9cdd5e798cb9217ef246964885e87d371ea553b3", default-features = false, features = ["test-utils"] }
+openmls_traits = { git = "https://github.com/xmtp/openmls", rev = "9cdd5e798cb9217ef246964885e87d371ea553b3", features = ["extensions-draft-08", "test-utils"] }
 p256 = { version = "0.13", features = ["ecdh", "jwk"] }
 percent-encoding = { version = "2" }
 rand-274715c4dabd11b0 = { package = "rand", version = "0.9", features = ["serde"] }
@@ -147,18 +147,18 @@ hpke-rs = { git = "https://github.com/xmtp/hpke-rs", rev = "3425025bb43b68bdef28
 hyper = { version = "1", features = ["http1", "http2", "server"] }
 idna = { version = "1" }
 indexmap = { version = "2", features = ["serde"] }
-itertools = { version = "0.14" }
+itertools = { version = "0.13" }
 k256 = { version = "0.13", default-features = false, features = ["ecdh", "ecdsa", "std"] }
 libcrux-ed25519 = { version = "0.0.7", default-features = false, features = ["rand"] }
 log = { version = "0.4", default-features = false, features = ["std"] }
 memchr = { version = "2" }
 nu-ansi-term = { version = "0.50" }
 num-traits = { version = "0.2", features = ["libm"] }
-openmls = { git = "https://github.com/xmtp/openmls", rev = "e125674303a715b00bf133ceba903862304eac83", default-features = false, features = ["extensions-draft-08", "test-utils"] }
-openmls_basic_credential = { git = "https://github.com/xmtp/openmls", rev = "e125674303a715b00bf133ceba903862304eac83", default-features = false, features = ["clonable", "test-utils"] }
-openmls_memory_storage = { git = "https://github.com/xmtp/openmls", rev = "e125674303a715b00bf133ceba903862304eac83", default-features = false, features = ["extensions-draft-08", "test-utils"] }
-openmls_rust_crypto = { git = "https://github.com/xmtp/openmls", rev = "e125674303a715b00bf133ceba903862304eac83", default-features = false, features = ["test-utils"] }
-openmls_traits = { git = "https://github.com/xmtp/openmls", rev = "e125674303a715b00bf133ceba903862304eac83", features = ["extensions-draft-08", "test-utils"] }
+openmls = { git = "https://github.com/xmtp/openmls", rev = "9cdd5e798cb9217ef246964885e87d371ea553b3", default-features = false, features = ["extensions-draft-08", "test-utils"] }
+openmls_basic_credential = { git = "https://github.com/xmtp/openmls", rev = "9cdd5e798cb9217ef246964885e87d371ea553b3", default-features = false, features = ["clonable", "test-utils"] }
+openmls_memory_storage = { git = "https://github.com/xmtp/openmls", rev = "9cdd5e798cb9217ef246964885e87d371ea553b3", default-features = false, features = ["extensions-draft-08", "test-utils"] }
+openmls_rust_crypto = { git = "https://github.com/xmtp/openmls", rev = "9cdd5e798cb9217ef246964885e87d371ea553b3", default-features = false, features = ["test-utils"] }
+openmls_traits = { git = "https://github.com/xmtp/openmls", rev = "9cdd5e798cb9217ef246964885e87d371ea553b3", features = ["extensions-draft-08", "test-utils"] }
 p256 = { version = "0.13", features = ["ecdh", "jwk"] }
 percent-encoding = { version = "2" }
 proc-macro2 = { version = "1", features = ["span-locations"] }


### PR DESCRIPTION
## Summary

Bumps the openmls dependency to the XMTP fork's `feature/external-commit-by-value` branch (commit 9cdd5e7).

The fork relaxes `add_proposal` / `add_proposals` on the external `CommitBuilder` from `&mut MlsGroup` to `BorrowMut<MlsGroup>`, allowing by-value `Add` and `AppDataUpdate` proposals to be carried in a single external commit (RFC 9420 §12.4.3.2). This is the openmls-side enabler for the atomic-external-commit flow built in PR-L11.

Touches: `Cargo.toml`, `Cargo.lock`, `crates/xmtp-workspace-hack/Cargo.toml`. No source-level changes in this PR.

## Stack

- Base: `tyler/qr-invite-l8-ingestion` (#3668) ← #3667 ← #3666 ← #3671 ← #3751 ← main.
- Downstream: PR-L11 (join_group_by_external_invite) is the first consumer of the new openmls API surface.

## Test plan

- [x] cargo check -p xmtp_mls passes against the bumped openmls.
- [ ] CI green (full build).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump openmls fork dependencies to `feature/external-commit-by-value` at `9cdd5e7`
> Updates all `openmls*` crate revisions in [Cargo.toml](https://github.com/xmtp/libxmtp/pull/3672/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542) and [crates/xmtp-workspace-hack/Cargo.toml](https://github.com/xmtp/libxmtp/pull/3672/files#diff-d376defcdc6ba9d6bc902fe0f3e91f5d4b09191e5bcc2776cf4fdf65e467df65) from `e125674` to `9cdd5e7`. Also downgrades `itertools` from `0.14` to `0.13` in the workspace-hack crate to match the new dependency tree.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6849a56.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
