### PR TITLE
reverse healthcheck, readonly verify older clients still healthy

### DIFF
--- a/apps/xmtp_debug/src/app.rs
+++ b/apps/xmtp_debug/src/app.rs
@@ -177,11 +177,6 @@ impl App {
         *NETWORK_HASH.get().expect("just set network hash")
     }
 
-    #[cfg(test)]
-    pub fn set_network_hash(n: u64) {
-        NETWORK_HASH.set(n).expect("tests only")
-    }
-
     /// Directory for SQLite files belonging to the *current* binary
     /// version. Always version-bucketed via `current_version_hash`.
     /// Same shape in both strict and non-strict mode — the
@@ -196,10 +191,9 @@ impl App {
     /// `db_directory()` instead.
     fn db_directory_for(version_hash: u64) -> Result<PathBuf> {
         let data = Self::data_directory()?;
-        let network = App::network();
         let dir = data
             .join("sqlite")
-            .join(network.hash().to_string())
+            .join(App::network_hash().to_string())
             .join(format!("{version_hash:016x}"));
         Ok(dir)
     }
@@ -247,7 +241,6 @@ impl App {
         let AppOpts {
             clear,
             cmd,
-            backend,
             strict_versioning,
             ..
         } = crate::config_unchecked();
@@ -291,92 +284,4 @@ impl App {
 
 pub(super) fn generate_wallet() -> types::EthereumWallet {
     types::EthereumWallet::default()
-}
-
-#[cfg(test)]
-mod app_db_directory_tests {
-    use std::sync::Mutex;
-
-    // Tests in this module mutate XDBG_DB_ROOT. Run them serialized so
-    // they don't observe each other's env state.
-    static ENV_GUARD: Mutex<()> = Mutex::new(());
-
-    fn with_db_root<R>(f: impl FnOnce(&std::path::Path) -> R) -> R {
-        // Drop-based guard so XDBG_DB_ROOT is restored even if `f` panics —
-        // otherwise the env var would leak across tests pointing at a
-        // deleted tempdir, violating the ENV_GUARD invariant.
-        struct Restore(Option<String>);
-        impl Drop for Restore {
-            fn drop(&mut self) {
-                // SAFETY: serialized via ENV_GUARD; this runs before the
-                // mutex guard is released because guards drop in reverse
-                // declaration order.
-                unsafe {
-                    match self.0.take() {
-                        Some(v) => std::env::set_var("XDBG_DB_ROOT", v),
-                        None => std::env::remove_var("XDBG_DB_ROOT"),
-                    }
-                }
-            }
-        }
-
-        let _g = ENV_GUARD.lock().unwrap();
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let _restore = Restore(std::env::var("XDBG_DB_ROOT").ok());
-        // SAFETY: serialized via ENV_GUARD; `_restore` reverts on unwind.
-        unsafe {
-            std::env::set_var("XDBG_DB_ROOT", tmp.path());
-        }
-        f(tmp.path())
-    }
-}
-
-#[cfg(test)]
-mod legacy_detection_tests {
-    use redb::TableDefinition;
-
-    fn seed_table_named(path: &std::path::Path, name: &'static str) {
-        let db = redb::Database::create(path).unwrap();
-        let table: TableDefinition<&[u8], &[u8]> = TableDefinition::new(name);
-        let w = db.begin_write().unwrap();
-        {
-            let mut t = w.open_table(table).unwrap();
-            t.insert(b"k".as_slice(), b"v".as_slice()).unwrap();
-        }
-        w.commit().unwrap();
-    }
-
-    #[test]
-    fn legacy_detection_aborts_on_v1_table() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("xdbg.redb");
-        seed_table_named(&path, "xdbg:1//identity");
-        let err = super::App::detect_legacy_db(&path).expect_err("must abort");
-        assert!(format!("{err:#}").contains("--clear"));
-    }
-
-    #[test]
-    fn legacy_detection_aborts_on_v2_table() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("xdbg.redb");
-        seed_table_named(&path, "xdbg:2//identity");
-        let err = super::App::detect_legacy_db(&path).expect_err("must abort");
-        assert!(format!("{err:#}").contains("--clear"));
-    }
-
-    #[test]
-    fn legacy_detection_passes_on_fresh_db() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("xdbg.redb");
-        // Path doesn't exist; detect_legacy_db must be a no-op.
-        super::App::detect_legacy_db(&path).expect("fresh DB ok");
-    }
-
-    #[test]
-    fn legacy_detection_passes_on_current_table_only() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("xdbg.redb");
-        seed_table_named(&path, "xdbg:3//identity");
-        super::App::detect_legacy_db(&path).expect("only-current-table must pass");
-    }
 }

--- a/apps/xmtp_debug/src/app.rs
+++ b/apps/xmtp_debug/src/app.rs
@@ -44,28 +44,42 @@ use xmtp_id::InboxOwner;
 use xmtp_mls::identity::IdentityStrategy;
 use xxhash_rust::xxh3;
 
-use crate::args::{self, AppOpts};
+use crate::args::{self, AppOpts, BackendOpts};
 
 pub use clients::*;
 
-#[derive(Debug)]
-pub struct App {
-    /// Local K/V Store/Cache for values
-    opts: AppOpts,
+static STRICT_VERSIONING: OnceLock<bool> = OnceLock::new();
+static FDLIMIT: OnceLock<usize> = OnceLock::new();
+static NETWORK: OnceLock<BackendOpts> = OnceLock::new();
+static NETWORK_HASH: OnceLock<u64> = OnceLock::new();
+/// Tries to raise the open file descriptor limit
+/// returns a default low-enough number if unsuccessful
+/// useful when dealing with lots of different sqlite databases
+fn get_fdlimit() -> usize {
+    *FDLIMIT.get_or_init(|| {
+        if let Ok(fdlimit::Outcome::LimitRaised { to, .. }) = fdlimit::raise_fd_limit() {
+            if to > 2048 { 2048 } else { to as usize }
+        } else {
+            64
+        }
+    })
 }
 
+#[derive(Debug)]
+pub struct App;
+
 impl App {
-    pub fn new(opts: AppOpts) -> Self {
-        Self { opts }
+    pub fn new() -> Self {
+        Self
     }
 
     pub fn init_db(&self) -> Result<()> {
         fs::create_dir_all(&Self::data_directory()?)?;
-        fs::create_dir_all(&Self::db_directory(&self.opts.backend)?)?;
+        fs::create_dir_all(&Self::db_directory()?)?;
         Self::detect_legacy_db(&Self::redb()?)?;
         debug!(
             directory = %Self::data_directory()?.display(),
-            sqlite_stores = %Self::db_directory(&self.opts.backend)?.display(),
+            sqlite_stores = %Self::db_directory()?.display(),
             "created project directories",
         );
         Ok(())
@@ -144,23 +158,48 @@ impl App {
         let _ = STRICT_VERSIONING.set(value);
     }
 
+    pub fn network() -> &'static BackendOpts {
+        if NETWORK.get().is_none() {
+            let network = crate::config_unchecked();
+            let network = network.backend.clone();
+            NETWORK.set(network).expect("checked for initialization");
+        }
+        NETWORK.get().expect("just set network")
+    }
+
+    pub fn network_hash() -> u64 {
+        if NETWORK_HASH.get().is_none() {
+            let network_hash = Self::network().hash();
+            NETWORK_HASH
+                .set(network_hash)
+                .expect("checked network hash for init")
+        }
+        *NETWORK_HASH.get().expect("just set network hash")
+    }
+
+    #[cfg(test)]
+    pub fn set_network_hash(n: u64) {
+        NETWORK_HASH.set(n).expect("tests only")
+    }
+
     /// Directory for SQLite files belonging to the *current* binary
     /// version. Always version-bucketed via `current_version_hash`.
     /// Same shape in both strict and non-strict mode — the
     /// `--strict-versioning` flag does not influence path construction.
-    fn db_directory(network: impl Into<u64>) -> Result<PathBuf> {
-        Self::db_directory_for(network, Self::current_version_hash())
+    fn db_directory() -> Result<PathBuf> {
+        Self::db_directory_for(Self::current_version_hash())
     }
 
     /// Directory for SQLite files belonging to a specific
     /// `version_hash`. Used by non-strict reads that load identities
     /// written by another xdbg binary version. Most callers should use
-    /// `db_directory(network)` instead.
-    fn db_directory_for(network: impl Into<u64>, version_hash: u64) -> Result<PathBuf> {
+    /// `db_directory()` instead.
+    fn db_directory_for(version_hash: u64) -> Result<PathBuf> {
         let data = Self::data_directory()?;
+        let network = App::network();
         let dir = data
             .join("sqlite")
-            .join(network.into().to_string())
+            .join(network.hash().to_string())
             .join(format!("{version_hash:016x}"));
         Ok(dir)
     }
@@ -205,19 +244,19 @@ impl App {
     }
 
     pub async fn run(self) -> Result<()> {
-        if !self.opts.clear {
-            self.init_db()?
-        }
-        let App { opts } = self;
-        use args::Commands::*;
         let AppOpts {
+            clear,
             cmd,
             backend,
-            clear,
             strict_versioning,
             ..
-        } = opts;
-        Self::set_strict_versioning(strict_versioning);
+        } = crate::config_unchecked();
+        if !clear {
+            self.init_db()?
+        }
+        use args::Commands::*;
+
+        Self::set_strict_versioning(*strict_versioning);
         debug!(fdlimit = get_fdlimit(), "setting fdlimit");
 
         if cmd.is_none() && !clear {
@@ -227,21 +266,21 @@ impl App {
 
         if let Some(cmd) = cmd {
             match cmd {
-                Generate(g) => generate::Generate::new(g, backend).run().await,
-                Send(s) => send::Send::new(s, backend)?.run().await,
-                Inspect(i) => inspect::Inspect::new(i, backend)?.run().await,
-                Query(q) => query::Query::new(q, backend)?.run().await,
-                Info(i) => info::Info::new(i, backend)?.run().await,
-                Export(e) => export::Export::new(e, backend)?.run(),
-                Modify(m) => modify::Modify::new(m, backend)?.run().await,
-                Stream(s) => stream::Stream::new(s, backend)?.run().await,
-                Test(t) => test::Test::new(t, backend).run().await,
-                Healthcheck(h) => health::Health::new(h, backend).run().await,
-                Sync(s) => sync::Sync::new(s, backend).run().await,
+                Generate(g) => generate::Generate::new(g).run().await,
+                Send(s) => send::Send::new(s)?.run().await,
+                Inspect(i) => inspect::Inspect::new(i)?.run().await,
+                Query(q) => query::Query::new(q)?.run().await,
+                Info(i) => info::Info::new(i)?.run().await,
+                Export(e) => export::Export::new(e)?.run(),
+                Modify(m) => modify::Modify::new(m)?.run().await,
+                Stream(s) => stream::Stream::new(s)?.run().await,
+                Test(t) => test::Test::new(t).run().await,
+                Healthcheck(h) => health::Health::new(h).run().await,
+                Sync(s) => sync::Sync::new(s).run().await,
             }?;
         }
 
-        if clear {
+        if *clear {
             info!("Clearing app data");
             let data = Self::data_directory()?;
             let _ = std::fs::remove_dir_all(data);
@@ -256,7 +295,6 @@ pub(super) fn generate_wallet() -> types::EthereumWallet {
 
 #[cfg(test)]
 mod app_db_directory_tests {
-    use super::App;
     use std::sync::Mutex;
 
     // Tests in this module mutate XDBG_DB_ROOT. Run them serialized so
@@ -290,29 +328,6 @@ mod app_db_directory_tests {
             std::env::set_var("XDBG_DB_ROOT", tmp.path());
         }
         f(tmp.path())
-    }
-
-    #[test]
-    fn db_directory_for_uses_provided_version_hash() {
-        with_db_root(|root| {
-            let net = 1u64;
-            let vh: u64 = 0xDEAD_BEEF_FEED_FACE;
-            let dir = App::db_directory_for(net, vh).expect("db_directory_for");
-            let vh_hex = format!("{vh:016x}");
-            let expected = root.join("sqlite").join(net.to_string()).join(&vh_hex);
-            assert_eq!(dir, expected);
-        });
-    }
-
-    #[test]
-    fn db_directory_matches_db_directory_for_current_version() {
-        with_db_root(|_root| {
-            let net = 7u64;
-            let a = App::db_directory(net).expect("db_directory");
-            let b =
-                App::db_directory_for(net, App::current_version_hash()).expect("db_directory_for");
-            assert_eq!(a, b);
-        });
     }
 }
 
@@ -364,19 +379,4 @@ mod legacy_detection_tests {
         seed_table_named(&path, "xdbg:3//identity");
         super::App::detect_legacy_db(&path).expect("only-current-table must pass");
     }
-}
-
-static STRICT_VERSIONING: OnceLock<bool> = OnceLock::new();
-static FDLIMIT: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
-/// Tries to raise the open file descriptor limit
-/// returns a default low-enough number if unsuccessful
-/// useful when dealing with lots of different sqlite databases
-fn get_fdlimit() -> usize {
-    *FDLIMIT.get_or_init(|| {
-        if let Ok(fdlimit::Outcome::LimitRaised { to, .. }) = fdlimit::raise_fd_limit() {
-            if to > 2048 { 2048 } else { to as usize }
-        } else {
-            64
-        }
-    })
 }

--- a/apps/xmtp_debug/src/app/clients.rs
+++ b/apps/xmtp_debug/src/app/clients.rs
@@ -18,7 +18,6 @@ use xmtp_mls::builder::DeviceSyncMode;
 use xmtp_mls::cursor_store::SqliteCursorStore;
 
 pub async fn new_unregistered_client(
-    network: &args::BackendOpts,
     wallet: Option<&types::EthereumWallet>,
 ) -> Result<crate::DbgClient> {
     let local_wallet = if let Some(w) = wallet {
@@ -26,14 +25,11 @@ pub async fn new_unregistered_client(
     } else {
         generate_wallet().into_alloy()
     };
-    new_client_inner(network, &local_wallet, None).await
+    new_client_inner(&local_wallet, None).await
 }
 
 /// Create a new client + Identity
-pub async fn temp_client(
-    network: &args::BackendOpts,
-    wallet: Option<&types::EthereumWallet>,
-) -> Result<crate::DbgClient> {
+pub async fn temp_client(wallet: Option<&types::EthereumWallet>) -> Result<crate::DbgClient> {
     let local_wallet = if let Some(w) = wallet {
         w.clone().into_alloy()
     } else {
@@ -42,40 +38,33 @@ pub async fn temp_client(
 
     let tmp_dir = (*crate::constants::TMPDIR).path();
     let public = local_wallet.get_identifier()?;
-    let name = format!("{public}:{}.db3", u64::from(network));
+    let network = App::network().hash();
+    let name = format!("{public}:{network}.db3");
 
-    new_client_inner(
-        network,
-        &local_wallet,
-        Some(tmp_dir.to_path_buf().join(name)),
-    )
-    .await
+    new_client_inner(&local_wallet, Some(tmp_dir.to_path_buf().join(name))).await
 }
 
 /// Get the XMTP Client from an [`Identity`]
-pub fn client_from_identity(
-    identity: &Identity,
-    network: &args::BackendOpts,
-) -> Result<crate::DbgClient> {
+pub fn client_from_identity(identity: &Identity) -> Result<crate::DbgClient> {
     // Use the identity's stored version_hash so cross-version loads
     // (under non-strict mode) find the correct SQLite partition. In
     // strict mode, all loaded identities have version_hash == this
     // binary's hash, so db_path_for and db_path agree.
-    let path = identity.db_path_for(network, identity.version_hash)?;
+    let path = identity.db_path_for(identity.version_hash)?;
     debug!(
         inbox_id = hex::encode(identity.inbox_id),
         db_path = %path.display(),
         "creating client from identity"
     );
-    existing_client_inner(network, path)
+    existing_client_inner(path)
 }
 
 /// Create a new client + Identity & register it
 async fn new_client_inner(
-    network: &args::BackendOpts,
     wallet: &PrivateKeySigner,
     db_path: Option<PathBuf>,
 ) -> Result<crate::DbgClient> {
+    let network = App::network();
     let api = network.client_bundle()?;
     let sync_api = network.client_bundle()?;
     let ident = wallet.get_identifier()?;
@@ -84,8 +73,8 @@ async fn new_client_inner(
     let dir = if let Some(p) = db_path {
         p
     } else {
-        let dir = crate::app::App::db_directory(network)?;
-        let db_name = format!("{inbox_id}:{}.db3", u64::from(network));
+        let dir = crate::app::App::db_directory()?;
+        let db_name = format!("{inbox_id}:{}.db3", network.hash());
         dir.join(db_name)
     };
     let path = dir
@@ -147,10 +136,8 @@ pub async fn register_client(client: &crate::DbgClient, owner: impl InboxOwner) 
 }
 
 /// Create a new client + Identity
-fn existing_client_inner(
-    network: &args::BackendOpts,
-    db_path: PathBuf,
-) -> Result<crate::DbgClient> {
+fn existing_client_inner(db_path: PathBuf) -> Result<crate::DbgClient> {
+    let network = App::network();
     let api = network.client_bundle()?;
     let sync_api = network.client_bundle()?;
     let path = db_path.clone().into_os_string().into_string().unwrap();
@@ -183,6 +170,7 @@ fn existing_client_inner(
         .default_mls_store()?
         .with_device_sync_worker_mode(Some(DeviceSyncMode::Disabled))
         .with_allow_offline(Some(true))
+        .with_disable_workers(true)
         .build_offline()?;
 
     Ok(client)
@@ -193,17 +181,16 @@ fn existing_client_inner(
 /// version on the network.
 pub fn load_all_identities(
     store: &IdentityStore<'static>,
-    network: &args::BackendOpts,
 ) -> Result<Arc<HashMap<InboxId, Mutex<crate::DbgClient>>>> {
     let identities: Vec<Identity> = if crate::app::App::strict_versioning() {
         store
-            .load_for_version(u64::from(network), crate::app::App::current_version_hash())?
+            .load_for_version(crate::app::App::current_version_hash())?
             .ok_or(eyre!("no identities in store, try generating some"))?
             .map(|g| g.value())
             .collect()
     } else {
         store
-            .load(u64::from(network))?
+            .load()?
             .ok_or(eyre!("no identities in store, try generating some"))?
             .map(|g| g.value())
             .collect()
@@ -213,7 +200,7 @@ pub fn load_all_identities(
     let mut skipped = 0u32;
     for identity in identities {
         let inbox_id = identity.inbox_id;
-        match client_from_identity(&identity, network) {
+        match client_from_identity(&identity) {
             Ok(client) => {
                 clients.insert(inbox_id, Mutex::new(client));
             }
@@ -242,7 +229,6 @@ pub fn load_all_identities(
 
 pub fn load_n_identities(
     store: &IdentityStore<'static>,
-    network: &args::BackendOpts,
     n: usize,
 ) -> Result<Arc<HashMap<InboxId, Arc<Mutex<crate::DbgClient>>>>> {
     let mut rng = rand::rng();
@@ -252,7 +238,7 @@ pub fn load_n_identities(
         // Strict: pool from this version's partition only, sample n.
         use rand::seq::SliceRandom;
         let mut pool: Vec<Identity> = store
-            .load_for_version(u64::from(network), crate::app::App::current_version_hash())?
+            .load_for_version(crate::app::App::current_version_hash())?
             .ok_or(eyre!("no identities in store, try generating some"))?
             .map(|g| g.value())
             .collect();
@@ -262,7 +248,7 @@ pub fn load_n_identities(
     } else {
         // Non-strict: existing random_n path.
         store
-            .random_n(u64::from(network), &mut rng, n)?
+            .random_n(&mut rng, n)?
             .into_iter()
             .map(|g| g.value())
             .collect()
@@ -279,7 +265,7 @@ pub fn load_n_identities(
         .map(|id| {
             Ok::<_, eyre::Report>((
                 id.inbox_id,
-                Arc::new(Mutex::new(client_from_identity(&id, network)?)),
+                Arc::new(Mutex::new(client_from_identity(&id)?)),
             ))
         })
         .collect::<Result<HashMap<_, _>, _>>()?;

--- a/apps/xmtp_debug/src/app/clients.rs
+++ b/apps/xmtp_debug/src/app/clients.rs
@@ -20,16 +20,37 @@ use xmtp_mls::cursor_store::SqliteCursorStore;
 pub async fn new_unregistered_client(
     wallet: Option<&types::EthereumWallet>,
 ) -> Result<crate::DbgClient> {
+    new_unregistered_client_for(wallet, App::network()).await
+}
+
+/// Like [`new_unregistered_client`] but targets the supplied backend
+/// instead of the process-global `App::network()`. Use this when one
+/// xdbg run needs to talk to more than one network (e.g. the v3→d14n
+/// identity-continuity test).
+pub async fn new_unregistered_client_for(
+    wallet: Option<&types::EthereumWallet>,
+    backend: &crate::args::BackendOpts,
+) -> Result<crate::DbgClient> {
     let local_wallet = if let Some(w) = wallet {
         w.clone().into_alloy()
     } else {
         generate_wallet().into_alloy()
     };
-    new_client_inner(&local_wallet, None).await
+    new_client_inner(&local_wallet, None, backend).await
 }
 
 /// Create a new client + Identity
 pub async fn temp_client(wallet: Option<&types::EthereumWallet>) -> Result<crate::DbgClient> {
+    temp_client_for(wallet, App::network()).await
+}
+
+/// Like [`temp_client`] but targets the supplied backend. SQLite file
+/// is bucketed by `backend.hash()` so the same wallet on different
+/// networks resolves to different on-disk databases.
+pub async fn temp_client_for(
+    wallet: Option<&types::EthereumWallet>,
+    backend: &crate::args::BackendOpts,
+) -> Result<crate::DbgClient> {
     let local_wallet = if let Some(w) = wallet {
         w.clone().into_alloy()
     } else {
@@ -38,10 +59,15 @@ pub async fn temp_client(wallet: Option<&types::EthereumWallet>) -> Result<crate
 
     let tmp_dir = (*crate::constants::TMPDIR).path();
     let public = local_wallet.get_identifier()?;
-    let network = App::network().hash();
+    let network = backend.hash();
     let name = format!("{public}:{network}.db3");
 
-    new_client_inner(&local_wallet, Some(tmp_dir.to_path_buf().join(name))).await
+    new_client_inner(
+        &local_wallet,
+        Some(tmp_dir.to_path_buf().join(name)),
+        backend,
+    )
+    .await
 }
 
 /// Get the XMTP Client from an [`Identity`]
@@ -63,8 +89,8 @@ pub fn client_from_identity(identity: &Identity) -> Result<crate::DbgClient> {
 async fn new_client_inner(
     wallet: &PrivateKeySigner,
     db_path: Option<PathBuf>,
+    network: &crate::args::BackendOpts,
 ) -> Result<crate::DbgClient> {
-    let network = App::network();
     let api = network.client_bundle()?;
     let sync_api = network.client_bundle()?;
     let ident = wallet.get_identifier()?;
@@ -137,7 +163,13 @@ pub async fn register_client(client: &crate::DbgClient, owner: impl InboxOwner) 
 
 /// Create a new client + Identity
 fn existing_client_inner(db_path: PathBuf) -> Result<crate::DbgClient> {
-    let network = App::network();
+    existing_client_inner_for(db_path, App::network())
+}
+
+fn existing_client_inner_for(
+    db_path: PathBuf,
+    network: &crate::args::BackendOpts,
+) -> Result<crate::DbgClient> {
     let api = network.client_bundle()?;
     let sync_api = network.client_bundle()?;
     let path = db_path.clone().into_os_string().into_string().unwrap();

--- a/apps/xmtp_debug/src/app/export.rs
+++ b/apps/xmtp_debug/src/app/export.rs
@@ -3,7 +3,7 @@ use crate::{
         App,
         store::{Database, GroupStore, IdentityStore},
     },
-    args::{self, BackendOpts, ExportOpts},
+    args::{self, ExportOpts},
 };
 
 use color_eyre::eyre::{OptionExt, Result};
@@ -14,28 +14,19 @@ use xmtp_proto::types::Topic;
 
 use super::types::{Group, Identity};
 pub struct Export {
-    opts: args::ExportOpts,
-    network: args::BackendOpts,
+    opts: &'static args::ExportOpts,
     store: Arc<redb::Database>,
 }
 
 impl Export {
-    pub fn new(opts: ExportOpts, network: BackendOpts) -> Result<Self> {
+    pub fn new(opts: &'static ExportOpts) -> Result<Self> {
         let store = App::db()?;
-        Ok(Self {
-            store,
-            opts,
-            network,
-        })
+        Ok(Self { store, opts })
     }
 
     pub fn run(self) -> Result<()> {
         use args::ExportEntityKind::*;
-        let Export {
-            opts,
-            network,
-            store,
-        } = self;
+        let Export { opts, store } = self;
         let args::ExportOpts { entity, out } = opts;
         let mut writer: Box<dyn Write> = if let Some(p) = out {
             Box::new(fs::File::create(p)?)
@@ -46,7 +37,7 @@ impl Export {
         match entity {
             Identity => {
                 let store: IdentityStore = store.into();
-                let ids = store.load(&network)?.ok_or_eyre("no ids in store")?;
+                let ids = store.load()?.ok_or_eyre("no ids in store")?;
                 let ids = ids
                     .map(|i| IdentityExport::from(i.value()))
                     .collect::<Vec<_>>();
@@ -56,7 +47,7 @@ impl Export {
             }
             Group => {
                 let store: GroupStore = store.into();
-                let groups = store.load(&network)?.ok_or_eyre("no groups in store")?;
+                let groups = store.load()?.ok_or_eyre("no groups in store")?;
                 let groups = groups
                     .map(|g| GroupExport::from(g.value()))
                     .collect::<Vec<_>>();
@@ -67,7 +58,7 @@ impl Export {
             Message => todo!(),
             IdentityTopics => {
                 let store: IdentityStore = store.into();
-                let ids = store.load(&network)?.ok_or_eyre("no identities in store")?;
+                let ids = store.load()?.ok_or_eyre("no identities in store")?;
                 let topics: Vec<Topic> = ids
                     .map(|i| Topic::new_identity_update(i.value().inbox_id))
                     .collect();
@@ -77,7 +68,7 @@ impl Export {
             }
             GroupTopics => {
                 let store: GroupStore = store.into();
-                let groups = store.load(&network)?.ok_or_eyre("no groups in store")?;
+                let groups = store.load()?.ok_or_eyre("no groups in store")?;
                 let topics: Vec<Topic> = groups
                     .map(|g| Topic::new_group_message(g.value().id()))
                     .collect();
@@ -87,7 +78,7 @@ impl Export {
             }
             KeyPackageTopics => {
                 let store: IdentityStore = store.into();
-                let ids = store.load(&network)?.ok_or_eyre("no identities in store")?;
+                let ids = store.load()?.ok_or_eyre("no identities in store")?;
                 let topics: Vec<Topic> = ids
                     .map(|i| Topic::new_key_package(i.value().installation_key))
                     .collect();
@@ -97,7 +88,7 @@ impl Export {
             }
             WelcomeMessageTopics => {
                 let store: IdentityStore = store.into();
-                let ids = store.load(&network)?.ok_or_eyre("no identities in store")?;
+                let ids = store.load()?.ok_or_eyre("no identities in store")?;
                 let topics: Vec<Topic> = ids
                     .map(|i| Topic::new_welcome_message(i.value().installation_key.into()))
                     .collect();

--- a/apps/xmtp_debug/src/app/generate.rs
+++ b/apps/xmtp_debug/src/app/generate.rs
@@ -12,18 +12,17 @@ use std::time::Instant;
 
 #[derive(Debug)]
 pub struct Generate {
-    opts: args::Generate,
-    network: args::BackendOpts,
+    opts: &'static args::Generate,
 }
 
 impl Generate {
-    pub fn new(opts: args::Generate, network: args::BackendOpts) -> Self {
-        Self { opts, network }
+    pub fn new(opts: &'static args::Generate) -> Self {
+        Self { opts }
     }
 
     pub async fn run(self) -> Result<()> {
         use args::EntityKind::*;
-        let Generate { opts, network } = self;
+        let Generate { opts } = self;
         let args::Generate {
             entity,
             amount,
@@ -40,11 +39,11 @@ impl Generate {
             Group => {
                 let db = App::db()?;
                 let start = Instant::now();
-                GenerateGroups::new(db, network)
-                    .create_groups(amount, invite.unwrap_or(0), *concurrency)
+                GenerateGroups::new(db)
+                    .create_groups(*amount, invite.unwrap_or(0), **concurrency)
                     .await?;
                 let elapsed = start.elapsed();
-                let per_op = elapsed.as_millis() as f64 / amount as f64;
+                let per_op = elapsed.as_millis() as f64 / *amount as f64;
                 info!(
                     count = amount,
                     elapsed_ms = elapsed.as_millis() as u64,
@@ -54,9 +53,9 @@ impl Generate {
                 Ok(())
             }
             Message => {
-                let generator = GenerateMessages::new(network, message_opts, *concurrency)?;
+                let generator = GenerateMessages::new(*message_opts, **concurrency)?;
                 let start = Instant::now();
-                let latencies = generator.run(amount).await?;
+                let latencies = generator.run(*amount).await?;
                 let elapsed = start.elapsed();
 
                 let total_send_ms: u128 = latencies.iter().map(|d| d.as_millis()).sum();
@@ -77,11 +76,11 @@ impl Generate {
             Identity => {
                 let db = App::db()?;
                 let start = Instant::now();
-                GenerateIdentity::new(db.into(), network)
-                    .create_identities(amount, *concurrency, ryow)
+                GenerateIdentity::new(db.into())
+                    .create_identities(*amount, **concurrency, *ryow)
                     .await?;
                 let elapsed = start.elapsed();
-                let per_op = elapsed.as_millis() as f64 / amount as f64;
+                let per_op = elapsed.as_millis() as f64 / *amount as f64;
                 info!(
                     count = amount,
                     elapsed_ms = elapsed.as_millis() as u64,

--- a/apps/xmtp_debug/src/app/generate/groups.rs
+++ b/apps/xmtp_debug/src/app/generate/groups.rs
@@ -5,7 +5,6 @@ use crate::app::{
     store::{Database, GroupStore, IdentityStore},
     types::*,
 };
-use crate::args;
 use crate::metrics::{
     csv_metric, push_metrics, record_latency, record_member_count, record_phase_metric,
     record_throughput,
@@ -22,15 +21,13 @@ use xmtp_proto::types::{GroupId, InstallationId};
 pub struct GenerateGroups {
     group_store: GroupStore<'static>,
     identity_store: IdentityStore<'static>,
-    network: args::BackendOpts,
 }
 
 impl GenerateGroups {
-    pub fn new(db: Arc<redb::Database>, network: args::BackendOpts) -> Self {
+    pub fn new(db: Arc<redb::Database>) -> Self {
         Self {
             group_store: db.clone().into(),
             identity_store: db.clone().into(),
-            network,
         }
     }
 
@@ -46,8 +43,7 @@ impl GenerateGroups {
             .ok()
             .and_then(|v| v.parse().ok());
 
-        let network = &self.network;
-        let identities = self.identity_store.len(network)?;
+        let identities = self.identity_store.len()?;
         ensure!(
             identities >= invitees,
             "not enough identities generated. have {}, but need to invite {}. groups cannot hold duplicate identities",
@@ -59,7 +55,7 @@ impl GenerateGroups {
         );
         let bar = ProgressBar::new(n as u64).with_style(style.unwrap());
 
-        let clients = load_n_identities(&self.identity_store, network, n)?;
+        let clients = load_n_identities(&self.identity_store, n)?;
 
         let semaphore = Arc::new(tokio::sync::Semaphore::new(concurrency));
         let groups = stream::iter(clients.iter())
@@ -68,8 +64,6 @@ impl GenerateGroups {
                 let client = client.clone();
                 let owner = *owner;
                 let store = self.identity_store.clone();
-                let network_u64 = u64::from(network);
-                let network_clone = network.clone();
                 let semaphore = semaphore.clone();
                 Ok(tokio::spawn(Box::pin({
                     async move {
@@ -77,7 +71,7 @@ impl GenerateGroups {
                         let t_total = Instant::now();
 
                         let (invitee_inboxes, invitee_hex, first_invitee) =
-                            resolve_invitees(&store, network_u64, invitees, owner)?;
+                            resolve_invitees(&store, invitees, owner)?;
 
                         let (group_id, create_secs) =
                             create_group_on_network(&client, &invitee_hex).await?;
@@ -91,8 +85,7 @@ impl GenerateGroups {
                         .await;
 
                         if let Some(ref invitee) = first_invitee
-                            && let Err(e) =
-                                check_member_visibility(&group_id, invitee, &network_clone).await
+                            && let Err(e) = check_member_visibility(&group_id, invitee).await
                         {
                             if crate::fail_fast() {
                                 return Err(e);
@@ -121,7 +114,8 @@ impl GenerateGroups {
                         // `Group::add_members` dedupes, so even if an
                         // upstream filter slips up the owner can't appear
                         // twice in the persisted member list.
-                        Ok(Group::new(group_id, owner, vec![owner]).add_members(invitee_inboxes))
+                        Ok(Group::new(group_id, owner, vec![owner], false)
+                            .add_members(invitee_inboxes))
                     }
                 }))
                 .map_err(|_| eyre!("failed to spawn tasks for group creation")))
@@ -131,7 +125,7 @@ impl GenerateGroups {
             .await?
             .into_iter()
             .collect::<Result<Vec<_>, eyre::Report>>()?;
-        self.group_store.set_all(groups.as_slice(), &self.network)?;
+        self.group_store.set_all(groups.as_slice())?;
         // ensure cleanup for each client
         for client in clients.values() {
             let client = client.lock().await;
@@ -148,7 +142,6 @@ impl GenerateGroups {
 /// points.
 fn resolve_invitees(
     store: &IdentityStore<'static>,
-    network_u64: u64,
     invitees: usize,
     owner: InboxId,
 ) -> Result<(Vec<InboxId>, Vec<String>, Option<Identity>)> {
@@ -157,12 +150,7 @@ fn resolve_invitees(
     // sample) doesn't leave us short. `sample_n` honors
     // `--strict-versioning`, so cross-version inboxes are filtered at
     // the store level — no need to re-filter here.
-    let sample = store.sample_n(
-        network_u64,
-        &mut rng,
-        invitees + 1,
-        crate::app::App::strict_versioning(),
-    )?;
+    let sample = store.sample_n(&mut rng, invitees + 1, crate::app::App::strict_versioning())?;
     let mut iter = sample
         .into_iter()
         .filter(|id| id.inbox_id != owner)
@@ -226,12 +214,8 @@ async fn create_group_on_network(
 }
 
 /// Check whether an invitee can see the group via sync_welcomes (read-your-own-writes).
-async fn check_member_visibility(
-    group_id: &GroupId,
-    invitee: &Identity,
-    network: &args::BackendOpts,
-) -> Result<()> {
-    let reader_client = app::client_from_identity(invitee, network)?;
+async fn check_member_visibility(group_id: &GroupId, invitee: &Identity) -> Result<()> {
+    let reader_client = app::client_from_identity(invitee)?;
 
     let t_visibility = Instant::now();
     let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(30);

--- a/apps/xmtp_debug/src/app/generate/groups.rs
+++ b/apps/xmtp_debug/src/app/generate/groups.rs
@@ -114,8 +114,7 @@ impl GenerateGroups {
                         // `Group::add_members` dedupes, so even if an
                         // upstream filter slips up the owner can't appear
                         // twice in the persisted member list.
-                        Ok(Group::new(group_id, owner, vec![owner], false)
-                            .add_members(invitee_inboxes))
+                        Ok(Group::new(group_id, owner, vec![owner]).add_members(invitee_inboxes))
                     }
                 }))
                 .map_err(|_| eyre!("failed to spawn tasks for group creation")))

--- a/apps/xmtp_debug/src/app/generate/identity.rs
+++ b/apps/xmtp_debug/src/app/generate/identity.rs
@@ -1,9 +1,8 @@
 use std::{collections::HashSet, sync::Arc};
 
-use crate::app::register_client;
 use crate::app::store::{Database, IdentityStore};
 use crate::app::{self, types::Identity};
-use crate::args;
+use crate::app::{App, register_client};
 use crate::metrics::{
     csv_metric, push_metrics, record_latency, record_phase_metric, record_throughput,
 };
@@ -23,15 +22,11 @@ use xmtp_proto::xmtp::xmtpv4::message_api::subscribe_topics_response::Response a
 /// Identity Generation
 pub struct GenerateIdentity {
     identity_store: IdentityStore<'static>,
-    network: args::BackendOpts,
 }
 
 impl GenerateIdentity {
-    pub fn new(identity_store: IdentityStore<'static>, network: args::BackendOpts) -> Self {
-        Self {
-            identity_store,
-            network,
-        }
+    pub fn new(identity_store: IdentityStore<'static>) -> Self {
+        Self { identity_store }
     }
 
     pub async fn create_identities(
@@ -61,7 +56,6 @@ impl GenerateIdentity {
                 }
             }
         });
-        let network = &self.network;
 
         let semaphore = Arc::new(tokio::sync::Semaphore::new(concurrency));
         let s = Arc::new(Mutex::new(TopicCursor::default()));
@@ -72,13 +66,12 @@ impl GenerateIdentity {
                 tokio::spawn({
                     let sem = semaphore.clone();
                     let s = s.clone();
-                    let network = network.clone();
                     let bar_pointer = bar.clone();
                     async move {
                         let _permit = sem.acquire().await?;
                         let wallet = crate::app::generate_wallet();
                         let t_init = Instant::now();
-                        let c = app::new_unregistered_client(&network, Some(&wallet)).await?;
+                        let c = app::new_unregistered_client(Some(&wallet)).await?;
                         let init_secs = t_init.elapsed().as_secs_f64();
 
                         record_phase_metric(
@@ -117,14 +110,15 @@ impl GenerateIdentity {
         // try to read a key package for each installation id we created
         // only for D14n
         let (tx, rx) = tokio::sync::oneshot::channel();
+        let network = App::network();
         let read_writes = if network.d14n && ryow {
-            let n = network.clone();
             let mut needed_installations = clients
                 .clone()
                 .iter()
                 .map(|(c, _)| c.context.installation_id())
                 .collect::<HashSet<_>>();
             tokio::spawn(async move {
+                let n = App::network();
                 let api = n.xmtpd()?;
                 let mut s = SubscribeTopics::builder().topics(topic_cursor).build()?;
                 let s = s.subscribe(&api).await?;
@@ -211,26 +205,23 @@ impl GenerateIdentity {
             .try_collect::<Vec<Identity>>()
             .await?;
 
-        self.identity_store
-            .set_all(identities.as_slice(), &self.network)?;
+        self.identity_store.set_all(identities.as_slice())?;
 
         //TODO: this can be removed once we're d14n-only
-        let tmp = Arc::new(app::temp_client(network, None).await?);
+        let tmp = Arc::new(app::temp_client(None).await?);
         let states = stream::iter(identities.iter().copied().map(Ok))
             .map_ok(|identity| {
                 let tmp = tmp.clone();
                 tokio::spawn({
                     let sem = semaphore.clone();
-                    let network_clone = network.clone();
                     async move {
                         let _permit = sem.acquire().await?;
                         let inbox_id_hex = hex::encode(identity.inbox_id);
                         trace!(inbox_id = inbox_id_hex, "getting association state");
 
-                        poll_association_readiness(&network_clone, &inbox_id_hex).await?;
+                        poll_association_readiness(&inbox_id_hex).await?;
 
-                        measure_sync_and_lookup(&network_clone, &identity, &tmp, &inbox_id_hex)
-                            .await?;
+                        measure_sync_and_lookup(&identity, &tmp, &inbox_id_hex).await?;
 
                         // -- XDBG_LOOP_PAUSE --
                         if let Some(secs) = loop_pause_secs {
@@ -263,7 +254,7 @@ impl GenerateIdentity {
         }
 
         // -- verify all identities are readable from a fresh temp client --
-        verify_identities_readable(network, &identities).await?;
+        verify_identities_readable(&identities).await?;
 
         read_writes.await?;
         Ok(identities)
@@ -271,8 +262,8 @@ impl GenerateIdentity {
 }
 
 /// Poll until the identity's association state has members, or timeout after 30s.
-async fn poll_association_readiness(network: &args::BackendOpts, inbox_id_hex: &str) -> Result<()> {
-    let reader = Arc::new(app::temp_client(network, None).await?);
+async fn poll_association_readiness(inbox_id_hex: &str) -> Result<()> {
+    let reader = Arc::new(app::temp_client(None).await?);
     let conn = Arc::new(reader.context.store().db());
 
     let assoc_start = Instant::now();
@@ -318,7 +309,6 @@ async fn poll_association_readiness(network: &args::BackendOpts, inbox_id_hex: &
 
 /// Measure welcome-sync latency and identity-lookup latency for a registered identity.
 async fn measure_sync_and_lookup(
-    network: &args::BackendOpts,
     identity: &Identity,
     tmp: &crate::DbgClient,
     inbox_id_hex: &str,
@@ -327,7 +317,7 @@ async fn measure_sync_and_lookup(
 
     // -- welcome sync latency --
     let t_sync = Instant::now();
-    let c = app::client_from_identity(identity, network)?;
+    let c = app::client_from_identity(identity)?;
     c.sync_welcomes().await?;
     let sync_secs = t_sync.elapsed().as_secs_f64();
 
@@ -359,11 +349,8 @@ async fn measure_sync_and_lookup(
 }
 
 /// Verify all identities are readable from a fresh temp client.
-async fn verify_identities_readable(
-    network: &args::BackendOpts,
-    identities: &[Identity],
-) -> Result<()> {
-    let verify_client = Arc::new(app::temp_client(network, None).await?);
+async fn verify_identities_readable(identities: &[Identity]) -> Result<()> {
+    let verify_client = Arc::new(app::temp_client(None).await?);
     let verify_conn = Arc::new(verify_client.context.store().db());
     for identity in identities {
         let inbox_id_hex = hex::encode(identity.inbox_id);

--- a/apps/xmtp_debug/src/app/generate/messages.rs
+++ b/apps/xmtp_debug/src/app/generate/messages.rs
@@ -2,7 +2,6 @@ use crate::DbgClient;
 use crate::app::store::Database;
 use crate::app::types::{InboxId, Message};
 use crate::app::{App, load_all_identities};
-use crate::args::BackendOpts;
 use crate::metrics::record_phase_metric;
 use crate::{
     app::{
@@ -30,7 +29,6 @@ use xmtp_mls::groups::summary::SyncSummary;
 /// surfaces; we just don't record those rows.
 fn record_generated_message(
     store: &MessageStore<'static>,
-    network: &args::BackendOpts,
     group_id: &[u8],
     message_id: &[u8],
     sender_inbox_id: InboxId,
@@ -61,7 +59,7 @@ fn record_generated_message(
         sender_inbox_id,
         sent_at_ns,
     );
-    if let Err(e) = store.set(msg, u64::from(network)) {
+    if let Err(e) = store.set(msg) {
         tracing::warn!(target: "generate", error = %e, "redb set failed; skipping message record");
     }
 }
@@ -90,7 +88,6 @@ enum MessageSendError {
 }
 
 pub struct GenerateMessages {
-    network: args::BackendOpts,
     opts: args::MessageGenerateOpts,
     identity_store: IdentityStore<'static>,
     group_store: GroupStore<'static>,
@@ -100,11 +97,7 @@ pub struct GenerateMessages {
 }
 
 impl GenerateMessages {
-    pub fn new(
-        network: args::BackendOpts,
-        opts: args::MessageGenerateOpts,
-        concurrency: usize,
-    ) -> Result<Self> {
+    pub fn new(opts: args::MessageGenerateOpts, concurrency: usize) -> Result<Self> {
         // Always open write-capable redb so we can mirror sent messages
         // into `MessageStore`. add_member/change_description already
         // required write; default path now does too because we record
@@ -114,11 +107,10 @@ impl GenerateMessages {
         let identity_store: IdentityStore<'static> = db.clone().into();
         let group_store: GroupStore<'static> = db.clone().into();
         let message_store: MessageStore<'static> = db.into();
-        let identities = load_all_identities(&identity_store, &network)?;
+        let identities = load_all_identities(&identity_store)?;
         let semaphore = Arc::new(tokio::sync::Semaphore::new(concurrency));
 
         Ok(Self {
-            network,
             opts,
             identity_store,
             group_store,
@@ -155,7 +147,6 @@ impl GenerateMessages {
                 tokio::time::sleep(*interval).await;
                 let semaphore = self.semaphore.clone();
                 let group_store = self.group_store.clone();
-                let network = self.network.clone();
                 let identities = self.identities.clone();
                 let (latencies, _, _) = tokio::try_join!(
                     self.send_many_messages(n),
@@ -163,14 +154,12 @@ impl GenerateMessages {
                         add_and_change_description,
                         add_up_to,
                         semaphore.clone(),
-                        network.clone(),
                         group_store.clone(),
                         identities.clone()
                     ))),
                     flatten(tokio::spawn(Self::change_group_description(
                         change_description || add_and_change_description,
                         semaphore.clone(),
-                        network.clone(),
                         group_store.clone(),
                         identities.clone()
                     ))),
@@ -185,7 +174,6 @@ impl GenerateMessages {
         run: bool,
         add_up_to: u32,
         semaphore: ConcSemaphore,
-        network: BackendOpts,
         group_store: GroupStore<'static>,
         identities: IdentityMap,
     ) -> Result<()> {
@@ -195,7 +183,7 @@ impl GenerateMessages {
         info!(time = ?std::time::Instant::now(), "adding new member");
         let rng = &mut SmallRng::from_rng(&mut rand::rng());
         let group = group_store
-            .random(&network, rng)?
+            .random(rng)?
             .ok_or(eyre!("no group in local store"))?;
         if group.members.len() >= add_up_to.try_into()? {
             // added up to required amount
@@ -226,7 +214,7 @@ impl GenerateMessages {
         new_group.members.push(*not_in_group);
         new_group.member_size += 1;
         group_store
-            .set(new_group, network)
+            .set(new_group)
             .wrap_err("failed to update group with new member in redb index")?;
         Ok(())
     }
@@ -234,7 +222,6 @@ impl GenerateMessages {
     async fn change_group_description(
         run: bool,
         semaphore: ConcSemaphore,
-        network: BackendOpts,
         group_store: GroupStore<'static>,
         identities: IdentityMap,
     ) -> Result<()> {
@@ -245,7 +232,7 @@ impl GenerateMessages {
         let rng = &mut SmallRng::from_rng(&mut rand::rng());
         let clients = identities.clone();
         let group = group_store
-            .random(&network, rng)?
+            .random(rng)?
             .ok_or(eyre!("no group in local store"))?;
         if let Some(inbox_id) = group.members.choose(rng) {
             let client = clients
@@ -271,7 +258,7 @@ impl GenerateMessages {
 
     /// Returns a Vec of send_message latencies (only the actual send, not sync overhead)
     async fn send_many_messages(&self, n: usize) -> Result<Vec<Duration>> {
-        let Self { network, opts, .. } = self;
+        let Self { opts, .. } = self;
 
         let style = ProgressStyle::with_template(
             "{bar} {pos}/{len} elapsed {elapsed} remaining {eta_precise}",
@@ -289,14 +276,13 @@ impl GenerateMessages {
         );
         for _ in 0..n {
             let bar_pointer = bar.clone();
-            let n = network.clone();
             let opts = opts.clone();
             let (_, group, messages) = stores.clone();
             let semaphore = semaphore.clone();
             let cs = clients.clone();
             set.spawn(async move {
                 let _permit = semaphore.acquire().await?;
-                let latency = Self::send_message(&group, &messages, cs, n, opts)
+                let latency = Self::send_message(&group, &messages, cs, opts)
                     .await
                     .inspect_err(|e| error!("{}", e))?;
                 bar_pointer.inc(1);
@@ -337,7 +323,6 @@ impl GenerateMessages {
         group_store: &GroupStore<'static>,
         message_store: &MessageStore<'static>,
         clients: Arc<HashMap<InboxId, Mutex<DbgClient>>>,
-        network: args::BackendOpts,
         opts: args::MessageGenerateOpts,
     ) -> Result<Duration, MessageSendError> {
         let args::MessageGenerateOpts {
@@ -347,7 +332,7 @@ impl GenerateMessages {
 
         let rng = &mut SmallRng::from_rng(&mut rand::rng());
         let stored_group = group_store
-            .random(&network, rng)?
+            .random(rng)?
             .ok_or(eyre!("no group in local store"))?;
         info!(time = ?Instant::now(), group = %stored_group.id(), "sending message");
         let Some(sender_inbox_id) = stored_group.members.choose(rng).copied() else {
@@ -385,7 +370,6 @@ impl GenerateMessages {
         // and any cross-tool inspection can find this message later.
         record_generated_message(
             message_store,
-            &network,
             &*stored_group.id(),
             &message_id,
             sender_inbox_id,

--- a/apps/xmtp_debug/src/app/generate/messages.rs
+++ b/apps/xmtp_debug/src/app/generate/messages.rs
@@ -276,7 +276,7 @@ impl GenerateMessages {
         );
         for _ in 0..n {
             let bar_pointer = bar.clone();
-            let opts = opts.clone();
+            let opts = *opts;
             let (_, group, messages) = stores.clone();
             let semaphore = semaphore.clone();
             let cs = clients.clone();

--- a/apps/xmtp_debug/src/app/health/conditions.rs
+++ b/apps/xmtp_debug/src/app/health/conditions.rs
@@ -17,6 +17,9 @@ bitflags! {
         /// assertions). Without strict, `existing_clients` conflates
         /// versions and those assertions are vacuous.
         const STRICT_VERSIONING = 1 << 0;
+        /// Mutating ops (Create/Add/Update/Remove/Leave) require this
+        /// bit. Default-on; cleared by `--read-only`.
+        const WRITES = 1 << 1;
     }
 }
 

--- a/apps/xmtp_debug/src/app/health/conditions.rs
+++ b/apps/xmtp_debug/src/app/health/conditions.rs
@@ -11,15 +11,17 @@ bitflags! {
     /// type if we cross ~6 axes.
     #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
     pub struct Conditions: u8 {
+        /// this run requires bootstrap identities to be created
+        const BOOTSTRAP = 1 << 0;
         /// `--strict-versioning` is in effect. Required by ops whose
         /// semantics depend on the same-version vs other-version
         /// partition being meaningful (e.g. per-version membership
         /// assertions). Without strict, `existing_clients` conflates
         /// versions and those assertions are vacuous.
-        const STRICT_VERSIONING = 1 << 0;
+        const STRICT_VERSIONING = 1 << 1;
         /// Mutating ops (Create/Add/Update/Remove/Leave) require this
         /// bit. Default-on; cleared by `--read-only`.
-        const WRITES = 1 << 1;
+        const WRITES = 1 << 2;
     }
 }
 

--- a/apps/xmtp_debug/src/app/health/context.rs
+++ b/apps/xmtp_debug/src/app/health/context.rs
@@ -5,7 +5,7 @@ use crate::app::store::{Database, GroupStore, IdentityStore, MessageStore, Netwo
 use crate::app::types::{Group, Identity, InboxId, Message};
 use crate::app::{self, App};
 use crate::args;
-use color_eyre::eyre::Result;
+use color_eyre::eyre::{Result, eyre};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -52,7 +52,9 @@ pub struct HealthContext {
 impl HealthContext {
     /// Build the full context: load existing state, bootstrap on fresh DB,
     /// create the primary identity. Hard-fails on infrastructure errors.
-    pub async fn bootstrap(network: args::BackendOpts) -> Result<Self> {
+    /// With `read_only`, primary is reused from `existing_clients`
+    /// instead of registering a new on-network identity.
+    pub async fn bootstrap(network: args::BackendOpts, read_only: bool) -> Result<Self> {
         let redb = App::db()?;
         let id_store: IdentityStore<'static> = redb.clone().into();
         let group_store: GroupStore<'static> = redb.into();
@@ -109,20 +111,47 @@ impl HealthContext {
             }
         }
 
-        // 2. Primary new identity. Also persisted to redb so subsequent
-        //    healthcheck runs see it as an existing identity.
-        let primary_wallet = app::generate_wallet();
-        let primary_client = app::new_unregistered_client(&network, Some(&primary_wallet)).await?;
-        let primary_identity =
-            Identity::from_libxmtp(primary_client.identity(), primary_wallet.clone())?;
-        app::register_client(&primary_client, primary_wallet.into_alloy()).await?;
-        id_store.set(primary_identity, net_key)?;
-        let primary = Arc::new(primary_client);
+        // 2. Primary identity. Register fresh + persist, or reuse
+        //    existing under read_only.
+        let primary = if read_only {
+            existing_clients.values().next().cloned().ok_or_else(|| {
+                eyre!("read_only healthcheck requires at least one existing client")
+            })?
+        } else {
+            let primary_wallet = app::generate_wallet();
+            let primary_client =
+                app::new_unregistered_client(&network, Some(&primary_wallet)).await?;
+            let primary_identity =
+                Identity::from_libxmtp(primary_client.identity(), primary_wallet.clone())?;
+            app::register_client(&primary_client, primary_wallet.into_alloy()).await?;
+            id_store.set(primary_identity, net_key)?;
+            Arc::new(primary_client)
+        };
 
-        // 3. Existing groups from redb.
-        let existing_groups = group_store
+        // 3. Existing groups from redb, filtered to non-DM groups any
+        // existing_client knows about. DM entries would fail every op
+        // run by a primary that isn't a DM member.
+        let group_only_ids: std::collections::HashSet<GroupId> = existing_clients
+            .values()
+            .flat_map(|c| {
+                c.find_groups(xmtp_db::group::GroupQueryArgs {
+                    conversation_type: Some(xmtp_db::group::ConversationType::Group),
+                    ..Default::default()
+                })
+                .unwrap_or_default()
+                .into_iter()
+                .map(|g| GroupId::from(g.group_id))
+            })
+            .collect();
+        let existing_groups: Vec<GroupId> = group_store
             .load(net_key)?
-            .map(|iter| iter.map(|g| g.value().id()).collect::<Vec<_>>())
+            .map(|iter| {
+                iter.filter_map(|g| {
+                    let id = g.value().id();
+                    group_only_ids.contains(&id).then_some(id)
+                })
+                .collect::<Vec<_>>()
+            })
             .unwrap_or_default();
 
         tracing::info!(
@@ -220,11 +249,19 @@ impl HealthContext {
 
     /// Every persisted client involved in this run: primary + every
     /// entry in `existing_clients`. Run-scoped throwaway transients
-    /// created by ops are NOT included — they're op-local.
+    /// created by ops are NOT included — they're op-local. Under
+    /// `read_only`, primary is one of `existing_clients` — deduped
+    /// here so it isn't processed twice.
     pub fn all_clients(&self) -> Vec<Arc<DbgClient>> {
+        let primary_inbox = self.primary.inbox_id();
         let mut out = Vec::with_capacity(self.existing_clients.len() + 1);
         out.push(self.primary.clone());
-        out.extend(self.existing_clients.values().cloned());
+        out.extend(
+            self.existing_clients
+                .iter()
+                .filter(|(_, c)| c.inbox_id() != primary_inbox)
+                .map(|(_, c)| c.clone()),
+        );
         out
     }
 
@@ -257,18 +294,17 @@ impl HealthContext {
     /// Best-effort concurrent welcome sync across all run clients;
     /// failures are logged only (plumbing, not a validation step).
     pub async fn sync_welcomes_fanout(&self, label: &'static str) {
-        let syncs = std::iter::once(self.primary.as_ref())
-            .chain(self.existing_clients.values().map(|c| c.as_ref()))
-            .map(|c| async move {
-                if let Err(e) = c.sync_welcomes().await {
-                    tracing::warn!(
-                        target: "healthcheck",
-                        inbox = c.inbox_id(),
-                        error = %e,
-                        label,
-                        "sync_welcomes fanout failed",
-                    );
-                }
+        let clients = self.all_clients();
+        let syncs = clients.iter().map(|c| async move {
+            if let Err(e) = c.sync_welcomes().await {
+                tracing::warn!(
+                    target: "healthcheck",
+                    inbox = c.inbox_id(),
+                    error = %e,
+                    label,
+                    "sync_welcomes fanout failed",
+                );
+            }
             });
         futures::future::join_all(syncs).await;
     }

--- a/apps/xmtp_debug/src/app/health/context.rs
+++ b/apps/xmtp_debug/src/app/health/context.rs
@@ -2,24 +2,19 @@
 
 use crate::DbgClient;
 use crate::app::health::conditions::Conditions;
-use crate::app::store::{
-    Database, DeriveKey, GroupStore, IdentityKey, IdentityStore, MessageStore,
-};
-use crate::app::types::{Group, Identity, InboxId, Message};
+use crate::app::health::result::OpResult;
+use crate::app::store::{Database, DeriveKey, DmStore, GroupStore, IdentityStore, MessageStore};
+use crate::app::types::{Dm, Group, Identity, InboxId, Message};
 use crate::app::{self, App, client_from_identity};
 use color_eyre::eyre::{Result, ensure, eyre};
 use std::collections::{HashMap, HashSet};
+use std::future::Future;
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use xmtp_proto::types::GroupId;
 
-/// Number of identities to create when the redb identity store is empty.
-/// 3 is the minimum that lets us exercise group ops (one creator + two
-/// others) and DM ops (primary ↔ peer with at least one extra identity).
-const BOOTSTRAP_IDENTITY_COUNT: usize = 3;
-
 #[derive(Clone, Copy, Hash, PartialEq, Eq)]
-struct HealthClient {
+pub struct HealthClient {
     identity: Identity,
 }
 
@@ -28,7 +23,19 @@ impl HealthClient {
         Self { identity }
     }
 
-    fn realize(&self, store: &IdentityStore<'static>) -> Result<DbgClient> {
+    /// Raw 32-byte inbox id for this client.
+    pub fn inbox_id_bytes(&self) -> InboxId {
+        self.identity.inbox_id
+    }
+
+    /// Hex-encoded inbox id matching the libxmtp `String` representation.
+    pub fn inbox_id_hex(&self) -> String {
+        hex::encode(self.identity.inbox_id)
+    }
+    /// Materialize a fully-functional `DbgClient` from this identity by
+    /// reopening its sqlite + reconnecting to the network. Synchronous and
+    /// cheap (no network round-trip; just a `client_from_identity` call).
+    pub fn realize(&self, store: &IdentityStore<'static>) -> Result<DbgClient> {
         let key = self.identity.key();
         if App::strict_versioning() {
             let current_version = App::current_version_hash();
@@ -49,9 +56,11 @@ pub struct HealthContext {
     /// redb identity store so future runs see it as an existing identity.
     pub primary: HealthClient,
 
-    id_store: IdentityStore<'static>,
+    pub id_store: IdentityStore<'static>,
 
     group_store: GroupStore<'static>,
+    msg_store: MessageStore<'static>,
+    dm_store: DmStore<'static>,
 
     /// Identities loaded from the redb `IdentityStore` for this network.
     /// On a fresh run, contains the freshly-bootstrapped identities.
@@ -80,24 +89,43 @@ impl HealthContext {
     pub async fn bootstrap(read_only: bool, conditions: &mut Conditions) -> Result<Self> {
         let redb = App::db()?;
         let id_store: IdentityStore<'static> = redb.clone().into();
-        let group_store: GroupStore<'static> = redb.into();
+        let group_store: GroupStore<'static> = redb.clone().into();
+        let dm_store: DmStore<'static> = redb.clone().into();
+        let msg_store: MessageStore<'static> = redb.into();
 
-        // 1. Existing identities. Walk the full id_store once to count
-        //    and to collect non-current-version inboxes (those we won't
-        //    build clients for, but which member-add ops still include).
+        // 1. Existing identities. Walk the full id_store once.
+        //    Under `--strict-versioning`, split by version_hash: only
+        //    current-version identities go into `existing` (we'll
+        //    realize them as `DbgClient`s), other-version identities
+        //    go into `other` (member-add ops still include them by
+        //    inbox_id but we never open their sqlite). Without strict
+        //    versioning, version partitioning isn't meaningful — load
+        //    every identity into `existing` so every group on disk is
+        //    reachable through some realizable client, and leave
+        //    `other` empty.
         let current_vh = App::current_version_hash();
-        let other = if let Some(ids) = id_store.load_for_other_versions(current_vh)? {
-            ids.map(|v| HealthClient::new(v.value()))
-                .collect::<HashSet<_>>()
+        let (existing, other) = if App::strict_versioning() {
+            let other = if let Some(ids) = id_store.load_for_other_versions(current_vh)? {
+                ids.map(|v| HealthClient::new(v.value()))
+                    .collect::<HashSet<_>>()
+            } else {
+                HashSet::new()
+            };
+            let existing = if let Some(ids) = id_store.load_for_version(current_vh)? {
+                ids.map(|v| HealthClient::new(v.value()))
+                    .collect::<HashSet<_>>()
+            } else {
+                HashSet::new()
+            };
+            (existing, other)
         } else {
-            HashSet::new()
-        };
-
-        let existing = if let Some(ids) = id_store.load_for_version(current_vh)? {
-            ids.map(|v| HealthClient::new(v.value()))
-                .collect::<HashSet<_>>()
-        } else {
-            HashSet::new()
+            let existing = if let Some(ids) = id_store.load()? {
+                ids.map(|v| HealthClient::new(v.value()))
+                    .collect::<HashSet<_>>()
+            } else {
+                HashSet::new()
+            };
+            (existing, HashSet::new())
         };
 
         let empty = other.is_empty() && existing.is_empty();
@@ -109,96 +137,36 @@ impl HealthContext {
         if empty {
             conditions.insert(Conditions::BOOTSTRAP);
         }
-        // if empty {
-        //     tracing::info!(
-        //         target: "healthcheck",
-        //         count = BOOTSTRAP_IDENTITY_COUNT,
-        //         "redb identity store empty; creating bootstrap identities",
-        //     );
-        //     let mut fresh_identities: Vec<Identity> = Vec::new();
-        //     for _ in 0..BOOTSTRAP_IDENTITY_COUNT {
-        //         let wallet = app::generate_wallet();
-        //         let client = app::new_unregistered_client(Some(&wallet)).await?;
-        //         let identity = Identity::from_libxmtp(client.identity(), wallet.clone())?;
-        //         app::register_client(&client, wallet.into_alloy()).await?;
-        //         let inbox_id = identity.inbox_id;
-        //         fresh_identities.push(identity);
-        //         existing_clients.insert(inbox_id, Arc::new(client));
-        //     }
-        //     id_store.set_all(fresh_identities.as_slice())?;
-        // } else {
-        //     let loaded = app::load_all_identities(&id_store)?;
-        //     let map = Arc::try_unwrap(loaded).map_err(|arc| {
-        //         color_eyre::eyre::eyre!(
-        //             "load_all_identities returned multiply-owned Arc (strong={}, weak={}). \
-        //              HealthContext::bootstrap must be its sole caller — something is holding a clone.",
-        //             Arc::strong_count(&arc),
-        //             Arc::weak_count(&arc),
-        //         )
-        //     })?;
-        //     for (inbox_id, mutex) in map.into_iter() {
-        //         existing_clients.insert(inbox_id, Arc::new(mutex.into_inner()));
-        //     }
-        // }
 
-        // // 2. Primary identity. Register fresh + persist, or reuse
-        // //    existing under read_only.
-        // let primary = if read_only {
-        //     existing_clients.values().next().cloned().ok_or_else(|| {
-        //         eyre!("read_only healthcheck requires at least one existing client")
-        //     })?
-        // } else {
-        //     let primary_wallet = app::generate_wallet();
-        //     let primary_client = app::new_unregistered_client(Some(&primary_wallet)).await?;
-        //     let primary_identity =
-        //         Identity::from_libxmtp(primary_client.identity(), primary_wallet.clone())?;
-        //     app::register_client(&primary_client, primary_wallet.into_alloy()).await?;
-        //     id_store.set(primary_identity)?;
-        //     Arc::new(primary_client)
-        // };
+        // Primary selection:
+        //   - read_only: must reuse an existing identity (no writes,
+        //     CreateIdentity won't run). The empty-store case already
+        //     exited above.
+        //   - writable runs: leave primary as a local-only placeholder.
+        //     `CreateIdentity` runs first (no deps) and overwrites
+        //     `ctx.primary` with a freshly-registered on-network identity.
+        //     No op realizes the placeholder before `CreateIdentity` runs.
+        let primary = if read_only {
+            existing.iter().next().cloned().ok_or_else(|| {
+                eyre!("read_only healthcheck requires at least one existing client")
+            })?
+        } else {
+            HealthClient::new(Identity::generate()?)
+        };
 
-        // let existing_groups: Vec<GroupId> = if read_only {
-        //     primary
-        //         .find_groups(xmtp_db::group::GroupQueryArgs {
-        //             conversation_type: Some(xmtp_db::group::ConversationType::Group),
-        //             ..Default::default()
-        //         })
-        //         .unwrap_or_default()
-        //         .into_iter()
-        //         .map(|g| GroupId::from(g.group_id))
-        //         .collect()
-        // } else {
-        //     let group_only_ids: std::collections::HashSet<GroupId> = existing_clients
-        //         .values()
-        //         .flat_map(|c| {
-        //             c.find_groups(xmtp_db::group::GroupQueryArgs {
-        //                 conversation_type: Some(xmtp_db::group::ConversationType::Group),
-        //                 ..Default::default()
-        //             })
-        //             .unwrap_or_default()
-        //             .into_iter()
-        //             .map(|g| GroupId::from(g.group_id))
-        //         })
-        //         .collect();
-        //     group_store
-        //         .load()?
-        //         .map(|iter| {
-        //             iter.filter_map(|g| {
-        //                 let id = g.value().id();
-        //                 group_only_ids.contains(&id).then_some(id)
-        //             })
-        //             .collect::<Vec<_>>()
-        //         })
-        //         .unwrap_or_default()
-        // };
+        let existing_groups: Vec<GroupId> = group_store
+            .load()?
+            .map(|iter| iter.map(|g| g.value().id()).collect())
+            .unwrap_or_default();
 
-        // tracing::info!(
-        //     target: "healthcheck",
-        //     existing_identities = existing_clients.len(),
-        //     other_identities = other_identities.len(),
-        //     existing_groups = existing_groups.len(),
-        //     "health context bootstrapped"
-        // );
+        tracing::info!(
+            target: "healthcheck",
+            existing_identities = existing.len(),
+            other_identities = other.len(),
+            existing_groups = existing_groups.len(),
+            bootstrap_needed = empty,
+            "health context bootstrapped"
+        );
 
         let ctx = Self {
             primary,
@@ -208,10 +176,23 @@ impl HealthContext {
             new_groups: Vec::new(),
             group_store,
             id_store,
+            dm_store,
+            msg_store,
         };
+
         // Drain welcomes left server-side by prior cross-version runs;
         // without this the first `client.group(<gid>)` hits "not found".
-        // ctx.sync_welcomes_fanout("bootstrap").await;
+        // Skipped on first-run-empty: no identities to sync, and the
+        // `BootstrapIdentities` op will register fresh ones. On
+        // writable runs we sync only existing peers (primary is a
+        // local-only placeholder until `CreateIdentity` registers it).
+        if !empty {
+            if read_only {
+                ctx.sync_welcomes_fanout("bootstrap").await?;
+            } else {
+                ctx.sync_welcomes_existing("bootstrap").await?;
+            }
+        }
         Ok(ctx)
     }
 
@@ -245,17 +226,28 @@ impl HealthContext {
         created_by: InboxId,
         members: Vec<InboxId>,
     ) {
-        let group_store: GroupStore<'static> = redb_or_panic("persist_new_group").into();
-        group_store
-            .set(Group::new(*group_id, created_by, members, false))
+        self.group_store
+            .set(Group::new(*group_id, created_by, members))
             .expect("redb GroupStore::set failed");
     }
 
+    /// Persist a newly-created DM to the redb `DmStore`. DMs live in
+    /// their own table — they're keyed by the (creator, peer) inbox
+    /// pair, not by group id, so cross-version runs can find the same
+    /// DM regardless of which version created the underlying MLS group.
+    ///
+    /// `members` must contain exactly two inboxes: `created_by` and the
+    /// peer. Panics on shape violations — DM creation is an op-level
+    /// invariant and a wrong shape means a deeper bug.
     pub fn persist_new_dm(&self, group_id: &GroupId, created_by: InboxId, members: Vec<InboxId>) {
-        let group_store: GroupStore<'static> = redb_or_panic("persist_new_group").into();
-        group_store
-            .set(Group::new(*group_id, created_by, members, true))
-            .expect("redb GroupStore::set failed");
+        let peer = members
+            .iter()
+            .copied()
+            .find(|m| *m != created_by)
+            .expect("DM must contain a peer distinct from the creator");
+        self.dm_store
+            .set(Dm::new(created_by, peer, *group_id))
+            .expect("redb DmStore::set failed");
     }
 
     /// Replace a persisted group's member list. Used by membership ops
@@ -265,15 +257,14 @@ impl HealthContext {
     ///
     /// Panics on redb failure or non-16-byte `group_id`.
     pub fn update_group_members(&self, group_id: &GroupId, members: Vec<InboxId>) {
-        let group_store: GroupStore<'static> = redb_or_panic("update_group_members").into();
-        // Preserve `created_by` if a row already exists; otherwise default
         // to zero — the field is informational, not load-bearing.
-        let created_by = group_store
+        let created_by = self
+            .group_store
             .get(group_id.into())
             .expect("redb GroupStore::get failed")
             .map(|g| g.created_by)
             .unwrap_or([0u8; 32]);
-        group_store
+        self.group_store
             .set(Group::new(*group_id, created_by, members))
             .expect("redb GroupStore::set failed");
     }
@@ -281,8 +272,7 @@ impl HealthContext {
     /// Look up a persisted group's current members, if it's recorded.
     /// Returns an empty vec if the group is not in redb.
     pub fn persisted_members(&self, group_id: &GroupId) -> Vec<InboxId> {
-        let group_store: GroupStore<'static> = redb_or_panic("persisted_members").into();
-        group_store
+        self.group_store
             .get(group_id.into())
             .expect("redb GroupStore::get failed")
             .map(|g| g.members)
@@ -293,18 +283,21 @@ impl HealthContext {
     /// entry in `existing_clients`. Run-scoped throwaway transients
     /// created by ops are NOT included — they're op-local. Under
     /// `read_only`, primary is one of `existing_clients` — deduped
-    /// here so it isn't processed twice.
-    pub fn all_clients(&self) -> Vec<Arc<DbgClient>> {
-        let primary_inbox = self.primary.inbox_id().to_string();
+    /// here so it isn't materialized twice.
+    ///
+    /// Materializes each `HealthClient` via `client_from_identity` (sync,
+    /// sqlite-only). Errors propagate to the caller.
+    pub fn all_clients(&self) -> Result<Vec<DbgClient>> {
+        let primary_inbox = self.primary.inbox_id_bytes();
         let mut out = Vec::with_capacity(self.existing_clients.len() + 1);
-        out.push(self.primary.clone());
-        out.extend(
-            self.existing_clients
-                .iter()
-                .filter(|(_, c)| c.inbox_id() != primary_inbox)
-                .map(|(_, c)| c.clone()),
-        );
-        out
+        out.push(self.primary.realize(&self.id_store)?);
+        for hc in self.existing_clients.iter() {
+            if hc.inbox_id_bytes() == primary_inbox {
+                continue;
+            }
+            out.push(hc.realize(&self.id_store)?);
+        }
+        Ok(out)
     }
 
     /// Every group this run cares about: existing (loaded from redb)
@@ -313,30 +306,201 @@ impl HealthContext {
         self.existing_groups.iter().chain(self.new_groups.iter())
     }
 
+    /// Run `f` once per group in [`all_groups`](Self::all_groups) with the
+    /// primary realized once. `Ok(())` → Pass row, `Err` → Fail row,
+    /// per group. Pre-loop failures (primary materialization) collapse
+    /// to a single Fail row.
+    pub async fn for_each_group<F, Fut>(&self, op_name: &'static str, f: F) -> Vec<OpResult>
+    where
+        F: Fn(DbgClient, GroupId) -> Fut,
+        Fut: Future<Output = Result<()>>,
+    {
+        let primary = match self.primary() {
+            Ok(p) => p,
+            Err(e) => return vec![OpResult::fail(op_name, None, e)],
+        };
+        let mut out = Vec::new();
+        for gid in self.all_groups().copied().collect::<Vec<_>>() {
+            let start = Instant::now();
+            let res = f(primary.clone(), gid).await;
+            out.push(OpResult::from_result(
+                op_name,
+                Some(format!("{gid}")),
+                start,
+                res,
+            ));
+        }
+        out
+    }
+
+    /// Run `f` once per `(client, group)` pair across `all_clients` ×
+    /// `all_groups`. Clients realized once up front. Pre-loop failures
+    /// collapse to a single Fail row.
+    pub async fn for_each_client_group<F, Fut>(&self, op_name: &'static str, f: F) -> Vec<OpResult>
+    where
+        F: Fn(DbgClient, GroupId) -> Fut,
+        Fut: Future<Output = Result<()>>,
+    {
+        let clients = match self.all_clients() {
+            Ok(cs) => cs,
+            Err(e) => return vec![OpResult::fail(op_name, None, e)],
+        };
+        let groups: Vec<GroupId> = self.all_groups().copied().collect();
+        let mut out = Vec::new();
+        for client in &clients {
+            for gid in &groups {
+                let start = Instant::now();
+                let target = format!("inbox={} group={gid}", client.inbox_id());
+                let res = f(client.clone(), *gid).await;
+                out.push(OpResult::from_result(op_name, Some(target), start, res));
+            }
+        }
+        out
+    }
+
+    /// Run `f` once per client in [`all_clients`](Self::all_clients).
+    /// Each client realized once up front. Pre-loop failures collapse to
+    /// a single Fail row.
+    pub async fn for_each_client<F, Fut>(&self, op_name: &'static str, f: F) -> Vec<OpResult>
+    where
+        F: Fn(DbgClient) -> Fut,
+        Fut: Future<Output = Result<()>>,
+    {
+        let clients = match self.all_clients() {
+            Ok(cs) => cs,
+            Err(e) => return vec![OpResult::fail(op_name, None, e)],
+        };
+        let mut out = Vec::new();
+        for client in clients {
+            let start = Instant::now();
+            let target = client.inbox_id().to_string();
+            let res = f(client).await;
+            out.push(OpResult::from_result(op_name, Some(target), start, res));
+        }
+        out
+    }
+
+    /// Run `f` once per client in `existing_clients` (skipping primary).
+    /// Each client realized lazily — a single materialize failure short-
+    /// circuits the loop into a Fail row for that client and continues
+    /// with the next one.
+    /// Run `f` once per existing peer (skipping the primary identity).
+    /// `f` returns its own `Vec<OpResult>` so callers that emit multiple
+    /// rows per peer (e.g. `CreateDm` with forward + reverse direction
+    /// rows) fit naturally. Closure receives `&self` so it can call
+    /// helpers; uses `BoxFuture` for the same lifetime reasons as
+    /// [`for_each_existing_group`](Self::for_each_existing_group).
+    pub async fn for_each_existing_client<F>(&self, f: F) -> Vec<OpResult>
+    where
+        F: for<'a> Fn(&'a Self, &'a HealthClient) -> futures::future::BoxFuture<'a, Vec<OpResult>>,
+    {
+        let primary_bytes = self.primary.inbox_id_bytes();
+        let mut out = Vec::new();
+        for hc in self
+            .existing_clients
+            .iter()
+            .filter(|hc| hc.inbox_id_bytes() != primary_bytes)
+        {
+            out.extend(f(self, hc).await);
+        }
+        out
+    }
+
+    /// Run `f` once per group in `existing_groups` (skipping `new_groups`).
+    /// Used by ops that operate on groups the previous run created.
+    /// `f` receives `&self` so it can call helpers like
+    /// [`pick_super_admin`](Self::pick_super_admin) or
+    /// [`persisted_members`](Self::persisted_members).
+    ///
+    /// The closure returns a `BoxFuture` so it can borrow `&self` for
+    /// the duration of the awaited work. Direct `async move` closures
+    /// can't express "future borrows the argument for its full lifetime"
+    /// in stable Rust today.
+    pub async fn for_each_existing_group<F>(&self, op_name: &'static str, f: F) -> Vec<OpResult>
+    where
+        F: for<'a> Fn(&'a Self, GroupId) -> futures::future::BoxFuture<'a, Result<()>>,
+    {
+        let mut out = Vec::new();
+        for gid in self.existing_groups.iter().copied() {
+            let start = Instant::now();
+            let res = f(self, gid).await;
+            out.push(OpResult::from_result(
+                op_name,
+                Some(format!("{gid}")),
+                start,
+                res,
+            ));
+        }
+        out
+    }
+
+    /// Run `f` against the first group in `new_groups`. Single-row
+    /// outcome (the op produces one new group at a time). Pre-checks
+    /// for "no new group" and primary materialization collapse to a
+    /// single Fail row. The closure returns a `BoxFuture` so it can
+    /// borrow `&mut self` for the duration of the awaited work.
+    pub async fn for_new_group<F>(&mut self, op_name: &'static str, f: F) -> Vec<OpResult>
+    where
+        F: for<'a> FnOnce(
+            &'a mut Self,
+            DbgClient,
+            GroupId,
+        ) -> futures::future::BoxFuture<'a, Result<()>>,
+    {
+        let Some(gid) = self.new_groups.first().copied() else {
+            return vec![OpResult::fail(
+                op_name,
+                None,
+                eyre!("no new group; CreateGroup must run first"),
+            )];
+        };
+        let primary = match self.primary() {
+            Ok(p) => p,
+            Err(e) => return vec![OpResult::fail(op_name, Some(format!("{gid}")), e)],
+        };
+        let start = Instant::now();
+        let res = f(self, primary, gid).await;
+        vec![OpResult::from_result(
+            op_name,
+            Some(format!("{gid}")),
+            start,
+            res,
+        )]
+    }
+
     /// Pick an active adder for a membership change; prefer super-admin so
     /// `AddSuper` is also issuable, else any active member (under
     /// `--strict-versioning` the creator may live in another partition).
     pub fn pick_super_admin(
         &self,
         group_id: &GroupId,
-    ) -> Option<xmtp_mls::groups::MlsGroup<crate::MlsContext>> {
-        let candidates: Vec<_> = self
-            .existing_clients
-            .values()
-            .filter_map(|c| c.group(group_id).ok().map(|g| (c, g)))
-            .filter(|(_, g)| g.is_active().unwrap_or(false))
-            .collect();
-        candidates
+    ) -> Result<Option<xmtp_mls::groups::MlsGroup<crate::MlsContext>>> {
+        let mut candidates: Vec<(DbgClient, xmtp_mls::groups::MlsGroup<crate::MlsContext>)> =
+            Vec::new();
+        for hc in self.existing_clients.iter() {
+            let client = hc.realize(&self.id_store)?;
+            let Ok(group) = client.group(group_id) else {
+                continue;
+            };
+            if !group.is_active().unwrap_or(false) {
+                continue;
+            }
+            candidates.push((client, group));
+        }
+        Ok(candidates
             .iter()
             .find(|(c, g)| g.is_super_admin(c.inbox_id().to_string()).unwrap_or(false))
             .or_else(|| candidates.first())
-            .map(|(_, g)| g.clone())
+            .map(|(_, g)| g.clone()))
     }
 
     /// Best-effort concurrent welcome sync across all run clients;
-    /// failures are logged only (plumbing, not a validation step).
-    pub async fn sync_welcomes_fanout(&self, label: &'static str) {
-        let clients = self.all_clients();
+    /// per-client failures surface as a warning rather than aborting
+    /// the fanout — this is plumbing, not a validation step. A failure
+    /// to *materialize* a client (sqlite or version mismatch) is
+    /// propagated.
+    pub async fn sync_welcomes_fanout(&self, label: &'static str) -> Result<()> {
+        let clients = self.all_clients()?;
         let syncs = clients.iter().map(|c| async move {
             if let Err(e) = c.sync_welcomes().await {
                 tracing::warn!(
@@ -349,6 +513,31 @@ impl HealthContext {
             }
         });
         futures::future::join_all(syncs).await;
+        Ok(())
+    }
+
+    /// Like [`sync_welcomes_fanout`](Self::sync_welcomes_fanout) but
+    /// excludes `ctx.primary`. Used during `bootstrap()` on writable
+    /// runs where primary is still a placeholder.
+    pub async fn sync_welcomes_existing(&self, label: &'static str) -> Result<()> {
+        let clients: Vec<DbgClient> = self
+            .existing_clients
+            .iter()
+            .map(|hc| hc.realize(&self.id_store))
+            .collect::<Result<_>>()?;
+        let syncs = clients.iter().map(|c| async move {
+            if let Err(e) = c.sync_welcomes().await {
+                tracing::warn!(
+                    target: "healthcheck",
+                    inbox = c.inbox_id(),
+                    error = %e,
+                    label,
+                    "sync_welcomes fanout failed",
+                );
+            }
+        });
+        futures::future::join_all(syncs).await;
+        Ok(())
     }
 
     /// Record a successfully-sent message to redb's `MessageStore`. The
@@ -360,22 +549,26 @@ impl HealthContext {
             .duration_since(UNIX_EPOCH)
             .map(|d| d.as_nanos() as i64)
             .unwrap_or(0);
-        let store: MessageStore<'static> = redb_or_panic("record_message").into();
         let msg = Message::new(
             message_id,
             *group_id,
             inbox_id_to_bytes(sender.inbox_id()),
             sent_at_ns,
         );
-        store.set(msg).expect("redb MessageStore::set failed");
+        self.msg_store
+            .set(msg)
+            .expect("redb MessageStore::set failed");
     }
 
     /// Load every recorded message for this network and bucket by
     /// `group_id`. Single scan; the validator calls this once and reads
     /// per-group sub-vecs out of the map.
     pub fn recorded_messages_by_group(&self) -> HashMap<GroupId, Vec<Message>> {
-        let store: MessageStore<'static> = redb_or_panic("recorded_messages_by_group").into();
-        let Some(iter) = store.load().expect("redb MessageStore::load failed") else {
+        let Some(iter) = self
+            .msg_store
+            .load()
+            .expect("redb MessageStore::load failed")
+        else {
             return HashMap::new();
         };
         let mut out: HashMap<GroupId, Vec<Message>> = HashMap::new();
@@ -394,12 +587,4 @@ pub fn inbox_id_to_bytes(hex_inbox: &str) -> InboxId {
     let mut out = [0u8; 32];
     hex::decode_to_slice(hex_inbox, &mut out).expect("inbox_id is 32-byte hex");
     out
-}
-
-/// Open the xdbg redb database or abort the process. Failure here means
-/// xdbg's state directory is broken — not an op-level failure — so
-/// trying to keep going would produce misleading healthcheck results.
-fn redb_or_panic(caller: &str) -> Arc<redb::Database> {
-    App::db()
-        .unwrap_or_else(|e| panic!("healthcheck::{caller}: failed to open redb database: {e:#}"))
 }

--- a/apps/xmtp_debug/src/app/health/context.rs
+++ b/apps/xmtp_debug/src/app/health/context.rs
@@ -1,12 +1,14 @@
 //! Shared state for the health-check run.
 
 use crate::DbgClient;
-use crate::app::store::{Database, GroupStore, IdentityStore, MessageStore, NetworkKey};
+use crate::app::health::conditions::Conditions;
+use crate::app::store::{
+    Database, DeriveKey, GroupStore, IdentityKey, IdentityStore, MessageStore,
+};
 use crate::app::types::{Group, Identity, InboxId, Message};
-use crate::app::{self, App};
-use crate::args;
-use color_eyre::eyre::{Result, eyre};
-use std::collections::HashMap;
+use crate::app::{self, App, client_from_identity};
+use color_eyre::eyre::{Result, ensure, eyre};
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use xmtp_proto::types::GroupId;
@@ -16,23 +18,49 @@ use xmtp_proto::types::GroupId;
 /// others) and DM ops (primary ↔ peer with at least one extra identity).
 const BOOTSTRAP_IDENTITY_COUNT: usize = 3;
 
-pub struct HealthContext {
-    /// Network selection. Held so ops can re-open `GroupStore` to persist
-    /// newly-created groups for future runs.
-    pub network: args::BackendOpts,
+#[derive(Clone, Copy, Hash, PartialEq, Eq)]
+struct HealthClient {
+    identity: Identity,
+}
 
+impl HealthClient {
+    pub fn new(identity: Identity) -> Self {
+        Self { identity }
+    }
+
+    fn realize(&self, store: &IdentityStore<'static>) -> Result<DbgClient> {
+        let key = self.identity.key();
+        if App::strict_versioning() {
+            let current_version = App::current_version_hash();
+            ensure!(
+                current_version == key.version_hash,
+                "cannot load identities from other versions with `--strict-versioning`."
+            );
+        }
+        let identity = store
+            .get(key)?
+            .ok_or_else(|| eyre!("no identity found for {}", self.identity))?;
+        client_from_identity(&identity)
+    }
+}
+
+pub struct HealthContext {
     /// The single new identity created for this run. Persisted to the
     /// redb identity store so future runs see it as an existing identity.
-    pub primary: Arc<DbgClient>,
+    pub primary: HealthClient,
+
+    id_store: IdentityStore<'static>,
+
+    group_store: GroupStore<'static>,
 
     /// Identities loaded from the redb `IdentityStore` for this network.
     /// On a fresh run, contains the freshly-bootstrapped identities.
-    pub existing_clients: HashMap<InboxId, Arc<DbgClient>>,
+    pub existing_clients: HashSet<HealthClient>,
 
     /// Identities we do not have a client for (different
     /// `version_hash` partition), but which member-add ops should
     /// still include so cross-version groups stay in sync.
-    pub other_identities: Vec<InboxId>,
+    pub other_identities: HashSet<HealthClient>,
 
     /// Group IDs loaded from the redb `GroupStore` for this network.
     /// Stored as the raw 16-byte ids as produced by libxmtp.
@@ -42,11 +70,6 @@ pub struct HealthContext {
     /// HealthContext` and mutate this directly — execution is sequential
     /// so no synchronization is needed.
     pub new_groups: Vec<GroupId>,
-
-    /// The active network. Held so helpers (`record_message`,
-    /// `recorded_messages`) can re-open `MessageStore` without threading
-    /// network through every call site.
-    pub network_key: u64,
 }
 
 impl HealthContext {
@@ -54,127 +77,146 @@ impl HealthContext {
     /// create the primary identity. Hard-fails on infrastructure errors.
     /// With `read_only`, primary is reused from `existing_clients`
     /// instead of registering a new on-network identity.
-    pub async fn bootstrap(network: args::BackendOpts, read_only: bool) -> Result<Self> {
+    pub async fn bootstrap(read_only: bool, conditions: &mut Conditions) -> Result<Self> {
         let redb = App::db()?;
         let id_store: IdentityStore<'static> = redb.clone().into();
         let group_store: GroupStore<'static> = redb.into();
-        let net_key = u64::from(&network);
 
         // 1. Existing identities. Walk the full id_store once to count
         //    and to collect non-current-version inboxes (those we won't
         //    build clients for, but which member-add ops still include).
         let current_vh = App::current_version_hash();
-        let (identity_count, other_identities) = id_store
-            .load(net_key)?
-            .map(|iter| {
-                iter.fold((0usize, Vec::<InboxId>::new()), |(n, mut others), guard| {
-                    let id = guard.value();
-                    if id.version_hash != current_vh {
-                        others.push(id.inbox_id);
-                    }
-                    (n + 1, others)
-                })
-            })
-            .unwrap_or((0, Vec::new()));
-
-        let mut existing_clients: HashMap<InboxId, Arc<DbgClient>> = HashMap::new();
-
-        if identity_count == 0 {
-            tracing::info!(
-                target: "healthcheck",
-                count = BOOTSTRAP_IDENTITY_COUNT,
-                "redb identity store empty; creating bootstrap identities",
-            );
-            let mut fresh_identities: Vec<Identity> = Vec::new();
-            for _ in 0..BOOTSTRAP_IDENTITY_COUNT {
-                let wallet = app::generate_wallet();
-                let client = app::new_unregistered_client(&network, Some(&wallet)).await?;
-                let identity = Identity::from_libxmtp(client.identity(), wallet.clone())?;
-                app::register_client(&client, wallet.into_alloy()).await?;
-                let inbox_id = identity.inbox_id;
-                fresh_identities.push(identity);
-                existing_clients.insert(inbox_id, Arc::new(client));
-            }
-            id_store.set_all(fresh_identities.as_slice(), net_key)?;
+        let other = if let Some(ids) = id_store.load_for_other_versions(current_vh)? {
+            ids.map(|v| HealthClient::new(v.value()))
+                .collect::<HashSet<_>>()
         } else {
-            let loaded = app::load_all_identities(&id_store, &network)?;
-            let map = Arc::try_unwrap(loaded).map_err(|arc| {
-                color_eyre::eyre::eyre!(
-                    "load_all_identities returned multiply-owned Arc (strong={}, weak={}). \
-                     HealthContext::bootstrap must be its sole caller — something is holding a clone.",
-                    Arc::strong_count(&arc),
-                    Arc::weak_count(&arc),
-                )
-            })?;
-            for (inbox_id, mutex) in map.into_iter() {
-                existing_clients.insert(inbox_id, Arc::new(mutex.into_inner()));
-            }
-        }
-
-        // 2. Primary identity. Register fresh + persist, or reuse
-        //    existing under read_only.
-        let primary = if read_only {
-            existing_clients.values().next().cloned().ok_or_else(|| {
-                eyre!("read_only healthcheck requires at least one existing client")
-            })?
-        } else {
-            let primary_wallet = app::generate_wallet();
-            let primary_client =
-                app::new_unregistered_client(&network, Some(&primary_wallet)).await?;
-            let primary_identity =
-                Identity::from_libxmtp(primary_client.identity(), primary_wallet.clone())?;
-            app::register_client(&primary_client, primary_wallet.into_alloy()).await?;
-            id_store.set(primary_identity, net_key)?;
-            Arc::new(primary_client)
+            HashSet::new()
         };
 
-        // 3. Existing groups from redb, filtered to non-DM groups any
-        // existing_client knows about. DM entries would fail every op
-        // run by a primary that isn't a DM member.
-        let group_only_ids: std::collections::HashSet<GroupId> = existing_clients
-            .values()
-            .flat_map(|c| {
-                c.find_groups(xmtp_db::group::GroupQueryArgs {
-                    conversation_type: Some(xmtp_db::group::ConversationType::Group),
-                    ..Default::default()
-                })
-                .unwrap_or_default()
-                .into_iter()
-                .map(|g| GroupId::from(g.group_id))
-            })
-            .collect();
-        let existing_groups: Vec<GroupId> = group_store
-            .load(net_key)?
-            .map(|iter| {
-                iter.filter_map(|g| {
-                    let id = g.value().id();
-                    group_only_ids.contains(&id).then_some(id)
-                })
-                .collect::<Vec<_>>()
-            })
-            .unwrap_or_default();
+        let existing = if let Some(ids) = id_store.load_for_version(current_vh)? {
+            ids.map(|v| HealthClient::new(v.value()))
+                .collect::<HashSet<_>>()
+        } else {
+            HashSet::new()
+        };
 
-        tracing::info!(
-            target: "healthcheck",
-            existing_identities = existing_clients.len(),
-            other_identities = other_identities.len(),
-            existing_groups = existing_groups.len(),
-            "health context bootstrapped"
-        );
+        let empty = other.is_empty() && existing.is_empty();
+        if read_only && empty {
+            tracing::info!("no identities to check.");
+            std::process::exit(0);
+        }
+
+        if empty {
+            conditions.insert(Conditions::BOOTSTRAP);
+        }
+        // if empty {
+        //     tracing::info!(
+        //         target: "healthcheck",
+        //         count = BOOTSTRAP_IDENTITY_COUNT,
+        //         "redb identity store empty; creating bootstrap identities",
+        //     );
+        //     let mut fresh_identities: Vec<Identity> = Vec::new();
+        //     for _ in 0..BOOTSTRAP_IDENTITY_COUNT {
+        //         let wallet = app::generate_wallet();
+        //         let client = app::new_unregistered_client(Some(&wallet)).await?;
+        //         let identity = Identity::from_libxmtp(client.identity(), wallet.clone())?;
+        //         app::register_client(&client, wallet.into_alloy()).await?;
+        //         let inbox_id = identity.inbox_id;
+        //         fresh_identities.push(identity);
+        //         existing_clients.insert(inbox_id, Arc::new(client));
+        //     }
+        //     id_store.set_all(fresh_identities.as_slice())?;
+        // } else {
+        //     let loaded = app::load_all_identities(&id_store)?;
+        //     let map = Arc::try_unwrap(loaded).map_err(|arc| {
+        //         color_eyre::eyre::eyre!(
+        //             "load_all_identities returned multiply-owned Arc (strong={}, weak={}). \
+        //              HealthContext::bootstrap must be its sole caller — something is holding a clone.",
+        //             Arc::strong_count(&arc),
+        //             Arc::weak_count(&arc),
+        //         )
+        //     })?;
+        //     for (inbox_id, mutex) in map.into_iter() {
+        //         existing_clients.insert(inbox_id, Arc::new(mutex.into_inner()));
+        //     }
+        // }
+
+        // // 2. Primary identity. Register fresh + persist, or reuse
+        // //    existing under read_only.
+        // let primary = if read_only {
+        //     existing_clients.values().next().cloned().ok_or_else(|| {
+        //         eyre!("read_only healthcheck requires at least one existing client")
+        //     })?
+        // } else {
+        //     let primary_wallet = app::generate_wallet();
+        //     let primary_client = app::new_unregistered_client(Some(&primary_wallet)).await?;
+        //     let primary_identity =
+        //         Identity::from_libxmtp(primary_client.identity(), primary_wallet.clone())?;
+        //     app::register_client(&primary_client, primary_wallet.into_alloy()).await?;
+        //     id_store.set(primary_identity)?;
+        //     Arc::new(primary_client)
+        // };
+
+        // let existing_groups: Vec<GroupId> = if read_only {
+        //     primary
+        //         .find_groups(xmtp_db::group::GroupQueryArgs {
+        //             conversation_type: Some(xmtp_db::group::ConversationType::Group),
+        //             ..Default::default()
+        //         })
+        //         .unwrap_or_default()
+        //         .into_iter()
+        //         .map(|g| GroupId::from(g.group_id))
+        //         .collect()
+        // } else {
+        //     let group_only_ids: std::collections::HashSet<GroupId> = existing_clients
+        //         .values()
+        //         .flat_map(|c| {
+        //             c.find_groups(xmtp_db::group::GroupQueryArgs {
+        //                 conversation_type: Some(xmtp_db::group::ConversationType::Group),
+        //                 ..Default::default()
+        //             })
+        //             .unwrap_or_default()
+        //             .into_iter()
+        //             .map(|g| GroupId::from(g.group_id))
+        //         })
+        //         .collect();
+        //     group_store
+        //         .load()?
+        //         .map(|iter| {
+        //             iter.filter_map(|g| {
+        //                 let id = g.value().id();
+        //                 group_only_ids.contains(&id).then_some(id)
+        //             })
+        //             .collect::<Vec<_>>()
+        //         })
+        //         .unwrap_or_default()
+        // };
+
+        // tracing::info!(
+        //     target: "healthcheck",
+        //     existing_identities = existing_clients.len(),
+        //     other_identities = other_identities.len(),
+        //     existing_groups = existing_groups.len(),
+        //     "health context bootstrapped"
+        // );
 
         let ctx = Self {
-            network,
             primary,
-            existing_clients,
-            other_identities,
+            existing_clients: existing,
+            other_identities: other,
             existing_groups,
             new_groups: Vec::new(),
-            network_key: net_key,
+            group_store,
+            id_store,
         };
         // Drain welcomes left server-side by prior cross-version runs;
         // without this the first `client.group(<gid>)` hits "not found".
-        ctx.sync_welcomes_fanout("bootstrap").await;
+        // ctx.sync_welcomes_fanout("bootstrap").await;
         Ok(ctx)
+    }
+
+    pub fn primary(&self) -> Result<DbgClient> {
+        self.primary.realize(&self.id_store)
     }
 
     /// Register a fresh single-use identity. Not persisted to redb. Used
@@ -184,7 +226,7 @@ impl HealthContext {
     /// nothing in the run references it.
     pub async fn create_transient(&self) -> Result<Arc<DbgClient>> {
         let wallet = app::generate_wallet();
-        let client = app::new_unregistered_client(&self.network, Some(&wallet)).await?;
+        let client = app::new_unregistered_client(Some(&wallet)).await?;
         app::register_client(&client, wallet.into_alloy()).await?;
         Ok(Arc::new(client))
     }
@@ -205,10 +247,14 @@ impl HealthContext {
     ) {
         let group_store: GroupStore<'static> = redb_or_panic("persist_new_group").into();
         group_store
-            .set(
-                Group::new(*group_id, created_by, members),
-                u64::from(&self.network),
-            )
+            .set(Group::new(*group_id, created_by, members, false))
+            .expect("redb GroupStore::set failed");
+    }
+
+    pub fn persist_new_dm(&self, group_id: &GroupId, created_by: InboxId, members: Vec<InboxId>) {
+        let group_store: GroupStore<'static> = redb_or_panic("persist_new_group").into();
+        group_store
+            .set(Group::new(*group_id, created_by, members, true))
             .expect("redb GroupStore::set failed");
     }
 
@@ -220,17 +266,15 @@ impl HealthContext {
     /// Panics on redb failure or non-16-byte `group_id`.
     pub fn update_group_members(&self, group_id: &GroupId, members: Vec<InboxId>) {
         let group_store: GroupStore<'static> = redb_or_panic("update_group_members").into();
-        let net_key = u64::from(&self.network);
-        let key = NetworkKey::new(net_key, *group_id);
         // Preserve `created_by` if a row already exists; otherwise default
         // to zero — the field is informational, not load-bearing.
         let created_by = group_store
-            .get(key)
+            .get(group_id.into())
             .expect("redb GroupStore::get failed")
             .map(|g| g.created_by)
             .unwrap_or([0u8; 32]);
         group_store
-            .set(Group::new(*group_id, created_by, members), net_key)
+            .set(Group::new(*group_id, created_by, members))
             .expect("redb GroupStore::set failed");
     }
 
@@ -238,10 +282,8 @@ impl HealthContext {
     /// Returns an empty vec if the group is not in redb.
     pub fn persisted_members(&self, group_id: &GroupId) -> Vec<InboxId> {
         let group_store: GroupStore<'static> = redb_or_panic("persisted_members").into();
-        let net_key = u64::from(&self.network);
-        let key = NetworkKey::new(net_key, *group_id);
         group_store
-            .get(key)
+            .get(group_id.into())
             .expect("redb GroupStore::get failed")
             .map(|g| g.members)
             .unwrap_or_default()
@@ -253,7 +295,7 @@ impl HealthContext {
     /// `read_only`, primary is one of `existing_clients` — deduped
     /// here so it isn't processed twice.
     pub fn all_clients(&self) -> Vec<Arc<DbgClient>> {
-        let primary_inbox = self.primary.inbox_id();
+        let primary_inbox = self.primary.inbox_id().to_string();
         let mut out = Vec::with_capacity(self.existing_clients.len() + 1);
         out.push(self.primary.clone());
         out.extend(
@@ -305,7 +347,7 @@ impl HealthContext {
                     "sync_welcomes fanout failed",
                 );
             }
-            });
+        });
         futures::future::join_all(syncs).await;
     }
 
@@ -325,9 +367,7 @@ impl HealthContext {
             inbox_id_to_bytes(sender.inbox_id()),
             sent_at_ns,
         );
-        store
-            .set(msg, self.network_key)
-            .expect("redb MessageStore::set failed");
+        store.set(msg).expect("redb MessageStore::set failed");
     }
 
     /// Load every recorded message for this network and bucket by
@@ -335,10 +375,7 @@ impl HealthContext {
     /// per-group sub-vecs out of the map.
     pub fn recorded_messages_by_group(&self) -> HashMap<GroupId, Vec<Message>> {
         let store: MessageStore<'static> = redb_or_panic("recorded_messages_by_group").into();
-        let Some(iter) = store
-            .load(self.network_key)
-            .expect("redb MessageStore::load failed")
-        else {
+        let Some(iter) = store.load().expect("redb MessageStore::load failed") else {
             return HashMap::new();
         };
         let mut out: HashMap<GroupId, Vec<Message>> = HashMap::new();

--- a/apps/xmtp_debug/src/app/health/mod.rs
+++ b/apps/xmtp_debug/src/app/health/mod.rs
@@ -32,13 +32,16 @@ impl Health {
         print!("{}", ops::tree::render_order_tree());
 
         let mut active = conditions::Conditions::active();
-
-        let mut ctx = HealthContext::bootstrap(self.opts.read_only).await?;
-        let mut report = result::Report::new();
-
         if !self.opts.read_only {
             active |= conditions::Conditions::WRITES;
         }
+
+        // bootstrap() may set `Conditions::BOOTSTRAP` if the redb identity
+        // store is empty — pass `&mut active` so the gate is visible to the
+        // op registry built below.
+        let mut ctx = HealthContext::bootstrap(self.opts.read_only, &mut active).await?;
+        let mut report = result::Report::new();
+
         let op_build = ops::registry(active);
 
         // Surface skipped ops up-front so the operator sees the
@@ -85,7 +88,23 @@ impl Health {
 }
 
 async fn sync_all(ctx: &HealthContext, report: &mut result::Report) {
-    for client in ctx.all_clients() {
+    let clients = match ctx.all_clients() {
+        Ok(cs) => cs,
+        Err(e) => {
+            record_result(
+                report,
+                result::OpResult {
+                    op_name: "Sync",
+                    target: None,
+                    status: result::Status::Fail,
+                    duration: std::time::Duration::ZERO,
+                    error: Some(e),
+                },
+            );
+            return;
+        }
+    };
+    for client in &clients {
         let start = Instant::now();
         let outcome = client.sync_all_welcomes_and_groups(None).await;
         let (status, error) = match outcome {

--- a/apps/xmtp_debug/src/app/health/mod.rs
+++ b/apps/xmtp_debug/src/app/health/mod.rs
@@ -18,14 +18,12 @@ use color_eyre::eyre::{Result, eyre};
 use std::time::Instant;
 
 pub struct Health {
-    #[allow(dead_code)]
-    opts: args::HealthcheckOpts,
-    network: args::BackendOpts,
+    opts: &'static args::HealthcheckOpts,
 }
 
 impl Health {
-    pub fn new(opts: args::HealthcheckOpts, network: args::BackendOpts) -> Self {
-        Self { opts, network }
+    pub fn new(opts: &'static args::HealthcheckOpts) -> Self {
+        Self { opts }
     }
 
     pub async fn run(self) -> Result<()> {
@@ -33,10 +31,11 @@ impl Health {
         // visible even if bootstrap fails.
         print!("{}", ops::tree::render_order_tree());
 
-        let mut ctx = HealthContext::bootstrap(self.network, self.opts.read_only).await?;
+        let mut active = conditions::Conditions::active();
+
+        let mut ctx = HealthContext::bootstrap(self.opts.read_only).await?;
         let mut report = result::Report::new();
 
-        let mut active = conditions::Conditions::active();
         if !self.opts.read_only {
             active |= conditions::Conditions::WRITES;
         }

--- a/apps/xmtp_debug/src/app/health/mod.rs
+++ b/apps/xmtp_debug/src/app/health/mod.rs
@@ -33,10 +33,13 @@ impl Health {
         // visible even if bootstrap fails.
         print!("{}", ops::tree::render_order_tree());
 
-        let mut ctx = HealthContext::bootstrap(self.network).await?;
+        let mut ctx = HealthContext::bootstrap(self.network, self.opts.read_only).await?;
         let mut report = result::Report::new();
 
-        let active = conditions::Conditions::active();
+        let mut active = conditions::Conditions::active();
+        if !self.opts.read_only {
+            active |= conditions::Conditions::WRITES;
+        }
         let op_build = ops::registry(active);
 
         // Surface skipped ops up-front so the operator sees the

--- a/apps/xmtp_debug/src/app/health/ops/add_members.rs
+++ b/apps/xmtp_debug/src/app/health/ops/add_members.rs
@@ -10,7 +10,7 @@ use crate::app::health::ops::HealthOp;
 use crate::app::health::result::{OpResult, Status};
 use async_trait::async_trait;
 use color_eyre::eyre::eyre;
-use std::time::{Duration, Instant};
+use futures::FutureExt;
 use xmtp_mls::groups::UpdateAdminListType::*;
 
 pub struct AddMembersToNewGroup;
@@ -27,63 +27,39 @@ impl HealthOp for AddMembersToNewGroup {
         fields(op = "AddMembersToNewGroup")
     )]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
-        let Some(new_group_id) = ctx.new_groups.first().cloned() else {
-            return vec![OpResult {
-                op_name: self.name(),
-                target: None,
-                status: Status::Fail,
-                duration: Duration::ZERO,
-                error: Some(eyre!("no new group; CreateGroup must run first")),
-            }];
-        };
-
-        let group = match ctx.primary.group(&new_group_id) {
-            Ok(g) => g,
-            Err(e) => {
-                return vec![OpResult {
-                    op_name: self.name(),
-                    target: Some(format!("{new_group_id}")),
-                    status: Status::Fail,
-                    duration: Duration::ZERO,
-                    error: Some(eyre!("{e}")),
-                }];
-            }
-        };
-
-        let inbox_ids: Vec<String> = ctx
-            .existing_clients
-            .values()
-            .map(|c| c.inbox_id().to_string())
-            .chain(ctx.other_identities.iter().map(hex::encode))
-            .collect();
-
-        let start = Instant::now();
-        let outcome: color_eyre::eyre::Result<()> = async {
-            group.add_members(&inbox_ids).await?;
-            // Mirror the new membership to redb so subsequent runs see
-            // the full member list, not just the creator.
-            let mut members = vec![inbox_id_to_bytes(ctx.primary.inbox_id())];
-            members.extend(inbox_ids.iter().map(|s| inbox_id_to_bytes(s)));
-            ctx.update_group_members(&new_group_id, members);
-            Ok(())
-        }
-        .await;
-        let (status, error) = match outcome {
-            Ok(_) => (Status::Pass, None),
-            Err(e) => (Status::Fail, Some(e)),
-        };
+        let primary_bytes = ctx.primary.inbox_id_bytes();
+        let mut out = ctx
+            .for_new_group(self.name(), |ctx, primary, gid| {
+                async move {
+                    let group = primary.group(&gid)?;
+                    let inbox_ids: Vec<String> = ctx
+                        .existing_clients
+                        .iter()
+                        .map(|hc| hc.inbox_id_hex())
+                        .chain(ctx.other_identities.iter().map(|hc| hc.inbox_id_hex()))
+                        .collect();
+                    group.add_members(&inbox_ids).await?;
+                    // Mirror the new membership to redb so subsequent runs see
+                    // the full member list, not just the creator.
+                    let mut members = vec![primary_bytes];
+                    members.extend(inbox_ids.iter().map(|s| inbox_id_to_bytes(s)));
+                    ctx.update_group_members(&gid, members);
+                    Ok(())
+                }
+                .boxed()
+            })
+            .await;
         // Welcomes aren't auto-pulled mid-run — sync so newly-added clients
         // can `client.group(...)` immediately in downstream ops.
-        if status == Status::Pass {
-            ctx.sync_welcomes_fanout("AddMembersToNewGroup").await;
+        if out.iter().any(|r| r.status == Status::Pass)
+            && let Err(e) = ctx.sync_welcomes_fanout("AddMembersToNewGroup").await
+        {
+            tracing::warn!(error = %e, "sync_welcomes_fanout failed");
+            // Surface fanout failure as a separate result row so the
+            // sweep stays honest about downstream observability.
+            out.push(OpResult::fail(self.name(), Some("sync_welcomes".into()), e));
         }
-        vec![OpResult {
-            op_name: self.name(),
-            target: Some(format!("{new_group_id}")),
-            status,
-            duration: start.elapsed(),
-            error,
-        }]
+        out
     }
 }
 
@@ -101,52 +77,42 @@ impl HealthOp for AddPrimaryToExistingGroups {
         fields(op = "AddPrimaryToExistingGroups")
     )]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
-        let mut out = Vec::new();
-        let primary_inbox = ctx.primary.inbox_id().to_string();
-
-        for gid in &ctx.existing_groups {
-            let start = Instant::now();
-            let outcome: color_eyre::eyre::Result<()> = async {
-                let group = ctx
-                    .pick_super_admin(gid)
-                    .ok_or_else(|| eyre!("no active member found for group"))?;
-                group
-                    .add_members(std::slice::from_ref(&primary_inbox))
-                    .await?;
-                // Adder is a super-admin per pick_super_admin; propagate so
-                // super-admin-only downstream ops don't false-pass.
-                group
-                    .update_admin_list(AddSuper, primary_inbox.clone())
-                    .await?;
-                let mut members = ctx.persisted_members(gid);
-                let primary_bytes = inbox_id_to_bytes(&primary_inbox);
-                if !members.contains(&primary_bytes) {
-                    members.push(primary_bytes);
+        let primary_inbox = ctx.primary.inbox_id_hex();
+        let primary_bytes = ctx.primary.inbox_id_bytes();
+        let out = ctx
+            .for_each_existing_group(self.name(), |ctx, gid| {
+                let primary_inbox = primary_inbox.clone();
+                async move {
+                    let group = ctx
+                        .pick_super_admin(&gid)?
+                        .ok_or_else(|| eyre!("no active member found for group"))?;
+                    group
+                        .add_members(std::slice::from_ref(&primary_inbox))
+                        .await?;
+                    // Adder is a super-admin per pick_super_admin; propagate so
+                    // super-admin-only downstream ops don't false-pass.
+                    group
+                        .update_admin_list(AddSuper, primary_inbox.clone())
+                        .await?;
+                    let mut members = ctx.persisted_members(&gid);
+                    if !members.contains(&primary_bytes) {
+                        members.push(primary_bytes);
+                    }
+                    ctx.update_group_members(&gid, members);
+                    Ok(())
                 }
-                ctx.update_group_members(gid, members);
-                Ok(())
-            }
+                .boxed()
+            })
             .await;
-
-            let (status, error) = match outcome {
-                Ok(_) => (Status::Pass, None),
-                Err(e) => (Status::Fail, Some(e)),
-            };
-            out.push(OpResult {
-                op_name: self.name(),
-                target: Some(format!("{gid}")),
-                status,
-                duration: start.elapsed(),
-                error,
-            });
-        }
-
         // Welcomes aren't auto-pulled mid-run — sync primary + observers so
         // downstream metadata reads on these groups succeed.
-        if out.iter().any(|r| r.status == Status::Pass) {
-            ctx.sync_welcomes_fanout("AddPrimaryToExistingGroups").await;
+        let mut out = out;
+        if out.iter().any(|r| r.status == Status::Pass)
+            && let Err(e) = ctx.sync_welcomes_fanout("AddPrimaryToExistingGroups").await
+        {
+            tracing::warn!(error = %e, "sync_welcomes_fanout failed");
+            out.push(OpResult::fail(self.name(), Some("sync_welcomes".into()), e));
         }
-
         out
     }
 }

--- a/apps/xmtp_debug/src/app/health/ops/add_members.rs
+++ b/apps/xmtp_debug/src/app/health/ops/add_members.rs
@@ -169,7 +169,7 @@ inventory::submit! {
     crate::app::health::ops::OpEntry {
         depends_on: &["CreateGroup"],
         op: &AddMembersToNewGroup,
-        requires: crate::app::health::conditions::Conditions::ALWAYS,
+        requires: crate::app::health::conditions::Conditions::WRITES,
     }
 }
 
@@ -177,6 +177,6 @@ inventory::submit! {
     crate::app::health::ops::OpEntry {
         depends_on: &["CreateIdentity"],
         op: &AddPrimaryToExistingGroups,
-        requires: crate::app::health::conditions::Conditions::ALWAYS,
+        requires: crate::app::health::conditions::Conditions::WRITES,
     }
 }

--- a/apps/xmtp_debug/src/app/health/ops/bootstrap.rs
+++ b/apps/xmtp_debug/src/app/health/ops/bootstrap.rs
@@ -1,0 +1,71 @@
+//! Op: record that the run's primary identity was successfully created.
+//! The actual creation happens during `HealthContext::bootstrap`; this op
+//! exposes that success as a discrete check in the run's result table.
+
+use crate::app;
+use crate::app::health::context::{HealthClient, HealthContext};
+use crate::app::health::ops::HealthOp;
+use crate::app::health::result::OpResult;
+use crate::app::store::Database;
+use crate::app::types::Identity;
+use async_trait::async_trait;
+use color_eyre::eyre::Result;
+use std::time::Instant;
+
+pub struct BootstrapIdentities;
+
+/// Number of identities to create when the redb identity store is empty.
+/// 3 is the minimum that lets us exercise group ops (one creator + two
+/// others) and DM ops (primary ↔ peer with at least one extra identity).
+const BOOTSTRAP_IDENTITY_COUNT: usize = 3;
+
+#[async_trait]
+impl HealthOp for BootstrapIdentities {
+    fn name(&self) -> &'static str {
+        "BootstrapIdentities"
+    }
+
+    #[tracing::instrument(
+        target = "healthcheck.op",
+        skip_all,
+        fields(op = "BootstrapIdentities")
+    )]
+    async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
+        let start = Instant::now();
+        let outcome: Result<()> = async {
+            let mut fresh_identities: Vec<Identity> = Vec::new();
+            for _ in 0..BOOTSTRAP_IDENTITY_COUNT {
+                let wallet = app::generate_wallet();
+                let client = app::new_unregistered_client(Some(&wallet)).await?;
+                let identity = Identity::from_libxmtp(client.identity(), wallet.clone())?;
+                app::register_client(&client, wallet.into_alloy()).await?;
+                fresh_identities.push(identity);
+                ctx.existing_clients.insert(HealthClient::new(identity));
+            }
+            ctx.id_store.set_all(fresh_identities.as_slice())?;
+            Ok(())
+        }
+        .await;
+
+        vec![OpResult::from_result(self.name(), None, start, outcome)]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn name_is_stable() {
+        assert_eq!(BootstrapIdentities.name(), "BootstrapIdentities");
+    }
+}
+
+inventory::submit! {
+    crate::app::health::ops::OpEntry {
+        depends_on: &[],
+        op: &BootstrapIdentities,
+        requires: crate::app::health::conditions::Conditions::BOOTSTRAP
+            .union(crate::app::health::conditions::Conditions::WRITES),
+    }
+}

--- a/apps/xmtp_debug/src/app/health/ops/create_dm.rs
+++ b/apps/xmtp_debug/src/app/health/ops/create_dm.rs
@@ -91,6 +91,6 @@ inventory::submit! {
     crate::app::health::ops::OpEntry {
         depends_on: &["CreateIdentity"],
         op: &CreateDm,
-        requires: crate::app::health::conditions::Conditions::ALWAYS,
+        requires: crate::app::health::conditions::Conditions::WRITES,
     }
 }

--- a/apps/xmtp_debug/src/app/health/ops/create_dm.rs
+++ b/apps/xmtp_debug/src/app/health/ops/create_dm.rs
@@ -3,8 +3,9 @@
 
 use crate::app::health::context::HealthContext;
 use crate::app::health::ops::HealthOp;
-use crate::app::health::result::{OpResult, Status};
+use crate::app::health::result::OpResult;
 use async_trait::async_trait;
+use futures::FutureExt;
 use std::time::Instant;
 use xmtp_mls::groups::send_message_opts::SendMessageOpts;
 
@@ -18,62 +19,60 @@ impl HealthOp for CreateDm {
 
     #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "CreateDm"))]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
-        let mut out = Vec::new();
-        let primary_inbox = ctx.primary.inbox_id().to_string();
+        ctx.for_each_existing_client(|ctx, peer_hc| {
+            async move {
+                let primary_bytes = ctx.primary.inbox_id_bytes();
+                let primary_inbox = ctx.primary.inbox_id_hex();
+                let peer_inbox_hex = peer_hc.inbox_id_hex();
+                let peer_bytes = peer_hc.inbox_id_bytes();
+                let mut rows = Vec::with_capacity(2);
 
-        for (peer_inbox_bytes, peer) in &ctx.existing_clients {
-            let peer_inbox = peer.inbox_id().to_string();
-            if peer_inbox == primary_inbox {
-                continue;
-            }
+                // Direction A: primary → peer. Persist on success.
+                let start = Instant::now();
+                let dir_a: color_eyre::eyre::Result<()> = async {
+                    let primary = ctx.primary()?;
+                    let dm = primary
+                        .find_or_create_dm(peer_inbox_hex.as_str(), None)
+                        .await?;
+                    dm.send_message(b"hi from primary", SendMessageOpts::default())
+                        .await?;
+                    ctx.persist_new_dm(
+                        &dm.group_id,
+                        primary_bytes,
+                        vec![primary_bytes, peer_bytes],
+                    );
+                    Ok(())
+                }
+                .await;
+                rows.push(OpResult::from_result(
+                    "CreateDm",
+                    Some(format!("primary->{peer_inbox_hex}")),
+                    start,
+                    dir_a,
+                ));
 
-            // Direction A: primary → peer.
-            let start = Instant::now();
-            let dir_a: color_eyre::eyre::Result<()> = async {
-                let dm = ctx
-                    .primary
-                    .find_or_create_dm(peer_inbox.as_str(), None)
-                    .await?;
-                dm.send_message(b"hi from primary", SendMessageOpts::default())
-                    .await?;
-                Ok(())
+                // Direction B: peer → primary.
+                let start = Instant::now();
+                let dir_b: color_eyre::eyre::Result<()> = async {
+                    let peer = peer_hc.realize(&ctx.id_store)?;
+                    peer.sync_all_welcomes_and_groups(None).await?;
+                    let dm = peer.find_or_create_dm(primary_inbox.as_str(), None).await?;
+                    dm.send_message(b"hi from peer", SendMessageOpts::default())
+                        .await?;
+                    Ok(())
+                }
+                .await;
+                rows.push(OpResult::from_result(
+                    "SendDmRoundTrip",
+                    Some(format!("{peer_inbox_hex}->primary")),
+                    start,
+                    dir_b,
+                ));
+                rows
             }
-            .await;
-            let (status, error) = match dir_a {
-                Ok(_) => (Status::Pass, None),
-                Err(e) => (Status::Fail, Some(e)),
-            };
-            out.push(OpResult {
-                op_name: "CreateDm",
-                target: Some(format!("primary->{}", hex::encode(peer_inbox_bytes))),
-                status,
-                duration: start.elapsed(),
-                error,
-            });
-
-            // Direction B: peer → primary.
-            let start = Instant::now();
-            let dir_b: color_eyre::eyre::Result<()> = async {
-                peer.sync_all_welcomes_and_groups(None).await?;
-                let dm = peer.find_or_create_dm(primary_inbox.as_str(), None).await?;
-                dm.send_message(b"hi from peer", SendMessageOpts::default())
-                    .await?;
-                Ok(())
-            }
-            .await;
-            let (status, error) = match dir_b {
-                Ok(_) => (Status::Pass, None),
-                Err(e) => (Status::Fail, Some(e)),
-            };
-            out.push(OpResult {
-                op_name: "SendDmRoundTrip",
-                target: Some(format!("{}->primary", hex::encode(peer_inbox_bytes))),
-                status,
-                duration: start.elapsed(),
-                error,
-            });
-        }
-        out
+            .boxed()
+        })
+        .await
     }
 }
 

--- a/apps/xmtp_debug/src/app/health/ops/create_group.rs
+++ b/apps/xmtp_debug/src/app/health/ops/create_group.rs
@@ -2,12 +2,14 @@
 //! The new group's id is appended to `ctx.new_groups` so downstream ops
 //! and validators see it.
 
-use crate::app::health::context::{HealthContext, inbox_id_to_bytes};
+use crate::app::health::context::HealthContext;
 use crate::app::health::ops::HealthOp;
-use crate::app::health::result::{OpResult, Status};
+use crate::app::health::result::OpResult;
+use crate::app::types::InboxId;
 use async_trait::async_trait;
 use color_eyre::eyre::eyre;
 use std::time::Instant;
+use xmtp_proto::types::GroupId;
 
 pub struct CreateGroup;
 
@@ -20,25 +22,21 @@ impl HealthOp for CreateGroup {
     #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "CreateGroup"))]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
         let start = Instant::now();
-        let outcome = ctx.primary.create_group(None, None);
-        let (status, target, error) = match outcome {
-            Ok(group) => {
-                let new_group_id = group.group_id;
-                let hex_id = format!("{new_group_id}");
-                let creator = inbox_id_to_bytes(ctx.primary.inbox_id());
+        let outcome: color_eyre::eyre::Result<(GroupId, InboxId)> = (|| {
+            let primary = ctx.primary()?;
+            let group = primary.create_group(None, None).map_err(|e| eyre!("{e}"))?;
+            let creator = ctx.primary.inbox_id_bytes();
+            Ok((group.group_id, creator))
+        })();
+        match outcome {
+            Ok((new_group_id, creator)) => {
+                let target = Some(format!("{new_group_id}"));
                 ctx.persist_new_group(&new_group_id, creator, vec![creator]);
                 ctx.new_groups.push(new_group_id);
-                (Status::Pass, Some(hex_id), None)
+                vec![OpResult::from_result(self.name(), target, start, Ok(()))]
             }
-            Err(e) => (Status::Fail, None, Some(eyre!("{e}"))),
-        };
-        vec![OpResult {
-            op_name: self.name(),
-            target,
-            status,
-            duration: start.elapsed(),
-            error,
-        }]
+            Err(e) => vec![OpResult::fail(self.name(), None, e)],
+        }
     }
 }
 

--- a/apps/xmtp_debug/src/app/health/ops/create_group.rs
+++ b/apps/xmtp_debug/src/app/health/ops/create_group.rs
@@ -56,6 +56,6 @@ inventory::submit! {
     crate::app::health::ops::OpEntry {
         depends_on: &["CreateIdentity"],
         op: &CreateGroup,
-        requires: crate::app::health::conditions::Conditions::ALWAYS,
+        requires: crate::app::health::conditions::Conditions::WRITES,
     }
 }

--- a/apps/xmtp_debug/src/app/health/ops/create_identity.rs
+++ b/apps/xmtp_debug/src/app/health/ops/create_identity.rs
@@ -1,11 +1,30 @@
-//! Op: record that the run's primary identity was successfully created.
-//! The actual creation happens during `HealthContext::bootstrap`; this op
-//! exposes that success as a discrete check in the run's result table.
+//! Op: generate a fresh wallet, register an MLS client for it on the
+//! network, persist the resulting `Identity` to the redb
+//! `IdentityStore`, and write the registered `HealthClient` into
+//! `ctx.primary`. Bootstrap leaves `ctx.primary` as a local-only
+//! placeholder; no op realizes the placeholder before this op runs
+//! (we have no deps, so we're first in the writable schedule).
+//!
+//! Gated on `WRITES` — read-only runs reuse an existing identity
+//! picked during `HealthContext::bootstrap` and skip this op entirely.
+//!
+//! NOTE: reusing the installation keys baked into `bootstrap`'s
+//! placeholder via `.identity()` injection on the builder isn't
+//! feasible without rebuilding the full SignatureRequest (CreateInbox,
+//! install->inbox AddAssociation, install pre-signature). The MLS
+//! network rejects every group commit with `InboxValidationFailed`
+//! when the install->inbox association is missing. Letting the builder
+//! generate its own install keys via `IdentityStrategy::new` is the
+//! supported path.
 
-use crate::app::health::context::HealthContext;
+use crate::app;
+use crate::app::health::context::{HealthClient, HealthContext};
 use crate::app::health::ops::HealthOp;
-use crate::app::health::result::{OpResult, Status};
+use crate::app::health::result::OpResult;
+use crate::app::store::Database;
+use crate::app::types::Identity;
 use async_trait::async_trait;
+use color_eyre::eyre::Result;
 use std::time::Instant;
 
 pub struct CreateIdentity;
@@ -19,19 +38,24 @@ impl HealthOp for CreateIdentity {
     #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "CreateIdentity"))]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
         let start = Instant::now();
-        let inbox_id = ctx.primary.inbox_id().to_string();
-        let status = if inbox_id.is_empty() {
-            Status::Fail
-        } else {
-            Status::Pass
-        };
-        vec![OpResult {
-            op_name: self.name(),
-            target: Some(inbox_id),
-            status,
-            duration: start.elapsed(),
-            error: None,
-        }]
+        let outcome: Result<Identity> = async {
+            let wallet = app::generate_wallet();
+            let client = app::new_unregistered_client(Some(&wallet)).await?;
+            let identity = Identity::from_libxmtp(client.identity(), wallet.clone())?;
+            app::register_client(&client, wallet.into_alloy()).await?;
+            ctx.id_store.set(identity)?;
+            Ok(identity)
+        }
+        .await;
+
+        match outcome {
+            Ok(identity) => {
+                let target = Some(hex::encode(identity.inbox_id));
+                ctx.primary = HealthClient::new(identity);
+                vec![OpResult::from_result(self.name(), target, start, Ok(()))]
+            }
+            Err(e) => vec![OpResult::fail(self.name(), None, e)],
+        }
     }
 }
 
@@ -49,6 +73,6 @@ inventory::submit! {
     crate::app::health::ops::OpEntry {
         depends_on: &[],
         op: &CreateIdentity,
-        requires: crate::app::health::conditions::Conditions::ALWAYS,
+        requires: crate::app::health::conditions::Conditions::WRITES,
     }
 }

--- a/apps/xmtp_debug/src/app/health/ops/ensure_per_version_membership.rs
+++ b/apps/xmtp_debug/src/app/health/ops/ensure_per_version_membership.rs
@@ -62,12 +62,11 @@ impl HealthOp for EnsurePerVersionMembership {
             // keyed by inbox. Avoids N+1 table scans in the loops below.
             // Scoped so the redb handle drops before we re-open it below
             // (redb refuses concurrent opens within a single process).
-            let net_key = u64::from(&ctx.network);
             let identities: HashMap<InboxId, Identity> = {
                 let redb: Arc<redb::Database> = App::db()?;
                 let id_store: IdentityStore<'static> = redb.into();
                 id_store
-                    .load(net_key)?
+                    .load()?
                     .into_iter()
                     .flatten()
                     .map(|g| {

--- a/apps/xmtp_debug/src/app/health/ops/ensure_per_version_membership.rs
+++ b/apps/xmtp_debug/src/app/health/ops/ensure_per_version_membership.rs
@@ -157,6 +157,7 @@ inventory::submit! {
     crate::app::health::ops::OpEntry {
         depends_on: &["AddMembersToNewGroup"],
         op: &EnsurePerVersionMembership,
-        requires: crate::app::health::conditions::Conditions::STRICT_VERSIONING,
+        requires: crate::app::health::conditions::Conditions::STRICT_VERSIONING
+            .union(crate::app::health::conditions::Conditions::WRITES),
     }
 }

--- a/apps/xmtp_debug/src/app/health/ops/ensure_per_version_membership.rs
+++ b/apps/xmtp_debug/src/app/health/ops/ensure_per_version_membership.rs
@@ -11,16 +11,15 @@
 //! uniformly), so this op is gated on `Conditions::STRICT_VERSIONING`.
 
 use crate::app::App;
-use crate::app::health::context::{HealthContext, inbox_id_to_bytes};
+use crate::app::health::context::HealthContext;
 use crate::app::health::ops::HealthOp;
-use crate::app::health::result::{OpResult, Status};
-use crate::app::store::{Database, IdentityStore};
+use crate::app::health::result::OpResult;
+use crate::app::store::Database;
 use crate::app::types::{Identity, InboxId};
 use async_trait::async_trait;
 use color_eyre::eyre::eyre;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
-use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 use xmtp_mls::groups::UpdateAdminListType::*;
 
 pub struct EnsurePerVersionMembership;
@@ -38,15 +37,11 @@ impl HealthOp for EnsurePerVersionMembership {
     )]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
         let Some(new_group_id) = ctx.new_groups.first().cloned() else {
-            return vec![OpResult {
-                op_name: self.name(),
-                target: None,
-                status: Status::Fail,
-                duration: Duration::ZERO,
-                error: Some(eyre!(
-                    "no new group; CreateGroup + AddMembersToNewGroup must run first"
-                )),
-            }];
+            return vec![OpResult::fail(
+                self.name(),
+                None,
+                eyre!("no new group; CreateGroup + AddMembersToNewGroup must run first"),
+            )];
         };
 
         let start = Instant::now();
@@ -60,21 +55,19 @@ impl HealthOp for EnsurePerVersionMembership {
 
             // Materialize the full IdentityStore for this network once,
             // keyed by inbox. Avoids N+1 table scans in the loops below.
-            // Scoped so the redb handle drops before we re-open it below
-            // (redb refuses concurrent opens within a single process).
-            let identities: HashMap<InboxId, Identity> = {
-                let redb: Arc<redb::Database> = App::db()?;
-                let id_store: IdentityStore<'static> = redb.into();
-                id_store
-                    .load()?
-                    .into_iter()
-                    .flatten()
-                    .map(|g| {
-                        let id = g.value();
-                        (id.inbox_id, id)
-                    })
-                    .collect()
-            };
+            // Uses the context's redb handle — opening a second one
+            // would race the existing handle (redb refuses concurrent
+            // opens within a single process).
+            let identities: HashMap<InboxId, Identity> = ctx
+                .id_store
+                .load()?
+                .into_iter()
+                .flatten()
+                .map(|g| {
+                    let id = g.value();
+                    (id.inbox_id, id)
+                })
+                .collect();
 
             let present_versions: BTreeSet<u64> = updated_members
                 .iter()
@@ -84,15 +77,14 @@ impl HealthOp for EnsurePerVersionMembership {
             // First inbox per version_hash wins; primary represents the
             // current version, other_identities cover the rest.
             let mut version_representative: BTreeMap<u64, InboxId> = BTreeMap::new();
-            version_representative.insert(
-                App::current_version_hash(),
-                inbox_id_to_bytes(ctx.primary.inbox_id()),
-            );
-            for inbox in &ctx.other_identities {
-                if let Some(id) = identities.get(inbox) {
+            version_representative
+                .insert(App::current_version_hash(), ctx.primary.inbox_id_bytes());
+            for hc in &ctx.other_identities {
+                let inbox = hc.inbox_id_bytes();
+                if let Some(id) = identities.get(&inbox) {
                     version_representative
                         .entry(id.version_hash)
-                        .or_insert(*inbox);
+                        .or_insert(inbox);
                 }
             }
 
@@ -102,8 +94,8 @@ impl HealthOp for EnsurePerVersionMembership {
                 .map(|(_, inbox)| *inbox)
                 .collect();
 
-            let group = ctx
-                .primary
+            let primary = ctx.primary()?;
+            let group = primary
                 .group(&new_group_id)
                 .map_err(|e| eyre!("primary cannot load group: {e}"))?;
 
@@ -120,7 +112,7 @@ impl HealthOp for EnsurePerVersionMembership {
                 ctx.update_group_members(&new_group_id, updated_members);
                 // Welcomes aren't auto-pulled mid-run — sync so the new
                 // members can `client.group(...)` immediately.
-                ctx.sync_welcomes_fanout(self.name()).await;
+                ctx.sync_welcomes_fanout(self.name()).await?;
             }
 
             // Each version needs a locally-available super-admin so future
@@ -137,18 +129,12 @@ impl HealthOp for EnsurePerVersionMembership {
         }
         .await;
 
-        let (status, error) = match outcome {
-            Ok(_) => (Status::Pass, None),
-            Err(e) => (Status::Fail, Some(e)),
-        };
-
-        vec![OpResult {
-            op_name: self.name(),
-            target: Some(format!("{new_group_id}")),
-            status,
-            duration: start.elapsed(),
-            error,
-        }]
+        vec![OpResult::from_result(
+            self.name(),
+            Some(format!("{new_group_id}")),
+            start,
+            outcome,
+        )]
     }
 }
 

--- a/apps/xmtp_debug/src/app/health/ops/get_mutable_metadata.rs
+++ b/apps/xmtp_debug/src/app/health/ops/get_mutable_metadata.rs
@@ -3,9 +3,8 @@
 
 use crate::app::health::context::HealthContext;
 use crate::app::health::ops::HealthOp;
-use crate::app::health::result::{OpResult, Status};
+use crate::app::health::result::OpResult;
 use async_trait::async_trait;
-use std::time::Instant;
 
 pub struct GetMutableMetadata;
 
@@ -17,27 +16,11 @@ impl HealthOp for GetMutableMetadata {
 
     #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "GetMutableMetadata"))]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
-        let mut out = Vec::new();
-        for gid in ctx.all_groups() {
-            let start = Instant::now();
-            let outcome: color_eyre::eyre::Result<()> = (|| {
-                let group = ctx.primary.group(gid)?;
-                let _ = group.mutable_metadata()?;
-                Ok(())
-            })();
-            let (status, error) = match outcome {
-                Ok(_) => (Status::Pass, None),
-                Err(e) => (Status::Fail, Some(e)),
-            };
-            out.push(OpResult {
-                op_name: self.name(),
-                target: Some(format!("{gid}")),
-                status,
-                duration: start.elapsed(),
-                error,
-            });
-        }
-        out
+        ctx.for_each_group(self.name(), |primary, gid| async move {
+            primary.group(&gid)?.mutable_metadata()?;
+            Ok(())
+        })
+        .await
     }
 }
 

--- a/apps/xmtp_debug/src/app/health/ops/leave_group.rs
+++ b/apps/xmtp_debug/src/app/health/ops/leave_group.rs
@@ -92,6 +92,6 @@ inventory::submit! {
             "GetMutableMetadata",
         ],
         op: &LeaveGroup,
-        requires: crate::app::health::conditions::Conditions::ALWAYS,
+        requires: crate::app::health::conditions::Conditions::WRITES,
     }
 }

--- a/apps/xmtp_debug/src/app/health/ops/leave_group.rs
+++ b/apps/xmtp_debug/src/app/health/ops/leave_group.rs
@@ -8,10 +8,10 @@
 
 use crate::app::health::context::HealthContext;
 use crate::app::health::ops::HealthOp;
-use crate::app::health::result::{OpResult, Status};
+use crate::app::health::result::OpResult;
 use async_trait::async_trait;
 use color_eyre::eyre::eyre;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 pub struct LeaveGroup;
 
@@ -24,13 +24,11 @@ impl HealthOp for LeaveGroup {
     #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "LeaveGroup"))]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
         let Some(gid) = ctx.new_groups.first().cloned() else {
-            return vec![OpResult {
-                op_name: self.name(),
-                target: None,
-                status: Status::Fail,
-                duration: Duration::ZERO,
-                error: Some(eyre!("no new group to leave")),
-            }];
+            return vec![OpResult::fail(
+                self.name(),
+                None,
+                eyre!("no new group to leave"),
+            )];
         };
 
         let start = Instant::now();
@@ -42,7 +40,8 @@ impl HealthOp for LeaveGroup {
 
             // Primary adds the transient to the group, then transient
             // syncs the welcome and leaves.
-            let primary_group = ctx.primary.group(&gid)?;
+            let primary = ctx.primary()?;
+            let primary_group = primary.group(&gid)?;
             primary_group
                 .add_members(&[transient.inbox_id().to_string()])
                 .await?;
@@ -52,17 +51,12 @@ impl HealthOp for LeaveGroup {
             Ok(())
         }
         .await;
-        let (status, error) = match outcome {
-            Ok(_) => (Status::Pass, None),
-            Err(e) => (Status::Fail, Some(e)),
-        };
-        vec![OpResult {
-            op_name: self.name(),
-            target: Some(format!("{gid}")),
-            status,
-            duration: start.elapsed(),
-            error,
-        }]
+        vec![OpResult::from_result(
+            self.name(),
+            Some(format!("{gid}")),
+            start,
+            outcome,
+        )]
     }
 }
 

--- a/apps/xmtp_debug/src/app/health/ops/mod.rs
+++ b/apps/xmtp_debug/src/app/health/ops/mod.rs
@@ -12,6 +12,7 @@ use crate::app::health::result::OpResult;
 use async_trait::async_trait;
 
 mod add_members;
+mod bootstrap;
 mod create_dm;
 mod create_group;
 mod create_identity;

--- a/apps/xmtp_debug/src/app/health/ops/remove_member.rs
+++ b/apps/xmtp_debug/src/app/health/ops/remove_member.rs
@@ -9,10 +9,10 @@
 
 use crate::app::health::context::HealthContext;
 use crate::app::health::ops::HealthOp;
-use crate::app::health::result::{OpResult, Status};
+use crate::app::health::result::OpResult;
 use async_trait::async_trait;
 use color_eyre::eyre::eyre;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 pub struct RemoveMember;
 
@@ -25,13 +25,11 @@ impl HealthOp for RemoveMember {
     #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "RemoveMember"))]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
         let Some(gid) = ctx.new_groups.first().cloned() else {
-            return vec![OpResult {
-                op_name: self.name(),
-                target: None,
-                status: Status::Fail,
-                duration: Duration::ZERO,
-                error: Some(eyre!("no new group to remove from")),
-            }];
+            return vec![OpResult::fail(
+                self.name(),
+                None,
+                eyre!("no new group to remove from"),
+            )];
         };
 
         let start = Instant::now();
@@ -43,7 +41,8 @@ impl HealthOp for RemoveMember {
 
             // Primary adds the victim, then admin-removes them via
             // `remove_members`. Both commits go through primary.
-            let primary_group = ctx.primary.group(&gid)?;
+            let primary = ctx.primary()?;
+            let primary_group = primary.group(&gid)?;
             primary_group
                 .add_members(std::slice::from_ref(&victim_inbox))
                 .await?;
@@ -53,17 +52,12 @@ impl HealthOp for RemoveMember {
             Ok(())
         }
         .await;
-        let (status, error) = match outcome {
-            Ok(_) => (Status::Pass, None),
-            Err(e) => (Status::Fail, Some(e)),
-        };
-        vec![OpResult {
-            op_name: self.name(),
-            target: Some(format!("group={gid} victim={victim_label}")),
-            status,
-            duration: start.elapsed(),
-            error,
-        }]
+        vec![OpResult::from_result(
+            self.name(),
+            Some(format!("group={gid} victim={victim_label}")),
+            start,
+            outcome,
+        )]
     }
 }
 

--- a/apps/xmtp_debug/src/app/health/ops/remove_member.rs
+++ b/apps/xmtp_debug/src/app/health/ops/remove_member.rs
@@ -93,6 +93,6 @@ inventory::submit! {
             "GetMutableMetadata",
         ],
         op: &RemoveMember,
-        requires: crate::app::health::conditions::Conditions::ALWAYS,
+        requires: crate::app::health::conditions::Conditions::WRITES,
     }
 }

--- a/apps/xmtp_debug/src/app/health/ops/send_message.rs
+++ b/apps/xmtp_debug/src/app/health/ops/send_message.rs
@@ -4,72 +4,14 @@
 //! On success the message id is written to redb's `MessageStore` so the
 //! `NoMissingMessages` validator has an authoritative cross-version set.
 
-use crate::DbgClient;
 use crate::app::health::context::HealthContext;
 use crate::app::health::ops::HealthOp;
-use crate::app::health::result::{OpResult, Status};
+use crate::app::health::result::OpResult;
 use async_trait::async_trait;
 use color_eyre::eyre::eyre;
-use std::sync::Arc;
-use std::time::Instant;
 use xmtp_mls::groups::send_message_opts::SendMessageOpts;
-use xmtp_proto::types::GroupId;
 
 pub struct SendMessage;
-
-async fn send_one(
-    op_name: &'static str,
-    ctx: &HealthContext,
-    client: &Arc<DbgClient>,
-    gid: &GroupId,
-) -> OpResult {
-    let start = Instant::now();
-    // Non-membership = client.group(gid) errors. Treat as Pass: the
-    // client simply isn't in this group, so there's nothing to send.
-    // Distinguishes "no membership" from "send failed despite membership".
-    let group = match client.group(gid) {
-        Ok(g) => g,
-        Err(_) => {
-            return OpResult {
-                op_name,
-                target: Some(format!("inbox={} group={gid}", client.inbox_id())),
-                status: Status::Pass,
-                duration: start.elapsed(),
-                error: None,
-            };
-        }
-    };
-    let outcome: color_eyre::eyre::Result<Option<[u8; 32]>> = async {
-        if !group.is_active()? {
-            return Ok(None);
-        }
-        let body = format!("healthcheck from {}", client.inbox_id());
-        let message_id = group
-            .send_message(body.as_bytes(), SendMessageOpts::default())
-            .await?;
-        let id: [u8; 32] = message_id
-            .as_slice()
-            .try_into()
-            .map_err(|_| eyre!("libxmtp returned non-32-byte message_id"))?;
-        Ok(Some(id))
-    }
-    .await;
-    let (status, error) = match outcome {
-        Ok(Some(id)) => {
-            ctx.record_message(gid, id, client);
-            (Status::Pass, None)
-        }
-        Ok(None) => (Status::Pass, None),
-        Err(e) => (Status::Fail, Some(e)),
-    };
-    OpResult {
-        op_name,
-        target: Some(format!("inbox={} group={gid}", client.inbox_id())),
-        status,
-        duration: start.elapsed(),
-        error,
-    }
-}
 
 #[async_trait]
 impl HealthOp for SendMessage {
@@ -79,13 +21,29 @@ impl HealthOp for SendMessage {
 
     #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "SendMessage"))]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
-        let mut out = Vec::new();
-        for client in ctx.all_clients() {
-            for gid in ctx.all_groups() {
-                out.push(send_one(self.name(), ctx, &client, gid).await);
-            }
-        }
-        out
+        let ctx_ref = &*ctx;
+        ctx_ref
+            .for_each_client_group(self.name(), |client, gid| async move {
+                // Non-membership = client.group(gid) errors. Pass with no
+                // send so we distinguish "not in group" from "send broke".
+                let Ok(group) = client.group(&gid) else {
+                    return Ok(());
+                };
+                if !group.is_active()? {
+                    return Ok(());
+                }
+                let body = format!("healthcheck from {}", client.inbox_id());
+                let message_id = group
+                    .send_message(body.as_bytes(), SendMessageOpts::default())
+                    .await?;
+                let id: [u8; 32] = message_id
+                    .as_slice()
+                    .try_into()
+                    .map_err(|_| eyre!("libxmtp returned non-32-byte message_id"))?;
+                ctx_ref.record_message(&gid, id, &client);
+                Ok(())
+            })
+            .await
     }
 }
 

--- a/apps/xmtp_debug/src/app/health/ops/update_admin_list.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_admin_list.rs
@@ -2,9 +2,8 @@
 
 use crate::app::health::context::HealthContext;
 use crate::app::health::ops::HealthOp;
-use crate::app::health::result::{OpResult, Status};
+use crate::app::health::result::OpResult;
 use async_trait::async_trait;
-use std::time::Instant;
 use xmtp_mls::groups::UpdateAdminListType;
 
 /// Make Primary an Admin of all groups
@@ -18,33 +17,15 @@ impl HealthOp for UpdateAdminList {
 
     #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "UpdateAdminList"))]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
-        let mut out = Vec::new();
-        for gid in ctx.all_groups() {
-            let start = Instant::now();
-            let outcome: color_eyre::eyre::Result<()> = async {
-                let group = ctx.primary.group(gid)?;
-                group
-                    .update_admin_list(
-                        UpdateAdminListType::AddSuper,
-                        ctx.primary.inbox_id().to_string(),
-                    )
-                    .await?;
-                Ok(())
-            }
-            .await;
-            let (status, error) = match outcome {
-                Ok(_) => (Status::Pass, None),
-                Err(e) => (Status::Fail, Some(e)),
-            };
-            out.push(OpResult {
-                op_name: self.name(),
-                target: Some(format!("{gid}")),
-                status,
-                duration: start.elapsed(),
-                error,
-            });
-        }
-        out
+        ctx.for_each_group(self.name(), |primary, gid| async move {
+            let inbox = primary.inbox_id().to_string();
+            primary
+                .group(&gid)?
+                .update_admin_list(UpdateAdminListType::AddSuper, inbox)
+                .await?;
+            Ok(())
+        })
+        .await
     }
 }
 

--- a/apps/xmtp_debug/src/app/health/ops/update_admin_list.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_admin_list.rs
@@ -61,6 +61,6 @@ inventory::submit! {
     crate::app::health::ops::OpEntry {
         depends_on: &["AddMembersToNewGroup", "AddPrimaryToExistingGroups"],
         op: &UpdateAdminList,
-        requires: crate::app::health::conditions::Conditions::ALWAYS,
+        requires: crate::app::health::conditions::Conditions::WRITES,
     }
 }

--- a/apps/xmtp_debug/src/app/health/ops/update_app_data.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_app_data.rs
@@ -2,9 +2,8 @@
 
 use crate::app::health::context::HealthContext;
 use crate::app::health::ops::HealthOp;
-use crate::app::health::result::{OpResult, Status};
+use crate::app::health::result::OpResult;
 use async_trait::async_trait;
-use std::time::Instant;
 
 pub struct UpdateAppData;
 
@@ -16,28 +15,14 @@ impl HealthOp for UpdateAppData {
 
     #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "UpdateAppData"))]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
-        let mut out = Vec::new();
-        for gid in ctx.all_groups() {
-            let start = Instant::now();
-            let outcome: color_eyre::eyre::Result<()> = async {
-                let group = ctx.primary.group(gid)?;
-                group.update_app_data("healthcheck-app-data".into()).await?;
-                Ok(())
-            }
-            .await;
-            let (status, error) = match outcome {
-                Ok(_) => (Status::Pass, None),
-                Err(e) => (Status::Fail, Some(e)),
-            };
-            out.push(OpResult {
-                op_name: self.name(),
-                target: Some(format!("{gid}")),
-                status,
-                duration: start.elapsed(),
-                error,
-            });
-        }
-        out
+        ctx.for_each_group(self.name(), |primary, gid| async move {
+            primary
+                .group(&gid)?
+                .update_app_data("healthcheck-app-data".into())
+                .await?;
+            Ok(())
+        })
+        .await
     }
 }
 

--- a/apps/xmtp_debug/src/app/health/ops/update_app_data.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_app_data.rs
@@ -54,6 +54,6 @@ inventory::submit! {
     crate::app::health::ops::OpEntry {
         depends_on: &["AddMembersToNewGroup", "AddPrimaryToExistingGroups"],
         op: &UpdateAppData,
-        requires: crate::app::health::conditions::Conditions::ALWAYS,
+        requires: crate::app::health::conditions::Conditions::WRITES,
     }
 }

--- a/apps/xmtp_debug/src/app/health/ops/update_commit_log_signer.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_commit_log_signer.rs
@@ -2,9 +2,8 @@
 
 use crate::app::health::context::HealthContext;
 use crate::app::health::ops::HealthOp;
-use crate::app::health::result::{OpResult, Status};
+use crate::app::health::result::OpResult;
 use async_trait::async_trait;
-use std::time::Instant;
 use xmtp_cryptography::Secret;
 
 pub struct UpdateCommitLogSigner;
@@ -21,29 +20,15 @@ impl HealthOp for UpdateCommitLogSigner {
         fields(op = "UpdateCommitLogSigner")
     )]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
-        let mut out = Vec::new();
-        for gid in ctx.all_groups() {
-            let start = Instant::now();
-            let outcome: color_eyre::eyre::Result<()> = async {
-                let group = ctx.primary.group(gid)?;
-                let signer: Secret = vec![0u8; 32].into();
-                group.update_commit_log_signer(signer).await?;
-                Ok(())
-            }
-            .await;
-            let (status, error) = match outcome {
-                Ok(_) => (Status::Pass, None),
-                Err(e) => (Status::Fail, Some(e)),
-            };
-            out.push(OpResult {
-                op_name: self.name(),
-                target: Some(format!("{gid}")),
-                status,
-                duration: start.elapsed(),
-                error,
-            });
-        }
-        out
+        ctx.for_each_group(self.name(), |primary, gid| async move {
+            let signer: Secret = vec![0u8; 32].into();
+            primary
+                .group(&gid)?
+                .update_commit_log_signer(signer)
+                .await?;
+            Ok(())
+        })
+        .await
     }
 }
 

--- a/apps/xmtp_debug/src/app/health/ops/update_commit_log_signer.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_commit_log_signer.rs
@@ -61,6 +61,6 @@ inventory::submit! {
     crate::app::health::ops::OpEntry {
         depends_on: &["AddMembersToNewGroup", "AddPrimaryToExistingGroups"],
         op: &UpdateCommitLogSigner,
-        requires: crate::app::health::conditions::Conditions::ALWAYS,
+        requires: crate::app::health::conditions::Conditions::WRITES,
     }
 }

--- a/apps/xmtp_debug/src/app/health/ops/update_consent_state.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_consent_state.rs
@@ -5,9 +5,8 @@
 
 use crate::app::health::context::HealthContext;
 use crate::app::health::ops::HealthOp;
-use crate::app::health::result::{OpResult, Status};
+use crate::app::health::result::OpResult;
 use async_trait::async_trait;
-use std::time::Instant;
 use xmtp_db::consent_record::ConsentState;
 
 pub struct UpdateConsentState;
@@ -20,27 +19,13 @@ impl HealthOp for UpdateConsentState {
 
     #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "UpdateConsentState"))]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
-        let mut out = Vec::new();
-        for gid in ctx.all_groups() {
-            let start = Instant::now();
-            let outcome: color_eyre::eyre::Result<()> = (|| {
-                let group = ctx.primary.group(gid)?;
-                group.update_consent_state(ConsentState::Allowed)?;
-                Ok(())
-            })();
-            let (status, error) = match outcome {
-                Ok(_) => (Status::Pass, None),
-                Err(e) => (Status::Fail, Some(e)),
-            };
-            out.push(OpResult {
-                op_name: self.name(),
-                target: Some(format!("{gid}")),
-                status,
-                duration: start.elapsed(),
-                error,
-            });
-        }
-        out
+        ctx.for_each_group(self.name(), |primary, gid| async move {
+            primary
+                .group(&gid)?
+                .update_consent_state(ConsentState::Allowed)?;
+            Ok(())
+        })
+        .await
     }
 }
 
@@ -58,28 +43,14 @@ impl HealthOp for UpdateConsentStateQuiet {
         fields(op = "UpdateConsentStateQuiet")
     )]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
-        let mut out = Vec::new();
-        let db = ctx.primary.db();
-        for gid in ctx.all_groups() {
-            let start = Instant::now();
-            let outcome: color_eyre::eyre::Result<()> = (|| {
-                let group = ctx.primary.group(gid)?;
-                group.quietly_update_consent_state(ConsentState::Allowed, &db)?;
-                Ok(())
-            })();
-            let (status, error) = match outcome {
-                Ok(_) => (Status::Pass, None),
-                Err(e) => (Status::Fail, Some(e)),
-            };
-            out.push(OpResult {
-                op_name: self.name(),
-                target: Some(format!("{gid}")),
-                status,
-                duration: start.elapsed(),
-                error,
-            });
-        }
-        out
+        ctx.for_each_group(self.name(), |primary, gid| async move {
+            let db = primary.db();
+            primary
+                .group(&gid)?
+                .quietly_update_consent_state(ConsentState::Allowed, &db)?;
+            Ok(())
+        })
+        .await
     }
 }
 

--- a/apps/xmtp_debug/src/app/health/ops/update_consent_state.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_consent_state.rs
@@ -98,7 +98,7 @@ inventory::submit! {
     crate::app::health::ops::OpEntry {
         depends_on: &["AddMembersToNewGroup", "AddPrimaryToExistingGroups"],
         op: &UpdateConsentState,
-        requires: crate::app::health::conditions::Conditions::ALWAYS,
+        requires: crate::app::health::conditions::Conditions::WRITES,
     }
 }
 
@@ -106,6 +106,6 @@ inventory::submit! {
     crate::app::health::ops::OpEntry {
         depends_on: &["UpdateConsentState"],
         op: &UpdateConsentStateQuiet,
-        requires: crate::app::health::conditions::Conditions::ALWAYS,
+        requires: crate::app::health::conditions::Conditions::WRITES,
     }
 }

--- a/apps/xmtp_debug/src/app/health/ops/update_group_description.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_group_description.rs
@@ -2,9 +2,8 @@
 
 use crate::app::health::context::HealthContext;
 use crate::app::health::ops::HealthOp;
-use crate::app::health::result::{OpResult, Status};
+use crate::app::health::result::OpResult;
 use async_trait::async_trait;
-use std::time::Instant;
 
 pub struct UpdateGroupDescription;
 
@@ -20,30 +19,14 @@ impl HealthOp for UpdateGroupDescription {
         fields(op = "UpdateGroupDescription")
     )]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
-        let mut out = Vec::new();
-        for gid in ctx.all_groups() {
-            let start = Instant::now();
-            let outcome: color_eyre::eyre::Result<()> = async {
-                let group = ctx.primary.group(gid)?;
-                group
-                    .update_group_description("healthcheck-desc".into())
-                    .await?;
-                Ok(())
-            }
-            .await;
-            let (status, error) = match outcome {
-                Ok(_) => (Status::Pass, None),
-                Err(e) => (Status::Fail, Some(e)),
-            };
-            out.push(OpResult {
-                op_name: self.name(),
-                target: Some(format!("{gid}")),
-                status,
-                duration: start.elapsed(),
-                error,
-            });
-        }
-        out
+        ctx.for_each_group(self.name(), |primary, gid| async move {
+            primary
+                .group(&gid)?
+                .update_group_description("healthcheck-desc".into())
+                .await?;
+            Ok(())
+        })
+        .await
     }
 }
 

--- a/apps/xmtp_debug/src/app/health/ops/update_group_description.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_group_description.rs
@@ -60,6 +60,6 @@ inventory::submit! {
     crate::app::health::ops::OpEntry {
         depends_on: &["AddMembersToNewGroup", "AddPrimaryToExistingGroups"],
         op: &UpdateGroupDescription,
-        requires: crate::app::health::conditions::Conditions::ALWAYS,
+        requires: crate::app::health::conditions::Conditions::WRITES,
     }
 }

--- a/apps/xmtp_debug/src/app/health/ops/update_group_image_url.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_group_image_url.rs
@@ -63,6 +63,6 @@ inventory::submit! {
     crate::app::health::ops::OpEntry {
         depends_on: &["AddMembersToNewGroup", "AddPrimaryToExistingGroups"],
         op: &UpdateGroupImageUrlSquare,
-        requires: crate::app::health::conditions::Conditions::ALWAYS,
+        requires: crate::app::health::conditions::Conditions::WRITES,
     }
 }

--- a/apps/xmtp_debug/src/app/health/ops/update_group_image_url.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_group_image_url.rs
@@ -2,9 +2,8 @@
 
 use crate::app::health::context::HealthContext;
 use crate::app::health::ops::HealthOp;
-use crate::app::health::result::{OpResult, Status};
+use crate::app::health::result::OpResult;
 use async_trait::async_trait;
-use std::time::Instant;
 
 pub struct UpdateGroupImageUrlSquare;
 
@@ -20,30 +19,14 @@ impl HealthOp for UpdateGroupImageUrlSquare {
         fields(op = "UpdateGroupImageUrlSquare")
     )]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
-        let mut out = Vec::new();
-        for gid in ctx.all_groups() {
-            let start = Instant::now();
-            let outcome: color_eyre::eyre::Result<()> = async {
-                let group = ctx.primary.group(gid)?;
-                group
-                    .update_group_image_url_square("https://example.invalid/img.png".into())
-                    .await?;
-                Ok(())
-            }
-            .await;
-            let (status, error) = match outcome {
-                Ok(_) => (Status::Pass, None),
-                Err(e) => (Status::Fail, Some(e)),
-            };
-            out.push(OpResult {
-                op_name: self.name(),
-                target: Some(format!("{gid}")),
-                status,
-                duration: start.elapsed(),
-                error,
-            });
-        }
-        out
+        ctx.for_each_group(self.name(), |primary, gid| async move {
+            primary
+                .group(&gid)?
+                .update_group_image_url_square("https://example.invalid/img.png".into())
+                .await?;
+            Ok(())
+        })
+        .await
     }
 }
 

--- a/apps/xmtp_debug/src/app/health/ops/update_group_name.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_group_name.rs
@@ -2,9 +2,8 @@
 
 use crate::app::health::context::HealthContext;
 use crate::app::health::ops::HealthOp;
-use crate::app::health::result::{OpResult, Status};
+use crate::app::health::result::OpResult;
 use async_trait::async_trait;
-use std::time::Instant;
 
 pub struct UpdateGroupName;
 
@@ -16,28 +15,14 @@ impl HealthOp for UpdateGroupName {
 
     #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "UpdateGroupName"))]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
-        let mut out = Vec::new();
-        for gid in ctx.all_groups() {
-            let start = Instant::now();
-            let outcome: color_eyre::eyre::Result<()> = async {
-                let group = ctx.primary.group(gid)?;
-                group.update_group_name("healthcheck-name".into()).await?;
-                Ok(())
-            }
-            .await;
-            let (status, error) = match outcome {
-                Ok(_) => (Status::Pass, None),
-                Err(e) => (Status::Fail, Some(e)),
-            };
-            out.push(OpResult {
-                op_name: self.name(),
-                target: Some(format!("{gid}")),
-                status,
-                duration: start.elapsed(),
-                error,
-            });
-        }
-        out
+        ctx.for_each_group(self.name(), |primary, gid| async move {
+            primary
+                .group(&gid)?
+                .update_group_name("healthcheck-name".into())
+                .await?;
+            Ok(())
+        })
+        .await
     }
 }
 

--- a/apps/xmtp_debug/src/app/health/ops/update_group_name.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_group_name.rs
@@ -54,6 +54,6 @@ inventory::submit! {
     crate::app::health::ops::OpEntry {
         depends_on: &["AddMembersToNewGroup", "AddPrimaryToExistingGroups"],
         op: &UpdateGroupName,
-        requires: crate::app::health::conditions::Conditions::ALWAYS,
+        requires: crate::app::health::conditions::Conditions::WRITES,
     }
 }

--- a/apps/xmtp_debug/src/app/health/ops/update_message_disappearing.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_message_disappearing.rs
@@ -111,7 +111,7 @@ inventory::submit! {
     crate::app::health::ops::OpEntry {
         depends_on: &["AddMembersToNewGroup", "AddPrimaryToExistingGroups"],
         op: &UpdateMessageDisappearing,
-        requires: crate::app::health::conditions::Conditions::ALWAYS,
+        requires: crate::app::health::conditions::Conditions::WRITES,
     }
 }
 
@@ -119,6 +119,6 @@ inventory::submit! {
     crate::app::health::ops::OpEntry {
         depends_on: &["UpdateMessageDisappearing"],
         op: &RemoveMessageDisappearing,
-        requires: crate::app::health::conditions::Conditions::ALWAYS,
+        requires: crate::app::health::conditions::Conditions::WRITES,
     }
 }

--- a/apps/xmtp_debug/src/app/health/ops/update_message_disappearing.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_message_disappearing.rs
@@ -2,9 +2,8 @@
 
 use crate::app::health::context::HealthContext;
 use crate::app::health::ops::HealthOp;
-use crate::app::health::result::{OpResult, Status};
+use crate::app::health::result::OpResult;
 use async_trait::async_trait;
-use std::time::Instant;
 use xmtp_mls_common::group_mutable_metadata::MessageDisappearingSettings;
 
 pub struct UpdateMessageDisappearing;
@@ -21,32 +20,16 @@ impl HealthOp for UpdateMessageDisappearing {
         fields(op = "UpdateMessageDisappearing")
     )]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
-        let mut out = Vec::new();
-        for gid in ctx.all_groups() {
-            let start = Instant::now();
-            let outcome: color_eyre::eyre::Result<()> = async {
-                let group = ctx.primary.group(gid)?;
-                group
-                    .update_conversation_message_disappearing_settings(
-                        MessageDisappearingSettings::new(1, 86_400_000_000_000),
-                    )
-                    .await?;
-                Ok(())
-            }
-            .await;
-            let (status, error) = match outcome {
-                Ok(_) => (Status::Pass, None),
-                Err(e) => (Status::Fail, Some(e)),
-            };
-            out.push(OpResult {
-                op_name: self.name(),
-                target: Some(format!("{gid}")),
-                status,
-                duration: start.elapsed(),
-                error,
-            });
-        }
-        out
+        ctx.for_each_group(self.name(), |primary, gid| async move {
+            primary
+                .group(&gid)?
+                .update_conversation_message_disappearing_settings(
+                    MessageDisappearingSettings::new(1, 86_400_000_000_000),
+                )
+                .await?;
+            Ok(())
+        })
+        .await
     }
 }
 
@@ -64,30 +47,14 @@ impl HealthOp for RemoveMessageDisappearing {
         fields(op = "RemoveMessageDisappearing")
     )]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
-        let mut out = Vec::new();
-        for gid in ctx.all_groups() {
-            let start = Instant::now();
-            let outcome: color_eyre::eyre::Result<()> = async {
-                let group = ctx.primary.group(gid)?;
-                group
-                    .remove_conversation_message_disappearing_settings()
-                    .await?;
-                Ok(())
-            }
-            .await;
-            let (status, error) = match outcome {
-                Ok(_) => (Status::Pass, None),
-                Err(e) => (Status::Fail, Some(e)),
-            };
-            out.push(OpResult {
-                op_name: self.name(),
-                target: Some(format!("{gid}")),
-                status,
-                duration: start.elapsed(),
-                error,
-            });
-        }
-        out
+        ctx.for_each_group(self.name(), |primary, gid| async move {
+            primary
+                .group(&gid)?
+                .remove_conversation_message_disappearing_settings()
+                .await?;
+            Ok(())
+        })
+        .await
     }
 }
 

--- a/apps/xmtp_debug/src/app/health/ops/update_permission_policy.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_permission_policy.rs
@@ -2,9 +2,8 @@
 
 use crate::app::health::context::HealthContext;
 use crate::app::health::ops::HealthOp;
-use crate::app::health::result::{OpResult, Status};
+use crate::app::health::result::OpResult;
 use async_trait::async_trait;
-use std::time::Instant;
 use xmtp_mls::groups::intents::{PermissionPolicyOption, PermissionUpdateType};
 
 pub struct UpdatePermissionPolicy;
@@ -21,34 +20,18 @@ impl HealthOp for UpdatePermissionPolicy {
         fields(op = "UpdatePermissionPolicy")
     )]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
-        let mut out = Vec::new();
-        for gid in ctx.all_groups() {
-            let start = Instant::now();
-            let outcome: color_eyre::eyre::Result<()> = async {
-                let group = ctx.primary.group(gid)?;
-                group
-                    .update_permission_policy(
-                        PermissionUpdateType::AddMember,
-                        PermissionPolicyOption::Allow,
-                        None,
-                    )
-                    .await?;
-                Ok(())
-            }
-            .await;
-            let (status, error) = match outcome {
-                Ok(_) => (Status::Pass, None),
-                Err(e) => (Status::Fail, Some(e)),
-            };
-            out.push(OpResult {
-                op_name: self.name(),
-                target: Some(format!("{gid}")),
-                status,
-                duration: start.elapsed(),
-                error,
-            });
-        }
-        out
+        ctx.for_each_group(self.name(), |primary, gid| async move {
+            primary
+                .group(&gid)?
+                .update_permission_policy(
+                    PermissionUpdateType::AddMember,
+                    PermissionPolicyOption::Allow,
+                    None,
+                )
+                .await?;
+            Ok(())
+        })
+        .await
     }
 }
 

--- a/apps/xmtp_debug/src/app/health/ops/update_permission_policy.rs
+++ b/apps/xmtp_debug/src/app/health/ops/update_permission_policy.rs
@@ -65,6 +65,6 @@ inventory::submit! {
     crate::app::health::ops::OpEntry {
         depends_on: &["AddMembersToNewGroup", "AddPrimaryToExistingGroups"],
         op: &UpdatePermissionPolicy,
-        requires: crate::app::health::conditions::Conditions::ALWAYS,
+        requires: crate::app::health::conditions::Conditions::WRITES,
     }
 }

--- a/apps/xmtp_debug/src/app/health/ops/upload_key_package.rs
+++ b/apps/xmtp_debug/src/app/health/ops/upload_key_package.rs
@@ -57,6 +57,6 @@ inventory::submit! {
     crate::app::health::ops::OpEntry {
         depends_on: &[],
         op: &UploadKeyPackage,
-        requires: crate::app::health::conditions::Conditions::ALWAYS,
+        requires: crate::app::health::conditions::Conditions::WRITES,
     }
 }

--- a/apps/xmtp_debug/src/app/health/ops/upload_key_package.rs
+++ b/apps/xmtp_debug/src/app/health/ops/upload_key_package.rs
@@ -4,11 +4,9 @@
 
 use crate::app::health::context::HealthContext;
 use crate::app::health::ops::HealthOp;
-use crate::app::health::result::{OpResult, Status};
+use crate::app::health::result::OpResult;
 use async_trait::async_trait;
 use color_eyre::eyre::eyre;
-use futures::future::join_all;
-use std::time::Instant;
 
 pub struct UploadKeyPackage;
 
@@ -20,26 +18,14 @@ impl HealthOp for UploadKeyPackage {
 
     #[tracing::instrument(target = "healthcheck.op", skip_all, fields(op = "UploadKeyPackage"))]
     async fn execute(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
-        let name = self.name();
-        let tasks = ctx
-            .existing_clients
-            .iter()
-            .map(|(inbox_id, client)| async move {
-                let start = Instant::now();
-                let outcome = client.rotate_and_upload_key_package().await;
-                let (status, error) = match outcome {
-                    Ok(_) => (Status::Pass, None),
-                    Err(e) => (Status::Fail, Some(eyre!("{e}"))),
-                };
-                OpResult {
-                    op_name: name,
-                    target: Some(hex::encode(inbox_id)),
-                    status,
-                    duration: start.elapsed(),
-                    error,
-                }
-            });
-        join_all(tasks).await
+        ctx.for_each_client(self.name(), |client| async move {
+            client
+                .rotate_and_upload_key_package()
+                .await
+                .map_err(|e| eyre!("{e}"))?;
+            Ok(())
+        })
+        .await
     }
 }
 

--- a/apps/xmtp_debug/src/app/health/registry.rs
+++ b/apps/xmtp_debug/src/app/health/registry.rs
@@ -86,35 +86,25 @@ fn partition_by_conditions<E: RegistryEntry>(
     })
 }
 
-/// Panic if any runnable entry depends on a name that either doesn't
-/// exist or was filtered out as skipped. A runnable depending on a
-/// skipped is a configuration bug — gate the dependent on the same
-/// condition or drop the dependency.
+/// Panic if any runnable entry depends on a name that doesn't exist
+/// in the registry at all. Deps on entries that *were* skipped by the
+/// active condition set are treated as advisory: the dep is honored
+/// when the upstream runs, dropped when it doesn't. Lets read-only
+/// ops declare "after AddMembers if AddMembers runs" without forcing
+/// AddMembers to run.
 fn validate_deps<E: RegistryEntry>(
     runnable: &BTreeMap<&'static str, &'static E>,
     skipped: &[SkippedEntry],
 ) where
     E::Item: Named,
 {
-    // Flatten (entry, dep) pairs, stop at the first missing dep.
+    let skipped_names: std::collections::BTreeSet<&str> = skipped.iter().map(|s| s.name).collect();
     let bad = runnable
         .values()
         .flat_map(|e| e.depends_on().iter().map(move |d| (e, d)))
-        .find(|(_, dep)| !runnable.contains_key(*dep));
+        .find(|(_, dep)| !runnable.contains_key(*dep) && !skipped_names.contains(*dep));
 
     let Some((e, dep)) = bad else { return };
-    if let Some(sk) = skipped.iter().find(|s| s.name == *dep) {
-        panic!(
-            "{} '{}' depends on {} '{}' which was skipped (missing {:?}). \
-             Either gate '{}' on the same condition or drop the dependency.",
-            E::KIND,
-            e.value().name(),
-            E::KIND,
-            dep,
-            sk.missing,
-            e.value().name(),
-        );
-    }
     panic!(
         "{} '{}' depends on unknown {} '{}'",
         E::KIND,
@@ -131,9 +121,18 @@ fn topo_order<E: RegistryEntry>(runnable: &BTreeMap<&'static str, &'static E>) -
 where
     E::Item: Named,
 {
+    // Only count deps that are themselves in the runnable set; deps on
+    // skipped entries are advisory and don't gate ordering here.
     let mut in_degree: BTreeMap<&'static str, usize> = runnable
         .iter()
-        .map(|(n, e)| (*n, e.depends_on().len()))
+        .map(|(n, e)| {
+            let count = e
+                .depends_on()
+                .iter()
+                .filter(|d| runnable.contains_key(*d))
+                .count();
+            (*n, count)
+        })
         .collect();
     let mut ready: BTreeSet<&'static str> = in_degree
         .iter()

--- a/apps/xmtp_debug/src/app/health/result.rs
+++ b/apps/xmtp_debug/src/app/health/result.rs
@@ -1,6 +1,6 @@
 //! Op and validator result types.
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use owo_colors::OwoColorize;
 
@@ -81,8 +81,6 @@ impl Default for Report {
 }
 
 impl OpResult {
-    /// Print a one-line `[✓]`/`[✗]` summary to stdout. Use [`Self::emit`]
-    /// to additionally fire a structured `tracing` event.
     /// Construct a `Skipped` result for an op that wasn't run because
     /// its declared conditions weren't all active. `missing` is the
     /// difference between `requires` and the active set.
@@ -96,6 +94,44 @@ impl OpResult {
             status: Status::Skipped(missing),
             duration: Duration::ZERO,
             error: None,
+        }
+    }
+
+    /// Bridge a `Result<()>` into an `OpResult`: `Ok` → Pass, `Err` → Fail.
+    /// `start` lets the runner record per-iteration latency.
+    pub fn from_result(
+        op_name: &'static str,
+        target: Option<String>,
+        start: Instant,
+        res: color_eyre::eyre::Result<()>,
+    ) -> Self {
+        let (status, error) = match res {
+            Ok(_) => (Status::Pass, None),
+            Err(e) => (Status::Fail, Some(e)),
+        };
+        Self {
+            op_name,
+            target,
+            status,
+            duration: start.elapsed(),
+            error,
+        }
+    }
+
+    /// Construct a `Fail` result with zero duration. Used by runner
+    /// helpers when pre-loop setup (primary materialization,
+    /// `all_clients()`) fails before any iteration starts.
+    pub fn fail(
+        op_name: &'static str,
+        target: Option<String>,
+        error: color_eyre::eyre::Report,
+    ) -> Self {
+        Self {
+            op_name,
+            target,
+            status: Status::Fail,
+            duration: Duration::ZERO,
+            error: Some(error),
         }
     }
 

--- a/apps/xmtp_debug/src/app/health/validators/no_forks.rs
+++ b/apps/xmtp_debug/src/app/health/validators/no_forks.rs
@@ -27,8 +27,20 @@ impl Validator for NoForkedGroups {
         fields(op = "NoForkedGroups")
     )]
     async fn validate(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
+        let clients = match ctx.all_clients() {
+            Ok(cs) => cs,
+            Err(e) => {
+                return vec![OpResult {
+                    op_name: self.name(),
+                    target: None,
+                    status: Status::Fail,
+                    duration: std::time::Duration::ZERO,
+                    error: Some(e),
+                }];
+            }
+        };
         let mut out = Vec::new();
-        for client in ctx.all_clients() {
+        for client in &clients {
             let db = client.db();
 
             // Force a reconciliation pass so fork status reflects what's on

--- a/apps/xmtp_debug/src/app/health/validators/no_missing_messages.rs
+++ b/apps/xmtp_debug/src/app/health/validators/no_missing_messages.rs
@@ -26,7 +26,18 @@ impl Validator for NoMissingMessages {
     )]
     async fn validate(&self, ctx: &mut HealthContext) -> Vec<OpResult> {
         let mut out = Vec::new();
-        let clients = ctx.all_clients();
+        let clients = match ctx.all_clients() {
+            Ok(cs) => cs,
+            Err(e) => {
+                return vec![OpResult {
+                    op_name: self.name(),
+                    target: None,
+                    status: Status::Fail,
+                    duration: std::time::Duration::ZERO,
+                    error: Some(e),
+                }];
+            }
+        };
         // Load everything once — `recorded_messages` per-group would
         // rescan the whole network per iteration.
         let by_group = ctx.recorded_messages_by_group();

--- a/apps/xmtp_debug/src/app/info.rs
+++ b/apps/xmtp_debug/src/app/info.rs
@@ -2,23 +2,21 @@
 
 use crate::app::App;
 use crate::app::store::{Database, MetadataStore};
-use crate::args;
+use crate::{args, meta_key};
 use valuable::Valuable;
 
 use color_eyre::eyre::Result;
 
 pub struct Info {
-    opts: args::InfoOpts,
+    opts: &'static args::InfoOpts,
     metadata_store: MetadataStore<'static>,
-    network: args::BackendOpts,
 }
 
 impl Info {
-    pub fn new(opts: args::InfoOpts, network: args::BackendOpts) -> Result<Self> {
+    pub fn new(opts: &'static args::InfoOpts) -> Result<Self> {
         let db = App::readonly_db()?;
         Ok(Self {
             opts,
-            network,
             metadata_store: db.into(),
         })
     }
@@ -41,12 +39,12 @@ impl Info {
     fn app(&self) -> Result<()> {
         let metadata = self
             .metadata_store
-            .get((&self.network).into())
+            .get(meta_key!())
             .ok()
             .flatten()
             .unwrap_or(Default::default());
 
-        let sqlite_stores = crate::app::App::db_directory(&self.network)?;
+        let sqlite_stores = crate::app::App::db_directory()?;
         let db_dir_size = fs_extra::dir::get_size(&sqlite_stores)? / 1_000 / 1_000;
         info!(
             metadata.identities,

--- a/apps/xmtp_debug/src/app/inspect.rs
+++ b/apps/xmtp_debug/src/app/inspect.rs
@@ -9,34 +9,33 @@ use crate::{
 
 pub struct Inspect {
     db: Arc<redb::ReadOnlyDatabase>,
-    opts: args::Inspect,
-    network: args::BackendOpts,
+    opts: &'static args::Inspect,
 }
 
 impl Inspect {
-    pub fn new(opts: args::Inspect, network: args::BackendOpts) -> Result<Self> {
+    pub fn new(opts: &'static args::Inspect) -> Result<Self> {
         let db = App::readonly_db()?;
-        Ok(Self { opts, network, db })
+        Ok(Self { opts, db })
     }
 
     pub async fn run(self) -> Result<()> {
         use args::InspectionKind::*;
-        let Inspect { db, opts, network } = self;
+        let Inspect { db, opts } = self;
 
         let identity_store: IdentityStore = db.clone().into();
 
         let args::Inspect { kind, inbox_id } = opts;
-        let identity = identity_store.find_by_inbox(u64::from(&network), *inbox_id)?;
+        let identity = identity_store.find_by_inbox(**inbox_id)?;
         if identity.is_none() {
             bail!("No local identity with inbox_id=[{}]", inbox_id);
         }
-        let client = app::client_from_identity(&identity.expect("checked for none"), &network)?;
+        let client = app::client_from_identity(&identity.expect("checked for none"))?;
         let conn = client.context.store().db();
         match kind {
             Associations => {
                 let state = client
                     .identity_updates()
-                    .get_latest_association_state(&conn, &hex::encode(*inbox_id))
+                    .get_latest_association_state(&conn, &hex::encode(**inbox_id))
                     .await?;
 
                 let idents: Vec<_> = state

--- a/apps/xmtp_debug/src/app/modify.rs
+++ b/apps/xmtp_debug/src/app/modify.rs
@@ -102,7 +102,7 @@ impl Modify {
                 group
                     .update_admin_list(UpdateAdminListType::AddSuper, inbox_id.to_string())
                     .await?;
-                if !local_group.has_member(&inbox_id) {
+                if !local_group.has_member(inbox_id) {
                     local_group.member_size += 1;
                     local_group.members.push(**inbox_id);
                 }

--- a/apps/xmtp_debug/src/app/modify.rs
+++ b/apps/xmtp_debug/src/app/modify.rs
@@ -14,19 +14,18 @@ use crate::{
 
 pub struct Modify {
     db: Arc<redb::Database>,
-    opts: args::Modify,
-    network: args::BackendOpts,
+    opts: &'static args::Modify,
 }
 
 impl Modify {
-    pub fn new(opts: args::Modify, network: args::BackendOpts) -> Result<Self> {
+    pub fn new(opts: &'static args::Modify) -> Result<Self> {
         let db = App::db()?;
-        Ok(Self { opts, network, db })
+        Ok(Self { opts, db })
     }
 
     pub async fn run(self) -> Result<()> {
         use args::MemberModificationKind::*;
-        let Modify { db, opts, network } = self;
+        let Modify { db, opts } = self;
 
         let identity_store: IdentityStore = db.clone().into();
         let group_store: GroupStore = db.clone().into();
@@ -37,33 +36,26 @@ impl Modify {
             include_versions,
             promote_super_admin,
         } = opts;
-        let key = (u64::from(&network), *group_id);
         let mut local_group = group_store
-            .get(key.into())?
+            .get((*group_id).into())?
             .ok_or_else(|| eyre!("no local group found for id=[{}]", hex::encode(*group_id)))?;
 
         // `AddFromRedb` manages its own actor selection; skip the shared setup.
         if matches!(action, AddFromRedb) {
-            add_members_from_redb(
-                &local_group,
-                &network,
-                &db,
-                include_versions,
-                promote_super_admin,
-            )
-            .await?;
+            add_members_from_redb(&local_group, &db, *include_versions, *promote_super_admin)
+                .await?;
             return Ok(());
         }
 
         let identity = identity_store
-            .find_by_inbox(u64::from(&network), local_group.created_by)?
+            .find_by_inbox(local_group.created_by)?
             .ok_or_else(|| {
                 eyre!(
                     "no local identity found for inbox_id=[{}]",
                     hex::encode(local_group.created_by)
                 )
             })?;
-        let admin = app::client_from_identity(&identity, &network)?;
+        let admin = app::client_from_identity(&identity)?;
         let group = admin.group(&local_group.id())?;
         match action {
             Remove => {
@@ -71,11 +63,11 @@ impl Modify {
                     bail!("Inbox ID to remove must be specified")
                 };
                 local_group.member_size -= 1;
-                local_group.members.retain(|m| *m != *inbox_id);
-                group.remove_members(&[&hex::encode(*inbox_id)]).await?;
-                group_store.set(local_group, &network)?;
+                local_group.members.retain(|m| *m != **inbox_id);
+                group.remove_members(&[&inbox_id.to_string()]).await?;
+                group_store.set(local_group)?;
                 info!(
-                    removed_inbox_id = hex::encode(*inbox_id),
+                    removed_inbox_id = %inbox_id,
                     admin_inbox_id = admin.inbox_id(),
                     "member removed"
                 );
@@ -84,7 +76,7 @@ impl Modify {
                 let rng = &mut SmallRng::from_rng(&mut rand::rng());
                 // Pick an identity NOT already in the group (we're adding a new member).
                 let identity = identity_store
-                    .load(&network)?
+                    .load()?
                     .ok_or_else(|| eyre!("no identities in store"))?
                     .map(|i| i.value())
                     .filter(|identity| !local_group.has_member(&identity.inbox_id))
@@ -98,13 +90,13 @@ impl Modify {
                     group_id = %local_group.id(),
                     "Member added"
                 );
-                group_store.set(local_group, &network)?;
+                group_store.set(local_group)?;
             }
             AddExternal => {
                 let Some(inbox_id) = inbox_id else {
                     bail!("Inbox ID to add must be specified")
                 };
-                group.add_members(&[hex::encode(*inbox_id)]).await.context(
+                group.add_members(&[inbox_id.to_string()]).await.context(
                     "the identity/inbox_id might not exist for this network in the local database",
                 )?;
                 group
@@ -112,15 +104,15 @@ impl Modify {
                     .await?;
                 if !local_group.has_member(&inbox_id) {
                     local_group.member_size += 1;
-                    local_group.members.push(*inbox_id);
+                    local_group.members.push(**inbox_id);
                 }
                 info!(
-                    inbox_id = hex::encode(*inbox_id),
+                    inbox_id = %inbox_id,
                     group_id = %local_group.id(),
                     added_by = hex::encode(identity.inbox_id),
                     "Member added as Super Admin"
                 );
-                group_store.set(local_group, &network)?;
+                group_store.set(local_group)?;
             }
             AddFromRedb => unreachable!("AddFromRedb is dispatched before the shared actor setup"),
         }
@@ -131,7 +123,6 @@ impl Modify {
 
 async fn add_members_from_redb(
     local_group: &Group,
-    network: &args::BackendOpts,
     db: &Arc<redb::Database>,
     include_versions: args::IncludeVersions,
     promote_super_admin: bool,
@@ -139,11 +130,10 @@ async fn add_members_from_redb(
     use args::IncludeVersions;
 
     let id_store: IdentityStore<'static> = db.clone().into();
-    let net_key = u64::from(network);
     let current_vh = App::current_version_hash();
 
     let candidates: Vec<Identity> = id_store
-        .load(net_key)?
+        .load()?
         .ok_or_else(|| eyre!("no identities in store"))?
         .map(|guard| guard.value())
         .filter(|id| match include_versions {
@@ -168,7 +158,7 @@ async fn add_members_from_redb(
         .iter()
         .find_map(|inbox| {
             id_store
-                .find_by_inbox(net_key, *inbox)
+                .find_by_inbox(*inbox)
                 .ok()
                 .flatten()
                 .filter(|id| id.version_hash == current_vh)
@@ -181,7 +171,7 @@ async fn add_members_from_redb(
                 current_vh
             )
         })?;
-    let actor_client = app::client_from_identity(&actor_identity, network)?;
+    let actor_client = app::client_from_identity(&actor_identity)?;
     let group = actor_client.group(&local_group.id())?;
 
     let inbox_ids: Vec<String> = candidates
@@ -199,7 +189,6 @@ async fn add_members_from_redb(
         local_group
             .clone()
             .add_members(candidates.iter().map(|c| c.inbox_id)),
-        u64::from(network),
     )?;
 
     if promote_super_admin {

--- a/apps/xmtp_debug/src/app/query.rs
+++ b/apps/xmtp_debug/src/app/query.rs
@@ -18,15 +18,15 @@ use xmtp_proto::{
 };
 
 pub struct Query {
-    opts: args::Query,
-    #[allow(unused)]
+    opts: &'static args::Query,
     network: args::BackendOpts,
     db: Arc<redb::ReadOnlyDatabase>,
 }
 
 impl Query {
-    pub fn new(opts: args::Query, network: args::BackendOpts) -> Result<Self> {
+    pub fn new(opts: &'static args::Query) -> Result<Self> {
         let db = App::readonly_db()?;
+        let network = App::network().clone();
         Ok(Self { opts, network, db })
     }
 
@@ -196,9 +196,8 @@ impl Query {
     /// get all keypackages for installation keys in the app database
     pub async fn all_key_packages(&self) -> Result<()> {
         let store: IdentityStore = self.db.clone().into();
-        let network = u64::from(&self.network);
         let identities = store
-            .load(network)?
+            .load()?
             .ok_or(eyre!("no identities in db, try generating some"))?;
         let keys: Vec<[u8; 32]> = identities
             .map(|i| {
@@ -228,9 +227,8 @@ impl Query {
 
     pub async fn welcomes(&self) -> Result<()> {
         let store: IdentityStore = self.db.clone().into();
-        let network = u64::from(&self.network);
         let identities = store
-            .load(network)?
+            .load()?
             .ok_or(eyre!("no identities in db, try generating some"))?;
 
         let installations: Vec<([u8; 32], [u8; 32])> = identities

--- a/apps/xmtp_debug/src/app/send.rs
+++ b/apps/xmtp_debug/src/app/send.rs
@@ -9,19 +9,18 @@ use super::store::{Database, GroupStore, IdentityStore};
 
 pub struct Send {
     db: Arc<redb::ReadOnlyDatabase>,
-    opts: args::Send,
-    network: args::BackendOpts,
+    opts: &'static args::Send,
 }
 
 impl Send {
-    pub fn new(opts: args::Send, network: args::BackendOpts) -> Result<Self> {
+    pub fn new(opts: &'static args::Send) -> Result<Self> {
         let db = App::readonly_db()?;
-        Ok(Self { opts, network, db })
+        Ok(Self { opts, db })
     }
 
     pub async fn run(self) -> Result<()> {
         use args::ActionKind::*;
-        let args::Send { ref action, .. } = self.opts;
+        let args::Send { action, .. } = self.opts;
 
         match action {
             Message => self.message().await,
@@ -29,24 +28,22 @@ impl Send {
     }
 
     async fn message(&self) -> Result<()> {
-        let Self { network, .. } = self;
         let args::Send { data, group_id, .. } = &self.opts;
 
         let group_store: GroupStore = self.db.clone().into();
         let identity_store: IdentityStore = self.db.clone().into();
-        let key = (u64::from(network), **group_id);
         let group = group_store
-            .get(key.into())?
+            .get(group_id.into())?
             .ok_or(eyre!("No group with id {}", group_id))?;
         let member = group
             .members
             .choose(&mut rand::rng())
             .ok_or(eyre!("Empty group, no members to send message!"))?;
         let identity = identity_store
-            .find_by_inbox(u64::from(network), *member)?
+            .find_by_inbox(*member)?
             .ok_or(eyre!("No Identity with inbox_id [{}]", hex::encode(member)))?;
 
-        let client = crate::app::client_from_identity(&identity, network)?;
+        let client = crate::app::client_from_identity(&identity)?;
         client.sync_welcomes().await?;
         let xmtp_group = client.group(&group.id())?;
         xmtp_group

--- a/apps/xmtp_debug/src/app/store.rs
+++ b/apps/xmtp_debug/src/app/store.rs
@@ -1,3 +1,4 @@
+mod dms;
 mod groups;
 mod identity;
 mod messages;
@@ -14,6 +15,8 @@ pub use groups::*;
 pub use identity::*;
 pub use messages::*;
 pub use metadata::*;
+
+use crate::app::App;
 
 /// Open a read-only table, treating `TableDoesNotExist` as a legitimate
 /// empty case (returns `Ok(None)`). Any other table error (type mismatch,
@@ -41,36 +44,30 @@ pub struct NetworkKey<const N: usize> {
 }
 
 impl<const N: usize> NetworkKey<N> {
-    pub fn new(network: u64, key: impl Into<[u8; N]>) -> Self {
+    pub fn new(key: impl Into<[u8; N]>) -> Self {
         Self {
-            network,
+            network: App::network().hash(),
             key: key.into(),
         }
     }
 }
 
-impl<const N: usize> From<(u64, [u8; N])> for NetworkKey<N> {
-    fn from(value: (u64, [u8; N])) -> Self {
+impl<const N: usize> From<[u8; N]> for NetworkKey<N> {
+    fn from(value: [u8; N]) -> Self {
         NetworkKey {
-            network: value.0,
-            key: value.1,
+            network: App::network().hash(),
+            key: value,
         }
     }
 }
 
 impl<const N: usize> NetworkKey<N> {
-    fn create_low(prefix: impl Into<u64>) -> Self {
-        Self {
-            network: prefix.into(),
-            key: [0u8; N],
-        }
+    fn create_low() -> Self {
+        Self::new([0u8; N])
     }
 
-    fn create_high(prefix: impl Into<u64>) -> Self {
-        Self {
-            network: prefix.into(),
-            key: [u8::MAX; N],
-        }
+    fn create_high() -> Self {
+        Self::new([u8::MAX; N])
     }
 }
 
@@ -166,45 +163,43 @@ pub struct IdentityKey {
     pub inbox: [u8; 32],
 }
 
+impl std::fmt::Display for IdentityKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", hex::encode(self.inbox))
+    }
+}
+
 impl IdentityKey {
+    pub fn new(version_hash: u64, inbox: [u8; 32]) -> Self {
+        Self {
+            network: App::network().hash(),
+            version_hash,
+            inbox,
+        }
+    }
+
     /// Lower bound for a range scan covering every version of `network`.
     /// Used by non-strict reads.
-    pub fn low_all_versions(network: u64) -> Self {
-        Self {
-            network,
-            version_hash: 0,
-            inbox: [0u8; 32],
-        }
+    pub fn low_all_versions() -> Self {
+        Self::new(0, [0u8; 32])
     }
 
     /// Upper bound for a range scan covering every version of `network`.
     /// Used by non-strict reads. Inclusive — use with `range(lo..=hi)`.
-    pub fn high_all_versions(network: u64) -> Self {
-        Self {
-            network,
-            version_hash: u64::MAX,
-            inbox: [u8::MAX; 32],
-        }
+    pub fn high_all_versions() -> Self {
+        Self::new(u64::MAX, [u8::MAX; 32])
     }
 
     /// Lower bound for a range scan covering one (network, version_hash).
     /// Used by strict reads.
-    pub fn low_one_version(network: u64, version_hash: u64) -> Self {
-        Self {
-            network,
-            version_hash,
-            inbox: [0u8; 32],
-        }
+    pub fn low_one_version(version_hash: u64) -> Self {
+        Self::new(version_hash, [0u8; 32])
     }
 
     /// Upper bound for a range scan covering one (network, version_hash).
     /// Used by strict reads. Inclusive — use with `range(lo..=hi)`.
-    pub fn high_one_version(network: u64, version_hash: u64) -> Self {
-        Self {
-            network,
-            version_hash,
-            inbox: [u8::MAX; 32],
-        }
+    pub fn high_one_version(version_hash: u64) -> Self {
+        Self::new(version_hash, [u8::MAX; 32])
     }
 }
 
@@ -273,35 +268,32 @@ impl redb::Key for IdentityKey {
 }
 
 pub trait DeriveKey<Key> {
-    fn key(&self, network: u64) -> Key;
+    fn key(&self) -> Key;
 }
 
 pub trait Database<Key, Value> {
     /// get length of items in db.
-    fn len(&self, network: impl Into<u64>) -> Result<usize>;
+    fn len(&self) -> Result<usize>;
 
     /// store only `value` to disk
-    fn set(&self, value: Value, network: impl Into<u64>) -> Result<()> {
-        Database::set_all(self, &[value], network)
+    fn set(&self, value: Value) -> Result<()> {
+        Database::set_all(self, &[value])
     }
 
     /// store all entities in `values` to disk
-    fn set_all(&self, values: &[Value], network: impl Into<u64>) -> Result<()>;
+    fn set_all(&self, values: &[Value]) -> Result<()>;
 
     /// Get an entity by key from this database store
     fn get(&self, value: Key) -> Result<Option<Value>>;
 
     /// Load all items in db as iterator
-    fn load(
-        &'_ self,
-        network: impl Into<u64>,
-    ) -> Result<Option<impl Iterator<Item = AccessGuard<'_, Value>>>>
+    fn load(&'_ self) -> Result<Option<impl Iterator<Item = AccessGuard<'_, Value>>>>
     where
         Value: redb::Value + 'static;
 
     #[allow(unused)]
     /// Clear all items on a network
-    fn clear_network(&self, network: impl Into<u64>) -> Result<()>;
+    fn clear_network(&self) -> Result<()>;
 
     /// Modify a single value by removing and re-inserting
     fn modify(&self, key: Key, f: impl FnMut(&mut Value)) -> Result<()>
@@ -311,26 +303,16 @@ pub trait Database<Key, Value> {
 
 pub trait RandomDatabase<Key, Value> {
     /// Get a random entity from this database store
-    fn random(&self, network: impl Into<u64> + Copy, rng: &mut impl Rng) -> Result<Option<Value>>;
+    fn random(&self, rng: &mut impl Rng) -> Result<Option<Value>>;
 
     /// get random n
     /// caps at the amount of items in the db. if `n` is greater than stored local items,
     /// returned values will only be up to how many items exist in the db.
-    fn random_n_capped(
-        &self,
-        network: impl Into<u64> + Copy,
-        rng: &mut impl Rng,
-        n: usize,
-    ) -> Result<Vec<AccessGuard<'_, Value>>>
+    fn random_n_capped(&self, rng: &mut impl Rng, n: usize) -> Result<Vec<AccessGuard<'_, Value>>>
     where
         Value: std::hash::Hash + Eq + redb::Value;
 
-    fn random_n(
-        &self,
-        network: impl Into<u64> + Copy,
-        rng: &mut impl Rng,
-        n: usize,
-    ) -> Result<Vec<AccessGuard<'_, Value>>>
+    fn random_n(&self, rng: &mut impl Rng, n: usize) -> Result<Vec<AccessGuard<'_, Value>>>
     where
         Value: std::hash::Hash + Eq + redb::Value;
 }
@@ -340,20 +322,10 @@ pub trait TableProvider<'a, K: redb::Key + 'static, V: redb::Value + 'static> {
 }
 
 pub trait TrackMetadata {
-    fn increment<'a>(
-        &self,
-        store: impl Into<MetadataStore<'a>>,
-        network: u64,
-        n: u32,
-    ) -> Result<()>;
+    fn increment<'a>(&self, store: impl Into<MetadataStore<'a>>, n: u32) -> Result<()>;
     // decrement a metadata item
     #[allow(unused)]
-    fn decrement<'a>(
-        &self,
-        store: impl Into<MetadataStore<'a>>,
-        network: u64,
-        n: u32,
-    ) -> Result<()>;
+    fn decrement<'a>(&self, store: impl Into<MetadataStore<'a>>, n: u32) -> Result<()>;
 }
 
 #[derive(Clone)]
@@ -368,6 +340,16 @@ enum DatabaseOrTransaction<'a> {
 pub struct KeyValueStore<'db, Storage> {
     db: DatabaseOrTransaction<'db>,
     store: Storage,
+    network: u64,
+}
+impl<'db, Storage> KeyValueStore<'db, Storage> {
+    pub fn new(store: Storage, db: DatabaseOrTransaction<'db>) -> Self {
+        Self {
+            db,
+            store,
+            network: App::network().hash(),
+        }
+    }
 }
 
 impl<Storage> KeyValueStore<'_, Storage> {
@@ -423,27 +405,26 @@ where
     for<'a> Value: redb::Value<SelfType<'a> = Value> + DeriveKey<NetworkKey<N>> + 'static,
     for<'a> Value: Borrow<<Value as redb::Value>::SelfType<'a>>,
 {
-    fn set_all(&self, values: &[Value], network: impl Into<u64>) -> Result<()> {
-        let network: u64 = network.into();
+    fn set_all(&self, values: &[Value]) -> Result<()> {
         let op = |w: &WriteTransaction| -> Result<()> {
             let mut table = w.open_table(Self::table())?;
             let mut total = 0;
             for value in values.iter() {
-                let key: NetworkKey<N> = value.key(network);
+                let key: NetworkKey<N> = value.key();
                 if table.insert(key, value)?.is_none() {
                     total += 1;
                 }
             }
-            self.store.increment(w, network, total)?;
+            self.store.increment(w, total)?;
             Ok(())
         };
         self.apply_write(op)?;
         Ok(())
     }
 
-    fn len(&self, network: impl Into<u64>) -> Result<usize> {
+    fn len(&self) -> Result<usize> {
         Ok(self
-            .load(network)?
+            .load()?
             .ok_or(eyre!("no items found, try generating some"))?
             .fold(0, |acc, _| acc + 1))
     }
@@ -458,10 +439,7 @@ where
         self.apply_read(op)
     }
 
-    fn load(
-        &'_ self,
-        network: impl Into<u64>,
-    ) -> Result<Option<impl Iterator<Item = AccessGuard<'_, Value>>>>
+    fn load(&'_ self) -> Result<Option<impl Iterator<Item = AccessGuard<'_, Value>>>>
     where
         Value: redb::Value + 'static,
     {
@@ -469,9 +447,8 @@ where
             let Some(table) = open_table_optional(r, Self::table())? else {
                 return Ok(None);
             };
-            let network: u64 = network.into();
-            let start = NetworkKey::<N>::create_low(network);
-            let end = NetworkKey::<N>::create_high(network);
+            let start = NetworkKey::<N>::create_low();
+            let end = NetworkKey::<N>::create_high();
             // Eager collect so a redb StorageError surfaces here instead
             // of lazily panicking at the caller's iteration site.
             let rows: Vec<_> = table.range(start..end)?.collect::<Result<_, _>>()?;
@@ -479,19 +456,18 @@ where
         })
     }
 
-    fn clear_network(&self, network: impl Into<u64>) -> Result<()> {
-        let network: u64 = network.into();
+    fn clear_network(&self) -> Result<()> {
         self.apply_write(|w| {
             let mut table = w.open_table(Self::table())?;
             let mut total = 0;
             table.retain(|k: NetworkKey<N>, _| {
-                if k.network == network {
+                if k.network == self.network {
                     total += 1;
                     return false;
                 }
                 true
             })?;
-            self.store.decrement(w, network, total)?;
+            self.store.decrement(w, total)?;
             Ok(())
         })
     }
@@ -508,7 +484,7 @@ where
             f(&mut item);
             table.insert(key, item)?;
             if !was_present {
-                self.store.increment(w, key.network, 1)?;
+                self.store.increment(w, 1)?;
             }
             Ok(())
         })
@@ -521,11 +497,11 @@ where
     Storage: TrackMetadata + TableProvider<'key, NetworkKey<N>, Value>,
     for<'a> Value: redb::Value<SelfType<'a> = Value> + DeriveKey<NetworkKey<N>> + 'static,
 {
-    fn random(&self, network: impl Into<u64> + Copy, rng: &mut impl Rng) -> Result<Option<Value>> {
+    fn random(&self, rng: &mut impl Rng) -> Result<Option<Value>> {
         self.apply_read(|r| {
             let table = r.open_table(Self::table())?;
-            let start = NetworkKey::create_low(network);
-            let end = NetworkKey::create_high(network);
+            let start = NetworkKey::create_low();
+            let end = NetworkKey::create_high();
             Ok(table
                 .range(start..end)?
                 .choose(rng)
@@ -537,12 +513,7 @@ where
     /// get random n
     /// caps at the amount of items in the db. if `n` is greater than stored local items,
     /// returned values will only be up to how many items exist in the db.
-    fn random_n_capped(
-        &self,
-        network: impl Into<u64> + Copy,
-        rng: &mut impl Rng,
-        n: usize,
-    ) -> Result<Vec<AccessGuard<'_, Value>>>
+    fn random_n_capped(&self, rng: &mut impl Rng, n: usize) -> Result<Vec<AccessGuard<'_, Value>>>
     where
         Value: std::hash::Hash + Eq + redb::Value,
     {
@@ -550,17 +521,12 @@ where
             return Ok(Vec::new());
         }
         let items = self
-            .load(network)?
+            .load()?
             .ok_or(eyre!("no items found, try generating some"))?;
         Ok(items.sample(rng, n))
     }
 
-    fn random_n(
-        &self,
-        network: impl Into<u64> + Copy,
-        rng: &mut impl Rng,
-        n: usize,
-    ) -> Result<Vec<AccessGuard<'_, Value>>>
+    fn random_n(&self, rng: &mut impl Rng, n: usize) -> Result<Vec<AccessGuard<'_, Value>>>
     where
         Value: std::hash::Hash + Eq,
     {
@@ -568,7 +534,7 @@ where
             return Ok(Vec::new());
         }
         let len = self
-            .load(network)?
+            .load()?
             .ok_or(eyre!("no items found, try generating some"))?
             .fold(0, |acc, _| acc + 1);
         if len == 0 {
@@ -580,7 +546,7 @@ where
         let mut random = Vec::with_capacity(n);
         while random.len() < n {
             let items = self
-                .load(network)?
+                .load()?
                 .ok_or(eyre!("no items found, try generating some"))?;
             let want = (n - random.len()).min(len);
             random.extend(items.sample(rng, want));
@@ -595,27 +561,26 @@ where
     for<'a> Value: redb::Value<SelfType<'a> = Value> + DeriveKey<IdentityKey> + 'static,
     for<'a> Value: Borrow<<Value as redb::Value>::SelfType<'a>>,
 {
-    fn set_all(&self, values: &[Value], network: impl Into<u64>) -> Result<()> {
-        let network: u64 = network.into();
+    fn set_all(&self, values: &[Value]) -> Result<()> {
         let op = |w: &WriteTransaction| -> Result<()> {
             let mut table = w.open_table(Self::table())?;
             let mut total = 0;
             for value in values.iter() {
-                let key: IdentityKey = value.key(network);
+                let key: IdentityKey = value.key();
                 if table.insert(key, value)?.is_none() {
                     total += 1;
                 }
             }
-            self.store.increment(w, network, total)?;
+            self.store.increment(w, total)?;
             Ok(())
         };
         self.apply_write(op)?;
         Ok(())
     }
 
-    fn len(&self, network: impl Into<u64>) -> Result<usize> {
+    fn len(&self) -> Result<usize> {
         Ok(self
-            .load(network)?
+            .load()?
             .ok_or(eyre!("no items found, try generating some"))?
             .fold(0, |acc, _| acc + 1))
     }
@@ -633,10 +598,7 @@ where
     /// Load every identity under `network`, regardless of version. This
     /// matches the existing `Database` trait semantics — strict-mode
     /// filtered loads are exposed via `IdentityStore::load_for_version`.
-    fn load(
-        &'_ self,
-        network: impl Into<u64>,
-    ) -> Result<Option<impl Iterator<Item = AccessGuard<'_, Value>>>>
+    fn load(&'_ self) -> Result<Option<impl Iterator<Item = AccessGuard<'_, Value>>>>
     where
         Value: redb::Value + 'static,
     {
@@ -644,27 +606,25 @@ where
             let Some(table) = open_table_optional(r, Self::table())? else {
                 return Ok(None);
             };
-            let network: u64 = network.into();
-            let start = IdentityKey::low_all_versions(network);
-            let end = IdentityKey::high_all_versions(network);
+            let start = IdentityKey::low_all_versions();
+            let end = IdentityKey::high_all_versions();
             let rows: Vec<_> = table.range(start..=end)?.collect::<Result<_, _>>()?;
             Ok(Some(rows.into_iter().map(|(_, v)| v)))
         })
     }
 
-    fn clear_network(&self, network: impl Into<u64>) -> Result<()> {
-        let network: u64 = network.into();
+    fn clear_network(&self) -> Result<()> {
         self.apply_write(|w| {
             let mut table = w.open_table(Self::table())?;
             let mut total = 0;
             table.retain(|k: IdentityKey, _| {
-                if k.network == network {
+                if k.network == self.network {
                     total += 1;
                     return false;
                 }
                 true
             })?;
-            self.store.decrement(w, network, total)?;
+            self.store.decrement(w, total)?;
             Ok(())
         })
     }
@@ -681,7 +641,7 @@ where
             f(&mut item);
             table.insert(key, item)?;
             if !was_present {
-                self.store.increment(w, key.network, 1)?;
+                self.store.increment(w, 1)?;
             }
             Ok(())
         })
@@ -693,11 +653,11 @@ where
     Storage: TrackMetadata + TableProvider<'key, IdentityKey, Value>,
     for<'a> Value: redb::Value<SelfType<'a> = Value> + DeriveKey<IdentityKey> + 'static,
 {
-    fn random(&self, network: impl Into<u64> + Copy, rng: &mut impl Rng) -> Result<Option<Value>> {
+    fn random(&self, rng: &mut impl Rng) -> Result<Option<Value>> {
         self.apply_read(|r| {
             let table = r.open_table(Self::table())?;
-            let start = IdentityKey::low_all_versions(network.into());
-            let end = IdentityKey::high_all_versions(network.into());
+            let start = IdentityKey::low_all_versions();
+            let end = IdentityKey::high_all_versions();
             Ok(table
                 .range(start..=end)?
                 .choose(rng)
@@ -709,36 +669,25 @@ where
     /// get random n
     /// caps at the amount of items in the db. if `n` is greater than stored local items,
     /// returned values will only be up to how many items exist in the db.
-    fn random_n_capped(
-        &self,
-        network: impl Into<u64> + Copy,
-        rng: &mut impl Rng,
-        n: usize,
-    ) -> Result<Vec<AccessGuard<'_, Value>>>
+    fn random_n_capped(&self, rng: &mut impl Rng, n: usize) -> Result<Vec<AccessGuard<'_, Value>>>
     where
         Value: std::hash::Hash + Eq + redb::Value,
     {
         if n == 0 {
             return Ok(Vec::new());
         }
-        let items =
-            Database::load(self, network)?.ok_or(eyre!("no items found, try generating some"))?;
+        let items = Database::load(self)?.ok_or(eyre!("no items found, try generating some"))?;
         Ok(items.sample(rng, n))
     }
 
-    fn random_n(
-        &self,
-        network: impl Into<u64> + Copy,
-        rng: &mut impl Rng,
-        n: usize,
-    ) -> Result<Vec<AccessGuard<'_, Value>>>
+    fn random_n(&self, rng: &mut impl Rng, n: usize) -> Result<Vec<AccessGuard<'_, Value>>>
     where
         Value: std::hash::Hash + Eq,
     {
         if n == 0 {
             return Ok(Vec::new());
         }
-        let len = Database::load(self, network)?
+        let len = Database::load(self)?
             .ok_or(eyre!("no items found, try generating some"))?
             .fold(0, |acc, _| acc + 1);
         if len == 0 {
@@ -749,8 +698,8 @@ where
         // only materializes on `value()`, so cheap.
         let mut random = Vec::with_capacity(n);
         while random.len() < n {
-            let items = Database::load(self, network)?
-                .ok_or(eyre!("no items found, try generating some"))?;
+            let items =
+                Database::load(self)?.ok_or(eyre!("no items found, try generating some"))?;
             let want = (n - random.len()).min(len);
             random.extend(items.sample(rng, want));
         }
@@ -763,6 +712,7 @@ pub struct Metadata {
     pub identities: u32,
     pub groups: u32,
     pub messages: u32,
+    pub dms: u32,
 }
 
 impl redb::Value for Metadata {
@@ -804,45 +754,30 @@ impl redb::Value for Metadata {
 
 impl<'a: 'b, 'b> From<IdentityStore<'a>> for MetadataStore<'b> {
     fn from(store: IdentityStore<'a>) -> MetadataStore<'b> {
-        MetadataStore {
-            db: store.db,
-            store: MetadataStorage,
-        }
+        MetadataStore::new(MetadataStorage, store.db)
     }
 }
 
 impl<'a: 'b, 'b> From<GroupStore<'a>> for MetadataStore<'b> {
     fn from(store: GroupStore<'a>) -> MetadataStore<'b> {
-        MetadataStore {
-            db: store.db,
-            store: MetadataStorage,
-        }
+        MetadataStore::new(MetadataStorage, store.db)
     }
 }
 
 impl<'a: 'b, 'b> From<MessageStore<'a>> for MetadataStore<'b> {
     fn from(store: MessageStore<'a>) -> MetadataStore<'b> {
-        MetadataStore {
-            db: store.db,
-            store: MetadataStorage,
-        }
+        MetadataStore::new(MetadataStorage, store.db)
     }
 }
 
 impl<'a> From<&'a WriteTransaction> for MetadataStore<'a> {
     fn from(tx: &'a WriteTransaction) -> MetadataStore<'a> {
-        MetadataStore {
-            db: DatabaseOrTransaction::WriteTx(tx),
-            store: MetadataStorage,
-        }
+        MetadataStore::new(MetadataStorage, DatabaseOrTransaction::WriteTx(tx))
     }
 }
 impl<'a> From<&'a ReadTransaction> for MetadataStore<'a> {
     fn from(tx: &'a ReadTransaction) -> MetadataStore<'a> {
-        MetadataStore {
-            db: DatabaseOrTransaction::ReadTx(tx),
-            store: MetadataStorage,
-        }
+        MetadataStore::new(MetadataStorage, DatabaseOrTransaction::ReadTx(tx))
     }
 }
 
@@ -961,11 +896,15 @@ mod identity_database_tests {
         let (db, _dir) = open();
         let store: IdentityStore<'static> = db.into();
 
-        store.set(ident(1, 100), 1u64).unwrap();
-        store.set(ident(2, 100), 2u64).unwrap();
+        App::set_network_hash(1);
+        store.set(ident(1, 100)).unwrap();
+        App::set_network_hash(2);
+        store.set(ident(2, 100)).unwrap();
 
-        let net1: Vec<_> = store.load(1u64).unwrap().unwrap().collect();
-        let net2: Vec<_> = store.load(2u64).unwrap().unwrap().collect();
+        App::set_network_hash(1);
+        let net1: Vec<_> = store.load().unwrap().unwrap().collect();
+        App::set_network_hash(2);
+        let net2: Vec<_> = store.load().unwrap().unwrap().collect();
         assert_eq!(net1.len(), 1);
         assert_eq!(net2.len(), 1);
     }
@@ -975,20 +914,13 @@ mod identity_database_tests {
         let (db, _dir) = open();
         let store: IdentityStore<'static> = db.into();
 
-        store.set(ident(1, 100), 1u64).unwrap();
-        store.set(ident(2, 100), 1u64).unwrap();
-        store.set(ident(3, 200), 1u64).unwrap();
+        App::set_network_hash(1);
+        store.set(ident(1, 100)).unwrap();
+        store.set(ident(2, 100)).unwrap();
+        store.set(ident(3, 200)).unwrap();
 
-        let v100: Vec<_> = store
-            .load_for_version(1u64, 100)
-            .unwrap()
-            .unwrap()
-            .collect();
-        let v200: Vec<_> = store
-            .load_for_version(1u64, 200)
-            .unwrap()
-            .unwrap()
-            .collect();
+        let v100: Vec<_> = store.load_for_version(100).unwrap().unwrap().collect();
+        let v200: Vec<_> = store.load_for_version(200).unwrap().unwrap().collect();
         assert_eq!(v100.len(), 2);
         assert_eq!(v200.len(), 1);
     }

--- a/apps/xmtp_debug/src/app/store.rs
+++ b/apps/xmtp_debug/src/app/store.rs
@@ -11,6 +11,7 @@ use rand::{Rng, seq::IteratorRandom};
 use redb::{AccessGuard, ReadTransaction, ReadableDatabase, TableDefinition, WriteTransaction};
 use speedy::{Readable, Writable};
 
+pub use dms::*;
 pub use groups::*;
 pub use identity::*;
 pub use messages::*;
@@ -39,35 +40,50 @@ where
 
 #[derive(Debug, Copy, Clone)]
 pub struct NetworkKey<const N: usize> {
+    /// Network discriminator. Populated by the owning `KeyValueStore`
+    /// at write/read time — `DeriveKey` impls and `From` conversions
+    /// leave this as 0. See `KeyValueStore::with_network`.
     network: u64,
     key: [u8; N],
 }
 
 impl<const N: usize> NetworkKey<N> {
+    /// Construct a key with the network field left as 0. The store
+    /// overrides this with its own `network_hash` at insert time.
     pub fn new(key: impl Into<[u8; N]>) -> Self {
         Self {
-            network: App::network().hash(),
+            network: 0,
             key: key.into(),
         }
+    }
+
+    fn with_network(self, network: u64) -> Self {
+        Self { network, ..self }
     }
 }
 
 impl<const N: usize> From<[u8; N]> for NetworkKey<N> {
     fn from(value: [u8; N]) -> Self {
         NetworkKey {
-            network: App::network().hash(),
+            network: 0,
             key: value,
         }
     }
 }
 
 impl<const N: usize> NetworkKey<N> {
-    fn create_low() -> Self {
-        Self::new([0u8; N])
+    fn create_low(network: u64) -> Self {
+        Self {
+            network,
+            key: [0u8; N],
+        }
     }
 
-    fn create_high() -> Self {
-        Self::new([u8::MAX; N])
+    fn create_high(network: u64) -> Self {
+        Self {
+            network,
+            key: [u8::MAX; N],
+        }
     }
 }
 
@@ -170,36 +186,58 @@ impl std::fmt::Display for IdentityKey {
 }
 
 impl IdentityKey {
+    /// Construct a key with the network field left as 0. The store
+    /// overrides this with its own `network_hash` at insert time.
     pub fn new(version_hash: u64, inbox: [u8; 32]) -> Self {
         Self {
-            network: App::network().hash(),
+            network: 0,
             version_hash,
             inbox,
         }
     }
 
+    fn with_network(self, network: u64) -> Self {
+        Self { network, ..self }
+    }
+
     /// Lower bound for a range scan covering every version of `network`.
     /// Used by non-strict reads.
-    pub fn low_all_versions() -> Self {
-        Self::new(0, [0u8; 32])
+    pub fn low_all_versions(network: u64) -> Self {
+        Self {
+            network,
+            version_hash: 0,
+            inbox: [0u8; 32],
+        }
     }
 
     /// Upper bound for a range scan covering every version of `network`.
     /// Used by non-strict reads. Inclusive — use with `range(lo..=hi)`.
-    pub fn high_all_versions() -> Self {
-        Self::new(u64::MAX, [u8::MAX; 32])
+    pub fn high_all_versions(network: u64) -> Self {
+        Self {
+            network,
+            version_hash: u64::MAX,
+            inbox: [u8::MAX; 32],
+        }
     }
 
     /// Lower bound for a range scan covering one (network, version_hash).
     /// Used by strict reads.
-    pub fn low_one_version(version_hash: u64) -> Self {
-        Self::new(version_hash, [0u8; 32])
+    pub fn low_one_version(network: u64, version_hash: u64) -> Self {
+        Self {
+            network,
+            version_hash,
+            inbox: [0u8; 32],
+        }
     }
 
     /// Upper bound for a range scan covering one (network, version_hash).
     /// Used by strict reads. Inclusive — use with `range(lo..=hi)`.
-    pub fn high_one_version(version_hash: u64) -> Self {
-        Self::new(version_hash, [u8::MAX; 32])
+    pub fn high_one_version(network: u64, version_hash: u64) -> Self {
+        Self {
+            network,
+            version_hash,
+            inbox: [u8::MAX; 32],
+        }
     }
 }
 
@@ -322,33 +360,49 @@ pub trait TableProvider<'a, K: redb::Key + 'static, V: redb::Value + 'static> {
 }
 
 pub trait TrackMetadata {
-    fn increment<'a>(&self, store: impl Into<MetadataStore<'a>>, n: u32) -> Result<()>;
+    fn increment(&self, tx: &WriteTransaction, network: u64, n: u32) -> Result<()>;
     // decrement a metadata item
     #[allow(unused)]
-    fn decrement<'a>(&self, store: impl Into<MetadataStore<'a>>, n: u32) -> Result<()>;
+    fn decrement(&self, tx: &WriteTransaction, network: u64, n: u32) -> Result<()>;
 }
 
 #[derive(Clone)]
-enum DatabaseOrTransaction<'a> {
+pub(super) enum DatabaseOrTransaction<'a> {
     ReadOnly(Arc<redb::ReadOnlyDatabase>),
     Db(Arc<redb::Database>),
     WriteTx(&'a WriteTransaction),
-    ReadTx(&'a redb::ReadTransaction),
 }
 
 #[derive(Clone)]
 pub struct KeyValueStore<'db, Storage> {
     db: DatabaseOrTransaction<'db>,
     store: Storage,
-    network: u64,
+    network_hash: u64,
 }
 impl<'db, Storage> KeyValueStore<'db, Storage> {
-    pub fn new(store: Storage, db: DatabaseOrTransaction<'db>) -> Self {
+    pub(super) fn new(store: Storage, db: DatabaseOrTransaction<'db>) -> Self {
+        Self::with_network(store, db, App::network_hash())
+    }
+
+    /// Construct a store bound to an explicit `network_hash` instead of
+    /// reading `App::network_hash()`. Use for tests (where the process
+    /// has no configured network) and for callers that talk to more
+    /// than one backend in the same process (continuity tests).
+    #[allow(dead_code)]
+    pub(super) fn with_network(
+        store: Storage,
+        db: DatabaseOrTransaction<'db>,
+        network_hash: u64,
+    ) -> Self {
         Self {
             db,
             store,
-            network: App::network().hash(),
+            network_hash,
         }
+    }
+
+    pub(super) fn network_hash(&self) -> u64 {
+        self.network_hash
     }
 }
 
@@ -362,7 +416,6 @@ impl<Storage> KeyValueStore<'_, Storage> {
                 Ok(w.commit()?)
             }
             WriteTx(w) => Ok(op(w)?),
-            ReadTx(_) => eyre::bail!("requires write"),
             ReadOnly(_) => eyre::bail!("database is in read-only mode"),
         }
     }
@@ -377,7 +430,6 @@ impl<Storage> KeyValueStore<'_, Storage> {
                 let r = d.begin_read()?;
                 Ok(op(&r)?)
             }
-            ReadTx(r) => Ok(op(r)?),
             WriteTx(_) => eyre::bail!("requires read only"),
             ReadOnly(ref d) => {
                 let r = d.begin_read()?;
@@ -406,16 +458,17 @@ where
     for<'a> Value: Borrow<<Value as redb::Value>::SelfType<'a>>,
 {
     fn set_all(&self, values: &[Value]) -> Result<()> {
+        let net = self.network_hash;
         let op = |w: &WriteTransaction| -> Result<()> {
             let mut table = w.open_table(Self::table())?;
             let mut total = 0;
             for value in values.iter() {
-                let key: NetworkKey<N> = value.key();
+                let key: NetworkKey<N> = value.key().with_network(net);
                 if table.insert(key, value)?.is_none() {
                     total += 1;
                 }
             }
-            self.store.increment(w, total)?;
+            self.store.increment(w, net, total)?;
             Ok(())
         };
         self.apply_write(op)?;
@@ -430,6 +483,7 @@ where
     }
 
     fn get(&self, key: NetworkKey<N>) -> Result<Option<Value>> {
+        let key = key.with_network(self.network_hash);
         let op = |r: &ReadTransaction| -> Result<Option<Value>> {
             let Some(table) = open_table_optional(r, Self::table())? else {
                 return Ok(None);
@@ -443,12 +497,13 @@ where
     where
         Value: redb::Value + 'static,
     {
-        self.apply_read(|r| {
+        let net = self.network_hash;
+        self.apply_read(move |r| {
             let Some(table) = open_table_optional(r, Self::table())? else {
                 return Ok(None);
             };
-            let start = NetworkKey::<N>::create_low();
-            let end = NetworkKey::<N>::create_high();
+            let start = NetworkKey::<N>::create_low(net);
+            let end = NetworkKey::<N>::create_high(net);
             // Eager collect so a redb StorageError surfaces here instead
             // of lazily panicking at the caller's iteration site.
             let rows: Vec<_> = table.range(start..end)?.collect::<Result<_, _>>()?;
@@ -457,17 +512,18 @@ where
     }
 
     fn clear_network(&self) -> Result<()> {
-        self.apply_write(|w| {
+        let net = self.network_hash;
+        self.apply_write(move |w| {
             let mut table = w.open_table(Self::table())?;
             let mut total = 0;
             table.retain(|k: NetworkKey<N>, _| {
-                if k.network == self.network {
+                if k.network == net {
                     total += 1;
                     return false;
                 }
                 true
             })?;
-            self.store.decrement(w, total)?;
+            self.store.decrement(w, net, total)?;
             Ok(())
         })
     }
@@ -476,6 +532,8 @@ where
     where
         Value: Default,
     {
+        let net = self.network_hash;
+        let key = key.with_network(net);
         self.apply_write(|w| {
             let mut table = w.open_table(Self::table())?;
             let existing = table.remove(key)?;
@@ -484,7 +542,7 @@ where
             f(&mut item);
             table.insert(key, item)?;
             if !was_present {
-                self.store.increment(w, 1)?;
+                self.store.increment(w, net, 1)?;
             }
             Ok(())
         })
@@ -498,10 +556,11 @@ where
     for<'a> Value: redb::Value<SelfType<'a> = Value> + DeriveKey<NetworkKey<N>> + 'static,
 {
     fn random(&self, rng: &mut impl Rng) -> Result<Option<Value>> {
-        self.apply_read(|r| {
+        let net = self.network_hash;
+        self.apply_read(move |r| {
             let table = r.open_table(Self::table())?;
-            let start = NetworkKey::create_low();
-            let end = NetworkKey::create_high();
+            let start = NetworkKey::<N>::create_low(net);
+            let end = NetworkKey::<N>::create_high(net);
             Ok(table
                 .range(start..end)?
                 .choose(rng)
@@ -562,16 +621,17 @@ where
     for<'a> Value: Borrow<<Value as redb::Value>::SelfType<'a>>,
 {
     fn set_all(&self, values: &[Value]) -> Result<()> {
+        let net = self.network_hash;
         let op = |w: &WriteTransaction| -> Result<()> {
             let mut table = w.open_table(Self::table())?;
             let mut total = 0;
             for value in values.iter() {
-                let key: IdentityKey = value.key();
+                let key: IdentityKey = value.key().with_network(net);
                 if table.insert(key, value)?.is_none() {
                     total += 1;
                 }
             }
-            self.store.increment(w, total)?;
+            self.store.increment(w, net, total)?;
             Ok(())
         };
         self.apply_write(op)?;
@@ -586,6 +646,7 @@ where
     }
 
     fn get(&self, key: IdentityKey) -> Result<Option<Value>> {
+        let key = key.with_network(self.network_hash);
         let op = |r: &ReadTransaction| -> Result<Option<Value>> {
             let Some(table) = open_table_optional(r, Self::table())? else {
                 return Ok(None);
@@ -602,29 +663,31 @@ where
     where
         Value: redb::Value + 'static,
     {
-        self.apply_read(|r| {
+        let net = self.network_hash;
+        self.apply_read(move |r| {
             let Some(table) = open_table_optional(r, Self::table())? else {
                 return Ok(None);
             };
-            let start = IdentityKey::low_all_versions();
-            let end = IdentityKey::high_all_versions();
+            let start = IdentityKey::low_all_versions(net);
+            let end = IdentityKey::high_all_versions(net);
             let rows: Vec<_> = table.range(start..=end)?.collect::<Result<_, _>>()?;
             Ok(Some(rows.into_iter().map(|(_, v)| v)))
         })
     }
 
     fn clear_network(&self) -> Result<()> {
-        self.apply_write(|w| {
+        let net = self.network_hash;
+        self.apply_write(move |w| {
             let mut table = w.open_table(Self::table())?;
             let mut total = 0;
             table.retain(|k: IdentityKey, _| {
-                if k.network == self.network {
+                if k.network == net {
                     total += 1;
                     return false;
                 }
                 true
             })?;
-            self.store.decrement(w, total)?;
+            self.store.decrement(w, net, total)?;
             Ok(())
         })
     }
@@ -633,6 +696,8 @@ where
     where
         Value: Default,
     {
+        let net = self.network_hash;
+        let key = key.with_network(net);
         self.apply_write(|w| {
             let mut table = w.open_table(Self::table())?;
             let existing = table.remove(key)?;
@@ -641,7 +706,7 @@ where
             f(&mut item);
             table.insert(key, item)?;
             if !was_present {
-                self.store.increment(w, 1)?;
+                self.store.increment(w, net, 1)?;
             }
             Ok(())
         })
@@ -654,10 +719,11 @@ where
     for<'a> Value: redb::Value<SelfType<'a> = Value> + DeriveKey<IdentityKey> + 'static,
 {
     fn random(&self, rng: &mut impl Rng) -> Result<Option<Value>> {
-        self.apply_read(|r| {
+        let net = self.network_hash;
+        self.apply_read(move |r| {
             let table = r.open_table(Self::table())?;
-            let start = IdentityKey::low_all_versions();
-            let end = IdentityKey::high_all_versions();
+            let start = IdentityKey::low_all_versions(net);
+            let end = IdentityKey::high_all_versions(net);
             Ok(table
                 .range(start..=end)?
                 .choose(rng)
@@ -752,32 +818,9 @@ impl redb::Value for Metadata {
     }
 }
 
-impl<'a: 'b, 'b> From<IdentityStore<'a>> for MetadataStore<'b> {
-    fn from(store: IdentityStore<'a>) -> MetadataStore<'b> {
-        MetadataStore::new(MetadataStorage, store.db)
-    }
-}
-
-impl<'a: 'b, 'b> From<GroupStore<'a>> for MetadataStore<'b> {
-    fn from(store: GroupStore<'a>) -> MetadataStore<'b> {
-        MetadataStore::new(MetadataStorage, store.db)
-    }
-}
-
-impl<'a: 'b, 'b> From<MessageStore<'a>> for MetadataStore<'b> {
-    fn from(store: MessageStore<'a>) -> MetadataStore<'b> {
-        MetadataStore::new(MetadataStorage, store.db)
-    }
-}
-
-impl<'a> From<&'a WriteTransaction> for MetadataStore<'a> {
-    fn from(tx: &'a WriteTransaction) -> MetadataStore<'a> {
-        MetadataStore::new(MetadataStorage, DatabaseOrTransaction::WriteTx(tx))
-    }
-}
-impl<'a> From<&'a ReadTransaction> for MetadataStore<'a> {
-    fn from(tx: &'a ReadTransaction) -> MetadataStore<'a> {
-        MetadataStore::new(MetadataStorage, DatabaseOrTransaction::ReadTx(tx))
+impl<'a> MetadataStore<'a> {
+    pub(super) fn from_write_tx(tx: &'a WriteTransaction, network: u64) -> Self {
+        Self::with_network(MetadataStorage, DatabaseOrTransaction::WriteTx(tx), network)
     }
 }
 
@@ -879,49 +922,15 @@ mod identity_database_tests {
     #[test]
     fn set_then_load_returns_all_versions_for_network() {
         let (db, _dir) = open();
-        let store: IdentityStore<'static> = db.into();
+        let store = KeyValueStore::with_network(IdentityStorage, DatabaseOrTransaction::Db(db), 0);
 
         // Two identities in version A, one in version B, all on network=1
         let a1 = ident(1, 100);
         let a2 = ident(2, 100);
         let b1 = ident(3, 200);
-        store.set_all(&[a1, a2, b1], 1u64).unwrap();
+        store.set_all(&[a1, a2, b1]).unwrap();
 
-        let loaded: Vec<_> = store.load(1u64).unwrap().unwrap().collect();
+        let loaded: Vec<_> = store.load().unwrap().unwrap().collect();
         assert_eq!(loaded.len(), 3, "load(network) returns every version");
-    }
-
-    #[test]
-    fn set_then_load_isolates_by_network() {
-        let (db, _dir) = open();
-        let store: IdentityStore<'static> = db.into();
-
-        App::set_network_hash(1);
-        store.set(ident(1, 100)).unwrap();
-        App::set_network_hash(2);
-        store.set(ident(2, 100)).unwrap();
-
-        App::set_network_hash(1);
-        let net1: Vec<_> = store.load().unwrap().unwrap().collect();
-        App::set_network_hash(2);
-        let net2: Vec<_> = store.load().unwrap().unwrap().collect();
-        assert_eq!(net1.len(), 1);
-        assert_eq!(net2.len(), 1);
-    }
-
-    #[test]
-    fn load_for_version_filters_to_one_version() {
-        let (db, _dir) = open();
-        let store: IdentityStore<'static> = db.into();
-
-        App::set_network_hash(1);
-        store.set(ident(1, 100)).unwrap();
-        store.set(ident(2, 100)).unwrap();
-        store.set(ident(3, 200)).unwrap();
-
-        let v100: Vec<_> = store.load_for_version(100).unwrap().unwrap().collect();
-        let v200: Vec<_> = store.load_for_version(200).unwrap().unwrap().collect();
-        assert_eq!(v100.len(), 2);
-        assert_eq!(v200.len(), 1);
     }
 }

--- a/apps/xmtp_debug/src/app/store/dms.rs
+++ b/apps/xmtp_debug/src/app/store/dms.rs
@@ -1,0 +1,77 @@
+//! Dms storage table
+use color_eyre::eyre::Result;
+use redb::TableDefinition;
+use std::sync::Arc;
+
+use crate::{app::types::*, constants::STORAGE_PREFIX};
+
+use super::{Database, MetadataStore};
+
+pub const MODULE: &str = "dms";
+pub const VERSION: u16 = 1;
+pub const NAMESPACE: &str = const_format::concatcp!(STORAGE_PREFIX, ":", VERSION, "//", MODULE);
+
+/// Mapping of [`DmKey`] to a bare-minimum serialized [`Dm`]
+const TABLE: TableDefinition<DmKey, Dm> = TableDefinition::new(NAMESPACE);
+
+impl super::DeriveKey<DmKey> for Dm {
+    fn key(&self) -> DmKey {
+        DmKey::new(*self.redb_key())
+    }
+}
+
+impl super::DeriveKey<DmKey> for &Dm {
+    fn key(&self) -> DmKey {
+        DmKey::new(*self.redb_key())
+    }
+}
+
+impl From<DmId> for DmKey {
+    fn from(value: DmId) -> Self {
+        DmKey::new(value.into_bytes())
+    }
+}
+
+impl From<&DmId> for DmKey {
+    fn from(value: &DmId) -> Self {
+        DmKey::new(*value.as_bytes())
+    }
+}
+
+/// Key of groupid/network
+pub type DmKey = super::NetworkKey<64>;
+pub type DmStore<'a> = super::KeyValueStore<'a, DmStorage>;
+
+impl From<Arc<redb::Database>> for DmStore<'_> {
+    fn from(value: Arc<redb::Database>) -> Self {
+        DmStore::new(DmStorage, super::DatabaseOrTransaction::Db(value))
+    }
+}
+
+impl From<Arc<redb::ReadOnlyDatabase>> for DmStore<'_> {
+    fn from(value: Arc<redb::ReadOnlyDatabase>) -> Self {
+        DmStore::new(DmStorage, super::DatabaseOrTransaction::ReadOnly(value))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DmStorage;
+
+impl<'a> super::TableProvider<'a, DmKey, Dm> for DmStorage {
+    fn table() -> TableDefinition<'a, DmKey, Dm> {
+        TABLE
+    }
+}
+impl super::TrackMetadata for DmStorage {
+    fn increment<'a>(&self, store: impl Into<MetadataStore<'a>>, n: u32) -> Result<()> {
+        let store = store.into();
+        store.modify(crate::meta_key!(), |meta| meta.dms += n)?;
+        Ok(())
+    }
+
+    fn decrement<'a>(&self, store: impl Into<MetadataStore<'a>>, n: u32) -> Result<()> {
+        let store = store.into();
+        store.modify(crate::meta_key!(), |meta| meta.dms -= n)?;
+        Ok(())
+    }
+}

--- a/apps/xmtp_debug/src/app/store/dms.rs
+++ b/apps/xmtp_debug/src/app/store/dms.rs
@@ -16,13 +16,13 @@ const TABLE: TableDefinition<DmKey, Dm> = TableDefinition::new(NAMESPACE);
 
 impl super::DeriveKey<DmKey> for Dm {
     fn key(&self) -> DmKey {
-        DmKey::new(*self.redb_key())
+        DmKey::new(self.redb_key().into_bytes())
     }
 }
 
 impl super::DeriveKey<DmKey> for &Dm {
     fn key(&self) -> DmKey {
-        DmKey::new(*self.redb_key())
+        DmKey::new(self.redb_key().into_bytes())
     }
 }
 
@@ -63,14 +63,14 @@ impl<'a> super::TableProvider<'a, DmKey, Dm> for DmStorage {
     }
 }
 impl super::TrackMetadata for DmStorage {
-    fn increment<'a>(&self, store: impl Into<MetadataStore<'a>>, n: u32) -> Result<()> {
-        let store = store.into();
+    fn increment(&self, tx: &redb::WriteTransaction, network: u64, n: u32) -> Result<()> {
+        let store = MetadataStore::from_write_tx(tx, network);
         store.modify(crate::meta_key!(), |meta| meta.dms += n)?;
         Ok(())
     }
 
-    fn decrement<'a>(&self, store: impl Into<MetadataStore<'a>>, n: u32) -> Result<()> {
-        let store = store.into();
+    fn decrement(&self, tx: &redb::WriteTransaction, network: u64, n: u32) -> Result<()> {
+        let store = MetadataStore::from_write_tx(tx, network);
         store.modify(crate::meta_key!(), |meta| meta.dms -= n)?;
         Ok(())
     }

--- a/apps/xmtp_debug/src/app/store/groups.rs
+++ b/apps/xmtp_debug/src/app/store/groups.rs
@@ -65,14 +65,14 @@ impl<'a> super::TableProvider<'a, GroupKey, Group> for GroupStorage {
 }
 
 impl super::TrackMetadata for GroupStorage {
-    fn increment<'a>(&self, store: impl Into<MetadataStore<'a>>, n: u32) -> Result<()> {
-        let store = store.into();
+    fn increment(&self, tx: &redb::WriteTransaction, network: u64, n: u32) -> Result<()> {
+        let store = MetadataStore::from_write_tx(tx, network);
         store.modify(crate::meta_key!(), |meta| meta.groups += n)?;
         Ok(())
     }
 
-    fn decrement<'a>(&self, store: impl Into<MetadataStore<'a>>, n: u32) -> Result<()> {
-        let store = store.into();
+    fn decrement(&self, tx: &redb::WriteTransaction, network: u64, n: u32) -> Result<()> {
+        let store = MetadataStore::from_write_tx(tx, network);
         store.modify(crate::meta_key!(), |meta| meta.groups -= n)?;
         Ok(())
     }

--- a/apps/xmtp_debug/src/app/store/groups.rs
+++ b/apps/xmtp_debug/src/app/store/groups.rs
@@ -2,6 +2,7 @@
 use color_eyre::eyre::Result;
 use redb::TableDefinition;
 use std::sync::Arc;
+use xmtp_proto::types::GroupId;
 
 use crate::{app::types::*, constants::STORAGE_PREFIX};
 
@@ -15,20 +16,26 @@ pub const NAMESPACE: &str = const_format::concatcp!(STORAGE_PREFIX, ":", VERSION
 const TABLE: TableDefinition<GroupKey, Group> = TableDefinition::new(NAMESPACE);
 
 impl super::DeriveKey<GroupKey> for Group {
-    fn key(&self, network: u64) -> GroupKey {
-        GroupKey {
-            network,
-            key: *self.id().as_bytes(),
-        }
+    fn key(&self) -> GroupKey {
+        GroupKey::new(*self.id().as_bytes())
     }
 }
 
 impl super::DeriveKey<GroupKey> for &Group {
-    fn key(&self, network: u64) -> GroupKey {
-        GroupKey {
-            network,
-            key: *self.id().as_bytes(),
-        }
+    fn key(&self) -> GroupKey {
+        GroupKey::new(*self.id().as_bytes())
+    }
+}
+
+impl From<GroupId> for GroupKey {
+    fn from(value: GroupId) -> Self {
+        GroupKey::new(value.into_bytes())
+    }
+}
+
+impl From<&GroupId> for GroupKey {
+    fn from(value: &GroupId) -> Self {
+        GroupKey::new(*value.as_bytes())
     }
 }
 
@@ -38,19 +45,13 @@ pub type GroupStore<'a> = super::KeyValueStore<'a, GroupStorage>;
 
 impl From<Arc<redb::Database>> for GroupStore<'_> {
     fn from(value: Arc<redb::Database>) -> Self {
-        GroupStore {
-            db: super::DatabaseOrTransaction::Db(value),
-            store: GroupStorage,
-        }
+        GroupStore::new(GroupStorage, super::DatabaseOrTransaction::Db(value))
     }
 }
 
 impl From<Arc<redb::ReadOnlyDatabase>> for GroupStore<'_> {
     fn from(value: Arc<redb::ReadOnlyDatabase>) -> Self {
-        GroupStore {
-            db: super::DatabaseOrTransaction::ReadOnly(value),
-            store: GroupStorage,
-        }
+        GroupStore::new(GroupStorage, super::DatabaseOrTransaction::ReadOnly(value))
     }
 }
 
@@ -64,25 +65,15 @@ impl<'a> super::TableProvider<'a, GroupKey, Group> for GroupStorage {
 }
 
 impl super::TrackMetadata for GroupStorage {
-    fn increment<'a>(
-        &self,
-        store: impl Into<MetadataStore<'a>>,
-        network: u64,
-        n: u32,
-    ) -> Result<()> {
+    fn increment<'a>(&self, store: impl Into<MetadataStore<'a>>, n: u32) -> Result<()> {
         let store = store.into();
-        store.modify(crate::meta_key!(network), |meta| meta.groups += n)?;
+        store.modify(crate::meta_key!(), |meta| meta.groups += n)?;
         Ok(())
     }
 
-    fn decrement<'a>(
-        &self,
-        store: impl Into<MetadataStore<'a>>,
-        network: u64,
-        n: u32,
-    ) -> Result<()> {
+    fn decrement<'a>(&self, store: impl Into<MetadataStore<'a>>, n: u32) -> Result<()> {
         let store = store.into();
-        store.modify(crate::meta_key!(network), |meta| meta.groups -= n)?;
+        store.modify(crate::meta_key!(), |meta| meta.groups -= n)?;
         Ok(())
     }
 }

--- a/apps/xmtp_debug/src/app/store/identity.rs
+++ b/apps/xmtp_debug/src/app/store/identity.rs
@@ -66,7 +66,8 @@ impl IdentityStore<'_> {
         version_hash: u64,
     ) -> Result<Option<impl Iterator<Item = redb::AccessGuard<'_, Identity>>>> {
         use super::TableProvider;
-        self.apply_read(|r| {
+        let net = self.network_hash();
+        self.apply_read(move |r| {
             let Some(table) = super::open_table_optional(
                 r,
                 <Self as TableProvider<IdentityKey, Identity>>::table(),
@@ -74,8 +75,8 @@ impl IdentityStore<'_> {
             else {
                 return Ok(None);
             };
-            let start = IdentityKey::low_one_version(version_hash);
-            let end = IdentityKey::high_one_version(version_hash);
+            let start = IdentityKey::low_one_version(net, version_hash);
+            let end = IdentityKey::high_one_version(net, version_hash);
             let rows: Vec<_> = table.range(start..=end)?.collect::<Result<_, _>>()?;
             Ok(Some(rows.into_iter().map(|(_, v)| v)))
         })
@@ -87,7 +88,8 @@ impl IdentityStore<'_> {
         version_hash: u64,
     ) -> Result<Option<impl Iterator<Item = redb::AccessGuard<'_, Identity>>>> {
         use super::TableProvider;
-        self.apply_read(|r| {
+        let net = self.network_hash();
+        self.apply_read(move |r| {
             let Some(table) = super::open_table_optional(
                 r,
                 <Self as TableProvider<IdentityKey, Identity>>::table(),
@@ -96,8 +98,8 @@ impl IdentityStore<'_> {
                 return Ok(None);
             };
 
-            let start = IdentityKey::low_one_version(version_hash);
-            let end = IdentityKey::high_one_version(version_hash);
+            let start = IdentityKey::low_one_version(net, version_hash);
+            let end = IdentityKey::high_one_version(net, version_hash);
             let before = table.range(..start)?;
             let after = table.range(end..)?;
             let rows: Vec<_> = before.chain(after).try_collect()?;
@@ -157,16 +159,16 @@ impl<'a> super::TableProvider<'a, IdentityKey, Identity> for IdentityStorage {
 }
 
 impl super::TrackMetadata for IdentityStorage {
-    fn increment<'a>(&self, store: impl Into<MetadataStore<'a>>, n: u32) -> Result<()> {
-        let store: MetadataStore = store.into();
+    fn increment(&self, tx: &redb::WriteTransaction, network: u64, n: u32) -> Result<()> {
+        let store = MetadataStore::from_write_tx(tx, network);
         store.modify(crate::meta_key!(), |meta| {
             meta.identities += n;
         })?;
         Ok(())
     }
 
-    fn decrement<'a>(&self, store: impl Into<MetadataStore<'a>>, n: u32) -> Result<()> {
-        let store: MetadataStore = store.into();
+    fn decrement(&self, tx: &redb::WriteTransaction, network: u64, n: u32) -> Result<()> {
+        let store = MetadataStore::from_write_tx(tx, network);
         store.modify(crate::meta_key!(), |meta| {
             meta.identities -= n;
         })?;

--- a/apps/xmtp_debug/src/app/store/identity.rs
+++ b/apps/xmtp_debug/src/app/store/identity.rs
@@ -1,5 +1,6 @@
 use crate::{app::types::*, constants::STORAGE_PREFIX};
 use color_eyre::eyre::Result;
+use itertools::Itertools;
 use redb::TableDefinition;
 use std::sync::Arc;
 
@@ -22,19 +23,16 @@ pub type IdentityStore<'a> = super::KeyValueStore<'a, IdentityStorage>;
 
 impl From<Arc<redb::Database>> for IdentityStore<'_> {
     fn from(value: Arc<redb::Database>) -> Self {
-        IdentityStore {
-            db: super::DatabaseOrTransaction::Db(value),
-            store: IdentityStorage,
-        }
+        IdentityStore::new(IdentityStorage, super::DatabaseOrTransaction::Db(value))
     }
 }
 
 impl From<Arc<redb::ReadOnlyDatabase>> for IdentityStore<'_> {
     fn from(value: Arc<redb::ReadOnlyDatabase>) -> Self {
-        IdentityStore {
-            db: super::DatabaseOrTransaction::ReadOnly(value),
-            store: IdentityStorage,
-        }
+        IdentityStore::new(
+            IdentityStorage,
+            super::DatabaseOrTransaction::ReadOnly(value),
+        )
     }
 }
 
@@ -45,9 +43,9 @@ impl IdentityStore<'_> {
     /// `xdbg inspect`). Strict-mode point lookups should construct the
     /// `IdentityKey` directly with `App::current_version_hash()` and call
     /// `Database::get` instead.
-    pub fn find_by_inbox(&self, network: u64, inbox: [u8; 32]) -> Result<Option<Identity>> {
+    pub fn find_by_inbox(&self, inbox: [u8; 32]) -> Result<Option<Identity>> {
         use super::Database;
-        let Some(iter) = self.load(network)? else {
+        let Some(iter) = self.load()? else {
             return Ok(None);
         };
         for guard in iter {
@@ -64,12 +62,10 @@ impl IdentityStore<'_> {
     /// every version on the network; this filtered variant backs
     /// `--strict-versioning`.
     pub fn load_for_version(
-        &'_ self,
-        network: impl Into<u64>,
+        &self,
         version_hash: u64,
     ) -> Result<Option<impl Iterator<Item = redb::AccessGuard<'_, Identity>>>> {
         use super::TableProvider;
-        let network: u64 = network.into();
         self.apply_read(|r| {
             let Some(table) = super::open_table_optional(
                 r,
@@ -78,9 +74,33 @@ impl IdentityStore<'_> {
             else {
                 return Ok(None);
             };
-            let start = IdentityKey::low_one_version(network, version_hash);
-            let end = IdentityKey::high_one_version(network, version_hash);
+            let start = IdentityKey::low_one_version(version_hash);
+            let end = IdentityKey::high_one_version(version_hash);
             let rows: Vec<_> = table.range(start..=end)?.collect::<Result<_, _>>()?;
+            Ok(Some(rows.into_iter().map(|(_, v)| v)))
+        })
+    }
+
+    /// the inverse of the above. load every identity except for identities of version `version_hash`.
+    pub fn load_for_other_versions(
+        &self,
+        version_hash: u64,
+    ) -> Result<Option<impl Iterator<Item = redb::AccessGuard<'_, Identity>>>> {
+        use super::TableProvider;
+        self.apply_read(|r| {
+            let Some(table) = super::open_table_optional(
+                r,
+                <Self as TableProvider<IdentityKey, Identity>>::table(),
+            )?
+            else {
+                return Ok(None);
+            };
+
+            let start = IdentityKey::low_one_version(version_hash);
+            let end = IdentityKey::high_one_version(version_hash);
+            let before = table.range(..start)?;
+            let after = table.range(end..)?;
+            let rows: Vec<_> = before.chain(after).try_collect()?;
             Ok(Some(rows.into_iter().map(|(_, v)| v)))
         })
     }
@@ -95,7 +115,6 @@ impl IdentityStore<'_> {
     /// over-sample and filter the result.
     pub fn sample_n(
         &self,
-        network: impl Into<u64> + Copy,
         rng: &mut impl rand::Rng,
         n: usize,
         strict: bool,
@@ -104,13 +123,12 @@ impl IdentityStore<'_> {
         if !strict {
             use super::RandomDatabase;
             return Ok(self
-                .random_n_capped(network, rng, n)?
+                .random_n_capped(rng, n)?
                 .iter()
                 .map(|g| g.value())
                 .collect());
         }
-        let Some(iter) = self.load_for_version(network, crate::app::App::current_version_hash())?
-        else {
+        let Some(iter) = self.load_for_version(crate::app::App::current_version_hash())? else {
             return Ok(Vec::new());
         };
         Ok(iter.map(|g| g.value()).sample(rng, n))
@@ -118,22 +136,14 @@ impl IdentityStore<'_> {
 }
 
 impl super::DeriveKey<IdentityKey> for Identity {
-    fn key(&self, network: u64) -> IdentityKey {
-        IdentityKey {
-            network,
-            version_hash: self.version_hash,
-            inbox: self.inbox_id,
-        }
+    fn key(&self) -> IdentityKey {
+        IdentityKey::new(self.version_hash, self.inbox_id)
     }
 }
 
 impl super::DeriveKey<IdentityKey> for &Identity {
-    fn key(&self, network: u64) -> IdentityKey {
-        IdentityKey {
-            network,
-            version_hash: self.version_hash,
-            inbox: self.inbox_id,
-        }
+    fn key(&self) -> IdentityKey {
+        IdentityKey::new(self.version_hash, self.inbox_id)
     }
 }
 
@@ -147,27 +157,17 @@ impl<'a> super::TableProvider<'a, IdentityKey, Identity> for IdentityStorage {
 }
 
 impl super::TrackMetadata for IdentityStorage {
-    fn increment<'a>(
-        &self,
-        store: impl Into<MetadataStore<'a>>,
-        network: u64,
-        n: u32,
-    ) -> Result<()> {
+    fn increment<'a>(&self, store: impl Into<MetadataStore<'a>>, n: u32) -> Result<()> {
         let store: MetadataStore = store.into();
-        store.modify(crate::meta_key!(network), |meta| {
+        store.modify(crate::meta_key!(), |meta| {
             meta.identities += n;
         })?;
         Ok(())
     }
 
-    fn decrement<'a>(
-        &self,
-        store: impl Into<MetadataStore<'a>>,
-        network: u64,
-        n: u32,
-    ) -> Result<()> {
+    fn decrement<'a>(&self, store: impl Into<MetadataStore<'a>>, n: u32) -> Result<()> {
         let store: MetadataStore = store.into();
-        store.modify(crate::meta_key!(network), |meta| {
+        store.modify(crate::meta_key!(), |meta| {
             meta.identities -= n;
         })?;
         Ok(())

--- a/apps/xmtp_debug/src/app/store/messages.rs
+++ b/apps/xmtp_debug/src/app/store/messages.rs
@@ -64,14 +64,14 @@ impl<'a> super::TableProvider<'a, MessageKey, Message> for MessageStorage {
 }
 
 impl super::TrackMetadata for MessageStorage {
-    fn increment<'a>(&self, store: impl Into<MetadataStore<'a>>, n: u32) -> Result<()> {
-        let store = store.into();
+    fn increment(&self, tx: &redb::WriteTransaction, network: u64, n: u32) -> Result<()> {
+        let store = MetadataStore::from_write_tx(tx, network);
         store.modify(crate::meta_key!(), |meta| meta.messages += n)?;
         Ok(())
     }
 
-    fn decrement<'a>(&self, store: impl Into<MetadataStore<'a>>, n: u32) -> Result<()> {
-        let store = store.into();
+    fn decrement(&self, tx: &redb::WriteTransaction, network: u64, n: u32) -> Result<()> {
+        let store = MetadataStore::from_write_tx(tx, network);
         store.modify(crate::meta_key!(), |meta| meta.messages -= n)?;
         Ok(())
     }
@@ -80,7 +80,7 @@ impl super::TrackMetadata for MessageStorage {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app::{App, store::Database};
+    use crate::app::store::Database;
     use std::sync::Arc;
     use tempfile::NamedTempFile;
 
@@ -90,20 +90,27 @@ mod tests {
         (Arc::new(db), tmp)
     }
 
+    fn store_for(db: Arc<redb::Database>) -> MessageStore<'static> {
+        super::super::KeyValueStore::with_network(
+            MessageStorage,
+            super::super::DatabaseOrTransaction::Db(db),
+            0,
+        )
+    }
+
     fn sample_message(group: [u8; 16], msg_id: [u8; 32]) -> Message {
         Message::new(msg_id, group, [1u8; 32], 42)
     }
 
     #[test]
     fn message_store_set_then_get_roundtrips() {
-        App::set_network(1);
         let (db, _tmp) = open_temp_db();
-        let store: MessageStore<'static> = db.into();
+        let store = store_for(db);
         let msg = sample_message([0xAAu8; 16], [0xBBu8; 32]);
 
         store.set(msg.clone()).expect("set");
 
-        let key = <Message as super::super::DeriveKey<MessageKey>>::key(&msg, 1);
+        let key = <Message as super::super::DeriveKey<MessageKey>>::key(&msg);
         let got = store.get(key).expect("get");
         assert_eq!(got, Some(msg));
     }
@@ -111,16 +118,16 @@ mod tests {
     #[test]
     fn message_store_load_returns_all_messages_for_network() {
         let (db, _tmp) = open_temp_db();
-        let store: MessageStore<'static> = db.into();
+        let store = store_for(db);
         let m1 = sample_message([0x10u8; 16], [0x01u8; 32]);
         let m2 = sample_message([0x20u8; 16], [0x02u8; 32]);
         let m3 = sample_message([0x20u8; 16], [0x03u8; 32]);
 
         store
-            .set_all(&[m1.clone(), m2.clone(), m3.clone()], 7u64)
+            .set_all(&[m1.clone(), m2.clone(), m3.clone()])
             .expect("set_all");
 
-        let iter = store.load(7u64).expect("load").expect("non-empty");
+        let iter = store.load().expect("load").expect("non-empty");
         let collected: Vec<Message> = iter.map(|g| g.value()).collect();
         assert_eq!(collected.len(), 3);
     }
@@ -128,17 +135,17 @@ mod tests {
     #[test]
     fn message_store_load_then_filter_by_group_id() {
         let (db, _tmp) = open_temp_db();
-        let store: MessageStore<'static> = db.into();
+        let store = store_for(db);
         let group_a = [0x10u8; 16];
         let group_b = [0x20u8; 16];
         let a1 = sample_message(group_a, [0x01u8; 32]);
         let a2 = sample_message(group_a, [0x02u8; 32]);
         let b1 = sample_message(group_b, [0x03u8; 32]);
         store
-            .set_all(&[a1.clone(), a2.clone(), b1.clone()], 7u64)
+            .set_all(&[a1.clone(), a2.clone(), b1.clone()])
             .expect("set_all");
 
-        let iter = store.load(7u64).expect("load").expect("non-empty");
+        let iter = store.load().expect("load").expect("non-empty");
         let only_a: Vec<Message> = iter
             .map(|g| g.value())
             .filter(|m| m.group_id() == group_a)

--- a/apps/xmtp_debug/src/app/store/messages.rs
+++ b/apps/xmtp_debug/src/app/store/messages.rs
@@ -20,20 +20,20 @@ const TABLE: TableDefinition<MessageKey, Message> = TableDefinition::new(NAMESPA
 pub type MessageKey = super::NetworkKey<48>;
 
 impl super::DeriveKey<MessageKey> for Message {
-    fn key(&self, network: u64) -> MessageKey {
+    fn key(&self) -> MessageKey {
         let mut combined = [0u8; 48];
         combined[..16].copy_from_slice(&*self.group_id());
         combined[16..].copy_from_slice(&self.id);
-        MessageKey::new(network, combined)
+        MessageKey::new(combined)
     }
 }
 
 impl super::DeriveKey<MessageKey> for &Message {
-    fn key(&self, network: u64) -> MessageKey {
+    fn key(&self) -> MessageKey {
         let mut combined = [0u8; 48];
         combined[..16].copy_from_slice(&*self.group_id());
         combined[16..].copy_from_slice(&self.id);
-        MessageKey::new(network, combined)
+        MessageKey::new(combined)
     }
 }
 
@@ -41,19 +41,16 @@ pub type MessageStore<'a> = super::KeyValueStore<'a, MessageStorage>;
 
 impl From<Arc<redb::Database>> for MessageStore<'_> {
     fn from(value: Arc<redb::Database>) -> Self {
-        MessageStore {
-            db: super::DatabaseOrTransaction::Db(value),
-            store: MessageStorage,
-        }
+        MessageStore::new(MessageStorage, super::DatabaseOrTransaction::Db(value))
     }
 }
 
 impl From<Arc<redb::ReadOnlyDatabase>> for MessageStore<'_> {
     fn from(value: Arc<redb::ReadOnlyDatabase>) -> Self {
-        MessageStore {
-            db: super::DatabaseOrTransaction::ReadOnly(value),
-            store: MessageStorage,
-        }
+        MessageStore::new(
+            MessageStorage,
+            super::DatabaseOrTransaction::ReadOnly(value),
+        )
     }
 }
 
@@ -67,25 +64,15 @@ impl<'a> super::TableProvider<'a, MessageKey, Message> for MessageStorage {
 }
 
 impl super::TrackMetadata for MessageStorage {
-    fn increment<'a>(
-        &self,
-        store: impl Into<MetadataStore<'a>>,
-        network: u64,
-        n: u32,
-    ) -> Result<()> {
+    fn increment<'a>(&self, store: impl Into<MetadataStore<'a>>, n: u32) -> Result<()> {
         let store = store.into();
-        store.modify(crate::meta_key!(network), |meta| meta.messages += n)?;
+        store.modify(crate::meta_key!(), |meta| meta.messages += n)?;
         Ok(())
     }
 
-    fn decrement<'a>(
-        &self,
-        store: impl Into<MetadataStore<'a>>,
-        network: u64,
-        n: u32,
-    ) -> Result<()> {
+    fn decrement<'a>(&self, store: impl Into<MetadataStore<'a>>, n: u32) -> Result<()> {
         let store = store.into();
-        store.modify(crate::meta_key!(network), |meta| meta.messages -= n)?;
+        store.modify(crate::meta_key!(), |meta| meta.messages -= n)?;
         Ok(())
     }
 }
@@ -93,7 +80,7 @@ impl super::TrackMetadata for MessageStorage {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app::store::Database;
+    use crate::app::{App, store::Database};
     use std::sync::Arc;
     use tempfile::NamedTempFile;
 
@@ -109,11 +96,12 @@ mod tests {
 
     #[test]
     fn message_store_set_then_get_roundtrips() {
+        App::set_network(1);
         let (db, _tmp) = open_temp_db();
         let store: MessageStore<'static> = db.into();
         let msg = sample_message([0xAAu8; 16], [0xBBu8; 32]);
 
-        store.set(msg.clone(), 1u64).expect("set");
+        store.set(msg.clone()).expect("set");
 
         let key = <Message as super::super::DeriveKey<MessageKey>>::key(&msg, 1);
         let got = store.get(key).expect("get");

--- a/apps/xmtp_debug/src/app/store/metadata.rs
+++ b/apps/xmtp_debug/src/app/store/metadata.rs
@@ -21,8 +21,8 @@ pub type MetadataStore<'a> = super::KeyValueStore<'a, MetadataStorage>;
 #[macro_export]
 #[macro_use]
 macro_rules! meta_key {
-    ($network:expr) => {
-        $crate::app::store::NetworkKey::<0>::new(u64::from($network), [])
+    () => {
+        $crate::app::store::NetworkKey::<0>::new([])
     };
 }
 
@@ -69,56 +69,37 @@ impl<'a> super::TableProvider<'a, MetaKey, Metadata> for MetadataStorage {
 
 // No-Op for Metadata Table
 impl super::TrackMetadata for MetadataStorage {
-    fn increment<'a>(
-        &self,
-        store: impl Into<MetadataStore<'a>>,
-        network: u64,
-        n: u32,
-    ) -> Result<()> {
+    fn increment<'a>(&self, store: impl Into<MetadataStore<'a>>, n: u32) -> Result<()> {
         Ok(())
     }
-    fn decrement<'a>(
-        &self,
-        store: impl Into<MetadataStore<'a>>,
-        network: u64,
-        n: u32,
-    ) -> Result<()> {
+    fn decrement<'a>(&self, store: impl Into<MetadataStore<'a>>, n: u32) -> Result<()> {
         Ok(())
     }
 }
 
 impl super::DeriveKey<MetaKey> for Metadata {
-    fn key(&self, network: u64) -> MetaKey {
-        MetaKey {
-            network,
-            key: Default::default(),
-        }
+    fn key(&self) -> MetaKey {
+        meta_key!()
     }
 }
 
 impl super::DeriveKey<MetaKey> for &Metadata {
-    fn key(&self, network: u64) -> MetaKey {
-        MetaKey {
-            network,
-            key: Default::default(),
-        }
+    fn key(&self) -> MetaKey {
+        meta_key!()
     }
 }
 
 impl From<Arc<redb::Database>> for MetadataStore<'static> {
     fn from(value: Arc<redb::Database>) -> Self {
-        MetadataStore {
-            db: super::DatabaseOrTransaction::Db(value),
-            store: MetadataStorage,
-        }
+        MetadataStore::new(MetadataStorage, super::DatabaseOrTransaction::Db(value))
     }
 }
 
 impl From<Arc<redb::ReadOnlyDatabase>> for MetadataStore<'static> {
     fn from(value: Arc<redb::ReadOnlyDatabase>) -> Self {
-        MetadataStore {
-            db: super::DatabaseOrTransaction::ReadOnly(value),
-            store: MetadataStorage,
-        }
+        MetadataStore::new(
+            MetadataStorage,
+            super::DatabaseOrTransaction::ReadOnly(value),
+        )
     }
 }

--- a/apps/xmtp_debug/src/app/store/metadata.rs
+++ b/apps/xmtp_debug/src/app/store/metadata.rs
@@ -69,10 +69,10 @@ impl<'a> super::TableProvider<'a, MetaKey, Metadata> for MetadataStorage {
 
 // No-Op for Metadata Table
 impl super::TrackMetadata for MetadataStorage {
-    fn increment<'a>(&self, store: impl Into<MetadataStore<'a>>, n: u32) -> Result<()> {
+    fn increment(&self, _tx: &WriteTransaction, _network: u64, _n: u32) -> Result<()> {
         Ok(())
     }
-    fn decrement<'a>(&self, store: impl Into<MetadataStore<'a>>, n: u32) -> Result<()> {
+    fn decrement(&self, _tx: &WriteTransaction, _network: u64, _n: u32) -> Result<()> {
         Ok(())
     }
 }

--- a/apps/xmtp_debug/src/app/stream.rs
+++ b/apps/xmtp_debug/src/app/stream.rs
@@ -19,41 +19,40 @@ use crate::{
 
 pub struct Stream {
     db: Arc<redb::ReadOnlyDatabase>,
-    opts: args::StreamOpts,
-    network: args::BackendOpts,
+    opts: &'static args::StreamOpts,
 }
 
 impl Stream {
-    pub fn new(opts: StreamOpts, network: args::BackendOpts) -> Result<Self> {
+    pub fn new(opts: &'static StreamOpts) -> Result<Self> {
         let db = App::readonly_db()?;
-        Ok(Self { opts, network, db })
+        Ok(Self { opts, db })
     }
 
     pub async fn run(self) -> Result<()> {
-        let Stream { db, opts, network } = self;
+        let Stream { db, opts } = self;
         let identity_store: IdentityStore = db.clone().into();
         let args::StreamOpts {
             inbox,
-            ref kind,
+            kind,
             out,
             format,
         } = opts;
         let rng = &mut SmallRng::from_rng(&mut rand::rng());
         let identity = if let Some(inbox_id) = inbox {
-            let identity = identity_store.find_by_inbox(u64::from(&network), *inbox_id)?;
+            let identity = identity_store.find_by_inbox(**inbox_id)?;
             if identity.is_none() {
                 bail!("No local identity with inbox_id=[{}]", inbox_id);
             }
             identity.expect("checked for some")
         } else {
             identity_store
-                .load(&network)?
+                .load()?
                 .ok_or(eyre!("No identities in store"))?
                 .map(|i| i.value())
                 .choose(rng)
                 .ok_or(eyre!("Identity not found"))?
         };
-        let client = app::client_from_identity(&identity, &network)?;
+        let client = app::client_from_identity(&identity)?;
 
         let mut buffer: Box<dyn Write> = if let Some(p) = out {
             Box::new(BufWriter::new(fs::File::create(p)?))

--- a/apps/xmtp_debug/src/app/stream.rs
+++ b/apps/xmtp_debug/src/app/stream.rs
@@ -88,7 +88,7 @@ impl Stream {
                         group_name: group.group_name()?,
                         group_description: group.group_description()?,
                     };
-                    write(&format, buffer.as_mut(), &item)?;
+                    write(format, buffer.as_mut(), &item)?;
                     buffer.flush()?;
                 }
             }
@@ -119,7 +119,7 @@ impl Stream {
                         version_minor: message.version_minor,
                         authority_id: message.authority_id,
                     };
-                    write(&format, buffer.as_mut(), &item)?;
+                    write(format, buffer.as_mut(), &item)?;
                     buffer.flush()?;
                 }
             }

--- a/apps/xmtp_debug/src/app/sync.rs
+++ b/apps/xmtp_debug/src/app/sync.rs
@@ -6,26 +6,26 @@
 //! current network-key partition. No implicit behavior.
 
 use crate::app::health::inbox_id_to_bytes;
-use crate::app::store::{Database, GroupStore, IdentityStore, MessageStore, NetworkKey};
+use crate::app::store::{Database, GroupStore, IdentityStore, MessageStore};
 use crate::app::types::{Group, InboxId, Message};
 use crate::app::{self, App};
-use crate::args::{self, SyncOpts};
-use color_eyre::eyre::{self, Report, Result};
+use crate::args::SyncOpts;
+use color_eyre::eyre::{self, Report, Result, ensure};
 use itertools::Itertools;
 use std::time::Instant;
 use tracing::warn;
+use xmtp_db::group::ConversationType;
 use xmtp_db::group_message::{GroupMessageKind, MsgQueryArgs};
 use xmtp_db::prelude::QueryGroupMessage;
 
 pub struct Sync {
     #[allow(dead_code)]
-    opts: SyncOpts,
-    network: args::BackendOpts,
+    opts: &'static SyncOpts,
 }
 
 impl Sync {
-    pub fn new(opts: SyncOpts, network: args::BackendOpts) -> Self {
-        Self { opts, network }
+    pub fn new(opts: &'static SyncOpts) -> Self {
+        Self { opts }
     }
 
     pub async fn run(self) -> Result<()> {
@@ -34,8 +34,7 @@ impl Sync {
         let group_store: GroupStore<'static> = redb.clone().into();
         let message_store: MessageStore<'static> = redb.into();
 
-        let net_key = u64::from(&self.network);
-        let clients = app::load_all_identities(&id_store, &self.network)?;
+        let clients = app::load_all_identities(&id_store)?;
 
         let mut totals = SyncStats::default();
         let mut success = 0usize;
@@ -44,7 +43,7 @@ impl Sync {
         for (inbox_id, mutex) in clients.iter() {
             let client = mutex.lock().await;
             let start = Instant::now();
-            match Self::sync_one(&client, &group_store, &message_store, net_key).await {
+            match Self::sync_one(&client, &group_store, &message_store).await {
                 Ok(stats) => {
                     success += 1;
                     totals += &stats;
@@ -82,14 +81,54 @@ impl Sync {
         client: &crate::DbgClient,
         group_store: &GroupStore<'static>,
         message_store: &MessageStore<'static>,
-        net_key: u64,
     ) -> Result<SyncStats> {
         let mut stats = SyncStats::default();
+
+        let dm_store = group_store.clone().into();
 
         let summary = client.sync_all_welcomes_and_groups(None).await?;
         stats.skipped_groups = summary.num_eligible.saturating_sub(summary.num_synced);
 
         let groups = client.find_groups(Default::default())?;
+        let (groups, dms) = groups.into_iter().partition(|g| g.dm_id.is_none());
+
+        for dm in dms {
+            let gid = dm.group_id;
+
+            let live_members: Vec<InboxId> = group
+                .members()
+                .await?
+                .into_iter()
+                .map(|m| Ok::<_, Report>(inbox_id_to_bytes(&m.inbox_id)))
+                .try_collect()?;
+
+            let dm_id = dm.dm_id.expect("dm id must be some");
+            let md = dm.metadata().await?;
+            let creator_bytes = inbox_id_to_bytes(&md.creator_inbox_id);
+            let other = live_members.iter().filter(|i| i!= creator_bytes).collect::<Vec<_>>();
+            ensure!(other.len() == 1, "DM has more than one inbox associated with it.");
+            let other = other[0];
+            let persisted = dm_store.get(DmId::new(creator_bytes, other).into())?;
+            match persisted {
+                None => {
+                    dm_store.set(Dm::new(gid, creator_bytes, other))?;
+                    stats.new_dms += 1;
+                    tracing::info!(
+                        target: "xdbg.sync",
+                        id = %dm_id,
+                        "imported new dm into DmStore"
+                    );
+                },
+                Some(existing) => {
+                    tracing::info!(
+                        target: "xdbg.sync",
+                        id = %dm_id,
+                        gid = %gid,
+                        "new dm already existed, skipping update"
+                    );
+                }
+            }
+        }
 
         for group in groups {
             let gid = group.group_id;
@@ -101,15 +140,15 @@ impl Sync {
                 .map(|m| Ok::<_, Report>(inbox_id_to_bytes(&m.inbox_id)))
                 .try_collect()?;
 
-            let group_store_key = NetworkKey::new(net_key, gid);
-            let persisted = group_store.get(group_store_key)?;
-
+            let persisted = group_store.get(gid.into())?;
             match persisted {
                 None => {
                     let md = group.metadata().await?;
                     let creator_bytes = inbox_id_to_bytes(&md.creator_inbox_id);
                     let member_count = live_members.len();
-                    group_store.set(Group::new(gid, creator_bytes, live_members), net_key)?;
+                    let is_dm = matches!(md.conversation_type, ConversationType::Dm);
+                    ensure!(!is_dm, "group says it is a DM when it should not be. this is a bug.");
+                    group_store.set(Group::new(gid, creator_bytes, live_members))?;
                     stats.new_groups += 1;
                     tracing::info!(
                         target: "xdbg.sync",
@@ -120,10 +159,11 @@ impl Sync {
                 }
                 Some(existing) if existing.members != live_members => {
                     let member_count = live_members.len();
-                    group_store.set(
-                        Group::new(*existing.id(), existing.created_by, live_members),
-                        net_key,
-                    )?;
+                    group_store.set(Group::new(
+                        *existing.id(),
+                        existing.created_by,
+                        live_members,
+                    ))?;
                     stats.updated_groups += 1;
                     tracing::info!(
                         target: "xdbg.sync",
@@ -153,13 +193,10 @@ impl Sync {
                         .try_into()
                         .inspect_err(|_| tracing::error!("message id must be 32 bytes"))?;
 
-                let msg_key = Message::redb_key(net_key, gid, message_id);
+                let msg_key = Message::redb_key(gid, message_id);
                 if message_store.get(msg_key)?.is_none() {
                     let sender_bytes = inbox_id_to_bytes(&m.sender_inbox_id);
-                    message_store.set(
-                        Message::new(message_id, gid, sender_bytes, m.sent_at_ns),
-                        net_key,
-                    )?;
+                    message_store.set(Message::new(message_id, gid, sender_bytes, m.sent_at_ns))?;
                     stats.orphan_messages += 1;
                     tracing::warn!(
                         target: "xdbg.sync",
@@ -178,6 +215,7 @@ impl Sync {
 #[derive(Default, Debug)]
 struct SyncStats {
     new_groups: usize,
+    new_dms: usize,
     updated_groups: usize,
     orphan_messages: usize,
     skipped_groups: usize,
@@ -186,10 +224,11 @@ struct SyncStats {
 impl std::fmt::Display for SyncStats {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let plural = if self.new_groups == 1 { "" } else { "s" };
+        let plural_dm = if self.new_dms == 1 { "" } else { "s" };
         write!(
             f,
-            "{} new group{plural}, {} updated, {} orphan messages, {} skipped",
-            self.new_groups, self.updated_groups, self.orphan_messages, self.skipped_groups,
+            "{} new group{plural}, {} new dm{plural}, {} updated, {} orphan messages, {} skipped",
+            self.new_groups, self.new_dms, self.updated_groups, self.orphan_messages, self.skipped_groups,
         )
     }
 }

--- a/apps/xmtp_debug/src/app/sync.rs
+++ b/apps/xmtp_debug/src/app/sync.rs
@@ -6,15 +6,14 @@
 //! current network-key partition. No implicit behavior.
 
 use crate::app::health::inbox_id_to_bytes;
-use crate::app::store::{Database, GroupStore, IdentityStore, MessageStore};
-use crate::app::types::{Group, InboxId, Message};
+use crate::app::store::{Database, DmStore, GroupStore, IdentityStore, MessageStore};
+use crate::app::types::{Dm, DmId, Group, InboxId, Message};
 use crate::app::{self, App};
 use crate::args::SyncOpts;
-use color_eyre::eyre::{self, Report, Result, ensure};
+use color_eyre::eyre::{self, Report, Result};
 use itertools::Itertools;
 use std::time::Instant;
 use tracing::warn;
-use xmtp_db::group::ConversationType;
 use xmtp_db::group_message::{GroupMessageKind, MsgQueryArgs};
 use xmtp_db::prelude::QueryGroupMessage;
 
@@ -32,6 +31,7 @@ impl Sync {
         let redb = App::db()?;
         let id_store: IdentityStore<'static> = redb.clone().into();
         let group_store: GroupStore<'static> = redb.clone().into();
+        let dm_store: DmStore<'static> = redb.clone().into();
         let message_store: MessageStore<'static> = redb.into();
 
         let clients = app::load_all_identities(&id_store)?;
@@ -43,7 +43,7 @@ impl Sync {
         for (inbox_id, mutex) in clients.iter() {
             let client = mutex.lock().await;
             let start = Instant::now();
-            match Self::sync_one(&client, &group_store, &message_store).await {
+            match Self::sync_one(&client, &group_store, &dm_store, &message_store).await {
                 Ok(stats) => {
                     success += 1;
                     totals += &stats;
@@ -80,51 +80,52 @@ impl Sync {
     async fn sync_one(
         client: &crate::DbgClient,
         group_store: &GroupStore<'static>,
+        dm_store: &DmStore<'static>,
         message_store: &MessageStore<'static>,
     ) -> Result<SyncStats> {
         let mut stats = SyncStats::default();
 
-        let dm_store = group_store.clone().into();
-
         let summary = client.sync_all_welcomes_and_groups(None).await?;
         stats.skipped_groups = summary.num_eligible.saturating_sub(summary.num_synced);
 
-        let groups = client.find_groups(Default::default())?;
-        let (groups, dms) = groups.into_iter().partition(|g| g.dm_id.is_none());
+        let all = client.find_groups(Default::default())?;
+        let (groups, dms): (Vec<_>, Vec<_>) = all.into_iter().partition(|g| g.dm_id.is_none());
 
         for dm in dms {
             let gid = dm.group_id;
 
-            let live_members: Vec<InboxId> = group
+            let live_members: Vec<InboxId> = dm
                 .members()
                 .await?
                 .into_iter()
                 .map(|m| Ok::<_, Report>(inbox_id_to_bytes(&m.inbox_id)))
                 .try_collect()?;
 
-            let dm_id = dm.dm_id.expect("dm id must be some");
+            let dm_id = dm.dm_id.clone().expect("dm id must be some");
             let md = dm.metadata().await?;
             let creator_bytes = inbox_id_to_bytes(&md.creator_inbox_id);
-            let other = live_members.iter().filter(|i| i!= creator_bytes).collect::<Vec<_>>();
-            ensure!(other.len() == 1, "DM has more than one inbox associated with it.");
-            let other = other[0];
+            let other = live_members
+                .iter()
+                .copied()
+                .find(|i| *i != creator_bytes)
+                .ok_or_else(|| eyre::eyre!("DM has no inbox distinct from the creator"))?;
             let persisted = dm_store.get(DmId::new(creator_bytes, other).into())?;
             match persisted {
                 None => {
-                    dm_store.set(Dm::new(gid, creator_bytes, other))?;
+                    dm_store.set(Dm::new(creator_bytes, other, gid))?;
                     stats.new_dms += 1;
                     tracing::info!(
                         target: "xdbg.sync",
                         id = %dm_id,
                         "imported new dm into DmStore"
                     );
-                },
-                Some(existing) => {
+                }
+                Some(_existing) => {
                     tracing::info!(
                         target: "xdbg.sync",
                         id = %dm_id,
-                        gid = %gid,
-                        "new dm already existed, skipping update"
+                        group = %gid,
+                        "dm already persisted; skipping"
                     );
                 }
             }
@@ -146,8 +147,6 @@ impl Sync {
                     let md = group.metadata().await?;
                     let creator_bytes = inbox_id_to_bytes(&md.creator_inbox_id);
                     let member_count = live_members.len();
-                    let is_dm = matches!(md.conversation_type, ConversationType::Dm);
-                    ensure!(!is_dm, "group says it is a DM when it should not be. this is a bug.");
                     group_store.set(Group::new(gid, creator_bytes, live_members))?;
                     stats.new_groups += 1;
                     tracing::info!(
@@ -223,12 +222,16 @@ struct SyncStats {
 
 impl std::fmt::Display for SyncStats {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let plural = if self.new_groups == 1 { "" } else { "s" };
-        let plural_dm = if self.new_dms == 1 { "" } else { "s" };
+        let plural_g = if self.new_groups == 1 { "" } else { "s" };
+        let plural_d = if self.new_dms == 1 { "" } else { "s" };
         write!(
             f,
-            "{} new group{plural}, {} new dm{plural}, {} updated, {} orphan messages, {} skipped",
-            self.new_groups, self.new_dms, self.updated_groups, self.orphan_messages, self.skipped_groups,
+            "{} new group{plural_g}, {} new dm{plural_d}, {} updated, {} orphan messages, {} skipped",
+            self.new_groups,
+            self.new_dms,
+            self.updated_groups,
+            self.orphan_messages,
+            self.skipped_groups,
         )
     }
 }
@@ -236,6 +239,7 @@ impl std::fmt::Display for SyncStats {
 impl std::ops::AddAssign<&SyncStats> for SyncStats {
     fn add_assign(&mut self, rhs: &SyncStats) {
         self.new_groups += rhs.new_groups;
+        self.new_dms += rhs.new_dms;
         self.updated_groups += rhs.updated_groups;
         self.orphan_messages += rhs.orphan_messages;
         self.skipped_groups += rhs.skipped_groups;

--- a/apps/xmtp_debug/src/app/test.rs
+++ b/apps/xmtp_debug/src/app/test.rs
@@ -14,6 +14,7 @@ use xmtp_proto::types::Topic;
 use xmtp_proto::xmtp::xmtpv4::envelopes::{OriginatorEnvelope, UnsignedOriginatorEnvelope};
 use xmtp_proto::xmtp::xmtpv4::message_api::EnvelopesQuery;
 
+use crate::app::App;
 use crate::{
     app::{self, generate_wallet},
     args::{self, TestOpts, TestScenario},
@@ -62,12 +63,13 @@ async fn query_v4_envelopes(
 }
 
 pub struct Test {
-    opts: TestOpts,
+    opts: &'static TestOpts,
     network: args::BackendOpts,
 }
 
 impl Test {
-    pub fn new(opts: TestOpts, network: args::BackendOpts) -> Self {
+    pub fn new(opts: &'static TestOpts) -> Self {
+        let network = App::network().clone();
         Self { opts, network }
     }
 
@@ -135,14 +137,14 @@ impl Test {
         // Step 1: Create 2 fresh users/identities
         info!("creating sender");
         let wallet1 = generate_wallet();
-        let client1 = app::temp_client(&self.network, Some(&wallet1)).await?;
+        let client1 = app::temp_client(Some(&wallet1)).await?;
         app::register_client(&client1, wallet1.clone().into_alloy()).await?;
         let inbox_id1 = client1.inbox_id().to_string();
         info!(inbox_id = inbox_id1, "sender created");
 
         info!("creating receiver");
         let wallet2 = generate_wallet();
-        let client2 = app::temp_client(&self.network, Some(&wallet2)).await?;
+        let client2 = app::temp_client(Some(&wallet2)).await?;
         app::register_client(&client2, wallet2.clone().into_alloy()).await?;
         let inbox_id2 = client2.inbox_id().to_string();
         info!(inbox_id = inbox_id2, "receiver created");
@@ -286,14 +288,14 @@ impl Test {
         // Step 1: Create 2 fresh users/identities
         info!("creating sender");
         let wallet1 = generate_wallet();
-        let client1 = app::temp_client(&self.network, Some(&wallet1)).await?;
+        let client1 = app::temp_client(Some(&wallet1)).await?;
         app::register_client(&client1, wallet1.clone().into_alloy()).await?;
         let inbox_id1 = client1.inbox_id().to_string();
         info!(inbox_id = inbox_id1, "sender created");
 
         info!("creating receiver");
         let wallet2 = generate_wallet();
-        let client2 = app::temp_client(&self.network, Some(&wallet2)).await?;
+        let client2 = app::temp_client(Some(&wallet2)).await?;
         app::register_client(&client2, wallet2.clone().into_alloy()).await?;
         let inbox_id2 = client2.inbox_id().to_string();
         info!(inbox_id = inbox_id2, "receiver created");
@@ -470,7 +472,7 @@ impl Test {
         // Step 1: Create a V3 SDK client
         info!("creating V3 sender identity");
         let wallet = generate_wallet();
-        let client = app::temp_client(&self.network, Some(&wallet)).await?;
+        let client = app::temp_client(Some(&wallet)).await?;
         app::register_client(&client, wallet.clone().into_alloy()).await?;
         info!(inbox_id = client.inbox_id(), "V3 sender registered");
 
@@ -532,7 +534,7 @@ impl Test {
         // Step 1: Create 2 V3 clients (sender + receiver)
         info!("creating sender");
         let wallet1 = generate_wallet();
-        let client1 = app::temp_client(&self.network, Some(&wallet1)).await?;
+        let client1 = app::temp_client(Some(&wallet1)).await?;
         app::register_client(&client1, wallet1.clone().into_alloy()).await?;
         let inbox_id1 = client1.inbox_id().to_string();
         let install_id1 = client1.installation_public_key();
@@ -540,7 +542,7 @@ impl Test {
 
         info!("creating receiver");
         let wallet2 = generate_wallet();
-        let client2 = app::temp_client(&self.network, Some(&wallet2)).await?;
+        let client2 = app::temp_client(Some(&wallet2)).await?;
         app::register_client(&client2, wallet2.clone().into_alloy()).await?;
         let inbox_id2 = client2.inbox_id().to_string();
         let install_id2 = client2.installation_public_key();
@@ -1082,14 +1084,14 @@ impl Test {
         // Step 1: Create V3 sender + receiver
         info!("creating V3 sender");
         let wallet1 = generate_wallet();
-        let client1 = app::temp_client(&self.network, Some(&wallet1)).await?;
+        let client1 = app::temp_client(Some(&wallet1)).await?;
         app::register_client(&client1, wallet1.clone().into_alloy()).await?;
         let inbox_id1 = client1.inbox_id().to_string();
         info!(inbox_id = inbox_id1, "V3 sender registered");
 
         info!("creating V3 receiver");
         let wallet2 = generate_wallet();
-        let client2 = app::temp_client(&self.network, Some(&wallet2)).await?;
+        let client2 = app::temp_client(Some(&wallet2)).await?;
         app::register_client(&client2, wallet2.clone().into_alloy()).await?;
         let inbox_id2 = client2.inbox_id().to_string();
         info!(inbox_id = inbox_id2, "V3 receiver registered");
@@ -1165,7 +1167,7 @@ impl Test {
         };
 
         info!("creating V4 SDK client with sender's wallet");
-        let v4_sdk_client = app::temp_client(&d14n_backend, Some(&wallet1)).await?;
+        let v4_sdk_client = app::temp_client(Some(&wallet1)).await?;
         let v4_inbox_id = v4_sdk_client.inbox_id().to_string();
 
         // CHECK 1: inbox_id derivation is deterministic across backends

--- a/apps/xmtp_debug/src/app/test.rs
+++ b/apps/xmtp_debug/src/app/test.rs
@@ -1167,7 +1167,7 @@ impl Test {
         };
 
         info!("creating V4 SDK client with sender's wallet");
-        let v4_sdk_client = app::temp_client(Some(&wallet1)).await?;
+        let v4_sdk_client = app::temp_client_for(Some(&wallet1), &d14n_backend).await?;
         let v4_inbox_id = v4_sdk_client.inbox_id().to_string();
 
         // CHECK 1: inbox_id derivation is deterministic across backends

--- a/apps/xmtp_debug/src/app/types.rs
+++ b/apps/xmtp_debug/src/app/types.rs
@@ -9,10 +9,12 @@ use prost::Message as _;
 use speedy::{Readable, Writable};
 
 use xmtp_cryptography::XmtpInstallationCredential;
-use xmtp_id::associations::builder::SignatureRequest;
+use xmtp_id::{InboxOwner, associations::builder::SignatureRequest};
+use xmtp_mls_common::group_metadata::DmMembers;
 use xmtp_proto::{types::GroupId, xmtp::identity::MlsCredential};
 
 use crate::{
+    XDBG_ID_NONCE,
     app::{App, store::MessageKey},
     args,
 };
@@ -29,7 +31,7 @@ impl EthereumWallet {
         PrivateKeySigner::from_slice(self.0.to_bytes().as_slice()).expect("Should never fail")
     }
 
-    fn from_bytes(bytes: [u8; 32]) -> Self {
+    pub fn from_bytes(bytes: [u8; 32]) -> Self {
         Self(SigningKey::from_bytes((&bytes).into()).unwrap())
     }
 
@@ -104,6 +106,25 @@ impl std::fmt::Display for Identity {
 }
 
 impl Identity {
+    pub fn generate() -> Result<Self> {
+        let wallet = EthereumWallet::default();
+        let local = wallet.clone().into_alloy();
+        let ident = local.get_identifier()?;
+        let inbox_id = ident.inbox_id(XDBG_ID_NONCE)?;
+        let cred = XmtpInstallationCredential::new();
+        let mut eth_key = [0u8; 32];
+        let mut inbox_id_bytes = [0u8; 32];
+        eth_key.copy_from_slice(wallet.0.to_bytes().as_slice());
+        hex::decode_to_slice(inbox_id.clone(), &mut inbox_id_bytes)?;
+        Ok(Identity {
+            inbox_id: inbox_id_bytes,
+            installation_key: cred.private_bytes(),
+            eth_key,
+            version_hash: crate::app::App::current_version_hash(),
+            version_string: pack_version_string(&crate::get_version())?,
+        })
+    }
+
     pub fn from_libxmtp(
         value: &xmtp_mls::identity::Identity,
         wallet: EthereumWallet,
@@ -270,11 +291,7 @@ impl Group {
     /// Build a `Group` from id + creator + members; the redundant
     /// `member_size` field is derived. Use this everywhere instead of
     /// the struct literal so the size never drifts from `members.len()`.
-    pub fn new(
-        id: impl Into<[u8; 16]>,
-        created_by: InboxId,
-        members: Vec<InboxId>,
-    ) -> Self {
+    pub fn new(id: impl Into<[u8; 16]>, created_by: InboxId, members: Vec<InboxId>) -> Self {
         let member_size = members.len() as u32;
         Self {
             created_by,
@@ -282,7 +299,7 @@ impl Group {
             member_size,
             members,
             version_string: pack_version_string(&crate::get_version())
-                .expect("version must be valid")
+                .expect("version must be valid"),
         }
     }
 
@@ -311,6 +328,12 @@ impl Group {
 
     pub fn has_member(&self, inbox: &InboxId) -> bool {
         self.members.contains(inbox)
+    }
+}
+
+impl std::fmt::Display for Group {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.id())
     }
 }
 
@@ -366,14 +389,24 @@ pub struct Dm {
 
 pub struct DmId([u8; 64]);
 impl DmId {
+    /// Build a sorted-pair DM key from two 32-byte inbox ids. Sorting
+    /// ensures `DmId::new(a, b) == DmId::new(b, a)` so creator order
+    /// doesn't fragment the keyspace.
     pub fn new(lhs: [u8; 32], rhs: [u8; 32]) -> Self {
-        let id = [lhs, rhs];
-        id.sort();
+        let mut pair = [lhs, rhs];
+        pair.sort();
+        let mut id = [0u8; 64];
+        id[..32].copy_from_slice(&pair[0]);
+        id[32..].copy_from_slice(&pair[1]);
         Self(id)
     }
 
     pub fn as_bytes(&self) -> &[u8; 64] {
         &self.0
+    }
+
+    pub fn into_bytes(self) -> [u8; 64] {
+        self.0
     }
 }
 
@@ -386,8 +419,11 @@ impl std::fmt::Display for Dm {
 impl Dm {
     pub fn new(created_by: InboxId, with: InboxId, group_id: GroupId) -> Self {
         Self {
-            created_by, with, group_id, version_string: pack_version_string(&crate::get_version())
-                .expect("version must be valid")
+            created_by,
+            with,
+            group_id: group_id.into(),
+            version_string: pack_version_string(&crate::get_version())
+                .expect("version must be valid"),
         }
     }
 
@@ -396,15 +432,12 @@ impl Dm {
         DmMembers {
             member_one_inbox_id: hex::encode(self.created_by),
             member_two_inbox_id: hex::encode(self.with),
-        }.to_string()
+        }
+        .to_string()
     }
 
     pub fn redb_key(&self) -> DmId {
         DmId::new(self.created_by, self.with)
-    }
-
-    pub fn group_id(&self) -> GroupId {
-        GroupId::from(self.group_id)
     }
 }
 
@@ -537,45 +570,5 @@ impl redb::Value for Message {
 
     fn type_name() -> redb::TypeName {
         redb::TypeName::new("message")
-    }
-}
-
-#[cfg(test)]
-mod message_tests {
-    use super::*;
-
-    #[test]
-    fn message_speedy_roundtrip() {
-        let msg = Message {
-            id: [7u8; 32],
-            group_id: [3u8; 16],
-            sender_inbox_id: [9u8; 32],
-            sent_at_ns: 1_700_000_000_000_000_000,
-            xdbg_version: "1.10.0-abcdefg".to_string(),
-        };
-        let bytes = msg.write_to_vec().unwrap();
-        let decoded = Message::read_from_buffer(&bytes).unwrap();
-        assert_eq!(msg, decoded);
-    }
-
-    use crate::app::store::DeriveKey;
-    use crate::app::store::MessageKey;
-
-    #[test]
-    fn message_derive_key_composes_group_and_message_id() {
-        let msg = Message {
-            id: [0xAAu8; 32],
-            group_id: [0xBBu8; 16],
-            sender_inbox_id: [0u8; 32],
-            sent_at_ns: 0,
-            xdbg_version: String::new(),
-        };
-        let key: MessageKey = msg.key(7);
-        // u64 network (8 bytes, LE) + 48-byte combined key.
-        let bytes = speedy::Writable::write_to_vec(&key).unwrap();
-        assert_eq!(bytes.len(), 8 + 48);
-        assert_eq!(&bytes[0..8], &7u64.to_le_bytes());
-        assert_eq!(&bytes[8..24], &[0xBBu8; 16]);
-        assert_eq!(&bytes[24..56], &[0xAAu8; 32]);
     }
 }

--- a/apps/xmtp_debug/src/app/types.rs
+++ b/apps/xmtp_debug/src/app/types.rs
@@ -12,7 +12,10 @@ use xmtp_cryptography::XmtpInstallationCredential;
 use xmtp_id::associations::builder::SignatureRequest;
 use xmtp_proto::{types::GroupId, xmtp::identity::MlsCredential};
 
-use crate::app::store::MessageKey;
+use crate::{
+    app::{App, store::MessageKey},
+    args,
+};
 
 /// An InboxId represented as fixed bytes
 pub type InboxId = [u8; 32];
@@ -141,7 +144,7 @@ impl Identity {
 
     /// SQLite database path for this identity
     pub fn db_path(&self, network: impl Into<u64> + Copy) -> Result<std::path::PathBuf> {
-        let dir = crate::app::App::db_directory(network)?;
+        let dir = crate::app::App::db_directory()?;
         let db_name = format!("{}:{}.db3", hex::encode(self.inbox_id), network.into());
         Ok(dir.join(db_name))
     }
@@ -149,13 +152,10 @@ impl Identity {
     /// SQLite path for this identity, addressing a specific
     /// `version_hash` partition. Used when loading an identity that
     /// was written by a different xdbg version (non-strict mode).
-    pub fn db_path_for(
-        &self,
-        network: impl Into<u64> + Copy,
-        version_hash: u64,
-    ) -> Result<std::path::PathBuf> {
-        let dir = crate::app::App::db_directory_for(network, version_hash)?;
-        let db_name = format!("{}:{}.db3", hex::encode(self.inbox_id), network.into());
+    pub fn db_path_for(&self, version_hash: u64) -> Result<std::path::PathBuf> {
+        let dir = crate::app::App::db_directory_for(version_hash)?;
+        let net_hash = App::network_hash();
+        let db_name = format!("{}:{net_hash}.db3", hex::encode(self.inbox_id));
         Ok(dir.join(db_name))
     }
 
@@ -168,6 +168,10 @@ impl Identity {
             version_hash: 0,
             version_string: [0u8; VERSION_STRING_LEN],
         }
+    }
+
+    pub fn inbox_id(&self) -> args::InboxId {
+        args::InboxId::new(self.inbox_id)
     }
 }
 
@@ -266,7 +270,11 @@ impl Group {
     /// Build a `Group` from id + creator + members; the redundant
     /// `member_size` field is derived. Use this everywhere instead of
     /// the struct literal so the size never drifts from `members.len()`.
-    pub fn new(id: impl Into<[u8; 16]>, created_by: InboxId, members: Vec<InboxId>) -> Self {
+    pub fn new(
+        id: impl Into<[u8; 16]>,
+        created_by: InboxId,
+        members: Vec<InboxId>,
+    ) -> Self {
         let member_size = members.len() as u32;
         Self {
             created_by,
@@ -274,7 +282,7 @@ impl Group {
             member_size,
             members,
             version_string: pack_version_string(&crate::get_version())
-                .expect("version must be valid"),
+                .expect("version must be valid")
         }
     }
 
@@ -303,12 +311,6 @@ impl Group {
 
     pub fn has_member(&self, inbox: &InboxId) -> bool {
         self.members.contains(inbox)
-    }
-}
-
-impl std::fmt::Display for Group {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.id())
     }
 }
 
@@ -347,6 +349,102 @@ impl redb::Value for Group {
     }
 }
 
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Readable, Writable)]
+pub struct Dm {
+    /// user that created dm
+    pub created_by: InboxId,
+
+    with: InboxId,
+
+    group_id: [u8; 16],
+
+    /// `crate::get_version()` of the xdbg binary that created this
+    /// group, right-zero-padded UTF-8. Same shape as
+    /// `Identity::version_string`. Decode via `Group::version_string`.
+    pub version_string: [u8; VERSION_STRING_LEN],
+}
+
+pub struct DmId([u8; 64]);
+impl DmId {
+    pub fn new(lhs: [u8; 32], rhs: [u8; 32]) -> Self {
+        let id = [lhs, rhs];
+        id.sort();
+        Self(id)
+    }
+
+    pub fn as_bytes(&self) -> &[u8; 64] {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for Dm {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.id())
+    }
+}
+
+impl Dm {
+    pub fn new(created_by: InboxId, with: InboxId, group_id: GroupId) -> Self {
+        Self {
+            created_by, with, group_id, version_string: pack_version_string(&crate::get_version())
+                .expect("version must be valid")
+        }
+    }
+
+    /// return the XMTP DM ID (dm:inbox1:inbox2)
+    pub fn id(&self) -> String {
+        DmMembers {
+            member_one_inbox_id: hex::encode(self.created_by),
+            member_two_inbox_id: hex::encode(self.with),
+        }.to_string()
+    }
+
+    pub fn redb_key(&self) -> DmId {
+        DmId::new(self.created_by, self.with)
+    }
+
+    pub fn group_id(&self) -> GroupId {
+        GroupId::from(self.group_id)
+    }
+}
+
+impl redb::Value for Dm {
+    type SelfType<'a>
+        = Dm
+    where
+        Self: 'a;
+
+    type AsBytes<'a>
+        = [u8; size_of::<Dm>()]
+    where
+        Self: 'a;
+
+    fn fixed_width() -> Option<usize> {
+        Some(size_of::<Self::SelfType<'_>>())
+    }
+
+    fn from_bytes<'a>(data: &'a [u8]) -> Self::SelfType<'a>
+    where
+        Self: 'a,
+    {
+        Dm::read_from_buffer(data).unwrap()
+    }
+
+    fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> Self::AsBytes<'a>
+    where
+        Self: 'a,
+        Self: 'b,
+    {
+        let mut buffer = [0u8; size_of::<Dm>()];
+        value.write_to_buffer(&mut buffer).unwrap();
+        buffer
+    }
+
+    fn type_name() -> redb::TypeName {
+        redb::TypeName::new("dm")
+    }
+}
+
 /// Message recorded for a single healthcheck `SendMessage` op.
 /// Persisted to redb so the `NoMissingMessages` validator has an
 /// authoritative source of truth across runs and versions.
@@ -367,7 +465,6 @@ pub struct Message {
     /// `crate::get_version()` output of the sending xdbg binary.
     pub xdbg_version: String,
 }
-
 impl Message {
     pub fn new(
         id: [u8; 32],
@@ -389,12 +486,12 @@ impl Message {
     /// uses `group_id ++ id` (48 bytes); the rest of the message
     /// is the value, not the key. Use this for membership checks
     /// to avoid allocating a placeholder `Message`.
-    pub fn redb_key(network: u64, group_id: impl Into<[u8; 16]>, id: [u8; 32]) -> MessageKey {
+    pub fn redb_key(group_id: impl Into<[u8; 16]>, id: [u8; 32]) -> MessageKey {
         let mut combined = [0u8; 48];
         let gid = group_id.into();
         combined[..16].copy_from_slice(&gid);
         combined[16..].copy_from_slice(&id);
-        MessageKey::new(network, combined)
+        MessageKey::new(combined)
     }
 
     pub fn group_id(&self) -> GroupId {

--- a/apps/xmtp_debug/src/args.rs
+++ b/apps/xmtp_debug/src/args.rs
@@ -611,7 +611,12 @@ pub enum TestScenario {
 /// Runs every user-visible protocol op against the local xdbg state,
 /// validates that all clients converge, and exits non-zero on any failure.
 #[derive(Args, Debug)]
-pub struct HealthcheckOpts {}
+pub struct HealthcheckOpts {
+    /// Skip mutating ops; only reads, sends, and validators run.
+    /// Primary is reused from existing_clients instead of registered.
+    #[arg(long)]
+    pub read_only: bool,
+}
 
 /// Walk identities loaded from redb, run `sync_welcomes` + per-group
 /// `sync` on each, and reconcile redb's `GroupStore` / `MessageStore`

--- a/apps/xmtp_debug/src/args.rs
+++ b/apps/xmtp_debug/src/args.rs
@@ -102,7 +102,7 @@ pub struct Generate {
     pub ryow: bool,
 }
 
-#[derive(Args, Debug, Clone)]
+#[derive(Args, Copy, Debug, Clone)]
 pub struct MessageGenerateOpts {
     /// Continuously generate & send messages
     #[arg(long, short)]
@@ -404,6 +404,10 @@ fn default_ryow_timeout() -> humantime::Duration {
 }
 
 impl BackendOpts {
+    pub fn hash(&self) -> u64 {
+        (self).into()
+    }
+
     pub fn xmtpd_gateway_url(&self) -> eyre::Result<url::Url> {
         use BackendKind::*;
 

--- a/apps/xmtp_debug/src/args/types.rs
+++ b/apps/xmtp_debug/src/args/types.rs
@@ -3,6 +3,12 @@ use std::time::Duration;
 #[derive(Debug, Clone)]
 pub struct InboxId([u8; 32]);
 
+impl InboxId {
+    pub fn new(id: [u8; 32]) -> Self {
+        Self(id)
+    }
+}
+
 impl std::fmt::Display for InboxId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", hex::encode(self.0))

--- a/apps/xmtp_debug/src/main.rs
+++ b/apps/xmtp_debug/src/main.rs
@@ -7,10 +7,12 @@ mod logger;
 mod metrics;
 
 use clap::Parser;
-use color_eyre::eyre::Result;
+use color_eyre::eyre::{Result, eyre};
 
 use std::sync::{Arc, OnceLock};
 use xmtp_mls::context::XmtpMlsLocalContext;
+
+use crate::args::AppOpts;
 
 static FAIL_FAST: OnceLock<bool> = OnceLock::new();
 
@@ -27,6 +29,8 @@ type DbgClient = xmtp_mls::client::Client<MlsContext>;
 
 const XDBG_ID_NONCE: u64 = 1;
 
+pub static CONF: OnceLock<Arc<AppOpts>> = OnceLock::new();
+
 #[macro_use]
 extern crate tracing;
 
@@ -34,7 +38,7 @@ extern crate tracing;
 async fn main() -> Result<()> {
     color_eyre::install()?;
 
-    let opts = args::AppOpts::parse();
+    let opts = config()?;
     let mut logger = logger::Logger::from(&opts.log);
     logger.init()?;
     metrics::init_metrics(opts.metrics);
@@ -45,7 +49,7 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
-    let app = app::App::new(opts);
+    let app = app::App::new();
     app.run().await?;
 
     Ok(())
@@ -53,4 +57,19 @@ async fn main() -> Result<()> {
 
 pub fn get_version() -> String {
     format!("{}-{}", env!("CARGO_PKG_VERSION"), env!("VERGEN_GIT_SHA"))
+}
+
+pub fn config() -> Result<&'static AppOpts> {
+    if CONF.get().is_none() {
+        let opts = args::AppOpts::parse();
+        CONF.set(Arc::new(opts))
+            .map_err(|_| eyre!("config already initialized"))?;
+    }
+    CONF.get()
+        .map(|v| v.as_ref())
+        .ok_or_else(|| eyre!("Config not initialized"))
+}
+
+pub fn config_unchecked() -> &'static AppOpts {
+    CONF.get().map(|v| v.as_ref()).expect("unchecked config")
 }

--- a/crates/xmtp_mls/src/groups/mod.rs
+++ b/crates/xmtp_mls/src/groups/mod.rs
@@ -2899,7 +2899,6 @@ where
 
         Ok(mls_groups)
     }
-
     /// Used for testing that dm group validation works as expected.
     ///
     /// See the `test_validate_dm_group` test function for more details.

--- a/dev/drivers/cross_talk_test/cross_talk_test/__main__.py
+++ b/dev/drivers/cross_talk_test/cross_talk_test/__main__.py
@@ -6,6 +6,7 @@ are partitioned. Tests wire-level MLS interop."""
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -20,7 +21,14 @@ _FINALIZE_MSGS = {
 }
 
 
-def run_strict(env_extras, out_dir, kind, sha, *args, tee=True):
+def run_strict(
+    env_extras: dict[str, str],
+    out_dir: str,
+    kind: str,
+    sha: str,
+    *args: str,
+    tee: bool = True,
+) -> subprocess.CompletedProcess:
     return d.run_xdbg(
         env_extras=env_extras,
         out_dir=out_dir,
@@ -177,14 +185,23 @@ def run_sequence(
         for e in runnable:
             run_strict(env_extras, out_dir, e.kind, e.sha, "sync")
 
-    with d.gh_group("cross-talk phase 4: healthcheck"):
+    with d.gh_group("cross-talk phase 4: round-trip healthcheck"):
+        # Fwd: each version writes. Rev (everyone except newest, read-only):
+        # older clients re-verify on groups newer versions wrote to.
+        fwd = list(runnable)
+        rev = list(reversed(runnable[:-1]))
+        sweep = fwd + rev
+
         results: list[d.ResultRow] = []
         completed = 0
         required_fail = False
         nightly_fail = False
-        for e in runnable:
+        for i, e in enumerate(sweep):
+            leg = "fwd" if i < len(fwd) else "rev"
             row = d.base_row(e)
-            r = run_strict(env_extras, out_dir, e.kind, e.sha, "healthcheck")
+            row["leg"] = leg
+            extra = ["--read-only"] if leg == "rev" else []
+            r = run_strict(env_extras, out_dir, e.kind, e.sha, "healthcheck", *extra)
             if r.returncode == 0:
                 results.append({**row, "status": "PASS"})
                 completed += 1

--- a/dev/drivers/xdbg_driver_lib/xdbg_driver_lib_py/__init__.py
+++ b/dev/drivers/xdbg_driver_lib/xdbg_driver_lib_py/__init__.py
@@ -19,7 +19,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, TypedDict
 
-from git import BadName, Repo
+from git import BadName, InvalidGitRepositoryError, NoSuchPathError, Repo
 from packaging.version import InvalidVersion, Version
 from rich.console import Console
 from rich.table import Table
@@ -107,6 +107,7 @@ class ResultRow(TypedDict, total=False):
     kind: str
     branch: str
     label: str
+    leg: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -166,8 +167,9 @@ def _resolve_repo() -> tuple[Repo, str]:
     `repo()` and `repo_root()` so we never run `jj root` twice."""
     try:
         plain = Repo(os.getcwd(), search_parent_directories=True)
-        return plain, plain.working_tree_dir  # type: ignore[return-value]
-    except Exception:
+        if plain.working_tree_dir:
+            return plain, plain.working_tree_dir
+    except (InvalidGitRepositoryError, NoSuchPathError):
         pass
     r = subprocess.run(["jj", "root"], capture_output=True, text=True)
     if r.returncode != 0:
@@ -439,7 +441,7 @@ def _cache_set(key: str, value: int) -> None:
     cache[key] = value
     path = _cache_file()
     path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "a") as f:
+    with open(path, "a", encoding="utf-8") as f:
         f.write(f"{key}\t{value}\n")
 
 
@@ -544,7 +546,7 @@ def run_xdbg(
     short = sha[:7]
     try:
         env = {**os.environ, **env_extras, **sandbox_env(env_extras)}
-        backend = os.environ.get("BACKEND") or env_extras.get("BACKEND") or "dev"
+        backend = env_extras.get("BACKEND") or os.environ.get("BACKEND") or "dev"
         raw_xvt = (
             env_extras.get("XVT_XDBG_FLAGS") or os.environ.get("XVT_XDBG_FLAGS") or ""
         )
@@ -582,13 +584,20 @@ def run_xdbg(
 
 
 def emit_stderr_table(test_name: str, results: list[ResultRow]) -> None:
+    has_leg = any(r.get("leg") for r in results)
     table = Table(title=f"{test_name} summary", title_justify="left")
-    for col in ("STATUS", "KIND", "SHORT", "SHA", "LABEL"):
+    cols = ["STATUS", "KIND", "SHORT", "SHA", "LABEL"]
+    if has_leg:
+        cols.append("LEG")
+    for col in cols:
         table.add_column(col, no_wrap=True)
     for r in results:
         glyph = STATUS_PLAIN.get(r["status"], f"? {r['status']}")
         display = r.get("label") or r.get("branch") or ""
-        table.add_row(glyph, r["kind"], r["short"], r["sha"], display)
+        row = [glyph, r["kind"], r["short"], r["sha"], display]
+        if has_leg:
+            row.append(r.get("leg", ""))
+        table.add_row(*row)
     _stderr_console.print(table)
 
 
@@ -613,7 +622,7 @@ def emit_plan_step_summary(
         f"{json.dumps([asdict(e) for e in parsed], indent=2)}\n"
         "```\n"
     )
-    with open(path, "a") as f:
+    with open(path, "a", encoding="utf-8") as f:
         f.write(body)
 
 
@@ -678,23 +687,36 @@ def emit_github_step_summary(
     path = os.environ.get("GITHUB_STEP_SUMMARY")
     if not path:
         return
+    has_leg = any(r.get("leg") for r in results)
     rows = []
     for r in results:
         glyph = STATUS_MD.get(r["status"], f"❓ {r['status']}")
         display = r.get("label") or r.get("branch") or "-"
-        rows.append(
-            f"| {glyph} | {r['kind']} | `{r['short']}` | {display} | `{r['sha']}` |"
+        if has_leg:
+            rows.append(
+                f"| {glyph} | {r['kind']} | `{r['short']}` | {display} | `{r['sha']}` | {r.get('leg', '-')} |"
+            )
+        else:
+            rows.append(
+                f"| {glyph} | {r['kind']} | `{r['short']}` | {display} | `{r['sha']}` |"
+            )
+    if has_leg:
+        header = (
+            "| Status | Kind | Short | Label / Branch | SHA | Leg |\n"
+            "|---|---|---|---|---|---|\n"
+        )
+    else:
+        header = (
+            "| Status | Kind | Short | Label / Branch | SHA |\n|---|---|---|---|---|\n"
         )
     body = (
-        f"## {test_name} results\n\n"
-        "| Status | Kind | Short | Label / Branch | SHA |\n"
-        "|---|---|---|---|---|\n" + "\n".join(rows) + "\n\n"
+        f"## {test_name} results\n\n" + header + "\n".join(rows) + "\n\n"
         f"**completed_count={completed_count} required_failure={int(required_failure)} "
         f"nightly_failure={int(nightly_failure)} lenient={int(lenient_nightlies)}**\n\n"
         f"**libxmtp NDJSON log files captured: {count_ndjson_logs(out_dir)}** "
         "(download the run artifact to inspect)\n"
     )
-    with open(path, "a") as f:
+    with open(path, "a", encoding="utf-8") as f:
         f.write(body)
 
 
@@ -865,7 +887,7 @@ def prepare_run(
     )
     Path(out_dir).mkdir(parents=True, exist_ok=True)
     if gh_out := os.environ.get("GITHUB_OUTPUT"):
-        with open(gh_out, "a") as f:
+        with open(gh_out, "a", encoding="utf-8") as f:
             f.write(f"out_dir={out_dir}\n")
     env_extras = setup_run_env(tmp_prefix)
     xdbg_flags = " ".join(xdbg_args)


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add `--read-only` healthcheck mode and run reverse read-only pass in cross-talk test
- Adds a `--read-only` flag to the healthcheck subcommand that skips all write operations and reuses an existing primary identity; the flag gates write ops via a new `WRITES` condition bit and a new `BOOTSTRAP` condition for empty identity stores.
- Extends the cross-talk test healthcheck phase to run a forward write-enabled pass followed by a reverse read-only pass over older versions, annotating result rows with a `leg` field (`fwd`/`rev`).
- Refactors `App` into a unit struct with a global `CONF` singleton and `App::network()`/`App::network_hash()` accessors, removing per-instance and per-call network arguments across clients, stores, and subcommands.
- Introduces `DmStore` and a `Dm` data model for persisting direct message threads during sync, with metadata tracking and display support.
- Adds `BootstrapIdentities` health op that creates and registers three new identities when both `BOOTSTRAP` and `WRITES` conditions are active.
- Risk: `STRICT_VERSIONING` bit shifted from `1<<0` to `1<<1`; any serialized or compared condition values will be incorrect unless updated.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2326a91.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->