### PR TITLE
drivers: force 200-col rich console in CI so tables don't truncate

### DIFF
--- a/dev/drivers/xdbg_driver_lib/xdbg_driver_lib_py/__init__.py
+++ b/dev/drivers/xdbg_driver_lib/xdbg_driver_lib_py/__init__.py
@@ -24,7 +24,16 @@ from packaging.version import InvalidVersion, Version
 from rich.console import Console
 from rich.table import Table
 
-_stderr_console = Console(stderr=True, highlight=False)
+
+def _console_width() -> int | None:
+    """Force a wide table in CI (GH Actions reports 80 cols but doesn't
+    actually wrap), keep auto-sizing on real TTYs."""
+    if os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS"):
+        return 200
+    return None
+
+
+_stderr_console = Console(stderr=True, highlight=False, width=_console_width())
 
 NIGHTLY_TAG_RE = re.compile(
     r"^(?:node-bindings|wasm-bindings|android|ios)-.*-nightly\.\d{8}\.[0-9a-f]{7}$"


### PR DESCRIPTION
small QoL fix

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Force 200-column rich console width in CI to prevent table truncation
> Adds a `_console_width()` helper in [`__init__.py`](https://github.com/xmtp/libxmtp/pull/3679/files#diff-ff400178609e2854f91476cad94afc7b2d274a3f52a1dfd3e707ae5be131c84b) that returns 200 when `CI` or `GITHUB_ACTIONS` is set, otherwise returns `None` to preserve auto-sizing. The `_stderr_console` is updated to pass this value as the `width` argument to `Console`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a9f5483.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->