### PR TITLE
docs: normalize Node and WASM 1.10.0 release notes structure to match iOS/Android

### DIFF
--- a/docs/release-notes/node-bindings/1.10.0.md
+++ b/docs/release-notes/node-bindings/1.10.0.md
@@ -2,18 +2,17 @@
 sdk = "node-bindings"
 previous_release_version = "1.10.0-dev"
 ---
-
 # Node SDK 1.10.0
+
+## What's Changed
 
 This release includes a performance fix, a breaking change to history sync, and new methods for manual archive management. Update as soon as possible to take advantage of these enhancements and fixes.
 
-### Performance improvement
-
-Fixed a performance issue that could cause slowdowns in apps with many conversations or heavy use of disappearing messages.
+## Breaking Changes
 
 ### History sync is now manual
 
-**THIS IS A BREAKING CHANGE.**
+**This is a breaking change.**
 
 Automatic sending of sync requests on new installations has been removed. XMTP SDKs no longer automatically send sync requests on new clients.
 
@@ -23,25 +22,24 @@ You must now call `sendSyncRequest()` explicitly after creating a client on a ne
 
 To learn more, see [Control history sync](https://docs.xmtp.org/chat-apps/list-stream-sync/history-sync#control-history-sync)
 
-### Manual history sync archive management
-
-These methods give you fine-grained control over history sync archives. Use them when you need to push data to a new installation proactively, inspect what's available before syncing, or process a specific archive by pin.
-
-- `sendSyncArchive(pin, options?, serverUrl?)`: Send an archive to the sync group without waiting for a request from another installation
-
-- `listAvailableArchives(daysCutoff)`: List archives available for import from the sync group
-
-- `processSyncArchive(archivePin?)`: Process an available archive from the sync group
-
-- `syncAllDeviceSyncGroups()`: Sync all device sync groups from the network
-
-To learn more, see [Control history sync](https://docs.xmtp.org/chat-apps/list-stream-sync/history-sync#control-history-sync)
-
 ### Upcoming deprecation of `preferences.sync()`
 
 In a future release, `preferences.sync()` will be deprecated. Use `syncAllDeviceSyncGroups()` instead to sync device sync groups from the network.
 
 To learn more, see [Sync device sync groups](https://docs.xmtp.org/chat-apps/list-stream-sync/history-sync#sync-device-sync-groups)
+
+## New Features
+
+### Manual history sync archive management
+
+These methods give you fine-grained control over history sync archives. Use them when you need to push data to a new installation proactively, inspect what's available before syncing, or process a specific archive by pin.
+
+- `sendSyncArchive(pin, options?, serverUrl?)`: Send an archive to the sync group without waiting for a request from another installation
+- `listAvailableArchives(daysCutoff)`: List archives available for import from the sync group
+- `processSyncArchive(archivePin?)`: Process an available archive from the sync group
+- `syncAllDeviceSyncGroups()`: Sync all device sync groups from the network
+
+To learn more, see [Control history sync](https://docs.xmtp.org/chat-apps/list-stream-sync/history-sync#control-history-sync)
 
 ### Archive-based backups
 
@@ -54,3 +52,7 @@ This feature includes three core methods:
 - `importArchive` — Import an archive into the current installation
 
 To learn more, see [Support archive-based backups.](https://docs.xmtp.org/chat-apps/list-stream-sync/archive-backups#1-create-the-archive)
+
+## Bug Fixes
+
+Fixed a performance issue that could cause slowdowns in apps with many conversations or heavy use of disappearing messages.

--- a/docs/release-notes/wasm-bindings/1.10.0.md
+++ b/docs/release-notes/wasm-bindings/1.10.0.md
@@ -2,18 +2,17 @@
 sdk = "wasm-bindings"
 previous_release_version = "1.10.0-dev"
 ---
-
 # WASM SDK 1.10.0
+
+## What's Changed
 
 This release includes a performance fix, a breaking change to history sync, and new methods for manual archive management. Update as soon as possible to take advantage of these enhancements and fixes.
 
-### Performance improvement
-
-Fixed a performance issue that could cause slowdowns in apps with many conversations or heavy use of disappearing messages.
+## Breaking Changes
 
 ### History sync is now manual
 
-**THIS IS A BREAKING CHANGE.**
+**This is a breaking change.**
 
 Automatic sending of sync requests on new installations has been removed. XMTP SDKs no longer automatically send sync requests on new clients.
 
@@ -23,25 +22,24 @@ You must now call `sendSyncRequest()` explicitly after creating a client on a ne
 
 To learn more, see [Control history sync](https://docs.xmtp.org/chat-apps/list-stream-sync/history-sync#control-history-sync)
 
-### Manual history sync archive management
-
-These methods give you fine-grained control over history sync archives. Use them when you need to push data to a new installation proactively, inspect what's available before syncing, or process a specific archive by pin.
-
-- `sendSyncArchive(pin, options?, serverUrl?)`: Send an archive to the sync group without waiting for a request from another installation
-
-- `listAvailableArchives(daysCutoff)`: List archives available for import from the sync group
-
-- `processSyncArchive(archivePin?)`: Process an available archive from the sync group
-
-- `syncAllDeviceSyncGroups()`: Sync all device sync groups from the network
-
-To learn more, see [Control history sync](https://docs.xmtp.org/chat-apps/list-stream-sync/history-sync#control-history-sync)
-
 ### Upcoming deprecation of `preferences.sync()`
 
 In a future release, `preferences.sync()` will be deprecated. Use `syncAllDeviceSyncGroups()` instead to sync device sync groups from the network.
 
 To learn more, see [Sync device sync groups](https://docs.xmtp.org/chat-apps/list-stream-sync/history-sync#sync-device-sync-groups)
+
+## New Features
+
+### Manual history sync archive management
+
+These methods give you fine-grained control over history sync archives. Use them when you need to push data to a new installation proactively, inspect what's available before syncing, or process a specific archive by pin.
+
+- `sendSyncArchive(pin, options?, serverUrl?)`: Send an archive to the sync group without waiting for a request from another installation
+- `listAvailableArchives(daysCutoff)`: List archives available for import from the sync group
+- `processSyncArchive(archivePin?)`: Process an available archive from the sync group
+- `syncAllDeviceSyncGroups()`: Sync all device sync groups from the network
+
+To learn more, see [Control history sync](https://docs.xmtp.org/chat-apps/list-stream-sync/history-sync#control-history-sync)
 
 ### Archive-based backups
 
@@ -54,3 +52,7 @@ This feature includes three core methods:
 - `importArchive` — Import an archive into the current installation
 
 To learn more, see [Support archive-based backups.](https://docs.xmtp.org/chat-apps/list-stream-sync/archive-backups#1-create-the-archive)
+
+## Bug Fixes
+
+Fixed a performance issue that could cause slowdowns in apps with many conversations or heavy use of disappearing messages.


### PR DESCRIPTION
Normalize Node and WASM 1.10.0 release notes to match the structure 
already used in ios/4.10.0.md and android/4.10.0.md.

No content changes, structural and formatting fixes only.

Changes:

node-bindings/1.10.0.md:
  Add `## What's Changed` section header before intro text
  Add `## Breaking Changes` section header
    `### History sync is now manual` → moved under `## Breaking Changes`
    `### Upcoming deprecation of preferences.sync()` → moved under `## Breaking Changes`
  Add `## New Features` section header
    `### Manual history sync archive management` → moved under `## New Features`
    `### Archive-based backups` → moved under `## New Features`
  Add `## Bug Fixes` section header
    `### Performance improvement` → removed subheading, text moved under `## Bug Fixes`
  `**THIS IS A BREAKING CHANGE.**` → `**This is a breaking change.**`

wasm-bindings/1.10.0.md:
  (identical structural changes as node-bindings/1.10.0.md)

Test plan:
Documentation-only change; no code paths affected.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Normalize Node and WASM 1.10.0 release notes structure to match iOS/Android
> Restructures the 1.10.0 release notes for [Node](https://github.com/xmtp/libxmtp/pull/3707/files#diff-883d74d020e02801e31065330f11fdbd52fd8892ed0e14c97ba4616d470e07df) and [WASM](https://github.com/xmtp/libxmtp/pull/3707/files#diff-1dd324ff90565158b66b4d4de5d306179d8970d17b88a2537449749d67fb51de) bindings to match the section layout used by the iOS and Android notes. Adds explicit `What's Changed`, `Breaking Changes`, `New Features`, and `Bug Fixes` headers, moves content into the appropriate sections, deduplicates the `preferences.sync()` deprecation notice, and normalizes minor formatting.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 83ce8bf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->