### PR TITLE
force commit log reconciliation for no fork check

### DIFF
--- a/apps/xmtp_debug/src/app/health/validators/no_forks.rs
+++ b/apps/xmtp_debug/src/app/health/validators/no_forks.rs
@@ -1,9 +1,8 @@
 //! Validator: every (client, group) pair must not be in a forked state.
 //!
-//! For each client, queries the local DB for every group's fork status via
-//! `QueryGroup::get_group_commit_log_forked_status`. A `Some(true)` is a
-//! fail. `Some(false)` and `None` are passes (the latter means commit-log
-//! verification isn't enabled for that group).
+//! Per client: force a fresh reconciliation tick so the DB column is current
+//! at check time, then read `is_commit_log_forked`. Without this, the
+//! healthcheck races the periodic CommitLogWorker and reports stale state.
 
 use crate::app::health::context::HealthContext;
 use crate::app::health::result::{OpResult, Status};
@@ -12,6 +11,7 @@ use async_trait::async_trait;
 use color_eyre::eyre::eyre;
 use std::time::Instant;
 use xmtp_db::prelude::QueryGroup;
+use xmtp_mls::groups::commit_log::CommitLogWorker;
 
 pub struct NoForkedGroups;
 
@@ -30,6 +30,22 @@ impl Validator for NoForkedGroups {
         let mut out = Vec::new();
         for client in ctx.all_clients() {
             let db = client.db();
+
+            // Force a reconciliation pass so fork status reflects what's on
+            // the server *now*, not what the last periodic tick wrote.
+            let tick_start = Instant::now();
+            let mut worker = CommitLogWorker::new(client.context.clone());
+            if let Err(e) = worker.tick().await {
+                out.push(OpResult {
+                    op_name: self.name(),
+                    target: Some(format!("inbox={} reconcile", client.inbox_id())),
+                    status: Status::Fail,
+                    duration: tick_start.elapsed(),
+                    error: Some(eyre!("commit-log reconcile failed: {e}")),
+                });
+                continue;
+            }
+
             for gid in ctx.all_groups() {
                 // Skip clients that aren't active members. A removed
                 // client's frozen local commit-log diverges from the

--- a/crates/xmtp_mls/src/groups/commit_log.rs
+++ b/crates/xmtp_mls/src/groups/commit_log.rs
@@ -228,7 +228,7 @@ where
         Ok(())
     }
 
-    async fn tick(&mut self) -> Result<(), CommitLogError> {
+    pub async fn tick(&mut self) -> Result<(), CommitLogError> {
         self.save_remote_commit_log().await?;
         self.update_forked_state().await?;
         self.publish_commit_logs_to_remote().await?;


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Force commit log reconciliation before fork checks in `NoForkedGroups` validator
- Makes `CommitLogWorker.tick()` public in [commit_log.rs](https://github.com/xmtp/libxmtp/pull/3683/files#diff-523943065ed63a511a3a552e44cb0ba0a05fecab9163088d5588cb5c949e6a5d) so external callers can trigger reconciliation.
- Before checking group fork status, `NoForkedGroups.validate` now constructs a `CommitLogWorker` per client and calls `tick()` to reconcile commit logs.
- If `tick()` fails, the validator emits a `Fail` result tagged `inbox=<id> reconcile` and skips group checks for that client.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized cd2ca4a.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->