### PR TITLE
perf(grpc): cache TLS endpoints so native root certs load once per host

### DIFF
--- a/apps/xmtp_debug/src/app/clients.rs
+++ b/apps/xmtp_debug/src/app/clients.rs
@@ -208,6 +208,50 @@ fn existing_client_inner_for(
     Ok(client)
 }
 
+/// Build clients for `identities` across many threads.
+///
+/// Each open is blocking SQLite + MLS work (no network — channels are
+/// lazy), so we heavily oversubscribe cores: `num_cpus * 10`. Identities
+/// are spread round-robin into per-thread buckets (moved, so we only need
+/// `Identity: Send`, not `Sync`, and need no shared lock). Each worker
+/// enters the current Tokio runtime context so `client_from_identity`
+/// behaves exactly as it did on the calling worker thread. Returns one
+/// `(inbox_id, result)` per identity in arbitrary order; callers decide
+/// whether to skip or propagate failures.
+fn load_clients_parallel(identities: Vec<Identity>) -> Vec<(InboxId, Result<crate::DbgClient>)> {
+    let n = identities.len();
+    if n == 0 {
+        return Vec::new();
+    }
+    let fanout = (num_cpus::get() * 10).clamp(1, n);
+    let handle = tokio::runtime::Handle::try_current().ok();
+
+    let mut buckets: Vec<Vec<Identity>> = (0..fanout).map(|_| Vec::new()).collect();
+    for (i, identity) in identities.into_iter().enumerate() {
+        buckets[i % fanout].push(identity);
+    }
+
+    std::thread::scope(|scope| {
+        let workers: Vec<_> = buckets
+            .into_iter()
+            .map(|bucket| {
+                let handle = handle.clone();
+                scope.spawn(move || {
+                    let _guard = handle.as_ref().map(|h| h.enter());
+                    bucket
+                        .into_iter()
+                        .map(|identity| (identity.inbox_id, client_from_identity(&identity)))
+                        .collect::<Vec<_>>()
+                })
+            })
+            .collect();
+        workers
+            .into_iter()
+            .flat_map(|w| w.join().expect("client load thread panicked"))
+            .collect()
+    })
+}
+
 /// Loads all identities. Honors `App::strict_versioning()`: when set,
 /// reads only this binary's version partition; otherwise reads every
 /// version on the network.
@@ -230,9 +274,8 @@ pub fn load_all_identities(
     let now = std::time::Instant::now();
     let mut clients = HashMap::new();
     let mut skipped = 0u32;
-    for identity in identities {
-        let inbox_id = identity.inbox_id;
-        match client_from_identity(&identity) {
+    for (inbox_id, result) in load_clients_parallel(identities) {
+        match result {
             Ok(client) => {
                 clients.insert(inbox_id, Mutex::new(client));
             }
@@ -292,14 +335,9 @@ pub fn load_n_identities(
         now.elapsed()
     );
     let now = std::time::Instant::now();
-    let clients = identities
+    let clients = load_clients_parallel(identities)
         .into_iter()
-        .map(|id| {
-            Ok::<_, eyre::Report>((
-                id.inbox_id,
-                Arc::new(Mutex::new(client_from_identity(&id)?)),
-            ))
-        })
+        .map(|(inbox_id, result)| Ok::<_, eyre::Report>((inbox_id, Arc::new(Mutex::new(result?)))))
         .collect::<Result<HashMap<_, _>, _>>()?;
     tracing::info!(
         "took {:?} to load {} xmtp clients",

--- a/apps/xmtp_debug/src/app/clients.rs
+++ b/apps/xmtp_debug/src/app/clients.rs
@@ -208,54 +208,36 @@ fn existing_client_inner_for(
     Ok(client)
 }
 
-/// Build clients for `identities` across many threads.
+/// Build clients for `identities` concurrently.
 ///
 /// Each open is blocking SQLite + MLS work (no network — channels are
-/// lazy), so we heavily oversubscribe cores: `num_cpus * 10`. Identities
-/// are spread round-robin into per-thread buckets (moved, so we only need
-/// `Identity: Send`, not `Sync`, and need no shared lock). Each worker
-/// enters the current Tokio runtime context so `client_from_identity`
-/// behaves exactly as it did on the calling worker thread. Returns one
-/// `(inbox_id, result)` per identity in arbitrary order; callers decide
+/// lazy), so we hand every client to Tokio's blocking pool via
+/// `spawn_blocking` and await them together rather than parking a runtime
+/// worker. Returns one `(inbox_id, result)` per identity; callers decide
 /// whether to skip or propagate failures.
-fn load_clients_parallel(identities: Vec<Identity>) -> Vec<(InboxId, Result<crate::DbgClient>)> {
-    let n = identities.len();
-    if n == 0 {
-        return Vec::new();
-    }
-    let fanout = (num_cpus::get() * 10).clamp(1, n);
-    let handle = tokio::runtime::Handle::try_current().ok();
-
-    let mut buckets: Vec<Vec<Identity>> = (0..fanout).map(|_| Vec::new()).collect();
-    for (i, identity) in identities.into_iter().enumerate() {
-        buckets[i % fanout].push(identity);
-    }
-
-    std::thread::scope(|scope| {
-        let workers: Vec<_> = buckets
-            .into_iter()
-            .map(|bucket| {
-                let handle = handle.clone();
-                scope.spawn(move || {
-                    let _guard = handle.as_ref().map(|h| h.enter());
-                    bucket
-                        .into_iter()
-                        .map(|identity| (identity.inbox_id, client_from_identity(&identity)))
-                        .collect::<Vec<_>>()
-                })
+async fn load_clients_parallel(
+    identities: Vec<Identity>,
+) -> Vec<(InboxId, Result<crate::DbgClient>)> {
+    let tasks: Vec<_> = identities
+        .into_iter()
+        .map(|identity| {
+            tokio::task::spawn_blocking(move || {
+                (identity.inbox_id, client_from_identity(&identity))
             })
-            .collect();
-        workers
-            .into_iter()
-            .flat_map(|w| w.join().expect("client load thread panicked"))
-            .collect()
-    })
+        })
+        .collect();
+
+    let mut clients = Vec::with_capacity(tasks.len());
+    for task in tasks {
+        clients.push(task.await.expect("client load task panicked"));
+    }
+    clients
 }
 
 /// Loads all identities. Honors `App::strict_versioning()`: when set,
 /// reads only this binary's version partition; otherwise reads every
 /// version on the network.
-pub fn load_all_identities(
+pub async fn load_all_identities(
     store: &IdentityStore<'static>,
 ) -> Result<Arc<HashMap<InboxId, Mutex<crate::DbgClient>>>> {
     let identities: Vec<Identity> = if crate::app::App::strict_versioning() {
@@ -274,7 +256,7 @@ pub fn load_all_identities(
     let now = std::time::Instant::now();
     let mut clients = HashMap::new();
     let mut skipped = 0u32;
-    for (inbox_id, result) in load_clients_parallel(identities) {
+    for (inbox_id, result) in load_clients_parallel(identities).await {
         match result {
             Ok(client) => {
                 clients.insert(inbox_id, Mutex::new(client));
@@ -302,7 +284,7 @@ pub fn load_all_identities(
     Ok(Arc::new(clients))
 }
 
-pub fn load_n_identities(
+pub async fn load_n_identities(
     store: &IdentityStore<'static>,
     n: usize,
 ) -> Result<Arc<HashMap<InboxId, Arc<Mutex<crate::DbgClient>>>>> {
@@ -336,6 +318,7 @@ pub fn load_n_identities(
     );
     let now = std::time::Instant::now();
     let clients = load_clients_parallel(identities)
+        .await
         .into_iter()
         .map(|(inbox_id, result)| Ok::<_, eyre::Report>((inbox_id, Arc::new(Mutex::new(result?)))))
         .collect::<Result<HashMap<_, _>, _>>()?;

--- a/apps/xmtp_debug/src/app/generate.rs
+++ b/apps/xmtp_debug/src/app/generate.rs
@@ -53,7 +53,7 @@ impl Generate {
                 Ok(())
             }
             Message => {
-                let generator = GenerateMessages::new(*message_opts, **concurrency)?;
+                let generator = GenerateMessages::new(*message_opts, **concurrency).await?;
                 let start = Instant::now();
                 let latencies = generator.run(*amount).await?;
                 let elapsed = start.elapsed();

--- a/apps/xmtp_debug/src/app/generate/groups.rs
+++ b/apps/xmtp_debug/src/app/generate/groups.rs
@@ -55,7 +55,7 @@ impl GenerateGroups {
         );
         let bar = ProgressBar::new(n as u64).with_style(style.unwrap());
 
-        let clients = load_n_identities(&self.identity_store, n)?;
+        let clients = load_n_identities(&self.identity_store, n).await?;
 
         let semaphore = Arc::new(tokio::sync::Semaphore::new(concurrency));
         let groups = stream::iter(clients.iter())

--- a/apps/xmtp_debug/src/app/generate/messages.rs
+++ b/apps/xmtp_debug/src/app/generate/messages.rs
@@ -97,7 +97,7 @@ pub struct GenerateMessages {
 }
 
 impl GenerateMessages {
-    pub fn new(opts: args::MessageGenerateOpts, concurrency: usize) -> Result<Self> {
+    pub async fn new(opts: args::MessageGenerateOpts, concurrency: usize) -> Result<Self> {
         // Always open write-capable redb so we can mirror sent messages
         // into `MessageStore`. add_member/change_description already
         // required write; default path now does too because we record
@@ -107,7 +107,7 @@ impl GenerateMessages {
         let identity_store: IdentityStore<'static> = db.clone().into();
         let group_store: GroupStore<'static> = db.clone().into();
         let message_store: MessageStore<'static> = db.into();
-        let identities = load_all_identities(&identity_store)?;
+        let identities = load_all_identities(&identity_store).await?;
         let semaphore = Arc::new(tokio::sync::Semaphore::new(concurrency));
 
         Ok(Self {

--- a/apps/xmtp_debug/src/app/sync.rs
+++ b/apps/xmtp_debug/src/app/sync.rs
@@ -34,7 +34,7 @@ impl Sync {
         let dm_store: DmStore<'static> = redb.clone().into();
         let message_store: MessageStore<'static> = redb.into();
 
-        let clients = app::load_all_identities(&id_store)?;
+        let clients = app::load_all_identities(&id_store).await?;
 
         let mut totals = SyncStats::default();
         let mut success = 0usize;

--- a/crates/xmtp_api_grpc/src/grpc_client/native.rs
+++ b/crates/xmtp_api_grpc/src/grpc_client/native.rs
@@ -1,5 +1,7 @@
 use crate::error::GrpcBuilderError;
 use http::Request;
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
 use std::time::Duration;
 use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
 use tonic::{body::Body, client::GrpcService};
@@ -76,10 +78,36 @@ pub(crate) fn apply_channel_options(endpoint: Endpoint, limit: u64) -> Endpoint 
         .rate_limit(limit, Duration::from_secs(60))
 }
 
+/// Cache of fully-built TLS endpoints, keyed by `(host, rate_limit)`.
+///
+/// Building the endpoint runs `ClientTlsConfig::with_enabled_roots()`, which
+/// makes tonic call `rustls_native_certs::load_native_certs()` and parse the
+/// whole OS trust store into a rustls `ClientConfig` on *every* call. On macOS
+/// that read is serialized through Security.framework (~40ms each), so callers
+/// that create many clients (e.g. loading 100 identities, each building an
+/// api + sync channel) paid it hundreds of times.
+///
+/// The built `Endpoint` owns an `Arc<ClientConfig>` with the parsed roots, so
+/// caching it and calling `connect_lazy()` on a clone pays that cost once per
+/// host while still handing every client its own connection (`connect_lazy`
+/// builds a fresh `Channel`). The cache key includes `limit` because it feeds
+/// the endpoint's rate-limit option.
+static TLS_ENDPOINTS: LazyLock<Mutex<HashMap<(String, u64), Endpoint>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
 #[tracing::instrument(level = "trace", skip_all)]
 pub fn create_tls_channel(address: String, limit: u64) -> Result<Channel, GrpcBuilderError> {
-    let channel = apply_channel_options(Channel::from_shared(address)?, limit)
-        .tls_config(ClientTlsConfig::new().with_enabled_roots())?
-        .connect_lazy();
-    Ok(channel)
+    // Hold the lock across the (one-time, per-key) build so concurrent callers
+    // for the same host load native certs exactly once instead of racing.
+    let mut endpoints = TLS_ENDPOINTS.lock().unwrap_or_else(|e| e.into_inner());
+    let endpoint = match endpoints.get(&(address.clone(), limit)) {
+        Some(endpoint) => endpoint.clone(),
+        None => {
+            let endpoint = apply_channel_options(Channel::from_shared(address.clone())?, limit)
+                .tls_config(ClientTlsConfig::new().with_enabled_roots())?;
+            endpoints.insert((address, limit), endpoint.clone());
+            endpoint
+        }
+    };
+    Ok(endpoint.connect_lazy())
 }


### PR DESCRIPTION
## Problem

Loading clients in xdbg was dominated by TLS setup, not DB or MLS work. Phase timing while loading 100 identities showed ~100% of the time inside `network.client_bundle()`, with a tell-tale monotonic +42ms-per-call stair-step — i.e. a global lock serializing ~42ms of work per call, paid **twice per client** (api + sync channel).

Root cause: `create_tls_channel` builds a fresh tonic `Endpoint` on every call, and `ClientTlsConfig::with_enabled_roots()` makes tonic call `rustls_native_certs::load_native_certs()` and parse the **entire OS trust store** into a rustls `ClientConfig` each time. On macOS that read is serialized through Security.framework (~40ms). 200 calls × ~40ms ≈ the ~9–19s we were seeing.

## Fix

**`xmtp_api_grpc`:** cache the built `Endpoint` per `(host, rate_limit)`. The endpoint owns an `Arc<ClientConfig>` with the already-parsed roots, so `connect_lazy()` on a cheap clone still hands **every client its own connection** — no change to connection topology or trust semantics — while the native-cert load happens **once per host**. The lock is held across the one-time build so concurrent first-callers load certs exactly once. This benefits every platform that creates clients (node/mobile too), not just xdbg.

**`xdbg`:** parallelize identity loading (was a sequential `for` loop). Each client open is blocking SQLite/MLS work, so they're handed to Tokio's blocking pool via `tokio::task::spawn_blocking` and awaited together; `load_all_identities` / `load_n_identities` and their callers become `async`.

## Result

`cargo xdbg -b dev generate -e message -a 1`, 100 clients:

| | load time |
|---|---|
| before | ~19s |
| after | **~185ms** |

No new dependencies. No trust-store/behavior change. Each client still gets its own connection.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --locked --all-features --all-targets --no-deps -- -Dwarnings` (full workspace, clean)
- [x] manual: 100-client xdbg load ~19s → ~185ms, sends still succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ## Problem
>
> Loading clients in xdbg was dominated by TLS setup, not DB or MLS work. Phase timing while loading 100 identities showed ~100% of the time inside `network.client_bundle()`, with a tell-tale monotonic +42ms-per-call stair-step — i.e. a global lock serializing ~42ms of work per call, paid **twice per client** (api + sync channel).
>
> Root cause: `create_tls_channel` builds a fresh tonic `Endpoint` on every call, and `ClientTlsConfig::with_enabled_roots()` makes tonic call `rustls_native_certs::load_native_certs()` and parse the **entire OS trust store** into a rustls `ClientConfig` each time. On macOS that read is serialized through Security.framework (~40ms). 200 calls × ~40ms ≈ the ~9–19s we were seeing.
>
> ## Fix
>
> **`xmtp_api_grpc`:** cache the built `Endpoint` per `(host, rate_limit)`. The endpoint owns an `Arc<ClientConfig>` with the already-parsed roots, so `connect_lazy()` on a cheap clone still hands **every client its own connection** — no change to connection topology or trust semantics — while the native-cert load happens **once per host**. The lock is held across the one-time build so concurrent first-callers load certs exactly once. This benefits every platform that creates clients (node/mobile too), not just xdbg.
>
> **`xdbg`:** parallelize identity loading (was a sequential `for` loop). Each client open is blocking SQLite/MLS work, so they're handed to Tokio's blocking pool via `tokio::task::spawn_blocking` and awaited together; `load_all_identities` / `load_n_identities` and their callers become `async`.
>
> ## Result
>
> `cargo xdbg -b dev generate -e message -a 1`, 100 clients:
>
> | | load time |
> |---|---|
> | before | ~19s |
> | after | **~185ms** |
>
> No new dependencies. No trust-store/behavior change. Each client still gets its own connection.
>
> ## Test plan
> - [x] `cargo fmt --check`
> - [x] `cargo clippy --locked --all-features --all-targets --no-deps -- -Dwarnings` (full workspace, clean)
> - [x] manual: 100-client xdbg load ~19s → ~185ms, sends still succeed
>
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)<!-- Macroscope's changelog starts here -->
> #### Changes since #3703 opened
>
> - Converted `load_clients_parallel`, `load_all_identities`, and `load_n_identities` utilities to async functions [69570ca]
> - Updated `GenerateMessages::new` constructor and `GenerateGroups::create_groups` workflow to async [69570ca]
> - Updated `Generate::run` and `Sync::run` command methods to await async operations [69570ca]
> <!-- Macroscope's changelog ends here -->
>
<!-- Macroscope's pull request summary ends here -->