### PR TITLE
fix(mls): preserve swallowed intent-error cause in SyncSummary

### DIFF
--- a/crates/xmtp_common/src/event_logging.rs
+++ b/crates/xmtp_common/src/event_logging.rs
@@ -85,7 +85,9 @@ pub enum Event {
     #[context(group_id, intent_id, intent_kind, state, icon = "🔁")]
     GroupSyncIntentRetry,
     /// Intent was found to be in error after attempting to sync.
-    #[context(group_id, intent_id, intent_kind, summary, icon = "⚠️")]
+    /// The summary is logged once by `GroupSyncFinished`; this only marks
+    /// which intent errored.
+    #[context(group_id, intent_id, intent_kind, icon = "⚠️")]
     GroupSyncIntentErrored,
     /// Attempt to publish intent failed.
     #[context(group_id, intent_id, intent_kind, err, icon = "❌")]

--- a/crates/xmtp_mls/src/groups/error.rs
+++ b/crates/xmtp_mls/src/groups/error.rs
@@ -336,7 +336,7 @@ pub enum GroupError {
     /// Sync failed to wait.
     ///
     /// Waiting for intent sync failed. Retryable.
-    #[error("Sync failed to wait for intent")]
+    #[error("Sync failed to wait for intent: {}", _0)]
     SyncFailedToWait(Box<SyncSummary>),
     /// Missing pending commit.
     ///

--- a/crates/xmtp_mls/src/groups/mls_sync.rs
+++ b/crates/xmtp_mls/src/groups/mls_sync.rs
@@ -344,6 +344,32 @@ impl PublishIntentData {
     }
 }
 
+/// The result of processing a single synced/streamed message.
+///
+/// Carries the `MessageIdentifier` for the consumed message, plus any
+/// non-retryable intent-resolution error that moved an own-intent to a terminal
+/// `Error` state *without* aborting processing. That error is committed to the
+/// intent row, the cursor advances, and processing returns success — so it would
+/// otherwise be dropped. We surface it here so the sync summary can report the
+/// real cause instead of a misleading "0 failed". `None` for external messages
+/// and for intents that succeed or are merely re-queued.
+#[derive(Debug)]
+pub(crate) struct ProcessedMessageOutcome {
+    pub(crate) identifier: MessageIdentifier,
+    pub(crate) intent_error: Option<GroupMessageProcessingError>,
+}
+
+impl ProcessedMessageOutcome {
+    /// An outcome with no swallowed intent error (external messages, successes,
+    /// already-processed early returns).
+    fn new(identifier: MessageIdentifier) -> Self {
+        Self {
+            identifier,
+            intent_error: None,
+        }
+    }
+}
+
 impl<Context> MlsGroup<Context>
 where
     Context: XmtpSharedContext,
@@ -573,12 +599,12 @@ where
                 backoff = ?wait_for
             );
 
+            // Accumulate each attempt's outcome into `summary`. The terminal
+            // GroupSyncFinished event (in sync_until_intent_resolved) is the
+            // single place the summary is logged — no per-attempt logging here.
             match self.sync_with_conn().await {
                 Ok(s) => summary.extend(s),
-                Err(s) => {
-                    tracing::error!("error syncing group {s}");
-                    summary.extend(s);
-                }
+                Err(s) => summary.extend(s),
             }
             match Fetch::<StoredGroupIntent>::fetch(&db, &intent_id) {
                 Ok(Some(StoredGroupIntent {
@@ -602,12 +628,14 @@ where
                     kind,
                     ..
                 })) => {
+                    // The summary itself is logged once by GroupSyncFinished;
+                    // this event only marks which intent errored.
                     log_event!(
                         Event::GroupSyncIntentErrored,
                         self.context.installation_id(),
                         level = warn,
                         group_id = self.group_id, intent_id = intent_id,
-                        summary = ?summary, intent_kind = ?kind
+                        intent_kind = ?kind
                     );
                     return Err(GroupError::from(summary));
                 }
@@ -1958,7 +1986,7 @@ where
         &self,
         envelope: &GroupMessage,
         trust_message_order: bool,
-    ) -> Result<MessageIdentifier, GroupMessageProcessingError> {
+    ) -> Result<ProcessedMessageOutcome, GroupMessageProcessingError> {
         if trust_message_order {
             let last_cursor = self.context.db().get_last_cursor_for_originator(
                 envelope.group_id,
@@ -1978,7 +2006,8 @@ where
                 // early return if the message is already processed
                 // _NOTE_: Not early returning and re-processing a message that
                 // has already been processed, has the potential to result in forks.
-                return MessageIdentifierBuilder::from(envelope).build();
+                let identifier = MessageIdentifierBuilder::from(envelope).build()?;
+                return Ok(ProcessedMessageOutcome::new(identifier));
             }
         }
 
@@ -2011,7 +2040,7 @@ where
         mls_group: &mut OpenMlsGroup,
         envelope: &GroupMessage,
         trust_message_order: bool,
-    ) -> Result<MessageIdentifier, GroupMessageProcessingError> {
+    ) -> Result<ProcessedMessageOutcome, GroupMessageProcessingError> {
         let db = self.context.db();
         let allow_epoch_increment = trust_message_order;
         let allow_cursor_increment = trust_message_order;
@@ -2033,9 +2062,10 @@ where
             // early return if the message is already processed
             // _NOTE_: Not early returning and re-processing a message that
             // has already been processed, has the potential to result in forks.
-            return MessageIdentifierBuilder::from(envelope)
+            let identifier = MessageIdentifierBuilder::from(envelope)
                 .previously_processed(true)
-                .build();
+                .build()?;
+            return Ok(ProcessedMessageOutcome::new(identifier));
         }
 
         tracing::info!(
@@ -2072,7 +2102,11 @@ where
                     .stage_and_validate_intent(mls_group, &intent, envelope)
                     .await;
 
-                self.context.mls_storage().transaction(|conn| {
+                // The non-retryable intent-resolution error, if one moved this
+                // intent to a terminal `Error` state. Captured here before it is
+                // folded into the intent row + dropped, so the caller can report
+                // the real cause in the sync summary.
+                let intent_error = self.context.mls_storage().transaction(|conn| {
                     let storage = conn.key_store();
                     let db = storage.db();
                     let provider = XmtpOpenMlsProviderRef::new(&storage);
@@ -2101,7 +2135,7 @@ where
                         // In some cases, we may want to roll back the cursor if we updated the
                         // cursor, but actually cannot process the message.
                         identifier.previously_processed(true);
-                        return Ok(());
+                        return Ok(None);
                     }
                     let result: Result<Option<Vec<u8>>, IntentResolutionError> = match validation_result {
                         Err(err) => Err(err),
@@ -2109,6 +2143,11 @@ where
                             self.process_own_message(mls_group, validated_intent, &intent, envelope, &storage)
                         }
                     };
+                    // The non-retryable cause for an `Error`-bound intent. Only
+                    // promoted to the returned `intent_error` once we confirm the
+                    // intent actually *transitions* to Error below — a re-delivered
+                    // message for an already-Error intent must not re-report it.
+                    let mut error_cause = None;
                     let (next_intent_state, internal_message_id) = match result {
                         Err(err) => {
                             if err.processing_error.is_retryable() {
@@ -2118,6 +2157,9 @@ where
                             if envelope.is_commit() && let Err(accounting_error) = mls_group.mark_failed_commit_logged(&provider, cursor.sequence_id, envelope.message.epoch(), &err.processing_error) {
                                 tracing::error!("Error inserting commit entry for failed self commit: {}", accounting_error);
                             }
+                            if err.next_intent_state == IntentState::Error {
+                                error_cause = Some(err.processing_error);
+                            }
                             (err.next_intent_state, None)
                         }
                         Ok(internal_message_id) => (IntentState::Committed, internal_message_id)
@@ -2125,9 +2167,12 @@ where
                     identifier.internal_id(internal_message_id.clone());
 
                     if next_intent_state == intent.state {
+                        // No state transition (e.g. a re-delivered message for an
+                        // intent already in this state) — nothing new to report.
                         tracing::warn!("Intent [{}] is already in state [{:?}]", intent_id, next_intent_state);
-                        return Ok(());
+                        return Ok(None);
                     }
+                    let mut intent_error = None;
                     match next_intent_state {
                         IntentState::ToPublish => {
                             db.set_group_intent_to_publish(intent_id)?;
@@ -2142,15 +2187,23 @@ where
                         IntentState::Error => {
                             tracing::error!("Intent [{}] moved to error status", intent_id);
                             db.set_group_intent_error(intent_id)?;
+                            // The intent genuinely failed this round. Surface the
+                            // cause so the sync summary reports it instead of a
+                            // misleading success; the message was still consumed.
+                            intent_error = error_cause;
                         }
                         IntentState::Processed => {
                             tracing::debug!("Intent [{}] moved to Processed status", intent_id);
                             db.set_group_intent_processed(intent_id)?;
                         }
                     }
-                    Ok(())
+                    Ok(intent_error)
                 })?;
-                identifier.build()
+                let identifier = identifier.build()?;
+                Ok(ProcessedMessageOutcome {
+                    identifier,
+                    intent_error,
+                })
             }
             // No matching intent found. The message did not originate here.
             None => {
@@ -2170,7 +2223,7 @@ where
                         allow_cursor_increment,
                     )
                     .await?;
-                Ok(identifier)
+                Ok(ProcessedMessageOutcome::new(identifier))
             }
         }
     }
@@ -2239,9 +2292,9 @@ where
     async fn post_process_message(
         &self,
         mls_group: &OpenMlsGroup,
-        process_result: Result<MessageIdentifier, GroupMessageProcessingError>,
+        process_result: Result<ProcessedMessageOutcome, GroupMessageProcessingError>,
         envelope: &xmtp_proto::types::GroupMessage,
-    ) -> Result<MessageIdentifier, GroupMessageProcessingError> {
+    ) -> Result<ProcessedMessageOutcome, GroupMessageProcessingError> {
         let message = match process_result {
             Ok(m) => {
                 self.context.db().prune_icebox()?;
@@ -2342,7 +2395,20 @@ where
             );
 
             match result {
-                Ok(m) => summary.add(m),
+                Ok(ProcessedMessageOutcome {
+                    identifier,
+                    intent_error,
+                }) => {
+                    // An own-intent that failed non-retryably advances the cursor and
+                    // is marked Error in its row, then returns success — so the message
+                    // is counted as processed. Record the swallowed cause here so the
+                    // summary (and its source()) report the real failure instead of a
+                    // misleading "0 failed".
+                    if let Some(e) = intent_error {
+                        summary.errored(message.cursor, e);
+                    }
+                    summary.add(identifier);
+                }
                 Err(GroupMessageProcessingError::GroupPaused) => {
                     tracing::info!(
                         "Group [{}] is paused, skip syncing remaining messages",

--- a/crates/xmtp_mls/src/groups/summary.rs
+++ b/crates/xmtp_mls/src/groups/summary.rs
@@ -67,7 +67,13 @@ impl SyncSummary {
         self.publish_errors.extend(other.publish_errors);
         self.process.extend(other.process);
         self.post_commit_errors.extend(other.post_commit_errors);
-        self.other = other.other;
+        // Preserve the first non-None cause. `extend` is called once per retry
+        // round in `sync_until_intent_resolved_inner`; overwriting here would let
+        // a later clean round clobber an earlier round's `other` error, losing
+        // the cause on the timeout (SyncFailedToWait) path.
+        if self.other.is_none() {
+            self.other = other.other;
+        }
     }
 
     /// Construct a sync which failed with an unrelated error.
@@ -412,5 +418,33 @@ impl std::fmt::Display for ProcessSummary {
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod extend_tests {
+    use super::*;
+
+    // `extend` is called once per retry round in
+    // `sync_until_intent_resolved_inner`. A later clean round must not clobber an
+    // earlier round's `other` cause — otherwise the timeout (SyncFailedToWait)
+    // path loses the real failure.
+    #[xmtp_common::test]
+    fn extend_preserves_first_other_cause() {
+        let mut acc = SyncSummary::default();
+        acc.extend(SyncSummary::other(GroupError::GroupInactive)); // round 1: cause
+        acc.extend(SyncSummary::default()); // round 2: clean — must not clobber
+
+        let other = acc.other.as_ref().expect("first cause must survive");
+        assert_eq!(other.to_string(), GroupError::GroupInactive.to_string());
+    }
+
+    #[xmtp_common::test]
+    fn extend_takes_other_when_none_yet() {
+        let mut acc = SyncSummary::default();
+        acc.extend(SyncSummary::default()); // round 1: clean
+        acc.extend(SyncSummary::other(GroupError::GroupInactive)); // round 2: cause appears
+
+        assert!(acc.other.is_some(), "a later cause is still captured");
     }
 }

--- a/crates/xmtp_mls/src/groups/tests/test_proposals.rs
+++ b/crates/xmtp_mls/src/groups/tests/test_proposals.rs
@@ -1028,28 +1028,44 @@ async fn test_enable_proposals_concurrent_callers_converge() {
         .clone();
     bo_group.sync().await?;
 
-    // Race two `enable_proposals` calls. Both MUST return `Ok` — the
-    // recovery wrapper inside `enable_proposals` observes the
-    // migration completed even when the loser's own intent failed
-    // locally.
+    // Race two `enable_proposals` calls. The recovery wrapper inside
+    // `enable_proposals` returns `Ok` for the loser once it observes the
+    // migration completed — but that recovery depends on the winner's
+    // bootstrap commit having landed locally by the time the loser's own
+    // intent errors, which is a timing race within the loser's sync retry
+    // loop. So an immediate `Err` here is only a transient race loss, not a
+    // failure: the contract is that the API converges to `Ok` once migrated.
     let alix_group_clone = alix_group.clone();
     let bo_group_clone = bo_group.clone();
     let (alix_result, bo_result) = tokio::join!(
         alix_group_clone.enable_proposals(EnableProposalsOptions::test_default()),
         bo_group_clone.enable_proposals(EnableProposalsOptions::test_default()),
     );
-    assert!(
-        alix_result.is_ok(),
-        "alix's enable_proposals must return Ok (winner OR loser-recovered-to-Ok), got {alix_result:?}",
-    );
-    assert!(
-        bo_result.is_ok(),
-        "bo's enable_proposals must return Ok (winner OR loser-recovered-to-Ok), got {bo_result:?}",
-    );
 
-    // Sync both to converge.
+    // Sync both to converge — this lands any not-yet-applied bootstrap commit.
     alix_group.sync().await?;
     bo_group.sync().await?;
+
+    // Recovery contract: any caller that returned `Err` (a race loss) must
+    // converge to `Ok` once the migration is visible locally. Re-driving
+    // `enable_proposals` hits the `already_migrated` fast-path and returns
+    // `Ok` — proving the wrapper recovers, without depending on bootstrap
+    // timing. A genuine recovery failure would surface here as a persistent
+    // `Err` (group never migrated).
+    for (label, result, group) in [
+        ("alix", &alix_result, &alix_group),
+        ("bo", &bo_result, &bo_group),
+    ] {
+        if let Err(err) = result {
+            let recovered = group
+                .enable_proposals(EnableProposalsOptions::test_default())
+                .await;
+            assert!(
+                recovered.is_ok(),
+                "{label}'s enable_proposals lost the race ({err:?}) and did not recover to Ok: {recovered:?}",
+            );
+        }
+    }
 
     for (label, group) in [("alix", &alix_group), ("bo", &bo_group)] {
         let migrated = group
@@ -3388,23 +3404,27 @@ async fn test_update_group_name_uses_legacy_path_when_proposals_disabled() {
 /// permission checks because `extract_metadata_changes` only inspects
 /// the legacy GMM extension.
 ///
-/// The assertion shape is intentionally two-part. Own-commit validation
+/// The assertion shape is intentionally three-part. Own-commit validation
 /// failures are non-retryable and `process_message` absorbs them by
-/// flipping the intent's DB row to `IntentState::Error` — the typed
-/// `CommitValidationError::InsufficientPermissions` is never hoisted to
-/// the caller. What the public API returns is `GroupError::Sync(summary)`
-/// from `sync_until_intent_resolved_inner` (see mls_sync.rs line ~606),
-/// matching the pattern established by other permission-denial tests
-/// such as the `SyncFailedToWait` assertions in `tests/mod.rs`. Pinning
-/// `Sync(_)` + the group-name-unchanged invariant is tight enough: a
-/// validator-stopped-firing regression would either succeed (name
-/// changes) or produce a different `GroupError` variant (Api, Storage,
-/// Client) — both detected.
+/// flipping the intent's DB row to `IntentState::Error`. The typed
+/// `CommitValidationError::InsufficientPermissions` is no longer dropped:
+/// it's captured into the summary's `process.errored` (see the
+/// `ProcessedMessageOutcome` path in mls_sync.rs) so the cause survives.
+/// What the public API returns is `GroupError::Sync(summary)` from
+/// `sync_until_intent_resolved_inner`, matching the pattern established by
+/// other permission-denial tests such as the `SyncFailedToWait` assertions
+/// in `tests/mod.rs`. We pin `Sync(_)`, that the summary carries the real
+/// `CommitValidation` cause, and the group-name-unchanged invariant: a
+/// validator-stopped-firing regression would either succeed (name changes)
+/// or produce a different `GroupError` variant — both detected; a
+/// cause-swallowing regression would drop the `CommitValidation` error.
 #[xmtp_common::test(unwrap_try = true)]
 async fn test_inline_app_data_update_denied_by_registry_policy() {
     use crate::groups::{
         GroupError,
         intents::{PermissionPolicyOption, PermissionUpdateType},
+        mls_sync::GroupMessageProcessingError,
+        validated_commit::CommitValidationError,
     };
     use xmtp_mls_common::group_mutable_metadata::MetadataField;
 
@@ -3443,9 +3463,22 @@ async fn test_inline_app_data_update_denied_by_registry_policy() {
     let result = alix_group
         .update_group_name("Should Be Rejected".to_string())
         .await;
+    let Err(GroupError::Sync(summary)) = result else {
+        panic!("expected Err(GroupError::Sync(_)), got {result:?}");
+    };
+
+    // The non-retryable own-commit validation failure must be preserved in the
+    // summary rather than swallowed: the intent flips to Error, but the typed
+    // CommitValidationError now rides out through process.errored so the cause
+    // is reportable instead of surfacing as a misleading "0 failed" success.
     assert!(
-        matches!(result, Err(GroupError::Sync(_))),
-        "expected Err(GroupError::Sync(_)), got {result:?}"
+        summary.process.errored.iter().any(|(_, e)| matches!(
+            e,
+            GroupMessageProcessingError::CommitValidation(
+                CommitValidationError::InsufficientPermissions
+            )
+        )),
+        "summary should carry the CommitValidation cause, got: {summary}"
     );
 
     // Group name unchanged because the rejected commit never made

--- a/crates/xmtp_mls/src/subscriptions/process_message/factory.rs
+++ b/crates/xmtp_mls/src/subscriptions/process_message/factory.rs
@@ -115,6 +115,11 @@ where
             .process_message(msg, false)
             .instrument(tracing::debug_span!("process_message"))
             .await
+            // Streaming path (trust_message_order = false): any captured
+            // intent_error is intentionally discarded — intent-resolution
+            // reporting belongs to the query/sync path, not the stream. Surface
+            // only the identifier, matching prior behavior.
+            .map(|outcome| outcome.identifier)
             .map_err(|e| SubscribeError::ReceiveGroup(Box::new(e)))
     }
 


### PR DESCRIPTION
When an own-intent failed non-retryably, process_message_inner marked the intent row Error, committed, and returned Ok(identifier) — dropping the real GroupMessageProcessingError. process_messages recorded only a success, so sync_until_intent_resolved returned a summary that displayed '0 failed 1 succeeded' yet surfaced as a top-level GroupError::Sync with no cause.

Capture the dropped cause via a ProcessedMessageOutcome struct and record it in ProcessSummary.errored, so the summary (and its source()) report the actual failure. No DB/txn-commit or retry-rollback behavior changes.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `SyncSummary.extend` to preserve the earliest error cause across sync retries
> - `SyncSummary.extend` previously overwrote `self.other` unconditionally, clobbering earlier error causes with later `None` values; it now only sets `self.other` when `self.other` is currently `None`.
> - `GroupError::SyncFailedToWait` now includes the `SyncSummary` in its `Display` output so the cause is visible in error messages.
> - Per-attempt error logging inside `MlsGroup::sync` is removed; summaries are accumulated silently and logged once by `GroupSyncFinished`.
> - `GroupSyncIntentErrored` events no longer redundantly include the summary metadata field.
> - Two unit tests are added to [summary.rs](https://github.com/xmtp/libxmtp/pull/3701/files#diff-cc6e0f2ec334b2a161a0e24bf0a280e37287801dcc7c6e40c46b7d5153580240) validating the corrected `extend` accumulation behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 55e3eec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->