### PR TITLE
small identity registration refactor for easier use from xdbg

### DIFF
--- a/crates/xmtp_id/src/associations/signature.rs
+++ b/crates/xmtp_id/src/associations/signature.rs
@@ -244,12 +244,16 @@ impl AccountId {
 }
 
 /// Decode the `legacy_signed_private_key` to legacy private / public key pairs & sign the `signature_text` with the private key.
+///
+/// Takes the key bytes by reference so callers can keep the source
+/// allocation in a `zeroize::Zeroizing` wrapper — no internal copy of
+/// the secret is created here.
 pub fn sign_with_legacy_key(
     signature_text: String,
-    legacy_signed_private_key: Vec<u8>,
+    legacy_signed_private_key: &[u8],
 ) -> Result<UnverifiedLegacyDelegatedSignature, SignatureError> {
     let legacy_signed_private_key_proto =
-        LegacySignedPrivateKeyProto::decode(legacy_signed_private_key.as_slice())?;
+        LegacySignedPrivateKeyProto::decode(legacy_signed_private_key)?;
     let signed_private_key::Union::Secp256k1(secp256k1) = legacy_signed_private_key_proto
         .union
         .ok_or(SignatureError::MalformedLegacyKey(

--- a/crates/xmtp_mls/src/client.rs
+++ b/crates/xmtp_mls/src/client.rs
@@ -989,8 +989,18 @@ where
             .collect())
     }
 
-    /// Upload a Key Package to the network and publish the signed identity update
-    /// from the provided SignatureRequest
+    /// **Production register entry point.** Run the full registration
+    /// pipeline from a completed [`SignatureRequest`]: validate
+    /// signatures, build + publish the identity update, upload a key
+    /// package, persist `StoredIdentity` + registration cursor, and
+    /// clean up old keys. Idempotent.
+    ///
+    /// FFI bindings (mobile / node / wasm) drive this method. Callers
+    /// outside the low-level identity construction code should prefer
+    /// this over the internal
+    /// [`Identity::persist_key_package`](crate::identity::Identity::persist_key_package)
+    /// primitive, which only handles the key-package upload + DB
+    /// persist step.
     pub async fn register_identity(
         &self,
         signature_request: SignatureRequest,

--- a/crates/xmtp_mls/src/identity.rs
+++ b/crates/xmtp_mls/src/identity.rs
@@ -1,9 +1,10 @@
 mod identity_ext;
+mod unregistered;
 pub use identity_ext::*;
+pub use unregistered::{PendingAttestation, UnregisteredIdentity};
 
 use crate::XmtpApi;
 use crate::groups::mls_ext::WelcomePointersExtension;
-use crate::identity_updates::{get_association_state_with_verifier, load_identity_updates};
 use crate::worker::NeedsDbReconnect;
 use derive_builder::Builder;
 use openmls::prelude::hash_ref::HashReference;
@@ -33,7 +34,7 @@ use xmtp_common::time::now_ns;
 use xmtp_common::{RetryableError, retryable};
 use xmtp_configuration::{
     CIPHERSUITE, CREATE_PQ_KEY_PACKAGE_EXTENSION, GROUP_MEMBERSHIP_EXTENSION_ID,
-    GROUP_PERMISSIONS_EXTENSION_ID, KEY_PACKAGE_ROTATION_INTERVAL_NS, MAX_INSTALLATIONS_PER_INBOX,
+    GROUP_PERMISSIONS_EXTENSION_ID, KEY_PACKAGE_ROTATION_INTERVAL_NS,
     MUTABLE_METADATA_EXTENSION_ID, WELCOME_POINTEE_ENCRYPTION_AEAD_TYPES_EXTENSION_ID,
     WELCOME_WRAPPER_ENCRYPTION_EXTENSION_ID,
 };
@@ -48,18 +49,13 @@ use xmtp_db::sql_key_store::{
 use xmtp_db::{ConnectionExt, MlsProviderExt};
 use xmtp_db::{Fetch, StorageError, Store};
 use xmtp_db::{XmtpOpenMlsProviderRef, prelude::*};
-use xmtp_id::associations::unverified::UnverifiedSignature;
 use xmtp_id::associations::{AssociationError, Identifier, InstallationKeyContext, PublicContext};
 use xmtp_id::key_package::KeyPackageVerificationError;
 use xmtp_id::key_package::{WrapperAlgorithm, WrapperEncryptionExtension};
 use xmtp_id::scw_verifier::SmartContractSignatureVerifier;
 use xmtp_id::{
     InboxId, InboxIdRef,
-    associations::{
-        MemberIdentifier,
-        builder::{SignatureRequest, SignatureRequestBuilder, SignatureRequestError},
-        sign_with_legacy_key,
-    },
+    associations::builder::{SignatureRequest, SignatureRequestError},
 };
 use xmtp_proto::types::InstallationId;
 use xmtp_proto::xmtp::identity::MlsCredential;
@@ -426,6 +422,10 @@ impl Identity {
     /// If a legacy key is provided, it will be used to sign the identity update and no wallet signature is needed.
     ///
     /// If no legacy key is provided, a wallet signature is always required.
+    ///
+    /// Compatibility shim over [`UnregisteredIdentity`]. New callers should
+    /// use that two-phase API directly:
+    /// `UnregisteredIdentity::generate` → `attest` → (caller signs) → `publish`.
     #[tracing::instrument(level = "trace", skip_all)]
     pub(crate) async fn new<ApiClient: XmtpApi, S: XmtpMlsStorageProvider>(
         inbox_id: InboxId,
@@ -436,180 +436,21 @@ impl Identity {
         mls_storage: &S,
         scw_signature_verifier: impl SmartContractSignatureVerifier,
     ) -> Result<Self, IdentityError> {
-        // check if address is already associated with an inbox_id
-        let inbox_ids = api_client
-            .get_inbox_ids(vec![identifier.clone().into()])
+        let mut pending =
+            UnregisteredIdentity::generate(inbox_id, identifier, nonce, legacy_signed_private_key)?;
+        pending
+            .attest(api_client, mls_storage, &scw_signature_verifier)
             .await?;
-        let associated_inbox_id = inbox_ids.get(&(&identifier).into());
-        let installation_keys = XmtpInstallationCredential::new();
 
-        if let Some(associated_inbox_id) = associated_inbox_id {
-            // If an inbox is associated with address, we'd use it to create Identity and ignore the nonce.
-            // We would need a signature from user's wallet.
-            if *associated_inbox_id != inbox_id {
-                return Err(IdentityError::NewIdentity("Inbox ID mismatch".to_string()));
-            }
-
-            // get sequence_id from identity updates and loaded into the DB
-            load_identity_updates(
-                api_client,
-                &mls_storage.db(),
-                &[associated_inbox_id.as_str()],
-            )
-            .await
-            .map_err(|e| {
-                IdentityError::NewIdentity(format!("Failed to load identity updates: {e}"))
-            })?;
-
-            let state = get_association_state_with_verifier(
-                &mls_storage.db(),
-                &inbox_id,
-                None,
-                &scw_signature_verifier,
-            )
-            .await
-            .map_err(|err| {
-                IdentityError::NewIdentity(format!("Error resolving identity state: {}", err))
-            })?;
-
-            let current_installation_count = state.installation_ids().len();
-            if current_installation_count >= MAX_INSTALLATIONS_PER_INBOX {
-                return Err(IdentityError::TooManyInstallations {
-                    inbox_id: associated_inbox_id.clone(),
-                    count: current_installation_count,
-                    max: MAX_INSTALLATIONS_PER_INBOX,
-                });
-            }
-
-            let builder = SignatureRequestBuilder::new(associated_inbox_id.clone());
-            let mut signature_request = builder
-                .add_association(
-                    MemberIdentifier::installation(installation_keys.public_slice().to_vec()),
-                    identifier.clone().into(),
-                )
-                .build();
-
-            let signature = installation_keys
-                .credential_sign::<InstallationKeyContext>(signature_request.signature_text())?;
-            signature_request
-                .add_signature(
-                    UnverifiedSignature::new_installation_key(
-                        signature,
-                        installation_keys.verifying_key(),
-                    ),
-                    scw_signature_verifier,
-                )
-                .await?;
-
-            let identity = Self {
-                inbox_id: associated_inbox_id.clone(),
-                installation_keys,
-                credential: create_credential(associated_inbox_id.clone())?,
-                signature_request: Some(signature_request),
-                is_ready: AtomicBool::new(false),
-            };
-
-            Ok(identity)
-        } else if let Some(legacy_signed_private_key) = legacy_signed_private_key {
-            // The legacy signed private key may only be used if the nonce is 0
-            if nonce != 0 {
-                return Err(IdentityError::NewIdentity(
-                    "Nonce must be 0 if legacy key is provided".to_string(),
-                ));
-            }
-            // If the inbox_id found on the network does not match the one generated from the address and nonce, we must error
-            let generated_inbox_id = identifier.inbox_id(nonce)?;
-            if inbox_id != generated_inbox_id {
-                return Err(IdentityError::NewIdentity(
-                    "Inbox ID doesn't match nonce & address".to_string(),
-                ));
-            }
-            let mut builder = SignatureRequestBuilder::new(inbox_id.clone());
-            builder = builder.create_inbox(identifier.clone(), nonce);
-            let mut signature_request = builder
-                .add_association(
-                    MemberIdentifier::installation(installation_keys.public_slice().to_vec()),
-                    identifier.clone().into(),
-                )
-                .build();
-
-            let sig = installation_keys
-                .credential_sign::<InstallationKeyContext>(signature_request.signature_text())?;
-
-            signature_request
-                .add_signature(
-                    UnverifiedSignature::new_installation_key(
-                        sig,
-                        installation_keys.verifying_key(),
-                    ),
-                    &scw_signature_verifier,
-                )
-                .await?;
-            signature_request
-                .add_signature(
-                    UnverifiedSignature::LegacyDelegated(sign_with_legacy_key(
-                        signature_request.signature_text(),
-                        legacy_signed_private_key,
-                    )?),
-                    scw_signature_verifier,
-                )
-                .await?;
-
-            // Make sure to register the identity before applying the signature request
-            let identity = Self {
-                inbox_id: inbox_id.clone(),
-                installation_keys,
-                credential: create_credential(inbox_id)?,
-                signature_request: None,
-                is_ready: AtomicBool::new(true),
-            };
-
-            identity.register(api_client, mls_storage).await?;
-
-            let identity_update = signature_request.build_identity_update()?;
-            api_client.publish_identity_update(identity_update).await?;
-
-            Ok(identity)
-        } else {
-            let generated_inbox_id = identifier.inbox_id(nonce)?;
-            if inbox_id != generated_inbox_id {
-                return Err(IdentityError::NewIdentity(
-                    "Inbox ID doesn't match nonce & address".to_string(),
-                ));
-            }
-            let mut builder = SignatureRequestBuilder::new(inbox_id.clone());
-            builder = builder.create_inbox(identifier.clone(), nonce);
-
-            let mut signature_request = builder
-                .add_association(
-                    MemberIdentifier::installation(installation_keys.public_slice().to_vec()),
-                    identifier.clone().into(),
-                )
-                .build();
-
-            // We can pre-sign the request with an installation key signature, since we have access to the key
-            let sig = installation_keys
-                .credential_sign::<InstallationKeyContext>(signature_request.signature_text())?;
-            signature_request
-                .add_signature(
-                    UnverifiedSignature::new_installation_key(
-                        sig,
-                        installation_keys.verifying_key(),
-                    ),
-                    scw_signature_verifier,
-                )
-                .await?;
-
-            let identity = Self {
-                inbox_id: inbox_id.clone(),
-                installation_keys,
-                credential: create_credential(inbox_id.clone())?,
-                signature_request: Some(signature_request),
-                is_ready: AtomicBool::new(false),
-            };
-
-            Ok(identity)
+        // Legacy V2 path completes registration inline; preserve that.
+        if pending.can_self_publish() {
+            return pending.publish(api_client, mls_storage).await;
         }
+
+        // Non-legacy branches return an `Identity` carrying an
+        // unfinished `signature_request` that the caller will complete
+        // and then drive through `Identity::register` themselves.
+        pending.into_legacy_shim()
     }
 
     pub fn inbox_id(&self) -> InboxIdRef<'_> {
@@ -678,8 +519,22 @@ impl Identity {
             .build(provider, include_post_quantum)
     }
 
+    /// Persist this identity's key package: rotate + upload one key
+    /// package to the network and write `StoredIdentity` to the local
+    /// DB. Idempotent — no-ops if a `StoredIdentity` already exists.
+    ///
+    /// **Most callers want [`Client::register_identity`](crate::Client::register_identity)
+    /// instead.** That is the full production pipeline: signature
+    /// validation, identity-update publish, registration cursor
+    /// bookkeeping, and old-key cleanup, in addition to what this
+    /// method does. It is also the API the FFI bindings drive.
+    ///
+    /// `persist_key_package` is a low-level primitive used internally
+    /// by the [`UnregisteredIdentity`](crate::identity::UnregisteredIdentity)
+    /// typestate flow once the identity-update publish has already
+    /// been arranged.
     #[tracing::instrument(level = "trace", skip_all)]
-    pub(crate) async fn register<ApiClient: XmtpApi, S: XmtpMlsStorageProvider>(
+    pub(crate) async fn persist_key_package<ApiClient: XmtpApi, S: XmtpMlsStorageProvider>(
         &self,
         api_client: &ApiClientWrapper<ApiClient>,
         mls_storage: &S,

--- a/crates/xmtp_mls/src/identity/unregistered.rs
+++ b/crates/xmtp_mls/src/identity/unregistered.rs
@@ -1,0 +1,376 @@
+//! Two-phase identity construction split from [`Identity::new`].
+//!
+//! Today's `Identity::new` mixes pure crypto, network reads, and (on the
+//! legacy path) network writes. This module separates them:
+//!
+//! - [`UnregisteredIdentity::generate`] — pure crypto (keypair + credential).
+//! - [`UnregisteredIdentity::attest`] — network read that classifies the
+//!   inbox state and pre-signs with the installation key.
+//! - [`UnregisteredIdentity::publish`] — network write that uploads the
+//!   key package, publishes the identity update, persists `StoredIdentity`,
+//!   and returns a registered [`Identity`].
+//!
+//! `Identity::new` is preserved as a backward-compat shim that drives this
+//! new API internally. Callers can migrate incrementally.
+use super::{Identity, IdentityError, create_credential};
+use crate::XmtpApi;
+use crate::identity_updates::{get_association_state_with_verifier, load_identity_updates};
+use std::sync::atomic::AtomicBool;
+use xmtp_api::ApiClientWrapper;
+use xmtp_configuration::MAX_INSTALLATIONS_PER_INBOX;
+use xmtp_cryptography::{CredentialSign, XmtpInstallationCredential};
+use xmtp_db::prelude::*;
+use xmtp_id::InboxId;
+use xmtp_id::associations::unverified::UnverifiedSignature;
+use xmtp_id::associations::{
+    Identifier, InstallationKeyContext, MemberIdentifier,
+    builder::{SignatureRequest, SignatureRequestBuilder},
+    sign_with_legacy_key,
+};
+use xmtp_id::scw_verifier::SmartContractSignatureVerifier;
+use zeroize::Zeroizing;
+
+/// Local-only identity material. No network calls performed yet.
+///
+/// Drive through the lifecycle by calling [`attest`](Self::attest) (network
+/// read, classifies the inbox) then either [`publish`](Self::publish)
+/// (network write, completes registration) — or, for branches that need an
+/// external wallet signature, add signatures via
+/// [`pending_signature`](Self::pending_signature) before calling `publish`.
+pub struct UnregisteredIdentity {
+    inbox_id: InboxId,
+    identifier: Identifier,
+    nonce: u64,
+    /// V2 legacy signed private key (when migrating an existing V2
+    /// inbox). Wrapped in `Zeroizing` so the bytes are wiped from
+    /// memory when the `UnregisteredIdentity` is dropped.
+    legacy_signed_private_key: Option<Zeroizing<Vec<u8>>>,
+    installation_keys: XmtpInstallationCredential,
+    pending: AttestationState,
+}
+
+/// Lifecycle state for an [`UnregisteredIdentity`].
+enum AttestationState {
+    /// Just generated. Must call `attest` before `publish`.
+    NotAttested,
+    /// Attested. Variants describe how to complete publishing.
+    Attested(PendingAttestation),
+}
+
+/// Network-discovered status of the inbox at attest time. Each variant
+/// carries the in-progress [`SignatureRequest`] that completes that
+/// branch's identity update.
+pub enum PendingAttestation {
+    /// Inbox already exists on network. Caller must add a wallet
+    /// signature to the [`SignatureRequest`] before calling
+    /// [`UnregisteredIdentity::publish`].
+    JoiningExistingInbox(SignatureRequest),
+    /// Fresh inbox claim. Caller must add a wallet signature before
+    /// publishing.
+    ClaimingNewInbox(SignatureRequest),
+    /// Fresh inbox claim signed by a legacy V2 key — no external
+    /// signature needed. Ready to publish immediately.
+    ReadyToPublish(SignatureRequest),
+}
+
+impl UnregisteredIdentity {
+    /// Pure crypto: generates an installation keypair and an OpenMLS
+    /// credential. Does not touch the network.
+    ///
+    /// `inbox_id` is the caller-provided identifier the on-network state
+    /// will be validated against during [`attest`](Self::attest).
+    pub fn generate(
+        inbox_id: InboxId,
+        identifier: Identifier,
+        nonce: u64,
+        legacy_signed_private_key: Option<Vec<u8>>,
+    ) -> Result<Self, IdentityError> {
+        Ok(Self {
+            inbox_id,
+            identifier,
+            nonce,
+            legacy_signed_private_key: legacy_signed_private_key.map(Zeroizing::new),
+            installation_keys: XmtpInstallationCredential::new(),
+            pending: AttestationState::NotAttested,
+        })
+    }
+
+    /// Network read: classify the inbox state, construct the appropriate
+    /// [`PendingAttestation`], and pre-sign the request with the
+    /// installation key.
+    ///
+    /// Idempotent: calling twice re-runs the network classification and
+    /// rebuilds the signature request.
+    #[tracing::instrument(level = "trace", skip_all)]
+    pub async fn attest<C: XmtpApi, S: XmtpMlsStorageProvider>(
+        &mut self,
+        api_client: &ApiClientWrapper<C>,
+        mls_storage: &S,
+        scw_signature_verifier: impl SmartContractSignatureVerifier,
+    ) -> Result<(), IdentityError> {
+        let pending = match self.lookup_associated_inbox(api_client).await? {
+            Some(inbox) => {
+                self.guard_inbox_match(&inbox)?;
+                self.load_and_check_installations(api_client, mls_storage, &scw_signature_verifier)
+                    .await?;
+                let req = self
+                    .build_and_presign(SignatureRequestBuilder::new(inbox), &scw_signature_verifier)
+                    .await?;
+                PendingAttestation::JoiningExistingInbox(req)
+            }
+            None if self.legacy_signed_private_key.is_some() => {
+                self.guard_legacy_preconditions()?;
+                let legacy = self.legacy_signed_private_key.clone().expect("checked");
+                let mut req = self
+                    .build_and_presign(self.fresh_builder(), &scw_signature_verifier)
+                    .await?;
+                self.add_legacy_signature(&mut req, legacy, &scw_signature_verifier)
+                    .await?;
+                PendingAttestation::ReadyToPublish(req)
+            }
+            None => {
+                self.ensure_generated_inbox_id_matches()?;
+                let req = self
+                    .build_and_presign(self.fresh_builder(), &scw_signature_verifier)
+                    .await?;
+                PendingAttestation::ClaimingNewInbox(req)
+            }
+        };
+
+        self.pending = AttestationState::Attested(pending);
+        Ok(())
+    }
+
+    async fn lookup_associated_inbox<C: XmtpApi>(
+        &self,
+        api_client: &ApiClientWrapper<C>,
+    ) -> Result<Option<InboxId>, IdentityError> {
+        let inbox_ids = api_client
+            .get_inbox_ids(vec![self.identifier.clone().into()])
+            .await?;
+        Ok(inbox_ids.get(&(&self.identifier).into()).cloned())
+    }
+
+    fn guard_inbox_match(&self, associated: &InboxId) -> Result<(), IdentityError> {
+        if *associated != self.inbox_id {
+            return Err(IdentityError::NewIdentity("Inbox ID mismatch".to_string()));
+        }
+        Ok(())
+    }
+
+    fn guard_legacy_preconditions(&self) -> Result<(), IdentityError> {
+        if self.nonce != 0 {
+            return Err(IdentityError::NewIdentity(
+                "Nonce must be 0 if legacy key is provided".to_string(),
+            ));
+        }
+        self.ensure_generated_inbox_id_matches()
+    }
+
+    async fn load_and_check_installations<C: XmtpApi, S: XmtpMlsStorageProvider>(
+        &self,
+        api_client: &ApiClientWrapper<C>,
+        mls_storage: &S,
+        scw_signature_verifier: &impl SmartContractSignatureVerifier,
+    ) -> Result<(), IdentityError> {
+        load_identity_updates(api_client, &mls_storage.db(), &[self.inbox_id.as_str()])
+            .await
+            .map_err(|e| {
+                IdentityError::NewIdentity(format!("Failed to load identity updates: {e}"))
+            })?;
+        let state = get_association_state_with_verifier(
+            &mls_storage.db(),
+            &self.inbox_id,
+            None,
+            scw_signature_verifier,
+        )
+        .await
+        .map_err(|err| {
+            IdentityError::NewIdentity(format!("Error resolving identity state: {err}"))
+        })?;
+        let count = state.installation_ids().len();
+        if count >= MAX_INSTALLATIONS_PER_INBOX {
+            return Err(IdentityError::TooManyInstallations {
+                inbox_id: self.inbox_id.clone(),
+                count,
+                max: MAX_INSTALLATIONS_PER_INBOX,
+            });
+        }
+        Ok(())
+    }
+
+    fn fresh_builder(&self) -> SignatureRequestBuilder {
+        SignatureRequestBuilder::new(self.inbox_id.clone())
+            .create_inbox(self.identifier.clone(), self.nonce)
+    }
+
+    async fn build_and_presign(
+        &self,
+        builder: SignatureRequestBuilder,
+        scw_signature_verifier: impl SmartContractSignatureVerifier,
+    ) -> Result<SignatureRequest, IdentityError> {
+        let mut req = builder
+            .add_association(
+                MemberIdentifier::installation(self.installation_keys.public_slice().to_vec()),
+                self.identifier.clone().into(),
+            )
+            .build();
+        self.presign_with_installation_key(&mut req, scw_signature_verifier)
+            .await?;
+        Ok(req)
+    }
+
+    async fn add_legacy_signature(
+        &self,
+        req: &mut SignatureRequest,
+        legacy: Zeroizing<Vec<u8>>,
+        scw_signature_verifier: impl SmartContractSignatureVerifier,
+    ) -> Result<(), IdentityError> {
+        req.add_signature(
+            UnverifiedSignature::LegacyDelegated(sign_with_legacy_key(
+                req.signature_text(),
+                &legacy,
+            )?),
+            scw_signature_verifier,
+        )
+        .await?;
+        Ok(())
+    }
+
+    fn ensure_generated_inbox_id_matches(&self) -> Result<(), IdentityError> {
+        let generated = self.identifier.inbox_id(self.nonce)?;
+        if self.inbox_id != generated {
+            return Err(IdentityError::NewIdentity(
+                "Inbox ID doesn't match nonce & address".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    async fn presign_with_installation_key(
+        &self,
+        req: &mut SignatureRequest,
+        scw_signature_verifier: impl SmartContractSignatureVerifier,
+    ) -> Result<(), IdentityError> {
+        let sig = self
+            .installation_keys
+            .credential_sign::<InstallationKeyContext>(req.signature_text())?;
+        req.add_signature(
+            UnverifiedSignature::new_installation_key(sig, self.installation_keys.verifying_key()),
+            scw_signature_verifier,
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// In-progress signature request the caller (wallet / SCW) must add
+    /// signatures to. Returns `None` if this branch is already complete
+    /// (legacy V2 path) or if [`attest`](Self::attest) hasn't run yet.
+    pub fn pending_signature(&mut self) -> Option<&mut SignatureRequest> {
+        match &mut self.pending {
+            AttestationState::Attested(
+                PendingAttestation::JoiningExistingInbox(req)
+                | PendingAttestation::ClaimingNewInbox(req),
+            ) => Some(req),
+            _ => None,
+        }
+    }
+
+    /// True iff the legacy V2 path applies and `publish` requires no
+    /// external signatures.
+    pub fn can_self_publish(&self) -> bool {
+        matches!(
+            self.pending,
+            AttestationState::Attested(PendingAttestation::ReadyToPublish(_))
+        )
+    }
+
+    /// Network write: uploads the key package, publishes the identity
+    /// update, persists `StoredIdentity`. Consumes self.
+    ///
+    /// Requires [`attest`](Self::attest) to have been called. For
+    /// `JoiningExistingInbox` / `ClaimingNewInbox`, the signature
+    /// request returned by [`pending_signature`](Self::pending_signature)
+    /// must be completed (wallet signature added) before calling this.
+    #[tracing::instrument(level = "trace", skip_all)]
+    pub async fn publish<C: XmtpApi, S: XmtpMlsStorageProvider>(
+        self,
+        api_client: &ApiClientWrapper<C>,
+        mls_storage: &S,
+    ) -> Result<Identity, IdentityError> {
+        let Self {
+            inbox_id,
+            installation_keys,
+            pending,
+            ..
+        } = self;
+        let AttestationState::Attested(pending) = pending else {
+            return Err(IdentityError::NewIdentity(
+                "publish() called before attest()".to_string(),
+            ));
+        };
+        let signature_request = match pending {
+            PendingAttestation::JoiningExistingInbox(req)
+            | PendingAttestation::ClaimingNewInbox(req)
+            | PendingAttestation::ReadyToPublish(req) => req,
+        };
+
+        // Build the identity update first so any signature-missing
+        // error (e.g. caller forgot to add a wallet signature) surfaces
+        // BEFORE `register()` performs its irreversible key-package
+        // upload + StoredIdentity persist. Without this ordering, a
+        // failed `build_identity_update()` would leave the system with
+        // a registered identity but no published update.
+        let credential = create_credential(signature_request.inbox_id())?;
+        let identity_update = signature_request.build_identity_update()?;
+
+        let identity = Identity {
+            inbox_id,
+            installation_keys,
+            credential,
+            signature_request: None,
+            is_ready: AtomicBool::new(true),
+        };
+
+        identity
+            .persist_key_package(api_client, mls_storage)
+            .await?;
+        api_client.publish_identity_update(identity_update).await?;
+
+        Ok(identity)
+    }
+
+    /// Compat: flatten state into the legacy [`Identity`] shape with
+    /// `signature_request: Some` and `is_ready: false`. Used by
+    /// `Identity::new` to preserve its pre-refactor return contract for
+    /// branches that require an external wallet signature.
+    pub(crate) fn into_legacy_shim(self) -> Result<Identity, IdentityError> {
+        let Self {
+            inbox_id,
+            installation_keys,
+            pending,
+            ..
+        } = self;
+        let AttestationState::Attested(pending) = pending else {
+            return Err(IdentityError::NewIdentity(
+                "into_legacy_shim() called before attest()".to_string(),
+            ));
+        };
+        let signature_request = match pending {
+            PendingAttestation::JoiningExistingInbox(req)
+            | PendingAttestation::ClaimingNewInbox(req) => req,
+            PendingAttestation::ReadyToPublish(_) => {
+                return Err(IdentityError::NewIdentity(
+                    "ReadyToPublish must go through publish(), not legacy shim".to_string(),
+                ));
+            }
+        };
+        Ok(Identity {
+            credential: create_credential(signature_request.inbox_id())?,
+            inbox_id,
+            installation_keys,
+            signature_request: Some(signature_request),
+            is_ready: AtomicBool::new(false),
+        })
+    }
+}


### PR DESCRIPTION
just makes the code more DRY. this will allow xdbg to generate an identity w/o registering it, and do the actual register step in a healthcheck op, rather than forcing identity registration to occur at generation time. 

IMO it also makes the code a little more readable and removes the monolithic `new` method

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refactor identity registration into a two-phase `UnregisteredIdentity` API for use from xdbg
> - Extracts identity creation logic from `Identity::new` into a new [`unregistered.rs`](https://github.com/xmtp/libxmtp/pull/3689/files#diff-8c2a4479db75235daaac89b1523a0c46e1a478b0ff52fa93755435c5924242ba) module with a two-phase flow: `generate` (pure crypto init) → `attest` (network read, install limit check, pre-sign) → `publish` (network write, returns registered `Identity`).
> - Introduces `UnregisteredIdentity` and `PendingAttestation` as public types re-exported from [`identity.rs`](https://github.com/xmtp/libxmtp/pull/3689/files#diff-7a53ab1775c572e550b2b08934d90d3f8433e012043b1ee641110036902663ed); `Identity::new` is now a shim over this new API.
> - The legacy V2 path (`can_self_publish`) still auto-publishes without an external signature; other paths return a `SignatureRequest` for the caller to complete before calling `publish`.
> - Changes `sign_with_legacy_key` in [`signature.rs`](https://github.com/xmtp/libxmtp/pull/3689/files#diff-09f89481d8b7852671ee9482149addf7d7c14f85a72c5343b094305a60863450) to accept `&[u8]` instead of `Vec<u8>`, supporting callers holding `Zeroizing`-wrapped key bytes.
> - Behavioral Change: callers of `sign_with_legacy_key` must now pass a slice reference instead of an owned `Vec`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 90ff85c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->