### PR TITLE
Downgrade chatty retry + sync logs

### DIFF
--- a/crates/xmtp_common/src/retry.rs
+++ b/crates/xmtp_common/src/retry.rs
@@ -338,7 +338,10 @@ macro_rules! retry_async {
                 Ok(v) => break Ok(v),
                 Err(e) => {
                     if (&e).is_retryable() && attempts < $retry.retries() {
-                        tracing::warn!(
+                        // A single retry is normal transient behavior; keep it at debug so a
+                        // flapping endpoint doesn't flood prod warn logs (only exhaustion warns).
+                        tracing::debug!(
+                            attempt = attempts,
                             "retrying function that failed with error={}",
                             e.to_string()
                         );
@@ -346,7 +349,12 @@ macro_rules! retry_async {
                             attempts += 1;
                             $crate::time::sleep(d).await;
                         } else {
-                            tracing::warn!("retry strategy exceeded max wait time");
+                            tracing::warn!(
+                                attempts,
+                                elapsed_ms = time_spent.elapsed().as_millis(),
+                                "retry strategy exceeded max wait time, giving up: {}",
+                                e.to_string()
+                            );
                             break Err(e);
                         }
                     } else {

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -353,12 +353,12 @@ where
         let conn = self.context.db();
 
         let epoch = self.epoch().await?;
-        tracing::info!(
+        tracing::debug!(
             inbox_id = self.context.inbox_id(),
             installation_id = %self.context.installation_id(),
             group_id = self.group_id.short_hex(),
-            "[{}] syncing group, epoch = {epoch}",
-            self.context.inbox_id(),
+            epoch,
+            "syncing group",
         );
 
         // Also sync the "stitched DMs", if any...

--- a/crates/xmtp_mls/src/groups/welcome_sync.rs
+++ b/crates/xmtp_mls/src/groups/welcome_sync.rs
@@ -325,11 +325,11 @@ where
         // group re-evaluation in `handle_group_paused` wouldn't fire
         // for a quiet paused group).
         if let Err(err) = self.unstick_paused_groups().await {
-            tracing::warn!(?err, "unstick_paused_groups failed, continuing with sync");
+            tracing::debug!(?err, "unstick_paused_groups failed, continuing with sync");
         }
 
         if let Err(err) = self.sync_welcomes().await {
-            tracing::warn!(?err, "sync_welcomes failed, continuing with group sync");
+            tracing::debug!(?err, "sync_welcomes failed, continuing with group sync");
         }
         let query_args = GroupQueryArgs {
             consent_states,


### PR DESCRIPTION
Continues the log-noise cleanup (after #3693). These three sites were among the top remaining volume sources in the production sample, all logging normal-course behavior at warn/info.

## Changes
- **`xmtp_common/src/retry.rs`** — the retry combinator (every API call funnels through it):
  - Per-attempt `"retrying function that failed"` was logged at **warn** on *every* retry. A single retry is normal transient behavior, so a flapping endpoint flooded prod warn logs. → **debug** (with an `attempt` field).
  - `"retry strategy exceeded max wait time"` stays at **warn** (it signals a call that never succeeded) but now carries context: `attempts`, `elapsed_ms`, and the error — previously it was a bare string with no indication of which call or how long.
- **`xmtp_mls/src/groups/mls_sync.rs`** — `"[{inbox_id}] syncing group, epoch = …"` fired at **info** on every group sync, and duplicated `inbox_id` (both a structured field *and* the `[{}]` message prefix). → **debug**, dropped the redundant prefix, `epoch` is now a field.
- **`xmtp_mls/src/groups/welcome_sync.rs`** — `"sync_welcomes failed, continuing with group sync"` and `"unstick_paused_groups failed, continuing with sync"` were **warn**, but both are explicitly non-fatal recovered paths. → **debug**.

Net effect: prod logs at `info`+ now reflect real problems; normal retry/sync churn drops to `debug`.

## Verification
- `cargo clippy --locked --all-features --all-targets --no-deps -- -Dwarnings` ✓
- `cargo fmt --check` ✓
- Log-level/message-only changes; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Downgrade retry and sync log levels from warn/info to debug
> - Retry attempts in `retry_async` now log at debug instead of warn; exhaustion logs still warn but now include attempt count, elapsed_ms, and the error message.
> - Group sync start in `MlsGroup.sync` is downgraded from info to debug and switches to structured fields (inbox_id, installation_id, group_id, epoch).
> - Failures in `WelcomeSync.sync_groups` for `unstick_paused_groups` and `sync_welcomes` are downgraded from warn to debug.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1e96453.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->