### PR TITLE
Downgrade per-item welcome/sync/query info logs to debug

### DIFF
--- a/crates/xmtp_api_d14n/src/queries/d14n/mls.rs
+++ b/crates/xmtp_api_d14n/src/queries/d14n/mls.rs
@@ -76,7 +76,7 @@ where
             .build()?
             .query(&self.client)
             .await?;
-        tracing::info!("got {} envelopes", result.results.len());
+        tracing::debug!("got {} envelopes", result.results.len());
         let extractor = CollectionExtractor::new(result.results, KeyPackagesExtractor::new());
         let key_packages = extractor.get()?;
         Ok(mls_v1::FetchKeyPackagesResponse { key_packages })
@@ -193,7 +193,7 @@ where
     ) -> Result<Vec<WelcomeMessage>, Self::Error> {
         let topic = TopicKind::WelcomeMessagesV1.create(installation_key);
         let cursor = self.cursor_store.latest(&topic, None)?;
-        tracing::info!("querying welcomes @{:?}", cursor);
+        tracing::debug!("querying welcomes @{:?}", cursor);
         let response = QueryEnvelope::builder()
             .topic(topic)
             .last_seen(cursor)

--- a/crates/xmtp_mls/src/groups/commit_log.rs
+++ b/crates/xmtp_mls/src/groups/commit_log.rs
@@ -266,7 +266,7 @@ where
             Ok(_) => {
                 // Publishing was successful, let's update every group's cursor
                 for conversation_cursor_info in &conversation_cursor_info {
-                    tracing::info!(
+                    tracing::debug!(
                         "Updating publish cursor for conversation {}",
                         hex::encode(&conversation_cursor_info.conversation_id)
                     );
@@ -422,7 +422,7 @@ where
 
         // Skip API call if there are no requests to make
         if query_log_requests.is_empty() {
-            tracing::info!("No commit log requests to query");
+            tracing::debug!("No commit log requests to query");
             return Ok(HashMap::new());
         }
 
@@ -646,7 +646,7 @@ where
             return Ok(());
         }
 
-        tracing::info!(group_id = %group_id, "Sending readd request");
+        tracing::debug!(group_id = %group_id, "Sending readd request");
 
         // Send oneshot message with readd request to super admins
         let latest_commit_sequence_id =
@@ -663,14 +663,14 @@ where
             })),
         };
         let readders = self.permitted_readders(&group_id).await?;
-        tracing::info!(
+        tracing::debug!(
             group_id = %group_id,
             "Sending readd request to {:?}",
             readders
         );
         Oneshot::send_message(self.context.clone(), readders, oneshot_message).await?;
 
-        tracing::info!(group_id = %group_id, "Sent readd request",);
+        tracing::debug!(group_id = %group_id, "Sent readd request",);
 
         // Mark readd as requested
         conn.update_requested_at_sequence_id(
@@ -679,7 +679,7 @@ where
             latest_commit_sequence_id as i64,
         )?;
 
-        tracing::info!(
+        tracing::debug!(
             group_id = %group_id,
             sequence_id = latest_commit_sequence_id,
             "Updated requested readd sequence id",
@@ -746,7 +746,11 @@ where
         let conn = self.context.db();
         let groups_for_readd = conn.get_conversation_ids_for_responding_readds()?;
 
-        tracing::info!(
+        // Runs every worker tick (~2s); only speak when there's actually work.
+        if groups_for_readd.is_empty() {
+            return Ok(());
+        }
+        tracing::debug!(
             "Processing readd requests for {} groups",
             groups_for_readd.len()
         );

--- a/crates/xmtp_mls/src/groups/mls_ext/decrypted_welcome.rs
+++ b/crates/xmtp_mls/src/groups/mls_ext/decrypted_welcome.rs
@@ -55,7 +55,7 @@ impl DecryptedWelcome {
             data,
             welcome_metadata,
         } = welcome_v1;
-        tracing::info!(id = %welcome.cursor, "Trying to decrypt welcome");
+        tracing::debug!(id = %welcome.cursor, "Trying to decrypt welcome");
         let wrapper_ciphersuite = WrapperAlgorithm::try_from(*wrapper_algorithm)?;
         let hash_ref = find_key_package_hash_ref(provider, hpke_public_key)?;
         let private_key = find_private_key(provider, &hash_ref, &wrapper_ciphersuite)?;
@@ -282,7 +282,7 @@ pub(crate) fn decrypt_welcome_pointer(
     provider: &impl XmtpMlsStorageProvider,
     welcome_pointer: &WelcomePointer,
 ) -> Result<DecryptedWelcomePointer, GroupError> {
-    tracing::info!("Trying to decrypt welcome pointer");
+    tracing::debug!("Trying to decrypt welcome pointer");
     let hash_ref = find_key_package_hash_ref(provider, &welcome_pointer.hpke_public_key)?;
     let wrapper_algorithm = WrapperAlgorithm::try_from(welcome_pointer.wrapper_algorithm)?;
     let private_key = find_private_key(provider, &hash_ref, &wrapper_algorithm)?;

--- a/crates/xmtp_mls/src/groups/oneshot.rs
+++ b/crates/xmtp_mls/src/groups/oneshot.rs
@@ -99,7 +99,7 @@ impl Oneshot {
         sender_installation_id: Vec<u8>,
         metadata: GroupMetadata,
     ) -> Result<(), GroupError> {
-        tracing::info!("Processing oneshot welcome");
+        tracing::debug!("Processing oneshot welcome");
         if let Some(message) = metadata.oneshot_message {
             Self::process_message(provider, sender_inbox_id, sender_installation_id, message)?;
         } else {

--- a/crates/xmtp_mls/src/groups/welcome_pointer.rs
+++ b/crates/xmtp_mls/src/groups/welcome_pointer.rs
@@ -14,7 +14,7 @@ pub async fn resolve_welcome_pointer<Context: crate::context::XmtpSharedContext>
 
     let decrypted_v1 = decrypted_welcome_pointer;
 
-    tracing::info!(
+    tracing::debug!(
         "Resolving welcome pointer for destination {}",
         decrypted_v1.destination
     );

--- a/crates/xmtp_mls/src/groups/welcome_sync.rs
+++ b/crates/xmtp_mls/src/groups/welcome_sync.rs
@@ -167,11 +167,7 @@ where
             .map(|group| {
                 let active_group_count = Arc::clone(&active_group_count);
                 async move {
-                    tracing::info!(
-                        inbox_id = self.context.inbox_id(),
-                        "[{}] syncing group",
-                        self.context.inbox_id()
-                    );
+                    tracing::debug!(inbox_id = self.context.inbox_id(), "syncing group");
                     let is_active = group
                         .load_mls_group_with_lock_async(async |mls_group| {
                             Ok::<bool, GroupError>(mls_group.is_active())
@@ -299,7 +295,7 @@ where
                     );
                     continue;
                 }
-                tracing::info!(
+                tracing::debug!(
                     group_id = hex::encode(group_id.as_ref()),
                     required = %required_str,
                     own = %own_version_str,
@@ -379,7 +375,7 @@ where
                 let inbox_id = self.context.inbox_id();
 
                 async move {
-                    tracing::info!(inbox_id, "[{}] syncing group", inbox_id);
+                    tracing::debug!(inbox_id, "syncing group");
 
                     let is_active_res = group
                         .load_mls_group_with_lock_async(async |mls_group| {

--- a/crates/xmtp_mls/src/groups/welcomes/xmtp_welcome.rs
+++ b/crates/xmtp_mls/src/groups/welcomes/xmtp_welcome.rs
@@ -250,7 +250,7 @@ where
         decrypted_welcome: DecryptedWelcome,
         events: &mut DeferredEvents,
     ) -> Result<CommitResult<C>, GroupError> {
-        tracing::info!("attempting to commit welcome={}", &self.welcome.cursor);
+        tracing::debug!("attempting to commit welcome={}", &self.welcome.cursor);
         let commit_result = self.context.mls_storage().transaction(|conn| {
             let storage = conn.key_store();
             // Savepoint transaction
@@ -311,7 +311,7 @@ where
             return Err(ProcessIntentError::WelcomeAlreadyProcessed(welcome.cursor).into());
         }
         if *cursor_increment {
-            tracing::info!("updating cursor to {}", welcome.cursor);
+            tracing::debug!("updating cursor to {}", welcome.cursor);
             // TODO: We update the cursor if this welcome decrypts successfully, but if previous welcomes
             // failed due to retriable errors, this will permanently skip them.
             db.update_cursor(
@@ -492,7 +492,7 @@ where
             }
         };
 
-        tracing::info!("storing group with welcome id {}", welcome.cursor);
+        tracing::debug!("storing group with welcome id {}", welcome.cursor);
 
         // If this is a re-add after leaving, update the existing group's membership state
         // before calling insert_or_replace_group
@@ -574,10 +574,7 @@ where
 
         added_msg.store_or_ignore(&db)?;
 
-        tracing::info!(
-            "[{}]: Created GroupUpdated message for welcome",
-            current_inbox_id
-        );
+        tracing::debug!("created GroupUpdated message for welcome, inbox_id={current_inbox_id}");
 
         let group = MlsGroup::new(
             context.clone(),
@@ -614,7 +611,7 @@ where
             cursor,
         )?;
 
-        tracing::info!(
+        tracing::debug!(
             inbox_id = %current_inbox_id,
             installation_id = %self.context.installation_id(),
             group_id = %group.group_id,

--- a/crates/xmtp_mls/src/mls_store.rs
+++ b/crates/xmtp_mls/src/mls_store.rs
@@ -77,7 +77,7 @@ where
             .api()
             .query_welcome_messages(installation_id)
             .await?;
-        tracing::info!("returning {} welcomes", welcomes.len());
+        tracing::debug!("returning {} welcomes", welcomes.len());
         Ok(welcomes)
     }
 

--- a/crates/xmtp_mls/src/subscriptions/process_welcome.rs
+++ b/crates/xmtp_mls/src/subscriptions/process_welcome.rs
@@ -144,7 +144,7 @@ where
                             .await;
                     }
                 }
-                tracing::info!(
+                tracing::debug!(
                     "could not find group for welcome {}, processing",
                     welcome.cursor
                 );
@@ -155,12 +155,12 @@ where
                         id: welcome.cursor,
                     }
                 } else {
-                    tracing::info!("Oneshot welcome message processed, skipping stream event.");
+                    tracing::debug!("Oneshot welcome message processed, skipping stream event.");
                     ProcessWelcomeResult::IgnoreId { id: welcome.cursor }
                 }
             }
             Group(ref id) => {
-                tracing::info!("stream got existing group, pulling from db.");
+                tracing::debug!("stream got existing group, pulling from db.");
                 let (group, stored_group) = MlsGroup::new_cached(self.context.clone(), id)?;
 
                 ProcessWelcomeResult::NewStored {

--- a/crates/xmtp_mls/src/subscriptions/stream_messages.rs
+++ b/crates/xmtp_mls/src/subscriptions/stream_messages.rs
@@ -440,7 +440,7 @@ where
             this.groups.set(next_msg.group_id, next_msg.cursor);
             return Poll::Ready(Some(Ok(stored)));
         }
-        tracing::info!(
+        tracing::debug!(
             "group_id@[{}] encountered newly unprocessed message @cursor=[{}]",
             next_msg.group_id,
             next_msg.cursor


### PR DESCRIPTION
Third log-noise PR (after #3693, #3696), driven by a **new herald log dump filtered to INFO-only** (2000 lines, ~15.5 min of healthy traffic — the first sample was TRACE-flooded and couldn't show INFO top-talkers).

## Headline finding from the INFO dump
**`"Processing readd requests for N groups"` was 1705 of 2000 lines (85%)** — `commit_log.rs` `handle_incoming_pending_readds`, which runs every ~2s worker tick and logged at info **even when N=0**. Fixed: early-return when empty + downgrade to debug. This single change removes the dominant INFO offender.

## Changes (all info→debug, per-item/steady-state churn)
- **commit_log.rs**: gate `"Processing readd requests"` on non-empty (the 85% offender); `"No commit log requests to query"` (nothing-to-do early return); the per-readd cluster (`Sending readd request`, `Sending readd request to`, `Sent readd request`, `Updated requested readd sequence id`); `Updating publish cursor for conversation` (per-conversation loop).
- **welcome_sync.rs**: two `"[{}] syncing group"` (per-group, also dropped the duplicate inbox_id prefix); `unstuck previously paused group` (per-group).
- **welcomes/xmtp_welcome.rs**: per-welcome routine logs (`attempting to commit welcome`, `updating cursor to`, `storing group with welcome id`, `Created GroupUpdated message`, `updated message cursor from welcome metadata`). Kept the semantic state-change events (re-add → ALLOWED, consent reset) and error logs at info/warn.
- **mls_ext/decrypted_welcome.rs**: `Trying to decrypt welcome` / `welcome pointer` (per-welcome).
- **welcome_pointer.rs**: `Resolving welcome pointer` (kept the retry-progress log).
- **mls_store.rs**: `returning N welcomes` (per query).
- **oneshot.rs**: `Processing oneshot welcome`.
- **subscriptions/process_welcome.rs**: 3 per-stream-event logs.
- **subscriptions/stream_messages.rs**: `encountered newly unprocessed message` (per message).
- **xmtp_api_d14n/.../mls.rs**: `got N envelopes`, `querying welcomes` (per query).

## Deliberately out of scope
- **mls_sync.rs** — the most sensitive code; its per-message logs are being decided separately to preserve debugging context.
- **The structured `log_event!` event system** (the `➣`-prefixed events like `GroupSyncGroupInactive`) — left untouched pending a separate evaluation of whether it's worth keeping.

## Verification
- `cargo clippy --locked --all-features --all-targets --no-deps -- -Dwarnings` ✓
- `cargo fmt --check` ✓
- Log-level/message-only changes; no behavior change except the readd early-return (skips a no-op log when there is no work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Downgrade per-item welcome, sync, and query log statements from info to debug
> Reduces log noise by lowering high-frequency, per-item `tracing` statements across welcome processing, group sync, commit log, and MLS query paths from `info` to `debug` level. Also adds an early-return guard in `handle_incoming_pending_readds` to skip logging entirely when there are no groups to process.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 357ed5d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->