### PR TITLE
honor .gitignore, otherwise dry-run tries to hash `target/` during local dev

### DIFF
--- a/dev/drivers/cross_talk_test/cross_talk_test/__main__.py
+++ b/dev/drivers/cross_talk_test/cross_talk_test/__main__.py
@@ -35,18 +35,18 @@ def run_strict(env_extras, out_dir, kind, sha, *args, tee=True):
 def preflight(env_extras: dict[str, str], e: d.Entry) -> tuple[str, str]:
     """Returns (status, reason). status in {ok, skip}; on hard failure exits."""
     mode = "full" if e.kind == "nightly" else "dry"
-    status, stderr = d.probe(mode, e.kind, e.sha)
+    status, stderr = d.build(mode, e.kind, e.sha)
     if status != "ok":
         if stderr:
             sys.stderr.write(stderr)
             sys.stderr.flush()
         if e.required:
-            d.gh_error(f"probe failed for {e.short} ({e.kind}) status={status}")
+            d.gh_error(f"build failed for {e.short} ({e.kind}) status={status}")
             sys.exit(1)
         d.gh_warning(
-            f"xdbg@{e.short} ({e.kind}) probe {status}; dropping from cross-talk plan"
+            f"xdbg@{e.short} ({e.kind}) build {status}; dropping from cross-talk plan"
         )
-        return ("skip", f"probe-{status}")
+        return ("skip", f"build-{status}")
     if not d.supports_flag(e.kind, e.sha, "--strict-versioning"):
         if e.required:
             d.gh_error(

--- a/dev/drivers/cross_version_test/cross_version_test/__main__.py
+++ b/dev/drivers/cross_version_test/cross_version_test/__main__.py
@@ -22,8 +22,8 @@ def run_sequence(
 
     for i, e in enumerate(parsed):
         row = d.base_row(e)
-        probe_mode = "dry" if e.required else "full"
-        status, stderr = d.probe(probe_mode, e.kind, e.sha)
+        build_mode = "dry" if e.required else "full"
+        status, stderr = d.build(build_mode, e.kind, e.sha)
         rest = parsed[i + 1 :]
 
         if status == "build-failed":
@@ -49,7 +49,7 @@ def run_sequence(
                 sys.stderr.flush()
             if e.required:
                 d.gh_error(
-                    f"run-sequence: aborting on probe eval failure for {e.short}"
+                    f"run-sequence: aborting on build eval failure for {e.short}"
                 )
                 results = d.record_not_run_remaining(
                     results + [{**row, "status": "FAIL"}], rest
@@ -57,7 +57,7 @@ def run_sequence(
                 required_fail = True
                 break
             d.gh_warning(
-                f"xdbg@{e.short} nightly {e.label} probe eval failed; skipping"
+                f"xdbg@{e.short} nightly {e.label} build eval failed; skipping"
             )
             results.append({**row, "status": "SKIP-EVAL"})
             nightly_fail = True

--- a/dev/drivers/xdbg_driver_lib/xdbg_driver_lib_py/__init__.py
+++ b/dev/drivers/xdbg_driver_lib/xdbg_driver_lib_py/__init__.py
@@ -381,9 +381,13 @@ def pick_versions(sample_size: int = 3) -> list[dict[str, Any]]:
 
 
 def flake_ref(kind: str, sha: str) -> str:
+    # HEAD uses git+file:// so nix's git fetcher honors .gitignore —
+    # skips target/ (~35GB) and .jj/ (~1.6GB). path:/abs/path would
+    # hash the entire tree (minutes). shallow=1 allows shallow clones.
+    # cwd-independent, so callers can set cwd to per-run tempdirs.
     if kind == "head":
         root = os.environ.get("GITHUB_WORKSPACE") or repo_root()
-        return f"path:{root}#xdbg"
+        return f"git+file://{root}?shallow=1#xdbg"
     return f"github:xmtp/libxmtp/{sha}#xdbg"
 
 
@@ -439,13 +443,14 @@ def _cache_set(key: str, value: int) -> None:
         f.write(f"{key}\t{value}\n")
 
 
-def probe(mode: str, kind: str, sha: str) -> tuple[str, str]:
-    """Returns (status, stderr) where status in {ok, build-failed, eval-failed}."""
+def build(mode: str, kind: str, sha: str) -> tuple[str, str]:
+    """Build xdbg via `nix build` (or `--dry-run` for `mode="dry"`).
+    Returns (status, stderr) where status in {ok, build-failed, eval-failed}."""
     args = ["nix", "build", "-L"]
     if mode == "dry":
         args.append("--dry-run")
     args.append(flake_ref(kind, sha))
-    label = f"probing xdbg@{sha[:7]} ({kind}{', dry' if mode == 'dry' else ''})"
+    label = f"building xdbg@{sha[:7]} ({kind}{', dry' if mode == 'dry' else ''})"
     with with_spinner(label):
         r = subprocess.run(args, cwd=repo_root(), capture_output=True, text=True)
     if r.returncode == 0:


### PR DESCRIPTION
avoids a long build time

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use `git+file://` flake reference for HEAD builds to honor `.gitignore`
> - Changes the flake reference for `kind=='head'` in `flake_ref` from `path:{root}#xdbg` to `git+file://{root}?shallow=1#xdbg` in [__init__.py](https://github.com/xmtp/libxmtp/pull/3680/files#diff-ff400178609e2854f91476cad94afc7b2d274a3f52a1dfd3e707ae5be131c84b). The `path:` fetcher includes all files in the directory, causing dry-run to hash untracked build artifacts like `target/`; the `git+file://` fetcher respects `.gitignore`.
> - Renames the public `probe` function to `build` and updates all callers in the cross-talk and cross-version test drivers.
> - Behavioral Change: shallow clones via `git+file://` require a git repo at `root` and change how Nix resolves the flake for HEAD, which may affect cwd-relative path behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee14dfe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->