### PR TITLE
patch tracing-oslog to remove panics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12096,8 +12096,7 @@ dependencies = [
 [[package]]
 name = "tracing-oslog"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76902d2a8d5f9f55a81155c08971734071968c90f2d9bfe645fe700579b2950"
+source = "git+https://github.com/insipx/tracing-oslog?rev=69cebec3804c33267b8d18aa50a5d9ba18617121#69cebec3804c33267b8d18aa50a5d9ba18617121"
 dependencies = [
  "cc",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -248,6 +248,7 @@ hpke-rs = { git = "https://github.com/xmtp/hpke-rs", rev = "3425025bb43b68bdef28
 hpke-rs-crypto = { git = "https://github.com/xmtp/hpke-rs", rev = "3425025bb43b68bdef28ce47da8013ae13b69cbc" }
 hpke-rs-libcrux = { git = "https://github.com/xmtp/hpke-rs", rev = "3425025bb43b68bdef28ce47da8013ae13b69cbc" }
 hpke-rs-rust-crypto = { git = "https://github.com/xmtp/hpke-rs", rev = "3425025bb43b68bdef28ce47da8013ae13b69cbc" }
+tracing-oslog = { git = "https://github.com/insipx/tracing-oslog", rev = "69cebec3804c33267b8d18aa50a5d9ba18617121" }
 
 [patch.crates-io.xmtp-workspace-hack]
 path = "crates/xmtp-workspace-hack"


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Patch `tracing-oslog` dependency to remove panics
Replaces the `tracing-oslog` crate with a forked version pinned to a specific git revision that removes panics from the library.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized bcccc6e.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->