### PR TITLE
fix(mls): make SyncSummary error-state consistent and preserve cause

### DIFF
--- a/crates/xmtp_mls/src/groups/summary.rs
+++ b/crates/xmtp_mls/src/groups/summary.rs
@@ -46,9 +46,19 @@ impl SyncSummary {
         self.process.new_messages.iter().find(|m| m.cursor == id)
     }
 
+    /// Whether the sync *operation* failed (publish, post-commit, or an
+    /// unrelated error). This is the single predicate that decides whether a
+    /// summary may sit in the `Err` position and which Display branch is used —
+    /// keep the two in lockstep.
+    ///
+    /// Note: per-message processing failures (`process.errored`) are
+    /// deliberately *not* counted here. A sync that decrypts some messages and
+    /// fails others is still a successful sync of the group as a whole; those
+    /// failures are reported inside the summary, not by flipping it to an error.
     pub fn is_errored(&self) -> bool {
         self.other.is_some()
-            || (!self.publish_errors.is_empty() && !self.post_commit_errors.is_empty())
+            || !self.publish_errors.is_empty()
+            || !self.post_commit_errors.is_empty()
     }
 
     pub fn add_publish_err(&mut self, e: GroupError) {
@@ -90,12 +100,24 @@ impl SyncSummary {
 }
 
 impl std::error::Error for SyncSummary {
+    /// Surface the first underlying cause so the error chain (e.g. the FFI
+    /// `Caused by:` walk) reaches the real failure instead of dead-ending at
+    /// the summary's flattened Display string. Prefer the sync-operation
+    /// errors, falling back to the first per-message processing error.
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        None
-    }
-
-    fn cause(&self) -> Option<&dyn std::error::Error> {
-        self.source()
+        if let Some(other) = self.other.as_deref() {
+            return Some(other);
+        }
+        if let Some(err) = self.publish_errors.first() {
+            return Some(err);
+        }
+        if let Some(err) = self.post_commit_errors.first() {
+            return Some(err);
+        }
+        self.process
+            .errored
+            .first()
+            .map(|(_, e)| e as &dyn std::error::Error)
     }
 }
 
@@ -107,10 +129,7 @@ impl std::fmt::Debug for SyncSummary {
 
 impl std::fmt::Display for SyncSummary {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.publish_errors.is_empty()
-            && self.post_commit_errors.is_empty()
-            && self.other.is_none()
-        {
+        if !self.is_errored() {
             let first_new = self
                 .process
                 .new_messages
@@ -446,5 +465,95 @@ mod extend_tests {
         acc.extend(SyncSummary::other(GroupError::GroupInactive)); // round 2: cause appears
 
         assert!(acc.other.is_some(), "a later cause is still captured");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::groups::mls_sync::GroupMessageProcessingError;
+    use std::error::Error;
+
+    // The Display "success" banner must fire iff is_errored() is false, and a
+    // summary may only be in the Err position when is_errored() is true. These
+    // two had drifted (Display used all-three-empty; is_errored() used && for
+    // publish/post_commit), so a publish-only failure printed the error banner
+    // while still reporting as not-errored. Lock the predicates together.
+    fn errored_banner(s: &SyncSummary) -> bool {
+        s.to_string().contains("Errors Occurred During Sync")
+    }
+
+    #[xmtp_common::test]
+    fn clean_summary_is_not_errored() {
+        let summary = SyncSummary::default();
+        assert!(!summary.is_errored());
+        assert!(!errored_banner(&summary));
+        assert!(summary.source().is_none());
+    }
+
+    #[xmtp_common::test]
+    fn publish_only_error_is_errored() {
+        let mut summary = SyncSummary::default();
+        summary.add_publish_err(GroupError::GroupInactive);
+        // Regression: with `&&` this returned false while Display showed the banner.
+        assert!(summary.is_errored());
+        assert!(errored_banner(&summary));
+    }
+
+    #[xmtp_common::test]
+    fn post_commit_only_error_is_errored() {
+        let mut summary = SyncSummary::default();
+        summary.add_post_commit_err(GroupError::GroupInactive);
+        assert!(summary.is_errored());
+        assert!(errored_banner(&summary));
+    }
+
+    #[xmtp_common::test]
+    fn other_error_is_errored_and_is_source() {
+        let mut summary = SyncSummary::default();
+        summary.add_other(GroupError::GroupInactive);
+        assert!(summary.is_errored());
+        // `other` is the highest-priority cause surfaced through the chain.
+        let source = summary.source().expect("source should be present");
+        assert_eq!(source.to_string(), GroupError::GroupInactive.to_string());
+    }
+
+    #[xmtp_common::test]
+    fn per_message_failures_do_not_flip_errored() {
+        // A sync that fails to process some messages is still a successful sync
+        // of the group as a whole — it stays Ok and prints the success line.
+        let mut process = ProcessSummary::default();
+        process.errored(
+            Cursor::new(7u64, 0u32),
+            GroupMessageProcessingError::InvalidPayload,
+        );
+        let mut summary = SyncSummary::default();
+        summary.add_process(process);
+
+        assert!(!summary.is_errored());
+        assert!(!errored_banner(&summary));
+        // ...but the failure is still reachable as the cause of last resort.
+        let source = summary
+            .source()
+            .expect("per-message error is the fallback source");
+        assert_eq!(
+            source.to_string(),
+            GroupMessageProcessingError::InvalidPayload.to_string()
+        );
+    }
+
+    #[xmtp_common::test]
+    fn source_prefers_other_over_per_message_error() {
+        let mut process = ProcessSummary::default();
+        process.errored(
+            Cursor::new(7u64, 0u32),
+            GroupMessageProcessingError::InvalidPayload,
+        );
+        let mut summary = SyncSummary::default();
+        summary.add_process(process);
+        summary.add_publish_err(GroupError::GroupInactive);
+
+        let source = summary.source().expect("source should be present");
+        assert_eq!(source.to_string(), GroupError::GroupInactive.to_string());
     }
 }


### PR DESCRIPTION
## Problem

`SyncSummary` had two predicates that disagreed about what "errored" means:

- **`Display`** (success banner) fires only when `publish_errors`, `post_commit_errors`, AND `other` are all empty.
- **`is_errored()`** used `&&` for publish/post_commit (`!publish.is_empty() && !post_commit.is_empty()`), so a sync with *only* publish errors (or only post-commit errors) returned `is_errored() == false` — reported as not-errored — while its `Display` printed the `===== Errors Occurred During Sync =====` banner.

These two govern whether a summary may sit in the `Err` position (`sync_with_conn`) and which `Display` branch is shown, so the divergence meant an `Ok(...)` summary could render as an error block (and vice versa).

Separately, `GroupError::Sync` / `SyncFailedToWait` box a `SyncSummary` whose `source()` returned `None`, so the FFI `Caused by:` chain dead-ended at the summary's flattened string — the underlying error was never reachable.

## Changes (summary.rs only)

- **`is_errored()`**: `&&` → `||` for publish/post_commit, and unify on one predicate. `process.errored` (per-message failures) is *deliberately excluded* and documented: a sync that decrypts some messages and fails others is still a successful sync of the group as a whole.
- **`Display`**: success branch is now `if !self.is_errored()` — the two can no longer drift.
- **`source()`**: returns the first available cause (`other` → first publish → first post_commit → first `process.errored`), so the FFI error chain reaches the real failure.
- **6 unit tests**: clean / publish-only / post-commit-only / other / per-message / source-priority. The publish-only test is the explicit regression guard for the `&&` bug.

## Verification

- `cargo clippy --locked -p xmtp_mls --all-features --all-targets --no-deps -- -Dwarnings` + `cargo fmt --check` clean
- New unit tests pass; sync/welcome/commit_log/process_message integration suites pass (no regression from the `is_errored` behavior change)

Pairs with #3701 (which captures the dropped intent-error cause into `process.errored`); this PR makes the type honest, #3701 fills in the cause. Independent-compiling; recommend landing this first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `SyncSummary` error detection logic and expose error cause via `source()`
> - `is_errored()` previously required both `publish_errors` and `post_commit_errors` to be non-empty (logical AND); it now returns `true` when any of `other`, `publish_errors`, or `post_commit_errors` is present.
> - `std::error::Error::source()` now returns the first available underlying error, preferring `other`, then `publish_errors`, then `post_commit_errors`, then per-message processing errors; previously it returned `None`.
> - `Display` formatting now delegates to `is_errored()` instead of duplicating the error-check logic.
> - Behavioral Change: callers relying on `is_errored()` returning `false` when only one of publish or post-commit errors is present will now see `true`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9d90b03.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->