### PR TITLE
bindings_node: expose Client.close() for clean shutdown (PR2/3)

### DIFF
--- a/bindings/node/src/client/mod.rs
+++ b/bindings/node/src/client/mod.rs
@@ -95,4 +95,20 @@ impl Client {
       .map_err(ErrorWrapper::from)?;
     Ok(())
   }
+
+  /// Cleanly shut down this client: cancel in-flight workers and streams, then
+  /// release the DB connection. Idempotent — a second call resolves to `Ok`.
+  ///
+  /// `await` this before deleting the SQLite file or dropping the client
+  /// reference to avoid late log spew from detached workers/streams firing
+  /// against a dead DB.
+  #[napi]
+  pub async fn close(&self) -> Result<()> {
+    self
+      .inner_client
+      .close()
+      .await
+      .map_err(ErrorWrapper::from)?;
+    Ok(())
+  }
 }

--- a/bindings/node/test/Client.test.ts
+++ b/bindings/node/test/Client.test.ts
@@ -388,6 +388,26 @@ describe('Client', () => {
     // Verify database operations work again after reconnecting
     expect(() => client.conversations().list()).not.toThrow()
   })
+
+  it('should close cleanly and be idempotent', async () => {
+    const user = createUser()
+    const client = await createRegisteredClient(user)
+
+    // Verify database operations work initially
+    expect(() => client.conversations().list()).not.toThrow()
+
+    // Close the client: stops workers/streams and releases the DB
+    await expect(client.close()).resolves.toBeUndefined()
+
+    // Database operations fail once the connection is released
+    expect(() => client.conversations().list()).toThrow()
+
+    // A second close is a no-op and still resolves
+    await expect(client.close()).resolves.toBeUndefined()
+
+    // Reconnecting after close is refused
+    await expect(client.dbReconnect()).rejects.toThrow()
+  })
 })
 
 describe('Streams', () => {


### PR DESCRIPTION
Second of three PRs adding `Client.close()` to libxmtp. This PR exposes the core `xmtp_mls::Client::close()` plumbing — landed in **PR1 (#3658)** — through the **Node binding**. No mobile surface change (that's PR3).

## What

Adds an async `close(): Promise<void>` to the Node `Client`:

```ts
await client.close()
// workers + streams cancelled, DB released — safe to delete the SQLite file
```

`close()` trips the `CancellationToken`, awaits `WorkerRunner::shutdown()` (bounded ~2s drain), disconnects the DB, and emits `Event::ClientClosed`. It is idempotent on the Rust side (`shutdown_complete` short-circuit) — a second call resolves cleanly. After close, `dbReconnect()` surfaces `ClientError::AlreadyClosed`, propagated as a normal JS error via `ErrorWrapper`. `releaseDbConnection` is unchanged for callers doing release-then-reconnect cycles.

## Why

From #3659 — the Convos / Herald team needs an awaitable "off button" for their Node SDK client: stop accepting new work, wait until in-flight workers/streams have actually stopped, release the DB pool, and get a single resolved promise back so they can confidently delete the SQLite file and drop JS references. `Drop` / napi finalizers cannot deliver that contract (sync, non-deterministic). `await client.close()` does.

Unblocks Herald once a `@xmtp/node-sdk` release ships.

## Test

Adds a case to `Client.test.ts` asserting `close()` resolves, releases the DB, is idempotent on a second call, and that `dbReconnect()` is refused post-close.

## Verification

- `cargo check`, `clippy --all-features -- -D warnings`, `cargo fmt --check` on `bindings_node` — all clean.
- napi codegen produces `close(): Promise<void>` in `index.d.ts`.
- Draft pending a local run of the vitest suite against the XMTP docker backend.

## Rollout

- PR1 — core plumbing in `xmtp_mls` ✅ #3658
- **PR2 — Node binding `close()` ← this PR**
- PR3 — uniffi mobile binding `close()`

Closes part of #3659.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose `Client.close()` as an async NAPI method for clean shutdown in Node bindings
> Adds a `close()` NAPI method to the Node `Client` in [mod.rs](https://github.com/xmtp/libxmtp/pull/3685/files#diff-67928cee58e53edbaf8e5b61a60407d11b15896f48429cc2fc3d3090a55e9b41) that forwards to the inner client's `close()` and maps errors via `ErrorWrapper`. A new test in [Client.test.ts](https://github.com/xmtp/libxmtp/pull/3685/files#diff-c575309eb5b0324a7943bc5a0408fa297f2315ea034f6818344344d26918561b) verifies that conversations work before close, throw after close, and that calling `close()` again is idempotent while `dbReconnect()` rejects post-close.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized afc4ab1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->