### PR TITLE
bindings/mobile: expose Client shutdown() for clean shutdown (PR3/3)

### DIFF
--- a/bindings/mobile/src/mls.rs
+++ b/bindings/mobile/src/mls.rs
@@ -700,8 +700,12 @@ impl FfiXmtpClient {
     /// `await` this before deleting the SQLite file or dropping the client
     /// reference to avoid late log spew from detached workers/streams firing
     /// against a dead DB.
+    ///
+    /// Named `shutdown` rather than `close` because uniffi reserves `close`
+    /// on every exported object for the Kotlin `Disposable` handle-disposal
+    /// method, which would conflict with this one.
     #[tracing::instrument(skip_all)]
-    pub async fn close(&self) -> Result<(), FfiError> {
+    pub async fn shutdown(&self) -> Result<(), FfiError> {
         Ok(self.inner_client.close().await?)
     }
 

--- a/bindings/mobile/src/mls.rs
+++ b/bindings/mobile/src/mls.rs
@@ -693,6 +693,18 @@ impl FfiXmtpClient {
         Ok(self.inner_client.reconnect_db()?)
     }
 
+    /// Cleanly shut down this client: cancel in-flight workers and detached
+    /// streams, then release the DB connection. Idempotent — a second call
+    /// resolves to `Ok`.
+    ///
+    /// `await` this before deleting the SQLite file or dropping the client
+    /// reference to avoid late log spew from detached workers/streams firing
+    /// against a dead DB.
+    #[tracing::instrument(skip_all)]
+    pub async fn close(&self) -> Result<(), FfiError> {
+        Ok(self.inner_client.close().await?)
+    }
+
     #[tracing::instrument(skip_all)]
     pub async fn find_inbox_id(
         &self,

--- a/bindings/mobile/src/mls/tests/client.rs
+++ b/bindings/mobile/src/mls/tests/client.rs
@@ -293,10 +293,10 @@ async fn test_get_hmac_keys() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_close_is_idempotent() {
+async fn test_shutdown_is_idempotent() {
     let client = new_test_client().await;
-    client.close().await.unwrap();
+    client.shutdown().await.unwrap();
     // A second call must resolve to Ok(()) without panicking — consumers may
-    // call close() defensively on a client they cannot prove is still open.
-    client.close().await.unwrap();
+    // call shutdown() defensively on a client they cannot prove is still open.
+    client.shutdown().await.unwrap();
 }

--- a/bindings/mobile/src/mls/tests/client.rs
+++ b/bindings/mobile/src/mls/tests/client.rs
@@ -291,3 +291,12 @@ async fn test_get_hmac_keys() {
         assert!(value.epoch >= 1);
     }
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_close_is_idempotent() {
+    let client = new_test_client().await;
+    client.close().await.unwrap();
+    // A second call must resolve to Ok(()) without panicking — consumers may
+    // call close() defensively on a client they cannot prove is still open.
+    client.close().await.unwrap();
+}


### PR DESCRIPTION
## Summary

Final PR of the `Client.close()` rollout tracked in #3659. Adds an async shutdown method to the uniffi mobile binding (`FfiXmtpClient`), delegating to the `xmtp_mls` `Client::close()` plumbing.

- **PR1** — core `xmtp_mls` plumbing — merged (#3658)
- **PR2** — Node binding `close()` — merged (#3685)
- **PR3** — uniffi mobile binding — this PR

## Changes

- `FfiXmtpClient::shutdown()` — `async fn shutdown(&self) -> Result<(), FfiError>`, placed in the `#[uniffi::export(async_runtime = "tokio")]` impl block next to `release_db_connection`/`db_reconnect`.
- `test_shutdown_is_idempotent` — creates a client, calls `shutdown()` twice, asserts both resolve `Ok`.

## Why `shutdown()` and not `close()`

uniffi auto-generates a synchronized `close()` on every exported object for the Kotlin `Disposable` handle-disposal contract. Exporting an `async fn close()` produced a second `suspend fun close()` and Kotlin rejected the conflicting overloads, failing the Android build. The method is named `shutdown()` to avoid that clash; napi (Node) and Swift don't generate the disposal `close()`, which is why PR2 could keep the `close()` name. The Swift/Kotlin SDK wrappers can still re-expose it as `close()` at their layer.

## Behavior

`shutdown()` cancels in-flight workers and detached streams, then releases the DB connection. It is idempotent. Consumers should `await` it before deleting the SQLite file or dropping the client reference, to avoid late log spew from detached workers/streams firing against a dead DB.

## Testing

- `cargo check -p xmtpv3 --tests`, `cargo fmt --check`, `cargo clippy -p xmtpv3 --tests` — clean
- `test_shutdown_is_idempotent` passes against the local XMTP docker backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ## Summary
>
> Final PR of the `Client.close()` rollout tracked in #3659. Adds an async shutdown method to the uniffi mobile binding (`FfiXmtpClient`), delegating to the `xmtp_mls` `Client::close()` plumbing.
>
> - **PR1** — core `xmtp_mls` plumbing — merged (#3658)
> - **PR2** — Node binding `close()` — merged (#3685)
> - **PR3** — uniffi mobile binding — this PR
>
> ## Changes
>
> - `FfiXmtpClient::shutdown()` — `async fn shutdown(&self) -> Result<(), FfiError>`, placed in the `#[uniffi::export(async_runtime = "tokio")]` impl block next to `release_db_connection`/`db_reconnect`.
> - `test_shutdown_is_idempotent` — creates a client, calls `shutdown()` twice, asserts both resolve `Ok`.
>
> ## Why `shutdown()` and not `close()`
>
> uniffi auto-generates a synchronized `close()` on every exported object for the Kotlin `Disposable` handle-disposal contract. Exporting an `async fn close()` produced a second `suspend fun close()` and Kotlin rejected the conflicting overloads, failing the Android build. The method is named `shutdown()` to avoid that clash; napi (Node) and Swift don't generate the disposal `close()`, which is why PR2 could keep the `close()` name. The Swift/Kotlin SDK wrappers can still re-expose it as `close()` at their layer.
>
> ## Behavior
>
> `shutdown()` cancels in-flight workers and detached streams, then releases the DB connection. It is idempotent. Consumers should `await` it before deleting the SQLite file or dropping the client reference, to avoid late log spew from detached workers/streams firing against a dead DB.
>
> ## Testing
>
> - `cargo check -p xmtpv3 --tests`, `cargo fmt --check`, `cargo clippy -p xmtpv3 --tests` — clean
> - `test_shutdown_is_idempotent` passes against the local XMTP docker backend
>
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)
> <!-- Macroscope's changelog starts here -->
> #### Changes since #3687 opened
>
> - Renamed `FfiXmtpClient.close()` async method to `shutdown()` to avoid uniffi `Disposable` collision [355ce50]
> <!-- Macroscope's changelog ends here -->
>
<!-- Macroscope's pull request summary ends here -->